### PR TITLE
MRG, BUG: Fix M/EEG topomap plotting

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -157,11 +157,13 @@ API
 
 - :meth:`mne.Epochs.shift_time` and :meth:`mne.Evoked.shift_time` now allow shifting times by arbitrary amounts (previously only by integer multiples of the sampling period), by `Daniel McCloy`_ and `Eric Larson`_.
 
-- The ``head_pos`` argument of :func:`mne.Evoked.plot_topomap` and related functions has been deprecated in favor of ``head_radius``, by `Eric Larson`_
+- The ``head_pos`` argument of :func:`mne.Evoked.plot_topomap` and related functions has been deprecated in favor of ``head_radius``, by `Eric Larson`_.
+
+- The ``layout`` argument to topomap-related functions such as :meth:`mne.Evoked.plot_topomap` and :func:`mne.viz.plot_tfr_topomap` has been deprecated in favor of channel-position based flattening based on the new ``sphere`` argument, by `Eric Larson`_.
 
 - The APIs of :meth:`mne.io.Raw.plot_projs_topomap`, :meth:`mne.Epochs.plot_projs_topomap` and :meth:`mne.Evoked.plot_projs_topomap` are now more similar to :func:`mne.viz.plot_projs_topomap` by `Daniel McCloy`_.
 
-- :func:`mne.viz.plot_projs_topomap` now accepts both :class:`~mne.channels.Layout` and :class:`~mne.Info` (previously one or the other), and will ignore :class:`~mne.Info` if :class:`~mne.channels.Layout` is provided `Daniel McCloy`_.
+- The function :func:`mne.setup_volume_source_space` has a ``sphere_units`` argument that defaults to ``'mm'`` in 0.20 but will change to ``'m'`` in 0.21, set it to avoid a warning by `Eric Larson`_.
 
 - :func:`mne.viz.plot_projs_topomap` and the related methods :meth:`mne.io.Raw.plot_projs_topomap`, :meth:`mne.Epochs.plot_projs_topomap` and :meth:`mne.Evoked.plot_projs_topomap` now accept parameter ``vlim`` to control the colormap, with keyword ``'joint'`` computing the colormap jointly across all projectors of a given channel type, by `Daniel McCloy`_.
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -159,7 +159,7 @@ API
 
 - The ``head_pos`` argument of :func:`mne.Evoked.plot_topomap` and related functions has been deprecated in favor of ``head_radius``, by `Eric Larson`_.
 
-- The ``layout`` argument to topomap-related functions such as :meth:`mne.Evoked.plot_topomap` and :func:`mne.viz.plot_tfr_topomap` has been deprecated in favor of channel-position based flattening based on the new ``sphere`` argument, by `Eric Larson`_.
+- The ``layout`` argument to topomap-related functions such as :meth:`mne.Evoked.plot_topomap` and :func:`mne.viz.plot_tfr_topomap` has been deprecated in favor of channel-position based flattening based on the ``info`` and ``sphere`` argument, by `Eric Larson`_.
 
 - The APIs of :meth:`mne.io.Raw.plot_projs_topomap`, :meth:`mne.Epochs.plot_projs_topomap` and :meth:`mne.Evoked.plot_projs_topomap` are now more similar to :func:`mne.viz.plot_projs_topomap` by `Daniel McCloy`_.
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -126,6 +126,8 @@ Bug
 
 - Fix handling of repeated events in :class:`mne.Epochs` by `Fahimeh Mamashli`_ and `Alex Gramfort`_
 
+- Fix many bugs with plotting sensors overlaid on a head outline. All plotting is now done in head coordinates and scaled by ``head_radius``, which defaults to 0.095, by `Eric Larson`_
+
 - Fix :func:`mne.io.anonymize_info` to allow shifting dates of service and to match anticipated changes in mne-cpp by `Luke Bloy`_
 
 - Fix reading of cardinals in .htps files (identifier are int not strings) by `Alex Gramfort`_
@@ -154,6 +156,8 @@ API
 - :meth:`mne.Epochs.plot` now accepts an ``event_id`` parameter (useful in tandem with ``event_colors`` for specifying event colors by name) by `Daniel McCloy`_.
 
 - :meth:`mne.Epochs.shift_time` and :meth:`mne.Evoked.shift_time` now allow shifting times by arbitrary amounts (previously only by integer multiples of the sampling period), by `Daniel McCloy`_ and `Eric Larson`_.
+
+- The ``head_pos`` argument of :func:`mne.Evoked.plot_topomap` and related functions has been deprecated in favor of ``head_radius``, by `Eric Larson`_
 
 - The APIs of :meth:`mne.io.Raw.plot_projs_topomap`, :meth:`mne.Epochs.plot_projs_topomap` and :meth:`mne.Evoked.plot_projs_topomap` are now more similar to :func:`mne.viz.plot_projs_topomap` by `Daniel McCloy`_.
 

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -185,6 +185,7 @@ Datasets
    brainstorm.bst_resting.data_path
    brainstorm.bst_raw.data_path
    eegbci.load_data
+   eegbci.standardize
    fetch_aparc_sub_parcellation
    fetch_fsaverage
    fetch_hcp_mmp_parcellation

--- a/examples/decoding/plot_decoding_csp_eeg.py
+++ b/examples/decoding/plot_decoding_csp_eeg.py
@@ -37,7 +37,7 @@ from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
 from sklearn.model_selection import ShuffleSplit, cross_val_score
 
 from mne import Epochs, pick_types, events_from_annotations
-from mne.channels import read_layout
+from mne.channels import make_standard_montage
 from mne.io import concatenate_raws, read_raw_edf
 from mne.datasets import eegbci
 from mne.decoding import CSP
@@ -56,6 +56,9 @@ runs = [6, 10, 14]  # motor imagery: hands vs feet
 
 raw_fnames = eegbci.load_data(subject, runs)
 raw = concatenate_raws([read_raw_edf(f, preload=True) for f in raw_fnames])
+eegbci.standardize(raw)  # set channel names
+montage = make_standard_montage('standard_1005')
+raw.set_montage(montage)
 
 # strip channel names of "." characters
 raw.rename_channels(lambda x: x.strip('.'))
@@ -102,9 +105,7 @@ print("Classification accuracy: %f / Chance level: %f" % (np.mean(scores),
 # plot CSP patterns estimated on full data for visualization
 csp.fit_transform(epochs_data, labels)
 
-layout = read_layout('EEG1005')
-csp.plot_patterns(epochs.info, layout=layout, ch_type='eeg',
-                  units='Patterns (AU)', size=1.5)
+csp.plot_patterns(epochs.info, ch_type='eeg', units='Patterns (AU)', size=1.5)
 
 ###############################################################################
 # Look at performance over time

--- a/examples/decoding/plot_decoding_spoc_CMC.py
+++ b/examples/decoding/plot_decoding_spoc_CMC.py
@@ -31,7 +31,6 @@ import mne
 from mne import Epochs
 from mne.decoding import SPoC
 from mne.datasets.fieldtrip_cmc import data_path
-from mne.channels import read_layout
 
 from sklearn.pipeline import make_pipeline
 from sklearn.linear_model import Ridge
@@ -87,5 +86,4 @@ plt.show()
 # Plot the contributions to the detected components (i.e., the forward model)
 
 spoc.fit(X, y)
-layout = read_layout('CTF151.lay')
-spoc.plot_patterns(meg_epochs.info, layout=layout)
+spoc.plot_patterns(meg_epochs.info)

--- a/examples/forward/plot_left_cerebellum_volume_source.py
+++ b/examples/forward/plot_left_cerebellum_volume_source.py
@@ -33,10 +33,10 @@ lh_surf = surf[0]
 
 # setup a volume source space of the left cerebellum cortex
 volume_label = 'Left-Cerebellum-Cortex'
-sphere = (0, 0, 0, 120)
-lh_cereb = setup_volume_source_space(subject, mri=aseg_fname, sphere=sphere,
-                                     volume_label=volume_label,
-                                     subjects_dir=subjects_dir)
+sphere = (0, 0, 0, 0.12)
+lh_cereb = setup_volume_source_space(
+    subject, mri=aseg_fname, sphere=sphere, volume_label=volume_label,
+    subjects_dir=subjects_dir, sphere_units='m')
 
 # Combine the source spaces
 src = surf + lh_cereb

--- a/examples/io/plot_read_proj.py
+++ b/examples/io/plot_read_proj.py
@@ -42,12 +42,12 @@ raw.plot_projs_topomap()
 # Display the projections one by one
 fig, axes = plt.subplots(1, len(empty_room_proj))
 for proj, ax in zip(empty_room_proj, axes):
-    proj.plot_topomap(axes=ax)
+    proj.plot_topomap(axes=ax, info=raw.info)
 
 ###############################################################################
 # Use the function in `mne.viz` to display a list of projections
 assert isinstance(empty_room_proj, list)
-mne.viz.plot_projs_topomap(empty_room_proj)
+mne.viz.plot_projs_topomap(empty_room_proj, info=raw.info)
 
 ###############################################################################
 # .. TODO: add this when the tutorial is up: "As shown in the tutorial
@@ -61,32 +61,3 @@ ecg_projs = read_proj(ecg_fname)
 # add them to raw and plot everything
 raw.add_proj(ecg_projs)
 raw.plot_projs_topomap()
-
-###############################################################################
-# Displaying the projections from a raw object requires no extra information
-# since all the layout information is present in `raw.info`.
-# MNE is able to automatically determine the layout for some magnetometer and
-# gradiometer configurations but not the layout of EEG electrodes.
-#
-# Here we display the `ecg_projs` individually and we provide extra parameters
-# for EEG. (Notice that planar projection refers to the gradiometers and axial
-# refers to magnetometers.)
-#
-# Notice that the conditional is just for illustration purposes. We could
-# `raw.info` in all cases to avoid the guesswork in `plot_topomap` and ensure
-# that the right layout is always found
-fig, axes = plt.subplots(1, len(ecg_projs))
-for proj, ax in zip(ecg_projs, axes):
-    if proj['desc'].startswith('ECG-eeg'):
-        proj.plot_topomap(axes=ax, info=raw.info)
-    else:
-        proj.plot_topomap(axes=ax)
-
-###############################################################################
-# The correct layout or a list of layouts from where to choose can also be
-# provided. Just for illustration purposes, here we generate the
-# `possible_layouts` from the raw object itself, but it can come from somewhere
-# else.
-possible_layouts = [mne.find_layout(raw.info, ch_type=ch_type)
-                    for ch_type in ('grad', 'mag', 'eeg')]
-mne.viz.plot_projs_topomap(ecg_projs, layout=possible_layouts)

--- a/examples/io/plot_read_proj.py
+++ b/examples/io/plot_read_proj.py
@@ -40,7 +40,8 @@ raw.plot_projs_topomap()
 
 ###############################################################################
 # Display the projections one by one
-fig, axes = plt.subplots(1, len(empty_room_proj))
+n_cols = len(empty_room_proj)
+fig, axes = plt.subplots(1, n_cols, figsize=(2 * n_cols, 2))
 for proj, ax in zip(empty_room_proj, axes):
     proj.plot_topomap(axes=ax, info=raw.info)
 

--- a/examples/visualization/plot_evoked_topomap.py
+++ b/examples/visualization/plot_evoked_topomap.py
@@ -81,12 +81,15 @@ evoked.plot_topomap(times, ch_type='mag', cmap='Spectral_r', res=32,
 # Compare this with ``extrapolate='head'`` (second topography below) where
 # extrapolation goes to 0 at the head circle and ``extrapolate='local'`` where
 # extrapolation is performed only within some distance from channels:
+
 extrapolations = ['box', 'head', 'local']
 fig, axes = plt.subplots(figsize=(7.5, 2.5), ncols=3)
 
+# Here we look at EEG channels, and use a custom head sphere to get all the
+# sensors to be well within the drawn head surface
 for ax, extr in zip(axes, extrapolations):
-    evoked.plot_topomap(0.1, ch_type='mag', size=2, extrapolate=extr, axes=ax,
-                        show=False, colorbar=False)
+    evoked.plot_topomap(0.1, ch_type='eeg', size=2, extrapolate=extr, axes=ax,
+                        show=False, colorbar=False, sphere=(0., 0., 0., 0.09))
     ax.set_title(extr, fontsize=14)
 
 ###############################################################################

--- a/examples/visualization/plot_evoked_topomap.py
+++ b/examples/visualization/plot_evoked_topomap.py
@@ -19,6 +19,7 @@ additional options.
 
 import numpy as np
 import matplotlib.pyplot as plt
+
 from mne.datasets import sample
 from mne import read_evokeds
 

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -287,8 +287,9 @@ def test_make_lcmv(tmpdir, reg, proj):
     # selection and rank reduction of the leadfield
     sphere = mne.make_sphere_model(r0=(0., 0., 0.), head_radius=0.080)
     src = mne.setup_volume_source_space(subject=None, pos=15., mri=None,
-                                        sphere=(0.0, 0.0, 0.0, 80.0),
-                                        bem=None, mindist=5.0, exclude=2.0)
+                                        sphere=(0.0, 0.0, 0.0, 0.08),
+                                        bem=None, mindist=5.0, exclude=2.0,
+                                        sphere_units='m')
 
     fwd_sphere = mne.make_forward_solution(evoked.info, trans=None, src=src,
                                            bem=sphere, eeg=False, meg=True)

--- a/mne/beamformer/tests/test_rap_music.py
+++ b/mne/beamformer/tests/test_rap_music.py
@@ -157,7 +157,8 @@ def test_rap_music_sphere():
     sphere = mne.make_sphere_model(r0=(0., 0., 0.04))
     src = mne.setup_volume_source_space(subject=None, pos=10.,
                                         sphere=(0.0, 0.0, 40, 65.0),
-                                        mindist=5.0, exclude=0.0)
+                                        mindist=5.0, exclude=0.0,
+                                        sphere_units='mm')
     forward = mne.make_forward_solution(evoked.info, trans=None, src=src,
                                         bem=sphere)
 

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -839,12 +839,7 @@ def fit_sphere_to_headshape(info, dig_kinds='auto', units='m', verbose=None):
     ----------
     info : instance of Info
         Measurement info.
-    dig_kinds : list of str | str
-        Kind of digitization points to use in the fitting. These can be any
-        combination of ('cardinal', 'hpi', 'eeg', 'extra'). Can also
-        be 'auto' (default), which will use only the 'extra' points if
-        enough (more than 10) are available, and if not, uses 'extra' and
-        'eeg' points.
+    %(dig_kinds)s
     units : str
         Can be "m" (default) or "mm".
 

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -832,8 +832,7 @@ def make_sphere_model(r0=(0., 0., 0.04), head_radius=0.09, info=None,
 # Sphere fitting
 
 @verbose
-def fit_sphere_to_headshape(info, dig_kinds='auto', units='m',
-                            move_origin=True, verbose=None):
+def fit_sphere_to_headshape(info, dig_kinds='auto', units='m', verbose=None):
     """Fit a sphere to the headshape points to determine head center.
 
     Parameters
@@ -874,7 +873,7 @@ def fit_sphere_to_headshape(info, dig_kinds='auto', units='m',
     if not isinstance(units, str) or units not in ('m', 'mm'):
         raise ValueError('units must be a "m" or "mm"')
     radius, origin_head, origin_device = _fit_sphere_to_headshape(
-        info, dig_kinds, move_origin=move_origin)
+        info, dig_kinds)
     if units == 'mm':
         radius *= 1e3
         origin_head *= 1e3
@@ -956,11 +955,10 @@ def get_fitting_dig(info, dig_kinds='auto', exclude_frontal=True,
 
 
 @verbose
-def _fit_sphere_to_headshape(info, dig_kinds, move_origin=True, verbose=None):
+def _fit_sphere_to_headshape(info, dig_kinds, verbose=None):
     """Fit a sphere to the given head shape."""
     hsp = get_fitting_dig(info, dig_kinds)
-    radius, origin_head = _fit_sphere(np.array(hsp), disp=False,
-                                      move_origin=move_origin)
+    radius, origin_head = _fit_sphere(np.array(hsp), disp=False)
     # compute origin in device coordinates
     dev_head_t = info['dev_head_t']
     if dev_head_t is None:
@@ -986,7 +984,7 @@ def _fit_sphere_to_headshape(info, dig_kinds, move_origin=True, verbose=None):
     return radius, origin_head, origin_device
 
 
-def _fit_sphere(points, disp='auto', move_origin=True):
+def _fit_sphere(points, disp='auto'):
     """Fit a sphere to an arbitrary set of points."""
     from scipy.optimize import fmin_cobyla
     if isinstance(disp, str) and disp == 'auto':
@@ -997,31 +995,20 @@ def _fit_sphere(points, disp='auto', move_origin=True):
     center_init = np.median(points, axis=0)
 
     # optimization
-    if move_origin:
-        x0 = np.concatenate([center_init, [radius_init]])
-    else:
-        x0 = [radius_init]
+    x0 = np.concatenate([center_init, [radius_init]])
 
     def cost_fun(center_rad):
-        if move_origin:
-            d = np.linalg.norm(points - center_rad[:3], axis=1) - center_rad[3]
-        else:
-            d = np.linalg.norm(points, axis=1) - center_rad[0]
+        d = np.linalg.norm(points - center_rad[:3], axis=1) - center_rad[3]
         d *= d
         return d.sum()
 
     def constraint(center_rad):
-        return center_rad[3 if move_origin else 0]  # radius must be >= 0
+        return center_rad[3]  # radius must be >= 0
 
     x_opt = fmin_cobyla(cost_fun, x0, constraint, rhobeg=radius_init,
                         rhoend=radius_init * 1e-6, disp=disp)
 
-    if move_origin:
-        origin = x_opt[:3]
-        radius = x_opt[3]
-    else:
-        origin = np.zeros(3)
-        radius = x_opt[0]
+    origin, radius = x_opt[:3], x_opt[3]
     return radius, origin
 
 

--- a/mne/channels/__init__.py
+++ b/mne/channels/__init__.py
@@ -3,6 +3,7 @@
 Can be used for setting of sensor locations used for processing and plotting.
 """
 
+from ..defaults import HEAD_SIZE_DEFAULT
 from .layout import (Layout, make_eeg_layout, make_grid_layout, read_layout,
                      find_layout, generate_2d_layout)
 from .montage import (DigMontage,
@@ -11,8 +12,7 @@ from .montage import (DigMontage,
                       read_dig_polhemus_isotrak, read_polhemus_fastscan,
                       compute_dev_head_t, make_standard_montage,
                       read_custom_montage, read_dig_hpts,
-                      compute_native_head_t, HEAD_SIZE_DEFAULT,
-                      )
+                      compute_native_head_t)
 from .channels import (equalize_channels, rename_channels, fix_mag_coil_types,
                        read_ch_connectivity, _get_ch_type,
                        find_ch_connectivity, make_1020_channel_selections)

--- a/mne/channels/__init__.py
+++ b/mne/channels/__init__.py
@@ -11,7 +11,7 @@ from .montage import (DigMontage,
                       read_dig_polhemus_isotrak, read_polhemus_fastscan,
                       compute_dev_head_t, make_standard_montage,
                       read_custom_montage, read_dig_hpts,
-                      compute_native_head_t,
+                      compute_native_head_t, HEAD_SIZE_DEFAULT,
                       )
 from .channels import (equalize_channels, rename_channels, fix_mag_coil_types,
                        read_ch_connectivity, _get_ch_type,

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -550,7 +550,8 @@ class SetChannelsMixin(object):
 
     def plot_sensors(self, kind='topomap', ch_type=None, title=None,
                      show_names=False, ch_groups=None, to_sphere=True,
-                     axes=None, block=False, show=True):
+                     axes=None, block=False, show=True,
+                     sphere=HEAD_SIZE_DEFAULT, verbose=None):
         """Plot sensor positions.
 
         Parameters
@@ -602,6 +603,8 @@ class SetChannelsMixin(object):
 
         show : bool
             Show figure if True. Defaults to True.
+        %(topomap_sphere_auto)s
+        %(verbose)s
 
         Returns
         -------
@@ -626,7 +629,7 @@ class SetChannelsMixin(object):
         return plot_sensors(self.info, kind=kind, ch_type=ch_type, title=title,
                             show_names=show_names, ch_groups=ch_groups,
                             to_sphere=to_sphere, axes=axes, block=block,
-                            show=show)
+                            show=show, sphere=sphere, verbose=verbose)
 
     @copy_function_doc_to_method_doc(anonymize_info)
     def anonymize(self, daysback=None, keep_his=False, verbose=None):

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -24,6 +24,7 @@ from ..io.pick import (channel_type, pick_info, pick_types, _picks_by_type,
                        channel_indices_by_type, pick_channels, _picks_to_idx)
 
 
+HEAD_SIZE_DEFAULT = 0.095  # in [m]
 DEPRECATED_PARAM = object()
 
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -14,6 +14,7 @@ import sys
 import numpy as np
 from scipy import sparse
 
+from ..defaults import HEAD_SIZE_DEFAULT
 from ..utils import (verbose, logger, warn, copy_function_doc_to_method_doc,
                      _check_preload, _validate_type, fill_doc, _check_option)
 from ..io.compensator import get_current_comp
@@ -22,7 +23,6 @@ from ..io.meas_info import anonymize_info, Info
 from ..io.pick import (channel_type, pick_info, pick_types, _picks_by_type,
                        _check_excludes_includes, _contains_ch_type,
                        channel_indices_by_type, pick_channels, _picks_to_idx)
-from ..defaults import HEAD_SIZE_DEFAULT
 
 
 DEPRECATED_PARAM = object()
@@ -550,8 +550,8 @@ class SetChannelsMixin(object):
 
     def plot_sensors(self, kind='topomap', ch_type=None, title=None,
                      show_names=False, ch_groups=None, to_sphere=True,
-                     axes=None, block=False, show=True,
-                     sphere=HEAD_SIZE_DEFAULT, verbose=None):
+                     axes=None, block=False, show=True, sphere=None,
+                     verbose=None):
         """Plot sensor positions.
 
         Parameters
@@ -1367,9 +1367,10 @@ def _compute_ch_connectivity(info, ch_type):
             raise RuntimeError('Cannot find a pair for some of the '
                                'gradiometers. Cannot compute connectivity '
                                'matrix.')
-        xy = _find_topomap_coords(info, picks[::2])  # only for one of the pair
+        # only for one of the pair
+        xy = _find_topomap_coords(info, picks[::2], sphere=HEAD_SIZE_DEFAULT)
     else:
-        xy = _find_topomap_coords(info, picks)
+        xy = _find_topomap_coords(info, picks, sphere=HEAD_SIZE_DEFAULT)
     tri = Delaunay(xy)
     neighbors = spatial_tris_connectivity(tri.simplices)
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -74,7 +74,7 @@ def _get_ch_type(inst, ch_type, allow_ref_meg=False):
     """
     if ch_type is None:
         allowed_types = ['mag', 'grad', 'planar1', 'planar2', 'eeg', 'csd',
-                         'fnirs_raw', 'fnirs_od', 'hbo', 'hbr']
+                         'fnirs_raw', 'fnirs_od', 'hbo', 'hbr', 'ecog', 'seeg']
         allowed_types += ['ref_meg'] if allow_ref_meg else []
         for type_ in allowed_types:
             if isinstance(inst, Info):

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -22,9 +22,9 @@ from ..io.meas_info import anonymize_info, Info
 from ..io.pick import (channel_type, pick_info, pick_types, _picks_by_type,
                        _check_excludes_includes, _contains_ch_type,
                        channel_indices_by_type, pick_channels, _picks_to_idx)
+from ..defaults import HEAD_SIZE_DEFAULT
 
 
-HEAD_SIZE_DEFAULT = 0.095  # in [m]
 DEPRECATED_PARAM = object()
 
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1351,7 +1351,7 @@ def _compute_ch_connectivity(info, ch_type):
     """
     from scipy.spatial import Delaunay
     from .. import spatial_tris_connectivity
-    from ..channels.layout import _auto_topomap_coords, _pair_grad_sensors
+    from ..channels.layout import _find_topomap_coords, _pair_grad_sensors
     combine_grads = (ch_type == 'grad' and FIFF.FIFFV_COIL_VV_PLANAR_T1 in
                      np.unique([ch['coil_type'] for ch in info['chs']]))
 
@@ -1363,9 +1363,9 @@ def _compute_ch_connectivity(info, ch_type):
             raise RuntimeError('Cannot find a pair for some of the '
                                'gradiometers. Cannot compute connectivity '
                                'matrix.')
-        xy = _auto_topomap_coords(info, picks[::2])  # only for one of the pair
+        xy = _find_topomap_coords(info, picks[::2])  # only for one of the pair
     else:
-        xy = _auto_topomap_coords(info, picks)
+        xy = _find_topomap_coords(info, picks)
     tri = Delaunay(xy)
     neighbors = spatial_tris_connectivity(tri.simplices)
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -548,6 +548,7 @@ class SetChannelsMixin(object):
         _set_montage(self.info, montage, raise_if_subset=raise_if_subset)
         return self
 
+    @verbose
     def plot_sensors(self, kind='topomap', ch_type=None, title=None,
                      show_names=False, ch_groups=None, to_sphere=True,
                      axes=None, block=False, show=True, sphere=None,
@@ -570,7 +571,7 @@ class SetChannelsMixin(object):
             channels are chosen in the order given above.
         title : str | None
             Title for the figure. If None (default), equals to ``'Sensor
-            positions (%s)' % ch_type``.
+            positions (%%s)' %% ch_type``.
         show_names : bool | array of str
             Whether to display all channel names. If an array, only the channel
             names in the array are shown. Defaults to False.
@@ -581,30 +582,26 @@ class SetChannelsMixin(object):
             array, the channels are divided by picks given in the array.
 
             .. versionadded:: 0.13.0
-
         to_sphere : bool
             Whether to project the 3d locations to a sphere. When False, the
             sensor array appears similar as to looking downwards straight above
             the subject's head. Has no effect when kind='3d'. Defaults to True.
 
             .. versionadded:: 0.14.0
-
         axes : instance of Axes | instance of Axes3D | None
             Axes to draw the sensors to. If ``kind='3d'``, axes must be an
             instance of Axes3D. If None (default), a new axes will be created.
 
             .. versionadded:: 0.13.0
-
         block : bool
             Whether to halt program execution until the figure is closed.
             Defaults to False.
 
             .. versionadded:: 0.13.0
-
         show : bool
             Show figure if True. Defaults to True.
         %(topomap_sphere_auto)s
-        %(verbose)s
+        %(verbose_meth)s
 
         Returns
         -------

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -21,7 +21,7 @@ from ..io.constants import FIFF
 from ..io.meas_info import Info
 from ..utils import (_clean_names, warn, _check_ch_locs, fill_doc,
                      _check_option, _check_sphere)
-from .channels import _get_ch_info, HEAD_SIZE_DEFAULT
+from .channels import _get_ch_info
 
 
 class Layout(object):
@@ -583,7 +583,7 @@ def _box_size(points, width=None, height=None, padding=0.0):
 
 
 def _find_topomap_coords(info, picks, layout=None, ignore_overlap=False,
-                         to_sphere=True, sphere=HEAD_SIZE_DEFAULT):
+                         to_sphere=True, sphere=None):
     """Guess the E/MEG layout and return appropriate topomap coordinates.
 
     Parameters

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -214,9 +214,11 @@ class DigMontage(object):
                 ' {fid:d} fiducials, {eeg:d} channels>').format(**n_points)
 
     @copy_function_doc_to_method_doc(plot_montage)
-    def plot(self, scale_factor=20, show_names=False, kind='3d', show=True):
+    def plot(self, scale_factor=20, show_names=False, kind='3d', show=True,
+             sphere=HEAD_SIZE_DEFAULT):
         return plot_montage(self, scale_factor=scale_factor,
-                            show_names=show_names, kind=kind, show=show)
+                            show_names=show_names, kind=kind, show=show,
+                            sphere=sphere)
 
     def save(self, fname):
         """Save digitization points to FIF.

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -38,9 +38,7 @@ from ..utils import (warn, logger, copy_function_doc_to_method_doc,
 from ._dig_montage_utils import _read_dig_montage_egi
 from ._dig_montage_utils import _parse_brainvision_dig_montage
 
-from .channels import DEPRECATED_PARAM
-
-HEAD_SIZE_DEFAULT = 0.095  # in [m]
+from .channels import DEPRECATED_PARAM, HEAD_SIZE_DEFAULT
 
 _BUILT_IN_MONTAGES = [
     'EGI_256',
@@ -217,8 +215,6 @@ class DigMontage(object):
 
     @copy_function_doc_to_method_doc(plot_montage)
     def plot(self, scale_factor=20, show_names=False, kind='3d', show=True):
-        # XXX: plot_montage takes an empty info and sets 'self'
-        #      Therefore it should not be a representation problem.
         return plot_montage(self, scale_factor=scale_factor,
                             show_names=show_names, kind=kind, show=show)
 

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -20,6 +20,7 @@ from functools import partial
 
 import numpy as np
 
+from ..defaults import HEAD_SIZE_DEFAULT
 from ..viz import plot_montage
 from ..transforms import (apply_trans, get_ras_to_neuromag_trans, _sph_to_cart,
                           _topo_to_sph, _frame_to_str, Transform,
@@ -38,7 +39,7 @@ from ..utils import (warn, logger, copy_function_doc_to_method_doc,
 from ._dig_montage_utils import _read_dig_montage_egi
 from ._dig_montage_utils import _parse_brainvision_dig_montage
 
-from .channels import DEPRECATED_PARAM, HEAD_SIZE_DEFAULT
+from .channels import DEPRECATED_PARAM
 
 _BUILT_IN_MONTAGES = [
     'EGI_256',
@@ -215,7 +216,7 @@ class DigMontage(object):
 
     @copy_function_doc_to_method_doc(plot_montage)
     def plot(self, scale_factor=20, show_names=False, kind='3d', show=True,
-             sphere=HEAD_SIZE_DEFAULT):
+             sphere=None):
         return plot_montage(self, scale_factor=scale_factor,
                             show_names=show_names, kind=kind, show=show,
                             sphere=sphere)

--- a/mne/channels/tests/test_layout.py
+++ b/mne/channels/tests/test_layout.py
@@ -15,14 +15,13 @@ import pytest
 import matplotlib.pyplot as plt
 
 from mne.channels import (make_eeg_layout, make_grid_layout, read_layout,
-                          find_layout)
-from mne.channels.layout import (_box_size, _auto_topomap_coords,
+                          find_layout, HEAD_SIZE_DEFAULT)
+from mne.channels.layout import (_box_size, _find_topomap_coords,
                                  generate_2d_layout)
 from mne.utils import run_tests_if_main
 from mne import pick_types, pick_info
 from mne.io import read_raw_kit, _empty_info, read_info
 from mne.io.constants import FIFF
-from mne.bem import fit_sphere_to_headshape
 from mne.utils import _TempDir
 
 io_dir = op.join(op.dirname(__file__), '..', '..', 'io')
@@ -77,7 +76,7 @@ def test_io_layout_lay():
     assert layout.names == layout_read.names
 
 
-def test_auto_topomap_coords():
+def test_find_topomap_coords():
     """Test mapping of coordinates in 3D space to 2D."""
     info = read_info(fif_fname)
     picks = pick_types(info, meg=False, eeg=True, eog=False, stim=False)
@@ -86,51 +85,57 @@ def test_auto_topomap_coords():
     # with the EEG channels
     del info['dig'][85]
 
-    # Remove head origin from channel locations, so mapping with digitization
-    # points yields the same result
-    dig_kinds = (FIFF.FIFFV_POINT_CARDINAL,
-                 FIFF.FIFFV_POINT_EEG,
-                 FIFF.FIFFV_POINT_EXTRA)
-    _, origin_head, _ = fit_sphere_to_headshape(info, dig_kinds, units='m')
-    for ch in info['chs']:
-        ch['loc'][:3] -= origin_head
-
     # Use channel locations
-    l0 = _auto_topomap_coords(info, picks)
+    kwargs = dict(ignore_overlap=False, to_sphere=True,
+                  head_radius=HEAD_SIZE_DEFAULT)
+    l0 = _find_topomap_coords(info, picks, **kwargs)
 
     # Remove electrode position information, use digitization points from now
     # on.
     for ch in info['chs']:
         ch['loc'].fill(np.nan)
 
-    l1 = _auto_topomap_coords(info, picks)
+    l1 = _find_topomap_coords(info, picks, **kwargs)
     assert_allclose(l1, l0, atol=1e-3)
+
+    for z_pt in ((HEAD_SIZE_DEFAULT, 0., 0.),
+                 (0., HEAD_SIZE_DEFAULT, 0.)):
+        info['dig'][-1]['r'] = z_pt
+        l1 = _find_topomap_coords(info, picks, **kwargs)
+        assert_allclose(l1[-1], z_pt[:2], err_msg='Z=0 point moved', atol=1e-6)
 
     # Test plotting mag topomap without channel locations: it should fail
     mag_picks = pick_types(info, meg='mag')
-    pytest.raises(ValueError, _auto_topomap_coords, info, mag_picks)
+    with pytest.raises(ValueError, match='Cannot determine location'):
+        _find_topomap_coords(info, mag_picks, **kwargs)
 
     # Test function with too many EEG digitization points: it should fail
     info['dig'].append({'r': [1, 2, 3], 'kind': FIFF.FIFFV_POINT_EEG})
-    pytest.raises(ValueError, _auto_topomap_coords, info, picks)
+    with pytest.raises(ValueError, match='Number of EEG digitization points'):
+        _find_topomap_coords(info, picks, **kwargs)
 
     # Test function with too little EEG digitization points: it should fail
     info['dig'] = info['dig'][:-2]
-    pytest.raises(ValueError, _auto_topomap_coords, info, picks)
+    with pytest.raises(ValueError, match='Number of EEG digitization points'):
+        _find_topomap_coords(info, picks, **kwargs)
 
     # Electrode positions must be unique
     info['dig'].append(info['dig'][-1])
-    pytest.raises(ValueError, _auto_topomap_coords, info, picks)
+    with pytest.raises(ValueError, match='overlapping positions'):
+        _find_topomap_coords(info, picks, **kwargs)
 
     # Test function without EEG digitization points: it should fail
     info['dig'] = [d for d in info['dig'] if d['kind'] != FIFF.FIFFV_POINT_EEG]
-    pytest.raises(RuntimeError, _auto_topomap_coords, info, picks)
+    with pytest.raises(RuntimeError, match='Did not find any digitization'):
+        _find_topomap_coords(info, picks, **kwargs)
 
     # Test function without any digitization points, it should fail
     info['dig'] = None
-    pytest.raises(RuntimeError, _auto_topomap_coords, info, picks)
+    with pytest.raises(RuntimeError, match='No digitization points found'):
+        _find_topomap_coords(info, picks, **kwargs)
     info['dig'] = []
-    pytest.raises(RuntimeError, _auto_topomap_coords, info, picks)
+    with pytest.raises(RuntimeError, match='No digitization points found'):
+        _find_topomap_coords(info, picks, **kwargs)
 
 
 def test_make_eeg_layout():

--- a/mne/channels/tests/test_layout.py
+++ b/mne/channels/tests/test_layout.py
@@ -87,7 +87,7 @@ def test_find_topomap_coords():
 
     # Use channel locations
     kwargs = dict(ignore_overlap=False, to_sphere=True,
-                  head_radius=HEAD_SIZE_DEFAULT)
+                  sphere=HEAD_SIZE_DEFAULT)
     l0 = _find_topomap_coords(info, picks, **kwargs)
 
     # Remove electrode position information, use digitization points from now

--- a/mne/datasets/eegbci/__init__.py
+++ b/mne/datasets/eegbci/__init__.py
@@ -1,3 +1,3 @@
 """EEG Motor Movement/Imagery Dataset."""
 
-from .eegbci import data_path, load_data
+from .eegbci import data_path, load_data, standardize

--- a/mne/datasets/eegbci/eegbci.py
+++ b/mne/datasets/eegbci/eegbci.py
@@ -164,3 +164,23 @@ def load_data(subject, runs, path=None, force_update=False, update_path=None,
         data_paths.extend(data_path(url, path, force_update, update_path))
 
     return data_paths
+
+
+def standardize(raw):
+    """Standardize channel positions and names.
+
+    Parameters
+    ----------
+    raw : instance of Raw
+        The raw data to standardize. Operates in-place.
+    """
+    rename = dict()
+    for name in raw.ch_names:
+        std_name = name.strip('.')
+        std_name = std_name.upper()
+        if std_name.endswith('Z'):
+            std_name = std_name[:-1] + 'z'
+        if std_name.startswith('FP'):
+            std_name = 'Fp' + std_name[2:]
+        rename[name] = std_name
+    raw.rename_channels(rename)

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -14,6 +14,7 @@ from scipy import linalg
 
 from .mixin import TransformerMixin
 from .base import BaseEstimator
+from ..channels import HEAD_SIZE_DEFAULT
 from ..cov import _regularized_covariance
 from ..utils import fill_doc, _check_option
 
@@ -290,13 +291,15 @@ class CSP(TransformerMixin, BaseEstimator):
                 X /= self.std_
         return X
 
+    @fill_doc
     def plot_patterns(self, info, components=None, ch_type=None, layout=None,
                       vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
                       colorbar=True, scalings=None, units='a.u.', res=64,
                       size=1, cbar_fmt='%3.1f', name_format='CSP%01d',
                       show=True, show_names=False, title=None, mask=None,
                       mask_params=None, outlines='head', contours=6,
-                      image_interp='bilinear', average=None, head_pos=None):
+                      image_interp='bilinear', average=None, head_pos=None,
+                      head_radius=HEAD_SIZE_DEFAULT):
         """Plot topographic patterns of components.
 
         The patterns explain how the measured data was generated from the
@@ -361,7 +364,7 @@ class CSP(TransformerMixin, BaseEstimator):
         cbar_fmt : str
             String format for colorbar values.
         name_format : str
-            String format for topomap values. Defaults to "CSP%01d".
+            String format for topomap values. Defaults to "CSP%%01d".
         show : bool
             Show figure if True.
         show_names : bool | callable
@@ -382,17 +385,7 @@ class CSP(TransformerMixin, BaseEstimator):
                 dict(marker='o', markerfacecolor='w', markeredgecolor='k',
                      linewidth=0, markersize=4)
 
-        outlines : 'head' | 'skirt' | dict | None
-            The outlines to be drawn. If 'head', the default head scheme will
-            be drawn. If 'skirt' the head scheme will be drawn, but sensors are
-            allowed to be plotted outside of the head circle. If dict, each key
-            refers to a tuple of x and y positions, the values in 'mask_pos'
-            will serve as image mask, and the 'autoshrink' (bool) field will
-            trigger automated shrinking of the positions due to points outside
-            the outline. Alternatively, a matplotlib patch object can be passed
-            for advanced masking options, either directly or as a function that
-            returns patches (required for multi-axis plots). If None, nothing
-            will be drawn. Defaults to 'head'.
+        %(topomap_outlines)s
         contours : int | array of float
             The number of contour lines to draw. If 0, no contours will be
             drawn. When an integer, matplotlib ticker locator is used to find
@@ -407,11 +400,8 @@ class CSP(TransformerMixin, BaseEstimator):
             (seconds). For example, 0.01 would translate into window that
             starts 5 ms before and ends 5 ms after a given time point.
             Defaults to None, which means no averaging.
-        head_pos : dict | None
-            If None (default), the sensors are positioned such that they span
-            the head circle. If dict, can have entries 'center' (tuple) and
-            'scale' (tuple) for what the center and scale of the head
-            should be relative to the electrode locations.
+        %(topomap_head_pos)s
+        %(topomap_head_radius_auto)s
 
         Returns
         -------
@@ -436,8 +426,9 @@ class CSP(TransformerMixin, BaseEstimator):
             time_format=name_format, size=size, show_names=show_names,
             title=title, mask_params=mask_params, mask=mask, outlines=outlines,
             contours=contours, image_interp=image_interp, show=show,
-            average=average, head_pos=head_pos)
+            average=average, head_pos=head_pos, head_radius=head_radius)
 
+    @fill_doc
     def plot_filters(self, info, components=None, ch_type=None, layout=None,
                      vmin=None, vmax=None, cmap='RdBu_r', sensors=True,
                      colorbar=True, scalings=None, units='a.u.', res=64,
@@ -509,7 +500,7 @@ class CSP(TransformerMixin, BaseEstimator):
         cbar_fmt : str
             String format for colorbar values.
         name_format : str
-            String format for topomap values. Defaults to "CSP%01d".
+            String format for topomap values. Defaults to "CSP%%01d".
         show : bool
             Show figure if True.
         show_names : bool | callable
@@ -530,17 +521,7 @@ class CSP(TransformerMixin, BaseEstimator):
                 dict(marker='o', markerfacecolor='w', markeredgecolor='k',
                      linewidth=0, markersize=4)
 
-        outlines : 'head' | 'skirt' | dict | None
-            The outlines to be drawn. If 'head', the default head scheme will
-            be drawn. If 'skirt' the head scheme will be drawn, but sensors are
-            allowed to be plotted outside of the head circle. If dict, each key
-            refers to a tuple of x and y positions, the values in 'mask_pos'
-            will serve as image mask, and the 'autoshrink' (bool) field will
-            trigger automated shrinking of the positions due to points outside
-            the outline. Alternatively, a matplotlib patch object can be passed
-            for advanced masking options, either directly or as a function that
-            returns patches (required for multi-axis plots). If None, nothing
-            will be drawn. Defaults to 'head'.
+        %(topomap_outlines)s
         contours : int | array of float
             The number of contour lines to draw. If 0, no contours will be
             drawn. When an integer, matplotlib ticker locator is used to find
@@ -555,11 +536,7 @@ class CSP(TransformerMixin, BaseEstimator):
             (seconds). For example, 0.01 would translate into window that
             starts 5 ms before and ends 5 ms after a given time point.
             Defaults to None, which means no averaging.
-        head_pos : dict | None
-            If None (default), the sensors are positioned such that they span
-            the head circle. If dict, can have entries 'center' (tuple) and
-            'scale' (tuple) for what the center and scale of the head
-            should be relative to the electrode locations.
+        %(topomap_head_pos)s
 
         Returns
         -------

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -343,7 +343,6 @@ class CSP(TransformerMixin, BaseEstimator):
 
             .. warning::  Interactive mode works smoothly only for a small
                 amount of topomaps.
-
         sensors : bool | str
             Add markers for sensor locations to the plot. Accepts matplotlib
             plot format string (e.g., 'r+' for red plusses). If True,
@@ -383,7 +382,6 @@ class CSP(TransformerMixin, BaseEstimator):
 
                 dict(marker='o', markerfacecolor='w', markeredgecolor='k',
                      linewidth=0, markersize=4)
-
         %(topomap_outlines)s
         contours : int | array of float
             The number of contour lines to draw. If 0, no contours will be
@@ -479,7 +477,6 @@ class CSP(TransformerMixin, BaseEstimator):
 
             .. warning::  Interactive mode works smoothly only for a small
                 amount of topomaps.
-
         sensors : bool | str
             Add markers for sensor locations to the plot. Accepts matplotlib
             plot format string (e.g., 'r+' for red plusses). If True,
@@ -519,7 +516,6 @@ class CSP(TransformerMixin, BaseEstimator):
 
                 dict(marker='o', markerfacecolor='w', markeredgecolor='k',
                      linewidth=0, markersize=4)
-
         %(topomap_outlines)s
         contours : int | array of float
             The number of contour lines to draw. If 0, no contours will be

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -14,7 +14,6 @@ from scipy import linalg
 
 from .mixin import TransformerMixin
 from .base import BaseEstimator
-from ..channels import HEAD_SIZE_DEFAULT
 from ..cov import _regularized_covariance
 from ..utils import fill_doc, _check_option
 
@@ -299,7 +298,7 @@ class CSP(TransformerMixin, BaseEstimator):
                       show=True, show_names=False, title=None, mask=None,
                       mask_params=None, outlines='head', contours=6,
                       image_interp='bilinear', average=None, head_pos=None,
-                      sphere=HEAD_SIZE_DEFAULT):
+                      sphere=None):
         """Plot topographic patterns of components.
 
         The patterns explain how the measured data was generated from the

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -299,7 +299,7 @@ class CSP(TransformerMixin, BaseEstimator):
                       show=True, show_names=False, title=None, mask=None,
                       mask_params=None, outlines='head', contours=6,
                       image_interp='bilinear', average=None, head_pos=None,
-                      head_radius=HEAD_SIZE_DEFAULT):
+                      sphere=HEAD_SIZE_DEFAULT):
         """Plot topographic patterns of components.
 
         The patterns explain how the measured data was generated from the
@@ -401,7 +401,7 @@ class CSP(TransformerMixin, BaseEstimator):
             starts 5 ms before and ends 5 ms after a given time point.
             Defaults to None, which means no averaging.
         %(topomap_head_pos)s
-        %(topomap_head_radius_auto)s
+        %(topomap_sphere_auto)s
 
         Returns
         -------
@@ -426,7 +426,7 @@ class CSP(TransformerMixin, BaseEstimator):
             time_format=name_format, size=size, show_names=show_names,
             title=title, mask_params=mask_params, mask=mask, outlines=outlines,
             contours=contours, image_interp=image_interp, show=show,
-            average=average, head_pos=head_pos, head_radius=head_radius)
+            average=average, head_pos=head_pos, sphere=sphere)
 
     @fill_doc
     def plot_filters(self, info, components=None, ch_type=None, layout=None,

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -95,3 +95,6 @@ def _handle_default(k, v=None):
             for key in this_mapping.keys():
                 this_mapping[key] = v
     return this_mapping
+
+
+HEAD_SIZE_DEFAULT = 0.095  # in [m]

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -43,8 +43,7 @@ from .bem import _check_origin
 from .evoked import EvokedArray, _check_decim
 from .baseline import rescale, _log_rescale
 from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
-                                SetChannelsMixin, InterpolationMixin,
-                                HEAD_SIZE_DEFAULT)
+                                SetChannelsMixin, InterpolationMixin)
 from .filter import detrend, FilterMixin
 from .event import _read_events_fif, make_fixed_length_events
 from .fixes import _get_args, rng_uniform
@@ -1080,7 +1079,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                          layout=None, cmap='RdBu_r', agg_fun=None, dB=True,
                          n_jobs=1, normalize=False, cbar_fmt='%0.3f',
                          outlines='head', axes=None, show=True,
-                         sphere=HEAD_SIZE_DEFAULT, verbose=None):
+                         sphere=None, verbose=None):
         return plot_epochs_psd_topomap(
             self, bands=bands, vmin=vmin, vmax=vmax, tmin=tmin, tmax=tmax,
             proj=proj, bandwidth=bandwidth, adaptive=adaptive,

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -43,7 +43,8 @@ from .bem import _check_origin
 from .evoked import EvokedArray, _check_decim
 from .baseline import rescale, _log_rescale
 from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
-                                SetChannelsMixin, InterpolationMixin)
+                                SetChannelsMixin, InterpolationMixin,
+                                HEAD_SIZE_DEFAULT)
 from .filter import detrend, FilterMixin
 from .event import _read_events_fif, make_fixed_length_events
 from .fixes import _get_args, rng_uniform
@@ -1078,14 +1079,15 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                          low_bias=True, normalization='length', ch_type=None,
                          layout=None, cmap='RdBu_r', agg_fun=None, dB=True,
                          n_jobs=1, normalize=False, cbar_fmt='%0.3f',
-                         outlines='head', axes=None, show=True, verbose=None):
+                         outlines='head', axes=None, show=True,
+                         sphere=HEAD_SIZE_DEFAULT, verbose=None):
         return plot_epochs_psd_topomap(
             self, bands=bands, vmin=vmin, vmax=vmax, tmin=tmin, tmax=tmax,
             proj=proj, bandwidth=bandwidth, adaptive=adaptive,
             low_bias=low_bias, normalization=normalization, ch_type=ch_type,
             layout=layout, cmap=cmap, agg_fun=agg_fun, dB=dB, n_jobs=n_jobs,
             normalize=normalize, cbar_fmt=cbar_fmt, outlines=outlines,
-            axes=axes, show=show, verbose=verbose)
+            axes=axes, show=show, sphere=sphere, verbose=verbose)
 
     @copy_function_doc_to_method_doc(plot_topo_image_epochs)
     def plot_topo_image(self, layout=None, sigma=0., vmin=None, vmax=None,

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1061,7 +1061,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                  xscale='linear', area_mode='std', area_alpha=0.33,
                  dB=True, estimate='auto', show=True, n_jobs=1,
                  average=False, line_alpha=None, spatial_colors=True,
-                 verbose=None):
+                 sphere=None, verbose=None):
         return plot_epochs_psd(self, fmin=fmin, fmax=fmax, tmin=tmin,
                                tmax=tmax, proj=proj, bandwidth=bandwidth,
                                adaptive=adaptive, low_bias=low_bias,
@@ -1070,7 +1070,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                                area_alpha=area_alpha, dB=dB, estimate=estimate,
                                show=show, n_jobs=n_jobs, average=average,
                                line_alpha=line_alpha,
-                               spatial_colors=spatial_colors, verbose=verbose)
+                               spatial_colors=spatial_colors, sphere=sphere,
+                               verbose=verbose)
 
     @copy_function_doc_to_method_doc(plot_epochs_psd_topomap)
     def plot_psd_topomap(self, bands=None, vmin=None, vmax=None, tmin=None,

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -298,13 +298,14 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                    scalings=None, titles=None, axes=None, cmap='RdBu_r',
                    colorbar=True, mask=None, mask_style=None,
                    mask_cmap='Greys', mask_alpha=.25, time_unit='s',
-                   show_names=None, group_by=None):
+                   show_names=None, group_by=None, sphere=None):
         return plot_evoked_image(
             self, picks=picks, exclude=exclude, unit=unit, show=show,
             clim=clim, xlim=xlim, proj=proj, units=units, scalings=scalings,
             titles=titles, axes=axes, cmap=cmap, colorbar=colorbar, mask=mask,
             mask_style=mask_style, mask_cmap=mask_cmap, mask_alpha=mask_alpha,
-            time_unit=time_unit, show_names=show_names, group_by=group_by)
+            time_unit=time_unit, show_names=show_names, group_by=group_by,
+            sphere=sphere)
 
     @copy_function_doc_to_method_doc(plot_evoked_topo)
     def plot_topo(self, layout=None, layout_scale=0.945, color=None,
@@ -353,10 +354,10 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
     @copy_function_doc_to_method_doc(plot_evoked_white)
     def plot_white(self, noise_cov, show=True, rank=None, time_unit='s',
-                   verbose=None):
+                   sphere=None, verbose=None):
         return plot_evoked_white(
             self, noise_cov=noise_cov, rank=rank, show=show,
-            time_unit=time_unit, verbose=verbose)
+            time_unit=time_unit, sphere=sphere, verbose=verbose)
 
     @copy_function_doc_to_method_doc(plot_evoked_joint)
     def plot_joint(self, times="peaks", title='', picks=None,
@@ -366,6 +367,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                                  exclude=exclude, show=show, ts_args=ts_args,
                                  topomap_args=topomap_args)
 
+    @fill_doc
     def animate_topomap(self, ch_type=None, times=None, frame_rate=None,
                         butterfly=False, blit=True, show=True, time_unit='s',
                         sphere=None):

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -13,8 +13,7 @@ import numpy as np
 
 from .baseline import rescale
 from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
-                                SetChannelsMixin, InterpolationMixin,
-                                HEAD_SIZE_DEFAULT)
+                                SetChannelsMixin, InterpolationMixin)
 from .channels.layout import _merge_grad_data, _pair_grad_sensors
 from .filter import detrend, FilterMixin
 from .utils import (check_fname, logger, verbose, _time_mask, warn, sizeof_fmt,
@@ -284,8 +283,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
              xlim='tight', proj=False, hline=None, units=None, scalings=None,
              titles=None, axes=None, gfp=False, window_title=None,
              spatial_colors=False, zorder='unsorted', selectable=True,
-             noise_cov=None, time_unit='s', sphere=HEAD_SIZE_DEFAULT,
-             verbose=None):
+             noise_cov=None, time_unit='s', sphere=None, verbose=None):
         return plot_evoked(
             self, picks=picks, exclude=exclude, unit=unit, show=show,
             ylim=ylim, proj=proj, xlim=xlim, hline=hline, units=units,
@@ -335,8 +333,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                      proj=False, show=True, show_names=False, title=None,
                      mask=None, mask_params=None, outlines='head',
                      contours=6, image_interp='bilinear', average=None,
-                     head_pos=None, axes=None, extrapolate='box',
-                     sphere=HEAD_SIZE_DEFAULT):
+                     head_pos=None, axes=None, extrapolate='box', sphere=None):
         return plot_evoked_topomap(
             self, times=times, ch_type=ch_type, layout=layout, vmin=vmin,
             vmax=vmax, cmap=cmap, sensors=sensors, colorbar=colorbar,
@@ -371,7 +368,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
     def animate_topomap(self, ch_type=None, times=None, frame_rate=None,
                         butterfly=False, blit=True, show=True, time_unit='s',
-                        sphere=HEAD_SIZE_DEFAULT):
+                        sphere=None):
         """Make animation of evoked data as topomap timeseries.
 
         The animation can be paused/resumed with left mouse button.
@@ -405,7 +402,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             or "s" (will become the default in 0.17).
 
             .. versionadded:: 0.16
-        %(topomap_sphere)s
+        %(topomap_sphere_auto)s
 
         Returns
         -------

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -679,7 +679,7 @@ class EvokedArray(Evoked):
 
         if data.ndim != 2:
             raise ValueError('Data must be a 2D array of shape (n_channels, '
-                             'n_samples)')
+                             'n_samples), got shape %s' % (data.shape,))
 
         if len(info['ch_names']) != np.shape(data)[0]:
             raise ValueError('Info (%s) and data (%s) must have same number '

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -13,7 +13,8 @@ import numpy as np
 
 from .baseline import rescale
 from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
-                                SetChannelsMixin, InterpolationMixin)
+                                SetChannelsMixin, InterpolationMixin,
+                                HEAD_SIZE_DEFAULT)
 from .channels.layout import _merge_grad_data, _pair_grad_sensors
 from .filter import detrend, FilterMixin
 from .utils import (check_fname, logger, verbose, _time_mask, warn, sizeof_fmt,
@@ -283,14 +284,15 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
              xlim='tight', proj=False, hline=None, units=None, scalings=None,
              titles=None, axes=None, gfp=False, window_title=None,
              spatial_colors=False, zorder='unsorted', selectable=True,
-             noise_cov=None, time_unit='s', verbose=None):
+             noise_cov=None, time_unit='s', head_radius=HEAD_SIZE_DEFAULT,
+             verbose=None):
         return plot_evoked(
             self, picks=picks, exclude=exclude, unit=unit, show=show,
             ylim=ylim, proj=proj, xlim=xlim, hline=hline, units=units,
             scalings=scalings, titles=titles, axes=axes, gfp=gfp,
             window_title=window_title, spatial_colors=spatial_colors,
             zorder=zorder, selectable=selectable, noise_cov=noise_cov,
-            time_unit=time_unit, verbose=verbose)
+            time_unit=time_unit, head_radius=head_radius, verbose=verbose)
 
     @copy_function_doc_to_method_doc(plot_evoked_image)
     def plot_image(self, picks=None, exclude='bads', unit=True, show=True,
@@ -333,7 +335,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                      proj=False, show=True, show_names=False, title=None,
                      mask=None, mask_params=None, outlines='head',
                      contours=6, image_interp='bilinear', average=None,
-                     head_pos=None, axes=None, extrapolate='box'):
+                     head_pos=None, axes=None, extrapolate='box',
+                     head_radius=HEAD_SIZE_DEFAULT):
         return plot_evoked_topomap(
             self, times=times, ch_type=ch_type, layout=layout, vmin=vmin,
             vmax=vmax, cmap=cmap, sensors=sensors, colorbar=colorbar,
@@ -343,7 +346,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             show_names=show_names, title=title, mask=mask,
             mask_params=mask_params, outlines=outlines, contours=contours,
             image_interp=image_interp, average=average, head_pos=head_pos,
-            axes=axes, extrapolate=extrapolate)
+            axes=axes, extrapolate=extrapolate, head_radius=head_radius)
 
     @copy_function_doc_to_method_doc(plot_evoked_field)
     def plot_field(self, surf_maps, time=None, time_label='t = %0.0f ms',
@@ -367,7 +370,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                                  topomap_args=topomap_args)
 
     def animate_topomap(self, ch_type=None, times=None, frame_rate=None,
-                        butterfly=False, blit=True, show=True, time_unit='s'):
+                        butterfly=False, blit=True, show=True, time_unit='s',
+                        head_radius=HEAD_SIZE_DEFAULT):
         """Make animation of evoked data as topomap timeseries.
 
         The animation can be paused/resumed with left mouse button.
@@ -401,6 +405,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             or "s" (will become the default in 0.17).
 
             .. versionadded:: 0.16
+        %(topomap_head_radius)s
 
         Returns
         -------
@@ -415,7 +420,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """
         return _topomap_animation(
             self, ch_type=ch_type, times=times, frame_rate=frame_rate,
-            butterfly=butterfly, blit=blit, show=show, time_unit=time_unit)
+            butterfly=butterfly, blit=blit, show=show, time_unit=time_unit,
+            head_radius=head_radius)
 
     def as_type(self, ch_type='grad', mode='fast'):
         """Compute virtual evoked using interpolated fields.

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -284,7 +284,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
              xlim='tight', proj=False, hline=None, units=None, scalings=None,
              titles=None, axes=None, gfp=False, window_title=None,
              spatial_colors=False, zorder='unsorted', selectable=True,
-             noise_cov=None, time_unit='s', head_radius=HEAD_SIZE_DEFAULT,
+             noise_cov=None, time_unit='s', sphere=HEAD_SIZE_DEFAULT,
              verbose=None):
         return plot_evoked(
             self, picks=picks, exclude=exclude, unit=unit, show=show,
@@ -292,7 +292,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             scalings=scalings, titles=titles, axes=axes, gfp=gfp,
             window_title=window_title, spatial_colors=spatial_colors,
             zorder=zorder, selectable=selectable, noise_cov=noise_cov,
-            time_unit=time_unit, head_radius=head_radius, verbose=verbose)
+            time_unit=time_unit, sphere=sphere, verbose=verbose)
 
     @copy_function_doc_to_method_doc(plot_evoked_image)
     def plot_image(self, picks=None, exclude='bads', unit=True, show=True,
@@ -336,7 +336,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                      mask=None, mask_params=None, outlines='head',
                      contours=6, image_interp='bilinear', average=None,
                      head_pos=None, axes=None, extrapolate='box',
-                     head_radius=HEAD_SIZE_DEFAULT):
+                     sphere=HEAD_SIZE_DEFAULT):
         return plot_evoked_topomap(
             self, times=times, ch_type=ch_type, layout=layout, vmin=vmin,
             vmax=vmax, cmap=cmap, sensors=sensors, colorbar=colorbar,
@@ -346,7 +346,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             show_names=show_names, title=title, mask=mask,
             mask_params=mask_params, outlines=outlines, contours=contours,
             image_interp=image_interp, average=average, head_pos=head_pos,
-            axes=axes, extrapolate=extrapolate, head_radius=head_radius)
+            axes=axes, extrapolate=extrapolate, sphere=sphere)
 
     @copy_function_doc_to_method_doc(plot_evoked_field)
     def plot_field(self, surf_maps, time=None, time_label='t = %0.0f ms',
@@ -371,7 +371,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
     def animate_topomap(self, ch_type=None, times=None, frame_rate=None,
                         butterfly=False, blit=True, show=True, time_unit='s',
-                        head_radius=HEAD_SIZE_DEFAULT):
+                        sphere=HEAD_SIZE_DEFAULT):
         """Make animation of evoked data as topomap timeseries.
 
         The animation can be paused/resumed with left mouse button.
@@ -405,7 +405,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             or "s" (will become the default in 0.17).
 
             .. versionadded:: 0.16
-        %(topomap_head_radius)s
+        %(topomap_sphere)s
 
         Returns
         -------
@@ -421,7 +421,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         return _topomap_animation(
             self, ch_type=ch_type, times=times, frame_rate=frame_rate,
             butterfly=butterfly, blit=blit, show=show, time_unit=time_unit,
-            head_radius=head_radius)
+            sphere=sphere)
 
     def as_type(self, ch_type='grad', mode='fast'):
         """Compute virtual evoked using interpolated fields.

--- a/mne/externals/doccer.py
+++ b/mne/externals/doccer.py
@@ -67,7 +67,11 @@ def docformat(docstring, docdict=None):
             indented[name] = '\n'.join(newlines)
         except IndexError:
             indented[name] = dstr
-    return docstring % indented
+    try:
+        return docstring % indented
+    except TypeError as exp:
+        raise TypeError('Error documenting %s:\n%s'
+                        % (docstring.split('\n')[0], str(exp)))
 
 
 def indentcount_lines(lines):

--- a/mne/inverse_sparse/tests/test_gamma_map.py
+++ b/mne/inverse_sparse/tests/test_gamma_map.py
@@ -101,9 +101,9 @@ def test_gamma_map_vol_sphere():
     info = evoked.info
     sphere = mne.make_sphere_model(r0=(0., 0., 0.), head_radius=0.080)
     src = mne.setup_volume_source_space(subject=None, pos=30., mri=None,
-                                        sphere=(0.0, 0.0, 0.0, 80.0),
+                                        sphere=(0.0, 0.0, 0.0, 0.08),
                                         bem=None, mindist=5.0,
-                                        exclude=2.0)
+                                        exclude=2.0, sphere_units='m')
     fwd = mne.make_forward_solution(info, trans=None, src=src, bem=sphere,
                                     eeg=False, meg=True)
 

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -174,9 +174,9 @@ def test_mxne_vol_sphere():
     info = evoked.info
     sphere = mne.make_sphere_model(r0=(0., 0., 0.), head_radius=0.080)
     src = mne.setup_volume_source_space(subject=None, pos=15., mri=None,
-                                        sphere=(0.0, 0.0, 0.0, 80.0),
+                                        sphere=(0.0, 0.0, 0.0, 0.08),
                                         bem=None, mindist=5.0,
-                                        exclude=2.0)
+                                        exclude=2.0, sphere_units='m')
     fwd = mne.make_forward_solution(info, trans=None, src=src,
                                     bem=sphere, eeg=False, meg=True)
 

--- a/mne/io/array/tests/test_array.py
+++ b/mne/io/array/tests/test_array.py
@@ -170,7 +170,7 @@ def test_array_raw():
     info = create_info(ch_names, Fs, 'ecog', montage=montage)
 
     raw = RawArray(data, info)
-    raw.plot_psd(average=False)  # looking for inexistent layout
+    raw.plot_psd(average=False)  # looking for nonexistent layout
     raw.plot_psd_topo()
 
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1569,7 +1569,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                  picks=None, ax=None, color='black', xscale='linear',
                  area_mode='std', area_alpha=0.33, dB=True, estimate='auto',
                  show=True, n_jobs=1, average=False, line_alpha=None,
-                 spatial_colors=True, verbose=None):
+                 spatial_colors=True, sphere=None, verbose=None):
         return plot_raw_psd(self, fmin=fmin, fmax=fmax, tmin=tmin, tmax=tmax,
                             proj=proj, n_fft=n_fft, n_overlap=n_overlap,
                             reject_by_annotation=reject_by_annotation,
@@ -1577,7 +1577,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                             area_mode=area_mode, area_alpha=area_alpha,
                             dB=dB, estimate=estimate, show=show, n_jobs=n_jobs,
                             average=average, line_alpha=line_alpha,
-                            spatial_colors=spatial_colors, verbose=verbose)
+                            spatial_colors=spatial_colors, sphere=sphere,
+                            verbose=verbose)
 
     @copy_function_doc_to_method_doc(plot_raw_psd_topo)
     def plot_psd_topo(self, tmin=0., tmax=None, fmin=0, fmax=100, proj=False,

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -298,6 +298,7 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
                       FIFF.FIFFV_EEG_CH, eog, ecg, emg, misc)
     eegs = [idx for idx, ch in enumerate(chs) if
             ch['coil_type'] == FIFF.FIFFV_COIL_EEG]
+    # XXX this should probably use mne.transforms._topo_to_sph and _sph_to_cart
     coords = _topo_to_sphere(pos, eegs)
     locs = np.full((len(chs), 12), np.nan)
     locs[:, :3] = coords

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -43,11 +43,11 @@ class Projection(dict):
 
         Parameters
         ----------
-        %(proj_topomap_kwargs)s
         info : instance of Info | None
             The measurement information to use to determine the layout. If both
             ``info`` and ``layout`` are provided, the layout will take
             precedence.
+        %(proj_topomap_kwargs)s
         %(topomap_sphere_auto)s
 
         Returns
@@ -237,7 +237,7 @@ class ProjMixin(object):
                            sensors=True, colorbar=False, res=64, size=1,
                            show=True, outlines='head', contours=6,
                            image_interp='bilinear', axes=None,
-                           vlim=(None, None)):
+                           vlim=(None, None), sphere=None):
         """Plot SSP vector.
 
         Parameters
@@ -247,7 +247,10 @@ class ProjMixin(object):
             ted in pairs and the RMS for each pair is plotted. If None
             (default), it will return all channel types present. If a list of
             ch_types is provided, it will return multiple figures.
+        layout : object
+            Deprecated, do not use.
         %(proj_topomap_kwargs)s
+        %(topomap_sphere_auto)s
 
         Returns
         -------

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -18,7 +18,6 @@ from .constants import FIFF
 from .pick import pick_types
 from .write import (write_int, write_float, write_string, write_name_list,
                     write_float_matrix, end_block, start_block)
-from ..defaults import HEAD_SIZE_DEFAULT
 from ..utils import logger, verbose, warn, fill_doc
 
 
@@ -39,7 +38,7 @@ class Projection(dict):
                      colorbar=False, res=64, size=1, show=True,
                      outlines='head', contours=6, image_interp='bilinear',
                      axes=None, vlim=(None, None), layout=None,
-                     sphere=HEAD_SIZE_DEFAULT):
+                     sphere=None):
         """Plot topographic maps of SSP projections.
 
         Parameters

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -8,7 +8,6 @@
 from copy import deepcopy
 from itertools import count
 from math import sqrt
-import warnings
 
 import numpy as np
 from scipy import linalg
@@ -19,6 +18,7 @@ from .constants import FIFF
 from .pick import pick_types
 from .write import (write_int, write_float, write_string, write_name_list,
                     write_float_matrix, end_block, start_block)
+from ..defaults import HEAD_SIZE_DEFAULT
 from ..utils import logger, verbose, warn, fill_doc
 
 
@@ -35,10 +35,11 @@ class Projection(dict):
         return "<Projection  |  %s>" % s
 
     @fill_doc
-    def plot_topomap(self, layout=None, cmap=None, sensors=True,
+    def plot_topomap(self, info, cmap=None, sensors=True,
                      colorbar=False, res=64, size=1, show=True,
                      outlines='head', contours=6, image_interp='bilinear',
-                     axes=None, vlim=(None, None), info=None):
+                     axes=None, vlim=(None, None), layout=None,
+                     sphere=HEAD_SIZE_DEFAULT):
         """Plot topographic maps of SSP projections.
 
         Parameters
@@ -48,6 +49,7 @@ class Projection(dict):
             The measurement information to use to determine the layout. If both
             ``info`` and ``layout`` are provided, the layout will take
             precedence.
+        %(topomap_sphere_auto)s
 
         Returns
         -------
@@ -59,10 +61,10 @@ class Projection(dict):
         .. versionadded:: 0.15.0
         """  # noqa: E501
         from ..viz.topomap import plot_projs_topomap
-        with warnings.catch_warnings(record=True):  # tight_layout fails
-            return plot_projs_topomap(self, layout, cmap, sensors, colorbar,
-                                      res, size, show, outlines,
-                                      contours, image_interp, axes, vlim, info)
+        return plot_projs_topomap(self, info, cmap, sensors, colorbar,
+                                  res, size, show, outlines,
+                                  contours, image_interp, axes, vlim, layout,
+                                  sphere=sphere)
 
 
 class ProjMixin(object):

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -42,7 +42,8 @@ from ..viz import (plot_ica_components, plot_ica_scores,
 from ..viz.ica import plot_ica_properties
 from ..viz.topomap import _plot_corrmap
 
-from ..channels.channels import _contains_ch_type, ContainsMixin
+from ..channels.channels import (_contains_ch_type, ContainsMixin,
+                                 HEAD_SIZE_DEFAULT)
 from ..io.write import start_file, end_file, write_id
 from ..utils import (check_version, logger, check_fname, verbose,
                      _reject_data_segments, check_random_state, _validate_type,
@@ -2436,7 +2437,8 @@ def _find_max_corrs(all_maps, target, threshold):
 @verbose
 def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
             plot=True, show=True, outlines='head', layout=None,
-            sensors=True, contours=6, cmap=None, verbose=None):
+            sensors=True, contours=6, cmap=None, sphere=HEAD_SIZE_DEFAULT,
+            verbose=None):
     """Find similar Independent Components across subjects by map similarity.
 
     Corrmap (Viola et al. 2009 Clin Neurophysiol) identifies the best group
@@ -2494,10 +2496,7 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
     show : bool
         Show figures if True.
     %(topomap_outlines)s
-    layout : None | Layout | list of Layout
-        Layout instance specifying sensor positions (does not need to be
-        specified for Neuromag data). Or a list of Layout if projections
-        are from different sensor types.
+    %(layout_dep)s
     sensors : bool | str
         Add markers for sensor locations to the plot. Accepts matplotlib plot
         format string (e.g., 'r+' for red plusses). If True, a circle will be
@@ -2511,6 +2510,7 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
     cmap : None | matplotlib colormap
         Colormap for the plot. If ``None``, defaults to 'Reds_r' for norm data,
         otherwise to 'RdBu_r'.
+    %(topomap_sphere_auto)s
     %(verbose)s
 
     Returns
@@ -2555,13 +2555,14 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
             template_fig = icas[template[0]].plot_components(
                 picks=template[1], ch_type=ch_type, title=ttl,
                 outlines=outlines, cmap=cmap, contours=contours, layout=layout,
-                show=show)
+                show=show, topomap_args=dict(sphere=sphere))
         else:  # plotting an array
             template_fig = _plot_corrmap([template], [0], [0], ch_type,
                                          icas[0].copy(), "Template",
                                          outlines=outlines, cmap=cmap,
                                          contours=contours, layout=layout,
-                                         show=show, template=True)
+                                         show=show, template=True,
+                                         sphere=sphere)
         template_fig.subplots_adjust(top=0.8)
         template_fig.canvas.draw()
 
@@ -2618,7 +2619,7 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
         labelled_ics = _plot_corrmap(allmaps, subjs, indices, ch_type, ica,
                                      label, outlines=outlines, cmap=cmap,
                                      contours=contours, layout=layout,
-                                     show=show)
+                                     show=show, sphere=sphere)
         return template_fig, labelled_ics
     else:
         return None

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1564,7 +1564,8 @@ class ICA(ContainsMixin):
                         colorbar=False, title=None, show=True, outlines='head',
                         contours=6, image_interp='bilinear', head_pos=None,
                         inst=None, plot_std=True, topomap_args=None,
-                        image_args=None, psd_args=None, reject='auto'):
+                        image_args=None, psd_args=None, reject='auto',
+                        sphere=None):
         return plot_ica_components(self, picks=picks, ch_type=ch_type,
                                    res=res, layout=layout, vmin=vmin,
                                    vmax=vmax, cmap=cmap, sensors=sensors,
@@ -1575,7 +1576,7 @@ class ICA(ContainsMixin):
                                    plot_std=plot_std,
                                    topomap_args=topomap_args,
                                    image_args=image_args, psd_args=psd_args,
-                                   reject=reject)
+                                   reject=reject, sphere=sphere)
 
     @copy_function_doc_to_method_doc(plot_ica_properties)
     def plot_properties(self, inst, picks=None, axes=None, dB=True,

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2435,8 +2435,8 @@ def _find_max_corrs(all_maps, target, threshold):
 
 @verbose
 def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
-            plot=True, show=True, verbose=None, outlines='head', layout=None,
-            sensors=True, contours=6, cmap=None):
+            plot=True, show=True, outlines='head', layout=None,
+            sensors=True, contours=6, cmap=None, verbose=None):
     """Find similar Independent Components across subjects by map similarity.
 
     Corrmap (Viola et al. 2009 Clin Neurophysiol) identifies the best group
@@ -2493,16 +2493,7 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
         to True.
     show : bool
         Show figures if True.
-    %(verbose)s
-    outlines : 'head' | dict | None
-        The outlines to be drawn. If 'head', a head scheme will be drawn. If
-        dict, each key refers to a tuple of x and y positions. The values in
-        'mask_pos' will serve as image mask. If None, nothing will be drawn.
-        Defaults to 'head'. If dict, the 'autoshrink' (bool) field will
-        trigger automated shrinking of the positions due to points outside the
-        outline. Moreover, a matplotlib patch object can be passed for
-        advanced masking options, either directly or as a function that returns
-        patches (required for multi-axis plots).
+    %(topomap_outlines)s
     layout : None | Layout | list of Layout
         Layout instance specifying sensor positions (does not need to be
         specified for Neuromag data). Or a list of Layout if projections
@@ -2520,6 +2511,7 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
     cmap : None | matplotlib colormap
         Colormap for the plot. If ``None``, defaults to 'Reds_r' for norm data,
         otherwise to 'RdBu_r'.
+    %(verbose)s
 
     Returns
     -------

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -42,8 +42,7 @@ from ..viz import (plot_ica_components, plot_ica_scores,
 from ..viz.ica import plot_ica_properties
 from ..viz.topomap import _plot_corrmap
 
-from ..channels.channels import (_contains_ch_type, ContainsMixin,
-                                 HEAD_SIZE_DEFAULT)
+from ..channels.channels import _contains_ch_type, ContainsMixin
 from ..io.write import start_file, end_file, write_id
 from ..utils import (check_version, logger, check_fname, verbose,
                      _reject_data_segments, check_random_state, _validate_type,
@@ -2437,8 +2436,7 @@ def _find_max_corrs(all_maps, target, threshold):
 @verbose
 def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
             plot=True, show=True, outlines='head', layout=None,
-            sensors=True, contours=6, cmap=None, sphere=HEAD_SIZE_DEFAULT,
-            verbose=None):
+            sensors=True, contours=6, cmap=None, sphere=None, verbose=None):
     """Find similar Independent Components across subjects by map similarity.
 
     Corrmap (Viola et al. 2009 Clin Neurophysiol) identifies the best group

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -542,7 +542,8 @@ def _add_exg(raw, kind, head_pos, interp, n_jobs, random_state):
         ch = None
     nn = np.zeros_like(exg_rr)
     nn[:, 2] = 1
-    src = setup_volume_source_space(pos=dict(rr=exg_rr, nn=nn))
+    src = setup_volume_source_space(pos=dict(rr=exg_rr, nn=nn),
+                                    sphere_units='mm')
     _log_ch('%s simulated and trace' % kind, info, ch)
     del ch, nn, noise
 

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -64,9 +64,10 @@ def test_iterable():
     """Test iterable support for simulate_raw."""
     raw = read_raw_fif(raw_fname_short).load_data()
     raw.pick_channels(raw.ch_names[:10] + ['STI 014'])
-    src = setup_volume_source_space(
-        pos=dict(rr=[[-0.05, 0, 0], [0.1, 0, 0]],
-                 nn=[[0, 1., 0], [0, 1., 0]]))
+    with pytest.deprecated_call(match='units'):
+        src = setup_volume_source_space(
+            pos=dict(rr=[[-0.05, 0, 0], [0.1, 0, 0]],
+                    nn=[[0, 1., 0], [0, 1., 0]]))
     assert src.kind == 'discrete'
     trans = None
     sphere = make_sphere_model(head_radius=None, info=raw.info)
@@ -437,8 +438,9 @@ def test_simulate_raw_chpi():
     raw.info.normalize_proj()
     sphere = make_sphere_model('auto', 'auto', raw.info)
     # make sparse spherical source space
-    sphere_vol = tuple(sphere['r0'] * 1000.) + (sphere.radius * 1000.,)
-    src = setup_volume_source_space(sphere=sphere_vol, pos=70.)
+    sphere_vol = tuple(sphere['r0']) + (sphere.radius,)
+    src = setup_volume_source_space(sphere=sphere_vol, pos=70.,
+                                    sphere_units='m')
     stcs = [_make_stc(raw, src)] * 15
     # simulate data with cHPI on
     raw_sim = simulate_raw(raw.info, stcs, None, src, sphere,

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -64,10 +64,9 @@ def test_iterable():
     """Test iterable support for simulate_raw."""
     raw = read_raw_fif(raw_fname_short).load_data()
     raw.pick_channels(raw.ch_names[:10] + ['STI 014'])
-    with pytest.deprecated_call(match='units'):
-        src = setup_volume_source_space(
-            pos=dict(rr=[[-0.05, 0, 0], [0.1, 0, 0]],
-                    nn=[[0, 1., 0], [0, 1., 0]]))
+    src = setup_volume_source_space(
+        pos=dict(rr=[[-0.05, 0, 0], [0.1, 0, 0]],
+                 nn=[[0, 1., 0], [0, 1., 0]]))
     assert src.kind == 'discrete'
     trans = None
     sphere = make_sphere_model(head_radius=None, info=raw.info)

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -33,7 +33,7 @@ from .surface import (read_surface, _create_surf_spacing, _get_ico_surface,
                       _CheckInside)
 from .utils import (get_subjects_dir, check_fname, logger, verbose,
                     _ensure_int, check_version, _get_call_line, warn,
-                    _check_fname, _check_path_like, has_nibabel)
+                    _check_fname, _check_path_like, has_nibabel, _check_sphere)
 from .parallel import parallel_func, check_n_jobs
 from .transforms import (invert_transform, apply_trans, _print_coord_trans,
                          combine_transforms, _get_trans,
@@ -1490,7 +1490,8 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
                               sphere=(0.0, 0.0, 0.0, 90.0), bem=None,
                               surface=None, mindist=5.0, exclude=0.0,
                               subjects_dir=None, volume_label=None,
-                              add_interpolator=True, verbose=None):
+                              add_interpolator=True, sphere_units=None,
+                              verbose=None):
     """Set up a volume source space with grid spacing or discrete source space.
 
     Parameters
@@ -1517,9 +1518,9 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
         else it will stay None.
     sphere : ndarray, shape (4,) | ConductorModel
         Define spherical source space bounds using origin and radius given
-        by (ox, oy, oz, rad) in mm. Only used if ``bem`` and ``surface``
-        are both None. Can also be a spherical ConductorModel, which will
-        use the origin and radius.
+        by (ox, oy, oz, rad) in ``sphere_units``.
+        Only used if ``bem`` and ``surface`` are both None. Can also be a
+        spherical ConductorModel, which will use the origin and radius.
     bem : str | None | ConductorModel
         Define source space bounds using a BEM file (specifically the inner
         skull surface) or a ConductorModel for a 1-layer of 3-layers BEM.
@@ -1538,6 +1539,11 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
     add_interpolator : bool
         If True and ``mri`` is not None, then an interpolation matrix
         will be produced.
+    sphere_units : str
+        Defaults to ``"mm"`` in 0.20 but will change to ``"m"`` in 0.21.
+        Set it explicitly to avoid warnings.
+
+        .. versionadded:: 0.20
     %(verbose)s
 
     Returns
@@ -1617,17 +1623,8 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
                                  'check  freesurfer lookup table.'
                                  % (label, mri))
 
-    if isinstance(sphere, ConductorModel):
-        if not sphere['is_sphere'] or len(sphere['layers']) == 0:
-            raise ValueError('sphere, if a ConductorModel, must be spherical '
-                             'with multiple layers, not a BEM or single-layer '
-                             'sphere (got %s)' % (sphere,))
-        sphere = tuple(1000 * sphere['r0']) + (1000 *
-                                               sphere['layers'][0]['rad'],)
-    sphere = np.asarray(sphere, dtype=float)
-    if sphere.size != 4:
-        raise ValueError('"sphere" must be array_like with 4 elements, got: %s'
-                         % (sphere,))
+    need_warn = sphere_units is None and not isinstance(sphere, ConductorModel)
+    sphere = _check_sphere(sphere, sphere_units=sphere_units)
 
     # triage bounding argument
     if bem is not None:
@@ -1647,8 +1644,12 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
         logger.info('Boundary surface file : %s', surf_extra)
     else:
         logger.info('Sphere                : origin at (%.1f %.1f %.1f) mm'
-                    % (sphere[0], sphere[1], sphere[2]))
-        logger.info('              radius  : %.1f mm' % sphere[3])
+                    % (1000 * sphere[0], 1000 * sphere[1], 1000 * sphere[2]))
+        logger.info('              radius  : %.1f mm' % (1000 * sphere[3],))
+        if need_warn:
+            warn('sphere_units defaults to mm in 0.20 but will change to m in '
+                 '0.21, set it explicitly to avoid this warning',
+                 DeprecationWarning)
 
     # triage pos argument
     if isinstance(pos, dict):
@@ -1713,7 +1714,7 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
             surf['rr'] *= 1e-3  # must be converted to meters
         else:  # Load an icosahedron and use that as the surface
             logger.info('Setting up the sphere...')
-            surf = dict(R=sphere[3] / 1000., r0=sphere[:3] / 1000.)
+            surf = dict(R=sphere[3], r0=sphere[:3])
         # Make the grid of sources in MRI space
         if volume_label is not None:
             sp = []
@@ -1725,6 +1726,7 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
         else:
             sp = [_make_volume_source_space(surf, pos, exclude, mindist, mri,
                                             volume_label)]
+    del sphere
     if volume_label is None:
         volume_label = ['the whole brain']
     assert len(volume_label) == len(sp)

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1487,7 +1487,7 @@ def setup_source_space(subject, spacing='oct6', surface='white',
 
 @verbose
 def setup_volume_source_space(subject=None, pos=5.0, mri=None,
-                              sphere=(0.0, 0.0, 0.0, 90.0), bem=None,
+                              sphere=None, bem=None,
                               surface=None, mindist=5.0, exclude=0.0,
                               subjects_dir=None, volume_label=None,
                               add_interpolator=True, sphere_units=None,
@@ -1521,6 +1521,8 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
         by (ox, oy, oz, rad) in ``sphere_units``.
         Only used if ``bem`` and ``surface`` are both None. Can also be a
         spherical ConductorModel, which will use the origin and radius.
+        The default (None) is a temporary alias for ``(0.0, 0.0, 0.0, 0.09)``
+        in meters.
     bem : str | None | ConductorModel
         Define source space bounds using a BEM file (specifically the inner
         skull surface) or a ConductorModel for a 1-layer of 3-layers BEM.
@@ -1623,6 +1625,12 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
                                  'check  freesurfer lookup table.'
                                  % (label, mri))
 
+    if sphere is None:  # just allow this until deprecation is over
+        sphere = np.array((0.0, 0.0, 0.0, 90.0))
+        if isinstance(sphere_units, str) and sphere_units == 'm':
+            sphere /= 1000.
+        else:
+            sphere_units = 'mm'
     need_warn = sphere_units is None and not isinstance(sphere, ConductorModel)
     sphere = _check_sphere(sphere, sphere_units=sphere_units)
 

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -269,7 +269,8 @@ def test_volume_source_space(tmpdir):
     # Spheres
     sphere = make_sphere_model(r0=(0., 0., 0.), head_radius=0.1,
                                relative_radii=(0.9, 1.0), sigmas=(0.33, 1.0))
-    src = setup_volume_source_space(pos=10)
+    with pytest.deprecated_call(match='sphere_units'):
+        src = setup_volume_source_space(pos=10)
     src_new = setup_volume_source_space(pos=10, sphere=sphere)
     _compare_source_spaces(src, src_new, mode='exact')
     with pytest.raises(ValueError, match='could not convert string to float'):

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -270,10 +270,10 @@ def test_volume_source_space(tmpdir):
     sphere = make_sphere_model(r0=(0., 0., 0.), head_radius=0.1,
                                relative_radii=(0.9, 1.0), sigmas=(0.33, 1.0))
     with pytest.deprecated_call(match='sphere_units'):
-        src = setup_volume_source_space(pos=10)
+        src = setup_volume_source_space(pos=10, sphere=(0., 0., 0., 90))
     src_new = setup_volume_source_space(pos=10, sphere=sphere)
     _compare_source_spaces(src, src_new, mode='exact')
-    with pytest.raises(ValueError, match='could not convert string to float'):
+    with pytest.raises(ValueError, match='sphere, if str'):
         setup_volume_source_space(sphere='foo')
     # Need a radius
     sphere = make_sphere_model(head_radius=None)

--- a/mne/tests/test_transforms.py
+++ b/mne/tests/test_transforms.py
@@ -182,7 +182,7 @@ def test_polar_to_cartesian():
                     _pol_to_cart(polar), atol=1e-7)
 
 
-def _topo_to_sphere(theta, radius):
+def _topo_to_phi_theta(theta, radius):
     """Convert using old function."""
     sph_phi = (0.5 - radius) * 180
     sph_theta = -theta
@@ -202,9 +202,9 @@ def test_topo_to_sph():
     new[:, [0, 1]] = new[:, [1, 0]] * [-1, 1]
     # old way
     for ii, (angle, radius) in enumerate(zip(angles, radii)):
-        sph_phi, sph_theta = _topo_to_sphere(angle, radius)
+        sph_phi, sph_theta = _topo_to_phi_theta(angle, radius)
         if ii == 0:
-            assert_allclose(_topo_to_sphere(angle, radius), [45, -30])
+            assert_allclose(_topo_to_phi_theta(angle, radius), [45, -30])
         azimuth = sph_theta / 180.0 * np.pi
         elevation = sph_phi / 180.0 * np.pi
         assert_allclose(sph[ii], [1., azimuth, np.pi / 2. - elevation],

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1834,7 +1834,6 @@ class AverageTFR(_BaseTFR):
             - dividing by the mean of baseline values, taking the log, and
               dividing by the standard deviation of log baseline values
               ('zlogratio')
-
         %(layout_dep)s
         vmin : float | callable | None
             The value specifying the lower bound of the color range. If None,

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1794,7 +1794,7 @@ class AverageTFR(_BaseTFR):
                      colorbar=True, unit=None, res=64, size=2,
                      cbar_fmt='%1.1e', show_names=False, title=None,
                      axes=None, show=True, outlines='head', head_pos=None,
-                     contours=6, head_radius=HEAD_SIZE_DEFAULT):
+                     contours=6, sphere=HEAD_SIZE_DEFAULT):
         """Plot topographic maps of time-frequency intervals of TFR data.
 
         Parameters
@@ -1900,7 +1900,7 @@ class AverageTFR(_BaseTFR):
             inaccurate, use array for accuracy). If an array, the values
             represent the levels for the contours. If colorbar=True, the ticks
             in colorbar correspond to the contour levels. Defaults to 6.
-        %(topomap_head_radius_auto)s
+        %(topomap_sphere_auto)s
 
         Returns
         -------
@@ -1916,7 +1916,7 @@ class AverageTFR(_BaseTFR):
                                 cbar_fmt=cbar_fmt, show_names=show_names,
                                 title=title, axes=axes, show=show,
                                 outlines=outlines, head_pos=head_pos,
-                                contours=contours, head_radius=head_radius)
+                                contours=contours, sphere=sphere)
 
     def _check_compat(self, tfr):
         """Check that self and tfr have the same time-frequency ranges."""

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1353,10 +1353,7 @@ class AverageTFR(_BaseTFR):
             Call pyplot.show() at the end.
         title : str | None
             String for title. Defaults to None (blank/no title).
-        layout : Layout | None
-            Layout instance specifying sensor positions. Used for interactive
-            plotting of topographies on rectangle selection. If possible, the
-            correct layout is inferred from the data.
+        %(layout_dep)s
         yscale : 'auto' (default) | 'linear' | 'log'
             The scale of y (frequency) axis. 'linear' gives linear y axis,
             'log' leads to log-spaced y axis and 'auto' detects if frequencies
@@ -1839,12 +1836,7 @@ class AverageTFR(_BaseTFR):
               dividing by the standard deviation of log baseline values
               ('zlogratio')
 
-        layout : None | Layout
-            Layout instance specifying sensor positions (does not need to
-            be specified for Neuromag data). If possible, the correct layout
-            file is inferred from the data; if no appropriate layout file was
-            found, the layout is automatically generated from the sensor
-            locations.
+        %(layout_dep)s
         vmin : float | callable | None
             The value specifying the lower bound of the color range. If None,
             and vmax is None, -vmax is used. Else np.min(data) or in case

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -26,8 +26,7 @@ from ..utils import (logger, verbose, _time_mask, _freq_mask, check_fname,
                      fill_doc, _prepare_write_metadata, _check_event_id,
                      _gen_events, SizeMixin, _is_numeric, _check_option,
                      _validate_type)
-from ..channels.channels import (ContainsMixin, UpdateChannelsMixin,
-                                 HEAD_SIZE_DEFAULT)
+from ..channels.channels import ContainsMixin, UpdateChannelsMixin
 from ..channels.layout import _pair_grad_sensors
 from ..io.pick import (pick_info, _picks_to_idx, channel_type, _pick_inst,
                        _get_channel_types)
@@ -1791,7 +1790,7 @@ class AverageTFR(_BaseTFR):
                      colorbar=True, unit=None, res=64, size=2,
                      cbar_fmt='%1.1e', show_names=False, title=None,
                      axes=None, show=True, outlines='head', head_pos=None,
-                     contours=6, sphere=HEAD_SIZE_DEFAULT):
+                     contours=6, sphere=None):
         """Plot topographic maps of time-frequency intervals of TFR data.
 
         Parameters

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -26,7 +26,8 @@ from ..utils import (logger, verbose, _time_mask, _freq_mask, check_fname,
                      fill_doc, _prepare_write_metadata, _check_event_id,
                      _gen_events, SizeMixin, _is_numeric, _check_option,
                      _validate_type)
-from ..channels.channels import ContainsMixin, UpdateChannelsMixin
+from ..channels.channels import (ContainsMixin, UpdateChannelsMixin,
+                                 HEAD_SIZE_DEFAULT)
 from ..channels.layout import _pair_grad_sensors
 from ..io.pick import (pick_info, _picks_to_idx, channel_type, _pick_inst,
                        _get_channel_types)
@@ -1786,13 +1787,14 @@ class AverageTFR(_BaseTFR):
         plt_show(show)
         return fig
 
+    @fill_doc
     def plot_topomap(self, tmin=None, tmax=None, fmin=None, fmax=None,
                      ch_type=None, baseline=None, mode='mean', layout=None,
                      vmin=None, vmax=None, cmap=None, sensors=True,
                      colorbar=True, unit=None, res=64, size=2,
                      cbar_fmt='%1.1e', show_names=False, title=None,
                      axes=None, show=True, outlines='head', head_pos=None,
-                     contours=6):
+                     contours=6, head_radius=HEAD_SIZE_DEFAULT):
         """Plot topographic maps of time-frequency intervals of TFR data.
 
         Parameters
@@ -1889,22 +1891,8 @@ class AverageTFR(_BaseTFR):
             The axes to plot to. If None the axes is defined automatically.
         show : bool
             Call pyplot.show() at the end.
-        outlines : 'head' | 'skirt' | dict | None
-            The outlines to be drawn. If 'head', the default head scheme will
-            be drawn. If 'skirt' the head scheme will be drawn, but sensors are
-            allowed to be plotted outside of the head circle. If dict, each key
-            refers to a tuple of x and y positions, the values in 'mask_pos'
-            will serve as image mask, and the 'autoshrink' (bool) field will
-            trigger automated shrinking of the positions due to points outside
-            the outline. Alternatively, a matplotlib patch object can be passed
-            for advanced masking options, either directly or as a function that
-            returns patches (required for multi-axis plots). If None, nothing
-            will be drawn. Defaults to 'head'.
-        head_pos : dict | None
-            If None (default), the sensors are positioned such that they span
-            the head circle. If dict, can have entries 'center' (tuple) and
-            'scale' (tuple) for what the center and scale of the head should be
-            relative to the electrode locations.
+        %(topomap_outlines)s
+        %(topomap_head_pos)s
         contours : int | array of float
             The number of contour lines to draw. If 0, no contours will be
             drawn. When an integer, matplotlib ticker locator is used to find
@@ -1912,6 +1900,7 @@ class AverageTFR(_BaseTFR):
             inaccurate, use array for accuracy). If an array, the values
             represent the levels for the contours. If colorbar=True, the ticks
             in colorbar correspond to the contour levels. Defaults to 6.
+        %(topomap_head_radius_auto)s
 
         Returns
         -------
@@ -1927,7 +1916,7 @@ class AverageTFR(_BaseTFR):
                                 cbar_fmt=cbar_fmt, show_names=show_names,
                                 title=title, axes=axes, show=show,
                                 outlines=outlines, head_pos=head_pos,
-                                contours=contours)
+                                contours=contours, head_radius=head_radius)
 
     def _check_compat(self, tfr):
         """Check that self and tfr have the same time-frequency ranges."""

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -15,7 +15,7 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_channels_spatial_filter, _check_one_ch_type,
                     _check_rank, _check_option, _check_depth, _check_combine,
                     _check_path_like, _check_src_normal, _check_stc_units,
-                    _check_pyqt5_version, _check_head_radius)
+                    _check_pyqt5_version, _check_sphere)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -15,7 +15,7 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_channels_spatial_filter, _check_one_ch_type,
                     _check_rank, _check_option, _check_depth, _check_combine,
                     _check_path_like, _check_src_normal, _check_stc_units,
-                    _check_pyqt5_version)
+                    _check_pyqt5_version, _check_head_radius)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -580,3 +580,18 @@ def _check_pyqt5_version():
              % (version,))
 
     return version
+
+
+def _check_head_radius(head_radius, info=None):
+    from ..bem import fit_sphere_to_headshape
+    if info is None:
+        _validate_type(head_radius, 'numeric', 'head_radius')
+    else:
+        _validate_type(head_radius, ('numeric', str), 'head_radius')
+        if isinstance(head_radius, str):
+            if head_radius != 'auto':
+                raise ValueError('head_radius, if str, must be "auto", got %r'
+                                 % (head_radius))
+            head_radius, _, _ = fit_sphere_to_headshape(
+                info, verbose=False, units='m', move_origin=False)
+    return float(head_radius)

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -583,7 +583,18 @@ def _check_pyqt5_version():
 
 
 def _check_sphere(sphere, info=None, sphere_units='m'):
-    from ..bem import fit_sphere_to_headshape, ConductorModel
+    from ..defaults import HEAD_SIZE_DEFAULT
+    from ..bem import fit_sphere_to_headshape, ConductorModel, get_fitting_dig
+    if sphere is None:
+        sphere = HEAD_SIZE_DEFAULT
+        if info is not None:
+            # Decide if we have enough dig points to do the auto fit
+            try:
+                get_fitting_dig(info, 'extra', verbose='error')
+            except (RuntimeError, ValueError):
+                pass
+            else:
+                sphere = 'auto'
     if isinstance(sphere, str):
         if sphere != 'auto':
             raise ValueError('sphere, if str, must be "auto", got %r'

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -71,12 +71,12 @@ extrapolate : str
         Extrapolate to four points placed to form a square encompassing all
         data points, where each side of the square is three times the range
         of the data in the respective dimension.
+    - 'local'
+        Extrapolate only to nearby points (approximately to points closer than
+        median inter-electrode distance).
     - 'head'
         Extrapolate to the edges of the head circle (does not work well
         with sensors outside the head circle).
-    - 'local'
-        Extrapolate only to nearby points (approximately to points closer than
-        median inter-electrode distance)
 """
 docdict['topomap_head_pos'] = """
 head_pos : dict | None

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -65,13 +65,18 @@ outlines : 'head' | 'skirt' | dict | None
 """
 docdict['topomap_extrapolate'] = """
 extrapolate : str
-    If 'box' (default) extrapolate to four points placed to form a square
-    encompassing all data points, where each side of the square is three
-    times the range of the data in the respective dimension. If 'head'
-    extrapolate to the edges of the head circle (or to the edges of the
-    skirt if ``outlines='skirt'``). If 'local' extrapolate only to nearby
-    points (approximately to points closer than median inter-electrode
-    distance).
+    Options:
+
+    - 'box' (default)
+        Extrapolate to four points placed to form a square encompassing all
+        data points, where each side of the square is three times the range
+        of the data in the respective dimension.
+    - 'head'
+        Extrapolate to the edges of the head circle (does not work well
+        with sensors outside the head circle).
+    - 'local'
+        Extrapolate only to nearby points (approximately to points closer than
+        median inter-electrode distance)
 """
 docdict['topomap_head_pos'] = """
 head_pos : dict | None

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -50,6 +50,36 @@ include_tmax : bool
 docdict["show"] = """
 show : bool
     Show figure if True."""
+# XXX need to update proj_topomap_kwargs below as well
+docdict['topomap_outlines'] = """
+outlines : 'head' | 'skirt' | dict | None
+    The outlines to be drawn. If 'head', the default head scheme will be
+    drawn. If 'skirt' the head scheme will be drawn, but sensors are
+    allowed to be plotted outside of the head circle. If dict, each key
+    refers to a tuple of x and y positions, the values in 'mask_pos' will
+    serve as image mask.
+    Alternatively, a matplotlib patch object can be passed for advanced
+    masking options, either directly or as a function that returns patches
+    (required for multi-axis plots). If None, nothing will be drawn.
+    Defaults to 'head'.
+"""
+docdict['topomap_head_pos'] = """
+head_pos : dict | None
+    Deprecated and will be removed in 0.21. Use ``head_radius`` instead.
+"""
+docdict['topomap_head_radius'] = """
+head_radius : float
+    The head radius to use for the cartoon head.
+
+    .. versionadded:: 0.20
+"""
+docdict['topomap_head_radius_auto'] = """
+head_radius : float | str
+    The head radius to use for the cartoon head.
+    Can be "auto" to use a digitization-based fit.
+
+    .. versionadded:: 0.20
+"""
 
 # Picks
 docdict['picks_header'] = 'picks : str | list | slice | None'
@@ -412,8 +442,7 @@ docdict["proj_topomap_kwargs"] = """
         drawn. If 'skirt' the head scheme will be drawn, but sensors are
         allowed to be plotted outside of the head circle. If dict, each key
         refers to a tuple of x and y positions, the values in 'mask_pos' will
-        serve as image mask, and the 'autoshrink' (bool) field will trigger
-        automated shrinking of the positions due to points outside the outline.
+        serve as image mask.
         Alternatively, a matplotlib patch object can be passed for advanced
         masking options, either directly or as a function that returns patches
         (required for multi-axis plots). If None, nothing will be drawn.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -50,7 +50,6 @@ include_tmax : bool
 docdict["show"] = """
 show : bool
     Show figure if True."""
-# XXX need to update proj_topomap_kwargs below as well
 docdict['topomap_outlines'] = """
 outlines : 'head' | 'skirt' | dict | None
     The outlines to be drawn. If 'head', the default head scheme will be
@@ -432,66 +431,61 @@ spatial_colors : bool
 
 # plot_projs_topomap
 docdict["proj_topomap_kwargs"] = """
-    layout : None | Layout | list of Layout
-        Layout instance specifying sensor positions (does not need to be
-        specified for Neuromag data). Or a list of Layout if projections
-        are from different sensor types.
-    cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
-        Colormap to use. If tuple, the first value indicates the colormap to
-        use and the second value is a boolean defining interactivity. In
-        interactive mode (only works if ``colorbar=True``) the colors are
-        adjustable by clicking and dragging the colorbar with left and right
-        mouse button. Left mouse button moves the scale up and down and right
-        mouse button adjusts the range. Hitting space bar resets the range. Up
-        and down arrows can be used to change the colormap. If None (default),
-        'Reds' is used for all positive data, otherwise defaults to 'RdBu_r'.
-        If 'interactive', translates to (None, True).
-    sensors : bool | str
-        Add markers for sensor locations to the plot. Accepts matplotlib plot
-        format string (e.g., 'r+' for red plusses). If True, a circle will be
-        used (via .add_artist). Defaults to True.
-    colorbar : bool
-        Plot a colorbar.
-    res : int
-        The resolution of the topomap image (n pixels along each side).
-    size : scalar
-        Side length of the topomaps in inches (only applies when plotting
-        multiple topomaps at a time).
-    show : bool
-        Show figure if True.
-    outlines : 'head' | 'skirt' | dict | None
-        The outlines to be drawn. If 'head', the default head scheme will be
-        drawn. If 'skirt' the head scheme will be drawn, but sensors are
-        allowed to be plotted outside of the head circle. If dict, each key
-        refers to a tuple of x and y positions, the values in 'mask_pos' will
-        serve as image mask.
-        Alternatively, a matplotlib patch object can be passed for advanced
-        masking options, either directly or as a function that returns patches
-        (required for multi-axis plots). If None, nothing will be drawn.
-        Defaults to 'head'.
-    contours : int | array of float
-        The number of contour lines to draw. If 0, no contours will be drawn.
-        When an integer, matplotlib ticker locator is used to find suitable
-        values for the contour thresholds (may sometimes be inaccurate, use
-        array for accuracy). If an array, the values represent the levels for
-        the contours. Defaults to 6.
-    image_interp : str
-        The image interpolation to be used. All matplotlib options are
-        accepted.
-    axes : instance of Axes | list | None
-        The axes to plot to. If list, the list must be a list of Axes of
-        the same length as the number of projectors. If instance of Axes,
-        there must be only one projector. Defaults to None.
-    vlim : tuple of length 2 | 'joint'
-        Colormap limits to use. If :class:`tuple`, specifies the lower and
-        upper bounds of the colormap (in that order); providing ``None`` for
-        either of these will set the corresponding boundary at the min/max of
-        the data (separately for each projector). The keyword value ``'joint'``
-        will compute the colormap limits jointly across all provided
-        projectors of the same channel type, using the min/max of the projector
-        data. If vlim is ``'joint'``, ``info`` must not be ``None``. Defaults
-        to ``(None, None)``.
-"""
+info : instance of Info
+    The info associated with the channels in the projectors.
+
+    .. versionchanged:: 0.20
+        The positional argument ``layout`` has been deprecated and replaced
+        by ``info``.
+cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
+    Colormap to use. If tuple, the first value indicates the colormap to
+    use and the second value is a boolean defining interactivity. In
+    interactive mode (only works if ``colorbar=True``) the colors are
+    adjustable by clicking and dragging the colorbar with left and right
+    mouse button. Left mouse button moves the scale up and down and right
+    mouse button adjusts the range. Hitting space bar resets the range. Up
+    and down arrows can be used to change the colormap. If None (default),
+    'Reds' is used for all positive data, otherwise defaults to 'RdBu_r'.
+    If 'interactive', translates to (None, True).
+sensors : bool | str
+    Add markers for sensor locations to the plot. Accepts matplotlib plot
+    format string (e.g., 'r+' for red plusses). If True, a circle will be
+    used (via .add_artist). Defaults to True.
+colorbar : bool
+    Plot a colorbar.
+res : int
+    The resolution of the topomap image (n pixels along each side).
+size : scalar
+    Side length of the topomaps in inches (only applies when plotting
+    multiple topomaps at a time).
+show : bool
+    Show figure if True.
+%(topomap_outlines)s
+contours : int | array of float
+    The number of contour lines to draw. If 0, no contours will be drawn.
+    When an integer, matplotlib ticker locator is used to find suitable
+    values for the contour thresholds (may sometimes be inaccurate, use
+    array for accuracy). If an array, the values represent the levels for
+    the contours. Defaults to 6.
+image_interp : str
+    The image interpolation to be used. All matplotlib options are
+    accepted.
+axes : instance of Axes | list | None
+    The axes to plot to. If list, the list must be a list of Axes of
+    the same length as the number of projectors. If instance of Axes,
+    there must be only one projector. Defaults to None.
+vlim : tuple of length 2 | 'joint'
+    Colormap limits to use. If :class:`tuple`, specifies the lower and
+    upper bounds of the colormap (in that order); providing ``None`` for
+    either of these will set the corresponding boundary at the min/max of
+    the data (separately for each projector). The keyword value ``'joint'``
+    will compute the colormap limits jointly across all provided
+    projectors of the same channel type, using the min/max of the projector
+    data. If vlim is ``'joint'``, ``info`` must not be ``None``. Defaults
+    to ``(None, None)``.
+layout : None
+    Deprecated, will be removed in 0.20. Use ``info`` instead.
+""" % docdict
 
 # Montage
 docdict["montage_deprecated"] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -12,6 +12,7 @@ import warnings
 import webbrowser
 
 from .config import get_config
+from ..defaults import HEAD_SIZE_DEFAULT
 from ..externals.doccer import filldoc, unindent_dict
 from .check import _check_option
 
@@ -82,20 +83,22 @@ sphere : float | array-like | instance of ConductorModel
     Can be array-like of shape (4,) to give the X/Y/Z origin and radius in
     meters, or a single float to give the radius (origin assumed 0, 0, 0).
     Can also be a spherical ConductorModel, which will use the origin and
-    radius.
+    radius. Can also be None (default) which is an alias for %s.
 
     .. versionadded:: 0.20
-"""
+""" % (HEAD_SIZE_DEFAULT,)
 docdict['topomap_sphere_auto'] = """
-sphere : float | array-like | str
+sphere : float | array-like | str | None
     The sphere parameters to use for the cartoon head.
     Can be array-like of shape (4,) to give the X/Y/Z origin and radius in
     meters, or a single float to give the radius (origin assumed 0, 0, 0).
     Can also be a spherical ConductorModel, which will use the origin and
     radius. Can be "auto" to use a digitization-based fit.
+    Can also be None (default) to use 'auto' when enough extra digitization
+    points are available, and %s otherwise.
 
     .. versionadded:: 0.20
-"""
+""" % (HEAD_SIZE_DEFAULT,)
 docdict['layout_dep'] = """
 layout : None
     Deprecated and will be removed in 0.21. Use ``sphere`` to control
@@ -279,7 +282,7 @@ dig_kinds : list of str | str
     Kind of digitization points to use in the fitting. These can be any
     combination of ('cardinal', 'hpi', 'eeg', 'extra'). Can also
     be 'auto' (default), which will use only the 'extra' points if
-    enough (more than 10) are available, and if not, uses 'extra' and
+    enough (more than 4) are available, and if not, uses 'extra' and
     'eeg' points.
 """
 docdict['exclude_frontal'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -65,18 +65,25 @@ outlines : 'head' | 'skirt' | dict | None
 """
 docdict['topomap_head_pos'] = """
 head_pos : dict | None
-    Deprecated and will be removed in 0.21. Use ``head_radius`` instead.
+    Deprecated and will be removed in 0.21. Use ``sphere`` instead.
 """
-docdict['topomap_head_radius'] = """
-head_radius : float
-    The head radius to use for the cartoon head.
+docdict['topomap_sphere'] = """
+sphere : float | array-like | instance of ConductorModel
+    The sphere parameters to use for the cartoon head.
+    Can be array-like of shape (4,) to give the X/Y/Z origin and radius in
+    meters, or a single float to give the radius (origin assumed 0, 0, 0).
+    Can also be a spherical ConductorModel, which will use the origin and
+    radius.
 
     .. versionadded:: 0.20
 """
-docdict['topomap_head_radius_auto'] = """
-head_radius : float | str
-    The head radius to use for the cartoon head.
-    Can be "auto" to use a digitization-based fit.
+docdict['topomap_sphere_auto'] = """
+sphere : float | array-like | str
+    The sphere parameters to use for the cartoon head.
+    Can be array-like of shape (4,) to give the X/Y/Z origin and radius in
+    meters, or a single float to give the radius (origin assumed 0, 0, 0).
+    Can also be a spherical ConductorModel, which will use the origin and
+    radius. Can be "auto" to use a digitization-based fit.
 
     .. versionadded:: 0.20
 """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -63,6 +63,16 @@ outlines : 'head' | 'skirt' | dict | None
     (required for multi-axis plots). If None, nothing will be drawn.
     Defaults to 'head'.
 """
+docdict['topomap_extrapolate'] = """
+extrapolate : str
+    If 'box' (default) extrapolate to four points placed to form a square
+    encompassing all data points, where each side of the square is three
+    times the range of the data in the respective dimension. If 'head'
+    extrapolate to the edges of the head circle (or to the edges of the
+    skirt if ``outlines='skirt'``). If 'local' extrapolate only to nearby
+    points (approximately to points closer than median inter-electrode
+    distance).
+"""
 docdict['topomap_head_pos'] = """
 head_pos : dict | None
     Deprecated and will be removed in 0.21. Use ``sphere`` instead.
@@ -86,6 +96,11 @@ sphere : float | array-like | str
     radius. Can be "auto" to use a digitization-based fit.
 
     .. versionadded:: 0.20
+"""
+docdict['layout_dep'] = """
+layout : None
+    Deprecated and will be removed in 0.21. Use ``sphere`` to control
+    head-sensor relationship instead.
 """
 
 # Picks

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -439,12 +439,6 @@ spatial_colors : bool
 
 # plot_projs_topomap
 docdict["proj_topomap_kwargs"] = """
-info : instance of Info
-    The info associated with the channels in the projectors.
-
-    .. versionchanged:: 0.20
-        The positional argument ``layout`` has been deprecated and replaced
-        by ``info``.
 cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
     Colormap to use. If tuple, the first value indicates the colormap to
     use and the second value is a boolean defining interactivity. In

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -8,7 +8,7 @@
 # License: Simplified BSD
 
 import numpy as np
-import collections
+import collections.abc
 from ...utils import get_config
 from ...utils.check import _check_option
 
@@ -42,7 +42,7 @@ def _check_color(color):
     from matplotlib.colors import colorConverter
     if isinstance(color, str):
         color = colorConverter.to_rgb(color)
-    elif isinstance(color, collections.Iterable):
+    elif isinstance(color, collections.abc.Iterable):
         np_color = np.array(color)
         if np_color.size % 3 != 0 and np_color.size % 4 != 0:
             raise ValueError("The expected valid format is RGB or RGBA.")

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -338,6 +338,8 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
 
         # detect ylims across figures
         if evoked and not manual_ylims:
+            # ensure get_ylim works properly
+            this_axes_dict['evoked'].figure.canvas.draw_idle()
             this_bot, this_top = this_axes_dict['evoked'].get_ylim()
             this_min = min(this_bot, this_top)
             this_max = max(this_bot, this_top)

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -14,6 +14,7 @@
 from collections import Counter
 from functools import partial
 from copy import deepcopy
+import warnings
 
 import numpy as np
 
@@ -557,7 +558,9 @@ def _plot_epochs_image(image, style_axes=True, epochs=None, picks=None,
         this_colorbar.ax.set_ylabel(unit, rotation=270, labelpad=12)
         if cmap[1]:
             ax_im.CB = DraggableColorbar(this_colorbar, im)
-        tight_layout(fig=fig)
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter('ignore')
+            tight_layout(fig=fig)
 
     # finish
     plt_show(show)

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -17,8 +17,8 @@ from copy import deepcopy
 
 import numpy as np
 
+from ..channels.channels import HEAD_SIZE_DEFAULT
 from ..defaults import _handle_default
-
 from ..utils import verbose, logger, warn, fill_doc, check_version
 from ..io.meas_info import create_info, _validate_type
 
@@ -879,7 +879,7 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
                     xscale='linear', area_mode='std', area_alpha=0.33,
                     dB=True, estimate='auto', show=True, n_jobs=1,
                     average=False, line_alpha=None, spatial_colors=True,
-                    verbose=None):
+                    head_radius=HEAD_SIZE_DEFAULT, verbose=None):
     """%(plot_psd_doc)s.
 
     Parameters
@@ -923,6 +923,7 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     %(plot_psd_average)s
     %(plot_psd_line_alpha)s
     %(plot_psd_spatial_colors)s
+    %(topomap_head_radius)s
     %(verbose)s
 
     Returns
@@ -951,7 +952,7 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     fig = _plot_psd(epochs, fig, freqs, psd_list, picks_list, titles_list,
                     units_list, scalings_list, ax_list, make_label, color,
                     area_mode, area_alpha, dB, estimate, average,
-                    spatial_colors, xscale, line_alpha)
+                    spatial_colors, xscale, line_alpha, head_radius)
     plt_show(show)
     return fig
 

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -18,7 +18,6 @@ import warnings
 
 import numpy as np
 
-from ..channels.channels import HEAD_SIZE_DEFAULT
 from ..defaults import _handle_default
 from ..utils import verbose, logger, warn, fill_doc, check_version
 from ..io.meas_info import create_info, _validate_type
@@ -884,7 +883,7 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
                     xscale='linear', area_mode='std', area_alpha=0.33,
                     dB=True, estimate='auto', show=True, n_jobs=1,
                     average=False, line_alpha=None, spatial_colors=True,
-                    sphere=HEAD_SIZE_DEFAULT, verbose=None):
+                    sphere=None, verbose=None):
     """%(plot_psd_doc)s.
 
     Parameters
@@ -928,7 +927,7 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     %(plot_psd_average)s
     %(plot_psd_line_alpha)s
     %(plot_psd_spatial_colors)s
-    %(topomap_sphere)s
+    %(topomap_sphere_auto)s
     %(verbose)s
 
     Returns

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -879,7 +879,7 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
                     xscale='linear', area_mode='std', area_alpha=0.33,
                     dB=True, estimate='auto', show=True, n_jobs=1,
                     average=False, line_alpha=None, spatial_colors=True,
-                    head_radius=HEAD_SIZE_DEFAULT, verbose=None):
+                    sphere=HEAD_SIZE_DEFAULT, verbose=None):
     """%(plot_psd_doc)s.
 
     Parameters
@@ -923,7 +923,7 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     %(plot_psd_average)s
     %(plot_psd_line_alpha)s
     %(plot_psd_spatial_colors)s
-    %(topomap_head_radius)s
+    %(topomap_sphere)s
     %(verbose)s
 
     Returns
@@ -952,7 +952,7 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     fig = _plot_psd(epochs, fig, freqs, psd_list, picks_list, titles_list,
                     units_list, scalings_list, ax_list, make_label, color,
                     area_mode, area_alpha, dB, estimate, average,
-                    spatial_colors, xscale, line_alpha, head_radius)
+                    spatial_colors, xscale, line_alpha, sphere)
     plt_show(show)
     return fig
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -36,7 +36,7 @@ from ..utils import (logger, _clean_names, warn, _pl, verbose, _validate_type,
 from .topo import _plot_evoked_topo
 from .topomap import (_prepare_topo_plot, plot_topomap, _get_pos_outlines,
                       _draw_outlines, _prepare_topomap, _set_contour_locator,
-                      _check_head_radius)
+                      _check_sphere)
 from ..channels.layout import _pair_grad_sensors, find_layout
 from ..channels.channels import HEAD_SIZE_DEFAULT
 
@@ -192,7 +192,7 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
                  noise_cov=None, colorbar=True, mask=None, mask_style=None,
                  mask_cmap=None, mask_alpha=.25, time_unit='s',
                  show_names=False, group_by=None,
-                 head_radius=HEAD_SIZE_DEFAULT):
+                 sphere=HEAD_SIZE_DEFAULT):
     """Aux function for plot_evoked and plot_evoked_image (cf. docstrings).
 
     Extra param is:
@@ -241,7 +241,7 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
                          mask_style=mask_style, mask_cmap=mask_cmap,
                          mask_alpha=mask_alpha, time_unit=time_unit,
                          show_names=show_names,
-                         head_radius=head_radius)
+                         sphere=sphere)
             if remove_xlabels and not ax.is_last_row():
                 ax.set_xticklabels([])
                 ax.set_xlabel("")
@@ -331,7 +331,7 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
                     units, scalings, hline, gfp, types, zorder, xlim, ylim,
                     times, bad_ch_idx, titles, ch_types_used, selectable,
                     False, line_alpha=1., nave=evoked.nave,
-                    time_unit=time_unit, head_radius=head_radius)
+                    time_unit=time_unit, sphere=sphere)
         plt.setp(axes, xlabel='Time (%s)' % time_unit)
 
     elif plot_type == 'image':
@@ -364,7 +364,7 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
 def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
                 scalings, hline, gfp, types, zorder, xlim, ylim, times,
                 bad_ch_idx, titles, ch_types_used, selectable, psd,
-                line_alpha, nave, time_unit, head_radius):
+                line_alpha, nave, time_unit, sphere):
     """Plot data as butterfly plot."""
     from matplotlib import patheffects, pyplot as plt
     from matplotlib.widgets import SpanSelector
@@ -372,7 +372,7 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
     texts = list()
     idxs = list()
     lines = list()
-    head_radius = _check_head_radius(head_radius, info)
+    sphere = _check_sphere(sphere, info)
     path_effects = [patheffects.withStroke(linewidth=2, foreground="w",
                                            alpha=0.75)]
     gfp_path_effects = [patheffects.withStroke(linewidth=5, foreground="w",
@@ -426,7 +426,7 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
                     x, y, z = locs3d.T
                     colors = _rgb(x, y, z)
                     _handle_spatial_colors(colors, info, idx, this_type, psd,
-                                           ax, head_radius)
+                                           ax, sphere)
                 else:
                     if isinstance(spatial_colors, (tuple, str)):
                         col = [spatial_colors]
@@ -534,13 +534,13 @@ def _add_nave(ax, nave):
             xytext=(0, 5), textcoords='offset pixels')
 
 
-def _handle_spatial_colors(colors, info, idx, ch_type, psd, ax, head_radius):
+def _handle_spatial_colors(colors, info, idx, ch_type, psd, ax, sphere):
     """Set up spatial colors."""
     used_nm = np.array(_clean_names(info['ch_names']))[idx]
     # find indices for bads
     bads = [np.where(used_nm == bad)[0][0] for bad in info['bads'] if bad in
             used_nm]
-    pos, outlines = _get_pos_outlines(info, idx, head_radius=head_radius)
+    pos, outlines = _get_pos_outlines(info, idx, sphere=sphere)
     loc = 1 if psd else 2  # Legend in top right for psd plot.
     _plot_legend(pos, colors, ax, bads, outlines, loc)
 
@@ -616,7 +616,7 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
                 scalings=None, titles=None, axes=None, gfp=False,
                 window_title=None, spatial_colors=False, zorder='unsorted',
                 selectable=True, noise_cov=None, time_unit='s',
-                head_radius=HEAD_SIZE_DEFAULT, verbose=None):
+                sphere=HEAD_SIZE_DEFAULT, verbose=None):
     """Plot evoked data using butterfly plots.
 
     Left click to a line shows the channel name. Selecting an area by clicking
@@ -709,7 +709,7 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
         The units for the time axis, can be "ms" or "s" (default).
 
         .. versionadded:: 0.16
-    %(topomap_head_radius)s
+    %(topomap_sphere)s
     %(verbose)s
 
     Returns
@@ -727,7 +727,7 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
         scalings=scalings, titles=titles, axes=axes, plot_type="butterfly",
         gfp=gfp, window_title=window_title, spatial_colors=spatial_colors,
         selectable=selectable, zorder=zorder, noise_cov=noise_cov,
-        time_unit=time_unit, head_radius=head_radius)
+        time_unit=time_unit, sphere=sphere)
 
 
 def plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
@@ -849,7 +849,7 @@ def plot_evoked_image(evoked, picks=None, exclude='bads', unit=True,
                       cmap='RdBu_r', colorbar=True, mask=None,
                       mask_style=None, mask_cmap="Greys", mask_alpha=.25,
                       time_unit='s', show_names="auto", group_by=None,
-                      head_radius=HEAD_SIZE_DEFAULT):
+                      sphere=HEAD_SIZE_DEFAULT):
     """Plot evoked data as images.
 
     Parameters
@@ -957,7 +957,7 @@ def plot_evoked_image(evoked, picks=None, exclude='bads', unit=True,
             group_by=dict(Left_ROI=[1, 2, 3, 4], Right_ROI=[5, 6, 7, 8])
 
         If None, all picked channels are plotted to the same axis.
-    %(topomap_head_radius)s
+    %(topomap_sphere)s
 
     Returns
     -------
@@ -971,7 +971,7 @@ def plot_evoked_image(evoked, picks=None, exclude='bads', unit=True,
                         colorbar=colorbar, mask=mask, mask_style=mask_style,
                         mask_cmap=mask_cmap, mask_alpha=mask_alpha,
                         time_unit=time_unit, show_names=show_names,
-                        group_by=group_by, head_radius=head_radius)
+                        group_by=group_by, sphere=sphere)
 
 
 def _plot_update_evoked(params, bools):
@@ -998,7 +998,7 @@ def _plot_update_evoked(params, bools):
 
 @verbose
 def plot_evoked_white(evoked, noise_cov, show=True, rank=None, time_unit='s',
-                      head_radius=HEAD_SIZE_DEFAULT, verbose=None):
+                      sphere=HEAD_SIZE_DEFAULT, verbose=None):
     """Plot whitened evoked response.
 
     Plots the whitened evoked response and the whitened GFP as described in
@@ -1019,7 +1019,7 @@ def plot_evoked_white(evoked, noise_cov, show=True, rank=None, time_unit='s',
         The units for the time axis, can be "ms" or "s" (default).
 
         .. versionadded:: 0.16
-    %(topomap_head_radius)s
+    %(topomap_sphere)s
     %(verbose)s
 
     Returns
@@ -1056,11 +1056,11 @@ def plot_evoked_white(evoked, noise_cov, show=True, rank=None, time_unit='s',
     """
     return _plot_evoked_white(evoked=evoked, noise_cov=noise_cov,
                               scalings=None, rank=rank, show=show,
-                              time_unit=time_unit, head_radius=head_radius)
+                              time_unit=time_unit, sphere=sphere)
 
 
 def _plot_evoked_white(evoked, noise_cov, scalings, rank, show, time_unit,
-                       head_radius):
+                       sphere):
     """Help plot_evoked_white.
 
     Additional Parameters
@@ -1387,7 +1387,7 @@ def plot_evoked_joint(evoked, times="peaks", title='', picks=None,
                        proj=False, hline=None, units=None, scalings=None,
                        titles=None, gfp=False, window_title=None,
                        spatial_colors=True, zorder='std',
-                       head_radius=HEAD_SIZE_DEFAULT)
+                       sphere=HEAD_SIZE_DEFAULT)
     ts_args_def.update(ts_args)
     _plot_evoked(evoked, axes=ts_ax, show=False, plot_type='butterfly',
                  exclude=[], set_tight_layout=False, **ts_args_def)
@@ -1676,13 +1676,13 @@ def _handle_styles_pce(styles, linestyles, colors, cmap, conditions):
 
 
 def _evoked_sensor_legend(info, picks, ymin, ymax, show_sensors, ax,
-                          head_radius):
+                          sphere):
     """Show sensor legend (location of a set of sensors on the head)."""
     if show_sensors is True:
         ymin, ymax = np.abs(ax.get_ylim())
         show_sensors = "lower right" if ymin > ymax else "upper right"
 
-    pos, outlines = _get_pos_outlines(info, picks, head_radius=head_radius)
+    pos, outlines = _get_pos_outlines(info, picks, sphere=sphere)
     show_sensors = _check_loc_legal(show_sensors, "show_sensors")
     _plot_legend(pos, ["k"] * len(picks), ax, list(), outlines,
                  show_sensors, size=25)
@@ -1889,7 +1889,7 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
                          truncate_xaxis=True, ylim=None, invert_y=False,
                          show_sensors=None, legend=True,
                          split_legend=None, axes=None, title=None, show=True,
-                         combine=None, head_radius=HEAD_SIZE_DEFAULT):
+                         combine=None, sphere=HEAD_SIZE_DEFAULT):
     """Plot evoked time courses for one or more conditions and/or channels.
 
     Parameters
@@ -2032,7 +2032,7 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
         unless ``picks`` is a single channel (not channel type) or
         ``axes='topo'``, in which cases no combining is performed. Defaults to
         ``None``.
-    %(topomap_head_radius)s
+    %(topomap_sphere)s
 
     Returns
     -------
@@ -2120,7 +2120,7 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
     one_evoked = evokeds[conditions[0]][0]
     times = one_evoked.times
     info = one_evoked.info
-    head_radius = _check_head_radius(head_radius, info)
+    sphere = _check_sphere(sphere, info)
     tmin, tmax = times[0], times[-1]
     # set some defaults
     if ylim is None:
@@ -2308,7 +2308,7 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
                  'Not showing channel locations.')
         else:
             _evoked_sensor_legend(one_evoked.info, pos_picks, ymin, ymax,
-                                  show_sensors, ax, head_radius)
+                                  show_sensors, ax, sphere)
     # add color/linestyle/colormap legend(s)
     if legend:
         _draw_legend_pce(legend, split_legend, _styles, _linestyles, _colors,

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -34,10 +34,11 @@ from ..utils import (logger, _clean_names, warn, _pl, verbose, _validate_type,
                      _check_if_nan, _check_ch_locs, fill_doc, _is_numeric)
 
 from .topo import _plot_evoked_topo
-from .topomap import (_prepare_topo_plot, plot_topomap, _check_outlines,
-                      _draw_outlines, _prepare_topomap, _set_contour_locator)
-from ..channels.layout import (_pair_grad_sensors, _find_topomap_coords,
-                               find_layout)
+from .topomap import (_prepare_topo_plot, plot_topomap, _get_pos_outlines,
+                      _draw_outlines, _prepare_topomap, _set_contour_locator,
+                      _check_head_radius)
+from ..channels.layout import _pair_grad_sensors, find_layout
+from ..channels.channels import HEAD_SIZE_DEFAULT
 
 
 def _butterfly_onpick(event, params):
@@ -190,7 +191,8 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
                  set_tight_layout=True, selectable=True, zorder='unsorted',
                  noise_cov=None, colorbar=True, mask=None, mask_style=None,
                  mask_cmap=None, mask_alpha=.25, time_unit='s',
-                 show_names=False, group_by=None):
+                 show_names=False, group_by=None,
+                 head_radius=HEAD_SIZE_DEFAULT):
     """Aux function for plot_evoked and plot_evoked_image (cf. docstrings).
 
     Extra param is:
@@ -238,7 +240,8 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
                          colorbar=colorbar, mask=mask,
                          mask_style=mask_style, mask_cmap=mask_cmap,
                          mask_alpha=mask_alpha, time_unit=time_unit,
-                         show_names=show_names)
+                         show_names=show_names,
+                         head_radius=head_radius)
             if remove_xlabels and not ax.is_last_row():
                 ax.set_xticklabels([])
                 ax.set_xlabel("")
@@ -328,7 +331,7 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
                     units, scalings, hline, gfp, types, zorder, xlim, ylim,
                     times, bad_ch_idx, titles, ch_types_used, selectable,
                     False, line_alpha=1., nave=evoked.nave,
-                    time_unit=time_unit)
+                    time_unit=time_unit, head_radius=head_radius)
         plt.setp(axes, xlabel='Time (%s)' % time_unit)
 
     elif plot_type == 'image':
@@ -361,7 +364,7 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
 def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
                 scalings, hline, gfp, types, zorder, xlim, ylim, times,
                 bad_ch_idx, titles, ch_types_used, selectable, psd,
-                line_alpha, nave, time_unit='ms'):
+                line_alpha, nave, time_unit, head_radius):
     """Plot data as butterfly plot."""
     from matplotlib import patheffects, pyplot as plt
     from matplotlib.widgets import SpanSelector
@@ -369,6 +372,7 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
     texts = list()
     idxs = list()
     lines = list()
+    head_radius = _check_head_radius(head_radius, info)
     path_effects = [patheffects.withStroke(linewidth=2, foreground="w",
                                            alpha=0.75)]
     gfp_path_effects = [patheffects.withStroke(linewidth=5, foreground="w",
@@ -422,7 +426,7 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
                     x, y, z = locs3d.T
                     colors = _rgb(x, y, z)
                     _handle_spatial_colors(colors, info, idx, this_type, psd,
-                                           ax)
+                                           ax, head_radius)
                 else:
                     if isinstance(spatial_colors, (tuple, str)):
                         col = [spatial_colors]
@@ -530,15 +534,13 @@ def _add_nave(ax, nave):
             xytext=(0, 5), textcoords='offset pixels')
 
 
-def _handle_spatial_colors(colors, info, idx, ch_type, psd, ax):
+def _handle_spatial_colors(colors, info, idx, ch_type, psd, ax, head_radius):
     """Set up spatial colors."""
     used_nm = np.array(_clean_names(info['ch_names']))[idx]
     # find indices for bads
     bads = [np.where(used_nm == bad)[0][0] for bad in info['bads'] if bad in
             used_nm]
-    pos = _find_topomap_coords(info, idx, ignore_overlap=True)
-    pos, outlines = _check_outlines(pos, np.array([1, 1]),
-                                    {'center': (0, 0), 'scale': (0.5, 0.5)})
+    pos, outlines = _get_pos_outlines(info, idx, head_radius=head_radius)
     loc = 1 if psd else 2  # Legend in top right for psd plot.
     _plot_legend(pos, colors, ax, bads, outlines, loc)
 
@@ -613,7 +615,8 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
                 ylim=None, xlim='tight', proj=False, hline=None, units=None,
                 scalings=None, titles=None, axes=None, gfp=False,
                 window_title=None, spatial_colors=False, zorder='unsorted',
-                selectable=True, noise_cov=None, time_unit='s', verbose=None):
+                selectable=True, noise_cov=None, time_unit='s',
+                head_radius=HEAD_SIZE_DEFAULT, verbose=None):
     """Plot evoked data using butterfly plots.
 
     Left click to a line shows the channel name. Selecting an area by clicking
@@ -706,6 +709,7 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
         The units for the time axis, can be "ms" or "s" (default).
 
         .. versionadded:: 0.16
+    %(topomap_head_radius)s
     %(verbose)s
 
     Returns
@@ -723,7 +727,7 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
         scalings=scalings, titles=titles, axes=axes, plot_type="butterfly",
         gfp=gfp, window_title=window_title, spatial_colors=spatial_colors,
         selectable=selectable, zorder=zorder, noise_cov=noise_cov,
-        time_unit=time_unit)
+        time_unit=time_unit, head_radius=head_radius)
 
 
 def plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
@@ -844,7 +848,8 @@ def plot_evoked_image(evoked, picks=None, exclude='bads', unit=True,
                       units=None, scalings=None, titles=None, axes=None,
                       cmap='RdBu_r', colorbar=True, mask=None,
                       mask_style=None, mask_cmap="Greys", mask_alpha=.25,
-                      time_unit='s', show_names="auto", group_by=None):
+                      time_unit='s', show_names="auto", group_by=None,
+                      head_radius=HEAD_SIZE_DEFAULT):
     """Plot evoked data as images.
 
     Parameters
@@ -952,6 +957,7 @@ def plot_evoked_image(evoked, picks=None, exclude='bads', unit=True,
             group_by=dict(Left_ROI=[1, 2, 3, 4], Right_ROI=[5, 6, 7, 8])
 
         If None, all picked channels are plotted to the same axis.
+    %(topomap_head_radius)s
 
     Returns
     -------
@@ -965,7 +971,7 @@ def plot_evoked_image(evoked, picks=None, exclude='bads', unit=True,
                         colorbar=colorbar, mask=mask, mask_style=mask_style,
                         mask_cmap=mask_cmap, mask_alpha=mask_alpha,
                         time_unit=time_unit, show_names=show_names,
-                        group_by=group_by)
+                        group_by=group_by, head_radius=head_radius)
 
 
 def _plot_update_evoked(params, bools):
@@ -992,8 +998,8 @@ def _plot_update_evoked(params, bools):
 
 @verbose
 def plot_evoked_white(evoked, noise_cov, show=True, rank=None, time_unit='s',
-                      verbose=None):
-    u"""Plot whitened evoked response.
+                      head_radius=HEAD_SIZE_DEFAULT, verbose=None):
+    """Plot whitened evoked response.
 
     Plots the whitened evoked response and the whitened GFP as described in
     [1]_. This function is especially useful for investigating noise
@@ -1013,6 +1019,7 @@ def plot_evoked_white(evoked, noise_cov, show=True, rank=None, time_unit='s',
         The units for the time axis, can be "ms" or "s" (default).
 
         .. versionadded:: 0.16
+    %(topomap_head_radius)s
     %(verbose)s
 
     Returns
@@ -1049,11 +1056,11 @@ def plot_evoked_white(evoked, noise_cov, show=True, rank=None, time_unit='s',
     """
     return _plot_evoked_white(evoked=evoked, noise_cov=noise_cov,
                               scalings=None, rank=rank, show=show,
-                              time_unit=time_unit)
+                              time_unit=time_unit, head_radius=head_radius)
 
 
-def _plot_evoked_white(evoked, noise_cov, scalings=None, rank=None, show=True,
-                       time_unit='s'):
+def _plot_evoked_white(evoked, noise_cov, scalings, rank, show, time_unit,
+                       head_radius):
     """Help plot_evoked_white.
 
     Additional Parameters
@@ -1379,7 +1386,8 @@ def plot_evoked_joint(evoked, times="peaks", title='', picks=None,
     ts_args_def = dict(picks=None, unit=True, ylim=None, xlim='tight',
                        proj=False, hline=None, units=None, scalings=None,
                        titles=None, gfp=False, window_title=None,
-                       spatial_colors=True, zorder='std')
+                       spatial_colors=True, zorder='std',
+                       head_radius=HEAD_SIZE_DEFAULT)
     ts_args_def.update(ts_args)
     _plot_evoked(evoked, axes=ts_ax, show=False, plot_type='butterfly',
                  exclude=[], set_tight_layout=False, **ts_args_def)
@@ -1667,16 +1675,14 @@ def _handle_styles_pce(styles, linestyles, colors, cmap, conditions):
     return styles, linestyles, colors, cmap, colorbar_title, colorbar_ticks
 
 
-def _evoked_sensor_legend(info, picks, ymin, ymax, show_sensors, ax):
+def _evoked_sensor_legend(info, picks, ymin, ymax, show_sensors, ax,
+                          head_radius):
     """Show sensor legend (location of a set of sensors on the head)."""
     if show_sensors is True:
         ymin, ymax = np.abs(ax.get_ylim())
         show_sensors = "lower right" if ymin > ymax else "upper right"
 
-    pos = _find_topomap_coords(info, picks, ignore_overlap=True)
-    head_pos = {'center': (0, 0), 'scale': (0.5, 0.5)}
-    pos, outlines = _check_outlines(pos, np.array([1, 1]), head_pos)
-
+    pos, outlines = _get_pos_outlines(info, picks, head_radius=head_radius)
     show_sensors = _check_loc_legal(show_sensors, "show_sensors")
     _plot_legend(pos, ["k"] * len(picks), ax, list(), outlines,
                  show_sensors, size=25)
@@ -1883,7 +1889,7 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
                          truncate_xaxis=True, ylim=None, invert_y=False,
                          show_sensors=None, legend=True,
                          split_legend=None, axes=None, title=None, show=True,
-                         combine=None):
+                         combine=None, head_radius=HEAD_SIZE_DEFAULT):
     """Plot evoked time courses for one or more conditions and/or channels.
 
     Parameters
@@ -2026,6 +2032,7 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
         unless ``picks`` is a single channel (not channel type) or
         ``axes='topo'``, in which cases no combining is performed. Defaults to
         ``None``.
+    %(topomap_head_radius)s
 
     Returns
     -------
@@ -2113,6 +2120,7 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
     one_evoked = evokeds[conditions[0]][0]
     times = one_evoked.times
     info = one_evoked.info
+    head_radius = _check_head_radius(head_radius, info)
     tmin, tmax = times[0], times[-1]
     # set some defaults
     if ylim is None:
@@ -2300,7 +2308,7 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
                  'Not showing channel locations.')
         else:
             _evoked_sensor_legend(one_evoked.info, pos_picks, ymin, ymax,
-                                  show_sensors, ax)
+                                  show_sensors, ax, head_radius)
     # add color/linestyle/colormap legend(s)
     if legend:
         _draw_legend_pce(legend, split_legend, _styles, _linestyles, _colors,

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -2191,7 +2191,8 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
                 linestyles=linestyles, styles=styles, vlines=vlines, ci=ci,
                 truncate_yaxis=truncate_yaxis, ylim=ylim, invert_y=invert_y,
                 legend=legend, show_sensors=show_sensors,
-                axes=ax, title=_title, split_legend=split_legend, show=show))
+                axes=ax, title=_title, split_legend=split_legend, show=show,
+                sphere=sphere))
         return figs
 
     # colors and colormap. This yields a `styles` dict with one entry per
@@ -2233,7 +2234,8 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
                 truncate_yaxis=truncate_yaxis, truncate_xaxis=truncate_xaxis,
                 ylim=ylim, invert_y=invert_y, show_sensors=show_sensors,
                 legend=legend, split_legend=split_legend,
-                picks=picks[pick_], combine=combine, axes=ax_, show=True)
+                picks=picks[pick_], combine=combine, axes=ax_, show=True,
+                sphere=sphere)
 
         layout = find_layout(info)
         # shift everything to the right by 15% of one axes width

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -36,7 +36,7 @@ from ..utils import (logger, _clean_names, warn, _pl, verbose, _validate_type,
 from .topo import _plot_evoked_topo
 from .topomap import (_prepare_topo_plot, plot_topomap, _check_outlines,
                       _draw_outlines, _prepare_topomap, _set_contour_locator)
-from ..channels.layout import (_pair_grad_sensors, _auto_topomap_coords,
+from ..channels.layout import (_pair_grad_sensors, _find_topomap_coords,
                                find_layout)
 
 
@@ -536,7 +536,7 @@ def _handle_spatial_colors(colors, info, idx, ch_type, psd, ax):
     # find indices for bads
     bads = [np.where(used_nm == bad)[0][0] for bad in info['bads'] if bad in
             used_nm]
-    pos = _auto_topomap_coords(info, idx, ignore_overlap=True, to_sphere=True)
+    pos = _find_topomap_coords(info, idx, ignore_overlap=True)
     pos, outlines = _check_outlines(pos, np.array([1, 1]),
                                     {'center': (0, 0), 'scale': (0.5, 0.5)})
     loc = 1 if psd else 2  # Legend in top right for psd plot.
@@ -1673,8 +1673,7 @@ def _evoked_sensor_legend(info, picks, ymin, ymax, show_sensors, ax):
         ymin, ymax = np.abs(ax.get_ylim())
         show_sensors = "lower right" if ymin > ymax else "upper right"
 
-    pos = _auto_topomap_coords(info, picks, ignore_overlap=True,
-                               to_sphere=True)
+    pos = _find_topomap_coords(info, picks, ignore_overlap=True)
     head_pos = {'center': (0, 0), 'scale': (0.5, 0.5)}
     pos, outlines = _check_outlines(pos, np.array([1, 1]), head_pos)
 

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -16,7 +16,7 @@ from .utils import (tight_layout, _prepare_trellis, _select_bads,
                     _plot_raw_onscroll, _mouse_click,
                     _plot_raw_onkey, plt_show, _convert_psds)
 from .topomap import (_prepare_topomap_plot, plot_topomap, _hide_frame,
-                      _plot_ica_topomap)
+                      _plot_ica_topomap, _make_head_outlines)
 from .raw import _prepare_mne_browse_raw, _plot_raw_traces
 from .epochs import _prepare_mne_browse_epochs, plot_epochs_image
 from .evoked import _butterfly_on_button_press, _butterfly_onpick
@@ -1067,12 +1067,13 @@ def _label_clicked(pos, params):
     fig, axes = _prepare_trellis(len(types), max_col=3)
     for ch_idx, ch_type in enumerate(types):
         try:
-            data_picks, pos, merge_grads, _, _, this_sphere = \
+            data_picks, pos, merge_grads, _, _, this_sphere, clip_origin = \
                 _prepare_topomap_plot(ica, ch_type)
         except Exception as exc:
             warn(str(exc))
             plt.close(fig)
             return
+        outlines = _make_head_outlines(this_sphere, pos, 'head', clip_origin)
         this_data = data[:, data_picks]
         ax = axes[ch_idx]
         if merge_grads:
@@ -1081,7 +1082,7 @@ def _label_clicked(pos, params):
             ax.set_title('%s %s' % (ica._ica_names[ii], ch_type), fontsize=12)
             data_ = _merge_grad_data(data_) if merge_grads else data_
             plot_topomap(data_.flatten(), pos, axes=ax, show=False,
-                         sphere=this_sphere)
+                         sphere=this_sphere, outlines=outlines)
             _hide_frame(ax)
     tight_layout(fig=fig)
     fig.subplots_adjust(top=0.88, bottom=0.)

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -1067,10 +1067,10 @@ def _label_clicked(pos, params):
     fig, axes = _prepare_trellis(len(types), max_col=3)
     for ch_idx, ch_type in enumerate(types):
         try:
-            data_picks, pos, merge_grads, _, _ = _prepare_topomap_plot(
-                ica, ch_type)
+            data_picks, pos, merge_grads, _, _, this_sphere = \
+                _prepare_topomap_plot(ica, ch_type)
         except Exception as exc:
-            warn(exc)
+            warn(str(exc))
             plt.close(fig)
             return
         this_data = data[:, data_picks]
@@ -1080,7 +1080,8 @@ def _label_clicked(pos, params):
         for ii, data_ in zip(ic_idx, this_data):
             ax.set_title('%s %s' % (ica._ica_names[ii], ch_type), fontsize=12)
             data_ = _merge_grad_data(data_) if merge_grads else data_
-            plot_topomap(data_.flatten(), pos, axes=ax, show=False)
+            plot_topomap(data_.flatten(), pos, axes=ax, show=False,
+                         sphere=this_sphere)
             _hide_frame(ax)
     tight_layout(fig=fig)
     fig.subplots_adjust(top=0.88, bottom=0.)

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -15,7 +15,7 @@ import numpy as np
 from .utils import (tight_layout, _prepare_trellis, _select_bads,
                     _plot_raw_onscroll, _mouse_click,
                     _plot_raw_onkey, plt_show, _convert_psds)
-from .topomap import (_prepare_topo_plot, plot_topomap, _hide_frame,
+from .topomap import (_prepare_topomap_plot, plot_topomap, _hide_frame,
                       _plot_ica_topomap)
 from .raw import _prepare_mne_browse_raw, _plot_raw_traces
 from .epochs import _prepare_mne_browse_epochs, plot_epochs_image
@@ -1067,9 +1067,8 @@ def _label_clicked(pos, params):
     fig, axes = _prepare_trellis(len(types), max_col=3)
     for ch_idx, ch_type in enumerate(types):
         try:
-            data_picks, pos, merge_grads, _, _ = _prepare_topo_plot(ica,
-                                                                    ch_type,
-                                                                    None)
+            data_picks, pos, merge_grads, _, _ = _prepare_topomap_plot(
+                ica, ch_type)
         except Exception as exc:
             warn(exc)
             plt.close(fig)

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -1,13 +1,16 @@
 """Functions to plot EEG sensor montages or digitizer montages."""
 from copy import deepcopy
 import numpy as np
-from ..utils import check_version, logger, _check_option, _validate_type
+from ..utils import (check_version, logger, _check_option, _validate_type,
+                     verbose)
 from . import plot_sensors
 from ..io._digitization import _get_fid_coords
+from ..channels.channels import HEAD_SIZE_DEFAULT
 
 
+@verbose
 def plot_montage(montage, scale_factor=20, show_names=True, kind='topomap',
-                 show=True):
+                 show=True, sphere=HEAD_SIZE_DEFAULT, verbose=None):
     """Plot a montage.
 
     Parameters
@@ -22,6 +25,8 @@ def plot_montage(montage, scale_factor=20, show_names=True, kind='topomap',
         Whether to plot the montage as '3d' or 'topomap' (default).
     show : bool
         Show figure if True.
+    %(topomap_sphere_auto)s
+    %(verbose)s
 
     Returns
     -------
@@ -64,7 +69,7 @@ def plot_montage(montage, scale_factor=20, show_names=True, kind='topomap',
 
     info = create_info(ch_names, sfreq=256, ch_types="eeg", montage=montage)
     fig = plot_sensors(info, kind=kind, show_names=show_names, show=show,
-                       title=title)
+                       title=title, sphere=sphere)
     collection = fig.axes[0].collections[0]
     if check_version("matplotlib", "1.4"):
         collection.set_sizes([scale_factor])

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -5,12 +5,11 @@ from ..utils import (check_version, logger, _check_option, _validate_type,
                      verbose)
 from . import plot_sensors
 from ..io._digitization import _get_fid_coords
-from ..channels.channels import HEAD_SIZE_DEFAULT
 
 
 @verbose
 def plot_montage(montage, scale_factor=20, show_names=True, kind='topomap',
-                 show=True, sphere=HEAD_SIZE_DEFAULT, verbose=None):
+                 show=True, sphere=None, verbose=None):
     """Plot a montage.
 
     Parameters

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -12,7 +12,6 @@ from functools import partial
 import numpy as np
 
 from ..annotations import _annotations_starts_stops
-from ..channels.channels import HEAD_SIZE_DEFAULT
 from ..filter import create_filter, _overlap_add_filter
 from ..io.pick import (pick_types, _pick_data_channels, pick_info,
                        _PICK_TYPES_KEYS, pick_channels)
@@ -567,8 +566,7 @@ def plot_raw_psd(raw, fmin=0, fmax=np.inf, tmin=None, tmax=None, proj=False,
                  picks=None, ax=None, color='black', xscale='linear',
                  area_mode='std', area_alpha=0.33, dB=True, estimate='auto',
                  show=True, n_jobs=1, average=False, line_alpha=None,
-                 spatial_colors=True, sphere=HEAD_SIZE_DEFAULT,
-                 verbose=None):
+                 spatial_colors=True, sphere=None, verbose=None):
     """%(plot_psd_doc)s.
 
     Parameters

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -12,6 +12,7 @@ from functools import partial
 import numpy as np
 
 from ..annotations import _annotations_starts_stops
+from ..channels.channels import HEAD_SIZE_DEFAULT
 from ..filter import create_filter, _overlap_add_filter
 from ..io.pick import (pick_types, _pick_data_channels, pick_info,
                        _PICK_TYPES_KEYS, pick_channels)
@@ -566,7 +567,8 @@ def plot_raw_psd(raw, fmin=0, fmax=np.inf, tmin=None, tmax=None, proj=False,
                  picks=None, ax=None, color='black', xscale='linear',
                  area_mode='std', area_alpha=0.33, dB=True, estimate='auto',
                  show=True, n_jobs=1, average=False, line_alpha=None,
-                 spatial_colors=True, verbose=None):
+                 spatial_colors=True, head_radius=HEAD_SIZE_DEFAULT,
+                 verbose=None):
     """%(plot_psd_doc)s.
 
     Parameters
@@ -609,6 +611,7 @@ def plot_raw_psd(raw, fmin=0, fmax=np.inf, tmin=None, tmax=None, proj=False,
     %(plot_psd_average)s
     %(plot_psd_line_alpha)s
     %(plot_psd_spatial_colors)s
+    %(topomap_head_radius_auto)s
     %(verbose)s
 
     Returns
@@ -637,7 +640,7 @@ def plot_raw_psd(raw, fmin=0, fmax=np.inf, tmin=None, tmax=None, proj=False,
     fig = _plot_psd(raw, fig, freqs, psd_list, picks_list, titles_list,
                     units_list, scalings_list, ax_list, make_label, color,
                     area_mode, area_alpha, dB, estimate, average,
-                    spatial_colors, xscale, line_alpha)
+                    spatial_colors, xscale, line_alpha, head_radius)
     plt_show(show)
     return fig
 

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -567,7 +567,7 @@ def plot_raw_psd(raw, fmin=0, fmax=np.inf, tmin=None, tmax=None, proj=False,
                  picks=None, ax=None, color='black', xscale='linear',
                  area_mode='std', area_alpha=0.33, dB=True, estimate='auto',
                  show=True, n_jobs=1, average=False, line_alpha=None,
-                 spatial_colors=True, head_radius=HEAD_SIZE_DEFAULT,
+                 spatial_colors=True, sphere=HEAD_SIZE_DEFAULT,
                  verbose=None):
     """%(plot_psd_doc)s.
 
@@ -611,7 +611,7 @@ def plot_raw_psd(raw, fmin=0, fmax=np.inf, tmin=None, tmax=None, proj=False,
     %(plot_psd_average)s
     %(plot_psd_line_alpha)s
     %(plot_psd_spatial_colors)s
-    %(topomap_head_radius_auto)s
+    %(topomap_sphere_auto)s
     %(verbose)s
 
     Returns
@@ -640,7 +640,7 @@ def plot_raw_psd(raw, fmin=0, fmax=np.inf, tmin=None, tmax=None, proj=False,
     fig = _plot_psd(raw, fig, freqs, psd_list, picks_list, titles_list,
                     units_list, scalings_list, ax_list, make_label, color,
                     area_mode, area_alpha, dB, estimate, average,
-                    spatial_colors, xscale, line_alpha, head_radius)
+                    spatial_colors, xscale, line_alpha, sphere)
     plt_show(show)
     return fig
 

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -204,7 +204,9 @@ def test_plot_ica_sources():
     fig = ica.plot_sources(raw)
     # also test mouse clicks
     data_ax = fig.axes[0]
+    assert len(plt.get_fignums()) == 1
     _fake_click(fig, data_ax, [-0.1, 0.9])  # click on y-label
+    assert len(plt.get_fignums()) == 2
     ica.exclude = [1]
     ica.plot_sources(raw)
 

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -451,21 +451,24 @@ def test_plot_sensors():
     # Click with no sensors
     _fake_click(fig, ax, (0., 0.), xform='data')
     _fake_click(fig, ax, (0, 0.), xform='data', kind='release')
-    assert len(fig.lasso.selection) == 0
+    assert fig.lasso.selection == []
 
-    # Lasso with 1 sensor
-    _fake_click(fig, ax, (-0.5, 0.5), xform='data')
+    # Lasso with 1 sensor (upper left)
+    _fake_click(fig, ax, (0, 1), xform='ax')
     plt.draw()
-    _fake_click(fig, ax, (0., 0.5), xform='data', kind='motion')
-    _fake_click(fig, ax, (0., 0.), xform='data', kind='motion')
+    assert fig.lasso.selection == []
+    _fake_click(fig, ax, (0.7, 1), xform='ax', kind='motion')
+    _fake_click(fig, ax, (0.7, 0.7), xform='ax', kind='motion')
     fig.canvas.key_press_event('control')
-    _fake_click(fig, ax, (-0.5, 0.), xform='data', kind='release')
-    assert len(fig.lasso.selection) == 1
+    _fake_click(fig, ax, (0, 0.7), xform='ax', kind='release')
+    assert fig.lasso.selection == ['MEG 0121']
 
-    _fake_click(fig, ax, (-0.09, -0.43), xform='data')  # single selection
-    assert len(fig.lasso.selection) == 2
-    _fake_click(fig, ax, (-0.09, -0.43), xform='data')  # deselect
-    assert len(fig.lasso.selection) == 1
+    _fake_click(fig, ax, (0.7, 1), xform='ax', kind='motion')
+    xy = ax.collections[0].get_offsets()
+    _fake_click(fig, ax, xy[2], xform='data')  # single selection
+    assert fig.lasso.selection == ['MEG 0121', 'MEG 0131']
+    _fake_click(fig, ax, xy[2], xform='data')  # deselect
+    assert fig.lasso.selection == ['MEG 0121']
     plt.close('all')
 
 

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -457,10 +457,10 @@ def test_plot_sensors():
     _fake_click(fig, ax, (0, 1), xform='ax')
     plt.draw()
     assert fig.lasso.selection == []
-    _fake_click(fig, ax, (0.7, 1), xform='ax', kind='motion')
-    _fake_click(fig, ax, (0.7, 0.7), xform='ax', kind='motion')
+    _fake_click(fig, ax, (0.65, 1), xform='ax', kind='motion')
+    _fake_click(fig, ax, (0.65, 0.65), xform='ax', kind='motion')
     fig.canvas.key_press_event('control')
-    _fake_click(fig, ax, (0, 0.7), xform='ax', kind='release')
+    _fake_click(fig, ax, (0, 0.65), xform='ax', kind='release')
     assert fig.lasso.selection == ['MEG 0121']
 
     _fake_click(fig, ax, (0.7, 1), xform='ax', kind='motion')

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -125,23 +125,26 @@ def test_plot_projs_topomap():
     plt.close('all')
 
 
-@pytest.mark.slowtest
-@testing.requires_testing_data
-def test_plot_topomap():
+def test_plot_topomap_animation():
     """Test topomap plotting."""
     # evoked
-    res = 8
-    fast_test = dict(res=res, contours=0, sensors=False, time_unit='s')
-    fast_test_noscale = dict(res=res, contours=0, sensors=False)
     evoked = read_evokeds(evoked_fname, 'Left Auditory',
                           baseline=(None, 0))
-
     # Test animation
     _, anim = evoked.animate_topomap(ch_type='grad', times=[0, 0.1],
                                      butterfly=False, time_unit='s')
     anim._func(1)  # _animate has to be tested separately on 'Agg' backend.
     plt.close('all')
 
+
+@pytest.mark.slowtest
+def test_plot_topomap():
+    """Test basics of topomap plotting."""
+    evoked = read_evokeds(evoked_fname, 'Left Auditory',
+                          baseline=(None, 0))
+    res = 8
+    fast_test = dict(res=res, contours=0, sensors=False, time_unit='s')
+    fast_test_noscale = dict(res=res, contours=0, sensors=False)
     ev_bad = evoked.copy().pick_types(meg=False, eeg=True)
     ev_bad.pick_channels(ev_bad.ch_names[:2])
     plt_topomap = partial(ev_bad.plot_topomap, **fast_test)

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -177,7 +177,8 @@ def test_plot_topomap_basic():
     plot_topomap(temp_data, info_sel, extrapolate='head', res=res)
 
     plt_topomap = partial(evoked.plot_topomap, **fast_test)
-    plt_topomap(0.1, layout=layout, scalings=dict(mag=0.1))
+    with pytest.deprecated_call(match='layout'):
+        plt_topomap(0.1, layout=layout, scalings=dict(mag=0.1))
     plt.close('all')
     axes = [plt.subplot(221), plt.subplot(222)]
     plt_topomap(axes=axes, colorbar=False)

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -18,20 +18,19 @@ from matplotlib.figure import Figure
 from matplotlib.patches import Circle
 
 from mne import (read_evokeds, read_proj, make_fixed_length_events, Epochs,
-                 compute_proj_evoked, find_layout)
-from mne.io.proj import make_eeg_average_ref_proj
+                 compute_proj_evoked, find_layout, pick_types)
+from mne.io.proj import make_eeg_average_ref_proj, Projection
 from mne.io import read_raw_fif, read_info
 from mne.io.constants import FIFF
 from mne.io.pick import pick_info, channel_indices_by_type
 from mne.io.compensator import get_current_comp
-from mne.io.proj import Projection
-from mne.channels import read_layout, make_eeg_layout
+from mne.channels import read_layout
 from mne.datasets import testing
 from mne.time_frequency.tfr import AverageTFR
 from mne.utils import run_tests_if_main
 
 from mne.viz import plot_evoked_topomap, plot_projs_topomap
-from mne.viz.topomap import (_check_outlines, _onselect, plot_topomap,
+from mne.viz.topomap import (_get_pos_outlines, _onselect, plot_topomap,
                              plot_arrowmap, plot_psds_topomap)
 from mne.viz.utils import _find_peaks, _fake_click
 
@@ -148,9 +147,8 @@ def test_plot_topomap():
     plt_topomap = partial(ev_bad.plot_topomap, **fast_test)
     plt_topomap(times=ev_bad.times[:2] - 1e-6)  # auto, plots EEG
     pytest.raises(ValueError, plt_topomap, ch_type='mag')
-    pytest.raises(TypeError, plt_topomap, head_pos='foo')
-    pytest.raises(KeyError, plt_topomap, head_pos=dict(foo='bar'))
-    pytest.raises(ValueError, plt_topomap, head_pos=dict(center=0))
+    with pytest.deprecated_call(match='head_pos'):
+        plt_topomap(head_pos='foo')
     pytest.raises(ValueError, plt_topomap, times=[-100])  # bad time
     pytest.raises(ValueError, plt_topomap, times=[[0]])  # bad time
 
@@ -271,35 +269,12 @@ def test_plot_topomap():
     # correspond with the EEG electrodes
     del evoked.info['dig'][85]
 
-    pos = make_eeg_layout(evoked.info).pos[:, :2]
-    pos, outlines = _check_outlines(pos, 'head')
-    assert ('head' in outlines.keys())
-    assert ('nose' in outlines.keys())
-    assert ('ear_left' in outlines.keys())
-    assert ('ear_right' in outlines.keys())
-    assert ('autoshrink' in outlines.keys())
-    assert (outlines['autoshrink'])
-    assert ('clip_radius' in outlines.keys())
-    assert_array_equal(outlines['clip_radius'], 0.5)
-
-    pos, outlines = _check_outlines(pos, 'skirt')
-    assert ('head' in outlines.keys())
-    assert ('nose' in outlines.keys())
-    assert ('ear_left' in outlines.keys())
-    assert ('ear_right' in outlines.keys())
-    assert ('autoshrink' in outlines.keys())
-    assert (not outlines['autoshrink'])
-    assert ('clip_radius' in outlines.keys())
-    assert_array_equal(outlines['clip_radius'], 0.625)
-
-    pos, outlines = _check_outlines(pos, 'skirt',
-                                    head_pos={'scale': [1.2, 1.2]})
-    assert_array_equal(outlines['clip_radius'], 0.75)
-
     # Plot skirt
     evoked.plot_topomap(times, ch_type='eeg', outlines='skirt', **fast_test)
 
     # Pass custom outlines without patch
+    eeg_picks = pick_types(evoked.info, meg=False, eeg=True)
+    pos, outlines = _get_pos_outlines(evoked.info, eeg_picks, 0.1)
     evoked.plot_topomap(times, ch_type='eeg', outlines=outlines, **fast_test)
     plt.close('all')
 
@@ -405,7 +380,7 @@ def test_plot_tfr_topomap():
         'button_release_event', plt.gcf().canvas, 0.9, 0.9, 1)
     erelease.xdata = 0.3
     erelease.ydata = 0.2
-    pos = [[0.11, 0.11], [0.25, 0.5], [0.0, 0.2], [0.2, 0.39]]
+    pos = np.array([[0.11, 0.11], [0.25, 0.5], [0.0, 0.2], [0.2, 0.39]])
     _onselect(eclick, erelease, tfr, pos, 'grad', 1, 3, 1, 3, 'RdBu_r', list())
     _onselect(eclick, erelease, tfr, pos, 'mag', 1, 3, 1, 3, 'RdBu_r', list())
     eclick.xdata = eclick.ydata = 0.

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -138,7 +138,7 @@ def test_plot_topomap_animation():
 
 
 @pytest.mark.slowtest
-def test_plot_topomap():
+def test_plot_topomap_basic():
     """Test basics of topomap plotting."""
     evoked = read_evokeds(evoked_fname, 'Left Auditory',
                           baseline=(None, 0))

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -108,20 +108,20 @@ def test_plot_projs_topomap():
     plot_projs_topomap(projs, info=info, colorbar=True, **fast_test)
     plt.close('all')
     ax = plt.subplot(111)
-    projs[3].plot_topomap()
-    plot_projs_topomap(projs[:1], axes=ax, **fast_test)  # test axes param
+    projs[3].plot_topomap(info)
+    plot_projs_topomap(projs[:1], info, axes=ax, **fast_test)  # test axes
     plt.close('all')
-    plot_projs_topomap(read_info(triux_fname)['projs'][-1:], **fast_test)
+    triux_info = read_info(triux_fname)
+    plot_projs_topomap(triux_info['projs'][-1:], triux_info, **fast_test)
     plt.close('all')
-    plot_projs_topomap(read_info(triux_fname)['projs'][:1], ** fast_test)
+    plot_projs_topomap(triux_info['projs'][:1], triux_info, **fast_test)
     plt.close('all')
     eeg_avg = make_eeg_average_ref_proj(info)
-    pytest.raises(RuntimeError, eeg_avg.plot_topomap)  # no layout
-    eeg_avg.plot_topomap(info=info, **fast_test)
+    eeg_avg.plot_topomap(info, **fast_test)
     plt.close('all')
     # test vlims
     for vlim in ('joint', (-1, 1), (None, 0.5), (0.5, None), (None, None)):
-        plot_projs_topomap(projs[:-1], vlim=vlim, info=info, colorbar=True)
+        plot_projs_topomap(projs[:-1], info, vlim=vlim, colorbar=True)
     plt.close('all')
 
 
@@ -462,9 +462,9 @@ def test_plot_topomap_neuromag122():
                                 col_names=evoked.ch_names, data=np.ones(122)),
                       explained_var=0.5)
 
-    plot_projs_topomap([proj], info=evoked.info, **fast_test)
-    plot_projs_topomap([proj], layout=layout, **fast_test)
-    pytest.raises(RuntimeError, plot_projs_topomap, [proj], **fast_test)
+    plot_projs_topomap([proj], evoked.info, **fast_test)
+    with pytest.deprecated_call(match='layout'):
+        plot_projs_topomap([proj], evoked.info, layout=layout, **fast_test)
 
 
 run_tests_if_main()

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -33,7 +33,7 @@ from .utils import (tight_layout, _setup_vmin_vmax, _prepare_trellis,
 from ..time_frequency import psd_multitaper
 from ..defaults import _handle_default
 from ..transforms import apply_trans, invert_transform
-from ..io.meas_info import Info
+from ..io.meas_info import Info, _simplify_info
 from ..io.proj import Projection
 
 
@@ -558,7 +558,7 @@ def _topomap_plot_sensors(pos_x, pos_y, sensors, ax):
 
 def _get_pos_outlines(info, picks, sphere, to_sphere=True):
     sphere = _check_sphere(sphere)
-    ch_type = _get_ch_type(info, None)
+    ch_type = _get_ch_type(pick_info(_simplify_info(info), picks), None)
     sphere = _adjust_meg_sphere(sphere, info, ch_type)
     pos = _find_topomap_coords(
         info, picks, ignore_overlap=True, to_sphere=to_sphere,

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -819,7 +819,7 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     cont = True
     if isinstance(contours, (np.ndarray, list)):
         pass
-    elif contours == 0 or (Zi == Zi[0, 0]).all():
+    elif contours == 0 or ((Zi == Zi[0, 0]) | np.isnan(Zi)).all():
         cont = None  # can't make contours for constant-valued functions
     if cont:
         with warnings.catch_warnings(record=True):

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -778,7 +778,6 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     xlim = np.inf, -np.inf,
     ylim = np.inf, -np.inf,
     mask_ = np.c_[outlines['mask_pos']]
-    print(outlines['mask_pos'][0].max())
     xmin, xmax = (np.min(np.r_[xlim[0], mask_[:, 0]]),
                   np.max(np.r_[xlim[1], mask_[:, 0]]))
     ymin, ymax = (np.min(np.r_[ylim[0], mask_[:, 1]]),

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -213,6 +213,12 @@ def plot_projs_topomap(projs, info, cmap=None, sensors=True,
     ----------
     projs : list of Projection
         The projections.
+    info : instance of Info
+        The info associated with the channels in the projectors.
+
+        .. versionchanged:: 0.20
+            The positional argument ``layout`` has been deprecated and replaced
+            by ``info``.
     %(proj_topomap_kwargs)s
     %(topomap_sphere_auto)s
     %(topomap_extrapolate)s

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1676,7 +1676,8 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
         if unit is not None:
             cax.set_title(unit)
         cbar = fig.colorbar(images[-1], ax=cax, cax=cax, format=cbar_fmt)
-        cbar.set_ticks(cn.levels)
+        if cn is not None:
+            cbar.set_ticks(cn.levels)
         cbar.ax.tick_params(labelsize=7)
         if cmap[1]:
             for im in images:

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -613,13 +613,25 @@ class _GridData(object):
         return self.interpolator(*args)
 
 
-def _plot_sensors(pos_x, pos_y, sensors, ax):
+def _topomap_plot_sensors(pos_x, pos_y, sensors, ax):
     """Plot sensors."""
     if sensors is True:
         ax.scatter(pos_x, pos_y, s=0.25, marker='o',
                    edgecolor=['k'] * len(pos_x), facecolor='none')
     else:
         ax.plot(pos_x, pos_y, sensors)
+
+
+def _get_pos_outlines(info, picks, ax, to_sphere):
+    pos = _find_topomap_coords(
+        info, picks, ignore_overlap=True, to_sphere=to_sphere)
+    if to_sphere:
+        outlines, head_pos = 'head', None
+    else:
+        outlines, head_pos = np.array([0.5, 0.5]), dict(
+            center=(0, 0), scale=(4.5, 4.5))
+    pos, outlines = _check_outlines(pos, outlines, head_pos)
+    return pos, outlines
 
 
 def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
@@ -885,12 +897,12 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
 
     pos_x, pos_y = pos.T
     if sensors is not False and mask is None:
-        _plot_sensors(pos_x, pos_y, sensors=sensors, ax=ax)
+        _topomap_plot_sensors(pos_x, pos_y, sensors=sensors, ax=ax)
     elif sensors and mask is not None:
         idx = np.where(mask)[0]
         ax.plot(pos_x[idx], pos_y[idx], **mask_params)
         idx = np.where(~mask)[0]
-        _plot_sensors(pos_x[idx], pos_y[idx], sensors=sensors, ax=ax)
+        _topomap_plot_sensors(pos_x[idx], pos_y[idx], sensors=sensors, ax=ax)
     elif not sensors and mask is not None:
         idx = np.where(mask)[0]
         ax.plot(pos_x[idx], pos_y[idx], **mask_params)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -39,7 +39,7 @@ from ..io.proj import Projection
 
 
 def _adjust_meg_sphere(sphere, info, ch_type):
-    sphere = _check_sphere(sphere)
+    sphere = _check_sphere(sphere, info)
     assert ch_type is not None
     if ch_type in ('mag', 'grad', 'planar1', 'planar2'):
         # move sphere X/Y (head coords) to device X/Y space

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -813,25 +813,19 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
                    aspect='equal', extent=(xmin, xmax, ymin, ymax),
                    interpolation=image_interp)
 
-    # This tackles an incomprehensible matplotlib bug if no contours are
-    # drawn. To avoid rescalings, we will always draw contours.
-    # But if no contours are desired we only draw one and make it invisible .
+    # gh-1432 had a workaround for no contours here, but we'll remove it
+    # because mpl has probably fixed it
     linewidth = mask_params['markeredgewidth']
-    no_contours = False
+    cont = True
     if isinstance(contours, (np.ndarray, list)):
-        pass  # contours precomputed
-    elif contours == 0:
-        contours, no_contours = 1, True
-    if (Zi == Zi[0, 0]).all():
+        pass
+    elif contours == 0 or (Zi == Zi[0, 0]).all():
         cont = None  # can't make contours for constant-valued functions
-    else:
+    if cont:
         with warnings.catch_warnings(record=True):
             warnings.simplefilter('ignore')
             cont = ax.contour(Xi, Yi, Zi, contours, colors='k',
                               linewidths=linewidth / 2.)
-    if no_contours and cont is not None:
-        for col in cont.collections:
-            col.set_visible(False)
 
     if patch_ is not None:
         im.set_clip_path(patch_)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2003,7 +2003,8 @@ def plot_layout(layout, picks=None, show=True):
                         hspace=None)
     ax.set(xticks=[], yticks=[], aspect='equal')
     pos = np.array([(p[0] + p[2] / 2., p[1] + p[3] / 2.) for p in layout.pos])
-    outlines = _make_head_outlines(0.5, pos)  # normalized
+    sphere = _check_sphere((0., 0., 0., 0.5))  # normalized
+    outlines = _make_head_outlines(sphere, pos)
     _draw_outlines(ax, outlines)
     picks = _picks_to_idx(len(layout.names), picks)
     pos = pos[picks]

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2094,7 +2094,7 @@ def _init_anim(ax, ax_line, ax_cbar, params, merge_grads, sphere):
         vmin, vmax = _setup_vmin_vmax(data, None, None)
         ax_line.set(yticks=np.around(np.linspace(vmin, vmax, 5), -1),
                     xlim=all_times[[0, -1]])
-        params['line'] = ax_line.axvline(all_times[0], color='r', lw=2, zorder=6)
+        params['line'] = ax_line.axvline(all_times[0], color='r')
         items.append(params['line'])
     if merge_grads:
         from mne.channels.layout import _merge_grad_data

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -25,7 +25,6 @@ from distutils.version import LooseVersion
 from itertools import cycle
 import warnings
 
-from ..channels.channels import HEAD_SIZE_DEFAULT
 from ..defaults import _handle_default
 from ..fixes import _get_status
 from ..io import show_fiff, Info
@@ -1501,8 +1500,7 @@ def _process_times(inst, use_times, n_peaks=None, few=False):
 @verbose
 def plot_sensors(info, kind='topomap', ch_type=None, title=None,
                  show_names=False, ch_groups=None, to_sphere=True, axes=None,
-                 block=False, show=True, sphere=HEAD_SIZE_DEFAULT,
-                 verbose=None):
+                 block=False, show=True, sphere=None, verbose=None):
     """Plot sensors positions.
 
     Parameters
@@ -1552,7 +1550,7 @@ def plot_sensors(info, kind='topomap', ch_type=None, title=None,
         .. versionadded:: 0.13.0
     show : bool
         Show figure if True. Defaults to True.
-    %(topomap_sphere)s
+    %(topomap_sphere_auto)s
     %(verbose)s
 
     Returns

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -25,7 +25,6 @@ from distutils.version import LooseVersion
 from itertools import cycle
 import warnings
 
-from ..channels.layout import _auto_topomap_coords
 from ..channels.channels import _contains_ch_type
 from ..defaults import _handle_default
 from ..fixes import _get_status
@@ -1639,12 +1638,9 @@ def plot_sensors(info, kind='topomap', ch_type=None, title=None,
                 if pick in value:
                     colors[pick_idx] = color_vals[ind]
                     break
-    if kind in ('topomap', 'select'):
-        pos = _auto_topomap_coords(info, picks, True, to_sphere=to_sphere)
-
     title = 'Sensor positions (%s)' % ch_type if title is None else title
-    fig = _plot_sensors(pos, colors, bads, ch_names, title, show_names, axes,
-                        show, kind == 'select', block=block,
+    fig = _plot_sensors(pos, info, picks, colors, bads, ch_names, title,
+                        show_names, axes, show, kind, block=block,
                         to_sphere=to_sphere)
     if kind == 'select':
         return fig, fig.lasso.selection
@@ -1681,17 +1677,17 @@ def _close_event(event, fig):
         fig.lasso.disconnect()
 
 
-def _plot_sensors(pos, colors, bads, ch_names, title, show_names, ax, show,
-                  select, block, to_sphere):
+def _plot_sensors(pos, info, picks, colors, bads, ch_names, title, show_names,
+                  ax, show, kind, block, to_sphere):
     """Plot sensors."""
     import matplotlib.pyplot as plt
     from mpl_toolkits.mplot3d import Axes3D
-    from .topomap import _check_outlines, _draw_outlines
+    from .topomap import _get_pos_outlines, _draw_outlines
     edgecolors = np.repeat('black', len(colors))
     edgecolors[bads] = 'red'
     if ax is None:
         fig = plt.figure(figsize=(max(plt.rcParams['figure.figsize']),) * 2)
-        if pos.shape[1] == 3:
+        if kind == '3d':
             Axes3D(fig)
             ax = fig.gca(projection='3d')
         else:
@@ -1699,7 +1695,7 @@ def _plot_sensors(pos, colors, bads, ch_names, title, show_names, ax, show,
     else:
         fig = ax.get_figure()
 
-    if pos.shape[1] == 3:
+    if kind == '3d':
         ax.text(0, 0, 0, '', zorder=1)
         ax.scatter(pos[:, 0], pos[:, 1], pos[:, 2], picker=True, c=colors,
                    s=75, edgecolor=edgecolors, linewidth=2)
@@ -1709,29 +1705,25 @@ def _plot_sensors(pos, colors, bads, ch_names, title, show_names, ax, show,
         ax.xaxis.set_label_text('x')
         ax.yaxis.set_label_text('y')
         ax.zaxis.set_label_text('z')
-    else:
+    else:  # kind in 'select', 'topomap'
         ax.text(0, 0, '', zorder=1)
-        # Equal aspect for 3D looks bad, so only use for 2D
-        ax.set(xticks=[], yticks=[], aspect='equal')
-        fig.subplots_adjust(left=0, bottom=0, right=1, top=1, wspace=None,
-                            hspace=None)
-        if to_sphere:
-            pos, outlines = _check_outlines(pos, 'head')
-        else:
-            pos, outlines = _check_outlines(pos, np.array([0.5, 0.5]),
-                                            {'center': (0, 0),
-                                             'scale': (4.5, 4.5)})
+
+        pos, outlines = _get_pos_outlines(info, picks, ax, to_sphere)
         _draw_outlines(ax, outlines)
-
-        pts = ax.scatter(pos[:, 0], pos[:, 1], picker=True, c=colors, s=25,
-                         edgecolor=edgecolors, linewidth=2, clip_on=False)
-
-        if select:
+        pts = ax.scatter(pos[:, 0], pos[:, 1], picker=True, clip_on=False,
+                         c=colors, edgecolors=edgecolors, s=25, lw=2)
+        raise RuntimeError
+        if kind == 'select':
             fig.lasso = SelectFromCollection(ax, pts, ch_names)
         else:
             fig.lasso = None
 
-        ax.axis("off")  # remove border around figure
+        # Equal aspect for 3D looks bad, so only use for 2D
+        ax.set(aspect='equal')
+        # XXX put these back
+        # fig.subplots_adjust(left=0, bottom=0, right=1, top=1, wspace=None,
+        #                     hspace=None)
+        # ax.axis("off")  # remove border around figure
 
     connect_picker = True
     if show_names:
@@ -1741,11 +1733,11 @@ def _plot_sensors(pos, colors, bads, ch_names, title, show_names, ax, show,
             indices = range(len(pos))
         for idx in indices:
             this_pos = pos[idx]
-            if pos.shape[1] == 3:
+            if kind == '3d':
                 ax.text(this_pos[0], this_pos[1], this_pos[2], ch_names[idx])
             else:
                 ax.text(this_pos[0] + 0.015, this_pos[1], ch_names[idx])
-        connect_picker = select
+        connect_picker = (kind == 'select')
     if connect_picker:
         picker = partial(_onpick_sensor, fig=fig, ax=ax, pos=pos,
                          ch_names=ch_names, show_names=show_names)

--- a/tutorials/intro/plot_40_sensor_locations.py
+++ b/tutorials/intro/plot_40_sensor_locations.py
@@ -31,13 +31,16 @@ raw = mne.io.read_raw_fif(sample_data_raw_file, preload=True, verbose=False)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # MNE-Python comes pre-loaded with information about the sensor positions of
-# many MEG and EEG systems. This information is stored in *layout files* and
-# *montages*. :class:`Layouts <mne.channels.Layout>` give sensor positions in 2
-# dimensions (defined by ``x``, ``y``, ``width``, and ``height`` values for
-# each sensor), and are primarily used for illustrative purposes (i.e., making
-# diagrams of approximate sensor positions in top-down diagrams of the head).
-# In contrast, :class:`montages <mne.channels.DigMontage>` contain sensor
-# positions in 3D (``x``, ``y``, ``z``, in meters). Many layout and montage
+# many MEG and EEG systems. This information is stored in *montages* and
+# *layout files*. :class:`montages <mne.channels.DigMontage>` contain sensor
+# positions in 3D (``x``, ``y``, ``z``, in meters), and can be used to set
+# the physical positions of sensors.
+#
+# For any given set of sensor positions (from a montage or otherwise), a
+# :class:`Layouts <mne.channels.Layout>` can be generated, mostly for the
+# purpose of interactively selecting channels.
+#
+# Many layout and montage
 # files are included during MNE-Python installation, and are stored in your
 # ``mne-python`` directory, in the :file:`mne/channels/data/layouts` and
 # :file:`mne/channels/data/montages` folders, respectively:

--- a/tutorials/intro/plot_40_sensor_locations.py
+++ b/tutorials/intro/plot_40_sensor_locations.py
@@ -30,26 +30,34 @@ raw = mne.io.read_raw_fif(sample_data_raw_file, preload=True, verbose=False)
 # About montages and layouts
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# MNE-Python comes pre-loaded with information about the sensor positions of
-# many MEG and EEG systems. This information is stored in *montages* and
-# *layout files*. :class:`montages <mne.channels.DigMontage>` contain sensor
+# :class:`Montages <mne.channels.DigMontage>` contain sensor
 # positions in 3D (``x``, ``y``, ``z``, in meters), and can be used to set
-# the physical positions of sensors.
+# the physical positions of sensors. By specifying the location of sensors
+# relative to the brain, :class:`Montages <mne.channels.DigMontage>` play an
+# important role in computing the forward solution and computing inverse
+# estimates.
 #
-# For any given set of sensor positions (from a montage or otherwise), a
-# :class:`Layouts <mne.channels.Layout>` can be generated, mostly for the
-# purpose of interactively selecting channels.
+# In contrast, :class:`Layouts <mne.channels.Layout>` are *idealized* 2-D
+# representations of sensor positions, and are primarily used for arranging
+# individual sensor subplots in a topoplot, or for showing the *approximate*
+# relative arrangement of sensors as seen from above.
 #
-# Many layout and montage
-# files are included during MNE-Python installation, and are stored in your
-# ``mne-python`` directory, in the :file:`mne/channels/data/layouts` and
-# :file:`mne/channels/data/montages` folders, respectively:
+# Working with built-in montages
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# The 3D coordinates of MEG sensors are included in the raw recordings from MEG
+# systems, and are automatically stored in the ``info`` attribute of the
+# :class:`~mne.io.Raw` file upon loading. EEG electrode locations are much more
+# variable because of differences in head shape. Idealized montages for many
+# EEG systems are included during MNE-Python installation; these files are
+# stored in your ``mne-python`` directory, in the
+# :file:`mne/channels/data/montages` folder:
 
-data_dir = os.path.join(os.path.dirname(mne.__file__), 'channels', 'data')
-for subfolder in ['layouts', 'montages']:
-    print('\nBUILT-IN {} FILES'.format(subfolder[:-1].upper()))
-    print('======================')
-    print(sorted(os.listdir(os.path.join(data_dir, subfolder))))
+montage_dir = os.path.join(os.path.dirname(mne.__file__),
+                           'channels', 'data', 'montages')
+print('\nBUILT-IN MONTAGE FILES')
+print('======================')
+print(sorted(os.listdir(montage_dir)))
 
 ###############################################################################
 # .. sidebar:: Computing sensor locations
@@ -58,35 +66,138 @@ for subfolder in ['layouts', 'montages']:
 #     are computed on a spherical head model, the `eeg_positions`_ repository
 #     provides code and documentation to this end.
 #
-# As you may be able to tell from the filenames shown above, the included
-# montage files are all for EEG systems. These are *idealized* sensor positions
-# based on a spherical head model. Montage files for MEG systems are not
-# provided because the 3D coordinates of MEG sensors are included in the raw
-# recordings from MEG systems, and are automatically stored in the ``info``
-# attribute of the :class:`~mne.io.Raw` file upon loading. In contrast, layout
-# files *are* included for MEG systems (to facilitate easy plotting of MEG
-# sensor location diagrams).
+# These built-in EEG montages can be loaded via
+# :func:`mne.channels.make_standard_montage`. Note that when loading via
+# :func:`~mne.channels.make_standard_montage`, provide the filename *without*
+# its file extension:
+
+ten_twenty_montage = mne.channels.make_standard_montage('standard_1020')
+print(ten_twenty_montage)
+
+###############################################################################
+# Once loaded, a montage can be applied to data via one of the instance methods
+# such as :meth:`raw.set_montage <mne.io.Raw.set_montage>`. It is also possible
+# to skip the loading step by passing the filename string directly to the
+# :meth:`~mne.io.Raw.set_montage>` method. This won't work with our sample
+# data, because it's channel names don't match the channel names in the
+# standard 10-20 montage, so these commands are not run here:
+
+# these will be equivalent:
+# raw_1020 = raw.copy().set_montage(ten_twenty_montage)
+# raw_1020 = raw.copy().set_montage('standard_1020')
+
+###############################################################################
+# :class:`Montage <mne.channels.DigMontage>` objects have a
+# :meth:`~mne.channels.DigMontage.plot` method for visualization of the sensor
+# locations in 3D; 2D projections are also possible by passing
+# ``kind='topomap'``:
+
+fig = ten_twenty_montage.plot(kind='3d')
+fig.gca().view_init(azim=70, elev=15)
+ten_twenty_montage.plot(kind='topomap', show_names=False)
+
+###############################################################################
+# .. _reading-dig-montages:
 #
-# You may also have noticed that the file formats and filename extensions of
-# layout and montage files vary considerably. This reflects different
-# manufacturers' conventions; to simplify this, the montage and layout loading
-# functions in MNE-Python take the filename *without its extension* so you
-# don't have to keep track of which file format is used by which manufacturer.
-# Examples of this can be seen in the following sections.
+# Reading sensor digitization files
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# If you have digitized the locations of EEG sensors on the scalp during your
-# recording session (e.g., with a Polhemus Fastrak digitizer), these can be
-# loaded in MNE-Python as :class:`~mne.channels.DigMontage` objects; see
-# :ref:`reading-dig-montages` (below).
+# In the sample data, setting the digitized EEG montage was done prior to
+# saving the :class:`~mne.io.Raw` object to disk, so the sensor positions are
+# already incorporated into the ``info`` attribute of the :class:`~mne.io.Raw`
+# object (see the documentation of the reading functions and
+# :meth:`~mne.io.Raw.set_montage` for details on how that works). Because of
+# that, we can plot sensor locations directly from the :class:`~mne.io.Raw`
+# object using the :meth:`~mne.io.Raw.plot_sensors` method, which provides
+# similar functionality to
+# :meth:`montage.plot() <mne.channels.DigMontage.plot>`.
+# :meth:`~mne.io.Raw.plot_sensors` also allows channel selection by type, can
+# color-code channels in various ways (by default, channels listed in
+# ``raw.info['bads']`` will be plotted in red), and allows drawing into an
+# existing matplotlib ``axes`` object (so the channel positions can easily be
+# made as a subplot in a multi-panel figure):
+
+# sphinx_gallery_thumbnail_number = 3
+fig = plt.figure()
+ax2d = fig.add_subplot(121)
+ax3d = fig.add_subplot(122, projection='3d')
+raw.plot_sensors(ch_type='eeg', axes=ax2d)
+raw.plot_sensors(ch_type='eeg', axes=ax3d, kind='3d')
+ax3d.view_init(azim=70, elev=15)
+
+###############################################################################
+# It's probably evident from the 2D topomap above that there is some
+# irregularity in the EEG sensor positions in the :ref:`sample dataset
+# <sample-dataset>` — this is because the sensor positions in that dataset are
+# digitizations of the sensor positions on an actual subject's head, rather
+# than idealized sensor positions based on a spherical head model. Depending on
+# what system was used to digitize the electrode positions (e.g., a Polhemus
+# Fastrak digitizer), you must use different montage reading functions (see
+# :ref:`dig-formats`). The resulting :class:`montage <mne.channels.DigMontage>`
+# can then be added to :class:`~mne.io.Raw` objects by passing it to the
+# :meth:`~mne.io.Raw.set_montage` method (just as we did above with the name of
+# the idealized montage ``'standard_1020'``). Once loaded, locations can be
+# plotted with :meth:`~mne.channels.DigMontage.plot` and saved with
+# :meth:`~mne.channels.DigMontage.save`, like when working with a standard
+# montage.
+#
+# .. note::
+#
+#     When setting a montage with :meth:`~mne.io.Raw.set_montage`
+#     the measurement info is updated in two places (the ``chs``
+#     and ``dig`` entries are updated). See :ref:`tut-info-class`.
+#     ``dig`` may contain HPI, fiducial, or head shape points in
+#     addition to electrode locations.
+#
+#
+# Rendering sensor position with mayavi
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# It is also possible to render an image of a MEG sensor helmet in 3D, using
+# mayavi instead of matplotlib, by calling the :func:`mne.viz.plot_alignment`
+# function:
+
+fig = mne.viz.plot_alignment(raw.info, trans=None, dig=False, eeg=False,
+                             surfaces=[], meg=['helmet', 'sensors'],
+                             coord_frame='meg')
+mne.viz.set_3d_view(fig, azimuth=50, elevation=90, distance=0.5)
+
+###############################################################################
+# :func:`~mne.viz.plot_alignment` requires an :class:`~mne.Info` object, and
+# can also render MRI surfaces of the scalp, skull, and brain (by passing
+# keywords like ``'head'``, ``'outer_skull'``, or ``'brain'`` to the
+# ``surfaces`` parameter) making it useful for :ref:`assessing coordinate frame
+# transformations <plot_source_alignment>`. For examples of various uses of
+# :func:`~mne.viz.plot_alignment`, see
+# :doc:`../../auto_examples/visualization/plot_montage`,
+# :doc:`../../auto_examples/visualization/plot_eeg_on_scalp`, and
+# :doc:`../../auto_examples/visualization/plot_meg_sensors`.
 #
 #
 # Working with layout files
-# ~~~~~~~~~~~~~~~~~~~~~~~~~
+# ^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# To load a layout file, use the :func:`mne.channels.read_layout`
-# function, and provide the filename *without* its file extension. You can then
-# visualize the layout using its :meth:`~mne.channels.Layout.plot` method, or
-# (equivalently) by passing it to :func:`mne.viz.plot_layout`:
+# As with montages, many layout files are included during MNE-Python
+# installation, and are stored in the :file:`mne/channels/data/layouts` folder:
+
+layout_dir = os.path.join(os.path.dirname(mne.__file__),
+                          'channels', 'data', 'layouts')
+print('\nBUILT-IN LAYOUT FILES')
+print('=====================')
+print(sorted(os.listdir(layout_dir)))
+
+###############################################################################
+# You may have noticed that the file formats and filename extensions of the
+# built-in layout and montage files vary considerably. This reflects different
+# manufacturers' conventions; to make loading easier the montage and layout
+# loading functions in MNE-Python take the filename *without its extension* so
+# you don't have to keep track of which file format is used by which
+# manufacturer.
+#
+# To load a layout file, use the :func:`mne.channels.read_layout` function, and
+# provide the filename *without* its file extension. You can then visualize the
+# layout using its :meth:`~mne.channels.Layout.plot` method, or (equivalently)
+# by passing it to :func:`mne.viz.plot_layout`:
 
 biosemi_layout = mne.channels.read_layout('biosemi')
 biosemi_layout.plot()  # same result as: mne.viz.plot_layout(biosemi_layout)
@@ -132,95 +243,6 @@ layout_from_raw.plot()
 # matters if you need to load the layout file in some other software
 # (MNE-Python can read either format equally well).
 #
-#
-# Working with montage files
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~
-#
-# Built-in montages are loaded and plotted in a very similar way to layouts.
-# However, the :meth:`~mne.channels.DigMontage.plot` method of
-# :class:`~mne.channels.DigMontage` objects has some additional parameters,
-# such as whether to display channel names or just points (the ``show_names``
-# parameter) and whether to display sensor positions in 3D or as a 2D topomap
-# (the ``kind`` parameter):
-
-ten_twenty_montage = mne.channels.make_standard_montage('standard_1020')
-ten_twenty_montage.plot(show_names=False)
-fig = ten_twenty_montage.plot(kind='3d')
-fig.gca().view_init(azim=70, elev=15)
-
-###############################################################################
-# Similar functionality is also available with the
-# :meth:`~mne.io.Raw.plot_sensors` method of :class:`~mne.io.Raw` objects,
-# again with the option to plot in either 2D or 3D.
-# :meth:`~mne.io.Raw.plot_sensors` also allows channel selection by type, can
-# color-code channels in various ways (by default, channels listed in
-# ``raw.info['bads']`` will be plotted in red), and allows drawing into an
-# existing matplotlib ``axes`` object (so the channel positions can easily be
-# made as a subplot in a multi-panel figure):
-
-fig = plt.figure()
-ax2d = fig.add_subplot(121)
-ax3d = fig.add_subplot(122, projection='3d')
-raw.plot_sensors(ch_type='eeg', axes=ax2d)
-raw.plot_sensors(ch_type='eeg', axes=ax3d, kind='3d')
-ax3d.view_init(azim=70, elev=15)
-
-###############################################################################
-# .. _reading-dig-montages:
-#
-# Reading sensor digitization files
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-#
-# It's probably evident from the 2D topomap above that there is some
-# irregularity in the EEG sensor positions in the :ref:`sample dataset
-# <sample-dataset>` — this is because the sensor positions in that dataset are
-# digitizations of the sensor positions on an actual subject's head. Depending
-# on what system was used to scan the positions one can use different
-# reading functions (see :ref:`dig-formats`).
-# The read :class:`montage <mne.channels.DigMontage>` can then be added
-# to :class:`~mne.io.Raw` objects with the :meth:`~mne.io.Raw.set_montage`
-# method; in the sample data this was done prior to saving the
-# :class:`~mne.io.Raw` object to disk, so the sensor positions are already
-# incorporated into the ``info`` attribute of the :class:`~mne.io.Raw` object.
-# See the documentation of the reading functions and
-# :meth:`~mne.io.Raw.set_montage` for further details. Once loaded,
-# locations can be plotted with :meth:`~mne.channels.DigMontage.plot` and
-# saved with :meth:`~mne.channels.DigMontage.save`, like when working
-# with a standard montage.
-#
-# The possibilities to read in digitized montage files are summarized
-# in :ref:`dig-formats`.
-#
-# .. note::
-#
-#     When setting a montage with :meth:`~mne.io.Raw.set_montage`
-#     the measurement info is updated at two places (the `chs`
-#     and `dig` entries are updated). See :ref:`tut-info-class`.
-#     `dig` will potentially contain more than channel locations,
-#     such HPI, head shape points or fiducials 3D coordinates.
-#
-# Rendering sensor position with mayavi
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-#
-# It is also possible to render an image of a MEG sensor helmet in 3D, using
-# mayavi instead of matplotlib, by calling the :func:`mne.viz.plot_alignment`
-# function:
-
-fig = mne.viz.plot_alignment(raw.info, trans=None, dig=False, eeg=False,
-                             surfaces=[], meg=['helmet', 'sensors'],
-                             coord_frame='meg')
-mne.viz.set_3d_view(fig, azimuth=50, elevation=90, distance=0.5)
-
-###############################################################################
-# :func:`~mne.viz.plot_alignment` requires an :class:`~mne.Info` object, and
-# can also render MRI surfaces of the scalp, skull, and brain (by passing
-# keywords like ``'head'``, ``'outer_skull'``, or ``'brain'`` to the
-# ``surfaces`` parameter) making it useful for :ref:`assessing coordinate frame
-# transformations <plot_source_alignment>`. For examples of various uses of
-# :func:`~mne.viz.plot_alignment`, see
-# :doc:`../../auto_examples/visualization/plot_montage`,
-# :doc:`../../auto_examples/visualization/plot_eeg_on_scalp`, and
-# :doc:`../../auto_examples/visualization/plot_meg_sensors`.
 #
 # .. LINKS
 #

--- a/tutorials/intro/plot_40_sensor_locations.py
+++ b/tutorials/intro/plot_40_sensor_locations.py
@@ -78,7 +78,7 @@ print(ten_twenty_montage)
 # Once loaded, a montage can be applied to data via one of the instance methods
 # such as :meth:`raw.set_montage <mne.io.Raw.set_montage>`. It is also possible
 # to skip the loading step by passing the filename string directly to the
-# :meth:`~mne.io.Raw.set_montage>` method. This won't work with our sample
+# :meth:`~mne.io.Raw.set_montage` method. This won't work with our sample
 # data, because it's channel names don't match the channel names in the
 # standard 10-20 montage, so these commands are not run here:
 

--- a/tutorials/preprocessing/plot_70_fnirs_processing.py
+++ b/tutorials/preprocessing/plot_70_fnirs_processing.py
@@ -190,7 +190,9 @@ mne.viz.plot_compare_evokeds(evoked_dict, combine="mean", ci=0.95,
 # Next we view how the topographic activity changes throughout the response.
 
 times = np.arange(-3.5, 13.2, 3.0)
-epochs['Tapping'].average(picks='hbo').plot_joint(times=times)
+topomap_args = dict(extrapolate='local')
+epochs['Tapping'].average(picks='hbo').plot_joint(
+    times=times, topomap_args=topomap_args)
 
 
 ###############################################################################
@@ -201,14 +203,18 @@ epochs['Tapping'].average(picks='hbo').plot_joint(times=times)
 # the location of activity. First we visualise the HbO activity.
 
 times = np.arange(4.0, 11.0, 1.0)
-epochs['Tapping/Left'].average(picks='hbo').plot_topomap(times=times)
-epochs['Tapping/Right'].average(picks='hbo').plot_topomap(times=times)
+epochs['Tapping/Left'].average(picks='hbo').plot_topomap(
+    times=times, **topomap_args)
+epochs['Tapping/Right'].average(picks='hbo').plot_topomap(
+    times=times, **topomap_args)
 
 ###############################################################################
 # And we also view the HbR activity for the two conditions.
 
-epochs['Tapping/Left'].average(picks='hbr').plot_topomap(times=times)
-epochs['Tapping/Right'].average(picks='hbr').plot_topomap(times=times)
+epochs['Tapping/Left'].average(picks='hbr').plot_topomap(
+    times=times, **topomap_args)
+epochs['Tapping/Right'].average(picks='hbr').plot_topomap(
+    times=times, **topomap_args)
 
 ###############################################################################
 # And we can plot the comparison at a single time point for two conditions.
@@ -220,20 +226,26 @@ evoked_left = epochs['Tapping/Left'].average()
 evoked_right = epochs['Tapping/Right'].average()
 
 evoked_left.plot_topomap(ch_type='hbo', times=ts, axes=axes[0, 0],
-                         vmin=vmin, vmax=vmax, colorbar=False)
+                         vmin=vmin, vmax=vmax, colorbar=False,
+                         **topomap_args)
 evoked_left.plot_topomap(ch_type='hbr', times=ts, axes=axes[1, 0],
-                         vmin=vmin, vmax=vmax, colorbar=False)
+                         vmin=vmin, vmax=vmax, colorbar=False,
+                         **topomap_args)
 evoked_right.plot_topomap(ch_type='hbo', times=ts, axes=axes[0, 1],
-                          vmin=vmin, vmax=vmax, colorbar=False)
+                          vmin=vmin, vmax=vmax, colorbar=False,
+                          **topomap_args)
 evoked_right.plot_topomap(ch_type='hbr', times=ts, axes=axes[1, 1],
-                          vmin=vmin, vmax=vmax, colorbar=False)
+                          vmin=vmin, vmax=vmax, colorbar=False,
+                          **topomap_args)
 
 evoked_diff = mne.combine_evoked([evoked_left, -evoked_right], weights='equal')
 
 evoked_diff.plot_topomap(ch_type='hbo', times=ts, axes=axes[0, 2],
-                         vmin=vmin, vmax=vmax)
+                         vmin=vmin, vmax=vmax,
+                         **topomap_args)
 evoked_diff.plot_topomap(ch_type='hbr', times=ts, axes=axes[1, 2],
-                         vmin=vmin, vmax=vmax, colorbar=True)
+                         vmin=vmin, vmax=vmax, colorbar=True,
+                         **topomap_args)
 
 for column, condition in enumerate(
         ['Tapping Left', 'Tapping Right', 'Left-Right']):

--- a/tutorials/source-modeling/plot_forward.py
+++ b/tutorials/source-modeling/plot_forward.py
@@ -125,14 +125,14 @@ mne.viz.plot_bem(subject=subject, subjects_dir=subjects_dir,
 
 ###############################################################################
 # To compute a volume based source space defined with a grid of candidate
-# dipoles inside a sphere of radius 90mm centered at (0.0, 0.0, 40.0)
+# dipoles inside a sphere of radius 90mm centered at (0.0, 0.0, 40.0) mm
 # you can use the following code.
 # Obviously here, the sphere is not perfect. It is not restricted to the
 # brain and it can miss some parts of the cortex.
 
-sphere = (0.0, 0.0, 40.0, 90.0)
+sphere = (0.0, 0.0, 0.04, 0.09)
 vol_src = mne.setup_volume_source_space(subject, subjects_dir=subjects_dir,
-                                        sphere=sphere)
+                                        sphere=sphere, sphere_units='m')
 print(vol_src)
 
 mne.viz.plot_bem(subject=subject, subjects_dir=subjects_dir,

--- a/tutorials/stats-sensor-space/plot_stats_spatio_temporal_cluster_sensors.py
+++ b/tutorials/stats-sensor-space/plot_stats_spatio_temporal_cluster_sensors.py
@@ -21,7 +21,6 @@ the possible interpretation of "significant" clusters.
 import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
-from mne.viz import plot_topomap
 
 import mne
 from mne.stats import spatio_temporal_cluster_test
@@ -119,9 +118,6 @@ good_cluster_inds = np.where(p_values < p_accept)[0]
 colors = {"Aud": "crimson", "Vis": 'steelblue'}
 linestyles = {"L": '-', "R": '--'}
 
-# get sensor positions via layout
-pos = mne.find_layout(epochs.info).pos
-
 # organize data for plotting
 evokeds = {cond: epochs[cond].average() for cond in event_id}
 
@@ -146,8 +142,11 @@ for i_clu, clu_idx in enumerate(good_cluster_inds):
     fig, ax_topo = plt.subplots(1, 1, figsize=(10, 3))
 
     # plot average test statistic and mark significant sensors
-    image, _ = plot_topomap(f_map, pos, mask=mask, axes=ax_topo, cmap='Reds',
-                            vmin=np.min, vmax=np.max, show=False)
+    f_evoked = mne.EvokedArray(f_map[:, np.newaxis], epochs.info, tmin=0)
+    f_evoked.plot_topomap(times=0, mask=mask, axes=ax_topo, cmap='Reds',
+                          vmin=np.min, vmax=np.max, show=False,
+                          colorbar=False, mask_params=dict(markersize=10))
+    image = ax_topo.images[0]
 
     # create additional axes (for ERF and colorbar)
     divider = make_axes_locatable(ax_topo)


### PR DESCRIPTION
Closes #3987
Closes #4880
Closes #5190 
Closes #5471
Closes #5472 
Closes #6304

Todo:
- [x] ensure our montages actually use the same head sizes (done by dig refactoring)
- [x] Make the `plot_sensors` be in physical coordinates
- [x] make all code assume a 0.095 m head radius
- [x] check that all examples in gist are fixed
- [x] deprecate params: `transform` in `montage`, `outlines`, ...
- [x] get tests to pass again
- [x] change to `sphere` rather than `head_radius` for consistency and flexibility
- [x] change units in `setup_volume_source_space` for consistency
- [x] move head relative to MEG sensors based on `info['dev_head_t']`
- [x] check `plot_topomap`, `plot_sensors`, `montage.plot` examples via `circle full`
- [x] add `setup_volume_source_space` param and `layout` deprecation to API section of `latest.inc`

cc @jona-sassenhagen @sappelhoff @cbrnr you might be interested in this plan.

After this, due to using physical units for the head, #5471 should be simpler.