### PR TITLE
FIX:7067 - None meas_date roundtrip

### DIFF
--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -25,7 +25,7 @@ from .ctf_comp import read_ctf_comp, write_ctf_comp
 from .write import (start_file, end_file, start_block, end_block,
                     write_string, write_dig_points, write_float, write_int,
                     write_coord_trans, write_ch_info, write_name_list,
-                    write_julian, write_float_matrix, write_id, DATE_NONE)
+                    write_julian, write_float_matrix, DATE_NONE)
 from .proc_history import _read_proc_history, _write_proc_history
 from ..transforms import invert_transform, Transform
 from ..utils import logger, verbose, warn, object_diff, _validate_type
@@ -1296,10 +1296,6 @@ def write_meas_info(fid, info, data_type=None, reset_range=True):
 
     # Measurement info
     start_block(fid, FIFF.FIFFB_MEAS_INFO)
-
-    # Add measurement id
-    if info['meas_id'] is not None:
-        write_id(fid, FIFF.FIFF_PARENT_BLOCK_ID, info['meas_id'])
 
     for event in info['events']:
         start_block(fid, FIFF.FIFFB_EVENTS)

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -218,7 +218,6 @@ def test_read_write_info(tmpdir):
         info['gantry_angle'] = 0.  # Elekta supine position
     gantry_angle = info['gantry_angle']
 
-    meas_id = info['meas_id']
     write_info(temp_file, info)
     info = read_info(temp_file)
     assert info['proc_history'][0]['creator'] == creator
@@ -227,9 +226,6 @@ def test_read_write_info(tmpdir):
     assert info['gantry_angle'] == gantry_angle
     assert info['subject_info']['height'] == 2.3
     assert info['subject_info']['weight'] == 11.1
-    for key in ['secs', 'usecs', 'version']:
-        assert info['meas_id'][key] == meas_id[key]
-    assert_array_equal(info['meas_id']['machid'], meas_id['machid'])
 
     # Test that writing twice produces the same file
     m1 = hashlib.md5()

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -245,6 +245,13 @@ def test_read_write_info(tmpdir):
     m2 = m2.hexdigest()
     assert m1 == m2
 
+    info = read_info(raw_fname)
+    info['meas_date'] = None
+    tmp_fname_3 = tmpdir.join('info3.fif')
+    write_info(tmp_fname_3, info)
+    info2 = read_info(tmp_fname_3)
+    assert info2['meas_date'] is None
+
 
 def test_io_dig_points(tmpdir):
     """Test Writing for dig files."""


### PR DESCRIPTION
Fixes #7067 

always writing meas_date seems like the most straight forward fix. Hopefully it doesn't break anything.

As a fix it does have the downside that if a fiff file exists on disk without a `meas_date` tag and a `meas_id` that isn't equal to `DATE_NONE` then on reading in the file the `meas_date` will be guessed.
