### PR TITLE
[MRG, DOC] Added linear algebra of transform to doc

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -15,7 +15,7 @@ Current (0.21.dev0)
 Changelog
 ~~~~~~~~~
 
-- Add space transform details to :ref:`plot_source_alignment` tutorial, by `Alex Rockhill`_
+- Add head to mri and mri to voxel space transform details to :ref:`plot_source_alignment` tutorial, by `Alex Rockhill`_
 
 - Modified :meth:`mne.Epochs.pick_types` to remove dropped channel types from ``reject`` and ``flat`` dictionaries by `Rahul Nadkarni`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -15,6 +15,8 @@ Current (0.21.dev0)
 Changelog
 ~~~~~~~~~
 
+- Add space transform details to `plot_source_alignment` tutorial by `Alex Rockhill`_
+
 - Modified :meth:`mne.Epochs.pick_types` to remove dropped channel types from ``reject`` and ``flat`` dictionaries by `Rahul Nadkarni`_
 
 - Improve memory efficiency of :func:`mne.concatenate_epochs` by `Eric Larson`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -15,7 +15,7 @@ Current (0.21.dev0)
 Changelog
 ~~~~~~~~~
 
-- Add space transform details to `plot_source_alignment` tutorial by `Alex Rockhill`_
+- Add space transform details to :ref:`plot_source_alignment` tutorial, by `Alex Rockhill`_
 
 - Modified :meth:`mne.Epochs.pick_types` to remove dropped channel types from ``reject`` and ``flat`` dictionaries by `Rahul Nadkarni`_
 

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -192,17 +192,17 @@ mne.viz.plot_alignment(raw.info, trans=trans, subject='sample',
 def plot_dig_alignment(points, coord_system='ras'):
     points = points.copy()
     if coord_system == 'mri':  # transform back to RAS
-        points = (points - 128) * 1e-3
-        points[:, [1, 2]] = points[:, [2, 1]]
-        points[:, 2] *= -1
+        points = ((points - 128) * [1, -1, 1])[:, [0, 2, 1]]
+    else:  # m → mm
+        points *= 1e3
     renderer = mne.viz.backends.renderer._get_renderer(
         size=(800, 400), bgcolor='w')
-    seghead_rr, seghead_tri = mne.read_surface(op.join(
-        subjects_dir, 'sample', 'surf', 'lh.seghead'))
+    seghead_rr, seghead_tri = mne.read_surface(
+        op.join(subjects_dir, 'sample', 'surf', 'lh.seghead'))
     renderer.mesh(*seghead_rr.T, triangles=seghead_tri, color=(0.7,) * 3,
                   opacity=0.2)
     for point in points:
-        renderer.sphere(center=point * 1e3, color='r', scale=5)
+        renderer.sphere(center=point, color='r', scale=5)
     mne.viz.set_3d_view(figure=renderer.figure, distance=1000,
                         focalpoint=(0., 0., 0.), elevation=90, azimuth=0)
     renderer.show()

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -186,7 +186,7 @@ mne.viz.plot_alignment(raw.info, trans=trans, subject='sample',
 # Let's step through the process that the transform is accomplishing.
 #
 # First, let's define a helper function to plot the alignment of the
-# points with the head using voxel coordinates.
+# points with the head.
 
 
 def plot_dig_alignment(points, coord_system='ras'):
@@ -226,9 +226,10 @@ plot_dig_alignment(head_space)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # Rotate and translate the points based on the coregistration.
 #
-# The plot below shows the head space coordinates transformed to mri
-# RAS coordinates. It correctly aligns to the head, which is also in RAS,
-# but still has to be transformed to the voxel coordinate space.
+# The plot below shows the head space coordinates transformed to meg
+# coordinates (still RAS). It correctly aligns to the head, which is also in
+# RAS, but still has to be transformed to the mri coordinate space, which
+# is in voxels.
 
 meg_space = mne.transforms.apply_trans(trans, head_space, move=True)
 plot_dig_alignment(meg_space)
@@ -237,9 +238,10 @@ plot_dig_alignment(meg_space)
 # Apply a second transform to get to mri space and plot again
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# This plot finally shows the coordinates in the T1 space. Since the head
+# This plot finally shows the coordinates in the mri space. Since the head
 # is plotted in RAS, we have to transform them back to have the plots match
-# since all the freesurfer surfaces are in RAS.
+# since all the head surface that it is being compared to in the plot is in
+# RAS.
 
 vox2ras_tkr = t1_mgh.header.get_vox2ras_tkr()
 ras2vox_tkr = linalg.inv(vox2ras_tkr)

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -203,7 +203,7 @@ def plot_dig_alignment(points, coord_system='ras'):
                   opacity=0.2)
     for point in points.copy():
         renderer.sphere(center=point * 1e3, color='r', scale=5)
-    mne.viz.set_3d_view(figure=renderer.fig, distance=1000,
+    mne.viz.set_3d_view(figure=renderer.figure, distance=1000,
                         focalpoint=(0., 0., 0.), elevation=90, azimuth=0)
     renderer.show()
 

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -73,10 +73,11 @@ t1_mgh = nib.MGHImage(t1w.dataobj, t1w.affine)
 #
 # * :blue:`"meg"`: the coordinate frame for the physical locations of MEG
 #   sensors
-# * :gray:`"mri"` (the coordinate frame for MRI images, and scalp/skull/brain
+# * :gray:`"mri"`: the coordinate frame for MRI images, and scalp/skull/brain
 #   surfaces derived from the MRI images
-# * :pink`"head"`: the coordinate frame for digitized sensor locations and
+# * :pink:`"head"`: the coordinate frame for digitized sensor locations and
 #   scalp landmarks ("fiducials")
+#
 #
 # Each of these, plus a fourth coordinate frame "ras", are described in more
 # detail below.

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -195,7 +195,7 @@ def plot_dig_alignment(points, coord_system='ras'):
         points = ((points - 128) * [1, -1, 1])[:, [0, 2, 1]]
     else:  # m → mm
         points *= 1e3
-    renderer = mne.viz.create_3d_figure(
+    renderer = mne.viz.backends.renderer.create_3d_figure(
         size=(800, 400), bgcolor='w', scene=False)
     seghead_rr, seghead_tri = mne.read_surface(
         op.join(subjects_dir, 'sample', 'surf', 'lh.seghead'))

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -212,8 +212,11 @@ def plot_dig_alignment(points, coord_system='ras'):
 # -------------------------------------------------------------
 # Adjust units by * 1e3 m -> mm.
 #
-# The plot below shows the unaligned digitization points in the
-# coordinate space native to the digitizer equipment.
+# The plot below shows the digitization points in the coordinate space
+# native to the digitizer equipment plotted with the head surface in
+# right-anterior-superior (RAS) coordinates. The relationship between the
+# 3D points in the head space would fit on the head but the transformation from
+# the coregistration has not been applied yet so there is a mismatch.
 
 head_space = np.array([dig['r'] for dig in
                        raw.info['dig']], dtype=float) * 1e3
@@ -225,9 +228,8 @@ plot_dig_alignment(head_space)
 # Rotate and translate the points based on the coregistration.
 #
 # The plot below shows the head space coordinates transformed to mri
-# right-anterior-superior (RAS) coordinates. It aligns to the head, which is
-# also in RAS correctly, but still has to be transformed to the voxel
-# coordinate space.
+# RAS coordinates. It correctly aligns to the head, which is also in RAS,
+# but still has to be transformed to the voxel coordinate space.
 
 trans_mm = trans.copy()
 trans_mm['trans'][:3, 3] *= 1e3
@@ -239,9 +241,12 @@ plot_dig_alignment(mri_space)
 # -----------------------------------------------
 # Transform the points from RAS to voxel space
 #
-# This plot finally shows the coordinates in the space that is relevant
-# to comparing to the anatomical T1 image, reconstructed brain areas and
-# source-space estimate; the common reference frame of the T1 voxels.
+# This plot finally shows the coordinates in the space that is relevant to
+# comparing to the anatomical T1 image, reconstructed brain areas and source-
+# space estimate; the common reference frame of the T1 voxels. Since the head
+# is plotted in RAS, we have to transform them back to have the plots match
+# since all the freesurfer surfaces are in RAS. But, now the coordinates are
+# in the T1 space (e.g. 256 x 256 x 256) so they can be compared to the T1.
 
 vox2ras_tkr = t1_mgh.header.get_vox2ras_tkr()
 ras2vox_tkr = scipy.linalg.inv(vox2ras_tkr)

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -201,7 +201,7 @@ def plot_dig_alignment(points, coord_system='ras'):
         subjects_dir, 'sample', 'surf', 'lh.seghead'))
     renderer.mesh(*seghead_rr.T, triangles=seghead_tri, color=(0.7,) * 3,
                   opacity=0.2)
-    for point in points.copy():
+    for point in points:
         renderer.sphere(center=point * 1e3, color='r', scale=5)
     mne.viz.set_3d_view(figure=renderer.figure, distance=1000,
                         focalpoint=(0., 0., 0.), elevation=90, azimuth=0)

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -195,7 +195,7 @@ def plot_dig_alignment(points, coord_system='ras'):
         points = ((points - 128) * [1, -1, 1])[:, [0, 2, 1]]
     else:  # m → mm
         points *= 1e3
-    renderer = mne.viz.backends.renderer.create_3d_figure(
+    renderer = mne.viz.backends.renderer._get_renderer(
         size=(800, 400), bgcolor='w')
     seghead_rr, seghead_tri = mne.read_surface(
         op.join(subjects_dir, 'sample', 'surf', 'lh.seghead'))

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -195,7 +195,7 @@ def plot_dig_alignment(points, coord_system='ras'):
         points = ((points - 128) * [1, -1, 1])[:, [0, 2, 1]]
     else:  # m → mm
         points *= 1e3
-    renderer = mne.viz.backends.renderer.create_3d_figure(
+    renderer = mne.viz.create_3d_figure(
         size=(800, 400), bgcolor='w', scene=False)
     seghead_rr, seghead_tri = mne.read_surface(
         op.join(subjects_dir, 'sample', 'surf', 'lh.seghead'))

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -212,9 +212,8 @@ def plot_dig_alignment(points, coord_system='ras'):
 # Plot untransformed head space digitized points as if they were in RAS space
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # The plot below shows the digitization points in the coordinate space
-# native to the digitizer equipment plotted with the head surface in
-# right-anterior-superior (RAS) coordinates. The relationship between the
-# 3D points in the head space would fit on the head but the transformation from
+# native to the digitizer equipment as described above. The 3D points in
+# head space would fit on the head but the transformation from
 # the coregistration has not been applied yet so there is a mismatch.
 
 head_space = np.array([dig['r'] for dig in
@@ -227,9 +226,11 @@ plot_dig_alignment(head_space)
 # Rotate and translate the points based on the coregistration.
 #
 # The plot below shows the head space coordinates transformed to meg
-# coordinates (still RAS). It correctly aligns to the head, which is also in
-# RAS, but still has to be transformed to the mri coordinate space, which
-# is in voxels.
+# coordinates. It correctly aligns to the head, but still has to be transformed
+# to the mri coordinate space, which is in voxels. In mri (voxel) space,
+# ``(0, 0, 0)`` is the left-, posterior-most coordinate on the inferior-most
+# slice compared to ``(0, 0, 0)`` being the center of the head in both head
+# and meg coordinate spaces.
 
 meg_space = mne.transforms.apply_trans(trans, head_space, move=True)
 plot_dig_alignment(meg_space)
@@ -238,10 +239,14 @@ plot_dig_alignment(meg_space)
 # Apply a second transform to get to mri space and plot again
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# This plot finally shows the coordinates in the mri space. Since the head
-# is plotted in RAS, we have to transform them back to have the plots match
-# since all the head surface that it is being compared to in the plot is in
-# RAS.
+# This plot finally shows the coordinates in the mri space, which looks the
+# same as the alignment meg coordinate space, but as can be seen in the
+# helper function we actually have to do a transformation back from mri to
+# meg space. This is because the freesurfer surfaces (the reconstructed head
+# surface that is plotted) are centered in the center of the head and in RAS
+# coordinates compared to the mri coordinate space which is centered in the
+# bottom corner and the order of the points is not RAS but based on the T1
+# image slices.
 
 vox2ras_tkr = t1_mgh.header.get_vox2ras_tkr()
 ras2vox_tkr = linalg.inv(vox2ras_tkr)

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -219,7 +219,7 @@ plot_dig_alignment(head_space)
 # Rotate and translate the points based on the coregistration
 
 trans_mm = trans.copy()
-trans_mm[:3, 3] *= 1e3
+trans_mm['trans'][:3, 3] *= 1e3
 mri_space = mne.transforms.apply_trans(trans_mm, head_space, move=True)
 plot_dig_alignment(mri_space)
 

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -195,7 +195,7 @@ def plot_dig_alignment(points, coord_system='ras'):
         points = ((points - 128) * [1, -1, 1])[:, [0, 2, 1]]
     else:  # m → mm
         points *= 1e3
-    renderer = mne.viz.backends.renderer._get_renderer(
+    renderer = mne.viz.backends.renderer.create_3d_figure(
         size=(800, 400), bgcolor='w')
     seghead_rr, seghead_tri = mne.read_surface(
         op.join(subjects_dir, 'sample', 'surf', 'lh.seghead'))

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -227,14 +227,13 @@ plot_dig_alignment(head_space)
 
 ###############################################################################
 # Next, we'll apply the precomputed ``trans`` to convert the digitized points
-# from "head" to "meg" coordinate frame. It looks pretty good, but the
-# coordinate frames aren't actually perfectly aligned yet. This underscores
-# why interactive use of `~mne.viz.plot_alignment` is such an important step:
-# static plots can sometimes *look okay* even if they're not actually aligned
-# properly.
+# from the "head" to the "mri" coordinate frame. Since the MRI scalp surface
+# is in RAS coordinates, the alignment fits as expected based on the
+# coregistration. But, there's one more step, the RAS coordinates have to be
+# transformed to match the mri aquisition which is in voxels.
 
-meg_space = mne.transforms.apply_trans(trans, head_space, move=True)
-plot_dig_alignment(meg_space)
+mri_space = mne.transforms.apply_trans(trans, head_space, move=True)
+plot_dig_alignment(mri_space)
 
 ###############################################################################
 # Finally, we'll apply a second transformation to the already-transformed
@@ -255,9 +254,9 @@ plot_dig_alignment(meg_space)
 vox2ras_tkr = t1_mgh.header.get_vox2ras_tkr()
 ras2vox_tkr = linalg.inv(vox2ras_tkr)
 
-vox_space = mne.transforms.apply_trans(ras2vox_tkr, meg_space * 1e3)  # m → mm
-mri_space = ((vox_space - 128) * [1, -1, 1])[:, [0, 2, 1]] * 1e-3
-plot_dig_alignment(mri_space)
+vox_space = mne.transforms.apply_trans(ras2vox_tkr, mri_space * 1e3)  # m → mm
+vox_space = ((vox_space - 128) * [1, -1, 1])[:, [0, 2, 1]] * 1e-3
+plot_dig_alignment(vox_space)
 
 
 ###############################################################################

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -235,7 +235,7 @@ plot_dig_alignment(head_space * 1e3)  # m → mm
 # from the "head" to the "mri" coordinate frame. Since the MRI scalp surface
 # is in RAS coordinates, the alignment fits as expected based on the
 # coregistration. But, there's one more step, the RAS coordinates have to be
-# transformed to match the mri aquisition which is in voxels.
+# transformed to match the MRI acquisition which is in voxels.
 
 mri_space = mne.transforms.apply_trans(trans, head_space, move=True)
 plot_dig_alignment(mri_space * 1e3)  # m → mm

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -186,7 +186,7 @@ mne.viz.plot_alignment(raw.info, trans=None, subject='sample', src=src,
 # First, let's define a helper function to plot the alignment of the
 # points with the head using voxel coordinates.
 
-def plot_alignment(points):
+def plot_dig_alignment(points):
     renderer_kwargs = dict(bgcolor='w', smooth_shading=False)
     renderer = mne.viz.backends.renderer._get_renderer(
         size=(800, 400), **renderer_kwargs)
@@ -211,15 +211,17 @@ def plot_alignment(points):
 
 head_space = np.array([dig['r'] for dig in
                        raw.info['dig']], dtype=float) * 1e3
-plot_alignment(head_space)
+plot_dig_alignment(head_space)
 
 ###############################################################################
 # Transform digitization points into MRI space
 # --------------------------------------------
 # Rotate and translate the points based on the coregistration
 
-mri_space = mne.transforms.apply_trans(trans, head_space, move=True)
-plot_alignment(mri_space)
+trans_mm = trans.copy()
+trans_mm[:3, 3] *= 1e3
+mri_space = mne.transforms.apply_trans(trans_mm, head_space, move=True)
+plot_dig_alignment(mri_space)
 
 ###############################################################################
 # Get landmarks in voxel space, using the T1 data
@@ -229,7 +231,7 @@ plot_alignment(mri_space)
 vox2ras_tkr = t1_mgh.header.get_vox2ras_tkr()
 ras2vox_tkr = scipy.linalg.inv(vox2ras_tkr)
 mri_voxel_space = mne.transforms.apply_trans(ras2vox_tkr, mri_space)
-plot_alignment(mri_voxel_space)
+plot_dig_alignment(mri_voxel_space)
 
 ###############################################################################
 # A good example

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -286,11 +286,11 @@ nasion_vox = mne.transforms.apply_trans(
     mri_to_vox, nasion_mri * 1e3, move=True)
 # plot it to make sure the transforms worked
 renderer = mne.viz.backends.renderer.create_3d_figure(
-    size=(600, 600), bgcolor='w', scene=False)
+    size=(400, 400), bgcolor='w', scene=False)
 add_head(renderer, scalp_points_in_vox, 'green', opacity=1)
-mne.viz.set_3d_view(figure=renderer.figure, distance=800,
-                    focalpoint=(0., 30., 30.), elevation=45, azimuth=180)
 renderer.sphere(center=nasion_vox, color='orange', scale=10)
+mne.viz.set_3d_view(figure=renderer.figure, distance=600.,
+                    focalpoint=(0., 125., 250.), elevation=45, azimuth=180)
 renderer.show()
 
 ###############################################################################

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -195,8 +195,8 @@ def plot_dig_alignment(points, coord_system='ras'):
         points = ((points - 128) * [1, -1, 1])[:, [0, 2, 1]]
     else:  # m → mm
         points *= 1e3
-    renderer = mne.viz.backends.renderer._get_renderer(
-        size=(800, 400), bgcolor='w')
+    renderer = mne.viz.backends.renderer.create_3d_figure(
+        size=(800, 400), bgcolor='w', scene=False)
     seghead_rr, seghead_tri = mne.read_surface(
         op.join(subjects_dir, 'sample', 'surf', 'lh.seghead'))
     renderer.mesh(*seghead_rr.T, triangles=seghead_tri, color=(0.7,) * 3,

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -252,7 +252,7 @@ add_head(renderer, scalp_pts_in_meg_coord, 'blue')
 add_head(renderer, scalp_pts_in_head_coord, 'pink')
 add_head(renderer, scalp_points_in_vox, 'green')
 mne.viz.set_3d_view(figure=renderer.figure, distance=800,
-                    focalpoint=(0., 0., 30.), elevation=105, azimuth=180)
+                    focalpoint=(0., 30., 30.), elevation=105, azimuth=180)
 renderer.show()
 
 ###############################################################################
@@ -289,7 +289,7 @@ renderer = mne.viz.backends.renderer.create_3d_figure(
     size=(600, 600), bgcolor='w', scene=False)
 add_head(renderer, scalp_points_in_vox, 'green', opacity=1)
 mne.viz.set_3d_view(figure=renderer.figure, distance=800,
-                    focalpoint=(0., 0., 0.), elevation=60, azimuth=180)
+                    focalpoint=(0., 30., 30.), elevation=45, azimuth=180)
 renderer.sphere(center=nasion_vox, color='orange', scale=10)
 renderer.show()
 

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -211,8 +211,6 @@ def plot_dig_alignment(points, coord_system='ras'):
 ###############################################################################
 # Plot untransformed head space digitized points as if they were in RAS space
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Adjust units by * 1e3 m -> mm.
-#
 # The plot below shows the digitization points in the coordinate space
 # native to the digitizer equipment plotted with the head surface in
 # right-anterior-superior (RAS) coordinates. The relationship between the
@@ -224,8 +222,8 @@ head_space = np.array([dig['r'] for dig in
 plot_dig_alignment(head_space)
 
 ###############################################################################
-# Apply the precomputed `trans` and plot again in meg space
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# Apply the precomputed ``trans`` and plot again in meg space
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # Rotate and translate the points based on the coregistration.
 #
 # The plot below shows the head space coordinates transformed to mri


### PR DESCRIPTION
Ok here is the linear algebra of how the transform happens. I think it's useful for developers but it's a bit hard to visualize without putting up some mayavi/matplotlib 3D figures with just points on them which would be far below the rest of the example quality-wise. If there is a way to plot it that looks nice, I could add that. I'm not sure if it'd be useful to print details about the scaling or anything but it does explain how I understand the transform to work. If that's helpful to have in docs then great, if this isn't good enough to be merged that would be understandable too.

Addresses https://github.com/mne-tools/mne-python/issues/7081