### PR TITLE
ENH: Adding support of GridSearchCV for mne.decoding.LinearModel

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -116,6 +116,8 @@ Bug
 
 - Fix handling of missing values (NaNs) in :func:`mne.time_frequency.psd_welch` by `Clemens Brunner`_
 
+- Fix :class:`mne.decoding.LinearModel` to support the refitted estimator of ``GridSearchCV`` in ``sklearn`` by `Chun-Hui Li`_
+
 API
 ~~~
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -281,3 +281,5 @@
 .. _Demetres Kostas: https://github.com/kostasde
 
 .. _Alex Rockhill: https://github.com/alexrockhill/
+
+.. _Chun-Hui Li: https://github.com/iamsc

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -117,7 +117,6 @@ class LinearModel(BaseEstimator):
             filters = self.model.best_estimator_.coef_
         else:
             raise ValueError('model does not have a `coef_` attribute.')
-        
         if filters.ndim == 2 and filters.shape[0] == 1:
             filters = filters[0]
         return filters

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -109,9 +109,15 @@ class LinearModel(BaseEstimator):
 
     @property
     def filters_(self):
-        if not hasattr(self.model, 'coef_'):
+        if hasattr(self.model, 'coef_'):
+            # Standard Linear Model
+            filters = self.model.coef_
+        elif hasattr(self.model.best_estimator_, 'coef_'):
+            # Linear Model with GridSearchCV
+            filters = self.model.best_estimator_.coef_
+        else:
             raise ValueError('model does not have a `coef_` attribute.')
-        filters = self.model.coef_
+        
         if filters.ndim == 2 and filters.shape[0] == 1:
             filters = filters[0]
         return filters

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -134,6 +134,7 @@ def test_get_coef():
         assert_equal(invs, list())
 
     # II. Test get coef for classification/regression estimators and pipelines
+    rng = np.random.RandomState(0)
     for clf in (lm_regression,
                 lm_gs_classification,
                 make_pipeline(StandardScaler(), lm_classification),
@@ -143,7 +144,7 @@ def test_get_coef():
         # according to the type of estimator.
         if is_classifier(clf):
             n, n_features = 1000, 3
-            X = np.random.rand(n, n_features)
+            X = rng.rand(n, n_features)
             y = np.arange(n) % 2
         else:
             X, y, A = _make_data(n_samples=1000, n_features=3, n_targets=1)
@@ -218,15 +219,17 @@ def test_linearmodel():
     """Test LinearModel class for computing filters and patterns."""
     # check categorical target fit in standard linear model
     from sklearn.linear_model import LinearRegression
-    np.random.seed(42)
+    rng = np.random.RandomState(0)
     clf = LinearModel()
     n, n_features = 20, 3
-    X = np.random.rand(n, n_features)
+    X = rng.rand(n, n_features)
     y = np.arange(n) % 2
     clf.fit(X, y)
     assert_equal(clf.filters_.shape, (n_features,))
     assert_equal(clf.patterns_.shape, (n_features,))
-    pytest.raises(ValueError, clf.fit, np.random.rand(n, n_features, 99), y)
+    with pytest.raises(ValueError):
+        wrong_X = rng.rand(n, n_features, 99)
+        clf.fit(wrong_X, y)
 
     # check categorical target fit in standard linear model with GridSearchCV
     from sklearn import svm
@@ -241,11 +244,13 @@ def test_linearmodel():
     clf.fit(X, y)
     assert_equal(clf.filters_.shape, (n_features,))
     assert_equal(clf.patterns_.shape, (n_features,))
-    pytest.raises(ValueError, clf.fit, np.random.rand(n, n_features, 99), y)
+    with pytest.raises(ValueError):
+        wrong_X = rng.rand(n, n_features, 99)
+        clf.fit(wrong_X, y)
 
     # check continuous target fit in standard linear model with GridSearchCV
     n_targets = 1
-    Y = np.random.rand(n, n_targets)
+    Y = rng.rand(n, n_targets)
     clf = LinearModel(
         GridSearchCV(
             svm.SVR(), parameters, cv=2,
@@ -255,16 +260,20 @@ def test_linearmodel():
     clf.fit(X, y)
     assert_equal(clf.filters_.shape, (n_features, ))
     assert_equal(clf.patterns_.shape, (n_features, ))
-    pytest.raises(ValueError, clf.fit, X, np.random.rand(n, n_features, 99))
+    with pytest.raises(ValueError):
+        wrong_y = rng.rand(n, n_features, 99)
+        clf.fit(X, wrong_y)
 
     # check multi-target fit in standard linear model
     n_targets = 5
-    Y = np.random.rand(n, n_targets)
+    Y = rng.rand(n, n_targets)
     clf = LinearModel(LinearRegression())
     clf.fit(X, Y)
     assert_equal(clf.filters_.shape, (n_targets, n_features))
     assert_equal(clf.patterns_.shape, (n_targets, n_features))
-    pytest.raises(ValueError, clf.fit, X, np.random.rand(n, n_features, 99))
+    with pytest.raises(ValueError):
+        wrong_y = rng.rand(n, n_features, 99)
+        clf.fit(X, wrong_y)
 
 
 @requires_version('sklearn', '0.18')

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -71,11 +71,21 @@ def test_get_coef():
     lm_regression = LinearModel(Ridge())
     assert (is_regressor(lm_regression))
 
-    parameters = {'kernel':['linear'], 'C':[1, 10, 100, 1000]}
-    lm_gs_classification = LinearModel(GridSearchCV(svm.SVC(), parameters, cv=5, refit=True, iid=False, n_jobs= 5))
+    parameters = {'kernel': ['linear'], 'C': [1, 10, 100, 1000]}
+    lm_gs_classification = LinearModel(
+        GridSearchCV(
+            svm.SVC(), parameters,
+            cv=5, refit=True, iid=False, n_jobs=5
+        )
+    )
     assert (is_classifier(lm_gs_classification))
 
-    lm_gs_regression = LinearModel(GridSearchCV(svm.SVR(), parameters, cv=5, refit=True, iid=False, n_jobs= 5))
+    lm_gs_regression = LinearModel(
+        GridSearchCV(
+            svm.SVR(), parameters, cv=5,
+            refit=True, iid=False, n_jobs=5
+        )
+    )
     assert (is_regressor(lm_gs_regression))
 
     # Define a classifier, an invertible transformer and an non-invertible one.
@@ -124,12 +134,17 @@ def test_get_coef():
         assert_equal(invs, list())
 
     # II. Test get coef for classification/regression estimators and pipelines
-    for clf in (lm_classification, make_pipeline(StandardScaler(), lm_classification),
-                lm_regression, make_pipeline(StandardScaler(), lm_regression),
-                lm_gs_classification, make_pipeline(StandardScaler(), lm_gs_classification),
-                lm_gs_regression, make_pipeline(StandardScaler(), lm_gs_regression)):
+    for clf in (lm_classification,
+                lm_regression,
+                lm_gs_classification,
+                lm_gs_regression,
+                make_pipeline(StandardScaler(), lm_classification),
+                make_pipeline(StandardScaler(), lm_regression),
+                make_pipeline(StandardScaler(), lm_gs_classification),
+                make_pipeline(StandardScaler(), lm_gs_regression)):
 
-        # generate some categorical/continuous data according to the type of estimator.
+        # generate some categorical/continuous data
+        # according to the type of estimator.
         if is_classifier(clf):
             n, n_features = 2000, 3
             X = np.random.rand(n, n_features)
@@ -205,7 +220,6 @@ def test_get_coef():
 @requires_version('sklearn', '0.15')
 def test_linearmodel():
     """Test LinearModel class for computing filters and patterns."""
-
     # check categorical target fit in standard linear model
     from sklearn.linear_model import LinearRegression
     np.random.seed(42)
@@ -221,17 +235,27 @@ def test_linearmodel():
     # check categorical target fit in standard linear model with GridSearchCV
     from sklearn import svm
     from sklearn.model_selection import GridSearchCV
-    parameters = {'kernel':['linear'], 'C':[1, 10, 100, 1000]}
-    clf = LinearModel(GridSearchCV(svm.SVC(), parameters, cv=5, refit=True, iid=False, n_jobs= 5))
+    parameters = {'kernel': ['linear'], 'C': [1, 10, 100, 1000]}
+    clf = LinearModel(
+        GridSearchCV(
+            svm.SVC(), parameters, cv=5,
+            refit=True, iid=False, n_jobs=5
+        )
+    )
     clf.fit(X, y)
     assert_equal(clf.filters_.shape, (n_features,))
     assert_equal(clf.patterns_.shape, (n_features,))
     pytest.raises(ValueError, clf.fit, np.random.rand(n, n_features, 99), y)
 
-    # check continous target fit in standard linear model with GridSearchCV
+    # check continuous target fit in standard linear model with GridSearchCV
     n_targets = 1
     Y = np.random.rand(n, n_targets)
-    clf = LinearModel(GridSearchCV(svm.SVR(), parameters, cv=5, refit=True, iid=False, n_jobs= 5))
+    clf = LinearModel(
+        GridSearchCV(
+            svm.SVR(), parameters, cv=5,
+            refit=True, iid=False, n_jobs=5
+        )
+    )
     clf.fit(X, y)
     assert_equal(clf.filters_.shape, (n_features, ))
     assert_equal(clf.patterns_.shape, (n_features, ))

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -71,7 +71,7 @@ def test_get_coef():
     lm_regression = LinearModel(Ridge())
     assert (is_regressor(lm_regression))
 
-    parameters = {'kernel': ['linear'], 'C': [1, 10, 100]}
+    parameters = {'kernel': ['linear'], 'C': [1, 10]}
     lm_gs_classification = LinearModel(
         GridSearchCV(
             svm.SVC(), parameters,
@@ -105,7 +105,7 @@ def test_get_coef():
         def inverse_transform(self, X):
             return X
 
-    X, y, A = _make_data(n_samples=2000, n_features=3, n_targets=1)
+    X, y, A = _make_data(n_samples=1000, n_features=3, n_targets=1)
 
     # I. Test inverse function
 
@@ -134,23 +134,19 @@ def test_get_coef():
         assert_equal(invs, list())
 
     # II. Test get coef for classification/regression estimators and pipelines
-    for clf in (lm_classification,
-                lm_regression,
+    for clf in (lm_regression,
                 lm_gs_classification,
-                lm_gs_regression,
                 make_pipeline(StandardScaler(), lm_classification),
-                make_pipeline(StandardScaler(), lm_regression),
-                make_pipeline(StandardScaler(), lm_gs_classification),
                 make_pipeline(StandardScaler(), lm_gs_regression)):
 
         # generate some categorical/continuous data
         # according to the type of estimator.
         if is_classifier(clf):
-            n, n_features = 2000, 3
+            n, n_features = 1000, 3
             X = np.random.rand(n, n_features)
             y = np.arange(n) % 2
         else:
-            X, y, A = _make_data(n_samples=2000, n_features=3, n_targets=1)
+            X, y, A = _make_data(n_samples=1000, n_features=3, n_targets=1)
             y = np.ravel(y)
 
         clf.fit(X, y)
@@ -205,7 +201,7 @@ def test_get_coef():
     # Check patterns with more than 1 regressor
     for n_features in [1, 5]:
         for n_targets in [1, 3]:
-            X, Y, A = _make_data(n_samples=5000, n_features=5, n_targets=3)
+            X, Y, A = _make_data(n_samples=3000, n_features=5, n_targets=3)
             lm = LinearModel(LinearRegression()).fit(X, Y)
             assert_array_equal(lm.filters_.shape, lm.patterns_.shape)
             assert_array_equal(lm.filters_.shape, [3, 5])
@@ -235,7 +231,7 @@ def test_linearmodel():
     # check categorical target fit in standard linear model with GridSearchCV
     from sklearn import svm
     from sklearn.model_selection import GridSearchCV
-    parameters = {'kernel': ['linear'], 'C': [1, 10, 100]}
+    parameters = {'kernel': ['linear'], 'C': [1, 10]}
     clf = LinearModel(
         GridSearchCV(
             svm.SVC(), parameters, cv=2,

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -71,19 +71,19 @@ def test_get_coef():
     lm_regression = LinearModel(Ridge())
     assert (is_regressor(lm_regression))
 
-    parameters = {'kernel': ['linear'], 'C': [1, 10, 100, 1000]}
+    parameters = {'kernel': ['linear'], 'C': [1, 10, 100]}
     lm_gs_classification = LinearModel(
         GridSearchCV(
             svm.SVC(), parameters,
-            cv=5, refit=True, iid=False, n_jobs=5
+            cv=2, refit=True, iid=False, n_jobs=1
         )
     )
     assert (is_classifier(lm_gs_classification))
 
     lm_gs_regression = LinearModel(
         GridSearchCV(
-            svm.SVR(), parameters, cv=5,
-            refit=True, iid=False, n_jobs=5
+            svm.SVR(), parameters, cv=2,
+            refit=True, iid=False, n_jobs=1
         )
     )
     assert (is_regressor(lm_gs_regression))
@@ -235,11 +235,11 @@ def test_linearmodel():
     # check categorical target fit in standard linear model with GridSearchCV
     from sklearn import svm
     from sklearn.model_selection import GridSearchCV
-    parameters = {'kernel': ['linear'], 'C': [1, 10, 100, 1000]}
+    parameters = {'kernel': ['linear'], 'C': [1, 10, 100]}
     clf = LinearModel(
         GridSearchCV(
-            svm.SVC(), parameters, cv=5,
-            refit=True, iid=False, n_jobs=5
+            svm.SVC(), parameters, cv=2,
+            refit=True, iid=False, n_jobs=1
         )
     )
     clf.fit(X, y)
@@ -252,8 +252,8 @@ def test_linearmodel():
     Y = np.random.rand(n, n_targets)
     clf = LinearModel(
         GridSearchCV(
-            svm.SVR(), parameters, cv=5,
-            refit=True, iid=False, n_jobs=5
+            svm.SVR(), parameters, cv=2,
+            refit=True, iid=False, n_jobs=1
         )
     )
     clf.fit(X, y)


### PR DESCRIPTION
#### Reference issue
Fixes #7027 .

#### What does this implement/fix?
This PR adds the support of `GridSearchCV` for `LinearModel`. I also ran the decoding/tests/test_base.py and got the 3 passed.
