### PR TITLE
BUG: CTF - set meas_date

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -74,6 +74,8 @@ Changelog
 Bug
 ~~~
 
+- Fix :meth:`mne.io.read_raw_ctf` to set measurement date from CTF ds files by `Luke Bloy`_.
+
 - Fix :meth:`mne.io.Raw.anonymize` correctly reset ``raw.annotations.orig_time`` by `Luke Bloy`_.
 
 - Fix date reading before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -141,11 +141,13 @@ class RawCTF(BaseRaw):
 
         # Add bad segments as Annotations (correct for start time)
         start_time = -res4['pre_trig_pts'] / float(info['sfreq'])
-        annot = _annotate_bad_segments(directory, start_time)
+        annot = _annotate_bad_segments(directory, start_time,
+                                       info['meas_date'])
         marker_annot = _read_annotations_ctf_call(
             directory=directory,
             total_offset=(res4['pre_trig_pts'] / res4['sfreq']),
             trial_duration=(res4['nsamp'] / res4['sfreq']),
+            meas_date=info['meas_date']
         )
         annot = marker_annot if annot is None else annot + marker_annot
         self.set_annotations(annot)

--- a/mne/io/ctf/info.py
+++ b/mne/io/ctf/info.py
@@ -13,7 +13,7 @@ import numpy as np
 from ...utils import logger, warn, _clean_names
 from ...transforms import (apply_trans, _coord_frame_name, invert_transform,
                            combine_transforms)
-from ...annotations import Annotations
+from ...annotations import Annotations, _handle_meas_date
 
 from ..meas_info import _empty_info
 from ..write import get_new_file_id
@@ -424,6 +424,7 @@ def _compose_meas_info(res4, coils, trans, eeg):
     info['meas_id']['usecs'] = 0
     info['meas_id']['secs'] = _convert_time(res4['data_date'],
                                             res4['data_time'])
+    info['meas_date'] = (info['meas_id']['secs'], info['meas_id']['usecs'])
     info['experimenter'] = res4['nf_operator']
     info['subject_info'] = dict(his_id=res4['nf_subject_id'])
     for filt in res4['filters']:
@@ -464,10 +465,12 @@ def _read_bad_chans(directory, info):
     return bad_chans
 
 
-def _annotate_bad_segments(directory, start_time):
+def _annotate_bad_segments(directory, start_time, meas_date):
     fname = op.join(directory, 'bad.segments')
     if not op.exists(fname):
         return None
+    orig_time = _handle_meas_date(meas_date)
+
     # read in bad segment file
     onsets = []
     durations = []
@@ -482,4 +485,4 @@ def _annotate_bad_segments(directory, start_time):
     if len(onsets) == 0:
         return None
 
-    return Annotations(onsets, durations, desc)
+    return Annotations(onsets, durations, desc, orig_time)

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -286,6 +286,7 @@ def test_saving_picked(tmpdir, comp_grade):
     temp_dir = str(tmpdir)
     out_fname = op.join(temp_dir, 'test_py_raw.fif')
     raw = read_raw_ctf(op.join(ctf_dir, ctf_fname_1_trial))
+    assert(raw.info['meas_date'] == (1367228160, 0))
     raw.crop(0, 1).load_data()
     assert raw.compensation_grade == get_current_comp(raw.info) == 0
     assert len(raw.info['comps']) == 5

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -115,6 +115,9 @@ def test_read_ctf(tmpdir):
         for t in ('dev_head_t', 'dev_ctf_t', 'ctf_head_t'):
             assert_allclose(raw.info[t]['trans'], raw_c.info[t]['trans'],
                             rtol=1e-4, atol=1e-7)
+        # XXX 2019/11/29 : MNC-C FIF conversion files don't have meas_date set.
+        # Consider adding meas_date to below checks once this is addressed in
+        # MNE-C
         for key in ('acq_pars', 'acq_stim', 'bads',
                     'ch_names', 'custom_ref_applied', 'description',
                     'events', 'experimenter', 'highpass', 'line_freq',


### PR DESCRIPTION
BUG: CTF IO never sets the meas_date.

I've checked on my data that the newly set meas_date is correct, at least to the day.

```
In [2]: raw = mne.io.read_raw_ctf('nnnn_20190724_01.ds')                                                                       
In [3]: mne.io.meas_info._stamp_to_dt(raw.info['meas_date'])                                                                                        
Out[3]: datetime.datetime(2019, 7, 24, 7, 55, tzinfo=datetime.timezone.utc)
```

I'm counting on existing annotations testing to be complete.