### PR TITLE
ENH: refactor _handle_event_colors

### DIFF
--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -1109,7 +1109,8 @@ def _prepare_mne_browse_epochs(params, projs, n_channels, n_epochs, scalings,
     epoch_nr = True
     if events is not None:
         event_set = set(events[:, 2])
-        event_colors = _handle_event_colors(event_set, event_colors, event_set)
+        event_colors = _handle_event_colors(event_colors, event_set,
+                                            params['epochs'].event_id)
         epoch_nr = False  # epoch number off by default to avoid overlap
         for label in ax.xaxis.get_ticklabels():
             label.set_visible(False)

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -31,7 +31,7 @@ from ..io.pick import (_DATA_CH_TYPES_SPLIT, pick_types, pick_info,
 from ..source_space import read_source_spaces, SourceSpaces, _read_mri_info
 from ..transforms import invert_transform, apply_trans
 from ..utils import (logger, verbose, get_subjects_dir, warn, _check_option,
-                     _mask_to_onsets_offsets)
+                     _mask_to_onsets_offsets, _pl)
 from ..io.pick import _picks_by_type
 from ..filter import estimate_ringing_samples
 from .utils import tight_layout, _get_color_list, _prepare_trellis, plt_show
@@ -1037,6 +1037,12 @@ def _handle_event_colors(color_dict, unique_events, event_id):
             else:                     # key not a valid event, warn and ignore
                 warn('Event ID %s is in the color dict but is not '
                      'present in events or event_id.' % key)
+        # warn if color_dict is missing any entries
+        unassigned = list(set(unique_events) - set(colors_out))
+        if len(unassigned):
+            unassigned_str = ', '.join(str(e) for e in unassigned)
+            warn('Color was not assigned for event%s %s. Default colors will '
+                 'be used.' % (_pl(unassigned), unassigned_str))
     # assign defaults if needed
     for event, color in zip(sorted(unique_events), default_colors):
         colors_out[event] = colors_out.get(event, color)

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -1022,31 +1022,30 @@ def plot_ideal_filter(freq, gain, axes=None, title='', flim=None, fscale='log',
 
 def _handle_event_colors(color_dict, unique_events, event_id):
     """Create event-integer-to-color mapping, assigning defaults as needed."""
-    default_colors = cycle(_get_color_list())
-    colors_out = dict()
+    default_colors = dict(zip(sorted(unique_events), cycle(_get_color_list())))
+    # warn if not enough colors
     if color_dict is None:
         if len(unique_events) > len(_get_color_list()):
             warn('More events than default colors available. You should pass '
                  'a list of unique colors.')
     else:
+        custom_colors = dict()
         for key, color in color_dict.items():
             if key in unique_events:  # key was a valid event integer
-                colors_out[key] = color
+                custom_colors[key] = color
             elif key in event_id:     # key was an event label
-                colors_out[event_id[key]] = color
+                custom_colors[event_id[key]] = color
             else:                     # key not a valid event, warn and ignore
                 warn('Event ID %s is in the color dict but is not '
-                     'present in events or event_id.' % key)
+                     'present in events or event_id.' % str(key))
         # warn if color_dict is missing any entries
-        unassigned = list(set(unique_events) - set(colors_out))
+        unassigned = sorted(set(unique_events) - set(custom_colors))
         if len(unassigned):
             unassigned_str = ', '.join(str(e) for e in unassigned)
             warn('Color was not assigned for event%s %s. Default colors will '
                  'be used.' % (_pl(unassigned), unassigned_str))
-    # assign defaults if needed
-    for event, color in zip(sorted(unique_events), default_colors):
-        colors_out[event] = colors_out.get(event, color)
-    return colors_out
+        default_colors.update(custom_colors)
+    return default_colors
 
 
 def plot_csd(csd, info=None, mode='csd', colorbar=True, cmap=None,

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -113,17 +113,19 @@ def test_plot_events():
     with pytest.warns(RuntimeWarning, match='will be ignored'):
         plot_events(events, raw.info['sfreq'], raw.first_samp,
                     event_id=event_labels)
-    with pytest.warns(RuntimeWarning, match='Color is not available'):
+    with pytest.warns(RuntimeWarning, match='Color was not assigned'):
         plot_events(events, raw.info['sfreq'], raw.first_samp,
                     color=color)
-    with pytest.warns(RuntimeWarning, match='event .* missing'):
+    with pytest.warns(RuntimeWarning, match=r'vent \d+ missing from event_id'):
         plot_events(events, raw.info['sfreq'], raw.first_samp,
                     event_id=event_labels, color=color)
-    with pytest.warns(RuntimeWarning, match='event .* missing'):
-        pytest.raises(ValueError, plot_events, events, raw.info['sfreq'],
-                      raw.first_samp, event_id={'aud_l': 1}, color=color)
-    pytest.raises(ValueError, plot_events, events, raw.info['sfreq'],
-                  raw.first_samp, event_id={'aud_l': 111}, color=color)
+    multimatch = r'event \d+ missing from event_id|in the color dict but is'
+    with pytest.warns(RuntimeWarning, match=multimatch):
+        plot_events(events, raw.info['sfreq'], raw.first_samp,
+                    event_id={'aud_l': 1}, color=color)
+    with pytest.raises(ValueError, match='from event_id is not present in'):
+        plot_events(events, raw.info['sfreq'], raw.first_samp,
+                    event_id={'aud_l': 111}, color=color)
     plt.close('all')
 
 

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -14,13 +14,15 @@ import pytest
 import matplotlib.pyplot as plt
 
 from mne import (read_events, read_cov, read_source_spaces, read_evokeds,
-                 read_dipole, SourceEstimate)
+                 read_dipole, SourceEstimate, pick_events)
 from mne.datasets import testing
 from mne.filter import create_filter
 from mne.io import read_raw_fif
 from mne.minimum_norm import read_inverse_operator
 from mne.viz import (plot_bem, plot_events, plot_source_spectrogram,
                      plot_snr_estimate, plot_filter, plot_csd)
+from mne.viz.misc import _handle_event_colors
+from mne.viz.utils import _get_color_list
 from mne.utils import requires_nibabel, run_tests_if_main
 from mne.time_frequency import CrossSpectralDensity
 
@@ -98,6 +100,22 @@ def test_plot_bem():
              orientation='coronal', brain_surfaces='white')
     plot_bem(subject='sample', subjects_dir=subjects_dir,
              orientation='coronal', slices=[25, 50], src=src_fname)
+
+
+def test_event_colors():
+    """Test color assignment."""
+    events = pick_events(_get_events(), include=[1, 2])
+    unique_events = set(events[:, 2])
+    # make sure defaults work
+    colors = _handle_event_colors(None, unique_events, dict())
+    default_colors = _get_color_list()
+    assert colors[1] == default_colors[0]
+    # make sure custom color overrides default
+    colors = _handle_event_colors(color_dict=dict(foo='k', bar='#facade'),
+                                  unique_events=unique_events,
+                                  event_id=dict(foo=1, bar=2))
+    assert colors[1] == 'k'
+    assert colors[2] == '#facade'
 
 
 def test_plot_events():

--- a/tutorials/epochs/plot_20_visualize_epochs.py
+++ b/tutorials/epochs/plot_20_visualize_epochs.py
@@ -68,7 +68,7 @@ del raw
 
 catch_trials_and_buttonpresses = mne.pick_events(events, include=[5, 32])
 epochs['face'].plot(events=catch_trials_and_buttonpresses,
-                    event_colors={32: 'red'})
+                    event_colors={32: 'red', 5: 'green'})
 
 ###############################################################################
 # Plotting projectors from an ``Epochs`` object

--- a/tutorials/epochs/plot_20_visualize_epochs.py
+++ b/tutorials/epochs/plot_20_visualize_epochs.py
@@ -68,7 +68,7 @@ del raw
 
 catch_trials_and_buttonpresses = mne.pick_events(events, include=[5, 32])
 epochs['face'].plot(events=catch_trials_and_buttonpresses,
-                    event_colors={32: 'red', 5: 'yellow'})
+                    event_colors={32: 'red'})
 
 ###############################################################################
 # Plotting projectors from an ``Epochs`` object


### PR DESCRIPTION
closes #7101 , which turned out not to have been a bug after all.  I was doing something like:

```python
epochs['face'].plot(..., event_colors=dict(buttonpress='red'))
```

in order to control the color of buttonpress events in a plot of "face" epochs.  The two problems with this:

1. `epochs['face']` drops all the other entries in `epochs.event_id` except for `{'face': 5}`, so the message that `"buttonpress" is in the color dict but not in events or event_id` is technically correct. However:

2. the error message implies that passing `event_colors=dict(face='blue')` should work, which it does not (on current master) because the color handling only accepts event integers as valid keys for the color dict.

This PR refactors `_handle_event_colors` to accept either valid event integers, or valid `event_id` string keys (or a mix of both).  It still won't fix my original problem of 

```python
epochs['face'].plot(..., event_colors=dict(buttonpress='red'))
```

because of `epochs['face']` causing other `event_id` entries to be dropped (I'm open to suggestions about how to make that work).  But it will allow

```python
epochs['face'].plot(..., event_colors=dict(face='blue'))
```

as well as the more general case

```python
epochs.plot(..., event_colors=dict(buttonpress='red', face='blue'))
```
