### PR TITLE
MRG, FIX: Allow unknown when setting montage

### DIFF
--- a/doc/changes/0.19.inc
+++ b/doc/changes/0.19.inc
@@ -9,6 +9,13 @@
 
 .. _changes_0_19:
 
+Version 0.19.3
+
+Bug
+~~~
+
+- Fix :func:`mne.io.Raw.set_montage` to allow using custom montages in unknown coordinates when LPA, Nasion, and/or RPA are not present by `Eric Larson`_
+
 Version 0.19.2
 --------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -458,6 +458,8 @@ def reset_warnings(gallery_conf, fname):
     warnings.filterwarnings(  # nilearn
         'ignore', message=r'sklearn\.externals\.joblib is deprecated.*',
         category=FutureWarning)
+    warnings.filterwarnings(  # nilearn
+        'ignore', message=r'The sklearn.* module is.*', category=FutureWarning)
     warnings.filterwarnings(  # deal with other modules having bad imports
         'ignore', message=".*ufunc size changed.*", category=RuntimeWarning)
     warnings.filterwarnings(  # realtime

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -455,6 +455,9 @@ def reset_warnings(gallery_conf, fname):
     warnings.filterwarnings(  # deal with bootstrap-theme bug
         'ignore', message=".*modify script_files in the theme.*",
         category=Warning)
+    warnings.filterwarnings(  # nilearn
+        'ignore', message=r'sklearn\.externals\.joblib is deprecated.*',
+        category=FutureWarning)
     warnings.filterwarnings(  # deal with other modules having bad imports
         'ignore', message=".*ufunc size changed.*", category=RuntimeWarning)
     warnings.filterwarnings(  # realtime

--- a/examples/visualization/plot_channel_epochs_image.py
+++ b/examples/visualization/plot_channel_epochs_image.py
@@ -50,7 +50,7 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
 
 # and order with spectral reordering
 # If you don't have scikit-learn installed set order_func to None
-from sklearn.cluster.spectral import spectral_embedding  # noqa
+from sklearn.manifold import spectral_embedding  # noqa
 from sklearn.metrics.pairwise import rbf_kernel   # noqa
 
 

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1656,8 +1656,7 @@ def test_set_montage_coord_frame_in_head_vs_unknown():
         ]
     )
 
-    _MSG = 'Points have to be provided as one dimensional arrays of length 3.'
-    with pytest.raises(ValueError, match=_MSG):
+    with pytest.warns(RuntimeWarning, match='assuming identity'):
         raw.set_montage(montage_in_unknown)
 
     raw.set_montage(montage_in_unknown_with_fid)

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -75,6 +75,8 @@ def pytest_configure(config):
     ignore:.*imp.*:DeprecationWarning
     ignore:scipy\.gradient is deprecated.*:DeprecationWarning
     ignore:Exception creating Regex for oneOf.*:SyntaxWarning
+    ignore:sklearn\.externals\.joblib is deprecated.*:FutureWarning
+    ignore:The sklearn.*module.*deprecated.*:FutureWarning
     always:.*get_data.* is deprecated in favor of.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):


### PR DESCRIPTION
Closes #7114.

For backward compat, we should allow setting montages with `coord_frame='unknown'` if not all fids are present. Now we do so with a warning.