### PR TITLE
MRG, ENH: Use datetime objects for meas_date

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -80,9 +80,13 @@ Bug
 
 - Fix :meth:`mne.io.read_raw_ctf` to set measurement date from CTF ds files by `Luke Bloy`_.
 
-- Fix :meth:`mne.io.Raw.anonymize` correctly reset ``raw.annotations.orig_time`` by `Luke Bloy`_.
+- Fix :meth:`mne.io.Raw.anonymize` to correctly reset ``raw.annotations.orig_time`` by `Luke Bloy`_.
 
-- The attribute :class:`mne.Annotations.orig_time <mne.Annotations>` is now read-only, and is a :class:`~python:datetime.datetime` object rather than float, by `Eric Larson`_
+- Fix :meth:`mne.io.Raw.anonymize` to correctly avoid shifting ``raw.annotations.onset`` relative to ``raw.first_samp`` by `Eric Larson`_
+
+- The attribute :class:`mne.Annotations.orig_time <mne.Annotations>` is now read-only, and is a :class:`~python:datetime.datetime` object (or None) rather than float, by `Eric Larson`_
+
+- The :class:`info['meas_date'] <mne.Info>` entry is now a :class:`~python:datetime.datetime` object (or None) rather than float, by `Eric Larson`_
 
 - Fix date reading before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -88,7 +88,7 @@ Bug
 
 - The attribute :class:`mne.Annotations.orig_time <mne.Annotations>` is now read-only, and is a :class:`~python:datetime.datetime` object (or None) rather than float, by `Eric Larson`_
 
-- Unity behavior of ``raw.annotations.append(...)`` when ``raw.info['meas_date']`` is None to make onsets absolute relative to ``first_samp`` as they are when ``raw.info['meas_date']`` is not None; i.e., you might need to do ``raw.annotations.append(old_time + raw.first_time)``, by `Eric Larson`_
+- Unify behavior of ``raw.annotations.append(...)`` when ``raw.info['meas_date']`` is None to make onsets absolute relative to ``first_samp`` as they are when ``raw.info['meas_date']`` is not None; i.e., you might need to do ``raw.annotations.append(old_time + raw.first_time)``, by `Eric Larson`_
 
 - The :class:`info['meas_date'] <mne.Info>` entry is now a :class:`~python:datetime.datetime` object (or None) rather than float, by `Eric Larson`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -82,6 +82,8 @@ Bug
 
 - Fix :meth:`mne.io.Raw.anonymize` correctly reset ``raw.annotations.orig_time`` by `Luke Bloy`_.
 
+- The attribute :class:`mne.Annotations.orig_time <mne.Annotations>` is now read-only, and is a :class:`~python:datetime.datetime` object rather than float, by `Eric Larson`_
+
 - Fix date reading before Unix time zero (1970 Jan 1) on Windows by `Alex Rockhill`_.
 
 - Fix bug running subprocesses (e.g., in :func:`mne.bem.make_watershed_bem`) in Jupyter notebooks, by `Eric Larson`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -21,6 +21,8 @@ Changelog
 
 - Add :func:`mne.chpi.calculate_head_pos_ctf` by `Luke Bloy`_
 
+- Add :func:`mne.io.Raw.set_meas_date` by `Eric Larson`_
+
 - Add command :ref:`gen_mne_setup_source_space` to quickly set up bilateral hemisphere surface-based source space with subsampling by `Victor Ferat`_.
 
 - Add command :ref:`gen_mne_sys_info` to print system information by `Eric Larson`_
@@ -85,6 +87,8 @@ Bug
 - Fix :meth:`mne.io.Raw.anonymize` to correctly avoid shifting ``raw.annotations.onset`` relative to ``raw.first_samp`` by `Eric Larson`_
 
 - The attribute :class:`mne.Annotations.orig_time <mne.Annotations>` is now read-only, and is a :class:`~python:datetime.datetime` object (or None) rather than float, by `Eric Larson`_
+
+- Unity behavior of ``raw.annotations.append(...)`` when ``raw.info['meas_date']`` is None to make onsets absolute relative to ``first_samp`` as they are when ``raw.info['meas_date']`` is not None; i.e., you might need to do ``raw.annotations.append(old_time + raw.first_time)``, by `Eric Larson`_
 
 - The :class:`info['meas_date'] <mne.Info>` entry is now a :class:`~python:datetime.datetime` object (or None) rather than float, by `Eric Larson`_
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -419,12 +419,8 @@ class Annotations(object):
 def _combine_annotations(one, two, one_n_samples, one_first_samp,
                          two_first_samp, sfreq, meas_date):
     """Combine a tuple of annotations."""
-    if one is None and two is None:
-        return None
-    elif two is None:
-        return one
-    elif one is None:
-        one = Annotations([], [], [], None)
+    assert one is not None
+    assert two is not None
 
     # Compute the shift necessary for alignment:
     # 1. The shift (in time) due to concatenation
@@ -435,9 +431,10 @@ def _combine_annotations(one, two, one_n_samples, one_first_samp,
         shift += one_first_samp / sfreq
         shift += (meas_date - one.orig_time).total_seconds()
     # 3. Shift by the difference in meas_date and two.orig_time
-    if two.orig_time is not None:
-        shift -= two_first_samp / sfreq
-        shift -= (meas_date - two.orig_time).total_seconds()
+    #    The meas_date of two is completely ignored here by design, as the
+    #    assumption of the concatenation is that the user is shifting
+    #    two onto the end of one in whatever the actual timeline was.
+    shift -= two_first_samp / sfreq
 
     onset = np.concatenate([one.onset, two.onset + shift])
     duration = np.concatenate([one.duration, two.duration])

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -403,8 +403,11 @@ class Annotations(object):
                 clip_right_elem.append(absolute_offset > absolute_tmax)
                 if clip_right_elem[-1]:
                     absolute_offset = absolute_tmax
-                durations.append(
-                    (absolute_offset - absolute_onset).total_seconds())
+                if clip_left_elem[-1] or clip_right_elem[-1]:
+                    durations.append(
+                        (absolute_offset - absolute_onset).total_seconds())
+                else:
+                    durations.append(duration)
                 onsets.append(
                     (absolute_onset - offset).total_seconds())
                 descriptions.append(description)

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -632,7 +632,7 @@ class SetChannelsMixin(object):
         ----------
         meas_date : datetime | float | tuple | None
             The new measurement date.
-            If datetime, it must be timezone-aware and in UTC.
+            If datetime object, it must be timezone-aware and in UTC.
             A tuple of (seconds, microseconds) or float (alias for
             ``(meas_date, 0)``) can also be passed and a datetime
             object will be automatically created. If None, will remove

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -650,7 +650,8 @@ class SetChannelsMixin(object):
         Notes
         -----
         If you want to remove all time references in the file, call
-        :func:`mne.anonymize_info` after calling ``inst.set_meas_date(None)``.
+        :func:`mne.io.anonymize_info(inst.info) <mne.io.anonymize>`
+        after calling ``inst.set_meas_date(None)``.
 
         .. versionadded:: 0.20
         """

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -645,7 +645,7 @@ class SetChannelsMixin(object):
 
         See Also
         --------
-        mne.io.Raw.anonymize_info
+        mne.io.Raw.anonymize
 
         Notes
         -----

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -645,12 +645,12 @@ class SetChannelsMixin(object):
 
         See Also
         --------
-        mne.io.Raw.anonymize
+        mne.io.Raw.anonymize_info
 
         Notes
         -----
         If you want to remove all time references in the file, call
-        :func:`mne.io.anonymize_info(inst.info) <mne.io.anonymize>`
+        :func:`mne.io.anonymize_info(inst.info) <mne.io.anonymize_info>`
         after calling ``inst.set_meas_date(None)``.
 
         .. versionadded:: 0.20

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -622,9 +622,43 @@ class SetChannelsMixin(object):
         .. versionadded:: 0.13.0
         """
         anonymize_info(self.info, daysback=daysback, keep_his=keep_his)
+        self.set_meas_date(self.info['meas_date'])  # unify annot update
+        return self
+
+    def set_meas_date(self, meas_date):
+        """Set the measurement start date.
+
+        Parameters
+        ----------
+        meas_date : datetime | float | tuple | None
+            The new measurement date.
+            If datetime, it must be timezone-aware and in UTC.
+            A tuple of (seconds, microseconds) or float (alias for
+            ``(meas_date, 0)``) can also be passed and a datetime
+            object will be automatically created. If None, will remove
+            the time reference.
+
+        Returns
+        -------
+        inst : instance of Raw | Epochs | Evoked
+            The modified raw instance. Operates in place.
+
+        See Also
+        --------
+        mne.io.Raw.anonymize
+
+        Notes
+        -----
+        If you want to remove all time references in the file, call
+        :func:`mne.anonymize_info` after calling ``inst.set_meas_date(None)``.
+
+        .. versionadded:: 0.20
+        """
+        from ..annotations import _handle_meas_date
+        meas_date = _handle_meas_date(meas_date)
+        self.info['meas_date'] = meas_date
         if hasattr(self, 'annotations'):
-            self.annotations._orig_time = self.info['meas_date']
-            self.annotations.onset -= self._first_time
+            self.annotations._orig_time = meas_date
         return self
 
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -22,7 +22,6 @@ from ..io.meas_info import anonymize_info, Info
 from ..io.pick import (channel_type, pick_info, pick_types, _picks_by_type,
                        _check_excludes_includes, _contains_ch_type,
                        channel_indices_by_type, pick_channels, _picks_to_idx)
-from ..annotations import _handle_meas_date
 
 
 DEPRECATED_PARAM = object()
@@ -624,11 +623,7 @@ class SetChannelsMixin(object):
         """
         anonymize_info(self.info, daysback=daysback, keep_his=keep_his)
         if hasattr(self, 'annotations'):
-            if self.info['meas_date'] is not None:
-                self.annotations._orig_time = \
-                    _handle_meas_date(self.info['meas_date'])
-            else:
-                self.annotations._orig_time = None
+            self.annotations._orig_time = self.info['meas_date']
             self.annotations.onset -= self._first_time
         return self
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -624,8 +624,11 @@ class SetChannelsMixin(object):
         """
         anonymize_info(self.info, daysback=daysback, keep_his=keep_his)
         if hasattr(self, 'annotations'):
-            self.annotations.orig_time = \
-                _handle_meas_date(self.info['meas_date'])
+            if self.info['meas_date'] is not None:
+                self.annotations._orig_time = \
+                    _handle_meas_date(self.info['meas_date'])
+            else:
+                self.annotations._orig_time = None
             self.annotations.onset -= self._first_time
         return self
 

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -23,7 +23,7 @@ from mne.datasets import testing, sample
 from mne.io import read_raw_fif, read_info
 from mne.utils import (run_tests_if_main, requires_mne,
                        requires_mayavi, requires_tvtk, requires_freesurfer,
-                       traits_test, ArgvSetter, modified_env)
+                       traits_test, ArgvSetter, modified_env, _stamp_to_dt)
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
@@ -369,7 +369,7 @@ def test_anonymize(tmpdir):
         mne_anonymize.run()
     info = read_info(out_fname)
     assert(op.exists(out_fname))
-    assert_equal(info['meas_date'], (946684800, 0))
+    assert info['meas_date'] == _stamp_to_dt((946684800, 0))
 
 
 run_tests_if_main()

--- a/mne/io/__init__.py
+++ b/mne/io/__init__.py
@@ -8,7 +8,7 @@
 from .open import fiff_open, show_fiff, _fiff_get_fid
 from .meas_info import (read_fiducials, write_fiducials, read_info, write_info,
                         _empty_info, _merge_info, _force_update_info, Info,
-                        anonymize_info, _stamp_to_dt)
+                        anonymize_info)
 
 from .proj import make_eeg_average_ref_proj, Projection
 from .tag import _loc_to_coil_trans, _coil_trans_to_loc, _loc_to_eeg_loc
@@ -54,19 +54,3 @@ from .fiff import Raw as RawFIF
 from .base import concatenate_raws
 from .reference import (set_eeg_reference, set_bipolar_reference,
                         add_reference_channels)
-
-__all__ = [
-    _coil_trans_to_loc, _empty_info, _fiff_get_fid, _force_update_info,
-    _loc_to_coil_trans, _loc_to_eeg_loc, _merge_info, _stamp_to_dt,
-    BaseRaw, Info, Projection, Raw, RawArray, RawFIF, add_reference_channels,
-    anonymize_info, array, base, brainvision, bti, cnt, concatenate_raws,
-    constants, ctf, edf, eeglab, egi, fiff, fiff_open, kit,
-    make_eeg_average_ref_proj, nicolet, pick, read_epochs_eeglab,
-    read_epochs_fieldtrip, read_epochs_kit, read_evoked_fieldtrip,
-    read_fiducials, read_info, read_raw_artemis123, read_raw_bdf,
-    read_raw_brainvision, read_raw_bti, read_raw_cnt, read_raw_ctf,
-    read_raw_curry, read_raw_edf, read_raw_eeglab, read_raw_egi,
-    read_raw_eximia, read_raw_fieldtrip, read_raw_fif, read_raw_gdf,
-    read_raw_kit, read_raw_nicolet, set_bipolar_reference, set_eeg_reference,
-    show_fiff, write_fiducials, write_info, read_raw_nirx,
-]

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -690,6 +690,11 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         return self._first_samps[0]
 
     @property
+    def first_time(self):
+        """The first time point (including first_samp but not meas_date)."""
+        return self._first_time
+
+    @property
     def last_samp(self):
         """The last data sample."""
         return self.first_samp + sum(self._raw_lengths) - 1
@@ -789,8 +794,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             if annotations.orig_time is None:
                 new_annotations.crop(0, self.times[-1] + delta,
                                      emit_warning=emit_warning)
-                if meas_date is not None:
-                    new_annotations.onset += self._first_time
+                new_annotations.onset += self._first_time
             else:
                 tmin = meas_date + timedelta(0, self._first_time)
                 tmax = tmin + timedelta(seconds=self.times[-1] + delta)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -10,6 +10,7 @@
 # License: BSD (3-clause)
 
 from copy import deepcopy
+from datetime import timedelta
 import os
 import os.path as op
 
@@ -36,7 +37,7 @@ from ..filter import (FilterMixin, notch_filter, resample,
 from ..parallel import parallel_func
 from ..utils import (_check_fname, _check_pandas_installed, sizeof_fmt,
                      _check_pandas_index_arguments, fill_doc, copy_doc,
-                     check_fname, _get_stim_channel,
+                     check_fname, _get_stim_channel, _stamp_to_dt,
                      logger, verbose, _time_mask, warn, SizeMixin,
                      copy_function_doc_to_method_doc, _validate_type,
                      _check_preload, _get_argvalues, _check_option)
@@ -44,7 +45,6 @@ from ..viz import plot_raw, plot_raw_psd, plot_raw_psd_topo
 from ..defaults import _handle_default
 from ..event import find_events, concatenate_events
 from ..annotations import Annotations, _combine_annotations, _sync_onset
-from ..annotations import _ensure_annotation_object
 
 
 def _set_pandas_dtype(df, columns, dtype):
@@ -356,6 +356,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         self._last_samps = np.array(last_samps)
         self._first_samps = np.array(first_samps)
         orig_ch_names = info['ch_names']
+        if isinstance(info['meas_date'], tuple):  # be permissive of old code
+            info['meas_date'] = _stamp_to_dt(info['meas_date'])
         info._check_consistency()  # make sure subclass did a good job
         self.info = info
         self.buffer_size_sec = float(buffer_size_sec)
@@ -720,12 +722,13 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             supplied.
         """
         first_samp_in_abs_time = (_handle_meas_date(self.info['meas_date']) +
-                                  self._first_time)
+                                  timedelta(0, self._first_time))
         if origin is None:
             origin = first_samp_in_abs_time
 
-        absolute_time = np.atleast_1d(times) + _handle_meas_date(origin)
-        times = (absolute_time - first_samp_in_abs_time)
+        delta = (_handle_meas_date(origin) -
+                 first_samp_in_abs_time).total_seconds()
+        times = np.atleast_1d(times) + delta
 
         return super(BaseRaw, self).time_as_index(times, use_rounding)
 
@@ -763,16 +766,13 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """
         meas_date = _handle_meas_date(self.info['meas_date'])
         if annotations is None:
-            if self.info['meas_date'] is not None:
-                orig_time = meas_date
-            else:
-                orig_time = None
+            orig_time = None if self.info['meas_date'] is None else meas_date
             self._annotations = Annotations([], [], [], orig_time)
         else:
-            _ensure_annotation_object(annotations)
+            _validate_type(annotations, Annotations, 'annotations')
 
             if self.info['meas_date'] is None and \
-               annotations.orig_time is not None:
+                    annotations.orig_time is not None:
                 raise RuntimeError('Ambiguous operation. Setting an Annotation'
                                    ' object with known ``orig_time`` to a raw'
                                    ' object which has ``meas_date`` set to'
@@ -784,27 +784,28 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                                    ' the raw object.')
 
             delta = 1. / self.info['sfreq']
-            time_of_first_sample = meas_date + self.first_samp * delta
+            time_of_first_sample = meas_date + timedelta(0, self._first_time)
             new_annotations = annotations.copy()
             if annotations.orig_time is None:
                 # Assume annotations to be relative to the data
-                new_annotations.orig_time = time_of_first_sample
+                new_annotations._orig_time = time_of_first_sample
 
             tmin = time_of_first_sample
-            tmax = tmin + self.times[-1] + delta
+            tmax = tmin + timedelta(seconds=self.times[-1] + delta)
             new_annotations.crop(tmin=tmin, tmax=tmax,
                                  emit_warning=emit_warning)
 
             if self.info['meas_date'] is None:
-                new_annotations.orig_time = None
+                new_annotations._orig_time = None
             elif annotations.orig_time != meas_date:
                 # XXX, TODO: this should be a function, method or something.
                 # maybe orig_time should have a setter
                 # new_annotations.orig_time = xxxxx # resets onset based on x
                 # new_annotations._update_orig(xxxx)
                 orig_time = new_annotations.orig_time
-                new_annotations.orig_time = meas_date
-                new_annotations.onset -= (meas_date - orig_time)
+                new_annotations._orig_time = meas_date
+                new_annotations.onset -= (
+                    meas_date - orig_time).total_seconds()
 
             self._annotations = new_annotations
 
@@ -1738,6 +1739,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         # now combine information from each raw file to construct new self
         annotations = self.annotations
+        assert annotations.orig_time == self.info['meas_date']
         edge_samps = list()
         for ri, r in enumerate(raws):
             n_samples = self.last_samp - self.first_samp + 1
@@ -1755,6 +1757,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             self._last_samps = np.r_[self._last_samps, r._last_samps]
             self._raw_extras += r._raw_extras
             self._filenames += r._filenames
+        assert annotations.orig_time == self.info['meas_date']
         self._update_times()
         self.set_annotations(annotations)
         for edge_samp in edge_samps:
@@ -1890,7 +1893,7 @@ class _RawShell(object):
     def set_annotations(self, annotations):
         if annotations is None:
             annotations = Annotations([], [], [], None)
-        self._annotations = annotations
+        self._annotations = annotations.copy()
 
 
 ###############################################################################

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -316,6 +316,8 @@ def _str_to_meas_date(date_str):
     if date_str in ['', '0', '00000000000000000000']:
         return None
 
+    # these calculations are in navie time but should be okay since
+    # they are relative (subtraction below)
     try:
         meas_date = datetime.strptime(date_str, '%Y%m%d%H%M%S%f')
     except ValueError as e:
@@ -774,7 +776,6 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale):
             coord_frame=FIFF.FIFFV_COORD_HEAD))
 
     info._update_redundant()
-    info._check_consistency()
     return (info, data_fname, fmt, order, n_samples, mrk_fname, montage,
             orig_units)
 

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -315,7 +315,7 @@ def _str_to_meas_date(date_str):
     if date_str in ['', '0', '00000000000000000000']:
         return None
 
-    # these calculations are in navie time but should be okay since
+    # these calculations are in naive time but should be okay since
     # they are relative (subtraction below)
     try:
         meas_date = datetime.strptime(date_str, '%Y%m%d%H%M%S%f')

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -14,13 +14,14 @@ import configparser
 import os
 import os.path as op
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from math import modf
 from io import StringIO
 
 import numpy as np
 
-from ...utils import verbose, logger, warn, fill_doc, _DefaultEventParser
+from ...utils import (verbose, logger, warn, fill_doc, _DefaultEventParser,
+                      _stamp_to_dt)
 from ..constants import FIFF
 from ..meas_info import _empty_info
 from ..base import BaseRaw
@@ -326,13 +327,8 @@ def _str_to_meas_date(date_str):
         else:
             raise
 
-    # We need list of unix time in milliseconds and as second entry
-    # the additional amount of microseconds
-    epoch = datetime.utcfromtimestamp(0)
-    unix_time = (meas_date - epoch).total_seconds()
-    unix_secs = int(modf(unix_time)[1])
-    microsecs = int(modf(unix_time)[0] * 1e6)
-    return unix_secs, microsecs
+    meas_date = meas_date.replace(tzinfo=timezone.utc)
+    return meas_date
 
 
 def _aux_vhdr_info(vhdr_fname):

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -15,13 +15,11 @@ import os
 import os.path as op
 import re
 from datetime import datetime, timezone
-from math import modf
 from io import StringIO
 
 import numpy as np
 
-from ...utils import (verbose, logger, warn, fill_doc, _DefaultEventParser,
-                      _stamp_to_dt)
+from ...utils import verbose, logger, warn, fill_doc, _DefaultEventParser
 from ..constants import FIFF
 from ..meas_info import _empty_info
 from ..base import BaseRaw

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -84,16 +84,16 @@ def test_orig_units(recwarn):
 
 DATE_TEST_CASES = np.array([
     ('Mk1=New Segment,,1,1,0,20131113161403794232\n',  # content
-     [1384359243, 794231],  # meas_date internal representation
+     [1384359243, 794232],  # meas_date internal representation
      '2013-11-13 16:14:03 GMT'),  # meas_date representation
 
     (('Mk1=New Segment,,1,1,0,20070716122240937454\n'
       'Mk2=New Segment,,2,1,0,20070716122240937455\n'),
-     [1184588560, 937453],
+     [1184588560, 937454],
      '2007-07-16 12:22:40 GMT'),
 
     ('Mk1=New Segment,,1,1,0,\nMk2=New Segment,,2,1,0,20070716122240937454\n',
-     [1184588560, 937453],
+     [1184588560, 937454],
      '2007-07-16 12:22:40 GMT'),
 
     ('Mk1=STATUS,,1,1,0\n', None, 'unspecified'),
@@ -532,7 +532,7 @@ def test_read_vmrk_annotations():
 def test_read_vhdr_annotations_and_events():
     """Test load brainvision annotations and parse them to events."""
     sfreq = 1000.0
-    expected_orig_time = _stamp_to_dt((1384359243, 794231))
+    expected_orig_time = _stamp_to_dt((1384359243, 794232))
     expected_onset_latency = np.array(
         [0, 486., 496., 1769., 1779., 3252., 3262., 4935., 4945., 5999., 6619.,
          6629., 7629., 7699.]

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -14,7 +14,7 @@ from numpy.testing import (assert_array_almost_equal, assert_array_equal,
 import pytest
 from tempfile import NamedTemporaryFile
 
-from mne.utils import _TempDir, run_tests_if_main
+from mne.utils import _TempDir, run_tests_if_main, _stamp_to_dt
 from mne import pick_types, read_annotations, concatenate_raws
 from mne.io.constants import FIFF
 from mne.io import read_raw_fif, read_raw_brainvision
@@ -135,10 +135,11 @@ def mocked_meas_date_file(_mocked_meas_date_data, request):
     lines[MEAS_DATE_LINE] = request.param['content']
     with open(vmrk_fname, 'w') as fout:
         fout.writelines(lines)
+    meas_date = request.param['meas_date']
+    if meas_date is not None:
+        meas_date = _stamp_to_dt(meas_date)
 
-    yield (
-        vhdr_fname, request.param['meas_date'], request.param['meas_date_repr']
-    )
+    yield vhdr_fname, meas_date, request.param['meas_date_repr']
 
 
 def test_meas_date(mocked_meas_date_file):
@@ -149,7 +150,7 @@ def test_meas_date(mocked_meas_date_file):
     if expected_meas is None:
         assert raw.info['meas_date'] is None
     else:
-        assert_allclose(raw.info['meas_date'], expected_meas)
+        assert raw.info['meas_date'] == expected_meas
 
 
 def test_vhdr_codepage_ansi():
@@ -531,7 +532,7 @@ def test_read_vmrk_annotations():
 def test_read_vhdr_annotations_and_events():
     """Test load brainvision annotations and parse them to events."""
     sfreq = 1000.0
-    expected_orig_time = 1384359243.794231
+    expected_orig_time = _stamp_to_dt((1384359243, 794231))
     expected_onset_latency = np.array(
         [0, 486., 496., 1769., 1779., 3252., 3262., 4935., 4945., 5999., 6619.,
          6629., 7629., 7699.]

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -14,7 +14,7 @@ from itertools import count
 
 import numpy as np
 
-from ...utils import logger, verbose
+from ...utils import logger, verbose, _stamp_to_dt
 from ...transforms import (combine_transforms, invert_transform,
                            Transform)
 from .._digitization import _make_bti_dig_points
@@ -1089,7 +1089,7 @@ def _get_bti_info(pdf_fname, config_fname, head_shape_fname, rotation_x,
     if pdf_fname is not None:
         info = _empty_info(sfreq)
         date = bti_info['processes'][0]['timestamp']
-        info['meas_date'] = (date, 0)
+        info['meas_date'] = _stamp_to_dt((date, 0))
     else:  # these cannot be guessed from config, see docstring
         info = _empty_info(1.0)
         info['sfreq'] = None

--- a/mne/io/ctf/info.py
+++ b/mne/io/ctf/info.py
@@ -13,7 +13,7 @@ import numpy as np
 from ...utils import logger, warn, _clean_names
 from ...transforms import (apply_trans, _coord_frame_name, invert_transform,
                            combine_transforms)
-from ...annotations import Annotations, _handle_meas_date
+from ...annotations import Annotations
 
 from ..meas_info import _empty_info
 from ..write import get_new_file_id
@@ -469,7 +469,6 @@ def _annotate_bad_segments(directory, start_time, meas_date):
     fname = op.join(directory, 'bad.segments')
     if not op.exists(fname):
         return None
-    orig_time = _handle_meas_date(meas_date)
 
     # read in bad segment file
     onsets = []
@@ -485,4 +484,4 @@ def _annotate_bad_segments(directory, start_time, meas_date):
     if len(onsets) == 0:
         return None
 
-    return Annotations(onsets, durations, desc, orig_time)
+    return Annotations(onsets, durations, desc, meas_date)

--- a/mne/io/ctf/markers.py
+++ b/mne/io/ctf/markers.py
@@ -6,7 +6,7 @@ import numpy as np
 import os.path as op
 from io import BytesIO
 
-from ...annotations import Annotations, _handle_meas_date
+from ...annotations import Annotations
 from .res4 import _read_res4
 from .info import _convert_time
 
@@ -66,9 +66,8 @@ def _read_annotations_ctf(directory):
 def _read_annotations_ctf_call(directory, total_offset, trial_duration,
                                meas_date):
     fname = op.join(directory, 'MarkerFile.mrk')
-    orig_time = _handle_meas_date(meas_date)
     if not op.exists(fname):
-        return Annotations(list(), list(), list(), orig_time=orig_time)
+        return Annotations(list(), list(), list(), orig_time=meas_date)
     else:
         markers = _get_markers(fname)
 
@@ -80,4 +79,4 @@ def _read_annotations_ctf_call(directory, total_offset, trial_duration,
         ])
 
         return Annotations(onset=onset, duration=np.zeros_like(onset),
-                           description=description, orig_time=orig_time)
+                           description=description, orig_time=meas_date)

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -352,7 +352,7 @@ def test_read_ctf_annotations():
     raw = RawArray(
         data=np.empty((1, 432000), dtype=np.float64),
         info=create_info(ch_names=1, sfreq=1200.0))
-    raw.info['meas_date'] = read_raw_ctf(somato_fname).info['meas_date']
+    raw.set_meas_date(read_raw_ctf(somato_fname).info['meas_date'])
     raw.set_annotations(read_annotations(somato_fname))
 
     events, _ = events_from_annotations(raw)

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -19,7 +19,8 @@ from mne.io import read_raw_fif, read_raw_ctf, RawArray
 from mne.io.compensator import get_current_comp
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.tests.test_annotations import _assert_annotations_equal
-from mne.utils import run_tests_if_main, _clean_names, catch_logging
+from mne.utils import (run_tests_if_main, _clean_names, catch_logging,
+                       _stamp_to_dt)
 from mne.datasets import testing, spm_face, brainstorm
 from mne.io.constants import FIFF
 
@@ -289,7 +290,7 @@ def test_saving_picked(tmpdir, comp_grade):
     temp_dir = str(tmpdir)
     out_fname = op.join(temp_dir, 'test_py_raw.fif')
     raw = read_raw_ctf(op.join(ctf_dir, ctf_fname_1_trial))
-    assert(raw.info['meas_date'] == (1367228160, 0))
+    assert raw.info['meas_date'] == _stamp_to_dt((1367228160, 0))
     raw.crop(0, 1).load_data()
     assert raw.compensation_grade == get_current_comp(raw.info) == 0
     assert len(raw.info['comps']) == 5
@@ -350,12 +351,13 @@ def test_read_ctf_annotations():
 
     raw = RawArray(
         data=np.empty((1, 432000), dtype=np.float64),
-        info=create_info(ch_names=1, sfreq=1200.0)
-    ).set_annotations(read_annotations(somato_fname))
+        info=create_info(ch_names=1, sfreq=1200.0))
+    raw.info['meas_date'] = read_raw_ctf(somato_fname).info['meas_date']
+    raw.set_annotations(read_annotations(somato_fname))
 
     events, _ = events_from_annotations(raw)
     latencies = np.sort(events[:, 0])
-    assert_array_equal(latencies, EXPECTED_LATENCIES)
+    assert_allclose(latencies, EXPECTED_LATENCIES, atol=1e-6)
 
 
 @testing.requires_testing_data
@@ -378,7 +380,7 @@ def test_read_ctf_annotations_smoke_test():
     assert_allclose(annot.onset, EXPECTED_ONSET)
 
     raw = read_raw_ctf(fname)
-    _assert_annotations_equal(raw.annotations, annot)
+    _assert_annotations_equal(raw.annotations, annot, 1e-6)
 
 
 run_tests_if_main()

--- a/mne/io/edf/tests/test_gdf.py
+++ b/mne/io/edf/tests/test_gdf.py
@@ -13,7 +13,6 @@ import scipy.io as sio
 
 from mne.datasets import testing
 from mne.io import read_raw_gdf
-from mne.io.meas_info import DATE_NONE
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.utils import run_tests_if_main
 from mne import pick_types, find_events, events_from_annotations
@@ -54,7 +53,7 @@ def test_gdf_data():
     assert len(raw.annotations.duration == 963)
 
     # gh-5604
-    assert raw.info['meas_date'] == DATE_NONE
+    assert raw.info['meas_date'] is None
 
 
 @testing.requires_testing_data
@@ -80,7 +79,7 @@ def test_gdf2_data():
     assert_array_equal(events[:, 2], [20, 28])
 
     # gh-5604
-    assert raw.info['meas_date'] == DATE_NONE
+    assert raw.info['meas_date'] is None
     _test_raw_reader(read_raw_gdf, input_fname=gdf2_path + '.gdf',
                      eog=None, misc=None)
 

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -18,7 +18,8 @@ import numpy as np
 from scipy import linalg
 
 from ..pick import pick_types
-from ...utils import verbose, logger, warn, fill_doc, _check_option
+from ...utils import (verbose, logger, warn, fill_doc, _check_option,
+                      _stamp_to_dt)
 from ...transforms import apply_trans, als_ras_trans
 from ..base import BaseRaw
 from ..utils import _mult_cal_one
@@ -668,7 +669,8 @@ def get_kit_info(rawfile, allow_unknown_format):
 
     # Create raw.info dict for raw fif object with SQD data
     info = _empty_info(float(sqd['sfreq']))
-    info.update(meas_date=(create_time, 0), lowpass=sqd['lowpass'],
+    info.update(meas_date=_stamp_to_dt((create_time, 0)),
+                lowpass=sqd['lowpass'],
                 highpass=sqd['highpass'], kit_system_id=sysid)
 
     # Creates a list of dicts of meg channels for raw.info

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1930,6 +1930,9 @@ def anonymize_info(info, daysback=None, keep_his=False, verbose=None):
     keep_his : bool
         If True his_id of subject_info will NOT be overwritten.
         Defaults to False.
+
+        .. warning:: This could mean that ``info`` is not fully
+                     anonymized. Use with caution.
     %(verbose)s
 
     Returns
@@ -2012,7 +2015,7 @@ def anonymize_info(info, daysback=None, keep_his=False, verbose=None):
         if subject_info.get('id') is not None:
             subject_info['id'] = default_subject_id
         if keep_his:
-            warn('Not fully anonymizing info - keeping \'his_id\'')
+            logger.info('Not fully anonymizing info - keeping \'his_id\'')
         elif subject_info.get('his_id') is not None:
             subject_info['his_id'] = str(default_subject_id)
 

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -2078,8 +2078,8 @@ def anonymize_info(info, daysback=None, keep_his=False):
                 di[k] = default_str
 
     err_mesg = ('anonymize_info generated an inconsistent info object. Most '
-                'often this is because daysback parameter was too large.\n'
-                'Underlying Error:')
+                'often this is because daysback parameter was too large. '
+                'Underlying Error:\n')
     info._check_consistency(prepend_error=err_mesg)
 
     return info

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1973,9 +1973,9 @@ def anonymize_info(info, daysback=None, keep_his=False):
     none_meas_date = info['meas_date'] is None
 
     if none_meas_date:
-        logger.warning('Input info has \'meas_date\' set to None.'
-                       ' Removing all information from time/date structures.'
-                       ' *NOT* performing any time shifts')
+        warn('Input info has \'meas_date\' set to None.'
+             ' Removing all information from time/date structures.'
+             ' *NOT* performing any time shifts')
         info['meas_date'] = None
     else:
         # compute timeshift delta
@@ -2010,7 +2010,7 @@ def anonymize_info(info, daysback=None, keep_his=False):
         if subject_info.get('id') is not None:
             subject_info['id'] = default_subject_id
         if keep_his:
-            logger.warning('Not fully anonymizing info - keeping \'his_id\'')
+            warn('Not fully anonymizing info - keeping \'his_id\'')
         elif subject_info.get('his_id') is not None:
             subject_info['his_id'] = str(default_subject_id)
 

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1915,7 +1915,8 @@ def _add_timedelta_to_stamp(meas_date_stamp, delta_t):
     return meas_date_stamp
 
 
-def anonymize_info(info, daysback=None, keep_his=False):
+@verbose
+def anonymize_info(info, daysback=None, keep_his=False, verbose=None):
     """Anonymize measurement information in place.
 
     Parameters
@@ -1929,6 +1930,7 @@ def anonymize_info(info, daysback=None, keep_his=False):
     keep_his : bool
         If True his_id of subject_info will NOT be overwritten.
         Defaults to False.
+    %(verbose)s
 
     Returns
     -------

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -28,7 +28,8 @@ from .write import (start_file, end_file, start_block, end_block,
                     write_julian, write_float_matrix, write_id, DATE_NONE)
 from .proc_history import _read_proc_history, _write_proc_history
 from ..transforms import invert_transform, Transform
-from ..utils import logger, verbose, warn, object_diff, _validate_type
+from ..utils import (logger, verbose, warn, object_diff, _validate_type,
+                     _stamp_to_dt, _dt_to_stamp)
 from ._digitization import (_format_dig_points, _dig_kind_proper,
                             _dig_kind_rev, _dig_kind_ints, _read_dig_fif)
 from ._digitization import write_dig as _dig_write_dig
@@ -118,22 +119,6 @@ def _get_valid_units():
 def _summarize_str(st):
     """Make summary string."""
     return st[:56][::-1].split(',', 1)[-1][::-1] + ', ...'
-
-
-def _dt_to_stamp(inp_date):
-    """Convert a datetime object to a meas_date."""
-    return int(inp_date.timestamp() // 1), inp_date.microsecond
-
-
-def _stamp_to_dt(utc_stamp):
-    """Convert timestamp to datetime object in Windows-friendly way."""
-    # The min on windows is 86400
-    stamp = [int(s) for s in utc_stamp]
-    if len(stamp) == 1:  # In case there is no microseconds information
-        stamp.append(0)
-    return (datetime.datetime.fromtimestamp(0,
-                                            tz=datetime.timezone.utc) +
-            datetime.timedelta(0, stamp[0], stamp[1]))  # day, sec, μs
 
 
 def _unique_channel_names(ch_names):
@@ -243,11 +228,12 @@ class Info(dict):
         Tilt angle of the gantry in degrees.
     lowpass : float
         Lowpass corner frequency in Hertz.
-    meas_date : tuple of int
-        The first element of this list is a UNIX timestamp (seconds since
-        1970-01-01 00:00:00) denoting the date and time at which the
-        measurement was taken. The second element is the additional number of
-        microseconds.
+    meas_date : datetime
+        The time (UTC) of the recording.
+
+        .. versionchanged:: 0.20
+           This is stored as a :class:`~python:datetime.datetime` object
+           instead of a tuple of seconds/microseconds.
     utc_offset : str
         "UTC offset of related meas_date (sHH:MM).
 
@@ -547,8 +533,7 @@ class Info(dict):
                     entr = 'unspecified'
                 else:
                     # first entry in meas_date is meaningful
-                    entr = (_stamp_to_dt(v).strftime('%Y-%m-%d %H:%M:%S') +
-                            ' GMT')
+                    entr = v.strftime('%Y-%m-%d %H:%M:%S') + ' GMT'
             elif k == 'kit_system_id' and v is not None:
                 from .kit.constants import KIT_SYSNAMES
                 entr = '%i (%s)' % (v, KIT_SYSNAMES.get(v, 'unknown'))
@@ -591,19 +576,20 @@ class Info(dict):
             raise RuntimeError(msg % (prepend_error, missing,))
         meas_date = self.get('meas_date')
         if meas_date is not None:
-            if (not isinstance(self['meas_date'], tuple) or
-                    len(self['meas_date']) != 2):
-                raise RuntimeError('%sinfo["meas_date"] must be a tuple '
-                                   'of length 2 or None, got "%r"'
+            if (not isinstance(self['meas_date'], datetime.datetime) or
+                    self['meas_date'].tzinfo is None or
+                    self['meas_date'].tzinfo is not datetime.timezone.utc):
+                raise RuntimeError('%sinfo["meas_date"] must be a datetime '
+                                   'object in UTC or None, got "%r"'
                                    % (prepend_error, repr(self['meas_date']),))
-            if (meas_date[0] < np.iinfo('>i4').min or
-                    meas_date[0] > np.iinfo('>i4').max):
-                raise RuntimeError('%sinfo["meas_date"] must be between "%r" '
-                                   'and "%r", got "%r"'
-                                   % (prepend_error,
-                                      (np.iinfo('>i4').min, 0),
-                                      (np.iinfo('>i4').max, 0),
-                                      self['meas_date'],))
+            meas_date_stamp = _dt_to_stamp(meas_date)
+            if (meas_date_stamp[0] < np.iinfo('>i4').min or
+                    meas_date_stamp[0] > np.iinfo('>i4').max):
+                raise RuntimeError(
+                    '%sinfo["meas_date"] seconds must be between "%r" '
+                    'and "%r", got "%r"'
+                    % (prepend_error, (np.iinfo('>i4').min, 0),
+                       (np.iinfo('>i4').max, 0), meas_date_stamp[0],))
 
         for key in ('file_id', 'meas_id'):
             value = self.get(key)
@@ -1260,6 +1246,8 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
         meas_date = (info['meas_id']['secs'], info['meas_id']['usecs'])
     if np.array_equal(meas_date, DATE_NONE):
         meas_date = None
+    else:
+        meas_date = _stamp_to_dt(meas_date)
     info['meas_date'] = meas_date
     info['utc_offset'] = utc_offset
 
@@ -1443,7 +1431,7 @@ def write_meas_info(fid, info, data_type=None, reset_range=True):
     if info.get('proj_name') is not None:
         write_string(fid, FIFF.FIFF_PROJ_NAME, info['proj_name'])
     if info.get('meas_date') is not None:
-        write_int(fid, FIFF.FIFF_MEAS_DATE, info['meas_date'])
+        write_int(fid, FIFF.FIFF_MEAS_DATE, _dt_to_stamp(info['meas_date']))
     if info.get('utc_offset') is not None:
         write_string(fid, FIFF.FIFF_UTC_OFFSET, info['utc_offset'])
     write_int(fid, FIFF.FIFF_NCHAN, info['nchan'])
@@ -1920,27 +1908,11 @@ def _force_update_info(info_base, info_target):
             i_targ[key] = val
 
 
-def _add_timedelta_to_meas_date(meas_date, delta_t):
-    """Add a timedelta to a meas_date tuple.
-
-    Parameters
-    ----------
-    meas_date : tuple | None
-        The Info object you want to use for overwriting values
-        in target Info objects.
-    delta_t : datetime.timedelta
-        The time difference that is added to the meas_date timestamp
-
-    Returns
-    -------
-    new_meas_date : tuple | none
-        The new meas_date tuple.
-    """
-    if meas_date is None:
-        new_meas_date = None
-    else:
-        new_meas_date = _dt_to_stamp(_stamp_to_dt(meas_date) + delta_t)
-    return new_meas_date
+def _add_timedelta_to_stamp(meas_date_stamp, delta_t):
+    """Add a timedelta to a meas_date tuple."""
+    if meas_date_stamp is not None:
+        meas_date_stamp = _dt_to_stamp(_stamp_to_dt(meas_date_stamp) + delta_t)
+    return meas_date_stamp
 
 
 def anonymize_info(info, daysback=None, keep_his=False):
@@ -2008,12 +1980,11 @@ def anonymize_info(info, daysback=None, keep_his=False):
     else:
         # compute timeshift delta
         if daysback is None:
-            delta_t = _stamp_to_dt(info['meas_date']) - default_anon_dos
+            delta_t = info['meas_date'] - default_anon_dos
         else:
             delta_t = datetime.timedelta(days=daysback)
         # adjust meas_date
-        info['meas_date'] = _add_timedelta_to_meas_date(info['meas_date'],
-                                                        -delta_t)
+        info['meas_date'] = info['meas_date'] - delta_t
 
     # file_id and meas_id
     for key in ('file_id', 'meas_id'):
@@ -2023,8 +1994,8 @@ def anonymize_info(info, daysback=None, keep_his=False):
             if none_meas_date:
                 tmp = DATE_NONE
             else:
-                tmp = _add_timedelta_to_meas_date((value['secs'],
-                                                   value['usecs']), -delta_t)
+                tmp = _add_timedelta_to_stamp(
+                    (value['secs'], value['usecs']), -delta_t)
             value['secs'] = tmp[0]
             value['usecs'] = tmp[1]
             # The following copy is needed for a test CTF dataset
@@ -2083,11 +2054,12 @@ def anonymize_info(info, daysback=None, keep_his=False):
             else:
                 this_t0 = (record['block_id']['secs'],
                            record['block_id']['usecs'])
-                this_t1 = _add_timedelta_to_meas_date(this_t0, -delta_t)
+                this_t1 = _add_timedelta_to_stamp(
+                    this_t0, -delta_t)
                 record['block_id']['secs'] = this_t1[0]
                 record['block_id']['usecs'] = this_t1[1]
-                record['date'] = _add_timedelta_to_meas_date(record['date'],
-                                                             -delta_t)
+                record['date'] = _add_timedelta_to_stamp(
+                    record['date'], -delta_t)
 
     hi = info.get('helium_info')
     if hi is not None:
@@ -2096,8 +2068,8 @@ def anonymize_info(info, daysback=None, keep_his=False):
         if none_meas_date and hi.get('meas_date') is not None:
             hi['meas_date'] = DATE_NONE
         elif hi.get('meas_date') is not None:
-            hi['meas_date'] = _add_timedelta_to_meas_date(hi['meas_date'],
-                                                          -delta_t)
+            hi['meas_date'] = _add_timedelta_to_stamp(
+                hi['meas_date'], -delta_t)
 
     di = info.get('device_info')
     if di is not None:

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -573,6 +573,10 @@ def test_anonymize(tmpdir):
                                     duration=[1, 1],
                                     description='dummy',
                                     orig_time=None))
+    first_samp = raw.first_samp
+    expected_onset = np.arange(2) + raw._first_time
+    assert raw.first_samp == first_samp
+    assert_allclose(raw.annotations.onset, expected_onset)
 
     # Test instance method
     events = read_events(event_name)
@@ -583,12 +587,17 @@ def test_anonymize(tmpdir):
 
     # test that annotations are correctly zeroed
     raw.anonymize()
+    assert raw.first_samp == first_samp
+    assert_allclose(raw.annotations.onset, expected_onset)
     assert raw.annotations.orig_time == raw.info['meas_date']
     stamp = _dt_to_stamp(raw.info['meas_date'])
     assert raw.annotations.orig_time == _stamp_to_dt(stamp)
+
     raw.info['meas_date'] = None
     raw.anonymize()
     assert raw.annotations.orig_time is None
+    assert raw.first_samp == first_samp
+    assert_allclose(raw.annotations.onset, expected_onset)
 
 
 @testing.requires_testing_data

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -518,8 +518,7 @@ def _test_anonymize_info(base_info):
     new_info = anonymize_info(base_info.copy())
     assert_object_equal(new_info, exp_info)
 
-    with pytest.warns(RuntimeWarning, match="keeping 'his_id'"):
-        new_info = anonymize_info(base_info.copy(), keep_his=True)
+    new_info = anonymize_info(base_info.copy(), keep_his=True)
     assert_object_equal(new_info, exp_info_2)
 
     new_info = anonymize_info(base_info.copy(), daysback=delta_t_2.days)

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -544,21 +544,23 @@ def _test_anonymize_info(base_info):
     assert_object_equal(new_info, exp_info_3)
 
 
-def test_meas_date_convert(tmpdir):
-    """Test conversions of meas_date to datetime objects."""
-    meas_date = (1346981585, 835782)
-    meas_datetime = _stamp_to_dt(meas_date)
-    meas_date2 = _dt_to_stamp(meas_datetime)
-    assert(meas_date == meas_date2)
-    assert(meas_datetime == datetime(2012, 9, 7, 1, 33, 5, 835782,
-                                     tzinfo=timezone.utc))
+@pytest.mark.parametrize('meas_date, dt', [
+    [(1346981585, 835782), (2012, 9, 7, 1, 33, 5, 835782)],
     # test old dates for BIDS anonymization
-    meas_date = (-1533443343, 24382)
+    [(-1533443343, 24382), (1921, 5, 29, 19, 30, 57, 24382)],
+    # gh-7116
+    [(-908196946, 988669), (1941, 3, 22, 11, 4, 14, 988669)],
+])
+def test_meas_date_convert(meas_date, dt):
+    """Test conversions of meas_date to datetime objects."""
     meas_datetime = _stamp_to_dt(meas_date)
     meas_date2 = _dt_to_stamp(meas_datetime)
-    assert(meas_date == meas_date2)
-    assert(meas_datetime == datetime(1921, 5, 29, 19, 30, 57, 24382,
-                                     tzinfo=timezone.utc))
+    assert meas_date == meas_date2
+    assert meas_datetime == datetime(*dt, tzinfo=timezone.utc)
+    # smoke test for info __repr__
+    info = create_info(1, 1000., 'eeg')
+    info['meas_date'] = meas_date
+    assert str(dt[0]) in repr(info)
 
 
 def test_anonymize(tmpdir):

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -139,11 +139,7 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
     assert concat_raw.last_samp - last_samp + first_samp == last_samp + 1
     idx = np.where(concat_raw.annotations.description == 'BAD boundary')[0]
 
-    if concat_raw.info['meas_date'] is None:
-        expected_bad_boundary_onset = ((last_samp - first_samp) /
-                                       raw.info['sfreq'])
-    else:
-        expected_bad_boundary_onset = raw._last_time
+    expected_bad_boundary_onset = raw._last_time
 
     assert_array_almost_equal(concat_raw.annotations.onset[idx],
                               expected_bad_boundary_onset,
@@ -262,7 +258,7 @@ def test_meas_date_orig_time():
     # Consider annot.orig_time to be raw.first_sample and clip
     raw = _raw_annot(None, None)
     assert raw.annotations.orig_time is None
-    assert raw.annotations.onset[0] == 0.5
+    assert raw.annotations.onset[0] == 1.5
     assert raw.annotations.duration[0] == 0.2
 
 

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -105,7 +105,7 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
             assert isinstance(d, DigPoint), (di, d)
 
     # gh-5604
-    assert _handle_meas_date(raw.info['meas_date']) >= 0
+    assert _handle_meas_date(raw.info['meas_date']) >= _handle_meas_date(0)
 
     # test resetting raw
     if test_kwargs:
@@ -242,14 +242,14 @@ def test_meas_date_orig_time():
     # clips the annotations based on raw.data and resets the annotation based
     # on raw.info['meas_date]
     raw = _raw_annot(1, 1.5)
-    assert raw.annotations.orig_time == 1
+    assert raw.annotations.orig_time == _handle_meas_date(1)
     assert raw.annotations.onset[0] == 1
 
     # meas_time is set and orig_time is None:
     # Consider annot.orig_time to be raw.frist_sample, clip and reset
     # annotations to have the raw.annotations.orig_time == raw.info['meas_date]
     raw = _raw_annot(1, None)
-    assert raw.annotations.orig_time == 1
+    assert raw.annotations.orig_time == _handle_meas_date(1)
     assert raw.annotations.onset[0] == 1.5
 
     # meas_time is None and orig_time is set:
@@ -318,7 +318,7 @@ def test_5839():
         raw = RawArray(data=np.empty((10, 10)),
                        info=create_info(ch_names=10, sfreq=10., ),
                        first_samp=10)
-        raw.info['meas_date'] = meas_date
+        raw.info['meas_date'] = _handle_meas_date(meas_date)
         raw.set_annotations(annotations=Annotations(onset=[.5],
                                                     duration=[.2],
                                                     description='dummy',
@@ -331,4 +331,4 @@ def test_5839():
     assert_array_equal(raw_A.annotations.onset, EXPECTED_ONSET)
     assert_array_equal(raw_A.annotations.duration, EXPECTED_DURATION)
     assert_array_equal(raw_A.annotations.description, EXPECTED_DESCRIPTION)
-    assert raw_A.annotations.orig_time == 0.0
+    assert raw_A.annotations.orig_time == _handle_meas_date(0.0)

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -226,7 +226,7 @@ def test_time_as_index_ref(offset, origin):
     """Test indexing of raw times."""
     info = create_info(ch_names=10, sfreq=10.)
     raw = RawArray(data=np.empty((10, 10)), info=info, first_samp=10)
-    raw.info['meas_date'] = _stamp_to_dt((1, 0))
+    raw.set_meas_date(1)
 
     relative_times = raw.times
     inds = raw.time_as_index(relative_times + offset,
@@ -317,14 +317,14 @@ def test_5839():
         raw = RawArray(data=np.empty((10, 10)),
                        info=create_info(ch_names=10, sfreq=10.),
                        first_samp=10)
-        raw.info['meas_date'] = meas_date
+        raw.set_meas_date(meas_date)
         raw.set_annotations(annotations=Annotations(onset=[.5],
                                                     duration=[.2],
                                                     description='dummy',
                                                     orig_time=None))
         return raw
 
-    raw_A, raw_B = [raw_factory(_stamp_to_dt((x, 0))) for x in [0, 2]]
+    raw_A, raw_B = [raw_factory((x, 0)) for x in [0, 2]]
     raw_A.append(raw_B)
 
     assert_array_equal(raw_A.annotations.onset, EXPECTED_ONSET)

--- a/mne/report.py
+++ b/mne/report.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from . import read_evokeds, read_events, pick_types, read_cov
 from .fixes import _get_img_fdata
-from .io import read_raw_fif, read_info, _stamp_to_dt
+from .io import read_raw_fif, read_info
 from .io.pick import _DATA_CH_TYPES_SPLIT
 from .utils import (logger, verbose, get_subjects_dir, warn,
                     fill_doc, _check_option)
@@ -1809,7 +1809,7 @@ class Report(object):
             ecg = 'Not available'
         meas_date = raw.info['meas_date']
         if meas_date is not None:
-            meas_date = _stamp_to_dt(meas_date).strftime("%B %d, %Y") + ' GMT'
+            meas_date = meas_date.strftime("%B %d, %Y") + ' GMT'
 
         html = raw_template.substitute(
             div_klass='raw', id=global_id, caption=caption, info=raw.info,

--- a/mne/simulation/evoked.py
+++ b/mne/simulation/evoked.py
@@ -140,6 +140,7 @@ def _add_noise(inst, cov, iir_filter, random_state, allow_subselection=True):
         data = data[np.newaxis]
     # Subselect if necessary
     info = inst.info
+    info._check_consistency()
     picks = gen_picks = slice(None)
     if allow_subselection:
         use_chs = list(set(info['ch_names']) & set(cov['names']))
@@ -147,6 +148,8 @@ def _add_noise(inst, cov, iir_filter, random_state, allow_subselection=True):
         logger.info('Adding noise to %d/%d channels (%d channels in cov)'
                     % (len(picks), len(info['chs']), len(cov['names'])))
         info = pick_info(inst.info, picks)
+        info._check_consistency()
+
         gen_picks = np.arange(info['nchan'])
     for epoch in data:
         epoch[picks] += _generate_noise(info, cov, iir_filter, random_state,

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -287,8 +287,8 @@ def test_crop_more():
     assert len(raw_concat.annotations) == 4
     assert_array_equal(raw_concat.annotations.description,
                        raw.annotations.description)
-    assert_allclose(raw.annotations.duration, duration, atol=1e-6)
-    assert_allclose(raw_concat.annotations.duration, duration, atol=1e-6)
+    assert_allclose(raw.annotations.duration, duration)
+    assert_allclose(raw_concat.annotations.duration, duration)
     assert_allclose(raw.annotations.onset, onset + offset)
     assert_allclose(raw_concat.annotations.onset, onset + offset,
                     atol=1. / raw.info['sfreq'])

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -651,7 +651,7 @@ def _create_annotation_based_on_descr(description, annotation_start_sampl=0,
     raw = RawArray(data=np.empty([10, 10], dtype=np.float64),
                    info=create_info(ch_names=10, sfreq=1000.),
                    first_samp=0)
-    raw.info['meas_date'] = 0
+    raw.info['meas_date'] = _stamp_to_dt((0, 0))
 
     # create dummy annotations based on the descriptions
     onset = raw.times[annotation_start_sampl]

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -369,13 +369,13 @@ def test_annotation_filtering(first_samp):
     # one last test: let's cut out a section entirely:
     # here the 1-3 second window should be skipped
     raw = raws_concat.copy()
-    raw.annotations.append(1., 2., 'foo')
+    raw.annotations.append(1. + raw._first_time, 2., 'foo')
     with catch_logging() as log:
         raw.filter(l_freq=50., h_freq=None, fir_design='firwin',
                    skip_by_annotation='foo', verbose='info')
     log = log.getvalue()
     assert '2 contiguous segments' in log
-    raw.annotations.append(2., 1., 'foo')  # shouldn't change anything
+    raw.annotations.append(2. + raw._first_time, 1., 'foo')  # shouldn't change
     with catch_logging() as log:
         raw.filter(l_freq=50., h_freq=None, fir_design='firwin',
                    skip_by_annotation='foo', verbose='info')

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -48,6 +48,7 @@ class _windows_datetime(datetime):
 
 @pytest.fixture(scope='function')
 def windows_like_datetime(monkeypatch):
+    """Ensure datetime.fromtimestamp is Windows-like."""
     if not sys.platform.startswith('win'):
         monkeypatch.setattr('mne.annotations.datetime', _windows_datetime)
     yield

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -32,8 +32,7 @@ from mne.epochs import (
     _handle_event_repeated)
 from mne.utils import (requires_pandas, run_tests_if_main, object_diff,
                        requires_version, catch_logging, _FakeNoPandas,
-                       assert_meg_snr, check_version, _stamp_to_dt,
-                       _dt_to_stamp)
+                       assert_meg_snr, check_version, _dt_to_stamp)
 from mne.chpi import read_head_pos, head_pos_to_trans_rot_t
 
 from mne.io import RawArray, read_raw_fif
@@ -2112,7 +2111,7 @@ def test_add_channels_epochs():
     epochs_meg2 = epochs_meg.copy()
     assert not epochs_meg.times.flags['WRITEABLE']
     assert not epochs_meg2.times.flags['WRITEABLE']
-    epochs_meg2.info['meas_date'] = _stamp_to_dt((0, 0))
+    epochs_meg2.set_meas_date(0)
     add_channels_epochs([epochs_meg2, epochs_eeg])
 
     epochs_meg2 = epochs_meg.copy()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -32,7 +32,8 @@ from mne.epochs import (
     _handle_event_repeated)
 from mne.utils import (requires_pandas, run_tests_if_main, object_diff,
                        requires_version, catch_logging, _FakeNoPandas,
-                       assert_meg_snr, check_version)
+                       assert_meg_snr, check_version, _stamp_to_dt,
+                       _dt_to_stamp)
 from mne.chpi import read_head_pos, head_pos_to_trans_rot_t
 
 from mne.io import RawArray, read_raw_fif
@@ -384,8 +385,8 @@ def test_reject():
                   events[::2][:3]]
         onsets[0] = onsets[0] + tmin - 0.499  # tmin < 0
         onsets[1] = onsets[1] + tmax - 0.001
-        first_time = (raw.info['meas_date'][0] + raw.info['meas_date'][1] *
-                      1e-6 + raw.first_samp / sfreq)
+        stamp = _dt_to_stamp(raw.info['meas_date'])
+        first_time = (stamp[0] + stamp[1] * 1e-6 + raw.first_samp / sfreq)
         for orig_time in [None, first_time]:
             annot = Annotations(onsets, [0.5, 0.5, 0.5], 'BAD', orig_time)
             raw.set_annotations(annot)
@@ -2111,7 +2112,7 @@ def test_add_channels_epochs():
     epochs_meg2 = epochs_meg.copy()
     assert not epochs_meg.times.flags['WRITEABLE']
     assert not epochs_meg2.times.flags['WRITEABLE']
-    epochs_meg2.info['meas_date'] = (0, 0)
+    epochs_meg2.info['meas_date'] = _stamp_to_dt((0, 0))
     add_channels_epochs([epochs_meg2, epochs_eeg])
 
     epochs_meg2 = epochs_meg.copy()

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -53,7 +53,8 @@ from .numerics import (hashfunc, _compute_row_norms,
                        _undo_scaling_array, _scaled_array, _replace_md5, _PCA,
                        _mask_to_onsets_offsets, _array_equal_nan,
                        _julian_to_cal, _cal_to_julian, _dt_to_julian,
-                       _julian_to_dt)
+                       _julian_to_dt, _dt_to_stamp, _stamp_to_dt,
+                       _check_dt)
 from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
                     _prepare_write_metadata, _FakeNoPandas, ShiftTimeMixin)
 from .linalg import (_svd_lwork, _repeated_svd,

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -355,10 +355,14 @@ def assert_object_equal(a, b):
 
 def _raw_annot(meas_date, orig_time):
     from .. import Annotations, create_info
+    from ..annotations import _handle_meas_date
     from ..io import RawArray
     info = create_info(ch_names=10, sfreq=10.)
     raw = RawArray(data=np.empty((10, 10)), info=info, first_samp=10)
+    if meas_date is not None:
+        meas_date = _handle_meas_date(meas_date)
     raw.info['meas_date'] = meas_date
+    raw.info._check_consistency()
     annot = Annotations([.5], [.2], ['dummy'], orig_time)
     raw.set_annotations(annotations=annot)
     return raw

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -15,7 +15,7 @@ import matplotlib.pyplot as plt
 from mne import read_events, pick_types, Annotations, create_info
 from mne.datasets import testing
 from mne.io import read_raw_fif, read_raw_ctf, RawArray
-from mne.utils import run_tests_if_main
+from mne.utils import run_tests_if_main, _stamp_to_dt, _dt_to_stamp
 from mne.viz.utils import _fake_click, _annotation_radio_clicked, _sync_onset
 from mne.viz import plot_raw, plot_sensors
 
@@ -276,8 +276,9 @@ def test_plot_raw():
                     kind='release')
 
         plt.close('all')
-    # test if meas_date has only one element
-    raw.info['meas_date'] = (raw.info['meas_date'][0], 0)
+    # test if meas_date is off
+    raw.info['meas_date'] = _stamp_to_dt(
+        (_dt_to_stamp(raw.info['meas_date'])[0], 0))
     annot = Annotations([1 + raw.first_samp / raw.info['sfreq']],
                         [5], ['bad'])
     with pytest.warns(RuntimeWarning, match='outside data range'):

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -15,7 +15,7 @@ import matplotlib.pyplot as plt
 from mne import read_events, pick_types, Annotations, create_info
 from mne.datasets import testing
 from mne.io import read_raw_fif, read_raw_ctf, RawArray
-from mne.utils import run_tests_if_main, _stamp_to_dt, _dt_to_stamp
+from mne.utils import run_tests_if_main, _dt_to_stamp
 from mne.viz.utils import _fake_click, _annotation_radio_clicked, _sync_onset
 from mne.viz import plot_raw, plot_sensors
 
@@ -277,8 +277,7 @@ def test_plot_raw():
 
         plt.close('all')
     # test if meas_date is off
-    raw.info['meas_date'] = _stamp_to_dt(
-        (_dt_to_stamp(raw.info['meas_date'])[0], 0))
+    raw.set_meas_date(_dt_to_stamp(raw.info['meas_date'])[0])
     annot = Annotations([1 + raw.first_samp / raw.info['sfreq']],
                         [5], ['bad'])
     with pytest.warns(RuntimeWarning, match='outside data range'):

--- a/tutorials/raw/plot_30_annotate_raw.py
+++ b/tutorials/raw/plot_30_annotate_raw.py
@@ -19,7 +19,7 @@ seconds before loading it into RAM to save memory:
 """
 
 import os
-from datetime import datetime
+from datetime import timedelta
 import mne
 
 sample_data_folder = mne.datasets.sample.data_path()
@@ -65,7 +65,7 @@ raw.set_annotations(my_annot)
 print(raw.annotations)
 
 # convert meas_date (a tuple of seconds, microseconds) into a float:
-meas_date = raw.info['meas_date'][0] + raw.info['meas_date'][1] / 1e6
+meas_date = raw.info['meas_date']
 orig_time = raw.annotations.orig_time
 print(meas_date == orig_time)
 
@@ -92,7 +92,7 @@ print(raw.annotations.onset)
 # seconds later than ``raw.info['meas_date']``.
 
 time_format = '%Y-%m-%d %H:%M:%S.%f'
-new_orig_time = datetime.utcfromtimestamp(meas_date + 50).strftime(time_format)
+new_orig_time = (meas_date + timedelta(seconds=50)).strftime(time_format)
 print(new_orig_time)
 
 later_annot = mne.Annotations(onset=[3, 5, 7],


### PR DESCRIPTION
~~Closes #7116.~~

~~First step, replicate the failure (hopefully). It passes locally on Linux but hopefully Azure shows the issue.~~

- [x] Use `datetime | None` objects for `info['meas_date']`.
- [x] Use `datetime | None` for `raw.annotations.orig_time`
- [x] Add code for `set_meas_date` that takes care of annotations and such. The anonymization code can use this / be refactored to use it. It only takes `datetime | None` as an argument.
- [x] ~~Extend set_meas_date and/or anonymize functions to kill some of these other dates (such as `meas_id`)~~
- [x] Fix bug where anonymizing would shift annotations by `raw._first_time`
- [x] Fix problems in Windows (`fromtimestamp`)