### PR TITLE
MRG, FIX: scaling in summarize_clusters_stc

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -78,6 +78,8 @@ Changelog
 Bug
 ~~~
 
+- Fix incorrect scaling of cluster temporal extent :func:`mne.stats.summarize_clusters_stc` by `Daniel McCloy`_.
+
 - Fix :meth:`mne.io.read_raw_ctf` to set measurement date from CTF ds files by `Luke Bloy`_.
 
 - Fix :meth:`mne.io.Raw.anonymize` correctly reset ``raw.annotations.orig_time`` by `Luke Bloy`_.

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1570,7 +1570,7 @@ def _reshape_clusters(clusters, sample_shape):
     return clusters
 
 
-def summarize_clusters_stc(clu, p_thresh=0.05, tstep=1e-3, tmin=0,
+def summarize_clusters_stc(clu, p_thresh=0.05, tstep=1.0, tmin=0,
                            subject='fsaverage', vertices=None):
     """Assemble summary SourceEstimate from spatiotemporal cluster results.
 
@@ -1584,7 +1584,10 @@ def summarize_clusters_stc(clu, p_thresh=0.05, tstep=1e-3, tmin=0,
     p_thresh : float
         The significance threshold for inclusion of clusters.
     tstep : float
-        The temporal difference between two time samples.
+        The time step between samples of the original :class:`STC
+        <mne.SourceEstimate>`, in seconds (i.e., ``1 / stc.sfreq``). Defaults
+        to ``1``, which will yield a colormap indicating cluster duration
+        measured in *samples* rather than *seconds*.
     tmin : float | int
         The time of the first sample.
     subject : str
@@ -1599,7 +1602,8 @@ def summarize_clusters_stc(clu, p_thresh=0.05, tstep=1e-3, tmin=0,
         A summary of the clusters. The first time point in this SourceEstimate
         object is the summation of all the clusters. Subsequent time points
         contain each individual cluster. The magnitude of the activity
-        corresponds to the length the cluster spans in time (in samples).
+        corresponds to the duration spanned by the cluster (duration units are
+        determined by ``tstep``).
     """
     if vertices is None:
         vertices = [np.arange(10242), np.arange(10242)]
@@ -1623,7 +1627,7 @@ def summarize_clusters_stc(clu, p_thresh=0.05, tstep=1e-3, tmin=0,
         data[v_inds, t_inds] = t_obs[t_inds, v_inds]
         # Store a nice visualization of the cluster by summing across time
         data = np.sign(data) * np.logical_not(data == 0) * tstep
-        data_summary[:, ii + 1] = 1e3 * np.sum(data, axis=1)
+        data_summary[:, ii + 1] = np.sum(data, axis=1)
         # Make the first "time point" a sum across all clusters for easy
         # visualization
     data_summary[:, 0] = np.sum(data_summary, axis=1)

--- a/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal.py
+++ b/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal.py
@@ -85,7 +85,7 @@ condition2 = apply_inverse(evoked2, inverse_operator, lambda2, method)
 condition1.crop(0, None)
 condition2.crop(0, None)
 tmin = condition1.tmin
-tstep = condition1.tstep
+tstep = condition1.tstep * 1000  # convert to milliseconds
 
 ###############################################################################
 # Transform to common cortical space

--- a/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal.py
+++ b/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal.py
@@ -184,6 +184,6 @@ subjects_dir = op.join(data_path, 'subjects')
 # blue blobs are for condition A < condition B, red for A > B
 brain = stc_all_cluster_vis.plot(
     hemi='both', views='lateral', subjects_dir=subjects_dir,
-    time_label='Duration significant (ms)', size=(800, 800),
+    time_label='temporal extent (ms)', size=(800, 800),
     smoothing_steps=5, clim=dict(kind='value', pos_lims=[0, 1, 40]))
 # brain.save_image('clusters.png')

--- a/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_2samp.py
+++ b/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_2samp.py
@@ -44,7 +44,7 @@ morph = mne.compute_source_morph(stc, 'sample', 'fsaverage',
                                  subjects_dir=subjects_dir)
 stc = morph.apply(stc)
 n_vertices_fsave, n_times = stc.data.shape
-tstep = stc.tstep
+tstep = stc.tstep * 1000  # convert to milliseconds
 
 n_subjects1, n_subjects2 = 7, 9
 print('Simulating data for %d and %d subjects.' % (n_subjects1, n_subjects2))

--- a/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_2samp.py
+++ b/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_2samp.py
@@ -108,5 +108,5 @@ subjects_dir = op.join(data_path, 'subjects')
 # blue blobs are for condition A != condition B
 brain = stc_all_cluster_vis.plot('fsaverage', hemi='both',
                                  views='lateral', subjects_dir=subjects_dir,
-                                 time_label='Duration significant (ms)',
+                                 time_label='temporal extent (ms)',
                                  clim=dict(kind='value', lims=[0, 1, 40]))

--- a/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_repeated_measures_anova.py
+++ b/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_repeated_measures_anova.py
@@ -89,7 +89,7 @@ for cond in ['l_aud', 'r_aud', 'l_vis', 'r_vis']:  # order is important
     conditions.append(condition)
 
 tmin = conditions[0].tmin
-tstep = conditions[0].tstep
+tstep = conditions[0].tstep * 1000  # convert to milliseconds
 
 ###############################################################################
 # Transform to common cortical space

--- a/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_repeated_measures_anova.py
+++ b/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal_repeated_measures_anova.py
@@ -239,7 +239,7 @@ subjects_dir = op.join(data_path, 'subjects')
 # stimulus modality and stimulus location
 
 brain = stc_all_cluster_vis.plot(subjects_dir=subjects_dir, views='lat',
-                                 time_label='Duration significant (ms)',
+                                 time_label='temporal extent (ms)',
                                  clim=dict(kind='value', lims=[0, 1, 40]))
 brain.save_image('cluster-lh.png')
 brain.show_view('medial')


### PR DESCRIPTION
there was a hard-coded `1e3` multiplication in `summarize_clusters_stc` that was cancelling out the effect of the default `tstep=1e-3` (which is probably why nobody noticed).  Passing any other value of `tstep` leads to really weird results; this should fix it.