### PR TITLE
VIZ, ENH: Add event dict to epochs plot signature

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -133,6 +133,8 @@ Bug
 API
 ~~~
 
+- :meth:`mne.Epochs.plot` now accepts an ``event_id`` parameter (useful in tandem with ``event_colors`` for specifying event colors by name) by `Daniel McCloy`_.
+
 - :meth:`mne.Epochs.shift_time` and :meth:`mne.Evoked.shift_time` now allow shifting times by arbitrary amounts (previously only by integer multiples of the sampling period), by `Daniel McCloy`_ and `Eric Larson`_.
 
 - The APIs of :meth:`mne.io.Raw.plot_projs_topomap`, :meth:`mne.Epochs.plot_projs_topomap` and :meth:`mne.Evoked.plot_projs_topomap` are now more similar to :func:`mne.viz.plot_projs_topomap` by `Daniel McCloy`_.

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1045,7 +1045,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
     def plot(self, picks=None, scalings=None, n_epochs=20, n_channels=20,
              title=None, events=None, event_colors=None, order=None,
              show=True, block=False, decim='auto', noise_cov=None,
-             butterfly=False, show_scrollbars=True, epoch_colors=None):
+             butterfly=False, show_scrollbars=True, epoch_colors=None,
+             event_id=None):
         return plot_epochs(self, picks=picks, scalings=scalings,
                            n_epochs=n_epochs, n_channels=n_channels,
                            title=title, events=events,
@@ -1053,7 +1054,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                            show=show, block=block, decim=decim,
                            noise_cov=noise_cov, butterfly=butterfly,
                            show_scrollbars=show_scrollbars,
-                           epoch_colors=epoch_colors)
+                           epoch_colors=epoch_colors, event_id=event_id)
 
     @copy_function_doc_to_method_doc(plot_epochs_psd)
     def plot_psd(self, fmin=0, fmax=np.inf, tmin=None, tmax=None,

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -819,6 +819,8 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
         Values in ``event_id`` will take precedence over those in
         ``epochs.event_id`` when there are overlapping keys.
 
+        .. versionadded:: 0.20
+
     Returns
     -------
     fig : instance of matplotlib.figure.Figure

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -724,7 +724,8 @@ def _epochs_axes_onclick(event, params):
 def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
                 title=None, events=None, event_colors=None, order=None,
                 show=True, block=False, decim='auto', noise_cov=None,
-                butterfly=False, show_scrollbars=True, epoch_colors=None):
+                butterfly=False, show_scrollbars=True, epoch_colors=None,
+                event_id=None):
     """Visualize epochs.
 
     Bad epochs can be marked with a left click on top of the epoch. Bad
@@ -811,6 +812,12 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
     %(show_scrollbars)s
     epoch_colors : list of (n_epochs) list (of n_channels) | None
         Colors to use for individual epochs. If None, use default colors.
+    event_id : dict | None
+        Dictionary of event labels (e.g. 'aud_l') as keys and associated event
+        integers as values. Useful when ``events`` contains event numbers not
+        present in ``epochs.event_id`` (e.g., because of event subselection).
+        Values in ``event_id`` will take precedence over those in
+        ``epochs.event_id`` when there are overlapping keys.
 
     Returns
     -------
@@ -849,7 +856,8 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
     params['label_click_fun'] = partial(_pick_bad_channels, params=params)
     _prepare_mne_browse_epochs(params, projs, n_channels, n_epochs, scalings,
                                title, picks, events=events, order=order,
-                               event_colors=event_colors, butterfly=butterfly)
+                               event_colors=event_colors, butterfly=butterfly,
+                               event_id=event_id)
     _prepare_projectors(params)
 
     callback_close = partial(_close_event, params=params)
@@ -948,7 +956,8 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
 
 def _prepare_mne_browse_epochs(params, projs, n_channels, n_epochs, scalings,
                                title, picks, events=None, event_colors=None,
-                               order=None, butterfly=False, info=None):
+                               order=None, butterfly=False, info=None,
+                               event_id=None):
     """Set up the mne_browse_epochs window."""
     import matplotlib as mpl
     from matplotlib.collections import LineCollection
@@ -1109,8 +1118,8 @@ def _prepare_mne_browse_epochs(params, projs, n_channels, n_epochs, scalings,
     epoch_nr = True
     if events is not None:
         event_set = set(events[:, 2])
-        event_colors = _handle_event_colors(event_colors, event_set,
-                                            params['epochs'].event_id)
+        ev_id = params['epochs'].event_id if event_id is None else event_id
+        event_colors = _handle_event_colors(event_colors, event_set, ev_id)
         epoch_nr = False  # epoch number off by default to avoid overlap
         for label in ax.xaxis.get_ticklabels():
             label.set_visible(False)

--- a/tutorials/epochs/plot_20_visualize_epochs.py
+++ b/tutorials/epochs/plot_20_visualize_epochs.py
@@ -67,8 +67,8 @@ del raw
 # responses also get marked (we'll plot them in red):
 
 catch_trials_and_buttonpresses = mne.pick_events(events, include=[5, 32])
-epochs['face'].plot(events=catch_trials_and_buttonpresses,
-                    event_colors={32: 'red', 5: 'green'})
+epochs['face'].plot(events=catch_trials_and_buttonpresses, event_id=event_dict,
+                    event_colors=dict(buttonpress='red', face='yellow'))
 
 ###############################################################################
 # Plotting projectors from an ``Epochs`` object

--- a/tutorials/epochs/plot_20_visualize_epochs.py
+++ b/tutorials/epochs/plot_20_visualize_epochs.py
@@ -64,7 +64,11 @@ del raw
 #
 # Here we'll plot only the "catch" trials from the :ref:`sample dataset
 # <sample-dataset>`, and pass in our events array so that the button press
-# responses also get marked (we'll plot them in red):
+# responses also get marked (we'll plot them in red). We also need to pass in
+# our ``event_dict`` so that the :meth:`~mne.Epochs.plot` method will know what
+# we mean by "buttonpress" — this is because subsetting the conditions by
+# calling ``epochs['face']`` automatically purges the dropped entries from
+# ``epochs.event_id``:
 
 catch_trials_and_buttonpresses = mne.pick_events(events, include=[5, 32])
 epochs['face'].plot(events=catch_trials_and_buttonpresses, event_id=event_dict,

--- a/tutorials/epochs/plot_20_visualize_epochs.py
+++ b/tutorials/epochs/plot_20_visualize_epochs.py
@@ -64,7 +64,8 @@ del raw
 #
 # Here we'll plot only the "catch" trials from the :ref:`sample dataset
 # <sample-dataset>`, and pass in our events array so that the button press
-# responses also get marked (we'll plot them in red). We also need to pass in
+# responses also get marked (we'll plot them in red, and plot the "face" events
+# defining time zero for each epoch in blue). We also need to pass in
 # our ``event_dict`` so that the :meth:`~mne.Epochs.plot` method will know what
 # we mean by "buttonpress" — this is because subsetting the conditions by
 # calling ``epochs['face']`` automatically purges the dropped entries from
@@ -72,7 +73,7 @@ del raw
 
 catch_trials_and_buttonpresses = mne.pick_events(events, include=[5, 32])
 epochs['face'].plot(events=catch_trials_and_buttonpresses, event_id=event_dict,
-                    event_colors=dict(buttonpress='red', face='yellow'))
+                    event_colors=dict(buttonpress='red', face='blue'))
 
 ###############################################################################
 # Plotting projectors from an ``Epochs`` object


### PR DESCRIPTION
as discussed in #7111, this adds an `event_id` parameter to `epochs.plot()` so that if users are passing in `events` that aren't part of `epochs.events`, they can specify event colors by name instead of by integer.

It also allows user-specified event colors for the t=0 event to override the (default) transparent green vertical line at t=0.  On this PR:

```python
catch_trials_and_buttonpresses = mne.pick_events(events, include=[5, 32])
epochs['face'].plot(events=catch_trials_and_buttonpresses, event_id=event_dict,
                    event_colors=dict(buttonpress='red', face='blue'))
```
yields this:

![this_PR](https://user-images.githubusercontent.com/1810515/70365603-1eff1680-1847-11ea-9601-f620d13ccd1d.png)

If no events are specified, or if the events passed to `plot()` don't include the event at t=0, the default line is still drawn (though it's been moved to zorder=0 to lie behind the traces instead of on top of them):

```python
buttonpresses_only = mne.pick_events(events, include=[32])
epochs['face'].plot(events=buttonpresses_only, event_id=event_dict,
                    event_colors=dict(buttonpress='red'))
```

![this_PR_2](https://user-images.githubusercontent.com/1810515/70365606-26262480-1847-11ea-91d5-4f894844597d.png)

