### PR TITLE
Remove incorrect transpose when selecting xDAWN filters

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -146,6 +146,8 @@ Bug
 
 - Fix :class:`mne.decoding.LinearModel` to support the refitted estimator of ``GridSearchCV`` in ``sklearn`` by `Chun-Hui Li`_
 
+- Fix bug in :class:`~mne.preprocessing.Xdawn` where filters where selected along the incorrect axis, by `Henrich Kolkhorst`_
+
 API
 ~~~
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -176,3 +176,5 @@ API
 - New methods :meth:`mne.Forward.pick_channels`, :meth:`mne.Covariance.pick_channels`, :meth:`mne.Info.pick_channels`, :meth:`mne.time_frequency.CrossSpectralDensity.pick_channels` by `Marijn van Vliet`_
 
 - New attributes ``mne.Forward.ch_names`` and ``mne.Info.ch_names`` by `Marijn van Vliet`_
+
+- In :class:`~mne.preprocessing.Xdawn`, the components are stored in the rows of attributes ``filters_`` and ``patterns_`` to be consistent with :class:`~mne.decoding.CSP` and :class:`~mne.preprocessing.ICA` by `Henrich Kolkhorst`_

--- a/examples/decoding/plot_decoding_xdawn_eeg.py
+++ b/examples/decoding/plot_decoding_xdawn_eeg.py
@@ -105,8 +105,8 @@ plt.show()
 
 
 ###############################################################################
-# The ``patterns_`` attribute of a fitted Xdawn instance (here from the last CV
-# fold) can be used for visualization.
+# The ``patterns_`` attribute of a fitted Xdawn instance (here from the last
+# cross-validation fold) can be used for visualization.
 
 fig, axes = plt.subplots(nrows=len(event_id), ncols=n_filter)
 fitted_xdawn = clf.steps[0][1]
@@ -124,4 +124,5 @@ for i, (cur_class, cur_patterns) in enumerate(fitted_xdawn.patterns_.items()):
         axes=axes[i, :],
         extrapolate='head',
         show=False)
+fig.subplots_adjust(hspace=0.1)
 plt.show()

--- a/examples/decoding/plot_decoding_xdawn_eeg.py
+++ b/examples/decoding/plot_decoding_xdawn_eeg.py
@@ -112,7 +112,7 @@ fig, axes = plt.subplots(nrows=len(event_id), ncols=n_filter)
 fitted_xdawn = clf.steps[0][1]
 for i, (cur_class, cur_patterns) in enumerate(fitted_xdawn.patterns_.items()):
     tmp_info = epochs.info.copy()
-    tmp_info['sfreq'] = 1
+    tmp_info['sfreq'] = 1.
     pattern_evoked = EvokedArray(cur_patterns[:n_filter].T, tmp_info, tmin=0)
     pattern_evoked.plot_topomap(
         times=np.arange(n_filter), ch_type=None,

--- a/examples/decoding/plot_decoding_xdawn_eeg.py
+++ b/examples/decoding/plot_decoding_xdawn_eeg.py
@@ -32,7 +32,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import classification_report, confusion_matrix
 from sklearn.preprocessing import MinMaxScaler
 
-from mne import io, pick_types, read_events, Epochs
+from mne import io, pick_types, read_events, Epochs, EvokedArray
 from mne.datasets import sample
 from mne.preprocessing import Xdawn
 from mne.decoding import Vectorizer
@@ -49,6 +49,7 @@ raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
 tmin, tmax = -0.1, 0.3
 event_id = dict(aud_l=1, aud_r=2, vis_l=3, vis_r=4)
+n_filter = 3
 
 # Setup for reading the raw data
 raw = io.read_raw_fif(raw_fname, preload=True)
@@ -63,7 +64,7 @@ epochs = Epochs(raw, events, event_id, tmin, tmax, proj=False,
                 verbose=False)
 
 # Create classification pipeline
-clf = make_pipeline(Xdawn(n_components=3),
+clf = make_pipeline(Xdawn(n_components=n_filter),
                     Vectorizer(),
                     MinMaxScaler(),
                     LogisticRegression(penalty='l1', solver='liblinear',
@@ -100,4 +101,27 @@ plt.yticks(tick_marks, target_names)
 tight_layout()
 plt.ylabel('True label')
 plt.xlabel('Predicted label')
+plt.show()
+
+
+###############################################################################
+# The ``patterns_`` attribute of a fitted Xdawn instance (here from the last CV
+# fold) can be used for visualization.
+
+fig, axes = plt.subplots(nrows=len(event_id), ncols=n_filter)
+fitted_xdawn = clf.steps[0][1]
+for i, (cur_class, cur_patterns) in enumerate(fitted_xdawn.patterns_.items()):
+    tmp_info = epochs.info.copy()
+    tmp_info['sfreq'] = 1
+    pattern_evoked = EvokedArray(cur_patterns[:n_filter].T, tmp_info, tmin=0)
+    pattern_evoked.plot_topomap(
+        times=np.arange(n_filter), ch_type=None,
+        scalings=None,
+        time_format='{} / comp. %01d'.format(cur_class),
+        colorbar=False,
+        head_pos={'center': [0, 0]},
+        show_names=False,
+        axes=axes[i, :],
+        extrapolate='head',
+        show=False)
 plt.show()

--- a/examples/decoding/plot_decoding_xdawn_eeg.py
+++ b/examples/decoding/plot_decoding_xdawn_eeg.py
@@ -124,5 +124,5 @@ for i, (cur_class, cur_patterns) in enumerate(fitted_xdawn.patterns_.items()):
         axes=axes[i, :],
         extrapolate='head',
         show=False)
-fig.subplots_adjust(hspace=0.1)
+fig.subplots_adjust(hspace=0.3)
 plt.show()

--- a/examples/preprocessing/plot_xdawn_denoising.py
+++ b/examples/preprocessing/plot_xdawn_denoising.py
@@ -66,7 +66,7 @@ plot_epochs_image(epochs['vis_r'], picks=[230], vmin=-500, vmax=500)
 
 ###############################################################################
 # Now, we estimate a set of xDAWN filters for the epochs (which contain only
-# the ``vis_r`` class.
+# the ``vis_r`` class).
 
 # Estimates signal covariance
 signal_cov = compute_raw_covariance(raw, picks=picks)

--- a/examples/preprocessing/plot_xdawn_denoising.py
+++ b/examples/preprocessing/plot_xdawn_denoising.py
@@ -64,6 +64,10 @@ epochs = Epochs(raw, events, event_id, tmin, tmax, proj=False,
 # Plot image epoch before xdawn
 plot_epochs_image(epochs['vis_r'], picks=[230], vmin=-500, vmax=500)
 
+###############################################################################
+# Now, we estimate a set of xDAWN filters for the epochs (which contain only
+# the ``vis_r`` class.
+
 # Estimates signal covariance
 signal_cov = compute_raw_covariance(raw, picks=picks)
 
@@ -73,7 +77,10 @@ xd = Xdawn(n_components=2, signal_cov=signal_cov)
 # Fit xdawn
 xd.fit(epochs)
 
-# Denoise epochs
+###############################################################################
+# Epochs are denoised by calling ``apply``, which by default keeps only the
+# signal subspace corresponding to the first ``n_components`` specified in the
+# ``Xdawn`` constructor above.
 epochs_denoised = xd.apply(epochs)
 
 # Plot image epoch after Xdawn

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -7,7 +7,8 @@ import numpy as np
 import os.path as op
 import sys
 
-from numpy.testing import assert_array_equal, assert_array_almost_equal
+from numpy.testing import (assert_array_equal, assert_array_almost_equal,
+                           assert_allclose)
 import pytest
 
 from mne import (Epochs, read_events, pick_types, compute_raw_covariance,
@@ -73,7 +74,7 @@ def test_xdawn_fit():
     evoked = epochs['cond2'].average()
     assert_array_equal(evoked.data, xd.evokeds_['cond2'].data)
 
-    assert np.all(np.isclose(np.linalg.norm(xd.filters_['cond2'], axis=1), 1))
+    assert_allclose(np.linalg.norm(xd.filters_['cond2'], axis=1), 1)
 
     # ========== with signal cov provided ====================
     # Provide covariance object

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -303,6 +303,7 @@ def _simulate_erplike_mixed_data(n_epochs=100, n_channels=10):
     return epochs, mixing_mat
 
 
+@requires_sklearn
 def test_xdawn_decoding_performance():
     from sklearn.model_selection import KFold
     from sklearn.pipeline import make_pipeline

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -305,6 +305,7 @@ def _simulate_erplike_mixed_data(n_epochs=100, n_channels=10):
 
 @requires_sklearn
 def test_xdawn_decoding_performance():
+    """Test decoding performance and extracted pattern on synthetic data."""
     from sklearn.model_selection import KFold
     from sklearn.pipeline import make_pipeline
     from sklearn.linear_model import LogisticRegression

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -290,8 +290,9 @@ def _load_audvis_testdata():
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_xdawn_decoding_performance():
-    # this test is based on the plot-decoding-xdawn-eeg example
-    from sklearn.model_selection import  KFold
+    """Test decoding performance using xDAWN."""
+    # is based on the plot-decoding-xdawn-eeg example
+    from sklearn.model_selection import KFold
     from sklearn.pipeline import make_pipeline
     from sklearn.linear_model import LogisticRegression
     from sklearn.preprocessing import MinMaxScaler
@@ -339,5 +340,6 @@ def test_xdawn_decoding_performance():
 
     assert np.mean(cv_accuracy_xdawn_trans) >= expected_accuracy
     assert_allclose(cv_accuracy_xdawn_trans, cv_accuracy_xdawn, atol=0.01)
+
 
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -345,7 +345,7 @@ def test_xdawn_decoding_performance():
         assert_allclose(cv_accuracy_xdawn, expected_accuracy, atol=0.01)
 
         # for both event types, the first component should "match" the mixing
-        fitted_xdawn = cur_pipeline[0]
+        fitted_xdawn = cur_pipeline.steps[0][1]
         if isinstance(fitted_xdawn, Xdawn):
             relev_patterns = np.concatenate([
                 fitted_xdawn.patterns_[cur_class][:1, :]

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -73,6 +73,8 @@ def test_xdawn_fit():
     evoked = epochs['cond2'].average()
     assert_array_equal(evoked.data, xd.evokeds_['cond2'].data)
 
+    assert np.all(np.isclose(np.linalg.norm(xd.filters_['cond2'], axis=1), 1))
+
     # ========== with signal cov provided ====================
     # Provide covariance object
     signal_cov = compute_raw_covariance(raw, picks=picks)
@@ -242,8 +244,8 @@ def test_XdawnTransformer():
 
     xdt = _XdawnTransformer()
     xdt.fit(X, y)
-    assert_array_almost_equal(xd.filters_['cond2'][:, :2],
-                              xdt.filters_.reshape(2, 2, 8)[0].T)
+    assert_array_almost_equal(xd.filters_['cond2'][:2, :],
+                              xdt.filters_.reshape(2, 2, 8)[0])
 
     # Transform testing
     xdt.transform(X[1:, ...])  # different number of epochs

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -305,9 +305,9 @@ def test_xdawn_decoding_performance():
     xdawn_pipeline = make_pipeline(Xdawn(n_components=3),
                                    Vectorizer(),
                                    MinMaxScaler(),
-                                   LogisticRegression(penalty='l1',
-                                                      solver='liblinear',
-                                                      multi_class='auto'))
+                                   LogisticRegression(
+                                       penalty='l1', solver='liblinear',
+                                       multi_class='auto'))
     cv = KFold(n_splits=5, shuffle=False)
     predictions = np.empty_like(labels, dtype=float)
     for cur_train_idxs, cur_test_idxs in cv.split(epochs, labels):
@@ -321,11 +321,11 @@ def test_xdawn_decoding_performance():
 
     # results should be the same as with the Xdawn transformer
     xdawn_trans_pipeline = make_pipeline(_XdawnTransformer(n_components=3),
-                                   Vectorizer(),
-                                   MinMaxScaler(),
-                                   LogisticRegression(penalty='l1',
-                                                      solver='liblinear',
-                                                      multi_class='auto'))
+                                         Vectorizer(),
+                                         MinMaxScaler(),
+                                         LogisticRegression(
+                                             penalty='l1', solver='liblinear',
+                                             multi_class='auto'))
 
     cv = KFold(n_splits=5, shuffle=False)
     predictions_trans = np.empty_like(labels, dtype=float)
@@ -338,6 +338,6 @@ def test_xdawn_decoding_performance():
     cv_accuracy_xdawn_trans = accuracy_score(labels, predictions_trans)
 
     assert np.mean(cv_accuracy_xdawn_trans) >= expected_accuracy
-    assert_allclose(cv_accuracy_xdawn_trans, cv_accuracy_xdawn)
+    assert_allclose(cv_accuracy_xdawn_trans, cv_accuracy_xdawn, atol=0.01)
 
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -322,14 +322,12 @@ def test_xdawn_decoding_performance():
         Xdawn(n_components=n_xdawn_comps),
         Vectorizer(),
         MinMaxScaler(),
-        LogisticRegression(
-            penalty='l1', solver='liblinear', multi_class='auto'))
+        LogisticRegression(penalty='l1', solver='liblinear'))
     xdawn_trans_pipe = make_pipeline(
         _XdawnTransformer(n_components=n_xdawn_comps),
         Vectorizer(),
         MinMaxScaler(),
-        LogisticRegression(
-            penalty='l1', solver='liblinear', multi_class='auto'))
+        LogisticRegression(penalty='l1', solver='liblinear'))
 
     for cur_pipeline, cur_pipeline_input in (
             (xdawn_pipe, epochs),

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -13,7 +13,7 @@ import pytest
 
 from mne import (Epochs, read_events, pick_types, compute_raw_covariance,
                  create_info, EpochsArray)
-from mne.datasets import testing
+from mne.datasets import testing, sample
 from mne.decoding import Vectorizer
 from mne.io import read_raw_fif
 from mne.utils import (requires_sklearn, run_tests_if_main, check_version,
@@ -268,7 +268,6 @@ def test_XdawnTransformer():
 
 
 def _load_audvis_testdata():
-    from mne.datasets import sample
     data_path = sample.data_path(download=False)
     raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
     event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
@@ -288,7 +287,7 @@ def _load_audvis_testdata():
 
 
 @pytest.mark.slowtest
-@testing.requires_testing_data
+@sample.requires_sample_data
 def test_xdawn_decoding_performance():
     """Test decoding performance using xDAWN."""
     # is based on the plot-decoding-xdawn-eeg example

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -137,6 +137,7 @@ def _fit_xdawn(epochs_data, y, n_components, reg=None, signal_cov=None,
     -------
     filters : array, shape (n_channels, n_channels)
         The Xdawn components used to decompose the data for each event type.
+        Each row corresponds to one component.
     patterns : array, shape (n_channels, n_channels)
         The Xdawn patterns used to restore the signals for each event type.
     evokeds : array, shape (n_class, n_components, n_times)
@@ -371,7 +372,8 @@ class Xdawn(_XdawnTransformer):
     ----------
     filters_ : dict of ndarray
         If fit, the Xdawn components used to decompose the data for each event
-        type, else empty.
+        type, else empty. For each event type, the filters are in the rows of
+        the corresponding array.
     patterns_ : dict of ndarray
         If fit, the Xdawn patterns used to restore the signals for each event
         type, else empty.
@@ -474,8 +476,8 @@ class Xdawn(_XdawnTransformer):
         idx = np.argsort([value for _, value in epochs.event_id.items()])
         for eid, this_filter, this_pattern, this_evo in zip(
                 epochs.event_id, filters[idx], patterns[idx], evokeds[idx]):
-            self.filters_[eid] = this_filter.T
-            self.patterns_[eid] = this_pattern.T
+            self.filters_[eid] = this_filter
+            self.patterns_[eid] = this_pattern
             n_events = len(epochs[eid])
             evoked = EvokedArray(this_evo, use_info, tmin=epochs.tmin,
                                  comment=eid, nave=n_events)

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -627,7 +627,7 @@ class Xdawn(_XdawnTransformer):
         logger.info('Transforming to Xdawn space')
 
         # Apply unmixing
-        sources = np.dot(self.filters_[eid].T, data)
+        sources = np.dot(self.filters_[eid], data)
 
         if include not in (None, list()):
             mask = np.ones(len(sources), dtype=np.bool)
@@ -639,7 +639,7 @@ class Xdawn(_XdawnTransformer):
             sources[exclude_] = 0.
             logger.info('Zeroing out %i Xdawn components' % len(exclude_))
         logger.info('Inverse transforming to sensor space')
-        data = np.dot(self.patterns_[eid], sources)
+        data = np.dot(self.patterns_[eid].T, sources)
 
         return data
 


### PR DESCRIPTION
#### What does this implement/fix?
This removes the incorrect transpose when saving the obtained filters/patterns in the ``Xdawn`` instance. 

#### Reference issue
Fixes  #7127

#### Additional information

I also ran the ``plot_decoding_xdawn_eeg`` example with the ``pyriemann`` implementation of ``Xdawn``, which yielded a bit better accuracies (0.88 for pyriemann vs 0.86 for this PR with the MNE implementation). This might be due to different covariance calculations/regularization. The estimated patterns look similar.
