### PR TITLE
MRG, ENH: Speed up forward computations with Numba

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -67,6 +67,8 @@ Changelog
 
 - Speed up :func:`mne.beamformer.make_lcmv` and :func:`mne.beamformer.make_dics` calculations by vectorizing linear algebra calls by `Dmitrii Altukhov`_ and `Eric Larson`_
 
+- Speed up :func:`mne.make_forward_solution` using Numba, by `Eric Larson`_
+
 - For KIT systems without built-in layout, :func:`mne.channels.find_layout` now falls back on an automatically generated layout, by `Christian Brodbeck`_
 
 - :meth:`mne.Epochs.plot` now takes a ``epochs_colors`` parameter to color specific epoch segments by `Mainak Jas`_

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -433,6 +433,7 @@ def _fit_chpi_quat(coil_dev_rrs, coil_head_rrs, x0):
     """Fit rotation and translation (quaternion) parameters for cHPI coils."""
     from scipy.optimize import fmin_cobyla
     denom = np.linalg.norm(coil_head_rrs - np.mean(coil_head_rrs, axis=0))
+    denom *= denom
     objective = partial(_chpi_objective, coil_dev_rrs=coil_dev_rrs,
                         coil_head_rrs=coil_head_rrs)
     x0 = x0.copy()

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -49,8 +49,7 @@ from .fixes import jit
 from .transforms import (apply_trans, invert_transform, _angle_between_quats,
                          quat_to_rot, rot_to_quat)
 from .utils import (verbose, logger, use_log_level, _check_fname, warn,
-                    _check_option, _svd_lwork, _repeated_svd,
-                    ddot, dgemm, dgemv)
+                    _check_option)
 
 # Eventually we should add:
 #   hpicons
@@ -381,8 +380,7 @@ def _get_hpi_initial_fit(info, adjust=False, verbose=None):
     return hpi_rrs
 
 
-def _magnetic_dipole_objective(x, B, B2, coils, scale, method, too_close,
-                               lwork):
+def _magnetic_dipole_objective(x, B, B2, coils, scale, method, too_close):
     """Project data onto right eigenvectors of whitened forward."""
     if method == 'forward':
         fwd = _magnetic_dipole_field_vec(x[np.newaxis, :], coils, too_close)
@@ -391,24 +389,28 @@ def _magnetic_dipole_objective(x, B, B2, coils, scale, method, too_close,
         # Eventually we can try incorporating external bases here, which
         # is why the :3 is on the SVD below
         fwd = _sss_basis(dict(origin=x, int_order=1, ext_order=0), coils).T
+    return _magnetic_dipole_delta(fwd, scale, B, B2)
+
+
+@jit()
+def _magnetic_dipole_delta(fwd, scale, B, B2):
     # Here we use .T to get scale to Fortran order, which speeds things up
-    fwd = dgemm(alpha=1., a=fwd, b=scale.T)  # np.dot(fwd, scale.T)
-    one = _repeated_svd(fwd, lwork, overwrite_a=True)[2]
-    one = dgemv(alpha=1, a=one, x=B)
-    Bm2 = ddot(one, one)
+    fwd = np.dot(fwd, scale.T)
+    one = np.linalg.svd(fwd, full_matrices=False)[2]
+    one = np.dot(one, B)
+    Bm2 = np.dot(one, one)
     return B2 - Bm2
 
 
 def _fit_magnetic_dipole(B_orig, x0, coils, scale, method, too_close):
     """Fit a single bit of data (x0 = pos)."""
     from scipy.optimize import fmin_cobyla
-    B = dgemv(alpha=1, a=scale, x=B_orig)  # np.dot(scale, B_orig)
-    B2 = ddot(B, B)  # np.dot(B, B)
-    lwork = _svd_lwork((3, B_orig.shape[0]))
+    B = np.dot(scale, B_orig)
+    B2 = np.dot(B, B)
     objective = partial(_magnetic_dipole_objective, B=B, B2=B2,
                         coils=coils, scale=scale, method=method,
-                        too_close=too_close, lwork=lwork)
-    x = fmin_cobyla(objective, x0, (), rhobeg=1e-4, rhoend=1e-5, disp=False)
+                        too_close=too_close)
+    x = fmin_cobyla(objective, x0, (), rhobeg=1e-3, rhoend=1e-5, disp=False)
     return x, 1. - objective(x) / B2
 
 
@@ -430,7 +432,7 @@ def _unit_quat_constraint(x):
 def _fit_chpi_quat(coil_dev_rrs, coil_head_rrs, x0):
     """Fit rotation and translation (quaternion) parameters for cHPI coils."""
     from scipy.optimize import fmin_cobyla
-    denom = np.sum((coil_head_rrs - np.mean(coil_head_rrs, axis=0)) ** 2)
+    denom = np.linalg.norm(coil_head_rrs - np.mean(coil_head_rrs, axis=0))
     objective = partial(_chpi_objective, coil_dev_rrs=coil_dev_rrs,
                         coil_head_rrs=coil_head_rrs)
     x0 = x0.copy()

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -45,6 +45,7 @@ from .io.ctf.trans import _make_ctf_coord_trans_set
 from .forward import (_magnetic_dipole_field_vec, _create_meg_coils,
                       _concatenate_coils)
 from .cov import make_ad_hoc_cov, compute_whitener
+from .fixes import jit
 from .transforms import (apply_trans, invert_transform, _angle_between_quats,
                          quat_to_rot, rot_to_quat)
 from .utils import (verbose, logger, use_log_level, _check_fname, warn,
@@ -411,6 +412,7 @@ def _fit_magnetic_dipole(B_orig, x0, coils, scale, method, too_close):
     return x, 1. - objective(x) / B2
 
 
+@jit()
 def _chpi_objective(x, coil_dev_rrs, coil_head_rrs):
     """Compute objective function."""
     d = np.dot(coil_dev_rrs, quat_to_rot(x[:3]).T)

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -15,6 +15,7 @@ at which the fix is no longer needed.
 import inspect
 from distutils.version import LooseVersion
 from math import log
+import os
 from pathlib import Path
 import warnings
 
@@ -1195,25 +1196,25 @@ try:
         return numba.jit(nopython=nopython, nogil=nogil, fastmath=fastmath,
                          cache=cache, **kwargs)
 except ImportError:
+    has_numba = False
+else:
+    has_numba = (os.getenv('MNE_USE_NUMBA', 'true').lower() == 'true')
+
+
+if not has_numba:
     def jit(**kwargs):  # noqa
         def _jit(func):
             return func
         return _jit
     prange = range
-    has_numba = False
+    bincount = np.bincount
 else:
-    has_numba = True
-
-
-if has_numba:
     @jit()
     def bincount(x, weights, minlength):  # noqa: D103
         out = np.zeros(minlength)
         for idx, w in zip(x, weights):
             out[idx] += w
         return out
-else:
-    bincount = np.bincount
 
 
 ###############################################################################

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -1205,6 +1205,17 @@ else:
     has_numba = True
 
 
+if has_numba:
+    @jit()
+    def bincount(x, weights, minlength):  # noqa: D103
+        out = np.zeros(minlength)
+        for idx, w in zip(x, weights):
+            out[idx] += w
+        return out
+else:
+    bincount = np.bincount
+
+
 ###############################################################################
 # Python 3.5 compat with pathlib.Path-like objects
 

--- a/mne/forward/_compute_forward.py
+++ b/mne/forward/_compute_forward.py
@@ -669,8 +669,7 @@ _MIN_DIST_LIMIT = 1e-5
 
 def _magnetic_dipole_field_vec(rrs, coils, too_close='raise'):
     rmags, cosmags, ws, bins = _triage_coils(coils)
-    fwd = np.zeros((3 * len(rrs), bins[-1] + 1))
-    min_dist = _compute_mdfv(fwd, rrs, rmags, cosmags, ws, bins, too_close)
+    fwd, min_dist = _compute_mdfv(rrs, rmags, cosmags, ws, bins, too_close)
     if min_dist < _MIN_DIST_LIMIT:
         msg = 'Coil too close (dist = %g mm)' % (min_dist * 1000,)
         if too_close == 'raise':
@@ -681,7 +680,7 @@ def _magnetic_dipole_field_vec(rrs, coils, too_close='raise'):
 
 
 @jit()
-def _compute_mdfv(fwd, rrs, rmags, cosmags, ws, bins, too_close):
+def _compute_mdfv(rrs, rmags, cosmags, ws, bins, too_close):
     """Compute an MEG forward solution for a set of magnetic dipoles."""
     # The code below is a more efficient version (~30x) of this:
     # for ri, rr in enumerate(rrs):
@@ -698,6 +697,7 @@ def _compute_mdfv(fwd, rrs, rmags, cosmags, ws, bins, too_close):
     #                                   axis=1)[:, np.newaxis] -
     #                 dist2 * this_coil['cosmag']) / dist5
     #         fwd[3*ri:3*ri+3, k] = 1e-7 * np.dot(this_coil['w'], sum_)
+    fwd = np.zeros((3 * len(rrs), bins[-1] + 1))
     min_dist = np.inf
     ws2 = ws.reshape(-1, 1)
     for ri in range(len(rrs)):
@@ -715,7 +715,7 @@ def _compute_mdfv(fwd, rrs, rmags, cosmags, ws, bins, too_close):
         for ii in range(3):
             fwd[3 * ri + ii] = bincount(bins, sum_[:, ii], bins[-1] + 1)
     fwd *= 1e-7
-    return min_dist
+    return fwd, min_dist
 
 
 # #############################################################################

--- a/mne/forward/_compute_forward.py
+++ b/mne/forward/_compute_forward.py
@@ -784,6 +784,7 @@ def _prep_field_computation(rr, bem, fwd_data, n_jobs, verbose=None):
                                                        mults, n_jobs)
                 else:
                     # Compute solution for EEG sensor
+                    logger.info('Setting up for EEG...')
                     solution = _bem_specify_els(bem, coils, mults)
             else:
                 solution = csolution = bem

--- a/mne/forward/_compute_forward.py
+++ b/mne/forward/_compute_forward.py
@@ -19,9 +19,10 @@
 import numpy as np
 from copy import deepcopy
 
-from ..surface import fast_cross_3d, _project_onto_surface
+from ..surface import _project_onto_surface, _jit_cross
 from ..io.constants import FIFF, FWD
 from ..transforms import apply_trans
+from ..fixes import jit, bincount
 from ..utils import logger, verbose, _pl, warn, fill_doc
 from ..parallel import parallel_func
 from ..io.compensator import get_current_comp, make_compensator
@@ -98,6 +99,7 @@ def _lin_field_coeff(surf, mult, rmags, cosmags, ws, bins, n_jobs):
     return mult * np.sum(coeffs, axis=0)
 
 
+@jit()
 def _do_lin_field_coeff(bem_rr, tris, tn, ta, rmags, cosmags, ws, bins):
     """Compute field coefficients (parallel-friendly).
 
@@ -129,12 +131,13 @@ def _do_lin_field_coeff(bem_rr, tris, tn, ta, rmags, cosmags, ws, bins):
         Linear coefficients with effect of each BEM vertex on each sensor (?)
     """
     coeff = np.zeros((bins[-1] + 1, len(bem_rr)))
-    w_cosmags = ws[:, np.newaxis] * cosmags
-    diff = rmags[:, np.newaxis, :] - bem_rr
+    w_cosmags = ws.reshape(-1, 1) * cosmags
+    diff = rmags.reshape(rmags.shape[0], 1, rmags.shape[1]) - bem_rr
     den = np.sum(diff * diff, axis=-1)
     den *= np.sqrt(den)
     den *= 3
-    for tri, tri_nn, tri_area in zip(tris, tn, ta):
+    for ti in range(len(tris)):
+        tri, tri_nn, tri_area = tris[ti], tn[ti], ta[ti]
         # Accumulate the coefficients for each triangle node and add to the
         # corresponding coefficient matrix
 
@@ -147,13 +150,14 @@ def _do_lin_field_coeff(bem_rr, tris, tn, ta, rmags, cosmags, ws, bins):
         #     res = np.sum(coil['w'][np.newaxis, :] * x, axis=1)
         #     coeff[j][tri + off] += mult * res
 
-        c = fast_cross_3d(diff[:, tri], tri_nn)
-        c *= w_cosmags[:, np.newaxis]
+        c = np.empty((diff.shape[0], tri.shape[0], diff.shape[2]))
+        _jit_cross(c, diff[:, tri], tri_nn)
+        c *= w_cosmags.reshape(w_cosmags.shape[0], 1, w_cosmags.shape[1])
         for ti in range(3):
             x = np.sum(c[:, ti], axis=-1)
             x /= den[:, tri[ti]] / tri_area
             coeff[:, tri[ti]] += \
-                np.bincount(bins, weights=x, minlength=bins[-1] + 1)
+                bincount(bins, weights=x, minlength=bins[-1] + 1)
     return coeff
 
 
@@ -302,6 +306,7 @@ _MAG_FACTOR = 1e-7  # μ_0 / (4π)
 #     return np.sum(Q * diff, axis=1) / (diff2 * np.sqrt(diff2))
 
 
+@jit()
 def _bem_inf_pots(mri_rr, bem_rr, mri_Q=None):
     """Compute the infinite medium potential in all 3 directions.
 
@@ -321,14 +326,15 @@ def _bem_inf_pots(mri_rr, bem_rr, mri_Q=None):
     # NOTE: the (μ_0 / (4π) factor has been moved to _prep_field_communication
     # Get position difference vector between BEM vertex and dipole
     diff = np.empty((len(mri_rr), 3, len(bem_rr)))
-    for ri, rr in enumerate(mri_rr):
+    for ri in range(mri_rr.shape[0]):
+        rr = mri_rr[ri]
         this_diff = bem_rr - rr
-        diff_norm = np.sum(this_diff * this_diff, axis=1, keepdims=True)
+        diff_norm = np.sum(this_diff * this_diff, axis=1)
         diff_norm *= np.sqrt(diff_norm)
-        diff_norm[diff_norm == 0] = 1
+        diff_norm[diff_norm == 0] = 1.
         if mri_Q is not None:
             this_diff = np.dot(this_diff, mri_Q.T)
-        this_diff /= diff_norm
+        this_diff /= diff_norm.reshape(-1, 1)
         diff[ri] = this_diff.T
 
     return diff
@@ -350,6 +356,7 @@ def _bem_inf_pots(mri_rr, bem_rr, mri_Q=None):
 #     return np.sum(x * d, axis=1) / (diff2 * np.sqrt(diff2))
 
 
+@jit()
 def _bem_inf_fields(rr, rmag, cosmag):
     """Compute infinite-medium magnetic field at one MEG sensor.
 
@@ -372,18 +379,24 @@ def _bem_inf_fields(rr, rmag, cosmag):
     # rr, rmag refactored according to Equation (19) in Mosher, 1999
     # Knowing that we're doing all directions, refactor above function:
 
-    diff = rmag.T[np.newaxis, :, :] - rr[:, :, np.newaxis]
-    diff_norm = np.sum(diff * diff, axis=1)
+    # rr, 3, rmag
+    diff = rmag.T.reshape(1, 3, rmag.shape[0]) - rr.reshape(rr.shape[0], 3, 1)
+    diff_norm = np.sum(diff * diff, axis=1)  # rr, rmag
     diff_norm *= np.sqrt(diff_norm)  # Get magnitude of distance cubed
-    diff_norm[diff_norm == 0] = 1  # avoid nans
+    diff_norm_ = diff_norm.reshape(-1)
+    diff_norm_[diff_norm_ == 0] = 1  # avoid nans
 
     # This is the result of cross-prod calcs with basis vectors,
     # as if we had taken (Q=np.eye(3)), then multiplied by cosmags
     # factor, and then summed across directions
-    x = np.array([diff[:, 1] * cosmag[:, 2] - diff[:, 2] * cosmag[:, 1],
-                  diff[:, 2] * cosmag[:, 0] - diff[:, 0] * cosmag[:, 2],
-                  diff[:, 0] * cosmag[:, 1] - diff[:, 1] * cosmag[:, 0]])
-    return np.rollaxis(x / diff_norm, 1)
+    x = np.empty((rr.shape[0], 3, rmag.shape[0]))
+    x[:, 0] = diff[:, 1] * cosmag[:, 2] - diff[:, 2] * cosmag[:, 1]
+    x[:, 1] = diff[:, 2] * cosmag[:, 0] - diff[:, 0] * cosmag[:, 2]
+    x[:, 2] = diff[:, 0] * cosmag[:, 1] - diff[:, 1] * cosmag[:, 0]
+    diff_norm = diff_norm_.reshape((rr.shape[0], 1, rmag.shape[0]))
+    x /= diff_norm
+    # x.shape == (rr.shape[0], 3, rmag.shape[0])
+    return x
 
 
 @fill_doc
@@ -423,7 +436,8 @@ def _bem_pot_or_field(rr, mri_rr, mri_Q, coils, solution, bem_rr, n_jobs,
     # reduce memory by chunking within _do_inf_pots and parallelize, too:
     parallel, p_fun, _ = parallel_func(_do_inf_pots, n_jobs)
     nas = np.array_split
-    B = np.sum(parallel(p_fun(mri_rr, sr.copy(), mri_Q, sol.copy())
+    B = np.sum(parallel(p_fun(mri_rr, sr.copy(), np.ascontiguousarray(mri_Q),
+                              np.array(sol))  # copy and contig
                         for sr, sol in zip(nas(bem_rr, n_jobs),
                                            nas(solution.T, n_jobs))), axis=0)
     # The copy()s above should make it so the whole objects don't need to be
@@ -466,8 +480,7 @@ def _do_prim_curr(rr, coils):
         p = _bem_inf_fields(rr[start:stop], rmags, cosmags)
         p *= ws
         p.shape = (3 * (stop - start), -1)
-        pc[3 * start:3 * stop] = [np.bincount(bins, pp, bins[-1] + 1)
-                                  for pp in p]
+        pc[3 * start:3 * stop] = [bincount(bins, pp, bins[-1] + 1) for pp in p]
     return pc
 
 
@@ -535,18 +548,21 @@ def _sphere_field(rrs, coils, sphere):
     by Matti Hämäläinen, February 1990
     """
     rmags, cosmags, ws, bins = _triage_coils(coils)
-    del coils
-    n_coils = bins[-1] + 1
-
     # Shift to the sphere model coordinates
-    rrs = rrs - sphere['r0']
+    return _do_sphere_field(rrs, rmags, cosmags, ws, bins, sphere['r0'])
 
+
+@jit()
+def _do_sphere_field(rrs, rmags, cosmags, ws, bins, r0):
+    n_coils = bins[-1] + 1
+    rrs = rrs - r0
     B = np.zeros((3 * len(rrs), n_coils))
-    for ri, rr in enumerate(rrs):
+    for ri in range(len(rrs)):
+        rr = rrs[ri]
         # Check for a dipole at the origin
         if np.sqrt(np.dot(rr, rr)) <= 1e-10:
             continue
-        this_poss = rmags - sphere['r0']
+        this_poss = rmags - r0
 
         # Vector from dipole to the field point
         a_vec = this_poss - rr
@@ -563,12 +579,16 @@ def _sphere_field(rrs, coils, sphere):
         r0e = np.sum(rr * cosmags, axis=1)
         g = (g0 * r0e - gr * re) / (F * F)
         good = (a > 0) | (r > 0) | ((a * r) + 1 > 1e-5)
-        v1 = fast_cross_3d(rr[np.newaxis, :], cosmags)
-        v2 = fast_cross_3d(rr[np.newaxis, :], this_poss)
-        xx = ((good * ws)[:, np.newaxis] *
-              (v1 / F[:, np.newaxis] + v2 * g[:, np.newaxis]))
-        zz = np.array([np.bincount(bins, x, n_coils) for x in xx.T])
-        B[3 * ri:3 * ri + 3, :] = zz
+        rr_ = rr.reshape(1, 3)
+        v1 = np.empty((cosmags.shape[0], 3))
+        _jit_cross(v1, rr_, cosmags)
+        v2 = np.empty((cosmags.shape[0], 3))
+        _jit_cross(v2, rr_, this_poss)
+        xx = ((good * ws).reshape(-1, 1) *
+              (v1 / F.reshape(-1, 1) + v2 * g.reshape(-1, 1)))
+        for jj in range(3):
+            zz = bincount(bins, xx[:, jj], n_coils)
+            B[3 * ri + jj, :] = zz
     B *= _MAG_FACTOR
     return B
 
@@ -647,6 +667,21 @@ def _triage_coils(coils):
 # MAGNETIC DIPOLE (e.g. CHPI)
 
 def _magnetic_dipole_field_vec(rrs, coils, too_close='raise'):
+    rmags, cosmags, ws, bins = _triage_coils(coils)
+    fwd = np.zeros((3 * len(rrs), bins[-1] + 1))
+    min_dist = _compute_mdfv(fwd, rrs, rmags, cosmags, ws, bins)
+    if min_dist < 1e-5:
+        msg = 'Coil too close (dist = %g m)' % min_dist
+        if too_close == 'raise':
+            raise RuntimeError(msg)
+        else:  # warning
+            func = warn if too_close == 'warning' else logger.info
+            func('Coil too close (dist = %g m)' % min_dist)
+    return fwd
+
+
+@jit()
+def _compute_mdfv(fwd, rrs, rmags, cosmags, ws, bins):
     """Compute an MEG forward solution for a set of magnetic dipoles."""
     # The code below is a more efficient version (~30x) of this:
     # for ri, rr in enumerate(rrs):
@@ -663,27 +698,21 @@ def _magnetic_dipole_field_vec(rrs, coils, too_close='raise'):
     #                                   axis=1)[:, np.newaxis] -
     #                 dist2 * this_coil['cosmag']) / dist5
     #         fwd[3*ri:3*ri+3, k] = 1e-7 * np.dot(this_coil['w'], sum_)
-    rmags, cosmags, ws, bins = _triage_coils(coils)
-    del coils
-    fwd = np.empty((3 * len(rrs), bins[-1] + 1), order='F')
-    for ri, rr in enumerate(rrs):
+    min_dist = np.inf
+    ws2 = ws.reshape(-1, 1)
+    for ri in range(len(rrs)):
+        rr = rrs[ri]
         diff = rmags - rr
-        dist2 = np.sum(diff * diff, axis=1)[:, np.newaxis]
+        dist2_ = np.sum(diff * diff, axis=1)
+        dist2 = dist2_.reshape(-1, 1)
         dist = np.sqrt(dist2)
-        if (dist < 1e-5).any():
-            msg = 'Coil too close (dist = %g m)' % dist.min()
-            if too_close == 'raise':
-                raise RuntimeError(msg)
-            else:  # warning
-                func = warn if too_close == 'warning' else logger.info
-                func('Coil too close (dist = %g m)' % dist.min())
-        sum_ = ws[:, np.newaxis] * (3 * diff * np.sum(diff * cosmags,
-                                                      axis=1)[:, np.newaxis] -
-                                    dist2 * cosmags) / (dist2 * dist2 * dist)
+        min_dist = min(dist.min(), min_dist)
+        t_ = np.sum(diff * cosmags, axis=1)
+        t = t_.reshape(-1, 1)
+        sum_ = ws2 * (3 * diff * t - dist2 * cosmags) / (dist2 * dist2 * dist)
         for ii in range(3):
-            fwd[3 * ri + ii] = np.bincount(bins, sum_[:, ii], bins[-1] + 1)
-    fwd *= 1e-7
-    return fwd
+            fwd[3 * ri + ii] = bincount(bins, sum_[:, ii], bins[-1] + 1)
+    return min_dist
 
 
 # #############################################################################
@@ -810,7 +839,8 @@ def _compute_forwards_meeg(rr, fd, n_jobs, silent=False):
     # The dipole location and orientation must be transformed to mri coords
     mri_rr = None
     if fd['head_mri_t'] is not None:
-        mri_rr = apply_trans(fd['head_mri_t']['trans'], rr)
+        mri_rr = np.ascontiguousarray(
+            apply_trans(fd['head_mri_t']['trans'], rr))
     mri_Q, bem_rr, fun = fd['mri_Q'], fd['bem_rr'], fd['fun']
     for ci in range(len(fd['coils_list'])):
         coils, ccoils = fd['coils_list'][ci], fd['ccoils_list'][ci]

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -172,7 +172,11 @@ requires_good_network = partial(
          '    raise ImportError')
 requires_nitime = partial(requires_module, name='nitime')
 requires_h5py = partial(requires_module, name='h5py')
-requires_numpydoc = partial(requires_module, name='numpydoc')
+
+
+def requires_numpydoc(func):
+    """Decorate tests that need numpydoc."""
+    return requires_version('numpydoc', '1.0')(func)  # validate needs 1.0
 
 
 def check_version(library, min_version):

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -117,6 +117,7 @@ known_config_types = (
     'MNE_SKIP_TESTING_DATASET_TESTS',
     'MNE_STIM_CHANNEL',
     'MNE_USE_CUDA',
+    'MNE_USE_NUMBA',
     'MNE_SKIP_FS_FLASH_CALL',
     'SUBJECTS_DIR',
 )


### PR DESCRIPTION
This forward code takes 24 sec on master and 17 sec on this PR:

<details>

```
import time
import mne
from mne.datasets import sample
data_path = sample.data_path()
subjects_dir = data_path + '/subjects'
subject = 'sample'
bem = subjects_dir + '/sample/bem/sample-5120-5120-5120-bem-sol.fif'
raw_fname = data_path + '/MEG/sample/sample_audvis_raw.fif'
trans = data_path + '/MEG/sample/sample_audvis_raw-trans.fif'
src = mne.setup_source_space(subject, spacing='oct6',
                             subjects_dir=subjects_dir, add_dist='patch')


def test():
    t0 = time.time()
    mne.make_forward_solution(raw_fname, trans=trans, src=src, bem=bem,
                              verbose=True)
    print(time.time() - t0)


if __name__ == '__main__':
    test()
```

</details>

This cHPI fitting code takes 3.5 sec on master and 2.6 sec on this PR:

<details>

```
import time
import mne
from mne.tests.test_chpi import _assert_quats
data_path = mne.datasets.testing.data_path(download=False)
chpi_fif_fname = data_path + '/SSS/test_move_anon_raw.fif'
pos_fname = data_path + '/SSS/test_move_anon_raw.pos'
mf_quats = mne.chpi.read_head_pos(pos_fname)
raw = mne.io.read_raw_fif(chpi_fif_fname, allow_maxshield='yes', preload=True)


def test():
    py_quats = mne.chpi._calculate_chpi_positions(raw, verbose=True)
    _assert_quats(py_quats, mf_quats, dist_tol=0.004, angle_tol=3.5)


if __name__ == '__main__':
    t0 = time.time()
    test()
    print(time.time() - t0)
```

</details>