### PR TITLE
MRG, FIX: Make mne.bem.make_watershed_bem write correct surfaces inside bem directory

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -156,7 +156,7 @@ Bug
 
 - Fix bug in :class:`~mne.preprocessing.Xdawn` where filters where selected along the incorrect axis, by `Henrich Kolkhorst`_
 
-- Fix bug in :func:`mne.bem.make_watershed_bem` where the surfaces were not saved properly by `Yu-Han Luo`_
+- Fix bug in :func:`mne.bem.make_watershed_bem` where some surfaces were saved incorrectly in the working directory by `Yu-Han Luo`_
 
 API
 ~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -152,6 +152,8 @@ Bug
 
 - Fix bug in :class:`~mne.preprocessing.Xdawn` where filters where selected along the incorrect axis, by `Henrich Kolkhorst`_
 
+- Fix bug in :func:`mne.bem.make_watershed_bem` where the surfaces were not saved properly by `Yu-Han Luo`_
+
 API
 ~~~
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -283,3 +283,5 @@
 .. _Alex Rockhill: https://github.com/alexrockhill/
 
 .. _Chun-Hui Li: https://github.com/iamsc
+
+.. _Yu-Han Luo: https://github.com/yh-luo

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1160,18 +1160,15 @@ def make_watershed_bem(subject, subjects_dir=None, overwrite=False,
             rr, tris, volume_info = read_surface(surf_ws_out,
                                                  read_metadata=True)
 
-            if overwrite:
-                # replace volume info, 'head' stays
-                volume_info.update(new_info)
-                write_surface(surf_ws_out, rr, tris, volume_info=volume_info,
-                              overwrite=True)
-            else:
+            if not overwrite:
                 orig_surf = op.join(ws_dir,
                                     '%s_%s_original_surface' % (subject, s))
                 # rename surfaces with the original volume info
                 os.rename(surf_ws_out, orig_surf)
-                volume_info.update(new_info)
-                write_surface(surf_ws_out, rr, tris, volume_info=volume_info)
+            # replace volume info, 'head' stays
+            volume_info.update(new_info)
+            write_surface(surf_ws_out, rr, tris, volume_info=volume_info)
+
             # Create symbolic links
             surf_out = op.join(bem_dir, '%s.surf' % s)
             if not overwrite and op.exists(surf_out):

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1159,15 +1159,10 @@ def make_watershed_bem(subject, subjects_dir=None, overwrite=False,
 
             rr, tris, volume_info = read_surface(surf_ws_out,
                                                  read_metadata=True)
-
-            if not overwrite:
-                orig_surf = op.join(ws_dir,
-                                    '%s_%s_original_surface' % (subject, s))
-                # rename surfaces with the original volume info
-                os.rename(surf_ws_out, orig_surf)
             # replace volume info, 'head' stays
             volume_info.update(new_info)
-            write_surface(surf_ws_out, rr, tris, volume_info=volume_info)
+            write_surface(surf_ws_out, rr, tris, volume_info=volume_info,
+                          overwrite=True)
 
             # Create symbolic links
             surf_out = op.join(bem_dir, '%s.surf' % s)
@@ -1178,12 +1173,6 @@ def make_watershed_bem(subject, subjects_dir=None, overwrite=False,
                     os.remove(surf_out)
                 _symlink(surf_ws_out, surf_out, copy)
                 skip_symlink = False
-
-        if new_info:
-            logger.info('Updated the volume info from T1.')
-            if not overwrite:
-                logger.info('To use the original volume info, create symbolic '
-                            'links for original surfaces.')
 
         if skip_symlink:
             logger.info("Unable to create all symbolic links to .surf files "

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1183,12 +1183,10 @@ def make_watershed_bem(subject, subjects_dir=None, overwrite=False,
                 skip_symlink = False
 
         if new_info:
+            logger.info('Updated the volume info from T1.')
             if not overwrite:
-                logger.info('Updated the volume info from T1. To use the '
-                            'original volume info, create symbolic links for '
-                            'original surfaces.')
-            else:
-                logger.info('Updated the volume info from T1.')
+                logger.info('To use the original volume info, create symbolic '
+                            'links for original surfaces.')
 
         if skip_symlink:
             logger.info("Unable to create all symbolic links to .surf files "

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1166,9 +1166,10 @@ def make_watershed_bem(subject, subjects_dir=None, overwrite=False,
                 write_surface(surf_ws_out, rr, tris, volume_info=volume_info,
                               overwrite=True)
             else:
-                orig_surf_ws_out = op.join(ws_dir, '%s_%s_original_surface' % (subject, s))
+                orig_surf = op.join(ws_dir,
+                                    '%s_%s_original_surface' % (subject, s))
                 # rename surfaces with the original volume info
-                os.rename(surf_ws_out, orig_surf_ws_out)
+                os.rename(surf_ws_out, orig_surf)
                 volume_info.update(new_info)
                 write_surface(surf_ws_out, rr, tris, volume_info=volume_info)
             # Create symbolic links
@@ -1184,8 +1185,8 @@ def make_watershed_bem(subject, subjects_dir=None, overwrite=False,
         if new_info:
             if not overwrite:
                 logger.info('Updated the volume info from T1. To use the '
-                'original volume info, recreate symbolic links for original'
-                'surfaces.')
+                            'original volume info, create symbolic links for '
+                            'original surfaces.')
             else:
                 logger.info('Updated the volume info from T1.')
 


### PR DESCRIPTION
#### Reference issue
Fixes #7139.


#### What does this implement/fix?
Make `mne.bem.make_watershed_bem` write correct surfaces inside bem directory.

- Before fix
```
.
├── brain
├── inner_skull
├── outer_skin
└── outer_skull
```
- After fix
```
bem
└── watershed
    ├── sample_brain_surface
    ├── sample_inner_skull_surface
    ├── sample_outer_skin_surface
    └── sample_outer_skull_surface
```


#### Additional information
Details are in #7139.
