### PR TITLE
Add support for borders in add_label

### DIFF
--- a/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
@@ -68,7 +68,7 @@ evoked.crop(tmin=-0.1, tmax=0.4)
 forward = mne.read_forward_solution(fwd_fname)
 
 ###############################################################################
-# Run the solver
+# Run solver
 
 # alpha parameter is between 0 and 100 (100 gives 0 active source)
 alpha = 40.  # general regularization parameter

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -510,6 +510,7 @@ class _Brain(object):
                                      % filepath)
             label = read_label(filepath)
             ids = label.vertices
+            scalars = label.values
         else:
             # try to extract parameters from label instance
             try:
@@ -536,8 +537,8 @@ class _Brain(object):
                                  '"values"')
             hemi = self._check_hemi(hemi)
 
-            if scalar_thresh is not None:
-                ids = ids[scalars >= scalar_thresh]
+        if scalar_thresh is not None:
+            ids = ids[scalars >= scalar_thresh]
 
         # XXX: add support for label_name
         self._label_name = label_name

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -555,14 +555,22 @@ class _Brain(object):
                 ci = 0 if hemi == 'lh' else 1
             views_dict = lh_views_dict if hemi == 'lh' else rh_views_dict
             self._renderer.subplot(ri, ci)
-            self._renderer.mesh(x=self.geo[hemi].coords[:, 0],
-                                y=self.geo[hemi].coords[:, 1],
-                                z=self.geo[hemi].coords[:, 2],
-                                triangles=self.geo[hemi].faces,
-                                scalars=label,
-                                color=None,
-                                colormap=ctable,
-                                backface_culling=False)
+            if borders:
+                surface = {
+                    'rr': self.geo[hemi].coords,
+                    'tris': self.geo[hemi].faces,
+                }
+                self._renderer.contour(surface, label, [1.0], color=color,
+                                       tube=True)
+            else:
+                self._renderer.mesh(x=self.geo[hemi].coords[:, 0],
+                                    y=self.geo[hemi].coords[:, 1],
+                                    z=self.geo[hemi].coords[:, 2],
+                                    triangles=self.geo[hemi].faces,
+                                    scalars=label,
+                                    color=None,
+                                    colormap=ctable,
+                                    backface_culling=False)
             self._renderer.set_camera(azimuth=views_dict[v].azim,
                                       elevation=views_dict[v].elev)
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -562,7 +562,7 @@ class _Brain(object):
                     'tris': self.geo[hemi].faces,
                 }
                 self._renderer.contour(surface, label, [1.0], color=color,
-                                       tube=True)
+                                       kind='tube')
             else:
                 self._renderer.mesh(x=self.geo[hemi].coords[:, 0],
                                     y=self.geo[hemi].coords[:, 1],

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -99,7 +99,7 @@ def test_brain_add_label(renderer):
                    surf=surf, subjects_dir=subjects_dir)
     label = read_label(fname_label)
     brain.add_label(fname_label)
-    brain.add_label(label)
+    brain.add_label(label, scalar_thresh=0.)
 
 
 @testing.requires_testing_data

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -126,13 +126,13 @@ class _Renderer(_BaseRenderer):
             surface.actor.property.backface_culling = backface_culling
         return surface
 
-    def contour(self, surface, scalars, contours, line_width=1.0, opacity=1.0,
+    def contour(self, surface, scalars, contours, width=1.0, opacity=1.0,
                 vmin=None, vmax=None, colormap=None,
-                normalized_colormap=False, tube=False, color=None):
+                normalized_colormap=False, kind='line', color=None):
         mesh = _create_mesh_surf(surface, self.fig, scalars=scalars)
         with warnings.catch_warnings(record=True):  # traits
             cont = self.mlab.pipeline.contour_surface(
-                mesh, contours=contours, line_width=1.0, vmin=vmin, vmax=vmax,
+                mesh, contours=contours, line_width=width, vmin=vmin, vmax=vmax,
                 opacity=opacity, figure=self.fig)
             cont.module_manager.scalar_lut_manager.lut.table = colormap
 

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -128,7 +128,7 @@ class _Renderer(_BaseRenderer):
 
     def contour(self, surface, scalars, contours, line_width=1.0, opacity=1.0,
                 vmin=None, vmax=None, colormap=None,
-                normalized_colormap=False):
+                normalized_colormap=False, tube=False, color=None):
         mesh = _create_mesh_surf(surface, self.fig, scalars=scalars)
         with warnings.catch_warnings(record=True):  # traits
             cont = self.mlab.pipeline.contour_surface(

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -132,8 +132,8 @@ class _Renderer(_BaseRenderer):
         mesh = _create_mesh_surf(surface, self.fig, scalars=scalars)
         with warnings.catch_warnings(record=True):  # traits
             cont = self.mlab.pipeline.contour_surface(
-                mesh, contours=contours, line_width=width, vmin=vmin, vmax=vmax,
-                opacity=opacity, figure=self.fig)
+                mesh, contours=contours, line_width=width, vmin=vmin,
+                vmax=vmax, opacity=opacity, figure=self.fig)
             cont.module_manager.scalar_lut_manager.lut.table = colormap
 
     def surface(self, surface, color=None, opacity=1.0,

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -184,9 +184,9 @@ class _Renderer(_BaseRenderer):
                                   rng=[vmin, vmax], show_scalar_bar=False,
                                   smooth_shading=smooth_shading)
 
-    def contour(self, surface, scalars, contours, line_width=1.0, opacity=1.0,
+    def contour(self, surface, scalars, contours, width=1.0, opacity=1.0,
                 vmin=None, vmax=None, colormap=None,
-                normalized_colormap=False, tube=False, color=None):
+                normalized_colormap=False, kind='line', color=None):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)
             from pyvista import PolyData
@@ -200,10 +200,10 @@ class _Renderer(_BaseRenderer):
             pd = PolyData(vertices, triangles)
             pd.point_arrays['scalars'] = scalars
             mesh = pd.contour(isosurfaces=contours, rng=(vmin, vmax))
-            if isinstance(tube, float):
-                mesh = mesh.tube(radius=tube)
-            elif tube:
-                mesh = mesh.tube()
+            line_width = width
+            if kind == 'tube':
+                mesh = mesh.tube(radius=width)
+                line_width = 1.0
             self.plotter.add_mesh(mesh,
                                   show_scalar_bar=False,
                                   line_width=line_width,

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -200,7 +200,7 @@ class _Renderer(_BaseRenderer):
             pd = PolyData(vertices, triangles)
             pd.point_arrays['scalars'] = scalars
             mesh = pd.contour(isosurfaces=contours, rng=(vmin, vmax))
-            if isinstance(tube, int):
+            if isinstance(tube, float):
                 mesh = mesh.tube(radius=tube)
             elif tube:
                 mesh = mesh.tube()

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -186,22 +186,29 @@ class _Renderer(_BaseRenderer):
 
     def contour(self, surface, scalars, contours, line_width=1.0, opacity=1.0,
                 vmin=None, vmax=None, colormap=None,
-                normalized_colormap=False):
+                normalized_colormap=False, tube=False, color=None):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)
             from pyvista import PolyData
-            cmap = _get_colormap_from_array(colormap, normalized_colormap)
+            if colormap is not None:
+                colormap = _get_colormap_from_array(colormap,
+                                                    normalized_colormap)
             vertices = np.array(surface['rr'])
             triangles = np.array(surface['tris'])
             n_triangles = len(triangles)
             triangles = np.c_[np.full(n_triangles, 3), triangles]
             pd = PolyData(vertices, triangles)
             pd.point_arrays['scalars'] = scalars
-            self.plotter.add_mesh(pd.contour(isosurfaces=contours,
-                                             rng=(vmin, vmax)),
+            mesh = pd.contour(isosurfaces=contours, rng=(vmin, vmax))
+            if isinstance(tube, int):
+                mesh = mesh.tube(radius=tube)
+            elif tube:
+                mesh = mesh.tube()
+            self.plotter.add_mesh(mesh,
                                   show_scalar_bar=False,
                                   line_width=line_width,
-                                  cmap=cmap,
+                                  color=color,
+                                  cmap=colormap,
                                   opacity=opacity,
                                   smooth_shading=self.figure.smooth_shading)
 

--- a/mne/viz/backends/base_renderer.py
+++ b/mne/viz/backends/base_renderer.py
@@ -70,7 +70,7 @@ class _BaseRenderer(metaclass=ABCMeta):
     @abstractclassmethod
     def contour(self, surface, scalars, contours, line_width=1.0, opacity=1.0,
                 vmin=None, vmax=None, colormap=None,
-                normalized_colormap=False):
+                normalized_colormap=False, tube=False, color=None):
         """Add a contour in the scene.
 
         Parameters

--- a/mne/viz/backends/base_renderer.py
+++ b/mne/viz/backends/base_renderer.py
@@ -68,9 +68,9 @@ class _BaseRenderer(metaclass=ABCMeta):
         pass
 
     @abstractclassmethod
-    def contour(self, surface, scalars, contours, line_width=1.0, opacity=1.0,
+    def contour(self, surface, scalars, contours, width=1.0, opacity=1.0,
                 vmin=None, vmax=None, colormap=None,
-                normalized_colormap=False, tube=False, color=None):
+                normalized_colormap=False, kind='line', color=None):
         """Add a contour in the scene.
 
         Parameters
@@ -81,8 +81,8 @@ class _BaseRenderer(metaclass=ABCMeta):
             The scalar valued associated to the vertices.
         contours: int | list
              Specifying a list of values will only give the requested contours.
-        line_width: float
-            The width of the lines.
+        width: float
+            The width of the lines or radius of the tubes.
         opacity: float
             The opacity of the contour.
         vmin: float | None
@@ -93,6 +93,14 @@ class _BaseRenderer(metaclass=ABCMeta):
             If None, the max of the data will be used
         colormap:
             The colormap to use.
+        normalized_colormap: bool
+            Specify if the values of the colormap are between 0 and 1.
+        kind: 'line' | 'tube'
+            The type of the primitives to use to display the contours.
+        color:
+            The color of the mesh as a tuple (red, green, blue) of float
+            values between 0 and 1 or a valid color name (i.e. 'white'
+            or 'w').
         """
         pass
 

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -113,7 +113,7 @@ def test_3d_backend(renderer):
 
     # use contour
     rend.contour(surface=ct_surface, scalars=ct_scalars,
-                 contours=ct_levels)
+                 contours=ct_levels, tube=True)
 
     # use sphere
     rend.sphere(center=sph_center, color=sph_color,

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -113,7 +113,9 @@ def test_3d_backend(renderer):
 
     # use contour
     rend.contour(surface=ct_surface, scalars=ct_scalars,
-                 contours=ct_levels, tube=True)
+                 contours=ct_levels, kind='line')
+    rend.contour(surface=ct_surface, scalars=ct_scalars,
+                 contours=ct_levels, kind='tube')
 
     # use sphere
     rend.sphere(center=sph_center, color=sph_color,


### PR DESCRIPTION
This PR adds support for the `borders` parameter in the `add_label()` function of the `_Brain` object.

Closes part of #7143
