### PR TITLE
MRG: Use latest version 0.23.0 of pyvista instead of master

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - mne
   - https://api.github.com/repos/numpy/numpydoc/zipball/master
   - vtk
-  - https://github.com/pyvista/pyvista/zipball/master
+  - pyvista>=0.23.0
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - mne
   - https://api.github.com/repos/numpy/numpydoc/zipball/master
   - vtk
-  - pyvista>=0.23.0
+  - pyvista==0.22.4
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - mne
   - https://api.github.com/repos/numpy/numpydoc/zipball/master
   - vtk
-  - https://github.com/pyvista/pyvista/zipball/0f418a83e0ca89874af3b21e0a4ae902c798b021
+  - https://api.github.com/repos/pyvista/pyvista/zipball/1fff9141fcbed7eb5940edf4918130bb41ff13f9
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - mne
   - https://api.github.com/repos/numpy/numpydoc/zipball/master
   - vtk
-  - https://api.github.com/repos/pyvista/pyvista/zipball/1fff9141fcbed7eb5940edf4918130bb41ff13f9
+  - https://api.github.com/repos/pyvista/pyvista/zipball/566a4cf5fd81590c1f9f1b24f1c23a9d5f622d8a
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - mne
   - https://api.github.com/repos/numpy/numpydoc/zipball/master
   - vtk
-  - https://api.github.com/repos/pyvista/pyvista/zipball/8ddad9c314b26740777f9fe5813af5f2bc15a50e
+  - pyvista>=0.23.0
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - mne
   - https://api.github.com/repos/numpy/numpydoc/zipball/master
   - vtk
-  - https://api.github.com/repos/pyvista/pyvista/zipball/5b5a09d70579a2f34ae2344f7596196dc0244703
+  - https://api.github.com/repos/pyvista/pyvista/zipball/8ddad9c314b26740777f9fe5813af5f2bc15a50e
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - mne
   - https://api.github.com/repos/numpy/numpydoc/zipball/master
   - vtk
-  - https://api.github.com/repos/pyvista/pyvista/zipball/229b026ed9221ffa1c865b172cae0be1149b834d
+  - https://api.github.com/repos/pyvista/pyvista/zipball/5b5a09d70579a2f34ae2344f7596196dc0244703
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - mne
   - https://api.github.com/repos/numpy/numpydoc/zipball/master
   - vtk
-  - pyvista==0.22.4
+  - https://github.com/pyvista/pyvista/zipball/0f418a83e0ca89874af3b21e0a4ae902c798b021
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - mne
   - https://api.github.com/repos/numpy/numpydoc/zipball/master
   - vtk
-  - https://api.github.com/repos/pyvista/pyvista/zipball/566a4cf5fd81590c1f9f1b24f1c23a9d5f622d8a
+  - https://api.github.com/repos/pyvista/pyvista/zipball/02160d4d421805697e06541937bad4b8ae069dfc
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - mne
   - https://api.github.com/repos/numpy/numpydoc/zipball/master
   - vtk
-  - https://api.github.com/repos/pyvista/pyvista/zipball/02160d4d421805697e06541937bad4b8ae069dfc
+  - https://api.github.com/repos/pyvista/pyvista/zipball/229b026ed9221ffa1c865b172cae0be1149b834d
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -45,6 +45,7 @@ class _Figure(object):
         self.store['shape'] = shape
         self.store['off_screen'] = off_screen
         self.store['border'] = False
+        self.store['auto_update'] = False
 
     def build(self):
         with warnings.catch_warnings():
@@ -58,6 +59,7 @@ class _Figure(object):
 
         if self.plotter_class == Plotter:
             self.store.pop('title', None)
+            self.store.pop('auto_update', None)
 
         if self.plotter is None:
             plotter = self.plotter_class(**self.store)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ xlrd
 pydocstyle
 flake8
 https://github.com/mcmtroffaes/sphinxcontrib-bibtex/zipball/29694f215b39d64a31b845aafd9ff2ae9329494f
-https://github.com/pyvista/pyvista/zipball/master
+pyvista>=0.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ xlrd
 pydocstyle
 flake8
 https://github.com/mcmtroffaes/sphinxcontrib-bibtex/zipball/29694f215b39d64a31b845aafd9ff2ae9329494f
-https://github.com/pyvista/pyvista/zipball/1fff9141fcbed7eb5940edf4918130bb41ff13f9
+https://github.com/pyvista/pyvista/zipball/566a4cf5fd81590c1f9f1b24f1c23a9d5f622d8a

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ xlrd
 pydocstyle
 flake8
 https://github.com/mcmtroffaes/sphinxcontrib-bibtex/zipball/29694f215b39d64a31b845aafd9ff2ae9329494f
-https://github.com/pyvista/pyvista/zipball/229b026ed9221ffa1c865b172cae0be1149b834d
+https://github.com/pyvista/pyvista/zipball/5b5a09d70579a2f34ae2344f7596196dc0244703

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ xlrd
 pydocstyle
 flake8
 https://github.com/mcmtroffaes/sphinxcontrib-bibtex/zipball/29694f215b39d64a31b845aafd9ff2ae9329494f
-https://github.com/pyvista/pyvista/zipball/566a4cf5fd81590c1f9f1b24f1c23a9d5f622d8a
+https://github.com/pyvista/pyvista/zipball/02160d4d421805697e06541937bad4b8ae069dfc

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ xlrd
 pydocstyle
 flake8
 https://github.com/mcmtroffaes/sphinxcontrib-bibtex/zipball/29694f215b39d64a31b845aafd9ff2ae9329494f
-pyvista==0.22.4
+https://github.com/pyvista/pyvista/zipball/0f418a83e0ca89874af3b21e0a4ae902c798b021

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ xlrd
 pydocstyle
 flake8
 https://github.com/mcmtroffaes/sphinxcontrib-bibtex/zipball/29694f215b39d64a31b845aafd9ff2ae9329494f
-https://github.com/pyvista/pyvista/zipball/02160d4d421805697e06541937bad4b8ae069dfc
+https://github.com/pyvista/pyvista/zipball/229b026ed9221ffa1c865b172cae0be1149b834d

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ xlrd
 pydocstyle
 flake8
 https://github.com/mcmtroffaes/sphinxcontrib-bibtex/zipball/29694f215b39d64a31b845aafd9ff2ae9329494f
-pyvista>=0.23.0
+pyvista==0.22.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ xlrd
 pydocstyle
 flake8
 https://github.com/mcmtroffaes/sphinxcontrib-bibtex/zipball/29694f215b39d64a31b845aafd9ff2ae9329494f
-https://github.com/pyvista/pyvista/zipball/8ddad9c314b26740777f9fe5813af5f2bc15a50e
+pyvista>=0.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ xlrd
 pydocstyle
 flake8
 https://github.com/mcmtroffaes/sphinxcontrib-bibtex/zipball/29694f215b39d64a31b845aafd9ff2ae9329494f
-https://github.com/pyvista/pyvista/zipball/5b5a09d70579a2f34ae2344f7596196dc0244703
+https://github.com/pyvista/pyvista/zipball/8ddad9c314b26740777f9fe5813af5f2bc15a50e

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ xlrd
 pydocstyle
 flake8
 https://github.com/mcmtroffaes/sphinxcontrib-bibtex/zipball/29694f215b39d64a31b845aafd9ff2ae9329494f
-https://github.com/pyvista/pyvista/zipball/0f418a83e0ca89874af3b21e0a4ae902c798b021
+https://github.com/pyvista/pyvista/zipball/1fff9141fcbed7eb5940edf4918130bb41ff13f9


### PR DESCRIPTION
This PR updates the package requirements for the pyvista 3d backend.