### PR TITLE
BF/ENH: Make _read_elp_besa() respect fiducial points

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -83,6 +83,8 @@ Changelog
 
 - Add the ability to :func:`mne.channels.equalize_channels` to also re-order the channels and also operate on instances of :class:`mne.Info`, :class:`mne.Forward`, :class:`mne.Covariance` and :class:`mne.time_frequency.CrossSpectralDensity` by `Marijn van Vliet`_
 
+- Allow `mne.channels.read_custom_montage` to handle fiducial points for BESA spherical (``.elp``) files by `_Richard Höchenberger`_
+
 Bug
 ~~~
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -83,7 +83,7 @@ Changelog
 
 - Add the ability to :func:`mne.channels.equalize_channels` to also re-order the channels and also operate on instances of :class:`mne.Info`, :class:`mne.Forward`, :class:`mne.Covariance` and :class:`mne.time_frequency.CrossSpectralDensity` by `Marijn van Vliet`_
 
-- Allow `mne.channels.read_custom_montage` to handle fiducial points for BESA spherical (``.elp``) files by `_Richard Höchenberger`_
+- Allow `mne.channels.read_custom_montage` to handle fiducial points for BESA spherical (``.elp``) files by `Richard Höchenberger`_
 
 Bug
 ~~~

--- a/mne/channels/_standard_montage_utils.py
+++ b/mne/channels/_standard_montage_utils.py
@@ -294,7 +294,13 @@ def _read_elp_besa(fname, head_size):
     if head_size is not None:
         pos *= head_size / np.median(np.linalg.norm(pos, axis=1))
 
-    return make_dig_montage(ch_pos=OrderedDict(zip(ch_names, pos)))
+    ch_pos = OrderedDict(zip(ch_names, pos))
+
+    fid_names = ('Nz', 'LPA', 'RPA')
+    # No one grants that the fid names actually exist.
+    nasion, lpa, rpa = [ch_pos.pop(n, None) for n in fid_names]
+
+    return make_dig_montage(ch_pos=ch_pos, nasion=nasion, lpa=lpa, rpa=rpa)
 
 
 def _read_brainvision(fname, head_size, unit):

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -240,10 +240,13 @@ def test_documented():
     pytest.param(
         partial(read_custom_montage, head_size=None, unit='n/a'),
         ('346\n'  # XXX: this should actually race an error 346 != 4
-         'EEG\t      F3\t -62.027\t -50.053\t      85\n'
-         'EEG\t      Fz\t  45.608\t      90\t      85\n'
-         'EEG\t      F4\t   62.01\t  50.103\t      85\n'
-         'EEG\t      FCz\t   68.01\t  58.103\t      85\n'),
+         'FID\t      LPA\t -120.03\t      0\t      85\n'
+         'FID\t      RPA\t  120.03\t      0\t      85\n'
+         'FID\t      Nz\t   114.03\t     90\t      85\n'
+         'EEG\t      F3\t  -62.027\t -50.053\t     85\n'
+         'EEG\t      Fz\t   45.608\t      90\t     85\n'
+         'EEG\t      F4\t    62.01\t  50.103\t     85\n'
+         'EEG\t      FCz\t   68.01\t  58.103\t     85\n'),
         make_dig_montage(
             ch_pos={
                 'F3': [-0.48200427, 0.57551063, 0.39869712],
@@ -251,7 +254,9 @@ def test_documented():
                 'F4': [0.48142596, 0.57584026, 0.39891983],
                 'FCz': [0.41645989, 0.66914889, 0.31827805],
             },
-            nasion=None, lpa=None, rpa=None,
+            nasion=[4.75366562e-17, 7.76332511e-01, -3.46132681e-01],
+            lpa=[-7.35898963e-01, 9.01216309e-17, -4.25385374e-01],
+            rpa=[0.73589896, 0., -0.42538537],
         ),
         'elp', id='BESA spherical model'),
 


### PR DESCRIPTION
#### What does this implement/fix?
I had trouble reading a BESA spherical `elp` file using `channels.read_custom_montage()`, as the fiducials were treated as sensor channels. This PR adds special handling for the fiducials.