### PR TITLE
MRG, MAINT: Make CI tracebacks easier to read

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,14 +150,14 @@ script:
         python mne/tests/test_evoked.py;
       fi;
     - echo pytest -m "${CONDITION}" --cov=mne ${USE_DIRS}
-    - pytest -m "${CONDITION}" --cov=mne ${USE_DIRS}
+    - pytest -m "${CONDITION}" --tb=short --cov=mne ${USE_DIRS}
     # run the minimal one with the testing data
     - if [ "${DEPS}" == "minimal" ]; then
         export MNE_SKIP_TESTING_DATASET_TESTS=false;
         python -c 'import mne; mne.datasets.testing.data_path(verbose=True)';
       fi;
     - if [ "${DEPS}" == "minimal" ]; then
-        pytest -m "${CONDITION}" --cov=mne ${USE_DIRS};
+        pytest -m "${CONDITION}" --tb=short --cov=mne ${USE_DIRS};
       fi;
 
 after_script:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,7 +156,7 @@ jobs:
     displayName: 'Print config and test access to commands'
   - script: python -c "import mne; mne.datasets.testing.data_path(verbose=True)"
     displayName: 'Get test data'
-  - script: pytest -m "not ultraslowtest" --cov=mne mne
+  - script: pytest -m "not ultraslowtest" --tb=short --cov=mne mne
     displayName: 'Run tests'
   - script: codecov --root %BUILD_REPOSITORY_LOCALPATH% -t %CODECOV_TOKEN%
     displayName: 'Codecov'


### PR DESCRIPTION
In local testing the `--tb=auto` with `--show-locals` is nice, but on CIs it makes navigating the failure logs pretty miserable. So on CIs we now do `--tb=short`, so instead of a single failure looking like this (175 lines for the whole thing):

<details>

```
omar:mne-python larsoner$ pytest mne/minimum_norm/tests/test_inverse.py -k apply_inverse_operator
Test session starts (platform: darwin, Python 3.7.3, pytest 5.2.0, pytest-sugar 0.9.2)
rootdir: /Users/larsoner/python/mne-python, inifile: setup.cfg
plugins: astropy-header-0.1.1, arraydiff-0.3, sugar-0.9.2, remotedata-0.3.2, timeout-1.3.3, openfiles-0.4.0, mock-1.11.0, cov-2.7.1, doctestplus-0.5.0
collecting ... 

―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_apply_inverse_operator[testing_data] ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

evoked = <Evoked  |  'Left Auditory' (average, N=6), [0, 0.1998] sec, 376 ch, ~3.8 MB>

    @pytest.mark.slowtest
    def test_apply_inverse_operator(evoked):
        """Test MNE inverse application."""
        # use fname_inv as it will be faster than fname_full (fewer verts and chs)
        inverse_operator = read_inverse_operator(fname_inv)
    
        # Inverse has 306 channels - 4 proj = 302
        assert (compute_rank_inverse(inverse_operator) == 302)
    
        # Inverse has 306 channels - 4 proj = 302
        assert (compute_rank_inverse(inverse_operator) == 302)
    
>       stc = apply_inverse(evoked, inverse_operator, lambda2, "MNE")

evoked     = <Evoked  |  'Left Auditory' (average, N=6), [0, 0.1998] sec, 376 ch, ~3.8 MB>
inverse_operator = <InverseOperator | MEG channels: 305 | EEG channels: 59 | Source space: surface with 498 sources | Source orientation: Free>

mne/minimum_norm/tests/test_inverse.py:410: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
</Users/larsoner/python/mne-python/mne/externals/decorator.py:decorator-gen-309>:2: in apply_inverse
    ???
mne/utils/_logging.py:90: in wrapper
    return function(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

evoked = <Evoked  |  'Left Auditory' (average, N=6), [0, 0.1998] sec, 376 ch, ~3.8 MB>
inverse_operator = <InverseOperator | MEG channels: 305 | EEG channels: 59 | Source space: surface with 498 sources | Source orientation: Free>, lambda2 = 0.1111111111111111
method = 'MNE', pick_ori = None, prepared = False, label = None, method_params = None, return_residual = False, verbose = None

    @verbose
    def apply_inverse(evoked, inverse_operator, lambda2=1. / 9., method="dSPM",
                      pick_ori=None, prepared=False, label=None,
                      method_params=None, return_residual=False, verbose=None):
        """Apply inverse operator to evoked data.
    
        Parameters
        ----------
        evoked : Evoked object
            Evoked data.
        inverse_operator : instance of InverseOperator
            Inverse operator.
        lambda2 : float
            The regularization parameter.
        method : "MNE" | "dSPM" | "sLORETA" | "eLORETA"
            Use minimum norm [1]_, dSPM (default) [2]_, sLORETA [3]_, or
            eLORETA [4]_.
        pick_ori : None | "normal" | "vector"
            By default (None) pooling is performed by taking the norm of loose/free
            orientations. In case of a fixed source space no norm is computed
            leading to signed source activity.
            If "normal" only the radial component is kept. This is only implemented
            when working with loose orientations.
            If "vector", no pooling of the orientations is done and the vector
            result will be returned in the form of a
            :class:`mne.VectorSourceEstimate` object. This is only implemented when
            working with loose orientations.
        prepared : bool
            If True, do not call :func:`prepare_inverse_operator`.
        label : Label | None
            Restricts the source estimates to a given label. If None,
            source estimates will be computed for the entire source space.
        method_params : dict | None
            Additional options for eLORETA. See Notes for details.
    
            .. versionadded:: 0.16
        return_residual : bool
            If True (default False), return the residual evoked data.
            Cannot be used with ``method=='eLORETA'``.
    
            .. versionadded:: 0.17
        %(verbose)s
    
        Returns
        -------
        stc : SourceEstimate | VectorSourceEstimate | VolSourceEstimate
            The source estimates.
        residual : instance of Evoked
            The residual evoked data, only returned if return_residual is True.
    
        See Also
        --------
        apply_inverse_raw : Apply inverse operator to raw object.
        apply_inverse_epochs : Apply inverse operator to epochs object.
    
        Notes
        -----
        Currently only the ``method='eLORETA'`` has additional options.
        It performs an iterative fit with a convergence criterion, so you can
        pass a ``method_params`` :class:`dict` with string keys mapping to values
        for:
    
            'eps' : float
                The convergence epsilon (default 1e-6).
            'max_iter' : int
                The maximum number of iterations (default 20).
                If less regularization is applied, more iterations may be
                necessary.
            'force_equal' : bool
                Force all eLORETA weights for each direction for a given
                location equal. The default is None, which means ``True`` for
                loose-orientation inverses and ``False`` for free- and
                fixed-orientation inverses. See below.
    
        The eLORETA paper [4]_ defines how to compute inverses for fixed- and
        free-orientation inverses. In the free orientation case, the X/Y/Z
        orientation triplet for each location is effectively multiplied by a
        3x3 weight matrix. This is the behavior obtained with
        ``force_equal=False`` parameter.
    
        However, other noise normalization methods (dSPM, sLORETA) multiply all
        orientations for a given location by a single value.
        Using ``force_equal=True`` mimics this behavior by modifying the iterative
        algorithm to choose uniform weights (equivalent to a 3x3 diagonal matrix
        with equal entries).
    
        It is necessary to use ``force_equal=True``
        with loose orientation inverses (e.g., ``loose=0.2``), otherwise the
        solution resembles a free-orientation inverse (``loose=1.0``).
        It is thus recommended to use ``force_equal=True`` for loose orientation
        and ``force_equal=False`` for free orientation inverses. This is the
        behavior used when the parameter ``force_equal=None`` (default behavior).
    
        References
        ----------
        .. [1] Hämäläinen M S and Ilmoniemi R. Interpreting magnetic fields of
               the brain: minimum norm estimates. Medical & Biological Engineering
               & Computing, 32(1):35-42, 1994.
        .. [2] Dale A, Liu A, Fischl B, Buckner R. (2000) Dynamic statistical
               parametric mapping: combining fMRI and MEG for high-resolution
               imaging of cortical activity. Neuron, 26:55-67.
        .. [3] Pascual-Marqui RD (2002), Standardized low resolution brain
               electromagnetic tomography (sLORETA): technical details. Methods
               Find. Exp. Clin. Pharmacology, 24(D):5-12.
        .. [4] Pascual-Marqui RD (2007). Discrete, 3D distributed, linear imaging
               methods of electric neuronal activity. Part 1: exact, zero error
               localization. arXiv:0710.3341
        """
>       raise RuntimeError
E       RuntimeError

evoked     = <Evoked  |  'Left Auditory' (average, N=6), [0, 0.1998] sec, 376 ch, ~3.8 MB>
inverse_operator = <InverseOperator | MEG channels: 305 | EEG channels: 59 | Source space: surface with 498 sources | Source orientation: Free>
label      = None
lambda2    = 0.1111111111111111
method     = 'MNE'
method_params = None
pick_ori   = None
prepared   = False
return_residual = False
verbose    = None

mne/minimum_norm/inverse.py:869: RuntimeError

 mne/minimum_norm/tests/test_inverse.py ⨯                                                                                                                            100% ██████████
----------------------------------------------------- generated xml file: /Users/larsoner/python/mne-python/junit-results.xml ------------------------------------------------------
============================================================================ slowest 20 test durations =============================================================================
3.95s setup    mne/minimum_norm/tests/test_inverse.py::test_apply_inverse_operator[testing_data]
0.22s call     mne/minimum_norm/tests/test_inverse.py::test_apply_inverse_operator[testing_data]

(0.00 durations hidden.  Use -vv to show these durations.)
============================================================================= short test summary info ==============================================================================
FAILED mne/minimum_norm/tests/test_inverse.py::test_apply_inverse_operator[testing_data] - RuntimeError

Results (4.88s):
       1 failed
         - mne/minimum_norm/tests/test_inverse.py:398 test_apply_inverse_operator[testing_data]
```

</details>

It will now look like this (28 lines for the whole thing):

```
omar:mne-python larsoner$ pytest mne/minimum_norm/tests/test_inverse.py -k apply_inverse_operator --tb=short
Test session starts (platform: darwin, Python 3.7.3, pytest 5.2.0, pytest-sugar 0.9.2)
rootdir: /Users/larsoner/python/mne-python, inifile: setup.cfg
plugins: astropy-header-0.1.1, arraydiff-0.3, sugar-0.9.2, remotedata-0.3.2, timeout-1.3.3, openfiles-0.4.0, mock-1.11.0, cov-2.7.1, doctestplus-0.5.0
collecting ... 

―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_apply_inverse_operator[testing_data] ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
mne/minimum_norm/tests/test_inverse.py:410: in test_apply_inverse_operator
    stc = apply_inverse(evoked, inverse_operator, lambda2, "MNE")
</Users/larsoner/python/mne-python/mne/externals/decorator.py:decorator-gen-309>:2: in apply_inverse
    ???
mne/utils/_logging.py:90: in wrapper
    return function(*args, **kwargs)
mne/minimum_norm/inverse.py:869: in apply_inverse
    raise RuntimeError
E   RuntimeError

 mne/minimum_norm/tests/test_inverse.py ⨯                                                                                                                            100% ██████████
----------------------------------------------------- generated xml file: /Users/larsoner/python/mne-python/junit-results.xml ------------------------------------------------------
============================================================================ slowest 20 test durations =============================================================================
3.39s setup    mne/minimum_norm/tests/test_inverse.py::test_apply_inverse_operator[testing_data]
0.17s call     mne/minimum_norm/tests/test_inverse.py::test_apply_inverse_operator[testing_data]

(0.00 durations hidden.  Use -vv to show these durations.)
============================================================================= short test summary info ==============================================================================
FAILED mne/minimum_norm/tests/test_inverse.py::test_apply_inverse_operator[testing_data] - RuntimeError

Results (3.86s):
       1 failed
         - mne/minimum_norm/tests/test_inverse.py:398 test_apply_inverse_operator[testing_data]
      38 deselected
```