### PR TITLE
MRG, ENH: Extend reduce_rank=True support and better deficiency check

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -69,6 +69,8 @@ Changelog
 
 - Improved :ref:`limo-dataset` usage and :ref:`example <ex-limo-data>` for usage of :func:`mne.stats.linear_regression` by `Jose Alanis`_
 
+- Add support for ``reduce_rank=True`` for vector beamformers by `Eric Larson`_
+
 - Speed up :func:`mne.beamformer.make_lcmv` and :func:`mne.beamformer.make_dics` calculations by vectorizing linear algebra calls by `Dmitrii Altukhov`_ and `Eric Larson`_
 
 - Speed up :func:`mne.make_forward_solution` using Numba, by `Eric Larson`_

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -240,6 +240,10 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
 
     # leadfield rank and optional rank reduction
     _validate_type(reduce_rank, bool, "reduce_rank", "a boolean")
+    _check_option('inversion', inversion, ('matrix', 'single'))
+    if reduce_rank and inversion == 'single':
+        raise ValueError('reduce_rank cannot be used with inversion="single", '
+                         'use inversion="matrix" instead.')
     if n_orient > 1:
         _, Gk_s, _ = np.linalg.svd(Gk, full_matrices=False)
         assert Gk_s.shape == (n_sources, n_orient)
@@ -264,9 +268,7 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
                 if inversion == 'single':
                     # Invert for each dipole separately using plain division
                     diags = np.diagonal(Ck, axis1=1, axis2=2)
-                    if reduce_rank:
-                        diags[np.arange(len(diags)),
-                              np.argmin(diags, axis=1)] = np.inf
+                    assert not reduce_rank   # guaranteed above
                     with np.errstate(divide='ignore'):
                         diags = 1. / diags
                     # set the diagonal of each 3x3

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -13,13 +13,12 @@ import numpy as np
 from scipy import linalg
 
 from ..cov import Covariance, make_ad_hoc_cov
-from ..fixes import pinv
 from ..forward.forward import is_fixed_orient, _restrict_forward_to_src_sel
 from ..io.proj import make_projector, Projection
 from ..minimum_norm.inverse import _get_vertno, _prepare_forward
 from ..source_space import label_src_vertno_sel
 from ..utils import (verbose, check_fname, _reg_pinv, _check_option, logger,
-                     _pl, _check_src_normal, check_version)
+                     _pl, _check_src_normal, check_version, _validate_type)
 from ..time_frequency.csd import CrossSpectralDensity
 
 from ..externals.h5io import read_hdf5, write_hdf5
@@ -138,15 +137,7 @@ def _normalized_weights(Wk, Gk, Cm_inv_sq, reduce_rank, nn, sk):
         # These are ordered smallest to largest, so we set the first one
         # to inf -- then the 1. / s below will turn this to zero, as needed.
         s[:, 0] = np.inf
-    try:
-        with np.errstate(divide='raise'):
-            s = 1. / s
-    except FloatingPointError:
-        raise ValueError(
-            'Singular matrix detected when estimating spatial filters. '
-            'Consider reducing the rank of the forward operator by using '
-            'reduce_rank=True.'
-        )
+    s = 1. / s
     norm = np.matmul(u * s[:, np.newaxis], u.transpose(0, 2, 1))
 
     # Reapply source covariance after inversion
@@ -247,6 +238,17 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
     if check_version('numpy', '1.17'):
         pinv_kwargs['hermitian'] = True
 
+    # leadfield rank and optional rank reduction
+    _validate_type(reduce_rank, bool, "reduce_rank", "a boolean")
+    if n_orient > 1:
+        _, Gk_s, _ = np.linalg.svd(Gk, full_matrices=False)
+        assert Gk_s.shape == (n_sources, n_orient)
+        if not reduce_rank and (Gk_s[:, 0] > 1e6 * Gk_s[:, 2]).any():
+            raise ValueError(
+                'Singular matrix detected when estimating spatial filters. '
+                'Consider reducing the rank of the forward operator by using '
+                'reduce_rank=True.')
+
     with _noop_indentation_context():
         if (inversion == 'matrix' and pick_ori == 'max-power' and
                 weight_norm in ['unit-noise-gain', 'nai']):
@@ -261,8 +263,12 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
                 # Free source orientation
                 if inversion == 'single':
                     # Invert for each dipole separately using plain division
+                    diags = np.diagonal(Ck, axis1=1, axis2=2)
+                    if reduce_rank:
+                        diags[np.arange(len(diags)),
+                              np.argmin(diags, axis=1)] = np.inf
                     with np.errstate(divide='ignore'):
-                        diags = 1. / np.diagonal(Ck, axis1=1, axis2=2)
+                        diags = 1. / diags
                     # set the diagonal of each 3x3
                     norm = np.zeros((n_sources, n_orient, n_orient), Ck.dtype)
                     for k in range(n_sources):
@@ -271,11 +277,21 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
                     assert Ck.shape[1:] == (3, 3)
                     # Invert for all dipoles simultaneously using matrix
                     # inversion.
-                    norm = pinv(Ck, **pinv_kwargs)
+                    u, s, v = np.linalg.svd(
+                        Ck, full_matrices=False, **pinv_kwargs)
+                    if reduce_rank:
+                        s[:, 2] = np.inf
+                    # mimic default np.linalg.pinv behavior
+                    cutoff = 1e-15 * s[:, 0][:, np.newaxis]
+                    s[s <= cutoff] = np.inf
+                    s = 1. / s
+                    norm = np.matmul(
+                        v.transpose(0, 2, 1),
+                        s[:, :, np.newaxis] * u.transpose((0, 2, 1)))
                 # Reapply source covariance after inversion
                 norm *= sk[:, :, np.newaxis]
                 norm *= sk[:, np.newaxis, :]
-            else:
+            else:  # n_orient == 1
                 assert Ck.shape[1:] == (1, 1)
                 # Fixed source orientation
                 with np.errstate(divide='ignore'):

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -242,8 +242,11 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
     _validate_type(reduce_rank, bool, "reduce_rank", "a boolean")
     _check_option('inversion', inversion, ('matrix', 'single'))
     if reduce_rank and inversion == 'single':
-        raise ValueError('reduce_rank cannot be used with inversion="single", '
-                         'use inversion="matrix" instead.')
+        raise ValueError('reduce_rank cannot be used with inversion="single"; '
+                         'consider using inversion="matrix" if you have a '
+                         'rank-deficient forward model (i.e., from a sphere '
+                         'model with MEG channels), otherwise consider using '
+                         'reduce_rank=False')
     if n_orient > 1:
         _, Gk_s, _ = np.linalg.svd(Gk, full_matrices=False)
         assert Gk_s.shape == (n_sources, n_orient)

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -179,18 +179,6 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
     _check_option('inversion', inversion, ['single', 'matrix'])
     _check_option('weight_norm', weight_norm, ['unit-noise-gain', 'nai', None])
 
-    # Leadfield rank and optional rank reduction
-    # (to deal with problems with complex eigenvalues within the computation
-    # of the optimal orientation when using pinv if the leadfield was only
-    # rank 2 (e.g., with the spherical headmodel of the phantom data),
-    # see gh-4568 and gh-4628.
-    if reduce_rank and not (pick_ori == 'max-power' and inversion == 'matrix'):
-        raise NotImplementedError(
-            'The computation of spatial filters with rank reduction using '
-            'reduce_rank=True is only implemented with pick_ori=="max-power" '
-            'and inversion="matrix".'
-        )
-
     frequencies = [np.mean(freq_bin) for freq_bin in csd.frequencies]
     n_freqs = len(frequencies)
     n_orient = forward['sol']['ncol'] // forward['nsource']

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -103,6 +103,10 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
         each spatial location, prior to inversion. This may be necessary when
         you use a single sphere model for MEG and ``mode='vertex'``.
         Defaults to ``False``.
+
+        .. versionchanged:: 0.20
+           Support for reducing rank in all modes (previously only supported
+           ``pick='max_power'`` with weight normalization).
     %(verbose)s
 
     Returns

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -98,15 +98,7 @@ def make_dics(info, forward, csd, reg=0.05, label=None, pick_ori=None,
     real_filter : bool
         If ``True``, take only the real part of the cross-spectral-density
         matrices to compute real filters. Defaults to ``False``.
-    reduce_rank : bool
-        If ``True``, the rank of the forward operator will be reduced by 1 for
-        each spatial location, prior to inversion. This may be necessary when
-        you use a single sphere model for MEG and ``mode='vertex'``.
-        Defaults to ``False``.
-
-        .. versionchanged:: 0.20
-           Support for reducing rank in all modes (previously only supported
-           ``pick='max_power'`` with weight normalization).
+    %(reduce_rank)s
     %(verbose)s
 
     Returns
@@ -606,11 +598,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
     real_filter : bool
         If ``True``, take only the real part of the cross-spectral-density
         matrices to compute real filters. Defaults to ``False``.
-    reduce_rank : bool
-        If ``True``, the rank of the forward operator will be reduced by 1 for
-        each spatial location, prior to inversion. This may be necessary when
-        you use a single sphere model for MEG and ``mode='vertex'``.
-        Defaults to ``False``.
+    %(reduce_rank)s
     %(verbose)s
 
     Returns

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -67,14 +67,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
         will be computed (Borgiotti-Kaplan beamformer) [2]_,
         if 'nai', the Neural Activity Index [1]_ will be computed,
         if None, the unit-gain LCMV beamformer [2]_ will be computed.
-    reduce_rank : bool
-        If True, the rank of the leadfield will be reduced by 1 for each
-        spatial location. Setting reduce_rank to True is typically necessary
-        if you use a single sphere model for MEG.
-
-        .. versionchanged:: 0.20
-           Support for reducing rank in all modes (previously only supported
-           ``pick='max_power'`` with weight normalization).
+    %(reduce_rank)s
     %(depth)s
 
         .. versionadded:: 0.18

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -15,7 +15,7 @@ from ..forward import _subject_from_forward
 from ..minimum_norm.inverse import combine_xyz, _check_reference, _check_depth
 from ..cov import compute_covariance
 from ..source_estimate import _make_stc, _get_src_type
-from ..utils import (logger, verbose, warn, _validate_type, _reg_pinv,
+from ..utils import (logger, verbose, warn, _reg_pinv,
                      _check_channels_spatial_filter, _check_option)
 from ..utils import _check_one_ch_type, _check_rank, _check_info_inv
 from .. import Epochs
@@ -71,6 +71,10 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
         If True, the rank of the leadfield will be reduced by 1 for each
         spatial location. Setting reduce_rank to True is typically necessary
         if you use a single sphere model for MEG.
+
+        .. versionchanged:: 0.20
+           Support for reducing rank in all modes (previously only supported
+           ``pick='max_power'`` with weight normalization).
     %(depth)s
 
         .. versionadded:: 0.18
@@ -161,15 +165,6 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
     Cm = np.dot(whitener, np.dot(Cm, whitener.T))
     rank_int = sum(rank.values())
     del rank
-
-    # leadfield rank and optional rank reduction
-    if reduce_rank:
-        if not pick_ori == 'max-power':
-            raise NotImplementedError('The computation of spatial filters '
-                                      'with rank reduction using reduce_rank '
-                                      'parameter is only implemented with '
-                                      'pick_ori=="max-power".')
-        _validate_type(reduce_rank, bool, "reduce_rank", "a boolean")
 
     # compute spatial filter
     n_orient = 3 if is_free_ori else 1

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -141,11 +141,9 @@ def test_make_dics(tmpdir, _load_forward):
         make_dics(epochs.info, fwd_vol, csd, pick_ori="normal")
 
     # Test invalid combinations of parameters
-    with pytest.raises(NotImplementedError, match='implemented with pick_ori'):
-        make_dics(epochs.info, fwd_free, csd, reduce_rank=True, pick_ori=None)
-    with pytest.raises(NotImplementedError, match='implemented with pick_ori'):
-        make_dics(epochs.info, fwd_free, csd, reduce_rank=True,
-                  pick_ori='max-power', inversion='single')
+    with pytest.raises(ValueError, match='reduce_rank cannot be used with'):
+        make_dics(epochs.info, fwd_free, csd, inversion='single',
+                  reduce_rank=True)
     with pytest.raises(ValueError, match='not stable with depth'):
         make_dics(epochs.info, fwd_free, csd, weight_norm='unit-noise-gain',
                   inversion='single', normalize_fwd=True)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -283,6 +283,17 @@ docdict['pick_ori-vec'] = """
 
         .. versionadded:: 0.20
 """
+docdict['reduce_rank'] = """
+reduce_rank : bool
+    If True, the rank of the denominator of the beamformer formula (i.e.,
+    during pseudo-inversion) will be reduced by one for each spatial location.
+    Setting ``reduce_rank=True`` is typically necessary if you use a single
+    sphere model with MEG data.
+
+    .. versionchanged:: 0.20
+        Support for reducing rank in all modes (previously only supported
+        ``pick='max_power'`` with weight normalization).
+"""
 
 # Forward
 docdict['on_missing'] = """


### PR DESCRIPTION
Closes #5880.

@agramfort `reduce_rank=True` was still only implemented for `pick_ori == 'max_power' and weight_norm is not None`. This adds support for the other modes, plus a sanity check on the gain matrix directly rather than relying on `linalg` functions to fail.

@britta-wstnr @wmvanvliet it would be good if you could take a look.