### PR TITLE
MRG: Add annotations_from_events

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -85,6 +85,8 @@ Changelog
 
 - Allow `mne.channels.read_custom_montage` to handle fiducial points for BESA spherical (``.elp``) files by `Richard Höchenberger`_
 
+- Add function to convert events to annotations :func:`mne.annotations_from_events` by `Nicolas Barascud`_
+
 Bug
 ~~~
 

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -465,6 +465,7 @@ Events
    write_events
    concatenate_epochs
    events_from_annotations
+   annotations_from_events
 
 :py:mod:`mne.event`:
 

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -72,7 +72,8 @@ from .source_space import (read_source_spaces, vertex_to_mni,
                            add_source_space_distances, morph_source_spaces,
                            get_volume_labels_from_aseg,
                            get_volume_labels_from_src)
-from .annotations import Annotations, read_annotations, events_from_annotations
+from .annotations import (Annotations, read_annotations, annotations_from_events,
+                          events_from_annotations)
 from .epochs import (BaseEpochs, Epochs, EpochsArray, read_epochs,
                      concatenate_epochs, make_fixed_length_epochs)
 from .evoked import Evoked, EvokedArray, read_evokeds, write_evokeds, combine_evoked

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -907,28 +907,28 @@ def _check_event_id(event_id, raw):
     elif callable(event_id) or isinstance(event_id, dict):
         return event_id
     else:
-        raise ValueError('Invalid input event_id')
+        raise ValueError('Invalid type for event_id (should be None, "auto", '
+                         'dict or callable). Got {}'.format(type(event_id)))
 
 
 def _check_event_description(event_desc, events):
     """Check event_id and convert to default format."""
-    # check out event_id dict
     if event_desc is None:  # convert to int to make typing-checks happy
         event_desc = list(np.unique(events[:, 2]))
-
-    if isinstance(event_desc, np.ndarray):
-        if event_desc.ndim == 1:
-            event_desc = list(event_desc)
 
     if isinstance(event_desc, dict):
         for val in event_desc.values():
             _validate_type(val, (str, None), 'Event names')
-    elif isinstance(event_desc, list):
-        event_desc = dict(zip(event_desc, (str(i) for i in event_desc)))
+    elif isinstance(event_desc, (list, np.ndarray)):
+        event_desc = np.asarray(event_desc)
+        assert event_desc.ndim == 1
+        event_desc = dict(zip(event_desc, map(str, event_desc)))
     elif callable(event_desc):
         pass
     else:
-        raise ValueError('Invalid input event_id')
+        raise ValueError('Invalid type for event_desc (should be None, list, '
+                         '1darray, dict or callable). Got {}'.format(
+                             type(event_desc)))
 
     return event_desc
 
@@ -1043,7 +1043,7 @@ def annotations_from_events(events, sfreq, event_desc=None, first_samp=0,
         The events.
     sfreq : float
         Sampling frequency.
-    event_desc : dict | callable | None
+    event_desc : dict | list | 1darray | callable | None
         Events description. Can be:
 
         - **dict**: map integer event codes (keys) to descriptions (values).

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1043,14 +1043,14 @@ def annotations_from_events(events, sfreq, event_desc=None, first_samp=0,
         The events.
     sfreq : float
         Sampling frequency.
-    event_desc : dict | list | 1darray | callable | None
+    event_desc : dict | array-like | callable | None
         Events description. Can be:
 
         - **dict**: map integer event codes (keys) to descriptions (values).
           Only the descriptions present will be mapped, others will be ignored.
-        - **list** or **1darray**: integers event codes to include. Only the
-          event codes present will be mapped, others will be ignored. Event
-          codes will be passed as string descriptions.
+        - **array-like**: list, or 1d array of integers event codes to include.
+          Only the event codes present will be mapped, others will be ignored.
+          Event codes will be passed as string descriptions.
         - **callable**: must take a integer event code as input and return a
           string description or None to ignore it.
         - **None**: Use integer event codes as descriptions.

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -977,3 +977,43 @@ def events_from_annotations(raw, event_id="auto",
                 (list(event_id_.keys()),))
 
     return events, event_id_
+
+
+@verbose
+def annotations_from_events(events, sfreq, first_samp=0, orig_time=None,
+                            verbose=None):
+    """Convert an event array to an Annotations object.
+
+    Parameters
+    ----------
+    events : ndarray, shape (n_events, 3)
+        The events.
+    sfreq : float
+        Sampling frequency.
+    first_samp : int
+        The first data sample. See :attr:`mne.io.Raw.first_samp` docstring.
+    orig_time : float | str | datetime | tuple of int | None
+        Determines the starting time of annotation acquisition. If None
+        (default), starting time is determined from beginning of raw data
+        acquisition. For details, see :meth:`mne.Annotations` docstring.
+    %(verbose)s
+
+    Returns
+    -------
+    annot : instance of Annotations | None
+        The annotations.
+
+    Notes
+    -----
+    Annotations returned by this function will all have zero (null) duration.
+
+    """
+    onsets = [(e[0] - first_samp) / sfreq for e in events]
+    descriptions = [str(e[2]) for e in events]
+    durations = [0. for _ in range(len(events))]  # dummy durations
+    annots = Annotations(onset=onsets,
+                         duration=durations,
+                         description=descriptions,
+                         orig_time=orig_time)
+
+    return annots

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1006,7 +1006,6 @@ def annotations_from_events(events, sfreq, first_samp=0, orig_time=None,
     Notes
     -----
     Annotations returned by this function will all have zero (null) duration.
-
     """
     onsets = [(e[0] - first_samp) / sfreq for e in events]
     descriptions = [str(e[2]) for e in events]

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -923,8 +923,7 @@ def _check_event_description(event_desc, events):
         event_desc = dict(zip(event_desc, (str(i) for i in event_desc)))
     elif callable(event_desc):
         pass
-    else:
-        event_desc = {event_desc: str(event_desc)}
+
     return event_desc
 
 
@@ -1043,6 +1042,8 @@ def annotations_from_events(events, sfreq, event_desc=None, first_samp=0,
 
         - **dict**: map integer event codes (keys) to descriptions (values).
           Only the descriptions present will be mapped, others will be ignored.
+        - **list**: integer event codes (values) to include. Others will be
+          ignored. Event codes will be converted to string descriptions.
         - **callable**: must take a integer event code as input and return a
           string description or None to ignore it.
         - **None**: Use integer event codes as descriptions.

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -917,7 +917,6 @@ def _check_event_description(event_desc, events):
         event_desc = list(np.unique(events[:, 2]))
 
     if isinstance(event_desc, np.ndarray):
-        event_desc = event_desc.squeeze()  # remove singletons
         if event_desc.ndim == 1:
             event_desc = list(event_desc)
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -916,6 +916,11 @@ def _check_event_description(event_desc, events):
     if event_desc is None:  # convert to int to make typing-checks happy
         event_desc = list(np.unique(events[:, 2]))
 
+    if isinstance(event_desc, np.ndarray):
+        event_desc = event_desc.squeeze()  # remove singletons
+        if event_desc.ndim == 1:
+            event_desc = list(event_desc)
+
     if isinstance(event_desc, dict):
         for val in event_desc.values():
             _validate_type(val, (str, None), 'Event names')
@@ -923,6 +928,8 @@ def _check_event_description(event_desc, events):
         event_desc = dict(zip(event_desc, (str(i) for i in event_desc)))
     elif callable(event_desc):
         pass
+    else:
+        raise ValueError('Invalid input event_id')
 
     return event_desc
 
@@ -1042,8 +1049,9 @@ def annotations_from_events(events, sfreq, event_desc=None, first_samp=0,
 
         - **dict**: map integer event codes (keys) to descriptions (values).
           Only the descriptions present will be mapped, others will be ignored.
-        - **list**: integer event codes (values) to include. Others will be
-          ignored. Event codes will be converted to string descriptions.
+        - **list** or **1darray**: integers event codes to include. Only the
+          event codes present will be mapped, others will be ignored. Event
+          codes will be passed as string descriptions.
         - **callable**: must take a integer event code as input and return a
           string description or None to ignore it.
         - **None**: Use integer event codes as descriptions.

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -907,7 +907,7 @@ def _check_event_id(event_id, raw):
     elif callable(event_id) or isinstance(event_id, dict):
         return event_id
     else:
-        raise ValueError('Invalid type for event_id (should be None, "auto", '
+        raise ValueError('Invalid type for event_id (should be None, str, '
                          'dict or callable). Got {}'.format(type(event_id)))
 
 
@@ -919,7 +919,7 @@ def _check_event_description(event_desc, events):
     if isinstance(event_desc, dict):
         for val in event_desc.values():
             _validate_type(val, (str, None), 'Event names')
-    elif isinstance(event_desc, (list, np.ndarray)):
+    elif isinstance(event_desc, collections.Iterable):
         event_desc = np.asarray(event_desc)
         assert event_desc.ndim == 1
         event_desc = dict(zip(event_desc, map(str, event_desc)))

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1000,7 +1000,7 @@ def annotations_from_events(events, sfreq, first_samp=0, orig_time=None,
 
     Returns
     -------
-    annot : instance of Annotations | None
+    annot : instance of Annotations
         The annotations.
 
     Notes

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -868,7 +868,7 @@ def _select_events_based_on_id(events, event_desc):
             continue
 
         if isinstance(event_desc, dict):
-            if e[2] in event_desc and event_desc[e[2]] is not None:
+            if event_desc.get(e[2]) is not None:
                 event_desc_[e[2]] = event_desc[e[2]]
             else:
                 continue
@@ -1067,9 +1067,9 @@ def annotations_from_events(events, sfreq, event_desc=None, first_samp=0,
     event_desc = _check_event_description(event_desc, events)
     event_sel, event_desc_ = _select_events_based_on_id(events, event_desc)
     events_sel = events[event_sel]
-    onsets = [(e[0] - first_samp) / sfreq for e in events_sel]
+    onsets = (events_sel[:, 0] - first_samp) / sfreq
     descriptions = [event_desc_[e[2]] for e in events_sel]
-    durations = [0. for _ in range(len(events_sel))]  # dummy durations
+    durations = np.zeros(len(events_sel))  # dummy durations
 
     # Create annotations
     annots = Annotations(onset=onsets,

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1163,7 +1163,7 @@ def test_annotations_from_events():
 
     with pytest.raises(ValueError, match='Invalid type for event_desc'):
         annots = annotations_from_events(events, sfreq=raw.info['sfreq'],
-                                         event_desc='auto',
+                                         event_desc=1,
                                          first_samp=raw.first_samp,
                                          orig_time=None)
 

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1155,7 +1155,7 @@ def test_annotations_from_events():
     # 5. Pass numpy array
     # -------------------------------------------------------------------------
     event_desc = np.array([[1, 2, 3], [1, 2, 3]])
-    with pytest.raises(AssertionError):  # a 2D array should fail
+    with pytest.raises(ValueError, match='event_desc must be 1D'):
         annots = annotations_from_events(events, sfreq=raw.info['sfreq'],
                                          event_desc=event_desc,
                                          first_samp=raw.first_samp,

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1130,7 +1130,18 @@ def test_annotations_from_events():
     assert np.all([a in ['one', 'two', 'three'] for a in annots.description])
     assert len(annots) == events[events[:, 2] <= 3].shape[0]
 
-    # 3. Try passing callable
+    # 3. Pass list
+    # -------------------------------------------------------------------------
+    event_desc = [1, 2, 3]
+    annots = annotations_from_events(events, sfreq=raw.info['sfreq'],
+                                     event_desc=event_desc,
+                                     first_samp=raw.first_samp,
+                                     orig_time=None)
+
+    assert np.all([a in ['1', '2', '3'] for a in annots.description])
+    assert len(annots) == events[events[:, 2] <= 3].shape[0]
+
+    # 4. Try passing callable
     # -------------------------------------------------------------------------
     event_desc = lambda d: 'event{}'.format(d)  # noqa:E731
     annots = annotations_from_events(events, sfreq=raw.info['sfreq'],

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -621,7 +621,7 @@ def test_events_from_annot_in_raw_objects():
     with pytest.raises(ValueError, match='not find any of the events'):
         events_from_annotations(raw, regexp='not_there')
 
-    with pytest.raises(ValueError, match='Invalid input event_id'):
+    with pytest.raises(ValueError, match='Invalid type for event_id'):
         events_from_annotations(raw, event_id='wrong')
 
     # concat does not introduce BAD or EDGE
@@ -1152,16 +1152,22 @@ def test_annotations_from_events():
     assert np.all(['event' in a for a in annots.description])
     assert len(annots) == events.shape[0]
 
-    # 3. Pass numpy array
+    # 5. Pass numpy array
     # -------------------------------------------------------------------------
     event_desc = np.array([[1, 2, 3], [1, 2, 3]])
-    with pytest.raises(ValueError):  # a 2D array should fail
+    with pytest.raises(AssertionError):  # a 2D array should fail
         annots = annotations_from_events(events, sfreq=raw.info['sfreq'],
                                          event_desc=event_desc,
                                          first_samp=raw.first_samp,
                                          orig_time=None)
 
-    event_desc = np.array([[1, 2, 3], ])
+    with pytest.raises(ValueError, match='Invalid type for event_desc'):
+        annots = annotations_from_events(events, sfreq=raw.info['sfreq'],
+                                         event_desc='auto',
+                                         first_samp=raw.first_samp,
+                                         orig_time=None)
+
+    event_desc = np.array([1, 2, 3])
     annots = annotations_from_events(events, sfreq=raw.info['sfreq'],
                                      event_desc=event_desc,
                                      first_samp=raw.first_samp,

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1152,5 +1152,22 @@ def test_annotations_from_events():
     assert np.all(['event' in a for a in annots.description])
     assert len(annots) == events.shape[0]
 
+    # 3. Pass numpy array
+    # -------------------------------------------------------------------------
+    event_desc = np.array([[1, 2, 3], [1, 2, 3]])
+    with pytest.raises(ValueError):  # a 2D array should fail
+        annots = annotations_from_events(events, sfreq=raw.info['sfreq'],
+                                         event_desc=event_desc,
+                                         first_samp=raw.first_samp,
+                                         orig_time=None)
+
+    event_desc = np.array([[1, 2, 3], ])
+    annots = annotations_from_events(events, sfreq=raw.info['sfreq'],
+                                     event_desc=event_desc,
+                                     first_samp=raw.first_samp,
+                                     orig_time=None)
+    assert np.all([a in ['1', '2', '3'] for a in annots.description])
+    assert len(annots) == events[events[:, 2] <= 3].shape[0]
+
 
 run_tests_if_main()

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -2,27 +2,32 @@
 #
 # License: BSD 3 clause
 
-import os.path as op
-import sys
-from collections import OrderedDict
 from datetime import datetime, timezone
 from itertools import repeat
+from collections import OrderedDict
+import sys
+
+import os.path as op
+
+import pytest
+from pytest import approx
+from numpy.testing import (assert_equal, assert_array_equal,
+                           assert_array_almost_equal, assert_allclose)
+
+import numpy as np
 
 import mne
-import numpy as np
-import pytest
-from mne import (Annotations, Epochs, annotations_from_events, create_info,
-                 events_from_annotations, read_annotations)
-from mne.annotations import (_handle_meas_date,
-                             _read_annotations_txt_parse_header, _sync_onset)
+from mne import (create_info, read_annotations, annotations_from_events,
+                 events_from_annotations)
+from mne import Epochs, Annotations
+from mne.utils import (run_tests_if_main, _TempDir, requires_version,
+                       catch_logging)
+from mne.utils import (assert_and_remove_boundary_annot, _raw_annot,
+                       _dt_to_stamp, _stamp_to_dt)
+from mne.io import read_raw_fif, RawArray, concatenate_raws
+from mne.annotations import (_sync_onset, _handle_meas_date,
+                             _read_annotations_txt_parse_header)
 from mne.datasets import testing
-from mne.io import RawArray, concatenate_raws, read_raw_fif
-from mne.utils import (_dt_to_stamp, _raw_annot, _stamp_to_dt, _TempDir,
-                       assert_and_remove_boundary_annot, catch_logging,
-                       requires_version, run_tests_if_main)
-from numpy.testing import (assert_allclose, assert_array_almost_equal,
-                           assert_array_equal, assert_equal)
-from pytest import approx
 
 data_dir = op.join(testing.data_path(download=False), 'MEG', 'sample')
 fif_fname = op.join(op.dirname(__file__), '..', 'io', 'tests', 'data',

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1104,13 +1104,12 @@ def test_annotations_from_events():
     annots = annotations_from_events(events, raw.info['sfreq'],
                                      first_samp=raw.first_samp,
                                      orig_time=None)
-    print(annots[0])
     assert len(annots) == events.shape[0]
 
     # Convert back to events
     raw.set_annotations(annots)
     events_out, _ = events_from_annotations(raw, event_id=int)
-    print(events_out)
     assert_array_equal(events, events_out)
 
 
+run_tests_if_main()


### PR DESCRIPTION
This adds a new function that creates annotations from an event array. 

Fixes issue raised in #6125.

#### TODO/ To discuss: 
- [x] conversion round trip : events -> annotations -> events
- [x] add `events_id` parameter
- [x] ~add optional `durations` argument ?~
- [x] ~should function accept `raw` instance as argument ? (makes it possible to infer `first_samp` `orig_time` and `sfreq`~