### PR TITLE
MRG, DOC: Improve styling using classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
             command: |
               python -m pip install --user --upgrade --progress-bar off pip numpy vtk
               python -m pip install --user --upgrade --progress-bar off -r requirements.txt
-              python -m pip install --user --upgrade --progress-bar off ipython sphinx_fontawesome sphinx_bootstrap_theme "https://api.github.com/repos/sphinx-gallery/sphinx-gallery/zipball/master" memory_profiler "https://api.github.com/repos/nipy/PySurfer/zipball/master"
+              python -m pip install --user --upgrade --progress-bar off ipython sphinx_fontawesome sphinx_bootstrap_theme "https://api.github.com/repos/larsoner/sphinx-gallery/zipball/classes" memory_profiler "https://api.github.com/repos/nipy/PySurfer/zipball/master"
               python -m pip install --user -e .
 
         - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
             command: |
               python -m pip install --user --upgrade --progress-bar off pip numpy vtk
               python -m pip install --user --upgrade --progress-bar off -r requirements.txt
-              python -m pip install --user --upgrade --progress-bar off ipython sphinx_fontawesome sphinx_bootstrap_theme "https://api.github.com/repos/larsoner/sphinx-gallery/zipball/classes" memory_profiler "https://api.github.com/repos/nipy/PySurfer/zipball/master"
+              python -m pip install --user --upgrade --progress-bar off ipython sphinx_fontawesome sphinx_bootstrap_theme "https://api.github.com/repos/sphinx-gallery/sphinx-gallery/zipball/master" memory_profiler "https://api.github.com/repos/nipy/PySurfer/zipball/master"
               python -m pip install --user -e .
 
         - save_cache:

--- a/doc/_static/reset-syntax.css
+++ b/doc/_static/reset-syntax.css
@@ -1,9 +1,0 @@
-.highlight a {
-    color: rgb(41, 122, 204);
-}
-.highlight * {
-    color: inherit;
-    font-weight: inherit;
-    font-style: inherit;
-    background-color: #fafafa;
-}

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -8,6 +8,18 @@ html {
   position: relative;
   min-height: 100%;
 }
+
+/* Syntax reset */
+.highlight a {
+    color: var(--a-color);
+}
+.highlight * {
+    color: inherit;
+    font-weight: inherit;
+    font-style: inherit;
+    background-color: #fafafa;
+}
+
 /* overrides of bootstrap fonts */
 body {
     font-family:"Source Sans Pro", sans-serif;
@@ -444,7 +456,13 @@ div.institutions a {
   .hidden {
     display: none;
   }
-  /* Pandas DataFrame _repr_html_ */
+
+/* Pandas DataFrame _repr_html_ */
 table.dataframe th,td {
     padding: 5px;
+}
+
+/* Sphinx-gallery backreference links */
+a[class^="sphx-glr-backref-module-mne"] {
+    font-weight: 600;
 }

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,7 +1,5 @@
 {% extends "!layout.html" %}
 
-{% set css_files = css_files + ['_static/reset-syntax.css'] %}
-
 {% block extrahead %}
 
     <script type="text/javascript" src="{{ pathto('_static/copybutton.js', 1) }}"></script>

--- a/tutorials/intro/plot_10_overview.py
+++ b/tutorials/intro/plot_10_overview.py
@@ -207,7 +207,7 @@ fig.subplots_adjust(right=0.7)  # make room for the legend
 #
 # The :class:`~mne.io.Raw` object and the events array are the bare minimum
 # needed to create an :class:`~mne.Epochs` object, which we create with the
-# :class:`mne.Epochs` class constructor. Here we'll also specify some data
+# :class:`~mne.Epochs` class constructor. Here we'll also specify some data
 # quality constraints: we'll reject any epoch where peak-to-peak signal
 # amplitude is beyond reasonable limits for that channel type. This is done
 # with a *rejection dictionary*; you may include or omit thresholds for any of


### PR DESCRIPTION
Proof of concept for https://github.com/sphinx-gallery/sphinx-gallery/pull/581. It makes MNE links in code blocks bold, and leaves the other ones (Python, Matplotlib, etc.) as the standard weight.

It also removes `reset-syntax.css` in favor of just having our CSS all in `style.css`.

~~WIP until the SG PR is merged, then I'll remove the `circleci` changes.~~