### PR TITLE
MAINT: Bump up to 3.8 on CIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
     build_docs:
       docker:
-        - image: circleci/python:3.7-stretch
+        - image: circleci/python:3.8-buster
       steps:
         - checkout
         - run:
@@ -317,7 +317,7 @@ jobs:
     linkcheck:
       # there are a few files excluded from this for expediency, see Makefile
       docker:
-        - image: circleci/python:3.6-jessie
+        - image: circleci/python:3.8-buster
       steps:
         - checkout
         - run:
@@ -346,7 +346,7 @@ jobs:
 
     deploy:
       docker:
-        - image: circleci/python:3.6-jessie
+        - image: circleci/python:3.8-buster
       steps:
         - attach_workspace:
             at: /tmp/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: c
+language: generic
 dist: xenial
 cache:
   apt: true
@@ -7,7 +7,7 @@ env:
     # TRAVIS_PYTHON_VERSION is only needed for neo's setup.py
     # OPENBLAS_NUM_THREADS=1 avoid slowdowns:
     # https://github.com/xianyi/OpenBLAS/issues/731
-    global: PYTHON_VERSION=3.7 DISPLAY=:99.0 MNE_LOGGING_LEVEL=warning
+    global: PYTHON_VERSION=3.8 DISPLAY=:99.0 MNE_LOGGING_LEVEL=warning
             TRAVIS_PYTHON_VERSION=3.7 CONDA_VERSION=">=4.3.27"
             OPENBLAS_NUM_THREADS=1
 
@@ -25,7 +25,7 @@ matrix:
         - os: linux
           env: MNE_STIM_CHANNEL=STI101
           language: python
-          python: "3.7"
+          python: "3.8"
           addons:
             apt:
               packages:


### PR DESCRIPTION
Dipy [pushed their binaries](https://github.com/nipy/dipy/issues/2004) so let's see if we can move up to 3.8 now.