### PR TITLE
MRG: Bump colorbar control points

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -863,64 +863,61 @@ class _Brain(object):
     def update_fmax(self, fmax):
         """Set the colorbar max point."""
         from ..backends._pyvista import _set_colormap_range
-        if fmax > self._data['fmid']:
-            ctable = self.update_lut(fmax=fmax)
-            ctable = (ctable * 255).astype(np.uint8)
-            center = self._data['center']
-            for hemi in ['lh', 'rh']:
-                actor = self._data.get(hemi + '_actor')
-                if actor is not None:
-                    fmin = self._data['fmin']
-                    center = self._data['center']
-                    dt_max = fmax
-                    dt_min = fmin if center is None else -1 * fmax
-                    rng = [dt_min, dt_max]
-                    if self._colorbar_added:
-                        scalar_bar = self._renderer.plotter.scalar_bar
-                    else:
-                        scalar_bar = None
-                    _set_colormap_range(actor, ctable, scalar_bar, rng)
-                    self._data['fmax'] = fmax
-                    self._data['ctable'] = ctable
+        ctable = self.update_lut(fmax=fmax)
+        ctable = (ctable * 255).astype(np.uint8)
+        center = self._data['center']
+        for hemi in ['lh', 'rh']:
+            actor = self._data.get(hemi + '_actor')
+            if actor is not None:
+                fmin = self._data['fmin']
+                center = self._data['center']
+                dt_max = fmax
+                dt_min = fmin if center is None else -1 * fmax
+                rng = [dt_min, dt_max]
+                if self._colorbar_added:
+                    scalar_bar = self._renderer.plotter.scalar_bar
+                else:
+                    scalar_bar = None
+                _set_colormap_range(actor, ctable, scalar_bar, rng)
+                self._data['fmax'] = fmax
+                self._data['ctable'] = ctable
 
     def update_fmid(self, fmid):
         """Set the colorbar mid point."""
         from ..backends._pyvista import _set_colormap_range
-        if self._data['fmin'] < fmid < self._data['fmax']:
-            ctable = self.update_lut(fmid=fmid)
-            ctable = (ctable * 255).astype(np.uint8)
-            for hemi in ['lh', 'rh']:
-                actor = self._data.get(hemi + '_actor')
-                if actor is not None:
-                    if self._colorbar_added:
-                        scalar_bar = self._renderer.plotter.scalar_bar
-                    else:
-                        scalar_bar = None
-                    _set_colormap_range(actor, ctable, scalar_bar)
-                    self._data['fmid'] = fmid
-                    self._data['ctable'] = ctable
+        ctable = self.update_lut(fmid=fmid)
+        ctable = (ctable * 255).astype(np.uint8)
+        for hemi in ['lh', 'rh']:
+            actor = self._data.get(hemi + '_actor')
+            if actor is not None:
+                if self._colorbar_added:
+                    scalar_bar = self._renderer.plotter.scalar_bar
+                else:
+                    scalar_bar = None
+                _set_colormap_range(actor, ctable, scalar_bar)
+                self._data['fmid'] = fmid
+                self._data['ctable'] = ctable
 
     def update_fmin(self, fmin):
         """Set the colorbar min point."""
         from ..backends._pyvista import _set_colormap_range
-        if fmin < self._data['fmid']:
-            ctable = self.update_lut(fmin=fmin)
-            ctable = (ctable * 255).astype(np.uint8)
-            for hemi in ['lh', 'rh']:
-                actor = self._data.get(hemi + '_actor')
-                if actor is not None:
-                    fmax = self._data['fmax']
-                    center = self._data['center']
-                    dt_max = fmax
-                    dt_min = fmin if center is None else -1 * fmax
-                    rng = [dt_min, dt_max]
-                    if self._colorbar_added:
-                        scalar_bar = self._renderer.plotter.scalar_bar
-                    else:
-                        scalar_bar = None
-                    _set_colormap_range(actor, ctable, scalar_bar, rng)
-                    self._data['fmin'] = fmin
-                    self._data['ctable'] = ctable
+        ctable = self.update_lut(fmin=fmin)
+        ctable = (ctable * 255).astype(np.uint8)
+        for hemi in ['lh', 'rh']:
+            actor = self._data.get(hemi + '_actor')
+            if actor is not None:
+                fmax = self._data['fmax']
+                center = self._data['center']
+                dt_max = fmax
+                dt_min = fmin if center is None else -1 * fmax
+                rng = [dt_min, dt_max]
+                if self._colorbar_added:
+                    scalar_bar = self._renderer.plotter.scalar_bar
+                else:
+                    scalar_bar = None
+                _set_colormap_range(actor, ctable, scalar_bar, rng)
+                self._data['fmin'] = fmin
+                self._data['ctable'] = ctable
 
     def update_fscale(self, fscale):
         """Scale the colorbar points."""

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -793,14 +793,18 @@ class _Brain(object):
         center = self._data['center']
         colormap = self._data['colormap']
         transparent = self._data['transparent']
-        fmin = self._data['fmin'] if fmin is None else fmin
-        fmid = self._data['fmid'] if fmid is None else fmid
-        fmax = self._data['fmax'] if fmax is None else fmax
-
+        lims = dict(fmin=fmin, fmid=fmid, fmax=fmax)
+        lims = {key: self._data[key] if val is None else val
+                for key, val in lims.items()}
+        assert all(val is not None for val in lims.values())
+        if lims['fmin'] > lims['fmid']:
+            lims['fmin'] = lims['fmid']
+        if lims['fmax'] < lims['fmid']:
+            lims['fmax'] = lims['fmid']
+        self._data.update(lims)
         self._data['ctable'] = \
-            calculate_lut(colormap, alpha=alpha, fmin=fmin, fmid=fmid,
-                          fmax=fmax, center=center, transparent=transparent)
-
+            calculate_lut(colormap, alpha=alpha, center=center,
+                          transparent=transparent, **lims)
         return self._data['ctable']
 
     def set_data_smoothing(self, n_steps):

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -100,7 +100,7 @@ class BumpColorbarPoints(object):
                 self.brain.update_fmid(value)
                 reps['fmid'].SetValue(value)
             reps['fmax'].SetValue(value)
-        if time.time() > self.last_update + 1. / 30.:
+        if time.time() > self.last_update + 1. / 60.:
             self.callback[self.name](value)
             self.last_update = time.time()
 

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -16,9 +16,9 @@ class IntSlider(object):
         self.callback = callback
         self.name = name
 
-    def __call__(self, idx):
+    def __call__(self, value):
         """Round the label of the slider."""
-        idx = int(round(idx))
+        idx = int(round(value))
         for slider in self.plotter.slider_widgets:
             name = getattr(slider, "name", None)
             if name == self.name:
@@ -121,20 +121,20 @@ class _TimeViewer(object):
 
         # smoothing slider
         default_smoothing_value = 7
-        set_smoothing = IntSlider(
+        self.set_smoothing = IntSlider(
             plotter=self.plotter,
             callback=brain.set_data_smoothing,
             name="smoothing"
         )
         smoothing_slider = self.plotter.add_slider_widget(
-            set_smoothing,
+            self.set_smoothing,
             value=default_smoothing_value,
             rng=[1, 15], title="smoothing",
             pointa=(0.82, 0.90),
             pointb=(0.98, 0.90)
         )
         smoothing_slider.name = 'smoothing'
-        set_smoothing(default_smoothing_value)
+        self.set_smoothing(default_smoothing_value)
 
         # orientation slider
         orientation = [
@@ -177,13 +177,13 @@ class _TimeViewer(object):
         # colormap slider
         scaling_limits = [0.2, 2.0]
         fmin = brain._data["fmin"]
-        update_fmin = BumpColorbarPoints(
+        self.update_fmin = BumpColorbarPoints(
             plotter=self.plotter,
             brain=brain,
             name="fmin"
         )
         fmin_slider = self.plotter.add_slider_widget(
-            update_fmin,
+            self.update_fmin,
             value=fmin,
             rng=_get_range(brain), title="fmin",
             pointa=(0.82, 0.26),
@@ -192,13 +192,13 @@ class _TimeViewer(object):
         )
         fmin_slider.name = "fmin"
         fmid = brain._data["fmid"]
-        update_fmid = BumpColorbarPoints(
+        self.update_fmid = BumpColorbarPoints(
             plotter=self.plotter,
             brain=brain,
             name="fmid",
         )
         fmid_slider = self.plotter.add_slider_widget(
-            update_fmid,
+            self.update_fmid,
             value=fmid,
             rng=_get_range(brain), title="fmid",
             pointa=(0.82, 0.42),
@@ -207,13 +207,13 @@ class _TimeViewer(object):
         )
         fmid_slider.name = "fmid"
         fmax = brain._data["fmax"]
-        update_fmax = BumpColorbarPoints(
+        self.update_fmax = BumpColorbarPoints(
             plotter=self.plotter,
             brain=brain,
             name="fmax",
         )
         fmax_slider = self.plotter.add_slider_widget(
-            update_fmax,
+            self.update_fmax,
             value=fmax,
             rng=_get_range(brain), title="fmax",
             pointa=(0.82, 0.58),

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -193,7 +193,7 @@ class _TimeViewer(object):
         fmin_slider = self.plotter.add_slider_widget(
             update_fmin,
             value=fmin,
-            rng=_get_range(fmin, scaling_limits), title="fmin",
+            rng=_get_range(brain), title="fmin",
             pointa=(0.82, 0.26),
             pointb=(0.98, 0.26),
         )
@@ -207,7 +207,7 @@ class _TimeViewer(object):
         fmid_slider = self.plotter.add_slider_widget(
             update_fmid,
             value=fmid,
-            rng=_get_range(fmid, scaling_limits), title="fmid",
+            rng=_get_range(brain), title="fmid",
             pointa=(0.82, 0.42),
             pointb=(0.98, 0.42),
         )
@@ -221,7 +221,7 @@ class _TimeViewer(object):
         fmax_slider = self.plotter.add_slider_widget(
             update_fmax,
             value=fmax,
-            rng=_get_range(fmax, scaling_limits), title="fmax",
+            rng=_get_range(brain), title="fmax",
             pointa=(0.82, 0.58),
             pointb=(0.98, 0.58),
         )
@@ -272,5 +272,7 @@ def _set_slider_style(slider, show_label=True):
         slider_rep.ShowSliderLabelOff()
 
 
-def _get_range(val, rng):
-    return [val * rng[0], val * rng[1]]
+def _get_range(brain):
+    import numpy as np
+    val = abs(brain._data['array'])
+    return [np.min(val), np.max(val)]

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -196,7 +196,6 @@ class _TimeViewer(object):
             rng=_get_range(fmin, scaling_limits), title="fmin",
             pointa=(0.82, 0.26),
             pointb=(0.98, 0.26),
-            event_type='always'
         )
         fmin_slider.name = "fmin"
         fmid = brain._data["fmid"]
@@ -211,7 +210,6 @@ class _TimeViewer(object):
             rng=_get_range(fmid, scaling_limits), title="fmid",
             pointa=(0.82, 0.42),
             pointb=(0.98, 0.42),
-            event_type='always'
         )
         fmid_slider.name = "fmid"
         fmax = brain._data["fmax"]
@@ -226,7 +224,6 @@ class _TimeViewer(object):
             rng=_get_range(fmax, scaling_limits), title="fmax",
             pointa=(0.82, 0.58),
             pointb=(0.98, 0.58),
-            event_type='always'
         )
         fmax_slider.name = "fmax"
         update_fscale = UpdateColorbarScale(

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -150,9 +150,10 @@ def test_brain_timeviewer(renderer):
 
     time_viewer = _TimeViewer(brain_data)
     time_viewer.set_smoothing(value=1)
-    time_viewer.update_fmax(value=11.0)
-    time_viewer.update_fmid(value=5.0)
-    time_viewer.update_fmin(value=0.0)
+    time_viewer.update_fmin(value=12.0)
+    time_viewer.update_fmax(value=4.0)
+    time_viewer.update_fmid(value=6.0)
+    time_viewer.update_fmid(value=4.0)
 
 
 def test_brain_colormap():

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -145,8 +145,8 @@ def test_brain_timeviewer(renderer):
 
     brain_data.set_data_smoothing(n_steps=1)
     brain_data.set_time_point(time_idx=0)
-    brain_data.update_fmax(fmax=1.0)
-    brain_data.update_fmid(fmid=0.5)
+    brain_data.update_fmax(fmax=11.0)
+    brain_data.update_fmid(fmid=5.0)
     brain_data.update_fmin(fmin=0.0)
 
     _TimeViewer(brain_data)

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -146,13 +146,13 @@ def test_brain_timeviewer(renderer):
                         colormap='hot', vertices=hemi_vertices,
                         colorbar=False, time=[0])
 
-    brain_data.set_data_smoothing(n_steps=1)
     brain_data.set_time_point(time_idx=0)
-    brain_data.update_fmax(fmax=11.0)
-    brain_data.update_fmid(fmid=5.0)
-    brain_data.update_fmin(fmin=0.0)
 
-    _TimeViewer(brain_data)
+    time_viewer = _TimeViewer(brain_data)
+    time_viewer.set_smoothing(value=1)
+    time_viewer.update_fmax(value=11.0)
+    time_viewer.update_fmid(value=5.0)
+    time_viewer.update_fmin(value=0.0)
 
 
 def test_brain_colormap():

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -8,9 +8,12 @@
 #
 # License: Simplified BSD
 
+import os.path as path
+
 import pytest
 import numpy as np
-import os.path as path
+from numpy.testing import assert_allclose
+
 from mne import read_source_estimate
 from mne.datasets import testing
 from mne.viz._brain import _Brain, _TimeViewer
@@ -166,3 +169,92 @@ def test_brain_colormap():
     colormap = cm.get_cmap(colormap)
     calculate_lut(colormap, alpha=alpha, fmin=fmin,
                   fmid=fmid, fmax=fmax, center=center)
+
+    cmap = cm.get_cmap(colormap)
+    zero_alpha = np.array([1., 1., 1., 0])
+    half_alpha = np.array([1., 1., 1., 0.5])
+    atol = 1.5 / 256.
+
+    # fmin < fmid < fmax
+    lut = calculate_lut(colormap, alpha, 1, 2, 3)
+    assert lut.shape == (256, 4)
+    assert_allclose(lut[0], cmap(0) * zero_alpha, atol=atol)
+    assert_allclose(lut[127], cmap(0.5), atol=atol)
+    assert_allclose(lut[-1], cmap(1.), atol=atol)
+    # divergent
+    lut = calculate_lut(colormap, alpha, 0, 1, 2, 0)
+    assert lut.shape == (256, 4)
+    assert_allclose(lut[0], cmap(0), atol=atol)
+    assert_allclose(lut[63], cmap(0.25), atol=atol)
+    assert_allclose(lut[127], cmap(0.5) * zero_alpha, atol=atol)
+    assert_allclose(lut[192], cmap(0.75), atol=atol)
+    assert_allclose(lut[-1], cmap(1.), atol=atol)
+
+    # fmin == fmid == fmax
+    lut = calculate_lut(colormap, alpha, 1, 1, 1)
+    zero_alpha = np.array([1., 1., 1., 0])
+    assert lut.shape == (256, 4)
+    assert_allclose(lut[0], cmap(0) * zero_alpha, atol=atol)
+    assert_allclose(lut[1], cmap(0.5), atol=atol)
+    assert_allclose(lut[-1], cmap(1.), atol=atol)
+    # divergent
+    lut = calculate_lut(colormap, alpha, 0, 0, 0, 0)
+    assert lut.shape == (256, 4)
+    assert_allclose(lut[0], cmap(0), atol=atol)
+    assert_allclose(lut[127], cmap(0.5) * zero_alpha, atol=atol)
+    assert_allclose(lut[-1], cmap(1.), atol=atol)
+
+    # fmin == fmid < fmax
+    lut = calculate_lut(colormap, alpha, 1, 1, 2)
+    assert lut.shape == (256, 4)
+    assert_allclose(lut[0], cmap(0.) * zero_alpha, atol=atol)
+    assert_allclose(lut[1], cmap(0.5), atol=atol)
+    assert_allclose(lut[-1], cmap(1.), atol=atol)
+    # divergent
+    lut = calculate_lut(colormap, alpha, 1, 1, 2, 0)
+    assert lut.shape == (256, 4)
+    assert_allclose(lut[0], cmap(0), atol=atol)
+    assert_allclose(lut[62], cmap(0.245), atol=atol)
+    assert_allclose(lut[64], cmap(0.5) * zero_alpha, atol=atol)
+    assert_allclose(lut[127], cmap(0.5) * zero_alpha, atol=atol)
+    assert_allclose(lut[191], cmap(0.5) * zero_alpha, atol=atol)
+    assert_allclose(lut[193], cmap(0.755), atol=atol)
+    assert_allclose(lut[-1], cmap(1.), atol=atol)
+    lut = calculate_lut(colormap, alpha, 0, 0, 1, 0)
+    assert lut.shape == (256, 4)
+    assert_allclose(lut[0], cmap(0), atol=atol)
+    assert_allclose(lut[126], cmap(0.25), atol=atol)
+    assert_allclose(lut[127], cmap(0.5) * zero_alpha, atol=atol)
+    assert_allclose(lut[129], cmap(0.75), atol=atol)
+    assert_allclose(lut[-1], cmap(1.), atol=atol)
+
+    # fmin < fmid == fmax
+    lut = calculate_lut(colormap, alpha, 1, 2, 2)
+    assert lut.shape == (256, 4)
+    assert_allclose(lut[0], cmap(0) * zero_alpha, atol=atol)
+    assert_allclose(lut[-2], cmap(0.5), atol=atol)
+    assert_allclose(lut[-1], cmap(1.), atol=atol)
+    # divergent
+    lut = calculate_lut(colormap, alpha, 1, 2, 2, 0)
+    assert lut.shape == (256, 4)
+    assert_allclose(lut[0], cmap(0), atol=atol)
+    assert_allclose(lut[1], cmap(0.25), atol=2 * atol)
+    assert_allclose(lut[32], cmap(0.375) * half_alpha, atol=atol)
+    assert_allclose(lut[64], cmap(0.5) * zero_alpha, atol=atol)
+    assert_allclose(lut[127], cmap(0.5) * zero_alpha, atol=atol)
+    assert_allclose(lut[191], cmap(0.5) * zero_alpha, atol=atol)
+    assert_allclose(lut[223], cmap(0.625) * half_alpha, atol=atol)
+    assert_allclose(lut[-2], cmap(0.7475), atol=2 * atol)
+    assert_allclose(lut[-1], cmap(1.), atol=2 * atol)
+    lut = calculate_lut(colormap, alpha, 0, 1, 1, 0)
+    assert lut.shape == (256, 4)
+    assert_allclose(lut[0], cmap(0), atol=atol)
+    assert_allclose(lut[1], cmap(0.25), atol=2 * atol)
+    assert_allclose(lut[64], cmap(0.375) * half_alpha, atol=atol)
+    assert_allclose(lut[127], cmap(0.5) * zero_alpha, atol=atol)
+    assert_allclose(lut[191], cmap(0.625) * half_alpha, atol=atol)
+    assert_allclose(lut[-2], cmap(0.75), atol=2 * atol)
+    assert_allclose(lut[-1], cmap(1.), atol=atol)
+
+    with pytest.raises(ValueError, match=r'.*fmin \(1\) <= fmid \(0\) <= fma'):
+        calculate_lut(colormap, alpha, 1, 0, 2)


### PR DESCRIPTION
This PR furthers the discussion around the control over the end points of the colorbar in `_TimeViewer` and offers a prototype that 'snaps back' the value when they reach the limits (idea coming from @agramfort).

Here is an animation:

![output](https://user-images.githubusercontent.com/18143289/72088031-b4d80680-3309-11ea-803c-33203282634c.gif)

what do you think @larsoner ? It's an alternative for the bumping of the values.

It's an item of #7162

---

**ToDo**
- [x] Set the limits of all three to be the same, min/max of the abs(data) (suggested in https://github.com/mne-tools/mne-python/pull/7188#issuecomment-572658131)
- [x] Rollback `event_type` to default (suggested in https://github.com/mne-tools/mne-python/pull/7188#issuecomment-572688662)