### PR TITLE
Support multiple TAL channels in BDF reader

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -174,6 +174,8 @@ Bug
 
 - Fix bug in :func:`mne.bem.make_watershed_bem` where some surfaces were saved incorrectly in the working directory by `Yu-Han Luo`_
 
+- Fix support for multiple TAL (annotations) channels in BDF reader by `Clemens Brunner`_
+
 API
 ~~~
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -284,7 +284,7 @@ def _read_segment_file(data, idx, fi, start, stop, raw_extras, chs, filenames):
                 # This now has size (n_chunks_read, n_samp[ci])
                 ch_data = many_chunk[:, ch_offsets[ci]:ch_offsets[ci + 1]]
 
-                if len(tal_idx) and ci == tal_idx[0]:
+                if len(tal_idx) and ci in tal_idx:
                     tal_data.append(ch_data)
                     continue
 


### PR DESCRIPTION
Fixes #7189.

It would be good to check that both the data and annotations are read correctly. There are 463 annotations, which seems to be correct even though SigViewer only reports 30 (but I think this is because SigViewer only uses the first annotation channel and ignores the rest).