### PR TITLE
MRG: Add support for smoothing_steps=0

### DIFF
--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -74,7 +74,7 @@ class _TimeViewer(object):
         smoothing_slider = self.plotter.add_slider_widget(
             set_smoothing,
             value=default_smoothing_value,
-            rng=[1, 15], title="smoothing",
+            rng=[0, 15], title="smoothing",
             pointa=(0.82, 0.90),
             pointb=(0.98, 0.90)
         )

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -85,7 +85,7 @@ def test_brain_add_data(renderer):
 
     brain_data.add_data(hemi_data, fmin=fmin, hemi=hemi, fmax=fmax,
                         colormap='hot', vertices=hemi_vertices,
-                        colorbar=False, time=None)
+                        smoothing_steps=0, colorbar=False, time=None)
     brain_data.add_data(hemi_data, fmin=fmin, hemi=hemi, fmax=fmax,
                         colormap='hot', vertices=hemi_vertices,
                         initial_time=0., colorbar=True, time=None)


### PR DESCRIPTION
This PR adds support for 'nearest' interpolation when the number of `smoothing_steps=0`.

Example with `plot_visualize_stc.py`:

smoothing_steps=0 | smoothing_steps=1 | smoothing_steps=10
------------------------|--------------------------|---------------------------
![2020-01-10_1920x1080](https://user-images.githubusercontent.com/18143289/72144248-89502d00-3398-11ea-8237-39fb028e64a7.png) | ![2020-01-10_1920x1080](https://user-images.githubusercontent.com/18143289/72144531-d8965d80-3398-11ea-902d-d41d8d5ee2d4.png) | ![2020-01-10_1920x1080](https://user-images.githubusercontent.com/18143289/72144273-94a35880-3398-11ea-9707-028227fb4c94.png)

It's an item of #7162