### PR TITLE
MRG+1, ENH: add border argument for topomap extrapolation

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -91,6 +91,8 @@ Changelog
 
 - Add function to convert events to annotations :func:`mne.annotations_from_events` by `Nicolas Barascud`_
 
+- Add ``border`` argument to :func:`mne.viz.plot_topomap`. ``border`` controls the value of the edge points to which topomap values are extrapolated. ``border='mean'`` sets these points value to the average of their neighbours. By `Mikołaj Magnuski`_
+
 Bug
 ~~~
 

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -334,7 +334,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                      proj=False, show=True, show_names=False, title=None,
                      mask=None, mask_params=None, outlines='head',
                      contours=6, image_interp='bilinear', average=None,
-                     head_pos=None, axes=None, extrapolate='box', sphere=None):
+                     head_pos=None, axes=None, extrapolate='box', sphere=None,
+                     border=0):
         return plot_evoked_topomap(
             self, times=times, ch_type=ch_type, layout=layout, vmin=vmin,
             vmax=vmax, cmap=cmap, sensors=sensors, colorbar=colorbar,
@@ -344,7 +345,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             show_names=show_names, title=title, mask=mask,
             mask_params=mask_params, outlines=outlines, contours=contours,
             image_interp=image_interp, average=average, head_pos=head_pos,
-            axes=axes, extrapolate=extrapolate, sphere=sphere)
+            axes=axes, extrapolate=extrapolate, sphere=sphere, border=border)
 
     @copy_function_doc_to_method_doc(plot_evoked_field)
     def plot_field(self, surf_maps, time=None, time_label='t = %0.0f ms',

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -38,7 +38,7 @@ class Projection(dict):
                      colorbar=False, res=64, size=1, show=True,
                      outlines='head', contours=6, image_interp='bilinear',
                      axes=None, vlim=(None, None), layout=None,
-                     sphere=None):
+                     sphere=None, border=0):
         """Plot topographic maps of SSP projections.
 
         Parameters
@@ -49,6 +49,7 @@ class Projection(dict):
             precedence.
         %(proj_topomap_kwargs)s
         %(topomap_sphere_auto)s
+        %(topomap_border)s
 
         Returns
         -------
@@ -63,7 +64,7 @@ class Projection(dict):
         return plot_projs_topomap(self, info, cmap, sensors, colorbar,
                                   res, size, show, outlines,
                                   contours, image_interp, axes, vlim, layout,
-                                  sphere=sphere)
+                                  sphere=sphere, border=border)
 
 
 class ProjMixin(object):
@@ -237,7 +238,8 @@ class ProjMixin(object):
                            sensors=True, colorbar=False, res=64, size=1,
                            show=True, outlines='head', contours=6,
                            image_interp='bilinear', axes=None,
-                           vlim=(None, None), sphere=None):
+                           vlim=(None, None), sphere=None, extrapolate='box',
+                           border=0):
         """Plot SSP vector.
 
         Parameters
@@ -251,6 +253,10 @@ class ProjMixin(object):
             Deprecated, do not use.
         %(proj_topomap_kwargs)s
         %(topomap_sphere_auto)s
+        %(topomap_extrapolate)s
+
+            .. versionadded:: 0.20
+        %(topomap_border)s
 
         Returns
         -------
@@ -259,13 +265,13 @@ class ProjMixin(object):
         """
         if self.info['projs'] is not None or len(self.info['projs']) != 0:
             from ..viz.topomap import plot_projs_topomap
-            fig = plot_projs_topomap(self.info['projs'], layout=layout,
-                                     cmap=cmap, sensors=sensors,
-                                     colorbar=colorbar, res=res, size=size,
-                                     show=show, outlines=outlines,
-                                     contours=contours,
+            fig = plot_projs_topomap(self.info['projs'], self.info, cmap=cmap,
+                                     sensors=sensors, colorbar=colorbar,
+                                     res=res, size=size, show=show,
+                                     outlines=outlines, contours=contours,
                                      image_interp=image_interp, axes=axes,
-                                     vlim=vlim, info=self.info)
+                                     vlim=vlim, sphere=sphere,
+                                     extrapolate=extrapolate, border=border)
         else:
             raise ValueError("Info is missing projs. Nothing to plot.")
         return fig

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -78,6 +78,13 @@ extrapolate : str
         Extrapolate to the edges of the head circle (does not work well
         with sensors outside the head circle).
 """
+docdict['topomap_border'] = """
+border : float | 'mean'
+    Value to extrapolate to on the topomap borders. If ``'mean'`` then each
+    extrapolated point has the average value of its neighbours.
+
+    .. versionadded:: 0.20
+"""
 docdict['topomap_head_pos'] = """
 head_pos : dict | None
     Deprecated and will be removed in 0.21. Use ``sphere`` instead.

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -190,7 +190,7 @@ def test_plot_topomap_basic():
     info_sel = pick_info(evoked.info, picks)
     plot_topomap(temp_data, info_sel, extrapolate='local', res=res)
     plot_topomap(temp_data, info_sel, extrapolate='head', res=res)
-    
+
     # border=0 and border='mean':
     # ---------------------------
     ch_names = list('abcde')
@@ -211,7 +211,8 @@ def test_plot_topomap_basic():
     assert np.abs(img_data[31, 1] - 5.) > 4
 
     # border='mean'
-    ax, _ = plot_topomap(data, info, extrapolate='head', border='mean', sphere=1)
+    ax, _ = plot_topomap(data, info, extrapolate='head', border='mean',
+                         sphere=1)
     img_data = ax.get_array().data
 
     assert np.abs(img_data[31, 31] - 5.) < 0.025

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -199,7 +199,7 @@ def test_plot_topomap_basic():
     ch_pos_dict = {name: pos for name, pos in zip(ch_names, ch_pos)}
     dig = make_dig_montage(ch_pos_dict, coord_frame='head')
 
-    data = np.ones(5) * 5
+    data = np.full(5, 5) + np.random.RandomState(23).randn(5)
     info = create_info(ch_names, 250, ['eeg'] * 5)
     info.set_montage(dig)
 
@@ -207,16 +207,16 @@ def test_plot_topomap_basic():
     ax, _ = plot_topomap(data, info, extrapolate='head', border=0, sphere=1)
     img_data = ax.get_array().data
 
-    assert np.abs(img_data[31, 31] - 5.) < 0.025
-    assert np.abs(img_data[31, 1] - 5.) > 4
+    assert np.abs(img_data[31, 31] - data[0]) < 0.12
+    assert np.abs(img_data[31, 1]) < 0.1
 
     # border='mean'
     ax, _ = plot_topomap(data, info, extrapolate='head', border='mean',
                          sphere=1)
     img_data = ax.get_array().data
 
-    assert np.abs(img_data[31, 31] - 5.) < 0.025
-    assert np.abs(img_data[31, 1] - 5.) < 0.025
+    assert np.abs(img_data[31, 31] - data[0]) < 0.12
+    assert img_data[31, 31] > 5
 
     # other:
     # ------

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -218,6 +218,16 @@ def test_plot_topomap_basic():
     assert np.abs(img_data[31, 31] - data[0]) < 0.12
     assert img_data[31, 31] > 5
 
+    # error when not numeric or str:
+    error_msg = 'border must be an instance of numeric or str'
+    with pytest.raises(TypeError, match=error_msg):
+        plot_topomap(data, info, extrapolate='head', border=[1, 2, 3])
+
+    # error when str is not 'mean':
+    error_msg = 'border must be numeric or "mean", got \'fancy\''
+    with pytest.raises(ValueError, match=error_msg):
+        plot_topomap(data, info, extrapolate='head', border='fancy')
+
     # other:
     # ------
     plt_topomap = partial(evoked.plot_topomap, **fast_test)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -224,6 +224,7 @@ def plot_projs_topomap(projs, info, cmap=None, sensors=True,
     %(topomap_extrapolate)s
 
         .. versionadded:: 0.20
+    %(topomap_border)s
 
     Returns
     -------
@@ -668,9 +669,7 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
 
         .. versionadded:: 0.18
     %(topomap_sphere)s
-    border : float | 'mean'
-        Value to extrapolate to on the topomap borders. If ``'mean'`` then
-        each extrapolated point has the average value of its neighbours.
+    %(topomap_border)s
 
     Returns
     -------

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -549,7 +549,7 @@ class _GridData(object):
 
         if isinstance(self.border, str):
             if self.border != 'mean':
-                msg = 'border must be numeric or "mean", got %r'
+                msg = 'border must be numeric or "mean", got {!r}'
                 raise ValueError(msg.format(self.border))
             # border = 'mean'
             n_points = v.shape[0]

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -549,7 +549,8 @@ class _GridData(object):
 
         if isinstance(self.border, str):
             if self.border != 'mean':
-                raise ValueError('border must be numeric or "mean", got %r' % (self.border,))
+                msg = 'border must be numeric or "mean", got %r'
+                raise ValueError(msg.format(self.border))
             # border = 'mean'
             n_points = v.shape[0]
             v_extra = np.zeros(self.n_extra)
@@ -892,7 +893,7 @@ def _plot_ica_topomap(ica, idx=0, ch_type=None, res=64, layout=None,
                       title=None, show=True, outlines='head', contours=6,
                       image_interp='bilinear', head_pos=None, axes=None,
                       sensors=True, allow_ref_meg=False, extrapolate='box',
-                      sphere=None):
+                      sphere=None, border=0):
     """Plot single ica map to axes."""
     from matplotlib.axes import Axes
 
@@ -923,7 +924,7 @@ def _plot_ica_topomap(ica, idx=0, ch_type=None, res=64, layout=None,
         data.ravel(), pos, vmin=vmin_, vmax=vmax_, res=res, axes=axes,
         cmap=cmap, outlines=outlines, contours=contours, sensors=sensors,
         image_interp=image_interp, show=show, extrapolate=extrapolate,
-        head_pos=head_pos, sphere=sphere)[0]
+        head_pos=head_pos, sphere=sphere, border=border)[0]
     if colorbar:
         cbar, cax = _add_colorbar(axes, im, cmap, pad=.05, title="AU",
                                   format='%3.2f')
@@ -1366,8 +1367,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
                         show=True, show_names=False, title=None, mask=None,
                         mask_params=None, outlines='head', contours=6,
                         image_interp='bilinear', average=None, head_pos=None,
-                        axes=None, extrapolate='box',
-                        sphere=None):
+                        axes=None, extrapolate='box', sphere=None, border=0):
     """Plot topographic maps of specific time points of evoked data.
 
     Parameters
@@ -1490,6 +1490,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
 
         .. versionadded:: 0.18
     %(topomap_sphere_auto)s
+    %(topomap_border)s
 
     Returns
     -------
@@ -1643,7 +1644,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
                   show_names=show_names, cmap=cmap[0], mask_params=mask_params,
                   outlines=outlines, contours=contours, head_pos=head_pos,
                   image_interp=image_interp, show=False,
-                  extrapolate=extrapolate, sphere=sphere)
+                  extrapolate=extrapolate, sphere=sphere, border=border)
     for idx, time in enumerate(times):
         tp, cn, interp = _plot_topomap(
             data[:, idx], pos, axes=axes[idx],


### PR DESCRIPTION
#### Reference issue
Continuation of [topomap extrapolation pull request](GH-5754).

#### What does this implement/fix?
This adds a `border` argument to `mne.viz.plot_topomap` that allows to change the values set to extrapolation points. The default is zero, just as before, but `'mean'` allows to extrapolate to mean of channels that are neighbours to given extrapolation point. See the example below:
![image](https://user-images.githubusercontent.com/8452354/72207309-54c39a80-3498-11ea-8ac6-63e5d7babf13.png)

(I know, I will have to fix the channel positions after the recent changes to plot_topomap channel position handling)

`border='mean'` is especially useful when plotting log-power (and setting `vmin`, `vmax`):
![image](https://user-images.githubusercontent.com/8452354/72219724-5305df80-3549-11ea-88cf-b9dde21be55e.png)


This is a draft at this point, but feel free to comment.

#### TODOs:
- [x] add tests
- [x] `%()s` docs
- [x] expose `border` in other topomap functions?