### PR TITLE
Eeglab reader: look for fdt if EEG.data file name is wrong

### DIFF
--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -44,8 +44,9 @@ def _check_fname(fname, dataname):
         fdt_from_set_fname = op.splitext(fname)[0] + '.fdt'
         if op.exists(fdt_from_set_fname):
             data_fname = fdt_from_set_fname
-            msg = ('Data filename in EEG.data ({}) is incorrect, using the '
-                   'correct file name ({}).')
+            msg = ('Data file name in EEG.data ({}) is incorrect, the file '
+                   'name must have changed on disk, using the correct file '
+                   'name ({}).')
             warn(msg.format(dataname, op.basename(fdt_from_set_fname)))
         elif not data_fname == fdt_from_set_fname:
             msg = 'Could not find the .fdt data file, tried {} and {}.'

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -39,12 +39,12 @@ def _check_fname(fname, dataname):
     if not op.exists(data_fname):
         fdt_from_set_fname = op.join(op.splitext(fname)[0], '.fdt')
         if op.exists(fdt_from_set_fname):
-            fname = fdt_from_set_fname
+            data_fname = fdt_from_set_fname
             msg = ('Data filename in EEG.data ({}) is incorrect, using the '
                    'correct file name ({}).')
             warn(msg.format(dataname, op.basename(fdt_from_set_fname)))
         # else raise error?
-    return fname
+    return data_fname
 
 
 def _check_load_mat(fname, uint16_codec):

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -27,8 +27,8 @@ def _check_fname(fname, dataname):
     """Check whether the filename is valid.
 
     Check if the file extension is ``.fdt`` (older ``.dat`` being invalid) or
-    whether the ``EEG.data`` filename exists. If ``EEG.data`` file is absent the
-    set file name with .set changed to .fdt is checked.
+    whether the ``EEG.data`` filename exists. If ``EEG.data`` file is absent
+    the set file name with .set changed to .fdt is checked.
     """
     fmt = str(op.splitext(dataname)[-1])
     if fmt == '.dat':

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -47,7 +47,9 @@ def _check_fname(fname, dataname):
             msg = ('Data filename in EEG.data ({}) is incorrect, using the '
                    'correct file name ({}).')
             warn(msg.format(dataname, op.basename(fdt_from_set_fname)))
-        # else raise error?
+        elif not data_fname == fdt_from_set_fname:
+            msg = 'Could not find the .fdt data file, tried {} and {}.'
+            raise FileNotFoundError(msg.format(data_fname, fdt_from_set_fname))
     return data_fname
 
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -23,15 +23,28 @@ from ...annotations import Annotations, read_annotations
 CAL = 1e-6
 
 
-def _check_fname(fname):
-    """Check if the file extension is valid."""
-    fmt = str(op.splitext(fname)[-1])
+def _check_fname(fname, dataname):
+    """Check if the file extension is valid or whether the filename
+    is valid."""
+    fmt = str(op.splitext(dataname)[-1])
     if fmt == '.dat':
         raise NotImplementedError(
             'Old data format .dat detected. Please update your EEGLAB '
             'version and resave the data in .fdt format')
     elif fmt != '.fdt':
         raise IOError('Expected .fdt file format. Found %s format' % fmt)
+
+    basedir = op.dirname(fname)
+    data_fname = op.join(basedir, dataname)
+    if not op.exists(data_fname):
+        fdt_from_set_fname = op.join(op.splitext(fname)[0], '.fdt')
+        if op.exists(fdt_from_set_fname):
+            fname = fdt_from_set_fname
+            msg = ('Data filename in EEG.data ({}) is incorrect, using the '
+                   'correct file name ({}).')
+            warn(msg.format(dataname, op.basename(fdt_from_set_fname)))
+        # else raise error?
+    return fname
 
 
 def _check_load_mat(fname, uint16_codec):
@@ -279,7 +292,6 @@ class RawEEGLAB(BaseRaw):
     @verbose
     def __init__(self, input_fname, eog=(),
                  preload=False, uint16_codec=None, verbose=None):  # noqa: D102
-        basedir = op.dirname(input_fname)
         eeg = _check_load_mat(input_fname, uint16_codec)
         if eeg.trials != 1:
             raise TypeError('The number of trials is %d. It must be 1 for raw'
@@ -291,8 +303,7 @@ class RawEEGLAB(BaseRaw):
 
         # read the data
         if isinstance(eeg.data, str):
-            data_fname = op.join(basedir, eeg.data)
-            _check_fname(data_fname)
+            data_fname = _check_fname(input_fname, eeg.data)
             logger.info('Reading %s' % data_fname)
 
             super(RawEEGLAB, self).__init__(
@@ -542,9 +553,7 @@ class EpochsEEGLAB(BaseEpochs):
                                  '(event id %i)' % (key, val))
 
         if isinstance(eeg.data, str):
-            basedir = op.dirname(input_fname)
-            data_fname = op.join(basedir, eeg.data)
-            _check_fname(data_fname)
+            data_fname = _check_fname(input_fname, eeg.data)
             with open(data_fname, 'rb') as data_fid:
                 data = np.fromfile(data_fid, dtype=np.float32)
                 data = data.reshape((eeg.nbchan, eeg.pnts, eeg.trials),

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -24,8 +24,12 @@ CAL = 1e-6
 
 
 def _check_fname(fname, dataname):
-    """Check if the file extension is valid or whether the filename
-    is valid."""
+    """Check whether the filename is valid.
+
+    Check if the file extension is ``.fdt`` (older ``.dat`` being invalid) or
+    whether the ``EEG.data`` filename exists. If ``EEG.data`` file is absent the
+    set file name with .set changed to .fdt is checked.
+    """
     fmt = str(op.splitext(dataname)[-1])
     if fmt == '.dat':
         raise NotImplementedError(
@@ -37,7 +41,7 @@ def _check_fname(fname, dataname):
     basedir = op.dirname(fname)
     data_fname = op.join(basedir, dataname)
     if not op.exists(data_fname):
-        fdt_from_set_fname = op.join(op.splitext(fname)[0], '.fdt')
+        fdt_from_set_fname = op.splitext(fname)[0] + '.fdt'
         if op.exists(fdt_from_set_fname):
             data_fname = fdt_from_set_fname
             msg = ('Data filename in EEG.data ({}) is incorrect, using the '

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -136,7 +136,7 @@ def test_io_set_raw_more(tmpdir):
                         'event': [eeg.event[0], eeg.event[0]],
                         'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}},
                appendmat=False, oned_as='row')
-    with pytest.warns(RuntimeWarning, match="is incorrect, using the"):
+    with pytest.warns(RuntimeWarning, match="must have changed on disk"):
         read_raw_eeglab(input_fname=overlap_fname, preload=True)
 
     # raise error when both EEG.data and fdt name from set are wrong

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -83,11 +83,10 @@ def test_io_set_raw(fname):
 def test_io_set_raw_more(tmpdir):
     """Test importing EEGLAB .set files."""
     tmpdir = str(tmpdir)
-    # test reading file with one event (read old version)
     eeg = io.loadmat(raw_fname_mat, struct_as_record=False,
                      squeeze_me=True)['EEG']
 
-    # test negative event latencies
+    # test reading file with one event (read old version)
     negative_latency_fname = op.join(tmpdir, 'test_negative_latency.set')
     evnts = deepcopy(eeg.event[0])
     evnts.latency = 0
@@ -103,6 +102,7 @@ def test_io_set_raw_more(tmpdir):
     with pytest.warns(RuntimeWarning, match="has a sample index of -1."):
         read_raw_eeglab(input_fname=negative_latency_fname, preload=True)
 
+    # test negative event latencies
     evnts.latency = -1
     io.savemat(negative_latency_fname,
                {'EEG': {'trials': eeg.trials, 'srate': eeg.srate,
@@ -126,6 +126,7 @@ def test_io_set_raw_more(tmpdir):
                appendmat=False, oned_as='row')
     shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
                     overlap_fname.replace('.set', '.fdt'))
+    read_raw_eeglab(input_fname=overlap_fname, preload=True)
 
     # test reading file when the EEG.data name is wrong
     io.savemat(overlap_fname,

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -139,6 +139,18 @@ def test_io_set_raw_more(tmpdir):
     with pytest.warns(RuntimeWarning, match="is incorrect, using the"):
         read_raw_eeglab(input_fname=overlap_fname, preload=True)
 
+    # raise error when both EEG.data and fdt name from set are wrong
+    overlap_fname = 'test_ovrlap_event.set'
+    io.savemat(overlap_fname,
+               {'EEG': {'trials': eeg.trials, 'srate': eeg.srate,
+                        'nbchan': eeg.nbchan, 'data': 'test_overla_event.fdt',
+                        'epoch': eeg.epoch,
+                        'event': [eeg.event[0], eeg.event[0]],
+                        'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}},
+               appendmat=False, oned_as='row')
+    with pytest.raises(FileNotFoundError, match="not find the .fdt data file"):
+        read_raw_eeglab(input_fname=overlap_fname, preload=True)
+
     # test reading file with one channel
     one_chan_fname = op.join(tmpdir, 'test_one_channel.set')
     io.savemat(one_chan_fname,

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -140,7 +140,7 @@ def test_io_set_raw_more(tmpdir):
         read_raw_eeglab(input_fname=overlap_fname, preload=True)
 
     # raise error when both EEG.data and fdt name from set are wrong
-    overlap_fname = 'test_ovrlap_event.set'
+    overlap_fname = op.join(tmpdir, 'test_ovrlap_event.set')
     io.savemat(overlap_fname,
                {'EEG': {'trials': eeg.trials, 'srate': eeg.srate,
                         'nbchan': eeg.nbchan, 'data': 'test_overla_event.fdt',

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -127,6 +127,17 @@ def test_io_set_raw_more(tmpdir):
     shutil.copyfile(op.join(base_dir, 'test_raw.fdt'),
                     overlap_fname.replace('.set', '.fdt'))
 
+    # test reading file when the EEG.data name is wrong
+    io.savemat(overlap_fname,
+               {'EEG': {'trials': eeg.trials, 'srate': eeg.srate,
+                        'nbchan': eeg.nbchan, 'data': 'test_overla_event.fdt',
+                        'epoch': eeg.epoch,
+                        'event': [eeg.event[0], eeg.event[0]],
+                        'chanlocs': eeg.chanlocs, 'pnts': eeg.pnts}},
+               appendmat=False, oned_as='row')
+    with pytest.warns(RuntimeWarning, match="is incorrect, using the"):
+        read_raw_eeglab(input_fname=overlap_fname, preload=True)
+
     # test reading file with one channel
     one_chan_fname = op.join(tmpdir, 'test_one_channel.set')
     io.savemat(one_chan_fname,


### PR DESCRIPTION
#### Reference issue
Fixes #7192

#### What does this implement/fix?
When `EEG.data` file name is wrong (the file is not present) an additional check is performed: set file name is used replacing ".set" with ".fdt". This is a common problem when set files are renamed in the operating system and not via eeglab (which also changes `EEG.data`).
