### PR TITLE
RF: Ignore `mri_dir` returned by `bem._prepare_env()`

### DIFF
--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1090,8 +1090,7 @@ def make_watershed_bem(subject, subjects_dir=None, overwrite=False,
     .. versionadded:: 0.10
     """
     from .viz.misc import plot_bem
-    env, mri_dir = _prepare_env(subject, subjects_dir,
-                                requires_freesurfer=True)[:2]
+    env = _prepare_env(subject, subjects_dir, requires_freesurfer=True)[0]
     tempdir = _TempDir()  # fsl and Freesurfer create some random junk in CWD
     run_subprocess_env = partial(run_subprocess, env=env,
                                  cwd=tempdir)


### PR DESCRIPTION
#### What does this implement/fix?
`bem.make_watershed_bem()` calls `_prepare_env()`, which returns a tuple of 3 values; of those, 2 are currently assigned to variables. However, the second one, `mri_dir`, is then overwritten again just a few lines further down without ever getting used:

https://github.com/mne-tools/mne-python/blob/9d512217cf367f0b71d69602c91839dfd96298cf/mne/bem.py#L1093-L1101

This PR drops the first, unused assignment of `mri_dir`.
