### PR TITLE
WIP: Speed up non-3D tests

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -107,8 +107,6 @@ def matplotlib_config():
         pass
     else:
         ETSConfig.toolkit = 'qt4'
-    from mne.viz.backends.renderer import _enable_3d_backend_testing
-    _enable_3d_backend_testing()
 
 
 def _replace(mod, key):
@@ -195,6 +193,8 @@ def renderer(backend_name):
     """Yield the 3D backends."""
     from mne.viz.backends.renderer import _use_test_3d_backend
     from mne.viz.backends.tests._utils import has_mayavi, has_pyvista
+    from mne.viz.backends.renderer import _enable_3d_backend_testing
+    _enable_3d_backend_testing()
     if backend_name == 'mayavi':
         if not has_mayavi():
             pytest.skip("Test skipped, requires mayavi.")


### PR DESCRIPTION
I've noticed that, even if an individual test is fast, doing:
```
pytest mne/tests/test_... -k ...
```
will take some seconds. This is because, at least on my laptop, I get:
```
$ time pytest mne/utils/tests/test_bunch.py 
Test session starts (platform: darwin, Python 3.7.3, pytest 5.2.0, pytest-sugar 0.9.2)
rootdir: /Users/larsoner/python/mne-python, inifile: setup.cfg
plugins: astropy-header-0.1.1, arraydiff-0.3, sugar-0.9.2, remotedata-0.3.2, timeout-1.3.3, openfiles-0.4.0, mock-1.11.0, cov-2.7.1, doctestplus-0.5.0
collecting ... 
 mne/utils/tests/test_bunch.py ✓                                                                                                                                     100% ██████████
----------------------------------------------------- generated xml file: /Users/larsoner/python/mne-python/junit-results.xml ------------------------------------------------------
============================================================================ slowest 20 test durations =============================================================================
2.12s setup    mne/utils/tests/test_bunch.py::test_pickle

(0.00 durations hidden.  Use -vv to show these durations.)

Results (2.15s):
       1 passed

real	0m4.822s
```
On this PR I get:
```
$ time pytest mne/utils/tests/test_bunch.py 
... 
 mne/utils/tests/test_bunch.py ✓                                                                                                                                     100% ██████████
----------------------------------------------------- generated xml file: /Users/larsoner/python/mne-python/junit-results.xml ------------------------------------------------------
============================================================================ slowest 20 test durations =============================================================================
0.22s setup    mne/utils/tests/test_bunch.py::test_pickle

(0.00 durations hidden.  Use -vv to show these durations.)

Results (0.26s):
       1 passed

real	0m2.276s
```
@GuillaumeFavelier would you be up for taking over and ensuring that all tests that require the 3D backends make use of this? For example not everything uses `renderer`, such as `test_plot_vec_source_estimates`, so we might need to create some new fixture and pass it to those tests until they do. If it's not clear or you are not enthusiastic about doing it I can give it a shot.

This 2 sec overhead may seem trivial, but when doing TDD and iterating in code it gets annoying, so whatever we can do to get good speed gains is beneficial in the long run.