### PR TITLE
MRG: Add support for playback in time_viewer

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -830,8 +830,9 @@ class _Brain(object):
                             act_data = act_data[:, time_idx]
                         else:
                             times = np.arange(self._n_times)
-                    act_data = interp1d(times, act_data, 'linear', axis=1,
-                                        assume_sorted=True)(time_idx)
+                            act_data = interp1d(
+                                times, act_data, 'linear', axis=1,
+                                assume_sorted=True)(time_idx)
 
                     adj_mat = mesh_edges(self.geo[hemi].faces)
                     smooth_mat = smoothing_matrix(vertices,
@@ -870,12 +871,13 @@ class _Brain(object):
                     act_data = smooth_mat.dot(act_data)
                 _set_mesh_scalars(pd, act_data, 'Data')
                 if callable(time_label) and time_actor is not None:
-                    if isinstance(time_idx, float):
-                        ifunc = interp1d(times, self._data['time'])
-                        time = ifunc(time_idx)
-                        time_actor.SetInput(time_label(time))
+                    if isinstance(time_idx, int):
+                        self._current_time = time[time_idx]
+                        time_actor.SetInput(time_label(self._current_time))
                     else:
-                        time_actor.SetInput(time_label(time[time_idx]))
+                        ifunc = interp1d(times, self._data['time'])
+                        self._current_time = ifunc(time_idx)
+                        time_actor.SetInput(time_label(self._current_time))
                 self._data['time_idx'] = time_idx
 
     def update_fmax(self, fmax):

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -816,6 +816,7 @@ class _Brain(object):
             Number of smoothing steps
         """
         from ..backends._pyvista import _set_mesh_scalars
+        from scipy.interpolate import interp1d
         for hemi in ['lh', 'rh']:
             pd = self._data.get(hemi + '_mesh')
             if pd is not None:
@@ -823,10 +824,14 @@ class _Brain(object):
                 vertices = self._data[hemi + '_vertices']
                 if pd is not None:
                     time_idx = self._data['time_idx']
-                    if self._data['array'].ndim == 1:
-                        act_data = array
-                    elif self._data['array'].ndim == 2:
-                        act_data = array[:, time_idx]
+                    act_data = array
+                    if self._data['array'].ndim == 2:
+                        if isinstance(time_idx, int):
+                            act_data = act_data[:, time_idx]
+                        else:
+                            times = np.arange(self._n_times)
+                    act_data = interp1d(times, act_data, 'linear', axis=1,
+                                        assume_sorted=True)(time_idx)
 
                     adj_mat = mesh_edges(self.geo[hemi].faces)
                     smooth_mat = smoothing_matrix(vertices,
@@ -839,7 +844,7 @@ class _Brain(object):
     def set_time_point(self, time_idx):
         """Set the time point shown."""
         from ..backends._pyvista import _set_mesh_scalars
-        time_idx = int(time_idx)
+        from scipy.interpolate import interp1d
         for hemi in ['lh', 'rh']:
             pd = self._data.get(hemi + '_mesh')
             if pd is not None:
@@ -855,13 +860,22 @@ class _Brain(object):
 
                 if isinstance(time_idx, int):
                     act_data = act_data[:, time_idx]
+                else:
+                    times = np.arange(self._n_times)
+                    act_data = interp1d(times, act_data, 'linear', axis=1,
+                                        assume_sorted=True)(time_idx)
 
                 smooth_mat = self._data[hemi + '_smooth_mat']
                 if smooth_mat is not None:
                     act_data = smooth_mat.dot(act_data)
                 _set_mesh_scalars(pd, act_data, 'Data')
                 if callable(time_label) and time_actor is not None:
-                    time_actor.SetInput(time_label(time[time_idx]))
+                    if isinstance(time_idx, float):
+                        ifunc = interp1d(times, self._data['time'])
+                        time = ifunc(time_idx)
+                        time_actor.SetInput(time_label(time))
+                    else:
+                        time_actor.SetInput(time_label(time[time_idx]))
                 self._data['time_idx'] = time_idx
 
     def update_fmax(self, fmax):

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -960,6 +960,9 @@ class _Brain(object):
                     scalar_bar = None
                 _set_colormap_range(actor, ctable, scalar_bar, rng)
                 self._data['ctable'] = ctable
+        self._data['fmin'] = fmin
+        self._data['fmid'] = fmid
+        self._data['fmax'] = fmax
 
     @property
     def data(self):

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -37,9 +37,9 @@ class UpdateColorbarScale(object):
     def __call__(self, value):
         """Update the colorbar sliders."""
         self.brain.update_fscale(value)
-        fmin = self.brain._data['fmin'] * value
-        fmid = self.brain._data['fmid'] * value
-        fmax = self.brain._data['fmax'] * value
+        fmin = self.brain._data['fmin']
+        fmid = self.brain._data['fmid']
+        fmax = self.brain._data['fmax']
         for slider in self.plotter.slider_widgets:
             name = getattr(slider, "name", None)
             if name == "fmin":
@@ -51,6 +51,9 @@ class UpdateColorbarScale(object):
             elif name == "fmax":
                 slider_rep = slider.GetRepresentation()
                 slider_rep.SetValue(fmax)
+            elif name == "fscale":
+                slider_rep = slider.GetRepresentation()
+                slider_rep.SetValue(1.0)
 
 
 class BumpColorbarPoints(object):
@@ -244,6 +247,7 @@ class _TimeViewer(object):
             pointa=(0.82, 0.10),
             pointb=(0.98, 0.10)
         )
+        fscale_slider.name = "fscale"
 
         # add toggle to start/stop playback
         self.playback = False

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -334,12 +334,18 @@ class _TimeViewer(object):
         self.playback_speed = speed
 
     def play(self):
+        from scipy.interpolate import interp1d
         if self.playback:
             self.time_elapsed += self.refresh_rate
             if self.time_elapsed >= self.playback_speed * 10:
                 times = self.brain._data['time']
                 time_idx = self.brain._data['time_idx']
-                time = times[time_idx] + 1. / self.playback_speed
+                if isinstance(time_idx, float):
+                    ifunc = interp1d(times, times)
+                    time = ifunc(time_idx)
+                else:
+                    time = times[time_idx]
+                time = time + 1. / self.playback_speed
                 idx = np.argmin(np.abs(times - time))
 
                 max_time = len(self.brain._data['time'])

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -179,19 +179,13 @@ class _TimeViewer(object):
 
         # playback speed
         default_playback_speed = 1
-        self.set_playback_speed = IntSlider(
-            plotter=self.plotter,
-            callback=self.set_playback_speed,
-            name="playback_speed"
-        )
         playback_speed_slider = self.plotter.add_slider_widget(
             self.set_playback_speed,
             value=default_playback_speed,
-            rng=[1, 100], title="playback speed",
+            rng=[0.01, 1], title="playback speed",
             pointa=(0.02, 0.1),
             pointb=(0.18, 0.1)
         )
-        playback_speed_slider.name = "playback_speed"
 
         # colormap slider
         scaling_limits = [0.2, 2.0]
@@ -338,7 +332,7 @@ class _TimeViewer(object):
         if self.playback:
             time_data = self.brain._data['time']
             times = np.arange(self.brain._n_times)
-            time_shift = self.refresh_rate_ms / self.playback_speed
+            time_shift = self.refresh_rate_ms * self.playback_speed
             time_point = self.brain._current_time + time_shift
             if time_point < np.max(time_data):
                 ifunc = interp1d(time_data, times)

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -255,7 +255,6 @@ class _TimeViewer(object):
         # add toggle to start/stop playback
         self.playback = False
         self.playback_speed = default_playback_speed
-        self.time_elapsed = 0
         self.refresh_rate_ms = max(int(round(1000. / 60.)), 1)
         self.plotter.add_callback(self.play, self.refresh_rate_ms)
         self.plotter.add_key_event('space', self.toggle_playback)

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -236,12 +236,12 @@ class _TimeViewer(object):
             event_type="always",
         )
         fmax_slider.name = "fmax"
-        update_fscale = UpdateColorbarScale(
+        self.update_fscale = UpdateColorbarScale(
             plotter=self.plotter,
             brain=brain,
         )
         fscale_slider = self.plotter.add_slider_widget(
-            update_fscale,
+            self.update_fscale,
             value=1.0,
             rng=scaling_limits, title="fscale",
             pointa=(0.82, 0.10),

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -338,15 +338,12 @@ class _TimeViewer(object):
         if self.playback:
             self.time_elapsed += self.refresh_rate
             if self.time_elapsed >= self.playback_speed * 10:
-                times = self.brain._data['time']
+                time_data = self.brain._data['time']
                 time_idx = self.brain._data['time_idx']
-                if isinstance(time_idx, float):
-                    ifunc = interp1d(times, times)
-                    time = ifunc(time_idx)
-                else:
-                    time = times[time_idx]
-                time = time + 1. / self.playback_speed
-                idx = np.argmin(np.abs(times - time))
+                times = np.arange(self.brain._n_times)
+                ifunc = interp1d(times, time_data)
+                time_point = ifunc(time_idx) + 1. / self.playback_speed
+                idx = np.argmin(np.abs(time_data - time_point))
 
                 max_time = len(self.brain._data['time'])
                 if time_idx < max_time:

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -317,13 +317,6 @@ class _TimeViewer(object):
                 slider.On()
             else:
                 slider.Off()
-        for button in self.plotter.button_widgets:
-            name = getattr(button, "name", None)
-            if name != "toggle_interface":
-                if self.visibility:
-                    button.On()
-                else:
-                    button.Off()
         if self.visibility:
             self.interface_actor.SetInput("Hide")
         else:

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -5,7 +5,6 @@
 # License: Simplified BSD
 
 import time
-import warnings
 import numpy as np
 
 
@@ -119,7 +118,7 @@ class _TimeViewer(object):
             scalar_bar.SetOrientationToVertical()
             scalar_bar.SetHeight(0.6)
             scalar_bar.SetWidth(0.05)
-            scalar_bar.SetPosition(0.02, 0.35)
+            scalar_bar.SetPosition(0.02, 0.2)
 
         # smoothing slider
         default_smoothing_value = 7
@@ -253,40 +252,11 @@ class _TimeViewer(object):
         self.refresh_rate = 16
         self.refresh_rate_ms = self.refresh_rate / 1000.
         self.plotter.add_callback(self.play, self.refresh_rate)
-        self.plotter.add_callback(self.perform_maintenance)
-        self.button_size = 40
-        self.font_size = 14
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=FutureWarning)
-            playback_button = self.plotter.add_checkbox_button_widget(
-                self.toggle_playback,
-                value=False,
-                size=self.button_size,
-                position=(0, 0)
-            )
-        playback_button.name = "toggle_playback"
-        self.playback_actor = self.plotter.add_text(
-            text="Start",
-            font_size=self.font_size,
-            position=(0, 0)
-        )
+        self.plotter.add_key_event('space', self.toggle_playback)
 
         # add toggle to show/hide interface
         self.visibility = True
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=FutureWarning)
-            interface_button = self.plotter.add_checkbox_button_widget(
-                self.toggle_interface,
-                value=True,
-                size=self.button_size,
-                position=(0, 0)
-            )
-        interface_button.name = "toggle_interface"
-        self.interface_actor = self.plotter.add_text(
-            text="Hide",
-            font_size=self.font_size,
-            position=(0, 0)
-        )
+        self.plotter.add_key_event('y', self.toggle_interface)
 
         # set the slider style
         _set_slider_style(smoothing_slider)
@@ -300,29 +270,17 @@ class _TimeViewer(object):
 
         # set the text style
         _set_text_style(self.time_actor)
-        _set_text_style(self.playback_actor)
-        _set_text_style(self.interface_actor)
 
-        self.perform_maintenance()
-
-    def toggle_interface(self, state):
-        self.visibility = state
+    def toggle_interface(self):
+        self.visibility = not self.visibility
         for slider in self.plotter.slider_widgets:
             if self.visibility:
                 slider.On()
             else:
                 slider.Off()
-        if self.visibility:
-            self.interface_actor.SetInput("Hide")
-        else:
-            self.interface_actor.SetInput("Show")
 
-    def toggle_playback(self, state):
-        self.playback = state
-        if self.playback:
-            self.playback_actor.SetInput("Stop")
-        else:
-            self.playback_actor.SetInput("Start")
+    def toggle_playback(self):
+        self.playback = not self.playback
 
     def set_playback_speed(self, speed):
         self.playback_speed = speed
@@ -344,46 +302,7 @@ class _TimeViewer(object):
                         slider_rep = slider.GetRepresentation()
                         slider_rep.SetValue(idx)
             else:
-                self.toggle_playback(False)
-                for button in self.plotter.button_widgets:
-                    name = getattr(button, "name", None)
-                    if name == "toggle_playback":
-                        button_rep = button.GetRepresentation()
-                        button_rep.SetState(0)
-
-    def place_widget(self, position):
-        if hasattr(self.plotter, 'ren_win'):
-            window_size = self.plotter.ren_win.GetSize()
-            position = (
-                position[0] * window_size[0],
-                position[1] * window_size[1]
-            )
-        return position
-
-    def set_bounds(self, position):
-        bounds = [
-            position[0], position[0] + self.button_size,
-            position[1], position[1] + self.button_size,
-            0., 0.
-        ]
-        return bounds
-
-    def perform_maintenance(self):
-        for button in self.plotter.button_widgets:
-            name = getattr(button, "name", None)
-            if name == "toggle_playback":
-                button_rep = button.GetRepresentation()
-                position = self.place_widget((0.02, 0.17))
-                bounds = self.set_bounds(position)
-                button_rep.PlaceWidget(bounds)
-            elif name == "toggle_interface":
-                button_rep = button.GetRepresentation()
-                position = self.place_widget((0.02, 0.27))
-                bounds = self.set_bounds(position)
-                button_rep.PlaceWidget(bounds)
-
-        self.playback_actor.SetPosition(self.place_widget((0.06, 0.17)))
-        self.interface_actor.SetPosition(self.place_widget((0.06, 0.27)))
+                self.playback = False
 
 
 def _set_slider_style(slider, show_label=True):

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -138,6 +138,7 @@ class _Renderer(_BaseRenderer):
 
             self.plotter = self.figure.build()
             self.plotter.hide_axes()
+            self.plotter.disable_depth_peeling()
 
     def subplot(self, x, y):
         with warnings.catch_warnings():


### PR DESCRIPTION
This PR adds basic support for brain/time playback in `_TimeViewer`. It's still a work in progress since for now only a simple call to `set_time_point()` is done every second with an increment of `playback_speed`. I had to modify the UI as well to make room for this new slider. Playback is started/stopped with the shortcut `t`.

**ToDo**
- [x] Support time dilation
- [x] Use space for playback shortcut
- [x] Snap `fscale` back to 1
- [x] Improve coverage

It's an item of #7162

---

**Screenshot**

![2020-01-13_1920x1080](https://user-images.githubusercontent.com/18143289/72259342-819abd80-3610-11ea-9583-fa2dc8adfc2b.png)

**Animation**

![output](https://user-images.githubusercontent.com/18143289/72259601-2d440d80-3611-11ea-96f3-9ba4aca42dd2.gif)
*(`t` is pressed twice to start and stop the playback)*