### PR TITLE
MAINT: Simplify CI installation of PyQt5 dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,10 +61,10 @@ jobs:
 
         # https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
         # https://github.com/golemfactory/golem/issues/1019
-        # run:
-        #   name: Fix libgcc_s.so.1 pthread_cancel bug
-        #   command: |
-        #     sudo apt-get install qt5-default
+        - run:
+            name: Install PyQt5 dependencies
+            command: |
+              sudo apt-get install libxkbcommon-x11-0
 
         - run:
             name: Install graphviz and fonts needed for diagrams
@@ -93,7 +93,7 @@ jobs:
             name: Check installation
             command: |
                which python
-               mne sys_info
+               QT_DEBUG_PLUGINS=1 mne sys_info
                LIBGL_DEBUG=verbose python -c "from mayavi import mlab; import matplotlib.pyplot as plt; mlab.figure(); plt.figure()"
                python -c "import mne; mne.set_config('MNE_USE_CUDA', 'false')"  # this is needed for the config tutorial
                python -c "import mne; mne.set_config('MNE_LOGGING_LEVEL', 'info')"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,10 +61,10 @@ jobs:
 
         # https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
         # https://github.com/golemfactory/golem/issues/1019
-        - run:
-            name: Fix libgcc_s.so.1 pthread_cancel bug
-            command: |
-              sudo apt-get install qt5-default
+        # run:
+        #   name: Fix libgcc_s.so.1 pthread_cancel bug
+        #   command: |
+        #     sudo apt-get install qt5-default
 
         - run:
             name: Install graphviz and fonts needed for diagrams

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
-language: c
+language: generic
 dist: xenial
 cache:
-  apt: true
   pip: true
+addons:
+  apt:
+    packages:
+      - libxkbcommon-x11-0
 env:
     # TRAVIS_PYTHON_VERSION is only needed for neo's setup.py
     # OPENBLAS_NUM_THREADS=1 avoid slowdowns:
@@ -26,10 +29,7 @@ matrix:
           env: MNE_STIM_CHANNEL=STI101
           language: python
           python: "3.7"
-          addons:
-            apt:
-              packages:
-                - qt5-default  # Qt 5.12 release needs this to avoid a missing library bug
+
         # Old dependencies
         - os: linux
           env: PYTHON_VERSION=3.5


### PR DESCRIPTION
Want this to fail on CircleCI so that I can then try an interactive SSH session and iteratively install packages to see what's actually needed rather than getting all of `qt5-default`.