### PR TITLE
MRG, FIX, ENH: overhaul to_data_frame method

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -116,6 +116,8 @@ Bug
 
 - Fix missing xlabel for :func:`mne.io.Raw.plot_psd` and similar functions when passing a subset of axes from a figure by `Alex Gramfort`_
 
+- Fix wrong DataFrame index when ``index=None`` in methods :meth:`mne.io.Raw.to_data_frame`, :meth:`mne.Epochs.to_data_frame`, :meth:`mne.Evoked.to_data_frame`, and :meth:`mne.SourceEstimate.to_data_frame`, by `Daniel McCloy`_.
+
 - Fix incorrect scaling of cluster temporal extent in :func:`mne.stats.summarize_clusters_stc` by `Daniel McCloy`_.
 
 - Fix :func:`mne.viz.plot_sensors` to always plot in head coordinate frame by `Daniel McCloy`_.
@@ -222,6 +224,8 @@ API
 ~~~
 
 - :meth:`mne.Epochs.plot` now accepts an ``event_id`` parameter (useful in tandem with ``event_colors`` for specifying event colors by name) by `Daniel McCloy`_.
+
+- New time conversion options for methods :meth:`mne.io.Raw.to_data_frame`, :meth:`mne.Epochs.to_data_frame`, :meth:`mne.Evoked.to_data_frame`, and :meth:`mne.SourceEstimate.to_data_frame`, by `Daniel McCloy`_.
 
 - :meth:`mne.Epochs.shift_time` and :meth:`mne.Evoked.shift_time` now allow shifting times by arbitrary amounts (previously only by integer multiples of the sampling period), by `Daniel McCloy`_ and `Eric Larson`_.
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1719,8 +1719,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
 
         Parameters
         ----------
-        index : str | list of str | None
-            %(df_index_epo)s
+        %(df_index_epo)s
             Valid string values are 'time', 'epoch', and 'condition'.
             Defaults to ``None``.
         %(df_time_format)s

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -624,8 +624,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         Parameters
         ----------
-        index : 'time' | None
-            %(df_index_evk)s
+        %(df_index_evk)s
             Defaults to ``None``.
         %(df_time_format)s
         %(picks_all)s

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -72,10 +72,14 @@ class ToDataFrameMixin(object):
         Parameters
         ----------
         %(picks_all)s
-        index : tuple of str | None
-            Column to be used as index for the data. Valid string options
-            are 'epoch', 'time' and 'condition'. If None, all three info
-            columns will be included in the table as categorial data.
+        index : str | list of str | None
+            Specifies how to index the DataFrame. Valid string options are
+            'epoch', 'time' and 'condition'. If a list of strings is provided,
+            they will be used to create a :class:`pandas.MultiIndex` with
+            levels occurring in the order given. If ``None``, a sequential
+            integer index (:class:`pandas.RangeIndex`) will be used, and
+            'condition', 'epoch' and 'time' will be included in the DataFrame
+            as columns.
         scaling_time : float
             Scaling to be applied to time units.
         scalings : dict | None

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1666,10 +1666,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         ----------
         %(df_index_raw)s
             Defaults to ``None``.
-        %(df_time_format)s
-            If ``'datetime'``, time values will be converted to
-            :class:`pandas.Timestamp` values, relative to
-            ``raw.info['meas_date']`` and offset by ``raw.first_samp``.
+        %(df_time_format_raw)s
         %(picks_all)s
         start : int | None
             Starting sample index for creating the DataFrame from a temporal

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -79,7 +79,11 @@ class ToDataFrameMixin(object):
             levels occurring in the order given. If ``None``, a sequential
             integer index (:class:`pandas.RangeIndex`) will be used, and
             'condition', 'epoch' and 'time' will be included in the DataFrame
-            as columns.
+            as columns. If 'time' is included in the index, it will be
+            converted to :class:`pandas.DatetimeIndex` (for
+            :class:`~mne.io.Raw` objects) or :class:`pandas.TimedeltaIndex`
+            (for :class:`~mne.Epochs`, :class:`~mne.Evoked`, or
+            :class:`~mne.SourceEstimate` objects).
         scaling_time : float
             Scaling to be applied to time units.
         scalings : dict | None

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1664,12 +1664,11 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         Parameters
         ----------
-        index : 'time' | None
-            %(df_index_raw)s
+        %(df_index_raw)s
             Defaults to ``None``.
         %(df_time_format)s
             If ``'datetime'``, time values will be converted to
-            :class:`pandas.Datetime` values, relative to
+            :class:`pandas.Timestamp` values, relative to
             ``raw.info['meas_date']`` and offset by ``raw.first_samp``.
         %(picks_all)s
         start : int | None

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -208,7 +208,7 @@ class ToDataFrameMixin(object):
             if 'time' in index and not long_format:
                 _set_pandas_dtype(df, ['time'], np.int64)
             df.set_index(index, inplace=True)
-            if all(i in default_index for i in index):
+            if all(i in index for i in default_index):
                 if isinstance(self, _BaseSourceEstimate):
                     df.columns.name = 'source'
                 else:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -195,8 +195,6 @@ class ToDataFrameMixin(object):
 
         if index is not None:
             _check_pandas_index_arguments(index, default_index)
-        else:
-            index = default_index
 
         if copy is True:
             data = data.copy()
@@ -210,11 +208,11 @@ class ToDataFrameMixin(object):
             if 'time' in index and not long_format:
                 _set_pandas_dtype(df, ['time'], np.int64)
             df.set_index(index, inplace=True)
-        if all(i in default_index for i in index):
-            if isinstance(self, _BaseSourceEstimate):
-                df.columns.name = 'source'
-            else:
-                df.columns.name = 'channel'
+            if all(i in default_index for i in index):
+                if isinstance(self, _BaseSourceEstimate):
+                    df.columns.name = 'source'
+                else:
+                    df.columns.name = 'channel'
 
         if long_format:
             df = df.stack().reset_index()

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -197,18 +197,18 @@ def test_find_events_backward_compatibility():
 @pytest.mark.parametrize('fname', [edf_path, bdf_path])
 def test_to_data_frame(fname):
     """Test EDF/BDF Raw Pandas exporter."""
-    ext = op.splitext(fname)[1][1:].lower()
+    ext = op.splitext(fname)[1].lstrip('.').lower()
     if ext == 'edf':
         raw = read_raw_edf(fname, preload=True, verbose='error')
     elif ext == 'bdf':
         raw = read_raw_bdf(fname, preload=True, verbose='error')
     _, times = raw[0, :10]
-    df = raw.to_data_frame()
+    df = raw.to_data_frame(index='time')
     assert (df.columns == raw.ch_names).all()
     assert_array_equal(np.round(times * 1e3), df.index.values[:10])
     df = raw.to_data_frame(index=None, scalings={'eeg': 1e13})
-    assert 'time' in df.index.names
-    assert_array_equal(df.values[:, 0], raw._data[0] * 1e13)
+    assert 'time' in df.columns
+    assert_array_equal(df.values[:, 1], raw._data[0] * 1e13)
 
 
 def test_read_raw_edf_stim_channel_input_parameters():

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1158,11 +1158,24 @@ def test_to_data_frame():
     assert ('time' in df.columns)
     assert_array_equal(df.values[:, 1], raw._data[0] * 1e13)
     assert_array_equal(df.values[:, 3], raw._data[2] * 1e15)
-
+    # test long format
     df_long = raw.to_data_frame(long_format=True)
     assert(len(df_long) == raw.get_data().size)
     expected = ('time', 'channel', 'ch_type', 'value')
     assert set(expected) == set(df_long.columns)
+
+
+@requires_pandas
+@pytest.mark.parametrize('time_format', (None, 'ms', 'timedelta', 'datetime'))
+def test_to_data_frame_time_format(time_format):
+    """Test time conversion in epochs Pandas exporter."""
+    from pandas import Timedelta, Timestamp
+    raw = read_raw_fif(test_fif_fname, preload=True)
+    # test time_format
+    df = raw.to_data_frame(time_format=time_format)
+    dtypes = {None: np.float64, 'ms': np.int64, 'timedelta': Timedelta,
+              'datetime': Timestamp}
+    assert isinstance(df['time'].iloc[0], dtypes[time_format])
 
 
 def test_add_channels():

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1149,6 +1149,7 @@ def test_raw_copy():
 @requires_pandas
 def test_to_data_frame():
     """Test raw Pandas exporter."""
+    from pandas import Timedelta
     raw = read_raw_fif(test_fif_fname, preload=True)
     _, times = raw[0, :10]
     df = raw.to_data_frame(index='time')
@@ -1163,6 +1164,14 @@ def test_to_data_frame():
     assert(len(df_long) == raw.get_data().size)
     expected = ('time', 'channel', 'ch_type', 'value')
     assert set(expected) == set(df_long.columns)
+    # test bad time format
+    with pytest.raises(ValueError, match='not a valid time format. Valid'):
+        raw.to_data_frame(time_format='foo')
+    # test time format error handling
+    raw.set_meas_date(None)
+    with pytest.warns(RuntimeWarning, match='Cannot convert to Datetime when'):
+        df = raw.to_data_frame(time_format='datetime')
+    assert isinstance(df['time'].iloc[0], Timedelta)
 
 
 @requires_pandas

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1151,20 +1151,18 @@ def test_to_data_frame():
     """Test raw Pandas exporter."""
     raw = read_raw_fif(test_fif_fname, preload=True)
     _, times = raw[0, :10]
-    df = raw.to_data_frame()
+    df = raw.to_data_frame(index='time')
     assert ((df.columns == raw.ch_names).all())
     assert_array_equal(np.round(times * 1e3), df.index.values[:10])
     df = raw.to_data_frame(index=None)
-    assert ('time' in df.index.names)
-    assert_array_equal(df.values[:, 0], raw._data[0] * 1e13)
-    assert_array_equal(df.values[:, 2], raw._data[2] * 1e15)
+    assert ('time' in df.columns)
+    assert_array_equal(df.values[:, 1], raw._data[0] * 1e13)
+    assert_array_equal(df.values[:, 3], raw._data[2] * 1e15)
 
-    df = raw.to_data_frame(long_format=True)
-    assert(len(df) == raw.get_data().size)
-    assert("time" in df.columns)
-    assert("channel" in df.columns)
-    assert("ch_type" in df.columns)
-    assert("observation" in df.columns)
+    df_long = raw.to_data_frame(long_format=True)
+    assert(len(df_long) == raw.get_data().size)
+    expected = ('time', 'channel', 'ch_type', 'value')
+    assert set(expected) == set(df_long.columns)
 
 
 def test_add_channels():

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1142,7 +1142,7 @@ class _BaseSourceEstimate(TimeMixin):
         # check pandas once here, instead of in each private utils function
         pd = _check_pandas_installed()  # noqa
         # arg checking
-        valid_index_args = ['time']
+        valid_index_args = ['time', 'subject']
         valid_time_formats = ['ms', 'timedelta']
         index = _check_pandas_index_arguments(index, valid_index_args)
         time_format = _check_time_format(time_format, valid_time_formats)

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1129,8 +1129,7 @@ class _BaseSourceEstimate(TimeMixin):
 
         Parameters
         ----------
-        index : 'time' | None
-            %(df_index_evk)s
+        %(df_index_evk)s
             Defaults to ``None``.
         %(df_time_format)s
         %(df_scalings)s

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1746,9 +1746,11 @@ def test_to_data_frame():
         epochs.to_data_frame(index='qux')
     with pytest.raises(TypeError, match='index must be `None` or a string or'):
         epochs.to_data_frame(np.arange(400))
-    # test wide and long formats
+    # test wide format
     df_wide = epochs.to_data_frame()
     assert all(np.in1d(epochs.ch_names, df_wide.columns))
+    assert all(np.in1d(['time', 'epoch', 'condition'], df_wide.columns))
+    # test long format
     df_long = epochs.to_data_frame(long_format=True)
     expected = ('condition', 'epoch', 'time', 'channel', 'ch_type', 'value')
     assert set(expected) == set(df_long.columns)

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1756,6 +1756,8 @@ def test_to_data_frame():
     assert set(expected) == set(df_long.columns)
     assert set(epochs.ch_names) == set(df_long['channel'])
     assert(len(df_long) == epochs.get_data().size)
+    # test long format w/ index
+    df_long = epochs.to_data_frame(long_format=True, index=['epoch'])
     del df_wide, df_long
     # test scalings
     df = epochs.to_data_frame(index=['condition', 'epoch', 'time'])

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1764,15 +1764,17 @@ def test_to_data_frame():
 
 @requires_pandas
 @pytest.mark.parametrize('index', ('time', ['condition', 'time', 'epoch'],
-                                   ['epoch', 'time'], ['time', 'epoch']))
+                                   ['epoch', 'time'], ['time', 'epoch'], None))
 def test_to_data_frame_index(index):
     """Test index creation in epochs Pandas exporter."""
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events, {'a': 1, 'b': 2}, tmin, tmax, picks=picks)
     df = epochs.to_data_frame(picks=[11, 12, 14], index=index)
     # test index order/heirarchy preservation
+    if not isinstance(index, list):
+        index = [index]
     assert (df.index.names == index)
-    # test that non-indexed data were present as categorial variables
+    # test that non-indexed data were present as columns
     non_index = list(set(['condition', 'time', 'epoch']) - set(index))
     if len(non_index):
         assert all(np.in1d(non_index, df.columns))

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1772,7 +1772,7 @@ def test_to_data_frame_index(index):
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events, {'a': 1, 'b': 2}, tmin, tmax, picks=picks)
     df = epochs.to_data_frame(picks=[11, 12, 14], index=index)
-    # test index order/heirarchy preservation
+    # test index order/hierarchy preservation
     if not isinstance(index, list):
         index = [index]
     assert (df.index.names == index)

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -15,7 +15,7 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_channels_spatial_filter, _check_one_ch_type,
                     _check_rank, _check_option, _check_depth, _check_combine,
                     _check_path_like, _check_src_normal, _check_stc_units,
-                    _check_pyqt5_version, _check_sphere)
+                    _check_pyqt5_version, _check_sphere, _check_time_format)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,
@@ -59,3 +59,5 @@ from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
                     _prepare_write_metadata, _FakeNoPandas, ShiftTimeMixin)
 from .linalg import (_svd_lwork, _repeated_svd,
                      dgesdd, dgemm, zgemm, dgemv, ddot, LinAlgError, eigh)
+from .dataframe import (_set_pandas_dtype, _scale_dataframe_data,
+                        _convert_times, _build_data_frame)

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -245,13 +245,13 @@ def _check_pandas_installed(strict=True):
 
 def _check_pandas_index_arguments(index, defaults):
     """Check pandas index arguments."""
-    if not any(isinstance(index, k) for k in (list, tuple)):
+    if isinstance(index, str):
         index = [index]
-    invalid_choices = [e for e in index if e not in defaults]
+    invalid_choices = set(index) - set(defaults)
     if invalid_choices:
         options = [', '.join(e) for e in [invalid_choices, defaults]]
-        raise ValueError('[%s] is not an valid option. Valid index'
-                         'values are \'None\' or %s' % tuple(options))
+        raise ValueError('"%s" is not an valid option. Valid index '
+                         'values are `None` or %s' % tuple(options))
 
 
 def _check_ch_locs(chs):

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -249,12 +249,16 @@ def _check_pandas_index_arguments(index, valid):
         return
     if isinstance(index, str):
         index = [index]
+    if not isinstance(index, list):
+        raise TypeError('index must be `None` or a string or list of strings,'
+                        ' got type {}.'.format(type(index)))
     invalid = set(index) - set(valid)
     if invalid:
         plural = ('is not a valid option',
                   'are not valid options')[int(len(invalid) > 1)]
-        raise ValueError('"{}" {}. Valid index options are `None`, {}'
-                         .format(', '.join(invalid), plural, ', '.join(valid)))
+        raise ValueError('"{}" {}. Valid index options are `None`, "{}".'
+                         .format('", "'.join(invalid), plural,
+                                 '", "'.join(valid)))
     return index
 
 

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -243,15 +243,33 @@ def _check_pandas_installed(strict=True):
             return False
 
 
-def _check_pandas_index_arguments(index, defaults):
+def _check_pandas_index_arguments(index, valid):
     """Check pandas index arguments."""
+    if index is None:
+        return
     if isinstance(index, str):
         index = [index]
-    invalid_choices = set(index) - set(defaults)
-    if invalid_choices:
-        options = [', '.join(e) for e in [invalid_choices, defaults]]
-        raise ValueError('"%s" is not an valid option. Valid index '
-                         'values are `None` or %s' % tuple(options))
+    invalid = set(index) - set(valid)
+    if invalid:
+        plural = ('is not a valid option',
+                  'are not valid options')[int(len(invalid) > 1)]
+        raise ValueError('"{}" {}. Valid index options are `None`, {}'
+                         .format(', '.join(invalid), plural, ', '.join(valid)))
+    return index
+
+
+def _check_time_format(time_format, valid, meas_date=None):
+    """Check time_format argument."""
+    if time_format not in valid and time_format is not None:
+        valid_str = '", "'.join(valid)
+        raise ValueError('"{}" is not a valid time format. Valid options are '
+                         '"{}" and None.'.format(time_format, valid_str))
+    # allow datetime only if meas_date available
+    if time_format == 'datetime' and meas_date is None:
+        warn("Cannot convert to Datetime when raw.info['meas_date'] is "
+             "None. Falling back to Timedelta.")
+        time_format = 'timedelta'
+    return time_format
 
 
 def _check_ch_locs(chs):

--- a/mne/utils/dataframe.py
+++ b/mne/utils/dataframe.py
@@ -37,7 +37,7 @@ def _convert_times(inst, times, time_format):
     # private function; pandas already checked in calling function
     from pandas import to_timedelta
     if time_format == 'ms':
-        times = np.round(times * 1e3).astype(int)
+        times = np.round(times * 1e3).astype(np.int64)
     elif time_format == 'timedelta':
         times = to_timedelta(times, unit='s')
     elif time_format == 'datetime':

--- a/mne/utils/dataframe.py
+++ b/mne/utils/dataframe.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""inst.to_data_frame() helper functions."""
+# Authors: Daniel McCloy <dan@mccloy.info>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+
+from ._logging import logger
+from ..defaults import _handle_default
+
+
+def _set_pandas_dtype(df, columns, dtype):
+    """Try to set the right columns to dtype."""
+    for column in columns:
+        df[column] = df[column].astype(dtype)
+        logger.info('Converting "%s" to "%s"...' % (column, dtype))
+
+
+def _scale_dataframe_data(inst, data, picks, scalings):
+    ch_types = inst.get_channel_types()
+    ch_types_used = list()
+    scalings = _handle_default('scalings', scalings)
+    for tt in scalings.keys():
+        if tt in ch_types:
+            ch_types_used.append(tt)
+    for tt in ch_types_used:
+        scaling = scalings[tt]
+        idx = [ii for ii in range(len(picks)) if ch_types[ii] == tt]
+        if len(idx):
+            data[:, idx] *= scaling
+    return data
+
+
+def _convert_times(inst, times, time_format):
+    """Convert vector of time in seconds to ms, datetime, or timedelta."""
+    # private function; pandas already checked in calling function
+    from pandas import to_timedelta
+    if time_format == 'ms':
+        times = np.round(times * 1e3).astype(int)
+    elif time_format == 'timedelta':
+        times = to_timedelta(times, unit='s')
+    elif time_format == 'datetime':
+        times = (to_timedelta(times + inst.first_time, unit='s') +
+                 inst.info['meas_date'])
+    return times
+
+
+def _build_data_frame(inst, data, picks, long_format, mindex, index,
+                      default_index, col_names=None, col_kind='channel'):
+    """Build DataFrame from MNE-object-derived data array."""
+    # private function; pandas already checked in calling function
+    from pandas import DataFrame
+    from ..source_estimate import _BaseSourceEstimate
+    # build DataFrame
+    if col_names is None:
+        col_names = [inst.ch_names[p] for p in picks]
+    df = DataFrame(data, columns=col_names)
+    for i, (k, v) in enumerate(mindex):
+        df.insert(i, k, v)
+    # build Index
+    if long_format:
+        df.set_index(default_index, inplace=True)
+        df.columns.name = col_kind
+    elif index is not None:
+        df.set_index(index, inplace=True)
+        if set(index) == set(default_index):
+            df.columns.name = col_kind
+    # long format
+    if long_format:
+        df = df.stack().reset_index()
+        df.rename(columns={0: 'value'}, inplace=True)
+        # add column for channel types (as appropriate)
+        ch_map = (None if isinstance(inst, _BaseSourceEstimate) else
+                  dict(zip(np.array(inst.ch_names)[picks],
+                           np.array(inst.get_channel_types())[picks])))
+        if ch_map is not None:
+            col_index = len(df.columns) - 1
+            ch_type = df['channel'].map(ch_map)
+            df.insert(col_index, 'ch_type', ch_type)
+        # restore index
+        if index is not None:
+            df.set_index(index, inplace=True)
+        # convert channel/vertex/ch_type columns to factors
+        to_factor = [c for c in df.columns.tolist()
+                     if c not in ('time', 'value')]
+        _set_pandas_dtype(df, to_factor, 'category')
+    return df

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -579,16 +579,16 @@ docdict['df_index'] = """
 index : {} | None
     Kind of index to use for the DataFrame. If ``None``, a sequential
     integer index (:class:`pandas.RangeIndex`) will be used. If ``'time'``, a
-    :class:`pandas.Float64Index`, :class:`pandas.Int64Index`, {} will be used
+    :class:`pandas.Float64Index`, :class:`pandas.Int64Index`, {}or
+    :class:`pandas.TimedeltaIndex` will be used
     (depending on the value of ``time_format``). {}
 """
-datetime = ':class:`pandas.TimedeltaIndex`, or :class:`pandas.DatetimeIndex`'
-no_datetime = 'or :class:`pandas.TimedeltaIndex`'
+datetime = ':class:`pandas.DatetimeIndex`, '
 multiindex = ('If a list of two or more string values, a '
               ':class:`pandas.MultiIndex` will be created. ')
 raw = ("'time'", datetime, '')
-epo = ('str | list of str', no_datetime, multiindex)
-evk = ("'time'", no_datetime, '')
+epo = ('str | list of str', '', multiindex)
+evk = ("'time'", '', '')
 docdict['df_index_raw'] = docdict['df_index'].format(*raw)
 docdict['df_index_epo'] = docdict['df_index'].format(*epo)
 docdict['df_index_evk'] = docdict['df_index'].format(*evk)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -576,6 +576,7 @@ transparent : bool | None
 """
 # DataFrames
 docdict['df_index'] = """
+index : {} | None
     Kind of index to use for the DataFrame. If ``None``, a sequential
     integer index (:class:`pandas.RangeIndex`) will be used. If ``'time'``, a
     :class:`pandas.Float64Index`, :class:`pandas.Int64Index`, {} will be used
@@ -585,9 +586,9 @@ datetime = ':class:`pandas.TimedeltaIndex`, or :class:`pandas.DatetimeIndex`'
 no_datetime = 'or :class:`pandas.TimedeltaIndex`'
 multiindex = ('If a list of two or more string values, a '
               ':class:`pandas.MultiIndex` will be created. ')
-raw = (datetime, '')
-epo = (no_datetime, multiindex)
-evk = (no_datetime, '')
+raw = ("'time'", datetime, '')
+epo = ('str | list of str', no_datetime, multiindex)
+evk = ("'time'", no_datetime, '')
 docdict['df_index_raw'] = docdict['df_index'].format(*raw)
 docdict['df_index_epo'] = docdict['df_index'].format(*epo)
 docdict['df_index_evk'] = docdict['df_index'].format(*evk)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -574,6 +574,61 @@ transparent : bool | None
     If True, use a linear transparency between fmin and fmid.
     None will choose automatically based on colormap type.
 """
+# DataFrames
+docdict['df_index'] = """
+    Kind of index to use for the DataFrame. If ``None``, a sequential
+    integer index (:class:`pandas.RangeIndex`) will be used. If ``'time'``, a
+    :class:`pandas.Float64Index`, :class:`pandas.Int64Index`, {} will be used
+    (depending on the value of ``time_format``). {}
+"""
+datetime = ':class:`pandas.TimedeltaIndex`, or :class:`pandas.DatetimeIndex`'
+no_datetime = 'or :class:`pandas.TimedeltaIndex`'
+multiindex = ('If a list of two or more string values, a '
+              ':class:`pandas.MultiIndex` will be created. ')
+raw = (datetime, '')
+epo = (no_datetime, multiindex)
+evk = (no_datetime, '')
+docdict['df_index_raw'] = docdict['df_index'].format(*raw)
+docdict['df_index_epo'] = docdict['df_index'].format(*epo)
+docdict['df_index_evk'] = docdict['df_index'].format(*evk)
+docdict['df_time_format'] = """
+time_format : str
+    Desired time format. If ``None``, no conversion is applied, and time values
+    remain as float values in seconds. If ``'ms'``, time values will be rounded
+    to the nearest millisecond and converted to integers. If ``'timedelta'``,
+    time values will be converted to :class:`pandas.Timedelta` values. Defaults
+    to ``'ms'``.
+"""
+docdict['df_scalings'] = """
+scalings : dict | None
+    Scaling factor applied to the channels picked. If ``None``, defaults to
+    ``dict(eeg=1e6, mag=1e15, grad=1e13)`` — i.e., converts EEG to μV,
+    magnetometers to fT, and gradiometers to fT/cm.
+"""
+docdict['df_copy'] = """
+copy : bool
+    If ``True``, data will be copied. Otherwise data may be modified in place.
+    Defaults to ``True``.
+"""
+docdict['df_longform'] = """
+long_format : bool
+    If True, the DataFrame is returned in long format where each row is one
+    observation of the signal at a unique combination of time point{}.
+    {}Defaults to ``False``.
+"""
+ch_type = ('For convenience, a ``ch_type`` column is added to facilitate '
+           'subsetting the resulting DataFrame. ')
+raw = (' and channel', ch_type)
+epo = (', channel, epoch number, and condition', ch_type)
+stc = (' and vertex', '')
+docdict['df_longform_raw'] = docdict['df_longform'].format(*raw)
+docdict['df_longform_epo'] = docdict['df_longform'].format(*epo)
+docdict['df_longform_stc'] = docdict['df_longform'].format(*stc)
+docdict['df_return'] = """
+df : instance of pandas.DataFrame
+    A dataframe suitable for usage with other statistical/plotting/analysis
+    packages.
+"""
 
 # Finalize
 docdict = unindent_dict(docdict)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -593,7 +593,7 @@ docdict['df_index_raw'] = docdict['df_index'].format(*raw)
 docdict['df_index_epo'] = docdict['df_index'].format(*epo)
 docdict['df_index_evk'] = docdict['df_index'].format(*evk)
 docdict['df_time_format'] = """
-time_format : str
+time_format : str | None
     Desired time format. If ``None``, no conversion is applied, and time values
     remain as float values in seconds. If ``'ms'``, time values will be rounded
     to the nearest millisecond and converted to integers. If ``'timedelta'``,

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -592,14 +592,19 @@ evk = ("'time'", '', '')
 docdict['df_index_raw'] = docdict['df_index'].format(*raw)
 docdict['df_index_epo'] = docdict['df_index'].format(*epo)
 docdict['df_index_evk'] = docdict['df_index'].format(*evk)
-docdict['df_time_format'] = """
+docdict['df_tf'] = """
 time_format : str | None
     Desired time format. If ``None``, no conversion is applied, and time values
     remain as float values in seconds. If ``'ms'``, time values will be rounded
     to the nearest millisecond and converted to integers. If ``'timedelta'``,
-    time values will be converted to :class:`pandas.Timedelta` values. Defaults
-    to ``'ms'``.
+    time values will be converted to :class:`pandas.Timedelta` values. {}
+    Defaults to ``'ms'``.
 """
+raw_tf = ("If ``'datetime'``, time values will be converted to "
+          ":class:`pandas.Timestamp` values, relative to "
+          "``raw.info['meas_date']`` and offset by ``raw.first_samp``. ")
+docdict['df_time_format_raw'] = docdict['df_tf'].format(raw_tf)
+docdict['df_time_format'] = docdict['df_tf'].format('')
 docdict['df_scalings'] = """
 scalings : dict | None
     Scaling factor applied to the channels picked. If ``None``, defaults to


### PR DESCRIPTION
closes #7179 

- [x] minor refactor of `_check_pandas_index_arguments`
- [x] fix `to_data_frame()` docstring re: tuples vs lists
- [x] make `index=None` work as described
- [x] fix logic when setting title of columns
- [x] provide different options for time conversion: keep as float, or convert to integer milliseconds, pd.Timedelta, or (raw only) pd.Timestamp
- [x] make the datetime/timedelta change work with `long_format=True`
- [x] improve tests

cc @jona-sassenhagen @dengemann @choldgraf @larsoner @agramfort 