### PR TITLE
Disable depth peeling by default

### DIFF
--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -138,6 +138,7 @@ class _Renderer(_BaseRenderer):
 
             self.plotter = self.figure.build()
             self.plotter.hide_axes()
+            self.plotter.disable_depth_peeling()
 
     def subplot(self, x, y):
         with warnings.catch_warnings():


### PR DESCRIPTION
This is follow-up of https://github.com/pyvista/pyvista/pull/529#issuecomment-574076243 and disables depth peeling by default. It can still be enabled locally if needed depending on the use cases.