### PR TITLE
MRG: Add support for auto_scaling in time_viewer

### DIFF
--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1680,6 +1680,7 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
 
     time_label, times = _handle_time(time_label, time_unit, stc.times)
     # convert control points to locations in colormap
+    user_colormap = colormap  # save the original colormap
     colormap, scale_pts, diverging, transparent, _ = _limits_to_control_points(
         clim, stc.data, colormap, transparent)
 
@@ -1722,6 +1723,8 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
                 kwargs["fmin"] = scale_pts[0]
                 kwargs["fmid"] = scale_pts[1]
                 kwargs["fmax"] = scale_pts[2]
+                kwargs["clim"] = clim
+                kwargs["user_colormap"] = user_colormap
             with warnings.catch_warnings(record=True):  # traits warnings
                 brain.add_data(**kwargs)
     if time_viewer:

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -10,6 +10,7 @@
 import numpy as np
 import os
 from os.path import join as pjoin
+from .._3d import _limits_to_control_points
 from ...label import read_label
 from .colormap import calculate_lut
 from .view import lh_views_dict, rh_views_dict, View
@@ -935,6 +936,49 @@ class _Brain(object):
             actor = self._data.get(hemi + '_actor')
             if actor is not None:
                 center = self._data['center']
+                dt_max = fmax
+                dt_min = fmin if center is None else -1 * fmax
+                rng = [dt_min, dt_max]
+                if self._colorbar_added:
+                    scalar_bar = self._renderer.plotter.scalar_bar
+                else:
+                    scalar_bar = None
+                _set_colormap_range(actor, ctable, scalar_bar, rng)
+                self._data['ctable'] = ctable
+
+    def update_auto_scaling(self, state):
+        from ..backends._pyvista import _set_colormap_range
+        if not hasattr(self, '_backup'):
+            self._backup = self._data.copy()
+        if state:
+            clim = 'auto'
+            colormap = self._data['colormap']
+            transparent = self._data['transparent']
+            time_idx = self._data['time_idx']
+            array = self._data['array']
+            if self._data['array'].ndim == 1:
+                act_data = array
+            elif self._data['array'].ndim == 2:
+                act_data = array[:, time_idx]
+            colormap, scale_pts, diverging, transparent, _ = \
+                _limits_to_control_points(clim, act_data, colormap,
+                                          transparent)
+            fmin, fmid, fmax = scale_pts
+            center = 0. if diverging else None
+            self._data['center'] = center
+            self._data['colormap'] = colormap
+            self._data['transparent'] = transparent
+        else:
+            self._data.update(self._backup)
+            center = self._data['center']
+            fmin = self._data['fmin']
+            fmid = self._data['fmid']
+            fmax = self._data['fmax']
+        ctable = self.update_lut(fmin=fmin, fmid=fmid, fmax=fmax)
+        ctable = (ctable * 255).astype(np.uint8)
+        for hemi in ['lh', 'rh']:
+            actor = self._data.get(hemi + '_actor')
+            if actor is not None:
                 dt_max = fmax
                 dt_min = fmin if center is None else -1 * fmax
                 rng = [dt_min, dt_max]

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -970,12 +970,13 @@ class _Brain(object):
     def update_auto_scaling(self, restore=False):
         from ..backends._pyvista import _set_colormap_range
         from scipy.interpolate import interp1d
-        if 'lims' in self._data['clim']:
+        user_clim = self._data['clim']
+        if user_clim is not None and 'lims' in user_clim:
             allow_pos_lims = False
         else:
             allow_pos_lims = True
-        if restore:
-            clim = self._data['clim']
+        if user_clim is not None and restore:
+            clim = user_clim
         else:
             clim = 'auto'
         colormap = self._data['colormap']

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -949,7 +949,14 @@ class _Brain(object):
     def update_auto_scaling(self, state):
         from ..backends._pyvista import _set_colormap_range
         if not hasattr(self, '_backup'):
-            self._backup = self._data.copy()
+            self._backup = {
+                'fmin': self._data['fmin'],
+                'fmid': self._data['fmid'],
+                'fmax': self._data['fmax'],
+                'center': self._data['center'],
+                'colormap': self._data['colormap'],
+                'transparent': self._data['transparent'],
+            }
         if state:
             clim = 'auto'
             colormap = self._data['colormap']
@@ -974,6 +981,7 @@ class _Brain(object):
             fmin = self._data['fmin']
             fmid = self._data['fmid']
             fmax = self._data['fmax']
+
         ctable = self.update_lut(fmin=fmin, fmid=fmid, fmax=fmax)
         ctable = (ctable * 255).astype(np.uint8)
         for hemi in ['lh', 'rh']:

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -967,6 +967,7 @@ class _Brain(object):
 
     def update_auto_scaling(self, state):
         from ..backends._pyvista import _set_colormap_range
+        from scipy.interpolate import interp1d
         if not hasattr(self, '_backup'):
             self._backup = {
                 'fmin': self._data['fmin'],
@@ -981,11 +982,15 @@ class _Brain(object):
             colormap = self._data['colormap']
             transparent = self._data['transparent']
             time_idx = self._data['time_idx']
-            array = self._data['array']
-            if self._data['array'].ndim == 1:
-                act_data = array
-            elif self._data['array'].ndim == 2:
-                act_data = array[:, time_idx]
+            act_data = self._data['array']
+            if self._data['array'].ndim == 2:
+                if isinstance(time_idx, int):
+                    act_data = act_data[:, time_idx]
+                else:
+                    times = np.arange(self._n_times)
+                    act_data = interp1d(
+                        times, act_data, 'linear', axis=1,
+                        assume_sorted=True)(time_idx)
             colormap, scale_pts, diverging, transparent, _ = \
                 _limits_to_control_points(clim, act_data, colormap,
                                           transparent)

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -229,7 +229,7 @@ class _Brain(object):
                  time_label="time index=%d", colorbar=True,
                  hemi=None, remove_existing=None, time_label_size=None,
                  initial_time=None, scale_factor=None, vector_alpha=None,
-                 verbose=None):
+                 clim=None, user_colormap=None, verbose=None):
         u"""Display data from a numpy array on the surface.
 
         This provides a similar interface to
@@ -390,6 +390,8 @@ class _Brain(object):
             fmin, fmid, fmax, center, array
         )
 
+        self._data['clim'] = clim
+        self._data['user_colormap'] = user_colormap
         self._data['time'] = time
         self._data['initial_time'] = initial_time
         self._data['time_label'] = time_label
@@ -965,11 +967,19 @@ class _Brain(object):
         self._data['fmid'] = fmid
         self._data['fmax'] = fmax
 
-    def update_auto_scaling(self):
+    def update_auto_scaling(self, restore=False):
         from ..backends._pyvista import _set_colormap_range
         from scipy.interpolate import interp1d
-        clim = 'auto'
+        if 'lims' in self._data['clim']:
+            allow_pos_lims = False
+        else:
+            allow_pos_lims = True
+        if restore:
+            clim = self._data['clim']
+        else:
+            clim = 'auto'
         colormap = self._data['colormap']
+        user_colormap = self._data['user_colormap']
         transparent = self._data['transparent']
         time_idx = self._data['time_idx']
         act_data = self._data['array']
@@ -982,8 +992,8 @@ class _Brain(object):
                     times, act_data, 'linear', axis=1,
                     assume_sorted=True)(time_idx)
         colormap, scale_pts, diverging, transparent, _ = \
-            _limits_to_control_points(clim, act_data, colormap,
-                                      transparent)
+            _limits_to_control_points(clim, act_data, user_colormap,
+                                      transparent, allow_pos_lims)
         fmin, fmid, fmax = scale_pts
         center = 0. if diverging else None
         self._data['center'] = center

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -965,47 +965,30 @@ class _Brain(object):
         self._data['fmid'] = fmid
         self._data['fmax'] = fmax
 
-    def update_auto_scaling(self, state):
+    def update_auto_scaling(self):
         from ..backends._pyvista import _set_colormap_range
         from scipy.interpolate import interp1d
-        if not hasattr(self, '_backup'):
-            self._backup = {
-                'fmin': self._data['fmin'],
-                'fmid': self._data['fmid'],
-                'fmax': self._data['fmax'],
-                'center': self._data['center'],
-                'colormap': self._data['colormap'],
-                'transparent': self._data['transparent'],
-            }
-        if state:
-            clim = 'auto'
-            colormap = self._data['colormap']
-            transparent = self._data['transparent']
-            time_idx = self._data['time_idx']
-            act_data = self._data['array']
-            if self._data['array'].ndim == 2:
-                if isinstance(time_idx, int):
-                    act_data = act_data[:, time_idx]
-                else:
-                    times = np.arange(self._n_times)
-                    act_data = interp1d(
-                        times, act_data, 'linear', axis=1,
-                        assume_sorted=True)(time_idx)
-            colormap, scale_pts, diverging, transparent, _ = \
-                _limits_to_control_points(clim, act_data, colormap,
-                                          transparent)
-            fmin, fmid, fmax = scale_pts
-            center = 0. if diverging else None
-            self._data['center'] = center
-            self._data['colormap'] = colormap
-            self._data['transparent'] = transparent
-        else:
-            self._data.update(self._backup)
-            center = self._data['center']
-            fmin = self._data['fmin']
-            fmid = self._data['fmid']
-            fmax = self._data['fmax']
-
+        clim = 'auto'
+        colormap = self._data['colormap']
+        transparent = self._data['transparent']
+        time_idx = self._data['time_idx']
+        act_data = self._data['array']
+        if self._data['array'].ndim == 2:
+            if isinstance(time_idx, int):
+                act_data = act_data[:, time_idx]
+            else:
+                times = np.arange(self._n_times)
+                act_data = interp1d(
+                    times, act_data, 'linear', axis=1,
+                    assume_sorted=True)(time_idx)
+        colormap, scale_pts, diverging, transparent, _ = \
+            _limits_to_control_points(clim, act_data, colormap,
+                                      transparent)
+        fmin, fmid, fmax = scale_pts
+        center = 0. if diverging else None
+        self._data['center'] = center
+        self._data['colormap'] = colormap
+        self._data['transparent'] = transparent
         ctable = self.update_lut(fmin=fmin, fmid=fmid, fmax=fmax)
         ctable = (ctable * 255).astype(np.uint8)
         for hemi in ['lh', 'rh']:

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -264,8 +264,10 @@ class _TimeViewer(object):
         self.plotter.add_key_event('y', self.toggle_interface)
 
         # add toggle for auto-scaling
-        self.brain = brain
         self.plotter.add_key_event('t', self.toggle_auto_scaling)
+
+        # add toggle for auto-scaling
+        self.plotter.add_key_event('u', self.restore_user_scaling)
 
         # set the slider style
         _set_slider_style(smoothing_slider)
@@ -290,6 +292,23 @@ class _TimeViewer(object):
 
     def toggle_auto_scaling(self):
         self.brain.update_auto_scaling()
+        fmin = self.brain._data['fmin']
+        fmid = self.brain._data['fmid']
+        fmax = self.brain._data['fmax']
+        for slider in self.plotter.slider_widgets:
+            name = getattr(slider, "name", None)
+            if name == "fmin":
+                slider_rep = slider.GetRepresentation()
+                slider_rep.SetValue(fmin)
+            elif name == "fmid":
+                slider_rep = slider.GetRepresentation()
+                slider_rep.SetValue(fmid)
+            elif name == "fmax":
+                slider_rep = slider.GetRepresentation()
+                slider_rep.SetValue(fmax)
+
+    def restore_user_scaling(self):
+        self.brain.update_auto_scaling(restore=True)
         fmin = self.brain._data['fmin']
         fmid = self.brain._data['fmid']
         fmax = self.brain._data['fmax']

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -263,10 +263,10 @@ class _TimeViewer(object):
         self.visibility = True
         self.plotter.add_key_event('y', self.toggle_interface)
 
-        # add toggle for auto-scaling
-        self.plotter.add_key_event('t', self.toggle_auto_scaling)
+        # apply auto-scaling action
+        self.plotter.add_key_event('t', self.apply_auto_scaling)
 
-        # add toggle for auto-scaling
+        # restore user scaling action
         self.plotter.add_key_event('u', self.restore_user_scaling)
 
         # set the slider style
@@ -290,7 +290,7 @@ class _TimeViewer(object):
             else:
                 slider.Off()
 
-    def toggle_auto_scaling(self):
+    def apply_auto_scaling(self):
         self.brain.update_auto_scaling()
         fmin = self.brain._data['fmin']
         fmid = self.brain._data['fmid']

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -246,6 +246,11 @@ class _TimeViewer(object):
         self.visibility = True
         self.plotter.add_key_event('y', self.toggle_interface)
 
+        # add toggle for auto-scaling
+        self.auto_scaling = False
+        self.brain = brain
+        self.plotter.add_key_event('t', self.toggle_auto_scaling)
+
     def toggle_interface(self):
         self.visibility = not self.visibility
         for slider in self.plotter.slider_widgets:
@@ -253,6 +258,10 @@ class _TimeViewer(object):
                 slider.On()
             else:
                 slider.Off()
+
+    def toggle_auto_scaling(self):
+        self.auto_scaling = not self.auto_scaling
+        self.brain.update_auto_scaling(self.auto_scaling)
 
 
 def _set_slider_style(slider, show_label=True):

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -221,12 +221,12 @@ class _TimeViewer(object):
             event_type="always",
         )
         fmax_slider.name = "fmax"
-        update_fscale = UpdateColorbarScale(
+        self.update_fscale = UpdateColorbarScale(
             plotter=self.plotter,
             brain=brain,
         )
         fscale_slider = self.plotter.add_slider_widget(
-            update_fscale,
+            self.update_fscale,
             value=1.0,
             rng=scaling_limits, title="fscale",
             pointa=(0.82, 0.10),
@@ -262,6 +262,7 @@ class _TimeViewer(object):
     def toggle_auto_scaling(self):
         self.auto_scaling = not self.auto_scaling
         self.brain.update_auto_scaling(self.auto_scaling)
+        self.update_fscale(1)
 
 
 def _set_slider_style(slider, show_label=True):

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -264,7 +264,6 @@ class _TimeViewer(object):
         self.plotter.add_key_event('y', self.toggle_interface)
 
         # add toggle for auto-scaling
-        self.auto_scaling = False
         self.brain = brain
         self.plotter.add_key_event('t', self.toggle_auto_scaling)
 
@@ -290,9 +289,21 @@ class _TimeViewer(object):
                 slider.Off()
 
     def toggle_auto_scaling(self):
-        self.auto_scaling = not self.auto_scaling
-        self.brain.update_auto_scaling(self.auto_scaling)
-        self.update_fscale(1)
+        self.brain.update_auto_scaling()
+        fmin = self.brain._data['fmin']
+        fmid = self.brain._data['fmid']
+        fmax = self.brain._data['fmax']
+        for slider in self.plotter.slider_widgets:
+            name = getattr(slider, "name", None)
+            if name == "fmin":
+                slider_rep = slider.GetRepresentation()
+                slider_rep.SetValue(fmin)
+            elif name == "fmid":
+                slider_rep = slider.GetRepresentation()
+                slider_rep.SetValue(fmid)
+            elif name == "fmax":
+                slider_rep = slider.GetRepresentation()
+                slider_rep.SetValue(fmax)
 
     def toggle_playback(self):
         self.playback = not self.playback

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -171,6 +171,7 @@ def test_brain_timeviewer(renderer):
     time_viewer.update_fscale(value=1.1)
     time_viewer.toggle_interface()
     time_viewer.toggle_playback()
+    time_viewer.toggle_auto_scaling()
 
 
 def test_brain_colormap():

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -171,7 +171,7 @@ def test_brain_timeviewer(renderer):
     time_viewer.update_fscale(value=1.1)
     time_viewer.toggle_interface()
     time_viewer.toggle_playback()
-    time_viewer.toggle_auto_scaling()
+    time_viewer.apply_auto_scaling()
     time_viewer.restore_user_scaling()
 
 

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -172,6 +172,7 @@ def test_brain_timeviewer(renderer):
     time_viewer.toggle_interface()
     time_viewer.toggle_playback()
     time_viewer.toggle_auto_scaling()
+    time_viewer.restore_user_scaling()
 
 
 def test_brain_colormap():


### PR DESCRIPTION
This PR adds support for `auto_scaling` to `_TimeViewer`. It can be enabled by pressing the shortcut `t`. This is still a prototype and I was wondering what would be the best UX actually:

1) Is it more like a 'auto-mode' *(toggle event)*:
* Pressing 'auto-scaling' enables 'auto-mode'
* During playback, the scaling is updated at each step
* If the user modifies the `clim`  values given automatically, they snap back to the detected values

2) Or more like 'help me find a good start' *(action event)*:
* Pressing 'auto-scaling' changes the values
* During playback, the current values are used, no auto-scaling is done
* If the user modifies `clim`, it will be updated accordingly


It's an item of #7162