### PR TITLE
MRG: Add support for hemi=split in time_viewer

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -184,6 +184,9 @@ class _Brain(object):
         # for now only one color bar can be added
         # since it is the same for all figures
         self._colorbar_added = False
+        # for now only one time label can be added
+        # since it is the same for all figures
+        self._time_label_added = False
         # array of data used by TimeViewer
         self._data = {}
         self.geo, self._hemi_meshes, self._overlays = {}, {}, {}
@@ -448,13 +451,15 @@ class _Brain(object):
             self._data[hemi + '_actor'] = actor
             self._data[hemi + '_mesh'] = mesh
             if array.ndim >= 2 and callable(time_label):
-                time_actor = self._renderer.text2d(
-                    x_window=0.95, y_window=y_txt,
-                    size=time_label_size,
-                    text=time_label(time[time_idx]),
-                    justification='right'
-                )
-                self._data[hemi + '_time_actor'] = time_actor
+                if not self._time_label_added:
+                    time_actor = self._renderer.text2d(
+                        x_window=0.95, y_window=y_txt,
+                        size=time_label_size,
+                        text=time_label(time[time_idx]),
+                        justification='right'
+                    )
+                    self._data['_time_actor'] = time_actor
+                    self._time_label_added = True
             if colorbar and not self._colorbar_added:
                 self._renderer.scalarbar(source=actor, n_labels=8,
                                          bgcolor=(0.5, 0.5, 0.5))
@@ -852,7 +857,7 @@ class _Brain(object):
                 array = self._data[hemi + '_array']
                 time = self._data['time']
                 time_label = self._data['time_label']
-                time_actor = self._data.get(hemi + '_time_actor')
+                time_actor = self._data.get('_time_actor')
                 if array.ndim == 1:
                     continue  # skip data without time axis
                 # interpolation

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -398,8 +398,11 @@ class _Brain(object):
         self._data['time_idx'] = time_idx
         self._data['transparent'] = transparent
         # data specific for a hemi
-        self._data[hemi + '_array'] = array
-        self._data[hemi + '_vertices'] = vertices
+        self._data[hemi] = dict()
+        self._data[hemi]['actor'] = list()
+        self._data[hemi]['mesh'] = list()
+        self._data[hemi]['array'] = array
+        self._data[hemi]['vertices'] = vertices
 
         self._data['alpha'] = alpha
         self._data['colormap'] = colormap
@@ -419,7 +422,7 @@ class _Brain(object):
                                           adj_mat,
                                           smoothing_steps)
             act_data = smooth_mat.dot(act_data)
-            self._data[hemi + '_smooth_mat'] = smooth_mat
+            self._data[hemi]['smooth_mat'] = smooth_mat
 
         dt_max = fmax
         dt_min = fmin if center is None else -1 * fmax
@@ -448,8 +451,8 @@ class _Brain(object):
                 actor, mesh = mesh_data
             else:
                 actor, mesh = mesh_data, None
-            self._data[hemi + '_actor'] = actor
-            self._data[hemi + '_mesh'] = mesh
+            self._data[hemi]['actor'].append(actor)
+            self._data[hemi]['mesh'].append(mesh)
             if array.ndim >= 2 and callable(time_label):
                 if not self._time_label_added:
                     time_actor = self._renderer.text2d(
@@ -458,7 +461,7 @@ class _Brain(object):
                         text=time_label(time[time_idx]),
                         justification='right'
                     )
-                    self._data['_time_actor'] = time_actor
+                    self._data['time_actor'] = time_actor
                     self._time_label_added = True
             if colorbar and not self._colorbar_added:
                 self._renderer.scalarbar(source=actor, n_labels=8,
@@ -825,21 +828,20 @@ class _Brain(object):
         """
         from ..backends._pyvista import _set_mesh_scalars
         from scipy.interpolate import interp1d
+        time_idx = self._data['time_idx']
         for hemi in ['lh', 'rh']:
-            pd = self._data.get(hemi + '_mesh')
-            if pd is not None:
-                array = self._data[hemi + '_array']
-                vertices = self._data[hemi + '_vertices']
-                if pd is not None:
-                    time_idx = self._data['time_idx']
-                    act_data = array
-                    if self._data['array'].ndim == 2:
+            hemi_data = self._data.get(hemi)
+            if hemi_data is not None:
+                array = hemi_data['array']
+                vertices = hemi_data['vertices']
+                for mesh in hemi_data['mesh']:
+                    if array.ndim == 2:
                         if isinstance(time_idx, int):
-                            act_data = act_data[:, time_idx]
+                            act_data = array[:, time_idx]
                         else:
                             times = np.arange(self._n_times)
                             act_data = interp1d(
-                                times, act_data, 'linear', axis=1,
+                                times, array, 'linear', axis=1,
                                 assume_sorted=True)(time_idx)
 
                     adj_mat = mesh_edges(self.geo[hemi].faces)
@@ -847,46 +849,47 @@ class _Brain(object):
                                                   adj_mat, int(n_steps),
                                                   verbose=False)
                     act_data = smooth_mat.dot(act_data)
-                    _set_mesh_scalars(pd, act_data, 'Data')
-                    self._data[hemi + '_smooth_mat'] = smooth_mat
+                    _set_mesh_scalars(mesh, act_data, 'Data')
+                    self._data[hemi]['smooth_mat'] = smooth_mat
 
     def set_time_point(self, time_idx):
         """Set the time point shown."""
         from ..backends._pyvista import _set_mesh_scalars
         from scipy.interpolate import interp1d
+        time = self._data['time']
+        time_label = self._data['time_label']
+        time_actor = self._data.get('time_actor')
         for hemi in ['lh', 'rh']:
-            pd = self._data.get(hemi + '_mesh')
-            if pd is not None:
-                array = self._data[hemi + '_array']
-                time = self._data['time']
-                time_label = self._data['time_label']
-                time_actor = self._data.get('_time_actor')
-                if array.ndim == 1:
-                    continue  # skip data without time axis
-                # interpolation
-                if array.ndim == 2:
-                    act_data = array
+            hemi_data = self._data.get(hemi)
+            if hemi_data is not None:
+                array = hemi_data['array']
+                for mesh in hemi_data['mesh']:
+                    if array.ndim == 1:
+                        continue  # skip data without time axis
+                    # interpolation
+                    if array.ndim == 2:
+                        act_data = array
 
-                if isinstance(time_idx, int):
-                    act_data = act_data[:, time_idx]
-                else:
-                    times = np.arange(self._n_times)
-                    act_data = interp1d(times, act_data, 'linear', axis=1,
-                                        assume_sorted=True)(time_idx)
-
-                smooth_mat = self._data[hemi + '_smooth_mat']
-                if smooth_mat is not None:
-                    act_data = smooth_mat.dot(act_data)
-                _set_mesh_scalars(pd, act_data, 'Data')
-                if callable(time_label) and time_actor is not None:
                     if isinstance(time_idx, int):
-                        self._current_time = time[time_idx]
-                        time_actor.SetInput(time_label(self._current_time))
+                        act_data = act_data[:, time_idx]
                     else:
-                        ifunc = interp1d(times, self._data['time'])
-                        self._current_time = ifunc(time_idx)
-                        time_actor.SetInput(time_label(self._current_time))
-                self._data['time_idx'] = time_idx
+                        times = np.arange(self._n_times)
+                        act_data = interp1d(times, act_data, 'linear', axis=1,
+                                            assume_sorted=True)(time_idx)
+
+                    smooth_mat = hemi_data['smooth_mat']
+                    if smooth_mat is not None:
+                        act_data = smooth_mat.dot(act_data)
+                    _set_mesh_scalars(mesh, act_data, 'Data')
+                    if callable(time_label) and time_actor is not None:
+                        if isinstance(time_idx, int):
+                            self._current_time = time[time_idx]
+                            time_actor.SetInput(time_label(self._current_time))
+                        else:
+                            ifunc = interp1d(times, self._data['time'])
+                            self._current_time = ifunc(time_idx)
+                            time_actor.SetInput(time_label(self._current_time))
+                    self._data['time_idx'] = time_idx
 
     def update_fmax(self, fmax):
         """Set the colorbar max point."""
@@ -894,21 +897,21 @@ class _Brain(object):
         ctable = self.update_lut(fmax=fmax)
         ctable = (ctable * 255).astype(np.uint8)
         center = self._data['center']
+        fmin = self._data['fmin']
         for hemi in ['lh', 'rh']:
-            actor = self._data.get(hemi + '_actor')
-            if actor is not None:
-                fmin = self._data['fmin']
-                center = self._data['center']
-                dt_max = fmax
-                dt_min = fmin if center is None else -1 * fmax
-                rng = [dt_min, dt_max]
-                if self._colorbar_added:
-                    scalar_bar = self._renderer.plotter.scalar_bar
-                else:
-                    scalar_bar = None
-                _set_colormap_range(actor, ctable, scalar_bar, rng)
-                self._data['fmax'] = fmax
-                self._data['ctable'] = ctable
+            hemi_data = self._data.get(hemi)
+            if hemi_data is not None:
+                for actor in hemi_data['actor']:
+                    dt_max = fmax
+                    dt_min = fmin if center is None else -1 * fmax
+                    rng = [dt_min, dt_max]
+                    if self._colorbar_added:
+                        scalar_bar = self._renderer.plotter.scalar_bar
+                    else:
+                        scalar_bar = None
+                    _set_colormap_range(actor, ctable, scalar_bar, rng)
+                    self._data['fmax'] = fmax
+                    self._data['ctable'] = ctable
 
     def update_fmid(self, fmid):
         """Set the colorbar mid point."""
@@ -916,61 +919,64 @@ class _Brain(object):
         ctable = self.update_lut(fmid=fmid)
         ctable = (ctable * 255).astype(np.uint8)
         for hemi in ['lh', 'rh']:
-            actor = self._data.get(hemi + '_actor')
-            if actor is not None:
-                if self._colorbar_added:
-                    scalar_bar = self._renderer.plotter.scalar_bar
-                else:
-                    scalar_bar = None
-                _set_colormap_range(actor, ctable, scalar_bar)
-                self._data['fmid'] = fmid
-                self._data['ctable'] = ctable
+            hemi_data = self._data.get(hemi)
+            if hemi_data is not None:
+                for actor in hemi_data['actor']:
+                    if self._colorbar_added:
+                        scalar_bar = self._renderer.plotter.scalar_bar
+                    else:
+                        scalar_bar = None
+                    _set_colormap_range(actor, ctable, scalar_bar)
+                    self._data['fmid'] = fmid
+                    self._data['ctable'] = ctable
 
     def update_fmin(self, fmin):
         """Set the colorbar min point."""
         from ..backends._pyvista import _set_colormap_range
         ctable = self.update_lut(fmin=fmin)
         ctable = (ctable * 255).astype(np.uint8)
+        center = self._data['center']
+        fmax = self._data['fmax']
         for hemi in ['lh', 'rh']:
-            actor = self._data.get(hemi + '_actor')
-            if actor is not None:
-                fmax = self._data['fmax']
-                center = self._data['center']
-                dt_max = fmax
-                dt_min = fmin if center is None else -1 * fmax
-                rng = [dt_min, dt_max]
-                if self._colorbar_added:
-                    scalar_bar = self._renderer.plotter.scalar_bar
-                else:
-                    scalar_bar = None
-                _set_colormap_range(actor, ctable, scalar_bar, rng)
-                self._data['fmin'] = fmin
-                self._data['ctable'] = ctable
+            hemi_data = self._data.get(hemi)
+            if hemi_data is not None:
+                for actor in hemi_data['actor']:
+                    dt_max = fmax
+                    dt_min = fmin if center is None else -1 * fmax
+                    rng = [dt_min, dt_max]
+                    if self._colorbar_added:
+                        scalar_bar = self._renderer.plotter.scalar_bar
+                    else:
+                        scalar_bar = None
+                    _set_colormap_range(actor, ctable, scalar_bar, rng)
+                    self._data['fmin'] = fmin
+                    self._data['ctable'] = ctable
 
     def update_fscale(self, fscale):
         """Scale the colorbar points."""
         from ..backends._pyvista import _set_colormap_range
+        center = self._data['center']
         fmin = self._data['fmin'] * fscale
         fmid = self._data['fmid'] * fscale
         fmax = self._data['fmax'] * fscale
         ctable = self.update_lut(fmin=fmin, fmid=fmid, fmax=fmax)
         ctable = (ctable * 255).astype(np.uint8)
         for hemi in ['lh', 'rh']:
-            actor = self._data.get(hemi + '_actor')
-            if actor is not None:
-                center = self._data['center']
-                dt_max = fmax
-                dt_min = fmin if center is None else -1 * fmax
-                rng = [dt_min, dt_max]
-                if self._colorbar_added:
-                    scalar_bar = self._renderer.plotter.scalar_bar
-                else:
-                    scalar_bar = None
-                _set_colormap_range(actor, ctable, scalar_bar, rng)
-                self._data['ctable'] = ctable
-        self._data['fmin'] = fmin
-        self._data['fmid'] = fmid
-        self._data['fmax'] = fmax
+            hemi_data = self._data.get(hemi)
+            if hemi_data is not None:
+                for actor in hemi_data['actor']:
+                    dt_max = fmax
+                    dt_min = fmin if center is None else -1 * fmax
+                    rng = [dt_min, dt_max]
+                    if self._colorbar_added:
+                        scalar_bar = self._renderer.plotter.scalar_bar
+                    else:
+                        scalar_bar = None
+                    _set_colormap_range(actor, ctable, scalar_bar, rng)
+                    self._data['ctable'] = ctable
+                    self._data['fmin'] = fmin
+                    self._data['fmid'] = fmid
+                    self._data['fmax'] = fmax
 
     @property
     def data(self):

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -864,18 +864,14 @@ class _Brain(object):
             if hemi_data is not None:
                 array = hemi_data['array']
                 for mesh in hemi_data['mesh']:
-                    if array.ndim == 1:
-                        continue  # skip data without time axis
                     # interpolation
                     if array.ndim == 2:
-                        act_data = array
-
-                    if isinstance(time_idx, int):
-                        act_data = act_data[:, time_idx]
-                    else:
-                        times = np.arange(self._n_times)
-                        act_data = interp1d(times, act_data, 'linear', axis=1,
-                                            assume_sorted=True)(time_idx)
+                        if isinstance(time_idx, int):
+                            act_data = array[:, time_idx]
+                        else:
+                            times = np.arange(self._n_times)
+                            act_data = interp1d(times, array, 'linear', axis=1,
+                                                assume_sorted=True)(time_idx)
 
                     smooth_mat = hemi_data['smooth_mat']
                     if smooth_mat is not None:

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -751,8 +751,15 @@ class _Brain(object):
         elif isinstance(view, dict):
             view = View(azim=view['azimuth'],
                         elev=view['elevation'])
-        self._renderer.set_camera(azimuth=view.azim,
-                                  elevation=view.elev)
+        for hemi in ['lh', 'rh']:
+            for ri, v in enumerate(self._views):
+                if self._hemi != 'split':
+                    ci = 0
+                else:
+                    ci = 0 if hemi == 'lh' else 1
+                self._renderer.subplot(ri, ci)
+                self._renderer.set_camera(azimuth=view.azim,
+                                          elevation=view.elev)
 
     def save_image(self, filename, mode='rgb'):
         """Save view from all panels to disk.

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -743,7 +743,7 @@ class _Brain(object):
         """Close all figures and cleanup data structure."""
         self._renderer.close()
 
-    def show_view(self, view=None, roll=None, distance=None):
+    def show_view(self, view=None, roll=None, distance=None, row=0):
         """Orient camera to display view."""
         views_dict = lh_views_dict if self._hemi == 'lh' else rh_views_dict
         if isinstance(view, str):
@@ -752,14 +752,13 @@ class _Brain(object):
             view = View(azim=view['azimuth'],
                         elev=view['elevation'])
         for hemi in ['lh', 'rh']:
-            for ri, v in enumerate(self._views):
-                if self._hemi != 'split':
-                    ci = 0
-                else:
-                    ci = 0 if hemi == 'lh' else 1
-                self._renderer.subplot(ri, ci)
-                self._renderer.set_camera(azimuth=view.azim,
-                                          elevation=view.elev)
+            if self._hemi != 'split':
+                ci = 0
+            else:
+                ci = 0 if hemi == 'lh' else 1
+            self._renderer.subplot(row, ci)
+            self._renderer.set_camera(azimuth=view.azim,
+                                      elevation=view.elev)
 
     def save_image(self, filename, mode='rgb'):
         """Save view from all panels to disk.

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -743,22 +743,19 @@ class _Brain(object):
         """Close all figures and cleanup data structure."""
         self._renderer.close()
 
-    def show_view(self, view=None, roll=None, distance=None, row=0):
+    def show_view(self, view=None, roll=None, distance=None, row=0, col=0,
+                  hemi=None):
         """Orient camera to display view."""
-        views_dict = lh_views_dict if self._hemi == 'lh' else rh_views_dict
+        hemi = self._hemi if hemi is None else hemi
+        views_dict = lh_views_dict if hemi == 'lh' else rh_views_dict
         if isinstance(view, str):
             view = views_dict.get(view)
         elif isinstance(view, dict):
             view = View(azim=view['azimuth'],
                         elev=view['elevation'])
-        for hemi in ['lh', 'rh']:
-            if self._hemi != 'split':
-                ci = 0
-            else:
-                ci = 0 if hemi == 'lh' else 1
-            self._renderer.subplot(row, ci)
-            self._renderer.set_camera(azimuth=view.azim,
-                                      elevation=view.elev)
+        self._renderer.subplot(row, col)
+        self._renderer.set_camera(azimuth=view.azim,
+                                  elevation=view.elev)
 
     def save_image(self, filename, mode='rgb'):
         """Save view from all panels to disk.

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -206,7 +206,7 @@ class _TimeViewer(object):
         self.set_smoothing(default_smoothing_value)
 
         # time label
-        self.time_actor = brain._data.get('_time_actor')
+        self.time_actor = brain._data.get('time_actor')
         if self.time_actor is not None:
             self.time_actor.SetPosition(0.5, 0.03)
             self.time_actor.GetTextProperty().SetJustificationToCentered()

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -271,14 +271,14 @@ class _TimeViewer(object):
         self.plotter.add_key_event('y', self.toggle_interface)
 
         # set the slider style
-        _set_slider_style(smoothing_slider)
-        _set_slider_style(orientation_slider, show_label=False)
-        _set_slider_style(fmin_slider)
-        _set_slider_style(fmid_slider)
-        _set_slider_style(fmax_slider)
-        _set_slider_style(fscale_slider)
-        _set_slider_style(playback_speed_slider)
-        _set_slider_style(time_slider, show_label=False)
+        self.set_slider_style(smoothing_slider)
+        self.set_slider_style(orientation_slider, show_label=False)
+        self.set_slider_style(fmin_slider)
+        self.set_slider_style(fmid_slider)
+        self.set_slider_style(fmax_slider)
+        self.set_slider_style(fscale_slider)
+        self.set_slider_style(playback_speed_slider)
+        self.set_slider_style(time_slider, show_label=False)
 
         # set the text style
         _set_text_style(self.time_actor)
@@ -326,18 +326,30 @@ class _TimeViewer(object):
                 self.playback = False
             self.plotter.update()  # critical for smooth animation
 
+    def set_slider_style(self, slider, show_label=True):
+        if slider is not None:
+            slider_rep = slider.GetRepresentation()
+            slider_rep.SetSliderLength(0.02)
+            slider_rep.SetSliderWidth(0.04)
+            slider_rep.SetTubeWidth(0.005)
+            slider_rep.SetEndCapLength(0.01)
+            slider_rep.SetEndCapWidth(0.02)
+            slider_rep.GetSliderProperty().SetColor((0.5, 0.5, 0.5))
+            if not show_label:
+                slider_rep.ShowSliderLabelOff()
 
-def _set_slider_style(slider, show_label=True):
-    if slider is not None:
-        slider_rep = slider.GetRepresentation()
-        slider_rep.SetSliderLength(0.02)
-        slider_rep.SetSliderWidth(0.04)
-        slider_rep.SetTubeWidth(0.005)
-        slider_rep.SetEndCapLength(0.01)
-        slider_rep.SetEndCapWidth(0.02)
-        slider_rep.GetSliderProperty().SetColor((0.5, 0.5, 0.5))
-        if not show_label:
-            slider_rep.ShowSliderLabelOff()
+            # add support for split window
+            shape = self.plotter.shape
+            pointa = slider_rep.GetPoint1Coordinate().GetValue()
+            pointb = slider_rep.GetPoint2Coordinate().GetValue()
+            pointa = _normalize(pointa, shape)
+            pointb = _normalize(pointb, shape)
+            slider_rep.GetPoint1Coordinate().\
+                SetCoordinateSystemToNormalizedDisplay()
+            slider_rep.GetPoint1Coordinate().SetValue(pointa[0], pointa[1])
+            slider_rep.GetPoint2Coordinate().\
+                SetCoordinateSystemToNormalizedDisplay()
+            slider_rep.GetPoint2Coordinate().SetValue(pointb[0], pointb[1])
 
 
 def _set_text_style(text_actor):
@@ -349,3 +361,7 @@ def _set_text_style(text_actor):
 def _get_range(brain):
     val = np.abs(brain._data['array'])
     return [np.min(val), np.max(val)]
+
+
+def _normalize(point, shape):
+    return (point[0] / shape[1], point[1] / shape[0])

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -115,6 +115,10 @@ class _TimeViewer(object):
         self.brain = brain
         self.plotter = brain._renderer.plotter
 
+        # put all controls on first view
+        if self.brain._hemi == 'split':
+            self.plotter.subplot(0, 0)
+
         # scalar bar
         if brain._colorbar_added:
             scalar_bar = self.plotter.scalar_bar
@@ -161,11 +165,10 @@ class _TimeViewer(object):
         )
 
         # time label
-        for hemi in brain._hemis:
-            self.time_actor = brain._data.get(hemi + '_time_actor')
-            if self.time_actor is not None:
-                self.time_actor.SetPosition(0.5, 0.03)
-                self.time_actor.GetTextProperty().SetJustificationToCentered()
+        self.time_actor = brain._data.get('_time_actor')
+        if self.time_actor is not None:
+            self.time_actor.SetPosition(0.5, 0.03)
+            self.time_actor.GetTextProperty().SetJustificationToCentered()
 
         # time slider
         max_time = len(brain._data['time']) - 1

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -111,10 +111,13 @@ class BumpColorbarPoints(object):
 class ShowView(object):
     """Class that selects the correct view."""
 
-    def __init__(self, plotter=None, brain=None, row=None, name=None):
+    def __init__(self, plotter=None, brain=None, row=None, col=None,
+                 hemi=None, name=None):
         self.plotter = plotter
         self.brain = brain
         self.row = row
+        self.col = col
+        self.hemi = hemi
         self.name = name
 
     def __call__(self, value):
@@ -122,8 +125,8 @@ class ShowView(object):
         for slider in self.plotter.slider_widgets:
             name = getattr(slider, "name", None)
             if name == self.name:
-                self.brain.show_view(value,
-                                     row=self.row)
+                self.brain.show_view(value, row=self.row, col=self.col,
+                                     hemi=self.hemi)
 
 
 class _TimeViewer(object):
@@ -149,25 +152,29 @@ class _TimeViewer(object):
         if self.brain._hemi == 'split':
             self.plotter.subplot(0, 0)
 
-        for idx, view in enumerate(self.brain._views):
-            self.plotter.subplot(idx, 0)
-            name = "orientation" + str(idx)
-            self.show_view = ShowView(
-                plotter=self.plotter,
-                brain=self.brain,
-                row=idx,
-                name=name
-            )
-            orientation_slider = self.plotter.add_text_slider_widget(
-                self.show_view,
-                value=0,
-                data=orientation,
-                pointa=(0.82, 0.74),
-                pointb=(0.98, 0.74),
-                event_type='always'
-            )
-            orientation_slider.name = name
-            self.set_slider_style(orientation_slider, show_label=False)
+        for hemi in self.brain._hemis:
+            ci = 0 if hemi == 'lh' else 1
+            for ri, view in enumerate(self.brain._views):
+                self.plotter.subplot(ri, ci)
+                name = "orientation" + str(ri) + "_" + str(ci)
+                self.show_view = ShowView(
+                    plotter=self.plotter,
+                    brain=self.brain,
+                    hemi=hemi,
+                    row=ri,
+                    col=ci,
+                    name=name
+                )
+                orientation_slider = self.plotter.add_text_slider_widget(
+                    self.show_view,
+                    value=0,
+                    data=orientation,
+                    pointa=(0.82, 0.74),
+                    pointb=(0.98, 0.74),
+                    event_type='always'
+                )
+                orientation_slider.name = name
+                self.set_slider_style(orientation_slider, show_label=False)
 
         # necessary because show_view modified subplot
         if self.brain._hemi == 'split':

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -115,7 +115,31 @@ class _TimeViewer(object):
         self.brain = brain
         self.plotter = brain._renderer.plotter
 
-        # put all controls on first view
+        # default: put orientation slider on the first view
+        if self.brain._hemi == 'split':
+            self.plotter.subplot(0, 0)
+
+        # orientation slider
+        orientation = [
+            'lateral',
+            'medial',
+            'rostral',
+            'caudal',
+            'dorsal',
+            'ventral',
+            'frontal',
+            'parietal'
+        ]
+        orientation_slider = self.plotter.add_text_slider_widget(
+            brain.show_view,
+            value=0,
+            data=orientation,
+            pointa=(0.82, 0.74),
+            pointb=(0.98, 0.74),
+            event_type='always'
+        )
+
+        # necessary because show_view modified subplot
         if self.brain._hemi == 'split':
             self.plotter.subplot(0, 0)
 
@@ -143,26 +167,6 @@ class _TimeViewer(object):
         )
         smoothing_slider.name = 'smoothing'
         self.set_smoothing(default_smoothing_value)
-
-        # orientation slider
-        orientation = [
-            'lateral',
-            'medial',
-            'rostral',
-            'caudal',
-            'dorsal',
-            'ventral',
-            'frontal',
-            'parietal'
-        ]
-        orientation_slider = self.plotter.add_text_slider_widget(
-            brain.show_view,
-            value=0,
-            data=orientation,
-            pointa=(0.82, 0.74),
-            pointb=(0.98, 0.74),
-            event_type='always'
-        )
 
         # time label
         self.time_actor = brain._data.get('_time_actor')

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -163,6 +163,8 @@ def test_brain_timeviewer(renderer):
     brain_data.set_time_point(time_idx=0)
 
     time_viewer = _TimeViewer(brain_data)
+    time_viewer.show_view('lat', update_widget=True)
+    time_viewer.show_view('medial', update_widget=True)
     time_viewer.set_smoothing(value=1)
     time_viewer.update_fmin(value=12.0)
     time_viewer.update_fmax(value=4.0)

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -46,8 +46,10 @@ def test_brain_init(renderer):
     with pytest.raises(KeyError):
         _Brain(subject_id=subject_id, hemi='foo', surf=surf)
 
-    _Brain(subject_id, hemi, surf, size=(300, 300),
-           subjects_dir=subjects_dir)
+    brain = _Brain(subject_id, hemi, surf, size=(300, 300),
+                   subjects_dir=subjects_dir)
+    brain.show_view(view=dict(azimuth=180., elevation=90.))
+    brain.close()
 
 
 @testing.requires_testing_data
@@ -57,6 +59,7 @@ def test_brain_screenshot(renderer):
                    surf=surf, subjects_dir=subjects_dir)
     img = brain.screenshot(mode='rgb')
     assert(img.shape == (600, 600, 3))
+    brain.close()
 
 
 @testing.requires_testing_data
@@ -94,7 +97,8 @@ def test_brain_add_data(renderer):
                         smoothing_steps=0, colorbar=False, time=None)
     brain_data.add_data(hemi_data, fmin=fmin, hemi=hemi, fmax=fmax,
                         colormap='hot', vertices=hemi_vertices,
-                        initial_time=0., colorbar=True, time=None)
+                        initial_time=0., colorbar=False, time=None)
+    brain_data.close()
 
 
 @testing.requires_testing_data
@@ -106,6 +110,7 @@ def test_brain_add_label(renderer):
     label = read_label(fname_label)
     brain.add_label(fname_label)
     brain.add_label(label, scalar_thresh=0.)
+    brain.close()
 
 
 @testing.requires_testing_data
@@ -115,6 +120,7 @@ def test_brain_add_foci(renderer):
                    surf=surf, subjects_dir=subjects_dir)
     brain.add_foci([0], coords_as_verts=True,
                    hemi='lh', color='blue')
+    brain.close()
 
 
 @testing.requires_testing_data
@@ -123,6 +129,7 @@ def test_brain_add_text(renderer):
     brain = _Brain(subject_id, hemi='lh', size=250,
                    surf=surf, subjects_dir=subjects_dir)
     brain.add_text(x=0, y=0, text='foo')
+    brain.close()
 
 
 @testing.requires_testing_data
@@ -147,18 +154,17 @@ def test_brain_timeviewer(renderer):
     stc_data.shape = (n_verts, n_time)
     stc = SourceEstimate(stc_data, vertices, 1, 1)
 
-    hemi = 'lh'
-    hemi_data = getattr(stc, hemi + '_data')
-    hemi_vertices = stc.vertices[0]
     fmin = stc.data.min()
     fmax = stc.data.max()
-
-    brain_data = _Brain(subject_id, hemi, surf, size=300,
+    brain_data = _Brain(subject_id, 'split', surf, size=300,
                         subjects_dir=subjects_dir)
-
-    brain_data.add_data(hemi_data, fmin=fmin, hemi=hemi, fmax=fmax,
-                        colormap='hot', vertices=hemi_vertices,
-                        colorbar=False)
+    for hemi in ['lh', 'rh']:
+        hemi_idx = 0 if hemi == 'lh' else 1
+        data = getattr(stc, hemi + '_data')
+        vertices = stc.vertices[hemi_idx]
+        brain_data.add_data(data, fmin=fmin, hemi=hemi, fmax=fmax,
+                            colormap='hot', vertices=vertices,
+                            colorbar=True)
 
     brain_data.set_time_point(time_idx=0)
 


### PR DESCRIPTION
This PR starts the work on `hemi=split`. Let's go incrementally on this one. For now I put all the controls on the first view.

Using `plot_visualize_stc.py` with `hemi=split`:

![2020-01-16_1920x1080](https://user-images.githubusercontent.com/18143289/72523313-cff1cb80-385f-11ea-9041-feb5d2cae419.png)

The zoom between the views is not linked, that would be nice to have I think.

**ToDo**
- [x] Unify `show_view()` when `hemi=split` or when `len(views)>1`
- [x] Fix playback when `len(views)>1`
- [x] Fix default orientation value

It's an item of #7162