### PR TITLE
[MRG] FIX: read easycap-M10 montage

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -91,6 +91,9 @@ Changelog
 
 - Add function to convert events to annotations :func:`mne.annotations_from_events` by `Nicolas Barascud`_
 
+- More accurate coordinate system for Easycap montages in :func:`mne.channels.make_standard_montage` by `Christian Brodbeck`_
+
+
 Bug
 ~~~
 
@@ -177,6 +180,8 @@ Bug
 - Fix bug in :func:`mne.bem.make_watershed_bem` where some surfaces were saved incorrectly in the working directory by `Yu-Han Luo`_
 
 - Fix support for multiple TAL (annotations) channels in BDF reader by `Clemens Brunner`_
+
+- Fix bug in :func:`mne.channels.make_standard_montage` which would return `easycap-M1` even when requesting `easycap-M10` by `Christian Brodbeck`_
 
 API
 ~~~

--- a/examples/visualization/plot_montage.py
+++ b/examples/visualization/plot_montage.py
@@ -2,7 +2,7 @@
 """
 .. _plot_montage:
 
-Plotting sensor layouts of EEG Systems
+Plotting sensor layouts of EEG systems
 ======================================
 
 This example illustrates how to load all the EEG system montages

--- a/mne/channels/_standard_montage_utils.py
+++ b/mne/channels/_standard_montage_utils.py
@@ -264,10 +264,7 @@ def _read_theta_phi_in_degrees(fname, head_size, fid_names):
     ch_names, theta, phi = _safe_np_loadtxt(fname, **options)
 
     radii = np.full(len(phi), head_size)
-    pos = _sph_to_cart(np.stack(
-        [radii, np.deg2rad(phi), np.deg2rad(theta)],
-        axis=-1,
-    ))
+    pos = _sph_to_cart(np.array([radii, np.deg2rad(phi), np.deg2rad(theta)]).T)
     ch_pos = OrderedDict(zip(ch_names, pos))
 
     nasion, lpa, rpa = None, None, None

--- a/mne/channels/_standard_montage_utils.py
+++ b/mne/channels/_standard_montage_utils.py
@@ -240,6 +240,12 @@ def _read_theta_phi_in_degrees(fname, head_size, fid_names=None,
     ch_names, theta, phi = _safe_np_loadtxt(fname, skip_header=1,
                                             dtype=(_str, 'i4', 'i4'))
     if add_fiducials:
+        # Add fiducials based on 10/20 spherical coordinate definitions
+        # http://chgd.umich.edu/wp-content/uploads/2014/06/
+        # 10-20_system_positioning.pdf
+        # extrapolated from other sensor coordinates in the Easycap layouts
+        # https://www.easycap.de/wp-content/uploads/2018/02/
+        # Easycap-Equidistant-Layouts.pdf
         assert fid_names is None
         fid_names = ['Nasion', 'LPA', 'RPA']
         ch_names.extend(fid_names)

--- a/mne/channels/_standard_montage_utils.py
+++ b/mne/channels/_standard_montage_utils.py
@@ -50,13 +50,16 @@ def _easycap(basename, head_size):
 
     ch_pos = montage._get_ch_pos()
 
-    nasion = np.concatenate([[0], ch_pos['Fpz'][1:]])
-    lpa = np.mean([ch_pos['FT9'],
-                   ch_pos['TP9']], axis=0)
-    lpa *= head_size / np.linalg.norm(lpa)  # on sphere
-    rpa = np.mean([ch_pos['FT10'],
-                   ch_pos['TP10']], axis=0)
-    rpa *= head_size / np.linalg.norm(rpa)
+    if basename == 'easycap-M1.txt':
+        nasion = np.concatenate([[0], ch_pos['Fpz'][1:]])
+        lpa = np.mean([ch_pos['FT9'], ch_pos['TP9']], axis=0)
+        lpa *= head_size / np.linalg.norm(lpa)  # on sphere
+        rpa = np.mean([ch_pos['FT10'], ch_pos['TP10']], axis=0)
+        rpa *= head_size / np.linalg.norm(rpa)
+    elif basename == 'easycap-M10.txt':
+        nasion = lpa = rpa = None
+    else:
+        raise NotImplementedError("%r montage" % basename)
 
     fids_montage = make_dig_montage(
         coord_frame='unknown', nasion=nasion, lpa=lpa, rpa=rpa,
@@ -127,7 +130,7 @@ standard_montage_look_up_table = {
     'EGI_256': _egi_256,
 
     'easycap-M1': partial(_easycap, basename='easycap-M1.txt'),
-    'easycap-M10': partial(_easycap, basename='easycap-M1.txt'),
+    'easycap-M10': partial(_easycap, basename='easycap-M10.txt'),
 
     'GSN-HydroCel-128': partial(_hydrocel, basename='GSN-HydroCel-128.sfp'),
     'GSN-HydroCel-129': partial(_hydrocel, basename='GSN-HydroCel-129.sfp'),

--- a/mne/channels/_standard_montage_utils.py
+++ b/mne/channels/_standard_montage_utils.py
@@ -53,13 +53,15 @@ def _easycap(basename, head_size):
     if basename == 'easycap-M1.txt':
         nasion = np.concatenate([[0], ch_pos['Fpz'][1:]])
         lpa = np.mean([ch_pos['FT9'], ch_pos['TP9']], axis=0)
-        lpa *= head_size / np.linalg.norm(lpa)  # on sphere
         rpa = np.mean([ch_pos['FT10'], ch_pos['TP10']], axis=0)
-        rpa *= head_size / np.linalg.norm(rpa)
     elif basename == 'easycap-M10.txt':
-        nasion = lpa = rpa = None
+        nasion = np.concatenate([[0], ch_pos['35'][1:]])
+        lpa = np.mean([ch_pos['60'], ch_pos['59']], axis=0)
+        rpa = np.mean([ch_pos['52'], ch_pos['53']], axis=0)
     else:
         raise NotImplementedError("%r montage" % basename)
+    lpa *= head_size / np.linalg.norm(lpa)  # on sphere
+    rpa *= head_size / np.linalg.norm(rpa)
 
     fids_montage = make_dig_montage(
         coord_frame='unknown', nasion=nasion, lpa=lpa, rpa=rpa,

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -186,7 +186,7 @@ class DigMontage(object):
                 ' {fid:d} fiducials, {eeg:d} channels>').format(**n_points)
 
     @copy_function_doc_to_method_doc(plot_montage)
-    def plot(self, scale_factor=20, show_names=False, kind='3d', show=True,
+    def plot(self, scale_factor=20, show_names=True, kind='topomap', show=True,
              sphere=None):
         return plot_montage(self, scale_factor=scale_factor,
                             show_names=show_names, kind=kind, show=show,


### PR DESCRIPTION
There was a bug in the standard montage reader that read easycap-M1 even when `easycap-M10` was specified.

While investigating I also noticed that the `DigMontage.plot` default parameters don't agree with the documentation, below I changed the default parameters to match the docs (since the docs do agree with the default parameters of `plot_montage()`). 