### PR TITLE
FIX: Fix actor getting fetched from hemi data

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -993,15 +993,14 @@ class _Brain(object):
         user_colormap = self._data['user_colormap']
         transparent = self._data['transparent']
         time_idx = self._data['time_idx']
-        act_data = self._data['array']
-        if self._data['array'].ndim == 2:
-            if isinstance(time_idx, int):
-                act_data = act_data[:, time_idx]
-            else:
-                times = np.arange(self._n_times)
-                act_data = interp1d(
-                    times, act_data, 'linear', axis=1,
-                    assume_sorted=True)(time_idx)
+        array = self._data['array']
+        if isinstance(time_idx, int):
+            act_data = array[:, time_idx]
+        else:
+            times = np.arange(self._n_times)
+            act_data = interp1d(
+                times, array, 'linear', axis=1,
+                assume_sorted=True)(time_idx)
         colormap, scale_pts, diverging, transparent, _ = \
             _limits_to_control_points(clim, act_data, user_colormap,
                                       transparent, allow_pos_lims)
@@ -1013,17 +1012,18 @@ class _Brain(object):
         ctable = self.update_lut(fmin=fmin, fmid=fmid, fmax=fmax)
         ctable = (ctable * 255).astype(np.uint8)
         for hemi in ['lh', 'rh']:
-            actor = self._data.get(hemi + '_actor')
-            if actor is not None:
-                dt_max = fmax
-                dt_min = fmin if center is None else -1 * fmax
-                rng = [dt_min, dt_max]
-                if self._colorbar_added:
-                    scalar_bar = self._renderer.plotter.scalar_bar
-                else:
-                    scalar_bar = None
-                _set_colormap_range(actor, ctable, scalar_bar, rng)
-                self._data['ctable'] = ctable
+            hemi_data = self._data.get(hemi)
+            if hemi_data is not None:
+                for actor in hemi_data['actor']:
+                    dt_max = fmax
+                    dt_min = fmin if center is None else -1 * fmax
+                    rng = [dt_min, dt_max]
+                    if self._colorbar_added:
+                        scalar_bar = self._renderer.plotter.scalar_bar
+                    else:
+                        scalar_bar = None
+                    _set_colormap_range(actor, ctable, scalar_bar, rng)
+                    self._data['ctable'] = ctable
 
     @property
     def data(self):


### PR DESCRIPTION
After merging #7219, the API to fetch hemi data has changed in `_Brain`. The result is that although the values for the `auto-scaling` are correct, the colorbar is not changed. This PR updates the old method used in `update_auto_scaling()`.

Before | PR
----------|------
![2020-01-17_1920x1080](https://user-images.githubusercontent.com/18143289/72622840-52ec5200-3944-11ea-889e-0b8ff8e7f3f0.png) | ![2020-01-17_1920x1080](https://user-images.githubusercontent.com/18143289/72622770-33552980-3944-11ea-9983-c1255924cbe9.png)
