### PR TITLE
[WIP] Beamformer: Refactor the selection of optimal source orientation

### DIFF
--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -154,7 +154,8 @@ def _normalized_weights(Wk, Gk, Cm_inv_sq, reduce_rank, nn, sk):
     norm *= sk[:, np.newaxis, :]
     power = np.matmul(norm, np.matmul(Wk, Gk))  # np.dot for each source
 
-   # Determine orientation of max power
+    # Determine orientation of max power
+    assert power.shape == (Wk.shape[0], 3, 3)  # sources, 3, 3
     Wk = _pick_ori(power, Wk, Gk, Cm_inv_sq, nn)
 
 
@@ -177,6 +178,7 @@ def _pick_ori(power, Wk, Gk, Cm_inv, nn):
     """
     # Determine orientation of max power
     assert power.dtype in (np.float64, np.complex128)  # LCMV, DICS
+    assert power.ndim == 3 and power.shape[1:] == (3, 3)
     eig_vals, eig_vecs = np.linalg.eig(power)
     if not np.iscomplexobj(power) and np.iscomplexobj(eig_vecs):
         raise ValueError('The eigenspectrum of the leadfield is '

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -156,10 +156,10 @@ def _normalized_weights(Wk, Gk, Cm_inv_sq, reduce_rank, nn, sk):
 
     # Determine orientation of max power
     assert power.shape == (Wk.shape[0], 3, 3)  # sources, 3, 3
-    Wk = _pick_ori(power, Wk, Gk, Cm_inv_sq, nn)
+    Wk = _pick_max_power_ori(power, Wk, Gk, Cm_inv_sq, nn)
 
 
-def _pick_ori(power, Wk, Gk, Cm_inv, nn):
+def _pick_max_power_ori(power, Wk, Gk, Cm_inv, nn):
     """Pick the orientation that maximizes output power.
 
     Parameters
@@ -326,7 +326,7 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
                                       Wk.transpose(0, 2, 1))
 
                 # Determine orientation of max. power
-                Wk = _pick_ori(power, Wk, Gk, Cm_inv, nn)
+                Wk = _pick_max_power_ori(power, Wk, Gk, Cm_inv, nn)
 
     W = Wk.reshape(n_sources * n_orient, n_channels)
     del Gk, Wk, sk

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -154,6 +154,53 @@ def _normalized_weights(Wk, Gk, Cm_inv_sq, reduce_rank, nn, sk):
     norm *= sk[:, np.newaxis, :]
     power = np.matmul(norm, np.matmul(Wk, Gk))  # np.dot for each source
 
+    # import ipdb
+    # ipdb.set_trace()
+    Wk = _pick_ori(power, Wk, Gk, Cm_inv_sq, nn)
+
+    # # Determine orientation of max power
+    # assert power.dtype in (np.float64, np.complex128)  # LCMV, DICS
+    # eig_vals, eig_vecs = np.linalg.eig(power)
+    # if not np.iscomplexobj(power) and np.iscomplexobj(eig_vecs):
+    #     raise ValueError('The eigenspectrum of the leadfield is '
+    #                      'complex. Consider reducing the rank of the '
+    #                      'leadfield by using reduce_rank=True.')
+    # idx_max = np.argmax(eig_vals, axis=1)
+    # max_power_ori = eig_vecs[np.arange(eig_vecs.shape[0]), :, idx_max]
+
+    # # set the (otherwise arbitrary) sign to match the normal
+    # sign = np.sign(np.sum(max_power_ori * nn, axis=1, keepdims=True))
+    # sign[sign == 0] = 1
+    # max_power_ori *= sign
+
+    # # Compute the filter in the orientation of max power
+    # Wk_max = np.matmul(max_power_ori[:, np.newaxis], Wk)[:, 0]
+    # Gk_max = np.matmul(Gk, max_power_ori[:, :, np.newaxis])
+    # denom = np.matmul(Gk_max.transpose(0, 2, 1),
+    #                   np.matmul(Cm_inv_sq[np.newaxis], Gk_max))[:, 0]
+    # np.sqrt(denom, out=denom)
+    # Wk_max /= denom
+    # # All three entries get the same value from this operation
+    # Wk[:] = Wk_max[:, np.newaxis]
+
+
+def _pick_ori(power, Wk, Gk, Cm_inv, nn):
+    """Pick the orientation that maximizes output power.
+
+    Parameters
+    ----------
+    power : ndarray, shape (n_sources, 3, 3)
+        Power source estimate.
+    Wk : ndarray, shape (n_sources, 3, n_channels)
+        Part of the beamformer computation, G.T @ Cm_inv.
+    Gk : ndarray, shape (n_sources, n_channels, 3)
+        The leadfield matrix.
+    Cm_inv : ndarray, shape (n_channels, n_channels)
+        The inverted covariance matrix as used in the denominator of the
+        beamformer equation, can be Cm_inv or Cm_inv_squared.
+    nn : ndarray, shape (n_sources, 3)
+        The source normals.
+    """
     # Determine orientation of max power
     assert power.dtype in (np.float64, np.complex128)  # LCMV, DICS
     eig_vals, eig_vecs = np.linalg.eig(power)
@@ -173,11 +220,13 @@ def _normalized_weights(Wk, Gk, Cm_inv_sq, reduce_rank, nn, sk):
     Wk_max = np.matmul(max_power_ori[:, np.newaxis], Wk)[:, 0]
     Gk_max = np.matmul(Gk, max_power_ori[:, :, np.newaxis])
     denom = np.matmul(Gk_max.transpose(0, 2, 1),
-                      np.matmul(Cm_inv_sq[np.newaxis], Gk_max))[:, 0]
+                      np.matmul(Cm_inv[np.newaxis], Gk_max))[:, 0]
     np.sqrt(denom, out=denom)
     Wk_max /= denom
     # All three entries get the same value from this operation
     Wk[:] = Wk_max[:, np.newaxis]
+
+    return Wk
 
 
 @contextmanager
@@ -298,18 +347,20 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
                     # the cov matrix.
                     power = np.matmul(np.matmul(Wk, Cm),
                                       Wk.transpose(0, 2, 1))
-                assert power.shape == (n_sources, 3, 3)
-                _, u_ = np.linalg.eigh(power.real)
-                max_power_ori = u_[:, :, -1]
-                assert max_power_ori.shape == (n_sources, 3)
 
-                # set the (otherwise arbitrary) sign to match the normal
-                signs = np.sign(np.sum(max_power_ori * nn, axis=1))
-                signs[signs == 0] = 1.
-                max_power_ori *= signs[:, np.newaxis]
-                # all three entries get the same value from this operation
-                Wk[:] = np.sum(max_power_ori[:, :, np.newaxis] * Wk, axis=1,
-                               keepdims=True)
+                Wk = _pick_ori(power, Wk, Gk, Cm_inv, nn)
+                # assert power.shape == (n_sources, 3, 3)
+                # _, u_ = np.linalg.eigh(power.real)
+                # max_power_ori = u_[:, :, -1]
+                # assert max_power_ori.shape == (n_sources, 3)
+
+                # # set the (otherwise arbitrary) sign to match the normal
+                # signs = np.sign(np.sum(max_power_ori * nn, axis=1))
+                # signs[signs == 0] = 1.
+                # max_power_ori *= signs[:, np.newaxis]
+                # # all three entries get the same value from this operation
+                # Wk[:] = np.sum(max_power_ori[:, :, np.newaxis] * Wk, axis=1,
+                #                keepdims=True)
     W = Wk.reshape(n_sources * n_orient, n_channels)
     del Gk, Wk, sk
 

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -165,7 +165,7 @@ def _pick_ori(power, Wk, Gk, Cm_inv, nn):
     Parameters
     ----------
     power : ndarray, shape (n_sources, 3, 3)
-        Power source estimate.
+        Source covariance, with power source estimate on diagonal.
     Wk : ndarray, shape (n_sources, 3, n_channels)
         Part of the beamformer computation, G.T @ Cm_inv.
     Gk : ndarray, shape (n_sources, n_channels, 3)


### PR DESCRIPTION
Refactoring of the different code path for source orientation selection `pick_ori='max-power'` in the beamformer. Now, both `weight_norm=None` and `weight_norm='unit-noise-gain'` use the code.

This is the first step to see whether the former code paths really differ a lot - and the first step to cleaner code. 
**Tests** might fail at this stage for the `weight_norm=None` case and might need to be adapted after further evaluation.

@wmvanvliet can you see what this gives us with the simulation?

Will solve issue #7225 
