### PR TITLE
FIX: Disable depth peeling for multi-views

### DIFF
--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -144,6 +144,7 @@ class _Renderer(_BaseRenderer):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)
             self.plotter.subplot(x, y)
+            self.plotter.disable_depth_peeling()
 
     def scene(self):
         return self.figure


### PR DESCRIPTION
This PR is a follow-up of #7207 and disables depth peeling for all the views (not only the first one).