### PR TITLE
TST: Opt in BackgroundPlotter alpha testing

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - mne
   - https://api.github.com/repos/numpy/numpydoc/zipball/master
   - vtk
-  - https://api.github.com/repos/pyvista/pyvista/zipball/master
+  - https://api.github.com/repos/pyvista/pyvista/zipball/backgroundplotter_sphinx_test
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ xlrd
 pydocstyle
 flake8
 https://github.com/mcmtroffaes/sphinxcontrib-bibtex/zipball/29694f215b39d64a31b845aafd9ff2ae9329494f
-https://github.com/pyvista/pyvista/zipball/master
+https://github.com/pyvista/pyvista/zipball/backgroundplotter_sphinx_test


### PR DESCRIPTION
This PR borrows the CIs to test the new API of `BackgroundPlotter`. This is not intended to be merged. It will be closed after testing.

Related to #7228, https://github.com/pyvista/pyvista/pull/548