### PR TITLE
FIX: Add support for hemi=both in _TimeViewer

### DIFF
--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -429,19 +429,6 @@ class _TimeViewer(object):
             if not show_label:
                 slider_rep.ShowSliderLabelOff()
 
-            # add support for split window
-            shape = self.plotter.shape
-            pointa = slider_rep.GetPoint1Coordinate().GetValue()
-            pointb = slider_rep.GetPoint2Coordinate().GetValue()
-            pointa = _normalize(pointa, shape)
-            pointb = _normalize(pointb, shape)
-            slider_rep.GetPoint1Coordinate().\
-                SetCoordinateSystemToNormalizedDisplay()
-            slider_rep.GetPoint1Coordinate().SetValue(pointa[0], pointa[1])
-            slider_rep.GetPoint2Coordinate().\
-                SetCoordinateSystemToNormalizedDisplay()
-            slider_rep.GetPoint2Coordinate().SetValue(pointb[0], pointb[1])
-
 
 def _set_text_style(text_actor):
     if text_actor is not None:

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -164,6 +164,9 @@ class _TimeViewer(object):
 
         for hemi in self.brain._hemis:
             ci = 0 if hemi == 'lh' else 1
+            # with both, all hemis are on the same view
+            if self.brain._hemi == 'both':
+                ci = 0
             for ri, view in enumerate(self.brain._views):
                 self.plotter.subplot(ri, ci)
                 name = "orientation_" + str(ri) + "_" + str(ci)


### PR DESCRIPTION
This PR fixes the support of `hemi=both` for the `_TimeViewer`. I also ported the patch from #7227.

Closes #7250 