### PR TITLE
MRG: Update stc.plot documentation about hemi

### DIFF
--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1562,8 +1562,11 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
         is None, the environment will be used.
     surface : str
         The type of surface (inflated, white etc.).
-    hemi : str, 'lh' | 'rh' | 'split' | 'both'
-        The hemisphere to display.
+    hemi : str
+        Hemisphere id (ie 'lh', 'rh', 'both', or 'split'). In the case
+        of 'both', both hemispheres are shown in the same window.
+        In the case of 'split' hemispheres are displayed side-by-side
+        in different viewing panes.
     %(colormap)s
         The default ('auto') uses 'hot' for one-sided data and
         'mne' for two-sided data.


### PR DESCRIPTION
This PR follows https://github.com/mne-tools/mne-python/issues/7250#issuecomment-578122285 and updates the documentation of `hemi` in `plot_source_estimates()` (which in turn will affect `stc.plot()`). Hopefully it's clearer now.

It's an item of https://github.com/mne-tools/mne-python/issues/7162