### PR TITLE
FIX: fix sphere radius in topomap

### DIFF
--- a/examples/visualization/plot_evoked_topomap.py
+++ b/examples/visualization/plot_evoked_topomap.py
@@ -100,7 +100,7 @@ for ax, extr in zip(axes, extrapolations):
 # post-stimulus, add channel labels, title and adjust plot margins:
 evoked.plot_topomap(0.1, ch_type='mag', show_names=True, colorbar=False,
                     size=6, res=128, title='Auditory response',
-                    time_unit='s')
+                    time_unit='s', extrapolate='local', border='mean')
 plt.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.88)
 
 ###############################################################################

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -208,7 +208,7 @@ def test_plot_topomap_basic():
     img_data = ax.get_array().data
 
     assert np.abs(img_data[31, 31] - data[0]) < 0.12
-    assert np.abs(img_data[31, 1]) < 0.1
+    assert np.abs(img_data[10, 54]) < 0.3
 
     # border='mean'
     ax, _ = plot_topomap(data, info, extrapolate='head', border='mean',
@@ -216,7 +216,7 @@ def test_plot_topomap_basic():
     img_data = ax.get_array().data
 
     assert np.abs(img_data[31, 31] - data[0]) < 0.12
-    assert img_data[31, 31] > 5
+    assert img_data[10, 54] > 5
 
     # error when not numeric or str:
     error_msg = 'border must be an instance of numeric or str'

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -505,10 +505,11 @@ def _get_extra_points(pos, extrapolate, sphere):
         new_pos = np.concatenate([hull_extended] + add_points)
     else:
         # return points on the head circle
-        angle = np.arcsin(distance / 2 / head_radius) * 2
+        angle = np.arcsin(distance / 2 / head_radius)
         points_l = np.arange(0, 2 * np.pi, angle)
-        points_x = np.cos(points_l) * head_radius + x
-        points_y = np.sin(points_l) * head_radius + y
+        use_radius = head_radius * 1.1
+        points_x = np.cos(points_l) * use_radius + x
+        points_y = np.sin(points_l) * use_radius + y
         new_pos = np.stack([points_x, points_y], axis=1)
         if colinear:
             tri = Delaunay(np.concatenate([pos, new_pos], axis=0))

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -754,7 +754,7 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
             data = _merge_grad_data(data[picks]).reshape(-1)
         else:
             picks = list(range(data.shape[0]))
-            pos = _find_topomap_coords(pos, picks=picks)
+            pos = _find_topomap_coords(pos, picks=picks, sphere=sphere)
 
     if data.ndim > 1:
         raise ValueError("Data needs to be array of shape (n_sensors,); got "


### PR DESCRIPTION
@larsoner
That was the tiny bug that caused sphere not being of requested radius. The `sphere` variable was not passed to `_find_topomap_coords`.

Now it looks a bit better:
<img src="https://user-images.githubusercontent.com/8452354/73191261-7de65b00-4127-11ea-97bc-a6a5eaa72e18.png" width="200px">

but the extrapolation is still not correct. I will check in a while, maybethe `sphere` is not passed also to some extrapolation functions?

### TODO:
- [x] change / fix previous border test
- [x] fix extrapolation