### PR TITLE
MRG, ENH: Allow using multiclass roc_auc

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -116,6 +116,8 @@ Bug
 
 - Fix :func:`mne.io.read_raw_cnt` for version 1 of format in the presence of annotations by `Alex Gramfort`_.
 
+- Fix :class:`mne.decoding.GeneralizingEstimator` and related classes to support multi-class sklearn scorers such as ``'roc_auc_ovo'`` and ``'roc_auc_ovo_weighted'`` by `Eric Larson`_
+
 - Fix :meth:`mne.io.read_raw_ctf` to set measurement date from CTF ds files by `Luke Bloy`_.
 
 - Fix :meth:`mne.io.read_raw_brainvision` when channel names have spaces by `Sebastian Major`_.

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -684,11 +684,10 @@ def _fix_auc(scoring, y):
     # This fixes sklearn's inability to compute roc_auc when y not in [0, 1]
     # scikit-learn/scikit-learn#6874
     if scoring is not None:
-        if (
-            hasattr(scoring, '_score_func') and
-            hasattr(scoring._score_func, '__name__') and
-            scoring._score_func.__name__ == 'roc_auc_score'
-        ):
+        score_func = getattr(scoring, '_score_func', None)
+        kwargs = getattr(scoring, '_kwargs', {})
+        if (getattr(score_func, '__name__', '') == 'roc_auc_score' and
+                kwargs.get('multi_class', 'raise') == 'raise'):
             if np.ndim(y) != 1 or len(set(y)) != 2:
                 raise ValueError('roc_auc scoring can only be computed for '
                                  'two-class problems.')


### PR DESCRIPTION
As of https://github.com/scikit-learn/scikit-learn/pull/15274 it should be possible (and correct?) to be able to use `roc_auc` with multiclass problems, provided you use `ovo` scoring.

@agramfort let me know if this is incorrect, or if it's still not advisable. I am somewhat naively using `roc_auc_ovo_weighted` for my multiclass one-vs-rest classification...