### PR TITLE
MRG, MAINT: Fixes for matplotlib deprecations

### DIFF
--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -453,10 +453,11 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
                 # plot channels
                 for ch_idx, z in enumerate(z_ord):
                     line_list.append(
-                        ax.plot(times, D[ch_idx], picker=3.,
+                        ax.plot(times, D[ch_idx], picker=True,
                                 zorder=z + 1 if spatial_colors is True else 1,
                                 color=colors[ch_idx], alpha=line_alpha,
                                 linewidth=0.5)[0])
+                    line_list[-1].set_pickradius(3.)
 
             if gfp:  # 'only' or boolean True
                 gfp_color = 3 * (0.,) if spatial_colors is True else (0., 1.,

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -170,7 +170,7 @@ def _add_colorbar(ax, im, cmap, side="right", pad=.05, title=None,
     from mpl_toolkits.axes_grid1 import make_axes_locatable  # noqa: F401
     divider = make_axes_locatable(ax)
     cax = divider.append_axes(side, size=size, pad=pad)
-    cbar = plt.colorbar(im, cax=cax, cmap=cmap, format=format)
+    cbar = plt.colorbar(im, cax=cax, format=format)
     if cmap is not None and cmap[1]:
         ax.CB = DraggableColorbar(cbar, im)
     if title is not None:


### PR DESCRIPTION
Fixes a `picker` deprecation and that there is no need to pass `cmap` because it's part of `im`.