### PR TITLE
MRG, FIX: Fix bug with update

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -132,6 +132,8 @@ Bug
 
 - The attribute :class:`mne.Annotations.orig_time <mne.Annotations>` is now read-only, and is a :class:`~python:datetime.datetime` object (or None) rather than float, by `Eric Larson`_
 
+- Fix bug where MRI distances were not properly initialized in :ref:`gen_mne_coreg` by `Eric Larson`_
+
 - Fix ``xscale='log'`` in :meth:`mne.io.Raw.plot_psd` and related functions by `Alex Gramfort`_
 
 - Unify behavior of ``raw.annotations.append(...)`` when ``raw.info['meas_date']`` is None to make onsets absolute relative to ``first_samp`` as they are when ``raw.info['meas_date']`` is not None; i.e., you might need to do ``raw.annotations.append(old_time + raw.first_time)``, by `Eric Larson`_

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -485,12 +485,12 @@ class CoregModel(HasPrivateTraits):
         return points
 
     def _nearest_calc_default(self):
-        return _DistanceQuery(np.zeros((1, 3)))
+        return _DistanceQuery(
+            self.processed_high_res_mri_points * self.parameters[6:9])
 
     @on_trait_change('processed_high_res_mri_points')
     def _update_nearest_calc(self):
-        self.nearest_calc = _DistanceQuery(
-            self.processed_high_res_mri_points * self.parameters[6:9])
+        self.nearest_calc = self._nearest_calc_default()
 
     @cached_property
     def _get_transformed_high_res_mri_points(self):

--- a/mne/gui/_marker_gui.py
+++ b/mne/gui/_marker_gui.py
@@ -13,7 +13,7 @@ from mayavi.tools.mlab_scene_model import MlabSceneModel
 from pyface.api import confirm, error, FileDialog, OK, YES
 from traits.api import (HasTraits, HasPrivateTraits, on_trait_change,
                         cached_property, Instance, Property, Array, Bool,
-                        Button, Enum, File, Float, List, Str)
+                        Button, Enum, File, Float, List, Str, ArrayOrNone)
 from traitsui.api import View, Item, HGroup, VGroup, CheckListEditor
 from traitsui.menu import Action, CancelButton
 
@@ -217,7 +217,7 @@ class MarkerPointDest(MarkerPoints):  # noqa: D401
     name = Property(Str, depends_on='src1.name,src2.name')
     dir = Property(Str, depends_on='src1.dir,src2.dir')
 
-    points = Property(Array(float, (5, 3)),
+    points = Property(ArrayOrNone(float, (5, 3)),
                       depends_on=['method', 'src1.points', 'src1.use',
                                   'src2.points', 'src2.use'])
     enabled = Property(Bool, depends_on=['points'])

--- a/mne/gui/_viewer.py
+++ b/mne/gui/_viewer.py
@@ -14,7 +14,8 @@ from mayavi.sources.vtk_data_source import VTKDataSource
 from mayavi.tools.mlab_scene_model import MlabSceneModel
 from traits.api import (HasTraits, HasPrivateTraits, on_trait_change,
                         Instance, Array, Bool, Button, Enum, Float, Int, List,
-                        Range, Str, RGBColor, Property, cached_property)
+                        Range, Str, RGBColor, Property, cached_property,
+                        ArrayOrNone)
 from traitsui.api import (View, Item, HGroup, VGrid, VGroup, Spring,
                           TextEditor)
 from tvtk.api import tvtk
@@ -208,7 +209,7 @@ class PointObject(Object):
     # projection onto a surface
     nearest = Instance(_DistanceQuery)
     check_inside = Instance(_CheckInside)
-    project_to_trans = Array(float, shape=(4, 4))
+    project_to_trans = ArrayOrNone(float, shape=(4, 4))
     project_to_surface = Bool(False, label='Project', desc='project points '
                               'onto the surface')
     orient_to_surface = Bool(False, label='Orient', desc='orient points '

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -16,6 +16,7 @@ import pytest
 import mne
 from mne.datasets import testing
 from mne.io.kit.tests import data_dir as kit_data_dir
+from mne.surface import dig_mri_distances
 from mne.transforms import invert_transform
 from mne.utils import (run_tests_if_main, requires_mayavi, traits_test,
                        modified_env)
@@ -314,6 +315,37 @@ def test_coreg_model_with_fsaverage(tmpdir):
     assert model.hsp.n_omitted == 1
     model.hsp.file = kit_raw_path
     assert model.hsp.n_omitted == 0
+
+
+@testing.requires_testing_data
+@requires_mayavi
+@traits_test
+def test_coreg_gui_automation():
+    """Test that properties get properly updated."""
+    from mne.gui._file_traits import DigSource
+    from mne.gui._fiducials_gui import MRIHeadWithFiducialsModel
+    from mne.gui._coreg_gui import CoregModel
+    subject = 'sample'
+    hsp = DigSource()
+    hsp.file = raw_path
+    mri = MRIHeadWithFiducialsModel(subjects_dir=subjects_dir, subject=subject)
+    model = CoregModel(mri=mri, hsp=hsp)
+    # gh-7254
+    assert not (model.nearest_transformed_high_res_mri_idx_hsp == 0).all()
+    model.fit_fiducials()
+    model.icp_iterations = 2
+    model.nasion_weight = 2.
+    model.fit_icp()
+    model.omit_hsp_points(distance=5e-3)
+    model.icp_iterations = 2
+    model.fit_icp()
+    errs_icp = np.median(
+        model._get_point_distance())
+    assert 2e-3 < errs_icp < 3e-3
+    info = mne.io.read_info(raw_path)
+    errs_nearest = np.median(
+        dig_mri_distances(info, fname_trans, subject, subjects_dir))
+    assert 1e-3 < errs_nearest < 2e-3
 
 
 run_tests_if_main()


### PR DESCRIPTION
Closes #7254

@zuxfoucault can you confirm this fixes your problem?

The fix I came up with with was just to set `_nearest_calc_default` to actually use the processed points. The `ArrayOrNone` changes are just to help us ensure that we don't use values before we should, and thankfully they do not break anything at least in local testing.