### PR TITLE
MRG: Refactor OFF_SCREEN variable

### DIFF
--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -142,9 +142,8 @@ def test_brain_timeviewer(renderer):
     if renderer.get_3d_backend() == "mayavi":
         pytest.skip()  # Skip PySurfer.TimeViewer
     else:
-        # Disable testing to allow interactive window-
-        import pyvista
-        pyvista.OFF_SCREEN = False
+        # Disable testing to allow interactive window
+        renderer.MNE_3D_OFF_SCREEN = False
         renderer.MNE_3D_BACKEND_TESTING = False
 
     sample_src = read_source_spaces(src_fname)

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -141,9 +141,12 @@ def test_brain_timeviewer(renderer):
     """Test _TimeViewer primitives."""
     if renderer.get_3d_backend() == "mayavi":
         pytest.skip()  # Skip PySurfer.TimeViewer
-    else:
+    elif renderer.get_3d_backend() == "pyvista":
+        # Widgets are not available offscreen
+        import pyvista
+        orig_offscreen = pyvista.OFF_SCREEN
+        pyvista.OFF_SCREEN = False
         # Disable testing to allow interactive window
-        renderer.MNE_3D_OFF_SCREEN = False
         renderer.MNE_3D_BACKEND_TESTING = False
 
     sample_src = read_source_spaces(src_fname)
@@ -191,6 +194,9 @@ def test_brain_timeviewer(renderer):
     link_viewer.set_time_point(value=0)
     link_viewer.set_playback_speed(value=0.1)
     link_viewer.toggle_playback()
+
+    if renderer.get_3d_backend() == "pyvista":
+        pyvista.OFF_SCREEN = orig_offscreen
 
 
 def test_brain_colormap():

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -114,7 +114,8 @@ class _Renderer(_BaseRenderer):
 
     def __init__(self, fig=None, size=(600, 600), bgcolor='black',
                  name="PyVista Scene", show=False, shape=(1, 1)):
-        from .renderer import MNE_3D_BACKEND_TESTING, MNE_3D_OFF_SCREEN
+        from pyvista import OFF_SCREEN
+        from .renderer import MNE_3D_BACKEND_TESTING
         figure = _Figure(title=name, size=size, shape=shape,
                          background_color=bgcolor, notebook=None)
         self.font_family = "arial"
@@ -132,7 +133,7 @@ class _Renderer(_BaseRenderer):
             self.figure = fig
 
         # Enable off_screen if sphinx-gallery or testing
-        if MNE_3D_OFF_SCREEN:
+        if OFF_SCREEN:
             self.figure.store['off_screen'] = True
 
         with warnings.catch_warnings():

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -114,8 +114,7 @@ class _Renderer(_BaseRenderer):
 
     def __init__(self, fig=None, size=(600, 600), bgcolor='black',
                  name="PyVista Scene", show=False, shape=(1, 1)):
-        from pyvista import OFF_SCREEN
-        from .renderer import MNE_3D_BACKEND_TESTING
+        from .renderer import MNE_3D_BACKEND_TESTING, MNE_3D_OFF_SCREEN
         figure = _Figure(title=name, size=size, shape=shape,
                          background_color=bgcolor, notebook=None)
         self.font_family = "arial"
@@ -133,7 +132,7 @@ class _Renderer(_BaseRenderer):
             self.figure = fig
 
         # Enable off_screen if sphinx-gallery or testing
-        if OFF_SCREEN:
+        if MNE_3D_OFF_SCREEN:
             self.figure.store['off_screen'] = True
 
         with warnings.catch_warnings():

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -15,6 +15,7 @@ from ...utils import logger, verbose, get_config, _check_option
 
 MNE_3D_BACKEND = None
 MNE_3D_BACKEND_TESTING = False
+MNE_3D_OFF_SCREEN = False
 
 
 _fromlist = ('_Renderer', '_Projection', '_close_all', '_check_3d_figure',
@@ -167,14 +168,19 @@ def _use_test_3d_backend(backend_name):
     backend_name : str
         The 3d backend to use in the context.
     """
+    global MNE_3D_OFF_SCREEN
     global MNE_3D_BACKEND_TESTING
+    orig_offscreen = MNE_3D_OFF_SCREEN
+    orig_testing = MNE_3D_BACKEND_TESTING
+    MNE_3D_OFF_SCREEN = True
     MNE_3D_BACKEND_TESTING = True
     try:
         with use_3d_backend(backend_name):
             with _testing_context():  # noqa: F821
                 yield
     finally:
-        MNE_3D_BACKEND_TESTING = False
+        MNE_3D_OFF_SCREEN = orig_offscreen
+        MNE_3D_BACKEND_TESTING = orig_testing
 
 
 def set_3d_view(figure, azimuth=None, elevation=None,

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -15,7 +15,6 @@ from ...utils import logger, verbose, get_config, _check_option
 
 MNE_3D_BACKEND = None
 MNE_3D_BACKEND_TESTING = False
-MNE_3D_OFF_SCREEN = False
 
 
 _fromlist = ('_Renderer', '_Projection', '_close_all', '_check_3d_figure',
@@ -168,18 +167,14 @@ def _use_test_3d_backend(backend_name):
     backend_name : str
         The 3d backend to use in the context.
     """
-    global MNE_3D_OFF_SCREEN
     global MNE_3D_BACKEND_TESTING
-    orig_offscreen = MNE_3D_OFF_SCREEN
     orig_testing = MNE_3D_BACKEND_TESTING
-    MNE_3D_OFF_SCREEN = True
     MNE_3D_BACKEND_TESTING = True
     try:
         with use_3d_backend(backend_name):
             with _testing_context():  # noqa: F821
                 yield
     finally:
-        MNE_3D_OFF_SCREEN = orig_offscreen
         MNE_3D_BACKEND_TESTING = orig_testing
 
 

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -672,9 +672,12 @@ def test_link_brains(renderer):
     """Test plotting linked brains."""
     if renderer.get_3d_backend() == "mayavi":
         pytest.skip()  # Skip PySurfer.TimeViewer
-    else:
+    elif renderer.get_3d_backend() == "pyvista":
+        # Widgets are not available offscreen
+        import pyvista
+        orig_offscreen = pyvista.OFF_SCREEN
+        pyvista.OFF_SCREEN = False
         # Disable testing to allow interactive window
-        renderer.MNE_3D_OFF_SCREEN = False
         renderer.MNE_3D_BACKEND_TESTING = False
     with pytest.raises(ValueError, match='is empty'):
         link_brains([])
@@ -700,6 +703,9 @@ def test_link_brains(renderer):
         clim='auto'
     )
     link_brains(brain)
+
+    if renderer.get_3d_backend() == "pyvista":
+        pyvista.OFF_SCREEN = orig_offscreen
 
 
 run_tests_if_main()

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -674,8 +674,7 @@ def test_link_brains(renderer):
         pytest.skip()  # Skip PySurfer.TimeViewer
     else:
         # Disable testing to allow interactive window
-        import pyvista
-        pyvista.OFF_SCREEN = False
+        renderer.MNE_3D_OFF_SCREEN = False
         renderer.MNE_3D_BACKEND_TESTING = False
     with pytest.raises(ValueError, match='is empty'):
         link_brains([])


### PR DESCRIPTION
This PR prevents setting `pyvista.OFF_SCREEN` globally (*i.e.* in tests, ... etc) by managing a renderer `MNE_3D_OFF_SCREEN` variable instead.

Also, before #7266, the [tests were done offscreen by default](https://github.com/mne-tools/mne-python/pull/7266/files#diff-7d015438f1f32b2f4c28f713c2e3e7b1L130) with `_use_test_3d_backend()` so this PR fixes this.

This variable is still set globally in `_testing_context()` (this one restores the original value) and in the `doc` which is fine by me.