### PR TITLE
MRG, MAINT: Refactor clim handling

### DIFF
--- a/examples/inverse/plot_lcmv_beamformer_volume.py
+++ b/examples/inverse/plot_lcmv_beamformer_volume.py
@@ -3,8 +3,8 @@
 Compute LCMV inverse solution in volume source space
 ====================================================
 
-Compute LCMV beamformer on an auditory evoked dataset in a volume source space,
-and show activation on ``fsaverage``.
+Compute LCMV beamformers on an auditory evoked dataset in a volume source
+space, and show activation on ``fsaverage``.
 """
 # Author: Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -3101,7 +3101,7 @@ def plot_brain_colorbar(ax, clim, colormap='auto', transparent=True,
     ticks = _get_map_ticks(mapdata)
     colormap, lims = _linearize_map(mapdata)
     del mapdata
-    norm = Normalize(vmin=lims[0], vmax=lims[1])
+    norm = Normalize(vmin=lims[0], vmax=lims[2])
     cbar = ColorbarBase(ax, colormap, norm=norm, ticks=ticks,
                         label=label, orientation=orientation)
     # make the colorbar background match the brain color

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1222,36 +1222,42 @@ def _sensor_shape(coil):
     return rrs, tris
 
 
-def _limits_to_control_points(clim, stc_data, colormap, transparent,
-                              allow_pos_lims=True, linearize=False):
-    """Convert limits (values or percentiles) to control points.
+def _process_clim(clim, colormap, transparent, data=0., allow_pos_lims=True):
+    """Convert colormap/clim options to dict.
 
-    This function also does the nonlinear scaling of the colormap in the
-    case of a diverging colormap, and it forces transparency in the
-    alpha channel.
+    This fills in any "auto" entries properly such that round-trip
+    calling gives the same results.
     """
     # Based on type of limits specified, get cmap control points
     import matplotlib.pyplot as plt
-    from matplotlib.colors import ListedColormap
-    if colormap == 'auto':
-        if clim == 'auto':
-            if allow_pos_lims and (stc_data < 0).any():
-                colormap = 'mne'
+    from matplotlib.colors import Colormap
+    _validate_type(colormap, (str, Colormap), 'colormap')
+    data = np.asarray(data)
+    if isinstance(colormap, str):
+        if colormap == 'auto':
+            if clim == 'auto':
+                if allow_pos_lims and (data < 0).any():
+                    colormap = 'mne'
+                else:
+                    colormap = 'hot'
             else:
-                colormap = 'hot'
+                if 'lims' in clim:
+                    colormap = 'hot'
+                else:  # 'pos_lims' in clim
+                    colormap = 'mne'
+        if colormap in ('mne', 'mne_analyze'):
+            colormap = mne_analyze_colormap([0, 1, 2], format='matplotlib')
         else:
-            if 'lims' in clim:
-                colormap = 'hot'
-            else:  # 'pos_lims' in clim
-                colormap = 'mne'
+            colormap = plt.get_cmap(colormap)
+    assert isinstance(colormap, Colormap)
     diverging_maps = ['PiYG', 'PRGn', 'BrBG', 'PuOr', 'RdGy', 'RdBu',
                       'RdYlBu', 'RdYlGn', 'Spectral', 'coolwarm', 'bwr',
                       'seismic']
     diverging_maps += [d + '_r' for d in diverging_maps]
-    diverging_maps += ['mne', 'mne_analyze', ]
+    diverging_maps += ['mne', 'mne_analyze']
     if clim == 'auto':
         # this is merely a heuristic!
-        if allow_pos_lims and colormap in diverging_maps:
+        if allow_pos_lims and colormap.name in diverging_maps:
             key = 'pos_lims'
         else:
             key = 'lims'
@@ -1265,8 +1271,8 @@ def _limits_to_control_points(clim, stc_data, colormap, transparent,
     if 'pos_lims' in clim and not allow_pos_lims:
         raise ValueError('Cannot use "pos_lims" for clim, use "lims" '
                          'instead')
-    diverging_lims = 'pos_lims' in clim
-    ctrl_pts = np.array(clim['pos_lims' if diverging_lims else 'lims'])
+    diverging = 'pos_lims' in clim
+    ctrl_pts = np.array(clim['pos_lims' if diverging else 'lims'])
     ctrl_pts = np.array(ctrl_pts, float)
     if ctrl_pts.shape != (3,):
         raise ValueError('clim has shape %s, it must be (3,)'
@@ -1277,60 +1283,77 @@ def _limits_to_control_points(clim, stc_data, colormap, transparent,
     clim_kind = clim.get('kind', 'percent')
     _check_option("clim['kind']", clim_kind, ['value', 'values', 'percent'])
     if clim_kind == 'percent':
-        perc_data = np.abs(stc_data) if diverging_lims else stc_data
+        perc_data = np.abs(data) if diverging else data
         ctrl_pts = np.percentile(perc_data, ctrl_pts)
         logger.info('Using control points %s' % (ctrl_pts,))
+    assert len(ctrl_pts) == 3
+    clim = dict(kind='value')
+    clim['pos_lims' if diverging else 'lims'] = ctrl_pts
+    mapdata = dict(clim=clim, colormap=colormap, transparent=transparent)
+    return mapdata
+
+
+def _separate_map(mapdata):
+    """Help plotters that cannot handle limit equality."""
+    diverging = 'pos_lims' in mapdata['clim']
+    key = 'pos_lims' if diverging else 'lims'
+    ctrl_pts = np.array(mapdata['clim'][key])
+    assert ctrl_pts.shape == (3,)
     if len(set(ctrl_pts)) == 1:  # three points match
         if ctrl_pts[0] == 0:  # all are zero
             warn('All data were zero')
             ctrl_pts = np.arange(3, dtype=float)
-            ticks = [0]
         else:
             ctrl_pts *= [0., 0.5, 1]  # all nonzero pts == max
-            ticks = ctrl_pts[-1:]
     elif len(set(ctrl_pts)) == 2:  # two points match
         # if points one and two are identical, add a tiny bit to the
         # control point two; if points two and three are identical,
         # subtract a tiny bit from point two.
         bump = 1e-5 if ctrl_pts[0] == ctrl_pts[1] else -1e-5
         ctrl_pts[1] = ctrl_pts[0] + bump * (ctrl_pts[2] - ctrl_pts[0])
-        ticks = ctrl_pts[::2]
-    else:
-        ticks = ctrl_pts
+    mapdata['clim'][key] = ctrl_pts
 
-    if colormap in ('mne', 'mne_analyze'):
-        colormap = mne_analyze_colormap([0, 1, 2], format='matplotlib')
-    # scale colormap so that the bounds given by scale_pts actually work
-    colormap = plt.get_cmap(colormap)
-    if diverging_lims:
-        # remap -ctrl_norm[2]->ctrl_norm[2] to 0->1
-        ctrl_norm = np.concatenate([-ctrl_pts[::-1] / ctrl_pts[2], [0],
-                                    ctrl_pts / ctrl_pts[2]]) / 2 + 0.5
+
+def _linearize_map(mapdata):
+    from matplotlib.colors import ListedColormap
+    diverging = 'pos_lims' in mapdata['clim']
+    scale_pts = mapdata['clim']['pos_lims' if diverging else 'lims']
+    if diverging:
+        lims = [-scale_pts[2], scale_pts[2]]
+        ctrl_norm = np.concatenate([-scale_pts[::-1] / scale_pts[2], [0],
+                                    scale_pts / scale_pts[2]]) / 2 + 0.5
         linear_norm = [0, 0.25, 0.5, 0.5, 0.5, 0.75, 1]
         trans_norm = [1, 1, 0, 0, 0, 1, 1]
-        scale_pts = [-ctrl_pts[2], ctrl_pts[2]]
-        idx = int(ticks[0] == 0)
-        ticks = list(-np.array(ticks[idx:])[::-1]) + [0] + list(ticks[idx:])
     else:
-        # remap ctrl_norm[0]->ctrl_norm[2] to 0->1
-        ctrl_norm = [
-            0, (ctrl_pts[1] - ctrl_pts[0]) / (ctrl_pts[2] - ctrl_pts[0]), 1]
+        lims = [scale_pts[0], scale_pts[2]]
+        range_ = scale_pts[2] - scale_pts[0]
+        mid = (scale_pts[1] - scale_pts[0]) / range_ if range_ > 0 else 0.5
+        ctrl_norm = [0, mid, 1]
         linear_norm = [0, 0.5, 1]
         trans_norm = [0, 1, 1]
-        scale_pts = [ctrl_pts[0], ctrl_pts[2]]
-    if linearize:  # matplotlib
-        # do the piecewise linear transformation
-        interp_to = np.linspace(0, 1, 256)
-        colormap = np.array(colormap(
-            np.interp(interp_to, ctrl_norm, linear_norm)))
-        if transparent:
-            colormap[:, 3] = np.interp(interp_to, ctrl_norm, trans_norm)
-        assert len(scale_pts) == 2
-        scale_pts = np.array([scale_pts[0], np.mean(scale_pts), scale_pts[1]])
-        colormap = ListedColormap(colormap)
-    else:  # mayavi / PySurfer will do the transformation for us
-        scale_pts = ctrl_pts
-    return colormap, scale_pts, diverging_lims, transparent, ticks
+    # do the piecewise linear transformation
+    interp_to = np.linspace(0, 1, 256)
+    colormap = np.array(mapdata['colormap'](
+        np.interp(interp_to, ctrl_norm, linear_norm)))
+    if mapdata['transparent']:
+        colormap[:, 3] = np.interp(interp_to, ctrl_norm, trans_norm)
+    lims = np.array([lims[0], np.mean(lims), lims[1]])
+    colormap = ListedColormap(colormap)
+    return colormap, lims
+
+
+def _get_map_ticks(mapdata):
+    diverging = 'pos_lims' in mapdata['clim']
+    ticks = mapdata['clim']['pos_lims' if diverging else 'lims']
+    delta = 1e-2 * (ticks[2] - ticks[0])
+    if ticks[1] <= ticks[0] + delta:  # Only two worth showing
+        ticks = ticks[::2]
+    if ticks[1] <= ticks[0] + delta:  # Actually only one
+        ticks = ticks[::2]
+    if diverging:
+        idx = int(ticks[0] == 0)
+        ticks = list(-np.array(ticks[idx:])[::-1]) + [0] + list(ticks[idx:])
+    return np.array(ticks)
 
 
 def _handle_time(time_label, time_unit, times):
@@ -1448,9 +1471,10 @@ def _plot_mpl_stc(stc, subject=None, surface='inflated', hemi='lh',
                  'par': {'elev': 30, 'azim': -60}}
     kwargs = dict(lh=lh_kwargs, rh=rh_kwargs)
     _check_option('views', views, sorted(lh_kwargs.keys()))
-    colormap, scale_pts, _, _, _ = _limits_to_control_points(
-        clim, stc.data, colormap, transparent, linearize=True)
-    del transparent
+    mapdata = _process_clim(clim, colormap, transparent, stc.data)
+    _separate_map(mapdata)
+    colormap, scale_pts = _linearize_map(mapdata)
+    del transparent, mapdata
 
     time_label, times = _handle_time(time_label, time_unit, stc.times)
     fig = plt.figure(figsize=(6, 6)) if figure is None else figure
@@ -1713,9 +1737,19 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
 
     time_label, times = _handle_time(time_label, time_unit, stc.times)
     # convert control points to locations in colormap
-    user_colormap = colormap  # save the original colormap
-    colormap, scale_pts, diverging, transparent, _ = _limits_to_control_points(
-        clim, stc.data, colormap, transparent)
+    mapdata = _process_clim(clim, colormap, transparent, stc.data)
+    # XXX we should only need to do this for PySurfer/Mayavi, the PyVista
+    # plotter should be smart enough to do this separation in the cmap-to-ctab
+    # conversion. But this will need to be another refactoring that will
+    # hopefully restore this line:
+    #
+    # if get_3d_backend() == 'mayavi':
+    _separate_map(mapdata)
+    colormap = mapdata['colormap']
+    diverging = 'pos_lims' in mapdata['clim']
+    scale_pts = mapdata['clim']['pos_lims' if diverging else 'lims']
+    transparent = mapdata['transparent']
+    del mapdata
 
     if hemi in ['both', 'split']:
         hemis = ['lh', 'rh']
@@ -1757,7 +1791,6 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
                 kwargs["fmid"] = scale_pts[1]
                 kwargs["fmax"] = scale_pts[2]
                 kwargs["clim"] = clim
-                kwargs["user_colormap"] = user_colormap
             with warnings.catch_warnings(record=True):  # traits warnings
                 brain.add_data(**kwargs)
     if time_viewer:
@@ -2120,8 +2153,14 @@ def plot_volume_source_estimates(stc, src, subject=None, subjects_dir=None,
     fig.tight_layout()
 
     allow_pos_lims = (mode != 'glass_brain')
-    colormap, scale_pts, diverging, _, ticks = _limits_to_control_points(
-        clim, stc.data, colormap, transparent, allow_pos_lims, linearize=True)
+    mapdata = _process_clim(clim, colormap, transparent, stc.data,
+                            allow_pos_lims)
+    _separate_map(mapdata)
+    diverging = 'pos_lims' in mapdata['clim']
+    ticks = _get_map_ticks(mapdata)
+    colormap, scale_pts = _linearize_map(mapdata)
+    del mapdata
+
     ylim = [min((scale_pts[0], ydata.min())),
             max((scale_pts[-1], ydata.max()))]
     ylim = np.array(ylim) + np.array([-1, 1]) * 0.05 * np.diff(ylim)[0]
@@ -2312,8 +2351,12 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
     time_label, times = _handle_time(time_label, time_unit, stc.times)
 
     # convert control points to locations in colormap
-    colormap, scale_pts, _, transparent, _ = _limits_to_control_points(
-        clim, stc.data, colormap, transparent, allow_pos_lims=False)
+    mapdata = _process_clim(clim, colormap, transparent, stc.data,
+                            allow_pos_lims=False)
+    colormap = mapdata['colormap']
+    scale_pts = mapdata['clim']['lims']  # pos_lims not allowed
+    transparent = mapdata['transparent']
+    del mapdata
 
     if hemi in ['both', 'split']:
         hemis = ['lh', 'rh']
@@ -3054,10 +3097,12 @@ def plot_brain_colorbar(ax, clim, colormap='auto', transparent=True,
     """
     from matplotlib.colorbar import ColorbarBase
     from matplotlib.colors import Normalize
-    cmap, scale_pts, diverging, _, ticks = _limits_to_control_points(
-        clim, 0., colormap, transparent=True, linearize=True)
-    norm = Normalize(vmin=scale_pts[0], vmax=scale_pts[-1])
-    cbar = ColorbarBase(ax, cmap, norm=norm, ticks=ticks,
+    mapdata = _process_clim(clim, colormap, transparent)
+    ticks = _get_map_ticks(mapdata)
+    colormap, lims = _linearize_map(mapdata)
+    del mapdata
+    norm = Normalize(vmin=lims[0], vmax=lims[1])
+    cbar = ColorbarBase(ax, colormap, norm=norm, ticks=ticks,
                         label=label, orientation=orientation)
     # make the colorbar background match the brain color
     cbar.patch.set(facecolor=bgcolor)

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -10,7 +10,7 @@
 import numpy as np
 import os
 from os.path import join as pjoin
-from .._3d import _limits_to_control_points
+from .._3d import _process_clim
 from ...label import read_label
 from .colormap import calculate_lut
 from .view import lh_views_dict, rh_views_dict, View
@@ -232,7 +232,7 @@ class _Brain(object):
                  time_label="time index=%d", colorbar=True,
                  hemi=None, remove_existing=None, time_label_size=None,
                  initial_time=None, scale_factor=None, vector_alpha=None,
-                 clim=None, user_colormap=None, verbose=None):
+                 clim=None, verbose=None):
         u"""Display data from a numpy array on the surface.
 
         This provides a similar interface to
@@ -394,7 +394,6 @@ class _Brain(object):
         )
 
         self._data['clim'] = clim
-        self._data['user_colormap'] = user_colormap
         self._data['time'] = time
         self._data['initial_time'] = initial_time
         self._data['time_label'] = time_label
@@ -984,7 +983,6 @@ class _Brain(object):
         else:
             clim = 'auto'
         colormap = self._data['colormap']
-        user_colormap = self._data['user_colormap']
         transparent = self._data['transparent']
         time_idx = self._data['time_idx']
         array = self._data['array']
@@ -995,9 +993,13 @@ class _Brain(object):
             act_data = interp1d(
                 times, array, 'linear', axis=1,
                 assume_sorted=True)(time_idx)
-        colormap, scale_pts, diverging, transparent, _ = \
-            _limits_to_control_points(clim, act_data, user_colormap,
-                                      transparent, allow_pos_lims)
+        mapdata = _process_clim(clim, colormap, transparent, act_data,
+                                allow_pos_lims)
+        diverging = 'pos_lims' in mapdata['clim']
+        colormap = mapdata['colormap']
+        scale_pts = mapdata['clim']['pos_lims' if diverging else 'lims']
+        transparent = mapdata['transparent']
+        del mapdata
         fmin, fmid, fmax = scale_pts
         center = 0. if diverging else None
         self._data['center'] = center

--- a/mne/viz/_brain/colormap.py
+++ b/mne/viz/_brain/colormap.py
@@ -85,8 +85,8 @@ def calculate_lut(lut_table, alpha, fmin, fmid, fmax, center=None,
 
     Parameters
     ----------
-    lim_cmap : str | LinearSegmentedColormap
-        Color map obtained from MNE._limits_to_control_points.
+    lim_cmap : Colormap
+        Color map obtained from _process_mapdata.
     alpha : float
         Alpha value to apply globally to the overlay. Has no effect with mpl
         backend.

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -11,9 +11,10 @@ import os.path as op
 from pathlib import Path
 
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_allclose
 import pytest
 import matplotlib.pyplot as plt
+from matplotlib.colors import Colormap
 
 from mne import (make_field_map, pick_channels_evoked, read_evokeds,
                  read_trans, read_dipole, SourceEstimate, VectorSourceEstimate,
@@ -30,7 +31,8 @@ from mne.viz import (plot_sparse_source_estimates, plot_source_estimates,
                      snapshot_brain_montage, plot_head_positions,
                      plot_alignment, plot_volume_source_estimates,
                      plot_sensors_connectivity, plot_brain_colorbar,
-                     link_brains)
+                     link_brains, mne_analyze_colormap)
+from mne.viz._3d import _process_clim, _linearize_map, _get_map_ticks
 from mne.viz.utils import _fake_click
 from mne.utils import (requires_mayavi, requires_pysurfer, run_tests_if_main,
                        requires_nibabel, check_version, requires_dipy,
@@ -346,8 +348,8 @@ def test_plot_alignment(tmpdir, renderer):
 @testing.requires_testing_data
 @requires_pysurfer
 @traits_test
-def test_limits_to_control_points(renderer):
-    """Test functionality for determining control points."""
+def test_process_clim_plot(renderer):
+    """Test functionality for determining control points with stc.plot."""
     sample_src = read_source_spaces(src_fname)
     kwargs = dict(subjects_dir=subjects_dir, smoothing_steps=1)
 
@@ -388,6 +390,71 @@ def test_limits_to_control_points(renderer):
     with pytest.warns(RuntimeWarning, match='All data were zero'):
         plot_source_estimates(stc, **kwargs)
     renderer._close_all()
+
+
+def _assert_mapdata_equal(a, b):
+    __tracebackhide__ = True
+    assert set(a.keys()) == {'clim', 'colormap', 'transparent'}
+    assert a.keys() == b.keys()
+    assert a['transparent'] == b['transparent'], 'transparent'
+    aa, bb = a['clim'], b['clim']
+    assert aa.keys() == bb.keys(), 'clim keys'
+    assert aa['kind'] == bb['kind'] == 'value'
+    key = 'pos_lims' if 'pos_lims' in aa else 'lims'
+    assert_array_equal(aa[key], bb[key], err_msg=key)
+    assert isinstance(a['colormap'], Colormap), 'Colormap'
+    assert isinstance(b['colormap'], Colormap), 'Colormap'
+    assert a['colormap'].name == b['colormap'].name
+
+
+def test_process_clim_round_trip():
+    """Test basic input-output support."""
+    # With some negative data
+    out = _process_clim('auto', 'auto', True, -1.)
+    want = dict(
+        colormap=mne_analyze_colormap([0, 0.5, 1], 'matplotlib'),
+        clim=dict(kind='value', pos_lims=[1, 1, 1]),
+        transparent=True,)
+    _assert_mapdata_equal(out, want)
+    out2 = _process_clim(**out)
+    _assert_mapdata_equal(out, out2)
+    _linearize_map(out)  # smoke test
+    ticks = _get_map_ticks(out)
+    assert_allclose(ticks, [-1, 0, 1])
+
+    # With some positive data
+    out = _process_clim('auto', 'auto', True, 1.)
+    want = dict(
+        colormap=plt.get_cmap('hot'),
+        clim=dict(kind='value', lims=[1, 1, 1]),
+        transparent=True,)
+    _assert_mapdata_equal(out, want)
+    out2 = _process_clim(**out)
+    _assert_mapdata_equal(out, out2)
+    _linearize_map(out)
+    ticks = _get_map_ticks(out)
+    assert_allclose(ticks, [1])
+
+    # With some actual inputs
+    clim = dict(kind='value', pos_lims=[0, 0.5, 1])
+    out = _process_clim(clim, 'auto', True)
+    want = dict(
+        colormap=mne_analyze_colormap([0, 0.5, 1], 'matplotlib'),
+        clim=clim, transparent=True)
+    _assert_mapdata_equal(out, want)
+    _linearize_map(out)
+    ticks = _get_map_ticks(out)
+    assert_allclose(ticks, [-1, -0.5, 0, 0.5, 1])
+
+    clim = dict(kind='value', pos_lims=[0.25, 0.5, 1])
+    out = _process_clim(clim, 'auto', True)
+    want = dict(
+        colormap=mne_analyze_colormap([0, 0.5, 1], 'matplotlib'),
+        clim=clim, transparent=True)
+    _assert_mapdata_equal(out, want)
+    _linearize_map(out)
+    ticks = _get_map_ticks(out)
+    assert_allclose(ticks, [-1, -0.5, -0.25, 0, 0.25, 0.5, 1])
 
 
 @testing.requires_testing_data
@@ -569,7 +636,7 @@ def test_plot_volume_source_estimates_morph():
 @requires_pysurfer
 @requires_mayavi
 @traits_test
-def test_plot_vec_source_estimates():
+def test_plot_vector_source_estimates():
     """Test plotting of vector source estimates."""
     sample_src = read_source_spaces(src_fname)
 

--- a/tutorials/source-modeling/plot_mne_dspm_source_localization.py
+++ b/tutorials/source-modeling/plot_mne_dspm_source_localization.py
@@ -5,7 +5,7 @@ Source localization with MNE/dSPM/sLORETA/eLORETA
 =================================================
 
 The aim of this tutorial is to teach you how to compute and apply a linear
-inverse method such as MNE/dSPM/sLORETA/eLORETA on evoked/raw/epochs data.
+minimum-norm inverse method on evoked/raw/epochs data.
 """
 
 # sphinx_gallery_thumbnail_number = 10

--- a/tutorials/source-modeling/plot_visualize_stc.py
+++ b/tutorials/source-modeling/plot_visualize_stc.py
@@ -1,7 +1,7 @@
 """
 .. _tut_viz_stcs:
 
-Visualize Source time courses
+Visualize source time courses
 =============================
 
 This tutorial focuses on visualization of stcs.

--- a/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal.py
+++ b/tutorials/stats-source-space/plot_stats_cluster_spatio_temporal.py
@@ -3,7 +3,7 @@
 Permutation t-test on source data with spatio-temporal clustering
 =================================================================
 
-Tests if the evoked response is significantly different between
+This example tests if the evoked response is significantly different between
 two conditions across subjects. Here just for demonstration purposes
 we simulate data from multiple subjects using one subject's data.
 The multiple comparisons problem is addressed with a cluster-level


### PR DESCRIPTION
Refactors `_limits_to_control_points` into a new, slightly simpler `_process_clim` that should round-trip correctly. It now just takes `clim, colormap, transparent, data, allow_pos_lims` and returns a dict with keys`'clim', 'colormap', 'transparent'`. `data` is only used with `clim='auto'` and `kind='percent'`, and `allow_pos_lims` should be fixed for a given plot type (always `True` except for vector source estimates IIRC). I touched a few examples that use `stc.plot` to see if they look okay.

@GuillaumeFavelier there is probably lots of refactoring to be done at the `_Brain` end, e.g.:

- it looks like there is some duplicated `fmin/fmid/fmax` handling for example
- in principle we should not need to require `fmin < fmid` but just `fmin <= fmid` (see `XXX` in the code)
- you can probably now get `'auto'` mode to work properly hopefully without too much work

Feel free to push commits to my branch to accomplish this / fix these things. Or if you think it would be simpler, let's review and merge this then you can tweak `_Brain` in a subsequent PR as this one shouldn't change anything about the functionality (my vote would be to change `_Brain` in a separate PR).