### PR TITLE
MRG, BUG: Return self from methods

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -132,6 +132,8 @@ Bug
 
 - Fix :meth:`mne.io.Raw.anonymize` to correctly avoid shifting ``raw.annotations.onset`` relative to ``raw.first_samp`` by `Eric Larson`_
 
+- Fix :meth:`mne.io.Raw.set_channel_types` and :meth:`mne.io.Raw.rename_channels` and related methods to return the instance instead of ``None`` by `Eric Larson`_
+
 - :meth:`mne.Epochs.iter_evoked` now does not return a copy of info when ``copy=False`` (default parameter) by `Alex Gramfort`_
 
 - The attribute :class:`mne.Annotations.orig_time <mne.Annotations>` is now read-only, and is a :class:`~python:datetime.datetime` object (or None) rather than float, by `Eric Larson`_

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -429,19 +429,28 @@ class SetChannelsMixin(MontageMixin):
     def set_channel_types(self, mapping, verbose=None):
         """Define the sensor type of channels.
 
-        Note: The following sensor types are accepted:
-            ecg, eeg, emg, eog, exci, ias, misc, resp, seeg, stim, syst, ecog,
-            hbo, hbr, fnirs_raw, fnirs_od
-
         Parameters
         ----------
         mapping : dict
-            A dictionary mapping a channel to a sensor type (str)
-            {'EEG061': 'eog'}.
+            A dictionary mapping a channel to a sensor type (str), e.g.,
+            ``{'EEG061': 'eog'}``.
         %(verbose_meth)s
+
+        Returns
+        -------
+        inst : instance of Raw | Epochs | Evoked
+            The instance (modified in place).
+
+            .. versionchanged:: 0.20
+               Return the instance.
 
         Notes
         -----
+        The following sensor types are accepted:
+
+            ecg, eeg, emg, eog, exci, ias, misc, resp, seeg, stim, syst, ecog,
+            hbo, hbr, fnirs_raw, fnirs_od
+
         .. versionadded:: 0.9.0
         """
         ch_names = self.info['ch_names']
@@ -490,6 +499,7 @@ class SetChannelsMixin(MontageMixin):
         msg = "The unit for channel(s) {0} has changed from {1} to {2}."
         for this_change, names in unit_changes.items():
             warn(msg.format(", ".join(sorted(names)), *this_change))
+        return self
 
     def rename_channels(self, mapping):
         """Rename channels.
@@ -501,11 +511,20 @@ class SetChannelsMixin(MontageMixin):
             e.g. {'EEG061' : 'EEG161'}. Can also be a callable function
             that takes and returns a string (new in version 0.10.0).
 
+        Returns
+        -------
+        inst : instance of Raw | Epochs | Evoked
+            The instance (modified in place).
+
+            .. versionchanged:: 0.20
+               Return the instance.
+
         Notes
         -----
         .. versionadded:: 0.9.0
         """
         rename_channels(self.info, mapping)
+        return self
 
     @verbose
     def plot_sensors(self, kind='topomap', ch_type=None, title=None,

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -106,7 +106,7 @@ def test_set_channel_types():
     pytest.raises(RuntimeError, raw2.set_channel_types, mapping)  # has prj
     raw2.add_proj([], remove_existing=True)
     with pytest.warns(RuntimeWarning, match='The unit for channel'):
-        raw2.set_channel_types(mapping)
+        raw2 = raw2.set_channel_types(mapping)
     info = raw2.info
     assert info['chs'][372]['ch_name'] == 'EEG 058'
     assert info['chs'][372]['kind'] == FIFF.FIFFV_ECOG_CH
@@ -242,7 +242,7 @@ def test_1020_selection():
     loc_fname = op.join(base_dir, 'test_chans.locs')
     raw = read_raw_eeglab(raw_fname, preload=True)
     montage = read_custom_montage(loc_fname)
-    raw.rename_channels(dict(zip(raw.ch_names, montage.ch_names)))
+    raw = raw.rename_channels(dict(zip(raw.ch_names, montage.ch_names)))
     raw.set_montage(montage)
 
     for input in ("a_string", 100, raw, [1, 2]):


### PR DESCRIPTION
We should return `self` from these methods as usual.