### PR TITLE
Bugfix: Combline planar grads for TFR with mean, not RMS

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -89,8 +89,7 @@ Changelog
 
 - Allow returning vector source estimates from sparse inverse solvers through ``pick_ori='vector'`` by `Christian Brodbeck`_
 
-- Add NIRS support to :func:`
-   plot_topomap` by `Robert Luke`_
+- Add NIRS support to :func:`mne.viz.plot_topomap` by `Robert Luke`_
 
 - Add the ability to :func:`mne.channels.equalize_channels` to also re-order the channels and also operate on instances of :class:`mne.Info`, :class:`mne.Forward`, :class:`mne.Covariance` and :class:`mne.time_frequency.CrossSpectralDensity` by `Marijn van Vliet`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -208,6 +208,8 @@ Bug
 
 - Fix bug in :func:`mne.channels.make_standard_montage` which would return `easycap-M1` even when requesting `easycap-M10` by `Christian Brodbeck`_
 
+- Fix the way planar gradiometers are combined in :func:`mne.viz.topomap.plot_tfr_topomap` and :func:`mne.viz.topomap.plot_epochs_psd_topomap` by `Geoff Brookshire`_
+
 API
 ~~~
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -208,7 +208,7 @@ Bug
 
 - Fix bug in :func:`mne.channels.make_standard_montage` which would return `easycap-M1` even when requesting `easycap-M10` by `Christian Brodbeck`_
 
-- Fix the way planar gradiometers are combined in :func:`mne.viz.plot_tfr_topomap` and :func:`mne.viz.plot_epochs_psd_topomap` by `Geoff Brookshire`_
+- Fix the way planar gradiometers are combined in :func:`mne.viz.plot_tfr_topomap` and :meth:`mne.Epochs.plot_psd_topomap` by `Geoff Brookshire`_
 
 API
 ~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -89,7 +89,8 @@ Changelog
 
 - Allow returning vector source estimates from sparse inverse solvers through ``pick_ori='vector'`` by `Christian Brodbeck`_
 
-- Add NIRS support to :func:`mne.viz.plot_topomap` by `Robert Luke`_
+- Add NIRS support to :func:`
+   plot_topomap` by `Robert Luke`_
 
 - Add the ability to :func:`mne.channels.equalize_channels` to also re-order the channels and also operate on instances of :class:`mne.Info`, :class:`mne.Forward`, :class:`mne.Covariance` and :class:`mne.time_frequency.CrossSpectralDensity` by `Marijn van Vliet`_
 
@@ -208,7 +209,7 @@ Bug
 
 - Fix bug in :func:`mne.channels.make_standard_montage` which would return `easycap-M1` even when requesting `easycap-M10` by `Christian Brodbeck`_
 
-- Fix the way planar gradiometers are combined in :func:`mne.viz.topomap.plot_tfr_topomap` and :func:`mne.viz.topomap.plot_epochs_psd_topomap` by `Geoff Brookshire`_
+- Fix the way planar gradiometers are combined in :func:`mne.viz.plot_tfr_topomap` and :func:`mne.viz.plot_epochs_psd_topomap` by `Geoff Brookshire`_
 
 API
 ~~~

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -291,3 +291,5 @@
 .. _Fu-Te Wong: https://github.com/zuxfoucault
 
 .. _Sebastian Major: https://github.com/major-s
+
+.. _Geoff Brookshire: https://github.com/gbrookshire

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1189,7 +1189,7 @@ def plot_tfr_topomap(tfr, tmin=None, tmax=None, fmin=None, fmax=None,
         used.
     ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg' | None
         The channel type to plot. For 'grad', the gradiometers are collected in
-        pairs and the RMS for each pair is plotted. If None, then channels are
+        pairs and the mean for each pair is plotted. If None, then channels are
         chosen in the order given above.
     baseline : tuple or list of length 2
         The time interval to apply rescaling / baseline correction. If None do
@@ -1288,7 +1288,7 @@ def plot_tfr_topomap(tfr, tmin=None, tmax=None, fmin=None, fmax=None,
 
     # merging grads before rescaling makes ERDs visible
     if merge_grads:
-        data = _merge_grad_data(data)
+        data = _merge_grad_data(data, method='mean')
 
     data = rescale(data, tfr.times, baseline, mode, copy=True)
 
@@ -1807,7 +1807,7 @@ def plot_epochs_psd_topomap(epochs, bands=None, vmin=None, vmax=None,
         the signal (as in nitime).
     ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg' | None
         The channel type to plot. For 'grad', the gradiometers are collected in
-        pairs and the RMS for each pair is plotted. If None, then first
+        pairs and the mean for each pair is plotted. If None, then first
         available channel type from order given above is used. Defaults to
         None.
     %(layout_dep)s
@@ -1862,7 +1862,7 @@ def plot_epochs_psd_topomap(epochs, bands=None, vmin=None, vmax=None,
     psds = np.mean(psds, axis=0)
 
     if merge_grads:
-        psds = _merge_grad_data(psds)
+        psds = _merge_grad_data(psds, method='mean')
 
     return plot_psds_topomap(
         psds=psds, freqs=freqs, pos=pos, agg_fun=agg_fun, vmin=vmin,


### PR DESCRIPTION
#### What does this implement/fix?
When plotting the topography of a TFR, planar gradiometers were automatically being combined using the RMS of both sensors. However, since TFRs are not sensitive to the direction of a dipole, this behavior is unexpected. Furthermore, this makes it impossible to see "negative" power when comparing the difference between two conditions. After computing power / TFRs, planar gradiometers should be combined by taking the mean, not the RMS.

This commit changes topoplots to combine planar grads using mean, not RMS, for TFR and PSD.

#### Additional information
This page explains a similar analysis in Fieldtrip: http://www.fieldtriptoolbox.org/example/combineplanar_pipelineorder/