### PR TITLE
Refactor reload_backend()

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -143,7 +143,7 @@ class _Brain(object):
                  foreground=None, figure=None, subjects_dir=None,
                  views=['lateral'], offset=True, show_toolbar=False,
                  offscreen=False, interaction=None, units='mm'):
-        from ..backends.renderer import _Renderer, _check_3d_figure
+        from ..backends.renderer import _get_renderer, _check_3d_figure
         from matplotlib.colors import colorConverter
 
         if interaction is not None:
@@ -197,8 +197,8 @@ class _Brain(object):
 
         if figure is not None and not isinstance(figure, int):
             _check_3d_figure(figure)
-        self._renderer = _Renderer(size=fig_size, bgcolor=background,
-                                   shape=(n_row, n_col), fig=figure)
+        self._renderer = _get_renderer(size=fig_size, bgcolor=background,
+                                       shape=(n_row, n_col), fig=figure)
 
         for h in self._hemis:
             # Initialize a Surface object as the geometry

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -10,7 +10,6 @@ import os
 import pytest
 import numpy as np
 
-from mne.viz.backends.renderer import get_3d_backend, set_3d_backend
 from mne.viz.backends.tests._utils import (skips_if_not_mayavi,
                                            skips_if_not_pyvista)
 
@@ -37,9 +36,9 @@ def test_backend_environment_setup(backend, backend_mocker, monkeypatch):
     # reload the renderer to check if the 3d backend selection by
     # environment variable has been updated correctly
     from mne.viz.backends import renderer
-    set_3d_backend(backend)
+    renderer.set_3d_backend(backend)
     assert renderer.MNE_3D_BACKEND == backend
-    assert get_3d_backend() == backend
+    assert renderer.get_3d_backend() == backend
 
 
 def test_3d_functions(renderer):


### PR DESCRIPTION
This PR changes the API of renderer so that the private `_reload_backend()` only reloads the given backend and `get_3d_backend()` always returns a valid backend name (to avoid getting  `None` for example). It also limits the amount of backend reloads to the bare minimum:

scenario |`master` | PR
----------|---------------|-------
example.py | Using mayavi 3d backend.<br>Using mayavi 3d backend. | Using mayavi 3d backend.
with `use_3d_backend('pyvista')` | Using pyvista 3d backend.<br>Using pyvista 3d backend.<br>Using mayavi 3d backend.<br>Using mayavi 3d backend. | Using mayavi 3d backend.<br>Using pyvista 3d backend.<br>Using mayavi 3d backend.
with `set_3d_backend('pyvista')` | Using pyvista 3d backend.<br>Using pyvista 3d backend. | Using pyvista 3d backend.
with `MNE_3D_BACKEND=pyvista` | Using pyvista 3d backend. | Using pyvista 3d backend.
