### PR TITLE
MRG, FIX: Fix curry reader

### DIFF
--- a/mne/io/ctf/trans.py
+++ b/mne/io/ctf/trans.py
@@ -31,7 +31,7 @@ def _make_transform_card(fro, to, r_lpa, r_nasion, r_rpa):
     return Transform(fro, to, trans)
 
 
-def _quaternion_align(from_frame, to_frame, from_pts, to_pts):
+def _quaternion_align(from_frame, to_frame, from_pts, to_pts, diff_tol=1e-4):
     """Perform an alignment using the unit quaternions (modifies points)."""
     assert from_pts.shape[1] == to_pts.shape[1] == 3
 
@@ -85,7 +85,7 @@ def _quaternion_align(from_frame, to_frame, from_pts, to_pts):
                     '(orig : %7.2f %7.2f %7.2f mm) diff = %8.3f mm'
                     % (tuple(1000 * to) + tuple(1000 * rr) +
                        tuple(1000 * fro) + (1000 * diff,)))
-        if diff > 1e-4:
+        if diff > diff_tol:
             raise RuntimeError('Something is wrong: quaternion matching did '
                                'not work (see above)')
     return Transform(from_frame, to_frame, trans)

--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -12,27 +12,36 @@ import numpy as np
 
 from ..base import BaseRaw
 from ..meas_info import create_info
+from ..tag import _coil_trans_to_loc
 from ..utils import _read_segments_file, _mult_cal_one
 from ..constants import FIFF
+from ...surface import _normal_orth
+from ...transforms import apply_trans, Transform
 from ...utils import check_fname, check_version, logger, verbose, warn
 from ...annotations import Annotations
 
-FILE_EXTENSIONS = {"Curry 7": {"info": ".dap",
-                               "data": ".dat",
-                               "labels": ".rs3",
-                               "events": ".cef"},
-                   "Curry 8": {"info": ".cdt.dpa",
-                               "data": ".cdt",
-                               "labels": ".cdt.dpa",
-                               "events": ".cdt.cef"}}
+FILE_EXTENSIONS = {
+    "Curry 7": {
+        "info": ".dap",
+        "data": ".dat",
+        "labels": ".rs3",
+        "events": ".cef",
+        "hpi": ".hpi",
+    },
+    "Curry 8": {
+        "info": ".cdt.dpa",
+        "data": ".cdt",
+        "labels": ".cdt.dpa",
+        "events": ".cdt.cef",
+        "hpi": ".cdt.hpi",
+    }
+}
 CHANTYPES = {"meg": "_MAG1", "eeg": "", "misc": "_OTHERS"}
 FIFFV_CHANTYPES = {"meg": FIFF.FIFFV_MEG_CH, "eeg": FIFF.FIFFV_EEG_CH,
                    "misc": FIFF.FIFFV_MISC_CH}
 SI_UNITS = dict(V=FIFF.FIFF_UNIT_V, T=FIFF.FIFF_UNIT_T)
 SI_UNIT_SCALE = dict(c=1e-2, m=1e-3, u=1e-6, μ=1e-6, n=1e-9, p=1e-12, f=1e-15)
 
-CurryFileStructure = namedtuple('CurryFileStructure',
-                                'info, data, labels, events')
 CurryParameters = namedtuple('CurryParameters',
                              'n_samples, sfreq, is_ascii, unit_dict')
 
@@ -42,27 +51,21 @@ def _get_curry_version(file_extension):
     return "Curry 8" if "cdt" in file_extension else "Curry 7"
 
 
-def _get_curry_file_structure(fname, required=[]):
-    """Store paths to a CurryFileStructure and check for required files."""
+def _get_curry_file_structure(fname, required=()):
+    """Store paths to a dict and check for required files."""
     _msg = "The following required files cannot be found: {0}.\nPlease make " \
            "sure all required files are located in the same directory as {1}."
 
     # we don't use os.path.splitext to also handle extensions like .cdt.dpa
     fname_base, ext = fname.split(".", maxsplit=1)
     version = _get_curry_version(ext)
+    my_curry = dict()
+    for key in ('info', 'data', 'labels', 'events', 'hpi'):
+        fname = fname_base + FILE_EXTENSIONS[version][key]
+        if op.isfile(fname):
+            my_curry[key] = fname
 
-    info = fname_base + FILE_EXTENSIONS[version]["info"]
-    data = fname_base + FILE_EXTENSIONS[version]["data"]
-    labels = fname_base + FILE_EXTENSIONS[version]["labels"]
-    events = fname_base + FILE_EXTENSIONS[version]["events"]
-    my_curry = CurryFileStructure(
-        info=info if op.isfile(info) else None,
-        data=data if op.isfile(data) else None,
-        labels=labels if op.isfile(labels) else None,
-        events=events if op.isfile(events) else None)
-
-    missing = [fname_base + FILE_EXTENSIONS[version][field]
-               for field in required if getattr(my_curry, field) is None]
+    missing = [field for field in required if field not in my_curry]
     if missing:
         raise FileNotFoundError(_msg.format(np.unique(missing), fname))
 
@@ -158,18 +161,25 @@ def _read_curry_parameters(fname):
     return CurryParameters(n_samples, true_sfreq, is_ascii, unit_dict)
 
 
-def _read_curry_info(info_fname, label_fname):
+def _read_curry_info(curry_paths):
     """Extract info from curry parameter files."""
-    curry_params = _read_curry_parameters(info_fname)
+    curry_params = _read_curry_parameters(curry_paths['info'])
+    R = np.eye(4)
+    R[1, 1] = -1  # reverse front/back
+    R[:3, 3] = [0., -0.02, -0.12]  # shift down and back
+    curry_dev_dev_t = Transform(FIFF.FIFFV_MNE_COORD_CTF_DEVICE,
+                                FIFF.FIFFV_COORD_DEVICE, R)
 
     # read labels from label files
+    label_fname = curry_paths['labels']
+    types = ["meg", "eeg", "misc"]
     labels = _read_curry_lines(label_fname,
-                               ["LABELS" + CHANTYPES[key] for key in
-                                ["meg", "eeg", "misc"]])
-
+                               ["LABELS" + CHANTYPES[key] for key in types])
     sensors = _read_curry_lines(label_fname,
-                                ["SENSORS" + CHANTYPES[key] for key in
-                                 ["meg", "eeg", "misc"]])
+                                ["SENSORS" + CHANTYPES[key] for key in types])
+    normals = _read_curry_lines(label_fname,
+                                ['NORMALS' + CHANTYPES[key] for key in types])
+    assert len(labels) == len(sensors) == len(normals)
 
     all_chans = list()
     for key in ["meg", "eeg", "misc"]:
@@ -177,9 +187,30 @@ def _read_curry_info(info_fname, label_fname):
             ch = {"ch_name": chan,
                   "unit": curry_params.unit_dict[key],
                   "kind": FIFFV_CHANTYPES[key]}
-            if key in ("meg", "eeg"):
-                loc = sensors["SENSORS" + CHANTYPES[key]][ind]
-                ch["loc"] = np.array(loc, dtype=float)
+            if key == "eeg":
+                loc = np.array(sensors["SENSORS" + CHANTYPES[key]][ind], float)
+                # XXX just the sensor, where is ref (next 3)?
+                assert loc.shape == (3,)
+                loc /= 1000.  # to meters
+                loc = np.concatenate([loc, np.zeros(9)])
+                ch['loc'] = loc
+                # XXX need to check/ensure this
+                ch['coord_frame'] = FIFF.FIFFV_COORD_HEAD
+            elif key == 'meg':
+                pos = np.array(sensors["SENSORS" + CHANTYPES[key]][ind], float)
+                pos /= 1000.  # to meters
+                pos = pos[:3]  # just the inner coil
+                pos = apply_trans(curry_dev_dev_t, pos)
+                nn = np.array(normals["NORMALS" + CHANTYPES[key]][ind], float)
+                assert np.isclose(np.linalg.norm(nn), 1., atol=1e-4)
+                nn /= np.linalg.norm(nn)
+                nn = apply_trans(curry_dev_dev_t, nn, move=False)
+                trans = np.eye(4)
+                trans[:3, 3] = pos
+                trans[:3, :3] = _normal_orth(nn).T
+                ch['loc'] = _coil_trans_to_loc(trans)
+                # XXX need to check this, too
+                ch['coord_frame'] = FIFF.FIFFV_COORD_DEVICE
 
             all_chans.append(ch)
 
@@ -192,7 +223,8 @@ def _read_curry_info(info_fname, label_fname):
         ch_dict['cal'] = SI_UNIT_SCALE[all_chans[ind]['unit'][0]]
         if ch_dict["kind"] in (FIFF.FIFFV_MEG_CH,
                                FIFF.FIFFV_EEG_CH):
-            ch_dict["loc"] = all_chans[ind]["loc"]
+            ch_dict["loc"][:] = all_chans[ind]["loc"]
+        ch_dict['coil_type'] = FIFF.FIFFV_COIL_CTF_GRAD
 
     return info, curry_params.n_samples, curry_params.is_ascii
 
@@ -241,10 +273,10 @@ def _read_annotations_curry(fname, sfreq='auto'):
     """
     required = ["events", "info"] if sfreq == 'auto' else ["events"]
     curry_paths = _get_curry_file_structure(fname, required)
-    events = _read_events_curry(curry_paths.events)
+    events = _read_events_curry(curry_paths['events'])
 
     if sfreq == 'auto':
-        sfreq = _read_curry_parameters(curry_paths.info).sfreq
+        sfreq = _read_curry_parameters(curry_paths['info']).sfreq
 
     onset = events[:, 0] / sfreq
     duration = np.zeros(events.shape[0])
@@ -293,14 +325,12 @@ class RawCurry(BaseRaw):
     @verbose
     def __init__(self, fname, preload=False, verbose=None):
 
-        curry_paths = _get_curry_file_structure(fname, required=["info",
-                                                                 "data",
-                                                                 "labels"])
+        curry_paths = _get_curry_file_structure(
+            fname, required=["info", "data", "labels"])
 
-        data_fname = op.abspath(curry_paths.data)
+        data_fname = op.abspath(curry_paths['data'])
 
-        info, n_samples, is_ascii = _read_curry_info(curry_paths.info,
-                                                     curry_paths.labels)
+        info, n_samples, is_ascii = _read_curry_info(curry_paths)
 
         last_samps = [n_samples - 1]
         self._is_ascii = is_ascii
@@ -309,10 +339,10 @@ class RawCurry(BaseRaw):
             info, preload, filenames=[data_fname], last_samps=last_samps,
             orig_format='int', verbose=verbose)
 
-        if curry_paths.events is not None:
+        if 'events' in curry_paths:
             logger.info('Event file found. Extracting Annotations from'
-                        ' %s...' % curry_paths.events)
-            annots = _read_annotations_curry(curry_paths.events,
+                        ' %s...' % curry_paths['events'])
+            annots = _read_annotations_curry(curry_paths['events'],
                                              sfreq=self.info["sfreq"])
             self.set_annotations(annots)
         else:

--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -167,7 +167,7 @@ def _read_curry_info(curry_paths):
     """Extract info from curry parameter files."""
     curry_params = _read_curry_parameters(curry_paths['info'])
     R = np.eye(4)
-    R[1, 1] = -1  # reverse front/back
+    R[[0, 1], [0, 1]] = -1  # rotate 180 deg
     # shift down and back
     # (chosen by eyeballing to make the CTF helmet look roughly correct)
     R[:3, 3] = [0., -0.02, -0.12]
@@ -269,13 +269,12 @@ def _make_trans_dig(label_fname, info, curry_dev_dev_t):
                 kind=kind, ident=ident, r=r,
                 coord_frame=FIFF.FIFFV_COORD_DEVICE))
     if len(cards) == 3:  # have all three
-        # Left and right are switched in their coords (?)
         info['dev_head_t'] = Transform(
             'meg', 'head',
             get_ras_to_neuromag_trans(
                 *(cards[key] for key in (FIFF.FIFFV_POINT_NASION,
-                                         FIFF.FIFFV_POINT_RPA,
-                                         FIFF.FIFFV_POINT_LPA))))
+                                         FIFF.FIFFV_POINT_LPA,
+                                         FIFF.FIFFV_POINT_RPA))))
         for d in info['dig']:
             d.update(coord_frame=FIFF.FIFFV_COORD_HEAD,
                      r=apply_trans(info['dev_head_t'], d['r']))

--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -17,7 +17,8 @@ from ..utils import _read_segments_file, _mult_cal_one
 from ..constants import FIFF
 from ...surface import _normal_orth
 from ...transforms import apply_trans, Transform, get_ras_to_neuromag_trans
-from ...utils import check_fname, check_version, logger, verbose, warn
+from ...utils import (check_fname, check_version, logger, verbose, warn,
+                      _check_fname)
 from ...annotations import Annotations
 
 FILE_EXTENSIONS = {
@@ -55,6 +56,7 @@ def _get_curry_file_structure(fname, required=()):
     """Store paths to a dict and check for required files."""
     _msg = "The following required files cannot be found: {0}.\nPlease make " \
            "sure all required files are located in the same directory as {1}."
+    _check_fname(fname, overwrite='read', must_exist=True)
 
     # we don't use os.path.splitext to also handle extensions like .cdt.dpa
     fname_base, ext = fname.split(".", maxsplit=1)

--- a/mne/io/curry/tests/test_curry.py
+++ b/mne/io/curry/tests/test_curry.py
@@ -88,6 +88,7 @@ def test_read_raw_curry(fname, tol, preload, bdf_curry_ref):
         raw.get_data(picks=picks, start=start, stop=stop),
         bdf_curry_ref.get_data(picks=picks, start=start, stop=stop),
         rtol=tol)
+    assert raw.info['dev_head_t'] is None
 
 
 @testing.requires_testing_data
@@ -107,6 +108,8 @@ def test_read_raw_curry_rfDC(fname, tol):
 
     assert_allclose(raw.get_data(eeg_names),
                     bti_rfDC.get_data(eeg_names), rtol=tol)
+    assert raw.info['dev_head_t'] is None
+    assert bti_rfDC.info['dev_head_t'] is not None  # XXX probably a BTI bug
 
 
 @testing.requires_testing_data
@@ -122,6 +125,7 @@ def test_read_events_curry_are_same_as_bdf(fname):
     raw = read_raw_curry(fname)
     events, _ = events_from_annotations(raw, event_id=EVENT_ID)
     assert_allclose(events, REF_EVENTS)
+    assert raw.info['dev_head_t'] is None
 
 
 def test_check_missing_files():

--- a/mne/io/curry/tests/test_curry.py
+++ b/mne/io/curry/tests/test_curry.py
@@ -10,16 +10,18 @@ import numpy as np
 from shutil import copyfile
 
 import pytest
-
 from numpy.testing import assert_allclose, assert_array_equal
+
 from mne.annotations import events_from_annotations
+from mne.bem import _fit_sphere
 from mne.datasets import testing
 from mne.event import find_events
+from mne.io import _loc_to_coil_trans
 from mne.io.constants import FIFF
 from mne.io.edf import read_raw_bdf
 from mne.io.bti import read_raw_bti
 from mne.io.curry import read_raw_curry
-from mne.utils import check_version, run_tests_if_main
+from mne.utils import check_version, run_tests_if_main, catch_logging
 from mne.annotations import read_annotations
 from mne.io.curry.curry import (_get_curry_version, _get_curry_file_structure,
                                 _read_events_curry, FILE_EXTENSIONS)
@@ -91,16 +93,141 @@ def test_read_raw_curry(fname, tol, preload, bdf_curry_ref):
     assert raw.info['dev_head_t'] is None
 
 
+# These values taken from a different recording but allow us to test
+# using our existing filres
+
+HPI_CONTENT = """\
+FileVersion:	804
+NumCoils:	10
+
+0	1	-50.67	50.98	133.15	0.006406		1	46.45	51.51	143.15	0.006789		1	39.38	-26.67	155.51	0.008034		1	-36.72	-39.95	142.83	0.007700		1	1.61	16.95	172.76	0.001788		0	0.00	0.00	0.00	0.000000		0	0.00	0.00	0.00	0.000000		0	0.00	0.00	0.00	0.000000		0	0.00	0.00	0.00	0.000000		0	0.00	0.00	0.00	0.000000
+"""  # noqa: E501
+
+
+LM_CONTENT = """
+
+LANDMARKS_MAG1 START
+   ListDescription      = functional landmark positions
+   ListUnits            = mm
+   ListNrColumns        =  3
+   ListNrRows           =  8
+   ListNrTimepts        =  1
+   ListNrBlocks         =  1
+   ListBinary           =  0
+   ListType             =  1
+   ListTrafoType        =  1
+   ListGridType         =  2
+   ListFirstColumn      =  1
+   ListIndexMin         = -1
+   ListIndexMax         = -1
+   ListIndexAbsMax      = -1
+LANDMARKS_MAG1 END
+
+LANDMARKS_MAG1 START_LIST	# Do not edit!
+  75.4535	 5.32907e-15	 2.91434e-16
+  1.42109e-14	-75.3212	 9.71445e-16
+ -74.4568	-1.42109e-14	 2.51188e-15
+ -59.7558	 35.5804	 66.822
+  43.15	 43.4107	 78.0027
+  38.8415	-41.1884	 81.9941
+ -36.683	-59.5119	 66.4338
+ -1.07259	-1.88025	 103.747
+LANDMARKS_MAG1 END_LIST
+
+LM_INDICES_MAG1 START
+   ListDescription      = functional landmark PAN info
+   ListUnits            =
+   ListNrColumns        =  1
+   ListNrRows           =  3
+   ListNrTimepts        =  1
+   ListNrBlocks         =  1
+   ListBinary           =  0
+   ListType             =  0
+   ListTrafoType        =  0
+   ListGridType         =  2
+   ListFirstColumn      =  1
+   ListIndexMin         = -1
+   ListIndexMax         = -1
+   ListIndexAbsMax      = -1
+LM_INDICES_MAG1 END
+
+LM_INDICES_MAG1 START_LIST	# Do not edit!
+  2
+  1
+  3
+LM_INDICES_MAG1 END_LIST
+
+LM_REMARKS_MAG1 START
+   ListDescription      = functional landmark labels
+   ListUnits            =
+   ListNrColumns        =  40
+   ListNrRows           =  8
+   ListNrTimepts        =  1
+   ListNrBlocks         =  1
+   ListBinary           =  0
+   ListType             =  5
+   ListTrafoType        =  0
+   ListGridType         =  2
+   ListFirstColumn      =  1
+   ListIndexMin         = -1
+   ListIndexMax         = -1
+   ListIndexAbsMax      = -1
+LM_REMARKS_MAG1 END
+
+LM_REMARKS_MAG1 START_LIST	# Do not edit!
+Left ear
+Nasion
+Right ear
+HPI1
+HPI2
+HPI3
+HPI4
+HPI5
+LM_REMARKS_MAG1 END_LIST
+
+"""
+
+WANT_TRANS = np.array(
+    [[0.99729224, -0.07353067, -0.00119791, 0.00126953],
+     [0.07319243, 0.99085848, 0.11332405, 0.02670814],
+     [-0.00714583, -0.11310488, 0.99355736, 0.04721836],
+     [0., 0., 0., 1.]])
+
+
 @testing.requires_testing_data
 @pytest.mark.parametrize('fname,tol', [
     pytest.param(curry7_rfDC_file, 1e-6, id='curry 7'),
     pytest.param(curry8_rfDC_file, 1e-3, id='curry 8'),
 ])
-def test_read_raw_curry_rfDC(fname, tol):
+@pytest.mark.parametrize('mock_dev_head_t', [True, False])
+def test_read_raw_curry_rfDC(fname, tol, mock_dev_head_t, tmpdir):
     """Test reading CURRY files."""
+    if mock_dev_head_t:
+        if 'Curry 7' in fname:  # not supported yet
+            return
+        # copy files to tmpdir
+        base = op.splitext(fname)[0]
+        for ext in ('.cdt', '.cdt.dpa'):
+            src = base + ext
+            dst = op.join(tmpdir, op.basename(base) + ext)
+            copyfile(src, dst)
+            if ext == '.cdt.dpa':
+                with open(dst, 'a') as fid:
+                    fid.write(LM_CONTENT)
+        fname = op.join(tmpdir, op.basename(fname))
+        with open(fname + '.hpi', 'w') as fid:
+            fid.write(HPI_CONTENT)
+
     # check data
     bti_rfDC = read_raw_bti(pdf_fname=bti_rfDC_file, head_shape_fname=None)
-    raw = read_raw_curry(fname)
+    with catch_logging() as log:
+        raw = read_raw_curry(fname, verbose=True)
+    log = log.getvalue()
+    if mock_dev_head_t:
+        assert 'Composing device' in log
+    else:
+        assert 'Leaving device' in log
+        assert 'no landmark' in log
 
     # test on the eeg chans, since these were not renamed by curry
     eeg_names = [ch["ch_name"] for ch in raw.info["chs"]
@@ -108,8 +235,43 @@ def test_read_raw_curry_rfDC(fname, tol):
 
     assert_allclose(raw.get_data(eeg_names),
                     bti_rfDC.get_data(eeg_names), rtol=tol)
-    assert raw.info['dev_head_t'] is None
     assert bti_rfDC.info['dev_head_t'] is not None  # XXX probably a BTI bug
+    if mock_dev_head_t:
+        assert raw.info['dev_head_t'] is not None
+        assert_allclose(raw.info['dev_head_t']['trans'], WANT_TRANS, atol=1e-5)
+    else:
+        assert raw.info['dev_head_t'] is None
+
+    # check that most MEG sensors are approximately oriented outward from
+    # the device origin
+    n_meg = n_eeg = n_other = 0
+    pos = list()
+    nn = list()
+    for ch in raw.info['chs']:
+        if ch['kind'] == FIFF.FIFFV_MEG_CH:
+            assert ch['coil_type'] == FIFF.FIFFV_COIL_CTF_GRAD
+            t = _loc_to_coil_trans(ch['loc'])
+            pos.append(t[:3, 3])
+            nn.append(t[:3, 2])
+            assert_allclose(np.linalg.norm(nn[-1]), 1.)
+            n_meg += 1
+        elif ch['kind'] == FIFF.FIFFV_EEG_CH:
+            assert ch['coil_type'] == FIFF.FIFFV_COIL_EEG
+            n_eeg += 1
+        else:
+            assert ch['coil_type'] == FIFF.FIFFV_COIL_NONE
+            n_other += 1
+    assert n_meg == 148
+    assert n_eeg == 31
+    assert n_other == 15
+    pos = np.array(pos)
+    nn = np.array(nn)
+    rad, origin = _fit_sphere(pos, disp=False)
+    assert 0.11 < rad < 0.13
+    pos -= origin
+    pos /= np.linalg.norm(pos, axis=1, keepdims=True)
+    angles = np.abs(np.rad2deg(np.arccos((pos * nn).sum(-1))))
+    assert (angles < 20).sum() > 100
 
 
 @testing.requires_testing_data

--- a/mne/io/curry/tests/test_curry.py
+++ b/mne/io/curry/tests/test_curry.py
@@ -131,8 +131,10 @@ def test_check_missing_files():
     with pytest.raises(IOError, match="file type .*? must end with"):
         _read_events_curry(invalid_fname)
 
-    with pytest.raises(FileNotFoundError, match="files cannot be found"):
+    with pytest.raises(FileNotFoundError, match='does not exist'):
         _get_curry_file_structure(invalid_fname)
+
+    with pytest.raises(FileNotFoundError, match="files cannot be found"):
         _get_curry_file_structure(missing_event_file,
                                   required=["info", "events"])
 

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -19,6 +19,7 @@ from struct import pack
 
 import numpy as np
 from scipy.sparse import coo_matrix, csr_matrix, eye as speye
+from scipy import linalg
 
 from .io.constants import FIFF
 from .io.open import fiff_open
@@ -321,6 +322,16 @@ def _project_onto_surface(rrs, surf, project_rrs=False, return_nn=False,
                                      len(surf['rr']))
             out += (nn[idx],)
     return out
+
+
+def _normal_orth(nn):
+    """Compute orthogonal basis given a normal."""
+    assert nn.shape == (3,)
+    u, _, _ = linalg.svd(np.eye(3) - np.outer(nn, nn))
+    #  Make sure that ez is in the direction of nn
+    if np.dot(nn, u[:, 2]) < 0:
+        u *= -1.0
+    return u.T
 
 
 @verbose

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -67,6 +67,7 @@ docstring_ignores = {
 char_limit = 800  # XX eventually we should probably get this lower
 tab_ignores = [
     'mne.channels.tests.test_montage',
+    'mne.io.curry.tests.test_curry',
 ]
 error_ignores = {
     # These we do not live by:

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -13,7 +13,7 @@ from mne import (read_surface, write_surface, decimate_surface, pick_types,
                  dig_mri_distances)
 from mne.surface import (read_morph_map, _compute_nearest,
                          fast_cross_3d, get_head_surf, read_curvature,
-                         get_meg_helmet_surf)
+                         get_meg_helmet_surf, _normal_orth)
 from mne.utils import (_TempDir, requires_vtk, catch_logging,
                        run_tests_if_main, object_diff)
 from mne.io import read_info
@@ -216,6 +216,14 @@ def test_dig_mri_distances(dig_kinds, exclude, count, bounds, outliers):
     assert dists.shape == (count,)
     assert bounds[0] < np.mean(dists) < bounds[1]
     assert np.sum(dists > 0.03) == outliers
+
+
+def test_normal_orth():
+    """Test _normal_orth."""
+    nns = np.eye(3)
+    for nn in nns:
+        ori = _normal_orth(nn)
+        assert_allclose(ori[:, 2], nn, atol=1e-12)
 
 
 run_tests_if_main()

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -223,7 +223,7 @@ def test_normal_orth():
     nns = np.eye(3)
     for nn in nns:
         ori = _normal_orth(nn)
-        assert_allclose(ori[:, 2], nn, atol=1e-12)
+        assert_allclose(ori[2], nn, atol=1e-12)
 
 
 run_tests_if_main()

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -140,12 +140,12 @@ def _check_fname(fname, overwrite=False, must_exist=False, name='File'):
     _validate_type(fname, 'path-like', 'fname')
     if op.isfile(fname):
         if not overwrite:
-            raise IOError('Destination file exists. Please use option '
-                          '"overwrite=True" to force overwriting.')
+            raise FileExistsError('Destination file exists. Please use option '
+                                  '"overwrite=True" to force overwriting.')
         elif overwrite != 'read':
             logger.info('Overwriting existing file.')
     elif must_exist:
-        raise IOError('%s "%s" does not exist' % (name, fname))
+        raise FileNotFoundError('%s "%s" does not exist' % (name, fname))
     return str(fname)
 
 


### PR DESCRIPTION
Our curry reader currently does not populate `info['chs'][ii]['loc']`, `info['dig']`, or `info['dev_head_t']` properly. 

@DiGyt did you try to do any source localization, `plot_sensors`, etc. with the curry reader?

1000 nAm current phantom results have 2.1 mm error, 99%+ GOF:

![Screenshot from 2020-02-10 13-42-20](https://user-images.githubusercontent.com/2365790/74181134-b0578400-4c0e-11ea-80e6-0fa354fb44e6.png)

Todo:

- [x] Add or mock some test data where `dev_head_t` is actually calculated
- [x] ~~Update `get_phantom_dipoles`~~
- [x] ~~Add phantom data as OSF.io dataset~~
- [x] ~~Add Curry phantom example~~

Closes #7300