### PR TITLE
[MRG] ENH: better sel channels visibility

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -107,6 +107,8 @@ Changelog
 
 - Add function :func:`mne.preprocessing.annotate_movement` to annotate periods with head motion and :func:`mne.preprocessing.compute_average_dev_head_t` to re-estimate the device to head transform with average head position during segments with acceptable head movement. by `Adonay Nunes`_
 
+- Make selected channels more distinguishable in :meth:`mne.Epochs.plot_sensors` when using ``kind='select'`` by `Mikołaj Magnuski`_
+
 Bug
 ~~~
 

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -467,6 +467,12 @@ def test_plot_sensors():
     _fake_click(fig, ax, (0, 0.65), xform='ax', kind='release')
     assert fig.lasso.selection == ['MEG 0121']
 
+    # check that point appearance changes
+    fc = fig.lasso.collection.get_facecolors()
+    ec = fig.lasso.collection.get_edgecolors()
+    assert (fc[:, -1] == [0.3, 1., 0.3]).all()
+    assert (ec[:, -1] == [0.3, 1., 0.3]).all()
+
     _fake_click(fig, ax, (0.7, 1), xform='ax', kind='motion')
     xy = ax.collections[0].get_offsets()
     _fake_click(fig, ax, xy[2], xform='data')  # single selection

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2044,11 +2044,14 @@ class SelectFromCollection(object):
 
         # Ensure that we have separate colors for each object
         self.fc = collection.get_facecolors()
+        self.ec = collection.get_edgecolors()
         if len(self.fc) == 0:
             raise ValueError('Collection must have a facecolor')
         elif len(self.fc) == 1:
             self.fc = np.tile(self.fc, self.Npts).reshape(self.Npts, -1)
+            self.ec = np.tile(self.ec, self.Npts).reshape(self.Npts, -1)
         self.fc[:, -1] = self.alpha_other  # deselect in the beginning
+        self.ec[:, -1] = self.alpha_other
 
         self.lasso = LassoSelector(ax, onselect=self.on_select,
                                    lineprops={'color': 'red', 'linewidth': .5})
@@ -2073,6 +2076,10 @@ class SelectFromCollection(object):
         self.fc[:, -1] = self.alpha_other
         self.fc[inds, -1] = 1
         self.collection.set_facecolors(self.fc)
+
+        self.ec[:, -1] = self.alpha_other
+        self.ec[inds, -1] = 1
+        self.collection.set_edgecolors(self.ec)
         self.canvas.draw_idle()
         self.canvas.callbacks.process('lasso_event')
 
@@ -2087,7 +2094,9 @@ class SelectFromCollection(object):
             self.selection.append(ch_name)
             this_alpha = 1
         self.fc[ind, -1] = this_alpha
+        self.ec[ind, -1] = this_alpha
         self.collection.set_facecolors(self.fc)
+        self.collection.set_edgecolors(self.ec)
         self.canvas.draw_idle()
         self.canvas.callbacks.process('lasso_event')
 
@@ -2095,7 +2104,9 @@ class SelectFromCollection(object):
         """Disconnect the lasso selector."""
         self.lasso.disconnect_events()
         self.fc[:, -1] = 1
+        self.ec[:, -1] = 1
         self.collection.set_facecolors(self.fc)
+        self.collection.set_edgecolors(self.ec)
         self.canvas.draw_idle()
 
 


### PR DESCRIPTION
Currently doing `epochs.plot_sensors(kind='select')` and lasso-selecting some channels leads to selected channels not being clearly distinguishable:
<img src=https://user-images.githubusercontent.com/8452354/74072886-aa905180-4a08-11ea-9de9-a54d6588e6c3.PNG width="250px">

I've added changes to edgecolors with lasso selection to make the channels more visible:
<img src=https://user-images.githubusercontent.com/8452354/74072903-bed44e80-4a08-11ea-899a-b3c60629c922.PNG width="250px">

## TODOs:
- [x] test?
- [x] what's new