### PR TITLE
MRG, FIX: make labels in epochs.plot start at 0, fixes issue #7260

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -15,6 +15,8 @@ Current (0.20.dev0)
 Changelog
 ~~~~~~~~~
 
+- Improved :func:`mne.plot_evokeds` to label epoch counts starting from 0 `Sophie Herbst`_
+
 - Add :func:`mne.minimum_norm.resolution_metrics` to compute various resolution metrics for inverse solutions, by `Olaf Hauk`_
 
 - Add current source density :func:`mne.preprocessing.compute_current_source_density` to compute the surface Laplacian in order to reduce volume conduction in data by `Alex Rockhill`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -15,7 +15,7 @@ Current (0.20.dev0)
 Changelog
 ~~~~~~~~~
 
-- Improved :func:`mne.plot_evokeds` to label epoch counts starting from 0 `Sophie Herbst`_
+- Improved :func:`mne.viz.plot_epochs` to label epoch counts starting from 0 `Sophie Herbst`_
 
 - Add :func:`mne.minimum_norm.resolution_metrics` to compute various resolution metrics for inverse solutions, by `Olaf Hauk`_
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -293,3 +293,5 @@
 .. _Sebastian Major: https://github.com/major-s
 
 .. _Geoff Brookshire: https://github.com/gbrookshire
+
+.. _Sophie Herbst: https://github.com/SophieHerbst

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1252,7 +1252,10 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         keep = np.setdiff1d(np.arange(len(self.events)), try_idx)
         self._getitem(keep, reason, copy=False, drop_event_id=False)
         count = len(try_idx)
-        logger.info('Dropped %d epoch%s' % (count, _pl(count)))
+        logger.info('Dropped %d epoch%s: %s' % (count, _pl(count), 
+                                                np.array2string(np.sort(try_idx), 
+                                                                precision=0, 
+                                                                separator=',')))
         return self
 
     def _get_epoch_from_raw(self, idx, verbose=None):

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1252,10 +1252,9 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         keep = np.setdiff1d(np.arange(len(self.events)), try_idx)
         self._getitem(keep, reason, copy=False, drop_event_id=False)
         count = len(try_idx)
-        logger.info('Dropped %d epoch%s: %s' % (count, _pl(count), 
-                                                np.array2string(np.sort(try_idx), 
-                                                                precision=0, 
-                                                                separator=',')))
+        logger.info('Dropped %d epoch%s: %s' %
+                    (count, _pl(count), ', '.join(map(str, np.sort(try_idx)))))
+
         return self
 
     def _get_epoch_from_raw(self, idx, verbose=None):

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -1095,7 +1095,7 @@ def _prepare_mne_browse_epochs(params, projs, n_channels, n_epochs, scalings,
     ticks = epoch_times + 0.5 * n_times
     ax.set_xticks(ticks)
     ax2.set_xticks(ticks[:n_epochs])
-    labels = list(range(1, len(ticks) + 1))  # epoch numbers
+    labels = list(range(0, len(ticks)))  # epoch numbers
     ax.set_xticklabels(labels)
     xlim = epoch_times[-1] + len(orig_epoch_times)
     ax_hscroll.set_xlim(0, xlim)
@@ -1107,7 +1107,7 @@ def _prepare_mne_browse_epochs(params, projs, n_channels, n_epochs, scalings,
     hticks = list()
     for tick in hscroll_ticks:
         hticks.append(epoch_times.flat[np.abs(epoch_times - tick).argmin()])
-    hlabels = [x // n_times + 1 for x in hticks]
+    hlabels = [x // n_times for x in hticks]
     ax_hscroll.set_xticks(hticks)
     ax_hscroll.set_xticklabels(hlabels)
 

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -57,7 +57,7 @@ def test_plot_epochs_basic(capsys):
     epochs.info['lowpass'] = 10.  # allow heavy decim during plotting
     fig = epochs.plot(scalings=None, title='Epochs')
     ticks = [x.get_text() for x in fig.axes[0].get_xticklabels()]
-    assert ticks == ['1']
+    assert ticks == ['0']
     plt.close('all')
     # covariance / whitening
     cov = read_cov(cov_fname)


### PR DESCRIPTION
Makes epochs.plot() start at 0 instead of 1 (issue #7260). 
Note: a bug with spyder (#6528) prevents me from testing what happens after closing the interactive plot. I checked that the indices returned for manually selected epochs start with 0, too. 

Closes #7260