### PR TITLE
[MRG+1] FIX: extra points placement when 3 channels

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -216,6 +216,8 @@ Bug
 
 - Fix the way planar gradiometers are combined in :func:`mne.viz.plot_tfr_topomap` and :meth:`mne.Epochs.plot_psd_topomap` by `Geoff Brookshire`_
 
+- Fix placement of extrapolation points in :meth:`mne.Evoked.plot_topomap` and related functions when exactly three channels were used by `Mikołaj Magnuski`_.
+
 API
 ~~~
 

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -191,6 +191,12 @@ def test_plot_topomap_basic():
     plot_topomap(temp_data, info_sel, extrapolate='local', res=res)
     plot_topomap(temp_data, info_sel, extrapolate='head', res=res)
 
+    # make sure extrapolation works for 3 channels with border='mean'
+    # (if extra points are placed incorrectly some of them have only
+    #  other extra points as neighbours and border='mean' fails)
+    plot_topomap(temp_data, info_sel, extrapolate='local', border='mean',
+                 res=res)
+
     # border=0 and border='mean':
     # ---------------------------
     ch_names = list('abcde')

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -520,7 +520,7 @@ def _get_extra_points(pos, extrapolate, sphere):
         points_x = np.cos(points_l) * use_radius + x
         points_y = np.sin(points_l) * use_radius + y
         new_pos = np.stack([points_x, points_y], axis=1)
-        if colinear:
+        if colinear or pos.shape[0] == 3:
             tri = Delaunay(np.concatenate([pos, new_pos], axis=0))
             return new_pos, tri
     tri.add_points(new_pos)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -442,11 +442,10 @@ def _get_extra_points(pos, extrapolate, sphere):
     diffs = np.diff(pos, axis=0)
     with np.errstate(divide='ignore'):
         slopes = diffs[:, 1] / diffs[:, 0]
-    colinear = ((slopes == slopes[0]).all() or np.isinf(slopes).all() or
-                pos.shape[0] < 4)
+    colinear = ((slopes == slopes[0]).all() or np.isinf(slopes).all())
 
     # compute median inter-electrode distance
-    if colinear:
+    if colinear or pos.shape[0] < 4:
         dim = 1 if diffs[:, 1].sum() > diffs[:, 0].sum() else 0
         sorting = np.argsort(pos[:, dim])
         pos_sorted = pos[sorting, :]
@@ -462,8 +461,9 @@ def _get_extra_points(pos, extrapolate, sphere):
         distance = np.median(distances)
 
     if extrapolate == 'local':
-        if colinear:
-            # special case for colinear points
+        if colinear or pos.shape[0] < 4:
+            # special case for colinear points and when there is too
+            # little points for Delaunay (needs at least 3)
             edge_points = sorting[[0, -1]]
             line_len = np.diff(pos[edge_points, :], axis=0)
             unit_vec = line_len / np.linalg.norm(line_len) * distance
@@ -473,6 +473,15 @@ def _get_extra_points(pos, extrapolate, sphere):
                         np.concatenate([-unit_vec, unit_vec], axis=0))
             new_pos = np.concatenate([pos + unit_vec_par,
                                       pos - unit_vec_par, edge_pos], axis=0)
+
+            if pos.shape[0] == 3:
+                # there may be some new_pos points that are too close
+                # to the original points
+                new_pos_diff = pos[..., np.newaxis] - new_pos.T[np.newaxis, :]
+                new_pos_diff = np.linalg.norm(new_pos_diff, axis=1)
+                good_extra = (new_pos_diff > 0.5 * distance).all(axis=0)
+                new_pos = new_pos[good_extra]
+
             tri = Delaunay(np.concatenate([pos, new_pos], axis=0))
             return new_pos, tri
 


### PR DESCRIPTION
When testing code for `border='auto'` PR (as previously discussed with @larsoner, BTW I'll submit it soon) I found a small funny bug:
in `plot_topomap` with 3 channels extrapolations points were sometimes placed inadequately (red: original points, green: extrapolation points:
<img src=https://user-images.githubusercontent.com/8452354/74106646-dc202e80-4b68-11ea-94f9-6c6579f31bb1.PNG width="300px">
This was because all n_channels==3 cases were treated as colinear (this, in turn, was a quick hack for Delaunay needing more than 3 points to work) even when the 3 channels were not colinear. This incorrect placement of extrapolation points can lead to `border='mean'` not working because some extrapolation points may no longer have any original points as neighbours (only other extrapolation points). Now extrapolation points too close to original points are removed in `n_channels==3` case and the `border='mean'` error should no longer happen:
<img src=https://user-images.githubusercontent.com/8452354/74106836-4dacac80-4b6a-11ea-8f07-63c5407ffe15.PNG width="300px">

## TODOs:
- [x] I'll just need to test this more extensively locally 
- [x] add what's new entry?