### PR TITLE
[MRG] Fix handling of cell arrays and loading of evoked mat files when channels are not in info

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -236,6 +236,10 @@ Bug
 
 - Fix the way planar gradiometers are combined in :func:`mne.viz.plot_tfr_topomap` and :meth:`mne.Epochs.plot_psd_topomap` by `Geoff Brookshire`_
 
+- Improve error message when trying to load FieldTrip data from a cell array by `Thomas Hartmann`_
+
+- Fix bug in :fun:`mne.read_evoked_fieldtrip` causing it to crash when channels were present in the provided Info object but were not present in the data by `Thomas Hartmann`_
+
 - Fix placement of extrapolation points in :meth:`mne.Evoked.plot_topomap` and related functions when exactly three channels were used by `Mikołaj Magnuski`_.
 
 - Fix bug in reading annotations in :func:`read_annotations`, which would not accept ";" character by `Adam Li`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -238,7 +238,7 @@ Bug
 
 - Improve error message when trying to load FieldTrip data from a cell array by `Thomas Hartmann`_
 
-- Fix bug in :fun:`mne.read_evoked_fieldtrip` causing it to crash when channels were present in the provided Info object but were not present in the data by `Thomas Hartmann`_
+- Fix bug in :func:`mne.read_evoked_fieldtrip` causing it to crash when channels were present in the provided Info object but were not present in the data by `Thomas Hartmann`_
 
 - Fix placement of extrapolation points in :meth:`mne.Evoked.plot_topomap` and related functions when exactly three channels were used by `Mikołaj Magnuski`_.
 

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -239,7 +239,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.79', misc='0.5')
+    releases = dict(testing='0.80', misc='0.5')
     # And also update the "md5_hashes['testing']" variable below.
 
     # To update any other dataset, update the data archive itself (upload
@@ -323,7 +323,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='12b75d1cb7df9dfb4ad73ed82f61094f',
         somato='f08f17924e23c57a751b3bed4a05fe02',
         spm='9f43f67150e3b694b523a21eb929ea75',
-        testing='7a8f1804a38e72394cd64aca1dad7cd3',
+        testing='de51a47739798064fd20bd3345d5eba0',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         fnirs_motor='c4935d19ddab35422a69f3326a01fef8',
         opm='370ad1dcfd5c47e029e692c85358a374',

--- a/mne/io/fieldtrip/fieldtrip.py
+++ b/mne/io/fieldtrip/fieldtrip.py
@@ -7,7 +7,7 @@
 import numpy as np
 
 from .utils import _create_info, _set_tmin, _create_events, \
-    _create_event_metadata
+    _create_event_metadata, _validate_ft_struct
 from .. import RawArray
 from ...epochs import EpochsArray
 from ...evoked import EvokedArray
@@ -51,6 +51,8 @@ def read_raw_fieldtrip(fname, info, data_name='data'):
 
     # load data and set ft_struct to the heading dictionary
     ft_struct = ft_struct[data_name]
+
+    _validate_ft_struct(ft_struct)
 
     info = _create_info(ft_struct, info)  # create info structure
     data = np.array(ft_struct['trial'])  # create the main data array
@@ -113,6 +115,8 @@ def read_epochs_fieldtrip(fname, info, data_name='data',
     # load data and set ft_struct to the heading dictionary
     ft_struct = ft_struct[data_name]
 
+    _validate_ft_struct(ft_struct)
+
     info = _create_info(ft_struct, info)  # create info structure
     data = np.array(ft_struct['trial'])  # create the epochs data array
     events = _create_events(ft_struct, trialinfo_column)
@@ -162,6 +166,8 @@ def read_evoked_fieldtrip(fname, info, comment=None,
                          ignore_fields=['previous'],
                          variable_names=[data_name])
     ft_struct = ft_struct[data_name]
+
+    _validate_ft_struct(ft_struct)
 
     info = _create_info(ft_struct, info)  # create info structure
     data_evoked = ft_struct['avg']  # create evoked data

--- a/mne/io/fieldtrip/tests/test_fieldtrip.py
+++ b/mne/io/fieldtrip/tests/test_fieldtrip.py
@@ -41,7 +41,8 @@ no_info_warning = {'expected_warning': RuntimeWarning,
 @testing.requires_testing_data
 # Reading the sample CNT data results in a RuntimeWarning because it cannot
 # parse the measurement date. We need to ignore that warning.
-@pytest.mark.filterwarnings('ignore::RuntimeWarning')
+@pytest.mark.filterwarnings('ignore:.*parse meas date.*:RuntimeWarning')
+@pytest.mark.filterwarnings('ignore:.*number of bytes.*:RuntimeWarning')
 @pytest.mark.parametrize('cur_system, version, use_info',
                          all_test_params_epochs)
 def test_read_evoked(cur_system, version, use_info):
@@ -75,7 +76,8 @@ def test_read_evoked(cur_system, version, use_info):
 @testing.requires_testing_data
 # Reading the sample CNT data results in a RuntimeWarning because it cannot
 # parse the measurement date. We need to ignore that warning.
-@pytest.mark.filterwarnings('ignore::RuntimeWarning')
+@pytest.mark.filterwarnings('ignore:.*parse meas date.*:RuntimeWarning')
+@pytest.mark.filterwarnings('ignore:.*number of bytes.*:RuntimeWarning')
 @pytest.mark.parametrize('cur_system, version, use_info',
                          all_test_params_epochs)
 # Strange, non-deterministic Pandas errors:
@@ -128,7 +130,8 @@ def test_read_epochs(cur_system, version, use_info):
 @testing.requires_testing_data
 # Reading the sample CNT data results in a RuntimeWarning because it cannot
 # parse the measurement date. We need to ignore that warning.
-@pytest.mark.filterwarnings('ignore::RuntimeWarning')
+@pytest.mark.filterwarnings('ignore:.*parse meas date.*:RuntimeWarning')
+@pytest.mark.filterwarnings('ignore:.*number of bytes.*:RuntimeWarning')
 @pytest.mark.parametrize('cur_system, version, use_info', all_test_params_raw)
 def test_raw(cur_system, version, use_info):
     """Test comparing reading a raw fiff file and the FieldTrip version."""

--- a/mne/io/fieldtrip/tests/test_fieldtrip.py
+++ b/mne/io/fieldtrip/tests/test_fieldtrip.py
@@ -256,7 +256,7 @@ def test_throw_exception_on_cellarray(version, type):
 
 @testing.requires_testing_data
 def test_evoked_with_missing_channels():
-    """Test _create_info on evoked data when channels are missing from info"""
+    """Test _create_info on evoked data when channels are missing from info."""
     cur_system = 'neuromag306'
     test_data_folder_ft = get_data_paths(cur_system)
     info = get_raw_info(cur_system)

--- a/mne/io/fieldtrip/tests/test_fieldtrip.py
+++ b/mne/io/fieldtrip/tests/test_fieldtrip.py
@@ -260,7 +260,8 @@ def test_evoked_with_missing_channels():
     cur_system = 'neuromag306'
     test_data_folder_ft = get_data_paths(cur_system)
     info = get_raw_info(cur_system)
-    del info['ch_names'][1:20]
+    del info['chs'][1:20]
+    info._update_redundant()
 
     with pytest.warns(RuntimeWarning):
         mne.read_evoked_fieldtrip(

--- a/mne/io/fieldtrip/tests/test_fieldtrip.py
+++ b/mne/io/fieldtrip/tests/test_fieldtrip.py
@@ -228,3 +228,27 @@ def test_one_channel_elec_bug(version):
 
     with pytest.warns(**no_info_warning):
         mne.io.read_raw_fieldtrip(fname, info=None)
+
+
+@testing.requires_testing_data
+# Reading the sample CNT data results in a RuntimeWarning because it cannot
+# parse the measurement date. We need to ignore that warning.
+@pytest.mark.filterwarnings('ignore::RuntimeWarning')
+@pytest.mark.parametrize('version', all_versions)
+@pytest.mark.parametrize('type', ['averaged', 'epoched', 'raw'])
+@requires_h5py
+def test_throw_exception_on_cellarray(version, type):
+    """Test for a meaningful exception when the data is a cell array."""
+    fname = os.path.join(get_data_paths('cellarray'),
+                         '%s_%s.mat' % (type, version))
+
+    info = get_raw_info('CNT')
+
+    with pytest.raises(RuntimeError, match='Loading of data in cell arrays '
+                                           'is not supported'):
+        if type == 'averaged':
+            mne.read_evoked_fieldtrip(fname, info)
+        elif type == 'epoched':
+            mne.read_epochs_fieldtrip(fname, info)
+        elif type == 'raw':
+            mne.io.read_raw_fieldtrip(fname, info)

--- a/mne/io/fieldtrip/tests/test_fieldtrip.py
+++ b/mne/io/fieldtrip/tests/test_fieldtrip.py
@@ -233,7 +233,8 @@ def test_one_channel_elec_bug(version):
 @testing.requires_testing_data
 # Reading the sample CNT data results in a RuntimeWarning because it cannot
 # parse the measurement date. We need to ignore that warning.
-@pytest.mark.filterwarnings('ignore::RuntimeWarning')
+@pytest.mark.filterwarnings('ignore:.*parse meas date.*:RuntimeWarning')
+@pytest.mark.filterwarnings('ignore:.*number of bytes.*:RuntimeWarning')
 @pytest.mark.parametrize('version', all_versions)
 @pytest.mark.parametrize('type', ['averaged', 'epoched', 'raw'])
 @requires_h5py

--- a/mne/io/fieldtrip/tests/test_fieldtrip.py
+++ b/mne/io/fieldtrip/tests/test_fieldtrip.py
@@ -252,3 +252,16 @@ def test_throw_exception_on_cellarray(version, type):
             mne.read_epochs_fieldtrip(fname, info)
         elif type == 'raw':
             mne.io.read_raw_fieldtrip(fname, info)
+
+
+@testing.requires_testing_data
+def test_evoked_with_missing_channels():
+    """Test _create_info on evoked data when channels are missing from info"""
+    cur_system = 'neuromag306'
+    test_data_folder_ft = get_data_paths(cur_system)
+    info = get_raw_info(cur_system)
+    del info['ch_names'][1:20]
+
+    with pytest.warns(RuntimeWarning):
+        mne.read_evoked_fieldtrip(
+            os.path.join(test_data_folder_ft, 'averaged_v7.mat'), info)

--- a/mne/io/fieldtrip/utils.py
+++ b/mne/io/fieldtrip/utils.py
@@ -30,6 +30,12 @@ NOINFO_WARNING = 'Importing FieldTrip data without an info dict from the ' \
                  'source analysis, channel interpolation etc.'
 
 
+def _validate_ft_struct(ft_struct):
+    """Run validation checks on the ft_structure"""
+    if isinstance(ft_struct, list):
+        raise RuntimeError('Loading of data in cell arrays is not supported')
+
+
 def _create_info(ft_struct, raw_info):
     """Create MNE info structure from a FieldTrip structure."""
     if raw_info is None:

--- a/mne/io/fieldtrip/utils.py
+++ b/mne/io/fieldtrip/utils.py
@@ -57,7 +57,7 @@ def _create_info(ft_struct, raw_info):
             ch_names = new_chs
             ft_struct['label'] = ch_names
 
-            if 'trial ' in ft_struct:
+            if 'trial' in ft_struct:
                 if ft_struct['trial'].ndim == 2:
                     ft_struct['trial'] = np.delete(ft_struct['trial'],
                                                    missing_chan_idx,

--- a/mne/io/fieldtrip/utils.py
+++ b/mne/io/fieldtrip/utils.py
@@ -56,10 +56,18 @@ def _create_info(ft_struct, raw_info):
             new_chs = [ch for ch in ch_names if ch not in missing_channels]
             ch_names = new_chs
             ft_struct['label'] = ch_names
-            if ft_struct['trial'].ndim == 2:
-                ft_struct['trial'] = np.delete(ft_struct['trial'],
-                                               missing_chan_idx,
-                                               axis=0)
+
+            if 'trial ' in ft_struct:
+                if ft_struct['trial'].ndim == 2:
+                    ft_struct['trial'] = np.delete(ft_struct['trial'],
+                                                   missing_chan_idx,
+                                                   axis=0)
+
+            if 'avg' in ft_struct:
+                if ft_struct['avg'].ndim == 2:
+                    ft_struct['avg'] = np.delete(ft_struct['avg'],
+                                                 missing_chan_idx,
+                                                 axis=0)
 
         info['sfreq'] = sfreq
         ch_idx = [info['ch_names'].index(ch) for ch in ch_names]

--- a/mne/io/fieldtrip/utils.py
+++ b/mne/io/fieldtrip/utils.py
@@ -31,7 +31,7 @@ NOINFO_WARNING = 'Importing FieldTrip data without an info dict from the ' \
 
 
 def _validate_ft_struct(ft_struct):
-    """Run validation checks on the ft_structure"""
+    """Run validation checks on the ft_structure."""
     if isinstance(ft_struct, list):
         raise RuntimeError('Loading of data in cell arrays is not supported')
 


### PR DESCRIPTION
#### Reference issue
Fixes #7293 


#### What does this implement/fix?
This PR fixes two bugs found when investigating #7293:

1. The error message returned when the data structure is a cell array was not intuitive.
2. When a channel was not present in the `info` object but in the loaded evoked data, the function would crash.
