### PR TITLE
WIP: Add help window to the _TimeViewer

### DIFF
--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -404,11 +404,6 @@ class _TimeViewer(object):
         # add toggle to show/hide interface
         self.visibility = True
 
-        # display help
-        self.help_actor = self.plotter.add_text(
-            text="Press ? to show help window"
-        )
-
         # set the slider style
         self.set_slider_style(smoothing_slider)
         self.set_slider_style(fmin_slider)
@@ -426,6 +421,8 @@ class _TimeViewer(object):
             'u': self.restore_user_scaling,
             ' ': self.toggle_playback,
         }
+        menu = self.plotter.main_menu.addMenu('Help')
+        menu.addAction('Show MNE key bindings\t?', self.help)
 
     def keyPressEvent(self, event):
         callback = self.key_bindings.get(event.text())
@@ -434,12 +431,6 @@ class _TimeViewer(object):
 
     def toggle_interface(self):
         self.visibility = not self.visibility
-
-        # manage help text
-        if self.visibility:
-            self.help_actor.VisibilityOn()
-        else:
-            self.help_actor.VisibilityOff()
 
         # manage sliders
         for slider in self.plotter.slider_widgets:

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -6,6 +6,7 @@
 
 import time
 import numpy as np
+from ..utils import plt_show, figure_nobar
 
 
 class IntSlider(object):
@@ -409,6 +410,12 @@ class _TimeViewer(object):
         # restore user scaling action
         self.plotter.add_key_event('u', self.restore_user_scaling)
 
+        # display help
+        self.help_actor = self.plotter.add_text(
+            text="Press h to show help window"
+        )
+        self.plotter.add_key_event('h', self.help)
+
         # set the slider style
         self.set_slider_style(smoothing_slider)
         self.set_slider_style(fmin_slider)
@@ -420,6 +427,13 @@ class _TimeViewer(object):
 
     def toggle_interface(self):
         self.visibility = not self.visibility
+
+        # manage help text
+        if self.visibility:
+            self.help_actor.VisibilityOn()
+        else:
+            self.help_actor.VisibilityOff()
+
         # manage sliders
         for slider in self.plotter.slider_widgets:
             slider_rep = slider.GetRepresentation()
@@ -490,6 +504,37 @@ class _TimeViewer(object):
             slider_rep.GetSliderProperty().SetColor((0.5, 0.5, 0.5))
             if not show_label:
                 slider_rep.ShowSliderLabelOff()
+
+    def help(self):
+        shortcuts = {
+            'h': 'Display help window',
+            'y': 'Toggle interface',
+            't': 'Apply auto-scaling',
+            'u': 'Restore original clim',
+            'Space': 'Start/Pause playback'
+        }
+        text = [str(s) + " : \n" for s in shortcuts.keys()]
+        text2 = [str(s) + "\n" for s in shortcuts.values()]
+        text, text2 = ''.join(text), ''.join(text2)
+        width, height = 9, 5
+
+        fig_help = figure_nobar(figsize=(width, height), dpi=80)
+        fig_help.canvas.set_window_title('Help')
+
+        ax = fig_help.add_subplot(111)
+        celltext = [[c1, c2] for c1, c2 in zip(text.strip().split("\n"),
+                                               text2.strip().split("\n"))]
+        table = ax.table(cellText=celltext, loc="center", cellLoc="left")
+        table.auto_set_font_size(False)
+        table.set_fontsize(12)
+        ax.set_axis_off()
+        for (row, col), cell in table.get_celld().items():
+            cell.set_edgecolor(None)  # remove cell borders
+            if col == 0:
+                cell._loc = 'right'
+
+        fig_help.canvas.draw()
+        plt_show(fig=fig_help, warn=False)
 
 
 class _LinkViewer(object):

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -428,9 +428,13 @@ class _TimeViewer(object):
         }
 
     def keyPressEvent(self, event):
-        callback = self.key_bindings.get(event.text())
-        if callback is not None:
-            callback()
+        from PyQt5 import QtCore
+        if event.key() == QtCore.Qt.Key_Question:
+            self.help()
+        else:
+            callback = self.key_bindings.get(event.text())
+            if callback is not None:
+                callback()
 
     def toggle_interface(self):
         self.visibility = not self.visibility

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -416,9 +416,9 @@ class _TimeViewer(object):
         # setup key bindings
         self.key_bindings = {
             '?': self.help,
-            'y': self.toggle_interface,
-            't': self.apply_auto_scaling,
-            'u': self.restore_user_scaling,
+            'i': self.toggle_interface,
+            's': self.apply_auto_scaling,
+            'r': self.restore_user_scaling,
             ' ': self.toggle_playback,
         }
         menu = self.plotter.main_menu.addMenu('Help')
@@ -506,9 +506,9 @@ class _TimeViewer(object):
     def help(self):
         pairs = [
             ('?', 'Display help window'),
-            ('y', 'Toggle interface'),
-            ('t', 'Apply auto-scaling'),
-            ('u', 'Restore original clim'),
+            ('i', 'Toggle interface'),
+            ('s', 'Apply auto-scaling'),
+            ('r', 'Restore original clim'),
             ('Space', 'Start/Pause playback'),
         ]
         text1, text2 = zip(*pairs)

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -506,18 +506,18 @@ class _TimeViewer(object):
                 slider_rep.ShowSliderLabelOff()
 
     def help(self):
-        shortcuts = {
-            'h': 'Display help window',
-            'y': 'Toggle interface',
-            't': 'Apply auto-scaling',
-            'u': 'Restore original clim',
-            'Space': 'Start/Pause playback'
-        }
-        text = [str(s) + " : \n" for s in shortcuts.keys()]
-        text2 = [str(s) + "\n" for s in shortcuts.values()]
-        text, text2 = ''.join(text), ''.join(text2)
+        pairs = [
+            ('h', 'Display help window'),
+            ('y', 'Toggle interface'),
+            ('t', 'Apply auto-scaling'),
+            ('u', 'Restore original clim'),
+            ('Space', 'Start/Pause playback'),
+        ]
+        text1, text2 = zip(*pairs)
+        text1 = '\n'.join(text1)
+        text2 = '\n'.join(text2)
         _show_help(
-            col1=text,
+            col1=text1,
             col2=text2,
             width=5,
             height=2,

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -429,7 +429,7 @@ class _TimeViewer(object):
 
     def keyPressEvent(self, event):
         from PyQt5 import QtCore
-        if event.key() == QtCore.Qt.Key_Question:
+        if event.key() == QtCore.Qt.Key_questiondown:
             self.help()
         else:
             callback = self.key_bindings.get(event.text())

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -428,13 +428,9 @@ class _TimeViewer(object):
         }
 
     def keyPressEvent(self, event):
-        from PyQt5 import QtCore
-        if event.key() == QtCore.Qt.Key_Question:
-            self.help()
-        else:
-            callback = self.key_bindings.get(event.text())
-            if callback is not None:
-                callback()
+        callback = self.key_bindings.get(event.text())
+        if callback is not None:
+            callback()
 
     def toggle_interface(self):
         self.visibility = not self.visibility

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -428,13 +428,9 @@ class _TimeViewer(object):
         }
 
     def keyPressEvent(self, event):
-        from PyQt5 import QtCore
-        if event.key() == QtCore.Qt.Key_questiondown:
-            self.help()
-        else:
-            callback = self.key_bindings.get(event.text())
-            if callback is not None:
-                callback()
+        callback = self.key_bindings.get(event.text())
+        if callback is not None:
+            callback()
 
     def toggle_interface(self):
         self.visibility = not self.visibility

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -6,7 +6,7 @@
 
 import time
 import numpy as np
-from ..utils import plt_show, figure_nobar
+from ..utils import _show_help
 
 
 class IntSlider(object):
@@ -516,25 +516,12 @@ class _TimeViewer(object):
         text = [str(s) + " : \n" for s in shortcuts.keys()]
         text2 = [str(s) + "\n" for s in shortcuts.values()]
         text, text2 = ''.join(text), ''.join(text2)
-        width, height = 9, 5
-
-        fig_help = figure_nobar(figsize=(width, height), dpi=80)
-        fig_help.canvas.set_window_title('Help')
-
-        ax = fig_help.add_subplot(111)
-        celltext = [[c1, c2] for c1, c2 in zip(text.strip().split("\n"),
-                                               text2.strip().split("\n"))]
-        table = ax.table(cellText=celltext, loc="center", cellLoc="left")
-        table.auto_set_font_size(False)
-        table.set_fontsize(12)
-        ax.set_axis_off()
-        for (row, col), cell in table.get_celld().items():
-            cell.set_edgecolor(None)  # remove cell borders
-            if col == 0:
-                cell._loc = 'right'
-
-        fig_help.canvas.draw()
-        plt_show(fig=fig_help, warn=False)
+        _show_help(
+            col1=text,
+            col2=text2,
+            width=5,
+            height=2,
+        )
 
 
 class _LinkViewer(object):

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1235,19 +1235,13 @@ def _select_bads(event, params, bads):
     return bads
 
 
-def _onclick_help(event, params):
-    """Draw help window."""
-    text, text2 = _get_help_text(params)
-
-    width, height = 9, 5
-
+def _show_help(col1, col2, width, height):
     fig_help = figure_nobar(figsize=(width, height), dpi=80)
     fig_help.canvas.set_window_title('Help')
-    params['fig_help'] = fig_help
 
     ax = fig_help.add_subplot(111)
-    celltext = [[c1, c2] for c1, c2 in zip(text.strip().split("\n"),
-                                           text2.strip().split("\n"))]
+    celltext = [[c1, c2] for c1, c2 in zip(col1.strip().split("\n"),
+                                           col2.strip().split("\n"))]
     table = ax.table(cellText=celltext, loc="center", cellLoc="left")
     table.auto_set_font_size(False)
     table.set_fontsize(12)
@@ -1267,6 +1261,17 @@ def _onclick_help(event, params):
         plt_show(fig=fig_help, warn=False)
     except Exception:
         pass
+
+
+def _onclick_help(event, params):
+    """Draw help window."""
+    col1, col2 = _get_help_text(params)
+    params['fig_help'] = _show_help(
+        col1=col1,
+        col2=col2,
+        width=9,
+        height=5,
+    )
 
 
 def _key_press(event):


### PR DESCRIPTION
This PR adds a `matplotlib` figure to display help. The shortcut is `h`:

![2020-02-10_1920x1080](https://user-images.githubusercontent.com/18143289/74163568-da1aa600-4c22-11ea-9273-efe78901e3e6.png)

- [x] Refactor existing code in `mne/viz/utils.py` (suggested in https://github.com/mne-tools/mne-python/pull/7305#discussion_r377147858)
- [x] Find satisfying geometry/size (suggested in https://github.com/mne-tools/mne-python/pull/7305#issuecomment-584187390)
- [x] Use `tuple` instead of `dict` to respect order (suggested in https://github.com/mne-tools/mne-python/pull/7305#discussion_r377663004)
- [x] Use `?` as shortcut to show the help window (suggested in https://github.com/mne-tools/mne-python/pull/7247#issuecomment-584207042)
- [x] Use a `Help` menu instead of a label (suggested in https://github.com/mne-tools/mne-python/pull/7305#discussion_r378898948)
- [x] Update the shorcuts (suggested in https://github.com/mne-tools/mne-python/pull/7305#issuecomment-585843912)
- [ ] Increase line spacing (suggetsed in https://github.com/mne-tools/mne-python/pull/7305#issuecomment-585865607)

Closes https://github.com/mne-tools/mne-python/issues/7268
It's an item of #7162 