### PR TITLE
MRG, ENH: Add rank to fit_dipole

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -97,6 +97,8 @@ Changelog
 
 - Allow `mne.channels.read_custom_montage` to handle fiducial points for BESA spherical (``.elp``) files by `Richard Höchenberger`_
 
+- Add ``rank`` argument to :func:`mne.fit_dipole` by `Eric Larson`_
+
 - Add function to convert events to annotations :func:`mne.annotations_from_events` by `Nicolas Barascud`_
 
 - Add function to calculate scalp coupling index for fNIRS data :func:`mne.preprocessing.nirs.scalp_coupling_index` by `Robert Luke`_

--- a/doc/overview/roadmap.rst
+++ b/doc/overview/roadmap.rst
@@ -30,6 +30,8 @@ In particular, the new API should:
 4. Not introduce any significant speed penalty (e.g., < 10% slower) compared
    to the existing, more specialized/limited functions.
 
+More details are in :gh:`4859`.
+
 
 3D visualization
 ^^^^^^^^^^^^^^^^

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -1097,7 +1097,7 @@ def _fit_dipole_fixed(min_dist_to_inner_skull, B_orig, t, guess_rrs,
 
 @verbose
 def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
-               pos=None, ori=None, verbose=None):
+               pos=None, ori=None, rank=None, verbose=None):
     """Fit a dipole.
 
     Parameters
@@ -1134,6 +1134,9 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
         for each time instant.
 
         .. versionadded:: 0.12
+    %(rank_None)s
+
+        .. versionadded:: 0.20
     %(verbose)s
 
     Returns
@@ -1310,7 +1313,7 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     # whitener = np.dot(whitener, cov['eigvec'])
 
     whitener, _, rank = compute_whitener(cov, info, picks=picks,
-                                         return_rank=True)
+                                         rank=rank, return_rank=True)
 
     # Proceed to computing the fits (make_guess_data)
     if fixed_position:

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -92,7 +92,7 @@ def test_dipole_fitting_ctf():
     # for now our CTF phantom fitting tutorials will have to do
     # (otherwise we need to add that to the testing dataset, which is
     # a bit too big)
-    fit_dipole(evoked, cov, sphere)
+    fit_dipole(evoked, cov, sphere, rank=dict(meg=len(evoked.data)))
 
 
 @pytest.mark.slowtest
@@ -136,7 +136,8 @@ def test_dipole_fitting(tmpdir):
     # Run mne-python version
     sphere = make_sphere_model(head_radius=0.1)
     with pytest.warns(RuntimeWarning, match='projection'):
-        dip, residual = fit_dipole(evoked, cov, sphere, fname_fwd)
+        dip, residual = fit_dipole(evoked, cov, sphere, fname_fwd,
+                                   rank='info')  # just to test rank support
     assert isinstance(residual, Evoked)
 
     # Sanity check: do our residuals have less power than orig data?


### PR DESCRIPTION
- Adds `rank` argument to control rank when using whitening in dipole fitting
- I realized a link to #4859 was missing from the roadmap so I snuck it in here