### PR TITLE
Use latest version 0.23.1 of pyvista instead of master

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - mne
   - https://api.github.com/repos/numpy/numpydoc/zipball/master
   - vtk
-  - https://api.github.com/repos/pyvista/pyvista/zipball/master
+  - pyvista>=0.23.1
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -210,7 +210,7 @@ class _TimeViewer(object):
         self.brain = brain
         self.brain.time_viewer = self
         self.plotter = brain._renderer.plotter
-        self.interactor = self.plotter.interactor
+        self.interactor = self.plotter
         self.interactor.keyPressEvent = self.keyPressEvent
 
         # orientation slider

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ xlrd
 pydocstyle
 flake8
 https://github.com/mcmtroffaes/sphinxcontrib-bibtex/zipball/29694f215b39d64a31b845aafd9ff2ae9329494f
-https://github.com/pyvista/pyvista/zipball/master
+pyvista>=0.23.1


### PR DESCRIPTION
This PR updates the package requirements for the pyvista 3d backend.