### PR TITLE
MRG, FIX: Fix scalp coupling index test that intermittently failed

### DIFF
--- a/mne/preprocessing/tests/test_scalp_coupling_index.py
+++ b/mne/preprocessing/tests/test_scalp_coupling_index.py
@@ -49,6 +49,12 @@ def test_scalp_coupling_index(fname, fmt, tmpdir):
     # Set next two channels to anti correlation
     raw._data[4] = new_data
     raw._data[5] = new_data * -1.0
+    # Set next two channels to be uncorrelated
+    rng = np.random.RandomState(0)
+    raw._data[6] = new_data
+    raw._data[7] = rng.rand(raw._data[0].shape[0])
     # Check values
     sci = scalp_coupling_index(raw)
     assert_allclose(sci[0:6], [1, 1, 1, 1, -1, -1], atol=0.01)
+    assert np.abs(sci[6]) < 0.5
+    assert np.abs(sci[7]) < 0.5

--- a/mne/preprocessing/tests/test_scalp_coupling_index.py
+++ b/mne/preprocessing/tests/test_scalp_coupling_index.py
@@ -49,12 +49,6 @@ def test_scalp_coupling_index(fname, fmt, tmpdir):
     # Set next two channels to anti correlation
     raw._data[4] = new_data
     raw._data[5] = new_data * -1.0
-    # Set next two channels to be uncorrelated
-    # TODO: this might be a bad idea as sometimes random noise might correlate
-    raw._data[6] = new_data
-    raw._data[7] = np.random.rand(raw._data[0].shape[0])
     # Check values
     sci = scalp_coupling_index(raw)
     assert_allclose(sci[0:6], [1, 1, 1, 1, -1, -1], atol=0.01)
-    assert np.abs(sci[6]) < 0.5
-    assert np.abs(sci[7]) < 0.5


### PR DESCRIPTION
#### Reference issue
Fixes issue raised in #7180 .


#### What does this implement/fix?
This test was intermittently failing see #7180 
The test was assuming that random noise would be correlated less than 0.5, but sometimes by chance this happens.