### PR TITLE
BF: Make read_custom_montage() respect unit kwarg for Theta-phi montages

### DIFF
--- a/mne/channels/_standard_montage_utils.py
+++ b/mne/channels/_standard_montage_utils.py
@@ -9,7 +9,7 @@ import numpy as np
 from functools import partial
 import xml.etree.ElementTree as ElementTree
 
-from .montage import make_dig_montage
+from .montage import make_dig_montage, _check_unit_and_get_scaling
 from ..transforms import _sph_to_cart
 from . import __file__ as _CHANNELS_INIT_FILE
 
@@ -236,7 +236,7 @@ def _read_elc(fname, head_size):
 
 
 def _read_theta_phi_in_degrees(fname, head_size, fid_names=None,
-                               add_fiducials=False):
+                               add_fiducials=False, unit='m'):
     ch_names, theta, phi = _safe_np_loadtxt(fname, skip_header=1,
                                             dtype=(_str, 'i4', 'i4'))
     if add_fiducials:
@@ -252,8 +252,12 @@ def _read_theta_phi_in_degrees(fname, head_size, fid_names=None,
         theta = np.append(theta, [115, -115, 115])
         phi = np.append(phi, [90, 0, 0])
 
+    VALID_SCALES = dict(mm=1e-3, cm=1e-2, m=1)
+    scale = _check_unit_and_get_scaling(unit, VALID_SCALES)
+
     radii = np.full(len(phi), head_size)
     pos = _sph_to_cart(np.array([radii, np.deg2rad(phi), np.deg2rad(theta)]).T)
+    pos *= scale
     ch_pos = OrderedDict(zip(ch_names, pos))
 
     nasion, lpa, rpa = None, None, None

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -965,10 +965,11 @@ def read_custom_montage(fname, head_size=HEAD_SIZE_DEFAULT, unit='m',
         '.sfp' (BESA/EGI files), '.csd',
         ‘.elc’, ‘.txt’, ‘.csd’, ‘.elp’ (BESA spherical),
         .bvef (BrainVision files).
-
     head_size : float | None
         The size of the head in [m]. If none, returns the values read from the
-        file with no modification. Defaults to 95mm.
+        file with no modification. Defaults to 0.095m.
+    unit : 'm' | 'cm' | 'mm'
+        Unit of the head size. Defaults to 'm'.
     coord_frame : str | None
         The coordinate frame of the points. Usually this is "unknown"
         for native digitizer space. Defaults to None, which is "unknown" for
@@ -1041,6 +1042,7 @@ def read_custom_montage(fname, head_size=HEAD_SIZE_DEFAULT, unit='m',
             raise ValueError(
                 "``head_size`` cannot be None for '{}'".format(ext))
         montage = _read_theta_phi_in_degrees(fname, head_size=head_size,
+                                             unit=unit,
                                              fid_names=('Nz', 'LPA', 'RPA'))
 
     elif ext in SUPPORTED_FILE_EXT['standard BESA spherical']:


### PR DESCRIPTION
#### Reference issue
Fixes (the first bits of) #7320.

#### What does this implement/fix?
Makes `montage.read_custom_montage()` pass the `unit` kwarg down to `_read_theta_phi_in_degrees()`
