### PR TITLE
TST: Deprecation warning: 'TraitTuple'

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -78,6 +78,7 @@ def pytest_configure(config):
     ignore:sklearn\.externals\.joblib is deprecated.*:FutureWarning
     ignore:The sklearn.*module.*deprecated.*:FutureWarning
     ignore:.*TraitTuple.*trait.*handler.*deprecated.*:DeprecationWarning
+    ignore:.*rich_compare.*metadata.*deprecated.*:DeprecationWarning
     always:.*get_data.* is deprecated in favor of.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -77,6 +77,7 @@ def pytest_configure(config):
     ignore:scipy\.gradient is deprecated.*:DeprecationWarning
     ignore:sklearn\.externals\.joblib is deprecated.*:FutureWarning
     ignore:The sklearn.*module.*deprecated.*:FutureWarning
+    ignore:.*TraitTuple.*trait.*handler.*deprecated.*:DeprecationWarning
     always:.*get_data.* is deprecated in favor of.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):


### PR DESCRIPTION
This PR tries to reproduce recent Travis failure on https://github.com/mne-tools/mne-python/pull/7247:

```
DeprecationWarning: 'TraitTuple' trait handler has been deprecated. Use Tuple instead.
```

Reference:
https://travis-ci.org/mne-tools/mne-python/jobs/650433990?utm_medium=notification&utm_source=github_status
