### PR TITLE
API: properly deprecate changes in to_data_frame

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -57,7 +57,8 @@ from .utils import (_check_fname, check_fname, logger, verbose,
                     _check_event_id, _gen_events, _check_option,
                     _check_combine, ShiftTimeMixin, _build_data_frame,
                     _check_pandas_index_arguments, _convert_times,
-                    _scale_dataframe_data, _check_time_format)
+                    _scale_dataframe_data, _check_time_format,
+                    _check_scaling_time)
 from .utils.docs import fill_doc
 
 
@@ -1709,8 +1710,9 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         return self, indices
 
     @fill_doc
-    def to_data_frame(self, index=None, time_format='ms', picks=None,
-                      scalings=None, copy=True, long_format=False):
+    def to_data_frame(self, picks=None, index=None, scaling_time=None,
+                      scalings=None, copy=True, long_format=False,
+                      time_format='ms'):
         """Export data in tabular structure as a pandas DataFrame.
 
         Channels are converted to columns in the DataFrame. By default,
@@ -1721,19 +1723,24 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
 
         Parameters
         ----------
+        %(picks_all)s
         %(df_index_epo)s
             Valid string values are 'time', 'epoch', and 'condition'.
             Defaults to ``None``.
-        %(df_time_format)s
-        %(picks_all)s
+        %(df_scaling_time_deprecated)s
         %(df_scalings)s
         %(df_copy)s
         %(df_longform_epo)s
+        %(df_time_format)s
+
+            .. versionadded:: 0.20
 
         Returns
         -------
         %(df_return)s
         """
+        # check deprecation
+        _check_scaling_time(scaling_time)
         # check pandas once here, instead of in each private utils function
         pd = _check_pandas_installed()  # noqa
         # arg checking

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -20,7 +20,8 @@ from .utils import (check_fname, logger, verbose, _time_mask, warn, sizeof_fmt,
                     SizeMixin, copy_function_doc_to_method_doc, _validate_type,
                     fill_doc, _check_option, ShiftTimeMixin, _build_data_frame,
                     _check_pandas_installed, _check_pandas_index_arguments,
-                    _convert_times, _scale_dataframe_data, _check_time_format)
+                    _convert_times, _scale_dataframe_data, _check_time_format,
+                    _check_scaling_time)
 from .viz import (plot_evoked, plot_evoked_topomap, plot_evoked_field,
                   plot_evoked_image, plot_evoked_topo)
 from .viz.evoked import plot_evoked_white, plot_evoked_joint
@@ -614,8 +615,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         return out
 
     @fill_doc
-    def to_data_frame(self, index=None, time_format='ms', picks=None,
-                      scalings=None, copy=True, long_format=False):
+    def to_data_frame(self, picks=None, index=None, scaling_time=None,
+                      scalings=None, copy=True, long_format=False,
+                      time_format='ms'):
         """Export data in tabular structure as a pandas DataFrame.
 
         Channels are converted to columns in the DataFrame. By default,
@@ -624,18 +626,23 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         Parameters
         ----------
+        %(picks_all)s
         %(df_index_evk)s
             Defaults to ``None``.
-        %(df_time_format)s
-        %(picks_all)s
+        %(df_scaling_time_deprecated)s
         %(df_scalings)s
         %(df_copy)s
         %(df_longform_raw)s
+        %(df_time_format)s
+
+            .. versionadded:: 0.20
 
         Returns
         -------
         %(df_return)s
         """
+        # check deprecation
+        _check_scaling_time(scaling_time)
         # check pandas once here, instead of in each private utils function
         pd = _check_pandas_installed()  # noqa
         # arg checking

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -41,7 +41,7 @@ from ..utils import (_check_fname, _check_pandas_installed, sizeof_fmt,
                      copy_function_doc_to_method_doc, _validate_type,
                      _check_preload, _get_argvalues, _check_option,
                      _build_data_frame, _convert_times, _scale_dataframe_data,
-                     _check_time_format)
+                     _check_time_format, _check_scaling_time)
 from ..viz import plot_raw, plot_raw_psd, plot_raw_psd_topo
 from ..event import find_events, concatenate_events
 from ..annotations import Annotations, _combine_annotations, _sync_onset
@@ -1654,9 +1654,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         return int(np.ceil(buffer_size_sec * self.info['sfreq']))
 
     @fill_doc
-    def to_data_frame(self, index=None, time_format='ms', picks=None,
-                      start=None, stop=None, scalings=None, copy=True,
-                      long_format=False):
+    def to_data_frame(self, picks=None, index=None, scaling_time=None,
+                      scalings=None, copy=True, start=None, stop=None,
+                      long_format=False, time_format='ms'):
         """Export data in tabular structure as a pandas DataFrame.
 
         Channels are converted to columns in the DataFrame. By default, an
@@ -1665,24 +1665,30 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         Parameters
         ----------
+        %(picks_all)s
         %(df_index_raw)s
             Defaults to ``None``.
-        %(df_time_format_raw)s
-        %(picks_all)s
-        start : int | None
-            Starting sample index for creating the DataFrame from a temporal
-            span of the Raw object.
-        stop : int | None
-            Ending sample index for creating the DataFrame from a temporal span
-            of the Raw object.
+        %(df_scaling_time_deprecated)s
         %(df_scalings)s
         %(df_copy)s
+        start : int | None
+            Starting sample index for creating the DataFrame from a temporal
+            span of the Raw object. ``None`` (the default) uses the first
+            sample.
+        stop : int | None
+            Ending sample index for creating the DataFrame from a temporal span
+            of the Raw object. ``None`` (the default) uses the last sample.
         %(df_longform_raw)s
+        %(df_time_format_raw)s
+
+            .. versionadded:: 0.20
 
         Returns
         -------
         %(df_return)s
         """
+        # check deprecation
+        _check_scaling_time(scaling_time)
         # check pandas once here, instead of in each private utils function
         pd = _check_pandas_installed()  # noqa
         # arg checking

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -24,7 +24,7 @@ from .utils import (get_subjects_dir, _check_subject, logger, verbose,
                     fill_doc, _check_option, _validate_type, _check_src_normal,
                     _check_stc_units, _check_pandas_installed,
                     _check_pandas_index_arguments, _convert_times,
-                    _build_data_frame, _check_time_format)
+                    _build_data_frame, _check_time_format, _check_scaling_time)
 from .viz import (plot_source_estimates, plot_vector_source_estimates,
                   plot_volume_source_estimates)
 from .io.base import TimeMixin
@@ -1119,8 +1119,8 @@ class _BaseSourceEstimate(TimeMixin):
         return stcs
 
     @fill_doc
-    def to_data_frame(self, index=None, time_format='ms', scalings=None,
-                      long_format=False):
+    def to_data_frame(self, index=None, scaling_time=None, scalings=None,
+                      long_format=False, time_format='ms'):
         """Export data in tabular structure as a pandas DataFrame.
 
         Vertices are converted to columns in the DataFrame. By default,
@@ -1131,14 +1131,19 @@ class _BaseSourceEstimate(TimeMixin):
         ----------
         %(df_index_evk)s
             Defaults to ``None``.
-        %(df_time_format)s
+        %(df_scaling_time_deprecated)s
         %(df_scalings)s
         %(df_longform_stc)s
+        %(df_time_format)s
+
+            .. versionadded:: 0.20
 
         Returns
         -------
         %(df_return)s
         """
+        # check deprecation
+        _check_scaling_time(scaling_time)
         # check pandas once here, instead of in each private utils function
         pd = _check_pandas_installed()  # noqa
         # arg checking

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1739,13 +1739,16 @@ def test_to_data_frame():
     """Test epochs Pandas exporter."""
     raw, events, picks = _get_data()
     epochs = Epochs(raw, events, {'a': 1, 'b': 2}, tmin, tmax, picks=picks)
+    # test deprecation
+    with pytest.deprecated_call(match='scaling_time is deprecated'):
+        epochs.to_data_frame(scaling_time=1e2)
     # test index checking
     with pytest.raises(ValueError, match='options. Valid index options are'):
         epochs.to_data_frame(index=['foo', 'bar'])
     with pytest.raises(ValueError, match='"qux" is not a valid option'):
         epochs.to_data_frame(index='qux')
     with pytest.raises(TypeError, match='index must be `None` or a string or'):
-        epochs.to_data_frame(np.arange(400))
+        epochs.to_data_frame(index=np.arange(400))
     # test wide format
     df_wide = epochs.to_data_frame()
     assert all(np.in1d(epochs.ch_names, df_wide.columns))

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -355,7 +355,7 @@ def test_to_data_frame():
     with pytest.raises(ValueError, match='"qux" is not a valid option'):
         ave.to_data_frame(index='qux')
     with pytest.raises(TypeError, match='index must be `None` or a string or'):
-        ave.to_data_frame(np.arange(400))
+        ave.to_data_frame(index=np.arange(400))
     # test setting index
     df = ave.to_data_frame(index='time')
     assert 'time' not in df.columns

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -60,4 +60,4 @@ from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
 from .linalg import (_svd_lwork, _repeated_svd,
                      dgesdd, dgemm, zgemm, dgemv, ddot, LinAlgError, eigh)
 from .dataframe import (_set_pandas_dtype, _scale_dataframe_data,
-                        _convert_times, _build_data_frame)
+                        _convert_times, _build_data_frame, _check_scaling_time)

--- a/mne/utils/dataframe.py
+++ b/mne/utils/dataframe.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from ._logging import logger
 from ..defaults import _handle_default
+from ..utils import warn
 
 
 def _set_pandas_dtype(df, columns, dtype):
@@ -30,6 +31,16 @@ def _scale_dataframe_data(inst, data, picks, scalings):
         if len(idx):
             data[:, idx] *= scaling
     return data
+
+
+def _check_scaling_time(scaling_time):
+    """Check deprecated parameter."""
+    if scaling_time is not None:
+        warn('scaling_time is deprecated in version 0.20 and will be '
+             'removed in version 0.21. To replicate old behavior, use '
+             'time_format="ms" to get time in milliseconds, or use '
+             'time_format=None and scale the time column (in seconds) '
+             'after DataFrame creation.', DeprecationWarning)
 
 
 def _convert_times(inst, times, time_format):

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -614,6 +614,12 @@ transparent : bool | None
     None will choose automatically based on colormap type.
 """
 # DataFrames
+docdict['df_scaling_time_deprecated'] = """
+scaling_time : None
+    Deprecated; use ``time_format`` instead. If you need to scale time values
+    by a factor other than 1000 (seconds → milliseconds), create the DataFrame
+    first, then scale its ``time`` column afterwards.
+"""
 docdict['df_index'] = """
 index : {} | None
     Kind of index to use for the DataFrame. If ``None``, a sequential


### PR DESCRIPTION
This PR adds a proper deprecation cycle to the API changes in #7206 

It also restores parameter order to more closely match what it used to be, to minimize downstream code breakage with positional argument passing.