### PR TITLE
Expose number of ICA iterations as ICA.n_iter_

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -119,6 +119,8 @@ Changelog
 
 - Allow retrieval of the number of Infomax ICA iterations via the new ``return_n_iter`` keyword argument of :func:`mne.preprocessing.infomax` by `Richard Höchenberger`_
 
+- Expose the number of ICA iterations during the fitting procedure via the ``n_iter_`` attribute of :class:`mne.preprocessing.ICA` by `Richard Höchenberger`_
+
 Bug
 ~~~
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2042,7 +2042,8 @@ def _write_ica(fid, ica):
     n_samples = getattr(ica, 'n_samples_', None)
     ica_misc = {'n_samples_': (None if n_samples is None else int(n_samples)),
                 'labels_': getattr(ica, 'labels_', None),
-                'method': getattr(ica, 'method', None)}
+                'method': getattr(ica, 'method', None),
+                'n_iter_': getattr(ica, 'n_iter_', None)}
 
     write_string(fid, FIFF.FIFF_MNE_ICA_INTERFACE_PARAMS,
                  _serialize(ica_init))
@@ -2069,7 +2070,6 @@ def _write_ica(fid, ica):
     write_double_matrix(fid, FIFF.FIFF_MNE_ICA_MATRIX, ica.unmixing_matrix_)
 
     #   Write bad components
-
     write_int(fid, FIFF.FIFF_MNE_ICA_BADS, list(ica.exclude))
 
     # Done!
@@ -2182,6 +2182,8 @@ def read_ica(fname, verbose=None):
             ica.labels_ = labels_
     if 'method' in ica_misc:
         ica.method = ica_misc['method']
+    if 'n_iter_' in ica_misc:
+        ica.n_iter_ = ica_misc['n_iter_']
 
     logger.info('Ready.')
 

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -166,7 +166,7 @@ def test_ica_n_iter_(method):
             ica.fit(raw)
 
     assert_equal(ica.n_iter_, max_iter)
-    
+
     # Test I/O roundtrip.
     tempdir = _TempDir()
     output_fname = op.join(tempdir, 'test_ica-ica.fif')

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -149,6 +149,26 @@ def test_ica_simple(method):
 
 
 @requires_sklearn
+@pytest.mark.parametrize("method", ["infomax", "fastica", "picard"])
+def test_ica_n_iter_(method):
+    """Test that ICA.n_iter_ is set after fitting."""
+    _skip_check_picard(method)
+
+    raw = read_raw_fif(raw_fname).crop(0.5, stop).load_data()
+    n_components = 3
+    max_iter = 1
+    ica = ICA(n_components=n_components, max_iter=max_iter, method=method)
+
+    if method == 'infomax':
+        ica.fit(raw)
+    else:
+        with pytest.warns(UserWarning, match='did not converge'):
+            ica.fit(raw)
+
+    assert ica.n_iter_ == max_iter
+
+
+@requires_sklearn
 @pytest.mark.parametrize("method", ["fastica", "picard"])
 def test_ica_rank_reduction(method):
     """Test recovery ICA rank reduction."""
@@ -195,7 +215,8 @@ def test_ica_reset(method):
         'n_samples_',
         'pca_components_',
         'pca_explained_variance_',
-        'pca_mean_'
+        'pca_mean_',
+        'n_iter_'
     )
     with pytest.warns(UserWarning, match='did not converge'):
         ica = ICA(

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -165,7 +165,17 @@ def test_ica_n_iter_(method):
         with pytest.warns(UserWarning, match='did not converge'):
             ica.fit(raw)
 
-    assert ica.n_iter_ == max_iter
+    assert_equal(ica.n_iter_, max_iter)
+    
+    # Test I/O roundtrip.
+    tempdir = _TempDir()
+    output_fname = op.join(tempdir, 'test_ica-ica.fif')
+    _assert_ica_attributes(ica)
+    ica.save(output_fname)
+    ica = read_ica(output_fname)
+    _assert_ica_attributes(ica)
+
+    assert_equal(ica.n_iter_, max_iter)
 
 
 @requires_sklearn


### PR DESCRIPTION
### What does this implement/fix?
The changes in this PR enable the user to retrieve the number of completed ICA iterations via `ICA.n_iter_` after `ICA.fit()` has been called. <strike>Currently only works with FastICA and Picard (will always be `None` for Infomax)</strike>