### PR TITLE
Add return_n_iter kwarg to infomax()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -117,6 +117,8 @@ Changelog
 
 - Make selected channels more distinguishable in :meth:`mne.Epochs.plot_sensors` when using ``kind='select'`` by `Mikołaj Magnuski`_
 
+- Allow retrieval of the number of Infomax ICA iterations via the new ``return_n_iter`` keyword argument of :func:`mne.preprocessing.infomax` by `Richard Höchenberger`_
+
 Bug
 ~~~
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -672,9 +672,10 @@ class ICA(ContainsMixin):
             ica.fit(data[:, sel])
             self.unmixing_matrix_ = ica.components_
         elif self.method in ('infomax', 'extended-infomax'):
-            self.unmixing_matrix_ = infomax(data[:, sel],
-                                            random_state=random_state,
-                                            **self.fit_params)
+            self.unmixing_matrix_, n_iter = infomax(data[:, sel],
+                                                    random_state=random_state,
+                                                    return_n_iter=True,
+                                                    **self.fit_params)
         elif self.method == 'picard':
             from picard import picard
             _, W, _ = picard(data[:, sel].T, whiten=False,

--- a/mne/preprocessing/infomax_.py
+++ b/mne/preprocessing/infomax_.py
@@ -16,7 +16,7 @@ def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
             anneal_deg=60., anneal_step=0.9, extended=True, n_subgauss=1,
             kurt_size=6000, ext_blocks=1, max_iter=200, random_state=None,
             blowup=1e4, blowup_fac=0.5, n_small_angle=20, use_bias=True,
-            verbose=None):
+            verbose=None, return_n_iter=False):
     """Run (extended) Infomax ICA decomposition on raw data.
 
     Parameters
@@ -80,11 +80,16 @@ def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
         This quantity indicates if the bias should be computed.
         Defaults to True.
     %(verbose)s
+    return_n_iter : bool
+        Whether to return the number of iterations performed. Defaults to
+        False.
 
     Returns
     -------
     unmixing_matrix : np.ndarray, shape (n_features, n_features)
         The linear unmixing operator.
+    n_iter : int
+        The number of iterations. Only returned if ``return_max_iter=True``.
 
     References
     ----------
@@ -305,4 +310,7 @@ def infomax(data, weights=None, l_rate=None, block=None, w_change=1e-12,
                                  'might not be invertible!')
 
     # prepare return values
-    return weights.T
+    if return_n_iter:
+        return weights.T, step
+    else:
+        return weights.T

--- a/mne/preprocessing/tests/test_infomax.py
+++ b/mne/preprocessing/tests/test_infomax.py
@@ -4,6 +4,8 @@
 
 # Parts of this code are taken from scikit-learn
 
+import pytest
+
 import numpy as np
 from numpy.testing import assert_almost_equal
 
@@ -176,6 +178,21 @@ def test_non_square_infomax():
         if not add_noise:
             assert_almost_equal(np.dot(s1_, s1) / n_samples, 1, decimal=2)
             assert_almost_equal(np.dot(s2_, s2) / n_samples, 1, decimal=2)
+
+
+@pytest.mark.parametrize("return_n_iter", [True, False])
+def test_infomax_n_iter(return_n_iter):
+    """Test the return_n_iter kwarg."""
+    X = np.random.random((3, 100))
+    max_iter = 1
+    r = infomax(X, max_iter=max_iter, extended=True,
+                return_n_iter=return_n_iter)
+
+    if return_n_iter:
+        assert isinstance(r, tuple)
+        assert r[1] == max_iter
+    else:
+        assert isinstance(r, np.ndarray)
 
 
 def _get_pca(rng=None):


### PR DESCRIPTION
#### What does this implement/fix?
Add `return_n_iter` kwarg to `infomax()`
Allows retrieval of the number of iterations performed. If `False` (default), only the ICA weights are returned. If `True`, returns a tuple `(weights, n_iter)`.


#### Additional information
Previous behavior of `infomax()` is not altered.