### PR TITLE
Fix Extended Infomax support of run_ica()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -238,6 +238,8 @@ Bug
 
 - Fix bug in reading annotations in :func:`read_annotations`, which would not accept ";" character by `Adam Li`_
 
+- Fix Extended Infomax support of :func:`mne.preprocessing.run_ica` by `Richard Höchenberger`_
+
 API
 ~~~
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -671,7 +671,7 @@ class ICA(ContainsMixin):
                           **self.fit_params)
             ica.fit(data[:, sel])
             self.unmixing_matrix_ = ica.components_
-        elif self.method in ('infomax', 'extended-infomax'):
+        elif self.method == 'infomax':
             self.unmixing_matrix_, n_iter = infomax(data[:, sel],
                                                     random_state=random_state,
                                                     return_n_iter=True,
@@ -2376,10 +2376,16 @@ def run_ica(raw, n_components, max_pca_components=100,
     ica : instance of ICA
         The ICA object with detected artifact sources marked for exclusion.
     """
+    if method == 'extended-infomax':
+        method = 'infomax'
+        fit_params = dict(extended=True)
+    else:
+        fit_params = None
+        
     ica = ICA(n_components=n_components, max_pca_components=max_pca_components,
               n_pca_components=n_pca_components, method=method,
               noise_cov=noise_cov, random_state=random_state, verbose=verbose,
-              allow_ref_meg=allow_ref_meg)
+              allow_ref_meg=allow_ref_meg, fit_params=fit_params)
 
     ica.fit(raw, start=start, stop=stop, picks=picks)
     logger.info('%s' % ica)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -705,7 +705,8 @@ def test_ica_additional(method):
 
 
 @requires_sklearn
-@pytest.mark.parametrize("method", ["fastica", "picard"])
+@pytest.mark.parametrize("method", ["fastica", "picard", "infomax",
+                                    "extended-infomax"])
 def test_run_ica(method):
     """Test run_ica function."""
     _skip_check_picard(method)
@@ -714,9 +715,16 @@ def test_run_ica(method):
     params += [(None, -1, slice(2), [0, 1])]  # varicance, kurtosis idx
     params += [(None, 'MEG 1531')]  # ECG / EOG channel params
     for idx, ch_name in product(*params):
-        run_ica(raw, n_components=2, start=0, stop=0.5, start_find=0,
-                stop_find=5, ecg_ch=ch_name, eog_ch=ch_name, method=method,
-                skew_criterion=idx, var_criterion=idx, kurt_criterion=idx)
+        ica = run_ica(raw, n_components=2, start=0, stop=0.5, start_find=0,
+                      stop_find=5, ecg_ch=ch_name, eog_ch=ch_name,
+                      method=method, skew_criterion=idx, var_criterion=idx,
+                      kurt_criterion=idx)
+
+        if method == 'extended-infomax':
+            assert ica.method == 'infomax'
+            assert ica.fit_params['extended'] is True
+        else:
+            assert ica.method == method
 
 
 @requires_sklearn


### PR DESCRIPTION
#### What does this implement/fix?
Passing `method='extended-infomax'` to `preprocessing.run_ica()` couldn't actually invoke Extended Infomax

#### Additional information
The valid `method` value of `run_ica()` deviate from those of `ICA` in that `'extended-infomax'` is valid in the former, but raises an error in the latter. Not sure if that's still there for backward-compat _or_ bc it was overlooked during some refactoring. What this PR does is that, when `extended-infomax` is requested in `run_pca()`, it would instantiate `ICA` with `method='infomax'` and`fit_params=dict(extended=True)`.

On another side note, when looking through `tests/test_ica.py` I noticed that `infomax` is mentioned nowhere, so it currently pretty much goes untested (aside from the algorithm itself, which _is_ being tested in `tests/infomax.py`).