### PR TITLE
MRG, ENH: Speed up convert_forward_solution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ jobs:
             command: |
                which python
                QT_DEBUG_PLUGINS=1 mne sys_info
+               python -c "import numpy; numpy.show_config()"
                LIBGL_DEBUG=verbose python -c "from mayavi import mlab; import matplotlib.pyplot as plt; mlab.figure(); plt.figure()"
                python -c "import mne; mne.set_config('MNE_USE_CUDA', 'false')"  # this is needed for the config tutorial
                python -c "import mne; mne.set_config('MNE_LOGGING_LEVEL', 'info')"

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ install:
     - python setup.py build
     - python setup.py install
     - mne sys_info
+    - python -c "import numpy; numpy.show_config()"
     - SRC_DIR=$(pwd)
     - cd ~
     # Trigger download of testing data. Note that

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -154,6 +154,8 @@ jobs:
     displayName: 'Install MNE-Python dev'
   - script: mne sys_info
     displayName: 'Print config and test access to commands'
+  - script: python -c "import numpy; numpy.show_config()"
+    displayName: Print NumPy config
   - script: python -c "import mne; mne.datasets.testing.data_path(verbose=True)"
     displayName: 'Get test data'
   - script: pytest -m "not ultraslowtest" --tb=short --cov=mne mne

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -320,7 +320,7 @@ def test_localization_bias_fixed(bias_params_fixed, method, lower, upper,
 
 
 @pytest.mark.parametrize('method, lower, upper, depth', [
-    ('MNE', 32, 35, dict(limit=None, combine_xyz=False, exp=1.)),  # DICS def
+    ('MNE', 32, 36, dict(limit=None, combine_xyz=False, exp=1.)),  # DICS def
     ('MNE', 78, 81, 0.8),  # MNE default
     ('MNE', 89, 92, dict(limit_depth_chs='whiten')),  # sparse default
     ('dSPM', 85, 87, 0.8),

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -19,7 +19,6 @@ from struct import pack
 
 import numpy as np
 from scipy.sparse import coo_matrix, csr_matrix, eye as speye
-from scipy import linalg
 
 from .io.constants import FIFF
 from .io.open import fiff_open

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -328,7 +328,8 @@ def _normal_orth(nn):
     """Compute orthogonal basis given a normal."""
     assert nn.shape[-1:] == (3,)
     prod = np.einsum('...i,...j->...ij', nn, nn)
-    u, _, _ = np.linalg.svd(np.eye(3) - prod, full_matrices=False)
+    _, u = np.linalg.eigh(np.eye(3) - prod)
+    u = u[..., ::-1]
     #  Make sure that ez is in the direction of nn
     signs = np.sign(np.matmul(nn[..., np.newaxis, :], u[..., -1:]))
     signs[signs == 0] = 1

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -326,12 +326,14 @@ def _project_onto_surface(rrs, surf, project_rrs=False, return_nn=False,
 
 def _normal_orth(nn):
     """Compute orthogonal basis given a normal."""
-    assert nn.shape == (3,)
-    u, _, _ = linalg.svd(np.eye(3) - np.outer(nn, nn))
+    assert nn.shape[-1:] == (3,)
+    prod = np.einsum('...i,...j->...ij', nn, nn)
+    u, _, _ = np.linalg.svd(np.eye(3) - prod, full_matrices=False)
     #  Make sure that ez is in the direction of nn
-    if np.dot(nn, u[:, 2]) < 0:
-        u *= -1.0
-    return u.T
+    signs = np.sign(np.matmul(nn[..., np.newaxis, :], u[..., -1:]))
+    signs[signs == 0] = 1
+    u *= signs
+    return u.swapaxes(-1, -2)
 
 
 @verbose


### PR DESCRIPTION
I noticed in https://travis-ci.org/mne-tools/mne-python/jobs/650978029?utm_medium=notification&utm_source=github_status that a lot of time was spent in:
```
115.44s call     mne/inverse_sparse/tests/test_mxne_inverse.py::test_mxne_inverse_standard
```
Profiling suggests that about half the time was spent in `convert_forward_solution`, and a lot of that was in `_normal_orth`, so this might be a speed regression due to #7290.

In any case, this PR takes that test from 23 sec to 14 sec on my system. Timings for `mne/tests/test_chpi.py` don't change, so the n-dim generalization that this makes use of seems to be not so painful for the single vector case.