### PR TITLE
BF: Write ICA.fit_params to disk on ICA.save()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -246,6 +246,8 @@ Bug
 
 - Fix bug in reading annotations in :func:`read_annotations`, which would not accept ";" character by `Adam Li`_
 
+- Include ``fit_params`` when saving an :class:`~mne.preprocessing.ICA` instance to disk by `Richard Höchenberger`_
+
 API
 ~~~
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2045,10 +2045,7 @@ def _write_ica(fid, ica):
                 'method': getattr(ica, 'method', None),
                 'n_iter_': getattr(ica, 'n_iter_', None)}
 
-    write_string(fid, FIFF.FIFF_MNE_ICA_INTERFACE_PARAMS,
-                 _serialize(ica_init))
-
-    #   ICA misct params
+    #   ICA misc params
     write_string(fid, FIFF.FIFF_MNE_ICA_MISC_PARAMS,
                  _serialize(ica_misc))
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2043,7 +2043,8 @@ def _write_ica(fid, ica):
     ica_misc = {'n_samples_': (None if n_samples is None else int(n_samples)),
                 'labels_': getattr(ica, 'labels_', None),
                 'method': getattr(ica, 'method', None),
-                'n_iter_': getattr(ica, 'n_iter_', None)}
+                'n_iter_': getattr(ica, 'n_iter_', None),
+                'fit_params': getattr(ica, 'fit_params', None)}
 
     #   ICA misc params
     write_string(fid, FIFF.FIFF_MNE_ICA_MISC_PARAMS,
@@ -2181,6 +2182,8 @@ def read_ica(fname, verbose=None):
         ica.method = ica_misc['method']
     if 'n_iter_' in ica_misc:
         ica.n_iter_ = ica_misc['n_iter_']
+    if 'fit_params' in ica_misc:
+        ica.fit_params = ica_misc['fit_params']
 
     logger.info('Ready.')
 


### PR DESCRIPTION
#### What does this implement/fix?
- Fixes: `ICA.fit_params` used not to be written to disk on `ICA.save()`
- Optimizes: `ica_init` used to be written to disk twice