### PR TITLE
WIP: Disable depth peeling with rcparams

### DIFF
--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -632,9 +632,9 @@ def _testing_context(interactive):
 @contextmanager
 def _disabled_depth_peeling():
     from pyvista import rcParams
-    old_params = rcParams
+    depth_peeling_enabled = rcParams["depth_peeling"]["enabled"]
     rcParams["depth_peeling"]["enabled"] = False
     try:
         yield
     finally:
-        rcParams = old_params
+        rcParams["depth_peeling"]["enabled"] = depth_peeling_enabled

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -25,11 +25,13 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import pyvista
     from pyvista import (Plotter, BackgroundPlotter, PolyData,
-                         Line, close_all, UnstructuredGrid)
+                         Line, close_all, UnstructuredGrid,
+                         rcParams)
     from pyvista.utilities import try_callback
 
 
 _FIGURES = dict()
+rcParams["depth_peeling"]["enabled"] = False
 
 
 class _Figure(object):
@@ -143,13 +145,11 @@ class _Renderer(_BaseRenderer):
 
             self.plotter = self.figure.build()
             self.plotter.hide_axes()
-            self.plotter.disable_depth_peeling()
 
     def subplot(self, x, y):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)
             self.plotter.subplot(x, y)
-            self.plotter.disable_depth_peeling()
 
     def scene(self):
         return self.figure

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -25,13 +25,11 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import pyvista
     from pyvista import (Plotter, BackgroundPlotter, PolyData,
-                         Line, close_all, UnstructuredGrid,
-                         rcParams)
+                         Line, close_all, UnstructuredGrid)
     from pyvista.utilities import try_callback
 
 
 _FIGURES = dict()
-rcParams["depth_peeling"]["enabled"] = False
 
 
 class _Figure(object):
@@ -142,8 +140,8 @@ class _Renderer(_BaseRenderer):
             warnings.filterwarnings("ignore", category=FutureWarning)
             if MNE_3D_BACKEND_TESTING:
                 self.figure.plotter_class = Plotter
-
-            self.plotter = self.figure.build()
+            with _disabled_depth_peeling():
+                self.plotter = self.figure.build()
             self.plotter.hide_axes()
 
     def subplot(self, x, y):
@@ -629,3 +627,14 @@ def _testing_context(interactive):
     finally:
         pyvista.OFF_SCREEN = orig_offscreen
         renderer.MNE_3D_BACKEND_TESTING = orig_testing
+
+
+@contextmanager
+def _disabled_depth_peeling():
+    from pyvista import rcParams
+    old_params = rcParams
+    rcParams["depth_peeling"]["enabled"] = False
+    try:
+        yield
+    finally:
+        rcParams = old_params


### PR DESCRIPTION
This PR is a follow-up of https://github.com/mne-tools/mne-python/pull/7330#issuecomment-587441394 and disables completely depth peeling in the pyvista 3d backend without doing any window testing.