### PR TITLE
Deprecate run_ica()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -288,3 +288,5 @@ API
 - In :class:`~mne.preprocessing.Xdawn`, the components are stored in the rows of attributes ``filters_`` and ``patterns_`` to be consistent with :class:`~mne.decoding.CSP` and :class:`~mne.preprocessing.ICA` by `Henrich Kolkhorst`_
 
 - Drop ``unit`` keyword argument from :func:`mne.channels.read_custom_montage`, as it was unused by `Richard Höchenberger`_
+
+- Deprecate :func:`mne.preprocessing.run_ica`, use :meth:`mne.preprocessing.ICA.detect_artifacts` instead by `Richard Höchenberger`_

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -51,7 +51,7 @@ from ..utils import (check_version, logger, check_fname, verbose,
                      compute_corr, _get_inst_data, _ensure_int,
                      copy_function_doc_to_method_doc, _pl, warn, Bunch,
                      _check_preload, _check_compensation_grade, fill_doc,
-                     _check_option, _PCA)
+                     _check_option, _PCA, deprecated)
 from ..utils.check import _check_all_same_channel_names
 
 from ..fixes import _get_args, _safe_svd
@@ -2255,6 +2255,8 @@ def _detect_artifacts(ica, raw, start_find, stop_find, ecg_ch, ecg_score_func,
     logger.info('Ready.')
 
 
+@deprecated('run_ica() is deprecated and will be removed in 0.21, use '
+            'ICA.detect_artifacts() instead')
 @verbose
 def run_ica(raw, n_components, max_pca_components=100,
             n_pca_components=64, noise_cov=None,

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -737,7 +737,7 @@ def test_ica_additional(method):
 
 @requires_sklearn
 @pytest.mark.parametrize("method", ("fastica", "picard", "infomax"))
-# varicance, kurtosis idx
+# variance, kurtosis idx
 @pytest.mark.parametrize("idx", (None, -1, slice(2), [0, 1]))
 # ECG / EOG channel params
 @pytest.mark.parametrize("ch_name", (None, 'MEG 1531'))

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -736,15 +736,16 @@ def test_ica_additional(method):
 
 
 @requires_sklearn
-@pytest.mark.parametrize("method", ["fastica", "picard"])
-def test_run_ica(method):
+@pytest.mark.parametrize("method", ("fastica", "picard", "infomax"))
+# varicance, kurtosis idx
+@pytest.mark.parametrize("idx", (None, -1, slice(2), [0, 1]))
+# ECG / EOG channel params
+@pytest.mark.parametrize("ch_name", (None, 'MEG 1531'))
+def test_run_ica(method, idx, ch_name):
     """Test run_ica function."""
     _skip_check_picard(method)
     raw = read_raw_fif(raw_fname).crop(1.5, stop).load_data()
-    params = []
-    params += [(None, -1, slice(2), [0, 1])]  # varicance, kurtosis idx
-    params += [(None, 'MEG 1531')]  # ECG / EOG channel params
-    for idx, ch_name in product(*params):
+    with pytest.warns(DeprecationWarning, match='run_ica() is deprecated'):
         run_ica(raw, n_components=2, start=0, stop=0.5, start_find=0,
                 stop_find=5, ecg_ch=ch_name, eog_ch=ch_name, method=method,
                 skew_criterion=idx, var_criterion=idx, kurt_criterion=idx)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -737,14 +737,26 @@ def test_ica_additional(method):
 
 @requires_sklearn
 @pytest.mark.parametrize("method", ("fastica", "picard", "infomax"))
-# variance, kurtosis idx
 @pytest.mark.parametrize("idx", (None, -1, slice(2), [0, 1]))
-# ECG / EOG channel params
 @pytest.mark.parametrize("ch_name", (None, 'MEG 1531'))
-def test_run_ica(method, idx, ch_name):
+def test_detect_artifacts_replacement_of_run_ica(method, idx, ch_name):
     """Test run_ica function."""
     _skip_check_picard(method)
     raw = read_raw_fif(raw_fname).crop(1.5, stop).load_data()
+    ica = ICA(n_components=2, method=method)
+    ica.fit(raw)
+    ica.detect_artifacts(raw, start_find=0, stop_find=5, ecg_ch=ch_name,
+                         eog_ch=ch_name, skew_criterion=idx,
+                         var_criterion=idx, kurt_criterion=idx)
+
+
+@requires_sklearn
+def test_run_ica_deprecation():
+    """Test that run_ica() has been deprecated."""
+    raw = read_raw_fif(raw_fname).crop(1.5, stop).load_data()
+    method = 'fastica'
+    idx = None
+    ch_name = None
     with pytest.warns(DeprecationWarning, match='run_ica() is deprecated'):
         run_ica(raw, n_components=2, start=0, stop=0.5, start_find=0,
                 stop_find=5, ecg_ch=ch_name, eog_ch=ch_name, method=method,

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -740,7 +740,7 @@ def test_ica_additional(method):
 @pytest.mark.parametrize("idx", (None, -1, slice(2), [0, 1]))
 @pytest.mark.parametrize("ch_name", (None, 'MEG 1531'))
 def test_detect_artifacts_replacement_of_run_ica(method, idx, ch_name):
-    """Test run_ica function."""
+    """Test replacement workflow for deprecated run_ica() function."""
     _skip_check_picard(method)
     raw = read_raw_fif(raw_fname).crop(1.5, stop).load_data()
     ica = ICA(n_components=2, method=method)


### PR DESCRIPTION
#### What does this implement/fix?
<strike>Removes the `mne.preprocessing.ica.run_ica()` function. All it does it instantiate an `ICA` object and then run an artifact detection. However, the same can be achieved by using `ICA.detect_artifacts()`.</strike>
Deprecates `mne.preprocessing.ica.run_ica()` in favor of `ICA.detect_artifacts()`