### PR TITLE
MRG, ENH: Always show event counts

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -73,6 +73,8 @@ Changelog
 
 - Add reader for ``*.dat`` electrode position files :func:`mne.channels.read_dig_dat` by `Christian Brodbeck`_
 
+- Improved :func:`mne.viz.plot_events` to always show event counts by `Eric Larson`_
+
 - Improved :ref:`limo-dataset` usage and :ref:`example <ex-limo-data>` for usage of :func:`mne.stats.linear_regression` by `Jose Alanis`_
 
 - Add support for ``reduce_rank=True`` for vector beamformers by `Eric Larson`_

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -599,7 +599,7 @@ def plot_events(events, sfreq=None, first_samp=0, color=None, event_id=None,
     max_x = (events[np.in1d(events[:, 2], unique_events_id), 0].max() -
              first_samp) / sfreq
 
-    hs, labels = list(), list()
+    handles, labels = list(), list()
     for idx, ev in enumerate(unique_events_id):
         ev_mask = events[:, 2] == ev
         count = ev_mask.sum()
@@ -614,7 +614,7 @@ def plot_events(events, sfreq=None, first_samp=0, color=None, event_id=None,
         kwargs = {}
         if ev in color:
             kwargs['color'] = color[ev]
-        hs.append(
+        handles.append(
             ax.plot((events[ev_mask, 0] - first_samp) / sfreq,
                     y, '.', clip_on=False, **kwargs)[0])
 
@@ -632,11 +632,11 @@ def plot_events(events, sfreq=None, first_samp=0, color=None, event_id=None,
     fig = fig if fig is not None else plt.gcf()
     # reverse order so that the highest numbers are at the top
     # (match plot order)
-    hs, labels = hs[::-1], labels[::-1]
+    handles, labels = handles[::-1], labels[::-1]
     box = ax.get_position()
     factor = 0.8 if event_id is not None else 0.9
     ax.set_position([box.x0, box.y0, box.width * factor, box.height])
-    ax.legend(hs, labels, loc='center left', bbox_to_anchor=(1, 0.5),
+    ax.legend(handles, labels, loc='center left', bbox_to_anchor=(1, 0.5),
               fontsize='small')
     fig.canvas.draw()
     plt_show(show)

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -616,7 +616,7 @@ def plot_events(events, sfreq=None, first_samp=0, color=None, event_id=None,
             kwargs['color'] = color[ev]
         hs.append(
             ax.plot((events[ev_mask, 0] - first_samp) / sfreq,
-                    y, '.', **kwargs)[0])
+                    y, '.', clip_on=False, **kwargs)[0])
 
     if equal_spacing:
         ax.set_ylim(0, unique_events_id.size + 1)

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -596,21 +596,27 @@ def plot_events(events, sfreq=None, first_samp=0, color=None, event_id=None,
     unique_events_id = np.array(unique_events_id)
     min_event = np.min(unique_events_id)
     max_event = np.max(unique_events_id)
+    max_x = (events[np.in1d(events[:, 2], unique_events_id), 0].max() -
+             first_samp) / sfreq
 
+    hs, labels = list(), list()
     for idx, ev in enumerate(unique_events_id):
         ev_mask = events[:, 2] == ev
-        kwargs = {}
+        count = ev_mask.sum()
+        if count == 0:
+            continue
+        y = np.full(count, idx + 1 if equal_spacing else events[ev_mask, 2][0])
         if event_id is not None:
-            event_label = '{} ({})'.format(event_id_rev[ev], np.sum(ev_mask))
-            kwargs['label'] = event_label
+            event_label = '%s (%s)' % (event_id_rev[ev], count)
+        else:
+            event_label = 'N=%d' % (count,)
+        labels.append(event_label)
+        kwargs = {}
         if ev in color:
             kwargs['color'] = color[ev]
-        if equal_spacing:
+        hs.append(
             ax.plot((events[ev_mask, 0] - first_samp) / sfreq,
-                    (idx + 1) * np.ones(ev_mask.sum()), '.', **kwargs)
-        else:
-            ax.plot((events[ev_mask, 0] - first_samp) / sfreq,
-                    events[ev_mask, 2], '.', **kwargs)
+                    y, '.', **kwargs)[0])
 
     if equal_spacing:
         ax.set_ylim(0, unique_events_id.size + 1)
@@ -619,16 +625,19 @@ def plot_events(events, sfreq=None, first_samp=0, color=None, event_id=None,
     else:
         ax.set_ylim([min_event - 1, max_event + 1])
 
-    ax.set(xlabel=xlabel, ylabel='Events id')
+    ax.set(xlabel=xlabel, ylabel='Events id', xlim=[0, max_x])
 
     ax.grid(True)
 
     fig = fig if fig is not None else plt.gcf()
-    if event_id is not None:
-        box = ax.get_position()
-        ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
-        ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
-        fig.canvas.draw()
+    hs = hs[::-1]
+
+    box = ax.get_position()
+    factor = 0.8 if event_id is not None else 0.9
+    ax.set_position([box.x0, box.y0, box.width * factor, box.height])
+    ax.legend(hs, labels, loc='center left', bbox_to_anchor=(1, 0.5),
+              fontsize='small')
+    fig.canvas.draw()
     plt_show(show)
     return fig
 

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -630,8 +630,9 @@ def plot_events(events, sfreq=None, first_samp=0, color=None, event_id=None,
     ax.grid(True)
 
     fig = fig if fig is not None else plt.gcf()
-    hs = hs[::-1]
-
+    # reverse order so that the highest numbers are at the top
+    # (match plot order)
+    hs, labels = hs[::-1], labels[::-1]
     box = ax.get_position()
     factor = 0.8 if event_id is not None else 0.9
     ax.set_position([box.x0, box.y0, box.width * factor, box.height])

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -124,13 +124,15 @@ def test_plot_events():
     color = {1: 'green', 2: 'yellow', 3: 'red', 4: 'c'}
     raw = _get_raw()
     events = _get_events()
-    plot_events(events, raw.info['sfreq'], raw.first_samp)
+    fig = plot_events(events, raw.info['sfreq'], raw.first_samp)
+    assert fig.axes[0].get_legend() is not None  # legend even with no event_id
     plot_events(events, raw.info['sfreq'], raw.first_samp, equal_spacing=False)
     # Test plotting events without sfreq
     plot_events(events, first_samp=raw.first_samp)
     with pytest.warns(RuntimeWarning, match='will be ignored'):
-        plot_events(events, raw.info['sfreq'], raw.first_samp,
-                    event_id=event_labels)
+        fig = plot_events(events, raw.info['sfreq'], raw.first_samp,
+                          event_id=event_labels)
+    assert fig.axes[0].get_legend() is not None
     with pytest.warns(RuntimeWarning, match='Color was not assigned'):
         plot_events(events, raw.info['sfreq'], raw.first_samp,
                     color=color)

--- a/tutorials/intro/plot_10_overview.py
+++ b/tutorials/intro/plot_10_overview.py
@@ -190,8 +190,8 @@ event_dict = {'auditory/left': 1, 'auditory/right': 2, 'visual/left': 3,
 # attribute to get the sampling frequency of the recording (so our x-axis will
 # be in seconds instead of in samples).
 
-fig = mne.viz.plot_events(events, event_id=event_dict, sfreq=raw.info['sfreq'])
-fig.subplots_adjust(right=0.7)  # make room for the legend
+fig = mne.viz.plot_events(events, event_id=event_dict, sfreq=raw.info['sfreq'],
+                          first_samp=raw.first_samp)
 
 ###############################################################################
 # For paradigms that are not event-related (e.g., analysis of resting-state


### PR DESCRIPTION
On `master` when you provide `event_id` to `plot_events` you get:

![Screenshot from 2020-02-19 11-41-40](https://user-images.githubusercontent.com/2365790/74854111-dd8deb80-530c-11ea-8ae6-2f18df19320f.png)

But then if you omit `event_id` you lose event count information:

![Screenshot from 2020-02-19 11-40-50](https://user-images.githubusercontent.com/2365790/74854129-e67ebd00-530c-11ea-81ff-edb32f0cf52a.png)

This PR makes it so that this information is restored:

![Screenshot from 2020-02-19 11-40-18](https://user-images.githubusercontent.com/2365790/74854148-eda5cb00-530c-11ea-9140-596d59196ddc.png)

The other option (instead of having a legend) would be to just print the counts to the right of each row, but this seems more consistent with the `event_id` case (we'd probably want to change that to also have the counts to the right, then why have the legend at all, etc.).

This PR also fixes the ordering of the legend to match the top-to-bottom ordering of the actual events themselves.