### PR TITLE
WIP: Use all channels in fnirs conversion. Don't exclude bads

### DIFF
--- a/mne/preprocessing/nirs/__init__.py
+++ b/mne/preprocessing/nirs/__init__.py
@@ -6,7 +6,8 @@
 #
 # License: BSD (3-clause)
 
-from .nirs import short_channels, source_detector_distances, _check_channels_ordered, _channel_frequencies
+from .nirs import short_channels, source_detector_distances, _check_channels_ordered,\
+    _channel_frequencies, _fnirs_check_bads, _fnirs_spread_bads
 from ._optical_density import optical_density
 from ._beer_lambert_law import beer_lambert_law
 from ._scalp_coupling_index import scalp_coupling_index

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -58,7 +58,7 @@ def short_channels(info, threshold=0.01):
 
 def _channel_frequencies(raw):
     """Return the light frequency for each channel."""
-    picks = _picks_to_idx(raw.info, 'fnirs_od', exclude=[])
+    picks = _picks_to_idx(raw.info, 'fnirs', exclude=[])
     freqs = np.empty(picks.size, int)
     for ii in picks:
         freqs[ii] = raw.info['chs'][ii]['loc'][9]
@@ -69,7 +69,7 @@ def _check_channels_ordered(raw, freqs):
     """Check channels followed expected fNIRS format."""
     # Every second channel should be same SD pair
     # and have the specified light frequencies.
-    picks = _picks_to_idx(raw.info, 'fnirs_od', exclude=[])
+    picks = _picks_to_idx(raw.info, 'fnirs', exclude=[])
     for ii in picks[::2]:
         ch1_name_info = re.match(r'S(\d+)_D(\d+) (\d+)',
                                  raw.info['chs'][ii]['ch_name'])
@@ -83,3 +83,31 @@ def _check_channels_ordered(raw, freqs):
             raise RuntimeError('NIRS channels not ordered correctly')
 
     return picks
+
+
+def _fnirs_check_bads(raw):
+    """Check consistent labeling of bads across fnirs optodes."""
+    # For an optode pair, if one component (light frequency or chroma) is
+    # marked as bad then they all should be. This function checks that all
+    # optodes are marked bad consistently.
+    picks = _picks_to_idx(raw.info, 'fnirs', exclude=[])
+    for ii in picks[::2]:
+        bad_opto = set(raw.info['bads']).intersection(raw.ch_names[ii:ii + 2])
+        if len(bad_opto) == 1:
+            raise RuntimeError('NIRS bad labelling is not consistent')
+
+
+def _fnirs_spread_bads(raw):
+    """Spread bad labeling across fnirs channels."""
+    # For an optode if any component (light frequency or chroma) is marked
+    # as bad, then they all should be. This function will find any pairs marked
+    # as bad and spread the bad marking to all components of the optode pair.
+    picks = _picks_to_idx(raw.info, 'fnirs', exclude=[])
+    new_bads = list()
+    for ii in picks[::2]:
+        bad_opto = set(raw.info['bads']).intersection(raw.ch_names[ii:ii + 2])
+        if len(bad_opto) > 0:
+            new_bads.extend(raw.ch_names[ii:ii + 2])
+    raw.info['bads'] = new_bads
+
+    return raw

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -30,7 +30,7 @@ def source_detector_distances(info, picks=None):
     """
     dist = [linalg.norm(ch['loc'][3:6] - ch['loc'][6:9])
             for ch in info['chs']]
-    picks = _picks_to_idx(info, picks)
+    picks = _picks_to_idx(info, picks, exclude=[])
     return np.array(dist, float)[picks]
 
 
@@ -58,7 +58,7 @@ def short_channels(info, threshold=0.01):
 
 def _channel_frequencies(raw):
     """Return the light frequency for each channel."""
-    picks = _picks_to_idx(raw.info, 'fnirs_od')
+    picks = _picks_to_idx(raw.info, 'fnirs_od', exclude=[])
     freqs = np.empty(picks.size, int)
     for ii in picks:
         freqs[ii] = raw.info['chs'][ii]['loc'][9]
@@ -69,7 +69,7 @@ def _check_channels_ordered(raw, freqs):
     """Check channels followed expected fNIRS format."""
     # Every second channel should be same SD pair
     # and have the specified light frequencies.
-    picks = _picks_to_idx(raw.info, 'fnirs_od')
+    picks = _picks_to_idx(raw.info, 'fnirs_od', exclude=[])
     for ii in picks[::2]:
         ch1_name_info = re.match(r'S(\d+)_D(\d+) (\d+)',
                                  raw.info['chs'][ii]['ch_name'])

--- a/mne/preprocessing/tests/test_nirs.py
+++ b/mne/preprocessing/tests/test_nirs.py
@@ -1,0 +1,81 @@
+# Authors: Robert Luke <mail@robertluke.net>
+#          Eric Larson <larson.eric.d@gmail.com>
+#          Alexandre Gramfort <alexandre.gramfort@inria.fr>
+#
+# License: BSD (3-clause)
+
+import os.path as op
+
+import pytest
+
+from mne.datasets.testing import data_path
+from mne.io import read_raw_nirx
+from mne.preprocessing.nirs import optical_density, beer_lambert_law,\
+    _fnirs_check_bads, _fnirs_spread_bads
+
+from mne.datasets import testing
+
+fname_nirx_15_0 = op.join(data_path(download=False),
+                          'NIRx', 'nirx_15_0_recording')
+fname_nirx_15_2 = op.join(data_path(download=False),
+                          'NIRx', 'nirx_15_2_recording')
+fname_nirx_15_2_short = op.join(data_path(download=False),
+                                'NIRx', 'nirx_15_2_recording_w_short')
+
+
+@testing.requires_testing_data
+@pytest.mark.parametrize('fname', ([fname_nirx_15_2_short, fname_nirx_15_2,
+                                    fname_nirx_15_0]))
+def test_fnirs_check_bads(fname):
+    """Test checking of bad markings."""
+    # No bad channels, so these should all pass
+    raw = read_raw_nirx(fname)
+    _fnirs_check_bads(raw)
+    raw = optical_density(raw)
+    _fnirs_check_bads(raw)
+    raw = beer_lambert_law(raw)
+    _fnirs_check_bads(raw)
+
+    # Mark pairs of bad channels, so these should all pass
+    raw = read_raw_nirx(fname)
+    raw.info['bads'] = raw.ch_names[0:2]
+    _fnirs_check_bads(raw)
+    raw = optical_density(raw)
+    _fnirs_check_bads(raw)
+    raw = beer_lambert_law(raw)
+    _fnirs_check_bads(raw)
+
+    # Mark single channel as bad, so these should all fail
+    raw = read_raw_nirx(fname)
+    raw.info['bads'] = raw.ch_names[0:1]
+    pytest.raises(RuntimeError, _fnirs_check_bads, raw)
+    raw = optical_density(raw)
+    pytest.raises(RuntimeError, _fnirs_check_bads, raw)
+    raw = beer_lambert_law(raw)
+    pytest.raises(RuntimeError, _fnirs_check_bads, raw)
+
+
+@testing.requires_testing_data
+@pytest.mark.parametrize('fname', ([fname_nirx_15_2_short, fname_nirx_15_2,
+                                    fname_nirx_15_0]))
+def test_fnirs_spread_bads(fname):
+    """Test checking of bad markings."""
+    # Test spreading upwards in frequency and on raw data
+    raw = read_raw_nirx(fname)
+    raw.info['bads'] = ['S1_D1 760']
+    raw = _fnirs_spread_bads(raw)
+    assert raw.info['bads'] == ['S1_D1 760', 'S1_D1 850']
+
+    # Test spreading downwards in frequency and on od data
+    raw = optical_density(raw)
+    raw.info['bads'] = raw.ch_names[5:6]
+    raw = _fnirs_spread_bads(raw)
+    assert raw.info['bads'] == raw.ch_names[4:6]
+
+    # Test spreading multiple bads and on chroma data
+    raw = beer_lambert_law(raw)
+    raw.info['bads'] = [raw.ch_names[x] for x in [1, 8]]
+    print(raw.info['bads'])
+    raw = _fnirs_spread_bads(raw)
+    print(raw.info['bads'])
+    assert raw.info['bads'] == [raw.ch_names[x] for x in [0, 1, 8, 9]]


### PR DESCRIPTION
#### What does this implement/fix?
FNIRS channels that had been marked as bad were not being converted. I think all channels should be converted to the final hbo/hbr, then the downstream processing can choose what to do with bad channels.

Adds two internal function for checking that nirs channel labelling of bads is consistent. And nother function that spreads bad marking to ensure it is consistent.