### PR TITLE
MRG, BUG: _Renderer not found

### DIFF
--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -242,5 +242,5 @@ def create_3d_figure(size, bgcolor=(0, 0, 0), handle=None):
     figure : object
         The requested empty scene.
     """
-    renderer = _get_renderer(fig=handle, size=size, bgcolor=bgcolor)  # noqa: F821
+    renderer = _get_renderer(fig=handle, size=size, bgcolor=bgcolor)
     return renderer.scene()

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -242,5 +242,5 @@ def create_3d_figure(size, bgcolor=(0, 0, 0), handle=None):
     figure : object
         The requested empty scene.
     """
-    renderer = _Renderer(fig=handle, size=size, bgcolor=bgcolor)  # noqa: F821
+    renderer = _get_renderer(fig=handle, size=size, bgcolor=bgcolor)  # noqa: F821
     return renderer.scene()

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -39,7 +39,7 @@ from mne.viz.utils import _fake_click
 from mne.utils import (requires_mayavi, requires_pysurfer, run_tests_if_main,
                        requires_nibabel, check_version, requires_dipy,
                        traits_test, requires_version, catch_logging,
-                       run_subprocess)
+                       run_subprocess, modified_env)
 from mne.datasets import testing
 from mne.source_space import read_source_spaces
 from mne.bem import read_bem_solution, read_bem_surfaces
@@ -772,9 +772,13 @@ def test_link_brains(renderer_interactive):
 
 def test_renderer(renderer):
     """Test that renderers are available on demand."""
+    backend = renderer.get_3d_backend()
     cmd = [sys.executable, '-uc',
-           'import mne; mne.viz.create_3d_figure((800, 600))']
-    run_subprocess(cmd)
+            'import mne; mne.viz.create_3d_figure((800, 600)); '
+            'backend = mne.viz.get_3d_backend(); '
+            'assert backend == %r, backend' % (backend,)]
+    with modified_env(MNE_3D_BACKEND=backend):
+        run_subprocess(cmd)
 
 
 run_tests_if_main()

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -770,7 +770,7 @@ def test_link_brains(renderer_interactive):
     link_brains(brain)
 
 
-def test_renderer():
+def test_renderer(renderer):
     """Test that renderers are available on demand."""
     cmd = [sys.executable, '-uc',
            'import mne; mne.viz.create_3d_figure((800, 600))']

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -774,9 +774,9 @@ def test_renderer(renderer):
     """Test that renderers are available on demand."""
     backend = renderer.get_3d_backend()
     cmd = [sys.executable, '-uc',
-            'import mne; mne.viz.create_3d_figure((800, 600)); '
-            'backend = mne.viz.get_3d_backend(); '
-            'assert backend == %r, backend' % (backend,)]
+           'import mne; mne.viz.create_3d_figure((800, 600)); '
+           'backend = mne.viz.get_3d_backend(); '
+           'assert backend == %r, backend' % (backend,)]
     with modified_env(MNE_3D_BACKEND=backend):
         run_subprocess(cmd)
 

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -10,6 +10,7 @@
 import gc
 import os.path as op
 from pathlib import Path
+import sys
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
@@ -37,7 +38,8 @@ from mne.viz._3d import _process_clim, _linearize_map, _get_map_ticks
 from mne.viz.utils import _fake_click
 from mne.utils import (requires_mayavi, requires_pysurfer, run_tests_if_main,
                        requires_nibabel, check_version, requires_dipy,
-                       traits_test, requires_version, catch_logging)
+                       traits_test, requires_version, catch_logging,
+                       run_subprocess)
 from mne.datasets import testing
 from mne.source_space import read_source_spaces
 from mne.bem import read_bem_solution, read_bem_surfaces
@@ -766,6 +768,13 @@ def test_link_brains(renderer_interactive):
         clim='auto'
     )
     link_brains(brain)
+
+
+def test_renderer():
+    """Test that renderers are available on demand."""
+    cmd = [sys.executable, '-uc',
+           'import mne; mne.viz.create_3d_figure((800, 600))']
+    run_subprocess(cmd)
 
 
 run_tests_if_main()


### PR DESCRIPTION
Okay I remember why I went with `_get_renderer` (which was removed in #7292). @GuillaumeFavelier this code snippet:
```
import mne
mne.viz.create_3d_figure((800, 600))
```
gives:
```
Traceback (most recent call last):
  File "/Users/larsoner/Desktop/bug.py", line 2, in <module>
    mne.viz.create_3d_figure((800, 600))
  File "/Users/larsoner/python/mne-python/mne/viz/backends/renderer.py", line 245, in create_3d_figure
    renderer = _Renderer(fig=handle, size=size, bgcolor=bgcolor)  # noqa: F821
NameError: name '_Renderer' is not defined
```
We don't hit this in tests (and CircleCI) probably because by the time we call a `create_3d_figure` we have already done a `stc.plot` or something else that would have loaded a backend (or tried to load the given backend in a `pytest` way).

The simplest fix is probably to restore `_get_renderer`, but I leave it up to you to figure out @GuillaumeFavelier. In the meantime I've added a test to replicate the problem. Feel free to push directly to my branch to fix.