### PR TITLE
Remove Tools menu in _TimeViewer

### DIFF
--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -473,6 +473,15 @@ class _TimeViewer(object):
             self._mouse_no_mvt = -1
             self.enable_point_picking()
 
+        # remove default picking menu
+        main_menu = self.plotter.main_menu
+        to_remove = list()
+        for action in main_menu.actions():
+            if action.text() == "Tools":
+                to_remove.append(action)
+        for action in to_remove:
+            main_menu.removeAction(action)
+
         # setup key bindings
         self.key_bindings = {
             '?': self.help,


### PR DESCRIPTION
This PR removes the `Tools` menu in the `_TimeViewer` interface as suggested in https://github.com/mne-tools/mne-python/pull/7247#issuecomment-589599734

The removed menu presented options for default picking in PyVista which are not compatible with https://github.com/mne-tools/mne-python/pull/7247 and can be misleading (https://github.com/mne-tools/mne-python/pull/7247#issuecomment-588279423 and https://github.com/mne-tools/mne-python/pull/7247#issuecomment-587833079)

It's an item of #7162