### PR TITLE
DOC: tweaks to colormap documentation

### DIFF
--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -163,7 +163,7 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
         Color to use for lines around nodes. See matplotlib.colors.
     linewidth : float
         Line width to use for connections.
-    colormap : str
+    colormap : str | instance of matplotlib.colors.LinearSegmentedColormap
         Colormap to use for coloring the connections.
     vmin : float | None
         Minimum value for colormap. If None, it is determined automatically.

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -203,7 +203,8 @@ def mne_analyze_colormap(limits=[5, 10, 15], format='mayavi'):
     Returns
     -------
     cmap : instance of colormap | array
-        A teal->blue->gray->red->yellow colormap.
+        A teal->blue->gray->red->yellow colormap. See docstring of the 'format'
+        argument for further details.
 
     Notes
     -----


### PR DESCRIPTION
Just some minor tweaks to the documentation based on feedback I got here from colleagues.

It seems there is a bit of inconsistency as to what kind of colormap arguments some functions accept. Might be worthwhile for someone to follow up on this and make sure colormap takes both `str` and `colors.LinearSegmentedColormap` everywhere. In this function, it just seems to be a documentation issue though