### PR TITLE
MRG, BUG: Cleaner error messages about stat_fun

### DIFF
--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -17,7 +17,7 @@ from .parametric import f_oneway, ttest_1samp_no_p
 from ..parallel import parallel_func, check_n_jobs
 from ..fixes import jit, has_numba
 from ..utils import (split_list, logger, verbose, ProgressBar, warn, _pl,
-                     check_random_state, _check_option)
+                     check_random_state, _check_option, _validate_type)
 from ..source_estimate import SourceEstimate
 
 
@@ -847,6 +847,7 @@ def _permutation_cluster_test(X, threshold, n_permutations, tail, stat_fun,
     # Step 1: Calculate t-stat for original data
     # -------------------------------------------------------------
     t_obs = stat_fun(*X)
+    _validate_type(t_obs, np.ndarray, 'return value of stat_fun')
     logger.info('stat_fun(H1): min=%f max=%f' % (np.min(t_obs), np.max(t_obs)))
 
     # test if stat_fun treats variables independently
@@ -862,6 +863,10 @@ def _permutation_cluster_test(X, threshold, n_permutations, tail, stat_fun,
             buffer_size = None
 
     # The stat should have the same shape as the samples for no conn.
+    if t_obs.size != np.prod(sample_shape):
+        raise ValueError('t_obs.shape %s provided by stat_fun %s is not '
+                         'compatible with the sample shape %s'
+                         % (t_obs.shape, stat_fun, sample_shape))
     if connectivity is None or connectivity is False:
         t_obs.shape = sample_shape
 


### PR DESCRIPTION
Cleans up some error messages related to `stat_fun`. IIRC someone had a problem with this on the mailing list, and at some point I forgot to put a `return val` in my custom `stat_fun` and got a weird error about `None`.

No need for `latest.inc` update because this just makes error messages better.