### PR TITLE
MRG, FIX: Fix fetching bugs

### DIFF
--- a/mne/utils/tests/test_fetching.py
+++ b/mne/utils/tests/test_fetching.py
@@ -3,7 +3,8 @@ import os.path as op
 
 import pytest
 
-from mne.utils import _fetch_file, requires_good_network, catch_logging
+from mne.utils import (_fetch_file, requires_good_network, catch_logging,
+                       sizeof_fmt)
 
 
 @pytest.mark.timeout(60)
@@ -16,9 +17,9 @@ def test_fetch_file(url, tmpdir):
     tempdir = str(tmpdir)
     archive_name = op.join(tempdir, "download_test")
     with catch_logging() as log:
-        _fetch_file(url, archive_name, timeout=30., verbose='debug')
+        _fetch_file(url, archive_name, timeout=30., verbose=True)
     log = log.getvalue()
-    assert 'Resuming at' not in log
+    assert ', resuming at' not in log
     with open(archive_name, 'rb') as fid:
         data = fid.read()
     stop = len(data) // 2
@@ -26,10 +27,10 @@ def test_fetch_file(url, tmpdir):
     with open(archive_name + '.part', 'wb') as fid:
         fid.write(data[:stop])
     with catch_logging() as log:
-        _fetch_file(url, archive_name, timeout=30., verbose='debug')
+        _fetch_file(url, archive_name, timeout=30., verbose=True)
     log = log.getvalue()
-    assert 'Resuming at %s' % stop in log
-    with pytest.raises(Exception, match='unknown url type'):
+    assert ', resuming at %s' % sizeof_fmt(stop) in log
+    with pytest.raises(Exception, match='Cannot use'):
         _fetch_file('NOT_AN_ADDRESS', op.join(tempdir, 'test'), verbose=False)
     resume_name = op.join(tempdir, "download_resume")
     # touch file


### PR DESCRIPTION
In maybe 10% of PRs we get sporadic failures downloading the test data or in `test_constants.py` [of the form](https://travis-ci.org/mne-tools/mne-python/jobs/657984986):
```
RuntimeError: URL could not be parsed properly (total size 1030996061 != file size 1)
```
I could replicate it locally by running `pytest mne/io/tests/test_constants.py` a lot (like 10-20 times) -- I'd see the failure every once in a while.

This has to do with our not handling `chunked` data protocol properly. The chunked protocol causes the `headers['Content-Length']` to be None/missing, which we currently treat as a file size of `1` but then later don't handle properly. We can and should still read data even if we don't know the total size rather than fail out. This PR simplifies a lot of the logic in our downloader in order hopefully to help. It also reduces the number of times that we open URLs to get information from them (hopefully it's only once now).

I simplified our code for following redirects, under the assumption that modern Python will not require us to go through and manually follow multiple redirects. In testing it seems okay and `nilearn` (where we originally adapted our code) does not even try to do this, so I think it'll be okay. I'm running with `[circle full]` just to test all of our downloads, though.