### PR TITLE
Fix initial_time in _TimeViewer

### DIFF
--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -348,6 +348,7 @@ class _TimeViewer(object):
         )
         time_slider = self.plotter.add_slider_widget(
             self.time_call,
+            value=self.brain._data['time_idx'],
             rng=[0, max_time],
             pointa=(0.23, 0.1),
             pointb=(0.77, 0.1),


### PR DESCRIPTION
This PR fixes the default time value for `_TimeViewer`. The diff is very short, a connection with the slider was missing.

Closes #7379 
It's an item of #7162