### PR TITLE
Fix window name in _TimeViewer

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -202,7 +202,8 @@ class _Brain(object):
             _check_3d_figure(figure)
         self._renderer = _get_renderer(size=fig_size, bgcolor=background,
                                        shape=(n_row, n_col), fig=figure)
-        _set_3d_title(figure=self._renderer.figure, title=self._title)
+        if self._title is not None:
+            _set_3d_title(figure=self._renderer.figure, title=self._title)
 
         for h in self._hemis:
             # Initialize a Surface object as the geometry

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -199,7 +199,8 @@ class _Brain(object):
 
         if figure is not None and not isinstance(figure, int):
             _check_3d_figure(figure)
-        self._renderer = _get_renderer(size=fig_size, bgcolor=background,
+        self._renderer = _get_renderer(name=title, size=fig_size,
+                                       bgcolor=background,
                                        shape=(n_row, n_col), fig=figure)
 
         for h in self._hemis:

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -143,7 +143,8 @@ class _Brain(object):
                  foreground=None, figure=None, subjects_dir=None,
                  views=['lateral'], offset=True, show_toolbar=False,
                  offscreen=False, interaction=None, units='mm'):
-        from ..backends.renderer import _get_renderer, _check_3d_figure
+        from ..backends.renderer import (_get_renderer, _check_3d_figure,
+                                         _set_3d_title)
         from matplotlib.colors import colorConverter
 
         if interaction is not None:
@@ -201,6 +202,7 @@ class _Brain(object):
             _check_3d_figure(figure)
         self._renderer = _get_renderer(size=fig_size, bgcolor=background,
                                        shape=(n_row, n_col), fig=figure)
+        _set_3d_title(figure=self._renderer.figure, title=self._title)
 
         for h in self._hemis:
             # Initialize a Surface object as the geometry

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -199,8 +199,7 @@ class _Brain(object):
 
         if figure is not None and not isinstance(figure, int):
             _check_3d_figure(figure)
-        self._renderer = _get_renderer(name=title, size=fig_size,
-                                       bgcolor=background,
+        self._renderer = _get_renderer(size=fig_size, bgcolor=background,
                                        shape=(n_row, n_col), fig=figure)
 
         for h in self._hemis:

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -203,7 +203,7 @@ class _Brain(object):
         self._renderer = _get_renderer(size=fig_size, bgcolor=background,
                                        shape=(n_row, n_col), fig=figure)
         if self._title is not None:
-            _set_3d_title(figure=self._renderer.figure, title=self._title)
+            _set_3d_title(fig=self._renderer.scene(), title=self._title)
 
         for h in self._hemis:
             # Initialize a Surface object as the geometry

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -203,7 +203,7 @@ class _Brain(object):
         self._renderer = _get_renderer(size=fig_size, bgcolor=background,
                                        shape=(n_row, n_col), fig=figure)
         if self._title is not None:
-            _set_3d_title(fig=self._renderer.scene(), title=self._title)
+            _set_3d_title(figure=self._renderer.scene(), title=self._title)
 
         for h in self._hemis:
             # Initialize a Surface object as the geometry

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -70,7 +70,7 @@ def test_brain_init(renderer):
         _Brain(subject_id=subject_id, hemi='foo', surf=surf)
 
     brain = _Brain(subject_id, hemi, surf, size=(300, 300),
-                   subjects_dir=subjects_dir)
+                   subjects_dir=subjects_dir, title='test')
     brain.show_view(view=dict(azimuth=180., elevation=90.))
     brain.close()
 


### PR DESCRIPTION
This PR fixes the window title of `_TimeViewer`. The diff is very short, the `title` parameter was not passed to `_get_renderer()`.

It's an item of #7162