### PR TITLE
Add clear_points in _TimeViewer

### DIFF
--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -488,6 +488,7 @@ class _TimeViewer(object):
             'i': self.toggle_interface,
             's': self.apply_auto_scaling,
             'r': self.restore_user_scaling,
+            'c': self.clear_points,
             ' ': self.toggle_playback,
         }
         menu = self.plotter.main_menu.addMenu('Help')
@@ -716,6 +717,14 @@ class _TimeViewer(object):
         self.picked_points[mesh._hemi].remove(mesh._vertex_id)
         self.plotter.remove_actor(mesh._actors)
 
+    def clear_points(self):
+        for sphere in self._spheres:
+            vertex_id = sphere._vertex_id
+            hemi = sphere._hemi
+            if vertex_id in self.picked_points[hemi]:
+                self.remove_point(sphere)
+        self._spheres.clear()
+
     def plot_time_course(self, hemi, vertex_id, color):
         time = self.brain._data['time']
         hemi_str = 'L' if hemi == 'lh' else 'R'
@@ -744,6 +753,7 @@ class _TimeViewer(object):
             ('i', 'Toggle interface'),
             ('s', 'Apply auto-scaling'),
             ('r', 'Restore original clim'),
+            ('c', 'Clear all traces'),
             ('Space', 'Start/Pause playback'),
         ]
         text1, text2 = zip(*pairs)

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -199,11 +199,9 @@ def test_brain_timeviewer_traces(renderer_interactive, hemi):
     assert len(spheres) == len(hemi_str)
 
     # test removing points
-    for sphere in spheres:
-        time_viewer.remove_point(sphere)
+    time_viewer.clear_points()
     assert len(picked_points['lh']) == 0
     assert len(picked_points['rh']) == 0
-    spheres.clear()  # necessary for the rest of the test
 
     # test picking a cell at random
     for idx, current_hemi in enumerate(hemi_str):


### PR DESCRIPTION
This PR adds a shortcut `c` to clear all traces, the help window is also updated.

Here is an animation with `show_traces='separate'`:

![output](https://user-images.githubusercontent.com/18143289/75900751-b4597900-5e3d-11ea-98c0-4c4531800732.gif)

It's an item of #7162 