### PR TITLE
MRG, MAINT: Decrease memory usage of plot_forward.py

### DIFF
--- a/tutorials/source-modeling/plot_forward.py
+++ b/tutorials/source-modeling/plot_forward.py
@@ -106,19 +106,18 @@ mne.viz.plot_alignment(info, trans, subject=subject, dig=True,
 # :func:`mne.setup_source_space`, while **volumetric** source space is computed
 # using :func:`mne.setup_volume_source_space`.
 #
-# We will now compute a surface-based source space with an OCT-6 resolution.
-# See :ref:`setting_up_source_space` for details on source space definition
-# and spacing parameter.
+# We will now compute a surface-based source space with an ``'oct6'``
+# resolution. See :ref:`setting_up_source_space` for details on source space
+# definition and spacing parameter.
 
-src = mne.setup_source_space(subject, spacing='oct6',
-                             subjects_dir=subjects_dir, add_dist=False)
+src = mne.setup_source_space(subject, spacing='oct6', add_dist='patch',
+                             subjects_dir=subjects_dir)
 print(src)
 
 ###############################################################################
 # The surface based source space ``src`` contains two parts, one for the left
-# hemisphere (4098 locations) and one for the right hemisphere
-# (4098 locations). Sources can be visualized on top of the BEM surfaces
-# in purple.
+# hemisphere (4098 locations) and one for the right hemisphere (4098
+# locations). Sources can be visualized on top of the BEM surfaces in purple.
 
 mne.viz.plot_bem(subject=subject, subjects_dir=subjects_dir,
                  brain_surfaces='white', src=src, orientation='coronal')
@@ -222,16 +221,15 @@ print("Leadfield size : %d sensors x %d dipoles" % leadfield.shape)
 
 ###############################################################################
 # This is equivalent to the following code that explicitly applies the
-# forward operator to a source estimate composed of the identity operator:
-
-import numpy as np  # noqa
-
-n_dipoles = leadfield.shape[1]
-vertices = [src_hemi['vertno'] for src_hemi in fwd_fixed['src']]
-stc = mne.SourceEstimate(1e-9 * np.eye(n_dipoles), vertices, tmin=0., tstep=1)
-leadfield = mne.apply_forward(fwd_fixed, stc, info).data / 1e-9
-
-###############################################################################
+# forward operator to a source estimate composed of the identity operator
+# (which we omit here because it uses a lot of memory)::
+#
+#     >>> import numpy as np
+#     >>> n_dipoles = leadfield.shape[1]
+#     >>> vertices = [src_hemi['vertno'] for src_hemi in fwd_fixed['src']]
+#     >>> stc = mne.SourceEstimate(1e-9 * np.eye(n_dipoles), vertices)
+#     >>> leadfield = mne.apply_forward(fwd_fixed, stc, info).data / 1e-9
+#
 # To save to disk a forward solution you can use
 # :func:`mne.write_forward_solution` and to read it back from disk
 # :func:`mne.read_forward_solution`. Don't forget that FIF files containing
@@ -240,8 +238,7 @@ leadfield = mne.apply_forward(fwd_fixed, stc, info).data / 1e-9
 # To get a fixed-orientation forward solution, use
 # :func:`mne.convert_forward_solution` to convert the free-orientation
 # solution to (surface-oriented) fixed orientation.
-
-###############################################################################
+#
 # Exercise
 # --------
 #

--- a/tutorials/source-modeling/plot_mne_dspm_source_localization.py
+++ b/tutorials/source-modeling/plot_mne_dspm_source_localization.py
@@ -60,7 +60,7 @@ evoked.plot_topomap(times=np.linspace(0.05, 0.15, 5), ch_type='mag',
 # Show whitening
 evoked.plot_white(noise_cov, time_unit='s')
 
-del epochs  # to save memory
+del epochs, raw  # to save memory
 
 ###############################################################################
 # Inverse modeling: MNE/dSPM on evoked and raw data
@@ -71,9 +71,8 @@ fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-oct-6-fwd.fif'
 fwd = mne.read_forward_solution(fname_fwd)
 
 # make an MEG inverse operator
-info = evoked.info
-inverse_operator = make_inverse_operator(info, fwd, noise_cov,
-                                         loose=0.2, depth=0.8)
+inverse_operator = make_inverse_operator(
+    evoked.info, fwd, noise_cov, loose=0.2, depth=0.8)
 del fwd
 
 # You can write it to disk with::
@@ -98,11 +97,9 @@ stc, residual = apply_inverse(evoked, inverse_operator, lambda2,
 # -------------
 # View activation time-series
 
-plt.figure()
-plt.plot(1e3 * stc.times, stc.data[::100, :].T)
-plt.xlabel('time (ms)')
-plt.ylabel('%s value' % method)
-plt.show()
+fig, ax = plt.subplots()
+ax.plot(1e3 * stc.times, stc.data[::100, :].T)
+ax.set(xlabel='time (ms)', ylabel='%s value' % method)
 
 ###############################################################################
 # Examine the original data and the residual after fitting:
@@ -178,7 +175,8 @@ del stc_vec
 surfer_kwargs['clim'].update(kind='percent', lims=[99, 99.9, 99.99])
 for mi, method in enumerate(['dSPM', 'sLORETA', 'eLORETA']):
     stc = apply_inverse(evoked, inverse_operator, lambda2,
-                        method=method, pick_ori=None)
+                        method=method, pick_ori=None,
+                        verbose=True)
     brain = stc.plot(figure=mi, **surfer_kwargs)
     brain.add_text(0.1, 0.9, method, 'title', font_size=20)
     del stc


### PR DESCRIPTION
@drammock okay for you? It turns out that the `np.eye(n_sources)` was causing ~500 MB of mem usage (`8192 ** 2 * 8 = 536870912`) so just making a comment about it should fix our recent CircleCI failures, as in local testing it goes from ~2100 MB in `master` down to ~1500 MB in this PR.