### PR TITLE
DOC: Fix typo

### DIFF
--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -56,8 +56,8 @@ def maxwell_filter(raw, origin='auto', int_order=8, ext_order=3,
 
         .. warning:: Automatic bad channel detection is not currently
                      implemented. It is critical to mark bad channels in
-                     ``raw.info['bads']`` prior to processing
-                     in orider to prevent artifact spreading.
+                     ``raw.info['bads']`` prior to processing in order to
+                     prevent artifact spreading.
     origin : array-like, shape (3,) | str
         Origin of internal and external multipolar moment space in meters.
         The default is ``'auto'``, which means ``(0., 0., 0.)`` when


### PR DESCRIPTION
#### What does this implement/fix?
Fixes a typo in a docstring.
