### PR TITLE
MRG: Add reset_camera() primitive in _Renderer

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -775,6 +775,7 @@ class _Brain(object):
         self._renderer.subplot(row, col)
         self._renderer.set_camera(azimuth=view.azim,
                                   elevation=view.elev)
+        self._renderer.reset_camera()
 
     def save_image(self, filename, mode='rgb'):
         """Save view from all panels to disk.

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -276,8 +276,9 @@ class _Renderer(_BaseRenderer):
                      focalpoint=focalpoint)
 
     def reset_camera(self):
-        if self.fig is not None:
-            self.fig.scene.renderer.reset_camera()
+        renderer = getattr(self.fig.scene, 'renderer', None)
+        if renderer is not None:
+            renderer.reset_camera()
 
     def screenshot(self, mode='rgb', filename=None):
         return _take_3d_screenshot(figure=self.fig, mode=mode,

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -275,6 +275,9 @@ class _Renderer(_BaseRenderer):
                      elevation=elevation, distance=distance,
                      focalpoint=focalpoint)
 
+    def reset_camera(self):
+        self.fig.scene.renderer.reset_camera()
+
     def screenshot(self, mode='rgb', filename=None):
         return _take_3d_screenshot(figure=self.fig, mode=mode,
                                    filename=filename)

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -276,7 +276,8 @@ class _Renderer(_BaseRenderer):
                      focalpoint=focalpoint)
 
     def reset_camera(self):
-        self.fig.scene.renderer.reset_camera()
+        if self.fig is not None:
+            self.fig.scene.renderer.reset_camera()
 
     def screenshot(self, mode='rgb', filename=None):
         return _take_3d_screenshot(figure=self.fig, mode=mode,

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -426,6 +426,9 @@ class _Renderer(_BaseRenderer):
         _set_3d_view(self.figure, azimuth=azimuth, elevation=elevation,
                      distance=distance, focalpoint=focalpoint)
 
+    def reset_camera(self):
+        self.plotter.reset_camera()
+
     def screenshot(self, mode='rgb', filename=None):
         return _take_3d_screenshot(figure=self.figure, mode=mode,
                                    filename=filename)

--- a/mne/viz/backends/base_renderer.py
+++ b/mne/viz/backends/base_renderer.py
@@ -349,6 +349,11 @@ class _BaseRenderer(metaclass=ABCMeta):
         pass
 
     @abstractclassmethod
+    def reset_camera(self):
+        """Reset the camera properties."""
+        pass
+
+    @abstractclassmethod
     def screenshot(self, mode='rgb', filename=None):
         """Take a screenshot of the scene.
 

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -150,4 +150,5 @@ def test_3d_backend(renderer):
     rend.set_camera(azimuth=180.0, elevation=90.0,
                     distance=cam_distance,
                     focalpoint=center)
+    rend.reset_camera()
     rend.show()


### PR DESCRIPTION
This PR fixes the `focalpoint` issue when `hemi='both'` in _TimeViewer. It should be placed between the hemispheres.

`master`  | PR
------------|------
![2020-03-05_1920x1080](https://user-images.githubusercontent.com/18143289/75962368-f0372180-5ec3-11ea-9c91-0fdd7dcc2b56.png) | ![2020-03-05_1920x1080](https://user-images.githubusercontent.com/18143289/75962309-d3025300-5ec3-11ea-85b6-d9db17082b82.png)

It's an item of #7162 