### PR TITLE
MRG, API: Remove function meant to be private

### DIFF
--- a/mne/preprocessing/bads.py
+++ b/mne/preprocessing/bads.py
@@ -3,8 +3,10 @@
 
 
 import numpy as np
+from ..utils import deprecated
 
 
+@deprecated('find_outliers is deprecated and will be removed in 0.20')
 def find_outliers(X, threshold=3.0, max_iter=2):
     """Find outliers based on iterated Z-scoring.
 
@@ -26,6 +28,10 @@ def find_outliers(X, threshold=3.0, max_iter=2):
     bad_idx : np.ndarray of int, shape (n_features)
         The outlier indices.
     """
+    return _find_outliers(X, threshold, max_iter)
+
+
+def _find_outliers(X, threshold=3.0, max_iter=2):
     from scipy.stats import zscore
     my_mask = np.zeros(len(X), dtype=np.bool)
     for _ in range(max_iter):

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -56,7 +56,7 @@ from ..utils.check import _check_all_same_channel_names
 
 from ..fixes import _get_args, _safe_svd
 from ..filter import filter_data
-from .bads import find_outliers
+from .bads import _find_outliers
 from .ctps_ import ctps
 from ..io.pick import channel_type, pick_channels_regexp
 
@@ -1087,7 +1087,7 @@ class ICA(ContainsMixin):
                 stop=stop, l_freq=l_freq, h_freq=h_freq,
                 reject_by_annotation=reject_by_annotation)]
             # pick last scores
-            this_idx = find_outliers(scores[-1], threshold=threshold)
+            this_idx = _find_outliers(scores[-1], threshold=threshold)
             idx += [this_idx]
             self.labels_['%s/%i/' % (prefix, ii) + ch] = list(this_idx)
 
@@ -2452,7 +2452,7 @@ def _find_max_corrs(all_maps, target, threshold):
         max_corrs = [list(np.nonzero(s_corr > threshold)[0])
                      for s_corr in abs_corrs]
     else:
-        max_corrs = [list(find_outliers(s_corr, threshold=threshold))
+        max_corrs = [list(_find_outliers(s_corr, threshold=threshold))
                      for s_corr in abs_corrs]
 
     am = [l[i] for l, i_s in zip(abs_corrs, max_corrs)
@@ -2526,7 +2526,7 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
         If list of floats, search for the best map in the specified range of
         correlation strengths. As correlation values, must be between 0 and 1
         If float > 0, select ICs correlating better than this.
-        If float > 1, use find_outliers to identify ICs within subjects (not in
+        If float > 1, use z-scoring to identify ICs within subjects (not in
         original Corrmap)
         Defaults to "auto".
     label : None | str
@@ -2614,8 +2614,8 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
 
     # first run: use user-selected map
     threshold = np.atleast_1d(np.array(threshold, float)).ravel()
-    threshold_err = ('No component detected using find_outliers when '
-                     'using threshold%s %s, consider using a more lenient '
+    threshold_err = ('No component detected using when z-scoring '
+                     'threshold%s %s, consider using a more lenient '
                      'threshold' % (threshold_extra, threshold))
     if len(all_maps) == 0:
         raise RuntimeError(threshold_err)

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -220,7 +220,6 @@ detrend
 dir_tree_find
 fast_cross_3d
 fiff_open
-find_outliers
 find_source_space_hemi
 find_tag
 get_score_funcs


### PR DESCRIPTION
This function appears never to have been meant to be public, let's explicitly make it private.

I'm not entirely sure we even need to bother with a deprecation cycle here but I'm putting it in to be safe. I didn't add a `latest.inc` update, though, as it seems unnecessary in this case, but I can add it if others disagree.