### PR TITLE
MRG, MAINT: Use VTK 8.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,10 +29,10 @@ dependencies:
 - traits>=4.6.0
 - pyface>=6
 - traitsui>=6
+- vtk
 - pip:
   - mne
   - https://api.github.com/repos/numpy/numpydoc/zipball/master
-  - vtk
   - pyvista>=0.23.1
   - mayavi
   - PySurfer[save_movie]


### PR DESCRIPTION
Anaconda now has a newer VTK (8.2) than pip (8.1.2), so let's use it. It's possible that this might fix some depth buffer problems for people -- @bloyl you had an issue open about this #7107, it's possible 8.2 already fixes the problem if you feel like trying it.