### PR TITLE
MRG: Set _Brain window title

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -143,8 +143,7 @@ class _Brain(object):
                  foreground=None, figure=None, subjects_dir=None,
                  views=['lateral'], offset=True, show_toolbar=False,
                  offscreen=False, interaction=None, units='mm'):
-        from ..backends.renderer import (_get_renderer, _check_3d_figure,
-                                         _set_3d_title)
+        from ..backends.renderer import _get_renderer, _check_3d_figure
         from matplotlib.colors import colorConverter
 
         if interaction is not None:
@@ -200,10 +199,9 @@ class _Brain(object):
 
         if figure is not None and not isinstance(figure, int):
             _check_3d_figure(figure)
-        self._renderer = _get_renderer(size=fig_size, bgcolor=background,
+        self._renderer = _get_renderer(name=title, size=fig_size,
+                                       bgcolor=background,
                                        shape=(n_row, n_col), fig=figure)
-        if self._title is not None:
-            _set_3d_title(figure=self._renderer.scene(), title=self._title)
 
         for h in self._hemis:
             # Initialize a Surface object as the geometry

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -203,8 +203,6 @@ class _Brain(object):
         self._renderer = _get_renderer(name=subject_id, size=fig_size,
                                        bgcolor=background,
                                        shape=(n_row, n_col), fig=figure)
-        if self._title is not None:
-            _set_3d_title(figure=self._renderer.scene(), title=self._title)
 
         for h in self._hemis:
             # Initialize a Surface object as the geometry
@@ -237,6 +235,10 @@ class _Brain(object):
                     self._hemi_meshes[h] = mesh
                     self._renderer.set_camera(azimuth=views_dict[v].azim,
                                               elevation=views_dict[v].elev)
+
+        if self._title is not None:
+            _set_3d_title(figure=self._renderer.scene(), title=self._title)
+
         # Force rendering
         self._renderer.show()
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -143,7 +143,8 @@ class _Brain(object):
                  foreground=None, figure=None, subjects_dir=None,
                  views=['lateral'], offset=True, show_toolbar=False,
                  offscreen=False, interaction=None, units='mm'):
-        from ..backends.renderer import _get_renderer, _check_3d_figure
+        from ..backends.renderer import (_get_renderer, _check_3d_figure,
+                                         _set_3d_title)
         from matplotlib.colors import colorConverter
 
         if interaction is not None:
@@ -199,9 +200,11 @@ class _Brain(object):
 
         if figure is not None and not isinstance(figure, int):
             _check_3d_figure(figure)
-        self._renderer = _get_renderer(name=title, size=fig_size,
+        self._renderer = _get_renderer(name=subject_id, size=fig_size,
                                        bgcolor=background,
                                        shape=(n_row, n_col), fig=figure)
+        if self._title is not None:
+            _set_3d_title(figure=self._renderer.scene(), title=self._title)
 
         for h in self._hemis:
             # Initialize a Surface object as the geometry

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -550,7 +550,7 @@ def _set_3d_view(figure, azimuth, elevation, focalpoint, distance):
         position, cen, view_up]
 
 
-def _set_3d_title(figure, title, size=40):
+def _set_3d_title(figure, title, size=16):
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=FutureWarning)
         figure.plotter.add_text(title, font_size=size, color='white')


### PR DESCRIPTION
This PR follows https://github.com/mne-tools/mne-python/pull/7382 and unifies the behaviour of the `title` parameter of `_Brain`.

It's of course still possible to add a title string label with `set_3d_title()`.

It's an item of #7162 