### PR TITLE
FIX: Fix rank reduction for beamformers

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -134,7 +134,7 @@ Changelog
 Bug
 ~~~
 
-- Fix the ``reduce_rank`` parameter in :func:`mne.beamformer.make_lcmv` and :func:`mne.beamformer.make_dics` to reduce the rank of the leadfield instead of the rank of the denominator of the beamformer formula by `Britta Westner`_.
+- Fix the ``reduce_rank`` parameter in :func:`mne.beamformer.make_lcmv` and :func:`mne.beamformer.make_dics` to reduce the rank of the leadfield first before then reducing the rank of the denominator of the beamformer formula for the inversion by `Britta Westner`_ and `Eric Larson`_.
 
 - Allow :func:`mne.channels.read_dig_hpts` to accept point categories (eg. EEG) to be specified in upper case by `Alex Gramfort`_.
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -134,6 +134,8 @@ Changelog
 Bug
 ~~~
 
+- Fix the ``reduce_rank`` parameter in :func:`mne.beamformer.make_lcmv` and :func:`mne.beamformer.make_dics` to reduce the rank of the leadfield instead of the rank of the denominator of the beamformer formula by `Britta Westner`_.
+
 - Allow :func:`mne.channels.read_dig_hpts` to accept point categories (eg. EEG) to be specified in upper case by `Alex Gramfort`_.
 
 - Fix a bug in :meth:`mne.MixedSourceEstimate.plot_surface` that prevented plotting in latest PySurfer by `Christian O'Reilly`_.

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -18,8 +18,7 @@ from ..io.proj import make_projector, Projection
 from ..minimum_norm.inverse import _get_vertno, _prepare_forward
 from ..source_space import label_src_vertno_sel
 from ..utils import (verbose, check_fname, _reg_pinv, _check_option, logger,
-                     _pl, _check_src_normal, check_version, _validate_type,
-                     warn)
+                     _pl, _check_src_normal, check_version, warn)
 from ..time_frequency.csd import CrossSpectralDensity
 
 from ..externals.h5io import read_hdf5, write_hdf5
@@ -260,7 +259,6 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
     # inversion of the denominator
     _check_option('inversion', inversion, ('matrix', 'single'))
     if reduce_rank and inversion == 'single':
-        # TODO: what about the leadfield rank reduction with backprojection?
         raise ValueError('reduce_rank cannot be used with inversion="single"; '
                          'consider using inversion="matrix" if you have a '
                          'rank-deficient forward model (i.e., from a sphere '
@@ -283,6 +281,7 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
         s[:, np.argmin(s, axis=1)] = 0.  # set the smalles singular value to 0.
         # expand s to match dimension of u
         s_full = np.zeros(Gk.shape)
+        # TODO: vectorize?
         for s_full_vox, s_vox in zip(s_full, s):
             np.fill_diagonal(s_full_vox, s_vox)
 

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -18,7 +18,7 @@ from ..io.proj import make_projector, Projection
 from ..minimum_norm.inverse import _get_vertno, _prepare_forward
 from ..source_space import label_src_vertno_sel
 from ..utils import (verbose, check_fname, _reg_pinv, _check_option, logger,
-                     _pl, _check_src_normal, check_version, warn)
+                     _pl, _check_src_normal, check_version)
 from ..time_frequency.csd import CrossSpectralDensity
 
 from ..externals.h5io import read_hdf5, write_hdf5
@@ -282,8 +282,7 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
             raise ValueError(
                 'Singular matrix detected when estimating spatial filters. '
                 'Consider reducing the rank of the forward operator by using '
-                'reduce_rank="leadfield" or of the beamformer denominator by '
-                'using reduce_rank="denominator".')
+                'reduce_rank=True.')
 
     # rank reduction of the lead field
     if reduce_rank is True:

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -122,14 +122,8 @@ def _reduce_leadfield_rank(G):
     u, s, v = np.linalg.svd(G)
     s[:, -1] = 0.  # set the smallest singular value to 0.
 
-    # expand s to match dimension of u
-    s_full = np.zeros(G.shape)
-    # TODO: vectorize?
-    for s_full_vox, s_vox in zip(s_full, s):
-        np.fill_diagonal(s_full_vox, s_vox)
-
     # backproject
-    G = np.matmul(u, np.matmul(s_full, v))
+    G = np.matmul(u[..., :3], s[..., None] * v)
 
     return G
 

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -120,7 +120,7 @@ def _reduce_leadfield_rank(G):
     """Reduce the rank of the leadfield."""
     # decompose lead field
     u, s, v = np.linalg.svd(G)
-    s[:, np.argmin(s, axis=1)] = 0.  # set the smallest singular value to 0.
+    s[:, -1] = 0.  # set the smallest singular value to 0.
 
     # expand s to match dimension of u
     s_full = np.zeros(G.shape)


### PR DESCRIPTION
As discussed in https://github.com/mne-tools/mne-python/pull/7168, the option `reduce_rank=True` does not behave as one might expect:
The code is actually not implementing lead field rank reduction but reducing the rank of the denominator of the beamformer formula.

This PR fixes this, and completely swaps the old rank reduction for the lead field one.

Tests are left to fail for first round, so we can see what will change with this in place.
