### PR TITLE
MRG, STY: Allow wrapping long API lines in HTML

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -480,3 +480,7 @@ a[class^="sphx-glr-backref-module-mne"] {  /* make all MNE things bold */
 a[class^="sphx-glr-backref-module-mne"]:hover {
     color: var(--a-color-light);
 }
+/* Long API titles need to wrap for mobile */
+div[id^="mne-"] h1 {
+    word-break: break-word;
+}

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -484,3 +484,6 @@ a[class^="sphx-glr-backref-module-mne"]:hover {
 div[id^="mne-"] h1 {
     word-break: break-word;
 }
+div[id^="examples-using-"] h2 {
+    word-break: break-word;
+}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -51,7 +51,7 @@
 
 {% block relbar1 %}
 {% if build_dev_html|tobool %}
-<div class="row devbar alert alert-danger">
+<div class="d-block devbar alert alert-danger">
 This documentation is for <strong>development version {{ release }}</strong>.
 </div>
 {% endif %}


### PR DESCRIPTION
Allows long API titles like `mne.minimum_norm.source_induced_power` to wrap.

A [better solution](https://stackoverflow.com/questions/23107990/word-wrap-on-non-alphabetical-character) would be to change `autosummary` to put each `X.`/`Y.` of `X.Y.Z` in a separate `span`, then you can make it break on the periods. But this is a lot more work for a marginal benefit.