### PR TITLE
Ensure corrected p-values are always <= 1.0

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -277,6 +277,8 @@ Bug
 
 - Update old url link in :func:`mne.datasets.eegbci.load_data` to ``EEGMI_URL = 'https://physionet.org/files/eegmmidb/1.0.0/'`` by `Ramiro Gatti`_
 
+- Ensure corrected p-values calculated by :func:`mne.stats.bonferroni_correction` never exceed the value of 1.0 by `Richard Höchenberger`_
+
 API
 ~~~
 

--- a/mne/stats/multi_comp.py
+++ b/mne/stats/multi_comp.py
@@ -95,6 +95,7 @@ def bonferroni_correction(pval, alpha=0.05):
     """
     pval = np.asarray(pval)
     pval_corrected = pval * float(pval.size)
-    pval_corrected.clip(max=1.)  # p-values must not be larger than 1.
+    # p-values must not be larger than 1.
+    pval_corrected = pval_corrected.clip(max=1.)
     reject = pval_corrected < alpha
     return reject, pval_corrected

--- a/mne/stats/multi_comp.py
+++ b/mne/stats/multi_comp.py
@@ -95,5 +95,6 @@ def bonferroni_correction(pval, alpha=0.05):
     """
     pval = np.asarray(pval)
     pval_corrected = pval * float(pval.size)
+    pval_corrected.clip(max=1.)  # p-values must not be larger than 1.
     reject = pval_corrected < alpha
     return reject, pval_corrected

--- a/mne/stats/tests/test_multi_comp.py
+++ b/mne/stats/tests/test_multi_comp.py
@@ -44,3 +44,10 @@ def test_multi_pval_correction():
     thresh_fdr = np.min(np.abs(T)[reject_fdr])
     assert 0 <= (reject_fdr.sum() - 50) <= 50 * 1.05
     assert thresh_uncorrected <= thresh_fdr <= thresh_bonferroni
+
+
+def test_bonferroni_pval_clip():
+    """Test that p-values are never exceed 1.0."""
+    p = (0.2, 0.9)
+    _, p_corrected = bonferroni_correction(p)
+    assert p_corrected.max() <= 1.0

--- a/mne/stats/tests/test_multi_comp.py
+++ b/mne/stats/tests/test_multi_comp.py
@@ -7,6 +7,13 @@ import pytest
 from mne.stats import fdr_correction, bonferroni_correction
 
 
+def test_bonferroni_pval_clip():
+    """Test that p-values are never exceed 1.0."""
+    p = (0.2, 0.9)
+    _, p_corrected = bonferroni_correction(p)
+    assert p_corrected.max() <= 1.0
+
+
 def test_multi_pval_correction():
     """Test pval correction for multi comparison (FDR and Bonferroni)."""
     rng = np.random.RandomState(0)
@@ -24,7 +31,7 @@ def test_multi_pval_correction():
     thresh_bonferroni = stats.t.ppf(1.0 - alpha / n_tests, n_samples - 1)
     assert pval_bonferroni.ndim == 2
     assert reject_bonferroni.ndim == 2
-    assert_allclose(pval_bonferroni / 10000, pval)
+    assert_allclose(pval_bonferroni, (pval * 10000).clip(max=1))
     reject_expected = pval_bonferroni < alpha
     assert_array_equal(reject_bonferroni, reject_expected)
 
@@ -44,10 +51,3 @@ def test_multi_pval_correction():
     thresh_fdr = np.min(np.abs(T)[reject_fdr])
     assert 0 <= (reject_fdr.sum() - 50) <= 50 * 1.05
     assert thresh_uncorrected <= thresh_fdr <= thresh_bonferroni
-
-
-def test_bonferroni_pval_clip():
-    """Test that p-values are never exceed 1.0."""
-    p = (0.2, 0.9)
-    _, p_corrected = bonferroni_correction(p)
-    assert p_corrected.max() <= 1.0


### PR DESCRIPTION
#### Reference issue
Fixes GH-7354.


#### What does this implement/fix?
Clips p-values produced by Bonferroni correction at 1.0
