### PR TITLE
WIP: Expose ignore_overlap to evoked plot_topomap function

### DIFF
--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -336,7 +336,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                      mask=None, mask_params=None, outlines='head',
                      contours=6, image_interp='bilinear', average=None,
                      head_pos=None, axes=None, extrapolate='box', sphere=None,
-                     border=0):
+                     border=0, ignore_overlap=False):
         return plot_evoked_topomap(
             self, times=times, ch_type=ch_type, layout=layout, vmin=vmin,
             vmax=vmax, cmap=cmap, sensors=sensors, colorbar=colorbar,
@@ -346,7 +346,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             show_names=show_names, title=title, mask=mask,
             mask_params=mask_params, outlines=outlines, contours=contours,
             image_interp=image_interp, average=average, head_pos=head_pos,
-            axes=axes, extrapolate=extrapolate, sphere=sphere, border=border)
+            axes=axes, extrapolate=extrapolate, sphere=sphere, border=border,
+            ignore_overlap=ignore_overlap)
 
     @copy_function_doc_to_method_doc(plot_evoked_field)
     def plot_field(self, surf_maps, time=None, time_label='t = %0.0f ms',

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -67,7 +67,8 @@ def _deprecate_layout(layout):
              'in 0.21', DeprecationWarning)
 
 
-def _prepare_topomap_plot(inst, ch_type, layout=None, sphere=None):
+def _prepare_topomap_plot(inst, ch_type, layout=None, sphere=None,
+                          ignore_overlap=False):
     """Prepare topo plot."""
     info = copy.deepcopy(inst if isinstance(inst, Info) else inst.info)
     sphere, clip_origin = _adjust_meg_sphere(sphere, info, ch_type)
@@ -111,7 +112,8 @@ def _prepare_topomap_plot(inst, ch_type, layout=None, sphere=None):
         if len(picks) == 0:
             raise ValueError("No channels of type %r" % ch_type)
 
-        pos = _find_topomap_coords(info, picks, sphere=sphere)
+        pos = _find_topomap_coords(info, picks, sphere=sphere,
+                                   ignore_overlap=ignore_overlap)
 
     ch_names = [info['ch_names'][k] for k in picks]
     if merge_grads:
@@ -602,9 +604,8 @@ def _topomap_plot_sensors(pos_x, pos_y, sensors, ax):
 def _get_pos_outlines(info, picks, sphere, to_sphere=True):
     ch_type = _get_ch_type(pick_info(_simplify_info(info), picks), None)
     sphere, clip_origin = _adjust_meg_sphere(sphere, info, ch_type)
-    pos = _find_topomap_coords(
-        info, picks, ignore_overlap=True, to_sphere=to_sphere,
-        sphere=sphere)
+    pos = _find_topomap_coords(info, picks, ignore_overlap=True,
+                               to_sphere=to_sphere, sphere=sphere)
     outlines = _make_head_outlines(sphere, pos, 'head', clip_origin)
     return pos, outlines
 
@@ -1378,7 +1379,8 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
                         show=True, show_names=False, title=None, mask=None,
                         mask_params=None, outlines='head', contours=6,
                         image_interp='bilinear', average=None, head_pos=None,
-                        axes=None, extrapolate='box', sphere=None, border=0):
+                        axes=None, extrapolate='box', sphere=None, border=0,
+                        ignore_overlap=False):
     """Plot topographic maps of specific time points of evoked data.
 
     Parameters
@@ -1502,6 +1504,9 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
         .. versionadded:: 0.18
     %(topomap_sphere_auto)s
     %(topomap_border)s
+    ignore_overlap : bool
+        Should overlapping channels be ignored, and allow to be plotted.
+        Overlapping channels can cause distorted figures. Defaults to False.
 
     Returns
     -------
@@ -1531,7 +1536,8 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None, layout=None,
     mask_params['markeredgewidth'] *= size / 2.
 
     picks, pos, merge_grads, names, ch_type, sphere, clip_origin = \
-        _prepare_topomap_plot(evoked, ch_type, layout, sphere=sphere)
+        _prepare_topomap_plot(evoked, ch_type, layout, sphere=sphere,
+                              ignore_overlap=ignore_overlap)
     outlines = _make_head_outlines(sphere, pos, outlines, clip_origin,
                                    head_pos)
 


### PR DESCRIPTION
#### What does this implement/fix?
It is common in fNIRS to have source and detectors in a criss-cross pattern. I try and illustrate this below (excuse the poor ascii art)...

Here sources are indicated by `[s]`, and detectors by`[d]`. Channels are then formed between the sources and detectors indicated by a `-`, and by `x` where two sources and detectors have overlapping channels.  For example there is a channel between s2 and d3, and one between s3 and d2 that overlap.
```python
[s2]  -  [d2]  -  [s4] 
      x        x         
[s3]  -  [d3]  -  [s5] 
```

This approach is used purposely to reduce noise (the overlapping channels should be measuring the same brain region), and for redundancy (its common to have a source or detector that fails or is blocked by hair/scars/etc).

Currently if you have this criss-cross pattern then the location of the channels is very close and MNE throws an error similar to... `The following electrodes have overlapping positions, which causes problems during visualization: S2_D3 hbo, S3_D2 hbo, ...`

In the future I would like to develop a way to combine overlapping channels in to a single optimal channel. But for now I would just like to be able to force MNE to allow me to view the data as a topomap. So I have exposed the ignore_overlap variable that was available in the lower level topomap function.

#### Additional information
I am keen to hear other approaches to how I can address this issue. I probably should have opened an issue and discussed the approach before I coded it.

None of the current nirs test data have overlapping channels. I will make sure the next set I upload does.