### PR TITLE
MRG, FIX: Fix BrainVision reader headers

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -177,7 +177,9 @@ Bug
 
 - Fix :meth:`mne.read_epochs_eeglab` that ignored channel locations by `Alex Gramfort`_.
 
-- Fix :meth:`mne.io.read_raw_brainvision` when channel names have spaces by `Sebastian Major`_.
+- Fix :func:`mne.io.read_raw_brainvision` when channel names have spaces by `Sebastian Major`_.
+
+- Fix :func:`mne.io.read_raw_brainvision` when ``"Core"`` is in the data header by `Eric Larson`_
 
 - Fix :meth:`mne.io.Raw.anonymize` to correctly reset ``raw.annotations.orig_time`` by `Luke Bloy`_.
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -13,7 +13,8 @@ import numpy as np
 
 from .utils import (_pl, check_fname, _validate_type, verbose, warn, logger,
                     _check_pandas_installed, _mask_to_onsets_offsets,
-                    _DefaultEventParser, _check_dt, _stamp_to_dt, _dt_to_stamp)
+                    _DefaultEventParser, _check_dt, _stamp_to_dt, _dt_to_stamp,
+                    _check_fname)
 
 from .io.write import (start_block, end_block, write_float, write_name_list,
                        write_double, start_file)
@@ -632,6 +633,7 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None):
     from .io.curry.curry import _read_annotations_curry
     from .io.ctf.markers import _read_annotations_ctf
 
+    fname = _check_fname(fname, overwrite='read', must_exist=True)
     name = op.basename(fname)
     if name.endswith(('fif', 'fif.gz')):
         # Read FiF files

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -632,8 +632,11 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None):
     from .io.cnt.cnt import _read_annotations_cnt
     from .io.curry.curry import _read_annotations_curry
     from .io.ctf.markers import _read_annotations_ctf
-
-    fname = _check_fname(fname, overwrite='read', must_exist=True)
+    _validate_type(fname, 'path-like', 'fname')
+    fname = _check_fname(
+        fname, overwrite='read', must_exist=True,
+        allow_dir=str(fname).endswith('.ds'),  # allow_dir for CTF
+        name='fname')
     name = op.basename(fname)
     if name.endswith(('fif', 'fif.gz')):
         # Read FiF files

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -155,7 +155,7 @@ def fix_pytest_tmpdir_35():
 
     for key in ('stat', 'mkdir', 'makedirs', 'access'):
         _replace(os, key)
-    for key in ('split', 'splitext', 'realpath', 'join'):
+    for key in ('split', 'splitext', 'realpath', 'join', 'basename'):
         _replace(op, key)
 
 

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -5,16 +5,14 @@
 #
 # License: BSD (3-clause)
 import os.path as op
-from os import unlink
 import shutil
 
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose, assert_equal)
 import pytest
-from tempfile import NamedTemporaryFile
 
-from mne.utils import _TempDir, run_tests_if_main, _stamp_to_dt
+from mne.utils import run_tests_if_main, _stamp_to_dt
 from mne import pick_types, read_annotations, concatenate_raws
 from mne.io.constants import FIFF
 from mne.io import read_raw_fif, read_raw_brainvision
@@ -153,11 +151,11 @@ def test_meas_date(mocked_meas_date_file):
         assert raw.info['meas_date'] == expected_meas
 
 
-def test_vhdr_codepage_ansi():
+def test_vhdr_codepage_ansi(tmpdir):
     """Test BV reading with ANSI codepage."""
     raw_init = read_raw_brainvision(vhdr_path)
     data_expected, times_expected = raw_init[:]
-    tempdir = _TempDir()
+    tempdir = str(tmpdir)
     ansi_vhdr_path = op.join(tempdir, op.split(vhdr_path)[-1])
     ansi_vmrk_path = op.join(tempdir, op.split(vmrk_path)[-1])
     ansi_eeg_path = op.join(tempdir, op.split(eeg_path)[-1])
@@ -188,11 +186,49 @@ def test_vhdr_codepage_ansi():
     assert_allclose(times_new, times_expected, atol=1e-15)
 
 
-def test_ascii():
+@pytest.mark.parametrize('header', [
+    b'BrainVision Data Exchange %s File Version 1.0\n',
+    # 2.0, space, core, comma
+    b'Brain Vision Core Data Exchange %s File, Version 2.0\n',
+    # bad
+    b'Brain Vision Core Data Exchange %s File, Version 3.0\n',
+])
+def test_vhdr_versions(tmpdir, header):
+    """Test BV reading with different header variants."""
+    raw_init = read_raw_brainvision(vhdr_path)
+    data_expected, times_expected = raw_init[:]
+    use_vhdr_path = op.join(tmpdir, op.split(vhdr_path)[-1])
+    use_vmrk_path = op.join(tmpdir, op.split(vmrk_path)[-1])
+    use_eeg_path = op.join(tmpdir, op.split(eeg_path)[-1])
+    shutil.copy(eeg_path, use_eeg_path)
+    with open(use_vhdr_path, 'wb') as fout:
+        with open(vhdr_path, 'rb') as fin:
+            for line in fin:
+                # Common Infos section
+                if line.startswith(b'Brain'):
+                    line = header % b'Header'
+                fout.write(line)
+    with open(use_vmrk_path, 'wb') as fout:
+        with open(vmrk_path, 'rb') as fin:
+            for line in fin:
+                # Common Infos section
+                if line.startswith(b'Brain'):
+                    line = header % b'Marker'
+                fout.write(line)
+
+    if b'3.0' in header:  # bad case
+        with pytest.raises(ValueError, match=r'3\.0.*Contact MNE-Python'):
+            read_raw_brainvision(use_vhdr_path)
+        return
+    raw = read_raw_brainvision(use_vhdr_path)
+    data_new, _ = raw[:]
+    assert_allclose(data_new, data_expected, atol=1e-15)
+
+
+def test_ascii(tmpdir):
     """Test ASCII BV reading."""
     raw = read_raw_brainvision(vhdr_path)
-    tempdir = _TempDir()
-    ascii_vhdr_path = op.join(tempdir, op.split(vhdr_path)[-1])
+    ascii_vhdr_path = op.join(tmpdir, op.split(vhdr_path)[-1])
     # copy marker file
     shutil.copy(vhdr_path.replace('.vhdr', '.vmrk'),
                 ascii_vhdr_path.replace('.vhdr', '.vmrk'))
@@ -508,7 +544,7 @@ def test_brainvision_neuroone_export():
 
 
 @testing.requires_testing_data
-def test_read_vmrk_annotations():
+def test_read_vmrk_annotations(tmpdir):
     """Test load brainvision annotations."""
     sfreq = 1000.0
 
@@ -516,16 +552,11 @@ def test_read_vmrk_annotations():
     # delete=False is for Windows compatibility
     with open(vmrk_path) as myfile:
         head = [next(myfile) for x in range(6)]
-    with NamedTemporaryFile(mode='w+', suffix='.vmrk', delete=False) as temp:
+    fname = tmpdir.join('temp.vmrk')
+    with open(str(fname), 'w') as temp:
         for item in head:
             temp.write(item)
-        temp.seek(0)
-        read_annotations(temp.name, sfreq=sfreq)
-    try:
-        temp.close()
-        unlink(temp.name)
-    except IOError:
-        pass
+    read_annotations(fname, sfreq=sfreq)
 
 
 @testing.requires_testing_data

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -135,10 +135,11 @@ def _check_event_id(event_id, events):
     return event_id
 
 
-def _check_fname(fname, overwrite=False, must_exist=False, name='File'):
+def _check_fname(fname, overwrite=False, must_exist=False, name='File',
+                 allow_dir=False):
     """Check for file existence."""
     _validate_type(fname, 'path-like', 'fname')
-    if op.isfile(fname):
+    if op.isfile(fname) or (allow_dir and op.isdir(fname)):
         if not overwrite:
             raise FileExistsError('Destination file exists. Please use option '
                                   '"overwrite=True" to force overwriting.')


### PR DESCRIPTION
Closes #7415.

Also modernizes the BV tests a bit.

@tvanasse feel free to test to see if it fixes your problem. Locally this now works for me:
```Python
import mne
file = mne.io.read_raw_brainvision('Scan_2_EPI_MB.vhdr')
custom_montage = mne.channels.read_custom_montage('BC-MR-32-X3.bvef')
```