### PR TITLE
WIP, ENH: Nicer ProgressBar

### DIFF
--- a/mne/utils/progressbar.py
+++ b/mne/utils/progressbar.py
@@ -38,8 +38,6 @@ class ProgressBar(object):
         This does not include characters used for the message or percent
         complete. Can be "auto" (default) to try to set a sane value based
         on the terminal width.
-    progress_character : char
-        Character in the progress bar that indicates the portion completed.
     spinner : bool
         Show a spinner.  Useful for long-running processes that may not
         increment the progress bar very often.  This provides the user with
@@ -49,28 +47,14 @@ class ProgressBar(object):
         a sane value based on the current terminal width.
     verbose_bool : bool | 'auto'
         If True, show progress. 'auto' will use the current MNE verbose level.
-
-    Examples
-    --------
-    >>> progress = ProgressBar(13000)
-    >>> progress.update(3000) # doctest: +SKIP
-    [.........                               ] 23.07692 |
-    >>> progress.update(6000) # doctest: +SKIP
-    [..................                      ] 46.15385 |
-
-    >>> progress = ProgressBar(13000, spinner=True)
-    >>> progress.update(3000) # doctest: +SKIP
-    [.........                               ] 23.07692 |
-    >>> progress.update(6000) # doctest: +SKIP
-    [..................                      ] 46.15385 /
     """
 
     spinner_symbols = ['|', '/', '-', '\\']
-    template = '\r[{0}{1}] {2} {3} {4}'
+    template = '\r{2}▕{0}{1}▏{3} {4}'
 
     def __init__(self, max_value, initial_value=0, mesg='', max_chars='auto',
-                 progress_character='.', spinner=False,
-                 max_total_width='auto', verbose_bool=True):  # noqa: D102
+                 spinner=False, max_total_width='auto',
+                 verbose_bool='auto'):  # noqa: D102
         self.cur_value = initial_value
         if isinstance(max_value, Iterable):
             self.max_value = len(max_value)
@@ -79,7 +63,6 @@ class ProgressBar(object):
             self.max_value = max_value
             self.iterable = None
         self.mesg = mesg
-        self.progress_character = progress_character
         self.spinner = spinner
         self.spinner_index = 0
         self.n_spinner = len(self.spinner_symbols)
@@ -141,16 +124,22 @@ class ProgressBar(object):
         # The \r tells the cursor to return to the beginning of the line rather
         # than starting a new line.  This allows us to have a progressbar-style
         # display in the console window.
-        progress = '%6.02f%%' % (progress * 100,)
+        progress = '%5.01f%%' % (progress * 100,)
         progress = progress if self.cur_value <= max_value else 'unknown'
-        bar = self.template.format(
-            self.progress_character * num_chars, ' ' * num_left,
-            progress, self.mesg, self.spinner_symbols[self.spinner_index])
+        if self.spinner:
+            spinner = self.spinner_symbols[self.spinner_index]
+        else:
+            spinner = ''
+        bar = self.template.format('█' * num_chars, '░' * num_left,
+                                   progress, self.mesg, spinner)
         bar = bar[:self.max_total_width]
         # Force a flush because sometimes when using bash scripts and pipes,
         # the output is not printed until after the program exits.
         if self._do_print:
-            sys.stdout.write(bar)
+            try:
+                sys.stdout.buffer.write(bar.encode('utf-8'))
+            except AttributeError:
+                sys.stdout.write(bar)
             sys.stdout.flush()
         # Increment the spinner
         if self.spinner:
@@ -186,7 +175,7 @@ class ProgressBar(object):
 
         Parameters
         ----------
-        seq : iterable
+        seq : ndarray
             The sequence.
         """
         while True:
@@ -257,7 +246,4 @@ class _PBSubsetUpdater(object):
 
 def _get_terminal_width():
     """Get the terminal width."""
-    if sys.version[0] == '2':
-        return 80
-    else:
-        return shutil.get_terminal_size((80, 20)).columns
+    return shutil.get_terminal_size((80, 20)).columns

--- a/mne/utils/tests/test_progressbar.py
+++ b/mne/utils/tests/test_progressbar.py
@@ -37,7 +37,7 @@ def test_progressbar_parallel_basic(capsys):
                                        verbose=True)
     out = parallel(p_fun(x) for x in range(10))
     assert out == list(range(10))
-    assert '100.00%' in capsys.readouterr().out
+    assert '100.0%' in capsys.readouterr().out
 
 
 def _identity_block(x, pb):
@@ -63,7 +63,7 @@ def test_progressbar_parallel_advanced(capsys):
     assert not op.isfile(pb._mmap_fname), '__exit__ not called?'
     out = np.concatenate(out)
     assert_array_equal(out, arr)
-    assert '100.00%' in capsys.readouterr().out
+    assert '100.0%' in capsys.readouterr().out
 
 
 def _identity_block_wide(x, pb):
@@ -91,4 +91,4 @@ def test_progressbar_parallel_more(capsys):
                          shape=len(arr) * 2).sum()
         assert sum_ == len(arr) * 2
     assert not op.isfile(pb._mmap_fname), '__exit__ not called?'
-    assert '100.00%' in capsys.readouterr().out
+    assert '100.0%' in capsys.readouterr().out


### PR DESCRIPTION
Using the [snippet from 7155](https://github.com/mne-tools/mne-python/pull/7155#issuecomment-594819745) on `master` we get:
```
Downloading https://github.com/mne-tools/mne-python/blob/master/README.rst (0 bytes)
[............................................................] unknown (   75 kB,    74 kB/s) |
File saved as /tmp/null.

[............................................................] 100.00% Finding flat segments /
Marking 0.01% of time points (3 segments) and 0/364 channels bad: []
[............................................................] 100.00% Fitting GeneralizingEstimator |
[............................................................] 100.00% Scoring GeneralizingEstimator |
```
This PR adds to / changes our code to look better:
```
Downloading https://github.com/mne-tools/mne-python/blob/master/README.rst (0 bytes)
unknown▕████████████████████████████████████████████████████████████▏(   75 kB,    74 kB/s) |
File saved as /tmp/null.

100.00%▕████████████████████████████████████████████████████████████▏Finding flat segments /
Marking 0.01% of time points (3 segments) and 0/364 channels bad: []
100.0%▕████████████████████████████████████████████████████████████▏Fitting GeneralizingEstimator 
100.0%▕████████████████████████████████████████████████████████████▏Scoring GeneralizingEstimator
```
And #7155 offloads the work to tqdm to achieve:
```
Downloading https://github.com/mne-tools/mne-python/blob/master/README.rst (0 bytes)
  0%|                                                                                    |  : 75.3k/0.00 [00:00<00:00,     576kB/s]
File saved as /tmp/null.

Finding flat segments
100%|███████████████████████████████████████████████████████████████████████████████| Channels : 364/364 [00:00<00:00, 2995.46it/s]
Marking 0.01% of time points (3 segments) and 0/364 channels bad
100%|██████████████████████████████████████████████████████████| Fitting GeneralizingEstimator : 106/106 [00:03<00:00,   34.89it/s]
100%|██████████████████████████████████████████████████████| Scoring GeneralizingEstimator : 11236/11236 [00:18<00:00,  598.40it/s]
```
Either this or #7155 should be merged before 0.20.