### PR TITLE
DOC: improve docstring for extract_label_time_course

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -323,7 +323,7 @@ intersphinx_mapping = {
     'surfer': ('https://pysurfer.github.io/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
     'seaborn': ('https://seaborn.pydata.org/', None),
-    'statsmodels': ('http://www.statsmodels.org/dev', None),
+    'statsmodels': ('https://www.statsmodels.org/dev', None),
     'patsy': ('https://patsy.readthedocs.io/en/latest', None),
     # There are some problems with dipy's redirect:
     # https://github.com/nipy/dipy/issues/1955

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1566,7 +1566,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
 
         Notes
         -----
-        @(eltc_mode_notes)s
+        %(eltc_mode_notes)s
         """
         label_tc = extract_label_time_course(
             self, labels, src, mode=mode, return_generator=False,
@@ -2835,7 +2835,7 @@ def extract_label_time_course(stcs, labels, src, mode='mean_flip',
 
     Notes
     -----
-    @(eltc_mode_notes)s
+    %(eltc_mode_notes)s
 
     If encountering a ``ValueError`` due to mismatch between number of
     source points in the subject source space and computed ``stc`` object set

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1549,15 +1549,10 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
 
         Parameters
         ----------
-        labels : Label | BiHemiLabel | list of Label or BiHemiLabel
-            The labels for which to extract the time courses.
-        src : list
-            Source spaces for left and right hemisphere.
-        mode : str
-            Extraction mode, see explanation below.
-        allow_empty : bool
-            Instead of emitting an error, return all-zero time course for
-            labels that do not have any vertices in the source estimate.
+        %(eltc_labels)s
+        %(eltc_src)s
+        %(eltc_mode)s
+        %(eltc_allow_empty)s
         %(verbose_meth)s
 
         Returns
@@ -1571,26 +1566,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
 
         Notes
         -----
-        Valid values for mode are:
-
-        - 'mean'
-              Average within each label.
-        - 'mean_flip'
-              Average within each label with sign flip depending
-              on source orientation.
-        - 'pca_flip'
-              Apply an SVD to the time courses within each label
-              and use the scaled and sign-flipped first right-singular vector
-              as the label time course. The scaling is performed such that the
-              power of the label time course is the same as the average
-              per-vertex time course power within the label. The sign of the
-              resulting time course is adjusted by multiplying it with
-              "sign(dot(u, flip))" where u is the first left-singular vector,
-              and flip is a sing-flip vector based on the vertex normals. This
-              procedure assures that the phase does not randomly change by 180
-              degrees from one stc to the next.
-        - 'max'
-              Max value within each label.
+        @(eltc_mode_notes)s
         """
         label_tc = extract_label_time_course(
             self, labels, src, mode=mode, return_generator=False,
@@ -2844,15 +2820,10 @@ def extract_label_time_course(stcs, labels, src, mode='mean_flip',
     ----------
     stcs : SourceEstimate | list (or generator) of SourceEstimate
         The source estimates from which to extract the time course.
-    labels : Label | BiHemiLabel | list of Label or BiHemiLabel
-        The labels for which to extract the time course.
-    src : list
-        Source spaces for left and right hemisphere.
-    mode : str
-        Extraction mode, see explanation above.
-    allow_empty : bool
-        Instead of emitting an error, return all-zero time courses for labels
-        that do not have any vertices in the source estimate.
+    %(eltc_labels)s
+    %(eltc_src)s
+    %(eltc_mode)s
+    %(eltc_allow_empty)s
     return_generator : bool
         If True, a generator instead of a list is returned.
     %(verbose)s
@@ -2864,26 +2835,7 @@ def extract_label_time_course(stcs, labels, src, mode='mean_flip',
 
     Notes
     -----
-    Valid values for mode are:
-
-    ``'mean'``
-        Average within each label.
-    ``'mean_flip'``
-        Average within each label with sign flip depending
-        on source orientation.
-    ``'pca_flip'``
-        Apply an SVD to the time courses within each label
-        and use the scaled and sign-flipped first right-singular vector
-        as the label time course. The scaling is performed such that the
-        power of the label time course is the same as the average
-        per-vertex time course power within the label. The sign of the
-        resulting time course is adjusted by multiplying it with
-        "sign(dot(u, flip))" where u is the first left-singular vector,
-        and flip is a sing-flip vector based on the vertex normals. This
-        procedure assures that the phase does not randomly change by 180
-        degrees from one stc to the next.
-    ``'max'``
-        Max value within each label.
+    @(eltc_mode_notes)s
 
     If encountering a ``ValueError`` due to mismatch between number of
     source points in the subject source space and computed ``stc`` object set

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -728,6 +728,50 @@ transparent : bool | None
     If True, use a linear transparency between fmin and fmid.
     None will choose automatically based on colormap type.
 """
+
+# STC label time course
+docdict['eltc_labels'] = """
+labels : Label | BiHemiLabel | list of Label or BiHemiLabel
+    The labels for which to extract the time course.
+"""
+docdict['eltc_src'] = """
+src : list
+    Source spaces for left and right hemisphere.
+"""
+docdict['eltc_mode'] = """
+mode : str
+    Extraction mode, see Notes.
+"""
+docdict['eltc_allow_empty'] = """
+allow_empty : bool
+    Instead of emitting an error, return all-zero time courses for labels
+    that do not have any vertices in the source estimate. Default is ``False``.
+"""
+docdict['eltc_mode_notes'] = """
+Valid values for ``mode`` are:
+
+``'max'``
+    Maximum value across vertices at each time point within each label.
+``'mean'``
+    Average across vertices at each time point within each label. Ignores
+    orientation of sources.
+``'mean_flip'``
+    Finds the dominant direction of source orientations within each label,
+    applies a sign-flip to time series at vertices whose orientation is more
+    than 180° different from the dominant direction, and then averages across
+    vertices at each time point within each label.
+``'pca_flip'``
+    Applies singular value decomposition to the time courses within each label,
+    and uses the first right-singular vector as the representative label time
+    course. This signal is scaled so that its power matches the average
+    (per-vertex) power within the label, and sign-flipped by multiplying by
+    ``np.sign(u @ flip)``, where ``u`` is the first left-singular vector and
+    ``flip`` is the same sign-flip vector used when ``mode='mean_flip'``. This
+    sign-flip ensures that extracting time courses from the same label in
+    similar STCs does not result in 180° direction/phase changes.
+"""
+
+
 # DataFrames
 docdict['df_scaling_time_deprecated'] = """
 scaling_time : None

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -756,10 +756,10 @@ Valid values for ``mode`` are:
     Average across vertices at each time point within each label. Ignores
     orientation of sources.
 ``'mean_flip'``
-    Finds the dominant direction of source orientations within each label,
-    applies a sign-flip to time series at vertices whose orientation is more
-    than 180° different from the dominant direction, and then averages across
-    vertices at each time point within each label.
+    Finds the dominant direction of source space normal vector orientations
+    within each label, applies a sign-flip to time series at vertices whose
+    orientation is more than 180° different from the dominant direction, and
+    then averages across vertices at each time point within each label.
 ``'pca_flip'``
     Applies singular value decomposition to the time courses within each label,
     and uses the first right-singular vector as the representative label time
@@ -770,7 +770,6 @@ Valid values for ``mode`` are:
     sign-flip ensures that extracting time courses from the same label in
     similar STCs does not result in 180° direction/phase changes.
 """
-
 
 # DataFrames
 docdict['df_scaling_time_deprecated'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -750,17 +750,17 @@ allow_empty : bool
 docdict['eltc_mode_notes'] = """
 Valid values for ``mode`` are:
 
-``'max'``
+- ``'max'``
     Maximum value across vertices at each time point within each label.
-``'mean'``
+- ``'mean'``
     Average across vertices at each time point within each label. Ignores
     orientation of sources.
-``'mean_flip'``
+- ``'mean_flip'``
     Finds the dominant direction of source space normal vector orientations
     within each label, applies a sign-flip to time series at vertices whose
     orientation is more than 180° different from the dominant direction, and
     then averages across vertices at each time point within each label.
-``'pca_flip'``
+- ``'pca_flip'``
     Applies singular value decomposition to the time courses within each label,
     and uses the first right-singular vector as the representative label time
     course. This signal is scaled so that its power matches the average


### PR DESCRIPTION
gives (hopefully) better explanation for the various `mode` options; converts func & method to use docdict along the way.