### PR TITLE
Fix EDF lowpass filter value of 0Hz

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -485,7 +485,7 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
     if lowpass.size == 0:
         pass  # Placeholder for future use. Lowpass set in _empty_info.
     elif all(lowpass):
-        if lowpass[0] in ('NaN', '0'):
+        if lowpass[0] in ('NaN', '0', '0.0'):
             pass  # Placeholder for future use. Lowpass set in _empty_info.
         else:
             info['lowpass'] = float(lowpass[0])

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -485,7 +485,7 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
     if lowpass.size == 0:
         pass  # Placeholder for future use. Lowpass set in _empty_info.
     elif all(lowpass):
-        if lowpass[0] == 'NaN':
+        if lowpass[0] in ('NaN', '0'):
             pass  # Placeholder for future use. Lowpass set in _empty_info.
         else:
             info['lowpass'] = float(lowpass[0])

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -13,7 +13,7 @@ import inspect
 
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
-                           assert_equal)
+                           assert_equal, assert_allclose)
 from scipy.io import loadmat
 
 import pytest
@@ -366,5 +366,7 @@ run_tests_if_main()
 @testing.requires_testing_data
 def test_edf_lowpass_zero():
     """Test if a lowpass filter of 0Hz is mapped to the Nyquist frequency."""
-    raw = read_raw_edf(edf_stim_resamp_path)
-    assert np.isclose(raw.info["lowpass"], raw.info["sfreq"] / 2)
+    with pytest.warns(RuntimeWarning, match='too long.*truncated'):
+        raw = read_raw_edf(edf_stim_resamp_path)
+    print(raw.info["lowpass"])
+    assert_allclose(raw.info["lowpass"], raw.info["sfreq"] / 2)

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -361,3 +361,10 @@ def test_bdf_multiple_annotation_channels():
 
 
 run_tests_if_main()
+
+
+@testing.requires_testing_data
+def test_edf_lowpass_zero():
+    """Test if a lowpass filter of 0Hz is mapped to the Nyquist frequency."""
+    raw = read_raw_edf(edf_stim_resamp_path)
+    assert np.isclose(raw.info["lowpass"], raw.info["sfreq"] / 2)

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -368,5 +368,4 @@ def test_edf_lowpass_zero():
     """Test if a lowpass filter of 0Hz is mapped to the Nyquist frequency."""
     with pytest.warns(RuntimeWarning, match='too long.*truncated'):
         raw = read_raw_edf(edf_stim_resamp_path)
-    print(raw.info["lowpass"])
     assert_allclose(raw.info["lowpass"], raw.info["sfreq"] / 2)


### PR DESCRIPTION
Fixes #7421.

I wanted to include a test, so I checked if an existing EDF file has a `LP: 0Hz` entry in its header. Indeed, it seems like `test_edf_stim_resamp.edf` does have this entry, but I get

```
RuntimeWarning: 24 channel names are too long, have been truncated to 15 characters:
['EEG LDAMT_01-REF', 'EEG LDAMT_02-REF', 'EEG LDAMT_03-REF', 'EEG LDAMT_04-REF', 'EEG LDAMT_05-REF', 'EEG LDAMT_06-REF', 'EEG LDAMT_07-REF', 'EEG LDAMT_08-REF', 'EEG LDPMT_01-REF', 'EEG LDPMT_02-REF', 'EEG LDPMT_03-REF', 'EEG LDPMT_04-REF', 'EEG LDPMT_05-REF', 'EEG LDPMT_06-REF', 'EEG LDPMT_07-REF', 'EEG LDPMT_08-REF', 'EEG RDAMT_01-REF', 'EEG RDAMT_02-REF', 'EEG RDAMT_03-REF', 'EEG RDAMT_04-REF', 'EEG RDAMT_05-REF', 'EEG RDAMT_06-REF', 'EEG RDAMT_07-REF', 'EEG RDAMT_08-REF']
```

Which means that I get a Pytest error for something else I don't even want to test. Any ideas how to prevent Pytest from converting the warning to an error?

Other than that, this fixes the bug and the test also covers this corner case.