### PR TITLE
Make current time window more obvious

### DIFF
--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -696,7 +696,7 @@ def _prepare_mne_browse_raw(params, title, bgcolor, color, bad_color, inds,
     hsel_patch = mpl.patches.Rectangle((params['t_start'], 0),
                                        params['duration'], 1, edgecolor='k',
                                        facecolor=(0.75, 0.75, 0.75),
-                                       alpha=0.25, linewidth=1, clip_on=False)
+                                       alpha=0.25, linewidth=4, clip_on=False)
     ax_hscroll.add_patch(hsel_patch)
     params['hsel_patch'] = hsel_patch
     ax_hscroll.set_xlim(params['first_time'], params['first_time'] +


### PR DESCRIPTION
It is hard to see the location of the currently visible time segment in the overview bar (x scroll bar), so I increased the line width.

Before:
<img width="1211" alt="before" src="https://user-images.githubusercontent.com/4377312/76532856-80063e00-6477-11ea-9087-a884a50e8386.png">

After:
<img width="1211" alt="after" src="https://user-images.githubusercontent.com/4377312/76532869-8694b580-6477-11ea-8527-37876857dda5.png">
