### PR TITLE
WIP, FIX: Offload filtering step for find_bad_channels_maxwell

### DIFF
--- a/mne/preprocessing/otp.py
+++ b/mne/preprocessing/otp.py
@@ -89,7 +89,7 @@ def oversampled_temporal_projection(raw, duration=10., picks=None,
 
     n_samp = int(round(float(duration) * raw.info['sfreq']))
     starts, stops, windows = _get_lims_cola(
-        n_samp, len(raw.times), raw.info['sfreq'], picks_good)
+        n_samp, len(raw.times), raw.info['sfreq'])
     min_samp = (stops - starts).min()
     if min_samp < len(picks_good) - 1:
         raise ValueError('duration (%s) yielded %s samples, which is fewer '

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1049,6 +1049,7 @@ def test_find_bad_channels_maxwell(bads):
     """Test automatic bad channel detection."""
     raw = mne.io.read_raw_fif(sample_fname, allow_maxshield='yes')
     raw.fix_mag_coil_types().load_data().pick_types(exclude=())
+    raw.filter(None, 40)
     raw.info['bads'] = bads
     # maxfilter -autobad on -v -f test_raw.fif -force -cal off -ctc off -regularize off -list -o test_raw.fif -f ~/mne_data/MNE-testing-data/MEG/sample/sample_audvis_trunc_raw.fif  # noqa: E501
     got_bads = find_bad_channels_maxwell(

--- a/mne/preprocessing/utils.py
+++ b/mne/preprocessing/utils.py
@@ -27,7 +27,7 @@ def check_cola(win, nperseg, noverlap, tol=1e-10):
     return np.max(np.abs(deviation)) < tol
 
 
-def _get_lims_cola(n_samp, n_times, sfreq, picks):
+def _get_lims_cola(n_samp, n_times, sfreq):
     from scipy.signal import get_window
     if n_samp > n_times:
         raise ValueError('Effective duration (%s) must be at most the '

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -98,7 +98,10 @@ crosstalk_file = os.path.join(sample_data_folder, 'SSS', 'ct_sparse_mgh.fif')
 #     bad channel noise from spreading.
 #
 # Let's see if we can automatically detect it. To do this we need to
-# operate on a low-passed signal:
+# operate on a signal without line noise or cHPI signals, which is most
+# easily achieved using :func:`mne.chpi.filter_chpi`,
+# :func:`mne.io.Raw.notch_filter`, or :meth:`mne.io.Raw.filter`. For simplicity
+# we just low-pass filter these data:
 
 raw.info['bads'] = []
 raw_check = raw.copy().pick_types(exclude=()).filter(None, 40)


### PR DESCRIPTION
Moves the filtering step out of `find_bad_channels_maxwell`. This makes our outputs differ from MaxFilter a bit more, but:

1. It is better in principle (and practice) to filter all the data, then process in chunks, rather than filter each chunk independently (more edge artifacts)
2. By moving the filtering out of the function, it allows the user to choose the filtering tradeoffs
3. Based on inspecting the results with @hoechenberger , it seems like we do at least as well on this PR as we do in `master`

This PR also make a couple of tweaks found while working on this:

1. Improves `verbose=True` and `verbose='debug'` output messaging
2. Cleans up how `raw.plot` filtering triages FIR vs IIR to match what `mne/filter.py` does (leads to better `padlen` in `raw.plot`)
3. Cleans up unused var in `_get_lims_cola`

WIP for now while @hoechenberger and I test a bit more.