### PR TITLE
MRG, ENH: Better introspection for optimization

### DIFF
--- a/mne/externals/decorator.py
+++ b/mne/externals/decorator.py
@@ -40,9 +40,9 @@ import operator
 import itertools
 import collections
 
-__version__ = '4.3.2'
+__version__ = '4.4.2'
 
-if sys.version >= '3':
+if sys.version_info >= (3,):
     from inspect import getfullargspec
 
     def get_init(cls):
@@ -179,8 +179,7 @@ class FunctionMaker(object):
         # Ensure each generated function has a unique filename for profilers
         # (such as cProfile) that depend on the tuple of (<filename>,
         # <definition line>, <function name>) being unique.
-        filename = '<%s:decorator-gen-%d>' % (
-            __file__, next(self._compile_count))
+        filename = '<decorator-gen-%d>' % next(self._compile_count)
         try:
             code = compile(src, filename, 'single')
             exec(code, evaldict)
@@ -284,12 +283,12 @@ def decorator(caller, _func=None):
         doc = caller.__call__.__doc__
     evaldict = dict(_call=caller, _decorate_=decorate)
     dec = FunctionMaker.create(
-        '%s(%s func)' % (name, defaultargs),
+        '%s(func, %s)' % (name, defaultargs),
         'if func is None: return lambda func:  _decorate_(func, _call, (%s))\n'
         'return _decorate_(func, _call, (%s))' % (defaultargs, defaultargs),
         evaldict, doc=doc, module=caller.__module__, __wrapped__=caller)
     if defaults:
-        dec.__defaults__ = defaults + (None,)
+        dec.__defaults__ = (None,) + defaults
     return dec
 
 

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -2287,7 +2287,6 @@ class _Interp2(object):
 
     """
 
-    @verbose
     def __init__(self, interp='hann'):
         # set up interpolation
         self._last = dict()

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1816,7 +1816,7 @@ def _do_forward_solution(subject, meas, fname=None, src=None, spacing=None,
 
 
 @verbose
-def average_forward_solutions(fwds, weights=None):
+def average_forward_solutions(fwds, weights=None, verbose=None):
     """Average forward solutions.
 
     Parameters
@@ -1828,6 +1828,7 @@ def average_forward_solutions(fwds, weights=None):
         Weights to apply to each forward solution in averaging. If None,
         forward solutions will be equally weighted. Weights must be
         non-negative, and will be adjusted to sum to one.
+    %(verbose)s
 
     Returns
     -------

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -30,7 +30,6 @@ def _check_ori(pick_ori, forward):
                          'orientation forward solution.')
 
 
-@verbose
 def _prepare_weights(forward, gain, source_weighting, weights, weights_min):
     mask = None
     if isinstance(weights, _BaseSourceEstimate):

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -295,6 +295,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         # most classes only store real data, they won't need anything special
         return self._dtype_
 
+    @verbose
     def _read_segment(self, start=0, stop=None, sel=None, data_buffer=None,
                       projector=None, verbose=None):
         """Read a chunk of raw data.
@@ -728,8 +729,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             data = self._data[sel, start:stop]
         else:
             data = self._read_segment(start=start, stop=stop, sel=sel,
-                                      projector=self._projector,
-                                      verbose=self.verbose)
+                                      projector=self._projector)
         times = self.times[start:stop]
         return data, times
 
@@ -836,7 +836,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
     @verbose
     def apply_function(self, fun, picks=None, dtype=None, n_jobs=1,
-                       channel_wise=True, *args, **kwargs):
+                       channel_wise=True, verbose=None, *args, **kwargs):
         """Apply a function to a subset of channels.
 
         The function "fun" is applied to the channels defined in "picks". The
@@ -876,14 +876,12 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             False, the function will be applied to all channels at once.
 
             .. versionadded:: 0.18
+        %(verbose_meth)s
         *args : list
             Additional positional arguments to pass to fun (first pos. argument
             of fun is the timeseries of a channel).
         **kwargs : dict
-            Keyword arguments to pass to fun. Note that if "verbose" is passed
-            as a member of ``kwargs``, it will be consumed and will override
-            the default mne-python verbose level (see :func:`mne.verbose` and
-            :ref:`Logging documentation <tut_logging>` for more).
+            Keyword arguments to pass to fun.
 
         Returns
         -------

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -8,7 +8,7 @@ from os import path
 
 import numpy as np
 
-from ...utils import warn, verbose, fill_doc, _check_option
+from ...utils import warn, fill_doc, _check_option
 from ...channels.layout import _topo_to_sphere
 from ..constants import FIFF
 from ..utils import (_mult_cal_one, _find_channels, _create_chs, read_str)
@@ -398,7 +398,6 @@ class RawCNT(BaseRaw):
         self.set_annotations(
             _read_annotations_cnt(input_fname, data_format=data_format))
 
-    @verbose
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Take a chunk of raw data, multiply by mult or cals, and store."""
         if 'stim_channel' in self._raw_extras[0]:

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -155,7 +155,6 @@ class RawCTF(BaseRaw):
         if clean_names:
             self._clean_names()
 
-    @verbose
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
         si = self._raw_extras[fi]

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -133,7 +133,6 @@ class RawEDF(BaseRaw):
         self.set_annotations(Annotations(onset=onset, duration=duration,
                                          description=desc, orig_time=None))
 
-    @verbose
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
         return _read_segment_file(data, idx, fi, start, stop,
@@ -204,7 +203,6 @@ class RawGDF(BaseRaw):
         self.set_annotations(Annotations(onset=onset, duration=duration,
                                          description=desc, orig_time=None))
 
-    @verbose
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
         return _read_segment_file(data, idx, fi, start, stop,

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -229,7 +229,6 @@ class RawKIT(BaseRaw):
         self._raw_extras[0]['stim'] = stim
         self._raw_extras[0]['stim_code'] = stim_code
 
-    @verbose
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
         nchan = self._raw_extras[fi]['nchan']

--- a/mne/minimum_norm/spatial_resolution.py
+++ b/mne/minimum_norm/spatial_resolution.py
@@ -15,7 +15,7 @@ from mne.utils import logger, verbose
 
 @verbose
 def resolution_metrics(resmat, src, function='psf', metric='peak_err',
-                       threshold=0.5):
+                       threshold=0.5, verbose=None):
     """Compute spatial resolution metrics for linear solvers.
 
     Parameters
@@ -45,7 +45,7 @@ def resolution_metrics(resmat, src, function='psf', metric='peak_err',
         Spatial-extent-based metrics:
 
         - ``'sd_ext'`` spatial deviation (e.g. [1,2]_).
-        - ``'maxrad_ext'`` maximum radius to 50% of max amplitude.
+        - ``'maxrad_ext'`` maximum radius to 50%% of max amplitude.
 
         Amplitude-based metrics:
 
@@ -56,6 +56,7 @@ def resolution_metrics(resmat, src, function='psf', metric='peak_err',
     threshold : float
         Amplitude fraction threshold for spatial extent metric 'maxrad_ext'.
         Defaults to 0.5.
+    %(verbose)s
 
     Returns
     -------

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1554,7 +1554,7 @@ class ICA(ContainsMixin):
         return data
 
     @verbose
-    def save(self, fname):
+    def save(self, fname, verbose=None):
         """Store ICA solution into a fiff file.
 
         Parameters
@@ -1562,6 +1562,7 @@ class ICA(ContainsMixin):
         fname : str
             The absolute path of the file name to save the ICA solution into.
             The file name should end with -ica.fif or -ica.fif.gz.
+        %(verbose_meth)s
 
         Returns
         -------

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -2721,8 +2721,7 @@ def morph_source_spaces(src_from, subject_to, surf='white', subject_from=None,
                   rr=to['rr'] / 1000.)
         src_out.append(to)
         logger.info('[done]\n')
-    info = dict(working_dir=os.getcwd(),
-                command_line=_get_call_line(in_verbose=True))
+    info = dict(working_dir=os.getcwd(), command_line=_get_call_line())
     return SourceSpaces(src_out, info=info)
 
 

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -20,13 +20,13 @@ from .check import (check_fname, check_version, check_random_state,
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,
-                     _get_call_line, _get_numpy_libs)
+                     _get_numpy_libs)
 from .docs import (copy_function_doc_to_method_doc, copy_doc, linkcode_resolve,
                    open_docs, deprecated, fill_doc, copy_base_doc_to_subclass_doc)
 from .fetching import _fetch_file, _url_to_local_path
 from ._logging import (verbose, logger, set_log_level, set_log_file,
                        use_log_level, catch_logging, warn, filter_out_warnings,
-                       ETSContext, wrapped_stdout)
+                       ETSContext, wrapped_stdout, _get_call_line)
 from .misc import (run_subprocess, _pl, _clean_names, pformat, _file_like,
                    _explain_exception, _get_argvalues, sizeof_fmt,
                    running_subprocess, _DefaultEventParser)

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -69,7 +69,7 @@ def verbose(function):
     wrap_src = """\
 try:
     verbose
-except NameError:
+except (NameError, UnboundLocalError):
     verbose = None
 if verbose is None:
     try:

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -67,6 +67,10 @@ def verbose(function):
         pass
 
     wrap_src = """\
+try:
+    verbose
+except NameError:
+    verbose = None
 if verbose is None:
     try:
         verbose = self.verbose

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -541,7 +541,7 @@ def _get_call_line(in_verbose=False):
     # function or not.
     # NB This probably only works for functions that are undecorated,
     # or decorated by `verbose`.
-    back = 2 if not in_verbose else 4
+    back = 2 if not in_verbose else 3
     call_frame = inspect.getouterframes(inspect.currentframe())[back][0]
     context = inspect.getframeinfo(call_frame).code_context
     context = 'unknown' if context is None else context[0].strip()

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -6,7 +6,6 @@
 
 import atexit
 from functools import partial
-import inspect
 import json
 import os
 import os.path as op
@@ -533,16 +532,3 @@ def sys_info(fid=None, show_paths=False):
                 version = mod.__version__
             out += '%s%s\n' % (version, extra)
     print(out, end='', file=fid)
-
-
-def _get_call_line(in_verbose=False):
-    """Get the call line from within a function."""
-    # XXX Eventually we could auto-triage whether in a `verbose` decorated
-    # function or not.
-    # NB This probably only works for functions that are undecorated,
-    # or decorated by `verbose`.
-    back = 2 if not in_verbose else 3
-    call_frame = inspect.getouterframes(inspect.currentframe())[back][0]
-    context = inspect.getframeinfo(call_frame).code_context
-    context = 'unknown' if context is None else context[0].strip()
-    return context

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -261,12 +261,12 @@ def _clean_names(names, remove_whitespace=False, before_dash=True):
 def _get_argvalues():
     """Return all arguments (except self) and values of read_raw_xxx."""
     # call stack
-    # read_raw_xxx -> EOF -> verbose() -> BaseRaw.__init__ -> get_argvalues
+    # read_raw_xxx -> <decorator-gen-000> -> BaseRaw.__init__ -> _get_argvalues
 
     # This is equivalent to `frame = inspect.stack(0)[4][0]` but faster
     frame = inspect.currentframe()
     try:
-        for _ in range(4):
+        for _ in range(3):
             frame = frame.f_back
         fname = frame.f_code.co_filename
         if not fnmatch.fnmatch(fname, '*/mne/io/*'):

--- a/mne/utils/tests/test_config.py
+++ b/mne/utils/tests/test_config.py
@@ -3,8 +3,7 @@ import os
 import pytest
 
 from mne.utils import (set_config, get_config, get_config_path,
-                       set_memmap_min_size, _get_stim_channel, sys_info,
-                       verbose, _get_call_line)
+                       set_memmap_min_size, _get_stim_channel, sys_info)
 
 
 def test_config(tmpdir):
@@ -76,20 +75,3 @@ def test_sys_info():
     sys_info(fid=out)
     out = out.getvalue()
     assert ('numpy:' in out)
-
-
-def test_get_call_line():
-    """Test getting a call line."""
-    @verbose
-    def foo(verbose=None):
-        return _get_call_line(in_verbose=True)
-
-    for v in (None, True):
-        my_line = foo(verbose=v)  # testing
-        assert my_line == 'my_line = foo(verbose=v)  # testing'
-
-    def bar():
-        return _get_call_line(in_verbose=False)
-
-    my_line = bar()  # testing more
-    assert my_line == 'my_line = bar()  # testing more'


### PR DESCRIPTION
Simplifies our `verbose` wrapping a little bit. Checked that `import mne` times are unchaged. Achieves a couple of things:

1. Cleans up tracebacks by removing one level of depth.
    <details>

    master
    ```
    larsoner@bunk:~/Desktop/richard$ python -ui find_bads.py 
    ^CTraceback (most recent call last):
      File "find_bads.py", line 21, in <module>
        test()
      File "find_bads.py", line 14, in test
        bads = mne.preprocessing.find_bad_channels_maxwell(
      File "</home/larsoner/python/mne-python/mne/externals/decorator.py:decorator-gen-373>", line 2, in find_bad_channels_maxwell
      File "/home/larsoner/python/mne-python/mne/utils/_logging.py", line 89, in wrapper
        return function(*args, **kwargs)
      File "/home/larsoner/python/mne-python/mne/preprocessing/maxwell.py", line 1901, in 
    find_bad_channels_maxwell
        time.sleep(60)
    KeyboardInterrupt
    ```
    PR
    ```
    larsoner@bunk:~/Desktop/richard$ python -ui find_bads.py 
    ^CTraceback (most recent call last):
      File "find_bads.py", line 21, in <module>
        test()
      File "find_bads.py", line 14, in test
        bads = mne.preprocessing.find_bad_channels_maxwell(
      File "<decorator-gen-373>", line 9, in find_bad_channels_maxwell
      File "/home/larsoner/python/mne-python/mne/preprocessing/maxwell.py", line 1901, in find_bad_channels_maxwell
        time.sleep(60)
    KeyboardInterrupt
    ```
    </details>

2. Simplifies `verbose` code (see changes).

3. Improves `snakeviz`:
    <details>

     master has a nasty recursion/repetition going on (note what I moused over to make pink shows up multiple places). It makes it hard to see what is actually taking time, and also snakeviz/the browser struggles to render the default 1/1000 limit:
    ![Screenshot from 2020-03-12 13-39-56](https://user-images.githubusercontent.com/2365790/76550767-09624400-6469-11ea-9232-7a421ed87915.png)


    PR does not have this issue:
    ![Screenshot from 2020-03-12 13-40-10](https://user-images.githubusercontent.com/2365790/76550752-036c6300-6469-11ea-87ae-3cad555f8631.png)

4. I've always struggled to use `lprof` with `verbose` decorated functions because they are wrapped. With this PR you can just use `__wrapped__` and it works:
    ```
    lprun -f find_bad_channels_maxwell.__wrapped__ test()
    ```

5. Updates our `externals/decorator.py` with the latest version. Not necessary for functionality but might as well be done to get any bug fixes.