### PR TITLE
MNT: Exclude pytest 5.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_install:
         fi;
       fi
     # Always install these via pip so we get the latest possible versions (testing bugfixes)
-    - pip install --upgrade pytest pytest-sugar pytest-cov pytest-mock pytest-timeout codecov
+    - pip install --upgrade pytest!=5.4.0 pytest-sugar pytest-cov pytest-mock pytest-timeout codecov
     - if [ "${DEPS}" != "minimal" ]; then
         pip install nitime;
       fi

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
 - pillow
 - statsmodels
 - jupyter
-- pytest
+- pytest!=5.4.0
 - pytest-cov
 - pytest-mock
 - pytest-timeout

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pandas
 numexpr
 python-picard
 statsmodels
-pytest!=4.6.0
+pytest!=4.6.0,!=5.4.0
 pytest-cov
 pytest-faulthandler
 pytest-mock


### PR DESCRIPTION
This PR skips `pytest 5.4.0` because of the issues with `pytest-sugar`.

Closes https://github.com/mne-tools/mne-python/issues/7437