### PR TITLE
Shorten repr of Annotations if necessary

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -206,7 +206,7 @@ class Annotations(object):
     def __repr__(self):
         """Show the representation."""
         counter = collections.Counter(self.description)
-        kinds = ', '.join(['%s (%s)' % k for k in counter.items()])
+        kinds = ', '.join(['%s (%s)' % k for k in sorted(counter.items())])
         kinds = (': ' if len(kinds) > 0 else '') + kinds
         s = ('Annotations  |  %s segment%s%s' %
              (len(self.onset), _pl(len(self.onset)), kinds))

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from itertools import takewhile
 import collections
 import warnings
+from textwrap import shorten
 import numpy as np
 
 from .utils import (_pl, check_fname, _validate_type, verbose, warn, logger,
@@ -205,15 +206,11 @@ class Annotations(object):
     def __repr__(self):
         """Show the representation."""
         counter = collections.Counter(self.description)
-        kinds = ['%s (%s)' % k for k in counter.items()]
-        kinds = ', '.join(kinds[:3]) + ('' if len(kinds) <= 3 else '...')
+        kinds = ', '.join(['%s (%s)' % k for k in counter.items()])
         kinds = (': ' if len(kinds) > 0 else '') + kinds
-        if self.orig_time is None:
-            orig = 'orig_time : None'
-        else:
-            orig = 'orig_time : %s' % self.orig_time
-        return ('<Annotations  |  %s segment%s %s, %s>'
-                % (len(self.onset), _pl(len(self.onset)), kinds, orig))
+        s = ('Annotations  |  %s segment%s%s' %
+             (len(self.onset), _pl(len(self.onset)), kinds))
+        return '<' + shorten(s, width=77, placeholder=' ...') + '>'
 
     def __len__(self):
         """Return the number of annotations."""

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1189,4 +1189,21 @@ def test_annotations_from_events():
     assert len(annots) == events[events[:, 2] <= 3].shape[0]
 
 
+def test_repr():
+    """Test repr of Annotations."""
+
+    # short annotation repr (< 79 characters)
+    r = repr(Annotations(range(3), [0] * 3, list("abc")))
+    assert r == '<Annotations | 3 segments: a (1), b (1), c (1)>'
+
+    # long annotation repr (> 79 characters, will be shortened)
+    r = repr(Annotations(range(14), [0] * 14, list("abcdefghijklmn")))
+    assert r == ('<Annotations | 14 segments: a (1), b (1), c (1), d (1), '
+                 'e (1), f (1), g ...>')
+
+    # empty Annotations
+    r = repr(Annotations([], [], []))
+    assert r == '<Annotations | 0 segments>'
+
+
 run_tests_if_main()


### PR DESCRIPTION
Fixes #7429.

Before (94 characters):
```
<Annotations  |  14 segments : a (1), b (1), c (1)..., orig_time : 2013-11-04 14:35:26.150000>
```

After (76 characters):
```
<Annotations | 14 segments: a (1), b (1), c (1), d (1), e (1), f (1), g ...>
```

