### PR TITLE
[MRG] Shorter raw repr

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -208,7 +208,7 @@ class Annotations(object):
         counter = collections.Counter(self.description)
         kinds = ', '.join(['%s (%s)' % k for k in sorted(counter.items())])
         kinds = (': ' if len(kinds) > 0 else '') + kinds
-        s = ('Annotations  |  %s segment%s%s' %
+        s = ('Annotations | %s segment%s%s' %
              (len(self.onset), _pl(len(self.onset)), kinds))
         return '<' + shorten(s, width=77, placeholder=' ...') + '>'
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1596,10 +1596,10 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
     def __repr__(self):  # noqa: D105
         name = self.filenames[0]
-        name = 'None' if name is None else op.basename(name)
+        name = '' if name is None else op.basename(name) + ', '
         size_str = str(sizeof_fmt(self._size))  # str in case it fails -> None
         size_str += ', data%s loaded' % ('' if self.preload else ' not')
-        s = ('%s, n_channels x n_times : %s x %s (%0.1f sec), ~%s'
+        s = ('%s%s x %s (%0.1f s), ~%s'
              % (name, len(self.ch_names), self.n_times, self.times[-1],
                 size_str))
         return "<%s  |  %s>" % (self.__class__.__name__, s)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1602,7 +1602,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         s = ('%s%s x %s (%0.1f s), ~%s'
              % (name, len(self.ch_names), self.n_times, self.times[-1],
                 size_str))
-        return "<%s  |  %s>" % (self.__class__.__name__, s)
+        return "<%s | %s>" % (self.__class__.__name__, s)
 
     def add_events(self, events, stim_channel=None, replace=False):
         """Add events to stim channel.

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -327,3 +327,13 @@ def test_5839():
     assert_array_equal(raw_A.annotations.duration, EXPECTED_DURATION)
     assert_array_equal(raw_A.annotations.description, EXPECTED_DESCRIPTION)
     assert raw_A.annotations.orig_time == _stamp_to_dt((0, 0))
+
+
+def test_repr():
+    """Test repr of Raw."""
+
+    fs = 256
+    ch_names = ["C3", "Cz", "C4"]
+    info = create_info(ch_names, sfreq=fs)
+    r = repr(RawArray(np.zeros((len(ch_names), 10 * fs)), info))
+    assert r == '<RawArray | 3 x 2560 (10.0 s), ~70 kB, data loaded>'

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -7,6 +7,7 @@
 
 from os import path as op
 import math
+import re
 
 import pytest
 import numpy as np
@@ -331,9 +332,8 @@ def test_5839():
 
 def test_repr():
     """Test repr of Raw."""
-
-    fs = 256
-    ch_names = ["C3", "Cz", "C4"]
-    info = create_info(ch_names, sfreq=fs)
-    r = repr(RawArray(np.zeros((len(ch_names), 10 * fs)), info))
-    assert r == '<RawArray | 3 x 2560 (10.0 s), ~70 kB, data loaded>'
+    sfreq = 256
+    info = create_info(3, sfreq)
+    r = repr(RawArray(np.zeros((3, 10 * sfreq)), info))
+    assert re.search('<RawArray | 3 x 2560 (10.0 s), ~.* kB, data loaded>',
+                     r) is not None, r

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1191,7 +1191,6 @@ def test_annotations_from_events():
 
 def test_repr():
     """Test repr of Annotations."""
-
     # short annotation repr (< 79 characters)
     r = repr(Annotations(range(3), [0] * 3, list("abc")))
     assert r == '<Annotations | 3 segments: a (1), b (1), c (1)>'


### PR DESCRIPTION
Just like #7441 did for `Annotations`, this PR makes the repr of `Raw` objects a bit shorter.

Before (93 characters):
```
<RawEDF  |  S001R04.edf, n_channels x n_times : 64 x 20000 (125.0 sec), ~9.9 MB, data loaded>
```

After (68 characters):

```
<RawEDF  |  S001R04.edf, 64 x 20000 (125.0 s), ~9.9 MB, data loaded>
```