### PR TITLE
Don't use pytest 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_install:
         fi;
       fi
     # Always install these via pip so we get the latest possible versions (testing bugfixes)
-    - pip install --upgrade pytest!=5.4.0 pytest-sugar pytest-cov pytest-mock pytest-timeout codecov
+    - pip install --upgrade "pytest<5.4" pytest-sugar pytest-cov pytest-mock pytest-timeout codecov
     - if [ "${DEPS}" != "minimal" ]; then
         pip install nitime;
       fi

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
 - pillow
 - statsmodels
 - jupyter
-- pytest!=5.4.0
+- pytest<5.4
 - pytest-cov
 - pytest-mock
 - pytest-timeout

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pandas
 numexpr
 python-picard
 statsmodels
-pytest!=4.6.0,!=5.4.0
+pytest!=4.6.0,<5.4
 pytest-cov
 pytest-faulthandler
 pytest-mock


### PR DESCRIPTION
Pytest 5.4.1 is out and we didn't exclude it (still not working).