### PR TITLE
MRG, ENH: Raw data reading refactor

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -91,6 +91,8 @@ Changelog
 
 - Speed up :func:`mne.make_forward_solution` using Numba, by `Eric Larson`_
 
+- Speed up :func:`mne.io.read_raw_fif` data reading when the recording is long and there are many data tags repeatedly accessed, by `Eric Larson`_
+
 - For KIT systems without built-in layout, :func:`mne.channels.find_layout` now falls back on an automatically generated layout, by `Christian Brodbeck`_
 
 - :meth:`mne.Epochs.plot` now takes a ``epochs_colors`` parameter to color specific epoch segments by `Mainak Jas`_

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -340,7 +340,8 @@ class Raw(BaseRaw):
             use = (stop > bounds[:-1]) & (start < bounds[1:])
             offset = 0
             for ei in np.where(use)[0]:
-                first, last = bounds[ei:ei + 2]
+                first = bounds[ei]
+                last = bounds[ei + 1]
                 nsamp = last - first
                 ent = ents[ei]
                 first_pick = max(start - first, 0)

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -431,25 +431,25 @@ def test_split_files(tmpdir):
     raw_crop = raw_1.copy().crop(0, 1)
     raw_crop.save(split_fname, buffer_size_sec=1., overwrite=True)
     raw_read = read_raw_fif(split_fname)
-    assert_array_equal(raw_read._raw_extras[0]['nsamp'], (301,))
+    assert_array_equal(np.diff(raw_read._raw_extras[0]['bounds']), (301,))
     assert_allclose(raw_crop[:][0], raw_read[:][0])
     # 2 buffers required
     raw_crop.save(split_fname, buffer_size_sec=0.5, overwrite=True)
     raw_read = read_raw_fif(split_fname)
-    assert_array_equal(raw_read._raw_extras[0]['nsamp'], (151, 150))
+    assert_array_equal(np.diff(raw_read._raw_extras[0]['bounds']), (151, 150))
     assert_allclose(raw_crop[:][0], raw_read[:][0])
     # 2 buffers required
     raw_crop.save(split_fname,
                   buffer_size_sec=1. - 1.01 / raw_crop.info['sfreq'],
                   overwrite=True)
     raw_read = read_raw_fif(split_fname)
-    assert_array_equal(raw_read._raw_extras[0]['nsamp'], (300, 1))
+    assert_array_equal(np.diff(raw_read._raw_extras[0]['bounds']), (300, 1))
     assert_allclose(raw_crop[:][0], raw_read[:][0])
     raw_crop.save(split_fname,
                   buffer_size_sec=1. - 2.01 / raw_crop.info['sfreq'],
                   overwrite=True)
     raw_read = read_raw_fif(split_fname)
-    assert_array_equal(raw_read._raw_extras[0]['nsamp'], (299, 2))
+    assert_array_equal(np.diff(raw_read._raw_extras[0]['bounds']), (299, 2))
     assert_allclose(raw_crop[:][0], raw_read[:][0])
 
 

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -431,32 +431,25 @@ def test_split_files(tmpdir):
     raw_crop = raw_1.copy().crop(0, 1)
     raw_crop.save(split_fname, buffer_size_sec=1., overwrite=True)
     raw_read = read_raw_fif(split_fname)
-    assert len(raw_read._raw_extras[0]) == 1
-    assert raw_read._raw_extras[0][0]['nsamp'] == 301
+    assert_array_equal(raw_read._raw_extras[0]['nsamp'], (301,))
     assert_allclose(raw_crop[:][0], raw_read[:][0])
     # 2 buffers required
     raw_crop.save(split_fname, buffer_size_sec=0.5, overwrite=True)
     raw_read = read_raw_fif(split_fname)
-    assert len(raw_read._raw_extras[0]) == 2
-    assert raw_read._raw_extras[0][0]['nsamp'] == 151
-    assert raw_read._raw_extras[0][1]['nsamp'] == 150
+    assert_array_equal(raw_read._raw_extras[0]['nsamp'], (151, 150))
     assert_allclose(raw_crop[:][0], raw_read[:][0])
     # 2 buffers required
     raw_crop.save(split_fname,
                   buffer_size_sec=1. - 1.01 / raw_crop.info['sfreq'],
                   overwrite=True)
     raw_read = read_raw_fif(split_fname)
-    assert len(raw_read._raw_extras[0]) == 2
-    assert raw_read._raw_extras[0][0]['nsamp'] == 300
-    assert raw_read._raw_extras[0][1]['nsamp'] == 1
+    assert_array_equal(raw_read._raw_extras[0]['nsamp'], (300, 1))
     assert_allclose(raw_crop[:][0], raw_read[:][0])
     raw_crop.save(split_fname,
                   buffer_size_sec=1. - 2.01 / raw_crop.info['sfreq'],
                   overwrite=True)
     raw_read = read_raw_fif(split_fname)
-    assert len(raw_read._raw_extras[0]) == 2
-    assert raw_read._raw_extras[0][0]['nsamp'] == 299
-    assert raw_read._raw_extras[0][1]['nsamp'] == 2
+    assert_array_equal(raw_read._raw_extras[0]['nsamp'], (299, 2))
     assert_allclose(raw_crop[:][0], raw_read[:][0])
 
 


### PR DESCRIPTION
In `mne/io/fiff/raw.py` we iterate over tags to figure out which ones to read. This will slow down as you access data later and later in the file, so a better strategy is to construct arrays of starts/stops and then figure out which tags to read based on that (a simple `searchsorted` or even `np.where` will yield the answers). 

First step is then to refactor the reading function to "reformat raw_extras to be a dict of list/ndarray rather than list of dict (faster access)", which is done here. Hopefully all is green and we can move on to the speedup part.

At least `pytest mne/io` works locally...

- [x] Refactor list of dict to dict of ndarray
- [x] Refactor reading function to use start and stop points
- [x] @hubertjb tests speed

This should in the end be pretty straightforward so we can get it into 0.20.

Closes #7436