### PR TITLE
Shorter Info repr

### DIFF
--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -83,16 +83,16 @@ def test_orig_units(recwarn):
 DATE_TEST_CASES = np.array([
     ('Mk1=New Segment,,1,1,0,20131113161403794232\n',  # content
      [1384359243, 794232],  # meas_date internal representation
-     '2013-11-13 16:14:03 GMT'),  # meas_date representation
+     '2013-11-13 16:14:03 UTC'),  # meas_date representation
 
     (('Mk1=New Segment,,1,1,0,20070716122240937454\n'
       'Mk2=New Segment,,2,1,0,20070716122240937455\n'),
      [1184588560, 937454],
-     '2007-07-16 12:22:40 GMT'),
+     '2007-07-16 12:22:40 UTC'),
 
     ('Mk1=New Segment,,1,1,0,\nMk2=New Segment,,2,1,0,20070716122240937454\n',
      [1184588560, 937454],
-     '2007-07-16 12:22:40 GMT'),
+     '2007-07-16 12:22:40 UTC'),
 
     ('Mk1=STATUS,,1,1,0\n', None, 'unspecified'),
     ('Mk1=New Segment,,1,1,0,\n', None, 'unspecified'),

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -593,7 +593,7 @@ class Info(dict, MontageMixin):
                           for ii in _dig_kind_ints if ii in counts]
                 counts = (' (%s)' % (', '.join(counts))) if len(counts) else ''
                 entr = '%d item%s%s' % (len(v), _pl(len(v)), counts)
-            elif k == 'dev_head_t':
+            elif isinstance(v, Transform):
                 # show entry only for non-identity transform
                 if not np.allclose(v["trans"], np.eye(v["trans"].shape[0])):
                     frame1 = _coord_frame_name(v['from'])

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -605,19 +605,22 @@ class Info(dict, MontageMixin):
                 entr = '{:.1f} Hz'.format(v)
             elif isinstance(v, str):
                 entr = shorten(v, MAX_WIDTH, placeholder=' ...')
+            elif k == 'chs':
+                ch_types = [channel_type(self, idx) for idx in range(len(v))]
+                ch_counts = Counter(ch_types)
+                entr = "%s" % ', '.join("%d %s" % (count, ch_type.upper())
+                                        for ch_type, count
+                                        in ch_counts.items())
+            elif k == 'custom_ref_applied':
+                entr = str(v) if v else ''
             else:
                 this_len = (len(v) if hasattr(v, '__len__') else
                             ('%s' % v if v is not None else None))
-                entr = (('%d item%s' % (this_len, _pl(this_len)))
+                entr = (('%d item%s (%s)' % (this_len, _pl(this_len),
+                                             type(v).__name__))
                         if isinstance(this_len, int)
                         else ('%s' % this_len if this_len else ''))
-            if k == 'chs':
-                ch_types = [channel_type(self, idx) for idx in range(len(v))]
-                ch_counts = Counter(ch_types)
-                entr += " (%s)" % ', '.join("%s: %d" % (ch_type.upper(), count)
-                                            for ch_type, count
-                                            in ch_counts.items())
-            if entr != '' and entr != '0 items':
+            if entr != '' and not entr.startswith('0 items'):
                 non_empty += 1
                 strs.append('%s: %s' % (k, entr))
         st = '\n '.join(sorted(strs))

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -30,7 +30,7 @@ from .write import (start_file, end_file, start_block, end_block,
 from .proc_history import _read_proc_history, _write_proc_history
 from ..transforms import invert_transform, Transform, _coord_frame_name
 from ..utils import (logger, verbose, warn, object_diff, _validate_type,
-                     _stamp_to_dt, _dt_to_stamp)
+                     _stamp_to_dt, _dt_to_stamp, _pl)
 from ._digitization import (_format_dig_points, _dig_kind_proper,
                             _dig_kind_rev, _dig_kind_ints, _read_dig_fif)
 from ._digitization import write_dig as _dig_write_dig
@@ -592,7 +592,7 @@ class Info(dict, MontageMixin):
                                      _dig_kind_proper[_dig_kind_rev[ii]])
                           for ii in _dig_kind_ints if ii in counts]
                 counts = (' (%s)' % (', '.join(counts))) if len(counts) else ''
-                entr = '%d items%s' % (len(v), counts)
+                entr = '%d item%s%s' % (len(v), _pl(len(v)), counts)
             elif k == 'dev_head_t':
                 # show entry only for non-identity transform
                 if not np.allclose(v["trans"], np.eye(v["trans"].shape[0])):
@@ -606,7 +606,8 @@ class Info(dict, MontageMixin):
             else:
                 this_len = (len(v) if hasattr(v, '__len__') else
                             ('%s' % v if v is not None else None))
-                entr = (('%d items' % this_len) if isinstance(this_len, int)
+                entr = (('%d item%s' % (this_len, _pl(this_len)))
+                        if isinstance(this_len, int)
                         else ('%s' % this_len if this_len else ''))
             if k == 'chs':
                 ch_types = [channel_type(self, idx) for idx in range(len(v))]

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -576,7 +576,7 @@ class Info(dict, MontageMixin):
                     entr += ', '.join(v)
                     entr = shorten(entr, MAX_WIDTH, placeholder=' ...') + ')'
                 else:
-                    entr = '0 items'  # always show
+                    entr = '[]'  # always show
                     non_empty -= 1  # don't count as non-empty
             elif k == 'projs':
                 if v:

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -564,11 +564,19 @@ class Info(dict, MontageMixin):
         strs = ['<Info | %s non-empty values']
         non_empty = 0
         for k, v in self.items():
-            if k in ['bads', 'ch_names']:
+            if k == 'ch_names':
                 if v:
                     entr = shorten(', '.join(v), MAX_WIDTH, placeholder=' ...')
                 else:
-                    entr = '[]'  # always show bads
+                    entr = '[]'  # always show
+                    non_empty -= 1  # don't count as non-empty
+            elif k == 'bads':
+                if v:
+                    entr = '{} items ('.format(len(v))
+                    entr += ', '.join(v)
+                    entr = shorten(entr, MAX_WIDTH, placeholder=' ...') + ')'
+                else:
+                    entr = '[]'  # always show
                     non_empty -= 1  # don't count as non-empty
             elif k == 'projs':
                 if v:

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -28,7 +28,7 @@ from .write import (start_file, end_file, start_block, end_block,
                     write_coord_trans, write_ch_info, write_name_list,
                     write_julian, write_float_matrix, write_id, DATE_NONE)
 from .proc_history import _read_proc_history, _write_proc_history
-from ..transforms import invert_transform, Transform
+from ..transforms import invert_transform, Transform, _coord_frame_name
 from ..utils import (logger, verbose, warn, object_diff, _validate_type,
                      _stamp_to_dt, _dt_to_stamp)
 from ._digitization import (_format_dig_points, _dig_kind_proper,
@@ -585,6 +585,14 @@ class Info(dict, MontageMixin):
                           for ii in _dig_kind_ints if ii in counts]
                 counts = (' (%s)' % (', '.join(counts))) if len(counts) else ''
                 entr = '%d items%s' % (len(v), counts)
+            elif k == 'dev_head_t':
+                # show entry only for non-identity transform
+                if not np.allclose(v["trans"], np.eye(v["trans"].shape[0])):
+                    frame1 = _coord_frame_name(v['from'])
+                    frame2 = _coord_frame_name(v['to'])
+                    entr = '%s -> %s transform' % (frame1, frame2)
+                else:
+                    entr = ''
             else:
                 this_len = (len(v) if hasattr(v, '__len__') else
                             ('%s' % v if v is not None else None))

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -560,12 +560,13 @@ class Info(dict, MontageMixin):
 
     def __repr__(self):
         """Summarize info instead of printing all."""
+        MAX_WIDTH = 68
         strs = ['<Info | %s non-empty values']
         non_empty = 0
         for k, v in self.items():
             if k in ['bads', 'ch_names']:
                 if v:
-                    entr = shorten(', '.join(v), width=68, placeholder=' ...')
+                    entr = shorten(', '.join(v), MAX_WIDTH, placeholder=' ...')
                 else:
                     entr = '[]'  # always show bads
                     non_empty -= 1  # don't count as non-empty
@@ -573,7 +574,7 @@ class Info(dict, MontageMixin):
                 if v:
                     entr = ', '.join(p['desc'] + ': o%s' %
                                      {0: 'ff', 1: 'n'}[p['active']] for p in v)
-                    entr = shorten(entr, width=68, placeholder=' ...')
+                    entr = shorten(entr, MAX_WIDTH, placeholder=' ...')
                 else:
                     entr = '[]'  # always show projs
                     non_empty -= 1  # don't count as non-empty
@@ -600,6 +601,8 @@ class Info(dict, MontageMixin):
                     entr = '%s -> %s transform' % (frame1, frame2)
                 else:
                     entr = ''
+            elif isinstance(v, str):
+                entr = shorten(v, MAX_WIDTH, placeholder=' ...')
             else:
                 this_len = (len(v) if hasattr(v, '__len__') else
                             ('%s' % v if v is not None else None))

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -621,6 +621,8 @@ class Info(dict, MontageMixin):
                                         in ch_counts.items())
             elif k == 'custom_ref_applied':
                 entr = str(bool(v))
+                if not v:
+                    non_empty -= 1  # don't count if 0
             else:
                 try:
                     this_len = len(v)

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -601,6 +601,8 @@ class Info(dict, MontageMixin):
                     entr = '%s -> %s transform' % (frame1, frame2)
                 else:
                     entr = ''
+            elif k in ['sfreq', 'lowpass', 'highpass']:
+                entr = '{:.1f} Hz'.format(v)
             elif isinstance(v, str):
                 entr = shorten(v, MAX_WIDTH, placeholder=' ...')
             else:
@@ -615,8 +617,6 @@ class Info(dict, MontageMixin):
                 entr += " (%s)" % ', '.join("%s: %d" % (ch_type.upper(), count)
                                             for ch_type, count
                                             in ch_counts.items())
-            if k in ['sfreq', 'lowpass', 'highpass']:
-                entr += ' Hz'
             if entr != '' and entr != '0 items':
                 non_empty += 1
                 strs.append('%s: %s' % (k, entr))

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -564,8 +564,11 @@ class Info(dict, MontageMixin):
         non_empty = 0
         for k, v in self.items():
             if k in ['bads', 'ch_names']:
-                entr = ', '.join(v) if v else '[]'  # always show bads
-                entr = shorten(entr, width=68, placeholder=' ...')
+                if v:
+                    entr = shorten(', '.join(v), width=68, placeholder=' ...')
+                else:
+                    entr = '[]'  # always show bads
+                    non_empty -= 1  # don't count as non-empty
             elif k == 'projs':
                 if v:
                     entr = ', '.join(p['desc'] + ': o%s' %
@@ -573,6 +576,7 @@ class Info(dict, MontageMixin):
                     entr = shorten(entr, width=68, placeholder=' ...')
                 else:
                     entr = '[]'  # always show projs
+                    non_empty -= 1  # don't count as non-empty
             elif k == 'meas_date':
                 if v is None:
                     entr = 'unspecified'

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -576,7 +576,7 @@ class Info(dict, MontageMixin):
                     entr += ', '.join(v)
                     entr = shorten(entr, MAX_WIDTH, placeholder=' ...') + ')'
                 else:
-                    entr = '[]'  # always show
+                    entr = '0 items'  # always show
                     non_empty -= 1  # don't count as non-empty
             elif k == 'projs':
                 if v:
@@ -622,13 +622,17 @@ class Info(dict, MontageMixin):
             elif k == 'custom_ref_applied':
                 entr = str(bool(v))
             else:
-                this_len = (len(v) if hasattr(v, '__len__') else
-                            ('%s' % v if v is not None else None))
-                entr = (('%d item%s (%s)' % (this_len, _pl(this_len),
-                                             type(v).__name__))
-                        if isinstance(this_len, int)
-                        else ('%s' % this_len if this_len else ''))
-            if entr != '' and not entr.startswith('0 items'):
+                try:
+                    this_len = len(v)
+                except TypeError:
+                    entr = '{}'.format(v) if v is not None else ''
+                else:
+                    if this_len > 0:
+                        entr = ('%d item%s (%s)' % (this_len, _pl(this_len),
+                                                    type(v).__name__))
+                    else:
+                        entr = ''
+            if entr != '':
                 non_empty += 1
                 strs.append('%s: %s' % (k, entr))
         st = '\n '.join(sorted(strs))

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -564,12 +564,15 @@ class Info(dict, MontageMixin):
         non_empty = 0
         for k, v in self.items():
             if k in ['bads', 'ch_names']:
-                entr = ', '.join(v) if v else ''
+                entr = ', '.join(v) if v else '[]'  # always show bads
                 entr = shorten(entr, width=68, placeholder=' ...')
-            elif k == 'projs' and v:
-                entr = ', '.join(p['desc'] + ': o%s' %
-                                 {0: 'ff', 1: 'n'}[p['active']] for p in v)
-                entr = shorten(entr, width=68, placeholder=' ...')
+            elif k == 'projs':
+                if v:
+                    entr = ', '.join(p['desc'] + ': o%s' %
+                                     {0: 'ff', 1: 'n'}[p['active']] for p in v)
+                    entr = shorten(entr, width=68, placeholder=' ...')
+                else:
+                    entr = '[]'  # always show projs
             elif k == 'meas_date':
                 if v is None:
                     entr = 'unspecified'

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -620,7 +620,7 @@ class Info(dict, MontageMixin):
                                         for ch_type, count
                                         in ch_counts.items())
             elif k == 'custom_ref_applied':
-                entr = str(v) if v else ''
+                entr = str(bool(v))
             else:
                 this_len = (len(v) if hasattr(v, '__len__') else
                             ('%s' % v if v is not None else None))

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -696,6 +696,7 @@ def test_equalize_channels():
 
 
 def test_repr():
+    """Test Info repr."""
     info = create_info(1, 1000, 'eeg')
     assert '8 non-empty values' in repr(info)
 

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -698,7 +698,7 @@ def test_equalize_channels():
 def test_repr():
     """Test Info repr."""
     info = create_info(1, 1000, 'eeg')
-    assert '8 non-empty values' in repr(info)
+    assert '7 non-empty values' in repr(info)
 
     t = Transform(1, 2, np.ones((4, 4)))
     info['dev_head_t'] = t

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -28,6 +28,7 @@ from mne.io.meas_info import (Info, create_info, _merge_info,
 from mne.io._digitization import (_write_dig_points, _read_dig_points,
                                   _make_dig_points,)
 from mne.io import read_raw_ctf
+from mne.transforms import Transform
 from mne.utils import run_tests_if_main, catch_logging, assert_object_equal
 from mne.channels import make_standard_montage, equalize_channels
 
@@ -692,6 +693,15 @@ def test_equalize_channels():
 
     assert info1.ch_names == ['CH1', 'CH2']
     assert info2.ch_names == ['CH1', 'CH2']
+
+
+def test_repr():
+    info = create_info(1, 1000, 'eeg')
+    assert '8 non-empty values' in repr(info)
+
+    t = Transform(1, 2, np.ones((4, 4)))
+    info['dev_head_t'] = t
+    assert 'dev_head_t: MEG device -> isotrak transform' in repr(info)
 
 
 run_tests_if_main()

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -152,11 +152,8 @@ def test_info():
     # Test info attribute in API objects
     for obj in [raw, epochs, evoked]:
         assert (isinstance(obj.info, Info))
-        info_str = '%s' % obj.info
-        assert len(info_str.split('\n')) == len(obj.info.keys()) + 2
-        assert all(k in info_str for k in obj.info.keys())
         rep = repr(obj.info)
-        assert '2002-12-03 19:01:10 GMT' in rep, rep
+        assert '2002-12-03 19:01:10 UTC' in rep, rep
         assert '146 items (3 Cardinal, 4 HPI, 61 EEG, 78 Extra)' in rep
         dig_rep = repr(obj.info['dig'][0])
         assert 'LPA' in dig_rep, dig_rep


### PR DESCRIPTION
Like #7441 (shorter `Annotations` repr) and #7443 (shorter `Raw` repr), this PR creates a much shorter `Info` repr. I really do think that printing all empty fields is not useful and makes it much harder to find information contained in the `Info` dict, so I only display non-empty values. I also consider empty lists as empty so they are not included in the repr. Furthermore, I don't need to see the types explicitly, this is mostly clear from the value (and why would I need to know that in the first place).

Before:
```
<Info | 16 non-empty fields
    bads : list | 0 items
    ch_names : list | Fc5., Fc3., Fc1., Fcz., Fc2., Fc4., Fc6., C5.., C3.., ...
    chs : list | 64 items (EEG: 64)
    comps : list | 0 items
    custom_ref_applied : NamedInt | 0 (FIFFV_MNE_CUSTOM_REF_OFF)
    dev_head_t : Transform | 3 items
    events : list | 0 items
    highpass : float | 0.0 Hz
    hpi_meas : list | 0 items
    hpi_results : list | 0 items
    lowpass : float | 80.0 Hz
    meas_date : datetime | 2009-08-12 16:15:00 GMT
    nchan : int | 64
    proc_history : list | 0 items
    projs : list | 0 items
    sfreq : float | 160.0 Hz
    acq_pars : NoneType
    acq_stim : NoneType
    ctf_head_t : NoneType
    description : NoneType
    dev_ctf_t : NoneType
    device_info : NoneType
    dig : NoneType
    experimenter : NoneType
    file_id : NoneType
    gantry_angle : NoneType
    helium_info : NoneType
    hpi_subsystem : NoneType
    kit_system_id : NoneType
    line_freq : NoneType
    meas_id : NoneType
    proj_id : NoneType
    proj_name : NoneType
    subject_info : NoneType
    utc_offset : NoneType
    xplotter_layout : NoneType
>
```

After:
```
<Info | 9 non-empty values
 ch_names: Fc5., Fc3., Fc1., Fcz., Fc2., Fc4., Fc6., C5.., C3.., C1.., ...
 chs: 64 items (EEG: 64)
 custom_ref_applied: 0 (FIFFV_MNE_CUSTOM_REF_OFF)
 dev_head_t: 3 items
 highpass: 0.0 Hz
 lowpass: 80.0 Hz
 meas_date: 2009-08-12 16:15:00 UTC
 nchan: 64
 sfreq: 160.0 Hz
>
```