### PR TITLE
MRG: Use the renderer fixture in test_mixed_sources_plot_surface

### DIFF
--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -719,7 +719,7 @@ def test_brain_colorbar(orientation, diverging, lims):
 @requires_pysurfer
 @testing.requires_testing_data
 @traits_test
-def test_mixed_sources_plot_surface(garbage_collect):
+def test_mixed_sources_plot_surface(renderer):
     """Test plot_surface() for  mixed source space."""
     src = read_source_spaces(fwd_fname2)
     N = np.sum([s['nuse'] for s in src])  # number of sources


### PR DESCRIPTION
This short PR follows the tests on https://github.com/mne-tools/mne-python/pull/7294 and modifies `test_mixed_sources_plot_surface` to use the `renderer` fixture. I also removed `garbage_collect` according to https://github.com/mne-tools/mne-python/pull/7294#discussion_r391942199 advice