### PR TITLE
FIX: do not project to sphere; DOC - explain how to get EEGLAB-like topoplots

### DIFF
--- a/examples/visualization/plot_eeglab_head_sphere.py
+++ b/examples/visualization/plot_eeglab_head_sphere.py
@@ -17,7 +17,6 @@ layout in mne.
 # License: BSD (3-clause)
 import numpy as np
 from matplotlib import pyplot as plt
-from os import path as op
 
 import mne
 from mne.viz import plot_topomap
@@ -93,10 +92,10 @@ print([f'{v:0.5f}' for v in [x, y, z, radius]])
 fig, ax = plt.subplots(ncols=2, figsize=(8, 4), gridspec_kw=dict(top=0.9))
 
 # we plot the channel positions with default sphere - the mne way
-fake_raw.plot_sensors(axes=ax[0], show=False)
+fake_evoked.plot_sensors(axes=ax[0], show=False)
 
 # in the second panel we plot the positions using the EEGLAB reference sphere
-fake_raw.plot_sensors(sphere=(x, y, z, radius), axes=ax[1], show=False)
+fake_evoked.plot_sensors(sphere=(x, y, z, radius), axes=ax[1], show=False)
 
 # make x and limits the same in both panels
 ylm = ax[1].get_ylim()
@@ -119,8 +118,8 @@ ax[1].set_title('EEGLAB channel projection', fontweight='bold')
 
 fig, ax = plt.subplots(ncols=2, figsize=(8, 4), gridspec_kw=dict(top=0.9))
 
-plot_topomap(fake_raw.data[:, 0], axes=ax[0], show=False)
-plot_topomap(fake_raw.data[:, 0], sphere=(x, y, z, radius), axes=ax[1],
+plot_topomap(fake_evoked.data[:, 0], axes=ax[0], show=False)
+plot_topomap(fake_evoked.data[:, 0], sphere=(x, y, z, radius), axes=ax[1],
              show=False)
 
 # make x and limits the same in both panels

--- a/examples/visualization/plot_eeglab_head_sphere.py
+++ b/examples/visualization/plot_eeglab_head_sphere.py
@@ -79,7 +79,7 @@ y = pos[-1, 1]
 z = pos[:, -1].mean()
 
 # lets print the values we got:
-print([f'{v:0.5f} for v in [x, y, z, radius]])
+print([f'{v:0.5f}' for v in [x, y, z, radius]])
 
 ###############################################################################
 # Compare MNE and EEGLAB channel layout
@@ -114,7 +114,7 @@ ax[1].set_title('EEGLAB channel projection', fontweight='bold')
 # --------------------
 #
 # As the last step we do the same, but plotting the topomaps. These will not
-# be particularily interesting as they will show random data but hopefully you
+# be particularly interesting as they will show random data but hopefully you
 # will see the difference.
 
 fig, ax = plt.subplots(ncols=2, figsize=(8, 4), gridspec_kw=dict(top=0.9))

--- a/examples/visualization/plot_eeglab_head_sphere.py
+++ b/examples/visualization/plot_eeglab_head_sphere.py
@@ -1,0 +1,135 @@
+"""
+.. _ex-topomap-eeglab-style:
+
+========================================
+How to plot topomaps the way EEGLAB does
+========================================
+
+If you have previous EEGLAB experience you may have noticed that topomaps
+(topoplots) generated using mne-python look a little different from those
+created in EEGLAB. If you prefer the EEGLAB style this example will show you
+how to calculate head sphere origin and radius to obtain EEGLAB-like channel
+layout in mne.
+
+"""
+# Authors: Mikołaj Magnuski <mmagnuski@swps.edu.pl>
+#
+# License: BSD (3-clause)
+import numpy as np
+from matplotlib import pyplot as plt
+from os import path as op
+
+import mne
+from mne.viz import plot_topomap
+
+
+print(__doc__)
+
+###############################################################################
+# Create fake data
+# ----------------
+#
+# First we will create a simple evoked object with a single timepoint using
+# biosemi 10-20 channel layout.
+
+biosemi_montage = mne.channels.make_standard_montage('biosemi64')
+n_channels = len(biosemi_montage.ch_names)
+fake_info = mne.create_info(ch_names=biosemi_montage.ch_names, sfreq=250.,
+                            ch_types='eeg')
+
+rng = np.random.RandomState(0)
+data = rng.randn((n_channels, 1)) * 1e-6
+fake_evoked = mne.io.RawArray(data, fake_info)
+fake_evoked.set_montage(biosemi_montage)
+
+###############################################################################
+# Calculate sphere origin and radius
+# ----------------------------------
+#
+# EEGLAB plots head outline at the level where head circumference is measured
+# in 10-20 system (a line going through Fpz, T8/T4, Oz and T7/T3 channels).
+# MNE places the head outline lower on the z dimension: approximattely at the
+# level of LPA, RPA fiducial markers. Therefore to use the EEGLAB layout we
+# have to move the origin of the reference sphere (a sphere that is used as a
+# reference when projecting channel locations to a 2d plane) a few centimeters
+# up.
+#
+# Instead of approximating this position by eye, as we did in the sensor
+# locations tutorial :ref:`tut-sensor-locations`, we will calculate it using
+# the position of Fpz, T8, Oz and T7 channels available in out montage.
+
+# first we obtain the 3d positions of selected channels (this should be easier
+# once we have ``.get_channel_positions()`` method available):
+check_ch = ['Oz', 'Fpz', 'T7', 'T8']
+ch_idx = [fake_evoked.ch_names.index(ch) for ch in check_ch]
+pos = np.stack([fake_evoked.info['chs'][idx]['loc'][:3] for idx in ch_idx])
+
+# now we calculate the radius from T7 and T8 x position
+# (we could use Oz and Fpz y positions as well)
+radius = np.abs(pos[[2, 3], 0]).mean()
+
+# then we obtain the x, y, z sphere center this way:
+# x - x position of the Oz channel (should be very close to 0)
+# y - y position of the T8 channel (should be very close to 0 too)
+# z - average z position of Oz, Fpz, T7 and T8 (their z position should be the
+#     the same, so we could also use just one of these channels), it should be
+#     positive and somewhere around `0.03` (3 cm)
+x = pos[0, 0]
+y = pos[-1, 1]
+z = pos[:, -1].mean()
+
+# lets print the values we got:
+print([f'{v:0.5f} for v in [x, y, z, radius]])
+
+###############################################################################
+# Compare MNE and EEGLAB channel layout
+# -------------------------------------
+#
+# We already have the required x, y, z sphere center and its radius - we can
+# use these values passing them to the ``sphere`` argument of many
+# topo-plotting functions (by passing ``sphere=(x, y, z, radius)``).
+
+# create a two-panel figure with some space for the titles at the top
+fig, ax = plt.subplots(ncols=2, figsize=(8, 4), gridspec_kw=dict(top=0.9))
+
+# we plot the channel positions with default sphere - the mne way
+fake_raw.plot_sensors(axes=ax[0], show=False)
+
+# in the second panel we plot the positions using the EEGLAB reference sphere
+fake_raw.plot_sensors(sphere=(x, y, z, radius), axes=ax[1], show=False)
+
+# make x and limits the same in both panels
+ylm = ax[1].get_ylim()
+xlm = ax[1].get_xlim()
+ax[0].set_ylim(ylm)
+ax[0].set_xlim(xlm)
+
+# add titles
+fig.texts[0].remove()
+ax[0].set_title('MNE channel projection', fontweight='bold')
+ax[1].set_title('EEGLAB channel projection', fontweight='bold')
+
+###############################################################################
+# Topomaps (topoplots)
+# --------------------
+#
+# As the last step we do the same, but plotting the topomaps. These will not
+# be particularily interesting as they will show random data but hopefully you
+# will see the difference.
+
+fig, ax = plt.subplots(ncols=2, figsize=(8, 4), gridspec_kw=dict(top=0.9))
+
+plot_topomap(fake_raw.data[:, 0], axes=ax[0], show=False)
+plot_topomap(fake_raw.data[:, 0], sphere=(x, y, z, radius), axes=ax[1],
+             show=False)
+
+# make x and limits the same in both panels
+ylm = ax[1].get_ylim()
+xlm = ax[1].get_xlim()
+ax[0].set_ylim(ylm)
+ax[0].set_xlim(xlm)
+
+# add titles
+fig.texts[0].remove()
+ax[0].set_title('MNE', fontweight='bold')
+ax[1].set_title('EEGLAB', fontweight='bold')

--- a/examples/visualization/plot_eeglab_head_sphere.py
+++ b/examples/visualization/plot_eeglab_head_sphere.py
@@ -48,13 +48,13 @@ fake_evoked.set_montage(biosemi_montage)
 # measured
 # in the 10-20 system (a line going through Fpz, T8/T4, Oz and T7/T3 channels).
 # MNE-Python places the head outline lower on the z dimension, at the level of
-# the anatomical landmarks :term:`LPA, RPA, and NAS <fiducial points>`.
+# the anatomical landmarks :term:`LPA, RPA, and NAS <fiducial point>`.
 # Therefore to use the EEGLAB layout we
 # have to move the origin of the reference sphere (a sphere that is used as a
 # reference when projecting channel locations to a 2d plane) a few centimeters
 # up.
 #
-# Instead of approximating this position by eye, as we did in `the sensor
+# Instead of approximating this position by eye, as we did in :ref:`the sensor
 # locations tutorial <tut-sensor-locations>`, here we will calculate it using
 # the position of Fpz, T8, Oz and T7 channels available in our montage.
 

--- a/examples/visualization/plot_eeglab_head_sphere.py
+++ b/examples/visualization/plot_eeglab_head_sphere.py
@@ -19,7 +19,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 import mne
-from mne.viz import plot_topomap
 
 
 print(__doc__)
@@ -38,7 +37,7 @@ fake_info = mne.create_info(ch_names=biosemi_montage.ch_names, sfreq=250.,
 
 rng = np.random.RandomState(0)
 data = rng.normal(size=(n_channels, 1)) * 1e-6
-fake_evoked = mne.io.RawArray(data, fake_info)
+fake_evoked = mne.EvokedArray(data, fake_info)
 fake_evoked.set_montage(biosemi_montage)
 
 ###############################################################################
@@ -118,9 +117,10 @@ ax[1].set_title('EEGLAB channel projection', fontweight='bold')
 
 fig, ax = plt.subplots(ncols=2, figsize=(8, 4), gridspec_kw=dict(top=0.9))
 
-plot_topomap(fake_evoked.data[:, 0], axes=ax[0], show=False)
-plot_topomap(fake_evoked.data[:, 0], sphere=(x, y, z, radius), axes=ax[1],
-             show=False)
+mne.viz.plot_topomap(fake_evoked.data[:, 0], fake_evoked.info, axes=ax[0],
+                     show=False)
+mne.viz.plot_topomap(fake_evoked.data[:, 0], fake_evoked.info, axes=ax[1],
+                     show=False, sphere=(x, y, z, radius))
 
 # make x and limits the same in both panels
 ylm = ax[1].get_ylim()
@@ -129,6 +129,5 @@ ax[0].set_ylim(ylm)
 ax[0].set_xlim(xlm)
 
 # add titles
-fig.texts[0].remove()
 ax[0].set_title('MNE', fontweight='bold')
 ax[1].set_title('EEGLAB', fontweight='bold')

--- a/examples/visualization/plot_eeglab_head_sphere.py
+++ b/examples/visualization/plot_eeglab_head_sphere.py
@@ -89,19 +89,14 @@ print([f'{v:0.5f}' for v in [x, y, z, radius]])
 # topo-plotting functions (by passing ``sphere=(x, y, z, radius)``).
 
 # create a two-panel figure with some space for the titles at the top
-fig, ax = plt.subplots(ncols=2, figsize=(8, 4), gridspec_kw=dict(top=0.9))
+fig, ax = plt.subplots(ncols=2, figsize=(8, 4), gridspec_kw=dict(top=0.9),
+                       sharex=True, sharey=True)
 
 # we plot the channel positions with default sphere - the mne way
 fake_evoked.plot_sensors(axes=ax[0], show=False)
 
 # in the second panel we plot the positions using the EEGLAB reference sphere
 fake_evoked.plot_sensors(sphere=(x, y, z, radius), axes=ax[1], show=False)
-
-# make x and limits the same in both panels
-ylm = ax[1].get_ylim()
-xlm = ax[1].get_xlim()
-ax[0].set_ylim(ylm)
-ax[0].set_xlim(xlm)
 
 # add titles
 fig.texts[0].remove()
@@ -116,18 +111,13 @@ ax[1].set_title('EEGLAB channel projection', fontweight='bold')
 # be particularly interesting as they will show random data but hopefully you
 # will see the difference.
 
-fig, ax = plt.subplots(ncols=2, figsize=(8, 4), gridspec_kw=dict(top=0.9))
+fig, ax = plt.subplots(ncols=2, figsize=(8, 4), gridspec_kw=dict(top=0.9),
+                       sharex=True, sharey=True)
 
 mne.viz.plot_topomap(fake_evoked.data[:, 0], fake_evoked.info, axes=ax[0],
                      show=False)
 mne.viz.plot_topomap(fake_evoked.data[:, 0], fake_evoked.info, axes=ax[1],
                      show=False, sphere=(x, y, z, radius))
-
-# make x and limits the same in both panels
-ylm = ax[1].get_ylim()
-xlm = ax[1].get_xlim()
-ax[0].set_ylim(ylm)
-ax[0].set_xlim(xlm)
 
 # add titles
 ax[0].set_title('MNE', fontweight='bold')

--- a/examples/visualization/plot_eeglab_head_sphere.py
+++ b/examples/visualization/plot_eeglab_head_sphere.py
@@ -6,10 +6,10 @@ How to plot topomaps the way EEGLAB does
 ========================================
 
 If you have previous EEGLAB experience you may have noticed that topomaps
-(topoplots) generated using mne-python look a little different from those
+(topoplots) generated using MNE-Python look a little different from those
 created in EEGLAB. If you prefer the EEGLAB style this example will show you
 how to calculate head sphere origin and radius to obtain EEGLAB-like channel
-layout in mne.
+layout in MNE.
 
 """
 # Authors: Mikołaj Magnuski <mmagnuski@swps.edu.pl>
@@ -44,20 +44,21 @@ fake_evoked.set_montage(biosemi_montage)
 # Calculate sphere origin and radius
 # ----------------------------------
 #
-# EEGLAB plots head outline at the level where head circumference is measured
-# in 10-20 system (a line going through Fpz, T8/T4, Oz and T7/T3 channels).
-# MNE places the head outline lower on the z dimension: approximattely at the
-# level of LPA, RPA fiducial markers. Therefore to use the EEGLAB layout we
+# EEGLAB plots head outline at the level where the head circumference is
+# measured
+# in the 10-20 system (a line going through Fpz, T8/T4, Oz and T7/T3 channels).
+# MNE-Python places the head outline lower on the z dimension, at the level of
+# the anatomical landmarks :term:`LPA, RPA, and NAS <fiducial points>`.
+# Therefore to use the EEGLAB layout we
 # have to move the origin of the reference sphere (a sphere that is used as a
 # reference when projecting channel locations to a 2d plane) a few centimeters
 # up.
 #
-# Instead of approximating this position by eye, as we did in the sensor
-# locations tutorial :ref:`tut-sensor-locations`, we will calculate it using
-# the position of Fpz, T8, Oz and T7 channels available in out montage.
+# Instead of approximating this position by eye, as we did in `the sensor
+# locations tutorial <tut-sensor-locations>`, here we will calculate it using
+# the position of Fpz, T8, Oz and T7 channels available in our montage.
 
-# first we obtain the 3d positions of selected channels (this should be easier
-# once we have ``.get_channel_positions()`` method available):
+# first we obtain the 3d positions of selected channels
 check_ch = ['Oz', 'Fpz', 'T7', 'T8']
 ch_idx = [fake_evoked.ch_names.index(ch) for ch in check_ch]
 pos = np.stack([fake_evoked.info['chs'][idx]['loc'][:3] for idx in ch_idx])
@@ -67,11 +68,11 @@ pos = np.stack([fake_evoked.info['chs'][idx]['loc'][:3] for idx in ch_idx])
 radius = np.abs(pos[[2, 3], 0]).mean()
 
 # then we obtain the x, y, z sphere center this way:
-# x - x position of the Oz channel (should be very close to 0)
-# y - y position of the T8 channel (should be very close to 0 too)
-# z - average z position of Oz, Fpz, T7 and T8 (their z position should be the
-#     the same, so we could also use just one of these channels), it should be
-#     positive and somewhere around `0.03` (3 cm)
+# x: x position of the Oz channel (should be very close to 0)
+# y: y position of the T8 channel (should be very close to 0 too)
+# z: average z position of Oz, Fpz, T7 and T8 (their z position should be the
+#    the same, so we could also use just one of these channels), it should be
+#    positive and somewhere around `0.03` (3 cm)
 x = pos[0, 0]
 y = pos[-1, 1]
 z = pos[:, -1].mean()
@@ -83,7 +84,7 @@ print([f'{v:0.5f}' for v in [x, y, z, radius]])
 # Compare MNE and EEGLAB channel layout
 # -------------------------------------
 #
-# We already have the required x, y, z sphere center and its radius - we can
+# We already have the required x, y, z sphere center and its radius — we can
 # use these values passing them to the ``sphere`` argument of many
 # topo-plotting functions (by passing ``sphere=(x, y, z, radius)``).
 

--- a/examples/visualization/plot_eeglab_head_sphere.py
+++ b/examples/visualization/plot_eeglab_head_sphere.py
@@ -37,7 +37,7 @@ fake_info = mne.create_info(ch_names=biosemi_montage.ch_names, sfreq=250.,
                             ch_types='eeg')
 
 rng = np.random.RandomState(0)
-data = rng.randn((n_channels, 1)) * 1e-6
+data = rng.normal(size=(n_channels, 1)) * 1e-6
 fake_evoked = mne.io.RawArray(data, fake_info)
 fake_evoked.set_montage(biosemi_montage)
 

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -727,9 +727,10 @@ def _auto_topomap_coords(info, picks, ignore_overlap, to_sphere, sphere):
         # translate to sphere origin, transform/flatten Z, translate back
         locs3d -= sphere[:3]
         # use spherical (theta, pol) as (r, theta) for polar->cartesian
-        out = _pol_to_cart(_cart_to_sph(locs3d)[:, 1:][:, ::-1])
+        cart_coords = _cart_to_sph(locs3d)
+        out = _pol_to_cart(cart_coords[:, 1:][:, ::-1])
         # scale from radians to mm
-        out *= (sphere[3] / (np.pi / 2.))
+        out *= cart_coords[:, [0]] / (np.pi / 2.)
         out += sphere[:2]
     else:
         out = _pol_to_cart(_cart_to_sph(locs3d))

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -270,7 +270,7 @@ def test_find_ch_adjacency():
     data_path = testing.data_path()
 
     raw = read_raw_fif(raw_fname, preload=True)
-    sizes = {'mag': 828, 'grad': 1700, 'eeg': 386}
+    sizes = {'mag': 828, 'grad': 1700, 'eeg': 384}
     nchans = {'mag': 102, 'grad': 204, 'eeg': 60}
     for ch_type in ['mag', 'grad', 'eeg']:
         conn, ch_names = find_ch_adjacency(raw.info, ch_type)

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -492,9 +492,9 @@ def test_plot_sensors():
     plt.draw()
     assert fig.lasso.selection == []
     _fake_click(fig, ax, (0.65, 1), xform='ax', kind='motion')
-    _fake_click(fig, ax, (0.65, 0.65), xform='ax', kind='motion')
+    _fake_click(fig, ax, (0.65, 0.7), xform='ax', kind='motion')
     fig.canvas.key_press_event('control')
-    _fake_click(fig, ax, (0, 0.65), xform='ax', kind='release')
+    _fake_click(fig, ax, (0, 0.7), xform='ax', kind='release')
     assert fig.lasso.selection == ['MEG 0121']
 
     # check that point appearance changes

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -228,7 +228,7 @@ def test_plot_topomap_basic(monkeypatch):
         plot_topomap(data, info, extrapolate='head', border=[1, 2, 3])
 
     # error when str is not 'mean':
-    error_msg = 'border must be numeric or "mean", got \'fancy\''
+    error_msg = "The only allowed value is 'mean', but got 'fancy' instead."
     with pytest.raises(ValueError, match=error_msg):
         plot_topomap(data, info, extrapolate='head', border='fancy')
 

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -591,6 +591,12 @@ class _GridData(object):
         assert pos.ndim == 2 and pos.shape[1] == 2, pos.shape
         _validate_type(border, ('numeric', str), 'border')
 
+        # check that border, if string, is correct
+        if isinstance(border, str):
+            if border != 'mean':
+                msg = 'border must be numeric or "mean", got {!r}'
+                raise ValueError(msg.format(border))
+
         # Adding points outside the extremes helps the interpolators
         outer_pts, mask_pts, tri = _get_extra_points(
             pos, extrapolate, origin, radii)
@@ -611,10 +617,7 @@ class _GridData(object):
         from scipy.interpolate import CloughTocher2DInterpolator
 
         if isinstance(self.border, str):
-            if self.border != 'mean':
-                msg = 'border must be numeric or "mean", got {!r}'
-                raise ValueError(msg.format(self.border))
-            # border = 'mean'
+            # we've already checked that border = 'mean'
             n_points = v.shape[0]
             v_extra = np.zeros(self.n_extra)
             indices, indptr = self.tri.vertex_neighbor_vertices

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -593,9 +593,7 @@ class _GridData(object):
 
         # check that border, if string, is correct
         if isinstance(border, str):
-            if border != 'mean':
-                msg = 'border must be numeric or "mean", got {!r}'
-                raise ValueError(msg.format(border))
+            _check_option('border', border, ('mean',), extra='when a string')
 
         # Adding points outside the extremes helps the interpolators
         outer_pts, mask_pts, tri = _get_extra_points(

--- a/tutorials/intro/plot_40_sensor_locations.py
+++ b/tutorials/intro/plot_40_sensor_locations.py
@@ -114,7 +114,7 @@ biosemi_montage.plot(show_names=False)
 # By default a sphere  with an origin in ``(0, 0, 0)`` x, y, z coordinates and
 # radius of ``0.095`` meters (9.5 cm) is used. You can use a different sphere
 # radius by passing a single value to ``sphere`` argument in any function that
-# plots channels in 2d (like :meth:`~mne.channels.DigMontage.plot`that we use
+# plots channels in 2d (like :meth:`~mne.channels.DigMontage.plot` that we use
 # here, but also for example :func:`mne.viz.plot_topomap`):
 
 biosemi_montage.plot(show_names=False, sphere=0.07)

--- a/tutorials/intro/plot_40_sensor_locations.py
+++ b/tutorials/intro/plot_40_sensor_locations.py
@@ -153,7 +153,8 @@ biosemi_montage.plot(sphere=(0, 0, 0.035, 0.094))
 n_channels = len(biosemi_montage.ch_names)
 fake_info = mne.create_info(ch_names=biosemi_montage.ch_names, sfreq=250.,
                             ch_types=['eeg'] * n_channels)
-data = np.random.random((n_channels, 10))
+rng = np.random.RandomState(0)
+data = rng.randn((n_channels, 10)) * 1e-6
 fake_raw = mne.io.RawArray(data, fake_info)
 fake_raw.set_montage(biosemi_montage)
 

--- a/tutorials/intro/plot_40_sensor_locations.py
+++ b/tutorials/intro/plot_40_sensor_locations.py
@@ -103,9 +103,9 @@ ten_twenty_montage.plot(kind='topomap', show_names=False)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # Channel positions in 2d space are obtained by projecting their actual 3d
-# positions onto a sphere. Because ``'standard_1020'`` montage contains
-# realistic, not spherical, channel positions, we will use a different montage
-# to demonstrate controlling how channels are projected to 2d space.
+# positions using a sphere as a reference. Because ``'standard_1020'`` montage
+# contains realistic, not spherical, channel positions, we will use a different
+# montage to demonstrate controlling how channels are projected to 2d space.
 
 biosemi_montage = mne.channels.make_standard_montage('biosemi64')
 biosemi_montage.plot(show_names=False)
@@ -147,36 +147,9 @@ biosemi_montage.plot(sphere=(0, 0, 0.035, 0.094))
 # Instead of approximating the EEGLAB-esque sphere location as above, you can
 # calculate the sphere origin from position of Oz, Fpz, T3/T7 or T4/T8
 # channels. This is easier once the montage has been applied to the data and
-# channel positions are in head space - see this example
-# (all the code below should be a separate example):
+# channel positions are in the head space - see
+# :ref:`this example <ex-topomap-eeglab-style>`.
 
-n_channels = len(biosemi_montage.ch_names)
-fake_info = mne.create_info(ch_names=biosemi_montage.ch_names, sfreq=250.,
-                            ch_types=['eeg'] * n_channels)
-rng = np.random.RandomState(0)
-data = rng.randn((n_channels, 10)) * 1e-6
-fake_raw = mne.io.RawArray(data, fake_info)
-fake_raw.set_montage(biosemi_montage)
-
-check_ch = ['Oz', 'Fpz', 'T7', 'T8']
-pos = fake_raw._get_channel_positions(picks=check_ch)
-radius = pos[-1, 0].mean()
-x, y, z = pos[0, 0], pos[-1, 1], pos[:, -1].mean()
-
-print([f'{v:0.5f} for v in [x, y, z, radius]])
-
-fig, ax = plt.subplots(ncols=2, figsize=(8, 4))
-fake_raw.plot_sensors(axes=ax[0], show=False)
-fake_raw.plot_sensors(sphere=(x, y, z, radius), axes=ax[1], show=False)
-
-fig.texts[0].remove()
-ax[0].set_title('MNE channel projection', fontweight='bold')
-ax[1].set_title('EEGLAB channel projection', fontweight='bold')
-
-ylm = ax[1].get_ylim()
-xlm = ax[1].get_xlim()
-ax[0].set_ylim(ylm)
-ax[0].set_xlim(xlm)
 
 ###############################################################################
 # .. _reading-dig-montages:

--- a/tutorials/intro/plot_40_sensor_locations.py
+++ b/tutorials/intro/plot_40_sensor_locations.py
@@ -162,8 +162,7 @@ pos = fake_raw._get_channel_positions(picks=check_ch)
 radius = pos[-1, 0].mean()
 x, y, z = pos[0, 0], pos[-1, 1], pos[:, -1].mean()
 
-with np.printoptions(precision=5, suppress=True):
-    print(np.array([x, y, z, radius]))
+print([f'{v:0.5f} for v in [x, y, z, radius]])
 
 fig, ax = plt.subplots(ncols=2, figsize=(8, 4))
 fake_raw.plot_sensors(axes=ax[0], show=False)

--- a/tutorials/intro/plot_40_sensor_locations.py
+++ b/tutorials/intro/plot_40_sensor_locations.py
@@ -172,7 +172,7 @@ biosemi_montage.plot(sphere=(0, 0, 0.035, 0.094))
 # existing matplotlib ``axes`` object (so the channel positions can easily be
 # made as a subplot in a multi-panel figure):
 
-# sphinx_gallery_thumbnail_number = 3
+# sphinx_gallery_thumbnail_number = 8
 fig = plt.figure()
 ax2d = fig.add_subplot(121)
 ax3d = fig.add_subplot(122, projection='3d')


### PR DESCRIPTION
Fixes #7341 
Currently all channels are projected to a sphere so the sphere radius does not take any effect. If we don't project to a sphere the sphere radius changes the channel positioning with respect to head outline: 
![image](https://user-images.githubusercontent.com/8452354/76755365-04acd100-6784-11ea-88a6-6e37d2b145d6.png)

However this means that channel positions that are not spherical, like EGI (or standard_1020) do not look so good because we no longer project to sphere.
![topo_sphere_changes](https://user-images.githubusercontent.com/8452354/76754925-4426ed80-6783-11ea-8ac6-8144297c0551.PNG)

One way to circumvent this would be to project to sphere and then scale channel positions by the average channel pos radius (currently each channel is scaled by its own radius, so the channels are no longer on a sphere).

