### PR TITLE
ENH: Small mne.grand_average() changes

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -135,6 +135,8 @@ Changelog
 
 - Support for saving movies of source time courses (STCs) with ``brain.save_movie`` method and from graphical user interface by `Guillaume Favelier`_
 
+- :func:`mne.grand_average` now produces a warning when only a single dataset was passed, instead of raising by `Richard Höchenberger`_
+
 Bug
 ~~~
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -135,7 +135,7 @@ Changelog
 
 - Support for saving movies of source time courses (STCs) with ``brain.save_movie`` method and from graphical user interface by `Guillaume Favelier`_
 
-- :func:`mne.grand_average` now produces a warning when only a single dataset was passed, instead of raising by `Richard Höchenberger`_
+- :func:`mne.grand_average` now produces a warning when only a single dataset was passed, instead of raising an error by `Richard Höchenberger`_
 
 Bug
 ~~~

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -561,13 +561,13 @@ def grand_average(all_inst, interpolate_bads=True, drop_bads=True):
     grand_average : Evoked | AverageTFR
         The grand average data. Same type as input.
 
-    Warns
-    -----
-    If ``all_inst`` contains only a single element.
-
     Raises
     ------
     If ``all_inst`` is empty, or if not all elements are evokeds.
+
+    Warns
+    -----
+    If ``all_inst`` contains only a single element.
 
     Notes
     -----

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -581,7 +581,7 @@ def grand_average(all_inst, interpolate_bads=True, drop_bads=True):
     if not all_inst:
         raise ValueError('Please pass a list of Evoked or AverageTFR objects.')
     elif len(all_inst) == 1:
-        warn('Only a single evoked object was passed to mne.grand_average().')
+        warn('Only a single dataset was passed to mne.grand_average().')
 
     inst_type = type(all_inst[0])
     _validate_type(all_inst[0], (Evoked, AverageTFR), 'All elements')

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -528,19 +528,20 @@ def _freq_mask(freqs, sfreq, fmin=None, fmax=None, raise_error=True):
 
 
 def grand_average(all_inst, interpolate_bads=True, drop_bads=True):
-    """Make grand average of a list evoked or AverageTFR data.
+    """Make grand average of a list of Evoked or AverageTFR data.
 
-    For evoked data, the function interpolates bad channels based on the
-    ``interpolate_bads`` parameter. If ``interpolate_bads`` is True, the grand
-    average file will contain good channels and the bad channels interpolated
-    from the good MEG/EEG channels.
-    For AverageTFR data, the function takes the subset of channels not marked
-    as bad in any of the instances.
+    For :class:`mne.Evoked` data, the function interpolates bad channels based
+    on the ``interpolate_bads`` parameter. If ``interpolate_bads`` is True,
+    the grand average file will contain good channels and the bad channels
+    interpolated from the good MEG/EEG channels.
+    For :class:`mne.time_frequency.AverageTFR` data, the function takes the
+    subset of channels not marked as bad in any of the instances.
 
-    The grand_average.nave attribute will be equal to the number
+    The ``grand_average.nave`` attribute will be equal to the number
     of evoked datasets used to calculate the grand average.
 
-    Note: Grand average evoked should not be used for source localization.
+    .. note:: A grand average evoked should not be used for source
+              localization.
 
     Parameters
     ----------

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -561,6 +561,14 @@ def grand_average(all_inst, interpolate_bads=True, drop_bads=True):
     grand_average : Evoked | AverageTFR
         The grand average data. Same type as input.
 
+    Warns
+    -----
+    If ``all_inst`` contains only a single element.
+
+    Raises
+    ------
+    If ``all_inst`` is empty, or if not all elements are evokeds.
+
     Notes
     -----
     .. versionadded:: 0.11.0
@@ -569,7 +577,12 @@ def grand_average(all_inst, interpolate_bads=True, drop_bads=True):
     from ..evoked import Evoked
     from ..time_frequency import AverageTFR
     from ..channels.channels import equalize_channels
-    assert len(all_inst) > 1
+
+    if not all_inst:
+        raise ValueError('Please pass a list of Evoked or AverageTFR objects.')
+    elif len(all_inst) == 1:
+        warn('Only a single evoked object was passed to mne.grand_average().')
+
     inst_type = type(all_inst[0])
     _validate_type(all_inst[0], (Evoked, AverageTFR), 'All elements')
     for inst in all_inst:

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -478,7 +478,7 @@ def test_grand_average_len_1():
     # returns a list of length 1
     evokeds = read_evokeds(ave_fname, condition=[0], proj=True)
 
-    with pytest.warns(RuntimeWarning, match='Only a single evoked'):
+    with pytest.warns(RuntimeWarning, match='Only a single dataset'):
         gave = grand_average(evokeds)
 
     assert_allclose(gave.data, evokeds[0].data)

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -468,16 +468,17 @@ def test_julian_conversions():
 
 
 def test_grand_average_empty_sequence():
+    """Test if mne.grand_average handles an empty sequence correctly."""
     with pytest.raises(ValueError, match='Please pass a list of Evoked'):
         grand_average([])
 
 
 def test_grand_average_len_1():
-    base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests',
-                       'data')
-    fname = op.join(base_dir, 'test-ave.fif')
-    evokeds = read_evokeds(fname, condition=[0], proj=True)  # list of length 0
+    """Test if mne.grand_average handles a sequence of length 1 correctly."""
+    # returns a list of length 1
+    evokeds = read_evokeds(ave_fname, condition=[0], proj=True)
 
     with pytest.warns(RuntimeWarning, match='Only a single evoked'):
         gave = grand_average(evokeds)
-        assert_allclose(gave.data, evokeds[0].data)
+
+    assert_allclose(gave.data, evokeds[0].data)

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -21,7 +21,7 @@ from mne.utils import (_get_inst_data, hashfunc,
                        _undo_scaling_cov, _apply_scaling_array,
                        _undo_scaling_array, _PCA, requires_sklearn,
                        _array_equal_nan, _julian_to_cal, _cal_to_julian,
-                       _dt_to_julian, _julian_to_dt)
+                       _dt_to_julian, _julian_to_dt, grand_average)
 
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -465,3 +465,19 @@ def test_julian_conversions():
 
         assert (jd == _dt_to_julian(dd))
         assert (jd == _cal_to_julian(cal[0], cal[1], cal[2]))
+
+
+def test_grand_average_empty_sequence():
+    with pytest.raises(ValueError, match='Please pass a list of Evoked'):
+        grand_average([])
+
+
+def test_grand_average_len_1():
+    base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests',
+                       'data')
+    fname = op.join(base_dir, 'test-ave.fif')
+    evokeds = read_evokeds(fname, condition=[0], proj=True)  # list of length 0
+
+    with pytest.warns(RuntimeWarning, match='Only a single evoked'):
+        gave = grand_average(evokeds)
+        assert_allclose(gave.data, evokeds[0].data)


### PR DESCRIPTION
#### Reference issue
Required for mne-tools/mne-study-template#57


#### What does this implement/fix?
Raises when an empty sequence was passed, and emits a warning when a sequence of length 1 was passed.

Previous behavior was to always assert a length >1.

This is required to implement mne-tools/mne-study-template#57
