### PR TITLE
MRG, ENH: Allow just line freq filtering

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -27,6 +27,8 @@ Changelog
 
 - Add :func:`mne.chpi.compute_chpi_amplitudes`, :func:`mne.chpi.compute_chpi_locs`, and :func:`mne.chpi.compute_head_pos` to compute head positions from cHPI coil locations by `Eric Larson`_ and `Luke Bloy`_
 
+- Add ``allow_line_only`` option to :func:`mne.chpi.filter_chpi` to allow filtering line frequencies only in files that do not have cHPI information by `Eric Larson`_
+
 - Add :func:`mne.io.Raw.set_meas_date` by `Eric Larson`_
 
 - Add ``copy`` parameter to :meth:`mne.Epochs.iter_evoked` by `Alex Gramfort`_

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -1031,7 +1031,7 @@ def filter_chpi(raw, include_line=True, t_step=0.01, t_window=None,
     ----------
     raw : instance of Raw
         Raw data with cHPI information. Must be preloaded. Operates in-place.
-    include_line : bool | int
+    include_line : bool
         If True, also filter line noise.
     t_step : float
         Time step to use for estimation, default is 0.01 (10 ms).

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -25,6 +25,7 @@ import numpy as np
 from scipy import linalg
 import itertools
 
+from .io.base import BaseRaw
 from .io.meas_info import _simplify_info
 from .io.pick import (pick_types, pick_channels, pick_channels_regexp,
                       pick_info)
@@ -214,10 +215,12 @@ def extract_chpi_locs_ctf(raw, verbose=None):
 # ############################################################################
 # Estimate positions from data
 @verbose
-def _get_hpi_info(info, verbose=None):
+def _get_hpi_info(info, allow_empty=False, verbose=None):
     """Get HPI information from raw."""
     if len(info['hpi_meas']) == 0 or \
             ('coil_freq' not in info['hpi_meas'][0]['hpi_coils'][0]):
+        if allow_empty:
+            return np.empty(0), None, np.empty(0)
         raise RuntimeError('Appropriate cHPI information not found in'
                            'info["hpi_meas"] and info["hpi_subsystem"], '
                            'cannot process cHPI')
@@ -435,16 +438,19 @@ def _fit_coil_order_dev_head_trans(dev_pnts, head_pnts):
 
 @verbose
 def _setup_hpi_amplitude_fitting(info, t_window, remove_aliased=False,
-                                 ext_order=1, verbose=None):
+                                 ext_order=1, allow_empty=False, verbose=None):
     """Generate HPI structure for HPI localization."""
     # grab basic info.
-    hpi_freqs, hpi_pick, hpi_ons = _get_hpi_info(info)
+    hpi_freqs, hpi_pick, hpi_ons = _get_hpi_info(info, allow_empty=allow_empty)
     _validate_type(t_window, (str, 'numeric'), 't_window')
     if isinstance(t_window, str):
         if t_window != 'auto':
             raise ValueError('t_window must be "auto" if a string, got %r'
                              % (t_window,))
-        t_window = max(5. / min(hpi_freqs), 1. / np.diff(hpi_freqs).min())
+        if len(hpi_freqs):
+            t_window = max(5. / min(hpi_freqs), 1. / np.diff(hpi_freqs).min())
+        else:
+            t_window = 0.2
     t_window = float(t_window)
     if t_window <= 0:
         raise ValueError('t_window (%s) must be > 0' % (t_window,))
@@ -1015,7 +1021,7 @@ def _chpi_locs_to_times_dig(chpi_locs):
 
 @verbose
 def filter_chpi(raw, include_line=True, t_step=0.01, t_window=None,
-                ext_order=1, verbose=None):
+                ext_order=1, allow_line_only=False, verbose=None):
     """Remove cHPI and line noise from data.
 
     .. note:: This function will only work properly if cHPI was on
@@ -1025,12 +1031,17 @@ def filter_chpi(raw, include_line=True, t_step=0.01, t_window=None,
     ----------
     raw : instance of Raw
         Raw data with cHPI information. Must be preloaded. Operates in-place.
-    include_line : bool
+    include_line : bool | int
         If True, also filter line noise.
     t_step : float
         Time step to use for estimation, default is 0.01 (10 ms).
     %(chpi_t_window)s
     %(chpi_ext_order)s
+    allow_line_only : bool
+        If True, allow filtering line noise only. The default is False,
+        which only allows the function to run when cHPI information is present.
+
+        .. versionadded:: 0.20
     %(verbose)s
 
     Returns
@@ -1047,6 +1058,7 @@ def filter_chpi(raw, include_line=True, t_step=0.01, t_window=None,
 
     .. versionadded:: 0.12
     """
+    _validate_type(raw, BaseRaw, 'raw')
     if not raw.preload:
         raise RuntimeError('raw data must be preloaded')
     if t_window is None:
@@ -1058,8 +1070,12 @@ def filter_chpi(raw, include_line=True, t_step=0.01, t_window=None,
     if t_step <= 0:
         raise ValueError('t_step (%s) must be > 0' % (t_step,))
     n_step = int(np.ceil(t_step * raw.info['sfreq']))
-    hpi = _setup_hpi_amplitude_fitting(raw.info, t_window, remove_aliased=True,
-                                       ext_order=ext_order, verbose=False)
+    if include_line and raw.info['line_freq'] is None:
+        raise RuntimeError('include_line=True but raw.info["line_freq"] is '
+                           'None, consider setting it to the line frequency')
+    hpi = _setup_hpi_amplitude_fitting(
+        raw.info, t_window, remove_aliased=True, ext_order=ext_order,
+        allow_empty=allow_line_only, verbose=False)
 
     fit_idxs = np.arange(0, len(raw.times) + hpi['n_window'] // 2, n_step)
     n_freqs = len(hpi['freqs'])


### PR DESCRIPTION
In principle we should be able to run `filter_chpi` to remove line frequencies even if cHPI is off. This is useful for example when processing files in batches where some have cHPI on/enabled and others don't.