### PR TITLE
MRG, FIX: Offload filtering step for find_bad_channels_maxwell

### DIFF
--- a/mne/io/array/array.py
+++ b/mne/io/array/array.py
@@ -53,7 +53,7 @@ class RawArray(BaseRaw):
     @verbose
     def __init__(self, data, info, first_samp=0, copy='auto',
                  verbose=None):  # noqa: D102
-        _validate_type(info, "info")
+        _validate_type(info, 'info', 'info')
         _check_option('copy', copy, ('data', 'info', 'both', 'auto', None))
         dtype = np.complex128 if np.any(np.iscomplex(data)) else np.float64
         orig_data = data

--- a/mne/io/proc_history.py
+++ b/mne/io/proc_history.py
@@ -3,8 +3,6 @@
 #          Eric Larson <larson.eric.d@gmail.com>
 # License: Simplified BSD
 
-from os import path as op
-
 import numpy as np
 from scipy.sparse import csc_matrix
 

--- a/mne/io/proc_history.py
+++ b/mne/io/proc_history.py
@@ -15,7 +15,7 @@ from .write import (start_block, end_block, write_int, write_float,
                     write_float_sparse, write_id)
 from .tag import find_tag
 from .constants import FIFF
-from ..utils import warn
+from ..utils import warn, _check_fname
 
 _proc_keys = ['parent_file_id', 'block_id', 'parent_block_id',
               'date', 'experimenter', 'creator']
@@ -165,8 +165,7 @@ _sss_cal_casters = (np.array, np.array)
 
 def _read_ctc(fname):
     """Read cross-talk correction matrix."""
-    if not isinstance(fname, str) or not op.isfile(fname):
-        raise ValueError('fname must be a file that exists, not %s' % fname)
+    fname = _check_fname(fname, overwrite='read', must_exist=True)
     f, tree, _ = fiff_open(fname)
     with f as fid:
         sss_ctc = _read_maxfilter_record(fid, tree)['sss_ctc']

--- a/mne/preprocessing/_fine_cal.py
+++ b/mne/preprocessing/_fine_cal.py
@@ -25,7 +25,7 @@ def read_fine_calibration(fname):
         Fine calibration information.
     """
     # Read new sensor locations
-    _check_fname(fname, overwrite='read', must_exist=True)
+    fname = _check_fname(fname, overwrite='read', must_exist=True)
     check_fname(fname, 'cal', ('.dat',))
     ch_names = list()
     locs = list()
@@ -68,7 +68,7 @@ def write_fine_calibration(fname, calibration):
     calibration : dict
         Fine calibration information.
     """
-    _check_fname(fname, overwrite=True)
+    fname = _check_fname(fname, overwrite=True)
     check_fname(fname, 'cal', ('.dat',))
 
     with open(fname, 'wb') as cal_file:

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -845,8 +845,6 @@ def _get_decomp(trans, all_coils, cal, regularize, exp, ignore_ref,
 
     # Pseudo-inverse of total multipolar moment basis set (Part of Eq. 37)
     cond = sing[0] / sing[-1]
-    # logger.debug('    Decomposition matrix condition (%0.3f/%0.3f): %0.1f'
-    #              % (sing[0], sing[-1], cond))
     if bad_condition != 'ignore' and cond >= 1000.:
         msg = 'Matrix is badly conditioned: %0.0f >= 1000' % cond
         if bad_condition == 'error':

--- a/mne/preprocessing/otp.py
+++ b/mne/preprocessing/otp.py
@@ -89,7 +89,7 @@ def oversampled_temporal_projection(raw, duration=10., picks=None,
 
     n_samp = int(round(float(duration) * raw.info['sfreq']))
     starts, stops, windows = _get_lims_cola(
-        n_samp, len(raw.times), raw.info['sfreq'], picks_good)
+        n_samp, len(raw.times), raw.info['sfreq'])
     min_samp = (stops - starts).min()
     if min_samp < len(picks_good) - 1:
         raise ValueError('duration (%s) yielded %s samples, which is fewer '

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1049,6 +1049,7 @@ def test_find_bad_channels_maxwell(bads):
     """Test automatic bad channel detection."""
     raw = mne.io.read_raw_fif(sample_fname, allow_maxshield='yes')
     raw.fix_mag_coil_types().load_data().pick_types(exclude=())
+    raw.filter(None, 40)
     raw.info['bads'] = bads
     # maxfilter -autobad on -v -f test_raw.fif -force -cal off -ctc off -regularize off -list -o test_raw.fif -f ~/mne_data/MNE-testing-data/MEG/sample/sample_audvis_trunc_raw.fif  # noqa: E501
     got_bads = find_bad_channels_maxwell(

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -3,8 +3,9 @@
 # License: BSD (3-clause)
 
 import os.path as op
-import numpy as np
+import pathlib
 
+import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
 from scipy import sparse
@@ -701,13 +702,14 @@ def test_cross_talk(tmpdir):
     raw.info['bads'] = bads
     sss_ctc = read_crop(sss_ctc_fname)
     with use_coil_def(elekta_def_fname):
-        raw_sss = maxwell_filter(raw, cross_talk=ctc_fname,
+        raw_sss = maxwell_filter(raw, cross_talk=pathlib.Path(ctc_fname),
                                  origin=mf_head_origin, regularize=None,
                                  bad_condition='ignore')
     assert_meg_snr(raw_sss, sss_ctc, 275.)
     py_ctc = raw_sss.info['proc_history'][0]['max_info']['sss_ctc']
     assert (len(py_ctc) > 0)
-    pytest.raises(ValueError, maxwell_filter, raw, cross_talk=raw)
+    with pytest.raises(TypeError, match='path-like'):
+        maxwell_filter(raw, cross_talk=raw)
     pytest.raises(ValueError, maxwell_filter, raw, cross_talk=raw_fname)
     mf_ctc = sss_ctc.info['proc_history'][0]['max_info']['sss_ctc']
     del mf_ctc['block_id']  # we don't write this
@@ -828,7 +830,7 @@ def test_shielding_factor(tmpdir):
     _assert_shielding(read_crop(sss_erm_fine_cal_fname), erm_power, 12)  # 2.0)
     raw_sss = maxwell_filter(raw_erm, coord_frame='meg', regularize=None,
                              origin=mf_meg_origin,
-                             calibration=fine_cal_fname)
+                             calibration=pathlib.Path(fine_cal_fname))
     _assert_shielding(raw_sss, erm_power, 12)  # 2.0)
 
     # Crosstalk

--- a/mne/preprocessing/utils.py
+++ b/mne/preprocessing/utils.py
@@ -27,7 +27,7 @@ def check_cola(win, nperseg, noverlap, tol=1e-10):
     return np.max(np.abs(deviation)) < tol
 
 
-def _get_lims_cola(n_samp, n_times, sfreq, picks):
+def _get_lims_cola(n_samp, n_times, sfreq):
     from scipy.signal import get_window
     if n_samp > n_times:
         raise ValueError('Effective duration (%s) must be at most the '

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -98,7 +98,10 @@ crosstalk_file = os.path.join(sample_data_folder, 'SSS', 'ct_sparse_mgh.fif')
 #     bad channel noise from spreading.
 #
 # Let's see if we can automatically detect it. To do this we need to
-# operate on a low-passed signal:
+# operate on a signal without line noise or cHPI signals, which is most
+# easily achieved using :func:`mne.chpi.filter_chpi`,
+# :func:`mne.io.Raw.notch_filter`, or :meth:`mne.io.Raw.filter`. For simplicity
+# we just low-pass filter these data:
 
 raw.info['bads'] = []
 raw_check = raw.copy().pick_types(exclude=()).filter(None, 40)


### PR DESCRIPTION
Moves the filtering step out of `find_bad_channels_maxwell`. This makes our outputs differ from MaxFilter a bit more, but:

1. It is better in principle (and practice) to filter all the data, then process in chunks, rather than filter each chunk independently (more edge artifacts)
2. By moving the filtering out of the function, it allows the user to choose the filtering tradeoffs
3. Based on inspecting the results with @hoechenberger , it seems like we do at least as well on this PR as we do in `master`

This PR also make a couple of tweaks found while working on this:

1. Improves `verbose=True` and `verbose='debug'` output messaging
2. Cleans up how `raw.plot` filtering triages FIR vs IIR to match what `mne/filter.py` does (leads to better `padlen` in `raw.plot`)
3. Cleans up unused var in `_get_lims_cola`
4. Separates Maxwell filtering steps a bit so that not as many things need to be recalculated

WIP for now while @hoechenberger and I test a bit more. Redo of #7432 which I errantly merged then force-pushed out of `master`.

Closes #7466