### PR TITLE
MRG, DOC: Clustering docstrings and connectivity=None

### DIFF
--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -1033,6 +1033,7 @@ Logging and Configuration
    set_log_level
    set_log_file
    set_config
+   set_cache_dir
    sys_info
    verbose
 

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1050,10 +1050,10 @@ def permutation_cluster_test(
         The data to be clustered. Each array in ``X`` should contain the
         observations for one group. The first dimension of each array is the
         number of observations from that group; remaining dimensions comprise
-        the size of a single observation. For example if X = [X1, X2]
-        with X1.shape = (20, 50, 4) and X2.shape = (17, 50, 4), then X has
-        2 groups with respectively 20 and 17 observations in each, and
-        each data point is of shape (50, 4).
+        the size of a single observation. For example if ``X = [X1, X2]``
+        with ``X1.shape = (20, 50, 4)`` and ``X2.shape = (17, 50, 4)``, then
+        ``X`` has 2 groups with respectively 20 and 17 observations in each,
+        and each data point is of shape ``(50, 4)``.
     %(clust_thresh_f)s
     %(clust_nperm_int)s
     %(clust_tail)s

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1069,6 +1069,7 @@ def permutation_cluster_test(
     %(clust_stepdown)s
     %(clust_power_f)s
     %(clust_out)s
+        Default is ``'mask'``.
     %(clust_disjoint)s
     %(clust_buffer)s
     %(verbose)s
@@ -1130,6 +1131,7 @@ def permutation_cluster_1samp_test(
     %(clust_stepdown)s
     %(clust_power_t)s
     %(clust_out)s
+        Default is ``'mask'``.
     %(clust_disjoint)s
     %(clust_buffer)s
     %(verbose)s
@@ -1214,6 +1216,7 @@ def spatio_temporal_cluster_1samp_test(
     %(clust_stepdown)s
     %(clust_power_t)s
     %(clust_out)s
+        Default is ``'indices'``.
     %(clust_disjoint)s
     %(clust_buffer)s
     %(verbose)s
@@ -1284,6 +1287,7 @@ def spatio_temporal_cluster_test(
     %(clust_stepdown)s
     %(clust_power_f)s
     %(clust_out)s
+        Default is ``'indices'``.
     %(clust_disjoint)s
     %(clust_buffer)s
 

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1046,14 +1046,14 @@ def permutation_cluster_test(
 
     Parameters
     ----------
-    X : list
-        List of nd-arrays containing the data. Each element of X contains
-        the samples for one group. First dimension of each element is the
-        number of samples/observations in this group. The other dimensions
-        are for the size of the observations. For example if X = [X1, X2]
-        with X1.shape = (20, 50, 4) and X2.shape = (17, 50, 4) one has
-        2 groups with respectively 20 and 17 observations in each.
-        Each data point is of shape (50, 4).
+    X : list of array, shape (n_observations, p[, q])
+        The data to be clustered. Each array in ``X`` should contain the
+        observations for one group. The first dimension of each array is the
+        number of observations from that group; remaining dimensions comprise
+        the size of a single observation. For example if X = [X1, X2]
+        with X1.shape = (20, 50, 4) and X2.shape = (17, 50, 4), then X has
+        2 groups with respectively 20 and 17 observations in each, and
+        each data point is of shape (50, 4).
     %(clust_thresh_f)s
     %(clust_nperm_int)s
     %(clust_tail)s
@@ -1113,11 +1113,13 @@ def permutation_cluster_1samp_test(
 
     Parameters
     ----------
-    X : array, shape=(n_samples, p[, q])
-        Array where the first dimension corresponds to the
-        difference in paired samples (observations) in two conditions.
-        ``X[k]`` can be a 1D or 2D array (time series
-        or TF image) associated to the kth observation.
+    X : array, shape (n_observations, p[, q])
+        The data to be clustered. The first dimension should correspond to the
+        difference between paired samples (observations) in two conditions.
+        The subarrays ``X[k]`` can be 1D (e.g., time series) or 2D (e.g.,
+        time-frequency image) associated with the kth observation. For
+        spatiotemporal data, see also
+        :func:`mne.stats.spatio_temporal_cluster_1samp_test`.
     %(clust_thresh_t)s
     %(clust_nperm_all)s
     %(clust_tail)s
@@ -1203,15 +1205,15 @@ def spatio_temporal_cluster_1samp_test(
         verbose=None):
     """Non-parametric cluster-level paired t-test for spatio-temporal data.
 
-    This function provides a convenient wrapper for data organized in the form
-    (observations x time x space) to use
-    :func:`mne.stats.permutation_cluster_1samp_test`, which contains more
-    complete documentation.
+    This function provides a convenient wrapper for
+    :func:`mne.stats.permutation_cluster_1samp_test`, for use with data
+    organized in the form (observations × time × space).
 
     Parameters
     ----------
     X : array, shape (n_observations, n_times, n_vertices)
-        Array data of the difference between two conditions.
+        The data to be clustered. The first dimension should correspond to the
+        difference between paired samples (observations) in two conditions.
     %(clust_thresh_t)s
     %(clust_nperm_all)s
     %(clust_tail)s
@@ -1279,15 +1281,19 @@ def spatio_temporal_cluster_test(
         check_disjoint=False, buffer_size=1000):
     """Non-parametric cluster-level test for spatio-temporal data.
 
-    This function provides a convenient wrapper for data organized in the form
-    (observations x time x space) to use
-    :func:`mne.stats.permutation_cluster_test`. See [1]_ for more information.
+    This function provides a convenient wrapper for
+    :func:`mne.stats.permutation_cluster_test`, for use with data
+    organized in the form (observations × time × space).
+    See [1]_ for more information.
 
     Parameters
     ----------
-    X : list of array
-        List of data arrays, shape ``(n_observations, n_times, n_vertices)``
-        in each group.
+    X : list of array, shape (n_observations, n_times, n_vertices)
+        The data to be clustered. Each array in ``X`` should contain the
+        observations for one group. The first dimension of each array is the
+        number of observations from that group (and may vary between groups);
+        the remaining dimensions (times and vertices) should match across all
+        groups.
     %(clust_thresh_f)s
     %(clust_nperm_int)s
     %(clust_tail)s

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1058,11 +1058,7 @@ def permutation_cluster_test(
     %(clust_nperm_int)s
     %(clust_tail)s
     %(clust_stat_f)s
-    connectivity : scipy.sparse.spmatrix
-        Defines connectivity between features. The matrix is assumed to
-        be symmetric and only the upper triangular half is used.
-        Default is None, i.e, a regular lattice connectivity.
-        Can also be False to assume no connectivity.
+    %(clust_conn_nsamp)s
     %(n_jobs)s
     %(seed)s
     %(clust_maxstep)s
@@ -1122,14 +1118,7 @@ def permutation_cluster_1samp_test(
     %(clust_nperm_all)s
     %(clust_tail)s
     %(clust_stat_t)s
-    connectivity : scipy.sparse.spmatrix | None | False
-        Defines connectivity between features. The matrix is assumed to
-        be symmetric and only the upper triangular half is used.
-        This matrix must be square with dimension (n_vertices * n_times) or
-        (n_vertices). Default is None, i.e, a regular lattice connectivity.
-        Use square n_vertices matrix for datasets with a large temporal
-        extent to save on memory and computation time. Can also be False
-        to assume no connectivity.
+    %(clust_conn_1samp)s
     %(verbose)s
     %(n_jobs)s
     %(seed)s
@@ -1216,13 +1205,7 @@ def spatio_temporal_cluster_1samp_test(
     %(clust_nperm_all)s
     %(clust_tail)s
     %(clust_stat_t)s
-    connectivity : scipy.sparse.spmatrix or None
-        Defines connectivity between features. The matrix is assumed to
-        be symmetric and only the upper triangular half is used.
-        This matrix must be square with dimension (n_vertices * n_times) or
-        (n_vertices). Default is None, i.e, a regular lattice connectivity.
-        Use square n_vertices matrix for datasets with a large temporal
-        extent to save on memory and computation time.
+    %(clust_conn_st_1samp)s
     %(n_jobs)s
     %(seed)s
     %(clust_maxstep)s
@@ -1291,10 +1274,7 @@ def spatio_temporal_cluster_test(
     %(clust_nperm_int)s
     %(clust_tail)s
     %(clust_stat_f)s
-    connectivity : scipy.sparse.spmatrix or None
-        Defines connectivity between features. The matrix is assumed to
-        be symmetric and only the upper triangular half is used.
-        Default is None, i.e, a regular lattice connectivity.
+    %(clust_conn_st_nsamp)s
     %(verbose)s
     %(n_jobs)s
     %(seed)s

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1042,7 +1042,7 @@ def permutation_cluster_test(
     multiple comparisons using permutations and cluster level correction.
     Each element of the list X contains the data for one group of
     observations. Randomized data are generated with random partitions
-    of the data.
+    of the data. See :footcite:`MarisOostenveld2007` for details.
 
     Parameters
     ----------
@@ -1090,9 +1090,7 @@ def permutation_cluster_test(
 
     References
     ----------
-    .. [1] Maris/Oostenveld (2007), "Nonparametric statistical testing of
-       EEG- and MEG-data" Journal of Neuroscience Methods,
-       Vol. 164, No. 1., pp. 177-190. doi:10.1016/j.jneumeth.2007.03.024.
+    .. footbibliography::
     """
     stat_fun, threshold = _check_fun(X, stat_fun, threshold, tail, 'between')
     return _permutation_cluster_test(
@@ -1165,7 +1163,8 @@ def permutation_cluster_1samp_test(
     distributions in the two conditions are significantly different.
     The procedure uses a cluster analysis with permutation test
     for calculating corrected p-values. Randomized data are generated with
-    random sign flips. See [1]_ for more information.
+    random sign flips. See :footcite:`MarisOostenveld2007` for more
+    information.
 
     Because a 1-sample t-test on the difference in observations is
     mathematically equivalent to a paired t-test, internally this function
@@ -1183,9 +1182,7 @@ def permutation_cluster_1samp_test(
 
     References
     ----------
-    .. [1] Maris/Oostenveld (2007), "Nonparametric statistical testing of
-       EEG- and MEG-data" Journal of Neuroscience Methods,
-       Vol. 164, No. 1., pp. 177-190. doi:10.1016/j.jneumeth.2007.03.024.
+    .. footbibliography::
     """
     stat_fun, threshold = _check_fun(X, stat_fun, threshold, tail)
     return _permutation_cluster_test(
@@ -1207,7 +1204,8 @@ def spatio_temporal_cluster_1samp_test(
 
     This function provides a convenient wrapper for
     :func:`mne.stats.permutation_cluster_1samp_test`, for use with data
-    organized in the form (observations × time × space).
+    organized in the form (observations × time × space). See
+    :footcite:`MarisOostenveld2007` for details.
 
     Parameters
     ----------
@@ -1251,12 +1249,7 @@ def spatio_temporal_cluster_1samp_test(
 
     References
     ----------
-    .. [1] Maris/Oostenveld, "Nonparametric statistical testing of
-       EEG- and MEG-data" Journal of Neuroscience Methods,
-       Vol. 164, No. 1., pp. 177-190. doi:10.1016/j.jneumeth.2007.03.024
-    .. [2] Smith/Nichols (2009), "Threshold-free cluster enhancement:
-       Addressing problems of smoothing, threshold dependence, and
-       localisation in cluster inference", NeuroImage 44 (2009) 83-98.
+    .. footbibliography::
     """
     n_samples, n_times, n_vertices = X.shape
     # convert spatial_exclude before passing on if necessary
@@ -1284,7 +1277,7 @@ def spatio_temporal_cluster_test(
     This function provides a convenient wrapper for
     :func:`mne.stats.permutation_cluster_test`, for use with data
     organized in the form (observations × time × space).
-    See [1]_ for more information.
+    See :footcite::`MarisOostenveld2007` for more information.
 
     Parameters
     ----------
@@ -1327,9 +1320,7 @@ def spatio_temporal_cluster_test(
 
     References
     ----------
-    .. [1] Maris/Oostenveld (2007), "Nonparametric statistical testing of
-       EEG- and MEG-data", Journal of Neuroscience Methods,
-       Vol. 164, No. 1., pp. 177-190. doi:10.1016/j.jneumeth.2007.03.024.
+    .. footbibliography::
     """
     n_samples, n_times, n_vertices = X[0].shape
     # convert spatial_exclude before passing on if necessary

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1263,7 +1263,7 @@ def spatio_temporal_cluster_test(
     This function provides a convenient wrapper for
     :func:`mne.stats.permutation_cluster_test`, for use with data
     organized in the form (observations × time × space).
-    See :footcite::`MarisOostenveld2007` for more information.
+    See :footcite:`MarisOostenveld2007` for more information.
 
     Parameters
     ----------

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1054,24 +1054,10 @@ def permutation_cluster_test(
         with X1.shape = (20, 50, 4) and X2.shape = (17, 50, 4) one has
         2 groups with respectively 20 and 17 observations in each.
         Each data point is of shape (50, 4).
-    threshold : float | dict | None
-        If threshold is None, it will choose an F-threshold equivalent to
-        p < 0.05 for the given number of observations (only valid when
-        using an F-statistic). If a dict is used, then threshold-free
-        cluster enhancement (TFCE) will be used, and it must have keys
-        ``'start'`` and ``'step'`` to specify the integration parameters,
-        see the :ref:`TFCE example <tfce_example>`.
-    n_permutations : int
-        The number of permutations to compute.
-    tail : -1 or 0 or 1 (default = 0)
-        If tail is 0, the statistic is thresholded on both sides of
-        the distribution.
-        If tail is 1, the statistic is thresholded above threshold.
-        If tail is -1, the statistic is thresholded below threshold, and
-        the values in ``threshold`` must correspondingly be negative.
-    stat_fun : callable | None
-        Function called to calculate statistics, must accept 1d-arrays as
-        arguments (default None uses :func:`mne.stats.f_oneway`).
+    %(clust_thresh_f)s
+    %(clust_nperm_int)s
+    %(clust_tail)s
+    %(clust_stat_f)s
     connectivity : scipy.sparse.spmatrix
         Defines connectivity between features. The matrix is assumed to
         be symmetric and only the upper triangular half is used.
@@ -1079,44 +1065,16 @@ def permutation_cluster_test(
         Can also be False to assume no connectivity.
     %(n_jobs)s
     %(seed)s
-    max_step : int
-        When connectivity is a n_vertices x n_vertices matrix, specify the
-        maximum number of steps between vertices along the second dimension
-        (typically time) to be considered connected. This is not used for full
-        or None connectivity matrices.
+    %(clust_maxstep)s
     exclude : bool array or None
         Mask to apply to the data to exclude certain points from clustering
         (e.g., medial wall vertices). Should be the same shape as X. If None,
         no points are excluded.
-    step_down_p : float
-        To perform a step-down-in-jumps test, pass a p-value for clusters to
-        exclude from each successive iteration. Default is zero, perform no
-        step-down test (since no clusters will be smaller than this value).
-        Setting this to a reasonable value, e.g. 0.05, can increase sensitivity
-        but costs computation time.
-    t_power : float
-        Power to raise the statistical values (usually F-values) by before
-        summing (sign will be retained). Note that t_power == 0 will give a
-        count of nodes in each cluster, t_power == 1 will weight each node by
-        its statistical score.
-    out_type : str
-        For arrays with connectivity, this sets the output format for clusters.
-        If 'mask', it will pass back a list of boolean mask arrays.
-        If 'indices', it will pass back a list of lists, where each list is the
-        set of vertices in a given cluster. Note that the latter may use far
-        less memory for large datasets.
-    check_disjoint : bool
-        If True, the connectivity matrix (or list) will be examined to
-        determine of it can be separated into disjoint sets. In some cases
-        (usually with connectivity as a list and many "time" points), this
-        can lead to faster clustering, but results should be identical.
-    buffer_size : int or None
-        The statistics will be computed for blocks of variables of size
-        "buffer_size" at a time. This is option significantly reduces the
-        memory requirements when n_jobs > 1 and memory sharing between
-        processes is enabled (see set_cache_dir()), as X will be shared
-        between processes and each process only needs to allocate space
-        for a small block of variables.
+    %(clust_stepdown)s
+    %(clust_power_f)s
+    %(clust_out)s
+    %(clust_disjoint)s
+    %(clust_buffer)s
     %(verbose)s
 
     Returns
@@ -1160,24 +1118,10 @@ def permutation_cluster_1samp_test(
         difference in paired samples (observations) in two conditions.
         ``X[k]`` can be a 1D or 2D array (time series
         or TF image) associated to the kth observation.
-    threshold : float | dict | None
-        If threshold is None, it will choose a t-threshold equivalent to
-        p < 0.05 for the given number of observations (only valid when
-        using an t-statistic). If a dict is used, then threshold-free
-        cluster enhancement (TFCE) will be used, and it must have keys
-        ``'start'`` and ``'step'`` to specify the integration parameters,
-        see the :ref:`TFCE example <tfce_example>`.
-    n_permutations : int | 'all'
-        The maximum number of permutations to compute. Can be 'all'
-        to perform an exact test.
-    tail : -1 or 0 or 1 (default = 0)
-        If tail is 1, the statistic is thresholded above threshold.
-        If tail is -1, the statistic is thresholded below threshold.
-        If tail is 0, the statistic is thresholded on both sides of
-        the distribution.
-    stat_fun : callable | None
-        Function used to compute the statistical map (default None will use
-        :func:`mne.stats.ttest_1samp_no_p`).
+    %(clust_thresh_t)s
+    %(clust_nperm_all)s
+    %(clust_tail)s
+    %(clust_stat_t)s
     connectivity : scipy.sparse.spmatrix | None | False
         Defines connectivity between features. The matrix is assumed to
         be symmetric and only the upper triangular half is used.
@@ -1189,44 +1133,17 @@ def permutation_cluster_1samp_test(
     %(verbose)s
     %(n_jobs)s
     %(seed)s
-    max_step : int
-        When connectivity is a n_vertices x n_vertices matrix, specify the
-        maximum number of steps between vertices along the second dimension
-        (typically time) to be considered connected. This is not used for full
-        or None connectivity matrices.
+    %(clust_maxstep)s
     exclude : bool array or None
         Mask to apply to the data to exclude certain points from clustering
         (e.g., medial wall vertices). Should be the same shape as X. If None,
         no points are excluded.
-    step_down_p : float
-        To perform a step-down-in-jumps test, pass a p-value for clusters to
-        exclude from each successive iteration. Default is zero, perform no
-        step-down test (since no clusters will be smaller than this value).
-        Setting this to a reasonable value, e.g. 0.05, can increase sensitivity
-        but costs computation time.
-    t_power : float
-        Power to raise the statistical values (usually t-values) by before
-        summing (sign will be retained). Note that t_power == 0 will give a
-        count of nodes in each cluster, t_power == 1 will weight each node by
-        its statistical score.
-    out_type : str
-        For arrays with connectivity, this sets the output format for clusters.
-        If 'mask', it will pass back a list of boolean mask arrays.
-        If 'indices', it will pass back a list of lists, where each list is the
-        set of vertices in a given cluster. Note that the latter may use far
-        less memory for large datasets.
-    check_disjoint : bool
-        If True, the connectivity matrix (or list) will be examined to
-        determine of it can be separated into disjoint sets. In some cases
-        (usually with connectivity as a list and many "time" points), this
-        can lead to faster clustering, but results should be identical.
-    buffer_size : int or None
-        The statistics will be computed for blocks of variables of size
-        "buffer_size" at a time. This is option significantly reduces the
-        memory requirements when n_jobs > 1 and memory sharing between
-        processes is enabled (see set_cache_dir()), as X will be shared
-        between processes and each process only needs to allocate space
-        for a small block of variables.
+    %(clust_stepdown)s
+    %(clust_power_t)s
+    %(clust_out)s
+    %(clust_disjoint)s
+    %(clust_buffer)s
+    %(verbose)s
 
     Returns
     -------
@@ -1295,24 +1212,10 @@ def spatio_temporal_cluster_1samp_test(
     ----------
     X : array, shape (n_observations, n_times, n_vertices)
         Array data of the difference between two conditions.
-    threshold : float | dict | None
-        If threshold is None, it will choose a t-threshold equivalent to
-        p < 0.05 for the given number of observations (only valid when
-        using an t-statistic). If a dict is used, then threshold-free
-        cluster enhancement (TFCE) will be used, and it must have keys
-        ``'start'`` and ``'step'`` to specify the integration parameters,
-        see the :ref:`TFCE example <tfce_example>`.
-    n_permutations : int | 'all'
-        The number of permutations to compute. Can be "all" to perform
-        an exact test.
-    tail : -1 or 0 or 1 (default = 0)
-        If tail is 1, the statistic is thresholded above threshold.
-        If tail is -1, the statistic is thresholded below threshold.
-        If tail is 0, the statistic is thresholded on both sides of
-        the distribution.
-    stat_fun : callable | None
-        Function used to compute the statistical map (default None will use
-        :func:`mne.stats.ttest_1samp_no_p`).
+    %(clust_thresh_t)s
+    %(clust_nperm_all)s
+    %(clust_tail)s
+    %(clust_stat_t)s
     connectivity : scipy.sparse.spmatrix or None
         Defines connectivity between features. The matrix is assumed to
         be symmetric and only the upper triangular half is used.
@@ -1322,42 +1225,15 @@ def spatio_temporal_cluster_1samp_test(
         extent to save on memory and computation time.
     %(n_jobs)s
     %(seed)s
-    max_step : int
-        When connectivity is a n_vertices x n_vertices matrix, specify the
-        maximum number of steps between vertices along the second dimension
-        (typically time) to be considered connected. This is not used for full
-        or None connectivity matrices.
+    %(clust_maxstep)s
     spatial_exclude : list of int or None
         List of spatial indices to exclude from clustering.
-    step_down_p : float
-        To perform a step-down-in-jumps test, pass a p-value for clusters to
-        exclude from each successive iteration. Default is zero, perform no
-        step-down test (since no clusters will be smaller than this value).
-        Setting this to a reasonable value, e.g. 0.05, can increase sensitivity
-        but costs computation time.
-    t_power : float
-        Power to raise the statistical values (usually t-values) by before
-        summing (sign will be retained). Note that t_power == 0 will give a
-        count of nodes in each cluster, t_power == 1 will weight each node by
-        its statistical score.
-    out_type : str
-        For arrays with connectivity, this sets the output format for clusters.
-        If 'mask', it will pass back a list of boolean mask arrays.
-        If 'indices', it will pass back a list of lists, where each list is the
-        set of vertices in a given cluster. Note that the latter may use far
-        less memory for large datasets.
-    check_disjoint : bool
-        If True, the connectivity matrix (or list) will be examined to
-        determine of it can be separated into disjoint sets. In some cases
-        (usually with connectivity as a list and many "time" points), this
-        can lead to faster clustering, but results should be identical.
-    buffer_size : int or None
-        The statistics will be computed for blocks of variables of size
-        "buffer_size" at a time. This is option significantly reduces the
-        memory requirements when n_jobs > 1 and memory sharing between
-        processes is enabled (see set_cache_dir()), as X will be shared
-        between processes and each process only needs to allocate space
-        for a small block of variables.
+    %(clust_stepdown)s
+    %(clust_power_t)s
+    %(clust_out)s
+    %(clust_disjoint)s
+    %(clust_buffer)s
+    %(verbose)s
     %(verbose)s
 
     Returns
@@ -1412,21 +1288,10 @@ def spatio_temporal_cluster_test(
     X : list of array
         List of data arrays, shape ``(n_observations, n_times, n_vertices)``
         in each group.
-    threshold : float | dict | None
-        If threshold is None, it will choose an F-threshold equivalent to
-        p < 0.05 for the given number of observations (only valid when
-        using an F-statistic). If a dict is used, then threshold-free
-        cluster enhancement (TFCE) will be used, and it must have keys
-        ``'start'`` and ``'step'`` to specify the integration parameters,
-        see the :ref:`TFCE example <tfce_example>`.
-    n_permutations : int
-        See permutation_cluster_test.
-    tail : -1 or 0 or 1 (default = 0)
-        See permutation_cluster_test.
-    stat_fun : callable | None
-        Function called to calculate statistics, must accept 1d-arrays as
-        arguments (default None uses :func:`mne.stats.f_oneway`). It
-        should also return a 1-d array.
+    %(clust_thresh_f)s
+    %(clust_nperm_int)s
+    %(clust_tail)s
+    %(clust_stat_f)s
     connectivity : scipy.sparse.spmatrix or None
         Defines connectivity between features. The matrix is assumed to
         be symmetric and only the upper triangular half is used.
@@ -1434,42 +1299,14 @@ def spatio_temporal_cluster_test(
     %(verbose)s
     %(n_jobs)s
     %(seed)s
-    max_step : int
-        When connectivity is a n_vertices x n_vertices matrix, specify the
-        maximum number of steps between vertices along the second dimension
-        (typically time) to be considered connected. This is not used for full
-        or None connectivity matrices.
+    %(clust_maxstep)s
     spatial_exclude : list of int or None
         List of spatial indices to exclude from clustering.
-    step_down_p : float
-        To perform a step-down-in-jumps test, pass a p-value for clusters to
-        exclude from each successive iteration. Default is zero, perform no
-        step-down test (since no clusters will be smaller than this value).
-        Setting this to a reasonable value, e.g. 0.05, can increase sensitivity
-        but costs computation time.
-    t_power : float
-        Power to raise the statistical values (usually F-values) by before
-        summing (sign will be retained). Note that t_power == 0 will give a
-        count of nodes in each cluster, t_power == 1 will weight each node by
-        its statistical score.
-    out_type : str
-        For arrays with connectivity, this sets the output format for clusters.
-        If 'mask', it will pass back a list of boolean mask arrays.
-        If 'indices', it will pass back a list of lists, where each list is the
-        set of vertices in a given cluster. Note that the latter may use far
-        less memory for large datasets.
-    check_disjoint : bool
-        If True, the connectivity matrix (or list) will be examined to
-        determine of it can be separated into disjoint sets. In some cases
-        (usually with connectivity as a list and many "time" points), this
-        can lead to faster clustering, but results should be identical.
-    buffer_size : int or None
-        The statistics will be computed for blocks of variables of size
-        "buffer_size" at a time. This is option significantly reduces the
-        memory requirements when n_jobs > 1 and memory sharing between
-        processes is enabled (see set_cache_dir()), as X will be shared
-        between processes and each process only needs to allocate space
-        for a small block of variables.
+    %(clust_stepdown)s
+    %(clust_power_f)s
+    %(clust_out)s
+    %(clust_disjoint)s
+    %(clust_buffer)s
 
     Returns
     -------

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1058,7 +1058,7 @@ def permutation_cluster_test(
     %(clust_nperm_int)s
     %(clust_tail)s
     %(clust_stat_f)s
-    %(clust_conn_nsamp)s
+    %(clust_con_n)s
     %(n_jobs)s
     %(seed)s
     %(clust_maxstep)s
@@ -1119,7 +1119,7 @@ def permutation_cluster_1samp_test(
     %(clust_nperm_all)s
     %(clust_tail)s
     %(clust_stat_t)s
-    %(clust_conn_1samp)s
+    %(clust_con_1)s
     %(verbose)s
     %(n_jobs)s
     %(seed)s
@@ -1207,7 +1207,7 @@ def spatio_temporal_cluster_1samp_test(
     %(clust_nperm_all)s
     %(clust_tail)s
     %(clust_stat_t)s
-    %(clust_conn_st_1samp)s
+    %(clust_con_st1)s
     %(n_jobs)s
     %(seed)s
     %(clust_maxstep)s
@@ -1277,7 +1277,7 @@ def spatio_temporal_cluster_test(
     %(clust_nperm_int)s
     %(clust_tail)s
     %(clust_stat_f)s
-    %(clust_conn_st_nsamp)s
+    %(clust_con_stn)s
     %(verbose)s
     %(n_jobs)s
     %(seed)s

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -808,17 +808,17 @@ stat_fun : callable | None
 """
 docdict['clust_stat_f'] = docdict['clust_stat'].format('f_oneway')
 docdict['clust_stat_t'] = docdict['clust_stat'].format('ttest_1samp_no_p')
-docdict['clust_conn'] = """
+docdict['clust_con'] = """
 connectivity : scipy.sparse.spmatrix | None | False
     Defines connectivity between locations in the data, where "locations" can
     be spatial vertices, frequency bins, etc. If ``False``, assumes no
     connectivity (each location is treated as independent and unconnected).
     If ``None``, a regular lattice connectivity is assumed, connecting
-    each {sp} location to its neighbor(s) along the last dimension of {eachgrp}
-    ``{x}``{lastdim}.
+    each {sp} location to its neighbor(s) along the last dimension
+    of {{eachgrp}} ``{{x}}``{lastdim}.
     If ``connectivity`` is a matrix, it is assumed to be symmetric (only the
     upper triangular half is used) and must be square with dimension equal to
-    ``{x}.shape[-1]`` {parone} or ``{x}.shape[-1] * {x}.shape[-2]``
+    ``{{x}}.shape[-1]`` {parone} or ``{{x}}.shape[-1] * {{x}}.shape[-2]``
     {partwo}.{memory}
 """
 mem = (' If spatial connectivity is uniform in time, it is recommended to use '
@@ -827,14 +827,14 @@ mem = (' If spatial connectivity is uniform in time, it is recommended to use '
        'of temporal adjacency to consider when clustering.')
 st = dict(sp='spatial', lastdim='', parone='(n_vertices)',
           partwo='(n_times * n_vertices)', memory=mem)
-tf = dict(sp='', lastdim=' (or the last two dimensions if {x} is 2D)',
+tf = dict(sp='', lastdim=' (or the last two dimensions if ``{x}`` is 2D)',
           parone='', partwo='', memory='')
 nogroups = dict(eachgrp='', x='X')
 groups = dict(eachgrp='each group ', x='X[k]')
-docdict['clust_conn_st_1samp'] = docdict['clust_conn'].format(**st, **nogroups)
-docdict['clust_conn_st_nsamp'] = docdict['clust_conn'].format(**st, **groups)
-docdict['clust_conn_1samp'] = docdict['clust_conn'].format(**tf, **nogroups)
-docdict['clust_conn_nsamp'] = docdict['clust_conn'].format(**tf, **groups)
+docdict['clust_con_st1'] = docdict['clust_con'].format(**st).format(**nogroups)
+docdict['clust_con_stn'] = docdict['clust_con'].format(**st).format(**groups)
+docdict['clust_con_1'] = docdict['clust_con'].format(**tf).format(**nogroups)
+docdict['clust_con_n'] = docdict['clust_con'].format(**tf).format(**groups)
 docdict['clust_maxstep'] = """
 max_step : int
     Maximum distance along the second dimension (typically this is the "time"

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -818,10 +818,10 @@ connectivity : scipy.sparse.spmatrix | None | False
     ``{x}``{lastdim}.
     If ``connectivity`` is a matrix, it is assumed to be symmetric (only the
     upper triangular half is used) and must be square with dimension equal to
-    ``{x}.shape[-1]`` {parone} or ``{x}.shape[-1] * {x}.shape[-2]`` {partwo}.
-    {memory}
+    ``{x}.shape[-1]`` {parone} or ``{x}.shape[-1] * {x}.shape[-2]``
+    {partwo}.{memory}
 """
-mem = ('If spatial connectivity is uniform in time, it is recommended to use '
+mem = (' If spatial connectivity is uniform in time, it is recommended to use '
        'a square matrix with dimension ``{x}.shape[-1]`` (n_vertices) to save '
        'memory and computation, and to use ``max_step`` to define the extent '
        'of temporal adjacency to consider when clustering.')

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -771,6 +771,90 @@ Valid values for ``mode`` are:
     similar STCs does not result in 180° direction/phase changes.
 """
 
+# Clustering
+docdict['clust_thresh'] = """
+threshold : float | dict | None
+    If numeric, vertices with data values more extreme than ``threshold`` will
+    be used to form clusters. If threshold is ``None``, {} will be chosen
+    automatically that corresponds to a p-value of 0.05 for the given number of
+    observations (only valid when using {}). If ``threshold`` is a
+    :class:`dict` (with keys ``'start'`` and ``'step'``) then threshold-free
+    cluster enhancement (TFCE) will be used (see the
+    :ref:`TFCE example <tfce_example>`).
+"""
+f_test = ('an F-threshold', 'an F-statistic')
+t_test = ('a t-threshold', 'a t-statistic')
+docdict['clust_thresh_f'] = docdict['clust_thresh'].format(*f_test)
+docdict['clust_thresh_t'] = docdict['clust_thresh'].format(*t_test)
+docdict['clust_nperm'] = """
+n_permutations : int{}
+    The number of permutations to compute.{}
+"""
+nperm_all = (" | 'all'", " Can be 'all' to perform an exact test.")
+docdict['clust_nperm_all'] = docdict['clust_nperm'].format(*nperm_all)
+docdict['clust_nperm_int'] = docdict['clust_nperm'].format('', '')
+docdict['clust_tail'] = """
+tail : int
+    If tail is 1, the statistic is thresholded above threshold.
+    If tail is -1, the statistic is thresholded below threshold.
+    If tail is 0, the statistic is thresholded on both sides of
+    the distribution.
+"""
+docdict['clust_stat'] = """
+stat_fun : callable | None
+    Function called to calculate the test statistic. Must accept 1D-array as
+    input and return a 1D array. If ``None`` (the default), uses
+    :func:`mne.stats.{}`.
+"""
+docdict['clust_stat_f'] = docdict['clust_stat'].format('f_oneway')
+docdict['clust_stat_t'] = docdict['clust_stat'].format('ttest_1samp_no_p')
+docdict['clust_maxstep'] = """
+max_step : int
+    Maximum distance along the second dimension (typically this is the "time"
+    axis) between samples that are considered "connected". Only used
+    when ``connectivity`` has shape (n_vertices, n_vertices).
+"""
+docdict['clust_stepdown'] = """
+step_down_p : float
+    To perform a step-down-in-jumps test, pass a p-value for clusters to
+    exclude from each successive iteration. Default is zero, perform no
+    step-down test (since no clusters will be smaller than this value).
+    Setting this to a reasonable value, e.g. 0.05, can increase sensitivity
+    but costs computation time.
+"""
+docdict['clust_power'] = """
+t_power : float
+    Power to raise the statistical values (usually {}-values) by before
+    summing (sign will be retained). Note that ``t_power=0`` will give a
+    count of locations in each cluster, ``t_power=1`` will weight each location
+    by its statistical score.
+"""
+docdict['clust_power_t'] = docdict['clust_power'].format('t')
+docdict['clust_power_f'] = docdict['clust_power'].format('F')
+docdict['clust_out'] = """
+out_type : 'mask' | 'indices'
+    Output format of clusters. If ``'mask'``, returns boolean arrays the same
+    shape as the input data, with ``True`` values indicating locations that are
+    part of a cluster. If ``'indices'``, returns a list of lists, where each
+    sublist contains the indices of locations that together form a cluster.
+    Note that for large datasets, ``'indices'`` may use far less memory than
+    ``'mask'``. Default is ``'indices'``.
+"""
+docdict['clust_disjoint'] = """
+check_disjoint : bool
+    Whether to check if the connectivity matrix can be separated into disjoint
+    sets before clustering. This may lead to faster clustering, especially if
+    the second dimension of ``X`` (usually the "time" dimension) is large.
+"""
+docdict['clust_buffer'] = """
+buffer_size : int | None
+    Block size to use when computing test statistics. This can significantly
+    reduce memory usage when n_jobs > 1 and memory sharing between processes is
+    enabled (see :func:`mne.set_cache_dir`), because ``X`` will be shared
+    between processes and each process only needs to allocate space for a small
+    block of locations at a time.
+"""
+
 # DataFrames
 docdict['df_scaling_time_deprecated'] = """
 scaling_time : None

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -813,8 +813,8 @@ connectivity : scipy.sparse.spmatrix | None | False
     Defines connectivity between locations in the data, where "locations" can
     be spatial vertices, frequency bins, etc. If ``False``, assumes no
     connectivity (each location is treated as independent and unconnected).
-    If ``None``, a regular lattice connectivity is assumed, connecting each
-    {sp} location to its neighbor(s) along the last dimension of {eachgrp}
+    If ``None``, a regular lattice connectivity is assumed, connecting
+    each {sp} location to its neighbor(s) along the last dimension of {eachgrp}
     ``{x}``{lastdim}.
     If ``connectivity`` is a matrix, it is assumed to be symmetric (only the
     upper triangular half is used) and must be square with dimension equal to
@@ -865,7 +865,7 @@ out_type : 'mask' | 'indices'
     part of a cluster. If ``'indices'``, returns a list of lists, where each
     sublist contains the indices of locations that together form a cluster.
     Note that for large datasets, ``'indices'`` may use far less memory than
-    ``'mask'``. Default is ``'indices'``.
+    ``'mask'``.
 """
 docdict['clust_disjoint'] = """
 check_disjoint : bool

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -808,6 +808,33 @@ stat_fun : callable | None
 """
 docdict['clust_stat_f'] = docdict['clust_stat'].format('f_oneway')
 docdict['clust_stat_t'] = docdict['clust_stat'].format('ttest_1samp_no_p')
+docdict['clust_conn'] = """
+connectivity : scipy.sparse.spmatrix | None | False
+    Defines connectivity between locations in the data, where "locations" can
+    be spatial vertices, frequency bins, etc. If ``False``, assumes no
+    connectivity (each location is treated as independent and unconnected).
+    If ``None``, a regular lattice connectivity is assumed, connecting each
+    {sp} location to its neighbor(s) along the last dimension of {eachgrp}
+    ``{x}``{lastdim}.
+    If ``connectivity`` is a matrix, it is assumed to be symmetric (only the
+    upper triangular half is used) and must be square with dimension equal to
+    ``{x}.shape[-1]`` {parone} or ``{x}.shape[-1] * {x}.shape[-2]`` {partwo}.
+    {memory}
+"""
+mem = ('If spatial connectivity is uniform in time, it is recommended to use '
+       'a square matrix with dimension ``{x}.shape[-1]`` (n_vertices) to save '
+       'memory and computation, and to use ``max_step`` to define the extent '
+       'of temporal adjacency to consider when clustering.')
+st = dict(sp='spatial', lastdim='', parone='(n_vertices)',
+          partwo='(n_times * n_vertices)', memory=mem)
+tf = dict(sp='', lastdim=' (or the last two dimensions if {x} is 2D)',
+          parone='', partwo='', memory='')
+nogroups = dict(eachgrp='', x='X')
+groups = dict(eachgrp='each group ', x='X[k]')
+docdict['clust_conn_st_1samp'] = docdict['clust_conn'].format(**st, **nogroups)
+docdict['clust_conn_st_nsamp'] = docdict['clust_conn'].format(**st, **groups)
+docdict['clust_conn_1samp'] = docdict['clust_conn'].format(**tf, **nogroups)
+docdict['clust_conn_nsamp'] = docdict['clust_conn'].format(**tf, **groups)
 docdict['clust_maxstep'] = """
 max_step : int
     Maximum distance along the second dimension (typically this is the "time"

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -780,7 +780,7 @@ threshold : float | dict | None
     observations (only valid when using {}). If ``threshold`` is a
     :class:`dict` (with keys ``'start'`` and ``'step'``) then threshold-free
     cluster enhancement (TFCE) will be used (see the
-    :ref:`TFCE example <tfce_example>`).
+    :ref:`TFCE example <tfce_example>` and :footcite:`SmithNichols2009`).
 """
 f_test = ('an F-threshold', 'an F-statistic')
 t_test = ('a t-threshold', 'a t-statistic')


### PR DESCRIPTION
In preparation for addressing #7463, this cleans up the docstrings for the 4 public-facing clustering functions:

- `mne.stats.permutation_cluster_test`
- `mne.stats.permutation_cluster_1samp_test`
- `mne.stats.spatio_temporal_cluster_test`
- `mne.stats.spatio_temporal_cluster_1samp_test`

remaining tasks:

- [x] figure out whether to change behavior of `connectivity=None` (see #7463 for discussion) *after extensive testing: I was wrong, everything works as expected with the current implementation.* closes #7463
- [x] revise entry for `connectivity` parameter in docstrings accordingly.
