### PR TITLE
MRG: [DOC] MNE does no longer auto apply average ref

### DIFF
--- a/examples/preprocessing/plot_rereference_eeg.py
+++ b/examples/preprocessing/plot_rereference_eeg.py
@@ -45,7 +45,7 @@ epochs_params = dict(events=events, event_id=event_id, tmin=tmin, tmax=tmax,
 fig, (ax1, ax2, ax3) = plt.subplots(nrows=3, ncols=1, sharex=True)
 
 # We first want to plot the data without any added reference (i.e., using only
-# the reference that was applied during recording of the data.)
+# the reference that was applied during recording of the data).
 # However, this particular data already has an average reference projection
 # applied that we now need to remove again using :func:`mne.set_eeg_reference`
 raw, _ = mne.set_eeg_reference(raw, [])  # use [] to remove average projection

--- a/examples/preprocessing/plot_rereference_eeg.py
+++ b/examples/preprocessing/plot_rereference_eeg.py
@@ -44,17 +44,14 @@ epochs_params = dict(events=events, event_id=event_id, tmin=tmin, tmax=tmax,
 
 fig, (ax1, ax2, ax3) = plt.subplots(nrows=3, ncols=1, sharex=True)
 
-# No reference. This assumes that the EEG has already been referenced properly.
-# This explicitly prevents MNE from adding a default EEG reference. Any average
-# reference projector is automatically removed.
-raw.set_eeg_reference([])
+# We start with no reference, assuming that the EEG is already referenced
+# properly after reading in the data.
 evoked_no_ref = mne.Epochs(raw, **epochs_params).average()
 
 evoked_no_ref.plot(axes=ax1, titles=dict(eeg='Original reference'), show=False,
                    time_unit='s')
 
-# Average reference. This is normally added by default, but can also be added
-# explicitly.
+# Add an average reference.
 raw.set_eeg_reference('average', projection=True)
 evoked_car = mne.Epochs(raw, **epochs_params).average()
 

--- a/examples/preprocessing/plot_rereference_eeg.py
+++ b/examples/preprocessing/plot_rereference_eeg.py
@@ -44,14 +44,19 @@ epochs_params = dict(events=events, event_id=event_id, tmin=tmin, tmax=tmax,
 
 fig, (ax1, ax2, ax3) = plt.subplots(nrows=3, ncols=1, sharex=True)
 
-# We start with no reference, assuming that the EEG is already referenced
-# properly after reading in the data.
+# We first want to plot the data without any added reference (i.e., using only
+# the reference that was applied during recording of the data.)
+# However, this particular data already has an average reference projection
+# applied that we now need to remove again using :func:`mne.set_eeg_reference`
+raw, _ = mne.set_eeg_reference(raw, [])  # use [] to remove average projection
 evoked_no_ref = mne.Epochs(raw, **epochs_params).average()
 
 evoked_no_ref.plot(axes=ax1, titles=dict(eeg='Original reference'), show=False,
                    time_unit='s')
 
-# Add an average reference.
+# Now we want to plot the data with an average reference, so let's add the
+# projection we removed earlier back to the data. Note that we can use
+# "set_eeg_reference" as a method on the ``raw`` object as well.
 raw.set_eeg_reference('average', projection=True)
 evoked_car = mne.Epochs(raw, **epochs_params).average()
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -318,7 +318,6 @@ class SetChannelsMixin(MontageMixin):
             Data with EEG channels re-referenced. If ``ref_channels='average'``
             and ``projection=True`` a projection will be added instead of
             directly re-referencing the data.
-
         %(set_eeg_reference_see_also_notes)s
         """
         from ..io.reference import set_eeg_reference

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -282,39 +282,10 @@ class SetChannelsMixin(MontageMixin):
                           ch_type='auto', verbose=None):
         """Specify which reference to use for EEG data.
 
-        By default, MNE-Python will automatically re-reference the EEG signal
-        to use an average reference (see below). Use this function to
-        explicitly specify the desired reference for EEG. This can be either an
-        existing electrode or a new virtual channel. This function will
-        re-reference the data according to the desired reference and prevent
-        MNE-Python from automatically adding an average reference projection.
-
-        Some common referencing schemes and the corresponding value for the
-        ``ref_channels`` parameter:
-
-        No re-referencing:
-            If the EEG data is already using the proper reference, set
-            ``ref_channels=[]``. This will prevent MNE-Python from
-            automatically adding an average reference projection.
-
-        Average reference:
-            A new virtual reference electrode is created by averaging the
-            current EEG signal by setting ``ref_channels='average'``. Bad EEG
-            channels are automatically excluded if they are properly set in
-            ``info['bads']``.
-
-        A single electrode:
-            Set ``ref_channels`` to a list containing the name of the channel
-            that will act as the new reference, for example
-            ``ref_channels=['Cz']``.
-
-        The mean of multiple electrodes:
-            A new virtual reference electrode is created by computing the
-            average of the current EEG signal recorded from two or more
-            selected channels. Set ``ref_channels`` to a list of channel names,
-            indicating which channels to use. For example, to apply an average
-            mastoid reference, when using the 10-20 naming scheme, set
-            ``ref_channels=['M1', 'M2']``.
+        Use this function to explicitly specify the desired reference for EEG.
+        This can be either an existing electrode or a new virtual channel.
+        This function will re-reference the data according to the desired
+        reference.
 
         Parameters
         ----------
@@ -348,26 +319,7 @@ class SetChannelsMixin(MontageMixin):
             and ``projection=True`` a projection will be added instead of
             directly re-referencing the data.
 
-        See Also
-        --------
-        mne.set_bipolar_reference : Convenience function for creating bipolar
-                                    references.
-
-        Notes
-        -----
-        1. If a reference is requested that is not the average reference, this
-           function removes any pre-existing average reference projections.
-
-        2. During source localization, the EEG signal should have an average
-           reference.
-
-        3. In order to apply a reference, the data must be preloaded. This is
-           not necessary if ``ref_channels='average'`` and ``projection=True``.
-
-        4. For an average reference, bad EEG channels are automatically
-           excluded if they are properly set in ``info['bads']``.
-
-        .. versionadded:: 0.9.0
+        %(set_eeg_reference_see_also_notes)s
         """
         from ..io.reference import set_eeg_reference
         return set_eeg_reference(self, ref_channels=ref_channels, copy=False,

--- a/mne/io/fieldtrip/tests/helpers.py
+++ b/mne/io/fieldtrip/tests/helpers.py
@@ -122,11 +122,6 @@ def get_raw_data(system, drop_extra_chs=False):
     if system == 'eximia':
         crop -= 0.5 * (1.0 / raw_data.info['sfreq'])
     raw_data.crop(0, crop)
-    if any([type_ in raw_data for type_ in ['eeg', 'ecog', 'seeg']]):
-        raw_data.set_eeg_reference([])
-    else:
-        with pytest.raises(ValueError, match='No EEG, ECoG or sEEG channels'):
-            raw_data.set_eeg_reference([])
     raw_data.del_proj('all')
     raw_data.info['comps'] = []
     raw_data.drop_channels(cfg_local['removed_chan_names'])

--- a/mne/io/fieldtrip/tests/helpers.py
+++ b/mne/io/fieldtrip/tests/helpers.py
@@ -8,7 +8,6 @@ import os
 import types
 
 import numpy as np
-import pytest
 
 import mne
 

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -331,45 +331,7 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
         Array of reference data subtracted from EEG channels. This will be
         ``None`` if ``ref_channels='average'`` and ``projection=True``.
 
-    See Also
-    --------
-    set_bipolar_reference : Convenience function for creating bipolar
-                            references.
-
-    Notes
-    -----
-    Some common referencing schemes and the corresponding value for the
-    ``ref_channels`` parameter:
-
-    Average reference:
-        A new virtual reference electrode is created by averaging the current
-        EEG signal by setting ``ref_channels='average'``. Bad EEG channels are
-        automatically excluded if they are properly set in ``info['bads']``.
-
-    A single electrode:
-        Set ``ref_channels`` to a list containing the name of the channel that
-        will act as the new reference, for example ``ref_channels=['Cz']``.
-
-    The mean of multiple electrodes:
-        A new virtual reference electrode is created by computing the average
-        of the current EEG signal recorded from two or more selected channels.
-        Set ``ref_channels`` to a list of channel names, indicating which
-        channels to use. For example, to apply an average mastoid reference,
-        when using the 10-20 naming scheme, set ``ref_channels=['M1', 'M2']``.
-
-    1. If a reference is requested that is not the average reference, this
-       function removes any pre-existing average reference projections.
-
-    2. During source localization, the EEG signal should have an average
-       reference.
-
-    3. In order to apply a reference, the data must be preloaded. This is not
-       necessary if ``ref_channels='average'`` and ``projection=True``.
-
-    4. For an average reference, bad EEG channels are automatically excluded if
-       they are properly set in ``info['bads']``.
-
-    .. versionadded:: 0.9.0
+    %(set_eeg_reference_see_also_notes)s
     """
     _check_can_reref(inst)
 

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -330,7 +330,6 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
     ref_data : array
         Array of reference data subtracted from EEG channels. This will be
         ``None`` if ``ref_channels='average'`` and ``projection=True``.
-
     %(set_eeg_reference_see_also_notes)s
     """
     _check_can_reref(inst)

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -287,12 +287,10 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
                       projection=False, ch_type='auto', verbose=None):
     """Specify which reference to use for EEG data.
 
-    By default, MNE-Python will automatically re-reference the EEG signal to
-    use an average reference (see below). Use this function to explicitly
-    specify the desired reference for EEG. This can be either an existing
-    electrode or a new virtual channel. This function will re-reference the
-    data according to the desired reference and prevent MNE-Python from
-    automatically adding an average reference projection.
+    Use this function to explicitly specify the desired reference for EEG.
+    This can be either an existing electrode or a new virtual channel.
+    This function will re-reference the data according to the desired
+    reference.
 
     Parameters
     ----------
@@ -300,10 +298,9 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
         Instance of Raw or Epochs with EEG channels and reference channel(s).
     ref_channels : list of str | str
         The name(s) of the channel(s) used to construct the reference. To apply
-        an average reference, specify ``'average'`` here (default). If an empty
-        list is specified, the data is assumed to already have a proper
-        reference and MNE will not attempt any re-referencing of the data.
-        Defaults to an average reference.
+        an average reference, specify ``'average'`` here (default). Specify an
+        empty list to remove a potentially existing average reference
+        projection. Defaults to an average reference.
     copy : bool
         Specifies whether the data will be copied (True) or modified in-place
         (False). Defaults to True.
@@ -343,11 +340,6 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
     -----
     Some common referencing schemes and the corresponding value for the
     ``ref_channels`` parameter:
-
-    No re-referencing:
-        If the EEG data is already using the proper reference, set
-        ``ref_channels=[]``. This will prevent MNE-Python from automatically
-        adding an average reference projection.
 
     Average reference:
         A new virtual reference electrode is created by averaging the current
@@ -436,9 +428,7 @@ def set_eeg_reference(inst, ref_channels='average', copy=True,
         ref_channels = ch_sel
 
     if ref_channels == []:
-        logger.info('EEG data marked as already having the desired reference. '
-                    'Preventing automatic future re-referencing to an average '
-                    'reference.')
+        logger.info('EEG data marked as already having the desired reference.')
     else:
         logger.info('Applying a custom %s '
                     'reference.' % DEFAULTS['titles'][type_])

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -295,6 +295,50 @@ chpi_locs : dict
     "times", "rrs", "moments", and "gofs".
 """
 
+# EEG reference: set_eeg_reference
+docdict['set_eeg_reference_see_also_notes'] = """
+See Also
+--------
+set_bipolar_reference : Convenience function for creating bipolar
+                        references.
+
+Notes
+-----
+Some common referencing schemes and the corresponding value for the
+``ref_channels`` parameter:
+
+Average reference:
+    A new virtual reference electrode is created by averaging the current
+    EEG signal by setting ``ref_channels='average'``. Bad EEG channels are
+    automatically excluded if they are properly set in ``info['bads']``.
+
+A single electrode:
+    Set ``ref_channels`` to a list containing the name of the channel that
+    will act as the new reference, for example ``ref_channels=['Cz']``.
+
+The mean of multiple electrodes:
+    A new virtual reference electrode is created by computing the average
+    of the current EEG signal recorded from two or more selected channels.
+    Set ``ref_channels`` to a list of channel names, indicating which
+    channels to use. For example, to apply an average mastoid reference,
+    when using the 10-20 naming scheme, set ``ref_channels=['M1', 'M2']``.
+
+1. If a reference is requested that is not the average reference, this
+   function removes any pre-existing average reference projections.
+
+2. During source localization, the EEG signal should have an average
+   reference.
+
+3. In order to apply a reference, the data must be preloaded. This is not
+   necessary if ``ref_channels='average'`` and ``projection=True``.
+
+4. For an average reference, bad EEG channels are automatically excluded if
+   they are properly set in ``info['bads']``.
+
+.. versionadded:: 0.9.0
+"""
+
+
 # Maxwell filtering
 docdict['maxwell_origin_int_ext_calibration_cross'] = """
 origin : array-like, shape (3,) | str

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -307,16 +307,16 @@ Notes
 Some common referencing schemes and the corresponding value for the
 ``ref_channels`` parameter:
 
-Average reference:
+- Average reference:
     A new virtual reference electrode is created by averaging the current
     EEG signal by setting ``ref_channels='average'``. Bad EEG channels are
     automatically excluded if they are properly set in ``info['bads']``.
 
-A single electrode:
+- A single electrode:
     Set ``ref_channels`` to a list containing the name of the channel that
     will act as the new reference, for example ``ref_channels=['Cz']``.
 
-The mean of multiple electrodes:
+- The mean of multiple electrodes:
     A new virtual reference electrode is created by computing the average
     of the current EEG signal recorded from two or more selected channels.
     Set ``ref_channels`` to a list of channel names, indicating which

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -299,7 +299,7 @@ chpi_locs : dict
 docdict['set_eeg_reference_see_also_notes'] = """
 See Also
 --------
-set_bipolar_reference : Convenience function for creating bipolar
+mne.set_bipolar_reference : Convenience function for creating bipolar
                         references.
 
 Notes

--- a/tutorials/evoked/plot_eeg_erp.py
+++ b/tutorials/evoked/plot_eeg_erp.py
@@ -20,6 +20,10 @@ raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
 raw = mne.io.read_raw_fif(raw_fname, preload=True)
 
+# This particular dataset already has an average reference projection added
+# that we now want to remove for the sake of this example.
+raw.set_eeg_reference([])
+
 ###############################################################################
 # Let's restrict the data to the EEG channels
 raw.pick_types(meg=False, eeg=True, eog=True)
@@ -65,8 +69,8 @@ raw.plot_sensors('3d')  # in 3D
 # Setting EEG reference
 # ---------------------
 #
-# Let's first inspect our Raw object with its original reference
-# (i.e., after loading).
+# Let's first inspect our Raw object with its original reference that was
+# applied during the recording of the data.
 # We define Epochs and compute an ERP for the left auditory condition.
 reject = dict(eeg=180e-6, eog=150e-6)
 event_id, tmin, tmax = {'left/auditory': 1}, -0.2, 0.5
@@ -81,7 +85,9 @@ evoked_no_ref.plot(titles=dict(eeg=title), time_unit='s')
 evoked_no_ref.plot_topomap(times=[0.1], size=3., title=title, time_unit='s')
 
 ###############################################################################
-# **Common average reference** (car)
+# **Common average reference (car)**: We add back the average reference
+# projection that we removed at the beginning of this example (right after
+# loading the data.)
 raw_car, _ = mne.set_eeg_reference(raw, 'average', projection=True)
 evoked_car = mne.Epochs(raw_car, **epochs_params).average()
 del raw_car  # save memory

--- a/tutorials/evoked/plot_eeg_erp.py
+++ b/tutorials/evoked/plot_eeg_erp.py
@@ -87,7 +87,7 @@ evoked_no_ref.plot_topomap(times=[0.1], size=3., title=title, time_unit='s')
 ###############################################################################
 # **Common average reference (car)**: We add back the average reference
 # projection that we removed at the beginning of this example (right after
-# loading the data.)
+# loading the data).
 raw_car, _ = mne.set_eeg_reference(raw, 'average', projection=True)
 evoked_car = mne.Epochs(raw_car, **epochs_params).average()
 del raw_car  # save memory

--- a/tutorials/evoked/plot_eeg_erp.py
+++ b/tutorials/evoked/plot_eeg_erp.py
@@ -18,7 +18,6 @@ from mne.datasets import sample
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
-# these data already have an EEG average reference
 raw = mne.io.read_raw_fif(raw_fname, preload=True)
 
 ###############################################################################
@@ -50,7 +49,6 @@ raw.set_channel_types(mapping={'EOG': 'eog'})
 # The EEG channels in the sample dataset already have locations.
 # These locations are available in the 'loc' of each channel description.
 # For the first channel we get
-
 print(raw.info['chs'][0]['loc'])
 
 ###############################################################################
@@ -67,32 +65,23 @@ raw.plot_sensors('3d')  # in 3D
 # Setting EEG reference
 # ---------------------
 #
-# Let's first remove the reference from our Raw object.
-#
-# This explicitly prevents MNE from adding a default EEG average reference
-# required for source localization.
-
-raw_no_ref, _ = mne.set_eeg_reference(raw, [])
-
-###############################################################################
-# We next define Epochs and compute an ERP for the left auditory condition.
+# Let's first inspect our Raw object with its original reference
+# (i.e., after loading).
+# We define Epochs and compute an ERP for the left auditory condition.
 reject = dict(eeg=180e-6, eog=150e-6)
 event_id, tmin, tmax = {'left/auditory': 1}, -0.2, 0.5
 events = mne.read_events(event_fname)
 epochs_params = dict(events=events, event_id=event_id, tmin=tmin, tmax=tmax,
                      reject=reject)
 
-evoked_no_ref = mne.Epochs(raw_no_ref, **epochs_params).average()
-del raw_no_ref  # save memory
+evoked_no_ref = mne.Epochs(raw, **epochs_params).average()
 
 title = 'EEG Original reference'
 evoked_no_ref.plot(titles=dict(eeg=title), time_unit='s')
 evoked_no_ref.plot_topomap(times=[0.1], size=3., title=title, time_unit='s')
 
 ###############################################################################
-# **Average reference**: This is normally added by default, but can also
-# be added explicitly.
-raw.del_proj()
+# **Common average reference** (car)
 raw_car, _ = mne.set_eeg_reference(raw, 'average', projection=True)
 evoked_car = mne.Epochs(raw_car, **epochs_params).average()
 del raw_car  # save memory

--- a/tutorials/evoked/plot_eeg_erp.py
+++ b/tutorials/evoked/plot_eeg_erp.py
@@ -21,7 +21,7 @@ event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
 raw = mne.io.read_raw_fif(raw_fname, preload=True)
 
 # This particular dataset already has an average reference projection added
-# that we now want to remove for the sake of this example.
+# that we now want to remove it for the sake of this example.
 raw.set_eeg_reference([])
 
 ###############################################################################

--- a/tutorials/io/plot_20_reading_eeg_data.py
+++ b/tutorials/io/plot_20_reading_eeg_data.py
@@ -173,7 +173,8 @@ Setting EEG references
 The preferred method for applying an EEG reference in MNE is
 :func:`mne.set_eeg_reference`, or equivalent instance methods like
 :meth:`raw.set_eeg_reference() <mne.io.Raw.set_eeg_reference>`. By default,
-an average reference is used. See :ref:`tut-set-eeg-ref` for more information.
+the data are assumed to already be properly referenced. See
+:ref:`tut-set-eeg-ref` for more information.
 
 Reading electrode locations and head shapes for EEG recordings
 ==============================================================

--- a/tutorials/preprocessing/plot_55_setting_eeg_reference.py
+++ b/tutorials/preprocessing/plot_55_setting_eeg_reference.py
@@ -192,6 +192,9 @@ for title, proj in zip(['Original', 'Average'], [False, True]):
 # the source modeling is performed. In contrast, applying an average reference
 # by the traditional subtraction method offers no such guarantee.
 #
+# For these reasons, when performing inverse imaging, *MNE-Python will raise
+# a ``ValueError`` if there are EEG channels present and something other than
+# an average reference strategy has been specified*.
 #
 # .. LINKS
 #

--- a/tutorials/preprocessing/plot_55_setting_eeg_reference.py
+++ b/tutorials/preprocessing/plot_55_setting_eeg_reference.py
@@ -192,17 +192,6 @@ for title, proj in zip(['Original', 'Average'], [False, True]):
 # the source modeling is performed. In contrast, applying an average reference
 # by the traditional subtraction method offers no such guarantee.
 #
-# XXX: IS THIS TRUE?
-# For these reasons, when performing inverse imaging, *MNE-Python will
-# automatically average-reference the EEG channels if they are present and no
-# reference strategy has been specified*. If you want to perform inverse
-# imaging and do not want to use an average reference (and hence you accept the
-# risks presented in the previous paragraphs), you can force MNE-Python to
-# relax its average reference requirement by passing an empty list to
-# :meth:`~mne.io.Raw.set_eeg_reference` (i.e., by calling
-# ``raw.set_eeg_reference(ref_channels=[])``) prior to performing inverse
-# imaging.
-#
 #
 # .. LINKS
 #

--- a/tutorials/preprocessing/plot_55_setting_eeg_reference.py
+++ b/tutorials/preprocessing/plot_55_setting_eeg_reference.py
@@ -192,6 +192,7 @@ for title, proj in zip(['Original', 'Average'], [False, True]):
 # the source modeling is performed. In contrast, applying an average reference
 # by the traditional subtraction method offers no such guarantee.
 #
+# XXX: IS THIS TRUE?
 # For these reasons, when performing inverse imaging, *MNE-Python will
 # automatically average-reference the EEG channels if they are present and no
 # reference strategy has been specified*. If you want to perform inverse


### PR DESCRIPTION
closes #7471 

These are the files I could catch that did still assume MNE-Python to auto apply an average ref projection. Also, the docstr of `set_eeg_reference` was still assuming that.

I wasn't sure with `tutorials/preprocessing/plot_55_setting_eeg_reference.py` --> see my inline "todo" comment there marked with `XXX`

PS: What was the PR that removed the auto average ref behavior of MNE?