### PR TITLE
MRG: purge old scikits.learn imports

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -305,7 +305,7 @@ API
   - NumPy 1.13.3
   - SciPy 1.0.0
   - matplotlib 2.1
-  - scikit-learn 1.19.1 (optional requirement)
+  - scikit-learn 0.19.1 (optional requirement)
   - pandas 0.21 (optional requirement)
 
 - :meth:`mne.Epochs.plot` now accepts an ``event_id`` parameter (useful in tandem with ``event_colors`` for specifying event colors by name) by `Daniel McCloy`_.

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -152,10 +152,6 @@ def test_permutation_large_n_samples(numba_conditional):
 
 def test_permutation_step_down_p(numba_conditional):
     """Test cluster level permutations with step_down_p."""
-    try:
-        from sklearn.feature_extraction.image import grid_to_graph
-    except ImportError:
-        return
     rng = np.random.RandomState(0)
     # subjects, time points, spatial points
     X = rng.randn(9, 2, 10)

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -20,7 +20,8 @@ from mne.stats.cluster_level import (permutation_cluster_test, f_oneway,
                                      spatio_temporal_cluster_test,
                                      spatio_temporal_cluster_1samp_test,
                                      ttest_1samp_no_p, summarize_clusters_stc)
-from mne.utils import run_tests_if_main, catch_logging, check_version
+from mne.utils import (run_tests_if_main, catch_logging, check_version,
+                       requires_sklearn)
 
 
 @pytest.fixture(scope="function", params=('Numba', 'NumPy'))
@@ -265,12 +266,10 @@ def test_cluster_permutation_t_test(numba_conditional, stat_fun):
                 condition1, threshold=1, stat_fun=lambda x: stat_fun(x)[:-1])
 
 
+@requires_sklearn
 def test_cluster_permutation_with_connectivity(numba_conditional):
     """Test cluster level permutations with connectivity matrix."""
-    try:
-        from sklearn.feature_extraction.image import grid_to_graph
-    except ImportError:
-        return
+    from sklearn.feature_extraction.image import grid_to_graph
     condition1_1d, condition2_1d, condition1_2d, condition2_2d = \
         _get_conditions()
 
@@ -423,12 +422,10 @@ def test_cluster_permutation_with_connectivity(numba_conditional):
                     buffer_size=None)
 
 
+@requires_sklearn
 def test_permutation_connectivity_equiv(numba_conditional):
     """Test cluster level permutations with and without connectivity."""
-    try:
-        from sklearn.feature_extraction.image import grid_to_graph
-    except ImportError:
-        return
+    from sklearn.feature_extraction.image import grid_to_graph
     rng = np.random.RandomState(0)
     # subjects, time points, spatial points
     n_time = 2
@@ -496,12 +493,10 @@ def test_permutation_connectivity_equiv(numba_conditional):
         assert_array_equal(stat_map, this_stat_map)
 
 
+@requires_sklearn
 def test_spatio_temporal_cluster_connectivity(numba_conditional):
     """Test spatio-temporal cluster permutations."""
-    try:
-        from sklearn.feature_extraction.image import grid_to_graph
-    except ImportError:
-        return
+    from sklearn.feature_extraction.image import grid_to_graph
     condition1_1d, condition2_1d, condition1_2d, condition2_2d = \
         _get_conditions()
 

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -153,10 +153,7 @@ def test_permutation_large_n_samples(numba_conditional):
 def test_permutation_step_down_p(numba_conditional):
     """Test cluster level permutations with step_down_p."""
     try:
-        try:
-            from sklearn.feature_extraction.image import grid_to_graph
-        except ImportError:
-            from scikits.learn.feature_extraction.image import grid_to_graph  # noqa: F401,E501 analysis:ignore
+        from sklearn.feature_extraction.image import grid_to_graph
     except ImportError:
         return
     rng = np.random.RandomState(0)
@@ -275,10 +272,7 @@ def test_cluster_permutation_t_test(numba_conditional, stat_fun):
 def test_cluster_permutation_with_connectivity(numba_conditional):
     """Test cluster level permutations with connectivity matrix."""
     try:
-        try:
-            from sklearn.feature_extraction.image import grid_to_graph
-        except ImportError:
-            from scikits.learn.feature_extraction.image import grid_to_graph
+        from sklearn.feature_extraction.image import grid_to_graph
     except ImportError:
         return
     condition1_1d, condition2_1d, condition1_2d, condition2_2d = \
@@ -436,10 +430,7 @@ def test_cluster_permutation_with_connectivity(numba_conditional):
 def test_permutation_connectivity_equiv(numba_conditional):
     """Test cluster level permutations with and without connectivity."""
     try:
-        try:
-            from sklearn.feature_extraction.image import grid_to_graph
-        except ImportError:
-            from scikits.learn.feature_extraction.image import grid_to_graph
+        from sklearn.feature_extraction.image import grid_to_graph
     except ImportError:
         return
     rng = np.random.RandomState(0)
@@ -512,10 +503,7 @@ def test_permutation_connectivity_equiv(numba_conditional):
 def test_spatio_temporal_cluster_connectivity(numba_conditional):
     """Test spatio-temporal cluster permutations."""
     try:
-        try:
-            from sklearn.feature_extraction.image import grid_to_graph
-        except ImportError:
-            from scikits.learn.feature_extraction.image import grid_to_graph
+        from sklearn.feature_extraction.image import grid_to_graph
     except ImportError:
         return
     condition1_1d, condition2_1d, condition1_2d, condition2_2d = \

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1199,9 +1199,6 @@ class deprecated(object):
     # Adapted from http://wiki.python.org/moin/PythonDecoratorLibrary,
     # but with many changes.
 
-    # scikit-learn will not import on all platforms b/c it can be
-    # sklearn or scikits.learn, so a self-contained example is used above
-
     def __init__(self, extra=''):  # noqa: D102
         self.extra = extra
 


### PR DESCRIPTION
Since we've bumped the minimum sklearn to 0.19.1, there should be no need to try/except importing from `scikits.learn` anymore.