### PR TITLE
MRG, ENH: Speed up info copy

### DIFF
--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -101,6 +101,12 @@ class DigPoint(dict):
         pos = ('(%0.1f, %0.1f, %0.1f) mm' % tuple(1000 * self['r'])).ljust(25)
         return ('<DigPoint | %s : %s : %s frame>' % (id_, pos, cf))
 
+    # speed up info copy by only deep copying the mutable item
+    def __deepcopy__(self, memodict):
+        return DigPoint(
+            kind=self['kind'], r=self['r'].copy(),
+            ident=self['ident'], coord_frame=self['coord_frame'])
+
     def __eq__(self, other):  # noqa: D105
         """Compare two DigPoints.
 

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -103,6 +103,7 @@ class DigPoint(dict):
 
     # speed up info copy by only deep copying the mutable item
     def __deepcopy__(self, memodict):
+        """Make a deepcopy."""
         return DigPoint(
             kind=self['kind'], r=self['r'].copy(),
             ident=self['ident'], coord_frame=self['coord_frame'])

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -278,7 +278,7 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
             fid.seek(data_offset + 75 * ch_idx + 59)
             sensitivity = np.fromfile(fid, dtype='f4', count=1)[0]
             fid.seek(data_offset + 75 * ch_idx + 71)
-            cal = np.fromfile(fid, dtype='f4', count=1)
+            cal = np.fromfile(fid, dtype='f4', count=1)[0]
             cals.append(cal * sensitivity * 1e-6 / 204.8)
 
     info = _empty_info(sfreq)

--- a/mne/io/fieldtrip/utils.py
+++ b/mne/io/fieldtrip/utils.py
@@ -309,9 +309,10 @@ def _process_channel_meg(cur_ch, grad):
     original_orientation = np.squeeze(grad['chanori'][chan_idx_in_grad, :])
     try:
         orientation = rotation3d_align_z_axis(original_orientation).T
-        orientation = orientation.flatten()
     except AssertionError:
-        orientation = np.eye(4, 4).flatten()
+        orientation = np.eye(3)
+    assert orientation.shape == (3, 3)
+    orientation = orientation.flatten()
     chanunit = grad['chanunit'][chan_idx_in_grad]
 
     cur_ch['loc'] = np.hstack((position, orientation))

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -643,6 +643,7 @@ class Info(dict, MontageMixin):
         return st
 
     def __deepcopy__(self, memodict):
+        """Make a deepcopy."""
         result = Info.__new__(Info)
         for k, v in self.items():
             # chs is roughly half the time but most are immutable

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -30,7 +30,7 @@ from .write import (start_file, end_file, start_block, end_block,
 from .proc_history import _read_proc_history, _write_proc_history
 from ..transforms import invert_transform, Transform, _coord_frame_name
 from ..utils import (logger, verbose, warn, object_diff, _validate_type,
-                     _stamp_to_dt, _dt_to_stamp, _pl)
+                     _stamp_to_dt, _dt_to_stamp, _pl, _is_numeric)
 from ._digitization import (_format_dig_points, _dig_kind_proper,
                             _dig_kind_rev, _dig_kind_ints, _read_dig_fif)
 from ._digitization import write_dig as _dig_write_dig
@@ -540,7 +540,7 @@ class Info(dict, MontageMixin):
         info : instance of Info
             The copied info.
         """
-        return Info(deepcopy(self))
+        return deepcopy(self)
 
     def normalize_proj(self):
         """(Re-)Normalize projection vectors after subselection.
@@ -642,6 +642,40 @@ class Info(dict, MontageMixin):
         st %= non_empty
         return st
 
+    def __deepcopy__(self, memodict):
+        result = Info.__new__(Info)
+        for k, v in self.items():
+            # chs is roughly half the time but most are immutable
+            if k == 'chs':
+                # dict shallow copy is fast, so use it then overwrite
+                result[k] = list()
+                for ch in v:
+                    ch = ch.copy()  # shallow
+                    ch['loc'] = ch['loc'].copy()
+                    result[k].append(ch)
+            elif k == 'ch_names':
+                # we know it's list of str, shallow okay and saves ~100 µs
+                result[k] = v.copy()
+            elif k == 'hpi_meas':
+                hms = list()
+                for hm in v:
+                    hm = hm.copy()
+                    # the only mutable thing here is some entries in coils
+                    hm['hpi_coils'] = [coil.copy() for coil in hm['hpi_coils']]
+                    # There is a *tiny* risk here that someone could write
+                    # raw.info['hpi_meas'][0]['hpi_coils'][1]['epoch'] = ...
+                    # and assume that info.copy() will make an actual copy,
+                    # but copying these entries has a 2x slowdown penalty so
+                    # probably not worth it for such a deep corner case:
+                    # for coil in hpi_coils:
+                    #     for key in ('epoch', 'slopes', 'corr_coeff'):
+                    #         coil[key] = coil[key].copy()
+                    hms.append(hm)
+                result[k] = hms
+            else:
+                result[k] = deepcopy(v, memodict)
+        return result
+
     def _check_consistency(self, prepend_error=''):
         """Do some self-consistency checks and datatype tweaks."""
         missing = [bad for bad in self['bads'] if bad not in self['ch_names']]
@@ -669,6 +703,27 @@ class Info(dict, MontageMixin):
         for key in ('sfreq', 'highpass', 'lowpass'):
             if self.get(key) is not None:
                 self[key] = float(self[key])
+
+        # Ensure info['chs'] has immutable entries (copies much faster)
+        scalar_keys = ('unit_mul range cal kind coil_type unit '
+                       'coord_frame scanno logno').split()
+        for ci, ch in enumerate(self['chs']):
+            ch_name = ch['ch_name']
+            if not isinstance(ch_name, str):
+                raise TypeError(
+                    'Bad info: info["chs"][%d]["ch_name"] is not a string, '
+                    'got type %s' % (ci, type(ch_name)))
+            for key in scalar_keys:
+                val = ch.get(key, 1)
+                if not _is_numeric(val):
+                    raise TypeError(
+                        'Bad info: info["chs"][%d][%r] = %s is type %s, must '
+                        'be float or int' % (ci, key, val, type(val)))
+            loc = ch['loc']
+            if not (isinstance(loc, np.ndarray) and loc.shape == (12,)):
+                raise TypeError(
+                    'Bad info: info["chs"][%d]["loc"] must be ndarray with '
+                    '12 elements, got %r' % (ci, loc))
 
         # make sure channel names are not too long
         self._check_ch_name_length()
@@ -1146,12 +1201,15 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
                     hc['number'] = int(read_tag(fid, pos).data)
                 elif kind == FIFF.FIFF_EPOCH:
                     hc['epoch'] = read_tag(fid, pos).data
+                    hc['epoch'].flags.writeable = False
                 elif kind == FIFF.FIFF_HPI_SLOPES:
                     hc['slopes'] = read_tag(fid, pos).data
+                    hc['slopes'].flags.writeable = False
                 elif kind == FIFF.FIFF_HPI_CORR_COEFF:
                     hc['corr_coeff'] = read_tag(fid, pos).data
+                    hc['corr_coeff'].flags.writeable = False
                 elif kind == FIFF.FIFF_HPI_COIL_FREQ:
-                    hc['coil_freq'] = read_tag(fid, pos).data
+                    hc['coil_freq'] = float(read_tag(fid, pos).data)
             hcs.append(hc)
         hm['hpi_coils'] = hcs
         hms.append(hm)

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -35,6 +35,7 @@ class Projection(dict):
 
     # speed up info copy by taking advantage of mutability
     def __deepcopy__(self, memodict):
+        """Make a deepcopy."""
         cls = self.__class__
         result = cls.__new__(cls)
         for k, v in self.items():

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -33,6 +33,19 @@ class Projection(dict):
         s += ", n_channels : %s" % self['data']['ncol']
         return "<Projection  |  %s>" % s
 
+    # speed up info copy by taking advantage of mutability
+    def __deepcopy__(self, memodict):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        for k, v in self.items():
+            if k == 'data':
+                v = v.copy()
+                v['data'] = v['data'].copy()
+                result[k] = v
+            else:
+                result[k] = v  # kind, active, desc, explained_var immutable
+        return result
+
     @fill_doc
     def plot_topomap(self, info, cmap=None, sensors=True,
                      colorbar=False, res=64, size=1, show=True,

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -443,6 +443,23 @@ def test_check_consistency():
         info3 = create_info(ch_names=['a', 'b', 'b', 'c', 'b'], sfreq=1000.)
     assert_array_equal(info3['ch_names'], ['a', 'b-0', 'b-1', 'c', 'b-2'])
 
+    # a few bad ones
+    idx = 0
+    ch = info['chs'][idx]
+    for key, bad, match in (('ch_name', 1., 'not a string'),
+                            ('loc', np.zeros(15), '12 elements'),
+                            ('cal', np.ones(1), 'float or int')):
+        info._check_consistency()  # okay
+        old = ch[key]
+        ch[key] = bad
+        if key == 'ch_name':
+            info['ch_names'][idx] = bad
+        with pytest.raises(TypeError, match=match):
+            info._check_consistency()
+        ch[key] = old
+        if key == 'ch_name':
+            info['ch_names'][idx] = old
+
 
 def _test_anonymize_info(base_info):
     """Test that sensitive information can be anonymized."""


### PR DESCRIPTION
Sometimes I find that `info.copy()` is a significant bottleneck in some operations. It turns out this can be avoided if we leverage knowledge of our internal structures and object mutability by overridding a few `__deepcopy__` defs:

1. three entries in `info` (`chs`, `ch_names`, `hpi_meas`), plus two others that affect it:
2. `DigPoint` (hence `info['dig']`)
3. `Projection` (hence `info['projs']`)

This code:
```Jupyter
import mne
fname = mne.datasets.testing.data_path() + '/SSS/test_move_anon_raw.fif'
info = mne.io.read_info(fname)
%timeit info.copy()
```
on master (top) and this PR (bottom; ~10x faster) gives:
```
6.08 ms ± 333 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
580 µs ± 2.57 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
Switching to `sample_audvis_raw.fif` we see similar timings (~8x speedup):
```
3.88 ms ± 23.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
487 µs ± 4.66 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

Along the way I added some extra checks to `info._check_consistency()` that showed inconsistencies in dimensionality in `cnt` and `fieldtrip` code that I fixed.

This is mostly internal with some speedups throughout the code base so doesn't seem like it needs a `latest.inc` update.