### PR TITLE
MRG, FIX: Remove cruft

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -84,6 +84,7 @@ def pytest_configure(config):
     ignore:.*In future, it will be an error for 'np.bool_'.*:DeprecationWarning
     ignore:.*Converting `np\.character` to a dtype is deprecated.*:DeprecationWarning
     ignore:.*sphinx\.util\.smartypants is deprecated.*:
+    ignore:.*pandas\.util\.testing is deprecated.*:
     always:.*get_data.* is deprecated in favor of.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from distutils.version import LooseVersion
 from io import StringIO
 import os.path as op
 from datetime import datetime, timezone

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -403,7 +403,6 @@ def test_hash():
 @pytest.mark.parametrize('whiten', (True, False))
 def test_pca(n_components, whiten):
     """Test PCA equivalence."""
-    import sklearn
     from sklearn.decomposition import PCA
     n_samples, n_dim = 1000, 10
     X = np.random.RandomState(0).randn(n_samples, n_dim)
@@ -415,15 +414,10 @@ def test_pca(n_components, whiten):
     assert_array_equal(X, X_orig)
     X_mne = pca_mne.fit_transform(X)
     assert_array_equal(X, X_orig)
-    old_sklearn = LooseVersion(sklearn.__version__) < LooseVersion('0.19')
-    if whiten and old_sklearn:
-        X_skl *= np.sqrt((n_samples - 1.) / n_samples)
     assert_allclose(X_skl, X_mne)
     for key in ('mean_', 'components_',
                 'explained_variance_', 'explained_variance_ratio_'):
         val_skl, val_mne = getattr(pca_skl, key), getattr(pca_mne, key)
-        if key == 'explained_variance_' and old_sklearn:
-            val_skl *= n_samples / (n_samples - 1.)  # old bug
         assert_allclose(val_skl, val_mne)
     if isinstance(n_components, float):
         assert 1 < pca_mne.n_components_ < n_dim


### PR DESCRIPTION
Just removing some version cruft we no longer need because our minimum is 0.19. Also adding one more ignore needed for latest dev `pandas` with `statsmodels` importing something deprecated