### PR TITLE
DOC: Annotations class accepts float as duration param

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -66,8 +66,9 @@ class Annotations(object):
     ----------
     onset : array of float, shape (n_annotations,)
         The starting time of annotations in seconds after ``orig_time``.
-    duration : array of float, shape (n_annotations,)
-        Durations of the annotations in seconds.
+    duration : array of float, shape (n_annotations,) | float
+        Durations of the annotations in seconds. If a float, all the
+        annotations are given the same duration.
     description : array of str, shape (n_annotations,) | str
         Array of strings containing description for each annotation. If a
         string, all the annotations are given the same description. To reject


### PR DESCRIPTION
#### What does this implement/fix?
`mne.Annotations` can handle `duration` being a float or array with only a single element. Add this info to the docstring.

This use case is already covered by the existing tests.