### PR TITLE
MRG: Test SCI correctly checks file type at start of function

### DIFF
--- a/mne/preprocessing/nirs/_scalp_coupling_index.py
+++ b/mne/preprocessing/nirs/_scalp_coupling_index.py
@@ -6,6 +6,7 @@
 
 import numpy as np
 
+from ... import pick_types
 from ...io import BaseRaw
 from ...utils import _validate_type, verbose
 from ..nirs import _channel_frequencies, _check_channels_ordered
@@ -44,12 +45,12 @@ def scalp_coupling_index(raw, l_freq=0.7, h_freq=1.5,
     raw = raw.copy().load_data()
     _validate_type(raw, BaseRaw, 'raw')
 
-    freqs = np.unique(_channel_frequencies(raw))
-    picks = _check_channels_ordered(raw, freqs)
-
-    if not len(picks):
+    if not len(pick_types(raw.info, fnirs='fnirs_od')):
         raise RuntimeError('Scalp coupling index '
                            'should be run on optical density data.')
+
+    freqs = np.unique(_channel_frequencies(raw))
+    picks = _check_channels_ordered(raw, freqs)
 
     filtered_data = filter_data(raw._data, raw.info['sfreq'], l_freq, h_freq,
                                 picks=picks, verbose=verbose,

--- a/mne/preprocessing/tests/test_scalp_coupling_index.py
+++ b/mne/preprocessing/tests/test_scalp_coupling_index.py
@@ -12,7 +12,8 @@ from numpy.testing import assert_allclose, assert_array_less
 
 from mne.datasets.testing import data_path
 from mne.io import read_raw_nirx
-from mne.preprocessing.nirs import optical_density, scalp_coupling_index
+from mne.preprocessing.nirs import optical_density, scalp_coupling_index,\
+    beer_lambert_law
 from mne.datasets import testing
 
 fname_nirx_15_0 = op.join(data_path(download=False),
@@ -30,7 +31,9 @@ fname_nirx_15_2_short = op.join(data_path(download=False),
 def test_scalp_coupling_index(fname, fmt, tmpdir):
     """Test converting NIRX files."""
     assert fmt in ('nirx', 'fif')
-    raw = read_raw_nirx(fname)
+    raw = read_raw_nirx(fname).load_data()
+    pytest.raises(RuntimeError, scalp_coupling_index, raw)
+
     raw = optical_density(raw)
     sci = scalp_coupling_index(raw)
 
@@ -58,3 +61,7 @@ def test_scalp_coupling_index(fname, fmt, tmpdir):
     assert_allclose(sci[0:6], [1, 1, 1, 1, -1, -1], atol=0.01)
     assert np.abs(sci[6]) < 0.5
     assert np.abs(sci[7]) < 0.5
+
+    # Ensure function errors if wrong type is passed in
+    raw = beer_lambert_law(raw)
+    pytest.raises(RuntimeError, scalp_coupling_index, raw)

--- a/mne/preprocessing/tests/test_scalp_coupling_index.py
+++ b/mne/preprocessing/tests/test_scalp_coupling_index.py
@@ -32,7 +32,8 @@ def test_scalp_coupling_index(fname, fmt, tmpdir):
     """Test converting NIRX files."""
     assert fmt in ('nirx', 'fif')
     raw = read_raw_nirx(fname).load_data()
-    pytest.raises(RuntimeError, scalp_coupling_index, raw)
+    with pytest.raises(RuntimeError, match='Scalp'):
+        scalp_coupling_index(raw)
 
     raw = optical_density(raw)
     sci = scalp_coupling_index(raw)
@@ -64,4 +65,5 @@ def test_scalp_coupling_index(fname, fmt, tmpdir):
 
     # Ensure function errors if wrong type is passed in
     raw = beer_lambert_law(raw)
-    pytest.raises(RuntimeError, scalp_coupling_index, raw)
+    with pytest.raises(RuntimeError, match='Scalp'):
+        scalp_coupling_index(raw)


### PR DESCRIPTION
#### Reference issue
General fNIRS tweaks #7057 


#### What does this implement/fix?
The previous check for the signal type was never reached as previous functions would fail. Moved check forward and added tests.


#### Additional information
Caught this one because I was going through the code coverage trying to hit 100%