### PR TITLE
MRG: Test warnings if NIRS channels are not correctly ordered

### DIFF
--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -81,9 +81,14 @@ def _check_channels_ordered(raw, freqs):
                (ch1_name_info.groups()[1] != ch2_name_info.groups()[1]) or \
                (int(ch1_name_info.groups()[2]) != freqs[0]) or \
                (int(ch2_name_info.groups()[2]) != freqs[1]):
-                raise RuntimeError('NIRS channels not ordered correctly')
+                raise ValueError('NIRS channels not ordered correctly. '
+                                 'Channels must be ordered as source '
+                                 'detector pairs with frequencies:',
+                                 freqs)
     else:
-        raise RuntimeError('NIRS channels not ordered correctly')
+        raise ValueError('NIRS channels not ordered correctly. '
+                         'An even number of NIRS channels is required.',
+                         raw.ch_names)
 
     return picks
 

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -70,28 +70,25 @@ def _check_channels_ordered(raw, freqs):
     # Every second channel should be same SD pair
     # and have the specified light frequencies.
     picks = _picks_to_idx(raw.info, 'fnirs', exclude=[])
-    if len(picks) % 2 == 0:
-        for ii in picks[::2]:
-            ch1_name_info = re.match(r'S(\d+)_D(\d+) (\d+)',
-                                     raw.info['chs'][ii]['ch_name'])
-            ch2_name_info = re.match(r'S(\d+)_D(\d+) (\d+)',
-                                     raw.info['chs'][ii + 1]['ch_name'])
+    if len(picks) % 2 != 0:
+        raise ValueError(
+            'NIRS channels not ordered correctly. An even number of NIRS '
+            'channels is required. %d channels were provided: %r'
+            % (len(raw.ch_names), raw.ch_names))
+    for ii in picks[::2]:
+        ch1_name_info = re.match(r'S(\d+)_D(\d+) (\d+)',
+                                 raw.info['chs'][ii]['ch_name'])
+        ch2_name_info = re.match(r'S(\d+)_D(\d+) (\d+)',
+                                 raw.info['chs'][ii + 1]['ch_name'])
 
-            if (ch1_name_info.groups()[0] != ch2_name_info.groups()[0]) or \
-               (ch1_name_info.groups()[1] != ch2_name_info.groups()[1]) or \
-               (int(ch1_name_info.groups()[2]) != freqs[0]) or \
-               (int(ch2_name_info.groups()[2]) != freqs[1]):
-                err = ('NIRS channels not ordered correctly. '
-                       'Channels must be ordered as source '
-                       'detector pairs with frequencies: %d & %d'
-                       % (freqs[0], freqs[1]))
-                raise ValueError(err)
-    else:
-        err = ('NIRS channels not ordered correctly. '
-               'An even number of NIRS channels is required. '
-               '%d channels were provided: %r'
-               % (len(raw.ch_names), raw.ch_names))
-        raise ValueError(err)
+        if (ch1_name_info.groups()[0] != ch2_name_info.groups()[0]) or \
+           (ch1_name_info.groups()[1] != ch2_name_info.groups()[1]) or \
+           (int(ch1_name_info.groups()[2]) != freqs[0]) or \
+           (int(ch2_name_info.groups()[2]) != freqs[1]):
+            raise ValueError(
+                'NIRS channels not ordered correctly. Channels must be ordered'
+                ' as source detector pairs with frequencies: %d & %d'
+                % (freqs[0], freqs[1]))
 
     return picks
 

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -81,14 +81,17 @@ def _check_channels_ordered(raw, freqs):
                (ch1_name_info.groups()[1] != ch2_name_info.groups()[1]) or \
                (int(ch1_name_info.groups()[2]) != freqs[0]) or \
                (int(ch2_name_info.groups()[2]) != freqs[1]):
-                raise ValueError('NIRS channels not ordered correctly. '
-                                 'Channels must be ordered as source '
-                                 'detector pairs with frequencies:',
-                                 freqs)
+                err = ('NIRS channels not ordered correctly. '
+                       'Channels must be ordered as source '
+                       'detector pairs with frequencies: %d & %d'
+                       % (freqs[0], freqs[1]))
+                raise ValueError(err)
     else:
-        raise ValueError('NIRS channels not ordered correctly. '
-                         'An even number of NIRS channels is required.',
-                         raw.ch_names)
+        err = ('NIRS channels not ordered correctly. '
+               'An even number of NIRS channels is required. '
+               '%d channels were provided: %r'
+               % (len(raw.ch_names), raw.ch_names))
+        raise ValueError(err)
 
     return picks
 

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -70,17 +70,20 @@ def _check_channels_ordered(raw, freqs):
     # Every second channel should be same SD pair
     # and have the specified light frequencies.
     picks = _picks_to_idx(raw.info, 'fnirs', exclude=[])
-    for ii in picks[::2]:
-        ch1_name_info = re.match(r'S(\d+)_D(\d+) (\d+)',
-                                 raw.info['chs'][ii]['ch_name'])
-        ch2_name_info = re.match(r'S(\d+)_D(\d+) (\d+)',
-                                 raw.info['chs'][ii + 1]['ch_name'])
+    if len(picks) % 2 == 0:
+        for ii in picks[::2]:
+            ch1_name_info = re.match(r'S(\d+)_D(\d+) (\d+)',
+                                     raw.info['chs'][ii]['ch_name'])
+            ch2_name_info = re.match(r'S(\d+)_D(\d+) (\d+)',
+                                     raw.info['chs'][ii + 1]['ch_name'])
 
-        if (ch1_name_info.groups()[0] != ch2_name_info.groups()[0]) or \
-           (ch1_name_info.groups()[1] != ch2_name_info.groups()[1]) or \
-           (int(ch1_name_info.groups()[2]) != freqs[0]) or \
-           (int(ch2_name_info.groups()[2]) != freqs[1]):
-            raise RuntimeError('NIRS channels not ordered correctly')
+            if (ch1_name_info.groups()[0] != ch2_name_info.groups()[0]) or \
+               (ch1_name_info.groups()[1] != ch2_name_info.groups()[1]) or \
+               (int(ch1_name_info.groups()[2]) != freqs[0]) or \
+               (int(ch2_name_info.groups()[2]) != freqs[1]):
+                raise RuntimeError('NIRS channels not ordered correctly')
+    else:
+        raise RuntimeError('NIRS channels not ordered correctly')
 
     return picks
 

--- a/mne/preprocessing/tests/test_beer_lambert_law.py
+++ b/mne/preprocessing/tests/test_beer_lambert_law.py
@@ -51,6 +51,16 @@ def test_beer_lambert(fname, fmt, tmpdir):
 
 
 @testing.requires_testing_data
+def test_beer_lambert_unordered_errors():
+    """NIRS data requires specific ordering and naming of channels."""
+    raw = read_raw_nirx(fname_nirx_15_0)
+    raw = optical_density(raw)
+    raw.pick([0, 1, 2])
+    with pytest.raises(RuntimeError, match='ordered'):
+        beer_lambert_law(raw)
+
+
+@testing.requires_testing_data
 def test_beer_lambert_v_matlab():
     """Compare MNE results to MATLAB toolbox."""
     raw = read_raw_nirx(fname_nirx_15_0)

--- a/mne/preprocessing/tests/test_beer_lambert_law.py
+++ b/mne/preprocessing/tests/test_beer_lambert_law.py
@@ -54,10 +54,16 @@ def test_beer_lambert(fname, fmt, tmpdir):
 def test_beer_lambert_unordered_errors():
     """NIRS data requires specific ordering and naming of channels."""
     raw = read_raw_nirx(fname_nirx_15_0)
-    raw = optical_density(raw)
-    raw.pick([0, 1, 2])
-    with pytest.raises(RuntimeError, match='ordered'):
-        beer_lambert_law(raw)
+    raw_od = optical_density(raw)
+    raw_od.pick([0, 1, 2])
+    with pytest.raises(ValueError, match='ordered'):
+        beer_lambert_law(raw_od)
+
+    # Test that an error is thrown if inconsistent frequencies used in data
+    raw_od = optical_density(raw)
+    raw_od.rename_channels({'S2_D2 760': 'S2_D2 770'})
+    with pytest.raises(ValueError, match='ordered'):
+        beer_lambert_law(raw_od)
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
#### Reference issue
General fNIRS tweaking #7057 


#### What does this implement/fix?
Added test to ensure that NIRS data is stored as paired wavelength data. Noticed that if an odd number of channels existed that the check failed.

