### PR TITLE
BF: Allow reading of FIF files with incorrect date

### DIFF
--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -239,7 +239,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.81', misc='0.5')
+    releases = dict(testing='0.82', misc='0.5')
     # And also update the "md5_hashes['testing']" variable below.
 
     # To update any other dataset, update the data archive itself (upload
@@ -323,7 +323,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='12b75d1cb7df9dfb4ad73ed82f61094f',
         somato='ea825966c0a1e9b2f84e3826c5500161',
         spm='9f43f67150e3b694b523a21eb929ea75',
-        testing='f1cb4447a0c27a120ad0f7fb98ae8368',
+        testing='4089649dff26f9f095d434b5a544f1a4',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         fnirs_motor='c4935d19ddab35422a69f3326a01fef8',
         opm='370ad1dcfd5c47e029e692c85358a374',

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1004,7 +1004,14 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
             if not np.isnan(tag.data):
                 highpass = float(tag.data)
         elif kind == FIFF.FIFF_MEAS_DATE:
-            tag = read_tag(fid, pos)
+            try:
+                tag = read_tag(fid, pos)
+            except OverflowError:
+                warn('Encountered an error while trying to read the '
+                     'measurement date from the input data. No measurement '
+                     'date will be set. Please check the integrity of the '
+                     'measurement date in the input data.')
+                continue
             meas_date = tuple(tag.data)
             if len(meas_date) == 1:  # can happen from old C conversions
                 meas_date = (meas_date[0], 0)
@@ -1241,7 +1248,14 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
                 tag = read_tag(fid, pos)
                 si['middle_name'] = str(tag.data)
             elif kind == FIFF.FIFF_SUBJ_BIRTH_DAY:
-                tag = read_tag(fid, pos)
+                try:
+                    tag = read_tag(fid, pos)
+                except OverflowError:
+                    warn('Encountered an error while trying to read the '
+                         'birthday from the input data. No birthday will be '
+                         'set. Please check the integrity of the birthday '
+                         'information in the input data.')
+                    continue
                 si['birthday'] = tag.data
             elif kind == FIFF.FIFF_SUBJ_SEX:
                 tag = read_tag(fid, pos)

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1004,14 +1004,7 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
             if not np.isnan(tag.data):
                 highpass = float(tag.data)
         elif kind == FIFF.FIFF_MEAS_DATE:
-            try:
-                tag = read_tag(fid, pos)
-            except OverflowError:
-                warn('Encountered an error while trying to read the '
-                     'measurement date from the input data. No measurement '
-                     'date will be set. Please check the integrity of the '
-                     'measurement date in the input data.')
-                continue
+            tag = read_tag(fid, pos)
             meas_date = tuple(tag.data)
             if len(meas_date) == 1:  # can happen from old C conversions
                 meas_date = (meas_date[0], 0)

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -38,6 +38,7 @@ base_dir = op.join(op.dirname(__file__), 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
 chpi_fname = op.join(base_dir, 'test_chpi_raw_sss.fif')
 event_name = op.join(base_dir, 'test-eve.fif')
+
 kit_data_dir = op.join(op.dirname(__file__), '..', 'kit', 'tests', 'data')
 hsp_fname = op.join(kit_data_dir, 'test_hsp.txt')
 elp_fname = op.join(kit_data_dir, 'test_elp.txt')
@@ -47,6 +48,8 @@ sss_path = op.join(data_path, 'SSS')
 pre = op.join(sss_path, 'test_move_anon_')
 sss_ctc_fname = pre + 'crossTalk_raw_sss.fif'
 ctf_fname = op.join(data_path, 'CTF', 'testdata_ctf.ds')
+raw_invalid_bday_fname = op.join(data_path, 'misc',
+                                 'test_invalid_birthday_raw.fif')
 
 
 def test_get_valid_units():
@@ -720,6 +723,13 @@ def test_repr():
     t = Transform(1, 2, np.ones((4, 4)))
     info['dev_head_t'] = t
     assert 'dev_head_t: MEG device -> isotrak transform' in repr(info)
+
+
+def test_invalid_subject_birthday():
+    """Test handling of an invalid birthday in the raw file."""
+    with pytest.warns(RuntimeWarning, match='No birthday will be set'):
+        raw = read_raw_fif(raw_invalid_bday_fname)
+    assert 'birthday' not in raw.info['subject_info']
 
 
 run_tests_if_main()

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -49,7 +49,7 @@ pre = op.join(sss_path, 'test_move_anon_')
 sss_ctc_fname = pre + 'crossTalk_raw_sss.fif'
 ctf_fname = op.join(data_path, 'CTF', 'testdata_ctf.ds')
 raw_invalid_bday_fname = op.join(data_path, 'misc',
-                                 'test_invalid_birthday_raw.fif')
+                                 'sample_invalid_birthday_raw.fif')
 
 
 def test_get_valid_units():


### PR DESCRIPTION
#### Reference issue
Fixes GH-7492.

#### What does this implement/fix?
Currently, FIF files that have an invalid birthday or measurement date set cannot be read, as an exception is raised (see #7492). This PR catches the exception, skips the entry (effectively adding it as `None` to the `info` dict), and emits a warning. This way, users can at least load the data, even though the metadata may then be partially incomplete.


#### Additional information
Tested with the problematic Cam-CAN data mentioned in #7492.

I need advise on how to best come up with a test for this.