### PR TITLE
update what's new [skip travis][skip azp]

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -298,6 +298,10 @@ Bug
 API
 ~~~
 
+- ``mne.io.pick.get_channel_types`` is now called ``mne.io.pick.get_channel_type_constants`` to better reflect its return values, by `Daniel McCloy`_.
+
+- Methods :meth:`mne.io.Raw.get_channel_types`, :meth:`mne.Epochs.get_channel_types`, and :meth:`mne.Evoked.get_channel_types` now accept parameters ``picks``, ``unique``, and ``only_data_chs``, by `Daniel McCloy`_.
+
 - :meth:`mne.Evoked.as_type` now returns an instance of :class:`mne.EvokedArray` by `Sophie Herbst`_ and `Alex Gramfort`_
 
 - Bumped minimum requirements to fall 2017 versions by `Eric Larson`_:

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -300,8 +300,6 @@ API
 
 - ``mne.io.pick.get_channel_types`` is now called ``mne.io.pick.get_channel_type_constants`` to better reflect its return values, by `Daniel McCloy`_.
 
-- Methods :meth:`mne.io.Raw.get_channel_types`, :meth:`mne.Epochs.get_channel_types`, and :meth:`mne.Evoked.get_channel_types` now accept parameters ``picks``, ``unique``, and ``only_data_chs``, by `Daniel McCloy`_.
-
 - :meth:`mne.Evoked.as_type` now returns an instance of :class:`mne.EvokedArray` by `Sophie Herbst`_ and `Alex Gramfort`_
 
 - Bumped minimum requirements to fall 2017 versions by `Eric Larson`_:


### PR DESCRIPTION
includes the "what's new" entries that were omitted from #7486 