### PR TITLE
MRG, FIX: Update installation instructions

### DIFF
--- a/doc/install/mne_python.rst
+++ b/doc/install/mne_python.rst
@@ -138,7 +138,7 @@ MNE-Python with all dependencies is update your base Anaconda environment:
 
        $ curl --remote-name https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml
        $ conda env update --file environment.yml
-       $ pip install "PyQt5>=5.10,!=5.14.1"
+       $ pip install "PyQt5>=5.10,<5.14"
 
 .. collapse:: |windows| Windows
 


### PR DESCRIPTION
Closes #7449.

Point picking breakage appears not to be our problem or even Mayavi's, but rather at the VTK level. Probably VTK 8.2 is not compatible with PyQt5 >= 5.14, so we'll need to wait for the VTK9 update to try again (and to get a full 3.8 CI running).