### PR TITLE
MRG: Add test that NIRS naming matches stored frequency

### DIFF
--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -81,6 +81,18 @@ def _check_channels_ordered(raw, freqs):
         ch2_name_info = re.match(r'S(\d+)_D(\d+) (\d+)',
                                  raw.info['chs'][ii + 1]['ch_name'])
 
+        if raw.info['chs'][ii]['loc'][9] != \
+                float(ch1_name_info.groups()[2]) or \
+                raw.info['chs'][ii + 1]['loc'][9] != \
+                float(ch2_name_info.groups()[2]):
+            raise ValueError(
+                'NIRS channels not ordered correctly. Channel name and NIRS'
+                ' frequency do not match: %s -> %s & %s -> %s'
+                % (raw.info['chs'][ii]['ch_name'],
+                   raw.info['chs'][ii]['loc'][9],
+                   raw.info['chs'][ii + 1]['ch_name'],
+                   raw.info['chs'][ii + 1]['loc'][9]))
+
         if (ch1_name_info.groups()[0] != ch2_name_info.groups()[0]) or \
            (ch1_name_info.groups()[1] != ch2_name_info.groups()[1]) or \
            (int(ch1_name_info.groups()[2]) != freqs[0]) or \

--- a/mne/preprocessing/tests/test_beer_lambert_law.py
+++ b/mne/preprocessing/tests/test_beer_lambert_law.py
@@ -59,10 +59,16 @@ def test_beer_lambert_unordered_errors():
     with pytest.raises(ValueError, match='ordered'):
         beer_lambert_law(raw_od)
 
-    # Test that an error is thrown if inconsistent frequencies used in data
+    # Test that an error is thrown if channel naming frequency doesn't match
+    # what is stored in loc[9], which should hold the light frequency too.
     raw_od = optical_density(raw)
     raw_od.rename_channels({'S2_D2 760': 'S2_D2 770'})
-    with pytest.raises(ValueError, match='ordered'):
+    with pytest.raises(ValueError, match='frequency do not match'):
+        beer_lambert_law(raw_od)
+
+    # Test that an error is thrown if inconsistent frequencies used in data
+    raw_od.info['chs'][2]['loc'][9] = 770.0
+    with pytest.raises(ValueError, match='pairs with frequencies'):
         beer_lambert_law(raw_od)
 
 


### PR DESCRIPTION
#### Reference issue
General fNIRS tweaks #7057.


#### What does this implement/fix?
In #7064 the NIRS light frequency was moved from being stored in the channel name to being stored in `info['chs'][ii]['loc'][9]`. However, the frequency is still stored in the channel name for ease of reading, plotting, and because MNE throws an error if two channels have the same name. 

This PR adds a check that the light frequency stored in the `ch_name` and in `loc` match. And adds tests.


#### Additional information
People shouldn't mess with the channel names and this is specified in the docs already. https://github.com/mne-tools/mne-python/blob/master/tutorials/io/plot_30_reading_fnirs_data.py#L26
