### PR TITLE
MRG, MAINT: Better checks for int-ness

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1032,8 +1032,11 @@ def _check_stim_channel(stim_channel, ch_names,
     """Check that the stimulus channel exists in the current datafile."""
     DEFAULT_STIM_CH_NAMES = ['status', 'trigger']
 
-    if stim_channel is None:
+    if stim_channel is None or stim_channel is False:
         return [], []
+
+    if stim_channel is True:  # convenient aliases
+        stim_channel = 'auto'
 
     elif isinstance(stim_channel, str):
         if stim_channel == 'auto':

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -106,9 +106,16 @@ def test_bdf_crop_save_stim_channel(tmpdir):
 
 
 @testing.requires_testing_data
-def test_edf_reduced():
-    """Test EDF with various sampling rates."""
-    _test_raw_reader(read_raw_edf, input_fname=edf_reduced, verbose='error')
+@pytest.mark.parametrize('fname', [
+    edf_reduced,
+    edf_overlap_annot_path,
+])
+@pytest.mark.parametrize('stim_channel', (None, False, 'auto'))
+def test_edf_others(fname, stim_channel):
+    """Test EDF with various sampling rates and overlapping annotations."""
+    _test_raw_reader(
+        read_raw_edf, input_fname=fname, stim_channel=stim_channel,
+        verbose='error')
 
 
 def test_edf_data():

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -100,6 +100,12 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
     assert raw.__class__.__name__ in repr(raw)  # to test repr
     assert raw.info.__class__.__name__ in repr(raw.info)
     assert isinstance(raw.info['dig'], (type(None), list))
+    data_max = full_data.max()
+    data_min = full_data.min()
+    # these limits could be relaxed if we actually find data with
+    # huge values (in SI units)
+    assert data_max < 1e5
+    assert data_min > -1e5
     if isinstance(raw.info['dig'], list):
         for di, d in enumerate(raw.info['dig']):
             assert isinstance(d, DigPoint), (di, d)

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -21,6 +21,10 @@ def _ensure_int(x, name='unknown', must_be='an int'):
     # This is preferred over numbers.Integral, see:
     # https://github.com/scipy/scipy/pull/7351#issuecomment-299713159
     try:
+        # someone passing True/False is much more likely to be an error than
+        # intentional usage
+        if isinstance(x, bool):
+            raise TypeError()
         x = int(operator.index(x))
     except TypeError:
         raise TypeError('%s must be %s, got %s' % (name, must_be, type(x)))

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -18,7 +18,7 @@ from mne.io.pick import pick_channels_cov
 from mne.utils import (check_random_state, _check_fname, check_fname,
                        _check_subject, requires_mayavi, traits_test,
                        _check_mayavi_version, _check_info_inv, _check_option,
-                       check_version, _check_path_like)
+                       check_version, _check_path_like, _validate_type)
 data_path = testing.data_path(download=False)
 base_dir = op.join(data_path, 'MEG', 'sample')
 fname_raw = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc_raw.fif')
@@ -174,3 +174,10 @@ def test_check_path_like():
     assert _check_path_like(str_path) is True
     assert _check_path_like(pathlib_path) is True
     assert _check_path_like(no_path) is False
+
+
+def test_validate_type():
+    """Test _validate_type."""
+    _validate_type(1, 'int-like')
+    with pytest.raises(TypeError, match='int-like'):
+        _validate_type(False, 'int-like')


### PR DESCRIPTION
Be more permissive of True/False in `read_raw_edf`, but also more strict in `_validate_types` since passing a `bool` to act as an `int` is much more likely to cause unexpected behaviors than expected ones (and easily worked around with `int(my_bool)` if people actually want to provide an int).

No need for `latest.inc` update I think since this is mostly an internal change (except maybe for being more permissive, but I'm not sure that's even worth advertising).

Closes #7485