### PR TITLE
MRG, FIX: Add support for BIDS-style raw files to reports

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -289,6 +289,8 @@ Bug
 
 - Fix bug in reading annotations in :func:`read_annotations`, which would not accept ";" character by `Adam Li`_
 
+- Fix bug in :func:`mne.Report.parse_folder`, which would not recognize `*meg.fif` files by `Dmitrii Altukhov`_.
+
 - Include ``fit_params`` when saving an :class:`~mne.preprocessing.ICA` instance to disk by `Richard Höchenberger`_
 
 - Update old url link in :func:`mne.datasets.eegbci.load_data` to ``EEGMI_URL = 'https://physionet.org/files/eegmmidb/1.0.0/'`` by `Ramiro Gatti`_

--- a/mne/report.py
+++ b/mne/report.py
@@ -40,7 +40,7 @@ VALID_EXTENSIONS = ['raw.fif', 'raw.fif.gz', 'sss.fif', 'sss.fif.gz',
                     '-eve.fif', '-eve.fif.gz', '-cov.fif', '-cov.fif.gz',
                     '-trans.fif', '-trans.fif.gz', '-fwd.fif', '-fwd.fif.gz',
                     '-epo.fif', '-epo.fif.gz', '-inv.fif', '-inv.fif.gz',
-                    '-ave.fif', '-ave.fif.gz', 'T1.mgz']
+                    '-ave.fif', '-ave.fif.gz', 'T1.mgz', 'meg.fif']
 SECTION_ORDER = ['raw', 'events', 'epochs', 'evoked', 'covariance', 'trans',
                  'mri', 'forward', 'inverse']
 
@@ -203,7 +203,7 @@ def _get_toc_property(fname):
         tooltip = fname
         text = op.basename(fname)
     elif fname.endswith(('raw.fif', 'raw.fif.gz',
-                         'sss.fif', 'sss.fif.gz')):
+                         'sss.fif', 'sss.fif.gz', 'meg.fif')):
         div_klass = 'raw'
         tooltip = fname
         text = op.basename(fname)
@@ -260,7 +260,7 @@ def _iterate_files(report, fnames, info, cov, baseline, sfreq, on_error,
                               fname))
         try:
             if fname.endswith(('raw.fif', 'raw.fif.gz',
-                               'sss.fif', 'sss.fif.gz')):
+                               'sss.fif', 'sss.fif.gz', 'meg.fif')):
                 html = report._render_raw(fname)
                 report_fname = fname
                 report_sectionlabel = 'raw'

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -55,12 +55,14 @@ def test_render_report(renderer, tmpdir):
     """Test rendering -*.fif files for mne report."""
     tempdir = str(tmpdir)
     raw_fname_new = op.join(tempdir, 'temp_raw.fif')
+    raw_fname_new_bids = op.join(tempdir, 'temp_meg.fif')
     ms_fname_new = op.join(tempdir, 'temp_ms_raw.fif')
     event_fname_new = op.join(tempdir, 'temp_raw-eve.fif')
     cov_fname_new = op.join(tempdir, 'temp_raw-cov.fif')
     fwd_fname_new = op.join(tempdir, 'temp_raw-fwd.fif')
     inv_fname_new = op.join(tempdir, 'temp_raw-inv.fif')
     for a, b in [[raw_fname, raw_fname_new],
+                 [raw_fname, raw_fname_new_bids],
                  [ms_fname, ms_fname_new],
                  [event_fname, event_fname_new],
                  [cov_fname, cov_fname_new],


### PR DESCRIPTION
#### Reference issue
Fixes #7493 


#### What does this implement/fix?
`mne.Report.parse_folder` used to ignore `meg.fif` raw files although in the documentation example
[Getting started with mne.Report](https://mne.tools/dev/auto_tutorials/misc/plot_report.html#sphx-glr-auto-tutorials-misc-plot-report-py) `_meg.fif` is listed within the supported formats.
This PR fixes file fetching in `report.py` so it actually loads `meg.fif`.