### PR TITLE
MRG, ENH: Allow picking without preload

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -15,6 +15,8 @@ Current (0.21.dev0)
 Changelog
 ~~~~~~~~~
 
+- Allow picking channels in raw instances (e.g., :meth:`mne.io.Raw.pick_types`) without preloading data, by `Eric Larson`_
+
 - Add support for signals in mV for :func:`mne.io.read_raw_brainvision` by `Clemens Brunner`_
 
 Bug

--- a/examples/connectivity/plot_mixed_source_space_connectivity.py
+++ b/examples/connectivity/plot_mixed_source_space_connectivity.py
@@ -69,9 +69,9 @@ vol_src = setup_volume_source_space(
 src += vol_src
 
 # Load data
-raw = read_raw_fif(fname_raw, preload=True)
+raw = read_raw_fif(fname_raw)
+raw.pick_types(meg=True, eeg=False, eog=True, stim=True).load_data()
 events = mne.find_events(raw)
-raw.pick_types(meg=True, eeg=False, eog=True)
 noise_cov = mne.read_cov(fname_cov)
 
 # compute the fwd matrix

--- a/examples/connectivity/plot_mne_inverse_envelope_correlation.py
+++ b/examples/connectivity/plot_mne_inverse_envelope_correlation.py
@@ -39,7 +39,7 @@ raw_fname = op.join(data_path, 'MEG', 'bst_resting',
 # hurt SNR) and downsample. Then we compute SSP projectors and apply them.
 
 raw = mne.io.read_raw_ctf(raw_fname, verbose='error')
-raw.crop(0, 60).load_data().pick_types(meg=True, eeg=False).resample(80)
+raw.crop(0, 60).pick_types(meg=True, eeg=False).load_data().resample(80)
 raw.apply_gradient_compensation(3)
 projs_ecg, _ = compute_proj_ecg(raw, n_grad=1, n_mag=2)
 projs_eog, _ = compute_proj_eog(raw, n_grad=1, n_mag=2, ch_name='MLT31-4407')

--- a/examples/connectivity/plot_mne_inverse_envelope_correlation_volume.py
+++ b/examples/connectivity/plot_mne_inverse_envelope_correlation_volume.py
@@ -34,7 +34,7 @@ crop_to = 60.
 # hurt SNR) and downsample. Then we compute SSP projectors and apply them.
 
 raw = mne.io.read_raw_ctf(raw_fname, verbose='error')
-raw.crop(0, crop_to).load_data().pick_types(meg=True, eeg=False).resample(80)
+raw.crop(0, crop_to).pick_types(meg=True, eeg=False).load_data().resample(80)
 raw.apply_gradient_compensation(3)
 projs_ecg, _ = compute_proj_ecg(raw, n_grad=1, n_mag=2)
 projs_eog, _ = compute_proj_eog(raw, n_grad=1, n_mag=2, ch_name='MLT31-4407')

--- a/examples/decoding/plot_decoding_csp_timefreq.py
+++ b/examples/decoding/plot_decoding_csp_timefreq.py
@@ -37,12 +37,13 @@ event_id = dict(hands=2, feet=3)  # motor imagery: hands vs feet
 subject = 1
 runs = [6, 10, 14]
 raw_fnames = eegbci.load_data(subject, runs)
-raw = concatenate_raws([read_raw_edf(f, preload=True) for f in raw_fnames])
+raw = concatenate_raws([read_raw_edf(f) for f in raw_fnames])
 
 # Extract information from the raw file
 sfreq = raw.info['sfreq']
 events, _ = events_from_annotations(raw, event_id=dict(T1=2, T2=3))
 raw.pick_types(meg=False, eeg=True, stim=False, eog=False, exclude='bads')
+raw.load_data()
 
 # Assemble the classifier using scikit-learn pipeline
 clf = make_pipeline(CSP(n_components=4, reg=None, log=True, norm_trace=False),

--- a/examples/decoding/plot_decoding_spoc_CMC.py
+++ b/examples/decoding/plot_decoding_spoc_CMC.py
@@ -39,14 +39,14 @@ from sklearn.model_selection import KFold, cross_val_predict
 # Define parameters
 fname = data_path() + '/SubjectCMC.ds'
 raw = mne.io.read_raw_ctf(fname)
-raw.crop(50., 250.).load_data()  # crop for memory purposes
+raw.crop(50., 250.)  # crop for memory purposes
 
 # Filter muscular activity to only keep high frequencies
-emg = raw.copy().pick_channels(['EMGlft'])
+emg = raw.copy().pick_channels(['EMGlft']).load_data()
 emg.filter(20., None, fir_design='firwin')
 
 # Filter MEG data to focus on beta band
-raw.pick_types(meg=True, ref_meg=True, eeg=False, eog=False)
+raw.pick_types(meg=True, ref_meg=True, eeg=False, eog=False).load_data()
 raw.filter(15., 30., fir_design='firwin')
 
 # Build epochs as sliding windows over the continuous raw file

--- a/examples/inverse/plot_tf_lcmv.py
+++ b/examples/inverse/plot_tf_lcmv.py
@@ -36,7 +36,7 @@ fname_label = data_path + '/MEG/sample/labels/%s.label' % label_name
 
 ###############################################################################
 # Read raw data, preload to allow filtering
-raw = mne.io.read_raw_fif(raw_fname, preload=True)
+raw = mne.io.read_raw_fif(raw_fname)
 raw.info['bads'] = ['MEG 2443']  # 1 bad MEG channel
 
 # Pick a selection of magnetometer channels. A subset of all channels was used
@@ -46,7 +46,7 @@ raw.info['bads'] = ['MEG 2443']  # 1 bad MEG channel
 # but here we use raw.pick_types() to save memory.
 left_temporal_channels = mne.read_selection('Left-temporal')
 raw.pick_types(meg='mag', eeg=False, eog=False, stim=False, exclude='bads',
-               selection=left_temporal_channels)
+               selection=left_temporal_channels).load_data()
 reject = dict(mag=4e-12)
 # Re-normalize our empty-room projectors, which should be fine after
 # subselection

--- a/examples/preprocessing/plot_eeg_csd.py
+++ b/examples/preprocessing/plot_eeg_csd.py
@@ -27,11 +27,10 @@ data_path = sample.data_path()
 
 ###############################################################################
 # Load sample subject data
-raw = mne.io.read_raw_fif(data_path + '/MEG/sample/sample_audvis_raw.fif',
-                          preload=True)
+raw = mne.io.read_raw_fif(data_path + '/MEG/sample/sample_audvis_raw.fif')
+raw = raw.pick_types(meg=False, eeg=True, eog=True, ecg=True, stim=True,
+                     exclude=raw.info['bads']).load_data()
 events = mne.find_events(raw)
-raw = raw.pick_types(meg=False, eeg=True, eog=True, ecg=True, stim=False,
-                     exclude=raw.info['bads'])
 raw.set_eeg_reference(projection=True).apply_proj()
 
 ###############################################################################

--- a/examples/preprocessing/plot_run_ica.py
+++ b/examples/preprocessing/plot_run_ica.py
@@ -31,8 +31,8 @@ print(__doc__)
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 
-raw = mne.io.read_raw_fif(raw_fname, preload=True)
-raw.pick_types(meg=True, eeg=False, exclude='bads', stim=True)
+raw = mne.io.read_raw_fif(raw_fname)
+raw.pick_types(meg=True, eeg=False, exclude='bads', stim=True).load_data()
 raw.filter(1, 30, fir_design='firwin')
 
 # longer + more epochs for more artifact exposure

--- a/examples/stats/plot_linear_regression_raw.py
+++ b/examples/stats/plot_linear_regression_raw.py
@@ -30,8 +30,8 @@ from mne.stats.regression import linear_regression_raw
 # Load and preprocess data
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
-raw = mne.io.read_raw_fif(raw_fname, preload=True)
-raw.pick_types(meg='grad', stim=True, eeg=False)
+raw = mne.io.read_raw_fif(raw_fname)
+raw.pick_types(meg='grad', stim=True, eeg=False).load_data()
 raw.filter(1, None, fir_design='firwin')  # high-pass
 
 # Set up events

--- a/examples/time_frequency/plot_time_frequency_global_field_power.py
+++ b/examples/time_frequency/plot_time_frequency_global_field_power.py
@@ -86,8 +86,9 @@ frequency_map = list()
 
 for band, fmin, fmax in iter_freqs:
     # (re)load the data to save memory
-    raw = mne.io.read_raw_fif(raw_fname, preload=True)
+    raw = mne.io.read_raw_fif(raw_fname)
     raw.pick_types(meg='grad', eog=True)  # we just look at gradiometers
+    raw.load_data()
 
     # bandpass filter
     raw.filter(fmin, fmax, n_jobs=1,  # use more jobs to speed up.

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -457,5 +457,5 @@ class RawArtemis123(BaseRaw):
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
-        _read_segments_file(self, data, idx, fi, start,
-                            stop, cals, mult, dtype='>f4')
+        _read_segments_file(
+            self, data, idx, fi, start, stop, cals, mult, dtype='>f4')

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -129,6 +129,8 @@ def _read_segments_c(raw, data, idx, fi, start, stop, cals, mult):
     n_channels = raw._raw_extras[fi]['orig_nchan']
     block = np.zeros((n_channels, stop - start))
     with open(raw._filenames[fi], 'rb', buffering=0) as fid:
+        if isinstance(idx, slice):
+            idx = np.arange(idx.start, idx.stop)
         for ch_id in idx:
             fid.seek(start * n_bytes + ch_id * n_bytes * n_samples)
             block[ch_id] = np.fromfile(fid, dtype, stop - start)

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -65,18 +65,16 @@ class RawBrainVision(BaseRaw):
         vhdr_fname = op.abspath(vhdr_fname)
         (info, data_fname, fmt, order, n_samples, mrk_fname, montage,
          orig_units) = _get_vhdr_info(vhdr_fname, eog, misc, scale)
-        self._order = order
-        self._n_samples = n_samples
 
         with open(data_fname, 'rb') as f:
             if isinstance(fmt, dict):  # ASCII, this will be slow :(
-                if self._order == 'F':  # multiplexed, channels in columns
+                if order == 'F':  # multiplexed, channels in columns
                     n_skip = 0
                     for ii in range(int(fmt['skiplines'])):
                         n_skip += len(f.readline())
                     offsets = np.cumsum([n_skip] + [len(line) for line in f])
                     n_samples = len(offsets) - 1
-                elif self._order == 'C':  # vectorized, channels, in rows
+                elif order == 'C':  # vectorized, channels, in rows
                     raise NotImplementedError()
             else:
                 n_data_ch = int(info['nchan'])
@@ -86,10 +84,12 @@ class RawBrainVision(BaseRaw):
                 offsets = None
                 n_samples = n_samples // (dtype_bytes * n_data_ch)
 
+        raw_extras = dict(
+            offsets=offsets, fmt=fmt, order=order, n_samples=n_samples)
         super(RawBrainVision, self).__init__(
             info, last_samps=[n_samples - 1], filenames=[data_fname],
             orig_format=fmt, preload=preload, verbose=verbose,
-            raw_extras=[offsets], orig_units=orig_units)
+            raw_extras=[raw_extras], orig_units=orig_units)
 
         self.set_montage(montage)
 
@@ -100,18 +100,19 @@ class RawBrainVision(BaseRaw):
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
         # read data
-        n_data_ch = len(self.ch_names)
-        if self._order == 'C':
+        n_data_ch = self._raw_extras[fi]['orig_nchan']
+        fmt = self._raw_extras[fi]['fmt']
+        if self._raw_extras[fi]['order'] == 'C':
             _read_segments_c(self, data, idx, fi, start, stop, cals, mult)
-        elif isinstance(self.orig_format, str):
-            dtype = _fmt_dtype_dict[self.orig_format]
+        elif isinstance(fmt, str):
+            dtype = _fmt_dtype_dict[fmt]
             _read_segments_file(self, data, idx, fi, start, stop, cals, mult,
                                 dtype=dtype, n_channels=n_data_ch)
         else:
-            offsets = self._raw_extras[fi]
+            offsets = self._raw_extras[fi]['offsets']
             with open(self._filenames[fi], 'rb') as fid:
                 fid.seek(offsets[start])
-                block = np.empty((len(self.ch_names), stop - start))
+                block = np.empty((n_data_ch, stop - start))
                 for ii in range(stop - start):
                     line = fid.readline().decode('ASCII')
                     line = line.strip().replace(',', '.').split()
@@ -121,13 +122,14 @@ class RawBrainVision(BaseRaw):
 
 def _read_segments_c(raw, data, idx, fi, start, stop, cals, mult):
     """Read chunk of vectorized raw data."""
-    n_samples = raw._n_samples
-    dtype = _fmt_dtype_dict[raw.orig_format]
-    n_bytes = _fmt_byte_dict[raw.orig_format]
-    n_channels = len(raw.ch_names)
+    n_samples = raw._raw_extras[fi]['n_samples']
+    fmt = raw._raw_extras[fi]['fmt']
+    dtype = _fmt_dtype_dict[fmt]
+    n_bytes = _fmt_byte_dict[fmt]
+    n_channels = raw._raw_extras[fi]['orig_nchan']
     block = np.zeros((n_channels, stop - start))
     with open(raw._filenames[fi], 'rb', buffering=0) as fid:
-        for ch_id in np.arange(n_channels)[idx]:
+        for ch_id in idx:
             fid.seek(start * n_bytes + ch_id * n_bytes * n_samples)
             block[ch_id] = np.fromfile(fid, dtype, stop - start)
 

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -961,7 +961,8 @@ class RawBTi(BaseRaw):
         bti_info = self._raw_extras[fi]
         fname = bti_info['pdf_fname']
         dtype = bti_info['dtype']
-        n_channels = self.info['nchan']
+        assert len(bti_info['chs']) == self._raw_extras[fi]['orig_nchan']
+        n_channels = len(bti_info['chs'])
         n_bytes = np.dtype(dtype).itemsize
         data_left = (stop - start) * n_channels
         read_cals = np.empty((bti_info['total_chans'],))

--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -452,6 +452,8 @@ class RawCurry(BaseRaw):
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
         if self._raw_extras[fi]['is_ascii']:
+            if isinstance(idx, slice):
+                idx = np.arange(idx.start, idx.stop)
             kwargs = dict(skiprows=start, usecols=idx)
             if check_version("numpy", "1.16.0"):
                 kwargs['max_rows'] = stop - start

--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -434,11 +434,11 @@ class RawCurry(BaseRaw):
         info, n_samples, is_ascii = _read_curry_info(curry_paths)
 
         last_samps = [n_samples - 1]
-        self._is_ascii = is_ascii
+        raw_extras = dict(is_ascii=is_ascii)
 
         super(RawCurry, self).__init__(
             info, preload, filenames=[data_fname], last_samps=last_samps,
-            orig_format='int', verbose=verbose)
+            orig_format='int', raw_extras=[raw_extras], verbose=verbose)
 
         if 'events' in curry_paths:
             logger.info('Event file found. Extracting Annotations from'
@@ -451,24 +451,18 @@ class RawCurry(BaseRaw):
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
-        if self._is_ascii:
-            ch_idx = range(0, len(self.ch_names))
+        if self._raw_extras[fi]['is_ascii']:
+            kwargs = dict(skiprows=start, usecols=idx)
             if check_version("numpy", "1.16.0"):
-                block = np.loadtxt(self.filenames[0],
-                                   skiprows=start,
-                                   usecols=ch_idx[idx],
-                                   max_rows=stop - start).T
+                kwargs['max_rows'] = stop - start
             else:
                 warn("Data reading might take longer for ASCII files. Update "
                      "numpy to version 1.16.0 or greater for more efficient "
                      "data reading.")
-                block = np.loadtxt(self.filenames[0],
-                                   skiprows=start,
-                                   usecols=ch_idx[idx]).T
-                block = block[:, :stop - start]
+            block = np.loadtxt(self._filenames[0], **kwargs)[:stop - start].T
             data_view = data[:, :block.shape[1]]
             _mult_cal_one(data_view, block, idx, cals, mult)
 
         else:
-            _read_segments_file(self, data, idx, fi, start, stop, cals,
-                                mult, dtype="<f4")
+            _read_segments_file(
+                self, data, idx, fi, start, stop, cals, mult, dtype="<f4")

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -314,8 +314,12 @@ def _read_segment_file(data, idx, fi, start, stop, raw_extras, filenames):
         stim_channel_idx = np.array([], int)
     else:
         stim_channel_idx = list()
+        if isinstance(idx, slice):
+            use_idx = np.arange(idx.start, idx.stop)
+        else:
+            use_idx = idx
         for stim_ch in stim_channel:
-            stim_ch_idx = np.where(idx == stim_ch)[0].tolist()
+            stim_ch_idx = np.where(use_idx == stim_ch)[0].tolist()
             if len(stim_ch_idx):
                 stim_channel_idx.append(stim_ch_idx)
         stim_channel_idx = np.array(stim_channel_idx).ravel()

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -363,8 +363,8 @@ class RawEEGLAB(BaseRaw):
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
-        _read_segments_file(self, data, idx, fi, start, stop, cals, mult,
-                            dtype=np.float32, n_channels=self.info['nchan'])
+        _read_segments_file(
+            self, data, idx, fi, start, stop, cals, mult, dtype='<f4')
 
 
 class EpochsEEGLAB(BaseEpochs):

--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -219,14 +219,14 @@ class RawEGI(BaseRaw):
             logger.info('    Excluding events {%s} ...' %
                         ", ".join([k for i, k in enumerate(event_codes)
                                    if i not in include_]))
-            self._new_trigger = _combine_triggers(egi_events[include_],
-                                                  remapping=event_ids)
+            egi_info['new_trigger'] = _combine_triggers(
+                egi_events[include_], remapping=event_ids)
             self.event_id = dict(zip([e for e in event_codes if e in
                                       include_names], event_ids))
         else:
             # No events
             self.event_id = None
-            self._new_trigger = None
+            egi_info['new_trigger'] = None
         info = _empty_info(egi_info['samp_rate'])
         my_time = datetime.datetime(
             egi_info['year'], egi_info['month'], egi_info['day'],
@@ -236,7 +236,7 @@ class RawEGI(BaseRaw):
         ch_names = [channel_naming % (i + 1) for i in
                     range(egi_info['n_channels'])]
         ch_names.extend(list(egi_info['event_codes']))
-        if self._new_trigger is not None:
+        if egi_info['new_trigger'] is not None:
             ch_names.append('STI 014')  # our new_trigger
         nchan = len(ch_names)
         cals = np.repeat(cal, nchan)
@@ -263,6 +263,7 @@ class RawEGI(BaseRaw):
         dtype = egi_info['dtype']
         n_chan_read = egi_info['n_channels'] + egi_info['n_events']
         offset = 36 + egi_info['n_events'] * 4
+        trigger_ch = egi_info['new_trigger']
         _read_segments_file(self, data, idx, fi, start, stop, cals, mult,
                             dtype=dtype, n_channels=n_chan_read, offset=offset,
-                            trigger_ch=self._new_trigger)
+                            trigger_ch=trigger_ch)

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -492,6 +492,8 @@ class RawMff(BaseRaw):
 
         # Check how many channels to read are from each type
         bounds = egi_info['kind_bounds']
+        if isinstance(idx, slice):
+            idx = np.arange(idx.start, idx.stop)
         eeg_out = np.where(idx < bounds[1])[0]
         eeg_in = idx[eeg_out]
         stim_out = np.where((idx >= bounds[1]) & (idx < bounds[2]))[0]

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -149,12 +149,16 @@ def test_io_egi_pns_mff():
 
 
 @requires_testing_data
-def test_io_egi_pns_mff_bug():
+@pytest.mark.parametrize('preload', (True, False))
+def test_io_egi_pns_mff_bug(preload):
     """Test importing EGI MFF with PNS data (BUG)."""
     egi_fname_mff = op.join(data_path(), 'EGI', 'test_egi_pns_bug.mff')
     with pytest.warns(RuntimeWarning, match='EGI PSG sample bug'):
-        raw = read_raw_egi(egi_fname_mff, include=None, preload=True,
+        raw = read_raw_egi(egi_fname_mff, include=None, preload=preload,
                            verbose='warning')
+    assert len(raw.annotations) == 1
+    assert_allclose(raw.annotations.duration, [0.004])
+    assert_allclose(raw.annotations.onset, [13.948])
     egi_fname_mat = op.join(data_path(), 'EGI', 'test_egi_pns.mat')
     mc = sio.loadmat(egi_fname_mat)
     pns_chans = pick_types(raw.info, ecg=True, bio=True, emg=True)

--- a/mne/io/eximia/eximia.py
+++ b/mne/io/eximia/eximia.py
@@ -87,4 +87,5 @@ class RawEximia(BaseRaw):
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
-        _read_segments_file(self, data, idx, fi, start, stop, cals, mult)
+        _read_segments_file(
+            self, data, idx, fi, start, stop, cals, mult, dtype='<i2')

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -337,6 +337,7 @@ class Raw(BaseRaw):
         with _fiff_get_fid(self._filenames[fi]) as fid:
             bounds = self._raw_extras[fi]['bounds']
             ents = self._raw_extras[fi]['ent']
+            nchan = self._raw_extras[fi]['orig_nchan']
             use = (stop > bounds[:-1]) & (start < bounds[1:])
             offset = 0
             for ei in np.where(use)[0]:
@@ -350,9 +351,9 @@ class Raw(BaseRaw):
                 # only read data if it exists
                 if ent is not None:
                     one = read_tag(fid, ent.pos,
-                                   shape=(nsamp, self.info['nchan']),
+                                   shape=(nsamp, nchan),
                                    rlims=(first_pick, last_pick)).data
-                    one.shape = (picksamp, self.info['nchan'])
+                    one.shape = (picksamp, nchan)
                     _mult_cal_one(data[:, offset:(offset + picksamp)],
                                   one.T, idx, cals, mult)
                 offset += picksamp

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -408,7 +408,7 @@ def _get_fname_rep(fname):
     if not _file_like(fname):
         return fname
     else:
-        return 'File-like %r' % (fname,)
+        return 'File-like'
 
 
 def _check_entry(first, nent):

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1527,7 +1527,7 @@ def test_file_like(kind, preload, split, tmpdir):
     else:
         fname = test_fif_fname
     if preload is str:
-        preload = tmpdir.join('memmap')
+        preload = str(tmpdir.join('memmap'))
     with open(str(fname), 'rb') as file_fid:
         fid = BytesIO(file_fid.read()) if kind == 'bytes' else file_fid
         assert not fid.closed
@@ -1547,6 +1547,11 @@ def test_file_like(kind, preload, split, tmpdir):
             _test_raw_reader(read_raw_fif, **kwargs)
         assert not fid.closed
         assert not file_fid.closed
+        with pytest.warns(None):
+            raw = read_raw_fif(fid, preload=preload)
+        rep = repr(raw)
+        assert rep.count('<') == 1
+        assert rep.count('>') == 1
     assert file_fid.closed
 
 

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1547,11 +1547,6 @@ def test_file_like(kind, preload, split, tmpdir):
             _test_raw_reader(read_raw_fif, **kwargs)
         assert not fid.closed
         assert not file_fid.closed
-        with pytest.warns(None):
-            raw = read_raw_fif(fid, preload=preload)
-        rep = repr(raw)
-        assert rep.count('<') == 1
-        assert rep.count('>') == 1
     assert file_fid.closed
 
 

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1434,28 +1434,27 @@ def test_drop_channels_mixin():
 
 
 @testing.requires_testing_data
-def test_pick_channels_mixin():
+@pytest.mark.parametrize('preload', (True, False))
+def test_pick_channels_mixin(preload):
     """Test channel-picking functionality."""
-    # preload is True
-
-    raw = read_raw_fif(fif_fname, preload=True)
+    raw = read_raw_fif(fif_fname, preload=preload)
+    raw_orig = raw.copy()
     ch_names = raw.ch_names[:3]
 
     ch_names_orig = raw.ch_names
     dummy = raw.copy().pick_channels(ch_names)
     assert ch_names == dummy.ch_names
     assert ch_names_orig == raw.ch_names
-    assert len(ch_names_orig) == raw._data.shape[0]
+    assert len(ch_names_orig) == raw.get_data().shape[0]
 
     raw.pick_channels(ch_names)  # copy is False
     assert ch_names == raw.ch_names
     assert len(ch_names) == len(raw._cals)
-    assert len(ch_names) == raw._data.shape[0]
-    pytest.raises(ValueError, raw.pick_channels, ch_names[0])
+    assert len(ch_names) == raw.get_data().shape[0]
+    with pytest.raises(ValueError, match='must be'):
+        raw.pick_channels(ch_names[0])
 
-    raw = read_raw_fif(fif_fname, preload=False)
-    pytest.raises(RuntimeError, raw.pick_channels, ch_names)
-    pytest.raises(RuntimeError, raw.drop_channels, ch_names)
+    assert_allclose(raw[:][0], raw_orig[:3][0])
 
 
 @testing.requires_testing_data

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -231,9 +231,10 @@ class RawKIT(BaseRaw):
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
-        nchan = self._raw_extras[fi]['nchan']
+        params = self._raw_extras[fi]
+        nchan = params['nchan']
         data_left = (stop - start) * nchan
-        conv_factor = self._raw_extras[fi]['conv_factor']
+        conv_factor = params['conv_factor']
 
         n_bytes = 2
         # Read up to 100 MB of data at a time.
@@ -245,7 +246,7 @@ class RawKIT(BaseRaw):
             data_offset = unpack('i', fid.read(KIT.INT))[0]
             pointer = start * nchan * KIT.SHORT
             fid.seek(data_offset + pointer)
-            stim = self._raw_extras[fi]['stim']
+            stim = params['stim']
             for blk_start in np.arange(0, data_left, blk_size) // nchan:
                 blk_size = min(blk_size, data_left - blk_start * nchan)
                 block = np.fromfile(fid, dtype='h', count=blk_size)
@@ -256,11 +257,9 @@ class RawKIT(BaseRaw):
 
                 # Create a synthetic stim channel
                 if stim is not None:
-                    params = self._raw_extras[fi]
-                    stim_ch = _make_stim_channel(block[stim, :],
-                                                 params['slope'],
-                                                 params['stimthresh'],
-                                                 params['stim_code'], stim)
+                    stim_ch = _make_stim_channel(
+                        block[stim, :], params['slope'], params['stimthresh'],
+                        params['stim_code'], stim)
                     block = np.vstack((block, stim_ch))
 
                 _mult_cal_one(data_view, block, idx, None, mult)

--- a/mne/io/nicolet/nicolet.py
+++ b/mne/io/nicolet/nicolet.py
@@ -161,4 +161,5 @@ class RawNicolet(BaseRaw):
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
-        _read_segments_file(self, data, idx, fi, start, stop, cals, mult)
+        _read_segments_file(
+            self, data, idx, fi, start, stop, cals, mult, dtype='<i2')

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -269,11 +269,12 @@ class RawNIRX(BaseRaw):
         The returned data interleaves the wavelengths.
         """
         sdindex = self._raw_extras[fi]['sd_index']
+        nchan = self._raw_extras[fi]['orig_nchan']
 
         wls = [
             _read_csv_rows_cols(
                 self._raw_extras[fi]['files'][key],
-                start, stop, sdindex, len(self.ch_names) // 2).T
+                start, stop, sdindex, nchan // 2).T
             for key in ('wl1', 'wl2')
         ]
 

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -517,7 +517,7 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
             # otherwise it's modified inplace
             _copy_channel(inst, an, 'TMP')
             an = 'TMP'
-        _apply_reference(inst, [ca], [an])
+        _apply_reference(inst, [ca], [an])  # ensures preloaded
         an_idx = inst.ch_names.index(an)
         inst.info['chs'][an_idx] = chs
         inst.info['chs'][an_idx]['ch_name'] = name

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -182,6 +182,10 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
     for preload_kwarg in preload_kwargs:
         these_kwargs = kwargs.copy()
         these_kwargs.update(preload_kwarg)
+        # dont use the same filename or it could create problems
+        if isinstance(these_kwargs.get('preload', None), str) and \
+                op.isfile(these_kwargs['preload']):
+            these_kwargs['preload'] += '-1'
         whole_raw = reader(**these_kwargs)
         print(whole_raw)  # __repr__
         assert n_ch >= 2

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -72,6 +72,9 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
         del kwargs['montage']
     if test_preloading:
         raw = reader(preload=True, **kwargs)
+        rep = repr(raw)
+        assert rep.count('<') == 1
+        assert rep.count('>') == 1
         if montage is not None:
             raw.set_montage(montage)
         # don't assume the first is preloaded
@@ -180,6 +183,7 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
         these_kwargs = kwargs.copy()
         these_kwargs.update(preload_kwarg)
         whole_raw = reader(**these_kwargs)
+        print(whole_raw)  # __repr__
         assert n_ch >= 2
         picks_1 = picks[:n_ch // 2]
         picks_2 = picks[n_ch // 2:]

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -169,6 +169,30 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
         for ch_name, unit in raw._orig_units.items():
             assert unit.lower() in valid_units_lower, ch_name
 
+    # Test picking with and without preload
+    if test_preloading:
+        preload_kwargs = (dict(preload=True), dict(preload=False))
+    else:
+        preload_kwargs = (dict(),)
+    n_ch = len(raw.ch_names)
+    picks = rng.permutation(n_ch)
+    for preload_kwarg in preload_kwargs:
+        these_kwargs = kwargs.copy()
+        these_kwargs.update(preload_kwarg)
+        whole_raw = reader(**these_kwargs)
+        assert n_ch >= 2
+        picks_1 = picks[:n_ch // 2]
+        picks_2 = picks[n_ch // 2:]
+        raw_1 = whole_raw.copy().pick(picks_1)
+        raw_2 = whole_raw.copy().pick(picks_2)
+        data, times = whole_raw[:]
+        data_1, times_1 = raw_1[:]
+        data_2, times_2 = raw_2[:]
+        assert_array_equal(times, times_1)
+        assert_array_equal(data[picks_1], data_1)
+        assert_array_equal(times, times_2,)
+        assert_array_equal(data[picks_2], data_2)
+
     return raw
 
 

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -182,7 +182,7 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
     for preload_kwarg in preload_kwargs:
         these_kwargs = kwargs.copy()
         these_kwargs.update(preload_kwarg)
-        # dont use the same filename or it could create problems
+        # don't use the same filename or it could create problems
         if isinstance(these_kwargs.get('preload', None), str) and \
                 op.isfile(these_kwargs['preload']):
             these_kwargs['preload'] += '-1'

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -196,10 +196,10 @@ def _file_size(fname):
 
 
 def _read_segments_file(raw, data, idx, fi, start, stop, cals, mult,
-                        dtype='<i2', n_channels=None, offset=0,
-                        trigger_ch=None):
+                        dtype, n_channels=None, offset=0, trigger_ch=None):
     """Read a chunk of raw data."""
-    n_channels = raw.info['nchan'] if n_channels is None else n_channels
+    if n_channels is None:
+        n_channels = raw._raw_extras[fi]['orig_nchan']
 
     n_bytes = np.dtype(dtype).itemsize
     # data_offset and data_left count data samples (channels x time points),

--- a/tutorials/evoked/plot_eeg_erp.py
+++ b/tutorials/evoked/plot_eeg_erp.py
@@ -18,15 +18,15 @@ from mne.datasets import sample
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
-raw = mne.io.read_raw_fif(raw_fname, preload=True)
+raw = mne.io.read_raw_fif(raw_fname)
+
+###############################################################################
+# Let's restrict the data to the EEG channels
+raw.pick_types(meg=False, eeg=True, eog=True).load_data()
 
 # This particular dataset already has an average reference projection added
 # that we now want to remove it for the sake of this example.
 raw.set_eeg_reference([])
-
-###############################################################################
-# Let's restrict the data to the EEG channels
-raw.pick_types(meg=False, eeg=True, eog=True)
 
 ###############################################################################
 # By looking at the measurement info you will see that we have now

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -22,7 +22,7 @@ sample_data_folder = mne.datasets.sample.data_path()
 sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
                                     'sample_audvis_raw.fif')
 raw = mne.io.read_raw_fif(sample_data_raw_file, verbose=False)
-raw.crop(tmax=60).load_data()
+raw.crop(tmax=60)
 
 ###############################################################################
 # Background on SSS and Maxwell filtering
@@ -104,7 +104,7 @@ crosstalk_file = os.path.join(sample_data_folder, 'SSS', 'ct_sparse_mgh.fif')
 # we just low-pass filter these data:
 
 raw.info['bads'] = []
-raw_check = raw.copy().pick_types(exclude=()).filter(None, 40)
+raw_check = raw.copy().pick_types(exclude=()).load_data().filter(None, 40)
 auto_noisy_chs, auto_flat_chs = mne.preprocessing.find_bad_channels_maxwell(
     raw_check, cross_talk=crosstalk_file, calibration=fine_cal_file,
     verbose=True)

--- a/tutorials/raw/plot_10_raw_overview.py
+++ b/tutorials/raw/plot_10_raw_overview.py
@@ -90,7 +90,7 @@ print(raw)
 # :meth:`~mne.io.Raw.crop` the :class:`~mne.io.Raw` object to 60 seconds so it
 # uses less memory and runs more smoothly on our documentation server.
 
-raw.crop(tmax=60).load_data()
+raw.crop(tmax=60)
 
 ###############################################################################
 # Querying the Raw object
@@ -203,7 +203,7 @@ print(np.diff(raw.time_as_index([1, 2, 3])))
 # :class:`~mne.io.Raw` objects have a number of methods that modify the
 # :class:`~mne.io.Raw` instance in-place and return a reference to the modified
 # instance. This can be useful for `method chaining`_
-# (e.g., ``raw.crop(...).filter(...).pick_channels(...).plot()``)
+# (e.g., ``raw.crop(...).pick_channels(...).filter(...).plot()``)
 # but it also poses a problem during interactive analysis: if you modify your
 # :class:`~mne.io.Raw` object for an exploratory plot or analysis (say, by
 # dropping some channels), you will then need to re-load the data (and repeat

--- a/tutorials/sample-datasets/plot_brainstorm_auditory.py
+++ b/tutorials/sample-datasets/plot_brainstorm_auditory.py
@@ -74,11 +74,10 @@ erm_fname = op.join(data_path, 'MEG', 'bst_auditory',
 # In the memory saving mode we use ``preload=False`` and use the memory
 # efficient IO which loads the data on demand. However, filtering and some
 # other functions require the data to be preloaded in the memory.
-preload = not use_precomputed
-raw = read_raw_ctf(raw_fname1, preload=preload)
+raw = read_raw_ctf(raw_fname1)
 n_times_run1 = raw.n_times
-mne.io.concatenate_raws([raw, read_raw_ctf(raw_fname2, preload=preload)])
-raw_erm = read_raw_ctf(erm_fname, preload=preload)
+mne.io.concatenate_raws([raw, read_raw_ctf(raw_fname2)])
+raw_erm = read_raw_ctf(erm_fname)
 
 ###############################################################################
 # Data channel array consisted of 274 MEG axial gradiometers, 26 MEG reference
@@ -98,7 +97,7 @@ raw_erm = read_raw_ctf(erm_fname, preload=preload)
 raw.set_channel_types({'HEOG': 'eog', 'VEOG': 'eog', 'ECG': 'ecg'})
 if not use_precomputed:
     # Leave out the two EEG channels for easier computation of forward.
-    raw.pick(['meg', 'stim', 'misc', 'eog', 'ecg'])
+    raw.pick(['meg', 'stim', 'misc', 'eog', 'ecg']).load_data()
 
 ###############################################################################
 # For noise reduction, a set of bad segments have been identified and stored

--- a/tutorials/source-modeling/plot_beamformer_lcmv.py
+++ b/tutorials/source-modeling/plot_beamformer_lcmv.py
@@ -51,7 +51,7 @@ subjects_dir = data_path + '/subjects'
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 
 # Read the raw data
-raw = mne.io.read_raw_fif(raw_fname, preload=True)
+raw = mne.io.read_raw_fif(raw_fname)
 raw.info['bads'] = ['MEG 2443']  # bad MEG channel
 
 # Set up the epoching

--- a/tutorials/source-modeling/plot_eeg_mri_coords.py
+++ b/tutorials/source-modeling/plot_eeg_mri_coords.py
@@ -117,7 +117,7 @@ print(trans)  # should be mri->head, as the "native" space here is MRI
 # shown by :meth:`~mne.io.Raw.plot_sensors`.
 
 raw = mne.io.read_raw_fif(fname_raw)
-raw.load_data().pick_types(meg=False, eeg=True, stim=True, exclude=())
+raw.pick_types(meg=False, eeg=True, stim=True, exclude=()).load_data()
 raw.set_montage(dig_montage)
 raw.plot_sensors(show_names=True)
 


### PR DESCRIPTION
I realized that a clean path to picking without preload is to follow this to-do list:

- [x] Ensure that `self._read_segment_file` for all readers is implemented such that:
    1. `self._raw_extras` is always a list of dict, and `self._raw_extras[fi]['orig_nchan']` gets automatically added by `BaseRaw` to store the original number of channels on disk (as it's used by many readers, might as well add it in one place). 
    2. It only uses the attributes `self._filenames` and `self._raw_extras`. This mostly requires removing uses of `self.info`, but these uses are fairly rare.

    Most of our readers were already close to being stuctured this way, so this was a fairly simple refactoring. This is in the current commit. It uses a little wrapper `_ReadSegmentFileProtector` to make sure only the correct two attributes are used. It also changes `idx` to always be a ndarray of int rather than possibly being a slice because this simplifies some code and shouldn't incur much of any performance penalty (will check against master before merge).

    The one annoying thing I had to do to make this work was update `egimff` annotation setting, which was previously being done using a hack marked with `XXX` but now uses `self.set_annotations` like elsewhere in `mne/io/*/*`.

- [x] Make a new variable `self._read_picks` that is used to sub-index when reading. Currently this is just `np.arange(self._raw_extras[fi]['orig_nchan'])`, so it's a no-op, but should allow us to ...

- [x] Add support for `raw.pick_types` without preload by subselecting `self._read_picks`. Currently this is not done because I want to make sure the changes thus far lead to green CIs (I think they will).

- [x] Add tests for pick-without-preload.

- [x] Update examples where picking is used to do it before `load_data` to save memory.

- [x] Double-check that this PR does not slow down I/O with profiling.

- [x] Update `latest.inc`

TL;DR: `BaseRaw` keeps track of which picks from the original data on disk we actually need and doing the appropriate subselection (the new thing), and each individual reader just needs to care about reading a set of `idx` indices of data from the original ones on disk (which has always been the case, just clearer now).

Marking for 0.21 because this is a big enough change that we should probably do it at the beginning of a release cycle rather than the end.

Closes #1766.