### PR TITLE
MRG, ENH: Dont require preload for raw resample

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -17,6 +17,8 @@ Changelog
 
 - Add support for signals in mV for :func:`mne.io.read_raw_brainvision` by `Clemens Brunner`_
 
+- Allow resampling raw data with :func:`mne.io.Raw.resample` without preloading data, by `Eric Larson`_
+
 - :func:`mne.viz.plot_dipole_locations` and :meth:`mne.Dipole.plot_locations` gained a ``title`` argument to specify a custom figure title in ``orthoview`` mode by `Richard Höchenberger`_
 
 - Added temporal derivative distribution repair :func:`mne.preprocessing.nirs.temporal_derivative_distribution_repair` by `Robert Luke`_

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -965,6 +965,16 @@ def test_crop():
 
 
 @testing.requires_testing_data
+def test_resample_equiv():
+    """Test resample (with I/O and multiple files)."""
+    raw = read_raw_fif(fif_fname).crop(0, 1)
+    raw_preload = raw.copy().load_data()
+    for r in (raw, raw_preload):
+        r.resample(r.info['sfreq'] / 4.)
+    assert_allclose(raw._data, raw_preload._data)
+
+
+@testing.requires_testing_data
 @pytest.mark.parametrize('preload', (True, False))
 def test_resample(tmpdir, preload):
     """Test resample (with I/O and multiple files)."""


### PR DESCRIPTION
Relaxes the requirement that data be preloaded before resampling. Should help on low-memory machines. Probably worth doing early in 0.21 rather than before cutting 0.20, hence the WIP.

Todo:

- [x] Update `latest.inc`