### PR TITLE
MRG: Change _TimeViewer slider style

### DIFF
--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -417,10 +417,9 @@ class _TimeViewer(object):
         if slider is not None:
             slider_rep = slider.GetRepresentation()
             slider_rep.SetSliderLength(0.02)
-            slider_rep.SetSliderWidth(0.04)
-            slider_rep.SetTubeWidth(0.005)
-            slider_rep.SetEndCapLength(0.01)
-            slider_rep.SetEndCapWidth(0.02)
+            slider_rep.SetSliderWidth(0.06)
+            slider_rep.SetTubeWidth(0.02)
+            slider_rep.GetCapProperty().SetOpacity(0)
             slider_rep.GetSliderProperty().SetColor((0.5, 0.5, 0.5))
             if not show_label:
                 slider_rep.ShowSliderLabelOff()
@@ -541,7 +540,7 @@ class _TimeViewer(object):
         # Colormap slider
         pointa = np.array((0.82, 0.26))
         pointb = np.array((0.98, 0.26))
-        shift = np.array([0, 0.08])
+        shift = np.array([0, 0.12])
         fmin = self.brain._data["fmin"]
         self.fmin_call = BumpColorbarPoints(
             plotter=self.plotter,

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -417,8 +417,8 @@ class _TimeViewer(object):
         if slider is not None:
             slider_rep = slider.GetRepresentation()
             slider_rep.SetSliderLength(0.02)
-            slider_rep.SetSliderWidth(0.06)
-            slider_rep.SetTubeWidth(0.06)
+            slider_rep.SetSliderWidth(0.04)
+            slider_rep.SetTubeWidth(0.04)
             slider_rep.GetCapProperty().SetOpacity(0)
             slider_rep.GetSliderProperty().SetColor((0.5, 0.5, 0.5))
             if not show_label:
@@ -540,7 +540,7 @@ class _TimeViewer(object):
         # Colormap slider
         pointa = np.array((0.82, 0.26))
         pointb = np.array((0.98, 0.26))
-        shift = np.array([0, 0.12])
+        shift = np.array([0, 0.1])
         fmin = self.brain._data["fmin"]
         self.fmin_call = BumpColorbarPoints(
             plotter=self.plotter,

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -316,6 +316,11 @@ class _TimeViewer(object):
             'c': self.clear_points,
             ' ': self.toggle_playback,
         }
+        self.slider_length = 0.02
+        self.slider_width = 0.04
+        self.slider_color = (0.43137255, 0.44313725, 0.45882353)
+        self.slider_tube_width = 0.04
+        self.slider_tube_color = (0.69803922, 0.70196078, 0.70980392)
 
         # Direct access parameters:
         self.brain = brain
@@ -413,14 +418,16 @@ class _TimeViewer(object):
                 self.playback = False
         self.plotter.update()  # critical for smooth animation
 
-    def set_slider_style(self, slider, show_label=True):
+    def set_slider_style(self, slider, show_label=True, show_cap=False):
         if slider is not None:
             slider_rep = slider.GetRepresentation()
-            slider_rep.SetSliderLength(0.02)
-            slider_rep.SetSliderWidth(0.04)
-            slider_rep.SetTubeWidth(0.04)
-            slider_rep.GetCapProperty().SetOpacity(0)
-            slider_rep.GetSliderProperty().SetColor((0.5, 0.5, 0.5))
+            slider_rep.SetSliderLength(self.slider_length)
+            slider_rep.SetSliderWidth(self.slider_width)
+            slider_rep.SetTubeWidth(self.slider_tube_width)
+            slider_rep.GetSliderProperty().SetColor(self.slider_color)
+            slider_rep.GetTubeProperty().SetColor(self.slider_tube_color)
+            if not show_cap:
+                slider_rep.GetCapProperty().SetOpacity(0)
             if not show_label:
                 slider_rep.ShowSliderLabelOff()
 

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -418,7 +418,7 @@ class _TimeViewer(object):
             slider_rep = slider.GetRepresentation()
             slider_rep.SetSliderLength(0.02)
             slider_rep.SetSliderWidth(0.06)
-            slider_rep.SetTubeWidth(0.02)
+            slider_rep.SetTubeWidth(0.06)
             slider_rep.GetCapProperty().SetOpacity(0)
             slider_rep.GetSliderProperty().SetColor((0.5, 0.5, 0.5))
             if not show_label:


### PR DESCRIPTION
It occurs to me that I never asked for feedbacks for the slider style, I just went with what I found practical but apparently the current design has some limitations. For example, since the slider tube is very thin it's easy to miss it and rotate the brain instead (reported in https://github.com/mne-tools/mne-python/pull/7247#issuecomment-583536539 and offline by @hoechenberger). This PR tries to address that by changing the style of the slider (and by doing so, modify it's hitbox).

I suggest 2 styles of sliders. In both styles I removed the end cap. In style 1, I increased the tube width but the overall style stays similar. The style 2 is a bit extreme but fixes the original issue quite easily.

<details>

```py
import os
import mne
from mne.datasets import sample
data_path = sample.data_path()
sample_dir = os.path.join(data_path, 'MEG', 'sample')
subjects_dir = os.path.join(data_path, 'subjects')
fname_stc = os.path.join(sample_dir, 'sample_audvis-meg')
stc = mne.read_source_estimate(fname_stc, subject='sample')
initial_time = 0.1
mne.viz.set_3d_backend('pyvista')
brain = stc.plot(subjects_dir=subjects_dir, initial_time=initial_time,
                 clim=dict(kind='value', pos_lims=[3, 6, 9]),
                 hemi='lh',
                 )
```

</details>

`master` | Style 1 | Style 2
------------|-----------|-----------
![image](https://user-images.githubusercontent.com/18143289/77524949-85f11b80-6e88-11ea-9a6f-eaf6339a2cb8.png) | ![image](https://user-images.githubusercontent.com/18143289/77524893-6ce86a80-6e88-11ea-80c2-09a2e58d209c.png) | ![image](https://user-images.githubusercontent.com/18143289/77525150-d9fc0000-6e88-11ea-85ec-c3fa15c509c7.png)


Except the size, it's also possible to change the colors (*c.f.* https://github.com/pyvista/pyvista/pull/511):

![image](https://user-images.githubusercontent.com/18143289/77525668-ae2d4a00-6e89-11ea-81ae-4b1ad11ae677.png)

Sadly, changing the shape or replacing the handle by a texture would require way more work on the VTK part.

It's an item of #7162 