### PR TITLE
Disable _TimeViewer when no time info is provided

### DIFF
--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1753,7 +1753,8 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
                              spacing=spacing, time_viewer=time_viewer,
                              colorbar=colorbar, transparent=transparent)
     time_viewer, show_traces = _check_time_viewer_compatibility(time_viewer,
-                                                                show_traces)
+                                                                show_traces,
+                                                                stc, hemi)
     if get_3d_backend() == "mayavi":
         from surfer import Brain, TimeViewer
     else:  # PyVista
@@ -1827,7 +1828,22 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
     return brain
 
 
-def _check_time_viewer_compatibility(time_viewer, show_traces):
+def _check_stc_time(stc, hemi):
+    # check if there is time info
+    if hemi in ['both', 'split']:
+        hemis = ['lh', 'rh']
+    else:
+        hemis = [hemi]
+    for hemi in hemis:
+        array = getattr(stc, hemi + '_data')
+        if array.ndim == 1:
+            return False
+        elif array.ndim == 2 and array.shape[1] == 1:
+            return False
+    return True
+
+
+def _check_time_viewer_compatibility(time_viewer, show_traces, stc, hemi):
     from .backends.renderer import get_3d_backend
     using_mayavi = get_3d_backend() == "mayavi"
     _check_option('time_viewer', time_viewer, (True, False, 'auto'))
@@ -1849,6 +1865,8 @@ def _check_time_viewer_compatibility(time_viewer, show_traces):
         if not check_version('surfer', '0.9'):
             raise RuntimeError('This function requires pysurfer version '
                                '>= 0.9')
+
+    time_viewer = _check_stc_time(stc, hemi)
     return time_viewer, show_traces
 
 
@@ -2410,7 +2428,8 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
     from .backends.renderer import get_3d_backend
     # Import here to avoid circular imports
     time_viewer, show_traces = _check_time_viewer_compatibility(time_viewer,
-                                                                show_traces)
+                                                                show_traces,
+                                                                stc, hemi)
     if get_3d_backend() == "mayavi":
         from surfer import Brain, TimeViewer
     else:  # PyVista

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1865,8 +1865,8 @@ def _check_time_viewer_compatibility(time_viewer, show_traces, stc, hemi):
         if not check_version('surfer', '0.9'):
             raise RuntimeError('This function requires pysurfer version '
                                '>= 0.9')
-
-    time_viewer = _check_stc_time(stc, hemi)
+    if time_viewer:
+        time_viewer = _check_stc_time(stc, hemi)
     return time_viewer, show_traces
 
 

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -302,8 +302,6 @@ class _TimeViewer(object):
     def __init__(self, brain, show_traces=False):
         from ..backends._pyvista import _require_minimum_version
         _require_minimum_version('0.24')
-        if not _check_brain_time(brain):
-            return
 
         # Default configuration
         self.playback = False
@@ -977,19 +975,6 @@ class _LinkViewer(object):
                         callback=callback,
                         event_type=event_type
                     )
-
-
-def _check_brain_time(brain):
-    # check if there is time info
-    for hemi in ['lh', 'rh']:
-        hemi_data = brain._data.get(hemi)
-        if hemi_data is not None:
-            array = hemi_data['array']
-            if array.ndim == 1:
-                return False
-            elif array.ndim == 2 and array.shape[1] == 1:
-                return False
-    return True
 
 
 def _get_range(brain):

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -302,6 +302,8 @@ class _TimeViewer(object):
     def __init__(self, brain, show_traces=False):
         from ..backends._pyvista import _require_minimum_version
         _require_minimum_version('0.24')
+        if not _check_brain_time(brain):
+            return
 
         # Default configuration
         self.playback = False
@@ -551,7 +553,7 @@ class _TimeViewer(object):
             time_label = self.brain._data['time_label']
             if callable(time_label):
                 current_time = time_label(current_time)
-            time_slider.GetRepresentation().SetTitleText(current_time)
+                time_slider.GetRepresentation().SetTitleText(current_time)
 
         # Playback speed slider
         self.playback_speed_call = SmartSlider(
@@ -975,6 +977,19 @@ class _LinkViewer(object):
                         callback=callback,
                         event_type=event_type
                     )
+
+
+def _check_brain_time(brain):
+    # check if there is time info
+    for hemi in ['lh', 'rh']:
+        hemi_data = brain._data.get(hemi)
+        if hemi_data is not None:
+            array = hemi_data['array']
+            if array.ndim == 1:
+                return False
+            elif array.ndim == 2 and array.shape[1] == 1:
+                return False
+    return True
 
 
 def _get_range(brain):


### PR DESCRIPTION
This PR locally tests the given brain and disables the `_TimeViewer` wrapping when no time information is provided. For instance this happens in `examples/forward/plot_source_space_morphing.py`.