### PR TITLE
RF: Change viz backend loading

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -227,7 +227,7 @@ def renderer(backend_name, garbage_collect):
     with _use_test_3d_backend(backend_name):
         from mne.viz.backends import renderer
         yield renderer
-        renderer._close_all()
+        renderer.backend._close_all()
 
 
 @pytest.yield_fixture
@@ -254,7 +254,7 @@ def renderer_interactive(backend_name_interactive):
     with _use_test_3d_backend(backend_name_interactive, interactive=True):
         from mne.viz.backends import renderer
         yield renderer
-        renderer._close_all()
+        renderer.backend._close_all()
 
 
 def _check_skip_backend(name):

--- a/mne/report.py
+++ b/mne/report.py
@@ -68,17 +68,14 @@ def _fig_to_img(fig, image_format='png', scale=None, **kwargs):
         plt.close('all')
         fig = fig(**kwargs)
     elif not isinstance(fig, Figure):
-        from .viz.backends.renderer import (
-            _check_3d_figure, _take_3d_screenshot,
-            _close_3d_figure, MNE_3D_BACKEND_TESTING
-        )
-        _check_3d_figure(figure=fig)
+        from .viz.backends.renderer import (backend, MNE_3D_BACKEND_TESTING)
+        backend._check_3d_figure(figure=fig)
         if not MNE_3D_BACKEND_TESTING:
-            img = _take_3d_screenshot(figure=fig)
+            img = backend._take_3d_screenshot(figure=fig)
         else:  # Testing mode
             img = np.zeros((2, 2, 3))
 
-        _close_3d_figure(figure=fig)
+        backend._close_3d_figure(figure=fig)
         fig = _ndarray_to_fig(img)
 
     output = BytesIO()
@@ -139,27 +136,24 @@ def _figs_to_mrislices(sl, n_jobs, **kwargs):
 def _iterate_trans_views(function, **kwargs):
     """Auxiliary function to iterate over views in trans fig."""
     import matplotlib.pyplot as plt
-    from .viz.backends.renderer import (
-        _check_3d_figure, _take_3d_screenshot, _close_all,
-        _set_3d_view, MNE_3D_BACKEND_TESTING
-    )
+    from .viz.backends.renderer import (backend, MNE_3D_BACKEND_TESTING)
 
     fig = function(**kwargs)
-    _check_3d_figure(fig)
+    backend._check_3d_figure(fig)
 
     views = [(90, 90), (0, 90), (0, -90)]
     fig2, axes = plt.subplots(1, len(views))
     for view, ax in zip(views, axes):
-        _set_3d_view(fig, azimuth=view[0], elevation=view[1],
-                     focalpoint=None, distance=None)
+        backend.__base___set_3d_view(fig, azimuth=view[0], elevation=view[1],
+                                     focalpoint=None, distance=None)
         if not MNE_3D_BACKEND_TESTING:
-            im = _take_3d_screenshot(figure=fig)
+            im = backend._take_3d_screenshot(figure=fig)
         else:  # Testing mode
             im = np.zeros((2, 2, 3))
         ax.imshow(im)
         ax.axis('off')
 
-    _close_all()
+    backend._close_all()
     img = _fig_to_img(fig2, image_format='png')
     return img
 

--- a/mne/report.py
+++ b/mne/report.py
@@ -68,7 +68,7 @@ def _fig_to_img(fig, image_format='png', scale=None, **kwargs):
         plt.close('all')
         fig = fig(**kwargs)
     elif not isinstance(fig, Figure):
-        from .viz.backends.renderer import (backend, MNE_3D_BACKEND_TESTING)
+        from .viz.backends.renderer import backend, MNE_3D_BACKEND_TESTING
         backend._check_3d_figure(figure=fig)
         if not MNE_3D_BACKEND_TESTING:
             img = backend._take_3d_screenshot(figure=fig)
@@ -136,7 +136,7 @@ def _figs_to_mrislices(sl, n_jobs, **kwargs):
 def _iterate_trans_views(function, **kwargs):
     """Auxiliary function to iterate over views in trans fig."""
     import matplotlib.pyplot as plt
-    from .viz.backends.renderer import (backend, MNE_3D_BACKEND_TESTING)
+    from .viz.backends.renderer import backend, MNE_3D_BACKEND_TESTING
 
     fig = function(**kwargs)
     backend._check_3d_figure(fig)

--- a/mne/report.py
+++ b/mne/report.py
@@ -144,8 +144,8 @@ def _iterate_trans_views(function, **kwargs):
     views = [(90, 90), (0, 90), (0, -90)]
     fig2, axes = plt.subplots(1, len(views))
     for view, ax in zip(views, axes):
-        backend.__base___set_3d_view(fig, azimuth=view[0], elevation=view[1],
-                                     focalpoint=None, distance=None)
+        backend._set_3d_view(fig, azimuth=view[0], elevation=view[1],
+                             focalpoint=None, distance=None)
         if not MNE_3D_BACKEND_TESTING:
             im = backend._take_3d_screenshot(figure=fig)
         else:  # Testing mode

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -146,8 +146,7 @@ class _Brain(object):
                  foreground=None, figure=None, subjects_dir=None,
                  views=['lateral'], offset=True, show_toolbar=False,
                  offscreen=False, interaction=None, units='mm'):
-        from ..backends.renderer import (_get_renderer, _check_3d_figure,
-                                         _set_3d_title)
+        from ..backends.renderer import backend, _get_renderer
         from matplotlib.colors import colorConverter
 
         if interaction is not None:
@@ -200,10 +199,11 @@ class _Brain(object):
         offset = None if (not offset or hemi != 'both') else 0.0
 
         if figure is not None and not isinstance(figure, int):
-            _check_3d_figure(figure)
+            backend._check_3d_figure(figure)
         self._renderer = _get_renderer(name=subject_id, size=fig_size,
                                        bgcolor=background,
-                                       shape=(n_row, n_col), fig=figure)
+                                       shape=(n_row, n_col),
+                                       fig=figure)
 
         for h in self._hemis:
             # Initialize a Surface object as the geometry
@@ -239,7 +239,8 @@ class _Brain(object):
                                               elevation=views_dict[v].elev)
 
         if self._title is not None:
-            _set_3d_title(figure=self._renderer.scene(), title=self._title)
+            backend._set_3d_title(figure=self._renderer.scene(),
+                                  title=self._title)
 
         # Force rendering
         self._renderer.show()

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -20,17 +20,19 @@ MNE_3D_BACKEND_TESTING = False
 _fromlist = ('_Renderer', '_Projection', '_close_all', '_check_3d_figure',
              '_set_3d_view', '_set_3d_title', '_close_3d_figure',
              '_take_3d_screenshot', '_testing_context')
-_name_map = dict(mayavi='_pysurfer_mayavi', pyvista='_pyvista')
+_name_map = dict(mayavi='._pysurfer_mayavi', pyvista='._pyvista')
 
 
 def _reload_backend(backend_name):
     # This is (hopefully) the equivalent to:
     #    from ._whatever_name import ...
-    _mod = importlib.__import__(
-        _name_map[backend_name], {'__name__': __name__},
-        level=1, fromlist=_fromlist)
+    _mod = importlib.import_module(name=_name_map[backend_name],
+                                   package='mne.viz.backends')
+
     for key in _fromlist:
         globals()[key] = getattr(_mod, key)
+    del _mod
+
     logger.info('Using %s 3d backend.\n' % backend_name)
 
 

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -17,28 +17,20 @@ MNE_3D_BACKEND = None
 MNE_3D_BACKEND_TESTING = False
 
 
-_fromlist = ('_Renderer', '_Projection', '_close_all', '_check_3d_figure',
-             '_set_3d_view', '_set_3d_title', '_close_3d_figure',
-             '_take_3d_screenshot', '_testing_context')
-_name_map = dict(mayavi='._pysurfer_mayavi', pyvista='._pyvista')
+_backend_name_map = dict(mayavi='._pysurfer_mayavi', pyvista='._pyvista')
+backend = None
 
 
 def _reload_backend(backend_name):
-    # This is (hopefully) the equivalent to:
-    #    from ._whatever_name import ...
-    _mod = importlib.import_module(name=_name_map[backend_name],
-                                   package='mne.viz.backends')
-
-    for key in _fromlist:
-        globals()[key] = getattr(_mod, key)
-    del _mod
-
+    global backend
+    backend = importlib.import_module(name=_backend_name_map[backend_name],
+                                      package='mne.viz.backends')
     logger.info('Using %s 3d backend.\n' % backend_name)
 
 
 def _get_renderer(*args, **kwargs):
     set_3d_backend(get_3d_backend(), verbose=False)
-    return _Renderer(*args, **kwargs)  # noqa: F821
+    return backend._Renderer(*args, **kwargs)
 
 
 @verbose
@@ -191,7 +183,7 @@ def _use_test_3d_backend(backend_name, interactive=False):
     MNE_3D_BACKEND_TESTING = True
     try:
         with use_3d_backend(backend_name):
-            with _testing_context(interactive):  # noqa: F821
+            with backend._testing_context(interactive):
                 yield
     finally:
         MNE_3D_BACKEND_TESTING = orig_testing
@@ -214,9 +206,9 @@ def set_3d_view(figure, azimuth=None, elevation=None,
     distance : float
         The distance to the focal point.
     """
-    _set_3d_view(figure=figure, azimuth=azimuth,  # noqa: F821
-                 elevation=elevation, focalpoint=focalpoint,
-                 distance=distance)
+    backend._set_3d_view(figure=figure, azimuth=azimuth,
+                         elevation=elevation, focalpoint=focalpoint,
+                         distance=distance)
 
 
 def set_3d_title(figure, title, size=40):
@@ -231,7 +223,7 @@ def set_3d_title(figure, title, size=40):
     size : int
         The size of the title.
     """
-    _set_3d_title(figure=figure, title=title, size=size)  # noqa: F821
+    backend._set_3d_title(figure=figure, title=title, size=size)
 
 
 def create_3d_figure(size, bgcolor=(0, 0, 0), handle=None):

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -45,14 +45,14 @@ def test_3d_functions(renderer):
     """Test figure management functions."""
     fig = renderer.create_3d_figure((300, 300))
     # Mayavi actually needs something in the display to set the title
-    wrap_renderer = renderer._Renderer(fig=fig)
+    wrap_renderer = renderer.backend._Renderer(fig=fig)
     wrap_renderer.sphere(np.array([0., 0., 0.]), 'w', 1.)
-    renderer._check_3d_figure(fig)
-    renderer._set_3d_view(figure=fig, azimuth=None, elevation=None,
-                          focalpoint=(0., 0., 0.), distance=None)
-    renderer._set_3d_title(figure=fig, title='foo')
-    renderer._take_3d_screenshot(figure=fig)
-    renderer._close_all()
+    renderer.backend._check_3d_figure(fig)
+    renderer.backend._set_3d_view(figure=fig, azimuth=None, elevation=None,
+                                  focalpoint=(0., 0., 0.), distance=None)
+    renderer.backend._set_3d_title(figure=fig, title='foo')
+    renderer.backend._take_3d_screenshot(figure=fig)
+    renderer.backend._close_all()
 
 
 def test_3d_backend(renderer):
@@ -102,7 +102,7 @@ def test_3d_backend(renderer):
     cam_distance = 5 * tet_size
 
     # init scene
-    rend = renderer._Renderer(size=win_size, bgcolor=win_color)
+    rend = renderer.backend._Renderer(size=win_size, bgcolor=win_color)
     rend.set_interactive()
 
     # use mesh

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -177,7 +177,7 @@ def test_plot_alignment(tmpdir, renderer):
             'r': [0.08436285, -0.02850276, -0.04127743]}]
     write_dig(fiducials_path, fid, 5)
 
-    renderer._close_all()
+    renderer.backend._close_all()
     evoked = read_evokeds(evoked_fname)[0]
     sample_src = read_source_spaces(src_fname)
     bti = read_raw_bti(pdf_fname, config_fname, hs_fname, convert=True,
@@ -194,10 +194,10 @@ def test_plot_alignment(tmpdir, renderer):
             meg.append('ref')
         fig = plot_alignment(info, read_trans(trans_fname), subject='sample',
                              subjects_dir=subjects_dir, meg=meg)
-        rend = renderer._Renderer(fig=fig)
+        rend = renderer.backend._Renderer(fig=fig)
         rend.close()
     # KIT ref sensor coil def is defined
-    renderer._close_all()
+    renderer.backend._close_all()
     info = infos['Neuromag']
     pytest.raises(TypeError, plot_alignment, 'foo', trans_fname,
                   subject='sample', subjects_dir=subjects_dir)
@@ -208,9 +208,9 @@ def test_plot_alignment(tmpdir, renderer):
                   src=sample_src)
     sample_src.plot(subjects_dir=subjects_dir, head=True, skull=True,
                     brain='white')
-    renderer._close_all()
+    renderer.backend._close_all()
     # no-head version
-    renderer._close_all()
+    renderer.backend._close_all()
     # all coord frames
     pytest.raises(ValueError, plot_alignment, info)
     plot_alignment(info, surfaces=[])
@@ -219,7 +219,7 @@ def test_plot_alignment(tmpdir, renderer):
                              coord_frame=coord_frame, trans=Path(trans_fname),
                              subject='sample', mri_fiducials=fiducials_path,
                              subjects_dir=subjects_dir, src=src_fname)
-    renderer._close_all()
+    renderer.backend._close_all()
     # EEG only with strange options
     evoked_eeg_ecog_seeg = evoked.copy().pick_types(meg=False, eeg=True)
     evoked_eeg_ecog_seeg.info['projs'] = []  # "remove" avg proj
@@ -231,7 +231,7 @@ def test_plot_alignment(tmpdir, renderer):
                        surfaces=['white', 'outer_skin', 'outer_skull'],
                        meg=['helmet', 'sensors'],
                        eeg=['original', 'projected'], ecog=True, seeg=True)
-    renderer._close_all()
+    renderer.backend._close_all()
 
     sphere = make_sphere_model(info=evoked.info, r0='auto', head_radius='auto')
     bem_sol = read_bem_solution(op.join(subjects_dir, 'sample', 'bem',
@@ -279,7 +279,7 @@ def test_plot_alignment(tmpdir, renderer):
     fig = plot_alignment(trans=trans_fname, subject='sample', meg=False,
                          coord_frame='mri', subjects_dir=subjects_dir,
                          surfaces=['brain'], bem=sphere, show_axes=True)
-    renderer._close_all()
+    renderer.backend._close_all()
     if renderer.get_3d_backend() == 'mayavi':
         import mayavi  # noqa: F401 analysis:ignore
         assert isinstance(fig, mayavi.core.scene.Scene)
@@ -340,7 +340,7 @@ def test_plot_alignment(tmpdir, renderer):
     log = log.getvalue()
     assert '26 fnirs locations' in log
 
-    renderer._close_all()
+    renderer.backend._close_all()
 
 
 @pytest.mark.slowtest  # can be slow on OSX
@@ -520,7 +520,7 @@ def test_plot_dipole_orientations(renderer):
         dipoles.plot_locations(trans=trans, subject='sample',
                                subjects_dir=subjects_dir,
                                mode=mode, coord_frame=coord_frame)
-    renderer._close_all()
+    renderer.backend._close_all()
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
When working on https://github.com/mne-tools/mne-bids/pull/376, which effectively turns all warnings into errors that make our unit tests fail, I discovered that `mne.viz.backends.renderer`
would always produce this odd warning:

```python
<frozen importlib._bootstrap>:1072: in _calc___package__
    ???
E   ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
        globals    = {'__name__': 'mne.viz.backends.renderer'}
        package    = None
        spec       = None
```

I found out that this is related to using `importlib.__import__()` for loading the required backend module. I have now switched the relevant code to `importlib.load_module()`, which makes
the warning disappear at least locally (Python 3.8, macOS). 