### PR TITLE
MRG, FIX: Fix single time point

### DIFF
--- a/examples/forward/plot_source_space_morphing.py
+++ b/examples/forward/plot_source_space_morphing.py
@@ -4,8 +4,8 @@ Use source space morphing
 =========================
 
 This example shows how to use source space morphing (as opposed to
-SourceEstimate morphing) to create data that can be compared between
-subjects.
+:class:`~mne.SourceEstimate` morphing) to create data that can be compared
+between subjects.
 
 .. warning:: Source space morphing will likely lead to source spaces that are
              less evenly sampled than source spaces created for individual

--- a/examples/forward/plot_source_space_morphing.py
+++ b/examples/forward/plot_source_space_morphing.py
@@ -61,7 +61,7 @@ kwargs = dict(clim=dict(kind='percent', lims=[0, 50, 99]),
 # Our testing code suggests a correlation of higher than 0.99.
 
 brain_subject = mag_map.plot(  # plot forward in subject source space (morphed)
-    time_label=None, subjects_dir=subjects_dir, **kwargs)
+    time_label='Morphed', subjects_dir=subjects_dir, **kwargs)
 
 brain_fs = mag_map_fs.plot(  # plot forward in original source space (remapped)
-    time_label=None, subjects_dir=subjects_dir, **kwargs)
+    time_label='Remapped', subjects_dir=subjects_dir, **kwargs)

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -316,11 +316,18 @@ class _IntLike(object):
 int_like = _IntLike()
 
 
+class _Callable(object):
+    @classmethod
+    def __instancecheck__(cls, other):
+        return callable(other)
+
+
 _multi = {
     'str': (str,),
     'numeric': (np.floating, float, int_like),
     'path-like': (str, Path),
-    'int-like': (int_like,)
+    'int-like': (int_like,),
+    'callable': (_Callable(),),
 }
 try:
     _multi['path-like'] += (os.PathLike,)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -778,6 +778,17 @@ interpolation : str | None
     Must be one of 'linear', 'nearest', 'zero', 'slinear', 'quadratic',
     or 'cubic'.
 """
+docdict["show_traces"] = """
+show_traces : bool | str
+    If True, enable interactive picking of a point on the surface of the
+    brain and plot it's time course using the bottom 1/3 of the figure.
+    This feature is only available with the PyVista 3d backend when
+    ``time_viewer=True``. Defaults to 'auto', which will use True if and
+    only if ``time_viewer=True``, the backend is PyVista, and there is more
+    than one time point.
+
+    .. versionadded:: 0.20.0
+"""
 
 # STC label time course
 docdict['eltc_labels'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -789,6 +789,13 @@ show_traces : bool | str
 
     .. versionadded:: 0.20.0
 """
+docdict["time_label"] = """
+time_label : str | callable | None
+    Format of the time label (a format string, a function that maps
+    floating point time values to strings, or None for no label). The
+    default is ``'auto'``, which will use ``time=%%0.2f ms`` if there
+    is more than one time point.
+"""
 
 # STC label time course
 docdict['eltc_labels'] = """

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1458,7 +1458,9 @@ def _smooth_plot(this_time, params):
     colors[:, :3] += greymap(curv_ave)[:, :3] * (1. - colors[:, [3]])
     colors[:, 3] = 1.
     facecolors[:] = colors
-    ax.set_title(params['time_label'] % (times[time_idx] * scaler), color='w')
+    if params['time_label'] is not None:
+        ax.set_title(params['time_label'](times[time_idx] * scaler,),
+                     color='w')
     _set_aspect_equal(ax)
     ax.axis('off')
     ax.set(xlim=[-80, 80], ylim=(-80, 80), zlim=[-80, 80])
@@ -1561,8 +1563,7 @@ def _plot_mpl_stc(stc, subject=None, surface='inflated', hemi='lh',
         if initial_time is None:
             initial_time = 0
         slider = Slider(ax=ax_time, label='Time', valmin=times[0],
-                        valmax=times[-1], valinit=initial_time,
-                        valfmt=time_label)
+                        valmax=times[-1], valinit=initial_time)
         time_viewer.slider = slider
         callback_slider = partial(_smooth_plot, params=params)
         slider.on_changed(callback_slider)

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -486,12 +486,11 @@ class _Brain(object):
                 ci = 0
             else:
                 ci = 0 if hemi == 'lh' else 1
-            if not self._time_label_added:
+            if not self._time_label_added and time_label is not None:
                 time_actor = self._renderer.text2d(
                     x_window=0.95, y_window=y_txt,
                     size=time_label_size,
-                    text=time_label(self._current_time)
-                    if time_label is not None else None,
+                    text=time_label(self._current_time),
                     justification='right'
                 )
                 self._data['time_actor'] = time_actor

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -17,7 +17,7 @@ from .colormap import calculate_lut
 from .surface import Surface
 from .view import lh_views_dict, rh_views_dict, View
 
-from .._3d import _process_clim
+from .._3d import _process_clim, _handle_time
 
 from ...morph import _hemi_morph
 from ...label import read_label
@@ -248,7 +248,7 @@ class _Brain(object):
     def add_data(self, array, fmin=None, fmid=None, fmax=None,
                  thresh=None, center=None, transparent=False, colormap="auto",
                  alpha=1, vertices=None, smoothing_steps=None, time=None,
-                 time_label="time index=%d", colorbar=True,
+                 time_label="auto", colorbar=True,
                  hemi=None, remove_existing=None, time_label_size=None,
                  initial_time=None, scale_factor=None, vector_alpha=None,
                  clim=None, verbose=None):
@@ -307,9 +307,7 @@ class _Brain(object):
             Default : 7
         time : numpy array
             time points in the data array (if data is 2D or 3D)
-        time_label : str | callable | None
-            format of the time label (a format string, a function that maps
-            floating point time values to strings, or None for no label)
+        %(time_label)s
         colorbar : bool
             whether to add a colorbar to the figure
         hemi : str | None
@@ -321,7 +319,6 @@ class _Brain(object):
             Remove surface added by previous "add_data" call. Useful for
             conserving memory when displaying different data in a loop.
         time_label_size : int
-            Not supported yet.
             Font size of the time label (default 14)
         initial_time : float | None
             Time initially shown in the plot. ``None`` to use the first time
@@ -392,16 +389,10 @@ class _Brain(object):
                 time_idx = 0
             else:
                 time_idx = self._to_time_index(initial_time)
-            self._data["time_idx"] = time_idx
 
-            # time label
-            if isinstance(time_label, str):
-                time_label_fmt = time_label
-
-                def time_label(x):
-                    return time_label_fmt % x
-            self._data["time_label"] = time_label
-            y_txt = 0.05 + 0.1 * bool(colorbar)
+        # time label
+        time_label, _ = _handle_time(time_label, 's', time)
+        y_txt = 0.05 + 0.1 * bool(colorbar)
 
         if array.ndim == 3:
             if array.shape[1] != 3:
@@ -495,16 +486,16 @@ class _Brain(object):
                 ci = 0
             else:
                 ci = 0 if hemi == 'lh' else 1
-            if array.ndim >= 2 and callable(time_label):
-                if not self._time_label_added:
-                    time_actor = self._renderer.text2d(
-                        x_window=0.95, y_window=y_txt,
-                        size=time_label_size,
-                        text=time_label(self._current_time),
-                        justification='right'
-                    )
-                    self._data['time_actor'] = time_actor
-                    self._time_label_added = True
+            if not self._time_label_added:
+                time_actor = self._renderer.text2d(
+                    x_window=0.95, y_window=y_txt,
+                    size=time_label_size,
+                    text=time_label(self._current_time)
+                    if time_label is not None else None,
+                    justification='right'
+                )
+                self._data['time_actor'] = time_actor
+                self._time_label_added = True
             if colorbar and not self._colorbar_added:
                 self._renderer.scalarbar(source=actor, n_labels=8,
                                          bgcolor=(0.5, 0.5, 0.5))

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -391,8 +391,11 @@ class _TimeViewer(object):
             callback()
 
     def _set_time_slider_visibility(self):
-        # no-op if we actually have time points
+        # if we actually have time points, we will show the slider so
+        # hide the time actor
         if self.brain._times is not None and len(self.brain._times) > 1:
+            if self.time_actor is not None:
+                self.time_actor.VisibilityOff()
             return
         # otherwise, hide the irrelevant sliders
         for slider in self.plotter.slider_widgets:
@@ -412,12 +415,12 @@ class _TimeViewer(object):
 
         # manage time label
         time_label = self.brain._data['time_label']
-        if callable(time_label) and self.time_actor is not None:
-            if self.visibility:
-                self.time_actor.VisibilityOff()
-            else:
+        if self.time_actor is not None:
+            if self.visibility and time_label is not None:
                 self.time_actor.SetInput(time_label(self.brain._current_time))
                 self.time_actor.VisibilityOn()
+            else:
+                self.time_actor.VisibilityOff()
 
         # hide time labels that are not relevant
         self._set_time_slider_visibility()
@@ -591,8 +594,10 @@ class _TimeViewer(object):
         if callable(time_label):
             current_time = time_label(current_time)
         else:
-            current_time = ''
+            current_time = time_label
         time_slider.GetRepresentation().SetTitleText(current_time)
+        if self.time_actor is not None:
+            self.time_actor.SetInput(current_time)
         del current_time
 
         # Playback speed slider

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -7,6 +7,7 @@
 import warnings
 import time
 import traceback
+import sys
 
 import numpy as np
 
@@ -22,7 +23,7 @@ def safe_event(fun, *args, **kwargs):
     try:
         return fun(*args, **kwargs)
     except Exception:
-        traceback.print_exc()
+        traceback.print_exc(file=sys.stderr)
 
 
 class MplCanvas(object):

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -6,10 +6,23 @@
 
 import warnings
 import time
+import traceback
+
 import numpy as np
+
 from ..utils import _check_option, _show_help, _get_color_list, tight_layout
+from ...externals.decorator import decorator
 from ...source_space import vertex_to_mni
 from ...utils import _ReuseCycle
+
+
+@decorator
+def safe_event(fun, *args, **kwargs):
+    """Protect against PyQt5 exiting on event-handling errors."""
+    try:
+        return fun(*args, **kwargs)
+    except Exception:
+        traceback.print_exc()
 
 
 class MplCanvas(object):
@@ -370,6 +383,7 @@ class _TimeViewer(object):
         # show everything at the end
         self.toggle_interface()
 
+    @safe_event
     def keyPressEvent(self, event):
         callback = self.key_bindings.get(event.text())
         if callback is not None:
@@ -900,6 +914,7 @@ class _TimeViewer(object):
             height=2,
         )
 
+    @safe_event
     def clean(self):
         # resolve the reference cycle
         self.clear_points()

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -450,23 +450,31 @@ class _TimeViewer(object):
     def set_playback_speed(self, speed):
         self.playback_speed = speed
 
+    @safe_event
     def play(self):
         if self.playback:
-            this_time = time.time()
-            delta = this_time - self._last_tick
-            self._last_tick = time.time()
-            time_data = self.brain._data['time']
-            times = np.arange(self.brain._n_times)
-            time_shift = delta * self.playback_speed
-            max_time = np.max(time_data)
-            time_point = min(self.brain._current_time + time_shift, max_time)
-            # always use linear here -- this does not determine the data
-            # interpolation mode, it just finds where we are (in time) in
-            # terms of the time indices
-            idx = np.interp(time_point, time_data, times)
-            self.time_call(idx, update_widget=True)
-            if time_point == max_time:
+            try:
+                self._advance()
+            except Exception:
                 self.playback = False
+                raise
+
+    def _advance(self):
+        this_time = time.time()
+        delta = this_time - self._last_tick
+        self._last_tick = time.time()
+        time_data = self.brain._data['time']
+        times = np.arange(self.brain._n_times)
+        time_shift = delta * self.playback_speed
+        max_time = np.max(time_data)
+        time_point = min(self.brain._current_time + time_shift, max_time)
+        # always use linear here -- this does not determine the data
+        # interpolation mode, it just finds where we are (in time) in
+        # terms of the time indices
+        idx = np.interp(time_point, time_data, times)
+        self.time_call(idx, update_widget=True)
+        if time_point == max_time:
+            self.playback = False
 
     def set_slider_style(self, slider, show_label=True, show_cap=False):
         if slider is not None:


### PR DESCRIPTION
Alternative to #7518.

I think we should show the (incorrectly-named) `_TimeViewer` even if there is a single time point because it shows useful controls like clim, view, etc. (and others if we add them later). This hides the playback speed and time slider as well.