### PR TITLE
MRG, MAINT: Remove outdated buttons, update image

### DIFF
--- a/doc/carousel.inc
+++ b/doc/carousel.inc
@@ -69,12 +69,12 @@
           </div>
 
           <div class="item">
-            <div class="chopper container"><img src="_images/sphx_glr_plot_visualize_evoked_009.png" alt="Visualization" class="carousel-image"></div>
+            <div class="chopper container"><img src="_images/sphx_glr_plot_20_visualize_evoked_007.png" alt="Visualization" class="carousel-image"></div>
             <div class="container">
               <div class="carousel-caption">
                 <h2>Data visualization.</h2>
                 <p>Explore your data from multiple perspectives.</p>
-                <p><a class="btn btn-info btn-sm" href="auto_tutorials/evoked/plot_visualize_evoked.html" role="button">Check it out</a></p>
+                <p><a class="btn btn-info btn-sm" href="auto_tutorials/evoked/plot_20_visualize_evoked.html" role="button">Check it out</a></p>
               </div>
             </div>
           </div>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,36 +30,6 @@
 
 .. container:: row limitedwidth
 
-    .. buttons
-    .. raw:: html
-
-        <div class="col-lg-3 col-md-4 col-sm-6 table-like bottommargin">
-        <a href="auto_examples/index.html#input-output" class="btn btn-primary btn-lg btn-cont">Data I/O</a>
-        </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 table-like bottommargin">
-        <a href="auto_examples/index.html#preprocessing" class="btn btn-primary btn-lg btn-cont">Preprocessing</a>
-        </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 table-like bottommargin">
-        <a href="auto_examples/index.html#visualization" class="btn btn-primary btn-lg btn-cont">Visualization</a>
-        </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 table-like bottommargin">
-        <a href="auto_examples/index.html#inverse-problem-and-source-analysis" class="btn btn-primary btn-lg btn-cont">Source estimation</a>
-        </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 table-like bottommargin">
-        <a href="auto_examples/index.html#time-frequency-examples" class="btn btn-primary btn-lg btn-cont">Time-frequency</a>
-        </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 table-like bottommargin">
-        <a href="auto_examples/index.html#connectivity-analysis-examples" class="btn btn-primary btn-lg btn-cont">Connectivity</a>
-        </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 table-like bottommargin">
-        <a href="auto_examples/index.html#machine-learning-decoding-encoding-and-mvpa" class="btn btn-primary btn-lg btn-cont">Machine learning</a>
-        </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 table-like bottommargin">
-        <a href="auto_examples/index.html#statistics-examples" class="btn btn-primary btn-lg btn-cont">Statistics</a>
-        </div>
-
-.. container:: row limitedwidth
-
     .. financial support
     .. container:: col-sm-8
 


### PR DESCRIPTION
We probably shouldn't have the example buttons on the landing page anymore, they are outdated and point people to `examples` pages which are not the best place to get started. People should follow the "overview" to figure out where to go, which hopefully will be clear enough just being at the top.

Also fixed a bug with an ~~link and~~ image.