### PR TITLE
MRG, ENH: Allow float clipping

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -37,6 +37,8 @@ Changelog
 
 - Add functionality to interpolate bad NIRS channels by `Robert Luke`_
 
+- Add support to in :meth:`mne.io.Raw.plot` for passing ``clipping`` as a float to clip to a proportion of the dedicated channel range by `Eric Larson`_
+
 - Add function :func:`mne.preprocessing.annotate_muscle_zscore` to annotate periods with muscle artifacts. by `Adonay Nunes`_
 
 - Support for saving movies of source time courses (STCs) with ``brain.save_movie`` method and from graphical user interface by `Guillaume Favelier`_
@@ -45,6 +47,8 @@ Bug
 ~~~
 
 - Fix bug with :func:`mne.minimum_norm.compute_source_psd_epochs` and :func:`mne.minimum_norm.source_band_induced_power` raised errors when ``method='eLORETA'`` by `Eric Larson`_
+
+- The default plotting mode for :func:`mne.io.Raw.plot` and :ref:`gen_mne_browse_raw` has been changed to ``clipping=3.`` to facilitate data analysis with large deflections, by `Eric Larson`_
 
 - Fix handling of NaN when using TFCE in clustering functions such as :func:`mne.stats.spatio_temporal_cluster_1samp_test` by `Eric Larson`_
 

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -90,6 +90,7 @@ def run():
     lowpass = options.lowpass
     filtorder = options.filtorder
     clipping = options.clipping
+    clipping = None if clipping.lower() == 'none' else clipping
     try:
         clipping = float(clipping)  # allow float and convert it
     except Exception:

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -94,7 +94,7 @@ def run():
         clipping = None if clipping.lower() == 'none' else clipping
     try:
         clipping = float(clipping)  # allow float and convert it
-    except ValueError:
+    except (TypeError, ValueError):
         pass
     filterchpi = options.filterchpi
     verbose = options.verbose

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -20,6 +20,7 @@ def run():
     """Run command."""
     import matplotlib.pyplot as plt
     from mne.commands.utils import get_optparser, _add_verbose_flag
+    from mne.viz import _RAW_CLIP_DEF
 
     parser = get_optparser(__file__, usage='usage: %prog raw [options]')
 
@@ -65,7 +66,7 @@ def run():
                       default=4)
     parser.add_option("--clipping", dest="clipping",
                       help="Enable trace clipping mode, either 'clamp' or "
-                      "'transparent'", default=1.5)
+                      "'transparent'", default=_RAW_CLIP_DEF)
     parser.add_option("--filterchpi", dest="filterchpi",
                       help="Enable filtering cHPI signals.", default=None,
                       action="store_true")

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -90,7 +90,8 @@ def run():
     lowpass = options.lowpass
     filtorder = options.filtorder
     clipping = options.clipping
-    clipping = None if clipping.lower() == 'none' else clipping
+    if isinstance(clipping, str):
+        clipping = None if clipping.lower() == 'none' else clipping
     try:
         clipping = float(clipping)  # allow float and convert it
     except Exception:

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -65,7 +65,7 @@ def run():
                       default=4)
     parser.add_option("--clipping", dest="clipping",
                       help="Enable trace clipping mode, either 'clamp' or "
-                      "'transparent'", default=None)
+                      "'transparent'", default=1.5)
     parser.add_option("--filterchpi", dest="filterchpi",
                       help="Enable filtering cHPI signals.", default=None,
                       action="store_true")
@@ -89,6 +89,10 @@ def run():
     lowpass = options.lowpass
     filtorder = options.filtorder
     clipping = options.clipping
+    try:
+        clipping = float(clipping)  # allow float and convert it
+    except Exception:
+        pass
     filterchpi = options.filterchpi
     verbose = options.verbose
 

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -94,7 +94,7 @@ def run():
         clipping = None if clipping.lower() == 'none' else clipping
     try:
         clipping = float(clipping)  # allow float and convert it
-    except Exception:
+    except ValueError:
         pass
     filterchpi = options.filterchpi
     verbose = options.verbose

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -90,12 +90,14 @@ def run():
     lowpass = options.lowpass
     filtorder = options.filtorder
     clipping = options.clipping
-    try:
-        clipping = float(clipping)  # allow float and convert it
-    except (TypeError, ValueError):  # catch None and non-float str
-        pass
     if isinstance(clipping, str):
-        clipping = None if clipping.lower() == 'none' else clipping
+        if clipping.lower() == 'none':
+            clipping = None
+        else:
+            try:
+                clipping = float(clipping)  # allow float and convert it
+            except ValueError:
+                pass
     filterchpi = options.filterchpi
     verbose = options.verbose
 

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -90,12 +90,12 @@ def run():
     lowpass = options.lowpass
     filtorder = options.filtorder
     clipping = options.clipping
-    if isinstance(clipping, str):
-        clipping = None if clipping.lower() == 'none' else clipping
     try:
         clipping = float(clipping)  # allow float and convert it
-    except (TypeError, ValueError):
+    except ValueError:
         pass
+    if isinstance(clipping, str):
+        clipping = None if clipping.lower() == 'none' else clipping
     filterchpi = options.filterchpi
     verbose = options.verbose
 

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -92,7 +92,7 @@ def run():
     clipping = options.clipping
     try:
         clipping = float(clipping)  # allow float and convert it
-    except ValueError:
+    except (TypeError, ValueError):  # catch None and non-float str
         pass
     if isinstance(clipping, str):
         clipping = None if clipping.lower() == 'none' else clipping

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1401,7 +1401,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
              bgcolor='w', color=None, bad_color=(0.8, 0.8, 0.8),
              event_color='cyan', scalings=None, remove_dc=True, order=None,
              show_options=False, title=None, show=True, block=False,
-             highpass=None, lowpass=None, filtorder=4, clipping=None,
+             highpass=None, lowpass=None, filtorder=4, clipping=1.5,
              show_first_samp=False, proj=True, group_by='type',
              butterfly=False, decim='auto', noise_cov=None, event_id=None,
              show_scrollbars=True, show_scalebars=True, verbose=None):

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -42,7 +42,7 @@ from ..utils import (_check_fname, _check_pandas_installed, sizeof_fmt,
                      _check_preload, _get_argvalues, _check_option,
                      _build_data_frame, _convert_times, _scale_dataframe_data,
                      _check_time_format)
-from ..viz import plot_raw, plot_raw_psd, plot_raw_psd_topo
+from ..viz import plot_raw, plot_raw_psd, plot_raw_psd_topo, _RAW_CLIP_DEF
 from ..event import find_events, concatenate_events
 from ..annotations import Annotations, _combine_annotations, _sync_onset
 
@@ -1401,7 +1401,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
              bgcolor='w', color=None, bad_color=(0.8, 0.8, 0.8),
              event_color='cyan', scalings=None, remove_dc=True, order=None,
              show_options=False, title=None, show=True, block=False,
-             highpass=None, lowpass=None, filtorder=4, clipping=1.5,
+             highpass=None, lowpass=None, filtorder=4, clipping=_RAW_CLIP_DEF,
              show_first_samp=False, proj=True, group_by='type',
              butterfly=False, decim='auto', noise_cov=None, event_id=None,
              show_scrollbars=True, show_scalebars=True, verbose=None):

--- a/mne/viz/__init__.py
+++ b/mne/viz/__init__.py
@@ -22,7 +22,7 @@ from .evoked import (plot_evoked, plot_evoked_image, plot_evoked_white,
 from .circle import plot_connectivity_circle, circular_layout
 from .epochs import (plot_drop_log, plot_epochs, plot_epochs_psd,
                      plot_epochs_image)
-from .raw import plot_raw, plot_raw_psd, plot_raw_psd_topo
+from .raw import plot_raw, plot_raw_psd, plot_raw_psd_topo, _RAW_CLIP_DEF
 from .ica import (plot_ica_scores, plot_ica_sources, plot_ica_overlay,
                   _plot_sources_raw, _plot_sources_epochs, plot_ica_properties)
 from .montage import plot_montage

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -801,8 +801,11 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
             elif params['clipping'] is not None:
                 l, w = this_t[0], this_t[-1] - this_t[0]
                 ylim = params['ax'].get_ylim()
-                b = max(offset - params['clipping'], ylim[0])
-                h = min(2 * params['clipping'], ylim[1] - b)
+                b = offset - params['clipping']  # max(, ylim[0])
+                h = 2 * params['clipping']  # min(, ylim[1] - b)
+                assert ylim[1] <= ylim[0]  # inverted
+                b = max(b, ylim[1])
+                h = min(h, ylim[0] - b)
                 rect = Rectangle((l, b), w, h, transform=ax.transData)
                 lines[ii].set_clip_path(rect)
 

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -102,7 +102,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
              bgcolor='w', color=None, bad_color=(0.8, 0.8, 0.8),
              event_color='cyan', scalings=None, remove_dc=True, order=None,
              show_options=False, title=None, show=True, block=False,
-             highpass=None, lowpass=None, filtorder=4, clipping=None,
+             highpass=None, lowpass=None, filtorder=4, clipping=1.5,
              show_first_samp=False, proj=True, group_by='type',
              butterfly=False, decim='auto', noise_cov=None, event_id=None,
              show_scrollbars=True, show_scalebars=True, verbose=None):
@@ -185,11 +185,17 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
 
         .. versionchanged:: 0.18
            Support for ``filtorder=0`` to use FIR filtering.
-    clipping : str | None
+    clipping : str | float | None
         If None, channels are allowed to exceed their designated bounds in
         the plot. If "clamp", then values are clamped to the appropriate
         range for display, creating step-like artifacts. If "transparent",
         then excessive values are not shown, creating gaps in the traces.
+        If float, values are outside the float factor ``clipping`` beyond their
+        dedicated range, so ``clipping=1.`` is an alias for
+        ``clipping='transparent'``.
+
+        .. versionchanged:: 0.21
+           Support for float, and default changed from None to 1.5.
     show_first_samp : bool
         If True, show time axis relative to the ``raw.first_samp``.
     proj : bool
@@ -278,7 +284,13 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
                                  duration=duration)
     _validate_type(raw, BaseRaw, 'raw', 'Raw')
     n_channels = min(len(raw.info['chs']), n_channels)
-    _check_option('clipping', clipping, [None, 'clamp', 'transparent'])
+    _validate_type(clipping, (None, 'numeric', str), 'clipping')
+    if isinstance(clipping, str):
+        _check_option('clipping', clipping, ['clamp', 'transparent'],
+                      extra='when a string')
+        clipping = 1. if clipping == 'transparent' else clipping
+    elif clipping is not None:
+        clipping = float(clipping)
     duration = min(raw.times[-1], float(duration))
 
     # figure out the IIR filtering parameters
@@ -728,6 +740,7 @@ def _prepare_mne_browse_raw(params, title, bgcolor, color, bad_color, inds,
 def _plot_raw_traces(params, color, bad_color, event_lines=None,
                      event_color=None):
     """Plot raw traces."""
+    from matplotlib.patches import Rectangle
     lines = params['lines']
     info = params['info']
     inds = params['inds']
@@ -768,12 +781,6 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
             # apply user-supplied scale factor
             this_data = params['data'][inds[ch_ind]] * params['scale_factor']
 
-            # clip to range (if relevant)
-            if params['clipping'] == 'transparent':
-                this_data[np.abs(this_data) > 1] = np.nan
-            elif params['clipping'] == 'clamp':
-                np.clip(this_data, -1, 1, out=this_data)
-
             # set color
             this_color = bad_color if ch_name in info['bads'] else color
             if isinstance(this_color, dict):
@@ -784,6 +791,15 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
             else:
                 this_decim = 1
             this_t = params['times'][::this_decim] + params['first_time']
+
+            # clip to range (if relevant)
+            if params['clipping'] == 'clamp':
+                np.clip(this_data, -1, 1, out=this_data)
+            elif params['clipping'] is not None:
+                l, w = this_t[0], this_t[-1] - this_t[0]
+                b, h = offset - params['clipping'], 2 * params['clipping']
+                rect = Rectangle((l, b), w, h, transform=ax.transData)
+                lines[ii].set_clip_path(rect)
 
             # subtraction here gets correct orientation for flipped ylim
             lines[ii].set_ydata(offset - this_data[..., ::this_decim])

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -193,8 +193,8 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
         the plot. If "clamp", then values are clamped to the appropriate
         range for display, creating step-like artifacts. If "transparent",
         then excessive values are not shown, creating gaps in the traces.
-        If float, values are outside the float factor ``clipping`` beyond their
-        dedicated range, so ``clipping=1.`` is an alias for
+        If float, clipping occurs for values beyond the ``clipping`` multiple
+        of their dedicated range, so ``clipping=1.`` is an alias for
         ``clipping='transparent'``.
 
         .. versionchanged:: 0.21

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -97,12 +97,15 @@ def _pick_bad_channels(event, params):
     _plot_update_raw_proj(params, None)
 
 
+_RAW_CLIP_DEF = 3.
+
+
 @verbose
 def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
              bgcolor='w', color=None, bad_color=(0.8, 0.8, 0.8),
              event_color='cyan', scalings=None, remove_dc=True, order=None,
              show_options=False, title=None, show=True, block=False,
-             highpass=None, lowpass=None, filtorder=4, clipping=1.5,
+             highpass=None, lowpass=None, filtorder=4, clipping=_RAW_CLIP_DEF,
              show_first_samp=False, proj=True, group_by='type',
              butterfly=False, decim='auto', noise_cov=None, event_id=None,
              show_scrollbars=True, show_scalebars=True, verbose=None):
@@ -797,7 +800,9 @@ def _plot_raw_traces(params, color, bad_color, event_lines=None,
                 np.clip(this_data, -1, 1, out=this_data)
             elif params['clipping'] is not None:
                 l, w = this_t[0], this_t[-1] - this_t[0]
-                b, h = offset - params['clipping'], 2 * params['clipping']
+                ylim = params['ax'].get_ylim()
+                b = max(offset - params['clipping'], ylim[0])
+                h = min(2 * params['clipping'], ylim[1] - b)
                 rect = Rectangle((l, b), w, h, transform=ax.transData)
                 lines[ii].set_clip_path(rect)
 


### PR DESCRIPTION
This improves our clipping to use `matplotlib` to cut off values rather than using `np.nan`. This is better because `np.nan` can cause the entire trace to be removed, this will cause it to still exist but just be invisible outside the appropriate "box".

Also proposes changing the default `clipping=None` to `clipping=1.5`, but this is certainly up for debate. WIP because we need to run some examples and decide, and it should go in 0.21.

Todo:

- [x] Decide on default
- [x] `latest.inc`

Some related discussion in #7521