### PR TITLE
MRG, MAINT: Use preleases to catch bugs early

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ jobs:
             command: |
               python -m pip install --user --upgrade --progress-bar off pip numpy vtk setuptools
               python -m pip install --user --upgrade --progress-bar off -r requirements.txt
+              python -m pip install --user --upgrade --pre sphinx
               python -m pip install --user --upgrade --progress-bar off ipython sphinx_fontawesome sphinx_bootstrap_theme memory_profiler "https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip"
               python -m pip install --user --upgrade seaborn
               python -m pip install --user -e .


### PR DESCRIPTION
In this case, sphinx prerelease (3.0.0b1 is on PyPi now).

Setting to WIP just until 0.20 is out