### PR TITLE
MRG: Fix bug in scalp coupling index.

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -20,7 +20,7 @@ Changelog
 Bug
 ~~~
 
-- Nothing yet
+- Fix bug with :func:`mne.preprocessing.nirs.scalp_coupling_index` where filter transition was incorrectly assigned by `Robert Luke`_.
 
 API
 ~~~

--- a/mne/preprocessing/nirs/_scalp_coupling_index.py
+++ b/mne/preprocessing/nirs/_scalp_coupling_index.py
@@ -54,8 +54,8 @@ def scalp_coupling_index(raw, l_freq=0.7, h_freq=1.5,
 
     filtered_data = filter_data(raw._data, raw.info['sfreq'], l_freq, h_freq,
                                 picks=picks, verbose=verbose,
-                                l_trans_bandwidth=h_trans_bandwidth,
-                                h_trans_bandwidth=l_trans_bandwidth)
+                                l_trans_bandwidth=l_trans_bandwidth,
+                                h_trans_bandwidth=h_trans_bandwidth)
 
     sci = np.zeros(picks.shape)
     for ii in picks[::2]:


### PR DESCRIPTION
#### What does this implement/fix?
The filter parameters for scalp coupling index were being passed incorrectly to the downstream function.
