### PR TITLE
MRG: Pick canonical NIRS response figure for gallery thumbnail 

### DIFF
--- a/tutorials/preprocessing/plot_70_fnirs_processing.py
+++ b/tutorials/preprocessing/plot_70_fnirs_processing.py
@@ -14,7 +14,7 @@ deoxyhaemoglobin (HbR) concentration.
 
 Here we will work with the :ref:`fNIRS motor data <fnirs-motor-dataset>`.
 """
-# sphinx_gallery_thumbnail_number = 12
+# sphinx_gallery_thumbnail_number = 14
 
 import os
 import numpy as np


### PR DESCRIPTION

#### Reference issue
General NIRS tweaks #7057 


#### What does this implement/fix?
Pick a NIRS specific figure for the thumbnail.

