### PR TITLE
MRG, DOC: cosmetic changes to what's new for 0.20

### DIFF
--- a/doc/changes/0.20.inc
+++ b/doc/changes/0.20.inc
@@ -15,9 +15,9 @@ Version 0.20
 Changelog
 ~~~~~~~~~
 
-- Improved :func:`mne.viz.plot_epochs` to label epoch counts starting from 0 `Sophie Herbst`_
+- Improved :func:`mne.viz.plot_epochs` to label epoch counts starting from 0, by `Sophie Herbst`_
 
-- Add :func:`minimum_norm.apply_inverse_cov` to compute static power by applying inverse solutions to a data covariance matrix by `Denis Engemann`_,`Luke Bloy`_, and `Eric Larson`_
+- Add :func:`minimum_norm.apply_inverse_cov` to compute static power by applying inverse solutions to a data covariance matrix by `Denis Engemann`_, `Luke Bloy`_, and `Eric Larson`_
 
 - Add :func:`mne.minimum_norm.resolution_metrics` to compute various resolution metrics for inverse solutions, by `Olaf Hauk`_
 


### PR DESCRIPTION
tiny fix to the `whats_new` page for 0.20:

- @bloyl's name was failing to link in one case because it followed directly after a comma (lacked a leading space)
- tiny grammar tweak