### PR TITLE
MRG, ENH: Better progressbar smoothing

### DIFF
--- a/mne/utils/progressbar.py
+++ b/mne/utils/progressbar.py
@@ -45,7 +45,7 @@ class ProgressBar(object):
         from ..externals.tqdm import auto
         tqdm = auto.tqdm
         defaults = dict(
-            leave=True, mininterval=0.016, miniters=0, smoothing=0.9,
+            leave=True, mininterval=0.016, miniters=1, smoothing=0.05,
             bar_format='{percentage:3.0f}%|{bar}| {desc} : {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt:>11}{postfix}]',  # noqa: E501
         )
         for key, val in defaults.items():


### PR DESCRIPTION
In testing ([this gist](https://gist.github.com/larsoner/c56b2521925273094208f33aa1e5cff1) and also long, slow clustering operations) this seems to be a better smoothing param. Turns out that `smoothing=0.9` was doing almost nothing. Using `smoothing=0.05` gives much smoother time remaining and ops/sec estimates.

@drammock I think you mentioned that the PB updates were a bit erratic, can you see if this fixes it for you?