### PR TITLE
MRG, FIX: Use tobytes instead of tostring

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -85,6 +85,7 @@ def pytest_configure(config):
     ignore:.*Converting `np\.character` to a dtype is deprecated.*:DeprecationWarning
     ignore:.*sphinx\.util\.smartypants is deprecated.*:
     ignore:.*pandas\.util\.testing is deprecated.*:
+    ignore:.*tostring.*is deprecated.*:DeprecationWarning
     always:.*get_data.* is deprecated in favor of.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -8,7 +8,6 @@ import numpy as np
 
 from numpy.testing import assert_array_equal, assert_allclose, assert_equal
 
-from mne import io, pick_types
 from mne.fixes import einsum, rfft, irfft
 from mne.utils import requires_sklearn, run_tests_if_main
 from mne.decoding import ReceptiveField, TimeDelayingRidge
@@ -26,11 +25,6 @@ tmin, tmax = -0.1, 0.5
 event_id = dict(aud_l=1, vis_l=3)
 
 # Loading raw data
-raw = io.read_raw_fif(raw_fname, preload=True)
-picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
-                   eog=False, exclude='bads')
-picks = picks[:2]
-
 n_jobs_test = (1, 'cuda')
 
 

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -675,27 +675,27 @@ def _read_dipole_bdip(fname):
 def _write_dipole_bdip(fname, dip):
     with open(fname, 'wb+') as fid:
         for ti, t in enumerate(dip.times):
-            fid.write(np.zeros(1, '>i4').tostring())  # int dipole
-            fid.write(np.array([t, 0]).astype('>f4').tostring())
-            fid.write(np.zeros(3, '>f4').tostring())  # r0
-            fid.write(dip.pos[ti].astype('>f4').tostring())  # pos
+            fid.write(np.zeros(1, '>i4').tobytes())  # int dipole
+            fid.write(np.array([t, 0]).astype('>f4').tobytes())
+            fid.write(np.zeros(3, '>f4').tobytes())  # r0
+            fid.write(dip.pos[ti].astype('>f4').tobytes())  # pos
             Q = dip.amplitude[ti] * dip.ori[ti]
-            fid.write(Q.astype('>f4').tostring())
-            fid.write(np.array(dip.gof[ti] / 100., '>f4').tostring())
+            fid.write(Q.astype('>f4').tobytes())
+            fid.write(np.array(dip.gof[ti] / 100., '>f4').tobytes())
             has_errors = int(bool(len(dip.conf)))
-            fid.write(np.array(has_errors, '>i4').tostring())  # has_errors
-            fid.write(np.zeros(1, '>f4').tostring())  # noise level
+            fid.write(np.array(has_errors, '>i4').tobytes())  # has_errors
+            fid.write(np.zeros(1, '>f4').tobytes())  # noise level
             for key in _BDIP_ERROR_KEYS:
                 val = dip.conf[key][ti] if key in dip.conf else 0.
                 assert val.shape == ()
-                fid.write(np.array(val, '>f4').tostring())
-            fid.write(np.zeros(25, '>f4').tostring())
+                fid.write(np.array(val, '>f4').tobytes())
+            fid.write(np.zeros(25, '>f4').tobytes())
             conf = dip.conf['vol'][ti] if 'vol' in dip.conf else 0.
-            fid.write(np.array(conf, '>f4').tostring())
+            fid.write(np.array(conf, '>f4').tobytes())
             khi2 = dip.khi2[ti] if dip.khi2 is not None else 0
-            fid.write(np.array(khi2, '>f4').tostring())
-            fid.write(np.zeros(1, '>f4').tostring())  # prob
-            fid.write(np.zeros(1, '>f4').tostring())  # total noise est
+            fid.write(np.array(khi2, '>f4').tobytes())
+            fid.write(np.zeros(1, '>f4').tobytes())  # prob
+            fid.write(np.zeros(1, '>f4').tobytes())  # total noise est
 
 
 # #############################################################################

--- a/mne/event.py
+++ b/mne/event.py
@@ -181,7 +181,7 @@ def _read_events_fif(fid, tree):
         elif kind == FIFF.FIFF_MNE_EVENT_COMMENTS:
             tag = read_tag(fid, pos)
             event_id = tag.data
-            event_id = event_id.tostring().decode('latin-1').split('\x00')[:-1]
+            event_id = event_id.tobytes().decode('latin-1').split('\x00')[:-1]
             assert len(event_id) == len(event_list)
             event_id = {k: v[2] for k, v in zip(event_id, event_list)}
             break

--- a/mne/externals/h5io/_h5io.py
+++ b/mne/externals/h5io/_h5io.py
@@ -333,7 +333,7 @@ def _triage_read(node, slash='ignore'):
         cast = int if type_str == 'int' else float
         data = cast(np.array(node)[0])
     elif type_str == 'datetime':
-        data = text_type(np.array(node).tostring().decode('utf-8'))
+        data = text_type(np.array(node).tobytes().decode('utf-8'))
         data = fromisoformat(data)
     elif type_str.startswith('np_'):
         np_type = type_str.split('_')[1]
@@ -342,9 +342,9 @@ def _triage_read(node, slash='ignore'):
     elif type_str in ('unicode', 'ascii', 'str'):  # 'str' for backward compat
         decoder = 'utf-8' if type_str == 'unicode' else 'ASCII'
         cast = text_type if type_str == 'unicode' else str
-        data = cast(np.array(node).tostring().decode(decoder))
+        data = cast(np.array(node).tobytes().decode(decoder))
     elif type_str == 'json':
-        node_unicode = str(np.array(node).tostring().decode('utf-8'))
+        node_unicode = str(np.array(node).tobytes().decode('utf-8'))
         data = json.loads(node_unicode)
     elif type_str == 'None':
         data = None
@@ -489,7 +489,7 @@ def _list_file_contents(h5file):
             desc = 'Text: %s'
             decoder = 'utf-8' if type_str == 'unicode' else 'ASCII'
             cast = text_type if type_str == 'unicode' else str
-            data = cast(np.array(data).tostring().decode(decoder))
+            data = cast(np.array(data).tobytes().decode(decoder))
             desc_val = data[:10] + '...' if len(data) > 10 else data
         else:
             desc = 'Items: %s'

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -390,7 +390,7 @@ def _serialize_volume_info(volume_info):
             if not (np.array_equal(volume_info[key], [20]) or np.array_equal(
                     volume_info[key], [2, 0, 20])):
                 warnings.warn("Unknown extension code.")
-            strings.append(np.array(volume_info[key], dtype='>i4').tostring())
+            strings.append(np.array(volume_info[key], dtype='>i4').tobytes())
         elif key in ('valid', 'filename'):
             val = volume_info[key]
             strings.append('{} = {}\n'.format(key, val).encode('utf-8'))

--- a/mne/forward/_lead_dots.py
+++ b/mne/forward/_lead_dots.py
@@ -77,7 +77,7 @@ def _get_legen_table(ch_type, volume_integral=False, n_coeff=100,
         lut = leg_fun(x_interp, n_coeff).astype(np.float32)
         if not force_calc:
             with open(fname, 'wb') as fid:
-                fid.write(lut.tostring())
+                fid.write(lut.tobytes())
     else:
         logger.info('Reading Legendre%s table...' % extra_str)
         with open(fname, 'rb', buffering=0) as fid:

--- a/mne/io/tag.py
+++ b/mne/io/tag.py
@@ -265,7 +265,7 @@ def _read_string(fid, tag, shape, rlims):
     """Read a string tag."""
     # Always decode to ISO 8859-1 / latin1 (FIFF standard).
     d = _frombuffer_rows(fid, tag.size, dtype='>c', shape=shape, rlims=rlims)
-    return str(d.tostring().decode('latin1', 'ignore'))
+    return str(d.tobytes().decode('latin1', 'ignore'))
 
 
 def _read_complex_float(fid, tag, shape, rlims):
@@ -344,7 +344,7 @@ def _read_ch_info_struct(fid, tag, shape, rlims):
     )
     # channel name
     ch_name = np.frombuffer(fid.read(16), dtype=">c")
-    ch_name = ch_name[:np.argmax(ch_name == b'')].tostring()
+    ch_name = ch_name[:np.argmax(ch_name == b'')].tobytes()
     d['ch_name'] = ch_name.decode()
     # coil coordinate system definition
     d['coord_frame'] = _coord_dict.get(d['kind'], FIFF.FIFFV_COORD_UNKNOWN)

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -32,11 +32,11 @@ def _write(fid, data, kind, data_size, FIFFT_TYPE, dtype):
     # XXX for string types the data size is used as
     # computed in ``write_string``.
 
-    fid.write(np.array(kind, dtype='>i4').tostring())
-    fid.write(np.array(FIFFT_TYPE, dtype='>i4').tostring())
-    fid.write(np.array(data_size, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tostring())
-    fid.write(np.array(data, dtype=dtype).tostring())
+    fid.write(np.array(kind, dtype='>i4').tobytes())
+    fid.write(np.array(FIFFT_TYPE, dtype='>i4').tobytes())
+    fid.write(np.array(data_size, dtype='>i4').tobytes())
+    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tobytes())
+    fid.write(np.array(data, dtype=dtype).tobytes())
 
 
 def _get_split_size(split_size):
@@ -55,11 +55,11 @@ def _get_split_size(split_size):
 
 def write_nop(fid, last=False):
     """Write a FIFF_NOP."""
-    fid.write(np.array(FIFF.FIFF_NOP, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFT_VOID, dtype='>i4').tostring())
-    fid.write(np.array(0, dtype='>i4').tostring())
+    fid.write(np.array(FIFF.FIFF_NOP, dtype='>i4').tobytes())
+    fid.write(np.array(FIFF.FIFFT_VOID, dtype='>i4').tobytes())
+    fid.write(np.array(0, dtype='>i4').tobytes())
     next_ = FIFF.FIFFV_NEXT_NONE if last else FIFF.FIFFV_NEXT_SEQ
-    fid.write(np.array(next_, dtype='>i4').tostring())
+    fid.write(np.array(next_, dtype='>i4').tobytes())
 
 
 def write_int(fid, kind, data):
@@ -139,16 +139,16 @@ def write_float_matrix(fid, kind, mat):
 
     data_size = 4 * mat.size + 4 * (mat.ndim + 1)
 
-    fid.write(np.array(kind, dtype='>i4').tostring())
-    fid.write(np.array(FIFFT_MATRIX_FLOAT, dtype='>i4').tostring())
-    fid.write(np.array(data_size, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tostring())
-    fid.write(np.array(mat, dtype='>f4').tostring())
+    fid.write(np.array(kind, dtype='>i4').tobytes())
+    fid.write(np.array(FIFFT_MATRIX_FLOAT, dtype='>i4').tobytes())
+    fid.write(np.array(data_size, dtype='>i4').tobytes())
+    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tobytes())
+    fid.write(np.array(mat, dtype='>f4').tobytes())
 
     dims = np.empty(mat.ndim + 1, dtype=np.int32)
     dims[:mat.ndim] = mat.shape[::-1]
     dims[-1] = mat.ndim
-    fid.write(np.array(dims, dtype='>i4').tostring())
+    fid.write(np.array(dims, dtype='>i4').tobytes())
     check_fiff_length(fid)
 
 
@@ -159,16 +159,16 @@ def write_double_matrix(fid, kind, mat):
 
     data_size = 8 * mat.size + 4 * (mat.ndim + 1)
 
-    fid.write(np.array(kind, dtype='>i4').tostring())
-    fid.write(np.array(FIFFT_MATRIX_DOUBLE, dtype='>i4').tostring())
-    fid.write(np.array(data_size, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tostring())
-    fid.write(np.array(mat, dtype='>f8').tostring())
+    fid.write(np.array(kind, dtype='>i4').tobytes())
+    fid.write(np.array(FIFFT_MATRIX_DOUBLE, dtype='>i4').tobytes())
+    fid.write(np.array(data_size, dtype='>i4').tobytes())
+    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tobytes())
+    fid.write(np.array(mat, dtype='>f8').tobytes())
 
     dims = np.empty(mat.ndim + 1, dtype=np.int32)
     dims[:mat.ndim] = mat.shape[::-1]
     dims[-1] = mat.ndim
-    fid.write(np.array(dims, dtype='>i4').tostring())
+    fid.write(np.array(dims, dtype='>i4').tobytes())
     check_fiff_length(fid)
 
 
@@ -179,17 +179,17 @@ def write_int_matrix(fid, kind, mat):
 
     data_size = 4 * mat.size + 4 * 3
 
-    fid.write(np.array(kind, dtype='>i4').tostring())
-    fid.write(np.array(FIFFT_MATRIX_INT, dtype='>i4').tostring())
-    fid.write(np.array(data_size, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tostring())
-    fid.write(np.array(mat, dtype='>i4').tostring())
+    fid.write(np.array(kind, dtype='>i4').tobytes())
+    fid.write(np.array(FIFFT_MATRIX_INT, dtype='>i4').tobytes())
+    fid.write(np.array(data_size, dtype='>i4').tobytes())
+    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tobytes())
+    fid.write(np.array(mat, dtype='>i4').tobytes())
 
     dims = np.empty(3, dtype=np.int32)
     dims[0] = mat.shape[1]
     dims[1] = mat.shape[0]
     dims[2] = 2
-    fid.write(np.array(dims, dtype='>i4').tostring())
+    fid.write(np.array(dims, dtype='>i4').tobytes())
     check_fiff_length(fid)
 
 
@@ -200,16 +200,16 @@ def write_complex_float_matrix(fid, kind, mat):
 
     data_size = 4 * 2 * mat.size + 4 * (mat.ndim + 1)
 
-    fid.write(np.array(kind, dtype='>i4').tostring())
-    fid.write(np.array(FIFFT_MATRIX_COMPLEX_FLOAT, dtype='>i4').tostring())
-    fid.write(np.array(data_size, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tostring())
-    fid.write(np.array(mat, dtype='>c8').tostring())
+    fid.write(np.array(kind, dtype='>i4').tobytes())
+    fid.write(np.array(FIFFT_MATRIX_COMPLEX_FLOAT, dtype='>i4').tobytes())
+    fid.write(np.array(data_size, dtype='>i4').tobytes())
+    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tobytes())
+    fid.write(np.array(mat, dtype='>c8').tobytes())
 
     dims = np.empty(mat.ndim + 1, dtype=np.int32)
     dims[:mat.ndim] = mat.shape[::-1]
     dims[-1] = mat.ndim
-    fid.write(np.array(dims, dtype='>i4').tostring())
+    fid.write(np.array(dims, dtype='>i4').tobytes())
     check_fiff_length(fid)
 
 
@@ -220,16 +220,16 @@ def write_complex_double_matrix(fid, kind, mat):
 
     data_size = 8 * 2 * mat.size + 4 * (mat.ndim + 1)
 
-    fid.write(np.array(kind, dtype='>i4').tostring())
-    fid.write(np.array(FIFFT_MATRIX_COMPLEX_DOUBLE, dtype='>i4').tostring())
-    fid.write(np.array(data_size, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tostring())
-    fid.write(np.array(mat, dtype='>c16').tostring())
+    fid.write(np.array(kind, dtype='>i4').tobytes())
+    fid.write(np.array(FIFFT_MATRIX_COMPLEX_DOUBLE, dtype='>i4').tobytes())
+    fid.write(np.array(data_size, dtype='>i4').tobytes())
+    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tobytes())
+    fid.write(np.array(mat, dtype='>c16').tobytes())
 
     dims = np.empty(mat.ndim + 1, dtype=np.int32)
     dims[:mat.ndim] = mat.shape[::-1]
     dims[-1] = mat.ndim
-    fid.write(np.array(dims, dtype='>i4').tostring())
+    fid.write(np.array(dims, dtype='>i4').tobytes())
     check_fiff_length(fid)
 
 
@@ -265,16 +265,16 @@ def write_id(fid, kind, id_=None):
     id_ = _generate_meas_id() if id_ is None else id_
 
     data_size = 5 * 4                       # The id comprises five integers
-    fid.write(np.array(kind, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFT_ID_STRUCT, dtype='>i4').tostring())
-    fid.write(np.array(data_size, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tostring())
+    fid.write(np.array(kind, dtype='>i4').tobytes())
+    fid.write(np.array(FIFF.FIFFT_ID_STRUCT, dtype='>i4').tobytes())
+    fid.write(np.array(data_size, dtype='>i4').tobytes())
+    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tobytes())
 
     # Collect the bits together for one write
     arr = np.array([id_['version'],
                     id_['machid'][0], id_['machid'][1],
                     id_['secs'], id_['usecs']], dtype='>i4')
-    fid.write(arr.tostring())
+    fid.write(arr.tobytes())
 
 
 def start_block(fid, kind):
@@ -339,52 +339,52 @@ def end_file(fid):
 def write_coord_trans(fid, trans):
     """Write a coordinate transformation structure."""
     data_size = 4 * 2 * 12 + 4 * 2
-    fid.write(np.array(FIFF.FIFF_COORD_TRANS, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFT_COORD_TRANS_STRUCT, dtype='>i4').tostring())
-    fid.write(np.array(data_size, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tostring())
-    fid.write(np.array(trans['from'], dtype='>i4').tostring())
-    fid.write(np.array(trans['to'], dtype='>i4').tostring())
+    fid.write(np.array(FIFF.FIFF_COORD_TRANS, dtype='>i4').tobytes())
+    fid.write(np.array(FIFF.FIFFT_COORD_TRANS_STRUCT, dtype='>i4').tobytes())
+    fid.write(np.array(data_size, dtype='>i4').tobytes())
+    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tobytes())
+    fid.write(np.array(trans['from'], dtype='>i4').tobytes())
+    fid.write(np.array(trans['to'], dtype='>i4').tobytes())
 
     #   The transform...
     rot = trans['trans'][:3, :3]
     move = trans['trans'][:3, 3]
-    fid.write(np.array(rot, dtype='>f4').tostring())
-    fid.write(np.array(move, dtype='>f4').tostring())
+    fid.write(np.array(rot, dtype='>f4').tobytes())
+    fid.write(np.array(move, dtype='>f4').tobytes())
 
     #   ...and its inverse
     trans_inv = linalg.inv(trans['trans'])
     rot = trans_inv[:3, :3]
     move = trans_inv[:3, 3]
-    fid.write(np.array(rot, dtype='>f4').tostring())
-    fid.write(np.array(move, dtype='>f4').tostring())
+    fid.write(np.array(rot, dtype='>f4').tobytes())
+    fid.write(np.array(move, dtype='>f4').tobytes())
 
 
 def write_ch_info(fid, ch):
     """Write a channel information record to a fif file."""
     data_size = 4 * 13 + 4 * 7 + 16
 
-    fid.write(np.array(FIFF.FIFF_CH_INFO, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFT_CH_INFO_STRUCT, dtype='>i4').tostring())
-    fid.write(np.array(data_size, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tostring())
+    fid.write(np.array(FIFF.FIFF_CH_INFO, dtype='>i4').tobytes())
+    fid.write(np.array(FIFF.FIFFT_CH_INFO_STRUCT, dtype='>i4').tobytes())
+    fid.write(np.array(data_size, dtype='>i4').tobytes())
+    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tobytes())
 
     #   Start writing fiffChInfoRec
-    fid.write(np.array(ch['scanno'], dtype='>i4').tostring())
-    fid.write(np.array(ch['logno'], dtype='>i4').tostring())
-    fid.write(np.array(ch['kind'], dtype='>i4').tostring())
-    fid.write(np.array(ch['range'], dtype='>f4').tostring())
-    fid.write(np.array(ch['cal'], dtype='>f4').tostring())
-    fid.write(np.array(ch['coil_type'], dtype='>i4').tostring())
-    fid.write(np.array(ch['loc'], dtype='>f4').tostring())  # writing 12 values
+    fid.write(np.array(ch['scanno'], dtype='>i4').tobytes())
+    fid.write(np.array(ch['logno'], dtype='>i4').tobytes())
+    fid.write(np.array(ch['kind'], dtype='>i4').tobytes())
+    fid.write(np.array(ch['range'], dtype='>f4').tobytes())
+    fid.write(np.array(ch['cal'], dtype='>f4').tobytes())
+    fid.write(np.array(ch['coil_type'], dtype='>i4').tobytes())
+    fid.write(np.array(ch['loc'], dtype='>f4').tobytes())  # writing 12 values
 
     #   unit and unit multiplier
-    fid.write(np.array(ch['unit'], dtype='>i4').tostring())
-    fid.write(np.array(ch['unit_mul'], dtype='>i4').tostring())
+    fid.write(np.array(ch['unit'], dtype='>i4').tobytes())
+    fid.write(np.array(ch['unit_mul'], dtype='>i4').tobytes())
 
     #   Finally channel name
     ch_name = ch['ch_name'][:15]
-    fid.write(np.array(ch_name, dtype='>c').tostring())
+    fid.write(np.array(ch_name, dtype='>c').tobytes())
     fid.write(b'\0' * (16 - len(ch_name)))
 
 
@@ -397,14 +397,14 @@ def write_dig_points(fid, dig, block=False, coord_frame=None):
         if coord_frame is not None:
             write_int(fid, FIFF.FIFF_MNE_COORD_FRAME, coord_frame)
         for d in dig:
-            fid.write(np.array(FIFF.FIFF_DIG_POINT, '>i4').tostring())
-            fid.write(np.array(FIFF.FIFFT_DIG_POINT_STRUCT, '>i4').tostring())
-            fid.write(np.array(data_size, dtype='>i4').tostring())
-            fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, '>i4').tostring())
+            fid.write(np.array(FIFF.FIFF_DIG_POINT, '>i4').tobytes())
+            fid.write(np.array(FIFF.FIFFT_DIG_POINT_STRUCT, '>i4').tobytes())
+            fid.write(np.array(data_size, dtype='>i4').tobytes())
+            fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, '>i4').tobytes())
             #   Start writing fiffDigPointRec
-            fid.write(np.array(d['kind'], '>i4').tostring())
-            fid.write(np.array(d['ident'], '>i4').tostring())
-            fid.write(np.array(d['r'][:3], '>f4').tostring())
+            fid.write(np.array(d['kind'], '>i4').tobytes())
+            fid.write(np.array(d['ident'], '>i4').tobytes())
+            fid.write(np.array(d['r'][:3], '>f4').tobytes())
         if block:
             end_block(fid, FIFF.FIFFB_ISOTRAK)
 
@@ -439,17 +439,17 @@ def write_float_sparse(fid, kind, mat, fmt='auto'):
     nrow = mat.shape[0]
     data_size = 4 * nnzm + 4 * nnzm + 4 * (nrow + 1) + 4 * 4
 
-    fid.write(np.array(kind, dtype='>i4').tostring())
-    fid.write(np.array(FIFFT_MATRIX_FLOAT_RCS, dtype='>i4').tostring())
-    fid.write(np.array(data_size, dtype='>i4').tostring())
-    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tostring())
+    fid.write(np.array(kind, dtype='>i4').tobytes())
+    fid.write(np.array(FIFFT_MATRIX_FLOAT_RCS, dtype='>i4').tobytes())
+    fid.write(np.array(data_size, dtype='>i4').tobytes())
+    fid.write(np.array(FIFF.FIFFV_NEXT_SEQ, dtype='>i4').tobytes())
 
-    fid.write(np.array(mat.data, dtype='>f4').tostring())
-    fid.write(np.array(mat.indices, dtype='>i4').tostring())
-    fid.write(np.array(mat.indptr, dtype='>i4').tostring())
+    fid.write(np.array(mat.data, dtype='>f4').tobytes())
+    fid.write(np.array(mat.indices, dtype='>i4').tobytes())
+    fid.write(np.array(mat.indptr, dtype='>i4').tobytes())
 
     dims = [nnzm, mat.shape[0], mat.shape[1], 2]
-    fid.write(np.array(dims, dtype='>i4').tostring())
+    fid.write(np.array(dims, dtype='>i4').tobytes())
     check_fiff_length(fid)
 
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -97,20 +97,20 @@ def _write_stc(filename, tmin, tstep, vertices, data):
     fid = open(filename, 'wb')
 
     # write start time in ms
-    fid.write(np.array(1000 * tmin, dtype='>f4').tostring())
+    fid.write(np.array(1000 * tmin, dtype='>f4').tobytes())
     # write sampling rate in ms
-    fid.write(np.array(1000 * tstep, dtype='>f4').tostring())
+    fid.write(np.array(1000 * tstep, dtype='>f4').tobytes())
     # write number of vertices
-    fid.write(np.array(vertices.shape[0], dtype='>u4').tostring())
+    fid.write(np.array(vertices.shape[0], dtype='>u4').tobytes())
     # write the vertex indices
-    fid.write(np.array(vertices, dtype='>u4').tostring())
+    fid.write(np.array(vertices, dtype='>u4').tobytes())
 
     # write the number of timepts
-    fid.write(np.array(data.shape[1], dtype='>u4').tostring())
+    fid.write(np.array(data.shape[1], dtype='>u4').tobytes())
     #
     # write the data
     #
-    fid.write(np.array(data.T, dtype='>f4').tostring())
+    fid.write(np.array(data.T, dtype='>f4').tobytes())
 
     # close the file
     fid.close()
@@ -171,7 +171,7 @@ def _write_3(fid, val):
     f_bytes[0] = (val >> 16) & 255
     f_bytes[1] = (val >> 8) & 255
     f_bytes[2] = val & 255
-    fid.write(f_bytes.tostring())
+    fid.write(f_bytes.tobytes())
 
 
 def _write_w(filename, vertices, data):
@@ -194,7 +194,7 @@ def _write_w(filename, vertices, data):
     fid = open(filename, 'wb')
 
     # write 2 zero bytes
-    fid.write(np.zeros((2), dtype=np.uint8).tostring())
+    fid.write(np.zeros((2), dtype=np.uint8).tobytes())
 
     # write number of vertices/sources (3 byte integer)
     vertices_n = len(vertices)
@@ -204,7 +204,7 @@ def _write_w(filename, vertices, data):
     for i in range(vertices_n):
         _write_3(fid, vertices[i])
         # XXX: without float() endianness is wrong, not sure why
-        fid.write(np.array(float(data[i]), dtype='>f4').tostring())
+        fid.write(np.array(float(data[i]), dtype='>f4').tobytes())
 
     # close the file
     fid.close()

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -980,8 +980,8 @@ def write_surface(fname, coords, faces, create_stamp='', volume_info=None,
         vnum = len(coords)
         fnum = len(faces)
         fid.write(pack('>2i', vnum, fnum))
-        fid.write(np.array(coords, dtype='>f4').tostring())
-        fid.write(np.array(faces, dtype='>i4').tostring())
+        fid.write(np.array(coords, dtype='>f4').tobytes())
+        fid.write(np.array(faces, dtype='>i4').tobytes())
 
         # Add volume info, if given
         if volume_info is not None and len(volume_info) > 0:

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -644,7 +644,7 @@ def object_hash(x, h=None):
         x = np.asarray(x)
         h.update(str(x.shape).encode('utf-8'))
         h.update(str(x.dtype).encode('utf-8'))
-        h.update(x.tostring())
+        h.update(x.tobytes())
     elif isinstance(x, datetime):
         object_hash(_dt_to_stamp(x))
     elif hasattr(x, '__len__'):


### PR DESCRIPTION
NumPy has deprecated `tostring` so let's use `tobytes`.

This is a simple search-and-replace plus removing a few lines in `test_receptive_field` that needlessly read `raw` data.