### PR TITLE
MAINT: Catch un-nested reads

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -130,6 +130,20 @@ def matplotlib_config():
     cbook.CallbackRegistry = CallbackRegistryReraise
 
 
+def pytest_collectreport(report):
+    """Check that no MNE classes were instantiated during collection."""
+    from mne.io.base import TrackingMixin
+    instances = list()
+    for key in TrackingMixin.__refs__:
+        instances.extend(key._get_instances())
+    if instances:
+        pytest.exit('\nLoaded data found during test collection:\n\n'
+                    '    %s\n\nPlease nest data loading in tests.\n'
+                    % ('\n    '.join('%s line %s: %s'
+                       % (inst[1], inst[2], inst[0])
+                       for inst in instances)))
+
+
 @pytest.fixture()
 def check_gui_ci():
     """Skip tests that are not reliable on CIs."""

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -38,7 +38,7 @@ from .io.pick import (pick_types, channel_indices_by_type, channel_type,
                       _pick_aux_channels, _DATA_CH_TYPES_SPLIT,
                       _picks_to_idx)
 from .io.proj import setup_proj, ProjMixin, _proj_equal
-from .io.base import BaseRaw, TimeMixin
+from .io.base import BaseRaw, TimeMixin, TrackingMixin
 from .bem import _check_origin
 from .evoked import EvokedArray, _check_decim
 from .baseline import rescale, _log_rescale
@@ -299,7 +299,7 @@ def _handle_event_repeated(events, event_id, event_repeated, selection,
 @fill_doc
 class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                  SetChannelsMixin, InterpolationMixin, FilterMixin,
-                 TimeMixin, SizeMixin, GetEpochsMixin):
+                 TimeMixin, SizeMixin, GetEpochsMixin, TrackingMixin):
     """Abstract base class for Epochs-type classes.
 
     This class provides basic functionality and should never be instantiated
@@ -531,6 +531,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                 self._data[ii] = np.dot(self._projector, epoch)
         self._filename = str(filename) if filename is not None else filename
         self._check_consistency()
+        TrackingMixin.__init__(self, BaseEpochs)
 
     def _check_consistency(self):
         """Check invariants of epochs object."""

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -36,7 +36,7 @@ from .io.proj import ProjMixin
 from .io.write import (start_file, start_block, end_file, end_block,
                        write_int, write_string, write_float_matrix,
                        write_id, write_float)
-from .io.base import TimeMixin, _check_maxshield
+from .io.base import TimeMixin, TrackingMixin, _check_maxshield
 
 _aspect_dict = {
     'average': FIFF.FIFFV_ASPECT_AVERAGE,
@@ -57,7 +57,7 @@ _aspect_rev = {val: key for key, val in _aspect_dict.items()}
 @fill_doc
 class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
              InterpolationMixin, FilterMixin, TimeMixin, SizeMixin,
-             ShiftTimeMixin):
+             ShiftTimeMixin, TrackingMixin):
     """Evoked data.
 
     Parameters
@@ -124,6 +124,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         # project and baseline correct
         if proj:
             self.apply_proj()
+        TrackingMixin.__init__(self, Evoked)
 
     @property
     def kind(self):

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -16,7 +16,7 @@ from mne.surface import (read_morph_map, _compute_nearest, _tessellate_sphere,
                          get_meg_helmet_surf, _normal_orth)
 from mne.utils import (_TempDir, requires_vtk, catch_logging,
                        run_tests_if_main, object_diff, requires_freesurfer)
-from mne.io import read_info
+from mne.io import read_info, read_raw_fif
 from mne.io.constants import FIFF
 from mne.transforms import _get_trans
 

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -26,7 +26,8 @@ from .docs import (copy_function_doc_to_method_doc, copy_doc, linkcode_resolve,
 from .fetching import _fetch_file, _url_to_local_path
 from ._logging import (verbose, logger, set_log_level, set_log_file,
                        use_log_level, catch_logging, warn, filter_out_warnings,
-                       ETSContext, wrapped_stdout, _get_call_line)
+                       ETSContext, wrapped_stdout, _get_call_line,
+                       _get_calling_frame_info)
 from .misc import (run_subprocess, _pl, _clean_names, pformat, _file_like,
                    _explain_exception, _get_argvalues, sizeof_fmt,
                    running_subprocess, _DefaultEventParser)


### PR DESCRIPTION
Seeing the un-nested `read_raw_fif` in #7551 made me wonder if there was a way to catch this sort of thing. Turns out there are ways of tracking refs that shouldn't cause ref cycle problems or anything. Adds < 1 ms to test runs. Gives this output for un-nested reads (where here I've intentionally added a bad one):
```
larsoner@bunk:~/python/mne-python$ pytest mne/tests/test_surface.py 
Test session starts (platform: linux, Python 3.8.0, pytest 5.4.1.dev62+g2d9dac95e, pytest-sugar 0.9.2)
rootdir: /home/larsoner/python/mne-python, inifile: setup.cfg
plugins: mock-1.11.2, hypothesis-5.7.0, cov-2.8.1, timeout-1.3.3, sugar-0.9.2
collecting ... 
------------------------------------------------------ generated xml file: /home/larsoner/python/mne-python/junit-results.xml ------------------------------------------------------
! _pytest.outcomes.Exit: 
Loaded data found during test collection:

    /home/larsoner/python/mne-python/mne/tests/test_surface.py line 35: <Raw | sample_audvis_trunc_raw.fif, 376 x 6007 (20.0 s), ~3.6 MB, data not loaded>

Please nest data loading in tests. !

Results (0.22s):
```
Seems potentially worth it to give people a nice message (and automatically catch) when they don't nest raw/epochs/evoked reads in tests. But maybe it's too magical. I'll let @agramfort decide :)