### PR TITLE
DOC: fix link in docstr [skip ci]

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1087,7 +1087,7 @@ def read_ch_connectivity(fname, picks=None):
 
     More information on these neighbor definitions can be found on the related
     `FieldTrip documentation pages
-    <http://www.fieldtrip.org/template/neighbours>`__.
+    <http://www.fieldtriptoolbox.org/template/neighbours/>`_.
 
     Parameters
     ----------


### PR DESCRIPTION
I skipped CI because this change is so minor.