### PR TITLE
MRG, FIX: parallel n_jobs check

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -36,6 +36,8 @@ Bug
 
 - Fix bug with :func:`mne.make_forward_dipole` where :func:`mne.write_forward_solution` could not be used by `Eric Larson`_
 
+- Fix bug that prevents ``n_jobs`` from being a NumPy integer type, by `Daniel McCloy`_.
+
 API
 ~~~
 

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -9,6 +9,7 @@ import os
 
 from . import get_config
 from .utils import logger, verbose, warn, ProgressBar
+from .utils.check import int_like
 from .fixes import _get_args
 
 if 'MNE_FORCE_SERIAL' in os.environ:
@@ -153,8 +154,7 @@ def check_n_jobs(n_jobs, allow_cuda=False):
         The checked number of jobs. Always positive (or 'cuda' if
         applicable).
     """
-    from numpy import integer
-    if not isinstance(n_jobs, (int, integer)):
+    if not isinstance(n_jobs, int_like):
         if not allow_cuda:
             raise ValueError('n_jobs must be an integer')
         elif not isinstance(n_jobs, str) or n_jobs != 'cuda':

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -153,7 +153,8 @@ def check_n_jobs(n_jobs, allow_cuda=False):
         The checked number of jobs. Always positive (or 'cuda' if
         applicable).
     """
-    if not isinstance(n_jobs, int):
+    from numpy import integer
+    if not isinstance(n_jobs, (int, integer)):
         if not allow_cuda:
             raise ValueError('n_jobs must be an integer')
         elif not isinstance(n_jobs, str) or n_jobs != 'cuda':


### PR DESCRIPTION
This fails on master, and passes on this PR:

```python
import numpy as np
import mne
mne.parallel.check_n_jobs(np.int64(6))
```

strangely, I was definitely passing in a plain `int`, not a numpy type, so `n_jobs` must have been recast somewhere in between my call to `mne.time_frequency.psd_multitaper` and the eventual check.  If it's important to dig in and figure out where/why that happened, LMK.

I didn't see a file `mne/tests/test_parallel.py`... do we not test the parallel capabilities?