### PR TITLE
MRG: Remove toolbars in PyVista plotter

### DIFF
--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -159,6 +159,8 @@ class _Renderer(_BaseRenderer):
             with _disabled_depth_peeling():
                 self.plotter = self.figure.build()
             self.plotter.hide_axes()
+            self.plotter.default_camera_tool_bar.close()
+            self.plotter.saved_cameras_tool_bar.close()
             _enable_aa(self.figure, self.plotter)
 
     def subplot(self, x, y):

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -159,8 +159,10 @@ class _Renderer(_BaseRenderer):
             with _disabled_depth_peeling():
                 self.plotter = self.figure.build()
             self.plotter.hide_axes()
-            self.plotter.default_camera_tool_bar.close()
-            self.plotter.saved_cameras_tool_bar.close()
+            if hasattr(self.plotter, "default_camera_tool_bar"):
+                self.plotter.default_camera_tool_bar.close()
+            if hasattr(self.plotter, "saved_cameras_tool_bar"):
+                self.plotter.saved_cameras_tool_bar.close()
             _enable_aa(self.figure, self.plotter)
 
     def subplot(self, x, y):


### PR DESCRIPTION
This small PR disables the default camera toolbars which are not compatible with `_TimeViewer`. Its features are either unused or duplicated.

This simplifies the window design overall.

`master` | PR
------------|-----
![image](https://user-images.githubusercontent.com/18143289/78663524-8cdd4c80-78d2-11ea-9e8c-4d7594b3fed4.png) | ![image](https://user-images.githubusercontent.com/18143289/78663464-73d49b80-78d2-11ea-91c5-acfddede3e92.png)
