### PR TITLE
WIP: Deregister plotter from the figure list in close()

### DIFF
--- a/examples/visualization/plot_publication_figure.py
+++ b/examples/visualization/plot_publication_figure.py
@@ -109,7 +109,7 @@ plt.rcParams.update({
 # :func:`~matplotlib.pyplot.subplot2grid`, or adding each axes manually) are
 # shown commented out, for reference.
 
-# sphinx_gallery_thumbnail_number = 5
+# sphinx_gallery_thumbnail_number = 4
 # figsize unit is inches
 fig, axes = plt.subplots(nrows=2, ncols=1, figsize=(4.5, 3.),
                          gridspec_kw=dict(height_ratios=[3, 4]))

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -28,6 +28,7 @@ with warnings.catch_warnings():
     from pyvista import (Plotter, BackgroundPlotter, PolyData,
                          Line, close_all, UnstructuredGrid)
     from pyvista.utilities import try_callback
+    from pyvista.plotting.plotting import _ALL_PLOTTERS
 
 
 _FIGURES = dict()
@@ -583,7 +584,11 @@ def _check_3d_figure(figure):
 def _close_3d_figure(figure):
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=FutureWarning)
+        # close the window
         figure.plotter.close()
+        # free memory and deregister from the scraper
+        figure.plotter.deep_clean()
+        del _ALL_PLOTTERS[figure.plotter._id_name]
 
 
 def _take_3d_screenshot(figure, mode='rgb', filename=None):


### PR DESCRIPTION
This PR fixes the last part of https://github.com/mne-tools/mne-python/issues/7526 about the figures still registered after `close()`. It's also a way more aggressive closing so I started Circle on this one.

Closes https://github.com/mne-tools/mne-python/issues/7526