### PR TITLE
Rework _Brain show

### DIFF
--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1788,12 +1788,17 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
 
     if title is None:
         title = subject if len(hemis) > 1 else '%s - %s' % (subject, hemis[0])
+    kwargs = {
+        "subject_id": subject, "hemi": hemi, "surf": surface,
+        "title": title, "cortex": cortex, "size": size,
+        "background": background, "foreground": foreground,
+        "figure": figure, "subjects_dir": subjects_dir,
+        "views": views
+    }
+    if get_3d_backend() == "pyvista":
+        kwargs["show"] = not time_viewer
     with warnings.catch_warnings(record=True):  # traits warnings
-        brain = Brain(subject, hemi=hemi, surf=surface,
-                      title=title, cortex=cortex, size=size,
-                      background=background, foreground=foreground,
-                      figure=figure, subjects_dir=subjects_dir,
-                      views=views)
+        brain = Brain(**kwargs)
     center = 0. if diverging else None
     for hemi in hemis:
         hemi_idx = 0 if hemi == 'lh' else 1
@@ -1816,7 +1821,7 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
                 kwargs["min"] = scale_pts[0]
                 kwargs["mid"] = scale_pts[1]
                 kwargs["max"] = scale_pts[2]
-            else:
+            else:  # pyvista
                 kwargs["fmin"] = scale_pts[0]
                 kwargs["fmid"] = scale_pts[1]
                 kwargs["fmax"] = scale_pts[2]

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -87,6 +87,8 @@ class _Brain(object):
         camera.
     units : str
         Can be 'm' or 'mm' (default).
+    show : bool
+        Display the window as soon as it is ready. Defaults to True.
 
     Attributes
     ----------
@@ -145,7 +147,8 @@ class _Brain(object):
                  cortex=None, alpha=1.0, size=800, background="black",
                  foreground=None, figure=None, subjects_dir=None,
                  views=['lateral'], offset=True, show_toolbar=False,
-                 offscreen=False, interaction=None, units='mm'):
+                 offscreen=False, interaction=None, units='mm',
+                 show=True):
         from ..backends.renderer import backend, _get_renderer
         from matplotlib.colors import colorConverter
 
@@ -242,8 +245,8 @@ class _Brain(object):
                     self._renderer.set_camera(azimuth=views_dict[v].azim,
                                               elevation=views_dict[v].elev)
 
-        # Force rendering
-        self._renderer.show()
+        if show:
+            self._renderer.show()
 
     @verbose
     def add_data(self, array, fmin=None, fmid=None, fmax=None,
@@ -739,6 +742,10 @@ class _Brain(object):
     def close(self):
         """Close all figures and cleanup data structure."""
         self._renderer.close()
+
+    def show(self):
+        """Display the window."""
+        self._renderer.show()
 
     def show_view(self, view=None, roll=None, distance=None, row=0, col=0,
                   hemi=None):

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -383,6 +383,7 @@ class _TimeViewer(object):
 
         # show everything at the end
         self.toggle_interface()
+        self.brain.show()
 
     @safe_event
     def keyPressEvent(self, event):

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -710,12 +710,11 @@ class _TimeViewer(object):
                 warnings.filterwarnings("ignore", category=UserWarning)
                 self.mpl_canvas.axes.set(xlim=xlim)
             vlayout = self.plotter.frame.layout()
-            if self.separate_canvas:
-                self.mpl_canvas.show()
-            else:
+            if not self.separate_canvas:
                 vlayout.addWidget(self.mpl_canvas.canvas)
                 vlayout.setStretch(0, 2)
                 vlayout.setStretch(1, 1)
+            self.mpl_canvas.show()
 
             # get brain data
             for idx, hemi in enumerate(['lh', 'rh']):

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -38,6 +38,7 @@ class _Figure(object):
     def __init__(self, plotter=None,
                  plotter_class=None,
                  display=None,
+                 show=False,
                  title='PyVista Scene',
                  size=(600, 600),
                  shape=(1, 1),
@@ -53,6 +54,7 @@ class _Figure(object):
         self.notebook = notebook
 
         self.store = dict()
+        self.store['show'] = show
         self.store['title'] = title
         self.store['window_size'] = size
         self.store['shape'] = shape
@@ -133,7 +135,7 @@ class _Renderer(_BaseRenderer):
     def __init__(self, fig=None, size=(600, 600), bgcolor='black',
                  name="PyVista Scene", show=False, shape=(1, 1)):
         from .renderer import MNE_3D_BACKEND_TESTING
-        figure = _Figure(title=name, size=size, shape=shape,
+        figure = _Figure(show=show, title=name, size=size, shape=shape,
                          background_color=bgcolor, notebook=None)
         self.font_family = "arial"
         if isinstance(fig, int):
@@ -435,6 +437,8 @@ class _Renderer(_BaseRenderer):
 
     def show(self):
         self.figure.display = self.plotter.show()
+        if hasattr(self.plotter, "app_window"):
+            self.plotter.app_window.show()
         return self.scene()
 
     def close(self):

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -69,6 +69,7 @@ class _Figure(object):
             self.plotter_class = Plotter
 
         if self.plotter_class == Plotter:
+            self.store.pop('show', None)
             self.store.pop('title', None)
             self.store.pop('auto_update', None)
 


### PR DESCRIPTION
**TL:DR**: `_TimeViewer` is displayed only once, when the UI is ready.

The default plotter of the pyvista backend is interactive as soon as it opens that's why one can notice every piece of the interface being added when `time_viewer=True` resulting in the jerkiness mentioned by @hoechenberger in https://github.com/mne-tools/mne-python/pull/7572#issuecomment-610382365 and @jasmainak in https://github.com/mne-tools/mne-python/pull/7247#issuecomment-587833079.

This PR fixes this behaviour by showing the `_TimeViewer` only when when it's ready (once every GUI element is set up). To achieve that I have to make `_Brain` aware that `time_viewer` is set. So I introduced the `show` parameter.

This way, the behaviour of `_Brain` is more consistent with all the basic `_3d.py` primitives and the `show` parameter is now connected to the rest of the viz pipeline.