### PR TITLE
MRG, FIX: Datetime call in gdf 2.x age calculation

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -42,6 +42,10 @@ Bug
 
 - Fix bug that prevents ``n_jobs`` from being a NumPy integer type, by `Daniel McCloy`_.
 
+- Fix bug with :func:`mne.io.read_raw_gdf` where birthdays were not parsed properly, leading to an error by `Svea Marie Meyer`_
+
+
+
 API
 ~~~
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -299,3 +299,5 @@
 .. _Adam Li: http://github.com/adam2392
 
 .. _Ramiro Gatti: https://github.com/ragatti
+
+.. _Svea Marie Meyer: https://github.com/SveaMeyer13

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -857,12 +857,12 @@ def _read_gdf_header(fname, exclude):
             if birthday == 0:
                 birthday = datetime(1, 1, 1, tzinfo=timezone.utc)
             else:
-                birthday = (datetime(1, 1, 1) +
+                birthday = (datetime(1, 1, 1, tzinfo=timezone.utc) +
                             timedelta(birthday * pow(2, -32) - 367))
             patient['birthday'] = birthday
             if patient['birthday'] != datetime(1, 1, 1, 0, 0,
                                                tzinfo=timezone.utc):
-                today = datetime.today(tzinfo=timezone.utc)
+                today = datetime.now(tz=timezone.utc)
                 patient['age'] = today.year - patient['birthday'].year
                 today = today.replace(year=patient['birthday'].year)
                 if today < patient['birthday']:


### PR DESCRIPTION
#### Reference issue
WIth regards to  #7124 .


#### What does this implement/fix?
While importing a GDF 2.x file with

```python
from mne import io
io.read_raw_gdf(fname, preload=True)
```

we encountered the following error:
 
```python
Extracting EDF parameters from /home/svea/Desktop/mne_examples/sample_data/B0103T.gdf...
GDF file detected
Traceback (most recent call last):
  File "/home/svea/Desktop/mne_examples/online_linear_demo.py", line 17, in <module>
    raw = io.read_raw_gdf(raw_fname, preload=True)
  File "/home/svea/Desktop/mne_examples/venv/lib/python3.7/site-packages/mne/io/edf/edf.py", line 1327, in read_raw_gdf
    verbose=verbose)
  File "<decorator-gen-164>", line 21, in __init__
  File "/home/svea/Desktop/mne_examples/venv/lib/python3.7/site-packages/mne/io/edf/edf.py", line 189, in __init__
    exclude, preload)
  File "/home/svea/Desktop/mne_examples/venv/lib/python3.7/site-packages/mne/io/edf/edf.py", line 377, in _get_info
    edf_info, orig_units = _read_header(fname, exclude)
  File "/home/svea/Desktop/mne_examples/venv/lib/python3.7/site-packages/mne/io/edf/edf.py", line 366, in _read_header
    return _read_gdf_header(fname, exclude), None
  File "/home/svea/Desktop/mne_examples/venv/lib/python3.7/site-packages/mne/io/edf/edf.py", line 865, in _read_gdf_header
    today = datetime.today(tzinfo=timezone.utc)
TypeError: today() takes no keyword arguments
```

After closer investigation, we suspect that it was caused by the changes introduced by #7124 and released in v0.20.0.

As stated in the [Python docs for datetime](https://docs.python.org/3.7/library/datetime.html#datetime.datetime.now),
datetime.now(tz=timezone.utc) should be the syntactically correct functional equivalent.

To then make today and patient['birthday'] comparable, we add tzinfo to birthday (in line 860).