### PR TITLE
MRG, FIX: Fix labeling for broken raw

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -40,6 +40,8 @@ Bug
 
 - Fix bug with :func:`mne.make_forward_dipole` where :func:`mne.write_forward_solution` could not be used by `Eric Larson`_
 
+- Fix bug with :meth:`mne.io.Raw.plot` when ``scalings='auto'`` where bad data would prevent channel plotting by `Eric Larson`_
+
 - Fix bug that prevents ``n_jobs`` from being a NumPy integer type, by `Daniel McCloy`_.
 
 API

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -293,6 +293,12 @@ def test_plot_raw():
     for key in ['down', 'up', 'escape']:
         fig.canvas.key_press_event(key)
 
+    raw._data[:] = np.nan
+    # this should (at least) not die, the output should pretty clearly show
+    # that there is a problem so probably okay to just plot something blank
+    with pytest.warns(None):
+        raw.plot(scalings='auto')
+
     plt.close('all')
 
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1880,10 +1880,11 @@ def _compute_scalings(scalings, inst, remove_dc=False, duration=10):
             this_data = this_data[:, :this_data.shape[1] // length * length]
             shape = this_data.shape  # original shape
             this_data = this_data.T.reshape(-1, length, shape[0])  # segment
-            this_data -= this_data.mean(0)  # subtract segment means
+            this_data -= np.nanmean(this_data, 0)  # subtract segment means
             this_data = this_data.T.reshape(shape)  # reshape into original
-
-        iqr = np.diff(np.percentile(this_data.ravel(), [25, 75]))
+        this_data = this_data.ravel()
+        this_data = this_data[np.isfinite(this_data)]
+        iqr = np.diff(np.percentile(this_data, [25, 75]))
         scalings[key] = iqr.item()
     return scalings
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1884,8 +1884,11 @@ def _compute_scalings(scalings, inst, remove_dc=False, duration=10):
             this_data = this_data.T.reshape(shape)  # reshape into original
         this_data = this_data.ravel()
         this_data = this_data[np.isfinite(this_data)]
-        iqr = np.diff(np.percentile(this_data, [25, 75]))
-        scalings[key] = iqr.item()
+        if this_data.size:
+            iqr = np.diff(np.percentile(this_data, [25, 75]))[0]
+        else:
+            iqr = 1.
+        scalings[key] = iqr
     return scalings
 
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -546,7 +546,8 @@ def _draw_proj_checkbox(event, params, draw_current_state=True):
 
 def _simplify_float(label):
     # Heuristic to turn floats to ints where possible (e.g. -500.0 to -500)
-    if isinstance(label, float) and float(str(label)) != round(label):
+    if isinstance(label, float) and np.isfinite(label) and \
+            float(str(label)) != round(label):
         label = round(label, 2)
     return label
 


### PR DESCRIPTION
Why the data are `nan` is another issue, but at least `raw.plot` should not die with a cryptic message. We could perhaps also add a warning, this PR will make it so the user sees something like this, which pretty clearly indicates a problem (so maybe it's enough already):

![Screenshot from 2020-04-08 10-29-21](https://user-images.githubusercontent.com/2365790/78796058-d76ad180-7983-11ea-8463-5a5b64e4851a.png)
