### PR TITLE
MRG, FIX: Fix reading EGI data with pauses

### DIFF
--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -239,7 +239,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.82', misc='0.5')
+    releases = dict(testing='0.84', misc='0.5')
     # And also update the "md5_hashes['testing']" variable below.
 
     # To update any other dataset, update the data archive itself (upload
@@ -323,7 +323,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='12b75d1cb7df9dfb4ad73ed82f61094f',
         somato='ea825966c0a1e9b2f84e3826c5500161',
         spm='9f43f67150e3b694b523a21eb929ea75',
-        testing='4089649dff26f9f095d434b5a544f1a4',
+        testing='25fbb89902adfee47a77807270cc0857',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         fnirs_motor='c4935d19ddab35422a69f3326a01fef8',
         opm='370ad1dcfd5c47e029e692c85358a374',

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -45,9 +45,10 @@ def _read_mff_header(filepath):
     bad = (n_samps_epochs != n_samps_block or
            not (epochs['first_samps'] < epochs['last_samps']).all() or
            not (epochs['first_samps'][1:] >= epochs['last_samps'][:-1]).all())
-    egi_internal_error = 'Internal EGI inconsistency'
     if bad:
-        raise RuntimeError(egi_internal_error)
+        raise RuntimeError('EGI epoch first/last samps could not be parsed:\n'
+                           '%s\n%s' % (list(epochs['first_samps']),
+                                       list(epochs['last_samps'])))
     summaryinfo.update(epochs)
     # index which samples in raw are actually readable from disk (i.e., not
     # in a skip)
@@ -83,7 +84,9 @@ def _read_mff_header(filepath):
             chan_unit.append('uV')
             n_chans = n_chans + 1
     if n_chans != summaryinfo['n_channels']:
-        raise RuntimeError(egi_internal_error)
+        raise RuntimeError('Number of defined channels (%d) did not match the '
+                           'expected channels (%d)'
+                           % (n_chans, summaryinfo['n_channels']))
 
     # Check presence of PNS data
     pns_names = []
@@ -96,7 +99,9 @@ def _read_mff_header(filepath):
                                       signal_samples[:-1]) and
                        pns_samples[-1] in (signal_samples[-1] - np.arange(2)))
         if not same_blocks:
-            raise RuntimeError(egi_internal_error)
+            raise RuntimeError('PNS and signals samples did not match:\n'
+                               '%s\nvs\n%s'
+                               % (list(pns_samples), list(signal_samples)))
 
         pns_file = op.join(filepath, 'pnsSet.xml')
         pns_obj = parse(pns_file)

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -56,14 +56,13 @@ def _read_mff_header(filepath):
         for ei, e in enumerate(epochs[key]):
             if e % div != 0:
                 raise RuntimeError('Could not parse epoch time %s' % (e,))
-            e //= div
-            epochs[key][ei] = (e * signal_blocks['sfreq']) // 1000
+            epochs[key][ei] = e // div
         # Should be safe to cast to int now, which makes things later not
         # upbroadcast to float
         epochs[key] = np.array(epochs[key], np.int64)
+        epochs[key] *= signal_blocks['sfreq']
+        epochs[key] //= 1000
     n_samps_block = signal_blocks['samples_block'].sum()
-    n_samps_epochs = sum(l - f for l, f in zip(epochs['last_samps'],
-                                               epochs['first_samps']))
     n_samps_epochs = (epochs['last_samps'] - epochs['first_samps']).sum()
     bad = (n_samps_epochs != n_samps_block or
            not (epochs['first_samps'] < epochs['last_samps']).all() or

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -41,6 +41,10 @@ def _read_mff_header(filepath):
     if n_samps_epochs == n_samps_block * 1000:
         for key in ('last_samps', 'first_samps'):
             epochs[key] //= 1000
+    for key in ('last_samps', 'first_samps'):
+        # Should be safe to cast to int now, which makes things later not
+        # upbroadcast to float
+        epochs[key] = epochs[key].astype(np.int64)
     n_samps_epochs = (epochs['last_samps'] - epochs['first_samps']).sum()
     bad = (n_samps_epochs != n_samps_block or
            not (epochs['first_samps'] < epochs['last_samps']).all() or

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -48,7 +48,7 @@ def _read_mff_header(filepath):
         record_time)
     if g is None:
         raise RuntimeError('Could not parse recordTime %r' % (record_time,))
-    frac = g.groups(0)[0]
+    frac = g.groups()[0]
     assert len(frac) in (6, 9) and all(f.isnumeric() for f in frac)  # regex
     div = 1000 if len(frac) == 6 else 1000000
     for key in ('last_samps', 'first_samps'):

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -60,7 +60,8 @@ def _read_mff_header(filepath):
         # Should be safe to cast to int now, which makes things later not
         # upbroadcast to float
         epochs[key] = np.array(epochs[key], np.int64)
-        epochs[key] *= signal_blocks['sfreq']
+        with np.errstate(over='raise'):
+            epochs[key] *= signal_blocks['sfreq']
         epochs[key] //= 1000
     n_samps_block = signal_blocks['samples_block'].sum()
     n_samps_epochs = (epochs['last_samps'] - epochs['first_samps']).sum()

--- a/mne/io/egi/events.py
+++ b/mne/io/egi/events.py
@@ -22,19 +22,18 @@ def _read_events(input_fname, info):
     info : dict
         Header info array.
     """
-    mff_events, event_codes = _read_mff_events(input_fname, info['sfreq'],
-                                               info['n_samples'])
+    n_samples = info['last_samps'][-1]
+    mff_events, event_codes = _read_mff_events(input_fname, info['sfreq'])
     info['n_events'] = len(event_codes)
     info['event_codes'] = np.asarray(event_codes).astype('<U4')
-    events = np.zeros([info['n_events'],
-                      info['n_segments'] * info['n_samples']])
+    events = np.zeros([info['n_events'], info['n_segments'] * n_samples])
     for n, event in enumerate(event_codes):
         for i in mff_events[event]:
             events[n][i] = n + 1
     return events, info
 
 
-def _read_mff_events(filename, sfreq, nsamples):
+def _read_mff_events(filename, sfreq):
     """Extract the events.
 
     Parameters
@@ -72,8 +71,7 @@ def _read_mff_events(filename, sfreq, nsamples):
     events_tims = dict()
     for ev in code:
         trig_samp = list(c['start_sample'] for n,
-                         c in enumerate(markers) if (c['name'] == ev and
-                         c['start_sample'] < nsamples))
+                         c in enumerate(markers) if c['name'] == ev)
         events_tims.update({ev: trig_samp})
     return events_tims, code
 

--- a/mne/io/egi/general.py
+++ b/mne/io/egi/general.py
@@ -49,7 +49,8 @@ def _get_ep_info(filepath):
     epochfile = filepath + '/epochs.xml'
     epochlist = parse(epochfile)
     epochs = epochlist.getElementsByTagName('epoch')
-    epoch_info = list()
+    keys = ('first_samps', 'last_samps', 'first_blocks', 'last_blocks')
+    epoch_info = {key: list() for key in keys}
     for epoch in epochs:
         ep_begin = int(epoch.getElementsByTagName('beginTime')[0]
                        .firstChild.data)
@@ -58,10 +59,12 @@ def _get_ep_info(filepath):
                           .firstChild.data)
         last_block = int(epoch.getElementsByTagName('lastBlock')[0]
                          .firstChild.data)
-        epoch_info.append({'first_samp': ep_begin,
-                           'last_samp': ep_end,
-                           'first_block': first_block,
-                           'last_block': last_block})
+        epoch_info['first_samps'].append(ep_begin)
+        epoch_info['last_samps'].append(ep_end)
+        epoch_info['first_blocks'].append(first_block)
+        epoch_info['last_blocks'].append(last_block)
+    for key in keys:
+        epoch_info[key] = np.array(epoch_info[key], int)
     return epoch_info
 
 

--- a/mne/io/egi/general.py
+++ b/mne/io/egi/general.py
@@ -64,7 +64,7 @@ def _get_ep_info(filepath):
         epoch_info['first_blocks'].append(first_block)
         epoch_info['last_blocks'].append(last_block)
     for key in keys:
-        epoch_info[key] = np.array(epoch_info[key], int)
+        epoch_info[key] = np.array(epoch_info[key], np.uint64)
     return epoch_info
 
 

--- a/mne/io/egi/general.py
+++ b/mne/io/egi/general.py
@@ -63,8 +63,8 @@ def _get_ep_info(filepath):
         epoch_info['last_samps'].append(ep_end)
         epoch_info['first_blocks'].append(first_block)
         epoch_info['last_blocks'].append(last_block)
-    for key in keys:
-        epoch_info[key] = np.array(epoch_info[key], np.uint64)
+    # Don't turn into ndarray here, keep native int because it can deal with
+    # huge numbers (could use np.uint64 but it's more work)
     return epoch_info
 
 

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -32,15 +32,16 @@ egi_pause_w1337_fname = op.join(egi_path, 'w1337_20191014_105416.mff')
 
 
 @requires_testing_data
-@pytest.mark.parametrize('fname, n_pause, n_events', [
-    (egi_pause_fname, 2, 18),
-    (egi_eprime_pause_fname, 2, 18),
-    (egi_pause_w1337_fname, 2, 0),
+@pytest.mark.parametrize('fname, n_pause, n_events, sfreq', [
+    (egi_pause_fname, 2, 18, 250),
+    (egi_eprime_pause_fname, 2, 18, 250),
+    (egi_pause_w1337_fname, 2, 0, 250),
 ])
-def test_egi_mff_pause(fname, n_pause, n_events):
+def test_egi_mff_pause(fname, n_pause, n_events, sfreq):
     """Test EGI MFF with pauses."""
     with pytest.warns(RuntimeWarning, match='Acquisition skips detected'):
         raw = _test_raw_reader(read_raw_egi, input_fname=fname)
+    assert raw.info['sfreq'] == sfreq
     assert len(raw.annotations) == n_pause
     if n_events == 0:
         with pytest.raises(ValueError, match='Consider using .*events_from'):
@@ -70,6 +71,7 @@ def test_io_egi_mff():
     include = ['DIN1', 'DIN2', 'DIN3', 'DIN4', 'DIN5', 'DIN7']
     raw = _test_raw_reader(read_raw_egi, input_fname=egi_mff_fname,
                            include=include, channel_naming='EEG %03d')
+    assert raw.info['sfreq'] == 1000.
 
     assert_equal('eeg' in raw, True)
     eeg_chan = [c for c in raw.ch_names if 'EEG' in c]


### PR DESCRIPTION
I implemented fixes mostly blind based on how I thought the format worked, let's see if it's correct.

@Lx37 @rhancockn @mmagnuski @christian-oreilly @ViridianForge 

1. You have reported problems/tried fixes, can you see if the branch from this PR (`larsoner:egi`) works with your data?
2. If you have ideas about how MFF works internally, please also review at the changes!

@rhancockn it would be nice to add more rigorous tests for the data you added to the testing dataset. For example, if in some other EGI browser software you can pick out some specific event number + times that we could hard code in the test then `assert_array_equal` in the test, that would help. Currently I just check the number of events, and I have no idea if it's actually correct, it's just the count I got once I had the potential fix implemented. Having some ground truth to put in the test would help...

Closes #5374.
Closes #4826.
Closes #5373.
Closes #5027.