### PR TITLE
TST: Use the standard Plotter for testing

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -247,9 +247,6 @@ class _Brain(object):
                     self._renderer.set_camera(azimuth=views_dict[v].azim,
                                               elevation=views_dict[v].elev)
 
-        if show:
-            self._renderer.show()
-
     @verbose
     def add_data(self, array, fmin=None, fmid=None, fmax=None,
                  thresh=None, center=None, transparent=False, colormap="auto",

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -158,8 +158,7 @@ class _Renderer(_BaseRenderer):
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)
-            if MNE_3D_BACKEND_TESTING:
-                self.figure.plotter_class = Plotter
+            self.figure.plotter_class = Plotter
             with _disabled_depth_peeling():
                 self.plotter = self.figure.build()
             self.plotter.hide_axes()


### PR DESCRIPTION
This PR forces the usage of the standard `Plotter` in the `PyVista` backend. It's for testing only and should not be merged.

Here is a minimal script that reproduces https://github.com/mne-tools/mne-python/issues/7599 with the standard `Plotter` on VTK 9:

```py
import os
import mne
from mne.datasets import sample
data_path = sample.data_path()
sample_dir = os.path.join(data_path, 'MEG', 'sample')
subjects_dir = os.path.join(data_path, 'subjects')
fname_stc = os.path.join(sample_dir, 'sample_audvis-meg')
stc = mne.read_source_estimate(fname_stc, subject='sample')
initial_time = 0.13
mne.viz.set_3d_backend('pyvista')
brain = stc.plot(subjects_dir=subjects_dir, initial_time=initial_time,
                 clim=dict(kind='value', pos_lims=[3, 6, 9]),
                 time_viewer=False, hemi='lh')
brain.show()
```