### PR TITLE
MRG, ENH: Allow pick_ori="vector" with fixed ori inv

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -21,6 +21,8 @@ Changelog
 
 - Allow resampling raw data with :func:`mne.io.Raw.resample` without preloading data, by `Eric Larson`_
 
+- Allow using ``pick_ori='vector'`` with a fixed-orientation inverse to facilitate visualization with :func:`mne.viz.plot_vector_source_estimates` by `Eric Larson`_
+
 - :func:`mne.viz.plot_dipole_locations` and :meth:`mne.Dipole.plot_locations` gained a ``title`` argument to specify a custom figure title in ``orthoview`` mode by `Richard Höchenberger`_
 
 - Added temporal derivative distribution repair :func:`mne.preprocessing.nirs.temporal_derivative_distribution_repair` by `Robert Luke`_

--- a/examples/inverse/plot_vector_mne_solution.py
+++ b/examples/inverse/plot_vector_mne_solution.py
@@ -6,7 +6,16 @@ Plotting the full vector-valued MNE solution
 The source space that is used for the inverse computation defines a set of
 dipoles, distributed across the cortex. When visualizing a source estimate, it
 is sometimes useful to show the dipole directions in addition to their
-estimated magnitude.
+estimated magnitude. This can be accomplished by computing a
+:class:`mne.VectorSourceEstimate` and plotting it with
+:meth:`stc.plot <mne.VectorSourceEstimate.plot>`, which uses
+:func:`~mne.viz.plot_vector_source_estimates` under the hood rather than
+:func:`~mne.viz.plot_source_estimates`.
+
+It can also be instructive to visualize the actual dipole/activation locations
+in 3D space in a glass brain, as opposed to activations imposed on an inflated
+surface (as typically done in :meth:`mne.SourceEstimate.plot`), as it allows
+you to get a better sense of the true underlying source geometry.
 """
 # Author: Marijn van Vliet <w.m.vanvliet@gmail.com>
 #
@@ -37,5 +46,20 @@ stc = apply_inverse(evoked, inv, lambda2, 'dSPM', pick_ori='vector')
 # Use peak getter to move visualization to the time point of the peak magnitude
 _, peak_time = stc.magnitude().get_peak(hemi='lh')
 
-# Plot the source estimate
-brain = stc.plot(initial_time=peak_time, hemi='lh', subjects_dir=subjects_dir)
+###############################################################################
+# Plot the source estimate:
+brain = stc.plot(
+    initial_time=peak_time, hemi='lh', subjects_dir=subjects_dir)
+
+###############################################################################
+# You can also do this with a fixed-orientation inverse. It looks a lot like
+# the result above because the ``loose=0.2`` orientation constraint keeps
+# sources close to fixed orientation:
+
+fname_inv_fixed = (
+    data_path + '/MEG/sample/sample_audvis-meg-oct-6-meg-fixed-inv.fif')
+inv_fixed = read_inverse_operator(fname_inv_fixed)
+stc_fixed = apply_inverse(
+    evoked, inv_fixed, lambda2, 'dSPM', pick_ori='vector')
+brain_fixed = stc_fixed.plot(
+    initial_time=peak_time, hemi='lh', subjects_dir=subjects_dir)

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -751,9 +751,6 @@ def _assemble_kernel(inv, label, method, pick_ori, use_cps=True, verbose=None):
 def _check_ori(pick_ori, source_ori, src, allow_vector=True):
     """Check pick_ori."""
     _check_option('pick_ori', pick_ori, [None, 'normal', 'vector'])
-    if pick_ori == 'vector' and source_ori != FIFF.FIFFV_MNE_FREE_ORI:
-        raise RuntimeError('pick_ori="vector" cannot be combined with an '
-                           'inverse operator with fixed orientations.')
     _check_src_normal(pick_ori, src)
 
 

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -671,8 +671,6 @@ def test_make_inverse_operator_vector(evoked, noise_cov):
     inv_1 = make_inverse_operator(evoked.info, fwd, noise_cov, loose=1)
     inv_2 = make_inverse_operator(evoked.info, fwd_surf, noise_cov, depth=None,
                                   use_cps=True)
-    inv_3 = make_inverse_operator(evoked.info, fwd_surf, noise_cov, fixed=True,
-                                  use_cps=True)
     inv_4 = make_inverse_operator(evoked.info, fwd, noise_cov,
                                   loose=.2, depth=None)
 
@@ -685,10 +683,6 @@ def test_make_inverse_operator_vector(evoked, noise_cov):
             stc_vec = apply_inverse(evoked, inv, pick_ori='vector',
                                     method=method)
             assert_allclose(stc.data, stc_vec.magnitude().data)
-
-    # Vector estimates don't work when using fixed orientations
-    with pytest.raises(RuntimeError, match='fixed orientation'):
-        apply_inverse(evoked, inv_3, pick_ori='vector')
 
     # When computing with vector fields, computing the difference between two
     # evokeds and then performing the inverse should yield the same result as

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -413,10 +413,16 @@ def _make_stc(data, vertices, src_type=None, tmin=None, tstep=None,
     # massage the data
     if src_type == 'surface' and vector:
         n_vertices = len(vertices[0]) + len(vertices[1])
-        data = np.matmul(
-            np.transpose(source_nn.reshape(n_vertices, 3, 3), axes=[0, 2, 1]),
-            data.reshape(n_vertices, 3, -1)
-        )
+        assert data.shape[0] in (n_vertices, n_vertices * 3)
+        if data.shape[0] == n_vertices:  # fixed orientation
+            data = data[:, np.newaxis] * source_nn[:, :, np.newaxis]
+        else:
+            data = np.matmul(
+                np.transpose(
+                    source_nn.reshape(n_vertices, 3, 3), axes=[0, 2, 1]),
+                data.reshape(n_vertices, 3, -1)
+            )
+        assert data.shape[:2] == (n_vertices, 3)
     elif src_type in ('volume', 'discrete') and vector:
         data = data.reshape((-1, 3, data.shape[-1]))
     else:

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -985,8 +985,11 @@ def test_vec_stc_inv_fixed(invs, pick_ori):
     """Test vector STC behavior with fixed-orientation inverses."""
     evoked, _, _, _, fixed, fixedish = invs
     stc_fixed = apply_inverse(evoked, fixed)
+    stc_fixed_vector = apply_inverse(evoked, fixed, pick_ori='vector')
+    assert_allclose(stc_fixed.data, stc_fixed_vector.normal(fixed['src']).data)
     stc_fixedish = apply_inverse(evoked, fixedish, pick_ori=pick_ori)
     if pick_ori == 'vector':
+        assert_allclose(stc_fixed_vector.data, stc_fixedish.data, atol=1e-2)
         # two ways here: with magnitude...
         assert_allclose(
             abs(stc_fixed).data, stc_fixedish.magnitude().data, atol=1e-2)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -463,7 +463,7 @@ pick_ori : None | "normal" | "vector"
     - ``"vector"``
         No pooling of the orientations is done, and the vector result
         will be returned in the form of a :class:`mne.VectorSourceEstimate`
-        object. This is only implemented when working with loose orientations.
+        object.
 """
 docdict['reduce_rank'] = """
 reduce_rank : bool


### PR DESCRIPTION
One advantage of `plot_vector_source_estimates` is that the arrows + glass brain represent the true geometry of the source space better than an inflated view. It would be nice to be able to use this function, even if you are working with fixed orientations. This PR enables `pick_ori='vector'` with fixed-orientation inverses.