### PR TITLE
MRG, FIX: Fix mne_setup_forward_model

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,6 +86,7 @@ jobs:
     MNE_LOGGING_LEVEL: 'warning'
     MNE_FORCE_SERIAL: 'true'
     OPENBLAS_NUM_THREADS: 1
+    MKL_NUM_THREADS: 1
     AZURE_CI_WINDOWS: 'true'
     CONDA_VERSION: '>=4.3.27'
   strategy:

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -40,6 +40,8 @@ Bug
 
 - Fix bug with :func:`mne.read_epochs` when loading data in complex format with ``preload=False`` by `Eric Larson`_
 
+- Fix :ref:`gen_mne_setup_forward_model` to have it actually compute the BEM solution in addition to creating the BEM model by `Eric Larson`_
+
 - Fix bug with :func:`mne.preprocessing.nirs.scalp_coupling_index` where filter transition was incorrectly assigned by `Robert Luke`_
 
 - Fix bug with :func:`mne.make_forward_dipole` where :func:`mne.write_forward_solution` could not be used by `Eric Larson`_

--- a/mne/commands/mne_setup_forward_model.py
+++ b/mne/commands/mne_setup_forward_model.py
@@ -116,6 +116,10 @@ def run():
     fname = os.path.join(subjects_dir, subject, "bem", fname)
     # Save source space to file
     mne.write_bem_surfaces(fname, bem_model)
+    # Compute the solution
+    sol_fname = os.path.splitext(fname)[0] + '-sol.fif'
+    bem_sol = mne.make_bem_solution(bem_model, verbose=verbose)
+    mne.write_bem_solution(sol_fname, bem_sol)
 
 
 mne.utils.run_command_if_main()

--- a/mne/commands/mne_setup_source_space.py
+++ b/mne/commands/mne_setup_source_space.py
@@ -16,6 +16,7 @@ Examples
 import sys
 
 import mne
+from mne.utils import _check_option
 
 
 def run():
@@ -69,6 +70,12 @@ def run():
                             ' (one for each hemisphere).',
                       default=1,
                       type='int')
+    parser.add_option('--add-dist',
+                      dest='add_dist',
+                      help='Add distances. Can be "True", "False", or "patch" '
+                      'to only compute cortical patch statistics (like the '
+                      '--cps option in MNE-C; requires SciPy >= 1.3)',
+                      default='True')
     parser.add_option('-o', '--overwrite',
                       dest='overwrite',
                       help='to write over existing files',
@@ -90,6 +97,9 @@ def run():
     oct = options.oct
     surface = options.surface
     n_jobs = options.n_jobs
+    add_dist = options.add_dist
+    _check_option('add_dist', add_dist, ('True', 'False', 'patch'))
+    add_dist = {'True': True, 'False': False, 'patch': 'patch'}[add_dist]
     verbose = True if options.verbose is not None else False
     overwrite = True if options.overwrite is not None else False
 
@@ -121,13 +131,13 @@ def run():
     # Create source space
     src = mne.setup_source_space(subject=subject, spacing=use_spacing,
                                  surface=surface, subjects_dir=subjects_dir,
-                                 n_jobs=n_jobs, verbose=verbose)
+                                 n_jobs=n_jobs, add_dist=add_dist,
+                                 verbose=verbose)
     # Morph source space if --morph is set
     if subject_to is not None:
         src = mne.morph_source_spaces(src, subject_to=subject_to,
                                       subjects_dir=subjects_dir,
-                                      surf=surface,
-                                      verbose=verbose)
+                                      surf=surface, verbose=verbose)
 
     # Save source space to file
     src.save(fname=fname, overwrite=overwrite)

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -281,7 +281,6 @@ def test_flash_bem(tmpdir):
         assert len(tris) == 5120
 
 
-@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_setup_source_space(tmpdir):
     """Test mne setup_source_space."""
@@ -292,7 +291,7 @@ def test_setup_source_space(tmpdir):
     # Test  command
     with ArgvSetter(('--src', use_fname, '-d', subjects_dir,
                      '-s', 'sample', '--morph', 'sample',
-                     '--ico', '3', '--verbose')):
+                     '--add-dist', 'False', '--ico', '3', '--verbose')):
         mne_setup_source_space.run()
     src = read_source_spaces(use_fname)
     assert len(src) == 2
@@ -311,20 +310,21 @@ def test_setup_source_space(tmpdir):
             assert mne_setup_source_space.run()
 
 
-@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_setup_forward_model(tmpdir):
-    """Test mne setup_source_space."""
+    """Test mne setup_forward_model."""
     check_usage(mne_setup_forward_model, force_help=True)
     # Using the sample dataset
     subjects_dir = op.join(testing.data_path(download=False), 'subjects')
     use_fname = op.join(tmpdir, "model-bem.fif")
     # Test  command
-    with ArgvSetter(('--model', use_fname, '-d', subjects_dir,
+    with ArgvSetter(('--model', use_fname, '-d', subjects_dir, '--homog',
                      '-s', 'sample', '--ico', '3', '--verbose')):
         mne_setup_forward_model.run()
     model = read_bem_surfaces(use_fname)
-    assert len(model) == 3
+    assert len(model) == 1
+    sol_fname = op.splitext(use_fname)[0] + '-sol.fif'
+    read_bem_solution(sol_fname)
 
 
 @pytest.mark.slowtest


### PR DESCRIPTION
1. Make `mne_setup_forward_model` compute and save the BEM solution (clearly nobody has really been using this command-line tool...)
2. Try to speed up Azure with `MKL_NUM_THREADS: 1`, can compare to [this run](https://dev.azure.com/mne-tools/mne-python/_build/results?buildId=6549&view=logs&j=b195a6e3-7484-5943-e627-0b35c27605d6&t=6dcb3581-08d4-5e76-74f2-6edaf20ff912) (0:46:23) to check
3. Speed up BEM test by computing the `--homog` rather than 3-layer
4. Speed up a test that takes ~180sec on Azure and ~77 sec locally, now takes ~2 sec locally (by not adding source space distances)