### PR TITLE
ENH: psd topomap improvements

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -19,6 +19,8 @@ Changelog
 
 - Add support for signals in mV for :func:`mne.io.read_raw_brainvision` by `Clemens Brunner`_
 
+- :meth:`mne.Epochs.plot_psd_topomap`, :func:`mne.viz.plot_epochs_psd_topomap`, and :func:`mne.viz.pot_psds_topomap` now allow joint colorbar limits across subplots, by `Daniel McCloy`_.
+
 - Allow resampling raw data with :func:`mne.io.Raw.resample` without preloading data, by `Eric Larson`_
 
 - :func:`mne.viz.plot_dipole_locations` and :meth:`mne.Dipole.plot_locations` gained a ``title`` argument to specify a custom figure title in ``orthoview`` mode by `Richard Höchenberger`_
@@ -54,4 +56,4 @@ Bug
 API
 ~~~
 
-- Nothing yet
+- ``vmin`` and ``vmax`` parameters are deprecated in :meth:`mne.Epochs.plot_psd_topomap`, :func:`mne.viz.plot_epochs_psd_topomap`, and :func:`mne.viz.pot_psds_topomap`; use new ``vlim`` parameter instead, by `Daniel McCloy`_.

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -19,7 +19,7 @@ Changelog
 
 - Add support for signals in mV for :func:`mne.io.read_raw_brainvision` by `Clemens Brunner`_
 
-- :meth:`mne.Epochs.plot_psd_topomap`, :func:`mne.viz.plot_epochs_psd_topomap`, and :func:`mne.viz.pot_psds_topomap` now allow joint colorbar limits across subplots, by `Daniel McCloy`_.
+- :meth:`mne.Epochs.plot_psd_topomap` and :func:`mne.viz.plot_epochs_psd_topomap` now allow joint colorbar limits across subplots, by `Daniel McCloy`_.
 
 - Allow resampling raw data with :func:`mne.io.Raw.resample` without preloading data, by `Eric Larson`_
 
@@ -56,4 +56,4 @@ Bug
 API
 ~~~
 
-- ``vmin`` and ``vmax`` parameters are deprecated in :meth:`mne.Epochs.plot_psd_topomap`, :func:`mne.viz.plot_epochs_psd_topomap`, and :func:`mne.viz.pot_psds_topomap`; use new ``vlim`` parameter instead, by `Daniel McCloy`_.
+- ``vmin`` and ``vmax`` parameters are deprecated in :meth:`mne.Epochs.plot_psd_topomap` and :func:`mne.viz.plot_epochs_psd_topomap`; use new ``vlim`` parameter instead, by `Daniel McCloy`_.

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -233,6 +233,7 @@ Visualization
    plot_dipole_locations
    plot_drop_log
    plot_epochs
+   plot_epochs_psd_topomap
    plot_events
    plot_evoked
    plot_evoked_image

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1091,7 +1091,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                          cmap='RdBu_r', agg_fun=None, dB=True,
                          n_jobs=1, normalize=False, cbar_fmt='%0.3f',
                          outlines='head', axes=None, show=True,
-                         sphere=None, verbose=None):
+                         sphere=None, vlim=(None, None), verbose=None):
         return plot_epochs_psd_topomap(
             self, bands=bands, vmin=vmin, vmax=vmax, tmin=tmin, tmax=tmax,
             proj=proj, bandwidth=bandwidth, adaptive=adaptive,

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1088,8 +1088,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
     def plot_psd_topomap(self, bands=None, vmin=None, vmax=None, tmin=None,
                          tmax=None, proj=False, bandwidth=None, adaptive=False,
                          low_bias=True, normalization='length', ch_type=None,
-                         cmap='RdBu_r', agg_fun=None, dB=True,
-                         n_jobs=1, normalize=False, cbar_fmt='%0.3f',
+                         cmap=None, agg_fun=None, dB=True,
+                         n_jobs=1, normalize=False, cbar_fmt='auto',
                          outlines='head', axes=None, show=True,
                          sphere=None, vlim=(None, None), verbose=None):
         return plot_epochs_psd_topomap(

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1098,7 +1098,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
             low_bias=low_bias, normalization=normalization, ch_type=ch_type,
             cmap=cmap, agg_fun=agg_fun, dB=dB, n_jobs=n_jobs,
             normalize=normalize, cbar_fmt=cbar_fmt, outlines=outlines,
-            axes=axes, show=show, sphere=sphere, verbose=verbose)
+            axes=axes, show=show, sphere=sphere, vlim=vlim, verbose=verbose)
 
     @copy_function_doc_to_method_doc(plot_topo_image_epochs)
     def plot_topo_image(self, layout=None, sigma=0., vmin=None, vmax=None,

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -118,6 +118,19 @@ sphere : float | array-like | str | None
     .. versionadded:: 0.20
 """ % (HEAD_SIZE_DEFAULT,)
 
+docdict["vlim_joint"] = """
+vlim : tuple of length 2 | 'joint'
+    Colormap limits to use. If a :class:`tuple` of floats, specifies the
+    lower and upper bounds of the colormap (in that order); providing
+    ``None`` for either entry will set the corresponding boundary at the
+    min/max of the data (separately for each topomap). Elements of the
+    :class:`tuple` may also be callable functions which take in a
+    :class:`NumPy array <numpy.ndarray>` and return a scalar.
+    If ``vlim='joint'``, will compute the colormap limits jointly across
+    all topomaps of the same channel type, using the min/max of the data.
+    Defaults to ``(None, None)``.
+"""
+
 # Picks
 docdict['picks_header'] = 'picks : str | list | slice | None'
 docdict['picks_base'] = docdict['picks_header'] + """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -132,6 +132,18 @@ vlim : tuple of length 2 | 'joint'
 
     .. versionadded:: 0.21
 """
+docdict['cmap_psd_topo'] = """
+cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
+    Colormap to use. If :class:`tuple`, the first value indicates the colormap
+    to use and the second value is a boolean defining interactivity. In
+    interactive mode the colors are adjustable by clicking and dragging the
+    colorbar with left and right mouse button. Left mouse button moves the
+    scale up and down and right mouse button adjusts the range. Hitting
+    space bar resets the range. Up and down arrows can be used to change
+    the colormap. If ``None``, ``'Reds'`` is used for data that is either
+    all-positive or all-negative, and ``'RdBu_r'`` is used otherwise.
+    ``'interactive'`` is equivalent to ``(None, True)``. Defaults to ``None``.
+"""
 
 # Picks
 docdict['picks_header'] = 'picks : str | list | slice | None'

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -161,18 +161,18 @@ cbar_fmt : str
     to '%%0.3f' if ``dB=False`` and '%%0.1f' if ``dB=True``. Defaults to
     ``'auto'``.
 """
-docdict['psd_topo_normalize'] """
+docdict['psd_topo_normalize'] = """
 normalize : bool
     If True, each band will be divided by the total power. Defaults to
     False.
 """
-docdict['psd_topo_bands'] """
+docdict['psd_topo_bands'] = """
 bands : list of tuple | None
     The frequencies or frequency ranges to plot. Length-2 tuples specify
     a single frequency and a subplot title (e.g.,
     ``(6.5, 'presentation rate')``); length-3 tuples specify lower and
     upper band edges and a subplot title. If ``None`` (the default),
-    expands to:
+    expands to::
 
         bands = [(0, 4, 'Delta'), (4, 8, 'Theta'), (8, 12, 'Alpha'),
                  (12, 30, 'Beta'), (30, 45, 'Gamma')]
@@ -180,7 +180,7 @@ bands : list of tuple | None
     In bands where a single frequency is provided, the topomap will reflect
     the single frequency bin that is closest to the provided value.
 """
-docdict['psd_topo_axes'] """
+docdict['psd_topo_axes'] = """
 axes : list of Axes | None
     List of axes to plot consecutive topographies to. If ``None`` the axes
     will be created automatically. Defaults to ``None``.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -118,7 +118,8 @@ sphere : float | array-like | str | None
     .. versionadded:: 0.20
 """ % (HEAD_SIZE_DEFAULT,)
 
-docdict["vlim_joint"] = """
+# PSD topomaps
+docdict["psd_topo_vlim_joint"] = """
 vlim : tuple of length 2 | 'joint'
     Colormap limits to use. If a :class:`tuple` of floats, specifies the
     lower and upper bounds of the colormap (in that order); providing
@@ -132,7 +133,17 @@ vlim : tuple of length 2 | 'joint'
 
     .. versionadded:: 0.21
 """
-docdict['cmap_psd_topo'] = """
+docdict['psd_topo_agg_fun'] = """
+agg_fun : callable
+    The function used to aggregate over frequencies. Defaults to
+    :func:`numpy.sum` if ``normalize=True``, else :func:`numpy.mean`.
+"""
+docdict['psd_topo_dB'] = """
+dB : bool
+    If ``True``, transform data to decibels (with ``10 * np.log10(data)``)
+    following the application of ``agg_fun``. Ignored if ``normalize=True``.
+"""
+docdict['psd_topo_cmap'] = """
 cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
     Colormap to use. If :class:`tuple`, the first value indicates the colormap
     to use and the second value is a boolean defining interactivity. In
@@ -143,6 +154,36 @@ cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
     the colormap. If ``None``, ``'Reds'`` is used for data that is either
     all-positive or all-negative, and ``'RdBu_r'`` is used otherwise.
     ``'interactive'`` is equivalent to ``(None, True)``. Defaults to ``None``.
+"""
+docdict['psd_topo_cbar_fmt'] = """
+cbar_fmt : str
+    Format string for the colorbar tick labels. If ``'auto'``, is equivalent
+    to '%%0.3f' if ``dB=False`` and '%%0.1f' if ``dB=True``. Defaults to
+    ``'auto'``.
+"""
+docdict['psd_topo_normalize'] """
+normalize : bool
+    If True, each band will be divided by the total power. Defaults to
+    False.
+"""
+docdict['psd_topo_bands'] """
+bands : list of tuple | None
+    The frequencies or frequency ranges to plot. Length-2 tuples specify
+    a single frequency and a subplot title (e.g.,
+    ``(6.5, 'presentation rate')``); length-3 tuples specify lower and
+    upper band edges and a subplot title. If ``None`` (the default),
+    expands to:
+
+        bands = [(0, 4, 'Delta'), (4, 8, 'Theta'), (8, 12, 'Alpha'),
+                 (12, 30, 'Beta'), (30, 45, 'Gamma')]
+
+    In bands where a single frequency is provided, the topomap will reflect
+    the single frequency bin that is closest to the provided value.
+"""
+docdict['psd_topo_axes'] """
+axes : list of Axes | None
+    List of axes to plot consecutive topographies to. If ``None`` the axes
+    will be created automatically. Defaults to ``None``.
 """
 
 # Picks

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -129,6 +129,8 @@ vlim : tuple of length 2 | 'joint'
     If ``vlim='joint'``, will compute the colormap limits jointly across
     all topomaps of the same channel type, using the min/max of the data.
     Defaults to ``(None, None)``.
+
+    .. versionadded:: 0.21
 """
 
 # Picks

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -158,7 +158,7 @@ cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
 docdict['psd_topo_cbar_fmt'] = """
 cbar_fmt : str
     Format string for the colorbar tick labels. If ``'auto'``, is equivalent
-    to '%%0.3f' if ``dB=False`` and '%%0.1f' if ``dB=True``. Defaults to
+    to '%0.3f' if ``dB=False`` and '%0.1f' if ``dB=True``. Defaults to
     ``'auto'``.
 """
 docdict['psd_topo_normalize'] = """
@@ -843,7 +843,7 @@ docdict["time_label"] = """
 time_label : str | callable | None
     Format of the time label (a format string, a function that maps
     floating point time values to strings, or None for no label). The
-    default is ``'auto'``, which will use ``time=%%0.2f ms`` if there
+    default is ``'auto'``, which will use ``time=%0.2f ms`` if there
     is more than one time point.
 """
 

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -317,7 +317,6 @@ def test_plot_psd_epochs():
     with pytest.warns(DeprecationWarning, match='provided values for "vlim"'):
         epochs.plot_psd_topomap(vmax=5, vlim=(None, 7))
     plt.close('all')
-
     # test defaults
     fig = epochs.plot_psd_topomap()
     assert len(fig.axes) == 10  # default: 5 bands (δ, θ, α, β, γ) + colorbars
@@ -327,13 +326,14 @@ def test_plot_psd_epochs():
     vmax_0 = fig.axes[0].images[0].norm.vmax
     assert all(vmin_0 == ax.images[0].norm.vmin for ax in fig.axes[1:5])
     assert all(vmax_0 == ax.images[0].norm.vmax for ax in fig.axes[1:5])
-    # with a flat channel
+    # test support for single-bin bands
+    fig = epochs.plot_psd_topomap(bands=[(20, '20 Hz'), (15, 25, '15-25 Hz')])
+    # test with a flat channel
     err_str = 'for channel %s' % epochs.ch_names[2]
     epochs.get_data()[0, 2, :] = 0
     for dB in [True, False]:
         with pytest.warns(UserWarning, match=err_str):
             epochs.plot_psd(dB=dB)
-
     plt.close('all')
 
 

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -308,10 +308,25 @@ def test_plot_psd_epochs():
     epochs.plot_psd(average=True, spatial_colors=False)
     epochs.plot_psd(average=False, spatial_colors=True)
     epochs.plot_psd(average=False, spatial_colors=False)
-    pytest.raises(RuntimeError, epochs.plot_psd_topomap,
-                  bands=[(0, 0.01, 'foo')])  # no freqs in range
-    epochs.plot_psd_topomap()
+    # test plot_psd_topomap errors
+    with pytest.raises(RuntimeError, match='No frequencies in band'):
+        epochs.plot_psd_topomap(bands=[(0, 0.01, 'foo')])
+    # test vmin, vmax deprecation
+    with pytest.warns(DeprecationWarning, match='you didn\'t specify "vlim"'):
+        epochs.plot_psd_topomap(vmax=5)
+    with pytest.warns(DeprecationWarning, match='provided values for "vlim"'):
+        epochs.plot_psd_topomap(vmax=5, vlim=(None, 7))
+    plt.close('all')
 
+    # test defaults
+    fig = epochs.plot_psd_topomap()
+    assert len(fig.axes) == 10  # default: 5 bands (δ, θ, α, β, γ) + colorbars
+    # test joint vlim
+    fig = epochs.plot_psd_topomap(vlim='joint')
+    vmin_0 = fig.axes[0].images[0].norm.vmin
+    vmax_0 = fig.axes[0].images[0].norm.vmax
+    assert all(vmin_0 == ax.images[0].norm.vmin for ax in fig.axes[1:5])
+    assert all(vmax_0 == ax.images[0].norm.vmax for ax in fig.axes[1:5])
     # with a flat channel
     err_str = 'for channel %s' % epochs.ch_names[2]
     epochs.get_data()[0, 2, :] = 0

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2015,9 +2015,9 @@ def plot_psds_topomap(
                  (12, 30, 'Beta'), (30, 45, 'Gamma')]
 
     if agg_fun is None:
-        agg_fun = np.sum if normalize is True else np.mean
+        agg_fun = np.sum if normalize else np.mean
 
-    if normalize is True:
+    if normalize:
         psds /= psds.sum(axis=-1)[..., None]
         assert np.allclose(psds.sum(axis=-1), 1.)
 
@@ -2046,7 +2046,7 @@ def plot_psds_topomap(
             raise RuntimeError('No frequencies in band "%s" (%s, %s)'
                                % (title, fmin, fmax))
         data = agg_fun(psds[:, freq_mask], axis=1)
-        if dB is True and normalize is False:
+        if dB and not normalize:
             data = 10 * np.log10(data)
             unit = 'dB'
         else:

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1838,13 +1838,7 @@ def plot_epochs_psd_topomap(epochs, bands=None, vmin=None, vmax=None,
     ----------
     epochs : instance of Epochs
         The epochs object.
-    bands : list of tuple | None
-        The lower and upper frequency and the name for that band. If None,
-        (default) expands to:
-
-        bands = [(0, 4, 'Delta'), (4, 8, 'Theta'), (8, 12, 'Alpha'),
-                 (12, 30, 'Beta'), (30, 45, 'Gamma')]
-
+    %(psd_topo_bands)s
     vmin : None
         Deprecated; use ``vlim`` instead.
     vmax : None
@@ -1873,29 +1867,18 @@ def plot_epochs_psd_topomap(epochs, bands=None, vmin=None, vmax=None,
         pairs and the mean for each pair is plotted. If None, then first
         available channel type from order given above is used. Defaults to
         None.
-    %(cmap_psd_topo)s
-    agg_fun : callable
-        The function used to aggregate over frequencies.
-        Defaults to np.sum. if normalize is True, else np.mean.
-    dB : bool
-        If True, transform data to decibels (with ``10 * np.log10(data)``)
-        following the application of `agg_fun`. Only valid if normalize is
-        False.
+    %(psd_topo_cmap)s
+    %(psd_topo_agg_fun)s
+    %(psd_topo_dB)s
     %(n_jobs)s
-    normalize : bool
-        If True, each band will be divided by the total power. Defaults to
-        False.
-    cbar_fmt : str
-        The colorbar format. If ``'auto'``, is equivalent to '%%0.3f' if
-        ``dB=False`` and '%%0.1f' if ``dB=True``. Defaults to ``'auto'``.
+    %(psd_topo_normalize)s
+    %(psd_topo_cbar_fmt)s
     %(topomap_outlines)s
-    axes : list of Axes | None
-        List of axes to plot consecutive topographies to. If None the axes
-        will be created automatically. Defaults to None.
+    %(psd_topo_axes)s
     show : bool
         Show figure if True.
     %(topomap_sphere_auto)s
-    %(vlim_joint)s
+    %(psd_topo_vlim_joint)s
     %(verbose)s
 
     Returns
@@ -1941,43 +1924,22 @@ def plot_psds_topomap(
         Frequencies used to compute psds.
     pos : numpy.ndarray of float, shape (n_sensors, 2)
         The positions of the sensors.
-    agg_fun : callable
-        The function used to aggregate over frequencies. Defaults to
-        :func:`numpy.sum` if normalize is ``True``, else :func:`numpy.mean`.
+    %(psd_topo_agg_fun)s
     vmin : None
         Deprecated; use ``vlim`` instead.
     vmax : None
         Deprecated; use ``vlim`` instead.
-    bands : list of tuple | None
-        The frequencies or frequency ranges to plot. Length-2 tuples specify
-        a single frequency and a subplot title (e.g.,
-        ``(6.5, 'presentation rate')``); length-3 tuples specify lower and
-        upper band edges and a subplot title. If ``None`` (the default),
-        expands to:
-
-            bands = [(0, 4, 'Delta'), (4, 8, 'Theta'), (8, 12, 'Alpha'),
-                     (12, 30, 'Beta'), (30, 45, 'Gamma')]
-
-        In bands where a single frequency is provided, the topomap will reflect
-        the single frequency bin that is closest to the provided value.
-    %(cmap_psd_topo)s
-    dB : bool
-        If True, transform data to decibels (with ``10 * np.log10(data)``)
-        following the application of `agg_fun`. Only valid if normalize is
-        False.
-    normalize : bool
-        If True, each band will be divided by the total power. Defaults to
-        False.
-    cbar_fmt : str
-        The colorbar format. Defaults to '%%0.3f'.
+    %(psd_topo_bands)s
+    %(psd_topo_cmap)s
+    %(psd_topo_dB)s
+    %(psd_topo_normalize)s
+    %(psd_topo_cbar_fmt)s
     %(topomap_outlines)s
-    axes : list of axes | None
-        List of axes to plot consecutive topographies to. If None the axes
-        will be created automatically. Defaults to None.
+    %(psd_topo_axes)s
     show : bool
         Show figure if True.
     %(topomap_sphere)s
-    %(vlim_joint)s
+    %(psd_topo_vlim_joint)s
 
     Returns
     -------

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2021,10 +2021,8 @@ def plot_psds_topomap(
     else:  # upconvert single freqs to band upper/lower edges as needed
         bin_spacing = np.diff(freqs)[0]
         bin_edges = np.array([0, bin_spacing]) - bin_spacing / 2
-        for ix, band in enumerate(bands):
-            if len(band) == 2:
-                bin_freq = freqs[np.argmin(np.abs(freqs - band[0]))]
-                bands[ix] = tuple(bin_edges + bin_freq) + (band[-1],)
+        bands = [tuple(bin_edges + freqs[np.argmin(np.abs(freqs - band[0]))]) +
+                 (band[1],) if len(band) == 2 else band for band in bands]
 
     if agg_fun is None:
         agg_fun = np.sum if normalize else np.mean

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1828,7 +1828,7 @@ def plot_epochs_psd_topomap(epochs, bands=None, vmin=None, vmax=None,
                             bandwidth=None, adaptive=False, low_bias=True,
                             normalization='length', ch_type=None,
                             cmap=None, agg_fun=None, dB=False, n_jobs=1,
-                            normalize=False, cbar_fmt='%0.3f',
+                            normalize=False, cbar_fmt='auto',
                             outlines='head', axes=None, show=True,
                             sphere=None, vlim=(None, None), verbose=None):
     """Plot the topomap of the power spectral density across epochs.
@@ -1894,7 +1894,8 @@ def plot_epochs_psd_topomap(epochs, bands=None, vmin=None, vmax=None,
         If True, each band will be divided by the total power. Defaults to
         False.
     cbar_fmt : str
-        The colorbar format. Defaults to '%%0.3f'.
+        The colorbar format. If ``'auto'``, is equivalent to '%%0.3f' if
+        ``dB=False`` and '%%0.1f' if ``dB=True``. Defaults to ``'auto'``.
     %(topomap_outlines)s
     axes : list of Axes | None
         List of axes to plot consecutive topographies to. If None the axes
@@ -1925,6 +1926,9 @@ def plot_epochs_psd_topomap(epochs, bands=None, vmin=None, vmax=None,
 
     if merge_channels:
         psds, names = _merge_ch_data(psds, ch_type, names, method='mean')
+
+    if cbar_fmt == 'auto':
+        cbar_fmt = '%0.1f' if dB else '%0.3f'
 
     return plot_psds_topomap(
         psds=psds, freqs=freqs, pos=pos, agg_fun=agg_fun, vmin=vmin,

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -288,7 +288,7 @@ def plot_projs_topomap(projs, info, cmap=None, sensors=True,
     Returns
     -------
     fig : instance of matplotlib.figure.Figure
-        Figure distributing one image per channel across sensor topography.
+        Figure with a topomap subplot for each projector.
 
     Notes
     -----

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1949,7 +1949,7 @@ def plot_psds_topomap(
     Returns
     -------
     fig : instance of matplotlib.figure.Figure
-        Figure distributing one image per channel across sensor topography.
+        Figure with a topomap subplot for each band.
     """
     import matplotlib.pyplot as plt
     sphere = _check_sphere(sphere)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -226,7 +226,7 @@ def _add_colorbar(ax, im, cmap, side="right", pad=.05, title=None,
                   format=None, size="5%"):
     """Add a colorbar to an axis."""
     import matplotlib.pyplot as plt
-    from mpl_toolkits.axes_grid1 import make_axes_locatable  # noqa: F401
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
     divider = make_axes_locatable(ax)
     cax = divider.append_axes(side, size=size, pad=pad)
     cbar = plt.colorbar(im, cax=cax, format=format)
@@ -1814,8 +1814,8 @@ def _plot_topomap_multi_cbar(data, pos, ax, title=None, unit=None, vmin=None,
                          cmap=cmap[0], image_interp='bilinear', contours=0,
                          outlines=outlines, show=False, sphere=sphere)
 
-    if colorbar is True:
-        cbar, cax = _add_colorbar(ax, im, cmap, pad=.25, title=None,
+    if colorbar:
+        cbar, cax = _add_colorbar(ax, im, cmap, pad=0.25, title=None,
                                   size="10%", format=cbar_fmt)
         cbar.set_ticks((vmin, vmax))
         if unit is not None:
@@ -1950,8 +1950,8 @@ def plot_psds_topomap(
     pos : numpy.ndarray of float, shape (n_sensors, 2)
         The positions of the sensors.
     agg_fun : callable
-        The function used to aggregate over frequencies.
-        Defaults to np.sum. if normalize is True, else np.mean.
+        The function used to aggregate over frequencies. Defaults to
+        :func:`numpy.sum` if normalize is ``True``, else :func:`numpy.mean`.
     vmin : None
         Deprecated; use ``vlim`` instead.
     vmax : None

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1794,14 +1794,13 @@ def _slider_changed(val, ax, data, times, pos, scaling, func, time_format,
         ax.set_title(time_format % (val * scaling_time))
 
 
-def _plot_topomap_multi_cbar(data, pos, ax, title=None, unit=None, vmin=None,
-                             vmax=None, cmap=None, outlines='head',
-                             colorbar=False, cbar_fmt='%3.3f',
-                             sphere=None):
+def _plot_topomap_multi_cbar(data, pos, ax, vmin, vmax, title=None, unit=None,
+                             cmap=None, outlines='head', colorbar=False,
+                             cbar_fmt='%3.3f', sphere=None):
     """Plot topomap multi cbar."""
     _hide_frame(ax)
-    vmin = np.min(data) if vmin is None else vmin
-    vmax = np.max(data) if vmax is None else vmax
+    vmin = data.min() if vmin is None else vmin
+    vmax = data.max() if vmax is None else vmax
     # this definition of "norm" allows non-diverging colormap for cases where
     # min & vmax are both negative (e.g., when they are power in dB)
     signs = np.sign([vmin, vmax])
@@ -2062,8 +2061,8 @@ def plot_psds_topomap(
         else:
             unit = 'power'
 
-        _plot_topomap_multi_cbar(data, pos, ax, title=title, vmin=vmin,
-                                 vmax=vmax, cmap=cmap, outlines=outlines,
+        _plot_topomap_multi_cbar(data, pos, ax, vmin=vmin, vmax=vmax,
+                                 title=title, cmap=cmap, outlines=outlines,
                                  colorbar=True, unit=unit, cbar_fmt=cbar_fmt,
                                  sphere=sphere)
     tight_layout(fig=fig)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1957,12 +1957,17 @@ def plot_psds_topomap(
     vmax : None
         Deprecated; use ``vlim`` instead.
     bands : list of tuple | None
-        The lower and upper frequency and the name for that band. If None,
-        (default) expands to:
+        The frequencies or frequency ranges to plot. Length-2 tuples specify
+        a single frequency and a subplot title (e.g.,
+        ``(6.5, 'presentation rate')``); length-3 tuples specify lower and
+        upper band edges and a subplot title. If ``None`` (the default),
+        expands to:
 
             bands = [(0, 4, 'Delta'), (4, 8, 'Theta'), (8, 12, 'Alpha'),
                      (12, 30, 'Beta'), (30, 45, 'Gamma')]
 
+        In bands where a single frequency is provided, the topomap will reflect
+        the single frequency bin that is closest to the provided value.
     cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
         Colormap to use. If tuple, the first value indicates the colormap to
         use and the second value is a boolean defining interactivity. In
@@ -2013,6 +2018,13 @@ def plot_psds_topomap(
     if bands is None:
         bands = [(0, 4, 'Delta'), (4, 8, 'Theta'), (8, 12, 'Alpha'),
                  (12, 30, 'Beta'), (30, 45, 'Gamma')]
+    else:  # upconvert single freqs to band upper/lower edges as needed
+        bin_spacing = np.diff(freqs)[0]
+        bin_edges = np.array([0, bin_spacing]) - bin_spacing / 2
+        for ix, band in enumerate(bands):
+            if len(band) == 2:
+                bin_freq = freqs[np.argmin(np.abs(freqs - band[0]))]
+                bands[ix] = tuple(bin_edges + bin_freq) + (band[-1],)
 
     if agg_fun is None:
         agg_fun = np.sum if normalize else np.mean

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1872,16 +1872,7 @@ def plot_epochs_psd_topomap(epochs, bands=None, vmin=None, vmax=None,
         pairs and the mean for each pair is plotted. If None, then first
         available channel type from order given above is used. Defaults to
         None.
-    cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
-        Colormap to use. If tuple, the first value indicates the colormap to
-        use and the second value is a boolean defining interactivity. In
-        interactive mode the colors are adjustable by clicking and dragging the
-        colorbar with left and right mouse button. Left mouse button moves the
-        scale up and down and right mouse button adjusts the range. Hitting
-        space bar resets the range. Up and down arrows can be used to change
-        the colormap. If None (default), 'Reds' is used for data that is either
-        all-positive or all-negative, otherwise defaults to 'RdBu_r'.
-        ``'interactive'`` is equivalent to ``(None, True)``.
+    %(cmap_psd_topo)s
     agg_fun : callable
         The function used to aggregate over frequencies.
         Defaults to np.sum. if normalize is True, else np.mean.
@@ -1971,16 +1962,7 @@ def plot_psds_topomap(
 
         In bands where a single frequency is provided, the topomap will reflect
         the single frequency bin that is closest to the provided value.
-    cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
-        Colormap to use. If tuple, the first value indicates the colormap to
-        use and the second value is a boolean defining interactivity. In
-        interactive mode the colors are adjustable by clicking and dragging the
-        colorbar with left and right mouse button. Left mouse button moves the
-        scale up and down and right mouse button adjusts the range. Hitting
-        space bar resets the range. Up and down arrows can be used to change
-        the colormap. If None (default), 'Reds' is used for all positive data,
-        otherwise defaults to 'RdBu_r'. If 'interactive', translates to
-        (None, True).
+    %(cmap_psd_topo)s
     dB : bool
         If True, transform data to decibels (with ``10 * np.log10(data)``)
         following the application of `agg_fun`. Only valid if normalize is

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1965,8 +1965,9 @@ def plot_psds_topomap(
         warn(msg, DeprecationWarning)
 
     if bands is None:
-        bands = [(0, 4, 'Delta'), (4, 8, 'Theta'), (8, 12, 'Alpha'),
-                 (12, 30, 'Beta'), (30, 45, 'Gamma')]
+        bands = [(0, 4, 'Delta (0-4 Hz)'), (4, 8, 'Theta (4-8 Hz)'),
+                 (8, 12, 'Alpha (8-12 Hz)'), (12, 30, 'Beta (12-30 Hz)'),
+                 (30, 45, 'Gamma (30-45 Hz)')]
     else:  # upconvert single freqs to band upper/lower edges as needed
         bin_spacing = np.diff(freqs)[0]
         bin_edges = np.array([0, bin_spacing]) - bin_spacing / 2

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1794,13 +1794,14 @@ def _slider_changed(val, ax, data, times, pos, scaling, func, time_format,
         ax.set_title(time_format % (val * scaling_time))
 
 
-def _plot_topomap_multi_cbar(data, pos, ax, vmin, vmax, title=None, unit=None,
-                             cmap=None, outlines='head', colorbar=False,
-                             cbar_fmt='%3.3f', sphere=None):
+def _plot_topomap_multi_cbar(data, pos, ax, title=None, unit=None, vmin=None,
+                             vmax=None, cmap=None, outlines='head',
+                             colorbar=False, cbar_fmt='%3.3f',
+                             sphere=None):
     """Plot topomap multi cbar."""
     _hide_frame(ax)
-    vmin = data.min() if vmin is None else vmin
-    vmax = data.max() if vmax is None else vmax
+    vmin = np.min(data) if vmin is None else vmin
+    vmax = np.max(data) if vmax is None else vmax
     # this definition of "norm" allows non-diverging colormap for cases where
     # min & vmax are both negative (e.g., when they are power in dB)
     signs = np.sign([vmin, vmax])
@@ -2050,8 +2051,8 @@ def plot_psds_topomap(
         else:
             unit = 'power'
 
-        _plot_topomap_multi_cbar(data, pos, ax, vmin=vmin, vmax=vmax,
-                                 title=title, cmap=cmap, outlines=outlines,
+        _plot_topomap_multi_cbar(data, pos, ax, title=title, vmin=vmin,
+                                 vmax=vmax, cmap=cmap, outlines=outlines,
                                  colorbar=True, unit=unit, cbar_fmt=cbar_fmt,
                                  sphere=sphere)
     tight_layout(fig=fig)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2027,7 +2027,7 @@ def plot_psds_topomap(
         agg_fun = np.sum if normalize else np.mean
 
     if normalize:
-        psds /= psds.sum(axis=-1)[..., None]
+        psds /= psds.sum(axis=-1, keepdims=True)
         assert np.allclose(psds.sum(axis=-1), 1.)
 
     n_axes = len(bands)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1919,9 +1919,6 @@ def plot_epochs_psd_topomap(epochs, bands=None, vmin=None, vmax=None,
     if merge_channels:
         psds, names = _merge_ch_data(psds, ch_type, names, method='mean')
 
-    if cbar_fmt == 'auto':
-        cbar_fmt = '%0.1f' if dB else '%0.3f'
-
     return plot_psds_topomap(
         psds=psds, freqs=freqs, pos=pos, agg_fun=agg_fun, vmin=vmin,
         vmax=vmax, bands=bands, cmap=cmap, dB=dB, normalize=normalize,
@@ -1989,6 +1986,9 @@ def plot_psds_topomap(
     """
     import matplotlib.pyplot as plt
     sphere = _check_sphere(sphere)
+
+    if cbar_fmt == 'auto':
+        cbar_fmt = '%0.1f' if dB else '%0.3f'
 
     if vmin is not None or vmax is not None:
         if vlim == (None, None):

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1953,15 +1953,16 @@ def plot_psds_topomap(
         cbar_fmt = '%0.1f' if dB else '%0.3f'
 
     if vmin is not None or vmax is not None:
+        msg = ('"vmin" and "vmax" are deprecated and will be removed in '
+               'version 0.22. Use "vlim" instead. ')
         if vlim == (None, None):
-            msg = ('Since you didn\'t specify "vlim", your provided values of '
-                   '"vmin" and "vmax" will be used.')
+            msg += ('Since you didn\'t specify "vlim", your provided values '
+                    'of "vmin" and "vmax" will be used.')
             vlim = (vmin, vmax)
         else:
-            msg = ('Your provided values for "vlim" will be used, and "vmin" '
-                   'and "vmax" will be ignored.')
-        warn('"vmin" and "vmax" are deprecated in favor of a single argument '
-             '"vlim". ' + msg, DeprecationWarning)
+            msg += ('Your provided values for "vlim" will be used, and "vmin" '
+                    'and "vmax" will be ignored.')
+        warn(msg, DeprecationWarning)
 
     if bands is None:
         bands = [(0, 4, 'Delta'), (4, 8, 'Theta'), (8, 12, 'Alpha'),

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2041,11 +2041,14 @@ def plot_psds_topomap(
 
     # handle vmin/vmax
     if vlim == 'joint':
-        _freq_mask = np.any([(fmin < freqs) & (freqs < fmax)
-                             for (fmin, fmax, _) in bands], axis=0)
-        _data = 10 * np.log10(psds) if dB and not normalize else psds
-        vmin = _data[:, _freq_mask].min()
-        vmax = _data[:, _freq_mask].max()
+        _freq_masks = [(fmin < freqs) & (freqs < fmax)
+                       for (fmin, fmax, _) in bands]
+        _datas = [agg_fun(psds[:, _freq_mask], axis=1)
+                  for _freq_mask in _freq_masks]
+        _datas = [10 * np.log10(_d) if (dB and not normalize) else _d
+                  for _d in _datas]
+        vmin = np.array(_datas).min()
+        vmax = np.array(_datas).max()
     else:
         vmin, vmax = vlim
 

--- a/tutorials/epochs/plot_20_visualize_epochs.py
+++ b/tutorials/epochs/plot_20_visualize_epochs.py
@@ -189,7 +189,7 @@ epochs['auditory'].plot_image(picks='mag', combine='mean')
 # plot the global field power (useful for combining sensors that respond with
 # opposite polarity).
 
-# sphinx_gallery_thumbnail_number = 12
+# sphinx_gallery_thumbnail_number = 10
 epochs['auditory'].plot_image(picks=['MEG 0242', 'MEG 0243'])
 epochs['auditory'].plot_image(picks=['MEG 0242', 'MEG 0243'], combine='gfp')
 

--- a/tutorials/epochs/plot_20_visualize_epochs.py
+++ b/tutorials/epochs/plot_20_visualize_epochs.py
@@ -131,6 +131,32 @@ epochs.plot_sensors(kind='topomap', ch_type='all')
 epochs['auditory'].plot_psd(picks='eeg')
 
 ###############################################################################
+# It is also possible to plot spectral estimates across sensors as a scalp
+# topography, using :meth:`~mne.Epochs.plot_psd_topomap`. The default
+# parameters will plot five frequency bands (δ, θ, α, β, γ), and will plot
+# the power estimates in decibels:
+
+epochs['visual/right'].plot_psd_topomap()
+
+###############################################################################
+# Just like :meth:`~mne.Epochs.plot_projs_topomap`,
+# :meth:`~mne.Epochs.plot_psd_topomap` has a ``vlim='joint'`` option for fixing
+# the colorbar limits jointly across all subplots, to give a better sense of
+# the relative magnitude in each band. If you want to view different frequency
+# bands than the defaults, the ``bands`` parameter takes a list of tuples, with
+# each tuple containing either a single frequency and a subplot title, or
+# lower/upper frequency limits and a subplot title:
+
+bands = [(10, '10 Hz'), (15, '15 Hz'), (20, '20 Hz'), (10, 20, '10-20 Hz')]
+epochs['visual/right'].plot_psd_topomap(bands=bands, vlim='joint')
+
+###############################################################################
+# If you prefer untransformed power estimates, you can pass ``dB=False``. It is
+# also possible to normalize the power estimates by dividing by the total power
+# across all frequencies, by passing ``normalize=True``. See the docstring of
+# :meth:`~mne.Epochs.plot_psd_topomap` for details.
+#
+#
 # Plotting ``Epochs`` as an image map
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
@@ -163,7 +189,7 @@ epochs['auditory'].plot_image(picks='mag', combine='mean')
 # plot the global field power (useful for combining sensors that respond with
 # opposite polarity).
 
-# sphinx_gallery_thumbnail_number = 8
+# sphinx_gallery_thumbnail_number = 12
 epochs['auditory'].plot_image(picks=['MEG 0242', 'MEG 0243'])
 epochs['auditory'].plot_image(picks=['MEG 0242', 'MEG 0243'], combine='gfp')
 

--- a/tutorials/epochs/plot_20_visualize_epochs.py
+++ b/tutorials/epochs/plot_20_visualize_epochs.py
@@ -133,8 +133,9 @@ epochs['auditory'].plot_psd(picks='eeg')
 ###############################################################################
 # It is also possible to plot spectral estimates across sensors as a scalp
 # topography, using :meth:`~mne.Epochs.plot_psd_topomap`. The default
-# parameters will plot five frequency bands (δ, θ, α, β, γ), and will plot
-# the power estimates in decibels:
+# parameters will plot five frequency bands (δ, θ, α, β, γ), will compute power
+# based on magnetometer channels, and will plot the power estimates in
+# decibels:
 
 epochs['visual/right'].plot_psd_topomap()
 
@@ -142,13 +143,15 @@ epochs['visual/right'].plot_psd_topomap()
 # Just like :meth:`~mne.Epochs.plot_projs_topomap`,
 # :meth:`~mne.Epochs.plot_psd_topomap` has a ``vlim='joint'`` option for fixing
 # the colorbar limits jointly across all subplots, to give a better sense of
-# the relative magnitude in each band. If you want to view different frequency
-# bands than the defaults, the ``bands`` parameter takes a list of tuples, with
-# each tuple containing either a single frequency and a subplot title, or
-# lower/upper frequency limits and a subplot title:
+# the relative magnitude in each band. You can change which channel type is
+# used  via the ``ch_type`` parameter, and if you want to view different
+# frequency bands than the defaults, the ``bands`` parameter takes a list of
+# tuples, with each tuple containing either a single frequency and a subplot
+# title, or lower/upper frequency limits and a subplot title:
 
 bands = [(10, '10 Hz'), (15, '15 Hz'), (20, '20 Hz'), (10, 20, '10-20 Hz')]
-epochs['visual/right'].plot_psd_topomap(bands=bands, vlim='joint')
+epochs['visual/right'].plot_psd_topomap(bands=bands, vlim='joint',
+                                        ch_type='grad')
 
 ###############################################################################
 # If you prefer untransformed power estimates, you can pass ``dB=False``. It is


### PR DESCRIPTION
closes #7586 

- [x] allow `epochs.plot_psd_topomap(..., vlim='joint')`
- [x] ~~allow logarithmic colormap~~ YAGNI: already a parameter `dB=True`
- [x] make single-frequency-bin band selection easy
- [x] test `vlim='joint'`
- [x] ~~test logarithmic colormap~~ YAGNI
- [x] test single-bin selection
- [x] update example/tutorial to demo new features
- [x] add `cbar_fmt='auto'` to show fewer decimals for dB scale
- [x] don't default to RdBu_r colormap: power is one-sided