### PR TITLE
ENH: Allow path-like values passed to set_config

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -54,6 +54,7 @@ Bug
 
 - Fix bug with :func:`mne.io.read_raw_edf` where recording ID was not read properly for non-ASCII characters by `Lx37`_
 
+- Make :func:`mne.set_config` accept arbitrary input values as long as they can be represented as a string by `Richard Höchenberger`_
 
 API
 ~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -54,7 +54,7 @@ Bug
 
 - Fix bug with :func:`mne.io.read_raw_edf` where recording ID was not read properly for non-ASCII characters by `Lx37`_
 
-- Make :func:`mne.set_config` accept arbitrary input values as long as they can be represented as a string by `Richard Höchenberger`_
+- Make :func:`mne.set_config` accept path-like input values by `Richard Höchenberger`_
 
 API
 ~~~

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -263,8 +263,9 @@ def set_config(key, value, home_dir=None, set_env=True):
     _validate_type(key, 'str', "key")
     # While JSON allow non-string types, we allow users to override config
     # settings using env, which are strings, so we enforce that here
-    _validate_type(value, (str, type(None)), "value",
-                   "None or string")
+    _validate_type(value, (str, 'path-like', type(None)), 'value')
+    if value is not None:
+        value = str(value)
 
     if key not in known_config_types and not \
             any(k in key for k in known_config_wildcards):

--- a/mne/utils/tests/test_config.py
+++ b/mne/utils/tests/test_config.py
@@ -1,6 +1,7 @@
 from io import StringIO
 import os
 import pytest
+from pathlib import Path
 
 from mne.utils import (set_config, get_config, get_config_path,
                        set_memmap_min_size, _get_stim_channel, sys_info)
@@ -12,6 +13,8 @@ def test_config(tmpdir):
     key = '_MNE_PYTHON_CONFIG_TESTING'
     value = '123456'
     value2 = '123'
+    value3 = Path('/foo/bar')
+
     old_val = os.getenv(key, None)
     os.environ[key] = value
     assert (get_config(key) == value)
@@ -35,6 +38,11 @@ def test_config(tmpdir):
     assert (key not in os.environ)
     if old_val is not None:
         os.environ[key] = old_val
+
+    # Check serialization from Path to string
+    with pytest.warns(RuntimeWarning, match='non-standard'):
+        set_config(key, value3, home_dir=tempdir)
+
     # Check if get_config with key=None returns all config
     key = 'MNE_PYTHON_TESTING_KEY'
     assert key not in get_config(home_dir=tempdir)


### PR DESCRIPTION
#### Reference issue
Fixes #7622


#### What does this implement/fix?
Allows to pass<strike> arbitrary</strike> `path-like` values to `set_config` <strike>as long as they're `None` or can be cast into a string. No further type checking is performed.</strike>

#### Additional information
<strike>Also this PR includes a small fix to the `config` test suite, as one of the tests was expecting a `TypeError`, while in fact a `RuntimeWarning` is raised.</strike>