### PR TITLE
FIX: Circle timeout after plot_visualize_stc

### DIFF
--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -13,11 +13,10 @@ import sys
 
 import numpy as np
 
-from . import _Brain
 from ..utils import _check_option, _show_help, _get_color_list, tight_layout
 from ...externals.decorator import decorator
 from ...source_space import vertex_to_mni
-from ...utils import _ReuseCycle, warn, copy_doc
+from ...utils import _ReuseCycle, warn
 
 
 @decorator
@@ -362,8 +361,6 @@ class _TimeViewer(object):
         # Direct access parameters:
         self.brain = brain
         self.brain.time_viewer = self
-        self.brain._save_movie = self.brain.save_movie
-        self.brain.save_movie = self.save_movie
         self.plotter = brain._renderer.plotter
         self.main_menu = self.plotter.main_menu
         self.window = self.plotter.app_window
@@ -467,7 +464,7 @@ class _TimeViewer(object):
         self.interactor.setCursor(QCursor(Qt.WaitCursor))
 
         try:
-            self.brain._save_movie(
+            self.brain.save_movie(
                 filename=filename,
                 time_dilation=(1. / self.playback_speed),
                 callback=frame_callback,
@@ -481,7 +478,6 @@ class _TimeViewer(object):
         # restore cursor
         self.interactor.setCursor(default_cursor)
 
-    @copy_doc(_Brain.save_movie)
     def save_movie(self, filename=None, **kwargs):
         from pyvista.plotting.qt_plotting import FileDialog
 

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -660,6 +660,7 @@ class _TimeViewer(object):
         # Playback speed slider
         if time_slider is None:
             self.playback_speed_call = None
+            playback_speed_slider = None
         else:
             self.playback_speed_call = SmartSlider(
                 plotter=self.plotter,

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -13,10 +13,11 @@ import sys
 
 import numpy as np
 
+from . import _Brain
 from ..utils import _check_option, _show_help, _get_color_list, tight_layout
 from ...externals.decorator import decorator
 from ...source_space import vertex_to_mni
-from ...utils import _ReuseCycle, warn
+from ...utils import _ReuseCycle, warn, copy_doc
 
 
 @decorator
@@ -361,6 +362,9 @@ class _TimeViewer(object):
         # Direct access parameters:
         self.brain = brain
         self.brain.time_viewer = self
+        # replace brain's save_movie function
+        self.brain._save_movie = self.brain.save_movie
+        self.brain.save_movie = self.save_movie
         self.plotter = brain._renderer.plotter
         self.main_menu = self.plotter.main_menu
         self.window = self.plotter.app_window
@@ -478,6 +482,7 @@ class _TimeViewer(object):
         # restore cursor
         self.interactor.setCursor(default_cursor)
 
+    @copy_doc(_Brain.save_movie)
     def save_movie(self, filename=None, **kwargs):
         from pyvista.plotting.qt_plotting import FileDialog
 
@@ -1098,6 +1103,10 @@ class _TimeViewer(object):
 
     @safe_event
     def clean(self):
+        # restore brain's save_movie function
+        self.brain.save_movie = self.brain._save_movie
+        self.brain._save_movie = None
+
         # resolve the reference cycle
         self.clear_points()
         self.actions.clear()

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -468,7 +468,7 @@ class _TimeViewer(object):
         self.interactor.setCursor(QCursor(Qt.WaitCursor))
 
         try:
-            self.brain.save_movie(
+            self.brain._save_movie(
                 filename=filename,
                 time_dilation=(1. / self.playback_speed),
                 callback=frame_callback,

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -325,9 +325,6 @@ class _TimeViewer(object):
         # Direct access parameters:
         self.brain = brain
         self.brain.time_viewer = self
-        # replace brain's save_movie function
-        self.brain._save_movie = self.brain.save_movie
-        self.brain.save_movie = self.save_movie
         self.plotter = brain._renderer.plotter
         self.main_menu = self.plotter.main_menu
         self.window = self.plotter.app_window
@@ -431,7 +428,7 @@ class _TimeViewer(object):
         self.interactor.setCursor(QCursor(Qt.WaitCursor))
 
         try:
-            self.brain._save_movie(
+            self.brain.save_movie(
                 filename=filename,
                 time_dilation=(1. / self.playback_speed),
                 callback=frame_callback,
@@ -1073,10 +1070,6 @@ class _TimeViewer(object):
 
     @safe_event
     def clean(self):
-        # restore brain's save_movie function
-        self.brain.save_movie = self.brain._save_movie
-        self.brain._save_movie = None
-
         # resolve the reference cycle
         self.clear_points()
         self.actions.clear()


### PR DESCRIPTION
I realized that since #7612 has been merged, Circle reaches timeout after `plot_visualize_stc`. I can't reproduce locally so I decided to investigate in here.

- [x] Find that the issue is related to the wrapping of `_Brain.save_movie`
- [ ] Resolve `save_movie` reference cycle (waiting for CircleCI)
- [x] Fix `UnboundLocalError`: `playback_speed_slider` used without being declared