### PR TITLE
MRG, ENH: Add volumetric atlas support

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -25,7 +25,7 @@ Changelog
 
 - Add :meth:`mne.MixedSourceEstimate.surface` and :meth:`mne.MixedSourceEstimate.volume` methods to allow surface and volume extraction by `Eric Larson`_
 
-- Add support to :func:`mne.extract_label_time_course` for vector-valued :class:`VectorSourceEstimate` and :class:`mne.MixedVectorSourceEstimate` by `Eric Larson`_
+- Add support to :func:`mne.extract_label_time_course` for vector-valued and volumetric source estimates by `Eric Larson`_
 
 - Allow resampling raw data with :func:`mne.io.Raw.resample` without preloading data, by `Eric Larson`_
 
@@ -91,6 +91,8 @@ Bug
 - Fix bug with :func:`mne.io.read_raw_gdf` where birthdays were not parsed properly, leading to an error by `Svea Marie Meyer`_
 
 - Fix bug with :func:`mne.io.read_raw_edf` where recording ID was not read properly for non-ASCII characters by `Lx37`_
+
+- Fix bug with :func:`mne.get_volume_labels_from_aseg` where the returned labels were alphabetical instead of reflecting their volumetric ID-based order by `Eric Larson`_
 
 - Make :func:`mne.set_config` accept path-like input values by `Richard Höchenberger`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -27,6 +27,8 @@ Changelog
 
 - Add support to :func:`mne.extract_label_time_course` for vector-valued and volumetric source estimates by `Eric Larson`_
 
+- Add method :meth:`mne.VolSourceEstimate.in_label` by `Eric Larson`_
+
 - Allow resampling raw data with :func:`mne.io.Raw.resample` without preloading data, by `Eric Larson`_
 
 - Allow using ``pick_ori='vector'`` with a fixed-orientation inverse to facilitate visualization with :func:`mne.viz.plot_vector_source_estimates` by `Eric Larson`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -35,6 +35,8 @@ Changelog
 
 - Added temporal derivative distribution repair :func:`mne.preprocessing.nirs.temporal_derivative_distribution_repair` by `Robert Luke`_
 
+- Add :func:`mne.read_freesurfer_lut` to make it easier to work with volume atlases by `Eric Larson`_
+
 - Add functionality to interpolate bad NIRS channels by `Robert Luke`_
 
 - Add support to in :meth:`mne.io.Raw.plot` for passing ``clipping`` as a float to clip to a proportion of the dedicated channel range by `Eric Larson`_

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -118,6 +118,7 @@ File I/O
    read_events
    read_evokeds
    read_evoked_fieldtrip
+   read_freesurfer_lut
    read_forward_solution
    read_label
    read_morph_map

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -72,7 +72,7 @@ from .source_space import (read_source_spaces, vertex_to_mni,
                            setup_volume_source_space, SourceSpaces,
                            add_source_space_distances, morph_source_spaces,
                            get_volume_labels_from_aseg,
-                           get_volume_labels_from_src)
+                           get_volume_labels_from_src, read_freesurfer_lut)
 from .annotations import (Annotations, read_annotations, annotations_from_events,
                           events_from_annotations)
 from .epochs import (BaseEpochs, Epochs, EpochsArray, read_epochs,

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -368,7 +368,8 @@ def src_volume_labels():
     atlas_ids = mne.read_freesurfer_lut()[0]
     src = mne.setup_volume_source_space(
         'sample', 7., mri='aseg.mgz', volume_label=volume_labels,
-        add_interpolator=False, bem=fname_bem, atlas_ids=atlas_ids)
+        add_interpolator=False, bem=fname_bem, atlas_ids=atlas_ids,
+        subjects_dir=subjects_dir)
     lut, _ = mne.read_freesurfer_lut()
     assert len(volume_labels) == 46
     assert volume_labels[0] == 'Unknown'

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -33,8 +33,11 @@ s_path = op.join(test_path, 'MEG', 'sample')
 fname_evoked = op.join(s_path, 'sample_audvis_trunc-ave.fif')
 fname_cov = op.join(s_path, 'sample_audvis_trunc-cov.fif')
 fname_fwd = op.join(s_path, 'sample_audvis_trunc-meg-eeg-oct-4-fwd.fif')
+bem_path = op.join(test_path, 'subjects', 'sample', 'bem')
+fname_bem = op.join(bem_path, 'sample-1280-bem.fif')
+fname_aseg = op.join(test_path, 'subjects', 'sample', 'mri', 'aseg.mgz')
 subjects_dir = op.join(test_path, 'subjects')
-fname_src = op.join(subjects_dir, 'sample', 'bem', 'sample-oct-4-src.fif')
+fname_src = op.join(bem_path, 'sample-oct-4-src.fif')
 subjects_dir = op.join(test_path, 'subjects')
 fname_cov = op.join(s_path, 'sample_audvis_trunc-cov.fif')
 fname_trans = op.join(s_path, 'sample_audvis_trunc-trans.fif')
@@ -353,3 +356,21 @@ def all_src_types_inv_evoked(_all_src_types_inv_evoked):
     invs = {key: val.copy() for key, val in invs.items()}
     evoked = evoked.copy()
     return invs, evoked
+
+
+@pytest.fixture(scope='session')
+@pytest.mark.slowtest
+@pytest.mark.parametrize(params=[testing._pytest_param()])
+def src_volume_labels():
+    """Create a 7mm source space with labels."""
+    volume_labels = mne.get_volume_labels_from_aseg(fname_aseg)
+    # providing the IDs makes things a tiny bit faster
+    atlas_ids = mne.read_freesurfer_lut()[0]
+    src = mne.setup_volume_source_space(
+        'sample', 7., mri='aseg.mgz', volume_label=volume_labels,
+        add_interpolator=False, bem=fname_bem, atlas_ids=atlas_ids)
+    lut, _ = mne.read_freesurfer_lut()
+    assert len(volume_labels) == 46
+    assert volume_labels[0] == 'Unknown'
+    assert lut['Unknown'] == 0  # it will be excluded during label gen
+    return src, tuple(volume_labels)

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -364,14 +364,12 @@ def all_src_types_inv_evoked(_all_src_types_inv_evoked):
 def src_volume_labels():
     """Create a 7mm source space with labels."""
     volume_labels = mne.get_volume_labels_from_aseg(fname_aseg)
-    # providing the IDs makes things a tiny bit faster
-    atlas_ids = mne.read_freesurfer_lut()[0]
     src = mne.setup_volume_source_space(
         'sample', 7., mri='aseg.mgz', volume_label=volume_labels,
-        add_interpolator=False, bem=fname_bem, atlas_ids=atlas_ids,
+        add_interpolator=False, bem=fname_bem,
         subjects_dir=subjects_dir)
     lut, _ = mne.read_freesurfer_lut()
     assert len(volume_labels) == 46
     assert volume_labels[0] == 'Unknown'
     assert lut['Unknown'] == 0  # it will be excluded during label gen
-    return src, tuple(volume_labels)
+    return src, tuple(volume_labels), lut

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -736,7 +736,7 @@ def _make_guesses(surf, grid, exclude, mindist, n_jobs=1, verbose=None):
                     % (1000 * surf['R']))
     logger.info('Filtering (grid = %6.f mm)...' % (1000 * grid))
     src = _make_volume_source_space(surf, grid, exclude, 1000 * mindist,
-                                    do_neighbors=False, n_jobs=n_jobs)
+                                    do_neighbors=False, n_jobs=n_jobs)[0]
     assert 'vertno' in src
     # simplify the result to make things easier later
     src = dict(rr=src['rr'][src['vertno']], nn=src['nn'][src['vertno']],

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -298,12 +298,12 @@ def test_make_forward_solution_sphere(tmpdir):
 def test_forward_mixed_source_space(tmpdir):
     """Test making the forward solution for a mixed source space."""
     # get the surface source space
+    rng = np.random.RandomState(0)
     surf = read_source_spaces(fname_src)
 
     # setup two volume source spaces
     label_names = get_volume_labels_from_aseg(fname_aseg)
-    vol_labels = [label_names[int(np.random.rand() * len(label_names))]
-                  for _ in range(2)]
+    vol_labels = rng.choice(label_names, 2)
     vol1 = setup_volume_source_space('sample', pos=20., mri=fname_aseg,
                                      volume_label=vol_labels[0],
                                      add_interpolator=False)

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1638,12 +1638,16 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
         if hemi == 'lh':
             use = self.__class__(
                 self.lh_data, [self.vertices[0], []], self.tmin, self.tstep)
+            meth = use.get_peak
         elif hemi == 'rh':
             use = self.__class__(
                 self.rh_data, [[], self.vertices[1]], self.tmin, self.tstep)
+            meth = use.get_peak
         else:
-            use = self
-        return use.get_peak(tmin, tmax, mode, vert_as_index, time_as_index)
+            meth = super().get_peak
+        return meth(tmin=tmin, tmax=tmax, mode=mode,
+                    vert_as_index=vert_as_index,
+                    time_as_index=time_as_index)
 
     @fill_doc
     def center_of_mass(self, subject=None, hemi=None, restrict_vertices=False,
@@ -2806,11 +2810,11 @@ def _gen_extract_label_time_course(stcs, labels, src, mode='mean',
                 label_tc[i] = func(flip, stc.data[vertidx])
 
         # extract label time series for the vol src space (only mean supported)
-        offset = nvert[:-n_aseg].sum()  # effectively :2 or :0
+        offset = nvert[:-n_mean].sum()  # effectively :2 or :0
         for i, nv in enumerate(nvert[2:]):
             if nv != 0:
                 v2 = offset + nv
-                label_tc[n_aparc + i] = np.mean(stc.data[offset:v2], axis=0)
+                label_tc[n_mode + i] = np.mean(stc.data[offset:v2], axis=0)
                 offset = v2
 
         # this is a generator!

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1842,7 +1842,8 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
         """
         return extract_label_time_course(
             self, labels, src, mode=mode, return_generator=False,
-            allow_empty=allow_empty, verbose=verbose)
+            allow_empty=allow_empty, trans=trans,
+            mri_resolution=mri_resolution, verbose=verbose)
 
     @fill_doc
     def in_label(self, label, mri, src, trans=None):

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1553,7 +1553,7 @@ def _check_mri(mri, subject, subjects_dir):
     return mri
 
 
-#@verbose
+@verbose
 def setup_volume_source_space(subject=None, pos=5.0, mri=None,
                               sphere=None, bem=None,
                               surface=None, mindist=5.0, exclude=0.0,

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1710,7 +1710,6 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
                              'discrete source space, mri must be None if '
                              'pos is a dict')
 
-    clean_atlas = False
     if volume_label is not None:
         volume_label = _check_volume_labels(volume_label, mri)
     assert volume_label is None or isinstance(volume_label, dict)

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -2613,6 +2613,9 @@ def get_volume_labels_from_aseg(mgz_fname, return_colors=False):
 
     Notes
     -----
+    .. versionchanged:: 0.21.0
+       The label names are now sorted in the same order as their corresponding
+       values in the MRI file.
     .. versionadded:: 0.9.0
     """
     import nibabel as nib
@@ -2621,7 +2624,8 @@ def get_volume_labels_from_aseg(mgz_fname, return_colors=False):
     ids, colors = read_freesurfer_lut()
     # restrict to the ones in the MRI, sorted by label name
     keep = np.in1d(list(ids.values()), want)
-    keys = sorted(key for ki, key in enumerate(colors.keys()) if keep[ki])
+    keys = sorted((key for ki, key in enumerate(colors.keys()) if keep[ki]),
+                  key=lambda x: ids[x])
     colors = [colors[k] for k in keys]
     if return_colors:
         out = keys, colors

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1767,7 +1767,7 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
         logger.info('MRI volume            : %s' % mri)
         logger.info('')
         logger.info('Reading %s...' % mri)
-        vol_info.update(_get_mri_info_data(mri, data=volume_label is not None))
+        vol_info = _get_mri_info_data(mri, data=volume_label is not None)
 
     exclude /= 1000.0  # convert exclude from m to mm
     logger.info('')

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -559,7 +559,7 @@ def test_volume_labels_morph(tmpdir):
     evoked.info.normalize_proj()
     n_ch = len(evoked.ch_names)
     aseg_fname = op.join(subjects_dir, 'sample', 'mri', 'aseg.mgz')
-    label_names = get_volume_labels_from_aseg(aseg_fname)
+    label_names = sorted(get_volume_labels_from_aseg(aseg_fname))
     src = setup_volume_source_space(
         'sample', subjects_dir=subjects_dir, volume_label=label_names[:2],
         mri=aseg_fname)

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -26,8 +26,7 @@ from mne import (stats, SourceEstimate, VectorSourceEstimate,
 from mne.datasets import testing
 from mne.fixes import fft, _get_img_fdata
 from mne.source_estimate import grade_to_tris, _get_vol_mask
-from mne.source_space import (_get_src_nn, get_volume_labels_from_aseg,
-                              read_freesurfer_lut)
+from mne.source_space import _get_src_nn
 from mne.minimum_norm import (read_inverse_operator, apply_inverse,
                               apply_inverse_epochs, make_inverse_operator)
 from mne.label import read_labels_from_annot, label_sign_flip
@@ -49,8 +48,6 @@ fname_cov = op.join(
 fname_evoked = op.join(data_path, 'MEG', 'sample',
                        'sample_audvis_trunc-ave.fif')
 fname_raw = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc_raw.fif')
-fname_bem = op.join(
-    data_path, 'subjects', 'sample', 'bem', 'sample-1280-bem.fif')
 fname_t1 = op.join(data_path, 'subjects', 'sample', 'mri', 'T1.mgz')
 fname_fs_t1 = op.join(data_path, 'subjects', 'fsaverage', 'mri', 'T1.mgz')
 fname_aseg = op.join(data_path, 'subjects', 'sample', 'mri', 'aseg.mgz')
@@ -646,22 +643,7 @@ def test_extract_label_time_course(kind, vector):
     assert (x.size == 0)
 
 
-@pytest.fixture(scope='module')
-@pytest.mark.parametrize(params=[testing._pytest_param()])
-def src_volume_labels():
-    """Create a 7mm source space with labels."""
-    volume_labels = get_volume_labels_from_aseg(fname_aseg)
-    src = setup_volume_source_space(
-        'sample', 7., mri='aseg.mgz', volume_label=volume_labels,
-        add_interpolator=False, bem=fname_bem)
-    lut, _ = read_freesurfer_lut()
-    assert len(volume_labels) == 46
-    assert volume_labels[0] == 'Unknown'
-    assert lut['Unknown'] == 0  # it will be excluded during label gen
-    return src, volume_labels
-
-
-@pytest.mark.slowtest  # ~3 sec to generate the vol above ...
+# XXX need two modes: nearest and interp (probably)
 @pytest.mark.parametrize('vector', (False, True))
 def test_extract_label_time_course_volume(vector, src_volume_labels):
     """Test extraction of label time courses from Vol(Vector)SourceEstimate."""

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -566,8 +566,8 @@ def test_read_freesurfer_lut(fname):
 
 @testing.requires_testing_data
 @requires_nibabel()
-@pytest.mark.parametrize('pass_atlas_ids', (True, False))
-def test_source_space_from_label(tmpdir, pass_atlas_ids):
+@pytest.mark.parametrize('pass_ids', (True, False))
+def test_source_space_from_label(tmpdir, pass_ids):
     """Test generating a source space from volume label."""
     aseg_short = 'aseg.mgz'
     atlas_ids, _ = read_freesurfer_lut()
@@ -581,27 +581,28 @@ def test_source_space_from_label(tmpdir, pass_atlas_ids):
             subjects_dir=subjects_dir)
 
     # Test T1.mgz provided
-    with pytest.raises(RuntimeError, match='consider passing mri="aseg.mgz"'):
+    with pytest.raises(RuntimeError, match=r'Must use a \*aseg.mgz file'):
         setup_volume_source_space(
             'sample', mri='T1.mgz', volume_label=volume_label,
             subjects_dir=subjects_dir)
 
     # Test invalid volume label
-    if pass_atlas_ids:
-        match = "'Hello World!' not found in atlas_ids"
-    else:
-        atlas_ids = None
-        match = "'Hello World!' not found in file"
     mri = aseg_short
-    with pytest.raises(ValueError, match=match):
+    with pytest.raises(ValueError, match="'Left-Cerebral' not found.*Did you"):
         setup_volume_source_space(
-            'sample', volume_label='Hello World!', mri=mri,
-            atlas_ids=atlas_ids, subjects_dir=subjects_dir)
+            'sample', volume_label='Left-Cerebral', mri=mri,
+            subjects_dir=subjects_dir)
+
+    # These should be equivalent
+    if pass_ids:
+        use_volume_label = {volume_label: atlas_ids[volume_label]}
+    else:
+        use_volume_label = volume_label
 
     # ensure it works even when not provided (detect that it should be aseg)
     src = setup_volume_source_space(
-        'sample', volume_label=volume_label, add_interpolator=False,
-        atlas_ids=atlas_ids, subjects_dir=subjects_dir)
+        'sample', volume_label=use_volume_label, add_interpolator=False,
+        subjects_dir=subjects_dir)
     assert_equal(volume_label, src[0]['seg_name'])
     assert src[0]['nuse'] == 404  # for our given pos and label
 
@@ -616,7 +617,7 @@ def test_source_space_exclusive_complete(src_volume_labels):
     """Test that we produce exclusive and complete labels."""
     # these two are neighbors and are quite large, so let's use them to
     # ensure no overlaps
-    src, volume_labels = src_volume_labels
+    src, volume_labels, _ = src_volume_labels
     ii = volume_labels.index('Left-Cerebral-White-Matter')
     jj = volume_labels.index('Left-Cerebral-Cortex')
     assert src[ii]['nuse'] == 755  # 2034 with pos=5, was 2832

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -18,7 +18,7 @@ from mne import (read_source_spaces, vertex_to_mni, write_source_spaces,
                  add_source_space_distances, read_bem_surfaces,
                  morph_source_spaces, SourceEstimate, make_sphere_model,
                  head_to_mni, read_trans, compute_source_morph,
-                 read_bem_solution)
+                 read_bem_solution, read_freesurfer_lut)
 from mne.utils import (requires_nibabel, run_subprocess,
                        modified_env, requires_mne, run_tests_if_main,
                        check_version)
@@ -543,39 +543,67 @@ def test_vertex_to_mni_fs_nibabel(monkeypatch):
     assert_allclose(coords, coords_2, atol=0.1)
 
 
-@testing.requires_testing_data
-@requires_nibabel()
-def test_get_volume_label_names():
+@pytest.mark.parametrize('fname', [
+    None,
+    op.join(op.dirname(mne.__file__), 'data', 'FreeSurferColorLUT.txt'),
+])
+def test_read_freesurfer_lut(fname):
     """Test reading volume label names."""
+    lut, colors = read_freesurfer_lut(fname)
+    assert list(lut).count('Brain-Stem') == 1
+    assert len(colors) == len(lut) == 1266
     aseg_fname = op.join(subjects_dir, 'sample', 'mri', 'aseg.mgz')
-    label_names, label_colors = get_volume_labels_from_aseg(aseg_fname,
-                                                            return_colors=True)
-    assert_equal(label_names.count('Brain-Stem'), 1)
-
-    assert_equal(len(label_colors), len(label_names))
+    label_names, label_colors = get_volume_labels_from_aseg(
+        aseg_fname, return_colors=True)
+    assert isinstance(label_names, list)
+    assert isinstance(label_colors, list)
+    assert label_names.count('Brain-Stem') == 1
+    for c in label_colors:
+        assert isinstance(c, np.ndarray)
+        assert c.shape == (4,)
+    assert len(label_names) == len(label_colors) == 46
 
 
 @testing.requires_testing_data
 @requires_nibabel()
-def test_source_space_from_label(tmpdir):
+@pytest.mark.parametrize('pass_atlas_ids', (True, False))
+def test_source_space_from_label(tmpdir, pass_atlas_ids):
     """Test generating a source space from volume label."""
-    aseg_fname = op.join(subjects_dir, 'sample', 'mri', 'aseg.mgz')
-    label_names = get_volume_labels_from_aseg(aseg_fname)
-    volume_label = label_names[int(np.random.rand() * len(label_names))]
+    aseg_short = 'aseg.mgz'
+    atlas_ids, _ = read_freesurfer_lut()
+    volume_label = 'Left-Cerebellum-Cortex'
 
     # Test pos as dict
     pos = dict()
-    pytest.raises(ValueError, setup_volume_source_space, 'sample', pos=pos,
-                  volume_label=volume_label, mri=aseg_fname)
+    with pytest.raises(ValueError, match='mri must be None if pos is a dict'):
+        setup_volume_source_space(
+            'sample', pos=pos, volume_label=volume_label, mri=aseg_short,
+            subjects_dir=subjects_dir)
+
+    # Test T1.mgz provided
+    with pytest.raises(RuntimeError, match='consider passing mri="aseg.mgz"'):
+        setup_volume_source_space(
+            'sample', mri='T1.mgz', volume_label=volume_label,
+            subjects_dir=subjects_dir)
 
     # Test invalid volume label
-    pytest.raises(ValueError, setup_volume_source_space, 'sample',
-                  volume_label='Hello World!', mri=aseg_fname)
+    if pass_atlas_ids:
+        match = "'Hello World!' not found in atlas_ids"
+    else:
+        atlas_ids = None
+        match = "'Hello World!' not found in file"
+    mri = aseg_short
+    with pytest.raises(ValueError, match=match):
+        setup_volume_source_space(
+            'sample', volume_label='Hello World!', mri=mri,
+            atlas_ids=atlas_ids, subjects_dir=subjects_dir)
 
-    src = setup_volume_source_space('sample', subjects_dir=subjects_dir,
-                                    volume_label=volume_label, mri=aseg_fname,
-                                    add_interpolator=False)
+    # ensure it works even when not provided (detect that it should be aseg)
+    src = setup_volume_source_space(
+        'sample', volume_label=volume_label, add_interpolator=False,
+        atlas_ids=atlas_ids, subjects_dir=subjects_dir)
     assert_equal(volume_label, src[0]['seg_name'])
+    assert src[0]['nuse'] == 404  # for our given pos and label
 
     # test reading and writing
     out_name = tmpdir.join('temp-src.fif')
@@ -644,10 +672,10 @@ def test_read_volume_from_src():
 @requires_nibabel()
 def test_combine_source_spaces(tmpdir):
     """Test combining source spaces."""
+    rng = np.random.RandomState(0)
     aseg_fname = op.join(subjects_dir, 'sample', 'mri', 'aseg.mgz')
     label_names = get_volume_labels_from_aseg(aseg_fname)
-    volume_labels = [label_names[int(np.random.rand() * len(label_names))]
-                     for ii in range(2)]
+    volume_labels = rng.choice(label_names, 2)
 
     # get a surface source space (no need to test creation here)
     srf = read_source_spaces(fname, patch_stats=False)

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -619,13 +619,15 @@ def test_source_space_exclusive_complete(src_volume_labels):
     src, volume_labels = src_volume_labels
     ii = volume_labels.index('Left-Cerebral-White-Matter')
     jj = volume_labels.index('Left-Cerebral-Cortex')
-    assert src[ii]['nuse'] == 786  # 2034 with pos=5, was 2832
-    assert src[jj]['nuse'] == 618  # 1520 with pos=5, was 2623
+    assert src[ii]['nuse'] == 755  # 2034 with pos=5, was 2832
+    assert src[jj]['nuse'] == 616  # 1520 with pos=5, was 2623
     src_full = read_source_spaces(fname_vol)
     # This implicitly checks for overlap because np.sort would preserve
     # duplicates, and it checks for completeness because the sets should match
     assert_array_equal(src_full[0]['vertno'],
                        np.sort(np.concatenate([s['vertno'] for s in src])))
+    for si, s in enumerate(src):
+        assert_allclose(src_full[0]['rr'], s['rr'], atol=1e-6)
 
 
 @pytest.mark.timeout(60)  # ~24 sec on Travis

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -612,19 +612,20 @@ def test_source_space_from_label(tmpdir, pass_atlas_ids):
     _compare_source_spaces(src, src_from_file, mode='approx')
 
 
-@testing.requires_testing_data
-def test_source_space_exclusive():
-    """Test that we produce exclusive labels."""
+def test_source_space_exclusive_complete(src_volume_labels):
+    """Test that we produce exclusive and complete labels."""
     # these two are neighbors and are quite large, so let's use them to
     # ensure no overlaps
-    volume_label = ['Left-Cerebral-White-Matter', 'Left-Cerebral-Cortex']
-    src = setup_volume_source_space(
-        'sample', subjects_dir=subjects_dir, volume_label=volume_label,
-        mri='aseg.mgz', add_interpolator=False)
-    assert src[0]['nuse'] == 2034  # was 2832
-    assert src[1]['nuse'] == 1520  # was 2623
-    overlap = np.in1d(src[0]['vertno'], src[1]['vertno']).mean()
-    assert overlap == 0.
+    src, volume_labels = src_volume_labels
+    ii = volume_labels.index('Left-Cerebral-White-Matter')
+    jj = volume_labels.index('Left-Cerebral-Cortex')
+    assert src[ii]['nuse'] == 786  # 2034 with pos=5, was 2832
+    assert src[jj]['nuse'] == 618  # 1520 with pos=5, was 2623
+    src_full = read_source_spaces(fname_vol)
+    # This implicitly checks for overlap because np.sort would preserve
+    # duplicates, and it checks for completeness because the sets should match
+    assert_array_equal(src_full[0]['vertno'],
+                       np.sort(np.concatenate([s['vertno'] for s in src])))
 
 
 @pytest.mark.timeout(60)  # ~24 sec on Travis

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -549,9 +549,9 @@ def test_vertex_to_mni_fs_nibabel(monkeypatch):
 ])
 def test_read_freesurfer_lut(fname):
     """Test reading volume label names."""
-    lut, colors = read_freesurfer_lut(fname)
-    assert list(lut).count('Brain-Stem') == 1
-    assert len(colors) == len(lut) == 1266
+    atlas_ids, colors = read_freesurfer_lut(fname)
+    assert list(atlas_ids).count('Brain-Stem') == 1
+    assert len(colors) == len(atlas_ids) == 1266
     aseg_fname = op.join(subjects_dir, 'sample', 'mri', 'aseg.mgz')
     label_names, label_colors = get_volume_labels_from_aseg(
         aseg_fname, return_colors=True)
@@ -562,6 +562,12 @@ def test_read_freesurfer_lut(fname):
         assert isinstance(c, np.ndarray)
         assert c.shape == (4,)
     assert len(label_names) == len(label_colors) == 46
+    with pytest.raises(ValueError, match='must be False'):
+        get_volume_labels_from_aseg(
+            aseg_fname, return_colors=True, atlas_ids=atlas_ids)
+    label_names_2 = get_volume_labels_from_aseg(
+        aseg_fname, atlas_ids=atlas_ids)
+    assert label_names == label_names_2
 
 
 @testing.requires_testing_data

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -439,8 +439,12 @@ def _ensure_trans(trans, fro='mri', to='head'):
     return trans
 
 
-def _get_trans(trans, fro='mri', to='head'):
+def _get_trans(trans, fro='mri', to='head', allow_none=True):
     """Get mri_head_t (from=mri, to=head) from mri filename."""
+    types = (Transform, 'path-like')
+    if allow_none:
+        types += (None,)
+    _validate_type(trans, types, 'trans')
     if _check_path_like(trans):
         trans = str(trans)
         if trans == 'fsaverage':
@@ -461,12 +465,10 @@ def _get_trans(trans, fro='mri', to='head'):
     elif isinstance(trans, Transform):
         fro_to_t = trans
         trans = 'instance of Transform'
-    elif trans is None:
+    else:
+        assert trans is None
         fro_to_t = Transform(fro, to)
         trans = 'identity'
-    else:
-        raise ValueError('transform type %s not known, must be str, dict, '
-                         'or None' % type(trans))
     # it's usually a head->MRI transform, so we probably need to invert it
     fro_to_t = _ensure_trans(fro_to_t, fro, to)
     return fro_to_t, trans

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -879,7 +879,7 @@ labels : Label | BiHemiLabel | list of Label or BiHemiLabel | str
     also be a string path to a MGZ atlas for the subject (e.g., their
     'aseg.mgz').
 
-    .. versionchanged 0.21.0::
+    .. versionchanged:: 0.21.0
        Support for volume source estimates.
 """
 docdict['eltc_src'] = """
@@ -900,6 +900,24 @@ allow_empty : bool | str
 
     .. versionchanged:: 0.21.0
        Support for "ignore".
+"""
+docdict['eltc_trans'] = """
+trans : str | instance of Transform
+    If str, the path to the head<->MRI transform ``*-trans.fif`` file
+    during coregistration. Only needed when using a volume atlas and
+    ``src`` is in head coordinates (i.e., comes from a forward or inverse).
+
+    .. versionadded:: 0.21.0
+"""
+docdict['eltc_mri_resolution'] = """
+mri_resolution : bool
+    If True (default), the volume source space will be upsampled to the
+    original MRI resolution via trilinear interpolation before the atlas values
+    are extracted. This ensnures that each atlas label will contain source
+    activations. When False, only the original source space points are used,
+    and some atlas labels thus may not contain any source space vertices.
+
+    .. versionadded:: 0.21.0
 """
 docdict['eltc_mode_notes'] = """
 Valid values for ``mode`` are:

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -588,15 +588,22 @@ exclude_frontal : bool
     If True, exclude points that have both negative Z values
     (below the nasion) and positivy Y values (in front of the LPA/RPA).
 """
+_trans_base = """\
+If str, the path to the head<->MRI transform ``*-trans.fif`` file produced
+    during coregistration. Can also be ``'fsaverage'`` to use the built-in
+    fsaverage transformation."""
+docdict['trans_not_none'] = """
+trans : str | dict | instance of Transform
+    %s
+""" % (_trans_base,)
 docdict['trans'] = """
 trans : str | dict | instance of Transform | None
-    If str, the path to the head<->MRI transform ``*-trans.fif`` file produced
-    during coregistration. Can also be ``'fsaverage'`` to use the built-in
-    fsaverage transformation. If trans is None, an identity matrix is assumed.
+    %s
+    If trans is None, an identity matrix is assumed.
 
     .. versionchanged:: 0.19
        Support for 'fsaverage' argument.
-"""
+""" % (_trans_base,)
 docdict['subjects_dir'] = """
 subjects_dir : str | None
     The path to the freesurfer subjects reconstructions.
@@ -871,14 +878,17 @@ time_label : str | callable | None
     is more than one time point.
 """
 
+
 # STC label time course
 docdict['eltc_labels'] = """
 labels : Label | BiHemiLabel | list | tuple | str
     If using a surface or mixed source space, this should be the
     :class:`~mne.Label`'s for which to extract the time course.
-    If working with whole-brain volume source estimates, this can also be:
+    If working with whole-brain volume source estimates, this must be one of:
 
-    - a string path to a MGZ atlas for the subject (e.g., their 'aseg.mgz')
+    - a string path to a FreeSurfer atlas for the subject (e.g., their
+      'aparc.a2009s+aseg.mgz') to extract time courses for all volumes in the
+      atlas
     - a two-element list or tuple, the first element being a path to an atlas,
       and the second being a list or dict of ``volume_labels`` to extract
       (see :func:`mne.setup_volume_source_space` for details).
@@ -887,8 +897,8 @@ labels : Label | BiHemiLabel | list | tuple | str
        Support for volume source estimates.
 """
 docdict['eltc_src'] = """
-src : list
-    Source spaces for left and right hemisphere.
+src : instance of SourceSpaces
+    The source spaces for the source time courses.
 """
 docdict['eltc_mode'] = """
 mode : str
@@ -905,14 +915,13 @@ allow_empty : bool | str
     .. versionchanged:: 0.21.0
        Support for "ignore".
 """
-docdict['eltc_trans'] = """
-trans : str | instance of Transform
-    If str, the path to the head<->MRI transform ``*-trans.fif`` file
-    during coregistration. Only needed when using a volume atlas and
+docdict
+docdict['eltc_trans'] = """%s
+    Only needed when using a volume atlas and
     ``src`` is in head coordinates (i.e., comes from a forward or inverse).
 
     .. versionadded:: 0.21.0
-"""
+""" % (docdict['trans_not_none'],)
 docdict['eltc_mri_resolution'] = """
 mri_resolution : bool
     If True (default), the volume source space will be upsampled to the
@@ -923,6 +932,10 @@ mri_resolution : bool
 
     .. versionadded:: 0.21.0
 """
+docdict['eltc_returns'] = """
+label_tc : array | list (or generator) of array, shape (n_labels[, n_orient], n_times)
+    Extracted time course for each label and source estimate.
+"""  # noqa: E501
 docdict['eltc_mode_notes'] = """
 Valid values for ``mode`` are:
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -873,8 +873,14 @@ time_label : str | callable | None
 
 # STC label time course
 docdict['eltc_labels'] = """
-labels : Label | BiHemiLabel | list of Label or BiHemiLabel
+labels : Label | BiHemiLabel | list of Label or BiHemiLabel | str
     The labels for which to extract the time course.
+    If a whole-brain volume source estimates are used, this can
+    also be a string path to a MGZ atlas for the subject (e.g., their
+    'aseg.mgz').
+
+    .. versionchanged 0.21.0::
+       Support for volume source estimates.
 """
 docdict['eltc_src'] = """
 src : list
@@ -885,9 +891,15 @@ mode : str
     Extraction mode, see Notes.
 """
 docdict['eltc_allow_empty'] = """
-allow_empty : bool
-    Instead of emitting an error, return all-zero time courses for labels
-    that do not have any vertices in the source estimate. Default is ``False``.
+allow_empty : bool | str
+    ``False`` (default) will emit an error if there are labels that have no
+    vertices in the source estimate. ``True`` and ``'ignore'`` will return
+    all-zero time courses for labels that do not have any vertices in the
+    source estimate, and True will emit a warning while and "ignore" will
+    just log a message.
+
+    .. versionchanged:: 0.21.0
+       Support for "ignore".
 """
 docdict['eltc_mode_notes'] = """
 Valid values for ``mode`` are:
@@ -919,9 +931,9 @@ Valid values for ``mode`` are:
     ``'mean'`` when a vector source estimate is supplied.
 
     .. versionadded:: 0.21
-       Support for ``'auto'`` and vector source estimates.
+       Support for ``'auto'``, vector, and volume source estimates.
 
-The only modes that work for vector source estimates are ``'mean'``,
+The only modes that work for vector and volume source estimates are ``'mean'``,
 ``'max'``, and ``'auto'``.
 """
 docdict['get_peak_parameters'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -873,11 +873,15 @@ time_label : str | callable | None
 
 # STC label time course
 docdict['eltc_labels'] = """
-labels : Label | BiHemiLabel | list of Label or BiHemiLabel | str
-    The labels for which to extract the time course.
-    If a whole-brain volume source estimates are used, this can
-    also be a string path to a MGZ atlas for the subject (e.g., their
-    'aseg.mgz').
+labels : Label | BiHemiLabel | list | tuple | str
+    If using a surface or mixed source space, this should be the
+    :class:`~mne.Label`'s for which to extract the time course.
+    If working with whole-brain volume source estimates, this can also be:
+
+    - a string path to a MGZ atlas for the subject (e.g., their 'aseg.mgz')
+    - a two-element list or tuple, the first element being a path to an atlas,
+      and the second being a list or dict of ``volume_labels`` to extract
+      (see :func:`mne.setup_volume_source_space` for details).
 
     .. versionchanged:: 0.21.0
        Support for volume source estimates.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -924,6 +924,23 @@ Valid values for ``mode`` are:
 The only modes that work for vector source estimates are ``'mean'``,
 ``'max'``, and ``'auto'``.
 """
+docdict['get_peak_parameters'] = """
+tmin : float | None
+    The minimum point in time to be considered for peak getting.
+tmax : float | None
+    The maximum point in time to be considered for peak getting.
+mode : {'pos', 'neg', 'abs'}
+    How to deal with the sign of the data. If 'pos' only positive
+    values will be considered. If 'neg' only negative values will
+    be considered. If 'abs' absolute values will be considered.
+    Defaults to 'abs'.
+vert_as_index : bool
+    Whether to return the vertex index (True) instead of of its ID
+    (False, default).
+time_as_index : bool
+    Whether to return the time index (True) instead of the latency
+    (False, default).
+"""
 
 # Clustering
 docdict['clust_thresh'] = """

--- a/tutorials/source-modeling/plot_visualize_stc.py
+++ b/tutorials/source-modeling/plot_visualize_stc.py
@@ -15,6 +15,10 @@ First, we get the paths for the evoked data and the time courses (stcs).
 """
 
 import os
+import os.path as op
+
+import numpy as np
+import matplotlib.pyplot as plt
 
 import mne
 from mne.datasets import sample
@@ -106,6 +110,26 @@ stc.plot(src, subject='sample', subjects_dir=subjects_dir)
 # visualization, a glass brain does not show us one slice but what we would
 # see if the brain was transparent like glass.
 stc.plot(src, subject='sample', subjects_dir=subjects_dir, mode='glass_brain')
+
+###############################################################################
+# You can also extract label time courses using volumetric atlases. Here we'll
+# use the built-in ``aparc.a2009s+aseg.mgz``:
+
+fname_aseg = op.join(subjects_dir, 'sample', 'mri', 'aparc.a2009s+aseg.mgz')
+label_names = mne.get_volume_labels_from_aseg(fname_aseg)
+label_tc = stc.extract_label_time_course(
+    fname_aseg, src=src, trans=inv['mri_head_t'])
+lidx, tidx = np.unravel_index(np.argmax(label_tc), label_tc.shape)
+fig, ax = plt.subplots(1)
+ax.plot(stc.times, label_tc.T, 'k', lw=1., alpha=0.5)
+xy = np.array([stc.times[tidx], label_tc[lidx, tidx]])
+xytext = xy + [0.01, 1]
+ax.annotate(
+    label_names[lidx], xy, xytext, arrowprops=dict(arrowstyle='->'), color='r')
+ax.set(xlim=stc.times[[0, -1]], xlabel='Time (s)', ylabel='Actiavtion')
+for key in ('right', 'top'):
+    ax.spines[key].set_visible(False)
+fig.tight_layout()
 
 ###############################################################################
 # Vector Source Estimates

--- a/tutorials/source-modeling/plot_visualize_stc.py
+++ b/tutorials/source-modeling/plot_visualize_stc.py
@@ -126,7 +126,7 @@ xy = np.array([stc.times[tidx], label_tc[lidx, tidx]])
 xytext = xy + [0.01, 1]
 ax.annotate(
     label_names[lidx], xy, xytext, arrowprops=dict(arrowstyle='->'), color='r')
-ax.set(xlim=stc.times[[0, -1]], xlabel='Time (s)', ylabel='Actiavtion')
+ax.set(xlim=stc.times[[0, -1]], xlabel='Time (s)', ylabel='Activation')
 for key in ('right', 'top'):
     ax.spines[key].set_visible(False)
 fig.tight_layout()


### PR DESCRIPTION
Adds volume label support to `extract_label_time_course`. Requires #7597 (and follow-up PRs).

- [x] Add `mne.read_freesurfer_lut` as suggested by @vferat [here](https://github.com/mne-tools/mne-python/issues/6155#issuecomment-612420561) to make `setup_volume_source_space` more general and pave the way for more generic atlas support
- [x] Speed up `setup_volume_source_space` with many labels by refactoring `_make_volume_source_space`
- [x] Add test that `setup_volume_source_space` with all volume labels of `aseg.mgz` creates a complete source space
- [x] Add `extract_label_time_course` VolSourceEstimate support via atlas
- [x] Add `vol_stc.in_label` volume atlas support

Next PRs:

- Ensure all source estimate types work with SourceMorph (#7564)
- Update docs about `src` in SourceMorph (#7007)

Closes #6155.