### PR TITLE
MRG, FIX: Report BEM toggling

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -44,6 +44,8 @@ Bug
 
 - Fix bug with :func:`mne.read_epochs` when loading data in complex format with ``preload=False`` by `Eric Larson`_
 
+- Fix bug with :class:`mne.Report` where the BEM section could not be toggled by `Eric Larson`_
+
 - Fix bug when using :meth:`mne.Epochs.crop` to exclude the baseline period would break :func:`mne.Epochs.save` / :func:`mne.read_epochs` round-trip by `Eric Larson`_
 
 - Fix :ref:`gen_mne_setup_forward_model` to have it actually compute the BEM solution in addition to creating the BEM model by `Eric Larson`_

--- a/mne/report.py
+++ b/mne/report.py
@@ -1471,7 +1471,7 @@ class Report(object):
                 self.html.append(self._render_bem(
                     self.subject, self.subjects_dir, mri_decim, n_jobs))
                 self.fnames.append('bem')
-                self._sectionlabels.append('mri')
+                self._sectionlabels.append('bem')
             else:
                 warn('`subjects_dir` and `subject` not provided. Cannot '
                      'render MRI and -trans.fif(.gz) files.')
@@ -1963,7 +1963,7 @@ class Report(object):
             return html
 
     def _render_bem(self, subject, subjects_dir, decim, n_jobs,
-                    section='mri', caption='BEM'):
+                    section='bem', caption='BEM'):
         """Render mri+bem (only PNG)."""
         import nibabel as nib
 
@@ -2004,13 +2004,13 @@ class Report(object):
 
         global_id = self._get_id()
 
-        if section == 'mri' and 'mri' not in self.sections:
-            self.sections.append('mri')
-            self._sectionvars['mri'] = 'mri'
+        if section == 'bem' and 'bem' not in self.sections:
+            self.sections.append('bem')
+            self._sectionvars['bem'] = 'bem'
 
         name = caption
 
-        html += u'<li class="mri" id="%d">\n' % global_id
+        html += u'<li class="report_%s" id="%d">\n' % (section, global_id)
         html += u'<h4>%s</h4>\n' % name  # all other captions are h4
         html += self._render_one_bem_axis(mri_fname, surf_fnames, global_id,
                                           shape, 'axial', decim, n_jobs)

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -254,8 +254,11 @@ def test_render_mri(renderer, tmpdir):
     assert repr(report)
     report.add_bem_to_section('sample', caption='extra', section='foo',
                               subjects_dir=subjects_dir, decim=30)
-    report.save(op.join(tempdir, 'report.html'), open_browser=False,
-                overwrite=True)
+    fname = op.join(tempdir, 'report.html')
+    report.save(fname, open_browser=False, overwrite=True)
+    with open(fname, 'r') as fid:
+        html = fid.read()
+    assert 'class="report_foo"' in html
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
I noticed that you can't toggle the BEM using the buttons at the top of the report because the class is not set properly. This fixes that, and also makes the section naming consistent (always "bem" instead of sometimes "bem" and sometimes "mri".