### PR TITLE
MRG, FIX: Fix bug when EDF has null bytes

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -48,6 +48,8 @@ Bug
 
 - Fix :ref:`gen_mne_setup_forward_model` to have it actually compute the BEM solution in addition to creating the BEM model by `Eric Larson`_
 
+- Fix bug with :func:`mne.io.read_raw_edf` where null bytes were not properly handled, causing an error when opening a file by `Eric Larson`_
+
 - Fix bug with :func:`mne.preprocessing.nirs.scalp_coupling_index` where filter transition was incorrectly assigned by `Robert Luke`_
 
 - Fix bug with :func:`mne.make_forward_dipole` where :func:`mne.write_forward_solution` could not be used by `Eric Larson`_

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -521,6 +521,10 @@ def _parse_prefilter_string(prefiltering):
     return highpass, lowpass
 
 
+def _edf_str_int(x, fid=None):
+    return int(x.decode().rstrip('\x00'))
+
+
 def _read_edf_header(fname, exclude):
     """Read header information from EDF+ or BDF file."""
     edf_info = {'events': []}
@@ -549,7 +553,7 @@ def _read_edf_header(fname, exclude):
         meas_date = datetime(year + century, month, day, hour, minute, sec,
                              tzinfo=timezone.utc)
 
-        header_nbytes = int(fid.read(8).decode())
+        header_nbytes = _edf_str_int(fid.read(8))
 
         # The following 44 bytes sometimes identify the file type, but this is
         # not guaranteed. Therefore, we skip this field and use the file
@@ -559,7 +563,7 @@ def _read_edf_header(fname, exclude):
         fid.read(44)
         subtype = os.path.splitext(fname)[1][1:].lower()
 
-        n_records = int(fid.read(8).decode())
+        n_records = _edf_str_int(fid.read(8))
         record_length = fid.read(8).decode().strip('\x00').strip()
         record_length = np.array([float(record_length), 1.])  # in seconds
         if record_length[0] == 0:
@@ -567,7 +571,7 @@ def _read_edf_header(fname, exclude):
             warn('Header information is incorrect for record length. Default '
                  'record length set to 1.')
 
-        nchan = int(fid.read(4).decode())
+        nchan = _edf_str_int(fid.read(4))
         channels = list(range(nchan))
         ch_names = [fid.read(16).strip().decode('latin-1') for ch in channels]
         exclude = _find_exclude_idx(ch_names, exclude)
@@ -609,8 +613,7 @@ def _read_edf_header(fname, exclude):
         highpass, lowpass = _parse_prefilter_string(prefiltering)
 
         # number of samples per record
-        n_samps = np.array([int(fid.read(8).decode()) for ch
-                            in channels])
+        n_samps = np.array([_edf_str_int(fid.read(8)) for ch in channels])
 
         # Populate edf_info
         edf_info.update(


### PR DESCRIPTION
Takes care of a bug where you could get during EDF reads:
```
E       ValueError: invalid literal for int() with base 10: '36096\x00\x00\x00'
```
Stripping the null bytes fixes the issue.