### PR TITLE
MRG, ENH: Add label extraction for vector source estimates

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -25,6 +25,8 @@ Changelog
 
 - Add :meth:`mne.MixedSourceEstimate.surface` and :meth:`mne.MixedSourceEstimate.volume` methods to allow surface and volume extraction by `Eric Larson`_
 
+- Add support to :func:`mne.extract_label_time_course` for vector-valued :class:`VectorSourceEstimate` and :class:`mne.MixedVectorSourceEstimate` by `Eric Larson`_
+
 - Allow resampling raw data with :func:`mne.io.Raw.resample` without preloading data, by `Eric Larson`_
 
 - Allow using ``pick_ori='vector'`` with a fixed-orientation inverse to facilitate visualization with :func:`mne.viz.plot_vector_source_estimates` by `Eric Larson`_
@@ -86,4 +88,3 @@ API
 - ``vmin`` and ``vmax`` parameters are deprecated in :meth:`mne.Epochs.plot_psd_topomap` and :func:`mne.viz.plot_epochs_psd_topomap`; use new ``vlim`` parameter instead, by `Daniel McCloy`_.
 
 - The method ``stc_mixed.plot_surface`` for a :class:`mne.MixedSourceEstimate` has been deprecated in favor of :meth:`stc.surface().plot(...) <mne.MixedSourceEstimate.surface>` by `Eric Larson`_
-

--- a/examples/inverse/plot_label_source_activations.py
+++ b/examples/inverse/plot_label_source_activations.py
@@ -14,6 +14,7 @@ also using a sign flip.
 # License: BSD (3-clause)
 
 import matplotlib.pyplot as plt
+import matplotlib.patheffects as path_effects
 
 import mne
 from mne.datasets import sample
@@ -36,7 +37,9 @@ evoked = mne.read_evokeds(fname_evoked, condition=0, baseline=(None, 0))
 inverse_operator = read_inverse_operator(fname_inv)
 src = inverse_operator['src']
 
+###############################################################################
 # Compute inverse solution
+# ------------------------
 pick_ori = "normal"  # Get signed values to see the effect of sign filp
 stc = apply_inverse(evoked, inverse_operator, lambda2, method,
                     pick_ori=pick_ori)
@@ -50,12 +53,46 @@ for mode in modes:
     tcs[mode] = stc.extract_label_time_course(label, src, mode=mode)
 print("Number of vertices : %d" % len(stc_label.data))
 
+###############################################################################
 # View source activations
+# -----------------------
+
 fig, ax = plt.subplots(1)
 t = 1e3 * stc_label.times
-ax.plot(t, stc_label.data.T, 'k', linewidth=0.5)
+ax.plot(t, stc_label.data.T, 'k', linewidth=0.5, alpha=0.5)
+pe = [path_effects.Stroke(linewidth=5, foreground='w', alpha=0.5),
+      path_effects.Normal()]
 for mode, tc in tcs.items():
-    ax.plot(t, tc[0], linewidth=3, label=str(mode))
+    ax.plot(t, tc[0], linewidth=3, label=str(mode), path_effects=pe)
+xlim = t[[0, -1]]
+ylim = [-27, 22]
 ax.legend(loc='upper right')
 ax.set(xlabel='Time (ms)', ylabel='Source amplitude',
-       title='Activations in Label : %s' % label)
+       title='Activations in Label %r' % (label.name),
+       xlim=xlim, ylim=ylim)
+mne.viz.tight_layout()
+
+###############################################################################
+# Using vector solutions
+# ----------------------
+# It's also possible to compute label time courses for a
+# :class:`mne.VectorSourceEstimate`, but only with ``mode='mean'``.
+
+pick_ori = 'vector'
+stc_vec = apply_inverse(evoked, inverse_operator, lambda2, method,
+                        pick_ori=pick_ori)
+data = stc_vec.extract_label_time_course(label, src)
+fig, ax = plt.subplots(1)
+stc_vec_label = stc_vec.in_label(label)
+colors = ['#EE6677', '#228833', '#4477AA']
+for ii, name in enumerate('XYZ'):
+    color = colors[ii]
+    ax.plot(t, stc_vec_label.data[:, ii].T, color=color, lw=0.5, alpha=0.5,
+            zorder=5 - ii)
+    ax.plot(t, data[0, ii], lw=3, color=color, label='+' + name, zorder=8 - ii,
+            path_effects=pe)
+ax.legend(loc='upper right')
+ax.set(xlabel='Time (ms)', ylabel='Source amplitude',
+       title='Mean vector activations in Label %r' % (label.name,),
+       xlim=xlim, ylim=ylim)
+mne.viz.tight_layout()

--- a/examples/inverse/plot_label_source_activations.py
+++ b/examples/inverse/plot_label_source_activations.py
@@ -9,7 +9,8 @@ to average the times series in a label. We compare a simple average, with an
 averaging using the dipoles normal (flip mode) and then a PCA,
 also using a sign flip.
 """
-# Author: Alexandre Gramfort <alexandre.gramfort@inria.fr>
+# Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
+#          Eric Larson <larson.eric.d@gmail.com>
 #
 # License: BSD (3-clause)
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -888,7 +888,10 @@ Valid values for ``mode`` are:
     Maximum value across vertices at each time point within each label.
 - ``'mean'``
     Average across vertices at each time point within each label. Ignores
-    orientation of sources.
+    orientation of sources for standard source estimates, which varies
+    across the cortical surface, which can lead to cancellation.
+    Vector source estimates are always in XYZ / RAS orientation, and are thus
+    already geometrically aligned.
 - ``'mean_flip'``
     Finds the dominant direction of source space normal vector orientations
     within each label, applies a sign-flip to time series at vertices whose
@@ -903,6 +906,15 @@ Valid values for ``mode`` are:
     ``flip`` is the same sign-flip vector used when ``mode='mean_flip'``. This
     sign-flip ensures that extracting time courses from the same label in
     similar STCs does not result in 180° direction/phase changes.
+- ``'auto'`` (default)
+    Uses ``'mean_flip'`` when a standard source estimate is applied, and
+    ``'mean'`` when a vector source estimate is supplied.
+
+    .. versionadded:: 0.21
+       Support for ``'auto'`` and vector source estimates.
+
+The only modes that work for vector source estimates are ``'mean'``,
+``'max'``, and ``'auto'``.
 """
 
 # Clustering


### PR DESCRIPTION
Helpful when working in free or even loose orientation because you can extract the vector source activations, and then take the norm (or do PCA, a Hotelling test, etc.) rather than having to take the norm or just the normal component.

Eventually I see this as being especially useful with volumetric source models with free orientation, so it lays the groundwork for #6155 to be useful.