### PR TITLE
MRG, MAINT: Modernize maxwell_filter tests

### DIFF
--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -31,7 +31,7 @@ from ..io.write import _generate_meas_id, DATE_NONE
 from ..io import _loc_to_coil_trans, _coil_trans_to_loc, BaseRaw, RawArray
 from ..io.pick import pick_types, pick_info
 from ..utils import (verbose, logger, _clean_names, warn, _time_mask, _pl,
-                     _check_option, _ensure_int)
+                     _check_option, _ensure_int, _validate_type)
 from ..fixes import _get_args, _safe_svd, einsum, bincount
 from ..channels.channels import _get_T1T2_mag_inds
 
@@ -240,8 +240,7 @@ def _prep_maxwell_filter(
     # Our code follows the same standard that ``scipy`` uses for ``sph_harm``.
 
     # triage inputs ASAP to avoid late-thrown errors
-    if not isinstance(raw, BaseRaw):
-        raise TypeError('raw must be Raw, not %s' % type(raw))
+    _validate_type(raw, BaseRaw, 'raw')
     _check_usable(raw)
     _check_regularize(regularize)
     st_correlation = float(st_correlation)
@@ -791,6 +790,7 @@ def _copy_preload_add_channels(raw, add_channels, copy):
 
 def _check_pos(pos, head_frame, raw, st_fixed, sfreq):
     """Check for a valid pos array and transform it to a more usable form."""
+    _validate_type(pos, (np.ndarray, None), 'head_pos')
     if pos is None:
         return [None, np.array([-1])]
     if not head_frame:


### PR DESCRIPTION
Looking through the code, noticed that we should tweaking some of our `maxwell_filter` tests to use more modern `pytest` syntax, and use `_validate_type` as well.

Will merge once CIs are happy since this is a pretty straightforward maintenance thing.