### PR TITLE
MRG, FIX: Use nearest in grid in setup_volume_source_space

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -44,6 +44,8 @@ Changelog
 Bug
 ~~~
 
+- Fix bug with :func:`mne.setup_volume_source_space` when ``volume_label`` was supplied where voxels slightly (in a worst case, about 37% times ``pos`` in distance) outside the voxel-grid-based bounds of regions were errantly included, by `Eric Larson`_
+
 - Fix bug with :func:`mne.minimum_norm.compute_source_psd_epochs` and :func:`mne.minimum_norm.source_band_induced_power` raised errors when ``method='eLORETA'`` by `Eric Larson`_
 
 - Fix handling of NaN when using TFCE in clustering functions such as :func:`mne.stats.spatio_temporal_cluster_1samp_test` by `Eric Larson`_

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -577,10 +577,13 @@ def test_volume_labels_morph(tmpdir):
     n_on = np.array(img.dataobj).astype(bool).sum()
     # This was 291 on `master` before gh-5590. Then refactoring transforms
     # it became 279 despite a < 1e-8 change in vox_mri_t
-    assert n_on in (279, 291)
+    # Then it dropped to 123 once nearest-voxel was used in gh-7653
+    assert n_on in (123, 279, 291)
     img = stc.as_volume(src, mri_resolution=False)
     n_on = np.array(img.dataobj).astype(bool).sum()
-    assert n_on == 44  # was 20 on `master` before gh-5590
+    # was 20 on `master` before gh-5590
+    # then 44 before gh-7653, which took it back to 20
+    assert n_on == 20
 
 
 run_tests_if_main()

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -584,6 +584,21 @@ def test_source_space_from_label(tmpdir):
     _compare_source_spaces(src, src_from_file, mode='approx')
 
 
+@testing.requires_testing_data
+def test_source_space_exclusive():
+    """Test that we produce exclusive labels."""
+    # these two are neighbors and are quite large, so let's use them to
+    # ensure no overlaps
+    volume_label = ['Left-Cerebral-White-Matter', 'Left-Cerebral-Cortex']
+    src = setup_volume_source_space(
+        'sample', subjects_dir=subjects_dir, volume_label=volume_label,
+        mri='aseg.mgz', add_interpolator=False)
+    assert src[0]['nuse'] == 2034  # was 2832
+    assert src[1]['nuse'] == 1520  # was 2623
+    overlap = np.in1d(src[0]['vertno'], src[1]['vertno']).mean()
+    assert overlap == 0.
+
+
 @pytest.mark.timeout(60)  # ~24 sec on Travis
 @pytest.mark.slowtest
 @testing.requires_testing_data


### PR DESCRIPTION
The old code for subselecting volumes based on `volume_label` used `_compute_nearest`, which is fine if you use *the entire set of volume grid voxels* and see if what you're closest to matches the desired ID.

However, it used `_compute_nearest` with the *voxels matching the given ID*, and then checked to make sure that the source space `rr` were within some distance of these nearest neighbors based on the voxel spacing. This is problematic for two reasons:

1. Non-uniform `zooms` could break this, but in practice they are probably always the same. More importantly...
2. Checking the distance from the source space point its the nearest voxel center effectively forms a sphere in 3D space around each voxel center. Geometrically, at the boundaries of the sub-volume this forms a "bumpy surface" of inclusion composed of spheres when what you should have is a surface composed entirely of regular-grid cubes. Thus there are some vertices/locations that will belong to more than one ROI when using `volume_labels`, because they sit within the `dist`-based neighborhood/sphere of two different voxels (one having the volume ID of interest, and the other not).

Our old code used a maximal distance of `linalg.norm(vox_mri_t['trans'][:3, :3].sum(0) / 2.)`. Assuming unit length (WLOG) this forms a radius of 0.866 around each voxel center. The maximum error would thus be that minus 0.5 -- for a point directly in the middle of the line between two neighboring voxels -- so we could have been off by a factor of `0.366 * pos`, I think. Hence the line in `latest.inc` about over-extending in a worse case to 37% times pos.

This PR adds a test that fails on `master` and passes on this PR that the overlap between two neighboring regions is zero. To run it on `master` you'd need to run it with the commented-out `nuse`s, and you should see an overlap of 0.47. It's pretty bad, but I intentionally selected two complex surfaces with a high surface-to-volume ratio to exacerbate the problem, so hopefully it's a worst case...

It uses a procedure that should both be both faster and more robust, namely:

1. take our source `rr` and transforming to voxel i/j/k, which we know are on a regular grid
2. `np.round`
3. make sure they are actually in the volume
4. use them to index into our volume
5. check whether or not you get value of interest

It also will allow us to easily iterate over volume IDs for volumetric labeling, which is how I originally stumbled onto this issue, doing it this way was not equivalent...