### PR TITLE
FIX: Fix RAS coordinates in watershed bem surfaces

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -82,6 +82,8 @@ Bug
 
 - Fix bug with :func:`mne.beamformer.make_dics` where complex conjugates were not applied properly by `Britta Westner`_ and `Eric Larson`_
 
+- Fix bug with :func:`mne.bem.make_watershed_bem` where the RAS coordinates of watershed bem surfaces were not updated correctly from the volume file by `Yu-Han Luo`_
+
 API
 ~~~
 


### PR DESCRIPTION
#### Reference issue
Fixes #7570.

#### What does this implement/fix?
In v20, the RAS coordinates of the surfaces created by `mne.bem.make_water_shed_bem` were wrong (refer to #7570 for details). This PR fixes the problem and adds tests to `mne/commands/test_commands/test_watershed_bem` to check the RAS coordinates of the watershed BEM surfaces.

#### Additional information
The bug was found thanks to @mh105, replicated by @larsoner.