### PR TITLE
MRG, ENH: Remove redundant tests on make_flash_bem

### DIFF
--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1786,8 +1786,6 @@ def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
     """
     from .viz.misc import plot_bem
 
-    is_test = os.environ.get('MNE_SKIP_FS_FLASH_CALL', False)
-
     env, mri_dir, bem_dir = _prepare_env(subject, subjects_dir)
     tempdir = _TempDir()  # fsl and Freesurfer create some random junk in CWD
     run_subprocess_env = partial(run_subprocess, env=env,
@@ -1824,9 +1822,8 @@ def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
     flash5_dir = op.join(mri_dir, 'flash5')
     shutil.rmtree(flash5_dir, ignore_errors=True)
     os.makedirs(flash5_dir)
-    if not is_test:  # CIs don't have freesurfer, skipped when testing.
-        cmd = ['mri_convert', flash5_reg, op.join(mri_dir, 'flash5')]
-        run_subprocess_env(cmd)
+    cmd = ['mri_convert', flash5_reg, op.join(mri_dir, 'flash5')]
+    run_subprocess_env(cmd)
     # Step 5b and c : Convert the mgz volumes into COR
     convert_T1 = False
     T1_dir = op.join(mri_dir, 'T1')
@@ -1858,10 +1855,9 @@ def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
     else:
         logger.info("Brain volume is already in COR format")
     # Finally ready to go
-    if not is_test:  # CIs don't have freesurfer, skipped when testing.
-        logger.info("\n---- Creating the BEM surfaces ----")
-        cmd = ['mri_make_bem_surfaces', subject]
-        run_subprocess_env(cmd)
+    logger.info("\n---- Creating the BEM surfaces ----")
+    cmd = ['mri_make_bem_surfaces', subject]
+    run_subprocess_env(cmd)
     del tempdir  # ran our last subprocess; clean up directory
 
     logger.info("\n---- Converting the tri files into surf files ----")

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -20,7 +20,7 @@ from mne.commands import (mne_browse_raw, mne_bti2fiff, mne_clean_eog_ecg,
                           mne_show_info, mne_what, mne_setup_source_space,
                           mne_setup_forward_model, mne_anonymize,
                           mne_prepare_bem_model, mne_sys_info)
-from mne.datasets import testing, sample
+from mne.datasets import testing
 from mne.io import read_raw_fif, read_info
 from mne.utils import (run_tests_if_main, requires_mne,
                        requires_mayavi, requires_vtk, requires_freesurfer,
@@ -255,16 +255,14 @@ def test_watershed_bem(tmpdir):
         assert_allclose(vol_info['cras'], Pxyz_c, **kwargs)
 
 
-@pytest.mark.timeout(300)  # took 200 sec locally
+@pytest.mark.timeout(100)  # took ~70 sec locally
 @pytest.mark.slowtest
 @pytest.mark.ultraslowtest
 @requires_freesurfer
-@sample.requires_sample_data
+@testing.requires_testing_data
 def test_flash_bem(tmpdir):
     """Test mne flash_bem."""
     check_usage(mne_flash_bem, force_help=True)
-    # Using the sample dataset
-    subjects_dir = op.join(sample.data_path(download=False), 'subjects')
     # Copy necessary files to tempdir
     tempdir = str(tmpdir)
     mridata_path = op.join(subjects_dir, 'sample', 'mri')
@@ -283,17 +281,24 @@ def test_flash_bem(tmpdir):
         shutil.copyfile(in_fname, op.join(flash_path, op.basename(in_fname)))
     # Test mne flash_bem with --noconvert option
     # (since there are no DICOM Flash images in dataset)
-    out_fnames = list()
-    for kind in ('outer_skin', 'outer_skull', 'inner_skull'):
-        out_fnames.append(op.join(subject_path_new, 'bem', 'outer_skin.surf'))
-    assert not any(op.isfile(out_fname) for out_fname in out_fnames)
+    for s in ('outer_skin', 'outer_skull', 'inner_skull'):
+        assert not op.isfile(op.join(subject_path_new, 'bem', '%s.surf' % s))
     with ArgvSetter(('-d', tempdir, '-s', 'sample', '-n'),
                     disable_stdout=False, disable_stderr=False):
         mne_flash_bem.run()
-    # do they exist and are expected size
-    for out_fname in out_fnames:
-        _, tris = read_surface(out_fname)
-        assert len(tris) == 5120
+
+    kwargs = dict(rtol=1e-5, atol=1e-5)
+    for s in ('outer_skin', 'outer_skull', 'inner_skull'):
+        rr, tris = read_surface(op.join(subject_path_new, 'bem',
+                                        '%s.surf' % s))
+        assert_equal(len(tris), 5120)
+        assert_equal(tris.min(), 0)
+        assert_equal(rr.shape[0], tris.max() + 1)
+        # compare to the testing flash surfaces
+        rr_c, tris_c = read_surface(op.join(subjects_dir, 'sample', 'bem',
+                                            '%s.surf' % s))
+        assert_allclose(rr, rr_c, **kwargs)
+        assert_allclose(tris, tris_c, **kwargs)
 
 
 @testing.requires_testing_data

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -255,7 +255,7 @@ def test_watershed_bem(tmpdir):
         assert_allclose(vol_info['cras'], Pxyz_c, **kwargs)
 
 
-@pytest.mark.timeout(100)  # took ~70 sec locally
+@pytest.mark.timeout(120)  # took ~70 sec locally
 @pytest.mark.slowtest
 @pytest.mark.ultraslowtest
 @requires_freesurfer

--- a/mne/datasets/sample/__init__.py
+++ b/mne/datasets/sample/__init__.py
@@ -1,4 +1,3 @@
 """MNE sample dataset."""
 
-from .sample import (data_path, has_sample_data, get_version,
-                     requires_sample_data)
+from .sample import data_path, has_sample_data, get_version

--- a/mne/datasets/sample/sample.py
+++ b/mne/datasets/sample/sample.py
@@ -5,7 +5,7 @@
 
 from functools import partial
 
-from ...utils import verbose, get_config
+from ...utils import verbose
 from ..utils import (has_dataset, _data_path, _data_path_doc,
                      _get_version, _version_doc)
 
@@ -30,29 +30,3 @@ def get_version():  # noqa: D103
 
 
 get_version.__doc__ = _version_doc.format(name='sample')
-
-
-# Allow forcing of sample dataset skip
-def _skip_sample_data():
-    skip_testing = (get_config('MNE_SKIP_SAMPLE_DATASET_TESTS', 'false') ==
-                    'true')
-    skip = skip_testing or not has_sample_data()
-    return skip
-
-
-def requires_sample_data(func):
-    """Skip testing data test.
-
-    Parameters
-    ----------
-    func : callable
-        The function to decorate.
-
-    Returns
-    -------
-    dec_func : callable
-        The decorated function.
-    """
-    import pytest
-    return pytest.mark.skipif(_skip_sample_data(),
-                              reason='Requires sample dataset')(func)

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -238,7 +238,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.84', misc='0.5')
+    releases = dict(testing='0.85', misc='0.5')
     # And also update the "md5_hashes['testing']" variable below.
 
     # To update any other dataset, update the data archive itself (upload
@@ -322,7 +322,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='12b75d1cb7df9dfb4ad73ed82f61094f',
         somato='ea825966c0a1e9b2f84e3826c5500161',
         spm='9f43f67150e3b694b523a21eb929ea75',
-        testing='25fbb89902adfee47a77807270cc0857',
+        testing='1ef691944239411b869b3ed2f40a69fe',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         fnirs_motor='c4935d19ddab35422a69f3326a01fef8',
         opm='370ad1dcfd5c47e029e692c85358a374',

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -133,8 +133,8 @@ def test_make_bem_model(tmpdir, kwargs, fname):
     if len(kwargs.get('conductivity', (0, 0, 0))) == 1:
         assert 'distance' not in log
     else:
-        assert re.search(r'urfaces is approximately *3\.6 mm', log) is not None
-    assert re.search(r'inner skull CM is *0\.69 *-10\.00 *44\.26 mm',
+        assert re.search(r'urfaces is approximately *3\.4 mm', log) is not None
+    assert re.search(r'inner skull CM is *0\.65 *-9\.62 *43\.85 mm',
                      log) is not None
     model_c = read_bem_surfaces(fname)
     _compare_bem_surfaces(model, model_c)

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -3,7 +3,7 @@
 # License: BSD 3 clause
 
 from copy import deepcopy
-from os import remove, makedirs
+from os import makedirs
 import os.path as op
 import re
 from shutil import copy
@@ -11,7 +11,6 @@ from shutil import copy
 import numpy as np
 import pytest
 from numpy.testing import assert_equal, assert_allclose
-import matplotlib.pyplot as plt
 
 from mne import (make_bem_model, read_bem_surfaces, write_bem_surfaces,
                  make_bem_solution, read_bem_solution, write_bem_solution,
@@ -20,11 +19,10 @@ from mne.preprocessing.maxfilter import fit_sphere_to_headshape
 from mne.io.constants import FIFF
 from mne.transforms import translation
 from mne.datasets import testing
-from mne.utils import (run_tests_if_main, catch_logging,
-                       requires_freesurfer, requires_nibabel)
+from mne.utils import (run_tests_if_main, catch_logging)
 from mne.bem import (_ico_downsample, _get_ico_map, _order_surfaces,
                      _assert_complete_surface, _assert_inside,
-                     _check_surface_size, _bem_find_surface, make_flash_bem)
+                     _check_surface_size, _bem_find_surface)
 from mne.surface import read_surface
 from mne.io import read_info
 
@@ -366,43 +364,6 @@ def test_fit_sphere_to_headshape():
     info = Info(dig=dig[:6], dev_head_t=dev_head_t)
     pytest.raises(ValueError, fit_sphere_to_headshape, info, units='m')
     pytest.raises(TypeError, fit_sphere_to_headshape, 1, units='m')
-
-
-@requires_nibabel()
-@requires_freesurfer('mri_convert')
-@testing.requires_testing_data
-def test_make_flash_bem(tmpdir):
-    """Test computing bem from flash images."""
-    tmp = str(tmpdir)
-    bemdir = op.join(subjects_dir, 'sample', 'bem')
-    flash_path = op.join(subjects_dir, 'sample', 'mri', 'flash')
-
-    for surf in ('inner_skull', 'outer_skull', 'outer_skin'):
-        copy(op.join(bemdir, surf + '.surf'), tmp)
-        copy(op.join(bemdir, surf + '.tri'), tmp)
-    copy(op.join(bemdir, 'inner_skull_tmp.tri'), tmp)
-    copy(op.join(bemdir, 'outer_skin_from_testing.surf'), tmp)
-
-    # This function deletes the tri files at the end.
-    try:
-        make_flash_bem('sample', overwrite=True, subjects_dir=subjects_dir,
-                       flash_path=flash_path)
-        for surf in ('inner_skull', 'outer_skull', 'outer_skin'):
-            coords, faces = read_surface(op.join(bemdir, surf + '.surf'))
-            surf = 'outer_skin_from_testing' if surf == 'outer_skin' else surf
-            coords_c, faces_c = read_surface(op.join(tmp, surf + '.surf'))
-            assert_equal(0, faces.min())
-            assert_equal(coords.shape[0], faces.max() + 1)
-            assert_allclose(coords, coords_c)
-            assert_allclose(faces, faces_c)
-    finally:
-        for surf in ('inner_skull', 'outer_skull', 'outer_skin'):
-            remove(op.join(bemdir, surf + '.surf'))  # delete symlinks
-            copy(op.join(tmp, surf + '.tri'), bemdir)  # return deleted tri
-            copy(op.join(tmp, surf + '.surf'), bemdir)  # return moved surf
-        copy(op.join(tmp, 'inner_skull_tmp.tri'), bemdir)
-        copy(op.join(tmp, 'outer_skin_from_testing.surf'), bemdir)
-    plt.close('all')
 
 
 run_tests_if_main()

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -246,7 +246,6 @@ prepare_inverse_operator
 read_bad_channels
 read_fiducials
 read_tag
-requires_sample_data
 rescale
 setup_proj
 source_estimate_quantification


### PR DESCRIPTION
#### Reference issue
Enhance tests as stated in #7661.

#### What does this implement/fix?
Merge `mne/tests/test_bem.py::test_make_flash_bem` to `mne/commands/test_commands.py::test_flash_bem` to reduce test time.
Testing data would be more compact (does not need `COR*` files) and efficient (use resampled `T1.mgz` to save time) using the current test.

#### Additional information
Testing dataset should be updated if this PR is accepted, or the test may fail.