### PR TITLE
MRG: Add plot and axes option to plot_filter

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -45,6 +45,8 @@ Changelog
 
 - Add "on_missing='raise'" to :meth:`mne.io.Raw.set_montage` and related functions to allow ignoring of missing electrode coordinates by `Adam Li`_
 
+- Add ``plot`` option to :meth:`mne.viz.plot_filter` allowing selection of which filter properties are plotted and added option for user to supply ``axes`` by `Robert Luke`_
+
 Bug
 ~~~
 

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -814,6 +814,8 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
         A list of the requested plots from `time`, `magnitude` and `delay`.
         Default is to plot all three filter properties
         ('time', 'magnitude', 'delay').
+
+        .. versionadded:: 0.21.0
     axes : instance of Axes | list | None
         The axes to plot to. If list, the list must be a list of Axes of
         the same length as the number of requested plot types. If instance of

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -822,6 +822,8 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
         Axes, there must be only one filter property plotted.
         Defaults to `None`.
 
+        .. versionadded:: 0.21.0
+
     Returns
     -------
     fig : matplotlib.figure.Figure

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -94,7 +94,12 @@ def test_plot_filter():
     _, axes = plt.subplots(1)
     fig = plot_filter(h, sfreq, freq, gain, plot=('magnitude'), axes=axes)
     assert len(fig.axes) == 1
+    _, axes = plt.subplots(2)
+    fig = plot_filter(h, sfreq, freq, gain, plot=('magnitude', 'delay'),
+                      axes=axes)
+    assert len(fig.axes) == 2
     plt.close('all')
+    _, axes = plt.subplots(1)
     with pytest.raises(ValueError, match='Length of axes'):
         plot_filter(h, sfreq, freq, gain,
                     plot=('magnitude', 'delay'), axes=axes)

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -70,8 +70,34 @@ def test_plot_filter():
                            iir_params=dict(output='ba'))
     plot_filter(iir_ba, sfreq, freq, gain)
     plt.close('all')
-    plot_filter(h, sfreq, freq, gain, fscale='linear')
+    fig = plot_filter(h, sfreq, freq, gain, fscale='linear')
+    assert len(fig.axes) == 3
     plt.close('all')
+    fig = plot_filter(h, sfreq, freq, gain, fscale='linear',
+                      plot=('time', 'delay'))
+    assert len(fig.axes) == 2
+    plt.close('all')
+    fig = plot_filter(h, sfreq, freq, gain, fscale='linear',
+                      plot=['magnitude', 'delay'])
+    assert len(fig.axes) == 2
+    plt.close('all')
+    fig = plot_filter(h, sfreq, freq, gain, fscale='linear',
+                      plot='magnitude')
+    assert len(fig.axes) == 1
+    plt.close('all')
+    fig = plot_filter(h, sfreq, freq, gain, fscale='linear',
+                      plot=('magnitude'))
+    assert len(fig.axes) == 1
+    plt.close('all')
+    with pytest.raises(ValueError, match='Invalid value for the .plot'):
+        plot_filter(h, sfreq, freq, gain, plot=('turtles'))
+    _, axes = plt.subplots(1)
+    fig = plot_filter(h, sfreq, freq, gain, plot=('magnitude'), axes=axes)
+    assert len(fig.axes) == 1
+    plt.close('all')
+    with pytest.raises(ValueError, match='Length of axes'):
+        plot_filter(h, sfreq, freq, gain,
+                    plot=('magnitude', 'delay'), axes=axes)
 
 
 def test_plot_cov():


### PR DESCRIPTION
#### Reference issue
#7654


#### What does this implement/fix?
Add `plot` keyword to allow choice of filter properties to plot.  
Add `axes` keyword.


#### Additional information
Order of plots is not as specified by the user, not in fixed order as before
