### PR TITLE
MAINT: Use xdist and better sys_info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,18 +108,21 @@ jobs:
             name: Get data
             command: |
               python setup.py develop --user
-              if ! git remote -v | grep upstream ; then git remote add upstream git://github.com/mne-tools/mne-python.git; fi
-              git fetch upstream
-              git branch -a
               mkdir -p ~/mne_data
               touch pattern.txt;
               if [ "$CIRCLE_BRANCH" == "master" ] || [[ $(cat gitlog.txt) == *"[circle full]"* ]]; then
+                echo "Doing a full dev build";
                 echo html_dev > build.txt;
                 python -c "import mne; mne.datasets._download_all_example_data()";
               elif [ "$CIRCLE_BRANCH" == "maint/0.20" ]; then
+                echo "Doing a full stable build";
                 echo html_stable > build.txt;
                 python -c "import mne; mne.datasets._download_all_example_data()";
               else
+                echo "Doing a partial build";
+                if ! git remote -v | grep upstream ; then git remote add upstream git://github.com/mne-tools/mne-python.git; fi
+                git fetch upstream
+                git branch -a
                 FNAMES=$(git diff --name-only $(git merge-base $CIRCLE_BRANCH upstream/master) $CIRCLE_BRANCH);
                 if [[ $(cat gitlog.txt) == *"[circle front]"* ]]; then
                   FNAMES="tutorials/source-modeling/plot_mne_dspm_source_localization.py tutorials/machine-learning/plot_receptive_field.py examples/connectivity/plot_mne_inverse_label_connectivity.py tutorials/machine-learning/plot_sensors_decoding.py tutorials/stats-source-space/plot_stats_cluster_spatio_temporal.py tutorials/evoked/plot_20_visualize_evoked.py "${FNAMES};

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_install:
         fi;
       fi
     # Always install these via pip so we get the latest possible versions (testing bugfixes)
-    - pip install --upgrade "pytest<5.4" pytest-sugar pytest-cov pytest-mock pytest-timeout codecov
+    - pip install --upgrade "pytest<5.4" pytest-sugar pytest-cov pytest-mock pytest-timeout pytest-xdist codecov
     - if [ "${DEPS}" != "minimal" ]; then
         pip install nitime;
       fi
@@ -145,15 +145,15 @@ script:
         pip install -e .;
         python mne/tests/test_evoked.py;
       fi;
-    - echo pytest -m "${CONDITION}" --cov=mne ${USE_DIRS}
-    - pytest -m "${CONDITION}" --tb=short --cov=mne ${USE_DIRS}
+    - echo pytest -m "${CONDITION}" --cov=mne -n 1 ${USE_DIRS}
+    - pytest -m "${CONDITION}" --tb=short --cov=mne -n 1 ${USE_DIRS}
     # run the minimal one with the testing data
     - if [ "${DEPS}" == "minimal" ]; then
         export MNE_SKIP_TESTING_DATASET_TESTS=false;
         python -c 'import mne; mne.datasets.testing.data_path(verbose=True)';
       fi;
     - if [ "${DEPS}" == "minimal" ]; then
-        pytest -m "${CONDITION}" --tb=short --cov=mne ${USE_DIRS};
+        pytest -m "${CONDITION}" --tb=short --cov=mne -n 1 ${USE_DIRS};
       fi;
 
 after_script:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,7 +136,7 @@ jobs:
       set -e
       python -m pip install --upgrade pip setuptools
       python -m pip install --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" numpy scipy scikit-learn matplotlib h5py pandas Pillow
-      python -m pip install --upgrade nilearn "pyqt5<5.14" pyqt5-sip nibabel pytest pytest-cov pytest-faulthandler pytest-xdist pytest-mock pytest-sugar pytest-timeout joblib psutil https://github.com/numpy/numpydoc/archive/master.zip neo xlrd codecov
+      python -m pip install --upgrade nilearn "pyqt5<5.14" pyqt5-sip nibabel pytest pytest-cov pytest-xdist pytest-mock pytest-sugar pytest-timeout joblib psutil https://github.com/numpy/numpydoc/archive/master.zip neo xlrd codecov
       python -m pip install codecov
     condition: eq(variables['TEST_MODE'], 'pre-pip')
     displayName: 'Install dependencies with pip --pre'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,7 +136,7 @@ jobs:
       set -e
       python -m pip install --upgrade pip setuptools
       python -m pip install --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" numpy scipy scikit-learn matplotlib h5py pandas Pillow
-      python -m pip install --upgrade nilearn "pyqt5<5.14" pyqt5-sip nibabel pytest pytest-cov pytest-faulthandler pytest-mock pytest-sugar pytest-timeout joblib psutil https://github.com/numpy/numpydoc/archive/master.zip neo xlrd codecov
+      python -m pip install --upgrade nilearn "pyqt5<5.14" pyqt5-sip nibabel pytest pytest-cov pytest-faulthandler pytest-xdist pytest-mock pytest-sugar pytest-timeout joblib psutil https://github.com/numpy/numpydoc/archive/master.zip neo xlrd codecov
       python -m pip install codecov
     condition: eq(variables['TEST_MODE'], 'pre-pip')
     displayName: 'Install dependencies with pip --pre'
@@ -165,7 +165,7 @@ jobs:
     displayName: Print NumPy config
   - script: python -c "import mne; mne.datasets.testing.data_path(verbose=True)"
     displayName: 'Get test data'
-  - script: pytest -m "not ultraslowtest" --tb=short --cov=mne mne
+  - script: pytest -m "not ultraslowtest" --tb=short --cov=mne -n 1 mne
     displayName: 'Run tests'
   - script: codecov --root %BUILD_REPOSITORY_LOCALPATH% -t %CODECOV_TOKEN%
     displayName: 'Codecov'

--- a/doc/install/mne_python.rst
+++ b/doc/install/mne_python.rst
@@ -196,26 +196,28 @@ type the following command in a terminal::
 This should display some system information along with the versions of
 MNE-Python and its dependencies. Typical output looks like this::
 
-    Platform:      Linux-4.18.0-13-generic-x86_64-with-debian-buster-sid
-    Python:        3.6.8 |Anaconda, Inc.| (default, Dec 30 2018, 01:22:34)  [GCC 7.3.0]
-    Executable:    /home/travis/miniconda/bin/python
-    CPU:           x86_64: 48 cores
-    Memory:        62.7 GB
+    Platform:      Linux-5.0.0-1031-gcp-x86_64-with-glibc2.2.5
+    Python:        3.8.1 (default, Dec 20 2019, 10:06:11)  [GCC 7.4.0]
+    Executable:    /home/travis/virtualenv/python3.8.1/bin/python
+    CPU:           x86_64: 2 cores
+    Memory:        7.8 GB
 
-    mne:           0.17.0
-    numpy:         1.15.4 {blas=mkl_rt, lapack=mkl_rt}
-    scipy:         1.2.0
-    matplotlib:    3.0.2 {backend=Qt5Agg}
+    mne:           0.21.dev0
+    numpy:         1.19.0.dev0+8dfaa4a {blas=openblas, lapack=openblas}
+    scipy:         1.5.0.dev0+f614064
+    matplotlib:    3.2.1 {backend=Qt5Agg}
 
-    sklearn:       0.20.2
-    numba:         0.45.0
-    nibabel:       2.3.3
+    sklearn:       0.22.2.post1
+    numba:         0.49.0
+    nibabel:       3.1.0
     cupy:          Not found
-    pandas:        0.24.0
-    dipy:          0.15.0
-    mayavi:        4.7.1 {qt_api=pyqt5, PyQt5=5.10.1}
-    pyvista:       0.21.3
-    vtk:           8.2.0
+    pandas:        1.0.3
+    dipy:          1.1.1
+    mayavi:        4.7.2.dev0
+    pyvista:       0.24.1
+    vtk:           9.0.0
+    PyQt5:         5.14.1
+
 
 .. collapse:: |hand-stop-o| If you get an error...
     :class: danger

--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ dependencies:
 - pytest-cov
 - pytest-mock
 - pytest-timeout
+- pytest-xdist
 - joblib
 - psutil
 - flake8

--- a/environment.yml
+++ b/environment.yml
@@ -43,7 +43,6 @@ dependencies:
   - nibabel
   - nilearn
   - neo
-  - pytest-faulthandler
   - pytest-sugar
   - pydocstyle
   - codespell

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -503,11 +503,14 @@ def sys_info(fid=None, show_paths=False):
         out += '%0.1f GB\n' % (psutil.virtual_memory().total / float(2 ** 30),)
     out += '\n'
     libs = _get_numpy_libs()
+    has_3d = False
     for mod_name in ('mne', 'numpy', 'scipy', 'matplotlib', '', 'sklearn',
                      'numba', 'nibabel', 'cupy', 'pandas', 'dipy',
                      'mayavi', 'pyvista', 'vtk', 'PyQt5'):
         if mod_name == '':
             out += '\n'
+            continue
+        if mod_name == 'PyQt5' and not has_3d:
             continue
         out += ('%s:' % mod_name).ljust(ljust)
         try:
@@ -523,6 +526,8 @@ def sys_info(fid=None, show_paths=False):
                 extra = ' {%s}%s' % (libs, extra)
             elif mod_name == 'matplotlib':
                 extra = ' {backend=%s}%s' % (mod.get_backend(), extra)
+            elif mod_name in ('mayavi', 'vtk'):
+                has_3d = True
             if mod_name == 'vtk':
                 version = mod.VTK_VERSION
             elif mod_name == 'PyQt5':

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -460,21 +460,27 @@ def sys_info(fid=None, show_paths=False):
 
         >>> import mne
         >>> mne.sys_info() # doctest: +SKIP
-        Platform:      Linux-4.2.0-27-generic-x86_64-with-Ubuntu-15.10-wily
-        Python:        2.7.10 (default, Oct 14 2015, 16:09:02)  [GCC 5.2.1 20151010]
-        Executable:    /usr/bin/python
+        Platform:      Linux-5.0.0-1031-gcp-x86_64-with-glibc2.2.5
+        Python:        3.8.1 (default, Dec 20 2019, 10:06:11)  [GCC 7.4.0]
+        Executable:    /home/travis/virtualenv/python3.8.1/bin/python
+        CPU:           x86_64: 2 cores
+        Memory:        7.8 GB
 
-        mne:           0.12.dev0
-        numpy:         1.12.0.dev0+ec5bd81 {lapack=mkl_rt, blas=mkl_rt}
-        scipy:         0.18.0.dev0+3deede3
-        matplotlib:    1.5.1+1107.g1fa2697
+        mne:           0.21.dev0
+        numpy:         1.19.0.dev0+8dfaa4a {blas=openblas, lapack=openblas}
+        scipy:         1.5.0.dev0+f614064
+        matplotlib:    3.2.1 {backend=Qt5Agg}
 
-        sklearn:       0.18.dev0
-        nibabel:       2.1.0dev
-        mayavi:        4.3.1
-        cupy:          4.1.0
-        pandas:        0.17.1+25.g547750a
-        dipy:          0.14.0
+        sklearn:       0.22.2.post1
+        numba:         0.49.0
+        nibabel:       3.1.0
+        cupy:          Not found
+        pandas:        1.0.3
+        dipy:          1.1.1
+        mayavi:        4.7.2.dev0
+        pyvista:       0.24.1
+        vtk:           9.0.0
+        PyQt5:         5.14.1
     """  # noqa: E501
     ljust = 15
     out = 'Platform:'.ljust(ljust) + platform.platform() + '\n'
@@ -499,7 +505,7 @@ def sys_info(fid=None, show_paths=False):
     libs = _get_numpy_libs()
     for mod_name in ('mne', 'numpy', 'scipy', 'matplotlib', '', 'sklearn',
                      'numba', 'nibabel', 'cupy', 'pandas', 'dipy',
-                     'mayavi', 'pyvista', 'vtk'):
+                     'mayavi', 'pyvista', 'vtk', 'PyQt5'):
         if mod_name == '':
             out += '\n'
             continue
@@ -517,18 +523,10 @@ def sys_info(fid=None, show_paths=False):
                 extra = ' {%s}%s' % (libs, extra)
             elif mod_name == 'matplotlib':
                 extra = ' {backend=%s}%s' % (mod.get_backend(), extra)
-            elif mod_name == 'mayavi':
-                try:
-                    from pyface.qt import qt_api
-                except Exception:
-                    qt_api = 'unknown'
-                if qt_api == 'pyqt5':
-                    qt_version = _check_pyqt5_version()
-                    if qt_version != 'unknown':
-                        qt_api += ', PyQt5=%s' % (qt_version,)
-                extra = ' {qt_api=%s}%s' % (qt_api, extra)
             if mod_name == 'vtk':
                 version = mod.VTK_VERSION
+            elif mod_name == 'PyQt5':
+                version = _check_pyqt5_version()
             else:
                 version = mod.__version__
             out += '%s%s\n' % (version, extra)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ pytest-faulthandler
 pytest-mock
 pytest-sugar
 pytest-timeout
+pytest-xdist
 joblib
 psutil
 dipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ python-picard
 statsmodels
 pytest!=4.6.0,<5.4
 pytest-cov
-pytest-faulthandler
 pytest-mock
 pytest-sugar
 pytest-timeout


### PR DESCRIPTION
1. Use `pytest-xdist` with `-n 1` which runs jobs in a subprocess, thereby hopefully making it easier to tell what killed a test (#7673)
2. Update `sys_info` to report the PyQt5 version directly rather than as part of the `mayavi` entry.

Now I get:
```
$ mne sys_info
Platform:      Linux-5.4.0-26-generic-x86_64-with-glibc2.29
Python:        3.8.2 (default, Mar 13 2020, 10:14:16)  [GCC 9.3.0]
Executable:    /home/larsoner/.local/bin/python
CPU:           x86_64: 8 cores
Memory:        62.8 GB

mne:           0.21.dev0
numpy:         1.19.0.dev0+ad5d58c {blas=openblas, lapack=openblas}
scipy:         1.5.0.dev0+b8f50ef
matplotlib:    3.2.1.post1626+g537a8c905 {backend=Qt5Agg}

sklearn:       0.23.dev0
numba:         0.50.0dev0+109.g1f9d82fc8
nibabel:       2.5.1+159.gddf26830
cupy:          7.0.0rc1
pandas:        1.1.0.dev0+900.g6812842d3
dipy:          1.1.0dev
mayavi:        4.7.2.dev0
pyvista:       0.24.1
vtk:           9.0.0
PyQt5:         5.14.1
```