### PR TITLE
MRG, ENH: Speed up examples

### DIFF
--- a/tutorials/source-modeling/plot_mne_solutions.py
+++ b/tutorials/source-modeling/plot_mne_solutions.py
@@ -15,7 +15,7 @@ produced by MNE, dSPM, sLORETA, and eLORETA.
 
 import mne
 from mne.datasets import sample
-from mne.minimum_norm import make_inverse_operator, apply_inverse
+from mne.minimum_norm import read_inverse_operator, apply_inverse
 
 print(__doc__)
 
@@ -26,18 +26,16 @@ subjects_dir = data_path + '/subjects'
 fname_evoked = data_path + '/MEG/sample/sample_audvis-ave.fif'
 evoked = mne.read_evokeds(fname_evoked, condition='Left Auditory',
                           baseline=(None, 0))
-fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif'
-fname_cov = data_path + '/MEG/sample/sample_audvis-cov.fif'
-fwd = mne.read_forward_solution(fname_fwd)
-cov = mne.read_cov(fname_cov)
+fname_inv = \
+    data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-meg-eeg-inv.fif'
 
 ###############################################################################
 # Fixed orientation
 # -----------------
-# First let's create a fixed-orientation inverse, with the default weighting.
+# First let's load a loose-orientation (``loose=0.2```) inverse, with the
+# default depth weighting (0.8).
 
-inv = make_inverse_operator(evoked.info, fwd, cov, loose=0., depth=0.8,
-                            verbose=True)
+inv = read_inverse_operator(fname_inv)
 
 ###############################################################################
 # Let's look at the current estimates using MNE. We'll take the absolute
@@ -48,7 +46,7 @@ lambda2 = 1.0 / snr ** 2
 kwargs = dict(initial_time=0.08, hemi='both', subjects_dir=subjects_dir,
               size=(600, 600))
 
-stc = abs(apply_inverse(evoked, inv, lambda2, 'MNE', verbose=True))
+stc = apply_inverse(evoked, inv, lambda2, 'MNE', verbose=True)
 brain = stc.plot(figure=1, **kwargs)
 brain.add_text(0.1, 0.9, 'MNE', 'title', font_size=14)
 
@@ -56,59 +54,20 @@ brain.add_text(0.1, 0.9, 'MNE', 'title', font_size=14)
 ###############################################################################
 # Next let's use the default noise normalization, dSPM:
 
-stc = abs(apply_inverse(evoked, inv, lambda2, 'dSPM', verbose=True))
+stc = apply_inverse(evoked, inv, lambda2, 'dSPM', verbose=True)
 brain = stc.plot(figure=2, **kwargs)
 brain.add_text(0.1, 0.9, 'dSPM', 'title', font_size=14)
 
 ###############################################################################
 # And sLORETA:
 
-stc = abs(apply_inverse(evoked, inv, lambda2, 'sLORETA', verbose=True))
+stc = apply_inverse(evoked, inv, lambda2, 'sLORETA', verbose=True)
 brain = stc.plot(figure=3, **kwargs)
 brain.add_text(0.1, 0.9, 'sLORETA', 'title', font_size=14)
 
 ###############################################################################
 # And finally eLORETA:
 
-stc = abs(apply_inverse(evoked, inv, lambda2, 'eLORETA', verbose=True))
-brain = stc.plot(figure=4, **kwargs)
-brain.add_text(0.1, 0.9, 'eLORETA', 'title', font_size=14)
-
-###############################################################################
-# Free orientation
-# ----------------
-# Now let's not constrain the orientation of the dipoles at all by creating
-# a free-orientation inverse.
-
-inv = make_inverse_operator(evoked.info, fwd, cov, loose=1., depth=0.8,
-                            verbose=True)
-
-###############################################################################
-# Let's look at the current estimates using MNE. We'll take the absolute
-# value of the source estimates to simplify the visualization.
-
-stc = apply_inverse(evoked, inv, lambda2, 'MNE', verbose=True)
-brain = stc.plot(figure=5, **kwargs)
-brain.add_text(0.1, 0.9, 'MNE', 'title', font_size=14)
-
-
-###############################################################################
-# Next let's use the default noise normalization, dSPM:
-
-stc = apply_inverse(evoked, inv, lambda2, 'dSPM', verbose=True)
-brain = stc.plot(figure=6, **kwargs)
-brain.add_text(0.1, 0.9, 'dSPM', 'title', font_size=14)
-
-###############################################################################
-# sLORETA:
-
-stc = apply_inverse(evoked, inv, lambda2, 'sLORETA', verbose=True)
-brain = stc.plot(figure=7, **kwargs)
-brain.add_text(0.1, 0.9, 'sLORETA', 'title', font_size=14)
-
-###############################################################################
-# And finally eLORETA:
-
 stc = apply_inverse(evoked, inv, lambda2, 'eLORETA', verbose=True)
-brain = stc.plot(figure=8, **kwargs)
+brain = stc.plot(figure=4, **kwargs)
 brain.add_text(0.1, 0.9, 'eLORETA', 'title', font_size=14)


### PR DESCRIPTION
Tries to speed up our two slowest examples:
```
    - ../tutorials/source-modeling/plot_forward.py: 115.75 sec    448.3 MB
    - ../tutorials/source-modeling/plot_mne_solutions.py: 96.71 sec    383.4 MB
```
In the first one, if we use fewer sources it's faster. In the second one, just showing the loose inverse seems like enough (no need to compute and show fixed and free).