### PR TITLE
MRG, BUG, ENH: Fix sign and add ttest_ind_no_p

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -41,6 +41,8 @@ Changelog
 
 - Add function :func:`mne.preprocessing.annotate_muscle_zscore` to annotate periods with muscle artifacts. by `Adonay Nunes`_
 
+- Add :func:`mne.stats.ttest_ind_no_p` to mirror :func:`mne.stats.ttest_1samp_no_p` with hat correction by `Eric Larson`_
+
 - Support for saving movies of source time courses (STCs) with ``brain.save_movie`` method and from graphical user interface by `Guillaume Favelier`_
 
 - Add "on_missing='raise'" to :meth:`mne.io.Raw.set_montage` and related functions to allow ignoring of missing electrode coordinates by `Adam Li`_
@@ -59,6 +61,8 @@ Bug
 - PSD plots will now show non-data channels (e.g., ``misc``) if those channels are explicitly passed to ``picks``, by `Daniel McCloy`_.
 
 - Fix handling of NaN when using TFCE in clustering functions such as :func:`mne.stats.spatio_temporal_cluster_1samp_test` by `Eric Larson`_
+
+- Fix handling of signs when using TFCE by `Eric Larson`_
 
 - The :class:`mne.MixedSourceEstimate` class has been clarified to contain two cortical surface source spaces, plus at least one other source space. Creating source estimates in other orderings is not supported, by `Eric Larson`_
 

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -893,6 +893,7 @@ options):
    :toctree: generated/
 
    ttest_1samp_no_p
+   ttest_ind_no_p
    f_oneway
    f_mway_rm
    f_threshold_mway_rm

--- a/mne/stats/__init__.py
+++ b/mne/stats/__init__.py
@@ -1,7 +1,8 @@
 """Functions for statistical analysis."""
 
 from .parametric import (f_threshold_mway_rm, f_mway_rm, f_oneway,
-                         _parametric_ci, ttest_1samp_no_p)
+                         _parametric_ci, ttest_1samp_no_p,
+                         ttest_ind_no_p)
 from .permutations import (permutation_t_test, _ci,
                            bootstrap_confidence_interval)
 from .cluster_level import (

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -65,7 +65,7 @@ def ttest_1samp_no_p(X, sigma=0, method='relative'):
     return np.mean(X, axis=0) / np.sqrt(var / X.shape[0])
 
 
-def ttest_ind_no_p(a, b, equal_var=False, sigma=1e-3):
+def ttest_ind_no_p(a, b, equal_var=True, sigma=1e-3):
     """Independent samples t-test with hat adjustment and no p calculation.
 
     This is a modified version of :func:`scipy.stats.ttest_ind`. It operates

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -65,6 +65,55 @@ def ttest_1samp_no_p(X, sigma=0, method='relative'):
     return np.mean(X, axis=0) / np.sqrt(var / X.shape[0])
 
 
+def ttest_ind_no_p(a, b, equal_var=False, sigma=1e-3):
+    """Independent samples t-test with hat adjustment and no p calculation.
+
+    This is a modified version of :func:`scipy.stats.ttest_ind`. It operates
+    along the first axis.
+
+    Parameters
+    ----------
+    a : array-like
+        The first array.
+    b : array-like
+        The second array.
+    equal_var : bool
+        Assume equal variance. See :func:`scipy.stats.ttest_ind`.
+    sigma : float
+        The regularization. See :func:`ttest_1samp_no_p`.
+
+    Returns
+    -------
+    t : array
+        T values.
+    """
+    v1 = np.var(a, axis=0, ddof=1)
+    v2 = np.var(b, axis=0, ddof=1)
+    n1 = a.shape[0]
+    n2 = b.shape[0]
+    if equal_var:
+        df = n1 + n2 - 2.0
+        var = ((n1 - 1) * v1 + (n2 - 1) * v2) / df
+        var = var * (1.0 / n1 + 1.0 / n2)
+    else:
+        vn1 = v1 / n1
+        vn2 = v2 / n2
+        with np.errstate(divide='ignore', invalid='ignore'):
+            df = (vn1 + vn2)**2 / (vn1**2 / (n1 - 1) + vn2**2 / (n2 - 1))
+
+        # If df is undefined, variances are zero (assumes n1 > 0 & n2 > 0).
+        # Hence it doesn't matter what df is as long as it's not NaN.
+        df = np.where(np.isnan(df), 1, df)
+        var = vn1 + vn2
+    if sigma > 0:
+        var += sigma * np.max(var)
+    denom = np.sqrt(var)
+    d = np.mean(a, 0) - np.mean(b, 0)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        t = np.divide(d, denom)
+    return t
+
+
 def f_oneway(*args):
     """Perform a 1-way ANOVA.
 

--- a/mne/stats/tests/test_parametric.py
+++ b/mne/stats/tests/test_parametric.py
@@ -121,6 +121,7 @@ def test_f_twoway_rm():
 @pytest.mark.parametrize('kind, kwargs', [
     ('1samp', {}),
     ('ind', {}),  # equal_var=True is the default
+    ('ind', dict(equal_var=True)),
     ('ind', dict(equal_var=False)),
 ])
 @pytest.mark.parametrize('sigma', (0., 1e-3,))
@@ -142,7 +143,7 @@ def test_ttest_equiv(kind, kwargs, sigma, seed):
 
     X = rng.randn(3, 4, 5)
     if kind == 'ind':
-        X = [X, rng.randn(3, 4, 5)]
+        X = [X, rng.randn(30, 4, 5)]  # should differ based on equal_var
         got = ours(*X)
         want = theirs(*X)
     else:

--- a/mne/stats/tests/test_parametric.py
+++ b/mne/stats/tests/test_parametric.py
@@ -1,9 +1,13 @@
+from functools import partial
 from itertools import product
 
 import pytest
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import (assert_array_almost_equal, assert_allclose,
+                           assert_array_less)
 import numpy as np
+import scipy.stats
 
+import mne
 from mne.stats.parametric import (f_mway_rm, f_threshold_mway_rm,
                                   _map_effects)
 
@@ -112,3 +116,43 @@ def test_f_twoway_rm():
 
     fvals, _ = f_mway_rm(test_data, [8], 'A')
     assert_array_almost_equal(fvals, test_external['r_fvals_1way'], 5)
+
+
+@pytest.mark.parametrize('kind, kwargs', [
+    ('1samp', {}),
+    ('ind', {}),  # equal_var=True is the default
+    ('ind', dict(equal_var=False)),
+])
+@pytest.mark.parametrize('sigma', (0., 1e-3,))
+@pytest.mark.parametrize('seed', [0, 42, 1337])
+def test_ttest_equiv(kind, kwargs, sigma, seed):
+    """Test t-test equivalence."""
+    rng = np.random.RandomState(seed)
+
+    def theirs(*a, **kw):
+        f = getattr(scipy.stats, 'ttest_%s' % (kind,))
+        if kind == '1samp':
+            func = partial(f, popmean=0, **kwargs)
+        else:
+            func = partial(f, **kwargs)
+        return func(*a, **kw)[0]
+
+    ours = partial(getattr(mne.stats, 'ttest_%s_no_p' % (kind,)),
+                   sigma=sigma, **kwargs)
+
+    X = rng.randn(3, 4, 5)
+    if kind == 'ind':
+        X = [X, rng.randn(3, 4, 5)]
+        got = ours(*X)
+        want = theirs(*X)
+    else:
+        got = ours(X)
+        want = theirs(X)
+    if sigma == 0.:
+        assert_allclose(got, want, rtol=1e-7, atol=1e-6)
+    else:
+        assert not np.allclose(got, want, rtol=1e-7, atol=1e-6)
+        # should mostly be similar, but uniformly smaller because we add
+        # something to the divisor (var)
+        assert_allclose(got, want, rtol=2e-1, atol=1e-2)
+        assert_array_less(np.abs(got), np.abs(want))


### PR DESCRIPTION
Closes #7684.

@fleurgaudfernau can you try it?

Also adds `ttest_ind_no_p` like we have `ttest_1samp_no_p` because I've needed it / coded it before, and it was helpful for the test for TFCE to be able to use it.