### PR TITLE
DOC: Add "ambidextrous" to docstring

### DIFF
--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -490,7 +490,7 @@ class Info(dict, MontageMixin):
         sex : int
             Subject sex (0=unknown, 1=male, 2=female).
         hand : int
-            Handedness (1=right, 2=left).
+            Handedness (1=right, 2=left, 3=ambidextrous).
 
     * ``device_info`` dict:
 


### PR DESCRIPTION
#### What does this implement/fix?
Adds "ambidextrous" to `Info` docstring.

#### Additional information
As is defined in `io.constants` already.
