### PR TITLE
safer indexing/slicing in internal multitaper code

### DIFF
--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -299,7 +299,7 @@ def _mt_spectra(x, dpss, sfreq, n_fft=None):
         The frequency points in Hz of the spectra
     """
     if n_fft is None:
-        n_fft = x.shape[1]
+        n_fft = x.shape[-1]
 
     # remove mean (do not use in-place subtraction as it may modify input x)
     x = x - np.mean(x, axis=-1, keepdims=True)
@@ -315,9 +315,9 @@ def _mt_spectra(x, dpss, sfreq, n_fft=None):
     for idx, sig in enumerate(x):
         x_mt[idx] = rfft(sig[..., np.newaxis, :] * dpss, n=n_fft)
     # Adjust DC and maybe Nyquist, depending on one-sided transform
-    x_mt[:, :, 0] /= np.sqrt(2.)
+    x_mt[..., 0] /= np.sqrt(2.)
     if x.shape[1] % 2 == 0:
-        x_mt[:, :, -1] /= np.sqrt(2.)
+        x_mt[..., -1] /= np.sqrt(2.)
     return x_mt, freqs
 
 


### PR DESCRIPTION
This is a tiny fix to internal multitaper code. It shouldn't affect anything that uses the public API; these are changes I needed to make to use some of the private multitaper functions in my analysis pipeline, to allow using the private functions with both epochs and evoked objects. Should be fully backward-compatible, and should make future expansion of the multitaper API slightly easier.

(for those interested, in an SSVEP experiment I needed to keep the complex values --- which meant keeping the separate spectral estimates from each taper --- so that later I could hopefully get some phase-cancelling noise reduction in the non-carrier / non-oddball frequency bins).