### PR TITLE
MRG, FIX: Fix bug with get_peak

### DIFF
--- a/examples/inverse/plot_vector_mne_solution.py
+++ b/examples/inverse/plot_vector_mne_solution.py
@@ -20,6 +20,7 @@ you to get a better sense of the true underlying source geometry.
 # Author: Marijn van Vliet <w.m.vanvliet@gmail.com>
 #
 # License: BSD (3-clause)
+
 import mne
 from mne.datasets import sample
 from mne.minimum_norm import read_inverse_operator, apply_inverse


### PR DESCRIPTION
Fixes an error with `get_peak` made when refactoring in the atlas PR (showed up in CircleCI), and finally add more comprehensive tests so that `get_peak` is more robust.