### PR TITLE
MRG, ENH: Add example of projection to source space

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,6 +258,12 @@ jobs:
               if grep -q html_dev-pattern build.txt || grep -q html_dev-noplot build.txt; then
                 tar czf doc/_build/html/_downloads.tgz doc/_build/html/_downloads
                 rm -Rf doc/_build/html/_downloads
+                rm -f doc/auto_*/*/*.pickle
+                rm -f doc/auto_*/*/*.codeobj
+                rm -f doc/auto_*/*/*.md5
+                rm -f doc/auto_*/*/*.py
+                rm -f doc/auto_*/*/*.ipynb
+                rm -f doc/generated/*.examples
               fi
 
         # Save the JUnit file
@@ -266,7 +272,17 @@ jobs:
         - store_artifacts:
             path: doc/_build/test-results
             destination: test-results
-        # Save the outputs
+        # Save the SG RST
+        - store_artifacts:
+            path: doc/auto_examples
+            destination: auto_examples
+        - store_artifacts:
+            path: doc/auto_tutorials
+            destination: auto_tutorials
+        - store_artifacts:
+            path: doc/generated
+            destination: generated
+        # Save the HTML
         - store_artifacts:
             path: doc/_build/html/
             destination: dev

--- a/examples/decoding/plot_linear_model_patterns.py
+++ b/examples/decoding/plot_linear_model_patterns.py
@@ -7,19 +7,11 @@ Linear classifier on sensor data with plot patterns and filters
 Here decoding, a.k.a MVPA or supervised machine learning, is applied to M/EEG
 data in sensor space. Fit a linear classifier with the LinearModel object
 providing topographical patterns which are more neurophysiologically
-interpretable [1]_ than the classifier filters (weight vectors).
-The patterns explain how the MEG and EEG data were generated from the
-discriminant neural sources which are extracted by the filters.
+interpretable :footcite:`HaufeEtAl2014` than the classifier filters (weight
+vectors). The patterns explain how the MEG and EEG data were generated from
+the discriminant neural sources which are extracted by the filters.
 Note patterns/filters in MEG data are more similar than EEG data
 because the noise is less spatially correlated in MEG than EEG.
-
-References
-----------
-
-.. [1] Haufe, S., Meinecke, F., Görgen, K., Dähne, S., Haynes, J.-D.,
-       Blankertz, B., & Bießmann, F. (2014). On the interpretation of
-       weight vectors of linear models in multivariate neuroimaging.
-       NeuroImage, 87, 96–110. doi:10.1016/j.neuroimage.2013.10.067
 """
 # Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #          Romain Trachel <trachelr@gmail.com>
@@ -42,11 +34,12 @@ from mne.decoding import LinearModel
 print(__doc__)
 
 data_path = sample.data_path()
+sample_path = data_path + '/MEG/sample'
 
 ###############################################################################
 # Set parameters
-raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
-event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
+raw_fname = sample_path + '/sample_audvis_filt-0-40_raw.fif'
+event_fname = sample_path + '/sample_audvis_filt-0-40_raw-eve.fif'
 tmin, tmax = -0.1, 0.4
 event_id = dict(aud_l=1, vis_l=3)
 
@@ -68,6 +61,7 @@ meg_data = meg_epochs.get_data().reshape(len(labels), -1)
 
 ###############################################################################
 # Decoding in sensor space using a LogisticRegression classifier
+# --------------------------------------------------------------
 
 clf = LogisticRegression(solver='lbfgs')
 scaler = StandardScaler()
@@ -114,3 +108,8 @@ for name in ('patterns_', 'filters_'):
     coef = get_coef(clf, name, inverse_transform=True)
     evoked = EvokedArray(coef, epochs.info, tmin=epochs.tmin)
     evoked.plot_topomap(title='EEG %s' % name[:-1], time_unit='s')
+
+###############################################################################
+# References
+# ----------
+# .. footbibliography::

--- a/examples/decoding/plot_receptive_field_mtrf.py
+++ b/examples/decoding/plot_receptive_field_mtrf.py
@@ -6,24 +6,13 @@ Receptive Field Estimation and Prediction
 =========================================
 
 This example reproduces figures from Lalor et al's mTRF toolbox in
-matlab [1]_. We will show how the :class:`mne.decoding.ReceptiveField` class
+matlab :footcite:`CrosseEtAl2016`. We will show how the
+:class:`mne.decoding.ReceptiveField` class
 can perform a similar function along with scikit-learn. We will first fit a
 linear encoding model using the continuously-varying speech envelope to predict
 activity of a 128 channel EEG system. Then, we will take the reverse approach
 and try to predict the speech envelope from the EEG (known in the literature
 as a decoding model, or simply stimulus reconstruction).
-
-References
-----------
-.. [1] Crosse, M. J., Di Liberto, G. M., Bednar, A. & Lalor, E. C. (2016).
-       The Multivariate Temporal Response Function (mTRF) Toolbox:
-       A MATLAB Toolbox for Relating Neural Signals to Continuous Stimuli.
-       Frontiers in Human Neuroscience 10, 604. doi:10.3389/fnhum.2016.00604
-
-.. [2] Haufe, S., Meinecke, F., Goergen, K., Daehne, S., Haynes, J.-D.,
-       Blankertz, B., & Biessmann, F. (2014). On the interpretation of weight
-       vectors of linear models in multivariate neuroimaging. NeuroImage, 87,
-       96-110. doi:10.1016/j.neuroimage.2013.10.067
 
 .. _figure 1: https://www.frontiersin.org/articles/10.3389/fnhum.2016.00604/full#F1
 .. _figure 2: https://www.frontiersin.org/articles/10.3389/fnhum.2016.00604/full#F2
@@ -52,7 +41,8 @@ from sklearn.preprocessing import scale
 # Load the data from the publication
 # ----------------------------------
 #
-# First we will load the data collected in [1]_. In this experiment subjects
+# First we will load the data collected in :footcite:`CrosseEtAl2016`.
+# In this experiment subjects
 # listened to natural speech. Raw EEG and the speech stimulus are provided.
 # We will load these below, downsampling the data in order to speed up
 # computation since we know that our features are primarily low-frequency in
@@ -136,9 +126,10 @@ mne.viz.tight_layout()
 # ==============================
 # Finally, we will look at how the linear coefficients (sometimes
 # referred to as beta values) are distributed across time delays as well as
-# across the scalp. We will recreate `figure 1`_ and `figure 2`_ from [1]_.
+# across the scalp. We will recreate `figure 1`_ and `figure 2`_ from
+# :footcite:`CrosseEtAl2016`.
 
-# Print mean coefficients across all time delays / channels (see Fig 1 in [1])
+# Print mean coefficients across all time delays / channels (see Fig 1)
 time_plot = 0.180  # For highlighting a specific time.
 fig, ax = plt.subplots(figsize=(4, 8))
 max_coef = mean_coefs.max()
@@ -151,7 +142,7 @@ ax.set(xlabel='Delay (s)', ylabel='Channel', title="Mean Model\nCoefficients",
 plt.setp(ax.get_xticklabels(), rotation=45)
 mne.viz.tight_layout()
 
-# Make a topographic map of coefficients for a given delay (see Fig 2C in [1])
+# Make a topographic map of coefficients for a given delay (see Fig 2C)
 ix_plot = np.argmin(np.abs(time_plot - times))
 fig, ax = plt.subplots()
 mne.viz.plot_topomap(mean_coefs[:, ix_plot], pos=info, axes=ax, show=False,
@@ -167,7 +158,8 @@ mne.viz.tight_layout()
 # We will now demonstrate another use case for the for the
 # :class:`mne.decoding.ReceptiveField` class as we try to predict the stimulus
 # activity from the EEG data. This is known in the literature as a decoding, or
-# stimulus reconstruction model [1]_. A decoding model aims to find the
+# stimulus reconstruction model :footcite:`CrosseEtAl2016`.
+# A decoding model aims to find the
 # relationship between the speech signal and a time-delayed version of the EEG.
 # This can be useful as we exploit all of the available neural data in a
 # multivariate context, compared to the encoding case which treats each M/EEG
@@ -175,7 +167,8 @@ mne.viz.tight_layout()
 # better quality of fit (at the expense of not controlling for stimulus
 # covariance), especially for low SNR stimuli such as speech.
 
-# We use the same lags as in [1]. Negative lags now index the relationship
+# We use the same lags as in :footcite:`CrosseEtAl2016`. Negative lags now
+# index the relationship
 # between the neural response and the speech envelope earlier in time, whereas
 # positive lags would index how a unit change in the amplitude of the EEG would
 # affect later stimulus activity (obviously this should have an amplitude of
@@ -184,8 +177,9 @@ tmin, tmax = -.2, 0.
 
 # Initialize the model. Here the features are the EEG data. We also specify
 # ``patterns=True`` to compute inverse-transformed coefficients during model
-# fitting (cf. next section). We'll use a ridge regression estimator with an
-# alpha value similar to [1].
+# fitting (cf. next section and :footcite:`HaufeEtAl2014`).
+# We'll use a ridge regression estimator with an alpha value similar to
+# Crosse et al.
 sr = ReceptiveField(tmin, tmax, sfreq, feature_names=raw.ch_names,
                     estimator=1e4, scoring='corrcoef', patterns=True)
 # We'll have (tmax - tmin) * sfreq delays
@@ -238,7 +232,8 @@ mne.viz.tight_layout()
 # ==============================
 #
 # Finally, we will look at how the decoding model coefficients are distributed
-# across the scalp. We will attempt to recreate `figure 5`_ from [1]_. The
+# across the scalp. We will attempt to recreate `figure 5`_ from
+# :footcite:`CrosseEtAl2016`. The
 # decoding model weights reflect the channels that contribute most toward
 # reconstructing the stimulus signal, but are not directly interpretable in a
 # neurophysiological sense. Here we also look at the coefficients obtained
@@ -264,3 +259,8 @@ ax[1].set(title="Inverse-transformed coefficients\nbetween delays %s and %s"
 mne.viz.tight_layout()
 
 plt.show()
+
+###############################################################################
+# References
+# ----------
+# .. footbibliography::

--- a/examples/decoding/plot_receptive_field_mtrf.py
+++ b/examples/decoding/plot_receptive_field_mtrf.py
@@ -237,7 +237,8 @@ mne.viz.tight_layout()
 # decoding model weights reflect the channels that contribute most toward
 # reconstructing the stimulus signal, but are not directly interpretable in a
 # neurophysiological sense. Here we also look at the coefficients obtained
-# via an inversion procedure [2]_, which have a more straightforward
+# via an inversion procedure :footcite:`HaufeEtAl2014`, which have a more
+# straightforward
 # interpretation as their value (and sign) directly relates to the stimulus
 # signal's strength (and effect direction).
 
@@ -263,4 +264,5 @@ plt.show()
 ###############################################################################
 # References
 # ----------
+#
 # .. footbibliography::

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -20,7 +20,7 @@ class LinearModel(BaseEstimator):
     The linear model coefficients (filters) are used to extract discriminant
     neural sources from the measured data. This class computes the
     corresponding patterns of these linear filters to make them more
-    interpretable [1]_.
+    interpretable :footcite:`HaufeEtAl2014`.
 
     Parameters
     ----------
@@ -48,10 +48,7 @@ class LinearModel(BaseEstimator):
 
     References
     ----------
-    .. [1] Haufe, S., Meinecke, F., Gorgen, K., Dahne, S., Haynes, J.-D.,
-           Blankertz, B., & Biebmann, F. (2014). On the interpretation of
-           weight vectors of linear models in multivariate neuroimaging.
-           NeuroImage, 87, 96-110.
+    .. footbibliography::
     """
 
     def __init__(self, model=None):  # noqa: D102
@@ -299,7 +296,7 @@ def get_coef(estimator, attr='filters_', inverse_transform=False):
     """Retrieve the coefficients of an estimator ending with a Linear Model.
 
     This is typically useful to retrieve "spatial filters" or "spatial
-    patterns" of decoding models [1]_.
+    patterns" of decoding models :footcite:`HaufeEtAl2014`.
 
     Parameters
     ----------
@@ -319,10 +316,7 @@ def get_coef(estimator, attr='filters_', inverse_transform=False):
 
     References
     ----------
-    .. [1] Haufe, S., Meinecke, F., Gorgen, K., Dahne, S., Haynes, J.-D.,
-       Blankertz, B., & Biessmann, F. (2014). On the interpretation of weight
-       vectors of linear models in multivariate neuroimaging. NeuroImage, 87,
-       96-110. doi:10.1016/j.neuroimage.2013.10.067.
+    .. footbibliography::
     """
     # Get the coefficients of the last estimator in case of nested pipeline
     est = estimator

--- a/tutorials/machine-learning/plot_sensors_decoding.py
+++ b/tutorials/machine-learning/plot_sensors_decoding.py
@@ -197,8 +197,8 @@ print('Spatio-temporal: %0.1f%%' % (100 * score,))
 # We can use CSP with these data with:
 
 csp = CSP(n_components=3, norm_trace=False)
-clf = make_pipeline(csp, LogisticRegression(solver='lbfgs'))
-scores = cross_val_multiscore(clf, X, y, cv=5, n_jobs=1)
+clf_csp = make_pipeline(csp, LinearModel(LogisticRegression(solver='lbfgs')))
+scores = cross_val_multiscore(clf_csp, X, y, cv=5, n_jobs=1)
 print('CSP: %0.1f%%' % (100 * scores.mean(),))
 
 ###############################################################################
@@ -320,11 +320,11 @@ time_decod = SlidingEstimator(clf, n_jobs=1, scoring='roc_auc', verbose=True)
 time_decod.fit(X, y)
 
 coef = get_coef(time_decod, 'patterns_', inverse_transform=True)
-evoked = mne.EvokedArray(coef, epochs.info, tmin=epochs.times[0])
+evoked_time_gen = mne.EvokedArray(coef, epochs.info, tmin=epochs.times[0])
 joint_kwargs = dict(ts_args=dict(time_unit='s'),
                     topomap_args=dict(time_unit='s'))
-evoked.plot_joint(times=np.arange(0., .500, .100), title='patterns',
-                  **joint_kwargs)
+evoked_time_gen.plot_joint(times=np.arange(0., .500, .100), title='patterns',
+                           **joint_kwargs)
 
 ###############################################################################
 # Temporal generalization
@@ -379,6 +379,21 @@ ax.set_title('Temporal generalization')
 ax.axvline(0, color='k')
 ax.axhline(0, color='k')
 plt.colorbar(im, ax=ax)
+
+###############################################################################
+# Projecting sensor-space patterns to source space
+# ================================================
+# If you use a linear classifier (or regressor) for your data, you can also
+# project these to source space. For example, using our ``evoked_time_gen``
+# from before:
+
+fwd = mne.read_forward_solution(
+    data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif')
+cov = mne.compute_covariance(epochs, tmax=0.)
+inv = mne.minimum_norm.make_inverse_operator(
+    evoked_time_gen.info, fwd, cov, loose=0.)
+stc = mne.minimum_norm.apply_inverse(evoked_time_gen, inv, 1. / 9., 'dSPM')
+brain = stc.plot(hemi='split', views=('lat', 'med'), initial_time=0.1)
 
 ###############################################################################
 # Source-space decoding


### PR DESCRIPTION
@SherazKhan asked if we had an example of projecting decoder coefficients to source space yet and I didn't think we did. This adds it to the decoding tutorial, and cleans up some refs to use the new footbib magic.