### PR TITLE
MRG, FIX: Fix path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
                     fi;
                     if [[ $(cat $FNAME | grep -x ".*datasets.*hcp_mmp_parcellation.*" | wc -l) -gt 0 ]]; then
                       python -c "import mne; print(mne.datasets.sample.data_path(update_path=True))";
-                      python -c "import mne; print(mne.datasets.fetch_hcp_mmp_parcellation())" --accept-hcpmmp-license;
+                      python -c "import mne; print(mne.datasets.fetch_hcp_mmp_parcellation(subjects_dir=mne.datasets.sample.data_path() + '/subjects'))" --accept-hcpmmp-license;
                     fi;
                     if [[ $(cat $FNAME | grep -x ".*datasets.*misc.*" | wc -l) -gt 0 ]]; then
                       python -c "import mne; print(mne.datasets.misc.data_path(update_path=True))";

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -570,7 +570,7 @@ def _download_all_example_data(verbose=True):
                    eegbci, multimodal, opm, hf_sef, mtrf, fieldtrip_cmc,
                    kiloword, phantom_4dbti, sleep_physionet, limo,
                    fnirs_motor)
-    sample.data_path()
+    sample_path = sample.data_path()
     testing.data_path()
     misc.data_path()
     spm_face.data_path()
@@ -602,7 +602,7 @@ def _download_all_example_data(verbose=True):
     fetch_fsaverage(None)
     sys.argv += ['--accept-hcpmmp-license']
     try:
-        fetch_hcp_mmp_parcellation()
+        fetch_hcp_mmp_parcellation(subjects_dir=sample_path + '/subjects')
     finally:
         sys.argv.pop(-1)
     limo.load_data(subject=1, update_path=True)


### PR DESCRIPTION
In #7704 I removed a `SUBJECTS_DIR` env var in `.circleci/config.yml` to ensure it's always set properly in examples. This led to a CircleCI failure:

https://app.circleci.com/pipelines/github/mne-tools/mne-python/1377/workflows/28bc8b26-4c73-4c33-ae3b-1dd76b7f1d20/jobs/19789/steps

This should fix it by passing a path when doing `fetch_hcpmmp_parcellation`.