### PR TITLE
BF: Improvements to viz.get_3d_backend()

### DIFF
--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -135,13 +135,12 @@ def _get_3d_backend():
         MNE_3D_BACKEND = get_config(key='MNE_3D_BACKEND', default=None)
         if MNE_3D_BACKEND is None:  # try them in order
             for name in VALID_3D_BACKENDS:
-                MNE_3D_BACKEND = name
                 try:
                     _reload_backend(name)
                 except ImportError:
-                    pass
+                    continue
                 else:
-                    break
+                    MNE_3D_BACKEND = name
             else:
                 raise RuntimeError('Could not load any valid 3D backend: %s'
                                    % (VALID_3D_BACKENDS))

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -121,11 +121,7 @@ def get_3d_backend():
         The 3d backend currently in use. If no backend is found,
         returns ``None``.
     """
-    try:
-        backend = _get_3d_backend()
-    except RuntimeError:
-        return None
-    return backend
+    return MNE_3D_BACKEND
 
 
 def _get_3d_backend():

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -137,6 +137,7 @@ def _get_3d_backend():
                     continue
                 else:
                     MNE_3D_BACKEND = name
+                    break
             else:
                 raise RuntimeError('Could not load any valid 3D backend: %s'
                                    % (VALID_3D_BACKENDS))

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -121,7 +121,11 @@ def get_3d_backend():
         The 3d backend currently in use. If no backend is found,
         returns ``None``.
     """
-    return MNE_3D_BACKEND
+    try:
+        backend = _get_3d_backend()
+    except RuntimeError:
+        return None
+    return backend
 
 
 def _get_3d_backend():

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -10,7 +10,6 @@ import os
 import pytest
 import numpy as np
 
-import mne
 from mne.viz.backends.tests._utils import (skips_if_not_mayavi,
                                            skips_if_not_pyvista)
 
@@ -155,9 +154,10 @@ def test_3d_backend(renderer):
     rend.show()
 
 
-def test_get_3d_backend(backend_mocker):
-    """Test get_3d_backend private function call for side-effects."""
+def test_get_3d_backend():
+    """Test get_3d_backend function call for side-effects."""
+    from mne.viz.backends import renderer
     # Test twice to ensure the first call had no side-effect
-    mne.viz.backends.renderer.MNE_3D_BACKEND = None
-    assert mne.viz._get_3d_backend() is None
-    assert mne.viz._get_3d_backend() is None
+    orig_backend = renderer.MNE_3D_BACKEND
+    assert renderer.get_3d_backend() == orig_backend
+    assert renderer.get_3d_backend() == orig_backend

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -156,10 +156,8 @@ def test_3d_backend(renderer):
 
 
 @skips_if_not_pyvista
-def test_get_3d_backend():
+def test_get_3d_backend(backend_mocker):
     """Test get_3d_backend."""
-    orig_backend = mne.viz.backends.renderer.MNE_3D_BACKEND
-
     # Test the private function first.
     # Test twice to ensure the first call had no side-effect
     mne.viz.backends.renderer.MNE_3D_BACKEND = None
@@ -172,6 +170,3 @@ def test_get_3d_backend():
 
     mne.viz.set_3d_backend('pyvista')
     assert mne.viz.get_3d_backend() == 'pyvista'
-
-    # Restore.
-    mne.viz.backends.renderer.MNE_3D_BACKEND = orig_backend

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -155,15 +155,23 @@ def test_3d_backend(renderer):
     rend.show()
 
 
+@skips_if_not_pyvista
 def test_get_3d_backend():
     """Test get_3d_backend."""
     orig_backend = mne.viz.backends.renderer.MNE_3D_BACKEND
 
-    mne.viz.backends.renderer.MNE_3D_BACKEND = None
-
+    # Test the private function first.
     # Test twice to ensure the first call had no side-effect
+    mne.viz.backends.renderer.MNE_3D_BACKEND = None
+    assert mne.viz._get_3d_backend() is None
+    assert mne.viz._get_3d_backend() is None
+
+    # Now test the public function.
+    mne.viz.backends.renderer.MNE_3D_BACKEND = None
     assert mne.viz.get_3d_backend() is None
-    assert mne.viz.get_3d_backend() is None
+
+    mne.viz.set_3d_backend('pyvista')
+    assert mne.viz.get_3d_backend() == 'pyvista'
 
     # Restore.
     mne.viz.backends.renderer.MNE_3D_BACKEND = orig_backend

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -155,18 +155,9 @@ def test_3d_backend(renderer):
     rend.show()
 
 
-@skips_if_not_pyvista
 def test_get_3d_backend(backend_mocker):
-    """Test get_3d_backend."""
-    # Test the private function first.
+    """Test get_3d_backend private function call for side-effects."""
     # Test twice to ensure the first call had no side-effect
     mne.viz.backends.renderer.MNE_3D_BACKEND = None
     assert mne.viz._get_3d_backend() is None
     assert mne.viz._get_3d_backend() is None
-
-    # Now test the public function.
-    mne.viz.backends.renderer.MNE_3D_BACKEND = None
-    assert mne.viz.get_3d_backend() is None
-
-    mne.viz.set_3d_backend('pyvista')
-    assert mne.viz.get_3d_backend() == 'pyvista'

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -10,6 +10,7 @@ import os
 import pytest
 import numpy as np
 
+import mne
 from mne.viz.backends.tests._utils import (skips_if_not_mayavi,
                                            skips_if_not_pyvista)
 
@@ -152,3 +153,17 @@ def test_3d_backend(renderer):
                     focalpoint=center)
     rend.reset_camera()
     rend.show()
+
+
+def test_get_3d_backend():
+    """Test get_3d_backend."""
+    orig_backend = mne.viz.backends.renderer.MNE_3D_BACKEND
+
+    mne.viz.backends.renderer.MNE_3D_BACKEND = None
+
+    # Test twice to ensure the first call had no side-effect
+    assert mne.viz.get_3d_backend() is None
+    assert mne.viz.get_3d_backend() is None
+
+    # Restore.
+    mne.viz.backends.renderer.MNE_3D_BACKEND = orig_backend


### PR DESCRIPTION
#### What does this implement/fix?
This builds upon #7688.

On `master`, I observed the following behavior on a machine without a working 3D backend:

MWE:
```python
import mne

print(mne.viz.get_3d_backend())
print(mne.viz.get_3d_backend())
```

`master`:
```
None
pyvista
```

Reason is that when probing for usable backends, `MNE_3D_BACKEND` is being set _before the probing is carried out_, so when it fails, the variable has already been changed, and is not reset to its previous state. df2e395 fixes the behavior and only changes `MNE_3D_BACKEND` is probing the 3D backend was successful:
```
None
None
```

<strike>I also realized that `viz.get_3d_backend()` can be simplified much more: since `MNE_3D_BACKEND` should always contain the currently used backend, `get_3d_backend()` can simply return this value. There's no need to invoke `_get_3d_backend()`. These changes are implemented in 2729896</strike>