### PR TITLE
[MRG] Adding temporary fix for montage transformation.

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -55,6 +55,8 @@ Changelog
 
 - Add ``plot`` option to :meth:`mne.viz.plot_filter` allowing selection of which filter properties are plotted and added option for user to supply ``axes`` by `Robert Luke`_
 
+- Add ``transform_head`` option to :meth:`mne.io.Raw.set_montage` to allow transformation of montage to 'head' coordinates to be turned off by `Adam Li`_
+
 Bug
 ~~~
 

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -646,7 +646,8 @@ def _get_montage_in_head(montage):
 
 
 @fill_doc
-def _set_montage(info, montage, match_case=True, on_missing='raise'):
+def _set_montage(info, montage, match_case=True,
+                 transform_head=True, on_missing='raise'):
     """Apply montage to data.
 
     With a DigMontage, this function will replace the digitizer info with
@@ -661,6 +662,9 @@ def _set_montage(info, montage, match_case=True, on_missing='raise'):
         The measurement info to update.
     %(montage)s
     %(match_case)s
+    transform_head: bool
+            Apply the MNE head transformation to montage
+            (default is True), or not.
     %(on_missing_montage)s
 
     Notes
@@ -678,8 +682,10 @@ def _set_montage(info, montage, match_case=True, on_missing='raise'):
         _check_option('on_missing', on_missing, ['raise',
                                                  'ignore',
                                                  'warn'])
-
-        mnt_head = _get_montage_in_head(montage)
+        if transform_head:
+            mnt_head = _get_montage_in_head(montage)
+        else:
+            mnt_head = montage
 
         def _backcompat_value(pos, ref_pos):
             if any(np.isnan(pos)):

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -662,7 +662,7 @@ def _set_montage(info, montage, match_case=True,
         The measurement info to update.
     %(montage)s
     %(match_case)s
-    transform_head: bool
+    transform_head : bool
             Apply the MNE head transformation to montage
             (default is True), or not.
     %(on_missing_montage)s

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1211,10 +1211,12 @@ def test_set_montage_coord_frame_in_head_vs_unknown():
     raw.set_montage(montage_in_unknown, transform_head=False)
     assert _check_get_coord_frame(raw.info['dig']) == 'unknown'
 
+    # default should transform to head
     with pytest.warns(RuntimeWarning, match='Fiducial point '
                                             'nasion not found'):
         raw.set_montage(montage_in_unknown)
         assert _check_get_coord_frame(raw.info['dig']) == 'head'
+
 
 def test_set_montage_with_missing_coordinates():
     """Test set montage with missing coordinates."""

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1211,8 +1211,10 @@ def test_set_montage_coord_frame_in_head_vs_unknown():
     raw.set_montage(montage_in_unknown, transform_head=False)
     assert _check_get_coord_frame(raw.info['dig']) == 'unknown'
 
-    raw.set_montage(montage_in_unknown)
-    assert _check_get_coord_frame(raw.info['dig']) == 'head'
+    with pytest.warns(RuntimeWarning, match='Fiducial point '
+                                            'nasion not found'):
+        raw.set_montage(montage_in_unknown)
+        assert _check_get_coord_frame(raw.info['dig']) == 'head'
 
 def test_set_montage_with_missing_coordinates():
     """Test set montage with missing coordinates."""

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1203,6 +1203,14 @@ def test_set_montage_coord_frame_in_head_vs_unknown():
         [[0, 1, 2], [3, 4, 5], [6, 7, 8]],
     )
 
+    # test that unknown montage is still unknown
+    raw = _make_toy_raw(N_CHANNELS)
+    montage_in_unknown = _make_toy_dig_montage(
+        N_CHANNELS, coord_frame='unknown'
+    )
+    raw.set_montage(montage_in_unknown, transform_head=False)
+    assert _check_get_coord_frame(raw.info['dig']) == 'unknown'
+
 
 def test_set_montage_with_missing_coordinates():
     """Test set montage with missing coordinates."""

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1211,6 +1211,8 @@ def test_set_montage_coord_frame_in_head_vs_unknown():
     raw.set_montage(montage_in_unknown, transform_head=False)
     assert _check_get_coord_frame(raw.info['dig']) == 'unknown'
 
+    raw.set_montage(montage_in_unknown)
+    assert _check_get_coord_frame(raw.info['dig']) == 'head'
 
 def test_set_montage_with_missing_coordinates():
     """Test set montage with missing coordinates."""

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -150,7 +150,7 @@ class MontageMixin(object):
     """Mixin for Montage setting."""
 
     @verbose
-    def set_montage(self, montage, match_case=True,
+    def set_montage(self, montage, match_case=True, transform_head=True,
                     on_missing='raise', verbose=None):
         """Set EEG sensor configuration and head digitization.
 
@@ -158,6 +158,9 @@ class MontageMixin(object):
         ----------
         %(montage)s
         %(match_case)s
+        transform_head: bool
+            Apply the MNE head transformation to montage
+            (default is True), or not.
         %(on_missing_montage)s
         %(verbose_meth)s
 
@@ -175,7 +178,7 @@ class MontageMixin(object):
 
         from ..channels.montage import _set_montage
         info = self if isinstance(self, Info) else self.info
-        _set_montage(info, montage, match_case, on_missing)
+        _set_montage(info, montage, match_case, transform_head, on_missing)
         return self
 
 

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -158,7 +158,7 @@ class MontageMixin(object):
         ----------
         %(montage)s
         %(match_case)s
-        transform_head: bool
+        transform_head : bool
             Apply the MNE head transformation to montage
             (default is True), or not.
         %(on_missing_montage)s


### PR DESCRIPTION
#### Reference issue
Partially addresses problem in #7691 

#### What does this implement/fix?
Adds a boolean parameter to `set_montage` to allow head transformation of the montage to be turned off. This allows 'unknown' montages to be set on the Raw data structure.


#### Additional information
Defaults to true for backwards compatibility. 