### PR TITLE
MRG: Speedup testing of _Brain

### DIFF
--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -76,19 +76,13 @@ def test_brain(renderer):
         _Brain(subject_id=subject_id, hemi='foo', surf=surf)
 
     # cortex
-    for cortex in ['classic', 'low_contrast', 'high_contrast', 'bone']:
-        brain = _Brain(subject_id, hemi=hemi, surf=surf, size=size,
-                       subjects_dir=subjects_dir, title='test',
-                       cortex=cortex)
-        brain.close()
-
+    brain = _Brain(subject_id, hemi=hemi, surf=surf, size=size,
+                   subjects_dir=subjects_dir, title='test',
+                   cortex='low_contrast')
     # add_data
     stc = read_source_estimate(fname_stc)
     fmin = stc.data.min()
     fmax = stc.data.max()
-
-    brain = _Brain(subject_id, hemi=hemi, surf=surf, size=size,
-                   subjects_dir=subjects_dir)
     for h in brain._hemis:
         if h == 'lh':
             hi = 0

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -60,10 +60,10 @@ class TstVTKPicker(object):
 def test_brain(renderer):
     """Test initialization of the _Brain instance."""
     from mne.label import read_label
-
-    # init
     hemi = 'lh'
     surf = 'inflated'
+    cortex = 'low_contrast'
+    title = 'test'
     size = (300, 300)
 
     with pytest.raises(ValueError, match='"size" parameter must be'):
@@ -75,10 +75,9 @@ def test_brain(renderer):
     with pytest.raises(KeyError):
         _Brain(subject_id=subject_id, hemi='foo', surf=surf)
 
-    # cortex
     brain = _Brain(subject_id, hemi=hemi, surf=surf, size=size,
-                   subjects_dir=subjects_dir, title='test',
-                   cortex='low_contrast')
+                   subjects_dir=subjects_dir, title=title,
+                   cortex=cortex)
     # add_data
     stc = read_source_estimate(fname_stc)
     fmin = stc.data.min()

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -29,7 +29,6 @@ fname_stc = path.join(data_path, 'MEG/sample/sample_audvis_trunc-meg')
 fname_label = path.join(data_path, 'MEG/sample/labels/Vis-lh.label')
 src_fname = path.join(data_path, 'subjects', 'sample', 'bem',
                       'sample-oct-6-src.fif')
-surf = 'inflated'
 
 
 class TstVTKPicker(object):
@@ -58,9 +57,14 @@ class TstVTKPicker(object):
 
 
 @testing.requires_testing_data
-def test_brain_init(renderer):
+def test_brain(renderer):
     """Test initialization of the _Brain instance."""
+    from mne.label import read_label
+
+    # init
     hemi = 'lh'
+    surf = 'inflated'
+    size = (300, 300)
 
     with pytest.raises(ValueError, match='"size" parameter must be'):
         _Brain(subject_id=subject_id, hemi=hemi, surf=surf, size=[1, 2, 3])
@@ -71,114 +75,81 @@ def test_brain_init(renderer):
     with pytest.raises(KeyError):
         _Brain(subject_id=subject_id, hemi='foo', surf=surf)
 
+    # cortex
     for cortex in ['classic', 'low_contrast', 'high_contrast', 'bone']:
-        brain = _Brain(subject_id, hemi, surf, size=(300, 300),
+        brain = _Brain(subject_id, hemi=hemi, surf=surf, size=size,
                        subjects_dir=subjects_dir, title='test',
                        cortex=cortex)
-        brain.show_view(view=dict(azimuth=180., elevation=90.))
-    brain.close()
+        brain.close()
 
-
-@testing.requires_testing_data
-def test_brain_screenshot(renderer):
-    """Test screenshot of a _Brain instance."""
-    brain = _Brain(subject_id, hemi='both', size=600,
-                   surf=surf, subjects_dir=subjects_dir)
-    img = brain.screenshot(mode='rgb')
-    assert(img.shape == (600, 600, 3))
-    brain.close()
-
-
-@testing.requires_testing_data
-def test_brain_add_data(renderer):
-    """Test adding data in _Brain instance."""
+    # add_data
     stc = read_source_estimate(fname_stc)
-
-    hemi = 'lh'
-    hemi_data = stc.data[:len(stc.vertices[0]), 10]
-    hemi_vertices = stc.vertices[0]
     fmin = stc.data.min()
     fmax = stc.data.max()
 
-    brain_data = _Brain(subject_id, hemi, surf, size=300,
-                        subjects_dir=subjects_dir)
+    brain = _Brain(subject_id, hemi=hemi, surf=surf, size=size,
+                   subjects_dir=subjects_dir)
+    for h in brain._hemis:
+        if h == 'lh':
+            hi = 0
+        else:
+            hi = 1
+        hemi_data = stc.data[:len(stc.vertices[hi]), 10]
+        hemi_vertices = stc.vertices[hi]
 
-    with pytest.raises(TypeError, match='scale_factor'):
-        brain_data.add_data(hemi_data, scale_factor='foo')
-    with pytest.raises(TypeError, match='vector_alpha'):
-        brain_data.add_data(hemi_data, vector_alpha='foo')
-    with pytest.raises(ValueError, match='thresh'):
-        brain_data.add_data(hemi_data, thresh=-1)
-    with pytest.raises(ValueError, match='remove_existing'):
-        brain_data.add_data(hemi_data, remove_existing=-1)
-    with pytest.raises(ValueError, match='time_label_size'):
-        brain_data.add_data(hemi_data, time_label_size=-1)
-    with pytest.raises(ValueError, match='is positive'):
-        brain_data.add_data(hemi_data, smoothing_steps=-1)
-    with pytest.raises(TypeError, match='int or NoneType'):
-        brain_data.add_data(hemi_data, smoothing_steps='foo')
-    with pytest.raises(ValueError):
-        brain_data.add_data(array=np.array([0, 1, 2]))
-    with pytest.raises(ValueError):
-        brain_data.add_data(hemi_data, fmin=fmin, hemi=hemi,
-                            fmax=fmax, vertices=None)
+        with pytest.raises(TypeError, match='scale_factor'):
+            brain.add_data(hemi_data, hemi=h, scale_factor='foo')
+        with pytest.raises(TypeError, match='vector_alpha'):
+            brain.add_data(hemi_data, hemi=h, vector_alpha='foo')
+        with pytest.raises(ValueError, match='thresh'):
+            brain.add_data(hemi_data, hemi=h, thresh=-1)
+        with pytest.raises(ValueError, match='remove_existing'):
+            brain.add_data(hemi_data, hemi=h, remove_existing=-1)
+        with pytest.raises(ValueError, match='time_label_size'):
+            brain.add_data(hemi_data, hemi=h, time_label_size=-1)
+        with pytest.raises(ValueError, match='is positive'):
+            brain.add_data(hemi_data, hemi=h, smoothing_steps=-1)
+        with pytest.raises(TypeError, match='int or NoneType'):
+            brain.add_data(hemi_data, hemi=h, smoothing_steps='foo')
+        with pytest.raises(ValueError):
+            brain.add_data(array=np.array([0, 1, 2]), hemi=h)
+        with pytest.raises(ValueError):
+            brain.add_data(hemi_data, fmin=fmin, hemi=hemi,
+                           fmax=fmax, vertices=None)
 
-    brain_data.add_data(hemi_data, fmin=fmin, hemi=hemi, fmax=fmax,
-                        colormap='hot', vertices=hemi_vertices,
-                        smoothing_steps='nearest', colorbar=False, time=None)
-    brain_data.add_data(hemi_data, fmin=fmin, hemi=hemi, fmax=fmax,
-                        colormap='hot', vertices=hemi_vertices,
-                        smoothing_steps=1, initial_time=0., colorbar=False,
-                        time=None)
-    brain_data.close()
+        brain.add_data(hemi_data, fmin=fmin, hemi=h, fmax=fmax,
+                       colormap='hot', vertices=hemi_vertices,
+                       smoothing_steps='nearest', colorbar=False, time=None)
+        brain.add_data(hemi_data, fmin=fmin, hemi=h, fmax=fmax,
+                       colormap='hot', vertices=hemi_vertices,
+                       smoothing_steps=1, initial_time=0., colorbar=False,
+                       time=None)
 
+    # add label
+    label = read_label(fname_label)
+    brain.add_label(label, scalar_thresh=0.)
 
-@testing.requires_testing_data
-def test_brain_add_annotation(renderer):
-    """Test adding data in _Brain instance."""
+    # add foci
+    brain.add_foci([0], coords_as_verts=True,
+                   hemi=hemi, color='blue')
+
+    # add text
+    brain.add_text(x=0, y=0, text='foo')
+
+    # screenshot
+    brain.show_view(view=dict(azimuth=180., elevation=90.))
+    img = brain.screenshot(mode='rgb')
+    assert(img.shape == (size[0], size[1], 3))
+
+    # add annotation
     annots = ['aparc', 'PALS_B12_Lobes']
     borders = [True, 2]
     alphas = [1, 0.5]
-    brain = _Brain(subject_id='fsaverage', hemi='lh', size=500,
+    brain = _Brain(subject_id='fsaverage', hemi=hemi, size=size,
                    surf='inflated', subjects_dir=subjects_dir)
-
     for a, b, p in zip(annots, borders, alphas):
         brain.add_annotation(a, b, p)
-    brain.close()
 
-
-@testing.requires_testing_data
-def test_brain_add_label(renderer):
-    """Test adding data in _Brain instance."""
-    from mne.label import read_label
-    brain = _Brain(subject_id, hemi='lh', size=500,
-                   surf=surf, subjects_dir=subjects_dir)
-    label = read_label(fname_label)
-    brain.add_label(label, scalar_thresh=0.)
-    brain.close()
-
-    brain = _Brain(subject_id, hemi='split', size=500,
-                   surf=surf, subjects_dir=subjects_dir)
-    brain.add_label(fname_label)
-    brain.close()
-
-
-@testing.requires_testing_data
-def test_brain_add_foci(renderer):
-    """Test adding foci in _Brain instance."""
-    brain = _Brain(subject_id, hemi='lh', size=500,
-                   surf=surf, subjects_dir=subjects_dir)
-    brain.add_foci([0], coords_as_verts=True,
-                   hemi='lh', color='blue')
-    brain.close()
-
-
-@testing.requires_testing_data
-def test_brain_add_text(renderer):
-    """Test adding text in _Brain instance."""
-    brain = _Brain(subject_id, hemi='lh', size=250,
-                   surf=surf, subjects_dir=subjects_dir)
-    brain.add_text(x=0, y=0, text='foo')
     brain.close()
 
 
@@ -394,7 +365,7 @@ def test_brain_colormap():
         calculate_lut(colormap, alpha, 1, 0, 2)
 
 
-def _create_testing_brain(hemi):
+def _create_testing_brain(hemi, surf='inflated'):
     sample_src = read_source_spaces(src_fname)
 
     # dense version

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -76,6 +76,7 @@ class _Renderer(_BaseRenderer):
             self.fig = _mlab_figure(figure=fig, bgcolor=bgcolor, size=size)
         else:
             self.fig = fig
+        self.fig._window_size = size
         _toggle_mlab_render(self.fig, show)
 
     def subplot(self, x, y):
@@ -464,7 +465,7 @@ def _take_3d_screenshot(figure, mode='rgb', filename=None):
     if MNE_3D_BACKEND_TESTING:
         ndim = 3 if mode == 'rgb' else 4
         if figure.scene is None:
-            figure_size = (600, 600)
+            figure_size = figure._window_size
         else:
             figure_size = figure.scene._renwin.size
         return np.zeros(tuple(figure_size) + (ndim,), np.uint8)


### PR DESCRIPTION
This PR follows https://github.com/mne-tools/mne-python/pull/7701#issuecomment-623471954 idea and tries to decrease the number of calls to `_Brain.__init__()` which seems costly. Hopefully this will reduce testing time especially on macOS.