### PR TITLE
DOC: tiny typo fix [ci skip]

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1799,7 +1799,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         Notes
         -----
         This method returns a copy and does not modify the data it
-        operates on. It also returns an EpochsArraw instance.
+        operates on. It also returns an EpochsArray instance.
 
         .. versionadded:: 0.20.0
         """

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -451,7 +451,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         Notes
         -----
         This method returns a copy and does not modify the data it
-        operates on. It also returns an EvokedArraw instance.
+        operates on. It also returns an EvokedArray instance.
 
         .. versionadded:: 0.9.0
         """


### PR DESCRIPTION
tiny typo fix `Arraw` -> `Array`