### PR TITLE
MRG: Add ability to load NIRX data by passing path to header file

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -41,6 +41,8 @@ Changelog
 
 - Add functionality to interpolate bad NIRS channels by `Robert Luke`_
 
+- Added ability of :func:`mne.io.read_raw_nirx` to open data by passing path to header file `Robert Luke`_
+
 - Add :meth:`mne.channels.DigMontage.rename_channels` to allow renaming montage channels by `Eric Larson`_
 
 - Add support to in :meth:`mne.io.Raw.plot` for passing ``clipping`` as a float to clip to a proportion of the dedicated channel range by `Eric Larson`_

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -5,6 +5,7 @@
 from configparser import ConfigParser, RawConfigParser
 import glob as glob
 import re as re
+import os.path as op
 
 import numpy as np
 
@@ -23,7 +24,7 @@ def read_raw_nirx(fname, preload=False, verbose=None):
     Parameters
     ----------
     fname : str
-        Path to the NIRX data folder.
+        Path to the NIRX data folder or header file.
     %(preload)s
     %(verbose)s
 
@@ -50,7 +51,7 @@ class RawNIRX(BaseRaw):
     Parameters
     ----------
     fname : str
-        Path to the NIRX data folder.
+        Path to the NIRX data folder or header file.
     %(preload)s
     %(verbose)s
 
@@ -64,6 +65,9 @@ class RawNIRX(BaseRaw):
         from ...externals.pymatreader import read_mat
         from ...coreg import get_mni_fiducials  # avoid circular import prob
         logger.info('Loading %s' % fname)
+
+        if fname.endswith('.hdr'):
+            fname = op.dirname(op.abspath(fname))
 
         # Check if required files exist and store names for later use
         files = dict()

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -26,6 +26,17 @@ fname_nirx_15_2_short = op.join(data_path(download=False),
 
 
 @requires_testing_data
+def test_nirx_hdr_load():
+    """Test reading NIRX files using path to header file."""
+    fname = fname_nirx_15_2_short + "/NIRS-2019-08-23_001.hdr"
+    raw = read_raw_nirx(fname, preload=True)
+
+    # Test data import
+    assert raw._data.shape == (26, 145)
+    assert raw.info['sfreq'] == 12.5
+
+
+@requires_testing_data
 def test_nirx_15_2_short():
     """Test reading NIRX files."""
     raw = read_raw_nirx(fname_nirx_15_2_short, preload=True)


### PR DESCRIPTION
#### Reference issue
https://github.com/cbrnr/mnelab/issues/144#issuecomment-623066162


#### What does this implement/fix?
Allows user to pass the path to a NIRX header file to load data, rather than passing the path to the directory.

This was suggested as a way to easily add data loading to MNELAB (see comment above).

