### PR TITLE
Raise error if saving complex-valued STC as FIFF

### DIFF
--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1549,6 +1549,11 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
         rh_data = self.data[-len(self.rh_vertno):]
 
         if ftype == 'stc':
+            if np.iscomplexobj(self.data):
+                raise ValueError("Cannot save complex-valued STC data in "
+                                 "FIFF format; please set ftype='h5' to save "
+                                 "in HDF5 format instead, or cast the data to "
+                                 "real numbers before saving.")
             logger.info('Writing STC to disk...')
             _write_stc(fname + '-lh.stc', tmin=self.tmin, tstep=self.tstep,
                        vertices=self.lh_vertno, data=lh_data)

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -360,9 +360,9 @@ def test_io_stc(tmpdir):
         assert_array_almost_equal(v1, v2)
     assert_array_almost_equal(stc.tstep, stc2.tstep)
     # test warning for complex data
-    stc2.data += 0j
+    stc2.data = stc2.data.astype(np.complex128)
     with pytest.raises(ValueError, match='Cannot save complex-valued STC'):
-        stc.save(tmpdir.join('complex.stc'))
+        stc2.save(tmpdir.join('complex.stc'))
 
 
 @requires_h5py

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -359,6 +359,10 @@ def test_io_stc(tmpdir):
     for v1, v2 in zip(stc.vertices, stc2.vertices):
         assert_array_almost_equal(v1, v2)
     assert_array_almost_equal(stc.tstep, stc2.tstep)
+    # test warning for complex data
+    stc2.data += 0j
+    with pytest.raises(ValueError, match='Cannot save complex-valued STC'):
+        stc.save(tmpdir.join('complex.stc'))
 
 
 @requires_h5py


### PR DESCRIPTION
following offline discussion with @larsoner, this raises a `ValueError` (instead of warning) when attempting to save an STC containing complex-valued data in the FIFF format.