### PR TITLE
MRG, ENH: Add tol_kind option

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -31,6 +31,8 @@ Changelog
 
 - Add method :meth:`mne.VolSourceEstimate.in_label` by `Eric Larson`_
 
+- Add ``tol_kind`` option to :func:`mne.compute_rank` by `Eric Larson`_
+
 - Allow resampling raw data with :func:`mne.io.Raw.resample` without preloading data, by `Eric Larson`_
 
 - Allow using ``pick_ori='vector'`` with a fixed-orientation inverse to facilitate visualization with :func:`mne.viz.plot_vector_source_estimates` by `Eric Larson`_

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -522,6 +522,29 @@ rank : None | dict | 'info' | 'full'
     of :func:`mne.compute_rank` for details."""
 docdict['rank_None'] = docdict['rank'] + 'The default is None.'
 docdict['rank_info'] = docdict['rank'] + 'The default is "info".'
+docdict['rank_tol'] = """
+tol : float | 'auto'
+    Tolerance for singular values to consider non-zero in
+    calculating the rank. The singular values are calculated
+    in this method such that independent data are expected to
+    have singular value around one. Can be 'auto' to use the
+    same thresholding as :func:`scipy.linalg.orth`.
+"""
+docdict['rank_tol_kind'] = """
+tol_kind : str
+    Can be: "absolute" or "relative". After applying the chosen scale factors
+    / normalization to the data, the singular values are computed, and
+    the rank is then given by:
+
+    - ``'absolute'``
+        The number of singular values ``s`` greater than ``tol``.
+    - ``'relative'``
+        The number of singular values ``s`` greater than ``tol * s.max()``.
+
+    This value is ignored when ``tol`` is a string, as it's always relative.
+
+    .. versionadded:: 0.21.0
+"""
 
 # Inverses
 docdict['depth'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -532,16 +532,19 @@ tol : float | 'auto'
 """
 docdict['rank_tol_kind'] = """
 tol_kind : str
-    Can be: "absolute" or "relative". After applying the chosen scale factors
-    / normalization to the data, the singular values are computed, and
-    the rank is then given by:
+    Can be: "absolute" (default) or "relative". Only used if ``tol`` is a
+    float, because when ``tol`` is a string the mode is implicitly relative.
+    After applying the chosen scale factors / normalization to the data,
+    the singular values are computed, and the rank is then taken as:
 
     - ``'absolute'``
         The number of singular values ``s`` greater than ``tol``.
+        This mode can fail if your data do not adhere to typical
+        data scalings.
     - ``'relative'``
         The number of singular values ``s`` greater than ``tol * s.max()``.
-
-    This value is ignored when ``tol`` is a string, as it's always relative.
+        This mode can fail if you have one or more large components in the
+        data (e.g., artifacts).
 
     .. versionadded:: 0.21.0
 """


### PR DESCRIPTION
Digging through our code, I was a bit surprised to see that the `tol` we apply in `compute_rank` is an absolute one on the singular values (computed after whatever normalization/scaling you have selected). I've added a `tol_kind` option that allows treating this as a relative tolerance.

Another option would be to leave `tol` and add `rtol`, but that's weird because `tol='auto'` (and `tol='float32'`) already only behave as a relative tolerance, because they do the same thing that `pinv` does (scale relative to the max singular val).

Testing with some local MaxFiltered data suggests that it's more robust and flexible than using an absolute ``tol``. I also was able to add it to the dense `test_rank.py` tests without too many modifications/attempts to find a good value, which I can't say about the `absolute` version.