### PR TITLE
MRG: Motion Annotation

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -127,7 +127,6 @@ API
 
 - The method ``stc_mixed.plot_surface`` for a :class:`mne.MixedSourceEstimate` has been deprecated in favor of :meth:`stc.surface().plot(...) <mne.MixedSourceEstimate.surface>` by `Eric Larson`_
 
-- Add ``use_dev_head_trans`` parameter to :func:`mne.preprocessing.annotate_movement` to allow choosing the device to head
-transform is used to define the fixed cHPI coordinates By `Luke Bloy`_
+- Add ``use_dev_head_trans`` parameter to :func:`mne.preprocessing.annotate_movement` to allow choosing the device to head transform is used to define the fixed cHPI coordinates By `Luke Bloy`_
 
 - The function ``mne.channels.read_dig_captrack`` will be deprecated in version 0.22 in favor of :func:`mne.channels.read_dig_captrak` to correct the spelling error: "captraCK" -> "captraK", by `Stefan Appelhoff`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -127,4 +127,7 @@ API
 
 - The method ``stc_mixed.plot_surface`` for a :class:`mne.MixedSourceEstimate` has been deprecated in favor of :meth:`stc.surface().plot(...) <mne.MixedSourceEstimate.surface>` by `Eric Larson`_
 
+- Add ``use_dev_head_trans`` parameter to :func:`mne.preprocessing.annotate_movement` to allow choosing the device to head
+transfrom is used to define the fixed cHPI coordinates By `Luke Bloy`_
+
 - The function ``mne.channels.read_dig_captrack`` will be deprecated in version 0.22 in favor of :func:`mne.channels.read_dig_captrak` to correct the spelling error: "captraCK" -> "captraK", by `Stefan Appelhoff`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -128,6 +128,6 @@ API
 - The method ``stc_mixed.plot_surface`` for a :class:`mne.MixedSourceEstimate` has been deprecated in favor of :meth:`stc.surface().plot(...) <mne.MixedSourceEstimate.surface>` by `Eric Larson`_
 
 - Add ``use_dev_head_trans`` parameter to :func:`mne.preprocessing.annotate_movement` to allow choosing the device to head
-transfrom is used to define the fixed cHPI coordinates By `Luke Bloy`_
+transform is used to define the fixed cHPI coordinates By `Luke Bloy`_
 
 - The function ``mne.channels.read_dig_captrack`` will be deprecated in version 0.22 in favor of :func:`mne.channels.read_dig_captrak` to correct the spelling error: "captraCK" -> "captraK", by `Stefan Appelhoff`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -60,6 +60,8 @@ Bug
 
 - Fix bug with :func:`mne.setup_volume_source_space` when ``volume_label`` was supplied where voxels slightly (in a worst case, about 37% times ``pos`` in distance) outside the voxel-grid-based bounds of regions were errantly included, by `Eric Larson`_
 
+- Fix bug with :func:`mne.preprocessing.annotate_movement` where bad data segments, specified in ``raw.annotations``, would be handled incorrectly by `Luke Bloy`_
+
 - Fix bug with :func:`mne.compute_source_morph` when more than one volume source space was present (e.g., when using labels) where only the first label would be interpolated when ``mri_resolution=True`` by `Eric Larson`_
 
 - Fix bug with :func:`mne.minimum_norm.compute_source_psd_epochs` and :func:`mne.minimum_norm.source_band_induced_power` raised errors when ``method='eLORETA'`` by `Eric Larson`_

--- a/mne/preprocessing/tests/test_artifact_detection.py
+++ b/mne/preprocessing/tests/test_artifact_detection.py
@@ -12,6 +12,7 @@ from mne.datasets import testing
 from mne.io import read_raw_fif
 from mne.preprocessing import (annotate_movement, compute_average_dev_head_t,
                                annotate_muscle_zscore)
+from mne import Annotations
 
 data_path = testing.data_path(download=False)
 sss_path = op.join(data_path, 'SSS')
@@ -49,6 +50,11 @@ def test_movement_annotation_head_correction():
                               [0., 0., 0., 1.]])
 
     assert_allclose(dev_head_t_ori, dev_head_t['trans'], rtol=1e-5, atol=0)
+
+    # Smoke test skipping time due to previous annotations.
+    raw.set_annotations(Annotations([raw.times[0]], 0.1, 'bad'))
+    annot_dis, disp = annotate_movement(raw, pos, mean_distance_limit=.02)
+    assert(annot_dis.duration.size == 1)
 
 
 @testing.requires_testing_data


### PR DESCRIPTION

`mne.preprocessing.annotate_movement` computes HPI displacements from an average position. Bad data segments (in `raw.annotations`) where meant to be excluded from this averaging. However there is a bug in computing the weights for averaging

Basically the weights (`seg_good`) are defined from `pos` which has different time samples from `raw`. So the onsets/durations of the bad annotations do line up with the indices of the `seg_good` array.

This PR uses `compute_average_dev_head_t` to compute an average transform (ignoring bad segments) and uses that to compute the average HPI locations.

Additionally, I'd like to propose adding a flag `use_raw_head_trans` (or similarly named) that if set would use `raw.info['dev_head_t']` as opposed to `compute_average_dev_head_t`. The default would be `False`

