### PR TITLE
MRG, MAINT: Add links to mini-galleries

### DIFF
--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -1,5 +1,4 @@
-{{ fullname }}
-{{ underline }}
+{{ fullname | escape | underline}}
 
 .. currentmodule:: {{ module }}
 
@@ -7,7 +6,9 @@
    :special-members: __contains__,__getitem__,__iter__,__len__,__add__,__sub__,__mul__,__div__,__neg__,__hash__
    :members:
 
-.. include:: {{fullname}}.examples
+.. _sphx_glr_backreferences_{{ fullname }}:
+
+.. include:: {{ fullname }}.examples
 
 .. raw:: html
 

--- a/doc/_templates/autosummary/function.rst
+++ b/doc/_templates/autosummary/function.rst
@@ -1,9 +1,10 @@
-{{ fullname }}
-{{ underline }}
+{{ fullname | escape | underline}}
 
 .. currentmodule:: {{ module }}
 
 .. autofunction:: {{ objname }}
+
+.. _sphx_glr_backreferences_{{ fullname }}:
 
 .. include:: {{ fullname }}.examples
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -387,6 +387,8 @@ def append_attr_meth_examples(app, what, name, obj, options, lines):
             op.dirname(__file__), 'generated', '%s.examples' % (name,)))
         if size > 0:
             lines += """
+.. _sphx_glr_backreferences_{1}:
+
 .. rubric:: Examples using ``{0}``:
 
 .. include:: {1}.examples

--- a/examples/inverse/plot_morph_surface_stc.py
+++ b/examples/inverse/plot_morph_surface_stc.py
@@ -150,3 +150,7 @@ brain_inf.add_text(0.1, 0.9, 'Morphed to fsaverage (inflated)', 'title',
 
 stc_fsaverage = mne.compute_source_morph(stc,
                                          subjects_dir=subjects_dir).apply(stc)
+
+###############################################################################
+# For more examples, check out :ref:`examples using SourceMorph.apply
+# <sphx_glr_backreferences_mne.SourceMorph.apply>`.

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -270,8 +270,6 @@ class SourceMorph(object):
     .. note:: This class should not be instantiated directly.
               Use :func:`mne.compute_source_morph` instead.
 
-    .. versionadded:: 0.17
-
     Parameters
     ----------
     subject_from : str | None
@@ -318,6 +316,10 @@ class SourceMorph(object):
     src_data : dict
         Additional source data necessary to perform morphing.
     %(verbose)s
+
+    Notes
+    -----
+    .. versionadded:: 0.17
 
     References
     ----------

--- a/tutorials/source-modeling/plot_mne_dspm_source_localization.py
+++ b/tutorials/source-modeling/plot_mne_dspm_source_localization.py
@@ -167,16 +167,7 @@ del stc_vec
 # the source space.
 #
 # For more information about dipole orientations, see
-# :ref:`tut-dipole-orientations`.
-
-###############################################################################
-# Now let's look at each solver:
-
-surfer_kwargs['clim'].update(kind='percent', lims=[99, 99.9, 99.99])
-for mi, method in enumerate(['dSPM', 'sLORETA', 'eLORETA']):
-    stc = apply_inverse(evoked, inverse_operator, lambda2,
-                        method=method, pick_ori=None,
-                        verbose=True)
-    brain = stc.plot(figure=mi, **surfer_kwargs)
-    brain.add_text(0.1, 0.9, method, 'title', font_size=20)
-    del stc
+# :ref:`tut-dipole-orientations`. To see outputs using different methods, see
+# :ref:`tut-mne-fixed-free`. For other examples using evoked data, see
+# :ref:`examples using apply_inverse
+# <sphx_glr_backreferences_mne.minimum_norm.apply_inverse>`.


### PR DESCRIPTION
Mostly for @drammock during tutorial development. Allows linking directly to the SG mini-galleries for a given function/class/method. Cross-ref https://github.com/sphinx-gallery/sphinx-gallery/issues/496

Also speeds up one tutorial by removing some redundant calculations that are better explored in another tutorial.

@drammock feel free to review and merge if you're happy