### PR TITLE
MAINT: Add badges and tweak codecov

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. -*- mode: rst -*-
 
-|Travis|_ |Azure|_ |Circle|_ |Codecov|_ |PyPi|_ |conda-forge|_ |Zenodo|_
+|Travis|_ |Azure|_ |Circle|_ |Codecov|_ |PyPI|_ |conda-forge|_ |Zenodo|_
 
 |MNE|_
 
@@ -16,8 +16,8 @@
 .. |Codecov| image:: https://codecov.io/gh/mne-tools/mne-python/branch/master/graph/badge.svg
 .. _Codecov: https://codecov.io/gh/mne-tools/mne-python
 
-.. |PyPi| image:: https://img.shields.io/pypi/dm/mne.svg?label=PyPI%20downloads
-.. _PyPi: https://pypi.org/project/mne/
+.. |PyPI| image:: https://img.shields.io/pypi/dm/mne.svg?label=PyPI%20downloads
+.. _PyPI: https://pypi.org/project/mne/
 
 .. |conda-forge| image:: https://img.shields.io/conda/dn/conda-forge/mne.svg?label=Conda%20downloads
 .. _conda-forge: https://anaconda.org/conda-forge/mne

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,6 @@
 .. -*- mode: rst -*-
 
-
-|Travis|_ |Azure|_ |Circle|_ |Codecov|_ |Zenodo|_
+|Travis|_ |Azure|_ |Circle|_ |Codecov|_ |PyPi|_ |conda-forge|_ |Zenodo|_
 
 |MNE|_
 
@@ -11,11 +10,17 @@
 .. |Azure| image:: https://dev.azure.com/mne-tools/mne-python/_apis/build/status/mne-tools.mne-python?branchName=master
 .. _Azure: https://dev.azure.com/mne-tools/mne-python/_build/latest?definitionId=1&branchName=master
 
-.. |Circle| image:: https://circleci.com/gh/mne-tools/mne-python.svg?style=svg
+.. |Circle| image:: https://circleci.com/gh/mne-tools/mne-python.svg?style=shield
 .. _Circle: https://circleci.com/gh/mne-tools/mne-python
 
 .. |Codecov| image:: https://codecov.io/gh/mne-tools/mne-python/branch/master/graph/badge.svg
 .. _Codecov: https://codecov.io/gh/mne-tools/mne-python
+
+.. |PyPi| image:: https://img.shields.io/pypi/dm/mne.svg?label=Pypi%20downloads
+.. _PyPi: https://pypi.org/project/mne/
+
+.. |conda-forge| image:: https://img.shields.io/conda/dn/conda-forge/mne.svg?label=Conda%20downloads
+.. _conda-forge: https://anaconda.org/conda-forge/mne
 
 .. |Zenodo| image:: https://zenodo.org/badge/5822/mne-tools/mne-python.svg
 .. _Zenodo: https://zenodo.org/badge/latestdoi/5822/mne-tools/mne-python

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@
 .. |Codecov| image:: https://codecov.io/gh/mne-tools/mne-python/branch/master/graph/badge.svg
 .. _Codecov: https://codecov.io/gh/mne-tools/mne-python
 
-.. |PyPi| image:: https://img.shields.io/pypi/dm/mne.svg?label=Pypi%20downloads
+.. |PyPi| image:: https://img.shields.io/pypi/dm/mne.svg?label=PyPI%20downloads
 .. _PyPi: https://pypi.org/project/mne/
 
 .. |conda-forge| image:: https://img.shields.io/conda/dn/conda-forge/mne.svg?label=Conda%20downloads

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,14 +1,21 @@
+comment: false
+
+codecov:
+  notify:
+    require_ci_to_pass: no
+
 coverage:
-  precision: 2
-  round: down
-  range: "70...100"
   status:
-    project:
+    patch:
       default:
-        target: auto
-        threshold: 0.01
-    patch: false
-    changes: false
-comment:
-  layout: "header, diff, sunburst, uncovered"
-  behavior: default
+        target: 95%
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
+    project:
+      default: false
+      library:
+        target: 90%
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure


### PR DESCRIPTION
Adds PyPi and conda-forge download count badges to our readme, and tweaks `codecov` a bit so that 1) it doesn't comment (these aren't so useful) and 2) hopefully has fewer false alarms about problematic coverage.