### PR TITLE
Remove area edge lines in average PSD plots

### DIFF
--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -3221,7 +3221,7 @@ def _plot_psd(inst, fig, freqs, psd_list, picks_list, titles_list,
                     linewidth=0.5)
             if hyp_limits is not None:
                 ax.fill_between(freqs, hyp_limits[0], y2=hyp_limits[1],
-                                color=color, alpha=area_alpha)
+                                facecolor=color, alpha=area_alpha)
 
     if not average:
         picks = np.concatenate(picks_list)

--- a/tutorials/raw/plot_40_visualize_raw.py
+++ b/tutorials/raw/plot_40_visualize_raw.py
@@ -192,3 +192,4 @@ raw.plot_projs_topomap(colorbar=True)
 # .. LINKS
 #
 # .. _spectral density: https://en.wikipedia.org/wiki/Spectral_density
+

--- a/tutorials/raw/plot_40_visualize_raw.py
+++ b/tutorials/raw/plot_40_visualize_raw.py
@@ -188,7 +188,6 @@ raw.plot_sensors(ch_type='eeg')
 
 raw.plot_projs_topomap(colorbar=True)
 
-# XXX
 ###############################################################################
 # .. LINKS
 #

--- a/tutorials/raw/plot_40_visualize_raw.py
+++ b/tutorials/raw/plot_40_visualize_raw.py
@@ -188,8 +188,8 @@ raw.plot_sensors(ch_type='eeg')
 
 raw.plot_projs_topomap(colorbar=True)
 
+# XXX
 ###############################################################################
 # .. LINKS
 #
 # .. _spectral density: https://en.wikipedia.org/wiki/Spectral_density
-


### PR DESCRIPTION

#### Reference issue
Closes #7738

#### What does this implement/fix?
Do not plot lines on the edges of PSD areas
