### PR TITLE
Montage subset hotfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ docstring:
 	@$(PYTESTS) --doctest-modules mne/tests/test_docstring_parameters.py
 
 check-manifest:
-	check-manifest --ignore .circleci*,doc,logo,mne/io/*/tests/data*,mne/io/tests/data,mne/preprocessing/tests/data,.DS_Store
+	check-manifest --ignore .circleci/config.yml,doc,logo,mne/io/*/tests/data*,mne/io/tests/data,mne/preprocessing/tests/data,.DS_Store
 
 check-readme: clean wheel_quiet
 	twine check dist/*

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -641,17 +641,10 @@ def _set_montage_deprecation_helper(montage, update_ch_names, set_dig,
 
     # This is unlikely to be trigger but it applies in all cases
     if raise_if_subset is not DEPRECATED_PARAM:
-        if raise_if_subset:
-            warn((
-                'Using ``raise_if_subset`` to ``set_montage``  is deprecated'
-                ' and ``set_dig`` will be  removed in 0.21'
-            ), DeprecationWarning)
-        else:
-            raise ValueError(
-                'Using ``raise_if_subset`` to ``set_montage``  is deprecated'
-                ' and since 0.20 its value can only be True.'
-                ' It will be  removed in 0.21'
-            )
+        warn((
+            'Using ``raise_if_subset`` to ``set_montage``  is deprecated'
+            ' and ``set_dig`` will be  removed in 0.21'
+        ), DeprecationWarning)
 
 
 @fill_doc
@@ -737,11 +730,14 @@ def _set_montage(info, montage, raise_if_subset=DEPRECATED_PARAM,
         not_in_montage = [name for name, use in zip(info_names, info_names_use)
                           if use not in ch_pos_use]
         if len(not_in_montage):  # DigMontage is subset of info
-            raise ValueError('DigMontage is a only a subset of info. '
-                             'There are %s channel position%s not present in '
-                             'the DigMontage. The required channels are: %s'
-                             % (len(not_in_montage), _pl(not_in_montage),
-                                not_in_montage))
+            msg = ('DigMontage is a only a subset of info. '
+                   'There are %s channel position%s not present in '
+                   'the DigMontage. The required channels are: %s' %
+                   (len(not_in_montage), _pl(not_in_montage), not_in_montage))
+            if raise_if_subset:
+                raise ValueError(msg)
+            else:
+                warn(msg)
 
         for name, use in zip(info_names, info_names_use):
             _loc_view = info['chs'][info['ch_names'].index(name)]['loc']

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -738,6 +738,9 @@ def _set_montage(info, montage, raise_if_subset=DEPRECATED_PARAM,
                 raise ValueError(msg)
             else:
                 warn(msg)
+                info_names = [n for n in info_names if n not in not_in_montage]
+                info_names_use = [n for n in info_names_use
+                                  if n not in not_in_montage]
 
         for name, use in zip(info_names, info_names_use):
             _loc_view = info['chs'][info['ch_names'].index(name)]['loc']

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1162,10 +1162,6 @@ def test_set_dig_montage_parameters_deprecation():
     with pytest.deprecated_call():
         raw.set_montage(montage, raise_if_subset=True)
 
-    _msg = 'since 0.20 its value can only be True.'
-    with pytest.raises(ValueError, match=_msg):
-        raw.set_montage(montage, raise_if_subset=False)
-
     # Already deleted parameters in 0.20, just for completeness
     with pytest.raises(TypeError, match='unexpected keyword argument'):
         raw.set_montage(montage, set_dig=True)


### PR DESCRIPTION
Fixes #7615. This re-enables setting `raise_if_subset` to `False` in 0.20.