### PR TITLE
WIP: Enable usage of _nirs.fif

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -57,6 +57,8 @@ Changelog
 
 - Add ``plot`` option to :meth:`mne.viz.plot_filter` allowing selection of which filter properties are plotted and added option for user to supply ``axes`` by `Robert Luke`_
 
+- Accept filenames of raw .fif files to end on `_nirs.fif` to enable complicance with the Brain Imaging Data Structure by `Robert Luke`_
+
 Bug
 ~~~
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1324,7 +1324,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         fname = op.realpath(fname)
         check_fname(fname, 'raw', ('raw.fif', 'raw_sss.fif', 'raw_tsss.fif',
                                    'raw.fif.gz', 'raw_sss.fif.gz',
-                                   'raw_tsss.fif.gz', '_meg.fif'))
+                                   'raw_tsss.fif.gz', '_meg.fif', '_nirs.fif'))
 
         split_size = _get_split_size(split_size)
         if not self.preload and fname in self._filenames:

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -37,8 +37,8 @@ class Raw(BaseRaw):
         The raw filename to load. For files that have automatically been split,
         the split part will be automatically loaded. Filenames should end
         with raw.fif, raw.fif.gz, raw_sss.fif, raw_sss.fif.gz, raw_tsss.fif,
-        raw_tsss.fif.gz, or _meg.fif. If a file-like object is provided,
-        preloading must be used.
+        raw_tsss.fif.gz, _nirs.fif or _meg.fif. If a file-like object is
+        provided, preloading must be used.
 
         .. versionchanged:: 0.18
            Support for file-like objects.
@@ -132,7 +132,8 @@ class Raw(BaseRaw):
             if do_check_fname:
                 check_fname(fname, 'raw', (
                     'raw.fif', 'raw_sss.fif', 'raw_tsss.fif', 'raw.fif.gz',
-                    'raw_sss.fif.gz', 'raw_tsss.fif.gz', '_meg.fif'))
+                    'raw_sss.fif.gz', 'raw_tsss.fif.gz', '_meg.fif',
+                    '_nirs.fif'))
             # filename
             fname = op.realpath(fname)
             ext = os.path.splitext(fname)[1].lower()
@@ -427,8 +428,8 @@ def read_raw_fif(fname, allow_maxshield=False, preload=False, verbose=None):
         The raw filename to load. For files that have automatically been split,
         the split part will be automatically loaded. Filenames should end
         with raw.fif, raw.fif.gz, raw_sss.fif, raw_sss.fif.gz, raw_tsss.fif,
-        raw_tsss.fif.gz, or _meg.fif. If a file-like object is provided,
-        preloading must be used.
+        raw_tsss.fif.gz,  _nirs.fif or _meg.fif. If a file-like object is
+        provided, preloading must be used.
 
         .. versionchanged:: 0.18
            Support for file-like objects.


### PR DESCRIPTION
#### What does this implement/fix?
Similar to #6416 I wish to enable support for fif filenames ending in _nirs.fif for compliance with BIDS. This is also discussed in #4950


#### Additional information
The BIDS specification is not complete yet. But the NIRS spec is heavily based on previous specs such as MEG.
