### PR TITLE
Ica annotations

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -17,6 +17,8 @@ Changelog
 
 - Allow picking channels in raw instances (e.g., :meth:`mne.io.Raw.pick_types`) without preloading data, by `Eric Larson`_
 
+- :meth:`mne.preprocessing.ICA.plot_sources` now plots annotation markers similar to :meth:`mne.io.Raw.plot` by `Luke Bloy`_
+
 - Add support for signals in mV for :func:`mne.io.read_raw_brainvision` by `Clemens Brunner`_
 
 - :meth:`mne.Epochs.plot_psd_topomap` and :func:`mne.viz.plot_epochs_psd_topomap` now allow joint colorbar limits across subplots, by `Daniel McCloy`_.

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -13,7 +13,7 @@ import warnings
 import numpy as np
 
 from .utils import (tight_layout, _prepare_trellis, _select_bads,
-                    _plot_raw_onscroll, _mouse_click,
+                    _plot_raw_onscroll, _mouse_click, _plot_annotations,
                     _plot_raw_onkey, plt_show, _convert_psds)
 from .topomap import (_prepare_topomap_plot, plot_topomap, _hide_frame,
                       _plot_ica_topomap, _make_head_outlines)
@@ -900,13 +900,14 @@ def _plot_sources_raw(ica, raw, picks, exclude, start, stop, show, title,
                   n_times=raw.n_times, bad_color=bad_color, picks=picks,
                   first_time=first_time, data_picks=[], decim=1,
                   noise_cov=None, whitened_ch_names=(), clipping=None,
-                  show_scrollbars=show_scrollbars,
+                  added_label=list(), show_scrollbars=show_scrollbars,
                   show_scalebars=False)
     _prepare_mne_browse_raw(params, title, 'w', color, bad_color, inds,
                             n_channels)
     params['scale_factor'] = 1.0
     params['plot_fun'] = partial(_plot_raw_traces, params=params, color=color,
                                  bad_color=bad_color)
+    _plot_annotations(raw, params)
     params['update_fun'] = partial(_update_data, params)
     params['pick_bads_fun'] = partial(_pick_bads, params=params)
     params['label_click_fun'] = partial(_label_clicked, params=params)

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -10,7 +10,7 @@ from numpy.testing import assert_equal, assert_array_equal
 import pytest
 import matplotlib.pyplot as plt
 
-from mne import read_events, Epochs, read_cov, pick_types
+from mne import read_events, Epochs, read_cov, pick_types, Annotations
 from mne.io import read_raw_fif
 from mne.preprocessing import ICA, create_ecg_epochs, create_eog_epochs
 from mne.utils import run_tests_if_main, requires_sklearn
@@ -209,6 +209,14 @@ def test_plot_ica_sources():
     assert len(plt.get_fignums()) == 2
     ica.exclude = [1]
     ica.plot_sources(raw)
+
+    # test with annotations
+    orig_annot = raw.annotations
+    raw.set_annotations(Annotations([0.2], [0.1], 'Test'))
+    fig = ica.plot_sources(raw)
+    assert len(fig.axes[0].collections) == 1
+    assert len(fig.axes[1].collections) == 1
+    raw.set_annotations(orig_annot)
 
     raw.info['bads'] = ['MEG 0113']
     with pytest.raises(RuntimeError, match="Raw doesn't match fitted data"):

--- a/tutorials/preprocessing/plot_40_artifact_correction_ica.py
+++ b/tutorials/preprocessing/plot_40_artifact_correction_ica.py
@@ -232,7 +232,7 @@ ica.fit(filt_raw)
 # acceptable peak-to-peak amplitudes for each channel type, just like we used
 # when creating epoched data in the :ref:`tut-overview` tutorial).
 #
-# Now we can examine the ICs to see what they captured. 
+# Now we can examine the ICs to see what they captured.
 # :meth:`~mne.preprocessing.ICA.plot_sources` will show the time series of the
 # ICs. Note that in our call to :meth:`~mne.preprocessing.ICA.plot_sources` we
 # can use the original, unfiltered :class:`~mne.io.Raw` object:

--- a/tutorials/preprocessing/plot_40_artifact_correction_ica.py
+++ b/tutorials/preprocessing/plot_40_artifact_correction_ica.py
@@ -232,7 +232,7 @@ ica.fit(filt_raw)
 # acceptable peak-to-peak amplitudes for each channel type, just like we used
 # when creating epoched data in the :ref:`tut-overview` tutorial).
 #
-# Now we can examine the ICs to see what they captured.
+# Now we can examine the ICs to see what they captured. 
 # :meth:`~mne.preprocessing.ICA.plot_sources` will show the time series of the
 # ICs. Note that in our call to :meth:`~mne.preprocessing.ICA.plot_sources` we
 # can use the original, unfiltered :class:`~mne.io.Raw` object:


### PR DESCRIPTION
When calling `ica.plot_sources(raw)` annotations were not displayed.

This PR mimics what is done in `raw.plot` so they are displayed. I'm not sure what the best way to provide a test is. Maybe I should modifiy the tutorial to have an annotation?

Thoughts?