### PR TITLE
MRG, ENH: Speed up NIRx read without preload

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -53,6 +53,8 @@ Changelog
 
 - Add :func:`mne.stats.ttest_ind_no_p` to mirror :func:`mne.stats.ttest_1samp_no_p` with hat correction by `Eric Larson`_
 
+- Speed up raw data reading without preload in :func:`mne.io.read_raw_nirx` by `Eric Larson`_
+
 - Support for saving movies of source time courses (STCs) with ``brain.save_movie`` method and from graphical user interface by `Guillaume Favelier`_
 
 - Add ``mri`` argument to :func:`mne.viz.plot_bem` by `Eric Larson`_

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -245,7 +245,28 @@ class RawNIRX(BaseRaw):
                 info['chs'][ch_idx2 * 2 + 1]['loc'][:3] = ch_locs[ch_idx2, :]
             info['chs'][ch_idx2 * 2]['loc'][9] = fnirs_wavelengths[0]
             info['chs'][ch_idx2 * 2 + 1]['loc'][9] = fnirs_wavelengths[1]
-        raw_extras = {"sd_index": req_ind, 'files': files}
+
+        # Extract the start/stop numbers for samples in the CSV. In theory the
+        # sample bounds should just be 10 * the number of channels, but some
+        # files have mixed \n and \n\r endings (!) so we can't rely on it, and
+        # instead make a single pass over the entire file at the beginning so
+        # that we know how to seek and read later.
+        bounds = dict()
+        for key in ('wl1', 'wl2'):
+            offset = 0
+            bounds[key] = [offset]
+            with open(files[key], 'rb') as fid:
+                for line in fid:
+                    offset += len(line)
+                    bounds[key].append(offset)
+                assert offset == fid.tell()
+
+        # Extras required for reading data
+        raw_extras = {
+            'sd_index': req_ind,
+            'files': files,
+            'bounds': bounds,
+        }
 
         super(RawNIRX, self).__init__(
             info, preload, filenames=[fname], last_samps=[last_sample],
@@ -273,12 +294,12 @@ class RawNIRX(BaseRaw):
         The returned data interleaves the wavelengths.
         """
         sdindex = self._raw_extras[fi]['sd_index']
-        nchan = self._raw_extras[fi]['orig_nchan']
 
         wls = [
             _read_csv_rows_cols(
                 self._raw_extras[fi]['files'][key],
-                start, stop, sdindex, nchan // 2).T
+                start, stop, sdindex,
+                self._raw_extras[fi]['bounds'][key]).T
             for key in ('wl1', 'wl2')
         ]
 
@@ -293,18 +314,11 @@ class RawNIRX(BaseRaw):
         return data
 
 
-def _read_csv_rows_cols(fname, start, stop, cols, n_cols):
-    # The following is equivalent to:
-    # x = pandas.read_csv(fname, header=None, usecols=cols, skiprows=start,
-    #                     nrows=stop - start, delimiter=' ')
-    # But does not require Pandas, and is hopefully fast enough, as the
-    # reading should be done in C (CPython), as should the conversion to float
-    # (NumPy).
-    x = np.zeros((stop - start, n_cols))
-    with _open(fname) as fid:
-        for li, line in enumerate(fid):
-            if li >= start:
-                if li >= stop:
-                    break
-                x[li - start] = np.array(line.split(), float)[cols]
+def _read_csv_rows_cols(fname, start, stop, cols, bounds):
+    with open(fname, 'rb') as fid:
+        fid.seek(bounds[start])
+        data = fid.read(bounds[stop] - bounds[start]).decode('latin-1')
+        x = np.fromstring(data, float, sep=' ')
+    x.shape = (stop - start, -1)
+    x = x[:, cols]
     return x


### PR DESCRIPTION
Closes #7744

@rob-luke this code only takes 1 sec now, no idea how long it takes on `master` because I lost patience waiting after 30 seconds or so:
```Python
import time
import mne
fnirs_data_folder = mne.datasets.fnirs_motor.data_path()
fnirs_raw_dir = fnirs_data_folder + '/Participant-1'
raw = mne.io.read_raw_nirx(fnirs_raw_dir)
t0 = time.time()
raw.save('/dev/null', verbose='error')
print(time.time() - t0)
```