### PR TITLE
MRG, FIX: Fixes for BEM contours

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -100,7 +100,7 @@ Bug
 
 - Fix bug when using :meth:`mne.Epochs.crop` to exclude the baseline period would break :func:`mne.Epochs.save` / :func:`mne.read_epochs` round-trip by `Eric Larson`_
 
-- Fix bug with :func:`mne.viz.plot_bem` when MRIs are not in standard FreeSurfer orientation by `Eric Larson`_
+- Fix bug with :func:`mne.viz.plot_bem` and :class:`mne.Report` when plotting BEM contours when MRIs are not in standard FreeSurfer orientation by `Eric Larson`_
 
 - Fix :ref:`gen_mne_setup_forward_model` to have it actually compute the BEM solution in addition to creating the BEM model by `Eric Larson`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -55,7 +55,7 @@ Changelog
 
 - Support for saving movies of source time courses (STCs) with ``brain.save_movie`` method and from graphical user interface by `Guillaume Favelier`_
 
-- Add ``mri`` argument to :func:`mne.viz.plot_bem` by `Eric Larson`_
+- Add ``mri`` and ``show_orientation`` arguments to :func:`mne.viz.plot_bem` by `Eric Larson`_
 
 - Add "on_missing='raise'" to :meth:`mne.io.Raw.set_montage` and related functions to allow ignoring of missing electrode coordinates by `Adam Li`_
 

--- a/examples/visualization/plot_make_report.py
+++ b/examples/visualization/plot_make_report.py
@@ -5,7 +5,7 @@
 Make an MNE-Report with a Slider
 ================================
 
-In this example, MEG evoked data are plotted in an html slider.
+In this example, MEG evoked data are plotted in an HTML slider.
 """
 
 # Authors: Teon Brooks <teon.brooks@gmail.com>

--- a/mne/report.py
+++ b/mne/report.py
@@ -1975,14 +1975,9 @@ class Report(object):
         # Get the BEM surface filenames
         bem_path = op.join(subjects_dir, subject, 'bem')
 
-        if not op.isdir(bem_path):
-            warn('Subject bem directory "%s" does not exist' % bem_path)
-            return self._render_image_png(mri_fname, cmap='gray',
-                                          n_jobs=n_jobs)
-
-        surfaces = _get_bem_plotting_surfaces(bem_path, warn=True)
+        surfaces = _get_bem_plotting_surfaces(bem_path)
         if len(surfaces) == 0:
-            warn('No surfaces found at all, rendering empty MRI')
+            warn('No BEM surfaces found, rendering empty MRI')
             return self._render_image_png(mri_fname, cmap='gray',
                                           n_jobs=n_jobs)
 

--- a/mne/report.py
+++ b/mne/report.py
@@ -1995,10 +1995,13 @@ class Report(object):
         if section == 'bem' and 'bem' not in self.sections:
             self.sections.append('bem')
             self._sectionvars['bem'] = 'bem'
+            klass = 'bem'
+        else:
+            klass = 'report_' + _clean_varnames(section)
 
         name = caption
 
-        html += u'<li class="report_%s" id="%d">\n' % (section, global_id)
+        html += u'<li class="%s" id="%d">\n' % (klass, global_id)
         html += u'<h4>%s</h4>\n' % name  # all other captions are h4
         html += self._render_one_bem_axis(mri_fname, surfaces, global_id,
                                           'axial', decim, n_jobs)

--- a/mne/report.py
+++ b/mne/report.py
@@ -15,7 +15,6 @@ import re
 import codecs
 from shutil import copyfile
 import time
-from glob import glob
 import warnings
 import webbrowser
 import numpy as np
@@ -27,7 +26,7 @@ from .io.pick import _DATA_CH_TYPES_SPLIT
 from .utils import (logger, verbose, get_subjects_dir, warn,
                     fill_doc, _check_option)
 from .viz import plot_events, plot_alignment, plot_cov
-from .viz._3d import _plot_mri_contours
+from .viz.misc import _plot_mri_contours, _get_bem_plotting_surfaces, _mri_ori
 from .forward import read_forward_solution
 from .epochs import read_epochs
 from .minimum_norm import read_inverse_operator
@@ -1710,12 +1709,14 @@ class Report(object):
         return '\n'.join(html)
 
     def _render_one_bem_axis(self, mri_fname, surf_fnames, global_id,
-                             shape, orientation='coronal', decim=2, n_jobs=1):
+                             orientation='coronal', decim=2, n_jobs=1):
         """Render one axis of bem contours (only PNG)."""
-        orientation_name2axis = dict(sagittal=0, axial=1, coronal=2)
-        orientation_axis = orientation_name2axis[orientation]
-        n_slices = shape[orientation_axis]
-        orig_size = np.roll(shape, orientation_axis)[[1, 2]]
+        import nibabel as nib
+        nim = nib.load(mri_fname)
+        shape = nim.shape[:3]
+        (x, y, z), _, transpose, _ = _mri_ori(nim, orientation)
+        n_slices = shape[z]
+        orig_size = (shape[x], shape[y])[::(-1 if transpose else 1)]
 
         name = orientation
         html = []
@@ -1723,8 +1724,9 @@ class Report(object):
         slides_klass = '%s-%s' % (name, global_id)
 
         sl = np.arange(0, n_slices, decim)
-        kwargs = dict(mri_fname=mri_fname, surf_fnames=surf_fnames, show=False,
-                      orientation=orientation, img_output=orig_size)
+        kwargs = dict(mri_fname=mri_fname, surfaces=surf_fnames, show=False,
+                      orientation=orientation, img_output=orig_size, src=None,
+                      show_orientation=True)
         imgs = _figs_to_mrislices(sl, n_jobs, **kwargs)
         slices = []
         img_klass = 'slideimg-%s' % name
@@ -1965,8 +1967,6 @@ class Report(object):
     def _render_bem(self, subject, subjects_dir, decim, n_jobs,
                     section='bem', caption='BEM'):
         """Render mri+bem (only PNG)."""
-        import nibabel as nib
-
         subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
 
         # Get the MRI filename
@@ -1982,23 +1982,11 @@ class Report(object):
             return self._render_image_png(mri_fname, cmap='gray',
                                           n_jobs=n_jobs)
 
-        surf_fnames = []
-        for surf_name in ['*inner_skull', '*outer_skull', '*outer_skin']:
-            surf_fname = glob(op.join(bem_path, surf_name + '.surf'))
-            if len(surf_fname) > 0:
-                surf_fnames.append(surf_fname[0])
-            else:
-                warn('No surface found for %s.' % surf_name)
-                continue
-        if len(surf_fnames) == 0:
+        surfaces = _get_bem_plotting_surfaces(bem_path, warn=True)
+        if len(surfaces) == 0:
             warn('No surfaces found at all, rendering empty MRI')
             return self._render_image_png(mri_fname, cmap='gray',
                                           n_jobs=n_jobs)
-        # XXX : find a better way to get max range of slices
-        nim = nib.load(mri_fname)
-        data = _get_img_fdata(nim)
-        shape = data.shape
-        del data  # free up memory
 
         html = []
 
@@ -2012,12 +2000,12 @@ class Report(object):
 
         html += u'<li class="report_%s" id="%d">\n' % (section, global_id)
         html += u'<h4>%s</h4>\n' % name  # all other captions are h4
-        html += self._render_one_bem_axis(mri_fname, surf_fnames, global_id,
-                                          shape, 'axial', decim, n_jobs)
-        html += self._render_one_bem_axis(mri_fname, surf_fnames, global_id,
-                                          shape, 'sagittal', decim, n_jobs)
-        html += self._render_one_bem_axis(mri_fname, surf_fnames, global_id,
-                                          shape, 'coronal', decim, n_jobs)
+        html += self._render_one_bem_axis(mri_fname, surfaces, global_id,
+                                          'axial', decim, n_jobs)
+        html += self._render_one_bem_axis(mri_fname, surfaces, global_id,
+                                          'sagittal', decim, n_jobs)
+        html += self._render_one_bem_axis(mri_fname, surfaces, global_id,
+                                          'coronal', decim, n_jobs)
         html += u'</li>\n'
         return ''.join(html)
 

--- a/mne/report.py
+++ b/mne/report.py
@@ -1708,15 +1708,13 @@ class Report(object):
         html.append(u'</div>')
         return '\n'.join(html)
 
-    def _render_one_bem_axis(self, mri_fname, surf_fnames, global_id,
+    def _render_one_bem_axis(self, mri_fname, surfaces, global_id,
                              orientation='coronal', decim=2, n_jobs=1):
         """Render one axis of bem contours (only PNG)."""
         import nibabel as nib
         nim = nib.load(mri_fname)
-        shape = nim.shape[:3]
-        (x, y, z), _, transpose, _ = _mri_ori(nim, orientation)
-        n_slices = shape[z]
-        orig_size = (shape[x], shape[y])[::(-1 if transpose else 1)]
+        (_, _, z), _, _ = _mri_ori(nim, orientation)
+        n_slices = nim.shape[z]
 
         name = orientation
         html = []
@@ -1724,8 +1722,8 @@ class Report(object):
         slides_klass = '%s-%s' % (name, global_id)
 
         sl = np.arange(0, n_slices, decim)
-        kwargs = dict(mri_fname=mri_fname, surfaces=surf_fnames, show=False,
-                      orientation=orientation, img_output=orig_size, src=None,
+        kwargs = dict(mri_fname=mri_fname, surfaces=surfaces, show=False,
+                      orientation=orientation, img_output=True, src=None,
                       show_orientation=True)
         imgs = _figs_to_mrislices(sl, n_jobs, **kwargs)
         slices = []

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -272,6 +272,8 @@ def test_render_mri_without_bem(tmpdir):
     report = Report(info_fname=raw_fname,
                     subject='sample', subjects_dir=tempdir)
     report.parse_folder(tempdir, render_bem=False)
+    with pytest.warns(RuntimeWarning, match='No BEM surfaces found'):
+        report.parse_folder(tempdir, render_bem=True, mri_decim=20)
     report.save(op.join(tempdir, 'report.html'), open_browser=False)
 
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -407,33 +407,8 @@ def plot_evoked_field(evoked, surf_maps, time=None, time_label='t = %0.0f ms',
 
 def _plot_mri_contours(mri_fname, surf_fnames, orientation='coronal',
                        slices=None, show=True, img_output=False):
-    """Plot BEM contours on anatomical slices.
-
-    Parameters
-    ----------
-    mri_fname : str
-        The name of the file containing anatomical data.
-    surf_fnames : list of str
-        The filenames for the BEM surfaces in the format
-        ['inner_skull.surf', 'outer_skull.surf', 'outer_skin.surf'].
-    orientation : str
-        'coronal' or 'transverse' or 'sagittal'
-    slices : list of int
-        Slice indices.
-    show : bool
-        Call pyplot.show() at the end.
-    img_output : None | tuple
-        If tuple (width and height), images will be produced instead of a
-        single figure with many axes. This mode is designed to reduce the
-        (substantial) overhead associated with making tens to hundreds
-        of matplotlib axes, instead opting to re-use a single Axes instance.
-
-    Returns
-    -------
-    fig : instance of matplotlib.figure.Figure | list
-        The figure. Will instead be a list of png images if
-        img_output is a tuple.
-    """
+    """Plot BEM contours on anatomical slices."""
+    # XXX this should be refactored with misc._plot_mri_contours!
     import matplotlib.pyplot as plt
     import nibabel as nib
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -10,9 +10,7 @@
 #
 # License: Simplified BSD
 
-import base64
 from distutils.version import LooseVersion
-from io import BytesIO
 from itertools import cycle
 import os
 import os.path as op
@@ -42,7 +40,7 @@ from ..transforms import (_find_trans, apply_trans, rot_to_quat,
 from ..utils import (get_subjects_dir, logger, _check_subject, verbose, warn,
                      has_nibabel, check_version, fill_doc, _pl,
                      _ensure_int, _validate_type, _check_option)
-from .utils import (mne_analyze_colormap, _prepare_trellis, _get_color_list,
+from .utils import (mne_analyze_colormap, _get_color_list,
                     plt_show, tight_layout, figure_nobar, _check_time_unit)
 from ..bem import (ConductorModel, _bem_find_surface, _surf_dict, _surf_name,
                    read_bem_surfaces)
@@ -403,97 +401,6 @@ def plot_evoked_field(evoked, surf_maps, time=None, time_label='t = %0.0f ms',
     renderer.set_camera(azimuth=10, elevation=60)
     renderer.show()
     return renderer.scene()
-
-
-def _plot_mri_contours(mri_fname, surf_fnames, orientation='coronal',
-                       slices=None, show=True, img_output=False):
-    """Plot BEM contours on anatomical slices."""
-    # XXX this should be refactored with misc._plot_mri_contours!
-    import matplotlib.pyplot as plt
-    import nibabel as nib
-
-    _check_option('orientation', orientation, ['coronal', 'axial', 'sagittal'])
-
-    # Load the T1 data
-    nim = nib.load(mri_fname)
-    data = _get_img_fdata(nim)
-    try:
-        affine = nim.affine
-    except AttributeError:  # old nibabel
-        affine = nim.get_affine()
-
-    n_sag, n_axi, n_cor = data.shape
-    orientation_name2axis = dict(sagittal=0, axial=1, coronal=2)
-    orientation_axis = orientation_name2axis[orientation]
-
-    if slices is None:
-        n_slices = data.shape[orientation_axis]
-        slices = np.linspace(0, n_slices, 12, endpoint=False).astype(np.int)
-
-    # create of list of surfaces
-    surfs = list()
-
-    trans = linalg.inv(affine)
-    # XXX : next line is a hack don't ask why
-    trans[:3, -1] = [n_sag // 2, n_axi // 2, n_cor // 2]
-
-    for surf_fname in surf_fnames:
-        surf = read_surface(surf_fname, return_dict=True)[-1]
-        # move back surface to MRI coordinate system
-        surf['rr'] = nib.affines.apply_affine(trans, surf['rr'])
-        surfs.append(surf)
-
-    if img_output is None:
-        fig, axs, _, _ = _prepare_trellis(len(slices), 4)
-    else:
-        fig, ax = plt.subplots(1, 1, figsize=(7.0, 7.0))
-        axs = [ax] * len(slices)
-
-        fig_size = fig.get_size_inches()
-        w, h = img_output[0], img_output[1]
-        w2 = fig_size[0]
-        fig.set_size_inches([(w2 / float(w)) * w, (w2 / float(w)) * h])
-        plt.close(fig)
-
-    inds = dict(coronal=[0, 1, 2], axial=[2, 0, 1],
-                sagittal=[2, 1, 0])[orientation]
-    outs = []
-    for ax, sl in zip(axs, slices):
-        # adjust the orientations for good view
-        if orientation == 'coronal':
-            dat = data[:, :, sl].transpose()
-        elif orientation == 'axial':
-            dat = data[:, sl, :]
-        elif orientation == 'sagittal':
-            dat = data[sl, :, :]
-
-        # First plot the anatomical data
-        if img_output is not None:
-            ax.clear()
-        ax.imshow(dat, cmap=plt.cm.gray)
-        ax.axis('off')
-
-        # and then plot the contours on top
-        for surf in surfs:
-            with warnings.catch_warnings(record=True):  # no contours
-                warnings.simplefilter('ignore')
-                ax.tricontour(surf['rr'][:, inds[0]], surf['rr'][:, inds[1]],
-                              surf['tris'], surf['rr'][:, inds[2]],
-                              levels=[sl], colors='yellow', linewidths=2.0)
-        if img_output is not None:
-            ax.set_xticks([])
-            ax.set_yticks([])
-            ax.set_xlim(0, img_output[1])
-            ax.set_ylim(img_output[0], 0)
-            output = BytesIO()
-            fig.savefig(output, bbox_inches='tight',
-                        pad_inches=0, format='png')
-            outs.append(base64.b64encode(output.getvalue()).decode('ascii'))
-    if show:
-        plt.subplots_adjust(left=0., bottom=0., right=1., top=1., wspace=0.,
-                            hspace=0.)
-    plt_show(show)
-    return fig if img_output is None else outs
 
 
 @verbose

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -304,7 +304,7 @@ def _mri_ori(nim, orientation):
     axcodes = axcodes.replace('L', 'R').replace('P', 'A').replace('I', 'S')
     order = dict(
         coronal=('R', 'S', 'A'),
-        axial=('A', 'R', 'S'),
+        axial=('R', 'A', 'S'),
         sagittal=('A', 'S', 'R'),
     )[orientation]
     xyz = [axcodes.index(c) for c in order]

--- a/tutorials/source-modeling/plot_forward.py
+++ b/tutorials/source-modeling/plot_forward.py
@@ -57,7 +57,7 @@ subject = 'sample'
 #
 # Let's look at these surfaces. The function :func:`mne.viz.plot_bem`
 # assumes that you have the ``bem`` folder of your subject's FreeSurfer
-# reconstruction, containing the necessary files.
+# reconstruction, containing the necessary surface files.
 
 mne.viz.plot_bem(subject=subject, subjects_dir=subjects_dir,
                  brain_surfaces='white', orientation='coronal')


### PR DESCRIPTION
Should fix the bug mentioned in #7725. @christian-oreilly can you try it with your out-of-standard-ori MRI? I don't have any to test with but in principle I think this should work...

This PR also:

1. Should ensure that we always (by default) proceed through slices in L-to-R, P-to-A, and I-to-S order (previously it depended on the order in of the MRI).
2. Adds orientation markers to the edges of the plots by default (can be disabled with `show_orientations=False`)
3. Points out that there is a redundant and probably also wrong (for non-conform'ed MRIs) function `mne.viz._3d._plot_mri_contours` that we should really refactor with the `mne.viz.misc._plot_mri_contours` -- the function names match and there is a lot of similar code so it's unfortunate that we ended up with two copies, presumably due to @agramfort 6 years ago accidentally making two copies in https://github.com/mne-tools/mne-python/commit/5c1d64b1045f96c7c3a7e45bc4068e19fce695e7 :)
4. Changes the default `slices=None` from:
    ```
    np.linspace(0, n_slices, 12, endpoint=False)
    ```
    to:
    ```
    np.linspace(0, n_slices - 1, 14, endpoint=True)
    ```
    There is almost never any reason to show the first or last slice. On `master` we correctly avoid the last but not the first and unevenly sample in between, we now evenly sample from near-to-first to near-to-last instead by making 14 points evenly spaced between first and last slice (inclusive) and then excluding the first and last of those 14 to obtain 12.

On master for `plot_forward.py` we get:
![Screenshot from 2020-05-11 14-10-37](https://user-images.githubusercontent.com/2365790/81596807-b20e2080-9392-11ea-8e48-6960ad39fb3a.png)

And on this PR:

![Screenshot from 2020-05-11 14-20-32](https://user-images.githubusercontent.com/2365790/81596819-b5a1a780-9392-11ea-9414-e57d8b98fde8.png)

Note that there is a left-to-right flip here. On `master` the subject's left was shown on the right (radiological convention, probably not intentional) and this PR sets it to the more standard (for us at least) neurological convention of having the subject's left on the left. You can tell this by the fact that in the image from this PR, slice 177 (bottom left) has the pill on the right, and then the last slice is flipped left-right relative to the `master` plots.