### PR TITLE
Minor plot_raw aes improvement

### DIFF
--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -716,8 +716,6 @@ def _prepare_mne_browse_raw(params, title, bgcolor, color, bad_color, inds,
     ax_hscroll.set_xlim(params['first_time'], params['first_time'] +
                         params['n_times'] / float(info['sfreq']))
 
-    ax_vscroll.set_title('Ch.')
-
     vertline_color = (0., 0.75, 0.)
     params['ax_vertline'] = ax.axvline(0, color=vertline_color, zorder=4)
     params['ax_vertline'].ch_name = ''


### PR DESCRIPTION
This just removes the title "Ch." of the vertical (channel) scroll bar. I think it looks cleaner without the title, which can also interfere with annotations/events. It should also be pretty clear even without the title what that scrollbar is.

I also wanted to change the `hsel_patch` to a uniformly transparent filled rect. Currently, this rectangle (which indicates the current position in the scroll bar) has a darker border which isn't really necessary. However, unless someone has an idea how to achieve this (the patch should still extend over the upper and lower scrollbar boundaries) I think it is probably not possible (https://stackoverflow.com/questions/53803531/matplotlib-circle-patch-with-alpha-produces-overlap-of-edge-and-facecolor).