### PR TITLE
WIP, ENH: BrainVision impedance parsing

### DIFF
--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -851,16 +851,16 @@ def _check_bv_annot(descriptions):
 
 
 def parse_impedance(settings):
-    """
-    Parses impedances from the header file
+    """Parse impedances from the header file.
 
     :param settings: header settings lines
     :type settings: list
     :param info: BrainVision info parsed from the original parser
     :type info: dict
     """
-    electrode_imp_ranges = parse_impedance_ranges(settings)
-    impedance_setting_lines = [i for i in settings if i.startswith('Impedance')]
+    ranges = parse_impedance_ranges(settings)
+    impedance_setting_lines = [i for i in settings if
+                               i.startswith('Impedance')]
     impedances = dict()
     if len(impedance_setting_lines) > 0:
         idx = settings.index(impedance_setting_lines[0])
@@ -868,23 +868,25 @@ def parse_impedance(settings):
         impedance_unit = impedance_setting[1].lstrip('[').rstrip(']')
         impedance_time = impedance_setting[3]
         for setting in settings[idx + 1:]:
-            # Parse channel impedances until a line that doesn't start with a word (channel name) is found
+            # Parse channel impedances until a line that doesn't start
+            # with a word (channel name) delimited by ':' is found
             if re.match(r'\w+:', setting):
                 channel_imp_line = setting.split()
                 channel_name = channel_imp_line[0].rstrip(':')
-                imp_as_number = re.findall(r"[-+]?\d*\.\d+|\d+", channel_imp_line[1])
+                imp_as_number = re.findall(r"[-+]?\d*\.\d+|\d+",
+                                           channel_imp_line[1])
                 channel_impedance = dict(
                     imp=float(imp_as_number[0] if imp_as_number else 0),
                     imp_unit=impedance_unit,
                     imp_meas_time=datetime.strptime(impedance_time, "%H:%M:%S")
                 )
 
-                if channel_name == 'Ref' and 'Reference' in electrode_imp_ranges:
-                    channel_impedance.update(electrode_imp_ranges['Reference'])
-                elif channel_name == 'Gnd' and 'Ground' in electrode_imp_ranges:
-                    channel_impedance.update(electrode_imp_ranges['Ground'])
-                elif 'Data' in electrode_imp_ranges:
-                    channel_impedance.update(electrode_imp_ranges['Data'])
+                if channel_name == 'Ref' and 'Reference' in ranges:
+                    channel_impedance.update(ranges['Reference'])
+                elif channel_name == 'Gnd' and 'Ground' in ranges:
+                    channel_impedance.update(ranges['Ground'])
+                elif 'Data' in ranges:
+                    channel_impedance.update(ranges['Data'])
                 impedances[channel_name] = channel_impedance
             else:
                 break
@@ -892,15 +894,15 @@ def parse_impedance(settings):
 
 
 def parse_impedance_ranges(settings):
-    """
-    Parses the selected electrode impedance ranges from the BrainVision header
+    """Parse the selected electrode impedance ranges from the header.
 
     :param settings: header settings lines
     :type settings: list
     :returns parsed electrode impedances
     :rtype dict
     """
-    impedance_ranges = [item for item in settings if "Selected Impedance Measurement Range" in item]
+    impedance_ranges = [item for item in settings if
+                        "Selected Impedance Measurement Range" in item]
     electrode_imp_ranges = dict()
     if impedance_ranges:
         if len(impedance_ranges) == 1:
@@ -923,12 +925,11 @@ def parse_impedance_ranges(settings):
 
 
 def parse_segmentation(settings, cfg, common_info):
-    """
-    Parses the segmentation/averaging section of the BrainVision header
+    """Parse the segmentation/averaging section of the header.
 
     :param settings: header settings lines
     :type settings: list
-    :param cfg: cfg of the header file returned by mne.io.brainvision.brainvision._aux_vhdr_info
+    :param cfg: cfg of the header file returned by _aux_vhdr_info
     :type cfg: ConfigParser
     :param common_info: cinfo from the BrainVision header parser
     :type common_info: str
@@ -988,8 +989,7 @@ def parse_segmentation(settings, cfg, common_info):
 
 
 def parse_basic_segmentation(cfg, common_info):
-    """
-    Parses the segmentation info from the Common Infos using the ConfgiParser
+    """Parse the segmentation info from the Common Infos section.
 
     :param cfg: the ConfigParser from the BrainVision header parser
     :type cfg: ConfigParser
@@ -1016,9 +1016,11 @@ def parse_basic_segmentation(cfg, common_info):
 
 
 def get_segmentation_key_values(segmentation_settings, idx, delimiter=":"):
-    """
-    Parses the key value pairs from the Segmentation / Averaging section of the BrainVision header
-    Default delimiter is ':' where left side is considered the key, and right side is the value.
+    """Parse the key value pairs from the Segmentation / Averaging section.
+
+    Default delimiter is ':' where left side is considered the key,
+    and right side is the value.
+
     Values are parsed into arrays, elements can be split with a comma ','
     Stops the parsing when the first empty setting line is found
 

--- a/mne/io/brainvision/tests/data/test_segmentation_impedance.vhdr
+++ b/mne/io/brainvision/tests/data/test_segmentation_impedance.vhdr
@@ -138,22 +138,6 @@ Reference Electrode Selected Impedance Measurement Range: 0 - 10 kOhm
 Impedance [kOhm] at 17:25:01 :
 Fp1:         13
 Fp2:         13
-F3:           1
-F4:           9
 C3:           1
-C4:           4
-P3:          13
-P4:           4
-O1:          13
-O2:          13
-F7:          13
-F8:           3
-T3:          13
-T4:           2
-T5:          13
-T6:           7
-Fz:           3
-Cz:           1
-Pz:           5
 Ref:          0
 Gnd:         19

--- a/mne/io/brainvision/tests/data/test_segmentation_impedance.vhdr
+++ b/mne/io/brainvision/tests/data/test_segmentation_impedance.vhdr
@@ -1,0 +1,159 @@
+Brain Vision Data Exchange Header File Version 1.0
+; Data created by the Vision Recorder
+
+[Common Infos]
+Codepage=UTF-8
+DataFile=test.eeg
+MarkerFile=test.vmrk
+DataFormat=BINARY
+; Data orientation: MULTIPLEXED=ch1,pt1, ch2,pt1 ...
+DataOrientation=MULTIPLEXED
+NumberOfChannels=19
+; Sampling interval in microseconds
+SamplingInterval=1000
+SegmentationType=MARKERBASED
+SegmentDataPoints=1100
+Averaged=YES
+AveragedSegments=80
+
+[Binary Infos]
+BinaryFormat=IEEE_FLOAT_32
+
+[Channel Infos]
+; Each entry: Ch<Channel number>=<Name>,<Reference channel name>,
+; <Resolution in "Unit">,<Unit>, Future extensions..
+; Fields are delimited by commas, some fields might be omitted (empty).
+; Commas in channel names are coded as "\1".
+Ch1=Fp1,,1,µV
+Ch2=Fp2,,1,µV
+Ch3=F3,,1,µV
+Ch4=F4,,1,µV
+Ch5=C3,,1,µV
+Ch6=C4,,1,µV
+Ch7=P3,,1,µV
+Ch8=P4,,1,µV
+Ch9=O1,,1,µV
+Ch10=O2,,1,µV
+Ch11=F7,,1,µV
+Ch12=F8,,1,µV
+Ch13=T3,,1,µV
+Ch14=T4,,1,µV
+Ch15=T5,,1,µV
+Ch16=T6,,1,µV
+Ch17=Fz,,1,µV
+Ch18=Cz,,1,µV
+Ch19=Pz,,1,µV
+
+[Comment]
+
+A m p l i f i e r  S e t u p
+============================
+Number of channels: 19
+Sampling Rate [Hz]: 1000
+Sampling Interval [µS]: 1000
+
+Channels
+--------
+#     Name      Phys. Chn.    Resolution / Unit   Low Cutoff [s]   High Cutoff [Hz]   Notch [Hz]    Series Res. [kOhm] Gradient         Offset
+1     Fp1         1                0.1 µV             10              250              Off                0                 
+2     Fp2         2                0.1 µV             10              250              Off                0                 
+3     F3          3                0.1 µV             10              250              Off                0                 
+4     F4          4                0.1 µV             10              250              Off                0                 
+5     C3          5                0.1 µV             10              250              Off                0                 
+6     C4          6                0.1 µV             10              250              Off                0                 
+7     P3          7                0.1 µV             10              250              Off                0                 
+8     P4          8                0.1 µV             10              250              Off                0                 
+9     O1          9                0.1 µV             10              250              Off                0                 
+10    O2          10               0.1 µV             10              250              Off                0                 
+11    F7          11               0.1 µV             10              250              Off                0                 
+12    F8          12               0.1 µV             10              250              Off                0                 
+13    T3          13               0.1 µV             10              250              Off                0                 
+14    T4          14               0.1 µV             10              250              Off                0                 
+15    T5          15               0.1 µV             10              250              Off                0                 
+16    T6          16               0.1 µV             10              250              Off                0                 
+17    Fz          17               0.1 µV             10              250              Off                0                 
+18    Cz          18               0.1 µV             10              250              Off                0                 
+19    Pz          19               0.1 µV             10              250              Off                0                 
+
+S o f t w a r e  F i l t e r s
+==============================
+#     Low Cutoff [s]   High Cutoff [Hz]   Notch [Hz]
+1      1.59155          30                 Off
+2      1.59155          30                 Off
+3      1.59155          30                 Off
+4      1.59155          30                 Off
+5      1.59155          30                 Off
+6      1.59155          30                 Off
+7      1.59155          30                 Off
+8      1.59155          30                 Off
+9      1.59155          30                 Off
+10     1.59155          30                 Off
+11     1.59155          30                 Off
+12     1.59155          30                 Off
+13     1.59155          30                 Off
+14     1.59155          30                 Off
+15     1.59155          30                 Off
+16     1.59155          30                 Off
+17     1.59155          30                 Off
+18     1.59155          30                 Off
+19     1.59155          30                 Off
+
+
+
+S e g m e n t a t i o n  /  A v e r a g i n g
+=============================================
+Markers
+-------
+Stimulus    S  2        
+
+Interval
+--------
+Prestimulus [ms]: 100
+Poststimulus [ms]: 1000
+
+Artifact Rejection
+------------------
+	Gradient:        Disabled
+	Max. Difference: Disabled
+	Amplitude:       Disabled
+	Low Activity:    Disabled
+	Test Interval:   Whole Segment
+	Untested Channels:
+		C3, C4, F3, F4, F7, F8, Fp1, Fp2, O1, O2, P3, P4, T3, T4, T5, 
+		T6
+
+Averaging
+---------
+	Averaging is On
+	Baseline Correction is On
+
+Miscellaneous
+-------------
+	Max. Segments: unlimited
+
+
+Data Electrodes Selected Impedance Measurement Range: 0 - 5 kOhm
+Ground Electrode Selected Impedance Measurement Range: 0 - 10 kOhm
+Reference Electrode Selected Impedance Measurement Range: 0 - 10 kOhm
+Impedance [kOhm] at 17:25:01 :
+Fp1:         13
+Fp2:         13
+F3:           1
+F4:           9
+C3:           1
+C4:           4
+P3:          13
+P4:           4
+O1:          13
+O2:          13
+F7:          13
+F8:           3
+T3:          13
+T4:           2
+T5:          13
+T6:           7
+Fz:           3
+Cz:           1
+Pz:           5
+Ref:          0
+Gnd:         19

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -656,27 +656,21 @@ def test_parse_impedance():
     expected_impedances = {
         'Fp1': {'imp': 13.0, 'imp_unit': 'kOhm', 'imp_meas_time': datetime(1900, 1, 1, 17, 25, 1),
                 'imp_lower_bound': 0.0, 'imp_upper_bound': 5.0, 'imp_range_unit': 'kOhm'},
+        'Fp2': {'imp': 13.0, 'imp_unit': 'kOhm', 'imp_meas_time': datetime(1900, 1, 1, 17, 25, 1),
+                'imp_lower_bound': 0.0, 'imp_upper_bound': 5.0, 'imp_range_unit': 'kOhm'},
+        'C3': {'imp': 1.0, 'imp_unit': 'kOhm', 'imp_meas_time': datetime(1900, 1, 1, 17, 25, 1),
+                'imp_lower_bound': 0.0, 'imp_upper_bound': 5.0, 'imp_range_unit': 'kOhm'},
         'Ref': {'imp': 0.0, 'imp_unit': 'kOhm', 'imp_meas_time': datetime(1900, 1, 1, 17, 25, 1),
                 'imp_lower_bound': 0.0, 'imp_upper_bound': 10.0, 'imp_range_unit': 'kOhm'},
         'Gnd': {'imp': 19.0, 'imp_unit': 'kOhm', 'imp_meas_time': datetime(1900, 1, 1, 17, 25, 1),
                 'imp_lower_bound': 0.0, 'imp_upper_bound': 10.0, 'imp_range_unit': 'kOhm'}}
     with pytest.warns(RuntimeWarning, match='software filter'):
         raw = read_raw_brainvision(vhdr_segmentation_impedance, eog=eog)
-
-    assert expected_impedances['Fp1']['imp'] == raw.info['chs'][0]['imp']
-    assert expected_impedances['Fp1']['imp_unit'] == raw.info['chs'][0]['imp_unit']
-    assert expected_impedances['Fp1']['imp_meas_time'] == raw.info['chs'][0]['imp_meas_time']
-    assert expected_impedances['Fp1']['imp_lower_bound'] == raw.info['chs'][0]['imp_lower_bound']
-    assert expected_impedances['Fp1']['imp_upper_bound'] == raw.info['chs'][0]['imp_upper_bound']
-    assert expected_impedances['Gnd']['imp'] == raw.info['chs'][18]['imp']
-    assert expected_impedances['Gnd']['imp_unit'] == raw.info['chs'][18]['imp_unit']
-    assert expected_impedances['Gnd']['imp_meas_time'] == raw.info['chs'][18]['imp_meas_time']
-    assert expected_impedances['Gnd']['imp_lower_bound'] == raw.info['chs'][18]['imp_lower_bound']
-    assert expected_impedances['Gnd']['imp_upper_bound'] == raw.info['chs'][18]['imp_upper_bound']
+    assert_array_equal(expected_impedances, raw.impedances)
 
 
 def test_parse_segmentation():
-    expected = {'type': 'MARKERBASED', 'data_points': 1100, 'averaged': 'YES', 'averaged_segments': 80,
+    expected_segmentation = {'type': 'MARKERBASED', 'data_points': 1100, 'averaged': 'YES', 'averaged_segments': 80,
                 'artifact_rejection': {'Gradient': ['Disabled'], 'Max. Difference': ['Disabled'],
                                        'Amplitude': ['Disabled'], 'Low Activity': ['Disabled'],
                                        'Test Interval': ['Whole Segment'],
@@ -690,8 +684,7 @@ def test_parse_segmentation():
 
     with pytest.warns(RuntimeWarning, match='software filter'):
         raw = read_raw_brainvision(vhdr_segmentation_impedance, eog=eog)
-
-    assert_array_equal(expected, raw.info["segmentation"])
+    assert_array_equal(expected_segmentation, raw.segmentation)
 
 
 run_tests_if_main()

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -681,31 +681,4 @@ def test_parse_impedance():
     assert_array_equal(expected_impedances, raw.impedances)
 
 
-def test_parse_segmentation():
-    """Test case for the segmentation section parsing."""
-    expected_segmentation = {
-        'type': 'MARKERBASED',
-        'data_points': 1100,
-        'averaged': 'YES',
-        'averaged_segments': 80,
-        'artifact_rejection': {
-            'Gradient': ['Disabled'],
-            'Max. Difference': ['Disabled'],
-            'Amplitude': ['Disabled'], 'Low Activity': ['Disabled'],
-            'Test Interval': ['Whole Segment'],
-            'Untested Channels': ['C3', ' C4', ' F3', ' F4', ' F7', ' F8',
-                                  ' Fp1', ' Fp2', ' O1', ' O2', ' P3', ' P4',
-                                  ' T3', ' T4', ' T5', 'T6']
-        },
-        'intervals': {'Prestimulus': {'unit': 'ms', 'duration': '100'},
-                      'Poststimulus': {'unit': 'ms', 'duration': '1000'}},
-        'averaging': {'Averaging': ['On'], 'Baseline Correction': ['On']},
-        'miscellaneous': {'Max. Segments': ['unlimited']}
-    }
-
-    with pytest.warns(RuntimeWarning, match='software filter'):
-        raw = read_raw_brainvision(vhdr_segmentation_impedance, eog=eog)
-    assert_array_equal(expected_segmentation, raw.segmentation)
-
-
 run_tests_if_main()

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -45,7 +45,8 @@ vhdr_lowpass_path = op.join(data_dir, 'test_highpass.vhdr')
 vhdr_mixed_lowpass_path = op.join(data_dir, 'test_mixed_lowpass.vhdr')
 vhdr_lowpass_s_path = op.join(data_dir, 'test_lowpass_s.vhdr')
 vhdr_mixed_lowpass_s_path = op.join(data_dir, 'test_mixed_lowpass_s.vhdr')
-vhdr_segmentation_impedance = op.join(data_dir, 'test_segmentation_impedance.vhdr')
+vhdr_segmentation_impedance = op.join(data_dir,
+                                      'test_segmentation_impedance.vhdr')
 
 # VHDR exported with neuroone
 data_path = testing.data_path(download=False)
@@ -653,34 +654,54 @@ def test_event_id_stability_when_save_and_fif_reload(tmpdir):
 
 
 def test_parse_impedance():
+    """Test case for parsing the impedances from header."""
     expected_impedances = {
-        'Fp1': {'imp': 13.0, 'imp_unit': 'kOhm', 'imp_meas_time': datetime(1900, 1, 1, 17, 25, 1),
-                'imp_lower_bound': 0.0, 'imp_upper_bound': 5.0, 'imp_range_unit': 'kOhm'},
-        'Fp2': {'imp': 13.0, 'imp_unit': 'kOhm', 'imp_meas_time': datetime(1900, 1, 1, 17, 25, 1),
-                'imp_lower_bound': 0.0, 'imp_upper_bound': 5.0, 'imp_range_unit': 'kOhm'},
-        'C3': {'imp': 1.0, 'imp_unit': 'kOhm', 'imp_meas_time': datetime(1900, 1, 1, 17, 25, 1),
-                'imp_lower_bound': 0.0, 'imp_upper_bound': 5.0, 'imp_range_unit': 'kOhm'},
-        'Ref': {'imp': 0.0, 'imp_unit': 'kOhm', 'imp_meas_time': datetime(1900, 1, 1, 17, 25, 1),
-                'imp_lower_bound': 0.0, 'imp_upper_bound': 10.0, 'imp_range_unit': 'kOhm'},
-        'Gnd': {'imp': 19.0, 'imp_unit': 'kOhm', 'imp_meas_time': datetime(1900, 1, 1, 17, 25, 1),
-                'imp_lower_bound': 0.0, 'imp_upper_bound': 10.0, 'imp_range_unit': 'kOhm'}}
+        'Fp1': {'imp': 13.0, 'imp_unit': 'kOhm',
+                'imp_meas_time': datetime(1900, 1, 1, 17, 25, 1),
+                'imp_lower_bound': 0.0, 'imp_upper_bound': 5.0,
+                'imp_range_unit': 'kOhm'},
+        'Fp2': {'imp': 13.0, 'imp_unit': 'kOhm',
+                'imp_meas_time': datetime(1900, 1, 1, 17, 25, 1),
+                'imp_lower_bound': 0.0, 'imp_upper_bound': 5.0,
+                'imp_range_unit': 'kOhm'},
+        'C3': {'imp': 1.0, 'imp_unit': 'kOhm',
+               'imp_meas_time': datetime(1900, 1, 1, 17, 25, 1),
+               'imp_lower_bound': 0.0, 'imp_upper_bound': 5.0,
+               'imp_range_unit': 'kOhm'},
+        'Ref': {'imp': 0.0, 'imp_unit': 'kOhm',
+                'imp_meas_time': datetime(1900, 1, 1, 17, 25, 1),
+                'imp_lower_bound': 0.0, 'imp_upper_bound': 10.0,
+                'imp_range_unit': 'kOhm'},
+        'Gnd': {'imp': 19.0, 'imp_unit': 'kOhm',
+                'imp_meas_time': datetime(1900, 1, 1, 17, 25, 1),
+                'imp_lower_bound': 0.0, 'imp_upper_bound': 10.0,
+                'imp_range_unit': 'kOhm'}}
     with pytest.warns(RuntimeWarning, match='software filter'):
         raw = read_raw_brainvision(vhdr_segmentation_impedance, eog=eog)
     assert_array_equal(expected_impedances, raw.impedances)
 
 
 def test_parse_segmentation():
-    expected_segmentation = {'type': 'MARKERBASED', 'data_points': 1100, 'averaged': 'YES', 'averaged_segments': 80,
-                'artifact_rejection': {'Gradient': ['Disabled'], 'Max. Difference': ['Disabled'],
-                                       'Amplitude': ['Disabled'], 'Low Activity': ['Disabled'],
-                                       'Test Interval': ['Whole Segment'],
-                                       'Untested Channels': ['C3', ' C4', ' F3', ' F4', ' F7', ' F8', ' Fp1',
-                                                             ' Fp2', ' O1', ' O2', ' P3', ' P4', ' T3', ' T4',
-                                                             ' T5', 'T6']},
-                'intervals': {'Prestimulus': {'unit': 'ms', 'duration': '100'},
-                              'Poststimulus': {'unit': 'ms', 'duration': '1000'}},
-                'averaging': {'Averaging': ['On'], 'Baseline Correction': ['On']},
-                'miscellaneous': {'Max. Segments': ['unlimited']}}
+    """Test case for the segmentation section parsing."""
+    expected_segmentation = {
+        'type': 'MARKERBASED',
+        'data_points': 1100,
+        'averaged': 'YES',
+        'averaged_segments': 80,
+        'artifact_rejection': {
+            'Gradient': ['Disabled'],
+            'Max. Difference': ['Disabled'],
+            'Amplitude': ['Disabled'], 'Low Activity': ['Disabled'],
+            'Test Interval': ['Whole Segment'],
+            'Untested Channels': ['C3', ' C4', ' F3', ' F4', ' F7', ' F8',
+                                  ' Fp1', ' Fp2', ' O1', ' O2', ' P3', ' P4',
+                                  ' T3', ' T4', ' T5', 'T6']
+        },
+        'intervals': {'Prestimulus': {'unit': 'ms', 'duration': '100'},
+                      'Poststimulus': {'unit': 'ms', 'duration': '1000'}},
+        'averaging': {'Averaging': ['On'], 'Baseline Correction': ['On']},
+        'miscellaneous': {'Max. Segments': ['unlimited']}
+    }
 
     with pytest.warns(RuntimeWarning, match='software filter'):
         raw = read_raw_brainvision(vhdr_segmentation_impedance, eog=eog)


### PR DESCRIPTION
I was using the MNE tool for parsing BrainVision data files in a paper where we needed to parse all the information from the segmentation and impedance sections of a header file. As i did not find these informations in the current raw parsed data, an enhancement of the current parser was implemented that adds these sections to the raw info.

Considering a possible wider use case for these changes, we decided that this enhancement could be included in the tool directly.

---
**Enhancements:**

The function `parse_segmentation` takes any of the key-value pairs in the segmentation subsections of the BrainVision file starting with `S e g m e n t a t i o n  /  A v e r a g i n g`, as well as some of the added key-values in the Common Infos. The segmentation is stored in a new info item `segmentation`.

The function `parse_impedance` creates a `dict` of all the channel impedances from the header file. All of the channels in the raw info are iterated over, and if an impedance record exists, they are appended to the channel dict.

The header file that these were tested on is in `mne/io/brainvision/tests/data/test_segmentation_impedance.vhdr` (also used for the unit tests)

---

**Problems:**

However, even though these changes work well in our local environment and the parsing of the values in itself works good, implementing these changes directly to MNE causes some of the already existing unit tests to fail, and I'm not really sure how to solve these issues. When i try to add any new attributes to the info structure, even an empty list.

These are the failing tests:
```
FAILED mne/io/brainvision/tests/test_brainvision.py::test_brainvision_data_highpass_filters - RuntimeWarning: Could not get size for self.info
FAILED mne/io/brainvision/tests/test_brainvision.py::test_brainvision_data_lowpass_filters - RuntimeWarning: Could not get size for self.info
FAILED mne/io/brainvision/tests/test_brainvision.py::test_brainvision_data_partially_disabled_hw_filters - AssertionError: assert {'acq_pars', ... 'comps', ...} == {'acq_pars', ... 'comps', ...}
FAILED mne/io/brainvision/tests/test_brainvision.py::test_brainvision_data_software_filters_latin1_global_units - AssertionError: assert {'acq_pars', ... 'comps', ...} == {'acq_pars', ... 'comps', ...}
FAILED mne/io/brainvision/tests/test_brainvision.py::test_brainvision_data - RuntimeWarning: Could not get size for self.info
```

Any ideas where the problem could be for the existing tests and how this could be improved?
