### PR TITLE
MRG, DOC: Notes about info

### DIFF
--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -184,14 +184,17 @@ class Info(dict, MontageMixin):
     """Measurement information.
 
     This data structure behaves like a dictionary. It contains all metadata
-    that is available for a recording.
-
-    This class should not be instantiated directly. To create a measurement
-    information strucure, use :func:`mne.create_info`.
+    that is available for a recording. However, its keys are restricted to
+    those provided by the
+    `FIF format specification <https://github.com/mne-tools/fiff-constants>`__,
+    so new entries should not be manually added.
 
     The only entries that should be manually changed by the user are
     ``info['bads']`` and ``info['description']``. All other entries should
-    be considered read-only, or should be modified by functions or methods.
+    be considered read-only, or should be modified by MNE functions or methods.
+
+    This class should not be instantiated directly. To create a measurement
+    information strucure, use :func:`mne.create_info`.
 
     Attributes
     ----------

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -191,7 +191,9 @@ class Info(dict, MontageMixin):
 
     The only entries that should be manually changed by the user are
     ``info['bads']`` and ``info['description']``. All other entries should
-    be considered read-only, or should be modified by MNE functions or methods.
+    be considered read-only, though they can be modified by various MNE-Python
+    functions or methods (which have safeguards to ensure all fields remain in
+    sync).
 
     This class should not be instantiated directly. To create a measurement
     information strucure, use :func:`mne.create_info`.


### PR DESCRIPTION
Make it clearer that people (including devs) shouldn't generally add new stuff to `info`.