### PR TITLE
DOC: docstring fixes

### DIFF
--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -26,7 +26,7 @@ def ttest_1samp_no_p(X, sigma=0, method='relative'):
     X : array
         Array to return t-values for.
     sigma : float
-        The variance estate will be given by "var + sigma * max(var)" or
+        The variance estimate will be given by "var + sigma * max(var)" or
         "var + sigma", depending on "method". By default this is 0 (no
         adjustment). See Notes for details.
     method : str

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -26,8 +26,8 @@ def ttest_1samp_no_p(X, sigma=0, method='relative'):
     X : array
         Array to return t-values for.
     sigma : float
-        The variance estimate will be given by "var + sigma * max(var)" or
-        "var + sigma", depending on "method". By default this is 0 (no
+        The variance estimate will be given by ``var + sigma * max(var)`` or
+        ``var + sigma``, depending on "method". By default this is 0 (no
         adjustment). See Notes for details.
     method : str
         If 'relative', the minimum variance estimate will be sigma * max(var),

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -40,8 +40,8 @@ def ttest_1samp_no_p(X, sigma=0, method='relative'):
 
     Notes
     -----
-    To use the "hat" adjustment method [1]_, a value of ``sigma=1e-3`` may be a
-    reasonable choice.
+    To use the "hat" adjustment method (:footcite:`RidgwayEtAl2012`), a value
+    of ``sigma=1e-3`` may be a reasonable choice.
 
     You can use the conversion from ``scipy.stats.distributions.t.ppf``::
 
@@ -53,9 +53,7 @@ def ttest_1samp_no_p(X, sigma=0, method='relative'):
 
     References
     ----------
-    .. [1] Ridgway et al. 2012 "The problem of low variance voxels in
-       statistical parametric mapping; a new hat avoids a 'haircut'",
-       NeuroImage. 2012 Feb 1;59(3):2131-41.
+    .. footbibliography::
     """
     _check_option('method', method, ['absolute', 'relative'])
     var = np.var(X, axis=0, ddof=1)
@@ -66,10 +64,11 @@ def ttest_1samp_no_p(X, sigma=0, method='relative'):
 
 
 def ttest_ind_no_p(a, b, equal_var=True, sigma=1e-3):
-    """Independent samples t-test with hat adjustment and no p calculation.
+    """Independent samples t-test without p calculation.
 
     This is a modified version of :func:`scipy.stats.ttest_ind`. It operates
-    along the first axis.
+    along the first axis. The ``sigma`` parameter provides an optional "hat"
+    adjustment (see :func:`ttest_1samp_no_p` and :footcite:`RidgwayEtAl2012`).
 
     Parameters
     ----------
@@ -86,6 +85,10 @@ def ttest_ind_no_p(a, b, equal_var=True, sigma=1e-3):
     -------
     t : array
         T values.
+
+    References
+    ----------
+    .. footbibliography::
     """
     v1 = np.var(a, axis=0, ddof=1)
     v2 = np.var(b, axis=0, ddof=1)

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -63,7 +63,7 @@ def ttest_1samp_no_p(X, sigma=0, method='relative'):
     return np.mean(X, axis=0) / np.sqrt(var / X.shape[0])
 
 
-def ttest_ind_no_p(a, b, equal_var=True, sigma=1e-3):
+def ttest_ind_no_p(a, b, equal_var=True, sigma=0.):
     """Independent samples t-test without p calculation.
 
     This is a modified version of :func:`scipy.stats.ttest_ind`. It operates

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -19,7 +19,7 @@ def ttest_1samp_no_p(X, sigma=0, method='relative'):
 
     This is a modified version of :func:`scipy.stats.ttest_1samp` that avoids
     a (relatively) time-consuming p-value calculation, and can adjust
-    for implausibly small variance values [1]_.
+    for implausibly small variance values :footcite:`RidgwayEtAl2012`.
 
     Parameters
     ----------
@@ -40,7 +40,7 @@ def ttest_1samp_no_p(X, sigma=0, method='relative'):
 
     Notes
     -----
-    To use the "hat" adjustment method (:footcite:`RidgwayEtAl2012`), a value
+    To use the "hat" adjustment method :footcite:`RidgwayEtAl2012`, a value
     of ``sigma=1e-3`` may be a reasonable choice.
 
     You can use the conversion from ``scipy.stats.distributions.t.ppf``::


### PR DESCRIPTION
- fixes typo "estate" -> "estimate"
- fixes the default value of sigma in `ttest_ind_no_p` to match `ttest_1samp_no_p` (within-cycle change, so no deprecation needed)
- converts hat-adjustment citation in `ttest_1samp_no_p` to use `:footcite:` format.
- adds hat-adjustment citation to `ttest_ind_no_p`
- general docstring improvement of `ttest_ind_no_p`
