### PR TITLE
MRG, ENH: Minor speedup of permutation tests

### DIFF
--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -501,6 +501,7 @@ def _find_clusters_1dir(x, x_in, connectivity, max_step, t_power, ndimage):
         if x.ndim == 1:
             # slices
             clusters = ndimage.find_objects(labels, n_labels)
+            # equivalent to if len(clusters) == 0 but faster
             if not clusters:
                 sums = list()
             else:

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -454,8 +454,8 @@ def _find_clusters(x, threshold, tail=0, connectivity=None, max_step=1,
                 else:
                     len_c = len(c)
                 scores[c] += h * (len_c ** e_power)
-    # turn sums into ndarray after running
-    sums = np.concatenate(sums) if sums else np.empty(0)
+    # turn sums into array
+    sums = np.concatenate(sums) if sums else np.array([])
     if tfce:
         # each point gets treated independently
         clusters = np.arange(x.size)
@@ -514,15 +514,15 @@ def _find_clusters_1dir(x, x_in, connectivity, max_step, t_power, ndimage):
         else:
             # boolean masks (raveled)
             clusters = list()
-            sums = list()
-            for label in range(1, n_labels + 1):
-                c = labels == label
+            sums = np.empty(n_labels)
+            for label in range(n_labels):
+                c = labels == label + 1
                 clusters.append(c.ravel())
                 if t_power == 1:
-                    sums.append(np.sum(x[c]))
+                    sums[label] = np.sum(x[c])
                 else:
-                    sums.append(np.sum(np.sign(x[c]) *
-                                       np.abs(x[c]) ** t_power))
+                    sums[label] = np.sum(np.sign(x[c]) *
+                                         np.abs(x[c]) ** t_power)
     else:
         if x.ndim > 1:
             raise Exception("Data should be 1D when using a connectivity "

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -515,8 +515,8 @@ def _find_clusters_1dir(x, x_in, connectivity, max_step, t_power, ndimage):
             # boolean masks (raveled)
             clusters = list()
             sums = list()
-            for l in range(1, n_labels + 1):
-                c = labels == l
+            for label in range(1, n_labels + 1):
+                c = labels == label
                 clusters.append(c.ravel())
                 if t_power == 1:
                     sums.append(np.sum(x[c]))


### PR DESCRIPTION
Minor refactoring to speed up permutation tests. This PR brings about 1~2% speedup (best case 5%).

### Testing

#### Setup

```python
import numpy as np
import time
from mne.stats import permutation_cluster_1samp_test

def large_samples_perm(n_perm=100, n_space=100, n_time=100):
    noise_level = 20
    n_time_1 = n_time
    n_time_2 = n_time
    normfactor = np.hanning(20).sum()
    rng = np.random.RandomState(42)
    condition1_1d = rng.randn(n_time_1, n_space) * noise_level
    for c in condition1_1d:
        c[:] = np.convolve(c, np.hanning(20), mode="same") / normfactor
    pseudoekp = 10 * np.hanning(round(n_space / 2))[None, :]
    condition1_1d[:, round(n_space / 2):] += pseudoekp

    thresh_tfce = dict(start=0, step=0.2)
    permutation_cluster_1samp_test(condition1_1d, threshold=thresh_tfce,
                                   n_permutations=n_perm, tail=0, seed=1,
                                   buffer_size=None)
```

#### n_perm=100, n_space=100, n_time=100

```python
%timeit large_samples_perm()
# master: 436 ms ± 13.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# opt: 413 ms ± 2.04 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
5.2% speedup


#### n_perm=1000, n_space=100, n_time=100

```python
%timeit large_samples_perm(n_perm=1000, n_space=100, n_time=100)
# master: 3.85 s ± 13.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# opt: 3.75 s ± 6.31 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
2.6% speedup

#### n_perm=1000, n_space=300, n_time=300

```python
%timeit large_samples_perm(n_perm=1000, n_space=300, n_time=300)
# master: 5.83 s ± 22.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# opt: 5.73 s ± 31 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
1.7% speedup

#### n_perm=1000, n_space=1000, n_time=1000

```python
t0 = time.time()
large_samples_perm(n_perm=1000, n_space=1000, n_time=1000)
t1 = time.time()
elapsed = t1 - t0
# master: 17.224292039871216
# opt: 16.965471029281616
```
1.5% speedup