### PR TITLE
WIP, ENH: BrainVision segmentation parsing

### DIFF
--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -93,6 +93,11 @@ class RawBrainVision(BaseRaw):
 
         self.set_montage(montage)
 
+        settings, cfg, cinfo, _ = _aux_vhdr_info(vhdr_fname)
+        split_settings = settings.splitlines()
+
+        self.segmentation = _parse_segmentation(split_settings, cfg, cinfo)
+
         # Get annotations from vmrk file
         annots = read_annotations(mrk_fname, info['sfreq'])
         self.set_annotations(annots)
@@ -843,3 +848,147 @@ def _check_bv_annot(descriptions):
     bv_markers = (set(_BV_EVENT_IO_OFFSETS.keys())
                   .union(set(_OTHER_ACCEPTED_MARKERS.keys())))
     return len(markers_basename - bv_markers) == 0
+
+
+def _parse_segmentation(settings, cfg, common_info):
+    """Parse the segmentation/averaging section of the header.
+
+    Parameters
+    ----------
+    settings : list
+        the header settings lines
+    cfg : ConfigParser
+        cfg of the header file returned by _aux_vhdr_info
+    common_info : str
+        cinfostr from the BrainVision header parser
+
+    Returns
+    -------
+    dict : The parsed segmentation sections with their
+        key-value pairs as a dict
+    """
+    segmentation = dict()
+    if 'S e g m e n t a t i o n  /  A v e r a g i n g' in settings:
+        idx = settings.index('S e g m e n t a t i o n  /  A v e r a g i n g')
+        segmentation_settings = settings[idx:]
+        segmentation = _parse_basic_segmentation(cfg, common_info)
+
+        if "Markers" in segmentation_settings:
+            idx = segmentation_settings.index("Markers")
+            markers = list()
+            for setting in segmentation_settings[idx + 2:]:
+                if re.match(r'(\t)?\w', setting):
+                    markers.append(setting.strip())
+                else:
+                    break
+            segmentation["artifact_rejection"] = markers
+
+        if "Interval" in segmentation_settings:
+            idx = segmentation_settings.index("Interval")
+            intervals = dict()
+            for setting in segmentation_settings[idx + 2:]:
+                if re.match(r'(\t)?\w', setting):
+                    interval_setting = setting.split()
+                    intervals[interval_setting[0]] = {
+                        "unit": interval_setting[1].lstrip('[').rstrip(']:'),
+                        "duration": interval_setting[2]
+                    }
+                else:
+                    break
+            segmentation["intervals"] = intervals
+
+        if "Averaging" in segmentation_settings:
+            segmentation["averaging"] = _get_segmentation_key_values(
+                segmentation_settings,
+                segmentation_settings.index("Averaging"),
+                " is "
+            )
+
+        if "Artifact Rejection" in segmentation_settings:
+            segmentation["artifact_rejection"] = _get_segmentation_key_values(
+                segmentation_settings,
+                segmentation_settings.index("Artifact Rejection")
+            )
+
+        if "Miscellaneous" in segmentation_settings:
+            segmentation["miscellaneous"] = _get_segmentation_key_values(
+                segmentation_settings,
+                segmentation_settings.index("Miscellaneous")
+            )
+
+    return segmentation
+
+
+def _parse_basic_segmentation(cfg, common_info):
+    """Parse the segmentation info from the Common Infos section.
+
+    Parameters
+    ----------
+    settings : list
+        the header settings lines
+    cfg : ConfigParser
+        cfg of the header file returned by _aux_vhdr_info
+    common_info : str
+        cinfostr from the BrainVision header parser
+
+    Returns
+    -------
+    dict : The parsed segmentation key-values pairs
+        from the Common Infos section
+    """
+    segmentation = dict()
+
+    seg_type = cfg.get(common_info, "SegmentationType")
+    if seg_type:
+        segmentation["type"] = seg_type
+    seg_data_points = cfg.getint(common_info, "SegmentDataPoints")
+    if seg_data_points:
+        segmentation["data_points"] = seg_data_points
+    seg_averaged = cfg.get(common_info, "Averaged")
+    if seg_averaged:
+        segmentation["averaged"] = seg_averaged
+    seg_averaged_segments = cfg.getint(common_info, "AveragedSegments")
+    if seg_averaged_segments:
+        segmentation["averaged_segments"] = seg_averaged_segments
+
+    return segmentation
+
+
+def _get_segmentation_key_values(segmentation_settings, idx, delimiter=":"):
+    """Parse the key value pairs from the Segmentation / Averaging section.
+
+    Default delimiter is ':' where left side is considered the key,
+    and right side is the value.
+
+    Values are parsed into arrays, elements can be split with a comma ','
+    Stops the parsing when the first empty setting line is found
+
+    Parameters
+    ----------
+    segmentation_settings : list
+        the header settings lines
+    idx : int
+        starting index in the settings
+    delimiter : str
+        delimiter to split the key and value
+
+    Returns
+    -------
+    dict : The parsed key and values
+    """
+    key_name = None
+    values = dict()
+    for setting in segmentation_settings[idx + 2:]:
+        if re.match(r'(\t)?\w', setting):
+            setting = setting.split(delimiter)
+            key_name = setting[0].strip()
+            key_values = setting[1].strip().split(',')
+            values[key_name] = key_values if key_values[0] != '' else []
+        elif re.match(r'\t\t\w', setting) and key_name is not None:
+            key_values = setting.strip().split(',')
+            for val in key_values:
+                if val != '':
+                    values[key_name].append(val)
+        else:
+            break
+    return values

--- a/mne/io/brainvision/tests/data/test_segmentation_impedance.vhdr
+++ b/mne/io/brainvision/tests/data/test_segmentation_impedance.vhdr
@@ -1,0 +1,143 @@
+Brain Vision Data Exchange Header File Version 1.0
+; Data created by the Vision Recorder
+
+[Common Infos]
+Codepage=UTF-8
+DataFile=test.eeg
+MarkerFile=test.vmrk
+DataFormat=BINARY
+; Data orientation: MULTIPLEXED=ch1,pt1, ch2,pt1 ...
+DataOrientation=MULTIPLEXED
+NumberOfChannels=19
+; Sampling interval in microseconds
+SamplingInterval=1000
+SegmentationType=MARKERBASED
+SegmentDataPoints=1100
+Averaged=YES
+AveragedSegments=80
+
+[Binary Infos]
+BinaryFormat=IEEE_FLOAT_32
+
+[Channel Infos]
+; Each entry: Ch<Channel number>=<Name>,<Reference channel name>,
+; <Resolution in "Unit">,<Unit>, Future extensions..
+; Fields are delimited by commas, some fields might be omitted (empty).
+; Commas in channel names are coded as "\1".
+Ch1=Fp1,,1,µV
+Ch2=Fp2,,1,µV
+Ch3=F3,,1,µV
+Ch4=F4,,1,µV
+Ch5=C3,,1,µV
+Ch6=C4,,1,µV
+Ch7=P3,,1,µV
+Ch8=P4,,1,µV
+Ch9=O1,,1,µV
+Ch10=O2,,1,µV
+Ch11=F7,,1,µV
+Ch12=F8,,1,µV
+Ch13=T3,,1,µV
+Ch14=T4,,1,µV
+Ch15=T5,,1,µV
+Ch16=T6,,1,µV
+Ch17=Fz,,1,µV
+Ch18=Cz,,1,µV
+Ch19=Pz,,1,µV
+
+[Comment]
+
+A m p l i f i e r  S e t u p
+============================
+Number of channels: 19
+Sampling Rate [Hz]: 1000
+Sampling Interval [µS]: 1000
+
+Channels
+--------
+#     Name      Phys. Chn.    Resolution / Unit   Low Cutoff [s]   High Cutoff [Hz]   Notch [Hz]    Series Res. [kOhm] Gradient         Offset
+1     Fp1         1                0.1 µV             10              250              Off                0                 
+2     Fp2         2                0.1 µV             10              250              Off                0                 
+3     F3          3                0.1 µV             10              250              Off                0                 
+4     F4          4                0.1 µV             10              250              Off                0                 
+5     C3          5                0.1 µV             10              250              Off                0                 
+6     C4          6                0.1 µV             10              250              Off                0                 
+7     P3          7                0.1 µV             10              250              Off                0                 
+8     P4          8                0.1 µV             10              250              Off                0                 
+9     O1          9                0.1 µV             10              250              Off                0                 
+10    O2          10               0.1 µV             10              250              Off                0                 
+11    F7          11               0.1 µV             10              250              Off                0                 
+12    F8          12               0.1 µV             10              250              Off                0                 
+13    T3          13               0.1 µV             10              250              Off                0                 
+14    T4          14               0.1 µV             10              250              Off                0                 
+15    T5          15               0.1 µV             10              250              Off                0                 
+16    T6          16               0.1 µV             10              250              Off                0                 
+17    Fz          17               0.1 µV             10              250              Off                0                 
+18    Cz          18               0.1 µV             10              250              Off                0                 
+19    Pz          19               0.1 µV             10              250              Off                0                 
+
+S o f t w a r e  F i l t e r s
+==============================
+#     Low Cutoff [s]   High Cutoff [Hz]   Notch [Hz]
+1      1.59155          30                 Off
+2      1.59155          30                 Off
+3      1.59155          30                 Off
+4      1.59155          30                 Off
+5      1.59155          30                 Off
+6      1.59155          30                 Off
+7      1.59155          30                 Off
+8      1.59155          30                 Off
+9      1.59155          30                 Off
+10     1.59155          30                 Off
+11     1.59155          30                 Off
+12     1.59155          30                 Off
+13     1.59155          30                 Off
+14     1.59155          30                 Off
+15     1.59155          30                 Off
+16     1.59155          30                 Off
+17     1.59155          30                 Off
+18     1.59155          30                 Off
+19     1.59155          30                 Off
+
+
+
+S e g m e n t a t i o n  /  A v e r a g i n g
+=============================================
+Markers
+-------
+Stimulus    S  2        
+
+Interval
+--------
+Prestimulus [ms]: 100
+Poststimulus [ms]: 1000
+
+Artifact Rejection
+------------------
+	Gradient:        Disabled
+	Max. Difference: Disabled
+	Amplitude:       Disabled
+	Low Activity:    Disabled
+	Test Interval:   Whole Segment
+	Untested Channels:
+		C3, C4, F3, F4, F7, F8, Fp1, Fp2, O1, O2, P3, P4, T3, T4, T5, 
+		T6
+
+Averaging
+---------
+	Averaging is On
+	Baseline Correction is On
+
+Miscellaneous
+-------------
+	Max. Segments: unlimited
+
+
+Data Electrodes Selected Impedance Measurement Range: 0 - 5 kOhm
+Ground Electrode Selected Impedance Measurement Range: 0 - 10 kOhm
+Reference Electrode Selected Impedance Measurement Range: 0 - 10 kOhm
+Impedance [kOhm] at 17:25:01 :
+Fp1:         13
+Fp2:         13
+C3:           1
+Ref:          0
+Gnd:         19

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -44,6 +44,8 @@ vhdr_lowpass_path = op.join(data_dir, 'test_highpass.vhdr')
 vhdr_mixed_lowpass_path = op.join(data_dir, 'test_mixed_lowpass.vhdr')
 vhdr_lowpass_s_path = op.join(data_dir, 'test_lowpass_s.vhdr')
 vhdr_mixed_lowpass_s_path = op.join(data_dir, 'test_mixed_lowpass_s.vhdr')
+vhdr_segmentation_impedance = op.join(data_dir,
+                                      'test_segmentation_impedance.vhdr')
 
 # VHDR exported with neuroone
 data_path = testing.data_path(download=False)
@@ -648,6 +650,33 @@ def test_event_id_stability_when_save_and_fif_reload(tmpdir):
 
     assert event_id == original_event_id
     assert_array_equal(events, original_events)
+
+
+def test_parse_segmentation():
+    """Test case for the segmentation section parsing."""
+    expected_segmentation = {
+        'type': 'MARKERBASED',
+        'data_points': 1100,
+        'averaged': 'YES',
+        'averaged_segments': 80,
+        'artifact_rejection': {
+            'Gradient': ['Disabled'],
+            'Max. Difference': ['Disabled'],
+            'Amplitude': ['Disabled'], 'Low Activity': ['Disabled'],
+            'Test Interval': ['Whole Segment'],
+            'Untested Channels': ['C3', ' C4', ' F3', ' F4', ' F7', ' F8',
+                                  ' Fp1', ' Fp2', ' O1', ' O2', ' P3', ' P4',
+                                  ' T3', ' T4', ' T5', 'T6']
+        },
+        'intervals': {'Prestimulus': {'unit': 'ms', 'duration': '100'},
+                      'Poststimulus': {'unit': 'ms', 'duration': '1000'}},
+        'averaging': {'Averaging': ['On'], 'Baseline Correction': ['On']},
+        'miscellaneous': {'Max. Segments': ['unlimited']}
+    }
+
+    with pytest.warns(RuntimeWarning, match='software filter'):
+        raw = read_raw_brainvision(vhdr_segmentation_impedance, eog=eog)
+    assert_array_equal(expected_segmentation, raw.segmentation)
 
 
 run_tests_if_main()


### PR DESCRIPTION
This was originally in the #7771 Pull Request.

Added parsing of the segmentation metadata from the BrainVision header file. 

**Enhancements:**

The function `_parse_segmentation` takes any of the key-value pairs in the segmentation subsections of the BrainVision file starting with `S e g m e n t a t i o n  /  A v e r a g i n g`, as well as some of the added key-values in the Common Infos. The segmentation is stored in a new attribute `segmentation` of the `RawBrainvision` class.

In the original PR there was a suggestion that the dataset should be read as an Evoked dataset for `Averaged=YES`?