### PR TITLE
Alias temporal_derivative_distribution_repair to tddr

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -39,7 +39,7 @@ Changelog
 
 - :func:`mne.viz.plot_dipole_locations` and :meth:`mne.Dipole.plot_locations` gained a ``title`` argument to specify a custom figure title in ``orthoview`` mode by `Richard Höchenberger`_
 
-- Add temporal derivative distribution repair (TDDR) :func:`mne.preprocessing.nirs.temporal_derivative_distribution_repar` with shortened alias ``mne.preprocessing.nirs.tddr`` by `Robert Luke`_
+- Add temporal derivative distribution repair (TDDR) :func:`mne.preprocessing.nirs.temporal_derivative_distribution_repair` with shortened alias ``mne.preprocessing.nirs.tddr`` by `Robert Luke`_
 
 - Add :func:`mne.read_freesurfer_lut` to make it easier to work with volume atlases by `Eric Larson`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -39,7 +39,7 @@ Changelog
 
 - :func:`mne.viz.plot_dipole_locations` and :meth:`mne.Dipole.plot_locations` gained a ``title`` argument to specify a custom figure title in ``orthoview`` mode by `Richard Höchenberger`_
 
-- Added temporal derivative distribution repair (TDDR) :func:`mne.preprocessing.nirs.tddr` by `Robert Luke`_
+- Add temporal derivative distribution repair (TDDR) :func:`mne.preprocessing.nirs.tddr` by `Robert Luke`_
 
 - Add :func:`mne.read_freesurfer_lut` to make it easier to work with volume atlases by `Eric Larson`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -39,7 +39,7 @@ Changelog
 
 - :func:`mne.viz.plot_dipole_locations` and :meth:`mne.Dipole.plot_locations` gained a ``title`` argument to specify a custom figure title in ``orthoview`` mode by `Richard Höchenberger`_
 
-- Add temporal derivative distribution repair (TDDR) ``mne.preprocessing.nirs.tddr`` by `Robert Luke`_
+- Add temporal derivative distribution repair (TDDR) :func:`mne.preprocessing.nirs.temporal_derivative_distribution_repar` with shortened alias ``mne.preprocessing.nirs.tddr`` by `Robert Luke`_
 
 - Add :func:`mne.read_freesurfer_lut` to make it easier to work with volume atlases by `Eric Larson`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -39,7 +39,7 @@ Changelog
 
 - :func:`mne.viz.plot_dipole_locations` and :meth:`mne.Dipole.plot_locations` gained a ``title`` argument to specify a custom figure title in ``orthoview`` mode by `Richard Höchenberger`_
 
-- Add temporal derivative distribution repair (TDDR) :func:`mne.preprocessing.nirs.tddr` by `Robert Luke`_
+- Add temporal derivative distribution repair (TDDR) ``mne.preprocessing.nirs.tddr`` by `Robert Luke`_
 
 - Add :func:`mne.read_freesurfer_lut` to make it easier to work with volume atlases by `Eric Larson`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -39,7 +39,7 @@ Changelog
 
 - :func:`mne.viz.plot_dipole_locations` and :meth:`mne.Dipole.plot_locations` gained a ``title`` argument to specify a custom figure title in ``orthoview`` mode by `Richard Höchenberger`_
 
-- Added temporal derivative distribution repair :func:`mne.preprocessing.nirs.temporal_derivative_distribution_repair` by `Robert Luke`_
+- Added temporal derivative distribution repair (TDDR) :func:`mne.preprocessing.nirs.tddr` by `Robert Luke`_
 
 - Add :func:`mne.read_freesurfer_lut` to make it easier to work with volume atlases by `Eric Larson`_
 

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -387,7 +387,7 @@ Projections:
    source_detector_distances
    short_channels
    scalp_coupling_index
-   temporal_derivative_distribution_repair
+   tddr
 
 EEG referencing:
 

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -387,7 +387,7 @@ Projections:
    source_detector_distances
    short_channels
    scalp_coupling_index
-   tddr
+   temporal_derivative_distribution_repair
 
 EEG referencing:
 

--- a/examples/preprocessing/plot_fnirs_artifact_removal.py
+++ b/examples/preprocessing/plot_fnirs_artifact_removal.py
@@ -16,7 +16,8 @@ how artifact correction techniques attempt to correct the data.
 import os
 import mne
 
-from mne.preprocessing.nirs import optical_density, tddr
+from mne.preprocessing.nirs import (optical_density,
+                                    temporal_derivative_distribution_repair)
 
 ###############################################################################
 # Import data
@@ -74,7 +75,7 @@ corrupted_od.plot(n_channels=15, duration=400, show_scrollbars=False)
 # This approach corrects baseline shift and spike artifacts without the need
 # for any user-supplied parameters :footcite:`FishburnEtAl2019`.
 
-corrected_tddr = tddr(corrupted_od)
+corrected_tddr = temporal_derivative_distribution_repair(corrupted_od)
 corrected_tddr.plot(n_channels=15, duration=400, show_scrollbars=False)
 
 

--- a/examples/preprocessing/plot_fnirs_artifact_removal.py
+++ b/examples/preprocessing/plot_fnirs_artifact_removal.py
@@ -16,8 +16,7 @@ how artifact correction techniques attempt to correct the data.
 import os
 import mne
 
-from mne.preprocessing.nirs import (
-    optical_density, tddr)
+from mne.preprocessing.nirs import optical_density, tddr
 
 ###############################################################################
 # Import data

--- a/examples/preprocessing/plot_fnirs_artifact_removal.py
+++ b/examples/preprocessing/plot_fnirs_artifact_removal.py
@@ -17,7 +17,7 @@ import os
 import mne
 
 from mne.preprocessing.nirs import (
-    optical_density, temporal_derivative_distribution_repair)
+    optical_density, tddr)
 
 ###############################################################################
 # Import data
@@ -75,7 +75,7 @@ corrupted_od.plot(n_channels=15, duration=400, show_scrollbars=False)
 # This approach corrects baseline shift and spike artifacts without the need
 # for any user-supplied parameters :footcite:`FishburnEtAl2019`.
 
-corrected_tddr = temporal_derivative_distribution_repair(corrupted_od)
+corrected_tddr = tddr(corrupted_od)
 corrected_tddr.plot(n_channels=15, duration=400, show_scrollbars=False)
 
 

--- a/mne/preprocessing/nirs/__init__.py
+++ b/mne/preprocessing/nirs/__init__.py
@@ -6,9 +6,10 @@
 #
 # License: BSD (3-clause)
 
-from .nirs import short_channels, source_detector_distances, _check_channels_ordered,\
-    _channel_frequencies, _fnirs_check_bads, _fnirs_spread_bads
+from .nirs import (short_channels, source_detector_distances,
+                   _check_channels_ordered, _channel_frequencies,
+                   _fnirs_check_bads, _fnirs_spread_bads)
 from ._optical_density import optical_density
 from ._beer_lambert_law import beer_lambert_law
 from ._scalp_coupling_index import scalp_coupling_index
-from ._temporal_derivative_distribution_repair import temporal_derivative_distribution_repair
+from ._tddr import tddr

--- a/mne/preprocessing/nirs/__init__.py
+++ b/mne/preprocessing/nirs/__init__.py
@@ -12,4 +12,4 @@ from .nirs import (short_channels, source_detector_distances,
 from ._optical_density import optical_density
 from ._beer_lambert_law import beer_lambert_law
 from ._scalp_coupling_index import scalp_coupling_index
-from ._tddr import tddr
+from ._tddr import temporal_derivative_distribution_repair, tddr

--- a/mne/preprocessing/nirs/_tddr.py
+++ b/mne/preprocessing/nirs/_tddr.py
@@ -32,8 +32,8 @@ def temporal_derivative_distribution_repair(raw):
 
     Notes
     -----
-    There is a shorter alias :func:`mne.preprocessing.nirs.tddr` that can be
-    used instead of this function (e.g. if line length is an issue).
+    There is a shorter alias ``mne.preprocessing.nirs.tddr`` that can be used
+    instead of this function (e.g. if line length is an issue).
 
     References
     ----------

--- a/mne/preprocessing/nirs/_tddr.py
+++ b/mne/preprocessing/nirs/_tddr.py
@@ -33,7 +33,7 @@ def temporal_derivative_distribution_repair(raw):
     Notes
     -----
     There is a shorter alias :func:`mne.preprocessing.nirs.tddr` that can be
-    used instead of this function (e.g. if PEP8 character limit is an issue).
+    used instead of this function (e.g. if line length is an issue).
 
     References
     ----------

--- a/mne/preprocessing/nirs/_tddr.py
+++ b/mne/preprocessing/nirs/_tddr.py
@@ -60,26 +60,25 @@ tddr = temporal_derivative_distribution_repair
 # With permission https://github.com/frankfishburn/TDDR/issues/1.
 # The only modification is the name, scipy signal import and flake fixes.
 def _TDDR(signal, sample_rate):
-    """Correct data using the TDDR algorithm for motion correction.
-
-    The algorithm is described in:
-    Fishburn F.A., Ludlum R.S., Vaidya C.J., & Medvedev A.V. (2019).
-    Temporal Derivative Distribution Repair (TDDR): A motion correction
-    method for fNIRS. NeuroImage, 184, 171-179.
-    https://doi.org/10.1016/j.neuroimage.2018.09.025
-
-    Parameters
-    ----------
-    signal : ndarray
-        Uncorrected optical density data (sample x channel).
-    sample_rate : float
-        Sampling rate in Hz.
-
-    Returns
-    -------
-    signal_corrected : ndarray
-        Corrected optical density data (sample x channel).
-    """
+    # This function is the reference implementation for the TDDR algorithm for
+    #   motion correction of fNIRS data, as described in:
+    #
+    #   Fishburn F.A., Ludlum R.S., Vaidya C.J., & Medvedev A.V. (2019).
+    #   Temporal Derivative Distribution Repair (TDDR): A motion correction
+    #   method for fNIRS. NeuroImage, 184, 171-179.
+    #   https://doi.org/10.1016/j.neuroimage.2018.09.025
+    #
+    # Usage:
+    #   signals_corrected = TDDR( signals , sample_rate );
+    #
+    # Inputs:
+    #   signals: A [sample x channel] matrix of uncorrected optical density
+    #            data
+    #   sample_rate: A scalar reflecting the rate of acquisition in Hz
+    #
+    # Outputs:
+    #   signals_corrected: A [sample x channel] matrix of corrected optical
+    #   density data
     from scipy.signal import butter, filtfilt
     signal = np.array(signal)
     if len(signal.shape) != 1:

--- a/mne/preprocessing/nirs/_tddr.py
+++ b/mne/preprocessing/nirs/_tddr.py
@@ -12,7 +12,7 @@ from ...utils import _validate_type
 from ...io.pick import _picks_to_idx
 
 
-def tddr(raw):
+def temporal_derivative_distribution_repair(raw):
     """Apply temporal derivative distribution repair to data.
 
     Applies temporal derivative distribution repair (TDDR) to data
@@ -30,6 +30,11 @@ def tddr(raw):
     raw : instance of Raw
          Data with TDDR applied.
 
+    Notes
+    -----
+    There is a shorter alias :func:`mne.preprocessing.nirs.tddr` that can be
+    used instead of this function (e.g. if PEP8 character limit is an issue).
+
     References
     ----------
     .. footbibliography::
@@ -45,6 +50,10 @@ def tddr(raw):
         raw._data[pick] = _TDDR(raw._data[pick], raw.info['sfreq'])
 
     return raw
+
+
+# provide a short alias
+tddr = temporal_derivative_distribution_repair
 
 
 # Taken from https://github.com/frankfishburn/TDDR/ (MIT license).

--- a/mne/preprocessing/nirs/_tddr.py
+++ b/mne/preprocessing/nirs/_tddr.py
@@ -51,7 +51,7 @@ def tddr(raw):
 # With permission https://github.com/frankfishburn/TDDR/issues/1.
 # The only modification is the name, scipy signal import and flake fixes.
 def _TDDR(signal, sample_rate):
-    """Reference implementation for the TDDR algorithm for motion correction.
+    """Correct data using the TDDR algorithm for motion correction.
 
     The algorithm is described in:
     Fishburn F.A., Ludlum R.S., Vaidya C.J., & Medvedev A.V. (2019).

--- a/mne/preprocessing/nirs/_tddr.py
+++ b/mne/preprocessing/nirs/_tddr.py
@@ -12,10 +12,10 @@ from ...utils import _validate_type
 from ...io.pick import _picks_to_idx
 
 
-def temporal_derivative_distribution_repair(raw):
-    r"""Apply temporal derivative distribution repair to data.
+def tddr(raw):
+    """Apply temporal derivative distribution repair to data.
 
-    Applies temporal derivative distribution repair (TDDR) to data.
+    Applies temporal derivative distribution repair (TDDR) to data
     :footcite:`FishburnEtAl2019`. This approach removes baseline shift
     and spike artifacts without the need for any user-supplied parameters.
 
@@ -49,27 +49,28 @@ def temporal_derivative_distribution_repair(raw):
 
 # Taken from https://github.com/frankfishburn/TDDR/ (MIT license).
 # With permission https://github.com/frankfishburn/TDDR/issues/1.
-# The only modification is the name,  scipy signal import and flake fixes.
+# The only modification is the name, scipy signal import and flake fixes.
 def _TDDR(signal, sample_rate):
-    # This function is the reference implementation for the TDDR algorithm for
-    #   motion correction of fNIRS data, as described in:
-    #
-    #   Fishburn F.A., Ludlum R.S., Vaidya C.J., & Medvedev A.V. (2019).
-    #   Temporal Derivative Distribution Repair (TDDR): A motion correction
-    #   method for fNIRS. NeuroImage, 184, 171-179.
-    #   https://doi.org/10.1016/j.neuroimage.2018.09.025
-    #
-    # Usage:
-    #   signals_corrected = TDDR( signals , sample_rate );
-    #
-    # Inputs:
-    #   signals: A [sample x channel] matrix of uncorrected
-    #            optical density data
-    #   sample_rate: A scalar reflecting the rate of acquisition in Hz
-    #
-    # Outputs:
-    #   signals_corrected: A [sample x channel] matrix of corrected
-    #   optical density data
+    """Reference implementation for the TDDR algorithm for motion correction of
+    fNIRS data, as described in:
+
+      Fishburn F.A., Ludlum R.S., Vaidya C.J., & Medvedev A.V. (2019).
+      Temporal Derivative Distribution Repair (TDDR): A motion correction
+      method for fNIRS. NeuroImage, 184, 171-179.
+      https://doi.org/10.1016/j.neuroimage.2018.09.025
+
+    Parameters
+    ----------
+    signal : ndarray
+        Uncorrected optical density data (sample x channel).
+    sample_rate : float
+        Sampling rate in Hz.
+
+    Returns
+    -------
+    signal_corrected : ndarray
+        Corrected optical density data (sample x channel).
+    """
     from scipy.signal import butter, filtfilt
     signal = np.array(signal)
     if len(signal.shape) != 1:

--- a/mne/preprocessing/nirs/_tddr.py
+++ b/mne/preprocessing/nirs/_tddr.py
@@ -51,13 +51,13 @@ def tddr(raw):
 # With permission https://github.com/frankfishburn/TDDR/issues/1.
 # The only modification is the name, scipy signal import and flake fixes.
 def _TDDR(signal, sample_rate):
-    """Reference implementation for the TDDR algorithm for motion correction of
-    fNIRS data, as described in:
+    """Reference implementation for the TDDR algorithm for motion correction.
 
-      Fishburn F.A., Ludlum R.S., Vaidya C.J., & Medvedev A.V. (2019).
-      Temporal Derivative Distribution Repair (TDDR): A motion correction
-      method for fNIRS. NeuroImage, 184, 171-179.
-      https://doi.org/10.1016/j.neuroimage.2018.09.025
+    The algorithm is described in:
+    Fishburn F.A., Ludlum R.S., Vaidya C.J., & Medvedev A.V. (2019).
+    Temporal Derivative Distribution Repair (TDDR): A motion correction
+    method for fNIRS. NeuroImage, 184, 171-179.
+    https://doi.org/10.1016/j.neuroimage.2018.09.025
 
     Parameters
     ----------

--- a/mne/preprocessing/tests/test_temporal_derivative_distribution_repair.py
+++ b/mne/preprocessing/tests/test_temporal_derivative_distribution_repair.py
@@ -9,8 +9,7 @@ import numpy as np
 
 from mne.datasets.testing import data_path
 from mne.io import read_raw_nirx
-from mne.preprocessing.nirs import optical_density, \
-    tddr
+from mne.preprocessing.nirs import optical_density, tddr
 from mne.datasets import testing
 
 

--- a/mne/preprocessing/tests/test_temporal_derivative_distribution_repair.py
+++ b/mne/preprocessing/tests/test_temporal_derivative_distribution_repair.py
@@ -10,7 +10,7 @@ import numpy as np
 from mne.datasets.testing import data_path
 from mne.io import read_raw_nirx
 from mne.preprocessing.nirs import optical_density, \
-    temporal_derivative_distribution_repair
+    tddr
 from mne.datasets import testing
 
 
@@ -31,5 +31,5 @@ def test_temporal_derivative_distribution_repair(fname, tmpdir):
     raw._data[0, 0:30] = raw._data[0, 0:30] - (shift_amp)
     assert np.max(np.diff(raw._data[0])) > shift_amp
     # Ensure that applying the algorithm reduces the step change
-    raw = temporal_derivative_distribution_repair(raw)
+    raw = tddr(raw)
     assert np.max(np.diff(raw._data[0])) < shift_amp

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -249,6 +249,7 @@ read_tag
 rescale
 setup_proj
 source_estimate_quantification
+tddr
 whiten_evoked
 write_fiducials
 write_info


### PR DESCRIPTION
Fixes #7798. I've also made the docstring of the internal `_TDDR` function more Pythonic.