### PR TITLE
MRG: warning banner for old versions of docs

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -122,6 +122,11 @@ blockquote {
   border-radius: 0 0 4px 4px !important;
 }
 
+.devbar a {
+    color: #fff;
+    font-weight: bold;
+}
+
 .pad-top-30 {
   padding-top: 30px;
 }

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -2,6 +2,7 @@
 
 {% block extrahead %}
 
+    <link rel="canonical" href="https://mne.tools/stable/index.html" />
     <script type="text/javascript" src="{{ pathto('_static/copybutton.js', 1) }}"></script>
 
 {% if use_google_analytics|tobool %}
@@ -52,7 +53,8 @@
 {% block relbar1 %}
 {% if build_dev_html|tobool %}
 <div class="d-block devbar alert alert-danger">
-This documentation is for <strong>development version {{ release }}</strong>.
+This is documentation for the <strong></strong>unstable development version</strong> of MNE-Python.
+(To use it, <a href="https://mne.tools/dev/install/advanced.html#using-the-development-version-of-mne-python-latest-master">install latest master from GitHub</a>.).
 </div>
 {% endif %}
 
@@ -90,4 +92,5 @@ This documentation is for <strong>development version {{ release }}</strong>.
       <p class="text-center text-muted small">&copy; Copyright 2012-2020, MNE Developers. Last updated on 2020-03-27.</p>
     </div></div></div>
   </footer>
+  <script src="https://mne.tools/versionwarning.js"></script>
 {%- endblock %}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -53,9 +53,9 @@
 {% block relbar1 %}
 {% if build_dev_html|tobool %}
 <div class="d-block devbar alert alert-danger">
-This is documentation for the <strong>unstable development version</strong> of MNE-Python.
-To use it, <a href="https://mne.tools/dev/install/advanced.html#using-the-development-version-of-mne-python-latest-master">install latest master from GitHub</a>.
-Or, switch to the <a href="https://mne.tools/stable">current stable version</a>.
+This is documentation for the <em>unstable development version</em> of MNE-Python,
+<a href="https://mne.tools/dev/install/advanced.html#using-the-development-version-of-mne-python-latest-master">available here</a>.
+Or, switch to documentation for the <a href="https://mne.tools/stable">current stable version</a>.
 
 </div>
 {% endif %}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -53,8 +53,10 @@
 {% block relbar1 %}
 {% if build_dev_html|tobool %}
 <div class="d-block devbar alert alert-danger">
-This is documentation for the <strong></strong>unstable development version</strong> of MNE-Python.
-(To use it, <a href="https://mne.tools/dev/install/advanced.html#using-the-development-version-of-mne-python-latest-master">install latest master from GitHub</a>.).
+This is documentation for the <strong>unstable development version</strong> of MNE-Python.
+To use it, <a href="https://mne.tools/dev/install/advanced.html#using-the-development-version-of-mne-python-latest-master">install latest master from GitHub</a>.
+Or, switch to the <a href="https://mne.tools/stable">current stable version</a>.
+
 </div>
 {% endif %}
 


### PR DESCRIPTION
closes #7782 

- adds a call to `versionwarning.js` to the layout template
- styles the links in the resulting devbar

WIP until we iron out the style-related questions in [mne-tools.github.io#20](https://github.com/mne-tools/mne-tools.github.io/pull/20)