### PR TITLE
MRG, MAINT: Smaller PNGs during doc build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,12 @@ jobs:
               - pip-cache
 
         - run:
-            name: Install 3D rendering libraries
+            name: Install 3D rendering libraries \ PyQt5 dependencies \ graphviz \ optipng (for optimized images)
             command: |
-              sudo apt-get install libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3
+              sudo apt-get install libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3 \
+                  libxkbcommon-x11-0 \
+                  graphviz \
+                  optipng
 
         - run:
             name: Spin up Xvfb
@@ -64,15 +67,10 @@ jobs:
 
         # https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
         # https://github.com/golemfactory/golem/issues/1019
-        - run:
-            name: Install PyQt5 dependencies
-            command: |
-              sudo apt-get install libxkbcommon-x11-0
 
         - run:
-            name: Install graphviz and fonts needed for diagrams
+            name: Install fonts needed for diagrams
             command: |
-              sudo apt-get install graphviz
               mkdir -p $HOME/.fonts
               curl https://codeload.github.com/adobe-fonts/source-code-pro/tar.gz/2.030R-ro/1.050R-it | tar xz -C $HOME/.fonts
               curl https://codeload.github.com/adobe-fonts/source-sans-pro/tar.gz/2.045R-ro/1.095R-it | tar xz -C $HOME/.fonts

--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -8,8 +8,5 @@
 
 .. _sphx_glr_backreferences_{{ fullname }}:
 
-.. include:: {{ fullname }}.examples
-
-.. raw:: html
-
-    <div style='clear:both'></div>
+.. minigallery:: {{ fullname }}
+    :add-heading:

--- a/doc/_templates/autosummary/function.rst
+++ b/doc/_templates/autosummary/function.rst
@@ -6,8 +6,5 @@
 
 .. _sphx_glr_backreferences_{{ fullname }}:
 
-.. include:: {{ fullname }}.examples
-
-.. raw:: html
-
-    <div style='clear:both'></div>
+.. minigallery:: {{ fullname }}
+    :add-heading:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -391,12 +391,8 @@ def append_attr_meth_examples(app, what, name, obj, options, lines):
 
 .. rubric:: Examples using ``{0}``:
 
-.. include:: {1}.examples
-   :start-line: 5
+.. minigallery:: {1}
 
-.. raw:: html
-
-    <div style="clear:both"></div>
 """.format(name.split('.')[-1], name).split('\n')
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -537,6 +537,7 @@ sphinx_gallery_conf = {
     'capture_repr': ('_repr_html_',),
     'junit': op.join('..', 'test-results', 'sphinx-gallery', 'junit.xml'),
     'matplotlib_animations': True,
+    'compress_images': ('images', 'thumbnails'),
 }
 
 ##############################################################################


### PR DESCRIPTION
Also modernizes our inclusion of backrefs, and considates CircleCI `apt-get` to a single line.