### PR TITLE
Add wrapper read_raw for specific read_raw_xxx readers

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -73,6 +73,8 @@ Changelog
 
 - Add support for loading complex numbers from mat files by `Thomas Hartmann`_
 
+- Add generic reader function :func:`mne.io.read_raw` that loads files based on their extensions (it wraps the underlying specific ``read_raw_xxx`` functions) by `Clemens Brunner`_
+
 Bug
 ~~~
 

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -53,6 +53,7 @@ Reading raw data
    :toctree: generated/
 
    anonymize_info
+   read_raw
    read_raw_artemis123
    read_raw_bti
    read_raw_cnt

--- a/mne/io/__init__.py
+++ b/mne/io/__init__.py
@@ -47,6 +47,7 @@ from .eximia import read_raw_eximia
 from .nirx import read_raw_nirx
 from .fieldtrip import (read_raw_fieldtrip, read_epochs_fieldtrip,
                         read_evoked_fieldtrip)
+from ._read_raw import read_raw
 
 # for backward compatibility
 from .fiff import Raw

--- a/mne/io/_read_raw.py
+++ b/mne/io/_read_raw.py
@@ -1,0 +1,80 @@
+"""Generic wrapper function read_raw for specific read_raw_xxx readers."""
+
+# Authors: Clemens Brunner <clemens.brunner@gmail.com>
+#
+# License: BSD (3-clause)
+
+
+from pathlib import Path
+from functools import partial
+
+from . import (read_raw_edf, read_raw_bdf, read_raw_gdf, read_raw_brainvision,
+               read_raw_fif, read_raw_eeglab, read_raw_cnt, read_raw_egi,
+               read_raw_eximia, read_raw_nirx, read_raw_fieldtrip,
+               read_raw_artemis123, read_raw_nicolet, read_raw_kit,
+               read_raw_ctf)
+
+
+def _read_unsupported(fname, **kwargs):
+    ext = "".join(Path(fname).suffixes)
+    msg = f"Unsupported file type ({ext})."
+    suggest = kwargs.get("suggest")
+    if suggest is not None:
+        msg += f" Try reading a {suggest} file instead."
+    msg += " Consider using a dedicated reader function for more options."
+    raise ValueError(msg)
+
+
+# supported read file formats
+supported = {".edf": read_raw_edf,
+             ".bdf": read_raw_bdf,
+             ".gdf": read_raw_gdf,
+             ".vhdr": read_raw_brainvision,
+             ".fif": read_raw_fif,
+             ".fif.gz": read_raw_fif,
+             ".set": read_raw_eeglab,
+             ".cnt": read_raw_cnt,
+             ".mff": read_raw_egi,
+             ".nxe": read_raw_eximia,
+             ".hdr": read_raw_nirx,
+             ".mat": read_raw_fieldtrip,
+             ".bin": read_raw_artemis123,
+             ".data": read_raw_nicolet,
+             ".sqd": read_raw_kit,
+             ".ds": read_raw_ctf}
+
+# known but unsupported file formats
+suggested = {".vmrk": partial(_read_unsupported, suggest=".vhdr"),
+             ".eeg": partial(_read_unsupported, suggest=".vhdr")}
+
+# all known file formats
+readers = {**supported, **suggested}
+
+
+def read_raw(fname, *, preload=False, verbose=None, **kwargs):
+    """Read raw file.
+
+    Parameters
+    ----------
+    fname : str
+        File name to load.
+    **kwargs
+        Keyword arguments to pass to the underlying reader. For details, see
+        the arguments of the reader for the underlying file format.
+
+    Returns
+    -------
+    raw : mne.io.Raw
+        Raw object.
+
+    Notes
+    -----
+    This function is a wrapper for specific read_raw_xxx readers defined in the
+    readers dict. If it does not work with a specific file, try using a
+    dedicated reader function (read_raw_xxx) instead.
+    """
+    ext = "".join(Path(fname).suffixes)
+    if ext in readers:
+        return readers[ext](fname, preload=preload, verbose=verbose, **kwargs)
+    else:
+        _read_unsupported(fname)

--- a/mne/io/_read_raw.py
+++ b/mne/io/_read_raw.py
@@ -58,6 +58,8 @@ def read_raw(fname, *, preload=False, verbose=None, **kwargs):
     ----------
     fname : str
         File name to load.
+    %(preload)s
+    %(verbose)s
     **kwargs
         Keyword arguments to pass to the underlying reader. For details, see
         the arguments of the reader for the underlying file format.

--- a/mne/io/_read_raw.py
+++ b/mne/io/_read_raw.py
@@ -13,6 +13,7 @@ from . import (read_raw_edf, read_raw_bdf, read_raw_gdf, read_raw_brainvision,
                read_raw_eximia, read_raw_nirx, read_raw_fieldtrip,
                read_raw_artemis123, read_raw_nicolet, read_raw_kit,
                read_raw_ctf)
+from ..utils import fill_doc
 
 
 def _read_unsupported(fname, **kwargs):
@@ -51,6 +52,7 @@ suggested = {".vmrk": partial(_read_unsupported, suggest=".vhdr"),
 readers = {**supported, **suggested}
 
 
+@fill_doc
 def read_raw(fname, *, preload=False, verbose=None, **kwargs):
     """Read raw file.
 

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Generic tests that all raw classes should run."""
-# # Authors: MNE Developers
-#            Stefan Appelhoff <stefan.appelhoff@mailbox.org>
+# Authors: MNE Developers
+#          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #
 # License: BSD (3-clause)
 

--- a/mne/io/tests/test_read_raw.py
+++ b/mne/io/tests/test_read_raw.py
@@ -1,0 +1,36 @@
+"""Test generic read_raw function."""
+
+# Authors: Clemens Brunner <clemens.brunner@gmail.com>
+#
+# License: BSD (3-clause)
+
+
+import pytest
+
+from mne.io import read_raw
+
+
+@pytest.mark.parametrize('fname', ['x.xxx', 'x'])
+def test_read_raw_unsupported(fname):
+    """Test handling of unsupported file types."""
+    with pytest.raises(ValueError, match='Unsupported file type'):
+        read_raw(fname)
+
+
+@pytest.mark.parametrize('fname', ['x.vmrk', 'x.eeg'])
+def test_read_raw_suggested(fname):
+    """Test handling of unsupported file types with suggested alternatives."""
+    with pytest.raises(ValueError, match='Try reading'):
+        read_raw(fname)
+
+
+@pytest.mark.parametrize('fname', ['../edf/tests/data/test.edf',
+                                   '../edf/tests/data/test.bdf',
+                                   '../brainvision/tests/data/test.vhdr',
+                                   '../kit/tests/data/test.sqd'])
+def test_read_raw_supported(fname):
+    """Test supported file types."""
+    read_raw(fname)
+    read_raw(fname, verbose=False)
+    raw = read_raw(fname, preload=True)
+    assert "data loaded" in str(raw)

--- a/mne/io/tests/test_read_raw.py
+++ b/mne/io/tests/test_read_raw.py
@@ -4,10 +4,12 @@
 #
 # License: BSD (3-clause)
 
-
+from pathlib import Path
 import pytest
-
 from mne.io import read_raw
+
+
+base = Path(__file__).parent.parent
 
 
 @pytest.mark.parametrize('fname', ['x.xxx', 'x'])
@@ -24,10 +26,10 @@ def test_read_raw_suggested(fname):
         read_raw(fname)
 
 
-@pytest.mark.parametrize('fname', ['../edf/tests/data/test.edf',
-                                   '../edf/tests/data/test.bdf',
-                                   '../brainvision/tests/data/test.vhdr',
-                                   '../kit/tests/data/test.sqd'])
+@pytest.mark.parametrize('fname', [base / 'edf/tests/data/test.edf',
+                                   base / 'edf/tests/data/test.bdf',
+                                   base / 'brainvision/tests/data/test.vhdr',
+                                   base / 'kit/tests/data/test.sqd'])
 def test_read_raw_supported(fname):
     """Test supported file types."""
     read_raw(fname)


### PR DESCRIPTION
Fixes #7769.

This PR adds `mne.io.read_raw`, which is "just" a wrapper for specific readers. Based on the file extension, the wrapper dispatches known specific readers (and raises an error for unknown file types). I've included a suggested file type in the error message if the user tried to open a wrong file from formats consisting of multiple files (e.g. the BrainVision format has `.eeg`, `.vmrk`, and `.vhdr` files, of which only the last can be opened).

This is a first suggestion, please comment. We should also add a test - any suggestions what the test should do? I thought that we'd use `read_raw` to load each supported file type, and probably also an unsupported one.