### PR TITLE
[MRG] BUGFIX: new epochs doesn't inherit tmin

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -156,6 +156,8 @@ Bug
 
 - Fix bug in :func:`mne.read_epochs_fieldtrip` when importing data without a ``trialinfo`` field by `Thomas Hartmann`_
 
+- Fix bug in :func:`mne.viz.ica.plot_ica_properties` where time series plot doesn't start at the proper tmin by `Teon Brooks`_
+
 API
 ~~~
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -156,7 +156,7 @@ Bug
 
 - Fix bug in :func:`mne.read_epochs_fieldtrip` when importing data without a ``trialinfo`` field by `Thomas Hartmann`_
 
-- Fix bug in :func:`mne.viz.ica.plot_ica_properties` where time series plot doesn't start at the proper tmin by `Teon Brooks`_
+- Fix bug in :meth:`mne.preprocessing.ICA.plot_properties` where time series plot doesn't start at the proper tmin by `Teon Brooks`_
 
 API
 ~~~

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -149,7 +149,8 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
                            values=0.0,
                            axis=0)
     from ..epochs import EpochsArray
-    epochs_src = EpochsArray(epoch_data, epochs_src.info, verbose=0)
+    epochs_src = EpochsArray(epoch_data, epochs_src.info, tmin=epochs_src.tmin,
+                             verbose=0)
 
     plot_epochs_image(epochs_src, picks=pick, axes=[image_ax, erp_ax],
                       combine=None, colorbar=False, show=False,


### PR DESCRIPTION
tmin wasn't being passed to the newly constructed epochs object. This is fine if your epochs start at tmin=0, but it displays erroneously if tmin != 0