### PR TITLE
Remove double spaces in reprs

### DIFF
--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -431,7 +431,7 @@ class Beamformer(dict):
             subject = 'unknown'
         else:
             subject = '"%s"' % (self['subject'],)
-        out = ('<Beamformer  |  %s, subject %s, %s vert, %s ch'
+        out = ('<Beamformer | %s, subject %s, %s vert, %s ch'
                % (self['kind'], subject, n_verts, n_channels))
         if self['pick_ori'] is not None:
             out += ', %s ori' % (self['pick_ori'],)

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -63,7 +63,7 @@ class ConductorModel(dict):
         else:
             extra = ('BEM (%s layer%s)' % (len(self['surfs']),
                                            _pl(self['surfs'])))
-        return '<ConductorModel  |  %s>' % extra
+        return '<ConductorModel | %s>' % extra
 
     def copy(self):
         """Return copy of ConductorModel instance."""

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -208,7 +208,7 @@ class Covariance(dict):
             s = 'diagonal : %s' % self.data.size
         s += ", n_samples : %s" % self.nfree
         s += ", data : %s" % self.data
-        return "<Covariance  |  %s>" % s
+        return "<Covariance | %s>" % s
 
     def __add__(self, cov):
         """Add Covariance taking into account number of degrees of freedom."""

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -159,7 +159,7 @@ class ReceptiveField(BaseEstimator):
             s += "fit: False"
         if hasattr(self, 'scores_'):
             s += "scored (%s)" % self.scoring
-        return "<ReceptiveField  |  %s>" % s
+        return "<ReceptiveField | %s>" % s
 
     def _delay_and_reshape(self, X, y=None):
         """Delay and reshape the variables."""

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -112,7 +112,7 @@ class Dipole(object):
         s = "n_times : %s" % len(self.times)
         s += ", tmin : %0.3f" % np.min(self.times)
         s += ", tmax : %0.3f" % np.max(self.times)
-        return "<Dipole  |  %s>" % s
+        return "<Dipole | %s>" % s
 
     def save(self, fname, overwrite=False):
         """Save dipole in a .dip or .bdip file.
@@ -396,7 +396,7 @@ class DipoleFixed(ShiftTimeMixin):
         s = "n_times : %s" % len(self.times)
         s += ", tmin : %s" % np.min(self.times)
         s += ", tmax : %s" % np.max(self.times)
-        return "<DipoleFixed  |  %s>" % s
+        return "<DipoleFixed | %s>" % s
 
     def copy(self):
         """Copy the DipoleFixed object.

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1464,7 +1464,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
             s += ',' + '\n '.join([''] + counts)
         class_name = self.__class__.__name__
         class_name = 'Epochs' if class_name == 'BaseEpochs' else class_name
-        return '<%s  |  %s>' % (class_name, s)
+        return '<%s | %s>' % (class_name, s)
 
     @fill_doc
     def crop(self, tmin=None, tmax=None, include_tmax=True):

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -198,7 +198,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         s += ", [%0.5g, %0.5g] sec" % (self.times[0], self.times[-1])
         s += ", %s ch" % self.data.shape[0]
         s += ", ~%s" % (sizeof_fmt(self._size),)
-        return "<Evoked  |  %s>" % s
+        return "<Evoked | %s>" % s
 
     @property
     def ch_names(self):

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -32,7 +32,7 @@ class Projection(dict):
         s = "%s" % self['desc']
         s += ", active : %s" % self['active']
         s += ", n_channels : %s" % self['data']['ncol']
-        return "<Projection  |  %s>" % s
+        return "<Projection | %s>" % s
 
     # speed up info copy by taking advantage of mutability
     def __deepcopy__(self, memodict):

--- a/mne/io/tag.py
+++ b/mne/io/tag.py
@@ -43,7 +43,7 @@ class Tag(object):
         self.data = None
 
     def __repr__(self):  # noqa: D105
-        out = ("<Tag  |  kind %s - type %s - size %s - next %s - pos %s"
+        out = ("<Tag | kind %s - type %s - size %s - next %s - pos %s"
                % (self.kind, self.type, self.size, self.next, self.pos))
         if hasattr(self, 'data'):
             out += " - data %s" % self.data

--- a/mne/label.py
+++ b/mne/label.py
@@ -266,7 +266,7 @@ class Label(object):
         name = 'unknown, ' if self.subject is None else self.subject + ', '
         name += repr(self.name) if self.name is not None else "unnamed"
         n_vert = len(self)
-        return "<Label  |  %s, %s : %i vertices>" % (name, self.hemi, n_vert)
+        return "<Label | %s, %s : %i vertices>" % (name, self.hemi, n_vert)
 
     def __len__(self):
         """Return the number of vertices."""
@@ -838,7 +838,7 @@ class BiHemiLabel(object):
         self.hemi = 'both'
 
     def __repr__(self):  # noqa: D105
-        temp = "<BiHemiLabel  |  %s, lh : %i vertices,  rh : %i vertices>"
+        temp = "<BiHemiLabel | %s, lh : %i vertices,  rh : %i vertices>"
         name = 'unknown, ' if self.subject is None else self.subject + ', '
         name += repr(self.name) if self.name is not None else "unnamed"
         return temp % (name, len(self.lh), len(self.rh))

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -471,7 +471,7 @@ class SourceMorph(object):
             s += ", smooth : %s" % self.smooth
             s += ", xhemi" if self.xhemi else ""
 
-        return "<SourceMorph  |  %s>" % s
+        return "<SourceMorph | %s>" % s
 
     @verbose
     def save(self, fname, overwrite=False, verbose=None):

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -410,7 +410,7 @@ class ICA(ContainsMixin):
         if self.exclude:
             s += ', %i sources marked for exclusion' % len(self.exclude)
 
-        return '<ICA  |  %s>' % s
+        return '<ICA | %s>' % s
 
     @verbose
     def fit(self, inst, picks=None, start=None, stop=None, decim=None,

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -525,7 +525,7 @@ class _BaseSourceEstimate(TimeMixin):
         s += ", tmax : %s (ms)" % (1e3 * self.times[-1])
         s += ", tstep : %s (ms)" % (1e3 * self.tstep)
         s += ", data shape : %s" % (self.shape,)
-        return "<%s  |  %s>" % (type(self).__name__, s)
+        return "<%s | %s>" % (type(self).__name__, s)
 
     @fill_doc
     def get_peak(self, tmin=None, tmax=None, mode='abs',

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -178,7 +178,7 @@ class CrossSpectralDensity(object):
             time_str = 'unknown'
 
         return (
-            '<CrossSpectralDensity  |  '
+            '<CrossSpectralDensity | '
             'n_channels={}, time={}, frequencies={}>'
         ).format(self.n_channels, time_str, freq_str)
 

--- a/mne/time_frequency/tests/test_csd.py
+++ b/mne/time_frequency/tests/test_csd.py
@@ -58,19 +58,19 @@ def test_csd():
 def test_csd_repr():
     """Test string representation of CrossSpectralDensity."""
     csd = _make_csd()
-    assert str(csd) == ('<CrossSpectralDensity  |  n_channels=3, time=0.0 to '
+    assert str(csd) == ('<CrossSpectralDensity | n_channels=3, time=0.0 to '
                         '1.0 s, frequencies=1.0, 2.0, 3.0, 4.0 Hz.>')
 
-    assert str(csd.mean()) == ('<CrossSpectralDensity  |  n_channels=3, '
+    assert str(csd.mean()) == ('<CrossSpectralDensity | n_channels=3, '
                                'time=0.0 to 1.0 s, frequencies=1.0-4.0 Hz.>')
 
     csd_binned = csd.mean(fmin=[1, 3], fmax=[2, 4])
-    assert str(csd_binned) == ('<CrossSpectralDensity  |  n_channels=3, '
+    assert str(csd_binned) == ('<CrossSpectralDensity | n_channels=3, '
                                'time=0.0 to 1.0 s, frequencies=1.0-2.0, '
                                '3.0-4.0 Hz.>')
 
     csd_binned = csd.mean(fmin=[1, 2], fmax=[1, 4])
-    assert str(csd_binned) == ('<CrossSpectralDensity  |  n_channels=3, '
+    assert str(csd_binned) == ('<CrossSpectralDensity | n_channels=3, '
                                'time=0.0 to 1.0 s, frequencies=1.0, 2.0-4.0 '
                                'Hz.>')
 
@@ -78,7 +78,7 @@ def test_csd_repr():
     csd_no_time.tmin = None
     csd_no_time.tmax = None
     assert str(csd_no_time) == (
-        '<CrossSpectralDensity  |  n_channels=3, time=unknown, '
+        '<CrossSpectralDensity | n_channels=3, time=unknown, '
         'frequencies=1.0, 2.0, 3.0, 4.0 Hz.>'
     )
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1936,7 +1936,7 @@ class AverageTFR(_BaseTFR):
         s += ", nave : %d" % self.nave
         s += ', channels : %d' % self.data.shape[0]
         s += ', ~%s' % (sizeof_fmt(self._size),)
-        return "<AverageTFR  |  %s>" % s
+        return "<AverageTFR | %s>" % s
 
 
 @fill_doc
@@ -2036,7 +2036,7 @@ class EpochsTFR(_BaseTFR, GetEpochsMixin):
         s += ", epochs : %d" % self.data.shape[0]
         s += ', channels : %d' % self.data.shape[1]
         s += ', ~%s' % (sizeof_fmt(self._size),)
-        return "<EpochsTFR  |  %s>" % s
+        return "<EpochsTFR | %s>" % s
 
     def __abs__(self):
         """Take the absolute value."""

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -103,7 +103,7 @@ class Transform(dict):
         self['trans'] = trans
 
     def __repr__(self):  # noqa: D105
-        return ('<Transform  |  %s->%s>\n%s'
+        return ('<Transform | %s->%s>\n%s'
                 % (_coord_frame_name(self['from']),
                    _coord_frame_name(self['to']), self['trans']))
 


### PR DESCRIPTION
This PR changes `  |  ` (double spaces) to ` | ` (single spaces) in various reprs to make them consistent with the recently changed reprs for `Annotation`, `Info`, and `Raw`.