### PR TITLE
Deprecate meg=True in pick_types

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -183,4 +183,4 @@ API
 
 - The ``threshold`` argument in :meth:`mne.preprocessing.ICA.find_bads_ecg` defaults to ``None`` in version 0.21 but will change to ``'auto'`` in 0.22 by `Yu-Han Luo`_
 
-- The default argument ``meg=True`` in func:`mne.io.pick_types` will change to ``meg=False`` in version 0.22 by `Clemens Brunner`_
+- The default argument ``meg=True`` in :func:`mne.pick_types` will change to ``meg=False`` in version 0.22 by `Clemens Brunner`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -177,8 +177,10 @@ API
 
 - The method ``stc_mixed.plot_surface`` for a :class:`mne.MixedSourceEstimate` has been deprecated in favor of :meth:`stc.surface().plot(...) <mne.MixedSourceEstimate.surface>` by `Eric Larson`_
 
-- Add ``use_dev_head_trans`` parameter to :func:`mne.preprocessing.annotate_movement` to allow choosing the device to head transform is used to define the fixed cHPI coordinates By `Luke Bloy`_
+- Add ``use_dev_head_trans`` parameter to :func:`mne.preprocessing.annotate_movement` to allow choosing the device to head transform is used to define the fixed cHPI coordinates by `Luke Bloy`_
 
 - The function ``mne.channels.read_dig_captrack`` will be deprecated in version 0.22 in favor of :func:`mne.channels.read_dig_captrak` to correct the spelling error: "captraCK" -> "captraK", by `Stefan Appelhoff`_
 
 - The ``threshold`` argument in :meth:`mne.preprocessing.ICA.find_bads_ecg` defaults to ``None`` in version 0.21 but will change to ``'auto'`` in 0.22 by `Yu-Han Luo`_
+
+- The default argument ``meg=True`` in func:`mne.io.pick_types` will change to ``meg=False`` in version 0.22 by `Clemens Brunner`_

--- a/examples/preprocessing/plot_find_ref_artifacts.py
+++ b/examples/preprocessing/plot_find_ref_artifacts.py
@@ -50,7 +50,7 @@ raw = io.read_raw_fif(raw_fname, preload=True)
 # been applied to these data, much of the noise in the reference channels
 # (bottom of the plot) can still be seen in the standard channels.
 select_picks = np.concatenate(
-    (mne.pick_types(raw.info)[-32:],
+    (mne.pick_types(raw.info, meg=True)[-32:],
      mne.pick_types(raw.info, meg=False, ref_meg=True)))
 plot_kwargs = dict(
     duration=100, order=select_picks, n_channels=len(select_picks),

--- a/examples/preprocessing/plot_ica_comparison.py
+++ b/examples/preprocessing/plot_ica_comparison.py
@@ -31,7 +31,7 @@ raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 
 raw = mne.io.read_raw_fif(raw_fname, preload=True)
 
-picks = mne.pick_types(raw.info)
+picks = mne.pick_types(raw.info, meg=True)
 reject = dict(mag=5e-12, grad=4000e-13)
 raw.filter(1, 30, fir_design='firwin')
 

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -308,7 +308,7 @@ def test_apply_dics_ori_inv(_load_forward, pick_ori, inversion, idx,
     fwd_free, fwd_surf, fwd_fixed, fwd_vol = _load_forward
     epochs, _, csd, source_vertno, label, vertices, source_ind = \
         _simulate_data(fwd_fixed, idx)
-    epochs.pick_types('grad')
+    epochs.pick_types(meg='grad')
 
     reg_ = 5 if inversion == 'matrix' else 1
     filters = make_dics(epochs.info, fwd_surf, csd, label=label,
@@ -354,7 +354,7 @@ def test_real(_load_forward, idx, mat_tol, vol_tol):
     fwd_free, fwd_surf, fwd_fixed, fwd_vol = _load_forward
     epochs, _, csd, source_vertno, label, vertices, source_ind = \
         _simulate_data(fwd_fixed, idx)
-    epochs.pick_types('grad')
+    epochs.pick_types(meg='grad')
     reg = 1  # Lots of regularization for our toy dataset
     filters_real = make_dics(epochs.info, fwd_surf, csd, label=label, reg=reg,
                              real_filter=True)

--- a/mne/beamformer/tests/test_resolution_matrix.py
+++ b/mne/beamformer/tests/test_resolution_matrix.py
@@ -45,7 +45,7 @@ def test_resolution_matrix_lcmv():
 
     # evoked info
     info = mne.io.read_info(fname_evoked)
-    mne.pick_info(info, mne.pick_types(info), copy=False)  # good MEG channels
+    mne.pick_info(info, mne.pick_types(info, meg=True), copy=False)  # good MEG
 
     # noise covariance matrix
     # ad-hoc to avoid discrepancies due to regularisation of real noise

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -633,7 +633,7 @@ class UpdateChannelsMixin(object):
     """Mixin class for Raw, Evoked, Epochs, AverageTFR."""
 
     @verbose
-    def pick_types(self, meg=True, eeg=False, stim=False, eog=False,
+    def pick_types(self, meg=None, eeg=False, stim=False, eog=False,
                    ecg=False, emg=False, ref_meg='auto', misc=False,
                    resp=False, chpi=False, exci=False, ias=False, syst=False,
                    seeg=False, dipole=False, gof=False, bio=False, ecog=False,
@@ -644,10 +644,9 @@ class UpdateChannelsMixin(object):
         Parameters
         ----------
         meg : bool | str
-            If True include all MEG channels. If False include None.
-            If string it can be 'mag', 'grad', 'planar1' or 'planar2' to select
-            only magnetometers, all gradiometers, or a specific type of
-            gradiometer.
+            If True include MEG channels. If string it can be 'mag', 'grad',
+            'planar1' or 'planar2' to select only magnetometers, all
+            gradiometers, or a specific type of gradiometer.
         eeg : bool
             If True include EEG channels.
         stim : bool
@@ -659,8 +658,10 @@ class UpdateChannelsMixin(object):
         emg : bool
             If True include EMG channels.
         ref_meg : bool | str
-            If True include CTF / 4D reference channels. If 'auto', the
-            reference channels are only included if compensations are present.
+            If True include CTF / 4D reference channels. If 'auto', reference
+            channels are included if compensations are present and ``meg`` is
+            not False. Can also be the string options for the ``meg``
+            parameter.
         misc : bool
             If True include miscellaneous analog channels.
         resp : bool

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -295,7 +295,7 @@ def subjects_dir_tmp(tmpdir):
 @pytest.fixture(scope='session', params=[testing._pytest_param()])
 def _evoked_cov_sphere(_evoked):
     """Compute a small evoked/cov/sphere combo for use with forwards."""
-    evoked = _evoked.copy().pick_types()
+    evoked = _evoked.copy().pick_types(meg=True)
     evoked.pick_channels(evoked.ch_names[::4])
     assert len(evoked.ch_names) == 77
     cov = mne.read_cov(fname_cov)

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -457,7 +457,7 @@ def _prepare_for_forward(src, mri_head_t, info, bem, mindist, n_jobs,
     megcoils, compcoils, megnames, meg_info = [], [], [], []
     eegels, eegnames = [], []
 
-    if meg and len(pick_types(info, ref_meg=False, exclude=[])) > 0:
+    if meg and len(pick_types(info, meg=True, ref_meg=False, exclude=[])) > 0:
         megcoils, compcoils, megnames, meg_info = \
             _prep_meg_channels(info, ignore_ref=ignore_ref)
     if eeg and len(pick_types(info, meg=False, eeg=True, ref_meg=False,

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -315,7 +315,7 @@ def test_forward_mixed_source_space(tmpdir):
     src = surf + vol1 + vol2
 
     # calculate forward solution
-    fwd = make_forward_solution(fname_raw, fname_trans, src, fname_bem, None)
+    fwd = make_forward_solution(fname_raw, fname_trans, src, fname_bem)
     assert (repr(fwd))
 
     # extract source spaces

--- a/mne/io/array/tests/test_array.py
+++ b/mne/io/array/tests/test_array.py
@@ -85,7 +85,7 @@ def test_array_raw():
     types.extend(['ecog', 'seeg', 'hbo'])  # really 3 meg channels
     types.extend(['stim'] * 9)
     types.extend(['eeg'] * 60)
-    picks = np.concatenate([pick_types(raw.info)[::20],
+    picks = np.concatenate([pick_types(raw.info, meg=True)[::20],
                             pick_types(raw.info, meg=False, stim=True),
                             pick_types(raw.info, meg=False, eeg=True)[::20]])
     del raw
@@ -113,7 +113,7 @@ def test_array_raw():
     pytest.raises(TypeError, RawArray, info, data)
 
     # filtering
-    picks = pick_types(raw2.info, misc=True, exclude='bads')[:4]
+    picks = pick_types(raw2.info, meg=True, misc=True, exclude='bads')[:4]
     assert_equal(len(picks), 4)
     raw_lp = raw2.copy()
     kwargs = dict(fir_design='firwin', picks=picks)

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -98,7 +98,7 @@ def test_data():
 
     assert_array_almost_equal(data_py, data_Ykgw)
 
-    py_picks = pick_types(raw_py.info, stim=True, ref_meg=False,
+    py_picks = pick_types(raw_py.info, meg=True, stim=True, ref_meg=False,
                           exclude='bads')
     data_py, _ = raw_py[py_picks]
     assert_array_almost_equal(data_py, data_bin)

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -84,7 +84,7 @@ def test_data():
         assert_array_equal(stim1, stim2)
 
     # Binary file only stores the sensor channels
-    py_picks = pick_types(raw_py.info, exclude='bads')
+    py_picks = pick_types(raw_py.info, meg=True, exclude='bads')
     raw_bin = op.join(data_dir, 'test_bin_raw.fif')
     raw_bin = read_raw_fif(raw_bin, preload=True)
     bin_picks = pick_types(raw_bin.info, stim=True, exclude='bads')

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -87,7 +87,7 @@ def test_data():
     py_picks = pick_types(raw_py.info, meg=True, exclude='bads')
     raw_bin = op.join(data_dir, 'test_bin_raw.fif')
     raw_bin = read_raw_fif(raw_bin, preload=True)
-    bin_picks = pick_types(raw_bin.info, stim=True, exclude='bads')
+    bin_picks = pick_types(raw_bin.info, meg=True, stim=True, exclude='bads')
     data_bin, _ = raw_bin[bin_picks]
     data_py, _ = raw_py[py_picks]
 

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -421,10 +421,12 @@ def pick_types(info, meg=None, eeg=False, stim=False, eog=False, ecg=False,
                                'fnirs_raw', 'fnirs_od')
             if ch_type in ('grad', 'mag'):
                 pick[k] = _triage_meg_pick(info['chs'][k], meg)
-                deprecation_warn = True
+                if meg_default_arg:
+                    deprecation_warn = True
             elif ch_type == 'ref_meg':
                 pick[k] = _triage_meg_pick(info['chs'][k], ref_meg)
-                deprecation_warn = True
+                if meg_default_arg:
+                    deprecation_warn = True
             else:  # ch_type in ('hbo', 'hbr')
                 pick[k] = _triage_fnirs_pick(info['chs'][k], fnirs)
 

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -374,8 +374,8 @@ def pick_types(info, meg=None, eeg=False, stim=False, eog=False, ecg=False,
     # PickChannelsMixin
     if meg is None:
         meg = True
-        warn("The default of meg=True will change to meg=False in version "
-             "0.22.", DeprecationWarning)
+        warn("The default of meg=True will change to meg=False in version 0.22"
+             ", set meg explicitly to avoid this warning.", DeprecationWarning)
     exclude = _check_info_exclude(info, exclude)
     nchan = info['nchan']
     pick = np.zeros(nchan, dtype=np.bool)

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -656,7 +656,7 @@ def pick_channels_forward(orig, include=[], exclude=[], ordered=False,
     return fwd
 
 
-def pick_types_forward(orig, meg=True, eeg=False, ref_meg=True, seeg=False,
+def pick_types_forward(orig, meg=None, eeg=False, ref_meg=True, seeg=False,
                        ecog=False, include=[], exclude=[]):
     """Pick by channel type and names from a forward operator.
 
@@ -664,10 +664,10 @@ def pick_types_forward(orig, meg=True, eeg=False, ref_meg=True, seeg=False,
     ----------
     orig : dict
         A forward solution.
-    meg : bool or str
-        If True include all MEG channels. If False include None
-        If string it can be 'mag' or 'grad' to select only gradiometers
-        or magnetometers.
+    meg : bool | str
+        If True include MEG channels. If string it can be 'mag', 'grad',
+        'planar1' or 'planar2' to select only magnetometers, all gradiometers,
+        or a specific type of gradiometer.
     eeg : bool
         If True include EEG channels.
     ref_meg : bool

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from .constants import FIFF
 from ..utils import (logger, verbose, _validate_type, fill_doc, _ensure_int,
-                     _check_option)
+                     _check_option, warn)
 
 
 def get_channel_type_constants():
@@ -298,7 +298,7 @@ def _check_info_exclude(info, exclude):
     return exclude
 
 
-def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
+def pick_types(info, meg=None, eeg=False, stim=False, eog=False, ecg=False,
                emg=False, ref_meg='auto', misc=False, resp=False, chpi=False,
                exci=False, ias=False, syst=False, seeg=False, dipole=False,
                gof=False, bio=False, ecog=False, fnirs=False, csd=False,
@@ -310,10 +310,9 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
     info : dict
         The measurement info.
     meg : bool | str
-        If True include all MEG channels. If False include None
-        If string it can be 'mag', 'grad', 'planar1' or 'planar2' to select
-        only magnetometers, all gradiometers, or a specific type of
-        gradiometer.
+        If True include MEG channels. If string it can be 'mag', 'grad',
+        'planar1' or 'planar2' to select only magnetometers, all gradiometers,
+        or a specific type of gradiometer.
     eeg : bool
         If True include EEG channels.
     stim : bool
@@ -325,10 +324,9 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
     emg : bool
         If True include EMG channels.
     ref_meg : bool | str
-        If True include CTF / 4D reference channels. If 'auto', the
-        reference channels included if compensations are present
-        and ``meg`` is not False. Can also be the string options allowed
-        for the ``meg`` parameter.
+        If True include CTF / 4D reference channels. If 'auto', reference
+        channels are included if compensations are present and ``meg`` is not
+        False. Can also be the string options for the ``meg`` parameter.
     misc : bool
         If True include miscellaneous analog channels.
     resp : bool
@@ -374,6 +372,10 @@ def pick_types(info, meg=True, eeg=False, stim=False, eog=False, ecg=False,
     """
     # NOTE: Changes to this function's signature should also be changed in
     # PickChannelsMixin
+    if meg is None:
+        meg = True
+        warn("The default of meg=True will change to meg=False in version "
+             "0.22.", DeprecationWarning)
     exclude = _check_info_exclude(info, exclude)
     nchan = info['nchan']
     pick = np.zeros(nchan, dtype=np.bool)

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -375,6 +375,8 @@ def pick_types(info, meg=None, eeg=False, stim=False, eog=False, ecg=False,
     if meg is None:
         meg = True  # previous default arg
         meg_default_arg = True  # default argument for meg was used
+    else:
+        meg_default_arg = False
     # only issue deprecation warning if there are MEG channels in the data and
     # if the function was called with the default arg for meg
     deprecation_warn = False

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -944,7 +944,8 @@ def _pick_aux_channels(info, exclude='bads'):
 def _pick_data_or_ica(info, exclude=()):
     """Pick only data or ICA channels."""
     if any(ch_name.startswith('ICA') for ch_name in info['ch_names']):
-        picks = pick_types(info, exclude=exclude, misc=True)
+        # FIXME: is meg=True really correct here?
+        picks = pick_types(info, exclude=exclude, misc=True, meg=True)
     else:
         picks = _pick_data_channels(info, exclude=exclude, with_ref_meg=True)
     return picks

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -394,9 +394,8 @@ def pick_types(info, meg=None, eeg=False, stim=False, eog=False, ecg=False,
     for param in (eeg, stim, eog, ecg, emg, misc, resp, chpi, exci,
                   ias, syst, seeg, dipole, gof, bio, ecog, csd):
         if not isinstance(param, bool):
-            w = ('Parameters for all channel types (with the exception '
-                 'of "meg", "ref_meg" and "fnirs") must be of type bool, '
-                 'not {0}.')
+            w = ('Parameters for all channel types (with the exception of '
+                 '"meg", "ref_meg" and "fnirs") must be of type bool, not {}.')
             raise ValueError(w.format(type(param)))
 
     param_dict = dict(eeg=eeg, stim=stim, eog=eog, ecg=ecg, emg=emg,

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -560,6 +560,8 @@ def test_pick_types_deprecation():
 
     assert list(pick_types(info1, meg=True)) == [1, 2, 4]
     assert not list(pick_types(info1, meg=False))  # empty
+    assert list(pick_types(info1, meg='planar1')) == [2]
+    assert not list(pick_types(info1, meg='planar2'))  # empty
 
     # info without any MEG channels
     info2 = create_info(6, 256, ["eeg", "eeg", "eog", "misc", "stim", "hbo"])

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -549,4 +549,22 @@ def test_pick_channels_cov():
     assert 'loglik' not in cov_copy
 
 
+def test_pick_types_deprecation():
+    # info with MEG channels at indices 1, 2, and 4
+    info1 = create_info(6, 256, ["eeg", "mag", "grad", "misc", "grad", "hbo"])
+
+    with pytest.deprecated_call():
+        assert list(pick_types(info1)) == [1, 2, 4]
+        assert list(pick_types(info1, eeg=True)) == [0, 1, 2, 4]
+
+    assert list(pick_types(info1, meg=True)) == [1, 2, 4]
+    assert not list(pick_types(info1, meg=False))  # empty
+
+    # info without any MEG channels
+    info2 = create_info(6, 256, ["eeg", "eeg", "eog", "misc", "stim", "hbo"])
+
+    assert not list(pick_types(info2))  # empty
+    assert list(pick_types(info2, eeg=True)) == [0, 1]
+
+
 run_tests_if_main()

--- a/mne/io/tests/test_pick.py
+++ b/mne/io/tests/test_pick.py
@@ -550,6 +550,7 @@ def test_pick_channels_cov():
 
 
 def test_pick_types_deprecation():
+    """Test deprecation warning for pick_types(meg=True)."""
     # info with MEG channels at indices 1, 2, and 4
     info1 = create_info(6, 256, ["eeg", "mag", "grad", "misc", "grad", "hbo"])
 

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -190,7 +190,7 @@ def test_set_eeg_reference():
     # custom_ref_applied flag remains untouched.
     reref = raw.copy()
     reref.info['custom_ref_applied'] = FIFF.FIFFV_MNE_CUSTOM_REF_ON
-    reref.pick_types(eeg=False)  # Cause making average ref fail
+    reref.pick_types(meg=True, eeg=False)  # Cause making average ref fail
     pytest.raises(ValueError, set_eeg_reference, reref, projection=True)
     assert reref.info['custom_ref_applied'] == FIFF.FIFFV_MNE_CUSTOM_REF_ON
 

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -558,7 +558,7 @@ def test_orientation_prior(bias_params_free, method, looses, vmin, vmax,
 def test_inverse_residual(evoked, method):
     """Test MNE inverse application."""
     # use fname_inv as it will be faster than fname_full (fewer verts and chs)
-    evoked = evoked.pick_types()
+    evoked = evoked.pick_types(meg=True)
     inv = read_inverse_operator(fname_inv_fixed_depth)
     fwd = read_forward_solution(fname_fwd)
     pick_channels_forward(fwd, evoked.ch_names, copy=False)

--- a/mne/preprocessing/tests/test_ecg.py
+++ b/mne/preprocessing/tests/test_ecg.py
@@ -72,7 +72,7 @@ def test_find_ecg():
         raw.set_channel_types({'MEG 2641': 'ecg'})
     create_ecg_epochs(raw)
 
-    raw.load_data().pick_types()  # remove ECG
+    raw.load_data().pick_types(meg=True)  # remove ECG
     ecg_epochs = create_ecg_epochs(raw, keep_ecg=False)
     assert len(ecg_epochs.events) == n_events
     assert 'ECG-SYN' not in raw.ch_names

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -649,7 +649,7 @@ def test_fine_calibration():
     raw_sss_bad = maxwell_filter(
         raw_missing, calibration=fine_cal_fname, origin=mf_head_origin,
         regularize=None, bad_condition='ignore')
-    raw_missing.pick_types()  # actually remove bads
+    raw_missing.pick_types(meg=True)  # actually remove bads
     raw_sss_bad.pick_channels(raw_missing.ch_names)  # remove them here, too
     with pytest.warns(RuntimeWarning, match='cal channels not in data'):
         raw_sss_missing = maxwell_filter(
@@ -1094,7 +1094,7 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
         assert 0 in pick_types(raw.info, meg=False, eeg=True)
     if ignore_ref:
         # Fake a bad one, otherwise we don't find any
-        assert 42 in pick_types(raw.info, ref_meg=False)
+        assert 42 in pick_types(raw.info, meg=True, ref_meg=False)
         assert raw.ch_names[42:43] == want_bads
         raw._data[42] += np.random.RandomState(0).randn(len(raw.times))
     # maxfilter -autobad on -v -f test_raw.fif -force -cal off -ctc off -regularize off -list -o test_raw.fif -f ~/mne_data/MNE-testing-data/MEG/sample/sample_audvis_trunc_raw.fif  # noqa: E501

--- a/mne/simulation/tests/test_evoked.py
+++ b/mne/simulation/tests/test_evoked.py
@@ -97,7 +97,7 @@ def test_add_noise():
         rng = np.random.RandomState(0)
     raw = read_raw_fif(raw_fname)
     raw.del_proj()
-    picks = pick_types(raw.info, eeg=True, exclude=())
+    picks = pick_types(raw.info, meg=True, eeg=True, exclude=())
     cov = compute_raw_covariance(raw, picks=picks)
     with pytest.raises(RuntimeError, match='to be loaded'):
         add_noise(raw, cov)

--- a/mne/simulation/tests/test_raw.py
+++ b/mne/simulation/tests/test_raw.py
@@ -223,7 +223,7 @@ def test_simulate_raw_sphere(raw_data, tmpdir):
     cov['projs'] = raw.info['projs']
     raw.info['bads'] = raw.ch_names[:1]
     sphere_norad = make_sphere_model('auto', None, raw.info)
-    raw_meg = raw.copy().pick_types()
+    raw_meg = raw.copy().pick_types(meg=True)
     raw_sim = simulate_raw(raw_meg.info, stc, trans, src, sphere_norad,
                            head_pos=head_pos_sim)
     # Test IO on processed data

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -50,7 +50,7 @@ ctf_fname = op.join(testing.data_path(download=False), 'CTF',
 def test_compute_whitener(proj, pca):
     """Test properties of compute_whitener."""
     raw = read_raw_fif(raw_fname).crop(0, 3).load_data()
-    raw.pick_types(eeg=True, exclude=())
+    raw.pick_types(meg=True, eeg=True, exclude=())
     if proj:
         raw.apply_proj()
     else:
@@ -265,7 +265,8 @@ def test_cov_estimation_on_raw(method, tmpdir):
     else:
         # We explicitly zero out off-diag entries between channel types,
         # so let's just check MEG off-diag entries
-        off_diag = np.triu_indices(len(pick_types(raw.info, exclude=())))
+        off_diag = np.triu_indices(len(pick_types(raw.info, meg=True,
+                                                  exclude=())))
     for other in (cov_mne, cov):
         assert_allclose(np.diag(cov_np), np.diag(other.data), rtol=5e-6)
         assert_allclose(cov_np[off_diag], other.data[off_diag], rtol=4e-3)
@@ -697,7 +698,7 @@ def test_low_rank_cov(raw_epochs_events):
     del reg_r_only_cov, reg_r_cov
 
     # test that rank=306 is same as rank='full'
-    epochs_meg = epochs.copy().pick_types()
+    epochs_meg = epochs.copy().pick_types(meg=True)
     assert len(epochs_meg.ch_names) == 306
     epochs_meg.info.update(bads=[], projs=[])
     cov_full = compute_covariance(epochs_meg, method='oas',

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -403,7 +403,7 @@ def test_get_phantom_dipoles():
 def test_confidence(tmpdir):
     """Test confidence limits."""
     evoked = read_evokeds(fname_evo_full, 'Left Auditory', baseline=(None, 0))
-    evoked.crop(0.08, 0.08).pick_types()  # MEG-only
+    evoked.crop(0.08, 0.08).pick_types(meg=True)  # MEG-only
     cov = make_ad_hoc_cov(evoked.info)
     sphere = make_sphere_model((0., 0., 0.04), 0.08)
     dip_py = fit_dipole(evoked, cov, sphere)[0]

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -325,7 +325,7 @@ def test_evoked_resample():
 def test_evoked_filter():
     """Test filtering evoked data."""
     # this is mostly a smoke test as the Epochs and raw tests are more complete
-    ave = read_evokeds(fname, 0).pick_types('grad')
+    ave = read_evokeds(fname, 0).pick_types(meg='grad')
     ave.data[:] = 1.
     assert round(ave.info['lowpass']) == 172
     ave_filt = ave.copy().filter(None, 40., fir_design='firwin')

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -374,7 +374,7 @@ def test_needs_eeg_average_ref_proj():
 def test_sss_proj():
     """Test `meg` proj option."""
     raw = read_raw_fif(raw_fname)
-    raw.crop(0, 1.0).load_data().pick_types(exclude=())
+    raw.crop(0, 1.0).load_data().pick_types(meg=True, exclude=())
     raw.pick_channels(raw.ch_names[:51]).del_proj()
     with pytest.raises(ValueError, match='can only be used with Maxfiltered'):
         compute_proj_raw(raw, meg='combined')

--- a/mne/tests/test_rank.py
+++ b/mne/tests/test_rank.py
@@ -200,7 +200,7 @@ def test_cov_rank_estimation(rank_method, proj, meg):
 ])
 def test_maxfilter_get_rank(n_proj, fname, rank_orig, meg, tol_kind, tol):
     """Test maxfilter rank lookup."""
-    raw = read_raw_fif(fname).crop(0, 5).load_data().pick_types()
+    raw = read_raw_fif(fname).crop(0, 5).load_data().pick_types(meg=True)
     assert raw.info['projs'] == []
     mf = raw.info['proc_history'][0]['max_info']
     assert mf['sss_info']['nfree'] == rank_orig

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -45,7 +45,7 @@ def test_helmet():
     trans = _get_trans(fname_trans)[0]
     new_info = read_info(fname_raw)
     artemis_info = new_info.copy()
-    for pick in pick_types(new_info):
+    for pick in pick_types(new_info, meg=True):
         new_info['chs'][pick]['coil_type'] = 9999
         artemis_info['chs'][pick]['coil_type'] = \
             FIFF.FIFFV_COIL_ARTEMIS123_GRAD

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -84,7 +84,8 @@ def _get_data():
 
     # decimate for speed
     left_temporal_channels = mne.read_selection('Left-temporal')
-    picks = mne.pick_types(raw.info, selection=left_temporal_channels)
+    picks = mne.pick_types(raw.info, meg=True,
+                           selection=left_temporal_channels)
     picks = picks[::2]
     raw.pick_channels([raw.ch_names[ii] for ii in picks])
     del picks

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -1409,7 +1409,7 @@ def _plot_update_epochs_proj(params, bools=None):
 def _handle_picks(epochs):
     """Handle picks."""
     if any('ICA' in k for k in epochs.ch_names):
-        picks = pick_types(epochs.info, misc=True, ref_meg=False,
+        picks = pick_types(epochs.info, meg=True, misc=True, ref_meg=False,
                            exclude=[])
     else:
         picks = pick_types(epochs.info, meg=True, eeg=True, eog=True, ecg=True,

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -432,7 +432,7 @@ def test_plot_raw_psd():
 
     # gh-5046
     raw = read_raw_fif(raw_fname, preload=True).crop(0, 1)
-    picks = pick_types(raw.info)
+    picks = pick_types(raw.info, meg=True)
     raw.plot_psd(picks=picks, average=False)
     raw.plot_psd(picks=picks, average=True)
     plt.close('all')

--- a/tutorials/intro/plot_10_overview.py
+++ b/tutorials/intro/plot_10_overview.py
@@ -323,7 +323,7 @@ aud_evoked.plot_topomap(times=[0., 0.08, 0.1, 0.12, 0.2], ch_type='eeg')
 # :meth:`~mne.Evoked.plot_topo`:
 
 evoked_diff = mne.combine_evoked([aud_evoked, -vis_evoked], weights='equal')
-evoked_diff.pick_types('mag').plot_topo(color='r', legend=False)
+evoked_diff.pick_types(meg='mag').plot_topo(color='r', legend=False)
 
 ##############################################################################
 # Inverse modeling

--- a/tutorials/preprocessing/plot_30_filtering_resampling.py
+++ b/tutorials/preprocessing/plot_30_filtering_resampling.py
@@ -138,7 +138,7 @@ add_arrows(fig.axes[:2])
 # unaffected by the power line noise, we'll also specify a ``picks`` argument
 # so that only the magnetometers and gradiometers get filtered:
 
-meg_picks = mne.pick_types(raw.info)  # meg=True, eeg=False are the defaults
+meg_picks = mne.pick_types(raw.info, meg=True)
 freqs = (60, 120, 180, 240)
 raw_notch = raw.copy().notch_filter(freqs=freqs, picks=meg_picks)
 for title, data in zip(['Un', 'Notch '], [raw, raw_notch]):

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -104,7 +104,8 @@ crosstalk_file = os.path.join(sample_data_folder, 'SSS', 'ct_sparse_mgh.fif')
 # we just low-pass filter these data:
 
 raw.info['bads'] = []
-raw_check = raw.copy().pick_types(exclude=()).load_data().filter(None, 40)
+raw_check = raw.copy()
+raw_check.pick_types(meg=True, exclude=()).load_data().filter(None, 40)
 auto_noisy_chs, auto_flat_chs = mne.preprocessing.find_bad_channels_maxwell(
     raw_check, cross_talk=crosstalk_file, calibration=fine_cal_file,
     verbose=True)


### PR DESCRIPTION
Fixes #7710 (change the default `meg=True` to `meg=False` in a deprecation cycle.

- [x] Fix/prepare examples/tutorials/etc.
- [x] Change also in `pick_types_forward`?
- [x] ~~Any additional MEG bias we should remove in this PR?~~
- [x] ~~Make arguments kw-only?~~