### PR TITLE
MRG, ENH: Support n_col keyword in ica.plot_score

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -167,6 +167,8 @@ API
 
 - Python 3.5 is no longer supported, Python 3.6+ is required, by `Eric Larson`_
 
+- Add ``n_cols`` parameter to :meth:`mne.preprocessing.ICA.plot_scores` to allow plotting scores in multiple columns, by `Luke Bloy`_
+
 - In :func:`mne.stats.permutation_cluster_test` and :func:`mne.stats.permutation_cluster_1samp_test` the default parameter value ``out_type='mask'`` has changed to ``None``, which in 0.21 means ``'mask'`` but will change to mean ``'indices'`` in the next version, by `Daniel McCloy`_
 
 - ``vmin`` and ``vmax`` parameters are deprecated in :meth:`mne.Epochs.plot_psd_topomap` and :func:`mne.viz.plot_epochs_psd_topomap`; use new ``vlim`` parameter instead, by `Daniel McCloy`_.

--- a/examples/preprocessing/plot_find_ref_artifacts.py
+++ b/examples/preprocessing/plot_find_ref_artifacts.py
@@ -74,7 +74,7 @@ ica_tog.fit(raw_tog, picks=all_picks)
 bad_comps, scores = ica_tog.find_bads_ref(raw_tog, threshold=2.5)
 
 # Plot scores with bad components marked.
-ica_tog.plot_scores(scores, bad_comps, n_cols=1)
+ica_tog.plot_scores(scores, bad_comps)
 
 # Examine the properties of removed components. It's clear from the time
 # courses and topographies that these components represent external,
@@ -114,7 +114,7 @@ raw_sep.add_channels([ref_comps])
 bad_comps, scores = ica_sep.find_bads_ref(raw_sep, method="separate")
 
 # Plot scores with bad components marked.
-ica_sep.plot_scores(scores, bad_comps, n_cols=1)
+ica_sep.plot_scores(scores, bad_comps)
 
 # Examine the properties of removed components.
 ica_sep.plot_properties(raw_sep, picks=bad_comps)

--- a/examples/preprocessing/plot_find_ref_artifacts.py
+++ b/examples/preprocessing/plot_find_ref_artifacts.py
@@ -74,7 +74,7 @@ ica_tog.fit(raw_tog, picks=all_picks)
 bad_comps, scores = ica_tog.find_bads_ref(raw_tog, threshold=2.5)
 
 # Plot scores with bad components marked.
-ica_tog.plot_scores(scores, bad_comps)
+ica_tog.plot_scores(scores, bad_comps, n_cols=1)
 
 # Examine the properties of removed components. It's clear from the time
 # courses and topographies that these components represent external,
@@ -114,7 +114,7 @@ raw_sep.add_channels([ref_comps])
 bad_comps, scores = ica_sep.find_bads_ref(raw_sep, method="separate")
 
 # Plot scores with bad components marked.
-ica_sep.plot_scores(scores, bad_comps)
+ica_sep.plot_scores(scores, bad_comps, n_cols=1)
 
 # Examine the properties of removed components.
 ica_sep.plot_properties(raw_sep, picks=bad_comps)

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1712,11 +1712,12 @@ class ICA(ContainsMixin):
 
     @copy_function_doc_to_method_doc(plot_ica_scores)
     def plot_scores(self, scores, exclude=None, labels=None, axhline=None,
-                    title='ICA component scores', figsize=None,
+                    title='ICA component scores', figsize=None, n_cols=None,
                     show=True):
         return plot_ica_scores(
             ica=self, scores=scores, exclude=exclude, labels=labels,
-            axhline=axhline, title=title, figsize=figsize, show=show)
+            axhline=axhline, title=title, figsize=figsize, n_cols=n_cols,
+            show=show)
 
     @copy_function_doc_to_method_doc(plot_ica_overlay)
     def plot_overlay(self, inst, exclude=None, picks=None, start=None,

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -638,10 +638,10 @@ def plot_ica_scores(ica, scores, exclude=None, labels=None, axhline=None,
     if n_cols is None:
         # prefer more rows.
         n_rows = int(np.ceil(np.sqrt(n_scores)))
-        n_cols = int(np.ceil(n_scores / float(n_rows)))
+        n_cols = (n_scores - 1) // n_rows + 1
     else:
         n_cols = min(n_scores, n_cols)
-        n_rows = int(np.ceil(n_scores / float(n_cols)))
+        n_rows = (n_scores - 1) // n_cols + 1
 
     if figsize is None:
         figsize = (6.4 * n_cols, 2.7 * n_rows)

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -657,9 +657,16 @@ def plot_ica_scores(ica, scores, exclude=None, labels=None, axhline=None,
 
     if labels == 'ecg':
         labels = [label for label in ica.labels_ if label.startswith('ecg/')]
+        labels.sort(key=lambda l: l.split('/')[1])  # sort by index
+        if len(labels) == 0:
+            labels = [label for label in ica.labels_ if
+                      label.startswith('ecg')]
     elif labels == 'eog':
         labels = [label for label in ica.labels_ if label.startswith('eog/')]
         labels.sort(key=lambda l: l.split('/')[1])  # sort by index
+        if len(labels) == 0:
+            labels = [label for label in ica.labels_ if
+                      label.startswith('eog')]
     elif isinstance(labels, str):
         labels = [labels]
     elif labels is None:

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -636,11 +636,12 @@ def plot_ica_scores(ica, scores, exclude=None, labels=None, axhline=None,
     n_scores = len(scores)
 
     if n_cols is None:
-        n_cols = int(np.ceil(np.sqrt(n_scores)))
+        # prefer more rows.
+        n_rows = int(np.ceil(np.sqrt(n_scores)))
+        n_cols = int(np.ceil(n_scores / float(n_rows)))
     else:
         n_cols = min(n_scores, n_cols)
-
-    n_rows = int(np.ceil(n_scores / float(n_cols)))
+        n_rows = int(np.ceil(n_scores / float(n_cols)))
 
     if figsize is None:
         figsize = (6.4 * n_cols, 2.7 * n_rows)

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -302,7 +302,8 @@ def test_plot_ica_scores():
     # ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='ecg')
 
     # check setting number of columns (by checking largest colNum in figure)
-    fig = ica.plot_scores([[0.3, 0.2], [0.3, 0.2]], axhline=[0.1, -0.1])
+    fig = ica.plot_scores([[0.3, 0.2], [0.3, 0.2], [0.3, 0.2]],
+                          axhline=[0.1, -0.1])
     assert 1 == np.max([f.colNum for f in fig.get_children()
                         if hasattr(f, 'colNum')])
 

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -296,9 +296,26 @@ def test_plot_ica_scores():
     ica.labels_['eog'] = 0
     ica.labels_['ecg'] = 1
     ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1])
+    ica.plot_scores([[0.3, 0.2], [0.3, 0.2]], axhline=[0.1, -0.1])
     ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='foo')
     ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='eog')
-    ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='ecg')
+    # ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='ecg')
+
+    # check setting number of columns (by checking largest colNum in figure)
+    fig = ica.plot_scores([[0.3, 0.2], [0.3, 0.2]], axhline=[0.1, -0.1])
+    assert 1 == np.max([f.colNum for f in fig.get_children()
+                        if hasattr(f, 'colNum')])
+
+    fig = ica.plot_scores([[0.3, 0.2], [0.3, 0.2]], axhline=[0.1, -0.1],
+                          n_cols=1)
+    assert 0 == np.max([f.colNum for f in fig.get_children()
+                        if hasattr(f, 'colNum')])
+
+    # only use 1 column (even though 2 were requested)
+    fig = ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], n_cols=2)
+    assert 0 == np.max([f.colNum for f in fig.get_children()
+                        if hasattr(f, 'colNum')])
+
     pytest.raises(
         ValueError,
         ica.plot_scores,

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -291,12 +291,17 @@ def test_plot_ica_scores():
               max_pca_components=3, n_pca_components=3)
     with pytest.warns(RuntimeWarning, match='projection'):
         ica.fit(raw, picks=picks)
+    ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], figsize=(6.4, 2.7))
+    ica.plot_scores([[0.3, 0.2], [0.3, 0.2]], axhline=[0.1, -0.1])
+
+    # check labels
     ica.labels_ = dict()
-    ica.labels_['eog/0/foo'] = 0
     ica.labels_['eog'] = 0
     ica.labels_['ecg'] = 1
-    ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1])
-    ica.plot_scores([[0.3, 0.2], [0.3, 0.2]], axhline=[0.1, -0.1])
+    ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='eog')
+    ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='ecg')
+    ica.labels_['eog/0/foo'] = 0
+    ica.labels_['ecg/1/bar'] = 0
     ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='foo')
     ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='eog')
     ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='ecg')

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -299,9 +299,9 @@ def test_plot_ica_scores():
     ica.plot_scores([[0.3, 0.2], [0.3, 0.2]], axhline=[0.1, -0.1])
     ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='foo')
     ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='eog')
-    # ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='ecg')
+    ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='ecg')
 
-    # check setting number of columns (by checking largest colNum in figure)
+    # check setting number of columns
     fig = ica.plot_scores([[0.3, 0.2], [0.3, 0.2], [0.3, 0.2]],
                           axhline=[0.1, -0.1])
     assert 2 == fig.get_axes()[0].get_geometry()[1]

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -304,18 +304,14 @@ def test_plot_ica_scores():
     # check setting number of columns (by checking largest colNum in figure)
     fig = ica.plot_scores([[0.3, 0.2], [0.3, 0.2], [0.3, 0.2]],
                           axhline=[0.1, -0.1])
-    assert 1 == np.max([f.colNum for f in fig.get_children()
-                        if hasattr(f, 'colNum')])
-
+    assert 2 == fig.get_axes()[0].get_subplotspec().get_rows_columns()[1]
     fig = ica.plot_scores([[0.3, 0.2], [0.3, 0.2]], axhline=[0.1, -0.1],
                           n_cols=1)
-    assert 0 == np.max([f.colNum for f in fig.get_children()
-                        if hasattr(f, 'colNum')])
+    assert 1 == fig.get_axes()[0].get_subplotspec().get_rows_columns()[1]
 
     # only use 1 column (even though 2 were requested)
     fig = ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], n_cols=2)
-    assert 0 == np.max([f.colNum for f in fig.get_children()
-                        if hasattr(f, 'colNum')])
+    assert 1 == fig.get_axes()[0].get_subplotspec().get_rows_columns()[1]
 
     pytest.raises(
         ValueError,

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -304,14 +304,14 @@ def test_plot_ica_scores():
     # check setting number of columns (by checking largest colNum in figure)
     fig = ica.plot_scores([[0.3, 0.2], [0.3, 0.2], [0.3, 0.2]],
                           axhline=[0.1, -0.1])
-    assert 2 == fig.get_axes()[0].get_subplotspec().get_rows_columns()[1]
+    assert 2 == fig.get_axes()[0].get_geometry()[1]
     fig = ica.plot_scores([[0.3, 0.2], [0.3, 0.2]], axhline=[0.1, -0.1],
                           n_cols=1)
-    assert 1 == fig.get_axes()[0].get_subplotspec().get_rows_columns()[1]
+    assert 1 == fig.get_axes()[0].get_geometry()[1]
 
     # only use 1 column (even though 2 were requested)
     fig = ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], n_cols=2)
-    assert 1 == fig.get_axes()[0].get_subplotspec().get_rows_columns()[1]
+    assert 1 == fig.get_axes()[0].get_geometry()[1]
 
     pytest.raises(
         ValueError,


### PR DESCRIPTION
In playing with the recent ica ref channels artifact rejection (#7810), I'd sometimes have 4-5 score plots in one column, which I couldn't see.

This PR adds a parameter ('n_col') to 'ica_plot_scores' to use a grid with multiple columns.

There is a question about the following from the test.
```ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], labels='ecg')```
it fails on this PR and is currently commented out.

On master it passed but did not make a plot, because:
```
if labels == 'ecg':
        labels = [label for label in ica.labels_ if label.startswith('ecg/')]
```
returned `labels = []` and nothing was plotted.

I don't know enough about the ica labeling so someone should advice what the correct behavior is and how to test it.
 