### PR TITLE
WIP: Add CrossSpectralDensity.compute_coherence method

### DIFF
--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -378,6 +378,37 @@ class CrossSpectralDensity(object):
 
         return _vector_to_sym_mat(self._data[:, index])
 
+    def compute_coherence(self, frequency=None, index=None):
+        """Compute a sensor-to-sensor coherence matrix.
+
+        If there is only one matrix defined in the CSD object, calling this
+        method without any parameters will return the coherence matrix for it.
+        If multiple matrices are defined, use either the ``frequency`` or
+        ``index`` parameter to select one to compute coherence for.
+
+        Parameters
+        ----------
+        frequency : float | None
+            Compute the coherence matrix for a specific frequency. Only
+            available when no averaging across frequencies has been done.
+        index : int | None
+            Compute the coherence for the frequency or frequency-bin with the
+            given index.
+
+        Returns
+        -------
+        coh : ndarray, shape (n_channels, n_channels)
+            The sensor-to-sensor coherence matrix corresponding to the
+            requested frequency.
+
+        See Also
+        --------
+        get_data
+        """
+        cm = self.get_data(frequency=frequency, index=index)
+        psd = np.diag(cm).real
+        return np.abs(cm) ** 2 / psd[np.newaxis, :] / psd[:, np.newaxis]
+
     @copy_function_doc_to_method_doc(plot_csd)
     def plot(self, info=None, mode='csd', colorbar=True, cmap='viridis',
              n_cols=None, show=True):

--- a/mne/time_frequency/tests/test_csd.py
+++ b/mne/time_frequency/tests/test_csd.py
@@ -220,6 +220,20 @@ def test_csd_get_data():
     raises(IndexError, csd.mean().get_data, index=15)
 
 
+def test_csd_compute_coherence():
+    """Test computing coherence from a CSD matrix."""
+    csd = CrossSpectralDensity(
+        [1, np.sqrt(1 * 2), np.sqrt(1 * 3), 2, np.sqrt(2 * 3), 3],
+        ch_names=['CH1', 'CH2', 'CH3'],
+        frequencies=[1.],
+        tmin=0.,
+        tmax=0.,
+        n_fft=1,
+    )
+    coh = csd.compute_coherence(frequency=1)
+    assert_allclose(coh, np.ones((3, 3)))
+
+
 @requires_h5py
 def test_csd_save():
     """Test saving and loading a CrossSpectralDensity."""

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -1249,13 +1249,11 @@ def plot_csd(csd, info=None, mode='csd', colorbar=True, cmap=None,
 
         csd_mats = []
         for i in range(len(csd.frequencies)):
-            cm = csd.get_data(index=i)[ind][:, ind]
             if mode == 'csd':
+                cm = csd.get_data(index=i)[ind][:, ind]
                 cm = np.abs(cm) * scalings.get(ch_type, 1)
             elif mode == 'coh':
-                # Compute coherence from the CSD matrix
-                psd = np.diag(cm).real
-                cm = np.abs(cm) ** 2 / psd[np.newaxis, :] / psd[:, np.newaxis]
+                cm = csd.compute_coherence(index=i)[ind][:, ind]
             csd_mats.append(cm)
 
         vmax = np.max(csd_mats)


### PR DESCRIPTION
Computing sensor level coherence is quite simple, and useful if you for
example want to compute coherence between each MEG sensor and an
external source.

Todo:

 - [x] Implement `csd.compute_coherence` method
 - [x] Refactor `csd.plot(mode='coh')` to make use of the new method
 - [x] Unit test
 - [ ] Add example for computing sensor-level coherence with external source
 - [ ] Add entry to what's new
