### PR TITLE
MRG, ENH: Add estimation method legend

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -65,6 +65,8 @@ Changelog
 
 - Add ``plot`` option to :meth:`mne.viz.plot_filter` allowing selection of which filter properties are plotted and added option for user to supply ``axes`` by `Robert Luke`_
 
+- Add estimation method legend to :func:`mne.viz.plot_snr_estimate` by `Eric Larson`_
+
 - Add ``sources`` and ``detectors`` options for fNIRS use of :meth:`mne.viz.plot_alignment` allowing plotting of optode locations in addition to channel midpoint ``channels`` and ``path`` between fNIRS optodes by `Kyle Mathewson`_
 
 - Add ECoG misc EDF dataset to the :ref:`tut_working_with_ecog` tutorial to show snapshots of time-frequency activity by `Adam Li`_

--- a/examples/inverse/plot_snr_estimate.py
+++ b/examples/inverse/plot_snr_estimate.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """
-============================
-Plot an estimate of data SNR
-============================
+==================================
+Estimate data SNR using an inverse
+==================================
 
-This estimates the SNR as a function of time for a set of data.
+This estimates the SNR as a function of time for a set of data
+using a minimum-norm inverse operator.
 """
 # Author: Eric Larson <larson.eric.d@gmail.com>
 #

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1647,7 +1647,7 @@ def estimate_snr(evoked, inv, verbose=None):
     Returns
     -------
     snr : ndarray, shape (n_times,)
-        The SNR estimated from the whitened data.
+        The SNR estimated from the whitened data (i.e., GFP of whitened data).
     snr_est : ndarray, shape (n_times,)
         The SNR estimated using the mismatch between the unregularized
         solution and the regularized solution.

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1250,11 +1250,17 @@ def plot_snr_estimate(evoked, inv, show=True, verbose=None):
     ax.axhline(0, color='k', ls=':', lw=1)
     # Colors are "bluish green" and "vermilion" taken from:
     #  http://bconnelly.net/2013/10/creating-colorblind-friendly-figures/
-    ax.plot(evoked.times, snr_est, color=[0.0, 0.6, 0.5])
-    ax.plot(evoked.times, snr - 1, color=[0.8, 0.4, 0.0])
-    ax.set(xlim=lims[:2], ylim=lims[2:], ylabel='SNR', xlabel='Time (s)')
+    hs = list()
+    labels = ('Inverse', 'Whitened GFP')
+    hs.append(ax.plot(
+        evoked.times, snr_est, color=[0.0, 0.6, 0.5])[0])
+    hs.append(ax.plot(
+        evoked.times, snr - 1, color=[0.8, 0.4, 0.0])[0])
+    ax.set(xlim=lims[:2], ylim=lims[2:], ylabel='SNR',
+           xlabel='Time (s)')
     if evoked.comment is not None:
         ax.set_title(evoked.comment)
+    ax.legend(hs, labels, title='Estimation method')
     plt_show(show)
     return fig
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1215,7 +1215,7 @@ def _plot_evoked_white(evoked, noise_cov, scalings, rank, show, time_unit,
 
 
 @verbose
-def plot_snr_estimate(evoked, inv, show=True, verbose=None):
+def plot_snr_estimate(evoked, inv, show=True, axes=None, verbose=None):
     """Plot a data SNR estimate.
 
     Parameters
@@ -1226,6 +1226,10 @@ def plot_snr_estimate(evoked, inv, show=True, verbose=None):
         The minimum-norm inverse operator.
     show : bool
         Show figure if True.
+    axes : instance of Axes | None
+        The axes to plot into.
+
+        .. versionadded:: 0.21.0
     %(verbose)s
 
     Returns
@@ -1244,7 +1248,12 @@ def plot_snr_estimate(evoked, inv, show=True, verbose=None):
     import matplotlib.pyplot as plt
     from ..minimum_norm import estimate_snr
     snr, snr_est = estimate_snr(evoked, inv)
-    fig, ax = plt.subplots(1, 1)
+    _validate_type(axes, (None, plt.Axes))
+    if axes is None:
+        _, ax = plt.subplots(1, 1)
+    else:
+        ax = axes
+    fig = axes.figure
     lims = np.concatenate([evoked.times[[0, -1]], [-1, snr_est.max()]])
     ax.axvline(0, color='k', ls=':', lw=1)
     ax.axhline(0, color='k', ls=':', lw=1)

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1253,7 +1253,8 @@ def plot_snr_estimate(evoked, inv, show=True, axes=None, verbose=None):
         _, ax = plt.subplots(1, 1)
     else:
         ax = axes
-    fig = axes.figure
+        del axes
+    fig = ax.figure
     lims = np.concatenate([evoked.times[[0, -1]], [-1, snr_est.max()]])
     ax.axvline(0, color='k', ls=':', lw=1)
     ax.axhline(0, color='k', ls=':', lw=1)


### PR DESCRIPTION
Makes it clearer what the lines correspond to:

![Screenshot from 2020-05-26 13-26-41](https://user-images.githubusercontent.com/2365790/82931239-9723da80-9f54-11ea-805b-957083c11e3d.png)
