### PR TITLE
MRG, MAINT: Show how picks work for planars

### DIFF
--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -52,6 +52,29 @@ raw_invalid_bday_fname = op.join(data_path, 'misc',
                                  'sample_invalid_birthday_raw.fif')
 
 
+@pytest.mark.parametrize('kwargs, want', [
+    (dict(meg=False, eeg=True), [0]),
+    (dict(meg=False, fnirs=True), [5]),
+    (dict(meg=False, fnirs='hbo'), [5]),
+    (dict(meg=False, fnirs='hbr'), []),
+    (dict(meg=False, misc=True), [1]),
+    (dict(meg=True), [2, 3, 4]),
+    (dict(meg='grad'), [2, 3]),
+    (dict(meg='planar1'), [2]),
+    (dict(meg='planar2'), [3]),
+    (dict(meg='mag'), [4]),
+])
+def test_create_info_grad(kwargs, want):
+    """Test create_info behavior with grad coils."""
+    info = create_info(6, 256, ["eeg", "misc", "grad", "grad", "mag", "hbo"])
+    # Put these in an order such that grads get named "2" and "3", since
+    # they get picked based first on coil_type then ch_name...
+    assert [ch['ch_name'] for ch in info['chs']
+            if ch['coil_type'] == FIFF.FIFFV_COIL_VV_PLANAR_T1] == ['2', '3']
+    picks = pick_types(info, **kwargs)
+    assert_array_equal(picks, want)
+
+
 def test_get_valid_units():
     """Test the valid units."""
     valid_units = _get_valid_units()


### PR DESCRIPTION
Help for #7823

@cbrnr it turns out that there is only one planar grad coil type, then the `ch_name` is used to differentiate one from the other (they are named `MEGXXX2` and `MEGXXX3` by the system). So the behavior in your PR is okay, just confusing because you managed to make one of them end in `2` and the other not. Eventually we should add a note that picking this way only works when names are native / unchanged, but really this is a pretty deep corner case.