### PR TITLE
MRG, MAINT: Change default role in conf.py

### DIFF
--- a/doc/_includes/bem_model.rst
+++ b/doc/_includes/bem_model.rst
@@ -23,7 +23,7 @@ The watershed algorithm [Segonne *et al.*,
 2004] is part of the FreeSurfer software.
 The name of the program is mri_watershed .
 Its use in the MNE environment is facilitated by the script
-:ref:`gen_mne_watershed_bem`.
+:ref:`mne watershed_bem`.
 
 After ``mne watershed_bem`` has completed, the following files appear in the
 subject's :file:`bem/watershed` directory:
@@ -61,7 +61,7 @@ Creation of the BEM meshes using this method involves the following steps:
 
 - Creating a synthetic 5-degree flip angle FLASH volume, register
   it with the MPRAGE data, and run the segmentation and meshing program.
-  This step is accomplished by running the script :ref:`gen_mne_flash_bem`.
+  This step is accomplished by running the script :ref:`mne flash_bem`.
 
 - Inspecting the meshes with tkmedit, see :ref:`inspecting-meshes`.
 
@@ -88,10 +88,10 @@ Creating the surface tessellations
 ----------------------------------
 
 The BEM surface segmentation and tessellation is automated with the script
-:ref:`gen_mne_flash_bem`. It assumes that a FreeSurfer reconstruction for this
+:ref:`mne flash_bem`. It assumes that a FreeSurfer reconstruction for this
 subject is already in place.
 
-Before running :ref:`gen_mne_flash_bem` do the following:
+Before running :ref:`mne flash_bem` do the following:
 
 - Create symbolic links from the directories containing the 5-degree and
   30-degree flip angle FLASH series to ``flash05`` and ``flash30``,
@@ -161,6 +161,6 @@ Inspecting the meshes
 It is advisable to check the validity of the BEM meshes before
 using them. This can be done with:
 
-- the ``--view`` option of :ref:`gen_mne_flash_bem`
+- the ``--view`` option of :ref:`mne flash_bem`
 - calling :func:`mne.viz.plot_bem` directly
 - Using FreeSurfer tools ``tkmedit`` or ``freeview``

--- a/doc/_includes/channel_interpolation.rst
+++ b/doc/_includes/channel_interpolation.rst
@@ -29,7 +29,7 @@ where the :math:`C = (c_{1}, ..., c_{N})^{T}` are constants which must be estima
 .. math:: g_{m}(x) = \frac{1}{4 \pi}\sum_{n=1}^{\infty} \frac{2n + 1}{(n(n + 1))^m}P_{n}(x)
    :label: legendre
 
-where :math:`P_{n}(x)` are `Legendre polynomials`_ of order `n`.
+where :math:`P_{n}(x)` are `Legendre polynomials`_ of order :math:`n`.
 
 .. _Legendre polynomials: https://en.wikipedia.org/wiki/Legendre_polynomials
 

--- a/doc/_includes/forward.rst
+++ b/doc/_includes/forward.rst
@@ -203,7 +203,7 @@ and
     +------------------------------+-------------------------------+-------------------------------------------------+
     | :math:`T_2`                  | Not present                   | | MRI description filesSeparate                 |
     |                              |                               | | Separate ``-trans.fif`` files                 |
-    |                              |                               | | from :ref:`gen_mne_coreg`                     |
+    |                              |                               | | from :ref:`mne coreg`                         |
     |                              |                               | | Forward solution files                        |
     |                              |                               | | Inverse operator files                        |
     +------------------------------+-------------------------------+-------------------------------------------------+

--- a/doc/_includes/forward.rst
+++ b/doc/_includes/forward.rst
@@ -195,8 +195,8 @@ and
     | Transformation               | FreeSurfer                    | MNE                                             |
     +------------------------------+-------------------------------+-------------------------------------------------+
     | :math:`T_1`                  | Not present                   | | Measurement data files                        |
-    |                              |                               | | Forward solution files (`*fwd.fif`)           |
-    |                              |                               | | Inverse operator files (`*inv.fif`)           |
+    |                              |                               | | Forward solution files (``*fwd.fif``)         |
+    |                              |                               | | Inverse operator files (``*inv.fif``)         |
     +------------------------------+-------------------------------+-------------------------------------------------+
     | :math:`T_{s_1}\dots T_{s_n}` | Not present                   | Channel information in files                    |
     |                              |                               | containing :math:`T_1`.                         |
@@ -207,7 +207,7 @@ and
     |                              |                               | | Forward solution files                        |
     |                              |                               | | Inverse operator files                        |
     +------------------------------+-------------------------------+-------------------------------------------------+
-    | :math:`T_3`                  | `mri/*mgz` files              | :class:`nibabel.freesurfer.mghformat.MGHImage`  |
+    | :math:`T_3`                  | ``mri/*mgz`` files            | :class:`nibabel.freesurfer.mghformat.MGHImage`  |
     +------------------------------+-------------------------------+-------------------------------------------------+
     | :math:`T_4`                  | mri/transforms/talairach.xfm  | Internal reading                                |
     +------------------------------+-------------------------------+-------------------------------------------------+

--- a/doc/_includes/inverse.rst
+++ b/doc/_includes/inverse.rst
@@ -119,7 +119,7 @@ where
 
 is the spatially whitened gain matrix. We arrive at the whitened inverse
 operator equation :eq:`inv_m_tilde` by making the substitution for
-`G` from :eq:`inv_g_tilde` in :eq:`inv_m` as
+:math:`G` from :eq:`inv_g_tilde` in :eq:`inv_m` as
 
 .. math::
 

--- a/doc/changes/0.10.inc
+++ b/doc/changes/0.10.inc
@@ -100,9 +100,9 @@ API
 
 - Rename and deprecate ``mne.viz.plot_topo`` for ``mne.viz.plot_evoked_topo`` by `Jaakko Leppakangas`_
 
-- Deprecated :class: `mne.decoding.transformer.ConcatenateChannels` and replaced by :class: `mne.decoding.transformer.EpochsVectorizer` by `Romain Trachel`_
+- Deprecated ``mne.decoding.transformer.ConcatenateChannels`` and replaced by ``mne.decoding.EpochsVectorizer`` by `Romain Trachel`_
 
-- Deprecated `lws` and renamed `ledoit_wolf` for the ``reg`` argument in :class:`mne.decoding.CSP` by `Romain Trachel`_
+- Deprecated ``lws`` and renamed ``ledoit_wolf`` for the ``reg`` argument in :class:`mne.decoding.CSP` by `Romain Trachel`_
 
 - Redesigned and rewrote :meth:`mne.Epochs.plot` (no backwards compatibility) during the GSOC 2015 by `Jaakko Leppakangas`_, `Mainak Jas`_, `Federico Raimondo`_ and `Denis Engemann`_
 

--- a/doc/changes/0.12.inc
+++ b/doc/changes/0.12.inc
@@ -109,7 +109,7 @@ BUG
 
 - Fix bug in :class:`mne.Evoked` type setting in :func:`mne.stats.linear_regression_raw` by `Eric Larson`_
 
-- Fix bug in :class: `mne.io.edf.RawEDF` highpass filter setting to take max highpass to match warning message by `Teon Brooks`_
+- Fix bug in ``mne.io.edf.RawEDF`` highpass filter setting to take max highpass to match warning message by `Teon Brooks`_
 
 - Fix bugs with coordinane frame adjustments in ``mne.viz.plot_trans`` by `Eric Larson`_
 
@@ -136,9 +136,9 @@ BUG
 API
 ~~~
 
-- The default `picks=None` in :func:`mne.viz.plot_epochs_image` now only plots the first 5 channels, not all channels, by `Jona Sassenhagen`_
+- The default ``picks=None`` in :func:`mne.viz.plot_epochs_image` now only plots the first 5 channels, not all channels, by `Jona Sassenhagen`_
 
-- The ``mesh_color`` parameter in :func:`mne.viz.plot_dipole_locations` has been removed (use `brain_color` instead), by `Marijn van Vliet`_
+- The ``mesh_color`` parameter in :func:`mne.viz.plot_dipole_locations` has been removed (use ``brain_color`` instead), by `Marijn van Vliet`_
 
 - Deprecated functions ``mne.time_frequency.compute_raw_psd`` and ``mne.time_frequency.compute_epochs_psd``, replaced by :func:`mne.time_frequency.psd_welch` by `Chris Holdgraf`_
 
@@ -164,7 +164,7 @@ API
 
 - Subselecting channels can now emit a warning if many channels have been subselected from projection vectors. We recommend only computing projection vertors for and applying projectors to channels that will be used in the final analysis. However, after picking a subset of channels, projection vectors can be renormalized with :func:`mne.Info.normalize_proj` if necessary to avoid warnings about subselection. Changes by `Eric Larson`_ and `Alex Gramfort`_.
 
-- Rename and deprecate ``mne.Epochs.drop_bad_epochs`` to :func:`mne.Epochs.drop_bad`, and `mne.Epochs.drop_epochs`` to :func:`mne.Epochs.drop` by `Alex Gramfort`_.
+- Rename and deprecate ``mne.Epochs.drop_bad_epochs`` to :func:`mne.Epochs.drop_bad`, and ``mne.Epochs.drop_epochs`` to :func:`mne.Epochs.drop` by `Alex Gramfort`_.
 
 - The C wrapper ``mne.do_forward_solution`` has been deprecated in favor of the native Python version :func:`mne.make_forward_solution` by `Eric Larson`_
 

--- a/doc/changes/0.13.inc
+++ b/doc/changes/0.13.inc
@@ -42,9 +42,9 @@ Changelog
 
 - Add the option to plot brain surfaces and source spaces to :func:`viz.plot_bem` by `Christian Brodbeck`_
 
-- Add the ``--filterchpi`` option to :ref:`mne browse_raw <gen_mne_browse_raw>`, by `Felix Raimundo`_
+- Add the ``--filterchpi`` option to :ref:`mne browse_raw <mne browse_raw>`, by `Felix Raimundo`_
 
-- Add the ``--no-decimate`` option to :ref:`mne make_scalp_surfaces <gen_mne_make_scalp_surfaces>` to skip the high-resolution surface decimation step, by `Eric Larson`_
+- Add the ``--no-decimate`` option to :ref:`mne make_scalp_surfaces <mne make_scalp_surfaces>` to skip the high-resolution surface decimation step, by `Eric Larson`_
 
 - Add new class :class:`mne.decoding.EMS` to transform epochs with the event-matched spatial filters and add 'cv' parameter to :func:`mne.decoding.compute_ems`, by `Jean-Remi King`_
 

--- a/doc/changes/0.13.inc
+++ b/doc/changes/0.13.inc
@@ -64,7 +64,7 @@ Changelog
 
 - Adds new function :func:`mne.viz.plot_compare_evokeds` to show multiple evoked time courses at a single location, or the mean over a ROI, or the GFP, automatically averaging and calculating a CI if multiple subjects are given, by `Jona Sassenhagen`_
 
-- Added `transform_into` parameter into :class:`mne.decoding.CSP` to retrieve the average power of each source or the time course of each source, by `Jean-Remi King`_
+- Added ``transform_into`` parameter into :class:`mne.decoding.CSP` to retrieve the average power of each source or the time course of each source, by `Jean-Remi King`_
 
 - Added support for reading MaxShield (IAS) evoked data (e.g., from the acquisition machine) in :func:`mne.read_evokeds` by `Eric Larson`_
 
@@ -194,7 +194,7 @@ API
 
 - ``mne.decoding.EpochsVectorizer`` has been deprecated in favor of :class:`mne.decoding.Vectorizer` by `Asish Panda`_
 
-- The `epochs_data` parameter has been deprecated in :class:`mne.decoding.CSP`, in favour of the ``X`` parameter to comply to scikit-learn API, by `Jean-Remi King`_
+- The ``epochs_data`` parameter has been deprecated in :class:`mne.decoding.CSP`, in favour of the ``X`` parameter to comply to scikit-learn API, by `Jean-Remi King`_
 
 - Deprecated ``mne.time_frequency.cwt_morlet`` and ``mne.time_frequency.single_trial_power`` in favour of :func:`mne.time_frequency.tfr_morlet` with parameter average=False, by `Jean-Remi King`_ and `Alex Gramfort`_
 

--- a/doc/changes/0.13.inc
+++ b/doc/changes/0.13.inc
@@ -42,9 +42,9 @@ Changelog
 
 - Add the option to plot brain surfaces and source spaces to :func:`viz.plot_bem` by `Christian Brodbeck`_
 
-- Add the ``--filterchpi`` option to :ref:`mne browse_raw <mne browse_raw>`, by `Felix Raimundo`_
+- Add the ``--filterchpi`` option to :ref:`mne browse_raw`, by `Felix Raimundo`_
 
-- Add the ``--no-decimate`` option to :ref:`mne make_scalp_surfaces <mne make_scalp_surfaces>` to skip the high-resolution surface decimation step, by `Eric Larson`_
+- Add the ``--no-decimate`` option to :ref:`mne make_scalp_surfaces` to skip the high-resolution surface decimation step, by `Eric Larson`_
 
 - Add new class :class:`mne.decoding.EMS` to transform epochs with the event-matched spatial filters and add 'cv' parameter to :func:`mne.decoding.compute_ems`, by `Jean-Remi King`_
 

--- a/doc/changes/0.14.inc
+++ b/doc/changes/0.14.inc
@@ -24,7 +24,7 @@ Changelog
 
 - Add convenient default values to :meth:`mne.io.Raw.apply_hilbert` and :meth:`mne.io.Raw.apply_function` by `Denis Engemann`_
 
-- Remove MNE-C requirement for :ref:`mne make_scalp_surfaces <mne make_scalp_surfaces>` by `Eric Larson`_
+- Remove MNE-C requirement for :ref:`mne make_scalp_surfaces` by `Eric Larson`_
 
 - Add support for FastTrack Polhemus ``.mat`` file outputs in ``hsp`` argument of ``mne.channels.read_dig_montage`` by `Eric Larson`_
 

--- a/doc/changes/0.14.inc
+++ b/doc/changes/0.14.inc
@@ -24,7 +24,7 @@ Changelog
 
 - Add convenient default values to :meth:`mne.io.Raw.apply_hilbert` and :meth:`mne.io.Raw.apply_function` by `Denis Engemann`_
 
-- Remove MNE-C requirement for :ref:`mne make_scalp_surfaces <gen_mne_make_scalp_surfaces>` by `Eric Larson`_
+- Remove MNE-C requirement for :ref:`mne make_scalp_surfaces <mne make_scalp_surfaces>` by `Eric Larson`_
 
 - Add support for FastTrack Polhemus ``.mat`` file outputs in ``hsp`` argument of ``mne.channels.read_dig_montage`` by `Eric Larson`_
 

--- a/doc/changes/0.14.inc
+++ b/doc/changes/0.14.inc
@@ -196,7 +196,7 @@ API
 
 - An ``overwrite=False`` default parameter has been added to :func:`write_source_spaces` to protect against accidental overwrites, by `Eric Larson`_
 
-- The :class:`mne.decoding.LinearModel` class will no longer support `plot_filters` and `plot_patterns`, use :class:`mne.EvokedArray` with :func:`mne.decoding.get_coef` instead, by `Jean-Remi King`_
+- The :class:`mne.decoding.LinearModel` class will no longer support ``plot_filters`` and ``plot_patterns``, use :class:`mne.EvokedArray` with :func:`mne.decoding.get_coef` instead, by `Jean-Remi King`_
 
 - Made functions :func:`mne.time_frequency.tfr_array_multitaper`, :func:`mne.time_frequency.tfr_array_morlet`, :func:`mne.time_frequency.tfr_array_stockwell`, :func:`mne.time_frequency.psd_array_multitaper` and :func:`mne.time_frequency.psd_array_welch` public to allow computing TFRs and PSDs on numpy arrays by `Jaakko Leppakangas`_
 
@@ -204,7 +204,7 @@ API
 
 - :func:`mne.io.read_raw_egi` now names channels with pattern 'E<idx>'. This behavior can be changed with parameter ``channel_naming`` by `Jaakko Leppakangas`_
 
-- the `name`` parameter in :class:`mne.Epochs` is deprecated, by `Jaakko Leppakangas`_
+- the ``name`` parameter in :class:`mne.Epochs` is deprecated, by `Jaakko Leppakangas`_
 
 Authors
 ~~~~~~~

--- a/doc/changes/0.15.inc
+++ b/doc/changes/0.15.inc
@@ -82,7 +82,7 @@ Changelog
 
 - Add support for :class:`numpy.random.RandomState` argument to ``seed`` in :mod:`statistical clustering functions <mne.stats>` and better documentation of exact 1-sample tests by `Eric Larson`_
 
-- Extend :func:`mne.viz.plot_epochs_image`/:meth:`mne.Epochs.plot_image` with regards to grouping by or aggregating over channels. See the new example at `examples/visualization/plot_roi_erpimage_by_rt.py` by `Jona Sassenhagen`_
+- Extend :func:`mne.viz.plot_epochs_image`/:meth:`mne.Epochs.plot_image` with regards to grouping by or aggregating over channels. See the new example at ``examples/visualization/plot_roi_erpimage_by_rt.py`` by `Jona Sassenhagen`_
 
 - Add bootstrapped confidence intervals to :func:`mne.viz.plot_compare_evokeds` by `Jona Sassenhagen`_ and `Denis Engemann`_
 
@@ -120,7 +120,7 @@ BUG
 
 - :meth:`mne.concatenate_epochs` now maintains the relative position of events during concatenation by `Alexandre Barachant`_
 
-- Fix bug in script `mne make_scalp_surfaces` by `Denis Engemann`_ (this bug prevented creation of high-resolution meshes when they were absent in the first place.)
+- Fix bug in script ``mne make_scalp_surfaces`` by `Denis Engemann`_ (this bug prevented creation of high-resolution meshes when they were absent in the first place.)
 
 - Fix writing of raw files with empty set of annotations by `Jaakko Leppakangas`_
 

--- a/doc/changes/0.16.inc
+++ b/doc/changes/0.16.inc
@@ -111,7 +111,7 @@ Bug
 
 - Fix bug with events when saving split files using :meth:`mne.Epochs.save` by `Eric Larson`_
 
-- Fix bug in :class:`mne.decoding.SlidingEstimator` and :class:`mne.decoding.GeneralizingEstimator` to allow :func:`mne.decoding.cross_val_multiscore` to automatically detect whether the `base_estimator` is a classifier and use a `StratifiedKFold` instead of a `KFold` when `cv` is not specified, by `Jean-Remi King`_
+- Fix bug in :class:`mne.decoding.SlidingEstimator` and :class:`mne.decoding.GeneralizingEstimator` to allow :func:`mne.decoding.cross_val_multiscore` to automatically detect whether the ``base_estimator`` is a classifier and use a ``StratifiedKFold`` instead of a ``KFold`` when ``cv`` is not specified, by `Jean-Remi King`_
 
 - Fix bug in :func:`mne.set_eeg_reference` to remove an average reference projector when setting the reference to ``[]`` (i.e. do not change the existing reference) by `Clemens Brunner`_
 

--- a/doc/changes/0.17.inc
+++ b/doc/changes/0.17.inc
@@ -100,7 +100,7 @@ Changelog
 
 - Handle different time vectors in topography plots using :func:`mne.viz.plot_evoked_topo` by `Jussi Nurminen`_
 
-- Speed up :func:`mne.inverse_sparse.mixed_norm` if the :solver: parameter is set to ``bcd`` using :func:`scipy.linalg.get_blas_funcs` by `Quentin Bertrand`_
+- Speed up :func:`mne.inverse_sparse.mixed_norm` if the ``solver`` parameter is set to ``bcd`` using :func:`scipy.linalg.get_blas_funcs` by `Quentin Bertrand`_
 
 Bug
 ~~~

--- a/doc/changes/0.17.inc
+++ b/doc/changes/0.17.inc
@@ -36,7 +36,7 @@ Changelog
 
 - Add possibility to save :class:`mne.VolSourceEstimate` and :class:`mne.MixedSourceEstimate` to HDF5 format (file extension .h5) with :meth:`mne.VolSourceEstimate.save` and :meth:`mne.MixedSourceEstimate.save` by `Alex Gramfort`_
 
-- Add `replace` parameter to :meth:`mne.io.Raw.add_events` to allow adding events while removing the old ones on the stim channel by `Alex Gramfort`_
+- Add ``replace`` parameter to :meth:`mne.io.Raw.add_events` to allow adding events while removing the old ones on the stim channel by `Alex Gramfort`_
 
 - Add ability to pass ``axes`` to ``ts_args`` and ``topomap_args`` of :meth:`mne.viz.plot_evoked_joint` by `Jona Sassenhagen`_
 
@@ -54,7 +54,7 @@ Changelog
 
 - Add support for raw PSD plots in :meth:`mne.Report.parse_folder` via ``raw_psd`` argument of :class:`mne.Report` by `Eric Larson`_
 
-- Add `trig_shift_by_type` parameter in :func:`mne.io.read_raw_brainvision` to allow to specify offsets for arbitrary marker types by `Henrich Kolkhorst`_
+- Add ``trig_shift_by_type`` parameter in :func:`mne.io.read_raw_brainvision` to allow to specify offsets for arbitrary marker types by `Henrich Kolkhorst`_
 
 - Add progress bar support to :class:`mne.decoding.SlidingEstimator` and :class:`mne.decoding.GeneralizingEstimator` by `Eric Larson`_
 
@@ -66,7 +66,7 @@ Changelog
 
 - Add handling in :func:`mne.combine_evoked` and :func:`mne.grand_average` for input with the same channels in different orders, if required, by `Jona Sassenhagen`_
 
-- Add `split_naming` parameter to the `Raw.save` method to allow for BIDS-compatible raw file name construction by `Teon Brooks`_
+- Add ``split_naming`` parameter to the `mne.io.Raw.save` method to allow for BIDS-compatible raw file name construction by `Teon Brooks`_
 
 - Add ``origin`` parameter to :meth:`mne.Evoked.interpolate_bads` and related methods by `Eric Larson`_
 
@@ -100,7 +100,7 @@ Changelog
 
 - Handle different time vectors in topography plots using :func:`mne.viz.plot_evoked_topo` by `Jussi Nurminen`_
 
-- Speed up :func:`mne.inverse_sparse.mixed_norm` if the :solver: parameter is set to `bcd` using :func:`scipy.linalg.get_blas_funcs` by `Quentin Bertrand`_
+- Speed up :func:`mne.inverse_sparse.mixed_norm` if the :solver: parameter is set to ``bcd`` using :func:`scipy.linalg.get_blas_funcs` by `Quentin Bertrand`_
 
 Bug
 ~~~
@@ -145,7 +145,7 @@ Bug
 
 - Fix bug in :func:`mne.io.read_raw_edf` where GDF files had ``info['highpass']`` and ``info['lowpass']`` set to NaN and ``info['meas_date']`` set incorrectly, by `Eric Larson`_
 
-- Fix bug in :func:`mne.preprocessing.ICA.apply` to handle arrays as `exclude` property by `Joan Massich`_
+- Fix bug in :func:`mne.preprocessing.ICA.apply` to handle arrays as ``exclude`` property by `Joan Massich`_
 
 - Fix bug in ``method='eLORETA'`` for :func:`mne.minimum_norm.apply_inverse` when using a sphere model and saved ``inv`` by `Eric Larson`_
 
@@ -236,7 +236,7 @@ API
 
 - Calling :meth:``mne.io.pick.pick_info`` removing channels that are needed by compensation matrices (``info['comps']``) no longer raises ``RuntimeException`` but instead logs an info level message. By `Luke Bloy`_
 
-- :meth:`mne.Epochs.save` now has the parameter `fmt` to specify the desired format (precision) saving epoched data, by `Stefan Repplinger`_, `Eric Larson`_ and `Alex Gramfort`_
+- :meth:`mne.Epochs.save` now has the parameter ``fmt`` to specify the desired format (precision) saving epoched data, by `Stefan Repplinger`_, `Eric Larson`_ and `Alex Gramfort`_
 
 - Deprecated ``mne.SourceEstimate.morph_precomputed``, ``mne.SourceEstimate.morph``, ``mne.compute_morph_matrix``, ``mne.morph_data_precomputed`` and ``mne.morph_data`` in favor of :func:`mne.compute_source_morph`, by `Tommy Clausner`_
 
@@ -256,7 +256,7 @@ API
 
 - Deprecated save_stc_as_volume function in favor of :meth:`mne.VolSourceEstimate.as_volume` and :meth:`mne.VolSourceEstimate.save_as_volume` by `Alex Gramfort`_
 
-- `src.kind` now equals to `'mixed'` (and not `'combined'`) for a mixed source space (made of surfaces and volume grids) by `Alex Gramfort`_
+- ``src.kind`` now equals to ``'mixed'`` (and not ``'combined'``) for a mixed source space (made of surfaces and volume grids) by `Alex Gramfort`_
 
 - Deprecation of :attr:`mne.io.Raw.annotations` property in favor of :meth:`mne.io.Raw.set_annotations` by `Joan Massich`_
 

--- a/doc/changes/0.18.inc
+++ b/doc/changes/0.18.inc
@@ -56,7 +56,7 @@ Changelog
 
 - :meth:`mne.io.Raw.plot` now uses the lesser of ``n_channels`` and ``raw.ch_names``, by `Joan Massich`_
 
-- Add support for FIR filtering in :meth:`mne.io.Raw.plot` and :ref:`gen_mne_browse_raw` by passing ``filtorder=0`` or ``--filtorder 0``, respectively, by `Eric Larson`_
+- Add support for FIR filtering in :meth:`mne.io.Raw.plot` and :ref:`mne browse_raw` by passing ``filtorder=0`` or ``--filtorder 0``, respectively, by `Eric Larson`_
 
 - Add ``chunk_duration`` parameter to :func:`mne.events_from_annotations` to allow multiple events from a single annotation by `Joan Massich`_
 
@@ -88,7 +88,7 @@ Changelog
 
 - Add 448-labels subdivided aparc cortical parcellation by `Denis Engemann`_ and `Sheraz Khan`_
 
-- Add option to improve rendering in :ref:`gen_mne_coreg` for modern graphics cards by `Eric Larson`_
+- Add option to improve rendering in :ref:`mne coreg` for modern graphics cards by `Eric Larson`_
 
 - Add :func:`mne.preprocessing.mark_flat` to automate marking of flat channels and segments of raw data by `Eric Larson`_
 
@@ -143,7 +143,7 @@ Bug
 
 - Fix :meth:`mne.Epochs.plot` with ``scalings='auto'`` to properly compute channel-wise scalings by `Stefan Repplinger`_
 
-- Fix :func:`mne.gui.coregistration` and :ref:`mne coreg <gen_mne_coreg>` crashing with segmentation fault when switching subjects by `Eric Larson`_
+- Fix :func:`mne.gui.coregistration` and :ref:`mne coreg <mne coreg>` crashing with segmentation fault when switching subjects by `Eric Larson`_
 
 - Fix :func:`mne.io.read_raw_brainvision` to accommodate vmrk files which do not have any annotations by `Alexander Kovrig`_
 
@@ -172,15 +172,15 @@ Bug
 - Fix bug where loading epochs with ``preload=True`` and subsequently using :meth:`mne.Epochs.drop_bad` with new ``reject`` or ``flat`` entries leads to improper data (and ``epochs.selection``) since v0.16.0 by `Eric Larson`_.
   If your code uses ``Epochs(..., preload=True).drop_bad(reject=..., flat=...)``, we recommend regenerating these data.
 
-- Fix :ref:`gen_mne_flash_bem` to properly utilize ``flash30`` images when conversion from DICOM images is used, and to properly deal with non-standard acquisition affines by `Eric Larson`_
+- Fix :ref:`mne flash_bem` to properly utilize ``flash30`` images when conversion from DICOM images is used, and to properly deal with non-standard acquisition affines by `Eric Larson`_
 
 - Fix :meth:`mne.io.Raw.set_annotations` with ``annotations=None`` to create an empty annotations object with ``orig_time`` that matches the :class:`mne.io.Raw` instance by `Eric Larson`_
 
 - Fix :func:`mne.io.read_raw_edf` returning all the annotations with the same name in GDF files by `Joan Massich`_
 
-- Fix boundaries during plotting of raw data with :func:`mne.io.Raw.plot` and :ref:`gen_mne_browse_raw` on scaled displays (e.g., macOS with HiDPI/Retina screens) by `Clemens Brunner`_
+- Fix boundaries during plotting of raw data with :func:`mne.io.Raw.plot` and :ref:`mne browse_raw` on scaled displays (e.g., macOS with HiDPI/Retina screens) by `Clemens Brunner`_
 
-- Fix bug where filtering was not performed with ``lowpass`` or ``highpass`` in :meth:`mne.io.Raw.plot` and :ref:`gen_mne_browse_raw` by `Eric Larson`_
+- Fix bug where filtering was not performed with ``lowpass`` or ``highpass`` in :meth:`mne.io.Raw.plot` and :ref:`mne browse_raw` by `Eric Larson`_
 
 - Fix :func:`mne.simulation.simulate_evoked` that was failing to simulate the noise with heterogeneous sensor types due to poor conditioning of the noise covariance and make sure the projections from the noise covariance are taken into account `Alex Gramfort`_
 
@@ -204,7 +204,7 @@ Bug
 
 - Fix bug in :func:`mne.viz.plot_compare_evokeds` when ``evoked.times[0] >= 0`` would cause a problem with ``vlines='auto'`` mode by `Eric Larson`_
 
-- Fix path bugs in :func:`mne.bem.make_flash_bem` and :ref:`gen_mne_flash_bem` by `Eric Larson`_
+- Fix path bugs in :func:`mne.bem.make_flash_bem` and :ref:`mne flash_bem` by `Eric Larson`_
 
 - Fix :meth:`mne.time_frequency.AverageTFR.plot_joint` mishandling bad channels, by `David Haslacher`_ and `Jona Sassenhagen`_
 
@@ -214,7 +214,7 @@ Bug
 
 - Fix :func:`mne.compute_proj_raw` when ``duration != None`` not to apply existing proj and to avoid using duplicate raw data samples by `Eric Larson`_
 
-- Fix ``reject_by_annotation`` not being passed internally by :func:`mne.preprocessing.create_ecg_epochs` and :ref:`mne clean_eog_ecg <gen_mne_clean_eog_ecg>` to :func:`mne.preprocessing.find_ecg_events` by `Eric Larson`_
+- Fix ``reject_by_annotation`` not being passed internally by :func:`mne.preprocessing.create_ecg_epochs` and :ref:`mne clean_eog_ecg <mne clean_eog_ecg>` to :func:`mne.preprocessing.find_ecg_events` by `Eric Larson`_
 
 - Fix :func:`mne.io.read_raw_edf` failing when EDF header fields (such as patient name) contained special characters, by `Clemens Brunner`_
 

--- a/doc/changes/0.18.inc
+++ b/doc/changes/0.18.inc
@@ -151,7 +151,7 @@ Bug
 
 - Fix filtering functions (e.g., :meth:`mne.io.Raw.filter`) to properly take into account the two elements in ``n_pad`` parameter by `Bruno Nicenboim`_
 
-- Fix `feature_names` parameter change after fitting in :class:`mne.decoding.ReceptiveField` by `Jean-Remi King`_
+- Fix ``feature_names`` parameter change after fitting in :class:`mne.decoding.ReceptiveField` by `Jean-Remi King`_
 
 - Fix index error in :func:`mne.io.read_raw_cnt` when creating stim_channel manually by `Joan Massich`_
 
@@ -265,4 +265,4 @@ API
 
 - The peak finder that was formerly accessible via ``from mne.preprocessing.peak_finder import peak_finder`` should now be imported directly from the enclosing namespace as ``from mne.preprocessing import peak_finder`` by `Eric Larson`_
 
-- Deprecate ``mne.realtime`` module to make a standalone module `mne-realtime` that will live outside of this package by `Teon Brooks`_
+- Deprecate ``mne.realtime`` module to make a standalone module ``mne-realtime`` that will live outside of this package by `Teon Brooks`_

--- a/doc/changes/0.18.inc
+++ b/doc/changes/0.18.inc
@@ -143,7 +143,7 @@ Bug
 
 - Fix :meth:`mne.Epochs.plot` with ``scalings='auto'`` to properly compute channel-wise scalings by `Stefan Repplinger`_
 
-- Fix :func:`mne.gui.coregistration` and :ref:`mne coreg <mne coreg>` crashing with segmentation fault when switching subjects by `Eric Larson`_
+- Fix :func:`mne.gui.coregistration` and :ref:`mne coreg` crashing with segmentation fault when switching subjects by `Eric Larson`_
 
 - Fix :func:`mne.io.read_raw_brainvision` to accommodate vmrk files which do not have any annotations by `Alexander Kovrig`_
 
@@ -214,7 +214,7 @@ Bug
 
 - Fix :func:`mne.compute_proj_raw` when ``duration != None`` not to apply existing proj and to avoid using duplicate raw data samples by `Eric Larson`_
 
-- Fix ``reject_by_annotation`` not being passed internally by :func:`mne.preprocessing.create_ecg_epochs` and :ref:`mne clean_eog_ecg <mne clean_eog_ecg>` to :func:`mne.preprocessing.find_ecg_events` by `Eric Larson`_
+- Fix ``reject_by_annotation`` not being passed internally by :func:`mne.preprocessing.create_ecg_epochs` and :ref:`mne clean_eog_ecg` to :func:`mne.preprocessing.find_ecg_events` by `Eric Larson`_
 
 - Fix :func:`mne.io.read_raw_edf` failing when EDF header fields (such as patient name) contained special characters, by `Clemens Brunner`_
 

--- a/doc/changes/0.19.inc
+++ b/doc/changes/0.19.inc
@@ -41,15 +41,15 @@ Changelog
 
 - Now :func:`mne.io.read_raw_ctf` populates ``raw.annotations`` with the markers in ``MarkerFile.mrk`` if any by `Joan Massich`_
 
-- Add options for controlling the use of the ``-T1`` flag and the location of the brainmask output in :ref:`mne watershed_bem <mne watershed_bem>` by `Eric Larson`_
+- Add options for controlling the use of the ``-T1`` flag and the location of the brainmask output in :ref:`mne watershed_bem` by `Eric Larson`_
 
 - Add support to :func:`mne.read_annotations` to read CTF marker files by `Joan Massich`_
 
 - Do not convert effective number of averages (``nave`` attribute of :class:`mne.Evoked`) to integer except when saving to FIFF file by `Daniel McCloy`_.
 
-- Add automatic fiducial position estimation in :ref:`mne coreg <mne coreg>` using MNI Talairach fiducial locations in :func:`mne.coreg.get_mni_fiducials` by `Jon Houck`_ and `Eric Larson`_
+- Add automatic fiducial position estimation in :ref:`mne coreg` using MNI Talairach fiducial locations in :func:`mne.coreg.get_mni_fiducials` by `Jon Houck`_ and `Eric Larson`_
 
-- Add support for :ref:`mne coreg <mne coreg>` scaling surrogate subjects without surface reconstructions, such as those created for volumetric analyses only (e.g., with ``recon-all -autorecon1``) by `Eric Larson`_
+- Add support for :ref:`mne coreg` scaling surrogate subjects without surface reconstructions, such as those created for volumetric analyses only (e.g., with ``recon-all -autorecon1``) by `Eric Larson`_
 
 - Add reader for Curry data in :func:`mne.io.read_raw_curry` by `Dirk Gütlin`_
 
@@ -67,7 +67,7 @@ Changelog
 
 - Speed up :func:`mne.setup_volume_source_space`, especially when ``volume_label is not None`` by `Eric Larson`_
 
-- Speed up :ref:`mne coreg <mne coreg>` interactive and automated (ICP) alignment by using nearest-neighbor calculations in the MRI coordinate frame, by `Eric Larson`_
+- Speed up :ref:`mne coreg` interactive and automated (ICP) alignment by using nearest-neighbor calculations in the MRI coordinate frame, by `Eric Larson`_
 
 - Add :func:`mne.dig_mri_distances` to compute the distances between digitized head points and the MRI head surface by `Alex Gramfort`_ and `Eric Larson`_
 
@@ -91,7 +91,7 @@ Changelog
 
 - Add control over dipole colors in :func:`mne.viz.plot_dipole_locations` when using orthoview mode by `Eric Larson`_
 
-- Use second-order-sections filtering in :meth:`mne.io.Raw.plot` and :ref:`mne browse_raw <mne browse_raw>` by `Eric Larson`_
+- Use second-order-sections filtering in :meth:`mne.io.Raw.plot` and :ref:`mne browse_raw` by `Eric Larson`_
 
 - Add re-referencing functionality for ecog and seeg channel types in :func:`mne.set_eeg_reference` by `Keith Doelling`_
 

--- a/doc/changes/0.19.inc
+++ b/doc/changes/0.19.inc
@@ -53,13 +53,13 @@ Changelog
 
 - Add reader for Curry data in :func:`mne.io.read_raw_curry` by `Dirk Gütlin`_
 
-- Butterfly channel plots now possible for :meth:`mne.Epochs.plot_psd` with ``average=False``. Infrastructure for this function now shared with analogous Raw function, found in ``mne.viz.utils`` by `Jeff Hanna` _
+- Butterfly channel plots now possible for :meth:`mne.Epochs.plot_psd` with ``average=False``. Infrastructure for this function now shared with analogous Raw function, found in ``mne.viz.utils`` by `Jeff Hanna`_
 
 - Add option not to orthogonalize power envelopes with ``orthogonalize=False`` in :func:`mne.connectivity.envelope_correlation` by `Denis Engemann`_
 
 - Accept filenames of raw .fif files that end in ``_meg.fif`` to enable complicance with the Brain Imaging Data Structure by `Stefan Appelhoff`_
 
-- Add function to check the type of a FIF file using :func:`mne.what` and `mne what <gen_mne_what>` by `Eric Larson`_
+- Add function to check the type of a FIF file using :func:`mne.what` and :ref:`mne what` by `Eric Larson`_
 
 - Add support for specifying the initial time and/or position and providing a :class:`mne.SourceMorph` instead of :class:`mne.SourceSpaces` in :func:`mne.viz.plot_volume_source_estimates` by `Eric Larson`_
 
@@ -111,7 +111,7 @@ Bug
 
 - Fix :meth:`mne.io.Raw.filter` to deal with instances with no data channels properly by `Eric Larson`_
 
-- Fix one-sample baseline issue in :class:`mne.BaseEpochs` when using `tmin=0` by `Milan Rybář`_
+- Fix one-sample baseline issue in :class:`mne.BaseEpochs` when using ``tmin=0`` by `Milan Rybář`_
 
 - Fix bug in :func:`mne.viz.plot_volume_source_estimates` where ``'glass_brain'`` MRIs were not transformed to MNI space, by `Eric Larson`_
 

--- a/doc/changes/0.19.inc
+++ b/doc/changes/0.19.inc
@@ -41,15 +41,15 @@ Changelog
 
 - Now :func:`mne.io.read_raw_ctf` populates ``raw.annotations`` with the markers in ``MarkerFile.mrk`` if any by `Joan Massich`_
 
-- Add options for controlling the use of the ``-T1`` flag and the location of the brainmask output in :ref:`mne watershed_bem <gen_mne_watershed_bem>` by `Eric Larson`_
+- Add options for controlling the use of the ``-T1`` flag and the location of the brainmask output in :ref:`mne watershed_bem <mne watershed_bem>` by `Eric Larson`_
 
 - Add support to :func:`mne.read_annotations` to read CTF marker files by `Joan Massich`_
 
 - Do not convert effective number of averages (``nave`` attribute of :class:`mne.Evoked`) to integer except when saving to FIFF file by `Daniel McCloy`_.
 
-- Add automatic fiducial position estimation in :ref:`mne coreg <gen_mne_coreg>` using MNI Talairach fiducial locations in :func:`mne.coreg.get_mni_fiducials` by `Jon Houck`_ and `Eric Larson`_
+- Add automatic fiducial position estimation in :ref:`mne coreg <mne coreg>` using MNI Talairach fiducial locations in :func:`mne.coreg.get_mni_fiducials` by `Jon Houck`_ and `Eric Larson`_
 
-- Add support for :ref:`mne coreg <gen_mne_coreg>` scaling surrogate subjects without surface reconstructions, such as those created for volumetric analyses only (e.g., with ``recon-all -autorecon1``) by `Eric Larson`_
+- Add support for :ref:`mne coreg <mne coreg>` scaling surrogate subjects without surface reconstructions, such as those created for volumetric analyses only (e.g., with ``recon-all -autorecon1``) by `Eric Larson`_
 
 - Add reader for Curry data in :func:`mne.io.read_raw_curry` by `Dirk Gütlin`_
 
@@ -67,7 +67,7 @@ Changelog
 
 - Speed up :func:`mne.setup_volume_source_space`, especially when ``volume_label is not None`` by `Eric Larson`_
 
-- Speed up :ref:`mne coreg <gen_mne_coreg>` interactive and automated (ICP) alignment by using nearest-neighbor calculations in the MRI coordinate frame, by `Eric Larson`_
+- Speed up :ref:`mne coreg <mne coreg>` interactive and automated (ICP) alignment by using nearest-neighbor calculations in the MRI coordinate frame, by `Eric Larson`_
 
 - Add :func:`mne.dig_mri_distances` to compute the distances between digitized head points and the MRI head surface by `Alex Gramfort`_ and `Eric Larson`_
 
@@ -91,7 +91,7 @@ Changelog
 
 - Add control over dipole colors in :func:`mne.viz.plot_dipole_locations` when using orthoview mode by `Eric Larson`_
 
-- Use second-order-sections filtering in :meth:`mne.io.Raw.plot` and :ref:`mne browse_raw <gen_mne_browse_raw>` by `Eric Larson`_
+- Use second-order-sections filtering in :meth:`mne.io.Raw.plot` and :ref:`mne browse_raw <mne browse_raw>` by `Eric Larson`_
 
 - Add re-referencing functionality for ecog and seeg channel types in :func:`mne.set_eeg_reference` by `Keith Doelling`_
 

--- a/doc/changes/0.20.inc
+++ b/doc/changes/0.20.inc
@@ -35,9 +35,9 @@ Changelog
 
 - Add ``copy`` parameter to :meth:`mne.Epochs.iter_evoked` by `Alex Gramfort`_
 
-- Add command :ref:`gen_mne_setup_source_space` to quickly set up bilateral hemisphere surface-based source space with subsampling by `Victor Ferat`_.
+- Add command :ref:`mne setup_source_space` to quickly set up bilateral hemisphere surface-based source space with subsampling by `Victor Ferat`_.
 
-- Add command :ref:`gen_mne_sys_info` to print system information by `Eric Larson`_
+- Add command :ref:`mne sys_info` to print system information by `Eric Larson`_
 
 - Add function :func:`mne.make_fixed_length_epochs` to segment raw into fixed length epochs by `Mohammad Daneshzand`_
 
@@ -51,7 +51,7 @@ Changelog
 
 - Add support for plotting fNIRS channels in :func:`mne.viz.plot_alignment`, :func:`mne.viz.plot_evoked_topo` and :func:`mne.Evoked.animate_topomap` by `Eric Larson`_ and `Robert Luke`_
 
-- Add command line tool :ref:`gen_mne_anonymize` for anonymizing raw fiff files by `Luke Bloy`_
+- Add command line tool :ref:`mne anonymize` for anonymizing raw fiff files by `Luke Bloy`_
 
 - Add :func:`mne.preprocessing.find_bad_channels_maxwell` for automatic bad channel detection via Maxwell filtering by `Eric Larson`_
 
@@ -103,9 +103,9 @@ Changelog
 
 - :meth:`mne.Epochs.plot` now takes a ``epochs_colors`` parameter to color specific epoch segments by `Mainak Jas`_
 
-- Add command :ref:`gen_mne_setup_forward_model` to quickly create a BEM model for a subject by `Victor Ferat`_.
+- Add command :ref:`mne setup_forward_model` to quickly create a BEM model for a subject by `Victor Ferat`_.
 
-- Add command :ref:`gen_mne_prepare_bem_model` to quickly create a BEM solution using the linear collocation approach by `Victor Ferat`_.
+- Add command :ref:`mne prepare_bem_model` to quickly create a BEM solution using the linear collocation approach by `Victor Ferat`_.
 
 - Add support for reading ``.bdip`` Xfit binary dipole fit files in :func:`mne.read_dipole` by `Eric Larson`_
 
@@ -207,7 +207,7 @@ Bug
 
 - The attribute :class:`mne.Annotations.orig_time <mne.Annotations>` is now read-only, and is a :class:`~python:datetime.datetime` object (or None) rather than float, by `Eric Larson`_
 
-- Fix bug where MRI distances were not properly initialized in :ref:`gen_mne_coreg` by `Eric Larson`_
+- Fix bug where MRI distances were not properly initialized in :ref:`mne coreg` by `Eric Larson`_
 
 - Fix ``xscale='log'`` in :meth:`mne.io.Raw.plot_psd` and related functions by `Alex Gramfort`_
 

--- a/doc/changes/0.20.inc
+++ b/doc/changes/0.20.inc
@@ -279,9 +279,9 @@ Bug
 
 - Fix support for multiple TAL (annotations) channels in BDF reader by `Clemens Brunner`_
 
-- Fix missing `brainmask` file type in :func:`mne.bem.make_watershed_bem` by changing its default value to `ws.mgz` by `Fu-Te Wong`_
+- Fix missing ``brainmask`` file type in :func:`mne.bem.make_watershed_bem` by changing its default value to ``ws.mgz`` by `Fu-Te Wong`_
 
-- Fix bug in :func:`mne.channels.make_standard_montage` which would return `easycap-M1` even when requesting `easycap-M10` by `Christian Brodbeck`_
+- Fix bug in :func:`mne.channels.make_standard_montage` which would return ``easycap-M1`` even when requesting ``easycap-M10`` by `Christian Brodbeck`_
 
 - Fix the way planar gradiometers are combined in :func:`mne.viz.plot_tfr_topomap` and :meth:`mne.Epochs.plot_psd_topomap` by `Geoff Brookshire`_
 
@@ -293,7 +293,7 @@ Bug
 
 - Fix bug in reading annotations in :func:`read_annotations`, which would not accept ";" character by `Adam Li`_
 
-- Fix bug in :func:`mne.Report.parse_folder`, which would not recognize `*meg.fif` files by `Dmitrii Altukhov`_.
+- Fix bug in :func:`mne.Report.parse_folder`, which would not recognize ``*meg.fif`` files by `Dmitrii Altukhov`_.
 
 - Include ``fit_params`` when saving an :class:`~mne.preprocessing.ICA` instance to disk by `Richard Höchenberger`_
 

--- a/doc/changes/0.6.inc
+++ b/doc/changes/0.6.inc
@@ -119,7 +119,7 @@ API
 
 - Depth bias correction in dSPM/MNE/sLORETA make_inverse_operator is now done like in the C code using only gradiometers if present, else magnetometers, and EEG if no MEG channels are present.
 
-- Fixed-orientation inverse solutions need to be made using `fixed=True` option (using non-surface-oriented forward solutions if no depth weighting is used) to maintain compatibility with MNE C code.
+- Fixed-orientation inverse solutions need to be made using ``fixed=True`` option (using non-surface-oriented forward solutions if no depth weighting is used) to maintain compatibility with MNE C code.
 
 - Raw.save() will only overwrite the destination file, if it exists, if option overwrite=True is set.
 

--- a/doc/changes/0.7.inc
+++ b/doc/changes/0.7.inc
@@ -42,9 +42,9 @@ Changelog
 
 - Add fiducials read/write support by `Christian Brodbeck`_ and `Alex Gramfort`_
 
-- Add select / drop bad channels in `plot_raw` on click by `Denis Engemann`_
+- Add select / drop bad channels in ``plot_raw`` on click by `Denis Engemann`_
 
-- Add `ico` and `oct` source space creation in native Python by `Eric Larson`_
+- Add ``ico`` and ``oct`` source space creation in native Python by `Eric Larson`_
 
 - Add interactive rejection of bad trials in ``plot_epochs`` by `Denis Engemann`_
 
@@ -88,14 +88,14 @@ Changelog
 
 - Add Continuum Analytics Anaconda support by `Denis Engemann`_
 
-- Add `subtract evoked` option to beamformers by `Andrew Dykstra`_
+- Add ``subtract evoked`` option to beamformers by `Andrew Dykstra`_
 
-- Add new `transform` method to SourceEstimate(s) by `Andrew Dykstra`_
+- Add new ``transform`` method to SourceEstimate(s) by `Andrew Dykstra`_
 
 API
 ~~~
 
-- The pick_normal parameter for minimum norm solvers has been renamed as ``pick_ori`` and normal orientation picking is now achieved by passing the value "normal" for the `pick_ori` parameter.
+- The pick_normal parameter for minimum norm solvers has been renamed as ``pick_ori`` and normal orientation picking is now achieved by passing the value "normal" for the ``pick_ori`` parameter.
 
 - ICA objects now expose the measurement info of the object fitted.
 
@@ -105,7 +105,7 @@ API
 
 - The ``chs`` argument in ``mne.layouts.find_layout`` is deprecated and will be removed in MNE-Python 0.9. Use ``info`` instead.
 
-- ``plot_evoked`` and ``Epochs.plot`` now open a new figure by default. To plot on an existing figure please specify the `axes` parameter.
+- ``plot_evoked`` and ``Epochs.plot`` now open a new figure by default. To plot on an existing figure please specify the ``axes`` parameter.
 
 
 Authors

--- a/doc/changes/0.8.inc
+++ b/doc/changes/0.8.inc
@@ -48,7 +48,7 @@ Changelog
 
 - Add option to expand Labels defined in a source space to the original surface (``Label.fill()``) by `Christian Brodbeck`_
 
-- GUIs can be invoked form the command line using `$ mne coreg` and `$ mne kit2fiff` by `Christian Brodbeck`_
+- GUIs can be invoked form the command line using ``$ mne coreg`` and ``$ mne kit2fiff`` by `Christian Brodbeck`_
 
 - Add ``add_channels_epochs`` function to combine different recordings at the Epochs level by `Christian Brodbeck`_ and `Denis Engemann`_
 
@@ -98,7 +98,7 @@ Changelog
 
 - Add computation of point spread and cross-talk functions for MNE type solutions by `Alex Gramfort`_ and `Olaf Hauk`_
 
-- Add mask parameter to `plot_evoked_topomap` and ``evoked.plot_topomap`` by `Denis Engemann`_ and `Alex Gramfort`_
+- Add mask parameter to ``plot_evoked_topomap`` and ``evoked.plot_topomap`` by `Denis Engemann`_ and `Alex Gramfort`_
 
 - Add infomax and extended infomax ICA by `Denis Engemann`_, `Juergen Dammers`_ and `Lukas Breuer`_ and `Federico Raimondo`_
 
@@ -112,7 +112,7 @@ Changelog
 
 - Add InverseOperator class to display inverse operator info by `Mainak Jas`_
 
-- Add `$ mne report` command to generate html reports of MEG/EEG data analysis pipelines by `Mainak Jas`_, `Alex Gramfort`_ and `Denis Engemann`_
+- Add ``$ mne report`` command to generate html reports of MEG/EEG data analysis pipelines by `Mainak Jas`_, `Alex Gramfort`_ and `Denis Engemann`_
 
 - Improve ICA verbosity with regard to rank reduction by `Denis Engemann`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -100,7 +100,7 @@ Bug
 
 - Fix plotting with :func:`mne.viz.plot_evoked_topomap` to pre-existing axes by `Daniel McCloy`_
 
-- The default plotting mode for :func:`mne.io.Raw.plot` and :ref:`gen_mne_browse_raw` has been changed to ``clipping=3.`` to facilitate data analysis with large deflections, by `Eric Larson`_
+- The default plotting mode for :func:`mne.io.Raw.plot` and :ref:`mne browse_raw` has been changed to ``clipping=3.`` to facilitate data analysis with large deflections, by `Eric Larson`_
 
 - PSD plots will now show non-data channels (e.g., ``misc``) if those channels are explicitly passed to ``picks``, by `Daniel McCloy`_.
 
@@ -124,7 +124,7 @@ Bug
 
 - Fix bug with :func:`mne.viz.plot_bem` and :class:`mne.Report` when plotting BEM contours when MRIs are not in standard FreeSurfer orientation by `Eric Larson`_
 
-- Fix :ref:`gen_mne_setup_forward_model` to have it actually compute the BEM solution in addition to creating the BEM model by `Eric Larson`_
+- Fix :ref:`mne setup_forward_model` to have it actually compute the BEM solution in addition to creating the BEM model by `Eric Larson`_
 
 - Fix bug with :func:`mne.io.read_raw_edf` where null bytes were not properly handled, causing an error when opening a file by `Eric Larson`_
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -137,7 +137,7 @@ exclude_trees = ['_build']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-default_role = "autolink"
+default_role = "py:obj"
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 #add_function_parentheses = True

--- a/doc/install/pre_install.rst
+++ b/doc/install/pre_install.rst
@@ -75,8 +75,8 @@ If you want to transform sensor recordings into estimates of localized brain
 activity, you will need MNE-Python, plus :doc:`FreeSurfer <freesurfer>` to
 convert structural MRI scans into models of the scalp, inner/outer skull, and
 cortical surfaces (specifically, for command-line functions
-:ref:`gen_mne_flash_bem`, :ref:`gen_mne_watershed_bem`, and
-:ref:`gen_mne_make_scalp_surfaces`). If you follow the recommended installation
+:ref:`mne flash_bem`, :ref:`mne watershed_bem`, and
+:ref:`mne make_scalp_surfaces`). If you follow the recommended installation
 procedure using anaconda, you don't need to do anything extra — Freesurfer will
 automatically be installed.
 

--- a/doc/overview/cookbook.rst
+++ b/doc/overview/cookbook.rst
@@ -323,7 +323,7 @@ The corregistration is stored in ``-trans.fif`` file. If is present,
 you can follow :ref:`plot_source_alignment` to validate its correctness.
 If the ``-trans.fif`` is not present or the alignment is not correct
 you need to use :func:`mne.gui.coregistration` (or its convenient command line
-equivalent :ref:`gen_mne_coreg`) to generate it.
+equivalent :ref:`mne coreg`) to generate it.
 
 .. XXX: It would be good to link to the ``-trans.fif`` file description
 

--- a/doc/overview/faq.rst
+++ b/doc/overview/faq.rst
@@ -116,17 +116,17 @@ If the problem persists, `open a new issue
 <https://github.com/mne-tools/mne-python/issues/new?template=bug_report.md>`__
 and include the *smallest possible* code sample that replicates the error
 you're seeing. Paste the code sample into the issue, with a line containing
-three backticks (`\`\`\``) above and below the lines of code. This
+three backticks (\`\`\`) above and below the lines of code. This
 `minimal working example`_ should be self-contained, which means that
 MNE-Python contributors should be able to copy and paste the provided snippet
 and replicate the bug on their own computers.
 
-If you post to the
-[mailing list](https://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis)
+If you post to the `mailing list
+<https://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis>__
 instead, a `GitHub Public Gist <https://gist.github.com>`_ for the code sample
 is recommended; if you use the
 [Gitter channel](https://gitter.im/mne-tools/mne-python) the three backticks
-(`\`\`\``) trick works there too.
+(\`\`\`) trick works there too.
 
 
 Why is it dangerous to "pickle" my MNE-Python objects and data for later use?
@@ -410,7 +410,7 @@ order of difficulty):
    It can be helpful to run ``recon_all -autorecon1 -xopts xopts.txt`` in a
    clean directory first to see if this fixes everything, and, if not, then
    resorting to manual control point setting and/or talairach adjustment.
-   Once everything looks good at the end of `-autorecon1`, you can then run
+   Once everything looks good at the end of ``-autorecon1``, you can then run
    :ref:`gen_mne_watershed_bem` to see if the output is good. Once it is
    (and once brainmask.mgz is correct), you can then proceed with
    ``recon_all -autorecon2`` and ``recon_all -autorecon3`` to effectively

--- a/doc/overview/faq.rst
+++ b/doc/overview/faq.rst
@@ -213,7 +213,7 @@ The :func:`mne.what` function can be called on any :file:`.fif` file to
 identify the kind of data contained in the file. This will help you determine
 whether to use :func:`mne.read_cov`, :func:`mne.read_epochs`,
 :func:`mne.read_evokeds`, etc. There is also a corresponding command line tool
-:ref:`mne what <gen_mne_what>`:
+:ref:`mne what`:
 
 .. code-block:: console
 
@@ -355,7 +355,7 @@ This will plot the whitened evoked for the optimal estimator and display the
 My watershed BEM meshes look incorrect
 --------------------------------------
 
-After using :ref:`gen_mne_watershed_bem` or :func:`mne.bem.make_watershed_bem`
+After using :ref:`mne watershed_bem` or :func:`mne.bem.make_watershed_bem`
 you might find that the BEM meshes for the brain, inner skull, outer skull,
 and/or scalp surfaces do not look correct in :func:`mne.viz.plot_alignment`
 and :func:`mne.viz.plot_bem`.
@@ -380,9 +380,9 @@ order of difficulty):
 .. highlight:: console
 
 1. Changing the ``--preflood`` / ``-p`` parameter in
-   :ref:`gen_mne_watershed_bem`.
+   :ref:`mne watershed_bem`.
 2. Changing the ``--atlas`` and ``--gcaatlas`` options of
-   :ref:`gen_mne_watershed_bem`.
+   :ref:`mne watershed_bem`.
 3. Manually editing the meshes (see `this tutorial
    <https://github.com/ezemikulan/blender_freesurfer>`__.
 4. Manually running mri_watershed_ with various FreeSurfer flags (e.g.,
@@ -411,7 +411,7 @@ order of difficulty):
    clean directory first to see if this fixes everything, and, if not, then
    resorting to manual control point setting and/or talairach adjustment.
    Once everything looks good at the end of ``-autorecon1``, you can then run
-   :ref:`gen_mne_watershed_bem` to see if the output is good. Once it is
+   :ref:`mne watershed_bem` to see if the output is good. Once it is
    (and once brainmask.mgz is correct), you can then proceed with
    ``recon_all -autorecon2`` and ``recon_all -autorecon3`` to effectively
    complete all ``recon_all`` steps.

--- a/doc/overview/matlab.rst
+++ b/doc/overview/matlab.rst
@@ -20,8 +20,8 @@ Overview
 The MNE software contains a collection Matlab ``.m``-files to
 facilitate interfacing with binary file formats of the MNE software.
 The toolbox is located at ``$MNE_ROOT/share/matlab`` . The
-names of the MNE Matlab toolbox functions begin either with `mne_` or
-with `fiff_` . When you source the ``mne_setup`` script
+names of the MNE Matlab toolbox functions begin either with ``mne_`` or
+with ``fiff_`` . When you source the ``mne_setup`` script
 as described in :ref:`user_environment`, one of the following actions
 takes place:
 

--- a/doc/overview/roadmap.rst
+++ b/doc/overview/roadmap.rst
@@ -132,7 +132,7 @@ to go. Relevant tracking issues can be found under the tag :gh:`labels/DOC`.
 Coregistration / 3D viewer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:ref:`gen_mne_coreg` is an excellent tool for coregistration, but is limited
+:ref:`mne coreg` is an excellent tool for coregistration, but is limited
 by being tied to Mayavi, Traits, and TraitsUI. We should first refactor in
 several (mostly) separable steps:
 

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -226,6 +226,7 @@ Visualization
    add_background_image
    compare_fiff
    circular_layout
+   iter_topography
    mne_analyze_colormap
    plot_bem
    plot_brain_colorbar

--- a/doc/sphinxext/gen_commands.py
+++ b/doc/sphinxext/gen_commands.py
@@ -40,14 +40,16 @@ Command line tools using Python
 
 command_rst = """
 
-.. _gen_%s:
+.. _{0}:
 
-%s
-%s
+.. _gen_{1}:
+
+{0}
+{2}
 
 .. rst-class:: callout
 
-%s
+{3}
 
 """
 
@@ -100,10 +102,9 @@ def generate_commands_rst(app=None):
                 output.insert(ii + 3, '.. rst-class:: field-list cmd-list')
                 output.insert(ii + 4, '')
             output = '\n'.join(output)
-            f.write(command_rst % (cmd_name,
-                                   cmd_name.replace('mne_', 'mne '),
-                                   '=' * len(cmd_name),
-                                   output))
+            cmd_name_space = cmd_name.replace('mne_', 'mne ')
+            f.write(command_rst.format(
+                cmd_name_space, cmd_name, '=' * len(cmd_name_space), output))
     _replace_md5(out_fname)
 
 

--- a/doc/sphinxext/gen_commands.py
+++ b/doc/sphinxext/gen_commands.py
@@ -42,14 +42,12 @@ command_rst = """
 
 .. _{0}:
 
-.. _gen_{1}:
-
 {0}
-{2}
+{1}
 
 .. rst-class:: callout
 
-{3}
+{2}
 
 """
 
@@ -104,7 +102,7 @@ def generate_commands_rst(app=None):
             output = '\n'.join(output)
             cmd_name_space = cmd_name.replace('mne_', 'mne ')
             f.write(command_rst.format(
-                cmd_name_space, cmd_name, '=' * len(cmd_name_space), output))
+                cmd_name_space, '=' * len(cmd_name_space), output))
     _replace_md5(out_fname)
 
 

--- a/examples/connectivity/plot_mne_inverse_coherence_epochs.py
+++ b/examples/connectivity/plot_mne_inverse_coherence_epochs.py
@@ -127,7 +127,7 @@ print(freqs[1])
 #
 # Finally, we'll generate a SourceEstimate with the coherence. This is simple
 # since we used a single seed. For more than one seed we would have to choose
-# one of the slices within `coh`.
+# one of the slices within ``coh``.
 #
 # .. note:: We use a hack to save the frequency axis as time.
 #

--- a/examples/decoding/plot_ems_filtering.py
+++ b/examples/decoding/plot_ems_filtering.py
@@ -124,7 +124,7 @@ evoked = EvokedArray(filters, epochs.info, tmin=epochs.tmin)
 evoked.plot_topomap(time_unit='s', scalings=1)
 
 #############################################################################
-# Note that a similar transformation can be applied with `compute_ems`
+# Note that a similar transformation can be applied with ``compute_ems``
 # However, this function replicates Schurger et al's original paper, and thus
 # applies the normalization outside a leave-one-out cross-validation, which we
 # recommend not to do.

--- a/examples/stats/plot_sensor_regression.py
+++ b/examples/stats/plot_sensor_regression.py
@@ -70,7 +70,8 @@ for cond in names:
                               topomap_args=dict(time_unit='s'))
 
 ##############################################################################
-# Because the `linear_regression` function also estimates p values, we can --
+# Because the :func:`~mne.stats.linear_regression` function also estimates
+# p values, we can --
 # after applying FDR correction for multiple comparisons -- also visualise the
 # statistical significance of the regression of word concreteness.
 # The :func:`mne.viz.plot_evoked_image` function takes a `mask` parameter.

--- a/examples/stats/plot_sensor_regression.py
+++ b/examples/stats/plot_sensor_regression.py
@@ -74,7 +74,7 @@ for cond in names:
 # p values, we can --
 # after applying FDR correction for multiple comparisons -- also visualise the
 # statistical significance of the regression of word concreteness.
-# The :func:`mne.viz.plot_evoked_image` function takes a `mask` parameter.
+# The :func:`mne.viz.plot_evoked_image` function takes a ``mask`` parameter.
 # If we supply it with a boolean mask of the positions where we can reject
 # the null hypothesis, points that are not significant will be shown
 # transparently, and if desired, in a different colour palette and surrounded

--- a/examples/visualization/plot_evoked_topomap.py
+++ b/examples/visualization/plot_evoked_topomap.py
@@ -35,8 +35,8 @@ condition = 'Left Auditory'
 evoked = read_evokeds(fname, condition=condition, baseline=(None, 0))
 
 ###############################################################################
-# Basic `plot_topomap` options
-# ----------------------------
+# Basic :func:`~mne.viz.plot_topomap` options
+# -------------------------------------------
 #
 # We plot evoked topographies using :func:`mne.Evoked.plot_topomap`. The first
 # argument, ``times`` allows to specify time instants (in seconds!) for which
@@ -68,8 +68,8 @@ evoked.plot_topomap(times, ch_type='mag', average=0.05, time_unit='s')
 evoked.plot_topomap(times, ch_type='grad', time_unit='s')
 
 ###############################################################################
-# Additional `plot_topomap` options
-# ---------------------------------
+# Additional :func:`~mne.viz.plot_topomap` options
+# ------------------------------------------------
 #
 # We can also use a range of various :func:`mne.viz.plot_topomap` arguments
 # that control how the topography is drawn. For example:

--- a/examples/visualization/plot_topo_customized.py
+++ b/examples/visualization/plot_topo_customized.py
@@ -3,8 +3,8 @@
 Plot custom topographies for MEG sensors
 ========================================
 
-This example exposes the `iter_topography` function that makes it
-very easy to generate custom sensor topography plots.
+This example exposes the :func:`~mne.viz.iter_topography` function that makes
+it very easy to generate custom sensor topography plots.
 Here we will plot the power spectrum of each channel on a topographic
 layout.
 

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -556,7 +556,7 @@ def make_bem_model(subject, ico=4, conductivity=(0.3, 0.006, 0.3),
     -------
     surfaces : list of dict
         The BEM surfaces. Use `make_bem_solution` to turn these into a
-        `ConductorModel` suitable for forward calculation.
+        `~mne.bem.ConductorModel` suitable for forward calculation.
 
     See Also
     --------

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1117,7 +1117,7 @@ def read_ch_connectivity(fname, picks=None):
 
     More information on these neighbor definitions can be found on the related
     `FieldTrip documentation pages
-    <http://www.fieldtriptoolbox.org/template/neighbours/>`_.
+    <http://www.fieldtriptoolbox.org/template/neighbours/>`__.
 
     Parameters
     ----------
@@ -1453,7 +1453,7 @@ def make_1020_channel_selections(info, midline="z"):
     This passes through all channel names, and uses a simple heuristic to
     separate channel names into three Region of Interest-based selections:
     Left, Midline and Right. The heuristic is that channels ending on any of
-    the characters in `midline` are filed under that heading, otherwise those
+    the characters in ``midline`` are filed under that heading, otherwise those
     ending in odd numbers under "Left", those in even numbers under "Right".
     Other channels are ignored. This is appropriate for 10/20 files, but not
     for other channel naming conventions.
@@ -1463,12 +1463,12 @@ def make_1020_channel_selections(info, midline="z"):
     ----------
     info : instance of Info
         Where to obtain the channel names from. The picks will
-        be in relation to the position in `info["ch_names"]`. If possible, this
-        lists will be sorted by y value position of the channel locations,
+        be in relation to the position in ``info["ch_names"]``. If possible,
+        this lists will be sorted by y value position of the channel locations,
         i.e., from back to front.
     midline : str
-        Names ending in any of these characters are stored under the `Midline`
-        key. Defaults to 'z'. Note that capitalization is ignored.
+        Names ending in any of these characters are stored under the
+        ``Midline`` key. Defaults to 'z'. Note that capitalization is ignored.
 
     Returns
     -------

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -898,7 +898,7 @@ class UpdateChannelsMixin(object):
             type as the current object.
         force_update_info : bool
             If True, force the info for objects to be appended to match the
-            values in `self`. This should generally only be used when adding
+            values in ``self``. This should generally only be used when adding
             stim channels for which important metadata won't be overwritten.
 
             .. versionadded:: 0.12

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -23,7 +23,7 @@ def _calc_h(cosang, stiffness=4, n_legendre_terms=50):
         cosine of angles between pairs of points on a spherical surface. This
         is equivalent to the dot product of unit vectors.
     stiffness : float
-        stiffnes of the spline. Also referred to as `m`.
+        stiffnes of the spline. Also referred to as ``m``.
     n_legendre_terms : int
         number of Legendre terms to evaluate.
     """

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -372,7 +372,7 @@ def find_layout(info, ch_type=None, exclude='bads'):
     ch_type : {'mag', 'grad', 'meg', 'eeg'} | None
         The channel type for selecting single channel layouts.
         Defaults to None. Note, this argument will only be considered for
-        VectorView type layout. Use `meg` to force using the full layout
+        VectorView type layout. Use ``'meg'`` to force using the full layout
         in situations where the info does only contain one sensor type.
     exclude : list of str | str
         List of channels to exclude. If empty do not exclude any.

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -344,7 +344,7 @@ def read_dig_dat(fname):
     .. Warning::
         This function was implemented based on ``*.dat`` files available from
         `Compumedics <https://compumedicsneuroscan.com/scan-acquire-
-        configuration-files/>`_ and might not work as expected with novel
+        configuration-files/>`__ and might not work as expected with novel
         files. If it does not read your files correctly please contact the
         mne-python developers.
 
@@ -480,8 +480,8 @@ def read_dig_hpts(fname, unit='mm'):
     where:
 
     ``<*category*>``
-        defines the type of points. Allowed categories are: `hpi`,
-        `cardinal` (fiducial), `eeg`, and `extra` corresponding to
+        defines the type of points. Allowed categories are: ``hpi``,
+        ``cardinal`` (fiducial), ``eeg``, and ``extra`` corresponding to
         head-position indicator coil locations, cardinal landmarks, EEG
         electrode locations, and additional head surface points,
         respectively.

--- a/mne/commands/mne_anonymize.py
+++ b/mne/commands/mne_anonymize.py
@@ -5,7 +5,7 @@
 """Anonymize raw fif file.
 
 To anonymize other file types call :func:`mne.io.anonymize_info` on their
-`info` objects and resave to disk.
+:class:`~mne.Info` objects and resave to disk.
 
 Examples
 --------

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -312,8 +312,8 @@ def make_ad_hoc_cov(info, std=None, verbose=None):
         Measurement info.
     std : dict of float | None
         Standard_deviation of the diagonal elements. If dict, keys should be
-        `grad` for gradiometers, `mag` for magnetometers and `eeg` for EEG
-        channels. If None, default values will be used (see Notes).
+        ``'grad'`` for gradiometers, ``'mag'`` for magnetometers and ``'eeg'``
+        for EEG channels. If None, default values will be used (see Notes).
     %(verbose)s
 
     Returns
@@ -1498,7 +1498,7 @@ def regularize(cov, info, mag=0.1, grad=0.1, eeg=0.1, exclude='bads',
         Regularization factor for MEG magnetometers.
     grad : float (default 0.1)
         Regularization factor for MEG gradiometers. Must be the same as
-        `mag` if data have been processed with SSS.
+        ``mag`` if data have been processed with SSS.
     eeg : float (default 0.1)
         Regularization factor for EEG.
     exclude : list | 'bads' (default 'bads')
@@ -1689,7 +1689,7 @@ def compute_whitener(noise_cov, info=None, picks=None, rank=None,
     noise_cov : Covariance
         The noise covariance.
     info : dict | None
-        The measurement info. Can be None if `noise_cov` has already been
+        The measurement info. Can be None if ``noise_cov`` has already been
         prepared with :func:`prepare_noise_cov`.
     %(picks_good_data_noref)s
     %(rank_None)s

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -364,7 +364,7 @@ class CSP(TransformerMixin, BaseEstimator):
             If True, show channel names on top of the map. If a callable is
             passed, channel names will be formatted using the callable; e.g.,
             to delete the prefix 'MEG ' from all channel names, pass the
-            function lambda x: x.replace('MEG ', ''). If `mask` is not None,
+            function lambda x: x.replace('MEG ', ''). If ``mask`` is not None,
             only significant sensors will be shown.
         title : str | None
             Title. If None (default), no title is displayed.
@@ -492,7 +492,7 @@ class CSP(TransformerMixin, BaseEstimator):
             If True, show channel names on top of the map. If a callable is
             passed, channel names will be formatted using the callable; e.g.,
             to delete the prefix 'MEG ' from all channel names, pass the
-            function lambda x: x.replace('MEG ', ''). If `mask` is not None,
+            function lambda x: x.replace('MEG ', ''). If ``mask`` is not None,
             only significant sensors will be shown.
         title : str | None
             Title. If None (default), no title is displayed.

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -37,7 +37,7 @@ class ReceptiveField(BaseEstimator):
     estimator : instance of sklearn.base.BaseEstimator | float | None
         The model used in fitting inputs and outputs. This can be any
         scikit-learn-style model that contains a fit and predict method. If a
-        float is passed, it will be interpreted as the `alpha` parameter
+        float is passed, it will be interpreted as the ``alpha`` parameter
         to be passed to a Ridge regression model. If `None`, then a Ridge
         regression model with an alpha of 0 will be used.
     fit_intercept : bool | None

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -606,7 +606,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         Decimation can be done multiple times. For example,
         ``epochs.decimate(2).decimate(2)`` will be the same as
         ``epochs.decimate(4)``.
-        If `decim` is 1, this method does not copy the underlying data.
+        If ``decim`` is 1, this method does not copy the underlying data.
 
         .. versionadded:: 0.10.0
         """
@@ -927,7 +927,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         are not considered data channels (they are of misc type) and only data
         channels are selected when picks is None.
 
-        The `method` parameter allows e.g. robust averaging.
+        The ``method`` parameter allows e.g. robust averaging.
         For example, one could do:
 
             >>> from scipy.stats import trim_mean  # doctest:+SKIP
@@ -1658,7 +1658,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
             the entries is a list of str, event_ids in that list will be
             grouped together before equalizing trial counts across conditions.
             In the case where partial matching is used (using '/' in
-            `event_ids`), `event_ids` will be matched according to the
+            ``event_ids``), ``event_ids`` will be matched according to the
             provided tags, that is, processing works as if the event_ids
             matched by the provided tags had been supplied instead.
             The event_ids must identify nonoverlapping subsets of the epochs.
@@ -1810,7 +1810,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         """Compute virtual epochs using interpolated fields.
 
         .. Warning:: Using virtual epochs to compute inverse can yield
-            unexpected results. The virtual channels have `'_v'` appended
+            unexpected results. The virtual channels have ``'_v'`` appended
             at the end of the names to emphasize that the data contained in
             them are interpolated.
 
@@ -1819,8 +1819,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         ch_type : str
             The destination channel type. It can be 'mag' or 'grad'.
         mode : str
-            Either `'accurate'` or `'fast'`, determines the quality of the
-            Legendre polynomial expansion used. `'fast'` should be sufficient
+            Either ``'accurate'`` or ``'fast'``, determines the quality of the
+            Legendre polynomial expansion used. ``'fast'`` should be sufficient
             for most applications.
 
         Returns

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1999,10 +1999,10 @@ class Epochs(BaseEpochs):
 
         .. versionadded:: 0.16
     event_repeated : str
-        How to handle duplicates in `events[:, 0]`. Can be 'error' (default),
-        to raise an error, 'drop' to only retain the row occurring first in the
-        `events`, or 'merge' to combine the coinciding events (=duplicates)
-        into a new event (see Notes for details).
+        How to handle duplicates in ``events[:, 0]``. Can be ``'error'``
+        (default), to raise an error, 'drop' to only retain the row occurring
+        first in the ``events``, or ``'merge'`` to combine the coinciding
+        events (=duplicates) into a new event (see Notes for details).
 
         .. versionadded:: 0.19
     %(verbose)s
@@ -2035,7 +2035,7 @@ class Epochs(BaseEpochs):
     filename : str
         The filename of the object.
     times :  ndarray
-        Time vector in seconds. Goes from `tmin` to `tmax`. Time interval
+        Time vector in seconds. Goes from ``tmin`` to ``tmax``. Time interval
         between consecutive time samples is equal to the inverse of the
         sampling frequency.
     %(verbose)s
@@ -2057,12 +2057,15 @@ class Epochs(BaseEpochs):
     :meth:`mne.Epochs.iter_evoked` or :meth:`mne.Epochs.next`) use the same
     internal state.
 
-    If `event_repeated` is set to "merge", the coinciding events (duplicates)
-    will be merged into a single event_id and assigned a new id_number as
-    follows: `event_id['{event_id_1}/{event_id_2}/...'] = new_id_number`.
-    For example with the event_id {'aud': 1, 'vis': 2} and the events
-    [[0, 0, 1], [0, 0, 2]], the "merge" behavior will update both event_id and
-    events to be: {'aud/vis': 3} and [[0, 0, 3], ] respectively.
+    If ``event_repeated`` is set to ``'merge'``, the coinciding events
+    (duplicates) will be merged into a single event_id and assigned a new
+    id_number as::
+
+        event_id['{event_id_1}/{event_id_2}/...'] = new_id_number
+
+    For example with the event_id ``{'aud': 1, 'vis': 2}`` and the events
+    ``[[0, 0, 1], [0, 0, 2]]``, the "merge" behavior will update both event_id
+    and events to be: ``{'aud/vis': 3}`` and ``[[0, 0, 3]]`` respectively.
     """
 
     @verbose
@@ -3041,9 +3044,9 @@ def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
         The epochs to operate on.
     head_pos : array | tuple | None
         The array should be of shape ``(N, 10)``, holding the position
-        parameters as returned by e.g. `read_head_pos`. For backward
+        parameters as returned by e.g. ``read_head_pos``. For backward
         compatibility, this can also be a tuple of ``(trans, rot t)``
-        as returned by `head_pos_to_trans_rot_t`.
+        as returned by ``head_pos_to_trans_rot_t``.
     orig_sfreq : float | None
         The original sample frequency of the data (that matches the
         event sample numbers in ``epochs.events``). Can be ``None``

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -101,7 +101,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
     data : array of shape (n_channels, n_times)
         Evoked response.
     times :  array
-        Time vector in seconds. Goes from `tmin` to `tmax`. Time interval
+        Time vector in seconds. Goes from ``tmin`` to ``tmax``. Time interval
         between consecutive time samples is equal to the inverse of the
         sampling frequency.
     %(verbose)s
@@ -430,7 +430,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """Compute virtual evoked using interpolated fields.
 
         .. Warning:: Using virtual evoked to compute inverse can yield
-            unexpected results. The virtual channels have `'_v'` appended
+            unexpected results. The virtual channels have ``'_v'`` appended
             at the end of the names to emphasize that the data contained in
             them are interpolated.
 
@@ -439,8 +439,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         ch_type : str
             The destination channel type. It can be 'mag' or 'grad'.
         mode : str
-            Either `'accurate'` or `'fast'`, determines the quality of the
-            Legendre polynomial expansion used. `'fast'` should be sufficient
+            Either ``'accurate'`` or ``'fast'``, determines the quality of the
+            Legendre polynomial expansion used. ``'fast'`` should be sufficient
             for most applications.
 
         Returns
@@ -842,9 +842,9 @@ def combine_evoked(all_evoked, weights):
     ``combine_evoked([evoked1, -evoked2], 'equal')``
 
     .. Warning::
-        If you provide an array of weights instead of using `'equal'` or
-        `'nave'`, strange things may happen with your resulting signal
-        amplitude and/or `.nave` attribute.
+        If you provide an array of weights instead of using ``'equal'`` or
+        ``'nave'``, strange things may happen with your resulting signal
+        amplitude and/or ``.nave`` attribute.
 
     Parameters
     ----------

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -368,7 +368,7 @@ def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
     evoked : Evoked | Epochs | Raw
         The measurement file. Need to have info attribute.
     trans : str | 'auto' | None
-        The full path to the `*-trans.fif` file produced during
+        The full path to the ``*-trans.fif`` file produced during
         coregistration. If present or found using 'auto'
         the maps will be in MRI coordinates.
         If None, map for EEG data will not be available.
@@ -382,8 +382,8 @@ def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
         If None, a map for each available channel type will be returned.
         Else only the specified type will be used.
     mode : 'accurate' | 'fast'
-        Either `'accurate'` or `'fast'`, determines the quality of the
-        Legendre polynomial expansion used. `'fast'` should be sufficient
+        Either ``'accurate'`` or ``'fast'``, determines the quality of the
+        Legendre polynomial expansion used. ``'fast'`` should be sufficient
         for most applications.
     meg_surf : 'helmet' | 'head'
         Should be ``'helmet'`` or ``'head'`` to specify in which surface

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -886,7 +886,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             Data type to use for raw data after applying the function. If None
             the data type is not modified.
         n_jobs : int (default: 1)
-            Number of jobs to run in parallel. Ignored if `channel_wise` is
+            Number of jobs to run in parallel. Ignored if ``channel_wise`` is
             False.
         channel_wise : bool (default: True)
             Whether to apply the function to each channel individually. If
@@ -2128,7 +2128,7 @@ def concatenate_raws(raws, preload=None, events_list=None, verbose=None):
     raw : instance of Raw
         The result of the concatenation (first Raw instance passed in).
     events : ndarray of int, shape (n_events, 3)
-        The events. Only returned if `event_list` is not None.
+        The events. Only returned if ``event_list`` is not None.
     """
     if events_list is not None:
         if len(events_list) != len(raws):

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -248,7 +248,7 @@ def read_epochs_eeglab(input_fname, events=None, event_id=None,
         If int, a dict will be created with
         the id as string. If a list, all events with the IDs specified
         in the list are used. If None, the event_id is constructed from the
-        EEGLAB (.set) file with each descriptions copied from `eventtype`.
+        EEGLAB (.set) file with each descriptions copied from ``eventtype``.
     eog : list | tuple | 'auto'
         Names or indices of channels that should be designated EOG channels.
         If 'auto', the channel names containing ``EOG`` or ``EYE`` are used.

--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -107,7 +107,7 @@ def read_raw_egi(input_fname, eog=None, misc=None,
     include : None | list
        The event channels to be ignored when creating the synthetic
        trigger. Defaults to None.
-       Note. Overrides `exclude` parameter.
+       Note. Overrides ``exclude`` parameter.
     exclude : None | list
        The event channels to be ignored when creating the synthetic
        trigger. Defaults to None. If None, channels that have more than

--- a/mne/label.py
+++ b/mne/label.py
@@ -532,7 +532,7 @@ class Label(object):
         -----
         This function will set label.pos to be all zeros. If the positions
         on the new surface are required, consider using mne.read_surface
-        with label.vertices.
+        with ``label.vertices``.
         """
         subject = _check_subject(self.subject, subject)
         return self.morph(subject, subject, smooth, grade, subjects_dir,
@@ -584,7 +584,7 @@ class Label(object):
         -----
         This function will set label.pos to be all zeros. If the positions
         on the new surface are required, consider using `mne.read_surface`
-        with `label.vertices`.
+        with ``label.vertices``.
         """
         from .morph import compute_source_morph, grade_to_vertices
         subject_from = _check_subject(self.subject, subject_from)

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -499,7 +499,7 @@ def compute_source_psd(raw, inverse_operator, lambda2=1. / 9., method="dSPM",
     stc_psd : instance of SourceEstimate | VolSourceEstimate
         The PSD of each of the sources.
     sensor_psd : instance of EvokedArray
-        The PSD of each sensor. Only returned if `return_sensor` is True.
+        The PSD of each sensor. Only returned if ``return_sensor`` is True.
 
     See Also
     --------

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -47,7 +47,7 @@ def compute_source_morph(src, subject_from=None, subject_to='fsaverage',
         If None (default), then ``src[0]['subject_his_id]'`` will be used.
     subject_to : str | None
         Name of the subject to which to morph as named in the SUBJECTS_DIR.
-        Default is `'fsaverage'`. If None, ``src_to[0]['subject_his_id']``
+        Default is ``'fsaverage'``. If None, ``src_to[0]['subject_his_id']``
         will be used.
 
         .. versionchanged:: 0.20

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -180,7 +180,7 @@ class ICA(ContainsMixin):
         [1]_, [2]_, [3]_ and [4]_.
     fit_params : dict | None
         Additional parameters passed to the ICA estimator as specified by
-        `method`.
+        ``method``.
     max_iter : int
         Maximum number of iterations during fit. Defaults to 200. The actual
         number of iterations it took :meth:`ICA.fit` to complete will be stored
@@ -202,23 +202,23 @@ class ICA(ContainsMixin):
         If fit, the actual number of PCA components used for ICA decomposition.
     pre_whitener_ : ndarray, shape (n_channels, 1) or (n_channels, n_channels)
         If fit, array used to pre-whiten the data prior to PCA.
-    pca_components_ : ndarray, shape (`max_pca_components`, n_channels)
+    pca_components_ : ndarray, shape ``(max_pca_components, n_channels)``
         If fit, the PCA components.
     pca_mean_ : ndarray, shape (n_channels,)
         If fit, the mean vector used to center the data before doing the PCA.
-    pca_explained_variance_ : ndarray, shape (`max_pca_components`,)
+    pca_explained_variance_ : ndarray, shape ``(max_pca_components,)``
         If fit, the variance explained by each PCA component.
-    mixing_matrix_ : ndarray, shape (`n_components_`, `n_components_`)
+    mixing_matrix_ : ndarray, shape ``(n_components_, n_components_)``
         If fit, the whitened mixing matrix to go back from ICA space to PCA
         space.
-        It is, in combination with the `pca_components_`, used by
+        It is, in combination with the ``pca_components_``, used by
         :meth:`ICA.apply` and :meth:`ICA.get_components` to re-mix/project
         a subset of the ICA components into the observed channel space.
         The former method also removes the pre-whitening (z-scaling) and the
         de-meaning.
-    unmixing_matrix_ : ndarray, shape (`n_components_`, `n_components_`)
+    unmixing_matrix_ : ndarray, shape ``(n_components_, n_components_)``
         If fit, the whitened matrix to go from PCA space to ICA space.
-        Used, in combination with the `pca_components_`, by the methods
+        Used, in combination with the ``pca_components_``, by the methods
         :meth:`ICA.get_sources` and :meth:`ICA.apply` to unmix the observed
         data.
     exclude : array-like of int
@@ -227,8 +227,9 @@ class ICA(ContainsMixin):
         The components identified manually and by the various automatic
         artifact detection methods should be (manually) appended
         (e.g. ``ica.exclude.extend(eog_inds)``).
-        (There is also an `exclude` parameter in the :meth:`ICA.apply` method.)
-        To scrap all marked components, set this attribute to an empty list.
+        (There is also an ``exclude`` parameter in the :meth:`ICA.apply`
+        method.) To scrap all marked components, set this attribute to an empty
+        list.
     info : None | instance of Info
         The measurement info copied from the object fitted.
     n_samples_ : int
@@ -296,7 +297,7 @@ class ICA(ContainsMixin):
     see :class:`~sklearn.decomposition.FastICA`, :func:`~picard.picard`,
     :func:`~mne.preprocessing.infomax`.
 
-    Reducing the tolerance (set in `fit_params`) speeds up estimation at the
+    Reducing the tolerance (set in ``fit_params``) speeds up estimation at the
     cost of consistency of the obtained results. It is difficult to directly
     compare tolerance levels between Infomax and Picard, but for Picard and
     FastICA a good rule of thumb is ``tol_fastica == tol_picard ** 2``.
@@ -451,17 +452,17 @@ class ICA(ContainsMixin):
                               eog=250e-6 # V (EOG channels)
                               )
 
-            It only applies if `inst` is of type Raw.
+            It only applies if ``inst`` is of type Raw.
         flat : dict | None
             Rejection parameters based on flatness of signal.
             Valid keys are 'grad', 'mag', 'eeg', 'seeg', 'ecog', 'eog', 'ecg',
             'hbo', 'hbr'.
             Values are floats that set the minimum acceptable peak-to-peak
             amplitude. If flat is None then no rejection is done.
-            It only applies if `inst` is of type Raw.
+            It only applies if ``inst`` is of type Raw.
         tstep : float
             Length of data chunks for artifact rejection in seconds.
-            It only applies if `inst` is of type Raw.
+            It only applies if ``inst`` is of type Raw.
         reject_by_annotation : bool
             Whether to omit bad segments from the data before fitting. If True,
             annotated segments with a description that starts with 'bad' are
@@ -810,7 +811,7 @@ class ICA(ContainsMixin):
         This method will return the sources in the container format passed.
         Typical usecases:
 
-        1. pass Raw object to use `raw.plot` for ICA sources
+        1. pass Raw object to use `raw.plot <mne.io.Raw.plot>` for ICA sources
         2. pass Epochs object to compute trial-based statistics in ICA space
         3. pass Evoked object to investigate time-locking in ICA space
 
@@ -1809,8 +1810,8 @@ class ICA(ContainsMixin):
         raw : instance of Raw
             Raw object to draw sources from. No components are actually removed
             here, i.e. ica is not applied to raw in this function. Use
-            `ica.apply()` for this after inspection of the identified
-            components.
+            `ica.apply() <ICA.apply>` for this after inspection of the
+            identified components.
         start_find : int | float | None
             First sample to include for artifact search. If float, data will be
             interpreted as time in seconds. If None, data will be used from the
@@ -1820,11 +1821,11 @@ class ICA(ContainsMixin):
             be interpreted as time in seconds. If None, data will be used to
             the last sample.
         ecg_ch : str | ndarray | None
-            The `target` argument passed to ica.find_sources_raw. Either the
+            The ``target`` argument passed to ica.find_sources_raw. Either the
             name of the ECG channel or the ECG time series. If None, this step
             will be skipped.
         ecg_score_func : str | callable
-            The `score_func` argument passed to ica.find_sources_raw. Either
+            The ``score_func`` argument passed to ica.find_sources_raw. Either
             the name of function supported by ICA or a custom function.
         ecg_criterion : float | int | list-like | slice
             The indices of the sorted ecg scores. If float, sources with
@@ -1833,12 +1834,12 @@ class ICA(ContainsMixin):
             accordingly. E.g. range(2) would return the two sources with the
             highest absolute score. If None, this step will be skipped.
         eog_ch : list | str | ndarray | None
-            The `target` argument or the list of target arguments subsequently
+            The ``target`` argument or the list of target arguments subsequently
             passed to ica.find_sources_raw. Either the name of the vertical EOG
             channel or the corresponding EOG time series. If None, this step
             will be skipped.
         eog_score_func : str | callable
-            The `score_func` argument passed to ica.find_sources_raw. Either
+            The ``score_func`` argument passed to ica.find_sources_raw. Either
             the name of function supported by ICA or a custom function.
         eog_criterion : float | int | list-like | slice
             The indices of the sorted eog scores. If float, sources with
@@ -2454,9 +2455,9 @@ def corrmap(icas, template, threshold="auto", label=None, ch_type="eeg",
     the analysis is repeated with the mean of the maps identified in the first
     stage.
 
-    Run with `plot` and `show` set to `True` and `label=False` to find
+    Run with ``plot`` and ``show`` set to ``True`` and ``label=False`` to find
     good parameters. Then, run with labelling enabled to apply the
-    labelling in the IC objects. (Running with both `plot` and `labels`
+    labelling in the IC objects. (Running with both ``plot`` and ``labels``
     off does nothing.)
 
     Outputs a list of fitted ICAs with the indices of the marked ICs in a

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1834,10 +1834,10 @@ class ICA(ContainsMixin):
             accordingly. E.g. range(2) would return the two sources with the
             highest absolute score. If None, this step will be skipped.
         eog_ch : list | str | ndarray | None
-            The ``target`` argument or the list of target arguments subsequently
-            passed to ica.find_sources_raw. Either the name of the vertical EOG
-            channel or the corresponding EOG time series. If None, this step
-            will be skipped.
+            The ``target`` argument or the list of target arguments
+            subsequently passed to ica.find_sources_raw. Either the name of the
+            vertical EOG channel or the corresponding EOG time series. If None,
+            this step will be skipped.
         eog_score_func : str | callable
             The ``score_func`` argument passed to ica.find_sources_raw. Either
             the name of function supported by ICA or a custom function.

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -38,7 +38,7 @@ def short_channels(info, threshold=0.01):
     r"""Determine which NIRS channels are short.
 
     Channels with a source to detector distance of less than
-    `threshold` are reported as short. The default threshold is 0.01 m.
+    ``threshold`` are reported as short. The default threshold is 0.01 m.
 
     Parameters
     ----------

--- a/mne/rank.py
+++ b/mne/rank.py
@@ -311,7 +311,7 @@ def compute_rank(inst, rank=None, scalings=None, info=None, tol='auto',
         Rank will be estimated from the data after proper scaling of
         different channel types.
     ``'info'``
-        Rank is inferred from `info`. If data have been processed
+        Rank is inferred from ``info``. If data have been processed
         with Maxwell filtering, the Maxwell filtering header is used.
         Otherwise, the channel counts themselves are used.
         In both cases, the number of projectors is subtracted from

--- a/mne/report.py
+++ b/mne/report.py
@@ -1232,8 +1232,8 @@ class Report(object):
             Must have at least 2 elements.
         captions : list of str | list of float | None
             A list of captions to the figures. If float, a str will be
-            constructed as `%f s`. If None, it will default to
-            `Data slice %d`.
+            constructed as ``%f s``. If None, it will default to
+            ``Data slice %d``.
         section : str
             Name of the section. If section already exists, the figures
             will be appended to the end of the section.

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -153,9 +153,9 @@ def simulate_raw(info, stc=None, trans=None, src=None, bem=None, head_pos=None,
     trans : dict | str | None
         Either a transformation filename (usually made using mne_analyze)
         or an info dict (usually opened using read_trans()).
-        If string, an ending of `.fif` or `.fif.gz` will be assumed to
+        If string, an ending of ``.fif`` or ``.fif.gz`` will be assumed to
         be in FIF format, any other ending will be assumed to be a text
-        file with a 4x4 transformation matrix (like the `--trans` MNE-C
+        file with a 4x4 transformation matrix (like the ``--trans`` MNE-C
         option). If trans is None, an identity transform will be used.
     src : str | instance of SourceSpaces | None
         Source space corresponding to the stc. If string, should be a source

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2333,7 +2333,7 @@ class MixedSourceEstimate(_BaseMixedSourceEstimate):
             The hemisphere to display. Using 'both' or 'split' requires
             PySurfer version 0.4 or above.
         colormap : str | np.ndarray of float, shape(n_colors, 3 | 4)
-            Name of colormap to use. See `plot_source_estimates`.
+            Name of colormap to use. See `~mne.viz.plot_source_estimates`.
         time_label : str
             How to print info about the time instant visualized.
         smoothing_steps : int
@@ -2354,7 +2354,8 @@ class MixedSourceEstimate(_BaseMixedSourceEstimate):
         colorbar : bool
             If True, display colorbar on scene.
         clim : str | dict
-            Colorbar properties specification. See `plot_source_estimates`.
+            Colorbar properties specification.
+            See `~mne.viz.plot_source_estimates`.
 
         Returns
         -------

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -323,10 +323,10 @@ class SourceSpaces(list):
             FreeSurfer surface is used (Surface RAS).
         trans : dict, str, or None
             Either a transformation filename (usually made using mne_analyze)
-            or an info dict (usually opened using read_trans()).
-            If string, an ending of `.fif` or `.fif.gz` will be assumed to be
-            in FIF format, any other ending will be assumed to be a text file
-            with a 4x4 transformation matrix (like the `--trans` MNE-C option.
+            or an info dict (usually opened using read_trans()). If string, an
+            ending of ``.fif`` or ``.fif.gz`` will be assumed to be in FIF
+            format, any other ending will be assumed to be a text file with a
+            4x4 transformation matrix (like the ``--trans`` MNE-C option.
             Must be provided if source spaces are in head coordinates and
             include_surfaces and mri_resolution are True.
         mri_resolution : bool
@@ -1598,21 +1598,21 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
         Defaults to None.
     pos : float | dict
         Positions to use for sources. If float, a grid will be constructed
-        with the spacing given by `pos` in mm, generating a volume source
+        with the spacing given by ``pos`` in mm, generating a volume source
         space. If dict, pos['rr'] and pos['nn'] will be used as the source
         space locations (in meters) and normals, respectively, creating a
         discrete source space.
 
-        .. note:: For a discrete source space (`pos` is a dict),
+        .. note:: For a discrete source space (``pos`` is a dict),
                   ``mri`` must be None.
     mri : str | None
         The filename of an MRI volume (mgh or mgz) to create the
         interpolation matrix over. Source estimates obtained in the
         volume source space can then be morphed onto the MRI volume
         using this interpolator. If pos is a dict, this cannot be None.
-        If subject name is provided, `pos` is a float or `volume_label`
-        are not provided then the `mri` parameter will default to 'T1.mgz'
-        or `aseg.mgz`, respectively, else it will stay None.
+        If subject name is provided, ``pos`` is a float or ``volume_label``
+        are not provided then the ``mri`` parameter will default to 'T1.mgz'
+        or ``aseg.mgz``, respectively, else it will stay None.
     sphere : ndarray, shape (4,) | ConductorModel | None
         Define spherical source space bounds using origin and radius given
         by (ox, oy, oz, rad) in ``sphere_units``.
@@ -1624,7 +1624,7 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
         skull surface) or a ConductorModel for a 1-layer of 3-layers BEM.
     surface : str | dict | None
         Define source space bounds using a FreeSurfer surface file. Can
-        also be a dictionary with entries `'rr'` and `'tris'`, such as
+        also be a dictionary with entries ``'rr'`` and ``'tris'``, such as
         those returned by :func:`mne.read_surface`.
     mindist : float
         Exclude points closer than this distance (mm) to the bounding surface.
@@ -1682,7 +1682,7 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
 
     To create a discrete source space, ``pos`` must be a dict, ``mri`` must be
     None, and ``volume_label`` must be None. To create a whole brain volume
-    source space, `pos` must be a float and 'mri' must be provided.
+    source space, ``pos`` must be a float and 'mri' must be provided.
 
     To create a volume source space from label, ``pos`` must be a float,
     ``volume_label`` must be provided, and 'mri' must refer to a .mgh or .mgz
@@ -2491,8 +2491,8 @@ def add_source_space_distances(src, dist_limit=np.inf, n_jobs=1, verbose=None):
     -----
     This function can be memory- and CPU-intensive. On a high-end machine
     (2012) running 6 jobs in parallel, an ico-5 (10242 per hemi) source space
-    takes about 10 minutes to compute all distances (`dist_limit = np.inf`).
-    With `dist_limit = 0.007`, computing distances takes about 1 minute.
+    takes about 10 minutes to compute all distances (``dist_limit = np.inf``).
+    With ``dist_limit = 0.007``, computing distances takes about 1 minute.
 
     We recommend computing distances once per source space and then saving
     the source space to disk, as the computed distances will automatically be

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1436,7 +1436,7 @@ def summarize_clusters_stc(clu, p_thresh=0.05, tstep=1.0, tmin=0,
         The name of the subject.
     vertices : list of array | None
         The vertex numbers associated with the source space locations. Defaults
-        to None. If None, equals ```[np.arange(10242), np.arange(10242)]```.
+        to None. If None, equals ``[np.arange(10242), np.arange(10242)]``.
 
     Returns
     -------

--- a/mne/stats/permutations.py
+++ b/mne/stats/permutations.py
@@ -120,8 +120,8 @@ def bootstrap_confidence_interval(arr, ci=.95, n_bootstraps=2000,
     Returns
     -------
     cis : ndarray, shape (2, ...)
-        Containing the lower boundary of the CI at ``cis[0, ...]`` and the upper
-        boundary of the CI at ``cis[1, ...]``.
+        Containing the lower boundary of the CI at ``cis[0, ...]`` and the
+        upper boundary of the CI at ``cis[1, ...]``.
     """
     if stat_fun == "mean":
         def stat_fun(x):

--- a/mne/stats/permutations.py
+++ b/mne/stats/permutations.py
@@ -113,15 +113,15 @@ def bootstrap_confidence_interval(arr, ci=.95, n_bootstraps=2000,
     n_bootstraps : int
         Number of bootstraps.
     stat_fun : str | callable
-        Can be "mean", "median", or a callable operating along `axis=0`.
+        Can be "mean", "median", or a callable operating along ``axis=0``.
     random_state : int | float | array_like | None
         The seed at which to initialize the bootstrap.
 
     Returns
     -------
     cis : ndarray, shape (2, ...)
-        Containing the lower boundary of the CI at `cis[0, ...]` and the upper
-        boundary of the CI at `cis[1, ...]`.
+        Containing the lower boundary of the CI at ``cis[0, ...]`` and the upper
+        boundary of the CI at ``cis[1, ...]``.
     """
     if stat_fun == "mean":
         def stat_fun(x):

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -190,9 +190,9 @@ def linear_regression_raw(raw, events, event_id=None, tmin=-.1, tmax=1,
         used.
     covariates : dict-like | None
         If dict-like (e.g., a pandas DataFrame), values have to be array-like
-        and of the same length as the rows in ```events```. Keys correspond
+        and of the same length as the rows in ``events``. Keys correspond
         to additional event types/conditions to be estimated and are matched
-        with the time points given by the first column of ```events```. If
+        with the time points given by the first column of ``events``. If
         None, only binary events (from event_id) are used.
     reject : None | dict
         For cleaning raw data before the regression is performed: set up
@@ -352,8 +352,8 @@ def _prepare_rerp_preds(n_samples, sfreq, events, event_id=None, tmin=-.1,
         else:  # for predictors from covariates, e.g. continuous ones
             covs = covariates[cond]
             if len(covs) != len(events):
-                error = ("Condition {0} from ```covariates``` is "
-                         "not the same length as ```events```").format(cond)
+                error = ("Condition {0} from ``covariates`` is "
+                         "not the same length as ``events``").format(cond)
                 raise ValueError(error)
             onsets = -(events[np.where(covs != 0), 0] + tmin_)[0]
             v = np.asarray(covs)[np.nonzero(covs)].astype(float)

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -51,9 +51,9 @@ def get_head_surf(subject, source=('bem', 'head'), subjects_dir=None,
     subject : str
         Subject name.
     source : str | list of str
-        Type to load. Common choices would be `'bem'` or `'head'`. We first
-        try loading `'$SUBJECTS_DIR/$SUBJECT/bem/$SUBJECT-$SOURCE.fif'`, and
-        then look for `'$SUBJECT*$SOURCE.fif'` in the same directory by going
+        Type to load. Common choices would be ``'bem'`` or ``'head'``. We first
+        try loading ``'$SUBJECTS_DIR/$SUBJECT/bem/$SUBJECT-$SOURCE.fif'``, and
+        then look for ``'$SUBJECT*$SOURCE.fif'`` in the same directory by going
         through all files matching the pattern. The head surface will be read
         from the first file containing a head surface. Can also be a list
         to try multiple strings.

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -228,7 +228,6 @@ get_version
 invert_transform
 is_power2
 is_fixed_orient
-iter_topography
 kit2fiff
 label_src_vertno_sel
 make_eeg_average_ref_proj

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -565,7 +565,7 @@ def cwt(X, Ws, use_fft=True, mode='same', decim=1):
         Use FFT for convolutions. Defaults to True.
     mode : 'same' | 'valid' | 'full'
         Convention for convolution. 'full' is currently not implemented with
-        `use_fft=False`. Defaults to 'same'.
+        ``use_fft=False``. Defaults to ``'same'``.
     decim : int | slice
         To reduce memory usage, decimation factor after time-frequency
         decomposition.
@@ -1161,18 +1161,18 @@ class AverageTFR(_BaseTFR):
 
             .. versionadded:: 0.16.0
         mask_style : None | 'both' | 'contour' | 'mask'
-            If `mask` is not None: if 'contour', a contour line is drawn around
-            the masked areas (``True`` in `mask`). If 'mask', entries not
-            ``True`` in `mask` are shown transparently. If 'both', both a contour
-            and transparency are used.
-            If ``None``, defaults to 'both' if `mask` is not None, and is ignored
-            otherwise.
+            If ``mask`` is not None: if ``'contour'``, a contour line is drawn
+            around the masked areas (``True`` in ``mask``). If ``'mask'``,
+            entries not ``True`` in ``mask`` are shown transparently. If
+            ``'both'``, both a contour and transparency are used.
+            If ``None``, defaults to ``'both'`` if ``mask`` is not None, and is
+            ignored otherwise.
 
              .. versionadded:: 0.17
         mask_cmap : matplotlib colormap | (colormap, bool) | 'interactive'
             The colormap chosen for masked parts of the image (see below), if
-            `mask` is not ``None``. If None, `cmap` is reused. Defaults to
-            ``Greys``. Not interactive. Otherwise, as `cmap`.
+            ``mask`` is not ``None``. If None, ``cmap`` is reused. Defaults to
+            ``'Greys'``. Not interactive. Otherwise, as ``cmap``.
 
              .. versionadded:: 0.17
         mask_alpha : float
@@ -1334,11 +1334,11 @@ class AverageTFR(_BaseTFR):
             available is used.
         vmin : float | None
             The minimum value of the color scale for the image (for
-            topomaps, see `topomap_args`). If vmin is None, the data
+            topomaps, see ``topomap_args``). If vmin is None, the data
             absolute minimum value is used.
         vmax : float | None
             The maximum value of the color scale for the image (for
-            topomaps, see `topomap_args`). If vmax is None, the data
+            topomaps, see ``topomap_args``). If vmax is None, the data
             absolute maximum value is used.
         cmap : matplotlib colormap
             The colormap to use.
@@ -1360,17 +1360,17 @@ class AverageTFR(_BaseTFR):
             Type of aggregation to perform across selected channels.
         exclude : list of str | 'bads'
             Channels names to exclude from being shown. If 'bads', the
-            bad channels are excluded. Defaults to an empty list, i.e., `[]`.
+            bad channels are excluded. Defaults to an empty list, i.e., ``[]``.
         topomap_args : None | dict
-            A dict of `kwargs` that are forwarded to
-            :func:`mne.viz.plot_topomap` to style the topomaps. `axes` and
-            `show` are ignored. If `times` is not in this dict, automatic
+            A dict of ``kwargs`` that are forwarded to
+            :func:`mne.viz.plot_topomap` to style the topomaps. ``axes`` and
+            ``show`` are ignored. If ``times`` is not in this dict, automatic
             peak detection is used. Beyond that, if ``None``, no customizable
             arguments will be passed.
             Defaults to ``None``.
         image_args : None | dict
-            A dict of `kwargs` that are forwarded to :meth:`AverageTFR.plot`
-            to style the image. `axes` and `show` are ignored. Beyond that,
+            A dict of ``kwargs`` that are forwarded to :meth:`AverageTFR.plot`
+            to style the image. ``axes`` and ``show`` are ignored. Beyond that,
             if ``None``, no customizable arguments will be passed.
             Defaults to ``None``.
         %(verbose_meth)s
@@ -1382,18 +1382,18 @@ class AverageTFR(_BaseTFR):
 
         Notes
         -----
-        `timefreqs` has three different modes: tuples, dicts, and auto.
+        ``timefreqs`` has three different modes: tuples, dicts, and auto.
         For (list of) tuple(s) mode, each tuple defines a pair
         (time, frequency) in s and Hz on the TFR plot. For example, to
         look at 10 Hz activity 1 second into the epoch and 3 Hz activity
-        300 msec into the epoch,::
+        300 msec into the epoch, ::
 
             timefreqs=((1, 10), (.3, 3))
 
         If provided as a dictionary, (time, frequency) tuples are keys and
         (time_window, frequency_window) tuples are the values - indicating the
         width of the windows (centered on the time and frequency indicated by
-        the key) to be averaged over. For example,::
+        the key) to be averaged over. For example, ::
 
             timefreqs={(1, 10): (0.1, 2)}
 
@@ -1867,7 +1867,7 @@ class AverageTFR(_BaseTFR):
             If True, show channel names on top of the map. If a callable is
             passed, channel names will be formatted using the callable; e.g.,
             to delete the prefix 'MEG ' from all channel names, pass the
-            function lambda x: x.replace('MEG ', ''). If `mask` is not None,
+            function lambda x: x.replace('MEG ', ''). If ``mask`` is not None,
             only significant sensors will be shown.
         title : str | None
             Title. If None (default), no title is displayed.
@@ -2269,7 +2269,7 @@ def read_tfrs(fname, condition=None):
     Returns
     -------
     tfrs : list of instances of AverageTFR | instance of AverageTFR
-        Depending on `condition` either the TFR object or a list of multiple
+        Depending on ``condition`` either the TFR object or a list of multiple
         TFR objects.
 
     See Also

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -470,7 +470,7 @@ bad_condition : str
 head_pos : array | None
     If array, movement compensation will be performed.
     The array should be of shape (N, 10), holding the position
-    parameters as returned by e.g. `read_head_pos`.
+    parameters as returned by e.g. ``read_head_pos``.
 """
 docdict['maxwell_st_fixed_only'] = """
 st_fixed : bool
@@ -555,10 +555,10 @@ depth : None | float | dict
     How to weight (or normalize) the forward using a depth prior.
     If float (default 0.8), it acts as the depth weighting exponent (``exp``)
     to use, which must be between 0 and 1. None is equivalent to 0, meaning
-    no depth weighting is performed. It can also be a `dict` containing
-    keyword arguments to pass to :func:`mne.forward.compute_depth_prior`
-    (see docstring for details and defaults). This is effectively ignored
-    when ``method='eLORETA'``.
+    no depth weighting is performed. It can also be a :class:`python:dict`
+    containing keyword arguments to pass to
+    :func:`mne.forward.compute_depth_prior` (see docstring for details and
+    defaults). This is effectively ignored when ``method='eLORETA'``.
 
     .. versionchanged:: 0.20
        Depth bias ignored for ``method='eLORETA'``.
@@ -660,7 +660,7 @@ head_pos : None | str | dict | tuple | array
     be the time points and entries should be 4x4 ``dev_head_t``
     matrices. If None, the original head position (from
     ``info['dev_head_t']``) will be used. If tuple, should have the
-    same format as data returned by `head_pos_to_trans_rot_t`.
+    same format as data returned by ``head_pos_to_trans_rot_t``.
     If array, should be of the form returned by
     :func:`mne.chpi.read_head_pos`.
 """
@@ -716,9 +716,9 @@ indicate the boundaries of the filter (--). The line noise frequency is
 also indicated with a dashed line (-.)
 """
 docdict['plot_psd_picks_good_data'] = docdict['picks_good_data'][:-2] + """
-    Cannot be None if `ax` is supplied.If both `picks` and `ax` are None
+    Cannot be None if ``ax`` is supplied.If both ``picks`` and ``ax`` are None
     separate subplots will be created for each standard channel type
-    (`mag`, `grad`, and `eeg`).
+    (``mag``, ``grad``, and ``eeg``).
 """
 docdict["plot_psd_color"] = """
 color : str | tuple

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -143,6 +143,14 @@ ch_type : str
 
     .. versionadded:: 0.21
 """
+docdict['topomap_show_names'] = """
+show_names : bool | callable
+    If True, show channel names on top of the map. If a callable is
+    passed, channel names will be formatted using the callable; e.g., to
+    delete the prefix 'MEG ' from all channel names, pass the function
+    ``lambda x: x.replace('MEG ', '')``. If ``mask`` is not None, only
+    significant sensors will be shown.
+"""
 
 # PSD topomaps
 docdict["psd_topo_vlim_joint"] = """
@@ -555,7 +563,7 @@ depth : None | float | dict
     How to weight (or normalize) the forward using a depth prior.
     If float (default 0.8), it acts as the depth weighting exponent (``exp``)
     to use, which must be between 0 and 1. None is equivalent to 0, meaning
-    no depth weighting is performed. It can also be a :class:`python:dict`
+    no depth weighting is performed. It can also be a :class:`dict`
     containing keyword arguments to pass to
     :func:`mne.forward.compute_depth_prior` (see docstring for details and
     defaults). This is effectively ignored when ``method='eLORETA'``.

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -471,9 +471,10 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
     bem : list of dict | instance of ConductorModel | None
         Can be either the BEM surfaces (list of dict), a BEM solution or a
         sphere model. If None, we first try loading
-        `'$SUBJECTS_DIR/$SUBJECT/bem/$SUBJECT-$SOURCE.fif'`, and then look for
-        `'$SUBJECT*$SOURCE.fif'` in the same directory. For `'outer_skin'`,
-        the subjects bem and bem/flash folders are searched. Defaults to None.
+        ``'$SUBJECTS_DIR/$SUBJECT/bem/$SUBJECT-$SOURCE.fif'``, and then look
+        for ``'$SUBJECT*$SOURCE.fif'`` in the same directory. For
+        ``'outer_skin'``, the subjects bem and bem/flash folders are searched.
+        Defaults to None.
     seeg : bool
         If True (default), show sEEG electrodes.
     fnirs : str | list | bool | None
@@ -2724,7 +2725,8 @@ def snapshot_brain_montage(fig, montage, hide_sensors=True):
 
     Note that this will take the raw values for 3d coordinates of each channel,
     without applying any transforms. If brain images are flipped up/dn upon
-    using `imshow`, check your matplotlib backend as this behavior changes.
+    using `~matplotlib.pyplot.imshow`, check your matplotlib backend as this
+    behavior changes.
 
     Parameters
     ----------
@@ -2732,9 +2734,9 @@ def snapshot_brain_montage(fig, montage, hide_sensors=True):
         The figure on which you've plotted electrodes using
         :func:`mne.viz.plot_alignment`.
     montage : instance of DigMontage or Info | dict
-        The digital montage for the electrodes plotted in the scene. If `Info`,
-        channel positions will be pulled from the `loc` field of `chs`.
-        dict should have ch:xyz mappings.
+        The digital montage for the electrodes plotted in the scene. If
+        :class:`~mne.Info`, channel positions will be pulled from the ``loc``
+        field of ``chs``. dict should have ch:xyz mappings.
     hide_sensors : bool
         Whether to remove the spheres in the scene before taking a snapshot.
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2949,7 +2949,7 @@ def _get_dipole_loc(dipole, trans, subject, subjects_dir, coord_frame):
     #
     # We could do this with two resample_from_to calls, but it's cleaner,
     # faster, and we get fewer boundary artifacts if we do it in one shot.
-    # So first olve usamp s.t. ``upsamp @ vox_ras_t == RAS_AFFINE``` (2):
+    # So first olve usamp s.t. ``upsamp @ vox_ras_t == RAS_AFFINE`` (2):
     upsamp = np.linalg.solve(vox_ras_t['trans'].T, RAS_AFFINE.T).T
     # Now figure out how we would resample from RAS to head or MRI coords:
     if coord_frame == 'head':

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -148,9 +148,10 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
     evoked : bool
         Draw the ER[P/F] below the image or not.
     ts_args : None | dict
-        Arguments passed to a call to `plot_compare_evokeds` to style
+        Arguments passed to a call to `~mne.viz.plot_compare_evokeds` to style
         the evoked plot below the image. Defaults to an empty dictionary,
-        meaning `plot_compare_evokeds` will be called with default parameters.
+        meaning `~mne.viz.plot_compare_evokeds` will be called with default
+        parameters.
     title : None | str
         If :class:`str`, will be plotted as figure title. Otherwise, the
         title will indicate channel(s) or channel type being plotted. Defaults
@@ -765,7 +766,7 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
         Events to show with vertical bars. If events are provided, the epoch
         numbers are not shown to prevent overlap. You can toggle epoch
         numbering through options (press 'o' key). You can use
-        :func:`mne.viz.plot_events` as a legend for the colors. By default, the
+        `~mne.viz.plot_events` as a legend for the colors. By default, the
         coloring scheme is the same.
 
         .. warning::  If the epochs have been resampled, the events no longer
@@ -776,7 +777,7 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
         Dictionary of event_id value and its associated color. If None,
         colors are automatically drawn from a default list (cycled through if
         number of events longer than list of default colors). Uses the same
-        coloring scheme as :func:`mne.viz.plot_events`.
+        coloring scheme as `~mne.viz.plot_events`.
 
         .. versionadded:: 0.14.0
     order : array of str | None

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -914,7 +914,7 @@ def plot_evoked_image(evoked, picks=None, exclude='bads', unit=True,
         .. versionadded:: 0.16
     mask : ndarray | None
         An array of booleans of the same shape as the data. Entries of the
-        data that correspond to ```False`` in the mask are masked (see
+        data that correspond to ``False`` in the mask are masked (see
         ``do_mask`` below). Useful for, e.g., masking for statistical
         significance.
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -952,12 +952,12 @@ def plot_evoked_image(evoked, picks=None, exclude='bads', unit=True,
         if ``picks`` contains fewer than 25 entries.
     group_by : None | dict
         If a dict, the values must be picks, and ``axes`` must also be a dict
-        with matching keys, or None. If ``axes`` is None, one figure and one axis
-        will be created for each entry in ``group_by``.
-        Then, for each entry, the picked channels will be plotted
-        to the corresponding axis. If ``titles`` are None, keys will become plot
-        titles. This is useful for e.g. ROIs. Each entry must contain only
-        one channel type. For example::
+        with matching keys, or None. If ``axes`` is None, one figure and one
+        axis will be created for each entry in ``group_by``.Then, for each
+        entry, the picked channels will be plotted to the corresponding axis.
+        If ``titles`` are None, keys will become plot titles. This is useful
+        for e.g. ROIs. Each entry must contain only one channel type.
+        For example::
 
             group_by=dict(Left_ROI=[1, 2, 3, 4], Right_ROI=[5, 6, 7, 8])
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -661,7 +661,7 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
         defaults to ``dict(eeg=1e6, grad=1e13, mag=1e15)``.
     titles : dict | None
         The titles associated with the channels. If None, defaults to
-        `dict(eeg='EEG', grad='Gradiometers', mag='Magnetometers')`.
+        ``dict(eeg='EEG', grad='Gradiometers', mag='Magnetometers')``.
     axes : instance of Axes | list | None
         The axes to plot to. If list, the list must be a list of Axes of
         the same length as the number of channel types. If instance of
@@ -678,11 +678,11 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
         channels are plotted black and bad channels red. Defaults to False.
     zorder : str | callable
         Which channels to put in the front or back. Only matters if
-        `spatial_colors` is used.
-        If str, must be `std` or `unsorted` (defaults to `unsorted`). If
-        `std`, data with the lowest standard deviation (weakest effects) will
+        ``spatial_colors`` is used.
+        If str, must be ``std`` or ``unsorted`` (defaults to ``unsorted``). If
+        ``std``, data with the lowest standard deviation (weakest effects) will
         be put in front so that they are not obscured by those with stronger
-        effects. If `unsorted`, channels are z-sorted as in the evoked
+        effects. If ``unsorted``, channels are z-sorted as in the evoked
         instance.
         If callable, must take one argument: a numpy array of the same
         dimensionality as the evoked raw data; and return a list of
@@ -769,7 +769,7 @@ def plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
         the maximum absolute peak.
     scalings : dict | None
         The scalings of the channel types to be applied for plotting. If None,`
-        defaults to `dict(eeg=1e6, grad=1e13, mag=1e15)`.
+        defaults to ``dict(eeg=1e6, grad=1e13, mag=1e15)``.
     title : str
         Title of the figure.
     proj : bool | 'interactive'
@@ -895,10 +895,10 @@ def plot_evoked_image(evoked, picks=None, exclude='bads', unit=True,
         The axes to plot to. If list, the list must be a list of Axes of
         the same length as the number of channel types. If instance of
         Axes, there must be only one channel type plotted.
-        If `group_by` is a dict, this cannot be a list, but it can be a dict
-        of lists of axes, with the keys matching those of `group_by`. In that
+        If ``group_by`` is a dict, this cannot be a list, but it can be a dict
+        of lists of axes, with the keys matching those of ``group_by``. In that
         case, the provided axes will be used for the corresponding groups.
-        Defaults to `None`.
+        Defaults to ``None``.
     cmap : matplotlib colormap | (colormap, bool) | 'interactive'
         Colormap. If tuple, the first value indicates the colormap to use and
         the second value is a boolean defining interactivity. In interactive
@@ -915,25 +915,25 @@ def plot_evoked_image(evoked, picks=None, exclude='bads', unit=True,
     mask : ndarray | None
         An array of booleans of the same shape as the data. Entries of the
         data that correspond to ```False`` in the mask are masked (see
-        `do_mask` below). Useful for, e.g., masking for statistical
+        ``do_mask`` below). Useful for, e.g., masking for statistical
         significance.
 
         .. versionadded:: 0.16
     mask_style : None | 'both' | 'contour' | 'mask'
-        If `mask` is not None: if 'contour', a contour line is drawn around
-        the masked areas (``True`` in `mask`). If 'mask', entries not
-        ``True`` in `mask` are shown transparently. If 'both', both a contour
+        If ``mask`` is not None: if 'contour', a contour line is drawn around
+        the masked areas (``True`` in ``mask``). If 'mask', entries not
+        ``True`` in ``mask`` are shown transparently. If 'both', both a contour
         and transparency are used.
-        If ``None``, defaults to 'both' if `mask` is not None, and is ignored
+        If ``None``, defaults to 'both' if ``mask`` is not None, and is ignored
         otherwise.
 
          .. versionadded:: 0.16
     mask_cmap : matplotlib colormap | (colormap, bool) | 'interactive'
         The colormap chosen for masked parts of the image (see below), if
-        `mask` is not ``None``. If None, `cmap` is reused. Defaults to
-        ``Greys``. Not interactive. Otherwise, as `cmap`.
+        ``mask`` is not ``None``. If None, ``cmap`` is reused. Defaults to
+        ``Greys``. Not interactive. Otherwise, as ``cmap``.
     mask_alpha : float
-        A float between 0 and 1. If `mask` is not None, this sets the
+        A float between 0 and 1. If ``mask`` is not None, this sets the
         alpha level (degree of transparency) for the masked-out segments.
         I.e., if 0, masked-out segments are not visible at all.
         Defaults to .25.
@@ -947,15 +947,15 @@ def plot_evoked_image(evoked, picks=None, exclude='bads', unit=True,
         Determines if channel names should be plotted on the y axis. If False,
         no names are shown. If True, ticks are set automatically by matplotlib
         and the corresponding channel names are shown. If "all", all channel
-        names are shown. If "auto", is set to False if `picks` is ``None``,
+        names are shown. If "auto", is set to False if ``picks`` is ``None``,
         to ``True`` if ``picks`` contains 25 or more entries, or to "all"
         if ``picks`` contains fewer than 25 entries.
     group_by : None | dict
-        If a dict, the values must be picks, and `axes` must also be a dict
-        with matching keys, or None. If `axes` is None, one figure and one axis
-        will be created for each entry in `group_by`.
+        If a dict, the values must be picks, and ``axes`` must also be a dict
+        with matching keys, or None. If ``axes`` is None, one figure and one axis
+        will be created for each entry in ``group_by``.
         Then, for each entry, the picked channels will be plotted
-        to the corresponding axis. If `titles` are None, keys will become plot
+        to the corresponding axis. If ``titles`` are None, keys will become plot
         titles. This is useful for e.g. ROIs. Each entry must contain only
         one channel type. For example::
 
@@ -1314,7 +1314,7 @@ def plot_evoked_joint(evoked, times="peaks", title='', picks=None,
         If ``None``, no customizable arguments will be passed.
         Defaults to ``None``.
     topomap_args : None | dict
-        A dict of `kwargs` that are forwarded to
+        A dict of ``kwargs`` that are forwarded to
         :meth:`mne.Evoked.plot_topomap` to style the topomaps.
         If it is not in this dict, ``outlines='skirt'`` will be passed.
         ``show``, ``times``, ``colorbar`` are illegal.
@@ -2063,7 +2063,8 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
     Notes
     -----
     If the parameters ``styles``, ``colors``, or ``linestyles`` are passed as
-    :class:`dicts <dict>`, then ``evokeds`` must also be a :class:`dict`, and
+    :class:`dicts <python:dict>`, then ``evokeds`` must also be a
+    :class:`python:dict`, and
     the keys of the plot-style parameters must either match the keys of
     ``evokeds``, or match a ``/``-separated partial key ("condition") of
     ``evokeds``. For example, if evokeds has keys "Aud/L", "Aud/R", "Vis/L",

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -602,7 +602,7 @@ def plot_ica_scores(ica, scores, exclude=None, labels=None, axhline=None,
         will be used.
     labels : str | list | 'ecg' | 'eog' | None
         The labels to consider for the axes tests. Defaults to None.
-        If list, should match the outer shape of `scores`.
+        If list, should match the outer shape of ``scores``.
         If 'ecg' or 'eog', the ``labels_`` attributes will be looked up.
         Note that '/' is used internally for sublabels specifying ECG and
         EOG channels.

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -863,8 +863,8 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
 
         .. versionadded:: 0.18
     plot : list | tuple | str
-        A list of the requested plots from `time`, `magnitude` and `delay`.
-        Default is to plot all three filter properties
+        A list of the requested plots from ``time``, ``magnitude`` and
+        ``delay``. Default is to plot all three filter properties
         ('time', 'magnitude', 'delay').
 
         .. versionadded:: 0.21.0
@@ -872,7 +872,7 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
         The axes to plot to. If list, the list must be a list of Axes of
         the same length as the number of requested plot types. If instance of
         Axes, there must be only one filter property plotted.
-        Defaults to `None`.
+        Defaults to ``None``.
 
         .. versionadded:: 0.21.0
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -32,14 +32,13 @@ def iter_topography(info, layout=None, on_pick=None, fig=None,
     a series of matplotlib axis objects and data / channel
     indices, both corresponding to the sensor positions
     of the related layout passed or inferred from the channel info.
-    `iter_topography`, hence, allows to conveniently realize custom
-    topography plots.
+    Hence, this enables convenient topography plot customization.
 
     Parameters
     ----------
     info : instance of Info
         The measurement info.
-    layout : instance of mne.layout.Layout | None
+    layout : instance of mne.channels.Layout | None
         The layout to use. If None, layout will be guessed.
     on_pick : callable | None
         The callback function to be invoked on clicking one
@@ -600,7 +599,7 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
         absolute peak.
     scalings : dict | None
         The scalings of the channel types to be applied for plotting. If None,`
-        defaults to `dict(eeg=1e6, grad=1e13, mag=1e15)`.
+        defaults to ``dict(eeg=1e6, grad=1e13, mag=1e15)``.
     title : str
         Title of the figure.
     proj : bool | 'interactive'
@@ -870,7 +869,7 @@ def plot_topo_image_epochs(epochs, layout=None, sigma=0., vmin=None,
         Title of the figure.
     scalings : dict | None
         The scalings of the channel types to be applied for plotting. If
-        ``None``, defaults to `dict(eeg=1e6, grad=1e13, mag=1e15)`.
+        ``None``, defaults to ``dict(eeg=1e6, grad=1e13, mag=1e15)``.
     border : str
         Matplotlib borders style to be used for each sensor plot.
     fig_facecolor : color

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -684,7 +684,7 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         Location information for the data points(/channels).
         If an array, for each data point, the x and y coordinates.
         If an Info object, it must contain only one data type and
-        exactly `len(data)` data channels, and the x/y coordinates will
+        exactly ``len(data)`` data channels, and the x/y coordinates will
         be inferred from this Info object.
     vmin : float | callable | None
         The value specifying the lower bound of the color range.
@@ -711,12 +711,12 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         If True, show channel names on top of the map. If a callable is
         passed, channel names will be formatted using the callable; e.g., to
         delete the prefix 'MEG ' from all channel names, pass the function
-        lambda x: x.replace('MEG ', ''). If `mask` is not None, only
+        lambda x: x.replace('MEG ', ''). If ``mask`` is not None, only
         significant sensors will be shown.
-        If `True`, a list of names must be provided (see `names` keyword).
+        If ``True``, a list of names must be provided (see ``names`` keyword).
     mask : ndarray of bool, shape (n_channels, n_times) | None
         The channels to be marked as significant at a given time point.
-        Indices set to `True` will be considered. Defaults to None.
+        Indices set to ``True`` will be considered. Defaults to None.
     mask_params : dict | None
         Additional plotting parameters for plotting significant sensors.
         Default (None) equals::
@@ -1319,7 +1319,7 @@ def plot_tfr_topomap(tfr, tmin=None, tmax=None, fmin=None, fmax=None,
         If True, show channel names on top of the map. If a callable is passed,
         channel names will be formatted using the callable; e.g., to delete the
         prefix 'MEG ' from all channel names, pass the function
-        ``lambda x: x.replace('MEG ', '')``. If `mask` is not None, only
+        ``lambda x: x.replace('MEG ', '')``. If ``mask`` is not None, only
         significant sensors will be shown.
     title : str | None
         Plot title. If None (default), no title is displayed.
@@ -2543,12 +2543,12 @@ def plot_arrowmap(data, info_from, info_to=None, scale=3e-10, vmin=None,
         If True, show channel names on top of the map. If a callable is
         passed, channel names will be formatted using the callable; e.g., to
         delete the prefix 'MEG ' from all channel names, pass the function
-        lambda x: x.replace('MEG ', ''). If `mask` is not None, only
+        lambda x: x.replace('MEG ', ''). If ``mask`` is not None, only
         significant sensors will be shown.
-        If `True`, a list of names must be provided (see `names` keyword).
+        If ``True``, a list of names must be provided (see ``names`` keyword).
     mask : ndarray of bool, shape (n_channels, n_times) | None
         The channels to be marked as significant at a given time point.
-        Indices set to `True` will be considered. Defaults to None.
+        Indices set to ``True`` will be considered. Defaults to None.
     mask_params : dict | None
         Additional plotting parameters for plotting significant sensors.
         Default (None) equals::

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -707,12 +707,7 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         The axes to plot to. If None, the current axes will be used.
     names : list | None
         List of channel names. If None, channel names are not plotted.
-    show_names : bool | callable
-        If True, show channel names on top of the map. If a callable is
-        passed, channel names will be formatted using the callable; e.g., to
-        delete the prefix 'MEG ' from all channel names, pass the function
-        lambda x: x.replace('MEG ', ''). If ``mask`` is not None, only
-        significant sensors will be shown.
+    %(topomap_show_names)s
         If ``True``, a list of names must be provided (see ``names`` keyword).
     mask : ndarray of bool, shape (n_channels, n_times) | None
         The channels to be marked as significant at a given time point.
@@ -1315,12 +1310,7 @@ def plot_tfr_topomap(tfr, tmin=None, tmax=None, fmin=None, fmax=None,
         topomaps at a time).
     cbar_fmt : str
         String format for colorbar values.
-    show_names : bool | callable
-        If True, show channel names on top of the map. If a callable is passed,
-        channel names will be formatted using the callable; e.g., to delete the
-        prefix 'MEG ' from all channel names, pass the function
-        ``lambda x: x.replace('MEG ', '')``. If ``mask`` is not None, only
-        significant sensors will be shown.
+    %(topomap_show_names)s
     title : str | None
         Plot title. If None (default), no title is displayed.
     axes : instance of Axes | None
@@ -1513,12 +1503,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
         be show.
     show : bool
         Show figure if True.
-    show_names : bool | callable
-        If ``True``, show channel names on top of the map. If a callable is
-        passed, channel names will be formatted using the callable; e.g., to
-        delete the prefix 'MEG ' from all channel names, pass the function
-        ``lambda x: x.replace('MEG ', '')``. If ``mask`` is not ``None``, names
-        of significant sensors only will be shown.
+    %(topomap_show_names)s
     title : str | None
         Title. If None (default), no title is displayed.
     mask : ndarray of bool, shape (n_channels, n_times) | None
@@ -2539,12 +2524,7 @@ def plot_arrowmap(data, info_from, info_to=None, scale=3e-10, vmin=None,
         The axes to plot to. If None, a new figure will be created.
     names : list | None
         List of channel names. If None, channel names are not plotted.
-    show_names : bool | callable
-        If True, show channel names on top of the map. If a callable is
-        passed, channel names will be formatted using the callable; e.g., to
-        delete the prefix 'MEG ' from all channel names, pass the function
-        lambda x: x.replace('MEG ', ''). If ``mask`` is not None, only
-        significant sensors will be shown.
+    %(topomap_show_names)s
         If ``True``, a list of names must be provided (see ``names`` keyword).
     mask : ndarray of bool, shape (n_channels, n_times) | None
         The channels to be marked as significant at a given time point.

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -124,10 +124,10 @@ def tight_layout(pad=1.2, h_pad=None, w_pad=None, fig=None):
         fraction of the font-size.
     h_pad : float
         Padding height between edges of adjacent subplots.
-        Defaults to `pad_inches`.
+        Defaults to ``pad_inches``.
     w_pad : float
         Padding width between edges of adjacent subplots.
-        Defaults to `pad_inches`.
+        Defaults to ``pad_inches``.
     fig : instance of Figure
         Figure to apply changes to.
     """
@@ -1442,8 +1442,8 @@ def _fake_click(fig, ax, point, xform='ax', button=1, kind='press'):
 def add_background_image(fig, im, set_ratios=None):
     """Add a background image to a plot.
 
-    Adds the image specified in `im` to the
-    figure `fig`. This is generally meant to
+    Adds the image specified in ``im`` to the
+    figure ``fig``. This is generally meant to
     be done with topo plots, though it could work
     for any plot.
 
@@ -2066,13 +2066,13 @@ class SelectFromCollection(object):
         Collection you want to select from.
     alpha_other : 0 <= float <= 1
         To highlight a selection, this tool sets all selected points to an
-        alpha value of 1 and non-selected points to `alpha_other`.
+        alpha value of 1 and non-selected points to ``alpha_other``.
         Defaults to 0.3.
 
     Notes
     -----
     This tool selects collection objects based on their *origins*
-    (i.e., `offsets`). Emits mpl event 'lasso_event' when selection is ready.
+    (i.e., ``offsets``). Emits mpl event 'lasso_event' when selection is ready.
     """
 
     def __init__(self, ax, collection, ch_names,

--- a/tutorials/discussions/plot_background_filtering.py
+++ b/tutorials/discussions/plot_background_filtering.py
@@ -934,7 +934,7 @@ baseline_plot(x)
 # -----------
 # Depending on the function or method used, the filter type can be specified.
 # To name an example, in :func:`mne.filter.create_filter`, the relevant
-# arguments would be ``l_freq``, ```h_freq``, ```method``, and if the method is
+# arguments would be ``l_freq``, ``h_freq``, ``method``, and if the method is
 # FIR ``fir_window`` and ``fir_design``.
 #
 #

--- a/tutorials/discussions/plot_background_filtering.py
+++ b/tutorials/discussions/plot_background_filtering.py
@@ -934,8 +934,8 @@ baseline_plot(x)
 # -----------
 # Depending on the function or method used, the filter type can be specified.
 # To name an example, in :func:`mne.filter.create_filter`, the relevant
-# arguments would be `l_freq`, `h_freg`, `method`, and if the method is FIR
-# `fir_window` and `fir_design`.
+# arguments would be ``l_freq``, ```h_freq``, ```method``, and if the method is
+# FIR ``fir_window`` and ``fir_design``.
 #
 #
 # Cutoff frequency
@@ -975,7 +975,7 @@ filter_length = fir_coefs.shape[0]
 ###############################################################################
 # .. note:: If you are using an IIR filter, :func:`mne.filter.create_filter`
 #           will not print a filter length and transition bandwidth to the log.
-#           Instead, you can specify the roll-off with the `iir_params`
+#           Instead, you can specify the roll-off with the ``iir_params``
 #           argument or stay with the default, which is a fourth order
 #           (Butterworth) filter.
 #

--- a/tutorials/discussions/plot_background_filtering.py
+++ b/tutorials/discussions/plot_background_filtering.py
@@ -943,7 +943,7 @@ baseline_plot(x)
 # The cutoff of FIR filters in MNE is defined as half-amplitude cutoff in the
 # middle of the transition band. That is, if you construct a lowpass FIR filter
 # with ``h_freq = 40``, the filter function will provide a transition
-# bandwidth that depends on the `h_trans_bandwidth` argument. The desired
+# bandwidth that depends on the ``h_trans_bandwidth`` argument. The desired
 # half-amplitude  cutoff of the lowpass FIR filter is then at
 # ``h_freq + transition_bandwidth/2.``.
 #

--- a/tutorials/intro/plot_20_events_from_raw.py
+++ b/tutorials/intro/plot_20_events_from_raw.py
@@ -129,7 +129,7 @@ print(events[:5])  # show the first 5
 #     MNE-Python events are actually *three* values: in between the sample
 #     number and the integer event code is a value indicating what the event
 #     code was on the immediately preceding sample. In practice, that value is
-#     almost always `0`, but it can be used to detect the *endpoint* of an
+#     almost always ``0``, but it can be used to detect the *endpoint* of an
 #     event whose duration is longer than one sample. See the documentation of
 #     :func:`mne.find_events` for more details.
 #

--- a/tutorials/io/plot_10_reading_meg_data.py
+++ b/tutorials/io/plot_10_reading_meg_data.py
@@ -40,7 +40,7 @@ MEG data from the Artemis123 system can be read with\
 
 MNE-Python provides :func:`mne.io.read_raw_bti` to read and convert 4D / BTI
 data. This reader function will by default replace the original channel names,
-typically composed of the letter `A` and the channel number with Neuromag.
+typically composed of the letter ``A`` and the channel number with Neuromag.
 To import the data, the following input files are mandatory:
 
 - A data file (typically c,rfDC)

--- a/tutorials/misc/plot_report.py
+++ b/tutorials/misc/plot_report.py
@@ -134,7 +134,7 @@ report.save('report_cov.html')
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # The python interface has greater flexibility compared to the :ref:`command
-# line interface <gen_mne_report>`. For example, custom plots can be added via
+# line interface <mne report>`. For example, custom plots can be added via
 # the :meth:`~mne.Report.add_figs_to_section` method:
 
 # generate a custom plot:

--- a/tutorials/preprocessing/plot_15_handling_bad_channels.py
+++ b/tutorials/preprocessing/plot_15_handling_bad_channels.py
@@ -36,7 +36,7 @@ raw = mne.io.read_raw_fif(sample_data_raw_file, verbose=False)
 # this by
 # keeping track of the bad channel indices in a list and looking at that list
 # when doing analysis or plotting tasks. The list of bad channels is stored in
-# the ``'bads'``` field of the :class:`~mne.Info` object that is attached to
+# the ``'bads'`` field of the :class:`~mne.Info` object that is attached to
 # :class:`~mne.io.Raw`, :class:`~mne.Epochs`, and :class:`~mne.Evoked` objects.
 
 print(raw.info['bads'])

--- a/tutorials/preprocessing/plot_15_handling_bad_channels.py
+++ b/tutorials/preprocessing/plot_15_handling_bad_channels.py
@@ -36,7 +36,7 @@ raw = mne.io.read_raw_fif(sample_data_raw_file, verbose=False)
 # this by
 # keeping track of the bad channel indices in a list and looking at that list
 # when doing analysis or plotting tasks. The list of bad channels is stored in
-# the `'bads'` field of the :class:`~mne.Info` object that is attached to
+# the ``'bads'``` field of the :class:`~mne.Info` object that is attached to
 # :class:`~mne.io.Raw`, :class:`~mne.Epochs`, and :class:`~mne.Evoked` objects.
 
 print(raw.info['bads'])

--- a/tutorials/sample-datasets/plot_sleep.py
+++ b/tutorials/sample-datasets/plot_sleep.py
@@ -96,7 +96,8 @@ raw_train.plot(duration=60, scalings='auto')
 # Extract 30s events from annotations
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# The Sleep Physionet dataset is annotated using `8 labels <physionet_labels>`:
+# The Sleep Physionet dataset is annotated using
+# `8 labels <physionet_labels>`_:
 # Wake (W), Stage 1, Stage 2, Stage 3, Stage 4 corresponding to the range from
 # light sleep to deep sleep, REM sleep (R) where REM is the abbreviation for
 # Rapid Eye Movement sleep, movement (M), and Stage (?) for any none scored
@@ -246,7 +247,7 @@ def eeg_power_band(epochs):
 # and a final estimator, while the FunctionTransformer converts a python
 # function in an estimator compatible object. In this manner we can create
 # scikit-learn estimator that takes :class:`mne.Epochs` thanks to
-# `eeg_power_band` function we just created.
+# ``eeg_power_band`` function we just created.
 
 pipe = make_pipeline(FunctionTransformer(eeg_power_band, validate=False),
                      RandomForestClassifier(n_estimators=100, random_state=42))

--- a/tutorials/simulation/plot_creating_data_structures.py
+++ b/tutorials/simulation/plot_creating_data_structures.py
@@ -110,8 +110,9 @@ print(custom_raw)
 #
 # To create an :class:`mne.Epochs` object from scratch, you can use the
 # :class:`mne.EpochsArray` class, which uses a numpy array directly without
-# wrapping a raw object. The array must be of `shape(n_epochs, n_chans,
-# n_times)`. The proper units of measure are listed above.
+# wrapping a raw object. The array must be of shape
+# ``(n_epochs, n_chans, n_times)```. The proper units of measure are listed
+# above.
 
 # Generate some random data: 10 epochs, 5 channels, 2 seconds per epoch
 sfreq = 100

--- a/tutorials/simulation/plot_creating_data_structures.py
+++ b/tutorials/simulation/plot_creating_data_structures.py
@@ -67,11 +67,11 @@ print(info)
 #           :class:`mne.Info` object, it is important that the
 #           fields are consistent:
 #
-#           - The length of the channel information field `chs` must be
-#             `nchan`.
-#           - The length of the `ch_names` field must be `nchan`.
-#           - The `ch_names` field should be consistent with the `name` field
-#             of the channel information contained in `chs`.
+#           - The length of the channel information field ``chs`` must be
+#             ``nchan``.
+#           - The length of the ``ch_names`` field must be ``nchan``.
+#           - The ``ch_names`` field should be consistent with the ``name`` field
+#             of the channel information contained in ``chs``.
 #
 # -------------------------------------
 # Creating :class:`~mne.io.Raw` objects
@@ -125,10 +125,10 @@ info = mne.create_info(
 
 ###############################################################################
 # It is necessary to supply an "events" array in order to create an Epochs
-# object. This is of `shape(n_events, 3)` where the first column is the sample
-# number (time) of the event, the second column indicates the value from which
-# the transition is made from (only used when the new value is bigger than the
-# old one), and the third column is the new event value.
+# object. This is of shape ``(n_events, 3)``` where the first column is the
+# sample number (time) of the event, the second column indicates the value from
+# which the transition is made from (only used when the new value is bigger
+# than the old one), and the third column is the new event value.
 
 # Create an event matrix: 10 events with alternating event codes
 events = np.array([
@@ -170,8 +170,8 @@ _ = custom_epochs['smiling'].average().plot(time_unit='s')
 # Creating :class:`~mne.Evoked` Objects
 # -------------------------------------
 # If you already have data that is collapsed across trials, you may also
-# directly create an evoked array.  Its constructor accepts an array of
-# `shape(n_chans, n_times)` in addition to some bookkeeping parameters.
+# directly create an evoked array.  Its constructor accepts an array of shape
+# ``(n_chans, n_times)``` in addition to some bookkeeping parameters.
 # The proper units of measure for the data are listed above.
 
 # The averaged data

--- a/tutorials/simulation/plot_creating_data_structures.py
+++ b/tutorials/simulation/plot_creating_data_structures.py
@@ -111,7 +111,7 @@ print(custom_raw)
 # To create an :class:`mne.Epochs` object from scratch, you can use the
 # :class:`mne.EpochsArray` class, which uses a numpy array directly without
 # wrapping a raw object. The array must be of shape
-# ``(n_epochs, n_chans, n_times)```. The proper units of measure are listed
+# ``(n_epochs, n_chans, n_times)``. The proper units of measure are listed
 # above.
 
 # Generate some random data: 10 epochs, 5 channels, 2 seconds per epoch
@@ -126,7 +126,7 @@ info = mne.create_info(
 
 ###############################################################################
 # It is necessary to supply an "events" array in order to create an Epochs
-# object. This is of shape ``(n_events, 3)``` where the first column is the
+# object. This is of shape ``(n_events, 3)`` where the first column is the
 # sample number (time) of the event, the second column indicates the value from
 # which the transition is made from (only used when the new value is bigger
 # than the old one), and the third column is the new event value.
@@ -172,7 +172,7 @@ _ = custom_epochs['smiling'].average().plot(time_unit='s')
 # -------------------------------------
 # If you already have data that is collapsed across trials, you may also
 # directly create an evoked array.  Its constructor accepts an array of shape
-# ``(n_chans, n_times)``` in addition to some bookkeeping parameters.
+# ``(n_chans, n_times)`` in addition to some bookkeeping parameters.
 # The proper units of measure for the data are listed above.
 
 # The averaged data

--- a/tutorials/simulation/plot_creating_data_structures.py
+++ b/tutorials/simulation/plot_creating_data_structures.py
@@ -70,8 +70,8 @@ print(info)
 #           - The length of the channel information field ``chs`` must be
 #             ``nchan``.
 #           - The length of the ``ch_names`` field must be ``nchan``.
-#           - The ``ch_names`` field should be consistent with the ``name`` field
-#             of the channel information contained in ``chs``.
+#           - The ``ch_names`` field should be consistent with the ``name``
+#             field of the channel information contained in ``chs``.
 #
 # -------------------------------------
 # Creating :class:`~mne.io.Raw` objects

--- a/tutorials/simulation/plot_point_spread.py
+++ b/tutorials/simulation/plot_point_spread.py
@@ -143,7 +143,7 @@ brain_gen = stc_gen.plot(clim=clim, **kwargs)
 #
 # Use the forward solution and add Gaussian noise to simulate sensor-space
 # (evoked) data from the known source-space signals. The amount of noise is
-# controlled by `nave` (higher values imply less noise).
+# controlled by ``nave`` (higher values imply less noise).
 #
 evoked_gen = simulate_evoked(fwd, stc_gen, evoked.info, cov, nave,
                              random_state=seed)
@@ -166,7 +166,7 @@ brain_inv = stc_inv.plot(**kwargs)
 ###############################################################################
 # Exercises
 # ---------
-#    - Change the `method` parameter to either `dSPM` or `MNE` to explore the
-#      effect of the inverse method.
-#    - Try setting `evoked_snr` to a small, finite value, e.g. 3., to see the
+#    - Change the ``method`` parameter to either ``'dSPM'`` or ``'MNE'`` to
+#      explore the effect of the inverse method.
+#    - Try setting ``evoked_snr`` to a small, finite value, e.g. 3., to see the
 #      effect of noise.

--- a/tutorials/source-modeling/plot_forward.py
+++ b/tutorials/source-modeling/plot_forward.py
@@ -41,14 +41,10 @@ subject = 'sample'
 # example the inner skull surface, the outer skull surface and the outer skin
 # surface, a.k.a. scalp surface.
 #
-# Computing the BEM surfaces requires FreeSurfer and makes use of either of
-# the two following command line tools:
-#
-#   - :ref:`gen_mne_watershed_bem`
-#   - :ref:`gen_mne_flash_bem`
-#
-# Or by calling in a Python script one of the functions
-# :func:`mne.bem.make_watershed_bem` or :func:`mne.bem.make_flash_bem`.
+# Computing the BEM surfaces requires FreeSurfer and makes use of
+# the command-line tools :ref:`mne watershed_bem` or :ref:`mne flash_bem`, or
+# the related functions :func:`mne.bem.make_watershed_bem` or
+# :func:`mne.bem.make_flash_bem`.
 #
 # Here we'll assume it's already computed. It takes a few minutes per subject.
 #
@@ -71,7 +67,7 @@ mne.viz.plot_bem(subject=subject, subjects_dir=subjects_dir,
 # to align the head and the sensors in stored in a so-called **trans file**.
 # It is a FIF file that ends with ``-trans.fif``. It can be obtained with
 # :func:`mne.gui.coregistration` (or its convenient command line
-# equivalent :ref:`gen_mne_coreg`), or mrilab if you're using a Neuromag
+# equivalent :ref:`mne coreg`), or mrilab if you're using a Neuromag
 # system.
 #
 # Here we assume the coregistration is done, so we just visually check the

--- a/tutorials/source-modeling/plot_object_source_estimate.py
+++ b/tutorials/source-modeling/plot_object_source_estimate.py
@@ -22,7 +22,7 @@ It only stores the amplitudes of activations but
 not the locations of the sources. To get access to the locations
 you need to have the :class:`source space <mne.SourceSpaces>`
 (often abbreviated ``src``) used to compute the
-:class:`forward operator <mne.Forward>` (often abbreviated `fwd`).
+:class:`forward operator <mne.Forward>` (often abbreviated ``fwd``).
 
 See :ref:`tut-forward` for more details on forward modeling, and
 :ref:`tut-inverse-methods`

--- a/tutorials/stats-sensor-space/plot_stats_spatio_temporal_cluster_sensors.py
+++ b/tutorials/stats-sensor-space/plot_stats_spatio_temporal_cluster_sensors.py
@@ -79,7 +79,7 @@ plt.title('Between-sensor adjacency')
 # Compute permutation statistic
 # -----------------------------
 #
-# How does it work? We use clustering to `bind` together features which are
+# How does it work? We use clustering to "bind" together features which are
 # similar. Our features are the magnetic fields measured over our sensor
 # array at different times. This reduces the multiple comparison problem.
 # To compute the actual test-statistic, we first sum all F-values in all


### PR DESCRIPTION
Our `defaut_role = 'autolink'` could silently fail to link, leaving italics behind. This PR changes it to `default_role = 'py:obj'`:

1. We now usually don't have to prepend `:py:meth:` or similar to intersphinx things to link
2. Bad links now do cause warnings (which are treated as errors) in our build

This caused me to update a bunch of docstrings that were previously rendering as italicts or errantly linking. I also changed how `gen_commands.py` links so that we can just do directly:
```
:ref:`mne what`
```
instead of
```
:ref:`gen_mne_what`
```

@drammock feel free to review and merge if you're happy