### PR TITLE
MRG: Add support for foreground in _Brain

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -112,6 +112,8 @@ Bug
 
 - Fix bug where :class:`VolSourceEstimate.vertices <mne.VolSourceEstimate>` was an instance of :class:`~numpy.ndarray` instead of :class:`python:list` of one :class:`~numpy.ndarray`, by `Eric Larson`_
 
+- Fix default to be ``foreground=None`` in :func:`mne.viz.plot_source_estimates` to use white or black text based on the background color by `Eric Larson`_
+
 - Fix bug with :func:`mne.io.Raw.plot` where toggling all projectors did not actually take effect by `Eric Larson`_
 
 - Fix bug with :func:`mne.read_epochs` when loading data in complex format with ``preload=False`` by `Eric Larson`_

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1584,7 +1584,7 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
              subjects_dir=None,
              figure=None, views='lat', colorbar=True, clim='auto',
              cortex="classic", size=800, background="black",
-             foreground="white", initial_time=None, time_unit='s',
+             foreground=None, initial_time=None, time_unit='s',
              backend='auto', spacing='oct6', title=None,
              show_traces='auto', verbose=None):
         brain = plot_source_estimates(
@@ -2179,7 +2179,7 @@ class VectorSourceEstimate(_BaseVectorSourceEstimate,
              overlay_alpha=None, vector_alpha=1.0, scale_factor=None,
              time_viewer='auto', subjects_dir=None, figure=None, views='lat',
              colorbar=True, clim='auto', cortex='classic', size=800,
-             background='black', foreground='white', initial_time=None,
+             background='black', foreground=None, initial_time=None,
              time_unit='s', show_traces='auto', verbose=None):  # noqa: D102
 
         return plot_vector_source_estimates(

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1550,7 +1550,7 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
                           time_viewer='auto', subjects_dir=None, figure=None,
                           views='lat', colorbar=True, clim='auto',
                           cortex="classic", size=800, background="black",
-                          foreground="white", initial_time=None,
+                          foreground=None, initial_time=None,
                           time_unit='s', backend='auto', spacing='oct6',
                           title=None, show_traces='auto', verbose=None):
     """Plot SourceEstimate with PySurfer.
@@ -1616,9 +1616,9 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
         Has no effect with mpl backend.
     background : matplotlib color
         Color of the background of the display window.
-    foreground : matplotlib color
+    foreground : matplotlib color | None
         Color of the foreground of the display window. Has no effect with mpl
-        backend.
+        backend. None will choose white or black based on the background color.
     initial_time : float | None
         The time to display on the plot initially. ``None`` to display the
         first time sample (default).
@@ -2224,7 +2224,7 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
                                  subjects_dir=None, figure=None, views='lat',
                                  colorbar=True, clim='auto', cortex='classic',
                                  size=800, background='black',
-                                 foreground='white', initial_time=None,
+                                 foreground=None, initial_time=None,
                                  time_unit='s', show_traces='auto',
                                  verbose=None):
     """Plot VectorSourceEstimate with PySurfer.
@@ -2290,8 +2290,9 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
         a square window, or the (width, height) of a rectangular window.
     background : matplotlib color
         Color of the background of the display window.
-    foreground : matplotlib color
+    foreground : matplotlib color | None
         Color of the foreground of the display window.
+        None will choose black or white based on the background color.
     initial_time : float | None
         The time to display on the plot initially. ``None`` to display the
         first time sample (default).

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -177,10 +177,12 @@ class _Brain(object):
 
         if isinstance(background, str):
             background = colorConverter.to_rgb(background)
+        self._bg_color = background
         if foreground is None:
-            foreground = "white"
+            foreground = 'w' if sum(self._bg_color) < 2 else 'k'
         if isinstance(foreground, str):
             foreground = colorConverter.to_rgb(foreground)
+        self._fg_color = foreground
         if isinstance(views, str):
             views = [views]
         n_row = len(views)
@@ -193,7 +195,6 @@ class _Brain(object):
                              'sequence of ints.')
         fig_size = size if len(size) == 2 else size * 2  # 1-tuple to 2-tuple
 
-        self._foreground = foreground
         self._hemi = hemi
         self._units = units
         self._subject_id = subject_id
@@ -523,7 +524,7 @@ class _Brain(object):
             if not self._time_label_added and time_label is not None:
                 time_actor = self._renderer.text2d(
                     x_window=0.95, y_window=y_txt,
-                    color=self._foreground,
+                    color=self._fg_color,
                     size=time_label_size,
                     text=time_label(self._current_time),
                     justification='right'
@@ -532,7 +533,7 @@ class _Brain(object):
                 self._time_label_added = True
             if colorbar and not self._colorbar_added:
                 self._renderer.scalarbar(source=actor, n_labels=8,
-                                         color=self._foreground,
+                                         color=self._fg_color,
                                          bgcolor=(0.5, 0.5, 0.5))
                 self._colorbar_added = True
             self._renderer.set_camera(azimuth=views_dict[v].azim,

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -521,6 +521,7 @@ class _Brain(object):
             if not self._time_label_added and time_label is not None:
                 time_actor = self._renderer.text2d(
                     x_window=0.95, y_window=y_txt,
+                    color=self._foreground,
                     size=time_label_size,
                     text=time_label(self._current_time),
                     justification='right'
@@ -529,6 +530,7 @@ class _Brain(object):
                 self._time_label_added = True
             if colorbar and not self._colorbar_added:
                 self._renderer.scalarbar(source=actor, n_labels=8,
+                                         color=self._foreground,
                                          bgcolor=(0.5, 0.5, 0.5))
                 self._colorbar_added = True
             self._renderer.set_camera(azimuth=views_dict[v].azim,

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -177,6 +177,8 @@ class _Brain(object):
 
         if isinstance(background, str):
             background = colorConverter.to_rgb(background)
+        if foreground is None:
+            foreground = "white"
         if isinstance(foreground, str):
             foreground = colorConverter.to_rgb(foreground)
         if isinstance(views, str):

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -529,12 +529,19 @@ class _TimeViewer(object):
 
     def set_slider_style(self, slider, show_label=True, show_cap=False):
         if slider is not None:
+            foreground_color = self.brain._foreground
             slider_rep = slider.GetRepresentation()
             slider_rep.SetSliderLength(self.slider_length)
             slider_rep.SetSliderWidth(self.slider_width)
             slider_rep.SetTubeWidth(self.slider_tube_width)
             slider_rep.GetSliderProperty().SetColor(self.slider_color)
             slider_rep.GetTubeProperty().SetColor(self.slider_tube_color)
+            slider_rep.GetLabelProperty().SetShadow(False)
+            slider_rep.GetLabelProperty().SetBold(True)
+            slider_rep.GetLabelProperty().SetColor(foreground_color)
+            slider_rep.GetTitleProperty().ShallowCopy(
+                slider_rep.GetLabelProperty()
+            )
             if not show_cap:
                 slider_rep.GetCapProperty().SetOpacity(0)
             if not show_label:

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -529,7 +529,6 @@ class _TimeViewer(object):
 
     def set_slider_style(self, slider, show_label=True, show_cap=False):
         if slider is not None:
-            foreground_color = self.brain._foreground
             slider_rep = slider.GetRepresentation()
             slider_rep.SetSliderLength(self.slider_length)
             slider_rep.SetSliderWidth(self.slider_width)
@@ -538,7 +537,7 @@ class _TimeViewer(object):
             slider_rep.GetTubeProperty().SetColor(self.slider_tube_color)
             slider_rep.GetLabelProperty().SetShadow(False)
             slider_rep.GetLabelProperty().SetBold(True)
-            slider_rep.GetLabelProperty().SetColor(foreground_color)
+            slider_rep.GetLabelProperty().SetColor(self.brain._fg_color)
             slider_rep.GetTitleProperty().ShallowCopy(
                 slider_rep.GetLabelProperty()
             )

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -258,9 +258,12 @@ class _Renderer(_BaseRenderer):
             self.mlab.text3d(x, y, z, text, scale=scale, color=color,
                              figure=self.fig)
 
-    def scalarbar(self, source, title=None, n_labels=4, bgcolor=None):
+    def scalarbar(self, source, color="white", title=None, n_labels=4,
+                  bgcolor=None):
         with warnings.catch_warnings(record=True):  # traits
-            self.mlab.scalarbar(source, title=title, nb_labels=n_labels)
+            bar = self.mlab.scalarbar(source, title=title, nb_labels=n_labels)
+        if color is not None:
+            bar.label_text_property.color = _check_color(color)
         if bgcolor is not None:
             from tvtk.api import tvtk
             bgcolor = np.asarray(bgcolor)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -432,13 +432,16 @@ class _Renderer(_BaseRenderer):
                                           name=text,
                                           shape_opacity=0)
 
-    def scalarbar(self, source, title=None, n_labels=4, bgcolor=None):
+    def scalarbar(self, source, color="white", title=None, n_labels=4,
+                  bgcolor=None):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)
-            self.plotter.add_scalar_bar(title=title, n_labels=n_labels,
+            self.plotter.add_scalar_bar(color=color, title=title,
+                                        n_labels=n_labels,
                                         use_opacity=False, n_colors=256,
                                         position_x=0.15,
                                         position_y=0.05, width=0.7,
+                                        shadow=False, bold=True,
                                         label_font_size=22,
                                         font_family=self.font_family,
                                         background_color=bgcolor)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -25,8 +25,11 @@ from ...utils import copy_base_doc_to_subclass_doc
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import pyvista
-    from pyvista import (Plotter, BackgroundPlotter, PolyData,
-                         Line, close_all, UnstructuredGrid)
+    from pyvista import Plotter, PolyData, Line, close_all, UnstructuredGrid
+    try:
+        from pyvistaqt import BackgroundPlotter  # noqa
+    except ImportError:
+        from pyvista import BackgroundPlotter
     from pyvista.utilities import try_callback
     from pyvista.plotting.plotting import _ALL_PLOTTERS
 

--- a/mne/viz/backends/base_renderer.py
+++ b/mne/viz/backends/base_renderer.py
@@ -332,13 +332,16 @@ class _BaseRenderer(metaclass=ABCMeta):
         pass
 
     @abstractclassmethod
-    def scalarbar(self, source, title=None, n_labels=4):
+    def scalarbar(self, source, color="white", title=None, n_labels=4,
+                  bgcolor=None):
         """Add a scalar bar in the scene.
 
         Parameters
         ----------
         source:
             The object of the scene used for the colormap.
+        color:
+            The color of the label text.
         title: str | None
             The title of the scalar bar.
         n_labels: int | None

--- a/mne/viz/backends/base_renderer.py
+++ b/mne/viz/backends/base_renderer.py
@@ -346,6 +346,8 @@ class _BaseRenderer(metaclass=ABCMeta):
             The title of the scalar bar.
         n_labels: int | None
             The number of labels to display on the scalar bar.
+        bgcolor:
+            The color of the background when there is transparency.
         """
         pass
 


### PR DESCRIPTION
This PR adds support for the `foreground` parameter in `_Brain`. This parameter influences the color of the labels displayed (scalar bar label, time label and slider title and label).

Following the example given in https://github.com/mne-tools/mne-python/issues/7842#issue-626271633, this is what I obtain now:

time_viewer=False | time_viewer=True
---|---
![image](https://user-images.githubusercontent.com/18143289/83123549-58695e00-a0d5-11ea-9d3a-ee841e0edfde.png) | ![image](https://user-images.githubusercontent.com/18143289/83123657-7a62e080-a0d5-11ea-8620-c7375022b32d.png)

Closes https://github.com/mne-tools/mne-python/issues/7842
It's an item of https://github.com/mne-tools/mne-python/issues/7162