### PR TITLE
Allow find_bad_channels_maxwell() to return scores

### DIFF
--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1888,7 +1888,7 @@ def find_bad_channels_maxwell(
 
         .. warning:: This feature is experimental and may change in a future
                      version of MNE-Python without prior notice. Please
-                     report any problems and improvement proposals to the
+                     report any problems and enhancement proposals to the
                      developers.
     %(maxwell_origin_int_ext_calibration_cross)s
     %(maxwell_coord)s

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -2108,6 +2108,7 @@ def find_bad_channels_maxwell(
     flat_chs = sorted((f for f, c in flat_chs.items() if c >= min_count),
                       key=lambda x: raw.ch_names.index(x))
 
+    # Only include MEG channels.
     scores_flat = scores_flat[params['meg_picks']]
     thresh_flat = thresh_flat[params['meg_picks']]
     scores_noisy = scores_noisy[params['meg_picks']]

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1885,6 +1885,11 @@ def find_bad_channels_maxwell(
     return_scores : bool
         If ``True``, return a dictionary with scoring information for each
         evaluated segment of the data. Default is ``False``.
+
+        .. warning:: This feature is experimental and may change in a future
+                     version of MNE-Python without prior notice. Please
+                     report any problems and improvement proposals to the
+                     developers.
     %(maxwell_origin_int_ext_calibration_cross)s
     %(maxwell_coord)s
     %(maxwell_reg_ref_cond_pos)s

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1918,6 +1918,7 @@ def find_bad_channels_maxwell(
           The thresholds above which a score classified a segment as "flat".
 
         - ``scores_noisy`` : ndarray, shape (n_meg, n_windows)
+
           The scores for testing whether MEG channels are noisy.
 
         - ``limits_noisy`` : ndarray, shape (n_meg, n_windows)

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -2032,6 +2032,11 @@ def find_bad_channels_maxwell(
         chunk_raw = RawArray(
             orig_data, params['info'],
             first_samp=raw.first_samp + start, copy='data', verbose=False)
+
+        t = chunk_raw.times[[0, -1]] + start / raw.info['sfreq']
+        logger.info('        Interval %3d: %8.3f - %8.3f'
+                    % ((si + 1,) + tuple(t[[0, -1]])))
+
         # Flat pass: var < 0.01 fT/cm or 0.01 fT for at 30 ms (or 20 samples)
         n = stop - start
         flat_stop = n - (n % flat_step)
@@ -2040,7 +2045,7 @@ def find_bad_channels_maxwell(
         delta = np.std(data, axis=-1).min(-1)  # min std across segments
 
         # We may want to return this later if `return_scores=True`.
-        bins[si, :] = chunk_raw.times[0], chunk_raw.times[-1]
+        bins[si, :] = t[0], t[-1]
         scores_flat[good_meg_picks, si] = delta
         thresh_flat[good_meg_picks] = these_limits.reshape(-1, 1)
 
@@ -2057,9 +2062,6 @@ def find_bad_channels_maxwell(
         chunk_noisy = list()
         params['st_duration'] = int(round(
             chunk_raw.times[-1] * raw.info['sfreq']))
-        t = chunk_raw.times[[0, -1]] + start / raw.info['sfreq']
-        logger.info('        Interval %3d: %8.3f - %8.3f'
-                    % ((si + 1,) + tuple(t[[0, -1]])))
         for n_iter in range(1, 101):  # iteratively exclude the worst ones
             assert set(raw.info['bads']) & set(chunk_noisy) == set()
             params['good_mask'][:] = [

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1877,13 +1877,14 @@ def find_bad_channels_maxwell(
         Detection limit (default is 7.). Smaller values will find more bad
         channels at increased risk of including good ones.
     duration : float
-        Duration into which to window the data for processing. Default is 5.
+        Duration of the segments into which to slice the data for processing,
+        in seconds. Default is 5.
     min_count : int
         Minimum number of times a channel must show up as bad in a chunk.
         Default is 5.
-    return_scores : True
-        If True (default False), return a dictionary with scoring information
-        for each evaluated segment of the data.
+    return_scores : bool
+        If ``True``, return a dictionary with scoring information for each
+        evaluated segment of the data. Default is ``False``.
     %(maxwell_origin_int_ext_calibration_cross)s
     %(maxwell_coord)s
     %(maxwell_reg_ref_cond_pos)s
@@ -1915,7 +1916,6 @@ def find_bad_channels_maxwell(
         - ``limits_flat`` : ndarray, shape (n_meg, n_windows)
 
           The thresholds above which a score classified a segment as "flat".
-
 
         - ``scores_noisy`` : ndarray, shape (n_meg, n_windows)
           The scores for testing whether MEG channels are noisy.

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1905,6 +1905,15 @@ def find_bad_channels_maxwell(
         Only returned when ``return_scores`` is ``True``. It contains the
         following keys:
 
+        - ``ch_names`` : ndarray, shape (n_meg,)
+
+          The names of the MEG channels. Their order corresponds to the order
+          of rows in the ``scores`` and ``limits`` arrays.
+
+        - ``ch_types`` : ndarray, shape (n_meg,)
+
+          The types of the MEG channels in ``ch_names`` (``mag``, ``grad``).
+
         - ``bin_edges`` : ndarray, shape (n_windows + 1,)
 
           The window boundaries (in seconds) used to calculate the scores.
@@ -2008,7 +2017,9 @@ def find_bad_channels_maxwell(
     flat_step = max(20, int(30 * raw.info['sfreq'] / 1000.))
     all_flats = set()
 
-    # Return values for `return_scores=True`.
+    # Prepare variables to return if `return_scores=True`.
+    ch_names = np.array(raw.ch_names)[params['meg_picks']]
+    ch_types = np.array(raw.get_channel_types(params['meg_picks']))
     bin_edges = np.r_[starts, stops[-1]]  # Ensure we include the endpoint!
     # We create ndarrays with one row per channel, regardless of channel type
     # and whether the channel has been marked as "bad" in info or not. This
@@ -2107,7 +2118,9 @@ def find_bad_channels_maxwell(
     logger.info('[done]')
 
     if return_scores:
-        scores = dict(bin_edges=bin_edges,
+        scores = dict(ch_names=ch_names,
+                      ch_types=ch_types,
+                      bin_edges=bin_edges,
                       scores_flat=scores_flat,
                       limits_flat=thresh_flat,
                       scores_noisy=scores_noisy,

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1925,11 +1925,16 @@ def find_bad_channels_maxwell(
             The score thresholds above which a segment was claffified as
             "noisy".
 
+<<<<<<< HEAD
         .. note:: The scores and limits for channels marked as ``bad`` in the
                   input data will either be set to ``np.inf`` or ``-np.inf``,
                   such that the comparison between the scores and their
                   corresponding limits via the "greater than" and "less than"
                   operators will not yield the channel as auto-detected bad.
+=======
+        The scores and limits for channels marked as ``bad`` in the input data
+        will will be set to ``np.nan``.
+>>>>>>> parent of 5f36bd168... Use inf, -inf instead of nan
 
     See Also
     --------
@@ -2021,11 +2026,11 @@ def find_bad_channels_maxwell(
     ch_names = np.array(raw.ch_names)
     ch_types = np.array(raw.get_channel_types())
 
-    scores_flat = np.full((len(ch_names), len(starts)), np.inf)
-    scores_noisy = np.full_like(scores_flat, fill_value=-np.inf)
+    scores_flat = np.full((len(ch_names), len(starts)), np.nan)
+    scores_noisy = np.full_like(scores_flat, fill_value=np.nan)
 
-    thresh_flat = np.full((len(ch_names), 1), -np.inf)
-    thresh_noisy = np.full_like(thresh_flat, fill_value=np.inf)
+    thresh_flat = np.full((len(ch_names), 1), np.nan)
+    thresh_noisy = np.full_like(thresh_flat, fill_value=np.nan)
 
     for si, (start, stop) in enumerate(zip(starts, stops)):
         n_iter = 0

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1906,33 +1906,21 @@ def find_bad_channels_maxwell(
         following keys:
 
         - ``ch_names`` : ndarray, shape (n_meg,)
-
-          The names of the MEG channels. Their order corresponds to the order
-          of rows in the ``scores`` and ``limits`` arrays.
-
+            The names of the MEG channels. Their order corresponds to the order
+            of rows in the ``scores`` and ``limits`` arrays.
         - ``ch_types`` : ndarray, shape (n_meg,)
-
-          The types of the MEG channels in ``ch_names`` (``mag``, ``grad``).
-
+            The types of the MEG channels in ``ch_names`` (``'mag'``,
+            ``'grad'``).
         - ``bin_edges`` : ndarray, shape (n_windows + 1,)
-
-          The window boundaries (in seconds) used to calculate the scores.
-
+            The window boundaries (in seconds) used to calculate the scores.
         - ``scores_flat`` : ndarray, shape (n_meg, n_windows)
-
-          The scores for testing whether MEG channels are flat.
-
+            The scores for testing whether MEG channels are flat.
         - ``limits_flat`` : ndarray, shape (n_meg, n_windows)
-
-          The thresholds above which a score classified a segment as "flat".
-
+            The thresholds above which a score classified a segment as "flat".
         - ``scores_noisy`` : ndarray, shape (n_meg, n_windows)
-
-          The scores for testing whether MEG channels are noisy.
-
+            The scores for testing whether MEG channels are noisy.
         - ``limits_noisy`` : ndarray, shape (n_meg, n_windows)
-
-          The thresholds above which a score classified a segment as "noisy".
+            The thresholds above which a score classified a segment as "noisy".
 
         Segments of channels marked as ``bad`` will be ``np.nan``.
 

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1928,8 +1928,8 @@ def find_bad_channels_maxwell(
         .. note:: The scores and limits for channels marked as ``bad`` in the
                   input data will either be set to ``np.inf`` or ``-np.inf``,
                   such that the comparison between the scores and their
-                  corresponding limits via `<` and `>` will not yield
-                  the channel as auto-detected bad.
+                  corresponding limits via the "greater than" and "less than"
+                  operators will not yield the channel as auto-detected bad.
 
     See Also
     --------

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1925,16 +1925,9 @@ def find_bad_channels_maxwell(
             The score thresholds above which a segment was claffified as
             "noisy".
 
-<<<<<<< HEAD
         .. note:: The scores and limits for channels marked as ``bad`` in the
-                  input data will either be set to ``np.inf`` or ``-np.inf``,
-                  such that the comparison between the scores and their
-                  corresponding limits via the "greater than" and "less than"
-                  operators will not yield the channel as auto-detected bad.
-=======
-        The scores and limits for channels marked as ``bad`` in the input data
-        will will be set to ``np.nan``.
->>>>>>> parent of 5f36bd168... Use inf, -inf instead of nan
+                  input data will will be set to ``np.nan``.
+
 
     See Also
     --------

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1924,7 +1924,7 @@ def find_bad_channels_maxwell(
         - ``limits_noisy`` : ndarray, shape (n_meg, n_windows)
 
           The thresholds above which a score classified a segment as "noisy".
-        
+
         Segments of channels marked as ``bad`` will be ``np.nan``.
 
     See Also
@@ -2007,7 +2007,7 @@ def find_bad_channels_maxwell(
 
     flat_step = max(20, int(30 * raw.info['sfreq'] / 1000.))
     all_flats = set()
-    
+
     # Return values for `return_scores=True`.
     bin_edges = np.r_[starts, stops[-1]]  # Ensure we include the endpoint!
     # We create ndarrays with one row per channel, regardless of channel type

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1922,7 +1922,8 @@ def find_bad_channels_maxwell(
         - ``limits_noisy`` : ndarray, shape (n_meg, 1)
             The thresholds above which a score classified a segment as "noisy".
 
-        Segments of channels marked as ``bad`` will be ``np.nan``.
+        The scores and limits for channels marked as ``bad`` in the input data
+        will will be set to ``np.nan``.
 
     See Also
     --------

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -2018,12 +2018,10 @@ def find_bad_channels_maxwell(
     ch_names = np.array(raw.ch_names)
     ch_types = np.array(raw.get_channel_types())
 
-    scores_flat = np.empty((len(ch_names), len(starts)))
-    scores_flat.fill(np.nan)
+    scores_flat = np.full((len(ch_names), len(starts)), np.nan)
     scores_noisy = np.full_like(scores_flat, fill_value=np.nan)
 
-    thresh_flat = np.empty((len(ch_names), 1))
-    thresh_flat.fill(np.nan)
+    thresh_flat = np.full((len(ch_names), 1), np.nan)
     thresh_noisy = np.full_like(thresh_flat, fill_value=np.nan)
 
     for si, (start, stop) in enumerate(zip(starts, stops)):

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1925,8 +1925,11 @@ def find_bad_channels_maxwell(
             The score thresholds above which a segment was claffified as
             "noisy".
 
-        The scores and limits for channels marked as ``bad`` in the input data
-        will will be set to ``np.nan``.
+        .. note:: The scores and limits for channels marked as ``bad`` in the
+                  input data will either be set to ``np.inf`` or ``-np.inf``,
+                  such that the comparison between the scores and their
+                  corresponding limits via `<` and `>` will not yield
+                  the channel as auto-detected bad.
 
     See Also
     --------
@@ -2018,11 +2021,11 @@ def find_bad_channels_maxwell(
     ch_names = np.array(raw.ch_names)
     ch_types = np.array(raw.get_channel_types())
 
-    scores_flat = np.full((len(ch_names), len(starts)), np.nan)
-    scores_noisy = np.full_like(scores_flat, fill_value=np.nan)
+    scores_flat = np.full((len(ch_names), len(starts)), np.inf)
+    scores_noisy = np.full_like(scores_flat, fill_value=-np.inf)
 
-    thresh_flat = np.full((len(ch_names), 1), np.nan)
-    thresh_noisy = np.full_like(thresh_flat, fill_value=np.nan)
+    thresh_flat = np.full((len(ch_names), 1), -np.inf)
+    thresh_noisy = np.full_like(thresh_flat, fill_value=np.inf)
 
     for si, (start, stop) in enumerate(zip(starts, stops)):
         n_iter = 0

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1933,7 +1933,6 @@ def find_bad_channels_maxwell(
         .. note:: The scores and limits for channels marked as ``bad`` in the
                   input data will will be set to ``np.nan``.
 
-
     See Also
     --------
     mark_flat

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -2012,7 +2012,7 @@ def find_bad_channels_maxwell(
     # makes indexing in the loop easier. We only filter this down to the subset
     # of MEG channels after all processing is done.
     ch_names = np.array(raw.ch_names)
-    ch_types = np.array(raw.get_channel_types(ch_names))
+    ch_types = np.array(raw.get_channel_types())
     scores_flat = np.empty((len(ch_names), len(starts)))
     thresh_flat = scores_flat.copy()
     scores_noisy = scores_flat.copy()

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -2076,15 +2076,15 @@ def find_bad_channels_maxwell(
             z = (range_ - mean) / std
             idx = np.argmax(z)
             max_ = z[idx]
-            name = raw.ch_names[these_picks[idx]]
 
             # We may want to return this later if `return_scores=True`.
-            scores_noisy[these_picks, si] = max_
+            scores_noisy[these_picks, si] = z
             thresh_noisy[these_picks, si] = limit
 
             if max_ < limit:
                 break
 
+            name = raw.ch_names[these_picks[idx]]
             logger.debug('            Bad:       %s %0.1f'
                          % (name, max_))
             these_picks.pop(idx)

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1917,11 +1917,13 @@ def find_bad_channels_maxwell(
         - ``scores_flat`` : ndarray, shape (n_meg, n_windows)
             The scores for testing whether MEG channels are flat.
         - ``limits_flat`` : ndarray, shape (n_meg, 1)
-            The thresholds above which a score classified a segment as "flat".
+            The score thresholds above which a segment was claffified as
+            "flat".
         - ``scores_noisy`` : ndarray, shape (n_meg, n_windows)
             The scores for testing whether MEG channels are noisy.
         - ``limits_noisy`` : ndarray, shape (n_meg, 1)
-            The thresholds above which a score classified a segment as "noisy".
+            The score thresholds above which a segment was claffified as
+            "noisy".
 
         The scores and limits for channels marked as ``bad`` in the input data
         will will be set to ``np.nan``.

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1906,8 +1906,8 @@ def find_bad_channels_maxwell(
         following keys:
 
         - ``ch_names`` : ndarray, shape (n_meg,)
-            The names of the MEG channels. Their order corresponds to the order
-            of rows in the ``scores`` and ``limits`` arrays.
+            The names of the MEG channels. Their order corresponds to the
+            order of rows in the ``scores`` and ``limits`` arrays.
         - ``ch_types`` : ndarray, shape (n_meg,)
             The types of the MEG channels in ``ch_names`` (``'mag'``,
             ``'grad'``).
@@ -2006,15 +2006,14 @@ def find_bad_channels_maxwell(
     all_flats = set()
 
     # Prepare variables to return if `return_scores=True`.
-    ch_names = np.array(raw.ch_names)[params['meg_picks']]
-    ch_types = np.array(raw.get_channel_types(params['meg_picks']))
     bin_edges = np.r_[starts, stops[-1]]  # Ensure we include the endpoint!
     # We create ndarrays with one row per channel, regardless of channel type
     # and whether the channel has been marked as "bad" in info or not. This
     # makes indexing in the loop easier. We only filter this down to the subset
-    # of all MEG channels after all processing is done.
-    scores_flat = np.empty((len(raw.ch_names), len(starts)))
-    scores_flat.fill(np.nan)
+    # of MEG channels after all processing is done.
+    ch_names = np.array(raw.ch_names)
+    ch_types = np.array(raw.get_channel_types(ch_names))
+    scores_flat = np.empty((len(ch_names), len(starts)))
     thresh_flat = scores_flat.copy()
     scores_noisy = scores_flat.copy()
     thresh_noisy = scores_flat.copy()
@@ -2097,6 +2096,8 @@ def find_bad_channels_maxwell(
                       key=lambda x: raw.ch_names.index(x))
 
     # Only include MEG channels.
+    ch_names = ch_names[params['meg_picks']]
+    ch_types = ch_types[params['meg_picks']]
     scores_flat = scores_flat[params['meg_picks']]
     thresh_flat = thresh_flat[params['meg_picks']]
     scores_noisy = scores_noisy[params['meg_picks']]

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1157,14 +1157,7 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
         # Check "flat" scores.
         scores_flat = got_scores['scores_flat']
         limits_flat = got_scores['limits_flat']
-        # The following essentially is just this:
-        #     n_segments_below_limit = (scores_flat < limits_flat).sum(-1)
-        # made to work with NaN's in the scores.
-        n_segments_below_limit = np.less(
-            scores_flat, limits_flat,
-            where=np.equal(np.isnan(scores_flat), False),
-            out=np.full_like(scores_flat, fill_value=False)).sum(-1)
-
+        n_segments_below_limit = (scores_flat < limits_flat).sum(-1)
         ch_idx = np.where(n_segments_below_limit >=
                           min(min_count, len(got_scores['bins'])))
         flats = set(got_scores['ch_names'][ch_idx])
@@ -1173,14 +1166,7 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
         # Check "noisy" scores.
         scores_noisy = got_scores['scores_noisy']
         limits_noisy = got_scores['limits_noisy']
-        # The following essentially is just this:
-        #     n_segments_beyond_limit = (scores_noisy > limits_noisy).sum(-1)
-        # made to work with NaN's in the scores.
-        n_segments_beyond_limit = np.greater(
-            scores_noisy, limits_noisy,
-            where=np.equal(np.isnan(scores_noisy), False),
-            out=np.full_like(scores_noisy, fill_value=False)).sum(-1)
-
+        n_segments_beyond_limit = (scores_noisy > limits_noisy).sum(-1)
         ch_idx = np.where(n_segments_beyond_limit >=
                           min(min_count, len(got_scores['bins'])))
         bads = set(got_scores['ch_names'][ch_idx])

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1145,15 +1145,24 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
         assert list(got_scores['ch_types']) == ch_types
 
         assert (got_scores['scores_flat'].shape ==
-                got_scores['limits_flat'].shape ==
                 got_scores['scores_noisy'].shape ==
-                got_scores['limits_noisy'].shape ==
                 (len(meg_chs), len(got_scores['bin_edges']) - 1))
+
+        assert (got_scores['limits_flat'].shape ==
+                got_scores['limits_noisy'].shape ==
+                (len(meg_chs), 1))
 
         # Check "flat" scores.
         scores_flat = got_scores['scores_flat']
         limits_flat = got_scores['limits_flat']
-        n_segments_below_limit = (scores_flat < limits_flat).sum(-1)
+        # The following essentially is just this:
+        #     n_segments_below_limit = (scores_flat < limits_flat).sum(-1)
+        # made to work with NaN's in the scores.
+        n_segments_below_limit = np.less(
+            scores_flat, limits_flat,
+            where=np.equal(np.isnan(scores_flat), False),
+            out=np.full_like(scores_flat, fill_value=False)).sum(-1)
+
         ch_idx = np.where(n_segments_below_limit >=
                           min(min_count, len(got_scores['bin_edges']) - 1))
         flats = set(got_scores['ch_names'][ch_idx])
@@ -1162,7 +1171,14 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
         # Check "noisy" scores.
         scores_noisy = got_scores['scores_noisy']
         limits_noisy = got_scores['limits_noisy']
-        n_segments_beyond_limit = (scores_noisy > limits_noisy).sum(-1)
+        # The following essentially is just this:
+        #     n_segments_beyond_limit = (scores_noisy > limits_noisy).sum(-1)
+        # made to work with NaN's in the scores.
+        n_segments_beyond_limit = np.greater(
+            scores_noisy, limits_noisy,
+            where=np.equal(np.isnan(scores_noisy), False),
+            out=np.full_like(scores_noisy, fill_value=False)).sum(-1)
+
         ch_idx = np.where(n_segments_beyond_limit >=
                           min(min_count, len(got_scores['bin_edges']) - 1))
         bads = set(got_scores['ch_names'][ch_idx])

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1150,21 +1150,23 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
                 got_scores['limits_noisy'].shape ==
                 (len(meg_chs), len(got_scores['bin_edges']) - 1))
 
-        for want_bad in want_bads:
-            ch_idx = list(got_scores['ch_names']).index(want_bad)
-            scores = got_scores['scores_noisy'][ch_idx]
-            limits = got_scores['limits_noisy'][ch_idx]
-            n_segments_exceed_limit = (scores > limits).sum()
-            assert (n_segments_exceed_limit >=
-                    min(min_count, len(got_scores['bin_edges']) - 1))
+        # Check "flat" scores.
+        scores_flat = got_scores['scores_flat']
+        limits_flat = got_scores['limits_flat']
+        n_segments_below_limit = (scores_flat < limits_flat).sum(-1)
+        ch_idx = np.where(n_segments_below_limit >=
+                          min(min_count, len(got_scores['bin_edges']) - 1))
+        flats = set(got_scores['ch_names'][ch_idx])
+        assert flats == set(want_flats)
 
-        for want_flat in want_flats:
-            ch_idx = list(got_scores['ch_names']).index(want_flat)
-            scores = got_scores['scores_flat'][ch_idx]
-            limits = got_scores['limits_flat'][ch_idx]
-            n_segments_below_limit = (scores < limits).sum()
-            assert (n_segments_below_limit >=
-                    min(min_count, len(got_scores['bin_edges']) - 1))
+        # Check "noisy" scores.
+        scores_noisy = got_scores['scores_noisy']
+        limits_noisy = got_scores['limits_noisy']
+        n_segments_below_limit = (scores_noisy > limits_noisy).sum(-1)
+        ch_idx = np.where(n_segments_below_limit >=
+                          min(min_count, len(got_scores['bin_edges']) - 1))
+        bads = set(got_scores['ch_names'][ch_idx])
+        assert bads == set(want_bads)
 
 
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1157,7 +1157,14 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
         # Check "flat" scores.
         scores_flat = got_scores['scores_flat']
         limits_flat = got_scores['limits_flat']
-        n_segments_below_limit = (scores_flat < limits_flat).sum(-1)
+        # The following essentially is just this:
+        #     n_segments_below_limit = (scores_flat < limits_flat).sum(-1)
+        # made to work with NaN's in the scores.
+        n_segments_below_limit = np.less(
+            scores_flat, limits_flat,
+            where=np.equal(np.isnan(scores_flat), False),
+            out=np.full_like(scores_flat, fill_value=False)).sum(-1)
+
         ch_idx = np.where(n_segments_below_limit >=
                           min(min_count, len(got_scores['bins'])))
         flats = set(got_scores['ch_names'][ch_idx])
@@ -1166,7 +1173,14 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
         # Check "noisy" scores.
         scores_noisy = got_scores['scores_noisy']
         limits_noisy = got_scores['limits_noisy']
-        n_segments_beyond_limit = (scores_noisy > limits_noisy).sum(-1)
+        # The following essentially is just this:
+        #     n_segments_beyond_limit = (scores_noisy > limits_noisy).sum(-1)
+        # made to work with NaN's in the scores.
+        n_segments_beyond_limit = np.greater(
+            scores_noisy, limits_noisy,
+            where=np.equal(np.isnan(scores_noisy), False),
+            out=np.full_like(scores_noisy, fill_value=False)).sum(-1)
+
         ch_idx = np.where(n_segments_beyond_limit >=
                           min(min_count, len(got_scores['bins'])))
         bads = set(got_scores['ch_names'][ch_idx])

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1162,8 +1162,8 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
         # Check "noisy" scores.
         scores_noisy = got_scores['scores_noisy']
         limits_noisy = got_scores['limits_noisy']
-        n_segments_below_limit = (scores_noisy > limits_noisy).sum(-1)
-        ch_idx = np.where(n_segments_below_limit >=
+        n_segments_beyond_limit = (scores_noisy > limits_noisy).sum(-1)
+        ch_idx = np.where(n_segments_beyond_limit >=
                           min(min_count, len(got_scores['bin_edges']) - 1))
         bads = set(got_scores['ch_names'][ch_idx])
         assert bads == set(want_bads)

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1143,10 +1143,12 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
 
         assert list(got_scores['ch_names']) == meg_chs
         assert list(got_scores['ch_types']) == ch_types
+        # Check that time is monotonically increasing.
+        assert (np.diff(got_scores['bins'].flatten()) >= 0).all()
 
         assert (got_scores['scores_flat'].shape ==
                 got_scores['scores_noisy'].shape ==
-                (len(meg_chs), len(got_scores['bin_edges']) - 1))
+                (len(meg_chs), len(got_scores['bins'])))
 
         assert (got_scores['limits_flat'].shape ==
                 got_scores['limits_noisy'].shape ==
@@ -1164,7 +1166,7 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
             out=np.full_like(scores_flat, fill_value=False)).sum(-1)
 
         ch_idx = np.where(n_segments_below_limit >=
-                          min(min_count, len(got_scores['bin_edges']) - 1))
+                          min(min_count, len(got_scores['bins'])))
         flats = set(got_scores['ch_names'][ch_idx])
         assert flats == set(want_flats)
 
@@ -1180,7 +1182,7 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
             out=np.full_like(scores_noisy, fill_value=False)).sum(-1)
 
         ch_idx = np.where(n_segments_beyond_limit >=
-                          min(min_count, len(got_scores['bin_edges']) - 1))
+                          min(min_count, len(got_scores['bins'])))
         bads = set(got_scores['ch_names'][ch_idx])
         assert bads == set(want_bads)
 

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1061,18 +1061,25 @@ def test_mf_skips():
 
 
 @testing.requires_testing_data
-@pytest.mark.parametrize('fname, bads, annot, add_ch, ignore_ref, want_bads', [
-    # Neuromag data tested against MF
-    (sample_fname, [], False, False, False, ['MEG 2443']),
-    # add 0111 to test picking, add annot to test it, and prepend chs for idx
-    (sample_fname, ['MEG 0111'], True, True, False, ['MEG 2443']),
-    # CTF data seems to be sensitive to linalg lib (?) because some channels
-    # are very close to the limit, so we just check that one shows up
-    (ctf_fname_continuous, [], False, False, False, {'BR1-4304'}),
-    (ctf_fname_continuous, [], False, False, True, ['MLC24-4304']),  # faked
-])
+@pytest.mark.parametrize(
+    ('fname', 'bads', 'annot', 'add_ch', 'ignore_ref', 'want_bads',
+     'return_scores'), [
+        # Neuromag data tested against MF
+        (sample_fname, [], False, False, False, ['MEG 2443'], False),
+        # add 0111 to test picking, add annot to test it, and prepend chs for
+        # idx
+        (sample_fname, ['MEG 0111'], True, True, False, ['MEG 2443'], False),
+        # CTF data seems to be sensitive to linalg lib (?) because some
+        # channels are very close to the limit, so we just check that one shows
+        # up
+        (ctf_fname_continuous, [], False, False, False, {'BR1-4304'}, False),
+        # faked
+        (ctf_fname_continuous, [], False, False, True, ['MLC24-4304'], False),
+        # For `return_scores=True`
+        (sample_fname, ['MEG 0111'], True, True, False, ['MEG 2443'], True)
+    ])
 def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
-                                   want_bads):
+                                   want_bads, return_scores):
     """Test automatic bad channel detection."""
     if fname.endswith('.ds'):
         raw = read_raw_ctf(fname).load_data()
@@ -1086,6 +1093,9 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
     raw._data[flat_idx] = 0  # MaxFilter didn't have this but doesn't affect it
     want_flats = [raw.ch_names[flat_idx]]
     raw.apply_gradient_compensation(0)
+
+    min_count = 5
+
     if add_ch:
         raw_eeg = read_raw_fif(fname)
         raw_eeg.pick_types(meg=False, eeg=True, exclude=()).load_data()
@@ -1105,10 +1115,19 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
         assert step == 1502
         raw.annotations.append(step * dt + raw._first_time, dt, 'BAD')
     with catch_logging() as log:
-        got_bads, got_flats = find_bad_channels_maxwell(
+        return_vals = find_bad_channels_maxwell(
             raw, origin=(0., 0., 0.04), regularize=None,
             bad_condition='ignore', skip_by_annotation='BAD', verbose=True,
-            ignore_ref=ignore_ref)
+            ignore_ref=ignore_ref, min_count=min_count,
+            return_scores=return_scores)
+
+    if return_scores:
+        assert len(return_vals) == 3
+        got_bads, got_flats, got_scores = return_vals
+    else:
+        assert len(return_vals) == 2
+        got_bads, got_flats = return_vals
+
     if isinstance(want_bads, list):
         assert got_bads == want_bads  # from MaxFilter
     else:
@@ -1117,6 +1136,35 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
     log = log.getvalue()
     assert 'Interval   1:    0.00' in log
     assert 'Interval   2:    5.00' in log
+
+    if return_scores:
+        meg_chs = raw.copy().pick_types(meg=True, exclude=[]).ch_names
+        ch_types = raw.get_channel_types(meg_chs)
+
+        assert list(got_scores['ch_names']) == meg_chs
+        assert list(got_scores['ch_types']) == ch_types
+
+        assert (got_scores['scores_flat'].shape ==
+                got_scores['limits_flat'].shape ==
+                got_scores['scores_noisy'].shape ==
+                got_scores['limits_noisy'].shape ==
+                (len(meg_chs), len(got_scores['bin_edges']) - 1))
+
+        for want_bad in want_bads:
+            ch_idx = list(got_scores['ch_names']).index(want_bad)
+            scores = got_scores['scores_noisy'][ch_idx]
+            limits = got_scores['limits_noisy'][ch_idx]
+            n_segments_exceed_limit = (scores > limits).sum()
+            assert (n_segments_exceed_limit >=
+                    min(min_count, len(got_scores['bin_edges']) - 1))
+
+        for want_flat in want_flats:
+            ch_idx = list(got_scores['ch_names']).index(want_flat)
+            scores = got_scores['scores_flat'][ch_idx]
+            limits = got_scores['limits_flat'][ch_idx]
+            n_segments_below_limit = (scores < limits).sum()
+            assert (n_segments_below_limit >=
+                    min(min_count, len(got_scores['bin_edges']) - 1))
 
 
 run_tests_if_main()

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -116,6 +116,7 @@ auto_noisy_chs, auto_flat_chs, auto_scores = find_bad_channels_maxwell(
 print(auto_noisy_chs)  # we should find them!
 print(auto_flat_chs)  # none for this dataset
 
+###############################################################################
 # Now we can update the list of bad channels in the dataset. We first create a
 # set (a collection of unique values) to ensure no channel appears more than
 # once in the list.
@@ -124,6 +125,7 @@ bads = set([*raw.info['bads'], *auto_noisy_chs, *auto_flat_chs])
 bads = list(bads)
 raw.info['bads'] = bads
 
+###############################################################################
 # We called `~mne.preprocessing.find_bad_channels_maxwell` with the optional
 # keyword argument ``return_scores=True``, causing the function to return a
 # dictionary of all data related to the scoring used to classify channels as
@@ -166,6 +168,7 @@ for ch_type in ('mag', 'grad'):
     fig.tight_layout(rect=[0, 0.03, 1, 0.95])
     plt.show()
 
+###############################################################################
 # .. note:: You can use the very same code as above to produce figures for
 #           *flat* channel detection; simply replace the word "noisy" with
 #           "flat", and invert the ``mask``, such that it reads:

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -166,8 +166,9 @@ ax[0].set_title('All Scores', fontweight='bold')
 # Now, only plot scores that exceeded the limits. We do this by placing a mask
 # on all data points less than or equal to the limits.
 mask = scores <= limits
-sns.heatmap(data=data_to_plot, mask=mask, cmap='Reds',
-            cbar_kws=dict(label='Score'), ax=ax[1])
+sns.heatmap(data=data_to_plot, mask=mask,
+            vmin=limits.min(), vmax=scores.max(),  # May be omitted.
+            cmap='Reds', cbar_kws=dict(label='Score'), ax=ax[1])
 [ax[1].axvline(x, ls='dashed', lw=0.25, dashes=(25, 15), color='gray')
     for x in range(1, len(bins))]
 ax[1].set_title('Scores > Limit', fontweight='bold')

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -19,6 +19,7 @@ import os
 import matplotlib.pyplot as plt
 import seaborn as sns
 import pandas as pd
+# import numpy as np
 import mne
 from mne.preprocessing import find_bad_channels_maxwell
 
@@ -168,9 +169,8 @@ ax[0].set_title('All Scores', fontweight='bold')
 # plotting function to avoid a (harmless) warning about missing values.
 # However, this is purely optional.
 mask = scores <= limits
-sns.heatmap(data=data_to_plot, mask=mask,
-            vmin=limits.min(), vmax=scores.max(),  # May be omitted.
-            cmap='Reds', cbar_kws=dict(label='Score'), ax=ax[1])
+sns.heatmap(data=data_to_plot, mask=mask, cmap='Reds',
+            cbar_kws=dict(label='Score'), ax=ax[1])
 [ax[1].axvline(x, ls='dashed', lw=0.25, dashes=(25, 15), color='gray')
     for x in range(1, len(bins))]
 ax[1].set_title('Scores > Limit', fontweight='bold')

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -142,7 +142,7 @@ scores = auto_scores['scores_noisy'][ch_subset]
 limits = auto_scores['limits_noisy'][ch_subset]
 bins = auto_scores['bins']  # The the windows that were evaluated.
 # We will label each segment by its start and stop time, with up to 3
-# 3 digits before and 3 digits after the decimal place (1 ms precision).
+# digits before and 3 digits after the decimal place (1 ms precision).
 bin_labels = [f'{start:3.3f} – {stop:3.3f}'
               for start, stop in bins]
 

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -163,10 +163,8 @@ sns.heatmap(data=data_to_plot, cmap='Reds', cbar_kws=dict(label='Score'),
     for x in range(1, len(bins))]
 ax[0].set_title('All Scores', fontweight='bold')
 
-# Now, only plot scores that exceeded the limits.
-# We also pass the optional parameters ``vmin`` and ``vmax`` to the
-# plotting function to avoid a (harmless) warning about missing values.
-# However, this is purely optional.
+# Now, only plot scores that exceeded the limits. We do this by placing a mask
+# on all data points less than or equal to the limits.
 mask = scores <= limits
 sns.heatmap(data=data_to_plot, mask=mask, cmap='Reds',
             cbar_kws=dict(label='Score'), ax=ax[1])

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -134,7 +134,7 @@ raw.info['bads'] = bads
 # In the following, we will generate such visualizations for
 # the automated detection of *noisy* gradiometer channels.
 
-# Only select the data for mag or grad channels.
+# Only select the data forgradiometer channels.
 ch_type = 'grad'
 ch_subset = auto_scores['ch_types'] == ch_type
 ch_names = auto_scores['ch_names'][ch_subset]

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -131,7 +131,7 @@ raw.info['bads'] = bads
 #
 # In the following, we will generate a total of four of such visualizations for
 # the automated detection of *noisy* channels.
-# %%
+
 for ch_type in ('mag', 'grad'):
     # Only select the data for mag or grad channels.
     ch_subset = auto_scores['ch_types'] == ch_type

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -1,3 +1,4 @@
+# %%
 """
 .. _tut-artifact-sss:
 
@@ -19,6 +20,7 @@ import os
 import matplotlib.pyplot as plt
 import seaborn as sns
 import pandas as pd
+import numpy as np
 import mne
 from mne.preprocessing import find_bad_channels_maxwell
 
@@ -133,16 +135,19 @@ raw.info['bads'] = bads
 #
 # In the following, we will generate a total of four of such visualizations for
 # the automated detection of *noisy* channels.
-
+# %%
 for ch_type in ('mag', 'grad'):
     # Only select the data for mag or grad channels.
     ch_subset = auto_scores['ch_types'] == ch_type
     ch_names = auto_scores['ch_names'][ch_subset]
     scores = auto_scores['scores_noisy'][ch_subset]
     limits = auto_scores['limits_noisy'][ch_subset]
-    # Number of time windows
+    # Number of time windows.
     segments = range(1, len(auto_scores['bin_edges']))
 
+    # We store the data in a Pandas DataFrame. The seaborn heatmap function
+    # we will call below will then be able to automatically assign the correct
+    # labels to all axes.
     data_to_plot = pd.DataFrame(data=scores,
                                 columns=pd.Index(segments, name='Segment'),
                                 index=pd.Index(ch_names, name='Channel'))
@@ -160,7 +165,7 @@ for ch_type in ('mag', 'grad'):
     # However, this is purely optional.
     mask = scores <= limits
     sns.heatmap(data=data_to_plot, mask=mask,
-                vmin=limits.min(), vmax=limits.max(),  # May be omitted.
+                vmin=limits.min(), vmax=scores.max(),  # May be omitted.
                 cmap='Reds', cbar_kws=dict(label='Score'), ax=ax[1])
     ax[1].set_title('Scores > Limit', fontweight='bold')
 
@@ -168,12 +173,14 @@ for ch_type in ('mag', 'grad'):
     fig.tight_layout(rect=[0, 0.03, 1, 0.95])
     plt.show()
 
+# %%
 ###############################################################################
+#
 # .. note:: You can use the very same code as above to produce figures for
-#           *flat* channel detection; simply replace the word "noisy" with
+#           *flat* channel detection. Simply replace the word "noisy" with
 #           "flat", and invert the ``mask``, such that it reads:
-#           ``mask = scores >= limits`` to omit all scores that do not qualify
-#           as "flat" when generating the right subplots.
+#           ``mask = scores >= limits``. Lastly, in the second plot command,
+#           set ``vmin=scores.min()`` and ``vmax=limits.max()``.
 #
 # You can see the un-altered scores for each channel and time segment in the
 # left subplots, and thresholded scores – those which exceeded a certain limit

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -144,7 +144,6 @@ for ch_type in ('mag', 'grad'):
     data_to_plot = pd.DataFrame(data=scores,
                                 columns=pd.Index(segments, name='Segment'),
                                 index=pd.Index(ch_names, name='Channel'))
-
     # Plot the "raw" scores.
     fig, ax = plt.subplots(1, 2, figsize=(12, 5))
     fig.suptitle(f'Automated noisy channel detection: {ch_type}',
@@ -154,9 +153,13 @@ for ch_type in ('mag', 'grad'):
     ax[0].set_title('All Scores', fontweight='bold')
 
     # Only plot scores that exceeded the limits.
+    # We also pass the optional parameters ``vmin`` and ``vmax`` to the
+    # plotting function to avoid a (harmless) warning about missing values.
+    # However, this is purely optional.
     mask = scores <= limits
-    sns.heatmap(data=data_to_plot, mask=mask, cmap='Reds',
-                cbar_kws=dict(label='Score'), ax=ax[1])
+    sns.heatmap(data=data_to_plot, mask=mask,
+                vmin=limits.min(), vmax=limits.max(),  # May be omitted.
+                cmap='Reds', cbar_kws=dict(label='Score'), ax=ax[1])
     ax[1].set_title('Scores > Limit', fontweight='bold')
 
     # Figure title should not overlap with subplots.

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -16,7 +16,11 @@ As usual we'll start by importing the modules we need, loading some
 """
 
 import os
+import matplotlib.pyplot as plt
+import seaborn as sns
+import pandas as pd
 import mne
+from mne.preprocessing import find_bad_channels_maxwell
 
 sample_data_folder = mne.datasets.sample.data_path()
 sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
@@ -106,18 +110,90 @@ crosstalk_file = os.path.join(sample_data_folder, 'SSS', 'ct_sparse_mgh.fif')
 raw.info['bads'] = []
 raw_check = raw.copy()
 raw_check.pick_types(meg=True, exclude=()).load_data().filter(None, 40)
-auto_noisy_chs, auto_flat_chs = mne.preprocessing.find_bad_channels_maxwell(
+auto_noisy_chs, auto_flat_chs, auto_scores = find_bad_channels_maxwell(
     raw_check, cross_talk=crosstalk_file, calibration=fine_cal_file,
-    verbose=True)
+    return_scores=True, verbose=True)
 print(auto_noisy_chs)  # we should find them!
 print(auto_flat_chs)  # none for this dataset
-raw.info['bads'].extend(auto_noisy_chs + auto_flat_chs)
+
+# Now we can update the list of bad channels in the dataset. We first create a
+# set (a collection of unique values) to ensure no channel appears more than
+# once in the list.
+
+bads = set([*raw.info['bads'], *auto_noisy_chs, *auto_flat_chs])
+bads = list(bads)
+raw.info['bads'] = bads
+
+# We called `~mne.preprocessing.find_bad_channels_maxwell` with the optional
+# keyword argument ``return_scores=True``, causing the function to return a
+# dictionary of all data related to the scoring used to classify channels as
+# noisy or flat. This information can be used to produce diagnostic figures.
+#
+# In the following, we will generate a total of four of such visualizations for
+# the automated detection of *noisy* channels.
+# %%
+for ch_type in ('mag', 'grad'):
+    # Only select the data for mag or grad channels.
+    ch_subset = auto_scores['ch_types'] == ch_type
+    ch_names = auto_scores['ch_names'][ch_subset]
+    scores = auto_scores['scores_noisy'][ch_subset]
+    limits = auto_scores['limits_noisy'][ch_subset]
+    # Number of time windows
+    segments = range(1, len(auto_scores['bin_edges']))
+
+    data_to_plot = pd.DataFrame(data=scores,
+                                columns=pd.Index(segments, name='Segment'),
+                                index=pd.Index(ch_names, name='Channel'))
+
+    # Plot the "raw" scores.
+    fig, ax = plt.subplots(1, 2, figsize=(12, 5))
+    fig.suptitle(f'Automated noisy channel detection: {ch_type}',
+                 fontsize=16, fontweight='bold')
+    sns.heatmap(data=data_to_plot, cmap='Reds', cbar_kws=dict(label='Score'),
+                ax=ax[0])
+    ax[0].set_title('All Scores', fontweight='bold')
+
+    # Only plot scores that exceeded the limits.
+    mask = scores <= limits
+    sns.heatmap(data=data_to_plot, mask=mask, cmap='Reds',
+                cbar_kws=dict(label='Score'), ax=ax[1])
+    ax[1].set_title('Scores > Limit', fontweight='bold')
+
+    # Figure title should not overlap with subplots.
+    fig.tight_layout(rect=[0, 0.03, 1, 0.95])
+    plt.show()
+
+# .. note:: You can use the very same code as above to produce figures for
+#           *flat* channel detection; simply replace the word "noisy" with
+#           "flat", and invert the ``mask``, such that it reads:
+#           ``mask = scores >= limits`` to omit all scores that do not qualify
+#           as "flat" when generating the right subplots.
+
+# You can see the un-altered scores for each channel and time segment in the
+# left subplots, and thresholded scores – those which exceeded a certain limit
+# of noisiness – in the right subplots. While the right subplot is entirely
+# white for the magnetometers, we can see a horizontal line extending all the
+# way from left to right for the gradiometers. This line corresponds to channel
+# ``MEG 2443``, which was reported as auto-detected noisy channel in the step
+# above. But we can also see another channel exceeding the limits, apparently
+# in a more transient fashion. It was therefore *not* detected as bad, because
+# the number of segments in which it exceeded the limits was less than 5,
+# which MNE-Python uses by default.
+
+# .. note:: You can request a different number of segments that must be
+#           found to be problematic before
+#           `~mne.preprocessing.find_bad_channels_maxwell` reports them as bad.
+#           To do this, pass the keyword argument ``min_count`` to the
+#           function.
 
 ###############################################################################
-# But this algorithm is not perfect. For example, it misses ``MEG 2313``,
-# which has some flux jumps, because there are not enough flux jumps in the
-# recording. So it can still be useful to manually inspect and mark bad
-# channels:
+# Obviously, this algorithm is not perfect. Specifically, on closer inspection
+# of the raw data after looking at the diagnostic plots above, it becomes clear
+# that the channel exceeding the "noise" limits in some segments without
+# qualifying as "bad", in fact contains some flux jumps. There were just not
+# *enough* flux jumps in the recording for our automated detecion to report the
+# channel as bad. So it can still be useful to manually inspect and mark bad
+# channels. The channel in question is ``MEG 2313``. Let's mark it as bad:
 
 raw.info['bads'] += ['MEG 2313']  # from manual inspection
 

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -172,7 +172,6 @@ for ch_type in ('mag', 'grad'):
 
     # Figure title should not overlap with subplots.
     fig.tight_layout(rect=[0, 0.03, 1, 0.95])
-    plt.show()
 
 ###############################################################################
 #

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -19,7 +19,6 @@ import os
 import matplotlib.pyplot as plt
 import seaborn as sns
 import pandas as pd
-# import numpy as np
 import mne
 from mne.preprocessing import find_bad_channels_maxwell
 

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -19,6 +19,7 @@ import os
 import matplotlib.pyplot as plt
 import seaborn as sns
 import pandas as pd
+import numpy as np
 import mne
 from mne.preprocessing import find_bad_channels_maxwell
 
@@ -117,11 +118,9 @@ print(auto_noisy_chs)  # we should find them!
 print(auto_flat_chs)  # none for this dataset
 
 ###############################################################################
-# Now we can update the list of bad channels in the dataset. We first create a
-# set (a collection of unique values) to ensure no channel appears more than
-# once; we then sort the channels alphabetically.
+# Now we can update the list of bad channels in the dataset.
 
-bads = set([*raw.info['bads'], *auto_noisy_chs, *auto_flat_chs])
+bads = [*raw.info['bads'], *auto_noisy_chs, *auto_flat_chs]
 bads = sorted(bads)
 raw.info['bads'] = bads
 
@@ -163,11 +162,9 @@ sns.heatmap(data=data_to_plot, cmap='Reds', cbar_kws=dict(label='Score'),
     for x in range(1, len(bins))]
 ax[0].set_title('All Scores', fontweight='bold')
 
-# Now, only plot scores that exceeded the limits. We do this by placing a mask
-# on all data points less than or equal to the limits.
-mask = scores <= limits
-sns.heatmap(data=data_to_plot, mask=mask,
-            vmin=limits.min(), vmax=scores.max(),  # May be omitted.
+# Now, adjust the color range to highlight segments that exceeded the limit.
+sns.heatmap(data=data_to_plot,
+            vmin=np.nanmin(limits),  # bads in input data have NaN limits
             cmap='Reds', cbar_kws=dict(label='Score'), ax=ax[1])
 [ax[1].axvline(x, ls='dashed', lw=0.25, dashes=(25, 15), color='gray')
     for x in range(1, len(bins))]
@@ -180,9 +177,8 @@ fig.tight_layout(rect=[0, 0.03, 1, 0.95])
 #
 # .. note:: You can use the very same code as above to produce figures for
 #           *flat* channel detection. Simply replace the word "noisy" with
-#           "flat", and invert the ``mask``, such that it reads:
-#           ``mask = scores >= limits``. Lastly, in the second plot command,
-#           set ``vmin=scores.min()`` and ``vmax=limits.max()``.
+#           "flat", and replace ``vmin=np.nanmin(limits)`` with
+#           ``vmax=np.nanmax(limits)``.
 #
 # You can see the un-altered scores for each channel and time segment in the
 # left subplots, and thresholded scores – those which exceeded a certain limit

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -140,14 +140,14 @@ for ch_type in ('mag', 'grad'):
     ch_names = auto_scores['ch_names'][ch_subset]
     scores = auto_scores['scores_noisy'][ch_subset]
     limits = auto_scores['limits_noisy'][ch_subset]
-    # Number of time windows.
-    segments = range(1, len(auto_scores['bin_edges']))
+    bins = auto_scores['bins']  # The the windows that were evaluated.
+    bin_labels = [f'{start} – {stop}' for start, stop in bins]
 
     # We store the data in a Pandas DataFrame. The seaborn heatmap function
     # we will call below will then be able to automatically assign the correct
     # labels to all axes.
     data_to_plot = pd.DataFrame(data=scores,
-                                columns=pd.Index(segments, name='Segment'),
+                                columns=pd.Index(bin_labels, name='Time (s)'),
                                 index=pd.Index(ch_names, name='Channel'))
     # Plot the "raw" scores.
     fig, ax = plt.subplots(1, 2, figsize=(12, 5))

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -174,7 +174,7 @@ for ch_type in ('mag', 'grad'):
 #           "flat", and invert the ``mask``, such that it reads:
 #           ``mask = scores >= limits`` to omit all scores that do not qualify
 #           as "flat" when generating the right subplots.
-
+#
 # You can see the un-altered scores for each channel and time segment in the
 # left subplots, and thresholded scores – those which exceeded a certain limit
 # of noisiness – in the right subplots. While the right subplot is entirely
@@ -185,7 +185,7 @@ for ch_type in ('mag', 'grad'):
 # in a more transient fashion. It was therefore *not* detected as bad, because
 # the number of segments in which it exceeded the limits was less than 5,
 # which MNE-Python uses by default.
-
+#
 # .. note:: You can request a different number of segments that must be
 #           found to be problematic before
 #           `~mne.preprocessing.find_bad_channels_maxwell` reports them as bad.

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -1,4 +1,3 @@
-# %%
 """
 .. _tut-artifact-sss:
 
@@ -20,7 +19,6 @@ import os
 import matplotlib.pyplot as plt
 import seaborn as sns
 import pandas as pd
-import numpy as np
 import mne
 from mne.preprocessing import find_bad_channels_maxwell
 
@@ -135,7 +133,7 @@ raw.info['bads'] = bads
 #
 # In the following, we will generate a total of four of such visualizations for
 # the automated detection of *noisy* channels.
-# %%
+
 for ch_type in ('mag', 'grad'):
     # Only select the data for mag or grad channels.
     ch_subset = auto_scores['ch_types'] == ch_type
@@ -173,7 +171,6 @@ for ch_type in ('mag', 'grad'):
     fig.tight_layout(rect=[0, 0.03, 1, 0.95])
     plt.show()
 
-# %%
 ###############################################################################
 #
 # .. note:: You can use the very same code as above to produce figures for

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -131,51 +131,52 @@ raw.info['bads'] = bads
 # dictionary of all data related to the scoring used to classify channels as
 # noisy or flat. This information can be used to produce diagnostic figures.
 #
-# In the following, we will generate a total of four of such visualizations for
-# the automated detection of *noisy* channels.
+# In the following, we will generate such visualizations for
+# the automated detection of *noisy* gradiometer channels.
 
-for ch_type in ('mag', 'grad'):
-    # Only select the data for mag or grad channels.
-    ch_subset = auto_scores['ch_types'] == ch_type
-    ch_names = auto_scores['ch_names'][ch_subset]
-    scores = auto_scores['scores_noisy'][ch_subset]
-    limits = auto_scores['limits_noisy'][ch_subset]
-    bins = auto_scores['bins']  # The the windows that were evaluated.
-    # We will label each segment by its start and stop time, with up to 3
-    # 3 digits before and 3 digits after the decimal place (1 ms precision).
-    bin_labels = [f'{start:3.3f} – {stop:3.3f}'
-                  for start, stop in bins]
+# Only select the data for mag or grad channels.
+ch_type = 'grad'
+ch_subset = auto_scores['ch_types'] == ch_type
+ch_names = auto_scores['ch_names'][ch_subset]
+scores = auto_scores['scores_noisy'][ch_subset]
+limits = auto_scores['limits_noisy'][ch_subset]
+bins = auto_scores['bins']  # The the windows that were evaluated.
+# We will label each segment by its start and stop time, with up to 3
+# 3 digits before and 3 digits after the decimal place (1 ms precision).
+bin_labels = [f'{start:3.3f} – {stop:3.3f}'
+              for start, stop in bins]
 
-    # We store the data in a Pandas DataFrame. The seaborn heatmap function
-    # we will call below will then be able to automatically assign the correct
-    # labels to all axes.
-    data_to_plot = pd.DataFrame(data=scores,
-                                columns=pd.Index(bin_labels, name='Time (s)'),
-                                index=pd.Index(ch_names, name='Channel'))
-    # Plot the "raw" scores.
-    fig, ax = plt.subplots(1, 2, figsize=(12, 8))
-    fig.suptitle(f'Automated noisy channel detection: {ch_type}',
-                 fontsize=16, fontweight='bold')
-    sns.heatmap(data=data_to_plot, cmap='Reds', cbar_kws=dict(label='Score'),
-                ax=ax[0])
-    [ax[0].axvline(x, ls='dashed', lw=0.25, dashes=(25, 15), color='gray')
-     for x in range(1, len(bins))]
-    ax[0].set_title('All Scores', fontweight='bold')
+# We store the data in a Pandas DataFrame. The seaborn heatmap function
+# we will call below will then be able to automatically assign the correct
+# labels to all axes.
+data_to_plot = pd.DataFrame(data=scores,
+                            columns=pd.Index(bin_labels, name='Time (s)'),
+                            index=pd.Index(ch_names, name='Channel'))
 
-    # Only plot scores that exceeded the limits.
-    # We also pass the optional parameters ``vmin`` and ``vmax`` to the
-    # plotting function to avoid a (harmless) warning about missing values.
-    # However, this is purely optional.
-    mask = scores <= limits
-    sns.heatmap(data=data_to_plot, mask=mask,
-                vmin=limits.min(), vmax=scores.max(),  # May be omitted.
-                cmap='Reds', cbar_kws=dict(label='Score'), ax=ax[1])
-    [ax[1].axvline(x, ls='dashed', lw=0.25, dashes=(25, 15), color='gray')
-     for x in range(1, len(bins))]
-    ax[1].set_title('Scores > Limit', fontweight='bold')
+# First, plot the "raw" scores.
+fig, ax = plt.subplots(1, 2, figsize=(12, 8))
+fig.suptitle(f'Automated noisy channel detection: {ch_type}',
+             fontsize=16, fontweight='bold')
+sns.heatmap(data=data_to_plot, cmap='Reds', cbar_kws=dict(label='Score'),
+            ax=ax[0])
+[ax[0].axvline(x, ls='dashed', lw=0.25, dashes=(25, 15), color='gray')
+    for x in range(1, len(bins))]
+ax[0].set_title('All Scores', fontweight='bold')
 
-    # Figure title should not overlap with subplots.
-    fig.tight_layout(rect=[0, 0.03, 1, 0.95])
+# Now, only plot scores that exceeded the limits.
+# We also pass the optional parameters ``vmin`` and ``vmax`` to the
+# plotting function to avoid a (harmless) warning about missing values.
+# However, this is purely optional.
+mask = scores <= limits
+sns.heatmap(data=data_to_plot, mask=mask,
+            vmin=limits.min(), vmax=scores.max(),  # May be omitted.
+            cmap='Reds', cbar_kws=dict(label='Score'), ax=ax[1])
+[ax[1].axvline(x, ls='dashed', lw=0.25, dashes=(25, 15), color='gray')
+    for x in range(1, len(bins))]
+ax[1].set_title('Scores > Limit', fontweight='bold')
+
+# The figure title should not overlap with the subplots.
+fig.tight_layout(rect=[0, 0.03, 1, 0.95])
 
 ###############################################################################
 #

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -119,10 +119,10 @@ print(auto_flat_chs)  # none for this dataset
 ###############################################################################
 # Now we can update the list of bad channels in the dataset. We first create a
 # set (a collection of unique values) to ensure no channel appears more than
-# once in the list.
+# once; we then sort the channels alphabetically.
 
 bads = set([*raw.info['bads'], *auto_noisy_chs, *auto_flat_chs])
-bads = list(bads)
+bads = sorted(bads)
 raw.info['bads'] = bads
 
 ###############################################################################
@@ -141,7 +141,10 @@ for ch_type in ('mag', 'grad'):
     scores = auto_scores['scores_noisy'][ch_subset]
     limits = auto_scores['limits_noisy'][ch_subset]
     bins = auto_scores['bins']  # The the windows that were evaluated.
-    bin_labels = [f'{start} – {stop}' for start, stop in bins]
+    # We will label each segment by its start and stop time, with up to 3
+    # 3 digits before and 3 digits after the decimal place (1 ms precision).
+    bin_labels = [f'{start:3.3f} – {stop:3.3f}'
+                  for start, stop in bins]
 
     # We store the data in a Pandas DataFrame. The seaborn heatmap function
     # we will call below will then be able to automatically assign the correct
@@ -150,7 +153,7 @@ for ch_type in ('mag', 'grad'):
                                 columns=pd.Index(bin_labels, name='Time (s)'),
                                 index=pd.Index(ch_names, name='Channel'))
     # Plot the "raw" scores.
-    fig, ax = plt.subplots(1, 2, figsize=(12, 5))
+    fig, ax = plt.subplots(1, 2, figsize=(12, 8))
     fig.suptitle(f'Automated noisy channel detection: {ch_type}',
                  fontsize=16, fontweight='bold')
     sns.heatmap(data=data_to_plot, cmap='Reds', cbar_kws=dict(label='Score'),

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -158,6 +158,8 @@ for ch_type in ('mag', 'grad'):
                  fontsize=16, fontweight='bold')
     sns.heatmap(data=data_to_plot, cmap='Reds', cbar_kws=dict(label='Score'),
                 ax=ax[0])
+    [ax[0].axvline(x, ls='dashed', lw=0.25, dashes=(25, 15), color='gray')
+     for x in range(1, len(bins))]
     ax[0].set_title('All Scores', fontweight='bold')
 
     # Only plot scores that exceeded the limits.
@@ -168,6 +170,8 @@ for ch_type in ('mag', 'grad'):
     sns.heatmap(data=data_to_plot, mask=mask,
                 vmin=limits.min(), vmax=scores.max(),  # May be omitted.
                 cmap='Reds', cbar_kws=dict(label='Score'), ax=ax[1])
+    [ax[1].axvline(x, ls='dashed', lw=0.25, dashes=(25, 15), color='gray')
+     for x in range(1, len(bins))]
     ax[1].set_title('Scores > Limit', fontweight='bold')
 
     # Figure title should not overlap with subplots.

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -191,9 +191,9 @@ for ch_type in ('mag', 'grad'):
 # of the raw data after looking at the diagnostic plots above, it becomes clear
 # that the channel exceeding the "noise" limits in some segments without
 # qualifying as "bad", in fact contains some flux jumps. There were just not
-# *enough* flux jumps in the recording for our automated detecion to report the
-# channel as bad. So it can still be useful to manually inspect and mark bad
-# channels. The channel in question is ``MEG 2313``. Let's mark it as bad:
+# *enough* flux jumps in the recording for our automated procedure to report
+# the channel as bad. So it can still be useful to manually inspect and mark
+# bad channels. The channel in question is ``MEG 2313``. Let's mark it as bad:
 
 raw.info['bads'] += ['MEG 2313']  # from manual inspection
 


### PR DESCRIPTION
#### What does this implement/fix?
Inspired by https://github.com/mne-tools/mne-study-template/issues/118#issuecomment-630847578, I have added a new parameter `return_scores` to `preprocessing.find_bad_channels_maxwell()`.

If True, we will now return a dictionary with alle the scores, limits, and corresponding channel names and types. 

<strike>
- the edges of the time windows analyzed
- the corresponding evaluation of a channel being flat in this window
- the corresponding evaluation of a channel being noisy in this window

I currently refer to the latter two values as "scores", but actually they are just boolean values. So the returned ndarrays `scores_flat` and `scores_noisy` only contain True and False for each channels in all evaluated time segments. Wonder if there's a better name we could use?
</strike>

#### Additional information
I first wanted to ask for feedback before starting to add tests.