### PR TITLE
MRG, ENH: Allow reading broken file

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -71,6 +71,8 @@ Changelog
 
 - Add ECoG misc EDF dataset to the :ref:`tut_working_with_ecog` tutorial to show snapshots of time-frequency activity by `Adam Li`_
 
+- Add better support for reading corrupted FIF files in :func:`mne.io.read_raw_fif` by `Eric Larson`_
+
 - BIDS conformity: When saving FIF files to disk and the files are split into parts, the ``split_naming='bids'`` parameter now uses a "_split-%d" naming instead of the previous "_part-%d", by `Stefan Appelhoff`_
 
 - Add support for loading complex numbers from mat files by `Thomas Hartmann`_

--- a/mne/datasets/testing/_testing.py
+++ b/mne/datasets/testing/_testing.py
@@ -52,9 +52,12 @@ def requires_testing_data(func):
                               reason='Requires testing dataset')(func)
 
 
-def _pytest_param():
+def _pytest_param(*args, **kwargs):
+    if len(args) == len(kwargs) == 0:
+        args = ('testing_data',)
     import pytest
     # turn anything that uses testing data into an auto-skipper by
-    # setting params=[testing._pytest_param()]
-    return pytest.param('testing_data', marks=pytest.mark.skipif(
+    # setting params=[testing._pytest_param()], or by parametrizing functions
+    # with testing._pytest_param(whatever)
+    return pytest.param(*args, **kwargs, marks=pytest.mark.skipif(
         _skip_testing_data(), reason='Requires testing dataset'))

--- a/mne/io/tag.py
+++ b/mne/io/tag.py
@@ -50,7 +50,7 @@ class Tag(object):
         out += ">"
         return out
 
-    def __cmp__(self, tag):  # noqa: D105
+    def __eq__(self, tag):  # noqa: D105
         return int(self.kind == tag.kind and
                    self.type == tag.type and
                    self.size == tag.size and
@@ -447,11 +447,11 @@ def read_tag(fid, pos=None, shape=None, rlims=None):
             tag.data = _read_matrix(fid, tag, shape, rlims, matrix_coding)
         else:
             #   All other data types
-            fun = _call_dict.get(tag.type)
-            if fun is not None:
-                tag.data = fun(fid, tag, shape, rlims)
-            else:
+            try:
+                fun = _call_dict[tag.type]
+            except KeyError:
                 raise Exception('Unimplemented tag data type %s' % tag.type)
+            tag.data = fun(fid, tag, shape, rlims)
     if tag.next != FIFF.FIFFV_NEXT_SEQ:
         # f.seek(tag.next,0)
         fid.seek(tag.next, 1)  # XXX : fix? pb when tag.next < 0


### PR DESCRIPTION
Closes #7844

With these changes, I can read the file and get the warning:
```
RuntimeWarning: FIF raw buffer could not be read, acquisition error likely: 10000 samples set to zero
```
After some effort messing with bytes in our testing files, I couldn't make a test that actually hits this warning (breaking the tag always broke the `'nent'` for our files). But I did write a consistency test that works for all of our files, and emits the warnings if we add the problematic file to the list of files to test.