### PR TITLE
MRG, DOC: Add evoked movecomp to example

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -152,6 +152,8 @@ Bug
 
 - Fix bug that prevents ``n_jobs`` from being a NumPy integer type, by `Daniel McCloy`_.
 
+- Fix bug with :func:`mne.epochs.average_movements` where epoch weights were computed using all basis vectors instead of the internal basis only by `Eric Larson`_
+
 - Fix bug with :func:`mne.io.read_raw_gdf` where birthdays were not parsed properly, leading to an error by `Svea Marie Meyer`_
 
 - Fix bug with :func:`mne.io.read_raw_edf` where recording ID was not read properly for non-ASCII characters by `Lx37`_

--- a/examples/preprocessing/plot_movement_compensation.py
+++ b/examples/preprocessing/plot_movement_compensation.py
@@ -66,11 +66,20 @@ evoked_stat.plot_topomap(title='Stationary', **topo_kwargs)
 # Second, take a naive average, which averages across epochs that have been
 # simulated to have different head positions and orientations, thereby
 # spatially smearing the activity.
-evoked = mne.Epochs(raw, events, 1, -0.2, 0.8).average()
+epochs = mne.Epochs(raw, events, 1, -0.2, 0.8)
+evoked = epochs.average()
 evoked.plot_topomap(title='Moving: naive average', **topo_kwargs)
 
 ###############################################################################
 # Third, use raw movement compensation (restores pattern).
 raw_sss = maxwell_filter(raw, head_pos=head_pos)
 evoked_raw_mc = mne.Epochs(raw_sss, events, 1, -0.2, 0.8).average()
-evoked_raw_mc.plot_topomap(title='Moving: movement compensated', **topo_kwargs)
+evoked_raw_mc.plot_topomap(title='Moving: movement compensated (raw)',
+                           **topo_kwargs)
+
+###############################################################################
+# Fourth, use evoked movement compensation. For these data, which contain
+# very large rotations, it does not as cleanly restore the pattern.
+evoked_evo_mc = mne.epochs.average_movements(epochs, head_pos=head_pos)
+evoked_evo_mc.plot_topomap(title='Moving: movement compensated (evoked)',
+                           **topo_kwargs)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3192,6 +3192,7 @@ def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
     decomp_coil_scale = coil_scale[good_mask]
     exp = dict(int_order=int_order, ext_order=ext_order, head_frame=True,
                origin=origin)
+    n_in = _get_n_moments(int_order)
     for ei, epoch in enumerate(epochs):
         event_time = epochs.events[epochs._current - 1, 0] / orig_sfreq
         use_idx = np.where(t <= event_time)[0]
@@ -3215,8 +3216,8 @@ def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
         if not reuse:
             S = _trans_sss_basis(exp, all_coils, trans,
                                  coil_scale=decomp_coil_scale)
-            # Get the weight from the un-regularized version
-            weight = np.sqrt(np.sum(S * S))  # frobenius norm (eq. 44)
+            # Get the weight from the un-regularized version (eq. 44)
+            weight = np.linalg.norm(S[:, :n_in])
             # XXX Eventually we could do cross-talk and fine-cal here
             S *= weight
         S_decomp += S  # eq. 41


### PR DESCRIPTION
I realized that we didn't have an example of evoked movement compensation in our docs. This adds one to the end of the simulation. It also fixes a tiny bug with the weight calculation. In testing it doesn't actually affect the values, but worth doing anyway.