### PR TITLE
DOC: update link to glasser supplementary info; convert to footbib

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -392,7 +392,7 @@
   url = {https://static-content.springer.com/esm/art%3A10.1038%2Fnature18933/MediaObjects/41586_2016_BFnature18933_MOESM330_ESM.pdf#page=2},
   journal = {Nature},
   number = {7615},
-  title = {Supplementary neuroanatomical results for “A multi-modal parcellation of human cerebral cortex”},
+  title = {Supplementary neuroanatomical results for “{A} multi-modal parcellation of human cerebral cortex”},
   volume = {536},
   year = {2016}
 }

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -376,7 +376,7 @@
   publisher={Elsevier}
 }
 
-@article{GlasserEtAl2016a,
+@article{GlasserEtAl2016,
   author = {Glasser, Matthew F. and Coalson, Timothy S. and Robinson, Emma C. and Hacker, Carl D. and Harwell, John and Yacoub, Essa and Ugurbil, Kamil and Andersson, Jesper and Beckmann, Christian F. and Jenkinson, Mark and Smith, Stephen M. and Van Essen, David C.},
   doi = {10.1038/nature18933},
   journal = {Nature},
@@ -387,7 +387,7 @@
   year = {2016}
 }
 
-@article{GlasserEtAl2016b,
+@article{GlasserEtAl2016supp,
   author = {Glasser, Matthew F. and Coalson, Timothy S. and Robinson, Emma C. and Hacker, Carl D. and Harwell, John and Yacoub, Essa and Ugurbil, Kamil and Andersson, Jesper and Beckmann, Christian F. and Jenkinson, Mark and Smith, Stephen M. and Van Essen, David C.},
   url = {https://static-content.springer.com/esm/art%3A10.1038%2Fnature18933/MediaObjects/41586_2016_BFnature18933_MOESM330_ESM.pdf#page=2},
   journal = {Nature},

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -376,13 +376,23 @@
   publisher={Elsevier}
 }
 
-@article{GlasserEtAl2016,
+@article{GlasserEtAl2016a,
   author = {Glasser, Matthew F. and Coalson, Timothy S. and Robinson, Emma C. and Hacker, Carl D. and Harwell, John and Yacoub, Essa and Ugurbil, Kamil and Andersson, Jesper and Beckmann, Christian F. and Jenkinson, Mark and Smith, Stephen M. and Van Essen, David C.},
   doi = {10.1038/nature18933},
   journal = {Nature},
   number = {7615},
   pages = {171-178},
-  title = {A Multi-Modal Parcellation of Human Cerebral Cortex},
+  title = {A multi-modal parcellation of human cerebral cortex},
+  volume = {536},
+  year = {2016}
+}
+
+@article{GlasserEtAl2016b,
+  author = {Glasser, Matthew F. and Coalson, Timothy S. and Robinson, Emma C. and Hacker, Carl D. and Harwell, John and Yacoub, Essa and Ugurbil, Kamil and Andersson, Jesper and Beckmann, Christian F. and Jenkinson, Mark and Smith, Stephen M. and Van Essen, David C.},
+  url = {https://static-content.springer.com/esm/art%3A10.1038%2Fnature18933/MediaObjects/41586_2016_BFnature18933_MOESM330_ESM.pdf#page=2},
+  journal = {Nature},
+  number = {7615},
+  title = {Supplementary neuroanatomical results for “A multi-modal parcellation of human cerebral cortex”},
   volume = {536},
   year = {2016}
 }

--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
   - https://github.com/numpy/numpydoc/archive/master.zip
   - imageio-ffmpeg>=0.4.1
   - vtk
-  - pyvista>=0.24
+  - pyvista==0.24
   - https://github.com/enthought/mayavi/archive/master.zip
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -651,8 +651,9 @@ def fetch_aparc_sub_parcellation(subjects_dir=None, verbose=None):
 def fetch_hcp_mmp_parcellation(subjects_dir=None, combine=True, verbose=None):
     """Fetch the HCP-MMP parcellation.
 
-    This will download and install the HCP-MMP parcellation [1]_ files for
-    FreeSurfer's fsaverage [2]_ to the specified directory.
+    This will download and install the HCP-MMP parcellation
+    :footcite:`GlasserEtAl2016a` files for FreeSurfer's fsaverage
+    :footcite:`Mills2016` to the specified directory.
 
     Parameters
     ----------
@@ -661,7 +662,7 @@ def fetch_hcp_mmp_parcellation(subjects_dir=None, combine=True, verbose=None):
         ``subjects_dir + '/fsaverage/label'``.
     combine : bool
         If True, also produce the combined/reduced set of 23 labels per
-        hemisphere as ``HCPMMP1_combined.annot`` [3]_.
+        hemisphere as ``HCPMMP1_combined.annot`` :footcite:`GlasserEtAl2016b`.
     %(verbose)s
 
     Notes
@@ -671,13 +672,8 @@ def fetch_hcp_mmp_parcellation(subjects_dir=None, combine=True, verbose=None):
 
     References
     ----------
-    .. [1] Glasser MF et al. (2016) A multi-modal parcellation of human
-           cerebral cortex. Nature 536:171-178.
-    .. [2] Mills K (2016) HCP-MMP1.0 projected on fsaverage.
-           https://figshare.com/articles/HCP-MMP1_0_projected_on_fsaverage/3498446/2
-    .. [3] Glasser MF et al. (2016) Supplemental information.
-           https://images.nature.com/full/nature-assets/nature/journal/v536/n7615/extref/nature18933-s3.pdf
-    """  # noqa: E501
+    .. footbibliography::
+    """
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
     destination = op.join(subjects_dir, 'fsaverage', 'label')
     fnames = [op.join(destination, '%s.HCPMMP1.annot' % hemi)

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -652,7 +652,7 @@ def fetch_hcp_mmp_parcellation(subjects_dir=None, combine=True, verbose=None):
     """Fetch the HCP-MMP parcellation.
 
     This will download and install the HCP-MMP parcellation
-    :footcite:`GlasserEtAl2016a` files for FreeSurfer's fsaverage
+    :footcite:`GlasserEtAl2016` files for FreeSurfer's fsaverage
     :footcite:`Mills2016` to the specified directory.
 
     Parameters
@@ -662,7 +662,8 @@ def fetch_hcp_mmp_parcellation(subjects_dir=None, combine=True, verbose=None):
         ``subjects_dir + '/fsaverage/label'``.
     combine : bool
         If True, also produce the combined/reduced set of 23 labels per
-        hemisphere as ``HCPMMP1_combined.annot`` :footcite:`GlasserEtAl2016b`.
+        hemisphere as ``HCPMMP1_combined.annot``
+        :footcite:`GlasserEtAl2016supp`.
     %(verbose)s
 
     Notes

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,5 @@ flake8
 https://github.com/mcmtroffaes/sphinxcontrib-bibtex/archive/29694f215b39d64a31b845aafd9ff2ae9329494f.zip
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1
-pyvista>=0.24
+pyvista==0.24
 tqdm


### PR DESCRIPTION
fixes a 404 link, and converts the docstring to use `footcite` while we're at it.