### PR TITLE
MRG, MAINT: Update dataset and add constant test

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -85,7 +85,7 @@ def pytest_configure(config):
     ignore:scipy\.gradient is deprecated.*:DeprecationWarning
     ignore:sklearn\.externals\.joblib is deprecated.*:FutureWarning
     ignore:The sklearn.*module.*deprecated.*:FutureWarning
-    ignore:.*TraitTuple.*trait.*handler.*deprecated.*:DeprecationWarning
+    ignore:.*trait.*handler.*deprecated.*:DeprecationWarning
     ignore:.*rich_compare.*metadata.*deprecated.*:DeprecationWarning
     ignore:.*In future, it will be an error for 'np.bool_'.*:DeprecationWarning
     ignore:.*Converting `np\.character` to a dtype is deprecated.*:DeprecationWarning

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -239,7 +239,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.87', misc='0.6')
+    releases = dict(testing='0.89', misc='0.6')
     # And also update the "md5_hashes['testing']" variable below.
 
     # To update any other dataset, update the data archive itself (upload
@@ -326,7 +326,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='12b75d1cb7df9dfb4ad73ed82f61094f',
         somato='ea825966c0a1e9b2f84e3826c5500161',
         spm='9f43f67150e3b694b523a21eb929ea75',
-        testing='a6e18de6405d84599c6d4dfb4c1d2b14',
+        testing='33c0ed664923acb2fee4737db6d02781',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         fnirs_motor='c4935d19ddab35422a69f3326a01fef8',
         opm='370ad1dcfd5c47e029e692c85358a374',

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -73,7 +73,7 @@ from pyface.api import (error, confirm, OK, YES, NO, CANCEL, information,
                         FileDialog, GUI)
 from traits.api import (Bool, Button, cached_property, DelegatesTo, Directory,
                         Enum, Float, HasTraits, HasPrivateTraits, Instance,
-                        Int, on_trait_change, Property, Str, List, RGBColor)
+                        Int, on_trait_change, Property, Str, List)
 from traitsui.api import (View, Item, Group, HGroup, VGroup, VGrid, EnumEditor,
                           Handler, Label, Spring, InstanceEditor, StatusItem,
                           UIInfo)
@@ -100,6 +100,11 @@ from ._viewer import (HeadViewController, PointObject, SurfaceObject,
                       _RESET_LABEL, _RESET_WIDTH,
                       laggy_float_editor_scale, laggy_float_editor_deg,
                       laggy_float_editor_mm, laggy_float_editor_weight)
+
+try:
+    from traitsui.api import RGBColor
+except ImportError:
+    from traits.api import RGBColor
 
 defaults = DEFAULTS['coreg']
 

--- a/mne/gui/_viewer.py
+++ b/mne/gui/_viewer.py
@@ -14,8 +14,7 @@ from mayavi.sources.vtk_data_source import VTKDataSource
 from mayavi.tools.mlab_scene_model import MlabSceneModel
 from traits.api import (HasTraits, HasPrivateTraits, on_trait_change,
                         Instance, Array, Bool, Button, Enum, Float, Int, List,
-                        Range, Str, RGBColor, Property, cached_property,
-                        ArrayOrNone)
+                        Range, Str, Property, cached_property, ArrayOrNone)
 from traitsui.api import (View, Item, HGroup, VGrid, VGroup, Spring,
                           TextEditor)
 from tvtk.api import tvtk
@@ -27,6 +26,10 @@ from ..utils import SilenceStdout
 from ..viz.backends._pysurfer_mayavi import (_create_mesh_surf,
                                              _toggle_mlab_render)
 
+try:
+    from traitsui.api import RGBColor
+except ImportError:
+    from traits.api import RGBColor
 
 headview_borders = VGroup(Item('headview', style='custom', show_label=False),
                           show_border=True, label='View')

--- a/mne/tests/test_defaults.py
+++ b/mne/tests/test_defaults.py
@@ -1,5 +1,7 @@
 from copy import deepcopy
 
+import numpy as np
+from numpy.testing import assert_allclose
 from mne.defaults import _handle_default
 
 
@@ -18,3 +20,63 @@ def test_handle_default():
             assert x[key] != z[key]
         else:
             assert x[key] == z[key]
+
+
+def test_si_units():
+    """Test that our scalings actually produce SI units."""
+    scalings = _handle_default('scalings', None)
+    units = _handle_default('units', None)
+    # Add a bad one to test that we actually detect it
+    assert 'csd_bad' not in scalings
+    scalings['csd_bad'] = 1e5
+    units['csd_bad'] = 'V/m²'
+    assert set(scalings) == set(units)
+    known_prefixes = {
+        '': 1,
+        'm': 1e-3,
+        'c': 1e-2,
+        'µ': 1e-6,
+        'n': 1e-9,
+        'f': 1e-15,
+    }
+    known_SI = {'V', 'T', 'Am', 'm', 'M',
+                'AU', 'GOF'}  # not really SI but we tolerate them
+    powers = '²'
+
+    def _split_si(x):
+        if x == 'nAm':
+            prefix, si = 'n', 'Am'
+        elif x == 'GOF':
+            prefix, si = '', 'GOF'
+        elif x == 'AU':
+            prefix, si = '', 'AU'
+        elif len(x) == 2:
+            if x[1] in powers:
+                prefix, si = '', x
+            else:
+                prefix, si = x
+        else:
+            assert len(x) in (0, 1), x
+            prefix, si = '', x
+        return prefix, si
+
+    for key, scale in scalings.items():
+        unit = units[key]
+        try:
+            num, denom = unit.split('/')
+        except ValueError:  # not enough to unpack
+            num, denom = unit, ''
+        # check the numerator and denominator
+        num_prefix, num_SI = _split_si(num)
+        assert num_prefix in known_prefixes
+        assert num_SI in known_SI
+        den_prefix, den_SI = _split_si(denom)
+        assert den_prefix in known_prefixes
+        if not (den_SI == den_prefix == ''):
+            assert den_SI.strip(powers) in known_SI
+        # reconstruct the scale factor
+        want_scale = known_prefixes[den_prefix] / known_prefixes[num_prefix]
+        if key in ('csd_bad', 'csd'):  # XXX CSD is wrong...
+            assert not np.isclose(scale, want_scale, rtol=10)
+        else:
+            assert_allclose(scale, want_scale, rtol=1e-12)


### PR DESCRIPTION
Keep things green:

1. Update `conftest.py` to deal with new traitsui deprecations that aren't in our code
2. Update some imports for latest traits/traitsui
3. Update testing dataset that is part of #7656 but not ready to be merged, needs to be updated for things like #7863 to further update the dataset
4. Adds SI unit test for `defaults` (showing it's currently wrong for CSD)