### PR TITLE
MRG, FIX: Fix get_channel_types

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -180,6 +180,10 @@ Bug
 
 - Fix bug with :func:`mne.bem.make_watershed_bem` where the RAS coordinates of watershed bem surfaces were not updated correctly from the volume file by `Yu-Han Luo`_
 
+- Fix bug with :meth:`mne.io.Raw.get_channel_types` and related methods where the ordering of ``picks`` was not preserved, by `Eric Larson`_
+
+- Fix bug with :meth:`mne.io.Raw.plot_psd` with ``average=False`` and multiple channel types where channel locations were not shown properly by `Eric Larson`_
+
 - Fix bug in FieldTrip reader functions when channels are missing in the ``info`` object by `Thomas Hartmann`_
 
 - Throw proper error when trying to import FieldTrip Epochs data with non-uniform time for trials by `Thomas Hartmann`_

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -1141,8 +1141,7 @@ def _get_channel_types(info, picks=None, unique=False, only_data_chs=False):
     """Get the data channel types in an info instance."""
     none = 'data' if only_data_chs else 'all'
     picks = _picks_to_idx(info, picks, none, (), allow_empty=False)
-    ch_types = [channel_type(info, idx) for idx in range(info['nchan'])
-                if idx in picks]
+    ch_types = [channel_type(info, pick) for pick in picks]
     if only_data_chs:
         ch_types = [ch_type for ch_type in ch_types
                     if ch_type in _DATA_CH_TYPES_SPLIT]


### PR DESCRIPTION
Fixes a bug with `plot_psd` that was introduced by #7486. Basically the order in `picks` was not preserved, which was required by `plot_raw_psd` when there are multiple channel types.

Closes #7837