### PR TITLE
MRG, ENH: Add method to project onto max power ori

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -235,6 +235,8 @@ API
 
 - The method ``stc_mixed.plot_surface`` for a :class:`mne.MixedSourceEstimate` has been deprecated in favor of :meth:`stc.surface().plot(...) <mne.MixedSourceEstimate.surface>` by `Eric Larson`_
 
+- The method ``stc.normal`` for :class:`mne.VectorSourceEstimate` has been deprecated in favor of :meth:`stc.project('nn', src) <mne.VectorSourceEstimate.project>` by `Eric Larson`_
+
 - Add ``use_dev_head_trans`` parameter to :func:`mne.preprocessing.annotate_movement` to allow choosing the device to head transform is used to define the fixed cHPI coordinates by `Luke Bloy`_
 
 - The function ``mne.channels.read_dig_captrack`` will be deprecated in version 0.22 in favor of :func:`mne.channels.read_dig_captrak` to correct the spelling error: "captraCK" -> "captraK", by `Stefan Appelhoff`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -27,7 +27,7 @@ Changelog
 
 - Add :meth:`mne.MixedSourceEstimate.surface` and :meth:`mne.MixedSourceEstimate.volume` methods to allow surface and volume extraction by `Eric Larson`_
 
-- Add :meth:`mne.VectorSourceEstimate.project_onto` to project vector source estimates onto the direction of maximum source power by `Eric Larson`_
+- Add :meth:`mne.VectorSourceEstimate.project` to project vector source estimates onto the direction of maximum source power by `Eric Larson`_
 
 - Add support to :func:`mne.extract_label_time_course` for vector-valued and volumetric source estimates by `Eric Larson`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -27,6 +27,8 @@ Changelog
 
 - Add :meth:`mne.MixedSourceEstimate.surface` and :meth:`mne.MixedSourceEstimate.volume` methods to allow surface and volume extraction by `Eric Larson`_
 
+- Add :meth:`mne.VectorSourceEstimate.project_onto` to project vector source estimates onto the direction of maximum source power by `Eric Larson`_
+
 - Add support to :func:`mne.extract_label_time_course` for vector-valued and volumetric source estimates by `Eric Larson`_
 
 - Add method :meth:`mne.VolSourceEstimate.in_label` by `Eric Larson`_

--- a/examples/inverse/plot_vector_mne_solution.py
+++ b/examples/inverse/plot_vector_mne_solution.py
@@ -56,7 +56,7 @@ brain = stc.plot(
 ###############################################################################
 # Plot the activation in the direction of maximal power for this data:
 
-stc_max, directions = stc.project_onto(directions=None, src=inv['src'])
+stc_max, directions = stc.project('pca', src=inv['src'])
 # These directions must by design be close to the normals because this
 # inverse was computed with loose=0.2:
 print('Absolute cosine similarity between source normals and directions: '
@@ -64,7 +64,7 @@ print('Absolute cosine similarity between source normals and directions: '
 brain_max = stc_max.plot(
     initial_time=peak_time, hemi='lh', subjects_dir=subjects_dir,
     time_label='Max power')
-brain_normal = stc.normal(inv['src']).plot(
+brain_normal = stc.project('normal', inv['src'])[0].plot(
     initial_time=peak_time, hemi='lh', subjects_dir=subjects_dir,
     time_label='Normal')
 

--- a/examples/inverse/plot_vector_mne_solution.py
+++ b/examples/inverse/plot_vector_mne_solution.py
@@ -21,6 +21,7 @@ you to get a better sense of the true underlying source geometry.
 #
 # License: BSD (3-clause)
 
+import numpy as np
 import mne
 from mne.datasets import sample
 from mne.minimum_norm import read_inverse_operator, apply_inverse
@@ -51,6 +52,21 @@ _, peak_time = stc.magnitude().get_peak(hemi='lh')
 # Plot the source estimate:
 brain = stc.plot(
     initial_time=peak_time, hemi='lh', subjects_dir=subjects_dir)
+
+###############################################################################
+# Plot the activation in the direction of maximal power for this data:
+
+stc_max, directions = stc.project_onto(directions=None, src=inv['src'])
+# These directions must by design be close to the normals because this
+# inverse was computed with loose=0.2:
+print('Absolute cosine similarity between source normals and directions: '
+      f'{np.abs(np.sum(directions * inv["source_nn"][2::3], axis=-1)).mean()}')
+brain_max = stc_max.plot(
+    initial_time=peak_time, hemi='lh', subjects_dir=subjects_dir,
+    time_label='Max power')
+brain_normal = stc.normal(inv['src']).plot(
+    initial_time=peak_time, hemi='lh', subjects_dir=subjects_dir,
+    time_label='Normal')
 
 ###############################################################################
 # You can also do this with a fixed-orientation inverse. It looks a lot like

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -350,7 +350,7 @@ def test_localization_bias_loose(bias_params_fixed, method, lower, upper,
         evoked, inv_loose, lambda2, method, pick_ori=pick_ori)
     if pick_ori is not None:
         assert loc.data.ndim == 3
-        loc, directions = loc.project_onto(src=fwd['src'])
+        loc, directions = loc.project('pca', src=fwd['src'])
         abs_cos_sim = np.abs(np.sum(
             directions * inv_loose['source_nn'][2::3], axis=1))
         assert np.percentile(abs_cos_sim, 10) > 0.9  # most very aligned
@@ -548,7 +548,7 @@ def test_orientation_prior(bias_params_free, method, looses, vmin, vmax,
         [_get_src_nn(s) for s in inv['src']]))
     vec_stc_surf = np.matmul(rot, vec_stc.data)
     if 0. in looses:
-        vec_stc_normal = vec_stc.normal(inv['src'])
+        vec_stc_normal, _ = vec_stc.project('normal', inv['src'])
         assert_allclose(stcs[1].data, vec_stc_normal.data)
         del vec_stc
         assert_allclose(vec_stc_normal.data, vec_stc_surf[:, 2])
@@ -1078,8 +1078,9 @@ def test_inverse_mixed(all_src_types_inv_evoked):
                         stcs[kind].magnitude().data)
         assert_allclose(getattr(stcs['mixed'], kind)().magnitude().data,
                         stcs[kind].magnitude().data)
-    assert_allclose(stcs['mixed'].surface().normal(surf_src).data,
-                    stcs['surface'].normal(surf_src).data)
+    with pytest.deprecated_call():
+        assert_allclose(stcs['mixed'].surface().normal(surf_src).data,
+                        stcs['surface'].normal(surf_src).data)
 
 
 run_tests_if_main()

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1814,6 +1814,7 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
                             zip(src, self.vertices)])
         return normals
 
+    @fill_doc
     def project_onto(self, directions=None, src=None, use_cps=True):
         """Project the data for each vertex in a given direction.
 
@@ -1860,7 +1861,7 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
             # The sign is arbitrary, so let's flip it in the direction that
             # makes the resulting time series the most positive:
             if src is None:
-                signs = np.sum(v[:, 0], axis=1, keepdims=True)
+                signs = np.sum(v[:, 0].real, axis=1, keepdims=True)
             else:
                 normals = self._get_src_normals(src, use_cps)
                 signs = np.sum(directions * normals, axis=1, keepdims=True)

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1819,7 +1819,7 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
 
         Parameters
         ----------
-        directions : ndarray, shape (n_src, 3) | None
+        directions : ndarray, shape (n_vertices, 3) | None
             If None, SVD will be used to project onto the direction of
             maximal power.
         src : instance of SourceSpaces | None
@@ -1832,7 +1832,7 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
         -------
         stc : instance of SourceEstimate
             The projected source estimate.
-        normals : ndarray, shape (n_src, 3)
+        normals : ndarray, shape (n_vertices, 3)
             Only returned if ``normals is None``, the normals computed
             using SVD.
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1785,6 +1785,8 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
             data_mag, self.vertices, self.tmin, self.tstep, self.subject,
             self.verbose)
 
+    @deprecated('stc.normal(src) is deprecated and will be removed in 0.22, '
+                'use stc.project("normal", src)[0] instead')
     @fill_doc
     def normal(self, src, use_cps=True):
         """Compute activity orthogonal to the cortex.
@@ -1805,9 +1807,7 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
             The source estimate only retaining the activity orthogonal to the
             cortex.
         """
-        _check_src_normal('normal', src)
-        normals = self._get_src_normals(src, use_cps)
-        return self.project_onto(normals)
+        return self.project('normal', src, use_cps)[0]
 
     def _get_src_normals(self, src, use_cps):
         normals = np.vstack([_get_src_nn(s, use_cps, v) for s, v in
@@ -1815,16 +1815,25 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
         return normals
 
     @fill_doc
-    def project_onto(self, directions=None, src=None, use_cps=True):
+    def project(self, directions, src=None, use_cps=True):
         """Project the data for each vertex in a given direction.
 
         Parameters
         ----------
-        directions : ndarray, shape (n_vertices, 3) | None
-            If None, SVD will be used to project onto the direction of
-            maximal power.
+        directions : ndarray, shape (n_vertices, 3) | str
+            Can be:
+
+            - ``'normal'``
+                Project onto the source space normals.
+            - ``'pca'``
+                SVD will be used to project onto the direction of maximal
+                power for each source.
+            - :class:`~numpy.ndarray`, shape (n_vertices, 3)
+                Projection directions for each source.
         src : instance of SourceSpaces | None
-            Only used when ``directions is None``. See Notes.
+            The source spaces corresponding to the source estimate.
+            Not used when ``directions`` is an array, optional when
+            ``directions='pca'``.
         %(use_cps)s
             Should be the same value that was used when the forward model
             was computed (typically True).
@@ -1833,9 +1842,8 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
         -------
         stc : instance of SourceEstimate
             The projected source estimate.
-        normals : ndarray, shape (n_vertices, 3)
-            Only returned if ``normals is None``, the normals computed
-            using SVD.
+        directions : ndarray, shape (n_vertices, 3)
+            The directions that were computed (or just used).
 
         Notes
         -----
@@ -1848,39 +1856,48 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
 
         .. versionadded:: 0.21
         """
-        if directions is None:
-            x = self.data
-            if not np.isrealobj(self.data):
-                _check_option('stc.data.dtype', self.data.dtype,
-                              (np.complex64, np.complex128))
-                dtype = np.float32 if x.dtype == np.complex64 else np.float64
-                x = x.view(dtype)
-                assert x.shape[-1] == 2 * self.data.shape[-1]
-            u, _, v = np.linalg.svd(x, full_matrices=False)
-            directions = u[:, :, 0]
-            # The sign is arbitrary, so let's flip it in the direction that
-            # makes the resulting time series the most positive:
-            if src is None:
-                signs = np.sum(v[:, 0].real, axis=1, keepdims=True)
+        _validate_type(directions, (str, np.ndarray), 'directions')
+        _validate_type(src, (None, SourceSpaces), 'src')
+        if isinstance(directions, str):
+            _check_option('directions', directions, ('normal', 'pca'),
+                          extra='when str')
+
+            if directions == 'normal':
+                if src is None:
+                    raise ValueError(
+                        'If directions="normal", src cannot be None')
+                _check_src_normal('normal', src)
+                directions = self._get_src_normals(src, use_cps)
             else:
-                normals = self._get_src_normals(src, use_cps)
-                signs = np.sum(directions * normals, axis=1, keepdims=True)
-            assert signs.shape == (self.data.shape[0], 1)
-            signs = np.sign(signs)
-            signs[signs == 0] = 1.
-            directions *= signs
-            return_directions = True
-        else:
-            return_directions = False
+                assert directions == 'pca'
+                x = self.data
+                if not np.isrealobj(self.data):
+                    _check_option('stc.data.dtype', self.data.dtype,
+                                  (np.complex64, np.complex128))
+                    dtype = \
+                        np.float32 if x.dtype == np.complex64 else np.float64
+                    x = x.view(dtype)
+                    assert x.shape[-1] == 2 * self.data.shape[-1]
+                u, _, v = np.linalg.svd(x, full_matrices=False)
+                directions = u[:, :, 0]
+                # The sign is arbitrary, so let's flip it in the direction that
+                # makes the resulting time series the most positive:
+                if src is None:
+                    signs = np.sum(v[:, 0].real, axis=1, keepdims=True)
+                else:
+                    normals = self._get_src_normals(src, use_cps)
+                    signs = np.sum(directions * normals, axis=1, keepdims=True)
+                assert signs.shape == (self.data.shape[0], 1)
+                signs = np.sign(signs)
+                signs[signs == 0] = 1.
+                directions *= signs
         _check_option(
-            'normals.shape', directions.shape, [(self.data.shape[0], 3)])
+            'directions.shape', directions.shape, [(self.data.shape[0], 3)])
         data_norm = np.matmul(directions[:, np.newaxis], self.data)[:, 0]
-        out = self._scalar_class(
+        stc = self._scalar_class(
             data_norm, self.vertices, self.tmin, self.tstep, self.subject,
             self.verbose)
-        if return_directions:
-            out = (out, directions)
-        return out
+        return stc, directions
 
 
 class _BaseVolSourceEstimate(_BaseSourceEstimate):

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -17,7 +17,6 @@ from scipy.sparse import coo_matrix, block_diag as sparse_block_diag
 from .cov import Covariance
 from .evoked import _get_peak
 from .filter import resample
-from .fixes import einsum
 from .io.constants import FIFF
 from .surface import read_surface, _get_ico_surface, mesh_edges
 from .source_space import (_ensure_src, _get_morph_src_reordering,

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -1129,7 +1129,7 @@ def test_vec_stc_basic(tmpdir, klass, kind, dtype):
         [0, 1, 0],
         [np.sqrt(1. / 2.), 0, np.sqrt(1. / 2.)],
         [np.sqrt(1 / 3.)] * 3
-    ], dtype)
+    ], np.float32)
 
     data = np.array([
         [1, 0, 0],

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -11,6 +11,7 @@ from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose, assert_equal)
 import pytest
 from scipy import sparse
+from scipy.optimize import fmin_cobyla
 
 from mne import (stats, SourceEstimate, VectorSourceEstimate,
                  VolSourceEstimate, Label, read_source_spaces,
@@ -1119,23 +1120,32 @@ def test_mixed_stc(tmpdir):
     (VolVectorSourceEstimate, 'discrete'),
     (MixedVectorSourceEstimate, 'mixed'),
 ])
-def test_vec_stc_basic(tmpdir, klass, kind):
+@pytest.mark.parametrize('dtype', [
+    np.float32, np.float64, np.complex64, np.complex128])
+def test_vec_stc_basic(tmpdir, klass, kind, dtype):
     """Test (vol)vector source estimate."""
     nn = np.array([
         [1, 0, 0],
         [0, 1, 0],
-        [0, 0, 1],
+        [np.sqrt(1. / 2.), 0, np.sqrt(1. / 2.)],
         [np.sqrt(1 / 3.)] * 3
-    ])
+    ], dtype)
 
     data = np.array([
         [1, 0, 0],
         [0, 2, 0],
-        [3, 0, 0],
+        [-3, 0, 0],
         [1, 1, 1],
-    ])[:, :, np.newaxis]
-    magnitudes = np.linalg.norm(data, axis=1)[:, 0]
-    normals = np.array([1, 2, 0, np.sqrt(3)])
+    ], dtype)[:, :, np.newaxis]
+    amplitudes = np.array([1, 2, 3, np.sqrt(3)], dtype)
+    magnitudes = amplitudes.copy()
+    normals = np.array([1, 2, -3. / np.sqrt(2), np.sqrt(3)], dtype)
+    if dtype in (np.complex64, np.complex128):
+        data *= 1j
+        amplitudes *= 1j
+        normals *= 1j
+    directions = np.array(
+        [[1, 0, 0], [0, 1, 0], [-1, 0, 0], [1. / np.sqrt(3)] * 3])
     vol_kind = kind if kind in ('discrete', 'vol') else 'vol'
     vol_src = SourceSpaces([dict(nn=nn, type=vol_kind)])
     assert vol_src.kind == dict(vol='volume').get(vol_kind, vol_kind)
@@ -1155,12 +1165,16 @@ def test_vec_stc_basic(tmpdir, klass, kind):
         verts = surf_verts + vol_verts
         assert src.kind == 'mixed'
         data = np.tile(data, (2, 1, 1))
+        amplitudes = np.tile(amplitudes, 2)
         magnitudes = np.tile(magnitudes, 2)
         normals = np.tile(normals, 2)
+        directions = np.tile(directions, (2, 1))
     stc = klass(data, verts, 0, 1, 'foo')
+    amplitudes = amplitudes[:, np.newaxis]
+    magnitudes = magnitudes[:, np.newaxis]
 
     # Magnitude of the vectors
-    assert_array_equal(stc.magnitude().data[:, 0], magnitudes)
+    assert_array_equal(stc.magnitude().data, magnitudes)
 
     # Vector components projected onto the vertex normals
     if kind in ('vol', 'mixed'):
@@ -1168,7 +1182,18 @@ def test_vec_stc_basic(tmpdir, klass, kind):
             stc.normal(src)
     else:
         normal = stc.normal(src)
-        assert_array_equal(normal.data[:, 0], normals)
+        assert_allclose(normal.data[:, 0], normals)
+
+    # Maximal-variance component, either to keep amps pos or to align to src-nn
+    projected, got_directions = stc.project_onto(None)
+    assert_allclose(got_directions, directions)
+    assert_allclose(projected.data, amplitudes)
+    projected, got_directions = stc.project_onto(None, src)
+    flips = np.array([[1], [1], [-1.], [1]])
+    if klass is MixedVectorSourceEstimate:
+        flips = np.tile(flips, (2, 1))
+    assert_allclose(got_directions, directions * flips)
+    assert_allclose(projected.data, amplitudes * flips)
 
     out_name = tmpdir.join('temp.h5')
     stc.save(out_name)
@@ -1186,6 +1211,37 @@ def test_vec_stc_basic(tmpdir, klass, kind):
     data = data[:, :, np.newaxis]
     with pytest.raises(ValueError, match='3 dimensions for .*VectorSource'):
         klass(data, verts, 0, 1)
+
+
+@pytest.mark.parametrize('real', (True, False))
+def test_source_estime_project_onto(real):
+    """Test projecting a source estimate onto direction of max power."""
+    n_src, n_times = 4, 100
+    rng = np.random.RandomState(0)
+    data = rng.randn(n_src, 3, n_times)
+    if not real:
+        data = data + 1j * rng.randn(n_src, 3, n_times)
+        assert data.dtype == np.complex128
+    else:
+        assert data.dtype == np.float64
+
+    # Make sure that the normal we get maximizes the power
+    # (i.e., minimizes the negative power)
+    want_nn = np.empty((n_src, 3))
+    for ii in range(n_src):
+        x0 = np.ones(3)
+
+        def objective(x):
+            x = x / np.linalg.norm(x)
+            return -np.linalg.norm(np.dot(x, data[ii]))
+        want_nn[ii] = fmin_cobyla(objective, x0, (), rhobeg=0.1, rhoend=1e-6)
+    want_nn /= np.linalg.norm(want_nn, axis=1, keepdims=True)
+
+    stc = VolVectorSourceEstimate(data, [np.arange(n_src)], 0, 1)
+    stc_max, directions = stc.project_onto()
+    flips = np.sign(np.sum(directions * want_nn, axis=1, keepdims=True))
+    directions *= flips
+    assert_allclose(directions, want_nn, atol=1e-6)
 
 
 @pytest.fixture(scope='module', params=[testing._pytest_param()])

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -557,11 +557,11 @@ def _check_option(parameter, value, allowed_values, extra=''):
            '{options}, but got {value!r} instead.')
     allowed_values = list(allowed_values)  # e.g., if a dict was given
     if len(allowed_values) == 1:
-        options = f'The only allowed value is {allowed_values[0]}'
+        options = f'The only allowed value is {repr(allowed_values[0])}'
     else:
         options = 'Allowed values are '
-        options += ', '.join([f'{v}' for v in allowed_values[:-1]])
-        options += f' and {allowed_values[-1]}'
+        options += ', '.join([f'{repr(v)}' for v in allowed_values[:-1]])
+        options += f' and {repr(allowed_values[-1])}'
     raise ValueError(msg.format(parameter=parameter, options=options,
                                 value=value, extra=extra))
 

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -557,11 +557,11 @@ def _check_option(parameter, value, allowed_values, extra=''):
            '{options}, but got {value!r} instead.')
     allowed_values = list(allowed_values)  # e.g., if a dict was given
     if len(allowed_values) == 1:
-        options = 'The only allowed value is %r' % allowed_values[0]
+        options = f'The only allowed value is {allowed_values[0]}'
     else:
         options = 'Allowed values are '
-        options += ', '.join(['%r' % v for v in allowed_values[:-1]])
-        options += ' and %r' % allowed_values[-1]
+        options += ', '.join([f'{v}' for v in allowed_values[:-1]])
+        options += f' and {allowed_values[-1]}'
     raise ValueError(msg.format(parameter=parameter, options=options,
                                 value=value, extra=extra))
 


### PR DESCRIPTION
Useful for:

1. Converting `pick_ori='vector'` solutions to max-power-ori solutions
2. Eventually for `unit-noise-gain` vector beamformers we'll want to do this (probably)

In the beamformer PR, we can also check to see the extent to which `pick_ori='max-power'` agrees with `pick_ori='vector'` followed by `stc.project_onto()`.