### PR TITLE
Website contents

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -64,7 +64,7 @@ Or, switch to documentation for the <a href="https://mne.tools/stable">current s
 {% endblock %}
 
 {# put the sidebar before the body #}
-{% block sidebar1 %}{{ sidebar() }}{% endblock %}
+{% block sidebar1 %}{% endblock %}
 {% block sidebar2 %}{% endblock %}
 
 {%- block footer %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -325,7 +325,7 @@ intersphinx_mapping = {
     # There are some problems with dipy's redirect:
     # https://github.com/nipy/dipy/issues/1955
     'dipy': ('https://dipy.org/documentation/latest',
-             'https://dipy.org/documentation/1.0.0./objects.inv/'),
+             'https://dipy.org/documentation/1.1.1./objects.inv/'),
     'mne_realtime': ('https://mne.tools/mne-realtime', None),
     'picard': ('https://pierreablin.github.io/picard/', None),
 }

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -53,7 +53,7 @@
           <li style="background: url('_static/funding/cds.png') no-repeat left top; background-size: 24px 24px;"><b>Paris-Saclay Center for Data Science:</b> <a href="http://www.datascience-paris-saclay.fr"/>PARIS-SACLAY</a></li>
           <li style="background: url('_static/funding/google.svg') no-repeat left top; background-size: 24px 24px;"><b>Google:</b> Summer of code (×6)</li>
           <li style="background: url('_static/funding/amazon.svg') no-repeat left top; background-size: 24px 24px;"><b>Amazon:</b> - AWS Research Grants</li>
-          <li style="background: url('_static/funding/czi.svg') no-repeat left top; background-size: 24px 24px;"><b>Chan Zuckerberg Initiative:</b> - <a href="https://chanzuckerberg.com/eoss/proposals/improving-usability-of-core-neuroscience-analysis-tools-with-mne-python/">Essential Open Source Software for Science</a></li>
+          <li style="background: url('_static/funding/czi.svg') no-repeat left top; background-size: 24px 24px;"><b>Chan Zuckerberg Initiative:</b> <a href="https://chanzuckerberg.com/eoss/proposals/improving-usability-of-core-neuroscience-analysis-tools-with-mne-python/">Essential Open Source Software for Science</a></li>
         </ul>
       </div>
     </div>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -52,7 +52,7 @@
           <li style="background: url('_static/funding/anr.svg') no-repeat left top; background-size: 24px 10px;"><b>Agence Nationale de la Recherche:</b> 14-NEUC-0002-01<br><b>IDEX</b> Paris-Saclay, 11-IDEX-0003-02</li>
           <li style="background: url('_static/funding/cds.png') no-repeat left top; background-size: 24px 24px;"><b>Paris-Saclay Center for Data Science:</b> <a href="http://www.datascience-paris-saclay.fr"/>PARIS-SACLAY</a></li>
           <li style="background: url('_static/funding/google.svg') no-repeat left top; background-size: 24px 24px;"><b>Google:</b> Summer of code (×6)</li>
-          <li style="background: url('_static/funding/amazon.svg') no-repeat left top; background-size: 24px 24px;"><b>Amazon:</b> - AWS Research Grants</li>
+          <li style="background: url('_static/funding/amazon.svg') no-repeat left top; background-size: 24px 24px;"><b>Amazon:</b> AWS Research Grants</li>
           <li style="background: url('_static/funding/czi.svg') no-repeat left top; background-size: 24px 24px;"><b>Chan Zuckerberg Initiative:</b> <a href="https://chanzuckerberg.com/eoss/proposals/improving-usability-of-core-neuroscience-analysis-tools-with-mne-python/">Essential Open Source Software for Science</a></li>
         </ul>
       </div>


### PR DESCRIPTION
closes #7885 

also updates dipy intersphinx redirect to current release (problem still exists), and removes a spurious dash in the CZI entry of the funders box.