### PR TITLE
MRG: Extract measurement date and age for NIRX files

### DIFF
--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -122,13 +122,14 @@ class RawNIRX(BaseRaw):
         datetime_str = hdr['GeneralInfo']['Date'] + hdr['GeneralInfo']['Time']
         meas_date = None
         # Several formats have been observed so we try each in turn
-        try:
-            for dt_code in ['"%a, %b %d, %Y""%H:%M:%S.%f"', '"%a, %d %b %Y""%H:%M:%S.%f"']:
+        for dt_code in ['"%a, %b %d, %Y""%H:%M:%S.%f"',
+                        '"%a, %d %b %Y""%H:%M:%S.%f"']:
+            try:
                 meas_date = dt.datetime.strptime(datetime_str, dt_code)
                 meas_date = meas_date.replace(tzinfo=dt.timezone.utc)
                 break
-        except ValueError:
-            pass
+            except ValueError:
+                pass
         if meas_date is None:
             warn("Extraction of measurement date from NIRX file failed. "
                  "This can be caused by files saved in certain locales. "

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -246,10 +246,10 @@ class RawNIRX(BaseRaw):
         req_ind = req_ind.astype(int)
 
         # Generate meaningful channel names
-        def prepend(list, str):
+        def prepend(l, str):
             str += '{0}'
-            list = [str.format(i) for i in list]
-            return list
+            l = [str.format(i) for i in l]
+            return l
 
         snames = prepend(sources[req_ind], 'S')
         dnames = prepend(detectors[req_ind], '_D')

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -7,7 +7,6 @@ import glob as glob
 import re as re
 import os.path as op
 import datetime as dt
-import locale
 
 import numpy as np
 

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -123,15 +123,10 @@ class RawNIRX(BaseRaw):
         meas_date = None
         # Several formats have been observed so we try each in turn
         try:
-            dt_code = '"%a, %b %d, %Y""%H:%M:%S.%f"'
-            meas_date = dt.datetime.strptime(datetime_str, dt_code)
-            meas_date = meas_date.replace(tzinfo=dt.timezone.utc)
-        except ValueError:
-            pass
-        try:
-            dt_code = '"%a, %d %b %Y""%H:%M:%S.%f"'
-            meas_date = dt.datetime.strptime(datetime_str, dt_code)
-            meas_date = meas_date.replace(tzinfo=dt.timezone.utc)
+            for dt_code in ['"%a, %b %d, %Y""%H:%M:%S.%f"', '"%a, %d %b %Y""%H:%M:%S.%f"']:
+                meas_date = dt.datetime.strptime(datetime_str, dt_code)
+                meas_date = meas_date.replace(tzinfo=dt.timezone.utc)
+                break
         except ValueError:
             pass
         if meas_date is None:

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -253,7 +253,7 @@ class RawNIRX(BaseRaw):
         def prepend(list, str):
             str += '{0}'
             list = [str.format(i) for i in list]
-            return (list)
+            return list
 
         snames = prepend(sources[req_ind], 'S')
         dnames = prepend(detectors[req_ind], '_D')

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -246,10 +246,10 @@ class RawNIRX(BaseRaw):
         req_ind = req_ind.astype(int)
 
         # Generate meaningful channel names
-        def prepend(l, str):
+        def prepend(li, str):
             str += '{0}'
-            l = [str.format(i) for i in l]
-            return l
+            li = [str.format(i) for i in li]
+            return li
 
         snames = prepend(sources[req_ind], 'S')
         dnames = prepend(detectors[req_ind], '_D')

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -6,6 +6,7 @@
 import os.path as op
 import shutil
 import os
+import datetime as dt
 
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
@@ -79,12 +80,8 @@ def test_nirx_15_2_short():
     # Test data import
     assert raw._data.shape == (26, 145)
     assert raw.info['sfreq'] == 12.5
-    assert raw.info['meas_date'].month == 8
-    assert raw.info['meas_date'].day == 23
-    assert raw.info['meas_date'].year == 2019
-    assert raw.info['meas_date'].hour == 7
-    assert raw.info['meas_date'].minute == 37
-    assert raw.info['meas_date'].second == 4
+    assert raw.info['meas_date'] == dt.datetime(2019, 8, 23, 7, 37, 4, 540000,
+                                                tzinfo=dt.timezone.utc)
 
     # Test channel naming
     assert raw.info['ch_names'][:4] == ["S1_D1 760", "S1_D1 850",
@@ -278,12 +275,8 @@ def test_nirx_15_2():
     # Test data import
     assert raw._data.shape == (64, 67)
     assert raw.info['sfreq'] == 3.90625
-    assert raw.info['meas_date'].month == 10
-    assert raw.info['meas_date'].day == 2
-    assert raw.info['meas_date'].year == 2019
-    assert raw.info['meas_date'].hour == 9
-    assert raw.info['meas_date'].minute == 8
-    assert raw.info['meas_date'].second == 47
+    assert raw.info['meas_date'] == dt.datetime(2019, 10, 2, 9, 8, 47, 511000,
+                                                tzinfo=dt.timezone.utc)
 
     # Test channel naming
     assert raw.info['ch_names'][:4] == ["S1_D1 760", "S1_D1 850",
@@ -330,12 +323,9 @@ def test_nirx_15_0():
     # Test data import
     assert raw._data.shape == (20, 92)
     assert raw.info['sfreq'] == 6.25
-    assert raw.info['meas_date'].month == 10
-    assert raw.info['meas_date'].day == 27
-    assert raw.info['meas_date'].year == 2019
-    assert raw.info['meas_date'].hour == 13
-    assert raw.info['meas_date'].minute == 53
-    assert raw.info['meas_date'].second == 34
+    assert raw.info['meas_date'] == dt.datetime(2019, 10, 27, 13, 53, 34,
+                                                209000,
+                                                tzinfo=dt.timezone.utc)
 
     # Test channel naming
     assert raw.info['ch_names'][:12] == ["S1_D1 760", "S1_D1 850",

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -79,6 +79,12 @@ def test_nirx_15_2_short():
     # Test data import
     assert raw._data.shape == (26, 145)
     assert raw.info['sfreq'] == 12.5
+    assert raw.info['meas_date'].month == 8
+    assert raw.info['meas_date'].day == 23
+    assert raw.info['meas_date'].year == 2019
+    assert raw.info['meas_date'].hour == 7
+    assert raw.info['meas_date'].minute == 37
+    assert raw.info['meas_date'].second == 4
 
     # Test channel naming
     assert raw.info['ch_names'][:4] == ["S1_D1 760", "S1_D1 850",
@@ -92,7 +98,8 @@ def test_nirx_15_2_short():
     # Test info import
     assert raw.info['subject_info'] == dict(sex=1, first_name="MNE",
                                             middle_name="Test",
-                                            last_name="Recording")
+                                            last_name="Recording",
+                                            birthday=(2014, 8, 23))
 
     # Test distance between optodes matches values from
     # nirsite https://github.com/mne-tools/mne-testing-data/pull/51
@@ -179,8 +186,10 @@ def test_nirx_15_3_short():
     assert raw.info['chs'][1]['loc'][9] == 850
 
     # Test info import
-    assert raw.info['subject_info'] == dict(
-        sex=0, first_name="testMontage\\0ATestMontage")
+    assert raw.info['subject_info'] == dict(birthday=(2020, 8, 18),
+                                            sex=0,
+                                            first_name="testMontage\\0A"
+                                                       "TestMontage")
 
     # Test distance between optodes matches values from
     # https://github.com/mne-tools/mne-testing-data/pull/72
@@ -257,7 +266,8 @@ def test_encoding(tmpdir):
         for line in hdr:
             fid.write(line)
     # smoke test
-    read_raw_nirx(fname)
+    with pytest.raises(RuntimeWarning, match='Extraction of measurement date'):
+        read_raw_nirx(fname)
 
 
 @requires_testing_data
@@ -268,16 +278,24 @@ def test_nirx_15_2():
     # Test data import
     assert raw._data.shape == (64, 67)
     assert raw.info['sfreq'] == 3.90625
+    assert raw.info['meas_date'].month == 10
+    assert raw.info['meas_date'].day == 2
+    assert raw.info['meas_date'].year == 2019
+    assert raw.info['meas_date'].hour == 9
+    assert raw.info['meas_date'].minute == 8
+    assert raw.info['meas_date'].second == 47
 
     # Test channel naming
     assert raw.info['ch_names'][:4] == ["S1_D1 760", "S1_D1 850",
                                         "S1_D10 760", "S1_D10 850"]
 
     # Test info import
-    assert raw.info['subject_info'] == dict(sex=1, first_name="TestRecording")
+    assert raw.info['subject_info'] == dict(sex=1, first_name="TestRecording",
+                                            birthday=(1989, 10, 2))
 
     # Test trigger events
     assert_array_equal(raw.annotations.description, ['4.0', '6.0', '2.0'])
+    print(raw.annotations.onset)
 
     # Test location of detectors
     allowed_dist_error = 0.0002
@@ -312,6 +330,12 @@ def test_nirx_15_0():
     # Test data import
     assert raw._data.shape == (20, 92)
     assert raw.info['sfreq'] == 6.25
+    assert raw.info['meas_date'].month == 10
+    assert raw.info['meas_date'].day == 27
+    assert raw.info['meas_date'].year == 2019
+    assert raw.info['meas_date'].hour == 13
+    assert raw.info['meas_date'].minute == 53
+    assert raw.info['meas_date'].second == 34
 
     # Test channel naming
     assert raw.info['ch_names'][:12] == ["S1_D1 760", "S1_D1 850",
@@ -322,7 +346,8 @@ def test_nirx_15_0():
                                          "S6_D6 760", "S6_D6 850"]
 
     # Test info import
-    assert raw.info['subject_info'] == {'first_name': 'NIRX',
+    assert raw.info['subject_info'] == {'birthday': (2004, 10, 27),
+                                        'first_name': 'NIRX',
                                         'last_name': 'Test',
                                         'sex': FIFF.FIFFV_SUBJ_SEX_UNKNOWN}
 


### PR DESCRIPTION
#### What does this implement/fix?
Extract measurement date and birthday for NIRX files.


#### Additional information
The vendor software only allows saving of age as an integer. So I have taken the measurement date, subtracted the age integer from the years, and stored that as the birthday. Open to alternative suggestions.
