### PR TITLE
Fix _auto_topomap_coords docstring.

### DIFF
--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -637,7 +637,7 @@ def _auto_topomap_coords(info, picks, ignore_overlap, to_sphere, sphere):
         positions overlap, an error is thrown.
     to_sphere : bool
         If True, the radial distance of spherical coordinates is ignored, in
-        effect fitting the xyz-coordinates to a sphere. Defaults to True.
+        effect fitting the xyz-coordinates to a sphere.
     sphere : array-like | str
         The head sphere definition.
 


### PR DESCRIPTION
#### Reference issue
Example: Fixes #7893.


#### What does this implement/fix?
Fix ` _auto_topomap_coords docstring` doctring.
