### PR TITLE
MRG: Warn if NIRX directory structure has been modified from original format

### DIFF
--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -15,6 +15,7 @@ from ..meas_info import create_info, _format_dig_points
 from ...annotations import Annotations
 from ...transforms import apply_trans, _get_trans
 from ...utils import logger, verbose, fill_doc
+from ...utils import warn
 
 
 @fill_doc
@@ -71,7 +72,7 @@ class RawNIRX(BaseRaw):
 
         # Check if required files exist and store names for later use
         files = dict()
-        keys = ('dat', 'evt', 'hdr', 'inf', 'set', 'tpl', 'wl1', 'wl2',
+        keys = ('evt', 'hdr', 'inf', 'set', 'tpl', 'wl1', 'wl2',
                 'config.txt', 'probeInfo.mat')
         for key in keys:
             files[key] = glob.glob('%s/*%s' % (fname, key))
@@ -79,6 +80,11 @@ class RawNIRX(BaseRaw):
                 raise RuntimeError('Expect one %s file, got %d' %
                                    (key, len(files[key]),))
             files[key] = files[key][0]
+        if len(glob.glob('%s/*%s' % (fname, 'dat'))) != 1:
+            warn("A single dat file was expected in the specified path, but "
+                 "got %d. This may indicate that the file structure has been "
+                 "modified since the measurement was saved." %
+                 (len(glob.glob('%s/*%s' % (fname, 'dat')))))
 
         # Read number of rows/samples of wavelength data
         last_sample = -1

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -5,6 +5,7 @@
 
 import os.path as op
 import shutil
+import os
 
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
@@ -34,6 +35,17 @@ def test_nirx_hdr_load():
     # Test data import
     assert raw._data.shape == (26, 145)
     assert raw.info['sfreq'] == 12.5
+
+
+@requires_testing_data
+def test_nirx_dat_warn(tmpdir):
+    """Test reading NIRX files when missing data."""
+    shutil.copytree(fname_nirx_15_2_short, str(tmpdir) + "/data/")
+    os.rename(str(tmpdir) + "/data" + "/NIRS-2019-08-23_001.dat",
+              str(tmpdir) + "/data" + "/NIRS-2019-08-23_001.tmp")
+    fname = str(tmpdir) + "/data" + "/NIRS-2019-08-23_001.hdr"
+    with pytest.raises(RuntimeWarning, match='A single dat'):
+        read_raw_nirx(fname, preload=True)
 
 
 @requires_testing_data


### PR DESCRIPTION
#### Reference issue
Fixes #7894. @Swy7ch noted that the NIRX file reader checks for a dat file, but it is not used.

#### What does this implement/fix?
Instead of failing if the `.dat` is missing this now throws a warning to the user that the file structure has been modified from what the measurement machine saved.


#### Additional information
We have had some discussion about what the correct behaviour is. See the above linked issue for discussion.