### PR TITLE
MRG: Pin pyvista to 0.24.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
   - https://github.com/numpy/numpydoc/archive/master.zip
   - imageio-ffmpeg>=0.4.1
   - vtk
-  - pyvista==0.24
+  - pyvista==0.24.3
   - https://github.com/enthought/mayavi/archive/master.zip
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,5 @@ flake8
 https://github.com/mcmtroffaes/sphinxcontrib-bibtex/archive/29694f215b39d64a31b845aafd9ff2ae9329494f.zip
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1
-pyvista==0.24
+pyvista==0.24.3
 tqdm


### PR DESCRIPTION
This PR follows https://github.com/mne-tools/mne-python/pull/7791#issuecomment-643749902 and is a step forward towards full migration to `pyvista 0.25` (work in progress in https://github.com/mne-tools/mne-python/pull/7791) while (hopefully) making the CIs green on `master`