### PR TITLE
MRG, MAINT: Check usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,10 +105,10 @@ flake:
 	@echo "flake8 passed"
 
 codespell:  # running manually
-	@codespell --builtin clear,rare,informal,names -w -i 3 -q 3 -S $(CODESPELL_SKIPS) --ignore-words=ignore_words.txt $(CODESPELL_DIRS)
+	@codespell --builtin clear,rare,informal,names,usage -w -i 3 -q 3 -S $(CODESPELL_SKIPS) --ignore-words=ignore_words.txt $(CODESPELL_DIRS)
 
 codespell-error:  # running on travis
-	@codespell --builtin clear,rare,informal,names -i 0 -q 7 -S $(CODESPELL_SKIPS) --ignore-words=ignore_words.txt $(CODESPELL_DIRS)
+	@codespell --builtin clear,rare,informal,names,usage -i 0 -q 7 -S $(CODESPELL_SKIPS) --ignore-words=ignore_words.txt $(CODESPELL_DIRS)
 
 pydocstyle:
 	@echo "Running pydocstyle"

--- a/ignore_words.txt
+++ b/ignore_words.txt
@@ -32,3 +32,4 @@ dof
 nwe
 thead
 sherif
+master


### PR DESCRIPTION
Codespell recently added a `usage` dictionary to move toward #7901. This just has us use it, with an exception for `master` for now (no other changes needed for our codebase).