### PR TITLE
WIP: Warn if untested NIRX device

### DIFF
--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -22,6 +22,8 @@ from ...utils import warn
 def read_raw_nirx(fname, preload=False, verbose=None):
     """Reader for a NIRX fNIRS recording.
 
+    This function has only been tested with NIRScout devices.
+
     Parameters
     ----------
     fname : str
@@ -70,6 +72,9 @@ class RawNIRX(BaseRaw):
         if fname.endswith('.hdr'):
             fname = op.dirname(op.abspath(fname))
 
+        if not op.isdir(fname):
+            raise RuntimeError('The path you specified does not exist.')
+
         # Check if required files exist and store names for later use
         files = dict()
         keys = ('evt', 'hdr', 'inf', 'set', 'tpl', 'wl1', 'wl2',
@@ -91,6 +96,50 @@ class RawNIRX(BaseRaw):
         with _open(files['wl1']) as fid:
             for line in fid:
                 last_sample += 1
+
+        # Read header file
+        # The header file isn't compliant with the configparser. So all the
+        # text between comments must be removed before passing to parser
+        with _open(files['hdr']) as f:
+            hdr_str = f.read()
+        hdr_str = re.sub('#.*?#', '', hdr_str, flags=re.DOTALL)
+        hdr = RawConfigParser()
+        hdr.read_string(hdr_str)
+
+        # Check that the file format version is supported
+        if not any(item == hdr['GeneralInfo']['NIRStar'] for item in
+                   ["\"15.0\"", "\"15.2\""]):
+            raise RuntimeError('MNE does not support this NIRStar version'
+                               ' (%s)' % (hdr['GeneralInfo']['NIRStar'],))
+        if "NIRScout" not in hdr['GeneralInfo']['Device']:
+            warn("Only import of data from NIRScout devices have been "
+                 "thoroughly tested. You are using a %s device. " %
+                 hdr['GeneralInfo']['Device'])
+
+        # Parse required header fields
+
+        # Extract frequencies of light used by machine
+        fnirs_wavelengths = [int(s) for s in
+                             re.findall(r'(\d+)',
+                             hdr['ImagingParameters']['Wavelengths'])]
+
+        # Extract source-detectors
+        sources = np.asarray([int(s) for s in re.findall(r'(\d+)-\d+:\d+',
+                              hdr['DataStructure']['S-D-Key'])], int)
+        detectors = np.asarray([int(s) for s in re.findall(r'\d+-(\d+):\d+',
+                                hdr['DataStructure']['S-D-Key'])], int)
+
+        # Determine if short channels are present and on which detectors
+        if 'shortbundles' in hdr['ImagingParameters']:
+            short_det = [int(s) for s in
+                         re.findall(r'(\d+)',
+                         hdr['ImagingParameters']['ShortDetIndex'])]
+            short_det = np.array(short_det, int)
+        else:
+            short_det = []
+
+        # Extract sampling rate
+        samplingrate = float(hdr['ImagingParameters']['SamplingRate'])
 
         # Read participant information file
         inf = ConfigParser(allow_no_value=True)
@@ -120,46 +169,6 @@ class RawNIRX(BaseRaw):
         elif subject_info['sex'] in {'F', 'Female', '2'}:
             subject_info['sex'] = FIFF.FIFFV_SUBJ_SEX_FEMALE
         # NIRStar does not record an id, or handedness by default
-
-        # Read header file
-        # The header file isn't compliant with the configparser. So all the
-        # text between comments must be removed before passing to parser
-        with _open(files['hdr']) as f:
-            hdr_str = f.read()
-        hdr_str = re.sub('#.*?#', '', hdr_str, flags=re.DOTALL)
-        hdr = RawConfigParser()
-        hdr.read_string(hdr_str)
-
-        # Check that the file format version is supported
-        if not any(item == hdr['GeneralInfo']['NIRStar'] for item in
-                   ["\"15.0\"", "\"15.2\""]):
-            raise RuntimeError('MNE does not support this NIRStar version'
-                               ' (%s)' % (hdr['GeneralInfo']['NIRStar'],))
-
-        # Parse required header fields
-
-        # Extract frequencies of light used by machine
-        fnirs_wavelengths = [int(s) for s in
-                             re.findall(r'(\d+)',
-                             hdr['ImagingParameters']['Wavelengths'])]
-
-        # Extract source-detectors
-        sources = np.asarray([int(s) for s in re.findall(r'(\d+)-\d+:\d+',
-                              hdr['DataStructure']['S-D-Key'])], int)
-        detectors = np.asarray([int(s) for s in re.findall(r'\d+-(\d+):\d+',
-                                hdr['DataStructure']['S-D-Key'])], int)
-
-        # Determine if short channels are present and on which detectors
-        if 'shortbundles' in hdr['ImagingParameters']:
-            short_det = [int(s) for s in
-                         re.findall(r'(\d+)',
-                         hdr['ImagingParameters']['ShortDetIndex'])]
-            short_det = np.array(short_det, int)
-        else:
-            short_det = []
-
-        # Extract sampling rate
-        samplingrate = float(hdr['ImagingParameters']['SamplingRate'])
 
         # Read information about probe/montage/optodes
         # A word on terminology used here:

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -38,6 +38,13 @@ def test_nirx_hdr_load():
 
 
 @requires_testing_data
+def test_nirx_missing_warn():
+    """Test reading NIRX files when missing data."""
+    with pytest.raises(RuntimeError, match='The path you'):
+        read_raw_nirx(fname_nirx_15_2_short + "1", preload=True)
+
+
+@requires_testing_data
 def test_nirx_dat_warn(tmpdir):
     """Test reading NIRX files when missing data."""
     shutil.copytree(fname_nirx_15_2_short, str(tmpdir) + "/data/")


### PR DESCRIPTION
#### What does this implement/fix?
@cbrnr confirmed in #7894 that the NIRX format for saving data is not consistent across devices. I have only added test data for the NIRScout device I have access too. The function now throws a warning if used with an untested device.

#### Additional information
Next step is to improve the reader function to work with these alternative formats. But this warning seems prudent until someone with access to these devices adds reader support.

Closes #7913 