### PR TITLE
MRG, MAINT: Clean up use of bool, float, int

### DIFF
--- a/examples/simulation/plot_simulate_evoked_data.py
+++ b/examples/simulation/plot_simulate_evoked_data.py
@@ -46,7 +46,7 @@ labels = [mne.read_label(data_path + '/MEG/sample/labels/%s.label' % ln)
 ###############################################################################
 # Generate source time courses from 2 dipoles and the correspond evoked data
 
-times = np.arange(300, dtype=np.float) / raw.info['sfreq'] - 0.1
+times = np.arange(300, dtype=np.float64) / raw.info['sfreq'] - 0.1
 rng = np.random.RandomState(42)
 
 

--- a/examples/simulation/plot_simulated_raw_data_using_subject_anatomy.py
+++ b/examples/simulation/plot_simulated_raw_data_using_subject_anatomy.py
@@ -143,7 +143,7 @@ def data_fun(times, latency, duration):
 # event, the second is not used. The third one is the event id, which is
 # different for each of the 4 areas.
 
-times = np.arange(150, dtype=np.float) / info['sfreq']
+times = np.arange(150, dtype=np.float64) / info['sfreq']
 duration = 0.03
 rng = np.random.RandomState(7)
 source_simulator = mne.simulation.SourceSimulator(src, tstep=tstep)

--- a/examples/time_frequency/plot_time_frequency_simulated.py
+++ b/examples/time_frequency/plot_time_frequency_simulated.py
@@ -43,7 +43,7 @@ rng = np.random.RandomState(seed)
 noise = rng.randn(n_epochs, len(ch_names), n_times)
 
 # Add a 50 Hz sinusoidal burst to the noise and ramp it.
-t = np.arange(n_times, dtype=np.float) / sfreq
+t = np.arange(n_times, dtype=np.float64) / sfreq
 signal = np.sin(np.pi * 2. * 50. * t)  # 50 Hz sinusoid signal
 signal[np.logical_or(t < 0.45, t > 0.55)] = 0.  # Hard windowing
 on_time = np.logical_and(t >= 0.45, t <= 0.55)

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -260,7 +260,7 @@ def test_make_dics(tmpdir, _load_forward, idx, mat_tol, vol_tol):
     assert isinstance(filters, Beamformer)
     assert isinstance(filters_read, Beamformer)
     for key in ['tmin', 'tmax']:  # deal with strictness of object_diff
-        setattr(filters['csd'], key, np.float(getattr(filters['csd'], key)))
+        setattr(filters['csd'], key, np.float64(getattr(filters['csd'], key)))
     assert object_diff(filters, filters_read) == ''
 
 

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1341,7 +1341,7 @@ def _read_bem_surface(fid, this, def_coord_frame, s_id=None):
     if tag is None:
         raise ValueError('Vertex data not found')
 
-    res['rr'] = tag.data.astype(np.float)  # XXX : double because of mayavi bug
+    res['rr'] = tag.data.astype(np.float64)  # XXX : double because of mayavi
     if res['rr'].shape[0] != res['np']:
         raise ValueError('Vertex information is incorrect')
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -373,7 +373,7 @@ class SetChannelsMixin(MontageMixin):
         if len(pos) != len(names):
             raise ValueError('Number of channel positions not equal to '
                              'the number of names given.')
-        pos = np.asarray(pos, dtype=np.float)
+        pos = np.asarray(pos, dtype=np.float64)
         if pos.shape[-1] != 3 or pos.ndim != 2:
             msg = ('Channel positions must have the shape (n_points, 3) '
                    'not %s.' % (pos.shape,))

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -136,8 +136,8 @@ def _interpolate_bads_eeg(inst, origin, verbose=None):
     inst : mne.io.Raw, mne.Epochs or mne.Evoked
         The data to interpolate. Must be preloaded.
     """
-    bads_idx = np.zeros(len(inst.ch_names), dtype=np.bool)
-    goods_idx = np.zeros(len(inst.ch_names), dtype=np.bool)
+    bads_idx = np.zeros(len(inst.ch_names), dtype=bool)
+    goods_idx = np.zeros(len(inst.ch_names), dtype=bool)
 
     picks = pick_types(inst.info, meg=False, eeg=True, exclude=[])
     inst.info._check_consistency()

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -126,7 +126,7 @@ def _read_lout(fname):
                 name = chkind + ' ' + nb
             else:
                 cid, x, y, dx, dy, name = splits
-            pos.append(np.array([x, y, dx, dy], dtype=np.float))
+            pos.append(np.array([x, y, dx, dy], dtype=np.float64))
             names.append(name)
             ids.append(int(cid))
 
@@ -147,7 +147,7 @@ def _read_lay(fname):
                 name = chkind + ' ' + nb
             else:
                 cid, x, y, dx, dy, name = splits
-            pos.append(np.array([x, y, dx, dy], dtype=np.float))
+            pos.append(np.array([x, y, dx, dy], dtype=np.float64))
             names.append(name)
             ids.append(int(cid))
 

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -557,7 +557,7 @@ def _fit_chpi_amplitudes(raw, time_sl, hpi):
             # loads hpi_stim channel
             chpi_data = raw[hpi['hpi_pick'], time_sl][0]
 
-        ons = (np.round(chpi_data).astype(np.int) &
+        ons = (np.round(chpi_data).astype(np.int64) &
                hpi['on'][:, np.newaxis]).astype(bool)
         n_on = ons.all(axis=-1).sum(axis=0)
         if not (n_on >= 3).all():

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -88,6 +88,9 @@ def pytest_configure(config):
     ignore:.*trait.*handler.*deprecated.*:DeprecationWarning
     ignore:.*rich_compare.*metadata.*deprecated.*:DeprecationWarning
     ignore:.*In future, it will be an error for 'np.bool_'.*:DeprecationWarning
+    ignore:.*`np.bool` is a deprecated alias.*:DeprecationWarning
+    ignore:.*`np.int` is a deprecated alias.*:DeprecationWarning
+    ignore:.*`np.float` is a deprecated alias.*:DeprecationWarning
     ignore:.*Converting `np\.character` to a dtype is deprecated.*:DeprecationWarning
     ignore:.*sphinx\.util\.smartypants is deprecated.*:
     ignore:.*pandas\.util\.testing is deprecated.*:

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -91,6 +91,8 @@ def pytest_configure(config):
     ignore:.*`np.bool` is a deprecated alias.*:DeprecationWarning
     ignore:.*`np.int` is a deprecated alias.*:DeprecationWarning
     ignore:.*`np.float` is a deprecated alias.*:DeprecationWarning
+    ignore:.*`np.object` is a deprecated alias.*:DeprecationWarning
+    ignore:.*`np.long` is a deprecated alias:DeprecationWarning
     ignore:.*Converting `np\.character` to a dtype is deprecated.*:DeprecationWarning
     ignore:.*sphinx\.util\.smartypants is deprecated.*:
     ignore:.*pandas\.util\.testing is deprecated.*:

--- a/mne/connectivity/effective.py
+++ b/mne/connectivity/effective.py
@@ -133,7 +133,7 @@ def phase_slope_index(data, indices=None, sfreq=2 * np.pi,
     # allocate space for output
     out_shape = list(cohy.shape)
     out_shape[freq_dim] = n_bands
-    psi = np.zeros(out_shape, dtype=np.float)
+    psi = np.zeros(out_shape, dtype=np.float64)
 
     # allocate accumulator
     acc_shape = copy.copy(out_shape)

--- a/mne/connectivity/spectral.py
+++ b/mne/connectivity/spectral.py
@@ -980,7 +980,7 @@ def _prepare_connectivity(epoch_block, tmin, tmax, fmin, fmax, sfreq, indices,
             raise ValueError('define frequencies of interest using '
                              'cwt_freqs')
         else:
-            cwt_freqs = cwt_freqs.astype(np.float)
+            cwt_freqs = cwt_freqs.astype(np.float64)
         if any(cwt_freqs > (sfreq / 2.)):
             raise ValueError('entries in cwt_freqs cannot be '
                              'larger than Nyquist (sfreq / 2)')
@@ -1003,7 +1003,7 @@ def _prepare_connectivity(epoch_block, tmin, tmax, fmin, fmax, sfreq, indices,
                                   5. / np.min(fmin), five_cycle_freq))
 
     # create a frequency mask for all bands
-    freq_mask = np.zeros(len(freqs_all), dtype=np.bool)
+    freq_mask = np.zeros(len(freqs_all), dtype=bool)
     for f_lower, f_upper in zip(fmin, fmax):
         freq_mask |= ((freqs_all >= f_lower) & (freqs_all <= f_upper))
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -846,8 +846,8 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
         # prepare mean covs
         n_epoch_types = len(epochs)
         data_mean = [0] * n_epoch_types
-        n_samples = np.zeros(n_epoch_types, dtype=np.int)
-        n_epochs = np.zeros(n_epoch_types, dtype=np.int)
+        n_samples = np.zeros(n_epoch_types, dtype=np.int64)
+        n_epochs = np.zeros(n_epoch_types, dtype=np.int64)
 
         for ii, epochs_t in enumerate(epochs):
 
@@ -1757,7 +1757,7 @@ def compute_whitener(noise_cov, info=None, picks=None, rank=None,
     nzero = (eig > 0)
     eig[~nzero] = 0.  # get rid of numerical noise (negative) ones
 
-    W = np.zeros((n_chan, 1), dtype=np.float)
+    W = np.zeros((n_chan, 1), dtype=np.float64)
     W[nzero, 0] = 1.0 / np.sqrt(eig[nzero])
     #   Rows of eigvec are the eigenvectors
     W = W * noise_cov['eigvec']  # C ** -0.5
@@ -1963,7 +1963,7 @@ def _write_cov(fid, cov):
     else:
         # Store only lower part of covariance matrix
         dim = cov['dim']
-        mask = np.tril(np.ones((dim, dim), dtype=np.bool)) > 0
+        mask = np.tril(np.ones((dim, dim), dtype=bool)) > 0
         vals = cov['data'][mask].ravel()
         write_double(fid, FIFF.FIFF_MNE_COV, vals)
 

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -224,7 +224,7 @@ def _set_cv(cv, estimator=None, X=None, y=None):
     # Setup CV
     from sklearn import model_selection as models
     from sklearn.model_selection import (check_cv, StratifiedKFold, KFold)
-    if isinstance(cv, (int, np.int)):
+    if isinstance(cv, (int, np.int64)):
         XFold = StratifiedKFold if est_is_classifier else KFold
         cv = XFold(n_splits=cv)
     elif isinstance(cv, str):

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -108,7 +108,7 @@ def test_time_delay():
             _delay_time_series(X, tmin, tmax, sfreq=[1])
         # Delays must be int/float
         with pytest.raises(TypeError, match='.*complex.*'):
-            _delay_time_series(X, np.complex(tmin), tmax, 1)
+            _delay_time_series(X, np.complex128(tmin), tmax, 1)
         # Make sure swapaxes works
         start, stop = int(round(tmin * isfreq)), int(round(tmax * isfreq)) + 1
         n_delays = stop - start

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -1306,7 +1306,7 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     # cov = prepare_noise_cov(cov, info_nb, info_nb['ch_names'], verbose=False)
     # nzero = (cov['eig'] > 0)
     # n_chan = len(info_nb['ch_names'])
-    # whitener = np.zeros((n_chan, n_chan), dtype=np.float)
+    # whitener = np.zeros((n_chan, n_chan), dtype=np.float64)
     # whitener[nzero, nzero] = 1.0 / np.sqrt(cov['eig'][nzero])
     # whitener = np.dot(whitener, cov['eigvec'])
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -904,7 +904,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         else:
             if self._offset is None:
                 self._offset = np.zeros((len(self.ch_names), len(self.times)),
-                                        dtype=np.float)
+                                        dtype=np.float64)
             self._offset[ep_picks] -= evoked.data[picks]
         logger.info('[done]')
 

--- a/mne/event.py
+++ b/mne/event.py
@@ -49,7 +49,7 @@ def pick_events(events, include=None, exclude=None, step=False):
     if include is not None:
         if not isinstance(include, list):
             include = [include]
-        mask = np.zeros(len(events), dtype=np.bool)
+        mask = np.zeros(len(events), dtype=bool)
         for e in include:
             mask = np.logical_or(mask, events[:, 2] == e)
             if step:
@@ -58,7 +58,7 @@ def pick_events(events, include=None, exclude=None, step=False):
     elif exclude is not None:
         if not isinstance(exclude, list):
             exclude = [exclude]
-        mask = np.ones(len(events), dtype=np.bool)
+        mask = np.ones(len(events), dtype=bool)
         for e in exclude:
             mask = np.logical_and(mask, events[:, 2] != e)
             if step:
@@ -432,7 +432,7 @@ def find_stim_steps(raw, pad_start=None, pad_stop=None, merge=0,
     if np.any(data < 0):
         warn('Trigger channel contains negative values, using absolute value.')
         data = np.abs(data)  # make sure trig channel is positive
-    data = data.astype(np.int)
+    data = data.astype(np.int64)
 
     return _find_stim_steps(data, raw.first_samp, pad_start=pad_start,
                             pad_stop=pad_stop, merge=merge)
@@ -452,9 +452,9 @@ def _find_events(data, first_samp, verbose=None, output='onset',
     else:
         merge = 0
 
-    data = data.astype(np.int)
+    data = data.astype(np.int64)
     if uint_cast:
-        data = data.astype(np.uint16).astype(np.int)
+        data = data.astype(np.uint16).astype(np.int64)
     if data.min() < 0:
         warn('Trigger channel contains negative values, using absolute '
              'value. If data were acquired on a Neuromag system with '

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -746,7 +746,7 @@ class EvokedArray(Evoked):
         self.first = int(round(tmin * info['sfreq']))
         self.last = self.first + np.shape(data)[-1] - 1
         self.times = np.arange(self.first, self.last + 1,
-                               dtype=np.float) / info['sfreq']
+                               dtype=np.float64) / info['sfreq']
         self.info = info.copy()  # do not modify original info
         self.nave = nave
         self.kind = kind
@@ -1111,7 +1111,7 @@ def _read_evoked(fname, condition=None, kind='average', allow_maxshield=False):
         else:
             # Put the old style epochs together
             data = np.concatenate([e.data[None, :] for e in epoch], axis=0)
-        data = data.astype(np.float)
+        data = data.astype(np.float64)
 
         if first_time is not None and nsamp is not None:
             times = first_time + np.arange(nsamp) / info['sfreq']
@@ -1280,7 +1280,7 @@ def _get_peak(data, times, tmin=None, tmax=None, mode='abs'):
         raise ValueError('The tmin must be smaller or equal to tmax')
 
     time_win = (times >= tmin) & (times <= tmax)
-    mask = np.ones_like(data).astype(np.bool)
+    mask = np.ones_like(data).astype(bool)
     mask[:, time_win] = False
 
     maxfun = np.argmax

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -179,7 +179,7 @@ def _overlap_add_filter(x, h, n_fft=None, phase='zero', picks=None,
             # cost function based on number of multiplications
             N = 2 ** np.arange(np.ceil(np.log2(min_fft)),
                                np.ceil(np.log2(max_fft)) + 1, dtype=int)
-            cost = (np.ceil(n_x / (N - len(h) + 1).astype(np.float)) *
+            cost = (np.ceil(n_x / (N - len(h) + 1).astype(np.float64)) *
                     N * (np.log2(N) + 1))
 
             # add a heuristic term to prevent too-long FFT's which are slow
@@ -2005,7 +2005,7 @@ class FilterMixin(object):
         lowpass = self.info.get('lowpass')
         lowpass = np.inf if lowpass is None else lowpass
         self.info['lowpass'] = min(lowpass, sfreq / 2.)
-        new_times = (np.arange(self._data.shape[-1], dtype=np.float) /
+        new_times = (np.arange(self._data.shape[-1], dtype=np.float64) /
                      sfreq + self.times[0])
         # adjust indirectly affected variables
         if isinstance(self, BaseEpochs):

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -93,14 +93,14 @@ def _read_geometry(filepath, read_metadata=False, read_stamp=False):
             nvert = _fread3(fobj)
             nquad = _fread3(fobj)
             (fmt, div) = (">i2", 100.) if magic == QUAD_MAGIC else (">f4", 1.)
-            coords = np.fromfile(fobj, fmt, nvert * 3).astype(np.float) / div
+            coords = np.fromfile(fobj, fmt, nvert * 3).astype(np.float64) / div
             coords = coords.reshape(-1, 3)
             quads = _fread3_many(fobj, nquad * 4)
             quads = quads.reshape(nquad, 4)
             #
             #   Face splitting follows
             #
-            faces = np.zeros((2 * nquad, 3), dtype=np.int)
+            faces = np.zeros((2 * nquad, 3), dtype=np.int64)
             nface = 0
             for quad in quads:
                 if (quad[0] % 2) == 0:
@@ -127,7 +127,7 @@ def _read_geometry(filepath, read_metadata=False, read_stamp=False):
         else:
             raise ValueError("File does not appear to be a Freesurfer surface")
 
-    coords = coords.astype(np.float)  # XXX: due to mayavi bug on mac 32bits
+    coords = coords.astype(np.float64)  # XXX: due to mayavi bug on mac 32bits
 
     ret = (coords, faces)
     if read_metadata:

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -690,7 +690,7 @@ def make_forward_dipole(dipole, bem, info, trans=None, n_jobs=1, verbose=None):
     # Check for omissions due to proximity to inner skull in
     # make_forward_solution, which will result in an exception
     if fwd['src'][0]['nuse'] != len(pos):
-        inuse = fwd['src'][0]['inuse'].astype(np.bool)
+        inuse = fwd['src'][0]['inuse'].astype(bool)
         head = ('The following dipoles are outside the inner skull boundary')
         msg = len(head) * '#' + '\n' + head + '\n'
         for (t, pos) in zip(times[np.logical_not(inuse)],

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -175,12 +175,12 @@ def _block_diag(A, n):
     if na % n > 0:
         raise ValueError('Width of matrix must be a multiple of n')
 
-    tmp = np.arange(ma * bdn, dtype=np.int).reshape(bdn, ma)
+    tmp = np.arange(ma * bdn, dtype=np.int64).reshape(bdn, ma)
     tmp = np.tile(tmp, (1, n))
     ii = tmp.ravel()
 
-    jj = np.arange(na, dtype=np.int)[None, :]
-    jj = jj * np.ones(ma, dtype=np.int)[:, None]
+    jj = np.arange(na, dtype=np.int64)[None, :]
+    jj = jj * np.ones(ma, dtype=np.int64)[:, None]
     jj = jj.T.ravel()  # column indices foreach sparse bd
 
     bd = sparse.coo_matrix((A.T.ravel(), np.c_[ii, jj].T)).tocsc()
@@ -994,7 +994,7 @@ def compute_orient_prior(forward, loose=0.2, verbose=None):
     if not (0 <= loose <= 1):
         raise ValueError('loose value should be between 0 and 1, '
                          'got %s.' % (loose,))
-    orient_prior = np.ones(n_sources, dtype=np.float)
+    orient_prior = np.ones(n_sources, dtype=np.float64)
     if loose > 0.:
         if is_fixed_ori:
             raise ValueError('loose must be 0. with forward operator '

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -51,7 +51,7 @@ def _gamma_map_opt(M, G, alpha, maxit=10000, tol=1e-6, update_mode=1,
     M = M.copy()
 
     if gammas is None:
-        gammas = np.ones(G.shape[1], dtype=np.float)
+        gammas = np.ones(G.shape[1], dtype=np.float64)
 
     eps = np.finfo(float).eps
 
@@ -132,7 +132,7 @@ def _gamma_map_opt(M, G, alpha, maxit=10000, tol=1e-6, update_mode=1,
             gammas = np.repeat(gammas_comb / group_size, group_size)
 
         # compute convergence criterion
-        gammas_full = np.zeros(n_sources, dtype=np.float)
+        gammas_full = np.zeros(n_sources, dtype=np.float64)
         gammas_full[active_set] = gammas
 
         err = (np.sum(np.abs(gammas_full - gammas_full_old)) /

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -403,7 +403,7 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose='auto', depth=0.8,
     M_estimated = np.dot(gain[:, active_set], X)
 
     if mask is not None:
-        active_set_tmp = np.zeros(len(mask), dtype=np.bool)
+        active_set_tmp = np.zeros(len(mask), dtype=bool)
         active_set_tmp[mask] = active_set
         active_set = active_set_tmp
         del active_set_tmp
@@ -662,7 +662,7 @@ def tf_mixed_norm(evoked, forward, noise_cov,
     M_estimated = np.dot(gain[:, active_set], X)
 
     if mask is not None:
-        active_set_tmp = np.zeros(len(mask), dtype=np.bool)
+        active_set_tmp = np.zeros(len(mask), dtype=bool)
         active_set_tmp[mask] = active_set
         active_set = active_set_tmp
         del active_set_tmp

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -67,7 +67,7 @@ def prox_l21(Y, alpha, n_orient, shape=None, is_stft=False):
 
     Examples
     --------
-    >>> Y = np.tile(np.array([0, 4, 3, 0, 0], dtype=np.float), (2, 1))
+    >>> Y = np.tile(np.array([0, 4, 3, 0, 0], dtype=np.float64), (2, 1))
     >>> Y = np.r_[Y, np.zeros_like(Y)]
     >>> print(Y)  # doctest:+SKIP
     [[ 0.  4.  3.  0.  0.]
@@ -82,7 +82,7 @@ def prox_l21(Y, alpha, n_orient, shape=None, is_stft=False):
     [ True  True False False]
     """
     if len(Y) == 0:
-        return np.zeros_like(Y), np.zeros((0,), dtype=np.bool)
+        return np.zeros_like(Y), np.zeros((0,), dtype=bool)
     if shape is not None:
         shape_init = Y.shape
         Y = Y.reshape(*shape)
@@ -141,7 +141,7 @@ def prox_l1(Y, alpha, n_orient):
 
     Examples
     --------
-    >>> Y = np.tile(np.array([1, 2, 3, 2, 0], dtype=np.float), (2, 1))
+    >>> Y = np.tile(np.array([1, 2, 3, 2, 0], dtype=np.float64), (2, 1))
     >>> Y = np.r_[Y, np.zeros_like(Y)]
     >>> print(Y)  # doctest:+SKIP
     [[ 1.  2.  3.  2.  0.]
@@ -252,7 +252,7 @@ def _mixed_norm_solver_prox(M, G, alpha, lipschitz_constant, maxit=200,
     Y = np.zeros((n_sources, n_times))  # FISTA aux variable
     E = []  # track primal objective function
     highest_d_obj = - np.inf
-    active_set = np.ones(n_sources, dtype=np.bool)  # start with full AS
+    active_set = np.ones(n_sources, dtype=bool)  # start with full AS
 
     for i in range(maxit):
         X0, active_set_0 = X, active_set  # store previous values
@@ -332,7 +332,7 @@ def _mixed_norm_solver_bcd(M, G, alpha, lipschitz_constant, maxit=200,
 
     E = []  # track primal objective function
     highest_d_obj = - np.inf
-    active_set = np.zeros(n_sources, dtype=np.bool)  # start with full AS
+    active_set = np.zeros(n_sources, dtype=bool)  # start with full AS
 
     alpha_lc = alpha / lipschitz_constant
 
@@ -544,7 +544,7 @@ def mixed_norm_solver(M, G, alpha, maxit=3000, tol=1e-8, verbose=None,
         E = list()
         highest_d_obj = - np.inf
         X_init = None
-        active_set = np.zeros(n_dipoles, dtype=np.bool)
+        active_set = np.zeros(n_dipoles, dtype=bool)
         idx_large_corr = np.argsort(groups_norm2(np.dot(G.T, M), n_orient))
         new_active_idx = idx_large_corr[-active_set_size:]
         if n_orient > 1:
@@ -673,7 +673,7 @@ def iterative_mixed_norm_solver(M, G, alpha, n_mxne_iter, maxit=3000,
 
     E = list()
 
-    active_set = np.ones(G.shape[1], dtype=np.bool)
+    active_set = np.ones(G.shape[1], dtype=bool)
     weights = np.ones(G.shape[1])
     X = np.zeros((G.shape[1], M.shape[1]))
 
@@ -740,7 +740,7 @@ def tf_lipschitz_constant(M, G, phi, phiT, tol=1e-3, verbose=None):
     """
     n_times = M.shape[1]
     n_points = G.shape[1]
-    iv = np.ones((n_points, n_times), dtype=np.float)
+    iv = np.ones((n_points, n_times), dtype=np.float64)
     v = phi(iv)
     L = 1e100
     for it in range(100):
@@ -1251,7 +1251,7 @@ def _tf_mixed_norm_solver_bcd_active_set(M, G, alpha_space, alpha_time,
     n_positions = n_sources // n_orient
 
     Z = dict.fromkeys(np.arange(n_positions), 0.0)
-    active_set = np.zeros(n_sources, dtype=np.bool)
+    active_set = np.zeros(n_sources, dtype=bool)
     active = []
     if Z_init is not None:
         if Z_init.shape != (n_sources, phi.n_coefs.sum()):
@@ -1295,7 +1295,7 @@ def _tf_mixed_norm_solver_bcd_active_set(M, G, alpha_space, alpha_time,
 
         Z, as_, E_tmp, converged = _tf_mixed_norm_solver_bcd_(
             M, G[:, active_set], Z_init,
-            np.ones(len(active) * n_orient, dtype=np.bool),
+            np.ones(len(active) * n_orient, dtype=bool),
             candidates_, alpha_space, alpha_time,
             lipschitz_constant[active_set[::n_orient]], phi, phiT,
             w_space=w_space_as, w_time=w_time_as,
@@ -1547,7 +1547,7 @@ def iterative_tf_mixed_norm_solver(M, G, alpha_space, alpha_time,
 
     E = list()
 
-    active_set = np.ones(n_sources, dtype=np.bool)
+    active_set = np.ones(n_sources, dtype=bool)
     Z = np.zeros((n_sources, phi.n_coefs.sum()), dtype=np.complex)
 
     for k in range(n_tfmxne_iter):

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -1322,7 +1322,7 @@ def _tf_mixed_norm_solver_bcd_active_set(M, G, alpha_space, alpha_time,
         Z = np.vstack([Z[pos] for pos in range(len(Z)) if np.any(Z[pos])])
         X = phiT(Z)
     else:
-        Z = np.zeros((0, phi.n_coefs.sum()), dtype=np.complex)
+        Z = np.zeros((0, phi.n_coefs.sum()), dtype=np.complex128)
         X = np.zeros((0, n_times))
 
     return X, Z, active_set, E, gap
@@ -1548,7 +1548,7 @@ def iterative_tf_mixed_norm_solver(M, G, alpha_space, alpha_time,
     E = list()
 
     active_set = np.ones(n_sources, dtype=bool)
-    Z = np.zeros((n_sources, phi.n_coefs.sum()), dtype=np.complex)
+    Z = np.zeros((n_sources, phi.n_coefs.sum()), dtype=np.complex128)
 
     for k in range(n_tfmxne_iter):
         active_set_0 = active_set.copy()

--- a/mne/inverse_sparse/tests/test_mxne_debiasing.py
+++ b/mne/inverse_sparse/tests/test_mxne_debiasing.py
@@ -14,7 +14,7 @@ def test_compute_debiasing():
     rng = np.random.RandomState(42)
     G = rng.randn(10, 4)
     X = rng.randn(4, 20)
-    debias_true = np.arange(1, 5, dtype=np.float)
+    debias_true = np.arange(1, 5, dtype=np.float64)
     M = np.dot(G, X * debias_true[:, np.newaxis])
     debias = compute_bias(M, G, X, max_iter=10000, n_orient=1, tol=1e-7)
     assert_almost_equal(debias, debias_true, decimal=5)

--- a/mne/io/artemis123/utils.py
+++ b/mne/io/artemis123/utils.py
@@ -20,7 +20,7 @@ def _load_mne_locs(fname=None):
     with open(fname, 'r') as fid:
         for line in fid:
             vals = line.strip().split(',')
-            locs[vals[0]] = np.array(vals[1::], np.float)
+            locs[vals[0]] = np.array(vals[1::], np.float64)
 
     return locs
 
@@ -56,9 +56,9 @@ def _load_tristan_coil_locs(coil_loc_path):
             channel_info[vals[0]] = dict()
             if vals[6]:
                 channel_info[vals[0]]['inner_coil'] = \
-                    np.array(vals[2:5], np.float)
+                    np.array(vals[2:5], np.float64)
                 channel_info[vals[0]]['outer_coil'] = \
-                    np.array(vals[5:8], np.float)
+                    np.array(vals[5:8], np.float64)
             else:  # nothing supplied
                 channel_info[vals[0]]['inner_coil'] = np.zeros(3)
                 channel_info[vals[0]]['outer_coil'] = np.zeros(3)

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -647,7 +647,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale):
                 # highpass relaxed / no filters
                 highpass = [float(filt) if filt not in ('NaN', 'Off', 'DC')
                             else np.Inf for filt in highpass]
-                info['highpass'] = np.max(np.array(highpass, dtype=np.float))
+                info['highpass'] = np.max(np.array(highpass, dtype=np.float64))
                 # Coveniently enough 1 / np.Inf = 0.0, so this works for
                 # DC / no highpass filter
                 # filter time constant t [secs] to Hz conversion: 1/2*pi*t
@@ -662,7 +662,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale):
             else:
                 highpass = [float(filt) if filt not in ('NaN', 'Off', 'DC')
                             else 0.0 for filt in highpass]
-                info['highpass'] = np.min(np.array(highpass, dtype=np.float))
+                info['highpass'] = np.min(np.array(highpass, dtype=np.float64))
                 if info['highpass'] == 0.0 and len(set(highpass)) == 1:
                     # not actually heterogeneous in effect
                     # ... just heterogeneously disabled
@@ -691,7 +691,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale):
                 # infinitely relaxed / no filters
                 lowpass = [float(filt) if filt not in ('NaN', 'Off')
                            else 0.0 for filt in lowpass]
-                info['lowpass'] = np.min(np.array(lowpass, dtype=np.float))
+                info['lowpass'] = np.min(np.array(lowpass, dtype=np.float64))
                 try:
                     # filter time constant t [secs] to Hz conversion: 1/2*pi*t
                     info['lowpass'] = 1. / (2 * np.pi * info['lowpass'])
@@ -713,7 +713,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale):
                 # infinitely relaxed / no filters
                 lowpass = [float(filt) if filt not in ('NaN', 'Off')
                            else np.Inf for filt in lowpass]
-                info['lowpass'] = np.max(np.array(lowpass, dtype=np.float))
+                info['lowpass'] = np.max(np.array(lowpass, dtype=np.float64))
 
                 if np.isinf(info['lowpass']):
                     # No lowpass actually set for the weakest setting

--- a/mne/io/bti/read.py
+++ b/mne/io/bti/read.py
@@ -34,7 +34,7 @@ def read_char(fid, count=1):
 
 def read_bool(fid):
     """Read bool value from bti file."""
-    return _unpack_simple(fid, '>?', np.bool)
+    return _unpack_simple(fid, '>?', bool)
 
 
 def read_uint8(fid):

--- a/mne/io/ctf/info.py
+++ b/mne/io/ctf/info.py
@@ -479,8 +479,8 @@ def _annotate_bad_segments(directory, start_time, meas_date):
         for f in fid.readlines():
             tmp = f.strip().split()
             desc.append('bad_%s' % tmp[0])
-            onsets.append(np.float(tmp[1]) - start_time)
-            durations.append(np.float(tmp[2]) - np.float(tmp[1]))
+            onsets.append(np.float64(tmp[1]) - start_time)
+            durations.append(np.float64(tmp[2]) - np.float64(tmp[1]))
     # return None if there are no bad segments
     if len(onsets) == 0:
         return None

--- a/mne/io/ctf_comp.py
+++ b/mne/io/ctf_comp.py
@@ -109,8 +109,8 @@ def read_ctf_comp(fid, node, chs, verbose=None):
             #   Calibrate...
             _calibrate_comp(one, chs, mat['row_names'], mat['col_names'])
         else:
-            one['rowcals'] = np.ones(mat['data'].shape[0], dtype=np.float)
-            one['colcals'] = np.ones(mat['data'].shape[1], dtype=np.float)
+            one['rowcals'] = np.ones(mat['data'].shape[0], dtype=np.float64)
+            one['colcals'] = np.ones(mat['data'].shape[1], dtype=np.float64)
 
         compdata.append(one)
 

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -164,7 +164,7 @@ class RawKIT(BaseRaw):
 
         pick = pick_types(self.info, meg=False, ref_meg=False,
                           stim=True, exclude=[])
-        stim_ch = np.empty((1, stop), dtype=np.int)
+        stim_ch = np.empty((1, stop), dtype=np.int64)
         for b_start in range(start, stop, buffer_size):
             b_stop = b_start + buffer_size
             x = self[pick, b_start:b_stop][0]
@@ -686,7 +686,7 @@ def get_kit_info(rawfile, allow_unknown_format):
             z = cos(theta)
             vec_z = np.array([x, y, z])
             vec_z /= linalg.norm(vec_z)
-            vec_x = np.zeros(vec_z.size, dtype=np.float)
+            vec_x = np.zeros(vec_z.size, dtype=np.float64)
             if vec_z[1] < vec_z[2]:
                 if vec_z[0] < vec_z[1]:
                     vec_x[0] = 1.0

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1994,7 +1994,7 @@ def create_info(ch_names, sfreq, ch_types='misc', verbose=None):
     nchan = len(ch_names)
     if isinstance(ch_types, str):
         ch_types = [ch_types] * nchan
-    ch_types = np.atleast_1d(np.array(ch_types, np.str))
+    ch_types = np.atleast_1d(np.array(ch_types, np.str_))
     if ch_types.ndim != 1 or len(ch_types) != nchan:
         raise ValueError('ch_types and ch_names must be the same length '
                          '(%s != %s) for ch_types=%s'

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -383,7 +383,7 @@ def pick_types(info, meg=None, eeg=False, stim=False, eog=False, ecg=False,
 
     exclude = _check_info_exclude(info, exclude)
     nchan = info['nchan']
-    pick = np.zeros(nchan, dtype=np.bool)
+    pick = np.zeros(nchan, dtype=bool)
 
     _check_meg_type(ref_meg, allow_auto=True)
     _check_meg_type(meg)

--- a/mne/io/tests/test_compensator.py
+++ b/mne/io/tests/test_compensator.py
@@ -67,7 +67,7 @@ def test_compensation_mne():
         if comp is not None:
             raw.apply_gradient_compensation(comp)
         picks = pick_types(raw.info, meg=True, ref_meg=True)
-        events = np.array([[0, 0, 1]], dtype=np.int)
+        events = np.array([[0, 0, 1]], dtype=np.int64)
         evoked = Epochs(raw, events, 1, 0, 20e-3, picks=picks,
                         baseline=None).average()
         return evoked

--- a/mne/label.py
+++ b/mne/label.py
@@ -999,7 +999,7 @@ def write_label(filename, label, verbose=None):
 
     with open(filename, 'wb') as fid:
         n_vertices = len(label.vertices)
-        data = np.zeros((n_vertices, 5), dtype=np.float)
+        data = np.zeros((n_vertices, 5), dtype=np.float64)
         data[:, 0] = label.vertices
         data[:, 1:4] = 1e3 * label.pos
         data[:, 4] = label.values
@@ -1895,7 +1895,7 @@ def _read_annot(fname):
             np.fromfile(fid, '>c', length)  # discard orig_tab
 
             names = list()
-            ctab = np.zeros((n_entries, 5), np.int)
+            ctab = np.zeros((n_entries, 5), np.int64)
             for i in range(n_entries):
                 name_length = np.fromfile(fid, '>i4', 1)[0]
                 name = np.fromfile(fid, "|S%d" % name_length, 1)[0]
@@ -1909,7 +1909,7 @@ def _read_annot(fname):
             if ctab_version != 2:
                 raise Exception('Color table version not supported')
             n_entries = np.fromfile(fid, '>i4', 1)[0]
-            ctab = np.zeros((n_entries, 5), np.int)
+            ctab = np.zeros((n_entries, 5), np.int64)
             length = np.fromfile(fid, '>i4', 1)[0]
             np.fromfile(fid, "|S%d" % length, 1)  # Orig table path
             entries_to_read = np.fromfile(fid, '>i4', 1)[0]
@@ -2387,7 +2387,7 @@ def write_labels_to_annot(labels, subject=None, parc=None, overwrite=False,
                  'specify subject and subjects_dir parameters.')
 
         # Create annot and color table array to write
-        annot = np.empty(n_vertices, dtype=np.int)
+        annot = np.empty(n_vertices, dtype=np.int64)
         annot[:] = -1
         # create the annotation ids from the colors
         annot_id_coding = np.array((1, 2 ** 8, 2 ** 16))

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -193,7 +193,7 @@ def _compute_pow_plv(data, K, sel, Ws, source_ori, use_fft, Vh,
     shape, is_free_ori = _prepare_tfr(data, decim, pick_ori, Ws, K, source_ori)
     power = np.zeros(shape, dtype=np.float64)  # power or raw TFR
     # phase lock
-    plv = np.zeros(shape, dtype=np.complex) if with_plv else None
+    plv = np.zeros(shape, dtype=np.complex128) if with_plv else None
 
     for epoch in data:
         epoch = epoch[sel]  # keep only selected channels
@@ -217,7 +217,7 @@ def _single_epoch_tfr(data, is_free_ori, K, Ws, use_fft, decim, shape,
     """Compute single trial TFRs, either ITC, power or raw TFR."""
     tfr_e = np.zeros(shape, dtype=np.float64)  # power or raw TFR
     # phase lock
-    plv_e = np.zeros(shape, dtype=np.complex) if with_plv else None
+    plv_e = np.zeros(shape, dtype=np.complex128) if with_plv else None
     n_sources, _, n_times = shape
     for f, w in enumerate(Ws):
         tfr_ = cwt(data, [w], use_fft=use_fft, decim=decim)
@@ -225,7 +225,7 @@ def _single_epoch_tfr(data, is_free_ori, K, Ws, use_fft, decim, shape,
 
         # phase lock and power at freq f
         if with_plv:
-            plv_f = np.zeros((n_sources, n_times), dtype=np.complex)
+            plv_f = np.zeros((n_sources, n_times), dtype=np.complex128)
 
         tfr_f = np.zeros((n_sources, n_times), dtype=np.float64)
 

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -191,7 +191,7 @@ def _compute_pow_plv(data, K, sel, Ws, source_ori, use_fft, Vh,
                      with_power, with_plv, pick_ori, decim, verbose=None):
     """Aux function for induced power and PLV."""
     shape, is_free_ori = _prepare_tfr(data, decim, pick_ori, Ws, K, source_ori)
-    power = np.zeros(shape, dtype=np.float)  # power or raw TFR
+    power = np.zeros(shape, dtype=np.float64)  # power or raw TFR
     # phase lock
     plv = np.zeros(shape, dtype=np.complex) if with_plv else None
 
@@ -215,7 +215,7 @@ def _compute_pow_plv(data, K, sel, Ws, source_ori, use_fft, Vh,
 def _single_epoch_tfr(data, is_free_ori, K, Ws, use_fft, decim, shape,
                       with_plv, with_power):
     """Compute single trial TFRs, either ITC, power or raw TFR."""
-    tfr_e = np.zeros(shape, dtype=np.float)  # power or raw TFR
+    tfr_e = np.zeros(shape, dtype=np.float64)  # power or raw TFR
     # phase lock
     plv_e = np.zeros(shape, dtype=np.complex) if with_plv else None
     n_sources, _, n_times = shape
@@ -227,7 +227,7 @@ def _single_epoch_tfr(data, is_free_ori, K, Ws, use_fft, decim, shape,
         if with_plv:
             plv_f = np.zeros((n_sources, n_times), dtype=np.complex)
 
-        tfr_f = np.zeros((n_sources, n_times), dtype=np.float)
+        tfr_f = np.zeros((n_sources, n_times), dtype=np.float64)
 
         for k, t in enumerate([np.real(tfr_), np.imag(tfr_)]):
             sol = np.dot(K, t)

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -809,7 +809,7 @@ def _interpolate_data(stc, morph, mri_resolution, mri_space, output):
     vols = np.zeros((np.prod(shape[:3]), shape[3]), order='F')  # flatten
     n_vertices_seen = 0
     for this_inuse in inuse:
-        this_inuse = this_inuse.astype(np.bool)
+        this_inuse = this_inuse.astype(bool)
         n_vertices = np.sum(this_inuse)
         stc_slice = slice(n_vertices_seen, n_vertices_seen + n_vertices)
         vols[this_inuse] = stc.data[stc_slice]
@@ -1232,7 +1232,7 @@ def _morph_mult(data, e, use_sparse, idx_use_data, idx_use_out=None):
 def _sparse_argmax_nnz_row(csr_mat):
     """Return index of the maximum non-zero index in each row."""
     n_rows = csr_mat.shape[0]
-    idx = np.empty(n_rows, dtype=np.int)
+    idx = np.empty(n_rows, dtype=np.int64)
     for k in range(n_rows):
         row = csr_mat[k].tocoo()
         idx[k] = row.col[np.argmax(row.data)]

--- a/mne/preprocessing/_peak_finder.py
+++ b/mne/preprocessing/_peak_finder.py
@@ -102,7 +102,7 @@ def peak_finder(x0, thresh=None, extrema=1, verbose=None):
 
         # Preallocate max number of maxima
         maxPeaks = int(np.ceil(length / 2.0))
-        peak_loc = np.zeros(maxPeaks, dtype=np.int)
+        peak_loc = np.zeros(maxPeaks, dtype=np.int64)
         peak_mag = np.zeros(maxPeaks)
         c_ind = 0
         # Loop through extrema which should be peaks and then valleys

--- a/mne/preprocessing/bads.py
+++ b/mne/preprocessing/bads.py
@@ -30,7 +30,7 @@ def _find_outliers(X, threshold=3.0, max_iter=2, tail=0):
         The outlier indices.
     """
     from scipy.stats import zscore
-    my_mask = np.zeros(len(X), dtype=np.bool)
+    my_mask = np.zeros(len(X), dtype=bool)
     for _ in range(max_iter):
         X = np.ma.masked_array(X, my_mask)
         if tail == 0:

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -94,7 +94,7 @@ def qrs_detector(sfreq, ecg, thresh_value=0.6, levels=2.5, n_thresh=3,
             if window[0] > thresh1:
                 max_time = np.argmax(window)
                 time.append(ii + max_time)
-                nx = np.sum(np.diff(((window > thresh1).astype(np.int) ==
+                nx = np.sum(np.diff(((window > thresh1).astype(np.int64) ==
                                      1).astype(int)))
                 numcross.append(nx)
                 rms.append(np.sqrt(sum_squared(window) / window.size))

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -630,7 +630,7 @@ class Xdawn(_XdawnTransformer):
         sources = np.dot(self.filters_[eid], data)
 
         if include not in (None, list()):
-            mask = np.ones(len(sources), dtype=np.bool)
+            mask = np.ones(len(sources), dtype=bool)
             mask[np.unique(include)] = False
             sources[mask] = 0.
             logger.info('Zeroing out %i Xdawn components' % mask.sum())

--- a/mne/simulation/evoked.py
+++ b/mne/simulation/evoked.py
@@ -73,7 +73,7 @@ def simulate_evoked(fwd, stc, info, cov, nave=30, iir_filter=None,
     if nave < np.inf:
         noise = _simulate_noise_evoked(evoked, cov, iir_filter, random_state)
         evoked.data += noise.data / math.sqrt(nave)
-        evoked.nave = np.int(nave)
+        evoked.nave = np.int64(nave)
     if cov is not None and cov.get('projs', None):
         evoked.add_proj(cov['projs']).apply_proj()
     return evoked

--- a/mne/simulation/tests/test_source.py
+++ b/mne/simulation/tests/test_source.py
@@ -113,7 +113,7 @@ def test_simulate_sparse_stc(_get_fwd_labels):
     n_times = 10
     tmin = 0
     tstep = 1e-3
-    times = np.arange(n_times, dtype=np.float) * tstep + tmin
+    times = np.arange(n_times, dtype=np.float64) * tstep + tmin
 
     pytest.raises(ValueError, simulate_sparse_stc, fwd['src'], len(labels),
                   times, labels=labels, location='center', subject='sample',
@@ -221,7 +221,7 @@ def test_simulate_sparse_stc_single_hemi(_get_fwd_labels):
     n_times = 10
     tmin = 0
     tstep = 1e-3
-    times = np.arange(n_times, dtype=np.float) * tstep + tmin
+    times = np.arange(n_times, dtype=np.float64) * tstep + tmin
 
     stc_1 = simulate_sparse_stc(fwd['src'], len(labels_single_hemi), times,
                                 labels=labels_single_hemi, random_state=0)

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2725,7 +2725,7 @@ def _get_connectivity_from_edges(edges, n_times, verbose=None):
     n_vertices = edges.shape[0]
     logger.info("-- number of connected vertices : %d" % n_vertices)
     nnz = edges.col.size
-    aux = n_vertices * np.arange(n_times)[:, None] * np.ones((1, nnz), np.int)
+    aux = n_vertices * np.tile(np.arange(n_times)[:, None], (1, nnz))
     col = (edges.col[None, :] + aux).ravel()
     row = (edges.row[None, :] + aux).ravel()
     if n_times > 1:  # add temporal edges
@@ -2736,7 +2736,7 @@ def _get_connectivity_from_edges(edges, n_times, verbose=None):
         row = np.concatenate((row, o, d))
         col = np.concatenate((col, d, o))
     data = np.ones(edges.data.size * n_times + 2 * n_vertices * (n_times - 1),
-                   dtype=np.int)
+                   dtype=np.int64)
     connectivity = coo_matrix((data, (row, col)),
                               shape=(n_times * n_vertices,) * 2)
     return connectivity

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -803,7 +803,7 @@ def _read_one_source_space(fid, this):
     if tag is None:
         raise ValueError('Vertex data not found')
 
-    res['rr'] = tag.data.astype(np.float)  # double precision for mayavi
+    res['rr'] = tag.data.astype(np.float64)  # double precision for mayavi
     if res['rr'].shape[0] != res['np']:
         raise ValueError('Vertex information is incorrect')
 
@@ -835,7 +835,7 @@ def _read_one_source_space(fid, this):
     tag = find_tag(fid, this, FIFF.FIFF_MNE_SOURCE_SPACE_NUSE)
     if tag is None:
         res['nuse'] = 0
-        res['inuse'] = np.zeros(res['nuse'], dtype=np.int)
+        res['inuse'] = np.zeros(res['nuse'], dtype=np.int64)
         res['vertno'] = None
     else:
         res['nuse'] = int(tag.data)
@@ -843,7 +843,7 @@ def _read_one_source_space(fid, this):
         if tag is None:
             raise ValueError('Source selection information missing')
 
-        res['inuse'] = tag.data.astype(np.int).T
+        res['inuse'] = tag.data.astype(np.int64).T
         if len(res['inuse']) != res['np']:
             raise ValueError('Incorrect number of entries in source space '
                              'selection')

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -119,7 +119,7 @@ def _get_clusters_spatial(s, neighbors):
     # s is a vector of spatial indices that are significant, like:
     #     s = np.where(x_in)[0]
     # for x_in representing a single time-instant
-    r = np.ones(s.shape, np.bool)
+    r = np.ones(s.shape, bool)
     clusters = list()
     next_ind = 0 if s.size > 0 else -1
     while next_ind >= 0:

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -617,7 +617,7 @@ def _fread3(fobj):
 def _fread3_many(fobj, n):
     """Read 3-byte ints from an open binary file object."""
     b1, b2, b3 = np.fromfile(fobj, ">u1",
-                             3 * n).reshape(-1, 3).astype(np.int).T
+                             3 * n).reshape(-1, 3).astype(np.int64).T
     return (b1 << 16) + (b2 << 8) + b3
 
 
@@ -647,7 +647,7 @@ def read_curvature(filepath, binary=True):
             _fread3(fobj)
             curv = np.fromfile(fobj, ">i2", vnum) / 100
     if binary:
-        return 1 - np.array(curv != 0, np.int)
+        return 1 - np.array(curv != 0, np.int64)
     else:
         return curv
 

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -957,7 +957,7 @@ def test_read_annotation_txt_empty(
 def test_annotations_simple_iteration():
     """Test indexing Annotations."""
     NUM_ANNOT = 5
-    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
+    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str__)
     EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
     EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
 

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -957,7 +957,7 @@ def test_read_annotation_txt_empty(
 def test_annotations_simple_iteration():
     """Test indexing Annotations."""
     NUM_ANNOT = 5
-    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str__)
+    EXPECTED_ELEMENTS_TYPE = (np.float64, np.float64, np.str_)
     EXPECTED_ONSETS = EXPECTED_DURATIONS = [x for x in range(NUM_ANNOT)]
     EXPECTED_DESCS = [x.__repr__() for x in range(NUM_ANNOT)]
 

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -175,7 +175,7 @@ def test_compute_proj_epochs():
             p2_data = p2['data']['data'] * np.sign(p2['data']['data'][0, 0])
             if bad_ch in p1['data']['col_names']:
                 bad = p1['data']['col_names'].index('MEG 2443')
-                mask = np.ones(p1_data.size, dtype=np.bool)
+                mask = np.ones(p1_data.size, dtype=bool)
                 mask[bad] = False
                 p1_data = p1_data[:, mask]
                 p2_data = p2_data[:, mask]

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -988,7 +988,7 @@ def test_spatio_temporal_src_connectivity():
 def test_to_data_frame():
     """Test stc Pandas exporter."""
     n_vert, n_times = 10, 5
-    vertices = [np.arange(n_vert, dtype=np.int), np.empty(0, dtype=np.int)]
+    vertices = [np.arange(n_vert, dtype=np.int64), np.empty(0, dtype=np.int64)]
     data = rng.randn(n_vert, n_times)
     stc_surf = SourceEstimate(data, vertices=vertices, tmin=0, tstep=1,
                               subject='sample')
@@ -1010,7 +1010,7 @@ def test_to_data_frame():
 def test_to_data_frame_index(index):
     """Test index creation in stc Pandas exporter."""
     n_vert, n_times = 10, 5
-    vertices = [np.arange(n_vert, dtype=np.int), np.empty(0, dtype=np.int)]
+    vertices = [np.arange(n_vert, dtype=np.int64), np.empty(0, dtype=np.int64)]
     data = rng.randn(n_vert, n_times)
     stc = SourceEstimate(data, vertices=vertices, tmin=0, tstep=1,
                          subject='sample')

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -90,7 +90,7 @@ def test_compute_nearest():
     """Test nearest neighbor searches."""
     x = rng.randn(500, 3)
     x /= np.sqrt(np.sum(x ** 2, axis=1))[:, None]
-    nn_true = rng.permutation(np.arange(500, dtype=np.int))[:20]
+    nn_true = rng.permutation(np.arange(500, dtype=np.int64))[:20]
     y = x[nn_true]
 
     nn1 = _compute_nearest(x, y, method='BallTree')

--- a/mne/time_frequency/_stft.py
+++ b/mne/time_frequency/_stft.py
@@ -65,7 +65,7 @@ def stft(x, wsize, tstep=None, verbose=None):
     logger.info("Number of frequencies: %d" % n_freq)
     logger.info("Number of time steps: %d" % n_step)
 
-    X = np.zeros((n_signals, n_freq, n_step), dtype=np.complex)
+    X = np.zeros((n_signals, n_freq, n_step), dtype=np.complex128)
 
     if n_signals == 0:
         return X

--- a/mne/time_frequency/_stft.py
+++ b/mne/time_frequency/_stft.py
@@ -143,7 +143,7 @@ def istft(X, tstep=None, Tx=None):
 
     T = n_step * tstep
 
-    x = np.zeros((n_signals, T + wsize - tstep), dtype=np.float)
+    x = np.zeros((n_signals, T + wsize - tstep), dtype=np.float64)
 
     if n_signals == 0:
         return x[:, :Tx]
@@ -153,7 +153,7 @@ def istft(X, tstep=None, Tx=None):
     # win = win / norm(win);
 
     # Pre-processing for edges
-    swin = np.zeros(T + wsize - tstep, dtype=np.float)
+    swin = np.zeros(T + wsize - tstep, dtype=np.float64)
     for t in range(n_step):
         swin[t * tstep:t * tstep + wsize] += win ** 2
     swin = np.sqrt(swin / wsize)

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -47,7 +47,7 @@ def _precompute_st_windows(n_samp, start_f, stop_f, sfreq, width):
 
     k = width  # 1 for classical stowckwell transform
     f_range = np.arange(start_f, stop_f, 1)
-    windows = np.empty((len(f_range), len(tw)), dtype=np.complex)
+    windows = np.empty((len(f_range), len(tw)), dtype=np.complex128)
     for i_f, f in enumerate(f_range):
         if f == 0.:
             window = np.ones(len(tw))
@@ -62,7 +62,7 @@ def _precompute_st_windows(n_samp, start_f, stop_f, sfreq, width):
 def _st(x, start_f, windows):
     """Compute ST based on Ali Moukadem MATLAB code (used in tests)."""
     n_samp = x.shape[-1]
-    ST = np.empty(x.shape[:-1] + (len(windows), n_samp), dtype=np.complex)
+    ST = np.empty(x.shape[:-1] + (len(windows), n_samp), dtype=np.complex128)
     # do the work
     Fx = fftpack.fft(x)
     XF = np.concatenate([Fx, Fx], axis=-1)

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -1112,7 +1112,7 @@ def _execute_csd_function(X, times, frequencies, csd_function, params, n_fft,
 
     n_freqs = len(frequencies)
     csds_mean = np.zeros((n_channels * (n_channels + 1) // 2, n_freqs),
-                         dtype=np.complex)
+                         dtype=np.complex128)
 
     # Prepare the function that does the actual CSD computation for parallel
     # execution.

--- a/mne/time_frequency/tests/test_stft.py
+++ b/mne/time_frequency/tests/test_stft.py
@@ -12,7 +12,7 @@ def test_stft():
     f = 7.  # Hz
     for T in [127, 128]:  # try with even and odd numbers
         # Test with low frequency signal
-        t = np.arange(T).astype(np.float)
+        t = np.arange(T).astype(np.float64)
         x = np.sin(2 * np.pi * f * t / sfreq)
         x = np.array([x, x + 1.])
         wsize = 128

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -285,7 +285,7 @@ def test_tfr_multitaper():
     seed = 42
     rng = np.random.RandomState(seed)
     noise = 0.1 * rng.randn(n_epochs, len(ch_names), n_times)
-    t = np.arange(n_times, dtype=np.float) / sfreq
+    t = np.arange(n_times, dtype=np.float64) / sfreq
     signal = np.sin(np.pi * 2. * 50. * t)  # 50 Hz sinusoid signal
     signal[np.logical_or(t < 0.45, t > 0.55)] = 0.  # Hard windowing
     on_time = np.logical_and(t >= 0.45, t <= 0.55)
@@ -302,7 +302,7 @@ def test_tfr_multitaper():
     epochs = EpochsArray(data=dat, info=info, events=events, event_id=event_id,
                          reject=reject)
 
-    freqs = np.arange(35, 70, 5, dtype=np.float)
+    freqs = np.arange(35, 70, 5, dtype=np.float64)
 
     power, itc = tfr_multitaper(epochs, freqs=freqs, n_cycles=freqs / 2.,
                                 time_bandwidth=4.0)
@@ -657,7 +657,7 @@ def test_compute_tfr():
         if output in ('complex', 'avg_power_itc'):
             assert_equal(np.complex, out.dtype)
         else:
-            assert_equal(np.float, out.dtype)
+            assert_equal(np.float64, out.dtype)
         assert (np.all(np.isfinite(out)))
 
     # Check errors params

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -655,7 +655,7 @@ def test_compute_tfr():
 
         # Check types
         if output in ('complex', 'avg_power_itc'):
-            assert_equal(np.complex, out.dtype)
+            assert_equal(np.complex128, out.dtype)
         else:
             assert_equal(np.float64, out.dtype)
         assert (np.all(np.isfinite(out)))

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -372,7 +372,7 @@ def _compute_tfr(epoch_data, freqs, sfreq=1.0, method='morlet',
     elif output in ('complex', 'avg_power_itc'):
         # avg_power_itc is stored as power + 1i * itc to keep a
         # simple dimensionality
-        dtype = np.complex
+        dtype = np.complex128
 
     if ('avg_' in output) or ('itc' in output):
         out = np.empty((n_chans, n_freqs, n_times), dtype)
@@ -497,7 +497,7 @@ def _time_frequency_loop(X, Ws, output, use_fft, mode, decim):
     # Set output type
     dtype = np.float
     if output in ['complex', 'avg_power_itc']:
-        dtype = np.complex
+        dtype = np.complex128
 
     # Init outputs
     decim = _check_decim(decim)
@@ -514,7 +514,7 @@ def _time_frequency_loop(X, Ws, output, use_fft, mode, decim):
 
         # Inter-trial phase locking is apparently computed per taper...
         if 'itc' in output:
-            plf = np.zeros((n_freqs, n_times), dtype=np.complex)
+            plf = np.zeros((n_freqs, n_times), dtype=np.complex128)
 
         # Loop across epochs
         for epoch_idx, tfr in enumerate(coefs):
@@ -591,7 +591,7 @@ def cwt(X, Ws, use_fft=True, mode='same', decim=1):
 
     coefs = _cwt(X, Ws, mode, decim=decim, use_fft=use_fft)
 
-    tfrs = np.empty((n_signals, len(Ws), n_times), dtype=np.complex)
+    tfrs = np.empty((n_signals, len(Ws), n_times), dtype=np.complex128)
     for k, tfr in enumerate(coefs):
         tfrs[k] = tfr
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1463,7 +1463,7 @@ def _plot_mpl_stc(stc, subject=None, surface='inflated', hemi='lh',
 
     curv = nib.freesurfer.read_morph_data(
         op.join(subjects_dir, subject, 'surf', '%s.curv' % hemi))[inuse]
-    curv = np.clip(np.array(curv > 0, np.int), 0.33, 0.66)
+    curv = np.clip(np.array(curv > 0, np.int64), 0.33, 0.66)
     params = dict(ax=ax, stc=stc, coords=coords, faces=faces,
                   hemi_idx=hemi_idx, vertices=vertices, e=e,
                   smoothing_steps=smoothing_steps, n_verts=n_verts,

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -868,7 +868,7 @@ class _Brain(object):
                 rgb = np.round(np.multiply(colorConverter.to_rgb(color), 255))
                 cmap[:, :3] = rgb.astype(cmap.dtype)
 
-            ctable = cmap.astype(np.float) / 255.
+            ctable = cmap.astype(np.float64) / 255.
 
             mesh_data = self._renderer.mesh(
                 x=self.geo[hemi].coords[:, 0],
@@ -1447,7 +1447,7 @@ class _Brain(object):
             edges = mesh_edges(self.geo[hemi].faces)
             edges = edges.tocoo()
             border_edges = label[edges.row] != label[edges.col]
-            show = np.zeros(n_vertices, dtype=np.int)
+            show = np.zeros(n_vertices, dtype=np.int64)
             keep_idx = np.unique(edges.row[border_edges])
             if isinstance(borders, int):
                 for _ in range(borders):

--- a/mne/viz/_brain/colormap.py
+++ b/mne/viz/_brain/colormap.py
@@ -12,7 +12,7 @@ def create_lut(cmap, n_colors=256, center=None):
     """Return a colormap suitable for setting as a LUT."""
     from matplotlib import cm
     cmap = cm.get_cmap(cmap)
-    lut = np.round(cmap(np.linspace(0, 1, n_colors)) * 255.0).astype(np.int)
+    lut = np.round(cmap(np.linspace(0, 1, n_colors)) * 255.0).astype(np.int64)
     return lut
 
 
@@ -169,5 +169,5 @@ def calculate_lut(lut_table, alpha, fmin, fmid, fmax, center=None,
                                      lut_table[:, chan])
         lut_table = lut
 
-    lut_table = lut_table.astype(np.float) / 255.0
+    lut_table = lut_table.astype(np.float64) / 255.0
     return lut_table

--- a/mne/viz/_brain/surface.py
+++ b/mne/viz/_brain/surface.py
@@ -151,7 +151,7 @@ class Surface(object):
         """Load in curvature values from the ?h.curv file."""
         curv_path = path.join(self.data_path, 'surf', '%s.curv' % self.hemi)
         self.curv = read_curvature(curv_path, binary=False)
-        self.bin_curv = np.array(self.curv > 0, np.int)
+        self.bin_curv = np.array(self.curv > 0, np.int64)
         # morphometry (curvature) normalization in order to get gray cortex
         # TODO: delete self.grey_curv after cortex parameter
         # will be fully supported

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -124,11 +124,11 @@ class _Renderer(_BaseRenderer):
                 l_m = surface.module_manager.scalar_lut_manager
                 if colormap.dtype == np.uint8:
                     l_m.lut.table = colormap
-                elif colormap.dtype == np.float:
+                elif colormap.dtype == np.float64:
                     l_m.load_lut_from_list(colormap)
                 else:
                     raise TypeError('Expected type for colormap values are'
-                                    ' np.float or np.uint8: '
+                                    ' np.float64 or np.uint8: '
                                     '{} was given'.format(colormap.dtype))
             surface.actor.property.shading = shading
             surface.actor.property.backface_culling = backface_culling

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -221,7 +221,7 @@ class _Renderer(_BaseRenderer):
                 rgba = True
             if isinstance(colormap, np.ndarray):
                 if colormap.dtype == np.uint8:
-                    colormap = colormap.astype(np.float) / 255.
+                    colormap = colormap.astype(np.float64) / 255.
                 from matplotlib.colors import ListedColormap
                 colormap = ListedColormap(colormap)
 

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -36,15 +36,15 @@ def _check_color(color):
         np_color = np.array(color)
         if np_color.size % 3 != 0 and np_color.size % 4 != 0:
             raise ValueError("The expected valid format is RGB or RGBA.")
-        if np_color.dtype == np.int:
+        if np_color.dtype == np.int64:
             if (np_color < 0).any() or (np_color > 255).any():
                 raise ValueError("Values out of range [0, 255].")
-        elif np_color.dtype == np.float:
+        elif np_color.dtype == np.float64:
             if (np_color < 0.0).any() or (np_color > 1.0).any():
                 raise ValueError("Values out of range [0.0, 1.0].")
         else:
-            raise TypeError("Expected data type is `np.int` or `np.float` but "
-                            "{} was given.".format(np_color.dtype))
+            raise TypeError("Expected data type is `np.int64` or `np.float64` "
+                            "but {} was given.".format(np_color.dtype))
     else:
         raise TypeError("Expected type is `str` or iterable but "
                         "{} was given.".format(type(color)))

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -36,15 +36,16 @@ def _check_color(color):
         np_color = np.array(color)
         if np_color.size % 3 != 0 and np_color.size % 4 != 0:
             raise ValueError("The expected valid format is RGB or RGBA.")
-        if np_color.dtype == np.int64:
+        if np_color.dtype in (np.int64, np.int32):
             if (np_color < 0).any() or (np_color > 255).any():
                 raise ValueError("Values out of range [0, 255].")
         elif np_color.dtype == np.float64:
             if (np_color < 0.0).any() or (np_color > 1.0).any():
                 raise ValueError("Values out of range [0.0, 1.0].")
         else:
-            raise TypeError("Expected data type is `np.int64` or `np.float64` "
-                            "but {} was given.".format(np_color.dtype))
+            raise TypeError("Expected data type is `np.int64`, `np.int32`, or "
+                            "`np.float64` but {} was given."
+                            .format(np_color.dtype))
     else:
         raise TypeError("Expected type is `str` or iterable but "
                         "{} was given.".format(type(color)))

--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -50,7 +50,7 @@ def circular_layout(node_names, node_order, start_pos=90, start_between=True,
         raise ValueError('node_order has to be the same length as node_names')
 
     if group_boundaries is not None:
-        boundaries = np.array(group_boundaries, dtype=np.int)
+        boundaries = np.array(group_boundaries, dtype=np.int64)
         if np.any(boundaries >= n_nodes) or np.any(boundaries < 0):
             raise ValueError('"group_boundaries" has to be between 0 and '
                              'n_nodes - 1.')
@@ -78,7 +78,7 @@ def circular_layout(node_names, node_order, start_pos=90, start_between=True,
             start_pos += group_sep / 2
             boundaries = boundaries[1:] if n_group_sep > 1 else None
 
-    node_angles = np.ones(n_nodes, dtype=np.float) * node_sep
+    node_angles = np.ones(n_nodes, dtype=np.float64) * node_sep
     node_angles[0] = start_pos
     if boundaries is not None:
         node_angles[boundaries] += group_sep
@@ -325,7 +325,7 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
     # edges: We modulate the noise with the number of connections of the
     # node and the connection strength, such that the strongest connections
     # are closer to the node center
-    nodes_n_con = np.zeros((n_nodes), dtype=np.int)
+    nodes_n_con = np.zeros((n_nodes), dtype=np.int64)
     for i, j in zip(indices[0], indices[1]):
         nodes_n_con[i] += 1
         nodes_n_con[j] += 1

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -290,7 +290,7 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
 
         picks = np.array([pick for pick in picks if pick not in exclude])
 
-    types = np.array(_get_channel_types(info, picks), np.unicode)
+    types = np.array(_get_channel_types(info, picks), str)
     ch_types_used = list()
     for this_type in _VALID_CHANNEL_TYPES:
         if this_type in types:

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -2317,7 +2317,7 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
                        invert_y, vlines, tmin, tmax, units, skip_axlabel)
     # add inset scalp plot showing location of sensors picked
     if show_sensors:
-        _validate_type(show_sensors, (np.int, bool, str, type(None)),
+        _validate_type(show_sensors, (np.int64, bool, str, type(None)),
                        'show_sensors', 'numeric, str, None or bool')
         if not _check_ch_locs(np.array(one_evoked.info['chs'])[pos_picks]):
             warn('Cannot find channel coordinates in the supplied Evokeds. '

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -136,7 +136,7 @@ def test_plot_sparse_source_estimates(renderer_interactive):
     stc_data = np.zeros((len(inds), n_time))
     stc_data[0, 1] = 1.
     stc_data[1, 4] = 2.
-    vertices = [vertices[inds], np.empty(0, dtype=np.int)]
+    vertices = [vertices[inds], np.empty(0, dtype=np.int64)]
     stc = SourceEstimate(stc_data, vertices, 1, 1)
     surf = plot_sparse_source_estimates(sample_src, stc, bgcolor=(1, 1, 1),
                                         opacity=0.5, high_resolution=False)

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -282,7 +282,7 @@ def test_plot_butterfly():
     sfreq = 1000.
     data = np.sin(rng.randn(n_epochs, n_channels, n_times))
     events = np.array([np.arange(n_epochs), [0] * n_epochs, np.ones([n_epochs],
-                       dtype=np.int)]).T
+                       dtype=np.int64)]).T
     chanlist = ['eeg' if chan < n_channels // 3 else 'ecog'
                 if chan < n_channels // 2 else 'seeg'
                 for chan in range(n_channels)]

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -200,7 +200,7 @@ def test_plot_ica_sources():
     assert_array_equal(ica.exclude, [1])
     plt.close('all')
 
-    # dtype can change int->np.int after load, test it explicitly
+    # dtype can change int->np.int64 after load, test it explicitly
     ica.n_components_ = np.int64(ica.n_components_)
     fig = ica.plot_sources(raw)
     # also test mouse clicks

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2963,7 +2963,7 @@ def _plot_masked_image(ax, data, times, mask=None, yvals=None,
         if mask.all():
             t_end = ", all points masked)"
         else:
-            fraction = 1 - (np.float(mask.sum()) / np.float(mask.size))
+            fraction = 1 - (np.float64(mask.sum()) / np.float64(mask.size))
             t_end = ", %0.3g%% of points masked)" % (fraction * 100,)
     else:
         t_end = ")"


### PR DESCRIPTION
Closes #7914 

Done by substituting for example `(np\.float)([^1-9i])` with `np.float64$2` in vscode, then running `make flake` and manually fixing. Then still added to the `ignores` because (at least) numba and nibabel starting causing similar warnings in their code.