### PR TITLE
MRG: TimeViewer matplotlib figure color

### DIFF
--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -85,6 +85,19 @@ class MplCanvas(object):
                          framealpha=0.5, handlelength=1.)
         self.canvas.draw()
 
+    def set_color(self, bg_color, fg_color):
+        """Set the widget colors."""
+        self.axes.set_facecolor(bg_color)
+        self.axes.xaxis.label.set_color(fg_color)
+        self.axes.yaxis.label.set_color(fg_color)
+        self.axes.spines['top'].set_color(fg_color)
+        self.axes.spines['bottom'].set_color(fg_color)
+        self.axes.spines['left'].set_color(fg_color)
+        self.axes.spines['right'].set_color(fg_color)
+        self.axes.tick_params(axis='x', colors=fg_color)
+        self.axes.tick_params(axis='y', colors=fg_color)
+        self.fig.patch.set_facecolor(bg_color)
+
     def show(self):
         """Show the canvas."""
         self.canvas.show()
@@ -802,6 +815,10 @@ class _TimeViewer(object):
                 vlayout.addWidget(self.mpl_canvas.canvas)
                 vlayout.setStretch(0, 2)
                 vlayout.setStretch(1, 1)
+            self.mpl_canvas.set_color(
+                bg_color=self.brain._bg_color,
+                fg_color=self.brain._fg_color,
+            )
             self.mpl_canvas.show()
 
             # get brain data

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -1081,7 +1081,7 @@ class _TimeViewer(object):
                 self.time_line = self.mpl_canvas.plot_time_line(
                     x=current_time,
                     label='time',
-                    color='black',
+                    color=self.brain._fg_color,
                     lw=1,
                 )
             else:


### PR DESCRIPTION
This PR updates the background and foreground colors of the internal matplotlib figure depending on the palette chosen for `_Brain`.

background="white" | background="black" (default)
----|-----
![image](https://user-images.githubusercontent.com/18143289/85727895-b2bb0600-b6f7-11ea-8d15-329d347c2ae4.png) | ![image](https://user-images.githubusercontent.com/18143289/85727842-a636ad80-b6f7-11ea-8c8c-7523ea800cc4.png)


It's an item of #7162 