### PR TITLE
MRG, ENH: Scrape traces when available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,10 @@ jobs:
               echo "set -e" >> $BASH_ENV
               echo "export DISPLAY=:99" >> $BASH_ENV
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
+              echo "export XDG_RUNTIME_DIR=/tmp/runtime-circleci"  >> $BASH_ENV
               source tools/get_minimal_commands.sh
               echo "source ${PWD}/tools/get_minimal_commands.sh" >> $BASH_ENV
               echo "export MNE_3D_BACKEND=pyvista" >> $BASH_ENV
-              echo "export _MNE_BRAIN_TRACES_AUTO=false" >> $BASH_ENV
               echo "export PATH=~/.local/bin/:${MNE_ROOT}/bin:$PATH" >> $BASH_ENV
               echo "BASH_ENV:"
               cat $BASH_ENV

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -64,7 +64,7 @@ html-noplot:
 	@echo "Build finished. The HTML pages are in _build/html_stable."
 
 html_dev-front:
-	@PATTERN="\(plot_mne_dspm_source_localization.py\|plot_receptive_field.py\|plot_mne_inverse_label_connectivity.py\|plot_sensors_decoding.py\|plot_stats_cluster_spatio_temporal.py\|plot_visualize_evoked.py\)" make html_dev-pattern;
+	@PATTERN="\(plot_mne_dspm_source_localization.py\|plot_receptive_field.py\|plot_mne_inverse_label_connectivity.py\|plot_sensors_decoding.py\|plot_stats_cluster_spatio_temporal.py\|plot_20_visualize_evoked.py\)" make html_dev-pattern;
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) _build/dirhtml

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -73,6 +73,8 @@ Changelog
 
 - Speed up :meth:`mne.Epochs.copy` and :meth:`mne.Epochs.__getitem__` by avoiding copying immutable attributes by `Eric Larson`_
 
+- Speed up and reduce memory usage of :meth:`mne.SourceEstimate.plot` and related functions/methods when ``show_traces=True`` by `Eric Larson`_
+
 - Reduce memory usage of `~mne.io.Raw.plot_psd`, `~mne.time_frequency.psd_welch`, and `~mne.time_frequency.psd_array_welch` for long segments of data by `Eric Larson`_
 
 - Support for saving movies of source time courses (STCs) with ``brain.save_movie`` method and from graphical user interface by `Guillaume Favelier`_

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -384,7 +384,7 @@ if any(x in scrapers for x in ('pyvista', 'mayavi')):
 else:
     report_scraper = None
 if 'pyvista' in scrapers:
-    brain_scraper = mne.viz._3d._BrainScraper()
+    brain_scraper = mne.viz._brain._BrainScraper()
     scrapers = list(scrapers)
     scrapers.insert(scrapers.index('pyvista'), brain_scraper)
     scrapers = tuple(scrapers)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -383,6 +383,11 @@ if any(x in scrapers for x in ('pyvista', 'mayavi')):
     scrapers += (report_scraper,)
 else:
     report_scraper = None
+if 'pyvista' in scrapers:
+    brain_scraper = mne.viz._3d._BrainScraper()
+    scrapers = list(scrapers)
+    scrapers.insert(scrapers.index('pyvista'), brain_scraper)
+    scrapers = tuple(scrapers)
 
 
 def append_attr_meth_examples(app, what, name, obj, options, lines):

--- a/examples/inverse/plot_source_space_snr.py
+++ b/examples/inverse/plot_source_space_snr.py
@@ -5,7 +5,6 @@ Computing source space SNR
 ===============================
 
 This example shows how to compute and plot source space SNR as in [1]_.
-
 """
 # Author: Padma Sundaram <tottochan@gmail.com>
 #         Kaisu Lankinen <klankinen@mgh.harvard.edu>

--- a/examples/inverse/plot_source_space_snr.py
+++ b/examples/inverse/plot_source_space_snr.py
@@ -5,6 +5,7 @@ Computing source space SNR
 ===============================
 
 This example shows how to compute and plot source space SNR as in [1]_.
+
 """
 # Author: Padma Sundaram <tottochan@gmail.com>
 #         Kaisu Lankinen <klankinen@mgh.harvard.edu>

--- a/mne/tests/test_import_nesting.py
+++ b/mne/tests/test_import_nesting.py
@@ -25,10 +25,9 @@ if len(bad) > 0:
     out |= {'scipy submodules: %s' % list(bad)}
 
 # check sklearn and others
-_sklearn = _pandas = _mayavi = _matplotlib = False
 for x in sys.modules.keys():
     for key in ('sklearn', 'pandas', 'mayavi', 'pyvista', 'matplotlib',
-                'dipy', 'nibabel', 'cupy', 'picard'):
+                'dipy', 'nibabel', 'cupy', 'picard', 'pyvistaqt'):
         if x.startswith(key):
             out |= {key}
 if len(out) > 0:

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -975,7 +975,7 @@ docdict["show_traces"] = """
 show_traces : bool | str
     If True, enable interactive picking of a point on the surface of the
     brain and plot it's time course using the bottom 1/3 of the figure.
-    This feature is only available with the PyVista 3d backend when
+    This feature is only available with the PyVista 3d backend, and requires
     ``time_viewer=True``. Defaults to 'auto', which will use True if and
     only if ``time_viewer=True``, the backend is PyVista, and there is more
     than one time point.

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -11,9 +11,7 @@
 # License: Simplified BSD
 
 from distutils.version import LooseVersion
-import gc
 from itertools import cycle
-import os
 import os.path as op
 import sys
 import warnings
@@ -1774,9 +1772,7 @@ def _check_time_viewer_compatibility(brain, time_viewer, show_traces):
             not using_mayavi and
             time_viewer and
             brain._times is not None and
-            len(brain._times) > 1 and
-            # XXX temporary hidden workaround for memory problems on CircleCI
-            os.getenv('_MNE_BRAIN_TRACES_AUTO', 'true').lower() != 'false'
+            len(brain._times) > 1
         )
 
     if _get_3d_backend() == "mayavi" and all([time_viewer, show_traces]):
@@ -1786,6 +1782,9 @@ def _check_time_viewer_compatibility(brain, time_viewer, show_traces):
         if not check_version('surfer', '0.9'):
             raise RuntimeError('This function requires pysurfer version '
                                '>= 0.9')
+
+    if show_traces and not time_viewer:
+        raise ValueError('show_traces cannot be used when time_viewer=False')
 
     if time_viewer:
         if using_mayavi:
@@ -3189,69 +3188,3 @@ def _get_3d_option(key):
     opt = opt.lower()
     _check_option(f'3D option {key}', opt, ('true', 'false'))
     return opt == 'true'
-
-
-class _BrainScraper(object):
-    """Scrape Brain objects."""
-
-    def __repr__(self):
-        return '<BrainScraper>'
-
-    def __call__(self, block, block_vars, gallery_conf):
-        rst = ''
-        try:
-            from ._brain import _Brain
-        except ImportError:  # in case we haven't fired up the 3D plotting yet
-            return rst
-        for brain in block_vars['example_globals'].values():
-            # Only need to process if it's a brain with a time_viewer
-            # with traces on and shown in the same window, otherwise
-            # PyVista and matplotlib scrapers can just do the work
-            if (not isinstance(brain, _Brain)) or brain._closed:
-                continue
-            from sphinx_gallery.scrapers import figure_rst
-            from matplotlib.image import imsave
-            from .backends._pyvista import _process_events
-            img_fname = next(block_vars['image_path_iterator'])
-            img = brain.screenshot()
-            assert img.size > 0
-            if getattr(brain, 'time_viewer', None) is not None and \
-                    brain.time_viewer.show_traces and \
-                    not brain.time_viewer.separate_canvas:
-                canvas = brain.time_viewer.mpl_canvas.fig.canvas
-                canvas.draw_idle()
-                # In theory, one of these should work:
-                #
-                # trace_img = np.frombuffer(
-                #     canvas.tostring_rgb(), dtype=np.uint8)
-                # trace_img.shape = canvas.get_width_height()[::-1] + (3,)
-                #
-                # or
-                #
-                # trace_img = np.frombuffer(
-                #     canvas.tostring_rgb(), dtype=np.uint8)
-                # size = time_viewer.mpl_canvas.getSize()
-                # trace_img.shape = (size.height(), size.width(), 3)
-                #
-                # But in practice, sometimes the sizes does not match the
-                # renderer tostring_rgb() size. So let's directly use what
-                # matplotlib does in lib/matplotlib/backends/backend_agg.py
-                # before calling tobytes():
-                trace_img = np.asarray(
-                    canvas.renderer._renderer).take([0, 1, 2], axis=2)
-                # need to slice into trace_img because generally it's a bit
-                # smaller
-                delta = trace_img.shape[1] - img.shape[1]
-                if delta > 0:
-                    start = delta // 2
-                    trace_img = trace_img[:, start:start + img.shape[1]]
-                img = np.concatenate([img, trace_img], axis=0)
-            imsave(img_fname, img)
-            assert op.isfile(img_fname)
-            rst += figure_rst(
-                [img_fname], gallery_conf['src_dir'], brain._title)
-            brain.close()
-            _process_events(brain._renderer.plotter)
-            _process_events(brain._renderer.plotter)
-            gc.collect()
-        return rst

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -11,6 +11,7 @@
 # License: Simplified BSD
 
 from distutils.version import LooseVersion
+import gc
 from itertools import cycle
 import os
 import os.path as op
@@ -3188,3 +3189,69 @@ def _get_3d_option(key):
     opt = opt.lower()
     _check_option(f'3D option {key}', opt, ('true', 'false'))
     return opt == 'true'
+
+
+class _BrainScraper(object):
+    """Scrape Brain objects."""
+
+    def __repr__(self):
+        return '<BrainScraper>'
+
+    def __call__(self, block, block_vars, gallery_conf):
+        rst = ''
+        try:
+            from ._brain import _Brain
+        except ImportError:  # in case we haven't fired up the 3D plotting yet
+            return rst
+        for brain in block_vars['example_globals'].values():
+            # Only need to process if it's a brain with a time_viewer
+            # with traces on and shown in the same window, otherwise
+            # PyVista and matplotlib scrapers can just do the work
+            if (not isinstance(brain, _Brain)) or brain._closed:
+                continue
+            from sphinx_gallery.scrapers import figure_rst
+            from matplotlib.image import imsave
+            from .backends._pyvista import _process_events
+            img_fname = next(block_vars['image_path_iterator'])
+            img = brain.screenshot()
+            assert img.size > 0
+            if getattr(brain, 'time_viewer', None) is not None and \
+                    brain.time_viewer.show_traces and \
+                    not brain.time_viewer.separate_canvas:
+                canvas = brain.time_viewer.mpl_canvas.fig.canvas
+                canvas.draw_idle()
+                # In theory, one of these should work:
+                #
+                # trace_img = np.frombuffer(
+                #     canvas.tostring_rgb(), dtype=np.uint8)
+                # trace_img.shape = canvas.get_width_height()[::-1] + (3,)
+                #
+                # or
+                #
+                # trace_img = np.frombuffer(
+                #     canvas.tostring_rgb(), dtype=np.uint8)
+                # size = time_viewer.mpl_canvas.getSize()
+                # trace_img.shape = (size.height(), size.width(), 3)
+                #
+                # But in practice, sometimes the sizes does not match the
+                # renderer tostring_rgb() size. So let's directly use what
+                # matplotlib does in lib/matplotlib/backends/backend_agg.py
+                # before calling tobytes():
+                trace_img = np.asarray(
+                    canvas.renderer._renderer).take([0, 1, 2], axis=2)
+                # need to slice into trace_img because generally it's a bit
+                # smaller
+                delta = trace_img.shape[1] - img.shape[1]
+                if delta > 0:
+                    start = delta // 2
+                    trace_img = trace_img[:, start:start + img.shape[1]]
+                img = np.concatenate([img, trace_img], axis=0)
+            imsave(img_fname, img)
+            assert op.isfile(img_fname)
+            rst += figure_rst(
+                [img_fname], gallery_conf['src_dir'], brain._title)
+            brain.close()
+            _process_events(brain._renderer.plotter)
+            _process_events(brain._renderer.plotter)
+            gc.collect()
+        return rst

--- a/mne/viz/__init__.py
+++ b/mne/viz/__init__.py
@@ -29,4 +29,4 @@ from .montage import plot_montage
 from .backends.renderer import (set_3d_backend, get_3d_backend, use_3d_backend,
                                 set_3d_view, set_3d_title, create_3d_figure,
                                 get_brain_class)
-from . import backends
+from . import backends, _brain

--- a/mne/viz/_brain/__init__.py
+++ b/mne/viz/_brain/__init__.py
@@ -10,6 +10,7 @@
 # License: Simplified BSD
 
 from ._brain import _Brain
+from ._scraper import _BrainScraper
 from ._timeviewer import _TimeViewer, _LinkViewer
 
 __all__ = ['_Brain']

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -269,6 +269,7 @@ class _Brain(object):
                     self._renderer.set_camera(azimuth=views_dict[v].azim,
                                               elevation=views_dict[v].elev)
 
+        self._closed = False
         if show:
             self._renderer.show()
 
@@ -925,6 +926,7 @@ class _Brain(object):
 
     def close(self):
         """Close all figures and cleanup data structure."""
+        self._closed = True
         self._renderer.close()
 
     def show(self):

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -20,8 +20,6 @@ from .view import lh_views_dict, rh_views_dict, View
 from .._3d import _process_clim, _handle_time
 
 from ...surface import mesh_edges
-from ...morph import _hemi_morph
-from ...label import read_label, _read_annot
 from ...utils import (_check_option, logger, verbose, fill_doc, _validate_type,
                       use_log_level)
 
@@ -593,6 +591,7 @@ class _Brain(object):
         To remove previously added labels, run Brain.remove_labels().
         """
         from matplotlib.colors import colorConverter
+        from ...label import read_label
         if isinstance(label, str):
             if color is None:
                 color = "crimson"
@@ -821,6 +820,7 @@ class _Brain(object):
             These are passed to the underlying
             ``mayavi.mlab.pipeline.surface`` call.
         """
+        from ...label import _read_annot
         hemis = self._check_hemis(hemi)
 
         # Figure out where the data is coming from
@@ -1030,6 +1030,7 @@ class _Brain(object):
         n_steps : int
             Number of smoothing steps
         """
+        from ...morph import _hemi_morph
         for hemi in ['lh', 'rh']:
             hemi_data = self._data.get(hemi)
             if hemi_data is not None:

--- a/mne/viz/_brain/_scraper.py
+++ b/mne/viz/_brain/_scraper.py
@@ -1,0 +1,63 @@
+import os.path as op
+
+import numpy as np
+
+from ._brain import _Brain
+
+
+class _BrainScraper(object):
+    """Scrape Brain objects."""
+
+    def __repr__(self):
+        return '<BrainScraper>'
+
+    def __call__(self, block, block_vars, gallery_conf):
+        rst = ''
+        for brain in block_vars['example_globals'].values():
+            # Only need to process if it's a brain with a time_viewer
+            # with traces on and shown in the same window, otherwise
+            # PyVista and matplotlib scrapers can just do the work
+            if (not isinstance(brain, _Brain)) or brain._closed:
+                continue
+            from matplotlib.image import imsave
+            from sphinx_gallery.scrapers import figure_rst
+            img_fname = next(block_vars['image_path_iterator'])
+            img = brain.screenshot()
+            assert img.size > 0
+            if getattr(brain, 'time_viewer', None) is not None and \
+                    brain.time_viewer.show_traces and \
+                    not brain.time_viewer.separate_canvas:
+                canvas = brain.time_viewer.mpl_canvas.fig.canvas
+                canvas.draw_idle()
+                # In theory, one of these should work:
+                #
+                # trace_img = np.frombuffer(
+                #     canvas.tostring_rgb(), dtype=np.uint8)
+                # trace_img.shape = canvas.get_width_height()[::-1] + (3,)
+                #
+                # or
+                #
+                # trace_img = np.frombuffer(
+                #     canvas.tostring_rgb(), dtype=np.uint8)
+                # size = time_viewer.mpl_canvas.getSize()
+                # trace_img.shape = (size.height(), size.width(), 3)
+                #
+                # But in practice, sometimes the sizes does not match the
+                # renderer tostring_rgb() size. So let's directly use what
+                # matplotlib does in lib/matplotlib/backends/backend_agg.py
+                # before calling tobytes():
+                trace_img = np.asarray(
+                    canvas.renderer._renderer).take([0, 1, 2], axis=2)
+                # need to slice into trace_img because generally it's a bit
+                # smaller
+                delta = trace_img.shape[1] - img.shape[1]
+                if delta > 0:
+                    start = delta // 2
+                    trace_img = trace_img[:, start:start + img.shape[1]]
+                img = np.concatenate([img, trace_img], axis=0)
+            imsave(img_fname, img)
+            assert op.isfile(img_fname)
+            rst += figure_rst(
+                [img_fname], gallery_conf['src_dir'], brain._title)
+            brain.close()
+        return rst

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -18,9 +18,8 @@ from mne import SourceEstimate, read_source_estimate
 from mne.source_space import read_source_spaces, vertex_to_mni
 from mne.datasets import testing
 from mne.utils import check_version
-from mne.viz._brain import _Brain, _TimeViewer, _LinkViewer
+from mne.viz._brain import _Brain, _TimeViewer, _LinkViewer, _BrainScraper
 from mne.viz._brain.colormap import calculate_lut
-from mne.viz._3d import _BrainScraper
 
 from matplotlib import cm, image
 

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -17,10 +17,12 @@ from numpy.testing import assert_allclose
 from mne import SourceEstimate, read_source_estimate
 from mne.source_space import read_source_spaces, vertex_to_mni
 from mne.datasets import testing
+from mne.utils import check_version
 from mne.viz._brain import _Brain, _TimeViewer, _LinkViewer
 from mne.viz._brain.colormap import calculate_lut
+from mne.viz._3d import _BrainScraper
 
-from matplotlib import cm
+from matplotlib import cm, image
 
 data_path = testing.data_path(download=False)
 subject_id = 'sample'
@@ -198,7 +200,7 @@ def test_brain_timeviewer(renderer_interactive):
     pytest.param('split', marks=pytest.mark.slowtest),
     pytest.param('both', marks=pytest.mark.slowtest),
 ])
-def test_brain_timeviewer_traces(renderer_interactive, hemi):
+def test_brain_timeviewer_traces(renderer_interactive, hemi, tmpdir):
     """Test _TimeViewer traces."""
     if renderer_interactive._get_3d_backend() != 'pyvista':
         pytest.skip('Only PyVista supports traces')
@@ -250,6 +252,22 @@ def test_brain_timeviewer_traces(renderer_interactive, hemi):
 
         assert line.get_label() == label
     assert len(spheres) == len(hemi_str)
+
+    # and the scraper for it (will close the instance)
+    if not check_version('sphinx_gallery'):
+        return
+    screenshot = brain_data.screenshot()
+    fnames = [str(tmpdir.join('temp.png'))]
+    block_vars = dict(image_path_iterator=iter(fnames),
+                      example_globals=dict(brain=brain_data))
+    gallery_conf = dict(src_dir=str(tmpdir))
+    scraper = _BrainScraper()
+    rst = scraper(None, block_vars, gallery_conf)
+    assert 'temp.png' in rst
+    assert path.isfile(fnames[0])
+    img = image.imread(fnames[0])
+    assert img.shape[1] == screenshot.shape[1]  # same width
+    assert img.shape[0] > screenshot.shape[0]  # larger height
 
 
 @testing.requires_testing_data

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -719,6 +719,10 @@ def test_plot_vector_source_estimates(renderer_interactive):
         stc.plot('sample', subjects_dir=subjects_dir,
                  clim=dict(pos_lims=[1, 2, 3]))
 
+    with pytest.raises(ValueError, match='cannot be used'):
+        stc.plot('sample', subjects_dir=subjects_dir,
+                 show_traces=True, time_viewer=False)
+
 
 @pytest.mark.slowtest
 @testing.requires_testing_data

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -6,6 +6,7 @@ pytest-timeout
 pytest-xdist
 flake8
 https://github.com/larsoner/flake8-array-spacing/archive/master.zip
+https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip
 https://github.com/numpy/numpydoc/archive/master.zip
 https://github.com/codespell-project/codespell/archive/master.zip
 pydocstyle

--- a/tutorials/source-modeling/plot_mne_dspm_source_localization.py
+++ b/tutorials/source-modeling/plot_mne_dspm_source_localization.py
@@ -132,6 +132,7 @@ brain.add_text(0.1, 0.9, 'dSPM (plus location of maximal activation)', 'title',
 ###############################################################################
 # Morph data to average brain
 # ---------------------------
+# Next we morph data to ``fsaverage``.
 
 # setup source morph
 morph = mne.compute_source_morph(

--- a/tutorials/source-modeling/plot_visualize_stc.py
+++ b/tutorials/source-modeling/plot_visualize_stc.py
@@ -50,8 +50,7 @@ print(stc)
 # and ``pysurfer`` installed on your machine.
 initial_time = 0.1
 brain = stc.plot(subjects_dir=subjects_dir, initial_time=initial_time,
-                 clim=dict(kind='value', pos_lims=[3, 6, 9]),
-                 time_viewer=True)
+                 clim=dict(kind='value', pos_lims=[3, 6, 9]))
 
 ###############################################################################
 #


### PR DESCRIPTION
As @agramfort requested:

![Screenshot from 2020-06-25 10-33-04](https://user-images.githubusercontent.com/2365790/85740100-56dc8700-b6cf-11ea-9fa8-769286159f20.png)

Todo:

- [x] update latest.inc to mention efficiency gains
- [x] move scraper to mne/viz/_brain/scraper.py
- [x] add `show_traces=True, time_viewer=False` error