### PR TITLE
MRG: Add smoothing controller to TimeViewer for the notebook backend

### DIFF
--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -147,7 +147,7 @@ def test_cov_order():
     whitener_2, w_ch_names_2, n_nzero_2 = compute_whitener(
         cov_reorder, info, return_rank=True)
     assert_array_equal(w_ch_names_2, w_ch_names)
-    assert_allclose(whitener_2, whitener)
+    assert_allclose(whitener_2, whitener, rtol=1e-6)
     assert n_nzero == n_nzero_2
     # with pca
     assert n_nzero < whitener.shape[0]

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -22,7 +22,8 @@ from .._3d import _process_clim, _handle_time
 from ...surface import mesh_edges
 from ...morph import _hemi_morph
 from ...label import read_label, _read_annot
-from ...utils import _check_option, logger, verbose, fill_doc, _validate_type
+from ...utils import (_check_option, logger, verbose, fill_doc, _validate_type,
+                      use_log_level)
 
 
 class _Brain(object):
@@ -1003,10 +1004,11 @@ class _Brain(object):
                         % (len(hemi_data), self.geo[hemi].x.shape[0]))
                 morph_n_steps = 'nearest' if n_steps == 0 else n_steps
                 maps = sparse.eye(len(self.geo[hemi].coords), format='csr')
-                smooth_mat = _hemi_morph(
-                    self.geo[hemi].faces,
-                    np.arange(len(self.geo[hemi].coords)),
-                    vertices, morph_n_steps, maps, warn=False)
+                with use_log_level(False):
+                    smooth_mat = _hemi_morph(
+                        self.geo[hemi].faces,
+                        np.arange(len(self.geo[hemi].coords)),
+                        vertices, morph_n_steps, maps, warn=False)
                 self._data[hemi]['smooth_mat'] = smooth_mat
         self.set_time_point(self._data['time_idx'])
         self._data['smoothing_steps'] = n_steps

--- a/mne/viz/_brain/_notebook.py
+++ b/mne/viz/_brain/_notebook.py
@@ -33,6 +33,11 @@ class _NotebookInteractor(_PyVistaNotebookInteractor):
             self.set_orientation,
             orientation=self.time_viewer.orientation,
         )
+        # smoothing
+        self.controllers["smoothing"] = interactive(
+            self.brain.set_data_smoothing,
+            n_steps=self.time_viewer.default_smoothing_range,
+        )
 
     def set_orientation(self, orientation):
         row, col = self.plotter.index_to_loc(

--- a/mne/viz/_brain/_notebook.py
+++ b/mne/viz/_brain/_notebook.py
@@ -13,7 +13,7 @@ class _NotebookInteractor(_PyVistaNotebookInteractor):
         super().__init__(self.brain._renderer)
 
     def configure_controllers(self):
-        from ipywidgets import FloatSlider, interactive
+        from ipywidgets import IntSlider, FloatSlider, interactive
         super().configure_controllers()
         # time slider
         max_time = len(self.brain._data['time']) - 1
@@ -34,9 +34,15 @@ class _NotebookInteractor(_PyVistaNotebookInteractor):
             orientation=self.time_viewer.orientation,
         )
         # smoothing
+        self.sliders["smoothing"] = IntSlider(
+            value=self.brain._data['smoothing_steps'],
+            min=self.time_viewer.default_smoothing_range[0],
+            max=self.time_viewer.default_smoothing_range[1],
+            continuous_update=False
+        )
         self.controllers["smoothing"] = interactive(
             self.brain.set_data_smoothing,
-            n_steps=self.time_viewer.default_smoothing_range,
+            n_steps=self.sliders["smoothing"]
         )
 
     def set_orientation(self, orientation):

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -302,7 +302,7 @@ class _TimeViewer(object):
             'frontal',
             'parietal'
         ]
-        self.default_smoothing_range = (0, 15)
+        self.default_smoothing_range = [0, 15]
 
         # detect notebook
         if brain._notebook:

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -302,6 +302,7 @@ class _TimeViewer(object):
             'frontal',
             'parietal'
         ]
+        self.default_smoothing_range = (0, 15)
 
         # detect notebook
         if brain._notebook:
@@ -316,7 +317,6 @@ class _TimeViewer(object):
         self.visibility = False
         self.refresh_rate_ms = max(int(round(1000. / 60.)), 1)
         self.default_scaling_range = [0.2, 2.0]
-        self.default_smoothing_range = [0, 15]
         self.default_playback_speed_range = [0.01, 1]
         self.default_playback_speed_value = 0.05
         self.default_status_bar_msg = "Press ? for help"


### PR DESCRIPTION
This PR adds a controller to the `notebook` backend to set the number of smoothing steps when `time_viewer=True`.

**Issue**

The rendering cell is broken because of the text given by `logger` I think (the name of the backend and the number of iterations for smoothing).

![image](https://user-images.githubusercontent.com/18143289/85737915-fe71ad80-b6ff-11ea-9e94-98652e4329f2.png)

![image](https://user-images.githubusercontent.com/18143289/85741131-76d96e00-b702-11ea-90db-c1420ad4caba.png)

It's part of #7162.