### PR TITLE
MRG, MAINT: Simpler VTK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,7 @@ jobs:
         - run:
             name: Get Python running
             command: |
-              python -m pip install --user --upgrade --progress-bar off pip numpy setuptools
-              python -m pip install --user --upgrade --progress-bar off -f "https://vtk.org/download" "vtk>=9"
+              python -m pip install --user --upgrade --progress-bar off pip setuptools
               python -m pip install --user --upgrade --progress-bar off -r requirements.txt
               python -m pip uninstall -yq pysurfer mayavi
               python -m pip install --user --upgrade --progress-bar off --pre sphinx

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ before_install:
         pip uninstall -yq numpy
         pip install -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" --pre numpy
         pip install -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" scipy pandas scikit-learn matplotlib h5py Pillow
-        pip install -f "https://vtk.org/download" "vtk>=9"
         pip install --upgrade -r requirements.txt
       else
         git clone https://github.com/astropy/ci-helpers.git

--- a/environment.yml
+++ b/environment.yml
@@ -30,8 +30,6 @@ dependencies:
 - traitsui>=6
 - imageio>=2.6.1
 - pip:
-  - -i "https://pypi.org/simple/"
-  - -f "https://vtk.org/download"
   - mne
   - https://github.com/numpy/numpydoc/archive/master.zip
   - imageio-ffmpeg>=0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ pytest-xdist
 joblib
 psutil
 dipy
-vtk -f "https://vtk.org/download"
+vtk
 https://github.com/numpy/numpydoc/archive/master.zip
 https://github.com/enthought/mayavi/archive/master.zip
 PySurfer[save_movie]


### PR DESCRIPTION
VTK 9.0.1 plus Linux wheels are up on PyPi. Unfortunately rendering still appears to be broken on OSX. But in the meantime we should be able to get rid of the `-f vtk.org` stuff.