### PR TITLE
MRG, BUG: Fix vector scaling

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -142,6 +142,8 @@ Bug
 
 - Fix plotting with :func:`mne.viz.plot_evoked_topomap` to pre-existing axes by `Daniel McCloy`_
 
+- Fix bug with :func:`mne.viz.plot_vector_source_estimates` using the PyVista backend with ``time_viewer=True`` when updating the arrow colormaps by `Eric Larson`_
+
 - The default plotting mode for :func:`mne.io.Raw.plot` and :ref:`mne browse_raw` has been changed to ``clipping=3.`` to facilitate data analysis with large deflections, by `Eric Larson`_
 
 - PSD plots will now show non-data channels (e.g., ``misc``) if those channels are explicitly passed to ``picks``, by `Daniel McCloy`_.

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -982,13 +982,8 @@ class _Brain(object):
                           transparent=transparent, **lims) *
             255).astype(np.uint8)
         # update our values
-        dt_max = self._data['fmax']
-        if self._data['center'] is None:
-            dt_min = self._data['fmin']
-        else:
-            dt_min = -1 * dt_max
+        rng = self._cmap_range
         ctable = self._data['ctable']
-        rng = [dt_min, dt_max]
         for hemi in ['lh', 'rh']:
             hemi_data = self._data.get(hemi)
             if hemi_data is not None:
@@ -1115,12 +1110,10 @@ class _Brain(object):
         hemi_data = self._data.get(hemi)
         if hemi_data is not None:
             vertices = hemi_data['vertices']
-            fmin = self._data['fmin']
-            fmax = self._data['fmax']
             ctable = self._data['ctable']
             vector_alpha = self._data['vector_alpha']
             scale_factor = self._data['scale_factor']
-            rng = [fmin, fmax]
+            rng = self._cmap_range
             vertices = slice(None) if vertices is None else vertices
             x, y, z = np.array(self.geo[hemi].coords)[vertices].T
 
@@ -1151,6 +1144,16 @@ class _Brain(object):
                 _set_colormap_range(glyph_actor, ctable, None, rng)
                 # the glyphs are now ready to be displayed
                 glyph_actor.VisibilityOn()
+
+    @property
+    def _cmap_range(self):
+        dt_max = self._data['fmax']
+        if self._data['center'] is None:
+            dt_min = self._data['fmin']
+        else:
+            dt_min = -1 * dt_max
+        rng = [dt_min, dt_max]
+        return rng
 
     def _update_fscale(self, fscale):
         """Scale the colorbar points."""

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -189,7 +189,7 @@ class UpdateColorbarScale(object):
 
     def __call__(self, value):
         """Update the colorbar sliders."""
-        self.brain.update_fscale(value)
+        self.brain._update_fscale(value)
         for key in self.keys:
             if self.reps[key] is not None:
                 self.reps[key].SetValue(self.brain._data[key])
@@ -206,9 +206,9 @@ class BumpColorbarPoints(object):
         self.brain = brain
         self.name = name
         self.callback = {
-            "fmin": brain.update_fmin,
-            "fmid": brain.update_fmid,
-            "fmax": brain.update_fmax
+            "fmin": lambda fmin: brain.update_lut(fmin=fmin),
+            "fmid": lambda fmid: brain.update_lut(fmid=fmid),
+            "fmax": lambda fmax: brain.update_lut(fmax=fmax),
         }
         self.keys = ('fmin', 'fmid', 'fmax')
         self.reps = {key: None for key in self.keys}
@@ -219,28 +219,29 @@ class BumpColorbarPoints(object):
         vals = {key: self.brain._data[key] for key in self.keys}
         if self.name == "fmin" and self.reps["fmin"] is not None:
             if vals['fmax'] < value:
-                self.brain.update_fmax(value)
+                vals['fmax'] = value
                 self.reps['fmax'].SetValue(value)
             if vals['fmid'] < value:
-                self.brain.update_fmid(value)
+                vals['fmid'] = value
                 self.reps['fmid'].SetValue(value)
             self.reps['fmin'].SetValue(value)
         elif self.name == "fmid" and self.reps['fmid'] is not None:
             if vals['fmin'] > value:
-                self.brain.update_fmin(value)
+                vals['fmin'] = value
                 self.reps['fmin'].SetValue(value)
             if vals['fmax'] < value:
-                self.brain.update_fmax(value)
+                vals['fmax'] = value
                 self.reps['fmax'].SetValue(value)
             self.reps['fmid'].SetValue(value)
         elif self.name == "fmax" and self.reps['fmax'] is not None:
             if vals['fmin'] > value:
-                self.brain.update_fmin(value)
+                vals['fmin'] = value
                 self.reps['fmin'].SetValue(value)
             if vals['fmid'] > value:
-                self.brain.update_fmid(value)
+                vals['fmid'] = value
                 self.reps['fmid'].SetValue(value)
             self.reps['fmax'].SetValue(value)
+        self.brain.update_lut(**vals)
         if time.time() > self.last_update + 1. / 60.:
             self.callback[self.name](value)
             self.last_update = time.time()


### PR DESCRIPTION
Fixes the bug with glyph colormap not being updated, tested with:

<details>

```
import os.path as op
import mne

data_path = mne.datasets.sample.data_path()
sample_dir = op.join(data_path, 'MEG', 'sample')
subjects_dir = op.join(data_path, 'subjects')
inv = mne.minimum_norm.read_inverse_operator(op.join(
    sample_dir, 'sample_audvis-meg-oct-6-meg-inv.fif'))
evoked = mne.read_evokeds(op.join(sample_dir, 'sample_audvis-ave.fif'))[0]
evoked.apply_baseline((None, 0))
stc = mne.minimum_norm.apply_inverse(
    evoked, inv, method='dSPM', verbose='debug', pick_ori='vector')  # 'vector')
initial_time = 0.1

size = (800, 400)
with mne.viz.use_3d_backend('pyvista'):
    brain = stc.plot(subjects_dir=subjects_dir, initial_time=initial_time,
                     clim='auto', views='lat', hemi='lh',
                     smoothing_steps='nearest', verbose=True,
                     size=size, background='k')
```

</details>

A few things along the way:

1. Consolidate `update_lut` so that there is no longer a need for the very repeat-y `update_fmin`, `update_fmid`, and `update_fmax`
2. Refactor some time viewer slider controls to make one call to `update_lut` instead of potentially multiple calls like `update_fmin` followed by `update_fmid`
3. Make `update_fscale` private (I don't think it was meant to be public)
4. Never apply `alpha` to the LUT, but instead apply it to the `mesh(..., opacity=alpha)` instead.

Approximately 3x minus-to-plus ratio on this PR suggesting that it's DRYing out our code. No test added because I'm not sure that there is a great way to test this. In theory if there were existing vector + TimeViewer tests it could be added there, but in a quick check I did not see any. @GuillaumeFavelier feel free to correct me if I'm wrong...