### PR TITLE
MRG, VIZ, BUG: handle CSD channel type when topo plotting

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1262,7 +1262,7 @@ def find_ch_adjacency(info, ch_type):
     (has_vv_mag, has_vv_grad, is_old_vv, has_4D_mag, ctf_other_types,
      has_CTF_grad, n_kit_grads, has_any_meg, has_eeg_coils,
      has_eeg_coils_and_meg, has_eeg_coils_only,
-     has_neuromag_122_grad) = _get_ch_info(info)
+     has_neuromag_122_grad, has_csd_coils) = _get_ch_info(info)
     conn_name = None
     if has_vv_mag and ch_type == 'mag':
         conn_name = 'neuromag306mag'
@@ -1452,10 +1452,13 @@ def _get_ch_info(info):
                      FIFF.FIFFV_EEG_CH in channel_types)
     has_eeg_coils_and_meg = has_eeg_coils and has_any_meg
     has_eeg_coils_only = has_eeg_coils and not has_any_meg
+    has_csd_coils = (FIFF.FIFFV_COIL_EEG_CSD in coil_types and
+                     FIFF.FIFFV_EEG_CH in channel_types)
 
     return (has_vv_mag, has_vv_grad, is_old_vv, has_4D_mag, ctf_other_types,
             has_CTF_grad, n_kit_grads, has_any_meg, has_eeg_coils,
-            has_eeg_coils_and_meg, has_eeg_coils_only, has_neuromag_122_grad)
+            has_eeg_coils_and_meg, has_eeg_coils_only, has_neuromag_122_grad,
+            has_csd_coils)
 
 
 def make_1020_channel_selections(info, midline="z"):

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1448,8 +1448,7 @@ def _get_ch_info(info):
 
     has_any_meg = any([has_vv_mag, has_vv_grad, has_4D_mag, has_CTF_grad,
                        n_kit_grads])
-    has_eeg_coils = ((FIFF.FIFFV_COIL_EEG in coil_types or
-                      FIFF.FIFFV_COIL_EEG_CSD in coil_types) and
+    has_eeg_coils = (FIFF.FIFFV_COIL_EEG in coil_types and
                      FIFF.FIFFV_EEG_CH in channel_types)
     has_eeg_coils_and_meg = has_eeg_coils and has_any_meg
     has_eeg_coils_only = has_eeg_coils and not has_any_meg

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1448,7 +1448,8 @@ def _get_ch_info(info):
 
     has_any_meg = any([has_vv_mag, has_vv_grad, has_4D_mag, has_CTF_grad,
                        n_kit_grads])
-    has_eeg_coils = (FIFF.FIFFV_COIL_EEG in coil_types and
+    has_eeg_coils = ((FIFF.FIFFV_COIL_EEG in coil_types or
+                      FIFF.FIFFV_COIL_EEG_CSD in coil_types) and
                      FIFF.FIFFV_EEG_CH in channel_types)
     has_eeg_coils_and_meg = has_eeg_coils and has_any_meg
     has_eeg_coils_only = has_eeg_coils and not has_any_meg

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -214,7 +214,8 @@ def read_layout(kind, path=None, scale=True):
     return Layout(box=box, pos=pos, names=names, kind=kind, ids=ids)
 
 
-def make_eeg_layout(info, radius=0.5, width=None, height=None, exclude='bads'):
+def make_eeg_layout(info, radius=0.5, width=None, height=None, exclude='bads',
+                    csd=False):
     """Create .lout file from EEG electrode digitization.
 
     Parameters
@@ -232,6 +233,8 @@ def make_eeg_layout(info, radius=0.5, width=None, height=None, exclude='bads'):
     exclude : list of str | str
         List of channels to exclude. If empty do not exclude any.
         If 'bads', exclude channels in info['bads'] (default).
+    csd : bool
+        Whether the channels contain current-source-density-transformed data.
 
     Returns
     -------
@@ -249,8 +252,10 @@ def make_eeg_layout(info, radius=0.5, width=None, height=None, exclude='bads'):
     if height is not None and not (0 <= height <= 1.0):
         raise ValueError('The height parameter should be between 0 and 1.')
 
-    picks = pick_types(info, meg=False, eeg=True, ref_meg=False,
-                       exclude=exclude)
+    pick_kwargs = dict(meg=False, eeg=True, ref_meg=False, exclude=exclude)
+    if csd:
+        pick_kwargs.update(csd=True, eeg=False)
+    picks = pick_types(info, **pick_kwargs)
     loc2d = _find_topomap_coords(info, picks)
     names = [info['chs'][i]['ch_name'] for i in picks]
 
@@ -383,12 +388,13 @@ def find_layout(info, ch_type=None, exclude='bads'):
     layout : Layout instance | None
         None if layout not found.
     """
-    _check_option('ch_type', ch_type, [None, 'mag', 'grad', 'meg', 'eeg'])
+    _check_option('ch_type', ch_type, [None, 'mag', 'grad', 'meg', 'eeg',
+                                       'csd'])
 
     (has_vv_mag, has_vv_grad, is_old_vv, has_4D_mag, ctf_other_types,
      has_CTF_grad, n_kit_grads, has_any_meg, has_eeg_coils,
      has_eeg_coils_and_meg, has_eeg_coils_only,
-     has_neuromag_122_grad) = _get_ch_info(info)
+     has_neuromag_122_grad, has_csd_coils) = _get_ch_info(info)
     has_vv_meg = has_vv_mag and has_vv_grad
     has_vv_only_mag = has_vv_mag and not has_vv_grad
     has_vv_only_grad = has_vv_grad and not has_vv_mag
@@ -417,6 +423,8 @@ def find_layout(info, ch_type=None, exclude='bads'):
             raise RuntimeError('Cannot make EEG layout, no measurement info '
                                'was passed to `find_layout`')
         return make_eeg_layout(info, exclude=exclude)
+    elif has_csd_coils and ch_type in [None, 'csd']:
+        return make_eeg_layout(info, exclude=exclude, csd=True)
     elif has_4D_mag:
         layout_name = 'magnesWH3600'
     elif has_CTF_grad:
@@ -792,8 +800,7 @@ def _pair_grad_sensors(info, layout=None, topomap_coords=True, exclude='bads',
     pairs = defaultdict(list)
     grad_picks = pick_types(info, meg='grad', ref_meg=False, exclude=exclude)
 
-    (_, has_vv_grad, _, _, _, _, _, _, _, _, _, has_neuromag_122_grad) = \
-        _get_ch_info(info)
+    _, has_vv_grad, *_, has_neuromag_122_grad, _ = _get_ch_info(info)
 
     for i in grad_picks:
         ch = info['chs'][i]

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -214,8 +214,7 @@ def read_layout(kind, path=None, scale=True):
     return Layout(box=box, pos=pos, names=names, kind=kind, ids=ids)
 
 
-def make_eeg_layout(info, radius=0.5, width=None, height=None, exclude='bads',
-                    ch_types=['eeg']):
+def make_eeg_layout(info, radius=0.5, width=None, height=None, exclude='bads'):
     """Create .lout file from EEG electrode digitization.
 
     Parameters
@@ -233,9 +232,6 @@ def make_eeg_layout(info, radius=0.5, width=None, height=None, exclude='bads',
     exclude : list of str | str
         List of channels to exclude. If empty do not exclude any.
         If 'bads', exclude channels in info['bads'] (default).
-    ch_types : list of str
-        Which channel types will be included. Currently the only supported
-        options are ``'eeg'`` and ``'csd'``.
 
     Returns
     -------
@@ -253,14 +249,8 @@ def make_eeg_layout(info, radius=0.5, width=None, height=None, exclude='bads',
     if height is not None and not (0 <= height <= 1.0):
         raise ValueError('The height parameter should be between 0 and 1.')
 
-    # check for CSD
-    kwargs = dict(meg=False, ref_meg=False, exclude=exclude)
-    ch_types = [ch_types] if isinstance(ch_types, str) else ch_types
-    for ch_type in ch_types:
-        if ch_type is not None:
-            kwargs.update({ch_type: True})
-
-    picks = pick_types(info, **kwargs)
+    picks = pick_types(info, meg=False, eeg=True, ref_meg=False,
+                       exclude=exclude)
     loc2d = _find_topomap_coords(info, picks)
     names = [info['chs'][i]['ch_name'] for i in picks]
 
@@ -393,8 +383,7 @@ def find_layout(info, ch_type=None, exclude='bads'):
     layout : Layout instance | None
         None if layout not found.
     """
-    _check_option('ch_type', ch_type, [None, 'mag', 'grad', 'meg', 'eeg',
-                                       'csd'])
+    _check_option('ch_type', ch_type, [None, 'mag', 'grad', 'meg', 'eeg'])
 
     (has_vv_mag, has_vv_grad, is_old_vv, has_4D_mag, ctf_other_types,
      has_CTF_grad, n_kit_grads, has_any_meg, has_eeg_coils,
@@ -422,18 +411,19 @@ def find_layout(info, ch_type=None, exclude='bads'):
             layout_name = 'Vectorview-grad'
     elif has_neuromag_122_grad:
         layout_name = 'Neuromag_122'
-    elif ((has_eeg_coils_only and ch_type in [None, 'eeg', 'csd']) or
+    elif ((has_eeg_coils_only and ch_type in [None, 'eeg']) or
           (has_eeg_coils_and_meg and ch_type == 'eeg')):
         if not isinstance(info, (dict, Info)):
             raise RuntimeError('Cannot make EEG layout, no measurement info '
                                'was passed to `find_layout`')
-        return make_eeg_layout(info, exclude=exclude, ch_types=[ch_type])
+        return make_eeg_layout(info, exclude=exclude)
     elif has_4D_mag:
         layout_name = 'magnesWH3600'
     elif has_CTF_grad:
         layout_name = 'CTF-275'
     elif n_kit_grads > 0:
         layout_name = _find_kit_layout(info, n_kit_grads)
+
     # If no known layout is found, fall back on automatic layout
     if layout_name is None:
         xy = _find_topomap_coords(info, picks=range(info['nchan']),

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -2250,7 +2250,7 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
                 picks=picks[pick_], combine=combine, axes=ax_, show=True,
                 sphere=sphere)
 
-        layout = find_layout(info, ch_type=ch_type)
+        layout = find_layout(info)
         # shift everything to the right by 15% of one axes width
         layout.pos[:, 0] += layout.pos[0, 2] * .15
         layout.pos[:, 1] += layout.pos[0, 3] * .15

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -2250,7 +2250,7 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
                 picks=picks[pick_], combine=combine, axes=ax_, show=True,
                 sphere=sphere)
 
-        layout = find_layout(info)
+        layout = find_layout(info, ch_type=ch_type)
         # shift everything to the right by 15% of one axes width
         layout.pos[:, 0] += layout.pos[0, 2] * .15
         layout.pos[:, 1] += layout.pos[0, 3] * .15

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -326,8 +326,8 @@ def test_plot_compare_evokeds():
     # test with (fake) CSD data
     csd = _get_epochs(picks=np.arange(315, 320)).average()  # 5 EEG chs
     for entry in csd.info['chs']:
-        entry['coil_type'] = 6
-        entry['unit'] = 117
+        entry['coil_type'] = FIFF.FIFFV_COIL_EEG_CSD
+        entry['unit'] = FIFF.FIFF_UNIT_V_M2
     plot_compare_evokeds(csd, picks='csd', axes='topo')
     # old tests
     red.info['chs'][0]['loc'][:2] = 0  # test plotting channel at zero

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -42,7 +42,7 @@ picks = [0, 1, 2, 3, 4, 6, 7, 61, 122, 183, 244, 305]
 sel = [0, 7]
 
 
-def _get_epochs():
+def _get_epochs(picks=picks):
     """Get epochs."""
     raw = read_raw_fif(raw_fname)
     raw.add_proj([], remove_existing=True)
@@ -323,6 +323,12 @@ def test_plot_compare_evokeds():
     figs = plot_compare_evokeds(evoked_dict, axes='topo', legend=True)
     for fig in figs:
         assert len(fig.axes[0].lines) == len(evoked_dict)
+    # test with (fake) CSD data
+    csd = _get_epochs(picks=np.arange(315, 320)).average()  # 5 EEG chs
+    for entry in csd.info['chs']:
+        entry['coil_type'] = 6
+        entry['unit'] = 117
+    plot_compare_evokeds(csd, picks='csd', axes='topo')
     # old tests
     red.info['chs'][0]['loc'][:2] = 0  # test plotting channel at zero
     plot_compare_evokeds([red, blue], picks=[0],


### PR DESCRIPTION
closes #7933 

The approach in 1b9ff53 works, in that it yields a correct topo layout for the CSD-transformed EEG data. However, it breaks 3 tests in `mne/viz/tests/test_topo.py` so it's probably not an approach worth keeping.  Other possible approaches:

- add a new return value (`has_eeg_csd_coils`?) to `mne.channels.channels._get_ch_info` rather than hacking it to return `True` for `has_eeg_coils` when only CSD channels are present.
- in `mne.channels.layout.make_eeg_layout`, use a boolean `allow_csd` parameter instead of a `ch_types=['eeg', 'csd']` parameter; and make `eeg=True` always the case in the call to `pick_types` therein.

I'm not very familiar with this part of the codebase, so any suggestions are welcome.