### PR TITLE
[WIP] Use conda-forge packages when creating environment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -297,11 +297,11 @@ jobs:
       pip uninstall -y mne
       pip install --no-deps -e .
     displayName: 'Install MNE-Python'
-  - bash: |
-      source ~/miniforge/etc/profile.d/conda.sh
-      conda activate mne
-      python -c 'import mne; print(mne.sys_info())'
-    displayName: 'Print sys_info'
+  # - bash: |
+  #     source ~/miniforge/etc/profile.d/conda.sh
+  #     conda activate mne
+  #     python -c 'import mne; print(mne.sys_info())'
+  #   displayName: 'Print sys_info'
   - bash: |
       source ~/miniforge/etc/profile.d/conda.sh
       conda activate mne

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -288,7 +288,7 @@ jobs:
       conda env create -n mne -f $CONDA_ENV
       conda activate mne
       pip uninstall -y mne
-      pip install -e .
+      pip install --no-deps -e .
     displayName: 'Install conda-forge dependencies'
   - script: mne sys_info
     displayName: 'Print sys_info'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -290,7 +290,7 @@ jobs:
       source ~/miniforge/etc/profile.d/conda.sh
       conda activate base
       conda env create -n mne -f $CONDA_ENV
-      displayName: 'Install dependencies from conda-forge'
+    displayName: 'Install dependencies from conda-forge'
   - bash: |
       source ~/miniforge/etc/profile.d/conda.sh
       conda activate mne

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -284,6 +284,9 @@ jobs:
       wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniforge.sh --progress=dot:mega
       bash miniforge.sh -b -p ~/miniforge
       source ~/miniforge/etc/profile.d/conda.sh
+      conda init
+    displayName: 'Install miniforge'
+    - bash: |
       conda activate base
       conda env create -n mne -f $CONDA_ENV
     displayName: 'Install MNE-Python dependencies from conda-forge'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -277,8 +277,15 @@ jobs:
   pool:
     vmImage: 'ubuntu-18.04'
   variables:
+    DISPLAY: ':99'
     CONDA_ENV: 'environment_conda-forge.yml'
   steps:
+  - bash: |
+      sudo apt install libxkbcommon-x11-0 xvfb tcsh libxcb*
+    displayName: 'Install Ubuntu dependencies'
+  - bash: |
+      /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
+    displayName: 'Spin up Xvfb'
   - bash: |
       set -e
       wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniforge.sh --progress=dot:mega

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -273,7 +273,7 @@ jobs:
     condition: succeededOrFailed()
 
 
-- job: conda-forge
+- job: conda_forge
   pool:
     vmImage: 'ubuntu-18.04'
   variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -271,3 +271,37 @@ jobs:
       testRunTitle: 'Publish test results for $(Agent.JobName) $(TEST_MODE) $(PYTHON_VERSION)'
       failTaskOnFailedTests: true
     condition: succeededOrFailed()
+
+
+- job: conda-forge
+  pool:
+    vmImage: 'ubuntu-18.04'
+  variables:
+    CONDA_ENV: 'environment_conda-forge.yml'
+  steps:
+  - bash: |
+      set -e
+      wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniforge.sh --progress=dot:mega
+      bash miniforge.sh -b -p ~/miniforge
+      source ~/miniforge/etc/profile.d/conda.sh
+      conda activate base
+      conda env create -n mne -f $CONDA_ENV
+      conda activate mne
+      pip uninstall -y mne
+      pip install -e .
+    displayName: 'Install conda-forge dependencies'
+  - script: mne sys_info
+    displayName: 'Print sys_info'
+  - script: pytest --cov=mne mne
+    displayName: 'Run tests'
+  - script: codecov --root $BUILD_REPOSITORY_LOCALPATH -t $CODECOV_TOKEN
+    displayName: 'Codecov'
+    env:
+      CODECOV_TOKEN: $(CODECOV_TOKEN)
+    condition: succeededOrFailed()
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: 'junit-*.xml'
+      testRunTitle: 'Publish test results for $(Agent.JobName)'
+      failTaskOnFailedTests: true
+    condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -285,11 +285,11 @@ jobs:
       bash miniforge.sh -b -p ~/miniforge
       source ~/miniforge/etc/profile.d/conda.sh
       conda init
-    displayName: 'Install miniforge'
+    displayName: 'Install Miniforge'
     - bash: |
       conda activate base
       conda env create -n mne -f $CONDA_ENV
-    displayName: 'Install MNE-Python dependencies from conda-forge'
+    displayName: 'Install dependencies from conda-forge'
   - bash: |
       conda activate mne
       pip uninstall -y mne

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -286,11 +286,11 @@ jobs:
       source ~/miniforge/etc/profile.d/conda.sh
       conda init
     displayName: 'Install Miniforge'
-    - bash: |
+  - bash: |
       source ~/miniforge/etc/profile.d/conda.sh
       conda activate base
       conda env create -n mne -f $CONDA_ENV
-    displayName: 'Install dependencies from conda-forge'
+      displayName: 'Install dependencies from conda-forge'
   - bash: |
       source ~/miniforge/etc/profile.d/conda.sh
       conda activate mne

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -286,11 +286,13 @@ jobs:
       source ~/miniforge/etc/profile.d/conda.sh
       conda activate base
       conda env create -n mne -f $CONDA_ENV
+    displayName: 'Install MNE-Python dependencies from conda-forge'
+  - bash: |
       conda activate mne
       pip uninstall -y mne
       pip install --no-deps -e .
-    displayName: 'Install conda-forge dependencies'
-  - script: mne sys_info
+    displayName: 'Install MNE-Python'
+  - script: python -c 'import mne; print(mne.sys_info())'
     displayName: 'Print sys_info'
   - script: pytest --cov=mne mne
     displayName: 'Run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -287,10 +287,12 @@ jobs:
       conda init
     displayName: 'Install Miniforge'
     - bash: |
+      source ~/miniforge/etc/profile.d/conda.sh
       conda activate base
       conda env create -n mne -f $CONDA_ENV
     displayName: 'Install dependencies from conda-forge'
   - bash: |
+      source ~/miniforge/etc/profile.d/conda.sh
       conda activate mne
       pip uninstall -y mne
       pip install --no-deps -e .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -297,11 +297,11 @@ jobs:
       pip uninstall -y mne
       pip install --no-deps -e .
     displayName: 'Install MNE-Python'
-  # - bash: |
-  #     source ~/miniforge/etc/profile.d/conda.sh
-  #     conda activate mne
-  #     python -c 'import mne; print(mne.sys_info())'
-  #   displayName: 'Print sys_info'
+  - bash: |
+      source ~/miniforge/etc/profile.d/conda.sh
+      conda activate mne
+      python -c 'import mne; print(mne.sys_info())'
+    displayName: 'Print sys_info'
   - bash: |
       source ~/miniforge/etc/profile.d/conda.sh
       conda activate mne

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -297,11 +297,20 @@ jobs:
       pip uninstall -y mne
       pip install --no-deps -e .
     displayName: 'Install MNE-Python'
-  - script: python -c 'import mne; print(mne.sys_info())'
+  - bash: |
+      source ~/miniforge/etc/profile.d/conda.sh
+      conda activate mne
+      python -c 'import mne; print(mne.sys_info())'
     displayName: 'Print sys_info'
-  - script: pytest --cov=mne mne
+  - bash: |
+      source ~/miniforge/etc/profile.d/conda.sh
+      conda activate mne
+      pytest --cov=mne mne
     displayName: 'Run tests'
-  - script: codecov --root $BUILD_REPOSITORY_LOCALPATH -t $CODECOV_TOKEN
+  - bash: |
+      source ~/miniforge/etc/profile.d/conda.sh
+      conda activate mne
+      codecov --root $BUILD_REPOSITORY_LOCALPATH -t $CODECOV_TOKEN
     displayName: 'Codecov'
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: base
 channels:
-- defaults
+- conda-forge
 dependencies:
 - python>=3.5
 - pip
@@ -28,22 +28,21 @@ dependencies:
 - pyface>=6
 - traitsui>=6
 - imageio>=2.6.1
+- imageio-ffmpeg>=0.4.1
+- vtk>=9.0.1
+- pyvista>=0.24
+- nibabel
+- nilearn
+- pytest-sugar
+- pydocstyle
+- codespell
+- python-picard
+- tqdm
+- python-neo
+- dipy
+- pysurfer
 - pip:
   - mne
   - https://github.com/numpy/numpydoc/archive/master.zip
-  - imageio-ffmpeg>=0.4.1
-  - vtk>=9.0.1
-  - pyvista>=0.24
-  - pyvistaqt
   - https://github.com/enthought/mayavi/archive/master.zip
-  - PySurfer[save_movie]
-  - dipy --only-binary dipy
-  - nibabel
-  - nilearn
-  - neo
-  - pytest-sugar
-  - pydocstyle
-  - codespell
-  - python-picard
-  - tqdm
-  - PyQt5>=5.10
+  - pyvistaqt

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,7 @@ dependencies:
 - joblib
 - psutil
 - flake8
+- numpydoc>=1.0
 - numexpr
 - traits>=4.6.0
 - pyface>=6
@@ -43,6 +44,5 @@ dependencies:
 - pysurfer
 - pip:
   - mne
-  - https://github.com/numpy/numpydoc/archive/master.zip
   - https://github.com/enthought/mayavi/archive/master.zip
   - pyvistaqt

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,7 @@ dependencies:
 - imageio-ffmpeg>=0.4.1
 - vtk>=9.0.1
 - pyvista>=0.24
+- pyvistaqt
 - nibabel
 - nilearn
 - pytest-sugar
@@ -45,4 +46,3 @@ dependencies:
 - pip:
   - mne
   - https://github.com/enthought/mayavi/archive/master.zip
-  - pyvistaqt

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,49 @@
+name: base
+channels:
+- defaults
+dependencies:
+- python>=3.5
+- pip
+- numpy
+- scipy
+- matplotlib
+- numba
+- pandas>=0.18
+- xlrd
+- scikit-learn
+- h5py
+- pillow
+- statsmodels
+- jupyter
+- pytest<5.4
+- pytest-cov
+- pytest-mock
+- pytest-timeout
+- pytest-xdist
+- joblib
+- psutil
+- flake8
+- numexpr
+- traits>=4.6.0
+- pyface>=6
+- traitsui>=6
+- imageio>=2.6.1
+- pip:
+  - mne
+  - https://github.com/numpy/numpydoc/archive/master.zip
+  - imageio-ffmpeg>=0.4.1
+  - vtk>=9.0.1
+  - pyvista>=0.24
+  - pyvistaqt
+  - https://github.com/enthought/mayavi/archive/master.zip
+  - PySurfer[save_movie]
+  - dipy --only-binary dipy
+  - nibabel
+  - nilearn
+  - neo
+  - pytest-sugar
+  - pydocstyle
+  - codespell
+  - python-picard
+  - tqdm
+  - PyQt5>=5.10

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -1,6 +1,7 @@
 name: mne
 channels:
 - conda-forge
+- defaults
 dependencies:
 - python>=3.5
 - pip
@@ -15,14 +16,8 @@ dependencies:
 - pillow
 - statsmodels
 - jupyter
-- pytest<5.4
-- pytest-cov
-- pytest-mock
-- pytest-timeout
-- pytest-xdist
 - joblib
 - psutil
-- flake8
 - numpydoc>=1.0
 - numexpr
 - traits>=4.6.0
@@ -35,14 +30,21 @@ dependencies:
 - pyvistaqt
 - nibabel
 - nilearn
-- pytest-sugar
-- pydocstyle
-- codespell
 - python-picard
 - tqdm
 - python-neo
 - dipy
-- pysurfer
+# FIXME - pysurfer
+# For unit testing
+- pytest<5.4
+- pytest-cov
+- pytest-mock
+- pytest-timeout
+- pytest-xdist
+- pytest-sugar
+- pydocstyle
+- codespell
+- flake8
 - pip:
   - mne
   - https://github.com/enthought/mayavi/archive/master.zip

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -7,7 +7,7 @@ dependencies:
 - pip
 - numpy
 - scipy
-- matplotlib
+- matplotlib-base
 - numba
 - pandas>=0.18
 - xlrd
@@ -20,6 +20,7 @@ dependencies:
 - psutil
 - numpydoc>=1.0
 - numexpr
+- pyqt>=5.10,<5.14
 - traits>=4.6.0
 - pyface>=6
 - traitsui>=6

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -19,9 +19,6 @@ dependencies:
 - psutil
 - numexpr
 - pyqt>=5.10,<5.14
-- traits>=4.6.0
-# FIXME - pyface>=6
-- traitsui>=6
 - imageio>=2.6.1
 - imageio-ffmpeg>=0.4.1
 - vtk>=9.0.1
@@ -33,7 +30,11 @@ dependencies:
 - tqdm
 - python-neo
 - dipy
-# FIXME - pysurfer
+# FIXME - Mayavi stuff!
+# - pysurfer
+# - pyface>=6
+- traits>=4.6.0
+- traitsui>=6
 # For unit testing
 - pytest
 - pytest-cov

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -21,7 +21,7 @@ dependencies:
 - numexpr
 - pyqt>=5.10,<5.14
 - traits>=4.6.0
-- pyface>=6
+# FIXME - pyface>=6
 - traitsui>=6
 - imageio>=2.6.1
 - imageio-ffmpeg>=0.4.1

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -17,7 +17,6 @@ dependencies:
 - jupyter
 - joblib
 - psutil
-- numpydoc>=1.0
 - numexpr
 - pyqt>=5.10,<5.14
 - traits>=4.6.0
@@ -45,6 +44,7 @@ dependencies:
 - pydocstyle
 - codespell
 - flake8
+- numpydoc>=1.0
 - pip:
   - mne
   # - https://github.com/enthought/mayavi/archive/master.zip

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -36,7 +36,7 @@ dependencies:
 - dipy
 # FIXME - pysurfer
 # For unit testing
-- pytest<5.4
+- pytest
 - pytest-cov
 - pytest-mock
 - pytest-timeout

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -1,7 +1,6 @@
 name: mne
 channels:
 - conda-forge
-- defaults
 dependencies:
 - python>=3.5
 - pip

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -15,7 +15,7 @@ dependencies:
 - pillow
 - statsmodels
 - jupyter
-- pytest
+- pytest<5.4
 - pytest-cov
 - pytest-mock
 - pytest-timeout

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -1,4 +1,4 @@
-name: base
+name: mne
 channels:
 - conda-forge
 dependencies:

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -21,7 +21,7 @@ dependencies:
 - numexpr
 - pyqt>=5.10,<5.14
 - traits>=4.6.0
-- pyface>=6
+- pyface>=6,<7
 - traitsui>=6,<7
 - imageio>=2.6.1
 - imageio-ffmpeg>=0.4.1

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -22,7 +22,7 @@ dependencies:
 - pyqt>=5.10,<5.14
 - traits>=4.6.0
 - pyface>=6
-- traitsui>=6
+- traitsui>=6,<7
 - imageio>=2.6.1
 - imageio-ffmpeg>=0.4.1
 - vtk>=9.0.1

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -21,8 +21,8 @@ dependencies:
 - numexpr
 - pyqt>=5.10,<5.14
 - traits>=4.6.0
-- pyface>=6,<7
-- traitsui>=6,<7
+- pyface>=6
+- traitsui>=6
 - imageio>=2.6.1
 - imageio-ffmpeg>=0.4.1
 - vtk>=9.0.1

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -17,8 +17,12 @@ dependencies:
 - jupyter
 - joblib
 - psutil
+- numpydoc>=1.0
 - numexpr
 - pyqt>=5.10,<5.14
+- traits>=4.6.0
+# FIXME - pyface>=6
+- traitsui>=6
 - imageio>=2.6.1
 - imageio-ffmpeg>=0.4.1
 - vtk>=9.0.1
@@ -41,7 +45,6 @@ dependencies:
 - pydocstyle
 - codespell
 - flake8
-- numpydoc>=1.0
 - pip:
   - mne
   # - https://github.com/enthought/mayavi/archive/master.zip

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -47,4 +47,4 @@ dependencies:
 - flake8
 - pip:
   - mne
-  - https://github.com/enthought/mayavi/archive/master.zip
+  # - https://github.com/enthought/mayavi/archive/master.zip

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -15,7 +15,7 @@ dependencies:
 - pillow
 - statsmodels
 - jupyter
-- pytest<5.4
+- pytest
 - pytest-cov
 - pytest-mock
 - pytest-timeout

--- a/environment_conda-forge.yml
+++ b/environment_conda-forge.yml
@@ -17,12 +17,8 @@ dependencies:
 - jupyter
 - joblib
 - psutil
-- numpydoc>=1.0
 - numexpr
 - pyqt>=5.10,<5.14
-- traits>=4.6.0
-# FIXME - pyface>=6
-- traitsui>=6
 - imageio>=2.6.1
 - imageio-ffmpeg>=0.4.1
 - vtk>=9.0.1
@@ -45,6 +41,7 @@ dependencies:
 - pydocstyle
 - codespell
 - flake8
+- numpydoc>=1.0
 - pip:
   - mne
   # - https://github.com/enthought/mayavi/archive/master.zip


### PR DESCRIPTION
Use `conda-forge` channel, which has up-to-date versions of most of our dependencies, so we won't need to install them via `pip`. This should reduce the risk of ending up with an inconsistent environment, esp. if users install packages after initial environment creation.

x-ref #7945

cc @cbrnr 