### PR TITLE
[MRG] fix Issue with stc.project after restricting to a label

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -116,6 +116,8 @@ Bug
 
 - Fix bug with :func:`mne.preprocessing.ICA.find_bads_eog` when more than one EOG components are present by `Christian O'Reilly`_
 
+- Fix bug to permit :meth:`stc.project('nn', src) <mne.VectorSourceEstimate.project>` to be applied after ``stc`` was restricted to an :class:`mne.Label`, by `Luke Bloy`_
+
 - Fix bug with :func:`mne.io.Raw.set_meas_date` to support setting ``meas_date`` to ``None``, by `Luke Bloy`_
 
 - Fix bug with :func:`mne.setup_volume_source_space` when ``volume_label`` was supplied where voxels slightly (in a worst case, about 37% times ``pos`` in distance) outside the voxel-grid-based bounds of regions were errantly included, by `Eric Larson`_

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -116,7 +116,7 @@ Bug
 
 - Fix bug with :func:`mne.preprocessing.ICA.find_bads_eog` when more than one EOG components are present by `Christian O'Reilly`_
 
-- Fix bug to permit :meth:`stc.project('nn', src) <mne.VectorSourceEstimate.project>` to be applied after ``stc`` was restricted to an :class:`mne.Label`, by `Luke Bloy`_
+- Fix bug to permit :meth:`stc.project('nn', src) <mne.VectorSourceEstimate.project>` to be applied after ``stc`` was restricted to an :class:`mne.Label` by `Luke Bloy`_
 
 - Fix bug with :func:`mne.io.Raw.set_meas_date` to support setting ``meas_date`` to ``None``, by `Luke Bloy`_
 

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -3010,9 +3010,10 @@ def _get_src_nn(s, use_cps=True, vertices=None):
     vertices = s['vertno'] if vertices is None else vertices
     if use_cps and s.get('patch_inds') is not None:
         nn = np.empty((len(vertices), 3))
-        for p in np.searchsorted(s['vertno'], vertices):
+        for vp, p in enumerate(np.searchsorted(s['vertno'], vertices)):
+            assert(s['vertno'][p] == vertices[vp])
             #  Project out the surface normal and compute SVD
-            nn[p] = np.sum(
+            nn[vp] = np.sum(
                 s['nn'][s['pinfo'][s['patch_inds'][p]], :], axis=0)
         nn /= linalg.norm(nn, axis=-1, keepdims=True)
     else:


### PR DESCRIPTION
`source_space._get_src_nn` assumed a 1-1 mapping between `stc.vertices` and `src.vertices` which broke `stc.project` if `stc` was already restricted to a label or during the forward computation. 

Closes #7932

