### PR TITLE
MRG: Only process NIRX event files if they are present

### DIFF
--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -77,7 +77,7 @@ class RawNIRX(BaseRaw):
 
         # Check if required files exist and store names for later use
         files = dict()
-        keys = ('evt', 'hdr', 'inf', 'set', 'tpl', 'wl1', 'wl2',
+        keys = ('hdr', 'inf', 'set', 'tpl', 'wl1', 'wl2',
                 'config.txt', 'probeInfo.mat')
         for key in keys:
             files[key] = glob.glob('%s/*%s' % (fname, key))
@@ -288,19 +288,20 @@ class RawNIRX(BaseRaw):
             raw_extras=[raw_extras], verbose=verbose)
 
         # Read triggers from event file
-        with _open(files['evt']) as fid:
-            t = [re.findall(r'(\d+)', line) for line in fid]
-        onset = np.zeros(len(t), float)
-        duration = np.zeros(len(t), float)
-        description = [''] * len(t)
-        for t_idx in range(len(t)):
-            binary_value = ''.join(t[t_idx][1:])[::-1]
-            trigger_frame = float(t[t_idx][0])
-            onset[t_idx] = (trigger_frame) * (1.0 / samplingrate)
-            duration[t_idx] = 1.0  # No duration info stored in files
-            description[t_idx] = int(binary_value, 2) * 1.
-        annot = Annotations(onset, duration, description)
-        self.set_annotations(annot)
+        if op.isfile(files['hdr'][:-3] + 'evt'):
+            with _open(files['hdr'][:-3] + 'evt') as fid:
+                t = [re.findall(r'(\d+)', line) for line in fid]
+            onset = np.zeros(len(t), float)
+            duration = np.zeros(len(t), float)
+            description = [''] * len(t)
+            for t_idx in range(len(t)):
+                binary_value = ''.join(t[t_idx][1:])[::-1]
+                trigger_frame = float(t[t_idx][0])
+                onset[t_idx] = (trigger_frame) * (1.0 / samplingrate)
+                duration[t_idx] = 1.0  # No duration info stored in files
+                description[t_idx] = int(binary_value, 2) * 1.
+            annot = Annotations(onset, duration, description)
+            self.set_annotations(annot)
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a segment of data from a file.

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -46,6 +46,17 @@ def test_nirx_missing_warn():
 
 
 @requires_testing_data
+def test_nirx_missing_evt(tmpdir):
+    """Test reading NIRX files when missing data."""
+    shutil.copytree(fname_nirx_15_2_short, str(tmpdir) + "/data/")
+    os.rename(str(tmpdir) + "/data" + "/NIRS-2019-08-23_001.evt",
+              str(tmpdir) + "/data" + "/NIRS-2019-08-23_001.xxx")
+    fname = str(tmpdir) + "/data" + "/NIRS-2019-08-23_001.hdr"
+    raw = read_raw_nirx(fname, preload=True)
+    assert raw.annotations.onset.shape == (0, )
+
+
+@requires_testing_data
 def test_nirx_dat_warn(tmpdir):
     """Test reading NIRX files when missing data."""
     shutil.copytree(fname_nirx_15_2_short, str(tmpdir) + "/data/")


### PR DESCRIPTION
#### What does this implement/fix?
In the event that no triggers are sent during a recording (for example a resting state measurement) the event file is not created. This PR only tries to create annotations if the event file is present.


