### PR TITLE
MRG, MAINT: Clean up VTK9 offset array

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -451,8 +451,6 @@ def reset_warnings(gallery_conf, fname):
         'ignore', '.*semaphore_tracker: process died unexpectedly.*')
     warnings.filterwarnings(  # needed until SciPy 1.2.0 is released
         'ignore', '.*will be interpreted as an array index.*', module='scipy')
-    warnings.filterwarnings(  # PyVista needs to be updated (?)
-        'ignore', '.*VTK 9 no longer accepts an offset array.*')
     for key in ('HasTraits', r'numpy\.testing', 'importlib', r'np\.loads',
                 'Using or importing the ABCs from',  # internal modules on 3.7
                 r"it will be an error for 'np\.bool_'",  # ndimage

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -97,7 +97,6 @@ def pytest_configure(config):
     ignore:.*sphinx\.util\.smartypants is deprecated.*:
     ignore:.*pandas\.util\.testing is deprecated.*:
     ignore:.*tostring.*is deprecated.*:DeprecationWarning
-    ignore:VTK 9 no longer accepts an offset array:UserWarning
     always:.*get_data.* is deprecated in favor of.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):


### PR DESCRIPTION
Okay for you @GuillaumeFavelier ? This seems to be the right way to fix it (?) and it seems to work in a simple testing example:
```
import os.path as op
import mne

data_path = mne.datasets.sample.data_path()
sample_dir = op.join(data_path, 'MEG', 'sample')
subjects_dir = op.join(data_path, 'subjects')
inv = mne.minimum_norm.read_inverse_operator(op.join(
    sample_dir, 'sample_audvis-meg-oct-6-meg-inv.fif'))
evoked = mne.read_evokeds(op.join(sample_dir, 'sample_audvis-ave.fif'))[0]
evoked.apply_baseline((None, 0))
stc = mne.minimum_norm.apply_inverse(
    evoked, inv, method='dSPM', verbose='debug', pick_ori='vector')  # 'vector')
initial_time = 0.1

size = (800, 400)
with mne.viz.use_3d_backend('pyvista'):
    brain = stc.plot(subjects_dir=subjects_dir, initial_time=initial_time,
                     clim='auto', views='lat', hemi='lh',
                     smoothing_steps='nearest', verbose=True,
                     size=size, background='k')
```