### PR TITLE
MRG+1: BUG: info['bads'] order shouldn't matter in write_evokeds()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -105,11 +105,13 @@ Changelog
 
 - Add ``'auto'`` option to :meth:`mne.preprocessing.ICA.find_bads_ecg` to automatically determine the threshold for CTPS method by `Yu-Han Luo`_
 
-- Add a ``notebook`` 3d backend for visualization in jupyter notebook with :func:`mne.viz.set_3d_backend` by`Guillaume Favelier`_
+- Add a ``notebook`` 3d backend for visualization in jupyter notebook with :func:`mne.viz.set_3d_backend` by `Guillaume Favelier`_
 
 - Add support for reading and writing surfaces in Wavefront .obj format to the :func:`mne.read_surface` and :func:`mne.write_surface` by `Marijn van Vliet`_
 
 - Add tutorial on how to manually fix BEM meshes in Blender by `Marijn van Vliet`_ and `Ezequiel Mikulan`_
+
+- :func:`mne.write_evokeds` will now accept :class:`mne.Evoked` objects with differing channel orders in ``info['bads']``, which would previously raise an exception by `Richard Höchenberger`_
 
 Bug
 ~~~

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2908,7 +2908,7 @@ def _compare_epochs_infos(info1, info2, name):
     info2._check_consistency()
     if info1['nchan'] != info2['nchan']:
         raise ValueError(f'{name}.info[\'nchan\'] must match')
-    if info1['bads'] != info2['bads']:
+    if set(info1['bads']) != set(info2['bads']):
         raise ValueError(f'{name}.info[\'bads\'] must match')
     if info1['sfreq'] != info2['sfreq']:
         raise ValueError(f'{name}.info[\'sfreq\'] must match')

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -208,6 +208,15 @@ def test_io_evoked(tmpdir):
     with pytest.warns(RuntimeWarning, match='-ave.fif'):
         read_evokeds(fname2)
 
+    # test writing when order of bads doesn't match
+    fname3 = tmpdir.join('test-bad-bad-order-ave.fif')
+    condition = 'Left Auditory'
+    ave4 = read_evokeds(fname, condition)
+    ave4.info['bads'] = ave4.ch_names[:3]
+    ave5 = ave4.copy()
+    ave5.info['bads'] = ave4.info['bads'][::-1]
+    write_evokeds(fname3, [ave4, ave5])
+
     # constructor
     pytest.raises(TypeError, Evoked, fname)
 

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -209,7 +209,7 @@ def test_io_evoked(tmpdir):
         read_evokeds(fname2)
 
     # test writing when order of bads doesn't match
-    fname3 = tmpdir.join('test-bad-bad-order-ave.fif')
+    fname3 = tmpdir.join('test-bad-order-ave.fif')
     condition = 'Left Auditory'
     ave4 = read_evokeds(fname, condition)
     ave4.info['bads'] = ave4.ch_names[:3]


### PR DESCRIPTION
#### What does this implement/fix?

I ran into an issue where I created two Evokeds and their difference (via `combine_evoked()`); say, `e1`, `e2`, and `diff`.

I then wanted to write those Evokeds to a single file via `mne.write_evokeds([e1, e2, diff])`, which [failed](https://app.circleci.com/pipelines/github/mne-tools/mne-study-template/459/workflows/6ae202d0-9190-4192-bdfd-08f3e5f12fa3/jobs/477/steps) with a `ValueError`: "info['bads'] must match'". I looked into the `bads` lists and found that the order of bad channels in `diff` was different from the order in `e1` and `e2`; yet, the set of channels was identical.

While it probably would make sense to figure out where this difference comes from, it also got me thinking that an altered `bads` order shouldn't be a stopper when using `write_evokeds()`, as long as all passed Evoked objects mark the same channels as bad.

And this is exactly what this PR implements.