### PR TITLE
MRG, VIZ, MAINT: figure class proof-of-concept

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -476,6 +476,7 @@ def pytest_sessionfinish(session, exitstatus):
     n = session.config.option.durations
     if n is None:
         return
+    print('\n')
     try:
         import pytest_harvest
     except ImportError:

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -101,7 +101,7 @@ def _handle_default(k, v=None):
         if isinstance(v, dict):
             this_mapping.update(v)
         else:
-            for key in this_mapping.keys():
+            for key in this_mapping:
                 this_mapping[key] = v
     return this_mapping
 

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -440,19 +440,15 @@ def test_ica_core(method, n_components, noise_cov, n_pca_components):
         ica.fit(raw)
     assert_array_almost_equal(unmixing1, ica.unmixing_matrix_)
 
-        # test for gh-6271 (scaling of ICA traces)
-        fig = raw_sources.plot()
-        assert len(fig.axes[0].lines) in (4, 8)
-        for line in fig.axes[0].lines:
-            y = line.get_ydata()
-            if len(y) > 2:  # actual data, not markers
-                assert np.ptp(y) < 15
-        plt.close('all')
+    raw_sources = ica.get_sources(raw)
+    # test for #3804
+    assert_equal(raw_sources._filenames, [None])
+    print(raw_sources)
 
     # test for gh-6271 (scaling of ICA traces)
     fig = raw_sources.plot()
-    assert len(fig.axes[0].lines) in (5, 9)
-    for line in fig.axes[0].lines:
+    assert len(fig.mne.ax_main.lines) in (4, 8)
+    for line in fig.mne.ax_main.lines:
         y = line.get_ydata()
         if len(y) > 2:  # actual data, not markers
             assert np.ptp(y) < 15

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -440,10 +440,14 @@ def test_ica_core(method, n_components, noise_cov, n_pca_components):
         ica.fit(raw)
     assert_array_almost_equal(unmixing1, ica.unmixing_matrix_)
 
-    raw_sources = ica.get_sources(raw)
-    # test for #3804
-    assert_equal(raw_sources._filenames, [None])
-    print(raw_sources)
+        # test for gh-6271 (scaling of ICA traces)
+        fig = raw_sources.plot()
+        assert len(fig.axes[0].lines) in (4, 8)
+        for line in fig.axes[0].lines:
+            y = line.get_ydata()
+            if len(y) > 2:  # actual data, not markers
+                assert np.ptp(y) < 15
+        plt.close('all')
 
     # test for gh-6271 (scaling of ICA traces)
     fig = raw_sources.plot()

--- a/mne/viz/__init__.py
+++ b/mne/viz/__init__.py
@@ -32,4 +32,3 @@ from .backends.renderer import (set_3d_backend, get_3d_backend, use_3d_backend,
                                 get_brain_class)
 from . import backends
 from ._brain import Brain
-from ._figure import browse_figure

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1258,7 +1258,7 @@ class MNEBrowseFigure(MNEFigure):
             if active:
                 labels[ix] += ' (already applied)'
         # make figure
-        width = max([4, max([len(label) for label in labels]) / 6 + 0.5])
+        width = max([4, max([len(label) for label in labels]) / 8 + 0.5])
         height = (len(projs) + 1) / 6 + 1.5
         fig = self._new_child_figure(figsize=(width, height),
                                      fig_name='fig_proj',
@@ -1267,7 +1267,7 @@ class MNEBrowseFigure(MNEFigure):
         # make axes
         offset = (1 / 6 / height)
         position = (0, offset, 1, 0.8 - offset)
-        ax = fig.add_axes(position, frame_on=False)
+        ax = fig.add_axes(position, frame_on=False, aspect='equal')
         # make title
         first_line = ('Projectors already applied to the data are dimmed.\n'
                       if any(self.mne.projs_active) else '')

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -270,10 +270,9 @@ class MNEBrowseFigure(MNEFigure):
 
         # additional params for browse figures
         self.mne.ch_start = 0
+        self.mne.butterfly_image = None
         self.mne.projector = None
         self.mne.projs_active = np.array([p['active'] for p in self.mne.projs])
-        self.mne.event_lines = None
-        self.mne.event_texts = list()
         self.mne.whitened_ch_names = list()
         self.mne.use_noise_cov = self.mne.noise_cov is not None
         # annotations
@@ -285,6 +284,10 @@ class MNEBrowseFigure(MNEFigure):
         self.mne.annotation_segment_colors = dict()
         self.mne.annotation_hover_line = None
         self.mne.draggable_annotations = False
+        # lines
+        self.mne.event_lines = None
+        self.mne.event_texts = list()
+        self.mne.vline_visible = False
         # scalings
         self.mne.scale_factor = 0.5 if self.mne.butterfly else 1.
         self.mne.scalebars = dict()
@@ -732,7 +735,8 @@ class MNEBrowseFigure(MNEFigure):
         self._update_picks()
         self._update_trace_offsets()
         self._redraw(annotations=True)
-        self._show_vline(self.mne.vline.get_xdata())
+        if self.mne.vline_visible:
+            self._show_vline(self.mne.vline.get_xdata()[0])
         if self.mne.fig_selection is not None:
             # Show all radio buttons as selected when in butterfly mode
             fig = self.mne.fig_selection
@@ -1754,6 +1758,7 @@ class MNEBrowseFigure(MNEFigure):
             self.draw_artist(artist)
         self.canvas.blit()
         self.canvas.flush_events()
+        self.mne.vline_visible = True
 
     def _hide_vline(self):
         """Hide the vertical line."""
@@ -1764,6 +1769,7 @@ class MNEBrowseFigure(MNEFigure):
             self.draw_artist(artist)
         self.canvas.blit()
         self.canvas.flush_events()
+        self.mne.vline_visible = False
 
 
 def _figure(toolbar=True, FigureClass=MNEFigure, **kwargs):

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1429,7 +1429,6 @@ class MNEBrowseFigure(MNEFigure):
 
     def _update_yaxis_labels(self):
         """Change the y-axis labels."""
-        fontstyle = 'italic' if self.mne.use_noise_cov else 'normal'
         if self.mne.butterfly and self.mne.fig_selection is not None:
             exclude = ('Vertex', 'Custom')
             ticklabels = list(self.mne.ch_selections)
@@ -1444,8 +1443,12 @@ class MNEBrowseFigure(MNEFigure):
             ticklabels = np.array(_DATA_CH_TYPES_ORDER_DEFAULT)[ixs]
         else:
             ticklabels = self.mne.ch_names[self.mne.picks]
-        self.mne.ax_main.set_yticklabels(ticklabels, fontstyle=fontstyle,
-                                         picker=True)
+        texts = self.mne.ax_main.set_yticklabels(ticklabels, picker=True)
+        for text in texts:
+            sty = ('italic' if text.get_text() in self.mne.whitened_ch_names
+                   else 'normal')
+            text.set_style(sty)
+
 
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     # DATA TRACES

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1485,7 +1485,6 @@ class MNEBrowseFigure(MNEFigure):
                    else 'normal')
             text.set_style(sty)
 
-
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     # DATA TRACES
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -701,7 +701,7 @@ class MNEBrowseFigure(MNEFigure):
         inds = np.in1d(fig.lasso.ch_names, [ch_name])
         fig.lasso.disconnect()
         fig.lasso.alpha_other = 0.3
-        fig.lasso.linewidth_selected = 2
+        fig.lasso.linewidth_selected = 3
         fig.lasso.style_sensors(inds)
         fig.mne.parent_fig.mne.foo = ax.collections[0]
 
@@ -1150,7 +1150,8 @@ class MNEBrowseFigure(MNEFigure):
         plot_sensors(self.mne.info, kind='select', ch_type='all', title='',
                      axes=fig.mne.sensor_ax, ch_groups=self.mne.group_by,
                      show=False)
-        # style the sensors so their facecolor is easier to distinguish
+        # style the sensors so the selection is easier to distinguish
+        fig.lasso.linewidth_selected = 2
         self._update_highlighted_sensors()
         # add radio button axes
         radio_ax = fig.add_subplot(gs[5:-3], frame_on=False, aspect='equal')

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1404,7 +1404,9 @@ class MNEBrowseFigure(MNEFigure):
 
     def _check_update_vscroll_clicked(self, event):
         """Update vscroll patch on click, return True if location changed."""
-        new_ch_start = max(0, int(event.ydata - self.mne.n_channels / 2))
+        new_ch_start = np.clip(
+            int(round(event.ydata - self.mne.n_channels / 2)),
+            0, len(self.mne.ch_order) - self.mne.n_channels)
         if self.mne.ch_start != new_ch_start:
             self.mne.ch_start = new_ch_start
             self._update_picks()

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1504,8 +1504,8 @@ class MNEBrowseFigure(MNEFigure):
             ticklabels = np.array(ticklabels)[keep_mask]
         elif self.mne.butterfly:
             # XXX when numpy 1.15 is min version, replace next line with
-            #_, ixs, _ = np.intersect1d(_DATA_CH_TYPES_ORDER_DEFAULT,
-            #                           self.mne.ch_types, return_indices=True)
+            # _, ixs, _ = np.intersect1d(_DATA_CH_TYPES_ORDER_DEFAULT,
+            #                            self.mne.ch_types,return_indices=True)
             ixs = [_DATA_CH_TYPES_ORDER_DEFAULT.index(x) for x in
                    np.array(_DATA_CH_TYPES_ORDER_DEFAULT)[
                        np.in1d(_DATA_CH_TYPES_ORDER_DEFAULT,

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -275,6 +275,8 @@ class MNEBrowseFigure(MNEFigure):
         self.mne.projs_active = np.array([p['active'] for p in self.mne.projs])
         self.mne.whitened_ch_names = list()
         self.mne.use_noise_cov = self.mne.noise_cov is not None
+        self.mne.zorder = dict(ann=0, events=1, bads=2, data=3, mag=4, grad=5,
+                               scalebar=6, vline=7)
         # annotations
         self.mne.annotations = list()
         self.mne.hscroll_annotations = list()
@@ -360,9 +362,10 @@ class MNEBrowseFigure(MNEFigure):
                             self.mne.n_times / self.mne.info['sfreq'])
         # VLINE
         vline_color = (0., 0.75, 0.)
-        vline_kw = dict(visible=False, color=vline_color, animated=True)
-        vline = ax.axvline(0, zorder=4, **vline_kw)
-        vline_hscroll = ax_hscroll.axvline(0, zorder=2, **vline_kw)
+        vline_kw = dict(visible=False, color=vline_color, animated=True,
+                        zorder=self.mne.zorder['vline'])
+        vline = ax_main.axvline(0, **vline_kw)
+        vline_hscroll = ax_hscroll.axvline(0, **vline_kw)
         vline_text = ax_hscroll.text(
             self.mne.first_time, 1.2, '', fontsize=10, ha='right', va='bottom',
             **vline_kw)
@@ -1081,7 +1084,8 @@ class MNEBrowseFigure(MNEFigure):
         for idx, (start, end) in enumerate(segments):
             descr = self.mne.inst.annotations.description[idx]
             segment_color = self.mne.annotation_segment_colors[descr]
-            kwargs = dict(color=segment_color, alpha=0.3, zorder=0)
+            kwargs = dict(color=segment_color, alpha=0.3,
+                          zorder=self.mne.zorder['ann'])
             # draw all segments on ax_hscroll
             annot = self.mne.ax_hscroll.fill_betweenx((0, 1), start, end,
                                                       **kwargs)
@@ -1468,7 +1472,7 @@ class MNEBrowseFigure(MNEFigure):
         """Draw a scalebar."""
         from .utils import _simplify_float
         color = '#AA3377'  # purple
-        kwargs = dict(color=color, zorder=5)
+        kwargs = dict(color=color, zorder=self.mne.zorder['scalebar'])
         scaler = 1 if self.mne.butterfly else 2
         inv_norm = (scaler *
                     self.mne.scalings[ch_type] *
@@ -1729,8 +1733,8 @@ class MNEBrowseFigure(MNEFigure):
             xs = np.repeat(this_event_times, 2)
             ys = np.tile(ylim, n_visible_events)
             segs = np.vstack([xs, ys]).T.reshape(n_visible_events, 2, 2)
-            event_lines = LineCollection(segs, linewidths=0.5,
-                                         colors=colors, zorder=0)
+            event_lines = LineCollection(segs, linewidths=0.5, colors=colors,
+                                         zorder=self.mne.zorder['events'])
             self.mne.ax_main.add_collection(event_lines)
             self.mne.event_lines = event_lines
             # create event labels

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1691,14 +1691,11 @@ class MNEBrowseFigure(MNEFigure):
             line.set_xdata(this_times)
             line.set_ydata(this_data[..., ::decim[ii]])
             line.set_color(ch_colors[ii])
-            z_key = 'bads' if this_name in self.mne.info['bads'] else 'data'
-            this_z = self.mne.zorder[z_key]
-            if self.mne.butterfly:
-                if this_name not in self.mne.info['bads']:
-                    if this_type == 'mag':
-                        this_z = self.mne.zorder['mag']
-                    elif this_type == 'grad':
-                        this_z = self.mne.zorder['grad']
+            # z order
+            is_bad = this_name in self.mne.info['bads']
+            this_z = self.mne.zorder['bads' if is_bad else 'data']
+            if self.mne.butterfly and not is_bad:
+                this_z = self.mne.zorder.get(this_type, this_z)
             line.set_zorder(this_z)
         # update xlim
         self.mne.ax_main.set_xlim(*time_range)

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -671,7 +671,8 @@ class MNEBrowseFigure(MNEFigure):
             if event.mouseevent.button == 1:  # left click
                 self._toggle_bad_channel(ind)
             elif event.mouseevent.button == 3:  # right click
-                self._create_ch_location_fig(ind)
+                # self._create_ch_location_fig(ind)
+                pass
 
     def _new_child_figure(self, fig_name, **kwargs):
         """Instantiate a new MNE dialog figure (with event listeners)."""
@@ -685,24 +686,25 @@ class MNEBrowseFigure(MNEFigure):
 
     def _create_ch_location_fig(self, idx):
         """Show channel location figure; idx is index of *visible* channels."""
-        from .utils import _channel_type_prettyprint
-        pick = self.mne.picks[idx]
-        ch_name = self.mne.ch_names[pick]
-        ch_type = self.mne.ch_types[pick]
-        if ch_type not in _DATA_CH_TYPES_SPLIT:
-            return
-        # create figure and axes
-        fig = self._new_child_figure(figsize=(4, 4), fig_name=None,
-                                     window_title=f'Location of {ch_name}')
-        ax = fig.add_subplot()
-        title = f'{ch_name} position ({_channel_type_prettyprint[ch_type]})'
-        fig, _ = plot_sensors(self.mne.info, ch_type=ch_type, axes=ax,
-                              title=title, kind='select')
-        inds = np.in1d(fig.lasso.ch_names, [ch_name])
-        fig.lasso.disconnect()
-        fig.lasso.alpha_other = 0.3
-        fig.lasso.linewidth_selected = 3
-        fig.lasso.style_sensors(inds)
+        pass
+        # from .utils import _channel_type_prettyprint
+        # pick = self.mne.picks[idx]
+        # ch_name = self.mne.ch_names[pick]
+        # ch_type = self.mne.ch_types[pick]
+        # if ch_type not in _DATA_CH_TYPES_SPLIT:
+        #     return
+        # # create figure and axes
+        # fig = self._new_child_figure(figsize=(4, 4), fig_name=None,
+        #                              window_title=f'Location of {ch_name}')
+        # ax = fig.add_subplot()
+        # title = f'{ch_name} position ({_channel_type_prettyprint[ch_type]})'
+        # fig, _ = plot_sensors(self.mne.info, ch_type=ch_type, axes=ax,
+        #                       title=title, kind='select')
+        # inds = np.in1d(fig.lasso.ch_names, [ch_name])
+        # fig.lasso.disconnect()
+        # fig.lasso.alpha_other = 0.3
+        # fig.lasso.linewidth_selected = 3
+        # fig.lasso.style_sensors(inds)
 
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     # HELP DIALOG
@@ -806,7 +808,7 @@ class MNEBrowseFigure(MNEFigure):
             ('Left-click-and-drag on plot', ldrag),
             ('Left-click on plot background', 'Place vertical guide'),
             ('Right-click on plot background', 'Clear vertical guide'),
-            ('Right-click on channel name', rclick_name)
+            ('Right-click on channel name', None)  # TODO: rclick_name
         ])
         return help_text
 

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -381,7 +381,7 @@ class MNEBrowseFigure(MNEFigure):
         # HELP BUTTON: make it a proper button
         # XXX when matplotlib 3.0 is min version,
         # XXX uncomment next line and remove self._post_init()
-        # _ = Button(ax_help, 'Help')  # listener handled in _buttonpress()
+        # self.mne.button_help = Button(ax_help, 'Help')
         # PROJ BUTTON
         ax_proj = None
         if len(self.mne.projs) and not inst.proj:
@@ -396,7 +396,7 @@ class MNEBrowseFigure(MNEFigure):
             ax_proj.set_axes_locator(loc)
             # XXX when matplotlib 3.0 is min version,
             # XXX uncomment next line and remove self._post_init()
-            # _ = Button(ax_proj, 'Prj')  # listener handled in _buttonpress()
+            # self.mne.button_proj = Button(ax_proj, 'Prj')
 
         # INIT TRACES
         self.mne.traces = ax_main.plot(
@@ -415,9 +415,9 @@ class MNEBrowseFigure(MNEFigure):
         """Make buttons (fix for older matplotlib (older than 3.0?) XXX)."""
         from matplotlib.widgets import Button
         # HELP BUTTON: make it a proper button
-        _ = Button(self.mne.ax_help, 'Help')
+        self.mne.button_help = Button(self.mne.ax_help, 'Help')
         if len(self.mne.projs) and not self.mne.inst.proj:
-            _ = Button(self.mne.ax_proj, 'Prj')
+            self.mne.button_proj = Button(self.mne.ax_proj, 'Prj')
 
     def _close(self, event):
         """Handle close events (via keypress or window [x])."""

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1263,7 +1263,7 @@ class MNEBrowseFigure(MNEFigure):
             if active:
                 labels[ix] += ' (already applied)'
         # make figure
-        width = max([4, max([len(label) for label in labels]) / 8 + 0.5])
+        width = max([4.5, max([len(label) for label in labels]) / 8 + 0.5])
         height = (len(projs) + 1) / 6 + 1.5
         fig = self._new_child_figure(figsize=(width, height),
                                      fig_name='fig_proj',

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1081,7 +1081,7 @@ class MNEBrowseFigure(MNEFigure):
         for idx, (start, end) in enumerate(segments):
             descr = self.mne.inst.annotations.description[idx]
             segment_color = self.mne.annotation_segment_colors[descr]
-            kwargs = dict(color=segment_color, alpha=0.3)
+            kwargs = dict(color=segment_color, alpha=0.3, zorder=0)
             # draw all segments on ax_hscroll
             annot = self.mne.ax_hscroll.fill_betweenx((0, 1), start, end,
                                                       **kwargs)

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -606,16 +606,11 @@ class MNEBrowseFigure(MNEFigure):
             # click in main axes
             if (event.inaxes == ax_main and not annotating):
                 if not butterfly:
-                    good_cont, _ = self.mne.traces.contains(event)
-                    bad_cont, _ = self.mne.bad_traces.contains(event)
-                    if good_cont or bad_cont:
-                        x_ind = self.mne.inst.time_as_index(event.xdata)[0]
-                        dists = (self.mne.data[:, x_ind]
-                                 + self.mne.trace_offsets
-                                 - event.ydata)
-                        ind = np.argmin(np.abs(dists))
-                        self._toggle_bad_channel(ind)
-                        return
+                    for line in self.mne.traces:
+                        if line.contains(event)[0]:
+                            idx = self.mne.traces.index(line)
+                            self._toggle_bad_channel(idx)
+                            return
                 self._show_vline(event.xdata)  # butterfly / not on data trace
                 return
             # click in vertical scrollbar

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1327,8 +1327,6 @@ class MNEBrowseFigure(MNEFigure):
         """Mark/unmark bad channels; `idx` is index of *visible* channels."""
         pick = self.mne.picks[idx]
         ch_name = self.mne.ch_names[pick]
-        if not len(ch_name):
-            return
         # add/remove from bads list
         bads = self.mne.info['bads']
         marked_bad = ch_name not in bads

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -587,6 +587,8 @@ class MNEBrowseFigure(MNEFigure):
         elif key == 'd':  # DC shift
             self.mne.remove_dc = not self.mne.remove_dc
             self._redraw()
+        elif key == 'j':  # SSP window
+            self._toggle_proj_fig()
         elif key == 'p':  # toggle draggable annotations
             self._toggle_draggable_annotations(event)
             if self.mne.fig_annotation is not None:
@@ -748,6 +750,7 @@ class MNEBrowseFigure(MNEFigure):
         """Generate help dialog text; `None`-valued entries removed later."""
         is_mac = platform.system() == 'Darwin'
         inst = self.mne.instance_type
+        is_raw = inst == 'raw'
         ch_cmp = 'component' if inst == 'ica' else 'channel'
         ch_epo = 'epoch' if inst == 'epochs' else 'channel'
         ica_bad = 'Mark/unmark component for exclusion'
@@ -784,12 +787,13 @@ class MNEBrowseFigure(MNEFigure):
             ('+ or =', 'Increase signal scaling'),
             ('-', 'Decrease signal scaling'),
             ('b', 'Toggle butterfly mode' if inst != 'ica' else None),
-            ('d', 'Toggle DC removal' if inst == 'raw' else None),
+            ('d', 'Toggle DC removal' if is_raw else None),
             ('w', noise_cov),
             ('h', 'Show peak-to-peak histogram' if inst == 'epochs' else None),
             ('_USER INTERFACE', ' '),
-            ('a', 'Toggle annotation mode' if inst == 'raw' else None),
-            ('p', 'Toggle draggable annotations' if inst == 'raw' else None),
+            ('a', 'Toggle annotation mode' if is_raw else None),
+            ('j', 'Toggle SSP projector window' if is_raw else None),
+            ('p', 'Toggle draggable annotations' if is_raw else None),
             ('s', 'Toggle scalebars' if inst != 'ica' else None),
             ('z', 'Toggle scrollbars'),
             ('F11', 'Toggle fullscreen'),

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1557,6 +1557,7 @@ class MNEBrowseFigure(MNEFigure):
             _slice = slice(self.mne.ch_start,
                            self.mne.ch_start + self.mne.n_channels)
             self.mne.picks = self.mne.ch_order[_slice]
+            self.mne.n_channels = len(self.mne.picks)
 
     def _load_data(self, start=None, stop=None):
         """Retrieve the bit of data we need for plotting."""

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1006,7 +1006,6 @@ class MNEBrowseFigure(MNEFigure):
 
     def _setup_annotation_colors(self):
         """Set up colors for annotations."""
-
         # TODO disable for epochs/ica instance types
         raw = self.mne.inst
         segment_colors = getattr(self.mne, 'annotation_segment_colors', dict())

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -119,6 +119,8 @@ class MNEAnnotationFigure(MNEFigure):
         parent = self.mne.parent_fig
         # disable span selector
         parent.mne.ax_main.selector.active = False
+        # clear hover line
+        parent._remove_annotation_hover_line()
         # disconnect hover callback
         callback_id = parent.mne._callback_ids['motion_notify_event']
         parent.canvas.callbacks.disconnect(callback_id)

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1682,7 +1682,7 @@ class MNEBrowseFigure(MNEFigure):
                 clip = self.mne.clipping * (0.2 if self.mne.butterfly else 1)
                 bottom = max(this_offset - clip, ylim[1])
                 height = min(2 * clip, ylim[0] - bottom)
-                rect = Rectangle(xy=(time_range[0], bottom),
+                rect = Rectangle(xy=np.array([time_range[0], bottom]),
                                  width=time_range[1] - time_range[0],
                                  height=height,
                                  transform=self.mne.ax_main.transData)

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -576,7 +576,7 @@ class MNEBrowseFigure(MNEFigure):
             if self.mne.duration != old_dur:
                 self._update_hscroll()
                 self._redraw()
-        elif key == '?':  # help
+        elif key == '?':  # help window
             self._toggle_help_fig(event)
         elif key == 'f11':  # full screen
             self.canvas.manager.full_screen_toggle()

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1802,7 +1802,7 @@ def _figure(toolbar=True, FigureClass=MNEFigure, **kwargs):
     return fig
 
 
-def browse_figure(inst, **kwargs):
+def _browse_figure(inst, **kwargs):
     """Instantiate a new MNE browse-style figure."""
     from .utils import _get_figsize_from_config
     figsize = kwargs.pop('figsize', _get_figsize_from_config())

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -696,14 +696,13 @@ class MNEBrowseFigure(MNEFigure):
                                      window_title=f'Location of {ch_name}')
         ax = fig.add_subplot()
         title = f'{ch_name} position ({_channel_type_prettyprint[ch_type]})'
-        plot_sensors(self.mne.info, ch_type=ch_type, axes=ax, title=title,
-                     kind='select')
+        fig, _ = plot_sensors(self.mne.info, ch_type=ch_type, axes=ax,
+                              title=title, kind='select')
         inds = np.in1d(fig.lasso.ch_names, [ch_name])
         fig.lasso.disconnect()
         fig.lasso.alpha_other = 0.3
         fig.lasso.linewidth_selected = 3
         fig.lasso.style_sensors(inds)
-        fig.mne.parent_fig.mne.foo = ax.collections[0]
 
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     # HELP DIALOG

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -243,7 +243,6 @@ class MNEBrowseFigure(MNEFigure):
     def __init__(self, inst, figsize, xlabel='Time (s)', **kwargs):
         from matplotlib import rcParams
         from matplotlib.colors import to_rgba_array
-        from matplotlib.widgets import Button
         from matplotlib.patches import Rectangle
         from mpl_toolkits.axes_grid1.axes_size import Fixed
         from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
@@ -376,7 +375,9 @@ class MNEBrowseFigure(MNEFigure):
         loc = div.new_locator(nx=0, ny=0)
         ax_help.set_axes_locator(loc)
         # HELP BUTTON: make it a proper button
-        _ = Button(ax_help, 'Help')  # listener handled in _buttonpress()
+        # XXX when matplotlib 3.0 is min version,
+        # XXX uncomment next line and remove self._post_init()
+        # _ = Button(ax_help, 'Help')  # listener handled in _buttonpress()
         # PROJ BUTTON
         ax_proj = None
         if len(self.mne.projs) and not inst.proj:
@@ -389,7 +390,9 @@ class MNEBrowseFigure(MNEFigure):
             loc = div.new_locator(nx=4, ny=0)
             ax_proj = self.add_axes(proj_button_pos)
             ax_proj.set_axes_locator(loc)
-            _ = Button(ax_proj, 'Prj')  # listener handled in _buttonpress()
+            # XXX when matplotlib 3.0 is min version,
+            # XXX uncomment next line and remove self._post_init()
+            # _ = Button(ax_proj, 'Prj')  # listener handled in _buttonpress()
 
         # INIT TRACES
         self.mne.traces = ax_main.plot(
@@ -403,6 +406,14 @@ class MNEBrowseFigure(MNEFigure):
             vsel_patch=vsel_patch, hsel_patch=hsel_patch, vline=vline,
             vline_hscroll=vline_hscroll, vline_text=vline_text,
             fgcolor=fgcolor, bgcolor=bgcolor)
+
+    def _post_init(self):
+        """Make buttons (fix for older matplotlib (older than 3.0?) XXX)."""
+        from matplotlib.widgets import Button
+        # HELP BUTTON: make it a proper button
+        _ = Button(self.mne.ax_help, 'Help')
+        if len(self.mne.projs) and not self.mne.inst.proj:
+            _ = Button(self.mne.ax_proj, 'Prj')
 
     def _close(self, event):
         """Handle close events (via keypress or window [x])."""

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1683,7 +1683,7 @@ class MNEBrowseFigure(MNEFigure):
                 bottom = max(this_offset - clip, ylim[1])
                 height = min(2 * clip, ylim[0] - bottom)
                 rect = Rectangle(xy=(time_range[0], bottom),
-                                 width=np.diff(time_range),
+                                 width=time_range[1] - time_range[0],
                                  height=height,
                                  transform=self.mne.ax_main.transData)
                 line.set_clip_path(rect)

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -269,7 +269,6 @@ class MNEBrowseFigure(MNEFigure):
 
         # additional params for browse figures
         self.mne.ch_start = 0
-        self.mne.butterfly_image = None
         self.mne.projector = None
         self.mne.projs_active = np.array([p['active'] for p in self.mne.projs])
         self.mne.whitened_ch_names = list()

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -768,8 +768,10 @@ class MNEBrowseFigure(MNEFigure):
         rclick_name = dict(ica='Show diagnostics for component',
                            epoch='Show imageplot for channel',
                            raw='Show channel location')[inst]
-        ldrag = ('Show spectrum plot for selected time span;\nor (in '
-                 'annotation mode) add annotation') if inst == 'raw' else None
+        # TODO not yet implemented
+        # ldrag = ('Show spectrum plot for selected time span;\nor (in '
+        #          'annotation mode) add annotation') if inst== 'raw' else None
+        ldrag = 'add annotation (in annotation mode)' if is_raw else None
         noise_cov = (None if self.mne.noise_cov is None else
                      'Toggle signal whitening')
         # below, value " " is a hack to make "\n".split(value) have length 1

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -54,6 +54,8 @@ class MNEFigure(Figure):
         if event.key == self.mne.close_key:
             from matplotlib.pyplot import close
             close(self)
+        elif event.key == 'f11':  # full screen
+            self.canvas.manager.full_screen_toggle()
 
     def _buttonpress(self, event):
         """Handle buttonpress events."""
@@ -501,7 +503,6 @@ class MNEBrowseFigure(MNEFigure):
 
     def _keypress(self, event):
         """Handle keypress events."""
-        from matplotlib.pyplot import get_current_fig_manager
         key = event.key
         n_channels = self.mne.n_channels
         # scroll up/down
@@ -576,7 +577,7 @@ class MNEBrowseFigure(MNEFigure):
         elif key == '?':  # help
             self._toggle_help_fig(event)
         elif key == 'f11':  # full screen
-            get_current_fig_manager().full_screen_toggle()
+            self.canvas.manager.full_screen_toggle()
         elif key == 'a':  # annotation mode
             self._toggle_annotation_fig()
         elif key == 'b':  # butterfly mode

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -766,9 +766,10 @@ class MNEBrowseFigure(MNEFigure):
                    ('Increase', 'Decrease')]
         lclick_data = ica_bad if inst == 'ica' else f'Mark/unmark bad {ch_epo}'
         lclick_name = (ica_bad if inst == 'ica' else 'Mark/unmark bad channel')
-        rclick_name = dict(ica='Show diagnostics for component',
-                           epoch='Show imageplot for channel',
-                           raw='Show channel location')[inst]
+        # TODO not yet implemented
+        # rclick_name = dict(ica='Show diagnostics for component',
+        #                    epoch='Show imageplot for channel',
+        #                    raw='Show channel location')[inst]
         # TODO not yet implemented
         # ldrag = ('Show spectrum plot for selected time span;\nor (in '
         #          'annotation mode) add annotation') if inst== 'raw' else None

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1687,7 +1687,7 @@ class MNEBrowseFigure(MNEFigure):
                                  height=height,
                                  transform=self.mne.ax_main.transData)
                 line.set_clip_path(rect)
-            # subtraction yields correct orientation given inverted ylim
+            # update line data & color
             line.set_xdata(this_times)
             line.set_ydata(this_data[..., ::decim[ii]])
             line.set_color(ch_colors[ii])

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -671,8 +671,7 @@ class MNEBrowseFigure(MNEFigure):
             if event.mouseevent.button == 1:  # left click
                 self._toggle_bad_channel(ind)
             elif event.mouseevent.button == 3:  # right click
-                # self._create_ch_location_fig(ind)
-                pass
+                self._create_ch_location_fig(ind)
 
     def _new_child_figure(self, fig_name, **kwargs):
         """Instantiate a new MNE dialog figure (with event listeners)."""

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -286,8 +286,8 @@ def plot_raw_alt(raw, events=None, duration=10.0, start=0.0, n_channels=20,
         fig._create_selection_fig()
 
     # update projector and data, and plot
-    fig._update_trace_offsets()
     fig._update_projector()
+    fig._update_trace_offsets()
     fig._update_data()
     fig._draw_traces()
 

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -272,7 +272,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
     ``True``. This flag can be toggled by pressing 'd'.
     """
     from ..io.base import BaseRaw
-    from . import browse_figure
+    from ._figure import _browse_figure
 
     info = raw.info.copy()
     sfreq = info['sfreq']
@@ -435,7 +435,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
                   scalebars_visible=show_scalebars,
                   window_title=title)
 
-    fig = browse_figure(**params)
+    fig = _browse_figure(**params)
     fig._update_picks()
 
     # make channel selection dialog, if requested (doesn't work well in init)

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -201,10 +201,10 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
         Elekta's channel groupings (only works for Neuromag data),
         ``'position'`` groups the channels by the positions of the sensors.
         ``'selection'`` and ``'position'`` modes allow custom selections by
-        using lasso selector on the topomap. Pressing ``ctrl`` key while
+        using a lasso selector on the topomap. Pressing ``ctrl`` key while
         selecting allows appending to the current selection. Channels marked as
-        bad appear with red edges on the topomap. ``'type'`` and ``'original'``
-        groups the channels by type in butterfly mode whereas ``'selection'``
+        bad appear with red edges on the topomap. In butterfly mode, ``'type'``
+        and ``'original'`` group the channels by type, whereas ``'selection'``
         and ``'position'`` use regional grouping. ``'type'`` and ``'original'``
         modes are overridden with ``order`` keyword.
     butterfly : bool

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -23,7 +23,7 @@ from .utils import (_prepare_mne_browse, figure_nobar, plt_show,
                     _get_figsize_from_config, _setup_browser_offsets,
                     _compute_scalings, _handle_decim, _check_cov,
                     _set_ax_label_style, _simplify_float, _check_psd_fmax,
-                    _set_window_title, shorten_path_from_middle)
+                    _set_window_title, _shorten_path_from_middle)
 
 _RAW_CLIP_DEF = 1.5
 
@@ -328,7 +328,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
             extra = f' ... (+ {len(fnames)} more)' if len(fnames) else ''
             title = f'{title}{extra}'
             if len(title) > 60:
-                title = shorten_path_from_middle(title)
+                title = _shorten_path_from_middle(title)
     elif not isinstance(title, str):
         raise TypeError(f'title must be None or a string, got a {type(title)}')
 

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -437,6 +437,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
                   window_title=title)
 
     fig = _browse_figure(**params)
+    fig._post_init()
     fig._update_picks()
 
     # make channel selection dialog, if requested (doesn't work well in init)

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -437,7 +437,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
                   window_title=title)
 
     fig = _browse_figure(**params)
-    fig._post_init()
+    fig._post_init()  # XXX fix for older matplotlib
     fig._update_picks()
 
     # make channel selection dialog, if requested (doesn't work well in init)

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -132,7 +132,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
         matplotlib-compatible color. Can also be a `dict` mapping event numbers
         to colors, but if so it must include all events or include a "fallback"
         entry with key ``-1``.
-    scalings : dict | None
+    scalings : 'auto' | dict | None
         Scaling factors for the traces. If any fields in scalings are 'auto',
         the scaling factor is set to match the 99.5th percentile of a subset of
         the corresponding data. If scalings == 'auto', all scalings fields are
@@ -287,6 +287,8 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
     color = _handle_default('color', color)
     scalings = _compute_scalings(scalings, raw, remove_dc=remove_dc,
                                  duration=duration)
+    if scalings['whitened'] == 'auto':
+        scalings['whitened'] = 1.
     _validate_type(raw, BaseRaw, 'raw', 'Raw')
     decim, picks_data = _handle_decim(info, decim, lowpass)
     noise_cov = _check_cov(noise_cov, info)

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -281,7 +281,9 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
     ch_names = np.array(raw.ch_names)
     ch_types = np.array(raw.get_channel_types())
     if order is None:
-        ch_type_order = _DATA_CH_TYPES_ORDER_DEFAULT
+        # for backward compat, we swap the first two to keep grad before mag
+        ch_type_order = list(_DATA_CH_TYPES_ORDER_DEFAULT)
+        ch_type_order = tuple(['grad', 'mag'] + ch_type_order[2:])
         order = [pick_idx for order_type in ch_type_order
                  for pick_idx, pick_type in enumerate(ch_types)
                  if order_type == pick_type]

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -253,8 +253,10 @@ def test_plot_raw_traces():
     fig = plot_raw(raw, show_scrollbars=False)
 
     # Color setting
-    pytest.raises(KeyError, raw.plot, event_color={0: 'r'})
-    pytest.raises(TypeError, raw.plot, event_color={'foo': 'r'})
+    with pytest.raises(KeyError, match='must be strictly positive, or -1'):
+        raw.plot(event_color={0: 'r'})
+    with pytest.raises(TypeError, match='event_color key must be an int, got'):
+        raw.plot(event_color={'foo': 'r'})
     annot = Annotations([10, 10 + raw.first_samp / raw.info['sfreq']],
                         [10, 10], ['test', 'test'], raw.info['meas_date'])
     with pytest.warns(RuntimeWarning, match='outside data range'):

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -156,17 +156,18 @@ def test_scale_bar():
     sfreq = 1000.
     t = np.arange(10000) / sfreq
     data = np.sin(2 * np.pi * 10. * t)
-    # +/- 1000 fT, 400 fT/cm, 20 µV
+    # ± 1000 fT, 400 fT/cm, 20 µV
     data = data * np.array([[1000e-15, 400e-13, 20e-6]]).T
     info = create_info(3, sfreq, ('mag', 'grad', 'eeg'))
     raw = RawArray(data, info)
     fig = raw.plot()
-    ax = fig.axes[0]
+    ax = fig.mne.ax_main
     assert len(ax.texts) == 3  # our labels
-    for text, want in zip(ax.texts, ('800.0 fT/cm', '2000.0 fT', '40.0 µV')):
-        assert text.get_text().strip() == want
-    assert len(ax.lines) == 8  # green, data, nan, bars
-    for data, bar in zip(ax.lines[1:4], ax.lines[5:8]):
+    texts = tuple(t.get_text().strip() for t in ax.texts)
+    wants = ('2000.0 fT', '800.0 fT/cm', '40.0 µV')
+    assert texts == wants
+    assert len(ax.lines) == 7  # 1 green vline, 3 data, 3 scalebars
+    for data, bar in zip(fig.mne.traces, fig.mne.scalebars.values()):
         y = data.get_ydata()
         y_lims = [y.min(), y.max()]
         bar_lims = bar.get_ydata()
@@ -185,8 +186,8 @@ def test_plot_raw_traces():
                    group_by='original')
     assert len(plt.get_fignums()) == 1
 
-    # make sure fig._mne_params is present
-    assert isinstance(fig._mne_params, dict)
+    # make sure fig.mne param object is present
+    assert hasattr(fig, 'mne')
 
     # test mouse clicks
     x = fig.get_axes()[0].lines[1].get_xdata().mean()

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -47,7 +47,6 @@ def _get_events():
 def _annotation_helper(raw, events=False):
     """Test interactive annotations."""
     # Some of our checks here require modern mpl to work properly
-    mpl_good_enough = LooseVersion(matplotlib.__version__) >= '2.0'
     n_anns = len(raw.annotations)
     plt.close('all')
 
@@ -102,17 +101,15 @@ def _annotation_helper(raw, events=False):
     _fake_click(fig, data_ax, [2.5, 1.], xform='data', button=1, kind='motion')
     _fake_click(fig, data_ax, [2.5, 1.], xform='data', button=1,
                 kind='release')
-    if mpl_good_enough:
-        assert raw.annotations.onset[n_anns] == onset
-        assert_allclose(raw.annotations.duration[n_anns], 1.5)  # 4->1.5
+    assert raw.annotations.onset[n_anns] == onset
+    assert_allclose(raw.annotations.duration[n_anns], 1.5)  # 4->1.5
     # modify annotation from beginning
     _fake_click(fig, data_ax, [1., 1.], xform='data', button=1, kind='press')
     _fake_click(fig, data_ax, [0.5, 1.], xform='data', button=1, kind='motion')
     _fake_click(fig, data_ax, [0.5, 1.], xform='data', button=1,
                 kind='release')
-    if mpl_good_enough:
-        assert_allclose(raw.annotations.onset[n_anns], onset - 0.5, atol=1e-10)
-        assert_allclose(raw.annotations.duration[n_anns], 2.0)
+    assert_allclose(raw.annotations.onset[n_anns], onset - 0.5, atol=1e-10)
+    assert_allclose(raw.annotations.duration[n_anns], 2.0)
     assert len(raw.annotations.onset) == n_anns + 1
     assert len(raw.annotations.duration) == n_anns + 1
     assert len(raw.annotations.description) == n_anns + 1
@@ -131,9 +128,8 @@ def _annotation_helper(raw, events=False):
     assert len(raw.annotations.onset) == n_anns + 1
     assert len(raw.annotations.duration) == n_anns + 1
     assert len(raw.annotations.description) == n_anns + 1
-    if mpl_good_enough:
-        assert_allclose(raw.annotations.onset[n_anns], onset - 0.5, atol=1e-10)
-        assert_allclose(raw.annotations.duration[n_anns], 5.0)
+    assert_allclose(raw.annotations.onset[n_anns], onset - 0.5, atol=1e-10)
+    assert_allclose(raw.annotations.duration[n_anns], 5.0)
     assert len(fig.axes[0].texts) == n_anns + 1 + n_events + n_scale
     # Delete
     _fake_click(fig, data_ax, [1.5, 1.], xform='data', button=3,

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -66,14 +66,14 @@ def _annotation_helper(raw, events=False):
     # +2 from the scale bars
     n_scale = 2
     assert len(data_ax.texts) == n_anns + n_events + n_scale
-    # create label "BAD_", then modify description to create label "BAD test"
+    # modify description to create label "BAD test"
     ann_fig = fig.mne.fig_annotation
-    for key in ['enter', 'backspace'] + list(' test;'):  # semicolon is ignored
+    for key in ['backspace'] + list(' test;'):  # semicolon is ignored
         ann_fig.canvas.key_press_event(key)
     ann_fig.canvas.key_press_event('enter')
 
     # change annotation label
-    for ix in (0, -1):
+    for ix in (-1, 0):
         xy = ann_fig.mne.radio_ax.buttons.circles[ix].center
         _fake_click(ann_fig, ann_fig.mne.radio_ax, xy, xform='data')
 
@@ -263,7 +263,7 @@ def test_plot_raw_traces():
     # test order, title, & show_options kwargs
     with pytest.raises(ValueError, match='order should be array-like; got'):
         raw.plot(order='foo')
-    with pytest.raises(TypeError, match='title must be None or a string; got'):
+    with pytest.raises(TypeError, match='title must be None or a string, got'):
         raw.plot(title=1)
     raw.plot(show_options=True)
     plt.close('all')
@@ -508,7 +508,7 @@ def test_plot_sensors():
 
     # Lasso with 1 sensor (upper left)
     _fake_click(fig, ax, (0, 1), xform='ax')
-    plt.draw()
+    fig.canvas.draw()
     assert fig.lasso.selection == []
     _fake_click(fig, ax, (0.65, 1), xform='ax', kind='motion')
     _fake_click(fig, ax, (0.65, 0.7), xform='ax', kind='motion')

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -132,8 +132,7 @@ def _annotation_helper(raw, events=False):
     assert_allclose(raw.annotations.duration[n_anns], 5.0)
     assert len(fig.axes[0].texts) == n_anns + 1 + n_events + n_scale
     # Delete
-    _fake_click(fig, data_ax, [1.5, 1.], xform='data', button=3,
-                kind='press')
+    _fake_click(fig, data_ax, [1.5, 1.], xform='data', button=3, kind='press')
     # exit, re-enter, then exit a different way
     fig.canvas.key_press_event('a')  # exit
     fig.canvas.key_press_event('a')  # enter

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -340,11 +340,8 @@ def test_plot_raw_child_figures(raw, new_mpl):
     fig = raw.plot()
     assert len(plt.get_fignums()) == 1
     _child_fig_helper(fig, '?', 'fig_help', new_mpl)
-    print(fig.mne.child_figs)
     _child_fig_helper(fig, 'j', 'fig_proj', new_mpl)
-    print(fig.mne.child_figs)
     _child_fig_helper(fig, 'a', 'fig_annotation', new_mpl)
-    print(fig.mne.child_figs)
     # # test right-click → channel location popup
     _click_ch_name_helper(fig, ch_index=2, button=3)  # XXX currently no-op
     # XXX restore these lines after refactoring plot_sensors() and re-enabling

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -219,7 +219,7 @@ def test_scale_bar():
     ax = fig.mne.ax_main
     assert len(ax.texts) == 3  # our labels
     texts = tuple(t.get_text().strip() for t in ax.texts)
-    wants = ('2000.0 fT', '800.0 fT/cm', '40.0 µV')
+    wants = ('800.0 fT/cm', '2000.0 fT', '40.0 µV')
     assert texts == wants
     assert len(ax.lines) == 7  # 1 green vline, 3 data, 3 scalebars
     for data, bar in zip(fig.mne.traces, fig.mne.scalebars.values()):

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -500,8 +500,8 @@ def test_plot_sensors():
     # check that point appearance changes
     fc = fig.lasso.collection.get_facecolors()
     ec = fig.lasso.collection.get_edgecolors()
-    assert (fc[:, -1] == [0.3, 1., 0.3]).all()
-    assert (ec[:, -1] == [0.3, 1., 0.3]).all()
+    assert (fc[:, -1] == np.array([0.3, 1., 0.3])).all()
+    assert (ec[:, -1] == np.array([0.3, 1., 0.3])).all()
 
     _fake_click(fig, ax, (0.7, 1), xform='ax', kind='motion')
     xy = ax.collections[0].get_offsets()

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -182,7 +182,7 @@ def _child_fig_helper(fig, key, attr):
     # XXX this extra call to close_event() cause a failure
     if new_mpl:
         child_fig.canvas.close_event()
-    assert len(fig.mne.child_figs) == 0
+    assert len(fig.mne.child_figs) == 0  # XXX this fails with minimal deps
     assert len(plt.get_fignums()) == num_figs
     assert getattr(fig.mne, attr) is None
     # spawn again
@@ -271,10 +271,10 @@ def test_plot_raw_selection():
     assert sel_fig.lasso.selection == ['MEG 0121', 'MEG 0122', 'MEG 0123']
     # test joint closing of selection & data windows
     sel_fig.canvas.key_press_event(sel_fig.mne.close_key)
-    # XXX workaround: plt.close() doesn't spawn close_event on Agg backend?
+    # XXX workaround: plt.close() doesn't spawn close_event on Agg backend
     if new_mpl:
         sel_fig.canvas.close_event()
-    assert len(plt.get_fignums()) == 0
+    assert len(plt.get_fignums()) == 0  # XXX this fails with minimal deps
 
 
 def test_plot_raw_ssp_interaction():
@@ -289,7 +289,7 @@ def test_plot_raw_ssp_interaction():
     fig = raw.plot()
     # open SSP window
     _fake_click(fig, fig.mne.ax_proj, [0.5, 0.5])
-    assert len(plt.get_fignums()) == 2
+    assert len(plt.get_fignums()) == 2  # XXX this fails with minimal deps
     ssp_fig = fig.mne.fig_proj
     t = ssp_fig.mne.proj_checkboxes.labels
     ax = ssp_fig.mne.proj_checkboxes.ax

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -73,7 +73,8 @@ def _annotation_helper(raw, events=False):
     ann_fig.canvas.key_press_event('enter')
 
     # XXX: _fake_click raises an error on Agg backend
-    _annotation_radio_clicked('', ann_fig.mne.radio_ax.buttons, data_ax.selector)
+    _annotation_radio_clicked('', ann_fig.mne.radio_ax.buttons,
+                              data_ax.selector)
 
     # draw annotation
     fig.canvas.key_press_event('p')  # use snap mode

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -237,18 +237,16 @@ def test_plot_raw_traces():
     assert fig.mne.projector is not None  # on
     assert _proj_status(ax) == [True] * 3
 
-    # test keypresses
+    # test keypresses. testing twice → once in normal, once in butterfly view
+    keys = ('down', 'up', 'right', 'left', '-', '+', '=', 'd', 'd', 'pageup',
+            'pagedown', 'home', 'end', 'z', 'z', '?', 'f11', 'b')
     # test for group_by='original'
-    for key in ['down', 'up', 'right', 'left', 'o', '-', '+', '=', 'd', 'd',
-                'pageup', 'pagedown', 'home', 'end', '?', 'f11', 'z',
-                'escape']:
+    for key in 2 * keys + ('escape',):
         fig.canvas.key_press_event(key)
 
     # test for group_by='selection'
     fig = plot_raw(raw, events=events, group_by='selection')
-    for key in ['b', 'down', 'up', 'right', 'left', 'o', '-', '+', '=', 'd',
-                'd', 'pageup', 'pagedown', 'home', 'end', '?', 'f11', 'b', 'z',
-                'escape']:
+    for key in 2 * keys + ('escape',):
         fig.canvas.key_press_event(key)
 
     # test zen mode

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2130,7 +2130,7 @@ class SelectFromCollection(object):
             inters = set(inds) - set(sels)
             inds = list(inters.union(set(sels) - set(inds)))
 
-        self.selection = self.ch_names[inds]
+        self.selection = np.array(self.ch_names)[inds].tolist()
         self.style_sensors(inds)
         self.canvas.callbacks.process('lasso_event')
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1870,16 +1870,15 @@ def _compute_scalings(scalings, inst, remove_dc=False, duration=10):
         data = inst._data.swapaxes(0, 1).reshape([len(inst.ch_names), -1])
     # Iterate through ch types and update scaling if ' auto'
     for key, value in scalings.items():
-        if key not in ch_types.keys():
+        if key not in ch_types:
             continue
         if not (isinstance(value, str) and value == 'auto'):
             try:
                 scalings[key] = float(value)
             except Exception:
-                raise ValueError('scalings must be "auto" or float, got '
-                                 'scalings[%r]=%r which could not be '
-                                 'converted to float'
-                                 % (key, value))
+                raise ValueError(
+                    f'scalings must be "auto" or float, got scalings[{key}]='
+                    f'{value} which could not be converted to float')
             continue
         this_data = data[ch_types[key]]
         if remove_dc and (this_data.shape[1] / inst.info["sfreq"] >= duration):

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1661,7 +1661,6 @@ def plot_sensors(info, kind='topomap', ch_type=None, title=None,
                   for i, pick in enumerate(picks)]
     else:
         if ch_groups in ['position', 'selection']:
-            print(ch_groups)
             if ch_groups == 'position':
                 ch_groups = _divide_to_regions(info, add_stim=False)
                 ch_groups = list(ch_groups.values())

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -3222,11 +3222,11 @@ def _set_window_title(fig, title):
         fig.canvas.manager.set_window_title(title)
 
 
-def shorten_path_from_middle(path, max_len=60, replacement='...'):
-    """Truncate a file path from the middle by omitting complete elements."""
+def _shorten_path_from_middle(fpath, max_len=60, replacement='...'):
+    """Truncate a path from the middle by omitting complete path elements."""
     from os.path import sep
-    if len(path) > max_len:
-        pathlist = path.split(sep)
+    if len(fpath) > max_len:
+        pathlist = fpath.split(sep)
         # indices starting from middle, alternating sides, omitting final elem:
         # range(8) → 3, 4, 2, 5, 1, 6; range(7) → 2, 3, 1, 4, 0, 5
         ixs_to_trunc = list(zip(range(len(pathlist) // 2 - 1, -1, -1),
@@ -3239,7 +3239,7 @@ def shorten_path_from_middle(path, max_len=60, replacement='...'):
             if len(newpath) < max_len:
                 break
         return newpath
-    return path
+    return fpath
 
 
 def centers_to_edges(*arrays):

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -3310,6 +3310,8 @@ def shorten_path_from_middle(path, max_len=60, replacement='...'):
     from os.path import sep
     if len(path) > max_len:
         pathlist = path.split(sep)
+        # indices starting from middle, alternating sides, omitting final elem:
+        # range(8) → 3, 4, 2, 5, 1, 6; range(7) → 2, 3, 1, 4, 0, 5
         ixs_to_trunc = list(zip(range(len(pathlist) // 2 - 1, -1, -1),
                                 range(len(pathlist) // 2, len(pathlist) - 1)))
         ixs_to_trunc = np.array(ixs_to_trunc).flatten()
@@ -3320,6 +3322,7 @@ def shorten_path_from_middle(path, max_len=60, replacement='...'):
             if len(newpath) < max_len:
                 break
         return newpath
+    return path
 
 
 def centers_to_edges(*arrays):

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1877,8 +1877,8 @@ def _compute_scalings(scalings, inst, remove_dc=False, duration=10):
                 scalings[key] = float(value)
             except Exception:
                 raise ValueError(
-                    f'scalings must be "auto" or float, got scalings[{key}]='
-                    f'{value} which could not be converted to float')
+                    f'scalings must be "auto" or float, got scalings[{key!r}]='
+                    f'{value!r} which could not be converted to float')
             continue
         this_data = data[ch_types[key]]
         if remove_dc and (this_data.shape[1] / inst.info["sfreq"] >= duration):

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2083,7 +2083,7 @@ class SelectFromCollection(object):
     """
 
     def __init__(self, ax, collection, ch_names, alpha_other=0.5,
-                 linewidth_other=0.5):
+                 linewidth_other=0.5, alpha_selected=1, linewidth_selected=1):
         from matplotlib import __version__
         if LooseVersion(__version__) < LooseVersion('1.2.1'):
             raise ImportError('Interactive selection not possible for '
@@ -2095,6 +2095,8 @@ class SelectFromCollection(object):
         self.ch_names = ch_names
         self.alpha_other = alpha_other
         self.linewidth_other = linewidth_other
+        self.alpha_selected = alpha_selected
+        self.linewidth_selected = linewidth_selected
 
         self.xys = collection.get_offsets()
         self.Npts = len(self.xys)
@@ -2157,9 +2159,9 @@ class SelectFromCollection(object):
         self.ec[:, -1] = self.alpha_other / 2
         self.lw[:] = self.linewidth_other
         # style sensors at `inds`
-        self.fc[inds, -1] = 1
-        self.ec[inds, -1] = 1
-        self.lw[inds] = 1
+        self.fc[inds, -1] = self.alpha_selected
+        self.ec[inds, -1] = self.alpha_selected
+        self.lw[inds] = self.linewidth_selected
         self.collection.set_facecolors(self.fc)
         self.collection.set_edgecolors(self.ec)
         self.collection.set_linewidths(self.lw)
@@ -2168,8 +2170,8 @@ class SelectFromCollection(object):
     def disconnect(self):
         """Disconnect the lasso selector."""
         self.lasso.disconnect_events()
-        self.fc[:, -1] = 1
-        self.ec[:, -1] = 1
+        self.fc[:, -1] = self.alpha_selected
+        self.ec[:, -1] = self.alpha_selected
         self.collection.set_facecolors(self.fc)
         self.collection.set_edgecolors(self.ec)
         self.canvas.draw_idle()

--- a/tutorials/raw/plot_30_annotate_raw.py
+++ b/tutorials/raw/plot_30_annotate_raw.py
@@ -5,7 +5,7 @@
 Annotating continuous data
 ==========================
 
-This tutorial describes adding annotations to a :class:`~mne.io.Raw` object,
+This tutorial describes adding annotations to a `~mne.io.Raw` object,
 and how annotations are used in later stages of data processing.
 
 .. contents:: Page contents
@@ -14,7 +14,7 @@ and how annotations are used in later stages of data processing.
 
 As usual we'll start by importing the modules we need, loading some
 :ref:`example data <sample-dataset>`, and (since we won't actually analyze the
-raw data in this tutorial) cropping the :class:`~mne.io.Raw` object to just 60
+raw data in this tutorial) cropping the `~mne.io.Raw` object to just 60
 seconds before loading it into RAM to save memory:
 """
 
@@ -29,12 +29,12 @@ raw = mne.io.read_raw_fif(sample_data_raw_file, verbose=False)
 raw.crop(tmax=60).load_data()
 
 ###############################################################################
-# :class:`~mne.Annotations` in MNE-Python are a way of storing short strings of
-# information about temporal spans of a :class:`~mne.io.Raw` object. Below the
-# surface, :class:`~mne.Annotations` are :class:`list-like <list>` objects,
+# `~mne.Annotations` in MNE-Python are a way of storing short strings of
+# information about temporal spans of a `~mne.io.Raw` object. Below the
+# surface, `~mne.Annotations` are `list-like <list>` objects,
 # where each element comprises three pieces of information: an ``onset`` time
 # (in seconds), a ``duration`` (also in seconds), and a ``description`` (a text
-# string). Additionally, the :class:`~mne.Annotations` object itself also keeps
+# string). Additionally, the `~mne.Annotations` object itself also keeps
 # track of ``orig_time``, which is a `POSIX timestamp`_ denoting a real-world
 # time relative to which the annotation onsets should be interpreted.
 #
@@ -44,9 +44,9 @@ raw.crop(tmax=60).load_data()
 # Creating annotations programmatically
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# If you know in advance what spans of the :class:`~mne.io.Raw` object you want
-# to annotate, :class:`~mne.Annotations` can be created programmatically, and
-# you can even pass lists or arrays to the :class:`~mne.Annotations`
+# If you know in advance what spans of the `~mne.io.Raw` object you want
+# to annotate, `~mne.Annotations` can be created programmatically, and
+# you can even pass lists or arrays to the `~mne.Annotations`
 # constructor to annotate multiple spans at once:
 
 my_annot = mne.Annotations(onset=[3, 5, 7],
@@ -56,7 +56,7 @@ print(my_annot)
 
 ###############################################################################
 # Notice that ``orig_time`` is ``None``, because we haven't specified it. In
-# those cases, when you add the annotations to a :class:`~mne.io.Raw` object,
+# those cases, when you add the annotations to a `~mne.io.Raw` object,
 # it is assumed that the ``orig_time`` matches the time of the first sample of
 # the recording, so ``orig_time`` will be set to match the recording
 # measurement date (``raw.info['meas_date']``).
@@ -72,7 +72,7 @@ print(meas_date == orig_time)
 ###############################################################################
 # Since the example data comes from a Neuromag system that starts counting
 # sample numbers before the recording begins, adding ``my_annot`` to the
-# :class:`~mne.io.Raw` object also involved another automatic change: an offset
+# `~mne.io.Raw` object also involved another automatic change: an offset
 # equalling the time of the first recorded sample (``raw.first_samp /
 # raw.info['sfreq']``) was added to the ``onset`` values of each annotation
 # (see :ref:`time-as-index` for more info on ``raw.first_samp``):
@@ -87,7 +87,7 @@ print(raw.annotations.onset)
 # and the onset times will get adjusted based on the time difference between
 # your specified ``orig_time`` and ``raw.info['meas_date']``, but without the
 # additional adjustment for ``raw.first_samp``. ``orig_time`` can be specified
-# in various ways (see the documentation of :class:`~mne.Annotations` for the
+# in various ways (see the documentation of `~mne.Annotations` for the
 # options); here we'll use an `ISO 8601`_ formatted string, and set it to be 50
 # seconds later than ``raw.info['meas_date']``.
 
@@ -108,11 +108,11 @@ print(raw2.annotations.onset)
 # .. note::
 #
 #     If your annotations fall outside the range of data times in the
-#     :class:`~mne.io.Raw` object, the annotations outside the data range will
+#     `~mne.io.Raw` object, the annotations outside the data range will
 #     not be added to ``raw.annotations``, and a warning will be issued.
 #
-# Now that your annotations have been added to a :class:`~mne.io.Raw` object,
-# you can see them when you visualize the :class:`~mne.io.Raw` object:
+# Now that your annotations have been added to a `~mne.io.Raw` object,
+# you can see them when you visualize the `~mne.io.Raw` object:
 
 fig = raw.plot(start=2, duration=6)
 
@@ -121,14 +121,14 @@ fig = raw.plot(start=2, duration=6)
 # have different ``description`` values (which are printed along the top
 # edge of the plot area). Notice also that colored spans appear in the small
 # scroll bar at the bottom of the plot window, making it easy to quickly view
-# where in a :class:`~mne.io.Raw` object the annotations are so you can easily
+# where in a `~mne.io.Raw` object the annotations are so you can easily
 # browse through the data to find and examine them.
 #
 #
 # Annotating Raw objects interactively
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# Annotations can also be added to a :class:`~mne.io.Raw` object interactively
+# Annotations can also be added to a `~mne.io.Raw` object interactively
 # by clicking-and-dragging the mouse in the plot window. To do this, you must
 # first enter "annotation mode" by pressing :kbd:`a` while the plot window is
 # focused; this will bring up the annotation controls window:
@@ -149,13 +149,13 @@ fig.canvas.key_press_event('a')
 # .. warning::
 #
 #     Calling :meth:`~mne.io.Raw.set_annotations` **replaces** any annotations
-#     currently stored in the :class:`~mne.io.Raw` object, so be careful when
+#     currently stored in the `~mne.io.Raw` object, so be careful when
 #     working with annotations that were created interactively (you could lose
 #     a lot of work if you accidentally overwrite your interactive
 #     annotations). A good safeguard is to run
 #     ``interactive_annot = raw.annotations`` after you finish an interactive
 #     annotation session, so that the annotations are stored in a separate
-#     variable outside the :class:`~mne.io.Raw` object.
+#     variable outside the `~mne.io.Raw` object.
 #
 #
 # How annotations affect preprocessing and analysis
@@ -170,18 +170,18 @@ fig.canvas.key_press_event('a')
 # are "annotation aware" and will avoid using data that is annotated with a
 # description that begins with "bad" or "BAD"; such operations typically have a
 # boolean ``reject_by_annotation`` parameter. Examples of such operations are
-# independent components analysis (:class:`mne.preprocessing.ICA`), functions
+# independent components analysis (`mne.preprocessing.ICA`), functions
 # for finding heartbeat and blink artifacts
 # (:func:`~mne.preprocessing.find_ecg_events`,
 # :func:`~mne.preprocessing.find_eog_events`), and creation of epoched data
-# from continuous data (:class:`mne.Epochs`). See :ref:`tut-reject-data-spans`
+# from continuous data (`mne.Epochs`). See :ref:`tut-reject-data-spans`
 # for details.
 #
 #
 # Operations on Annotations objects
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# :class:`~mne.Annotations` objects can be combined by simply adding them with
+# `~mne.Annotations` objects can be combined by simply adding them with
 # the ``+`` operator, as long as they share the same ``orig_time``:
 
 new_annot = mne.Annotations(onset=3.75, duration=0.75, description='AAA')
@@ -196,7 +196,7 @@ raw.plot(start=2, duration=6)
 # new annotations to be merged.
 #
 # Individual annotations can be accessed by indexing an
-# :class:`~mne.Annotations` object, and subsets of the annotations can be
+# `~mne.Annotations` object, and subsets of the annotations can be
 # achieved by either slicing or indexing with a list, tuple, or array of
 # indices:
 
@@ -205,7 +205,7 @@ print(raw.annotations[:2])      # the first two annotations
 print(raw.annotations[(3, 2)])  # the fourth and third annotations
 
 ###############################################################################
-# You can also iterate over the annotations within an :class:`~mne.Annotations`
+# You can also iterate over the annotations within an `~mne.Annotations`
 # object:
 
 for ann in raw.annotations:
@@ -215,9 +215,9 @@ for ann in raw.annotations:
     print("'{}' goes from {} to {}".format(descr, start, end))
 
 ###############################################################################
-# Note that iterating, indexing and slicing :class:`~mne.Annotations` all
+# Note that iterating, indexing and slicing `~mne.Annotations` all
 # return a copy, so changes to an indexed, sliced, or iterated element will not
-# modify the original :class:`~mne.Annotations` object.
+# modify the original `~mne.Annotations` object.
 
 # later_annot WILL be changed, because we're modifying the first element of
 # later_annot.onset directly:
@@ -233,7 +233,7 @@ print(later_annot[0]['onset'])
 # Reading and writing Annotations to/from a file
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# :class:`~mne.Annotations` objects have a :meth:`~mne.Annotations.save` method
+# `~mne.Annotations` objects have a :meth:`~mne.Annotations.save` method
 # which can write :file:`.fif`, :file:`.csv`, and :file:`.txt` formats (the
 # format to write is inferred from the file extension in the filename you
 # provide). There is a corresponding :func:`~mne.read_annotations` function to

--- a/tutorials/raw/plot_40_visualize_raw.py
+++ b/tutorials/raw/plot_40_visualize_raw.py
@@ -7,14 +7,14 @@ Built-in plotting methods for Raw objects
 
 This tutorial shows how to plot continuous data as a time series, how to plot
 the spectral density of continuous data, and how to plot the sensor locations
-and projectors stored in :class:`~mne.io.Raw` objects.
+and projectors stored in `~mne.io.Raw` objects.
 
 .. contents:: Page contents
    :local:
    :depth: 2
 
 As usual we'll start by importing the modules we need, loading some
-:ref:`example data <sample-dataset>`, and cropping the :class:`~mne.io.Raw`
+:ref:`example data <sample-dataset>`, and cropping the `~mne.io.Raw`
 object to just 60 seconds before loading it into RAM to save memory:
 """
 
@@ -29,9 +29,8 @@ raw.crop(tmax=60).load_data()
 
 ###############################################################################
 # We've seen in :ref:`a previous tutorial <tut-raw-class>` how to plot data
-# from a :class:`~mne.io.Raw` object using :doc:`matplotlib
-# <matplotlib:index>`, but :class:`~mne.io.Raw` objects also have several
-# built-in plotting methods:
+# from a `~mne.io.Raw` object using :doc:`matplotlib <matplotlib:index>`,
+# but `~mne.io.Raw` objects also have several built-in plotting methods:
 #
 # - :meth:`~mne.io.Raw.plot`
 # - :meth:`~mne.io.Raw.plot_psd`


### PR DESCRIPTION
This is an element of #7751. It defines new classes:

- `MNEFigParams` (a simple attribute container)
- `MNEFigure` (wrapper for `matplotlib.figure.Figure` with our params added)
- `MNEBrowseFigure` (Figure class for raw.plot, ica.plot, epochs.plot)

So far just laying down the infrastructure, none of the instance methods are actually using the new classes yet.  If anyone wants to play around with it:

```python
import os
import matplotlib.pyplot as plt
import mne
plt.ion()
sample_data_folder = mne.datasets.sample.data_path()
sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
                                    'sample_audvis_raw.fif')
raw = mne.io.read_raw_fif(sample_data_raw_file, verbose=False)
fig = mne.viz.raw.plot_raw_alt(raw)
# the "params" live under fig.mne:
print(fig.mne.ax_help)  # etc
```