### PR TITLE
mrg: Add scalar mult and div operators for AverageTFR

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -19,6 +19,8 @@ Changelog
 
 - :meth:`mne.preprocessing.ICA.plot_sources` now plots annotation markers similar to :meth:`mne.io.Raw.plot` by `Luke Bloy`_
 
+- Add support for scalar multiplication and division of :class:`mne.time_frequency.AverageTFR` instances by `Luke Bloy`_
+
 - Add support for signals in mV for :func:`mne.io.read_raw_brainvision` by `Clemens Brunner`_
 
 - :meth:`mne.Epochs.plot_psd_topomap` and :func:`mne.viz.plot_epochs_psd_topomap` now allow joint colorbar limits across subplots, by `Daniel McCloy`_.

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -126,6 +126,8 @@ def test_time_frequency():
     print(itc.ch_names)  # test property
     itc += power  # test add
     itc -= power  # test sub
+    ret = itc * 23  # test mult
+    itc = ret / 23  # test dic
 
     power = power.apply_baseline(baseline=(-0.1, 0), mode='logratio')
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1931,18 +1931,12 @@ class AverageTFR(_BaseTFR):
         return self
 
     def __truediv__(self, a):  # noqa: D105
-        return self.__div__(a)
-
-    def __div__(self, a):  # noqa: D105
         """Divide instances."""
         out = self.copy()
         out /= a
         return out
 
     def __itruediv__(self, a):  # noqa: D105
-        return self.__idiv__(a)
-
-    def __idiv__(self, a):  # noqa: D105
         self.data /= a
         return self
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1930,6 +1930,32 @@ class AverageTFR(_BaseTFR):
         self.data -= tfr.data
         return self
 
+    def __truediv__(self, a):  # noqa: D105
+        return self.__div__(a)
+
+    def __div__(self, a):  # noqa: D105
+        """Divide instances."""
+        out = self.copy()
+        out /= a
+        return out
+
+    def __itruediv__(self, a):  # noqa: D105
+        return self.__idiv__(a)
+
+    def __idiv__(self, a):  # noqa: D105
+        self.data /= a
+        return self
+
+    def __mul__(self, a):
+        """Multiply source instances."""
+        out = self.copy()
+        out *= a
+        return out
+
+    def __imul__(self, a):  # noqa: D105
+        self.data *= a
+        return self
+
     def __repr__(self):  # noqa: D105
         s = "time : [%f, %f]" % (self.times[0], self.times[-1])
         s += ", freq : [%f, %f]" % (self.freqs[0], self.freqs[-1])


### PR DESCRIPTION

Add multiplication and division operators to `AverageTFR`

This enables computing group grand averages from lists using `np.mean` 