### PR TITLE
MRG, ENH: Add OpenGL info to mne sys_info

### DIFF
--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -461,27 +461,27 @@ def sys_info(fid=None, show_paths=False):
 
         >>> import mne
         >>> mne.sys_info() # doctest: +SKIP
-        Platform:      Linux-5.0.0-1031-gcp-x86_64-with-glibc2.2.5
-        Python:        3.8.1 (default, Dec 20 2019, 10:06:11)  [GCC 7.4.0]
-        Executable:    /home/travis/virtualenv/python3.8.1/bin/python
-        CPU:           x86_64: 2 cores
-        Memory:        7.8 GB
+        Platform:      Linux-4.15.0-1067-aws-x86_64-with-glibc2.2.5
+        Python:        3.8.1 (default, Feb  2 2020, 08:37:37)  [GCC 8.3.0]
+        Executable:    /usr/local/bin/python
+        CPU:           : 36 cores
+        Memory:        68.7 GB
 
         mne:           0.21.dev0
-        numpy:         1.19.0.dev0+8dfaa4a {blas=openblas, lapack=openblas}
-        scipy:         1.5.0.dev0+f614064
-        matplotlib:    3.2.1 {backend=Qt5Agg}
+        numpy:         1.19.0 {blas=openblas, lapack=openblas}
+        scipy:         1.5.1
+        matplotlib:    3.2.2 {backend=Qt5Agg}
 
-        sklearn:       0.22.2.post1
-        numba:         0.49.0
-        nibabel:       3.1.0
+        sklearn:       0.23.1
+        numba:         0.50.1
+        nibabel:       3.1.1
         cupy:          Not found
-        pandas:        1.0.3
+        pandas:        1.0.5
         dipy:          1.1.1
-        mayavi:        4.7.2.dev0
-        pyvista:       0.25.2 {pyvistaqt=0.1.0}
-        vtk:           9.0.0
-        PyQt5:         5.14.1
+        mayavi:        Not found
+        pyvista:       0.25.3 {pyvistaqt=0.1.1, OpenGL 3.3 (Core Profile) Mesa 18.3.6 via llvmpipe (LLVM 7.0, 256 bits)}
+        vtk:           9.0.1
+        PyQt5:         5.15.0
     """  # noqa: E501
     ljust = 15
     out = 'Platform:'.ljust(ljust) + platform.platform() + '\n'
@@ -528,12 +528,22 @@ def sys_info(fid=None, show_paths=False):
             elif mod_name == 'matplotlib':
                 extra += ' {backend=%s}%s' % (mod.get_backend(), extra)
             elif mod_name == 'pyvista':
+                extras = list()
                 try:
                     from pyvistaqt import __version__
                 except Exception:
                     pass
                 else:
-                    extra += f' {{pyvistaqt={__version__}}}'
+                    extras += [f'pyvistaqt={__version__}']
+                try:
+                    from pyvista import GPUInfo
+                except ImportError:
+                    pass
+                else:
+                    gi = GPUInfo()
+                    extras += [f'OpenGL {gi.version} via {gi.renderer}']
+                if extras:
+                    extra += f' {{{", ".join(extras)}}}'
             elif mod_name in ('mayavi', 'vtk'):
                 has_3d = True
             if mod_name == 'vtk':


### PR DESCRIPTION
Updates the pyvista line to (a few examples: CircleCI / Linux / macOS):
```
        pyvista:       0.25.3 {pyvistaqt=0.1.1, OpenGL 3.3 (Core Profile) Mesa 18.3.6 via llvmpipe (LLVM 7.0, 256 bits)}
        pyvista:       0.25.2 {pyvistaqt=0.1.0, OpenGL 4.5.0 NVIDIA 440.100 via GeForce GTX 650 Ti BOOST/PCIe/SSE2}
        pyvista:       0.25.2 {pyvistaqt=0.1.1, OpenGL 4.1 INTEL-14.6.18 via Intel(R) Iris(TM) Plus Graphics OpenGL Engine}
```
Should help us debug OpenGL problems as we move to PyVista. In theory we could do something similar for Mayavi but it would require us to do our own parsing of the OpenGL info dump, which is a pain, so not worth it for now.