### PR TITLE
VIZ, BUG: fix tickmarks in evoked topomap colorbar

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1761,7 +1761,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
             cax.set_title(unit)
         cbar = fig.colorbar(images[-1], ax=cax, cax=cax, format=cbar_fmt)
         if cn is not None:
-            cbar.set_ticks(cn.levels)
+            cbar.set_ticks(contours)
         cbar.ax.tick_params(labelsize=7)
         if cmap[1]:
             for im in images:

--- a/tutorials/evoked/plot_20_visualize_evoked.py
+++ b/tutorials/evoked/plot_20_visualize_evoked.py
@@ -19,15 +19,14 @@ import numpy as np
 import mne
 
 ###############################################################################
-# Instead of creating the :class:`~mne.Evoked` object from an
-# :class:`~mne.Epochs` object, we'll load an existing :class:`~mne.Evoked`
-# object from disk. Remember, the :file:`.fif` format can store multiple
-# :class:`~mne.Evoked` objects, so we'll end up with a :class:`list` of
-# :class:`~mne.Evoked` objects after loading. Recall also from the
+# Instead of creating the `~mne.Evoked` object from an `~mne.Epochs` object,
+# we'll load an existing `~mne.Evoked` object from disk. Remember, the
+# :file:`.fif` format can store multiple `~mne.Evoked` objects, so we'll end up
+# with a `list` of `~mne.Evoked` objects after loading. Recall also from the
 # :ref:`tut-section-load-evk` section of :ref:`the introductory Evoked tutorial
-# <tut-evoked-class>` that the sample :class:`~mne.Evoked` objects have not
-# been baseline-corrected and have unapplied projectors, so we'll take care of
-# that when loading:
+# <tut-evoked-class>` that the sample `~mne.Evoked` objects have not been
+# baseline-corrected and have unapplied projectors, so we'll take care of that
+# when loading:
 
 sample_data_folder = mne.datasets.sample.data_path()
 sample_data_evk_file = os.path.join(sample_data_folder, 'MEG', 'sample',


### PR DESCRIPTION
closes #7956 

When the last topomap drawn has low variance and hence no visible contour lines, only one tickmark is drawn on the colorbar, because it uses the *plotted* contours instead of the precomputed contour levels based on vmin/vmax.

https://github.com/mne-tools/mne-python/blob/2965cc3644538c97b297f131bbb46ce9f954ea6f/mne/viz/topomap.py#L1763-L1764
