### PR TITLE
Add low-pass filter to find_bad_channels_maxwell()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -119,6 +119,8 @@ Changelog
 
 - The ``reject_tmin`` and ``reject_tmax`` parameters of :class:`mne.Epochs` are now taken into account when using the ``reject_by_annotation`` parameter by `Stefan Appelhoff`_
 
+- :func:`mne.preprocessing.find_bad_channels_maxwell` now automatically applies a low-pass filter before running bad channel detection. This can be disabled, restoring previous behavior by `Richard Höchenberger`_
+
 Bug
 ~~~
 

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1978,16 +1978,16 @@ def find_bad_channels_maxwell(
     .. versionadded:: 0.20
     """
     if h_freq is not None:
-        if 'lowpass' in raw.info:
+        if raw.info.get('lowpass') and raw.info['lowpass'] < h_freq:
             msg = (f'The input data has already been low-pass filtered with a '
-                   f'{raw.info["lowpass"]} Hz cutoff frequency. If you wish '
-                   f'to avoid filtering again in find_bad_channels_maxwell(), '
-                   f'please pass `h_freq=None`.')
-            logger.warning(msg)
-
-        logger.info(f'Applying low-pass filter with {h_freq} Hz cutoff '
-                    f'frequency ...')
-        raw = raw.copy().filter(l_freq=None, h_freq=h_freq)
+                   f'{raw.info["lowpass"]} Hz cutoff frequency, which is '
+                   f'below the requested cutoff of {h_freq} Hz. Not applying '
+                   f'low-pass filter.')
+            logger.info(msg)
+        else:
+            logger.info(f'Applying low-pass filter with {h_freq} Hz cutoff '
+                        f'frequency ...')
+            raw = raw.copy().filter(l_freq=None, h_freq=h_freq)
 
     limit = float(limit)
     onsets, ends = _annotations_starts_stops(

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1897,7 +1897,7 @@ def find_bad_channels_maxwell(
     %(maxwell_skip)s
     h_freq : float | None
         The cutoff frequency (in Hz) of the low-pass filter that will be
-        applied before processing the data. This defaults to ``40.0``, which
+        applied before processing the data. This defaults to ``40.``, which
         should provide similar results to MaxFilter. If you do not wish to
         apply a filter, set this to ``None``.
     %(verbose)s

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1987,7 +1987,7 @@ def find_bad_channels_maxwell(
         else:
             logger.info(f'Applying low-pass filter with {h_freq} Hz cutoff '
                         f'frequency ...')
-            raw = raw.copy().filter(l_freq=None, h_freq=h_freq)
+            raw = raw.copy().load_data().filter(l_freq=None, h_freq=h_freq)
 
     limit = float(limit)
     onsets, ends = _annotations_starts_stops(

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1863,12 +1863,9 @@ def find_bad_channels_maxwell(
         origin='auto', int_order=8, ext_order=3, calibration=None,
         cross_talk=None, coord_frame='head', regularize='in', ignore_ref=False,
         bad_condition='error', head_pos=None, mag_scale=100.,
-        skip_by_annotation=('edge', 'bad_acq_skip'), verbose=None):
+        skip_by_annotation=('edge', 'bad_acq_skip'), h_freq=40.0,
+        verbose=None):
     r"""Find bad channels using Maxwell filtering.
-
-    .. note:: For closer equivalence with MaxFilter, it's recommended to
-        low-pass filter your data (e.g., at 40 Hz) prior to running this
-        function.
 
     Parameters
     ----------
@@ -1898,6 +1895,11 @@ def find_bad_channels_maxwell(
     %(maxwell_reg_ref_cond_pos)s
     %(maxwell_mag)s
     %(maxwell_skip)s
+    h_freq : float | None
+        The cutoff frequency (in Hz) of the low-pass filter that will be
+        applied before processing the data. This defaults to ``40.0``, which
+        should provide similar results to MaxFilter. If you do not wish to
+        apply a filter, set this to ``None``.
     %(verbose)s
 
     Returns
@@ -1975,6 +1977,18 @@ def find_bad_channels_maxwell(
 
     .. versionadded:: 0.20
     """
+    if h_freq is not None:
+        if 'lowpass' in raw.info:
+            msg = (f'The input data has already been low-pass filtered with a '
+                   f'{raw.info["lowpass"]} Hz cutoff frequency. If you wish '
+                   f'to avoid filtering again in find_bad_channels_maxwell(), '
+                   f'please pass `h_freq=None`.')
+            logger.warning(msg)
+
+        logger.info(f'Applying low-pass filter with {h_freq} Hz cutoff '
+                    f'frequency ...')
+        raw = raw.copy().filter(l_freq=None, h_freq=h_freq)
+
     limit = float(limit)
     onsets, ends = _annotations_starts_stops(
         raw, skip_by_annotation, invert=True)

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1077,23 +1077,27 @@ def test_mf_skips():
 @testing.requires_testing_data
 @pytest.mark.parametrize(
     ('fname', 'bads', 'annot', 'add_ch', 'ignore_ref', 'want_bads',
-     'return_scores'), [
+     'return_scores', 'h_freq'), [
         # Neuromag data tested against MF
-        (sample_fname, [], False, False, False, ['MEG 2443'], False),
+        (sample_fname, [], False, False, False, ['MEG 2443'], False, None),
         # add 0111 to test picking, add annot to test it, and prepend chs for
         # idx
-        (sample_fname, ['MEG 0111'], True, True, False, ['MEG 2443'], False),
+        (sample_fname, ['MEG 0111'], True, True, False, ['MEG 2443'], False,
+         None),
         # CTF data seems to be sensitive to linalg lib (?) because some
         # channels are very close to the limit, so we just check that one shows
         # up
-        (ctf_fname_continuous, [], False, False, False, {'BR1-4304'}, False),
+        (ctf_fname_continuous, [], False, False, False, {'BR1-4304'}, False,
+         None),
         # faked
-        (ctf_fname_continuous, [], False, False, True, ['MLC24-4304'], False),
+        (ctf_fname_continuous, [], False, False, True, ['MLC24-4304'], False,
+         None),
         # For `return_scores=True`
-        (sample_fname, ['MEG 0111'], True, True, False, ['MEG 2443'], True)
+        (sample_fname, ['MEG 0111'], True, True, False, ['MEG 2443'], True,
+         50)
     ])
 def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
-                                   want_bads, return_scores):
+                                   want_bads, return_scores, h_freq):
     """Test automatic bad channel detection."""
     if fname.endswith('.ds'):
         raw = read_raw_ctf(fname).load_data()
@@ -1133,7 +1137,7 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
             raw, origin=(0., 0., 0.04), regularize=None,
             bad_condition='ignore', skip_by_annotation='BAD', verbose=True,
             ignore_ref=ignore_ref, min_count=min_count,
-            return_scores=return_scores)
+            return_scores=return_scores, h_freq=h_freq)
 
     if return_scores:
         assert len(return_vals) == 3
@@ -1150,7 +1154,9 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
     log = log.getvalue()
     assert 'Interval   1:    0.00' in log
     assert 'Interval   2:    5.00' in log
-    assert 'data has already been low-pass filtered' in log
+
+    if h_freq is not None and h_freq > raw.info['lowpass']:
+        assert 'data has already been low-pass filtered' in log
 
     if return_scores:
         meg_chs = raw.copy().pick_types(meg=True, exclude=[]).ch_names

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1150,6 +1150,7 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
     log = log.getvalue()
     assert 'Interval   1:    0.00' in log
     assert 'Interval   2:    5.00' in log
+    assert 'data has already been low-pass filtered' in log
 
     if return_scores:
         meg_chs = raw.copy().pick_types(meg=True, exclude=[]).ch_names

--- a/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
+++ b/tutorials/preprocessing/plot_60_maxwell_filtering_sss.py
@@ -102,15 +102,10 @@ crosstalk_file = os.path.join(sample_data_folder, 'SSS', 'ct_sparse_mgh.fif')
 #     calling :func:`~mne.preprocessing.maxwell_filter` in order to prevent
 #     bad channel noise from spreading.
 #
-# Let's see if we can automatically detect it. To do this we need to
-# operate on a signal without line noise or cHPI signals, which is most
-# easily achieved using :func:`mne.chpi.filter_chpi`,
-# :func:`mne.io.Raw.notch_filter`, or :meth:`mne.io.Raw.filter`. For simplicity
-# we just low-pass filter these data:
+# Let's see if we can automatically detect it.
 
 raw.info['bads'] = []
 raw_check = raw.copy()
-raw_check.pick_types(meg=True, exclude=()).load_data().filter(None, 40)
 auto_noisy_chs, auto_flat_chs, auto_scores = find_bad_channels_maxwell(
     raw_check, cross_talk=crosstalk_file, calibration=fine_cal_file,
     return_scores=True, verbose=True)
@@ -118,6 +113,17 @@ print(auto_noisy_chs)  # we should find them!
 print(auto_flat_chs)  # none for this dataset
 
 ###############################################################################
+#
+# .. note:: `~mne.preprocessing.find_bad_channels_maxwell` needs to operate on
+#           a signal without line noise or cHPI signals. By default, it simply
+#           applies a low-pass filter with a cutoff frequency of 40 Hz to the
+#           data, which should remove these artifacts. You may also specify a
+#           different cutoff by passing the ``h_freq`` keyword argument. If you
+#           set ``h_freq=None``, no filtering will be applied. This can be
+#           useful if your data has already been preconditioned, for example
+#           using :func:`mne.chpi.filter_chpi`,
+#           :func:`mne.io.Raw.notch_filter`, or :meth:`mne.io.Raw.filter`.
+#
 # Now we can update the list of bad channels in the dataset.
 
 bads = raw.info['bads'] + auto_noisy_chs + auto_flat_chs


### PR DESCRIPTION
#### What does this implement/fix?

The current approach to using `find_bad_channels_maxwell()` requires users to manually low-pass filter their data before passing it to the function. This is kind of cumbersome.

This PR, therefore, adds a `h_freq` kwarg that sets the cutoff frequency of an automatically-applied low-pass filter. Passing `h_freq=None` disables filtering. If the input data has already been low-pass filtered, a helpful warning is emitted.

We already have a similar API in `preprocessing.compute_proj_ecg()`, so this change makes things more consistent within the `preprocessing` module.
