### PR TITLE
[MRG] Strip base directory name from Report captions when using parse_folder

### DIFF
--- a/tutorials/misc/plot_report.py
+++ b/tutorials/misc/plot_report.py
@@ -195,4 +195,3 @@ with mne.open_report('report.h5') as report:
 ###############################################################################
 # With the context manager, the updated report is also automatically saved
 # back to :file:`report.h5` upon leaving the block.
-# This line needs to be removed.

--- a/tutorials/misc/plot_report.py
+++ b/tutorials/misc/plot_report.py
@@ -195,3 +195,4 @@ with mne.open_report('report.h5') as report:
 ###############################################################################
 # With the context manager, the updated report is also automatically saved
 # back to :file:`report.h5` upon leaving the block.
+# This line needs to be removed.


### PR DESCRIPTION
#### What does this implement/fix?

When using `Report.parse_folder()`, including the "base directory" (i.e., folder name) in all captions's unnecessarily redundant and impairs legibility. This commit changes the behavior of `Report` such that when `parse_folder()` is used, the base directory name will be stripped from the captions.

### `master`
<img width="632" alt="Screenshot 2020-07-09 at 17 43 10" src="https://user-images.githubusercontent.com/2046265/87061253-d019c500-c20b-11ea-8483-41a752111c64.png">


### PR branch
<img width="632" alt="Screenshot 2020-07-09 at 17 42 39" src="https://user-images.githubusercontent.com/2046265/87061230-c728f380-c20b-11ea-89fe-b933ec11060c.png">
