### PR TITLE
MRG, ENH: Reduce memory usage of Welch PSD

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -73,6 +73,8 @@ Changelog
 
 - Speed up :meth:`mne.Epochs.copy` and :meth:`mne.Epochs.__getitem__` by avoiding copying immutable attributes by `Eric Larson`_
 
+- Reduce memory usage of `~mne.io.Raw.plot_psd`, `~mne.time_frequency.psd_welch`, and `~mne.time_frequency.psd_array_welch` for long segments of data by `Eric Larson`_
+
 - Support for saving movies of source time courses (STCs) with ``brain.save_movie`` method and from graphical user interface by `Guillaume Favelier`_
 
 - Add ``mri`` and ``show_orientation`` arguments to :func:`mne.viz.plot_bem` by `Eric Larson`_

--- a/mne/report.py
+++ b/mne/report.py
@@ -182,7 +182,7 @@ def _get_fname(fname):
 
 
 def _endswith(fname, exts):
-    """Aux function to test if fname ends with 'ext.fif'."""
+    """Aux function to test if fname ends with ext.fif for any ext in exts."""
     if isinstance(exts, str):
         exts = [exts]
     for ext in exts:

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -2,6 +2,7 @@
 #           Denis A. Engemann <denis.engemann@gmail.com>
 # License : BSD 3-clause
 
+from functools import partial
 import numpy as np
 
 from ..parallel import parallel_func
@@ -10,17 +11,30 @@ from ..utils import logger, verbose, _time_mask, _check_option
 from .multitaper import psd_array_multitaper
 
 
-def _spect_func(epoch, n_overlap, n_per_seg, nfft, fs, freq_mask, func,
-                average):
-    """Aux function."""
-    _, _, spect = func(epoch, fs=fs, nperseg=n_per_seg, noverlap=n_overlap,
-                       nfft=nfft, window='hamming')
-    spect = spect[..., freq_mask, :]
+def _decomp_aggregate_mask(epoch, func, average, freq_sl):
+    _, _, spect = func(epoch)
+    spect = spect[..., freq_sl, :]
     # Do the averaging here (per epoch) to save memory
     if average == 'mean':
         spect = np.nanmean(spect, axis=-1)
     elif average == 'median':
         spect = np.nanmedian(spect, axis=-1)
+    return spect
+
+
+def _spect_func(epoch, func, freq_sl, average):
+    """Aux function."""
+    # Decide if we should split this to save memory or not, since doing
+    # multiple calls will incur some performance overhead. Eventually we might
+    # want to write (really, go back to) our own spectrogram implementation
+    # that, if possible, averages after each transform, but this will incur
+    # a lot of overhead because of the many Python calls required.
+    kwargs = dict(func=func, average=average, freq_sl=freq_sl)
+    if epoch.nbytes > 10e6:
+        spect = np.apply_along_axis(
+            _decomp_aggregate_mask, -1, epoch, **kwargs)
+    else:
+        spect = _decomp_aggregate_mask(epoch, **kwargs)
     return spect
 
 
@@ -131,17 +145,21 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     logger.info("Effective window size : %0.3f (s)" % win_size)
     freqs = np.arange(n_fft // 2 + 1, dtype=float) * (sfreq / n_fft)
     freq_mask = (freqs >= fmin) & (freqs <= fmax)
-    freqs = freqs[freq_mask]
+    if not freq_mask.any():
+        raise ValueError(
+            f'No frequencies found between fmin={fmin} and fmax={fmax}')
+    freq_sl = slice(*(np.where(freq_mask)[0][[0, -1]] + [0, 1]))
+    del freq_mask
+    freqs = freqs[freq_sl]
 
     # Parallelize across first N-1 dimensions
     x_splits = np.array_split(x, n_jobs)
 
     from scipy.signal import spectrogram
     parallel, my_spect_func, n_jobs = parallel_func(_spect_func, n_jobs=n_jobs)
-
-    f_spect = parallel(my_spect_func(d, n_overlap=n_overlap,
-                                     n_per_seg=n_per_seg, nfft=n_fft, fs=sfreq,
-                                     freq_mask=freq_mask, func=spectrogram,
+    func = partial(spectrogram, noverlap=n_overlap, nperseg=n_per_seg,
+                   nfft=n_fft, fs=sfreq)
+    f_spect = parallel(my_spect_func(d, func=func, freq_sl=freq_sl,
                                      average=average)
                        for d in x_splits)
     psds = np.concatenate(f_spect, axis=0)

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -88,13 +88,15 @@ def test_psd():
     assert (len(freqs1) == np.floor(len(freqs2) / 2.))
     assert (psds1.shape[-1] == np.floor(psds2.shape[-1] / 2.))
 
-    # tests ValueError when n_per_seg=None and n_fft > signal length
     kws_psd.update(dict(n_fft=tmax * 1.1 * raw.info['sfreq']))
-    pytest.raises(ValueError, psd_welch, raw, proj=False, n_per_seg=None,
+    with pytest.raises(ValueError, match='n_fft is not allowed to be > n_tim'):
+        psd_welch(raw, proj=False, n_per_seg=None,
                   **kws_psd)
-    # ValueError when n_overlap > n_per_seg
     kws_psd.update(dict(n_fft=128, n_per_seg=64, n_overlap=90))
-    pytest.raises(ValueError, psd_welch, raw, proj=False, **kws_psd)
+    with pytest.raises(ValueError, match='n_overlap cannot be greater'):
+        psd_welch(raw, proj=False, **kws_psd)
+    with pytest.raises(ValueError, match='No frequencies found'):
+        psd_array_welch(np.zeros((1, 1000)), 1000., fmin=10, fmax=1)
 
     # -- Epochs/Evoked --
     events = read_events(event_fname)


### PR DESCRIPTION
This:
```
# -*- coding: utf-8 -*-
import os
import mne
sample_data_folder = mne.datasets.sample.data_path()
sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
                                    'sample_audvis_raw.fif')
raw = mne.io.read_raw_fif(sample_data_raw_file)
raw.plot_psd()
data_path = mne.datasets.brainstorm.bst_raw.data_path()
raw_path = (data_path + '/MEG/bst_raw/' +
            'subj001_somatosensory_20111109_01_AUX-f.ds')
raw = mne.io.read_raw_ctf(raw_path).load_data()
raw.plot_psd()
```
Goes from this on `master`:

![Screenshot from 2020-07-10 13-02-49](https://user-images.githubusercontent.com/2365790/87182099-75d33f80-c2b1-11ea-875f-66befcc42314.png)

To this:

![Screenshot from 2020-07-10 13-03-17](https://user-images.githubusercontent.com/2365790/87182103-78359980-c2b1-11ea-9298-f53da0878f15.png)

@agramfort feel free to try it on https://github.com/mne-tools/mne-study-template/pull/155