### PR TITLE
Ignore flake8 E741 (ambiguous variable name)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ doc-files = doc
 
 [flake8]
 exclude = __init__.py,*externals*,constants.py,fixes.py,resources.py
-ignore = W503,W504,I100,I101,I201,N806,E201,E202,E221,E222,E241
+ignore = W503,W504,I100,I101,I201,N806,E201,E202,E221,E222,E241,E741
 # We add A for the array-spacing plugin, and ignore the E ones it covers above
 select = A,E,F,W,C
 


### PR DESCRIPTION
Running flake8 on master gives me:
```
./tutorials/source-modeling/plot_background_freesurfer_mne.py:133:22: E741 ambiguous variable name 'I'
./tutorials/source-modeling/plot_background_freesurfer_mne.py:136:22: E741 ambiguous variable name 'I'
```

https://github.com/mne-tools/mne-python/blob/d839a6ce32da840d7ed4f4cec5340e479f8bde55/tutorials/source-modeling/plot_background_freesurfer_mne.py#L132-L137


I don't think this rule is very useful (as we'll spot badly-named variables during the code review anyway), so this PR disables it.
