### PR TITLE
MRG: When picking, remove inapplicable projectors

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -127,7 +127,7 @@ Changelog
 
 - Deletion of applied (active) projectors via `~mne.io.Raw.del_proj`, `~mne.Epochs.del_proj`, and `~mne.Evoked.del_proj` is now possible if the channels the to-be-removed projector applies to are not present in the data anymore by `Richard Höchenberger`_
 
-- When picking a subset of channels from `~mne.io.Raw`, `~mne.Epochs`, or `~mne.Evoked`, projectors that can only be applied to the removed channels will now be dropped automatically by `Richard Höchenberger`_
+- When picking a subset of channels, or when dropping channels from `~mne.io.Raw`, `~mne.Epochs`, or `~mne.Evoked`, projectors that can only be applied to the removed channels will now be dropped automatically by `Richard Höchenberger`_
 
 Bug
 ~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -125,8 +125,6 @@ Changelog
 
 - BrainVision data format files are now parsed for EEG impedance values in :func:`mne.io.read_raw_brainvision` and provided as a ``.impedances`` attribute of ``raw`` by `Stefan Appelhoff`_ and `Jan Sedivy`_
 
-- Deletion of applied (active) projectors via `~mne.io.Raw.del_proj`, `~mne.Epochs.del_proj`, and `~mne.Evoked.del_proj` is now possible if the channels the to-be-removed projector applies to are not present in the data anymore by `Richard Höchenberger`_
-
 - When picking a subset of channels, or when dropping channels from `~mne.io.Raw`, `~mne.Epochs`, or `~mne.Evoked`, projectors that can only be applied to the removed channels will now be dropped automatically by `Richard Höchenberger`_
 
 Bug

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -127,6 +127,8 @@ Changelog
 
 - Deletion of applied (active) projectors via `~mne.io.Raw.del_proj`, `~mne.Epochs.del_proj`, and `~mne.Evoked.del_proj` is now possible if the channels the to-be-removed projector applies to are not present in the data anymore by `Richard Höchenberger`_
 
+- When picking a subset of channels from `~mne.io.Raw`, `~mne.Epochs`, or `~mne.Evoked`, projectors that can only be applied to the removed channels will now be dropped automatically by `Richard Höchenberger`_
+
 Bug
 ~~~
 

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -293,7 +293,7 @@ def test_make_lcmv(tmpdir, reg, proj):
 
     # __repr__
     assert len(evoked.ch_names) == 22
-    assert len(evoked.info['projs']) == (4 if proj else 0)
+    assert len(evoked.info['projs']) == (3 if proj else 0)
     assert len(evoked.info['bads']) == 2
     rank = 17 if proj else 20
     assert 'LCMV' in repr(filters)

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -904,7 +904,7 @@ class UpdateChannelsMixin(object):
                 drop_idx.append(idx)
 
         for idx in drop_idx:
-            logger.warning(f"Removing projector {self.info['projs'][idx]}")
+            warn(f"Removing projector {self.info['projs'][idx]}")
         if drop_idx:
             self.del_proj(drop_idx)
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -893,7 +893,7 @@ class UpdateChannelsMixin(object):
         return self
 
     def _pick_projs(self):
-        """Only keep projectors whose channels are still in the data."""
+        """Keep only projectors which apply to at least 1 data channel."""
         drop_idx = []
         for idx, proj in enumerate(self.info['projs']):
             if not set(self.info['ch_names']) & set(proj['data']['col_names']):

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -901,7 +901,8 @@ class UpdateChannelsMixin(object):
 
         for idx in drop_idx:
             logger.info(f"Removing projector {self.info['projs'][idx]}")
-        if drop_idx:
+
+        if drop_idx and hasattr(self, 'del_proj'):
             self.del_proj(drop_idx)
 
         return self

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -864,7 +864,9 @@ class UpdateChannelsMixin(object):
         bad_idx = [self.ch_names.index(ch) for ch in ch_names
                    if ch in self.ch_names]
         idx = np.setdiff1d(np.arange(len(self.ch_names)), bad_idx)
-        return self._pick_drop_channels(idx)
+        self._pick_drop_channels(idx)
+        self._pick_projs()
+        return self
 
     def _pick_drop_channels(self, idx):
         # avoid circular imports

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -722,9 +722,7 @@ class UpdateChannelsMixin(object):
             ias=ias, syst=syst, seeg=seeg, dipole=dipole, gof=gof, bio=bio,
             ecog=ecog, fnirs=fnirs, include=include, exclude=exclude,
             selection=selection)
-        self._pick_drop_channels(idx)
-        self._pick_projs()
-        return self
+        return self._pick_drop_channels(idx)
 
     def pick_channels(self, ch_names, ordered=False):
         """Pick some channels.
@@ -758,10 +756,8 @@ class UpdateChannelsMixin(object):
 
         .. versionadded:: 0.9.0
         """
-        self._pick_drop_channels(pick_channels(self.info['ch_names'], ch_names,
-                                               ordered=ordered))
-        self._pick_projs()
-        return self
+        picks = pick_channels(self.info['ch_names'], ch_names, ordered=ordered)
+        return self._pick_drop_channels(picks)
 
     @fill_doc
     def pick(self, picks, exclude=()):
@@ -781,9 +777,7 @@ class UpdateChannelsMixin(object):
         """
         picks = _picks_to_idx(self.info, picks, 'all', exclude,
                               allow_empty=False)
-        self._pick_drop_channels(picks)
-        self._pick_projs()
-        return self
+        return self._pick_drop_channels(picks)
 
     def reorder_channels(self, ch_names):
         """Reorder channels.
@@ -864,9 +858,7 @@ class UpdateChannelsMixin(object):
         bad_idx = [self.ch_names.index(ch) for ch in ch_names
                    if ch in self.ch_names]
         idx = np.setdiff1d(np.arange(len(self.ch_names)), bad_idx)
-        self._pick_drop_channels(idx)
-        self._pick_projs()
-        return self
+        return self._pick_drop_channels(idx)
 
     def _pick_drop_channels(self, idx):
         # avoid circular imports
@@ -896,6 +888,8 @@ class UpdateChannelsMixin(object):
             self._data = self._data.take(idx, axis=axis)
         else:
             assert isinstance(self, BaseRaw) and not self.preload
+
+        self._pick_projs()
         return self
 
     def _pick_projs(self):

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -904,7 +904,7 @@ class UpdateChannelsMixin(object):
                 drop_idx.append(idx)
 
         for idx in drop_idx:
-            warn(f"Removing projector {self.info['projs'][idx]}")
+            logger.info(f"Removing projector {self.info['projs'][idx]}")
         if drop_idx:
             self.del_proj(drop_idx)
 

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -728,28 +728,31 @@ def test_proj(tmpdir):
         assert_allclose(data_proj_1, data_proj_2)
         assert_allclose(data_proj_2, np.dot(raw._projector, data_proj_2))
 
+    # Test that picking removes projectors ...
+    raw = read_raw_fif(fif_fname).apply_proj()
+    n_projs = len(raw.info['projs'])
+    raw.pick_types(meg=False, eeg=True)
+    assert len(raw.info['projs']) == n_projs - 3
+
+    # ... but only if it doesn't apply to any channels in the dataset anymore.
+    raw = read_raw_fif(fif_fname).apply_proj()
+    n_projs = len(raw.info['projs'])
+    raw.pick_types(meg='mag', eeg=True)
+    assert len(raw.info['projs']) == n_projs
+
+    # I/O roundtrip of an MEG projector with a Raw that only contains MEG
+    # data.
     out_fname = tmpdir.join('test_raw.fif')
     raw = read_raw_fif(test_fif_fname, preload=True).crop(0, 0.002)
+    proj = raw.info['projs'][-1]
     raw.pick_types(meg=False, eeg=True)
-    raw.info['projs'] = [raw.info['projs'][-1]]
+    raw.info['projs'] = [proj]  # Restore, because picking removed it!
     raw._data.fill(0)
     raw._data[-1] = 1.
     raw.save(out_fname)
     raw = read_raw_fif(out_fname, preload=False)
     raw.apply_proj()
     assert_allclose(raw[:, :][0][:1], raw[0, :][0])
-
-    # Read file again, apply proj, pick all channels one proj did NOT apply to;
-    # then try to delete this proj, which now exclusively refers to channels
-    # which are not present in the data anymore.
-    raw = read_raw_fif(fif_fname).apply_proj()
-    del_proj_idx = 0
-    picks = list(set(raw.ch_names) -
-                 set(raw.info['projs'][del_proj_idx]['data']['col_names']))
-    raw.pick(picks)
-    n_projs = len(raw.info['projs'])
-    raw.del_proj(del_proj_idx)
-    assert len(raw.info['projs']) == n_projs - 1
 
 
 @testing.requires_testing_data

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -731,7 +731,8 @@ def test_proj(tmpdir):
     # Test that picking removes projectors ...
     raw = read_raw_fif(fif_fname).apply_proj()
     n_projs = len(raw.info['projs'])
-    raw.pick_types(meg=False, eeg=True)
+    with pytest.warns(RuntimeWarning, match='Removing projector'):
+        raw.pick_types(meg=False, eeg=True)
     assert len(raw.info['projs']) == n_projs - 3
 
     # ... but only if it doesn't apply to any channels in the dataset anymore.
@@ -745,7 +746,8 @@ def test_proj(tmpdir):
     out_fname = tmpdir.join('test_raw.fif')
     raw = read_raw_fif(test_fif_fname, preload=True).crop(0, 0.002)
     proj = raw.info['projs'][-1]
-    raw.pick_types(meg=False, eeg=True)
+    with pytest.warns(RuntimeWarning, match='Removing projector'):
+        raw.pick_types(meg=False, eeg=True)
     raw.info['projs'] = [proj]  # Restore, because picking removed it!
     raw._data.fill(0)
     raw._data[-1] = 1.

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -740,7 +740,7 @@ def test_proj(tmpdir):
     raw.pick_types(meg='mag', eeg=True)
     assert len(raw.info['projs']) == n_projs
 
-    # I/O roundtrip of an MEG projector with a Raw that only contains MEG
+    # I/O roundtrip of an MEG projector with a Raw that only contains EEG
     # data.
     out_fname = tmpdir.join('test_raw.fif')
     raw = read_raw_fif(test_fif_fname, preload=True).crop(0, 0.002)

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1478,7 +1478,7 @@ def test_drop_channels_mixin():
     assert len(ch_names) == len(raw._cals)
     assert len(ch_names) == raw._data.shape[0]
 
-    # Test that picking all channels a projector applies to will lead to the
+    # Test that dropping all channels a projector applies to will lead to the
     # removal of said projector.
     raw = read_raw_fif(fif_fname).apply_proj()
     n_projs = len(raw.info['projs'])

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1478,6 +1478,13 @@ def test_drop_channels_mixin():
     assert len(ch_names) == len(raw._cals)
     assert len(ch_names) == raw._data.shape[0]
 
+    # Test that picking all channels a projector applies to will lead to the
+    # removal of said projector.
+    raw = read_raw_fif(fif_fname).apply_proj()
+    n_projs = len(raw.info['projs'])
+    raw.drop_channels(raw.info['projs'][-1]['data']['col_names'])  # EEG proj
+    assert len(raw.info['projs']) == n_projs - 1
+
 
 @testing.requires_testing_data
 @pytest.mark.parametrize('preload', (True, False))

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -731,8 +731,7 @@ def test_proj(tmpdir):
     # Test that picking removes projectors ...
     raw = read_raw_fif(fif_fname).apply_proj()
     n_projs = len(raw.info['projs'])
-    with pytest.warns(RuntimeWarning, match='Removing projector'):
-        raw.pick_types(meg=False, eeg=True)
+    raw.pick_types(meg=False, eeg=True)
     assert len(raw.info['projs']) == n_projs - 3
 
     # ... but only if it doesn't apply to any channels in the dataset anymore.
@@ -746,8 +745,7 @@ def test_proj(tmpdir):
     out_fname = tmpdir.join('test_raw.fif')
     raw = read_raw_fif(test_fif_fname, preload=True).crop(0, 0.002)
     proj = raw.info['projs'][-1]
-    with pytest.warns(RuntimeWarning, match='Removing projector'):
-        raw.pick_types(meg=False, eeg=True)
+    raw.pick_types(meg=False, eeg=True)
     raw.info['projs'] = [proj]  # Restore, because picking removed it!
     raw._data.fill(0)
     raw._data[-1] = 1.

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -222,8 +222,7 @@ class ProjMixin(object):
         """Remove SSP projection vector.
 
         .. note:: The projection vector can only be removed if it is inactive
-                  (has not been applied to the data), unless the channels it
-                  was applied to no longer exist in the data.
+                  (has not been applied to the data).
 
         Parameters
         ----------


### PR DESCRIPTION
#### What does this implement/fix?
Pick'ing may entirely eliminate a certain channel type from the resulting object. However, the list of projectors in `info['projs']` will remain unchanged. This can lead to problems in later processing steps, where situations may arise where one is trying to apply a projector for a channel type that is not present in the data anymore.

**MWE:**
```python
import mne
from mne.datasets import sample

data_path = sample.data_path()
raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
raw = mne.io.read_raw_fif(raw_fname, preload=True)

raw.set_eeg_reference(projection=True)
raw.pick_types(meg=False, eeg=True)  # Drop MEG data
raw.plot_projs_topomap()
```

**With `master`:**
A problem arises because although we dropped all MEG data, the MEG projectors are still present.

```python
Traceback (most recent call last):
  File "/private/tmp/mwe.py", line 10, in <module>
    raw.plot_projs_topomap()
  File "/Users/hoechenberger/Development/mne-python/mne/io/proj.py", line 280, in plot_projs_topomap
    fig = plot_projs_topomap(self.info['projs'], self.info, cmap=cmap,
  File "/Users/hoechenberger/Development/mne-python/mne/viz/topomap.py", line 324, in plot_projs_topomap
    use_info = pick_info(info, pick_channels(info_names, ch_names))
  File "<decorator-gen-8>", line 21, in pick_info
  File "/Users/hoechenberger/Development/mne-python/mne/io/pick.py", line 489, in pick_info
    raise ValueError('No channels match the selection.')
ValueError: No channels match the selection.
```

**With this PR:**
The MEG projectors get removed during the pick:
```
Removing projector <Projection | PCA-v1, active : False, n_channels : 102>
Removing projector <Projection | PCA-v2, active : False, n_channels : 102>
Removing projector <Projection | PCA-v3, active : False, n_channels : 102>
```
<img width="307" alt="Screenshot 2020-07-12 at 22 46 10" src="https://user-images.githubusercontent.com/2046265/87256291-7de9d580-c491-11ea-81e9-8bb502fb6600.png">

WIP because
- I'm looking for feedback, obviously
- tests are missing
- not sure if this would demand a deprecation cycle

Thanks!