### PR TITLE
WIP: Improve _Brain memory footprint

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -244,18 +244,21 @@ class _Brain(object):
                 if not (hemi in ['lh', 'rh'] and h != hemi):
                     ci = hi if hemi == 'split' else 0
                     self._renderer.subplot(ri, ci)
+                    kwargs = {
+                        "color": None,
+                        "scalars": self.geo[h].bin_curv,
+                        "vmin": geo_kwargs["vmin"],
+                        "vmax": geo_kwargs["vmax"],
+                        "colormap": geo_kwargs["colormap"],
+                        "opacity": alpha,
+                    }
                     if self._hemi_meshes.get(h) is None:
                         mesh_data = self._renderer.mesh(
                             x=self.geo[h].coords[:, 0],
                             y=self.geo[h].coords[:, 1],
                             z=self.geo[h].coords[:, 2],
                             triangles=self.geo[h].faces,
-                            color=None,
-                            scalars=self.geo[h].bin_curv,
-                            vmin=geo_kwargs["vmin"],
-                            vmax=geo_kwargs["vmax"],
-                            colormap=geo_kwargs["colormap"],
-                            opacity=alpha,
+                            **kwargs,
                         )
                         if isinstance(mesh_data, tuple):
                             actor, mesh = mesh_data
@@ -268,13 +271,9 @@ class _Brain(object):
                     else:
                         self._renderer._mesh(
                             self._hemi_meshes[h],
-                            color=None,
-                            scalars=self.geo[h].bin_curv,
-                            vmin=geo_kwargs["vmin"],
-                            vmax=geo_kwargs["vmax"],
-                            colormap=geo_kwargs["colormap"],
-                            opacity=alpha,
+                            **kwargs,
                         )
+                    del kwargs
                     self._renderer.set_camera(azimuth=views_dict[v].azim,
                                               elevation=views_dict[v].elev)
 
@@ -501,18 +500,21 @@ class _Brain(object):
             else:
                 ci = 0 if hemi == 'lh' else 1
             self._renderer.subplot(ri, ci)
+            kwargs = {
+                "color": None,
+                "colormap": self._data['ctable'],
+                "vmin": dt_min,
+                "vmax": dt_max,
+                "opacity": alpha,
+                "scalars": np.zeros(len(self.geo[hemi].coords)),
+            }
             if self._data[hemi]['mesh'] is None:
                 mesh_data = self._renderer.mesh(
                     x=self.geo[hemi].coords[:, 0],
                     y=self.geo[hemi].coords[:, 1],
                     z=self.geo[hemi].coords[:, 2],
                     triangles=self.geo[hemi].faces,
-                    color=None,
-                    colormap=self._data['ctable'],
-                    vmin=dt_min,
-                    vmax=dt_max,
-                    opacity=alpha,
-                    scalars=np.zeros(len(self.geo[hemi].coords)),
+                    **kwargs,
                 )
                 if isinstance(mesh_data, tuple):
                     actor, mesh = mesh_data
@@ -526,13 +528,9 @@ class _Brain(object):
             else:
                 self._renderer._mesh(
                     self._data[hemi]['mesh'],
-                    color=None,
-                    colormap=self._data['ctable'],
-                    vmin=dt_min,
-                    vmax=dt_max,
-                    opacity=alpha,
-                    scalars=np.zeros(len(self.geo[hemi].coords)),
+                    **kwargs,
                 )
+            del kwargs
 
         # 2) update time and smoothing properties
         # set_data_smoothing calls "set_time_point" for us, which will set

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -258,6 +258,7 @@ class _Brain(object):
                             y=self.geo[h].coords[:, 1],
                             z=self.geo[h].coords[:, 2],
                             triangles=self.geo[h].faces,
+                            normals=self.geo[h].nn,
                             **kwargs,
                         )
                         if isinstance(mesh_data, tuple):
@@ -514,6 +515,7 @@ class _Brain(object):
                     y=self.geo[hemi].coords[:, 1],
                     z=self.geo[hemi].coords[:, 2],
                     triangles=self.geo[hemi].faces,
+                    normals=self.geo[hemi].nn,
                     **kwargs,
                 )
                 if isinstance(mesh_data, tuple):

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1445,7 +1445,8 @@ class _Brain(object):
         for hemi in ['lh', 'rh']:
             hemi_data = self._data.get(hemi)
             if hemi_data is not None:
-                for actor in hemi_data['actor']:
+                if hemi_data['actor'] is not None:
+                    actor = hemi_data['actor']
                     vtk_lut = actor.GetMapper().GetLookupTable()
                     vtk_lut.SetNumberOfColors(n_col)
                     vtk_lut.SetRange([fmin, fmax])

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -867,7 +867,7 @@ class _TimeViewer(object):
                     self.act_data_smooth[hemi][0].shape
                 )
                 vertex_id = hemi_data['vertices'][ind[0]]
-                mesh = hemi_data['mesh'][-1]
+                mesh = hemi_data['mesh']
                 line = self.plot_time_course(hemi, vertex_id, color)
                 self.add_point(hemi, mesh, vertex_id, line, color)
 

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -68,7 +68,6 @@ class _Renderer(_BaseRenderer):
                  name=None, show=False, shape=(1, 1), smooth_shading=True):
         if bgcolor is not None:
             bgcolor = _check_color(bgcolor)
-        print(bgcolor)
         self.mlab = _import_mlab()
         self.shape = shape
         if fig is None:
@@ -95,6 +94,13 @@ class _Renderer(_BaseRenderer):
         if self.fig.scene is not None:
             self.fig.scene.interactor.interactor_style = \
                 tvtk.InteractorStyleTerrain()
+
+    def _mesh(self, mesh, color, opacity=1.0,
+              backface_culling=False, scalars=None, colormap=None,
+              vmin=None, vmax=None, interpolate_before_map=True,
+              representation='surface', line_width=1., **kwargs):
+        # XXX To do
+        pass
 
     def mesh(self, x, y, z, triangles, color, opacity=1.0, shading=False,
              backface_culling=False, scalars=None, colormap=None,

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -104,7 +104,7 @@ class _Renderer(_BaseRenderer):
     def mesh(self, x, y, z, triangles, color, opacity=1.0, shading=False,
              backface_culling=False, scalars=None, colormap=None,
              vmin=None, vmax=None, interpolate_before_map=True,
-             representation='surface', line_width=1., **kwargs):
+             representation='surface', line_width=1., normals=None, **kwargs):
         if color is not None:
             color = _check_color(color)
         if color is not None and isinstance(color, np.ndarray) \

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -99,8 +99,7 @@ class _Renderer(_BaseRenderer):
               backface_culling=False, scalars=None, colormap=None,
               vmin=None, vmax=None, interpolate_before_map=True,
               representation='surface', line_width=1., **kwargs):
-        # XXX To do
-        pass
+        raise NotImplementedError("This feature is not available with mayavi.")
 
     def mesh(self, x, y, z, triangles, color, opacity=1.0, shading=False,
              backface_culling=False, scalars=None, colormap=None,

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -175,7 +175,6 @@ class _Renderer(_BaseRenderer):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)
             if MNE_3D_BACKEND_TESTING:
-                self.figure.smooth_shading = False
                 self.tube_n_sides = 3
             with _disabled_depth_peeling():
                 self.plotter = self.figure.build()
@@ -222,7 +221,6 @@ class _Renderer(_BaseRenderer):
               backface_culling=False, scalars=None, colormap=None,
               vmin=None, vmax=None, interpolate_before_map=True,
               representation='surface', line_width=1., **kwargs):
-        smooth_shading = self.figure.smooth_shading
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)
             n_vertices = mesh.n_points
@@ -247,7 +245,7 @@ class _Renderer(_BaseRenderer):
                 rgba=rgba, opacity=opacity, cmap=colormap,
                 backface_culling=backface_culling,
                 rng=[vmin, vmax], show_scalar_bar=False,
-                smooth_shading=smooth_shading,
+                smooth_shading=self.figure.smooth_shading,
                 interpolate_before_map=interpolate_before_map,
                 representation=representation, line_width=line_width, **kwargs,
             )
@@ -381,8 +379,7 @@ class _Renderer(_BaseRenderer):
                     color=color,
                     show_scalar_bar=False,
                     cmap=cmap,
-                    smooth_shading=self.
-                    figure.smooth_shading
+                    smooth_shading=self.figure.smooth_shading,
                 )
         return tube
 

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -218,17 +218,14 @@ class _Renderer(_BaseRenderer):
     def set_interactive(self):
         self.plotter.enable_terrain_style()
 
-    def mesh(self, x, y, z, triangles, color, opacity=1.0, shading=False,
-             backface_culling=False, scalars=None, colormap=None,
-             vmin=None, vmax=None, interpolate_before_map=True,
-             representation='surface', line_width=1., **kwargs):
+    def _mesh(self, mesh, color, opacity=1.0,
+              backface_culling=False, scalars=None, colormap=None,
+              vmin=None, vmax=None, interpolate_before_map=True,
+              representation='surface', line_width=1., **kwargs):
+        smooth_shading = self.figure.smooth_shading
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)
-            smooth_shading = self.figure.smooth_shading
-            vertices = np.c_[x, y, z]
-            n_vertices = len(vertices)
-            triangles = np.c_[np.full(len(triangles), 3), triangles]
-            mesh = PolyData(vertices, triangles)
+            n_vertices = mesh.n_points
             rgba = False
             if color is not None and len(color) == n_vertices:
                 if color.shape[1] == 3:
@@ -237,10 +234,6 @@ class _Renderer(_BaseRenderer):
                     scalars = color
                 scalars = (scalars * 255).astype('ubyte')
                 color = None
-                # Disabling normal computation for smooth shading
-                # is a temporary workaround of:
-                # https://github.com/pyvista/pyvista-support/issues/15
-                smooth_shading = False
                 rgba = True
             if isinstance(colormap, np.ndarray):
                 if colormap.dtype == np.uint8:
@@ -259,6 +252,30 @@ class _Renderer(_BaseRenderer):
                 representation=representation, line_width=line_width, **kwargs,
             )
             return actor, mesh
+
+    def mesh(self, x, y, z, triangles, color, opacity=1.0, shading=False,
+             backface_culling=False, scalars=None, colormap=None,
+             vmin=None, vmax=None, interpolate_before_map=True,
+             representation='surface', line_width=1., **kwargs):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            vertices = np.c_[x, y, z]
+            triangles = np.c_[np.full(len(triangles), 3), triangles]
+            mesh = PolyData(vertices, triangles)
+        return self._mesh(
+            mesh,
+            color,
+            opacity,
+            backface_culling,
+            scalars,
+            colormap,
+            vmin,
+            vmax,
+            interpolate_before_map,
+            representation,
+            line_width,
+            **kwargs,
+        )
 
     def contour(self, surface, scalars, contours, width=1.0, opacity=1.0,
                 vmin=None, vmax=None, colormap=None,

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -249,17 +249,28 @@ class _Renderer(_BaseRenderer):
                 interpolate_before_map=interpolate_before_map,
                 representation=representation, line_width=line_width, **kwargs,
             )
+
+            try:
+                mesh.point_arrays["Normals"]
+            except KeyError:
+                pass
+            else:
+                prop = actor.GetProperty()
+                prop.SetInterpolationToPhong()
             return actor, mesh
 
     def mesh(self, x, y, z, triangles, color, opacity=1.0, shading=False,
              backface_culling=False, scalars=None, colormap=None,
              vmin=None, vmax=None, interpolate_before_map=True,
-             representation='surface', line_width=1., **kwargs):
+             representation='surface', line_width=1., normals=None, **kwargs):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)
             vertices = np.c_[x, y, z]
             triangles = np.c_[np.full(len(triangles), 3), triangles]
             mesh = PolyData(vertices, triangles)
+            if normals is not None:
+                mesh.point_arrays["Normals"] = normals
+                mesh.GetPointData().SetActiveNormals("Normals")
         return self._mesh(
             mesh,
             color,

--- a/mne/viz/backends/base_renderer.py
+++ b/mne/viz/backends/base_renderer.py
@@ -35,7 +35,8 @@ class _BaseRenderer(metaclass=ABCMeta):
     @abstractclassmethod
     def mesh(self, x, y, z, triangles, color, opacity=1.0, shading=False,
              backface_culling=False, scalars=None, colormap=None,
-             vmin=None, vmax=None, interpolate_before_map=True, **kwargs):
+             vmin=None, vmax=None, interpolate_before_map=True,
+             representation='surface', line_width=1., normals=None, **kwargs):
         """Add a mesh in the scene.
 
         Parameters
@@ -72,6 +73,12 @@ class _BaseRenderer(metaclass=ABCMeta):
             Enabling makes for a smoother scalars display. Default is True.
             When False, OpenGL will interpolate the mapped colors which can
             result is showing colors that are not present in the color map.
+        representation: str
+            The representation of the mesh: either 'surface' or 'wireframe'.
+        line_width: int
+            The width of the lines when representation='wireframe'.
+        normals: array, shape (n_vertices, 3)
+            The array containing the normal of each vertex.
         kwargs: args
             The arguments to pass to triangular_mesh
 


### PR DESCRIPTION
This PR follows https://github.com/mne-tools/mne-python/pull/7927#issuecomment-658737474 and uses various solutions to decrease memory consumption:

- [x] Avoid duplication of hemi init meshes by re-using the `vtkPolyData` dataset
- [x] Avoid duplication of hemi data by re-using the scene `vtkPolyData` dataset
- [x] Use kwargs to avoid code duplication between `mesh()` and `_mesh()`
- [x] Reuse `self.geo[hemi].nn` to avoid unnecessary computation

Feel free to comment on this @larsoner