### PR TITLE
MRG, ENH: Add method arg to interpolate_bads

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -57,6 +57,8 @@ Changelog
 
 - Add functionality to interpolate bad NIRS channels by `Robert Luke`_
 
+- Add ability to interpolate EEG channels using minimum-norm projection in :meth:`mne.io.Raw.interpolate_bads` and related functions with ``method=dict(eeg='MNE')`` by `Eric Larson`_
+
 - Added ability of :func:`mne.io.read_raw_nirx` to open data by passing path to header file `Robert Luke`_
 
 - Add :meth:`mne.channels.DigMontage.rename_channels` to allow renaming montage channels by `Eric Larson`_

--- a/examples/preprocessing/plot_interpolate_bad_channels.py
+++ b/examples/preprocessing/plot_interpolate_bad_channels.py
@@ -22,6 +22,8 @@ References
 #
 # License: BSD (3-clause)
 
+# sphinx_gallery_thumbnail_number = 2
+
 import mne
 from mne.datasets import sample
 
@@ -31,13 +33,20 @@ data_path = sample.data_path()
 
 fname = data_path + '/MEG/sample/sample_audvis-ave.fif'
 evoked = mne.read_evokeds(fname, condition='Left Auditory',
-                          baseline=(None, 0))
+                          baseline=(None, 0), proj=False)
 
 # plot with bads
-evoked.plot(exclude=[], time_unit='s')
+evoked.plot(exclude=[])
 
 # compute interpolation (also works with Raw and Epochs objects)
-evoked.interpolate_bads(reset_bads=False, verbose=False)
+evoked_interp = evoked.copy().interpolate_bads(reset_bads=False)
 
 # plot interpolated (previous bads)
-evoked.plot(exclude=[], time_unit='s')
+evoked_interp.comment += '(interpolated)'
+evoked_interp.plot(exclude=[])
+
+# you can also use minimum-norm for EEG as wel as MEG
+evoked_interp_mne = evoked.copy().interpolate_bads(
+    reset_bads=False, method=dict(eeg='MNE'), verbose=True)
+evoked_interp_mne.comment += ' (interpolated: eeg-MNE)'
+evoked_interp_mne.plot(exclude=[])

--- a/examples/preprocessing/plot_interpolate_bad_channels.py
+++ b/examples/preprocessing/plot_interpolate_bad_channels.py
@@ -33,7 +33,7 @@ data_path = sample.data_path()
 
 fname = data_path + '/MEG/sample/sample_audvis-ave.fif'
 evoked = mne.read_evokeds(fname, condition='Left Auditory',
-                          baseline=(None, 0), proj=False)
+                          baseline=(None, 0))
 
 # plot with bads
 evoked.plot(exclude=[])
@@ -45,7 +45,7 @@ evoked_interp = evoked.copy().interpolate_bads(reset_bads=False)
 evoked_interp.comment += '(interpolated)'
 evoked_interp.plot(exclude=[])
 
-# you can also use minimum-norm for EEG as wel as MEG
+# you can also use minimum-norm for EEG as well as MEG
 evoked_interp_mne = evoked.copy().interpolate_bads(
     reset_bads=False, method=dict(eeg='MNE'), verbose=True)
 evoked_interp_mne.comment += ' (interpolated: eeg-MNE)'

--- a/examples/preprocessing/plot_interpolate_bad_channels.py
+++ b/examples/preprocessing/plot_interpolate_bad_channels.py
@@ -5,17 +5,11 @@ Interpolate bad channels for MEG/EEG channels
 
 This example shows how to interpolate bad MEG/EEG channels
 
-    - Using spherical splines as described in [1]_ for EEG data.
-    - Using field interpolation for MEG data.
+- Using spherical splines from :footcite:`PerrinEtAl1989` for EEG data.
+- Using field interpolation for MEG and EEG data.
 
-The bad channels will still be marked as bad. Only the data in those channels
-is removed.
-
-References
-----------
-.. [1] Perrin, F., Pernier, J., Bertrand, O. and Echallier, JF. (1989)
-       Spherical splines for scalp potential and current density mapping.
-       Electroencephalography and Clinical Neurophysiology, Feb; 72(2):184-7.
+In this example, the bad channels will still be marked as bad.
+Only the data in those channels is replaced.
 """
 # Authors: Denis A. Engemann <denis.engemann@gmail.com>
 #          Mainak Jas <mainak.jas@telecom-paristech.fr>
@@ -36,17 +30,20 @@ evoked = mne.read_evokeds(fname, condition='Left Auditory',
                           baseline=(None, 0))
 
 # plot with bads
-evoked.plot(exclude=[])
+evoked.plot(exclude=[], picks=('grad', 'eeg'))
 
-# compute interpolation (also works with Raw and Epochs objects)
+###############################################################################
+# Compute interpolation (also works with Raw and Epochs objects)
 evoked_interp = evoked.copy().interpolate_bads(reset_bads=False)
+evoked_interp.plot(exclude=[], picks=('grad', 'eeg'))
 
-# plot interpolated (previous bads)
-evoked_interp.comment += '(interpolated)'
-evoked_interp.plot(exclude=[])
-
-# you can also use minimum-norm for EEG as well as MEG
+###############################################################################
+# You can also use minimum-norm for EEG as well as MEG
 evoked_interp_mne = evoked.copy().interpolate_bads(
     reset_bads=False, method=dict(eeg='MNE'), verbose=True)
-evoked_interp_mne.comment += ' (interpolated: eeg-MNE)'
-evoked_interp_mne.plot(exclude=[])
+evoked_interp_mne.plot(exclude=[], picks=('grad', 'eeg'))
+
+###############################################################################
+# References
+# ----------
+# .. footbibliography::

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -14,7 +14,7 @@ import sys
 import numpy as np
 from scipy import sparse
 
-from ..defaults import HEAD_SIZE_DEFAULT
+from ..defaults import HEAD_SIZE_DEFAULT, _handle_default
 from ..utils import (verbose, logger, warn, _check_preload, _validate_type,
                      fill_doc, _check_option)
 from ..io.compensator import get_current_comp
@@ -1025,7 +1025,7 @@ class InterpolationMixin(object):
 
     @verbose
     def interpolate_bads(self, reset_bads=True, mode='accurate',
-                         origin='auto', verbose=None):
+                         origin='auto', method=None, verbose=None):
         """Interpolate bad MEG and EEG channels.
 
         Operates in place.
@@ -1036,14 +1036,30 @@ class InterpolationMixin(object):
             If True, remove the bads from info.
         mode : str
             Either ``'accurate'`` or ``'fast'``, determines the quality of the
-            Legendre polynomial expansion used for interpolation of MEG
-            channels.
+            Legendre polynomial expansion used for interpolation of channels
+            using the minimum-norm method.
         origin : array-like, shape (3,) | str
             Origin of the sphere in the head coordinate frame and in meters.
             Can be ``'auto'`` (default), which means a head-digitization-based
             origin fit.
 
             .. versionadded:: 0.17
+        method : dict
+            Method to use for each channel type.
+            Currently only the key "eeg" has multiple options:
+
+            - ``"spline"`` (default)
+                Use spherical spline interpolation.
+            - ``"MNE"``
+                Use minimum-norm projection to a sphere and back.
+                This is the method used for MEG channels.
+
+            The value for "meg" is "MNE", and the value for
+            "fnirs" is "nearest". The default (None) is thus an alias for::
+
+                method=dict(meg="MNE", eeg="spline", fnirs="nearest")
+
+            .. versionadded:: 0.21
         %(verbose_meth)s
 
         Returns
@@ -1057,16 +1073,27 @@ class InterpolationMixin(object):
         """
         from ..bem import _check_origin
         from .interpolation import _interpolate_bads_eeg,\
-            _interpolate_bads_meg, _interpolate_bads_nirs
+            _interpolate_bads_meeg, _interpolate_bads_nirs
 
         _check_preload(self, "interpolation")
+        method = _handle_default('interpolation_method', method)
+        for key in method:
+            _check_option('method[key]', key, ('meg', 'eeg', 'fnirs'))
+        _check_option("method['eeg']", method['eeg'], ('spline', 'MNE'))
+        _check_option("method['meg']", method['meg'], ('MNE',))
+        _check_option("method['fnirs']", method['fnirs'], ('nearest',))
 
         if len(self.info['bads']) == 0:
             warn('No bad channels to interpolate. Doing nothing...')
             return self
+        logger.info('Interpolating bad channels')
         origin = _check_origin(origin, self.info)
-        _interpolate_bads_eeg(self, origin=origin)
-        _interpolate_bads_meg(self, mode=mode, origin=origin)
+        if method['eeg'] == 'spline':
+            _interpolate_bads_eeg(self, origin=origin)
+            eeg_mne = False
+        else:
+            eeg_mne = True
+        _interpolate_bads_meeg(self, mode=mode, origin=origin, eeg=eeg_mne)
         _interpolate_bads_nirs(self)
 
         if reset_bads is True:

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -6,12 +6,12 @@ import numpy as np
 from numpy.polynomial.legendre import legval
 from scipy import linalg
 
-from ..fixes import einsum
 from ..utils import logger, warn, verbose
+from ..io.meas_info import _simplify_info
 from ..io.pick import pick_types, pick_channels, pick_info
 from ..surface import _normalize_vectors
-from ..forward import _map_meg_channels
-from ..utils import _check_option
+from ..forward import _map_meg_or_eeg_channels
+from ..utils import _check_option, _validate_type
 
 
 def _calc_h(cosang, stiffness=4, n_legendre_terms=50):
@@ -85,6 +85,8 @@ def _make_interpolation_matrix(pos_from, pos_to, alpha=1e-5):
     """
     pos_from = pos_from.copy()
     pos_to = pos_to.copy()
+    n_from = pos_from.shape[0]
+    n_to = pos_to.shape[0]
 
     # normalize sensor positions to sphere
     _normalize_vectors(pos_from)
@@ -95,17 +97,18 @@ def _make_interpolation_matrix(pos_from, pos_to, alpha=1e-5):
     cosang_to_from = pos_to.dot(pos_from.T)
     G_from = _calc_g(cosang_from)
     G_to_from = _calc_g(cosang_to_from)
+    assert G_from.shape == (n_from, n_from)
+    assert G_to_from.shape == (n_to, n_from)
 
     if alpha is not None:
         G_from.flat[::len(G_from) + 1] += alpha
 
-    n_channels = G_from.shape[0]  # G_from should be square matrix
-    C = np.r_[np.c_[G_from, np.ones((n_channels, 1))],
-              np.c_[np.ones((1, n_channels)), 0]]
+    C = np.vstack([np.hstack([G_from, np.ones((n_from, 1))]),
+                   np.hstack([np.ones((1, n_from)), [[0]]])])
     C_inv = linalg.pinv(C)
 
-    interpolation = np.c_[G_to_from,
-                          np.ones((G_to_from.shape[0], 1))].dot(C_inv[:, :-1])
+    interpolation = np.hstack([G_to_from, np.ones((n_to, 1))]) @ C_inv[:, :-1]
+    assert interpolation.shape == (n_to, n_from)
     return interpolation
 
 
@@ -114,15 +117,9 @@ def _do_interp_dots(inst, interpolation, goods_idx, bads_idx):
     from ..io.base import BaseRaw
     from ..epochs import BaseEpochs
     from ..evoked import Evoked
-
-    if isinstance(inst, (BaseRaw, Evoked)):
-        inst._data[bads_idx] = interpolation.dot(inst._data[goods_idx])
-    elif isinstance(inst, BaseEpochs):
-        inst._data[:, bads_idx, :] = einsum(
-            'ij,xjy->xiy', interpolation, inst._data[:, goods_idx, :])
-    else:
-        raise ValueError('Inputs of type {} are not supported'
-                         .format(type(inst)))
+    _validate_type(inst, (BaseRaw, BaseEpochs, Evoked), 'inst')
+    inst._data[..., bads_idx, :] = np.matmul(
+        interpolation, inst._data[..., goods_idx, :])
 
 
 @verbose
@@ -172,9 +169,15 @@ def _interpolate_bads_eeg(inst, origin, verbose=None):
     _do_interp_dots(inst, interpolation, goods_idx, bads_idx)
 
 
-@verbose
 def _interpolate_bads_meg(inst, mode='accurate', origin=(0., 0., 0.04),
                           verbose=None, ref_meg=False):
+    return _interpolate_bads_meeg(
+        inst, mode, origin, ref_meg=ref_meg, eeg=False, verbose=verbose)
+
+
+@verbose
+def _interpolate_bads_meeg(inst, mode='accurate', origin=(0., 0., 0.04),
+                           meg=True, eeg=True, ref_meg=False, verbose=None):
     """Interpolate bad channels from data in good channels.
 
     Parameters
@@ -192,28 +195,39 @@ def _interpolate_bads_meg(inst, mode='accurate', origin=(0., 0., 0.04),
     %(verbose)s
     ref_meg : bool
         Should always be False; only exists for testing purpose.
+    meg : bool
+        If True, interpolate bad MEG channels.
+    eeg : bool
+        If True, interpolate bad EEG channels.
     """
-    picks_meg = pick_types(inst.info, meg=True, eeg=False,
-                           ref_meg=ref_meg, exclude=[])
-    picks_good = pick_types(inst.info, meg=True, eeg=False,
-                            ref_meg=ref_meg, exclude='bads')
-    meg_ch_names = [inst.info['ch_names'][p] for p in picks_meg]
-    bads_meg = [ch for ch in inst.info['bads'] if ch in meg_ch_names]
-
-    # select the bad meg channel to be interpolated
-    if len(bads_meg) == 0:
-        picks_bad = []
-    else:
-        picks_bad = pick_channels(inst.info['ch_names'], bads_meg,
+    bools = dict(meg=meg, eeg=eeg)
+    info = _simplify_info(inst.info)
+    for ch_type, do in bools.items():
+        if not do:
+            continue
+        kw = dict(meg=False, eeg=False)
+        kw[ch_type] = True
+        picks_type = pick_types(info, ref_meg=ref_meg, exclude=[], **kw)
+        picks_good = pick_types(info, ref_meg=ref_meg, exclude='bads', **kw)
+        use_ch_names = [inst.info['ch_names'][p] for p in picks_type]
+        bads_type = [ch for ch in inst.info['bads'] if ch in use_ch_names]
+        if len(bads_type) == 0 or len(picks_type) == 0:
+            continue
+        # select the bad channels to be interpolated
+        picks_bad = pick_channels(inst.info['ch_names'], bads_type,
                                   exclude=[])
-
-    # return without doing anything if there are no meg channels
-    if len(picks_meg) == 0 or len(picks_bad) == 0:
-        return
-    info_from = pick_info(inst.info, picks_good)
-    info_to = pick_info(inst.info, picks_bad)
-    mapping = _map_meg_channels(info_from, info_to, mode=mode, origin=origin)
-    _do_interp_dots(inst, mapping, picks_good, picks_bad)
+        if ch_type == 'eeg':
+            picks_to = picks_type
+            bad_sel = np.in1d(picks_type, picks_bad)
+        else:
+            picks_to = picks_bad
+            bad_sel = slice(None)
+        info_from = pick_info(inst.info, picks_good)
+        info_to = pick_info(inst.info, picks_to)
+        mapping = _map_meg_or_eeg_channels(
+            info_from, info_to, mode=mode, origin=origin)
+        mapping = mapping[bad_sel]
+        _do_interp_dots(inst, mapping, picks_good, picks_bad)
 
 
 @verbose

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -1,7 +1,7 @@
 import os.path as op
 
 import numpy as np
-from numpy.testing import (assert_allclose, assert_array_equal)
+from numpy.testing import assert_allclose, assert_array_equal
 import pytest
 from itertools import compress
 
@@ -12,6 +12,7 @@ from mne.utils import run_tests_if_main
 from mne.preprocessing.nirs import optical_density, scalp_coupling_index
 from mne.datasets.testing import data_path
 from mne.io import read_raw_nirx
+from mne.io.proj import _has_eeg_average_ref_proj
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
@@ -44,12 +45,20 @@ def _load_data(kind):
 
 
 @pytest.mark.parametrize('offset', (0., 0.1))
+@pytest.mark.parametrize('avg_proj, ctol', [
+    (True, (0.88, 0.93)),
+    (False, (0.98, 0.99)),
+])
+@pytest.mark.parametrize('method, atol', [
+    (None, 3e-6),
+    (dict(eeg='MNE'), 4e-6),
+])
 @pytest.mark.filterwarnings('ignore:.*than 20 mm from head frame origin.*')
-@pytest.mark.slowtest
-def test_interpolation_eeg(offset):
+def test_interpolation_eeg(offset, avg_proj, ctol, atol, method):
     """Test interpolation of EEG channels."""
     raw, epochs_eeg = _load_data('eeg')
     epochs_eeg = epochs_eeg.copy()
+    assert not _has_eeg_average_ref_proj(epochs_eeg.info['projs'])
     # Offsetting the coordinate frame should have no effect on the output
     for inst in (raw, epochs_eeg):
         for ch in inst.info['chs']:
@@ -62,47 +71,62 @@ def test_interpolation_eeg(offset):
     # check that interpolation does nothing if no bads are marked
     epochs_eeg.info['bads'] = []
     evoked_eeg = epochs_eeg.average()
+    kw = dict(method=method)
     with pytest.warns(RuntimeWarning, match='Doing nothing'):
-        evoked_eeg.interpolate_bads()
+        evoked_eeg.interpolate_bads(**kw)
 
     # create good and bad channels for EEG
     epochs_eeg.info['bads'] = []
     goods_idx = np.ones(len(epochs_eeg.ch_names), dtype=bool)
     goods_idx[epochs_eeg.ch_names.index('EEG 012')] = False
     bads_idx = ~goods_idx
+    pos = epochs_eeg._get_channel_positions()
 
     evoked_eeg = epochs_eeg.average()
+    if avg_proj:
+        evoked_eeg.set_eeg_reference(projection=True).apply_proj()
+        assert_allclose(evoked_eeg.data.mean(0), 0., atol=1e-20)
     ave_before = evoked_eeg.data[bads_idx]
 
     # interpolate bad channels for EEG
-    pos = epochs_eeg._get_channel_positions()
-    pos_good = pos[goods_idx]
-    pos_bad = pos[bads_idx]
-    interpolation = _make_interpolation_matrix(pos_good, pos_bad)
-    assert interpolation.shape == (1, len(epochs_eeg.ch_names) - 1)
-    interp_manual = np.dot(interpolation, evoked_eeg.data[goods_idx])
-
     epochs_eeg.info['bads'] = ['EEG 012']
     evoked_eeg = epochs_eeg.average()
-    interp_zero = evoked_eeg.interpolate_bads(
-        origin=(0., 0., 0.)).data[bads_idx]
-    assert_array_equal(interp_manual, interp_zero)
-    assert_allclose(ave_before, interp_zero, atol=3e-6)
-    assert 0.985 < np.corrcoef(ave_before, interp_zero)[0, 1] < 0.99
-    evoked_eeg.info['bads'] = ['EEG 012']
-    interp_fit = evoked_eeg.interpolate_bads().data[bads_idx]
+    if avg_proj:
+        evoked_eeg.set_eeg_reference(projection=True).apply_proj()
+        good_picks = pick_types(evoked_eeg.info, meg=False, eeg=True)
+        assert_allclose(evoked_eeg.data[good_picks].mean(0), 0., atol=1e-20)
+    evoked_eeg_bad = evoked_eeg.copy()
+    evoked_eeg_bad.data[
+        evoked_eeg.ch_names.index(epochs_eeg.info['bads'][0])] = 1e10
+    evoked_eeg_interp = evoked_eeg_bad.copy().interpolate_bads(
+        origin=(0., 0., 0.), **kw)
+    if avg_proj:
+        assert_allclose(evoked_eeg_interp.data.mean(0), 0., atol=1e-6)
+    interp_zero = evoked_eeg_interp.data[bads_idx]
+    if method is None:  # using
+        pos_good = pos[goods_idx]
+        pos_bad = pos[bads_idx]
+        interpolation = _make_interpolation_matrix(pos_good, pos_bad)
+        assert interpolation.shape == (1, len(epochs_eeg.ch_names) - 1)
+        interp_manual = np.dot(interpolation, evoked_eeg_bad.data[goods_idx])
+        assert_array_equal(interp_manual, interp_zero)
+        del interp_manual, interpolation, pos, pos_good, pos_bad
+    assert_allclose(ave_before, interp_zero, atol=atol)
+    assert ctol[0] < np.corrcoef(ave_before, interp_zero)[0, 1] < ctol[1]
+    interp_fit = evoked_eeg_bad.copy().interpolate_bads(**kw).data[bads_idx]
     assert_allclose(ave_before, interp_fit, atol=2e-6)
-    assert 0.99 < np.corrcoef(ave_before, interp_fit)[0, 1]  # better
+    assert ctol[1] < np.corrcoef(ave_before, interp_fit)[0, 1]  # better
 
     # check that interpolation fails when preload is False
     epochs_eeg.preload = False
-    pytest.raises(RuntimeError, epochs_eeg.interpolate_bads)
+    with pytest.raises(RuntimeError, match='requires epochs data to be loade'):
+        epochs_eeg.interpolate_bads(**kw)
     epochs_eeg.preload = True
 
     # check that interpolation changes the data in raw
     raw_eeg = io.RawArray(data=epochs_eeg._data[0], info=epochs_eeg.info)
     raw_before = raw_eeg._data[bads_idx]
-    raw_after = raw_eeg.interpolate_bads()._data[bads_idx]
+    raw_after = raw_eeg.interpolate_bads(**kw)._data[bads_idx]
     assert not np.all(raw_before == raw_after)
 
     # check that interpolation fails when preload is False
@@ -110,7 +134,8 @@ def test_interpolation_eeg(offset):
         assert hasattr(inst, 'preload')
         inst.preload = False
         inst.info['bads'] = [inst.ch_names[1]]
-        pytest.raises(RuntimeError, inst.interpolate_bads)
+        with pytest.raises(RuntimeError, match='requires.*data to be loaded'):
+            inst.interpolate_bads(**kw)
 
     # check that interpolation works with few channels
     raw_few = raw.copy().crop(0, 0.1).load_data()
@@ -120,7 +145,7 @@ def test_interpolation_eeg(offset):
     raw_few.info['bads'] = [raw_few.ch_names[-1]]
     orig_data = raw_few[1][0]
     with pytest.warns(None) as w:
-        raw_few.interpolate_bads(reset_bads=False)
+        raw_few.interpolate_bads(reset_bads=False, **kw)
     assert len([ww for ww in w if 'more than' not in str(ww.message)]) == 0
     new_data = raw_few[1][0]
     assert (new_data == 0).mean() < 0.5

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -46,8 +46,8 @@ def _load_data(kind):
 
 @pytest.mark.parametrize('offset', (0., 0.1))
 @pytest.mark.parametrize('avg_proj, ctol', [
-    (True, (0.88, 0.93)),
-    (False, (0.98, 0.99)),
+    (True, (0.86, 0.93)),
+    (False, (0.97, 0.99)),
 ])
 @pytest.mark.parametrize('method, atol', [
     (None, 3e-6),
@@ -114,7 +114,7 @@ def test_interpolation_eeg(offset, avg_proj, ctol, atol, method):
     assert_allclose(ave_before, interp_zero, atol=atol)
     assert ctol[0] < np.corrcoef(ave_before, interp_zero)[0, 1] < ctol[1]
     interp_fit = evoked_eeg_bad.copy().interpolate_bads(**kw).data[bads_idx]
-    assert_allclose(ave_before, interp_fit, atol=2e-6)
+    assert_allclose(ave_before, interp_fit, atol=2.5e-6)
     assert ctol[1] < np.corrcoef(ave_before, interp_fit)[0, 1]  # better
 
     # check that interpolation fails when preload is False

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -81,6 +81,7 @@ DEFAULTS = dict(
                    combine_xyz='spectral', allow_fixed_depth=False),
     depth_sparse=dict(exp=0.8, limit=None, limit_depth_chs='whiten',
                       combine_xyz='fro', allow_fixed_depth=True),
+    interpolation_method=dict(eeg='spline', meg='MNE', fnirs='nearest'),
 )
 
 

--- a/mne/forward/__init__.py
+++ b/mne/forward/__init__.py
@@ -18,5 +18,5 @@ from ._make_forward import (make_forward_solution, _prepare_for_forward,
 from ._compute_forward import (_magnetic_dipole_field_vec, _compute_forwards,
                                _concatenate_coils)
 from ._field_interpolation import (_make_surface_mapping, make_field_map,
-                                   _as_meg_type_inst, _map_meg_channels)
+                                   _as_meg_type_inst, _map_meg_or_eeg_channels)
 from . import _lead_dots  # for testing purposes

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 import numpy as np
 from scipy import linalg
 
-from ..io.constants import FWD
+from ..io.constants import FWD, FIFF
 from ..bem import _check_origin
 from ..io.pick import pick_types, pick_info
 from ..surface import get_head_surf, get_meg_helmet_surf
@@ -23,7 +23,7 @@ from ._make_forward import _create_meg_coils, _create_eeg_els, _read_coil_defs
 from ._lead_dots import (_do_self_dots, _do_surface_dots, _get_legen_table,
                          _do_cross_dots)
 from ..parallel import check_n_jobs
-from ..utils import logger, verbose, _check_option
+from ..utils import logger, verbose, _check_option, _reg_pinv
 from ..epochs import EpochsArray, BaseEpochs
 from ..evoked import Evoked, EvokedArray
 
@@ -78,41 +78,49 @@ def _compute_mapping_matrix(fmd, info):
 
     # SVD is numerically better than the eigenvalue composition even if
     # mat is supposed to be symmetric and positive definite
-    uu, sing, vv = linalg.svd(whitened_dots, full_matrices=False,
-                              overwrite_a=True)
-
-    # Eigenvalue truncation
-    sumk = np.cumsum(sing)
-    sumk /= sumk[-1]
-    fmd['nest'] = np.where(sumk > (1.0 - fmd['miss']))[0][0] + 1
-    logger.info('    Truncating at %d/%d components to omit less than %g '
-                '(%0.2g)' % (fmd['nest'], len(sing), fmd['miss'],
-                             1. - sumk[fmd['nest'] - 1]))
-    sing = 1.0 / sing[:fmd['nest']]
-
-    # Put the inverse together
-    inv = np.dot(uu[:, :fmd['nest']] * sing, vv[:fmd['nest']]).T
+    if fmd.get('pinv_method', 'tsvd') == 'tsvd':
+        inv, fmd['nest'] = _pinv_trunc(whitened_dots, fmd['miss'])
+    else:
+        assert fmd['pinv_method'] == 'tikhonov'
+        inv, _, fmd['nest'] = _reg_pinv(
+            whitened_dots, reg=fmd['miss'], rank=None, rcond=1e-6)
 
     # Sandwich with the whitener
     inv_whitened = np.dot(whitener.T, np.dot(inv, whitener))
 
     # Take into account that the lead fields used to compute
     # d->surface_dots were unprojected
-    inv_whitened_proj = (np.dot(inv_whitened.T, proj_op)).T
+    inv_whitened_proj = proj_op.T @ inv_whitened
 
     # Finally sandwich in the selection matrix
     # This one picks up the correct lead field projection
     mapping_mat = np.dot(fmd['surface_dots'], inv_whitened_proj)
 
     # Optionally apply the average electrode reference to the final field map
-    if fmd['kind'] == 'eeg':
-        if _has_eeg_average_ref_proj(projs):
-            logger.info('    The map will have average electrode reference')
-            mapping_mat -= np.mean(mapping_mat, axis=0)[np.newaxis, :]
+    if fmd['kind'] == 'eeg' and _has_eeg_average_ref_proj(projs):
+        logger.info(
+            '    The map has an average electrode reference '
+            f'({mapping_mat.shape[0]} channels)')
+        mapping_mat -= np.mean(mapping_mat, axis=0)
     return mapping_mat
 
 
-def _map_meg_channels(info_from, info_to, mode='fast', origin=(0., 0., 0.04)):
+def _pinv_trunc(x, miss):
+    """Compute pseudoinverse, truncating at most "miss" fraction of varexp."""
+    u, s, v = linalg.svd(x, full_matrices=False)
+
+    # Eigenvalue truncation
+    varexp = np.cumsum(s)
+    varexp /= varexp[-1]
+    n = np.where(varexp >= (1.0 - miss))[0][0] + 1
+    logger.info('    Truncating at %d/%d components to omit less than %g '
+                '(%0.2g)' % (n, len(s), miss, 1. - varexp[n - 1]))
+    s = 1. / s[:n]
+    inv = ((u[:, :n] * s) @ v[:n]).T
+    return inv, n
+
+
+def _map_meg_or_eeg_channels(info_from, info_to, mode, origin):
     """Find mapping from one set of channels to another.
 
     Parameters
@@ -132,35 +140,62 @@ def _map_meg_channels(info_from, info_to, mode='fast', origin=(0., 0., 0.04)):
 
     Returns
     -------
-    mapping : array
-        A mapping matrix of shape len(pick_to) x len(pick_from).
+    mapping : array, shape (n_to, n_from)
+        A mapping matrix.
     """
     # no need to apply trans because both from and to coils are in device
     # coordinates
-    templates = _read_coil_defs(verbose=False)
-    coils_from = _create_meg_coils(info_from['chs'], 'normal',
-                                   info_from['dev_head_t'], templates)
-    coils_to = _create_meg_coils(info_to['chs'], 'normal',
-                                 info_to['dev_head_t'], templates)
-    miss = 1e-4  # Smoothing criterion for MEG
+    info_kinds = set(ch['kind'] for ch in info_to['chs'])
+    info_kinds |= set(ch['kind'] for ch in info_from['chs'])
+    if FIFF.FIFFV_REF_MEG_CH in info_kinds:  # refs same as MEG
+        info_kinds |= set([FIFF.FIFFV_MEG_CH])
+        info_kinds -= set([FIFF.FIFFV_REF_MEG_CH])
+    info_kinds = sorted(info_kinds)
+    # This should be guaranteed by the callers
+    assert (len(info_kinds) == 1 and info_kinds[0] in (
+            FIFF.FIFFV_MEG_CH, FIFF.FIFFV_EEG_CH))
+    kind = 'eeg' if info_kinds[0] == FIFF.FIFFV_EEG_CH else 'meg'
+
+    #
+    # Step 1. Prepare the coil definitions
+    #
+    if kind == 'meg':
+        templates = _read_coil_defs(verbose=False)
+        coils_from = _create_meg_coils(info_from['chs'], 'normal',
+                                       info_from['dev_head_t'], templates)
+        coils_to = _create_meg_coils(info_to['chs'], 'normal',
+                                     info_to['dev_head_t'], templates)
+        miss = 1e-4
+        pinv_method = 'tsvd'
+    else:
+        coils_from = _create_eeg_els(info_from['chs'])
+        coils_to = _create_eeg_els(info_to['chs'])
+        miss = 1e-2
+        pinv_method = 'tikhonov'
+        if _has_eeg_average_ref_proj(info_from['projs']) and \
+                not _has_eeg_average_ref_proj(info_to['projs']):
+            raise RuntimeError(
+                'info_to must have an average EEG reference projector if '
+                'info_from has one')
     origin = _check_origin(origin, info_from)
     #
     # Step 2. Calculate the dot products
     #
-    int_rad, noise, lut_fun, n_fact = _setup_dots(mode, coils_from, 'meg')
-    logger.info('    Computing dot products for %i coils...'
-                % (len(coils_from)))
-    self_dots = _do_self_dots(int_rad, False, coils_from, origin, 'meg',
+    int_rad, noise, lut_fun, n_fact = _setup_dots(mode, coils_from, kind)
+    logger.info(f'    Computing dot products for {len(coils_from)} '
+                f'{kind.upper()} channels...')
+    self_dots = _do_self_dots(int_rad, False, coils_from, origin, kind,
                               lut_fun, n_fact, n_jobs=1)
-    logger.info('    Computing cross products for coils %i x %i coils...'
-                % (len(coils_from), len(coils_to)))
+    logger.info(f'    Computing cross products for {len(coils_from)} → '
+                f'{len(coils_to)} {kind.upper()} channels...')
     cross_dots = _do_cross_dots(int_rad, False, coils_from, coils_to,
-                                origin, 'meg', lut_fun, n_fact).T
+                                origin, kind, lut_fun, n_fact).T
 
     ch_names = [c['ch_name'] for c in info_from['chs']]
-    fmd = dict(kind='meg', ch_names=ch_names,
+    fmd = dict(kind=kind, ch_names=ch_names,
                origin=origin, noise=noise, self_dots=self_dots,
-               surface_dots=cross_dots, int_rad=int_rad, miss=miss)
+               surface_dots=cross_dots, int_rad=int_rad, miss=miss,
+               pinv_method=pinv_method)
 
     #
     # Step 3. Compute the mapping matrix
@@ -205,7 +240,9 @@ def _as_meg_type_inst(inst, ch_type='grad', mode='fast'):
 
     info_from = pick_info(inst.info, pick_from)
     info_to = pick_info(inst.info, pick_to)
-    mapping = _map_meg_channels(info_from, info_to, mode=mode)
+    # XXX someday we should probably expose the origin
+    mapping = _map_meg_or_eeg_channels(
+        info_from, info_to, origin=(0., 0., 0.04), mode=mode)
 
     # compute data by multiplying by the 'gain matrix' from
     # original sensors to virtual sensors

--- a/mne/forward/_lead_dots.py
+++ b/mne/forward/_lead_dots.py
@@ -316,7 +316,7 @@ def _do_self_dots(intrad, volume, coils, r0, ch_type, lut, n_fact, n_jobs):
         The integration products.
     """
     if ch_type == 'eeg':
-        intrad *= 0.7
+        intrad = intrad * 0.7
     # convert to normalized distances from expansion center
     rmags = [coil['rmag'] - r0[np.newaxis, :] for coil in coils]
     rlens = [np.sqrt(np.sum(r * r, axis=1)) for r in rmags]
@@ -379,6 +379,8 @@ def _do_cross_dots(intrad, volume, coils1, coils2, r0, ch_type,
     products : array, shape (n_coils, n_coils)
         The integration products.
     """
+    if ch_type == 'eeg':
+        intrad = intrad * 0.7
     rmags1 = [coil['rmag'] - r0[np.newaxis, :] for coil in coils1]
     rmags2 = [coil['rmag'] - r0[np.newaxis, :] for coil in coils2]
 
@@ -446,7 +448,7 @@ def _do_surface_dots(intrad, volume, coils, surf, sel, r0, ch_type,
     refl = None
     # virt_ref = False
     if ch_type == 'eeg':
-        intrad *= 0.7
+        intrad = intrad * 0.7
         # The virtual ref code is untested and unused, so it is
         # commented out for now
         # if virt_ref:

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2575,7 +2575,7 @@ def plot_arrowmap(data, info_from, info_to=None, scale=3e-10, vmin=None,
        DOI: 10.1016/S0022-0736(76)80041-6
     """
     from matplotlib import pyplot as plt
-    from ..forward import _map_meg_channels
+    from ..forward import _map_meg_or_eeg_channels
 
     sphere = _check_sphere(sphere, info_from)
     ch_type = _picks_by_type(info_from)
@@ -2605,7 +2605,11 @@ def plot_arrowmap(data, info_from, info_to=None, scale=3e-10, vmin=None,
                              "Got %s" % ch_type)
 
     if info_to is not info_from:
-        mapping = _map_meg_channels(info_from, info_to, mode='accurate')
+        info_to = pick_info(info_to, pick_types(info_to, meg=True))
+        info_from = pick_info(info_from, pick_types(info_from, meg=True))
+        # XXX should probably support the "origin" argument
+        mapping = _map_meg_or_eeg_channels(
+            info_from, info_to, origin=(0., 0., 0.04), mode='accurate')
         data = np.dot(mapping, data)
 
     _, pos, _, _, _, sphere, clip_origin = \


### PR DESCRIPTION
A first necessary step toward #3184 is to make it so that we can use minimum-norm mapping to go from EEG->EEG just like we do for MEG->MEG. To do this, I needed to refactor the minimum-norm mapping functions a bit, and now it's (just about) as easy to map EEG as it is MEG. This made me realize that we could easily provide MNE-based EEG channel reconstruction.

Related issues:

1. `fnirs` someday will hopefully support reconstruction schemes other than `method='nearest'` (currently the only one)
2. It's probably easy to add faster multipole-moment based interpolation for MEG [as well as EEG nowadays](https://www.researchgate.net/publication/342933701_Unified_expression_of_the_quasi-static_electromagnetic_field_Demonstration_with_MEG_and_EEG_signals)

Hence I added the API parameter `interpolate_bads(..., method=dict(eeg='spline')` (default equiv) or to use MNE you do `method=dict(eeg='MNE')`. Eventually we could for example do `interpolate_bads(..., method=dict(meg='sss', eeg='sss'))` if we implement the multipole-moment based reconstructions.