### PR TITLE
DOC: Rework "anonymization" docstrings

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -15,8 +15,8 @@ import numpy as np
 from scipy import sparse
 
 from ..defaults import HEAD_SIZE_DEFAULT
-from ..utils import (verbose, logger, warn, copy_function_doc_to_method_doc,
-                     _check_preload, _validate_type, fill_doc, _check_option)
+from ..utils import (verbose, logger, warn, _check_preload, _validate_type,
+                     fill_doc, _check_option)
 from ..io.compensator import get_current_comp
 from ..io.constants import FIFF
 from ..io.meas_info import anonymize_info, Info, MontageMixin

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -567,9 +567,24 @@ class SetChannelsMixin(MontageMixin):
                             to_sphere=to_sphere, axes=axes, block=block,
                             show=show, sphere=sphere, verbose=verbose)
 
-    @copy_function_doc_to_method_doc(anonymize_info)
+    @verbose
     def anonymize(self, daysback=None, keep_his=False, verbose=None):
-        """
+        """Anonymize measurement information in place.
+
+        Parameters
+        ----------
+        %(anonymize_info_parameters)s
+        %(verbose)s
+
+        Returns
+        -------
+        inst : instance of Raw | Epochs | Evoked
+            The modified instance.
+
+        Notes
+        -----
+        %(anonymize_info_notes)s
+
         .. versionadded:: 0.13.0
         """
         anonymize_info(self.info, daysback=daysback, keep_his=keep_his,

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -2110,48 +2110,17 @@ def anonymize_info(info, daysback=None, keep_his=False, verbose=None):
     ----------
     info : dict, instance of Info
         Measurement information for the dataset.
-    daysback : int | None
-        Number of days to subtract from all dates.
-        If None (default) the date of service will be set to Jan 1ˢᵗ 2000.
-        This parameter is ignored if ``info['meas_date'] is None``.
-    keep_his : bool
-        If True his_id of subject_info will NOT be overwritten.
-        Defaults to False.
-
-        .. warning:: This could mean that ``info`` is not fully
-                     anonymized. Use with caution.
+    %(anonymize_info_parameters)s
     %(verbose)s
 
     Returns
     -------
     info : instance of Info
-        Measurement information for the dataset.
+        The anonymized measurement information.
 
     Notes
     -----
-    Removes potentially identifying information if it exist in ``info``.
-    Specifically for each of the following we use:
-
-    - meas_date, file_id, meas_id
-          A default value, or as specified by ``daysback``.
-    - subject_info
-          Default values, except for 'birthday' which is adjusted
-          to maintain the subject age.
-    - experimenter, proj_name, description
-          Default strings.
-    - utc_offset
-          ``None``.
-    - proj_id
-          Zeros.
-    - proc_history
-          Dates use the meas_date logic, and experimenter a default string.
-    - helium_info, device_info
-          Dates use the meas_date logic, meta info uses defaults.
-
-    If ``info['meas_date']`` is None, it will remain None during processing
-    the above fields.
-
-    Operates in place.
+    %(anonymize_info_notes)s
     """
     _validate_type(info, 'info', "self")
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1318,6 +1318,46 @@ average : bool, default True
     .. versionadded:: 0.13.0
 """
 
+# Anonymization
+docdict['anonymize_info_parameters'] = """
+daysback : int | None
+    Number of days to subtract from all dates.
+    If ``None`` (default), the acquisition date, ``info['meas_date']``,
+    will be set to ``January 1ˢᵗ, 2000``. This parameter is ignored if
+    ``info['meas_date']`` is ``None`` (i.e., no acquisition date has been set).
+keep_his : bool
+    If ``True``, ``his_id`` of ``subject_info`` will **not** be overwritten.
+    Defaults to ``False``.
+
+    .. warning:: This could mean that ``info`` is not fully
+                 anonymized. Use with caution.
+"""
+docdict['anonymize_info_notes'] = """
+Removes potentially identifying information if it exists in ``info``.
+Specifically for each of the following we use:
+
+- meas_date, file_id, meas_id
+        A default value, or as specified by ``daysback``.
+- subject_info
+        Default values, except for 'birthday' which is adjusted
+        to maintain the subject age.
+- experimenter, proj_name, description
+        Default strings.
+- utc_offset
+        ``None``.
+- proj_id
+        Zeros.
+- proc_history
+        Dates use the ``meas_date`` logic, and experimenter a default string.
+- helium_info, device_info
+        Dates use the ``meas_date`` logic, meta info uses defaults.
+
+If ``info['meas_date']`` is ``None``, it will remain ``None`` during processing
+the above fields.
+
+Operates in place.
+"""
+
 # Finalize
 docdict = unindent_dict(docdict)
 fill_doc = filldoc(docdict, unindent_params=False)


### PR DESCRIPTION
#### Reference issue
Closes GH-7813.


#### What does this implement/fix?
Make use of the docdict and replace "date of service" with "date of acquisition". The warning mentioned in #7813 appears in the right place now (and only there). Also specifies correct return types for `.anonymize()`.