### PR TITLE
MRG, DOC: note on using picard for same solution as other algos

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -297,6 +297,17 @@ class ICA(ContainsMixin):
     see :class:`~sklearn.decomposition.FastICA`, :func:`~picard.picard`,
     :func:`~mne.preprocessing.infomax`.
 
+    .. note:: Picard can be used to solve the same problems as FastICA,
+              Infomax, and extended Infomax, but typically converges faster
+              than either of those methods. To make use of Picard's speed while
+              still obtaining the same solution as with other algorithms, you
+              need to specify ``method='picard'`` and ``fit_params`` as a
+              dictionary with the following combination of keys:
+
+              - ``dict(ortho=False, extended=False)`` for Infomax
+              - ``dict(ortho=False, extended=True)`` for extended Infomax
+              - ``dict(ortho=True, extended=True)`` for FastICA
+
     Reducing the tolerance (set in ``fit_params``) speeds up estimation at the
     cost of consistency of the obtained results. It is difficult to directly
     compare tolerance levels between Infomax and Picard, but for Picard and


### PR DESCRIPTION
Picard can be used to obtain the same solution as with FastICA, Infomax, or extended Infomax --> and apparently (according to Picard :wink: ) converges faster.

This sounds like a win for me, so I added this to the docs. WDYT?

@larsoner @cbrnr @agramfort @mmagnuski @pierreablin 

Info taken from README: https://github.com/pierreablin/picard

Previously discussed in [gitter](https://gitter.im/mne-tools/mne-python?at=5f16ce4815e5e72fb3679875), Thanks @cbrnr for making me aware of it.