### PR TITLE
FIX: smooth_mat logic in _Brain

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1136,7 +1136,7 @@ class _Brain(object):
                     time_actor.SetInput(time_label(self._current_time))
 
                 # interpolate in space
-                smooth_mat = hemi_data['smooth_mat']
+                smooth_mat = hemi_data.get('smooth_mat')
                 if smooth_mat is not None:
                     act_data = smooth_mat.dot(act_data)
 


### PR DESCRIPTION
This PR fixes the way the smoothing matrix is retrieved from internal data and solves the example described in https://github.com/mne-tools/mne-python/issues/8048#issue-664151155

mayavi | pyvista
----------|-----------
![image](https://user-images.githubusercontent.com/18143289/88275306-76220080-ccdd-11ea-898f-a8e9076a7265.png) | ![image](https://user-images.githubusercontent.com/18143289/88275276-630f3080-ccdd-11ea-9b41-7408150901b3.png)

Closes #8048