### PR TITLE
Better default legend in plot_compare_evokeds() for list of Evokeds

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -145,6 +145,7 @@ Changelog
 
 - Improved documentation building instructions and execution on Windows by `Eric Larson`_ and `kalenkovich`_
 
+- When passing a list of `~mne.Evoked` objects to `~mne.viz.plot_compare_evokeds`, each evoked's ``.comment`` attribute will be used to label the trace. If ``.comment`` is empty, a 1-based index is assigned as the label by  `Richard Höchenberger`_
 
 Bug
 ~~~

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -2136,13 +2136,12 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
     if isinstance(evokeds, (list, tuple)):
         evokeds_copy = evokeds.copy()
         evokeds = dict()
+
         for evk_idx, evk in enumerate(evokeds_copy, start=1):
-            try:
+            label = None
+            if hasattr(evk, 'comment'):
                 label = evk.comment
-            except AttributeError:  # e.g. list of lists or dict of lists
-                label = None
-            if not label:
-                label = str(evk_idx)
+            label = label if label else str(evk_idx)
             evokeds[label] = evk
         del evokeds_copy
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1929,7 +1929,7 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
         If a list of Evokeds, the contents are plotted with their
         ``.comment`` attributes used as condition labels. If no comment is set,
         the index of the respectiv Evoked the list will be used instead,
-        starting with `1` for the first Evoked.
+        starting with ``1`` for the first Evoked.
         If a dict whose values are Evoked objects, the contents are plotted as
         single time series each and the keys are used as labels.
         If a [dict/list] of lists, the unweighted mean is plotted as a time


### PR DESCRIPTION
#### What does this implement/fix?
When passing a list of Evoked's to `viz.plot_compare_evokeds()`, previously we would assign them sequential numbers (1 … N) as labels, which is … not necessarily too helpful.

But since by default we're also storing useful information about the condition(s) making up the Evoked in `Evoked.comment`, I thought we could make use of this to create more useful labels.

So now, for example, instead of getting this:
<img width="600" alt="Screenshot 2020-07-23 at 14 41 16" src="https://user-images.githubusercontent.com/2046265/88375707-5b629100-cd9c-11ea-8535-6d9e07171463.png">

we'll be getting this:
<img width="600" alt="Screenshot 2020-07-24 at 10 55 53" src="https://user-images.githubusercontent.com/2046265/88375727-65848f80-cd9c-11ea-910a-c5dd55f00fd7.png">

without having to pass a dict to `plot_compare_evokeds`.