### PR TITLE
MRG, FIX: Pin PyQt5 for HiDPI bug

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -37,4 +37,5 @@ dependencies:
   - nilearn
   - neo
   - python-picard
-  - PyQt5>=5.10
+  - PyQt5>=5.10,<5.14; platform_system == "Darwin"
+  - PyQt5>=5.10; platform_system != "Darwin"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 numpy
 scipy
 matplotlib
-pyqt5
+pyqt5>=5.10,<5.14; platform_system == "Darwin"
+pyqt5>=5.10; platform_system == "Darwin"
 pyqt5-sip
 sip
 scikit-learn


### PR DESCRIPTION
Until https://github.com/pyvista/pyvistaqt/issues/20 and https://gitlab.kitware.com/vtk/vtk/-/issues/17953 are fixed, we should pin PyQt5 < 5.14 on macOS.