### PR TITLE
[MRG] Bug fix - resample would break crop

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1158,7 +1158,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                     new_data[ci, this_sl] = resamp
 
         self._first_samps = (self._first_samps * ratio).astype(int)
-        self._last_samps = (np.array(self._first_samps) + n_news - 1).tolist()
+        self._last_samps = (np.array(self._first_samps) + n_news - 1)
         self._raw_lengths[ri] = list(n_news)
         assert np.array_equal(n_news, self._last_samps - self._first_samps + 1)
         self._data = new_data

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1045,6 +1045,9 @@ def test_resample(tmpdir, preload):
     assert raw1.last_samp == raw3.last_samp
     assert raw1.info['sfreq'] == raw3.info['sfreq']
 
+    # smoke test crop after resample
+    raw4.crop(tmin=raw4.times[1], tmax=raw4.times[-1])
+
     # test resampling of stim channel
 
     # basic decimation


### PR DESCRIPTION
resampling a raw would convert `raw._last_samps` to a list, which would break `raw.crop` which expected an `np.array`

This bug didn't exist in the last release, so I don't feel like this needs an entry in `latest.inc`. but if you think I should I can add it.