### PR TITLE
MRG, ENH: Volume rendering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ before_install:
     # Always install these via pip so we get the latest possible versions (testing bugfixes)
     - pip install --upgrade -r requirements_testing.txt codecov
     - if [ "${DEPS}" != "minimal" ]; then
-        pip install nitime;
+        pip install nitime pytest-xdist;
       fi
     # Don't source mne_setup_sh here because changing PATH etc. can't be done in a script
     - if [ "${DEPS}" != "minimal" ]; then
@@ -143,7 +143,7 @@ script:
         python mne/tests/test_evoked.py;
       fi;
     - echo 'pytest -m "${CONDITION}" --tb=short --cov=mne -vv ${USE_DIRS}'
-    - pytest -m "${CONDITION}" --tb=short --cov=mne -vv ${USE_DIRS}
+    - pytest -m "${CONDITION}" --tb=short --cov=mne -vv -n 1 ${USE_DIRS}
     # run the minimal one with the testing data
     - if [ "${DEPS}" == "minimal" ]; then
         export MNE_SKIP_TESTING_DATASET_TESTS=false;

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ before_install:
     # Always install these via pip so we get the latest possible versions (testing bugfixes)
     - pip install --upgrade -r requirements_testing.txt codecov
     - if [ "${DEPS}" != "minimal" ]; then
-        pip install nitime pytest-xdist;
+        pip install nitime;
       fi
     # Don't source mne_setup_sh here because changing PATH etc. can't be done in a script
     - if [ "${DEPS}" != "minimal" ]; then
@@ -143,7 +143,7 @@ script:
         python mne/tests/test_evoked.py;
       fi;
     - echo 'pytest -m "${CONDITION}" --tb=short --cov=mne -vv ${USE_DIRS}'
-    - pytest -m "${CONDITION}" --tb=short --cov=mne -vv -n 1 ${USE_DIRS}
+    - pytest -m "${CONDITION}" --tb=short --cov=mne -vv ${USE_DIRS}
     # run the minimal one with the testing data
     - if [ "${DEPS}" == "minimal" ]; then
         export MNE_SKIP_TESTING_DATASET_TESTS=false;

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -27,6 +27,8 @@ Changelog
 
 - Add :class:`mne.MixedVectorSourceEstimate` for vector source estimates for mixed source spaces, by `Eric Larson`_
 
+- Add mixed and volumetric source estimate plotting using volumetric ray-casting to :meth:`mne.MixedSourceEstimate.plot` and :meth:`mne.VolSourceEstimate.plot_3d` by `Eric Larson`_
+
 - Add :meth:`mne.MixedSourceEstimate.surface` and :meth:`mne.MixedSourceEstimate.volume` methods to allow surface and volume extraction by `Eric Larson`_
 
 - Add :meth:`mne.VectorSourceEstimate.project` to project vector source estimates onto the direction of maximum source power by `Eric Larson`_

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -596,6 +596,7 @@ numpydoc_xref_aliases = {
     'VolSourceEstimate': 'mne.VolSourceEstimate',
     'VolVectorSourceEstimate': 'mne.VolVectorSourceEstimate',
     'MixedSourceEstimate': 'mne.MixedSourceEstimate',
+    'MixedVectorSourceEstimate': 'mne.MixedVectorSourceEstimate',
     'SourceEstimate': 'mne.SourceEstimate', 'Projection': 'mne.Projection',
     'ConductorModel': 'mne.bem.ConductorModel',
     'Dipole': 'mne.Dipole', 'DipoleFixed': 'mne.DipoleFixed',

--- a/examples/inverse/plot_mixed_source_space_inverse.py
+++ b/examples/inverse/plot_mixed_source_space_inverse.py
@@ -136,8 +136,9 @@ src = inverse_operator['src']
 initial_time = 0.1
 stc_vec = apply_inverse(evoked, inverse_operator, lambda2, inv_method,
                         pick_ori='vector')
-brain = stc_vec.plot(hemi='both', src=inverse_operator['src'],
-                     initial_time=initial_time, subjects_dir=subjects_dir)
+brain = stc_vec.plot(
+    hemi='both', src=inverse_operator['src'], views='coronal',
+    initial_time=initial_time, subjects_dir=subjects_dir)
 
 ###############################################################################
 # Plot the surface

--- a/examples/inverse/plot_mixed_source_space_inverse.py
+++ b/examples/inverse/plot_mixed_source_space_inverse.py
@@ -129,16 +129,27 @@ stc = apply_inverse(evoked, inverse_operator, lambda2, inv_method,
 src = inverse_operator['src']
 
 ###############################################################################
+# Plot the mixed source estimate
+# ------------------------------
+
+# sphinx_gallery_thumbnail_number = 3
+initial_time = 0.1
+stc_vec = apply_inverse(evoked, inverse_operator, lambda2, inv_method,
+                        pick_ori='vector')
+brain = stc_vec.plot(hemi='both', views='frontal',
+                     resolution=1.,  # upsample to 1 mm resolution from "pos"
+                     src=inverse_operator['src'], trans=fname_trans,
+                     initial_time=initial_time, subjects_dir=subjects_dir)
+
+###############################################################################
 # Plot the surface
 # ----------------
-initial_time = 0.1
 brain = stc.surface().plot(initial_time=initial_time,
                            subjects_dir=subjects_dir)
 ###############################################################################
 # Plot the volume
 # ----------------
 
-# sphinx_gallery_thumbnail_number = 4
 fig = stc.volume().plot(initial_time=initial_time, src=src,
                         subjects_dir=subjects_dir)
 

--- a/examples/inverse/plot_mixed_source_space_inverse.py
+++ b/examples/inverse/plot_mixed_source_space_inverse.py
@@ -136,9 +136,7 @@ src = inverse_operator['src']
 initial_time = 0.1
 stc_vec = apply_inverse(evoked, inverse_operator, lambda2, inv_method,
                         pick_ori='vector')
-brain = stc_vec.plot(hemi='both', views='frontal',
-                     resolution=1.,  # upsample to 1 mm resolution from "pos"
-                     src=inverse_operator['src'], trans=fname_trans,
+brain = stc_vec.plot(hemi='both', src=inverse_operator['src'],
                      initial_time=initial_time, subjects_dir=subjects_dir)
 
 ###############################################################################

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -434,3 +434,17 @@ def src_volume_labels():
     assert volume_labels[0] == 'Unknown'
     assert lut['Unknown'] == 0  # it will be excluded during label gen
     return src, tuple(volume_labels), lut
+
+
+@pytest.fixture(scope='session')
+def pixel_ratio():
+    """Get the pixel ratio."""
+    try:
+        from PyQt5.QtWidgets import QApplication, QMainWindow
+        _ = QApplication.instance() or QApplication([])
+        window = QMainWindow()
+        ratio = float(window.devicePixelRatio())
+        window.close()
+    except Exception:
+        ratio = 1.
+    return ratio

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -321,6 +321,21 @@ def renderer_notebook():
         yield
 
 
+@pytest.fixture(scope='session')
+def pixel_ratio():
+    """Get the pixel ratio."""
+    from mne.viz.backends.tests._utils import (has_mayavi, has_pyvista,
+                                               has_pyqt5)
+    if not (has_mayavi() or has_pyvista()) or not has_pyqt5():
+        return 1.
+    from PyQt5.QtWidgets import QApplication, QMainWindow
+    _ = QApplication.instance() or QApplication([])
+    window = QMainWindow()
+    ratio = float(window.devicePixelRatio())
+    window.close()
+    return ratio
+
+
 @pytest.fixture(scope='function', params=[testing._pytest_param()])
 def subjects_dir_tmp(tmpdir):
     """Copy MNE-testing-data subjects_dir to a temp dir for manipulation."""
@@ -434,22 +449,3 @@ def src_volume_labels():
     assert volume_labels[0] == 'Unknown'
     assert lut['Unknown'] == 0  # it will be excluded during label gen
     return src, tuple(volume_labels), lut
-
-
-@pytest.fixture(scope='session')
-def pixel_ratio():
-    """Get the pixel ratio."""
-    try:
-        from PyQt5.QtCore import QT_VERSION_STR
-        # If Qt is too old (e.g., 5.6) this check bombs. So let's pick a
-        # version we actually want to support and go from there
-        if LooseVersion(QT_VERSION_STR) < LooseVersion('5.10'):
-            raise RuntimeError('Too old')  # go to the except
-        from PyQt5.QtWidgets import QApplication, QMainWindow
-        _ = QApplication.instance() or QApplication([])
-        window = QMainWindow()
-        ratio = float(window.devicePixelRatio())
-        window.close()
-    except Exception:
-        ratio = 1.
-    return ratio

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -440,6 +440,11 @@ def src_volume_labels():
 def pixel_ratio():
     """Get the pixel ratio."""
     try:
+        from PyQt5.QtCore import QT_VERSION_STR
+        # If Qt is too old (e.g., 5.6) this check bombs. So let's pick a
+        # version we actually want to support and go from there
+        if LooseVersion(QT_VERSION_STR) < LooseVersion('5.10'):
+            raise RuntimeError('Too old')  # go to the except
         from PyQt5.QtWidgets import QApplication, QMainWindow
         _ = QApplication.instance() or QApplication([])
         window = QMainWindow()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -98,6 +98,7 @@ def pytest_configure(config):
     ignore:.*pandas\.util\.testing is deprecated.*:
     ignore:.*tostring.*is deprecated.*:DeprecationWarning
     ignore:.*QDesktopWidget\.availableGeometry.*:DeprecationWarning
+    ignore:Unable to enable faulthandler.*:UserWarning
     always:.*get_data.* is deprecated in favor of.*:DeprecationWarning
     always::ResourceWarning
     """  # noqa: E501

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -83,7 +83,7 @@ DEFAULTS = dict(
                       combine_xyz='fro', allow_fixed_depth=True),
     interpolation_method=dict(eeg='spline', meg='MNE', fnirs='nearest'),
     volume_options=dict(
-        alpha=0.4, resolution=None, surface_alpha=None, blending='mip'),
+        alpha=None, resolution=1., surface_alpha=None, blending='mip'),
 )
 
 

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -82,6 +82,8 @@ DEFAULTS = dict(
     depth_sparse=dict(exp=0.8, limit=None, limit_depth_chs='whiten',
                       combine_xyz='fro', allow_fixed_depth=True),
     interpolation_method=dict(eeg='spline', meg='MNE', fnirs='nearest'),
+    volume_options=dict(
+        alpha=0.4, resolution=None, surface_alpha=None, blending='mip'),
 )
 
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -620,7 +620,7 @@ class _BaseSourceEstimate(TimeMixin):
              cortex="classic", size=800, background="black",
              foreground=None, initial_time=None, time_unit='s',
              backend='auto', spacing='oct6', title=None, show_traces='auto',
-             src=None, trans=None, volume_options=1., verbose=None):
+             src=None, volume_options=1., verbose=None):
         brain = plot_source_estimates(
             self, subject, surface=surface, hemi=hemi, colormap=colormap,
             time_label=time_label, smoothing_steps=smoothing_steps,
@@ -630,7 +630,7 @@ class _BaseSourceEstimate(TimeMixin):
             background=background, foreground=foreground,
             initial_time=initial_time, time_unit=time_unit, backend=backend,
             spacing=spacing, title=title, show_traces=show_traces,
-            src=src, trans=trans, volume_options=volume_options,
+            src=src, volume_options=volume_options,
             verbose=verbose)
         return brain
 
@@ -1907,8 +1907,8 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
              time_viewer='auto', subjects_dir=None, figure=None, views='lat',
              colorbar=True, clim='auto', cortex='classic', size=800,
              background='black', foreground=None, initial_time=None,
-             time_unit='s', show_traces='auto', src=None, trans=None,
-             volume_options=0.4, verbose=None):  # noqa: D102
+             time_unit='s', show_traces='auto', src=None, volume_options=1.,
+             verbose=None):  # noqa: D102
         return plot_vector_source_estimates(
             self, subject=subject, hemi=hemi, colormap=colormap,
             time_label=time_label, smoothing_steps=smoothing_steps,
@@ -1919,8 +1919,8 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
             colorbar=colorbar, clim=clim, cortex=cortex, size=size,
             background=background, foreground=foreground,
             initial_time=initial_time, time_unit=time_unit,
-            show_traces=show_traces, src=src, trans=trans,
-            volume_options=volume_options, verbose=verbose)
+            show_traces=show_traces, src=src, volume_options=volume_options,
+            verbose=verbose)
 
 
 class _BaseVolSourceEstimate(_BaseSourceEstimate):
@@ -1928,7 +1928,26 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
     _src_type = 'volume'
     _src_count = None
 
-    plot_3d = _BaseSourceEstimate.plot
+    @copy_function_doc_to_method_doc(plot_source_estimates)
+    def plot_3d(self, subject=None, surface='white', hemi='both',
+                colormap='auto', time_label='auto', smoothing_steps=10,
+                transparent=True, alpha=0.2, time_viewer='auto',
+                subjects_dir=None,
+                figure=None, views='rostral', colorbar=True, clim='auto',
+                cortex="classic", size=800, background="black",
+                foreground=None, initial_time=None, time_unit='s',
+                backend='auto', spacing='oct6', title=None, show_traces='auto',
+                src=None, volume_options=1., verbose=None):
+        return super().plot(
+            subject=subject, surface=surface, hemi=hemi, colormap=colormap,
+            time_label=time_label, smoothing_steps=smoothing_steps,
+            transparent=transparent, alpha=alpha, subjects_dir=subjects_dir,
+            figure=figure, views=views, colorbar=colorbar, clim=clim,
+            cortex=cortex, size=size, background=background,
+            foreground=foreground, initial_time=initial_time,
+            time_unit=time_unit, backend=backend, spacing=spacing, title=title,
+            show_traces=show_traces, src=src, volume_options=volume_options,
+            verbose=verbose)
 
     @copy_function_doc_to_method_doc(plot_volume_source_estimates)
     def plot(self, src, subject=None, subjects_dir=None, mode='stat_map',
@@ -2233,7 +2252,31 @@ class VolVectorSourceEstimate(_BaseVolSourceEstimate,
     """
 
     _scalar_class = VolSourceEstimate
-    plot_3d = _BaseVectorSourceEstimate.plot
+
+    # defaults differ: hemi='both', brain_alpha=0.2, views='rostral'
+    @copy_function_doc_to_method_doc(plot_vector_source_estimates)
+    def plot_3d(self, subject=None, hemi='both', colormap='hot',
+                time_label='auto',
+                smoothing_steps=10, transparent=True, brain_alpha=0.2,
+                overlay_alpha=None, vector_alpha=1.0, scale_factor=None,
+                time_viewer='auto', subjects_dir=None, figure=None,
+                views='rostral',
+                colorbar=True, clim='auto', cortex='classic', size=800,
+                background='black', foreground=None, initial_time=None,
+                time_unit='s', show_traces='auto', src=None,
+                volume_options=1., verbose=None):  # noqa: D102
+        return _BaseVectorSourceEstimate.plot(
+            self, subject=subject, hemi=hemi, colormap=colormap,
+            time_label=time_label, smoothing_steps=smoothing_steps,
+            transparent=transparent, brain_alpha=brain_alpha,
+            overlay_alpha=overlay_alpha, vector_alpha=vector_alpha,
+            scale_factor=scale_factor, time_viewer=time_viewer,
+            subjects_dir=subjects_dir, figure=figure, views=views,
+            colorbar=colorbar, clim=clim, cortex=cortex, size=size,
+            background=background, foreground=foreground,
+            initial_time=initial_time, time_unit=time_unit,
+            show_traces=show_traces, src=src, volume_options=volume_options,
+            verbose=verbose)
 
 
 @fill_doc

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -611,6 +611,29 @@ class _BaseSourceEstimate(TimeMixin):
                         src_type=self._src_type),
                    title='mnepython', overwrite=True)
 
+    @copy_function_doc_to_method_doc(plot_source_estimates)
+    def plot(self, subject=None, surface='inflated', hemi='lh',
+             colormap='auto', time_label='auto', smoothing_steps=10,
+             transparent=True, alpha=1.0, time_viewer='auto',
+             subjects_dir=None,
+             figure=None, views='lat', colorbar=True, clim='auto',
+             cortex="classic", size=800, background="black",
+             foreground=None, initial_time=None, time_unit='s',
+             backend='auto', spacing='oct6', title=None, show_traces='auto',
+             src=None, trans=None, volume_options=1., verbose=None):
+        brain = plot_source_estimates(
+            self, subject, surface=surface, hemi=hemi, colormap=colormap,
+            time_label=time_label, smoothing_steps=smoothing_steps,
+            transparent=transparent, alpha=alpha, time_viewer=time_viewer,
+            subjects_dir=subjects_dir, figure=figure, views=views,
+            colorbar=colorbar, clim=clim, cortex=cortex, size=size,
+            background=background, foreground=foreground,
+            initial_time=initial_time, time_unit=time_unit, backend=backend,
+            spacing=spacing, title=title, show_traces=show_traces,
+            src=src, trans=trans, volume_options=volume_options,
+            verbose=verbose)
+        return brain
+
     @property
     def sfreq(self):
         """Sample rate of the data."""
@@ -1576,28 +1599,6 @@ class SourceEstimate(_BaseSurfaceSourceEstimate):
             super().save(fname)
         logger.info('[done]')
 
-    @copy_function_doc_to_method_doc(plot_source_estimates)
-    def plot(self, subject=None, surface='inflated', hemi='lh',
-             colormap='auto', time_label='auto', smoothing_steps=10,
-             transparent=True, alpha=1.0, time_viewer='auto',
-             subjects_dir=None,
-             figure=None, views='lat', colorbar=True, clim='auto',
-             cortex="classic", size=800, background="black",
-             foreground=None, initial_time=None, time_unit='s',
-             backend='auto', spacing='oct6', title=None,
-             show_traces='auto', verbose=None):
-        brain = plot_source_estimates(
-            self, subject, surface=surface, hemi=hemi, colormap=colormap,
-            time_label=time_label, smoothing_steps=smoothing_steps,
-            transparent=transparent, alpha=alpha, time_viewer=time_viewer,
-            subjects_dir=subjects_dir, figure=figure, views=views,
-            colorbar=colorbar, clim=clim, cortex=cortex, size=size,
-            background=background, foreground=foreground,
-            initial_time=initial_time, time_unit=time_unit, backend=backend,
-            spacing=spacing, title=title, show_traces=show_traces,
-            verbose=verbose)
-        return brain
-
     @verbose
     def estimate_snr(self, info, fwd, cov, verbose=None):
         r"""Compute time-varying SNR in the source space.
@@ -1899,11 +1900,35 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
             self.verbose)
         return stc, directions
 
+    @copy_function_doc_to_method_doc(plot_vector_source_estimates)
+    def plot(self, subject=None, hemi='lh', colormap='hot', time_label='auto',
+             smoothing_steps=10, transparent=True, brain_alpha=0.4,
+             overlay_alpha=None, vector_alpha=1.0, scale_factor=None,
+             time_viewer='auto', subjects_dir=None, figure=None, views='lat',
+             colorbar=True, clim='auto', cortex='classic', size=800,
+             background='black', foreground=None, initial_time=None,
+             time_unit='s', show_traces='auto', src=None, trans=None,
+             volume_options=0.4, verbose=None):  # noqa: D102
+        return plot_vector_source_estimates(
+            self, subject=subject, hemi=hemi, colormap=colormap,
+            time_label=time_label, smoothing_steps=smoothing_steps,
+            transparent=transparent, brain_alpha=brain_alpha,
+            overlay_alpha=overlay_alpha, vector_alpha=vector_alpha,
+            scale_factor=scale_factor, time_viewer=time_viewer,
+            subjects_dir=subjects_dir, figure=figure, views=views,
+            colorbar=colorbar, clim=clim, cortex=cortex, size=size,
+            background=background, foreground=foreground,
+            initial_time=initial_time, time_unit=time_unit,
+            show_traces=show_traces, src=src, trans=trans,
+            volume_options=volume_options, verbose=verbose)
+
 
 class _BaseVolSourceEstimate(_BaseSourceEstimate):
 
     _src_type = 'volume'
     _src_count = None
+
+    plot_3d = _BaseSourceEstimate.plot
 
     @copy_function_doc_to_method_doc(plot_volume_source_estimates)
     def plot(self, src, subject=None, subjects_dir=None, mode='stat_map',
@@ -2162,8 +2187,8 @@ class VolSourceEstimate(_BaseVolSourceEstimate):
 
 
 @fill_doc
-class VolVectorSourceEstimate(_BaseVectorSourceEstimate,
-                              _BaseVolSourceEstimate):
+class VolVectorSourceEstimate(_BaseVolSourceEstimate,
+                              _BaseVectorSourceEstimate):
     """Container for volume source estimates.
 
     Parameters
@@ -2208,6 +2233,7 @@ class VolVectorSourceEstimate(_BaseVectorSourceEstimate,
     """
 
     _scalar_class = VolSourceEstimate
+    plot_3d = _BaseVectorSourceEstimate.plot
 
 
 @fill_doc
@@ -2258,27 +2284,6 @@ class VectorSourceEstimate(_BaseVectorSourceEstimate,
     """
 
     _scalar_class = SourceEstimate
-
-    @copy_function_doc_to_method_doc(plot_vector_source_estimates)
-    def plot(self, subject=None, hemi='lh', colormap='hot', time_label='auto',
-             smoothing_steps=10, transparent=True, brain_alpha=0.4,
-             overlay_alpha=None, vector_alpha=1.0, scale_factor=None,
-             time_viewer='auto', subjects_dir=None, figure=None, views='lat',
-             colorbar=True, clim='auto', cortex='classic', size=800,
-             background='black', foreground=None, initial_time=None,
-             time_unit='s', show_traces='auto', verbose=None):  # noqa: D102
-        return plot_vector_source_estimates(
-            self, subject=subject, hemi=hemi, colormap=colormap,
-            time_label=time_label, smoothing_steps=smoothing_steps,
-            transparent=transparent, brain_alpha=brain_alpha,
-            overlay_alpha=overlay_alpha, vector_alpha=vector_alpha,
-            scale_factor=scale_factor, time_viewer=time_viewer,
-            subjects_dir=subjects_dir, figure=figure, views=views,
-            colorbar=colorbar, clim=clim, cortex=cortex, size=size,
-            background=background, foreground=foreground,
-            initial_time=initial_time, time_unit=time_unit,
-            show_traces=show_traces, verbose=verbose,
-        )
 
 
 ###############################################################################

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1943,7 +1943,8 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
         return super().plot(
             subject=subject, surface=surface, hemi=hemi, colormap=colormap,
             time_label=time_label, smoothing_steps=smoothing_steps,
-            transparent=transparent, alpha=alpha, subjects_dir=subjects_dir,
+            transparent=transparent, alpha=alpha, time_viewer=time_viewer,
+            subjects_dir=subjects_dir,
             figure=figure, views=views, colorbar=colorbar, clim=clim,
             cortex=cortex, size=size, background=background,
             foreground=foreground, initial_time=initial_time,

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -620,7 +620,8 @@ class _BaseSourceEstimate(TimeMixin):
              cortex="classic", size=800, background="black",
              foreground=None, initial_time=None, time_unit='s',
              backend='auto', spacing='oct6', title=None, show_traces='auto',
-             src=None, volume_options=1., verbose=None):
+             src=None, volume_options=1., view_layout='vertical',
+             verbose=None):
         brain = plot_source_estimates(
             self, subject, surface=surface, hemi=hemi, colormap=colormap,
             time_label=time_label, smoothing_steps=smoothing_steps,
@@ -630,7 +631,7 @@ class _BaseSourceEstimate(TimeMixin):
             background=background, foreground=foreground,
             initial_time=initial_time, time_unit=time_unit, backend=backend,
             spacing=spacing, title=title, show_traces=show_traces,
-            src=src, volume_options=volume_options,
+            src=src, volume_options=volume_options, view_layout=view_layout,
             verbose=verbose)
         return brain
 
@@ -1908,7 +1909,7 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
              colorbar=True, clim='auto', cortex='classic', size=800,
              background='black', foreground=None, initial_time=None,
              time_unit='s', show_traces='auto', src=None, volume_options=1.,
-             verbose=None):  # noqa: D102
+             view_layout='vertical', verbose=None):  # noqa: D102
         return plot_vector_source_estimates(
             self, subject=subject, hemi=hemi, colormap=colormap,
             time_label=time_label, smoothing_steps=smoothing_steps,
@@ -1920,7 +1921,7 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
             background=background, foreground=foreground,
             initial_time=initial_time, time_unit=time_unit,
             show_traces=show_traces, src=src, volume_options=volume_options,
-            verbose=verbose)
+            view_layout=view_layout, verbose=verbose)
 
 
 class _BaseVolSourceEstimate(_BaseSourceEstimate):
@@ -1933,11 +1934,12 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
                 colormap='auto', time_label='auto', smoothing_steps=10,
                 transparent=True, alpha=0.2, time_viewer='auto',
                 subjects_dir=None,
-                figure=None, views='rostral', colorbar=True, clim='auto',
+                figure=None, views='axial', colorbar=True, clim='auto',
                 cortex="classic", size=800, background="black",
                 foreground=None, initial_time=None, time_unit='s',
                 backend='auto', spacing='oct6', title=None, show_traces='auto',
-                src=None, volume_options=1., verbose=None):
+                src=None, volume_options=1., view_layout='vertical',
+                verbose=None):
         return super().plot(
             subject=subject, surface=surface, hemi=hemi, colormap=colormap,
             time_label=time_label, smoothing_steps=smoothing_steps,
@@ -1947,7 +1949,7 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
             foreground=foreground, initial_time=initial_time,
             time_unit=time_unit, backend=backend, spacing=spacing, title=title,
             show_traces=show_traces, src=src, volume_options=volume_options,
-            verbose=verbose)
+            view_layout=view_layout, verbose=verbose)
 
     @copy_function_doc_to_method_doc(plot_volume_source_estimates)
     def plot(self, src, subject=None, subjects_dir=None, mode='stat_map',
@@ -2253,18 +2255,19 @@ class VolVectorSourceEstimate(_BaseVolSourceEstimate,
 
     _scalar_class = VolSourceEstimate
 
-    # defaults differ: hemi='both', brain_alpha=0.2, views='rostral'
+    # defaults differ: hemi='both', views='axial'
     @copy_function_doc_to_method_doc(plot_vector_source_estimates)
     def plot_3d(self, subject=None, hemi='both', colormap='hot',
                 time_label='auto',
-                smoothing_steps=10, transparent=True, brain_alpha=0.2,
+                smoothing_steps=10, transparent=True, brain_alpha=0.4,
                 overlay_alpha=None, vector_alpha=1.0, scale_factor=None,
                 time_viewer='auto', subjects_dir=None, figure=None,
-                views='rostral',
+                views='axial',
                 colorbar=True, clim='auto', cortex='classic', size=800,
                 background='black', foreground=None, initial_time=None,
                 time_unit='s', show_traces='auto', src=None,
-                volume_options=1., verbose=None):  # noqa: D102
+                volume_options=1., view_layout='vertical',
+                verbose=None):  # noqa: D102
         return _BaseVectorSourceEstimate.plot(
             self, subject=subject, hemi=hemi, colormap=colormap,
             time_label=time_label, smoothing_steps=smoothing_steps,
@@ -2276,7 +2279,7 @@ class VolVectorSourceEstimate(_BaseVolSourceEstimate,
             background=background, foreground=foreground,
             initial_time=initial_time, time_unit=time_unit,
             show_traces=show_traces, src=src, volume_options=volume_options,
-            verbose=verbose)
+            view_layout=view_layout, verbose=verbose)
 
 
 @fill_doc

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1007,14 +1007,11 @@ time_label : str | callable | None
     default is ``'auto'``, which will use ``time=%0.2f ms`` if there
     is more than one time point.
 """
-docdict["src_trans_volume_options"] = """
+docdict["src_volume_options"] = """
 src : instance of SourceSpaces | None
     The source space corresponding to the source estimate. Only necessary
     if the STC is a volume or mixed source estimate.
-trans : instance of Transform | None
-    Head to MRI transform. Only needed if ``stc`` is a volume or mixed
-    source estimate and ``src`` is in the head coordinate frame.
-volume_options : float | dict
+volume_options : float | dict | None
     Options for volumetric source estimate plotting, with key/value pairs:
 
     - ``'resolution'`` : float | None
@@ -1025,15 +1022,15 @@ volume_options : float | dict
     - ``'blending'`` : str
         Can be "mip" (default) for maximum intensity projection or
         "composite" for composite blending.
-    - ``'alpha'`` : float
-        Alpha for the volumetric rendering.
+    - ``'alpha'`` : float | None
+        Alpha for the volumetric rendering. Uses 0.4 for vector source
+        estimates and 1.0 for scalar source estimates.
     - ``'surface_alpha'`` : float | None
         Alpha for the surface enclosing the volume(s). None will use
         half the volume alpha. Set to zero to avoid plotting the surface.
 
-    A float input (default) will be used for the ``'alpha'`` entry.
-volume_alpha : float
-    Alpha to use for volumetric plotting.
+    A float input (default 1.) or None will be used for the ``'resolution'``
+    entry.
 """
 
 # STC label time course

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1007,7 +1007,34 @@ time_label : str | callable | None
     default is ``'auto'``, which will use ``time=%0.2f ms`` if there
     is more than one time point.
 """
+docdict["src_trans_volume_options"] = """
+src : instance of SourceSpaces | None
+    The source space corresponding to the source estimate. Only necessary
+    if the STC is a volume or mixed source estimate.
+trans : instance of Transform | None
+    Head to MRI transform. Only needed if ``stc`` is a volume or mixed
+    source estimate and ``src`` is in the head coordinate frame.
+volume_options : float | dict
+    Options for volumetric source estimate plotting, with key/value pairs:
 
+    - ``'resolution'`` : float | None
+        Resolution (in mm) of volume rendering. Smaller (e.g., 1.) looks
+        better at the cost of speed. None (default) uses the volume source
+        space resolution, which is often something like 7 or 5 mm,
+        without resampling.
+    - ``'blending'`` : str
+        Can be "mip" (default) for maximum intensity projection or
+        "composite" for composite blending.
+    - ``'alpha'`` : float
+        Alpha for the volumetric rendering.
+    - ``'surface_alpha'`` : float | None
+        Alpha for the surface enclosing the volume(s). None will use
+        half the volume alpha. Set to zero to avoid plotting the surface.
+
+    A float input (default) will be used for the ``'alpha'`` entry.
+volume_alpha : float
+    Alpha to use for volumetric plotting.
+"""
 
 # STC label time course
 docdict['eltc_labels'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -990,13 +990,15 @@ interpolation : str | None
     or 'cubic'.
 """
 docdict["show_traces"] = """
-show_traces : bool | str
+show_traces : bool | str | float
     If True, enable interactive picking of a point on the surface of the
-    brain and plot it's time course using the bottom 1/3 of the figure.
+    brain and plot its time course.
     This feature is only available with the PyVista 3d backend, and requires
     ``time_viewer=True``. Defaults to 'auto', which will use True if and
     only if ``time_viewer=True``, the backend is PyVista, and there is more
-    than one time point.
+    than one time point. If float (between zero and one), it specifies what
+    proportion of the total window should be devoted to traces (True is
+    equivalent to 0.25, i.e., it will occupy the bottom 1/4 of the figure).
 
     .. versionadded:: 0.20.0
 """
@@ -1007,7 +1009,7 @@ time_label : str | callable | None
     default is ``'auto'``, which will use ``time=%0.2f ms`` if there
     is more than one time point.
 """
-docdict["src_volume_options"] = """
+docdict["src_volume_options_layout"] = """
 src : instance of SourceSpaces | None
     The source space corresponding to the source estimate. Only necessary
     if the STC is a volume or mixed source estimate.
@@ -1031,6 +1033,9 @@ volume_options : float | dict | None
 
     A float input (default 1.) or None will be used for the ``'resolution'``
     entry.
+view_layout : str
+    Can be "vertical" (default) or "horizontal". When using "horizontal" mode,
+    the PyVista backend must be used and hemi cannot be "split".
 """
 
 # STC label time course

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1587,7 +1587,8 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
                           foreground=None, initial_time=None,
                           time_unit='s', backend='auto', spacing='oct6',
                           title=None, show_traces='auto',
-                          src=None, volume_options=1., verbose=None):
+                          src=None, volume_options=1., view_layout='vertical',
+                          verbose=None):
     """Plot SourceEstimate.
 
     Parameters
@@ -1674,7 +1675,7 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
 
         .. versionadded:: 0.17.0
     %(show_traces)s
-    %(src_volume_options)s
+    %(src_volume_options_layout)s
     %(verbose)s
 
     Returns
@@ -1715,14 +1716,15 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
         stc, overlay_alpha=alpha, brain_alpha=alpha, vector_alpha=alpha,
         cortex=cortex, foreground=foreground, size=size, scale_factor=None,
         show_traces=show_traces, src=src, volume_options=volume_options,
-        **kwargs)
+        view_layout=view_layout, **kwargs)
 
 
 def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
               smoothing_steps, subjects_dir, views, clim, figure, initial_time,
               time_unit, background, time_viewer, colorbar, transparent,
               brain_alpha, overlay_alpha, vector_alpha, cortex, foreground,
-              size, scale_factor, show_traces, src, volume_options):
+              size, scale_factor, show_traces, src, volume_options,
+              view_layout):
     from .backends.renderer import _get_3d_backend
     vec = stc._data_ndim == 3
     subjects_dir = get_subjects_dir(subjects_dir=subjects_dir,
@@ -1739,6 +1741,7 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
         from ._brain import _Brain as Brain
 
     _check_option('hemi', hemi, ['lh', 'rh', 'split', 'both'])
+    _check_option('view_layout', view_layout, ('vertical', 'horizontal'))
     time_label, times = _handle_time(time_label, time_unit, stc.times)
 
     # convert control points to locations in colormap
@@ -1784,8 +1787,12 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
     }
     if backend in ['pyvista', 'notebook']:
         kwargs["show"] = not time_viewer
+        kwargs["view_layout"] = view_layout
     else:
         kwargs.update(_check_pysurfer_antialias(Brain))
+        if view_layout != 'vertical':
+            raise ValueError('view_layout must be "vertical" when using the '
+                             'mayavi backend')
     with warnings.catch_warnings(record=True):  # traits warnings
         brain = Brain(**kwargs)
     del kwargs
@@ -1865,8 +1872,10 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
 
     # time_viewer and show_traces
     _check_option('time_viewer', time_viewer, (True, False, 'auto'))
-    _check_option('show_traces', show_traces,
-                  (True, False, 'auto', 'separate'))
+    _validate_type(show_traces, (str, bool, 'numeric'), 'show_traces')
+    if isinstance(show_traces, str):
+        _check_option('show_traces', show_traces, ('auto', 'separate'),
+                      extra='when a string')
     if time_viewer == 'auto':
         time_viewer = not using_mayavi
     if show_traces == 'auto':
@@ -2348,7 +2357,8 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
                                  size=800, background='black',
                                  foreground=None, initial_time=None,
                                  time_unit='s', show_traces='auto',
-                                 src=None, volume_options=1., verbose=None):
+                                 src=None, volume_options=1.,
+                                 view_layout='vertical', verbose=None):
     """Plot VectorSourceEstimate with PySurfer.
 
     A "glass brain" is drawn and all dipoles defined in the source estimate
@@ -2422,7 +2432,7 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
         Whether time is represented in seconds ("s", default) or
         milliseconds ("ms").
     %(show_traces)s
-    %(src_volume_options)s
+    %(src_volume_options_layout)s
     %(verbose)s
 
     Returns
@@ -2449,7 +2459,7 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
         brain_alpha=brain_alpha, overlay_alpha=overlay_alpha,
         vector_alpha=vector_alpha, cortex=cortex, foreground=foreground,
         size=size, scale_factor=scale_factor, show_traces=show_traces,
-        src=src, volume_options=volume_options)
+        src=src, volume_options=volume_options, view_layout=view_layout)
 
 
 @verbose

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1684,6 +1684,8 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
         matplotlib figure.
     """  # noqa: E501
     from .backends.renderer import _get_3d_backend, set_3d_backend
+    from ..source_estimate import _BaseSourceEstimate
+    _validate_type(stc, _BaseSourceEstimate, 'stc', 'source estimate')
     subjects_dir = get_subjects_dir(subjects_dir=subjects_dir,
                                     raise_error=True)
     subject = _check_subject(stc.subject, subject, True)
@@ -1722,8 +1724,6 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
               brain_alpha, overlay_alpha, vector_alpha, cortex, foreground,
               size, scale_factor, show_traces, src, volume_options):
     from .backends.renderer import _get_3d_backend
-    from ..source_estimate import _BaseSourceEstimate
-    _validate_type(stc, _BaseSourceEstimate, 'stc', 'source estimate')
     vec = stc._data_ndim == 3
     subjects_dir = get_subjects_dir(subjects_dir=subjects_dir,
                                     raise_error=True)
@@ -2437,6 +2437,9 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
     If the current magnitude overlay is not desired, set ``overlay_alpha=0``
     and ``smoothing_steps=1``.
     """
+    from ..source_estimate import _BaseVectorSourceEstimate
+    _validate_type(
+        stc, _BaseVectorSourceEstimate, 'stc', 'vector source estimate')
     return _plot_stc(
         stc, subject=subject, surface='white', hemi=hemi, colormap=colormap,
         time_label=time_label, smoothing_steps=smoothing_steps,

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -953,7 +953,7 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
     # initialize figure
     renderer = _get_renderer(fig, bgcolor=(0.5, 0.5, 0.5), size=(800, 800))
     if interaction == 'terrain':
-        renderer.set_interactive()
+        renderer.set_interaction('terrain')
 
     # plot surfaces
     alphas = dict(head=head_alpha, helmet=0.25, lh=hemi_val, rh=hemi_val)

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1184,26 +1184,30 @@ class _Brain(object):
         # update our values
         rng = self._cmap_range
         ctable = self._data['ctable']
+        if self._colorbar_added:
+            scalar_bar = self._renderer.plotter.scalar_bar
+        else:
+            scalar_bar = None
         for hemi in ['lh', 'rh', 'vol']:
             hemi_data = self._data.get(hemi)
             if hemi_data is not None:
                 if hemi_data.get('actors') is not None:
                     for actor in hemi_data['actors']:
-                        if self._colorbar_added:
-                            scalar_bar = self._renderer.plotter.scalar_bar
-                        else:
-                            scalar_bar = None
                         _set_colormap_range(actor, ctable, scalar_bar, rng)
+                        scalar_bar = None
 
                 grid_volume = hemi_data.get('grid_volume')
                 if grid_volume is not None:
-                    _set_volume_range(
-                        grid_volume, ctable, hemi_data['alpha'], rng)
+                    _set_volume_range(grid_volume, ctable, hemi_data['alpha'],
+                                      scalar_bar, rng)
+                    scalar_bar = None
 
                 glyph_actor = hemi_data.get('glyph_actor')
                 if glyph_actor is not None:
                     for glyph_actor_ in glyph_actor:
-                        _set_colormap_range(glyph_actor_, ctable, None, rng)
+                        _set_colormap_range(
+                            glyph_actor_, ctable, scalar_bar, rng)
+                        scalar_bar = None
 
     def set_data_smoothing(self, n_steps):
         """Set the number of smoothing steps.

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -304,8 +304,7 @@ class _Brain(object):
         _check_option('interaction', interaction, ('trackball', 'terrain'))
         for ri, ci, _ in self._iter_views('vol'):  # will traverse all
             self._renderer.subplot(ri, ci)
-            getattr(self._renderer.plotter,
-                    f'enable_{interaction}_style')()
+            self._renderer.set_interaction(interaction)
 
     def cortex_colormap(self, cortex):
         """Return the colormap corresponding to the cortex."""
@@ -1112,6 +1111,12 @@ class _Brain(object):
                   hemi=None):
         """Orient camera to display view."""
         hemi = self._hemi if hemi is None else hemi
+        if hemi == 'split':
+            if (self._view_layout == 'vertical' and col == 1 or
+                    self._view_layout == 'horizontal' and row == 1):
+                hemi = 'rh'
+            else:
+                hemi = 'lh'
         if isinstance(view, str):
             view = views_dicts[hemi].get(view)
         view = view.copy()

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -615,8 +615,7 @@ class _Brain(object):
         volume = self._data[hemi].get('grid_volume')
         if volume is not None:
             actor, _ = self._renderer.plotter.add_actor(
-                volume, reset_camera=False, name=None, culling=False,
-                pickable=False)  # setting this pickable segfaults on click...
+                volume, reset_camera=False, name=None, culling=False)
             return actor
         _validate_type(src, SourceSpaces, 'src')
         _check_option('src.kind', src.kind, ('volume',))
@@ -669,11 +668,12 @@ class _Brain(object):
             dimensions, origin, spacing, scalars, alpha, surface_alpha,
             resolution, blending)
         self._data[hemi]['grid'] = grid
+        self._data[hemi]['grid_src_mri_t'] = src_mri_t
+        self._data[hemi]['grid_shape'] = dimensions
         self._data[hemi]['grid_mapper'] = mapper
         self._data[hemi]['grid_volume'] = volume
         actor, _ = self._renderer.plotter.add_actor(
-            volume, reset_camera=False, name=None, culling=False,
-            pickable=False)  # setting this pickable segfaults on click...
+            volume, reset_camera=False, name=None, culling=False)
         return actor
 
     def _add_volume_object(self, dimensions, origin, spacing, scalars,
@@ -1359,18 +1359,18 @@ class _Brain(object):
                     name=str(hemi) + "_glyph"
                 )
                 if polydata is not None:
-                    if add:
+                    if not add:
+                        glyph_actor = hemi_data['glyph_actor'][count]
+                        glyph_mesh = hemi_data['glyph_mesh'][count]
+                        glyph_mesh.shallow_copy(polydata)
+                    else:
                         glyph_actor, _ = self._renderer.polydata(polydata)
                         assert not isinstance(glyph_actor, list)
                         glyph_actor.VisibilityOff()
                         glyph_actor.GetProperty().SetLineWidth(2.)
                         hemi_data['glyph_mesh'].append(polydata)
                         hemi_data['glyph_actor'].append(glyph_actor)
-                    glyph_actor = hemi_data['glyph_actor'][count]
-                    glyph_mesh = hemi_data['glyph_mesh'][count]
                     count += 1
-                    if not add:
-                        glyph_mesh.shallow_copy(polydata)
                     ctable = self._data['ctable']
                     rng = self._cmap_range
                     _set_colormap_range(glyph_actor, ctable, None, rng)

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -623,10 +623,13 @@ class _Brain(object):
     def _add_volume_data(self, hemi, src, volume_options):
         _validate_type(src, SourceSpaces, 'src')
         _check_option('src.kind', src.kind, ('volume',))
-        _validate_type(volume_options, (dict, 'numeric'), 'volume_options')
+        _validate_type(
+            volume_options, (dict, 'numeric', None), 'volume_options')
         assert hemi == 'vol'
         if not isinstance(volume_options, dict):
-            volume_options = dict(resolution=float(volume_options))
+            volume_options = dict(
+                resolution=float(volume_options) if volume_options is not None
+                else None)
         volume_options = _handle_default('volume_options', volume_options)
         allowed_types = (
             ['resolution', (None, 'numeric')],
@@ -1362,16 +1365,15 @@ class _Brain(object):
 
                 # update the glyphs
                 if vectors is not None:
-                    self.update_glyphs(hemi, vectors)
+                    self._update_glyphs(hemi, vectors)
 
         self._data['time_idx'] = time_idx
         self._update()
 
-    def update_glyphs(self, hemi, vectors):
+    def _update_glyphs(self, hemi, vectors):
         from ..backends._pyvista import _set_colormap_range
         hemi_data = self._data.get(hemi)
-        if hemi_data is None:
-            return
+        assert hemi_data is not None
         vertices = hemi_data['vertices']
         vector_alpha = self._data['vector_alpha']
         scale_factor = self._data['scale_factor']

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -620,13 +620,13 @@ class _Brain(object):
             volume_options = dict(volume_alpha=float(volume_options))
         volume_options = _handle_default('volume_options', volume_options)
         for key, types in (['resolution', (None, 'numeric')],
-                        ['blending', (str,)],
-                        ['alpha', ('numeric', None)],
-                        ['surface_alpha', (None, 'numeric')]):
+                           ['blending', (str,)],
+                           ['alpha', ('numeric', None)],
+                           ['surface_alpha', (None, 'numeric')]):
             _validate_type(volume_options[key], types,
-                        f'volume_options[{repr(key)}]')
+                           f'volume_options[{repr(key)}]')
         _check_option('volume_options["blending"]', volume_options['blending'],
-                    ('composite', 'mip'))
+                      ('composite', 'mip'))
         blending = volume_options['blending']
         alpha = volume_options['alpha']
         if alpha is None:
@@ -651,12 +651,12 @@ class _Brain(object):
             coords = np.array([c.ravel(order='F') for c in xyz]).T
             coords = apply_trans(src_mri_t, coords)
             self.geo[hemi] = Bunch(coords=coords)
-            self._data[hemi]['alpha'] = alpha  # this gets set incorrectly earlier
             vertices = self._data[hemi]['vertices']
             assert self._data[hemi]['array'].shape[0] == len(vertices)
             # MNE constructs the source space on a uniform grid in MRI space,
             # but let's make sure
-            assert np.allclose(src_mri_t[:3, :3], np.diag([src_mri_t[0, 0]] * 3))
+            assert np.allclose(
+                src_mri_t[:3, :3], np.diag([src_mri_t[0, 0]] * 3))
             spacing = np.diag(src_mri_t)[:3]
             origin = src_mri_t[:3, 3] - spacing / 2.
             scalars = np.zeros(np.prod(dimensions))
@@ -664,6 +664,7 @@ class _Brain(object):
             grid, grid_mesh, mapper, volume = self._add_volume_object(
                 dimensions, origin, spacing, scalars, alpha, surface_alpha,
                 resolution, blending)
+            self._data[hemi]['alpha'] = alpha  # incorrectly set earlier
             self._data[hemi]['grid'] = grid
             self._data[hemi]['grid_mesh'] = grid_mesh
             self._data[hemi]['grid_coords'] = coords

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -618,10 +618,6 @@ class _TimeViewer(object):
     def configure_sliders(self):
         rng = _get_range(self.brain)
         # Orientation slider
-        # default: put orientation slider on the first view
-        if self.brain._hemi in ('split', 'both'):
-            self.plotter.subplot(0, 0)
-
         # Use 'lh' as a reference for orientation for 'both'
         if self.brain._hemi == 'both':
             hemis_ref = ['lh']
@@ -655,9 +651,10 @@ class _TimeViewer(object):
                 self.set_slider_style(orientation_slider, show_label=False)
                 self.orientation_call(view, update_widget=True)
 
-        # necessary because show_view modified subplot
-        if self.brain._hemi in ('split', 'both'):
-            self.plotter.subplot(0, 0)
+        # Put other sliders on the bottom right view
+        ri = len(self.brain.views) - 1
+        ci = 1 if self.brain._hemi == 'split' else 0
+        self.plotter.subplot(ri, ci)
 
         # Smoothing slider
         self.smoothing_call = IntSlider(
@@ -1286,7 +1283,7 @@ class _LinkViewer(object):
 
 
 def _get_range(brain):
-    val = np.abs(brain._current_act_data)
+    val = np.abs(np.concatenate(list(brain._current_act_data.values())))
     return [np.min(val), np.max(val)]
 
 

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -1098,7 +1098,7 @@ class _TimeViewer(object):
             coords = self.brain._data[hemi]['grid_coords'][vertices]
             scalars = grid.cell_arrays['values'][vertices]
             spacing = np.array(grid.GetSpacing())
-            max_dist = np.linalg.norm(spacing) / np.sqrt(3)
+            max_dist = np.linalg.norm(spacing) / 2.
             origin = vtk_picker.GetRenderer().GetActiveCamera().GetPosition()
             ori = pos - origin
             ori /= np.linalg.norm(ori)

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -429,7 +429,7 @@ class _TimeViewer(object):
                 self.splitter.setSizes([sz[1], mpl_h])
                 self.mpl_canvas.canvas.setMinimumSize(0, 0)
             _process_events(self.plotter)
-            for hemi in self.brain._hemis:
+            for hemi in ('lh', 'rh'):
                 if hemi == 'rh' and self.brain._hemi == 'split':
                     continue
                 for ri, ci, v in self.brain._iter_views(hemi):
@@ -917,7 +917,7 @@ class _TimeViewer(object):
             vertices = hemi_data['vertices']
 
             # simulate a picked renderer
-            if self.brain._hemi == 'both' or hemi == 'vol':
+            if self.brain._hemi in ('both', 'rh') or hemi == 'vol':
                 idx = 0
             self.picked_renderer = self.plotter.renderers[idx]
 

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -330,6 +330,8 @@ class _TimeViewer(object):
         _require_minimum_version('0.24')
 
         # shared configuration
+        if hasattr(brain, 'time_viewer'):
+            raise RuntimeError('brain already has a TimeViewer')
         self.brain = brain
         self.orientation = list(_lh_views_dict.keys())
         self.default_smoothing_range = [0, 15]

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -139,6 +139,7 @@ class MplCanvas(object):
     on_motion_notify = on_button_press  # for now they can be the same
 
     def on_resize(self, event):
+        """Handle resize events."""
         tight_layout(fig=self.axes.figure)
 
 

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -853,8 +853,8 @@ class _TimeViewer(object):
         win = self.plotter.app_window
         dpi = win.windowHandle().screen().logicalDotsPerInch()
         ratio = (1 - self.interactor_fraction) / self.interactor_fraction
-        w = self.plotter.geometry().width()
-        h = self.plotter.geometry().height() / ratio
+        w = self.interactor.geometry().width()
+        h = self.interactor.geometry().height() / ratio
         # Get the fractional components for the brain and mpl
         self.mpl_canvas = MplCanvas(self, w / dpi, h / dpi, dpi)
         xlim = [np.min(self.brain._data['time']),
@@ -867,11 +867,11 @@ class _TimeViewer(object):
             from PyQt5.QtCore import Qt
             canvas = self.mpl_canvas.canvas
             vlayout = self.plotter.frame.layout()
-            vlayout.removeWidget(self.plotter)
+            vlayout.removeWidget(self.interactor)
             self.splitter = splitter = QSplitter(
                 orientation=Qt.Vertical, parent=self.plotter.frame)
             vlayout.addWidget(splitter)
-            splitter.addWidget(self.plotter)
+            splitter.addWidget(self.interactor)
             splitter.addWidget(canvas)
         self.mpl_canvas.set_color(
             bg_color=self.brain._bg_color,

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -1139,8 +1139,16 @@ class _TimeViewer(object):
         if hemi == 'vol':
             ijk = np.unravel_index(
                 vertex_id, np.array(mesh.GetDimensions()) - 1, order='F')
-            center = np.empty(3)
-            mesh.GetCell(*ijk).GetCentroid(center)
+            # should just be GetCentroid(center), but apparently it's VTK9+:
+            # center = np.empty(3)
+            # voxel.GetCentroid(center)
+            voxel = mesh.GetCell(*ijk)
+            pts = voxel.GetPoints()
+            n_pts = pts.GetNumberOfPoints()
+            center = np.empty((n_pts, 3))
+            for ii in range(pts.GetNumberOfPoints()):
+                pts.GetPoint(ii, center[ii])
+            center = np.mean(center, axis=0)
         else:
             center = mesh.GetPoints().GetPoint(vertex_id)
         del mesh

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -56,13 +56,13 @@ class MplCanvas(object):
         else:
             parent = time_viewer.window
         # prefer constrained layout here but live with tight_layout otherwise
+        context = nullcontext
+        extra_events = ('resize',)
         try:
             context = rc_context({'figure.constrained_layout.use': True})
-        except KeyError:
-            context = nullcontext
-            extra_events = ('resize',)
-        else:
             extra_events = ()
+        except KeyError:
+            pass
         with context:
             self.fig = Figure(figsize=(width, height), dpi=dpi)
         self.canvas = FigureCanvasQTAgg(self.fig)

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -32,6 +32,11 @@ src_fname = path.join(data_path, 'subjects', 'sample', 'bem',
                       'sample-oct-6-src.fif')
 
 
+class _Collection(object):
+    def GetNumberOfItems(self):
+        return 0
+
+
 class TstVTKPicker(object):
     """Class to test cell picking."""
 
@@ -55,6 +60,10 @@ class TstVTKPicker(object):
                 in range(vtk_cell.GetNumberOfPoints())]
         self.point_id = cell[0]
         return self.mesh.points[self.point_id]
+
+    def GetProp3Ds(self):
+        # XXX should make this actually return some to test it
+        return _Collection()
 
 
 @testing.requires_testing_data

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -238,7 +238,11 @@ def test_brain_timeviewer(renderer_interactive):
     pytest.param('split', marks=pytest.mark.slowtest),
     pytest.param('both', marks=pytest.mark.slowtest),
 ])
-@pytest.mark.parametrize('src', ('surface', 'volume', 'mixed'))
+@pytest.mark.parametrize('src', [
+    'surface',
+    pytest.param('volume', marks=pytest.mark.slowtest),
+    pytest.param('mixed', marks=pytest.mark.slowtest),
+])
 def test_brain_timeviewer_traces(renderer_interactive, hemi, src, tmpdir):
     """Test _TimeViewer traces."""
     if renderer_interactive._get_3d_backend() != 'pyvista':

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -102,20 +102,20 @@ def test_brain(renderer):
     title = 'test'
     size = (300, 300)
 
+    kwargs = dict(subject_id=subject_id, subjects_dir=subjects_dir)
     with pytest.raises(ValueError, match='"size" parameter must be'):
-        _Brain(subject_id=subject_id, hemi=hemi, surf=surf, size=[1, 2, 3])
+        _Brain(hemi=hemi, surf=surf, size=[1, 2, 3], **kwargs)
     with pytest.raises(TypeError, match='figure'):
-        _Brain(subject_id=subject_id, hemi=hemi, surf=surf, figure='foo')
+        _Brain(hemi=hemi, surf=surf, figure='foo', **kwargs)
     with pytest.raises(TypeError, match='interaction'):
-        _Brain(subject_id=subject_id, hemi=hemi, surf=surf, interaction=0)
+        _Brain(hemi=hemi, surf=surf, interaction=0, **kwargs)
     with pytest.raises(ValueError, match='interaction'):
-        _Brain(subject_id=subject_id, hemi=hemi, surf=surf, interaction='foo')
+        _Brain(hemi=hemi, surf=surf, interaction='foo', **kwargs)
     with pytest.raises(KeyError):
-        _Brain(subject_id=subject_id, hemi='foo', surf=surf)
+        _Brain(hemi='foo', surf=surf, **kwargs)
 
-    brain = _Brain(subject_id, hemi=hemi, surf=surf, size=size,
-                   subjects_dir=subjects_dir, title=title,
-                   cortex=cortex)
+    brain = _Brain(hemi=hemi, surf=surf, size=size, title=title,
+                   cortex=cortex, **kwargs)
     # add_data
     stc = read_source_estimate(fname_stc)
     fmin = stc.data.min()

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -78,14 +78,17 @@ class TstVTKPicker(object):
             return self.mesh.points[self.point_id]
 
     def GetProp3Ds(self):
+        """Return all picked Prop3Ds."""
         return _Collection(self._actors)
 
     def GetRenderer(self):
+        """Return the "renderer"."""
         return self  # set this to also be the renderer and active camera
 
     GetActiveCamera = GetRenderer
 
     def GetPosition(self):
+        """Return the position."""
         return np.array(self.GetPickPosition()) - (0, 0, 100)
 
 

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -205,9 +205,11 @@ def test_brain_timeviewer(renderer_interactive):
     """Test _TimeViewer primitives."""
     if renderer_interactive._get_3d_backend() != 'pyvista':
         pytest.skip('TimeViewer tests only supported on PyVista')
-    brain_data = _create_testing_brain(hemi='both')
+    brain_data = _create_testing_brain(hemi='both', show_traces=False)
 
-    time_viewer = _TimeViewer(brain_data)
+    with pytest.raises(RuntimeError, match='already'):
+        _TimeViewer(brain_data)
+    time_viewer = brain_data.time_viewer
     time_viewer.time_call(value=0)
     time_viewer.orientation_call(value='lat', update_widget=True)
     time_viewer.orientation_call(value='medial', update_widget=True)
@@ -242,8 +244,13 @@ def test_brain_timeviewer_traces(renderer_interactive, hemi, src, tmpdir):
     if renderer_interactive._get_3d_backend() != 'pyvista':
         pytest.skip('Only PyVista supports traces')
     brain_data = _create_testing_brain(
-        hemi=hemi, surf='white', src=src)
-    time_viewer = _TimeViewer(brain_data, show_traces=True)
+        hemi=hemi, surf='white', src=src,
+        volume_options=dict(resolution=None),  # for speed
+    )
+    with pytest.raises(RuntimeError, match='already'):
+        _TimeViewer(brain_data)
+    time_viewer = brain_data.time_viewer
+    assert time_viewer.show_traces
     assert hasattr(time_viewer, "picked_points")
     assert hasattr(time_viewer, "_spheres")
 
@@ -342,8 +349,7 @@ def test_brain_linkviewer(renderer_interactive, travis_macos):
         pytest.skip('Linkviewer only supported on PyVista')
     if travis_macos:
         pytest.skip('Linkviewer tests unstable on Travis macOS')
-    brain_data = _create_testing_brain(hemi='split')
-    _TimeViewer(brain_data)
+    brain_data = _create_testing_brain(hemi='split', show_traces=False)
 
     link_viewer = _LinkViewer(
         [brain_data],

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -71,8 +71,10 @@ def test_brain(renderer):
         _Brain(subject_id=subject_id, hemi=hemi, surf=surf, size=[1, 2, 3])
     with pytest.raises(TypeError, match='figure'):
         _Brain(subject_id=subject_id, hemi=hemi, surf=surf, figure='foo')
-    with pytest.raises(ValueError, match='interaction'):
+    with pytest.raises(TypeError, match='interaction'):
         _Brain(subject_id=subject_id, hemi=hemi, surf=surf, interaction=0)
+    with pytest.raises(ValueError, match='interaction'):
+        _Brain(subject_id=subject_id, hemi=hemi, surf=surf, interaction='foo')
     with pytest.raises(KeyError):
         _Brain(subject_id=subject_id, hemi='foo', surf=surf)
 

--- a/mne/viz/_brain/view.py
+++ b/mne/viz/_brain/view.py
@@ -41,5 +41,5 @@ rh_views_dict = _rh_views_dict.copy()
 for k, v in _rh_views_dict.items():
     rh_views_dict[k[:3]] = v
 # XXX shouldn't need the both/split
-views_dicts = dict(lh=lh_views_dict, rh=rh_views_dict, vol=lh_views_dict,
-                   both=lh_views_dict, split=lh_views_dict)
+views_dicts = dict(lh=lh_views_dict, vol=lh_views_dict, both=lh_views_dict,
+                   rh=rh_views_dict)

--- a/mne/viz/_brain/view.py
+++ b/mne/viz/_brain/view.py
@@ -40,6 +40,5 @@ for k, v in _lh_views_dict.items():
 rh_views_dict = _rh_views_dict.copy()
 for k, v in _rh_views_dict.items():
     rh_views_dict[k[:3]] = v
-# XXX shouldn't need the both/split
 views_dicts = dict(lh=lh_views_dict, vol=lh_views_dict, both=lh_views_dict,
                    rh=rh_views_dict)

--- a/mne/viz/_brain/view.py
+++ b/mne/viz/_brain/view.py
@@ -40,5 +40,6 @@ for k, v in _lh_views_dict.items():
 rh_views_dict = _rh_views_dict.copy()
 for k, v in _rh_views_dict.items():
     rh_views_dict[k[:3]] = v
+# XXX shouldn't need the both/split
 views_dicts = dict(lh=lh_views_dict, rh=rh_views_dict, vol=lh_views_dict,
-                   both=lh_views_dict)
+                   both=lh_views_dict, split=lh_views_dict)

--- a/mne/viz/_brain/view.py
+++ b/mne/viz/_brain/view.py
@@ -6,34 +6,39 @@
 #
 # License: Simplified BSD
 
-from collections import namedtuple
-
-
-View = namedtuple('View', 'elev azim')
-
-lh_views_dict = {'lateral': View(azim=180., elev=90.),
-                 'medial': View(azim=0., elev=90.0),
-                 'rostral': View(azim=90., elev=90.),
-                 'caudal': View(azim=270., elev=90.),
-                 'dorsal': View(azim=180., elev=0.),
-                 'ventral': View(azim=180., elev=180.),
-                 'frontal': View(azim=120., elev=80.),
-                 'parietal': View(azim=-120., elev=60.)}
-rh_views_dict = {'lateral': View(azim=180., elev=-90.),
-                 'medial': View(azim=0., elev=-90.0),
-                 'rostral': View(azim=-90., elev=-90.),
-                 'caudal': View(azim=90., elev=-90.),
-                 'dorsal': View(azim=180., elev=0.),
-                 'ventral': View(azim=180., elev=180.),
-                 'frontal': View(azim=60., elev=80.),
-                 'parietal': View(azim=-60., elev=60.)}
+_lh_views_dict = {
+    'lateral': dict(azimuth=180., elevation=90.),
+    'medial': dict(azimuth=0., elevation=90.0),
+    'rostral': dict(azimuth=90., elevation=90.),
+    'caudal': dict(azimuth=270., elevation=90.),
+    'dorsal': dict(azimuth=180., elevation=0.),
+    'ventral': dict(azimuth=180., elevation=180.),
+    'frontal': dict(azimuth=120., elevation=80.),
+    'parietal': dict(azimuth=-120., elevation=60.),
+    'sagittal': dict(azimuth=180., elevation=-90.),
+    'coronal': dict(azimuth=90., elevation=-90.),
+    'axial': dict(azimuth=180., elevation=0., roll=180),
+}
+_rh_views_dict = {
+    'lateral': dict(azimuth=180., elevation=-90.),
+    'medial': dict(azimuth=0., elevation=-90.0),
+    'rostral': dict(azimuth=-90., elevation=-90.),
+    'caudal': dict(azimuth=90., elevation=-90.),
+    'dorsal': dict(azimuth=180., elevation=0.),
+    'ventral': dict(azimuth=180., elevation=180.),
+    'frontal': dict(azimuth=60., elevation=80.),
+    'parietal': dict(azimuth=-60., elevation=60.),
+    'sagittal': dict(azimuth=180., elevation=-90.),
+    'coronal': dict(azimuth=90., elevation=-90.),
+    'axial': dict(azimuth=180., elevation=0., roll=180),
+}
 # add short-size version entries into the dict
-_lh_views_dict = dict()
-for k, v in lh_views_dict.items():
-    _lh_views_dict[k[:3]] = v
-lh_views_dict.update(_lh_views_dict)
+lh_views_dict = _lh_views_dict.copy()
+for k, v in _lh_views_dict.items():
+    lh_views_dict[k[:3]] = v
 
-_rh_views_dict = dict()
-for k, v in rh_views_dict.items():
-    _rh_views_dict[k[:3]] = v
-rh_views_dict.update(_rh_views_dict)
+rh_views_dict = _rh_views_dict.copy()
+for k, v in _rh_views_dict.items():
+    rh_views_dict[k[:3]] = v
+views_dicts = dict(lh=lh_views_dict, rh=rh_views_dict, vol=lh_views_dict,
+                   both=lh_views_dict)

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -89,16 +89,18 @@ class _Renderer(_BaseRenderer):
     def scene(self):
         return self.fig
 
-    def set_interactive(self):
+    def set_interaction(self, interaction):
         from tvtk.api import tvtk
         if self.fig.scene is not None:
             self.fig.scene.interactor.interactor_style = \
-                tvtk.InteractorStyleTerrain()
+                getattr(tvtk, f'InteractorStyle{interaction.capitalize()}')()
 
     def mesh(self, x, y, z, triangles, color, opacity=1.0, shading=False,
              backface_culling=False, scalars=None, colormap=None,
              vmin=None, vmax=None, interpolate_before_map=True,
-             representation='surface', line_width=1., normals=None, **kwargs):
+             representation='surface', line_width=1., normals=None,
+             pickable=None, **kwargs):
+        # normals and pickable are unused
         if color is not None:
             color = _check_color(color)
         if color is not None and isinstance(color, np.ndarray) \

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -299,10 +299,10 @@ class _Renderer(_BaseRenderer):
         _close_3d_figure(figure=self.fig)
 
     def set_camera(self, azimuth=None, elevation=None, distance=None,
-                   focalpoint=None):
+                   focalpoint=None, roll=None):
         _set_3d_view(figure=self.fig, azimuth=azimuth,
                      elevation=elevation, distance=distance,
-                     focalpoint=focalpoint)
+                     focalpoint=focalpoint, roll=roll)
 
     def reset_camera(self):
         renderer = getattr(self.fig.scene, 'renderer', None)
@@ -436,12 +436,12 @@ def _close_all():
     mlab.close(all=True)
 
 
-def _set_3d_view(figure, azimuth, elevation, focalpoint, distance):
+def _set_3d_view(figure, azimuth, elevation, focalpoint, distance, roll=None):
     from mayavi import mlab
     with warnings.catch_warnings(record=True):  # traits
         with SilenceStdout():
             mlab.view(azimuth, elevation, distance,
-                      focalpoint=focalpoint, figure=figure)
+                      focalpoint=focalpoint, figure=figure, roll=roll)
             mlab.draw(figure)
 
 

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -490,16 +490,16 @@ def _take_3d_screenshot(figure, mode='rgb', filename=None):
             figure_size = figure._window_size
         else:
             figure_size = figure.scene._renwin.size
-        return np.zeros(tuple(figure_size) + (ndim,), np.uint8)
+        img = np.zeros(tuple(figure_size) + (ndim,), np.uint8)
     else:
         from pyface.api import GUI
         gui = GUI()
         gui.process_events()
         with warnings.catch_warnings(record=True):  # traits
             img = mlab.screenshot(figure, mode=mode)
-        if isinstance(filename, str):
-            _save_figure(img, filename)
-        return img
+    if isinstance(filename, str):
+        _save_figure(img, filename)
+    return img
 
 
 @contextmanager

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -830,6 +830,7 @@ def _update_picking_callback(plotter,
         vtk.vtkCommand.EndPickEvent,
         on_pick
     )
+    picker.SetVolumeOpacityIsovalue(0.)
     plotter.picker = picker
 
 

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -216,8 +216,8 @@ class _Renderer(_BaseRenderer):
     def scene(self):
         return self.figure
 
-    def set_interactive(self):
-        self.plotter.enable_terrain_style()
+    def set_interaction(self, interaction):
+        getattr(self.plotter, f'enable_{interaction}_style')()
 
     def polydata(self, mesh, color=None, opacity=1.0, normals=None,
                  backface_culling=False, scalars=None, colormap=None,

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -201,7 +201,7 @@ class _Renderer(_BaseRenderer):
             yield
         finally:
             for _ in range(2):
-                self.plotter.app.processEvents()
+                _process_events(self.plotter)
             self.plotter.interactor.setMinimumSize(0, 0)
 
     def subplot(self, x, y):
@@ -535,9 +535,9 @@ class _Renderer(_BaseRenderer):
         _close_3d_figure(figure=self.figure)
 
     def set_camera(self, azimuth=None, elevation=None, distance=None,
-                   focalpoint=None):
+                   focalpoint=None, roll=None):
         _set_3d_view(self.figure, azimuth=azimuth, elevation=elevation,
-                     distance=distance, focalpoint=focalpoint)
+                     distance=distance, focalpoint=focalpoint, roll=roll)
 
     def reset_camera(self):
         self.plotter.reset_camera()
@@ -661,7 +661,7 @@ def _get_camera_direction(focalpoint, position):
     return r, theta, phi, focalpoint
 
 
-def _set_3d_view(figure, azimuth, elevation, focalpoint, distance):
+def _set_3d_view(figure, azimuth, elevation, focalpoint, distance, roll=None):
     position = np.array(figure.plotter.camera_position[0])
     focalpoint = np.array(figure.plotter.camera_position[1])
     r, theta, phi, fp = _get_camera_direction(focalpoint, position)
@@ -670,20 +670,19 @@ def _set_3d_view(figure, azimuth, elevation, focalpoint, distance):
         phi = _deg2rad(azimuth)
     if elevation is not None:
         theta = _deg2rad(elevation)
+    if roll is not None:
+        roll = _deg2rad(roll)
 
     renderer = figure.plotter.renderer
     bounds = np.array(renderer.ComputeVisiblePropBounds())
-    if distance is not None:
-        r = distance
-    else:
-        r = max(bounds[1::2] - bounds[::2]) * 2.0
-        distance = r
+    if distance is None:
+        distance = max(bounds[1::2] - bounds[::2]) * 2.0
+    distance = distance / 2.
 
     if focalpoint is not None:
-        cen = np.asarray(focalpoint)
+        focalpoint = np.asarray(focalpoint)
     else:
-        cen = (bounds[1::2] + bounds[::2]) * 0.5
-        focalpoint = cen
+        focalpoint = (bounds[1::2] + bounds[::2]) * 0.5
 
     # Now calculate the view_up vector of the camera.  If the view up is
     # close to the 'z' axis, the view plane normal is parallel to the
@@ -694,15 +693,19 @@ def _set_3d_view(figure, azimuth, elevation, focalpoint, distance):
         view_up = [np.sin(phi), np.cos(phi), 0]
 
     position = [
-        r * np.cos(phi) * np.sin(theta),
-        r * np.sin(phi) * np.sin(theta),
-        r * np.cos(theta)]
+        distance * np.cos(phi) * np.sin(theta),
+        distance * np.sin(phi) * np.sin(theta),
+        distance * np.cos(theta)]
     figure.plotter.camera_position = [
-        position, cen, view_up]
+        position, focalpoint, view_up]
+    if roll is not None:
+        figure.plotter.camera.SetRoll(roll)
+    # set the distance
 
     figure.plotter.renderer._azimuth = azimuth
     figure.plotter.renderer._elevation = elevation
     figure.plotter.renderer._distance = distance
+    figure.plotter.renderer._roll = roll
 
 
 def _set_3d_title(figure, title, size=16):
@@ -739,7 +742,9 @@ def _take_3d_screenshot(figure, mode='rgb', filename=None):
 
 def _process_events(plotter, show=False):
     if hasattr(plotter, 'app'):
-        plotter.app.processEvents()
+        with warnings.catch_warnings(record=True):
+            warnings.filterwarnings('ignore', 'constrained_layout')
+            plotter.app.processEvents()
         if show:
             plotter.app_window.show()
 
@@ -764,12 +769,9 @@ def _set_volume_range(volume, ctable, alpha, rng):
     import vtk
     color_tf = vtk.vtkColorTransferFunction()
     opacity_tf = vtk.vtkPiecewiseFunction()
-    assert ctable.shape == (256, 4)
-    for ii, color in enumerate(ctable):
-        loc = ii / 255.
+    for loc, color in zip(np.linspace(*rng, num=len(ctable)), ctable):
         color_tf.AddRGBPoint(loc, *color[:-1])
-        opacity_tf.AddPoint(
-            loc, color[-1] * alpha / 255. / 255.)
+        opacity_tf.AddPoint(loc, color[-1] * alpha / 255. / (len(ctable) - 1))
     color_tf.ClampingOn()
     opacity_tf.ClampingOn()
     volume.GetProperty().SetColor(color_tf)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -676,7 +676,7 @@ def _set_3d_view(figure, azimuth, elevation, focalpoint, distance, roll=None):
     renderer = figure.plotter.renderer
     bounds = np.array(renderer.ComputeVisiblePropBounds())
     if distance is None:
-        distance = max(bounds[1::2] - bounds[::2]) * 1.5
+        distance = max(bounds[1::2] - bounds[::2]) * 2.0
 
     if focalpoint is not None:
         focalpoint = np.asarray(focalpoint)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -676,8 +676,7 @@ def _set_3d_view(figure, azimuth, elevation, focalpoint, distance, roll=None):
     renderer = figure.plotter.renderer
     bounds = np.array(renderer.ComputeVisiblePropBounds())
     if distance is None:
-        distance = max(bounds[1::2] - bounds[::2]) * 2.0
-    distance = distance / 2.
+        distance = max(bounds[1::2] - bounds[::2]) * 1.5
 
     if focalpoint is not None:
         focalpoint = np.asarray(focalpoint)

--- a/mne/viz/backends/base_renderer.py
+++ b/mne/viz/backends/base_renderer.py
@@ -28,8 +28,8 @@ class _BaseRenderer(metaclass=ABCMeta):
         pass
 
     @abstractclassmethod
-    def set_interactive(self):
-        """Enable interactive mode."""
+    def set_interaction(self, interaction):
+        """Set interaction mode."""
         pass
 
     @abstractclassmethod

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -107,7 +107,8 @@ def test_3d_backend(renderer):
         bgcolor=win_color,
         smooth_shading=True,
     )
-    rend.set_interactive()
+    for interaction in ('terrain', 'trackball'):
+        rend.set_interaction(interaction)
 
     # use mesh
     mesh_data = rend.mesh(

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -758,7 +758,7 @@ def test_plot_source_estimates(renderer_interactive, all_src_types_inv_evoked,
     with pytest.raises(ValueError, match='unknown'):
         meth(**these_kwargs)
     # with resampling (actually downsampling but it's okay)
-    these_kwargs['volume_options'] = dict(resolution=20.)
+    these_kwargs['volume_options'] = dict(resolution=20., surface_alpha=0.)
     brain = meth(**these_kwargs)
     brain.close()
     del brain

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -709,7 +709,9 @@ def test_plot_source_estimates(renderer_interactive, all_src_types_inv_evoked,
     meth = getattr(stc, meth)
     kwargs = dict(subject='sample', subjects_dir=subjects_dir,
                   time_viewer=False, show_traces=False,  # for speed
-                  smoothing_steps=1, verbose='error', src=inv['src'])
+                  smoothing_steps=1, verbose='error', src=inv['src'],
+                  volume_options=dict(resolution=None),  # for speed
+                  )
     if pick_ori != 'vector':
         kwargs['surface'] = 'white'
     # Mayavi can't handle non-surface
@@ -748,12 +750,16 @@ def test_plot_source_estimates(renderer_interactive, all_src_types_inv_evoked,
     brain.close()
     assert brain._subplot_shape == (1, 3)
     del brain
+    these_kwargs = kwargs.copy()
+    these_kwargs['volume_options'] = dict(blending='foo')
     with pytest.raises(ValueError, match='mip'):
-        meth(volume_options=dict(blending='foo'), **kwargs)
+        meth(**these_kwargs)
+    these_kwargs['volume_options'] = dict(badkey='foo')
     with pytest.raises(ValueError, match='unknown'):
-        meth(volume_options=dict(badkey='foo'), **kwargs)
-    # no resampling
-    brain = meth(volume_options=dict(resolution=None), **kwargs)
+        meth(**these_kwargs)
+    # with resampling (actually downsampling but it's okay)
+    these_kwargs['volume_options'] = dict(resolution=20.)
+    brain = meth(**these_kwargs)
     brain.close()
     del brain
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ addopts =
     --doctest-ignore-import-errors --junit-xml=junit-results.xml
     --ignore=doc --ignore=logo --ignore=examples --ignore=tutorials
     --ignore=mne/gui/_*.py --ignore=mne/externals --ignore=mne/icons
+    --capture=sys
 junit_family = xunit2
 
 [pydocstyle]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ select = A,E,F,W,C
 
 [tool:pytest]
 addopts =
-    --durations=20 --doctest-modules -ra --cov-report=
+    --durations=20 --doctest-modules -ra --cov-report= --tb=short
     --doctest-ignore-import-errors --junit-xml=junit-results.xml
     --ignore=doc --ignore=logo --ignore=examples --ignore=tutorials
     --ignore=mne/gui/_*.py --ignore=mne/externals --ignore=mne/icons

--- a/tutorials/source-modeling/plot_beamformer_lcmv.py
+++ b/tutorials/source-modeling/plot_beamformer_lcmv.py
@@ -195,20 +195,33 @@ stc_vec = apply_lcmv(evoked, filters_vec, max_ori_out='signed')
 ###############################################################################
 # Visualize the reconstructed source activity
 # -------------------------------------------
-# We can visualize the source estimate in different ways, e.g. as an overlay
-# onto the MRI or as a glass brain.
+# We can visualize the source estimate in different ways, e.g. as a volume
+# rendering, an overlay onto the MRI, or as an overlay onto a glass brain.
+#
 # The plots for the scalar beamformer show brain activity in the right temporal
 # lobe around 100 ms post stimulus. This is expected given the left-ear
 # auditory stimulation of the experiment.
+#
+# Volumetric rendering (3D)
+# ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 lims = [0.3, 0.45, 0.6]
-
 kwargs = dict(src=forward['src'], subject='sample', subjects_dir=subjects_dir,
               initial_time=0.087, verbose=True)
+
+stc.plot_3d(clim=dict(kind='value', pos_lims=lims), hemi='rh', views='lat',
+            **kwargs)
+
+###############################################################################
+# On MRI slices (orthoview; 2D)
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 stc.plot(mode='stat_map', clim=dict(kind='value', pos_lims=lims), **kwargs)
 
 ###############################################################################
+# On MNI glass brain (orthoview; 2D)
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 stc.plot(mode='glass_brain', clim=dict(kind='value', lims=lims), **kwargs)
 
 ###############################################################################
@@ -219,6 +232,10 @@ stc.plot(mode='glass_brain', clim=dict(kind='value', lims=lims), **kwargs)
 
 # sphinx_gallery_thumbnail_number = 5
 
+stc_vec.plot_3d(clim=dict(kind='value', lims=lims), hemi='rh', views='lat',
+                **kwargs)
+
+###############################################################################
 stc_vec.plot(mode='stat_map', clim=dict(kind='value', pos_lims=lims), **kwargs)
 
 ###############################################################################

--- a/tutorials/source-modeling/plot_beamformer_lcmv.py
+++ b/tutorials/source-modeling/plot_beamformer_lcmv.py
@@ -209,8 +209,9 @@ lims = [0.3, 0.45, 0.6]
 kwargs = dict(src=forward['src'], subject='sample', subjects_dir=subjects_dir,
               initial_time=0.087, verbose=True)
 
-stc.plot_3d(clim=dict(kind='value', pos_lims=lims), hemi='rh', views='lat',
-            **kwargs)
+stc.plot_3d(clim=dict(kind='value', pos_lims=lims), hemi='both',
+            views=['sagittal', 'coronal', 'axial'], size=(800, 300),
+            view_layout='horizontal', show_traces=0.4, **kwargs)
 
 ###############################################################################
 # On MRI slices (orthoview; 2D)
@@ -232,8 +233,9 @@ stc.plot(mode='glass_brain', clim=dict(kind='value', lims=lims), **kwargs)
 
 # sphinx_gallery_thumbnail_number = 5
 
-stc_vec.plot_3d(clim=dict(kind='value', lims=lims), hemi='rh', views='lat',
-                **kwargs)
+stc_vec.plot_3d(clim=dict(kind='value', lims=lims), hemi='both',
+                views=['sagittal', 'coronal', 'axial'], size=(800, 300),
+                view_layout='horizontal', show_traces=0.4, **kwargs)
 
 ###############################################################################
 stc_vec.plot(mode='stat_map', clim=dict(kind='value', pos_lims=lims), **kwargs)


### PR DESCRIPTION
Closes #7648

- [x] Vector initialization
- [x] Vector updates with time-clicking and clims
- [x] Volume initialization (should be unified / not rely on vector-ness, just happen in `set_time_point` like everything else)
- [x] Volume updates (moving scalar setting to `set_time_point` should fix this)
- [x] Volume updates with time-clicking
- [x] Actually make it look good
- [x] Make it work for non-vector `stc.plot`
- [x] Volume-only plotting
- [x] Fix bug with pos_lims for volumetric plotting
- [x] Fix bug with volumetric plotting on macOS + VTK9 (https://github.com/pyvista/pyvista/issues/850)
- [x] Add colorbar for volume-only (needs appropriate actor, which we don't have for vol -- maybe fake one?)
- [x] Add terrain interaction
- [x] Volume updates with clims (currently requires changing the time point for some reason)
- [x] Fix bugs with multi-views and `hemi='split'` with vectors, actors, etc.
- [x] Deal with `offset` / `surface` issues, esp. when `hemi='split'` and/or `hemi='lh' / 'rh'` only
- [x] Add GFP
- [x] Add picking of max point from the volumes like we have for left/right hemi already
- [x] Clicking on volume: needs to be maximum along the ray
- [x] Clicking: needs to remove any spheres in ray path, if no spheres, then add new points
- [x] Add horizontal layout
- [x] Add QSplitter for configurable sizing
- [x] Add `show_traces=<float>` support to specify the fraction to dedicate to the time viewer
- [x] Fix actor transfer mapping for volume-only case (maybe use the `color_tf` directly?)
- [x] Divergent volume
- [x] Fix existing broken test
- [x] Sort out how to add actors to scenes (do we need different meshes? different actors? neither?)
- [x] Add tests for point picking of volumes and mixed
- [x] Add tests for divergent, view_layout, volume_options

@GuillaumeFavelier I think I have this at a point where I've worked out the transformations and data injection:

![Screenshot from 2020-07-27 17-02-27](https://user-images.githubusercontent.com/2365790/88592026-51a28d00-d02b-11ea-82cf-650b787fbdc8.png)

If you `mne.minimum_norm.write_inverse_operator('mixed-inv.fif', inverse_operator)` the inv operator from the modified `plot_mixed_source_space_inverse.py`, you can iterate with this much quicker script:

<details>

```
import os.path as op
import mne
from mne.minimum_norm import read_inverse_operator, apply_inverse

# Set dir
data_path = mne.datasets.sample.data_path()
subject = 'sample'
data_dir = op.join(data_path, 'MEG', subject)
subjects_dir = op.join(data_path, 'subjects')
fname_evoked = data_dir + '/sample_audvis-ave.fif'
fname_cov = data_dir + '/sample_audvis-shrunk-cov.fif'
fname_trans = data_dir + '/sample_audvis_raw-trans.fif'
condition = 'Left Auditory'
evoked = mne.read_evokeds(fname_evoked, condition=condition,
                          baseline=(None, 0))
noise_cov = mne.read_cov(fname_cov)
inv = read_inverse_operator('mixed-inv.fif')
stc_vec = apply_inverse(evoked, inv, pick_ori='vector')
with mne.viz.use_3d_backend('pyvista'):
    stc_vec.plot(views='rostral', hemi='both', src=inv['src'],
                 trans=fname_trans, initial_time=0.180,
                 subjects_dir=subjects_dir)
```

</details>

Can you take over and fit this into the `_Brain` + PyVista framework better? I have a checklist at the top for how I think it should go but feel free to update and change and push commits as you want.