### PR TITLE
MRG: Manually calculate channel location for NIRS data

### DIFF
--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -249,15 +249,10 @@ class RawNIRX(BaseRaw):
             det = int(requested_channels[ch_idx2, 1]) - 1
             info['chs'][ch_idx2 * 2]['loc'][6:9] = det_locs[det, :]
             info['chs'][ch_idx2 * 2 + 1]['loc'][6:9] = det_locs[det, :]
-            # Store channel location
-            # Channel locations for short channels are bodged,
-            # for short channels use the source location.
-            if det + 1 in short_det:
-                info['chs'][ch_idx2 * 2]['loc'][:3] = src_locs[src, :]
-                info['chs'][ch_idx2 * 2 + 1]['loc'][:3] = src_locs[src, :]
-            else:
-                info['chs'][ch_idx2 * 2]['loc'][:3] = ch_locs[ch_idx2, :]
-                info['chs'][ch_idx2 * 2 + 1]['loc'][:3] = ch_locs[ch_idx2, :]
+            # Store channel location as midpoint between source and detector.
+            midpoint = (src_locs[src, :] + det_locs[det, :]) / 2
+            info['chs'][ch_idx2 * 2]['loc'][:3] = midpoint
+            info['chs'][ch_idx2 * 2 + 1]['loc'][:3] = midpoint
             info['chs'][ch_idx2 * 2]['loc'][9] = fnirs_wavelengths[0]
             info['chs'][ch_idx2 * 2 + 1]['loc'][9] = fnirs_wavelengths[1]
 

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -167,9 +167,11 @@ class RawSNIRF(BaseRaw):
                                                chan + '/detectorIndex'))[0])
                 wve_idx = int(np.array(dat.get('nirs/data1/' +
                                                chan + '/wavelengthIndex'))[0])
-                info['chs'][idx]['loc'][0:3] = srcPos3D[src_idx - 1, :] / scal
                 info['chs'][idx]['loc'][3:6] = srcPos3D[src_idx - 1, :] / scal
                 info['chs'][idx]['loc'][6:9] = detPos3D[det_idx - 1, :] / scal
+                midpoint = (info['chs'][idx]['loc'][3:6] +
+                            info['chs'][idx]['loc'][6:9]) / 2
+                info['chs'][idx]['loc'][0:3] =midpoint
                 info['chs'][idx]['loc'][9] = fnirs_wavelengths[wve_idx - 1]
 
             super(RawSNIRF, self).__init__(info, preload, filenames=[fname],

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -171,7 +171,7 @@ class RawSNIRF(BaseRaw):
                 info['chs'][idx]['loc'][6:9] = detPos3D[det_idx - 1, :] / scal
                 midpoint = (info['chs'][idx]['loc'][3:6] +
                             info['chs'][idx]['loc'][6:9]) / 2
-                info['chs'][idx]['loc'][0:3] =midpoint
+                info['chs'][idx]['loc'][0:3] = midpoint
                 info['chs'][idx]['loc'][9] = fnirs_wavelengths[wve_idx - 1]
 
             super(RawSNIRF, self).__init__(info, preload, filenames=[fname],

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -169,6 +169,7 @@ class RawSNIRF(BaseRaw):
                                                chan + '/wavelengthIndex'))[0])
                 info['chs'][idx]['loc'][3:6] = srcPos3D[src_idx - 1, :] / scal
                 info['chs'][idx]['loc'][6:9] = detPos3D[det_idx - 1, :] / scal
+                # Store channel as mid point
                 midpoint = (info['chs'][idx]['loc'][3:6] +
                             info['chs'][idx]['loc'][6:9]) / 2
                 info['chs'][idx]['loc'][0:3] = midpoint


### PR DESCRIPTION
#### Reference issue
Follows https://github.com/mne-tools/mne-nirs/pull/146/files/9e103b071bafc988f93cab543f68571ed8ae5cf2#diff-97adcb285086e704b219a0e18ede4576. I noticed I was unable to exactly recreate the channel locations as we had this hack in MNE to deal with bad channel locations stored in nirx files.


#### What does this implement/fix?
Previously "channel" locations were read from the nirx files, and these are the midpoints between light source and detector. But these weren't coded correctly for detectors that were very close to sources, so we just took the source location in that instance. Now I calculate the channel location as the midpoint between source and detector. The result is basically the same, except the result is now consistent even for short channels.

#### Additional information
Channels aren't defined for all vendors. So it makes sense to calculate it ourselves in a consistent manner and do this across all file types.

Just some extra info on notation.  
Source: Physical device that emits light.  
Detector: Physical device that measures light.  
Channel: Common construct used in papers to describe where we are measuring, usually the mid point between source and detector. 