### PR TITLE
FIX: pick_types removes keys for dropped channels in reject, flat

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -15,6 +15,8 @@ Current (0.21.dev0)
 Changelog
 ~~~~~~~~~
 
+- Modified :meth:`mne.Epochs.pick_types` to remove dropped channel types from `reject` and `flat` dictionaries by `Rahul Nadkarni`_
+
 - Allow picking channels in raw instances (e.g., :meth:`mne.io.Raw.pick_types`) without preloading data, by `Eric Larson`_
 
 - :meth:`mne.preprocessing.ICA.plot_sources` now plots annotation markers similar to :meth:`mne.io.Raw.plot` by `Luke Bloy`_

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -311,3 +311,5 @@
 .. _Jan Sedivy: https://github.com/honzaseda
 
 .. _Johann Benerradi: https://github.com/HanBnrd
+
+.. _Rahul Nadkarni: https://github.com/rahuln

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -740,7 +740,23 @@ class UpdateChannelsMixin(object):
             ias=ias, syst=syst, seeg=seeg, dipole=dipole, gof=gof, bio=bio,
             ecog=ecog, fnirs=fnirs, include=include, exclude=exclude,
             selection=selection)
-        return self._pick_drop_channels(idx)
+
+        self._pick_drop_channels(idx)
+
+        # remove dropped channel types from reject and flat
+        if getattr(self, 'reject', None) is not None:
+            # use list(self.reject) to avoid RuntimeError for changing
+            # dictionary size during iteration
+            for ch_type in list(self.reject):
+                if ch_type not in self:
+                    del self.reject[ch_type]
+
+        if getattr(self, 'flat', None) is not None:
+            for ch_type in list(self.flat):
+                if ch_type not in self:
+                    del self.flat[ch_type]
+
+        return self
 
     def pick_channels(self, ch_names, ordered=False):
         """Pick some channels.

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -3003,4 +3003,20 @@ def test_epochs_get_data_item(preload):
     assert_array_equal(one_data, one_epo.get_data())
 
 
+def test_pick_types_reject_flat_keys():
+    """Test that epochs.pick_types removes keys from reject/flat."""
+    raw, events, _ = _get_data()
+    event_id = {'a/1': 1, 'a/2': 2, 'b/1': 3, 'b/2': 4}
+    picks = pick_types(raw.info, meg=True, eeg=True, ecg=True, eog=True)
+    epochs = Epochs(raw, events, event_id, preload=True, picks=picks,
+                    reject=dict(grad=1e-10, mag=1e-10, eeg=1e-3, eog=1e-3),
+                    flat=dict(grad=1e-16, mag=1e-16, eeg=1e-16, eog=1e-16))
+
+    assert sorted(epochs.reject.keys()) == ['eeg', 'eog', 'grad', 'mag']
+    assert sorted(epochs.flat.keys()) == ['eeg', 'eog', 'grad', 'mag']
+    epochs.pick_types(meg=True, eeg=False, ecg=False, eog=False)
+    assert sorted(epochs.reject.keys()) == ['grad', 'mag']
+    assert sorted(epochs.flat.keys()) == ['grad', 'mag']
+
+
 run_tests_if_main()


### PR DESCRIPTION
#### Reference issue
Fixes #8070.


#### What does this implement/fix?
Removes keys for dropped channels from `reject` and `flat` when calling `pick_types` in `mne.channels.channels.UpdateChannelsMixin`.


#### Additional information
Not sure if this is the right fix, but seems like this was the best way to access `reject` and `flat` when `pick_types` is called from any of `Raw`, `Evoked`, or `Epochs`.
