### PR TITLE
Fixing inconsistent documentation crop BaseEpochs, Evoked

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1505,14 +1505,12 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         Returns
         -------
         epochs : instance of Epochs
-            The cropped epochs.
+            The cropped epochs object, modified in-place.
 
         Notes
         -----
         Unlike Python slices, MNE time intervals include both their end points;
         crop(tmin, tmax) returns the interval tmin <= t <= tmax.
-
-        Note that the object is modified in place.
         """
         # XXX this could be made to work on non-preloaded data...
         _check_preload(self, 'Modifying data of epochs')

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1509,8 +1509,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
 
         Notes
         -----
-        Unlike Python slices, MNE time intervals include both their end points;
-        crop(tmin, tmax) returns the interval tmin <= t <= tmax.
+        %(notes_tmax_included_by_default)s
         """
         # XXX this could be made to work on non-preloaded data...
         _check_preload(self, 'Modifying data of epochs')

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -220,7 +220,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         Returns
         -------
         evoked : instance of Evoked
-            The cropped Evoked object.
+            The cropped Evoked object, modified in-place.
 
         Notes
         -----

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -224,8 +224,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         Notes
         -----
-        Unlike Python slices, MNE time intervals include both their end points;
-        crop(tmin, tmax) returns the interval tmin <= t <= tmax.
+        %(notes_tmax_included_by_default)s
         """
         mask = _time_mask(self.times, tmin, tmax, sfreq=self.info['sfreq'],
                           include_tmax=include_tmax)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -57,6 +57,12 @@ include_tmax : bool
 
     .. versionadded:: 0.19
 """
+docdict['notes_tmax_included_by_default'] = """
+Unlike Python slices, MNE time intervals by default include **both**
+their end points; ``crop(tmin, tmax)`` returns the interval
+``tmin <= t <= tmax``. Pass ``include_tmax=False`` to specify the half-open
+interval ``tmin <= t < tmax`` instead.
+"""
 docdict['raw_tmin'] = """
 tmin : float
     Start time of the raw data to use in seconds (must be >= 0).


### PR DESCRIPTION
#### Reference issue
Fixes #8069 .


#### What does this implement/fix?
Fixes the docstrings of BaseEpochs and Evoked, to make the documentation consistent and correct across BaseRaw/BaseEpochs/Evoked