### PR TITLE
MRG: Add reading of custom MNE info to SNIRF

### DIFF
--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -168,6 +168,8 @@ class RawNIRX(BaseRaw):
             subject_info['sex'] = FIFF.FIFFV_SUBJ_SEX_MALE
         elif subject_info['sex'] in {'F', 'Female', '2'}:
             subject_info['sex'] = FIFF.FIFFV_SUBJ_SEX_FEMALE
+        else:
+            subject_info['sex'] = FIFF.FIFFV_SUBJ_SEX_UNKNOWN
         # NIRStar does not record an id, or handedness by default
 
         # Read information about probe/montage/optodes

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -18,6 +18,7 @@ from mne.transforms import apply_trans, _get_trans
 from mne.utils import run_tests_if_main
 from mne.preprocessing.nirs import source_detector_distances,\
     short_channels
+from mne.io.constants import FIFF
 
 fname_nirx_15_0 = op.join(data_path(download=False),
                           'NIRx', 'nirx_15_0_recording')
@@ -236,7 +237,8 @@ def test_nirx_15_0():
 
     # Test info import
     assert raw.info['subject_info'] == {'first_name': 'NIRX',
-                                        'last_name': 'Test', 'sex': '0'}
+                                        'last_name': 'Test',
+                                        'sex': FIFF.FIFFV_SUBJ_SEX_UNKNOWN}
 
     # Test trigger events
     assert_array_equal(raw.annotations.description, ['1.0', '2.0', '2.0'])

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -11,7 +11,7 @@ from ...annotations import Annotations
 from ...utils import logger, verbose, fill_doc, warn
 from ...utils.check import _require_version
 from ..constants import FIFF
-from .._digitization import _make_dig_points, _format_dig_points
+from .._digitization import _make_dig_points
 from ...transforms import _frame_to_str
 
 
@@ -196,7 +196,8 @@ class RawSNIRF(BaseRaw):
                 info['chs'][idx]['loc'][9] = fnirs_wavelengths[wve_idx - 1]
 
             if 'MNE_coordFrame' in dat.get('nirs/metaDataTags/'):
-                coord_frame = int(dat.get('/nirs/metaDataTags/MNE_coordFrame')[0])
+                coord_frame = int(dat.get('/nirs/metaDataTags/MNE_coordFrame')
+                                  [0])
             else:
                 coord_frame = FIFF.FIFFV_COORD_UNKNOWN
 
@@ -216,7 +217,8 @@ class RawSNIRF(BaseRaw):
                         extra_ps[f'EEG{len(extra_ps) + 1:03d}'] = diglocs[idx]
                 info['dig'] = _make_dig_points(nasion=nasion, lpa=lpa, rpa=rpa,
                                                hpi=hpi, dig_ch_pos=extra_ps,
-                                               coord_frame=_frame_to_str[coord_frame])
+                                               coord_frame=_frame_to_str[
+                                                   coord_frame])
 
             super(RawSNIRF, self).__init__(info, preload, filenames=[fname],
                                            last_samps=[last_samps],

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -12,6 +12,7 @@ from ...utils import logger, verbose, fill_doc, warn
 from ...utils.check import _require_version
 from ..constants import FIFF
 from .._digitization import _make_dig_points, _format_dig_points
+from ...transforms import _frame_to_str
 
 
 @fill_doc
@@ -194,8 +195,8 @@ class RawSNIRF(BaseRaw):
                 info['chs'][idx]['loc'][0:3] = midpoint
                 info['chs'][idx]['loc'][9] = fnirs_wavelengths[wve_idx - 1]
 
-            if 'coordFrame' in dat.get('nirs/metaDataTags/'):
-                coord_frame = int(dat.get('/nirs/metaDataTags/coordFrame')[0])
+            if 'MNE_coordFrame' in dat.get('nirs/metaDataTags/'):
+                coord_frame = int(dat.get('/nirs/metaDataTags/MNE_coordFrame')[0])
             else:
                 coord_frame = FIFF.FIFFV_COORD_UNKNOWN
 
@@ -203,7 +204,7 @@ class RawSNIRF(BaseRaw):
                 diglocs = np.array(dat.get('/nirs/probe/landmarkPos3D'))
                 digname = np.array(dat.get('/nirs/probe/landmarkLabels'))
                 nasion, lpa, rpa, hpi = None, None, None, None
-                extra_pos = []
+                extra_ps = dict()
                 for idx, dign in enumerate(digname):
                     if dign == b'LPA':
                         lpa = diglocs[idx, :]
@@ -212,15 +213,10 @@ class RawSNIRF(BaseRaw):
                     elif dign == b'RPA':
                         rpa = diglocs[idx, :]
                     else:
-                        extra_pos.append(dict(
-                            kind=FIFF.FIFFV_POINT_EEG,  # as in read_raw_nirx
-                            r=diglocs[idx, :],
-                            ident=len(extra_pos) + 1,
-                            coord_frame=coord_frame,
-                        ))
-                info['dig'] = _make_dig_points(nasion=nasion, lpa=lpa,
-                                               rpa=rpa, hpi=hpi)
-                info['dig'].extend(_format_dig_points(extra_pos))
+                        extra_ps[f'EEG{len(extra_ps) + 1:03d}'] = diglocs[idx]
+                info['dig'] = _make_dig_points(nasion=nasion, lpa=lpa, rpa=rpa,
+                                               hpi=hpi, dig_ch_pos=extra_ps,
+                                               coord_frame=_frame_to_str[coord_frame])
 
             super(RawSNIRF, self).__init__(info, preload, filenames=[fname],
                                            last_samps=[last_samps],

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -215,8 +215,7 @@ class RawSNIRF(BaseRaw):
                         ))
                 info['dig'] = _make_dig_points(nasion=nasion, lpa=lpa,
                                                rpa=rpa, hpi=hpi)
-                for ex in _format_dig_points(extra_pos):
-                    info['dig'].append(ex)
+                info['dig'].extend(_format_dig_points(extra_pos))
 
             super(RawSNIRF, self).__init__(info, preload, filenames=[fname],
                                            last_samps=[last_samps],

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -194,6 +194,11 @@ class RawSNIRF(BaseRaw):
                 info['chs'][idx]['loc'][0:3] = midpoint
                 info['chs'][idx]['loc'][9] = fnirs_wavelengths[wve_idx - 1]
 
+            if 'coordFrame' in dat.get('nirs/metaDataTags/'):
+                coord_frame = int(dat.get('/nirs/metaDataTags/coordFrame')[0])
+            else:
+                coord_frame = FIFF.FIFFV_COORD_UNKNOWN
+
             if 'landmarkPos3D' in dat.get('nirs/probe/'):
                 diglocs = np.array(dat.get('/nirs/probe/landmarkPos3D'))
                 digname = np.array(dat.get('/nirs/probe/landmarkLabels'))
@@ -211,7 +216,7 @@ class RawSNIRF(BaseRaw):
                             kind=FIFF.FIFFV_POINT_EEG,  # as in read_raw_nirx
                             r=diglocs[idx, :],
                             ident=len(extra_pos) + 1,
-                            coord_frame=FIFF.FIFFV_COORD_HEAD,
+                            coord_frame=coord_frame,
                         ))
                 info['dig'] = _make_dig_points(nasion=nasion, lpa=lpa,
                                                rpa=rpa, hpi=hpi)

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -10,6 +10,7 @@ from ..meas_info import create_info
 from ...annotations import Annotations
 from ...utils import logger, verbose, fill_doc, warn
 from ...utils.check import _require_version
+from ..constants import FIFF
 
 
 @fill_doc
@@ -150,6 +151,21 @@ class RawSNIRF(BaseRaw):
             subject_info = {}
             names = np.array(dat.get('nirs/metaDataTags/SubjectID'))
             subject_info['first_name'] = names[0].decode('UTF-8')
+            # Read non standard (but allowed) custom metadata tags
+            if 'lastName' in dat.get('nirs/metaDataTags/'):
+                ln = dat.get('/nirs/metaDataTags/lastName')[0].decode('UTF-8')
+                subject_info['last_name'] = ln
+            if 'middleName' in dat.get('nirs/metaDataTags/'):
+                ln = dat.get('/nirs/metaDataTags/middleName')[0].decode('UTF-8')
+                subject_info['middle_name'] = ln
+            if 'sex' in dat.get('nirs/metaDataTags/'):
+                sex = dat.get('/nirs/metaDataTags/LengthUnit')[0].decode('UTF-8')
+                if sex in {'M', 'Male', '1', 1, 'm'}:
+                    subject_info['sex'] = FIFF.FIFFV_SUBJ_SEX_MALE
+                elif sex in {'F', 'Female', '2', 2, 'f'}:
+                    subject_info['sex'] = FIFF.FIFFV_SUBJ_SEX_FEMALE
+            # End non standard name reading
+            # Update info
             info.update(subject_info=subject_info)
 
             LengthUnit = np.array(dat.get('/nirs/metaDataTags/LengthUnit'))

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -203,7 +203,7 @@ class RawSNIRF(BaseRaw):
                 diglocs = np.array(dat.get('/nirs/probe/landmarkPos3D'))
                 digname = np.array(dat.get('/nirs/probe/landmarkLabels'))
                 nasion, lpa, rpa, hpi = None, None, None, None
-                extra_pos = []
+                extra_ps = dict()
                 for idx, dign in enumerate(digname):
                     if dign == b'LPA':
                         lpa = diglocs[idx, :]
@@ -212,15 +212,9 @@ class RawSNIRF(BaseRaw):
                     elif dign == b'RPA':
                         rpa = diglocs[idx, :]
                     else:
-                        extra_pos.append(dict(
-                            kind=FIFF.FIFFV_POINT_EEG,  # as in read_raw_nirx
-                            r=diglocs[idx, :],
-                            ident=len(extra_pos) + 1,
-                            coord_frame=coord_frame,
-                        ))
-                info['dig'] = _make_dig_points(nasion=nasion, lpa=lpa,
-                                               rpa=rpa, hpi=hpi)
-                info['dig'].extend(_format_dig_points(extra_pos))
+                        extra_ps[f'EEG{len(extra_ps) + 1:03d}'] = diglocs[idx]
+                info['dig'] = _make_dig_points(nasion=nasion, lpa=lpa, rpa=rpa,
+                                               hpi=hpi, dig_ch_pos=extra_ps)
 
             super(RawSNIRF, self).__init__(info, preload, filenames=[fname],
                                            last_samps=[last_samps],

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -203,7 +203,7 @@ class RawSNIRF(BaseRaw):
                 diglocs = np.array(dat.get('/nirs/probe/landmarkPos3D'))
                 digname = np.array(dat.get('/nirs/probe/landmarkLabels'))
                 nasion, lpa, rpa, hpi = None, None, None, None
-                extra_ps = dict()
+                extra_pos = []
                 for idx, dign in enumerate(digname):
                     if dign == b'LPA':
                         lpa = diglocs[idx, :]
@@ -212,9 +212,15 @@ class RawSNIRF(BaseRaw):
                     elif dign == b'RPA':
                         rpa = diglocs[idx, :]
                     else:
-                        extra_ps[f'EEG{len(extra_ps) + 1:03d}'] = diglocs[idx]
-                info['dig'] = _make_dig_points(nasion=nasion, lpa=lpa, rpa=rpa,
-                                               hpi=hpi, dig_ch_pos=extra_ps)
+                        extra_pos.append(dict(
+                            kind=FIFF.FIFFV_POINT_EEG,  # as in read_raw_nirx
+                            r=diglocs[idx, :],
+                            ident=len(extra_pos) + 1,
+                            coord_frame=coord_frame,
+                        ))
+                info['dig'] = _make_dig_points(nasion=nasion, lpa=lpa,
+                                               rpa=rpa, hpi=hpi)
+                info['dig'].extend(_format_dig_points(extra_pos))
 
             super(RawSNIRF, self).__init__(info, preload, filenames=[fname],
                                            last_samps=[last_samps],

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -160,11 +160,13 @@ class RawSNIRF(BaseRaw):
                 m = dat.get('/nirs/metaDataTags/middleName')[0].decode('UTF-8')
                 subject_info['middle_name'] = m
             if 'sex' in dat.get('nirs/metaDataTags/'):
-                s = dat.get('/nirs/metaDataTags/LengthUnit')[0].decode('UTF-8')
-                if s in {'M', 'Male', '1', 1, 'm'}:
+                s = dat.get('/nirs/metaDataTags/sex')[0].decode('UTF-8')
+                if s in {'M', 'Male', '1', 'm'}:
                     subject_info['sex'] = FIFF.FIFFV_SUBJ_SEX_MALE
-                elif s in {'F', 'Female', '2', 2, 'f'}:
+                elif s in {'F', 'Female', '2', 'f'}:
                     subject_info['sex'] = FIFF.FIFFV_SUBJ_SEX_FEMALE
+                elif s in {'0', 'u'}:
+                    subject_info['sex'] = FIFF.FIFFV_SUBJ_SEX_UNKNOWN
             # End non standard name reading
             # Update info
             info.update(subject_info=subject_info)

--- a/mne/io/snirf/tests/test_snirf.py
+++ b/mne/io/snirf/tests/test_snirf.py
@@ -93,8 +93,7 @@ def test_snirf_against_nirx():
 @requires_h5py
 @requires_testing_data
 def test_snirf_nonstandard(tmpdir):
-    """We have some custom tags to facilitate lossless writing and
-    reading within MNE, here we test those addditional tags."""
+    """Test custom tags."""
     from mne.externals.pymatreader.utils import _import_h5py
     h5py = _import_h5py()
     shutil.copy(fname_snirf_15_2_short, str(tmpdir) + "/mod.snirf")


### PR DESCRIPTION
#### Reference issue
I am adding a SNIRF writer at https://github.com/mne-tools/mne-nirs/pull/151


#### What does this implement/fix?
The SNIRF standard does not include some info that MNE has such as sex, middle name, last name (SNIRF has only SubjectID). 

To allow writing an MNE NIRS recording and reading it back without any loss, I have added non standard (but allowed) custom metadata tags to the SNIRF writer. In this PR I add reading of these extra values.


#### Additional information

- [x] Add reading of sex, middle name last name
- [x] Add reading of dig points 

I also noticed that unknown sex was not being correctly encoded in the NIRX reader.
