### PR TITLE
[MRG] Add GFPs to report

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -149,7 +149,7 @@ Changelog
 
 - Improved documentation building instructions and execution on Windows by `Eric Larson`_ and `kalenkovich`_
 
-- When passing a list of `~mne.Evoked` objects to `~mne.viz.plot_compare_evokeds`, each evoked's ``.comment`` attribute will be used to label the trace. If ``.comment`` is empty, a 1-based index is assigned as the label by `Richard Höchenberger`_
+- When passing a list of `~mne.Evoked` objects to `~mne.viz.plot_compare_evokeds`, each evoked's ``.comment`` attribute will be used to label the trace. If ``.comment`` is empty, a 1-based index is assigned as the label by  `Richard Höchenberger`_
 
 Bug
 ~~~
@@ -282,8 +282,6 @@ Bug
 - Fix bug in :func:`mne.read_epochs_fieldtrip` when importing data without a ``trialinfo`` field by `Thomas Hartmann`_
 
 - Fix bug in :meth:`mne.preprocessing.ICA.plot_properties` where time series plot doesn't start at the proper tmin by `Teon Brooks`_
-
-- `~mne.Report` now applies baseline correction by default when rendering (whitended) evoked data, as the documentation always suggested; pass ``baseline=None`` to disable this behavior by `Richard Höchenberger`_
 
 API
 ~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -149,7 +149,7 @@ Changelog
 
 - Improved documentation building instructions and execution on Windows by `Eric Larson`_ and `kalenkovich`_
 
-- When passing a list of `~mne.Evoked` objects to `~mne.viz.plot_compare_evokeds`, each evoked's ``.comment`` attribute will be used to label the trace. If ``.comment`` is empty, a 1-based index is assigned as the label by  `Richard Höchenberger`_
+- When passing a list of `~mne.Evoked` objects to `~mne.viz.plot_compare_evokeds`, each evoked's ``.comment`` attribute will be used to label the trace. If ``.comment`` is empty, a 1-based index is assigned as the label by `Richard Höchenberger`_
 
 Bug
 ~~~
@@ -282,6 +282,8 @@ Bug
 - Fix bug in :func:`mne.read_epochs_fieldtrip` when importing data without a ``trialinfo`` field by `Thomas Hartmann`_
 
 - Fix bug in :meth:`mne.preprocessing.ICA.plot_properties` where time series plot doesn't start at the proper tmin by `Teon Brooks`_
+
+- `~mne.Report` now applies baseline correction by default when rendering (whitended) evoked data, as the documentation always suggested; pass ``baseline=None`` to disable this behavior by `Richard Höchenberger`_
 
 API
 ~~~

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -541,6 +541,19 @@ Sensor Space Data
    read_selection
    rename_channels
 
+:py:mod:`mne.baseline`:
+
+.. automodule:: mne.baseline
+   :no-members:
+   :no-inherited-members:
+
+.. currentmodule:: mne.baseline
+
+.. autosummary::
+   :toctree: generated/
+
+   rescale
+
 
 Covariance computation
 ======================

--- a/mne/baseline.py
+++ b/mne/baseline.py
@@ -1,4 +1,4 @@
-"""Util function to baseline correct data."""
+"""Utility functions to baseline-correct data."""
 
 # Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #
@@ -32,14 +32,7 @@ def rescale(data, times, baseline, mode='mean', copy=True, picks=None,
         dimension should be time.
     times : 1D array
         Time instants is seconds.
-    baseline : tuple or list of length 2, or None
-        The time interval to apply rescaling / baseline correction.
-        If None do not apply it. If baseline is ``(bmin, bmax)``
-        the interval is between ``bmin`` (s) and ``bmax`` (s).
-        If ``bmin is None`` the beginning of the data is used
-        and if ``bmax is None`` then ``bmax`` is set to the end of the
-        interval. If baseline is ``(None, None)`` the entire time
-        interval is used. If baseline is None, no correction is applied.
+    %(rescale_baseline)s
     mode : 'mean' | 'ratio' | 'logratio' | 'percent' | 'zscore' | 'zlogratio'
         Perform baseline correction by
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -325,7 +325,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         See `Epochs` docstring.
     tmax : float
         See `Epochs` docstring.
-    baseline : None or tuple of length 2 (default (None, 0))
+    baseline : None | tuple of length 2
         See `Epochs` docstring.
     raw : Raw object
         An instance of Raw.
@@ -654,15 +654,9 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
 
         Parameters
         ----------
-        baseline : tuple of length 2
-            The time interval to apply baseline correction. If None do not
-            apply it. If baseline is (a, b) the interval is between "a (s)" and
-            "b (s)". If a is None the beginning of the data is used and if b is
-            None then b is set to the end of the interval. If baseline is equal
-            to (None, None) all the time interval is used. Correction is
-            applied by computing mean of the baseline period and subtracting it
-            from the data. The baseline (a, b) includes both endpoints, i.e.
-            all timepoints t such that a <= t <= b.
+        %(baseline)s
+            Defaults to ``(None, 0)``, i.e. beginning of the the data until
+            time point zero.
         %(verbose_meth)s
 
         Returns
@@ -1949,15 +1943,9 @@ class Epochs(BaseEpochs):
         Start time before event. If nothing is provided, defaults to -0.2.
     tmax : float
         End time after event. If nothing is provided, defaults to 0.5.
-    baseline : None or tuple of length 2 (default (None, 0))
-        The time interval to apply baseline correction. If None do not apply
-        it. If baseline is (a, b) the interval is between "a (s)" and "b (s)".
-        If a is None the beginning of the data is used and if b is None then b
-        is set to the end of the interval. If baseline is equal to (None, None)
-        all the time interval is used. Correction is applied by computing mean
-        of the baseline period and subtracting it from the data. The baseline
-        (a, b) includes both endpoints, i.e. all timepoints t such that
-        a <= t <= b.
+    %(baseline)s
+        Defaults to ``(None, 0)``, i.e. beginning of the the data until
+        time point zero.
     %(picks_all)s
     preload : bool
         Load all epochs from disk when creating the object
@@ -2223,15 +2211,8 @@ class EpochsArray(BaseEpochs):
     reject_tmax : scalar | None
         End of the time window used to reject epochs (with the default None,
         the window will end with tmax).
-    baseline : None or tuple of length 2 (default None)
-        The time interval to apply baseline correction. If None do not apply
-        it. If baseline is (a, b) the interval is between "a (s)" and "b (s)".
-        If a is None the beginning of the data is used and if b is None then b
-        is set to the end of the interval. If baseline is equal to (None, None)
-        all the time interval is used. Correction is applied by computing mean
-        of the baseline period and subtracting it from the data. The baseline
-        (a, b) includes both endpoints, i.e. all timepoints t such that
-        a <= t <= b.
+    %(baseline)s
+        Defaults to ``None``, i.e. no baseline correction.
     proj : bool | 'delayed'
         Apply SSP projection vectors. See :class:`mne.Epochs` for details.
     on_missing : str

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -152,15 +152,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         Parameters
         ----------
-        baseline : tuple of length 2
-            The time interval to apply baseline correction. If None do not
-            apply it. If baseline is (a, b) the interval is between "a (s)" and
-            "b (s)". If a is None the beginning of the data is used and if b is
-            None then b is set to the end of the interval. If baseline is equal
-            to (None, None) all the time interval is used. Correction is
-            applied by computing mean of the baseline period and subtracting it
-            from the data. The baseline (a, b) includes both endpoints, i.e.
-            all timepoints t such that a <= t <= b.
+        %(baseline)s
+            Defaults to ``(None, 0)``, i.e. beginning of the the data until
+            time point zero.
         %(verbose_meth)s
 
         Returns
@@ -922,15 +916,8 @@ def read_evokeds(fname, condition=None, baseline=None, kind='average',
         The index or list of indices of the evoked dataset to read. FIF files
         can contain multiple datasets. If None, all datasets are returned as a
         list.
-    baseline : None (default) or tuple of length 2
-        The time interval to apply baseline correction. If None do not apply
-        it. If baseline is (a, b) the interval is between "a (s)" and "b (s)".
-        If a is None the beginning of the data is used and if b is None then b
-        is set to the end of the interval. If baseline is equal to (None, None)
-        all the time interval is used. Correction is applied by computing mean
-        of the baseline period and subtracting it from the data. The baseline
-        (a, b) includes both endpoints, i.e. all timepoints t such that
-        a <= t <= b.
+    %(baseline)s
+        Defaults to ``None``, i.e. no baseline correction.
     kind : str
         Either 'average' or 'standard_error', the type of data to read.
     proj : bool

--- a/mne/report.py
+++ b/mne/report.py
@@ -1704,6 +1704,10 @@ class Report(object):
                                 div_klass=div_klass, id=global_id,
                                 tooltip=fname, color=color, text=ev.comment)
                             global_id += 1
+                        html_toc += toc_list.substitute(
+                            div_klass=div_klass, id=global_id,
+                            tooltip=fname, color=color, text='GFP')
+                        global_id += 1
                         html_toc += u'</ul></li>'
 
                     elif fname.endswith(tuple(VALID_EXTENSIONS +

--- a/mne/report.py
+++ b/mne/report.py
@@ -1987,7 +1987,7 @@ class Report(object):
         for fig in figs:
             img = _fig_to_img(fig, image_format)
             caption = self._gen_caption(prefix='Evoked',
-                                        suffix=f'(GFPs)',
+                                        suffix='(GFPs)',
                                         fname=evoked_fname,
                                         data_path=data_path)
             global_id = self._get_id()

--- a/mne/report.py
+++ b/mne/report.py
@@ -1954,7 +1954,7 @@ class Report(object):
                     message='Channel locations not available.*',
                     category=RuntimeWarning)
                 img = _fig_to_img(ev.plot, image_format, spatial_colors=True,
-                                  gfp=True, **kwargs)
+                                  **kwargs)
 
             caption = self._gen_caption(prefix='Evoked',
                                         suffix=f'({ev.comment})',

--- a/mne/report.py
+++ b/mne/report.py
@@ -909,7 +909,7 @@ class Report(object):
     """
 
     def __init__(self, info_fname=None, subjects_dir=None,
-                 subject=None, title=None, cov_fname=None, baseline=None,
+                 subject=None, title=None, cov_fname=None, baseline=(None, 0),
                  image_format='png', raw_psd=False, projs=False, verbose=None):
         self.info_fname = str(info_fname) if info_fname is not None else None
         self.cov_fname = str(cov_fname) if cov_fname is not None else None

--- a/mne/report.py
+++ b/mne/report.py
@@ -909,7 +909,7 @@ class Report(object):
     """
 
     def __init__(self, info_fname=None, subjects_dir=None,
-                 subject=None, title=None, cov_fname=None, baseline=(None, 0),
+                 subject=None, title=None, cov_fname=None, baseline=None,
                  image_format='png', raw_psd=False, projs=False, verbose=None):
         self.info_fname = str(info_fname) if info_fname is not None else None
         self.cov_fname = str(cov_fname) if cov_fname is not None else None

--- a/mne/report.py
+++ b/mne/report.py
@@ -27,7 +27,8 @@ from .io.pick import _DATA_CH_TYPES_SPLIT
 from .source_space import _mri_orientation
 from .utils import (logger, verbose, get_subjects_dir, warn,
                     fill_doc, _check_option)
-from .viz import plot_events, plot_alignment, plot_cov, plot_projs_topomap
+from .viz import (plot_events, plot_alignment, plot_cov, plot_projs_topomap,
+                  plot_compare_evokeds)
 from .viz.misc import _plot_mri_contours, _get_bem_plotting_surfaces
 from .forward import read_forward_solution
 from .epochs import read_epochs
@@ -1953,7 +1954,7 @@ class Report(object):
                     message='Channel locations not available.*',
                     category=RuntimeWarning)
                 img = _fig_to_img(ev.plot, image_format, spatial_colors=True,
-                                  **kwargs)
+                                  gfp=True, **kwargs)
 
             caption = self._gen_caption(prefix='Evoked',
                                         suffix=f'({ev.comment})',
@@ -1979,6 +1980,22 @@ class Report(object):
                 html.append(image_template.substitute(
                     img=img, div_klass='evoked', img_klass='evoked',
                     caption=caption, show=True, image_format=image_format))
+
+        # Plot GFP comparison.
+        figs = plot_compare_evokeds(evokeds=evokeds, ci=None,
+                                    show_sensors=True, **kwargs)
+        for fig in figs:
+            img = _fig_to_img(fig, image_format)
+            caption = self._gen_caption(prefix='Evoked',
+                                        suffix=f'(GFPs)',
+                                        fname=evoked_fname,
+                                        data_path=data_path)
+            global_id = self._get_id()
+            html.append(image_template.substitute(
+                img=img, id=global_id, div_klass='evoked',
+                img_klass='evoked', caption=caption, show=True,
+                image_format=image_format))
+
         logger.debug('Evoked: done')
         return '\n'.join(html)
 

--- a/mne/report.py
+++ b/mne/report.py
@@ -869,16 +869,8 @@ class Report(object):
         Title of the report.
     cov_fname : None | str
         Name of the file containing the noise covariance.
-    baseline : None or tuple of length 2 (default (None, 0))
-        The time interval to apply baseline correction for evokeds.
-        If None do not apply it. If baseline is (a, b)
-        the interval is between "a (s)" and "b (s)".
-        If a is None the beginning of the data is used
-        and if b is None then b is set to the end of the interval.
-        If baseline is equal to (None, None) all the time
-        interval is used.
-        The baseline (a, b) includes both endpoints, i.e. all
-        timepoints t such that a <= t <= b.
+    %(baseline)s
+        Defaults to ``None``, i.e. no baseline correction.
     image_format : str
         Default image format to use (default is 'png').
         SVG uses vector graphics, so fidelity is higher but can increase

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -14,6 +14,7 @@ from mne.utils import run_tests_if_main, requires_numpydoc, _pl
 public_modules = [
     # the list of modules users need to access for all functionality
     'mne',
+    'mne.baseline',
     'mne.beamformer',
     'mne.chpi',
     'mne.connectivity',

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -85,7 +85,8 @@ def test_render_report(renderer, tmpdir):
     epochs.save(epochs_fname, overwrite=True)
     # This can take forever (stall Travis), so let's make it fast
     # Also, make sure crop range is wide enough to avoid rendering bug
-    epochs.average().crop(0.1, 0.2).save(evoked_fname)
+    evoked = epochs.average().crop(0.1, 0.2)
+    evoked.save(evoked_fname)
 
     report = Report(info_fname=raw_fname_new, subjects_dir=subjects_dir,
                     projs=True)
@@ -116,6 +117,10 @@ def test_render_report(renderer, tmpdir):
     assert '<h4>SSP Projectors</h4>' in html
     # Projectors in `proj_fname_new`
     assert f'SSP Projectors: {op.basename(proj_fname_new)}' in html
+    # Evoked in `evoked_fname`
+    assert f'Evoked: {op.basename(evoked_fname)} ({evoked.comment})' in html
+    assert 'Topomap (ch_type =' in html
+    assert f'Evoked: {op.basename(evoked_fname)} (GFPs)' in html
 
     assert_equal(len(report.html), len(fnames))
     assert_equal(len(report.html), len(report.fnames))

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1403,13 +1403,11 @@ baseline : None | tuple of length 2
 
     .. note:: The baseline ``(a, b)`` includes both endpoints, i.e. all
                 timepoints ``t`` such that ``a <= t <= b``.
-
 """
-docdict['baseline'] = """
-    %(rescale_baseline)s
+docdict['baseline'] = """%(rescale_baseline)s
     Correction is applied by computing the mean
     of the baseline period and subtracting it from the data.
-"""
+"""  % docdict
 
 
 # Finalize

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1407,7 +1407,7 @@ baseline : None | tuple of length 2
 docdict['baseline'] = """%(rescale_baseline)s
     Correction is applied by computing the mean
     of the baseline period and subtracting it from the data.
-"""  % docdict
+""" % docdict
 
 
 # Finalize

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1390,8 +1390,8 @@ the above fields.
 Operates in place.
 """
 
-# Epochs & Evoked
-docdict['baseline'] = """
+# Baseline
+docdict['rescale_baseline'] = """
 baseline : None | tuple of length 2
     The time interval to consider as "baseline" when applying baseline
     correction. If ``None``, do not apply baseline correction.
@@ -1400,12 +1400,15 @@ baseline : None | tuple of length 2
     If ``a`` is ``None``, the **beginning** of the data is used; and if ``b``
     is ``None``, it is set to the **end** of the interval.
     If ``(None, None)``, the entire time interval is used.
-    Correction is applied by computing the mean
-    of the baseline period and subtracting it from the data.
 
     .. note:: The baseline ``(a, b)`` includes both endpoints, i.e. all
-              timepoints ``t`` such that ``a <= t <= b``.
+                timepoints ``t`` such that ``a <= t <= b``.
 
+"""
+docdict['baseline'] = """
+    %(rescale_baseline)s
+    Correction is applied by computing the mean
+    of the baseline period and subtracting it from the data.
 """
 
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1390,6 +1390,25 @@ the above fields.
 Operates in place.
 """
 
+# Epochs & Evoked
+docdict['baseline'] = """
+baseline : None | tuple of length 2
+    The time interval to consider as "baseline" when applying baseline
+    correction. If ``None``, do not apply baseline correction.
+    If a tuple ``(a, b)``, the interval is between ``a`` and ``b``
+    (in seconds), including the endpoints.
+    If ``a`` is ``None``, the **beginning** of the data is used; and if ``b``
+    is ``None``, it is set to the **end** of the interval.
+    If ``(None, None)``, the entire time interval is used.
+    Correction is applied by computing the mean
+    of the baseline period and subtracting it from the data.
+
+    .. note:: The baseline ``(a, b)`` includes both endpoints, i.e. all
+              timepoints ``t`` such that ``a <= t <= b``.
+
+"""
+
+
 # Finalize
 docdict = unindent_dict(docdict)
 fill_doc = filldoc(docdict, unindent_params=False)

--- a/tutorials/misc/plot_report.py
+++ b/tutorials/misc/plot_report.py
@@ -117,9 +117,9 @@ report.save('report_mri_bem.html')
 # Now let's look at how :class:`~mne.Report` handles :class:`~mne.Evoked` data
 # (we'll skip the MRIs to save computation time). The following code will
 # produce butterfly plots, topomaps, and comparisons of the global field
-# power (GFP) for different experimental conditions.
-# The GFP traces for the EEG data clearly look odd, indicating that we probably
-# should do a better job at data cleaning.
+# power (GFP) for different experimental conditions. When creating the report,
+# MNE applies a baseline correction by default, with a baseline period from the
+# beginning of the time interval to time point zero.
 
 pattern = 'sample_audvis-no-filter-ave.fif'
 report = mne.Report(verbose=True)

--- a/tutorials/misc/plot_report.py
+++ b/tutorials/misc/plot_report.py
@@ -115,7 +115,11 @@ report.save('report_mri_bem.html')
 
 ###############################################################################
 # Now let's look at how :class:`~mne.Report` handles :class:`~mne.Evoked` data
-# (we'll skip the MRIs to save computation time):
+# (we'll skip the MRIs to save computation time). The following code will
+# produce butterfly plots, topomaps, and comparisons of the global field
+# power (GFP) for different experimental conditions.
+# The GFP traces for the EEG data clearly look odd, indicating that we probably
+# should do a better job at data cleaning.
 
 pattern = 'sample_audvis-no-filter-ave.fif'
 report = mne.Report(verbose=True)

--- a/tutorials/misc/plot_report.py
+++ b/tutorials/misc/plot_report.py
@@ -131,7 +131,7 @@ report.save('report_evoked.html')
 # ``baseline`` argument, which should be a tuple with the starting and ending
 # time of the baseline period. For more details, read the documentation on
 # `~mne.Evoked.apply_baseline`. Here, we will apply baseline correction for a
-# a baseline period from the beginning of the time interval to time point zero.
+# baseline period from the beginning of the time interval to time point zero.
 
 baseline = (None, 0)
 pattern = 'sample_audvis-no-filter-ave.fif'

--- a/tutorials/misc/plot_report.py
+++ b/tutorials/misc/plot_report.py
@@ -117,9 +117,7 @@ report.save('report_mri_bem.html')
 # Now let's look at how :class:`~mne.Report` handles :class:`~mne.Evoked` data
 # (we'll skip the MRIs to save computation time). The following code will
 # produce butterfly plots, topomaps, and comparisons of the global field
-# power (GFP) for different experimental conditions. When creating the report,
-# MNE applies a baseline correction by default, with a baseline period from the
-# beginning of the time interval to time point zero.
+# power (GFP) for different experimental conditions.
 
 pattern = 'sample_audvis-no-filter-ave.fif'
 report = mne.Report(verbose=True)
@@ -127,13 +125,29 @@ report.parse_folder(path, pattern=pattern, render_bem=False)
 report.save('report_evoked.html')
 
 ###############################################################################
-# To render whitened :class:`~mne.Evoked` files with baseline correction, add
-# the noise covariance file. This will display ERP/ERF plots for both the
-# original and whitened :class:`~mne.Evoked` objects, but scalp topomaps only
-# for the original.
+# You have probably noticed that the EEG recordings look particularly odd. This
+# is because by default, `~mne.Report` does not apply baseline correction
+# before rendering evoked data. To request baseline correction, pass a
+# ``baseline`` argument, which should be a tuple with the starting and ending
+# time of the baseline period. For more details, read the documentation on
+# `~mne.Evoked.apply_baseline`. Here, we will apply baseline correction for a
+# a baseline period from the beginning of the time interval to time point zero.
+
+baseline = (None, 0)
+pattern = 'sample_audvis-no-filter-ave.fif'
+report = mne.Report(baseline=baseline, verbose=True)
+report.parse_folder(path, pattern=pattern, render_bem=False)
+report.save('report_evoked_baseline.html')
+
+###############################################################################
+# To render whitened :class:`~mne.Evoked` files with baseline correction, pass
+# the ``baseline`` argument we just used, and add the noise covariance file.
+# This will display ERP/ERF plots for both the original and whitened
+# :class:`~mne.Evoked` objects, but scalp topomaps only for the original.
 
 cov_fname = os.path.join(path, 'MEG', 'sample', 'sample_audvis-cov.fif')
-report = mne.Report(cov_fname=cov_fname, verbose=True)
+baseline = (None, 0)
+report = mne.Report(cov_fname=cov_fname, baseline=baseline, verbose=True)
 report.parse_folder(path, pattern=pattern, render_bem=False)
 report.save('report_evoked_whitened.html')
 

--- a/tutorials/misc/plot_report.py
+++ b/tutorials/misc/plot_report.py
@@ -127,9 +127,14 @@ report.save('report_evoked.html')
 ###############################################################################
 # You have probably noticed that the EEG recordings look particularly odd. This
 # is because by default, `~mne.Report` does not apply baseline correction
-# before rendering evoked data. To request baseline correction, pass a
-# ``baseline`` argument, which should be a tuple with the starting and ending
-# time of the baseline period. For more details, read the documentation on
+# before rendering evoked data. So if the dataset you wish to add to the report
+# has not been baseline-corrected already, you can request baseline correction
+# here. The MNE sample dataset we're using in this example has **not** been
+# baseline-corrected; so let's do this now for the report!
+#
+# To request baseline correction, pass a ``baseline`` argument to
+# `~mne.Report`, which should be a tuple with the starting and ending time of
+# the baseline period. For more details, see the documentation on
 # `~mne.Evoked.apply_baseline`. Here, we will apply baseline correction for a
 # baseline period from the beginning of the time interval to time point zero.
 


### PR DESCRIPTION
#### What does this implement/fix?
Add GFP traces to Report
- When plotting Evokeds, add a GFP trace to the sensor traces
- Also add a "GFP-only" comparison plot via `plot_compare_evokeds()`
- Slightly improves coverage of existing tests too

#### Additional information
I tested locally with some data, but let's see how CI artifacts come back. Any feedback greatly appreciated.