### PR TITLE
MRG, ENH: Add single_volume option to setup_volume_source_space

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -43,6 +43,8 @@ Changelog
 
 - Add support for omitting the SDR step in volumetric morphing by passing ``n_iter_sdr=()`` to `mne.compute_source_morph` by `Eric Larson`_
 
+- Add ``single_volume`` argument to :func:`mne.setup_volume_source_space` to facilitate creating source spaces with many volumes (e.g., all subvolumes of ``aseg.mgz``) by `Eric Larson`_
+
 - Add support for passing a string argument to ``bg_img`` in `mne.viz.plot_volume_source_estimates` by `Eric Larson`_
 
 - Add support for providing the destination surface source space in the ``src_to`` argument of :func:`mne.compute_source_morph` by `Eric Larson`_

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1565,7 +1565,7 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
                               surface=None, mindist=5.0, exclude=0.0,
                               subjects_dir=None, volume_label=None,
                               add_interpolator=True, sphere_units='m',
-                              verbose=None):
+                              single_volume=False, verbose=None):
     """Set up a volume source space with grid spacing or discrete source space.
 
     Parameters
@@ -1628,6 +1628,14 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
         Defaults to ``"m"``.
 
         .. versionadded:: 0.20
+    single_volume : bool
+        If True, multiple values of ``volume_label`` will be merged into a
+        a single source space instead of occupying multiple source spaces
+        (one for each sub-volume), i.e., ``len(src)`` will be ``1`` instead of
+        ``len(volume_label)``. This can help conserve memory and disk space
+        when many labels are used.
+
+        .. versionadded:: 0.21
     %(verbose)s
 
     Returns
@@ -1793,10 +1801,11 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
         # Make the grid of sources in MRI space
         sp = _make_volume_source_space(
             surf, pos, exclude, mindist, mri, volume_label,
-            vol_info=vol_info)
+            vol_info=vol_info, single_volume=single_volume)
     del sphere
     assert isinstance(sp, list)
-    assert len(sp) == 1 if volume_label is None else len(volume_label)
+    assert len(sp) == 1 if (volume_label is None or
+                            single_volume) else len(volume_label)
 
     # Compute an interpolation matrix to show data in MRI_VOXEL coord frame
     if mri is not None:
@@ -1966,7 +1975,7 @@ def _get_atlas_values(vol_info, rr):
 
 def _make_volume_source_space(surf, grid, exclude, mindist, mri=None,
                               volume_labels=None, do_neighbors=True, n_jobs=1,
-                              vol_info={}):
+                              vol_info={}, single_volume=False):
     """Make a source space which covers the volume bounded by surf."""
     # Figure out the grid size in the MRI coordinate frame
     if 'rr' in surf:
@@ -2065,6 +2074,16 @@ def _make_volume_source_space(surf, grid, exclude, mindist, mri=None,
             sp['mri_file'] = mri
             sps.append(sp)
         assert len(sps) == len(volume_labels)
+        # This will undo some of the work above, but the calculations are
+        # pretty trivial so allow it
+        if single_volume:
+            for sp in sps[1:]:
+                sps[0]['inuse'][sp['vertno']] = True
+            sp = sps[0]
+            sp['seg_name'] = '+'.join(s['seg_name'] for s in sps)
+            sps = sps[:1]
+            sp['vertno'] = np.where(sp['inuse'])[0]
+            sp['nuse'] = len(sp['vertno'])
     del sp, volume_labels
     if not do_neighbors:
         return sps

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -636,6 +636,13 @@ def test_source_space_exclusive_complete(src_volume_labels):
                        np.sort(np.concatenate([s['vertno'] for s in src])))
     for si, s in enumerate(src):
         assert_allclose(src_full[0]['rr'], s['rr'], atol=1e-6)
+    # also check single_volume=True -- should be the same result
+    src_single = setup_volume_source_space(
+        src[0]['subject_his_id'], 7., 'aseg.mgz', bem=fname_bem,
+        volume_label=volume_labels, single_volume=True, add_interpolator=False)
+    assert len(src_single) == 1
+    assert 'Unknown+Left-Cerebral-White-Matter+Left-' in repr(src_single)
+    assert_array_equal(src_full[0]['vertno'], src_single[0]['vertno'])
 
 
 @pytest.mark.timeout(60)  # ~24 sec on Travis

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -620,6 +620,7 @@ def test_source_space_from_label(tmpdir, pass_ids):
     _compare_source_spaces(src, src_from_file, mode='approx')
 
 
+@requires_nibabel()
 def test_source_space_exclusive_complete(src_volume_labels):
     """Test that we produce exclusive and complete labels."""
     # these two are neighbors and are quite large, so let's use them to
@@ -639,7 +640,8 @@ def test_source_space_exclusive_complete(src_volume_labels):
     # also check single_volume=True -- should be the same result
     src_single = setup_volume_source_space(
         src[0]['subject_his_id'], 7., 'aseg.mgz', bem=fname_bem,
-        volume_label=volume_labels, single_volume=True, add_interpolator=False)
+        volume_label=volume_labels, single_volume=True, add_interpolator=False,
+        subjects_dir=subjects_dir)
     assert len(src_single) == 1
     assert 'Unknown+Left-Cerebral-White-Matter+Left-' in repr(src_single)
     assert_array_equal(src_full[0]['vertno'], src_single[0]['vertno'])

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -387,8 +387,16 @@ class ETSContext(object):
 
 
 @contextlib.contextmanager
-def wrapped_stdout(indent=''):
-    """Wrap stdout writes to logger.info, with an optional indent prefix."""
+def wrapped_stdout(indent='', cull_newlines=False):
+    """Wrap stdout writes to logger.info, with an optional indent prefix.
+
+    Parameters
+    ----------
+    indent : str
+        The indentation to add.
+    cull_newlines : bool
+        If True, cull any new/blank lines at the end.
+    """
     orig_stdout = sys.stdout
     my_out = ClosingStringIO()
     sys.stdout = my_out
@@ -396,5 +404,11 @@ def wrapped_stdout(indent=''):
         yield
     finally:
         sys.stdout = orig_stdout
+        pending_newlines = 0
         for line in my_out.getvalue().split('\n'):
+            if not line.strip() and cull_newlines:
+                pending_newlines += 1
+                continue
+            for _ in range(pending_newlines):
+                logger.info('\n')
             logger.info(indent + line)


### PR DESCRIPTION
It's nice to be able to create a volumetric source space using FreeSurfer's complete `aseg.mgz` definition, without the `Unknown` vertices, like:
```
src_to_fname = op.join(subjects_dir, 'fsaverage', 'bem',
                       'fsaverage-vol-5-aseg-src.fif')
aseg_fname = op.join(subjects_dir, 'fsaverage', 'mri', 'aseg.mgz')
volume_label = mne.get_volume_labels_from_aseg(aseg_fname)
volume_label.pop(volume_label.index('Unknown'))
assert len(volume_label) == 43
if not op.isfile(src_to_fname):
    src_to = mne.setup_volume_source_space(
        'fsaverage', 5., 'aseg.mgz', volume_label=volume_label,
        subjects_dir=subjects_dir, verbose=True)
```
This creates a source space with 46 entries. A problem with this is that there is a ton of redundant information: the source `rr`, whether used or unused for a give subvol, are part of each of the 46 spaces. So when you go to save this to disk, you get a 2GB write error.

A nice solution is to merge all of these into a single volume with `single_volume=True`, which makes `len(src) == 1`, and takes up only 200 MB of disk space. Now that we have `extract_label_time_course` support for volumes and other extraction tools, it's easy enough to later extract the individual subvolumes later.

FWIW I actually prefer this method to using a `inner_skull`-bounded surface, as it ensures it only includes source points that FreeSurfer considered to be part of the actual brain by `.pop`-ing the `'Unknown'` label. Not sure if it's worth updating an example or tutorial to mention (or use) this approach...