### PR TITLE
MRG, BUG: Avoid warning about rank when its explicit

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -226,6 +226,8 @@ Bug
 
 - Fix bug with :func:`mne.viz.plot_bem` and :class:`mne.Report` when plotting BEM contours when MRIs are not in standard FreeSurfer orientation by `Eric Larson`_
 
+- Fix bug with :func:`mne.minimum_norm.make_inverse_operator` where it would warn even when an explicit ``rank`` was used by `Eric Larson`_
+
 - Fix bugs with :func:`mne.beamformer.make_lcmv` and :func:`mne.beamformer.make_dics` where:
 
   - Noise normalization factors ``weight_norm='unit-noise-gain'`` and ``weight_norm='nai'`` were computed incorrectly

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1396,7 +1396,8 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
     noise_cov = prepare_noise_cov(
         noise_cov, info, info_picked['ch_names'], rank)
     whitener, _ = compute_whitener(
-        noise_cov, info, info_picked['ch_names'], pca=pca, verbose=False)
+        noise_cov, info, info_picked['ch_names'], pca=pca, verbose=False,
+        rank=rank)
     gain = np.dot(whitener, forward['sol']['data'])
 
     logger.info('Creating the source covariance matrix')

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -1210,5 +1210,4 @@ def test_sss_rank():
     assert rank == 67
 
 
-
 run_tests_if_main()


### PR DESCRIPTION
`rank` was only passed to one of two functions that could compute the rank, so you could get a warning about rank deficiency even if you've explicitly set the rank.