### PR TITLE
MRG, ENH: Use numba to speed up summarize_clusters_stc

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -147,6 +147,8 @@ Changelog
 
 - When passing a list of `~mne.Evoked` objects to `~mne.viz.plot_compare_evokeds`, each evoked's ``.comment`` attribute will be used to label the trace. If ``.comment`` is empty, a 1-based index is assigned as the label by  `Richard Höchenberger`_
 
+- Speed up :func:`mne.stats.summarize_clusters_stc` using Numba by `Yu-Han Luo`_
+
 Bug
 ~~~
 

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -110,6 +110,11 @@ def _masked_sum_power(x, c, t_power):
     return np.sum(np.sign(x[c]) * np.abs(x[c]) ** t_power)
 
 
+@jit()
+def _sum_cluster_data(data, tstep):
+    return np.sign(data) * np.logical_not(data == 0) * tstep
+
+
 def _get_clusters_spatial(s, neighbors):
     """Form spatial clusters using neighbor lists.
 
@@ -1479,12 +1484,11 @@ def summarize_clusters_stc(clu, p_thresh=0.05, tstep=1.0, tmin=0,
     data_summary = np.zeros((n_vertices, len(good_cluster_inds) + 1))
     for ii, cluster_ind in enumerate(good_cluster_inds):
         data.fill(0)
-        v_inds = clusters[cluster_ind][1]
-        t_inds = clusters[cluster_ind][0]
+        t_inds, v_inds = clusters[cluster_ind]
         data[v_inds, t_inds] = t_obs[t_inds, v_inds]
         # Store a nice visualization of the cluster by summing across time
-        data = np.sign(data) * np.logical_not(data == 0) * tstep
-        data_summary[:, ii + 1] = np.sum(data, axis=1)
+        data_summary[:, ii + 1] = np.sum(_sum_cluster_data(data, tstep),
+                                         axis=1)
         # Make the first "time point" a sum across all clusters for easy
         # visualization
     data_summary[:, 0] = np.sum(data_summary, axis=1)


### PR DESCRIPTION
Use Numba to speed up converting spatiotemporal cluster results into SourceEstimate. This PR brings about 35% speedup.

#### Testing

[left_auditory_vs_visual_0_to_None.npz (~148MB)](https://www.dropbox.com/s/f0rmo1wf5871reu/left_auditory_vs_visual_0_to_None.npz?dl=0)

+ Processed from the `sample` dataset, duplicated to create 7 subjects
+ Used `oct6` source space to compute source estimates then morphed to `ico5` `fsaverage`
+ Sampling rate: 600 Hz
+ Time window: 0-500 ms after stimulus onset


```python
import mne
import numpy as np

# processed from the sample dataset
clu_fname = 'left_auditory_vs_visual_0_to_None.npz'

tstep = 0.0016649601096532323

# allow_pickle=True when you are certain that the data are not malicious!
cluster_result = np.load(clu_fname, allow_pickle=True)

clu = (cluster_result['t_obs'], cluster_result['clusters'],
       cluster_result['cluster_pv'], cluster_result['H0'])

stc_all_cluster_vis = mne.stats.summarize_clusters_stc(
    clu,
    tstep=tstep * 1000,
    subject='fsaverage')
```

#### Before

```
%time
CPU times: user 1min 23s, sys: 7.17 s, total: 1min 31s
Wall time: 1min 32s
```

#### After

```
%time
CPU times: user 32.8 s, sys: 27.4 s, total: 1min
Wall time: 1min
```

~35% speedup (65% of current processing time)

When the cluster results are huge, the for-loop in `mne.stats.summarize_clusters_stc` is too time-consuming. I tried to speed up the entire for-loop but it's currently impossible (data typing problem). I hope this PR helps.

#### mne.sys_info
```
Platform:      Linux-5.6.18-200.fc31.x86_64-x86_64-with-fedora-31-Thirty_One
Python:        3.7.7 (default, Mar 13 2020, 10:23:39)  [GCC 9.2.1 20190827 (Red Hat 9.2.1-1)]
Executable:    /home/yuhan/env/mnedev/bin/python
CPU:           x86_64: 4 cores
Memory:        15.5 GB

mne:           0.21.dev0
numpy:         1.18.4 {blas=openblas, lapack=openblas}
scipy:         1.4.1
matplotlib:    3.2.1 {backend=Qt5Agg}

sklearn:       0.23.0
numba:         0.49.1
nibabel:       3.1.0
cupy:          Not found
pandas:        1.0.3
dipy:          1.1.1
mayavi:        4.7.1
pyvista:       0.24.2 {OpenGL 4.5.0 NVIDIA 440.82 via GeForce 940MX/PCIe/SSE2}
vtk:           8.1.2
PyQt5:         5.13.2
```