### PR TITLE
MRG, FIX: Check reject_by_annotation in ica.plot_properties

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -157,6 +157,10 @@ Changelog
 
 - Speed up :func:`mne.stats.summarize_clusters_stc` using Numba by `Yu-Han Luo`_
 
+- Add ``reject_by_annotation=True`` to :func:`mne.make_fixed_length_epochs` to reject bad epochs based on annotation by `Yu-Han Luo`_
+
+- Add ``reject_by_annotation=True`` to :meth:`mne.preprocessing.ICA.plot_properties` to reject bad data segments based on annotation by `Yu-Han Luo`_
+
 Bug
 ~~~
 
@@ -290,6 +294,8 @@ Bug
 - Fix bug in :func:`mne.read_epochs_fieldtrip` when importing data without a ``trialinfo`` field by `Thomas Hartmann`_
 
 - Fix bug in :meth:`mne.preprocessing.ICA.plot_properties` where time series plot doesn't start at the proper tmin by `Teon Brooks`_
+
+- Fix bug with :meth:`mne.preprocessing.ICA.plot_properties` where a :class:`mne.io.Raw` object with annotations would lead to an error by `Yu-Han Luo`_
 
 API
 ~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -157,9 +157,7 @@ Changelog
 
 - Speed up :func:`mne.stats.summarize_clusters_stc` using Numba by `Yu-Han Luo`_
 
-- Add ``reject_by_annotation=True`` to :func:`mne.make_fixed_length_epochs` to reject bad epochs based on annotation by `Yu-Han Luo`_
-
-- Add ``reject_by_annotation=True`` to :meth:`mne.preprocessing.ICA.plot_properties` to reject bad data segments based on annotation by `Yu-Han Luo`_
+- Add ``reject_by_annotation=True`` to :func:`mne.make_fixed_length_epochs` and :meth:`mne.preprocessing.ICA.plot_properties` to reject bad data segments based on annotation by `Yu-Han Luo`_
 
 Bug
 ~~~

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -425,10 +425,7 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
         method equals 'auto' or is a list of str. Defaults to False.
 
         .. versionadded:: 0.12
-    reject_by_annotation : bool
-        Whether to reject based on annotations. If True (default), epochs
-        overlapping with segments whose description begins with ``'bad'`` are
-        rejected. If False, no rejection based on annotations is performed.
+    %(reject_by_annotation_epochs)s
 
         .. versionadded:: 0.14
     %(rank_None)s

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3277,8 +3277,8 @@ def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
 
 
 @verbose
-def make_fixed_length_epochs(raw, duration=1.,
-                             preload=False, verbose=None):
+def make_fixed_length_epochs(raw, duration=1., preload=False,
+                             reject_by_annotation=True, verbose=None):
     """Divide continuous raw data into equal-sized consecutive epochs.
 
     Parameters
@@ -3301,6 +3301,6 @@ def make_fixed_length_epochs(raw, duration=1.,
     """
     events = make_fixed_length_events(raw, 1, duration=duration)
     delta = 1. / raw.info['sfreq']
-    return Epochs(raw, events, event_id=[1], tmin=0.,
-                  tmax=duration - delta,
-                  verbose=verbose, baseline=None)
+    return Epochs(raw, events, event_id=[1], tmin=0., tmax=duration - delta,
+                  baseline=None, reject_by_annotation=reject_by_annotation,
+                  verbose=verbose)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2002,10 +2002,7 @@ class Epochs(BaseEpochs):
         warn, if 'ignore' it will proceed silently. Note.
         If none of the event ids are found in the data, an error will be
         automatically generated irrespective of this parameter.
-    reject_by_annotation : bool
-        Whether to reject based on annotations. If True (default), epochs
-        overlapping with segments whose description begins with ``'bad'`` are
-        rejected. If False, no rejection based on annotations is performed.
+    %(reject_by_annotation_epochs)s
     metadata : instance of pandas.DataFrame | None
         A :class:`pandas.DataFrame` specifying metadata about each epoch.
         If given, ``len(metadata)`` must equal ``len(events)``. The DataFrame
@@ -3288,10 +3285,7 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
     duration : float
         Duration of each epoch in seconds. Defaults to 1.
     %(preload)s
-    reject_by_annotation : bool
-        Whether to reject based on annotations. If ``True`` (default), epochs
-        overlapping with segments whose description begins with ``'bad'`` are
-        rejected. If ``False``, no rejection based on annotations is performed.
+    %(reject_by_annotation_epochs)s
 
         .. versionadded:: 0.21.0
     %(verbose)s

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3288,6 +3288,12 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
     duration : float
         Duration of each epoch in seconds. Defaults to 1.
     %(preload)s
+    reject_by_annotation : bool
+        Whether to reject based on annotations. If ``True`` (default), epochs
+        overlapping with segments whose description begins with ``'bad'`` are
+        rejected. If ``False``, no rejection based on annotations is performed.
+
+        .. versionadded:: 0.21.0
     %(verbose)s
 
     Returns
@@ -3301,6 +3307,6 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
     """
     events = make_fixed_length_events(raw, 1, duration=duration)
     delta = 1. / raw.info['sfreq']
-    return Epochs(raw, events, event_id=[1], tmin=0., tmax=duration - delta,
-                  baseline=None, reject_by_annotation=reject_by_annotation,
-                  verbose=verbose)
+    return Epochs(raw, events, event_id=[1], tmin=0, tmax=duration - delta,
+                  baseline=None, preload=preload,
+                  reject_by_annotation=reject_by_annotation, verbose=verbose)

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -165,8 +165,7 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
     return_ecg : bool
         Return ecg channel if synthesized. Defaults to False. If True and
         and ecg exists this will yield None.
-    reject_by_annotation : bool
-        Whether to omit data that is annotated as bad.
+    %(reject_by_annotation_all)s
 
         .. versionadded:: 0.18
     %(verbose)s
@@ -329,10 +328,7 @@ def create_ecg_epochs(raw, ch_name=None, event_id=999, picks=None, tmin=-0.5,
         When ECG is synthetically created (after picking), should it be added
         to the epochs? Must be False when synthetic channel is not used.
         Defaults to False.
-    reject_by_annotation : bool
-        Whether to reject based on annotations. If True (default), epochs
-        overlapping with segments whose description begins with ``'bad'`` are
-        rejected. If False, no rejection based on annotations is performed.
+    %(reject_by_annotation_epochs)s
 
         .. versionadded:: 0.14.0
     %(verbose)s

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -210,11 +210,7 @@ def create_eog_epochs(raw, ch_name=None, event_id=998, picks=None, tmin=-0.5,
         interval is used. If None, no correction is applied.
     preload : bool
         Preload epochs or not.
-    reject_by_annotation : bool
-        Whether to reject based on annotations. If True (default), segments
-        whose description begins with ``'bad'`` are not used for finding
-        artifacts and epochs overlapping with them are rejected. If False, no
-        rejection based on annotations is performed.
+    %(reject_by_annotation_epochs)s
 
         .. versionadded:: 0.14.0
     thresh : float

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1749,12 +1749,14 @@ class ICA(ContainsMixin):
     @copy_function_doc_to_method_doc(plot_ica_properties)
     def plot_properties(self, inst, picks=None, axes=None, dB=True,
                         plot_std=True, topomap_args=None, image_args=None,
-                        psd_args=None, figsize=None, show=True, reject='auto'):
+                        psd_args=None, figsize=None, show=True, reject='auto',
+                        reject_by_annotation=True):
         return plot_ica_properties(self, inst, picks=picks, axes=axes,
                                    dB=dB, plot_std=plot_std,
                                    topomap_args=topomap_args,
                                    image_args=image_args, psd_args=psd_args,
-                                   figsize=figsize, show=show, reject=reject)
+                                   figsize=figsize, show=show, reject=reject,
+                                   reject_by_annotation=reject_by_annotation)
 
     @copy_function_doc_to_method_doc(plot_ica_sources)
     def plot_sources(self, inst, picks=None, start=None,

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -474,11 +474,7 @@ class ICA(ContainsMixin):
         tstep : float
             Length of data chunks for artifact rejection in seconds.
             It only applies if ``inst`` is of type Raw.
-        reject_by_annotation : bool
-            Whether to omit bad segments from the data before fitting. If True,
-            annotated segments with a description that starts with 'bad' are
-            omitted. Has no effect if ``inst`` is an Epochs or Evoked object.
-            Defaults to True.
+        %(reject_by_annotation_raw)s
 
             .. versionadded:: 0.14.0
         %(verbose_meth)s
@@ -986,8 +982,7 @@ class ICA(ContainsMixin):
             Low pass frequency.
         h_freq : float
             High pass frequency.
-        reject_by_annotation : bool
-            If True, data annotated as bad will be omitted. Defaults to True.
+        %(reject_by_annotation_all)s
 
             .. versionadded:: 0.14.0
         %(verbose_meth)s
@@ -1196,8 +1191,7 @@ class ICA(ContainsMixin):
             threshold components will be masked and the z-score will
             be recomputed until no supra-threshold component remains.
             Defaults to 'ctps'.
-        reject_by_annotation : bool
-            If True, data annotated as bad will be omitted. Defaults to True.
+        %(reject_by_annotation_all)s
 
             .. versionadded:: 0.14.0
         measure : 'zscore' | 'correlation'
@@ -1316,8 +1310,7 @@ class ICA(ContainsMixin):
             Low pass frequency.
         h_freq : float
             High pass frequency.
-        reject_by_annotation : bool
-            If True, data annotated as bad will be omitted. Defaults to True.
+        %(reject_by_annotation_all)s
         method : 'together' | 'separate'
             Method to use to identify reference channel related components.
             Defaults to ``'together'``. See notes.
@@ -1446,8 +1439,7 @@ class ICA(ContainsMixin):
             Low pass frequency.
         h_freq : float
             High pass frequency.
-        reject_by_annotation : bool
-            If True, data annotated as bad will be omitted. Defaults to True.
+        %(reject_by_annotation_all)s
 
             .. versionadded:: 0.14.0
         measure : 'zscore' | 'correlation'

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -3029,9 +3029,9 @@ def test_make_fixed_length_epochs():
     raw_annot = raw.set_annotations(annot)
     epochs_annot = make_fixed_length_epochs(raw_annot, duration=1.0,
                                             preload=True)
-    assert len(epochs.events) > 10
-    assert len(epochs_annot.events) > 10
-    assert len(epochs.events) > len(epochs_annot.events)
+    assert len(epochs) > 10
+    assert len(epochs_annot) > 10
+    assert len(epochs) > len(epochs_annot)
 
 
 run_tests_if_main()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -22,7 +22,7 @@ import mne
 from mne import (Epochs, Annotations, read_events, pick_events, read_epochs,
                  equalize_channels, pick_types, pick_channels, read_evokeds,
                  write_evokeds, create_info, make_fixed_length_events,
-                 combine_evoked)
+                 make_fixed_length_epochs, combine_evoked)
 from mne.baseline import rescale
 from mne.fixes import rfft, rfftfreq
 from mne.preprocessing import maxwell_filter
@@ -3017,6 +3017,21 @@ def test_pick_types_reject_flat_keys():
     epochs.pick_types(meg=True, eeg=False, ecg=False, eog=False)
     assert sorted(epochs.reject.keys()) == ['grad', 'mag']
     assert sorted(epochs.flat.keys()) == ['grad', 'mag']
+
+
+@testing.requires_testing_data
+def test_make_fixed_length_epochs():
+    """Test dividing raw data into equal-sized consecutive epochs."""
+    raw = read_raw_fif(raw_fname, preload=True)
+    epochs = make_fixed_length_epochs(raw, duration=1, preload=True)
+    # Test Raw with annotations
+    annot = Annotations(onset=[0], duration=[5], description=['BAD'])
+    raw_annot = raw.set_annotations(annot)
+    epochs_annot = make_fixed_length_epochs(raw_annot, duration=1.0,
+                                            preload=True)
+    assert len(epochs.events) > 10
+    assert len(epochs_annot.events) > 10
+    assert len(epochs.events) > len(epochs_annot.events)
 
 
 run_tests_if_main()

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -206,11 +206,7 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
     proj : bool
         Apply SSP projection vectors. If inst is ndarray this is not used.
     %(n_jobs)s
-    reject_by_annotation : bool
-        Whether to omit bad segments from the data while computing the
-        PSD. If True, annotated segments with a description that starts
-        with 'bad' are omitted. Has no effect if ``inst`` is an Epochs or
-        Evoked object. Defaults to True.
+    %(reject_by_annotation_raw)s
 
         .. versionadded:: 0.15.0
     average : str | None

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -72,6 +72,24 @@ tmax : float
     End time of the raw data to use in seconds (cannot exceed data duration).
 """
 
+
+# Reject by annotation
+docdict['reject_by_annotation_all'] = """
+reject_by_annotation : bool
+    Whether to omit bad segments from the data before fitting. If ``True``
+    (default), annotated segments whose description begins with ``'bad'`` are
+    omitted. If ``False``, no rejection based on annotations is performed.
+"""
+docdict['reject_by_annotation_epochs'] = """
+reject_by_annotation : bool
+    Whether to reject based on annotations. If ``True`` (default), epochs
+    overlapping with segments whose description begins with ``'bad'`` are
+    rejected. If ``False``, no rejection based on annotations is performed.
+"""
+docdict['reject_by_annotation_raw'] = docdict['reject_by_annotation_all'] + """
+    Has no effect if ``inst`` is not a :class:`mne.io.Raw` object."""
+
+
 # General plotting
 docdict["show"] = """
 show : bool

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -310,6 +310,12 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
         If None, no rejection is applied. The default is 'auto',
         which applies the rejection parameters used when fitting
         the ICA object.
+    reject_by_annotation : bool
+        Whether to omit bad segments from the data. If ``True`` (default),
+        annotated segments with a description that starts with ``'bad'`` are
+        omitted. Has no effect if ``inst`` is an Epochs object.
+
+        .. versionadded:: 0.21.0
 
     Returns
     -------
@@ -393,10 +399,10 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
         from ..epochs import make_fixed_length_epochs
         inst_rejected = make_fixed_length_epochs(
             inst_rejected,
-            duration=2.,
-            verbose=False,
+            duration=2,
             preload=True,
-            reject_by_annotation=reject_by_annotation)
+            reject_by_annotation=reject_by_annotation,
+            verbose=False)
         inst = make_fixed_length_epochs(
             inst,
             duration=2,
@@ -408,9 +414,7 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
         drop_inds = None
         inst_rejected = inst
         kind = "Epochs"
-    if kind == 'Segment' and reject_by_annotation:
-        # get_sources requires clean epochs
-        inst_rejected.drop_bad()
+
     epochs_src = ica.get_sources(inst_rejected)
     data = epochs_src.get_data()
 
@@ -424,9 +428,6 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
         dropped_indices = []
 
     # getting ica sources from inst
-    if kind == 'Segment' and reject_by_annotation:
-        # get_sources requires clean epochs
-        inst.drop_bad()
     dropped_src = ica.get_sources(inst).get_data()
     dropped_src = np.swapaxes(dropped_src[:, picks, :], 0, 1)
 

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -310,10 +310,7 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
         If None, no rejection is applied. The default is 'auto',
         which applies the rejection parameters used when fitting
         the ICA object.
-    reject_by_annotation : bool
-        Whether to omit bad segments from the data. If ``True`` (default),
-        annotated segments with a description that starts with ``'bad'`` are
-        omitted. Has no effect if ``inst`` is an Epochs object.
+    %(reject_by_annotation_raw)s
 
         .. versionadded:: 0.21.0
 

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -604,11 +604,7 @@ def plot_raw_psd(raw, fmin=0, fmax=np.inf, tmin=None, tmax=None, proj=False,
     n_overlap : int
         The number of points of overlap between blocks. The default value
         is 0 (no overlap).
-    reject_by_annotation : bool
-        Whether to omit bad segments from the data while computing the
-        PSD. If True, annotated segments with a description that starts
-        with 'bad' are omitted. Has no effect if ``inst`` is an Epochs or
-        Evoked object. Defaults to True.
+    %(reject_by_annotation_raw)s
     %(plot_psd_picks_good_data)s
     ax : instance of Axes | None
         Axes to plot into. If None, axes will be created.

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -181,6 +181,23 @@ def test_plot_ica_properties():
         ica.plot_properties(epochs)
     plt.close('all')
 
+    # Test Raw with annotations
+    annot = Annotations(onset=[1], duration=[1], description=['BAD'])
+    raw_annot = _get_raw(preload=True).set_annotations(annot)
+
+    ica.fit(raw_annot)
+    # drop bad data segments
+    ica.plot_properties(raw_annot)
+    # don't drop
+    ica.plot_properties(raw_annot, reject_by_annotation=False)
+    # fitting with bad data
+    ica.fit(raw_annot, reject_by_annotation=False)
+    # drop bad data when plotting
+    ica.plot_properties(raw_annot)
+    # don't drop bad data when plotting
+    ica.plot_properties(raw_annot, reject_by_annotation=False)
+    plt.close('all')
+
 
 @requires_sklearn
 def test_plot_ica_sources():

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -185,13 +185,15 @@ def test_plot_ica_properties():
     annot = Annotations(onset=[1], duration=[1], description=['BAD'])
     raw_annot = _get_raw(preload=True).set_annotations(annot)
 
-    ica.fit(raw_annot)
+    with pytest.warns(UserWarning, match='did not converge'):
+        ica.fit(raw_annot)
     # drop bad data segments
     ica.plot_properties(raw_annot)
     # don't drop
     ica.plot_properties(raw_annot, reject_by_annotation=False)
     # fitting with bad data
-    ica.fit(raw_annot, reject_by_annotation=False)
+    with pytest.warns(UserWarning, match='did not converge'):
+        ica.fit(raw_annot, reject_by_annotation=False)
     # drop bad data when plotting
     ica.plot_properties(raw_annot)
     # don't drop bad data when plotting


### PR DESCRIPTION
Fix #8101 .

Because `reject_by_annotation` in `ica.fit()` defaults to `True`, reconstruction of source in `plot_properties` should take care of that or the error occurs due to the incorrect number of epochs.

**TODO**
- _Fix `ica.plot_properties`_
- _Fix `make_fixed_length_epochs`_
- _Update documentation of `reject_by_annotation` using docdict_
- _Update what's new_

### Before this PR

After adding annotations
```python
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-4-d42215032b75> in <module>
      6 
      7 ica.fit(raw)
----> 8 ica.plot_properties(raw, picks=[0, 1])

~/env/mne/lib64/python3.7/site-packages/mne/preprocessing/ica.py in plot_properties(self, inst, picks, axes, dB, plot_std, topomap_args, image_args, psd_args, figsize, show, reject)
   1631                                    topomap_args=topomap_args,
   1632                                    image_args=image_args, psd_args=psd_args,
-> 1633                                    figsize=figsize, show=show, reject=reject)
   1634 
   1635     @copy_function_doc_to_method_doc(plot_ica_sources)

~/env/mne/lib64/python3.7/site-packages/mne/viz/ica.py in plot_ica_properties(ica, inst, picks, axes, dB, plot_std, topomap_args, image_args, psd_args, figsize, show, reject)
    403 
    404     epochs_src = ica.get_sources(inst_rejected)
--> 405     data = epochs_src.get_data()
    406 
    407     ica_data = np.swapaxes(data[:, picks, :], 0, 1)

~/env/mne/lib64/python3.7/site-packages/mne/epochs.py in get_data(self, picks, item)
   1412             A view on epochs data.
   1413         """
-> 1414         return self._get_data(picks=picks, item=item)
   1415 
   1416     @property

<decorator-gen-182> in _get_data(self, out, picks, item, verbose)

~/env/mne/lib64/python3.7/site-packages/mne/epochs.py in _get_data(self, out, picks, item, verbose)
   1343                     else:
   1344                         epoch_noproj = None
-> 1345                         epoch = self._data[idx]
   1346                 else:  # from disk
   1347                     epoch_noproj = self._get_epoch_from_raw(idx)

IndexError: index 28 is out of bounds for axis 0 with size 28
```
![Figure_1](https://user-images.githubusercontent.com/29604854/89628888-876b2f80-d8cf-11ea-97fe-4970e3543406.png)

---

### After this PR

Before adding annotations
```python
import os

import mne

sample_data_folder = mne.datasets.sample.data_path()
sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
                                    'sample_audvis_raw.fif')
raw = mne.io.read_raw_fif(sample_data_raw_file)
raw.crop(tmax=60)

raw.load_data()
raw.filter(1, 40, n_jobs='cuda')

ica = mne.preprocessing.ICA()

ica.fit(raw)
ica.plot_properties(raw, picks=[0, 1])
```
![image](https://user-images.githubusercontent.com/29604854/89626165-8df7a800-d8cb-11ea-8a86-8f3888382ddf.png)
![image](https://user-images.githubusercontent.com/29604854/89626182-9354f280-d8cb-11ea-8891-ff5ce3842c32.png)

After adding annotations
```python

# refitting with annotations
a = mne.Annotations(onset=[3],
                    duration=[1],
                    description=['BAD'])
raw.set_annotations(a)

ica.fit(raw)
ica.plot_properties(raw, picks=[0, 1])
```
![image](https://user-images.githubusercontent.com/29604854/89626243-aa93e000-d8cb-11ea-8df5-e516bfaea013.png)
![image](https://user-images.githubusercontent.com/29604854/89626251-aebffd80-d8cb-11ea-89a1-c5271b6ccbb8.png)

This PR fixes the bug and the results are not influenced.
