### PR TITLE
MRG, MAINT: Go back to OrderedDict

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -2,6 +2,7 @@
 #
 # License: BSD (3-clause)
 
+from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
 import os.path as op
 import re
@@ -249,7 +250,7 @@ class Annotations(object):
             out_keys = ('onset', 'duration', 'description', 'orig_time')
             out_vals = (self.onset[key], self.duration[key],
                         self.description[key], self.orig_time)
-            return dict(zip(out_keys, out_vals))
+            return OrderedDict(zip(out_keys, out_vals))
         else:
             key = list(key) if isinstance(key, tuple) else key
             return Annotations(onset=self.onset[key],

--- a/mne/channels/_standard_montage_utils.py
+++ b/mne/channels/_standard_montage_utils.py
@@ -2,6 +2,7 @@
 #          Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #
 # License: BSD (3-clause)
+from collections import OrderedDict
 import os.path as op
 import numpy as np
 
@@ -90,7 +91,7 @@ def _mgh_or_standard(basename, head_size):
             ch_names_.append(line.strip(' ').strip('\n'))
 
     pos = np.array(pos)
-    ch_pos = dict(zip(ch_names_, pos))
+    ch_pos = OrderedDict(zip(ch_names_, pos))
     nasion, lpa, rpa = [ch_pos.pop(n) for n in fid_names]
     scale = head_size / np.median(np.linalg.norm(pos, axis=1))
     for value in ch_pos.values():
@@ -151,7 +152,7 @@ def _read_sfp(fname, head_size):
     ch_names, xs, ys, zs = _safe_np_loadtxt(fname, **options)
 
     pos = np.stack([xs, ys, zs], axis=-1)
-    ch_pos = dict(zip(ch_names, pos))
+    ch_pos = OrderedDict(zip(ch_names, pos))
     # no one grants that fid names are there.
     nasion, lpa, rpa = [ch_pos.pop(n, None) for n in fid_names]
 
@@ -177,7 +178,7 @@ def _read_csd(fname, head_size):
     if head_size is not None:
         pos *= head_size / np.median(np.linalg.norm(pos, axis=1))
 
-    return make_dig_montage(ch_pos=dict(zip(ch_names, pos)))
+    return make_dig_montage(ch_pos=OrderedDict(zip(ch_names, pos)))
 
 
 def _read_elc(fname, head_size):
@@ -225,7 +226,7 @@ def _read_elc(fname, head_size):
     if head_size is not None:
         pos *= head_size / np.median(np.linalg.norm(pos, axis=1))
 
-    ch_pos = dict(zip(ch_names_, pos))
+    ch_pos = OrderedDict(zip(ch_names_, pos))
     nasion, lpa, rpa = [ch_pos.pop(n, None) for n in fid_names]
 
     return make_dig_montage(ch_pos=ch_pos, coord_frame='unknown',
@@ -251,7 +252,7 @@ def _read_theta_phi_in_degrees(fname, head_size, fid_names=None,
 
     radii = np.full(len(phi), head_size)
     pos = _sph_to_cart(np.array([radii, np.deg2rad(phi), np.deg2rad(theta)]).T)
-    ch_pos = dict(zip(ch_names, pos))
+    ch_pos = OrderedDict(zip(ch_names, pos))
 
     nasion, lpa, rpa = None, None, None
     if fid_names is not None:
@@ -282,7 +283,7 @@ def _read_elp_besa(fname, head_size):
     if head_size is not None:
         pos *= head_size / np.median(np.linalg.norm(pos, axis=1))
 
-    ch_pos = dict(zip(ch_names, pos))
+    ch_pos = OrderedDict(zip(ch_names, pos))
 
     fid_names = ('Nz', 'LPA', 'RPA')
     # No one grants that the fid names actually exist.
@@ -310,4 +311,4 @@ def _read_brainvision(fname, head_size):
     if head_size is not None:
         pos *= head_size / np.median(np.linalg.norm(pos, axis=1))
 
-    return make_dig_montage(ch_pos=dict(zip(ch_names, pos)))
+    return make_dig_montage(ch_pos=OrderedDict(zip(ch_names, pos)))

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -5,6 +5,7 @@
 #          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 # License: BSD Style.
 
+from collections import OrderedDict
 import os
 import os.path as op
 import shutil
@@ -701,7 +702,7 @@ def fetch_hcp_mmp_parcellation(subjects_dir=None, combine=True, verbose=None):
             return
         # otherwise, let's make them
         logger.info('Creating combined labels')
-        groups = dict([
+        groups = OrderedDict([
             ('Primary Visual Cortex (V1)',
              ('V1',)),
             ('Early Visual Cortex',

--- a/mne/io/what.py
+++ b/mne/io/what.py
@@ -3,6 +3,8 @@
 #
 # License: BSD (3-clause)
 
+from collections import OrderedDict
+
 from ..fixes import _get_args
 from ..utils import _check_fname, logger
 
@@ -38,7 +40,7 @@ def what(fname):
     from ..proj import read_proj
     from .meas_info import read_fiducials
     _check_fname(fname, overwrite='read', must_exist=True)
-    checks = dict()
+    checks = OrderedDict()
     checks['raw'] = read_raw_fif
     checks['ica'] = read_ica
     checks['epochs'] = read_epochs

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -2,6 +2,7 @@
 #
 # License: BSD 3 clause
 
+from collections import OrderedDict
 from datetime import datetime, timezone
 from itertools import repeat
 import sys
@@ -967,7 +968,7 @@ def test_annotations_simple_iteration():
                         orig_time=None)
 
     for ii, elements in enumerate(annot[:2]):
-        assert isinstance(elements, dict)
+        assert isinstance(elements, OrderedDict)
         expected_values = (ii, ii, str(ii))
         for elem, expected_type, expected_value in zip(elements.values(),
                                                        EXPECTED_ELEMENTS_TYPE,

--- a/mne/utils/mixin.py
+++ b/mne/utils/mixin.py
@@ -4,7 +4,7 @@
 #
 # License: BSD (3-clause)
 
-
+from collections import OrderedDict
 from copy import deepcopy
 import logging
 import json
@@ -413,7 +413,7 @@ def _prepare_read_metadata(metadata):
         pd = _check_pandas_installed(strict=False)
         # use json.loads because this preserves ordering
         # (which is necessary for round-trip equivalence)
-        metadata = json.loads(metadata, object_pairs_hook=dict)
+        metadata = json.loads(metadata, object_pairs_hook=OrderedDict)
         assert isinstance(metadata, list)
         if pd:
             metadata = pd.DataFrame.from_records(metadata)


### PR DESCRIPTION
As discussed in #8014, reverts parts of #7635: dict ordering was a CPython implementation detail in 3.6, becoming an official language feature in 3.7, so to be safe let's use OrderedDict until we require 3.7+.