### PR TITLE
MRG, MAINT: Update nitpick_ignore for sphinx

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -116,6 +116,24 @@ nitpick_ignore = [
     ("py:class", "an object providing a view on D's values"),
     ("py:class", "a shallow copy of D"),
 ]
+for key in ('AcqParserFIF', 'BiHemiLabel', 'Dipole', 'DipoleFixed', 'Label',
+            'MixedSourceEstimate', 'MixedVectorSourceEstimate', 'Report',
+            'SourceEstimate', 'SourceMorph', 'VectorSourceEstimate',
+            'VolSourceEstimate', 'VolVectorSourceEstimate',
+            'channels.DigMontage', 'channels.Layout',
+            'decoding.CSP', 'decoding.EMS', 'decoding.FilterEstimator',
+            'decoding.GeneralizingEstimator', 'decoding.LinearModel',
+            'decoding.PSDEstimator', 'decoding.ReceptiveField',
+            'decoding.SPoC', 'decoding.Scaler', 'decoding.SlidingEstimator',
+            'decoding.TemporalFilter', 'decoding.TimeDelayingRidge',
+            'decoding.TimeFrequency', 'decoding.UnsupervisedSpatialFilter',
+            'decoding.Vectorizer',
+            'preprocessing.ICA', 'preprocessing.Xdawn',
+            'simulation.SourceSimulator',
+            'time_frequency.CrossSpectralDensity',
+            'utils.deprecated',
+            'viz.ClickableImage'):
+    nitpick_ignore.append(('py:obj', f'mne.{key}.__hash__'))
 suppress_warnings = ['image.nonlocal_uri']  # we intentionally link outside
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
Nitpicky got more nitpicky and catches a bunch of missing `__hash__` defs. We can just ignore these because we don't want to add these methods, and also don't want to switch to different `class.rst` templates depending on whether or not a given class defines the `__hash__` method.