### PR TITLE
MRG: Added support for NIRStar version 15.3

### DIFF
--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -108,7 +108,7 @@ class RawNIRX(BaseRaw):
 
         # Check that the file format version is supported
         if not any(item == hdr['GeneralInfo']['NIRStar'] for item in
-                   ["\"15.0\"", "\"15.2\""]):
+                   ["\"15.0\"", "\"15.2\"", "\"15.3\""]):
             raise RuntimeError('MNE does not support this NIRStar version'
                                ' (%s)' % (hdr['GeneralInfo']['NIRStar'],))
         if "NIRScout" not in hdr['GeneralInfo']['Device']:

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -107,10 +107,12 @@ class RawNIRX(BaseRaw):
         hdr.read_string(hdr_str)
 
         # Check that the file format version is supported
-        if not any(item == hdr['GeneralInfo']['NIRStar'] for item in
-                   ["\"15.0\"", "\"15.2\"", "\"15.3\""]):
+        if hdr['GeneralInfo']['NIRStar'] not in ['"15.0"', '"15.2"', '"15.3"']:
             raise RuntimeError('MNE does not support this NIRStar version'
                                ' (%s)' % (hdr['GeneralInfo']['NIRStar'],))
+        if hdr['GeneralInfo']['NIRStar'] in ['"15.3"']:
+            warn("Full MNE support for NIRStar version 15.3 currently under development.")        
+
         if "NIRScout" not in hdr['GeneralInfo']['Device']:
             warn("Only import of data from NIRScout devices have been "
                  "thoroughly tested. You are using a %s device. " %

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -110,8 +110,9 @@ class RawNIRX(BaseRaw):
         if hdr['GeneralInfo']['NIRStar'] not in ['"15.0"', '"15.2"', '"15.3"']:
             raise RuntimeError('MNE does not support this NIRStar version'
                                ' (%s)' % (hdr['GeneralInfo']['NIRStar'],))
-        if hdr['GeneralInfo']['NIRStar'] in ['"15.3"']:
-            warn("Full MNE support for NIRStar version 15.3 currently under development.")        
+        if hdr['GeneralInfo']['NIRStar'] == '"15.3"':
+            warn("Full support for NIRStar version 15.3 is currently under "
+                 "development.")
 
         if "NIRScout" not in hdr['GeneralInfo']['Device']:
             warn("Only import of data from NIRScout devices have been "


### PR DESCRIPTION
#### Reference issue
Fixes issue #8120 


#### What does this implement/fix?
Added support for NIRStar version 15.3 when importing NIRx data using mne.io.read_raw_nirx().
