### PR TITLE
MRG: Patch quiver3d()

### DIFF
--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -429,11 +429,16 @@ class _Renderer(_BaseRenderer):
             if mode == '2darrow':
                 return _arrow_glyph(grid, factor)
             elif mode == 'arrow' or mode == '3darrow':
+                mesh = _glyph(
+                    grid,
+                    orient='vec',
+                    scalars=scale,
+                    factor=factor
+                )
+                mesh = pyvista.wrap(mesh)
                 _add_mesh(
                     self.plotter,
-                    mesh=grid.glyph(orient='vec',
-                                    scale=scale,
-                                    factor=factor),
+                    mesh=mesh,
                     color=color,
                     opacity=opacity,
                     backface_culling=backface_culling


### PR DESCRIPTION
This PR fixes the bug with the axes in `plot_alignment()`. The visual bug happened because of a pre-processing in the PyVista `glyph()` filter that merges the coincident points. 

I'll see how to avoid this preprocessing if possible in PyVista directly.

Close #8115 