### PR TITLE
MRG, ENH: Speed up vol label extraction

### DIFF
--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2954,12 +2954,16 @@ def _prepare_label_extraction(stc, labels, src, mode, allow_empty, use_sparse):
     for li, label in enumerate(labels):
         if use_sparse:
             assert isinstance(label, dict)
+            vertidx = label['csr']
             # This can happen if some labels aren't present in the space
-            if label['csr'].shape[0] == 0:
+            if vertidx.shape[0] == 0:
                 bad_labels.append(label['name'])
-                label_vertidx.append(None)
-            else:
-                label_vertidx.append(label['csr'])
+                vertidx = None
+            # Efficiency shortcut: use linearity early to avoid redundant
+            # calculations
+            elif mode == 'mean':
+                vertidx = sparse.csr_matrix(vertidx.mean(axis=0))
+            label_vertidx.append(vertidx)
             label_flip.append(None)
             continue
         # standard case
@@ -3162,7 +3166,7 @@ def _gen_extract_label_time_course(stcs, labels, src, mode='mean',
                     assert mri_resolution
                     assert vertidx.shape[1] == stc.data.shape[0]
                     this_data = np.reshape(stc.data, (stc.data.shape[0], -1))
-                    this_data = vertidx * this_data
+                    this_data = vertidx @ this_data
                     this_data.shape = \
                         (this_data.shape[0],) + stc.data.shape[1:]
                 else:


### PR DESCRIPTION
When using `extract_label_time_course` with volumes and `mri_resolution=True` (default) and `mode='mean'` (default), for large volumetric regions like `Left-Cerebral-White-Matter` that are part of the LUT you can end up exploding data into a high-res MRI space. If you have 10000 time points, the CSR dot product will be a crazy shape like `(100000, 10000)` and kill memory; and even if it succeeds, it then takes the mean across the first dimension (high-res voxels).

There is a nice shortcut by linearity where the upsampling matrix itself can just be averaged across vertices head of time, so that the CSR dot result is just shape `(1, 10000)`, and the downstream code then takes `np.mean(..., axis=0)` of this as a no-op.

I also made a change from `*` to `@` in the code to make it clear that it's actually a dot product. The `*` is always with a sparse matrix, so it was always matrix product -- the code change is just to make it explicit.