### PR TITLE
MRG, FIX: Remove fix description for function not yet in stable

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -309,8 +309,6 @@ Bug
 
 - Fix bug with :meth:`mne.preprocessing.ICA.plot_properties` where a :class:`mne.io.Raw` object with annotations would lead to an error by `Yu-Han Luo`_
 
-- Fix bug with :func:`mne.channels.combine_channels` where events of class:`mne.Epochs` were not preserved by `Johann Benerradi`_
-
 API
 ~~~
 


### PR DESCRIPTION
#### Reference issue
Related to #8138.


#### What does this implement/fix?
Remove fix description in "What's new" for `mne.channels.combine_channels` because function not yet in stable release.
