### PR TITLE
CSP component order selection

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -177,6 +177,8 @@ Changelog
 
 - `~mne.Report.parse_folder` now accepts a path-like folder name (it used to work with strings only) by `Alex Gramfort`_
 
+- Add ``component_order`` parameter to :class:`mne.decoding.CSP` which allows switching between ``mutual_info`` (default) and ``alternate`` (a simpler and frequently used option) by `Martin Billinger`_ and `Clemens Brunner`_
+
 Bug
 ~~~
 

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -57,10 +57,8 @@
 @inproceedings{BarachantEtAl2010,
   author = {Barachant, Alexandre and Bonnet, Stephane and Congedo, Marco and Jutten, Christian},
   booktitle = {2010 IEEE International Workshop on Multimedia Signal Processing},
-  title = {Common Spatial Pattern revisited by Riemannian geometry},
+  title = {Common Spatial Pattern revisited by {Riemannian} geometry},
   year = {2010},
-  volume = {},
-  number = {},
   pages={472-476}
 }
 

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -59,7 +59,8 @@
   booktitle = {2010 IEEE International Workshop on Multimedia Signal Processing},
   title = {Common Spatial Pattern revisited by {Riemannian} geometry},
   year = {2010},
-  pages={472-476}
+  pages={472-476},
+  doi = {10.1109/MMSP.2010.5662067}
 }
 
 @book{Barber2012,

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -51,7 +51,8 @@
   pages = {14-30},
   title = {Electromagnetic Brain Mapping},
   volume = {18},
-  year = {2001}
+  year = {2001},
+  doi = {10.1109/MMSP.2010.5662067}
 }
 
 @inproceedings{BarachantEtAl2010,

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -54,6 +54,16 @@
   year = {2001}
 }
 
+@inproceedings{BarachantEtAl2010,
+  author = {Barachant, Alexandre and Bonnet, Stephane and Congedo, Marco and Jutten, Christian},
+  booktitle = {2010 IEEE International Workshop on Multimedia Signal Processing},
+  title = {Common Spatial Pattern revisited by Riemannian geometry},
+  year = {2010},
+  volume = {},
+  number = {},
+  pages={472-476}
+}
+
 @book{Barber2012,
   address = {{Cambridge}},
   author = {Barber, David},

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -51,8 +51,7 @@
   pages = {14-30},
   title = {Electromagnetic Brain Mapping},
   volume = {18},
-  year = {2001},
-  doi = {10.1109/MMSP.2010.5662067}
+  year = {2001}
 }
 
 @inproceedings{BarachantEtAl2010,

--- a/examples/decoding/plot_decoding_csp_eeg.py
+++ b/examples/decoding/plot_decoding_csp_eeg.py
@@ -5,8 +5,8 @@
 Motor imagery decoding from EEG data using the Common Spatial Pattern (CSP)
 ===========================================================================
 
-Decoding of motor imagery applied to EEG data decomposed using CSP.
-Here the classifier is applied to features extracted on CSP filtered signals.
+Decoding of motor imagery applied to EEG data decomposed using CSP. A
+classifier is then applied to features extracted on CSP-filtered signals.
 
 See https://en.wikipedia.org/wiki/Common_spatial_pattern and [1]_. The EEGBCI
 dataset is documented in [2]_. The data set is available at PhysioNet [3]_.

--- a/examples/decoding/plot_decoding_csp_timefreq.py
+++ b/examples/decoding/plot_decoding_csp_timefreq.py
@@ -49,7 +49,7 @@ raw.load_data()
 clf = make_pipeline(CSP(n_components=4, reg=None, log=True, norm_trace=False),
                     LinearDiscriminantAnalysis())
 n_splits = 5  # how many folds to use for cross-validation
-cv = StratifiedKFold(n_splits=n_splits, shuffle=True)
+cv = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=42)
 
 # Classification & time-frequency parameters
 tmin, tmax = -.200, 2.000

--- a/examples/decoding/plot_decoding_csp_timefreq.py
+++ b/examples/decoding/plot_decoding_csp_timefreq.py
@@ -1,7 +1,7 @@
 """
-============================================================================
-Decoding in time-frequency space data using the Common Spatial Pattern (CSP)
-============================================================================
+====================================================================
+Decoding in time-frequency space using Common Spatial Patterns (CSP)
+====================================================================
 
 The time-frequency decomposition is estimated by iterating over raw data that
 has been band-passed at different frequencies. This is used to compute a

--- a/examples/decoding/plot_decoding_csp_timefreq.py
+++ b/examples/decoding/plot_decoding_csp_timefreq.py
@@ -51,7 +51,7 @@ clf = make_pipeline(CSP(n_components=4, reg=None, log=True, norm_trace=False),
 n_splits = 5  # how many folds to use for cross-validation
 cv = StratifiedKFold(n_splits=n_splits, shuffle=True)
 
-# Classification & Time-frequency parameters
+# Classification & time-frequency parameters
 tmin, tmax = -.200, 2.000
 n_cycles = 10.  # how many complete cycles: used to define window size
 min_freq = 5.

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -24,8 +24,9 @@ class CSP(TransformerMixin, BaseEstimator):
 
     This class can be used as a supervised decomposition to estimate spatial
     filters for feature extraction. CSP in the context of EEG was first
-    described in [1]; a comprehensive tutorial on CSP can be found in [2].
-    Multi-class solving is implemented from [3].
+    described in :footcite:`KolesEtAl1990`; a comprehensive tutorial on CSP can
+    be found in :footcite:`BlankertzEtAl2008`. Multi-class solving is
+    implemented from :footcite:`Grosse-WentrupBuss2008`.
 
     Parameters
     ----------
@@ -52,9 +53,11 @@ class CSP(TransformerMixin, BaseEstimator):
         will return the data in CSP space.
     norm_trace : bool (default False)
         Normalize class covariance by its trace. Trace normalization is a step
-        of the original CSP algorithm [1]_ to eliminate magnitude variations in
-        the EEG between individuals. It is not applied in more recent work
-        [2]_, [3]_ and can have a negative impact on patterns order.
+        of the original CSP algorithm :footcite:`KolesEtAl1990` to eliminate
+        magnitude variations in the EEG between individuals. It is not applied
+        in more recent work :footcite:`BlankertzEtAl2008`,
+        :footcite:`Grosse-WentrupBuss2008` and can have a negative impact on
+        pattern order.
     cov_method_params : dict | None
         Parameters to pass to :func:`mne.compute_covariance`.
 
@@ -66,9 +69,10 @@ class CSP(TransformerMixin, BaseEstimator):
         If ``'mutual_info'`` order components by decreasing mutual information
         (in the two-class case this uses a simplification which orders
         components by decreasing absolute deviation of the eigenvalues from 0.5
-        [4]_). For the two-class case, ``'alternate'`` orders components by
-        starting with the largest eigenvalue, followed by the smallest, the
-        second-to-largest, the second-to-smallest, and so on [2]_.
+        :footcite:`BarachantEtAl2010`). For the two-class case, ``'alternate'``
+        orders components by starting with the largest eigenvalue, followed by
+        the smallest, the second-to-largest, the second-to-smallest, and so on
+        :footcite:`BlankertzEtAl2008`.
 
         .. versionadded:: 0.21
 
@@ -89,20 +93,7 @@ class CSP(TransformerMixin, BaseEstimator):
 
     References
     ----------
-    .. [1] Zoltan J. Koles, Michael S. Lazar, Steven Z. Zhou. Spatial Patterns
-           Underlying Population Differences in the Background EEG. Brain
-           Topography 2(4), 275-284, 1990.
-    .. [2] Benjamin Blankertz, Ryota Tomioka, Steven Lemm, Motoaki Kawanabe,
-           Klaus-Robert Müller. Optimizing Spatial Filters for Robust EEG
-           Single-Trial Analysis. IEEE Signal Processing Magazine 25(1), 41-56,
-           2008.
-    .. [3] Moritz Grosse-Wentrup, Martin Buss. Multiclass common spatial
-           patterns and information theoretic feature extraction. IEEE
-           Transactions on Biomedical Engineering 55(8), 2008.
-    .. [4] Alexandre Barachant, Stephane Bonnet, Marco Congedo, Christian
-           Jutten. Common Spatial Pattern revisited by Riemannian Geometry.
-           IEEE International Workshop on Multimedia Signal Processing (MMSP),
-           p. 472, 2010.
+    .. footbibliography::
     """
 
     def __init__(self, n_components=4, reg=None, log=None, cov_est='concat',

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -66,12 +66,12 @@ class CSP(TransformerMixin, BaseEstimator):
 
         .. versionadded:: 0.17
     component_order : 'mutual_info' | 'new' | 'old' | 'None' (default None)
-        If 'mutual_info' components are ordered by decreasing mutual information.
-        If 'old' components are ordered by starting with the largest
-        eigenvalue, followed by the smallest, the second-to-largest, the
-        second-to-smallest, and so on [2]_.
-        If 'new' components are ordered by decreasing absolute deviation
-        of the eigenvalues from 0.5 [4]_.
+        If 'mutual_info' order components by decreasing mutual information.
+        If 'old' order components by starting with the largest eigenvalue,
+        followed by the smallest, the second-to-largest, the second-to-
+        smallest, and so on [2]_.
+        If 'new' components are ordered by decreasing absolute deviation of
+        the eigenvalues from 0.5 [4]_.
         If the parameter is not set, component order is selected based on the
         number of classes. The two-class case defaults to 'new' and the
         multi-class case defaults to 'mutual_info'.
@@ -196,7 +196,8 @@ class CSP(TransformerMixin, BaseEstimator):
                                  .format(component_order))
 
         covs, sample_weights = self._compute_covariance_matrices(X, y)
-        eigen_vectors, eigen_values = self._decompose_covs(covs, sample_weights)
+        eigen_vectors, eigen_values = self._decompose_covs(covs,
+                                                           sample_weights)
         ix = self._order_components(covs, sample_weights,
                                     eigen_vectors, eigen_values,
                                     component_order)

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -135,6 +135,9 @@ class CSP(TransformerMixin, BaseEstimator):
 
     def _check_Xy(self, X, y=None):
         """Aux. function to check input data."""
+        if not isinstance(X, np.ndarray):
+            raise ValueError("X should be of type ndarray (got %s)."
+                             % type(X))
         if y is not None:
             if len(X) != len(y) or len(y) < 1:
                 raise ValueError('X and y must have the same length.')
@@ -156,9 +159,6 @@ class CSP(TransformerMixin, BaseEstimator):
         self : instance of CSP
             Returns the modified instance.
         """
-        if not isinstance(X, np.ndarray):
-            raise ValueError("X should be of type ndarray (got %s)."
-                             % type(X))
         self._check_Xy(X, y)
         n_channels = X.shape[1]
 
@@ -722,9 +722,6 @@ class SPoC(CSP):
         self : instance of SPoC
             Returns the modified instance.
         """
-        if not isinstance(X, np.ndarray):
-            raise ValueError("X should be of type ndarray (got %s)."
-                             % type(X))
         self._check_Xy(X, y)
 
         if len(np.unique(y)) < 2:

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -532,7 +532,7 @@ class CSP(TransformerMixin, BaseEstimator):
         return np.stack(covs), np.array(sample_weights)
 
     def _concat_cov(self, x_class):
-        """Concatenate epochs before computing the covariance"""
+        """Concatenate epochs before computing the covariance."""
         _, n_channels, _ = x_class.shape
 
         x_class = np.transpose(x_class, [1, 0, 2])
@@ -545,7 +545,7 @@ class CSP(TransformerMixin, BaseEstimator):
         return cov, weight
 
     def _epoch_cov(self, x_class):
-        """Mean of per-epoch covariances"""
+        """Mean of per-epoch covariances."""
         cov = sum(_regularized_covariance(
             this_X, reg=self.reg,
             method_params=self.cov_method_params,

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -611,15 +611,6 @@ class CSP(TransformerMixin, BaseEstimator):
         return ix
 
 
-def _compute_eigenvalues_from_eigenvectors(mat_a, mat_b, eigen_vectors):
-    """Use of the relation $Av = wBv$ to get eigenvalues (w) if only
-    the matrices A, B and the eigenvectors are known.
-    """
-    a = mat_a[0, :] @ eigen_vectors
-    b = mat_b[0, :] @ eigen_vectors
-    return a / b
-
-
 def _ajd_pham(X, eps=1e-6, max_iter=15):
     """Approximate joint diagonalization based on Pham's algorithm.
 

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -144,7 +144,7 @@ class CSP(TransformerMixin, BaseEstimator):
         if component_order not in ['mutual_info', 'alternate']:
             raise ValueError("'{}' is not a valid component order (valid "
                              "values are 'mutual_info' and 'alternate')."
-                             .format(self.component_order))
+                             .format(component_order))
         self.component_order = component_order
 
     def _check_Xy(self, X, y=None):

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -66,7 +66,9 @@ class CSP(TransformerMixin, BaseEstimator):
         If ``'mutual_info'`` order components by decreasing mutual information
         (in the two-class case this uses a simplification which orders
         components by decreasing absolute deviation of the eigenvalues from 0.5
-        [4]_).
+        [4]_). For the two-class case, ``'alternate'`` orders components by
+        starting with the largest eigenvalue, followed by the smallest, the
+        second-to-largest, the second-to-smallest, and so on [2]_.
 
         .. versionadded:: 0.21
 

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -62,7 +62,7 @@ class CSP(TransformerMixin, BaseEstimator):
     %(rank_None)s
 
         .. versionadded:: 0.17
-    component_order : 'mutual_info' | 'alternate' (default 'alternate')
+    component_order : 'mutual_info' | 'alternate' (default 'mutual_info')
         If ``'mutual_info'`` order components by decreasing mutual information
         (in the two-class case this uses a simplification which orders
         components by decreasing absolute deviation of the eigenvalues from 0.5

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -20,44 +20,41 @@ from ..utils import fill_doc, _check_option
 
 @fill_doc
 class CSP(TransformerMixin, BaseEstimator):
-    u"""M/EEG signal decomposition using the Common Spatial Patterns (CSP).
+    """M/EEG signal decomposition using the Common Spatial Patterns (CSP).
 
-    This object can be used as a supervised decomposition to estimate
-    spatial filters for feature extraction in a 2 class decoding problem.
-    CSP in the context of EEG was first described in [1]; a comprehensive
-    tutorial on CSP can be found in [2]. Multiclass solving is implemented
-    from [3].
+    This class can be used as a supervised decomposition to estimate spatial
+    filters for feature extraction. CSP in the context of EEG was first
+    described in [1]; a comprehensive tutorial on CSP can be found in [2].
+    Multi-class solving is implemented from [3].
 
     Parameters
     ----------
-    n_components : int, default 4
-        The number of components to decompose M/EEG signals.
-        This number should be set by cross-validation.
+    n_components : int (default 4)
+        The number of components to decompose M/EEG signals. This number should
+        be set by cross-validation.
     reg : float | str | None (default None)
-        If not None (same as ``'empirical'``, default), allow
-        regularization for covariance estimation.
-        If float, shrinkage is used (0 <= shrinkage <= 1).
-        For str options, ``reg`` will be passed to ``method`` to
+        If not None (same as ``'empirical'``, default), allow regularization
+        for covariance estimation. If float (between 0 and 1), shrinkage is
+        used. For str values, ``reg`` will be passed as ``method`` to
         :func:`mne.compute_covariance`.
     log : None | bool (default None)
-        If transform_into == 'average_power' and log is None or True, then
-        applies a log transform to standardize the features, else the features
-        are z-scored. If transform_into == 'csp_space', then log must be None.
-    cov_est : 'concat' | 'epoch', default 'concat'
-        If 'concat', covariance matrices are estimated on concatenated epochs
-        for each class.
-        If 'epoch', covariance matrices are estimated on each epoch separately
-        and then averaged over each class.
-    transform_into : {'average_power', 'csp_space'}
-        If 'average_power' then self.transform will return the average power of
-        each spatial filter. If 'csp_space' self.transform will return the data
-        in CSP space. Defaults to 'average_power'.
-    norm_trace : bool
-        Normalize class covariance by its trace. Defaults to False. Trace
-        normalization is a step of the original CSP algorithm [1]_ to eliminate
-        magnitude variations in the EEG between individuals. It is not applied
-        in more recent work [2]_, [3]_ and can have a negative impact on
-        patterns ordering.
+        If ``transform_into`` equals ``'average_power'`` and ``log`` is None or
+        True, then apply a log transform to standardize features, else features
+        are z-scored. If ``transform_into`` is ``'csp_space'``, ``log`` must be
+        None.
+    cov_est : 'concat' | 'epoch' (default 'concat')
+        If ``'concat'``, covariance matrices are estimated on concatenated
+        epochs for each class. If ``'epoch'``, covariance matrices are
+        estimated on each epoch separately and then averaged over each class.
+    transform_into : 'average_power' | 'csp_space' (default 'average_power')
+        If 'average_power' then ``self.transform`` will return the average
+        power of each spatial filter. If ``'csp_space'``, ``self.transform``
+        will return the data in CSP space.
+    norm_trace : bool (default False)
+        Normalize class covariance by its trace. Trace normalization is a step
+        of the original CSP algorithm [1]_ to eliminate magnitude variations in
+        the EEG between individuals. It is not applied in more recent work
+        [2]_, [3]_ and can have a negative impact on patterns order.
     cov_method_params : dict | None
         Parameters to pass to :func:`mne.compute_covariance`.
 
@@ -65,17 +62,13 @@ class CSP(TransformerMixin, BaseEstimator):
     %(rank_None)s
 
         .. versionadded:: 0.17
-    component_order : 'mutual_info' | 'new' | 'old' | 'None' (default None)
-        If 'mutual_info' order components by decreasing mutual information.
-        If 'old' order components by starting with the largest eigenvalue,
-        followed by the smallest, the second-to-largest, the second-to-
-        smallest, and so on [2]_.
-        If 'new' components are ordered by decreasing absolute deviation of
-        the eigenvalues from 0.5 [4]_.
-        If the parameter is not set, component order is selected based on the
-        number of classes. The two-class case defaults to 'new' and the
-        multi-class case defaults to 'mutual_info'.
-        Note that 'old' and 'new' can only be used with the two-class case.
+    component_order : 'mutual_info' | 'alternate' (default 'alternate')
+        If ``'mutual_info'`` order components by decreasing mutual information
+        (in the two-class case this uses a simplification which orders
+        components by decreasing absolute deviation of the eigenvalues from 0.5
+        [4]_).
+
+        .. versionadded:: 0.21
 
     Attributes
     ----------
@@ -101,25 +94,24 @@ class CSP(TransformerMixin, BaseEstimator):
            Klaus-Robert Müller. Optimizing Spatial Filters for Robust EEG
            Single-Trial Analysis. IEEE Signal Processing Magazine 25(1), 41-56,
            2008.
-    .. [3] Grosse-Wentrup, Moritz, and Martin Buss. Multiclass common spatial
+    .. [3] Moritz Grosse-Wentrup, Martin Buss. Multiclass common spatial
            patterns and information theoretic feature extraction. IEEE
-           Transactions on Biomedical Engineering, Vol 55, no. 8, 2008.
+           Transactions on Biomedical Engineering 55(8), 2008.
     .. [4] Alexandre Barachant, Stephane Bonnet, Marco Congedo, Christian
            Jutten. Common Spatial Pattern revisited by Riemannian Geometry.
            IEEE International Workshop on Multimedia Signal Processing (MMSP),
-           pp.472, 2010.
+           p. 472, 2010.
     """
 
-    def __init__(self, n_components=4, reg=None, log=None, cov_est="concat",
+    def __init__(self, n_components=4, reg=None, log=None, cov_est='concat',
                  transform_into='average_power', norm_trace=False,
-                 cov_method_params=None, rank=None, component_order=None):
-        """Init of CSP."""
+                 cov_method_params=None, rank=None,
+                 component_order='mutual_info'):
         # Init default CSP
         if not isinstance(n_components, int):
             raise ValueError('n_components must be an integer.')
         self.n_components = n_components
         self.rank = rank
-
         self.reg = reg
 
         # Init default cov_est
@@ -144,13 +136,17 @@ class CSP(TransformerMixin, BaseEstimator):
         self.log = log
 
         if not isinstance(norm_trace, bool):
-            raise ValueError('norm_trace must be a bool.')
+            raise ValueError('norm_trace must be a bool')
         self.norm_trace = norm_trace
         self.cov_method_params = cov_method_params
+        if component_order not in ['mutual_info', 'alternate']:
+            raise ValueError("'{}' is not a valid component order (valid "
+                             "values are 'mutual_info' and 'alternate')."
+                             .format(self.component_order))
         self.component_order = component_order
 
     def _check_Xy(self, X, y=None):
-        """Aux. function to check input data."""
+        """Check input data."""
         if not isinstance(X, np.ndarray):
             raise ValueError("X should be of type ndarray (got %s)."
                              % type(X))
@@ -181,26 +177,17 @@ class CSP(TransformerMixin, BaseEstimator):
         n_classes = len(self._classes)
         if n_classes < 2:
             raise ValueError("n_classes must be >= 2.")
-
-        if n_classes == 2:
-            component_order = self.component_order or 'new'
-            if component_order not in ['new', 'old', 'mutual_info']:
-                raise ValueError("'{}' is not a valid component order. Valid "
-                                 "values are 'mutual_info', 'new', 'old'."
-                                 .format(component_order))
-        else:
-            component_order = self.component_order or 'mutual_info'
-            if not component_order == 'mutual_info':
-                raise ValueError("'{}' is not a valid component order for "
-                                 "n_classes > 2. Use 'mutual_info' instead."
-                                 .format(component_order))
+        if n_classes > 2 and self.component_order == 'alternate':
+            raise ValueError("component_order='alternate' requires two "
+                             "classes, but data contains {} classes; use "
+                             "component_order='mutual_info' "
+                             "instead.".format(n_classes))
 
         covs, sample_weights = self._compute_covariance_matrices(X, y)
         eigen_vectors, eigen_values = self._decompose_covs(covs,
                                                            sample_weights)
-        ix = self._order_components(covs, sample_weights,
-                                    eigen_vectors, eigen_values,
-                                    component_order)
+        ix = self._order_components(covs, sample_weights, eigen_vectors,
+                                    eigen_values, self.component_order)
 
         eigen_vectors = eigen_vectors[:, ix]
 
@@ -594,16 +581,16 @@ class CSP(TransformerMixin, BaseEstimator):
             eigen_vectors[:, ii] /= np.sqrt(tmp)
         return eigen_vectors
 
-    def _order_components(self, covs, sample_weights,
-                          eigen_vectors, eigen_values,
-                          component_order):
-        if component_order == 'mutual_info':
+    def _order_components(self, covs, sample_weights, eigen_vectors,
+                          eigen_values, component_order):
+        n_classes = len(self._classes)
+        if component_order == 'mutual_info' and n_classes > 2:
             mutual_info = self._compute_mutual_info(covs, sample_weights,
                                                     eigen_vectors)
             ix = np.argsort(mutual_info)[::-1]
-        elif component_order == 'new':
+        elif component_order == 'mutual_info' and n_classes == 2:
             ix = np.argsort(np.abs(eigen_values - 0.5))[::-1]
-        elif component_order == 'old':
+        elif component_order == 'alternate' and n_classes == 2:
             i = np.argsort(eigen_values)
             ix = np.empty_like(i)
             ix[1::2] = i[:len(i) // 2]

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -15,7 +15,7 @@ from scipy import linalg
 from .base import BaseEstimator
 from .mixin import TransformerMixin
 from ..cov import _regularized_covariance
-from ..utils import fill_doc, _check_option
+from ..utils import fill_doc, _check_option, _validate_type
 
 
 @fill_doc
@@ -137,14 +137,11 @@ class CSP(TransformerMixin, BaseEstimator):
                                  '"csp_space".')
         self.log = log
 
-        if not isinstance(norm_trace, bool):
-            raise ValueError('norm_trace must be a bool')
+        _validate_type(norm_trace, bool, 'norm_trace')
         self.norm_trace = norm_trace
         self.cov_method_params = cov_method_params
-        if component_order not in ['mutual_info', 'alternate']:
-            raise ValueError("'{}' is not a valid component order (valid "
-                             "values are 'mutual_info' and 'alternate')."
-                             .format(component_order))
+        _check_option('component_order', component_order,
+                      ('mutual_info', 'alternate'))
         self.component_order = component_order
 
     def _check_Xy(self, X, y=None):

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -568,10 +568,8 @@ class CSP(TransformerMixin, BaseEstimator):
         return eigen_vectors, eigen_values
 
     def _compute_mutual_info(self, covs, sample_weights, eigen_vectors):
-        # class probability
         class_probas = sample_weights / sample_weights.sum()
 
-        # mutual information
         mutual_info = []
         for jj in range(eigen_vectors.shape[1]):
             aa, bb = 0, 0
@@ -589,7 +587,6 @@ class CSP(TransformerMixin, BaseEstimator):
         # Here we apply an euclidean mean. See pyRiemann for other metrics
         mean_cov = np.average(covs, axis=0, weights=sample_weights)
 
-        # normalize
         for ii in range(eigen_vectors.shape[1]):
             tmp = np.dot(np.dot(eigen_vectors[:, ii].T, mean_cov),
                          eigen_vectors[:, ii])

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -354,3 +354,7 @@ def test_csp_component_ordering():
     # p_alt arranges them to [0.8, 0.06, 0.5, 0.1]
     # p_mut arranges them to [0.06, 0.1, 0.8, 0.5]
     assert_array_almost_equal(p_alt, p_mut[[2, 0, 3, 1]])
+
+    # component_order='alternate' only works with two classes
+    csp = CSP(component_order='alternate')
+    pytest.raises(ValueError, csp.fit, X=np.ones((3, 4, 16)), y=[1, 2, 3])

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -342,6 +342,7 @@ def test_csp_component_ordering():
 
     pytest.raises(ValueError, CSP, component_order='invalid')
 
+    # component_order='alternate' only works with two classes
     csp = CSP(component_order='alternate')
     with pytest.raises(ValueError):
         csp.fit(np.zeros((3, 0, 0)), ['a', 'b', 'c'])
@@ -354,7 +355,3 @@ def test_csp_component_ordering():
     # p_alt arranges them to [0.8, 0.06, 0.5, 0.1]
     # p_mut arranges them to [0.06, 0.1, 0.8, 0.5]
     assert_array_almost_equal(p_alt, p_mut[[2, 0, 3, 1]])
-
-    # component_order='alternate' only works with two classes
-    csp = CSP(component_order='alternate')
-    pytest.raises(ValueError, csp.fit, X=np.ones((3, 4, 16)), y=[1, 2, 3])

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -342,6 +342,10 @@ def test_csp_component_ordering():
 
     pytest.raises(ValueError, CSP, component_order='invalid')
 
+    csp = CSP(component_order='alternate')
+    with pytest.raises(ValueError):
+        csp.fit(np.zeros((3, 0, 0)), ['a', 'b', 'c'])
+
     p_alt = CSP(component_order='alternate').fit(x, y).patterns_
     p_mut = CSP(component_order='mutual_info').fit(x, y).patterns_
 

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -340,14 +340,13 @@ def test_csp_component_ordering():
     """Test that CSP component ordering works as expected."""
     x, y = deterministic_toy_data(['class_a', 'class_b'])
 
-    p_new = CSP(component_order='new').fit(x, y).patterns_
-    p_old = CSP(component_order='old').fit(x, y).patterns_
+    pytest.raises(ValueError, CSP, component_order='invalid')
+
+    p_alt = CSP(component_order='alternate').fit(x, y).patterns_
     p_mut = CSP(component_order='mutual_info').fit(x, y).patterns_
 
-    assert_array_almost_equal(p_new, p_mut)
-
-    # This permutation of p_old and p_new is explained by the particular
+    # This permutation of p_alt and p_mut is explained by the particular
     # eigenvalues of the toy data: [0.06, 0.1,   0.5,  0.8].
-    # p_old arranges them to [0.8, 0.06, 0.5, 0.1]
-    # p_new arranges them to [0.06, 0.1, 0.8, 0.5]
-    assert_array_almost_equal(p_old, p_new[[2, 0, 3, 1]])
+    # p_alt arranges them to [0.8, 0.06, 0.5, 0.1]
+    # p_mut arranges them to [0.06, 0.1, 0.8, 0.5]
+    assert_array_almost_equal(p_alt, p_mut[[2, 0, 3, 1]])

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -5,7 +5,6 @@
 #
 # License: BSD (3-clause)
 
-import itertools
 import os.path as op
 
 import numpy as np
@@ -334,3 +333,19 @@ def test_csp_twoclass_symmetry():
 
     assert_array_almost_equal(log_power_ratio_ab,
                               log_power_ratio_ba)
+
+
+def test_csp_decomposition_selection():
+    x, y = deterministic_toy_data(['class_a', 'class_b'])
+
+    csp = CSP(cov_decomposition='eigen')
+    log_power_eigen = csp.fit_transform(x, y)
+
+    csp = CSP(cov_decomposition='pham')
+    log_power_pham = csp.fit_transform(x, y)
+
+    assert_array_almost_equal(log_power_eigen, log_power_pham)
+
+    with pytest.raises(ValueError):
+        csp = CSP(cov_decomposition='eigen')
+        csp.fit(np.random.randn(3, 5, 10), np.array(['A', 'B', 'C']))

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -335,17 +335,17 @@ def test_csp_twoclass_symmetry():
                               log_power_ratio_ba)
 
 
-def test_csp_decomposition_selection():
+def test_csp_component_ordering():
     x, y = deterministic_toy_data(['class_a', 'class_b'])
 
-    csp = CSP(cov_decomposition='eigen')
-    log_power_eigen = csp.fit_transform(x, y)
+    p_new = CSP(component_order='new').fit(x, y).patterns_
+    p_old = CSP(component_order='old').fit(x, y).patterns_
+    p_mut = CSP(component_order='mutual_info').fit(x, y).patterns_
 
-    csp = CSP(cov_decomposition='pham')
-    log_power_pham = csp.fit_transform(x, y)
+    assert_array_almost_equal(p_new, p_mut)
 
-    assert_array_almost_equal(log_power_eigen, log_power_pham)
-
-    with pytest.raises(ValueError):
-        csp = CSP(cov_decomposition='eigen')
-        csp.fit(np.random.randn(3, 5, 10), np.array(['A', 'B', 'C']))
+    # This permutation of p_old and p_new is explained by the particular
+    # eigenvalues of the toy data: [0.06, 0.1,   0.5,  0.8].
+    # p_old arranges them to [0.8, 0.06, 0.5, 0.1]
+    # p_new arranges them to [0.06, 0.1, 0.8, 0.5]
+    assert_array_almost_equal(p_old, p_new[[2, 0, 3, 1]])

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -321,6 +321,7 @@ def test_spoc():
 
 
 def test_csp_twoclass_symmetry():
+    """Test that CSP is symmetric when swapping classes."""
     x, y = deterministic_toy_data(['class_a', 'class_b'])
     csp = CSP(norm_trace=False, transform_into='average_power', log=True)
     log_power = csp.fit_transform(x, y)
@@ -336,6 +337,7 @@ def test_csp_twoclass_symmetry():
 
 
 def test_csp_component_ordering():
+    """Test that CSP component ordering works as expected."""
     x, y = deterministic_toy_data(['class_a', 'class_b'])
 
     p_new = CSP(component_order='new').fit(x, y).patterns_

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -109,7 +109,7 @@ def test_csp():
         CSP(reg=reg, norm_trace=False)
     for cov_est in ['foo', None]:
         pytest.raises(ValueError, CSP, cov_est=cov_est, norm_trace=False)
-    with pytest.raises(ValueError, match=TypeError):
+    with pytest.raises(TypeError, match='instance of bool'):
         CSP(norm_trace='foo')
     for cov_est in ['concat', 'epoch']:
         CSP(cov_est=cov_est, norm_trace=False)

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -109,7 +109,8 @@ def test_csp():
         CSP(reg=reg, norm_trace=False)
     for cov_est in ['foo', None]:
         pytest.raises(ValueError, CSP, cov_est=cov_est, norm_trace=False)
-    pytest.raises(ValueError, CSP, norm_trace='foo')
+    with pytest.raises(ValueError, match=TypeError):
+        CSP(norm_trace='foo')
     for cov_est in ['concat', 'epoch']:
         CSP(cov_est=cov_est, norm_trace=False)
 


### PR DESCRIPTION
#### Reference issue
Resolves #8074.

#### What does this implement/fix?
1. Add new parameter to `CSP` to select  how to order components.
2. Add additional tests to make sure nothing broke.
3. (optional) Refactoring
   - Moved duplicated data type check into `_check_Xy`.
   - Split `.fit()` into smaller functions for improved readability.

#### Additional information
I left the refactoring in for now because I already made it.
You may to prefer not to have these changes in order to keep the code closer to the original from pyRiemann.
Let me know :)