### PR TITLE
ENH: Better complex support for Evoked and SourceEstimate

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -14,9 +14,6 @@ Current (0.21.dev0)
 
 Changelog
 ~~~~~~~~~
-- Add support for writing and reading complex evoked data modifying :func:`mne.write_evokeds` and :func:`mne.read_evokeds` by `Lau Møller Andersen`_
-
-- Add error message when trying to save complex stc data in a non.-h5 format :meth:`mne.VolSourceEstimate.save` by `Lau Møller Andersen`_
 
 - Modified :meth:`mne.Epochs.pick_types` to remove dropped channel types from ``reject`` and ``flat`` dictionaries by `Rahul Nadkarni`_
 
@@ -172,6 +169,9 @@ Changelog
 
 Bug
 ~~~
+- Fix bug for writing and reading complex evoked data modifying :func:`mne.write_evokeds` and :func:`mne.read_evokeds` by `Lau Møller Andersen`_
+
+- Fix bug by adding error message when trying to save complex stc data in a non.-h5 format :meth:`mne.VolSourceEstimate.save` by `Lau Møller Andersen`_
 
 - Fix bug with :func:`mne.preprocessing.ICA.find_bads_eog` when more than one EOG components are present by `Christian O'Reilly`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -14,6 +14,9 @@ Current (0.21.dev0)
 
 Changelog
 ~~~~~~~~~
+- Add support for writing and reading complex evoked data modifying :func:`mne.write_evokeds` and :func:`mne.read_evokeds` by `Lau Møller Andersen`_
+
+- Add error message when trying to save complex stc data in a non.-h5 format :meth:`mne.VolSourceEstimate.save` by `Lau Møller Andersen`_
 
 - Modified :meth:`mne.Epochs.pick_types` to remove dropped channel types from ``reject`` and ``flat`` dictionaries by `Rahul Nadkarni`_
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -313,3 +313,5 @@
 .. _Johann Benerradi: https://github.com/HanBnrd
 
 .. _Rahul Nadkarni: https://github.com/rahuln
+
+.. _Lau Møller Andersen: https://github.com/ualsbombe

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -1205,7 +1205,7 @@ def _write_evokeds(fname, evoked, check=True):
             for k in range(e.info['nchan']):
                 decal[k] = 1.0 / (e.info['chs'][k]['cal'] *
                                   e.info['chs'][k].get('scale', 1.0))
-            
+
             if np.iscomplexobj(e.data):
                 write_function = write_complex_float_matrix
             else:

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -1205,7 +1205,7 @@ def _write_evokeds(fname, evoked, check=True):
             for k in range(e.info['nchan']):
                 decal[k] = 1.0 / (e.info['chs'][k]['cal'] *
                                   e.info['chs'][k].get('scale', 1.0))
-                
+            
             if np.iscomplexobj(e.data):
                 write_function = write_complex_float_matrix
             else:

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -36,7 +36,7 @@ from .io.meas_info import read_meas_info, write_meas_info
 from .io.proj import ProjMixin
 from .io.write import (start_file, start_block, end_file, end_block,
                        write_int, write_string, write_float_matrix,
-                       write_id, write_float)
+                       write_id, write_float, write_complex_float_matrix)
 from .io.base import TimeMixin, _check_maxshield
 
 _aspect_dict = {
@@ -1091,7 +1091,10 @@ def _read_evoked(fname, condition=None, kind='average', allow_maxshield=False):
         else:
             # Put the old style epochs together
             data = np.concatenate([e.data[None, :] for e in epoch], axis=0)
-        data = data.astype(np.float64)
+        if np.isrealobj(data):
+            data = data.astype(np.float64)
+        else:
+            data = data.astype(np.complex128)
 
         if first_time is not None and nsamp is not None:
             times = first_time + np.arange(nsamp) / info['sfreq']
@@ -1202,8 +1205,13 @@ def _write_evokeds(fname, evoked, check=True):
             for k in range(e.info['nchan']):
                 decal[k] = 1.0 / (e.info['chs'][k]['cal'] *
                                   e.info['chs'][k].get('scale', 1.0))
+                
+            if np.iscomplexobj(e.data):
+                write_function = write_complex_float_matrix
+            else:
+                write_function = write_float_matrix
 
-            write_float_matrix(fid, FIFF.FIFF_EPOCH, decal * e.data)
+            write_function(fid, FIFF.FIFF_EPOCH, decal * e.data)
             end_block(fid, aspect)
             end_block(fid, FIFF.FIFFB_EVOKED)
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2196,7 +2196,7 @@ class VolSourceEstimate(_BaseVolSourceEstimate):
             raise ValueError('Can only write to .stc or .w if a single volume '
                              'source space was used, use .h5 instead')
         if ftype != 'h5' and self.data.dtype == 'complex':
-            raise ValueError('Can only write non-complex data to .stc or .w' 
+            raise ValueError('Can only write non-complex data to .stc or .w'
                              ', use .h5 instead')
         if ftype == 'stc':
             logger.info('Writing STC to disk...')

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2195,6 +2195,9 @@ class VolSourceEstimate(_BaseVolSourceEstimate):
         if ftype != 'h5' and len(self.vertices) != 1:
             raise ValueError('Can only write to .stc or .w if a single volume '
                              'source space was used, use .h5 instead')
+        if ftype != 'h5' and self.data.dtype == 'complex':
+            raise ValueError('Can only write non-complex data to .stc or .w' 
+                             ', use .h5 instead')
         if ftype == 'stc':
             logger.info('Writing STC to disk...')
             if not (fname.endswith('-vl.stc') or fname.endswith('-vol.stc')):

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -200,6 +200,14 @@ def test_io_evoked(tmpdir):
             assert_equal(av1.last, av2.last)
             assert_equal(av1.first, av2.first)
             assert_equal(av1.comment, av2.comment)
+            
+    ## test saving and reading complex numbers in evokeds
+    ave_complex = ave.copy()
+    ave_complex._data = 1j * ave_complex.data
+    fname_temp = str(tmpdir.join('complex-ave.fif'))
+    ave_complex.save(fname_temp)
+    ave_complex = read_evokeds(fname_temp)[0]
+    assert_allclose(ave.data, ave_complex.data.imag)
 
     # test warnings on bad filenames
     fname2 = tmpdir.join('test-bad-name.fif')

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -200,8 +200,8 @@ def test_io_evoked(tmpdir):
             assert_equal(av1.last, av2.last)
             assert_equal(av1.first, av2.first)
             assert_equal(av1.comment, av2.comment)
-            
-    ## test saving and reading complex numbers in evokeds
+
+    # test saving and reading complex numbers in evokeds
     ave_complex = ave.copy()
     ave_complex._data = 1j * ave_complex.data
     fname_temp = str(tmpdir.join('complex-ave.fif'))

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -381,7 +381,8 @@ def test_io_stc(tmpdir):
 @requires_h5py
 def test_io_stc_h5(tmpdir):
     """Test IO for STC files using HDF5."""
-    for stc in [_fake_stc(Complex=True), _fake_vec_stc(Complex=True)]:
+    for stc in [_fake_stc(Complex=True), _fake_vec_stc(Complex=True),
+                _fake_stc(Complex=False), _fake_vec_stc(Complex=False)]:
         pytest.raises(ValueError, stc.save, tmpdir.join('tmp'),
                       ftype='foo')
         out_name = tmpdir.join('tmp')

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -261,14 +261,20 @@ def test_expand():
         pytest.raises(ValueError, stc.__add__, stc.in_label(labels_lh[0]))
 
 
-def _fake_stc(n_time=10, Complex=False):
+def _fake_stc(n_time=10, is_complex=False):
     verts = [np.arange(10), np.arange(90)]
-    return SourceEstimate(np.random.rand(100, n_time), verts, 0, 1e-1, 'foo')
+    data = np.random.rand(100, n_time)
+    if is_complex:
+        data.astype(complex)
+    return SourceEstimate(data, verts, 0, 1e-1, 'foo')
 
 
-def _fake_vec_stc(n_time=10, Complex=False):
+def _fake_vec_stc(n_time=10, is_complex=False):
     verts = [np.arange(10), np.arange(90)]
-    return VectorSourceEstimate(np.random.rand(100, 3, n_time), verts, 0, 1e-1,
+    data = np.random.rand(100, 3, n_time)
+    if is_complex:
+        data.astype(complex)
+    return VectorSourceEstimate(data, verts, 0, 1e-1,
                                 'foo')
 
 
@@ -381,8 +387,8 @@ def test_io_stc(tmpdir):
 @requires_h5py
 def test_io_stc_h5(tmpdir):
     """Test IO for STC files using HDF5."""
-    for stc in [_fake_stc(Complex=True), _fake_vec_stc(Complex=True),
-                _fake_stc(Complex=False), _fake_vec_stc(Complex=False)]:
+    for stc in [_fake_stc(is_complex=True), _fake_vec_stc(is_complex=True),
+                _fake_stc(is_complex=False), _fake_vec_stc(is_complex=False)]:
         pytest.raises(ValueError, stc.save, tmpdir.join('tmp'),
                       ftype='foo')
         out_name = tmpdir.join('tmp')

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -387,28 +387,32 @@ def test_io_stc(tmpdir):
 
 
 @requires_h5py
-def test_io_stc_h5(tmpdir):
+@pytest.mark.parametrize('is_complex', (True, False))
+@pytest.mark.parametrize('vector', (True, False))
+def test_io_stc_h5(tmpdir, is_complex, vector):
     """Test IO for STC files using HDF5."""
-    for stc in [_fake_stc(is_complex=True), _fake_vec_stc(is_complex=True),
-                _fake_stc(is_complex=False), _fake_vec_stc(is_complex=False)]:
-        pytest.raises(ValueError, stc.save, tmpdir.join('tmp'),
-                      ftype='foo')
-        out_name = tmpdir.join('tmp')
-        stc.save(out_name, ftype='h5')
-        stc.save(out_name, ftype='h5')  # test overwrite
-        stc3 = read_source_estimate(out_name)
-        stc4 = read_source_estimate(out_name + '-stc')
-        stc5 = read_source_estimate(out_name + '-stc.h5')
-        pytest.raises(RuntimeError, read_source_estimate, out_name,
-                      subject='bar')
-        for stc_new in stc3, stc4, stc5:
-            assert_equal(stc_new.subject, stc.subject)
-            assert_array_equal(stc_new.data, stc.data)
-            assert_array_equal(stc_new.tmin, stc.tmin)
-            assert_array_equal(stc_new.tstep, stc.tstep)
-            assert_equal(len(stc_new.vertices), len(stc.vertices))
-            for v1, v2 in zip(stc_new.vertices, stc.vertices):
-                assert_array_equal(v1, v2)
+    if vector:
+        stc = _fake_vec_stc(is_complex=is_complex)
+    else:
+        stc = _fake_stc(is_complex=is_complex)
+    pytest.raises(ValueError, stc.save, tmpdir.join('tmp'),
+                  ftype='foo')
+    out_name = tmpdir.join('tmp')
+    stc.save(out_name, ftype='h5')
+    stc.save(out_name, ftype='h5')  # test overwrite
+    stc3 = read_source_estimate(out_name)
+    stc4 = read_source_estimate(out_name + '-stc')
+    stc5 = read_source_estimate(out_name + '-stc.h5')
+    pytest.raises(RuntimeError, read_source_estimate, out_name,
+                  subject='bar')
+    for stc_new in stc3, stc4, stc5:
+        assert_equal(stc_new.subject, stc.subject)
+        assert_array_equal(stc_new.data, stc.data)
+        assert_array_equal(stc_new.tmin, stc.tmin)
+        assert_array_equal(stc_new.tstep, stc.tstep)
+        assert_equal(len(stc_new.vertices), len(stc.vertices))
+        for v1, v2 in zip(stc_new.vertices, stc.vertices):
+            assert_array_equal(v1, v2)
 
 
 def test_io_w(tmpdir):

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -261,12 +261,12 @@ def test_expand():
         pytest.raises(ValueError, stc.__add__, stc.in_label(labels_lh[0]))
 
 
-def _fake_stc(n_time=10):
+def _fake_stc(n_time=10, Complex=False):
     verts = [np.arange(10), np.arange(90)]
     return SourceEstimate(np.random.rand(100, n_time), verts, 0, 1e-1, 'foo')
 
 
-def _fake_vec_stc(n_time=10):
+def _fake_vec_stc(n_time=10, Complex=False):
     verts = [np.arange(10), np.arange(90)]
     return VectorSourceEstimate(np.random.rand(100, 3, n_time), verts, 0, 1e-1,
                                 'foo')
@@ -381,7 +381,7 @@ def test_io_stc(tmpdir):
 @requires_h5py
 def test_io_stc_h5(tmpdir):
     """Test IO for STC files using HDF5."""
-    for stc in [_fake_stc(), _fake_vec_stc()]:
+    for stc in [_fake_stc(Complex=True), _fake_vec_stc(Complex=True)]:
         pytest.raises(ValueError, stc.save, tmpdir.join('tmp'),
                       ftype='foo')
         out_name = tmpdir.join('tmp')

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -262,6 +262,7 @@ def test_expand():
 
 
 def _fake_stc(n_time=10, is_complex=False):
+    np.random.seed(7)
     verts = [np.arange(10), np.arange(90)]
     data = np.random.rand(100, n_time)
     if is_complex:
@@ -270,6 +271,7 @@ def _fake_stc(n_time=10, is_complex=False):
 
 
 def _fake_vec_stc(n_time=10, is_complex=False):
+    np.random.seed(7)
     verts = [np.arange(10), np.arange(90)]
     data = np.random.rand(100, 3, n_time)
     if is_complex:


### PR DESCRIPTION
#### Reference issue
Example: Fixes #8139 


#### What does this implement/fix?
Raises an error when complex VolSourceEstimate.data is saved to formats other .h5
Allows for _write_evokeds_ and _read_evokeds_ writing and reading complex data


#### Additional information
I haven't changed _test_evoked.py_ since I did not know whether any of the datasets had complex data to test it on
