### PR TITLE
MRG: Use GitHub Actions to replace Travis MacOS job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - '*'
   pull_request:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,9 @@ jobs:
         env:
           CONDITION: 'not slowtest'
           USE_DIRS: 'mne/'
-        name: 'Testing'
+        name: 'Run tests'
+      - uses: codecov/codecov-action@v1
+        if: success()
+        with:
+          token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
+        name: 'Upload coverage to CodeCov'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CIs
+name: CI
 on:
   push:
     branches:
@@ -11,10 +11,9 @@ jobs:
   osx:
     name: OSX
     runs-on: macos-latest
-    strategy:
-      matrix:
-        target:
-          - name: 'conda'
+    defaults:
+      run:
+        shell: bash
     env:
       PYTHON_VERSION: '3.7'
       MNE_LOGGING_LEVEL: 'warning'
@@ -24,17 +23,37 @@ jobs:
       CONDA_ENV: 'environment.yml'
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: goanpeca/setup-miniconda@v1
         with:
-          python-version: $PYTHON_VERSION
-          architecture: 'x64'
-        name: 'Setup python'
-      - run: |
-          python -m pip install --upgrade pip setuptools wheel
-        name: 'Setup pip'
-      - uses: s-weigand/setup-conda@v1
+          activate-environment: 'mne'
+          python-version: ${{ env.PYTHON_VERSION }}
+          environment-file: ${{ env.CONDA_ENV }}
         name: 'Setup conda'
-      - run: |
-          conda env update --file $CONDA_ENV
+      - shell: bash -l {0}
+        run: |
+          pip uninstall -yq mne
           pip install --upgrade -r requirements_testing.txt
+          pip install nitime
+          source tools/get_minimal_commands.sh
+          # the following fails with: cannot execute binary
+          # mne_surf2bem --version
         name: 'Install dependencies'
+      - shell: bash -l {0}
+        run: |
+          python setup.py build
+          python setup.py install
+          mne sys_info
+          python -c "import numpy; numpy.show_config()"
+        name: 'Install MNE'
+      - shell: bash -l {0}
+        run: |
+          python -c 'import mne; mne.datasets.testing.data_path(verbose=True)';
+        name: 'Download testing data'
+      - shell: bash -l {0}
+        run: |
+          echo 'pytest -m "${CONDITION}" --tb=short --cov=mne -vv ${USE_DIRS}'
+          pytest -m "${CONDITION}" --tb=short --cov=mne -vv ${USE_DIRS}
+        env:
+          CONDITION: 'not slowtest'
+          USE_DIRS: 'mne/'
+        name: 'Testing'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - '*'
   pull_request:
     branches:
-      - master
+      - '*'
 
 jobs:
   MacOS:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       OPENBLAS_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
       CONDA_ENV: 'environment.yml'
+      TRAVIS_OS_NAME: 'osx'
     steps:
       - uses: actions/checkout@v2
       - uses: goanpeca/setup-miniconda@v1
@@ -35,8 +36,7 @@ jobs:
           pip install --upgrade -r requirements_testing.txt
           pip install nitime
           source tools/get_minimal_commands.sh
-          # the following fails with: cannot execute binary
-          # mne_surf2bem --version
+          mne_surf2bem --version
         name: 'Install dependencies'
       - shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         shell: bash
     env:
-      PYTHON_VERSION: '3.7'
+      PYTHON_VERSION: '3.8'
       MNE_LOGGING_LEVEL: 'warning'
       OPENBLAS_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,12 @@ jobs:
         name: 'Download testing data'
       - shell: bash -l {0}
         run: |
+          echo "Print locale "
+          locale
+          echo "Other stuff"
+        name: 'Print locale'
+      - shell: bash -l {0}
+        run: |
           echo 'pytest -m "${CONDITION}" --tb=short --cov=mne -vv ${USE_DIRS}'
           pytest -m "${CONDITION}" --tb=short --cov=mne -vv ${USE_DIRS}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CIs
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  osx:
+    name: OSX
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target:
+          - name: 'conda'
+    env:
+      PYTHON_VERSION: '3.7'
+      MNE_LOGGING_LEVEL: 'warning'
+      CONDA_VERSION: '>=4.3.27'
+      OPENBLAS_NUM_THREADS: '1'
+      PYTHONUNBUFFERED: '1'
+      CONDA_ENV: 'environment.yml'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: $PYTHON_VERSION
+          architecture: 'x64'
+        name: 'Setup python'
+      - run: |
+          python -m pip install --upgrade pip setuptools wheel
+        name: 'Setup pip'
+      - uses: s-weigand/setup-conda@v1
+        name: 'Setup conda'
+      - run: |
+          conda env update --file $CONDA_ENV
+          pip install --upgrade -r requirements_testing.txt
+        name: 'Install dependencies'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,20 @@ jobs:
       TRAVIS_OS_NAME: 'osx'
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        env:
+          # Increase this value to reset cache if environment.yml has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml') }}
+        name: 'Cache conda'
       - uses: goanpeca/setup-miniconda@v1
         with:
           activate-environment: 'mne'
           python-version: ${{ env.PYTHON_VERSION }}
           environment-file: ${{ env.CONDA_ENV }}
+          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
         name: 'Setup conda'
       - shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,7 @@ on:
       - master
 
 jobs:
-  osx:
-    name: MacOS
+  MacOS:
     runs-on: macos-latest
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
     env:
       PYTHON_VERSION: '3.7'
       MNE_LOGGING_LEVEL: 'warning'
-      CONDA_VERSION: '>=4.3.27'
       OPENBLAS_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
       CONDA_ENV: 'environment.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
         name: 'Print locale'
       - shell: bash -l {0}
         run: |
-          echo 'pytest -m "${CONDITION}" --tb=short --cov=mne -vv ${USE_DIRS}'
-          pytest -m "${CONDITION}" --tb=short --cov=mne -vv ${USE_DIRS}
+          echo 'pytest -m "${CONDITION}" --tb=short --cov=mne --cov-report xml -vv ${USE_DIRS}'
+          pytest -m "${CONDITION}" --tb=short --cov=mne --cov-report xml -vv ${USE_DIRS}
         env:
           CONDITION: 'not slowtest'
           USE_DIRS: 'mne/'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,4 @@ jobs:
         name: 'Run tests'
       - uses: codecov/codecov-action@v1
         if: success()
-        with:
-          token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         name: 'Upload coverage to CodeCov'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   osx:
-    name: OSX
+    name: MacOS
     runs-on: macos-latest
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           environment-file: ${{ env.CONDA_ENV }}
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
         name: 'Setup conda'
-      - shell: bash -l {0}
+      - shell: bash -el {0}
         run: |
           pip uninstall -yq mne
           pip install --upgrade -r requirements_testing.txt
@@ -45,24 +45,24 @@ jobs:
           source tools/get_minimal_commands.sh
           mne_surf2bem --version
         name: 'Install dependencies'
-      - shell: bash -l {0}
+      - shell: bash -el {0}
         run: |
           python setup.py build
           python setup.py install
           mne sys_info
           python -c "import numpy; numpy.show_config()"
         name: 'Install MNE'
-      - shell: bash -l {0}
+      - shell: bash -el {0}
         run: |
           python -c 'import mne; mne.datasets.testing.data_path(verbose=True)';
         name: 'Download testing data'
-      - shell: bash -l {0}
+      - shell: bash -el {0}
         run: |
           echo "Print locale "
           locale
           echo "Other stuff"
         name: 'Print locale'
-      - shell: bash -l {0}
+      - shell: bash -el {0}
         run: |
           echo 'pytest -m "${CONDITION}" --tb=short --cov=mne --cov-report xml -vv ${USE_DIRS}'
           pytest -m "${CONDITION}" --tb=short --cov=mne --cov-report xml -vv ${USE_DIRS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ matrix:
         - os: linux
           env: CONDA_ENV="environment.yml"
 
-        # OSX conda
-        - os: osx
-          env: CONDA_ENV="environment.yml"
-
         # PIP + non-default stim channel + log level info
         - os: linux
           env: MNE_STIM_CHANNEL=STI101 MNE_LOGGING_LEVEL=info
@@ -48,9 +44,7 @@ matrix:
 
 # Setup anaconda
 before_install:
-    - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
-      fi;
+    - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
     - |
       if [ -z "$CONDA_ENV" ] && [ -z "$CONDA_DEPENDENCIES" ]; then
         pip uninstall -yq numpy
@@ -78,11 +72,6 @@ before_install:
       fi;
 
 install:
-    # Rvm overrides cd with a function so that it can hook into it to run
-    # some scripts, see https://github.com/travis-ci/travis-ci/issues/8703
-    - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-        unset -f cd;
-      fi;
     # Suppress the parallel outputs for logging cleanliness
     - python setup.py build
     - python setup.py install
@@ -104,11 +93,7 @@ script:
     # OSX runs ~2x slower than Linux on Travis, so skip any slow ones there
     # Until https://github.com/numpy/numpy/issues/15580 is resolved we also
     # need the --pre wheels to skip slow ones.
-    - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-        CONDITION='not slowtest';
-      else
-        CONDITION='not ultraslowtest';
-      fi;
+    - CONDITION='not ultraslowtest';
     # Determine directories to test (could use SPLIT=0 SPLIT=1 but currently
     # we are fast enough, so disable it)
     - if [ -z ${SPLIT} ]; then

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -819,7 +819,7 @@ def test_lcmv_reg_proj(proj, weight_norm):
     (0.05, 'unit-noise-gain', False, None, 83, 86),
     (0.05, 'unit-noise-gain', False, 0.8, 83, 86),  # depth same for wn != None
     # no reg
-    (0.00, 'unit-noise-gain', True, None, 63, 99),  # TODO: Still not stable
+    (0.00, 'unit-noise-gain', True, None, 45, 99),  # TODO: Still not stable
 ])
 def test_localization_bias_fixed(bias_params_fixed, reg, weight_norm, use_cov,
                                  depth, lower, upper):

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -175,9 +175,9 @@ def matplotlib_config():
 
 
 @pytest.fixture(scope='session')
-def travis_macos():
-    """Determine if running on Travis macOS."""
-    return (os.getenv('TRAVIS', 'false').lower() == 'true' and
+def ci_macos():
+    """Determine if running on MacOS CI."""
+    return (os.getenv('CI', 'false').lower() == 'true' and
             sys.platform == 'darwin')
 
 
@@ -189,10 +189,10 @@ def azure_windows():
 
 
 @pytest.fixture()
-def check_gui_ci(travis_macos, azure_windows):
+def check_gui_ci(ci_macos, azure_windows):
     """Skip tests that are not reliable on CIs."""
-    if azure_windows or travis_macos:
-        pytest.skip('Skipping GUI tests on Travis OSX and Azure Windows')
+    if azure_windows or ci_macos:
+        pytest.skip('Skipping GUI tests on MacOS CIs and Azure Windows')
 
 
 @pytest.fixture(scope='session', params=[testing._pytest_param()])

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -405,12 +405,10 @@ def test_brain_timeviewer_traces(renderer_interactive, hemi, src, tmpdir):
 
 @testing.requires_testing_data
 @pytest.mark.slowtest
-def test_brain_linkviewer(renderer_interactive, ci_macos):
+def test_brain_linkviewer(renderer_interactive):
     """Test _LinkViewer primitives."""
     if renderer_interactive._get_3d_backend() != 'pyvista':
         pytest.skip('Linkviewer only supported on PyVista')
-    if ci_macos:
-        pytest.skip('Linkviewer tests unstable on Travis macOS')
     brain_data = _create_testing_brain(hemi='split', show_traces=False)
 
     link_viewer = _LinkViewer(

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -396,11 +396,11 @@ def test_brain_timeviewer_traces(renderer_interactive, hemi, src, tmpdir):
 
 
 @testing.requires_testing_data
-def test_brain_linkviewer(renderer_interactive, travis_macos):
+def test_brain_linkviewer(renderer_interactive, ci_macos):
     """Test _LinkViewer primitives."""
     if renderer_interactive._get_3d_backend() != 'pyvista':
         pytest.skip('Linkviewer only supported on PyVista')
-    if travis_macos:
+    if ci_macos:
         pytest.skip('Linkviewer tests unstable on Travis macOS')
     brain_data = _create_testing_brain(hemi='split', show_traces=False)
 

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -190,6 +190,7 @@ class _Renderer(_BaseRenderer):
             warnings.filterwarnings("ignore", category=FutureWarning)
             if MNE_3D_BACKEND_TESTING:
                 self.tube_n_sides = 3
+                # smooth_shading=True fails on MacOS CIs
                 self.figure.smooth_shading = False
             with _disabled_depth_peeling():
                 self.plotter = self.figure.build()

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -190,6 +190,7 @@ class _Renderer(_BaseRenderer):
             warnings.filterwarnings("ignore", category=FutureWarning)
             if MNE_3D_BACKEND_TESTING:
                 self.tube_n_sides = 3
+                self.figure.smooth_shading = False
             with _disabled_depth_peeling():
                 self.plotter = self.figure.build()
             self.plotter.hide_axes()


### PR DESCRIPTION
This PR adds a new GHA workflow running on MacOS.

I use [`setup-miniconda`](https://github.com/marketplace/actions/setup-miniconda) to setup conda to avoid [a permission error on MacOS](https://github.com/actions/virtual-environments/issues/1003#issuecomment-638860704) (for more infos: https://github.com/actions/virtual-environments/issues/1003#issuecomment-638978803)

ToDo:

- [x] Set `TRAVIS_OS_NAME` to `osx` to fix `mne_surf2bem` failure
- [x] Remove entry from `.travis.yml`
- [x] Use `*` as branch filter
- [x] Rename the job from `OSX` to `MacOS`
- [x] Print `locale`
- [x] Add support for `codecov`
- [x] Remove unused `CONDA_VERSION` variable
- [x] Disable smooth shading in testing to solve  https://github.com/mne-tools/mne-python/pull/8161#issuecomment-680177213
- [x] Add support for caching `setup-miniconda`
- [x] Remove double skip for `test_brain_linkviewer()`
- [x] Fix `test_lcmv.py::test_localization_bias_fixed`
- [x] Fix coverage infos
- [x] Bump `PYTHON_VERSION` to `3.8`
- [x] Use `bash -el {0}` to fail early

<details>
<summary>Archive</summary>

I run this workflow on [my `master` branch](https://github.com/GuillaumeFavelier/mne-python/actions) to test it (the easiest solution I found).

Notes:

- `$SPLIT` is not supported (yet?)

why on Travis?

```
    - cd ~
    # Trigger download of testing data
    - if [ "${DEPS}" != "minimal" ]; then
        python -c 'import mne; mne.datasets.testing.data_path(verbose=True)';
      fi;
    - cd ${SRC_DIR}
```

</details>

Closes #8159