### PR TITLE
ENH: get only label vertex indices from _prepare_label_extraction wit…

### DIFF
--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2934,25 +2934,34 @@ def _temporary_vertices(src, vertices):
 
 def _prepare_label_extraction(stc, labels, src, mode, allow_empty, use_sparse):
     """Prepare indices and flips for extract_label_time_course."""
-    # if src is a mixed src space, the first 2 src spaces are surf type and
-    # the other ones are vol type. For mixed source space n_labels will be the
+    # If src is a mixed src space, the first 2 src spaces are surf type and
+    # the other ones are vol type. For mixed source space n_labels will be
     # given by the number of ROIs of the cortical parcellation plus the number
-    # of vol src space
+    # of vol src space.
+    # If mode=None and stc=None (i.e. no activation time courses provided, only
+    # compute vertex indices.
     from .label import label_sign_flip, Label, BiHemiLabel
 
-    # get vertices from source space, they have to be the same as in the stcs
-    vertno = stc.vertices
+    # if source estimate provided in stc, get vertices from source space and
+    # check that they are the same as in the stcs
+    if stc is not None:
+        vertno = stc.vertices
+
+        for s, v, hemi in zip(src, stc.vertices, ('left', 'right')):
+            n_missing = (~np.in1d(v, s['vertno'])).sum()
+            if n_missing:
+                raise ValueError('%d/%d %s hemisphere stc vertices missing from '
+                                 'the source space, likely mismatch'
+                                 % (n_missing, len(v), hemi))
+    else:
+        vertno = src['vertno']
+
     nvert = [len(vn) for vn in vertno]
 
-    # do the initialization
-    label_vertidx = list()
+    # initialization
     label_flip = list()
-    for s, v, hemi in zip(src, stc.vertices, ('left', 'right')):
-        n_missing = (~np.in1d(v, s['vertno'])).sum()
-        if n_missing:
-            raise ValueError('%d/%d %s hemisphere stc vertices missing from '
-                             'the source space, likely mismatch'
-                             % (n_missing, len(v), hemi))
+    label_vertidx = list()
+
     bad_labels = list()
     for li, label in enumerate(labels):
         if use_sparse:
@@ -2995,6 +3004,8 @@ def _prepare_label_extraction(stc, labels, src, mode, allow_empty, use_sparse):
         if len(this_vertidx) == 0:
             bad_labels.append(label.name)
             this_vertidx = None  # to later check if label is empty
+        elif mode is None:  # no flip if no source activation provided
+            this_flip = []
         elif mode not in ('mean', 'max'):  # mode-dependent initialization
             # label_sign_flip uses two properties:
             #

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2938,8 +2938,8 @@ def _prepare_label_extraction(stc, labels, src, mode, allow_empty, use_sparse):
     # the other ones are vol type. For mixed source space n_labels will be
     # given by the number of ROIs of the cortical parcellation plus the number
     # of vol src space.
-    # If mode=None and stc=None (i.e. no activation time courses provided, only
-    # compute vertex indices, label_flip will be empty list.
+    # If stc=None (i.e. no activation time courses provided) and mode='mean',
+    # only computes vertex indices and label_flip will be list of None.
     from .label import label_sign_flip, Label, BiHemiLabel
 
     # if source estimate provided in stc, get vertices from source space and
@@ -3004,8 +3004,6 @@ def _prepare_label_extraction(stc, labels, src, mode, allow_empty, use_sparse):
         if len(this_vertidx) == 0:
             bad_labels.append(label.name)
             this_vertidx = None  # to later check if label is empty
-        elif mode is None:  # no flip if no source activation provided
-            this_flip = []
         elif mode not in ('mean', 'max'):  # mode-dependent initialization
             # label_sign_flip uses two properties:
             #

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2950,8 +2950,8 @@ def _prepare_label_extraction(stc, labels, src, mode, allow_empty, use_sparse):
         for s, v, hemi in zip(src, stc.vertices, ('left', 'right')):
             n_missing = (~np.in1d(v, s['vertno'])).sum()
             if n_missing:
-                raise ValueError('%d/%d %s hemisphere stc vertices missing from '
-                                 'the source space, likely mismatch'
+                raise ValueError('%d/%d %s hemisphere stc vertices missing '
+                                 'from the source space, likely mismatch'
                                  % (n_missing, len(v), hemi))
     else:
         vertno = src['vertno']

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2939,7 +2939,7 @@ def _prepare_label_extraction(stc, labels, src, mode, allow_empty, use_sparse):
     # given by the number of ROIs of the cortical parcellation plus the number
     # of vol src space.
     # If mode=None and stc=None (i.e. no activation time courses provided, only
-    # compute vertex indices.
+    # compute vertex indices, label_flip will be empty list.
     from .label import label_sign_flip, Label, BiHemiLabel
 
     # if source estimate provided in stc, get vertices from source space and


### PR DESCRIPTION
…hout stc

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

#### Reference issue
Example: Fixes #8162.


#### What does this implement/fix?
I changed _prepare_label_extraction to return label indices for vertices in source space even if no STC is specified (i.e. without activation time courses). STCs are only required for "flipping" activation values when extracting time courses. The helper function now works with stc=None and mode=None,

#### Additional information
I'll use this to compute PSFs/CTFs for labels.