### PR TITLE
MRG: Trimming Sleep Physionet recordings to avoid W imbalance

### DIFF
--- a/tutorials/sample-datasets/plot_sleep.py
+++ b/tutorials/sample-datasets/plot_sleep.py
@@ -110,8 +110,8 @@ raw_train.plot(duration=60, scalings='auto')
 #
 # Moreover, the recordings contain long awake (W) regions before and after each
 # night. To limit the impact of class imbalance, we trim each recording by only
-# keeping 30 minutes of wake time before the first occurence and 30 minutes
-# after the last occurence of sleep stages.
+# keeping 30 minutes of wake time before the first occurrence and 30 minutes
+# after the last occurrence of sleep stages.
 
 annotation_desc_2_event_id = {'Sleep stage W': 1,
                               'Sleep stage 1': 2,

--- a/tutorials/sample-datasets/plot_sleep.py
+++ b/tutorials/sample-datasets/plot_sleep.py
@@ -120,15 +120,14 @@ annotation_desc_2_event_id = {'Sleep stage W': 1,
                               'Sleep stage 4': 4,
                               'Sleep stage R': 5}
 
+# keep last 30-min wake events before sleep and first 30-min wake events after
+# sleep and redefine annotations on raw data
+annot_train.crop(annot_train[1]['onset'] - 30 * 60,
+                 annot_train[-2]['onset'] + 30 * 60)
+raw_train.set_annotations(annot_train, emit_warning=False)
+
 events_train, _ = mne.events_from_annotations(
     raw_train, event_id=annotation_desc_2_event_id, chunk_duration=30.)
-
-# keep last 30-min wake events before sleep and first 30-min wake events after
-# sleep
-sleep_stage_inds = np.where(events_train[:, 2] > 1)[0]
-offset = int((30 * 60) / 30)
-events_train = events_train[
-    sleep_stage_inds[0] - offset:sleep_stage_inds[-1] + offset + 1]
 
 # create a new event_id that unifies stages 3 and 4
 event_id = {'Sleep stage W': 1,
@@ -162,13 +161,12 @@ print(epochs_train)
 
 raw_test = mne.io.read_raw_edf(bob_files[0])
 annot_test = mne.read_annotations(bob_files[1])
+annot_test.crop(annot_test[1]['onset'] - 30 * 60,
+                annot_test[-2]['onset'] + 30 * 60)
 raw_test.set_annotations(annot_test, emit_warning=False)
 raw_test.set_channel_types(mapping)
 events_test, _ = mne.events_from_annotations(
     raw_test, event_id=annotation_desc_2_event_id, chunk_duration=30.)
-sleep_stage_inds = np.where(events_test[:, 2] > 1)[0]
-events_test = events_test[
-    sleep_stage_inds[0] - offset:sleep_stage_inds[-1] + offset + 1]
 epochs_test = mne.Epochs(raw=raw_test, events=events_test, event_id=event_id,
                          tmin=0., tmax=tmax, baseline=None)
 

--- a/tutorials/sample-datasets/plot_sleep.py
+++ b/tutorials/sample-datasets/plot_sleep.py
@@ -110,8 +110,8 @@ raw_train.plot(duration=60, scalings='auto')
 #
 # Moreover, the recordings contain long awake (W) regions before and after each
 # night. To limit the impact of class imbalance, we trim each recording by only
-# keeping 5 minutes of wake time before the first occurence and 5 minutes after
-# the last occurence of sleep stages.
+# keeping 30 minutes of wake time before the first occurence and 30 minutes
+# after the last occurence of sleep stages.
 
 annotation_desc_2_event_id = {'Sleep stage W': 1,
                               'Sleep stage 1': 2,
@@ -123,10 +123,10 @@ annotation_desc_2_event_id = {'Sleep stage W': 1,
 events_train, _ = mne.events_from_annotations(
     raw_train, event_id=annotation_desc_2_event_id, chunk_duration=30.)
 
-# keep last 5-min wake events before sleep and first 5-min wake events after
+# keep last 30-min wake events before sleep and first 30-min wake events after
 # sleep
 sleep_stage_inds = np.where(events_train[:, 2] > 1)[0]
-offset = int((5 * 60) / 30)
+offset = int((30 * 60) / 30)
 events_train = events_train[
     sleep_stage_inds[0] - offset:sleep_stage_inds[-1] + offset + 1]
 


### PR DESCRIPTION
In the [example for the Sleep Physionet dataset](https://mne.tools/stable/auto_tutorials/sample-datasets/plot_sleep.html), there is a large class imbalance in favour of wake (W). This is because the recordings in this dataset were collected over longer periods of time and thus there are long periods of awake time before and after the night. It is common practice in the literature to trim the beginning and end parts of the recordings of this dataset to reduce class imbalance (e.g., https://arxiv.org/abs/1703.04046, https://arxiv.org/abs/1610.01683, https://arxiv.org/abs/1710.00633).

Following discussion with @agramfort, this PR modifies the example to only keep the last 30 minutes before the first sleep event and the first 30 minutes after the last sleep event when building the training and testing sets.