### PR TITLE
MRG, BUG: Fix sphere glyphs

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -313,7 +313,7 @@ Bug
 
 - Fix bug with :meth:`mne.io.Raw.plot_psd` with ``average=False`` and multiple channel types where channel locations were not shown properly by `Eric Larson`_
 
-- Fix bug with :func:`mne.viz.plot_sparse_source_estimates` when using ``'sphere'`` mode by `Eric Larson`_
+- Fix bug with :func:`mne.viz.plot_sparse_source_estimates` when using ``'sphere'`` mode by `Eric Larson`_ and `Guillaume Favelier`_
 
 - Fix bug in FieldTrip reader functions when channels are missing in the ``info`` object by `Thomas Hartmann`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -313,6 +313,8 @@ Bug
 
 - Fix bug with :meth:`mne.io.Raw.plot_psd` with ``average=False`` and multiple channel types where channel locations were not shown properly by `Eric Larson`_
 
+- Fix bug with :func:`mne.viz.plot_sparse_source_estimates` when using ``'sphere'`` mode by `Eric Larson`_
+
 - Fix bug in FieldTrip reader functions when channels are missing in the ``info`` object by `Thomas Hartmann`_
 
 - Throw proper error when trying to import FieldTrip Epochs data with non-uniform time for trials by `Thomas Hartmann`_

--- a/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/plot_time_frequency_mixed_norm_inverse.py
@@ -102,7 +102,7 @@ residual.crop(tmin=-0.05, tmax=0.3)
 plot_dipole_amplitudes(dipoles)
 
 ###############################################################################
-# Plot dipole location of the strongest dipole with MRI slices
+# Plot location of the strongest dipole with MRI slices
 idx = np.argmax([np.max(np.abs(dip.amplitude)) for dip in dipoles])
 plot_dipole_locations(dipoles[idx], forward['mri_head_t'], 'sample',
                       subjects_dir=subjects_dir, mode='orthoview',

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2671,9 +2671,11 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
 
         x, y, z = points[v]
         nx, ny, nz = normals[v]
+        renderer.sphere(center=points[v], color='red', scale=0.1)
         renderer.quiver3d(x=x, y=y, z=z, u=nx, v=ny, w=nz,
                           color=color_converter.to_rgb(c),
-                          mode=mode, scale=scale_factor)
+                          mode=mode, scale=scale_factor,
+                          opacity=0.5)
 
         for k in ind:
             vertno = vertnos[k]

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2671,11 +2671,9 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
 
         x, y, z = points[v]
         nx, ny, nz = normals[v]
-        renderer.sphere(center=points[v], color='red', scale=0.1)
         renderer.quiver3d(x=x, y=y, z=z, u=nx, v=ny, w=nz,
                           color=color_converter.to_rgb(c),
-                          mode=mode, scale=scale_factor,
-                          opacity=0.5)
+                          mode=mode, scale=scale_factor)
 
         for k in ind:
             vertno = vertnos[k]

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2574,6 +2574,8 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
     modes : list
         Should be a list, with each entry being ``'cone'`` or ``'sphere'``
         to specify how the dipoles should be shown.
+        The pivot for the glyphs in ``'cone'`` mode is always the tail
+        whereas the pivot in ``'sphere'`` mode is the center.
     scale_factors : list
         List of floating point scale factors for the markers.
     %(verbose)s

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -242,9 +242,11 @@ class _Renderer(_BaseRenderer):
                                    resolution=resolution, scalars=scalars,
                                    opacity=opacity, figure=self.fig)
             elif mode in ('cone', 'sphere'):
-                self.mlab.quiver3d(x, y, z, u, v, w, color=color,
-                                   mode=mode, scale_factor=scale,
-                                   opacity=opacity, figure=self.fig)
+                quiv = self.mlab.quiver3d(x, y, z, u, v, w, color=color,
+                                          mode=mode, scale_factor=scale,
+                                          opacity=opacity, figure=self.fig)
+                if mode == 'sphere':
+                    quiv.glyph.glyph_source.glyph_source.center = 0., 0., 0.
             else:
                 assert mode == 'cylinder', mode  # should be guaranteed above
                 quiv = self.mlab.quiver3d(x, y, z, u, v, w, mode=mode,

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -142,6 +142,8 @@ class _Renderer(_BaseRenderer):
                 from matplotlib.cm import get_cmap
                 l_m.load_lut_from_list(
                     get_cmap(colormap)(np.linspace(0, 1, 256)))
+            else:
+                assert color is not None
             surface.actor.property.shading = shading
             surface.actor.property.backface_culling = backface_culling
         return surface

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -465,6 +465,7 @@ class _Renderer(_BaseRenderer):
             else:
                 if mode == 'cone':
                     glyph = vtk.vtkConeSource()
+                    glyph.SetCenter(0.5, 0, 0)
                 elif mode == 'cylinder':
                     glyph = vtk.vtkCylinderSource()
                     glyph.SetRadius(0.15)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -466,6 +466,7 @@ class _Renderer(_BaseRenderer):
                 if mode == 'cone':
                     glyph = vtk.vtkConeSource()
                     glyph.SetCenter(0.5, 0, 0)
+                    glyph.SetRadius(0.15)
                 elif mode == 'cylinder':
                     glyph = vtk.vtkCylinderSource()
                     glyph.SetRadius(0.15)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -471,15 +471,13 @@ class _Renderer(_BaseRenderer):
                 else:
                     assert mode == 'sphere', mode  # guaranteed above
                     glyph = vtk.vtkSphereSource()
-                if glyph_center is not None:
-                    glyph.SetCenter(glyph_center)
-                if glyph_height is not None:
-                    glyph.SetHeight(glyph_height)
-                if glyph_center is not None:
-                    glyph.SetCenter(glyph_center)
-                if glyph_resolution is not None:
-                    glyph.SetResolution(glyph_resolution)
                 if mode == 'cylinder':
+                    if glyph_height is not None:
+                        glyph.SetHeight(glyph_height)
+                    if glyph_center is not None:
+                        glyph.SetCenter(glyph_center)
+                    if glyph_resolution is not None:
+                        glyph.SetResolution(glyph_resolution)
                     # fix orientation
                     glyph.Update()
                     tr = vtk.vtkTransform()
@@ -822,6 +820,8 @@ def _set_mesh_scalars(mesh, scalars, name):
 
 
 def _update_slider_callback(slider, callback, event_type):
+    _check_option('event_type', event_type,
+                  ['start', 'end', 'always'])
 
     def _the_callback(widget, event):
         value = widget.GetRepresentation().GetValue()
@@ -833,7 +833,8 @@ def _update_slider_callback(slider, callback, event_type):
         event = vtk.vtkCommand.StartInteractionEvent
     elif event_type == 'end':
         event = vtk.vtkCommand.EndInteractionEvent
-    elif event_type == 'always':
+    else:
+        assert event_type == 'always', event_type
         event = vtk.vtkCommand.InteractionEvent
 
     slider.RemoveObserver(event)

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -10,7 +10,8 @@
 import numpy as np
 import collections.abc
 
-VALID_3D_BACKENDS = ['mayavi', 'pyvista', 'notebook']
+VALID_3D_BACKENDS = ('mayavi', 'pyvista', 'notebook')
+ALLOWED_QUIVER_MODES = ('2darrow', 'arrow', 'cone', 'cylinder', 'sphere')
 
 
 def _get_colormap_from_array(colormap=None, normalized_colormap=False,

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from mne.viz.backends.tests._utils import (skips_if_not_mayavi,
                                            skips_if_not_pyvista)
+from mne.viz.backends._utils import ALLOWED_QUIVER_MODES
 
 
 @pytest.fixture
@@ -82,7 +83,6 @@ def test_3d_backend(renderer):
         "tris": tet_indices
     }
 
-    qv_mode = "arrow"
     qv_color = 'blue'
     qv_scale = tet_size / 2.0
     qv_center = np.array([np.mean((sph_center[va, :],
@@ -132,17 +132,22 @@ def test_3d_backend(renderer):
                 scale=sph_scale, radius=1.0)
 
     # use quiver3d
-    rend.quiver3d(x=qv_center[:, 0],
-                  y=qv_center[:, 1],
-                  z=qv_center[:, 2],
-                  u=qv_dir[:, 0],
-                  v=qv_dir[:, 1],
-                  w=qv_dir[:, 2],
-                  color=qv_color,
-                  scale=qv_scale,
-                  scale_mode=qv_scale_mode,
-                  scalars=qv_scalars,
-                  mode=qv_mode)
+    kwargs = dict(
+        x=qv_center[:, 0],
+        y=qv_center[:, 1],
+        z=qv_center[:, 2],
+        u=qv_dir[:, 0],
+        v=qv_dir[:, 1],
+        w=qv_dir[:, 2],
+        color=qv_color,
+        scale=qv_scale,
+        scale_mode=qv_scale_mode,
+        scalars=qv_scalars,
+    )
+    for mode in ALLOWED_QUIVER_MODES:
+        rend.quiver3d(mode=mode, **kwargs)
+    with pytest.raises(ValueError, match='Invalid value'):
+        rend.quiver3d(mode='foo', **kwargs)
 
     # use tube
     rend.tube(origin=np.array([[0, 0, 0]]),


### PR DESCRIPTION
Closes #8192

In this PR on mayavi:

![Screenshot from 2020-09-01 16-28-42](https://user-images.githubusercontent.com/2365790/91903218-e161d980-ec70-11ea-8a5a-bfb2436520e3.png)

pyvista:

![Screenshot from 2020-09-01 16-29-02](https://user-images.githubusercontent.com/2365790/91903223-e45cca00-ec70-11ea-92c4-401a5ab456af.png)

these look different but I think it might just be a subtle angle/perspective difference (?), here's a different angle:

![Screenshot from 2020-09-01 16-29-55](https://user-images.githubusercontent.com/2365790/91903269-f63e6d00-ec70-11ea-9e38-e9e7138ec6cb.png)
![Screenshot from 2020-09-01 16-30-29](https://user-images.githubusercontent.com/2365790/91903273-f8083080-ec70-11ea-8d63-7111bdd8f0c5.png)

@GuillaumeFavelier can you look and see if the difference is meaningful and if necessary push commits to fix it? Also might be a good idea to check the code for any other instances of `if/elif/elif` and change them to `if/elif/else` with an `assert` like I did here (preferably with a user-friendly `_check_option` so that the `assert` is just an internal sanity check).