### PR TITLE
MRG, ENH: Add cov.plot_topomap

### DIFF
--- a/examples/inverse/plot_mne_cov_power.py
+++ b/examples/inverse/plot_mne_cov_power.py
@@ -117,6 +117,9 @@ stc_base = apply_inverse_cov(base_cov, evoked.info, inverse_operator,
 
 ###############################################################################
 # And visualize power is relative to the baseline:
+
+# sphinx_gallery_thumbnail_number = 9
+
 stc_data /= stc_base
 brain = stc_data.plot(subject='sample', subjects_dir=subjects_dir,
                       clim=dict(kind='percent', lims=(50, 90, 98)))

--- a/examples/inverse/plot_mne_cov_power.py
+++ b/examples/inverse/plot_mne_cov_power.py
@@ -87,28 +87,11 @@ fig_data_cov = mne.viz.plot_cov(data_cov, epochs.info, show_svd=False)
 evoked = epochs.average().pick('meg')
 evoked.drop_channels(evoked.info['bads'])
 evoked.plot(time_unit='s')
-evoked.plot_topomap(times=np.linspace(0.05, 0.15, 5), ch_type='mag',
-                    time_unit='s')
-
-evoked_noise_cov = mne.EvokedArray(data=np.diag(noise_cov['data'])[:, None],
-                                   info=evoked.info)
-evoked_data_cov = mne.EvokedArray(data=np.diag(data_cov['data'])[:, None],
-                                  info=evoked.info)
-evoked_data_cov_white = mne.whiten_evoked(evoked_data_cov, noise_cov)
-
-
-def plot_cov_diag_topomap(evoked, ch_type='grad'):
-    evoked.plot_topomap(
-        ch_type=ch_type, times=[0],
-        vmin=np.min, vmax=np.max, cmap='viridis',
-        units=dict(mag='None', grad='None'),
-        scalings=dict(mag=1, grad=1),
-        cbar_fmt=None)
-
-
-plot_cov_diag_topomap(evoked_noise_cov, 'grad')
-plot_cov_diag_topomap(evoked_data_cov, 'grad')
-plot_cov_diag_topomap(evoked_data_cov_white, 'grad')
+evoked.plot_topomap(times=np.linspace(0.05, 0.15, 5), ch_type='mag')
+noise_cov.plot_topomap(evoked.info, 'grad', title='Noise')
+data_cov.plot_topomap(evoked.info, 'grad', title='Data')
+data_cov.plot_topomap(evoked.info, 'grad', noise_cov=noise_cov,
+                      title='Whitened data')
 
 ###############################################################################
 # Apply inverse operator to covariance

--- a/mne/externals/doccer.py
+++ b/mne/externals/doccer.py
@@ -70,7 +70,7 @@ def docformat(docstring, docdict=None, funcname=None):
     funcname = docstring.split('\n')[0] if funcname is None else funcname
     try:
         return docstring % indented
-    except (TypeError, KeyError) as exp:
+    except (TypeError, ValueError, KeyError) as exp:
         raise RuntimeError('Error documenting %s:\n%s'
                            % (funcname, str(exp)))
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -102,6 +102,10 @@ docdict["show"] = """
 show : bool
     Show figure if True.
 """
+docdict["title_None"] = """
+title : str | None
+    Title. If None (default), no title is displayed.
+"""
 docdict["plot_proj"] = """
 proj : bool | 'interactive' | 'reconstruct'
     If true SSP projections are applied before display. If 'interactive',
@@ -112,6 +116,84 @@ proj : bool | 'interactive' | 'reconstruct'
 
     .. versionchanged:: 0.21
        Support for 'reconstruct' was added.
+"""
+docdict["topomap_ch_type"] = """
+ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg' | None
+    The channel type to plot. For 'grad', the gradiometers are collected in
+    pairs and the RMS for each pair is plotted.
+    If None, then channels are chosen in the order given above.
+"""
+docdict["topomap_vmin_vmax"] = """
+vmin, vmax : float | callable | None
+    Lower and upper bounds of the colormap, in the same units as the data.
+    If ``vmin`` and ``vmax`` are both ``None``, they are set at ± the
+    maximum absolute value of the data (yielding a colormap with midpoint
+    at 0). If only one of ``vmin``, ``vmax`` is ``None``, will use
+    ``min(data)`` or ``max(data)``, respectively. If callable, should
+    accept a :class:`NumPy array <numpy.ndarray>` of data and return a
+    float.
+"""
+docdict["topomap_cmap"] = """
+cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
+    Colormap to use. If tuple, the first value indicates the colormap to
+    use and the second value is a boolean defining interactivity. In
+    interactive mode the colors are adjustable by clicking and dragging the
+    colorbar with left and right mouse button. Left mouse button moves the
+    scale up and down and right mouse button adjusts the range (zoom).
+    The mouse scroll can also be used to adjust the range. Hitting space
+    bar resets the range. Up and down arrows can be used to change the
+    colormap. If None (default), 'Reds' is used for all positive data,
+    otherwise defaults to 'RdBu_r'. If 'interactive', translates to
+    (None, True).
+
+    .. warning::  Interactive mode works smoothly only for a small amount
+        of topomaps. Interactive mode is disabled by default for more than
+        2 topomaps.
+"""
+docdict["topomap_sensors"] = """
+sensors : bool | str
+    Add markers for sensor locations to the plot. Accepts matplotlib plot
+    format string (e.g., 'r+' for red plusses). If True (default),
+    circles will be used.
+"""
+docdict["topomap_colorbar"] = """
+colorbar : bool
+    Plot a colorbar in the rightmost column of the figure.
+"""
+docdict["topomap_scalings"] = """
+scalings : dict | float | None
+    The scalings of the channel types to be applied for plotting.
+    If None, defaults to ``dict(eeg=1e6, grad=1e13, mag=1e15)``.
+"""
+docdict["topomap_units"] = """
+units : dict | str | None
+    The unit of the channel type used for colorbar label. If
+    scale is None the unit is automatically determined.
+"""
+docdict["topomap_res"] = """
+res : int
+    The resolution of the topomap image (n pixels along each side).
+"""
+docdict["topomap_size"] = """
+size : float
+    Side length per topomap in inches.
+"""
+docdict["topomap_cbar_fmt"] = """
+cbar_fmt : str
+    String format for colorbar values.
+"""
+docdict["topomap_mask"] = """
+mask : ndarray of bool, shape (n_channels, n_times) | None
+    The channels to be marked as significant at a given time point.
+    Indices set to ``True`` will be considered. Defaults to ``None``.
+"""
+docdict["topomap_mask_params"] = """
+mask_params : dict | None
+    Additional plotting parameters for plotting significant sensors.
+    Default (None) equals::
+
+        dict(marker='o', markerfacecolor='w', markeredgecolor='k',
+                linewidth=0, markersize=4)
 """
 docdict['topomap_outlines'] = """
 outlines : 'head' | 'skirt' | dict | None
@@ -124,6 +206,35 @@ outlines : 'head' | 'skirt' | dict | None
     masking options, either directly or as a function that returns patches
     (required for multi-axis plots). If None, nothing will be drawn.
     Defaults to 'head'.
+"""
+docdict['topomap_contours'] = """
+contours : int | array of float
+    The number of contour lines to draw. If 0, no contours will be drawn.
+    When an integer, matplotlib ticker locator is used to find suitable
+    values for the contour thresholds (may sometimes be inaccurate, use
+    array for accuracy). If an array, the values represent the levels for
+    the contours. The values are in µV for EEG, fT for magnetometers and
+    fT/m for gradiometers. If colorbar=True, the ticks in colorbar
+    correspond to the contour levels. Defaults to 6.
+"""
+docdict['topomap_image_interp'] = """
+image_interp : str
+    The image interpolation to be used. All matplotlib options are
+    accepted.
+"""
+docdict['topomap_average'] = """
+average : float | None
+    The time window around a given time to be used for averaging (seconds).
+    For example, 0.01 would translate into window that starts 5 ms before
+    and ends 5 ms after a given time point. Defaults to None, which means
+    no averaging.
+"""
+docdict['topomap_axes'] = """
+axes : instance of Axes | list | None
+    The axes to plot to. If list, the list must be a list of Axes of the
+    same length as ``times`` (unless ``times`` is None). If instance of
+    Axes, ``times`` must be a float or a list of one float.
+    Defaults to None.
 """
 docdict['topomap_extrapolate'] = """
 extrapolate : str

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -19,7 +19,8 @@ from matplotlib.figure import Figure
 from matplotlib.patches import Circle
 
 from mne import (read_evokeds, read_proj, make_fixed_length_events, Epochs,
-                 compute_proj_evoked, find_layout, pick_types, create_info)
+                 compute_proj_evoked, find_layout, pick_types, create_info,
+                 read_cov)
 from mne.io.proj import make_eeg_average_ref_proj, Projection
 from mne.io import read_raw_fif, read_info, RawArray
 from mne.io.constants import FIFF
@@ -28,7 +29,6 @@ from mne.io.compensator import get_current_comp
 from mne.channels import read_layout, make_dig_montage
 from mne.datasets import testing
 from mne.time_frequency.tfr import AverageTFR
-from mne.utils import run_tests_if_main
 
 from mne.viz import plot_evoked_topomap, plot_projs_topomap, topomap
 from mne.viz.topomap import (_get_pos_outlines, _onselect, plot_topomap,
@@ -48,6 +48,7 @@ raw_fname = op.join(base_dir, 'test_raw.fif')
 event_name = op.join(base_dir, 'test-eve.fif')
 ctf_fname = op.join(base_dir, 'test_ctf_comp_raw.fif')
 layout = read_layout('Vectorview-all')
+cov_fname = op.join(base_dir, 'test-cov.fif')
 
 
 def test_plot_topomap_interactive():
@@ -572,4 +573,10 @@ def test_plot_topomap_nirs_ica(fnirs_epochs):
     plt.close('all')
 
 
-run_tests_if_main()
+def test_plot_cov_topomap():
+    """Test plotting a covariance topomap."""
+    cov = read_cov(cov_fname)
+    info = read_info(evoked_fname)
+    cov.plot_topomap(info)
+    cov.plot_topomap(info, noise_cov=cov)
+    plt.close('all')

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1447,52 +1447,16 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
         automatically by checking for local maxima in global field power. If
         "interactive", the time can be set interactively at run-time by using a
         slider.
-    ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg' | None
-        The channel type to plot. For 'grad', the gradiometers are collected in
-        pairs and the RMS for each pair is plotted.
-        If None, then channels are chosen in the order given above.
-    vmin, vmax : float | callable | None
-        Lower and upper bounds of the colormap, in the same units as the data.
-        If ``vmin`` and ``vmax`` are both ``None``, they are set at ± the
-        maximum absolute value of the data (yielding a colormap with midpoint
-        at 0). If only one of ``vmin``, ``vmax`` is ``None``, will use
-        ``min(data)`` or ``max(data)``, respectively. If callable, should
-        accept a :class:`NumPy array <numpy.ndarray>` of data and return a
-        float.
-    cmap : matplotlib colormap | (colormap, bool) | 'interactive' | None
-        Colormap to use. If tuple, the first value indicates the colormap to
-        use and the second value is a boolean defining interactivity. In
-        interactive mode the colors are adjustable by clicking and dragging the
-        colorbar with left and right mouse button. Left mouse button moves the
-        scale up and down and right mouse button adjusts the range (zoom).
-        The mouse scroll can also be used to adjust the range. Hitting space
-        bar resets the range. Up and down arrows can be used to change the
-        colormap. If None (default), 'Reds' is used for all positive data,
-        otherwise defaults to 'RdBu_r'. If 'interactive', translates to
-        (None, True).
-
-        .. warning::  Interactive mode works smoothly only for a small amount
-            of topomaps. Interactive mode is disabled by default for more than
-            2 topomaps.
-
-    sensors : bool | str
-        Add markers for sensor locations to the plot. Accepts matplotlib plot
-        format string (e.g., 'r+' for red plusses). If True (default),
-        circles will be used.
-    colorbar : bool
-        Plot a colorbar in the rightmost column of the figure.
-    scalings : dict | float | None
-        The scalings of the channel types to be applied for plotting.
-        If None, defaults to ``dict(eeg=1e6, grad=1e13, mag=1e15)``.
-    units : dict | str | None
-        The unit of the channel type used for colorbar label. If
-        scale is None the unit is automatically determined.
-    res : int
-        The resolution of the topomap image (n pixels along each side).
-    size : float
-        Side length per topomap in inches.
-    cbar_fmt : str
-        String format for colorbar values.
+    %(topomap_ch_type)s
+    %(topomap_vmin_vmax)s
+    %(topomap_cmap)s
+    %(topomap_sensors)s
+    %(topomap_colorbar)s
+    %(topomap_scalings)s
+    %(topomap_units)s
+    %(topomap_res)s
+    %(topomap_size)s
+    %(topomap_cbar_fmt)s
     time_unit : str
         The units for the time axis, can be "ms" or "s" (default).
 
@@ -1500,44 +1464,18 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
     time_format : str | None
         String format for topomap values. Defaults (None) to "%%01d ms" if
         ``time_unit='ms'``, "%%0.3f s" if ``time_unit='s'``, and
-        "%%g" otherwise.
+        "%%g" otherwise. Can be an empty string to omit the time label.
     %(plot_proj)s
-    show : bool
-        Show figure if True.
+    %(show)s
     %(topomap_show_names)s
-    title : str | None
-        Title. If None (default), no title is displayed.
-    mask : ndarray of bool, shape (n_channels, n_times) | None
-        The channels to be marked as significant at a given time point.
-        Indices set to ``True`` will be considered. Defaults to ``None``.
-    mask_params : dict | None
-        Additional plotting parameters for plotting significant sensors.
-        Default (None) equals::
-
-            dict(marker='o', markerfacecolor='w', markeredgecolor='k',
-                 linewidth=0, markersize=4)
+    %(title_None)s
+    %(topomap_mask)s
+    %(topomap_mask_params)s
     %(topomap_outlines)s
-    contours : int | array of float
-        The number of contour lines to draw. If 0, no contours will be drawn.
-        When an integer, matplotlib ticker locator is used to find suitable
-        values for the contour thresholds (may sometimes be inaccurate, use
-        array for accuracy). If an array, the values represent the levels for
-        the contours. The values are in µV for EEG, fT for magnetometers and
-        fT/m for gradiometers. If colorbar=True, the ticks in colorbar
-        correspond to the contour levels. Defaults to 6.
-    image_interp : str
-        The image interpolation to be used. All matplotlib options are
-        accepted.
-    average : float | None
-        The time window around a given time to be used for averaging (seconds).
-        For example, 0.01 would translate into window that starts 5 ms before
-        and ends 5 ms after a given time point. Defaults to None, which means
-        no averaging.
-    axes : instance of Axes | list | None
-        The axes to plot to. If list, the list must be a list of Axes of the
-        same length as ``times`` (unless ``times`` is None). If instance of
-        Axes, ``times`` must be a float or a list of one float.
-        Defaults to None.
+    %(topomap_contours)s
+    %(topomap_image_interp)s
+    %(topomap_average)s
+    %(topomap_axes)s
     %(topomap_extrapolate)s
 
         .. versionadded:: 0.18
@@ -1587,6 +1525,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
     # time units / formatting
     time_unit, _ = _check_time_unit(time_unit, evoked.times)
     scaling_time = 1. if time_unit == 's' else 1e3
+    _validate_type(time_format, (None, str), 'time_format')
     if time_format is None:
         time_format = '%0.3f s' if time_unit == 's' else '%01d ms'
     del time_unit
@@ -1729,7 +1668,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
         images.append(tp)
         if cn is not None:
             contours_.append(cn)
-        if time_format is not None:
+        if time_format != '':
             axes[ax_idx].set_title(time_format % (time * scaling_time))
 
     if interactive:

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2012,8 +2012,7 @@ class DraggableColorbar(object):
         self.cbar.mappable.set_cmap(cmap)
         self.cbar.draw_all()
         self.mappable.set_cmap(cmap)
-        self.mappable.set_norm(self.cbar.norm)
-        self.cbar.patch.figure.canvas.draw()
+        self._update()
 
     def on_motion(self, event):
         """Handle mouse movements."""
@@ -2032,21 +2031,22 @@ class DraggableColorbar(object):
         elif event.button == 3:
             self.cbar.norm.vmin -= (perc * scale) * np.sign(dy)
             self.cbar.norm.vmax += (perc * scale) * np.sign(dy)
-        self.cbar.draw_all()
-        self.mappable.set_norm(self.cbar.norm)
-        self.cbar.patch.figure.canvas.draw()
+        self._update()
 
     def on_release(self, event):
         """Handle release."""
         self.press = None
-        self.mappable.set_norm(self.cbar.norm)
-        self.cbar.patch.figure.canvas.draw()
+        self._update()
 
     def on_scroll(self, event):
         """Handle scroll."""
         scale = 1.1 if event.step < 0 else 1. / 1.1
         self.cbar.norm.vmin *= scale
         self.cbar.norm.vmax *= scale
+        self._update()
+
+    def _update(self):
+        self.cbar.set_ticks(None, update_ticks=True)  # use default
         self.cbar.draw_all()
         self.mappable.set_norm(self.cbar.norm)
         self.cbar.patch.figure.canvas.draw()


### PR DESCRIPTION
Closes #7384
Closes #8183

- Also adds support for `time_label=''` to avoid having the time printed.
- With a bit of squaring, we get correct units / scale factors / whitening compared to what's in `master`.