### PR TITLE
MRG, ENH: Add on_missing to plot_events

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -101,7 +101,9 @@ Changelog
 
 - Add :func:`mne.viz.centers_to_edges` to help when using :meth:`matplotlib.axes.Axes.pcolormesh` with flat shading by `Eric Larson`_
 
-- Add "on_missing='raise'" to :meth:`mne.io.Raw.set_montage` and related functions to allow ignoring of missing electrode coordinates by `Adam Li`_
+- Add ``on_missing='raise'`` to :meth:`mne.io.Raw.set_montage` and related functions to allow ignoring of missing electrode coordinates by `Adam Li`_
+
+- Add ``on_missing='raise'`` to :func:`mne.viz.plot_events` to allow ignoring missing events when passing ``event_id`` by `Eric Larson`_
 
 - Add REST EEG infinity reference scheme to :meth:`mne.io.Raw.set_eeg_reference` and related functions by `Eric Larson`_
 

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1284,6 +1284,9 @@ def test_set_montage_with_missing_coordinates():
         raw.set_montage(montage_in_mri)
 
     with pytest.raises(ValueError, match='Invalid value'):
+        raw.set_montage(montage_in_mri, on_missing='foo')
+
+    with pytest.raises(TypeError, match='must be an instance'):
         raw.set_montage(montage_in_mri, on_missing=True)
 
     with pytest.warns(RuntimeWarning, match='DigMontage is '

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1376,7 +1376,8 @@ def apply_forward(fwd, stc, info, start=None, stop=None, use_cps=True,
     %(use_cps)s
 
         .. versionadded:: 0.15
-    %(on_missing)s Default is "raise".
+    %(on_missing_fwd)s
+        Default is "raise".
 
         .. versionadded:: 0.18
     %(verbose)s
@@ -1443,7 +1444,8 @@ def apply_forward_raw(fwd, stc, info, start=None, stop=None,
         Index of first time sample (index not time is seconds).
     stop : int, optional
         Index of first time sample not to include (index not time is seconds).
-    %(on_missing)s Default is "raise".
+    %(on_missing_fwd)s
+        Default is "raise".
 
         .. versionadded:: 0.18
     %(verbose)s
@@ -1490,7 +1492,8 @@ def restrict_forward_to_stc(fwd, stc, on_missing='ignore'):
         Forward operator.
     stc : instance of SourceEstimate
         Source estimate.
-    %(on_missing)s Default is "ignore".
+    %(on_missing_fwd)s
+        Default is "ignore".
 
         .. versionadded:: 0.18
 

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -720,12 +720,13 @@ def _on_missing(on_missing, msg):
     ValueError
         When on_missing is 'raise'.
     """
-    _check_option('on_missing', on_missing,
-                  ['raise', 'error', 'warn', 'warning', 'ignore'])
-
-    if on_missing in ('raise', 'error'):
+    _validate_type(on_missing, str, 'on_missing')
+    on_missing = 'raise' if on_missing == 'error' else on_missing
+    on_missing = 'warn' if on_missing == 'warning' else on_missing
+    _check_option('on_missing', on_missing, ['raise', 'warn', 'ignore'])
+    if on_missing == 'raise':
         raise ValueError(msg)
-    elif on_missing in ('warn', 'warning'):
+    elif on_missing == 'warn':
         warn(msg)
     else:  # Ignore
-        pass
+        assert on_missing == 'ignore'

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -964,10 +964,14 @@ docdict['use_cps_restricted'] = docdict['use_cps'] + """
 """
 
 # Forward
-docdict['on_missing'] = """
+_on_missing_base = """\
 on_missing : str
-    Behavior when ``stc`` has vertices that are not in ``fwd``.
-    Can be "ignore", "warn"", or "raise"."""
+    Can be 'raise' (default) to raise an error, 'warn' to emit a warning, or
+    'ignore' to ignore when
+"""
+docdict['on_missing_fwd'] = """
+%s ``stc`` has vertices that are not in ``fwd``.
+""" % (_on_missing_base,)
 docdict['dig_kinds'] = """
 dig_kinds : list of str | str
     Kind of digitization points to use in the fitting. These can be any
@@ -1194,14 +1198,19 @@ match_case : bool
 
     .. versionadded:: 0.20
 """
+docdict['on_missing_events'] = """
+%s event numbers from ``event_id`` are missing from ``events``.
+    When numbers from ``events`` are missing from ``event_id`` they will be
+    ignored and a warning emitted; consider using ``verbose='error'`` in
+    this case.
+
+    .. versionadded:: 0.21
+""" % (_on_missing_base,)
 docdict['on_missing_montage'] = """
-on_missing : str
-    Either 'raise', or 'warn' to raise an error/warning when
-    channels have missing coordinates,
-    or 'ignore' to set channels to np.nan and set montage.
+%s channels have missing coordinates.
 
     .. versionadded:: 0.20.1
-"""
+""" % (_on_missing_base,)
 docdict['rename_channels_mapping'] = """
 mapping : dict | callable
     A dictionary mapping the old channel to a new channel name

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -964,11 +964,9 @@ docdict['use_cps_restricted'] = docdict['use_cps'] + """
 """
 
 # Forward
-_on_missing_base = """\
-on_missing : str
-    Can be 'raise' (default) to raise an error, 'warn' to emit a warning, or
-    'ignore' to ignore when
-"""
+_on_missing_base = """on_missing : str
+    Can be ``'raise'`` (default) to raise an error, ``'warn'`` to emit a
+    warning, or ``'ignore'`` to ignore when"""
 docdict['on_missing_fwd'] = """
 %s ``stc`` has vertices that are not in ``fwd``.
 """ % (_on_missing_base,)

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -181,9 +181,24 @@ def test_plot_events():
     with pytest.warns(RuntimeWarning, match=multimatch):
         plot_events(events, raw.info['sfreq'], raw.first_samp,
                     event_id={'aud_l': 1}, color=color)
+    extra_id = {'missing': 111}
     with pytest.raises(ValueError, match='from event_id is not present in'):
         plot_events(events, raw.info['sfreq'], raw.first_samp,
-                    event_id={'aud_l': 111}, color=color)
+                    event_id=extra_id)
+    with pytest.raises(RuntimeError, match='No usable event IDs'):
+        plot_events(events, raw.info['sfreq'], raw.first_samp,
+                    event_id=extra_id, on_missing='ignore')
+    extra_id = {'aud_l': 1, 'missing': 111}
+    with pytest.warns(RuntimeWarning, match='from event_id is not present in'):
+        plot_events(events, raw.info['sfreq'], raw.first_samp,
+                    event_id=extra_id, on_missing='warn')
+    with pytest.warns(RuntimeWarning, match='event 2 missing'):
+        plot_events(events, raw.info['sfreq'], raw.first_samp,
+                    event_id=extra_id, on_missing='ignore')
+    events = events[events[:, 2] == 1]
+    assert len(events) > 0
+    plot_events(events, raw.info['sfreq'], raw.first_samp,
+                event_id=extra_id, on_missing='ignore')
     with pytest.raises(ValueError, match='No events'):
         plot_events(np.empty((0, 3)))
     plt.close('all')


### PR DESCRIPTION
Closes #6905

@AKMeunier @rderollepot can you see if this works for you?

Regarding being able to ignore the existing warning, you can now do `verbose='error'` if you really want to also ignore the `event 2 missing from event_id will be ignored` warnings.