### PR TITLE
MRG, FIX: ch_type in plot_projs_topomap

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -342,6 +342,7 @@ def plot_projs_topomap(projs, info, cmap=None, sensors=True,
         spheres.append(this_sphere)
         outliness.append(these_outlines)
         ch_typess.append(ch_type)
+        del data, pos, this_sphere, these_outlines, ch_type
     del sphere
 
     # setup axes
@@ -383,7 +384,7 @@ def plot_projs_topomap(projs, info, cmap=None, sensors=True,
                           outlines=_outlines, contours=contours,
                           image_interp=image_interp, show=False,
                           extrapolate=extrapolate, sphere=_sphere,
-                          border=border, ch_type=ch_type)[0]
+                          border=border, ch_type=_ch_type)[0]
 
         if colorbar:
             _add_colorbar(ax, im, cmap)

--- a/tutorials/preprocessing/plot_50_artifact_correction_ssp.py
+++ b/tutorials/preprocessing/plot_50_artifact_correction_ssp.py
@@ -15,7 +15,7 @@ heartbeat artifacts.
    :depth: 2
 
 We begin as always by importing the necessary Python modules. To save ourselves
-from repeatedly typing ``mne.preprocessing`` we'll directly import a couple
+from repeatedly typing ``mne.preprocessing`` we'll directly import a handful of
 functions from that submodule:
 """
 


### PR DESCRIPTION
Closes #7993

This bug was in this release so no need for `latest.inc` update. You can see the problem on `master` [here](https://mne.tools/dev/auto_tutorials/preprocessing/plot_50_artifact_correction_ssp.html#repairing-ecg-artifacts-with-ssp):

![](https://mne.tools/dev/_images/sphx_glr_plot_50_artifact_correction_ssp_016.png)