### PR TITLE
MRG, BUG: Fix STC limit bug

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -228,6 +228,8 @@ Bug
 
 - Fix bug with :func:`mne.viz.plot_vector_source_estimates` using the PyVista backend with ``time_viewer=True`` when updating the arrow colormaps by `Eric Larson`_
 
+- Fix bug with :func:`mne.viz.plot_vector_source_estimates` where ``clim='auto'`` and ``clim=dict(..., kind='percent')`` did not take into account the magnitude of the activation, by `Eric Larson`_
+
 - The default plotting mode for :func:`mne.io.Raw.plot` and :ref:`mne browse_raw` has been changed to ``clipping=3.`` to facilitate data analysis with large deflections, by `Eric Larson`_
 
 - PSD plots will now show non-data channels (e.g., ``misc``) if those channels are explicitly passed to ``picks``, by `Daniel McCloy`_.

--- a/examples/inverse/plot_vector_mne_solution.py
+++ b/examples/inverse/plot_vector_mne_solution.py
@@ -15,7 +15,7 @@ estimated magnitude. This can be accomplished by computing a
 It can also be instructive to visualize the actual dipole/activation locations
 in 3D space in a glass brain, as opposed to activations imposed on an inflated
 surface (as typically done in :meth:`mne.SourceEstimate.plot`), as it allows
-you to get a better sense of the true underlying source geometry.
+you to get a better sense of the underlying source geometry.
 """
 # Author: Marijn van Vliet <w.m.vanvliet@gmail.com>
 #

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1781,7 +1781,8 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
     time_label, times = _handle_time(time_label, time_unit, stc.times)
 
     # convert control points to locations in colormap
-    mapdata = _process_clim(clim, colormap, transparent, stc.data,
+    use = stc.magnitude().data if vec else stc.data
+    mapdata = _process_clim(clim, colormap, transparent, use,
                             allow_pos_lims=not vec)
 
     stc_surf, stc_vol, src_vol = _triage_stc(

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1381,7 +1381,9 @@ class _Brain(object):
                 glyph_mapper = hemi_data['glyph_mapper']
             if add:
                 glyph_actor = _create_actor(glyph_mapper)
-                glyph_actor.GetProperty().SetLineWidth(2.)
+                prop = glyph_actor.GetProperty()
+                prop.SetLineWidth(2.)
+                prop.SetOpacity(vector_alpha)
                 self._renderer.plotter.add_actor(glyph_actor)
                 hemi_data['glyph_actor'].append(glyph_actor)
             else:

--- a/tutorials/source-modeling/plot_visualize_stc.py
+++ b/tutorials/source-modeling/plot_visualize_stc.py
@@ -1,10 +1,11 @@
 """
 .. _tut_viz_stcs:
 
-Visualize source time courses
-=============================
+Visualize source time courses (stcs)
+====================================
 
-This tutorial focuses on visualization of stcs.
+This tutorial focuses on visualization of
+:term:`stcs <source estimates (abbr. stc)>`.
 
 .. contents:: Table of Contents
    :local:


### PR DESCRIPTION
Close #7911

On `master`, auto control points for the vec STC are `[1.86911522 2.26944519 6.37046324]` and standard STC are `[ 3.95048065  4.56941314 17.72451438]`. On this PR, there are two fixes:

1. `vector_alpha` actually has an effect
2. `_process_clim` uses the `.magnitude()` data for vector mode, which makes more sense.

On this PR, this code:

<details>

```
import os.path as op
import mne

data_path = mne.datasets.sample.data_path()
sample_dir = op.join(data_path, 'MEG', 'sample')
subjects_dir = op.join(data_path, 'subjects')
inv = mne.minimum_norm.read_inverse_operator(op.join(
    sample_dir, 'sample_audvis-meg-oct-6-meg-inv.fif'))
evoked = mne.read_evokeds(op.join(sample_dir, 'sample_audvis-ave.fif'))[0]
evoked.apply_baseline((None, 0))
stc = mne.minimum_norm.apply_inverse(
    evoked, inv, method='dSPM', verbose='debug', pick_ori='vector')
initial_time = 0.1
# stc, kwargs = stc, dict(overlay_alpha=0.5, brain_alpha=0.5, vector_alpha=0.)
stc, kwargs = stc.magnitude(), dict(alpha=0.5, surface='white')
brain = stc.plot(subjects_dir=subjects_dir, initial_time=initial_time,
                 clim='auto', hemi='lh', views='lat',
                 smoothing_steps='nearest', verbose=True,
                 time_viewer=False, size=(600, 600), background='k',
                 **kwargs)
brain.show_view('lat')
```

</details>

- Run as is (magnitude mode):
  - Mayavi
    ![Screenshot from 2020-09-02 15-47-59](https://user-images.githubusercontent.com/2365790/92029530-affe1200-ed33-11ea-8db5-3def7d5e7fc9.png)
  - PyVista
    ![Screenshot from 2020-09-02 15-48-25](https://user-images.githubusercontent.com/2365790/92029576-bf7d5b00-ed33-11ea-9c0b-7760ebc469cc.png)
- Run in vector mode (second `stc, kwargs` line commented out) produces:
  - Mayavi
    ![Screenshot from 2020-09-02 15-49-21](https://user-images.githubusercontent.com/2365790/92029669-e3d93780-ed33-11ea-9d50-fcfe21d75b85.png)
  - PyVista
    ![Screenshot from 2020-09-02 15-49-44](https://user-images.githubusercontent.com/2365790/92029724-f81d3480-ed33-11ea-90b0-0463c4f676ed.png)

The slight coloration of the brain itself differs because mayavi has backface culling on for the surface and our _Brain doesn't. I actually think our behavior is probably better for translucent brains.

There is a bug/mismatch where the limits are not computed properly in `auto` mode, probably related to whether or not the entire stc is used, or the initial time.