### PR TITLE
[MRG] BF: String formatting in exception message

### DIFF
--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -147,8 +147,8 @@ def _get_3d_backend():
                     MNE_3D_BACKEND = name
                     break
             else:
-                raise RuntimeError('Could not load any valid 3D backend: %s'
-                                   % (VALID_3D_BACKENDS))
+                raise RuntimeError(f'Could not load any valid 3D backend: '
+                                   f'{", ".join(VALID_3D_BACKENDS)}')
         else:
             _check_option('MNE_3D_BACKEND', MNE_3D_BACKEND, VALID_3D_BACKENDS)
             _reload_backend(MNE_3D_BACKEND)


### PR DESCRIPTION
#### What does this implement/fix?
#8194 introduced changes to `mne.viz.backends._utils.VALID_3D_BACKENDS`.

Now, if `viz.backends.renderer._get_3d_backend()` cannot find a valid backend, the string formatting
doesn't work (`VALID_3D_BACKENDS` is a tuple, and we're trying to format the string with only a single `%s`.

This commit not only fixes that, but improves formatting ever so slightly.


#### Additional information
@agramfort This is the reason why our scheduled study-template CI run failed last night.