### PR TITLE
MAINT: vectorize _read_annotations_edf

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -183,6 +183,8 @@ Changelog
 
 - Add ``component_order`` parameter to :class:`mne.decoding.CSP` which allows switching between ``mutual_info`` (default) and ``alternate`` (a simpler and frequently used option) by `Martin Billinger`_ and `Clemens Brunner`_
 
+- Speed up :func:`~mne.io.edf.edf._read_annotations_edf` by using numpy by `Jeroen Van Der Donckt`_
+
 Bug
 ~~~
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -183,7 +183,7 @@ Changelog
 
 - Add ``component_order`` parameter to :class:`mne.decoding.CSP` which allows switching between ``mutual_info`` (default) and ``alternate`` (a simpler and frequently used option) by `Martin Billinger`_ and `Clemens Brunner`_
 
-- Speed up :func:`~mne.io.edf.edf._read_annotations_edf` by using numpy by `Jeroen Van Der Donckt`_
+- Speed up reading of annotations in EDF+ files by `Jeroen Van Der Donckt`_
 
 Bug
 ~~~

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -317,3 +317,5 @@
 .. _Lau Møller Andersen: https://github.com/ualsbombe
 
 .. _Martin Schulz: https://github.com/marsipu
+
+.. _Jeroen Van Der Donckt: https://github.com/jvdd

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -7,6 +7,7 @@
 #          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #          Joan Massich <mailsik@gmail.com>
 #          Clemens Brunner <clemens.brunner@gmail.com>
+#          Jeroen Van Der Donckt (IDLab Ghent University - imec) <jeroen.vanderdonckt@ugent.be>
 #
 # License: BSD (3-clause)
 
@@ -1354,6 +1355,9 @@ def _read_annotations_edf(annotations):
             triggers = re.findall(pat, annot_file.read())
     else:
         tals = bytearray()
+        annotations = np.array(annotations) # To make sure that annotations is a ndarray
+        if annotations.ndim == 1: # Add the channel dimensions so that the code is vectorized in the following loop
+            annotations = np.expand_dims(annotations, axis=0)
         for chan in annotations:
             this_chan = chan.ravel()
             if this_chan.dtype == np.int32:  # BDF
@@ -1362,12 +1366,10 @@ def _read_annotations_edf(annotations):
                 # Why only keep the first 3 bytes as BDF values
                 # are stored with 24 bits (not 32)
                 this_chan = this_chan[:, :3].ravel()
-                for s in this_chan:
-                    tals.extend(s)
+                tals.extend(this_chan) # As ravel() returns a 1D array we can add all values at once
             else:
-                for s in this_chan:
-                    i = int(s)
-                    tals.extend(np.uint8([i % 256, i // 256]))
+                this_chan = chan.astype(int)
+                tals.extend(np.uint8([this_chan % 256, this_chan // 256]).flatten('F')) # Exploit np vectorized processing
 
         # use of latin-1 because characters are only encoded for the first 256
         # code points and utf-8 can triggers an "invalid continuation byte"

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -7,7 +7,7 @@
 #          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #          Joan Massich <mailsik@gmail.com>
 #          Clemens Brunner <clemens.brunner@gmail.com>
-#          Jeroen Van Der Donckt (IDLab Ghent University - imec) <jeroen.vanderdonckt@ugent.be>
+#          Jeroen Van Der Donckt (IDlab - imec) <jeroen.vanderdonckt@ugent.be>
 #
 # License: BSD (3-clause)
 
@@ -1355,9 +1355,7 @@ def _read_annotations_edf(annotations):
             triggers = re.findall(pat, annot_file.read())
     else:
         tals = bytearray()
-        annotations = np.array(annotations) # To make sure that annotations is a ndarray
-        if annotations.ndim == 1: # Add the channel dimensions so that the code is vectorized in the following loop
-            annotations = np.expand_dims(annotations, axis=0)
+        annotations = np.atleast_2d(annotations)
         for chan in annotations:
             this_chan = chan.ravel()
             if this_chan.dtype == np.int32:  # BDF
@@ -1366,10 +1364,13 @@ def _read_annotations_edf(annotations):
                 # Why only keep the first 3 bytes as BDF values
                 # are stored with 24 bits (not 32)
                 this_chan = this_chan[:, :3].ravel()
-                tals.extend(this_chan) # As ravel() returns a 1D array we can add all values at once
+                # As ravel() returns a 1D array we can add all values at once
+                tals.extend(this_chan)
             else:
                 this_chan = chan.astype(int)
-                tals.extend(np.uint8([this_chan % 256, this_chan // 256]).flatten('F')) # Exploit np vectorized processing
+                # Exploit np vectorized processing
+                tals.extend(np.uint8([this_chan % 256, this_chan // 256])
+                            .flatten('F'))
 
         # use of latin-1 because characters are only encoded for the first 256
         # code points and utf-8 can triggers an "invalid continuation byte"


### PR DESCRIPTION
Speedup the processing of the channel data in EDF+ TAL format through vectorizing the code.
This speedup tackles the time bottleneck when a RawEDF object is created.

Note: experimental results on private datasets yielded a speedup of 100-150x on EDF+C and EDF+D files of 20 - 360 MB when calling mne.io.read_raw_edf.

Author: Jeroen Van Der Donckt (IDLab Ghent University - imec)
