### PR TITLE
RFC: use MPL cycler colors / "dark mode" [ci skip]

### DIFF
--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -5,13 +5,16 @@
 # License: BSD (3-clause)
 
 from copy import deepcopy
+from matplotlib import rcParams
+
+black = rcParams['axes.edgecolor']
 
 DEFAULTS = dict(
-    color=dict(mag='darkblue', grad='b', eeg='k', eog='k', ecg='m', emg='k',
-               ref_meg='steelblue', misc='k', stim='k', resp='k', chpi='k',
-               exci='k', ias='k', syst='k', seeg='saddlebrown', dipole='k',
-               gof='k', bio='k', ecog='k', hbo='#AA3377', hbr='b',
-               fnirs_cw_amplitude='k', fnirs_od='k', csd='k'),
+    color=dict(mag='C0', grad='C4', eeg=black, eog=black, ecg='C6', emg=black,
+               ref_meg='C9', misc=black, stim=black, resp=black, chpi=black,
+               exci=black, ias=black, syst=black, seeg='C5', dipole=black,
+               gof=black, bio=black, ecog=black, hbo='C3', hbr='C4',
+               fnirs_cw_amplitude=black, fnirs_od=black, csd=black),
     units=dict(mag='fT', grad='fT/cm', eeg='µV', eog='µV', ecg='µV', emg='µV',
                misc='AU', seeg='mV', dipole='nAm', gof='GOF', bio='µV',
                ecog='µV', hbo='µM', hbr='µM', ref_meg='fT',


### PR DESCRIPTION
There's been some talk about making a "dark mode" for our 2D plotting.  I did a bit of investigating with `raw.plot()`, here's what I found:

- because we specify colors in `mne/defaults.py` (which gets loaded when the package is imported), using `plt.style.use('dark_mode')` or `with plt.style.context('dark_mode'):` don't work as expected unless the `import mne` statement comes **after** the style invocation.
- the default cycles don't have enough blue-ish colors to keep things roughly the same as they are now (we currently use 3 different shades of blue for mag, grad, and ref-meg channels).
- there is actually not very good parallelism between MPL normal mode and dark mode. I had wrongly thought that the "blue-orange-green-red..." sequence in default MPL style was replaced in dark mode by pale versions of each color but with roughly the same hue. This is not the case: below are the actual colors (with names made up by me), showing that, e.g. (for `C2`), what is green in normal mode is lavender in dark mode.  This is... not great.

```
#    |   normal mode     |      dark mode
# ------------------------------------------------
# C0 |  #1f77b4  blue    |  #8dd3c7  pale blue
# C1 |  #ff7f0e  orange  |  #feffb3  pale yellow
# C2 |  #2ca02c  green   |  #bfbbd9  pale lavender
# C3 |  #d62728  red     |  #fa8174  salmon
# C4 |  #9467bd  purple  |  #81b1d2  blue
# C5 |  #8c564b  brown   |  #fdb462  tangerine
# C6 |  #e377c2  pink    |  #b3de69  spring green
# C7 |  #7f7f7f  grey    |  #bc82bd  lavender
# C8 |  #bcbd22  yellow  |  #ccebc4  pale green
# C9 |  #17becf  teal    |  #ffed6f  yellow
```

See below for what is the best compromise I was able to come up with so far while using the default cycler colors. Obviously this is an incomplete attempt, just wanted to show the blue-and-teal-on-black look:

![darkmode](https://user-images.githubusercontent.com/1810515/92334997-5f025c80-f058-11ea-8057-32794e56d6bf.png)

### alternatives

we could roll-our-own dark mode by adding a couple keys to the default color dict (i.e., "foreground" and "background"), and then having a separate pre-defined dict for a dark-mode version of the default colors.

cc @cbrnr, who has expressed interest in this.