### PR TITLE
MRG: Set pyvista as default 3d backend

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -189,6 +189,8 @@ Changelog
 
 - Add reader for Persyst (.lay + .dat format) data in :func:`mne.io.read_raw_persyst` by `Adam Li`_
 
+- Use PyVista as the default backend for 3D visualization instead of Mayavi by `Guillaume Favelier`_
+
 Bug
 ~~~
 

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - imageio-ffmpeg>=0.4.1
   - vtk>=9.0.1
   - pyvista>=0.24
-  - pyvistaqt
+  - pyvistaqt>=0.2.0
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -10,7 +10,11 @@
 import numpy as np
 import collections.abc
 
-VALID_3D_BACKENDS = ('mayavi', 'pyvista', 'notebook')
+VALID_3D_BACKENDS = (
+    'pyvista',  # default 3d backend
+    'mayavi',
+    'notebook',
+)
 ALLOWED_QUIVER_MODES = ('2darrow', 'arrow', 'cone', 'cylinder', 'sphere')
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,5 @@ xlrd
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1
 pyvista>=0.24
-pyvistaqt
+pyvistaqt>=0.2.0
 tqdm


### PR DESCRIPTION
This PR follows https://github.com/mne-tools/mne-python/pull/8116#issuecomment-688680649 and sets PyVista as the default 3d backend.

AFAIK, coreg is the last big part of the codebase still not ported to pyvista and is next in my todo list.

It's an item of #7162 