### PR TITLE
Updated doc for time frequency analysis functions

### DIFF
--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -105,7 +105,9 @@ def tfr_array_stockwell(data, sfreq, fmin=None, fmax=None, n_fft=None,
 
 
     Same computation as the function tfr_stockwell.
-    Difference: tfr_stockwell takes epochs in the mne.Epochs format as input. This function, tfr_array_stockwell, takes epochs in the numpy.array format as input.
+    Difference: tfr_stockwell takes epochs in the mne.Epochs format as input.
+    This function, tfr_array_stockwell, takes epochs in the numpy.array format
+    as input.
 
     See [1]_, [2]_, [3]_, [4]_ for more information.
 
@@ -214,7 +216,8 @@ def tfr_stockwell(inst, fmin=None, fmax=None, n_fft=None,
     """Compute Time-Frequency Representation (TFR) using Stockwell Transform.
 
     Same computation as the function tfr_array_stockwell.
-    Difference: tfr_stockwell takes epochs in the mne.Epochs format as input; tfr_array_stockwell takes epochs in the numpy.array format as input.
+    Difference: tfr_stockwell takes epochs in the mne.Epochs format as input;
+    tfr_array_stockwell takes epochs in the numpy.array format as input.
 
     See [1]_, [2]_, [3]_, [4]_ for more information.
 

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -103,10 +103,8 @@ def tfr_array_stockwell(data, sfreq, fmin=None, fmax=None, n_fft=None,
                         width=1.0, decim=1, return_itc=False, n_jobs=1):
     """Compute power and intertrial coherence using Stockwell (S) transform.
 
-    Same computation as the function tfr_stockwell.
-    Difference: tfr_stockwell takes epochs in the mne.Epochs format as input.
-    This function, tfr_array_stockwell, takes epochs in the numpy.array format
-    as input.
+    Same computation as `~mne.time_frequency.tfr_stockwell`, but operates on
+    :class:`NumPy arrays <numpy.ndarray>` instead of `~mne.Epochs` objects.
 
     See :footcite:`Stockwell2007,MoukademEtAl2014,WheatEtAl2010,JonesEtAl2006`
     for more information.
@@ -199,9 +197,8 @@ def tfr_stockwell(inst, fmin=None, fmax=None, n_fft=None,
                   verbose=None):
     """Compute Time-Frequency Representation (TFR) using Stockwell Transform.
 
-    Same computation as the function tfr_array_stockwell.
-    Difference: tfr_stockwell takes epochs in the mne.Epochs format as input;
-    tfr_array_stockwell takes epochs in the numpy.array format as input.
+    Same computation as `~mne.time_frequency.tfr_array_stockwell`, but operates
+    on `~mne.Epochs` objects instead of :class:`NumPy arrays <numpy.ndarray>`.
 
     See :footcite:`Stockwell2007,MoukademEtAl2014,WheatEtAl2010,JonesEtAl2006`
     for more information.

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -103,6 +103,10 @@ def tfr_array_stockwell(data, sfreq, fmin=None, fmax=None, n_fft=None,
                         width=1.0, decim=1, return_itc=False, n_jobs=1):
     """Compute power and intertrial coherence using Stockwell (S) transform.
 
+
+    Same computation as the function tfr_stockwell.
+    Difference: tfr_stockwell takes epochs in the mne.Epochs format as input. This function, tfr_array_stockwell, takes epochs in the numpy.array format as input.
+
     See [1]_, [2]_, [3]_, [4]_ for more information.
 
     Parameters
@@ -207,7 +211,12 @@ def tfr_array_stockwell(data, sfreq, fmin=None, fmax=None, n_fft=None,
 def tfr_stockwell(inst, fmin=None, fmax=None, n_fft=None,
                   width=1.0, decim=1, return_itc=False, n_jobs=1,
                   verbose=None):
-    """Time-Frequency Representation (TFR) using Stockwell Transform.
+    """Compute Time-Frequency Representation (TFR) using Stockwell Transform.
+
+    Same computation as the function tfr_array_stockwell.
+    Difference: tfr_stockwell takes epochs in the mne.Epochs format as input; tfr_array_stockwell takes epochs in the numpy.array format as input.
+
+    See [1]_, [2]_, [3]_, [4]_ for more information.
 
     Parameters
     ----------
@@ -247,6 +256,26 @@ def tfr_stockwell(inst, fmin=None, fmax=None, n_fft=None,
     mne.time_frequency.tfr_array_multitaper
     mne.time_frequency.tfr_morlet
     mne.time_frequency.tfr_array_morlet
+
+    References
+    ----------
+    .. [1] Stockwell, R. G. "Why use the S-transform." AMS Pseudo-differential
+       operators: Partial differential equations and time-frequency
+       analysis 52 (2007): 279-309.
+    .. [2] Moukadem, A., Bouguila, Z., Abdeslam, D. O, and Dieterlen, A.
+       Stockwell transform optimization applied on the detection of split in
+       heart sounds (2014). Signal Processing Conference (EUSIPCO), 2013
+       Proceedings of the 22nd European, pages 2015--2019.
+    .. [3] Wheat, K., Cornelissen, P. L., Frost, S.J, and Peter C. Hansen
+       (2010). During Visual Word Recognition, Phonology Is Accessed
+       within 100 ms and May Be Mediated by a Speech Production
+       Code: Evidence from Magnetoencephalography. The Journal of
+       Neuroscience, 30 (15), 5229-5233.
+    .. [4] K. A. Jones and B. Porjesz and D. Chorlian and M. Rangaswamy and C.
+       Kamarajan and A. Padmanabhapillai and A. Stimus and H. Begleiter
+       (2006). S-transform time-frequency analysis of P300 reveals deficits in
+       individuals diagnosed with alcoholism.
+       Clinical Neurophysiology 117 2128--2143
 
     Notes
     -----

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -108,7 +108,8 @@ def tfr_array_stockwell(data, sfreq, fmin=None, fmax=None, n_fft=None,
     This function, tfr_array_stockwell, takes epochs in the numpy.array format
     as input.
 
-    See [1]_, [2]_, [3]_, [4]_ for more information.
+    See :footcite:`Stockwell2007,MoukademEtAl2014,WheatEtAl2010,JonesEtAl2006`
+    for more information.
 
     Parameters
     ----------
@@ -154,23 +155,7 @@ def tfr_array_stockwell(data, sfreq, fmin=None, fmax=None, n_fft=None,
 
     References
     ----------
-    .. [1] Stockwell, R. G. "Why use the S-transform." AMS Pseudo-differential
-       operators: Partial differential equations and time-frequency
-       analysis 52 (2007): 279-309.
-    .. [2] Moukadem, A., Bouguila, Z., Abdeslam, D. O, and Dieterlen, A.
-       Stockwell transform optimization applied on the detection of split in
-       heart sounds (2014). Signal Processing Conference (EUSIPCO), 2013
-       Proceedings of the 22nd European, pages 2015--2019.
-    .. [3] Wheat, K., Cornelissen, P. L., Frost, S.J, and Peter C. Hansen
-       (2010). During Visual Word Recognition, Phonology Is Accessed
-       within 100 ms and May Be Mediated by a Speech Production
-       Code: Evidence from Magnetoencephalography. The Journal of
-       Neuroscience, 30 (15), 5229-5233.
-    .. [4] K. A. Jones and B. Porjesz and D. Chorlian and M. Rangaswamy and C.
-       Kamarajan and A. Padmanabhapillai and A. Stimus and H. Begleiter
-       (2006). S-transform time-frequency analysis of P300 reveals deficits in
-       individuals diagnosed with alcoholism.
-       Clinical Neurophysiology 117 2128--2143
+    .. footbibliography::
     """
     _validate_type(data, np.ndarray, 'data')
     if data.ndim != 3:
@@ -218,7 +203,8 @@ def tfr_stockwell(inst, fmin=None, fmax=None, n_fft=None,
     Difference: tfr_stockwell takes epochs in the mne.Epochs format as input;
     tfr_array_stockwell takes epochs in the numpy.array format as input.
 
-    See [1]_, [2]_, [3]_, [4]_ for more information.
+    See :footcite:`Stockwell2007,MoukademEtAl2014,WheatEtAl2010,JonesEtAl2006`
+    for more information.
 
     Parameters
     ----------
@@ -265,23 +251,7 @@ def tfr_stockwell(inst, fmin=None, fmax=None, n_fft=None,
 
     References
     ----------
-    .. [1] Stockwell, R. G. "Why use the S-transform." AMS Pseudo-differential
-       operators: Partial differential equations and time-frequency
-       analysis 52 (2007): 279-309.
-    .. [2] Moukadem, A., Bouguila, Z., Abdeslam, D. O, and Dieterlen, A.
-       Stockwell transform optimization applied on the detection of split in
-       heart sounds (2014). Signal Processing Conference (EUSIPCO), 2013
-       Proceedings of the 22nd European, pages 2015--2019.
-    .. [3] Wheat, K., Cornelissen, P. L., Frost, S.J, and Peter C. Hansen
-       (2010). During Visual Word Recognition, Phonology Is Accessed
-       within 100 ms and May Be Mediated by a Speech Production
-       Code: Evidence from Magnetoencephalography. The Journal of
-       Neuroscience, 30 (15), 5229-5233.
-    .. [4] K. A. Jones and B. Porjesz and D. Chorlian and M. Rangaswamy and C.
-       Kamarajan and A. Padmanabhapillai and A. Stimus and H. Begleiter
-       (2006). S-transform time-frequency analysis of P300 reveals deficits in
-       individuals diagnosed with alcoholism.
-       Clinical Neurophysiology 117 2128--2143
+    .. footbibliography::
     """
     # verbose dec is used b/c subfunctions are verbose
     data = _get_data(inst, return_itc)

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -282,7 +282,6 @@ def tfr_stockwell(inst, fmin=None, fmax=None, n_fft=None,
        (2006). S-transform time-frequency analysis of P300 reveals deficits in
        individuals diagnosed with alcoholism.
        Clinical Neurophysiology 117 2128--2143
-
     """
     # verbose dec is used b/c subfunctions are verbose
     data = _get_data(inst, return_itc)

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -103,7 +103,6 @@ def tfr_array_stockwell(data, sfreq, fmin=None, fmax=None, n_fft=None,
                         width=1.0, decim=1, return_itc=False, n_jobs=1):
     """Compute power and intertrial coherence using Stockwell (S) transform.
 
-
     Same computation as the function tfr_stockwell.
     Difference: tfr_stockwell takes epochs in the mne.Epochs format as input.
     This function, tfr_array_stockwell, takes epochs in the numpy.array format

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -259,6 +259,10 @@ def tfr_stockwell(inst, fmin=None, fmax=None, n_fft=None,
     mne.time_frequency.tfr_morlet
     mne.time_frequency.tfr_array_morlet
 
+    Notes
+    -----
+    .. versionadded:: 0.9.0
+
     References
     ----------
     .. [1] Stockwell, R. G. "Why use the S-transform." AMS Pseudo-differential
@@ -279,9 +283,6 @@ def tfr_stockwell(inst, fmin=None, fmax=None, n_fft=None,
        individuals diagnosed with alcoholism.
        Clinical Neurophysiology 117 2128--2143
 
-    Notes
-    -----
-    .. versionadded:: 0.9.0
     """
     # verbose dec is used b/c subfunctions are verbose
     data = _get_data(inst, return_itc)

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -458,9 +458,11 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
                          zero_mean=True, time_bandwidth=None, use_fft=True,
                          decim=1, output='complex', n_jobs=1,
                          verbose=None):
-    """Compute time-frequency transforms using wavelets and multitaper windows.
+    """Compute Time-Frequency Representation (TFR) using DPSS tapers.
 
-    Uses Morlet wavelets windowed with multiple DPSS tapers.
+    Same computation as the function tfr_multitaper.
+    Difference: tfr_multitaper takes epochs in the mne.Epochs format as input.
+    This function, tfr_array_multitaper, takes epochs in the numpy.array format as input.
 
     Parameters
     ----------
@@ -471,7 +473,7 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
     freqs : array-like of float, shape (n_freqs,)
         The frequencies.
     n_cycles : float | array of float
-        Number of cycles  in the Morlet wavelet. Fixed number or one per
+        Number of cycles in the wavelet. Fixed number or one per
         frequency. Defaults to 7.0.
     zero_mean : bool
         If True, make sure the wavelets have a mean of zero. Defaults to True.

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -462,7 +462,8 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
 
     Same computation as the function tfr_multitaper.
     Difference: tfr_multitaper takes epochs in the mne.Epochs format as input.
-    This function, tfr_array_multitaper, takes epochs in the numpy.array format as input.
+    This function, tfr_array_multitaper, takes epochs in the numpy.array format
+    as input.
 
     Parameters
     ----------

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -460,10 +460,8 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
                          verbose=None):
     """Compute Time-Frequency Representation (TFR) using DPSS tapers.
 
-    Same computation as the function tfr_multitaper.
-    Difference: tfr_multitaper takes epochs in the mne.Epochs format as input.
-    This function, tfr_array_multitaper, takes epochs in the numpy.array format
-    as input.
+    Same computation as `~mne.time_frequency.tfr_multitaper`, but operates on
+    :class:`NumPy arrays <numpy.ndarray>` instead of `~mne.Epochs` objects.
 
     Parameters
     ----------

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -724,10 +724,8 @@ def tfr_array_morlet(epoch_data, sfreq, freqs, n_cycles=7.0,
                      n_jobs=1, verbose=None):
     """Compute time-frequency transform using Morlet wavelets.
 
-    Same computation as the function tfr_morlet.
-    Difference: tfr_morlet takes epochs in the mne.Epochs format as input.
-    This function, tfr_array_morlet, takes epochs in the numpy.array format
-    as input.
+    Same computation as `~mne.time_frequency.tfr_morlet`, but operates on
+    :class:`NumPy arrays <numpy.ndarray>` instead of `~mne.Epochs` objects.
 
     Parameters
     ----------
@@ -801,9 +799,9 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
                    n_jobs=1, picks=None, average=True, verbose=None):
     """Compute Time-Frequency Representation (TFR) using DPSS tapers.
 
-    Same computation as the function tfr_array_multitaper.
-    Difference: tfr_multitaper takes epochs in the mne.Epochs format as input;
-    tfr_array_multitaper takes epochs in the numpy.array format as input.
+    Same computation as `~mne.time_frequency.tfr_array_multitaper`, but
+    operates on `~mne.Epochs` objects instead of
+    :class:`NumPy arrays <numpy.ndarray>`.
 
     Parameters
     ----------

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -284,7 +284,7 @@ def _compute_tfr(epoch_data, freqs, sfreq=1.0, method='morlet',
     method : 'multitaper' | 'morlet', default 'morlet'
         The time-frequency method. 'morlet' convolves a Morlet wavelet.
         'multitaper' uses complex exponentials windowed with multiple DPSS
-        multitapers.
+        tapers.
     n_cycles : float | array of float, default 7.0
         Number of cycles  in the  wavelet. Fixed number
         or one per frequency.
@@ -725,7 +725,8 @@ def tfr_array_morlet(epoch_data, sfreq, freqs, n_cycles=7.0,
     """Compute time-frequency transform using Morlet wavelets.
     Same computation as the function tfr_morlet.
     Difference: tfr_morlet takes epochs in the mne.Epochs format as input.
-    This function, tfr_array_morlet, takes epochs in the numpy.array format as input.
+    This function, tfr_array_morlet, takes epochs in the numpy.array format
+    as input.
 
     Parameters
     ----------

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -286,7 +286,7 @@ def _compute_tfr(epoch_data, freqs, sfreq=1.0, method='morlet',
         'multitaper' uses complex exponentials windowed with multiple DPSS
         tapers.
     n_cycles : float | array of float, default 7.0
-        Number of cycles  in the  wavelet. Fixed number
+        Number of cycles in the wavelet. Fixed number
         or one per frequency.
     zero_mean : bool | None, default None
         None means True for method='multitaper' and False for method='morlet'.

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -723,6 +723,7 @@ def tfr_array_morlet(epoch_data, sfreq, freqs, n_cycles=7.0,
                      zero_mean=False, use_fft=True, decim=1, output='complex',
                      n_jobs=1, verbose=None):
     """Compute time-frequency transform using Morlet wavelets.
+
     Same computation as the function tfr_morlet.
     Difference: tfr_morlet takes epochs in the mne.Epochs format as input.
     This function, tfr_array_morlet, takes epochs in the numpy.array format

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -659,6 +659,10 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False, return_itc=True, decim=1,
                n_jobs=1, picks=None, zero_mean=True, average=True,
                output='power', verbose=None):
     """Compute Time-Frequency Representation (TFR) using Morlet wavelets.
+    
+    Same computation as `~mne.time_frequency.tfr_array_morlet`, but
+    operates on `~mne.Epochs` objects instead of
+    :class:`NumPy arrays <numpy.ndarray>`.
 
     Parameters
     ----------
@@ -722,7 +726,7 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False, return_itc=True, decim=1,
 def tfr_array_morlet(epoch_data, sfreq, freqs, n_cycles=7.0,
                      zero_mean=False, use_fft=True, decim=1, output='complex',
                      n_jobs=1, verbose=None):
-    """Compute time-frequency transform using Morlet wavelets.
+    """Compute Time-Frequency Representation (TFR) using Morlet wavelets.
 
     Same computation as `~mne.time_frequency.tfr_morlet`, but operates on
     :class:`NumPy arrays <numpy.ndarray>` instead of `~mne.Epochs` objects.

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -659,7 +659,7 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False, return_itc=True, decim=1,
                n_jobs=1, picks=None, zero_mean=True, average=True,
                output='power', verbose=None):
     """Compute Time-Frequency Representation (TFR) using Morlet wavelets.
-    
+
     Same computation as `~mne.time_frequency.tfr_array_morlet`, but
     operates on `~mne.Epochs` objects instead of
     :class:`NumPy arrays <numpy.ndarray>`.

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -283,10 +283,10 @@ def _compute_tfr(epoch_data, freqs, sfreq=1.0, method='morlet',
         Sampling frequency of the data.
     method : 'multitaper' | 'morlet', default 'morlet'
         The time-frequency method. 'morlet' convolves a Morlet wavelet.
-        'multitaper' uses Morlet wavelets windowed with multiple DPSS
+        'multitaper' uses complex exponentials windowed with multiple DPSS
         multitapers.
     n_cycles : float | array of float, default 7.0
-        Number of cycles  in the Morlet wavelet. Fixed number
+        Number of cycles  in the  wavelet. Fixed number
         or one per frequency.
     zero_mean : bool | None, default None
         None means True for method='multitaper' and False for method='morlet'.
@@ -723,8 +723,9 @@ def tfr_array_morlet(epoch_data, sfreq, freqs, n_cycles=7.0,
                      zero_mean=False, use_fft=True, decim=1, output='complex',
                      n_jobs=1, verbose=None):
     """Compute time-frequency transform using Morlet wavelets.
-
-    Convolves epoch data with selected Morlet wavelets.
+    Same computation as the function tfr_morlet.
+    Difference: tfr_morlet takes epochs in the mne.Epochs format as input.
+    This function, tfr_array_morlet, takes epochs in the numpy.array format as input.
 
     Parameters
     ----------
@@ -797,6 +798,10 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
                    use_fft=True, return_itc=True, decim=1,
                    n_jobs=1, picks=None, average=True, verbose=None):
     """Compute Time-Frequency Representation (TFR) using DPSS tapers.
+
+    Same computation as the function tfr_array_multitaper.
+    Difference: tfr_multitaper takes epochs in the mne.Epochs format as input;
+    tfr_array_multitaper takes epochs in the numpy.array format as input.
 
     Parameters
     ----------


### PR DESCRIPTION
#### Reference issue
Partly fixes #8215

#### What does this implement/fix?
Changed multitaper functions description which were wrongly
described as using Morlet wavelets

Also explained the connection between the functions:
tfr_multitaper vs tfr_array_multitaper
tfr_morlet vs tfr_array_morlet
tfr_stockwell vs tfr_array_stockwell
