### PR TITLE
FIX: Improve optimization of "auto" cHPI time window

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -47,6 +47,8 @@ Changelog
 
 - Add support for mixed source spaces to :func:`mne.compute_source_morph` by `Eric Larson`_
 
+- Add support for volume and mixed source spaces to :func:`mne.stats.summarize_clusters_stc` by `Eric Larson`_
+
 - Add support for omitting the SDR step in volumetric morphing by passing ``n_iter_sdr=()`` to `mne.compute_source_morph` by `Eric Larson`_
 
 - Add ``single_volume`` argument to :func:`mne.setup_volume_source_space` to facilitate creating source spaces with many volumes (e.g., all subvolumes of ``aseg.mgz``) by `Eric Larson`_
@@ -350,6 +352,8 @@ Bug
 - Fix bug with :meth:`mne.preprocessing.ICA.plot_properties` where a :class:`mne.io.Raw` object with annotations would lead to an error by `Yu-Han Luo`_
 
 - Fix bug with :func:`mne.events_from_annotations(raw.annotations) <mne.events_from_annotations>` when ``orig_time`` of annotations is None and ``raw.first_time > 0``, by `Alex Gramfort`_
+
+- Fix bug in :func:`mne.set_eeg_reference` and related functions to set ``info['custom_ref_applied']`` to ``True`` for 'ecog' and 'seeg' channels in addition to 'eeg' by `Liberty Hamilton`_
 
 - Fix bug with :func:`mne.chpi.compute_chpi_amplitudes` and :func:`mne.chpi.filter_chpi` to optimize time window length by `Steven Bierer`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -47,8 +47,6 @@ Changelog
 
 - Add support for mixed source spaces to :func:`mne.compute_source_morph` by `Eric Larson`_
 
-- Add support for volume and mixed source spaces to :func:`mne.stats.summarize_clusters_stc` by `Eric Larson`_
-
 - Add support for omitting the SDR step in volumetric morphing by passing ``n_iter_sdr=()`` to `mne.compute_source_morph` by `Eric Larson`_
 
 - Add ``single_volume`` argument to :func:`mne.setup_volume_source_space` to facilitate creating source spaces with many volumes (e.g., all subvolumes of ``aseg.mgz``) by `Eric Larson`_
@@ -353,7 +351,7 @@ Bug
 
 - Fix bug with :func:`mne.events_from_annotations(raw.annotations) <mne.events_from_annotations>` when ``orig_time`` of annotations is None and ``raw.first_time > 0``, by `Alex Gramfort`_
 
-- Fix bug in :func:`mne.set_eeg_reference` and related functions to set ``info['custom_ref_applied']`` to ``True`` for 'ecog' and 'seeg' channels in addition to 'eeg' by `Liberty Hamilton`_
+- Fix bug with :func:`mne.chpi.computer_chpi_amplitudes` and :func:`mne.chpi.filter_chpi` to optimize time window length by `Steven Bierer`_
 
 API
 ~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -351,7 +351,7 @@ Bug
 
 - Fix bug with :func:`mne.events_from_annotations(raw.annotations) <mne.events_from_annotations>` when ``orig_time`` of annotations is None and ``raw.first_time > 0``, by `Alex Gramfort`_
 
-- Fix bug with :func:`mne.chpi.computer_chpi_amplitudes` and :func:`mne.chpi.filter_chpi` to optimize time window length by `Steven Bierer`_
+- Fix bug with :func:`mne.chpi.compute_chpi_amplitudes` and :func:`mne.chpi.filter_chpi` to optimize time window length by `Steven Bierer`_
 
 API
 ~~~

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -321,3 +321,5 @@
 .. _Martin Schulz: https://github.com/marsipu
 
 .. _Jeroen Van Der Donckt: https://github.com/jvdd
+
+.. _Steven Bierer: https://github.com/neurolaunch

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -843,7 +843,7 @@ def compute_chpi_amplitudes(raw, t_step_min=0.01, t_window='auto',
           Ensures that neighboring frequencies can be disambiguated.
 
     The output is meant to be used with :func:`~mne.chpi.compute_chpi_locs`.
-    
+
     .. versionadded:: 0.20
     """
     hpi = _setup_hpi_amplitude_fitting(raw.info, t_window, ext_order=ext_order)
@@ -924,7 +924,7 @@ def compute_chpi_locs(info, chpi_amplitudes, t_step_max=1., too_close='raise',
     The number of fitted points ``n_pos`` will depend on the velocity of head
     movements as well as ``t_step_max`` (and ``t_step_min`` from
     :func:`mne.chpi.compute_chpi_amplitudes`).
-    
+
     .. versionadded:: 0.20
     """
     # Set up magnetic dipole fits

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -465,9 +465,7 @@ def _setup_hpi_amplitude_fitting(info, t_window, remove_aliased=False,
                            % (hpi_freqs[~keepers].tolist(), highest))
     # calculate optimal window length.
     if isinstance(t_window, str):
-        if t_window != 'auto':
-            raise ValueError('t_window must be "auto" if a string, got %r'
-                             % (t_window,))
+        _check_option('t_window', t_window, ('auto',), extra='if a string')
         if len(hpi_freqs):
             all_freqs = np.concatenate((hpi_freqs, line_freqs))
             delta_freqs = np.diff(np.unique(all_freqs))
@@ -837,8 +835,15 @@ def compute_chpi_amplitudes(raw, t_step_min=0.01, t_window='auto',
        sinusoidal amplitudes to MEG channels.
        It uses SVD to determine the phase/amplitude of the sinusoids.
 
-    The output is meant to be used with :func:`~mne.chpi.compute_chpi_locs`.
+    In "auto" mode, ``t_window`` will be set to the longer of:
 
+    1. Five cycles of the lowest HPI or line frequency.
+          Ensures that the frequency estimate is stable.
+    2. The reciprocal of the smallest difference between HPI and line freqs.
+          Ensures that neighboring frequencies can be disambiguated.
+
+    The output is meant to be used with :func:`~mne.chpi.compute_chpi_locs`.
+    
     .. versionadded:: 0.20
     """
     hpi = _setup_hpi_amplitude_fitting(raw.info, t_window, ext_order=ext_order)
@@ -919,14 +924,7 @@ def compute_chpi_locs(info, chpi_amplitudes, t_step_max=1., too_close='raise',
     The number of fitted points ``n_pos`` will depend on the velocity of head
     movements as well as ``t_step_max`` (and ``t_step_min`` from
     :func:`mne.chpi.compute_chpi_amplitudes`).
-
-    In "auto" mode, ``t_window`` will be set to the longer of:
-
-    1. Five cycles of the lowest HPI frequency.
-          Ensures that the frequency estimate is stable.
-    2. The reciprocal of the smallest difference between HPI frequencies.
-          Ensures that neighboring frequencies can be disambiguated.
-
+    
     .. versionadded:: 0.20
     """
     # Set up magnetic dipole fits

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -222,6 +222,11 @@ def test_calculate_chpi_positions_vv():
     mf_quats = read_head_pos(pos_fname)
     raw = read_raw_fif(chpi_fif_fname, allow_maxshield='yes')
     raw.crop(0, 5).load_data()
+    # check "auto" t_window estimation at full sampling rate
+    with catch_logging() as log:
+        compute_chpi_amplitudes(raw, t_step_min=0.1, t_window='auto',
+                                tmin=0, tmax=2, verbose=True)
+    assert '83.3 ms' in log.getvalue()
     # This is a little hack (aliasing while decimating) to make it much faster
     # for testing purposes only. We can relax this later if we find it breaks
     # something.
@@ -234,7 +239,6 @@ def test_calculate_chpi_positions_vv():
     assert '\nHPIFIT' in log
     assert 'Computing 4385 HPI location guesses' in log
     _assert_quats(py_quats, mf_quats, dist_tol=0.001, angle_tol=0.7)
-
     # degenerate conditions
     raw_no_chpi = read_raw_fif(sample_fname)
     with pytest.raises(RuntimeError, match='cHPI information not found'):


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
Optimizes window length for cHPI amplitude estimation by accounting for the line frequency and its harmonics. The change primarily helps separate higher HPI coil frequencies from nearby line harmonics, but it should also improve robustness for more standard HPI frequencies (e.g. 83 Hz).

