### PR TITLE
MRG: Remove unused code

### DIFF
--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -154,15 +154,6 @@ class RawNIRX(BaseRaw):
                                                            ['S-D-Key'])],
                                int)
 
-        # Determine if short channels are present and on which detectors
-        if 'shortbundles' in hdr['ImagingParameters']:
-            short_det = [int(s) for s in
-                         re.findall(r'(\d+)',
-                                    hdr['ImagingParameters']['ShortDetIndex'])]
-            short_det = np.array(short_det, int)
-        else:
-            short_det = []
-
         # Extract sampling rate
         samplingrate = float(hdr['ImagingParameters']['SamplingRate'])
 


### PR DESCRIPTION
#### Reference issue
in #8066 I removed a hack for calculating the position of short channels (where the source and detector are very close together). I left in some code that is doing nothing. Specific lines are [here](https://github.com/mne-tools/mne-python/pull/8066/files#diff-7c077bb43fb6aa0bdda5f6c0cdd99863L255-L257)


#### What does this implement/fix?
Removes unused code


#### Additional information
I am surprised linting didnt pick this up, I will be more cautious in the future.
