### PR TITLE
MRG, BUG: Fix topomap plotting

### DIFF
--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -21,7 +21,7 @@ from ..io.pick import pick_types, _picks_to_idx
 from ..io.constants import FIFF
 from ..io.meas_info import Info
 from ..utils import (_clean_names, warn, _check_ch_locs, fill_doc,
-                     _check_option, _check_sphere)
+                     _check_option, _check_sphere, logger)
 from .channels import _get_ch_info
 
 
@@ -657,6 +657,7 @@ def _auto_topomap_coords(info, picks, ignore_overlap, to_sphere, sphere):
     """
     from scipy.spatial.distance import pdist, squareform
     sphere = _check_sphere(sphere, info)
+    logger.debug(f'Generating coords using: {sphere}')
 
     picks = _picks_to_idx(info, picks, 'all', exclude=(), allow_empty=False)
     chs = [info['chs'][i] for i in picks]

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -20,6 +20,34 @@ logger = logging.getLogger('mne')  # one selection here used across mne-python
 logger.propagate = False  # don't propagate (in case of multiple imports)
 
 
+# class to provide frame information (should be low overhead, just on logger
+# calls)
+
+class _FrameFilter(logging.Filter):
+    def __init__(self):
+        self.add_frames = 0
+
+    def filter(self, record):
+        record.frame_info = 'Unknown'
+        if self.add_frames:
+            # 5 is the offset necessary to get out of here and the logging
+            # module, reversal is to put the oldest at the top
+            frame_info = _frame_info(5 + self.add_frames)[5:][::-1]
+            if len(frame_info):
+                frame_info[-1] = (frame_info[-1] + ' :').ljust(30)
+                if len(frame_info) > 1:
+                    frame_info[0] = '┌' + frame_info[0]
+                    frame_info[-1] = '└' + frame_info[-1]
+                for ii, info in enumerate(frame_info[1:-1], 1):
+                    frame_info[ii] = '├' + info
+                record.frame_info = '\n'.join(frame_info)
+        return True
+
+
+_filter = _FrameFilter()
+logger.addFilter(_filter)
+
+
 def verbose(function):
     """Verbose decorator to allow functions to override log-level.
 
@@ -105,19 +133,24 @@ class use_log_level(object):
     ----------
     level : int
         The level to use.
+    add_frames : int | None
+        Number of stack frames to include.
     """
 
-    def __init__(self, level):  # noqa: D102
+    def __init__(self, level, add_frames=None):  # noqa: D102
         self.level = level
+        self.add_frames = add_frames
+        self.old_frames = _filter.add_frames
 
     def __enter__(self):  # noqa: D105
-        self.old_level = set_log_level(self.level, True)
+        self.old_level = set_log_level(self.level, True, self.add_frames)
 
     def __exit__(self, *args):  # noqa: D105
-        set_log_level(self.old_level)
+        add_frames = self.old_frames if self.add_frames is not None else None
+        set_log_level(self.old_level, add_frames=add_frames)
 
 
-def set_log_level(verbose=None, return_old_level=False):
+def set_log_level(verbose=None, return_old_level=False, add_frames=None):
     """Set the logging level.
 
     Parameters
@@ -131,6 +164,10 @@ def set_log_level(verbose=None, return_old_level=False):
         it doesn't exist, defaults to INFO.
     return_old_level : bool
         If True, return the old verbosity level.
+    add_frames : int | None
+        If int, enable (>=1) or disable (0) the printing of stack frame
+        information using formatting. Default (None) does not change the
+        formatting. This can add overhead so is meant only for debugging.
 
     Returns
     -------
@@ -153,10 +190,16 @@ def set_log_level(verbose=None, return_old_level=False):
                              CRITICAL=logging.CRITICAL)
         _check_option('verbose', verbose, logging_types, '(when a string)')
         verbose = logging_types[verbose]
-    logger = logging.getLogger('mne')
     old_verbose = logger.level
     if verbose != old_verbose:
         logger.setLevel(verbose)
+    if add_frames is not None:
+        _filter.add_frames = int(add_frames)
+        fmt = '%(frame_info)s ' if add_frames else ''
+        fmt += '%(message)s'
+        fmt = logging.Formatter(fmt)
+        for handler in logger.handlers:
+            handler.setFormatter(fmt)
     return (old_verbose if return_old_level else None)
 
 
@@ -180,7 +223,6 @@ def set_log_file(fname=None, output_format='%(message)s', overwrite=None):
         but additionally raises a warning to notify the user that log
         entries will be appended.
     """
-    logger = logging.getLogger('mne')
     _remove_close_handlers(logger)
     if fname is not None:
         if op.isfile(fname) and overwrite is None:
@@ -412,3 +454,25 @@ def wrapped_stdout(indent='', cull_newlines=False):
             for _ in range(pending_newlines):
                 logger.info('\n')
             logger.info(indent + line)
+
+
+def _frame_info(n):
+    frame = inspect.currentframe()
+    try:
+        frame = frame.f_back
+        infos = list()
+        for _ in range(n):
+            try:
+                name = frame.f_globals['__name__']
+            except KeyError:  # in our verbose dec
+                pass
+            else:
+                infos.append(f'{name.lstrip("mne.")}:{frame.f_lineno}')
+            frame = frame.f_back
+            if frame is None:
+                break
+        return infos
+    except Exception:
+        return ['unknown']
+    finally:
+        del frame

--- a/mne/utils/tests/test_logging.py
+++ b/mne/utils/tests/test_logging.py
@@ -1,17 +1,45 @@
 import os
 import os.path as op
+import re
 import warnings
 
 import pytest
 
 from mne import read_evokeds
 from mne.utils import (warn, set_log_level, set_log_file, filter_out_warnings,
-                       verbose, _get_call_line, use_log_level, catch_logging)
+                       verbose, _get_call_line, use_log_level, catch_logging,
+                       logger)
+from mne.utils._logging import _frame_info
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 fname_evoked = op.join(base_dir, 'test-ave.fif')
 fname_log = op.join(base_dir, 'test-ave.log')
 fname_log_2 = op.join(base_dir, 'test-ave-2.log')
+
+
+@verbose
+def _fun(verbose=None):
+    logger.debug('Test')
+
+
+def test_frame_info(capsys, monkeypatch):
+    """Test _frame_info."""
+    stack = _frame_info(100)
+    assert 2 < len(stack) < 100
+    this, pytest_line = stack[:2]
+    assert re.match('^test_logging:[1-9][0-9]$', this) is not None, this
+    assert 'pytest' in pytest_line
+    capsys.readouterr()
+    with use_log_level('debug', add_frames=4):
+        _fun()
+    out, _ = capsys.readouterr()
+    out = out.replace('\n', ' ')
+    assert re.match(
+        '.*pytest'
+        '.*test_logging:[2-9][0-9] '
+        '.*test_logging:[1-9][0-9] :.*Test', out) is not None, this
+    monkeypatch.setattr('inspect.currentframe', lambda: None)
+    assert _frame_info(1) == ['unknown']
 
 
 def test_how_to_deal_with_warnings():

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -664,7 +664,10 @@ def _topomap_plot_sensors(pos_x, pos_y, sensors, ax):
 
 def _get_pos_outlines(info, picks, sphere, to_sphere=True):
     ch_type = _get_ch_type(pick_info(_simplify_info(info), picks), None)
+    orig_sphere = sphere
     sphere, clip_origin = _adjust_meg_sphere(sphere, info, ch_type)
+    logger.debug('Generating pos outlines with sphere '
+                 f'{sphere} from {orig_sphere} for {ch_type}')
     pos = _find_topomap_coords(
         info, picks, ignore_overlap=True, to_sphere=to_sphere,
         sphere=sphere)

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -3229,6 +3229,7 @@ def _plot_psd(inst, fig, freqs, psd_list, picks_list, titles_list,
         info = create_info([inst.ch_names[p] for p in picks],
                            inst.info['sfreq'], types)
         info['chs'] = [inst.info['chs'][p] for p in picks]
+        info['dev_head_t'] = inst.info['dev_head_t']
         valid_channel_types = [
             'mag', 'grad', 'eeg', 'csd', 'seeg', 'eog', 'ecg',
             'emg', 'dipole', 'gof', 'bio', 'ecog', 'hbo',


### PR DESCRIPTION
Adapted from https://github.com/mne-tools/mne-python/pull/8100#issuecomment-690088012:
```
import mne
raw = mne.io.read_raw_kit('010409_Motor_task_coregist-export_tiny.con')
raw.info['bads'] = ['MEG 099']
mne.set_log_level('debug', add_frames=5)
raw.plot_sensors()
raw.plot_psd()
```
Produces the same plots for both now:

![Screenshot from 2020-09-10 15-04-30](https://user-images.githubusercontent.com/2365790/92787265-f2000700-f376-11ea-9fce-e78e98ef4631.png)
![Screenshot from 2020-09-10 15-04-32](https://user-images.githubusercontent.com/2365790/92787277-f3c9ca80-f376-11ea-9d2b-27bee29ffbde.png)


We were missing a `dev_head_t`. I don't see an easy way for testing this since it's buried down in our PSD plotting code.

Also adds some nice debugging scaffolding allowing tracing of `logger` calls, the script above (because of the `add_frames=5') gives the output:

<details>

```
┌channels.channels:593
├viz.utils:1694
├viz.utils:1765
└viz.topomap:669 :              Generating pos outlines with sphere [0.00746787 0.01529428 0.         0.08327344] from [-0.00426583 -0.01838654  0.02782112  0.08327344] for mag
┌viz.utils:1694
├viz.utils:1765
├viz.topomap:671
├channels.layout:624
└channels.layout:660 :          Generating coords using: [0.00746787 0.01529428 0.         0.08327344]
┌viz.raw:643
├time_frequency.psd:247
└time_frequency.psd:145 :       Effective window size : 1.024 (s)
┌viz.raw:648
├viz.utils:3248
├viz.evoked:436
├viz.evoked:554
└viz.topomap:669 :              Generating pos outlines with sphere [0.00746787 0.01529428 0.         0.08327344] from [-0.00426583 -0.01838654  0.02782112  0.08327344] for mag
┌viz.evoked:436
├viz.evoked:554
├viz.topomap:671
├channels.layout:624
└channels.layout:660 :          Generating coords using: [0.00746787 0.01529428 0.         0.08327344]
```

</details>

This hopefully will save a bit of time iterating in the future.