### PR TITLE
FIX: Fix for PR #8238 _prepare_label_extraction

### DIFF
--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -2954,7 +2954,7 @@ def _prepare_label_extraction(stc, labels, src, mode, allow_empty, use_sparse):
                                  'from the source space, likely mismatch'
                                  % (n_missing, len(v), hemi))
     else:
-        vertno = src['vertno']
+        vertno = [s['vertno'] for s in src]
 
     nvert = [len(vn) for vn in vertno]
 


### PR DESCRIPTION
#### Reference issue
Fixes #8238.

#### What does this implement/fix?
Takes into account vertices from both hemispheres of source space object.

#### Additional information
Not included in tests yet (as discussed before with @larsoner).
