### PR TITLE
MAINT: Show test timings

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ omit =
     */setup.py
     */mne/fixes*
     */mne/utils/linalg.py
+    */mne/conftest.py
 
 [report]
 exclude_lines =

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -472,6 +472,7 @@ def download_is_error(monkeypatch):
 
 
 def pytest_sessionfinish(session, exitstatus):
+    """Handle the end of the session."""
     n = session.config.option.durations
     if n is None:
         return
@@ -486,7 +487,13 @@ def pytest_sessionfinish(session, exitstatus):
     res = pytest_harvest.get_session_synthesis_dct(session)
     files = dict()
     for key, val in res.items():
-        file_key = '/'.join(Path(key.split(':')[0]).parts[:-1])
+        parts = Path(key.split(':')[0]).parts
+        # split mne/tests/test_whatever.py into separate categories since these
+        # are essentially submodule-level tests. Keeping just [:3] works.
+        parts = parts[:3]
+        if not parts[-1].endswith('.py'):
+            parts = parts + ('',)
+        file_key = '/'.join(parts)
         files[file_key] = files.get(file_key, 0) + val['pytest_duration_s']
     files = sorted(list(files.items()), key=lambda x: x[1])[::-1]
     # print

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,7 +1,7 @@
 pytest!=4.6.0
 pytest-cov
 pytest-timeout
-https://github.com/larsoner/python-pytest-harvest/archive/doctest.zip
+git+https://github.com/larsoner/python-pytest-harvest@doctest
 flake8
 flake8-array-spacing
 https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,6 +1,7 @@
 pytest!=4.6.0
 pytest-cov
 pytest-timeout
+https://github.com/larsoner/python-pytest-harvest/archive/doctest.zip
 flake8
 flake8-array-spacing
 https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip


### PR DESCRIPTION
Hopefully should help diagnose recent [Travis timeouts](https://travis-ci.org/github/mne-tools/mne-python/jobs/726048452). For example locally:
```
$ pytest mne/utils/ mne/preprocessing/ mne/io/
...
=================================================================== slowest 20 test modules ====================================================================
74.66s total   mne/preprocessing/tests
37.59s total   mne/io/fieldtrip/tests
33.01s total   mne/io/fiff/tests
26.45s total   mne/io/eeglab/tests
12.42s total   mne/io/egi/tests
 7.85s total   mne/io/tests
 7.00s total   mne/io/edf/tests
 6.49s total   mne/io/bti/tests
 6.07s total   mne/io/ctf/tests
 3.04s total   mne/io/brainvision/tests
 2.82s total   mne/io/kit/tests
 2.77s total   mne/io/artemis123/tests
 1.86s total   mne/utils/tests
 0.92s total   mne/io/snirf/tests
 0.76s total   mne/io/nirx/tests
 0.65s total   mne/io/curry/tests
 0.61s total   mne/io/cnt/tests
 0.59s total   mne/io/eximia/tests
 0.48s total   mne/io/array/tests
 0.24s total   mne/io/persyst/tests
```
Ideally https://github.com/smarie/python-pytest-harvest/pull/41 will be merged and a new release made so we could just do `pytest-harvest` in the testing requirements, but this is probably good enough already (easy enough to update later).

Let's see if it works on the full test suite.