### PR TITLE
MRG, ENH: Add compute_native_head_t

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -81,7 +81,7 @@ Changelog
 
 - Add :meth:`mne.channels.DigMontage.rename_channels` to allow renaming montage channels by `Eric Larson`_
 
-- Add :meth:`mne.channels.DigMontage.compute_native_head_t` to allow computing the native-to-head transformation that will be applied when doing :meth:`raw.set_montage <mne.io.Raw.set_montage>` and related functions by `Eric Larson`_
+- Document :meth:`mne.channels.compute_native_head_t` to allow computing the native-to-head transformation that will be applied when doing :meth:`raw.set_montage <mne.io.Raw.set_montage>` and related functions by `Eric Larson`_
 
 - Add support to in :meth:`mne.io.Raw.plot` for passing ``clipping`` as a float to clip to a proportion of the dedicated channel range by `Eric Larson`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -81,6 +81,8 @@ Changelog
 
 - Add :meth:`mne.channels.DigMontage.rename_channels` to allow renaming montage channels by `Eric Larson`_
 
+- Add :meth:`mne.channels.DigMontage.compute_native_head_t` to allow computing the native-to-head transformation that will be applied when doing :meth:`raw.set_montage <mne.io.Raw.set_montage>` and related functions by `Eric Larson`_
+
 - Add support to in :meth:`mne.io.Raw.plot` for passing ``clipping`` as a float to clip to a proportion of the dedicated channel range by `Eric Larson`_
 
 - Add function :func:`mne.preprocessing.annotate_muscle_zscore` to annotate periods with muscle artifacts. by `Adonay Nunes`_

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -449,6 +449,7 @@ class Resetter(object):
         # turn it off here (otherwise the build can be very slow)
         plt.ioff()
         gc.collect()
+        plt.rcParams['animation.embed_limit'] = 30.
 
 
 def reset_warnings(gallery_conf, fname):

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -319,6 +319,7 @@ Projections:
 
    Layout
    DigMontage
+   compute_native_head_t
    fix_mag_coil_types
    read_polhemus_fastscan
    get_builtin_montages

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -998,9 +998,9 @@ def generate_2d_layout(xy, w=.07, h=.05, pad=.02, ch_names=None,
     xy : ndarray, shape (N, 2)
         The xy coordinates of sensor locations.
     w : float
-        The width of each sensor's axis (between 0 and 1)
+        The width of each sensor's axis (between 0 and 1).
     h : float
-        The height of each sensor's axis (between 0 and 1)
+        The height of each sensor's axis (between 0 and 1).
     pad : float
         Portion of the box to reserve for padding. The value can range between
         0.0 (boxes will touch, default) to 1.0 (boxes consist of only padding).

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -308,7 +308,7 @@ class DigMontage(object):
 
         Returns
         -------
-        tr : instance of Transformation
+        tr : instance of Transform
             The transformation. In the special case where the ``coord_frame``
             during montage init was ``'mri'``, this will be a :term:`trans`
             from the MRI to head coordinate frame.

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -303,22 +303,6 @@ class DigMontage(object):
 
         return dig_names
 
-    def compute_native_head_t(self):
-        """Compute the transformation to the head coordinate frame.
-
-        Returns
-        -------
-        tr : instance of Transform
-            The transformation. In the special case where the ``coord_frame``
-            during montage init was ``'mri'``, this will be a :term:`trans`
-            from the MRI to head coordinate frame.
-
-        Notes
-        -----
-        .. versionadded:: 0.21
-        """
-        return compute_native_head_t(self)
-
 
 VALID_SCALES = dict(mm=1e-3, cm=1e-2, m=1)
 

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -79,7 +79,7 @@ def make_dig_montage(ch_pos=None, nasion=None, lpa=None, rpa=None,
 
     Parameters
     ----------
-    ch_pos : dict
+    ch_pos : dict | None
         Dictionary of channel positions. Keys are channel names and values
         are 3D coordinates - array of shape (3,) - in native digitizer space
         in m.
@@ -116,6 +116,7 @@ def make_dig_montage(ch_pos=None, nasion=None, lpa=None, rpa=None,
     read_dig_fif
     read_dig_polhemus_isotrak
     """
+    _validate_type(ch_pos, (dict, None), 'ch_pos')
     if ch_pos is None:
         ch_names = None
     else:
@@ -301,6 +302,22 @@ class DigMontage(object):
             dig_names[dig_idx] = self.ch_names[ch_name_idx]
 
         return dig_names
+
+    def compute_native_head_t(self):
+        """Compute the transformation to the head coordinate frame.
+
+        Returns
+        -------
+        tr : instance of Transformation
+            The transformation. In the special case where the ``coord_frame``
+            during montage init was ``'mri'``, this will be a :term:`trans`
+            from the MRI to head coordinate frame.
+
+        Notes
+        -----
+        .. versionadded:: 0.21
+        """
+        return compute_native_head_t(self)
 
 
 VALID_SCALES = dict(mm=1e-3, cm=1e-2, m=1)
@@ -1161,7 +1178,7 @@ def compute_native_head_t(montage):
         A native-to-head transformation matrix.
     """
     # Get fiducial points and their coord_frame
-    fid_coords, coord_frame = _get_fid_coords(montage.dig)
+    fid_coords, coord_frame = _get_fid_coords(montage.dig, raise_error=False)
     if coord_frame is None:
         coord_frame = FIFF.FIFFV_COORD_UNKNOWN
     if coord_frame == FIFF.FIFFV_COORD_HEAD:

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -186,11 +186,12 @@ class DigMontage(object):
 
     @copy_function_doc_to_method_doc(plot_montage)
     def plot(self, scale_factor=20, show_names=True, kind='topomap', show=True,
-             sphere=None):
+             sphere=None, verbose=None):
         return plot_montage(self, scale_factor=scale_factor,
                             show_names=show_names, kind=kind, show=show,
                             sphere=sphere)
 
+    @fill_doc
     def rename_channels(self, mapping):
         """Rename the channels.
 
@@ -519,7 +520,6 @@ def read_dig_hpts(fname, unit='mm'):
         eeg    FP2  -31.9297  -70.6852  -57.4881
         eeg    F7  -6.1042  -68.2969   45.4939
         ...
-
     """
     from ._standard_montage_utils import _str_names, _str
     _scale = _check_unit_and_get_scaling(unit)
@@ -892,7 +892,7 @@ def read_dig_polhemus_isotrak(fname, ch_names=None, unit='m'):
         points otherwise.
     unit : 'm' | 'cm' | 'mm'
         Unit of the digitizer file. Polhemus ISOTrak systems data is usually
-        exported in meters. Defaults to 'm'
+        exported in meters. Defaults to 'm'.
 
     Returns
     -------
@@ -966,7 +966,7 @@ def read_polhemus_fastscan(fname, unit='mm'):
         The filepath of .txt Polhemus FastSCAN file.
     unit : 'm' | 'cm' | 'mm'
         Unit of the digitizer file. Polhemus FastSCAN systems data is usually
-        exported in millimeters. Defaults to 'mm'
+        exported in millimeters. Defaults to 'mm'.
 
     Returns
     -------
@@ -1029,6 +1029,11 @@ def read_custom_montage(fname, head_size=HEAD_SIZE_DEFAULT, coord_frame=None):
     montage : instance of DigMontage
         The montage.
 
+    See Also
+    --------
+    make_dig_montage
+    make_standard_montage
+
     Notes
     -----
     The function is a helper to read electrode positions you may have
@@ -1039,11 +1044,6 @@ def read_custom_montage(fname, head_size=HEAD_SIZE_DEFAULT, coord_frame=None):
     10/10 or 10/05) we recommend you use :func:`make_standard_montage`.
     If you can have positions in memory you can also use
     :func:`make_dig_montage` that takes arrays as input.
-
-    See Also
-    --------
-    make_dig_montage
-    make_standard_montage
     """
     from ._standard_montage_utils import (
         _read_theta_phi_in_degrees, _read_sfp, _read_csd, _read_elc,

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -25,7 +25,7 @@ from mne.channels import (get_builtin_montages, DigMontage, read_dig_dat,
                           read_dig_captrack,  # XXX: remove with 0.22
                           make_standard_montage, read_custom_montage,
                           compute_dev_head_t, make_dig_montage,
-                          read_dig_polhemus_isotrak,
+                          read_dig_polhemus_isotrak, compute_native_head_t,
                           read_polhemus_fastscan,
                           read_dig_hpts)
 from mne.channels.montage import transform_to_head, _check_get_coord_frame
@@ -109,7 +109,7 @@ def test_dig_montage_trans():
     ch_pos = {f'EEG{ii:3d}': pos for ii, pos in enumerate(ch_pos, 1)}
     montage = make_dig_montage(ch_pos, nasion=nasion, lpa=lpa, rpa=rpa,
                                coord_frame='mri')
-    trans = montage.compute_native_head_t()
+    trans = compute_native_head_t(montage)
     _ensure_trans(trans)
 
 
@@ -398,7 +398,7 @@ def test_montage_readers(
             assert isinstance(d1[key], int)
             assert isinstance(d2[key], int)
     with pytest.warns(None) as w:
-        xform = dig_montage.compute_native_head_t()
+        xform = compute_native_head_t(dig_montage)
     assert xform['to'] == FIFF.FIFFV_COORD_HEAD
     assert xform['from'] == FIFF.FIFFV_COORD_UNKNOWN
     n = int(np.allclose(xform['trans'], np.eye(4)))

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -35,7 +35,7 @@ from mne.io.constants import FIFF
 from mne.io._digitization import (_format_dig_points,
                                   _get_fid_coords, _get_dig_eeg,
                                   _count_points_by_type)
-
+from mne.transforms import _ensure_trans
 from mne.viz._3d import _fiducial_coords
 
 from mne.io.kit import read_mrk
@@ -101,6 +101,16 @@ def _make_toy_dig_montage(n_channels, **kwargs):
 
 def _get_dig_montage_pos(montage):
     return np.array([d['r'] for d in _get_dig_eeg(montage.dig)])
+
+
+def test_dig_montage_trans():
+    """Test getting a trans from montage."""
+    nasion, lpa, rpa, *ch_pos = np.random.RandomState(0).randn(10, 3)
+    ch_pos = {f'EEG{ii:3d}': pos for ii, pos in enumerate(ch_pos, 1)}
+    montage = make_dig_montage(ch_pos, nasion=nasion, lpa=lpa, rpa=rpa,
+                               coord_frame='mri')
+    trans = montage.compute_native_head_t()
+    _ensure_trans(trans)
 
 
 def test_fiducials():
@@ -387,6 +397,12 @@ def test_montage_readers(
         for key in ('coord_frame', 'ident', 'kind'):
             assert isinstance(d1[key], int)
             assert isinstance(d2[key], int)
+    with pytest.warns(None) as w:
+        xform = dig_montage.compute_native_head_t()
+    assert xform['to'] == FIFF.FIFFV_COORD_HEAD
+    assert xform['from'] == FIFF.FIFFV_COORD_UNKNOWN
+    n = int(np.allclose(xform['trans'], np.eye(4)))
+    assert len(w) == n
 
 
 @testing.requires_testing_data

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1236,7 +1236,8 @@ def get_mni_fiducials(subject, subjects_dir=None, verbose=None):
     Returns
     -------
     fids_mri : list
-        List of estimated fiducials (each point in a dict)
+        List of estimated fiducials (each point in a dict), in the order
+        LPA, nasion, RPA.
 
     Notes
     -----

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -275,7 +275,7 @@ def _get_data_as_dict_from_dig(dig):
     )
 
 
-def _get_fid_coords(dig):
+def _get_fid_coords(dig, raise_error=True):
     fid_coords = Bunch(nasion=None, lpa=None, rpa=None)
     fid_coord_frames = dict()
 
@@ -285,7 +285,7 @@ def _get_fid_coords(dig):
             fid_coords[key] = d['r']
             fid_coord_frames[key] = d['coord_frame']
 
-    if len(fid_coord_frames) > 0:
+    if len(fid_coord_frames) > 0 and raise_error:
         if set(fid_coord_frames.keys()) != set(['nasion', 'lpa', 'rpa']):
             raise ValueError("Some fiducial points are missing (got %s)." %
                              fid_coords.keys())

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -16,6 +16,7 @@ public_modules = [
     'mne',
     'mne.baseline',
     'mne.beamformer',
+    'mne.channels',
     'mne.chpi',
     'mne.connectivity',
     'mne.cov',

--- a/tutorials/misc/plot_ecog.py
+++ b/tutorials/misc/plot_ecog.py
@@ -62,7 +62,7 @@ print('Created %s channel positions' % len(ch_names))
 # data when applying the montage so that standard plotting functions like
 # :func:`mne.viz.plot_evoked_topomap` will be aligned properly.
 
-trans = montage.compute_native_head_t()
+trans = mne.channels.compute_native_head_t(montage)
 print(trans)
 
 ###############################################################################

--- a/tutorials/misc/plot_ecog.py
+++ b/tutorials/misc/plot_ecog.py
@@ -28,6 +28,8 @@ print(__doc__)
 # paths to mne datasets - sample ECoG and FreeSurfer subject
 misc_path = mne.datasets.misc.data_path()
 sample_path = mne.datasets.sample.data_path()
+subject = 'sample'
+subjects_dir = sample_path + '/subjects'
 
 ###############################################################################
 # Let's load some ECoG electrode locations and names, and turn them into
@@ -40,15 +42,28 @@ elec_df = pd.read_csv(misc_path + '/ecog/sample_ecog_electrodes.tsv',
 ch_names = elec_df['name'].tolist()
 ch_coords = elec_df[['x', 'y', 'z']].to_numpy(dtype=float)
 ch_pos = dict(zip(ch_names, ch_coords))
+# Ideally the nasion/LPA/RPA will also be present from the digitization, here
+# we use fiducials estimated from the subject's FreeSurfer MNI transformation:
+lpa, nasion, rpa = mne.coreg.get_mni_fiducials(
+    subject, subjects_dir=subjects_dir)
+lpa, nasion, rpa = lpa['r'], nasion['r'], rpa['r']
 
 ###############################################################################
 # Now we make a :class:`mne.channels.DigMontage` stating that the ECoG
-# contacts are in head coordinate system (although they are in MRI). This is
-# compensated below by the fact that we do not specify a trans file so the
-# Head<->MRI transform is the identity.
+# contacts are in the FreeSurfer surface RAS (i.e., MRI) coordinate system.
 
-montage = mne.channels.make_dig_montage(ch_pos, coord_frame='head')
+montage = mne.channels.make_dig_montage(
+    ch_pos, coord_frame='mri', nasion=nasion, lpa=lpa, rpa=rpa)
 print('Created %s channel positions' % len(ch_names))
+
+###############################################################################
+# Now we get the :term:`trans` that transforms from our MRI coordinate system
+# to the head coordinate frame. This transform will be applied to the
+# data when applying the montage so that standard plotting functions like
+# :func:`mne.viz.plot_evoked_topomap` will be aligned properly.
+
+trans = montage.compute_native_head_t()
+print(trans)
 
 ###############################################################################
 # Now that we have our montage, we can load in our corresponding
@@ -75,10 +90,9 @@ raw.set_montage(montage)
 # .. note:: These are not real electrodes for this subject, so they
 #           do not align to the cortical surface perfectly.
 
-subjects_dir = sample_path + '/subjects'
-fig = plot_alignment(raw.info, subject='sample', subjects_dir=subjects_dir,
-                     surfaces=['pial'])
-mne.viz.set_3d_view(fig, 200, 70)
+fig = plot_alignment(raw.info, subject=subject, subjects_dir=subjects_dir,
+                     surfaces=['pial'], trans=trans, coord_frame='mri')
+mne.viz.set_3d_view(fig, 200, 70, focalpoint=[0, -0.005, 0.03])
 
 xy, im = snapshot_brain_montage(fig, montage)
 


### PR DESCRIPTION
Alternative to #7709.
Closes #7709.

@adam2392 I think this is a better fix -- basically we expose a way to get the transformation that is applied when doing `raw.set_montage` so it  can be used later. This way, all of the coordinate frames (head and MRI) are correct according to our definitions, when possible.

@jeschj01 this simplifies a bit / shows you what I suggested that you do on gitter. Will be useful for #8190 and other ECoG/sEEG-related stuff.