### PR TITLE
maybe improve linkcheck?

### DIFF
--- a/doc/_includes/forward.rst
+++ b/doc/_includes/forward.rst
@@ -107,7 +107,7 @@ The coordinate systems related to MRI data are:
 **MNI Talairach coordinates**
 
     The definition of this coordinate system is discussed, e.g., in
-    http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach. This transformation
+    https://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach. This transformation
     is determined during the FreeSurfer reconstruction process. These
     coordinates are in MNI305 space.
 
@@ -125,7 +125,7 @@ The coordinate systems related to MRI data are:
     transformation, defined separately for negatice and positive MNI Talairach
     :math:`z` coordinates. These two transformations, denoted by :math:`T_-`
     and :math:`T_+` in :ref:`coordinate_system_figure`, are fixed as discussed in
-    http://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach (*Approach 2*).
+    https://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach (*Approach 2*).
 
 The different coordinate systems are related by coordinate transformations
 depicted in :ref:`coordinate_system_figure`. The arrows and coordinate

--- a/doc/install/mne_c.rst
+++ b/doc/install/mne_c.rst
@@ -189,7 +189,7 @@ If you encounter other errors installing MNE-C, please send a message to the
 .. _netpbm: http://netpbm.sourceforge.net/
 .. _MacPorts: https://www.macports.org/
 .. _Homebrew: https://brew.sh/
-.. _XCode developer tools: http://appstore.com/mac/apple/xcode
+.. _XCode developer tools: https://developer.apple.com/xcode/
 .. _xquartz: https://www.xquartz.org/
 .. _debian: https://packages.debian.org/jessie/amd64/libxp6/download
 .. _pkgs.org: https://pkgs.org/download/libxp6

--- a/doc/overview/faq.rst
+++ b/doc/overview/faq.rst
@@ -428,7 +428,7 @@ References
 
 .. _`the most current version`: https://github.com/mne-tools/mne-python/releases/latest
 .. _`minimal working example`: https://en.wikipedia.org/wiki/Minimal_Working_Example
-.. _mri_watershed: http://freesurfer.net/fswiki/mri_watershed
+.. _mri_watershed: https://freesurfer.net/fswiki/mri_watershed
 .. _mri_normalize: https://surfer.nmr.mgh.harvard.edu/fswiki/mri_normalize
 .. _freeview: https://surfer.nmr.mgh.harvard.edu/fswiki/FreeviewGuide/FreeviewIntroduction
 .. _`FreeSurfer listserv`: https://www.mail-archive.com/freesurfer@nmr.mgh.harvard.edu/

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -134,7 +134,7 @@ def compute_source_morph(src, subject_from=None, subject_to='fsaverage',
     subjects with the ``mris_left_right_register`` FreeSurfer command. The
     ``fsaverage_sym`` subject is included with FreeSurfer > 5.1 and can be
     obtained as described `here
-    <http://surfer.nmr.mgh.harvard.edu/fswiki/Xhemi>`_. For statistical
+    <https://surfer.nmr.mgh.harvard.edu/fswiki/Xhemi>`_. For statistical
     comparisons between hemispheres, use of the symmetric ``fsaverage_sym``
     model is recommended to minimize bias :footcite:`GreveEtAl2013`.
 


### PR DESCRIPTION
- updates a few URLs to explicitly use https
- changes xcode url, the old one was an appstore redirect that won't even load on non-macs
