### PR TITLE
MRG, ENH: Tweak vol plot defaults

### DIFF
--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -83,7 +83,8 @@ DEFAULTS = dict(
                       combine_xyz='fro', allow_fixed_depth=True),
     interpolation_method=dict(eeg='spline', meg='MNE', fnirs='nearest'),
     volume_options=dict(
-        alpha=None, resolution=1., surface_alpha=None, blending='mip'),
+        alpha=None, resolution=1., surface_alpha=None, blending='mip',
+        silhouette_alpha=None, silhouette_linewidth=2.),
 )
 
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1934,7 +1934,7 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
     @copy_function_doc_to_method_doc(plot_source_estimates)
     def plot_3d(self, subject=None, surface='white', hemi='both',
                 colormap='auto', time_label='auto', smoothing_steps=10,
-                transparent=True, alpha=0.2, time_viewer='auto',
+                transparent=True, alpha=0.1, time_viewer='auto',
                 subjects_dir=None,
                 figure=None, views='axial', colorbar=True, clim='auto',
                 cortex="classic", size=800, background="black",

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1304,11 +1304,16 @@ volume_options : float | dict | None
         Can be "mip" (default) for maximum intensity projection or
         "composite" for composite blending.
     - ``'alpha'`` : float | None
-        Alpha for the volumetric rendering. Uses 0.4 for vector source
+        Alpha for the volumetric rendering. Defaults are 0.4 for vector source
         estimates and 1.0 for scalar source estimates.
     - ``'surface_alpha'`` : float | None
-        Alpha for the surface enclosing the volume(s). None will use
+        Alpha for the surface enclosing the volume(s). None (default) will use
         half the volume alpha. Set to zero to avoid plotting the surface.
+    - ``'silhouette_alpha'`` : float | None
+        Alpha for a silhouette along the outside of the volume. None (default)
+        will use ``0.25 * surface_alpha``.
+    - ``'silhouette_linewidth'`` : float
+        The line width to use for the silhouette. Default is 2.
 
     A float input (default 1.) or None will be used for the ``'resolution'``
     entry.

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -733,11 +733,29 @@ class _Brain(object):
             actor_neg = None
         grid_mesh = self._data[hemi]['grid_mesh']
         if grid_mesh is not None:
+            import vtk
             _, prop = self._renderer.plotter.add_actor(
                 grid_mesh, reset_camera=False, name=None, culling=False,
                 pickable=False)
             prop.SetColor(*self._brain_color[:3])
             prop.SetOpacity(surface_alpha)
+            for ri, ci, v in self._iter_views('vol'):
+                self._renderer.subplot(ri, ci)
+                grid_silhouette = vtk.vtkPolyDataSilhouette()
+                grid_silhouette.SetInputData(grid_mesh.GetInput())
+                grid_silhouette.SetCamera(
+                    self._renderer.plotter.renderer.GetActiveCamera())
+                grid_silhouette.SetEnableFeatureAngle(0)
+                grid_silhouette_mapper = vtk.vtkPolyDataMapper()
+                grid_silhouette_mapper.SetInputConnection(
+                    grid_silhouette.GetOutputPort())
+                _, prop = self._renderer.plotter.add_actor(
+                    grid_silhouette_mapper, reset_camera=False, name=None,
+                    culling=False, pickable=False)
+                prop.SetColor(*self._brain_color[:3])
+                prop.SetOpacity(surface_alpha)
+                prop.SetLineWidth(1.)
+
         return actor_pos, actor_neg
 
     def add_label(self, label, color=None, alpha=1, scalar_thresh=None,

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -666,7 +666,10 @@ class _Brain(object):
             ['resolution', (None, 'numeric')],
             ['blending', (str,)],
             ['alpha', ('numeric', None)],
-            ['surface_alpha', (None, 'numeric')])
+            ['surface_alpha', (None, 'numeric')],
+            ['silhouette_alpha', (None, 'numeric')],
+            ['silhouette_linewidth', ('numeric',)],
+        )
         for key, types in allowed_types:
             _validate_type(volume_options[key], types,
                            f'volume_options[{repr(key)}]')
@@ -681,10 +684,14 @@ class _Brain(object):
         if alpha is None:
             alpha = 0.4 if self._data[hemi]['array'].ndim == 3 else 1.
         alpha = np.clip(float(alpha), 0., 1.)
-        surface_alpha = volume_options['surface_alpha']
         resolution = volume_options['resolution']
+        surface_alpha = volume_options['surface_alpha']
         if surface_alpha is None:
             surface_alpha = min(alpha / 2., 0.1)
+        silhouette_alpha = volume_options['silhouette_alpha']
+        if silhouette_alpha is None:
+            silhouette_alpha = surface_alpha / 4.
+        silhouette_linewidth = volume_options['silhouette_linewidth']
         del volume_options
         volume_pos = self._data[hemi].get('grid_volume_pos')
         volume_neg = self._data[hemi].get('grid_volume_neg')
@@ -739,22 +746,23 @@ class _Brain(object):
                 pickable=False)
             prop.SetColor(*self._brain_color[:3])
             prop.SetOpacity(surface_alpha)
-            for ri, ci, v in self._iter_views('vol'):
-                self._renderer.subplot(ri, ci)
-                grid_silhouette = vtk.vtkPolyDataSilhouette()
-                grid_silhouette.SetInputData(grid_mesh.GetInput())
-                grid_silhouette.SetCamera(
-                    self._renderer.plotter.renderer.GetActiveCamera())
-                grid_silhouette.SetEnableFeatureAngle(0)
-                grid_silhouette_mapper = vtk.vtkPolyDataMapper()
-                grid_silhouette_mapper.SetInputConnection(
-                    grid_silhouette.GetOutputPort())
-                _, prop = self._renderer.plotter.add_actor(
-                    grid_silhouette_mapper, reset_camera=False, name=None,
-                    culling=False, pickable=False)
-                prop.SetColor(*self._brain_color[:3])
-                prop.SetOpacity(surface_alpha)
-                prop.SetLineWidth(1.)
+            if silhouette_alpha > 0 and silhouette_linewidth > 0:
+                for ri, ci, v in self._iter_views('vol'):
+                    self._renderer.subplot(ri, ci)
+                    grid_silhouette = vtk.vtkPolyDataSilhouette()
+                    grid_silhouette.SetInputData(grid_mesh.GetInput())
+                    grid_silhouette.SetCamera(
+                        self._renderer.plotter.renderer.GetActiveCamera())
+                    grid_silhouette.SetEnableFeatureAngle(0)
+                    grid_silhouette_mapper = vtk.vtkPolyDataMapper()
+                    grid_silhouette_mapper.SetInputConnection(
+                        grid_silhouette.GetOutputPort())
+                    _, prop = self._renderer.plotter.add_actor(
+                        grid_silhouette_mapper, reset_camera=False, name=None,
+                        culling=False, pickable=False)
+                    prop.SetColor(*self._brain_color[:3])
+                    prop.SetOpacity(silhouette_alpha)
+                    prop.SetLineWidth(silhouette_linewidth)
 
         return actor_pos, actor_neg
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -684,7 +684,7 @@ class _Brain(object):
         surface_alpha = volume_options['surface_alpha']
         resolution = volume_options['resolution']
         if surface_alpha is None:
-            surface_alpha = min(alpha / 2., 0.4)
+            surface_alpha = min(alpha / 2., 0.1)
         del volume_options
         volume_pos = self._data[hemi].get('grid_volume_pos')
         volume_neg = self._data[hemi].get('grid_volume_neg')

--- a/mne/viz/_brain/view.py
+++ b/mne/viz/_brain/view.py
@@ -19,8 +19,7 @@ _lh_views_dict = {
     'parietal': dict(azimuth=-120., elevation=60., focalpoint=ORIGIN),
     'sagittal': dict(azimuth=180., elevation=-90., focalpoint=ORIGIN),
     'coronal': dict(azimuth=90., elevation=-90., focalpoint=ORIGIN),
-    'axial': dict(azimuth=180., elevation=0., focalpoint=ORIGIN,
-                  roll=180),
+    'axial': dict(azimuth=180., elevation=0., focalpoint=ORIGIN, roll=0),
 }
 _rh_views_dict = {
     'lateral': dict(azimuth=180., elevation=-90., focalpoint=ORIGIN),
@@ -33,8 +32,7 @@ _rh_views_dict = {
     'parietal': dict(azimuth=-60., elevation=60., focalpoint=ORIGIN),
     'sagittal': dict(azimuth=180., elevation=-90., focalpoint=ORIGIN),
     'coronal': dict(azimuth=90., elevation=-90., focalpoint=ORIGIN),
-    'axial': dict(azimuth=180., elevation=0., focalpoint=ORIGIN,
-                  roll=180),
+    'axial': dict(azimuth=180., elevation=0., focalpoint=ORIGIN, roll=0),
 }
 # add short-size version entries into the dict
 lh_views_dict = _lh_views_dict.copy()

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -1029,8 +1029,8 @@ def _volume(dimensions, origin, spacing, scalars,
         mapper.SetScalarModeToUseCellData()
         mapper.SetInputDataObject(grid)
     else:
-        upsampler = vtk.vtkImageResample()
-        upsampler.SetInterpolationModeToNearestNeighbor()
+        upsampler = vtk.vtkImageReslice()
+        upsampler.SetInterpolationModeToLinear()  # default anyway
         upsampler.SetOutputSpacing(*([resolution] * 3))
         upsampler.SetInputConnection(grid_alg.GetOutputPort())
         mapper.SetInputConnection(upsampler.GetOutputPort())

--- a/tutorials/source-modeling/plot_beamformer_lcmv.py
+++ b/tutorials/source-modeling/plot_beamformer_lcmv.py
@@ -3,8 +3,7 @@ Source reconstruction using an LCMV beamformer
 ==============================================
 
 This tutorial gives an overview of the beamformer method
-and shows how to use an LCMV beamformer to reconstruct source
-activity.
+and shows how to use an LCMV beamformer to reconstruct source activity.
 
 .. contents:: Page contents
    :local:


### PR DESCRIPTION
1. Change some defaults so that colors are more visible/true
2. Change one class so that setting the interpolation mode actually has an effect (for `vtkImageResample`, setting to nearest neighbor for example did nothing, now it does)
3. Change `roll` param for `axial` view to correct it

`master:`

![master](https://user-images.githubusercontent.com/2365790/92962802-8635a100-f43f-11ea-9392-0389e379fa2a.png)

PR:

![PR](https://user-images.githubusercontent.com/2365790/92962822-8df54580-f43f-11ea-80b4-2b91eb96cb40.png)

EDIT: Updated with silhouette:

![](https://user-images.githubusercontent.com/2365790/93019060-a03bc480-f5a2-11ea-9167-c929f1f3f1be.png)
