### PR TITLE
Reduce pyvista viz test time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,8 +127,8 @@ script:
         pip install -e .;
         python mne/tests/test_evoked.py;
       fi;
-    - echo 'pytest -m "${CONDITION}" --tb=short --cov=mne -vv ${USE_DIRS}'
-    - pytest -m "${CONDITION}" --tb=short --cov=mne -vv ${USE_DIRS}
+    - echo 'pytest -m "${CONDITION}" --tb=short --cov=mne -vv mne/viz'
+    - pytest -m "${CONDITION}" --tb=short --cov=mne -vv mne/viz
     # run the minimal one with the testing data
     - if [ "${DEPS}" == "minimal" ]; then
         export MNE_SKIP_TESTING_DATASET_TESTS=false;

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,8 +127,8 @@ script:
         pip install -e .;
         python mne/tests/test_evoked.py;
       fi;
-    - echo 'pytest -m "${CONDITION}" --tb=short --cov=mne -vv mne/viz'
-    - pytest -m "${CONDITION}" --tb=short --cov=mne -vv mne/viz
+    - echo 'pytest -m "${CONDITION}" --tb=short --cov=mne -vv ${USE_DIRS}'
+    - pytest -m "${CONDITION}" --tb=short --cov=mne -vv ${USE_DIRS}
     # run the minimal one with the testing data
     - if [ "${DEPS}" == "minimal" ]; then
         export MNE_SKIP_TESTING_DATASET_TESTS=false;

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -15,6 +15,7 @@ from ...utils import logger, verbose, get_config, _check_option
 
 MNE_3D_BACKEND = None
 MNE_3D_BACKEND_TESTING = False
+MNE_3D_BACKEND_INTERACTIVE = False
 
 
 _backend_name_map = dict(


### PR DESCRIPTION
This PR aims at reducing the time used by PyVista 3d viz tests. This is still a work in progress.

Try:

- [x] Returning an "unmapped" actor 
- [x]  `actor.SetVisibility(False)`

Closes https://github.com/mne-tools/mne-python/issues/8242