### PR TITLE
MRG, MAINT: Move tests

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -489,8 +489,9 @@ def pytest_sessionfinish(session, exitstatus):
     for key, val in res.items():
         parts = Path(key.split(':')[0]).parts
         # split mne/tests/test_whatever.py into separate categories since these
-        # are essentially submodule-level tests. Keeping just [:3] works.
-        parts = parts[:3]
+        # are essentially submodule-level tests. Keeping just [:3] works,
+        # except for mne/viz where we want level-4 granulatity
+        parts = parts[:4 if parts[:2] == ('mne', 'viz') else 3]
         if not parts[-1].endswith('.py'):
             parts = parts + ('',)
         file_key = '/'.join(parts)

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -20,10 +20,9 @@ from matplotlib.colors import Colormap
 
 from mne import (make_field_map, pick_channels_evoked, read_evokeds,
                  read_trans, read_dipole, SourceEstimate,
-                 VolSourceEstimate, make_sphere_model, use_coil_def,
+                 make_sphere_model, use_coil_def,
                  setup_volume_source_space, read_forward_solution,
-                 VolVectorSourceEstimate, convert_forward_solution,
-                 compute_source_morph, MixedSourceEstimate)
+                 convert_forward_solution, MixedSourceEstimate)
 from mne.source_estimate import _BaseVolSourceEstimate
 from mne.io import (read_raw_ctf, read_raw_bti, read_raw_kit, read_info,
                     read_raw_nirx)
@@ -32,14 +31,12 @@ from mne.io.pick import pick_info
 from mne.io.constants import FIFF
 from mne.viz import (plot_sparse_source_estimates, plot_source_estimates,
                      snapshot_brain_montage, plot_head_positions,
-                     plot_alignment, plot_volume_source_estimates,
-                     plot_sensors_connectivity, plot_brain_colorbar,
-                     link_brains, mne_analyze_colormap)
+                     plot_alignment, plot_sensors_connectivity,
+                     plot_brain_colorbar, link_brains, mne_analyze_colormap)
 from mne.viz._3d import _process_clim, _linearize_map, _get_map_ticks
 from mne.viz.utils import _fake_click
 from mne.utils import (requires_pysurfer, run_tests_if_main,
-                       requires_nibabel, requires_dipy,
-                       traits_test, requires_version, catch_logging,
+                       requires_nibabel, traits_test, catch_logging,
                        run_subprocess, modified_env)
 from mne.datasets import testing
 from mne.source_space import read_source_spaces
@@ -599,95 +596,6 @@ def test_snapshot_brain_montage(renderer):
 
     # Make sure we raise error if the figure has no scene
     pytest.raises(ValueError, snapshot_brain_montage, None, info)
-
-
-@pytest.mark.slowtest  # can be slow on OSX
-@testing.requires_testing_data
-@requires_dipy()
-@requires_nibabel()
-@requires_version('nilearn', '0.4')
-@pytest.mark.parametrize(
-    'mode, stype, init_t, want_t, init_p, want_p, bg_img', [
-        ('glass_brain', 's', None, 2, None, (-30.9, 18.4, 56.7), None),
-        ('stat_map', 'vec', 1, 1, None, (15.7, 16.0, -6.3), None),
-        ('glass_brain', 'vec', None, 1, (10, -10, 20), (6.6, -9., 19.9), None),
-        ('stat_map', 's', 1, 1, (-10, 5, 10), (-12.3, 2.0, 7.7), 'brain.mgz')])
-def test_plot_volume_source_estimates(mode, stype, init_t, want_t,
-                                      init_p, want_p, bg_img):
-    """Test interactive plotting of volume source estimates."""
-    forward = read_forward_solution(fwd_fname)
-    sample_src = forward['src']
-    if init_p is not None:
-        init_p = np.array(init_p) / 1000.
-
-    vertices = [s['vertno'] for s in sample_src]
-    n_verts = sum(len(v) for v in vertices)
-    n_time = 2
-    data = np.random.RandomState(0).rand(n_verts, n_time)
-
-    if stype == 'vec':
-        stc = VolVectorSourceEstimate(
-            np.tile(data[:, np.newaxis], (1, 3, 1)), vertices, 1, 1)
-    else:
-        assert stype == 's'
-        stc = VolSourceEstimate(data, vertices, 1, 1)
-    with pytest.warns(None):  # sometimes get scalars/index warning
-        with catch_logging() as log:
-            fig = stc.plot(
-                sample_src, subject='sample', subjects_dir=subjects_dir,
-                mode=mode, initial_time=init_t, initial_pos=init_p,
-                bg_img=bg_img, verbose=True)
-    log = log.getvalue()
-    want_str = 't = %0.3f s' % want_t
-    assert want_str in log, (want_str, init_t)
-    want_str = '(%0.1f, %0.1f, %0.1f) mm' % want_p
-    assert want_str in log, (want_str, init_p)
-    for ax_idx in [0, 2, 3, 4]:
-        _fake_click(fig, fig.axes[ax_idx], (0.3, 0.5))
-    fig.canvas.key_press_event('left')
-    fig.canvas.key_press_event('shift+right')
-    if bg_img is not None:
-        with pytest.raises(FileNotFoundError, match='MRI file .* not found'):
-            stc.plot(sample_src, subject='sample', subjects_dir=subjects_dir,
-                     mode='stat_map', bg_img='junk.mgz')
-
-
-@pytest.mark.slowtest  # can be slow on OSX
-@testing.requires_testing_data
-@requires_dipy()
-@requires_nibabel()
-@requires_version('nilearn', '0.4')
-def test_plot_volume_source_estimates_morph():
-    """Test interactive plotting of volume source estimates with morph."""
-    forward = read_forward_solution(fwd_fname)
-    sample_src = forward['src']
-    vertices = [s['vertno'] for s in sample_src]
-    n_verts = sum(len(v) for v in vertices)
-    n_time = 2
-    data = np.random.RandomState(0).rand(n_verts, n_time)
-    stc = VolSourceEstimate(data, vertices, 1, 1)
-    sample_src[0]['subject_his_id'] = 'sample'  # old src
-    morph = compute_source_morph(sample_src, 'sample', 'fsaverage', zooms=5,
-                                 subjects_dir=subjects_dir)
-    initial_pos = (-0.05, -0.01, -0.006)
-    with pytest.warns(None):  # sometimes get scalars/index warning
-        with catch_logging() as log:
-            stc.plot(morph, subjects_dir=subjects_dir, mode='glass_brain',
-                     initial_pos=initial_pos, verbose=True)
-    log = log.getvalue()
-    assert 't = 1.000 s' in log
-    assert '(-52.0, -8.0, -7.0) mm' in log
-
-    with pytest.raises(ValueError, match='Allowed values are'):
-        stc.plot(sample_src, 'sample', subjects_dir, mode='abcd')
-    vertices.append([])
-    surface_stc = SourceEstimate(data, vertices, 1, 1)
-    with pytest.raises(TypeError, match='an instance of VolSourceEstimate'):
-        plot_volume_source_estimates(surface_stc, sample_src, 'sample',
-                                     subjects_dir)
-    with pytest.raises(ValueError, match='Negative colormap limits'):
-        stc.plot(sample_src, 'sample', subjects_dir,
-                 clim=dict(lims=[-1, 2, 3], kind='value'))
 
 
 @pytest.mark.slowtest  # can be slow on OSX

--- a/mne/viz/tests/test_3d_mpl.py
+++ b/mne/viz/tests/test_3d_mpl.py
@@ -1,0 +1,115 @@
+# Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
+#          Denis Engemann <denis.engemann@gmail.com>
+#          Martin Luessi <mluessi@nmr.mgh.harvard.edu>
+#          Eric Larson <larson.eric.d@gmail.com>
+#          Mainak Jas <mainak@neuro.hut.fi>
+#          Mark Wronkiewicz <wronk.mark@gmail.com>
+#
+# License: Simplified BSD
+
+import os.path as op
+
+import numpy as np
+import pytest
+
+from mne import (read_forward_solution, VolSourceEstimate, SourceEstimate,
+                 VolVectorSourceEstimate, compute_source_morph)
+from mne.datasets import testing
+from mne.utils import (requires_dipy, requires_nibabel, requires_version,
+                       catch_logging)
+from mne.viz import plot_volume_source_estimates
+from mne.viz.utils import _fake_click
+
+data_dir = testing.data_path(download=False)
+subjects_dir = op.join(data_dir, 'subjects')
+fwd_fname = op.join(data_dir, 'MEG', 'sample',
+                    'sample_audvis_trunc-meg-vol-7-fwd.fif')
+
+
+@pytest.mark.slowtest  # can be slow on OSX
+@testing.requires_testing_data
+@requires_dipy()
+@requires_nibabel()
+@requires_version('nilearn', '0.4')
+@pytest.mark.parametrize(
+    'mode, stype, init_t, want_t, init_p, want_p, bg_img', [
+        ('glass_brain', 's', None, 2, None, (-30.9, 18.4, 56.7), None),
+        ('stat_map', 'vec', 1, 1, None, (15.7, 16.0, -6.3), None),
+        ('glass_brain', 'vec', None, 1, (10, -10, 20), (6.6, -9., 19.9), None),
+        ('stat_map', 's', 1, 1, (-10, 5, 10), (-12.3, 2.0, 7.7), 'brain.mgz')])
+def test_plot_volume_source_estimates(mode, stype, init_t, want_t,
+                                      init_p, want_p, bg_img):
+    """Test interactive plotting of volume source estimates."""
+    forward = read_forward_solution(fwd_fname)
+    sample_src = forward['src']
+    if init_p is not None:
+        init_p = np.array(init_p) / 1000.
+
+    vertices = [s['vertno'] for s in sample_src]
+    n_verts = sum(len(v) for v in vertices)
+    n_time = 2
+    data = np.random.RandomState(0).rand(n_verts, n_time)
+
+    if stype == 'vec':
+        stc = VolVectorSourceEstimate(
+            np.tile(data[:, np.newaxis], (1, 3, 1)), vertices, 1, 1)
+    else:
+        assert stype == 's'
+        stc = VolSourceEstimate(data, vertices, 1, 1)
+    with pytest.warns(None):  # sometimes get scalars/index warning
+        with catch_logging() as log:
+            fig = stc.plot(
+                sample_src, subject='sample', subjects_dir=subjects_dir,
+                mode=mode, initial_time=init_t, initial_pos=init_p,
+                bg_img=bg_img, verbose=True)
+    log = log.getvalue()
+    want_str = 't = %0.3f s' % want_t
+    assert want_str in log, (want_str, init_t)
+    want_str = '(%0.1f, %0.1f, %0.1f) mm' % want_p
+    assert want_str in log, (want_str, init_p)
+    for ax_idx in [0, 2, 3, 4]:
+        _fake_click(fig, fig.axes[ax_idx], (0.3, 0.5))
+    fig.canvas.key_press_event('left')
+    fig.canvas.key_press_event('shift+right')
+    if bg_img is not None:
+        with pytest.raises(FileNotFoundError, match='MRI file .* not found'):
+            stc.plot(sample_src, subject='sample', subjects_dir=subjects_dir,
+                     mode='stat_map', bg_img='junk.mgz')
+
+
+@pytest.mark.slowtest  # can be slow on OSX
+@testing.requires_testing_data
+@requires_dipy()
+@requires_nibabel()
+@requires_version('nilearn', '0.4')
+def test_plot_volume_source_estimates_morph():
+    """Test interactive plotting of volume source estimates with morph."""
+    forward = read_forward_solution(fwd_fname)
+    sample_src = forward['src']
+    vertices = [s['vertno'] for s in sample_src]
+    n_verts = sum(len(v) for v in vertices)
+    n_time = 2
+    data = np.random.RandomState(0).rand(n_verts, n_time)
+    stc = VolSourceEstimate(data, vertices, 1, 1)
+    sample_src[0]['subject_his_id'] = 'sample'  # old src
+    morph = compute_source_morph(sample_src, 'sample', 'fsaverage', zooms=5,
+                                 subjects_dir=subjects_dir)
+    initial_pos = (-0.05, -0.01, -0.006)
+    with pytest.warns(None):  # sometimes get scalars/index warning
+        with catch_logging() as log:
+            stc.plot(morph, subjects_dir=subjects_dir, mode='glass_brain',
+                     initial_pos=initial_pos, verbose=True)
+    log = log.getvalue()
+    assert 't = 1.000 s' in log
+    assert '(-52.0, -8.0, -7.0) mm' in log
+
+    with pytest.raises(ValueError, match='Allowed values are'):
+        stc.plot(sample_src, 'sample', subjects_dir, mode='abcd')
+    vertices.append([])
+    surface_stc = SourceEstimate(data, vertices, 1, 1)
+    with pytest.raises(TypeError, match='an instance of VolSourceEstimate'):
+        plot_volume_source_estimates(surface_stc, sample_src, 'sample',
+                                     subjects_dir)
+    with pytest.raises(ValueError, match='Negative colormap limits'):
+        stc.plot(sample_src, 'sample', subjects_dir,
+                 clim=dict(lims=[-1, 2, 3], kind='value'))


### PR DESCRIPTION
This PR:

1. moves mpl/nilearn-based volume plotting from `mne/viz/tests/test_3d.py` to new `mne/viz/tests/test_3d_mpl.py`
2. uses 4 rather than 3 levels of path depth for summary in `pytest-harvest`

It gives us a bit more granularity when looking at our timing results:
```
$ pytest mne/viz/
...
=================================================================== slowest 20 test modules ====================================================================
88.73s total   mne/viz/tests/test_3d.py
55.27s total   mne/viz/_brain/tests/
41.67s total   mne/viz/tests/test_3d_mpl.py
38.52s total   mne/viz/tests/test_ica.py
17.48s total   mne/viz/tests/test_epochs.py
15.28s total   mne/viz/tests/test_raw.py
14.64s total   mne/viz/tests/test_topomap.py
12.63s total   mne/viz/tests/test_evoked.py
11.28s total   mne/viz/tests/test_misc.py
 4.19s total   mne/viz/tests/test_topo.py
 1.30s total   mne/viz/tests/test_utils.py
```
The `plot_volume_source_estimates` that route through `nilearn` have always been somewhat separate anyway, so this seems useful conceptually, too.