### PR TITLE
MRG, MAINT: Reduce memory usage of examples

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1488,8 +1488,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         class_name = 'Epochs' if class_name == 'BaseEpochs' else class_name
         return '<%s | %s>' % (class_name, s)
 
-    @fill_doc
-    def crop(self, tmin=None, tmax=None, include_tmax=True):
+    @verbose
+    def crop(self, tmin=None, tmax=None, include_tmax=True, verbose=None):
         """Crop a time interval from the epochs.
 
         Parameters
@@ -1499,6 +1499,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         tmax : float | None
             End time of selection in seconds.
         %(include_tmax)s
+        %(verbose_meth)s
 
         Returns
         -------

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -236,8 +236,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """
         return self.times[-1]
 
-    @fill_doc
-    def crop(self, tmin=None, tmax=None, include_tmax=True):
+    @verbose
+    def crop(self, tmin=None, tmax=None, include_tmax=True, verbose=None):
         """Crop data to a given time interval.
 
         Parameters
@@ -247,6 +247,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         tmax : float | None
             End time of selection in seconds.
         %(include_tmax)s
+        %(verbose_meth)s
 
         Returns
         -------

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -120,7 +120,7 @@ def read_inverse_operator(fname, verbose=None):
     #
     logger.info('Reading inverse operator decomposition from %s...'
                 % fname)
-    f, tree, _ = fiff_open(fname, preload=True)
+    f, tree, _ = fiff_open(fname)
     with f as fid:
         #
         #   Find all inverse operators

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -692,8 +692,6 @@ def read_source_spaces(fname, patch_stats=False, verbose=None):
 
 def _read_one_source_space(fid, this):
     """Read one source space."""
-    FIFF_BEM_SURF_NTRI = 3104
-    FIFF_BEM_SURF_TRIANGLES = 3106
 
     res = dict()
 
@@ -796,7 +794,7 @@ def _read_one_source_space(fid, this):
 
     res['np'] = int(tag.data)
 
-    tag = find_tag(fid, this, FIFF_BEM_SURF_NTRI)
+    tag = find_tag(fid, this, FIFF.FIFF_BEM_SURF_NTRI)
     if tag is None:
         tag = find_tag(fid, this, FIFF.FIFF_MNE_SOURCE_SPACE_NTRI)
         if tag is None:
@@ -830,7 +828,7 @@ def _read_one_source_space(fid, this):
         raise ValueError('Vertex normal information is incorrect')
 
     if res['ntri'] > 0:
-        tag = find_tag(fid, this, FIFF_BEM_SURF_TRIANGLES)
+        tag = find_tag(fid, this, FIFF.FIFF_BEM_SURF_TRIANGLES)
         if tag is None:
             tag = find_tag(fid, this, FIFF.FIFF_MNE_SOURCE_SPACE_TRIANGLES)
             if tag is None:

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -692,7 +692,6 @@ def read_source_spaces(fname, patch_stats=False, verbose=None):
 
 def _read_one_source_space(fid, this):
     """Read one source space."""
-
     res = dict()
 
     tag = find_tag(fid, this, FIFF.FIFF_MNE_SOURCE_SPACE_ID)

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -399,8 +399,7 @@ def test_plot_compare_evokeds():
     plot_compare_evokeds([list(evoked_dict.values())], picks=[0],
                          ci=_parametric_ci)
     # smoke test for tmin >= 0 (from mailing list)
-    with pytest.warns(RuntimeWarning, match='Cropping removes baseline'):
-        red.crop(0.01, None)
+    red.crop(0.01, None)
     assert len(red.times) > 2
     plot_compare_evokeds(red)
     # plot a flat channel

--- a/tutorials/source-modeling/plot_forward.py
+++ b/tutorials/source-modeling/plot_forward.py
@@ -101,17 +101,21 @@ mne.viz.plot_alignment(info, trans, subject=subject, dig=True,
 # :func:`mne.setup_source_space`, while **volumetric** source space is computed
 # using :func:`mne.setup_volume_source_space`.
 #
-# We will now compute a surface-based source space with an ``'oct6'``
+# We will now compute a surface-based source space with an ``'oct4'``
 # resolution. See :ref:`setting_up_source_space` for details on source space
 # definition and spacing parameter.
+#
+# .. warning::
+#     ``'oct4'`` is used here just for speed, for real analyses the recommended
+#     spacing is ``'oct6'``.
 
-src = mne.setup_source_space(subject, spacing='oct6', add_dist='patch',
+src = mne.setup_source_space(subject, spacing='oct4', add_dist='patch',
                              subjects_dir=subjects_dir)
 print(src)
 
 ###############################################################################
 # The surface based source space ``src`` contains two parts, one for the left
-# hemisphere (4098 locations) and one for the right hemisphere (4098
+# hemisphere (258 locations) and one for the right hemisphere (258
 # locations). Sources can be visualized on top of the BEM surfaces in purple.
 
 mne.viz.plot_bem(subject=subject, subjects_dir=subjects_dir,
@@ -194,13 +198,14 @@ bem = mne.make_bem_solution(model)
 # parameter.
 
 fwd = mne.make_forward_solution(raw_fname, trans=trans, src=src, bem=bem,
-                                meg=True, eeg=False, mindist=5.0, n_jobs=2)
+                                meg=True, eeg=False, mindist=5.0, n_jobs=2,
+                                verbose=True)
 print(fwd)
 
 ###############################################################################
 # .. warning::
 #    Forward computation can remove vertices that are too close to (or outside)
-#    the inner skull surface. For example, here we have gone from 8096 to 7498
+#    the inner skull surface. For example, here we have gone from 516 to 474
 #    vertices in use. For many functions, such as
 #    :func:`mne.compute_source_morph`, it is important to pass ``fwd['src']``
 #    or ``inv['src']`` so that this removal is adequately accounted for.

--- a/tutorials/source-modeling/plot_mne_solutions.py
+++ b/tutorials/source-modeling/plot_mne_solutions.py
@@ -22,11 +22,11 @@ print(__doc__)
 data_path = sample.data_path()
 subjects_dir = data_path + '/subjects'
 
-# Read data
+# Read data (just MEG here for speed, though we could use MEG+EEG)
 fname_evoked = data_path + '/MEG/sample/sample_audvis-ave.fif'
 evoked = mne.read_evokeds(fname_evoked, condition='Left Auditory',
                           baseline=(None, 0))
-fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif'
+fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-oct-6-fwd.fif'
 fname_cov = data_path + '/MEG/sample/sample_audvis-cov.fif'
 fwd = mne.read_forward_solution(fname_fwd)
 cov = mne.read_cov(fname_cov)
@@ -51,7 +51,6 @@ kwargs = dict(initial_time=0.08, hemi='both', subjects_dir=subjects_dir,
 stc = abs(apply_inverse(evoked, inv, lambda2, 'MNE', verbose=True))
 brain = stc.plot(figure=1, **kwargs)
 brain.add_text(0.1, 0.9, 'MNE', 'title', font_size=14)
-
 
 ###############################################################################
 # Next let's use the default noise normalization, dSPM:
@@ -82,6 +81,7 @@ brain.add_text(0.1, 0.9, 'eLORETA', 'title', font_size=14)
 
 inv = make_inverse_operator(evoked.info, fwd, cov, loose=1., depth=0.8,
                             verbose=True)
+del fwd
 
 ###############################################################################
 # Let's look at the current estimates using MNE. We'll take the absolute
@@ -90,7 +90,6 @@ inv = make_inverse_operator(evoked.info, fwd, cov, loose=1., depth=0.8,
 stc = apply_inverse(evoked, inv, lambda2, 'MNE', verbose=True)
 brain = stc.plot(figure=5, **kwargs)
 brain.add_text(0.1, 0.9, 'MNE', 'title', font_size=14)
-
 
 ###############################################################################
 # Next let's use the default noise normalization, dSPM:

--- a/tutorials/source-modeling/plot_visualize_stc.py
+++ b/tutorials/source-modeling/plot_visualize_stc.py
@@ -57,7 +57,6 @@ brain = stc.plot(subjects_dir=subjects_dir, initial_time=initial_time,
 # You can also morph it to fsaverage and visualize it using a flatmap:
 
 # sphinx_gallery_thumbnail_number = 2
-
 stc_fs = mne.compute_source_morph(stc, 'sample', 'fsaverage', subjects_dir,
                                   smooth=5, verbose='error').apply(stc)
 brain = stc_fs.plot(subjects_dir=subjects_dir, initial_time=initial_time,
@@ -87,7 +86,8 @@ mpl_fig = stc.plot(subjects_dir=subjects_dir, initial_time=initial_time,
 # Let us load the sensor-level evoked data. We select the MEG channels
 # to keep things simple.
 evoked = read_evokeds(fname_evoked, condition=0, baseline=(None, 0))
-evoked.pick_types(meg=True, eeg=False)
+evoked.pick_types(meg=True, eeg=False).crop(
+    0.05, 0.15, verbose='error')  # 'error' here: ignore cutting off baseline
 
 ###############################################################################
 # Then, we can load the precomputed inverse operator from a file.
@@ -102,7 +102,6 @@ snr = 3.0
 lambda2 = 1.0 / snr ** 2
 method = "dSPM"  # use dSPM method (could also be MNE or sLORETA)
 stc = apply_inverse(evoked, inv, lambda2, method)
-stc.crop(0.0, 0.2)
 
 ###############################################################################
 # This time, we have a different container
@@ -154,8 +153,8 @@ fname_inv = data_path + '/MEG/sample/sample_audvis-meg-oct-6-meg-inv.fif'
 
 inv = read_inverse_operator(fname_inv)
 stc = apply_inverse(evoked, inv, lambda2, 'dSPM', pick_ori='vector')
-stc.plot(subject='sample', subjects_dir=subjects_dir,
-         initial_time=initial_time)
+brain = stc.plot(subject='sample', subjects_dir=subjects_dir,
+                 initial_time=initial_time)
 
 ###############################################################################
 # Dipole fits


### PR DESCRIPTION
Closes #8241

The goal is to reduce memory usage -- we'll see what CircleCI reports here vs on `master`. But some relevant test timings locally on master:
```
45.42s total   mne/minimum_norm/tests/
37.23s total   mne/tests/test_source_space.py
21.81s total   mne/forward/tests/
 0.00s total   mne/forward/_make_forward.py
```
This PR:
```
47.28s total   mne/minimum_norm/tests/
37.83s total   mne/tests/test_source_space.py
20.52s total   mne/forward/tests/
 0.00s total   mne/forward/_make_forward.py
```
So it looks like removing the `preload=True` from the `read_source_space` code (which was causing memory usage jumps in the hundreds of MB range) seems to be okay