### PR TITLE
MRG, ENH: Reduce memory usage

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -189,6 +189,8 @@ Changelog
 
 - Add ``component_order`` parameter to :class:`mne.decoding.CSP` which allows switching between ``mutual_info`` (default) and ``alternate`` (a simpler and frequently used option) by `Martin Billinger`_ and `Clemens Brunner`_
 
+- Add memory size information to the ``repr`` of :class:`mne.SourceSpaces` and :class:`mne.SourceEstimate` and related classes by `Eric Larson`_
+
 - Speed up reading of annotations in EDF+ files by `Jeroen Van Der Donckt`_
 
 - Add reader for Persyst (.lay + .dat format) data in :func:`mne.io.read_raw_persyst` by `Adam Li`_

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -192,6 +192,11 @@ general neuroimaging concepts. If you think a term is missing, please consider
         estimate activity for a given source while suppressing cross-talk from
         other regions, see :func:`mne.beamformer.make_lcmv`.
 
+    maximum intensity projection
+        A method of displaying activity within some volume by, for each pixel,
+        finding the maximum value along vector from the viewer to the pixel
+        (i.e., along the vector pependicular to the view plane).
+
     minimum-norm estimation
         Minimum-norm estimation (abbr. ``MNE``) can be used to generate a distributed
         map of activation on a :term:`source space`, usually on a cortical surface.

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -484,7 +484,6 @@ def pytest_sessionfinish(session, exitstatus):
         return
     from py.io import TerminalWriter
     # get the number to print
-    writer = TerminalWriter()
     res = pytest_harvest.get_session_synthesis_dct(session)
     files = dict()
     for key, val in res.items():
@@ -500,11 +499,13 @@ def pytest_sessionfinish(session, exitstatus):
     files = sorted(list(files.items()), key=lambda x: x[1])[::-1]
     # print
     files = files[:n]
-    writer.line()  # newline
-    writer.sep('=', f'slowest {n} test module{_pl(n)}')
-    names, timings = zip(*files)
-    timings = [f'{timing:0.2f}s total' for timing in timings]
-    rjust = max(len(timing) for timing in timings)
-    timings = [timing.rjust(rjust) for timing in timings]
-    for name, timing in zip(names, timings):
-        writer.line(f'{timing.ljust(15)}{name}')
+    if len(files):
+        writer = TerminalWriter()
+        writer.line()  # newline
+        writer.sep('=', f'slowest {n} test module{_pl(n)}')
+        names, timings = zip(*files)
+        timings = [f'{timing:0.2f}s total' for timing in timings]
+        rjust = max(len(timing) for timing in timings)
+        timings = [timing.rjust(rjust) for timing in timings]
+        for name, timing in zip(names, timings):
+            writer.line(f'{timing.ljust(15)}{name}')

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -155,9 +155,11 @@ def test_volume_stc(tmpdir):
 
     # now let's actually read a MNE-C processed file
     stc = read_source_estimate(fname_vol, 'sample')
-    assert (isinstance(stc, VolSourceEstimate))
+    assert isinstance(stc, VolSourceEstimate)
 
-    assert ('sample' in repr(stc))
+    assert 'sample' in repr(stc)
+    assert ' kB' in repr(stc)
+
     stc_new = stc
     pytest.raises(ValueError, stc.save, fname_vol, ftype='whatever')
     for ftype in ['w', 'h5']:

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -226,7 +226,8 @@ def test_discrete_source_space(tmpdir):
     # now do MRI
     pytest.raises(ValueError, setup_volume_source_space, 'sample',
                   pos=pos_dict, mri=fname_mri)
-    assert repr(src_new) == repr(src_c)
+    assert repr(src_new).split('~')[0] == repr(src_c).split('~')[0]
+    assert ' kB' in repr(src_new)
     assert src_new.kind == 'discrete'
     assert _get_src_type(src_new, None) == 'discrete'
 
@@ -267,6 +268,7 @@ def test_volume_source_space(tmpdir):
             'sample', bem=bem, mri=fname_mri, subjects_dir=subjects_dir)
     del bem
     assert repr(src) == repr(src_new)
+    assert ' MB' in repr(src)
     assert src.kind == 'volume'
     # Spheres
     sphere = make_sphere_model(r0=(0., 0., 0.), head_radius=0.1,
@@ -403,8 +405,8 @@ def test_setup_source_space(tmpdir):
         src_new = setup_source_space('fsaverage', spacing='ico5',
                                      subjects_dir=subjects_dir, add_dist=False)
     _compare_source_spaces(src, src_new, mode='approx')
-    assert_equal(repr(src), repr(src_new))
-    assert_equal(repr(src).count('surface ('), 2)
+    assert repr(src).split('~')[0] == repr(src_new).split('~')[0]
+    assert repr(src).count('surface (') == 2
     assert_array_equal(src[0]['vertno'], np.arange(10242))
     assert_array_equal(src[1]['vertno'], np.arange(10242))
 
@@ -758,7 +760,7 @@ def test_combine_source_spaces(tmpdir):
     src.save(src_out_name)
     src_from_file = read_source_spaces(src_out_name)
     _compare_source_spaces(src, src_from_file, mode='approx')
-    assert_equal(repr(src), repr(src_from_file))
+    assert repr(src).split('~')[0] == repr(src_from_file).split('~')[0]
     assert_equal(src.kind, 'mixed')
 
     # test that all source spaces are in MRI coordinates

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1301,8 +1301,8 @@ volume_options : float | dict | None
         space resolution, which is often something like 7 or 5 mm,
         without resampling.
     - ``'blending'`` : str
-        Can be "mip" (default) for maximum intensity projection or
-        "composite" for composite blending.
+        Can be "mip" (default) for :term:`maximum intensity projection` or
+        "composite" for composite blending using alpha values.
     - ``'alpha'`` : float | None
         Alpha for the volumetric rendering. Defaults are 0.4 for vector source
         estimates and 1.0 for scalar source estimates.


### PR DESCRIPTION
1. Add memory usage for SourceEstimate and SourceSpaces
2. Use native memory types for source space label info (no need to upcast to float, this requires 2x mem)
3. Add option to `prepare_inverse_operator` to avoid copying `src` as it can be hundreds of MB (this is pretty minor and I doubt users will care, mostly it helps internally with `apply_inverse`, so no `latest.inc` update)
4. Add "maximum intensity projection" to our glossary
5. Minor tweaks to `plot_visualize_stc.py` which is our latest [CircleCI failure culprit](https://app.circleci.com/pipelines/github/mne-tools/mne-python/3705/workflows/ad776bdf-33b0-4f7c-b08b-47c0c225403b/jobs/22337)