### PR TITLE
MRG, ENH: Add brain movies to rendered examples

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -512,6 +512,9 @@ img.logo {
   max-width: 360px;
   width: 100%;
 }
+img.hidden {
+  visibility: hidden;
+}
 div.border-top {
   border-top: 1px solid #ccc;
 }

--- a/doc/carousel.inc
+++ b/doc/carousel.inc
@@ -14,7 +14,7 @@
         <div class="carousel-inner">
 
           <div class="item active">
-            <div class="chopper container" style="background-image: url(_images/sphx_glr_plot_mne_dspm_source_localization_008.png)" title="dSPM">
+            <div class="chopper container" style="background-image: url(_images/sphx_glr_plot_mne_dspm_source_localization_008.gif)" title="dSPM">
               <div class="carousel-caption">
                 <h3>Source estimation</h3>
                 <p>Distributed, sparse, mixed-norm, beamformers, dipole fitting, and more.

--- a/examples/inverse/plot_vector_mne_solution.py
+++ b/examples/inverse/plot_vector_mne_solution.py
@@ -56,6 +56,10 @@ _, peak_time = stc.magnitude().get_peak(hemi='lh')
 brain = stc.plot(
     initial_time=peak_time, hemi='lh', subjects_dir=subjects_dir)
 
+# You can save a brain movie with:
+# brain.save_movie(time_dilation=20, tmin=0.05, tmax=0.15, framerate=10,
+#                  interpolation='linear')
+
 ###############################################################################
 # Plot the activation in the direction of maximal power for this data:
 

--- a/examples/inverse/plot_vector_mne_solution.py
+++ b/examples/inverse/plot_vector_mne_solution.py
@@ -53,12 +53,14 @@ _, peak_time = stc.magnitude().get_peak(hemi='lh')
 
 ###############################################################################
 # Plot the source estimate:
+
+# sphinx_gallery_thumbnail_number = 2
 brain = stc.plot(
     initial_time=peak_time, hemi='lh', subjects_dir=subjects_dir)
 
 # You can save a brain movie with:
-# brain.save_movie(time_dilation=20, tmin=0.05, tmax=0.15, framerate=10,
-#                  interpolation='linear')
+# brain.save_movie(time_dilation=20, tmin=0.05, tmax=0.16, framerate=10,
+#                  interpolation='linear', time_viewer=True)
 
 ###############################################################################
 # Plot the activation in the direction of maximal power for this data:

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -146,6 +146,11 @@ def test_docstring_parameters():
         for submod in name.split('.')[1:]:
             module = getattr(module, submod)
         classes = inspect.getmembers(module, inspect.isclass)
+        # XXX eventually this should be public
+        # XXX this should be correct but it's not
+        # if name == 'mne.viz':
+        #     from mne.viz._brain import _Brain
+        #     classes.append(('Brain', _Brain))
         for cname, cls in classes:
             if cname.startswith('_'):
                 continue

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -147,10 +147,9 @@ def test_docstring_parameters():
             module = getattr(module, submod)
         classes = inspect.getmembers(module, inspect.isclass)
         # XXX eventually this should be public
-        # XXX this should be correct but it's not
-        # if name == 'mne.viz':
-        #     from mne.viz._brain import _Brain
-        #     classes.append(('Brain', _Brain))
+        if name == 'mne.viz':
+            from mne.viz._brain import _Brain
+            classes.append(('Brain', _Brain))
         for cname, cls in classes:
             if cname.startswith('_'):
                 continue

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1259,8 +1259,10 @@ colormap : str | np.ndarray of float, shape(n_colors, 3 | 4)
 """
 docdict["transparent"] = """
 transparent : bool | None
-    If True, use a linear transparency between fmin and fmid.
-    None will choose automatically based on colormap type.
+    If True: use a linear transparency between fmin and fmid
+    and make values below fmin fully transparent (symmetrically for
+    divergent colormaps). None will choose automatically based on colormap
+    type.
 """
 docdict["brain_time_interpolation"] = """
 interpolation : str | None
@@ -1293,7 +1295,26 @@ time_label : str | callable | None
     default is ``'auto'``, which will use ``time=%0.2f ms`` if there
     is more than one time point.
 """
-docdict["src_volume_options_layout"] = """
+docdict["fmin_fmid_fmax"] = """
+fmin : float
+    Minimum value in colormap (uses real fmin if None).
+fmid : float
+    Intermediate value in colormap (fmid between fmin and
+    fmax if None).
+fmax : float
+    Maximum value in colormap (uses real max if None).
+"""
+docdict["thresh"] = """
+thresh : None or float
+    Not supported yet.
+    If not None, values below thresh will not be visible.
+"""
+docdict["center"] = """
+center : float or None
+    If not None, center of a divergent colormap, changes the meaning of
+    fmin, fmax and fmid.
+"""
+docdict["src_volume_options"] = """
 src : instance of SourceSpaces | None
     The source space corresponding to the source estimate. Only necessary
     if the STC is a volume or mixed source estimate.
@@ -1322,6 +1343,8 @@ volume_options : float | dict | None
 
     A float input (default 1.) or None will be used for the ``'resolution'``
     entry.
+"""
+docdict['view_layout'] = """
 view_layout : str
     Can be "vertical" (default) or "horizontal". When using "horizontal" mode,
     the PyVista backend must be used and hemi cannot be "split".

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1268,6 +1268,11 @@ interpolation : str | None
     Must be one of 'linear', 'nearest', 'zero', 'slinear', 'quadratic',
     or 'cubic'.
 """
+docdict["brain_screenshot_time_viewer"] = """
+time_viewer : bool
+    If True, include time viewer traces. Only used if
+    ``time_viewer=True`` and ``separate_canvas=False``.
+"""
 docdict["show_traces"] = """
 show_traces : bool | str | float
     If True, enable interactive picking of a point on the surface of the

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1714,7 +1714,8 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
 
         .. versionadded:: 0.17.0
     %(show_traces)s
-    %(src_volume_options_layout)s
+    %(src_volume_options)s
+    %(view_layout)s
     %(add_data_kwargs)s
     %(verbose)s
 
@@ -2509,7 +2510,8 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
         Whether time is represented in seconds ("s", default) or
         milliseconds ("ms").
     %(show_traces)s
-    %(src_volume_options_layout)s
+    %(src_volume_options)s
+    %(view_layout)s
     %(add_data_kwargs)s
     %(verbose)s
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -28,6 +28,7 @@ from ...utils import (_check_option, logger, verbose, fill_doc, _validate_type,
                       use_log_level, Bunch)
 
 
+@fill_doc
 class _Brain(object):
     """Class for visualizing a brain.
 
@@ -46,7 +47,7 @@ class _Brain(object):
         In the case of 'split' hemispheres are displayed side-by-side
         in different viewing panes.
     surf : str
-        freesurfer surface mesh name (ie 'white', 'inflated', etc.).
+        FreeSurfer surface mesh name (ie 'white', 'inflated', etc.).
     title : str
         Title for the window.
     cortex : str or None
@@ -75,7 +76,7 @@ class _Brain(object):
         instead of the value set using the SUBJECTS_DIR environment
         variable.
     views : list | str
-        views to use.
+        The views to use.
     offset : bool
         If True, aligs origin with medial wall. Useful for viewing inflated
         surface where hemispheres typically overlap (Default: True).
@@ -90,6 +91,7 @@ class _Brain(object):
         camera.
     units : str
         Can be 'm' or 'mm' (default).
+    %(view_layout)s
     show : bool
         Display the window as soon as it is ready. Defaults to True.
 
@@ -157,7 +159,6 @@ class _Brain(object):
        +---------------------------+--------------+-----------------------+
        | flatmaps                  |              | ✓                     |
        +---------------------------+--------------+-----------------------+
-
     """
 
     def __init__(self, subject_id, hemi, surf, title=None,
@@ -234,7 +235,7 @@ class _Brain(object):
         self.geo, self._overlays = {}, {}
         self.set_time_interpolation('nearest')
 
-        geo_kwargs = self.cortex_colormap(cortex)
+        geo_kwargs = self._cortex_colormap(cortex)
         # evaluate at the midpoint of the used colormap
         val = -geo_kwargs['vmin'] / (geo_kwargs['vmax'] - geo_kwargs['vmin'])
         self._brain_color = get_cmap(geo_kwargs['colormap'])(val)
@@ -319,7 +320,7 @@ class _Brain(object):
             self._renderer.subplot(ri, ci)
             self._renderer.set_interaction(interaction)
 
-    def cortex_colormap(self, cortex):
+    def _cortex_colormap(self, cortex):
         """Return the colormap corresponding to the cortex."""
         colormap_map = dict(classic=dict(colormap="Greys",
                                          vmin=-1, vmax=2),
@@ -363,42 +364,30 @@ class _Brain(object):
             If vectors with no time dimension are desired, consider using a
             singleton (e.g., ``np.newaxis``) to create a "time" dimension
             and pass ``time_label=None`` (vector values are not supported).
-        fmin : float
-            Minimum value in colormap (uses real fmin if None).
-        fmid : float
-            Intermediate value in colormap (fmid between fmin and
-            fmax if None).
-        fmax : float
-            Maximum value in colormap (uses real max if None).
-        thresh : None or float
-            Not supported yet.
-            if not None, values below thresh will not be visible
-        center : float or None
-            if not None, center of a divergent colormap, changes the meaning of
-            fmin, fmax and fmid.
-        transparent : bool
-            if True: use a linear transparency between fmin and fmid
-            and make values below fmin fully transparent (symmetrically for
-            divergent colormaps)
+        %(fmin_fmid_fmax)s
+        %(thresh)s
+        %(center)s
+        %(transparent)s
         colormap : str, list of color, or array
-            name of matplotlib colormap to use, a list of matplotlib colors,
+            Name of matplotlib colormap to use, a list of matplotlib colors,
             or a custom look up table (an n x 4 array coded with RBGA values
             between 0 and 255), the default "auto" chooses a default divergent
             colormap, if "center" is given (currently "icefire"), otherwise a
             default sequential colormap (currently "rocket").
         alpha : float in [0, 1]
-            alpha level to control opacity of the overlay.
+            Alpha level to control opacity of the overlay.
         vertices : numpy array
-            vertices for which the data is defined (needed if len(data) < nvtx)
+            Vertices for which the data is defined (needed if
+            ``len(data) < nvtx``).
         smoothing_steps : int or None
-            number of smoothing steps (smoothing is used if len(data) < nvtx)
-            The value 'nearest' can be used too.
-            Default : 7
+            Number of smoothing steps (smoothing is used if len(data) < nvtx)
+            The value 'nearest' can be used too. None (default) will use as
+            many as necessary to fill the surface.
         time : numpy array
-            time points in the data array (if data is 2D or 3D)
+            Time points in the data array (if data is 2D or 3D).
         %(time_label)s
         colorbar : bool
-            whether to add a colorbar to the figure. Can also be a tuple
+            Whether to add a colorbar to the figure. Can also be a tuple
             to give the (row, col) index of where to put the colorbar.
         hemi : str | None
             If None, it is assumed to belong to the hemisphere being
@@ -409,21 +398,19 @@ class _Brain(object):
             Remove surface added by previous "add_data" call. Useful for
             conserving memory when displaying different data in a loop.
         time_label_size : int
-            Font size of the time label (default 14)
+            Font size of the time label (default 14).
         initial_time : float | None
             Time initially shown in the plot. ``None`` to use the first time
             sample (default).
         scale_factor : float | None (default)
-            Not supported yet.
             The scale factor to use when displaying glyphs for vector-valued
             data.
         vector_alpha : float | None
-            Not supported yet.
-            alpha level to control opacity of the arrows. Only used for
+            Alpha level to control opacity of the arrows. Only used for
             vector-valued data. If None (default), ``alpha`` is used.
         clim : dict
             Original clim arguments.
-        %(src_volume_options_layout)s
+        %(src_volume_options)s
         colorbar_kwargs : dict | None
             Options to pass to :meth:`pyvista.BasePlotter.add_scalar_bar`
             (e.g., ``dict(title_font_size=10)``).
@@ -774,18 +761,18 @@ class _Brain(object):
         Parameters
         ----------
         label : str | instance of Label
-            label filepath or name. Can also be an instance of
+            Label filepath or name. Can also be an instance of
             an object with attributes "hemi", "vertices", "name", and
             optionally "color" and "values" (if scalar_thresh is not None).
         color : matplotlib-style color | None
-            anything matplotlib accepts: string, RGB, hex, etc. (default
-            "crimson")
+            Anything matplotlib accepts: string, RGB, hex, etc. (default
+            "crimson").
         alpha : float in [0, 1]
-            alpha level to control opacity
+            Alpha level to control opacity.
         scalar_thresh : None or number
-            threshold the label ids using this value in the label
+            Threshold the label ids using this value in the label
             file's scalar field (i.e. label only vertices with
-            scalar >= thresh)
+            scalar >= thresh).
         borders : bool | int
             Show only label borders. If int, specify the number of steps
             (away from the true border) along the cortical mesh to include
@@ -913,21 +900,21 @@ class _Brain(object):
 
         Parameters
         ----------
-        coords : numpy array
-            x, y, z coordinates in stereotaxic space (default) or array of
-            vertex ids (with ``coord_as_verts=True``)
+        coords : ndarray, shape (n_coords, 3)
+            Coordinates in stereotaxic space (default) or array of
+            vertex ids (with ``coord_as_verts=True``).
         coords_as_verts : bool
-            whether the coords parameter should be interpreted as vertex ids
+            Whether the coords parameter should be interpreted as vertex ids.
         map_surface : Freesurfer surf or None
-            surface to map coordinates through, or None to use raw coords
+            Surface to map coordinates through, or None to use raw coords.
         scale_factor : float
             Controls the size of the foci spheres (relative to 1cm).
         color : matplotlib color code
-            HTML name, RBG tuple, or hex code
+            HTML name, RBG tuple, or hex code.
         alpha : float in [0, 1]
-            opacity of focus gylphs
+            Opacity of focus gylphs.
         name : str
-            internal name to use
+            Internal name to use.
         hemi : str | None
             If None, it is assumed to belong to the hemipshere being
             shown. If two hemispheres are being shown, an error will
@@ -963,23 +950,27 @@ class _Brain(object):
         Parameters
         ----------
         x : Float
-            x coordinate
+            X coordinate.
         y : Float
-            y coordinate
+            Y coordinate.
         text : str
-            Text to add
+            Text to add.
         name : str
-            Name of the text (text label can be updated using update_text())
-        color : Tuple
+            Name of the text (text label can be updated using update_text()).
+        color : tuple
             Color of the text. Default is the foreground color set during
             initialization (default is black or white depending on the
             background color).
-        opacity : Float
-            Opacity of the text. Default: 1.0
+        opacity : float
+            Opacity of the text (default 1.0).
         row : int
-            Row index of which brain to use
+            Row index of which brain to use.
         col : int
-            Column index of which brain to use
+            Column index of which brain to use.
+        font_size : float | None
+            The font size to use.
+        justification : str | None
+            The text justification.
         """
         # XXX: support `name` should be added when update_text/remove_text
         # are implemented
@@ -1126,7 +1117,23 @@ class _Brain(object):
 
     def show_view(self, view=None, roll=None, distance=None, row=0, col=0,
                   hemi=None):
-        """Orient camera to display view."""
+        """Orient camera to display view.
+
+        Parameters
+        ----------
+        view : str | dict
+            String view, or a dict with azimuth and elevation.
+        roll : float | None
+            The roll.
+        distance : float | None
+            The distance.
+        row : int
+            The row to set.
+        col : int
+            The column to set.
+        hemi : str
+            Which hemi to use for string lookup (when in "both" mode).
+        """
         hemi = self._hemi if hemi is None else hemi
         if hemi == 'split':
             if (self._view_layout == 'vertical' and col == 1 or
@@ -1158,9 +1165,9 @@ class _Brain(object):
 
         Parameters
         ----------
-        filename: string
-            path to new image file
-        mode : string
+        filename : str
+            Path to new image file.
+        mode : str
             Either 'rgb' or 'rgba' for values to return.
         """
         self._renderer.screenshot(mode=mode, filename=filename)
@@ -1171,7 +1178,7 @@ class _Brain(object):
 
         Parameters
         ----------
-        mode : string
+        mode : str
             Either 'rgb' or 'rgba' for values to return.
         %(brain_screenshot_time_viewer)s
 
@@ -1214,18 +1221,13 @@ class _Brain(object):
             img = np.concatenate([img, trace_img], axis=0)
         return img
 
+    @fill_doc
     def update_lut(self, fmin=None, fmid=None, fmax=None):
         """Update color map.
 
         Parameters
         ----------
-        fmin : float | None
-            Minimum value in colormap.
-        fmid : float | None
-            Intermediate value in colormap (fmid between fmin and
-            fmax).
-        fmax : float | None
-            Maximum value in colormap.
+        %(fmin_fmid_fmax)s
         """
         from ..backends._pyvista import _set_colormap_range, _set_volume_range
         center = self._data['center']
@@ -1280,7 +1282,7 @@ class _Brain(object):
         Parameters
         ----------
         n_steps : int
-            Number of smoothing steps
+            Number of smoothing steps.
         """
         from ...morph import _hemi_morph
         for hemi in ['lh', 'rh']:
@@ -1341,7 +1343,14 @@ class _Brain(object):
             self._time_interp_inv = _safe_interp1d(idx, self._times)
 
     def set_time_point(self, time_idx):
-        """Set the time point shown (can be a float to interpolate)."""
+        """Set the time point shown (can be a float to interpolate).
+
+        Parameters
+        ----------
+        time_idx : int | float
+            The time index to use. Can be a float to use interpolation
+            between indices.
+        """
         from ..backends._pyvista import _set_mesh_scalars
         self._current_act_data = dict()
         time_actor = self._data.get('time_actor', None)
@@ -1466,7 +1475,7 @@ class _Brain(object):
         fmax = self._data['fmax'] * fscale
         self.update_lut(fmin=fmin, fmid=fmid, fmax=fmax)
 
-    def update_auto_scaling(self, restore=False):
+    def _update_auto_scaling(self, restore=False):
         user_clim = self._data['clim']
         if user_clim is not None and 'lims' in user_clim:
             allow_pos_lims = False
@@ -1549,12 +1558,16 @@ class _Brain(object):
         %(brain_time_interpolation)s
             If None, it uses the current ``brain.interpolation``,
             which defaults to ``'nearest'``. Defaults to None.
+        codec : str | None
+            The codec to use.
+        bitrate : float | None
+            The bitrate to use.
         callback : callable | None
             A function to call on each iteration. Useful for status message
             updates. It will be passed keyword arguments ``frame`` and
             ``n_frames``.
         %(brain_screenshot_time_viewer)s
-        **kwargs :
+        **kwargs : dict
             Specify additional options for :mod:`imageio`.
         """
         import imageio
@@ -1711,9 +1724,21 @@ class _Brain(object):
             show[keep_idx] = 1
             label *= show
 
+    @verbose
     def scale_data_colormap(self, fmin, fmid, fmax, transparent,
-                            center=None, alpha=1.0, data=None, verbose=None):
-        """Scale the data colormap."""
+                            center=None, alpha=1.0, verbose=None):
+        """Scale the data colormap.
+
+        Parameters
+        ----------
+        %(fmin_fmid_fmax)s
+        %(transparent)s
+        %(center)s
+        alpha : float in [0, 1]
+            Alpha level to control opacity.
+        %(verbose_meth)s
+        """
+        # XXX fmid/transparent/center not used, this is a bug
         lut_lst = self._data['ctable']
         n_col = len(lut_lst)
 
@@ -1744,7 +1769,13 @@ class _Brain(object):
                 self._renderer.figure.display.update()
 
     def get_picked_points(self):
-        """Return the vertices of the picked points."""
+        """Return the vertices of the picked points.
+
+        Returns
+        -------
+        points : list of int | None
+            The vertices picked by the time viewer.
+        """
         if hasattr(self, "time_viewer"):
             return self.time_viewer.picked_points
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1637,8 +1637,11 @@ class _Brain(object):
         -----
         Used by movie and image sequence saving functions.
         """
-        func = partial(self.time_viewer.callbacks["time"], update_widget=True)
-        # func = self.set_time_point
+        if hasattr(self, 'time_viewer'):
+            func = partial(self.time_viewer.callbacks["time"],
+                           update_widget=True)
+        else:
+            func = self.set_time_point
         current_time_idx = self._data["time_idx"]
         for ii, idx in enumerate(time_idx):
             func(idx)

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1571,7 +1571,7 @@ class _Brain(object):
             Specify additional options for :mod:`imageio`.
         """
         import imageio
-        images, kwargs = self._make_movie_frames(
+        images = self._make_movie_frames(
             time_dilation, tmin, tmax, framerate, interpolation, callback,
             time_viewer)
         # find imageio FFMPEG parameters

--- a/mne/viz/_brain/_scraper.py
+++ b/mne/viz/_brain/_scraper.py
@@ -51,6 +51,8 @@ class _BrainScraper(object):
                                      ('time_viewer', False)]:
                     if key not in kwargs:
                         kwargs[key] = default
+                if hasattr(brain, 'time_viewer'):
+                    assert kwargs['time_viewer'], 'Must use time_viewer=True'
                 frames = brain._make_movie_frames(callback=None, **kwargs)
 
                 # Turn them into an animation

--- a/mne/viz/_brain/_scraper.py
+++ b/mne/viz/_brain/_scraper.py
@@ -1,7 +1,5 @@
 import os.path as op
 
-import numpy as np
-
 from ._brain import _Brain
 
 
@@ -22,39 +20,8 @@ class _BrainScraper(object):
             from matplotlib.image import imsave
             from sphinx_gallery.scrapers import figure_rst
             img_fname = next(block_vars['image_path_iterator'])
-            img = brain.screenshot()
+            img = brain.screenshot(time_viewer=True)
             assert img.size > 0
-            if getattr(brain, 'time_viewer', None) is not None and \
-                    brain.time_viewer.show_traces and \
-                    not brain.time_viewer.separate_canvas:
-                canvas = brain.time_viewer.mpl_canvas.fig.canvas
-                canvas.draw_idle()
-                # In theory, one of these should work:
-                #
-                # trace_img = np.frombuffer(
-                #     canvas.tostring_rgb(), dtype=np.uint8)
-                # trace_img.shape = canvas.get_width_height()[::-1] + (3,)
-                #
-                # or
-                #
-                # trace_img = np.frombuffer(
-                #     canvas.tostring_rgb(), dtype=np.uint8)
-                # size = time_viewer.mpl_canvas.getSize()
-                # trace_img.shape = (size.height(), size.width(), 3)
-                #
-                # But in practice, sometimes the sizes does not match the
-                # renderer tostring_rgb() size. So let's directly use what
-                # matplotlib does in lib/matplotlib/backends/backend_agg.py
-                # before calling tobytes():
-                trace_img = np.asarray(
-                    canvas.renderer._renderer).take([0, 1, 2], axis=2)
-                # need to slice into trace_img because generally it's a bit
-                # smaller
-                delta = trace_img.shape[1] - img.shape[1]
-                if delta > 0:
-                    start = delta // 2
-                    trace_img = trace_img[:, start:start + img.shape[1]]
-                img = np.concatenate([img, trace_img], axis=0)
             imsave(img_fname, img)
             assert op.isfile(img_fname)
             rst += figure_rst(

--- a/mne/viz/_brain/_scraper.py
+++ b/mne/viz/_brain/_scraper.py
@@ -1,4 +1,4 @@
-import os.path as op
+from distutils.version import LooseVersion
 
 from ._brain import _Brain
 
@@ -11,20 +11,76 @@ class _BrainScraper(object):
 
     def __call__(self, block, block_vars, gallery_conf):
         rst = ''
-        for brain in block_vars['example_globals'].values():
+        for brain in list(block_vars['example_globals'].values()):
             # Only need to process if it's a brain with a time_viewer
             # with traces on and shown in the same window, otherwise
             # PyVista and matplotlib scrapers can just do the work
             if (not isinstance(brain, _Brain)) or brain._closed:
                 continue
-            from matplotlib.image import imsave
-            from sphinx_gallery.scrapers import figure_rst
-            img_fname = next(block_vars['image_path_iterator'])
+            import matplotlib
+            from matplotlib import animation, pyplot as plt
+            from sphinx_gallery.scrapers import matplotlib_scraper
             img = brain.screenshot(time_viewer=True)
-            assert img.size > 0
-            imsave(img_fname, img)
-            assert op.isfile(img_fname)
-            rst += figure_rst(
-                [img_fname], gallery_conf['src_dir'], brain._title)
+            dpi = 100.
+            figsize = (img.shape[1] / dpi, img.shape[0] / dpi)
+            fig = plt.figure(figsize=figsize, dpi=dpi)
+            ax = plt.Axes(fig, [0, 0, 1, 1])
+            fig.add_axes(ax)
+            img = ax.imshow(img)
+            movie_key = '# brain.save_movie'
+            if movie_key in block[1]:
+                kwargs = dict()
+                # Parse our parameters
+                lines = block[1].splitlines()
+                for li, line in enumerate(block[1].splitlines()):
+                    if line.startswith(movie_key):
+                        line = line[len(movie_key):].replace('..., ', '')
+                        for ni in range(1, 5):  # should be enough
+                            if len(lines) > li + ni and \
+                                    lines[li + ni].startswith('#  '):
+                                line = line + lines[li + ni][1:].strip()
+                            else:
+                                break
+                        assert line.startswith('(') and line.endswith(')')
+                        kwargs.update(eval(f'dict{line}'))
+                for key, default in [('time_dilation', 4),
+                                     ('framerate', 24),
+                                     ('tmin', None),
+                                     ('tmax', None),
+                                     ('interpolation', None),
+                                     ('time_viewer', False)]:
+                    if key not in kwargs:
+                        kwargs[key] = default
+                frames = brain._make_movie_frames(callback=None, **kwargs)
+
+                # Turn them into an animation
+                def func(frame):
+                    img.set_data(frame)
+                    return [img]
+
+                anim = animation.FuncAnimation(
+                    fig, func=func, frames=frames, blit=True,
+                    interval=1000. / kwargs['framerate'])
+
+                # Out to sphinx-gallery:
+                #
+                # 1. A static image but hide it (useful for carousel)
+                if LooseVersion(matplotlib.__version__) >= \
+                        LooseVersion('3.3.1') and \
+                        animation.FFMpegWriter.isAvailable():
+                    writer = 'ffmpeg'
+                elif animation.ImageMagickWriter.isAvailable():
+                    writer = 'imagemagick'
+                else:
+                    writer = None
+                static_fname = next(block_vars['image_path_iterator'])
+                static_fname = static_fname[:-4] + '.gif'
+                anim.save(static_fname, writer=writer, dpi=dpi)
+                rst += f'\n.. image:: /{static_fname}\n    :class: hidden\n'
+
+                # 2. An animation that will be embedded and visible
+                block_vars['example_globals']['_brain_anim_'] = anim
+
             brain.close()
+            rst += matplotlib_scraper(block, block_vars, gallery_conf)
         return rst

--- a/mne/viz/_brain/_timeviewer.py
+++ b/mne/viz/_brain/_timeviewer.py
@@ -273,13 +273,13 @@ class _TimeViewer(object):
             return
 
     def apply_auto_scaling(self):
-        self.brain.update_auto_scaling()
+        self.brain._update_auto_scaling()
         for key in ('fmin', 'fmid', 'fmax'):
             self.reps[key].SetValue(self.brain._data[key])
         self.plotter.update()
 
     def restore_user_scaling(self):
-        self.brain.update_auto_scaling(restore=True)
+        self.brain._update_auto_scaling(restore=True)
         for key in ('fmin', 'fmid', 'fmax'):
             self.reps[key].SetValue(self.brain._data[key])
         self.plotter.update()

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -407,7 +407,7 @@ def test_brain_timeviewer_traces(renderer_interactive, hemi, src, tmpdir):
     block = ('code', """
 something
 # brain.save_movie(time_dilation=1, framerate=1,
-#                  interpolation='linear')
+#                  interpolation='linear', time_viewer=True)
 #
 """, 1)
     gallery_conf = dict(src_dir=str(tmpdir), compress_images=[])

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -393,21 +393,34 @@ def test_brain_timeviewer_traces(renderer_interactive, hemi, src, tmpdir):
         time_viewer.on_pick(test_picker, None)
         assert len(spheres) < old_len
 
-    # and the scraper for it (will close the instance)
-    if not check_version('sphinx_gallery'):
-        return
     screenshot = brain_data.screenshot()
-    fnames = [str(tmpdir.join('temp.png'))]
+    screenshot_all = brain_data.screenshot(time_viewer=True)
+    assert screenshot.shape[0] < screenshot_all.shape[0]
+    # and the scraper for it (will close the instance)
+    # only test one condition to save time
+    if not (hemi == 'rh' and src == 'surface' and
+            check_version('sphinx_gallery')):
+        return
+    fnames = [str(tmpdir.join(f'temp_{ii}.png')) for ii in range(2)]
     block_vars = dict(image_path_iterator=iter(fnames),
                       example_globals=dict(brain=brain_data))
-    gallery_conf = dict(src_dir=str(tmpdir))
+    block = ('code', """
+something
+# brain.save_movie(time_dilation=1, framerate=1,
+#                  interpolation='linear')
+#
+""", 1)
+    gallery_conf = dict(src_dir=str(tmpdir), compress_images=[])
     scraper = _BrainScraper()
-    rst = scraper(None, block_vars, gallery_conf)
-    assert 'temp.png' in rst
-    assert path.isfile(fnames[0])
-    img = image.imread(fnames[0])
-    assert img.shape[1] == screenshot.shape[1]  # same width
-    assert img.shape[0] > screenshot.shape[0]  # larger height
+    rst = scraper(block, block_vars, gallery_conf)
+    gif_0 = fnames[0][:-3] + 'gif'
+    for fname in (gif_0, fnames[1]):
+        assert path.basename(fname) in rst
+        assert path.isfile(fname)
+        img = image.imread(fname)
+        assert img.shape[1] == screenshot.shape[1]  # same width
+        assert img.shape[0] > screenshot.shape[0]  # larger height
+        assert img.shape[:2] == screenshot_all.shape[:2]
 
 
 @testing.requires_testing_data

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -212,14 +212,6 @@ def mne_analyze_colormap(limits=[5, 10, 15], format='mayavi'):
     -----
     For this will return a colormap that will display correctly for data
     that are scaled by the plotting function to span [-fmax, fmax].
-
-    Examples
-    --------
-    The following code will plot a STC using standard MNE limits::
-
-        >>> colormap = mne.viz.mne_analyze_colormap(limits=[5, 10, 15])  # doctest: +SKIP
-        >>> brain = stc.plot('fsaverage', 'inflated', 'rh', colormap)  # doctest: +SKIP
-        >>> brain.scale_data_colormap(fmin=-15, fmid=0, fmax=15, transparent=False)  # doctest: +SKIP
     """  # noqa: E501
     # Ensure limits is an array
     limits = np.asarray(limits, dtype='float')

--- a/tutorials/source-modeling/plot_beamformer_lcmv.py
+++ b/tutorials/source-modeling/plot_beamformer_lcmv.py
@@ -232,16 +232,12 @@ stc.plot(mode='glass_brain', clim=dict(kind='value', lims=lims), **kwargs)
 # as small vectors in the visualization (in the 2D plotters, only the
 # magnitude can be shown):
 
-# sphinx_gallery_thumbnail_number = 8
+# sphinx_gallery_thumbnail_number = 7
 
 brain = stc_vec.plot_3d(
     clim=dict(kind='value', lims=lims), hemi='both',
     views=['coronal', 'sagittal', 'axial'], size=(800, 300),
     view_layout='horizontal', show_traces=0.3, **kwargs)
-
-# The movie on the MNE website can be generated with:
-# brain.save_movie(..., interpolation='linear', time_dilation=20,
-#                  framerate=10, time_viewer=True)
 
 ###############################################################################
 # Visualize the activity of the maximum voxel with all three components

--- a/tutorials/source-modeling/plot_beamformer_lcmv.py
+++ b/tutorials/source-modeling/plot_beamformer_lcmv.py
@@ -232,12 +232,16 @@ stc.plot(mode='glass_brain', clim=dict(kind='value', lims=lims), **kwargs)
 # as small vectors in the visualization (in the 2D plotters, only the
 # magnitude can be shown):
 
-# sphinx_gallery_thumbnail_number = 7
+# sphinx_gallery_thumbnail_number = 8
 
 brain = stc_vec.plot_3d(
     clim=dict(kind='value', lims=lims), hemi='both',
     views=['coronal', 'sagittal', 'axial'], size=(800, 300),
     view_layout='horizontal', show_traces=0.3, **kwargs)
+
+# The movie on the MNE website can be generated with:
+# brain.save_movie(..., interpolation='linear', time_dilation=20,
+#                  framerate=10, time_viewer=True)
 
 ###############################################################################
 # Visualize the activity of the maximum voxel with all three components

--- a/tutorials/source-modeling/plot_mne_dspm_source_localization.py
+++ b/tutorials/source-modeling/plot_mne_dspm_source_localization.py
@@ -136,6 +136,10 @@ brain.add_foci(vertno_max, coords_as_verts=True, hemi='rh', color='blue',
 brain.add_text(0.1, 0.9, 'dSPM (plus location of maximal activation)', 'title',
                font_size=14)
 
+# The documentation website's movie is generated with:
+# brain.save_movie(..., tmin=0.05, tmax=0.15, interpolation='linear',
+#                  time_dilation=20, framerate=10, time_viewer=True)
+
 ###############################################################################
 # There are many other ways to visualize and work with source data, see
 # for example:

--- a/tutorials/source-modeling/plot_mne_dspm_source_localization.py
+++ b/tutorials/source-modeling/plot_mne_dspm_source_localization.py
@@ -121,7 +121,7 @@ residual.plot(axes=axes)
 # Here we use peak getter to move visualization to the time point of the peak
 # and draw a marker at the maximum peak vertex.
 
-# sphinx_gallery_thumbnail_number = 8
+# sphinx_gallery_thumbnail_number = 9
 
 vertno_max, time_max = stc.get_peak(hemi='rh')
 

--- a/tutorials/source-modeling/plot_visualize_stc.py
+++ b/tutorials/source-modeling/plot_visualize_stc.py
@@ -56,7 +56,7 @@ brain = stc.plot(subjects_dir=subjects_dir, initial_time=initial_time,
 ###############################################################################
 # You can also morph it to fsaverage and visualize it using a flatmap:
 
-# sphinx_gallery_thumbnail_number = 2
+# sphinx_gallery_thumbnail_number = 3
 stc_fs = mne.compute_source_morph(stc, 'sample', 'fsaverage', subjects_dir,
                                   smooth=5, verbose='error').apply(stc)
 brain = stc_fs.plot(subjects_dir=subjects_dir, initial_time=initial_time,
@@ -65,6 +65,9 @@ brain = stc_fs.plot(subjects_dir=subjects_dir, initial_time=initial_time,
                     smoothing_steps=5, time_viewer=False,
                     add_data_kwargs=dict(
                         colorbar_kwargs=dict(label_font_size=10)))
+# You can save a movie like the one on our documentation website with:
+# brain.save_movie(time_dilation=20, tmin=0.05, tmax=0.16,
+#                  interpolation='linear')
 
 ###############################################################################
 # Note that here we used ``initial_time=0.1``, but we can also browse through

--- a/tutorials/source-modeling/plot_visualize_stc.py
+++ b/tutorials/source-modeling/plot_visualize_stc.py
@@ -67,7 +67,7 @@ brain = stc_fs.plot(subjects_dir=subjects_dir, initial_time=initial_time,
                         colorbar_kwargs=dict(label_font_size=10)))
 # You can save a movie like the one on our documentation website with:
 # brain.save_movie(time_dilation=20, tmin=0.05, tmax=0.16,
-#                  interpolation='linear')
+#                  interpolation='linear', framerate=10)
 
 ###############################################################################
 # Note that here we used ``initial_time=0.1``, but we can also browse through


### PR DESCRIPTION
Eventually it would be nice to have animations play for some of our source modeling examples. I plan to:

- [x] Add `time_viewer=False` to `brain.screenshot` to allow getting the brain+traces instead of just the traces
- [x] Add movie embedding by ~~using matplotlib's javascript (maybe just by subclassing their animation class?) and sphinx-gallery's animation code (maybe by making this public? not sure)~~ turning brain outputs into matplotlib figures and using matplotlib_scraper(...) directly
- [x] Add `# sphinx_gallery_brain_movie` code parsing that does `brain.save_movie(...)` then uses the javascript to embed a movie
- [x] Add tests

Not 100% sure it will work or produce movies of a reasonable size, but it would be pretty cool if it worked.