### PR TITLE
MRG, MAINT: Lower memory again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
     build_docs:
       docker:
-        - image: circleci/python:3.8.1-buster
+        - image: circleci/python:3.8.5-buster
       steps:
         - checkout
         - run:

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ doc/auto_examples/
 doc/auto_tutorials/
 doc/modules/generated/
 doc/sphinxext/cachedir
+tutorials/misc/report.h5
 pip-log.txt
 .coverage*
 tags

--- a/doc/carousel.inc
+++ b/doc/carousel.inc
@@ -14,7 +14,7 @@
         <div class="carousel-inner">
 
           <div class="item active">
-            <div class="chopper container" style="background-image: url(_images/sphx_glr_plot_mne_dspm_source_localization_009.png)" title="dSPM">
+            <div class="chopper container" style="background-image: url(_images/sphx_glr_plot_mne_dspm_source_localization_008.png)" title="dSPM">
               <div class="carousel-caption">
                 <h3>Source estimation</h3>
                 <p>Distributed, sparse, mixed-norm, beamformers, dipole fitting, and more.

--- a/examples/forward/plot_left_cerebellum_volume_source.py
+++ b/examples/forward/plot_left_cerebellum_volume_source.py
@@ -50,21 +50,18 @@ fig = mne.viz.plot_alignment(subject=subject, subjects_dir=subjects_dir,
 mne.viz.set_3d_view(fig, azimuth=173.78, elevation=101.75,
                     distance=0.30, focalpoint=(-0.03, -0.01, 0.03))
 
-##############################################################################
-# Compare volume source locations to segmentation file in freeview
 
-# Export source positions to nift file
-nii_fname = data_path + '/MEG/sample/mne_sample_lh-cerebellum-cortex.nii'
-
-src.export_volume(nii_fname, mri_resolution=True)
-
-# Uncomment the following lines to display source positions in freeview.
-'''
-# display image in freeview
-from mne.utils import run_subprocess
-mri_fname = subjects_dir + '/sample/mri/brain.mgz'
-run_subprocess(['freeview', '-v', mri_fname, '-v',
-                '%s:colormap=lut:opacity=0.5' % aseg_fname, '-v',
-                '%s:colormap=jet:colorscale=0,2' % nii_fname, '-slice',
-                '157 75 105'])
-'''
+###############################################################################
+# You can export source positions to a NIfTI file::
+#
+#     >>> nii_fname = 'mne_sample_lh-cerebellum-cortex.nii'
+#     >>> src.export_volume(nii_fname, mri_resolution=True)
+#
+# And display source positions in freeview::
+#
+#    >>> from mne.utils import run_subprocess
+#    >>> mri_fname = subjects_dir + '/sample/mri/brain.mgz'
+#    >>> run_subprocess(['freeview', '-v', mri_fname, '-v',
+#                        '%s:colormap=lut:opacity=0.5' % aseg_fname, '-v',
+#                        '%s:colormap=jet:colorscale=0,2' % nii_fname,
+#                        '-slice', '157 75 105'])

--- a/examples/inverse/plot_covariance_whitening_dspm.py
+++ b/examples/inverse/plot_covariance_whitening_dspm.py
@@ -1,4 +1,7 @@
 """
+
+.. _ex-covariance-whitening-dspm:
+
 ===================================================
 Demonstrate impact of whitening on source estimates
 ===================================================

--- a/examples/inverse/plot_custom_inverse_solver.py
+++ b/examples/inverse/plot_custom_inverse_solver.py
@@ -36,7 +36,7 @@ condition = 'Left Auditory'
 noise_cov = mne.read_cov(cov_fname)
 # Handling average file
 evoked = mne.read_evokeds(ave_fname, condition=condition, baseline=(None, 0))
-evoked.crop(tmin=0.04, tmax=0.18, verbose='error')  # ignore baseline
+evoked.crop(tmin=0.04, tmax=0.18)
 
 evoked = evoked.pick_types(eeg=False, meg=True)
 # Handling forward solution

--- a/examples/inverse/plot_mixed_norm_inverse.py
+++ b/examples/inverse/plot_mixed_norm_inverse.py
@@ -36,7 +36,7 @@ cov = mne.read_cov(cov_fname)
 # Handling average file
 condition = 'Left Auditory'
 evoked = mne.read_evokeds(ave_fname, condition=condition, baseline=(None, 0))
-evoked.crop(tmin=0, tmax=0.3, verbose='error')  # ignore baseline
+evoked.crop(tmin=0, tmax=0.3)
 # Handling forward solution
 forward = mne.read_forward_solution(fwd_fname)
 

--- a/examples/inverse/plot_multidict_reweighted_tfmxne.py
+++ b/examples/inverse/plot_multidict_reweighted_tfmxne.py
@@ -56,7 +56,7 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                     reject=reject, preload=True)
 evoked = epochs.filter(1, None).average()
 evoked = evoked.pick_types(meg=True)
-evoked.crop(tmin=0.008, tmax=0.2, verbose='error')  # ignore baseline
+evoked.crop(tmin=0.008, tmax=0.2)
 
 # Compute noise covariance matrix
 cov = mne.compute_covariance(epochs, rank='info', tmax=0.)
@@ -85,8 +85,8 @@ dipoles, residual = tf_mixed_norm(
 # Crop to remove edges
 for dip in dipoles:
     dip.crop(tmin=-0.05, tmax=0.3)
-evoked.crop(tmin=-0.05, tmax=0.3, verbose='error')
-residual.crop(tmin=-0.05, tmax=0.3, verbose='error')
+evoked.crop(tmin=-0.05, tmax=0.3)
+residual.crop(tmin=-0.05, tmax=0.3)
 
 
 ###############################################################################

--- a/examples/inverse/plot_rap_music.py
+++ b/examples/inverse/plot_rap_music.py
@@ -37,7 +37,7 @@ condition = 'Right Auditory'
 evoked = mne.read_evokeds(evoked_fname, condition=condition,
                           baseline=(None, 0))
 # select N100
-evoked.crop(tmin=0.05, tmax=0.15, verbose='error')  # ignore baseline
+evoked.crop(tmin=0.05, tmax=0.15)
 
 evoked.pick_types(meg=True, eeg=False)
 

--- a/examples/inverse/plot_vector_mne_solution.py
+++ b/examples/inverse/plot_vector_mne_solution.py
@@ -1,4 +1,7 @@
 """
+
+.. _ex-vector-mne-solution:
+
 ============================================
 Plotting the full vector-valued MNE solution
 ============================================

--- a/examples/visualization/montage.py
+++ b/examples/visualization/montage.py
@@ -6,7 +6,7 @@ Plotting sensor layouts of EEG systems
 ======================================
 
 This example illustrates how to load all the EEG system montages
-shipped in MNE-python, and display it on fsaverage template.
+shipped in MNE-python, and display it on the fsaverage template subject.
 """  # noqa: D205, D400
 # Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #          Joan Massich <mailsik@gmail.com>

--- a/examples/visualization/plot_make_report.py
+++ b/examples/visualization/plot_make_report.py
@@ -38,7 +38,7 @@ report.parse_folder(meg_path, on_error='ignore', mri_decim=10)
 # Load the evoked data
 evoked = read_evokeds(evoked_fname, condition='Left Auditory',
                       baseline=(None, 0), verbose=False)
-evoked.crop(0, .2, verbose='error')   # ignore baseline
+evoked.crop(0, .2)
 times = evoked.times[::4]
 # Create a list of figs for the slider
 figs = list()

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1609,8 +1609,8 @@ def _prep_fine_cal(info, fine_cal):
     from ._fine_cal import read_fine_calibration
     _validate_type(fine_cal, (dict, 'path-like'))
     if not isinstance(fine_cal, dict):
-        fine_cal = read_fine_calibration(fine_cal)
         extra = op.basename(str(fine_cal))
+        fine_cal = read_fine_calibration(fine_cal)
     else:
         extra = 'dict'
     logger.info(f'    Using fine calibration {extra}')

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -643,9 +643,13 @@ def test_fine_calibration():
 
     # Test 1D SSS fine calibration
     with use_coil_def(elekta_def_fname):
-        raw_sss = maxwell_filter(raw, calibration=fine_cal_fname,
-                                 origin=mf_head_origin, regularize=None,
-                                 bad_condition='ignore')
+        with catch_logging() as log:
+            raw_sss = maxwell_filter(raw, calibration=fine_cal_fname,
+                                     origin=mf_head_origin, regularize=None,
+                                     bad_condition='ignore', verbose=True)
+    log = log.getvalue()
+    assert 'Using fine calibration' in log
+    assert op.basename(fine_cal_fname) in log
     assert_meg_snr(raw_sss, sss_fine_cal, 82, 611)
     py_cal = raw_sss.info['proc_history'][0]['max_info']['sss_cal']
     assert (py_cal is not None)

--- a/tutorials/intro/plot_40_sensor_locations.py
+++ b/tutorials/intro/plot_40_sensor_locations.py
@@ -223,8 +223,7 @@ mne.viz.set_3d_view(fig, azimuth=50, elevation=90, distance=0.5)
 # keywords like ``'head'``, ``'outer_skull'``, or ``'brain'`` to the
 # ``surfaces`` parameter) making it useful for :ref:`assessing coordinate frame
 # transformations <plot_source_alignment>`. For examples of various uses of
-# :func:`~mne.viz.plot_alignment`, see
-# :doc:`../../auto_examples/visualization/plot_montage`,
+# :func:`~mne.viz.plot_alignment`, see :ref:`plot_montage`,
 # :doc:`../../auto_examples/visualization/plot_eeg_on_scalp`, and
 # :doc:`../../auto_examples/visualization/plot_meg_sensors`.
 #

--- a/tutorials/misc/plot_report.py
+++ b/tutorials/misc/plot_report.py
@@ -70,7 +70,7 @@ import mne
 path = mne.datasets.sample.data_path(verbose=False)
 report = mne.Report(verbose=True)
 report.parse_folder(path, pattern='*raw.fif', render_bem=False)
-report.save('report_basic.html')
+report.save('report_basic.html', overwrite=True)
 
 ###############################################################################
 # This report yields a textual summary of the :class:`~mne.io.Raw` files
@@ -85,7 +85,7 @@ report.save('report_basic.html')
 pattern = 'sample_audvis_filt-0-40_raw.fif'
 report = mne.Report(raw_psd=True, projs=True, verbose=True)
 report.parse_folder(path, pattern=pattern, render_bem=False)
-report.save('report_raw_psd.html')
+report.save('report_raw_psd.html', overwrite=True)
 
 ###############################################################################
 # The sample dataset also contains SSP projectors stored as *individual files*.
@@ -98,7 +98,7 @@ info_fname = os.path.join(path, 'MEG', 'sample',
 pattern = 'sample_audvis_*proj.fif'
 report = mne.Report(info_fname=info_fname, verbose=True)
 report.parse_folder(path, pattern=pattern, render_bem=False)
-report.save('report_proj.html')
+report.save('report_proj.html', overwrite=True)
 
 ###############################################################################
 # This time we'll pass a specific ``subject`` and ``subjects_dir`` (even though
@@ -111,7 +111,7 @@ report.save('report_proj.html')
 subjects_dir = os.path.join(path, 'subjects')
 report = mne.Report(subject='sample', subjects_dir=subjects_dir, verbose=True)
 report.parse_folder(path, pattern='', mri_decim=25)
-report.save('report_mri_bem.html')
+report.save('report_mri_bem.html', overwrite=True)
 
 ###############################################################################
 # Now let's look at how :class:`~mne.Report` handles :class:`~mne.Evoked` data
@@ -122,7 +122,7 @@ report.save('report_mri_bem.html')
 pattern = 'sample_audvis-no-filter-ave.fif'
 report = mne.Report(verbose=True)
 report.parse_folder(path, pattern=pattern, render_bem=False)
-report.save('report_evoked.html')
+report.save('report_evoked.html', overwrite=True)
 
 ###############################################################################
 # You have probably noticed that the EEG recordings look particularly odd. This
@@ -142,7 +142,7 @@ baseline = (None, 0)
 pattern = 'sample_audvis-no-filter-ave.fif'
 report = mne.Report(baseline=baseline, verbose=True)
 report.parse_folder(path, pattern=pattern, render_bem=False)
-report.save('report_evoked_baseline.html')
+report.save('report_evoked_baseline.html', overwrite=True)
 
 ###############################################################################
 # To render whitened :class:`~mne.Evoked` files with baseline correction, pass
@@ -154,7 +154,7 @@ cov_fname = os.path.join(path, 'MEG', 'sample', 'sample_audvis-cov.fif')
 baseline = (None, 0)
 report = mne.Report(cov_fname=cov_fname, baseline=baseline, verbose=True)
 report.parse_folder(path, pattern=pattern, render_bem=False)
-report.save('report_evoked_whitened.html')
+report.save('report_evoked_whitened.html', overwrite=True)
 
 ###############################################################################
 # If you want to actually *view* the noise covariance in the report, make sure
@@ -168,7 +168,7 @@ pattern = 'sample_audvis-cov.fif'
 info_fname = os.path.join(path, 'MEG', 'sample', 'sample_audvis-ave.fif')
 report = mne.Report(info_fname=info_fname, verbose=True)
 report.parse_folder(path, pattern=pattern, render_bem=False)
-report.save('report_cov.html')
+report.save('report_cov.html', overwrite=True)
 
 ###############################################################################
 # Adding custom plots to a report
@@ -188,7 +188,7 @@ fig = evoked.plot(show=False)
 
 # add the custom plot to the report:
 report.add_figs_to_section(fig, captions='Left Auditory', section='evoked')
-report.save('report_custom.html')
+report.save('report_custom.html', overwrite=True)
 
 ###############################################################################
 # Managing report sections
@@ -231,7 +231,7 @@ with mne.open_report('report.h5') as report:
                                captions='Left Auditory',
                                section='evoked',
                                replace=True)
-    report.save('report_final.html')
+    report.save('report_final.html', overwrite=True)
 
 ###############################################################################
 # With the context manager, the updated report is also automatically saved

--- a/tutorials/source-modeling/plot_beamformer_lcmv.py
+++ b/tutorials/source-modeling/plot_beamformer_lcmv.py
@@ -66,8 +66,8 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax,
                     baseline=(None, 0), preload=True, proj=proj,
                     reject=dict(grad=4000e-13, mag=4e-12, eog=150e-6))
 
-# for speed purposes, cut to a window of interest (ignore baseline, etc.)
-evoked = epochs.average().crop(0.05, 0.15, verbose='error')
+# for speed purposes, cut to a window of interest
+evoked = epochs.average().crop(0.05, 0.15)
 
 # Visualize averaged sensor space data
 evoked.plot_joint()

--- a/tutorials/source-modeling/plot_compute_covariance.py
+++ b/tutorials/source-modeling/plot_compute_covariance.py
@@ -173,7 +173,8 @@ evoked_meg.plot_white([noise_cov_baseline, noise_cov], time_unit='s')
 
 ##############################################################################
 # Based on the negative log-likelihood, the baseline covariance
-# seems more appropriate.
+# seems more appropriate. See :ref:`ex-covariance-whitening-dspm` for more
+# information.
 
 ###############################################################################
 # References

--- a/tutorials/source-modeling/plot_dipole_fit.py
+++ b/tutorials/source-modeling/plot_dipole_fit.py
@@ -37,7 +37,7 @@ evoked = mne.read_evokeds(fname_ave, condition='Right Auditory',
                           baseline=(None, 0))
 evoked.pick_types(meg=True, eeg=False)
 evoked_full = evoked.copy()
-evoked.crop(0.07, 0.08, verbose='error')  # ignore baseline
+evoked.crop(0.07, 0.08)
 
 # Fit a dipole
 dip = mne.fit_dipole(evoked, fname_cov, fname_bem, fname_trans)[0]

--- a/tutorials/source-modeling/plot_forward.py
+++ b/tutorials/source-modeling/plot_forward.py
@@ -198,7 +198,7 @@ bem = mne.make_bem_solution(model)
 # parameter.
 
 fwd = mne.make_forward_solution(raw_fname, trans=trans, src=src, bem=bem,
-                                meg=True, eeg=False, mindist=5.0, n_jobs=2,
+                                meg=True, eeg=False, mindist=5.0, n_jobs=1,
                                 verbose=True)
 print(fwd)
 

--- a/tutorials/source-modeling/plot_mne_dspm_source_localization.py
+++ b/tutorials/source-modeling/plot_mne_dspm_source_localization.py
@@ -8,8 +8,6 @@ The aim of this tutorial is to teach you how to compute and apply a linear
 minimum-norm inverse method on evoked/raw/epochs data.
 """
 
-# sphinx_gallery_thumbnail_number = 10
-
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -57,20 +55,25 @@ evoked.plot(time_unit='s')
 evoked.plot_topomap(times=np.linspace(0.05, 0.15, 5), ch_type='mag',
                     time_unit='s')
 
-# Show whitening:
-evoked.plot_white(noise_cov, time_unit='s')
+###############################################################################
+# It's also a good idea to look at whitened data:
 
+evoked.plot_white(noise_cov, time_unit='s')
 del epochs, raw  # to save memory
 
 ###############################################################################
 # Inverse modeling: MNE/dSPM on evoked and raw data
 # -------------------------------------------------
+# Here we first read the forward solution. You will likely need to compute
+# one for your own data -- see :ref:`tut-forward` for information on how
+# to do it.
 
-# Read the forward solution and compute the inverse operator
 fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-oct-6-fwd.fif'
 fwd = mne.read_forward_solution(fname_fwd)
 
-# make an MEG inverse operator
+###############################################################################
+# Next, we make an MEG inverse operator.
+
 inverse_operator = make_inverse_operator(
     evoked.info, fwd, noise_cov, loose=0.2, depth=0.8)
 del fwd
@@ -84,6 +87,8 @@ del fwd
 ###############################################################################
 # Compute inverse solution
 # ------------------------
+# We can use this to compute the inverse solution and obtain source time
+# courses:
 
 method = "dSPM"
 snr = 3.
@@ -95,7 +100,7 @@ stc, residual = apply_inverse(evoked, inverse_operator, lambda2,
 ###############################################################################
 # Visualization
 # -------------
-# View activation time-series
+# We can look at different dipole activations:
 
 fig, ax = plt.subplots()
 ax.plot(1e3 * stc.times, stc.data[::100, :].T)
@@ -116,6 +121,8 @@ residual.plot(axes=axes)
 # Here we use peak getter to move visualization to the time point of the peak
 # and draw a marker at the maximum peak vertex.
 
+# sphinx_gallery_thumbnail_number = 8
+
 vertno_max, time_max = stc.get_peak(hemi='rh')
 
 subjects_dir = data_path + '/subjects'
@@ -130,46 +137,14 @@ brain.add_text(0.1, 0.9, 'dSPM (plus location of maximal activation)', 'title',
                font_size=14)
 
 ###############################################################################
-# Morph data to average brain
-# ---------------------------
-# Next we morph data to ``fsaverage``.
-
-# setup source morph
-morph = mne.compute_source_morph(
-    src=inverse_operator['src'], subject_from=stc.subject,
-    subject_to='fsaverage', spacing=5,  # to ico-5
-    subjects_dir=subjects_dir)
-# morph data
-stc_fsaverage = morph.apply(stc)
-del stc
-
-brain = stc_fsaverage.plot(**surfer_kwargs)
-brain.add_text(0.1, 0.9, 'Morphed to fsaverage', 'title', font_size=20)
-del stc_fsaverage
-
-###############################################################################
-# Dipole orientations
-# -------------------
-# The ``pick_ori`` parameter of the
-# :func:`mne.minimum_norm.apply_inverse` function controls
-# the orientation of the dipoles. One useful setting is ``pick_ori='vector'``,
-# which will return an estimate that does not only contain the source power at
-# each dipole, but also the orientation of the dipoles.
-
-stc_vec = apply_inverse(evoked, inverse_operator, lambda2,
-                        method=method, pick_ori='vector')
-brain = stc_vec.plot(**surfer_kwargs)
-brain.add_text(0.1, 0.9, 'Vector solution', 'title', font_size=20)
-del stc_vec
-
-###############################################################################
-# Note that there is a relationship between the orientation of the dipoles and
-# the surface of the cortex. For this reason, we do not use an inflated
-# cortical surface for visualization, but the original surface used to define
-# the source space.
+# There are many other ways to visualize and work with source data, see
+# for example:
 #
-# For more information about dipole orientations, see
-# :ref:`tut-dipole-orientations`. To see outputs using different methods, see
-# :ref:`tut-mne-fixed-free`. For other examples using evoked data, see
-# :ref:`examples using apply_inverse
-# <sphx_glr_backreferences_mne.minimum_norm.apply_inverse>`.
+# - :ref:`tut-viz-stcs`
+# - :ref:`ex-morph-surface`
+# - :ref:`ex-morph-volume`
+# - :ref:`ex-vector-mne-solution`
+# - :ref:`tut-dipole-orientations`
+# - :ref:`tut-mne-fixed-free`
+# - :ref:`examples using apply_inverse
+#   <sphx_glr_backreferences_mne.minimum_norm.apply_inverse>`.

--- a/tutorials/source-modeling/plot_mne_solutions.py
+++ b/tutorials/source-modeling/plot_mne_solutions.py
@@ -30,8 +30,8 @@ fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-oct-6-fwd.fif'
 fname_cov = data_path + '/MEG/sample/sample_audvis-cov.fif'
 fwd = mne.read_forward_solution(fname_fwd)
 cov = mne.read_cov(fname_cov)
-# crop for speed in these examples, and ignore a baseline warning
-evoked.crop(0.05, 0.15, verbose='error')
+# crop for speed in these examples
+evoked.crop(0.05, 0.15)
 
 ###############################################################################
 # Fixed orientation

--- a/tutorials/source-modeling/plot_visualize_stc.py
+++ b/tutorials/source-modeling/plot_visualize_stc.py
@@ -1,5 +1,5 @@
 """
-.. _tut_viz_stcs:
+.. _tut-viz-stcs:
 
 Visualize source time courses (stcs)
 ====================================
@@ -67,7 +67,6 @@ brain = stc_fs.plot(subjects_dir=subjects_dir, initial_time=initial_time,
                         colorbar_kwargs=dict(label_font_size=10)))
 
 ###############################################################################
-#
 # Note that here we used ``initial_time=0.1``, but we can also browse through
 # time using ``time_viewer=True``.
 #
@@ -86,8 +85,7 @@ mpl_fig = stc.plot(subjects_dir=subjects_dir, initial_time=initial_time,
 # Let us load the sensor-level evoked data. We select the MEG channels
 # to keep things simple.
 evoked = read_evokeds(fname_evoked, condition=0, baseline=(None, 0))
-evoked.pick_types(meg=True, eeg=False).crop(
-    0.05, 0.15, verbose='error')  # 'error' here: ignore cutting off baseline
+evoked.pick_types(meg=True, eeg=False).crop(0.05, 0.15)
 # this risks aliasing, but these data are very smooth
 evoked.decimate(10, verbose='error')
 

--- a/tutorials/stats-source-space/plot_stats_cluster_time_frequency_repeated_measures_anova.py
+++ b/tutorials/stats-source-space/plot_stats_cluster_time_frequency_repeated_measures_anova.py
@@ -156,7 +156,7 @@ for effect, sig, effect_label in zip(fvals, pvals, effect_labels):
                times[-1], freqs[0], freqs[-1]], aspect='auto',
                origin='lower')
     # create mask for significant Time-frequency locations
-    effect = np.ma.masked_array(effect, [sig > .05])
+    effect[sig >= 0.05] = np.nan
     plt.imshow(effect.reshape(8, 211), cmap='RdBu_r', extent=[times[0],
                times[-1], freqs[0], freqs[-1]], aspect='auto',
                origin='lower')
@@ -203,8 +203,8 @@ T_obs, clusters, cluster_p_values, h0 = mne.stats.permutation_cluster_test(
 # Create new stats image with only significant clusters:
 
 good_clusters = np.where(cluster_p_values < .05)[0]
-T_obs_plot = np.ma.masked_array(T_obs,
-                                np.invert(clusters[np.squeeze(good_clusters)]))
+T_obs_plot = T_obs.copy()
+T_obs_plot[~clusters[np.squeeze(good_clusters)]] = np.nan
 
 plt.figure()
 for f_image, cmap in zip([T_obs, T_obs_plot], [plt.cm.gray, 'RdBu_r']):
@@ -221,10 +221,13 @@ plt.show()
 # Now using FDR:
 
 mask, _ = fdr_correction(pvals[2])
-T_obs_plot2 = np.ma.masked_array(T_obs, np.invert(mask))
+T_obs_plot2 = T_obs.copy()
+T_obs_plot2[~mask.reshape(T_obs_plot.shape)] = np.nan
 
 plt.figure()
 for f_image, cmap in zip([T_obs, T_obs_plot2], [plt.cm.gray, 'RdBu_r']):
+    if np.isnan(f_image).all():
+        continue  # nothing to show
     plt.imshow(f_image, cmap=cmap, extent=[times[0], times[-1],
                freqs[0], freqs[-1]], aspect='auto',
                origin='lower')


### PR DESCRIPTION
Another round. This time I cut down `plot_mne_dspm_source_localization` to deduplicate its content with other examples/tutorials, and removed a bunch of `verbose='error'`s that we no longer need.