### PR TITLE
MRG: ENH: Nicer platform string on macOS w/Python < 3.8

### DIFF
--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -493,8 +493,11 @@ def sys_info(fid=None, show_paths=False):
         # platform.mac_ver() if we're on Darwin, so we don't get a nice macOS
         # version number. Therefore, let's do this manually here.
         macos_ver = platform.mac_ver()[0]
-        macos_architecture = re.match('Darwin-.*?-(.*)', platform_str)[1]
-        platform_str = f'macOS-{macos_ver}-{macos_architecture}'
+        macos_architecture = re.findall('Darwin-.*?-(.*)', platform_str)
+        if macos_architecture:
+            macos_architecture = macos_architecture[0]
+            platform_str = f'macOS-{macos_ver}-{macos_architecture}'
+        del macos_ver, macos_architecture
 
     out = 'Platform:'.ljust(ljust) + platform_str + '\n'
     out += 'Python:'.ljust(ljust) + str(sys.version).replace('\n', ' ') + '\n'

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -13,6 +13,7 @@ import platform
 import shutil
 import sys
 import tempfile
+import re
 
 import numpy as np
 
@@ -486,7 +487,16 @@ def sys_info(fid=None, show_paths=False):
         PyQt5:         5.15.0
     """  # noqa: E501
     ljust = 15
-    out = 'Platform:'.ljust(ljust) + platform.platform() + '\n'
+    platform_str = platform.platform()
+    if platform.system() == 'Darwin' and sys.version_info[:2] < (3, 8):
+        # platform.system() in Python < 3.8 doesn't call
+        # platform.mac_ver() if we're on Darwin, so we don't get a nice macOS
+        # version number. Therefore, let's do this manually here.
+        macos_ver = platform.mac_ver()[0]
+        macos_architecture = re.match('Darwin-.*?-(.*)', platform_str)[1]
+        platform_str = f'macOS-{macos_ver}-{macos_architecture}'
+
+    out = 'Platform:'.ljust(ljust) + platform_str + '\n'
     out += 'Python:'.ljust(ljust) + str(sys.version).replace('\n', ' ') + '\n'
     out += 'Executable:'.ljust(ljust) + sys.executable + '\n'
     out += 'CPU:'.ljust(ljust) + ('%s: ' % platform.processor())

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -489,7 +489,7 @@ def sys_info(fid=None, show_paths=False):
     ljust = 15
     platform_str = platform.platform()
     if platform.system() == 'Darwin' and sys.version_info[:2] < (3, 8):
-        # platform.system() in Python < 3.8 doesn't call
+        # platform.platform() in Python < 3.8 doesn't call
         # platform.mac_ver() if we're on Darwin, so we don't get a nice macOS
         # version number. Therefore, let's do this manually here.
         macos_ver = platform.mac_ver()[0]

--- a/mne/utils/tests/test_config.py
+++ b/mne/utils/tests/test_config.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import platform
 import pytest
 from pathlib import Path

--- a/mne/utils/tests/test_config.py
+++ b/mne/utils/tests/test_config.py
@@ -1,4 +1,6 @@
 import os
+import sys
+import platform
 import pytest
 from pathlib import Path
 
@@ -83,3 +85,6 @@ def test_sys_info():
     sys_info(fid=out)
     out = out.getvalue()
     assert ('numpy:' in out)
+
+    if platform.system() == 'Darwin':
+        assert 'Platform:      macOS-' in out


### PR DESCRIPTION
#### What does this implement/fix?

Python 3.8's `platform.platform()` automatically maps the Darwin version to the correct macOS version, which is typically what we want in `sys_info()`. Make things consistent (and more useful) across all supported Python versions by  doing this mapping manually on Python <3.8.

`master` on Py3.6:
```
In [2]: mne.sys_info()
Platform:      Darwin-19.6.0-x86_64-i386-64bit
```
`master` on Py3.8:
```
Platform:      macOS-10.15.6-x86_64-i386-64bit
```
-----------

PR branch on on Py3.6:
```
Platform:      macOS-10.15.6-x86_64-i386-64bit
```
PR branch on Py3.8:
```
Platform:      macOS-10.15.6-x86_64-i386-64bit
```
