### PR TITLE
MRG, FIX: Fix single handling

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -20,8 +20,7 @@ Enhancements
 Bugs
 ~~~~
 
-- ...
-
+- Fix bug with :func:`mne.viz.plot_source_estimates` when using the PyVista backend where singleton time points were not handled properly, by `Eric Larson`_
 
 API changes
 ~~~~~~~~~~~

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1702,7 +1702,7 @@ def _safe_interp1d(x, y, kind='linear', axis=-1, assume_sorted=False):
     from scipy.interpolate import interp1d
     if y.shape[axis] == 1:
         def func(x):
-            return y.copy()
+            return np.take(y, np.zeros(np.asarray(x).shape, int), axis=axis)
         return func
     else:
         return interp1d(x, y, kind, axis=axis, assume_sorted=assume_sorted)

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -311,6 +311,7 @@ def test_brain_timeviewer_traces(renderer_interactive, hemi, src, tmpdir):
     brain_data = _create_testing_brain(
         hemi=hemi, surf='white', src=src, show_traces=0.5, initial_time=0,
         volume_options=None,  # for speed, don't upsample
+        n_time=1 if src == 'mixed' else 5,
     )
     with pytest.raises(RuntimeError, match='already'):
         _TimeViewer(brain_data)
@@ -550,7 +551,7 @@ def test_brain_colormap():
 
 
 def _create_testing_brain(hemi, surf='inflated', src='surface', size=300,
-                          **kwargs):
+                          n_time=5, **kwargs):
     assert src in ('surface', 'mixed', 'volume')
     meth = 'plot'
     if src in ('surface', 'mixed'):
@@ -574,7 +575,6 @@ def _create_testing_brain(hemi, surf='inflated', src='surface', size=300,
     # dense version
     rng = np.random.RandomState(0)
     vertices = [s['vertno'] for s in sample_src]
-    n_time = 5
     n_verts = sum(len(v) for v in vertices)
     stc_data = np.zeros((n_verts * n_time))
     stc_size = stc_data.size


### PR DESCRIPTION
Fixes errors of the form:
```
mne/viz/_brain/_brain.py:564: in add_data
    self.set_data_smoothing(self._data['smoothing_steps'])
mne/viz/_brain/_brain.py:1270: in set_data_smoothing
    self.set_time_point(self._data['time_idx'])
mne/viz/_brain/_brain.py:1346: in set_time_point
    grid.cell_arrays['values'][vertices] = values
../pyvista/pyvista/core/pyvista_ndarray.py:43: in __setitem__
    super().__setitem__(key, value)
E   ValueError: shape mismatch: value array of shape (150,1) could not be broadcast to indexing result of shape (150,)
```