### PR TITLE
BUG: Fix version on landing page

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -508,21 +508,40 @@ img.institution {
   max-height: 42px;
   max-width: 52px;
 }
+img.logo {
+  max-width: 360px;
+  width: 100%;
+}
 div.border-top {
   border-top: 1px solid #ccc;
 }
 .hidden {
   display: none;
 }
-.funding {
-  font-size: 12px;
+ul.list-funding {
+  padding-left: 0;
+  list-style: none;
 }
-.funding li {
+ul.list-funding li {
   padding-left: 28px;
   margin-top: 0px;
   margin-bottom: 8px;
   min-height: 24px;
-} /* Pandas DataFrame _repr_html_ */
+}
+ul.list-funding li img {
+  float: left;
+  position: relative;
+  left: -28px;
+  top: 0px;
+  width: 24px;
+  margin: 0px -24px 0px 0px;
+  clear: both;
+}
+ul.list-funding li p {
+  font-size: 12px;
+  margin-bottom: 0px;
+}
+/* Pandas DataFrame _repr_html_ */
 table.dataframe th,
 td {
   padding: 5px;
@@ -557,5 +576,9 @@ div[id^="examples-using-"] h2 {
 }
 /* Avoid awkward extra spacing in .. contents:: */
 div.contents ul li p {
+  margin: 0 0 0px;
+}
+/* Avoid extra spacing in our nested version */
+h3.panel-title p {
   margin: 0 0 0px;
 }

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,13 +5,18 @@
 
   <div class="col-xs-12 col-md-9 jumbotron align-center">
     <div class="col-xs-12 nopad">
-      <img src="_static/mne_logo.svg" style="max-width: 360px; width: 100%" alt="MNE">
-      <p>
-      Open-source Python package for exploring, visualizing, and
-      analyzing human neurophysiological data: MEG, EEG, sEEG, ECoG, NIRS, and more.
-      </p>
-    </div>
-    <div class="col-xs-12 nopad">
+
+.. image:: _static/mne_logo.svg
+   :alt: MNE
+   :class: logo
+   :align: center
+
+Open-source Python package for exploring, visualizing, and
+analyzing human neurophysiological data: MEG, EEG, sEEG, ECoG, NIRS, and more.
+
+.. raw:: html
+
+    </div><div class="col-xs-12 nopad">
 
 .. carousel
 .. include:: carousel.inc
@@ -26,13 +31,21 @@
 
   <div class="col-xs-12 col-sm-6 col-md-3">
     <div class="panel panel-default">
-      <div class="panel-heading"><h3 class="panel-title">Version 0.22.dev0</h3></div>
-      <div class="panel-body">
-        <ul>
-        <li><a href="whats_new.html">What's new</a></li>
-        <li><a href="install/mne_python.html">Installation</a></li>
-        <li><a href="overview/index.html">Documentation</a></li>
-        <li><a href="overview/cite.html">Cite</a></li>
+      <div class="panel-heading"><h3 class="panel-title">
+
+Version |version|
+
+.. raw:: html
+
+      </h3></div><div class="panel-body">
+
+- :ref:`whats_new`
+- :ref:`Installation <install_python_and_mne_python>`
+- :ref:`Documentation <documentation_overview>`
+- :ref:`Cite <cite>`
+
+.. raw:: html
+
       </div>
     </div>
   </div>
@@ -42,19 +55,41 @@
 
   <div class="col-xs-12 col-sm-6 col-md-3">
     <div class="panel panel-default">
-      <div class="panel-heading"><h3 class="panel-title">Direct financial support</h3></div>
-      <div class="panel-body funding">
-        <ul class="list-unstyled">
-          <li style="background: url('_static/funding/nih.png') no-repeat left top; background-size: 24px 24px;"> <b>National Institutes of Health:</b> <b>R01</b>-EB009048, EB009048, EB006385, HD40712, NS44319, NS37462, NS104585, <b>P41</b>-EB015896, RR14075-06</li>
-          <li style="background: url('_static/funding/nsf.png') no-repeat left top; background-size: 24px 24px;"><b>US National Science Foundation:</b> 0958669, 1042134</li>
-          <li style="background: url('_static/funding/erc.svg') no-repeat left top; background-size: 24px 24px;"><b>European Research Council:</b> <b>YStG</b>-263584, 676943</li>
-          <li style="background: url('_static/funding/doe.svg') no-repeat left top; background-size: 24px 24px;"><b>US Department of Energy:</b> DE-FG02-99ER62764 (MIND)</li>
-          <li style="background: url('_static/funding/anr.svg') no-repeat left top; background-size: 24px 10px;"><b>Agence Nationale de la Recherche:</b> 14-NEUC-0002-01<br><b>IDEX</b> Paris-Saclay, 11-IDEX-0003-02</li>
-          <li style="background: url('_static/funding/cds.png') no-repeat left top; background-size: 24px 24px;"><b>Paris-Saclay Center for Data Science:</b> <a href="http://www.datascience-paris-saclay.fr"/>PARIS-SACLAY</a></li>
-          <li style="background: url('_static/funding/google.svg') no-repeat left top; background-size: 24px 24px;"><b>Google:</b> Summer of code (×6)</li>
-          <li style="background: url('_static/funding/amazon.svg') no-repeat left top; background-size: 24px 24px;"><b>Amazon:</b> AWS Research Grants</li>
-          <li style="background: url('_static/funding/czi.svg') no-repeat left top; background-size: 24px 24px;"><b>Chan Zuckerberg Initiative:</b> <a href="https://chanzuckerberg.com/eoss/proposals/improving-usability-of-core-neuroscience-analysis-tools-with-mne-python/">Essential Open Source Software for Science</a></li>
-        </ul>
+      <div class="panel-heading"><h3 class="panel-title">
+
+Direct financial support
+
+.. raw:: html
+
+      </h3></div>
+      <div class="panel-body">
+
+.. rst-class:: list-funding list-unstyled
+
+- |nih| **National Institutes of Health:** **R01**-EB009048, EB009048, EB006385, HD40712, NS44319, NS37462, NS104585, **P41**-EB015896, RR14075-06
+- |nsf| **US National Science Foundation:** 0958669, 1042134
+- |erc| **European Research Council:** **YStG**-263584, 676943
+- |doe| **US Department of Energy:** DE-FG02-99ER62764 (MIND)
+- |anr| **Agence Nationale de la Recherche:** 14-NEUC-0002-01
+
+  **IDEX** Paris-Saclay, 11-IDEX-0003-02
+- |cds| **Paris-Saclay Center for Data Science:** `PARIS-SACLAY <http://www.datascience-paris-saclay.fr>`__
+- |goo| **Google:** Summer of code (×6)
+- |ama| **Amazon:** AWS Research Grants
+- |czi| **Chan Zuckerberg Initiative:** `Essential Open Source Software for Science <https://chanzuckerberg.com/eoss/proposals/improving-usability-of-core-neuroscience-analysis-tools-with-mne-python>`__
+
+.. raw:: html
+
       </div>
     </div>
   </div>
+
+.. |nih| image:: _static/funding/nih.png
+.. |nsf| image:: _static/funding/nsf.png
+.. |erc| image:: _static/funding/erc.svg
+.. |doe| image:: _static/funding/doe.svg
+.. |anr| image:: _static/funding/anr.svg
+.. |cds| image:: _static/funding/cds.png
+.. |goo| image:: _static/funding/google.svg
+.. |ama| image:: _static/funding/amazon.svg
+.. |czi| image:: _static/funding/czi.svg

--- a/doc/overview/index.rst
+++ b/doc/overview/index.rst
@@ -2,6 +2,8 @@
 
 .. include:: ../links.inc
 
+.. _documentation_overview:
+
 Documentation overview
 ======================
 


### PR DESCRIPTION
@rob-luke pointed out that our stable page lists 0.21.dev0 as the version on the right:

![Screenshot from 2020-09-22 08-39-59](https://user-images.githubusercontent.com/2365790/93883228-47a9ad00-fcaf-11ea-9031-f02d43021c8c.png)

This refactors the landing page to use the `|version|` substitution. It also uses more built-in RST to render rather than quite as much `.. raw:: html` which actually makes things a bit cleaner I think (e.g., make our docs slightly better if we ever want to build latex).