### PR TITLE
WIP: Plot Evoked in Report via joint_plot(), not separate time traces and topomaps

### DIFF
--- a/mne/report.py
+++ b/mne/report.py
@@ -1917,7 +1917,6 @@ class Report(object):
 
         html = []
         for ei, ev in enumerate(evokeds):
-            global_id = self._get_id()
             kwargs = dict(show=False)
             logger.debug('Evoked: Plotting instance %s/%s'
                          % (ei + 1, len(evokeds)))
@@ -1934,14 +1933,16 @@ class Report(object):
             for fig_num, fig in enumerate(figs):
                 img = _fig_to_img(fig, image_format)
                 if fig_num == 0:
+                    global_id = self._get_id()
                     caption = self._gen_caption(prefix='Evoked',
                                                 suffix=f'({ev.comment})',
                                                 fname=evoked_fname,
                                                 data_path=data_path)
                 else:
+                    global_id = None
                     caption = None
                 html.append(image_template.substitute(
-                    img=img, id=global_id, div_klass='evoked',
+                    img=img, div_klass='evoked', id=global_id,
                     img_klass='evoked', caption=caption, show=True,
                     image_format=image_format))
 

--- a/mne/report.py
+++ b/mne/report.py
@@ -1926,33 +1926,43 @@ class Report(object):
                     'ignore',
                     message='Channel locations not available.*',
                     category=RuntimeWarning)
-                img = _fig_to_img(ev.plot, image_format, spatial_colors=True,
-                                  **kwargs)
+                figs = ev.plot_joint(times='peaks', **kwargs)
 
-            caption = self._gen_caption(prefix='Evoked',
-                                        suffix=f'({ev.comment})',
-                                        fname=evoked_fname,
-                                        data_path=data_path)
-            html.append(image_template.substitute(
-                img=img, id=global_id, div_klass='evoked',
-                img_klass='evoked', caption=caption, show=True,
-                image_format=image_format))
-            has_types = []
-            if len(pick_types(ev.info, meg=False, eeg=True)) > 0:
-                has_types.append('eeg')
-            if len(pick_types(ev.info, meg='grad', eeg=False,
-                              ref_meg=False)) > 0:
-                has_types.append('grad')
-            if len(pick_types(ev.info, meg='mag', eeg=False)) > 0:
-                has_types.append('mag')
-            for ch_type in has_types:
-                logger.debug('    Topomap type %s' % ch_type)
-                img = _fig_to_img(ev.plot_topomap, image_format,
-                                  ch_type=ch_type, **kwargs)
-                caption = u'Topomap (ch_type = %s)' % ch_type
+            # Plot the figures and only add a caption to the first figure for
+            # each Evoked (as there may be several figures per Evoked if the
+            # data contains more than one channel type).
+            for fig_num, fig in enumerate(figs):
+                img = _fig_to_img(fig, image_format)
+                if fig_num == 0:
+                    caption = self._gen_caption(prefix='Evoked',
+                                                suffix=f'({ev.comment})',
+                                                fname=evoked_fname,
+                                                data_path=data_path)
+                else:
+                    caption = None
                 html.append(image_template.substitute(
-                    img=img, div_klass='evoked', img_klass='evoked',
-                    caption=caption, show=True, image_format=image_format))
+                    img=img, id=global_id, div_klass='evoked',
+                    img_klass='evoked', caption=caption, show=True,
+                    image_format=image_format))
+
+            # Plot topomaps.
+            #
+            # has_types = []
+            # if len(pick_types(ev.info, meg=False, eeg=True)) > 0:
+            #     has_types.append('eeg')
+            # if len(pick_types(ev.info, meg='grad', eeg=False,
+            #                   ref_meg=False)) > 0:
+            #     has_types.append('grad')
+            # if len(pick_types(ev.info, meg='mag', eeg=False)) > 0:
+            #     has_types.append('mag')
+            # for ch_type in has_types:
+            #     logger.debug(f'    Topomap type {ch_type}')
+            #     img = _fig_to_img(ev.plot_topomap, image_format,
+            #                       ch_type=ch_type, times='auto', **kwargs)
+            #     caption = f'Topomap (channel type: {ch_type})'
+            #     html.append(image_template.substitute(
+            #         img=img, div_klass='evoked', img_klass='evoked',
+            #         caption=caption, show=True, image_format=image_format))
 
         # Plot GFP comparison.
         figs = plot_compare_evokeds(evokeds=evokeds, ci=None,

--- a/mne/report.py
+++ b/mne/report.py
@@ -1968,13 +1968,19 @@ class Report(object):
         # Plot GFP comparison.
         figs = plot_compare_evokeds(evokeds=evokeds, ci=None,
                                     show_sensors=True, **kwargs)
-        for fig in figs:
+        for fig_num, fig in enumerate(figs):
             img = _fig_to_img(fig, image_format)
-            caption = self._gen_caption(prefix='Evoked',
-                                        suffix='(GFPs)',
-                                        fname=evoked_fname,
-                                        data_path=data_path)
-            global_id = self._get_id()
+
+            if fig_num == 0:
+                global_id = self._get_id()
+                caption = self._gen_caption(prefix='Evoked',
+                                            suffix='(GFPs)',
+                                            fname=evoked_fname,
+                                            data_path=data_path)
+            else:
+                global_id = None
+                caption = None
+
             html.append(image_template.substitute(
                 img=img, id=global_id, div_klass='evoked',
                 img_klass='evoked', caption=caption, show=True,

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -120,7 +120,6 @@ def test_render_report(renderer, tmpdir):
     assert f'SSP Projectors: {op.basename(proj_fname_new)}' in html
     # Evoked in `evoked_fname`
     assert f'Evoked: {op.basename(evoked_fname)} ({evoked.comment})' in html
-    assert 'Topomap (ch_type =' in html
     assert f'Evoked: {op.basename(evoked_fname)} (GFPs)' in html
 
     assert_equal(len(report.html), len(fnames))


### PR DESCRIPTION
#### What does this implement/fix?

Do not plot time traces and topomaps separately anymore. The joint plots select the GFP peaks for plotting the topomaps, which is a much more useful visualization than what we currently have in `master`.

#### Additional information
I'm leaving the old code in the file (commented out) so we can easily repurpose it later on should we feel like it.

Todo:
- [ ] Touch tutorial so we can see rendered results
- [ ] Ensure non-MEG/EEG channel types are plotted too
