### PR TITLE
WIP: Enable github codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+FROM continuumio/miniconda3
+
+# Options for common setup script
+ARG INSTALL_ZSH="true"
+ARG UPGRADE_PACKAGES="false"
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
+COPY .devcontainer/library-scripts/*.sh /tmp/library-scripts/
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
+# Copy environment_cs.yml (if found) to a temp locaition so we update the environment. Also
+# copy "noop.txt" so the COPY instruction does not fail if no environment_cs.yml exists.
+COPY .devontainer/environment_cs.yml* .devcontainer/noop.txt /tmp/conda-tmp/
+RUN if [ -f "/tmp/conda-tmp/environment_cs.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment_cs.yml; fi \
+    && rm -rf /tmp/conda-tmp
+
+# Install pylint
+RUN /opt/conda/bin/pip install pylint
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/environment_cs.yml
+++ b/.devcontainer/environment_cs.yml
@@ -1,0 +1,41 @@
+name: mne
+channels:
+- defaults
+- conda-forge
+dependencies:
+- python>=3.8
+- pip
+- numpy
+- scipy
+- matplotlib
+- numba
+- pandas
+- xlrd
+- scikit-learn
+- h5py
+- pillow
+- statsmodels
+- jupyter
+- joblib
+- psutil
+- numexpr
+- traits
+- pyface
+- traitsui
+- imageio
+- tqdm
+- spyder-kernels
+- vtk
+- pip:
+  - mne
+  - imageio-ffmpeg>=0.4.1
+  - pyvista>=0.24
+  - pyvistaqt>=0.2.0
+  - PySurfer[save_movie]
+  - dipy --only-binary dipy
+  - nibabel
+  - nilearn
+  - neo
+  - python-picard
+  - PyQt5>=5.10,<5.14; platform_system == "Darwin"
+  - PyQt5>=5.10; platform_system != "Darwin"

--- a/.devcontainer/library-scripts/README.md
+++ b/.devcontainer/library-scripts/README.md
@@ -1,0 +1,5 @@
+# Warning: Folder contents may be replaced
+
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+
+To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/.devcontainer/noop.txt
+++ b/.devcontainer/noop.txt
@@ -1,0 +1,3 @@
+This file is copied into the container along with environment.yml* from the
+parent folder. This is done to prevent the Dockerfile COPY instruction from 
+failing if no environment.yml is found.


### PR DESCRIPTION
#### What does this implement/fix?
As discussed with @larsoner at https://github.com/mne-tools/mne-nirs/pull/165#issuecomment-696710402. This enables a [GitHub codespaces](https://github.com/features/codespaces) python environment with mne.

#### Additional information
I have found this useful for editing code and running tests over at https://github.com/mne-tools/mne-nirs
I made a little gif of how it works below.

![ezgif-3-746e1704a2c7](https://user-images.githubusercontent.com/748691/93999438-28a73a00-fdd9-11ea-8140-85d1854897c7.gif)

I just copied the config over here. It may need specific tweaks to work optimally with MNE. But I thought I would gauge interest before optimising. This is more a coding environment, whereas binder is a notebook. This may be a way to lower the barrier for new coders (or it may just be another complication with more acronyms)