### PR TITLE
MRG, API: prep for to_data_frame default argument change

### DIFF
--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1596,7 +1596,8 @@ time_format : str | None
     remain as float values in seconds. If ``'ms'``, time values will be rounded
     to the nearest millisecond and converted to integers. If ``'timedelta'``,
     time values will be converted to :class:`pandas.Timedelta` values. {}
-    Defaults to ``'ms'``.
+    Default is ``'ms'`` in version 0.22, and will change to ``None`` in
+    version 0.23.
 """
 raw_tf = ("If ``'datetime'``, time values will be converted to "
           ":class:`pandas.Timestamp` values, relative to "


### PR DESCRIPTION
crossref #7206 (especially [this comment](https://github.com/mne-tools/mne-python/pull/7206#issuecomment-581697291))

The goal is to change default from `'ms'` to `None`. In this PR I'm only changing docstring, not raising a warning if the current default is passed.  I suppose I could change the default to `None` and have `None` temporarily mean `'ms'`, and add temporarily a valid argument `'s'` to get the behavior currently intended by `None`, and raise a warning if the value is `None` rather than `'s'` or `'ms'`?  But at least some people have learned that explicitly passing `None` is what they should do (e.g., #8044) so IMO raising a warning in that way would cause more confusion than it might avert.