### PR TITLE
MRG: Fix bug in nirs merge data

### DIFF
--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -977,6 +977,7 @@ def _merge_nirs_data(data, merged_names):
                 indices = np.append(indices, merged_names.index(sub_ch))
             data[idx] = np.mean(data[np.append(idx, indices)], axis=0)
             to_remove = np.append(to_remove, indices)
+    to_remove = np.unique(to_remove)
     for rem in sorted(to_remove, reverse=True):
         del merged_names[rem]
         data = np.delete(data, rem, 0)


### PR DESCRIPTION
#### What does this implement/fix?
The `_merge_nirs_data` function is used in topo plotting and averages channels that are close together for a nicer display. After a channel is merged it is then removed from the data. If the same channel was merged twice, then it was removed twice, but the second time it was removing legitimate data. This would then mean the size of data and pos was incorrect and a nice error was thrown in the following topo function (which made it easy for met to find this bug).  Here I just ensure each channel is only removed once.


#### Additional information
I think this is a candidate for back port. Whats involved in that?

I found this error because I am considering proposing a different distance for merging channels, but that's an enhancement and I will put in another PR. But it means others aren't likely to hit this bug unless they are playing with internal functions.