### PR TITLE
WIP: Use greater distance when defining overlapping nirs channels

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -147,9 +147,9 @@ def _average_fnirs_overlaps(info, ch_type, sphere):
     # Channels to be excluded from picks, as will be removed after merging
     channels_to_exclude = list()
 
-    if len(locs3d) > 1 and np.min(dist) < 1e-10:
+    if len(locs3d) > 1 and np.min(dist) < 0.015:
 
-        overlapping_mask = np.triu(squareform(dist < 1e-10))
+        overlapping_mask = np.triu(squareform(dist < 0.015))
         for chan_idx in range(overlapping_mask.shape[0]):
             already_overlapped = list(itertools.chain.from_iterable(
                 overlapping_channels))


### PR DESCRIPTION
#### What does this implement/fix?
When you have a NIRS recording with lots of very close channels the topomap looks bad. We had code to handle overlapping NIRS channels, but it was for exactly overlapping channels. This extends what's considered overlapping channels to 1.5cm. In NIRS experiments the source and detectors are ideally placed 3cm apart, so I have taken half this value and it looks nice in my figures.

Example of topoplot with existing value (note the small black dots representing channels in little clusters)...

![image](https://user-images.githubusercontent.com/748691/94234888-ee12de00-ff4d-11ea-9bf8-8f39b5484102.png)

And with the new value

![image](https://user-images.githubusercontent.com/748691/94234925-fff48100-ff4d-11ea-99c1-0d81638f04a1.png)


#### Additional information
1.5 cm seems to play nicely with the topographic plotting too. But Im open to other suggested values or perhaps a totally different approach?
