### PR TITLE
MRG: DOC: Better "reject" documentation

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -332,8 +332,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         An instance of Raw.
     %(picks_header)s
         See `Epochs` docstring.
-    reject : dict | None
-        See `Epochs` docstring.
+    %(reject_epochs)s
     flat : dict | None
         See `Epochs` docstring.
     decim : int
@@ -1131,11 +1130,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
 
         Parameters
         ----------
-        reject : dict | str | None
-            Rejection parameters based on peak-to-peak amplitude.
-            Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg'.
-            If reject is None then no rejection is done. If 'existing',
-            then the rejection parameters set at instantiation are used.
+        %(reject_drop_bad)s
         flat : dict | str | None
             Rejection parameters based on flatness of signal.
             Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg', and values
@@ -1940,16 +1935,7 @@ class Epochs(BaseEpochs):
         Load all epochs from disk when creating the object
         or wait before accessing each epoch (more memory
         efficient but can be slower).
-    reject : dict | None
-        Rejection parameters based on peak-to-peak amplitude.
-        Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg'.
-        If reject is None then no rejection is done. Example::
-
-            reject = dict(grad=4000e-13, # T / m (gradiometers)
-                          mag=4e-12, # T (magnetometers)
-                          eeg=40e-6, # V (EEG channels)
-                          eog=250e-6 # V (EOG channels)
-                          )
+    %(reject_epochs)s
     flat : dict | None
         Rejection parameters based on flatness of signal.
         Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg', and values
@@ -2172,17 +2158,7 @@ class EpochsArray(BaseEpochs):
         in the list are used. If None, all events will be used with
         and a dict is created with string integer names corresponding
         to the event id integers.
-    reject : dict | None
-        Rejection parameters based on peak-to-peak amplitude.
-        Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg'.
-        If reject is None then no rejection is done. Example::
-
-            reject = dict(grad=4000e-13, # T / m (gradiometers)
-                          mag=4e-12, # T (magnetometers)
-                          eeg=40e-6, # V (EEG channels)
-                          eog=250e-6 # V (EOG channels)
-                          )
-
+    %(reject_epochs)s
     flat : dict | None
         Rejection parameters based on flatness of signal.
         Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg', and values

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1761,6 +1761,42 @@ docdict['baseline_report'] = """%(rescale_baseline)s
     For `~mne.Epochs`, this algorithm is run **on each epoch individually.**
 """ % docdict
 
+# Epochs
+reject_common = """
+    Reject epochs based on peak-to-peak signal amplitude (PTP), i.e. the
+    absolute difference between the lowest and the highest signal value. In
+    each individual epoch, the PTP is calculated for every channel. If the
+    PTP of any one channel exceeds the rejection threshold, the respective
+    epoch will be dropped.
+
+    The dictionary keys correspond to the different channel types; valid
+    keys are: ``'grad'``, ``'mag'``, ``'eeg'``, ``'eog'``, and ``'ecg'``.
+
+    Example::
+
+        reject = dict(grad=4000e-13,  # unit: T / m (gradiometers)
+                        mag=4e-12,      # unit: T (magnetometers)
+                        eeg=40e-6,      # unit: V (EEG channels)
+                        eog=250e-6      # unit: V (EOG channels)
+                        )
+
+    .. note:: Since rejection is based on a signal **difference**
+              calculated for each channel separately, applying baseline
+              correction does not affect the rejection procedure, as the
+              difference will be preserved.
+"""
+docdict['reject_epochs'] = f"""
+reject : dict | None
+{reject_common}
+    If ``reject`` is ``None`` (default), no rejection is performed.
+"""
+docdict['reject_drop_bad'] = f"""
+reject : dict | str | None
+{reject_common}
+
+    If ``reject`` is ``None``, no rejection is performed. If ``'existing'``
+    (default), then the rejection parameters set at instantiation are used.
+"""
 
 # Finalize
 docdict = unindent_dict(docdict)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1775,10 +1775,10 @@ reject_common = """
     Example::
 
         reject = dict(grad=4000e-13,  # unit: T / m (gradiometers)
-                        mag=4e-12,      # unit: T (magnetometers)
-                        eeg=40e-6,      # unit: V (EEG channels)
-                        eog=250e-6      # unit: V (EOG channels)
-                        )
+                      mag=4e-12,      # unit: T (magnetometers)
+                      eeg=40e-6,      # unit: V (EEG channels)
+                      eog=250e-6      # unit: V (EOG channels)
+                      )
 
     .. note:: Since rejection is based on a signal **difference**
               calculated for each channel separately, applying baseline

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1793,7 +1793,6 @@ reject : dict | None
 docdict['reject_drop_bad'] = f"""
 reject : dict | str | None
 {reject_common}
-
     If ``reject`` is ``None``, no rejection is performed. If ``'existing'``
     (default), then the rejection parameters set at instantiation are used.
 """


### PR DESCRIPTION
#### What does this implement/fix?
I have received questions regarding the interaction between baseline correction and the `reject` parameter of `Epochs` (answer: there is none), leading me to believe that the docs could be improved.