### PR TITLE
WIP, ENH: Avoid ICA on rank-deficient data

### DIFF
--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -210,8 +210,12 @@ def test_plot_ica_sources():
     raw.pick_channels([raw.ch_names[k] for k in picks])
     ica_picks = pick_types(raw.info, meg=True, eeg=False, stim=False,
                            ecg=False, eog=False, exclude='bads')
+
     ica = ICA(n_components=2, max_pca_components=3, n_pca_components=3)
-    ica.fit(raw, picks=ica_picks)
+    with pytest.warns(RuntimeWarning,
+                      match='Projection vector.*should be unity'):
+        ica.fit(raw, picks=ica_picks)
+
     ica.exclude = [1]
     fig = ica.plot_sources(raw)
     fig.canvas.key_press_event('escape')


### PR DESCRIPTION
- `ICA.max_pca_components` can now be set to `rank` to limit the number of components to the rank the data.
- This is also the new default.
- The previous default value, ``None``,   is still an accepted, but deprecated.
- ``None``, too, now   dictates to use the rank of the data. Previously, it implied to   use the number of channels, which caused problems with   rank-deficient data.
- If requested number of ICA or PCA components exceeds the rank of   the data, we will now raise an exception.
- `compute_rank()` and `_estimate_rank_meeg_signals()` have gained   a `ref_meg=False` kwarg to allow for rank calculation to include MEG reference  channels. This was required to make some tests work.

Implementing this helped discover a few existing test cases that never converged because they fed rank-deficient data to ICA.

Closes #8313.

**I need help:**

- `mne/viz/tests/test_ica.py::test_plot_ica_overlay` doesn't pass because of #8315 
- `mne/preprocessing/tests/test_ica.py::test_ica_full_data_recovery` doesn't pass because the difference between actual and expected test results is too large. It's still rather small but larger than the predefined limits. I have no idea why that is the case, and whether it might be safe to just make the test more lenient or not.


