### PR TITLE
MRG, ENH: Speed up time_delaying_ridge using Numba

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -15,7 +15,7 @@ Current (0.22.dev0)
 Enhancements
 ~~~~~~~~~~~~
 
-- ...
+- Speed up :class:`mne.decoding.TimeDelayingRidge` with edge correction using Numba by `Eric Larson`_ (:gh:`8323`)
 
 Bugs
 ~~~~

--- a/examples/decoding/plot_receptive_field_mtrf.py
+++ b/examples/decoding/plot_receptive_field_mtrf.py
@@ -5,8 +5,8 @@
 Receptive Field Estimation and Prediction
 =========================================
 
-This example reproduces figures from Lalor et al's mTRF toolbox in
-matlab :footcite:`CrosseEtAl2016`. We will show how the
+This example reproduces figures from Lalor et al.'s mTRF toolbox in
+MATLAB :footcite:`CrosseEtAl2016`. We will show how the
 :class:`mne.decoding.ReceptiveField` class
 can perform a similar function along with scikit-learn. We will first fit a
 linear encoding model using the continuously-varying speech envelope to predict


### PR DESCRIPTION
I remembered that the edge correction was actually a painfully slow step in the Fourier method. Using Numba reduces the total example time from 7.2 to 6.1 sec on my system.