### PR TITLE
MRG, BUG: Fix errant writing of too large int (part 2/2)

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -43,6 +43,8 @@ Bugs
 
 - Fix bug when merging fNIRS channels in :func:`mne.viz.plot_evoked_topomap` and related functions by `Robert Luke`_ (:gh:`8306`)
 
+- Fix bug where events could overflow when writing to FIF by `Eric Larson`_ (:gh:`8324`)
+
 - :func:`mne.io.read_raw_edf` now supports EDF files with invalid recording dates by `Clemens Brunner`_ (:gh:`8283`)
 
 - Fix bug with :class:`mne.preprocessing.ICA` where ``n_pca_components`` as a :class:`python:float` would give the number of components that explained less than or equal to the given variance. It now gives greater than the given number for better usability and consistency with :class:`sklearn.decomposition.PCA`. Generally this will mean that one more component will be included, by `Eric Larson`_ (:gh:`8326`)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -27,6 +27,8 @@ Enhancements
 
 - Speed up :class:`mne.decoding.TimeDelayingRidge` with edge correction using Numba by `Eric Larson`_ (:gh:`8323`)
 
+- Add :meth:`mne.Epochs.reset_drop_log_selection` to facilitate writing epochs with many ignored entries in their drop log by `Eric Larson`_ (:gh:`8324`)
+
 - Add sEEG source visualization using :func:`mne.stc_near_sensors` and sEEG working tutorial by `Eric Larson`_ and `Adam Li`_ (:gh:`8402`)
 
 Bugs

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1632,7 +1632,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         # 1. meas_id block plus main epochs block
         total_size += 132
         # 2. measurement info (likely slight overestimate, but okay)
-        total_size += object_size(self.info)
+        total_size += object_size(self.info) + 16 * len(self.info)
         # 3. events and event_id in its own block
         total_size += (self.events.size * 4 +
                        len(_event_id_string(self.event_id)) + 72)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2671,6 +2671,11 @@ class EpochsFIF(BaseEpochs):
              reject_params, fmt) = \
                 _read_one_epoch_file(fid, tree, preload)
 
+            if (events[:, 0] < 0).any():
+                events = events.copy()
+                warn('Incorrect events detected on disk, setting event '
+                     'numbers to consecutive increasing integers')
+                events[:, 0] = np.arange(1, len(events) + 1)
             # here we ignore missing events, since users should already be
             # aware of missing events if they have saved data that way
             epoch = BaseEpochs(

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -577,6 +577,19 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         assert all(isinstance(log, tuple) for log in self.drop_log)
         assert all(isinstance(s, str) for log in self.drop_log for s in log)
 
+    def reset_drop_log_selection(self):
+        """Reset the drop_log and selection entries.
+
+        This method will simplify ``self.drop_log`` and ``self.selection``
+        so that they are meaningless (tuple of empty tuples and increasing
+        integers, respectively). This can be useful when concatenating
+        many Epochs instances, as ``drop_log`` can accumulate many entries
+        which can become problematic when saving.
+        """
+        self.selection = np.arange(len(self.events))
+        self.drop_log = (tuple(),) * len(self.events)
+        self._check_consistency()
+
     def load_data(self):
         """Load the data if not already preloaded.
 
@@ -1609,13 +1622,15 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         # check for file existence
         _check_fname(fname, overwrite)
 
-        split_size = _get_split_size(split_size)
+        split_size_bytes = _get_split_size(split_size)
 
         _check_option('fmt', fmt, ['single', 'double'])
 
         # to know the length accurately. The get_data() call would drop
         # bad epochs anyway
         self.drop_bad()
+        # total_size tracks sizes that get split
+        # over_size tracks overhead (tags, things that get written to each)
         if len(self) == 0:
             warn('Saving epochs with no data')
             total_size = 0
@@ -1625,37 +1640,69 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
             assert d.dtype in ('>f8', '<f8', '>c16', '<c16')
             total_size = d.nbytes * len(self)
         self._check_consistency()
+        over_size = 0
         if fmt == "single":
             total_size //= 2  # 64bit data converted to 32bit before writing.
-        total_size += 32  # FIF tags
+        over_size += 32  # FIF tags
         # Account for all the other things we write, too
         # 1. meas_id block plus main epochs block
-        total_size += 132
+        over_size += 132
         # 2. measurement info (likely slight overestimate, but okay)
-        total_size += object_size(self.info) + 16 * len(self.info)
+        over_size += object_size(self.info) + 16 * len(self.info)
         # 3. events and event_id in its own block
-        total_size += (self.events.size * 4 +
-                       len(_event_id_string(self.event_id)) + 72)
+        total_size += self.events.size * 4
+        over_size += len(_event_id_string(self.event_id)) + 72
         # 4. Metadata in a block of its own
         if self.metadata is not None:
-            total_size += len(_prepare_write_metadata(self.metadata)) + 56
+            total_size += len(_prepare_write_metadata(self.metadata))
+        over_size += 56
         # 5. first sample, last sample, baseline
-        total_size += 40 + 40 * (self.baseline is not None)
-        # 6. drop log
-        total_size += len(json.dumps(self.drop_log)) + 16
+        over_size += 40 * (self.baseline is not None) + 40
+        # 6. drop log: gets written to each, with IGNORE for ones that are
+        #    not part of it. So make a fake one with all having entries.
+        drop_size = len(json.dumps(self.drop_log)) + 16
+        drop_size += 8 * (len(self.selection) - 1)  # worst case: all but one
+        over_size += drop_size
         # 7. reject params
         reject_params = _pack_reject_params(self)
         if reject_params:
-            total_size += len(json.dumps(reject_params)) + 16
+            over_size += len(json.dumps(reject_params)) + 16
         # 8. selection
-        total_size += self.selection.size * 4 + 16
+        total_size += self.selection.size * 4
+        over_size += 16
         # 9. end of file tags
-        total_size += _NEXT_FILE_BUFFER
+        over_size += _NEXT_FILE_BUFFER
+        logger.debug(f'    Overhead size:   {str(over_size).rjust(15)}')
+        logger.debug(f'    Splittable size: {str(total_size).rjust(15)}')
+        logger.debug(f'    Split size:      {str(split_size_bytes).rjust(15)}')
+        # need at least one per
+        n_epochs = len(self)
+        n_per = total_size // n_epochs if n_epochs else 0
+        min_size = n_per + over_size
+        if split_size_bytes < min_size:
+            raise ValueError(
+                f'The split size {split_size} is too small to safely write '
+                'the epochs contents, minimum split size is '
+                f'{sizeof_fmt(min_size)} ({min_size} bytes)')
 
         # This is like max(int(ceil(total_size / split_size)), 1) but cleaner
-        n_parts = (total_size - 1) // split_size + 1
-        assert n_parts >= 1
-        epoch_idxs = np.array_split(np.arange(len(self)), n_parts)
+        n_parts = max(
+            (total_size - 1) // (split_size_bytes - over_size) + 1, 1)
+        assert n_parts >= 1, n_parts
+        if n_parts > 1:
+            logger.info(f'Splitting into {n_parts} parts')
+            if n_parts > 100:  # This must be an error
+                raise ValueError(
+                    f'Split size {split_size} would result in writing '
+                    f'{n_parts} files')
+
+        if len(self.drop_log) > 100000:
+            warn(f'epochs.drop_log contains {len(self.drop_log)} entries '
+                 f'which will incur up to a {sizeof_fmt(drop_size)} writing '
+                 f'overhead (per split file), consider using '
+                 'epochs.reset_drop_log_selection() prior to writing')
+
+        epoch_idxs = np.array_split(np.arange(n_epochs), n_parts)
 
         for part_idx, epoch_idx in enumerate(epoch_idxs):
             this_epochs = self[epoch_idx] if n_parts > 1 else self
@@ -2516,7 +2563,9 @@ def _read_one_epoch_file(f, tree, preload):
                 selection = np.array(tag.data)
             elif kind == FIFF.FIFF_MNE_EPOCHS_DROP_LOG:
                 tag = read_tag(fid, pos)
-                drop_log = tuple(tuple(x) for x in json.loads(tag.data))
+                drop_log = tag.data
+                drop_log = json.loads(drop_log)
+                drop_log = tuple(tuple(x) for x in drop_log)
             elif kind == FIFF.FIFF_MNE_EPOCHS_REJECT_FLAT:
                 tag = read_tag(fid, pos)
                 reject_params = json.loads(tag.data)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2083,11 +2083,14 @@ def _write_raw_buffer(fid, buf, cals, fmt):
 
     _check_option('fmt', fmt, ['short', 'int', 'single', 'double'])
 
+    cast_int = False  # allow unsafe cast
     if np.isrealobj(buf):
         if fmt == 'short':
             write_function = write_dau_pack16
+            cast_int = True
         elif fmt == 'int':
             write_function = write_int
+            cast_int = True
         elif fmt == 'single':
             write_function = write_float
         else:
@@ -2102,6 +2105,8 @@ def _write_raw_buffer(fid, buf, cals, fmt):
                              'writing complex data')
 
     buf = buf / np.ravel(cals)[:, None]
+    if cast_int:
+        buf = buf.astype(np.int32)
     write_function(fid, FIFF.FIFF_DATA_BUFFER, buf)
 
 

--- a/mne/io/tests/test_write.py
+++ b/mne/io/tests/test_write.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""Run tests for writing."""
+# Author: Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD (3-clause)
+
+import pytest
+
+from mne.io.constants import FIFF
+from mne.io.write import start_file, write_int
+
+
+def test_write_int(tmpdir):
+    """Test that write_int raises an error on bad values."""
+    with start_file(tmpdir.join('temp.fif')) as fid:
+        write_int(fid, FIFF.FIFF_MNE_EVENT_LIST, [2147483647])  # 2 ** 31 - 1
+        write_int(fid, FIFF.FIFF_MNE_EVENT_LIST, [])  # 2 ** 31 - 1
+        with pytest.raises(TypeError, match=r'.*exceeds max.*EVENT_LIST\)'):
+            write_int(fid, FIFF.FIFF_MNE_EVENT_LIST, [2147483648])  # 2 ** 31
+        with pytest.raises(TypeError, match='Cannot safely write'):
+            write_int(fid, FIFF.FIFF_MNE_EVENT_LIST, [0.])  # float

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -339,8 +339,9 @@ def check_fiff_length(fid, close=True):
     if fid.tell() > 2147483648:  # 2 ** 31, FIFF uses signed 32-bit locations
         if close:
             fid.close()
-        raise IOError('FIFF file exceeded 2GB limit, please split file or '
-                      'save to a different format')
+        raise IOError('FIFF file exceeded 2GB limit, please split file, reduce'
+                      ' split_size (if possible), or save to a different '
+                      'format')
 
 
 def end_file(fid):

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -64,10 +64,22 @@ def write_nop(fid, last=False):
     fid.write(np.array(next_, dtype='>i4').tobytes())
 
 
+INT32_MAX = 2147483647
+
+
 def write_int(fid, kind, data):
     """Write a 32-bit integer tag to a fif file."""
     data_size = 4
-    data = np.array(data, dtype='>i4').T
+    data = np.asarray(data)
+    if data.dtype.kind not in 'uib' and data.size > 0:
+        raise TypeError(
+            f'Cannot safely write data with dtype {data.dtype} as int')
+    max_val = data.max() if data.size > 0 else 0
+    if max_val > INT32_MAX:
+        raise TypeError(
+            f'Value {max_val} exceeds maximum allowed ({INT32_MAX}) for '
+            f'tag {kind}')
+    data = data.astype('>i4').T
     _write(fid, data, kind, data_size, FIFF.FIFFT_INT, '>i4')
 
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1089,7 +1089,7 @@ def test_epochs_io_preload(tmpdir, preload):
 
 @pytest.mark.parametrize('split_size, n_epochs, n_files, size', [
     ('1MB', 9, 3, 1024 * 1024),
-    ('2MB', 18, 2, 2 * 1024 * 1024),
+    # ('2MB', 18, 2, 2 * 1024 * 1024),  # Useful for debugging
 ])
 @pytest.mark.parametrize('metadata', [
     False,

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -24,9 +24,14 @@ from mne import (Epochs, Annotations, read_events, pick_events, read_epochs,
                  write_evokeds, create_info, make_fixed_length_events,
                  make_fixed_length_epochs, combine_evoked)
 from mne.baseline import rescale
+from mne.datasets import testing
+from mne.chpi import read_head_pos, head_pos_to_trans_rot_t
+from mne.event import merge_events
 from mne.fixes import rfft, rfftfreq
+from mne.io import RawArray, read_raw_fif
 from mne.io.constants import FIFF
-from mne.io.write import write_int, INT32_MAX
+from mne.io.proj import _has_eeg_average_ref_proj
+from mne.io.write import write_int, INT32_MAX, _get_split_size
 from mne.preprocessing import maxwell_filter
 from mne.epochs import (
     bootstrap, equalize_epoch_counts, combine_event_ids, add_channels_epochs,
@@ -35,14 +40,6 @@ from mne.epochs import (
 from mne.utils import (requires_pandas, object_diff,
                        catch_logging, _FakeNoPandas,
                        assert_meg_snr, check_version, _dt_to_stamp)
-from mne.chpi import read_head_pos, head_pos_to_trans_rot_t
-
-from mne.io import RawArray, read_raw_fif
-from mne.io.proj import _has_eeg_average_ref_proj
-from mne.io.write import _get_split_size
-from mne.event import merge_events
-from mne.io.constants import FIFF
-from mne.datasets import testing
 
 data_path = testing.data_path(download=False)
 fname_raw_testing = op.join(data_path, 'MEG', 'sample',


### PR DESCRIPTION
Closes #7897

@Alex159 can you switch to this branch and try your original code that failed and see where you get an error now? Hopefully it's in the instantiation of the Epochs object or during writing. If it's during writing, then we should figure out what other functions you're using that are modifying `events` without checking to see if the int32-max value is being exceeded.