### PR TITLE
MRG: ENH, BUG: Minor ICA cleanups

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -693,17 +693,16 @@ class ICA(ContainsMixin):
 
             if (self.n_components is not None and
                     self.max_pca_components_ < self.n_components):
-                msg = (f'You asked to select only a subset of PCA components '
-                       f'by passing '
-                       f'max_pca_components={self.max_pca_components}, '
-                       f'which equals {self.max_pca_components_} components '
-                       f'for this specific dataset. However, you also '
-                       f'requested to pass {self.n_components} of those '
-                       f'components to ICA, which is mathematically '
-                       f'impossible. Please either increase '
-                       f'max_pca_components, set it to None, '
-                       f'reduce n_components, or set n_components=None')
-                raise ValueError(msg)
+                raise ValueError(
+                    f'You asked to select only a subset of PCA components by '
+                    f'passing max_pca_components={self.max_pca_components}, '
+                    f'which equals {self.max_pca_components_} components '
+                    f'for this specific dataset. However, you also '
+                    f'requested to pass {self.n_components} of those '
+                    f'components to ICA, which is mathematically '
+                    f'impossible. Please either increase '
+                    f'max_pca_components, set it to None, reduce '
+                    f'n_components, or set n_components=None')
 
             pca = _PCA(n_components=self.max_pca_components_, whiten=True)
             data_transformed = pca.fit_transform(data.T)

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -669,7 +669,7 @@ class ICA(ContainsMixin):
 
         if (self.max_pca_components is None or
                 isinstance(self.max_pca_components, float)):
-            # Use all channels. For float input, we will reduce the number
+            # Use all channels. For float input <1.0, we will reduce the number
             # of retained components later.
             self.max_pca_components_ = n_channels
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -365,6 +365,10 @@ class ICA(ContainsMixin):
                  method='fastica', fit_params=None, max_iter=200,
                  allow_ref_meg=False, verbose=None):  # noqa: D102
         _validate_type(method, str, 'method')
+        _validate_type(n_components, ('numeric', None))
+        _validate_type(n_pca_components, ('numeric', None))
+        _validate_type(max_pca_components, ('numeric', None))
+
         if method != 'imported_eeglab':  # internal use only
             _check_option('method', method, ['fastica', 'infomax', 'picard'])
         if method == 'fastica' and not check_version('sklearn'):

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -684,7 +684,8 @@ class ICA(ContainsMixin):
         # as well, and we don't need to handle this case specially below.
         # Note that the result should be numerically identical to the first
         # PCA run for all retained components.
-        if isinstance(self.max_pca_components, float):
+        if (isinstance(self.max_pca_components, float) and
+                self.max_pca_components != 1.0):
             del data_transformed  # Free memory.
             self.max_pca_components_ = (np.sum(pca.explained_variance_ratio_
                                                .cumsum()

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -548,13 +548,13 @@ def test_ica_additional(method):
             ica_read = read_ica(test_ica_fname)
             assert (list(ica.exclude) == ica_read.exclude)
             assert_equal(ica.labels_, ica_read.labels_)
-            ica.apply(raw)
+            ica.apply(raw.copy())
             ica.exclude = []
-            ica.apply(raw, exclude=[1])
+            ica.apply(raw.copy(), exclude=[1])
             assert (ica.exclude == [])
 
             ica.exclude = [0, 1]
-            ica.apply(raw, exclude=[1])
+            ica.apply(raw.copy(), exclude=[1])
             assert (ica.exclude == [0, 1])
 
             ica_raw = ica.get_sources(raw)
@@ -608,8 +608,8 @@ def test_ica_additional(method):
         sources2 = ica_read.get_sources(raw)[:, :][0]
         assert_array_almost_equal(sources, sources2)
 
-        _raw1 = ica.apply(raw, exclude=[1])
-        _raw2 = ica_read.apply(raw, exclude=[1])
+        _raw1 = ica.apply(raw.copy(), exclude=[1])
+        _raw2 = ica_read.apply(raw.copy(), exclude=[1])
         assert_array_almost_equal(_raw1[:, :][0], _raw2[:, :][0])
 
     os.remove(test_ica_fname)
@@ -1105,7 +1105,7 @@ def test_ica_ctf():
 
         # test apply and get_sources
         for inst in [raw, epochs, evoked]:
-            ica.apply(inst)
+            ica.apply(inst.copy())
             ica.get_sources(inst)
 
     # test mixed compensation case
@@ -1119,7 +1119,7 @@ def test_ica_ctf():
     evoked = epochs.average()
     for inst in [raw, epochs, evoked]:
         with pytest.raises(RuntimeError, match='Compensation grade of ICA'):
-            ica.apply(inst)
+            ica.apply(inst.copy())
         with pytest.raises(RuntimeError, match='Compensation grade of ICA'):
             ica.get_sources(inst)
 

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -142,7 +142,7 @@ def test_ica_simple(method):
     A = rng.randn(n_components, n_components)
     data = np.dot(A, S)
     ica = ICA(n_components=n_components, method=method, random_state=0)
-    ica._fit(data, n_components, 0)
+    ica._fit(data, 0)
     transform = np.dot(np.dot(ica.unmixing_matrix_, ica.pca_components_), A)
     amari_distance = np.mean(np.sum(np.abs(transform), axis=1) /
                              np.max(np.abs(transform), axis=1) - 1.)


### PR DESCRIPTION
#### What does this implement/fix?
Some cherry-picks from #8328 

- add more validation
- fix bug if `max_pca_components` is a float
- remove redundant `max_pca_components ` argument from `ICA._fit`
- handle `max_pca_components=1.0` like `max_pca_components=None`
- make test cases more independent by avoiding side effects through repeated `ICA.apply()`'ing to the same object