### PR TITLE
MRG, BUG: Fix line color in ICA.plot_overlay

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -44,6 +44,7 @@ Bugs
 
 - ``ICA.max_pca_components`` will not be altered by calling `~mne.preprocessing.ICA.fit` anymore. Instead, the new attribute ``ICA.max_pca_components_`` will be set, by `Richard Höchenberger`_ (:gh:`8321`)
 
+- Fix bug that `~mne.viz.plot_ica_overlay` would sometimes not create red traces, by `Richard Höchenberger`_ (:gh:`8341`)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -872,12 +872,12 @@ def _plot_ica_overlay_evoked(evoked, evoked_cln, title, show):
     fig.suptitle(title)
     axes = axes.flatten() if isinstance(axes, np.ndarray) else axes
 
-    evoked.plot(axes=axes, show=show, time_unit='s')
+    evoked.plot(axes=axes, show=False, time_unit='s')
     for ax in fig.axes:
         for line in ax.get_lines():
             line.set_color('r')
     fig.canvas.draw()
-    evoked_cln.plot(axes=axes, show=show, time_unit='s')
+    evoked_cln.plot(axes=axes, show=False, time_unit='s')
     tight_layout(fig=fig)
 
     fig.subplots_adjust(top=0.90)


### PR DESCRIPTION
`ICA.plot_overlay()` didn't seem to work on my system with latest Matplotlib anymore (macOS, both the default and Qt5Agg backends). I would only see black traces, instead of red and black. Debugging showed that changig the colors of lines in a figure (in this case, from black to read) that has
been `show()`n was somehow part of the problem. Now we only `show()` once all plotting operations are done (We call `plt_show(show)` at the end of the plotting function), and this now works with the default macOS and the Qt5Agg backends for me.

