### PR TITLE
MRG, BUG: Fix handling of axes with constrained_layout=True

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -26,6 +26,8 @@ Bugs
 
 - Fix bug with :func:`mne.viz.plot_source_estimates` when using the PyVista backend where singleton time points were not handled properly by `Eric Larson`_ (:gh:`8285`)
 
+- Fix bug when passing ``axes`` to plotting functions, :func:`matplotlib.pyplot.tight_layout` will not be called when the figure was created using a constrained layout by `Eric Larson`_ (:gh:`8344`)
+
 - Fix bug with compensated CTF data when picking channels without preload by `Eric Larson`_ (:gh:`8318`)
 
 - Fix bug when merging fNIRS channels in :func:`mne.viz.plot_evoked_topomap` and related functions by `Robert Luke`_ (:gh:`8306`)

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -22,7 +22,7 @@ import mne
 from mne import (read_events, Epochs, read_cov, compute_covariance,
                  make_fixed_length_events, compute_proj_evoked)
 from mne.io import read_raw_fif
-from mne.utils import run_tests_if_main, catch_logging
+from mne.utils import run_tests_if_main, catch_logging, requires_version
 from mne.viz import plot_compare_evokeds, plot_evoked_white
 from mne.viz.utils import _fake_click
 from mne.datasets import testing
@@ -143,8 +143,16 @@ def test_plot_evoked():
         evoked.plot(verbose=True, time_unit='s')
     assert 'Need more than one' in log_file.getvalue()
 
-    fig, ax = plt.subplots(2, 1, constrained_layout=True)
+
+@requires_version('matplotlib', '2.2')
+def test_constrained_layout():
+    """Test that we handle constrained layouts correctly."""
+    fig, ax = plt.subplots(1, 1, constrained_layout=True)
+    assert fig.get_constrained_layout()
+    evoked = mne.read_evokeds(evoked_fname)[0]
+    evoked.pick(evoked.ch_names[:2])
     evoked.plot(axes=ax)  # smoke test that it does not break things
+    assert fig.get_constrained_layout()
     plt.close('all')
 
 

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -143,6 +143,10 @@ def test_plot_evoked():
         evoked.plot(verbose=True, time_unit='s')
     assert 'Need more than one' in log_file.getvalue()
 
+    fig, ax = plt.subplots(2, 1, constrained_layout=True)
+    evoked.plot(axes=ax)  # smoke test that it does not break things
+    plt.close('all')
+
 
 def _get_amplitudes(fig):
     amplitudes = [line.get_ydata() for ax in fig.axes

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -130,11 +130,22 @@ def tight_layout(pad=1.2, h_pad=None, w_pad=None, fig=None):
         Defaults to ``pad_inches``.
     fig : instance of Figure
         Figure to apply changes to.
+
+    Notes
+    -----
+    This will not force constrained_layout=False if the figure was created
+    with that method.
     """
     import matplotlib.pyplot as plt
     fig = plt.gcf() if fig is None else fig
 
     fig.canvas.draw()
+    try:
+        constrained = fig.get_constrained_layout()
+    except AttributeError:  # old matplotlib presumably
+        constrained = False
+    if constrained:
+        return  # no-op
     try:  # see https://github.com/matplotlib/matplotlib/issues/2654
         with warnings.catch_warnings(record=True) as ws:
             fig.tight_layout(pad=pad, h_pad=h_pad, w_pad=w_pad)
@@ -149,7 +160,6 @@ def tight_layout(pad=1.2, h_pad=None, w_pad=None, fig=None):
     for w in ws:
         w_msg = str(w.message) if hasattr(w, 'message') else w.get_message()
         if not w_msg.startswith('This figure includes Axes'):
-            raise RuntimeError(w_msg)
             warn(w_msg, w.category, 'matplotlib')
 
 


### PR DESCRIPTION
We should only internally do `tight_layout(...)` calls when axes were not created using `constrained_layout=True`. Our current code gets a matplotlib warning about disabling the `constrained_layout` of the axes.

Also fixes a bug where we would raise as error instead of re-emit as a warning