### PR TITLE
ENH: Remove 15-char limit for FIF

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -17,6 +17,8 @@ Enhancements
 
 - Speed up :class:`mne.decoding.TimeDelayingRidge` with edge correction using Numba by `Eric Larson`_ (:gh:`8323`)
 
+- Remove the 15-character limitation for channel names when writing to FIF format. If you need the old 15-character names, you can use something like ``raw.rename_channels({n: n[:13] for n in raw.ch_names}, allow_duplicates=True)``, by `Eric Larson`_ (:gh:`8346`)
+
 - The ``max_pca_components`` argument of `~mne.preprocessing.ICA` can now be a float between 0.0 and 1.0, allowing users to specify a relative amount of cumulative explained variance. This can be used to exclude "unimportant" principal components, thereby conducting a rank reduction of the data, by `Richard Höchenberger`_ (:gh:`8321`)
 
 - `~mne.preprocessing.ICA` has gained a new attribute ``max_pca_components_``, which will be set when calling `~mne.preprocessing.ICA.fit`, by `Richard Höchenberger`_ (:gh:`8321`)

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -192,12 +192,12 @@ class DigMontage(object):
                             sphere=sphere)
 
     @fill_doc
-    def rename_channels(self, mapping):
+    def rename_channels(self, mapping, allow_duplicates=False):
         """Rename the channels.
 
         Parameters
         ----------
-        %(rename_channels_mapping)s
+        %(rename_channels_mapping_duplicates)s
 
         Returns
         -------
@@ -206,7 +206,7 @@ class DigMontage(object):
         """
         from .channels import rename_channels
         temp_info = create_info(list(self._get_ch_pos()), 1000., 'eeg')
-        rename_channels(temp_info, mapping)
+        rename_channels(temp_info, mapping, allow_duplicates)
         self.ch_names = temp_info['ch_names']
 
     def save(self, fname):

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -83,10 +83,6 @@ def test_rename_channels():
     # Test bad input
     pytest.raises(ValueError, rename_channels, info, 1.)
     pytest.raises(ValueError, rename_channels, info, 1.)
-    # Test name too long (channel names must be less than 15 characters)
-    A16 = 'A' * 16
-    mapping = {'MEG 2641': A16}
-    pytest.raises(ValueError, rename_channels, info, mapping)
 
     # Test successful changes
     # Test ch_name and ch_names are changed

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -1059,7 +1059,7 @@ def _read_evoked(fname, condition=None, kind='average', allow_maxshield=False):
             elif my_kind == FIFF.FIFF_NO_SAMPLES:
                 tag = read_tag(fid, pos)
                 nsamp = int(tag.data)
-            elif my_kind == FIFF.FIFF_MNE_CH_REMAPPING:
+            elif my_kind == FIFF.FIFF_MNE_CH_NAME_MAPPING:
                 tag = read_tag(fid, pos)
                 remap = tag.data
 

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -26,11 +26,12 @@ from ..io.tree import dir_tree_find
 from ..io.tag import find_tag, read_tag
 from ..io.matrix import (_read_named_matrix, _transpose_named_matrix,
                          write_named_matrix)
-from ..io.meas_info import read_bad_channels, write_info
+from ..io.meas_info import (read_bad_channels, write_info, _remap_ch_names,
+                            write_ch_infos)
 from ..io.pick import (pick_channels_forward, pick_info, pick_channels,
                        pick_types)
 from ..io.write import (write_int, start_block, end_block,
-                        write_coord_trans, write_ch_info, write_name_list,
+                        write_coord_trans, write_name_list,
                         write_string, start_file, end_file, write_id)
 from ..io.base import BaseRaw
 from ..evoked import Evoked, EvokedArray
@@ -293,7 +294,9 @@ def _read_forward_meas_info(tree, fid):
         if kind == FIFF.FIFF_CH_INFO:
             tag = read_tag(fid, pos)
             chs.append(tag.data)
-    info['chs'] = chs
+    tag = find_tag(fid, parent_meg, FIFF.FIFF_MNE_CH_NAME_MAPPING)
+    remap = tag.data if tag is not None else None
+    info['chs'] = _remap_ch_names(chs, remap)
     info._update_redundant()
 
     #   Get the MRI <-> head coordinate transformation
@@ -920,11 +923,7 @@ def write_forward_meas_info(fid, info):
     if 'chs' in info:
         #  Channel information
         write_int(fid, FIFF.FIFF_NCHAN, len(info['chs']))
-        for k, c in enumerate(info['chs']):
-            #   Scan numbers may have been messed up
-            c = deepcopy(c)
-            c['scanno'] = k + 1
-            write_ch_info(fid, c)
+        write_ch_infos(fid, info['chs'])
     if 'bads' in info and len(info['bads']) > 0:
         #   Bad channels
         start_block(fid, FIFF.FIFFB_MNE_BAD_CHANNELS)

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -27,7 +27,7 @@ from ..io.tag import find_tag, read_tag
 from ..io.matrix import (_read_named_matrix, _transpose_named_matrix,
                          write_named_matrix)
 from ..io.meas_info import (read_bad_channels, write_info, _remap_ch_names,
-                            write_ch_infos)
+                            _write_ch_infos)
 from ..io.pick import (pick_channels_forward, pick_info, pick_channels,
                        pick_types)
 from ..io.write import (write_int, start_block, end_block,
@@ -923,7 +923,7 @@ def write_forward_meas_info(fid, info):
     if 'chs' in info:
         #  Channel information
         write_int(fid, FIFF.FIFF_NCHAN, len(info['chs']))
-        write_ch_infos(fid, info['chs'])
+        _write_ch_infos(fid, info['chs'])
     if 'bads' in info and len(info['bads']) > 0:
         #   Bad channels
         start_block(fid, FIFF.FIFFB_MNE_BAD_CHANNELS)

--- a/mne/io/array/tests/test_array.py
+++ b/mne/io/array/tests/test_array.py
@@ -27,11 +27,15 @@ def test_long_names():
     info = create_info(['a' * 15 + 'b', 'a' * 16], 1000., verbose='error')
     data = np.empty((2, 1000))
     raw = RawArray(data, info)
+    assert raw.ch_names == ['a' * 15 + 'b', 'a' * 16]
+    # and a way to get the old behavior
+    raw.rename_channels({k: k[:13] for k in raw.ch_names},
+                        allow_duplicates=True, verbose='error')
     assert raw.ch_names == ['a' * 13 + '-0', 'a' * 13 + '-1']
     info = create_info(['a' * 16] * 11, 1000., verbose='error')
     data = np.empty((11, 1000))
     raw = RawArray(data, info)
-    assert raw.ch_names == ['a' * 12 + '-%s' % ii for ii in range(11)]
+    assert raw.ch_names == ['a' * 16 + '-%s' % ii for ii in range(11)]
 
 
 def test_array_copy():

--- a/mne/io/constants.py
+++ b/mne/io/constants.py
@@ -478,6 +478,7 @@ FIFF.FIFF_MNE_COORD_FRAME            = 3506  # Coordinate frame employed. Defaul
                           #  FIFFB_MNE_INVERSE_SOLUTION   FIFFV_COORD_HEAD
 FIFF.FIFF_MNE_CH_NAME_LIST           = 3507
 FIFF.FIFF_MNE_FILE_NAME              = 3508  # This removes the collision with fiff_file.h (used to be 3501)
+FIFF.FIFF_MNE_CH_NAME_MAPPING        = 3509
 #
 # 3510... 3590... Source space or surface
 #

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -386,8 +386,9 @@ def test_bdf_multiple_annotation_channels():
 @testing.requires_testing_data
 def test_edf_lowpass_zero():
     """Test if a lowpass filter of 0Hz is mapped to the Nyquist frequency."""
-    with pytest.warns(RuntimeWarning, match='too long.*truncated'):
-        raw = read_raw_edf(edf_stim_resamp_path)
+    raw = read_raw_edf(edf_stim_resamp_path)
+    assert raw.ch_names[100] == 'EEG LDAMT_01-REF'
+    assert len(raw.ch_names[100]) > 15
     assert_allclose(raw.info["lowpass"], raw.info["sfreq"] / 2)
 
 

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -191,12 +191,12 @@ def test_io_egi_pns_mff(tmpdir):
     pns_chans = pick_types(raw.info, ecg=True, bio=True, emg=True)
     assert_equal(len(pns_chans), 7)
     names = [raw.ch_names[x] for x in pns_chans]
-    pns_names = ['Resp. Temperature'[:15],
+    pns_names = ['Resp. Temperature',
                  'Resp. Pressure',
                  'ECG',
                  'Body Position',
-                 'Resp. Effort Chest'[:15],
-                 'Resp. Effort Abdomen'[:15],
+                 'Resp. Effort Chest',
+                 'Resp. Effort Abdomen',
                  'EMG-Leg']
     _test_raw_reader(read_raw_egi, input_fname=egi_mff_pns_fname,
                      channel_naming='EEG %03d', verbose='error',
@@ -205,14 +205,13 @@ def test_io_egi_pns_mff(tmpdir):
                      )
     assert_equal(names, pns_names)
     mat_names = [
-        'Resp_Temperature'[:15],
+        'Resp_Temperature',
         'Resp_Pressure',
         'ECG',
         'Body_Position',
-        'Resp_Effort_Chest'[:15],
-        'Resp_Effort_Abdomen'[:15],
+        'Resp_Effort_Chest',
+        'Resp_Effort_Abdomen',
         'EMGLeg'
-
     ]
     egi_fname_mat = op.join(data_path(), 'EGI', 'test_egi_pns.mat')
     mc = sio.loadmat(egi_fname_mat)

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1643,7 +1643,7 @@ def write_meas_info(fid, info, data_type=None, reset_range=True):
         write_string(fid, FIFF.FIFF_XPLOTTER_LAYOUT, info['xplotter_layout'])
 
     #  Channel information
-    write_ch_infos(fid, info['chs'], reset_range)
+    _write_ch_infos(fid, info['chs'], reset_range)
 
     # Subject information
     if info.get('subject_info') is not None:
@@ -2331,7 +2331,7 @@ def _dict_unpack(obj, casts):
             for ii in range(n)]
 
 
-def write_ch_infos(fid, chs, reset_range=False):
+def _write_ch_infos(fid, chs, reset_range=False):
     orig_ch_names = [c['ch_name'] for c in chs]
     ch_names = orig_ch_names.copy()
     _unique_channel_names(ch_names, max_length=15, verbose='error')

--- a/mne/io/tests/test_constants.py
+++ b/mne/io/tests/test_constants.py
@@ -31,6 +31,7 @@ _dir_ignore_names = ('clear', 'copy', 'fromkeys', 'get', 'items', 'keys',
                      'viewitems', 'viewkeys', 'viewvalues',  # Py2
                      )
 _tag_ignore_names = (
+    'FIFF_MNE_CH_NAME_MAPPING',  # XXX before merge need this in fiff-constants
 )  # for fiff-constants pending updates
 _ignore_incomplete_enums = (  # XXX eventually we could complete these
     'bem_surf_id', 'cardinal_point_cardiac', 'cond_model', 'coord',

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -379,7 +379,7 @@ def test_set_bipolar_reference():
                                   ch_info={'kind': FIFF.FIFFV_MEG_CH},
                                   verbose='error')
     assert (not reref.info['custom_ref_applied'])
-    assert ('MEG 0111-MEG 0112'[:15] in reref.ch_names)
+    assert ('MEG 0111-MEG 0112' in reref.ch_names)
 
     # Test a battery of invalid inputs
     pytest.raises(ValueError, set_bipolar_reference, raw,

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -4,6 +4,7 @@
 # License: BSD (3-clause)
 
 from gzip import GzipFile
+import json
 import os.path as op
 import re
 import time
@@ -113,6 +114,13 @@ def write_julian(fid, kind, data):
     jd = np.sum(_cal_to_julian(*data))
     data = np.array(jd, dtype='>i4')
     _write(fid, data, kind, data_size, FIFF.FIFFT_JULIAN, '>i4')
+
+
+def write_dict_json_string(fid, kind, data):
+    """Write a dict to string via a JSON dump."""
+    assert isinstance(data, dict)
+    data = json.dumps(data, separators=(',', ':'))
+    write_string(fid, kind, data)
 
 
 def write_string(fid, kind, data):

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1209,7 +1209,7 @@ docdict['on_missing_montage'] = """
 
     .. versionadded:: 0.20.1
 """ % (_on_missing_base,)
-docdict['rename_channels_mapping'] = """
+docdict['rename_channels_mapping_duplicates'] = """
 mapping : dict | callable
     A dictionary mapping the old channel to a new channel name
     e.g. {'EEG061' : 'EEG161'}. Can also be a callable function
@@ -1217,6 +1217,11 @@ mapping : dict | callable
 
     .. versionchanged:: 0.10.0
        Support for a callable function.
+allow_duplicates : bool
+    If True (default False), allow duplicates, which will automatically
+    be renamed with ``-N`` at the end.
+
+    .. versionadded:: 0.22.0
 """
 
 # Brain plotting


### PR DESCRIPTION
Closes #8312.

- [x] Get it working
- [x] Communicate with Brainstorm and FieldTrip folks about this (https://github.com/brainstorm-tools/brainstorm3/issues/361, https://github.com/fieldtrip/fieldtrip/issues/1596)
- [ ] Add constant to fiff-constants (gives Jukka a chance to make it not in the MNE_ namespace if MEGIN would use it) (https://github.com/mne-tools/fiff-constants/pull/29)
- [ ] Update PR with newer `fiff-constants` commit, check `'bads'` handling/replacement
- [ ] Add test where a file is written with long names, then `monkeypatch` to make the tag empty on read, ensure it can still be written and read
- [ ] Add to MNE-MATLAB
