### PR TITLE
MRG, API: Deprecate max_pca_components

### DIFF
--- a/doc/_static/diagrams/ica.dot
+++ b/doc/_static/diagrams/ica.dot
@@ -20,8 +20,9 @@ digraph ICAdiagram {
           fontsize=12
           fontname="Source Code Pro"]
 
-    /* starting node */
+    /* starting nodes */
     sensor [label="Sensor data" shape="box" fillcolor="#bbbbbb"]
+    cov [label="Noise cov" shape="box" fillcolor="#bbbbbb"]
 
     /* ICA.FIT() */
     subgraph cluster_0 {
@@ -30,17 +31,20 @@ digraph ICAdiagram {
         fontcolor="#009988"
         penwidth=1.5
 
+
         /* PRE-WHITENING */
         subgraph cluster_1 {
-            label="Pre-whitening"
+            label="Whitening"
             style="dashed"
             fontname="Source Sans Pro"
             color="gray50"
             fontcolor="gray50"
             /* nodes & edges */
+            pre [label="Pre-\nwhiten" fontsize=11 shape="circle" fillcolor="#ee7733"]
+            pre -> pca
             pca        [label="PCA"                   shape="circle" fillcolor="#ee7733"]
             pcs        [label="Principal\ncomponents" shape="box"    fillcolor="#33bbee"]
-            pca -> pcs [label="max_pca_components\r"]
+            pca -> pcs
         }
 
         /* nodes & edges */
@@ -60,7 +64,8 @@ digraph ICAdiagram {
     }
 
     /* subgraph-crossing edges */
-    sensor -> pca  [label="all sensor channels\r" fontsize=14 fontname="Source Sans Pro"]
+    sensor -> pre  [label="all sensor channels\r" fontsize=14 fontname="Source Sans Pro"]
+    cov -> pre     [label="covariance or std. dev.\r" fontsize=14 fontname="Source Sans Pro"]
     pcs -> ica     [label="n_components\l"]
     ics -> recon   [constraint=false color="#ee3377"
                     xlabel="Retained ICs:\ln_components -\llen(ICA.exclude)\l"]

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -54,7 +54,7 @@ Bugs
 
 - Fix bug with :class:`~mne.preprocessing.ICA` where ``n_components=None, n_pca_components=None`` could lead to unstable unmixing matrix inversion by making ``n_components=None`` also use the lesser of ``n_components=0.999999`` and ``n_components=n_pca_components`` by `Eric Larson`_ (:gh:`8351`)
 
-- The ``ica.n_pca_components`` property is no longer be updated during :meth:`mne.preprocessing.ICA.fit`, instead ``ica.n_components_`` will be added to the instance by `Eric Larson`_
+- The ``ica.n_pca_components`` property is no longer be updated during :meth:`mne.preprocessing.ICA.fit`, instead ``ica.n_components_`` will be added to the instance by `Eric Larson`_ (:gh:`8351`)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -50,6 +50,8 @@ Bugs
 
 - Fix bug that `~mne.viz.plot_ica_overlay` would sometimes not create red traces, by `Richard Höchenberger`_ (:gh:`8341`)
 
+- Fix bug with :class:`~mne.preprocessing.ICA` where ``n_components=None, n_pca_components=None`` could lead to unstable unmixing matrix inversion by making ``n_components=None`` also use the lesser of ``n_components=0.999999`` and ``n_components=n_pca_components`` by `Eric Larson`_ (:gh:`8351`)
+
 - The ``ica.n_pca_components`` property is no longer be updated during :meth:`mne.preprocessing.ICA.fit`, instead ``ica.n_components_`` will be added to the instance by `Eric Larson`_
 
 API changes

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -17,6 +17,8 @@ Enhancements
 
 - Add ``n_pca_components`` argument to :func:`mne.viz.plot_ica_overlay` by `Eric Larson`_ (:gh:`8351`)
 
+- Add ``proj`` argument to :func:`mne.make_fixed_length_epochs` by `Eric Larson`_ (:gh:`8351`)
+
 - Speed up :class:`mne.decoding.TimeDelayingRidge` with edge correction using Numba by `Eric Larson`_ (:gh:`8323`)
 
 Bugs

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -15,11 +15,9 @@ Current (0.22.dev0)
 Enhancements
 ~~~~~~~~~~~~
 
+- Add ``n_pca_components`` argument to :func:`mne.viz.plot_ica_overlay` by `Eric Larson`_ (:gh:`8351`)
+
 - Speed up :class:`mne.decoding.TimeDelayingRidge` with edge correction using Numba by `Eric Larson`_ (:gh:`8323`)
-
-- The ``max_pca_components`` argument of `~mne.preprocessing.ICA` can now be a float between 0.0 and 1.0, allowing users to specify a relative amount of cumulative explained variance. This can be used to exclude "unimportant" principal components, thereby conducting a rank reduction of the data, by `Richard Höchenberger`_ (:gh:`8321`)
-
-- `~mne.preprocessing.ICA` has gained a new attribute ``max_pca_components_``, which will be set when calling `~mne.preprocessing.ICA.fit`, by `Richard Höchenberger`_ (:gh:`8321`)
 
 Bugs
 ~~~~
@@ -52,7 +50,9 @@ Bugs
 
 - Fix bug that `~mne.viz.plot_ica_overlay` would sometimes not create red traces, by `Richard Höchenberger`_ (:gh:`8341`)
 
+- The ``ica.n_pca_components`` property is no longer be updated during :meth:`mne.preprocessing.ICA.fit`, instead ``ica.n_components_`` will be added to the instance by `Eric Larson`_
+
 API changes
 ~~~~~~~~~~~
 
-...
+- The ``max_pca_components`` argument of :class:`~mne.preprocessing.ICA` has been deprecated, use ``n_pca_components`` instead by `Eric Larson`_

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1941,17 +1941,7 @@ class Epochs(BaseEpochs):
         Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg', and values
         are floats that set the minimum acceptable peak-to-peak amplitude.
         If flat is None then no rejection is done.
-    proj : bool | 'delayed'
-        Apply SSP projection vectors. If proj is 'delayed' and reject is not
-        None the single epochs will be projected before the rejection
-        decision, but used in unprojected state if they are kept.
-        This way deciding which projection vectors are good can be postponed
-        to the evoked stage without resulting in lower epoch counts and
-        without producing results different from early SSP application
-        given comparable parameters. Note that in this case baselining,
-        detrending and temporal decimation will be postponed.
-        If proj is False no projections will be applied which is the
-        recommended value if SSPs are not used for cleaning the data.
+    %(proj_epochs)s
     %(decim)s
     reject_tmin : scalar | None
         Start of the time window used to reject epochs (with the default None,
@@ -2591,17 +2581,7 @@ def read_epochs(fname, proj=True, preload=True, verbose=None):
         The epochs filename to load. Filename should end with -epo.fif or
         -epo.fif.gz. If a file-like object is provided, preloading must be
         used.
-    proj : bool | 'delayed'
-        Apply SSP projection vectors. If proj is 'delayed' and reject is not
-        None the single epochs will be projected before the rejection
-        decision, but used in unprojected state if they are kept.
-        This way deciding which projection vectors are good can be postponed
-        to the evoked stage without resulting in lower epoch counts and
-        without producing results different from early SSP application
-        given comparable parameters. Note that in this case baselining,
-        detrending and temporal decimation will be postponed.
-        If proj is False no projections will be applied which is the
-        recommended value if SSPs are not used for cleaning the data.
+    %(proj_epochs)s
     preload : bool
         If True, read all epochs from disk immediately. If False, epochs will
         be read on demand.
@@ -2641,17 +2621,7 @@ class EpochsFIF(BaseEpochs):
     fname : str | file-like
         The name of the file, which should end with -epo.fif or -epo.fif.gz. If
         a file-like object is provided, preloading must be used.
-    proj : bool | 'delayed'
-        Apply SSP projection vectors. If proj is 'delayed' and reject is not
-        None the single epochs will be projected before the rejection
-        decision, but used in unprojected state if they are kept.
-        This way deciding which projection vectors are good can be postponed
-        to the evoked stage without resulting in lower epoch counts and
-        without producing results different from early SSP application
-        given comparable parameters. Note that in this case baselining,
-        detrending and temporal decimation will be postponed.
-        If proj is False no projections will be applied which is the
-        recommended value if SSPs are not used for cleaning the data.
+    %(proj_epochs)s
     preload : bool
         If True, read all epochs from disk immediately. If False, epochs will
         be read on demand.
@@ -3218,7 +3188,8 @@ def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
 
 @verbose
 def make_fixed_length_epochs(raw, duration=1., preload=False,
-                             reject_by_annotation=True, verbose=None):
+                             reject_by_annotation=True, proj=True,
+                             verbose=None):
     """Divide continuous raw data into equal-sized consecutive epochs.
 
     Parameters
@@ -3231,6 +3202,9 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
     %(reject_by_annotation_epochs)s
 
         .. versionadded:: 0.21.0
+    %(proj_epochs)s
+
+        .. versionadded:: 0.22.0
     %(verbose)s
 
     Returns
@@ -3246,4 +3220,5 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
     delta = 1. / raw.info['sfreq']
     return Epochs(raw, events, event_id=[1], tmin=0, tmax=duration - delta,
                   baseline=None, preload=preload,
-                  reject_by_annotation=reject_by_annotation, verbose=verbose)
+                  reject_by_annotation=reject_by_annotation, proj=proj,
+                  verbose=verbose)

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -122,6 +122,9 @@ def _check_for_unsupported_ica_channels(picks, info, allow_ref_meg=False):
                          % (_pl(chs), chs, types))
 
 
+_KNOWN_ICA_METHODS = ('fastica', 'infomax', 'picard')
+
+
 @fill_doc
 class ICA(ContainsMixin):
     u"""Data decomposition using Independent Component Analysis (ICA).
@@ -360,7 +363,7 @@ class ICA(ContainsMixin):
     """  # noqa: E501
 
     @verbose
-    def __init__(self, n_components=None, max_pca_components=None,
+    def __init__(self, n_components=None, *, max_pca_components=None,
                  n_pca_components=None, noise_cov=None, random_state=None,
                  method='fastica', fit_params=None, max_iter=200,
                  allow_ref_meg=False, verbose=None):  # noqa: D102
@@ -374,7 +377,7 @@ class ICA(ContainsMixin):
                  DeprecationWarning)
 
         if method != 'imported_eeglab':  # internal use only
-            _check_option('method', method, ['fastica', 'infomax', 'picard'])
+            _check_option('method', method, _KNOWN_ICA_METHODS)
         if method == 'fastica' and not check_version('sklearn'):
             raise ImportError(
                 'The scikit-learn package is required for method="fastica".')
@@ -2342,6 +2345,9 @@ def read_ica(fname, verbose=None):
     ica_init, ica_misc = [_deserialize(k) for k in (ica_init, ica_misc)]
     current_fit = ica_init.pop('current_fit')
     max_pca_components = ica_init.pop('max_pca_components')
+    method = ica_misc.get('method', 'fastica')
+    if method in _KNOWN_ICA_METHODS:
+        ica_init['method'] = method
     if ica_init['noise_cov'] == Covariance.__name__:
         logger.info('Reading whitener drawn from noise covariance ...')
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -150,12 +150,12 @@ class ICA(ContainsMixin):
             Will select the smallest number of components required to explain
             the cumulative variance of the data greater than ``n_components``.
             Consider this hypothetical example: we have 3 components, the first
-            explaining 70%, the second 20%, and the third the remaining 10% of
-            the variance. Passing 0.8 here (corresponding to 80% of explained
-            variance) would yield the first two components, explaining 90% of
-            the variance: only by using both components the requested threshold
-            of 80% explained variance can be exceeded. The third component, on
-            the other hand, would be excluded.
+            explaining 70%%, the second 20%%, and the third the remaining 10%%
+            of the variance. Passing 0.8 here (corresponding to 80%% of
+            explained variance) would yield the first two components,
+            explaining 90%% of the variance: only by using both components the
+            requested threshold of 80%% explained variance can be exceeded. The
+            third component, on the other hand, would be excluded.
         - ``None``
             ``n_pca_components`` or ``0.999999`` will be used, whichever
             results in fewer components. This is done to avoid numerical

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -154,7 +154,8 @@ class ICA(ContainsMixin):
         - ``None``
             ``n_pca_components`` or ``0.999999`` will be used, whichever
             results in fewer components. This is done to avoid numerical
-            stability problems when whitening.
+            stability problems when whitening, particularly when working
+            with rank-deficient data.
 
         Defaults to ``None``. The actual number used when executing the
         :meth:`ICA.fit` method will be stored in the attribute

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -147,10 +147,15 @@ class ICA(ContainsMixin):
             Must be greater than 1 and less than or equal to
             ``n_pca_components``.
         - :class:`float` between 0 and 1 (exclusive)
-            The number of components with cumulative explained variance
-            of the data greater than ``n_components`` will be used. For
-            example, if 0.8 is passed then the number of components will
-            explain greater than 80%% of the variance.
+            Will select the smallest number of components required to explain
+            the cumulative variance of the data greater than ``n_components``.
+            Consider this hypothetical example: we have 3 components, the first
+            explaining 70%, the second 20%, and the third the remaining 10% of
+            the variance. Passing 0.8 here (corresponding to 80% of explained
+            variance) would yield the first two components, explaining 90% of
+            the variance: only by using both components the requested threshold
+            of 80% explained variance can be exceeded. The third component, on
+            the other hand, would be excluded.
         - ``None``
             ``n_pca_components`` or ``0.999999`` will be used, whichever
             results in fewer components. This is done to avoid numerical

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -141,39 +141,35 @@ class ICA(ContainsMixin):
         are passed to the ICA algorithm during fitting. If :class:`int`, must
         not be larger than ``max_pca_components``. If :class:`float` between 0
         and 1, the number of components with cumulative explained variance
+        (of the ``n_pca_components`` components)
         greater than ``n_components`` will be used. If ``None``,
-        ``max_pca_components`` will be used. Defaults to ``None``; the actual
+        ``n_pca_components`` will be used. Defaults to ``None``; the actual
         number used when executing the :meth:`ICA.fit` method will be stored in
         the attribute ``n_components_`` (note the trailing underscore).
-    max_pca_components : int | float | None
-        The number of principal components (from the pre-whitening PCA step)
-        that are retained for later use (i.e., for signal reconstruction in
-        `~mne.preprocessing.ICA.apply`; see the ``n_pca_components``
-        parameter). Use this parameter to reduce the dimensionality of the
-        input data via PCA before any further processing is performed.
-        If :class:`float` between 0 and 1, the number of components with
-        cumulative explained variance greater than ``max_pca_components`` will
-        be used. If ``1.0`` or ``None``, no dimensionality reduction occurs and
-        ``max_pca_components`` will equal the number of channels in the
-        `~mne.io.Raw` or `~mne.Epochs` object passed to
-        `~mne.preprocessing.ICA.fit`. Defaults to ``None``. When calling
-        `~mne.preprocessing.ICA.fit`, the attribute ``max_pca_components_``
-        will be set to the absolute number of retained PCA components.
 
         .. versionchanged:: 0.22
-            Added support for float to select components by cumulative
-            explained variance.
+           The number of components returned for a :class:`python:float`
+           is greater than the given variance level instead of less than or
+           equal to it.
+    max_pca_components : int | None
+        This parameter is deprecated and will be removed in 0.23. Use
+        ``n_pca_components`` instead.
     n_pca_components : int | float | None
         Total number of components (ICA + PCA) used for signal reconstruction
-        in :meth:`ICA.apply`. At minimum, at least ``n_components`` will be
+        in :meth:`ICA.apply`. At minimum, at least ``n_components`` must be
         used (unless modified by ``ICA.include`` or ``ICA.exclude``). If
         ``n_pca_components > n_components``, additional PCA components will be
         incorporated. If :class:`float` between 0 and 1, the number is chosen
         as the number of *PCA* components with cumulative explained variance
         greater than ``n_components`` (without accounting for ``ICA.include``
         or ``ICA.exclude``). If :class:`int` or :class:`float`,
-        ``n_components_ ≤ n_pca_components ≤ max_pca_components_`` must hold.
-        If ``None``, ``max_pca_components`` will be used. Defaults to ``None``.
+        ``n_components_ ≤ n_pca_components`` must hold.
+        If ``None``, all components (i.e., the number of channels) will be
+        used. Defaults to ``None``.
+
+        The value provided during class construction serves as a default value.
+        Different values can be provided in the :meth:`apply` method to test
+        different levels of PCA-based denoising.
 
         .. versionchanged:: 0.22
            The number of components returned for a :class:`python:float`
@@ -181,8 +177,8 @@ class ICA(ContainsMixin):
            equal to it.
     noise_cov : None | instance of Covariance
         Noise covariance used for pre-whitening. If None (default), channels
-        are scaled to unit variance ("z-standardized") prior to the whitening
-        by PCA.
+        are scaled to unit variance ("z-standardized") by type prior to the
+        whitening by PCA.
     %(random_state)s
         As estimation can be non-deterministic it can be useful to fix the
         random state to have reproducible results.
@@ -371,37 +367,45 @@ class ICA(ContainsMixin):
         _validate_type(method, str, 'method')
         _validate_type(n_components, ('numeric', None))
         _validate_type(n_pca_components, ('numeric', None))
-        _validate_type(max_pca_components, ('numeric', None))
+        _validate_type(max_pca_components, ('int-like', None))
+        if max_pca_components is not None:
+            warn(f'max_pca_components ({max_pca_components}) is deprecated and'
+                 ' will be removed in 0.23, use n_pca_components instead',
+                 DeprecationWarning)
 
         if method != 'imported_eeglab':  # internal use only
             _check_option('method', method, ['fastica', 'infomax', 'picard'])
         if method == 'fastica' and not check_version('sklearn'):
-            raise RuntimeError(
-                'The scikit-learn package is required for FastICA.')
+            raise ImportError(
+                'The scikit-learn package is required for method="fastica".')
+        if method == 'picard' and not check_version('picard'):
+            raise ImportError(
+                'The python-picard package is required for method="picard".')
 
         self.noise_cov = noise_cov
 
         if (n_components is not None and
                 max_pca_components is not None and
-                not isinstance(max_pca_components, float) and
                 n_components > max_pca_components):
-            raise ValueError('n_components must be smaller than '
-                             'max_pca_components')
+            raise ValueError(f'n_components ({n_components}) must be smaller '
+                             f'than max_pca_components ({max_pca_components})')
+
+        if (n_components is not None and
+                n_pca_components is not None and
+                not isinstance(n_pca_components, float) and
+                n_components > n_pca_components):
+            raise ValueError(f'n_components ({n_components}) must be smaller '
+                             f'than n_pca_components ({n_pca_components})')
 
         if (isinstance(n_components, float) and
                 not 0 < n_components <= 1):
             raise ValueError('Selecting ICA components by explained variance '
                              'needs values between 0.0 and 1.0')
 
-        if (isinstance(max_pca_components, float) and
-                not 0 < max_pca_components <= 1):
-            raise ValueError('Selecting PCA components by explained variance '
-                             'needs values between 0.0 and 1.0')
-
         self.current_fit = 'unfitted'
         self.verbose = verbose
         self.n_components = n_components
-        self.max_pca_components = max_pca_components
+        self._max_pca_components = max_pca_components
         self.n_pca_components = n_pca_components
         self.ch_names = None
         self.random_state = random_state
@@ -428,6 +432,13 @@ class ICA(ContainsMixin):
         self.method = method
         self.labels_ = dict()
         self.allow_ref_meg = allow_ref_meg
+
+    @property
+    def max_pca_components(self):
+        warn('The max_pca_components property is deprecated and will be '
+             'removed in 0.21, use n_pca_components instead',
+             DeprecationWarning)
+        return self._max_pca_components
 
     def __repr__(self):
         """ICA fit information."""
@@ -524,14 +535,10 @@ class ICA(ContainsMixin):
         logger.info('Fitting ICA to data using %i channels '
                     '(please be patient, this may take a while)' % len(picks))
 
-        self.max_pca_components_ = self.max_pca_components
-        if (self.max_pca_components_ is None or
-                self.max_pca_components_ == 1.0):
-            logger.info('Inferring max_pca_components from picks')
-            self.max_pca_components_ = len(picks)
-        elif self.max_pca_components_ > len(picks):
+        if self._max_pca_components is not None and \
+                self._max_pca_components > len(picks):
             raise ValueError(
-                f'ica.max_pca_components ({self.max_pca_components_}) cannot '
+                f'ica.max_pca_components ({self._max_pca_components}) cannot '
                 f'be greater than len(picks) ({len(picks)})')
 
         # n_components could be float 0 < x <= 1, but that's okay here
@@ -566,7 +573,7 @@ class ICA(ContainsMixin):
         """Aux method."""
         for key in ('pre_whitener_', 'unmixing_matrix_', 'mixing_matrix_',
                     'n_components_', 'n_samples_', 'pca_components_',
-                    'max_pca_components_', 'pca_explained_variance_',
+                    'pca_explained_variance_',
                     'pca_mean_', 'n_iter_', 'drop_inds_', 'reject_'):
             if hasattr(self, key):
                 delattr(self, key)
@@ -682,54 +689,34 @@ class ICA(ContainsMixin):
         self._compute_pre_whitener(data)
         data = self._pre_whiten(data)
 
-        if (self.max_pca_components is None or
-                isinstance(self.max_pca_components, float)):
-            # Use all channels. For float input <1.0, we will reduce the number
-            # of retained components later.
-            self.max_pca_components_ = n_channels
-
-        pca = _PCA(n_components=self.max_pca_components_, whiten=True)
-        data_transformed = pca.fit_transform(data.T)
-
-        # If user passed a float, re-run the PCA, but only keep the number of
-        # components required to explain the requested cumulative variance.
-        # While we could also simply select a sub-set of the data acquired
-        # above, re-running PCA from scratch is less bug-prone, as it will
-        # ensure that all internals of the _PCA instance are properly updated
-        # as well, and we don't need to handle this case specially below.
-        # Note that the result should be numerically identical to the first
-        # PCA run for all retained components.
-        if (isinstance(self.max_pca_components, float) and
-                self.max_pca_components != 1.0):
-            del data_transformed  # Free memory.
-            self.max_pca_components_, _ = _exp_var_ncomp(
-                pca.explained_variance_ratio_, self.max_pca_components)
-
-            if (self.n_components is not None and
-                    self.max_pca_components_ < self.n_components):
-                raise ValueError(
-                    f'You asked to select only a subset of PCA components by '
-                    f'passing max_pca_components={self.max_pca_components}, '
-                    f'which equals {self.max_pca_components_} components '
-                    f'for this specific dataset. However, you also '
-                    f'requested to pass {self.n_components} of those '
-                    f'components to ICA, which is mathematically '
-                    f'impossible. Please either increase '
-                    f'max_pca_components, set it to None, reduce '
-                    f'n_components, or set n_components=None')
-
-            pca = _PCA(n_components=self.max_pca_components_, whiten=True)
-            data_transformed = pca.fit_transform(data.T)
-
-        assert data_transformed.shape == (n_samples, self.max_pca_components_)
-        del data
+        pca = _PCA(n_components=self._max_pca_components, whiten=True)
+        data = pca.fit_transform(data.T)
+        use_ev = pca.explained_variance_ratio_
+        n_pca = self.n_pca_components
+        if isinstance(n_pca, float):
+            n_pca = int(_exp_var_ncomp(use_ev, n_pca)[0])
+        elif n_pca is None:
+            n_pca = len(use_ev)
+        assert isinstance(n_pca, (int, np.int_))
 
         # If user passed a float, select the PCA components explaining the
         # given cumulative variance. This information will later be used to
         # only submit the corresponding parts of the data to ICA.
-        if isinstance(self.n_components, float):
+        msg = None
+        if self.n_components is not None:
+            self.n_components_ = self.n_components
+        elif self.n_pca_components is not None:
+            self.n_components_ = self.n_pca_components
+        else:  # Both None
+            self.n_components_ = len(pca.components_)
+            msg = 'Selecting all PCA components'
+        if isinstance(self.n_components_, float):
+            # XXX not 100% sure if this should be use_ev or use_ev[:n_pca],
+            # i.e., is n_components float the threshold for the explained
+            # variance remaining after subselecting n_pca_components, or is
+            # it from the original data
             self.n_components_, ev = _exp_var_ncomp(
-                pca.explained_variance_ratio_, self.n_components)
+                use_ev[:n_pca], self.n_components_)
             if self.n_components_ == 1:
                 raise RuntimeError(
                     'One PCA component captures most of the '
@@ -737,13 +724,15 @@ class ICA(ContainsMixin):
                     'results in 1 component. You should select '
                     'a higher value.')
             msg = 'Selecting by explained variance'
-        else:
-            if self.n_components is not None:  # normal n case
-                self.n_components_ = _ensure_int(self.n_components)
-                msg = 'Selecting by number'
-            else:  # None case
-                self.n_components_ = len(pca.components_)
-                msg = 'Selecting all PCA components'
+        elif msg is None:
+            msg = 'Selecting by number'
+        # check to make sure something okay happened
+        if self.n_components_ > n_pca:
+            raise RuntimeError(
+                f'n_components={self.n_components} requires '
+                f'{self.n_components_} PCA values but n_pca_components '
+                f'({self.n_pca_components}) results in only {n_pca} '
+                'components')
         logger.info('%s: %s components' % (msg, self.n_components_))
 
         # the things to store for PCA
@@ -753,33 +742,33 @@ class ICA(ContainsMixin):
         del pca
         # update number of components
         self._update_ica_names()
-        if self.n_pca_components is not None:
-            if self.n_pca_components > len(self.pca_components_):
-                self.n_pca_components = len(self.pca_components_)
+        if self.n_pca_components is not None and \
+                self.n_pca_components > len(self.pca_components_):
+            raise ValueError(
+                f'n_pca_components ({self.n_pca_components}) is greater than '
+                f'the number of PCA components ({len(self.pca_components_)})')
 
         # take care of ICA
         sel = slice(0, self.n_components_)
         if self.method == 'fastica':
             from sklearn.decomposition import FastICA
-            ica = FastICA(whiten=False, random_state=random_state,
-                          **self.fit_params)
-            ica.fit(data_transformed[:, sel])
+            ica = FastICA(
+                whiten=False, random_state=random_state, **self.fit_params)
+            ica.fit(data[:, sel])
             self.unmixing_matrix_ = ica.components_
             self.n_iter_ = ica.n_iter_
         elif self.method in ('infomax', 'extended-infomax'):
-            unmixing_matrix, n_iter = infomax(data_transformed[:, sel],
-                                              random_state=random_state,
-                                              return_n_iter=True,
-                                              **self.fit_params)
+            unmixing_matrix, n_iter = infomax(
+                data[:, sel], random_state=random_state, return_n_iter=True,
+                **self.fit_params)
             self.unmixing_matrix_ = unmixing_matrix
             self.n_iter_ = n_iter
             del unmixing_matrix, n_iter
         elif self.method == 'picard':
             from picard import picard
-            _, W, _, n_iter = picard(data_transformed[:, sel].T, whiten=False,
-                                     return_n_iter=True,
-                                     random_state=random_state,
-                                     **self.fit_params)
+            _, W, _, n_iter = picard(
+                data[:, sel].T, whiten=False, return_n_iter=True,
+                random_state=random_state, **self.fit_params)
             self.unmixing_matrix_ = W
             self.n_iter_ = n_iter + 1  # picard() starts counting at 0
             del _, n_iter
@@ -1561,10 +1550,7 @@ class ICA(ContainsMixin):
         exclude : array_like of int
             The indices referring to columns in the ummixing matrix. The
             components to be zeroed out.
-        n_pca_components : int | float | None
-            The number of PCA components to be kept, either absolute (int)
-            or percentage of the explained variance (float). If None (default),
-            all PCA components will be used.
+        %(n_pca_components_apply)s
         start : int | float | None
             First sample to include. If float, data will be interpreted as
             time in seconds. If None, data will be used from the first sample.
@@ -1607,16 +1593,13 @@ class ICA(ContainsMixin):
         """Aux method."""
         _check_preload(raw, "ica.apply")
 
-        if n_pca_components is not None:
-            self.n_pca_components = n_pca_components
-
         start, stop = _check_start_stop(raw, start, stop)
 
         picks = pick_types(raw.info, meg=False, include=self.ch_names,
                            exclude='bads', ref_meg=False)
 
         data = raw[picks, start:stop][0]
-        data = self._pick_sources(data, include, exclude)
+        data = self._pick_sources(data, include, exclude, n_pca_components)
 
         raw[picks, start:stop] = data
         return raw
@@ -1637,11 +1620,8 @@ class ICA(ContainsMixin):
                                'ica.ch_names' % (len(self.ch_names),
                                                  len(picks)))
 
-        if n_pca_components is not None:
-            self.n_pca_components = n_pca_components
-
         data = np.hstack(epochs.get_data(picks))
-        data = self._pick_sources(data, include=include, exclude=exclude)
+        data = self._pick_sources(data, include, exclude, n_pca_components)
 
         # restore epochs, channels, tsl order
         epochs._data[:, picks] = np.array(
@@ -1664,30 +1644,30 @@ class ICA(ContainsMixin):
                                'with ica.ch_names' % (len(self.ch_names),
                                                       len(picks)))
 
-        if n_pca_components is not None:
-            self.n_pca_components = n_pca_components
-
         data = evoked.data[picks]
-        data = self._pick_sources(data, include=include,
-                                  exclude=exclude)
+        data = self._pick_sources(data, include, exclude, n_pca_components)
 
         # restore evoked
         evoked.data[picks] = data
 
         return evoked
 
-    def _pick_sources(self, data, include, exclude):
+    def _pick_sources(self, data, include, exclude, n_pca_components):
         """Aux function."""
+        if n_pca_components is None:
+            n_pca_components = self.n_pca_components
         data = self._pre_whiten(data)
         exclude = self._check_exclude(exclude)
-        _n_pca_comp = self._check_n_pca_components(self.n_pca_components)
+        _n_pca_comp = self._check_n_pca_components(n_pca_components)
         n_ch, _ = data.shape
 
-        if not(self.n_components_ <= _n_pca_comp <= self.max_pca_components_):
+        max_pca_components = self.pca_components_.shape[0]
+        if not self.n_components_ <= _n_pca_comp <= max_pca_components:
             raise ValueError(
                 f'n_pca_components ({_n_pca_comp}) must be >= '
                 f'n_components_ ({self.n_components_}) and <= '
-                'max_pca_components_ ({self.max_pca_components_}).')
+                'the total number of PCA components '
+                f'({max_pca_components}).')
 
         logger.info(f'    Transforming to ICA space ({self.n_components_} '
                     f'component{_pl(self.n_components_)})')
@@ -1844,9 +1824,10 @@ class ICA(ContainsMixin):
 
     @copy_function_doc_to_method_doc(plot_ica_overlay)
     def plot_overlay(self, inst, exclude=None, picks=None, start=None,
-                     stop=None, title=None, show=True):
+                     stop=None, title=None, show=True, n_pca_components=None):
         return plot_ica_overlay(self, inst=inst, exclude=exclude, picks=picks,
-                                start=start, stop=stop, title=title, show=show)
+                                start=start, stop=stop, title=title, show=show,
+                                n_pca_components=n_pca_components)
 
     def detect_artifacts(self, raw, start_find=None, stop_find=None,
                          ecg_ch=None, ecg_score_func='pearsonr',
@@ -1976,7 +1957,9 @@ class ICA(ContainsMixin):
                         f'variance ({100 * ev}≥{100 * _n_pca_comp}%)')
             _n_pca_comp = n
         elif _n_pca_comp is None:
-            _n_pca_comp = self.max_pca_components_
+            _n_pca_comp = self._max_pca_components
+            if _n_pca_comp is None:
+                _n_pca_comp = self.pca_components_.shape[0]
         elif _n_pca_comp < self.n_components_:
             _n_pca_comp = self.n_components_
 
@@ -2224,7 +2207,7 @@ def _write_ica(fid, ica):
     ica_init = dict(noise_cov=ica.noise_cov,
                     n_components=ica.n_components,
                     n_pca_components=ica.n_pca_components,
-                    max_pca_components=ica.max_pca_components,
+                    max_pca_components=ica._max_pca_components,
                     current_fit=ica.current_fit,
                     allow_ref_meg=ica.allow_ref_meg)
 
@@ -2254,8 +2237,6 @@ def _write_ica(fid, ica):
                 'labels_': getattr(ica, 'labels_', None),
                 'method': getattr(ica, 'method', None),
                 'n_iter_': getattr(ica, 'n_iter_', None),
-                'max_pca_components_': getattr(ica, 'max_pca_components_',
-                                               None),
                 'fit_params': getattr(ica, 'fit_params', None)}
 
     #   ICA misc params
@@ -2360,6 +2341,7 @@ def read_ica(fname, verbose=None):
 
     ica_init, ica_misc = [_deserialize(k) for k in (ica_init, ica_misc)]
     current_fit = ica_init.pop('current_fit')
+    max_pca_components = ica_init.pop('max_pca_components')
     if ica_init['noise_cov'] == Covariance.__name__:
         logger.info('Reading whitener drawn from noise covariance ...')
 
@@ -2378,6 +2360,7 @@ def read_ica(fname, verbose=None):
     ica.pca_mean_ = f(pca_mean)
     ica.pca_components_ = f(pca_components)
     ica.n_components_ = unmixing_matrix.shape[0]
+    ica._max_pca_components = max_pca_components
     ica._update_ica_names()
     ica.pca_explained_variance_ = f(pca_explained_variance)
     ica.unmixing_matrix_ = f(unmixing_matrix)
@@ -2396,13 +2379,6 @@ def read_ica(fname, verbose=None):
         ica.n_iter_ = ica_misc['n_iter_']
     if 'fit_params' in ica_misc:
         ica.fit_params = ica_misc['fit_params']
-
-    if ('max_pca_components_' in ica_misc and
-            ica_misc['max_pca_components_'] is not None):
-        ica.max_pca_components_ = ica_misc['max_pca_components_']
-    else:
-        # For backward-compatibility.
-        ica.max_pca_components_ = ica.max_pca_components
 
     logger.info('Ready.')
 
@@ -2740,8 +2716,7 @@ def read_ica_eeglab(fname):
     ica.current_fit = "eeglab"
     ica.ch_names = info["ch_names"]
     ica.n_pca_components = None
-    ica.max_pca_components = n_components
-    ica.max_pca_components_ = n_components
+    ica._max_pca_components = None
     ica.n_components_ = n_components
 
     ica.pre_whitener_ = np.ones((len(eeg.icachansind), 1))

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -224,6 +224,7 @@ def test_ica_n_iter_(method, tmpdir):
     else:
         with pytest.warns(UserWarning, match='did not converge'):
             ica.fit(raw)
+    assert ica.method == method
 
     assert_equal(ica.n_iter_, max_iter)
 
@@ -232,6 +233,7 @@ def test_ica_n_iter_(method, tmpdir):
     _assert_ica_attributes(ica, raw.get_data('data'), limits=(5, 110))
     ica.save(output_fname)
     ica = read_ica(output_fname)
+    assert ica.method == method
     _assert_ica_attributes(ica)
 
     assert_equal(ica.n_iter_, max_iter)
@@ -1078,10 +1080,12 @@ def test_max_pca_components(tmpdir):
         ica = ICA(max_pca_components=max_pca_components, method=method,
                   n_components=n_components, random_state=random_state)
     ica.fit(epochs)
+    assert ica.method == method
 
     _assert_ica_attributes(ica, epochs.get_data(), limits=(0.01, 50))
     ica.save(output_fname)
     ica = read_ica(output_fname)
+    assert ica.method == method
     with pytest.deprecated_call():
         assert ica.max_pca_components == max_pca_components
     assert_equal(ica.n_components, n_components)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -1059,7 +1059,7 @@ def test_eog_channel(method):
         assert not any('EOG' in ch for ch in ica.ch_names)
 
 
-def test_max_pca_components(max_pca_components, tmpdir):
+def test_max_pca_components(tmpdir):
     """Test max_pca_components."""
     max_pca_components = 15
     raw = read_raw_fif(raw_fname).crop(1.5, stop).load_data()
@@ -1074,14 +1074,16 @@ def test_max_pca_components(max_pca_components, tmpdir):
 
     output_fname = tmpdir.join('test_ica-ica.fif')
 
-    ica = ICA(max_pca_components=max_pca_components, method=method,
-              n_components=n_components, random_state=random_state)
+    with pytest.deprecated_call():
+        ica = ICA(max_pca_components=max_pca_components, method=method,
+                  n_components=n_components, random_state=random_state)
     ica.fit(epochs)
 
     _assert_ica_attributes(ica, epochs.get_data(), limits=(0.01, 50))
     ica.save(output_fname)
     ica = read_ica(output_fname)
-    assert_equal(ica.max_pca_components, max_pca_components)
+    with pytest.deprecated_call():
+        assert ica.max_pca_components == max_pca_components
     assert_equal(ica.n_components, n_components)
 
 

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -92,7 +92,6 @@ def test_ica_full_data_recovery(method):
         stuff = [(2, n_channels, True), (2, n_channels // 2, False)]
         for n_components, n_pca_components, ok in stuff:
             ica = ICA(n_components=n_components, random_state=0,
-                      max_pca_components=n_pca_components,
                       n_pca_components=n_pca_components,
                       method=method, max_iter=1)
             picks = list(range(n_channels))
@@ -108,7 +107,6 @@ def test_ica_full_data_recovery(method):
                 assert (np.max(diff) > 1e-14)
 
             ica = ICA(n_components=n_components, method=method,
-                      max_pca_components=n_pca_components,
                       n_pca_components=n_pca_components, random_state=0)
             with pytest.warns(None):  # sometimes warns
                 ica.fit(epochs, picks=picks)
@@ -163,9 +161,9 @@ def test_ica_simple(method):
 
 @requires_sklearn
 @pytest.mark.parametrize('n_components', (None, 0.9999, 8, 9, 10))
-@pytest.mark.parametrize('max_pca_components', [8, 9, 0.9999, 10])
+@pytest.mark.parametrize('n_pca_components', [8, 9, 0.9999, 10])
 @pytest.mark.filterwarnings('ignore:FastICA did not converge.*:UserWarning')
-def test_ica_noop(n_components, max_pca_components, tmpdir):
+def test_ica_noop(n_components, n_pca_components, tmpdir):
     """Test that our ICA is stable even with a bad max_pca_components."""
     data = np.random.RandomState(0).randn(10, 1000)
     info = create_info(10, 1000., 'eeg')
@@ -173,35 +171,31 @@ def test_ica_noop(n_components, max_pca_components, tmpdir):
     raw.set_eeg_reference()
     assert np.linalg.matrix_rank(raw.get_data()) == 9
     kwargs = dict(n_components=n_components,
-                  max_pca_components=max_pca_components, verbose=True)
+                  n_pca_components=n_pca_components, verbose=True)
     if isinstance(n_components, int) and \
-            isinstance(max_pca_components, int) and \
-            n_components > max_pca_components:
-        with pytest.raises(ValueError, match='n_components must be smaller.*'):
+            isinstance(n_pca_components, int) and \
+            n_components > n_pca_components:
+        with pytest.raises(ValueError, match='n_components.*must be smalle.*'):
             ICA(**kwargs)
         return
     ica = ICA(**kwargs)
-    if n_components == 10 and isinstance(max_pca_components, float):
-        with pytest.raises(ValueError, match='select only a subset'):
+    if n_components == 10 and n_pca_components == 0.9999:
+        with pytest.raises(RuntimeError, match='.*requires.*PCA.*'):
             ica.fit(raw)
         return
     ica.fit(raw)
+    assert ica._max_pca_components is None
     raw_new = ica.apply(raw.copy())
     # not a no-op
-    if max_pca_components == 8:  # XXX this fails: or n_pca_components == 8:
+    if n_pca_components == 8:
+        assert ica.n_pca_components == 8
+        assert not np.allclose(raw.get_data(), raw_new.get_data(), atol=0)
+        return
+    # breaks pseudoinversion
+    elif n_pca_components == 10 and n_components in (10, None):
+        # XXX this case should warn
         assert not np.allclose(raw.get_data(), raw_new.get_data())
         return
-    # XXX this case should warn?
-    if max_pca_components == 10:
-        assert ica.max_pca_components_ == 10
-        # XXX setting n_components to something safe prevents the blowup, maybe
-        # we don't need max_pca_components as float? For example setting the
-        # default or warning based on n_components is probably enough...
-        if not (max_pca_components == 10 and n_components in (8, 9, 0.9999)):
-            assert not np.allclose(raw.get_data(), raw_new.get_data())
-            return
-    else:
-        assert ica.max_pca_components_ == 9
     assert_allclose(raw.get_data(), raw_new.get_data(), err_msg='Id failure')
     _assert_ica_attributes(ica, data)
     # and with I/O
@@ -355,7 +349,6 @@ def test_ica_reset(method):
         'n_components_',
         'n_samples_',
         'pca_components_',
-        'max_pca_components_',
         'pca_explained_variance_',
         'pca_mean_',
         'n_iter_'
@@ -388,7 +381,7 @@ def test_ica_core(method):
                     baseline=(None, 0), preload=True)
     noise_cov = [None, test_cov]
     # removed None cases to speed up...
-    n_components = [2, 1.0]  # for future dbg add cases
+    n_components = [2, 0.95]  # for future dbg add cases
     max_pca_components = [3]
     picks_ = [picks]
     methods = [method]
@@ -396,17 +389,16 @@ def test_ica_core(method):
                               picks_, methods)
 
     # # test init catchers
-    with pytest.raises(ValueError, match='must be smaller than max_pca'):
-        ICA(n_components=3, max_pca_components=2)
+    with pytest.raises(ValueError, match='must be smaller than n_pca'):
+        ICA(n_components=3, n_pca_components=2)
     with pytest.raises(ValueError, match='explained variance needs values'):
-        ICA(n_components=2.3, max_pca_components=3)
+        ICA(n_components=2.3, n_pca_components=3)
 
     # test essential core functionality
     for n_cov, n_comp, max_n, pcks, method in iter_ica_params:
         # Test ICA raw
         ica = ICA(noise_cov=n_cov, n_components=n_comp,
-                  max_pca_components=max_n, n_pca_components=max_n,
-                  method=method, max_iter=1)
+                  n_pca_components=max_n, method=method, max_iter=1)
         with pytest.raises(ValueError, match='Cannot check for channels of t'):
             'meg' in ica
 
@@ -460,8 +452,7 @@ def test_ica_core(method):
         #######################################################################
         # test epochs decomposition
         ica = ICA(noise_cov=n_cov, n_components=n_comp,
-                  max_pca_components=max_n, n_pca_components=max_n,
-                  method=method)
+                  n_pca_components=max_n, method=method)
         with pytest.warns(None):  # sometimes warns
             ica.fit(epochs, picks=picks)
         _assert_ica_attributes(ica, epochs.get_data(picks), limits=(0.2, 20))
@@ -502,11 +493,11 @@ def test_ica_core(method):
         ica.apply(offender)
 
     # gh-7868
-    ica.max_pca_components = 3
-    ica.n_components = 0.99
-    with pytest.raises(ValueError, match='pca_components.*cannot be greater'):
+    ica.n_pca_components = 3
+    ica.n_components = None
+    with pytest.raises(ValueError, match='pca_components.*is greater'):
         ica.fit(epochs, picks=[0, 1])
-    ica.max_pca_components = None
+    ica.n_pca_components = None
     ica.n_components = 3
     with pytest.raises(ValueError, match='n_components.*cannot be greater'):
         ica.fit(epochs, picks=[0, 1])
@@ -535,8 +526,8 @@ def test_ica_additional(method, tmpdir):
     assert len(epochs) == 4
 
     # test if n_components=None works
-    ica = ICA(n_components=None, max_pca_components=None,
-              n_pca_components=None, method=method, max_iter=1)
+    ica = ICA(n_components=None, n_pca_components=None, method=method,
+              max_iter=1)
     with pytest.warns(UserWarning, match='did not converge'):
         ica.fit(epochs)
     _assert_ica_attributes(ica, epochs.get_data('data'), limits=(0.05, 20))
@@ -547,8 +538,8 @@ def test_ica_additional(method, tmpdir):
     del picks2
 
     test_cov2 = test_cov.copy()
-    ica = ICA(noise_cov=test_cov2, n_components=3, max_pca_components=4,
-              n_pca_components=4, method=method)
+    ica = ICA(noise_cov=test_cov2, n_components=3, n_pca_components=4,
+              method=method)
     assert (ica.info is None)
     with pytest.warns(RuntimeWarning, match='normalize_proj'):
         ica.fit(raw, picks[:5])
@@ -556,9 +547,9 @@ def test_ica_additional(method, tmpdir):
     assert (isinstance(ica.info, Info))
     assert (ica.n_components_ < 5)
 
-    ica = ICA(n_components=3, max_pca_components=4, method=method,
-              n_pca_components=4)
-    pytest.raises(RuntimeError, ica.save, '')
+    ica = ICA(n_components=3, n_pca_components=4, method=method)
+    with pytest.raises(RuntimeError, match='No fit'):
+        ica.save('')
 
     ica.fit(raw, picks=[1, 2, 3, 4, 5], start=start, stop=stop2)
     _assert_ica_attributes(
@@ -627,8 +618,7 @@ def test_ica_additional(method, tmpdir):
         read_ica(ica_badname)
 
     # test decim
-    ica = ICA(n_components=3, max_pca_components=4,
-              n_pca_components=4, method=method, max_iter=1)
+    ica = ICA(n_components=3, n_pca_components=4, method=method, max_iter=1)
     raw_ = raw.copy()
     for _ in range(3):
         raw_.append(raw_)
@@ -639,12 +629,11 @@ def test_ica_additional(method, tmpdir):
     assert raw_._data.shape[1] == n_samples
 
     # test expl var
-    ica = ICA(n_components=1.0, max_pca_components=4,
-              n_pca_components=4, method=method, max_iter=1)
+    ica = ICA(n_components=1.0, n_pca_components=4, method=method, max_iter=1)
     with pytest.warns(UserWarning, match='did not converge'):
         ica.fit(raw, picks=None, decim=3)
     _assert_ica_attributes(ica)
-    assert (ica.n_components_ == 4)
+    assert ica.n_components_ == 4
     ica_var = _ica_explained_variance(ica, raw, normalize=True)
     assert (np.all(ica_var[:-1] >= ica_var[1:]))
 
@@ -660,15 +649,15 @@ def test_ica_additional(method, tmpdir):
     # test reading and writing
     test_ica_fname = tmpdir.join('test-ica.fif')
     for cov in (None, test_cov):
-        ica = ICA(noise_cov=cov, n_components=2, max_pca_components=4,
-                  n_pca_components=4, method=method, max_iter=1)
+        ica = ICA(noise_cov=cov, n_components=2, n_pca_components=4,
+                  method=method, max_iter=1)
         with pytest.warns(None):  # ICA does not converge
             ica.fit(raw, picks=picks[:10], start=start, stop=stop2)
         _assert_ica_attributes(ica)
         sources = ica.get_sources(epochs).get_data()
         assert (ica.mixing_matrix_.shape == (2, 2))
         assert (ica.unmixing_matrix_.shape == (2, 2))
-        assert (ica.pca_components_.shape == (4, 10))
+        assert (ica.pca_components_.shape == (10, 10))
         assert (sources.shape[1] == ica.n_components_)
 
         for exclude in [[], [0], np.array([1, 2, 3])]:
@@ -922,8 +911,7 @@ def test_ica_reject_buffer(method):
     picks = pick_types(raw.info, meg=True, stim=False, ecg=False,
                        eog=False, exclude='bads')
     raw._data[2, 1000:1005] = 5e-12
-    ica = ICA(n_components=3, max_pca_components=4, n_pca_components=4,
-              method=method)
+    ica = ICA(n_components=3, n_pca_components=4, method=method)
     with catch_logging() as drop_log:
         ica.fit(raw, picks[:5], reject=dict(mag=2.5e-12), decim=2,
                 tstep=0.01, verbose=True, reject_by_annotation=False)
@@ -1071,10 +1059,9 @@ def test_eog_channel(method):
         assert not any('EOG' in ch for ch in ica.ch_names)
 
 
-@requires_sklearn
-@pytest.mark.parametrize('max_pca_components', (1.0, 15, 0.99, 0.5, 1.5))
 def test_max_pca_components(max_pca_components, tmpdir):
     """Test max_pca_components."""
+    max_pca_components = 15
     raw = read_raw_fif(raw_fname).crop(1.5, stop).load_data()
     events = read_events(event_name)
     picks = pick_types(raw.info, eeg=True, meg=False)
@@ -1087,63 +1074,15 @@ def test_max_pca_components(max_pca_components, tmpdir):
 
     output_fname = tmpdir.join('test_ica-ica.fif')
 
-    if max_pca_components == 1.5:
-        with pytest.raises(ValueError, match='PCA .* needs values between'):
-            ica = ICA(max_pca_components=max_pca_components, method=method,
-                      n_components=n_components, random_state=random_state)
-        return
-
     ica = ICA(max_pca_components=max_pca_components, method=method,
               n_components=n_components, random_state=random_state)
-
-    if max_pca_components == 0.5:
-        with pytest.raises(ValueError, match='increase max_pca_components'):
-            ica.fit(epochs)
-        return
-
     ica.fit(epochs)
 
     _assert_ica_attributes(ica, epochs.get_data(), limits=(0.01, 50))
     ica.save(output_fname)
     ica = read_ica(output_fname)
     assert_equal(ica.max_pca_components, max_pca_components)
-
-    if max_pca_components == 1.0:
-        expected_max_pca_components = epochs.info['nchan']
-        assert_equal(ica.max_pca_components_, expected_max_pca_components)
-    elif max_pca_components == 15:
-        expected_max_pca_components = 15
-        assert_equal(ica.max_pca_components_, expected_max_pca_components)
-
     assert_equal(ica.n_components, n_components)
-
-
-@requires_sklearn
-@pytest.mark.parametrize('method', ['infomax', 'fastica', 'picard'])
-def test_max_pca_components_(method, tmpdir):
-    """Test that max_pca_components_ gets populated when reading old file."""
-    _skip_check_picard(method)
-    fname = tmpdir.join('test_ica-ica.fif')
-
-    raw = read_raw_fif(raw_fname).crop(1.5, stop).load_data()
-    events = read_events(event_name)
-    picks = pick_types(raw.info, eeg=True, meg=False)
-    epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
-                    baseline=(None, 0), preload=True)
-
-    max_pca_components = 5
-    ica = ICA(max_pca_components=max_pca_components, method=method)
-    with pytest.warns(None):  # sometimes convergence
-        ica.fit(epochs)
-
-    # Old files don't have max_pca_components_; instead, during fitting,
-    # max_pca_components would get altered. Simulate an old file.
-    del ica.max_pca_components_
-
-    ica.save(fname)
-    ica = read_ica(fname)
-    # Now it should be there.
-    assert ica.max_pca_components_ == max_pca_components
 
 
 @requires_sklearn
@@ -1157,12 +1096,12 @@ def test_n_components_none(method, tmpdir):
     epochs = Epochs(raw, events, event_id, tmin, tmax, picks=picks,
                     baseline=(None, 0), preload=True)
 
-    max_pca_components = 10
+    n_pca_components = 10
     n_components = None
     random_state = 12345
 
     output_fname = tmpdir.join('test_ica-ica.fif')
-    ica = ICA(max_pca_components=max_pca_components, method=method,
+    ica = ICA(n_pca_components=n_pca_components, method=method,
               n_components=n_components, random_state=random_state)
     with pytest.warns(None):
         ica.fit(epochs)
@@ -1171,11 +1110,9 @@ def test_n_components_none(method, tmpdir):
 
     ica = read_ica(output_fname)
     _assert_ica_attributes(ica)
-
-    # ICA.fit() replaced max_pca_components, which was previously None,
-    # with the appropriate integer value.
-    assert_equal(ica.max_pca_components, 10)
+    assert ica.n_pca_components == 10
     assert ica.n_components is None
+    assert ica.n_components_ == 10
 
 
 @requires_sklearn
@@ -1203,7 +1140,8 @@ def test_n_components_and_max_pca_components_none(method, tmpdir):
 
     ica = read_ica(output_fname)
     _assert_ica_attributes(ica)
-    assert_equal(ica.max_pca_components_, epochs.info['nchan'])
+    with pytest.deprecated_call():
+        assert ica.max_pca_components is None
     assert ica.n_components is None
 
 
@@ -1412,7 +1350,10 @@ def _assert_ica_attributes(ica, data=None, limits=(1.0, 70)):
         n_ch, n_ch if ica.noise_cov is not None else 1)
 
     # PCA
-    n_pca = ica.max_pca_components_
+    with pytest.deprecated_call():
+        n_pca = ica.max_pca_components
+    if n_pca is None:
+        n_pca = ica.pca_components_.shape[0]
     assert ica.pca_components_.shape == (n_pca, n_ch), 'PCA shape'
     assert_allclose(np.dot(ica.pca_components_, ica.pca_components_.T),
                     np.eye(n_pca), atol=1e-6, err_msg='PCA orthogonality')

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -17,7 +17,7 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_path_like, _check_src_normal, _check_stc_units,
                     _check_pyqt5_version, _check_sphere, _check_time_format,
                     _check_freesurfer_home, _suggest, _require_version,
-                    _on_missing)
+                    _on_missing, int_like)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -81,6 +81,21 @@ standardize_names : bool
     channel names in the file will be used when possible.
 """
 
+# Epochs
+docdict['proj_epochs'] = """
+proj : bool | 'delayed'
+    Apply SSP projection vectors. If proj is 'delayed' and reject is not
+    None the single epochs will be projected before the rejection
+    decision, but used in unprojected state if they are kept.
+    This way deciding which projection vectors are good can be postponed
+    to the evoked stage without resulting in lower epoch counts and
+    without producing results different from early SSP application
+    given comparable parameters. Note that in this case baselining,
+    detrending and temporal decimation will be postponed.
+    If proj is False no projections will be applied which is the
+    recommended value if SSPs are not used for cleaning the data.
+"""
+
 # Reject by annotation
 docdict['reject_by_annotation_all'] = """
 reject_by_annotation : bool

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -698,7 +698,7 @@ References
 docdict['n_pca_components_apply'] = """
 n_pca_components : int | float | None
     The number of PCA components to be kept, either absolute (int)
-    or percentage of the explained variance (float). If None (default),
+    or fraction of the explained variance (float). If None (default),
     the ``ica.n_pca_components`` from initialization will be used.
 """
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -679,6 +679,13 @@ References
 .. footbibliography::
 """
 
+# ICA
+docdict['n_pca_components_apply'] = """
+n_pca_components : int | float | None
+    The number of PCA components to be kept, either absolute (int)
+    or percentage of the explained variance (float). If None (default),
+    the ``ica.n_pca_components`` from initialization will be used.
+"""
 
 # Maxwell filtering
 docdict['maxwell_origin'] = """

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -332,14 +332,12 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
     # -------------------------
     _validate_type(inst, (BaseRaw, BaseEpochs), "inst", "Raw or Epochs")
     _validate_type(ica, ICA, "ica", "ICA")
+    _validate_type(plot_std, (bool, 'numeric'), 'plot_std')
     if isinstance(plot_std, bool):
         num_std = 1. if plot_std else 0.
-    elif isinstance(plot_std, (float, int)):
-        num_std = plot_std
-        plot_std = True
     else:
-        raise ValueError('plot_std has to be a bool, int or float, '
-                         'got %s instead' % type(plot_std))
+        plot_std = True
+    num_std = float(plot_std)
 
     # if no picks given - plot the first 5 components
     limit = min(5, ica.n_components_) if picks is None else len(ica.ch_names)
@@ -399,12 +397,14 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
             duration=2,
             preload=True,
             reject_by_annotation=reject_by_annotation,
+            proj=False,
             verbose=False)
         inst = make_fixed_length_epochs(
             inst,
             duration=2,
             preload=True,
             reject_by_annotation=reject_by_annotation,
+            proj=False,
             verbose=False)
         kind = "Segment"
     else:

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -719,7 +719,7 @@ def plot_ica_scores(ica, scores, exclude=None, labels=None, axhline=None,
 
 @fill_doc
 def plot_ica_overlay(ica, inst, exclude=None, picks=None, start=None,
-                     stop=None, title=None, show=True, n_components=None):
+                     stop=None, title=None, show=True, n_pca_components=None):
     """Overlay of raw and cleaned signals given the unmixing matrix.
 
     This method helps visualizing signal quality and artifact rejection.

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -719,7 +719,7 @@ def plot_ica_scores(ica, scores, exclude=None, labels=None, axhline=None,
 
 @fill_doc
 def plot_ica_overlay(ica, inst, exclude=None, picks=None, start=None,
-                     stop=None, title=None, show=True):
+                     stop=None, title=None, show=True, n_components=None):
     """Overlay of raw and cleaned signals given the unmixing matrix.
 
     This method helps visualizing signal quality and artifact rejection.
@@ -747,6 +747,9 @@ def plot_ica_overlay(ica, inst, exclude=None, picks=None, start=None,
         The figure title.
     show : bool
         Show figure if True.
+    %(n_pca_components_apply)s
+
+        .. versionadded:: 0.22
 
     Returns
     -------
@@ -778,17 +781,20 @@ def plot_ica_overlay(ica, inst, exclude=None, picks=None, start=None,
         data, times = inst[picks, start_compare:stop_compare]
 
         raw_cln = ica.apply(inst.copy(), exclude=exclude,
-                            start=start, stop=stop)
+                            start=start, stop=stop,
+                            n_pca_components=n_pca_components)
         data_cln, _ = raw_cln[picks, start_compare:stop_compare]
         fig = _plot_ica_overlay_raw(data=data, data_cln=data_cln,
                                     times=times, title=title,
                                     ch_types_used=ch_types_used, show=show)
-    elif isinstance(inst, Evoked):
+    else:
+        assert isinstance(inst, Evoked)
         inst = inst.copy().crop(start, stop)
         if picks is not None:
             inst.info['comps'] = []  # can be safely disabled
             inst.pick_channels([inst.ch_names[p] for p in picks])
-        evoked_cln = ica.apply(inst.copy(), exclude=exclude)
+        evoked_cln = ica.apply(inst.copy(), exclude=exclude,
+                               n_pca_components=n_pca_components)
         fig = _plot_ica_overlay_evoked(evoked=inst, evoked_cln=evoked_cln,
                                        title=title, show=show)
 

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -58,7 +58,7 @@ def test_plot_ica_components():
     fast_test = {"res": res, "contours": 0, "sensors": False}
     raw = _get_raw()
     ica = ICA(noise_cov=read_cov(cov_fname), n_components=2,
-              max_pca_components=3, n_pca_components=3)
+              n_pca_components=3)
     ica_picks = _get_picks(raw)
     with pytest.warns(RuntimeWarning, match='projection'):
         ica.fit(raw, picks=ica_picks)
@@ -123,7 +123,7 @@ def test_plot_ica_properties():
                     baseline=(None, 0), preload=True)
 
     ica = ICA(noise_cov=read_cov(cov_fname), n_components=2, max_iter=1,
-              max_pca_components=2, n_pca_components=2, random_state=0)
+              n_pca_components=2, random_state=0)
     with pytest.warns(RuntimeWarning, match='projection'):
         ica.fit(raw)
 
@@ -210,7 +210,7 @@ def test_plot_ica_sources():
     raw.pick_channels([raw.ch_names[k] for k in picks])
     ica_picks = pick_types(raw.info, meg=True, eeg=False, stim=False,
                            ecg=False, eog=False, exclude='bads')
-    ica = ICA(n_components=2, max_pca_components=3, n_pca_components=3)
+    ica = ICA(n_components=2, n_pca_components=3)
     ica.fit(raw, picks=ica_picks)
     ica.exclude = [1]
     fig = ica.plot_sources(raw)
@@ -274,7 +274,7 @@ def test_plot_ica_overlay():
     raw = _get_raw(preload=True)
     picks = _get_picks(raw)
     ica = ICA(noise_cov=read_cov(cov_fname), n_components=2,
-              max_pca_components=3, n_pca_components=3, random_state=0)
+              n_pca_components=3, random_state=0)
     # can't use info.normalize_proj here because of how and when ICA and Epochs
     # objects do picking of Raw data
     with pytest.warns(RuntimeWarning, match='projection'):
@@ -285,7 +285,7 @@ def test_plot_ica_overlay():
     ica.plot_overlay(ecg_epochs.average())
     with pytest.warns(RuntimeWarning, match='projection'):
         eog_epochs = create_eog_epochs(raw, picks=picks)
-    ica.plot_overlay(eog_epochs.average())
+    ica.plot_overlay(eog_epochs.average(), n_pca_components=2)
     pytest.raises(TypeError, ica.plot_overlay, raw[:2, :3][0])
     pytest.raises(TypeError, ica.plot_overlay, raw, exclude=2)
     ica.plot_overlay(raw)
@@ -295,7 +295,7 @@ def test_plot_ica_overlay():
     raw = read_raw_fif(raw_ctf_fname)
     raw.apply_gradient_compensation(3)
     picks = pick_types(raw.info, meg=True, ref_meg=False)
-    ica = ICA(n_components=2, max_pca_components=3, n_pca_components=3)
+    ica = ICA(n_components=2, n_pca_components=3)
     ica.fit(raw, picks=picks)
     with pytest.warns(RuntimeWarning, match='longer than'):
         ecg_epochs = create_ecg_epochs(raw)
@@ -309,7 +309,7 @@ def test_plot_ica_scores():
     raw = _get_raw()
     picks = _get_picks(raw)
     ica = ICA(noise_cov=read_cov(cov_fname), n_components=2,
-              max_pca_components=3, n_pca_components=3)
+              n_pca_components=3)
     with pytest.warns(RuntimeWarning, match='projection'):
         ica.fit(raw, picks=picks)
     ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], figsize=(6.4, 2.7))
@@ -353,7 +353,7 @@ def test_plot_instance_components():
     raw = _get_raw()
     picks = _get_picks(raw)
     ica = ICA(noise_cov=read_cov(cov_fname), n_components=2,
-              max_pca_components=3, n_pca_components=3)
+              n_pca_components=3)
     with pytest.warns(RuntimeWarning, match='projection'):
         ica.fit(raw, picks=picks)
     ica.exclude = [0]

--- a/tutorials/preprocessing/plot_40_artifact_correction_ica.py
+++ b/tutorials/preprocessing/plot_40_artifact_correction_ica.py
@@ -70,25 +70,22 @@ raw.crop(tmax=60.)
 #     If you want to perform ICA with *no* dimensionality reduction (other than
 #     the number of Independent Components (ICs) given in ``n_components``, and
 #     any subsequent exclusion of ICs you specify in ``ICA.exclude``), pass
-#     ``max_pca_components=None`` and ``n_pca_components=None`` (these are the
-#     default values).
+#     ``n_pca_components=None`` (this is the default value).
 #
 #     However, if you *do* want to reduce dimensionality, consider this
 #     example: if you have 300 sensor channels and you set
-#     ``max_pca_components=200``, ``n_components=50`` and
-#     ``n_pca_components=None``, then the PCA step yields 200 PCs, the first 50
+#     ``n_pca_components=None`` and ``n_components=50``, then the the first 50
 #     PCs are sent to the ICA algorithm (yielding 50 ICs), and during
 #     reconstruction :meth:`~mne.preprocessing.ICA.apply` will use the 50 ICs
-#     plus PCs number 51-200 (the full PCA residual). If instead you specify
+#     plus PCs number 51-300 (the full PCA residual). If instead you specify
 #     ``n_pca_components=120`` then :meth:`~mne.preprocessing.ICA.apply` will
 #     reconstruct using the 50 ICs plus the first 70 PCs in the PCA residual
-#     (numbers 51-120).
+#     (numbers 51-120), thus discarding the smallest 180 components.
 #
 #     **If you have previously been using EEGLAB**'s ``runica()`` and are
 #     looking for the equivalent of its ``'pca', n`` option to reduce
-#     dimensionality via PCA before the ICA step, set ``max_pca_components=n``,
-#     while leaving ``n_components`` and ``n_pca_components`` at their default
-#     (i.e., ``None``).
+#     dimensionality via PCA before the ICA step, set ``n_pca_components=n``,
+#     while leaving ``n_components`` at its default (i.e., ``None``).
 #
 # MNE-Python implements three different ICA algorithms: ``fastica`` (the
 # default), ``picard``, and ``infomax``. FastICA and Infomax are both in fairly
@@ -112,11 +109,20 @@ raw.crop(tmax=60.)
 #
 # As is typically done with ICA, the data are first scaled to unit variance and
 # whitened using principal components analysis (PCA) before performing the ICA
-# decomposition. You can impose an optional dimensionality reduction at this
-# step by specifying ``max_pca_components``. From the retained Principal
-# Components (PCs), the first ``n_components`` are then passed to the ICA
-# algorithm (``n_components`` may be an integer number of components to use, or
-# a fraction of explained variance that used components should capture).
+# decomposition. This is a two-stage process:
+#
+# 1. To deal with different channel types having different units
+#    (e.g., Volts for EEG and Tesla for MEG), data must be pre-whitened.
+#    If ``noise_cov=None`` (default), all data of a given channel type is
+#    scaled by the standard deviation across all channels. If ``noise_cov`` is
+#    a :class:`~mne.Covariance`, the channels are pre-whitened using the
+#    covariance.
+# 2. The pre-whitened data are then decomposed using PCA.
+#
+# From the resulting principal components (PCs), the first ``n_components`` are
+# then passed to the ICA algorithm. ``n_components`` may be an integer number
+# of components to use, or a fraction of explained variance that the
+# ``n_pca_components`` components capture.
 #
 # After visualizing the Independent Components (ICs) and excluding any that
 # capture artifacts you want to repair, the sensor signal can be reconstructed
@@ -127,8 +133,8 @@ raw.crop(tmax=60.)
 # the "PCA residual"). If you want to reduce the number of components used at
 # the reconstruction stage, it is controlled by the ``n_pca_components``
 # parameter (which will in turn reduce the rank of your data; by default
-# ``n_pca_components = max_pca_components`` resulting in no additional
-# dimensionality reduction). The fitting and reconstruction procedures and the
+# ``n_pca_components=None`` resulting in no additional dimensionality
+# reduction). The fitting and reconstruction procedures and the
 # parameters that control dimensionality at various stages are summarized in
 # the diagram below:
 #


### PR DESCRIPTION
Todo:

- [x] Deprecate `max_pca_components`
- [x] Get `test_ica.py` working
- [x] Add `n_pca_components` to `plot_ica_overlay`
- [x] Make keyword-only after #8350 is in
- [x] Update `plot_40_artifact_correction_ica.py`
- [x] Add warning when `n_components` leads to unstable pseudoinversion
- [x] Update `doc/_static/diagrams/ica.dot`
- [x] Decide if `n_components` as float selects based on the variance remaining of the `n_pca_components` components. This is how `max_pca_components` worked (it was relative to that)

Closes #8337
Closes #8342
Closes #8327
Closes #8328 
Closes #8316
Closes #8313
Closes #7727
Closes #8353