### PR TITLE
WIP: Fix bugs in Brain

### DIFF
--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1846,7 +1846,6 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
                              'mayavi backend')
     with warnings.catch_warnings(record=True):  # traits warnings
         brain = Brain(**kwargs)
-
     del kwargs
     if scale_factor is None:
         # Configure the glyphs scale directly

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1950,7 +1950,8 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
             brain.setup_time_viewer(time_viewer=time_viewer,
                                     show_traces=show_traces)
     else:
-        brain.show()
+        if not using_mayavi:
+            brain.show()
 
     return brain
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1837,7 +1837,7 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
         "views": views, "alpha": brain_alpha,
     }
     if backend in ['pyvista', 'notebook']:
-        kwargs["show"] = not time_viewer
+        kwargs["show"] = False
         kwargs["view_layout"] = view_layout
     else:
         kwargs.update(_check_pysurfer_antialias(Brain))
@@ -1846,6 +1846,7 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
                              'mayavi backend')
     with warnings.catch_warnings(record=True):  # traits warnings
         brain = Brain(**kwargs)
+
     del kwargs
     if scale_factor is None:
         # Configure the glyphs scale directly
@@ -1949,6 +1950,8 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
         else:  # PyVista
             brain.setup_time_viewer(time_viewer=time_viewer,
                                     show_traces=show_traces)
+    else:
+        brain.show()
 
     return brain
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -931,7 +931,7 @@ class Brain(object):
         self.actions["movie"] = self.tool_bar.addAction(
             self.icons["movie"],
             "Save movie...",
-            self.save_movie
+            partial(self.save_movie, filename=None)
         )
         self.actions["visibility"] = self.tool_bar.addAction(
             self.icons["visibility_on"],

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -22,6 +22,7 @@ import vtk
 
 from .base_renderer import _BaseRenderer
 from ._utils import _get_colormap_from_array, ALLOWED_QUIVER_MODES
+from ...fixes import _get_args
 from ...utils import copy_base_doc_to_subclass_doc, _check_option
 from ...externals.decorator import decorator
 
@@ -658,6 +659,10 @@ def _add_mesh(plotter, *args, **kwargs):
         smooth_shading = kwargs.pop('smooth_shading')
     else:
         smooth_shading = True
+    # disable rendering pass for add_mesh, render()
+    # is called in show()
+    if 'render' in _get_args(plotter.add_mesh):
+        kwargs['render'] = False
     actor = plotter.add_mesh(*args, **kwargs)
     if smooth_shading and 'Normals' in mesh.point_arrays:
         prop = actor.GetProperty()

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -661,7 +661,7 @@ def _add_mesh(plotter, *args, **kwargs):
         smooth_shading = True
     # disable rendering pass for add_mesh, render()
     # is called in show()
-    if 'render' in _get_args(plotter.add_mesh):
+    if 'render' not in kwargs and 'render' in _get_args(plotter.add_mesh):
         kwargs['render'] = False
     actor = plotter.add_mesh(*args, **kwargs)
     if smooth_shading and 'Normals' in mesh.point_arrays:


### PR DESCRIPTION
This PR disables the rendering call each time a mesh is added to the scene in favour of only one call when everything is setup.

Quoting https://github.com/pyvista/pyvista/pull/935#issue-500086898:

> There are 2 main reasons for this:
> - Huge speed gain when hiding and displaying meshes.
> - It looks much more professionnal when clicking a button to see all the changes at once.