### PR TITLE
remove 1. instance of checking metadata [Fixes #8360]

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -411,7 +411,6 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
             # ensure metadata matches original events size
             self.selection = np.arange(len(events))
             self.events = events
-            self.metadata = metadata
             del events
 
             values = list(self.event_id.values())


### PR DESCRIPTION
Fixes #8360

Might be too good to be true, but so far it works for me:
I just removed the first instance of 
self.metadata = metadata in epochs.py
It occurs again later, after the events of interest were selected. 
