### PR TITLE
MRG: Toggle interaction with context manager

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2538,18 +2538,19 @@ class Brain(object):
                     framerate=24, interpolation=None, codec=None,
                     bitrate=None, callback=None, time_viewer=False, **kwargs):
         import imageio
-        images = self._make_movie_frames(
-            time_dilation, tmin, tmax, framerate, interpolation, callback,
-            time_viewer)
-        # find imageio FFMPEG parameters
-        if 'fps' not in kwargs:
-            kwargs['fps'] = framerate
-        if codec is not None:
-            kwargs['codec'] = codec
-        if bitrate is not None:
-            kwargs['bitrate'] = bitrate
-
-        imageio.mimwrite(filename, images)
+        from ..backends._pyvista import _disabled_interaction
+        with _disabled_interaction(self._renderer):
+            images = self._make_movie_frames(
+                time_dilation, tmin, tmax, framerate, interpolation, callback,
+                time_viewer)
+            # find imageio FFMPEG parameters
+            if 'fps' not in kwargs:
+                kwargs['fps'] = framerate
+            if codec is not None:
+                kwargs['codec'] = codec
+            if bitrate is not None:
+                kwargs['bitrate'] = bitrate
+            imageio.mimwrite(filename, images)
 
     @fill_doc
     def save_movie(self, filename, time_dilation=4., tmin=None, tmax=None,

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2543,14 +2543,14 @@ class Brain(object):
             images = self._make_movie_frames(
                 time_dilation, tmin, tmax, framerate, interpolation, callback,
                 time_viewer)
-            # find imageio FFMPEG parameters
-            if 'fps' not in kwargs:
-                kwargs['fps'] = framerate
-            if codec is not None:
-                kwargs['codec'] = codec
-            if bitrate is not None:
-                kwargs['bitrate'] = bitrate
-            imageio.mimwrite(filename, images)
+        # find imageio FFMPEG parameters
+        if 'fps' not in kwargs:
+            kwargs['fps'] = framerate
+        if codec is not None:
+            kwargs['codec'] = codec
+        if bitrate is not None:
+            kwargs['bitrate'] = bitrate
+        imageio.mimwrite(filename, images)
 
     @fill_doc
     def save_movie(self, filename, time_dilation=4., tmin=None, tmax=None,

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -233,12 +233,18 @@ def test_brain_save_movie(tmpdir, renderer):
     """Test saving a movie of a Brain instance."""
     if renderer._get_3d_backend() == "mayavi":
         pytest.skip('Save movie only supported on PyVista')
-    brain_data = _create_testing_brain(hemi='lh', time_viewer=False)
+    brain = _create_testing_brain(hemi='lh', time_viewer=False)
     filename = str(path.join(tmpdir, "brain_test.mov"))
-    brain_data.save_movie(filename, time_dilation=1,
-                          interpolation='nearest')
-    assert path.isfile(filename)
-    brain_data.close()
+    for interactive_state in (False, True):
+        # for coverage, we set interactivity
+        if interactive_state:
+            brain._renderer.plotter.enable()
+        else:
+            brain._renderer.plotter.disable()
+        brain.save_movie(filename, time_dilation=1,
+                         interpolation='nearest')
+        assert path.isfile(filename)
+    brain.close()
 
 
 @testing.requires_testing_data

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -1109,34 +1109,11 @@ def _disabled_depth_peeling():
 @contextmanager
 def _disabled_interaction(renderer):
     plotter = renderer.plotter
-
-    # def _noop(plotter, obj, event):
-    #     return
-
-    # func = plotter.key_press_event
-    # plotter.key_press_event = _noop
-    ren_win = plotter.ren_win
-    # for renderer in plotter.renderers:
-    #     renderer.SetInteractive(False)
-    iren = plotter.iren
-    iren.SetRenderWindow(None)
-    tmp_iren = vtk.vtkRenderWindowInteractor()
-    tmp_iren.SetInteractorStyle(None)
-    tmp_iren.SetRenderWindow(ren_win)
-    # ren_win.SetInteractor(tmp_iren)
-    plotter.iren = tmp_iren
-    # plotter._shadow_renderer.SetInteractive(True)
+    plotter.disable()
     try:
         yield
     finally:
-        tmp_iren.SetRenderWindow(None)
-        # for renderer in plotter.renderers:
-        #     renderer.SetInteractive(True)
-        plotter.iren = iren
-        iren.SetRenderWindow(ren_win)
-        # ren_win.SetInteractor(iren)
-        # plotter.key_press_event = func
-        # plotter._shadow_renderer.SetInteractive(False)
+        plotter.enable()
 
 
 @decorator

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -1109,11 +1109,14 @@ def _disabled_depth_peeling():
 @contextmanager
 def _disabled_interaction(renderer):
     plotter = renderer.plotter
-    plotter.disable()
-    try:
+    if not plotter.renderer.GetInteractive():
         yield
-    finally:
-        plotter.enable()
+    else:
+        plotter.disable()
+        try:
+            yield
+        finally:
+            plotter.enable()
 
 
 @decorator

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -1106,6 +1106,36 @@ def _disabled_depth_peeling():
         rcParams["depth_peeling"]["enabled"] = depth_peeling_enabled
 
 
+@contextmanager
+def _disabled_interaction(renderer):
+    plotter = renderer.plotter
+
+    # def _noop(plotter, obj, event):
+    #     return
+
+    # func = plotter.key_press_event
+    # plotter.key_press_event = _noop
+    ren_win = plotter.ren_win
+    # for renderer in plotter.renderers:
+    #     renderer.SetInteractive(False)
+    iren = plotter.iren
+    iren.SetRenderWindow(None)
+    tmp_iren = vtk.vtkRenderWindowInteractor()
+    tmp_iren.SetInteractorStyle(None)
+    tmp_iren.SetRenderWindow(ren_win)
+    # ren_win.SetInteractor(tmp_iren)
+    plotter.iren = tmp_iren
+    try:
+        yield
+    finally:
+        # for renderer in plotter.renderers:
+        #     renderer.SetInteractive(True)
+        plotter.iren = iren
+        iren.SetRenderWindow(ren_win)
+        # ren_win.SetInteractor(iren)
+        # plotter.key_press_event = func
+
+
 @decorator
 def run_once(fun, *args, **kwargs):
     """Run the function only once."""

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -1125,15 +1125,18 @@ def _disabled_interaction(renderer):
     tmp_iren.SetRenderWindow(ren_win)
     # ren_win.SetInteractor(tmp_iren)
     plotter.iren = tmp_iren
+    # plotter._shadow_renderer.SetInteractive(True)
     try:
         yield
     finally:
+        tmp_iren.SetRenderWindow(None)
         # for renderer in plotter.renderers:
         #     renderer.SetInteractive(True)
         plotter.iren = iren
         iren.SetRenderWindow(ren_win)
         # ren_win.SetInteractor(iren)
         # plotter.key_press_event = func
+        # plotter._shadow_renderer.SetInteractive(False)
 
 
 @decorator


### PR DESCRIPTION
This PR adds a context manager to toggle interactivity during movie in Brain.

This is still a work in progress, I got some warnings in `save_movie` if the user interacts:

```
WARN| vtkInteractorStyleTrackballCamera (0x563558f5de30): no current renderer on the interactor style.
```

@larsoner this is what I tried so far

Closes https://github.com/mne-tools/mne-python/issues/8363