### PR TITLE
MRG, DOC: Fix API documentation rendering in Webkit

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -585,3 +585,8 @@ div.contents ul li p {
 h3.panel-title p {
   margin: 0 0 0px;
 }
+/* Disable hyphenation in API reference table for Webkit-based browsers
+   to work around alignment bug */
+#python-api-reference table p {
+  -webkit-hyphens: none;
+}


### PR DESCRIPTION
`master`:
<img width="1082" alt="Screenshot 2020-10-15 at 12 08 39" src="https://user-images.githubusercontent.com/2046265/96109797-5450a800-0edf-11eb-8618-4cf80760764b.png">

this PR:
<img width="1082" alt="Screenshot 2020-10-15 at 12 08 26" src="https://user-images.githubusercontent.com/2046265/96109839-63cff100-0edf-11eb-9974-8b5de39da505.png">

Thanks @opyh for tracking this down!