### PR TITLE
MRG, DOC: Make clear which functions have been renamed

### DIFF
--- a/doc/changes/0.21.inc
+++ b/doc/changes/0.21.inc
@@ -399,6 +399,18 @@ API changes
 
   1. Arguments to clustering functions, such as `mne.stats.permutation_cluster_test`, and
   2. Function names for defining adjacency, such as `mne.spatio_temporal_src_adjacency` replacing ``mne.spatio_temporal_src_connectivity``.
+  
+  The complete list of changed function names is:
+
+  - ``mne.channels.find_ch_connectivity`` → `~mne.channels.find_ch_adjacency`
+  - ``mne.channels.read_ch_connectivity`` → `~mne.channels.read_ch_adjacency`
+  - ``mne.spatial_dist_connectivity`` → `~mne.spatial_dist_adjacency`
+  - ``mne.spatial_inter_hemi_connectivity`` → `~mne.spatial_inter_hemi_adjacency`
+  - ``mne.spatial_src_connectivity`` → `~mne.spatial_src_adjacency`
+  - ``mne.spatial_tris_connectivity`` → `~mne.spatial_tris_adjacency`
+  - ``mne.spatio_temporal_dist_connectivity`` → `~mne.spatio_temporal_dist_adjacency`
+  - ``mne.spatio_temporal_src_connectivity`` → `~mne.spatio_temporal_src_adjacency`
+  - ``mne.spatio_temporal_tris_connectivity`` → `~mne.spatio_temporal_tris_adjacency`
 
   "connectivity" is now reserved for discussions of functional and effective connectivity of the brain, and "adjacency" for source or sensor neighbor definitions for cluster-based analyses, by `Eric Larson`_.
 


### PR DESCRIPTION
@SophieHerbst got lost because after an MNE update,`mne.channels.find_ch_connectivity` and `mne.channels.read_ch_connectivity` were gone. Turns out these functions were renamerd, and this change was mentioned in the changelog indeed, but apparently not explicitly enough. Searching the docs for the function name wouldn't bring up helpful results either. This PR explicitly lists all `*connectivity` functions that have been renamed to `*adjacency` in the changelog, so it should be easier to discover these changes.