### PR TITLE
MRG, API: Remove trans

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -75,3 +75,5 @@ API changes
 - The ``max_pca_components`` argument of :class:`~mne.preprocessing.ICA` has been deprecated, use ``n_components`` during initialization and ``n_pca_components`` in :meth:`~mne.preprocessing.ICA.apply` instead by `Eric Larson`_ (:gh:`8351`)
 
 - The ``n_pca_components`` argument of :class:`~mne.preprocessing.ICA` has been deprecated, use ``n_pca_components`` in :meth:`~mne.preprocessing.ICA.apply` by `Eric Larson`_ (:gh:`8356`)
+
+- The ``trans`` argument of :func:`mne.extract_label_time_course` is deprecated and will be removed in 0.23 as it is no longer necessary by `Eric Larson`_

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1026,6 +1026,10 @@ docdict['trans_not_none'] = """
 trans : str | dict | instance of Transform
     %s
 """ % (_trans_base,)
+docdict['trans_deprecated'] = """
+trans : str | dict | instance of Transform
+    Deprecated and will be removed in 0.23, do not pass this argument.
+"""
 docdict['trans'] = """
 trans : str | dict | instance of Transform | None
     %s
@@ -1437,12 +1441,6 @@ allow_empty : bool | str
        Support for "ignore".
 """
 docdict
-docdict['eltc_trans'] = """%s
-    Only needed when using a volume atlas and
-    ``src`` is in head coordinates (i.e., comes from a forward or inverse).
-
-    .. versionadded:: 0.21.0
-""" % (docdict['trans_not_none'],)
 docdict['eltc_mri_resolution'] = """
 mri_resolution : bool
     If True (default), the volume source space will be upsampled to the


### PR DESCRIPTION
I started working on `labels_to_stc` for VolSourceEstimate / volumetric atlases, and I realized that we don't actually need the `trans` argument of `extract_label_time_course` because we can always easily reconstruct the `src[0]['rr']` in MRI space using the `src[0]['shape']` and `src[0]['mri_src_t']`. This deprecates `trans` in `extract_label_time_course`, though I'm half tempted just to leave it in as an argument since it doesn't hurt anything to include it and it's possible at some point in the future we might want it.

It was introduced as an argument only in 0.21, which is sad, and a fast turnaround for deprecation. So maybe we should actually backport this so that people using 0.21.1 get the warning and just remove `trans` from their code sooner.