### PR TITLE
Add fix to give a proper error message when an unsupported Nihon Kohden file is read.

### DIFF
--- a/mne/io/nihon/nihon.py
+++ b/mne/io/nihon/nihon.py
@@ -56,6 +56,7 @@ _valid_headers = [
     'EEG-2100  V02.00',
     'DAE-2100D V01.30',
     'DAE-2100D V02.00',
+    # 'EEG-1200A V01.00',  # Not working for the moment.
 ]
 
 
@@ -116,6 +117,9 @@ def _read_21e_file(fname):
                 elif keep_parsing is True:
                     idx, name = line.split('=')
                     idx = int(idx)
+                    if idx >= len(_chan_labels):
+                        n = idx - len(_chan_labels) + 1
+                        _chan_labels.extend(['UNK'] * n)
                     _chan_labels[idx] = name.strip()
     return _chan_labels
 


### PR DESCRIPTION
#### Reference issue

related #8385 

#### What does this implement/fix?
In #8385, the user wants to read an unsupported file 'EEG-1200A V01.00'. The problem is that it first tries to read the channel labels (which in this file version are more than in the supported versions) and it raises a `IndexError`.

This fixes this issue by extending the list of channel labels as needed. Now the error is as expected:

```ValueError: Not a valid Nihon Kohden EEG file (EEG-1200A V01.00)```


#### Additional information
Issue #8385 expects the data to be read. However, in order to have that kind of fix, more information on the internals of the data format are needed.
