### PR TITLE
WIP: Decrease Brain memory consumption

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -429,6 +429,12 @@ class Brain(object):
         # resolve the reference cycle
         self.geo.clear()
         self._hemi_meshes.clear()
+        for h in self._hemis:
+            actor = self._hemi_actors[h]
+            if actor is not None:
+                mapper = actor.GetMapper()
+                mapper.SetLookupTable(None)
+                actor.SetMapper(None)
         self._hemi_actors.clear()
         self._data.clear()
         for renderer in self.plotter.renderers:

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -442,6 +442,8 @@ class Brain(object):
         self.plotter.lighting = None
         self.plotter.interactor = None
         self.plotter.app_window = None
+        self.plotter._RenderWindow = None
+        self.plotter._Iren = None
         self.plotter = None
         self.main_menu = None
         self.window = None


### PR DESCRIPTION
The first goal is to collect all the remaining vtk objects:

```
mprof run mem_brain.py && mprof plot
```

mem_brain.py:

```py
import gc
import time
import numpy as np
import mne
rr, tris = mne.read_surface(mne.datasets.sample.data_path() + '/subjects/fsaverage/surf/lh.inflated')
tris = np.pad(tris, ((0, 0), (1, 0)), 'constant')
assert tris.shape[1] == 4
tris[:, 0] = 3
for _ in range(1):
    brain = mne.viz.Brain('fsaverage', 'both', 'inflated')
    brain.close()
    del brain
    time.sleep(0.1)
    gc.collect()
    print([o.__class__.__name__ for o in gc.get_objects() if o.__class__.__name__.startswith('vtk')], len(gc.get_objects()))
```

To remove:

```
['vtkXOpenGLRenderWindow', 'vtkGenericRenderWindowInteractor', 'vtkLookupTable', 'vtkOpenGLActor']
```

The second goal is to improve Brain memory consumption to help with https://github.com/mne-tools/mne-python/pull/8379

cc @larsoner 