### PR TITLE
WIP: Refs

### DIFF
--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -329,7 +329,11 @@ def _assert_no_instances(cls, when=''):
     gc.collect()
     objs = gc.get_objects()
     for obj in objs:
-        if isinstance(obj, cls):
+        try:
+            check = isinstance(obj, cls)
+        except Exception:  # such as a weakref
+            check = False
+        if check:
             rr = gc.get_referrers(obj)
             count = 0
             for r in rr:

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -297,6 +297,13 @@ def test_plot_ica_overlay():
     plt.close('all')
 
 
+def _get_geometry(fig):
+    try:
+        return fig.axes[0].get_subplotspec().get_geometry()  # pragma: no cover
+    except AttributeError:  # MPL < 3.4 (probably)
+        return fig.axes[0].get_geometry()  # pragma: no cover
+
+
 @requires_sklearn
 def test_plot_ica_scores():
     """Test plotting of ICA scores."""
@@ -323,20 +330,20 @@ def test_plot_ica_scores():
     # check setting number of columns
     fig = ica.plot_scores([[0.3, 0.2], [0.3, 0.2], [0.3, 0.2]],
                           axhline=[0.1, -0.1])
-    assert 2 == fig.get_axes()[0].get_geometry()[1]
+    assert 2 == _get_geometry(fig)[1]
     fig = ica.plot_scores([[0.3, 0.2], [0.3, 0.2]], axhline=[0.1, -0.1],
                           n_cols=1)
-    assert 1 == fig.get_axes()[0].get_geometry()[1]
+    assert 1 == _get_geometry(fig)[1]
 
     # only use 1 column (even though 2 were requested)
     fig = ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1], n_cols=2)
-    assert 1 == fig.get_axes()[0].get_geometry()[1]
+    assert 1 == _get_geometry(fig)[1]
 
-    pytest.raises(
-        ValueError,
-        ica.plot_scores,
-        [0.3, 0.2], axhline=[0.1, -0.1], labels=['one', 'one-too-many'])
-    pytest.raises(ValueError, ica.plot_scores, [0.2])
+    with pytest.raises(ValueError, match='Need as many'):
+        ica.plot_scores([0.3, 0.2], axhline=[0.1, -0.1],
+                        labels=['one', 'one-too-many'])
+    with pytest.raises(ValueError, match='The length of'):
+        ica.plot_scores([0.2])
     plt.close('all')
 
 


### PR DESCRIPTION
@GuillaumeFavelier on https://github.com/pyvista/pyvista/pull/958 and https://github.com/pyvista/pyvistaqt/pull/66 using `pytest mne/viz/_brain` I get:
```
Traceback (most recent call last):
  File "/home/larsoner/python/mne-python/mne/viz/_brain/_brain.py", line 45, in safe_event
    return fun(*args, **kwargs)
  File "/home/larsoner/python/mne-python/mne/viz/_brain/_brain.py", line 432, in _clean
    self.clear_points()
  File "/home/larsoner/python/mne-python/mne/viz/_brain/_brain.py", line 1245, in clear_points
    self.remove_point(sphere)
  File "/home/larsoner/python/mne-python/mne/viz/_brain/_brain.py", line 1235, in remove_point
    self.plotter.remove_actor(sphere._actors)
  File "/home/larsoner/python/pyvista/pyvista/plotting/plotting.py", line 616, in remove_actor
    renderer.remove_actor(actor, reset_camera)
  File "/home/larsoner/python/pyvista/pyvista/plotting/renderer.py", line 1174, in remove_actor
    rv = self.remove_actor(a, reset_camera=reset_camera)
  File "/home/larsoner/python/pyvista/pyvista/plotting/renderer.py", line 1182, in remove_actor
    _remove_mapper_from_plotter(self.parent, actor, False)
  File "/home/larsoner/python/pyvista/pyvista/plotting/renderer.py", line 1462, in _remove_mapper_from_plotter
    for name in list(plotter._scalar_bar_mappers.keys()):
AttributeError: 'NoneType' object has no attribute '_scalar_bar_mappers'
```
Can you look and push commits to fix?