### PR TITLE
fix: do not log about re-referencing when no such thing is done

### DIFF
--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -238,7 +238,8 @@ def add_reference_channels(inst, ref_channels, copy=True):
         for pi, picks in enumerate(inst._read_picks):
             inst._read_picks[pi] = np.concatenate([picks, [np.max(picks) + 1]])
     inst.info._check_consistency()
-    set_eeg_reference(inst, ref_channels=ref_channels, copy=False)
+    set_eeg_reference(inst, ref_channels=ref_channels, copy=False,
+                      verbose=False)
     return inst
 
 


### PR DESCRIPTION
This came up on gitter: https://gitter.im/mne-tools/mne-python?at=5f92ad30c990bb1c39277c8d

When users add a previously unknown reference channel using `add_reference_channels`, the channel is initialized as a vector of zeroes. No actual re-referencing takes place, however the log messages confusingly print: 

> EEG channel type selected for re-referencing Applying a custom EEG reference

This PR suppresses that confusing log message.