### PR TITLE
MRG, BUG: Ensure channel entries are valid

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -69,6 +69,8 @@ Bugs
 
 - Fix bug in :func:`mne.viz.plot_alignment` where ECoG and sEEG channels were not plotted and fNIRS channels were always plotted in the head coordinate frame by `Eric Larson`_ (:gh:`8393`)
 
+- Fix bug in :func:`mne.set_bipolar_reference` where ``ch_info`` could contain invalid channel information keys by `Eric Larson`_
+
 API changes
 ~~~~~~~~~~~
 

--- a/mne/channels/tests/test_layout.py
+++ b/mne/channels/tests/test_layout.py
@@ -39,10 +39,10 @@ def _get_test_info():
     loc = np.array([0., 0., 0., 1., 0., 0., 0., 1., 0., 0., 0., 1.],
                    dtype=np.float32)
     test_info['chs'] = [
-        {'cal': 1, 'ch_name': 'ICA 001', 'coil_type': 0, 'coord_Frame': 0,
+        {'cal': 1, 'ch_name': 'ICA 001', 'coil_type': 0, 'coord_frame': 0,
          'kind': 502, 'loc': loc.copy(), 'logno': 1, 'range': 1.0, 'scanno': 1,
          'unit': -1, 'unit_mul': 0},
-        {'cal': 1, 'ch_name': 'ICA 002', 'coil_type': 0, 'coord_Frame': 0,
+        {'cal': 1, 'ch_name': 'ICA 002', 'coil_type': 0, 'coord_frame': 0,
          'kind': 502, 'loc': loc.copy(), 'logno': 2, 'range': 1.0, 'scanno': 2,
          'unit': -1, 'unit_mul': 0},
         {'cal': 0.002142000012099743, 'ch_name': 'EOG 061', 'coil_type': 1,

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -9,6 +9,7 @@ import numpy as np
 from scipy import linalg
 
 from .constants import FIFF
+from .meas_info import _check_ch_keys
 from .proj import _has_eeg_average_ref_proj, make_eeg_average_ref_proj
 from .proj import setup_proj
 from .pick import pick_types, pick_channels, pick_channels_forward
@@ -467,7 +468,8 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
 
     # Merge specified and anode channel information dictionaries
     new_chs = []
-    for an, ci in zip(anode, ch_info):
+    for ci, (an, ch) in enumerate(zip(anode, ch_info)):
+        _check_ch_keys(ch, ci, name='ch_info', check_min=False)
         an_idx = inst.ch_names.index(an)
         this_chs = deepcopy(inst.info['chs'][an_idx])
 
@@ -475,7 +477,7 @@ def set_bipolar_reference(inst, anode, cathode, ch_name=None, ch_info=None,
         this_chs['loc'] = np.zeros(12)
         this_chs['coil_type'] = FIFF.FIFFV_COIL_EEG_BIPOLAR
 
-        this_chs.update(ci)
+        this_chs.update(ch)
         new_chs.append(this_chs)
 
     if copy:

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -485,6 +485,16 @@ def test_check_consistency():
         if key == 'ch_name':
             info['ch_names'][idx] = old
 
+    # bad channel entries
+    info2 = info.copy()
+    info2['chs'][0]['foo'] = 'bar'
+    with pytest.raises(KeyError, match='key errantly present'):
+        info2._check_consistency()
+    info2 = info.copy()
+    del info2['chs'][0]['loc']
+    with pytest.raises(KeyError, match='key missing'):
+        info2._check_consistency()
+
 
 def _test_anonymize_info(base_info):
     """Test that sensitive information can be anonymized."""

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -317,9 +317,12 @@ def test_set_bipolar_reference():
     raw = read_raw_fif(fif_fname, preload=True)
     raw.apply_proj()
 
-    reref = set_bipolar_reference(raw, 'EEG 001', 'EEG 002', 'bipolar',
-                                  {'kind': FIFF.FIFFV_EOG_CH,
-                                   'extra': 'some extra value'})
+    ch_info = {'kind': FIFF.FIFFV_EOG_CH, 'extra': 'some extra value'}
+    with pytest.raises(KeyError, match='key errantly present'):
+        set_bipolar_reference(raw, 'EEG 001', 'EEG 002', 'bipolar', ch_info)
+    ch_info.pop('extra')
+    reref = set_bipolar_reference(
+        raw, 'EEG 001', 'EEG 002', 'bipolar', ch_info)
     assert (reref.info['custom_ref_applied'])
 
     # Compare result to a manual calculation
@@ -345,7 +348,6 @@ def test_set_bipolar_reference():
             assert_equal(bp_info[key], FIFF.FIFFV_EOG_CH)
         else:
             assert_equal(bp_info[key], an_info[key])
-    assert_equal(bp_info['extra'], 'some extra value')
 
     # Minimalist call
     reref = set_bipolar_reference(raw, 'EEG 001', 'EEG 002')
@@ -364,8 +366,8 @@ def test_set_bipolar_reference():
         ['EEG 001', 'EEG 003'],
         ['EEG 002', 'EEG 004'],
         ['bipolar1', 'bipolar2'],
-        [{'kind': FIFF.FIFFV_EOG_CH, 'extra': 'some extra value'},
-         {'kind': FIFF.FIFFV_EOG_CH, 'extra': 'some extra value'}],
+        [{'kind': FIFF.FIFFV_EOG_CH},
+         {'kind': FIFF.FIFFV_EOG_CH}],
     )
     a = raw.copy().pick_channels(['EEG 001', 'EEG 002', 'EEG 003', 'EEG 004'])
     a = np.array([a._data[0, :] - a._data[1, :],

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1021,8 +1021,8 @@ class ICA(ContainsMixin):
             ch_info.append(dict(
                 ch_name=name, cal=1, logno=ii + 1,
                 coil_type=FIFF.FIFFV_COIL_NONE, kind=FIFF.FIFFV_MISC_CH,
-                coord_Frame=FIFF.FIFFV_COORD_UNKNOWN, unit=FIFF.FIFF_UNIT_NONE,
-                loc=np.array([0., 0., 0., 1.] * 3, dtype='f4'),
+                coord_frame=FIFF.FIFFV_COORD_UNKNOWN, unit=FIFF.FIFF_UNIT_NONE,
+                loc=np.zeros(12, dtype='f4'),
                 range=1.0, scanno=ii + 1, unit_mul=0))
 
         if add_channels is not None:


### PR DESCRIPTION
As mentioned in #8400. Exposed bugs in `set_bipolar_reference` and `ICA` keys, so worth a backport.