### PR TITLE
FIX: notebook attribute name

### DIFF
--- a/mne/viz/_brain/tests/test.ipynb
+++ b/mne/viz/_brain/tests/test.ipynb
@@ -45,7 +45,7 @@
     "                     time_viewer=True,\n",
     "                     hemi='split')\n",
     "    assert isinstance(brain, brain_class)\n",
-    "    assert brain.notebook\n",
+    "    assert brain._notebook\n",
     "    interactor = brain._renderer.figure.display\n",
     "    interactor.set_time_point({'new': 0})\n",
     "    brain.close()"


### PR DESCRIPTION
I intended to backport from `master` but this PR fixes the issue with the notebook test.