### PR TITLE
DOC: Better Annotations docs

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -64,6 +64,11 @@ def _check_o_d_s(onset, duration, description):
 class Annotations(object):
     """Annotation object for annotating segments of raw data.
 
+    .. note::
+       To convert events to `~mne.Annotations`, use
+       `~mne.annotations_from_events`. To convert existing `~mne.Annotations`
+       to events, use  `~mne.events_from_annotations`.
+
     Parameters
     ----------
     onset : array of float, shape (n_annotations,)
@@ -85,6 +90,11 @@ class Annotations(object):
         same time. If it is a string, it should conform to the ISO8601 format.
         More precisely to this '%Y-%m-%d %H:%M:%S.%f' particular case of the
         ISO8601 format where the delimiter between date and time is ' '.
+
+    See Also
+    --------
+    mne.annotations_from_events
+    mne.events_from_annotations
 
     Notes
     -----
@@ -988,6 +998,10 @@ def events_from_annotations(raw, event_id="auto",
     event_id : dict
         The event_id variable that can be passed to Epochs.
 
+    See Also
+    --------
+    mne.annotations_from_events
+
     Notes
     -----
     For data formats that store integer events as strings (e.g., NeuroScan
@@ -1076,6 +1090,10 @@ def annotations_from_events(events, sfreq, event_desc=None, first_samp=0,
     -------
     annot : instance of Annotations
         The annotations.
+
+    See Also
+    --------
+    mne.events_from_annotations
 
     Notes
     -----

--- a/tutorials/intro/plot_20_events_from_raw.py
+++ b/tutorials/intro/plot_20_events_from_raw.py
@@ -232,25 +232,24 @@ print(event_dict)
 print(events_from_annot[:5])
 
 ###############################################################################
-# To make the opposite conversion (from Events array to
+# To make the opposite conversion (from an Events array to an
 # :class:`~mne.Annotations` object), you can create a mapping from integer
-# Event ID to string descriptions, and use the :class:`~mne.Annotations`
-# constructor to create the :class:`~mne.Annotations` object, and use the
+# Event ID to string descriptions, use `~mne.annotations_from_events`
+# to construct the :class:`~mne.Annotations` object, and call the
 # :meth:`~mne.io.Raw.set_annotations` method to add the annotations to the
-# :class:`~mne.io.Raw` object. Because the :ref:`sample data <sample-dataset>`
-# was recorded on a Neuromag system (where sample numbering starts when the
-# acquisition system is initiated, not when the *recording* is initiated), we
-# also need to pass in the ``orig_time`` parameter so that the onsets are
-# properly aligned relative to the start of recording:
+# :class:`~mne.io.Raw` object.
+#
+# Because the :ref:`sample data <sample-dataset>` was recorded on a Neuromag
+# system (where sample numbering starts when the acquisition system is
+# initiated, not when the *recording* is initiated), we also need to pass in
+# the ``orig_time`` parameter so that the onsets are properly aligned relative
+# to the start of recording:
 
 mapping = {1: 'auditory/left', 2: 'auditory/right', 3: 'visual/left',
            4: 'visual/right', 5: 'smiley', 32: 'buttonpress'}
-onsets = events[:, 0] / raw.info['sfreq']
-durations = np.zeros_like(onsets)  # assumes instantaneous events
-descriptions = [mapping[event_id] for event_id in events[:, 2]]
-annot_from_events = mne.Annotations(onset=onsets, duration=durations,
-                                    description=descriptions,
-                                    orig_time=raw.info['meas_date'])
+annot_from_events = mne.annotations_from_events(
+    events=events, event_desc=mapping, sfreq=raw.info['sfreq'],
+    orig_time=raw.info['meas_date'])
 raw.set_annotations(annot_from_events)
 
 ###############################################################################


### PR DESCRIPTION
Added some cross-references and we're now using `annotations_from_events` in the tutorial – a function which I only came across accidentally, as it wasn't mentioned anywhere in the docs.

