### PR TITLE
MNT: use brain_gc fixture in some tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,8 @@ jobs:
             command: |
               python -m pip install --user --upgrade --progress-bar off pip setuptools
               python -m pip install --user --upgrade --progress-bar off --pre sphinx
+              python -m pip install --user --progress-bar off https://github.com/pyvista/pyvista/zipball/master
+              python -m pip install --user --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
               python -m pip install --user --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
               python -m pip uninstall -yq pysurfer mayavi
               python -m pip install --user -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ before_install:
         pip uninstall -yq numpy
         pip install -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" --pre "numpy<1.20.0.dev0+20200811"
         pip install -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" scipy pandas scikit-learn matplotlib h5py Pillow
+        pip install https://github.com/pyvista/pyvista/zipball/master
+        pip install https://github.com/pyvista/pyvistaqt/zipball/master
         pip install --upgrade -r requirements.txt
       else
         git clone https://github.com/astropy/ci-helpers.git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -210,6 +210,8 @@ jobs:
       python -m pip install --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" "numpy<1.20.0.dev0+20200811"
       python -m pip install --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" scipy pandas scikit-learn matplotlib h5py Pillow
       python -m pip install --upgrade --only-binary vtk vtk;
+      python -m pip install https://github.com/pyvista/pyvista/zipball/master
+      python -m pip install https://github.com/pyvista/pyvistaqt/zipball/master
       python -m pip install -r requirements.txt -r requirements_testing.txt codecov
     condition: eq(variables['TEST_MODE'], 'pre-pip')
     displayName: 'Install dependencies with pip --pre'

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -318,9 +318,9 @@ def _check_skip_backend(name):
 @pytest.fixture()
 def renderer_notebook():
     """Verify that pytest_notebook is installed."""
-    from mne.viz.backends.renderer import _use_test_3d_backend
-    with _use_test_3d_backend('notebook'):
-        yield
+    from mne.viz.backends import renderer
+    with renderer._use_test_3d_backend('notebook'):
+        yield renderer
 
 
 @pytest.fixture(scope='session')
@@ -474,7 +474,7 @@ def download_is_error(monkeypatch):
 @pytest.fixture()
 def brain_gc(request):
     """Ensure that brain can be properly garbage collected."""
-    keys = ('renderer_interactive', 'renderer')
+    keys = ('renderer_interactive', 'renderer', 'renderer_notebook')
     assert set(request.fixturenames) & set(keys) != set()
     for key in keys:
         if key in request.fixturenames:

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -479,6 +479,7 @@ def brain_gc(request):
     for key in keys:
         if key in request.fixturenames:
             is_pv = request.getfixturevalue(key)._get_3d_backend() == 'pyvista'
+            close_func = request.getfixturevalue(key).backend._close_all
             break
     if not is_pv:
         yield
@@ -487,6 +488,7 @@ def brain_gc(request):
     _assert_no_instances(Brain, 'before')
     ignore = set(id(o) for o in gc.get_objects())
     yield
+    close_func()
     _assert_no_instances(Brain, 'after')
     # We only check VTK for PyVista -- Mayavi/PySurfer is not as strict
     objs = gc.get_objects()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -484,6 +484,10 @@ def brain_gc(request):
     if not is_pv:
         yield
         return
+    import pyvista
+    if LooseVersion(pyvista.__version__) <= LooseVersion('0.26.1'):
+        yield
+        return
     from mne.viz import Brain
     _assert_no_instances(Brain, 'before')
     ignore = set(id(o) for o in gc.get_objects())

--- a/mne/viz/_brain/tests/test_notebook.py
+++ b/mne/viz/_brain/tests/test_notebook.py
@@ -12,7 +12,7 @@ PATH = os.path.dirname(os.path.realpath(__file__))
 @requires_version('nbformat')
 @requires_version('nbclient')
 @requires_version('ipympl')
-def test_notebook_3d_backend(renderer_notebook):
+def test_notebook_3d_backend(renderer_notebook, brain_gc):
     """Test executing a notebook that should not fail."""
     import nbformat
     from nbclient import NotebookClient

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -6,7 +6,8 @@ import matplotlib.pyplot as plt
 from contextlib import contextmanager
 from ...fixes import nullcontext
 from ._pyvista import _Renderer as _PyVistaRenderer
-from ._pyvista import _set_3d_view, _set_3d_title  # noqa: F401 analysis:ignore
+from ._pyvista import \
+    _close_all, _set_3d_view, _set_3d_title  # noqa: F401 analysis:ignore
 
 
 class _Renderer(_PyVistaRenderer):

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -105,7 +105,7 @@ def test_plot_head_positions():
 @requires_pysurfer
 @traits_test
 @pytest.mark.slowtest
-def test_plot_sparse_source_estimates(renderer_interactive):
+def test_plot_sparse_source_estimates(renderer_interactive, brain_gc):
     """Test plotting of (sparse) source estimates."""
     sample_src = read_source_spaces(src_fname)
 
@@ -142,6 +142,7 @@ def test_plot_sparse_source_estimates(renderer_interactive):
     if renderer_interactive._get_3d_backend() == 'mayavi':
         import mayavi  # noqa: F401 analysis:ignore
         assert isinstance(surf, mayavi.modules.surface.Surface)
+    renderer_interactive.backend._close_all()
 
 
 @testing.requires_testing_data

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -574,7 +574,8 @@ def test_snapshot_brain_montage(renderer):
 @pytest.mark.parametrize('pick_ori', ('vector', None))
 @pytest.mark.parametrize('kind', ('surface', 'volume', 'mixed'))
 def test_plot_source_estimates(renderer_interactive, all_src_types_inv_evoked,
-                               pick_ori, kind):
+                               pick_ori, kind, brain_gc):
+    # kind = 'surface'
     """Test plotting of scalar and vector source estimates."""
     invs, evoked = all_src_types_inv_evoked
     inv = invs[kind]
@@ -615,6 +616,7 @@ def test_plot_source_estimates(renderer_interactive, all_src_types_inv_evoked,
             these_kwargs = kwargs.copy()
             these_kwargs.pop('src')
             meth(**these_kwargs)
+    renderer_interactive.backend._close_all()
 
     with pytest.raises(ValueError, match='cannot be used'):
         these_kwargs = kwargs.copy()
@@ -648,6 +650,7 @@ def test_plot_source_estimates(renderer_interactive, all_src_types_inv_evoked,
         these_kwargs.update(surface='inflated', views='flat')
         with pytest.raises(ValueError, match='surface="flat".*views="flat"'):
             flat_meth(**these_kwargs)
+    renderer_interactive.backend._close_all()
 
     # just test one for speed
     if kind != 'mixed':
@@ -666,6 +669,7 @@ def test_plot_source_estimates(renderer_interactive, all_src_types_inv_evoked,
     these_kwargs['volume_options'] = dict(badkey='foo')
     with pytest.raises(ValueError, match='unknown'):
         meth(**these_kwargs)
+    renderer_interactive.backend._close_all()
     # with resampling (actually downsampling but it's okay)
     these_kwargs['volume_options'] = dict(resolution=20., surface_alpha=0.)
     brain = meth(**these_kwargs)

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -576,7 +576,6 @@ def test_snapshot_brain_montage(renderer):
 @pytest.mark.parametrize('kind', ('surface', 'volume', 'mixed'))
 def test_plot_source_estimates(renderer_interactive, all_src_types_inv_evoked,
                                pick_ori, kind, brain_gc):
-    # kind = 'surface'
     """Test plotting of scalar and vector source estimates."""
     invs, evoked = all_src_types_inv_evoked
     inv = invs[kind]

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -142,7 +142,6 @@ def test_plot_sparse_source_estimates(renderer_interactive, brain_gc):
     if renderer_interactive._get_3d_backend() == 'mayavi':
         import mayavi  # noqa: F401 analysis:ignore
         assert isinstance(surf, mayavi.modules.surface.Surface)
-    renderer_interactive.backend._close_all()
 
 
 @testing.requires_testing_data
@@ -616,7 +615,6 @@ def test_plot_source_estimates(renderer_interactive, all_src_types_inv_evoked,
             these_kwargs = kwargs.copy()
             these_kwargs.pop('src')
             meth(**these_kwargs)
-    renderer_interactive.backend._close_all()
 
     with pytest.raises(ValueError, match='cannot be used'):
         these_kwargs = kwargs.copy()
@@ -650,7 +648,6 @@ def test_plot_source_estimates(renderer_interactive, all_src_types_inv_evoked,
         these_kwargs.update(surface='inflated', views='flat')
         with pytest.raises(ValueError, match='surface="flat".*views="flat"'):
             flat_meth(**these_kwargs)
-    renderer_interactive.backend._close_all()
 
     # just test one for speed
     if kind != 'mixed':
@@ -669,7 +666,6 @@ def test_plot_source_estimates(renderer_interactive, all_src_types_inv_evoked,
     these_kwargs['volume_options'] = dict(badkey='foo')
     with pytest.raises(ValueError, match='unknown'):
         meth(**these_kwargs)
-    renderer_interactive.backend._close_all()
     # with resampling (actually downsampling but it's okay)
     these_kwargs['volume_options'] = dict(resolution=20., surface_alpha=0.)
     brain = meth(**these_kwargs)


### PR DESCRIPTION
This PR adds the `brain_gc` fixture in remaining 3d viz tests.

Closes #8403 

I ran the tests locally using master versions of `pyvista` and `pyvistaqt`. Maybe some adjustments are necessary.