### PR TITLE
MRG, BUG, VIZ: min annotation duration

### DIFF
--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1114,7 +1114,8 @@ class MNEBrowseFigure(MNEFigure):
         if len(raw.annotations):
             for idx, annot in enumerate(raw.annotations):
                 annot_start = _sync_onset(raw, annot['onset'])
-                annot_end = annot_start + annot['duration']
+                annot_end = annot_start + max(annot['duration'],
+                                              1 / self.mne.info['sfreq'])
                 segments.append((annot_start, annot_end))
         self.mne.annotation_segments = np.array(segments)
 

--- a/tutorials/intro/plot_20_events_from_raw.py
+++ b/tutorials/intro/plot_20_events_from_raw.py
@@ -17,8 +17,8 @@ In the :ref:`introductory tutorial <overview-tut-events-section>` we saw an
 example of reading experimental events from a :term:`"STIM" channel <stim
 channel>`; here we'll discuss :term:`events` and :term:`annotations` more
 broadly, give more detailed information about reading from STIM channels, and
-give an example of reading events that are in a marker file or included in the
-data file as an embedded array. The tutorials :ref:`tut-event-arrays` and
+give an example of reading events that are in a marker file or included in
+the data file as an embedded array. The tutorials :ref:`tut-event-arrays` and
 :ref:`tut-annotate-raw` discuss how to plot, combine, load, save, and
 export :term:`events` and :class:`~mne.Annotations` (respectively), and the
 latter tutorial also covers interactive annotation of :class:`~mne.io.Raw`


### PR DESCRIPTION
fix a bug I introduced in #7955 