### PR TITLE
DOC: 0.21.1 is yet to be released

### DIFF
--- a/doc/changes/0.21.inc
+++ b/doc/changes/0.21.inc
@@ -10,8 +10,8 @@
 
 .. _changes_0_21_1:
 
-Version 0.21.1
---------------
+Version 0.21.1 (unreleased)
+---------------------------
 
 .. |Eduard Ort| replace:: **Eduard Ort**
 


### PR DESCRIPTION
I was confused when I looked at the website with the stable version docs, opened Whats New, and saw changes for 0.21.1. Couldn't find that release anywhere, until I realized: oh, right, it hasn't been released yet! This PR makes that clear in the changelog.