### PR TITLE
[MRG] BUG: Do not allow baseline removal after preload

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -73,6 +73,8 @@ Bugs
 
 - Fix bug in :func:`mne.viz.plot_alignment` where ECoG and sEEG channels were not plotted and fNIRS channels were always plotted in the head coordinate frame by `Eric Larson`_ (:gh:`8393`)
 
+- Attempting to remove baseline correction from preloaded `~mne.Epochs` will now raise an exception by `Richard Höchenberger`_ (:gh:`8435`)
+
 API changes
 ~~~~~~~~~~~
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -653,12 +653,17 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
 
         Notes
         -----
-        Baseline correction can be done multiple times.
+        Baseline correction can be done multiple times, but can never be
+        reverted once the data has been loaded.
 
         .. versionadded:: 0.10.0
         """
         _check_baseline(baseline, self.tmin, self.tmax, self.info['sfreq'])
         if self.preload:
+            if self.baseline is not None and baseline is None:
+                raise RuntimeError('You cannot remove baseline correction '
+                                   'from preloaded data once it has been '
+                                   'applied.')
             picks = _pick_data_channels(self.info, exclude=[],
                                         with_ref_meg=True)
             picks_aux = _pick_aux_channels(self.info, exclude=[])

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -745,6 +745,16 @@ def test_epochs_baseline(preload):
     expected[0] = [-0.5, 0.5]
     assert_allclose(epochs.get_data()[0], expected)
 
+    # we should not be able to remove baseline correction after the data
+    # has been loaded
+    if preload:
+        with pytest.raises(RuntimeError,
+                           match='You cannot remove baseline correction'):
+            epochs.apply_baseline(None)
+    else:
+        epochs.apply_baseline(None)
+        assert epochs.baseline is None
+
 
 def test_epochs_bad_baseline():
     """Test Epochs initialization with bad baseline parameters."""

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -747,6 +747,7 @@ def test_epochs_baseline(preload):
 
     # we should not be able to remove baseline correction after the data
     # has been loaded
+    epochs.apply_baseline((None, None))
     if preload:
         with pytest.raises(RuntimeError,
                            match='You cannot remove baseline correction'):


### PR DESCRIPTION
#### What does this implement/fix?

In `master` and 0.21 it's possible to preload `Epochs`, apply baseline correction, and (seemingly) remove it again via `apply_baseline(None)`. This should not be allowed: removing BL correction can only happen as long as the data has not been loaded.