### PR TITLE
CI: Allow latest numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
     - |
       if [ -z "$CONDA_ENV" ] && [ -z "$CONDA_DEPENDENCIES" ]; then
         pip uninstall -yq numpy
-        pip install -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" --pre "numpy<1.20.0.dev0+20200811"
+        pip install -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" --pre numpy
         pip install -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" scipy pandas scikit-learn matplotlib h5py Pillow
         pip install https://github.com/pyvista/pyvista/zipball/master
         pip install https://github.com/pyvista/pyvistaqt/zipball/master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,7 +207,7 @@ jobs:
   - bash: |
       set -e
       python -m pip install --upgrade pip "setuptools<50.0"
-      python -m pip install --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" "numpy<1.20.0.dev0+20200811"
+      python -m pip install --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy
       python -m pip install --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" scipy pandas scikit-learn matplotlib h5py Pillow
       python -m pip install --upgrade --only-binary vtk vtk;
       python -m pip install https://github.com/pyvista/pyvista/zipball/master


### PR DESCRIPTION
Let's see if we can remove our problematic version pinning. I can't remember why we needed it 2 months ago, but I'm sure the CIs will remind me (and I'll look back if they fail).