### PR TITLE
WIP: STC baseline correction

### DIFF
--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -608,7 +608,6 @@ class _BaseSourceEstimate(TimeMixin):
         Notes
         -----
         Baseline correction can be done multiple times.
-
         """
         self.data = rescale(self.data, self.times, baseline, copy=False)
         return self

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -590,6 +590,30 @@ class _BaseSourceEstimate(TimeMixin):
             allow_empty=allow_empty, verbose=verbose)
 
     @verbose
+    def apply_baseline(self, baseline=(None, 0), *, verbose=None):
+        """Baseline correct source estimate data.
+
+        Parameters
+        ----------
+        %(baseline_stc)s
+            Defaults to ``(None, 0)``, i.e. beginning of the the data until
+            time point zero.
+        %(verbose_meth)s
+
+        Returns
+        -------
+        stc : instance of SourceEstimate
+            The baseline-corrected source estimate object.
+
+        Notes
+        -----
+        Baseline correction can be done multiple times.
+
+        """
+        self.data = rescale(self.data, self.times, baseline, copy=False)
+        return self
+
+    @verbose
     def save(self, fname, ftype='h5', verbose=None):
         """Save the full source estimate to an HDF5 file.
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -14,6 +14,7 @@ import numpy as np
 from scipy import linalg, sparse
 from scipy.sparse import coo_matrix, block_diag as sparse_block_diag
 
+from .baseline import rescale
 from .cov import Covariance
 from .evoked import _get_peak
 from .filter import resample

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -104,8 +104,8 @@ def test_stc_baseline_correction():
                 t1 = baseline[1]
 
             # indec for baseline interval (include boundary latencies)
-            imin = np.abs(times-t0).argmin()
-            imax = np.abs(times-t1).argmin() + 1
+            imin = np.abs(times - t0).argmin()
+            imax = np.abs(times - t1).argmin() + 1
 
             # apply baseline correction
             stc = stc.apply_baseline(baseline=baseline)

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -78,6 +78,15 @@ rng = np.random.RandomState(0)
 
 
 @testing.requires_testing_data
+def test_stc_baseline_correction():
+    """Test baseline correction for source estimate objects."""
+    stc = mne.read_source_estimate(fname_stc)
+
+    # simple baseline correction
+    stc.apply_baseline()
+
+
+@testing.requires_testing_data
 def test_spatial_inter_hemi_adjacency():
     """Test spatial adjacency between hemispheres."""
     # trivial cases

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -81,42 +81,26 @@ rng = np.random.RandomState(0)
 def test_stc_baseline_correction():
     """Test baseline correction for source estimate objects."""
     # test on different source estimates
-    stcs = []
-    stcs.append(read_source_estimate(fname_stc))
-    stcs.append(read_source_estimate(fname_vol, 'sample'))
-
+    stcs = [read_source_estimate(fname_stc), 
+            read_source_estimate(fname_vol, 'sample')]
     # test on different "baseline" intervals
     baselines = [(0., 0.1), (None, None)]
 
     for stc in stcs:
-
+        # apply baseline correction
+        stc = stc.apply_baseline(baseline=(start, stop))
         times = stc.times
 
-        for baseline in baselines:
-
-            if baseline[0] is None:
-                t0 = stc.times[0]
-            else:
-                t0 = baseline[0]
-            if baseline[1] is None:
-                t1 = stc.times[-1]
-            else:
-                t1 = baseline[1]
-
-            # indec for baseline interval (include boundary latencies)
+        for (start, stop) in baselines:
+            t0 = start or stc.times[0]
+            t1 = stop or stc.times[-1]
+            # index for baseline interval (include boundary latencies)
             imin = np.abs(times - t0).argmin()
             imax = np.abs(times - t1).argmin() + 1
-
-            # apply baseline correction
-            stc = stc.apply_baseline(baseline=baseline)
-
             # data matrix from baseline interval
             data_base = stc.data[:, imin:imax]
-
             mean_base = data_base.mean(axis=1)
-
             zero_array = np.zeros(mean_base.shape[0])
-
             # test if baseline properly subtracted (mean=zero for all sources)
             assert_array_almost_equal(mean_base, zero_array)
 

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -80,7 +80,7 @@ rng = np.random.RandomState(0)
 @testing.requires_testing_data
 def test_stc_baseline_correction():
     """Test baseline correction for source estimate objects."""
-    stc = mne.read_source_estimate(fname_stc)
+    stc = read_source_estimate(fname_stc)
 
     # simple baseline correction
     stc.apply_baseline()

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -87,11 +87,12 @@ def test_stc_baseline_correction():
     baselines = [(0., 0.1), (None, None)]
 
     for stc in stcs:
-        # apply baseline correction
-        stc = stc.apply_baseline(baseline=(start, stop))
         times = stc.times
 
         for (start, stop) in baselines:
+            # apply baseline correction, then check if it worked
+            stc = stc.apply_baseline(baseline=(start, stop))
+
             t0 = start or stc.times[0]
             t1 = stop or stc.times[-1]
             # index for baseline interval (include boundary latencies)

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -84,7 +84,7 @@ rng = np.random.RandomState(0)
 def test_stc_baseline_correction():
     """Test baseline correction for source estimate objects."""
     # test on different source estimates
-    stcs = [read_source_estimate(fname_stc), 
+    stcs = [read_source_estimate(fname_stc),
             read_source_estimate(fname_vol, 'sample')]
     # test on different "baseline" intervals
     baselines = [(0., 0.1), (None, None)]

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1800,7 +1800,7 @@ docdict['baseline_stc'] = """%(rescale_baseline)s
     approximately additive, and the noise level can be estimated from the
     baseline interval. This can be the case for non-normalized source
     activities (e.g. signed and unsigned MNE), but it is not the case for
-    normalized estimates (e.g. signal-to-noise ratios, dSPM, sLORETA). 
+    normalized estimates (e.g. signal-to-noise ratios, dSPM, sLORETA).
 
 """ % docdict
 docdict['baseline_report'] = """%(rescale_baseline)s

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1796,6 +1796,12 @@ docdict['baseline_stc'] = """%(rescale_baseline)s
     1. Calculate the mean signal of the baseline period.
     2. Subtract this mean from the **entire** source estimate data.
 
+    .. note:: Baseline correction is appropriate when signal and noise are
+    approximately additive, and the noise level can be estimated from the
+    baseline interval. This can be the case for non-normalized source
+    activities (e.g. signed and unsigned MNE), but it is not the case for
+    normalized estimates (e.g. signal-to-noise ratios, dSPM, sLORETA). 
+
 """ % docdict
 docdict['baseline_report'] = """%(rescale_baseline)s
     Correction is applied in the following way **to each channel:**

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1797,11 +1797,11 @@ docdict['baseline_stc'] = """%(rescale_baseline)s
     2. Subtract this mean from the **entire** source estimate data.
 
     .. note:: Baseline correction is appropriate when signal and noise are
-    approximately additive, and the noise level can be estimated from the
-    baseline interval. This can be the case for non-normalized source
-    activities (e.g. signed and unsigned MNE), but it is not the case for
-    normalized estimates (e.g. signal-to-noise ratios, dSPM, sLORETA).
-
+              approximately additive, and the noise level can be estimated from
+              the baseline interval. This can be the case for non-normalized
+              source activities (e.g. signed and unsigned MNE), but it is not
+              the case for normalized estimates (e.g. signal-to-noise ratios,
+              dSPM, sLORETA).
 """ % docdict
 docdict['baseline_report'] = """%(rescale_baseline)s
     Correction is applied in the following way **to each channel:**

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1789,6 +1789,14 @@ docdict['baseline_evoked'] = """%(rescale_baseline)s
     2. Subtract this mean from the **entire** ``Evoked``.
 
 """ % docdict
+docdict['baseline_stc'] = """%(rescale_baseline)s
+    Correction is applied **to each source individually** in the following
+    way:
+
+    1. Calculate the mean signal of the baseline period.
+    2. Subtract this mean from the **entire** source estimate data.
+
+""" % docdict
 docdict['baseline_report'] = """%(rescale_baseline)s
     Correction is applied in the following way **to each channel:**
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1802,6 +1802,7 @@ docdict['baseline_stc'] = """%(rescale_baseline)s
               source activities (e.g. signed and unsigned MNE), but it is not
               the case for normalized estimates (e.g. signal-to-noise ratios,
               dSPM, sLORETA).
+
 """ % docdict
 docdict['baseline_report'] = """%(rescale_baseline)s
     Correction is applied in the following way **to each channel:**


### PR DESCRIPTION
Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

#### Reference issue
#8232


#### What does this implement/fix?
Baseline-correction for source estimates is recommended/necessary for some processing steps. For example, for unsigned source estimates, differences in noise levels may result in differences in intensities (e.g. for conditions with very different numbers of trials). This can be compenstated for by baseline-correction.
I will add a method appy_baseline() to source_estimate.py, analogous to evoked.py. I will add documentation to highlight the caveats of baseline correction for source estimates.

#### Additional information
Any additional information you think is important.
