### PR TITLE
[MRG] Getting ch positions from DigMontage via get_positions()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -33,7 +33,7 @@ Enhancements
 
 - Add sEEG source visualization using :func:`mne.stc_near_sensors` and sEEG working tutorial by `Eric Larson`_ and `Adam Li`_ (:gh:`8402`)
 
-- Add :meth:`mne.channels.DigMontage.get_position`, which will return a dictionary of channel positions, coordinate frame and fiducial locations by `Adam Li`_ (:gh:`8460`)
+- Add :meth:`mne.channels.DigMontage.get_positions`, which will return a dictionary of channel positions, coordinate frame and fiducial locations by `Adam Li`_ (:gh:`8460`)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -33,6 +33,8 @@ Enhancements
 
 - Add sEEG source visualization using :func:`mne.stc_near_sensors` and sEEG working tutorial by `Eric Larson`_ and `Adam Li`_ (:gh:`8402`)
 
+- Add :meth:`mne.channels.DigMontage.get_position`, which will return a dictionary of channel positions, coordinate frame and fiducial locations by `Adam Li`_ (:gh:`8460`)
+
 Bugs
 ~~~~
 - Fix bug with reading split files that have dashes in the filename **by new contributor** |Eduard Ort|_ (:gh:`8339`)

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -317,7 +317,7 @@ class DigMontage(object):
             right preauricular point (``rpa``),
             Head Shape Polhemus (``hsp``), and
             Head Position Indicator(``hpi``).
-            E.g. ..
+            E.g.::
 
                 {
                     'ch_pos': {'EEG061': [0, 0, 0]},

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -316,7 +316,8 @@ class DigMontage(object):
             left preauricular point (``lpa``),
             right preauricular point (``rpa``),
             Head Shape Polhemus (``hsp``), and
-            Head Position Indicator(``hpi``). E.g. ..
+            Head Position Indicator(``hpi``).
+            E.g. ..
 
                 {
                     'ch_pos': {'EEG061': [0, 0, 0]},

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -28,7 +28,8 @@ from ..transforms import (apply_trans, get_ras_to_neuromag_trans, _sph_to_cart,
 from ..io._digitization import (_count_points_by_type,
                                 _get_dig_eeg, _make_dig_points, write_dig,
                                 _read_dig_fif, _format_dig_points,
-                                _get_fid_coords, _coord_frame_const)
+                                _get_fid_coords, _coord_frame_const,
+                                _get_data_as_dict_from_dig)
 from ..io.meas_info import create_info
 from ..io.open import fiff_open
 from ..io.pick import pick_types
@@ -303,6 +304,39 @@ class DigMontage(object):
             dig_names[dig_idx] = self.ch_names[ch_name_idx]
 
         return dig_names
+
+    def get_positions(self):
+        """Get all channel and fiducial positions.
+
+        All positions are in the ``head`` coordinate frame.
+
+        Returns
+        -------
+        positions : dict
+            A dictionary of the positions for channels (``ch_pos``),
+            coordinate frame (``coord_frame``), Nasion (``nasion``),
+            Left Periventricular (``lpa``), Right Periventricular
+            (``rpa``), (``hsp``), and (``hpi``).
+        """
+        # get channel positions as dict
+        ch_pos = self._get_ch_pos()
+
+        # _get_fid_coords(self.dig)
+        # get coordframe and fiducial coordinates
+        montage_bunch = _get_data_as_dict_from_dig(self.dig)
+        coord_frame = _frame_to_str.get(montage_bunch.coord_frame)
+
+        # return dictionary
+        positions = dict(
+            ch_pos=ch_pos,
+            coord_frame=coord_frame,
+            nasion=montage_bunch.nasion,
+            lpa=montage_bunch.lpa,
+            rpa=montage_bunch.rpa,
+            hsp=montage_bunch.hsp,
+            hpi=montage_bunch.hpi,
+        )
+        return positions
 
 
 VALID_SCALES = dict(mm=1e-3, cm=1e-2, m=1)

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -324,8 +324,8 @@ class DigMontage(object):
                     'nasion': [0, 0, 1],
                     'lpa': [0, 1, 0],
                     'rpa': [1, 0, 0],
-                    'hsp': [np.nan, np.nan, np.nan],
-                    'hpi': [np.nan, np.nan, np.nan]
+                    'hsp': None,
+                    'hpi': None
                 }
         """
         # get channel positions as dict

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -314,9 +314,20 @@ class DigMontage(object):
         -------
         positions : dict
             A dictionary of the positions for channels (``ch_pos``),
-            coordinate frame (``coord_frame``), Nasion (``nasion``),
-            Left Periventricular (``lpa``), Right Periventricular
-            (``rpa``), (``hsp``), and (``hpi``).
+            coordinate frame (``coord_frame``), nasion (``nasion``),
+            left preauricular point (``lpa``),
+            right preauricular point (``rpa``),
+            Head Shape Polhemus (``hsp``), and
+            Head Position Indicator(``hpi``). E.g. ..
+
+                {
+                    'ch_pos': {'EEG061': [0, 0, 0]},
+                    'nasion': [0, 0, 1],
+                    'lpa': [0, 1, 0],
+                    'rpa': [1, 0, 0],
+                    'hsp': [np.nan, np.nan, np.nan],
+                    'hpi': [np.nan, np.nan, np.nan]
+                }
         """
         # get channel positions as dict
         ch_pos = self._get_ch_pos()

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -308,8 +308,6 @@ class DigMontage(object):
     def get_positions(self):
         """Get all channel and fiducial positions.
 
-        All positions are in the ``head`` coordinate frame.
-
         Returns
         -------
         positions : dict

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1340,7 +1340,7 @@ def test_get_montage():
     # 2. now do a standard montage
     montage = make_standard_montage('mgh60')
     # set the montage; note renaming to make standard montage map
-    raw.set_montage(montage)
+    raw.set_montage(montage.copy())
 
     # get montage back and set it
     # the channel locations should be the same
@@ -1348,10 +1348,8 @@ def test_get_montage():
     test_montage = raw.get_montage()
     raw.set_montage(test_montage, on_missing='ignore')
 
-    # XXX: this fails for some reason for templates
-    # because coordinate frame gets set to head?
     # the montage should fulfill a roundtrip with make_dig_montage
-    test2_montage = make_dig_montage(**montage.get_positions())
+    test2_montage = make_dig_montage(**test_montage.get_positions())
     assert_object_equal(test2_montage.dig, test_montage.dig)
 
     # chs should not change
@@ -1403,6 +1401,10 @@ def test_get_montage():
     # if dig is not set in the info, then montage returns None
     raw.info['dig'] = None
     assert raw.get_montage() is None
+
+    # the montage should fulfill a roundtrip with make_dig_montage
+    test2_montage = make_dig_montage(**test_montage.get_positions())
+    assert_object_equal(test2_montage.dig, test_montage.dig)
 
 
 def test_read_dig_hpts():

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1340,7 +1340,7 @@ def test_get_montage():
     # 2. now do a standard montage
     montage = make_standard_montage('mgh60')
     # set the montage; note renaming to make standard montage map
-    raw.set_montage(montage.copy())
+    raw.set_montage(montage)
 
     # get montage back and set it
     # the channel locations should be the same

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1333,6 +1333,10 @@ def test_get_montage():
     # the montage does not change
     assert_object_equal(montage.dig, test_montage.dig)
 
+    # the montage should fulfill a roundtrip with make_dig_montage
+    test2_montage = make_dig_montage(**montage.get_positions())
+    assert_object_equal(test2_montage.dig, test_montage.dig)
+
     # 2. now do a standard montage
     montage = make_standard_montage('mgh60')
     # set the montage; note renaming to make standard montage map
@@ -1343,6 +1347,12 @@ def test_get_montage():
     raw2 = raw.copy()
     test_montage = raw.get_montage()
     raw.set_montage(test_montage, on_missing='ignore')
+
+    # XXX: this fails for some reason for templates
+    # because coordinate frame gets set to head?
+    # the montage should fulfill a roundtrip with make_dig_montage
+    test2_montage = make_dig_montage(**montage.get_positions())
+    assert_object_equal(test2_montage.dig, test_montage.dig)
 
     # chs should not change
     assert_object_equal(raw2.info['chs'], raw.info['chs'])


### PR DESCRIPTION
#### Reference issue
Fixes: #8451 


#### What does this implement/fix?
Adds `DigMontage.get_positions()` that would allow a full roundtrip with `make_dig_montage`. More importantly it obtains the DigMontage ch positions, coordinate frame and fiducials.

Adds a unit test. 


#### Additional information
~~For some reason the coordinate frame changes when using the template.~~ 

~~Is it safe to say we should have `get_positions` always return things in `coord_frame=head`? If so, what's suggestion to fix the unit test with the template that transforms unknown coordframe to the head coord_frame?~~ Now obtains the original coordinate frame.

