### PR TITLE
MRG, BUG: fix writing with bids naming when no split is needed.

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -54,6 +54,8 @@ Bugs
 
 - :func:`mne.io.read_raw_edf` now supports EDF files with invalid recording dates by `Clemens Brunner`_ (:gh:`8283`)
 
+- Fix bug with :func:`mne.io.Raw.save` when using ``split_naming='bids'`` where non-split files would still be named ``name_split-01_meg.fif`` instead of the requested ``name_meg.fif`` by `Alex Gramfort`_ and `Eric Larson`_ (:gh:`8464`)
+
 - Fix bug with :class:`mne.preprocessing.ICA` where ``n_pca_components`` as a :class:`python:float` would give the number of components that explained less than or equal to the given variance. It now gives greater than the given number for better usability and consistency with :class:`sklearn.decomposition.PCA`. Generally this will mean that one more component will be included, by `Eric Larson`_ (:gh:`8326`)
 
 - Fix bug with :class:`mne.preprocessing.ICA` where projections were not tracked properly by `Eric Larson`_

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -13,6 +13,7 @@ from copy import deepcopy
 from datetime import timedelta
 import os
 import os.path as op
+import shutil
 
 import numpy as np
 
@@ -1394,17 +1395,11 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         buffer_size = self._get_buffer_size(buffer_size_sec)
 
         # write the raw file
-        if split_naming == 'neuromag':
-            part_idx = 0
-        elif split_naming == 'bids':
-            part_idx = 1
-        else:
-            raise ValueError(
-                "split_naming must be either 'neuromag' or 'bids' instead "
-                "of '{}'.".format(split_naming))
+        _validate_type(split_naming, str, 'split_naming')
+        _check_option('split_naming', split_naming, ('neuromag', 'bids'))
         _write_raw(fname, self, info, picks, fmt, data_type, reset_range,
                    start, stop, buffer_size, projector, drop_small_buffer,
-                   split_size, split_naming, part_idx, None, overwrite)
+                   split_size, split_naming, 0, None, overwrite)
 
     def _tmin_tmax_to_start_stop(self, tmin, tmax):
         start = int(np.floor(tmin * self.info['sfreq']))
@@ -1855,18 +1850,28 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
         raise RuntimeError('Cannot write raw file with no data: %s -> %s '
                            '(max: %s) requested' % (start, stop, n_times_max))
 
+    base, ext = op.splitext(fname)
     if part_idx > 0:
-        base, ext = op.splitext(fname)
         if split_naming == 'neuromag':
             # insert index in filename
             use_fname = '%s-%d%s' % (base, part_idx, ext)
         elif split_naming == 'bids':
-            use_fname = _construct_bids_filename(base, ext, part_idx)
+            use_fname = _construct_bids_filename(base, ext, part_idx + 1)
             # check for file existence
             _check_fname(use_fname, overwrite)
-
     else:
         use_fname = fname
+    # reserve our BIDS split fname in case we need to split
+    if split_naming == 'bids' and part_idx == 0:
+        # reserve our possible split name
+        reserved_fname = _construct_bids_filename(base, ext, part_idx + 1)
+        logger.info(
+            f'Reserving possible split file {op.basename(reserved_fname)}')
+        _check_fname(reserved_fname, overwrite)
+        with open(reserved_fname, 'w') as fid:
+            pass
+    else:
+        reserved_fname = use_fname
     logger.info('Writing %s' % use_fname)
 
     picks = _picks_to_idx(info, picks, 'all', ())
@@ -1878,17 +1883,13 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
         write_int(fid, FIFF.FIFF_FIRST_SAMPLE, first_samp)
 
     # previous file name and id
-    if split_naming == 'neuromag':
-        part_idx_tag = part_idx - 1
-    else:
-        part_idx_tag = part_idx - 2
     if part_idx > 0 and prev_fname is not None:
         start_block(fid, FIFF.FIFFB_REF)
         write_int(fid, FIFF.FIFF_REF_ROLE, FIFF.FIFFV_ROLE_PREV_FILE)
         write_string(fid, FIFF.FIFF_REF_FILE_NAME, prev_fname)
         if info['meas_id'] is not None:
             write_id(fid, FIFF.FIFF_REF_FILE_ID, info['meas_id'])
-        write_int(fid, FIFF.FIFF_REF_FILE_NUM, part_idx_tag)
+        write_int(fid, FIFF.FIFF_REF_FILE_NUM, part_idx - 1)
         end_block(fid, FIFF.FIFFB_REF)
 
     pos_prev = fid.tell()
@@ -1916,6 +1917,7 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
                      'output buffer_size, will be written as zeroes.')
 
     n_current_skip = 0
+    final_fname = use_fname
     for first, last in zip(firsts, lasts):
         if do_skips:
             if ((first >= sk_onsets) & (last <= sk_ends)).any():
@@ -1963,11 +1965,12 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
         # with the "and" check
         if pos >= split_size - this_buff_size_bytes - _NEXT_FILE_BUFFER and \
                 first + buffer_size < stop:
+            final_fname = reserved_fname
             next_fname, next_idx = _write_raw(
                 fname, raw, info, picks, fmt,
                 data_type, reset_range, first + buffer_size, stop, buffer_size,
                 projector, drop_small_buffer, split_size, split_naming,
-                part_idx + 1, use_fname, overwrite)
+                part_idx + 1, final_fname, overwrite)
 
             start_block(fid, FIFF.FIFFB_REF)
             write_int(fid, FIFF.FIFF_REF_ROLE, FIFF.FIFFV_ROLE_NEXT_FILE)
@@ -1977,17 +1980,23 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
             write_int(fid, FIFF.FIFF_REF_FILE_NUM, next_idx)
             end_block(fid, FIFF.FIFFB_REF)
             break
-
         pos_prev = pos
 
-    logger.info('Closing %s [done]' % use_fname)
+    logger.info('Closing %s' % use_fname)
     if info.get('maxshield', False):
         end_block(fid, FIFF.FIFFB_IAS_RAW_DATA)
     else:
         end_block(fid, FIFF.FIFFB_RAW_DATA)
     end_block(fid, FIFF.FIFFB_MEAS)
     end_file(fid)
-    return use_fname, part_idx
+    if final_fname != use_fname:
+        logger.info(f'Renaming BIDS split file {op.basename(final_fname)}')
+        shutil.move(use_fname, final_fname)
+    elif reserved_fname != use_fname:
+        os.remove(reserved_fname)
+    if part_idx == 0:
+        logger.info('[done]')
+    return final_fname, part_idx
 
 
 def _start_writing_raw(name, info, sel, data_type,

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -371,6 +371,12 @@ def test_split_files(tmpdir):
     split_fname_bids_part1 = tmpdir.join('split_raw_split-01_meg.fif')
     split_fname_bids_part2 = tmpdir.join('split_raw_split-02_meg.fif')
     raw_1.set_annotations(Annotations([2.], [5.5], 'test'))
+
+    # Check that if BIDS is used and no split is needed it defaults to
+    # simple writing without _split- entity.
+    raw_1.save(split_fname, split_naming='bids')
+    assert op.exists(split_fname)
+
     raw_1.save(split_fname, buffer_size_sec=1.0, split_size='10MB')
 
     # check that the filenames match the intended pattern

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -374,18 +374,33 @@ def test_split_files(tmpdir):
 
     # Check that if BIDS is used and no split is needed it defaults to
     # simple writing without _split- entity.
-    raw_1.save(split_fname, split_naming='bids')
-    assert op.exists(split_fname)
+    raw_1.save(split_fname, split_naming='bids', verbose=True)
+    assert op.isfile(split_fname)
+    assert not op.isfile(split_fname_bids_part1)
+    for split_naming in ('neuromag', 'bids'):
+        with pytest.raises(FileExistsError, match='Destination file'):
+            raw_1.save(split_fname, split_naming=split_naming, verbose=True)
+    os.remove(split_fname)
+    with open(split_fname_bids_part1, 'w'):
+        pass
+    with pytest.raises(FileExistsError, match='Destination file'):
+        raw_1.save(split_fname, split_naming='bids', verbose=True)
+    assert not op.isfile(split_fname)
+    raw_1.save(split_fname, split_naming='neuromag', verbose=True)  # okay
+    os.remove(split_fname)
+    os.remove(split_fname_bids_part1)
 
-    raw_1.save(split_fname, buffer_size_sec=1.0, split_size='10MB')
+    raw_1.save(split_fname, buffer_size_sec=1.0, split_size='10MB',
+               verbose=True)
 
     # check that the filenames match the intended pattern
-    assert op.exists(split_fname_elekta_part2)
+    assert op.isfile(split_fname)
+    assert op.isfile(split_fname_elekta_part2)
     # check that filenames are being formatted correctly for BIDS
     raw_1.save(split_fname, buffer_size_sec=1.0, split_size='10MB',
-               split_naming='bids', overwrite=True)
-    assert op.exists(split_fname_bids_part1)
-    assert op.exists(split_fname_bids_part2)
+               split_naming='bids', overwrite=True, verbose=True)
+    assert op.isfile(split_fname_bids_part1)
+    assert op.isfile(split_fname_bids_part2)
 
     annot = Annotations(np.arange(20), np.ones((20,)), 'test')
     raw_1.set_annotations(annot)

--- a/mne/preprocessing/stim.py
+++ b/mne/preprocessing/stim.py
@@ -94,7 +94,6 @@ def fix_stim_artifact(inst, events=None, event_id=None, tmin=0.,
             first_samp = int(event_idx) - inst.first_samp + s_start
             last_samp = int(event_idx) - inst.first_samp + s_end
             _fix_artifact(data, window, picks, first_samp, last_samp, mode)
-
     elif isinstance(inst, BaseEpochs):
         if inst.reject is not None:
             raise RuntimeError('Reject is already applied. Use reject=None '


### PR DESCRIPTION
@larsoner I am curious how you would approach this.

Basically currently if you use bids split naming convention even if you don't need to split it will add a _split-01 in the first file.

do we have a way to detect early if the file will be split?