### PR TITLE
[MRG] Fixing documentation for plot_seeg and adding some tutorial links.

### DIFF
--- a/examples/inverse/plot_label_source_activations.py
+++ b/examples/inverse/plot_label_source_activations.py
@@ -41,7 +41,7 @@ src = inverse_operator['src']
 ###############################################################################
 # Compute inverse solution
 # ------------------------
-pick_ori = "normal"  # Get signed values to see the effect of sign filp
+pick_ori = "normal"  # Get signed values to see the effect of sign flip
 stc = apply_inverse(evoked, inverse_operator, lambda2, method,
                     pick_ori=pick_ori)
 

--- a/tutorials/misc/plot_seeg.py
+++ b/tutorials/misc/plot_seeg.py
@@ -148,9 +148,9 @@ clim = dict(kind='value', lims=np.percentile(abs(evoked.data), [10, 50, 75]))
 ###############################################################################
 # Plot 3D source (brain region) visualization:
 #
-# The time course shown here is the ``stc.data[idx]`` where ``idx`` is the index
-# of the source with the largest absolute value across any time point. In this
-# example, it is simply the source with the largest raw signal value.
+# The time course shown here is the ``stc.data[idx]`` where ``idx`` is the
+# index of the source with the largest absolute value across any time point.
+# In this example, it is simply the source with the largest raw signal value.
 
 # sphinx_gallery_thumbnail_number = 4
 

--- a/tutorials/misc/plot_seeg.py
+++ b/tutorials/misc/plot_seeg.py
@@ -145,11 +145,12 @@ stc = mne.stc_near_sensors(
 stc = abs(stc)  # just look at magnitude
 clim = dict(kind='value', lims=np.percentile(abs(evoked.data), [10, 50, 75]))
 
-# plot Nutmeg style
-stc.plot(vol_src, subject=subject, subjects_dir=subjects_dir, clim=clim)
-
 ###############################################################################
 # Plot 3D source (brain region) visualization:
+#
+# The time course shown here is the `stc.data[idx]` where `idx` is the index
+# of the source with the largest absolute value across any time point. In this
+# example, it is simply the source with the largest raw signal value.
 
 # sphinx_gallery_thumbnail_number = 4
 
@@ -162,3 +163,16 @@ brain = stc.plot_3d(
 # You can save a movie like the one on our documentation website with:
 # brain.save_movie(time_dilation=3, interpolation='linear', framerate=10,
 #                  time_viewer=True, filename='./mne-test-seeg.m4')
+
+###############################################################################
+# In this tutorial, we used a BEM surface for the `fsaverage` subject from
+# FreeSurfer.
+#
+# For additional common analyses of interest, see the following:
+#
+# - For volumetric plotting options, including limiting to a specific area of
+#   the volume specified by say an atlas, or plotting different types of
+#   source visualizations see:
+#   :ref:`tut-viz-stcs:Volume Source Estimates`.
+# - For extracting activation within a specific FreeSurfer volume and using
+#   different FreeSurfer volumes, see: :ref:`tut-freesurfer-mne`.

--- a/tutorials/misc/plot_seeg.py
+++ b/tutorials/misc/plot_seeg.py
@@ -176,3 +176,5 @@ brain = stc.plot_3d(
 #   :ref:`tut-viz-stcs:Volume Source Estimates`.
 # - For extracting activation within a specific FreeSurfer volume and using
 #   different FreeSurfer volumes, see: :ref:`tut-freesurfer-mne`.
+# - For working with BEM surfaces and using FreeSurfer, or mne to generate
+#   them, see: :ref:`tut-forward`.

--- a/tutorials/misc/plot_seeg.py
+++ b/tutorials/misc/plot_seeg.py
@@ -148,7 +148,7 @@ clim = dict(kind='value', lims=np.percentile(abs(evoked.data), [10, 50, 75]))
 ###############################################################################
 # Plot 3D source (brain region) visualization:
 #
-# The time course shown here is the `stc.data[idx]` where `idx` is the index
+# The time course shown here is the ``stc.data[idx]`` where ``idx`` is the index
 # of the source with the largest absolute value across any time point. In this
 # example, it is simply the source with the largest raw signal value.
 
@@ -165,7 +165,7 @@ brain = stc.plot_3d(
 #                  time_viewer=True, filename='./mne-test-seeg.m4')
 
 ###############################################################################
-# In this tutorial, we used a BEM surface for the `fsaverage` subject from
+# In this tutorial, we used a BEM surface for the ``fsaverage`` subject from
 # FreeSurfer.
 #
 # For additional common analyses of interest, see the following:
@@ -173,7 +173,7 @@ brain = stc.plot_3d(
 # - For volumetric plotting options, including limiting to a specific area of
 #   the volume specified by say an atlas, or plotting different types of
 #   source visualizations see:
-#   :ref:`tut-viz-stcs:Volume Source Estimates`.
+#   :ref:`tut-viz-stcs`.
 # - For extracting activation within a specific FreeSurfer volume and using
 #   different FreeSurfer volumes, see: :ref:`tut-freesurfer-mne`.
 # - For working with BEM surfaces and using FreeSurfer, or mne to generate

--- a/tutorials/misc/plot_seeg.py
+++ b/tutorials/misc/plot_seeg.py
@@ -148,9 +148,10 @@ clim = dict(kind='value', lims=np.percentile(abs(evoked.data), [10, 50, 75]))
 ###############################################################################
 # Plot 3D source (brain region) visualization:
 #
-# The time course shown here is the ``stc.data[idx]`` where ``idx`` is the
-# index of the source with the largest absolute value across any time point.
+# By default, `stc.plot_3d() <mne.VolSourceEstimate.plot_3d>` will show a time
+# course of the source with the largest absolute value across any time point.
 # In this example, it is simply the source with the largest raw signal value.
+# Its location is marked on the brain by a small blue sphere.
 
 # sphinx_gallery_thumbnail_number = 4
 


### PR DESCRIPTION
#### Reference issue
Closes: #8428 


#### What does this implement/fix?
Links the `plot_seeg.py` tutorial to other tutorials that will put into context how to:

1. work with BEM surfaces
2. work with different volumetric plotting options
3. work with FreeSurfer transformations and their different volumes

