### PR TITLE
TST: Cleaner matplotlib testing

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -126,6 +126,15 @@ def check_verbose(request):
                     ' modifies logger.level')
 
 
+@pytest.fixture(autouse=True)
+def close_all():
+    """Close all matplotlib plots, regardless of test status."""
+    # This adds < 1 µS in local testing, and we have ~2500 tests, so ~2 ms max
+    import matplotlib.pyplot as plt
+    yield
+    plt.close('all')
+
+
 @pytest.fixture(scope='function')
 def verbose_debug():
     """Run a test with debug verbosity."""

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -42,7 +42,7 @@ def raw():
 @pytest.fixture(scope='module')
 def new_mpl():
     """Check matplotlib version."""
-    return check_version('matplotlib', '3.0')
+    return check_version('matplotlib', '3.1')
 
 
 def _get_events():
@@ -286,7 +286,11 @@ def test_plot_raw_selection(raw, new_mpl):
     _fake_click(sel_fig, sensor_ax, (0.65, 1), xform='ax', kind='motion')
     _fake_click(sel_fig, sensor_ax, (0.65, 0.7), xform='ax', kind='motion')
     _fake_click(sel_fig, sensor_ax, (0, 0.7), xform='ax', kind='release')
-    assert sel_fig.lasso.selection == ['MEG 0121', 'MEG 0122', 'MEG 0123']
+    want = ['MEG 0121', 'MEG 0122', 'MEG 0123'] if new_mpl else \
+        ['MEG 0111', 'MEG 0112', 'MEG 0131', 'MEG 0132', 'MEG 0133']  # XXX old
+    want = sorted(want)
+    got = sorted(sel_fig.lasso.selection)
+    assert got == want
     # test joint closing of selection & data windows
     sel_fig.canvas.key_press_event(sel_fig.mne.close_key)
     _close_event(sel_fig)
@@ -304,7 +308,7 @@ def test_plot_raw_ssp_interaction(raw):
     fig = raw.plot()
     # open SSP window
     _fake_click(fig, fig.mne.ax_proj, [0.5, 0.5])
-    assert len(plt.get_fignums()) == 2  # XXX this fails with minimal deps
+    assert len(plt.get_fignums()) == 2
     ssp_fig = fig.mne.fig_proj
     t = ssp_fig.mne.proj_checkboxes.labels
     ax = ssp_fig.mne.proj_checkboxes.ax


### PR DESCRIPTION
Takes care of failures in `master` like:

https://travis-ci.org/github/mne-tools/mne-python/jobs/740934132

The real bug was just that the selection was wrong. This caused the figures not to be closed, which triggered another test to fail. So this adds a root-level `autouse=True` fixture that does `plt.close('all')` at the end of each test. In testing with no figures open `plt.close('all')` took < 1 uS, and with ~2500 tests we're adding on the order of 1 ms extra test time which is fine to have the added security of each test starting with no figures open.