### PR TITLE
less stringent check in _construct_bids_filename (req by derivatives)

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -34,6 +34,7 @@ from ..annotations import (_annotations_starts_stops, _write_annotations,
                            _handle_meas_date)
 from ..filter import (FilterMixin, notch_filter, resample, _resamp_ratio_len,
                       _resample_stim_channels, _check_fun)
+from ..fixes import nullcontext
 from ..parallel import parallel_func
 from ..utils import (_check_fname, _check_pandas_installed, sizeof_fmt,
                      _check_pandas_index_arguments, fill_doc, copy_doc,
@@ -1855,7 +1856,8 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
         if split_naming == 'neuromag':
             # insert index in filename
             use_fname = '%s-%d%s' % (base, part_idx, ext)
-        elif split_naming == 'bids':
+        else:
+            assert split_naming == 'bids'
             use_fname = _construct_bids_filename(base, ext, part_idx + 1)
             # check for file existence
             _check_fname(use_fname, overwrite)
@@ -1868,16 +1870,52 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
         logger.info(
             f'Reserving possible split file {op.basename(reserved_fname)}')
         _check_fname(reserved_fname, overwrite)
-        with open(reserved_fname, 'w') as fid:
-            pass
+        ctx = _ReservedFilename(reserved_fname)
     else:
         reserved_fname = use_fname
+        ctx = nullcontext()
     logger.info('Writing %s' % use_fname)
 
     picks = _picks_to_idx(info, picks, 'all', ())
     fid, cals = _start_writing_raw(use_fname, info, picks, data_type,
                                    reset_range, raw.annotations)
+    with ctx, fid:
+        final_fname = _write_raw_fid(
+            raw, info, picks, fid, cals, part_idx, start, stop,
+            buffer_size, prev_fname, split_size, use_fname,
+            projector, drop_small_buffer, fmt, fname, reserved_fname,
+            data_type, reset_range, split_naming, overwrite)
+    if final_fname != use_fname:
+        assert split_naming == 'bids'
+        logger.info(f'Renaming BIDS split file {op.basename(final_fname)}')
+        ctx.remove = False
+        shutil.move(use_fname, final_fname)
+    if part_idx == 0:
+        logger.info('[done]')
+    return final_fname, part_idx
 
+
+class _ReservedFilename:
+
+    def __init__(self, fname):
+        self.fname = fname
+        assert op.isdir(op.dirname(fname)), fname
+        with open(fname, 'w'):
+            pass
+        self.remove = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.remove:
+            os.remove(self.fname)
+
+
+def _write_raw_fid(raw, info, picks, fid, cals, part_idx, start, stop,
+                   buffer_size, prev_fname, split_size, use_fname,
+                   projector, drop_small_buffer, fmt, fname, reserved_fname,
+                   data_type, reset_range, split_naming, overwrite):
     first_samp = raw.first_samp + start
     if first_samp != 0:
         write_int(fid, FIFF.FIFF_FIRST_SAMPLE, first_samp)
@@ -1894,7 +1932,6 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
 
     pos_prev = fid.tell()
     if pos_prev > split_size:
-        fid.close()
         raise ValueError('file is larger than "split_size" after writing '
                          'measurement information, you must use a larger '
                          'value for split size: %s plus enough bytes for '
@@ -1952,7 +1989,6 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
         if overage > 0:
             # This should occur on the first buffer write of the file, so
             # we should mention the space required for the meas info
-            fid.close()
             raise ValueError(
                 'buffer size (%s) is too large for the given split size (%s) '
                 'by %s bytes after writing info (%s) and leaving enough space '
@@ -1989,14 +2025,7 @@ def _write_raw(fname, raw, info, picks, fmt, data_type, reset_range, start,
         end_block(fid, FIFF.FIFFB_RAW_DATA)
     end_block(fid, FIFF.FIFFB_MEAS)
     end_file(fid)
-    if final_fname != use_fname:
-        logger.info(f'Renaming BIDS split file {op.basename(final_fname)}')
-        shutil.move(use_fname, final_fname)
-    elif reserved_fname != use_fname:
-        os.remove(reserved_fname)
-    if part_idx == 0:
-        logger.info('[done]')
-    return final_fname, part_idx
+    return final_fname
 
 
 def _start_writing_raw(name, info, sel, data_type,

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -300,7 +300,9 @@ def _construct_bids_filename(base, ext, part_idx):
     """Construct a BIDS compatible filename for split files."""
     # insert index in filename
     deconstructed_base = base.split('_')
-    assert len(deconstructed_base) > 1
+    if len(deconstructed_base) < 2:
+        raise ValueError('Filename base must end with an underscore followed '
+                         f'by the modality (e.g., _eeg or _meg), got {base}')
     modality = deconstructed_base[-1]
     base = '_'.join(deconstructed_base[:-1])
     use_fname = '{}_split-{:02}_{}{}'.format(base, part_idx, modality, ext)

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -300,12 +300,8 @@ def _construct_bids_filename(base, ext, part_idx):
     """Construct a BIDS compatible filename for split files."""
     # insert index in filename
     deconstructed_base = base.split('_')
-    bids_supported = ['meg', 'eeg', 'ieeg']
-    for mod in bids_supported:
-        if mod in deconstructed_base:
-            idx = deconstructed_base.index(mod)
-            modality = deconstructed_base.pop(idx)
-    base = '_'.join(deconstructed_base)
+    assert len(deconstructed_base) > 1
+    modality = deconstructed_base[-1]
+    base = '_'.join(deconstructed_base[:-1])
     use_fname = '{}_split-{:02}_{}{}'.format(base, part_idx, modality, ext)
-
     return use_fname

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -12,6 +12,7 @@
 
 import numpy as np
 import os
+import os.path as op
 
 from .constants import FIFF
 from .meas_info import _get_valid_units
@@ -299,6 +300,8 @@ def _synthesize_stim_channel(events, n_samples):
 def _construct_bids_filename(base, ext, part_idx):
     """Construct a BIDS compatible filename for split files."""
     # insert index in filename
+    dirname = op.dirname(base)
+    base = op.basename(base)
     deconstructed_base = base.split('_')
     if len(deconstructed_base) < 2:
         raise ValueError('Filename base must end with an underscore followed '
@@ -306,4 +309,6 @@ def _construct_bids_filename(base, ext, part_idx):
     modality = deconstructed_base[-1]
     base = '_'.join(deconstructed_base[:-1])
     use_fname = '{}_split-{:02}_{}{}'.format(base, part_idx, modality, ext)
+    if dirname:
+        use_fname = op.join(dirname, use_fname)
     return use_fname


### PR DESCRIPTION
following issues in mne study template as we write files called

_split-01_raw.fif 

in the derivatives folder.