### PR TITLE
MNT: Pin pyvista

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - mne
   - imageio-ffmpeg>=0.4.1
   - vtk>=9.0.1
-  - pyvista>=0.24
+  - pyvista>=0.24,<0.27
   - pyvistaqt>=0.2.0
   - mayavi
   - PySurfer[save_movie]

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,6 @@ nilearn
 xlrd
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1
-pyvista>=0.24
+pyvista>=0.24,<0.27
 pyvistaqt>=0.2.0
 tqdm


### PR DESCRIPTION
PyVista released `0.27.0` recently and some adjustments seem necessary to fix:

```
mne/tests/test_report.py::test_render_add_sections[pyvista] Traceback (most recent call last):

  File "/home/travis/virtualenv/python3.8.1/lib/python3.8/site-packages/pyvistaqt/plotting.py", line 699, in _close

    super().close()

  File "/home/travis/virtualenv/python3.8.1/lib/python3.8/site-packages/pyvistaqt/plotting.py", line 476, in close

    BasePlotter.close(self)

  File "/home/travis/virtualenv/python3.8.1/lib/python3.8/site-packages/pyvista/plotting/plotting.py", line 2739, in close

    if self.iren is not None:

  File "/home/travis/virtualenv/python3.8.1/lib/python3.8/site-packages/vtkmodules/qt/QVTKRenderWindowInteractor.py", line 335, in __getattr__

    raise AttributeError(self.__class__.__name__ +

AttributeError: BackgroundPlotter has no attribute named iren
```

While I work on a fix, I suggest pinning PyVista to a previous version.

