### PR TITLE
[DOC] add link to resampling FAQ to all resampling methods

### DIFF
--- a/doc/overview/faq.rst
+++ b/doc/overview/faq.rst
@@ -221,6 +221,8 @@ whether to use :func:`mne.read_cov`, :func:`mne.read_epochs`,
     events
 
 
+.. _resampling-and-decimating:
+
 Resampling and decimating data
 ==============================
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1727,7 +1727,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         in the two sets of epochs. For example, if one had event times
         [1, 2, 3, 4, 120, 121] and the other one had [3.5, 4.5, 120.5, 121.5],
         it would remove events at times [1, 2] in the first epochs and not
-        [20, 21].
+        [120, 121].
 
         Parameters
         ----------

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -2018,6 +2018,9 @@ class FilterMixin(object):
                  pad='edge', verbose=None):  # lgtm
         """Resample data.
 
+        If appropriate, an anti-aliasing filter is applied before resampling.
+        See :ref:`resampling-and-decimating` for more information.
+
         .. note:: Data must be loaded.
 
         Parameters

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -2018,7 +2018,9 @@ class FilterMixin(object):
                  pad='edge', verbose=None):  # lgtm
         """Resample data.
 
-        If appropriate, an anti-aliasing filter is applied before resampling.
+        Through use of an FFT-based (fast Fourier transform) method for
+        resampling, aliasing artifacts are prevented as if an anti-aliasing
+        filter were applied beforehand.
         See :ref:`resampling-and-decimating` for more information.
 
         .. note:: Data must be loaded.

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -2018,9 +2018,7 @@ class FilterMixin(object):
                  pad='edge', verbose=None):  # lgtm
         """Resample data.
 
-        Through use of an FFT-based (fast Fourier transform) method for
-        resampling, aliasing artifacts are prevented as if an anti-aliasing
-        filter were applied beforehand.
+        If appropriate, an anti-aliasing filter is applied before resampling.
         See :ref:`resampling-and-decimating` for more information.
 
         .. note:: Data must be loaded.

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1058,9 +1058,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                  verbose=None):  # lgtm
         """Resample all channels.
 
-        Through use of an FFT-based (fast Fourier transform) method for
-        resampling, aliasing artifacts are prevented as if an anti-aliasing
-        filter were applied beforehand.
+        If appropriate, an anti-aliasing filter is applied before resampling.
         See :ref:`resampling-and-decimating` for more information.
 
         .. warning:: The intended purpose of this function is primarily to

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1058,7 +1058,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                  verbose=None):  # lgtm
         """Resample all channels.
 
-        If appropriate, an anti-aliasing filter is applied before resampling.
+        Through use of an FFT-based (fast Fourier transform) method for
+        resampling, aliasing artifacts are prevented as if an anti-aliasing
+        filter were applied beforehand.
         See :ref:`resampling-and-decimating` for more information.
 
         .. warning:: The intended purpose of this function is primarily to

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1058,6 +1058,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                  verbose=None):  # lgtm
         """Resample all channels.
 
+        If appropriate, an anti-aliasing filter is applied before resampling.
+        See :ref:`resampling-and-decimating` for more information.
+
         .. warning:: The intended purpose of this function is primarily to
                      speed up computations (e.g., projection calculation) when
                      precise timing of events is not required, as downsampling

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -712,7 +712,9 @@ class _BaseSourceEstimate(TimeMixin):
                  verbose=None):
         """Resample data.
 
-        If appropriate, an anti-aliasing filter is applied before resampling.
+        Through use of an FFT-based (fast Fourier transform) method for
+        resampling, aliasing artifacts are prevented as if an anti-aliasing
+        filter were applied beforehand.
         See :ref:`resampling-and-decimating` for more information.
 
         Parameters

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -712,6 +712,9 @@ class _BaseSourceEstimate(TimeMixin):
                  verbose=None):
         """Resample data.
 
+        If appropriate, an anti-aliasing filter is applied before resampling.
+        See :ref:`resampling-and-decimating` for more information.
+
         Parameters
         ----------
         sfreq : float

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -712,9 +712,7 @@ class _BaseSourceEstimate(TimeMixin):
                  verbose=None):
         """Resample data.
 
-        Through use of an FFT-based (fast Fourier transform) method for
-        resampling, aliasing artifacts are prevented as if an anti-aliasing
-        filter were applied beforehand.
+        If appropriate, an anti-aliasing filter is applied before resampling.
         See :ref:`resampling-and-decimating` for more information.
 
         Parameters


### PR DESCRIPTION
Came up in Gitter: [November 9, 2020 6:40 PM](https://gitter.im/mne-tools/mne-python?at=5fa97f0fd37a1a13d6975c37)

(@cbrnr feel free to push to this branch if you want to make this PR bigger in scope.)

For "resampling", MNE automatically applies anti-alias filters where appropriate. This small doc addition will clarify the situation for many users.

I was unsure about it personally, and tried looking into the source code ... but even from there it's not immediately obvious that anti-alias filtering is done. It seems to me like most of the magic is happening here:

I am still not sure that the filtering is truly done - but it may happen in the frequency domain code somehow.

https://github.com/mne-tools/mne-python/blob/bb16a3e6ea99024e468fa84c2ec55c344b47df7e/mne/cuda.py#L291-L340

