### PR TITLE
MRG, MAINT: Refactor volume interpolation code

### DIFF
--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -2302,109 +2302,140 @@ def _add_interpolator(sp):
     # Convert MRI voxels from destination (MRI volume) to source (volume
     # source space subset) coordinates
     #
-    vol_dims = s['vol_dims']
     combo_trans = combine_transforms(s['vox_mri_t'],
                                      invert_transform(s['src_mri_t']),
                                      'mri_voxel', 'mri_voxel')
-    del s
-    combo_trans['trans'] = combo_trans['trans'].astype(np.float32)
 
     logger.info('Setting up volume interpolation ...')
+    interp = _grid_interp(s['vol_dims'], (mri_width, mri_height, mri_depth),
+                          combo_trans['trans'])
+
+    # Compose the sparse matrices
+    for si, s in enumerate(sp):
+        # limit it columns that have any contribution from inuse
+        any_ = sparse.diags(
+            np.asarray(
+                interp[:, s['inuse'].astype(bool)].sum(1)
+            )[:, 0].astype(bool).astype(float)
+        )
+        s['interpolator'] = any_ * interp
+        logger.info('    %d/%d nonzero values for %s'
+                    % (len(s['interpolator'].data), nvox, s['seg_name']))
+    logger.info('[done]')
+
+
+def _grid_interp(from_shape, to_shape, trans, order=1):
+    """Compute a grid-to-grid linear or nearest interpolation given."""
+    from_shape = np.array(from_shape, int)
+    to_shape = np.array(to_shape, int)
+    trans = np.array(trans, np.float64)  # to -> from
+    assert trans.shape == (4, 4) and np.array_equal(trans[3], [0, 0, 0, 1])
+    assert from_shape.shape == to_shape.shape == (3,)
+    shape = (np.prod(to_shape), np.prod(from_shape))
+    data, indices, indptr = _grid_interp_jit(
+        from_shape, to_shape, trans, order)
+    data = np.concatenate(data)
+    indices = np.concatenate(indices)
+    indptr = np.cumsum(indptr)
+    interp = sparse.csr_matrix((data, indices, indptr), shape=shape)
+    return interp
+
+
+# This is all set up to do jit, but it's actually slower!
+def _grid_interp_jit(from_shape, to_shape, trans, order):
     # Loop over slices to save (lots of) memory
     # Note that it is the slowest incrementing index
     # This is equivalent to using mgrid and reshaping, but faster
-    datas = [list() for _ in range(len(sp))]
-    indicess = [list() for _ in range(len(sp))]
-    indptrs = [np.zeros(nvox + 1, np.int32) for _ in range(len(sp))]
+    assert order in (0, 1)
+    data = list()
+    indices = list()
+    nvox = np.prod(to_shape)
+    indptr = np.zeros(nvox + 1, np.int32)
+    mri_width, mri_height, mri_depth = to_shape
+    r0__ = np.empty((4, mri_height, mri_width), np.float64)
+    r0__[0, :, :] = np.arange(mri_width)
+    r0__[1, :, :] = np.arange(mri_height).reshape(1, mri_height, 1)
+    r0__[3, :, :] = 1
+    r0_ = np.reshape(r0__, (4, mri_width * mri_height))
+    width, height, _ = from_shape
+    trans = np.ascontiguousarray(trans)
+    maxs = (from_shape - 1).reshape(1, 3)
     for p in range(mri_depth):
-        js = np.arange(mri_width, dtype=np.float32)
-        js = np.tile(js[np.newaxis, :],
-                     (mri_height, 1)).ravel()
-        ks = np.arange(mri_height, dtype=np.float32)
-        ks = np.tile(ks[:, np.newaxis],
-                     (1, mri_width)).ravel()
-        ps = np.empty((mri_height, mri_width), np.float32).ravel()
-        ps.fill(p)
-        r0 = np.c_[js, ks, ps]
-        del js, ks, ps
+        r0_[2] = p
 
         # Transform our vertices from their MRI space into our source space's
         # frame (this is labeled as FIFFV_MNE_COORD_MRI_VOXEL, but it's
         # really a subset of the entire volume!)
-        r0 = apply_trans(combo_trans['trans'], r0)
-        rn = np.floor(r0).astype(int)
-        maxs = (vol_dims - 1)[np.newaxis, :]
-        good = np.where(np.logical_and(np.all(rn >= 0, axis=1),
-                                       np.all(rn < maxs, axis=1)))[0]
-        good.flags['WRITEABLE'] = False
+        r0 = (trans @ r0_)[:3].T
+        if order == 0:
+            rx = np.round(r0).astype(np.int32)
+            keep = np.where(np.logical_and(np.all(rx >= 0, axis=1),
+                                           np.all(rx <= maxs, axis=1)))[0]
+            indptr[keep + p * mri_height * mri_width + 1] = 1
+            indices.append(_vol_vertex(width, height, *rx[keep].T))
+            data.append(np.ones(len(keep)))
+            continue
+        rn = np.floor(r0).astype(np.int32)
+        good = np.where(np.logical_and(np.all(rn >= -1, axis=1),
+                                       np.all(rn <= maxs, axis=1)))[0]
+        if len(good) == 0:
+            continue
         rns = rn[good]
         r0s = r0[good]
-        del rn, r0
+        jj_g, kk_g, pp_g = (rns >= 0).T
+        jjp1_g, kkp1_g, ppp1_g = (rns < maxs).T  # same as rns + 1 <= maxs
 
         # now we take each MRI voxel *in this space*, and figure out how
         # to make its value the weighted sum of voxels in the volume source
-        # space. This is a 3D weighting scheme based (presumably) on the
+        # space. This is a trilinear interpolation based on the
         # fact that we know we're interpolating from one volumetric grid
         # into another.
         jj = rns[:, 0]
         kk = rns[:, 1]
         pp = rns[:, 2]
         vss = np.empty((len(jj), 8), np.int32)
-        width = vol_dims[0]
-        height = vol_dims[1]
         jjp1 = jj + 1
         kkp1 = kk + 1
         ppp1 = pp + 1
+        mask = np.empty((len(jj), 8), bool)
         vss[:, 0] = _vol_vertex(width, height, jj, kk, pp)
+        mask[:, 0] = jj_g & kk_g & pp_g
         vss[:, 1] = _vol_vertex(width, height, jjp1, kk, pp)
+        mask[:, 1] = jjp1_g & kk_g & pp_g
         vss[:, 2] = _vol_vertex(width, height, jjp1, kkp1, pp)
+        mask[:, 2] = jjp1_g & kkp1_g & pp_g
         vss[:, 3] = _vol_vertex(width, height, jj, kkp1, pp)
+        mask[:, 3] = jj_g & kkp1_g & pp_g
         vss[:, 4] = _vol_vertex(width, height, jj, kk, ppp1)
+        mask[:, 4] = jj_g & kk_g & ppp1_g
         vss[:, 5] = _vol_vertex(width, height, jjp1, kk, ppp1)
+        mask[:, 5] = jjp1_g & kk_g & ppp1_g
         vss[:, 6] = _vol_vertex(width, height, jjp1, kkp1, ppp1)
+        mask[:, 6] = jjp1_g & kkp1_g & ppp1_g
         vss[:, 7] = _vol_vertex(width, height, jj, kkp1, ppp1)
-        vss.flags['WRITEABLE'] = False
-        del jj, kk, pp, jjp1, kkp1, ppp1
-        for si, s in enumerate(sp):
-            uses = np.any(s['inuse'][vss], axis=1)
-            if uses.size == 0:
-                continue
-            # vertex (col) numbers in csr matrix
-            indicess[si].append(vss[uses].ravel())
-            indptrs[si][good[uses] + p * mri_height * mri_width + 1] = 8
+        mask[:, 7] = jj_g & kkp1_g & ppp1_g
+        indices.append(vss[mask])
+        indptr[good + p * mri_height * mri_width + 1] = mask.sum(1)
 
-            # figure out weights for each vertex
-            r0 = r0s[uses]
-            rn = rns[uses]
-            del uses
-            xf = r0[:, 0] - rn[:, 0].astype(np.float32)
-            yf = r0[:, 1] - rn[:, 1].astype(np.float32)
-            zf = r0[:, 2] - rn[:, 2].astype(np.float32)
-            omxf = 1.0 - xf
-            omyf = 1.0 - yf
-            omzf = 1.0 - zf
-            # each entry in the concatenation corresponds to a row of vss
-            datas[si].append(
-                np.array([omxf * omyf * omzf,
-                          xf * omyf * omzf,
-                          xf * yf * omzf,
-                          omxf * yf * omzf,
-                          omxf * omyf * zf,
-                          xf * omyf * zf,
-                          xf * yf * zf,
-                          omxf * yf * zf], order='F').T.ravel())
-            del r0, rn, xf, yf, zf, omxf, omyf, omzf
+        # figure out weights for each vertex
+        xf = r0s[:, 0] - rns[:, 0].astype(np.float64)
+        yf = r0s[:, 1] - rns[:, 1].astype(np.float64)
+        zf = r0s[:, 2] - rns[:, 2].astype(np.float64)
+        omxf = 1.0 - xf
+        omyf = 1.0 - yf
+        omzf = 1.0 - zf
 
-    # Compose the sparse matrices
-    for si, s in enumerate(sp):
-        indptr = np.cumsum(indptrs[si], out=indptrs[si])
-        indices = np.concatenate(indicess[si])
-        data = np.concatenate(datas[si])
-        s['interpolator'] = sparse.csr_matrix((data, indices, indptr),
-                                              shape=(nvox, s['np']))
-        logger.info('    %d/%d nonzero values for %s'
-                    % (len(data), nvox, s['seg_name']))
-    logger.info('[done]')
+        this_w = np.empty((len(good), 8), np.float64)
+        this_w[:, 0] = omxf * omyf * omzf
+        this_w[:, 1] = xf * omyf * omzf
+        this_w[:, 2] = xf * yf * omzf
+        this_w[:, 3] = omxf * yf * omzf
+        this_w[:, 4] = omxf * omyf * zf
+        this_w[:, 5] = xf * omyf * zf
+        this_w[:, 6] = xf * yf * zf
+        this_w[:, 7] = omxf * yf * zf
+        data.append(this_w[mask])
+    return data, indices, indptr
 
 
 def _pts_in_hull(pts, hull, tolerance=1e-12):
@@ -3003,7 +3034,7 @@ def _compare_source_spaces(src0, src1, mode='exact', nearest=True,
     Note: this function is also used by forward/tests/test_make_forward.py
     """
     from numpy.testing import (assert_allclose, assert_array_equal,
-                               assert_equal, assert_)
+                               assert_equal, assert_, assert_array_less)
     from scipy.spatial.distance import cdist
     if mode != 'exact' and 'approx' not in mode:  # 'nointerp' can be appended
         raise RuntimeError('unknown mode %s' % mode)
@@ -3026,8 +3057,9 @@ def _compare_source_spaces(src0, src1, mode='exact', nearest=True,
                 assert name in s1, f'{name} in s1 but not s0'
                 diffs = (s0['interpolator'] - s1['interpolator']).data
                 if len(diffs) > 0 and 'nointerp' not in mode:
-                    # 5%
-                    assert_(np.sqrt(np.mean(diffs ** 2)) < 0.10, name)
+                    # 10%
+                    assert_array_less(
+                        np.sqrt(np.mean(diffs ** 2)), 0.10, err_msg=name)
         for name in ['nn', 'rr', 'nuse_tri', 'coord_frame', 'tris']:
             if s0[name] is None:
                 assert_(s1[name] is None, name)

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -2318,7 +2318,7 @@ def _add_interpolator(sp):
                 interp[:, s['inuse'].astype(bool)].sum(1)
             )[:, 0].astype(bool).astype(float)
         )
-        s['interpolator'] = any_ * interp
+        s['interpolator'] = any_ @ interp
         logger.info('    %d/%d nonzero values for %s'
                     % (len(s['interpolator'].data), nvox, s['seg_name']))
     logger.info('[done]')


### PR DESCRIPTION
I am still annoyed by how slow the volumetric morphing is, so I decided to see if I could alleviate one bottleneck, namely the linear and zero-order interpolations. I never 100% understood Matti's volume interpolation code I adapted so many years ago, but based on how it works it should definitely be faster when we have lots of volumes to morph. Whether it's already the same speed as dipy and nibabel (scipy.ndimage) or faster with 1, 10, 100, or 1000 volumes remains to be determined, but I wouldn't be surprised if it were about the same speed with even just 1. It definitely will be with 1000.

In any case, to move toward being able to use the sparse matrix code I:

1. Refactored our `_add_interpolator` code to do a generic grid-to-grid interpolation
2. Added tests showing equivalences between `nibabel`, `dipy`, and our code for linear and nearest interpolation (it's a ton of combos but it takes only 0.3 sec on my machine)
3. Made the code `jit`-able but it didn't actually speed it up (thanks, vectorization!)
4. Fixed some minor bugs with our treatment of edge/border volume vertices in `_add_interpolator` (exposed by the nibabel/dipy equivalency tests), where some vertices could be interpolated to by a subset of the 8 possible vertices (e.g., 4 or 2 or even 1 of them) but it only added the interpolation if all could.

This should allow me to then speed up `SourceMorph._morph_vols`, but I'll do that in a subsequent PR. Even if it does not speed things up, this is already a nice refactoring + unit testing of our code.