### PR TITLE
Don't treat IPython warning as error (fixes debugging in PyCharm)

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -62,6 +62,7 @@ def pytest_configure(config):
     #   doc/conf.py.
     warning_lines = r"""
     error::
+    ignore:.*deprecated and ignored since IPython.*:DeprecationWarning
     ignore::ImportWarning
     ignore:the matrix subclass:PendingDeprecationWarning
     ignore:numpy.dtype size changed:RuntimeWarning


### PR DESCRIPTION
Fixes #8523.