### PR TITLE
[FIX] some post-merge fixes for SSD

### DIFF
--- a/examples/decoding/plot_ssd_spatial_filters.py
+++ b/examples/decoding/plot_ssd_spatial_filters.py
@@ -39,7 +39,7 @@ freqs_noise = 8, 13
 
 ssd = SSD(info=raw.info,
           reg='oas',
-          sort_by_spectral_ratio=False,  # False for purpose of exmple.
+          sort_by_spectral_ratio=False,  # False for purpose of example.
           filt_params_signal=dict(l_freq=freqs_sig[0], h_freq=freqs_sig[1],
                                   l_trans_bandwidth=1, h_trans_bandwidth=1),
           filt_params_noise=dict(l_freq=freqs_noise[0], h_freq=freqs_noise[1],
@@ -68,7 +68,7 @@ psd, freqs = mne.time_frequency.psd_array_welch(
     ssd_sources, sfreq=raw.info['sfreq'], n_fft=4096)
 
 # Get spec_ratio information (already sorted).
-# Note that this is not necessay if sort_by_spectral_ratio=True (default).
+# Note that this is not necessary if sort_by_spectral_ratio=True (default).
 spec_ratio, sorter = ssd.get_spectral_ratio(ssd_sources)
 
 # Plot spectral ratio (see Eq. 24 in Nikulin 2011).

--- a/examples/decoding/plot_ssd_spatial_filters.py
+++ b/examples/decoding/plot_ssd_spatial_filters.py
@@ -1,6 +1,6 @@
 """
 ===========================================================
-Compute Sepctro-Spatial Decomposition (SDD) spatial filters
+Compute Sepctro-Spatial Decomposition (SSD) spatial filters
 ===========================================================
 
 In this example, we will compute spatial filters for retaining
@@ -39,7 +39,7 @@ freqs_noise = 8, 13
 
 ssd = SSD(info=raw.info,
           reg='oas',
-          sort_by_spectral_ratio=False,  # True is recommended here.
+          sort_by_spectral_ratio=False,  # False for purpose of exmple.
           filt_params_signal=dict(l_freq=freqs_sig[0], h_freq=freqs_sig[1],
                                   l_trans_bandwidth=1, h_trans_bandwidth=1),
           filt_params_noise=dict(l_freq=freqs_noise[0], h_freq=freqs_noise[1],
@@ -68,6 +68,7 @@ psd, freqs = mne.time_frequency.psd_array_welch(
     ssd_sources, sfreq=raw.info['sfreq'], n_fft=4096)
 
 # Get spec_ratio information (already sorted).
+# Note that this is not necessay if sort_by_spectral_ratio=True (default).
 spec_ratio, sorter = ssd.get_spectral_ratio(ssd_sources)
 
 # Plot spectral ratio (see Eq. 24 in Nikulin 2011).

--- a/mne/decoding/ssd.py
+++ b/mne/decoding/ssd.py
@@ -42,8 +42,7 @@ class SSD(BaseEstimator, TransformerMixin):
         method to :func:`mne.compute_covariance`.
     n_components : int | None (default None)
         The number of components to extract from the signal.
-        If n_components is None, no dimensionality reduction is applied, and
-        the transformed data is projected in the whole source space.
+        If n_components is None, no dimensionality reduction is applied.
     picks : array of int | None (default None)
         The indices of good channels.
     sort_by_spectral_ratio : bool (default False)
@@ -54,7 +53,7 @@ class SSD(BaseEstimator, TransformerMixin):
         If return_filtered is True, data is bandpassed and projected onto
         the SSD components.
     n_fft : int (default None)
-       If sort_by_spectral_ratio is set to True, then the sources will be
+       If sort_by_spectral_ratio is set to True, then the SSD sources will be
        sorted accordingly to their spectral ratio which is calculated based on
        :func:`mne.time_frequency.psd_array_welch` function. The n_fft parameter
        set the length of FFT used.
@@ -223,7 +222,7 @@ class SSD(BaseEstimator, TransformerMixin):
         Parameters
         ----------
         ssd_sources : array
-            Data proyected on source space.
+            Data projectded to SSD space.
 
         Returns
         -------

--- a/mne/decoding/ssd.py
+++ b/mne/decoding/ssd.py
@@ -71,9 +71,9 @@ class SSD(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    filters_ : array, shape(n_channels, n_components)
+    filters_ : array, shape (n_channels, n_components)
         The spatial filters to be multiplied with the signal.
-    patterns_ : array, shape(n_components, n_channels)
+    patterns_ : array, shape (n_components, n_channels)
         The patterns for reconstructing the signal from the filtered data.
 
     References
@@ -182,7 +182,7 @@ class SSD(BaseEstimator, TransformerMixin):
 
         return self
 
-    def transform(self, X, y=None):
+    def transform(self, X):
         """Estimate epochs sources given the SSD filters.
 
         Parameters
@@ -191,8 +191,6 @@ class SSD(BaseEstimator, TransformerMixin):
             The input data from which to estimate the SSD. Either 2D array
             obtained from continuous data or 3D array obtained from epoched
             data.
-        y : None | array, shape (n_samples,)
-            Used for scikit-learn compatibility.
 
         Returns
         -------
@@ -253,12 +251,11 @@ class SSD(BaseEstimator, TransformerMixin):
         sorter_spec = spec_ratio.argsort()[::-1]
         return spec_ratio, sorter_spec
 
-    def apply(self):
-        """Not implemented, see ssd.inverse_transform() instead."""
-        # Exists because of _XdawnTransformer
-        raise NotImplementedError('See ssd.inverse_transform()')
+    def inverse_transform(self):
+        """Not implemented yet."""
+        raise NotImplementedError('inverse_transform is not yet available.')
 
-    def inverse_transform(self, X):
+    def apply_array(self, X):
         """Remove selected components from the signal.
 
         This procedure will reconstruct M/EEG signals from which the dynamics

--- a/mne/decoding/ssd.py
+++ b/mne/decoding/ssd.py
@@ -262,9 +262,8 @@ class SSD(BaseEstimator, TransformerMixin):
         (denoised by low-rank factorization).
         See :footcite:`HaufeEtAl2014b` for more information.
 
-        .. note:: Only NumPy arrays are supported
-           At this point, unlike in other classes with an apply method,
-           only NumPy arrays are supported but not instances of MNE objects.
+        .. note:: Unlike in other classes with an apply method,
+           only NumPy arrays are supported (not instances of MNE objects).
 
         Parameters
         ----------

--- a/mne/decoding/ssd.py
+++ b/mne/decoding/ssd.py
@@ -255,13 +255,17 @@ class SSD(BaseEstimator, TransformerMixin):
         """Not implemented yet."""
         raise NotImplementedError('inverse_transform is not yet available.')
 
-    def apply_array(self, X):
+    def apply(self, X):
         """Remove selected components from the signal.
 
         This procedure will reconstruct M/EEG signals from which the dynamics
         described by the excluded components is subtracted
         (denoised by low-rank factorization).
         See :footcite:`HaufeEtAl2014b` for more information.
+
+        .. note:: Only NumPy arrays are supported
+           At this point, unlike in other classes with an apply method,
+           only NumPy arrays are supported but not instances of MNE objects.
 
         Parameters
         ----------

--- a/mne/decoding/tests/test_ssd.py
+++ b/mne/decoding/tests/test_ssd.py
@@ -25,19 +25,19 @@ def simulate_data(freqs_sig=[9, 12], n_trials=100, n_channels=20,
     Data are simulated in the statistical source space, where n=n_components
     sources contain the peak of interest.
     """
-    rs = np.random.RandomState(random_state)
+    rng = np.random.RandomState(random_state)
 
     filt_params_signal = dict(l_freq=freqs_sig[0], h_freq=freqs_sig[1],
                               l_trans_bandwidth=1, h_trans_bandwidth=1,
                               fir_design='firwin')
 
     # generate an orthogonal mixin matrix
-    mixing_mat = np.linalg.svd(rs.randn(n_channels, n_channels))[0]
+    mixing_mat = np.linalg.svd(rng.randn(n_channels, n_channels))[0]
     # define sources
-    S_s = rs.randn(n_trials * n_samples, n_components)
+    S_s = rng.randn(n_trials * n_samples, n_components)
     # filter source in the specific freq. band of interest
     S_s = filter_data(S_s.T, samples_per_second, **filt_params_signal).T
-    S_n = rs.randn(n_trials * n_samples, n_channels - n_components)
+    S_n = rng.randn(n_trials * n_samples, n_channels - n_components)
     S = np.hstack((S_s, S_n))
     # mix data
     X_s = np.dot(mixing_mat[:, :n_components], S_s.T).T
@@ -133,7 +133,7 @@ def test_ssd():
     ssd = SSD(info, filt_params_signal, filt_params_noise,
               n_components=None, sort_by_spectral_ratio=False)
     ssd.fit(X)
-    X_denoised = ssd.inverse_transform(X)
+    X_denoised = ssd.apply_array(X)
     assert_array_almost_equal(X_denoised, X)
 
     # Power ratio ordering

--- a/mne/decoding/tests/test_ssd.py
+++ b/mne/decoding/tests/test_ssd.py
@@ -133,7 +133,7 @@ def test_ssd():
     ssd = SSD(info, filt_params_signal, filt_params_noise,
               n_components=None, sort_by_spectral_ratio=False)
     ssd.fit(X)
-    X_denoised = ssd.apply_array(X)
+    X_denoised = ssd.apply(X)
     assert_array_almost_equal(X_denoised, X)
 
     # Power ratio ordering


### PR DESCRIPTION
This PR implements a few post-merge fixes to #7070 for issues pointed out by @agramfort [cc @vpeterson]

@agramfort I put inverse_transform -> NotImplemented and propose to call it ``apply_array`` as this API works with arrays, not instances. I will personally do not have the bandwidth to implement a proper ``apply`` as far more handling of channels types will be needed. Note that CSP has got no ``apply`` method and XDawn's apply is like ICA in supporting instances.

Perhaps @vpeterson wants look into extensions in the future. For now I suggest let's focus on what necessarily has to be fixed.