### PR TITLE
MRG, ENH: Speed up morphing

### DIFF
--- a/examples/inverse/plot_morph_volume_stc.py
+++ b/examples/inverse/plot_morph_volume_stc.py
@@ -7,7 +7,7 @@ Morph volumetric source estimate
 
 This example demonstrates how to morph an individual subject's
 :class:`mne.VolSourceEstimate` to a common reference space. We achieve this
-using :class:`mne.SourceMorph`. Pre-computed data will be morphed based on
+using :class:`mne.SourceMorph`. Data will be morphed based on
 an affine transformation and a nonlinear registration method
 known as Symmetric Diffeomorphic Registration (SDR) by
 :footcite:`AvantsEtAl2008`.

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -534,7 +534,6 @@ class SourceMorph(object):
         resamp_0 = _grid_interp(
             src_shape, self.pre_affine.codomain_shape,
             linalg.inv(from_affine) @ self.pre_affine.codomain_grid2world)
-        assert self.pre_affine.domain_shape == self.pre_affine.codomain_shape
         # reslice to match what was used during the morph
         # (brain.mgz and whatever was used to create the source space
         #  will not necessarily have the same domain/zooms)

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -8,14 +8,14 @@ import os.path as op
 import warnings
 import copy
 import numpy as np
-from scipy import sparse
+from scipy import sparse, linalg
 
 from .fixes import _get_img_fdata
 from .parallel import parallel_func
 from .source_estimate import (
     _BaseSurfaceSourceEstimate, _BaseVolSourceEstimate, _BaseSourceEstimate,
     _get_ico_tris)
-from .source_space import SourceSpaces, _ensure_src
+from .source_space import SourceSpaces, _ensure_src, _grid_interp
 from .surface import read_morph_map, mesh_edges, read_surface, _compute_nearest
 from .transforms import _angle_between_quats, rot_to_quat
 from .utils import (logger, verbose, check_version, get_subjects_dir,
@@ -522,32 +522,45 @@ class SourceMorph(object):
         else:
             vol_verts = slice(None)
         # morph data
+        from_affine = np.dot(
+            self.src_data['src_affine_ras'],  # mri_ras_t
+            self.src_data['src_affine_vox'])  # vox_mri_t
+        from_affine[:3] *= 1000.
+        # equivalent of:
+        # _resample_from_to(img_real, from_affine,
+        #                   (self.pre_affine.codomain_shape,
+        #                   (self.pre_affine.codomain_grid2world))
+        src_shape = self.src_data['src_shape_full'][::-1]
+        resamp_0 = _grid_interp(
+            src_shape, self.pre_affine.codomain_shape,
+            linalg.inv(from_affine) @ self.pre_affine.codomain_grid2world)
+        assert self.pre_affine.domain_shape == self.pre_affine.codomain_shape
+        # reslice to match what was used during the morph
+        # (brain.mgz and whatever was used to create the source space
+        #  will not necessarily have the same domain/zooms)
+        # equivalent of:
+        # pre_affine.transform(img_real)
+        resamp_1 = _grid_interp(
+            self.pre_affine.codomain_shape, self.pre_affine.domain_shape,
+            linalg.inv(self.pre_affine.codomain_grid2world) @
+            self.pre_affine.affine @
+            self.pre_affine.domain_grid2world)
+        resamp_0_1 = resamp_1 @ resamp_0
+        resamp_2 = None
         for ii in ProgressBar(list(range(n_vols)), mesg=mesg):
             for attr in attrs:
                 # transform from source space to mri_from resolution/space
                 if vols is None:
-                    img_real = interp[:, ii].toarray()
+                    img_real = interp[:, ii]
                 else:
                     img_real = interp @ getattr(vols[:, ii], attr)
+                _debug_img(img_real, from_affine, 'From', src_shape)
+
+                img_real = resamp_0_1 @ img_real
+                if sparse.issparse(img_real):
+                    img_real = img_real.toarray()
                 img_real = img_real.reshape(
-                    self.src_data['src_shape_full'][::-1], order='F')
-                from_affine = np.dot(
-                    self.src_data['src_affine_ras'],  # mri_ras_t
-                    self.src_data['src_affine_vox'])  # vox_mri_t
-                from_affine[:3] *= 1000.
-                _debug_img(img_real, from_affine, 'From')
-
-                # reslice to match what was used during the morph
-                # (brain.mgz and whatever was used to create the source space
-                #  will not necessarily have the same domain/zooms)
-                img_real = _resample_from_to(
-                    img_real, from_affine,
-                    (self.pre_affine.codomain_shape,
-                     self.pre_affine.codomain_grid2world))
-                _debug_img(img_real, self.pre_affine.codomain_grid2world,
-                           'From-reslice')
-
-                img_real = self.pre_affine.transform(img_real)
+                    self.pre_affine.domain_shape, order='F')
                 if self.sdr_morph is not None:
                     img_real = self.sdr_morph.transform(img_real)
                 _debug_img(img_real, self.affine, 'From-reslice-transform')
@@ -556,15 +569,25 @@ class SourceMorph(object):
                 if self.src_data['to_vox_map'] is not None:
                     affine = self.affine
                     to_zooms = np.diag(self.src_data['to_vox_map'][1])[:3]
+                    # There might be some sparse equivalent to this but
+                    # not sure...
                     if not np.allclose(self.zooms, to_zooms, atol=1e-3):
                         img_real, affine = reslice(
                             img_real, self.affine, self.zooms, to_zooms)
                     _debug_img(img_real, affine,
                                'From-reslice-transform-src')
-                    img_real = _resample_from_to(
-                        img_real, affine, self.src_data['to_vox_map'])
+                    if resamp_2 is None:
+                        resamp_2 = _grid_interp(
+                            img_real.shape, self.src_data['to_vox_map'][0],
+                            linalg.inv(affine) @
+                            self.src_data['to_vox_map'][1])
+                    # Equivalent to:
+                    # _resample_from_to(
+                    #     img_real, affine, self.src_data['to_vox_map'])
+                    img_real = resamp_2 @ img_real.ravel(order='F')
                     _debug_img(img_real, self.src_data['to_vox_map'][1],
-                               'From-reslice-transform-src-subselect')
+                               'From-reslice-transform-src-subselect',
+                               self.src_data['to_vox_map'][0])
 
                 # This can be used to help debug, but it really should just
                 # show the brain filling the volume:
@@ -641,11 +664,16 @@ class SourceMorph(object):
 _slicers = list()
 
 
-def _debug_img(data, affine, title):
+def _debug_img(data, affine, title, shape=None):
     # XXX uncomment these lines for debugging help with volume morph
     # import nibabel as nib
+    # if sparse.issparse(data):
+    #     data = data.toarray()
+    # data = np.asarray(data)
+    # if shape is not None:
+    #     data = np.reshape(data, shape, order='F')
     # _slicers.append(nib.viewers.OrthoSlicer3D(
-    #     np.asarray(data), affine, axes=None, title=title))
+    #     data, affine, axes=None, title=title))
     # _slicers[-1].figs[0].suptitle(title, color='r')
     return
 
@@ -777,7 +805,7 @@ def _morphed_stc_as_volume(morph, stc, mri_resolution, mri_space, output):
 
     # setup empty volume
     if morph.src_data['to_vox_map'] is not None:
-        shape = morph.src_data['to_vox_map'][0][::-1]
+        shape = morph.src_data['to_vox_map'][0]
         affine = morph.src_data['to_vox_map'][1]
     else:
         shape = morph.shape


### PR DESCRIPTION
1. Reduce time in `examples/inverse/plot_morph_volume_stc.py`, which is a pretty representative case, when doing `precompute=True` on my machine from 5:32 to 3:23
2. Fix bug introduced by #8462 where `as_volume` did not produce the correct output shape (with unit test added)
3. Make testing of `_grid_interp` a bit more complete

I also opened a dipy issue to see if they're interested in using these techniques to get speedups at their end: https://github.com/dipy/dipy/issues/2293