### PR TITLE
MRG, ENH: Allow saving non-head cf in mon.save

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -53,9 +53,9 @@ Enhancements
 
 - Add :meth:`mne.channels.DigMontage.get_positions`, which will return a dictionary of channel positions, coordinate frame and fiducial locations (:gh:`8460` by `Adam Li`_)
 
-- Add ``picks`` parameter to :func:`mne.preprocessing.fix_stim_artifact` to specify which channel needs to be fixed (:gh:`8482` by `Alex Gramfort`_)
+- Add support for writing digitization points in a coordinate frame other than head in :meth:`mne.channels.DigMontage.save` (:gh:`8532` by `Eric Larson`_)
 
-- Add support for writing digitization points in a coordinate frame other than head in :meth:`mne.DigMontage.save` (:gh:`8532` by `Eric Larson`_)
+- Add ``picks`` parameter to :func:`mne.preprocessing.fix_stim_artifact` to specify which channel needs to be fixed (:gh:`8482` by `Alex Gramfort`_)
 
 - Further improved documentation building instructions and execution on Windows (:gh:`8502` by `kalenkovich`_ and `Eric Larson`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -55,6 +55,8 @@ Enhancements
 
 - Add ``picks`` parameter to :func:`mne.preprocessing.fix_stim_artifact` to specify which channel needs to be fixed (:gh:`8482` by `Alex Gramfort`_)
 
+- Add support for writing digitization points in a coordinate frame other than head in :meth:`mne.DigMontage.save` (:gh:`8532` by `Eric Larson`_)
+
 - Further improved documentation building instructions and execution on Windows (:gh:`8502` by `kalenkovich`_ and `Eric Larson`_)
 
 - Add option to disable TQDM entirely with ``MNE_TQDM='off'`` (:gh:`8515` by `Eric Larson`_)

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -56,9 +56,11 @@ _BUILT_IN_MONTAGES = [
 
 
 def _check_get_coord_frame(dig):
-    _MSG = 'Only single coordinate frame in dig is supported'
-    dig_coord_frames = set([d['coord_frame'] for d in dig])
-    assert len(dig_coord_frames) <= 1, _MSG
+    dig_coord_frames = sorted(set(d['coord_frame'] for d in dig))
+    if len(dig_coord_frames) != 1:
+        raise RuntimeError(
+            'Only a single coordinate frame in dig is supported, got '
+            f'{dig_coord_frames}')
     return _frame_to_str[dig_coord_frames.pop()] if dig_coord_frames else None
 
 
@@ -218,10 +220,8 @@ class DigMontage(object):
         fname : str
             The filename to use. Should end in .fif or .fif.gz.
         """
-        if _check_get_coord_frame(self.dig) != 'head':
-            raise RuntimeError('Can only write out digitization points in '
-                               'head coordinates.')
-        write_dig(fname, self.dig)
+        coord_frame = _check_get_coord_frame(self.dig)
+        write_dig(fname, self.dig, coord_frame)
 
     def __iadd__(self, other):
         """Add two DigMontages in place.

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -19,7 +19,7 @@ import matplotlib.pyplot as plt
 
 from mne import __file__ as _mne_file, create_info, read_evokeds, pick_types
 from mne.fixes import nullcontext
-from mne.utils._testing import _dig_sort_key, assert_object_equal
+from mne.utils._testing import assert_object_equal
 from mne.channels import (get_builtin_montages, DigMontage, read_dig_dat,
                           read_dig_egi, read_dig_captrak, read_dig_fif,
                           make_standard_montage, read_custom_montage,
@@ -102,7 +102,7 @@ def _get_dig_montage_pos(montage):
     return np.array([d['r'] for d in _get_dig_eeg(montage.dig)])
 
 
-def test_dig_montage_trans():
+def test_dig_montage_trans(tmpdir):
     """Test getting a trans from montage."""
     nasion, lpa, rpa, *ch_pos = np.random.RandomState(0).randn(10, 3)
     ch_pos = {f'EEG{ii:3d}': pos for ii, pos in enumerate(ch_pos, 1)}
@@ -110,6 +110,9 @@ def test_dig_montage_trans():
                                coord_frame='mri')
     trans = compute_native_head_t(montage)
     _ensure_trans(trans)
+    # ensure that we can save and load it, too
+    fname = tmpdir.join('temp-mon.fif')
+    _check_roundtrip(montage, fname, 'mri')
 
 
 def test_fiducials():
@@ -845,11 +848,12 @@ def test_fif_dig_montage(tmpdir):
                                 lpa=elp_points[1],
                                 rpa=elp_points[2],
                                 ch_pos=ch_pos)
-
-    pytest.raises(RuntimeError, montage.save, fname_temp)  # must be head coord
-
+    _check_roundtrip(montage, fname_temp, 'unknown')
     montage = transform_to_head(montage)
     _check_roundtrip(montage, fname_temp)
+    montage.dig[0]['coord_frame'] = FIFF.FIFFV_COORD_UNKNOWN
+    with pytest.raises(RuntimeError, match='Only a single coordinate'):
+        montage.save(fname_temp)
 
 
 @testing.requires_testing_data
@@ -891,9 +895,9 @@ def test_egi_dig_montage(tmpdir):
     )
 
     # test round-trip IO
-    temp_dir = str(tmpdir)
-    fname_temp = op.join(temp_dir, 'egi_test.fif')
-    _check_roundtrip(dig_montage_in_head, fname_temp)  # XXX: write forces head
+    fname_temp = tmpdir.join('egi_test.fif')
+    _check_roundtrip(dig_montage, fname_temp, 'unknown')
+    _check_roundtrip(dig_montage_in_head, fname_temp)
 
 
 def _pop_montage(dig_montage, ch_name):
@@ -1019,25 +1023,14 @@ def test_set_montage_mgh(rename):
 
 
 # XXX: this does not check ch_names + it cannot work because of write_dig
-def _check_roundtrip(montage, fname):
+def _check_roundtrip(montage, fname, coord_frame='head'):
     """Check roundtrip writing."""
     montage.save(fname)
     montage_read = read_dig_fif(fname=fname)
 
     assert_equal(repr(montage), repr(montage_read))
-    assert_equal(_check_get_coord_frame(montage_read.dig), 'head')
-
-    # XXX:  it tests the same as assert_dig_all_close but without info
-    #       This is a possible refactor
-    dig_py = sorted(montage_read.dig, key=_dig_sort_key)
-    dig_bin = sorted(montage.dig, key=_dig_sort_key)
-    assert len(dig_py) == len(dig_bin)
-    for ii, (d_py, d_bin) in enumerate(zip(dig_py, dig_bin)):
-        for key in ('ident', 'kind', 'coord_frame'):
-            assert d_py[key] == d_bin[key]
-        assert_allclose(d_py['r'], d_bin['r'], rtol=1e-5, atol=1e-5,
-                        err_msg='Failure on %s:\n%s\n%s'
-                        % (ii, d_py['r'], d_bin['r']))
+    assert_equal(_check_get_coord_frame(montage_read.dig), coord_frame)
+    assert_dig_allclose(montage, montage_read)
 
 
 def _fake_montage(ch_names):

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from ..utils import logger, warn, _check_option, Bunch, _validate_type
 
-from .constants import FIFF
+from .constants import FIFF, _coord_frame_named
 from .tree import dir_tree_find
 from .tag import read_tag
 from .write import (start_file, end_file, write_dig_points)
@@ -177,6 +177,7 @@ def _read_dig_fif(fid, meas_info):
         warn('Multiple Isotrak found')
     else:
         isotrak = isotrak[0]
+        coord_frame = FIFF.FIFFV_COORD_HEAD
         dig = []
         for k in range(isotrak['nent']):
             kind = isotrak['directory'][k].kind
@@ -184,7 +185,11 @@ def _read_dig_fif(fid, meas_info):
             if kind == FIFF.FIFF_DIG_POINT:
                 tag = read_tag(fid, pos)
                 dig.append(tag.data)
-                dig[-1]['coord_frame'] = FIFF.FIFFV_COORD_HEAD
+            elif kind == FIFF.FIFF_MNE_COORD_FRAME:
+                tag = read_tag(fid, pos)
+                coord_frame = _coord_frame_named.get(int(tag.data))
+        for d in dig:
+            d['coord_frame'] = coord_frame
     return _format_dig_points(dig)
 
 

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -474,17 +474,31 @@ def assert_dig_allclose(info_py, info_bin, limit=None):
     """Assert dig allclose."""
     from ..bem import fit_sphere_to_headshape
     from ..io.constants import FIFF
+    from ..io.meas_info import Info
+    from ..channels.montage import DigMontage
     # test dig positions
-    dig_py = sorted(info_py['dig'], key=_dig_sort_key)
-    dig_bin = sorted(info_bin['dig'], key=_dig_sort_key)
+    dig_py, dig_bin = info_py, info_bin
+    if isinstance(dig_py, Info):
+        assert isinstance(dig_bin, Info)
+        dig_py, dig_bin = dig_py['dig'], dig_bin['dig']
+    else:
+        assert isinstance(dig_bin, DigMontage)
+        assert isinstance(dig_py, DigMontage)
+        dig_py, dig_bin = dig_py.dig, dig_bin.dig
+        info_py = info_bin = None
+    assert isinstance(dig_py, list)
+    assert isinstance(dig_bin, list)
+    dig_py = sorted(dig_py, key=_dig_sort_key)
+    dig_bin = sorted(dig_bin, key=_dig_sort_key)
     assert len(dig_py) == len(dig_bin)
     for ii, (d_py, d_bin) in enumerate(zip(dig_py[:limit], dig_bin[:limit])):
         for key in ('ident', 'kind', 'coord_frame'):
-            assert d_py[key] == d_bin[key]
+            assert d_py[key] == d_bin[key], key
         assert_allclose(d_py['r'], d_bin['r'], rtol=1e-5, atol=1e-5,
                         err_msg='Failure on %s:\n%s\n%s'
                         % (ii, d_py['r'], d_bin['r']))
-    if any(d['kind'] == FIFF.FIFFV_POINT_EXTRA for d in dig_py):
+    if any(d['kind'] == FIFF.FIFFV_POINT_EXTRA for d in dig_py) and \
+            info_py is not None:
         r_bin, o_head_bin, o_dev_bin = fit_sphere_to_headshape(
             info_bin, units='m', verbose='error')
         r_py, o_head_py, o_dev_py = fit_sphere_to_headshape(


### PR DESCRIPTION
As discussed with @agramfort, there is no need to have this restriction. Simultaneously makes things more DRY and removes two `# XXX` comments from our code, which is nice.