### PR TITLE
CI: Use 20.04

### DIFF
--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -1,7 +1,7 @@
 on: [status]
 jobs:
   circleci_artifacts_redirector_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step

--- a/.github/workflows/codespell_and_flake.yml
+++ b/.github/workflows/codespell_and_flake.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   style:
     if: "github.repository == 'mne-tools/mne-python' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CODESPELL_DIRS: 'mne/ doc/ tutorials/ examples/'
       CODESPELL_SKIPS: 'doc/auto_*,*.fif,*.eve,*.gz,*.tgz,*.zip,*.mat,*.stc,*.label,*.w,*.bz2,*.annot,*.sulc,*.log,*.local-copy,*.orig_avg,*.inflated_avg,*.gii,*.pyc,*.doctree,*.pickle,*.inv,*.png,*.edf,*.touch,*.thickness,*.nofix,*.volume,*.defect_borders,*.mgh,lh.*,rh.*,COR-*,FreeSurferColorLUT.txt,*.examples,.xdebug_mris_calc,bad.segments,BadChannels,*.hist,empty_file,*.orig,*.js,*.map,*.ipynb,searchindex.dat,install_mne_c.rst,plot_*.rst,*.rst.txt,c_EULA.rst*,*.html,gdf_encodes.txt,*.svg'

--- a/.github/workflows/compat_minimal.yml
+++ b/.github/workflows/compat_minimal.yml
@@ -12,7 +12,7 @@ jobs:
   job:
     if: "github.repository == 'mne-tools/mne-python' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     name: 'py3.7'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash

--- a/.github/workflows/compat_old.yml
+++ b/.github/workflows/compat_old.yml
@@ -12,7 +12,7 @@ jobs:
   job:
     if: "github.repository == 'mne-tools/mne-python' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     name: 'py3.6'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     defaults:
       run:
         shell: bash

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -12,7 +12,7 @@ jobs:
   job:
     if: "github.repository == 'mne-tools/mne-python' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     name: 'py3.8'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash

--- a/.github/workflows/linux_pip.yml
+++ b/.github/workflows/linux_pip.yml
@@ -12,7 +12,7 @@ jobs:
   job:
     if: "github.repository == 'mne-tools/mne-python' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     name: 'py3.9'
-    runs-on: ubuntu-18.04  # same as ubuntu-latest, but more precise name
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -13,7 +13,7 @@ else # pip 3.9 (missing statsmodels and dipy)
 	# built using vtk master branch on an Ubuntu 18.04.5 VM and uploaded to OSF:
 	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 	pip install vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
-	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/5ee02e2f295f667e33f11e71946e774cca40256c
+	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/1ee2603fc6ec7bf1f712dadaf7db29590090173c
 	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 	pip install --progress-bar off --upgrade --pre PyQt5
 	python -c "import vtk"

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -13,7 +13,7 @@ else # pip 3.9 (missing statsmodels and dipy)
 	# built using vtk master branch on an Ubuntu 18.04.5 VM and uploaded to OSF:
 	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 	pip install vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
-	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
+	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/5ee02e2f295f667e33f11e71946e774cca40256c
 	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 	pip install --progress-bar off --upgrade --pre PyQt5
 	python -c "import vtk"

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -13,7 +13,7 @@ else # pip 3.9 (missing statsmodels and dipy)
 	# built using vtk master branch on an Ubuntu 18.04.5 VM and uploaded to OSF:
 	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 	pip install vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
-	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/1ee2603fc6ec7bf1f712dadaf7db29590090173c
+	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/5ee02e2f295f667e33f11e71946e774cca40256c
 	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 	pip install --progress-bar off --upgrade --pre PyQt5
 	python -c "import vtk"

--- a/tools/setup_xvfb.sh
+++ b/tools/setup_xvfb.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -ef
 
-sudo apt-get install -yq libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0
+sudo apt-get install -yqq libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset


### PR DESCRIPTION
In some of the GitHub Actions they warn that the meaning of `ubuntu-latest` will change from `18.04` to `20.04` at some point. This PR sets them explicitly to 20.04 for all but the `old` build. This really shouldn't matter for us too much since it's up to the upstream compiled libraries to work on older OSes. I hope this also fixes the 3.9-pre failures we've been getting when running `sys_info`. If it appears to, I'll probably restart that run a few times before merging to evaluate more thoroughly.