### PR TITLE
MRG, BUG: Fix support for KIT Berlin

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -138,6 +138,8 @@ Bugs
 
 - Fix inset sensor plots to always use equal aspect (:gh:`8545` by `Daniel McCloy`_)
 
+- Fix bug in :func:`mne.io.read_raw_kit` where scale factors for EEG channels could be set to zero (:gh:`8542` by `Eric Larson`_)
+
 - Fix reading GDF files with excluded channels in :func:`mne.io.read_raw_gdf` (:gh:`8520` by `Clemens Brunner`_)
 
 API changes

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -245,7 +245,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.108', misc='0.7')
+    releases = dict(testing='0.110', misc='0.7')
     # And also update the "md5_hashes['testing']" variable below.
     # To update any other dataset, update the data archive itself (upload
     # an updated version) and update the md5 hash.
@@ -331,7 +331,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='12b75d1cb7df9dfb4ad73ed82f61094f',
         somato='32fd2f6c8c7eb0784a1de6435273c48b',
         spm='9f43f67150e3b694b523a21eb929ea75',
-        testing='57a21229ebb11e3c470b5d0fdb80642f',
+        testing='c4cd3385f321cd1151ed9de34fc4ce5a',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         fnirs_motor='c4935d19ddab35422a69f3326a01fef8',
         opm='370ad1dcfd5c47e029e692c85358a374',

--- a/mne/io/kit/constants.py
+++ b/mne/io/kit/constants.py
@@ -48,6 +48,7 @@ KIT.FLL_SETTINGS = {
     50: (2, 1, 1),  # Hanger Type #3
     60: (2, 1, 1),  # Hanger Type #3
     100: (3, 3, 3),  # Low Band Kapper Type
+    101: (3, 3, 3),  # Low Band Kapper Type
     120: (3, 3, 3),  # Low Band Kapper Type
     200: (4, 4, 3),  # High Band Kapper Type
     300: (2, 2, 2),  # Kapper Type
@@ -164,6 +165,7 @@ KIT.SYSTEM_UMD_2019_09 = 54  # UMD September 3, 2019 -
 KIT.SYSTEM_YOKOGAWA_2017_01 = 1001  # Kanazawa (until 2017)
 KIT.SYSTEM_YOKOGAWA_2018_01 = 10020  # Kanazawa (since 2018)
 KIT.SYSTEM_YOKOGAWA_2020_08 = 10021  # Kanazawa (since August 2020)
+KIT.SYSTEM_BERLIN = 124
 # Sensor layouts for plotting
 KIT_LAYOUT = {
     KIT.SYSTEM_AS: None,
@@ -184,6 +186,7 @@ KIT_LAYOUT = {
     KIT.SYSTEM_YOKOGAWA_2017_01: None,
     KIT.SYSTEM_YOKOGAWA_2018_01: None,
     KIT.SYSTEM_YOKOGAWA_2020_08: None,
+    KIT.SYSTEM_BERLIN: None,
 }
 # Sensor neighbor definitions
 KIT_NEIGHBORS = {
@@ -205,6 +208,7 @@ KIT_NEIGHBORS = {
     KIT.SYSTEM_YOKOGAWA_2017_01: None,
     KIT.SYSTEM_YOKOGAWA_2018_01: None,
     KIT.SYSTEM_YOKOGAWA_2020_08: None,
+    KIT.SYSTEM_BERLIN: None,
 }
 # Names displayed in the info dict description
 KIT_SYSNAMES = {
@@ -225,6 +229,7 @@ KIT_SYSNAMES = {
     KIT.SYSTEM_YOKOGAWA_2017_01: 'Yokogawa of Kanazawa (until 2017)',
     KIT.SYSTEM_YOKOGAWA_2018_01: 'Yokogawa of Kanazawa (since 2018)',
     KIT.SYSTEM_YOKOGAWA_2020_08: 'Yokogawa of Kanazawa (since August 2020)',
+    KIT.SYSTEM_BERLIN: 'Physikalisch Technische Bundesanstalt, Berlin/128-channel MEG System',  # noqa: E501
 }
 
 LEGACY_AMP_PARAMS = {

--- a/mne/io/kit/constants.py
+++ b/mne/io/kit/constants.py
@@ -48,7 +48,7 @@ KIT.FLL_SETTINGS = {
     50: (2, 1, 1),  # Hanger Type #3
     60: (2, 1, 1),  # Hanger Type #3
     100: (3, 3, 3),  # Low Band Kapper Type
-    101: (3, 3, 3),  # Low Band Kapper Type
+    101: (1, 3, 2),  # Berlin (DC, 200 Hz, Through)
     120: (3, 3, 3),  # Low Band Kapper Type
     200: (4, 4, 3),  # High Band Kapper Type
     300: (2, 2, 2),  # Kapper Type
@@ -165,7 +165,8 @@ KIT.SYSTEM_UMD_2019_09 = 54  # UMD September 3, 2019 -
 KIT.SYSTEM_YOKOGAWA_2017_01 = 1001  # Kanazawa (until 2017)
 KIT.SYSTEM_YOKOGAWA_2018_01 = 10020  # Kanazawa (since 2018)
 KIT.SYSTEM_YOKOGAWA_2020_08 = 10021  # Kanazawa (since August 2020)
-KIT.SYSTEM_BERLIN = 124
+KIT.SYSTEM_EAGLE_TECHNOLOGY_PTB_2008 = 124
+
 # Sensor layouts for plotting
 KIT_LAYOUT = {
     KIT.SYSTEM_AS: None,
@@ -186,7 +187,7 @@ KIT_LAYOUT = {
     KIT.SYSTEM_YOKOGAWA_2017_01: None,
     KIT.SYSTEM_YOKOGAWA_2018_01: None,
     KIT.SYSTEM_YOKOGAWA_2020_08: None,
-    KIT.SYSTEM_BERLIN: None,
+    KIT.SYSTEM_EAGLE_TECHNOLOGY_PTB_2008: None,
 }
 # Sensor neighbor definitions
 KIT_NEIGHBORS = {
@@ -208,7 +209,7 @@ KIT_NEIGHBORS = {
     KIT.SYSTEM_YOKOGAWA_2017_01: None,
     KIT.SYSTEM_YOKOGAWA_2018_01: None,
     KIT.SYSTEM_YOKOGAWA_2020_08: None,
-    KIT.SYSTEM_BERLIN: None,
+    KIT.SYSTEM_EAGLE_TECHNOLOGY_PTB_2008: None,
 }
 # Names displayed in the info dict description
 KIT_SYSNAMES = {
@@ -229,7 +230,7 @@ KIT_SYSNAMES = {
     KIT.SYSTEM_YOKOGAWA_2017_01: 'Yokogawa of Kanazawa (until 2017)',
     KIT.SYSTEM_YOKOGAWA_2018_01: 'Yokogawa of Kanazawa (since 2018)',
     KIT.SYSTEM_YOKOGAWA_2020_08: 'Yokogawa of Kanazawa (since August 2020)',
-    KIT.SYSTEM_BERLIN: 'Physikalisch Technische Bundesanstalt, Berlin/128-channel MEG System',  # noqa: E501
+    KIT.SYSTEM_EAGLE_TECHNOLOGY_PTB_2008: 'Eagle Technology MEG (KIT/Yokogawa style) at PTB (since 2008, software upgrade in 2018)',  # noqa: E501
 }
 
 LEGACY_AMP_PARAMS = {

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -760,7 +760,7 @@ def get_kit_info(rawfile, allow_unknown_format, standardize_names=None,
     is_exg = [ch['type'] in (KIT.CHANNEL_EEG, KIT.CHANNEL_ECG)
               for ch in channels]
     exg_gains /= 2 ** (adc_stored - 14)
-    exg_gains[exg_gains == 0] = 1. / 2 ** 28
+    exg_gains[exg_gains == 0] = ad_to_volt
     conv_factor[is_exg] = exg_gains
     sqd['conv_factor'] = conv_factor[:, np.newaxis]
 

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -760,6 +760,7 @@ def get_kit_info(rawfile, allow_unknown_format, standardize_names=None,
     is_exg = [ch['type'] in (KIT.CHANNEL_EEG, KIT.CHANNEL_ECG)
               for ch in channels]
     exg_gains /= 2 ** (adc_stored - 14)
+    exg_gains[exg_gains == 0] = 1. / 2 ** 28
     conv_factor[is_exg] = exg_gains
     sqd['conv_factor'] = conv_factor[:, np.newaxis]
 

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -15,7 +15,7 @@ import mne
 from mne import pick_types, Epochs, find_events, read_events
 from mne.datasets.testing import requires_testing_data
 from mne.transforms import apply_trans
-from mne.utils import run_tests_if_main, assert_dig_allclose
+from mne.utils import assert_dig_allclose
 from mne.io import read_raw_fif, read_raw_kit, read_epochs_kit
 from mne.io.constants import FIFF
 from mne.io.kit.coreg import read_sns
@@ -49,6 +49,7 @@ ricoh_systems_paths += [op.join(
     data_path, 'KIT', 'Example_RICOH160-1_10020-export_anonymyze.con')]
 ricoh_systems_paths += [op.join(
     data_path, 'KIT', 'Example_RICOH160-1_10021-export_anonymyze.con')]
+berlin_path = op.join(data_path, 'KIT', 'data_berlin.con')
 
 
 @requires_testing_data
@@ -337,4 +338,18 @@ def test_ricoh_systems(tmpdir, fname, desc, system_id):
     assert raw.info['kit_system_id'] == system_id
 
 
-run_tests_if_main()
+@requires_testing_data
+def test_berlin():
+    """Test data from Berlin."""
+    # gh-8535
+    raw = read_raw_kit(berlin_path)
+    assert raw.info['description'] == 'Physikalisch Technische Bundesanstalt, Berlin/128-channel MEG System (124) V2R004 PQ1128R-N2'  # noqa: E501
+    assert raw.info['kit_system_id'] == 124
+    assert raw.info['highpass'] == 0.
+    assert raw.info['lowpass'] == 200.
+    assert raw.info['sfreq'] == 500.
+    n = int(round(28.77 * raw.info['sfreq']))
+    meg = raw.get_data('MEG 003', n, n + 1)[0, 0]
+    assert_allclose(meg, -8.89e-12, rtol=1e-3)
+    eeg = raw.get_data('E14', n, n + 1)[0, 0]
+    assert_allclose(eeg, -2.55, rtol=1e-3)


### PR DESCRIPTION
@UrbanM simplifying your example to get rid of all of the `scalings` stuff and doing:
```
python -ic "import mne; mne.io.read_raw_kit("data.con").plot()"
```
<img width="752" alt="Screen Shot 2020-11-18 at 5 28 46 PM" src="https://user-images.githubusercontent.com/2365790/99596693-c297f700-29c4-11eb-9a52-2890fefbf177.png">

You'll notice that the scale bar for EEG data is 40 uV. Your plot from version 0.20 had a pretty wild `400000.0 uV` scale bar which suggests things were wrong there, too (although at least they were non-zero!).

This almost certainly isn't correct, unless I got very lucky -- I need to dig into why your `exg_gains` are all zero. And if those are being read correctly as zero, what the actually correct fallback gain is to use. Can you browse these data in some KIT (or other) software and let me know what the correct voltage of some value in some EEG channel at some time is supposed to be? For example, E14 at 28.77 seconds seems to be the top of a fairly smooth peak.

I also have no idea if the names I gave to these constants are consistent, feel free to look at the diff and comment @UrbanM!

Closes #8535