### PR TITLE
MAINT: fix linkcheck

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -640,12 +640,9 @@
 @article {HaukEtAl2019,
 	author = {Hauk, Olaf and Stenroos, Matti and Treder, Matthias},
 	title = {Towards an Objective Evaluation of EEG/MEG Source Estimation Methods: The Linear Tool Kit},
-	elocation-id = {672956},
 	year = {2019},
 	doi = {10.1101/672956},
 	publisher = {Cold Spring Harbor Laboratory},
-	URL = {https://www.biorxiv.org/content/early/2019/06/18/672956},
-	eprint = {https://www.biorxiv.org/content/early/2019/06/18/672956.full.pdf},
 	journal = {bioRxiv}
 }
 


### PR DESCRIPTION
we don't need DOI, URL, ePrint, and eLocationID (eLocationID link gen is broken anyway, at least for bioRXive). Better would be to fix the upstream bib style so that if DOI is present the others are suppressed, but for now this is good enough.
