### PR TITLE
VIZ, FIX: epochs.plot() scalebars missing

### DIFF
--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -759,6 +759,8 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
     scalings = _handle_default('scalings_plot_raw', scalings)
     if scalings['whitened'] == 'auto':
         scalings['whitened'] = 1.
+    units = _handle_default('units', None)
+    unit_scalings = _handle_default('scalings', None)
     decim, picks_data = _handle_decim(epochs.info.copy(), decim, None)
     noise_cov = _check_cov(noise_cov, epochs.info)
     event_id_rev = {v: k for k, v in (event_id or {}).items()}
@@ -868,6 +870,8 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
                   use_noise_cov=noise_cov is not None,
                   # scalings
                   scalings=scalings,
+                  units=units,
+                  unit_scalings=unit_scalings,
                   # colors
                   ch_color_bad=(0.8, 0.8, 0.8),
                   ch_color_dict=color,

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -138,6 +138,17 @@ def test_plot_epochs_colors(epochs):
         epochs.plot(event_colors='r', event_color='b')
 
 
+def test_plot_epochs_scale_bar(epochs):
+    """Test scale bar for epochs."""
+    fig = epochs.plot()
+    fig.canvas.key_press_event('s')  # default is to not show scalebars
+    ax = fig.mne.ax_main
+    assert len(ax.texts) == 2  # only mag & grad in this instance
+    texts = tuple(t.get_text().strip() for t in ax.texts)
+    wants = ('800.0 fT/cm', '2000.0 fT')
+    assert texts == wants
+
+
 def test_plot_epochs_clicks(epochs, capsys):
     """Test plot_epochs mouse interaction."""
     fig = epochs.plot(events=epochs.events)


### PR DESCRIPTION
This fixes missing scalebars (toggled by pressing `'s'`) on epochs plots, and adds a test that would have caught their missingness.