### PR TITLE
DOC: fix crossrefs; add fsaverage details link

### DIFF
--- a/tutorials/discussions/plot_background_filtering.py
+++ b/tutorials/discussions/plot_background_filtering.py
@@ -710,7 +710,7 @@ plt.show()
 # a high-pass, it is important to keep in mind (as most authors note) that
 # filtering choices should depend on the frequency content of both the
 # signal(s) of interest and the noise to be suppressed. For example, in
-# some of the MNE-Python examples involving :ref:`sample-data`,
+# some of the MNE-Python examples involving the :ref:`sample-dataset` dataset,
 # high-pass values of around 1 Hz are used when looking at auditory
 # or visual N100 responses, because we analyze standard (not deviant) trials
 # and thus expect that contamination by later or slower components will

--- a/tutorials/source-modeling/plot_background_freesurfer.py
+++ b/tutorials/source-modeling/plot_background_freesurfer.py
@@ -103,9 +103,11 @@ brain.add_annotation('aparc.a2009s', borders=False)
 # data types that a subject reconstruction would yield and is required by
 # MNE-Python.
 #
-# See https://surfer.nmr.mgh.harvard.edu/fswiki/FsAverage for more
-# information. Furthermore a copy of 'fsaverage' can be found in
-# :ref:`sample-data`.
+# See https://surfer.nmr.mgh.harvard.edu/fswiki/FsAverage for an overview, and
+# https://surfer.nmr.mgh.harvard.edu/fswiki/Buckner40Notes for details about
+# the included subjects. A copy of 'fsaverage' can be found in the
+# :ref:`sample-dataset` dataset and is also distributed as a :ref:`standalone
+# dataset <fsaverage>`.
 #
 # When using ``'fsaverage'`` as value for the definition
 # of a subject when calling a function, the corresponding data will be read


### PR DESCRIPTION
A couple of tutorials link to `sample-data` (which resolves to "Writing examples" via matplotlib intersphinx) instead of `sample-dataset`.  This fixes it, and adds a new URL to the 'fsaverage' tutorial along the way.