### PR TITLE
MRG, ENH: Remove 15-char limit for FIF

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -36,6 +36,8 @@ Enhancements
 
 - Update the ``notebook`` 3d backend to use ``ipyvtk_simple`` for a better integration within ``Jupyter`` (:gh:`8503` by `Guillaume Favelier`_)
 
+- Remove the 15-character limitation for channel names when writing to FIF format. If you need the old 15-character names, you can use something like ``raw.rename_channels({n: n[:13] for n in raw.ch_names}, allow_duplicates=True)``, by `Eric Larson`_ (:gh:`8346`)
+
 - Add toggle-all button to :class:`mne.Report` HTML and ``width`` argument to :meth:`mne.Report.add_bem_to_section` (:gh:`8723` by `Eric Larson`_)
 
 - Add infant template MRI dataset downloader :func:`mne.datasets.fetch_infant_template` (:gh:`8738` by `Eric Larson`_ and `Christian O'Reilly`_)

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -195,12 +195,12 @@ class DigMontage(object):
                             sphere=sphere)
 
     @fill_doc
-    def rename_channels(self, mapping):
+    def rename_channels(self, mapping, allow_duplicates=False):
         """Rename the channels.
 
         Parameters
         ----------
-        %(rename_channels_mapping)s
+        %(rename_channels_mapping_duplicates)s
 
         Returns
         -------
@@ -209,7 +209,7 @@ class DigMontage(object):
         """
         from .channels import rename_channels
         temp_info = create_info(list(self._get_ch_pos()), 1000., 'eeg')
-        rename_channels(temp_info, mapping)
+        rename_channels(temp_info, mapping, allow_duplicates)
         self.ch_names = temp_info['ch_names']
 
     def save(self, fname):

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -83,10 +83,6 @@ def test_rename_channels():
     # Test bad input
     pytest.raises(ValueError, rename_channels, info, 1.)
     pytest.raises(ValueError, rename_channels, info, 1.)
-    # Test name too long (channel names must be less than 15 characters)
-    A16 = 'A' * 16
-    mapping = {'MEG 2641': A16}
-    pytest.raises(ValueError, rename_channels, info, mapping)
 
     # Test successful changes
     # Test ch_name and ch_names are changed

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -24,7 +24,7 @@ from .io.pick import (pick_types, pick_channels_cov, pick_channels, pick_info,
                       _DATA_CH_TYPES_SPLIT)
 
 from .io.constants import FIFF
-from .io.meas_info import read_bad_channels, create_info
+from .io.meas_info import _read_bad_channels, create_info
 from .io.tag import find_tag
 from .io.tree import dir_tree_find
 from .io.write import (start_block, end_block, write_int, write_name_list,
@@ -2022,7 +2022,7 @@ def _read_cov(fid, node, cov_kind, limited=False, verbose=None):
             projs = _read_proj(fid, this)
 
             #   Read the bad channel list
-            bads = read_bad_channels(fid, this)
+            bads = _read_bad_channels(fid, this, None)
 
             #   Put it together
             assert dim == len(data)

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -32,7 +32,8 @@ from .io.open import fiff_open
 from .io.tag import read_tag
 from .io.tree import dir_tree_find
 from .io.pick import pick_types, _picks_to_idx, _FNIRS_CH_TYPES_SPLIT
-from .io.meas_info import read_meas_info, write_meas_info
+from .io.meas_info import (read_meas_info, write_meas_info,
+                           _read_extended_ch_info, _rename_list)
 from .io.proj import ProjMixin
 from .io.write import (start_file, start_block, end_file, end_block,
                        write_int, write_string, write_float_matrix,
@@ -1080,7 +1081,9 @@ def _read_evoked(fname, condition=None, kind='average', allow_maxshield=False):
                 raise ValueError('Number of channels and number of '
                                  'channel definitions are different')
 
+            ch_names_mapping = _read_extended_ch_info(chs, my_evoked, fid)
             info['chs'] = chs
+            info['bads'][:] = _rename_list(info['bads'], ch_names_mapping)
             logger.info('    Found channel information in evoked data. '
                         'nchan = %d' % nchan)
             if sfreq > 0:

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -25,7 +25,7 @@ from ..io.tree import dir_tree_find
 from ..io.tag import find_tag, read_tag
 from ..io.matrix import (_read_named_matrix, _transpose_named_matrix,
                          write_named_matrix)
-from ..io.meas_info import (read_bad_channels, write_info, _write_ch_infos,
+from ..io.meas_info import (_read_bad_channels, write_info, _write_ch_infos,
                             _read_extended_ch_info, _make_ch_names_mapping,
                             _rename_list)
 from ..io.pick import (pick_channels_forward, pick_info, pick_channels,
@@ -324,7 +324,7 @@ def _read_forward_meas_info(tree, fid):
     else:
         raise ValueError('MEG/head coordinate transformation not found')
 
-    info['bads'] = read_bad_channels(
+    info['bads'] = _read_bad_channels(
         fid, parent_meg, ch_names_mapping=ch_names_mapping)
     # clean up our bad list, old versions could have non-existent bads
     info['bads'] = [bad for bad in info['bads'] if bad in info['ch_names']]

--- a/mne/io/array/tests/test_array.py
+++ b/mne/io/array/tests/test_array.py
@@ -28,11 +28,15 @@ def test_long_names():
     info = create_info(['a' * 15 + 'b', 'a' * 16], 1000., verbose='error')
     data = np.empty((2, 1000))
     raw = RawArray(data, info)
+    assert raw.ch_names == ['a' * 15 + 'b', 'a' * 16]
+    # and a way to get the old behavior
+    raw.rename_channels({k: k[:13] for k in raw.ch_names},
+                        allow_duplicates=True, verbose='error')
     assert raw.ch_names == ['a' * 13 + '-0', 'a' * 13 + '-1']
     info = create_info(['a' * 16] * 11, 1000., verbose='error')
     data = np.empty((11, 1000))
     raw = RawArray(data, info)
-    assert raw.ch_names == ['a' * 12 + '-%s' % ii for ii in range(11)]
+    assert raw.ch_names == ['a' * 16 + '-%s' % ii for ii in range(11)]
 
 
 def test_array_copy():

--- a/mne/io/constants.py
+++ b/mne/io/constants.py
@@ -31,6 +31,7 @@ FIFF.FIFFB_HPI_RESULT         = 109  # Result of a HPI fitting procedure
 FIFF.FIFFB_HPI_COIL           = 110  # Data acquired from one HPI coil
 FIFF.FIFFB_PROJECT            = 111
 FIFF.FIFFB_CONTINUOUS_DATA    = 112
+FIFF.FIFFB_CH_INFO            = 113  # Extra channel information
 FIFF.FIFFB_VOID               = 114
 FIFF.FIFFB_EVENTS             = 115
 FIFF.FIFFB_INDEX              = 116
@@ -156,6 +157,23 @@ FIFF.FIFF_HPI_FIT_DIST_LIMIT     = 244   # Limit for the coil distance differenc
 FIFF.FIFF_HPI_COIL_NO            = 245   # Coil number listed by HPI measurement
 FIFF.FIFF_HPI_COILS_USED         = 246   # List of coils finally used when the transformation was computed
 FIFF.FIFF_HPI_DIGITIZATION_ORDER = 247   # Which Isotrak digitization point corresponds to each of the coils energized
+
+
+#
+# Tags used for storing channel info
+#
+FIFF.FIFF_CH_SCAN_NO             = 250   # Channel scan number. Corresponds to fiffChInfoRec.scanNo field
+FIFF.FIFF_CH_LOGICAL_NO          = 251   # Channel logical number. Corresponds to fiffChInfoRec.logNo field
+FIFF.FIFF_CH_KIND                = 252   # Channel type. Corresponds to fiffChInfoRec.kind field"
+FIFF.FIFF_CH_RANGE               = 253   # Conversion from recorded number to (possibly virtual) voltage at the output"
+FIFF.FIFF_CH_CAL                 = 254   # Calibration coefficient from output voltage to some real units
+FIFF.FIFF_CH_LOC                 = 255   # Channel loc
+FIFF.FIFF_CH_UNIT                = 256   # Unit of the data
+FIFF.FIFF_CH_UNIT_MUL            = 257   # Unit multiplier exponent
+FIFF.FIFF_CH_DACQ_NAME           = 258   # Name of the channel in the data acquisition system. Corresponds to fiffChInfoRec.name.
+FIFF.FIFF_CH_COIL_TYPE           = 350   # Coil type in coil_def.dat
+FIFF.FIFF_CH_COORD_FRAME         = 351   # Coordinate frame (integer)
+
 #
 # Pointers
 #

--- a/mne/io/ctf_comp.py
+++ b/mne/io/ctf_comp.py
@@ -55,7 +55,7 @@ def _calibrate_comp(comp, chs, row_names, col_names,
 
 
 @verbose
-def read_ctf_comp(fid, node, chs, verbose=None):
+def read_ctf_comp(fid, node, chs, *, ch_names_mapping=None, verbose=None):
     """Read the CTF software compensation data from the given node.
 
     Parameters
@@ -67,6 +67,8 @@ def read_ctf_comp(fid, node, chs, verbose=None):
     chs : list
         The list of channels from info['chs'] to match with
         compensators that are read.
+    ch_names_mapping : dict | None
+        The channel renaming to use.
     %(verbose)s
 
     Returns
@@ -74,6 +76,8 @@ def read_ctf_comp(fid, node, chs, verbose=None):
     compdata : list
         The compensation data
     """
+    from .meas_info import _rename_comps
+    ch_names_mapping = dict() if ch_names_mapping is None else ch_names_mapping
     compdata = []
     comps = dir_tree_find(node, FIFF.FIFFB_MNE_CTF_COMP_DATA)
 
@@ -105,6 +109,7 @@ def read_ctf_comp(fid, node, chs, verbose=None):
 
         one['save_calibrated'] = bool(calibrated)
         one['data'] = mat
+        _rename_comps([one], ch_names_mapping)
         if not calibrated:
             #   Calibrate...
             _calibrate_comp(one, chs, mat['row_names'], mat['col_names'])

--- a/mne/io/ctf_comp.py
+++ b/mne/io/ctf_comp.py
@@ -55,7 +55,29 @@ def _calibrate_comp(comp, chs, row_names, col_names,
 
 
 @verbose
-def read_ctf_comp(fid, node, chs, *, ch_names_mapping=None, verbose=None):
+def read_ctf_comp(fid, node, chs, verbose=None):
+    """Read the CTF software compensation data from the given node.
+
+    Parameters
+    ----------
+    fid : file
+        The file descriptor.
+    node : dict
+        The node in the FIF tree.
+    chs : list
+        The list of channels from info['chs'] to match with
+        compensators that are read.
+    %(verbose)s
+
+    Returns
+    -------
+    compdata : list
+        The compensation data
+    """
+    return _read_ctf_comp(fid, node, chs, None)
+
+
+def _read_ctf_comp(fid, node, chs, ch_names_mapping):
     """Read the CTF software compensation data from the given node.
 
     Parameters

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -407,8 +407,9 @@ def test_bdf_multiple_annotation_channels():
 @testing.requires_testing_data
 def test_edf_lowpass_zero():
     """Test if a lowpass filter of 0Hz is mapped to the Nyquist frequency."""
-    with pytest.warns(RuntimeWarning, match='too long.*truncated'):
-        raw = read_raw_edf(edf_stim_resamp_path)
+    raw = read_raw_edf(edf_stim_resamp_path)
+    assert raw.ch_names[100] == 'EEG LDAMT_01-REF'
+    assert len(raw.ch_names[100]) > 15
     assert_allclose(raw.info["lowpass"], raw.info["sfreq"] / 2)
 
 

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -210,12 +210,12 @@ def test_io_egi_pns_mff(tmpdir):
     pns_chans = pick_types(raw.info, ecg=True, bio=True, emg=True)
     assert_equal(len(pns_chans), 7)
     names = [raw.ch_names[x] for x in pns_chans]
-    pns_names = ['Resp. Temperature'[:15],
+    pns_names = ['Resp. Temperature',
                  'Resp. Pressure',
                  'ECG',
                  'Body Position',
-                 'Resp. Effort Chest'[:15],
-                 'Resp. Effort Abdomen'[:15],
+                 'Resp. Effort Chest',
+                 'Resp. Effort Abdomen',
                  'EMG-Leg']
     _test_raw_reader(read_raw_egi, input_fname=egi_mff_pns_fname,
                      channel_naming='EEG %03d', verbose='error',
@@ -224,14 +224,13 @@ def test_io_egi_pns_mff(tmpdir):
                      )
     assert_equal(names, pns_names)
     mat_names = [
-        'Resp_Temperature'[:15],
+        'Resp_Temperature',
         'Resp_Pressure',
         'ECG',
         'Body_Position',
-        'Resp_Effort_Chest'[:15],
-        'Resp_Effort_Abdomen'[:15],
+        'Resp_Effort_Chest',
+        'Resp_Effort_Abdomen',
         'EMGLeg'
-
     ]
     egi_fname_mat = op.join(data_path(), 'EGI', 'test_egi_pns.mat')
     mc = sio.loadmat(egi_fname_mat)

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -25,7 +25,7 @@ from .tag import (read_tag, find_tag, _ch_coord_dict, _update_ch_info_named,
                   _rename_list)
 from .proj import (_read_proj, _write_proj, _uniquify_projs, _normalize_proj,
                    Projection)
-from .ctf_comp import read_ctf_comp, write_ctf_comp
+from .ctf_comp import _read_ctf_comp, write_ctf_comp
 from .write import (start_file, end_file, start_block, end_block,
                     write_string, write_dig_points, write_float, write_int,
                     write_coord_trans, write_ch_info, write_name_list,
@@ -920,7 +920,7 @@ def read_info(fname, verbose=None):
     return info
 
 
-def read_bad_channels(fid, node, *, ch_names_mapping=None):
+def read_bad_channels(fid, node):
     """Read bad channels.
 
     Parameters
@@ -929,14 +929,16 @@ def read_bad_channels(fid, node, *, ch_names_mapping=None):
         The file descriptor.
     node : dict
         The node of the FIF tree that contains info on the bad channels.
-    ch_names_mapping : dict | None
-        Short-to-long name mapping.
 
     Returns
     -------
     bads : list
         A list of bad channel's names.
     """
+    return _read_bad_channels(fid, node)
+
+
+def _read_bad_channels(fid, node, ch_names_mapping):
     ch_names_mapping = {} if ch_names_mapping is None else ch_names_mapping
     nodes = dir_tree_find(node, FIFF.FIFFB_MNE_BAD_CHANNELS)
 
@@ -1134,14 +1136,16 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
                 acq_stim = tag.data
 
     #   Load the SSP data
-    projs = _read_proj(fid, meas_info, ch_names_mapping=ch_names_mapping)
+    projs = _read_proj(
+        fid, meas_info, ch_names_mapping=ch_names_mapping)
 
     #   Load the CTF compensation data
-    comps = read_ctf_comp(
+    comps = _read_ctf_comp(
         fid, meas_info, chs, ch_names_mapping=ch_names_mapping)
 
     #   Load the bad channel list
-    bads = read_bad_channels(fid, meas_info, ch_names_mapping=ch_names_mapping)
+    bads = _read_bad_channels(
+        fid, meas_info, ch_names_mapping=ch_names_mapping)
 
     #
     #   Put the data together

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -6,7 +6,7 @@
 #
 # License: BSD (3-clause)
 
-from collections import Counter
+from collections import Counter, OrderedDict
 import contextlib
 from copy import deepcopy
 import datetime
@@ -21,7 +21,8 @@ from .pick import (channel_type, pick_channels, pick_info,
 from .constants import FIFF, _coord_frame_named
 from .open import fiff_open
 from .tree import dir_tree_find
-from .tag import read_tag, find_tag, _ch_coord_dict
+from .tag import (read_tag, find_tag, _ch_coord_dict, _update_ch_info_named,
+                  _rename_list)
 from .proj import (_read_proj, _write_proj, _uniquify_projs, _normalize_proj,
                    Projection)
 from .ctf_comp import read_ctf_comp, write_ctf_comp
@@ -32,7 +33,8 @@ from .write import (start_file, end_file, start_block, end_block,
 from .proc_history import _read_proc_history, _write_proc_history
 from ..transforms import invert_transform, Transform, _coord_frame_name
 from ..utils import (logger, verbose, warn, object_diff, _validate_type,
-                     _stamp_to_dt, _dt_to_stamp, _pl, _is_numeric)
+                     _stamp_to_dt, _dt_to_stamp, _pl, _is_numeric,
+                     _check_option)
 from ._digitization import (_format_dig_points, _dig_kind_proper, DigPoint,
                             _dig_kind_rev, _dig_kind_ints, _read_dig_fif)
 from ._digitization import write_dig as _dig_write_dig
@@ -100,9 +102,11 @@ def _get_valid_units():
     return tuple(valid_units)
 
 
-def _unique_channel_names(ch_names):
+@verbose
+def _unique_channel_names(ch_names, max_length=None, verbose=None):
     """Ensure unique channel names."""
-    FIFF_CH_NAME_MAX_LENGTH = 15
+    if max_length is not None:
+        ch_names[:] = [name[:max_length] for name in ch_names]
     unique_ids = np.unique(ch_names, return_index=True)[1]
     if len(unique_ids) != len(ch_names):
         dups = {ch_names[x]
@@ -113,8 +117,11 @@ def _unique_channel_names(ch_names):
             overlaps = np.where(np.array(ch_names) == ch_stem)[0]
             # We need an extra character since we append '-'.
             # np.ceil(...) is the maximum number of appended digits.
-            n_keep = (FIFF_CH_NAME_MAX_LENGTH - 1 -
-                      int(np.ceil(np.log10(len(overlaps)))))
+            if max_length is not None:
+                n_keep = (
+                    max_length - 1 - int(np.ceil(np.log10(len(overlaps)))))
+            else:
+                n_keep = np.inf
             n_keep = min(len(ch_stem), n_keep)
             ch_stem = ch_stem[:n_keep]
             for idx, ch_idx in enumerate(overlaps):
@@ -544,13 +551,13 @@ class Info(dict, MontageMixin):
             _format_trans(res, 'coord_trans')
         if self.get('dig', None) is not None and len(self['dig']):
             if isinstance(self['dig'], dict):  # needs to be unpacked
-                self['dig'] = _dict_unpack(self['dig'], _dig_cast)
+                self['dig'] = _dict_unpack(self['dig'], _DIG_CAST)
             if not isinstance(self['dig'][0], DigPoint):
                 self['dig'] = _format_dig_points(self['dig'])
         if isinstance(self.get('chs', None), dict):
             self['chs']['ch_name'] = [str(x) for x in np.char.decode(
                 self['chs']['ch_name'], encoding='utf8')]
-            self['chs'] = _dict_unpack(self['chs'], _ch_cast)
+            self['chs'] = _dict_unpack(self['chs'], _CH_CAST)
         for pi, proj in enumerate(self.get('projs', [])):
             if not isinstance(proj, Projection):
                 self['projs'][pi] = Projection(proj)
@@ -755,9 +762,6 @@ class Info(dict, MontageMixin):
                     'Bad info: info["chs"][%d]["loc"] must be ndarray with '
                     '12 elements, got %r' % (ci, loc))
 
-        # make sure channel names are not too long
-        self._check_ch_name_length()
-
         # make sure channel names are unique
         self['ch_names'] = _unique_channel_names(self['ch_names'])
         for idx, ch_name in enumerate(self['ch_names']):
@@ -766,18 +770,6 @@ class Info(dict, MontageMixin):
         if 'filename' in self:
             warn('the "filename" key is misleading '
                  'and info should not have it')
-
-    def _check_ch_name_length(self):
-        """Check that channel names are sufficiently short."""
-        bad_names = list()
-        for ch in self['chs']:
-            if len(ch['ch_name']) > 15:
-                bad_names.append(ch['ch_name'])
-                ch['ch_name'] = ch['ch_name'][:15]
-        if len(bad_names) > 0:
-            warn('%d channel names are too long, have been truncated to 15 '
-                 'characters:\n%s' % (len(bad_names), bad_names))
-            self._update_redundant()
 
     def _update_redundant(self):
         """Update the redundant entries."""
@@ -928,22 +920,24 @@ def read_info(fname, verbose=None):
     return info
 
 
-def read_bad_channels(fid, node):
+def read_bad_channels(fid, node, *, ch_names_mapping=None):
     """Read bad channels.
 
     Parameters
     ----------
     fid : file
         The file descriptor.
-
     node : dict
         The node of the FIF tree that contains info on the bad channels.
+    ch_names_mapping : dict | None
+        Short-to-long name mapping.
 
     Returns
     -------
     bads : list
         A list of bad channel's names.
     """
+    ch_names_mapping = {} if ch_names_mapping is None else ch_names_mapping
     nodes = dir_tree_find(node, FIFF.FIFFB_MNE_BAD_CHANNELS)
 
     bads = []
@@ -952,6 +946,7 @@ def read_bad_channels(fid, node):
             tag = find_tag(fid, node, FIFF.FIFF_MNE_CH_NAME_LIST)
             if tag is not None and tag.data is not None:
                 bads = tag.data.split(':')
+    bads[:] = _rename_list(bads, ch_names_mapping)
     return bads
 
 
@@ -1085,6 +1080,7 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
         elif kind == FIFF.FIFF_MNE_KIT_SYSTEM_ID:
             tag = read_tag(fid, pos)
             kit_system_id = int(tag.data)
+    ch_names_mapping = _read_extended_ch_info(chs, meas_info, fid)
 
     # Check that we have everything we need
     if nchan is None:
@@ -1138,13 +1134,14 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
                 acq_stim = tag.data
 
     #   Load the SSP data
-    projs = _read_proj(fid, meas_info)
+    projs = _read_proj(fid, meas_info, ch_names_mapping=ch_names_mapping)
 
     #   Load the CTF compensation data
-    comps = read_ctf_comp(fid, meas_info, chs)
+    comps = read_ctf_comp(
+        fid, meas_info, chs, ch_names_mapping=ch_names_mapping)
 
     #   Load the bad channel list
-    bads = read_bad_channels(fid, meas_info)
+    bads = read_bad_channels(fid, meas_info, ch_names_mapping=ch_names_mapping)
 
     #
     #   Put the data together
@@ -1434,6 +1431,48 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
     return info, meas
 
 
+def _read_extended_ch_info(chs, parent, fid):
+    ch_infos = dir_tree_find(parent, FIFF.FIFFB_CH_INFO)
+    if len(ch_infos) == 0:
+        return
+    _check_option('length of channel infos', len(ch_infos), [len(chs)])
+    logger.info('    Reading extended channel information')
+
+    # Here we assume that ``remap`` is in the same order as the channels
+    # themselves, which is hopefully safe enough.
+    ch_names_mapping = dict()
+    for new, ch in zip(ch_infos, chs):
+        for k in range(new['nent']):
+            kind = new['directory'][k].kind
+            try:
+                key, cast = _CH_READ_MAP[kind]
+            except KeyError:
+                # This shouldn't happen if we're up to date with the FIFF
+                # spec
+                warn(f'Discarding extra channel information kind {kind}')
+                continue
+            assert key in ch
+            data = read_tag(fid, new['directory'][k].pos).data
+            if data is not None:
+                data = cast(data)
+                if key == 'ch_name':
+                    ch_names_mapping[ch[key]] = data
+                ch[key] = data
+        _update_ch_info_named(ch)
+    # we need to return ch_names_mapping so that we can also rename the
+    # bad channels
+    return ch_names_mapping
+
+
+def _rename_comps(comps, ch_names_mapping):
+    if not (comps and ch_names_mapping):
+        return
+    for comp in comps:
+        data = comp['data']
+        for key in ('row_names', 'col_names'):
+            data[key][:] = _rename_list(data[key], ch_names_mapping)
+
+
 def _ensure_meas_date_none_or_dt(meas_date):
     if meas_date is None or np.array_equal(meas_date, DATE_NONE):
         meas_date = None
@@ -1600,12 +1639,14 @@ def write_meas_info(fid, info, data_type=None, reset_range=True):
         write_coord_trans(fid, info['dev_ctf_t'])
 
     #   Projectors
-    _write_proj(fid, info['projs'])
+    ch_names_mapping = _make_ch_names_mapping(info['chs'])
+    _write_proj(fid, info['projs'], ch_names_mapping=ch_names_mapping)
 
     #   Bad channels
     if len(info['bads']) > 0:
+        bads = _rename_list(info['bads'], ch_names_mapping)
         start_block(fid, FIFF.FIFFB_MNE_BAD_CHANNELS)
-        write_name_list(fid, FIFF.FIFF_MNE_CH_NAME_LIST, info['bads'])
+        write_name_list(fid, FIFF.FIFF_MNE_CH_NAME_LIST, bads)
         end_block(fid, FIFF.FIFFB_MNE_BAD_CHANNELS)
 
     #   General
@@ -1639,14 +1680,7 @@ def write_meas_info(fid, info, data_type=None, reset_range=True):
         write_string(fid, FIFF.FIFF_XPLOTTER_LAYOUT, info['xplotter_layout'])
 
     #  Channel information
-    for k, c in enumerate(info['chs']):
-        #   Scan numbers may have been messed up
-        c = deepcopy(c)
-        c['scanno'] = k + 1
-        # for float/double, the "range" param is unnecessary
-        if reset_range is True:
-            c['range'] = 1.0
-        write_ch_info(fid, c)
+    _write_ch_infos(fid, info['chs'], reset_range, ch_names_mapping)
 
     # Subject information
     if info.get('subject_info') is not None:
@@ -1717,7 +1751,11 @@ def write_meas_info(fid, info, data_type=None, reset_range=True):
         del hs
 
     #   CTF compensation info
-    write_ctf_comp(fid, info['comps'])
+    comps = info['comps']
+    if ch_names_mapping:
+        comps = deepcopy(comps)
+        _rename_comps(comps, ch_names_mapping)
+    write_ctf_comp(fid, comps)
 
     #   KIT system ID
     if info.get('kit_system_id') is not None:
@@ -2306,11 +2344,27 @@ def _bad_chans_comp(info, ch_names):
     return False, missing_ch_names
 
 
-_dig_cast = {'kind': int, 'ident': int, 'r': lambda x: x, 'coord_frame': int}
-_ch_cast = {'scanno': int, 'logno': int, 'kind': int,
-            'range': float, 'cal': float, 'coil_type': int,
-            'loc': lambda x: x, 'unit': int, 'unit_mul': int,
-            'ch_name': lambda x: x, 'coord_frame': int}
+_DIG_CAST = dict(
+    kind=int, ident=int, r=lambda x: x, coord_frame=int)
+# key -> const, cast, write
+_CH_INFO_MAP = OrderedDict(
+    scanno=(FIFF.FIFF_CH_SCAN_NO, int, write_int),
+    logno=(FIFF.FIFF_CH_LOGICAL_NO, int, write_int),
+    kind=(FIFF.FIFF_CH_KIND, int, write_int),
+    range=(FIFF.FIFF_CH_RANGE, float, write_float),
+    cal=(FIFF.FIFF_CH_CAL, float, write_float),
+    coil_type=(FIFF.FIFF_CH_COIL_TYPE, int, write_int),
+    loc=(FIFF.FIFF_CH_LOC, lambda x: x, write_float),
+    unit=(FIFF.FIFF_CH_UNIT, int, write_int),
+    unit_mul=(FIFF.FIFF_CH_UNIT_MUL, int, write_int),
+    ch_name=(FIFF.FIFF_CH_DACQ_NAME, str, write_string),
+    coord_frame=(FIFF.FIFF_CH_COORD_FRAME, int, write_int),
+)
+# key -> cast
+_CH_CAST = OrderedDict((key, val[1]) for key, val in _CH_INFO_MAP.items())
+# const -> key, cast
+_CH_READ_MAP = OrderedDict((val[0], (key, val[1]))
+                           for key, val in _CH_INFO_MAP.items())
 
 
 @contextlib.contextmanager
@@ -2320,8 +2374,8 @@ def _writing_info_hdf5(info):
     orig_chs = info['chs']
     try:
         if orig_dig is not None and len(orig_dig) > 0:
-            info['dig'] = _dict_pack(info['dig'], _dig_cast)
-        info['chs'] = _dict_pack(info['chs'], _ch_cast)
+            info['dig'] = _dict_pack(info['dig'], _DIG_CAST)
+        info['chs'] = _dict_pack(info['chs'], _CH_CAST)
         info['chs']['ch_name'] = np.char.encode(
             info['chs']['ch_name'], encoding='utf8')
         yield
@@ -2341,3 +2395,38 @@ def _dict_unpack(obj, casts):
     n = len(obj[list(casts)[0]])
     return [{key: cast(obj[key][ii]) for key, cast in casts.items()}
             for ii in range(n)]
+
+
+def _make_ch_names_mapping(chs):
+    orig_ch_names = [c['ch_name'] for c in chs]
+    ch_names = orig_ch_names.copy()
+    _unique_channel_names(ch_names, max_length=15, verbose='error')
+    ch_names_mapping = dict()
+    if orig_ch_names != ch_names:
+        ch_names_mapping.update(zip(orig_ch_names, ch_names))
+    return ch_names_mapping
+
+
+def _write_ch_infos(fid, chs, reset_range, ch_names_mapping):
+    ch_names_mapping = dict() if ch_names_mapping is None else ch_names_mapping
+    for k, c in enumerate(chs):
+        #   Scan numbers may have been messed up
+        c = c.copy()
+        c['ch_name'] = ch_names_mapping.get(c['ch_name'], c['ch_name'])
+        assert len(c['ch_name']) <= 15
+        c['scanno'] = k + 1
+        # for float/double, the "range" param is unnecessary
+        if reset_range:
+            c['range'] = 1.0
+        write_ch_info(fid, c)
+    # only write new-style channel information if necessary
+    if len(ch_names_mapping):
+        logger.info(
+            '    Writing channel names to FIF truncated to 15 characters '
+            'with remapping')
+        for ch in chs:
+            start_block(fid, FIFF.FIFFB_CH_INFO)
+            assert set(ch) == set(_CH_INFO_MAP)
+            for (key, (const, _, write)) in _CH_INFO_MAP.items():
+                write(fid, const, ch[key])
+            end_block(fid, FIFF.FIFFB_CH_INFO)

--- a/mne/io/tag.py
+++ b/mne/io/tag.py
@@ -356,12 +356,16 @@ def _read_ch_info_struct(fid, tag, shape, rlims):
     ch_name = ch_name[:np.argmax(ch_name == b'')].tobytes()
     d['ch_name'] = ch_name.decode()
     # coil coordinate system definition
+    _update_ch_info_named(d)
+    return d
+
+
+def _update_ch_info_named(d):
     d['coord_frame'] = _ch_coord_dict.get(d['kind'], FIFF.FIFFV_COORD_UNKNOWN)
     d['kind'] = _ch_kind_named.get(d['kind'], d['kind'])
     d['coil_type'] = _ch_coil_type_named.get(d['coil_type'], d['coil_type'])
     d['unit'] = _ch_unit_named.get(d['unit'], d['unit'])
     d['unit_mul'] = _ch_unit_mul_named.get(d['unit_mul'], d['unit_mul'])
-    return d
 
 
 def _read_old_pack(fid, tag, shape, rlims):
@@ -501,3 +505,7 @@ def has_tag(node, kind):
         if d.kind == kind:
             return True
     return False
+
+
+def _rename_list(bads, ch_names_mapping):
+    return [ch_names_mapping.get(bad, bad) for bad in bads]

--- a/mne/io/tests/test_constants.py
+++ b/mne/io/tests/test_constants.py
@@ -19,11 +19,12 @@ from mne.utils import _fetch_file, requires_good_network
 
 
 # https://github.com/mne-tools/fiff-constants/commits/master
-commit = '5bd84d224de502bee66f70b7867b8f45b45264c1'
+REPO = 'mne-tools'
+COMMIT = '5bd84d224de502bee66f70b7867b8f45b45264c1'
 
 # These are oddities that we won't address:
 iod_dups = (355, 359)  # these are in both MEGIN and MNE files
-tag_dups = (3501, 3507)  # in both MEGIN and MNE files
+tag_dups = (3501,)  # in both MEGIN and MNE files
 
 _dir_ignore_names = ('clear', 'copy', 'fromkeys', 'get', 'items', 'keys',
                      'pop', 'popitem', 'setdefault', 'update', 'values',
@@ -81,8 +82,8 @@ def test_constants(tmpdir):
     """Test compensation."""
     tmpdir = str(tmpdir)  # old pytest...
     dest = op.join(tmpdir, 'fiff.zip')
-    _fetch_file('https://codeload.github.com/mne-tools/fiff-constants/zip/' +
-                commit, dest)
+    _fetch_file('https://codeload.github.com/'
+                f'{REPO}/fiff-constants/zip/{COMMIT}', dest)
     names = list()
     with zipfile.ZipFile(dest, 'r') as ff:
         for name in ff.namelist():

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -415,7 +415,7 @@ def test_set_bipolar_reference(inst_type):
                                   ch_info={'kind': FIFF.FIFFV_MEG_CH},
                                   verbose='error')
     assert (not reref.info['custom_ref_applied'])
-    assert ('MEG 0111-MEG 0112'[:15] in reref.ch_names)
+    assert ('MEG 0111-MEG 0112' in reref.ch_names)
 
     # Test a battery of invalid inputs
     pytest.raises(ValueError, set_bipolar_reference, inst,

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -251,7 +251,6 @@ plot_epochs_psd_topomap
 plot_raw_psd_topo
 plot_source_spectrogram
 prepare_inverse_operator
-read_bad_channels
 read_fiducials
 read_tag
 rescale

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1407,7 +1407,7 @@ on_missing : str
 
     .. versionadded:: 0.20.1
 """ % (_on_missing_base,)
-docdict['rename_channels_mapping'] = """
+docdict['rename_channels_mapping_duplicates'] = """
 mapping : dict | callable
     A dictionary mapping the old channel to a new channel name
     e.g. {'EEG061' : 'EEG161'}. Can also be a callable function
@@ -1415,6 +1415,11 @@ mapping : dict | callable
 
     .. versionchanged:: 0.10.0
        Support for a callable function.
+allow_duplicates : bool
+    If True (default False), allow duplicates, which will automatically
+    be renamed with ``-N`` at the end.
+
+    .. versionadded:: 0.22.0
 """
 
 # Brain plotting


### PR DESCRIPTION
- [x] Get things working with the block-based method
- [x] Get other projects on board (taken care of in #8348)
- [x] Get https://github.com/mne-tools/fiff-constants/pull/33/ merged
- [x] Update PR with newer `fiff-constants` commit, check `'bads'` handling/replacement
- [x] Add test where a file is written with long names, then `monkeypatch` to make the tag empty on read, ensure it can still be written and read
- [x] Add to MNE-MATLAB

Closes #8348
Closes #8312