### PR TITLE
MNT: Add brain_gc fixture to test_process_clim_plot

### DIFF
--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -750,6 +750,7 @@ def _close_all():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=DeprecationWarning)
         close_all()
+    _FIGURES.clear()
 
 
 def _get_camera_direction(focalpoint, position):

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -373,10 +373,12 @@ def test_plot_alignment(tmpdir, renderer):
 @testing.requires_testing_data
 @requires_pysurfer
 @traits_test
-def test_process_clim_plot(renderer_interactive):
+def test_process_clim_plot(renderer_interactive, brain_gc):
     """Test functionality for determining control points with stc.plot."""
+    is_pyvista = renderer_interactive._get_3d_backend() == 'pyvista'
     sample_src = read_source_spaces(src_fname)
-    kwargs = dict(subjects_dir=subjects_dir, smoothing_steps=1)
+    kwargs = dict(subjects_dir=subjects_dir, smoothing_steps=1,
+                  time_viewer=False, show_traces=False)
 
     vertices = [s['vertno'] for s in sample_src]
     n_time = 5
@@ -391,6 +393,10 @@ def test_process_clim_plot(renderer_interactive):
     stc.plot(colormap='hot', clim='auto', **kwargs)
     stc.plot(colormap='mne', clim='auto', **kwargs)
     stc.plot(clim=dict(kind='value', lims=(10, 50, 90)), figure=99, **kwargs)
+    # figure has been set so the internal ref needs to be clean to avoid
+    # lingering VTK objects in memory
+    if is_pyvista:
+        renderer_interactive.backend._FIGURES.clear()
     pytest.raises(TypeError, stc.plot, clim='auto', figure=[0], **kwargs)
 
     # Test for correct clim values

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -375,7 +375,6 @@ def test_plot_alignment(tmpdir, renderer):
 @traits_test
 def test_process_clim_plot(renderer_interactive, brain_gc):
     """Test functionality for determining control points with stc.plot."""
-    is_pyvista = renderer_interactive._get_3d_backend() == 'pyvista'
     sample_src = read_source_spaces(src_fname)
     kwargs = dict(subjects_dir=subjects_dir, smoothing_steps=1,
                   time_viewer=False, show_traces=False)
@@ -393,10 +392,6 @@ def test_process_clim_plot(renderer_interactive, brain_gc):
     stc.plot(colormap='hot', clim='auto', **kwargs)
     stc.plot(colormap='mne', clim='auto', **kwargs)
     stc.plot(clim=dict(kind='value', lims=(10, 50, 90)), figure=99, **kwargs)
-    # figure has been set so the internal ref needs to be clean to avoid
-    # lingering VTK objects in memory
-    if is_pyvista:
-        renderer_interactive.backend._FIGURES.clear()
     pytest.raises(TypeError, stc.plot, clim='auto', figure=[0], **kwargs)
 
     # Test for correct clim values


### PR DESCRIPTION
This PR adds the `brain_gc` fixture in `test_process_clim_plot` (I missed it in https://github.com/mne-tools/mne-python/pull/8427) and fixes the issues with memory:

```
_______________________________________________________________________________ ERROR at teardown of test_process_clim_plot[pyvista] _______________________________________________________________________________
mne/conftest.py:522: in brain_gc
    assert len(bad) == 0, 'VTK objects linger:\n' + '\n'.join(bad)
E   AssertionError: VTK objects linger:
E     vtkXOpenGLRenderWindow
E     vtkGenericRenderWindowInteractor
E   assert 2 == 0
E     +2
E     -0
```

It's also important for https://github.com/mne-tools/mne-python/pull/8335 (that's how I discovered the issue in the first place)