### PR TITLE
FIX: Transpose issue of CSP.plot_filters

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -26,6 +26,8 @@ Current (0.22.dev0)
 
 .. |Austin Hurst| replace:: **Austin Hurst**
 
+.. |Hongjiang Ye| replace:: **Hongjiang Ye**
+
 
 Enhancements
 ~~~~~~~~~~~~
@@ -78,6 +80,8 @@ Enhancements
 
 Bugs
 ~~~~
+- Fix a transpose issue of :func:`mne.decoding.CSP.plot_filters` (:gh:`8580` **by new contributor** |Hongjiang Ye|_)
+
 - Fix :func:`mne.io.read_raw_curry` to deal with Curry datasets that have channels that are listed in the labels file, but which are absent from the saved data file (e.g. 'Ref' channel).  Also now populates info['meas_date'] if possible (:gh:`8400` **by new contributor** |Tod Flak|_)
 
 - Fix bug with mne.io.egi.tests/test_egi.py where it mandatorily downloaded testing data when it was not necessary (:gh:`8474` **by new contributor** |Aniket Pradhan|_)

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -339,3 +339,5 @@
 .. _Victoria Peterson: https://github.com/vpeterson
 
 .. _Evan Hathaway: https://github.com/ephathaway
+
+.. _Hongjiang Ye: https://github.com/rubyyhj

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -475,7 +475,7 @@ class CSP(TransformerMixin, BaseEstimator):
         info = cp.deepcopy(info)
         info['sfreq'] = 1.
         # create an evoked
-        filters = EvokedArray(self.filters_, info, tmin=0)
+        filters = EvokedArray(self.filters_.T, info, tmin=0)
         # the call plot_topomap
         return filters.plot_topomap(
             times=components, ch_type=ch_type, vmin=vmin,


### PR DESCRIPTION
#### Reference issue
Fixes #8579.


#### What does this implement/fix?
Just add a transpose to correct the CSP filters plot.

