### PR TITLE
Detect/correct invalid HP/LP settings in EDF/BDF/GDF

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -77,6 +77,7 @@ Enhancements
 
 - `mne.preprocessing.ICA.plot_sources` now displays an `mne.preprocessing.ICA.plot_properties` window when right-clicking on component names on the y-axis (:gh:`8381` by `Daniel McCloy`_)
 
+- :func:`mne.io.read_raw_edf`, :func:`mne.io.read_raw_bdf`, and :func:`mne.io.read_raw_gdf` now detect and handle invalid highpass/lowpass filter settings (:gh:`8584` by `Clemens Brunner`_)
 
 Bugs
 ~~~~

--- a/mne/datasets/testing/__init__.py
+++ b/mne/datasets/testing/__init__.py
@@ -1,4 +1,4 @@
 """MNE testing dataset."""
 
 from ._testing import (data_path, requires_testing_data, get_version,
-                       _pytest_param, _pytest_marks)
+                       _pytest_param, _pytest_mark)

--- a/mne/datasets/testing/__init__.py
+++ b/mne/datasets/testing/__init__.py
@@ -1,4 +1,4 @@
 """MNE testing dataset."""
 
 from ._testing import (data_path, requires_testing_data, get_version,
-                       _pytest_param)
+                       _pytest_param, _pytest_marks)

--- a/mne/datasets/testing/_testing.py
+++ b/mne/datasets/testing/_testing.py
@@ -47,7 +47,7 @@ def _skip_testing_data():
 
 def requires_testing_data(func):
     """Skip testing data test."""
-    return _pytest_marks()[0](func)
+    return _pytest_mark()(func)
 
 
 def _pytest_param(*args, **kwargs):
@@ -57,10 +57,10 @@ def _pytest_param(*args, **kwargs):
     # turn anything that uses testing data into an auto-skipper by
     # setting params=[testing._pytest_param()], or by parametrizing functions
     # with testing._pytest_param(whatever)
-    return pytest.param(*args, **kwargs, marks=_pytest_marks())
+    return pytest.param(*args, **kwargs, marks=_pytest_mark())
 
 
-def _pytest_marks():
+def _pytest_mark():
     import pytest
-    return [pytest.mark.skipif(
-        _skip_testing_data(), reason='Requires testing dataset')]
+    return pytest.mark.skipif(
+        _skip_testing_data(), reason='Requires testing dataset')

--- a/mne/datasets/testing/_testing.py
+++ b/mne/datasets/testing/_testing.py
@@ -47,9 +47,7 @@ def _skip_testing_data():
 
 def requires_testing_data(func):
     """Skip testing data test."""
-    import pytest
-    return pytest.mark.skipif(_skip_testing_data(),
-                              reason='Requires testing dataset')(func)
+    return _pytest_marks()[0](func)
 
 
 def _pytest_param(*args, **kwargs):
@@ -59,5 +57,10 @@ def _pytest_param(*args, **kwargs):
     # turn anything that uses testing data into an auto-skipper by
     # setting params=[testing._pytest_param()], or by parametrizing functions
     # with testing._pytest_param(whatever)
-    return pytest.param(*args, **kwargs, marks=pytest.mark.skipif(
-        _skip_testing_data(), reason='Requires testing dataset'))
+    return pytest.param(*args, **kwargs, marks=_pytest_marks())
+
+
+def _pytest_marks():
+    import pytest
+    return [pytest.mark.skipif(
+        _skip_testing_data(), reason='Requires testing dataset')]

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -348,13 +348,6 @@ def _read_header(fname, exclude):
     else:
         raise NotImplementedError(f'Only GDF, EDF, and BDF files are supported'
                                   f', got {ext}.')
-    hi, lo = edf_info['highpass'], edf_info['lowpass']
-    idx = hi > lo
-    if idx.any():
-        warn(f'Highpass cutoff frequency {hi} is greater than lowpass cutoff '
-             f'frequency {lo}. Setting both values to None.')
-        edf_info['highpass'][idx] = np.nan
-        edf_info['lowpass'][idx] = np.nan
     return edf_info, orig_units
 
 
@@ -480,6 +473,13 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
              'setting will be stored.')
     if np.isnan(info['lowpass']):
         info['lowpass'] = info['sfreq'] / 2.
+
+    if info['highpass'] > info['lowpass']:
+        warn(f'Highpass cutoff frequency {info["highpass"]} is greater than '
+             f'lowpass cutoff frequency {info["lowpass"]}. '
+             'Setting both values to None.')
+        info['highpass'] = None
+        info['lowpass'] = None
 
     # Some keys to be consistent with FIF measurement info
     info['description'] = None

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -342,13 +342,12 @@ def _read_header(fname, exclude):
     ext = os.path.splitext(fname)[1][1:].lower()
     logger.info('%s file detected' % ext.upper())
     if ext in ('bdf', 'edf'):
-        edf_info, orig_units = _read_edf_header(fname, exclude)
+        return _read_edf_header(fname, exclude)
     elif ext == 'gdf':
-        edf_info, orig_units = _read_gdf_header(fname, exclude), None
+        return _read_gdf_header(fname, exclude), None
     else:
-        raise NotImplementedError(f'Only GDF, EDF, and BDF files are supported'
-                                  f', got {ext}.')
-    return edf_info, orig_units
+        raise NotImplementedError(
+            f'Only GDF, EDF, and BDF files are supported, got {ext}.')
 
 
 def _get_info(fname, stim_channel, eog, misc, exclude, preload):
@@ -476,10 +475,10 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
 
     if info['highpass'] > info['lowpass']:
         warn(f'Highpass cutoff frequency {info["highpass"]} is greater than '
-             f'lowpass cutoff frequency {info["lowpass"]}. '
-             'Setting both values to None.')
-        info['highpass'] = None
-        info['lowpass'] = None
+             f'lowpass cutoff frequency {info["lowpass"]}, '
+             'setting values to 0 and Nyquist.')
+        info['highpass'] = 0.
+        info['lowpass'] = info['sfreq'] / 2.
 
     # Some keys to be consistent with FIF measurement info
     info['description'] = None

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -476,12 +476,12 @@ def _hp_lp_rev(*args, **kwargs):
 @pytest.mark.filterwarnings('ignore:.*too long.*:RuntimeWarning')
 @pytest.mark.parametrize('fname, lo, hi, warns', [
     (edf_path, 256, 0, False),
-    (edf_stim_resamp_path, 256, 0, True),
     (edf_uneven_path, 50, 0, False),
     (edf_stim_channel_path, 64, 0, False),
     pytest.param(edf_overlap_annot_path, 64, 0, False, marks=td_mark),
     pytest.param(edf_reduced, 256, 0, False, marks=td_mark),
-    pytest.param(test_generator_edf, 100, 0, False, marks=td_mark)
+    pytest.param(test_generator_edf, 100, 0, False, marks=td_mark),
+    pytest.param(edf_stim_resamp_path, 256, 0, True, marks=td_mark),
 ])
 def test_hp_lp_reversed(fname, lo, hi, warns, monkeypatch):
     """Test HP/LP reversed (gh-8584)."""

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -8,6 +8,7 @@
 #
 # License: BSD (3-clause)
 
+from functools import partial
 import os.path as op
 import inspect
 
@@ -22,15 +23,15 @@ from mne import pick_types, Annotations
 from mne.datasets import testing
 from mne.fixes import nullcontext
 from mne.utils import requires_pandas
-from mne.io import read_raw_edf, read_raw_bdf, read_raw_fif, edf
+from mne.io import read_raw_edf, read_raw_bdf, read_raw_fif, edf, read_raw_gdf
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.edf.edf import (_get_edf_default_event_id, _read_annotations_edf,
                             _read_ch, _parse_prefilter_string, _edf_str_int,
-                            _read_edf_header)
+                            _read_edf_header, _read_header)
 from mne.io.pick import channel_indices_by_type, get_channel_type_constants
 from mne.annotations import events_from_annotations, read_annotations
 
-testing_marks = testing._pytest_marks()
+td_mark = testing._pytest_mark()
 
 FILE = inspect.getfile(inspect.currentframe())
 data_dir = op.join(op.dirname(op.abspath(FILE)), 'data')
@@ -478,9 +479,9 @@ def _hp_lp_rev(*args, **kwargs):
     (edf_stim_resamp_path, 256, 0, True),
     (edf_uneven_path, 50, 0, False),
     (edf_stim_channel_path, 64, 0, False),
-    pytest.param(edf_overlap_annot_path, 64, 0, False, marks=testing_marks),
-    pytest.param(edf_reduced, 256, 0, False, marks=testing_marks),
-    pytest.param(test_generator_edf, 100, 0, False, marks=testing_marks)
+    pytest.param(edf_overlap_annot_path, 64, 0, False, marks=td_mark),
+    pytest.param(edf_reduced, 256, 0, False, marks=td_mark),
+    pytest.param(test_generator_edf, 100, 0, False, marks=td_mark)
 ])
 def test_hp_lp_reversed(fname, lo, hi, warns, monkeypatch):
     """Test HP/LP reversed (gh-8584)."""
@@ -491,7 +492,7 @@ def test_hp_lp_reversed(fname, lo, hi, warns, monkeypatch):
     monkeypatch.setattr(edf.edf, '_read_edf_header', _hp_lp_rev)
     if warns:
         ctx = pytest.warns(RuntimeWarning, match='greater than lowpass')
-        new_lo = new_hi = None
+        new_lo, new_hi = raw.info['sfreq'] / 2., 0.
     else:
         ctx = nullcontext()
         new_lo, new_hi = lo, hi
@@ -499,3 +500,11 @@ def test_hp_lp_reversed(fname, lo, hi, warns, monkeypatch):
         raw = read_raw_edf(fname)
     assert raw.info['lowpass'] == new_lo
     assert raw.info['highpass'] == new_hi
+
+
+def test_degenerate():
+    """Test checking of some bad inputs."""
+    for func in (read_raw_edf, read_raw_bdf, read_raw_gdf,
+                 partial(_read_header, exclude=())):
+        with pytest.raises(NotImplementedError, match='Only.*txt.*'):
+            func(edf_txt_stim_channel_path)


### PR DESCRIPTION
Fixes #8582. EDF/BDF/GDF files can contain invalid LP/HP filter settings (cutoff frequencies for HP can be greater than the one for LP). This PR (1) issues a warning and (2) sets HP/LP values for affected channels to `None`.