### PR TITLE
MRG, FIX, VIZ: correctly triage extrapolation mask for topos based on channel type

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -154,6 +154,8 @@ Bugs
 
 - Fix reading GDF files with excluded channels in :func:`mne.io.read_raw_gdf` (:gh:`8520` by `Clemens Brunner`_)
 
+- Fix automatic selection of extrapolation mask type from channel type when plotting field maps (:gh:`8589` by `Daniel McCloy`_)
+
 - Fix bug in :func:`mne.viz.set_3d_title` where 3D plot could have multiple titles that overlap (:gh:`8564` by `Guillaume Favelier`_)
 
 - Fix bug in :func:`mne.viz.set_3d_view` where plotter is not updated properly causing camera issues in the doc (:gh:`8564` by `Guillaume Favelier`_)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1771,7 +1771,8 @@ def _plot_topomap_multi_cbar(data, pos, ax, title=None, unit=None, vmin=None,
         ax.set_title(title, fontsize=10)
     im, _ = plot_topomap(data, pos, vmin=vmin, vmax=vmax, axes=ax,
                          cmap=cmap[0], image_interp='bilinear', contours=0,
-                         outlines=outlines, show=False, sphere=sphere)
+                         outlines=outlines, show=False, sphere=sphere,
+                         ch_type=ch_type)
 
     if colorbar:
         cbar, cax = _add_colorbar(ax, im, cmap, pad=0.25, title=None,

--- a/tutorials/epochs/plot_20_visualize_epochs.py
+++ b/tutorials/epochs/plot_20_visualize_epochs.py
@@ -139,10 +139,9 @@ epochs['auditory'].plot_psd(picks='eeg')
 
 ###############################################################################
 # It is also possible to plot spectral estimates across sensors as a scalp
-# topography, using `~mne.Epochs.plot_psd_topomap`. The default
-# parameters will plot five frequency bands (δ, θ, α, β, γ), will compute power
-# based on magnetometer channels, and will plot the power estimates in
-# decibels:
+# topography, using `~mne.Epochs.plot_psd_topomap`. The default parameters will
+# plot five frequency bands (δ, θ, α, β, γ), will compute power based on
+# magnetometer channels, and will plot the power estimates in decibels:
 
 epochs['visual/right'].plot_psd_topomap()
 


### PR DESCRIPTION
failure to pass through `ch_type` was the culprit; the underlying plotting function thought everything was 'eeg'.