### PR TITLE
WIP: Allow off-screen rendering

### DIFF
--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -656,3 +656,11 @@ def _create_testing_brain(hemi, surf='inflated', src='surface', size=300,
         clim=dict(kind='value', lims=(fmin, fmid, fmax)), src=sample_src,
         **kwargs)
     return brain_data
+
+
+@testing.requires_testing_data
+def test_off_screen(renderer, brain_gc):
+    """Test off-screen support."""
+    stc = read_source_estimate(fname_stc)
+    brain = stc.plot(subject='sample', subjects_dir=subjects_dir)
+    brain.close()


### PR DESCRIPTION
@GuillaumeFavelier while working on #8598 I noticed that I had to use `renderer_interactive`, but I don't see in principle why this should be necessary instead of just `renderer`. It seems like off-screen plotting should produce the same results as normal plotting. In other words, I think it's okay if widgets and such show up in the screenshots, but they shouldn't break anything by being there. The test added here shows that things are broken:

<details>

```
$ pytest mne/viz/_brain/tests/test_brain.py -k off_screen
...
mne/viz/_brain/tests/test_brain.py .2020-12-03 09:26:46.247 (   2.714s) [        42BFD740]  vtkAbstractWidget.cxx:117    ERR| vtkSliderWidget (0x5494c00): The interactor must be set prior to enabling the widget
2020-12-03 09:26:46.248 (   2.715s) [        42BFD740]  vtkAbstractWidget.cxx:117    ERR| vtkSliderWidget (0x80c41b0): The interactor must be set prior to enabling the widget
...
2020-12-03 09:26:46.251 (   2.718s) [        42BFD740]  vtkAbstractWidget.cxx:117    ERR| vtkSliderWidget (0x8185e50): The interactor must be set prior to enabling the widget
FE                                                                                                                                       [100%]
...
Traceback (most recent call last):
  File "/home/larsoner/python/mne-python/mne/viz/_brain/_brain.py", line 45, in safe_event
    return fun(*args, **kwargs)
  File "/home/larsoner/python/mne-python/mne/viz/_brain/_brain.py", line 448, in _clean
    self._clear_callbacks()
  File "/home/larsoner/python/mne-python/mne/viz/_brain/_brain.py", line 1357, in _clear_callbacks
    _remove_picking_callback(self._iren, self.plotter.picker)
  File "/home/larsoner/.local/lib/python3.8/site-packages/vtkmodules/qt/QVTKRenderWindowInteractor.py", line 335, in __getattr__
    raise AttributeError(self.__class__.__name__ +
AttributeError: BackgroundPlotter has no attribute named picker
===================================================================================== FAILURES =====================================================================================
_____________________________________________________________________________ test_off_screen[pyvista] _____________________________________________________________________________
mne/viz/_brain/tests/test_brain.py:665: in test_off_screen
    brain = stc.plot(subject='sample', subjects_dir=subjects_dir)
mne/source_estimate.py:653: in plot
    brain = plot_source_estimates(
<decorator-gen-139>:24: in plot_source_estimates
    ???
mne/viz/_3d.py:1794: in plot_source_estimates
    return _plot_stc(
mne/viz/_3d.py:1973: in _plot_stc
    brain.setup_time_viewer(time_viewer=time_viewer,
mne/viz/_brain/_brain.py:419: in setup_time_viewer
    self._configure_point_picking()
mne/viz/_brain/_brain.py:929: in _configure_point_picking
    _update_picking_callback(
mne/viz/backends/_pyvista.py:930: in _update_picking_callback
    interactor.AddObserver(
E   AttributeError: 'NoneType' object has no attribute 'AddObserver'
```

</details>

I can work on doing things like `if interactor is not None:` and making it so that widgets only get enabled if there actually is an interactor. Sound good?

Admittedly having the widgets and such show up when in off-screen mode is a bit weird, but really I don't see a reason not to support having them at least show up in both modes. It could also for example make it so we no longer need `renderer_interactive` at all, I think, which would be nice. This would make it so that plot windows no longer pop up (and steal focus for me at least) during testing, too...