### PR TITLE
MRG, BUG: find_ecg_events() didn't respect tstart when calculating average heart rate

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -163,6 +163,8 @@ Bugs
 
 - Fix bug in :func:`mne.viz.set_3d_view` where plotter is not updated properly causing camera issues in the doc (:gh:`8564` by `Guillaume Favelier`_)
 
+- :func:`mne.preprocessing.find_ecg_events` didn't take the ``tstart`` parameter value into account when calculating the average heart rate (:gh:`8605` by `Richard Höchenberger`_)
+
 API changes
 ~~~~~~~~~~~
 

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -231,8 +231,9 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
     ecg_events = remap[ecg_events]
 
     n_events = len(ecg_events)
-    minutes = len(ecg) / (raw.info['sfreq'] * 60.) - (tstart / 60.)
-    average_pulse = n_events / minutes
+    duration_sec = len(ecg) / raw.info['sfreq'] - tstart
+    duration_min = duration_sec / 60.
+    average_pulse = n_events / duration_min
     logger.info("Number of ECG events detected : %d (average pulse %d / "
                 "min.)" % (n_events, average_pulse))
 

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -136,7 +136,7 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
                     l_freq=5, h_freq=35, qrs_threshold='auto',
                     filter_length='10s', return_ecg=False,
                     reject_by_annotation=True, verbose=None):
-    """Find ECG peaks.
+    """Find ECG events by localizing the R wave peaks.
 
     Parameters
     ----------
@@ -146,9 +146,10 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
         The index to assign to found events.
     ch_name : None | str
         The name of the channel to use for ECG peak detection.
-        If None (default), a synthetic ECG channel is created from
-        cross channel average. Synthetic channel can only be created from
-        'meg' channels.
+        If ``None`` (default), ECG channel is used if present. If ``None`` and
+        **no** ECG channel is present, a synthetic ECG channel is created from
+        cross-channel average. This synthetic channel can only be created from
+        MEG channels.
     tstart : float
         Start detection after tstart seconds. Useful when beginning
         of run is noisy.
@@ -173,7 +174,7 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
     Returns
     -------
     ecg_events : array
-        Events.
+        The events corresponding to the peaks of the R waves.
     ch_ecg : string
         Name of channel used.
     average_pulse : float
@@ -212,7 +213,7 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
             verbose=use_verbose))
     ecg = np.concatenate(ecgs)
 
-    # detecting QRS and generating event file. Since not user-controlled, don't
+    # detecting QRS and generating events. Since not user-controlled, don't
     # output filter params here (hardcode verbose=False)
     ecg_events = qrs_detector(raw.info['sfreq'], ecg, tstart=tstart,
                               thresh_value=qrs_threshold, l_freq=None,
@@ -281,7 +282,7 @@ def create_ecg_epochs(raw, ch_name=None, event_id=999, picks=None, tmin=-0.5,
     raw : instance of Raw
         The raw data.
     ch_name : None | str
-        The name of the channel to use for ECG peak detection.
+        The name of the channel to use for ECG R wave peak detection.
         If None (default), ECG channel is used if present. If None and no
         ECG channel is present, a synthetic ECG channel is created from
         cross channel average. Synthetic channel can only be created from
@@ -339,7 +340,7 @@ def create_ecg_epochs(raw, ch_name=None, event_id=999, picks=None, tmin=-0.5,
     Returns
     -------
     ecg_epochs : instance of Epochs
-        Data epoched around ECG r-peaks.
+        Data epoched around ECG R wave peaks.
 
     See Also
     --------

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -231,7 +231,7 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
     ecg_events = remap[ecg_events]
 
     n_events = len(ecg_events)
-    minutes = len(ecg) / (raw.info['sfreq'] * 60.)
+    minutes = len(ecg) / (raw.info['sfreq'] * 60.) - (tstart / 60.)
     average_pulse = n_events / minutes
     logger.info("Number of ECG events detected : %d (average pulse %d / "
                 "min.)" % (n_events, average_pulse))

--- a/mne/preprocessing/tests/test_ecg.py
+++ b/mne/preprocessing/tests/test_ecg.py
@@ -79,11 +79,11 @@ def test_find_ecg():
     assert 'ECG-SYN' not in ecg_epochs.ch_names
 
 
-def test_find_ecg_events_tstart():
+@pytest.mark.parametrize('tstart', (0, 12))
+def test_find_ecg_events_tstart(tstart):
     """Ensure tstart is taken into account when calculating avg heart rate."""
     raw = read_raw_fif(raw_fname, preload=False)
     event_id = 999
-    tstart = raw.times[-1] / 2
     events, _, average_hr = find_ecg_events(raw=raw, event_id=event_id,
                                             tstart=tstart)
 

--- a/mne/preprocessing/tests/test_ecg.py
+++ b/mne/preprocessing/tests/test_ecg.py
@@ -1,5 +1,5 @@
 import os.path as op
-
+from numpy.testing import assert_allclose
 import pytest
 from mne.io import read_raw_fif
 from mne import pick_types
@@ -90,7 +90,7 @@ def test_find_ecg_events_tstart():
     duration_in_sec = len(raw) / raw.info['sfreq'] - tstart
     duration_in_min = duration_in_sec / 60
     average_hr_expected = len(events) / duration_in_min
-    assert average_hr == average_hr_expected
+    assert_allclose(average_hr, average_hr_expected)
 
 
 run_tests_if_main()

--- a/mne/preprocessing/tests/test_ecg.py
+++ b/mne/preprocessing/tests/test_ecg.py
@@ -83,9 +83,7 @@ def test_find_ecg():
 def test_find_ecg_events_tstart(tstart):
     """Ensure tstart is taken into account when calculating avg heart rate."""
     raw = read_raw_fif(raw_fname, preload=False)
-    event_id = 999
-    events, _, average_hr = find_ecg_events(raw=raw, event_id=event_id,
-                                            tstart=tstart)
+    events, _, average_hr = find_ecg_events(raw=raw, tstart=tstart)
 
     duration_in_sec = len(raw) / raw.info['sfreq'] - tstart
     duration_in_min = duration_in_sec / 60

--- a/mne/preprocessing/tests/test_ecg.py
+++ b/mne/preprocessing/tests/test_ecg.py
@@ -25,8 +25,8 @@ def test_find_ecg():
     raw_bad.annotations.append(raw.first_samp / raw.info['sfreq'],
                                1. / raw.info['sfreq'], 'BAD_values')
 
-    for ch_name, tstart in zip(['MEG 1531', None],
-                               [raw.times[-1] / 2, 0]):
+    for ch_name, tstart in zip(['MEG 1531', None, None],
+                               [raw.times[-1] / 2, raw.times[-1] / 2, 0]):
         events, ch_ECG, average_pulse, ecg = find_ecg_events(
             raw, event_id=999, ch_name=ch_name, tstart=tstart,
             return_ecg=True)

--- a/mne/preprocessing/tests/test_ecg.py
+++ b/mne/preprocessing/tests/test_ecg.py
@@ -79,4 +79,18 @@ def test_find_ecg():
     assert 'ECG-SYN' not in ecg_epochs.ch_names
 
 
+def test_find_ecg_events_tstart():
+    """Ensure tstart is taken into account when calculating avg heart rate."""
+    raw = read_raw_fif(raw_fname, preload=False)
+    event_id = 999
+    tstart = raw.times[-1] / 2
+    events, _, average_hr = find_ecg_events(raw=raw, event_id=event_id,
+                                            tstart=tstart)
+
+    duration_in_sec = len(raw) / raw.info['sfreq'] - tstart
+    duration_in_min = duration_in_sec / 60
+    average_hr_expected = len(events) / duration_in_min
+    assert average_hr == average_hr_expected
+
+
 run_tests_if_main()


### PR DESCRIPTION
MWE:
```python
import os
import mne
mne.set_log_level('error')

sample_data_folder = mne.datasets.sample.data_path()
sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
                                    'sample_audvis_raw.fif')
raw = mne.io.read_raw_fif(sample_data_raw_file)

_, _, avg_hr = mne.preprocessing.find_ecg_events(raw=raw)
print(avg_hr)

_, _, avg_hr = mne.preprocessing.find_ecg_events(raw=raw, tstart=120)
print(avg_hr)
```

This PR:
```
61.78988748454362
63.91261368728932
```

`master`:
```
61.78988748454361
36.296157683228415
```