### PR TITLE
MRG, ENH: Add DICS bias tests

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -101,7 +101,7 @@ Bugs
 
 - Fix bug with reading EDF and KIT files on big endian architectures such as s390x (:gh:`8618` by `Eric Larson`_)
 
-- Fix bug with :func:`mne.beamformer.apply_lcmv` where the whitener was not properly applied (:gh:`8610` by `Eric Larson`_)
+- Fix bug with :func:`mne.beamformer.apply_dics` where the whitener was not properly applied (:gh:`8610` by `Eric Larson`_)
 
 - Fix bug with `~mne.viz.plot_epochs_image` when ``order`` is supplied and multiple conditions are plotted (:gh:`8377` by `Daniel McCloy`_ )
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -101,6 +101,8 @@ Bugs
 
 - Fix bug with reading EDF and KIT files on big endian architectures such as s390x (:gh:`8618` by `Eric Larson`_)
 
+- Fix bug with :func:`mne.beamformer.apply_lcmv` where the whitener was not properly applied (:gh:`8610` by `Eric Larson`_)
+
 - Fix bug with `~mne.viz.plot_epochs_image` when ``order`` is supplied and multiple conditions are plotted (:gh:`8377` by `Daniel McCloy`_ )
 
 - Fix bug with :func:`mne.viz.plot_source_estimates` when using the PyVista backend where singleton time points were not handled properly (:gh:`8285` by `Eric Larson`_)

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -507,3 +507,15 @@ def read_beamformer(fname):
                   for arg in ('data', 'names', 'bads', 'projs', 'nfree', 'eig',
                               'eigvec', 'method', 'loglik')])
     return Beamformer(beamformer)
+
+
+def _proj_whiten_data(M, proj, filters):
+    if filters.get('is_ssp', True):
+        # check whether data and filter projs match
+        _check_proj_match(proj, filters)
+        if filters['whitener'] is None:
+            M = np.dot(filters['proj'], M)
+
+    if filters['whitener'] is not None:
+        M = np.dot(filters['whitener'], M)
+    return M

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -94,7 +94,7 @@ def _prepare_beamformer_input(info, forward, label=None, pick_ori=None,
         orient_std = np.ones(gain.shape[1])
 
     # Get the projector
-    proj, ncomp, _ = make_projector(
+    proj, _, _ = make_projector(
         info_picked['projs'], info_picked['ch_names'])
     return (is_free_ori, info_picked, proj, vertno, gain, whitener, nn,
             orient_std)
@@ -141,16 +141,9 @@ def _sym_inv_sm(x, reduce_rank, inversion, sk):
     return x_inv
 
 
-def _restore_pos_semidef(Cm):
-    # Restore to positive semi-definite, as
-    # (negative eigenvalues are errant / due to massive scaling differences)
-    s, u = np.linalg.eigh(Cm)
-    Cm[:] = np.dot(u * np.abs(s), u.T.conj())
-    return Cm
-
-
 def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
-                        reduce_rank, rank, inversion, nn, orient_std):
+                        reduce_rank, rank, inversion, nn, orient_std,
+                        whitener):
     """Compute a spatial beamformer filter (LCMV or DICS).
 
     For more detailed information on the parameters, see the docstrings of
@@ -180,6 +173,8 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
         The source normals.
     orient_std : ndarray, shape (n_dipoles,)
         The std of the orientation prior used in weighting the lead fields.
+    whitener : ndarray, shape (n_channels, n_channels)
+        The whitener.
 
     Returns
     -------
@@ -189,6 +184,13 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
     _check_option('weight_norm', weight_norm,
                   ['unit-noise-gain-invariant', 'unit-noise-gain',
                    'nai', None])
+
+    # Whiten the data covariance
+    Cm = whitener @ Cm @ whitener.T.conj()
+    # Restore to properly Hermitian as large whitening coefs can have bad
+    # rounding error
+    Cm[:] = (Cm + Cm.T.conj()) / 2.
+
     assert Cm.shape == (G.shape[0],) * 2
     s, _ = np.linalg.eigh(Cm)
     if not (s >= -s.max() * 1e-7).all():

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -141,6 +141,14 @@ def _sym_inv_sm(x, reduce_rank, inversion, sk):
     return x_inv
 
 
+def _restore_pos_semidef(Cm):
+    # Restore to positive semi-definite, as
+    # (negative eigenvalues are errant / due to massive scaling differences)
+    s, u = np.linalg.eigh(Cm)
+    Cm[:] = np.dot(u * np.abs(s), u.T.conj())
+    return Cm
+
+
 def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
                         reduce_rank, rank, inversion, nn, orient_std):
     """Compute a spatial beamformer filter (LCMV or DICS).

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -17,7 +17,7 @@ from ..forward import _subject_from_forward
 from ..minimum_norm.inverse import combine_xyz, _check_reference, _check_depth
 from ..source_estimate import _make_stc, _get_src_type
 from ..time_frequency import csd_fourier, csd_multitaper, csd_morlet
-from ._compute_beamformer import (_check_proj_match, _prepare_beamformer_input,
+from ._compute_beamformer import (_prepare_beamformer_input,
                                   _compute_beamformer, _check_src_type,
                                   Beamformer, _compute_power,
                                   _restore_pos_semidef, _proj_whiten_data)
@@ -193,11 +193,11 @@ def make_dics(info, forward, csd, reg=0.05, noise_csd=None, label=None,
                         (freq, i + 1, n_freqs))
 
         Cm = csd.get_data(index=i)
+
         # XXX: Weird that real_filter happens *before* whitening, which could
         # make things complex again...?
         if real_filter:
             Cm = Cm.real
-
         # Whiten the CSD
         Cm = np.dot(whitener, np.dot(Cm, whitener.conj().T))
         _restore_pos_semidef(Cm)

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -20,7 +20,7 @@ from ..time_frequency import csd_fourier, csd_multitaper, csd_morlet
 from ._compute_beamformer import (_check_proj_match, _prepare_beamformer_input,
                                   _compute_beamformer, _check_src_type,
                                   Beamformer, _compute_power,
-                                  _restore_pos_semidef)
+                                  _restore_pos_semidef, _proj_whiten_data)
 
 
 @verbose
@@ -263,9 +263,7 @@ def _apply_dics(data, filters, info, tmin):
             logger.info("Processing epoch : %d" % (i + 1))
 
         # Apply SSPs
-        if info['projs']:
-            _check_proj_match(info['projs'], filters)
-            M = np.dot(filters['proj'], M)
+        M = _proj_whiten_data(M, info['projs'], filters)
 
         stcs = []
         for W in Ws:

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -20,7 +20,7 @@ from ..time_frequency import csd_fourier, csd_multitaper, csd_morlet
 from ._compute_beamformer import (_prepare_beamformer_input,
                                   _compute_beamformer, _check_src_type,
                                   Beamformer, _compute_power,
-                                  _restore_pos_semidef, _proj_whiten_data)
+                                  _proj_whiten_data)
 
 
 @verbose
@@ -198,15 +198,13 @@ def make_dics(info, forward, csd, reg=0.05, noise_csd=None, label=None,
         # make things complex again...?
         if real_filter:
             Cm = Cm.real
-        # Whiten the CSD
-        Cm = np.dot(whitener, np.dot(Cm, whitener.conj().T))
-        _restore_pos_semidef(Cm)
 
         # compute spatial filter
         n_orient = 3 if is_free_ori else 1
         W, max_power_ori = _compute_beamformer(
             G, Cm, reg, n_orient, weight_norm, pick_ori, reduce_rank,
-            rank=rank, inversion=inversion, nn=nn, orient_std=orient_std)
+            rank=rank, inversion=inversion, nn=nn, orient_std=orient_std,
+            whitener=whitener)
         Ws.append(W)
         max_oris.append(max_power_ori)
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -16,7 +16,7 @@ from ..source_estimate import _make_stc, _get_src_type
 from ..utils import logger, verbose, _check_channels_spatial_filter
 from ..utils import _check_one_ch_type, _check_info_inv
 from ._compute_beamformer import (
-    _check_proj_match, _prepare_beamformer_input, _compute_power,
+    _prepare_beamformer_input, _compute_power,
     _compute_beamformer, _check_src_type, Beamformer, _restore_pos_semidef,
     _proj_whiten_data)
 

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -17,8 +17,7 @@ from ..utils import logger, verbose, _check_channels_spatial_filter
 from ..utils import _check_one_ch_type, _check_info_inv
 from ._compute_beamformer import (
     _prepare_beamformer_input, _compute_power,
-    _compute_beamformer, _check_src_type, Beamformer, _restore_pos_semidef,
-    _proj_whiten_data)
+    _compute_beamformer, _check_src_type, Beamformer, _proj_whiten_data)
 
 
 @verbose
@@ -169,9 +168,6 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
     Cm = data_cov._get_square()
     if 'estimator' in data_cov:
         del data_cov['estimator']
-
-    # Whiten the data covariance
-    Cm = _restore_pos_semidef(np.dot(whitener, np.dot(Cm, whitener.T)))
     rank_int = sum(rank.values())
     del rank
 
@@ -179,7 +175,8 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
     n_orient = 3 if is_free_ori else 1
     W, max_power_ori = _compute_beamformer(
         G, Cm, reg, n_orient, weight_norm, pick_ori, reduce_rank, rank_int,
-        inversion=inversion, nn=nn, orient_std=orient_std)
+        inversion=inversion, nn=nn, orient_std=orient_std,
+        whitener=whitener)
 
     # get src type to store with filters for _make_stc
     src_type = _get_src_type(forward['src'], vertno)

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -17,7 +17,8 @@ from ..utils import logger, verbose, _check_channels_spatial_filter
 from ..utils import _check_one_ch_type, _check_info_inv
 from ._compute_beamformer import (
     _check_proj_match, _prepare_beamformer_input, _compute_power,
-    _compute_beamformer, _check_src_type, Beamformer, _restore_pos_semidef)
+    _compute_beamformer, _check_src_type, Beamformer, _restore_pos_semidef,
+    _proj_whiten_data)
 
 
 @verbose
@@ -200,18 +201,6 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
         inversion=inversion)
 
     return filters
-
-
-def _proj_whiten_data(M, proj, filters):
-    if filters['is_ssp']:
-        # check whether data and filter projs match
-        _check_proj_match(proj, filters)
-        if filters['whitener'] is None:
-            M = np.dot(filters['proj'], M)
-
-    if filters['whitener'] is not None:
-        M = np.dot(filters['whitener'], M)
-    return M
 
 
 def _apply_lcmv(data, filters, info, tmin, max_ori_out):

--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -17,7 +17,7 @@ from ..utils import logger, verbose, _check_channels_spatial_filter
 from ..utils import _check_one_ch_type, _check_info_inv
 from ._compute_beamformer import (
     _check_proj_match, _prepare_beamformer_input, _compute_power,
-    _compute_beamformer, _check_src_type, Beamformer)
+    _compute_beamformer, _check_src_type, Beamformer, _restore_pos_semidef)
 
 
 @verbose
@@ -170,11 +170,7 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
         del data_cov['estimator']
 
     # Whiten the data covariance
-    Cm = np.dot(whitener, np.dot(Cm, whitener.T))
-    # Restore to positive semi-definite, as
-    # (negative eigenvalues are errant / due to massive scaling differences)
-    s, u = np.linalg.eigh(Cm)
-    Cm = np.dot(u * np.abs(s), u.T.conj())
+    Cm = _restore_pos_semidef(np.dot(whitener, np.dot(Cm, whitener.T)))
     rank_int = sum(rank.values())
     del rank
 

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -18,7 +18,7 @@ from mne.beamformer import (make_dics, apply_dics, apply_dics_epochs,
 from mne.beamformer._compute_beamformer import _prepare_beamformer_input
 from mne.beamformer._dics import _prepare_noise_csd
 from mne.time_frequency import csd_morlet
-from mne.utils import run_tests_if_main, object_diff, requires_h5py
+from mne.utils import object_diff, requires_h5py
 from mne.proj import compute_proj_evoked, make_projector
 from mne.surface import _compute_nearest
 from mne.beamformer.tests.test_lcmv import _assert_weight_norm

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -110,6 +110,18 @@ def _simulate_data(fwd, idx):  # Somewhere on the frontal lobe by default
 idx_param = pytest.mark.parametrize('idx', [0, 100, 200, 233])
 
 
+def _rand_csd(rng, info):
+    scales = mne.make_ad_hoc_cov(epochs.info).data
+    n = scales.size
+    # Some random complex correlation structure (with channel scalings)
+    data = rng.randn(n, n) + 1j * rng.randn(n, n)
+    data = data @ data.conj().T
+    data *= scales
+    data *= scales[:, np.newaxis]
+    data.flat[::n + 1] = scales
+    return data
+
+
 @pytest.mark.slowtest
 @testing.requires_testing_data
 @requires_h5py
@@ -127,14 +139,7 @@ def test_make_dics(tmpdir, _load_forward, idx, whiten):
         make_dics(epochs.info, fwd_surf, csd, label=label, pick_ori=None)
     if whiten:
         rng = np.random.RandomState(0)
-        scales = mne.make_ad_hoc_cov(epochs.info).data
-        n = scales.size
-        # Some random complex correlation structure (with channel scalings)
-        data = rng.randn(n, n) + 1j * rng.randn(n, n)
-        data = data @ data.conj().T
-        data *= scales
-        data *= scales[:, np.newaxis]
-        data.flat[::n + 1] = scales
+        data = _rand_csd(rng, info)
         noise_csd = CrossSpectralDensity(
             _sym_mat_to_vector(data), epochs.ch_names, 0., csd.n_fft)
     else:
@@ -669,4 +674,53 @@ def test_tf_dics(_load_forward, idx):
     assert np.all(np.isnan(stcs[0].data))
 
 
-run_tests_if_main()
+def _cov_as_csd(cov):
+    assert cov['data'].ndim == 2
+    assert len(cov['data']) == len(cov['names'])
+    # XXX we should probably make this meaningfully complex...
+    data = cov['data'].astype(np.complex128)
+    return CrossSpectralDensity(_sym_mat_to_vector(data), cov['names'], 0., 16)
+
+
+# XXX: Need to reset limits, uncomment all, add real_filter tests
+@pytest.mark.parametrize(
+    'reg, pick_ori, weight_norm, use_cov, depth, lower, upper', [
+        (0.05, None, 'unit-noise-gain-invariant', False, None, 26, 28),
+        # (0.05, None, 'unit-noise-gain-invariant', True, None, 40, 42),
+        (0.05, None, 'unit-noise-gain', False, None, 13, 14),
+        (0.05, None, 'unit-noise-gain', True, None, 1, 2),  # XXX 35, 37),
+        # (0.05, None, 'nai', True, None, 35, 37),
+        # (0.05, None, None, True, None, 12, 14),
+        # (0.05, None, None, True, 0.8, 39, 43),
+        (0.05, 'max-power', 'unit-noise-gain-invariant', False, None, 17, 20),
+        (0.05, 'max-power', 'unit-noise-gain', False, None, 17, 20),
+        # (0.05, 'max-power', 'nai', True, None, 21, 24),
+        # (0.05, 'max-power', None, True, None, 7, 10),
+        # (0.05, 'max-power', None, True, 0.8, 15, 18),
+        # no reg
+        # (0.00, None, None, True, None, 21, 32),
+        # (0.00, None, 'unit-noise-gain-invariant', True, None, 50, 65),
+        # (0.00, None, 'unit-noise-gain', True, None, 42, 65),
+        # (0.00, None, 'nai', True, None, 42, 65),
+        # (0.00, 'max-power', None, True, None, 13, 19),
+        # (0.00, 'max-power', 'unit-noise-gain-invariant', True, None, 43, 50),
+        # (0.00, 'max-power', 'unit-noise-gain', True, None, 43, 50),
+        # (0.00, 'max-power', 'nai', True, None, 43, 50),
+    ])
+def test_localization_bias_free(bias_params_free, reg, pick_ori, weight_norm,
+                                use_cov, depth, lower, upper):
+    """Test localization bias for free-orientation LCMV."""
+    evoked, fwd, noise_cov, data_cov, want = bias_params_free
+    noise_csd = _cov_as_csd(noise_cov)
+    data_csd = _cov_as_csd(data_cov)
+    del noise_cov, data_cov
+    if not use_cov:
+        evoked.pick_types(meg='grad')
+        noise_csd = None
+    loc = apply_dics(evoked, make_dics(
+        evoked.info, fwd, data_csd, reg, noise_csd, pick_ori=pick_ori,
+        weight_norm=weight_norm, depth=depth)).data
+    loc = np.linalg.norm(loc, axis=1) if pick_ori == 'vector' else np.abs(loc)
+    # Compute the percentage of sources for which there is no loc bias:
+    perc = (want == np.argmax(loc, axis=0)).mean() * 100
+    assert lower <= perc <= upper

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -685,6 +685,7 @@ def _cov_as_csd(cov, info):
 
 
 # Just test free ori here (assume fixed is same as LCMV if these are)
+# Changes here should be synced with test_lcmv.py
 @pytest.mark.parametrize(
     'reg, pick_ori, weight_norm, use_cov, depth, lower, upper, real_filter', [
         (0.05, None, 'unit-noise-gain-invariant', False, None, 26, 28, False),

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -690,8 +690,8 @@ def test_localization_bias_fixed(bias_params_fixed, reg, weight_norm, use_cov,
         # no reg
         (0.00, 'vector', None, True, None, 23, 24, 0.96, 0.97),
         (0.00, 'vector', 'unit-noise-gain-invariant', True, None, 52, 54, 0.95, 0.96),  # noqa: E501
-        (0.00, 'vector', 'unit-noise-gain', True, None, 44, 45, 0.97, 0.98),
-        (0.00, 'vector', 'nai', True, None, 44, 45, 0.97, 0.98),
+        (0.00, 'vector', 'unit-noise-gain', True, None, 44, 46, 0.97, 0.98),
+        (0.00, 'vector', 'nai', True, None, 44, 46, 0.97, 0.98),
         (0.00, 'max-power', None, True, None, 14, 15, 0, 0),
         (0.00, 'max-power', 'unit-noise-gain-invariant', True, None, 35, 37, 0, 0),  # noqa: E501
         (0.00, 'max-power', 'unit-noise-gain', True, None, 35, 37, 0, 0),
@@ -735,9 +735,9 @@ def test_localization_bias_free(bias_params_free, reg, pick_ori, weight_norm,
         (0.05, None, True, 0.8, 42, 43, 0.54, 0.56),
         # no reg
         (0.00, None, True, None, 50, 51, 0.57, 0.58),
-        (0.00, 'unit-noise-gain-invariant', True, None, 73, 74, 0.57, 0.58),
-        (0.00, 'unit-noise-gain', True, None, 73, 74, 0.57, 0.58),
-        (0.00, 'nai', True, None, 73, 74, 0.57, 0.58),
+        (0.00, 'unit-noise-gain-invariant', True, None, 73, 75, 0.57, 0.58),
+        (0.00, 'unit-noise-gain', True, None, 73, 75, 0.57, 0.58),
+        (0.00, 'nai', True, None, 73, 75, 0.57, 0.58),
     ])
 def test_orientation_max_power(bias_params_fixed, bias_params_free,
                                reg, weight_norm, use_cov, depth, lower, upper,

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -743,7 +743,7 @@ def test_orientation_max_power(bias_params_fixed, bias_params_free,
                                reg, weight_norm, use_cov, depth, lower, upper,
                                lower_ori, upper_ori):
     """Test orientation selection for bias for max-power LCMV."""
-    # we simulate data for the fixed orientation foward and beamform using
+    # we simulate data for the fixed orientation forward and beamform using
     # the free orientation forward, and check the orientation match at the end
     evoked, _, noise_cov, data_cov, want = bias_params_fixed
     fwd = bias_params_free[1]
@@ -762,7 +762,7 @@ def test_orientation_max_power(bias_params_fixed, bias_params_free,
     max_idx = np.argmax(loc, axis=0)
     perc = (want == max_idx).mean() * 100
     assert lower <= perc <= upper
-    # Comute the dot products of our forward normals and
+    # Compute the dot products of our forward normals and
     assert fwd['coord_frame'] == FIFF.FIFFV_COORD_HEAD
     nn = np.concatenate(
         [s['nn'][v] for s, v in zip(fwd['src'], filters['vertices'])])

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -684,8 +684,8 @@ def test_localization_bias_fixed(bias_params_fixed, reg, weight_norm, use_cov,
         (0.05, 'max-power', None, True, 0.8, 15, 18, 0, 0),
         (0.05, None, None, True, 0.8, 40, 42, 0, 0),
         # no reg
-        (0.00, 'vector', None, True, None, 21, 32, 0.93, 0.94),
-        (0.00, 'vector', 'unit-noise-gain-invariant', True, None, 50, 65, 0.90, 0.92),  # noqa: E501
+        (0.00, 'vector', None, True, None, 21, 32, 0.88, 0.94),
+        (0.00, 'vector', 'unit-noise-gain-invariant', True, None, 50, 65, 0.85, 0.92),  # noqa: E501
         (0.00, 'vector', 'unit-noise-gain', True, None, 42, 65, 0.96, 0.98),
         (0.00, 'vector', 'nai', True, None, 42, 65, 0.96, 0.98),
         (0.00, 'max-power', None, True, None, 13, 19, 0, 0),

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -10,6 +10,7 @@ from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_array_less)
 
 import mne
+from mne.transforms import apply_trans, invert_transform
 from mne import (convert_forward_solution, read_forward_solution, compute_rank,
                  VolVectorSourceEstimate, VolSourceEstimate, EvokedArray,
                  pick_channels_cov)
@@ -20,6 +21,7 @@ from mne.beamformer._compute_beamformer import _prepare_beamformer_input
 from mne.datasets import testing
 from mne.fixes import _get_args
 from mne.io.compensator import set_current_comp
+from mne.io.constants import FIFF
 from mne.minimum_norm import make_inverse_operator, apply_inverse
 from mne.minimum_norm.tests.test_inverse import _assert_free_ori_match
 from mne.simulation import simulate_evoked
@@ -670,7 +672,8 @@ def test_localization_bias_fixed(bias_params_fixed, reg, weight_norm, use_cov,
 
 # Changes here should be synced with test_dics.py
 @pytest.mark.parametrize(
-    'reg, pick_ori, weight_norm, use_cov, depth, lower, upper, lo, uo', [
+    'reg, pick_ori, weight_norm, use_cov, depth, lower, upper, '
+    'lower_ori, upper_ori', [
         (0.05, 'vector', 'unit-noise-gain-invariant', False, None, 26, 28, 0.82, 0.84),  # noqa: E501
         (0.05, 'vector', 'unit-noise-gain-invariant', True, None, 40, 42, 0.96, 0.98),  # noqa: E501
         (0.05, 'vector', 'unit-noise-gain', False, None, 13, 14, 0.79, 0.81),
@@ -695,7 +698,8 @@ def test_localization_bias_fixed(bias_params_fixed, reg, weight_norm, use_cov,
         (0.00, 'max-power', 'nai', True, None, 35, 37, 0, 0),
     ])
 def test_localization_bias_free(bias_params_free, reg, pick_ori, weight_norm,
-                                use_cov, depth, lower, upper, lo, uo):
+                                use_cov, depth, lower, upper,
+                                lower_ori, upper_ori):
     """Test localization bias for free-orientation LCMV."""
     evoked, fwd, noise_cov, data_cov, want = bias_params_free
     if not use_cov:
@@ -717,7 +721,60 @@ def test_localization_bias_free(bias_params_free, reg, pick_ori, weight_norm,
     max_idx = np.argmax(loc, axis=0)
     perc = (want == max_idx).mean() * 100
     assert lower <= perc <= upper
-    _assert_free_ori_match(ori, max_idx, lo, uo)
+    _assert_free_ori_match(ori, max_idx, lower_ori, upper_ori)
+
+
+# Changes here should be synced with the ones above, but these have meaningful
+# orientation values
+@pytest.mark.parametrize(
+    'reg, weight_norm, use_cov, depth, lower, upper, lower_ori, upper_ori', [
+        (0.05, 'unit-noise-gain-invariant', False, None, 38, 40, 0.52, 0.54),
+        (0.05, 'unit-noise-gain', False, None, 38, 40, 0.52, 0.54),
+        (0.05, 'nai', True, None, 56, 57, 0.56, 0.58),
+        (0.05, None, True, None, 27, 28, 0.54, 0.56),
+        (0.05, None, True, 0.8, 42, 43, 0.54, 0.56),
+        # no reg
+        (0.00, None, True, None, 50, 51, 0.57, 0.58),
+        (0.00, 'unit-noise-gain-invariant', True, None, 73, 74, 0.57, 0.58),
+        (0.00, 'unit-noise-gain', True, None, 73, 74, 0.57, 0.58),
+        (0.00, 'nai', True, None, 73, 74, 0.57, 0.58),
+    ])
+def test_orientation_max_power(bias_params_fixed, bias_params_free,
+                               reg, weight_norm, use_cov, depth, lower, upper,
+                               lower_ori, upper_ori):
+    """Test orientation selection for bias for max-power LCMV."""
+    # we simulate data for the fixed orientation foward and beamform using
+    # the free orientation forward, and check the orientation match at the end
+    evoked, _, noise_cov, data_cov, want = bias_params_fixed
+    fwd = bias_params_free[1]
+    if not use_cov:
+        evoked.pick_types(meg='grad')
+        noise_cov = None
+    with pytest.warns(None):  # rank deficiency of data_cov
+        filters = make_lcmv(evoked.info, fwd, data_cov, reg,
+                            noise_cov, pick_ori='max-power',
+                            weight_norm=weight_norm,
+                            depth=depth)
+    loc = apply_lcmv(evoked, filters).data
+    ori = filters['max_power_ori']
+    loc = np.abs(loc)
+    # Compute the percentage of sources for which there is no loc bias:
+    max_idx = np.argmax(loc, axis=0)
+    perc = (want == max_idx).mean() * 100
+    assert lower <= perc <= upper
+    # Comute the dot products of our forward normals and
+    assert fwd['coord_frame'] == FIFF.FIFFV_COORD_HEAD
+    nn = np.concatenate(
+        [s['nn'][v] for s, v in zip(fwd['src'], filters['vertices'])])
+    nn = nn[want]
+    nn = apply_trans(invert_transform(fwd['mri_head_t']), nn, move=False)
+    assert_allclose(np.linalg.norm(nn, axis=1), 1, atol=1e-6)
+    assert_allclose(np.linalg.norm(ori, axis=1), 1, atol=1e-12)
+    dots = np.abs((nn * ori).sum(-1))
+    assert_array_less(dots, 1)
+    assert_array_less(0, dots)
+    got = np.mean(dots)
+    assert lower_ori < got < upper_ori
 
 
 @pytest.mark.parametrize('weight_norm', ('nai', 'unit-noise-gain'))

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -684,10 +684,10 @@ def test_localization_bias_fixed(bias_params_fixed, reg, weight_norm, use_cov,
         (0.05, 'max-power', None, True, 0.8, 15, 18, 0, 0),
         (0.05, None, None, True, 0.8, 40, 42, 0, 0),
         # no reg
-        (0.00, 'vector', None, True, None, 21, 32, 0.88, 0.94),
-        (0.00, 'vector', 'unit-noise-gain-invariant', True, None, 50, 65, 0.85, 0.92),  # noqa: E501
-        (0.00, 'vector', 'unit-noise-gain', True, None, 42, 65, 0.96, 0.98),
-        (0.00, 'vector', 'nai', True, None, 42, 65, 0.96, 0.98),
+        (0.00, 'vector', None, True, None, 21, 32, 0.85, 0.94),
+        (0.00, 'vector', 'unit-noise-gain-invariant', True, None, 50, 65, 0.84, 0.92),  # noqa: E501
+        (0.00, 'vector', 'unit-noise-gain', True, None, 42, 65, 0.91, 0.99),
+        (0.00, 'vector', 'nai', True, None, 42, 65, 0.91, 0.99),
         (0.00, 'max-power', None, True, None, 13, 19, 0, 0),
         (0.00, 'max-power', 'unit-noise-gain-invariant', True, None, 43, 50, 0, 0),  # noqa: E501
         (0.00, 'max-power', 'unit-noise-gain', True, None, 43, 50, 0, 0),

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -686,7 +686,7 @@ def test_localization_bias_fixed(bias_params_fixed, reg, weight_norm, use_cov,
         (0.05, None, None, True, 0.8, 40, 42, 0, 0),
         # no reg
         (0.00, 'vector', None, True, None, 23, 24, 0.96, 0.97),
-        (0.00, 'vector', 'unit-noise-gain-invariant', True, None, 52, 53, 0.95, 0.96),  # noqa: E501
+        (0.00, 'vector', 'unit-noise-gain-invariant', True, None, 52, 54, 0.95, 0.96),  # noqa: E501
         (0.00, 'vector', 'unit-noise-gain', True, None, 44, 45, 0.97, 0.98),
         (0.00, 'vector', 'nai', True, None, 44, 45, 0.97, 0.98),
         (0.00, 'max-power', None, True, None, 14, 15, 0, 0),

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -35,6 +35,7 @@ s_path = op.join(test_path, 'MEG', 'sample')
 fname_evoked = op.join(s_path, 'sample_audvis_trunc-ave.fif')
 fname_cov = op.join(s_path, 'sample_audvis_trunc-cov.fif')
 fname_fwd = op.join(s_path, 'sample_audvis_trunc-meg-eeg-oct-4-fwd.fif')
+fname_fwd_full = op.join(s_path, 'sample_audvis_trunc-meg-eeg-oct-6-fwd.fif')
 bem_path = op.join(test_path, 'subjects', 'sample', 'bem')
 fname_bem = op.join(bem_path, 'sample-1280-bem.fif')
 fname_aseg = op.join(test_path, 'subjects', 'sample', 'mri', 'aseg.mgz')
@@ -240,7 +241,8 @@ def bias_params_free(evoked, noise_cov):
 def bias_params_fixed(evoked, noise_cov):
     """Provide inputs for fixed bias functions."""
     fwd = mne.read_forward_solution(fname_fwd)
-    fwd = mne.convert_forward_solution(fwd, force_fixed=True, surf_ori=True)
+    mne.convert_forward_solution(
+        fwd, force_fixed=True, surf_ori=True, copy=False)
     return _bias_params(evoked, noise_cov, fwd)
 
 
@@ -248,14 +250,23 @@ def _bias_params(evoked, noise_cov, fwd):
     evoked.pick_types(meg=True, eeg=True, exclude=())
     # restrict to limited set of verts (small src here) and one hemi for speed
     vertices = [fwd['src'][0]['vertno'].copy(), []]
-    stc = mne.SourceEstimate(np.zeros((sum(len(v) for v in vertices), 1)),
-                             vertices, 0., 1.)
+    stc = mne.SourceEstimate(
+        np.zeros((sum(len(v) for v in vertices), 1)), vertices, 0, 1)
     fwd = mne.forward.restrict_forward_to_stc(fwd, stc)
     assert fwd['sol']['row_names'] == noise_cov['names']
     assert noise_cov['names'] == evoked.ch_names
     evoked = mne.EvokedArray(fwd['sol']['data'].copy(), evoked.info)
     data_cov = noise_cov.copy()
-    data_cov['data'] = np.dot(fwd['sol']['data'], fwd['sol']['data'].T)
+    data = fwd['sol']['data'] @ fwd['sol']['data'].T
+    data *= 1e-14  # 100 nAm at each source, effectively (1e-18 would be 1 nAm)
+    # This is rank-deficient, so let's make it actually positive semidefinite
+    # by regularizing a tiny bit
+    data.flat[::data.shape[0] + 1] += mne.make_ad_hoc_cov(evoked.info)['data']
+    # Do our projection
+    proj, _, _ = mne.io.proj.make_projector(
+        data_cov['projs'], data_cov['names'])
+    data = proj @ data @ proj.T
+    data_cov['data'][:] = data
     assert data_cov['data'].shape[0] == len(noise_cov['names'])
     want = np.arange(fwd['sol']['data'].shape[1])
     if not mne.forward.is_fixed_orient(fwd):

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -31,7 +31,7 @@ from mne.minimum_norm import (apply_inverse, read_inverse_operator,
                               make_inverse_operator, apply_inverse_cov,
                               write_inverse_operator, prepare_inverse_operator,
                               compute_rank_inverse, INVERSE_METHODS)
-from mne.utils import _TempDir, run_tests_if_main, catch_logging
+from mne.utils import _TempDir, catch_logging
 
 test_path = testing.data_path(download=False)
 s_path = op.join(test_path, 'MEG', 'sample')
@@ -364,19 +364,19 @@ def test_localization_bias_loose(bias_params_fixed, method, lower, upper,
     assert lower <= perc <= upper, method
 
 
-@pytest.mark.parametrize('method, lower, upper, kwargs, depth, loose', [
-    ('MNE', 21, 24, {}, dict(limit=None, combine_xyz=False, exp=1.), 1),
-    ('MNE', 35, 40, {}, dict(limit_depth_chs=False), 1),  # ancient default
-    ('MNE', 45, 55, {}, 0.8, 1),  # MNE default
-    ('MNE', 65, 70, {}, dict(limit_depth_chs='whiten'), 1),  # sparse default
-    ('dSPM', 40, 45, {}, 0.8, 1),
-    ('sLORETA', 90, 95, {}, 0.8, 1),
-    ('eLORETA', 93, 100, dict(method_params=dict(force_equal=True)), None, 1),
-    ('eLORETA', 100, 100, {}, None, 1.0),
-    ('eLORETA', 100, 100, {}, 0.8, 1.0),
-    ('eLORETA', 100, 100, {}, 0.8, 0.999),
+@pytest.mark.parametrize('method, lower, upper, lo, uo, kwargs, depth, loose', [  # noqa: E501
+    ('MNE', 21, 24, 0.73, 0.75, {}, dict(limit=None, combine_xyz=False, exp=1.), 1),  # noqa: E501
+    ('MNE', 35, 40, 0.93, 0.94, {}, dict(limit_depth_chs=False), 1),  # ancient default  # noqa: E501
+    ('MNE', 45, 55, 0.94, 0.95, {}, 0.8, 1),  # MNE default
+    ('MNE', 65, 70, 0.945, 0.955, {}, dict(limit_depth_chs='whiten'), 1),  # sparse default  # noqa: E501
+    ('dSPM', 40, 45, 0.96, 0.97, {}, 0.8, 1),
+    ('sLORETA', 93, 95, 0.95, 0.96, {}, 0.8, 1),
+    ('eLORETA', 93, 100, 0.95, 0.96, dict(method_params=dict(force_equal=True)), None, 1),  # noqa: E501
+    ('eLORETA', 100, 100, 0.98, 0.99, {}, None, 1.0),
+    ('eLORETA', 100, 100, 0.98, 0.99, {}, 0.8, 1.0),
+    ('eLORETA', 100, 100, 0.98, 0.99, {}, 0.8, 0.999),
 ])
-def test_localization_bias_free(bias_params_free, method, lower, upper,
+def test_localization_bias_free(bias_params_free, method, lower, upper, lo, uo,
                                 kwargs, depth, loose):
     """Test inverse localization bias for free minimum-norm solvers."""
     evoked, fwd, noise_cov, _, want = bias_params_free
@@ -384,10 +384,13 @@ def test_localization_bias_free(bias_params_free, method, lower, upper,
                                      depth=depth)
     loc = apply_inverse(evoked, inv_free, lambda2, method,
                         pick_ori='vector', verbose='debug', **kwargs).data
+    ori = loc / np.linalg.norm(loc, axis=1, keepdims=True)
     loc = np.linalg.norm(loc, axis=1)
     # Compute the percentage of sources for which there is no loc bias:
-    perc = (want == np.argmax(loc, axis=0)).mean() * 100
+    max_idx = np.argmax(loc, axis=0)
+    perc = (want == max_idx).mean() * 100
     assert lower <= perc <= upper, method
+    _assert_free_ori_match(ori, max_idx, lo, uo)
 
 
 def test_apply_inverse_sphere(evoked):
@@ -1244,4 +1247,22 @@ def test_sss_rank():
     assert rank == 67
 
 
-run_tests_if_main()
+def _assert_free_ori_match(ori, max_idx, lo, uo):
+    __tracebackhide__ = True
+    # Because of how we construct our free ori tests, the correct orientations
+    # are just np.eye(3) repeated, so our dot products are just np.diag()
+    # of all of the orientations
+    if ori is None:
+        return
+    if ori.ndim == 3:  # time-varying
+        assert ori.shape == (ori.shape[0], 3, max_idx.size)
+        ori = ori[max_idx, :, np.arange(max_idx.size)]
+    else:
+        assert ori.ndim == 2
+        assert ori.shape == (ori.shape[0], 3)
+        ori = ori[max_idx]
+    assert ori.shape == (max_idx.size, 3)
+    ori.shape = (max_idx.size // 3, 3, 3)
+    dots = np.abs(np.diagonal(ori, axis1=1, axis2=2))
+    mu = np.mean(dots)
+    assert lo <= mu <= uo, mu


### PR DESCRIPTION
@wmvanvliet @britta-wstnr I am adding DICS bias tests along the lines of what we have for LCMV and minimum norm. After this PR is all good, we can add orientation tests to check the `max-power-ori` calculations.

However, it looks like `noise_csd`-based whitening is broken for DICS. I added a simple `_cov_as_csd` that just packs our data and noise cov into CSD objects, and the results should in principle match what we get for LCMV. I copied the code and limits from the LCMV tests. DICS performs within the same limits as LCMV as long as no whitening is used. Once things are whitened, things break. You can see that only the `noise_cov=False` versions of the bias tests are uncommented, except one -- the uncommented one went from the peak localization limit around 40 (meaning 40% of vertices were correctly localized exactly to the correct vertex) to being ~1%.

Two things I fixed so far:

1. Bad channel handling -- if there are bads in `info` but CSDs have the bad channels, there is a picking problem.
2. I added the same `_restore_pos_semidef` "trick" that we use for LCMV. Basically if EEG channels are used, the massive scale differences become a problem and the "trick" restores `Cm` to being positive semidefinite. (I'm not 100% sure it's correct but it seems to at least be okay for LCMV.) However, even without this hack workaround / fix, the localization limits have to be ~1%, so there is still something broken here.