### PR TITLE
MRG: Small fix to tutorial; rename plot_events ordinate label to "Event id"; improve some SSP docstrings

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -343,8 +343,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
     %(picks_header)s
         See `Epochs` docstring.
     %(reject_epochs)s
-    flat : dict | None
-        See `Epochs` docstring.
+    %(flat)s
     decim : int
         See `Epochs` docstring.
     reject_tmin : scalar | None
@@ -1190,12 +1189,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         Parameters
         ----------
         %(reject_drop_bad)s
-        flat : dict | str | None
-            Rejection parameters based on flatness of signal.
-            Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg', and values
-            are floats that set the minimum acceptable peak-to-peak amplitude.
-            If flat is None then no rejection is done. If 'existing',
-            then the flat parameters set at instantiation are used.
+        %(flat_drop_bad)s
         %(verbose_meth)s
 
         Returns
@@ -2072,11 +2066,7 @@ class Epochs(BaseEpochs):
         or wait before accessing each epoch (more memory
         efficient but can be slower).
     %(reject_epochs)s
-    flat : dict | None
-        Rejection parameters based on flatness of signal.
-        Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg', and values
-        are floats that set the minimum acceptable peak-to-peak amplitude.
-        If flat is None then no rejection is done.
+    %(flat)s
     %(proj_epochs)s
     %(decim)s
     reject_tmin : scalar | None
@@ -2285,11 +2275,7 @@ class EpochsArray(BaseEpochs):
         and a dict is created with string integer names corresponding
         to the event id integers.
     %(reject_epochs)s
-    flat : dict | None
-        Rejection parameters based on flatness of signal.
-        Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg', and values
-        are floats that set the minimum acceptable peak-to-peak amplitude.
-        If flat is None then no rejection is done.
+    %(flat)s
     reject_tmin : scalar | None
         Start of the time window used to reject epochs (with the default None,
         the window will start with tmin).

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -269,6 +269,13 @@ def create_ecg_epochs(raw, ch_name=None, event_id=999, picks=None, tmin=-0.5,
                       reject_by_annotation=True, decim=1, verbose=None):
     """Conveniently generate epochs around ECG artifact events.
 
+    %(create_ecg_epochs)s
+
+    .. note:: Filtering is only applied to the ECG channel while finding
+                events. The resulting ``ecg_epochs`` will have no filtering
+                applied (i.e., have the same filter properties as the input
+                ``raw`` instance).
+
     Parameters
     ----------
     raw : instance of Raw
@@ -308,12 +315,6 @@ def create_ecg_epochs(raw, ch_name=None, event_id=999, picks=None, tmin=-0.5,
     --------
     find_ecg_events
     compute_proj_ecg
-
-    Notes
-    -----
-    Filtering is only applied to the ECG channel while finding events.
-    The resulting ``ecg_epochs`` will have no filtering applied (i.e., have
-    the same filter properties as the input ``raw`` instance).
     """
     has_ecg = 'ecg' in raw or ch_name is not None
     if keep_ecg and (has_ecg or not preload):

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -142,30 +142,16 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
     ----------
     raw : instance of Raw
         The raw data.
-    event_id : int
-        The index to assign to found events.
-    ch_name : None | str
-        The name of the channel to use for ECG peak detection.
-        If ``None`` (default), ECG channel is used if present. If ``None`` and
-        **no** ECG channel is present, a synthetic ECG channel is created from
-        cross-channel average. This synthetic channel can only be created from
-        MEG channels.
-    tstart : float
-        Start detection after tstart seconds. Useful when beginning
-        of run is noisy.
-    l_freq : float
-        Low pass frequency to apply to the ECG channel while finding events.
-    h_freq : float
-        High pass frequency to apply to the ECG channel while finding events.
-    qrs_threshold : float | str
-        Between 0 and 1. qrs detection threshold. Can also be "auto" to
-        automatically choose the threshold that generates a reasonable
-        number of heartbeats (40-160 beats / min).
-    filter_length : str | int | None
-        Number of taps to use for filtering.
+    %(ecg_event_id)s
+    %(ecg_ch_name)s
+    %(ecg_tstart)s
+    %(ecg_filter_freqs)s
+    %(ecg_qrs_threshold)s
+    %(ecg_filter_length)s
     return_ecg : bool
-        Return ecg channel if synthesized. Defaults to False. If True and
-        and ecg exists this will yield None.
+        Return the ECG channel if it was synthesized. Defaults to ``False``.
+        If ``True`` and an actual ECG channel was found in the data, this will
+        return ``None``.
     %(reject_by_annotation_all)s
 
         .. versionadded:: 0.18
@@ -177,8 +163,12 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
         The events corresponding to the peaks of the R waves.
     ch_ecg : string
         Name of channel used.
-    average_pulse : float
-        Estimated average pulse.
+    average_pulse : float | np.nan
+        The estimated average pulse. If no ECG events could be found, this will
+        be ``nan``.
+    ecg : array | None
+        The ECG data of the synthesized ECG channel, if any. This will only
+        be returned if ``return_ecg=True`` was passed.
 
     See Also
     --------
@@ -282,47 +272,21 @@ def create_ecg_epochs(raw, ch_name=None, event_id=999, picks=None, tmin=-0.5,
     ----------
     raw : instance of Raw
         The raw data.
-    ch_name : None | str
-        The name of the channel to use for ECG R wave peak detection.
-        If None (default), ECG channel is used if present. If None and no
-        ECG channel is present, a synthetic ECG channel is created from
-        cross channel average. Synthetic channel can only be created from
-        MEG channels.
-    event_id : int
-        The index to assign to found events.
+    %(ecg_ch_name)s
+    %(ecg_event_id)s
     %(picks_all)s
     tmin : float
         Start time before event.
     tmax : float
         End time after event.
-    l_freq : float
-        Low pass frequency to apply to the ECG channel while finding events.
-    h_freq : float
-        High pass frequency to apply to the ECG channel while finding events.
-    reject : dict | None
-        Rejection parameters based on peak-to-peak amplitude.
-        Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg'.
-        If reject is None then no rejection is done. Example::
-
-            reject = dict(grad=4000e-13, # T / m (gradiometers)
-                          mag=4e-12, # T (magnetometers)
-                          eeg=40e-6, # V (EEG channels)
-                          eog=250e-6 # V (EOG channels)
-                          )
-
+    %(ecg_filter_freqs)s
+    %(reject_epochs)s
     flat : dict | None
         Rejection parameters based on flatness of signal.
         Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg', and values
         are floats that set the minimum acceptable peak-to-peak amplitude.
         If flat is None then no rejection is done.
-    baseline : tuple | list of length 2 | None
-        The time interval to apply rescaling / baseline correction.
-        If None do not apply it. If baseline is (a, b)
-        the interval is between "a (s)" and "b (s)".
-        If a is None the beginning of the data is used
-        and if b is None then b is set to the end of the interval.
-        If baseline is equal to (None, None) all the time
-        interval is used. If None, no correction is applied.
+    %(baseline_epochs)s
     preload : bool
         Preload epochs or not (default True). Must be True if
         keep_ecg is True.

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -164,9 +164,9 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
         The events corresponding to the peaks of the R waves.
     ch_ecg : string
         Name of channel used.
-    average_pulse : float | np.nan
+    average_pulse : float
         The estimated average pulse. If no ECG events could be found, this will
-        be ``nan``.
+        be zero.
     ecg : array | None
         The ECG data of the synthesized ECG channel, if any. This will only
         be returned if ``return_ecg=True`` was passed.

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -149,9 +149,9 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
     %(ecg_qrs_threshold)s
     %(ecg_filter_length)s
     return_ecg : bool
-        Return the ECG channel if it was synthesized. Defaults to ``False``.
-        If ``True`` and an actual ECG channel was found in the data, this will
-        return ``None``.
+        Return the ECG data. This is especially useful if no ECG channel
+        is present in the input data, so one will be synthesized. Defaults to
+        ``False``.
     %(reject_by_annotation_all)s
 
         .. versionadded:: 0.18

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -42,10 +42,8 @@ def qrs_detector(sfreq, ecg, thresh_value=0.6, levels=2.5, n_thresh=3,
         Low pass frequency
     h_freq : float
         High pass frequency
-    tstart : float
-        Start detection after tstart seconds.
-    filter_length : str | int | None
-        Number of taps to use for filtering.
+    %(ecg_tstart)s
+    %(ecg_filter_length)s
     %(verbose)s
 
     Returns
@@ -146,7 +144,10 @@ def find_ecg_events(raw, event_id=999, ch_name=None, tstart=0.0,
     %(ecg_ch_name)s
     %(ecg_tstart)s
     %(ecg_filter_freqs)s
-    %(ecg_qrs_threshold)s
+    qrs_threshold : float | str
+        Between 0 and 1. qrs detection threshold. Can also be "auto" to
+        automatically choose the threshold that generates a reasonable
+        number of heartbeats (40-160 beats / min).
     %(ecg_filter_length)s
     return_ecg : bool
         Return the ECG data. This is especially useful if no ECG channel
@@ -281,11 +282,7 @@ def create_ecg_epochs(raw, ch_name=None, event_id=999, picks=None, tmin=-0.5,
         End time after event.
     %(ecg_filter_freqs)s
     %(reject_epochs)s
-    flat : dict | None
-        Rejection parameters based on flatness of signal.
-        Valid keys are 'grad' | 'mag' | 'eeg' | 'eog' | 'ecg', and values
-        are floats that set the minimum acceptable peak-to-peak amplitude.
-        If flat is None then no rejection is done.
+    %(flat)s
     %(baseline_epochs)s
     preload : bool
         Preload epochs or not (default True). Must be True if

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -166,7 +166,7 @@ def create_eog_epochs(raw, ch_name=None, event_id=998, picks=None, tmin=-0.5,
                       thresh=None, decim=1, verbose=None):
     """Conveniently generate epochs around EOG artifact events.
 
-
+    %(create_eog_epochs)s
 
     Parameters
     ----------

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -166,6 +166,8 @@ def create_eog_epochs(raw, ch_name=None, event_id=998, picks=None, tmin=-0.5,
                       thresh=None, decim=1, verbose=None):
     """Conveniently generate epochs around EOG artifact events.
 
+
+
     Parameters
     ----------
     raw : instance of Raw

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -152,20 +152,7 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
                      meg='separate', verbose=None):
     """Compute SSP (signal-space projection) vectors for ECG artifacts.
 
-    This function will:
-
-    #. filter the ECG data channel,
-
-    #. find ECG R wave peaks using :func:`mne.preprocessing.find_ecg_events`,
-
-    #. filter the raw data,
-
-    #. create `~mne.Epochs` around the R wave peaks, capturing the heartbeats,
-
-    #. optionally average the `~mne.Epochs` to produce an `~mne.Evoked` if
-       ``average=True`` was passed (default), and finally
-
-    #. calculate SSP projection vectors on that data to capture the artifacts.
+    %(compute_proj_ecg)s
 
     .. note:: Raw data will be loaded if it hasn't been preloaded already.
 
@@ -280,21 +267,7 @@ def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
                      return_drop_log=False, meg='separate', verbose=None):
     """Compute SSP (signal-space projection) vectors for EOG artifacts.
 
-    This function will:
-
-    #. filter the EOG data channel,
-
-    #. find the peaks of eyeblinks in the EOG data using
-       :func:`mne.preprocessing.find_eog_events`,
-
-    #. filter the raw data,
-
-    #. create `~mne.Epochs` around the eyeblinks,
-
-    #. optionally average the `~mne.Epochs` to produce an `~mne.Evoked` if
-       ``average=True`` was passed (default), and finally
-
-    #. calculate SSP projection vectors on that data to capture the artifacts.
+    %(compute_proj_eog)s
 
     .. note:: Raw data must be preloaded.
 

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -150,7 +150,7 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
                      tstart=0., qrs_threshold='auto', filter_method='fir',
                      iir_params=None, copy=True, return_drop_log=False,
                      meg='separate', verbose=None):
-    """Compute SSP projections for ECG artifacts.
+    """Compute SSP (signal-space projection) vectors for ECG artifacts.
 
     This function will:
 
@@ -273,7 +273,7 @@ def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
                      eog_h_freq=10, tstart=0., filter_method='fir',
                      iir_params=None, ch_name=None, copy=True,
                      return_drop_log=False, meg='separate', verbose=None):
-    """Compute SSP projections for EOG artifacts.
+    """Compute SSP (signal-space projection) vectors for EOG artifacts.
 
     This function will:
 

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -154,13 +154,18 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
 
     This function will:
 
-      - filter the ECG data channel,
-      - find ECG R wave peaks using :func:`mne.preprocessing.find_ecg_events`,
-      - filter the raw data,
-      - create `~mne.Epochs` around the R wave peaks, capturing the heartbeats,
-      - optionally average the `~mne.Epochs` to produce an `~mne.Evoked` if
-        ``average=True`` was passed (default), and finally
-      - calculate SSP projection vectors on that data to capture the artifacts.
+    #. filter the ECG data channel,
+
+    #. find ECG R wave peaks using :func:`mne.preprocessing.find_ecg_events`,
+
+    #. filter the raw data,
+
+    #. create `~mne.Epochs` around the R wave peaks, capturing the heartbeats,
+
+    #. optionally average the `~mne.Epochs` to produce an `~mne.Evoked` if
+       ``average=True`` was passed (default), and finally
+
+    #. calculate SSP projection vectors on that data to capture the artifacts.
 
     .. note:: Raw data will be loaded if it hasn't been preloaded already.
 
@@ -277,14 +282,19 @@ def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
 
     This function will:
 
-      - filter the EOG data channel,
-      - find the peaks of eyeblinks in the EOG data using
-        :func:`mne.preprocessing.find_eog_events`,
-      - filter the raw data,
-      - create `~mne.Epochs` around the eyeblinks,
-      - optionally average the `~mne.Epochs` to produce an `~mne.Evoked` if
-        ``average=True`` was passed (default), and finally
-      - calculate SSP projection vectors on that data to capture the artifacts.
+    #. filter the EOG data channel,
+
+    #. find the peaks of eyeblinks in the EOG data using
+       :func:`mne.preprocessing.find_eog_events`,
+
+    #. filter the raw data,
+
+    #. create `~mne.Epochs` around the eyeblinks,
+
+    #. optionally average the `~mne.Epochs` to produce an `~mne.Evoked` if
+       ``average=True`` was passed (default), and finally
+
+    #. calculate SSP projection vectors on that data to capture the artifacts.
 
     .. note:: Raw data must be preloaded.
 

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -150,9 +150,19 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
                      tstart=0., qrs_threshold='auto', filter_method='fir',
                      iir_params=None, copy=True, return_drop_log=False,
                      meg='separate', verbose=None):
-    """Compute SSP/PCA projections for ECG artifacts.
+    """Compute SSP projections for ECG artifacts.
 
-    .. note:: raw data will be loaded if it is not already.
+    This function will:
+
+      - filter the ECG data channel,
+      - find ECG R wave peaks using :func:`mne.preprocessing.find_ecg_events`,
+      - filter the raw data,
+      - create `~mne.Epochs` around the R wave peaks, capturing the heartbeats,
+      - optionally average the `~mne.Epochs` to produce an `~mne.Evoked` if
+        ``average=True`` was passed (default), and finally
+      - calculate SSP projection vectors on that data to capture the artifacts.
+
+    .. note:: Raw data will be loaded if it hasn't been preloaded already.
 
     Parameters
     ----------
@@ -263,9 +273,20 @@ def compute_proj_eog(raw, raw_event=None, tmin=-0.2, tmax=0.2,
                      eog_h_freq=10, tstart=0., filter_method='fir',
                      iir_params=None, ch_name=None, copy=True,
                      return_drop_log=False, meg='separate', verbose=None):
-    """Compute SSP/PCA projections for EOG artifacts.
+    """Compute SSP projections for EOG artifacts.
 
-    .. note:: raw data must be preloaded.
+    This function will:
+
+      - filter the EOG data channel,
+      - find the peaks of eyeblinks in the EOG data using
+        :func:`mne.preprocessing.find_eog_events`,
+      - filter the raw data,
+      - create `~mne.Epochs` around the eyeblinks,
+      - optionally average the `~mne.Epochs` to produce an `~mne.Evoked` if
+        ``average=True`` was passed (default), and finally
+      - calculate SSP projection vectors on that data to capture the artifacts.
+
+    .. note:: Raw data must be preloaded.
 
     Parameters
     ----------

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -140,7 +140,7 @@ def _compute_proj(data, info, n_grad, n_mag, n_eeg, desc_prefix,
 @verbose
 def compute_proj_epochs(epochs, n_grad=2, n_mag=2, n_eeg=2, n_jobs=1,
                         desc_prefix=None, meg='separate', verbose=None):
-    """Compute SSP (spatial space projection) vectors on Epochs.
+    """Compute SSP (signal-space projection) vectors on epoched data.
 
     Parameters
     ----------
@@ -207,7 +207,7 @@ def _compute_cov_epochs(epochs, n_jobs):
 @verbose
 def compute_proj_evoked(evoked, n_grad=2, n_mag=2, n_eeg=2, desc_prefix=None,
                         meg='separate', verbose=None):
-    """Compute SSP (spatial space projection) vectors on Evoked.
+    """Compute SSP (signal-space projection) vectors on evoked data.
 
     Parameters
     ----------
@@ -253,7 +253,7 @@ def compute_proj_evoked(evoked, n_grad=2, n_mag=2, n_eeg=2, desc_prefix=None,
 def compute_proj_raw(raw, start=0, stop=None, duration=1, n_grad=2, n_mag=2,
                      n_eeg=0, reject=None, flat=None, n_jobs=1, meg='separate',
                      verbose=None):
-    """Compute SSP (spatial space projection) vectors on Raw.
+    """Compute SSP (signal-space projection) vectors on continuous data.
 
     Parameters
     ----------

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -141,6 +141,7 @@ def _compute_proj(data, info, n_grad, n_mag, n_eeg, desc_prefix,
 def compute_proj_epochs(epochs, n_grad=2, n_mag=2, n_eeg=2, n_jobs=1,
                         desc_prefix=None, meg='separate', verbose=None):
     """Compute SSP (signal-space projection) vectors on epoched data.
+
     %(compute_ssp)s
 
     Parameters
@@ -209,6 +210,7 @@ def _compute_cov_epochs(epochs, n_jobs):
 def compute_proj_evoked(evoked, n_grad=2, n_mag=2, n_eeg=2, desc_prefix=None,
                         meg='separate', verbose=None):
     """Compute SSP (signal-space projection) vectors on evoked data.
+
     %(compute_ssp)s
 
     Parameters
@@ -256,6 +258,7 @@ def compute_proj_raw(raw, start=0, stop=None, duration=1, n_grad=2, n_mag=2,
                      n_eeg=0, reject=None, flat=None, n_jobs=1, meg='separate',
                      verbose=None):
     """Compute SSP (signal-space projection) vectors on continuous data.
+
     %(compute_ssp)s
 
     Parameters

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -141,6 +141,7 @@ def _compute_proj(data, info, n_grad, n_mag, n_eeg, desc_prefix,
 def compute_proj_epochs(epochs, n_grad=2, n_mag=2, n_eeg=2, n_jobs=1,
                         desc_prefix=None, meg='separate', verbose=None):
     """Compute SSP (signal-space projection) vectors on epoched data.
+    %(compute_ssp)s
 
     Parameters
     ----------
@@ -208,6 +209,7 @@ def _compute_cov_epochs(epochs, n_jobs):
 def compute_proj_evoked(evoked, n_grad=2, n_mag=2, n_eeg=2, desc_prefix=None,
                         meg='separate', verbose=None):
     """Compute SSP (signal-space projection) vectors on evoked data.
+    %(compute_ssp)s
 
     Parameters
     ----------
@@ -254,6 +256,7 @@ def compute_proj_raw(raw, start=0, stop=None, duration=1, n_grad=2, n_mag=2,
                      n_eeg=0, reject=None, flat=None, n_jobs=1, meg='separate',
                      verbose=None):
     """Compute SSP (signal-space projection) vectors on continuous data.
+    %(compute_ssp)s
 
     Parameters
     ----------

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1935,6 +1935,23 @@ reject : dict | str | None
     If ``reject`` is ``None``, no rejection is performed. If ``'existing'``
     (default), then the rejection parameters set at instantiation are used.
 """
+flat_common = """
+    Rejection parameters based on flatness of signal.
+    Valid **keys** are ``'grad'``, ``'mag'``, ``'eeg'``, ``'eog'``, ``'ecg'``.
+    The **values** are floats that set the minimum acceptable peak-to-peak
+    amplitude (PTP). If the PTP is smaller than this threshold, the epoch will
+    be dropped. If ``None`` then no rejection is performed based on flatness
+    of the signal."""
+docdict['flat'] = f"""
+flat : dict | None
+{flat_common}
+"""
+docdict['flat_drop_bad'] = f"""
+flat : dict | str | None
+{flat_common}
+    If ``'existing'``, then the flat parameters set during epoch creation are
+    used.
+"""
 
 # SSP
 docdict['compute_ssp'] = """This function aims to find those SSP vectors that
@@ -1962,12 +1979,6 @@ l_freq : float
     Low pass frequency to apply to the ECG channel while finding events.
 h_freq : float
     High pass frequency to apply to the ECG channel while finding events.
-"""
-docdict['ecg_qrs_threshold'] = """
-qrs_threshold : float | str
-    Between 0 and 1. qrs detection threshold. Can also be "auto" to
-    automatically choose the threshold that generates a reasonable
-    number of heartbeats (40-160 beats / min).
 """
 docdict['ecg_filter_length'] = """
 filter_length : str | int | None

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1981,8 +1981,7 @@ tstart : float
     Start ECG detection after ``tstart`` seconds. Useful when the beginning
     of the run is noisy.
 """
-docdict['create_ecg_epochs'] = """
-This function will:
+docdict['create_ecg_epochs'] = """This function will:
 
 #. Filter the ECG data channel.
 
@@ -1994,8 +1993,7 @@ This function will:
 """
 
 # EOG detection
-docdict['create_eog_epochs'] = """
-This function will:
+docdict['create_eog_epochs'] = """This function will:
 
 #. Filter the EOG data channel.
 
@@ -2018,13 +2016,10 @@ compute_proj_common = """
 #. Optionally average the `~mne.Epochs` to produce an `~mne.Evoked` if
    ``average=True`` was passed (default).
 
-#. Calculate SSP projection vectors on that data to capture the artifacts.
-"""
-docdict['compute_proj_ecg'] = f"""%(create_ecg_epochs)s
-{compute_proj_common}
+#. Calculate SSP projection vectors on that data to capture the artifacts."""
+docdict['compute_proj_ecg'] = f"""%(create_ecg_epochs)s {compute_proj_common}
 """ % docdict
-docdict['compute_proj_eog'] = f"""%(create_eog_epochs)s
-{compute_proj_common}
+docdict['compute_proj_eog'] = f"""%(create_eog_epochs)s {compute_proj_common}
 """ % docdict
 
 # Other

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1953,14 +1953,6 @@ flat : dict | str | None
     used.
 """
 
-# SSP
-docdict['compute_ssp'] = """This function aims to find those SSP vectors that
-will project out the ``n`` most prominent signals from the data for each
-specified sensor type. Consequently, if the provided input data contains high
-levels of noise, the produced SSP vectors can then be used to eliminate that
-noise from the data.
-"""
-
 # ECG detection
 docdict['ecg_event_id'] = """
 event_id : int
@@ -1989,6 +1981,51 @@ tstart : float
     Start ECG detection after ``tstart`` seconds. Useful when the beginning
     of the run is noisy.
 """
+docdict['create_ecg_epochs'] = """
+This function will:
+
+#. Filter the ECG data channel.
+
+#. Find ECG R wave peaks using :func:`mne.preprocessing.find_ecg_events`.
+
+#. Filter the raw data.
+
+#. Create `~mne.Epochs` around the R wave peaks, capturing the heartbeats.
+"""
+
+# EOG detection
+docdict['create_eog_epochs'] = """
+This function will:
+
+#. Filter the EOG data channel.
+
+#. Find the peaks of eyeblinks in the EOG data using
+   :func:`mne.preprocessing.find_eog_events`.
+
+#. Filter the raw data.
+
+#. Create `~mne.Epochs` around the eyeblinks.
+"""
+
+# SSP
+docdict['compute_ssp'] = """This function aims to find those SSP vectors that
+will project out the ``n`` most prominent signals from the data for each
+specified sensor type. Consequently, if the provided input data contains high
+levels of noise, the produced SSP vectors can then be used to eliminate that
+noise from the data.
+"""
+compute_proj_common = """
+#. Optionally average the `~mne.Epochs` to produce an `~mne.Evoked` if
+   ``average=True`` was passed (default).
+
+#. Calculate SSP projection vectors on that data to capture the artifacts.
+"""
+docdict['compute_proj_ecg'] = f"""%(create_ecg_epochs)s
+{compute_proj_common}
+""" % docdict
+docdict['compute_proj_eog'] = f"""%(create_eog_epochs)s
+{compute_proj_common}
+""" % docdict
 
 # Other
 docdict['accept'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1937,11 +1937,11 @@ reject : dict | str | None
 """
 
 # SSP
-docdict['compute_ssp'] = """
-This function aims to find those SSP vectors that will project out the
-``n`` most prominent signals from the data for each specified sensor type.
-Consequently, if the provided input data contains high levels of noise, the
-produced SSP vectors can then be used to eliminate that noise from the data.
+docdict['compute_ssp'] = """This function aims to find those SSP vectors that
+will project out the ``n`` most prominent signals from the data for each
+specified sensor type. Consequently, if the provided input data contains high
+levels of noise, the produced SSP vectors can then be used to eliminate that
+noise from the data.
 """
 
 # ECG detection

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1941,7 +1941,7 @@ docdict['compute_ssp'] = """
 This function aims to find those SSP vectors that will project out the
 ``n`` most prominent signals from the data for each specified sensor type.
 Consequently, if the provided input data contains high levels of noise, the
-produced SSP vectors can be then used to eliminate that noise from the data.
+produced SSP vectors can then be used to eliminate that noise from the data.
 """
 
 # Other

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1954,7 +1954,7 @@ ch_name : None | str
     The name of the channel to use for ECG peak detection.
     If ``None`` (default), ECG channel is used if present. If ``None`` and
     **no** ECG channel is present, a synthetic ECG channel is created from
-    cross-channel average. This synthetic channel can only be created from
+    the cross-channel average. This synthetic channel can only be created from
     MEG channels.
 """
 docdict['ecg_filter_freqs'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1944,6 +1944,41 @@ Consequently, if the provided input data contains high levels of noise, the
 produced SSP vectors can then be used to eliminate that noise from the data.
 """
 
+# ECG detection
+docdict['ecg_event_id'] = """
+event_id : int
+    The index to assign to found ECG events.
+"""
+docdict['ecg_ch_name'] = """
+ch_name : None | str
+    The name of the channel to use for ECG peak detection.
+    If ``None`` (default), ECG channel is used if present. If ``None`` and
+    **no** ECG channel is present, a synthetic ECG channel is created from
+    cross-channel average. This synthetic channel can only be created from
+    MEG channels.
+"""
+docdict['ecg_filter_freqs'] = """
+l_freq : float
+    Low pass frequency to apply to the ECG channel while finding events.
+h_freq : float
+    High pass frequency to apply to the ECG channel while finding events.
+"""
+docdict['ecg_qrs_threshold'] = """
+qrs_threshold : float | str
+    Between 0 and 1. qrs detection threshold. Can also be "auto" to
+    automatically choose the threshold that generates a reasonable
+    number of heartbeats (40-160 beats / min).
+"""
+docdict['ecg_filter_length'] = """
+filter_length : str | int | None
+    Number of taps to use for filtering.
+"""
+docdict['ecg_tstart'] = """
+tstart : float
+    Start ECG detection after ``tstart`` seconds. Useful when the beginning
+    of the run is noisy.
+"""
+
 # Other
 docdict['accept'] = """
 accept : bool

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1936,6 +1936,14 @@ reject : dict | str | None
     (default), then the rejection parameters set at instantiation are used.
 """
 
+# SSP
+docdict['compute_ssp'] = """
+This function aims to find those SSP vectors that will project out the
+``n`` most prominent signals from the data for each specified sensor type.
+Consequently, if the provided input data contains high levels of noise, the
+produced SSP vectors can be then used to eliminate that noise from the data.
+"""
+
 # Other
 docdict['accept'] = """
 accept : bool

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -693,7 +693,7 @@ def plot_events(events, sfreq=None, first_samp=0, color=None, event_id=None,
     else:
         ax.set_ylim([min_event - 1, max_event + 1])
 
-    ax.set(xlabel=xlabel, ylabel='Events id', xlim=[0, max_x])
+    ax.set(xlabel=xlabel, ylabel='Event id', xlim=[0, max_x])
 
     ax.grid(True)
 

--- a/tutorials/preprocessing/plot_50_artifact_correction_ssp.py
+++ b/tutorials/preprocessing/plot_50_artifact_correction_ssp.py
@@ -228,8 +228,8 @@ ecg_evoked.plot_joint()
 # projectors for magnetometers, gradiometers, and EEG channels (default is two
 # projectors for each channel type).
 # :func:`~mne.preprocessing.compute_proj_ecg` also returns an :term:`events`
-# array containing the sample numbers corresponding to the onset of each
-# detected heartbeat.
+# array containing the sample numbers corresponding to the peak of the R wave
+# of each detected heartbeat.
 
 projs, events = compute_proj_ecg(raw, n_grad=1, n_mag=1, n_eeg=1, reject=None)
 

--- a/tutorials/preprocessing/plot_50_artifact_correction_ssp.py
+++ b/tutorials/preprocessing/plot_50_artifact_correction_ssp.py
@@ -228,8 +228,9 @@ ecg_evoked.plot_joint()
 # projectors for magnetometers, gradiometers, and EEG channels (default is two
 # projectors for each channel type).
 # :func:`~mne.preprocessing.compute_proj_ecg` also returns an :term:`events`
-# array containing the sample numbers corresponding to the peak of the R wave
-# of each detected heartbeat.
+# array containing the sample numbers corresponding to the peak of the
+# `R wave <https://en.wikipedia.org/wiki/QRS_complex>`__ of each detected
+# heartbeat.
 
 projs, events = compute_proj_ecg(raw, n_grad=1, n_mag=1, n_eeg=1, reject=None)
 


### PR DESCRIPTION
- ECG revents correspond to R wave peaks
- Ordinate label should be in singular, i.e. "Event id" instead of "Events id" – unless we want consistency with the `events_id` dict, but then it should be called "events_id"… which doesn't make too much sense to me
- improve some SSP docstrings