### PR TITLE
VIZ, MAINT: remove set_tight_layout from evoked plotting code

### DIFF
--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -192,7 +192,7 @@ def _plot_legend(pos, colors, axis, bads, outlines, loc, size=30):
 def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
                  units, scalings, titles, axes, plot_type, cmap=None,
                  gfp=False, window_title=None, spatial_colors=False,
-                 set_tight_layout=True, selectable=True, zorder='unsorted',
+                 selectable=True, zorder='unsorted',
                  noise_cov=None, colorbar=True, mask=None, mask_style=None,
                  mask_cmap=None, mask_alpha=.25, time_unit='s',
                  show_names=False, group_by=None, sphere=None):
@@ -237,7 +237,6 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
                          proj, xlim, hline, units, scalings, titles,
                          ax, plot_type, cmap=cmap, gfp=gfp,
                          window_title=window_title,
-                         set_tight_layout=set_tight_layout,
                          selectable=selectable, noise_cov=noise_cov,
                          colorbar=colorbar, mask=mask,
                          mask_style=mask_style, mask_cmap=mask_cmap,
@@ -301,7 +300,8 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
     fig = None
     if axes is None:
         fig, axes = plt.subplots(len(ch_types_used), 1)
-        plt.subplots_adjust(0.175, 0.08, 0.94, 0.94, 0.2, 0.63)
+        fig.subplots_adjust(left=0.125, bottom=0.1, right=0.975, top=0.92,
+                            hspace=0.63)
         if isinstance(axes, plt.Axes):
             axes = [axes]
         fig.set_size_inches(6.4, 2 + len(axes))
@@ -364,8 +364,6 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
 
     plt.setp(fig.axes[:len(ch_types_used) - 1], xlabel='')
     fig.canvas.draw()  # for axes plots update axes.
-    if set_tight_layout:
-        tight_layout(fig=fig)
     plt_show(show)
     return fig
 
@@ -1425,7 +1423,7 @@ def plot_evoked_joint(evoked, times="peaks", title='', picks=None,
                        sphere=None)
     ts_args_def.update(ts_args)
     _plot_evoked(evoked, axes=ts_ax, show=False, plot_type='butterfly',
-                 exclude=[], set_tight_layout=False, **ts_args_def)
+                 exclude=[], **ts_args_def)
 
     # handle title
     # we use a new axis for the title to handle scaling of plots


### PR DESCRIPTION
closes #8583 
closes #8597 (supersedes)

removes `set_tight_layout` from our internal evoked plotting code. This was a problem for users who were providing their own axes to `evoked.plot()`. Also tweaks the figure margins that we set when axes are not provided, to approximate what tight_layout would have yielded.

This is a short-term fix; soon evoked plots will use our new figure classes anyway.

cc @eort 