### PR TITLE
MRG, MAINT: Remove _read_dig_points

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -77,6 +77,8 @@ Enhancements
 
 - Add option to disable TQDM entirely with ``MNE_TQDM='off'`` (:gh:`8515` by `Eric Larson`_)
 
+- Add option ``on_header_missing`` to :func:`mne.channels.read_polhemus_fastscan` (:gh:`8622` by `Eric Larson`_)
+
 - `mne.preprocessing.ICA.plot_sources` now displays an `mne.preprocessing.ICA.plot_properties` window when right-clicking on component names on the y-axis (:gh:`8381` by `Daniel McCloy`_)
 
 - :func:`mne.io.read_raw_edf`, :func:`mne.io.read_raw_bdf`, and :func:`mne.io.read_raw_gdf` now detect and handle invalid highpass/lowpass filter settings (:gh:`8584` by `Clemens Brunner`_)

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -34,7 +34,7 @@ from ..io.meas_info import create_info
 from ..io.open import fiff_open
 from ..io.pick import pick_types
 from ..io.constants import FIFF
-from ..utils import (warn, copy_function_doc_to_method_doc, _pl,
+from ..utils import (warn, copy_function_doc_to_method_doc, _pl, verbose,
                      _check_option, _validate_type, _check_fname, _on_missing,
                      fill_doc)
 
@@ -971,7 +971,9 @@ def _is_polhemus_fastscan(fname):
     return 'FastSCAN' in header
 
 
-def read_polhemus_fastscan(fname, unit='mm'):
+@verbose
+def read_polhemus_fastscan(fname, unit='mm', on_header_missing='raise', *,
+                           verbose=None):
     """Read Polhemus FastSCAN digitizer data from a ``.txt`` file.
 
     Parameters
@@ -981,6 +983,8 @@ def read_polhemus_fastscan(fname, unit='mm'):
     unit : 'm' | 'cm' | 'mm'
         Unit of the digitizer file. Polhemus FastSCAN systems data is usually
         exported in millimeters. Defaults to 'mm'.
+    %(on_header_missing)s
+    %(verbose)s
 
     Returns
     -------
@@ -999,11 +1003,11 @@ def read_polhemus_fastscan(fname, unit='mm'):
     _check_option('fname', ext, VALID_FILE_EXT)
 
     if not _is_polhemus_fastscan(fname):
-        raise ValueError(
-            "%s does not contain Polhemus FastSCAN header" % fname)
+        msg = "%s does not contain a valid Polhemus FastSCAN header" % fname
+        _on_missing(on_header_missing, msg)
 
     points = _scale * np.loadtxt(fname, comments='%', ndmin=2)
-
+    _check_dig_shape(points)
     return points
 
 
@@ -1277,3 +1281,10 @@ def make_standard_montage(kind, head_size=HEAD_SIZE_DEFAULT):
     from ._standard_montage_utils import standard_montage_look_up_table
     _check_option('kind', kind, _BUILT_IN_MONTAGES)
     return standard_montage_look_up_table[kind](head_size=head_size)
+
+
+def _check_dig_shape(pts):
+    _validate_type(pts, np.ndarray, 'points')
+    if pts.ndim != 2 or pts.shape[-1] != 3:
+        raise ValueError(
+            f'Points must be of shape (n, 3) instead of {pts.shape}')

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -521,7 +521,7 @@ def test_read_dig_montage_using_polhemus_fastscan_error_handling(tmpdir):
     with open(fname, 'w') as fid:
         fid.write(content)
 
-    with pytest.raises(ValueError, match='not contain Polhemus FastSCAN'):
+    with pytest.raises(ValueError, match='not contain.*Polhemus FastSCAN'):
         _ = read_polhemus_fastscan(fname)
 
     EXPECTED_ERR_MSG = "allowed value is '.txt', but got '.bar' instead"

--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -27,7 +27,8 @@ from traitsui.menu import NoButtons
 from tvtk.pyface.scene_editor import SceneEditor
 
 from ..io.constants import FIFF
-from ..io._digitization import _read_dig_points, _make_dig_points
+from ..io._digitization import _make_dig_points
+from ..io.kit.coreg import _read_dig_kit
 from ..io.kit.kit import (RawKIT, KIT, _make_stim_channel, _default_stim_chs,
                           UnsupportedKITFormat)
 from ..transforms import (apply_trans, als_ras_trans,
@@ -175,7 +176,7 @@ class Kit2FiffModel(HasPrivateTraits):
             return
 
         try:
-            pts = _read_dig_points(self.fid_file)
+            pts = _read_dig_kit(self.fid_file)
             if len(pts) < 8:
                 raise ValueError("File contains %i points, need 8" % len(pts))
         except Exception as err:
@@ -227,7 +228,7 @@ class Kit2FiffModel(HasPrivateTraits):
             return
 
         try:
-            pts = _read_dig_points(fname)
+            pts = _read_dig_kit(fname)
             n_pts = len(pts)
             if n_pts > KIT.DIG_POINTS:
                 msg = ("The selected head shape contains {n_in} points, "

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -8,29 +8,25 @@
 # License: BSD (3-clause)
 
 import heapq
-from collections import Counter, OrderedDict
+from collections import Counter
 
 import datetime
 import os.path as op
-import re
 
 import numpy as np
 
-from ..utils import logger, warn, _check_option, Bunch, _validate_type
+from ..utils import logger, warn, Bunch, _validate_type
 
 from .constants import FIFF, _coord_frame_named
 from .tree import dir_tree_find
 from .tag import read_tag
 from .write import (start_file, end_file, write_dig_points)
 
-from ..transforms import (apply_trans, als_ras_trans, Transform,
+from ..transforms import (apply_trans, Transform,
                           get_ras_to_neuromag_trans, combine_transforms,
                           invert_transform, _to_const, _str_to_frame,
                           _coord_frame_name)
-
 from .. import __version__
-
-b = bytes  # alias
 
 _dig_kind_dict = {
     'cardinal': FIFF.FIFFV_POINT_CARDINAL,
@@ -306,75 +302,6 @@ def _get_fid_coords(dig, raise_error=True):
     return fid_coords, coord_frame
 
 
-def _read_dig_points(fname, comments='%', unit='auto'):
-    """Read digitizer data from a file.
-
-    If fname ends in .hsp or .esp, the function assumes digitizer files in [m],
-    otherwise it assumes space-delimited text files in [mm].
-
-    Parameters
-    ----------
-    fname : str
-        The filepath of space delimited file with points, or a .mat file
-        (Polhemus FastTrak format).
-    comments : str
-        The character used to indicate the start of a comment;
-        Default: '%'.
-    unit : 'auto' | 'm' | 'cm' | 'mm'
-        Unit of the digitizer files (hsp and elp). If not 'm', coordinates will
-        be rescaled to 'm'. Default is 'auto', which assumes 'm' for *.hsp and
-        *.elp files and 'mm' for *.txt files, corresponding to the known
-        Polhemus export formats.
-
-    Returns
-    -------
-    dig_points : np.ndarray, shape (n_points, 3)
-        Array of dig points in [m].
-    """
-    _check_option('unit', unit, ['auto', 'm', 'mm', 'cm'])
-
-    _, ext = op.splitext(fname)
-    if ext == '.elp' or ext == '.hsp':
-        # XXX: This should be dead code, but is deeply buried in
-        #      read_dig_montage. To be deprecated
-        # raise RuntimeError('if you are reading isotrak files please use'
-        #                    ' read_dig_polhemus_isotrak')
-        # Eventually it should use read_dig_polhemus_isotrak and/or
-        # read_dig_polhemus_fastscan, but needs refactoring to handle
-        # these formats better.
-        with open(fname) as fid:
-            file_str = fid.read()
-        value_pattern = r"\-?\d+\.?\d*e?\-?\d*"
-        coord_pattern = r"({0})\s+({0})\s+({0})\s*$".format(value_pattern)
-        if ext == '.hsp':
-            coord_pattern = '^' + coord_pattern
-        points_str = [m.groups() for m in re.finditer(coord_pattern, file_str,
-                                                      re.MULTILINE)]
-        dig_points = np.array(points_str, dtype=float)
-    elif ext == '.mat':  # like FastScan II
-        from scipy.io import loadmat
-        dig_points = loadmat(fname)['Points'].T
-    else:
-        dig_points = np.loadtxt(fname, comments=comments, ndmin=2)
-        if unit == 'auto':
-            unit = 'mm'
-        if dig_points.shape[1] > 3:
-            warn('Found %d columns instead of 3, using first 3 for XYZ '
-                 'coordinates' % (dig_points.shape[1],))
-            dig_points = dig_points[:, :3]
-
-    if dig_points.shape[-1] != 3:
-        raise ValueError(
-            'Data must be of shape (n, 3) instead of %s' % (dig_points.shape,))
-
-    if unit == 'mm':
-        dig_points /= 1000.
-    elif unit == 'cm':
-        dig_points /= 100.
-
-    return dig_points
-
-
 def _write_dig_points(fname, dig_points):
     """Write points to text file.
 
@@ -525,85 +452,6 @@ def _call_make_dig_points(nasion, lpa, rpa, hpi, extra, convert=True):
                                 extra_points=extra)
 
     return info_dig, ctf_head_t
-
-
-##############################################################################
-# From mne.io.kit
-def _set_dig_kit(mrk, elp, hsp, eeg):
-    """Add landmark points and head shape data to the KIT instance.
-
-    Digitizer data (elp and hsp) are represented in [mm] in the Polhemus
-    ALS coordinate system. This is converted to [m].
-
-    Parameters
-    ----------
-    mrk : None | str | array_like, shape (5, 3)
-        Marker points representing the location of the marker coils with
-        respect to the MEG Sensors, or path to a marker file.
-    elp : None | str | array_like, shape (8, 3)
-        Digitizer points representing the location of the fiducials and the
-        marker coils with respect to the digitized head shape, or path to a
-        file containing these points.
-    hsp : None | str | array, shape (n_points, 3)
-        Digitizer head shape points, or path to head shape file. If more
-        than 10`000 points are in the head shape, they are automatically
-        decimated.
-    eeg : dict
-        Ordered dict of EEG dig points.
-
-    Returns
-    -------
-    dig_points : list
-        List of digitizer points for info['dig'].
-    dev_head_t : dict
-        A dictionary describe the device-head transformation.
-    """
-    from ..coreg import fit_matched_points, _decimate_points
-    from ..io.kit.constants import KIT
-    from ..io.kit.coreg import read_mrk
-
-    if isinstance(hsp, str):
-        hsp = _read_dig_points(hsp)
-    n_pts = len(hsp)
-    if n_pts > KIT.DIG_POINTS:
-        hsp = _decimate_points(hsp, res=0.005)
-        n_new = len(hsp)
-        warn("The selected head shape contained {n_in} points, which is "
-             "more than recommended ({n_rec}), and was automatically "
-             "downsampled to {n_new} points. The preferred way to "
-             "downsample is using FastScan.".format(
-                 n_in=n_pts, n_rec=KIT.DIG_POINTS, n_new=n_new))
-
-    if isinstance(elp, str):
-        elp_points = _read_dig_points(elp)
-        if len(elp_points) != 8:
-            raise ValueError("File %r should contain 8 points; got shape "
-                             "%s." % (elp, elp_points.shape))
-        elp = elp_points
-    elif len(elp) not in (7, 8):
-        raise ValueError("ELP should contain 7 or 8 points; got shape "
-                         "%s." % (elp.shape,))
-    if isinstance(mrk, str):
-        mrk = read_mrk(mrk)
-
-    mrk = apply_trans(als_ras_trans, mrk)
-
-    nasion, lpa, rpa = elp[:3]
-    nmtrans = get_ras_to_neuromag_trans(nasion, lpa, rpa)
-    elp = apply_trans(nmtrans, elp)
-    hsp = apply_trans(nmtrans, hsp)
-    eeg = OrderedDict((k, apply_trans(nmtrans, p)) for k, p in eeg.items())
-
-    # device head transform
-    trans = fit_matched_points(tgt_pts=elp[3:], src_pts=mrk, out='trans')
-
-    nasion, lpa, rpa = elp[:3]
-    elp = elp[3:]
-
-    dig_points = _make_dig_points(nasion, lpa, rpa, elp, hsp, dig_ch_pos=eeg)
-    dev_head_t = Transform('meg', 'head', trans)
-
-    return dig_points, dev_head_t
 
 
 ##############################################################################

--- a/mne/io/kit/coreg.py
+++ b/mne/io/kit/coreg.py
@@ -4,6 +4,7 @@
 #
 # License: BSD (3-clause)
 
+from collections import OrderedDict
 from os import SEEK_CUR, path as op
 import pickle
 import re
@@ -11,8 +12,11 @@ from struct import unpack
 
 import numpy as np
 
-from .constants import KIT
-from .._digitization import _read_dig_points
+from .constants import KIT, FIFF
+from .._digitization import _make_dig_points
+from ...transforms import (Transform, apply_trans, get_ras_to_neuromag_trans,
+                           als_ras_trans)
+from ...utils import warn, _check_option
 
 
 def read_mrk(fname):
@@ -45,7 +49,7 @@ def read_mrk(fname):
                 pts.append(np.fromfile(fid, dtype='d', count=3))
                 mrk_points = np.array(pts)
     elif ext == '.txt':
-        mrk_points = _read_dig_points(fname, unit='m')
+        mrk_points = _read_dig_kit(fname, unit='m')
     elif ext == '.pickled':
         with open(fname, 'rb') as fid:
             food = pickle.load(fid)
@@ -86,3 +90,111 @@ def read_sns(fname):
     with open(fname) as fid:
         locs = np.array(p.findall(fid.read()), dtype=float)
     return locs
+
+
+def _set_dig_kit(mrk, elp, hsp, eeg):
+    """Add landmark points and head shape data to the KIT instance.
+
+    Digitizer data (elp and hsp) are represented in [mm] in the Polhemus
+    ALS coordinate system. This is converted to [m].
+
+    Parameters
+    ----------
+    mrk : None | str | array_like, shape (5, 3)
+        Marker points representing the location of the marker coils with
+        respect to the MEG Sensors, or path to a marker file.
+    elp : None | str | array_like, shape (8, 3)
+        Digitizer points representing the location of the fiducials and the
+        marker coils with respect to the digitized head shape, or path to a
+        file containing these points.
+    hsp : None | str | array, shape (n_points, 3)
+        Digitizer head shape points, or path to head shape file. If more
+        than 10`000 points are in the head shape, they are automatically
+        decimated.
+    eeg : dict
+        Ordered dict of EEG dig points.
+
+    Returns
+    -------
+    dig_points : list
+        List of digitizer points for info['dig'].
+    dev_head_t : dict
+        A dictionary describe the device-head transformation.
+    """
+    from ...coreg import fit_matched_points, _decimate_points
+
+    if isinstance(hsp, str):
+        hsp = _read_dig_kit(hsp)
+    n_pts = len(hsp)
+    if n_pts > KIT.DIG_POINTS:
+        hsp = _decimate_points(hsp, res=0.005)
+        n_new = len(hsp)
+        warn("The selected head shape contained {n_in} points, which is "
+             "more than recommended ({n_rec}), and was automatically "
+             "downsampled to {n_new} points. The preferred way to "
+             "downsample is using FastScan.".format(
+                 n_in=n_pts, n_rec=KIT.DIG_POINTS, n_new=n_new))
+
+    if isinstance(elp, str):
+        elp_points = _read_dig_kit(elp)
+        if len(elp_points) != 8:
+            raise ValueError("File %r should contain 8 points; got shape "
+                             "%s." % (elp, elp_points.shape))
+        elp = elp_points
+    elif len(elp) not in (7, 8):
+        raise ValueError("ELP should contain 7 or 8 points; got shape "
+                         "%s." % (elp.shape,))
+    if isinstance(mrk, str):
+        mrk = read_mrk(mrk)
+
+    mrk = apply_trans(als_ras_trans, mrk)
+
+    nasion, lpa, rpa = elp[:3]
+    nmtrans = get_ras_to_neuromag_trans(nasion, lpa, rpa)
+    elp = apply_trans(nmtrans, elp)
+    hsp = apply_trans(nmtrans, hsp)
+    eeg = OrderedDict((k, apply_trans(nmtrans, p)) for k, p in eeg.items())
+
+    # device head transform
+    trans = fit_matched_points(tgt_pts=elp[3:], src_pts=mrk, out='trans')
+
+    nasion, lpa, rpa = elp[:3]
+    elp = elp[3:]
+
+    dig_points = _make_dig_points(nasion, lpa, rpa, elp, hsp, dig_ch_pos=eeg)
+    dev_head_t = Transform('meg', 'head', trans)
+
+    return dig_points, dev_head_t
+
+
+def _read_dig_kit(fname, unit='auto'):
+    # Read dig points from a file and return ndarray, using FastSCAN for .txt
+    from ...channels.montage import (
+        read_polhemus_fastscan, read_dig_polhemus_isotrak, read_custom_montage,
+        _check_dig_shape)
+    assert unit in ('auto', 'm', 'mm')
+    _, ext = op.splitext(fname)
+    _check_option('file extension', ext[1:], ('hsp', 'elp', 'mat', 'txt'))
+    if ext == '.txt':
+        unit = 'mm' if unit == 'auto' else unit
+        out = read_polhemus_fastscan(fname, unit=unit,
+                                     on_header_missing='ignore')
+    elif ext in ('.hsp', '.elp'):
+        unit = 'm' if unit == 'auto' else unit
+        mon = read_dig_polhemus_isotrak(fname, unit=unit)
+        if fname.endswith('.hsp'):
+            dig = [d['r'] for d in mon.dig
+                   if d['kind'] != FIFF.FIFFV_POINT_CARDINAL]
+        else:
+            dig = [d['r'] for d in mon.dig]
+            if dig and \
+                    mon.dig[0]['kind'] == FIFF.FIFFV_POINT_CARDINAL and \
+                    mon.dig[0]['ident'] == FIFF.FIFFV_POINT_LPA:
+                # LPA, Nasion, RPA -> NLR
+                dig[:3] = [dig[1], dig[0], dig[2]]
+        out = np.array(dig, float)
+    else:
+        assert ext == '.mat'
+        out = np.array([d['r'] for d in read_custom_montage(fname).dig])
+    _check_dig_shape(out)
+    return out

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -27,10 +27,8 @@ from ...epochs import BaseEpochs
 from ..constants import FIFF
 from ..meas_info import _empty_info
 from .constants import KIT, LEGACY_AMP_PARAMS
-from .coreg import read_mrk
+from .coreg import read_mrk, _set_dig_kit
 from ...event import read_events
-
-from .._digitization import _set_dig_kit
 
 
 def _call_digitization(info, mrk, elp, hsp, kit_info):

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -14,6 +14,7 @@ from numpy.testing import assert_array_equal, assert_allclose
 from scipy import sparse
 
 from mne import Epochs, read_events, pick_info, pick_types, Annotations
+from mne.channels import read_polhemus_fastscan
 from mne.event import make_fixed_length_events
 from mne.datasets import testing
 from mne.io import (read_fiducials, write_fiducials, _coil_trans_to_loc,
@@ -25,11 +26,10 @@ from mne.io.meas_info import (Info, create_info, _merge_info,
                               _bad_chans_comp, _get_valid_units,
                               anonymize_info, _stamp_to_dt, _dt_to_stamp,
                               _add_timedelta_to_stamp)
-from mne.io._digitization import (_write_dig_points, _read_dig_points,
-                                  _make_dig_points,)
+from mne.io._digitization import _write_dig_points, _make_dig_points
 from mne.io import read_raw_ctf
 from mne.transforms import Transform
-from mne.utils import run_tests_if_main, catch_logging, assert_object_equal
+from mne.utils import catch_logging, assert_object_equal
 from mne.channels import make_standard_montage, equalize_channels
 
 fiducials_fname = op.join(op.dirname(__file__), '..', '..', 'data',
@@ -289,7 +289,7 @@ def test_read_write_info(tmpdir):
 
 def test_io_dig_points(tmpdir):
     """Test Writing for dig files."""
-    points = _read_dig_points(hsp_fname)
+    points = read_polhemus_fastscan(hsp_fname, on_header_missing='ignore')
 
     dest = str(tmpdir.join('test.txt'))
     dest_bad = str(tmpdir.join('test.mne'))
@@ -298,19 +298,22 @@ def test_io_dig_points(tmpdir):
     with pytest.raises(ValueError, match='extension'):
         _write_dig_points(dest_bad, points)
     _write_dig_points(dest, points)
-    points1 = _read_dig_points(dest, unit='m')
+    points1 = read_polhemus_fastscan(
+        dest, unit='m', on_header_missing='ignore')
     err = "Dig points diverged after writing and reading."
     assert_array_equal(points, points1, err)
 
     points2 = np.array([[-106.93, 99.80], [99.80, 68.81]])
     np.savetxt(dest, points2, delimiter='\t', newline='\n')
     with pytest.raises(ValueError, match='must be of shape'):
-        _read_dig_points(dest)
+        with pytest.warns(RuntimeWarning, match='FastSCAN header'):
+            read_polhemus_fastscan(dest, on_header_missing='warn')
 
 
 def test_make_dig_points():
     """Test application of Polhemus HSP to info."""
-    extra_points = _read_dig_points(hsp_fname)
+    extra_points = read_polhemus_fastscan(
+        hsp_fname, on_header_missing='ignore')
     info = create_info(ch_names=['Test Ch'], sfreq=1000.)
     assert info['dig'] is None
 
@@ -318,7 +321,7 @@ def test_make_dig_points():
     assert (info['dig'])
     assert_allclose(info['dig'][0]['r'], [-.10693, .09980, .06881])
 
-    elp_points = _read_dig_points(elp_fname)
+    elp_points = read_polhemus_fastscan(elp_fname, on_header_missing='ignore')
     nasion, lpa, rpa = elp_points[:3]
     info = create_info(ch_names=['Test Ch'], sfreq=1000.)
     assert info['dig'] is None
@@ -326,8 +329,7 @@ def test_make_dig_points():
     info['dig'] = _make_dig_points(nasion, lpa, rpa, elp_points[3:], None)
     assert (info['dig'])
     idx = [d['ident'] for d in info['dig']].index(FIFF.FIFFV_POINT_NASION)
-    assert_array_equal(info['dig'][idx]['r'],
-                       np.array([.0013930, .0131613, -.0046967]))
+    assert_allclose(info['dig'][idx]['r'], [.0013930, .0131613, -.0046967])
     pytest.raises(ValueError, _make_dig_points, nasion[:2])
     pytest.raises(ValueError, _make_dig_points, None, lpa[:2])
     pytest.raises(ValueError, _make_dig_points, None, None, rpa[:2])
@@ -763,6 +765,3 @@ def test_invalid_subject_birthday():
     with pytest.warns(RuntimeWarning, match='No birthday will be set'):
         raw = read_raw_fif(raw_invalid_bday_fname)
     assert 'birthday' not in raw.info['subject_info']
-
-
-run_tests_if_main()

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -51,8 +51,8 @@ preload : bool, str, or None (default None)
 """
 
 # Raw
-_on_missing_base = """on_missing : str
-    Can be ``'raise'`` (default) to raise an error, ``'warn'`` to emit a
+_on_missing_base = """\
+Can be ``'raise'`` (default) to raise an error, ``'warn'`` to emit a
     warning, or ``'ignore'`` to ignore when"""
 docdict['on_split_missing'] = """
 on_split_missing : str
@@ -1090,7 +1090,8 @@ stcs : instance of SourceEstimate | list of instances of SourceEstimate
 
 # Forward
 docdict['on_missing_fwd'] = """
-%s ``stc`` has vertices that are not in ``fwd``.
+on_missing : str
+    %s ``stc`` has vertices that are not in ``fwd``.
 """ % (_on_missing_base,)
 docdict['dig_kinds'] = """
 dig_kinds : list of str | str
@@ -1326,8 +1327,15 @@ match_case : bool
 
     .. versionadded:: 0.20
 """
+docdict['on_header_missing'] = """
+on_header_missing : str
+    %s the FastSCAN header is missing.
+
+    .. versionadded:: 0.22
+""" % (_on_missing_base,)
 docdict['on_missing_events'] = """
-%s event numbers from ``event_id`` are missing from ``events``.
+on_missing : str
+    %s event numbers from ``event_id`` are missing from ``events``.
     When numbers from ``events`` are missing from ``event_id`` they will be
     ignored and a warning emitted; consider using ``verbose='error'`` in
     this case.
@@ -1335,7 +1343,8 @@ docdict['on_missing_events'] = """
     .. versionadded:: 0.21
 """ % (_on_missing_base,)
 docdict['on_missing_montage'] = """
-%s channels have missing coordinates.
+on_missing : str
+    %s channels have missing coordinates.
 
     .. versionadded:: 0.20.1
 """ % (_on_missing_base,)


### PR DESCRIPTION
- Remove `mne.io._digitization._read_dig_points` and `_set_dig_kit` in favor of `mne.io.kit.coreg._read_dig_kit` and `_set_dig_kit`. The first function just reads files based on names that typically (I'm assuming) come with KIT machines to work the same way as it did before with KIT coreg, etc. The second does transforms necessary to get in the correct coondinate system. This is similar to how things work with CTF, and makes `_digitization` cleaner. The `_kit` functions now only show up in `io/kit` and `gui/*kit*`.
- Add `on_header_missing` to `read_polhemus_fastscan` because some of our testing files and such do not produce this header, and it's possible there are files in the wild that the KIT people are using that have this feature.

Part of #7591. @christianbrodbeck can you look since this messes with KIT?