### PR TITLE
MRG, MAINT: bump sphinxcontrib-bitex version

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -69,7 +69,6 @@ extensions = [
     'sphinx_bootstrap_theme',
     'sphinx_bootstrap_divs',
     'sphinxcontrib.bibtex',
-    'sphinxcontrib.bibtex2',
 ]
 
 linkcheck_ignore = [

--- a/examples/preprocessing/plot_eeg_csd.py
+++ b/examples/preprocessing/plot_eeg_csd.py
@@ -4,7 +4,7 @@ Transform EEG data using current source density (CSD)
 =====================================================
 
 This script shows an example of how to use CSD
-:footcite`PerrinEtAl1987,PerrinEtAl1989,Cohen2014,KayserTenke2015`.
+:footcite:`PerrinEtAl1987,PerrinEtAl1989,Cohen2014,KayserTenke2015`.
 CSD takes the spatial Laplacian of the sensor signal (derivative in both
 x and y). It does what a planar gradiometer does in MEG. Computing these
 spatial derivatives reduces point spread. CSD transformed data have a sharper

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -3,7 +3,7 @@ https://github.com/numpy/numpydoc/archive/master.zip
 sphinx_fontawesome
 sphinx_bootstrap_theme
 https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip
-https://github.com/mcmtroffaes/sphinxcontrib-bibtex/archive/29694f215b39d64a31b845aafd9ff2ae9329494f.zip
+sphinxcontrib-bibtex>=2.0.0
 memory_profiler
 neo
 seaborn


### PR DESCRIPTION
sphinxcontrib-bibtex just released version 2.0, which includes the footnote citation code we've been using from their `develop` branch for quite a while.