### PR TITLE
MRG, MAINT: Improve server env

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -272,7 +272,7 @@ def backend_name(request):
     yield request.param
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def renderer(backend_name, garbage_collect):
     """Yield the 3D backends."""
     from mne.viz.backends.renderer import _use_test_3d_backend
@@ -283,7 +283,7 @@ def renderer(backend_name, garbage_collect):
         renderer.backend._close_all()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def garbage_collect():
     """Garbage collect on exit."""
     yield
@@ -299,7 +299,7 @@ def backend_name_interactive(request):
     yield request.param
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def renderer_interactive(backend_name_interactive):
     """Yield the 3D backends."""
     from mne.viz.backends.renderer import _use_test_3d_backend

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -25,7 +25,7 @@ from mne.source_space import write_source_spaces
 data_path = testing.data_path(download=False)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def few_surfaces():
     """Set the _MNE_FEW_SURFACES env var."""
     with modified_env(_MNE_FEW_SURFACES='true'):

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -478,9 +478,10 @@ def sys_info(fid=None, show_paths=False):
         sklearn:       0.23.1
         numba:         0.50.1
         nibabel:       3.1.1
+        nilearn:       0.7.0
+        dipy:          1.1.1
         cupy:          Not found
         pandas:        1.0.5
-        dipy:          1.1.1
         mayavi:        Not found
         pyvista:       0.25.3 {pyvistaqt=0.1.1, OpenGL 3.3 (Core Profile) Mesa 18.3.6 via llvmpipe (LLVM 7.0, 256 bits)}
         vtk:           9.0.1
@@ -521,7 +522,7 @@ def sys_info(fid=None, show_paths=False):
     libs = _get_numpy_libs()
     has_3d = False
     for mod_name in ('mne', 'numpy', 'scipy', 'matplotlib', '', 'sklearn',
-                     'numba', 'nibabel', 'cupy', 'pandas', 'dipy',
+                     'numba', 'nibabel', 'nilearn', 'dipy', 'cupy', 'pandas',
                      'mayavi', 'pyvista', 'vtk', 'PyQt5'):
         if mod_name == '':
             out += '\n'

--- a/server_environment.yml
+++ b/server_environment.yml
@@ -1,5 +1,6 @@
 name: base
 channels:
+- conda-forge/label/vtk_dev
 - conda-forge
 dependencies:
 - python>=3.7

--- a/server_environment.yml
+++ b/server_environment.yml
@@ -8,18 +8,18 @@ dependencies:
 - ffmpeg
 - vtk
 - traits
-- nibabel
-- nilearn
 - scipy
 - numpy
 - matplotlib-base
-- ipympl
-- jupyter
 - pyvista
-- ipywidgets
+- nilearn
+- nibabel
 - nbformat
 - nbclient
-- jupyter_client!=6.1.5
 - mffpy>=0.5.7
 - pip:
   - mne
+  - jupyter
+  - ipympl
+  - ipywidgets
+  - jupyter_client!=6.1.5

--- a/server_environment.yml
+++ b/server_environment.yml
@@ -1,8 +1,6 @@
 name: base
 channels:
-- conda-forge/label/vtk_dev
 - conda-forge
-- defaults
 dependencies:
 - python>=3.7
 - pip
@@ -10,16 +8,18 @@ dependencies:
 - ffmpeg
 - vtk
 - traits
+- nibabel
+- nilearn
+- scipy
+- numpy
+- matplotlib-base
+- ipympl
+- jupyter
+- pyvista
+- ipywidgets
+- nbformat
+- nbclient
+- jupyter_client!=6.1.5
+- mffpy>=0.5.7
 - pip:
   - mne
-  - scipy
-  - numpy<1.19.0
-  - matplotlib
-  - ipympl
-  - jupyter
-  - pyvista
-  - ipywidgets
-  - nbformat
-  - nbclient
-  - jupyter_client!=6.1.5
-  - mffpy>=0.5.7


### PR DESCRIPTION
I really just want to add `nibabel` and `nilearn` to our `server_environment` because they are needed for some viz functions, but then I noticed some other stuff, so this PR will:

1. Add `nibabel` and `nilearn`
2. Remove `vtk_dev` channel
3. Remove `defaults` channel
4. Remove the `numpy<1.19.0` pin

Hopefully it all works but if it doesn't, hopefully I can at least get (1) in there. I'll need to double-check that the env otherwise looks the same in terms of what gets installed by looking at `mne sys_info`.