### PR TITLE
FIX: notebook 3d backend

### DIFF
--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -69,6 +69,7 @@ class _NotebookInteractor(object):
         return fig, dh
 
     def update(self):
+        self.plotter.render()
         self.dh.set_data(self.plotter.screenshot())
         self.fig.canvas.draw()
 


### PR DESCRIPTION
This PR fixes an issue with the `notebook` 3d backend where the interactions do not trigger an update until a particular slider is used.