### PR TITLE
MRG, BUG: Fix alpha for volumes

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -137,6 +137,8 @@ Bugs
 
 - Fix bug with coordinate frames when performing volumetric morphs via :func:`mne.compute_source_morph` and :meth:`mne.SourceMorph.apply` that could lead to ~5 mm bias (:gh:`8642` by `Eric Larson`_)
 
+- Fix bug with volumetric rendering alpha in :meth:`mne.VolSourceEstimate.plot_3d` and related functions (:gh:`8663` by `Eric Larson`_)
+
 - Fix missing documentation of :func:`mne.io.read_raw_nihon` in :ref:`tut-imorting-eeg-data` (:gh`8320` by `Adam Li`_)
 
 - Fix bug with :func:`mne.add_reference_channels` when :func:`mne.io.Raw.reorder_channels` or related methods are used afterward (:gh:`8303`, :gh:`#8484` by `Eric Larson`_)

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1242,6 +1242,15 @@ def _sensor_shape(coil):
     return rrs, tris
 
 
+def _get_cmap(colormap):
+    import matplotlib.pyplot as plt
+    if isinstance(colormap, str) and colormap in ('mne', 'mne_analyze'):
+        colormap = mne_analyze_colormap([0, 1, 2], format='matplotlib')
+    else:
+        colormap = plt.get_cmap(colormap)
+    return colormap
+
+
 def _process_clim(clim, colormap, transparent, data=0., allow_pos_lims=True):
     """Convert colormap/clim options to dict.
 
@@ -1249,7 +1258,6 @@ def _process_clim(clim, colormap, transparent, data=0., allow_pos_lims=True):
     calling gives the same results.
     """
     # Based on type of limits specified, get cmap control points
-    import matplotlib.pyplot as plt
     from matplotlib.colors import Colormap
     _validate_type(colormap, (str, Colormap), 'colormap')
     data = np.asarray(data)
@@ -1265,10 +1273,7 @@ def _process_clim(clim, colormap, transparent, data=0., allow_pos_lims=True):
                     colormap = 'hot'
                 else:  # 'pos_lims' in clim
                     colormap = 'mne'
-        if colormap in ('mne', 'mne_analyze'):
-            colormap = mne_analyze_colormap([0, 1, 2], format='matplotlib')
-        else:
-            colormap = plt.get_cmap(colormap)
+        colormap = _get_cmap(colormap)
     assert isinstance(colormap, Colormap)
     diverging_maps = ['PiYG', 'PRGn', 'BrBG', 'PuOr', 'RdGy', 'RdBu',
                       'RdYlBu', 'RdYlGn', 'Spectral', 'coolwarm', 'bwr',

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -56,10 +56,10 @@ class _Overlay(object):
         self._opacity = opacity
 
     def to_colors(self):
-        from matplotlib.cm import get_cmap
+        from .._3d import _get_cmap
         from matplotlib.colors import ListedColormap
         if isinstance(self._colormap, str):
-            cmap = get_cmap(self._colormap)
+            cmap = _get_cmap(self._colormap)
         else:
             cmap = ListedColormap(self._colormap / 255.)
 
@@ -344,8 +344,8 @@ class Brain(object):
                  offscreen=False, interaction='trackball', units='mm',
                  view_layout='vertical', show=True):
         from ..backends.renderer import backend, _get_renderer, _get_3d_backend
+        from .._3d import _get_cmap
         from matplotlib.colors import colorConverter
-        from matplotlib.cm import get_cmap
 
         if hemi in ('both', 'split'):
             self._hemis = ('lh', 'rh')
@@ -414,7 +414,7 @@ class Brain(object):
         geo_kwargs = self._cortex_colormap(cortex)
         # evaluate at the midpoint of the used colormap
         val = -geo_kwargs['vmin'] / (geo_kwargs['vmax'] - geo_kwargs['vmin'])
-        self._brain_color = get_cmap(geo_kwargs['colormap'])(val)
+        self._brain_color = _get_cmap(geo_kwargs['colormap'])(val)
 
         # load geometry for one or both hemispheres as necessary
         offset = None if (not offset or hemi != 'both') else 0.0
@@ -3096,6 +3096,9 @@ class _FakeIren():
         pass
 
     def SetEventInformation(self, *args, **kwargs):
+        pass
+
+    def CharEvent(self):
         pass
 
     def KeyPressEvent(self, *args, **kwargs):

--- a/mne/viz/_brain/colormap.py
+++ b/mne/viz/_brain/colormap.py
@@ -10,9 +10,9 @@ import numpy as np
 
 def create_lut(cmap, n_colors=256, center=None):
     """Return a colormap suitable for setting as a LUT."""
-    from matplotlib import cm
+    from .._3d import _get_cmap
     assert not (isinstance(cmap, str) and cmap == 'auto')
-    cmap = cm.get_cmap(cmap)
+    cmap = _get_cmap(cmap)
     lut = np.round(cmap(np.linspace(0, 1, n_colors)) * 255.0).astype(np.int64)
     return lut
 

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -13,7 +13,7 @@ import os.path as path
 
 import pytest
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 
 from mne import (read_source_estimate, SourceEstimate, MixedSourceEstimate,
                  VolSourceEstimate)
@@ -424,13 +424,18 @@ def test_brain_traces(renderer_interactive, hemi, src, tmpdir,
     brain = _create_testing_brain(
         hemi=hemi, surf='white', src=src, show_traces=0.5, initial_time=0,
         volume_options=None,  # for speed, don't upsample
-        n_time=1 if src == 'mixed' else 5,
+        n_time=1 if src == 'mixed' else 5, diverging=True,
         add_data_kwargs=dict(colorbar_kwargs=dict(n_labels=3)),
     )
     assert brain.show_traces
     assert hasattr(brain, "picked_points")
     assert hasattr(brain, "_spheres")
     assert brain.plotter.scalar_bar.GetNumberOfLabels() == 3
+    # mne_analyze should be chosen
+    ctab = brain._data['ctable']
+    assert_array_equal(ctab[0], [0, 255, 255, 255])  # opaque cyan
+    assert_array_equal(ctab[-1], [255, 255, 0, 255])  # opaque yellow
+    assert_allclose(ctab[len(ctab) // 2], [128, 128, 128, 0], atol=3)
 
     # add foci should work for volumes
     brain.add_foci([[0, 0, 0]], hemi='lh' if src == 'surface' else 'vol')
@@ -685,7 +690,7 @@ def test_calculate_lut():
 
 
 def _create_testing_brain(hemi, surf='inflated', src='surface', size=300,
-                          n_time=5, **kwargs):
+                          n_time=5, diverging=False, **kwargs):
     assert src in ('surface', 'mixed', 'volume')
     meth = 'plot'
     if src in ('surface', 'mixed'):
@@ -715,14 +720,17 @@ def _create_testing_brain(hemi, surf='inflated', src='surface', size=300,
     stc_data[(rng.rand(stc_size // 20) * stc_size).astype(int)] = \
         rng.rand(stc_data.size // 20)
     stc_data.shape = (n_verts, n_time)
+    if diverging:
+        stc_data -= 0.5
     stc = klass(stc_data, vertices, 1, 1)
 
-    fmin = stc.data.min()
-    fmax = stc.data.max()
-    fmid = (fmin + fmax) / 2.
+    clim = dict(kind='value', lims=[0.1, 0.2, 0.3])
+    if diverging:
+        clim['pos_lims'] = clim.pop('lims')
+
     brain_data = getattr(stc, meth)(
         subject=subject_id, hemi=hemi, surface=surf, size=size,
-        subjects_dir=subjects_dir, colormap='hot',
-        clim=dict(kind='value', lims=(fmin, fmid, fmax)), src=sample_src,
+        subjects_dir=subjects_dir, colormap='auto',
+        clim=clim, src=sample_src,
         **kwargs)
     return brain_data

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -898,8 +898,8 @@ def _set_volume_range(volume, ctable, alpha, scalar_bar, rng):
     color_tf = vtk.vtkColorTransferFunction()
     opacity_tf = vtk.vtkPiecewiseFunction()
     for loc, color in zip(np.linspace(*rng, num=len(ctable)), ctable):
-        color_tf.AddRGBPoint(loc, *color[:-1])
-        opacity_tf.AddPoint(loc, color[-1] * alpha / 255. / (len(ctable) - 1))
+        color_tf.AddRGBPoint(loc, *(color[:-1] / 255.))
+        opacity_tf.AddPoint(loc, color[-1] * alpha / 255.)
     color_tf.ClampingOn()
     opacity_tf.ClampingOn()
     volume.GetProperty().SetColor(color_tf)

--- a/tutorials/misc/plot_seeg.py
+++ b/tutorials/misc/plot_seeg.py
@@ -26,6 +26,7 @@ subject-specific MRI, or projection into a surface, see
 :ref:`tut_working_with_ecog`. In the ECoG example, we show
 how to visualize surface grid channels on the brain.
 """
+
 # Authors: Eric Larson <larson.eric.d@gmail.com>
 #          Adam Li <adam2392@gmail.com>
 #

--- a/tutorials/source-modeling/plot_beamformer_lcmv.py
+++ b/tutorials/source-modeling/plot_beamformer_lcmv.py
@@ -10,7 +10,8 @@ and shows how to use an LCMV beamformer to reconstruct source activity.
    :depth: 2
 
 """
-# Author: Britta Westner <britta.wstnr@gmail.com>
+# Authors: Britta Westner <britta.wstnr@gmail.com>
+#          Eric Larson <larson.eric.d@gmail.com>
 #
 # License: BSD (3-clause)
 


### PR DESCRIPTION
Some simple code to plot with `hot_r` with `transparent=True` and `alpha=1.` (should yield an opaque volume where values are large) looks like this on `master`:

![Screenshot from 2020-12-15 12-38-12](https://user-images.githubusercontent.com/2365790/102251266-93e14380-3ed2-11eb-9d48-78239b4ab347.png)

And on this PR it's correct:

![Screenshot from 2020-12-15 12-37-18](https://user-images.githubusercontent.com/2365790/102251271-95ab0700-3ed2-11eb-81de-008064d9cf1e.png)

The key was the opacity and color transfer functions both need to yield floats between 0 and 1, so we just need to divide both by 255 (ctable is `np.int8`) rather than doing whatever silly gymnastics we were doing before where the colors ranged from 0 to 255 and the alphas 0 to 1/255 (effectively).

While I was messing around with this I noticed `add_data` could not use `colormap='mne'` so I refactored our `get_cmap` calls. I also added a simple test to `test_brain` to make sure our `ctable` is correct.

@GuillaumeFavelier can you take a quick look? Not sure if this or #8335 should go in first, but I think they're going to conflict.