### PR TITLE
MRG, BUG: Fix bug with super versus eq in eSSS

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -21,7 +21,7 @@ Enhancements
 
 Bugs
 ~~~~
-- None yet
+- Fix bug with :func:`mne.preprocessing.maxwell_filter` where the eSSS basis had to exactly match the good channels instead of being a superset (:gh:`8675` by `Eric Larson`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -296,13 +296,13 @@ def _prep_maxwell_filter(
             item = 'extended_proj[%d]' % (pi,)
             _validate_type(proj, Projection, item)
             got_names = proj['data']['col_names']
-            diff = sorted(set(got_names).symmetric_difference(set(good_names)))
-            if diff:
-                raise ValueError('%s channel names (length %d) do not match '
-                                 'the good MEG channel names (length %d):\n%s'
-                                 % (item, len(got_names), len(good_names),
-                                    ', '.join(diff)))
-            extended_proj_.append(proj['data']['data'])
+            missing = sorted(set(good_names) - set(got_names))
+            if missing:
+                raise ValueError('%s channel names were missing some '
+                                 'good MEG channel names:\n%s'
+                                 % (item, ', '.join(missing)))
+            idx = [got_names.index(name) for name in good_names]
+            extended_proj_.append(proj['data']['data'][:, idx])
         extended_proj = np.concatenate(extended_proj_)
         logger.info('    Extending external SSS basis using %d projection '
                     'vectors' % (len(extended_proj),))

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -862,10 +862,14 @@ def test_esss(regularize, bads):
     assert 'Extending external SSS basis using 15 projection' in log
     assert_allclose(raw_sss_2._data, raw_sss._data, atol=1e-20)
 
+    # This should work, as the projectors should be a superset
+    raw_erm.info['bads'] = raw_erm.info['bads'] + ['MEG0112']
+    maxwell_filter(raw_erm, coord_frame='meg', extended_proj=proj_sss)
+
     # Degenerate condititons
     proj_sss = proj_sss[:2]
     proj_sss[0]['data']['col_names'] = proj_sss[0]['data']['col_names'][:-1]
-    with pytest.raises(ValueError, match='do not match the good MEG'):
+    with pytest.raises(ValueError, match='were missing'):
         maxwell_filter(raw_erm, coord_frame='meg', extended_proj=proj_sss)
     proj_sss[0] = 1.
     with pytest.raises(TypeError, match=r'extended_proj\[0\] must be an inst'):


### PR DESCRIPTION
In general the eSSS basis / projectors just need to be a superset of the good MEG channels in the data. This is particularly important when using empty-room data for an experiment with multiple runs where the runs could have different automatic (or manual) bad channels set.