### PR TITLE
CI, MAINT: pin sphinxcontrib-bibtex

### DIFF
--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -3,7 +3,7 @@ https://github.com/numpy/numpydoc/archive/master.zip
 sphinx_fontawesome
 sphinx_bootstrap_theme
 https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip
-sphinxcontrib-bibtex>=2.0.0
+sphinxcontrib-bibtex==2.0.0
 memory_profiler
 neo
 seaborn


### PR DESCRIPTION
Build is failing with sphinxcontrib-bibtex version 2.1.1, which introduced big changes to how references are resolved.  Pinning to 2.0.0 for now.