### PR TITLE
MRG, CI: never skip codespell/flake

### DIFF
--- a/.github/workflows/codespell_and_flake.yml
+++ b/.github/workflows/codespell_and_flake.yml
@@ -8,23 +8,7 @@ on:
       - '*'
 
 jobs:
-  check_skip:
-    runs-on: ubuntu-20.04
-    outputs:
-      skip: ${{ steps.result_step.outputs.ci-skip }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - id: result_step
-        uses: mstachniuk/ci-skip@master
-        with:
-          commit-filter: '[skip ci];[ci skip];[skip github]'
-          commit-filter-separator: ';'
-
   style:
-    needs: check_skip
-    if: ${{ needs.check_skip.outputs.skip == 'false' }}
     runs-on: ubuntu-20.04
     env:
       CODESPELL_DIRS: 'mne/ doc/ tutorials/ examples/'


### PR DESCRIPTION
per discussion on somewhere (Slack? gitter?) this removes the check-skip job for the GitHub workflow for codespell/flake, because 

1. style violations are easy to introduce, and
2. the style check is really fast anyway so it's fine to always run it even when you want to skip other workflows.