### PR TITLE
MRG, DOC: update contributors guide

### DIFF
--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -33,7 +33,7 @@ MNE-Python.
 .. collapse:: |rocket| Want an example to work through?
    :class: success
 
-   A great way to learn to contribute is to work through an actual example
+   A great way to learn to contribute is to work through an actual example.
    We recommend that you take a look at the `GitHub issues marked "easy"`_,
    pick one that looks interesting, and work through it while reading this
    guide!
@@ -147,8 +147,8 @@ If you don't see this or something similar:
 
    you need to add
 
-   - :file:`(Anaconda-Path)`
-   - :file:`(Anaconda-Path)\Scripts`
+   - :file:`{path_to_Anaconda}`
+   - :file:`{path_to_Anaconda}\\Scripts`
 
    to Windows-PATH.
 

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -722,7 +722,7 @@ Cross-reference everywhere
 Both the docstrings and dedicated documentation pages (tutorials, how-to
 examples, discussions, and glossary) should include cross-references to any
 mentioned module, class, function, method, attribute, or documentation page.
-There are sphinx directives for all of these (``:mod:``, ``:class:``,
+There are sphinx roles for all of these (``:mod:``, ``:class:``,
 ``:func:``, ``:meth:``, ``:attr:``, ``:doc:``) as well as a generic
 cross-reference directive (``:ref:``) for linking to specific sections of a
 documentation page.
@@ -744,8 +744,8 @@ dumped to file with commands like::
 
     $ python -m sphinx.ext.intersphinx https://docs.python.org/3/objects.inv > python.txt
 
-Note that anything surrounded by single backticks that does *not* have one of
-the directives (```:class:``, ``:func:``, etc) before it will be assumed to be
+Note that anything surrounded by single backticks that is *not* preceded by one
+of the API roles (``:class:``, ``:func:``, etc) will be assumed to be
 in the MNE-Python namespace. This can save some typing especially in
 tutorials; instead of ``see :func:`mne.io.Raw.plot_psd` for details`` you can
 instead type ``see `mne.io.Raw.plot_psd` for details``.

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -155,9 +155,9 @@ If you don't see this or something similar:
 - For Linux/MacOS, get `GNU Make`_
 - For Windows, you can install make for git BASH (which comes with `git for Windows`_):
 
-  1. Download :file:`make-{newest version}-without-guile-w32-bin.zip` from `ezwinports`_
+  1. Download :file:`make-{newest.version}-without-guile-w32-bin.zip` from `ezwinports`_
   2. Extract zip-folder
-  3. Copy the contents into :file:`{git-path}\mingw64\` (e.g. by merging the
+  3. Copy the contents into :file:`{path_to_git}\\mingw64\\` (e.g. by merging the
      folders with the equivalent ones already inside)
   4. For the first time using git BASH, you need to run once (to be able to
      activate your mnedev-environment): ::

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -691,7 +691,7 @@ such as embedding example code, citing references, or including rendered
 mathematics.  Note that we diverge from the NumPy docstring standard in a few
 ways:
 
-1. we use a module called ``sphinxcontrib-bibtex`` to render citations. Search
+1. We use a module called ``sphinxcontrib-bibtex`` to render citations. Search
    our source code (``git grep footcite`` and ``git grep footbibliography``) to
    see examples of how to add in-text citations and formatted references to
    your docstrings, examples, or tutorials. The structured bibliographic data
@@ -699,13 +699,13 @@ ways:
    adding new references (e.g., ``Singleauthor2019``,
    ``AuthoroneAuthortwo2020``, ``FirstauthorEtAl2021a``,
    ``FirstauthorEtAl2021b``).
-2. we don't explicitly say "optional" for optional keyword parameters (because
+2. We don't explicitly say "optional" for optional keyword parameters (because
    it's clear from the function or method signature which parameters have
    default values).
-3. for parameters that may take multiple types, we use pipe characters instead
-   of the word "or", like this: ``param_name : str | None``
-4. we don't include a ``Raises`` or ``Warns`` section describing
-   errors/warnings that might occur
+3. For parameters that may take multiple types, we use pipe characters instead
+   of the word "or", like this: ``param_name : str | None``.
+4. We don't include a ``Raises`` or ``Warns`` section describing
+   errors/warnings that might occur.
 
 
 Private function/method docstrings may be brief for simple functions/methods,

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -50,9 +50,9 @@ Overview of contribution process
 
 Changes to MNE-Python are typically made by `forking`_ the MNE-Python
 repository, making changes to your fork (usually by `cloning`_ it to your
-personal computer, making the changes, and then `pushing`_ the local changes up
-to your fork), and finally creating a `pull request`_ to incorporate your
-changes back into the shared "upstream" version of the codebase.
+personal computer, making the changes locally, and then `pushing`_ the local
+changes up to your fork), and finally creating a `pull request`_ to incorporate
+your changes back into the shared "upstream" version of the codebase.
 
 In general you'll be working with three different copies of the MNE-Python
 codebase: the official remote copy at https://github.com/mne-tools/mne-python
@@ -110,7 +110,7 @@ identifying yourself and your contact info::
 Make sure that the same email address is associated with your GitHub account
 and with your local git configuration. It is possible to associate multiple
 emails with a GitHub account, so if you initially set them up with different
-emails, just add the local email to the GitHub account.
+emails, you can add the local email to the GitHub account.
 
 Sooner or later, git is going to ask you what text editor you want it to use
 when writing commit messages, so you might as well configure that now too::
@@ -123,9 +123,12 @@ for more information.
 
 GNU Make
 ~~~~~~~~
-GNU Make facilitates deploying a package by executing corresponding commands
-from the ``Makefile``. For MNE-Python we have two Makefiles, one in the parent
-directory mainly for testing and one in ``/doc`` for building the documentation.
+
+We use `GNU Make`_ to organize commands or short scripts that are often needed
+in development. These are stored in files with the name ``Makefile``.
+MNE-Python has two Makefiles, one in the package's root directory (containing
+mainly testing commands) and one in ``/doc`` (containing recipes for building
+our documentation pages in different ways).
 
 To check if make is already installed type ::
 
@@ -209,7 +212,7 @@ separate environment for MNE-Python development (here we'll give it the name
     $ conda env create --file environment.yml --name mnedev
     $ conda activate mnedev
 
-Now you'll have *two* MNE-Python environments: ``base`` (or whatever custom
+Now you'll have *two* MNE-Python environments: ``mne`` (or whatever custom
 name you used when installing the stable version of MNE-Python) and ``mnedev``
 that we just created. At this point ``mnedev`` also has the stable version of
 MNE-Python (that's what the :file:`environment.yml` file installs), but we're
@@ -455,7 +458,7 @@ All new functionality must be documented
 
 This includes thorough docstring descriptions for all public API changes, as
 well as how-to examples or longer tutorials for major contributions. Docstrings
-for private functions may be more sparse, but should not be omitted.
+for private functions may be more sparse, but should usually not be omitted.
 
 
 Avoid API changes when possible
@@ -574,7 +577,7 @@ new feature etc.):
   .. |Your Name| replace:: **Your Name**
 
   - Short description of the changes (:gh:`0000` **by new contributor** |Your Name|_)
-  
+
   - ...
 
 where ``0000`` must be replaced with the respective GitHub pull request (PR)
@@ -678,12 +681,33 @@ single-character variable names, unless inside a :term:`comprehension <list
 comprehension>` or :ref:`generator <tut-generators>`.
 
 
-Follow NumPy style for docstrings
----------------------------------
+We (mostly) follow NumPy style for docstrings
+---------------------------------------------
 
-In most cases imitating existing docstrings will be sufficient, but consult the
-`Numpy docstring style guidelines`_ for more complicated formatting such as
-embedding example code, citing references, or including rendered mathematics.
+In most cases you can look at existing MNE-Python docstrings to figure out how
+yours should be formatted. If you can't find a relevant example, consult the
+`Numpy docstring style guidelines`_ for examples of more complicated formatting
+such as embedding example code, citing references, or including rendered
+mathematics.  Note that we diverge from the NumPy docstring standard in a few
+ways:
+
+1. we use a module called ``sphinxcontrib-bibtex`` to render citations. Search
+   our source code (``git grep footcite`` and ``git grep footbibliography``) to
+   see examples of how to add in-text citations and formatted references to
+   your docstrings, examples, or tutorials. The structured bibliographic data
+   lives in ``doc/references.bib``; please follow the existing key schema when
+   adding new references (e.g., ``Singleauthor2019``,
+   ``AuthoroneAuthortwo2020``, ``FirstauthorEtAl2021a``,
+   ``FirstauthorEtAl2021b``).
+2. we don't explicitly say "optional" for optional keyword parameters (because
+   it's clear from the function or method signature which parameters have
+   default values).
+3. for parameters that may take multiple types, we use pipe characters instead
+   of the word "or", like this: ``param_name : str | None``
+4. we don't include a ``Raises`` or ``Warns`` section describing
+   errors/warnings that might occur
+
+
 Private function/method docstrings may be brief for simple functions/methods,
 but complete docstrings are appropriate when private functions/methods are
 relatively complex. To run some basic tests on documentation, you can use::
@@ -719,6 +743,12 @@ we link to. Their inventories can be examined using a tool like `sphobjinv`_ or
 dumped to file with commands like::
 
     $ python -m sphinx.ext.intersphinx https://docs.python.org/3/objects.inv > python.txt
+
+Note that anything surrounded by single backticks that does *not* have one of
+the directives (```:class:``, ``:func:``, etc) before it will be assumed to be
+in the MNE-Python namespace. This can save some typing especially in
+tutorials; instead of ``see :func:`mne.io.Raw.plot_psd` for details`` you can
+instead type ``see `mne.io.Raw.plot_psd` for details``.
 
 
 Other style guidance

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -979,16 +979,16 @@ down the road. Here are the guidelines:
     `continuous integration`_ (CI) providers. Use them judiciously; *do not
     skip tests simply because they are failing*:
 
-    - ``[skip circle]`` Skip `circle`_, which tests successful building of our
-      documentation.
+    - ``[skip circle]`` Skip `CircleCI`_, which tests successful building of
+      our documentation.
 
-    - ``[skip travis]`` Skip `travis`_, which tests installation and execution
-      on Linux and macOS systems.
+    - ``[skip github]`` Skip our `GitHub Actions`_, which test installation
+      and execution on Linux and macOS systems.
 
     - ``[skip azp]`` Skip `azure`_ which tests installation and execution on
       Windows systems.
 
-    - ``[ci skip]`` is an alias for ``[skip travis][skip azp][skip circle]``.
+    - ``[ci skip]`` is an alias for ``[skip github][skip azp][skip circle]``.
       Notice that ``[skip ci]`` is not a valid tag.
 
     - ``[circle full]`` triggers a "full" documentation build, i.e., all code
@@ -1077,9 +1077,9 @@ it can serve as a useful example of what to expect from the PR review process.
 .. _Spyder: https://www.spyder-ide.org/
 .. _continuous integration: https://en.wikipedia.org/wiki/Continuous_integration
 .. _matplotlib: https://matplotlib.org/
-.. _travis: https://travis-ci.org/mne-tools/mne-python/branches
+.. _github actions: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions
 .. _azure: https://dev.azure.com/mne-tools/mne-python/_build/latest?definitionId=1&branchName=master
-.. _circle: https://circleci.com/gh/mne-tools/mne-python
+.. _CircleCI: https://circleci.com/gh/mne-tools/mne-python
 
 .. optipng
 

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -127,8 +127,8 @@ GNU Make
 We use `GNU Make`_ to organize commands or short scripts that are often needed
 in development. These are stored in files with the name ``Makefile``.
 MNE-Python has two Makefiles, one in the package's root directory (containing
-mainly testing commands) and one in ``/doc`` (containing recipes for building
-our documentation pages in different ways).
+mainly testing commands) and one in :file:`doc/` (containing recipes for
+building our documentation pages in different ways).
 
 To check if make is already installed type ::
 

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -125,7 +125,7 @@ GNU Make
 ~~~~~~~~
 
 We use `GNU Make`_ to organize commands or short scripts that are often needed
-in development. These are stored in files with the name ``Makefile``.
+in development. These are stored in files with the name :file:`Makefile`.
 MNE-Python has two Makefiles, one in the package's root directory (containing
 mainly testing commands) and one in :file:`doc/` (containing recipes for
 building our documentation pages in different ways).
@@ -147,17 +147,17 @@ If you don't see this or something similar:
 
    you need to add
 
-   - ``(Anaconda-Path)``
-   - ``(Anaconda-Path)\Scripts``
+   - :file:`(Anaconda-Path)`
+   - :file:`(Anaconda-Path)\Scripts`
 
    to Windows-PATH.
 
 - For Linux/MacOS, get `GNU Make`_
 - For Windows, you can install make for git BASH (which comes with `git for Windows`_):
 
-  1. Download ``make-(newest version)-without-guile-w32-bin.zip`` from `ezwinports`_
+  1. Download :file:`make-(newest version)-without-guile-w32-bin.zip` from `ezwinports`_
   2. Extract zip-folder
-  3. Copy the contents into ``(git-path)\mingw64\`` (e.g. by merging the folders with the equivalent ones already inside)
+  3. Copy the contents into :file:`(git-path)\mingw64\` (e.g. by merging the folders with the equivalent ones already inside)
   4. For the first time using git BASH, you need to run once (to be able to activate your mnedev-environment): ::
 
       $ conda init bash
@@ -262,8 +262,8 @@ the correct environment first (:samp:`conda activate mnedev`), and then do::
     $ pip install -e .
 
 The command ``pip install -e .`` installs a python module into the current
-environment by creating a link to the source code directory (instead of
-copying the code to pip's ``site_packages`` directory, which is what normally
+environment by creating a link to the source code directory (instead of copying
+the code to pip's :file:`site_packages` directory, which is what normally
 happens). This means that any edits you make to the MNE-Python source code will
 be reflected the next time you open a Python interpreter and ``import mne``
 (the ``-e`` flag of ``pip`` stands for an "editable" installation).
@@ -293,7 +293,8 @@ To build documentation, you will also require `optipng`_:
 
 - On MacOS, optipng can be installed using Homebrew.
 
-- On Windows, unzip optipng.exe from the `optipng for Windows`_ archive into the ``doc`` folder.
+- On Windows, unzip :file:`optipng.exe` from the `optipng for Windows`_ archive
+  into the :file:`doc/` folder.
 
 You can also choose to install some optional linters for reStructuredText::
 
@@ -449,7 +450,7 @@ General requirements
 All new functionality must have test coverage
 ---------------------------------------------
 
-For example, a new :class:`mne.Evoked` method in :file:`mne/evoked.py` should
+For example, a new `mne.Evoked` method in :file:`mne/evoked.py` should
 have a corresponding test in :file:`mne/tests/test_evoked.py`.
 
 
@@ -468,7 +469,7 @@ Changes to the public API (e.g., class/function/method names and signatures)
 should not be made lightly, as they can break existing user scripts. Changes to
 the API require a deprecation cycle (with warnings) so that users have time to
 adapt their code before API changes become default behavior. See :ref:`the
-deprecation section <deprecating>` and :class:`mne.utils.deprecated` for
+deprecation section <deprecating>` and `mne.utils.deprecated` for
 instructions. Bug fixes (when something isn't doing what it says it will do) do
 not require a deprecation cycle.
 
@@ -638,11 +639,11 @@ Make tests fast and thorough
 
 Whenever possible, use the testing dataset rather than one of the sample
 datasets when writing tests; it includes small versions of most MNE-Python
-objects (e.g., :class:`~mne.io.Raw` objects with short durations and few
+objects (e.g., `~mne.io.Raw` objects with short durations and few
 channels). You can also check which lines are missed by the tests, then modify
 existing tests (or write new ones) to target the missed lines. Here's an
 example that reports which lines within ``mne.viz`` are missed when running
-``test_evoked.py`` and ``test_topo.py``::
+:file:`test_evoked.py` and :file:`test_topo.py`::
 
     $ pytest --cov=mne.viz --cov-report=term-missing mne/viz/tests/test_evoked.py mne/viz/tests/test_topo.py
 
@@ -695,8 +696,8 @@ ways:
    our source code (``git grep footcite`` and ``git grep footbibliography``) to
    see examples of how to add in-text citations and formatted references to
    your docstrings, examples, or tutorials. The structured bibliographic data
-   lives in ``doc/references.bib``; please follow the existing key schema when
-   adding new references (e.g., ``Singleauthor2019``,
+   lives in :file:`doc/references.bib`; please follow the existing key scheme
+   when adding new references (e.g., ``Singleauthor2019``,
    ``AuthoroneAuthortwo2020``, ``FirstauthorEtAl2021a``,
    ``FirstauthorEtAl2021b``).
 2. We don't explicitly say "optional" for optional keyword parameters (because
@@ -905,7 +906,7 @@ These are typically used with a call like::
     $ mne browse_raw ~/mne_data/MNE-sample-data/MEG/sample/sample_audvis_raw.fif
 
 These are generally available for convenience, and can be useful for quick
-debugging (in this case, for :class:`mne.io.Raw.plot`).
+debugging (in this case, for `mne.io.Raw.plot`).
 
 If a given command-line function fails, they can also be executed as part of
 the ``mne`` module with ``python -m``. For example::

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -155,10 +155,12 @@ If you don't see this or something similar:
 - For Linux/MacOS, get `GNU Make`_
 - For Windows, you can install make for git BASH (which comes with `git for Windows`_):
 
-  1. Download :file:`make-(newest version)-without-guile-w32-bin.zip` from `ezwinports`_
+  1. Download :file:`make-{newest version}-without-guile-w32-bin.zip` from `ezwinports`_
   2. Extract zip-folder
-  3. Copy the contents into :file:`(git-path)\mingw64\` (e.g. by merging the folders with the equivalent ones already inside)
-  4. For the first time using git BASH, you need to run once (to be able to activate your mnedev-environment): ::
+  3. Copy the contents into :file:`{git-path}\mingw64\` (e.g. by merging the
+     folders with the equivalent ones already inside)
+  4. For the first time using git BASH, you need to run once (to be able to
+     activate your mnedev-environment): ::
 
       $ conda init bash
 
@@ -255,7 +257,7 @@ Finally, set up a link between your local clone and the official repository
 
 Now we'll remove the *stable* version of MNE-Python and replace it with the
 *development* version (the clone we just created with git). Make sure you're in
-the correct environment first (:samp:`conda activate mnedev`), and then do::
+the correct environment first (``conda activate mnedev``), and then do::
 
     $ cd $INSTALL_LOCATION/mne-python    # make sure we're in the right folder
     $ pip uninstall -y mne


### PR DESCRIPTION
some updates to our contributor guide, chiefly:

- where we diverge from the NumPy docstring standards
- how to do citations (thanks @johnsam7 for pointing out this info was missing)
- explain that MNE-Python-internal API crossrefs (i.e., not intersphinx) don't require directives
- fix name of default env (base → mne)

the rest is minor edits for readability/flow.