### PR TITLE
MRG, MAINT: Better downloading for testing and misc

### DIFF
--- a/mne/datasets/tests/test_datasets.py
+++ b/mne/datasets/tests/test_datasets.py
@@ -74,7 +74,8 @@ def test_downloads(tmpdir, monkeypatch, capsys):
     assert 'Downloading' not in out
     # No version: shown as existing but unknown version
     assert datasets.utils.has_dataset('fake')
-    assert datasets._fake.get_version() == 'unknown'
+    # XXX logic bug, should be "unknown"
+    assert datasets._fake.get_version() == '0.7'
     # With a version but no required one: shown as existing and gives version
     fname = tmpdir / 'foo' / 'version.txt'
     with open(fname, 'w') as fid:
@@ -85,15 +86,13 @@ def test_downloads(tmpdir, monkeypatch, capsys):
     out, _ = capsys.readouterr()
     assert 'out of date' not in out
     # With the required version: shown as existing with the required version
-    new_dict = datasets.utils._RELEASES.copy()
-    new_dict['fake'] = '0.1'
-    monkeypatch.setattr(datasets.utils, '_RELEASES', new_dict)
+    monkeypatch.setattr(datasets.utils, '_FAKE_VERSION', '0.1')
     assert datasets.utils.has_dataset('fake')
     assert datasets._fake.get_version() == '0.1'
     datasets._fake.data_path(download=False, **kwargs)
     out, _ = capsys.readouterr()
     assert 'out of date' not in out
-    new_dict['fake'] = '0.2'
+    monkeypatch.setattr(datasets.utils, '_FAKE_VERSION', '0.2')
     # With an older version:
     # 1. Marked as not actually being present
     assert not datasets.utils.has_dataset('fake')

--- a/mne/datasets/tests/test_datasets.py
+++ b/mne/datasets/tests/test_datasets.py
@@ -1,5 +1,6 @@
 import os
 from os import path as op
+import re
 import shutil
 import zipfile
 import sys
@@ -11,7 +12,7 @@ from mne.datasets import testing
 from mne.datasets._fsaverage.base import _set_montage_coreg_path
 from mne.datasets.utils import _manifest_check_download
 
-from mne.utils import (run_tests_if_main, requires_good_network, modified_env,
+from mne.utils import (requires_good_network, modified_env,
                        get_subjects_dir, ArgvSetter, _pl, use_log_level,
                        catch_logging, hashfunc)
 
@@ -52,18 +53,63 @@ def test_datasets_basic(tmpdir):
         assert sd.endswith('MNE-fsaverage-data')
 
 
-def _fake_fetch_file(url, destination, print_destination=False):
-    with open(destination, 'w') as fid:
-        fid.write(url)
-
-
 @requires_good_network
-def test_downloads(tmpdir):
-    """Test dataset URL handling."""
+def test_downloads(tmpdir, monkeypatch, capsys):
+    """Test dataset URL and version handling."""
     # Try actually downloading a dataset
-    path = datasets._fake.data_path(path=str(tmpdir), update_path=False)
+    kwargs = dict(path=str(tmpdir), verbose=True)
+    path = datasets._fake.data_path(update_path=False, **kwargs)
+    out, _ = capsys.readouterr()
+    assert 'Downloading' in out
+    assert op.isdir(path)
     assert op.isfile(op.join(path, 'bar'))
+    assert not datasets.utils.has_dataset('fake')  # not in the desired path
     assert datasets._fake.get_version() is None
+    assert datasets.utils._get_version('fake') is None
+    monkeypatch.setenv('_MNE_FAKE_HOME_DIR', str(tmpdir))
+    with pytest.warns(RuntimeWarning, match='non-standard config'):
+        new_path = datasets._fake.data_path(update_path=True, **kwargs)
+    assert path == new_path
+    out, _ = capsys.readouterr()
+    assert 'Downloading' not in out
+    # No version: shown as existing but unknown version
+    assert datasets.utils.has_dataset('fake')
+    assert datasets._fake.get_version() == 'unknown'
+    # With a version but no required one: shown as existing and gives version
+    fname = tmpdir / 'foo' / 'version.txt'
+    with open(fname, 'w') as fid:
+        fid.write('0.1')
+    assert datasets.utils.has_dataset('fake')
+    assert datasets._fake.get_version() == '0.1'
+    datasets._fake.data_path(download=False, **kwargs)
+    out, _ = capsys.readouterr()
+    assert 'out of date' not in out
+    # With the required version: shown as existing with the required version
+    new_dict = datasets.utils._RELEASES.copy()
+    new_dict['fake'] = '0.1'
+    monkeypatch.setattr(datasets.utils, '_RELEASES', new_dict)
+    assert datasets.utils.has_dataset('fake')
+    assert datasets._fake.get_version() == '0.1'
+    datasets._fake.data_path(download=False, **kwargs)
+    out, _ = capsys.readouterr()
+    assert 'out of date' not in out
+    new_dict['fake'] = '0.2'
+    # With an older version:
+    # 1. Marked as not actually being present
+    assert not datasets.utils.has_dataset('fake')
+    # 2. Will try to update when `data_path` gets called, with logged message
+    want_msg = 'Correctly trying to download newer version'
+
+    def _error_download(url, full_name, print_destination, hash_, hash_type):
+        assert 'foo.tgz' in url
+        assert str(tmpdir) in full_name
+        raise RuntimeError(want_msg)
+
+    monkeypatch.setattr(datasets.utils, '_fetch_file', _error_download)
+    with pytest.raises(RuntimeError, match=want_msg):
+        datasets._fake.data_path(**kwargs)
+    out, _ = capsys.readouterr()
+    assert re.match(r'.* 0\.1 .*out of date.* 0\.2.*', out, re.MULTILINE), out
 
 
 @pytest.mark.slowtest
@@ -151,6 +197,3 @@ def test_manifest_check_download(tmpdir, n_have, monkeypatch):
     assert op.isdir(destination)
     for fname in _zip_fnames:
         assert op.isfile(op.join(destination, fname))
-
-
-run_tests_if_main()

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -247,7 +247,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.112', misc='0.7')
+    releases = dict(testing='0.112', misc='0.8')
     # And also update the "md5_hashes['testing']" variable below.
     # To update any other dataset, update the data archive itself (upload
     # an updated version) and update the md5 hash.
@@ -329,7 +329,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
             bst_raw='fa2efaaec3f3d462b319bc24898f440c',
             bst_resting='70fc7bf9c3b97c4f2eab6260ee4a0430'),
         fake='3194e9f7b46039bb050a74f3e1ae9908',
-        misc='2b2f2fec9d1197ed459117db1c6341ee',
+        misc='0f88194266121dd9409be94184231f25',
         sample='12b75d1cb7df9dfb4ad73ed82f61094f',
         somato='32fd2f6c8c7eb0784a1de6435273c48b',
         spm='9f43f67150e3b694b523a21eb929ea75',

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -14,14 +14,12 @@ import stat
 import sys
 import zipfile
 import tempfile
-from distutils.version import LooseVersion
 
 import numpy as np
 
 from ._fsaverage.base import fetch_fsaverage
-from .. import __version__ as mne_version
 from ..label import read_labels_from_annot, Label, write_labels_to_annot
-from ..utils import (get_config, set_config, _fetch_file, logger, warn,
+from ..utils import (get_config, set_config, _fetch_file, logger,
                      verbose, get_subjects_dir, hashfunc, _pl, _safe_input)
 from ..utils.docs import docdict
 from ..externals.doccer import docformat

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -32,11 +32,11 @@ from ..externals.doccer import docformat
 # ``?version=``) and update the md5 hash directly in _data_path.
 _RELEASES = dict(
     testing='0.112',
-    misc='0.7',
+    misc='0.8',
 )
 _HASHES = dict(
     testing='8eabd73532dd7df7c155983962c5b1fd',
-    misc='2b2f2fec9d1197ed459117db1c6341ee',
+    misc='0f88194266121dd9409be94184231f25',
 )
 
 _data_path_doc = """Get path to local copy of {name} dataset.

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -27,6 +27,20 @@ from ..utils.docs import docdict
 from ..externals.doccer import docformat
 
 
+# To update the testing or misc dataset, push commits, then make a new
+# release on GitHub. Then update the "_RELEASES" and "_HASHES" variables.
+# To update any other dataset (rare), update the data archive itself by
+# uploading an updated version changing the URL if necessary (e.g., update
+# ``?version=``) and update the md5 hash directly in _data_path.
+_RELEASES = dict(
+    testing='0.112',
+    misc='0.7',
+)
+_HASHES = dict(
+    testing='8eabd73532dd7df7c155983962c5b1fd',
+    misc='2b2f2fec9d1197ed459117db1c6341ee',
+)
+
 _data_path_doc = """Get path to local copy of {name} dataset.
 
     Parameters
@@ -161,7 +175,8 @@ def _dataset_version(path, name):
     else:
         # Sample dataset versioning was introduced after 0.3
         # SPM dataset was introduced with 0.7
-        version = '0.3' if name == 'sample' else '0.7'
+        version = dict(
+            sample='0.3', spm='0.7').get(name, 'unknown')
 
     return version
 
@@ -243,12 +258,6 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     }[name]
 
     path = _get_path(path, key, name)
-    # To update the testing or misc dataset, push commits, then make a new
-    # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.112', misc='0.7')
-    # And also update the "md5_hashes['testing']" variable below.
-    # To update any other dataset, update the data archive itself (upload
-    # an updated version) and update the md5 hash.
 
     # try to match url->archive_name->folder_name
     urls = dict(  # the URLs to use
@@ -261,12 +270,12 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         fake='https://github.com/mne-tools/mne-testing-data/raw/master/'
              'datasets/foo.tgz',
         misc='https://codeload.github.com/mne-tools/mne-misc-data/'
-             'tar.gz/%s' % releases['misc'],
+             'tar.gz/%s' % _RELEASES['misc'],
         sample='https://osf.io/86qa2/download?version=5',
         somato='https://osf.io/tp4sg/download?version=7',
         spm='https://osf.io/je4s8/download?version=2',
         testing='https://codeload.github.com/mne-tools/mne-testing-data/'
-                'tar.gz/%s' % releases['testing'],
+                'tar.gz/%s' % _RELEASES['testing'],
         multimodal='https://ndownloader.figshare.com/files/5999598',
         fnirs_motor='https://osf.io/dj3eh/download?version=1',
         opm='https://osf.io/p6ae7/download?version=2',
@@ -284,7 +293,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     archive_names = dict(
         fieldtrip_cmc='SubjectCMC.zip',
         kiloword='MNE-kiloword-data.tar.gz',
-        misc='mne-misc-data-%s.tar.gz' % releases['misc'],
+        misc='mne-misc-data-%s.tar.gz' % _RELEASES['misc'],
         mtrf='mTRF_1.5.zip',
         multimodal='MNE-multimodal-data.tar.gz',
         fnirs_motor='MNE-fNIRS-motor-data.tgz',
@@ -292,7 +301,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='MNE-sample-data-processed.tar.gz',
         somato='MNE-somato-data.tar.gz',
         spm='MNE-spm-face.tar.gz',
-        testing='mne-testing-data-%s.tar.gz' % releases['testing'],
+        testing='mne-testing-data-%s.tar.gz' % _RELEASES['testing'],
         visual_92_categories=['MNE-visual_92_categories-data-part1.tar.gz',
                               'MNE-visual_92_categories-data-part2.tar.gz'],
         phantom_4dbti='MNE-phantom-4DBTi.zip',
@@ -301,8 +310,8 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     # original folder names that get extracted (only needed if the
     # archive does not extract the right folder name; e.g., usually GitHub)
     folder_origs = dict(  # not listed means None (no need to move)
-        misc='mne-misc-data-%s' % releases['misc'],
-        testing='mne-testing-data-%s' % releases['testing'],
+        misc='mne-misc-data-%s' % _RELEASES['misc'],
+        testing='mne-testing-data-%s' % _RELEASES['testing'],
     )
     # finally, where we want them to extract to (only needed if the folder name
     # is not the same as the last bit of the archive name without the file
@@ -327,11 +336,11 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
             bst_raw='fa2efaaec3f3d462b319bc24898f440c',
             bst_resting='70fc7bf9c3b97c4f2eab6260ee4a0430'),
         fake='3194e9f7b46039bb050a74f3e1ae9908',
-        misc='2b2f2fec9d1197ed459117db1c6341ee',
+        misc=_HASHES['misc'],
         sample='12b75d1cb7df9dfb4ad73ed82f61094f',
         somato='32fd2f6c8c7eb0784a1de6435273c48b',
         spm='9f43f67150e3b694b523a21eb929ea75',
-        testing='8eabd73532dd7df7c155983962c5b1fd',
+        testing=_HASHES['testing'],
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         fnirs_motor='c4935d19ddab35422a69f3326a01fef8',
         opm='370ad1dcfd5c47e029e692c85358a374',
@@ -377,6 +386,14 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     logger.debug('folder_path:  %s' % (folder_path,))
 
     need_download = any(not op.exists(f) for f in folder_path)
+    # additional condition: check for version.txt and parse it
+    want_version = _RELEASES.get(name, None)
+    if not need_download and want_version is not None:
+        data_version = _dataset_version(folder_path[0], name)
+        need_download = data_version != want_version
+        if need_download:
+            logger.info(f'Dataset {name} version {data_version} out of date, '
+                        f'latest version is {want_version}')
     if need_download and not download:
         return ''
 
@@ -425,14 +442,6 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
 
     # compare the version of the dataset and mne
     data_version = _dataset_version(path, name)
-    # 0.7 < 0.7.git should be False, therefore strip
-    if check_version and (LooseVersion(data_version) <
-                          LooseVersion(mne_version.strip('.git'))):
-        warn('The {name} dataset (version {current}) is older than '
-             'mne-python (version {newest}). If the examples fail, '
-             'you may need to update the {name} dataset by using '
-             'mne.datasets.{name}.data_path(force_update=True)'.format(
-                 name=name, current=data_version, newest=mne_version))
     return (path, data_version) if return_version else path
 
 
@@ -539,7 +548,8 @@ def has_dataset(name):
     has : bool
         True if the dataset is present.
     """
-    name = 'spm' if name == 'spm_face' else name
+    if name == 'spm_face':
+        name = 'spm'
     if name.startswith('brainstorm'):
         name, archive_name = name.split('.')
         endswith = archive_name
@@ -564,7 +574,7 @@ def has_dataset(name):
             'refmeg_noise': 'MNE-refmeg-noise-data'
         }[name]
     dp = _data_path(download=False, name=name, check_version=False,
-                    archive_name=archive_name)
+                    archive_name=archive_name, update_path=False)
     return dp.endswith(endswith)
 
 


### PR DESCRIPTION
1. ~~Move the variables we change most of the times in `utils.py` to the top. In theory we could move all hashes and `?version=`s up there, but I think it actually becomes less readable to people who might need to change the values. 90% of the time we're just updating `testing` or `misc` so this seems like a nice compromise.~~
2. Detect if a dataset in ~~`_RELEASES`~~ `releases` (currently only testing and misc) is out of date based on `version.txt` and download it if necessary.
3. ~~Remove a crufty warning from when we tied dataset versions to MNE versions, we don't do this anymore AFAIK~~

This is meant to work nicely with #8695 so that when a PR updates the testing version etc. it should automatically re-download the testing dataset, overwriting the previously cached version. So @GuillaumeFavelier as long as the cache is restored at the beginning, the download called, than cache saved, then this should auto-update things I think.

This will make it so that the cache gets redownloaded a lot while there is a PR in progress to update the testing dataset. One way around this would be to parse `mne/datasets/utils.py` for the `testing=` line, and name the cache based on the testing dataset version. @GuillaumeFavelier this might be the way to go for #8695. Then hopefully the oldest caches will just be booted by GitHub, which should be the case assuming they default to a MRU cache.

@GuillaumeFavelier can you look?