### PR TITLE
MRG, DOC: Mailing list, Gitter -> Discourse forum

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,13 +7,11 @@ assignees: ''
 ---
 
 **READ THIS FIRST:** If you are having trouble getting MNE-Python to work with
-your own data, you should ask for help on one of our other channels:
-
-- [email list](https://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis)
-- [Gitter (chat)](https://gitter.im/mne-tools/mne-python)
+your own data, you should ask for help on the
+[MNE Forum](https://mne.discourse.group).
 
 Our GitHub issue tracker is only used to report bugs and suggest improvements
-to MNE-Python. For any other questions, please use the email list or Gitter.
+to MNE-Python. For any other questions, please use the forum.
 Usage questions that are posted as GitHub issues are usually closed without
 being answered. See
 [the FAQ entry on filing bug reports](https://mne.tools/dev/overview/faq.html#i-think-i-found-a-bug-what-do-i-do)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Mailing list
-    url: http://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis
+  - name: Forum
+    url: https://mne.discourse.group
     about: For questions about analysis and usage, and announcements of interest to the neuroimaging community
-  - name: Gitter
-    url: https://gitter.im/mne-tools/mne-python
-    about: Users and developers can chat, troubleshoot and share code samples on our gitter channel

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -8,12 +8,8 @@ assignees: ''
 # https://github.com/matplotlib/matplotlib/blob/d9aee8eb2bd989d6cfbe21c31ff086dab935bde5/.github/ISSUE_TEMPLATE/questions.md
 ---
 
-If your issue is a usage question, you should ask for help on one of our other channels:
-
-- [email list](https://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis)
-- [Gitter (chat)](https://gitter.im/mne-tools/mne-python)
+If your issue is a usage question, you should ask for help on the
+[MNE Forum](https://mne.discourse.group).
 
 Our GitHub issue tracker is only used to report bugs and suggest improvements
-to MNE-Python. For any other questions, please use the email list or Gitter.
-Usage questions that are posted as GitHub issues are usually closed without
-being answered.
+to MNE-Python. For any other questions, please use the forum.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -7,9 +7,8 @@ documentation improvements (even just typo corrections). The best way to start
 contributing is by `opening an issue`_ on our GitHub page to discuss your ideas
 for changes or enhancements, or to tell us about behavior that you think might
 be a bug in MNE-Python. *For general troubleshooting of scripts that use
-MNE-Python*, you should instead write to the `MNE mailing list`_ or chat with
-developers on the `MNE gitter channel`_. Users and contributors to MNE-Python
-are expected to follow our `code of conduct`_.
+MNE-Python*, you should instead post on the `MNE Forum`_. Users and
+contributors to MNE-Python are expected to follow our `code of conduct`_.
 
 The `contributing guide`_ has details on the preferred contribution workflow
 and how best to configure your system for a smooth experience contributing to
@@ -17,8 +16,6 @@ MNE-Python.
 
 
 .. _`opening an issue`: https://github.com/mne-tools/mne-python/issues/new/choose
-.. _`MNE mailing list`: http://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis
-.. _`MNE gitter channel`: https://gitter.im/mne-tools/mne-python
-
+.. _`MNE Forum`: https://mne.discourse.group
 .. _`code of conduct`: https://github.com/mne-tools/.github/blob/master/CODE_OF_CONDUCT.md
 .. _`contributing guide`: https://mne-tools.github.io/dev/install/contributing.html

--- a/README.rst
+++ b/README.rst
@@ -115,10 +115,10 @@ Please see the documentation on the MNE-Python homepage:
 https://mne.tools/dev/install/contributing.html
 
 
-Mailing list
+Forum
 ^^^^^^^^^^^^
 
-http://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis
+https://mne.discourse.group
 
 
 Licensing

--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ https://mne.tools/dev/install/contributing.html
 
 
 Forum
-^^^^^^^^^^^^
+^^^^^^
 
 https://mne.discourse.group
 

--- a/doc/install/advanced.rst
+++ b/doc/install/advanced.rst
@@ -65,7 +65,7 @@ when choosing which notebook kernel to use. Otherwise, be sure to activate the
 ``mne`` environment before launching the notebook.
 
 If you use another Python setup and you encounter some difficulties please
-report them on the `MNE mailing list`_ or on the `GitHub issues page`_ to get
+report them on the `MNE Forum`_ or on the `GitHub issues page`_ to get
 assistance.
 
 It is also possible to interact with the 3D plots without installing Qt by using

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -22,9 +22,8 @@ documentation improvements (even just typo corrections). The best way to start
 contributing is by `opening an issue`_ on our GitHub page to discuss your ideas
 for changes or enhancements, or to tell us about behavior that you think might
 be a bug in MNE-Python. *For general troubleshooting of scripts that use
-MNE-Python*, you should instead write to the `MNE mailing list`_ or chat with
-developers on the `MNE gitter channel`_. Users and contributors to MNE-Python
-are expected to follow our `code of conduct`_.
+MNE-Python*, you should instead post on the `MNE Forum`_. Users and
+contributors to MNE-Python are expected to follow our `code of conduct`_.
 
 This page has details on the preferred contribution workflow
 and how best to configure your system for a smooth experience contributing to
@@ -39,8 +38,7 @@ MNE-Python.
    guide!
 
 .. _`opening an issue`: https://github.com/mne-tools/mne-python/issues/new/choose
-.. _`MNE mailing list`: http://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis
-.. _`MNE gitter channel`: https://gitter.im/mne-tools/mne-python
+.. _`MNE Forum`: https://mne.discourse.group
 
 .. _`code of conduct`: https://github.com/mne-tools/.github/blob/master/CODE_OF_CONDUCT.md
 .. _`GitHub issues marked "easy"`: https://github.com/mne-tools/mne-python/issues?q=is%3Aissue+is%3Aopen+label%3AEASY

--- a/doc/install/mne_c.rst
+++ b/doc/install/mne_c.rst
@@ -179,8 +179,8 @@ a typical 64-bit Ubuntu-like system this would be accomplished by:
     $ cd /usr/lib/x86_64-linux-gnu
     $ sudo ln -s libgfortran.so.1 $(find . -maxdepth 1 -type f -name libgfortran.so*)
 
-If you encounter other errors installing MNE-C, please send a message to the
-`MNE mailing list`_.
+If you encounter other errors installing MNE-C, please post a message to the
+`MNE Forum`_.
 
 .. links
 

--- a/doc/install/mne_python.rst
+++ b/doc/install/mne_python.rst
@@ -276,8 +276,8 @@ MNE-Python and its dependencies. Typical output looks like this::
 
 If something else went wrong during installation and you can't figure it out,
 check out the :doc:`advanced` page to see if your problem is discussed there.
-If not, the `MNE mailing list`_ and `MNE gitter channel`_ are
-good resources for troubleshooting installation problems.
+If not, the `MNE Forum`_ is a good resources for troubleshooting installation
+problems.
 
 
 Installing a Python IDE

--- a/doc/install/pre_install.rst
+++ b/doc/install/pre_install.rst
@@ -85,8 +85,8 @@ automatically be installed.
 Getting help
 ^^^^^^^^^^^^
 
-Help with installation is available through the `MNE mailing list`_ and
-`MNE gitter channel`_. See the :ref:`help` page for more information.
+Help with installation is available through the `MNE Forum`_. See the
+:ref:`help` page for more information.
 
 
 **Next:** :doc:`mne_python`

--- a/doc/links.inc
+++ b/doc/links.inc
@@ -17,9 +17,8 @@
 .. _`mne command line utilities`: http://www.nmr.mgh.harvard.edu/martinos/userInfo/data/MNE_register/
 .. _`mne-scripts`: https://github.com/mne-tools/mne-scripts/
 .. _`MNE-C manual`: https://mne.tools/mne-c-manual/MNE-manual-2.7.3.pdf
-.. _`MNE mailing list`: http://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis
 .. _`GitHub issues page`: https://github.com/mne-tools/mne-python/issues/
-.. _`MNE gitter channel`: https://gitter.im/mne-tools/mne-python
+.. _`MNE Forum`: https://mne.discourse.group
 .. _`MNE-BIDS`: https://mne-tools.github.io/mne-bids/
 .. _`MNE-HCP`: http://mne-tools.github.io/mne-hcp/
 .. _`MNE-Realtime`: https://github.com/mne-tools/mne-realtime

--- a/doc/overview/datasets_index.rst
+++ b/doc/overview/datasets_index.rst
@@ -6,8 +6,8 @@ Datasets Overview
 .. sidebar:: Contributing datasets to MNE-Python
 
     Do not hesitate to contact MNE-Python developers on the
-    `MNE Forum`_ to discuss the possibility of adding more publicly available
-    datasets.
+    `MNE Forum <https://mne.discourse.group>`_ to discuss the possibility of
+    adding more publicly available datasets.
 
 All the dataset fetchers are available in :mod:`mne.datasets`. To download any of the datasets,
 use the ``data_path`` (fetches full dataset) or the ``load_data`` (fetches dataset partially) functions.

--- a/doc/overview/datasets_index.rst
+++ b/doc/overview/datasets_index.rst
@@ -6,8 +6,8 @@ Datasets Overview
 .. sidebar:: Contributing datasets to MNE-Python
 
     Do not hesitate to contact MNE-Python developers on the
-    `MNE mailing list <http://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis>`_
-    to discuss the possibility of adding more publicly available datasets.
+    `MNE Forum`_ to discuss the possibility of adding more publicly available
+    datasets.
 
 All the dataset fetchers are available in :mod:`mne.datasets`. To download any of the datasets,
 use the ``data_path`` (fetches full dataset) or the ``load_data`` (fetches dataset partially) functions.

--- a/doc/overview/faq.rst
+++ b/doc/overview/faq.rst
@@ -72,7 +72,7 @@ I'm not sure how to do *X* analysis step with my *Y* data...
 ------------------------------------------------------------
 
 Knowing "the right thing" to do with EEG and MEG data is challenging. We use
-the `MNE mailing list`_ to discuss analysis strategies for different kinds of
+the `MNE Forum`_ to discuss analysis strategies for different kinds of
 data. It's worth searching the archives to see if there have been relevant
 discussions in the past, but don't hesitate to ask a new question if the answer
 isn't out there already.
@@ -84,13 +84,12 @@ I think I found a bug, what do I do?
 When you encounter an error message or unexpected results, it can be hard to
 tell whether it happened because of a bug in MNE-Python, a mistake in user
 code, a corrupted data file, or irregularities in the data itself. Your first
-step when asking for help should be the `MNE mailing list`_ or the
-`MNE Gitter channel`_, not GitHub. This bears repeating: *the GitHub issue
-tracker is not for usage help* — it is for software bugs, feature requests, and
-improvements to documentation. If you open an issue that contains only a usage
-question, we will close the issue and direct you to the mailing list or Gitter
-channel. If you're pretty sure the problem you've encountered is a software bug
-(not bad data or user error):
+step when asking for help should be the `MNE Forum`_, not GitHub. This bears
+repeating: *the GitHub issue tracker is not for usage help* — it is for
+software bugs, feature requests, and improvements to documentation. If you
+open an issue that contains only a usage question, we will close the issue and
+direct you to the forum. If you're pretty sure the problem you've encountered
+is a software bug (not bad data or user error):
 
 - Make sure you're using `the most current version`_. You can check it locally
   at a shell prompt with:
@@ -121,14 +120,6 @@ three backticks (\`\`\`) above and below the lines of code. This
 MNE-Python contributors should be able to copy and paste the provided snippet
 and replicate the bug on their own computers.
 
-If you post to the `mailing list
-<https://mail.nmr.mgh.harvard.edu/mailman/listinfo/mne_analysis>`__
-instead, a `GitHub Public Gist <https://gist.github.com>`_ for the code sample
-is recommended; if you use the
-`Gitter channel <https://gitter.im/mne-tools/mne-python>`_ the three backticks
-(\`\`\`) trick works there too.
-
-
 Why is it dangerous to "pickle" my MNE-Python objects and data for later use?
 -----------------------------------------------------------------------------
 
@@ -145,8 +136,8 @@ MNE-Python is designed to provide its own file saving formats (often based on
 the FIF standard) for its objects usually via a ``save`` method or ``write_*``
 method, e.g. :func:`mne.io.Raw.save`, :func:`mne.Epochs.save`,
 :func:`mne.write_evokeds`, :func:`mne.SourceEstimate.save`. If you have some
-data that you want to save but can't figure out how, shoot an email to the `MNE
-mailing list`_ or post it to the `GitHub issues page`_.
+data that you want to save but can't figure out how, post to the `MNE Forum`_
+or to the `GitHub issues page`_.
 
 If you want to write your own data to disk (e.g., subject behavioral scores),
 we strongly recommend using `h5io <https://github.com/h5io/h5io>`_, which is

--- a/doc/overview/get_help.rst
+++ b/doc/overview/get_help.rst
@@ -11,8 +11,8 @@ There are three main channels for obtaining help with MNE software tools.
   :ref:`the installation page <install_python_and_mne_python>` (look for the
   |hand-stop-o| symbols), and some tips related to 3D plotting problems on
   :ref:`the advanced setup page <troubleshoot_3d>`.
-- The `MNE mailing list`_ and `MNE gitter channel`_ are good places to go for
-  both troubleshooting and general questions.
+- The `MNE Forum`_ is a good placed to go for both troubleshooting and general
+  questions.
 - If you want to request new features or if you're confident that you have
   found a bug, please create a new issue on the `GitHub issues page`_.
   When reporting bugs, please try to replicate the bug with the MNE-Python


### PR DESCRIPTION
Replace all mentions of the mailing list and Gitter with references to the new Discourse forum.

Closes #8429