### PR TITLE
MRG, DOC: Make "rank" options in docs more accessible

### DIFF
--- a/mne/rank.py
+++ b/mne/rank.py
@@ -279,6 +279,8 @@ def compute_rank(inst, rank=None, scalings=None, info=None, tol='auto',
     channels or vertices) such that non-zero singular values
     should be close to one.
 
+    .. versionadded:: 0.18
+
     Parameters
     ----------
     inst : instance of Raw, Epochs, or Covariance
@@ -304,8 +306,6 @@ def compute_rank(inst, rank=None, scalings=None, info=None, tol='auto',
     rank : dict
         Estimated rank of the data for each channel type.
         To get the total rank, you can use ``sum(rank.values())``.
-
-    .. versionadded:: 0.18
     """
     from .io.base import BaseRaw
     from .epochs import BaseEpochs

--- a/mne/rank.py
+++ b/mne/rank.py
@@ -279,8 +279,6 @@ def compute_rank(inst, rank=None, scalings=None, info=None, tol='auto',
     channels or vertices) such that non-zero singular values
     should be close to one.
 
-    .. versionadded:: 0.18
-
     Parameters
     ----------
     inst : instance of Raw, Epochs, or Covariance

--- a/mne/rank.py
+++ b/mne/rank.py
@@ -305,27 +305,6 @@ def compute_rank(inst, rank=None, scalings=None, info=None, tol='auto',
         Estimated rank of the data for each channel type.
         To get the total rank, you can use ``sum(rank.values())``.
 
-    Notes
-    -----
-    The ``rank`` parameter can be:
-
-    :data:`python:None` (default)
-        Rank will be estimated from the data after proper scaling of
-        different channel types.
-    ``'info'``
-        Rank is inferred from ``info``. If data have been processed
-        with Maxwell filtering, the Maxwell filtering header is used.
-        Otherwise, the channel counts themselves are used.
-        In both cases, the number of projectors is subtracted from
-        the (effective) number of channels in the data.
-        For example, if Maxwell filtering reduces the rank to 68, with
-        two projectors the returned value will be 68.
-    ``'full'``
-        Rank is assumed to be full, i.e. equal to the
-        number of good channels. If a `Covariance` is passed, this can make
-        sense if it has been (possibly improperly) regularized without taking
-        into account the true data rank.
-
     .. versionadded:: 0.18
     """
     from .io.base import BaseRaw

--- a/mne/rank.py
+++ b/mne/rank.py
@@ -306,6 +306,10 @@ def compute_rank(inst, rank=None, scalings=None, info=None, tol='auto',
     rank : dict
         Estimated rank of the data for each channel type.
         To get the total rank, you can use ``sum(rank.values())``.
+
+    Notes
+    -----
+    .. versionadded:: 0.18
     """
     from .io.base import BaseRaw
     from .epochs import BaseEpochs

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -899,7 +899,7 @@ rank : None | 'info' | 'full' | dict
         data, for instance in case you have calculated it earlier.
         This parameter must be a dictionary whose **keys** correspond to
         channel types in the data (e.g. ``'meg'``, ``'mag'``, ``'grad'``,
-        ``'eeg'``), and whose **values** are integer values representing the
+        ``'eeg'``), and whose **values** are integers representing the
         respective ranks. For example, ``{'mag': 90, 'eeg': 45}`` will assume
         a rank of ``90`` and ``45`` for magnetometer data and EEG data,
         respectively. The ranks for all channel types present in the data, but

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -876,7 +876,7 @@ rank : None | dict | 'info' | 'full'
     This controls the rank computation that can be read from the
     measurement info or estimated from the data.
 
-    :data:`python:None` (default)
+    ``None``
         The rank will be estimated from the data after proper scaling of
         different channel types.
     ``'info'``
@@ -886,7 +886,7 @@ rank : None | dict | 'info' | 'full'
         In both cases, the number of projectors is subtracted from
         the (effective) number of channels in the data.
         For example, if Maxwell filtering reduces the rank to 68, with
-        two projectors the returned value will be 68.
+        two projectors the returned value will be 66.
     ``'full'``
         The rank is assumed to be full, i.e. equal to the
         number of good channels. If a `~mne.Covariance` is passed, this can

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -876,9 +876,6 @@ rank : None | dict | 'info' | 'full'
     This controls the rank computation that can be read from the
     measurement info or estimated from the data.
 
-    .. note:: For Maxwell-filtered data, you will typically want set this to
-              ``'info'``.
-
     :data:`python:None` (default)
         The rank will be estimated from the data after proper scaling of
         different channel types.
@@ -896,8 +893,8 @@ rank : None | dict | 'info' | 'full'
         make sense if it has been (possibly improperly) regularized without
         taking into account the true data rank.
 """
-docdict['rank_None'] = docdict['rank'] + 'The default is None.'
-docdict['rank_info'] = docdict['rank'] + 'The default is "info".'
+docdict['rank_None'] = docdict['rank'] + '\n    The default is ``None``.'
+docdict['rank_info'] = docdict['rank'] + '\n    The default is ``"info"``.'
 docdict['rank_tol'] = """
 tol : float | 'auto'
     Tolerance for singular values to consider non-zero in

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -893,18 +893,21 @@ rank : None | 'info' | 'full' | dict
         make sense if it has been (possibly improperly) regularized without
         taking into account the true data rank.
     :data:`python:dict`
-        A dictionary whose **keys** correspond to channels types in the data
-        (e.g. ``'meg'``, ``'mag'``, ``'grad'``, ``'eeg'``), and whose
-        **values** are integer values representing the respective ranks, which
-        you may have calculated earlier.
-        For example, ``{'mag': 90, 'eeg': 45}`` will assume a rank of ``90``
-        and ``45`` for magnetometer data and EEG data, respectively. The ranks
-        for all channel types present in the data, but **not** specified in the
-        dictionary will be estimated empirically. That is, if you passed a
-        dataset containing magnetometer, gradiometer, and EEG data together
-        with the dictionary from the previous example, only the gradiometer
-        rank would be determined, while the specified magnetometer and EEG
-        ranks would be taken for granted.
+        Calculate the rank only for a subset of channel types, and explicitly
+        specify the rank for the remaining channel types. This can be
+        extremely useful if you already **know** the rank of (part of) your
+        data, for instance in case you have calculated it earlier.
+        This parameter must be a dictionary whose **keys** correspond to
+        channels types in the data (e.g. ``'meg'``, ``'mag'``, ``'grad'``,
+        ``'eeg'``), and whose **values** are integer values representing the
+        respective ranks. For example, ``{'mag': 90, 'eeg': 45}`` will assume
+        a rank of ``90`` and ``45`` for magnetometer data and EEG data,
+        respectively. The ranks for all channel types present in the data, but
+        **not** specified in the dictionary will be estimated empirically.
+        That is, if you passed a dataset containing magnetometer, gradiometer,
+        and EEG data together with the dictionary from the previous example,
+        only the gradiometer rank would be determined, while the specified
+        magnetometer and EEG ranks would be taken for granted.
 """
 docdict['rank_None'] = docdict['rank'] + '\n    The default is ``None``.'
 docdict['rank_info'] = docdict['rank'] + '\n    The default is ``"info"``.'

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -882,7 +882,7 @@ rank : None | dict | 'info' | 'full'
     :data:`python:None` (default)
         The rank will be estimated from the data after proper scaling of
         different channel types.
-    ``'info'``        
+    ``'info'``
         The rank is inferred from ``info``. If data have been processed
         with Maxwell filtering, the Maxwell filtering header is used.
         Otherwise, the channel counts themselves are used.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -898,7 +898,7 @@ rank : None | 'info' | 'full' | dict
         extremely useful if you already **know** the rank of (part of) your
         data, for instance in case you have calculated it earlier.
         This parameter must be a dictionary whose **keys** correspond to
-        channels types in the data (e.g. ``'meg'``, ``'mag'``, ``'grad'``,
+        channel types in the data (e.g. ``'meg'``, ``'mag'``, ``'grad'``,
         ``'eeg'``), and whose **values** are integer values representing the
         respective ranks. For example, ``{'mag': 90, 'eeg': 45}`` will assume
         a rank of ``90`` and ``45`` for magnetometer data and EEG data,

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -874,8 +874,28 @@ extended_proj : list
 docdict['rank'] = """
 rank : None | dict | 'info' | 'full'
     This controls the rank computation that can be read from the
-    measurement info or estimated from the data. See ``Notes``
-    of :func:`mne.compute_rank` for details."""
+    measurement info or estimated from the data.
+
+    .. note:: For Maxwell-filtered data, you will typically want set this to
+              ``'info'``.
+
+    :data:`python:None` (default)
+        The rank will be estimated from the data after proper scaling of
+        different channel types.
+    ``'info'``        
+        The rank is inferred from ``info``. If data have been processed
+        with Maxwell filtering, the Maxwell filtering header is used.
+        Otherwise, the channel counts themselves are used.
+        In both cases, the number of projectors is subtracted from
+        the (effective) number of channels in the data.
+        For example, if Maxwell filtering reduces the rank to 68, with
+        two projectors the returned value will be 68.
+    ``'full'``
+        The rank is assumed to be full, i.e. equal to the
+        number of good channels. If a `~mne.Covariance` is passed, this can
+        make sense if it has been (possibly improperly) regularized without
+        taking into account the true data rank.
+"""
 docdict['rank_None'] = docdict['rank'] + 'The default is None.'
 docdict['rank_info'] = docdict['rank'] + 'The default is "info".'
 docdict['rank_tol'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -899,7 +899,7 @@ rank : None | 'info' | 'full' | dict
         you may have calculated earlier.
         For example, ``{'mag': 90, 'eeg': 45}`` will assume a rank of ``90``
         and ``45`` for magnetometer data and EEG data, respectively. The ranks
-        for all channel types present in the data, but **not** specified in the 
+        for all channel types present in the data, but **not** specified in the
         dictionary will be estimated empirically. That is, if you passed a
         dataset containing magnetometer, gradiometer, and EEG data together
         with the dictionary from the previous example, only the gradiometer

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -876,7 +876,7 @@ rank : None | 'info' | 'full' | dict
     This controls the rank computation that can be read from the
     measurement info or estimated from the data.
 
-    ``None``
+    :data:`python:None`
         The rank will be estimated from the data after proper scaling of
         different channel types.
     ``'info'``
@@ -892,25 +892,28 @@ rank : None | 'info' | 'full' | dict
         number of good channels. If a `~mne.Covariance` is passed, this can
         make sense if it has been (possibly improperly) regularized without
         taking into account the true data rank.
-    :data:`python:dict`
+    :class:`dict`
         Calculate the rank only for a subset of channel types, and explicitly
         specify the rank for the remaining channel types. This can be
         extremely useful if you already **know** the rank of (part of) your
         data, for instance in case you have calculated it earlier.
+
         This parameter must be a dictionary whose **keys** correspond to
         channel types in the data (e.g. ``'meg'``, ``'mag'``, ``'grad'``,
         ``'eeg'``), and whose **values** are integers representing the
         respective ranks. For example, ``{'mag': 90, 'eeg': 45}`` will assume
         a rank of ``90`` and ``45`` for magnetometer data and EEG data,
-        respectively. The ranks for all channel types present in the data, but
+        respectively.
+
+        The ranks for all channel types present in the data, but
         **not** specified in the dictionary will be estimated empirically.
         That is, if you passed a dataset containing magnetometer, gradiometer,
         and EEG data together with the dictionary from the previous example,
         only the gradiometer rank would be determined, while the specified
         magnetometer and EEG ranks would be taken for granted.
 """
-docdict['rank_None'] = docdict['rank'] + '\n    The default is ``None``.'
-docdict['rank_info'] = docdict['rank'] + '\n    The default is ``"info"``.'
+docdict['rank_None'] = docdict['rank'] + "\n    The default is ``None``."
+docdict['rank_info'] = docdict['rank'] + "\n    The default is ``'info'``."
 docdict['rank_tol'] = """
 tol : float | 'auto'
     Tolerance for singular values to consider non-zero in

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -872,7 +872,7 @@ extended_proj : list
 
 # Rank
 docdict['rank'] = """
-rank : None | dict | 'info' | 'full'
+rank : None | 'info' | 'full' | dict
     This controls the rank computation that can be read from the
     measurement info or estimated from the data.
 
@@ -892,6 +892,19 @@ rank : None | dict | 'info' | 'full'
         number of good channels. If a `~mne.Covariance` is passed, this can
         make sense if it has been (possibly improperly) regularized without
         taking into account the true data rank.
+    :data:`python:dict`
+        A dictionary whose **keys** correspond to channels types in the data
+        (e.g. ``'meg'``, ``'mag'``, ``'grad'``, ``'eeg'``), and whose
+        **values** are integer values representing the respective ranks, which
+        you may have calculated earlier.
+        For example, ``{'mag': 90, 'eeg': 45}`` will assume a rank of ``90``
+        and ``45`` for magnetometer data and EEG data, respectively. The ranks
+        for all channel types present in the data, but **not** specified in the 
+        dictionary will be estimated empirically. That is, if you passed a
+        dataset containing magnetometer, gradiometer, and EEG data together
+        with the dictionary from the previous example, only the gradiometer
+        rank would be determined, while the specified magnetometer and EEG
+        ranks would be taken for granted.
 """
 docdict['rank_None'] = docdict['rank'] + '\n    The default is ``None``.'
 docdict['rank_info'] = docdict['rank'] + '\n    The default is ``"info"``.'


### PR DESCRIPTION
Basically, I just moved the explanation of the different "rank" settings from the Notes section up to the `rank` parameter, where I think they belong. I also added an info box, suggesting to use `rank='info'` on Maxwell-filtered data. I had discussed this with @SophieHerbst, but would appreciate feedback from @agramfort and / or @larsoner
