### PR TITLE
WIP: Compare Beer-lambert to HOMER

### DIFF
--- a/mne/preprocessing/nirs/_beer_lambert_law.py
+++ b/mne/preprocessing/nirs/_beer_lambert_law.py
@@ -44,7 +44,7 @@ def beer_lambert_law(raw, ppf=0.1):
         EL = abs_coef * distances[ii] * ppf
         iEL = linalg.pinv(EL)
 
-        raw._data[[ii, ii + 1]] = (raw._data[[ii, ii + 1]].T @ iEL.T).T * 1e-3
+        raw._data[[ii, ii + 1]] = iEL @ raw._data[[ii, ii + 1]] * 1e-3
 
         # Update channel information
         coil_dict = dict(hbo=FIFF.FIFFV_COIL_FNIRS_HBO,


### PR DESCRIPTION
@rob-luke I'm trying to replicate some analysis done in HOMER and I can come pretty close when I use `beer_lambert(raw, ppf=30)` (MNE opaque, HOMER translucent):

![ch_10_h](https://user-images.githubusercontent.com/2365790/103930265-788de080-50ec-11eb-9b20-f0f79895b282.png)

The HOMER analysis used a partial pathlength factor of 6 mm. Any idea why I need to use `ppf=30` instead of `ppf=6` to get a  match? Does it have to do with HOMER using a "modified" Beer-Lambert law (MBLL)?

Speaking of which, I'm trying to reconcile 4.7 on page 35 of http://www.nmr.mgh.harvard.edu/DOT/resources/homer/HomER_UsersGuide_05-07-28.pdf with our code but I can't. Could you push some commits to add comments and/or point me to some docs that would allow me to put some inline code comments about the equations?

In the meantime this PR is just a cosmetic `(A.T @ B.T).T -> B @ A` change.