### PR TITLE
MRG, BUG: Fix Report.add_bem_to_section n_jobs != 1

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -27,7 +27,7 @@ Bugs
 
 - Fix bug with :func:`mne.preprocessing.maxwell_filter` where the eSSS basis had to exactly match the good channels instead of being a superset (:gh:`8675` by `Eric Larson`_)
 
-- Fix bug with :meth:`mne.Report.add_bem_to_section` where ``n_jobs != 1`` would cause ``n_jobs`` subsets of MRI images in some orientations to be flipped (:gh:`8712` by `Eric Larson`_)
+- Fix bug with :meth:`mne.Report.add_bem_to_section` where ``n_jobs != 1`` would cause ``n_jobs`` subsets of MRI images in some orientations to be flipped (:gh:`8713` by `Eric Larson`_)
 
 - Fix bug with :meth:`raw.plot() <mne.io.Raw.plot>` where annotations didn't immediately appear when changing window duration (:gh:`8689` by `Daniel McCloy`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -27,6 +27,8 @@ Bugs
 
 - Fix bug with :func:`mne.preprocessing.maxwell_filter` where the eSSS basis had to exactly match the good channels instead of being a superset (:gh:`8675` by `Eric Larson`_)
 
+- Fix bug with :meth:`mne.Report.add_bem_to_section` where ``n_jobs != 1`` would cause ``n_jobs`` subsets of MRI images in some orientations to be flipped (:gh:`8712` by `Eric Larson`_)
+
 - Fix bug with :meth:`raw.plot() <mne.io.Raw.plot>` where annotations didn't immediately appear when changing window duration (:gh:`8689` by `Daniel McCloy`_)
 
 API changes

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -444,7 +444,7 @@ def _plot_mri_contours(mri_fname, surfaces, src, orientation='coronal',
     fig.subplots_adjust(left=0., bottom=0., right=1., top=1., wspace=0.,
                         hspace=0.)
     plt_show(show, fig=fig)
-    return out
+    return out, flip_z
 
 
 def plot_bem(subject=None, subjects_dir=None, orientation='coronal',

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -555,7 +555,7 @@ def plot_bem(subject=None, subjects_dir=None, orientation='coronal',
 
     # Plot the contours
     return _plot_mri_contours(mri_fname, surfaces, src, orientation, slices,
-                              show, show_indices, show_orientation)
+                              show, show_indices, show_orientation)[0]
 
 
 def _get_bem_plotting_surfaces(bem_path):

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -148,6 +148,7 @@ def test_plot_topomap_animation(capsys):
     plt.close('all')
 
 
+@pytest.mark.filterwarnings('ignore:.*No contour levels.*:UserWarning')
 def test_plot_topomap_animation_nirs(fnirs_evoked, capsys):
     """Test topomap plotting for nirs data."""
     fig, anim = fnirs_evoked.animate_topomap(ch_type='hbo', verbose='debug')

--- a/tools/setup_xvfb.sh
+++ b/tools/setup_xvfb.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -ef
 
+sudo apt-get update
 sudo apt-get install -yqq libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset


### PR DESCRIPTION
Fixes a bug where, because of the `flip_z` that occurs in the MRI orthoview rendering, subsets of the BEMs were flipped when `n_jobs != 1` (otherwise it was flipped as a whole, which was still wrong but less annoying).