### PR TITLE
WIP: Add width argument, reduce default

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -19,7 +19,7 @@ Enhancements
 ~~~~~~~~~~~~
 - Update the ``notebook`` 3d backend to use ``ipyvtk_simple`` for a better integration within ``Jupyter`` (:gh:`8503` by `Guillaume Favelier`_)
 
-- Add toggle-all button to :class:`mne.Report` HTML (:gh:`8723` by `Eric Larson`_)
+- Add toggle-all button to :class:`mne.Report` HTML and ``width`` argument to :meth:`mne.Report.add_bem_to_section` (:gh:`8723` by `Eric Larson`_)
 
 - Speed up :func:`mne.inverse_sparse.tf_mixed_norm` using STFT/ISTFT linearity (:gh:`8697` by `Eric Larson`_)
 
@@ -34,6 +34,8 @@ Bugs
 - Fix bug with :meth:`raw.plot() <mne.io.Raw.plot>` where annotations didn't immediately appear when changing window duration (:gh:`8689` by `Daniel McCloy`_)
 
 - Fix bug with :func:`mne.io.read_raw_nicolet` where header type values such as num_sample and duration_in_sec where not parsed properly (:gh:`8712` by `Alex Gramfort`_)
+
+- Fix bug with ``replace`` argument of :meth:`mne.Report.add_bem_to_section` and :meth:`mne.Report.add_slider_to_section` (:gh:`8723` by `Eric Larson`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/report.py
+++ b/mne/report.py
@@ -715,7 +715,7 @@ Created on {{date}}.
 </footer>
 </body>
 </html>
-""")
+""")  # noqa: E501
 
 html_template = Template(u"""
 <li class="{{div_klass}}" id="{{id}}">
@@ -1828,7 +1828,6 @@ class Report(object):
 
     def _render_raw(self, raw_fname, data_path):
         """Render raw (only text)."""
-        import matplotlib.pyplot as plt
         global_id = self._get_id()
 
         raw = read_raw_fif(raw_fname, allow_maxshield='yes')

--- a/mne/report.py
+++ b/mne/report.py
@@ -24,11 +24,12 @@ from . import read_evokeds, read_events, pick_types, read_cov
 from .io import read_raw_fif, read_info
 from .io.pick import _DATA_CH_TYPES_SPLIT
 from .source_space import _mri_orientation
-from .utils import (logger, verbose, get_subjects_dir, warn,
+from .utils import (logger, verbose, get_subjects_dir, warn, _ensure_int,
                     fill_doc, _check_option, _validate_type, _safe_input)
 from .viz import (plot_events, plot_alignment, plot_cov, plot_projs_topomap,
                   plot_compare_evokeds)
 from .viz.misc import _plot_mri_contours, _get_bem_plotting_surfaces
+from .viz.utils import _ndarray_to_fig, _figure_agg
 from .forward import read_forward_solution
 from .epochs import read_epochs
 from .minimum_norm import read_inverse_operator
@@ -51,14 +52,6 @@ SECTION_ORDER = ['raw', 'events', 'epochs', 'ssp', 'evoked', 'covariance',
 
 ###############################################################################
 # PLOTTING FUNCTIONS
-
-def _ndarray_to_fig(img):
-    """Convert to MPL figure, adapted from matplotlib.image.imsave."""
-    figsize = np.array(img.shape[:2][::-1]) / 100.
-    fig = _figure_agg(dpi=100, figsize=figsize, frameon=False)
-    fig.figimage(img)
-    return fig
-
 
 def _fig_to_img(fig, image_format='png', scale=None, **kwargs):
     """Plot figure and create a binary image."""
@@ -401,14 +394,6 @@ def open_report(fname, **params):
 ###############################################################################
 # IMAGE FUNCTIONS
 
-def _figure_agg(**kwargs):
-    from matplotlib.figure import Figure
-    from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
-    fig = Figure(**kwargs)
-    FigureCanvas(fig)
-    return fig
-
-
 def _build_image_png(data, cmap='gray'):
     """Build an image encoded in base64."""
     import matplotlib.pyplot as plt
@@ -417,7 +402,7 @@ def _build_image_png(data, cmap='gray'):
     if figsize[0] == 1:
         figsize = tuple(figsize[1:])
         data = data[:, :, 0]
-    fig = _figure_agg(figsize=figsize, dpi=1.0, frameon=False)
+    fig = _figure_agg(figsize=figsize, dpi=100, frameon=False)
     cmap = getattr(plt.cm, cmap, plt.cm.gray)
     fig.figimage(data, cmap=cmap)
     output = BytesIO()
@@ -546,6 +531,7 @@ header_template = Template(u"""
             const [all, on, off] = getAllOnOff();
             const a = $('.mnetoggleall-btn').children();
             if (all.length == on.length)
+                /* If this character is changed, it should be changed in the HTML below as well */
                 a.html('☒')
             else
                 a.html('☑')
@@ -575,11 +561,28 @@ header_template = Template(u"""
         if (location.hash) shiftWindow();
         window.addEventListener("hashchange", shiftWindow);
 
+        /* Prevent navbar from covering content */
+        function fixNavbarPadding() {
+            $('body').css('padding-top', parseInt($('#main-navbar').css("height"))-30);
+        }
+        $(window).resize(function () { fixNavbarPadding(); });
+        $(window).load(function () { fixNavbarPadding(); });
+        var observer = new MutationObserver(function(mutations) {
+          mutations.forEach(function(mutation) {
+            if (mutation.attributeName === "class") {
+              var attributeValue = $(mutation.target).prop(mutation.attributeName);
+              if (attributeValue.includes(" in") || attributeValue.includes(" collapse")) {
+                fixNavbarPadding();
+              }
+            }
+          });
+        });
+
         /* Update things when document is ready */
         $( document ).ready(function() {
             updateToggleAllButton();
+            observer.observe($("#viewnavbar")[0], {attributes: true});
         });
-
         </script>
 <style type="text/css">
 
@@ -629,7 +632,6 @@ li{
 }
 
 #toc {
-  margin-top: navbar-height;
   position: fixed;
   width: 20%;
   height: 90%;
@@ -647,13 +649,8 @@ li{
     padding: 0 2px 3px 0;
 }
 
-div.footer {
-    background-color: #C0C0C0;
-    color: #000000;
-    padding: 3px 8px 3px 0;
-    clear: both;
-    font-size: 0.8em;
-    text-align: right;
+#godown{
+   height: 0px;
 }
 
 .navbar-toggle:after {
@@ -662,47 +659,61 @@ div.footer {
 .navbar-toggle.collapsed:after {
     content: "▼";
 }
+footer .navbar-fixed-bottom {
+    min-height: 0px;
+}
+footer .navbar-text {
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
+.w-100 {
+    width: 100%;
+}
 
 </style>
 </head>
 <body>
 
-<nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+<nav class="navbar navbar-inverse navbar-fixed-top navbar-static-top" role="navigation" id="main-navbar">
     <div class="container-fluid">
         <div class="navbar-header navbar-left">
             <ul class="nav nav-pills"><li class="active">
                 <a class="navbar-toggle" data-toggle="collapse" data-target="#viewnavbar" href="javascript:void(0)"></a>
             </li></ul>
-    </div>
+        </div>
         <h3 class="navbar-text" style="color:white">{{title}}</h3>
-        <ul class="nav nav-pills navbar-right in" style="margin-top: 7px;" id="viewnavbar">
+        <div class="nav-collapse navbar-right in" id="viewnavbar">
+            <ul class="nav nav-pills">
 
-        {{for section in sections}}
+            {{for section in sections}}
 
-        <li class="active {{sectionvars[section]}}-btn">
-           <a href="javascript:void(0)" onclick="toggleButton('.{{sectionvars[section]}}')" class="has_toggle">
-               {{section}}
-           </a>
-        </li>
+            <li class="active {{sectionvars[section]}}-btn">
+               <a href="javascript:void(0)" onclick="toggleButton('.{{sectionvars[section]}}')" class="has_toggle">
+                   {{section}}
+               </a>
+            </li>
 
-        {{endfor}}
+            {{endfor}}
 
-        <li class="active mnetoggleall-btn">
-           <a href="javascript:void(0)" onclick="toggleButton('.mnetoggleall')"> </a>
-        </li>
+            <li class="active mnetoggleall-btn">
+               <a href="javascript:void(0)" onclick="toggleButton('.mnetoggleall')">☒</a>
+            </li>
 
-        </ul>
+            </ul>
+        </div>
     </div>
 </nav>
 """)  # noqa: E501
 
 footer_template = HTMLTemplate(u"""
-</div></body>
-<div class="footer">
-        &copy; Copyright 2012-{{current_year}}, MNE Developers.
-      Created on {{date}}.
-      Powered by <a href="http://mne.tools/">MNE.
 </div>
+<footer>
+<div class="navbar navbar-default navbar-fixed-bottom text-center"><p class="navbar-text col-md-12">
+Created on {{date}}.
+</p></div></div>
+</footer>
+</body>
 </html>
 """)
 
@@ -1228,7 +1239,7 @@ class Report(object):
     @verbose
     def add_bem_to_section(self, subject, caption='BEM', section='bem',
                            decim=2, n_jobs=1, subjects_dir=None,
-                           replace=False, verbose=None):
+                           replace=False, width=512, verbose=None):
         """Render a bem slider html str.
 
         Parameters
@@ -1248,23 +1259,31 @@ class Report(object):
         replace : bool
             If ``True``, figures already present that have the same caption
             will be replaced. Defaults to ``False``.
+        width : int
+            The width of the MRI images (in pixels). Larger values will have
+            clearer surface lines, but will create larger HTML files.
+            Typically a factor of 2 more than the number of MRI voxels along
+            each dimension (typically 512, default) is reasonable.
+
+            .. versionadded:: 0.23
         %(verbose_meth)s
 
         Notes
         -----
         .. versionadded:: 0.9.0
         """
+        width = _ensure_int(width, 'width')
         caption = 'custom plot' if caption == '' else caption
         html = self._render_bem(subject=subject, subjects_dir=subjects_dir,
                                 decim=decim, n_jobs=n_jobs, section=section,
-                                caption=caption)
+                                caption=caption, width=width)
         html, caption, _ = self._validate_input(html, caption, section)
         sectionvar = self._sectionvars[section]
         # convert list->str
         assert isinstance(html, list)
         html = u''.join(html)
         self._add_or_replace('%s-#-%s-#-custom' % (caption[0], sectionvar),
-                             sectionvar, html)
+                             sectionvar, html, replace=replace)
 
     def add_slider_to_section(self, figs, captions=None, section='custom',
                               title='Slider', scale=None, image_format=None,
@@ -1362,7 +1381,8 @@ class Report(object):
             slider_full_template.substitute(id=global_id, title=title,
                                             div_klass=slider_klass,
                                             slider_id=slider_id, html=html,
-                                            image_html=image_html))
+                                            image_html=image_html),
+            replace=replace)
 
     ###########################################################################
     # HTML rendering
@@ -1765,7 +1785,8 @@ class Report(object):
         self.html.insert(1, html_toc)  # insert TOC
 
     def _render_one_bem_axis(self, mri_fname, surfaces, global_id,
-                             orientation='coronal', decim=2, n_jobs=1):
+                             orientation='coronal', decim=2, n_jobs=1,
+                             width=512):
         """Render one axis of bem contours (only PNG)."""
         import nibabel as nib
         nim = nib.load(mri_fname)
@@ -1781,10 +1802,10 @@ class Report(object):
         logger.debug(f'Rendering BEM {orientation} with {len(sl)} slices')
         kwargs = dict(mri_fname=mri_fname, surfaces=surfaces, show=False,
                       orientation=orientation, img_output=True, src=None,
-                      show_orientation=True)
+                      show_orientation=True, width=width)
         imgs = _figs_to_mrislices(sl, n_jobs, **kwargs)
         slices = []
-        img_klass = 'slideimg-%s' % name
+        img_klass = 'slideimg-%s w-100' % name
         div_klass = 'span12 %s' % slides_klass
         for ii, img in enumerate(imgs):
             slice_id = '%s-%s-%s' % (name, global_id, sl[ii])
@@ -1838,11 +1859,9 @@ class Report(object):
 
         raw_psd = {} if self.raw_psd is True else self.raw_psd
         if isinstance(raw_psd, dict):
-            from matplotlib.backends.backend_agg import FigureCanvasAgg
             n_ax = sum(kind in raw for kind in _DATA_CH_TYPES_SPLIT)
-            fig, axes = plt.subplots(n_ax, 1, figsize=(6, 1 + 1.5 * n_ax),
-                                     dpi=92)
-            FigureCanvasAgg(fig)
+            fig = _figure_agg(figsize=(6, 1 + 1.5 * n_ax), dpi=92)
+            axes = [fig.add_subplot(1, n_ax, ii + 1) for ii in range(n_ax)]
             img = _fig_to_img(raw.plot_psd, self.image_format,
                               ax=axes, **raw_psd)
             new_html = image_template.substitute(
@@ -2076,7 +2095,7 @@ class Report(object):
             return html
 
     def _render_bem(self, subject, subjects_dir, decim, n_jobs,
-                    section='bem', caption='BEM'):
+                    section='bem', caption='BEM', width=512):
         """Render mri+bem (only PNG)."""
         if subjects_dir is None:
             subjects_dir = self.subjects_dir
@@ -2108,7 +2127,7 @@ class Report(object):
         html += u'<h4>%s</h4>\n' % name  # all other captions are h4
         for view in _BEM_VIEWS:
             html += self._render_one_bem_axis(mri_fname, surfaces, global_id,
-                                              view, decim, n_jobs)
+                                              view, decim, n_jobs, width)
         html += u'</li>\n'
         return ''.join(html)
 

--- a/mne/viz/_brain/mplcanvas.py
+++ b/mne/viz/_brain/mplcanvas.py
@@ -9,7 +9,7 @@ from ...fixes import nullcontext
 
 
 class MplCanvas(object):
-    """Ultimately, this is a QWidget (as well as a FigureCanvasAgg, etc.)."""
+    """Ultimately, this is a QWidget (as well as a FigureCanvasQTAgg, etc.)."""
 
     def __init__(self, brain, width, height, dpi, notebook=False):
         from matplotlib import rc_context

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -25,6 +25,7 @@ from tvtk.pyface.tvtk_scene import TVTKScene
 
 from .base_renderer import _BaseRenderer
 from ._utils import _check_color, _alpha_blend_background, ALLOWED_QUIVER_MODES
+from ..utils import _ndarray_to_fig
 from ...surface import _normalize_vectors
 from ...utils import (_import_mlab, _validate_type, SilenceStdout,
                       copy_base_doc_to_subclass_doc, _check_option)
@@ -481,12 +482,7 @@ def _check_3d_figure(figure):
 
 
 def _save_figure(img, filename):
-    from matplotlib.backends.backend_agg import FigureCanvasAgg
-    from matplotlib.figure import Figure
-    fig = Figure(frameon=False)
-    FigureCanvasAgg(fig)
-    fig.figimage(img, resize=True)
-    fig.savefig(filename)
+    _ndarray_to_fig(img).savefig(filename)
 
 
 def _close_3d_figure(figure):

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -39,7 +39,8 @@ from ..utils import (logger, verbose, warn, _check_option, get_subjects_dir,
                      _mask_to_onsets_offsets, _pl, _on_missing)
 from ..io.pick import _picks_by_type
 from ..filter import estimate_ringing_samples
-from .utils import tight_layout, _get_color_list, _prepare_trellis, plt_show
+from .utils import (tight_layout, _get_color_list, _prepare_trellis, plt_show,
+                    _figure_agg)
 
 
 def _index_info_cov(info, cov, exclude):
@@ -305,7 +306,7 @@ def plot_source_spectrogram(stcs, freq_bins, tmin=None, tmax=None,
 
 def _plot_mri_contours(mri_fname, surfaces, src, orientation='coronal',
                        slices=None, show=True, show_indices=False,
-                       show_orientation=False, img_output=False):
+                       show_orientation=False, img_output=False, width=512):
     """Plot BEM contours on anatomical slices."""
     import matplotlib.pyplot as plt
     from matplotlib import patheffects
@@ -365,17 +366,21 @@ def _plot_mri_contours(mri_fname, surfaces, src, orientation='coronal',
 
     if img_output:
         n_col = n_axes = 1
-        fig, ax = plt.subplots(1, 1, figsize=(7.0, 7.0))
+        dpi = 96
+        # 2x standard MRI resolution is probably good enough for the
+        # traces
+        w = width / dpi
+        figsize = (w, w / data.shape[x] * data.shape[y])
+        fig = _figure_agg(figsize=figsize, dpi=dpi, facecolor='k')
+        ax = fig.add_axes([0, 0, 1, 1], frame_on=False, facecolor='k')
         axs = [ax] * len(slices)
-
-        w = fig.get_size_inches()[0]
-        fig.set_size_inches([w, w / data.shape[x] * data.shape[y]])
         plt.close(fig)
     else:
         n_col = 4
         fig, axs, _, _ = _prepare_trellis(len(slices), n_col)
+        fig.set_facecolor('k')
+        dpi = fig.get_dpi()
         n_axes = len(axs)
-    fig.set_facecolor('k')
     bounds = np.concatenate(
         [[-np.inf], slices[:-1] + np.diff(slices) / 2., [np.inf]])  # float
     slicer = [slice(None)] * 3
@@ -438,7 +443,7 @@ def _plot_mri_contours(mri_fname, surfaces, src, orientation='coronal',
         if img_output:
             output = BytesIO()
             fig.savefig(output, bbox_inches='tight',
-                        pad_inches=0, format='png')
+                        pad_inches=0, format='png', dpi=dpi)
             out.append(base64.b64encode(output.getvalue()).decode('ascii'))
 
     fig.subplots_adjust(left=0., bottom=0., right=1., top=1., wspace=0.,

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -59,7 +59,7 @@ def test_plot_topomap_interactive():
 
     plt.close('all')
     fig = plt.figure()
-    ax = fig.gca()
+    ax, canvas = fig.gca(), fig.canvas
 
     kwargs = dict(vmin=-240, vmax=240, times=[0.1], colorbar=False, axes=ax,
                   res=8, time_unit='s')

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -14,8 +14,6 @@ from numpy.testing import assert_array_equal, assert_equal
 import pytest
 import matplotlib
 import matplotlib.pyplot as plt
-from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
-from matplotlib.figure import Figure
 from matplotlib.patches import Circle
 
 from mne import (read_evokeds, read_proj, make_fixed_length_events, Epochs,
@@ -60,8 +58,7 @@ def test_plot_topomap_interactive():
     evoked.add_proj(compute_proj_evoked(evoked, n_mag=1))
 
     plt.close('all')
-    fig = Figure()
-    canvas = FigureCanvas(fig)
+    fig = plt.figure()
     ax = fig.gca()
 
     kwargs = dict(vmin=-240, vmax=240, times=[0.1], colorbar=False, axes=ax,

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2270,3 +2270,20 @@ def centers_to_edges(*arrays):
             arr[:-1] + arr_diff,
             [arr[-1] + arr_diff[-1]]]))
     return out
+
+
+def _figure_agg(**kwargs):
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+    from matplotlib.figure import Figure
+    fig = Figure(**kwargs)
+    FigureCanvasAgg(fig)
+    return fig
+
+
+def _ndarray_to_fig(img):
+    """Convert to MPL figure, adapted from matplotlib.image.imsave."""
+    dpi = 100
+    figsize = np.array(img.shape[:2][::-1]) / dpi
+    fig = _figure_agg(dpi=dpi, figsize=figsize, frameon=False)
+    fig.figimage(img, resize=True)
+    return fig

--- a/tutorials/misc/plot_report.py
+++ b/tutorials/misc/plot_report.py
@@ -177,7 +177,7 @@ report.save('report_cov.html', overwrite=True)
 #
 # The python interface has greater flexibility compared to the :ref:`command
 # line interface <mne report>`. For example, custom plots can be added via
-# the :meth:`~mne.Report.add_figs_to_section` method, and sliders with the
+# the :meth:`~mne.Report.add_figs_to_section` method, and sliders via the
 # :meth:`~mne.Report.add_slider_to_section`:
 
 # generate a custom plot:


### PR DESCRIPTION
1. Add `width` argument to `add_bems_to_section`, change from old default (7 inches in whatever your DPI was) to 512, thus reducing file sizes without losing any meaningful quality (2x the typical MRI resolution should be enough to see the BEM contours clearly). On my system this cuts down on the resulting report file size by a factor of 2.
2. Change CSS to have the images span 100% of the usable space (browser-upscaling)
3. Have BEM generation use Agg backend
4. DRY Agg-figure code
5. Fix bugs with `replace` being omitted in some Report functions
6. Make footer just show the date of creation, and make it sticky (informative, no need to advertise MNE nowadays I think)
7. Make header padding responsive to sizing changes. You can see the differences especially with an example like the following on `master` and this PR:
    ```
    import mne
    report = mne.Report()
    for html in range(10):
        html = str(html) * 20
        report.add_htmls_to_section(html, captions=html, section=html)
    report.save('report.html', overwrite=True)
    ```
    Changing the window size and toggling the visibility of the buttons no longer covers the page contents.

FYI I am using `Report` to look at a few dozen bad FreeSurfer BEMs and iteratively replace them as I fix them (in principle, have fixed 0 so far), hence why I'm finding and fixing all these bugs and making things more usable.