### PR TITLE
DOC: don't use single letter variable name in _compute_forward

### DIFF
--- a/mne/forward/_compute_forward.py
+++ b/mne/forward/_compute_forward.py
@@ -475,10 +475,10 @@ def _do_prim_curr(rr, coils):
     del coils
     pc = np.empty((len(rr) * 3, n_coils))
     for start, stop in _rr_bounds(rr, chunk=1):
-        p = _bem_inf_fields(rr[start:stop], rmags, cosmags)
-        p *= ws
-        p.shape = (3 * (stop - start), -1)
-        pc[3 * start:3 * stop] = [bincount(bins, pp, bins[-1] + 1) for pp in p]
+        pp = _bem_inf_fields(rr[start:stop], rmags, cosmags)
+        pp *= ws
+        pp.shape = (3 * (stop - start), -1)
+        pc[3 * start:3 * stop] = [bincount(bins, this_pp, bins[-1] + 1) for this_pp in pp]
     return pc
 
 

--- a/mne/forward/_compute_forward.py
+++ b/mne/forward/_compute_forward.py
@@ -478,7 +478,8 @@ def _do_prim_curr(rr, coils):
         pp = _bem_inf_fields(rr[start:stop], rmags, cosmags)
         pp *= ws
         pp.shape = (3 * (stop - start), -1)
-        pc[3 * start:3 * stop] = [bincount(bins, this_pp, bins[-1] + 1) for this_pp in pp]
+        pc[3 * start:3 * stop] = [bincount(bins, this_pp, bins[-1] + 1)
+                                  for this_pp in pp]
     return pc
 
 


### PR DESCRIPTION
I got a very cryptic error today when computing the forward:

```py
--> 270 fwd = mne.make_forward_solution(raw.info, trans_fname, src, bem)
    271 inv = make_inverse_operator(raw.info, fwd, cov)
    272 

<decorator-gen-302> in make_forward_solution(info, trans, src, bem, meg, eeg, mindist, ignore_ref, n_jobs, verbose)

/autofs/space/meghnn_001/users/mjas/github_repos/mne-python/mne/forward/_make_forward.py in make_forward_solution(***failed resolving arguments***)
    601     ccoils = [compcoils, None]
    602     infos = [meg_info, None]
--> 603     megfwd, eegfwd = _compute_forwards(rr, bem, coils, ccoils,
    604                                        infos, coil_types, n_jobs)
    605 

<decorator-gen-296> in _compute_forwards(rr, bem, coils_list, ccoils_list, infos, coil_types, n_jobs, verbose)

/autofs/space/meghnn_001/users/mjas/github_repos/mne-python/mne/forward/_compute_forward.py in _compute_forwards(rr, bem, coils_list, ccoils_list, infos, coil_types, n_jobs, verbose)
    917                     infos=infos, coil_types=coil_types)
    918     _prep_field_computation(rr, bem, fwd_data, n_jobs)
--> 919     Bs = _compute_forwards_meeg(rr, fwd_data, n_jobs)
    920     return Bs

/autofs/space/meghnn_001/users/mjas/github_repos/mne-python/mne/forward/_compute_forward.py in _compute_forwards_meeg(rr, fd, n_jobs, silent)
    863                         % (coil_type.upper(), len(rr), _pl(rr)))
    864         # Calculate forward solution using spherical or BEM model
--> 865         B = fun(rr, mri_rr, mri_Q, coils, solution, bem_rr, n_jobs,
    866                 coil_type)
    867 

/autofs/space/meghnn_001/users/mjas/github_repos/mne-python/mne/forward/_compute_forward.py in _bem_pot_or_field(rr, mri_rr, mri_Q, coils, solution, bem_rr, n_jobs, coil_type)
    446         # Primary current contribution (can be calc. in coil/dipole coords)
    447         parallel, p_fun, _ = parallel_func(_do_prim_curr, n_jobs)
--> 448         pcc = np.concatenate(parallel(p_fun(r, coils)
    449                                       for r in nas(rr, n_jobs)), axis=0)
    450         B += pcc

/autofs/space/meghnn_001/users/mjas/github_repos/mne-python/mne/forward/_compute_forward.py in <genexpr>(.0)
    446         # Primary current contribution (can be calc. in coil/dipole coords)
    447         parallel, p_fun, _ = parallel_func(_do_prim_curr, n_jobs)
--> 448         pcc = np.concatenate(parallel(p_fun(r, coils)
    449                                       for r in nas(rr, n_jobs)), axis=0)
    450         B += pcc

/autofs/space/meghnn_001/users/mjas/github_repos/mne-python/mne/forward/_compute_forward.py in _do_prim_curr(***failed resolving arguments***)
    479         p *= ws
    480         p.shape = (3 * (stop - start), -1)
--> 481         pc[3 * start:3 * stop] = [bincount(bins, pp, bins[-1] + 1) for pp in p]
    482     return pc
    483 

/autofs/space/meghnn_001/users/mjas/github_repos/mne-python/mne/forward/_compute_forward.py in <listcomp>(.0)
    479         p *= ws
    480         p.shape = (3 * (stop - start), -1)
--> 481         pc[3 * start:3 * stop] = [bincount(bins, pp, bins[-1] + 1) for pp in p]
    482     return pc
    483 

RuntimeError: In 'NRT_adapt_ndarray_to_python', 'descr' is NULL
```

Not sure why this happens. When I tried debugging I realized that I couldn't look at the variables because `p` conflicted with the `p` command. Hence, this pull request. Also, the error magically disappeared when I made the change and now going back to master, I can't reproduce it. Don't ask ...

I think removing the single letter variable name is a good idea in any case.