### PR TITLE
MRG: Support for non-FIFF files in Report.parse_folder

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -23,6 +23,8 @@ Enhancements
 
 - Speed up :func:`mne.inverse_sparse.tf_mixed_norm` using STFT/ISTFT linearity (:gh:`8697` by `Eric Larson`_)
 
+- `~mne.Report.parse_folder` now processes supported non-FIFF files by default, too (:gh:`8744` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 - Fix zen mode and scalebar toggling for :meth:`raw.plot() <mne.io.Raw.plot>` when using the ``macosx`` matplotlib backend (:gh:`8688` by `Daniel McCloy`_)

--- a/mne/report.py
+++ b/mne/report.py
@@ -210,7 +210,7 @@ def _endswith(fname, suffixes):
     for suffix in suffixes:
         for ext in SUPPORTED_READ_RAW_EXTENSIONS:
             if fname.endswith((f'-{suffix}{ext}', f'-{suffix}{ext}',
-                            f'_{suffix}{ext}', f'_{suffix}{ext}')):
+                               f'_{suffix}{ext}', f'_{suffix}{ext}')):
                 return True
     return False
 

--- a/mne/report.py
+++ b/mne/report.py
@@ -44,8 +44,7 @@ _BEM_VIEWS = ('axial', 'sagittal', 'coronal')
 
 # For raw files, we want to support different suffixes + extensions for all
 # supported file formats
-SUPPORTED_READ_RAW_EXTENSIONS = (('.fif', '.fif.gz') +
-                                 tuple(extension_reader_map.keys()))
+SUPPORTED_READ_RAW_EXTENSIONS = tuple(extension_reader_map.keys())
 RAW_EXTENSIONS = []
 for ext in SUPPORTED_READ_RAW_EXTENSIONS:
     RAW_EXTENSIONS.append(f'raw{ext}')

--- a/mne/report.py
+++ b/mne/report.py
@@ -1472,7 +1472,7 @@ class Report(object):
             files. If ``None``, include all supported file formats.
 
             .. versionchanged:: 0.23
-            Include supported non-FIFF files by default.
+               Include supported non-FIFF files by default.
         %(n_jobs)s
         mri_decim : int
             Use this decimation factor for generating MRI/BEM images

--- a/mne/report.py
+++ b/mne/report.py
@@ -21,7 +21,8 @@ import webbrowser
 import numpy as np
 
 from . import read_evokeds, read_events, pick_types, read_cov
-from .io import read_raw_fif, read_info
+from .io import read_raw, read_info
+from .io._read_raw import supported as extension_reader_map
 from .io.pick import _DATA_CH_TYPES_SPLIT
 from .source_space import _mri_orientation
 from .utils import (logger, verbose, get_subjects_dir, warn, _ensure_int,
@@ -40,14 +41,33 @@ from .externals.h5io import read_hdf5, write_hdf5
 
 _BEM_VIEWS = ('axial', 'sagittal', 'coronal')
 
-VALID_EXTENSIONS = ['raw.fif', 'raw.fif.gz', 'sss.fif', 'sss.fif.gz',
-                    'eve.fif', 'eve.fif.gz', 'cov.fif', 'cov.fif.gz',
-                    'proj.fif', 'prof.fif.gz', 'trans.fif', 'trans.fif.gz',
-                    'fwd.fif', 'fwd.fif.gz', 'epo.fif', 'epo.fif.gz',
-                    'inv.fif', 'inv.fif.gz', 'ave.fif', 'ave.fif.gz', 'T1.mgz',
-                    'meg.fif']
-SECTION_ORDER = ['raw', 'events', 'epochs', 'ssp', 'evoked', 'covariance',
-                 'trans', 'mri', 'forward', 'inverse']
+
+# For raw files, we want to support different suffixes + extensions for all
+# supported file formats
+SUPPORTED_READ_RAW_EXTENSIONS = (('.fif', '.fif.gz') +
+                                 tuple(extension_reader_map.keys()))
+RAW_EXTENSIONS = []
+for ext in SUPPORTED_READ_RAW_EXTENSIONS:
+    RAW_EXTENSIONS.append(f'raw{ext}')
+    if ext not in ('.bdf', '.edf', '.set', '.vhdr'):  # EEG-only formats
+        RAW_EXTENSIONS.append(f'meg{ext}')
+    RAW_EXTENSIONS.append(f'eeg{ext}')
+
+# Processed data will always be in (gzipped) FIFF format
+VALID_EXTENSIONS = ('sss.fif', 'sss.fif.gz',
+                    'eve.fif', 'eve.fif.gz',
+                    'cov.fif', 'cov.fif.gz',
+                    'proj.fif', 'prof.fif.gz',
+                    'trans.fif', 'trans.fif.gz',
+                    'fwd.fif', 'fwd.fif.gz',
+                    'epo.fif', 'epo.fif.gz',
+                    'inv.fif', 'inv.fif.gz',
+                    'ave.fif', 'ave.fif.gz',
+                    'T1.mgz') + tuple(RAW_EXTENSIONS)
+del RAW_EXTENSIONS
+
+SECTION_ORDER = ('raw', 'events', 'epochs', 'ssp', 'evoked', 'covariance',
+                 'trans', 'mri', 'forward', 'inverse')
 
 
 ###############################################################################
@@ -167,7 +187,7 @@ def _is_bad_fname(fname):
     if fname.endswith('(whitened)'):
         fname = fname[:-11]
 
-    if not fname.endswith(tuple(VALID_EXTENSIONS + ['bem', 'custom'])):
+    if not fname.endswith(VALID_EXTENSIONS + ('bem', 'custom')):
         return 'red'
     else:
         return ''
@@ -183,14 +203,15 @@ def _get_fname(fname):
     return fname
 
 
-def _endswith(fname, exts):
-    """Aux function to test if fname ends with ext.fif for any ext in exts."""
-    if isinstance(exts, str):
-        exts = [exts]
-    for ext in exts:
-        if fname.endswith((f'-{ext}.fif', f'-{ext}.fif.gz',
-                           f'_{ext}.fif', f'_{ext}.fif.gz')):
-            return True
+def _endswith(fname, suffixes):
+    """Aux function to test if file name includes the specified suffixes."""
+    if isinstance(suffixes, str):
+        suffixes = [suffixes]
+    for suffix in suffixes:
+        for ext in SUPPORTED_READ_RAW_EXTENSIONS:
+            if fname.endswith((f'-{suffix}{ext}', f'-{suffix}{ext}',
+                            f'_{suffix}{ext}', f'_{suffix}{ext}')):
+                return True
     return False
 
 
@@ -1435,7 +1456,7 @@ class Report(object):
         self.include = ''.join(include)
 
     @verbose
-    def parse_folder(self, data_path, pattern='*.fif', n_jobs=1, mri_decim=2,
+    def parse_folder(self, data_path, pattern=None, n_jobs=1, mri_decim=2,
                      sort_sections=True, on_error='warn', image_format=None,
                      render_bem=True, verbose=None):
         r"""Render all the files in the folder.
@@ -1445,10 +1466,13 @@ class Report(object):
         data_path : str
             Path to the folder containing data whose HTML report will be
             created.
-        pattern : str | list of str
+        pattern : None | str | list of str
             Filename pattern(s) to include in the report.
             Example: [\*raw.fif, \*ave.fif] will include Raw as well as Evoked
-            files.
+            files. If ``None``, include all supported file formats.
+
+            .. versionchanged:: 0.23
+            Include supported non-FIFF files by default.
         %(n_jobs)s
         mri_decim : int
             Use this decimation factor for generating MRI/BEM images
@@ -1483,7 +1507,9 @@ class Report(object):
         if self.title is None:
             self.title = 'MNE Report for ...%s' % self.data_path[-20:]
 
-        if not isinstance(pattern, (list, tuple)):
+        if pattern is None:
+            pattern = [f'*{ext}' for ext in SUPPORTED_READ_RAW_EXTENSIONS]
+        elif not isinstance(pattern, (list, tuple)):
             pattern = [pattern]
 
         # iterate through the possible patterns
@@ -1498,7 +1524,10 @@ class Report(object):
         fnames_to_remove = []
         for fname in fnames:
             if _endswith(fname, ('raw', 'sss', 'meg')):
-                inst = read_raw_fif(fname, allow_maxshield=True, preload=False)
+                kwargs = dict(fname=fname, preload=False)
+                if fname.endswith(('.fif', '.fif.gz')):
+                    kwargs['allow_maxshield'] = True
+                inst = read_raw(**kwargs)
             else:
                 continue
 
@@ -1758,8 +1787,7 @@ class Report(object):
                         global_id += 1
                         html_toc += u'</ul></li>'
 
-                    elif fname.endswith(tuple(VALID_EXTENSIONS +
-                                        ['bem', 'custom'])):
+                    elif fname.endswith(VALID_EXTENSIONS + ('bem', 'custom')):
                         html_toc += toc_list.substitute(div_klass=div_klass,
                                                         id=global_id,
                                                         tooltip=tooltip,
@@ -1830,7 +1858,11 @@ class Report(object):
         """Render raw (only text)."""
         global_id = self._get_id()
 
-        raw = read_raw_fif(raw_fname, allow_maxshield='yes')
+        kwargs = dict(fname=raw_fname, preload=False)
+        if raw_fname.endswith(('.fif', '.fif.gz')):
+            kwargs['allow_maxshield'] = True
+        raw = read_raw(**kwargs)
+
         extra = '(MaxShield on)' if raw.info.get('maxshield', False) else ''
         caption = self._gen_caption(prefix='Raw', suffix=extra,
                                     fname=raw_fname, data_path=data_path)
@@ -2147,7 +2179,7 @@ def _recursive_search(path, pattern):
         for f in fnmatch.filter(files, pattern):
             # only the following file types are supported
             # this ensures equitable distribution of jobs
-            if f.endswith(tuple(VALID_EXTENSIONS)):
+            if f.endswith(VALID_EXTENSIONS):
                 filtered_files.append(op.realpath(op.join(dirpath, f)))
 
     return filtered_files

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -41,6 +41,10 @@ trans_fname = op.join(report_dir, 'sample_audvis_trunc-trans.fif')
 inv_fname = op.join(report_dir,
                     'sample_audvis_trunc-meg-eeg-oct-6-meg-inv.fif')
 mri_fname = op.join(subjects_dir, 'sample', 'mri', 'T1.mgz')
+bdf_fname = op.realpath(op.join(op.dirname(__file__), '..', 'io',
+                                'edf', 'tests', 'data', 'test.bdf'))
+edf_fname = op.realpath(op.join(op.dirname(__file__), '..', 'io',
+                                'edf', 'tests', 'data', 'test.edf'))
 
 base_dir = op.realpath(op.join(op.dirname(__file__), '..', 'io', 'tests',
                                'data'))
@@ -57,7 +61,7 @@ def _get_example_figures():
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_render_report(renderer, tmpdir):
-    """Test rendering -*.fif files for mne report."""
+    """Test rendering *.fif files for mne report."""
     tempdir = str(tmpdir)
     raw_fname_new = op.join(tempdir, 'temp_raw.fif')
     raw_fname_new_bids = op.join(tempdir, 'temp_meg.fif')
@@ -168,6 +172,43 @@ def test_render_report(renderer, tmpdir):
         report.add_figs_to_section('foo', 'caption', 'section')
     with pytest.raises(TypeError, match='figure must be a'):
         report.add_figs_to_section(['foo'], 'caption', 'section')
+
+
+@testing.requires_testing_data
+def test_render_non_fiff(tmpdir):
+    """Test rendering non-FIFF files for mne report."""
+    tempdir = str(tmpdir)
+    fnames_in = [bdf_fname, edf_fname]
+    fnames_out = []
+    for fname in fnames_in:
+        basename = op.basename(fname)
+        basename, ext = op.splitext(basename)
+        fname_out = f'{basename}_raw{ext}'
+        outpath = op.join(tempdir, fname_out)
+        shutil.copyfile(fname, outpath)
+        fnames_out.append(fname_out)
+
+    report = Report()
+    report.parse_folder(data_path=tempdir, render_bem=False, on_error='raise')
+
+    # Check correct paths and filenames
+    for fname in fnames_out:
+        assert (op.basename(fname) in
+                [op.basename(x) for x in report.fnames])
+        assert (''.join(report.html).find(op.basename(fname)) != -1)
+
+    assert_equal(len(report.fnames), len(fnames_out))
+    assert_equal(len(report.html), len(report.fnames))
+    assert_equal(len(report.fnames), len(report))
+
+    report.data_path = tempdir
+    fname = op.join(tempdir, 'report.html')
+    report.save(fname=fname, open_browser=False)
+    with open(fname, 'rb') as fid:
+        html = fid.read().decode('utf-8')
+
+    assert '<h4>Raw: test_raw.bdf</h4>' in html
+    assert '<h4>Raw: test_raw.edf</h4>' in html
 
 
 @testing.requires_testing_data

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -194,7 +194,6 @@ def test_render_non_fiff(tmpdir):
     for fname in fnames_out:
         assert (op.basename(fname) in
                 [op.basename(x) for x in report.fnames])
-        assert (''.join(report.html).find(op.basename(fname)) != -1)
 
     assert len(report.fnames) == len(fnames_out)
     assert len(report.html) == len(report.fnames)

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -15,7 +15,6 @@ import shutil
 import pathlib
 
 import numpy as np
-from numpy.testing import assert_equal
 import pytest
 from matplotlib import pyplot as plt
 
@@ -109,9 +108,9 @@ def test_render_report(renderer, tmpdir):
                 [op.basename(x) for x in report.fnames])
         assert (''.join(report.html).find(op.basename(fname)) != -1)
 
-    assert_equal(len(report.fnames), len(fnames))
-    assert_equal(len(report.html), len(report.fnames))
-    assert_equal(len(report.fnames), len(report))
+    assert len(report.fnames) == len(fnames)
+    assert len(report.html) == len(report.fnames)
+    assert len(report.fnames) == len(report)
 
     # Check saving functionality
     report.data_path = tempdir
@@ -130,8 +129,8 @@ def test_render_report(renderer, tmpdir):
     assert 'Topomap (ch_type =' in html
     assert f'Evoked: {op.basename(evoked_fname)} (GFPs)' in html
 
-    assert_equal(len(report.html), len(fnames))
-    assert_equal(len(report.html), len(report.fnames))
+    assert len(report.html) == len(fnames)
+    assert len(report.html) == len(report.fnames)
 
     # Check saving same report to new filename
     report.save(fname=op.join(tempdir, 'report2.html'), open_browser=False)
@@ -197,9 +196,9 @@ def test_render_non_fiff(tmpdir):
                 [op.basename(x) for x in report.fnames])
         assert (''.join(report.html).find(op.basename(fname)) != -1)
 
-    assert_equal(len(report.fnames), len(fnames_out))
-    assert_equal(len(report.html), len(report.fnames))
-    assert_equal(len(report.fnames), len(report))
+    assert len(report.fnames) == len(fnames_out)
+    assert len(report.html) == len(report.fnames)
+    assert len(report.fnames) == len(report)
 
     report.data_path = tempdir
     fname = op.join(tempdir, 'report.html')
@@ -437,7 +436,7 @@ def test_validate_input():
                   comments=comments[:-1])
     values = report._validate_input(items, captions, section, comments=None)
     items_new, captions_new, comments_new = values
-    assert_equal(len(comments_new), len(items))
+    assert len(comments_new) == len(items)
 
 
 @requires_h5py

--- a/server_environment.yml
+++ b/server_environment.yml
@@ -15,7 +15,7 @@ dependencies:
 - pyvista
 - nilearn
 - nibabel
-- nbformat
+- nbformat <5.1  # XXX remove pinning once https://github.com/jupyter/nbformat/issues/206 has been fixed
 - nbclient
 - mffpy>=0.5.7
 - pip:


### PR DESCRIPTION
Support all non-FIFF files we can read when parsing a folder using `Report.parse_folder()`. Requested via https://mne.discourse.group/t/naming-convention-in-mne-vs-mne-bids-welcome-to-the-thunderdome/2467