### PR TITLE
MRG, VIZ: Fix title position in plot_sensors

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -45,6 +45,8 @@ Bugs
 
 - Fix anonymization issue of FIF files after IO round trip (:gh:`8731` by `Alex Gramfort`_)
 
+- Fix title not shown in :func:`mne.viz.plot_montage` (:gh:`8752` by `Clemens Brunner`_)
+
 
 API changes
 ~~~~~~~~~~~

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1068,8 +1068,10 @@ def _plot_sensors(pos, info, picks, colors, bads, ch_names, title, show_names,
         picker = partial(_onpick_sensor, fig=fig, ax=ax, pos=pos,
                          ch_names=ch_names, show_names=show_names)
         fig.canvas.mpl_connect('pick_event', picker)
-
-    _set_window_title(fig, title)
+    if axes_was_none:
+        _set_window_title(fig, title)
+    else:
+        ax.set(title=title)
     closed = partial(_close_event, fig=fig)
     fig.canvas.mpl_connect('close_event', closed)
     plt_show(show, block=block)

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1046,7 +1046,7 @@ def _plot_sensors(pos, info, picks, colors, bads, ch_names, title, show_names,
         # Equal aspect for 3D looks bad, so only use for 2D
         ax.set(aspect='equal')
         if axes_was_none:
-            fig.subplots_adjust(left=0, bottom=0, right=1, top=0.95)
+            fig.subplots_adjust(left=0, bottom=0, right=1, top=1)
         ax.axis("off")  # remove border around figure
     del sphere
 
@@ -1069,7 +1069,7 @@ def _plot_sensors(pos, info, picks, colors, bads, ch_names, title, show_names,
                          ch_names=ch_names, show_names=show_names)
         fig.canvas.mpl_connect('pick_event', picker)
 
-    ax.set(title=title)
+    _set_window_title(fig, title)
     closed = partial(_close_event, fig=fig)
     fig.canvas.mpl_connect('close_event', closed)
     plt_show(show, block=block)

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1045,8 +1045,10 @@ def _plot_sensors(pos, info, picks, colors, bads, ch_names, title, show_names,
 
         # Equal aspect for 3D looks bad, so only use for 2D
         ax.set(aspect='equal')
-        if axes_was_none:
+        if axes_was_none:  # we'll show the plot title as the window title
             fig.subplots_adjust(left=0, bottom=0, right=1, top=1)
+        else:  # make room for title in axes
+            fig.subplots_adjust(left=0, bottom=0, right=1, top=0.95)
         ax.axis("off")  # remove border around figure
     del sphere
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1046,8 +1046,7 @@ def _plot_sensors(pos, info, picks, colors, bads, ch_names, title, show_names,
         # Equal aspect for 3D looks bad, so only use for 2D
         ax.set(aspect='equal')
         if axes_was_none:
-            fig.subplots_adjust(left=0, bottom=0, right=1, top=1, wspace=None,
-                                hspace=None)
+            fig.subplots_adjust(left=0, bottom=0, right=1, top=0.95)
         ax.axis("off")  # remove border around figure
     del sphere
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1047,8 +1047,6 @@ def _plot_sensors(pos, info, picks, colors, bads, ch_names, title, show_names,
         ax.set(aspect='equal')
         if axes_was_none:  # we'll show the plot title as the window title
             fig.subplots_adjust(left=0, bottom=0, right=1, top=1)
-        else:  # make room for title in axes
-            fig.subplots_adjust(left=0, bottom=0, right=1, top=0.95)
         ax.axis("off")  # remove border around figure
     del sphere
 
@@ -1072,8 +1070,6 @@ def _plot_sensors(pos, info, picks, colors, bads, ch_names, title, show_names,
         fig.canvas.mpl_connect('pick_event', picker)
     if axes_was_none:
         _set_window_title(fig, title)
-    else:
-        ax.set(title=title)
     closed = partial(_close_event, fig=fig)
     fig.canvas.mpl_connect('close_event', closed)
     plt_show(show, block=block)


### PR DESCRIPTION
The title is out of bounds in figures created by `plot_sensors` (including `montage.plot()`).

Before:
<img width="752" alt="before" src="https://user-images.githubusercontent.com/4377312/104715584-0ab66a00-5727-11eb-94cf-95161af23654.png">

After:
<img width="752" alt="after" src="https://user-images.githubusercontent.com/4377312/104715606-1013b480-5727-11eb-9782-715f3e9bcdc0.png">
