### PR TITLE
DOC: improve glossary entry about fiducials

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -134,7 +134,7 @@ general neuroimaging concepts. If you think a term is missing, please consider
 
         Due to the common neuroimaging practice of placing fiducial objects on
         anatomical landmarks, the terms "fiducial", "anatomical landmark" and
-        "cardinal point" are often (erroneously) used interchangably.
+        "cardinal point" are often (erroneously) used interchangeably.
 
     first_samp
         The :attr:`~mne.io.Raw.first_samp` attribute of :class:`~mne.io.Raw`

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -119,9 +119,23 @@ general neuroimaging concepts. If you think a term is missing, please consider
         object class, and :ref:`tut-evoked-class` for a narrative overview.
 
     fiducial point
-        There are three fiducial (a.k.a. cardinal) points: the left
-        preauricular point (LPA), the right preauricular point (RPA)
-        and the nasion.
+        Generally speaking, fiducials are objects which are placed in the field of
+        view of an imaging system which appears in the produced image.
+        The image of a given fiducial object (or fiducial point) can then be used
+        as a point of reference in the image.
+        In the case of neuroimaging, fiducials are often placed on well-known
+        anatomical landmarks such as the nasion (NAS), or left and right
+        preauricular points (LPA and RPA), also known as cardinal points.
+        They are then used to facilitate the localization of sensors
+        and co-registration with other geometric data such as the
+        participant's own T1 weighted magnetic resonance head image,
+        a T1 weighted template head image, or a spherical head model.
+
+        Note that due the common use of placing fiducial objects on anatomical
+        landmarks, the terms "fiducial" and "anatomical landmark" are often
+        (erroneously) used synonymously. However, fiducials can be placed
+        anywhere in an image, and do not have to coincide with an anatomical
+        landmark.
 
     first_samp
         The :attr:`~mne.io.Raw.first_samp` attribute of :class:`~mne.io.Raw`

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -120,7 +120,7 @@ general neuroimaging concepts. If you think a term is missing, please consider
 
     fiducial point
         Generally speaking, fiducials are objects which are placed in the field of
-        view of an imaging system which appears in the produced image.
+        view of an imaging system which appear in the produced image.
         The image of a given fiducial object (or fiducial point) can then be used
         as a point of reference in the image.
         In the case of neuroimaging, fiducials are often placed on well-known

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -119,24 +119,22 @@ general neuroimaging concepts. If you think a term is missing, please consider
         object class, and :ref:`tut-evoked-class` for a narrative overview.
 
     fiducial point
-        Generally speaking, fiducials are objects which are placed in the field of
-        view of an imaging system and which then appear in the produced image.
-        The image of a given fiducial object (or fiducial point) can then be used
-        as a point of reference in that image.
-        In the case of neuroimaging, fiducials are often placed on well-known
-        anatomical landmarks on the body of a study participant such as the nasion
-        (NAS), or left and right preauricular points (LPA and RPA), also known as
-        cardinal points.
-        They are then used to facilitate the localization of sensors
-        and for their co-registration with other geometric data such as the
-        participant's own T1 weighted magnetic resonance head image,
-        a T1 weighted template head image, or a spherical head model.
+        Fiducials are objects placed in the field of view of an imaging system
+        to act as a known spatial reference location that is easy to localize.
+        In neuroimaging, fiducials are often placed on anatomical landmarks
+        such as the nasion (NAS) or left/right preauricular points (LPA and
+        RPA).
 
-        Note that due to the common use of placing fiducial objects on anatomical
-        landmarks, the terms "fiducial" and "anatomical landmark" are often
-        (erroneously) used synonymously. However, fiducials can be placed
-        anywhere in an image, and do not have to coincide with an anatomical
-        landmark.
+        These known reference locations are used to define a coordinate system 
+        used for localization of sensors (hence NAS, LPA and RPA are often
+        called "cardinal points" because they define the cardinal directions of
+        the "head" coordinate system). The cardinal points are also useful when
+        co-registering measurements in different coordinate systems (such as
+        aligning EEG sensor locations to an MRI of the subject's head).
+
+        Due to the common neuroimaging practice of placing fiducial objects on
+        anatomical landmarks, the terms "fiducial", "anatomical landmark" and
+        "cardinal point" are often (erroneously) used interchangably.
 
     first_samp
         The :attr:`~mne.io.Raw.first_samp` attribute of :class:`~mne.io.Raw`

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -120,18 +120,19 @@ general neuroimaging concepts. If you think a term is missing, please consider
 
     fiducial point
         Generally speaking, fiducials are objects which are placed in the field of
-        view of an imaging system which appear in the produced image.
+        view of an imaging system and which then appear in the produced image.
         The image of a given fiducial object (or fiducial point) can then be used
-        as a point of reference in the image.
+        as a point of reference in that image.
         In the case of neuroimaging, fiducials are often placed on well-known
-        anatomical landmarks such as the nasion (NAS), or left and right
-        preauricular points (LPA and RPA), also known as cardinal points.
+        anatomical landmarks on the body of a study participant such as the nasion
+        (NAS), or left and right preauricular points (LPA and RPA), also known as
+        cardinal points.
         They are then used to facilitate the localization of sensors
-        and co-registration with other geometric data such as the
+        and for their co-registration with other geometric data such as the
         participant's own T1 weighted magnetic resonance head image,
         a T1 weighted template head image, or a spherical head model.
 
-        Note that due the common use of placing fiducial objects on anatomical
+        Note that due to the common use of placing fiducial objects on anatomical
         landmarks, the terms "fiducial" and "anatomical landmark" are often
         (erroneously) used synonymously. However, fiducials can be placed
         anywhere in an image, and do not have to coincide with an anatomical

--- a/examples/visualization/plot_eeglab_head_sphere.py
+++ b/examples/visualization/plot_eeglab_head_sphere.py
@@ -60,7 +60,7 @@ fake_evoked.set_montage(biosemi_montage)
 
 # first we obtain the 3d positions of selected channels
 chs = ['Oz', 'Fpz', 'T7', 'T8']
-pos = np.stack([biosemi_montage.get_positions()["ch_pos"][ch] for ch in chs])
+pos = np.stack([biosemi_montage.get_positions()['ch_pos'][ch] for ch in chs])
 
 # now we calculate the radius from T7 and T8 x position
 # (we could use Oz and Fpz y positions as well)

--- a/examples/visualization/plot_eeglab_head_sphere.py
+++ b/examples/visualization/plot_eeglab_head_sphere.py
@@ -59,9 +59,8 @@ fake_evoked.set_montage(biosemi_montage)
 # the position of Fpz, T8, Oz and T7 channels available in our montage.
 
 # first we obtain the 3d positions of selected channels
-check_ch = ['Oz', 'Fpz', 'T7', 'T8']
-ch_idx = [fake_evoked.ch_names.index(ch) for ch in check_ch]
-pos = np.stack([fake_evoked.info['chs'][idx]['loc'][:3] for idx in ch_idx])
+chs = ['Oz', 'Fpz', 'T7', 'T8']
+pos = np.stack([biosemi_montage.get_positions()["ch_pos"][ch] for ch in chs])
 
 # now we calculate the radius from T7 and T8 x position
 # (we could use Oz and Fpz y positions as well)

--- a/tutorials/intro/plot_40_sensor_locations.py
+++ b/tutorials/intro/plot_40_sensor_locations.py
@@ -127,7 +127,8 @@ biosemi_montage.plot(show_names=False, sphere=(0.03, 0.02, 0.01, 0.075))
 
 ###############################################################################
 # In mne-python the head center and therefore the sphere center are calculated
-# using fiducial points. Because of this the head circle represents head
+# using :term:`fiducial points <fiducial point>`.
+# Because of this the head circle represents head
 # circumference at the nasion and ear level, and not where it is commonly
 # measured in 10-20 EEG system: above nasion at T4/T8, T3/T7, Oz, Fz level.
 # Notice below that by default T7 and Oz channels are placed within the head


### PR DESCRIPTION
The glossary entry was a bit misleading due to its brevity:

1. there is no limit to fiducial points (i.e., there can be more than 3)
2. LPA, RPA, and NAS are anatomical landmarks, but "fiducials" is often used as a synonymous term for that

Potential links to add:

- https://en.wikipedia.org/wiki/Fiducial_marker
- https://www.fieldtriptoolbox.org/faq/how_should_i_report_the_positions_of_the_fiducial_points_on_the_head/
- [bids disambiguation of anatomical landmarks and fiducials](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/03-electroencephalography.html#coordinate-system-json-_coordsystemjson)
