### PR TITLE
MRG: Brain silhouette

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,6 +34,8 @@ Enhancements
 
 - Add :func:`mne.io.read_raw_nedf` for reading StarStim / enobio NEDF files (:gh:`8734` by `Tristan Stenner`_)
 
+- Add the ``silhouette`` parameter to :class:`mne.viz.Brain` to display sharp edges and improve perception (:gh:`8771` by `Guillaume Favelier`_)
+
 
 Bugs
 ~~~~

--- a/examples/inverse/plot_mixed_source_space_inverse.py
+++ b/examples/inverse/plot_mixed_source_space_inverse.py
@@ -166,7 +166,7 @@ labels_parc = mne.read_labels_from_annot(
 label_ts = mne.extract_label_time_course(
     [stc], labels_parc, src, mode='mean', allow_empty=True)
 
-# plot the times series of 2 labels
+# Plot the times series of 2 labels
 fig, axes = plt.subplots(1)
 axes.plot(1e3 * stc.times, label_ts[0][0, :], 'k', label='bankssts-lh')
 axes.plot(1e3 * stc.times, label_ts[0][-1, :].T, 'r', label='Brain-stem')

--- a/examples/inverse/plot_mixed_source_space_inverse.py
+++ b/examples/inverse/plot_mixed_source_space_inverse.py
@@ -139,7 +139,8 @@ stc_vec = apply_inverse(evoked, inverse_operator, lambda2, inv_method,
                         pick_ori='vector')
 brain = stc_vec.plot(
     hemi='both', src=inverse_operator['src'], views='coronal',
-    initial_time=initial_time, subjects_dir=subjects_dir)
+    initial_time=initial_time, subjects_dir=subjects_dir,
+    brain_kwargs=dict(silhouette=True))
 
 ###############################################################################
 # Plot the surface

--- a/examples/inverse/plot_mixed_source_space_inverse.py
+++ b/examples/inverse/plot_mixed_source_space_inverse.py
@@ -166,7 +166,7 @@ labels_parc = mne.read_labels_from_annot(
 label_ts = mne.extract_label_time_course(
     [stc], labels_parc, src, mode='mean', allow_empty=True)
 
-# Plot the times series of 2 labels
+# plot the times series of 2 labels
 fig, axes = plt.subplots(1)
 axes.plot(1e3 * stc.times, label_ts[0][0, :], 'k', label='bankssts-lh')
 axes.plot(1e3 * stc.times, label_ts[0][-1, :].T, 'r', label='Brain-stem')

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -649,7 +649,7 @@ class _BaseSourceEstimate(TimeMixin):
              foreground=None, initial_time=None, time_unit='s',
              backend='auto', spacing='oct6', title=None, show_traces='auto',
              src=None, volume_options=1., view_layout='vertical',
-             add_data_kwargs=None, verbose=None):
+             add_data_kwargs=None, brain_kwargs=None, verbose=None):
         brain = plot_source_estimates(
             self, subject, surface=surface, hemi=hemi, colormap=colormap,
             time_label=time_label, smoothing_steps=smoothing_steps,
@@ -660,7 +660,8 @@ class _BaseSourceEstimate(TimeMixin):
             initial_time=initial_time, time_unit=time_unit, backend=backend,
             spacing=spacing, title=title, show_traces=show_traces,
             src=src, volume_options=volume_options, view_layout=view_layout,
-            add_data_kwargs=add_data_kwargs, verbose=verbose)
+            add_data_kwargs=add_data_kwargs, brain_kwargs=brain_kwargs,
+            verbose=verbose)
         return brain
 
     @property
@@ -1918,7 +1919,7 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
              background='black', foreground=None, initial_time=None,
              time_unit='s', show_traces='auto', src=None, volume_options=1.,
              view_layout='vertical', add_data_kwargs=None,
-             verbose=None):  # noqa: D102
+             brain_kwargs=None, verbose=None):  # noqa: D102
         return plot_vector_source_estimates(
             self, subject=subject, hemi=hemi, colormap=colormap,
             time_label=time_label, smoothing_steps=smoothing_steps,
@@ -1931,7 +1932,7 @@ class _BaseVectorSourceEstimate(_BaseSourceEstimate):
             initial_time=initial_time, time_unit=time_unit,
             show_traces=show_traces, src=src, volume_options=volume_options,
             view_layout=view_layout, add_data_kwargs=add_data_kwargs,
-            verbose=verbose)
+            brain_kwargs=brain_kwargs, verbose=verbose)
 
 
 class _BaseVolSourceEstimate(_BaseSourceEstimate):
@@ -1949,7 +1950,7 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
                 foreground=None, initial_time=None, time_unit='s',
                 backend='auto', spacing='oct6', title=None, show_traces='auto',
                 src=None, volume_options=1., view_layout='vertical',
-                add_data_kwargs=None, verbose=None):
+                add_data_kwargs=None, brain_kwargs=None, verbose=None):
         return super().plot(
             subject=subject, surface=surface, hemi=hemi, colormap=colormap,
             time_label=time_label, smoothing_steps=smoothing_steps,
@@ -1961,7 +1962,7 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
             time_unit=time_unit, backend=backend, spacing=spacing, title=title,
             show_traces=show_traces, src=src, volume_options=volume_options,
             view_layout=view_layout, add_data_kwargs=add_data_kwargs,
-            verbose=verbose)
+            brain_kwargs=brain_kwargs, verbose=verbose)
 
     @copy_function_doc_to_method_doc(plot_volume_source_estimates)
     def plot(self, src, subject=None, subjects_dir=None, mode='stat_map',
@@ -2280,7 +2281,8 @@ class VolVectorSourceEstimate(_BaseVolSourceEstimate,
                 background='black', foreground=None, initial_time=None,
                 time_unit='s', show_traces='auto', src=None,
                 volume_options=1., view_layout='vertical',
-                add_data_kwargs=None, verbose=None):  # noqa: D102
+                add_data_kwargs=None, brain_kwargs=None,
+                verbose=None):  # noqa: D102
         return _BaseVectorSourceEstimate.plot(
             self, subject=subject, hemi=hemi, colormap=colormap,
             time_label=time_label, smoothing_steps=smoothing_steps,
@@ -2293,7 +2295,7 @@ class VolVectorSourceEstimate(_BaseVolSourceEstimate,
             initial_time=initial_time, time_unit=time_unit,
             show_traces=show_traces, src=src, volume_options=volume_options,
             view_layout=view_layout, add_data_kwargs=add_data_kwargs,
-            verbose=verbose)
+            brain_kwargs=brain_kwargs, verbose=verbose)
 
 
 @fill_doc

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1535,7 +1535,7 @@ add_data_kwargs : dict | None
 """
 docdict['brain_kwargs'] = """
 brain_kwargs : dict | None
-    Additional arguments to brain.__init__ (e.g.,
+    Additional arguments to the :class:`mne.viz.Brain` constructor (e.g.,
     ``dict(silhouette=True)``).
 """
 docdict['views'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1533,6 +1533,11 @@ add_data_kwargs : dict | None
     Additional arguments to brain.add_data (e.g.,
     ``dict(time_label_size=10)``).
 """
+docdict['brain_kwargs'] = """
+brain_kwargs : dict | None
+    Additional arguments to brain.__init__ (e.g.,
+    ``dict(silhouette=True)``).
+"""
 docdict['views'] = """
 views : str | list
     View to use. Can be any of::

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2511,7 +2511,8 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
                                  time_unit='s', show_traces='auto',
                                  src=None, volume_options=1.,
                                  view_layout='vertical',
-                                 add_data_kwargs=None, verbose=None):
+                                 add_data_kwargs=None, brain_kwargs=None,
+                                 verbose=None):
     """Plot VectorSourceEstimate with PySurfer.
 
     A "glass brain" is drawn and all dipoles defined in the source estimate
@@ -2587,6 +2588,7 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
     %(src_volume_options)s
     %(view_layout)s
     %(add_data_kwargs)s
+    %(brain_kwargs)s
     %(verbose)s
 
     Returns
@@ -2614,7 +2616,7 @@ def plot_vector_source_estimates(stc, subject=None, hemi='lh', colormap='hot',
         vector_alpha=vector_alpha, cortex=cortex, foreground=foreground,
         size=size, scale_factor=scale_factor, show_traces=show_traces,
         src=src, volume_options=volume_options, view_layout=view_layout,
-        add_data_kwargs=add_data_kwargs)
+        add_data_kwargs=add_data_kwargs, brain_kwargs=brain_kwargs)
 
 
 @verbose

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1678,7 +1678,8 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
                           time_unit='s', backend='auto', spacing='oct6',
                           title=None, show_traces='auto',
                           src=None, volume_options=1., view_layout='vertical',
-                          add_data_kwargs=None, verbose=None):
+                          add_data_kwargs=None, brain_kwargs=None,
+                          verbose=None):
     """Plot SourceEstimate.
 
     Parameters
@@ -1772,6 +1773,7 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
     %(src_volume_options)s
     %(view_layout)s
     %(add_data_kwargs)s
+    %(brain_kwargs)s
     %(verbose)s
 
     Returns
@@ -1828,7 +1830,8 @@ def plot_source_estimates(stc, subject=None, surface='inflated', hemi='lh',
         stc, overlay_alpha=alpha, brain_alpha=alpha, vector_alpha=alpha,
         cortex=cortex, foreground=foreground, size=size, scale_factor=None,
         show_traces=show_traces, src=src, volume_options=volume_options,
-        view_layout=view_layout, add_data_kwargs=add_data_kwargs, **kwargs)
+        view_layout=view_layout, add_data_kwargs=add_data_kwargs,
+        brain_kwargs=brain_kwargs, **kwargs)
 
 
 def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
@@ -1836,7 +1839,7 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
               time_unit, background, time_viewer, colorbar, transparent,
               brain_alpha, overlay_alpha, vector_alpha, cortex, foreground,
               size, scale_factor, show_traces, src, volume_options,
-              view_layout, add_data_kwargs):
+              view_layout, add_data_kwargs, brain_kwargs):
     from .backends.renderer import _get_3d_backend
     from ..source_estimate import _BaseVolSourceEstimate
     vec = stc._data_ndim == 3
@@ -1895,10 +1898,11 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
         "figure": figure, "subjects_dir": subjects_dir,
         "views": views, "alpha": brain_alpha,
     }
+    if brain_kwargs is not None:
+        kwargs.update(brain_kwargs)
     if backend in ['pyvista', 'notebook']:
         kwargs["show"] = False
         kwargs["view_layout"] = view_layout
-        kwargs["silhouette"] = True
     else:
         kwargs.update(_check_pysurfer_antialias(Brain))
         if view_layout != 'vertical':

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1898,6 +1898,7 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
     if backend in ['pyvista', 'notebook']:
         kwargs["show"] = False
         kwargs["view_layout"] = view_layout
+        kwargs["silhouette"] = True
     else:
         kwargs.update(_check_pysurfer_antialias(Brain))
         if view_layout != 'vertical':

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -419,6 +419,9 @@ class Brain(object):
         }
         if isinstance(silhouette, dict):
             self._silhouette.update(silhouette)
+            self.silhouette = True
+        else:
+            self.silhouette = silhouette
         # for now only one color bar can be added
         # since it is the same for all figures
         self._colorbar_added = False
@@ -475,7 +478,7 @@ class Brain(object):
                         opacity=alpha,
                         name='curv',
                     )
-                    if silhouette is not None:
+                    if self.silhouette:
                         self._renderer._silhouette(
                             mesh=mesh._polydata,
                             color=self._silhouette["color"],

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -509,6 +509,9 @@ class Brain(object):
         if hemi == 'rh' and hasattr(self._renderer, "_orient_lights"):
             self._renderer._orient_lights()
 
+        # XXX: experimental feature
+        self._renderer._enable_ssao(mesh._polydata)
+
     def setup_time_viewer(self, time_viewer=True, show_traces=True):
         """Configure the time viewer parameters.
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -509,9 +509,6 @@ class Brain(object):
         if hemi == 'rh' and hasattr(self._renderer, "_orient_lights"):
             self._renderer._orient_lights()
 
-        # XXX: experimental feature
-        self._renderer._enable_ssao(mesh._polydata)
-
     def setup_time_viewer(self, time_viewer=True, show_traces=True):
         """Configure the time viewer parameters.
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -414,7 +414,7 @@ class Brain(object):
         self._silhouette = {
             'color': self._bg_color,
             'line_width': 2,
-            'alpha': 1.0,
+            'alpha': alpha,
             'decimate': 0.75,
         }
         if isinstance(silhouette, dict):

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -417,6 +417,7 @@ class Brain(object):
             'alpha': alpha,
             'decimate': 0.9,
         }
+        _validate_type(silhouette, (dict, bool), 'silhouette')
         if isinstance(silhouette, dict):
             self._silhouette.update(silhouette)
             self.silhouette = True

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -266,6 +266,11 @@ class Brain(object):
     units : str
         Can be 'm' or 'mm' (default).
     %(view_layout)s
+    silhouette : dict | bool
+       As a dict, it contains the ``color``, ``linewidth``, ``alpha`` opacity
+       and ``decimate`` LOD of the brain's silhouette to display. If True, the
+       default values are used and if False, no silhouette will be displayed.
+       Defaults to False.
     show : bool
         Display the window as soon as it is ready. Defaults to True.
 
@@ -344,7 +349,7 @@ class Brain(object):
                  foreground=None, figure=None, subjects_dir=None,
                  views='auto', offset=True, show_toolbar=False,
                  offscreen=False, interaction='trackball', units='mm',
-                 view_layout='vertical', show=True):
+                 view_layout='vertical', silhouette=False, show=True):
         from ..backends.renderer import backend, _get_renderer, _get_3d_backend
         from .._3d import _get_cmap
         from matplotlib.colors import colorConverter
@@ -405,6 +410,15 @@ class Brain(object):
         self._labels = {'lh': list(), 'rh': list()}
         self._annots = {'lh': list(), 'rh': list()}
         self._layered_meshes = {}
+        # default values for silhouette
+        self._silhouette = {
+            'color': self._bg_color,
+            'line_width': 2,
+            'alpha': 1.0,
+            'decimate': 0.75,
+        }
+        if isinstance(silhouette, dict):
+            self._silhouette.update(silhouette)
         # for now only one color bar can be added
         # since it is the same for all figures
         self._colorbar_added = False
@@ -461,6 +475,14 @@ class Brain(object):
                         opacity=alpha,
                         name='curv',
                     )
+                    if silhouette is not None:
+                        self._renderer._silhouette(
+                            mesh=mesh._polydata,
+                            color=self._silhouette["color"],
+                            line_width=self._silhouette["line_width"],
+                            alpha=self._silhouette["alpha"],
+                            decimate=self._silhouette["decimate"],
+                        )
                     self._layered_meshes[h] = mesh
                     # add metadata to the mesh for picking
                     mesh._polydata._hemi = h

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -415,7 +415,7 @@ class Brain(object):
             'color': self._bg_color,
             'line_width': 2,
             'alpha': alpha,
-            'decimate': 0.75,
+            'decimate': 0.9,
         }
         if isinstance(silhouette, dict):
             self._silhouette.update(silhouette)
@@ -478,20 +478,21 @@ class Brain(object):
                         opacity=alpha,
                         name='curv',
                     )
-                    if self.silhouette:
-                        self._renderer._silhouette(
-                            mesh=mesh._polydata,
-                            color=self._silhouette["color"],
-                            line_width=self._silhouette["line_width"],
-                            alpha=self._silhouette["alpha"],
-                            decimate=self._silhouette["decimate"],
-                        )
                     self._layered_meshes[h] = mesh
                     # add metadata to the mesh for picking
                     mesh._polydata._hemi = h
                 else:
                     actor = self._layered_meshes[h]._actor
                     self._renderer.plotter.add_actor(actor)
+                if self.silhouette:
+                    mesh = self._layered_meshes[h]
+                    self._renderer._silhouette(
+                        mesh=mesh._polydata,
+                        color=self._silhouette["color"],
+                        line_width=self._silhouette["line_width"],
+                        alpha=self._silhouette["alpha"],
+                        decimate=self._silhouette["decimate"],
+                    )
                 self._renderer.set_camera(**views_dicts[h][v])
 
         self.interaction = interaction

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -268,9 +268,9 @@ class Brain(object):
     %(view_layout)s
     silhouette : dict | bool
        As a dict, it contains the ``color``, ``linewidth``, ``alpha`` opacity
-       and ``decimate`` LOD of the brain's silhouette to display. If True, the
-       default values are used and if False, no silhouette will be displayed.
-       Defaults to False.
+       and ``decimate`` (level of decimation between 0 and 1 or None) of the
+       brain's silhouette to display. If True, the default values are used
+       and if False, no silhouette will be displayed. Defaults to False.
     show : bool
         Display the window as soon as it is ready. Defaults to True.
 

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -174,7 +174,7 @@ def test_brain_init(renderer, tmpdir, pixel_ratio, brain_gc):
     renderer.backend._close_all()
 
     brain = Brain(hemi=hemi, surf=surf, size=size, title=title,
-                  cortex=cortex, units='m', **kwargs)
+                  cortex=cortex, units='m', silhouette=True, **kwargs)
     with pytest.raises(TypeError, match='not supported'):
         brain._check_stc(hemi='lh', array=FakeSTC(), vertices=None)
     with pytest.raises(ValueError, match='add_data'):

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -174,7 +174,8 @@ def test_brain_init(renderer, tmpdir, pixel_ratio, brain_gc):
     renderer.backend._close_all()
 
     brain = Brain(hemi=hemi, surf=surf, size=size, title=title,
-                  cortex=cortex, units='m', silhouette=True, **kwargs)
+                  cortex=cortex, units='m',
+                  silhouette=dict(decimate=0.95), **kwargs)
     with pytest.raises(TypeError, match='not supported'):
         brain._check_stc(hemi='lh', array=FakeSTC(), vertices=None)
     with pytest.raises(ValueError, match='add_data'):

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -432,7 +432,10 @@ def test_brain_time_viewer(renderer_interactive, pixel_ratio, brain_gc):
     with pytest.raises(ValueError, match="got unknown keys"):
         _create_testing_brain(hemi='lh', surf='white', src='volume',
                               volume_options={'foo': 'bar'})
-    brain = _create_testing_brain(hemi='both', show_traces=False)
+    brain = _create_testing_brain(
+        hemi='both', show_traces=False,
+        brain_kwargs=dict(silhouette=dict(decimate=0.95))
+    )
     # test sub routines when show_traces=False
     brain._on_pick(None, None)
     brain._configure_vertex_time_course()

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -847,6 +847,23 @@ class _Renderer(_BaseRenderer):
         if line_width is not None:
             prop.SetLineWidth(line_width)
 
+    def _enable_ssao(self, dataset):
+        # MWE that reproduces the visual artifact:
+        basic_pass = vtk.vtkRenderStepsPass()
+        self.plotter.renderer.SetPass(basic_pass)
+
+        # minimal code to enable SSAO:
+        # basic_pass = vtk.vtkRenderStepsPass()
+        # bounds = np.asarray(dataset.GetBounds())
+        # scene_size = np.linalg.norm(bounds[:3] - bounds[3:])
+        # ssao = vtk.vtkSSAOPass()
+        # ssao.SetRadius(0.1 * scene_size)  # comparison radius
+        # ssao.SetBias(0.001 * scene_size)  # comparison bias
+        # ssao.SetKernelSize(128)  # number of samples used
+        # ssao.BlurOff()  # do not blur occlusion
+        # ssao.SetDelegatePass(basic_pass)
+        # self.plotter.renderer.SetPass(ssao)
+
 
 def _compute_normals(mesh):
     """Patch PyVista compute_normals."""

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -847,47 +847,6 @@ class _Renderer(_BaseRenderer):
         if line_width is not None:
             prop.SetLineWidth(line_width)
 
-    def _enable_ssao(self, dataset):
-        lightsP = vtk.vtkLightsPass()
-        opaqueP = vtk.vtkOpaquePass()
-        translucentP = vtk.vtkTranslucentPass()
-        volumeP  = vtk.vtkVolumetricPass()
-
-        collection = vtk.vtkRenderPassCollection()
-        collection.AddItem(lightsP)
-
-        # opaque passes
-        ssaoCamP = vtk.vtkCameraPass()
-        ssaoCamP.SetDelegatePass(opaqueP)
-
-        bounds = np.asarray(dataset.GetBounds())
-        scene_size = np.linalg.norm(bounds[:3] - bounds[3:])
-        ssaoP = vtk.vtkSSAOPass()
-        ssaoP.SetRadius(0.1 * scene_size)  # comparison radius
-        ssaoP.SetBias(0.001 * scene_size)  # comparison bias
-        ssaoP.SetKernelSize(128)  # number of samples used
-        ssaoP.BlurOff()  # do not blur occlusion
-        ssaoP.SetDelegatePass(ssaoCamP)
-        collection.AddItem(ssaoP)
-
-        # translucent and volumic passes
-        ddpP = vtk.vtkDualDepthPeelingPass()
-        ddpP.SetTranslucentPass(translucentP)
-        ddpP.SetVolumetricPass(volumeP)
-        collection.AddItem(ddpP)
-
-        # finally overlays
-        overP = vtk.vtkOverlayPass()
-        collection.AddItem(overP)
-
-        sequence = vtk.vtkSequencePass()
-        sequence.SetPasses(collection)
-
-        camP = vtk.vtkCameraPass()
-        camP.SetDelegatePass(sequence)
-
-        self.plotter.renderer.SetPass(camP)
-
 
 def _compute_normals(mesh):
     """Patch PyVista compute_normals."""

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -827,7 +827,9 @@ class _Renderer(_BaseRenderer):
             volume_neg = None
         return grid, grid_mesh, volume_pos, volume_neg
 
-    def _silhouette(self, mesh, color=None, line_width=None, alpha=None):
+    def _silhouette(self, mesh, color=None, line_width=None, alpha=None,
+                    decimate=None):
+        mesh = mesh.decimate(decimate) if decimate is not None else mesh
         silhouette_filter = vtk.vtkPolyDataSilhouette()
         silhouette_filter.SetInputData(mesh)
         silhouette_filter.SetCamera(self.plotter.renderer.GetActiveCamera())

--- a/tutorials/source-modeling/plot_beamformer_lcmv.py
+++ b/tutorials/source-modeling/plot_beamformer_lcmv.py
@@ -58,7 +58,7 @@ event_id = 1  # those are the trials with left-ear auditory stimuli
 tmin, tmax = -0.2, 0.5
 events = mne.find_events(raw)
 
-# Pick relevant channels
+# pick relevant channels
 raw.pick(['meg', 'eog'])  # pick channels of interest
 
 # Create epochs

--- a/tutorials/source-modeling/plot_beamformer_lcmv.py
+++ b/tutorials/source-modeling/plot_beamformer_lcmv.py
@@ -58,7 +58,7 @@ event_id = 1  # those are the trials with left-ear auditory stimuli
 tmin, tmax = -0.2, 0.5
 events = mne.find_events(raw)
 
-# pick relevant channels
+# Pick relevant channels
 raw.pick(['meg', 'eog'])  # pick channels of interest
 
 # Create epochs

--- a/tutorials/source-modeling/plot_beamformer_lcmv.py
+++ b/tutorials/source-modeling/plot_beamformer_lcmv.py
@@ -238,7 +238,8 @@ stc.plot(mode='glass_brain', clim=dict(kind='value', lims=lims), **kwargs)
 brain = stc_vec.plot_3d(
     clim=dict(kind='value', lims=lims), hemi='both',
     views=['coronal', 'sagittal', 'axial'], size=(800, 300),
-    view_layout='horizontal', show_traces=0.3, **kwargs)
+    view_layout='horizontal', show_traces=0.3,
+    brain_kwargs=dict(silhouette=True), **kwargs)
 
 ###############################################################################
 # Visualize the activity of the maximum voxel with all three components

--- a/tutorials/source-modeling/plot_visualize_stc.py
+++ b/tutorials/source-modeling/plot_visualize_stc.py
@@ -166,7 +166,8 @@ fname_inv = data_path + '/MEG/sample/sample_audvis-meg-oct-6-meg-inv.fif'
 inv = read_inverse_operator(fname_inv)
 stc = apply_inverse(evoked, inv, lambda2, 'dSPM', pick_ori='vector')
 brain = stc.plot(subject='sample', subjects_dir=subjects_dir,
-                 initial_time=initial_time)
+                 initial_time=initial_time, brain_kwargs=dict(
+                     silhouette=True))
 
 ###############################################################################
 # Dipole fits

--- a/tutorials/source-modeling/plot_visualize_stc.py
+++ b/tutorials/source-modeling/plot_visualize_stc.py
@@ -34,7 +34,7 @@ fname_evoked = data_path + '/MEG/sample/sample_audvis-ave.fif'
 fname_stc = os.path.join(sample_dir, 'sample_audvis-meg')
 
 ###############################################################################
-# Then, we read the stc from file
+# Then, we read the stc from file:
 stc = mne.read_source_estimate(fname_stc, subject='sample')
 
 ###############################################################################

--- a/tutorials/source-modeling/plot_visualize_stc.py
+++ b/tutorials/source-modeling/plot_visualize_stc.py
@@ -34,7 +34,7 @@ fname_evoked = data_path + '/MEG/sample/sample_audvis-ave.fif'
 fname_stc = os.path.join(sample_dir, 'sample_audvis-meg')
 
 ###############################################################################
-# Then, we read the stc from file:
+# Then, we read the stc from file
 stc = mne.read_source_estimate(fname_stc, subject='sample')
 
 ###############################################################################


### PR DESCRIPTION
This PR follows https://github.com/mne-tools/mne-python/pull/8749#issuecomment-764676327 and adds a `silhouette` parameter to `Brain.__init__()`.

master | PR
---|---
![image](https://user-images.githubusercontent.com/18143289/105478056-f92f0e00-5ca2-11eb-9df6-b0c11aa7883c.png) | ![image](https://user-images.githubusercontent.com/18143289/105478137-1663dc80-5ca3-11eb-8979-99e65ad6ad92.png)


*What would be even more helpful for this kind of mesh is ambient occlusion.*