### PR TITLE
MRG, BUG, DOC: derive GFP from average reference for EEG

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -62,7 +62,7 @@ Bugs
 
 - `mne.io.read_raw_egi` now correctly handles `pathlib.Path` filenames (:gh:`8759` by `Richard Höchenberger`_)
 
-- `mne.viz.plot_evoked` and `mne.Evoked.plot` now correctly plot global field power (GFP) for EEG data when ``gfp=True`` or ``gfp='only'`` is passed. For MEG data, we continue to plot the RMS, but now label it correctly as such (:gh:`8775` by `Richard Höchenberger`_)
+- `mne.viz.plot_evoked` and `mne.Evoked.plot` now correctly plot global field power (GFP) for EEG data when ``gfp=True`` or ``gfp='only'`` is passed (used to plot RMS). For MEG data, we continue to plot the RMS, but now label it correctly as such (:gh:`8775` by `Richard Höchenberger`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -61,6 +61,8 @@ Bugs
 
 - `mne.io.read_raw_egi` now correctly handles `pathlib.Path` filenames (:gh:`8759` by `Richard Höchenberger`_)
 
+- `mne.viz.plot_evoked` and `mne.Evoked.plot` now always correctly calculate global field power (GFP) based on the average-referenced signal (we used not to reference to average in previous versions) (:gh:`8775` by `Richard Höchenberger`_)
+
 API changes
 ~~~~~~~~~~~
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -38,8 +38,6 @@ Enhancements
 
 - Add :meth:`annotations.to_data_frame() <mne.Annotations.to_data_frame>` to return annotations as a pandas dataframe (:gh:`8783` by `Robert Luke`_)
 
-- `mne.viz.plot_evoked` and `mne.Evoked.plot` have gained the ``gfp='rms'`` and ``gfp='rms-only'`` parameter values to plot the RMS of the signal (:gh:`8775` by `Richard Höchenberger`_)
-
 Bugs
 ~~~~
 - Fix zen mode and scalebar toggling for :meth:`raw.plot() <mne.io.Raw.plot>` when using the ``macosx`` matplotlib backend (:gh:`8688` by `Daniel McCloy`_)
@@ -64,7 +62,7 @@ Bugs
 
 - `mne.io.read_raw_egi` now correctly handles `pathlib.Path` filenames (:gh:`8759` by `Richard Höchenberger`_)
 
-- `mne.viz.plot_evoked` and `mne.Evoked.plot` now correctly plot global field power (GFP) when ``gfp=True`` or ``gfp='only'`` is passed (we erroneously plotted the RMS in previous versions) (:gh:`8775` by `Richard Höchenberger`_)
+- `mne.viz.plot_evoked` and `mne.Evoked.plot` now correctly plot global field power (GFP) for EEG data when ``gfp=True`` or ``gfp='only'`` is passed. For MEG data, we continue to plot the RMS, but now label it correctly as such (:gh:`8775` by `Richard Höchenberger`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -36,6 +36,7 @@ Enhancements
 
 - Add :meth:`raw.describe() <mne.io.Raw.describe>` to display (or return) descriptive statistics for each channel (:gh:`8760` by `Clemens Brunner`_)
 
+- `mne.viz.plot_evoked` and `mne.Evoked.plot` have gained the ``gfp='power'`` and ``gfp='power-only'`` parameter values to plot the RMS power of the signal (:gh:`8775` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~
@@ -61,7 +62,7 @@ Bugs
 
 - `mne.io.read_raw_egi` now correctly handles `pathlib.Path` filenames (:gh:`8759` by `Richard Höchenberger`_)
 
-- `mne.viz.plot_evoked` and `mne.Evoked.plot` now always correctly calculate global field power (GFP) based on the average-referenced signal (we used not to reference to average in previous versions) (:gh:`8775` by `Richard Höchenberger`_)
+- `mne.viz.plot_evoked` and `mne.Evoked.plot` now correctly plot global field power (GFP) when ``gfp=True`` or ``gfp='only'`` is passed (we erroneously plotted the RMS in previous versions) (:gh:`8775` by `Richard Höchenberger`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -36,7 +36,7 @@ Enhancements
 
 - Add :meth:`raw.describe() <mne.io.Raw.describe>` to display (or return) descriptive statistics for each channel (:gh:`8760` by `Clemens Brunner`_)
 
-- `mne.viz.plot_evoked` and `mne.Evoked.plot` have gained the ``gfp='power'`` and ``gfp='power-only'`` parameter values to plot the RMS power of the signal (:gh:`8775` by `Richard Höchenberger`_)
+- `mne.viz.plot_evoked` and `mne.Evoked.plot` have gained the ``gfp='rms'`` and ``gfp='rms-only'`` parameter values to plot the RMS of the signal (:gh:`8775` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1,3 +1,4 @@
+% Encoding: UTF-8
 
 @article{AblinEtAl2018,
   author = {Ablin, Pierre and Cardoso, Jean-Francois and Gramfort, Alexandre},
@@ -1927,3 +1928,47 @@
 	keywords = {Average MRI templates, Brain development, Lifespan MRI, Neurodevelopmental MRI Database},
 	pages = {1254--1259}
 }
+
+@Article{Lehmann1980,
+  author    = {Dietrich Lehmann and Wolfgang Skrandies},
+  journal   = {Electroencephalography and Clinical Neurophysiology},
+  title     = {Reference-free identification of components of checkerboard-evoked multichannel potential fields},
+  year      = {1980},
+  issn      = {0013-4694},
+  month     = {jun},
+  number    = {6},
+  pages     = {609--621},
+  volume    = {48},
+  doi       = {10.1016/0013-4694(80)90419-8},
+  publisher = {Elsevier {BV}},
+}
+
+@Article{Lehmann1984,
+  author    = {Dietrich Lehmann and Wolfgang Skrandies},
+  journal   = {Progress in Neurobiology},
+  title     = {Spatial analysis of evoked potentials in man—a review},
+  year      = {1984},
+  issn      = {0301-0082},
+  month     = {jan},
+  number    = {3},
+  pages     = {227--250},
+  volume    = {23},
+  doi       = {10.1016/0301-0082(84)90003-0},
+  publisher = {Elsevier {BV}},
+}
+
+@Article{Murray2008,
+  author    = {Micah M. Murray and Denis Brunet and Christoph M. Michel},
+  journal   = {Brain Topography},
+  title     = {Topographic {ERP} Analyses: {A} Step-by-Step Tutorial Review},
+  year      = {2008},
+  issn      = {0896-0267},
+  month     = {mar},
+  number    = {4},
+  pages     = {249--264},
+  volume    = {20},
+  doi       = {10.1007/s10548-008-0054-5},
+  publisher = {Springer Science and Business Media {LLC}},
+}
+
+@Comment{jabref-meta: databaseType:bibtex;}

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -267,7 +267,7 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
         raise RuntimeError('Currently only single axis figures are supported'
                            ' for interactive SSP selection.')
 
-    _check_option('gfp', gfp, [True, False, 'only', 'power', 'power-only'])
+    _check_option('gfp', gfp, [True, False, 'only', 'rms', 'rms-only'])
 
     scalings = _handle_default('scalings', scalings)
     titles = _handle_default('titles', titles)
@@ -428,7 +428,7 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
             # Set amplitude scaling
             D = this_scaling * data[idx, :]
             _check_if_nan(D)
-            gfp_only = gfp == 'only' or gfp == 'power-only'
+            gfp_only = gfp == 'only' or gfp == 'rms-only'
             if not gfp_only:
                 chs = [info['chs'][i] for i in idx]
                 locs3d = np.array([ch['loc'][:3] for ch in chs])
@@ -477,8 +477,7 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
                 if gfp in [True, 'only']:
                     this_gfp = D.std(axis=0, ddof=0)
                     label = 'GFP'
-                elif gfp in ['power', 'power-only']:
-                    # RMS
+                elif gfp in ['rms', 'rms-only']:
                     this_gfp = np.linalg.norm(D, axis=0)
                     label = 'RMS'
 
@@ -680,26 +679,26 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
         The axes to plot to. If list, the list must be a list of Axes of
         the same length as the number of channel types. If instance of
         Axes, there must be only one channel type plotted.
-    gfp : bool | 'only' | 'power' | 'power-only'
-        Plot the global field power (GFP) or the root mean square (RMS) power
-        of the data. GFP is the standard deviation of signals across channels.
+    gfp : bool | 'only' | 'rms' | 'rms-only'
+        Plot the global field power (GFP) or the root mean square (RMS) of the
+        data. GFP is the standard deviation of signals across channels.
         This is equivalent to the RMS of an average-referenced signal.
 
         - ``True``
-            plot the GFP and the traces for all channels
+            Plot the GFP and the traces for all channels.
         - ``'only'``
-            plot the GFP, but omit the individual channel traces
-        - ``'power'``
-            plot the RMS and the traces for all channels
-        - ``'power-only'``
-            plot the RMS, but omit the individual channel traces
+            Plot the GFP, but omit the individual channel traces.
+        - ``'rms'``
+            Plot the RMS and the traces for all channels.
+        - ``'rms-only'``
+            Plot the RMS, but omit the individual channel traces.
 
         The color of the GFP/RMS trace will be green if
         ``spatial_colors=False``, and black otherwise.
 
         .. versionchanged:: 0.23
-           Plot GFP (and not RMS) by default. Add ``'power'`` and
-           ``'power-only'`` options.
+           Plot GFP (and not RMS) by default. Add ``'rms'`` and
+           ``'rms-only'`` options.
 
     window_title : str | None
         The title to put at the top of the figure.

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -479,7 +479,7 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
                     label = 'GFP'
                 elif gfp in ['power', 'power-only']:
                     # RMS
-                    this_gfp = np.sqrt((D ** 2).mean(axis=0))
+                    this_gfp = np.linalg.norm(D, axis=0)
                     label = 'RMS'
 
                 gfp_color = 3 * (0.,) if spatial_colors is True else (0., 1.,

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -685,11 +685,14 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
         of the data. GFP is the standard deviation of signals across channels.
         This is equivalent to the RMS of an average-referenced signal.
 
-        - ``True``: plot the GFP and the traces for all channels
-        - ``'only'``: plot the GFP, but omit the individual channel traces
-        - ``'power'``: plot the RMS and the traces for all channels
-        - ``'power-only'``: plot the RMS, but omit the individual channel
-           traces
+        - ``True``
+            plot the GFP and the traces for all channels
+        - ``'only'``
+            plot the GFP, but omit the individual channel traces
+        - ``'power'``
+            plot the RMS and the traces for all channels
+        - ``'power-only'``
+            plot the RMS, but omit the individual channel traces
 
         The color of the GFP/RMS trace will be green if
         ``spatial_colors=False``, and black otherwise.

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -479,7 +479,7 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
                         this_gfp = D.std(axis=0, ddof=0)
                         label = 'GFP'
                     else:
-                        this_gfp = np.linalg.norm(D, axis=0)
+                        this_gfp = np.sqrt((D ** 2).mean(axis=0))
                         label = 'RMS'
 
                 gfp_color = 3 * (0.,) if spatial_colors is True else (0., 1.,

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -474,9 +474,13 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
                     line_list[-1].set_pickradius(3.)
 
             if gfp:  # 'only' or boolean True
+                # GFP is the standard deviation of the signal across all
+                # channels for each time point:
+                #
+                # GFP(t) = √{[∑ (xᵢ(t) - x̅(t))²] / N}
+                this_gfp = D.std(axis=0, ddof=0)
                 gfp_color = 3 * (0.,) if spatial_colors is True else (0., 1.,
                                                                       0.)
-                this_gfp = np.sqrt((D * D).mean(axis=0))
                 this_ylim = ax.get_ylim() if (ylim is None or this_type not in
                                               ylim.keys()) else ylim[this_type]
                 if gfp_only:
@@ -674,8 +678,11 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
         the same length as the number of channel types. If instance of
         Axes, there must be only one channel type plotted.
     gfp : bool | 'only'
-        Plot GFP in green if True or "only". If "only", then the individual
-        channel traces will not be shown.
+        Plot the global field power (GFP), i.e. the standard deviation of
+        signals across channels. If ``True``,  the traces for all channels will
+        be plotted, too; if ``'only'``, the individual channel traces will
+        not be shown. The color of the GFP trace will be green if
+        ``spatial_colors=False``, and black otherwise.
     window_title : str | None
         The title to put at the top of the figure.
     spatial_colors : bool

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -698,7 +698,6 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
 
         .. versionchanged:: 0.23
            Plot GFP for EEG instead of RMS. Label RMS traces correctly as such.
-
     window_title : str | None
         The title to put at the top of the figure.
     spatial_colors : bool

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -267,7 +267,7 @@ def _plot_evoked(evoked, picks, exclude, unit, show, ylim, proj, xlim, hline,
         raise RuntimeError('Currently only single axis figures are supported'
                            ' for interactive SSP selection.')
 
-    _check_option('gfp', gfp, [True, False, 'only', 'rms', 'rms-only'])
+    _check_option('gfp', gfp, [True, False, 'only'])
 
     scalings = _handle_default('scalings', scalings)
     titles = _handle_default('titles', titles)
@@ -428,7 +428,7 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
             # Set amplitude scaling
             D = this_scaling * data[idx, :]
             _check_if_nan(D)
-            gfp_only = gfp == 'only' or gfp == 'rms-only'
+            gfp_only = gfp == 'only'
             if not gfp_only:
                 chs = [info['chs'][i] for i in idx]
                 locs3d = np.array([ch['loc'][:3] for ch in chs])
@@ -475,11 +475,12 @@ def _plot_lines(data, info, picks, fig, axes, spatial_colors, unit, units,
 
             if gfp:
                 if gfp in [True, 'only']:
-                    this_gfp = D.std(axis=0, ddof=0)
-                    label = 'GFP'
-                elif gfp in ['rms', 'rms-only']:
-                    this_gfp = np.linalg.norm(D, axis=0)
-                    label = 'RMS'
+                    if this_type == 'eeg':
+                        this_gfp = D.std(axis=0, ddof=0)
+                        label = 'GFP'
+                    else:
+                        this_gfp = np.linalg.norm(D, axis=0)
+                        label = 'RMS'
 
                 gfp_color = 3 * (0.,) if spatial_colors is True else (0., 1.,
                                                                       0.)
@@ -679,26 +680,24 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
         The axes to plot to. If list, the list must be a list of Axes of
         the same length as the number of channel types. If instance of
         Axes, there must be only one channel type plotted.
-    gfp : bool | 'only' | 'rms' | 'rms-only'
+    gfp : bool | 'only'
         Plot the global field power (GFP) or the root mean square (RMS) of the
-        data. GFP is the standard deviation of signals across channels.
-        This is equivalent to the RMS of an average-referenced signal.
+        data. For MEG data, this will plot the RMS. For EEG, it plots GFP,
+        i.e. the standard deviation of the signal across channels. The GFP is
+        equivalent to the RMS of an average-referenced signal.
 
         - ``True``
-            Plot the GFP and the traces for all channels.
+            Plot GFP or RMS (for EEG and MEG, respectively) and traces for all
+            channels.
         - ``'only'``
-            Plot the GFP, but omit the individual channel traces.
-        - ``'rms'``
-            Plot the RMS and the traces for all channels.
-        - ``'rms-only'``
-            Plot the RMS, but omit the individual channel traces.
+            Plot GFP or RMS (for EEG and MEG, respectively), and omit the
+            traces for individual channels.
 
         The color of the GFP/RMS trace will be green if
         ``spatial_colors=False``, and black otherwise.
 
         .. versionchanged:: 0.23
-           Plot GFP (and not RMS) by default. Add ``'rms'`` and
-           ``'rms-only'`` options.
+           Plot GFP for EEG instead of RMS. Label RMS traces correctly as such.
 
     window_title : str | None
         The title to put at the top of the figure.

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -188,8 +188,8 @@ def _get_amplitudes(fig):
 
 @pytest.mark.parametrize('picks, rlims, avg_proj', [
     (default_picks[:-4], (0.59, 0.61), False),  # MEG
-    (np.arange(340, 360), (0.49, 0.51), True),  # EEG
-    (np.arange(340, 360), (0.78, 0.80), False),  # EEG
+    (np.arange(340, 360), (0.56, 0.57), True),  # EEG
+    (np.arange(340, 360), (0.79, 0.81), False),  # EEG
 ])
 def test_plot_evoked_reconstruct(picks, rlims, avg_proj):
     """Test proj="reconstruct"."""

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -124,7 +124,15 @@ def test_plot_evoked():
 
     # test GFP only
     evoked.plot(gfp='only', time_unit='s')
-    pytest.raises(ValueError, evoked.plot, gfp='foo', time_unit='s')
+
+    # test RMS
+    evoked.plot(gfp='power', time_unit='s')
+    evoked.plot(gfp='power-only', time_unit='s')
+    plt.close('all')
+
+    # Test invalid `gfp`
+    with pytest.raises(ValueError):
+        evoked.plot(gfp='foo', time_unit='s')
 
     # plot with bad channels excluded, spatial_colors, zorder & pos. layout
     evoked.rename_channels({'MEG 0133': 'MEG 0000'})

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -126,8 +126,8 @@ def test_plot_evoked():
     evoked.plot(gfp='only', time_unit='s')
 
     # test RMS
-    evoked.plot(gfp='power', time_unit='s')
-    evoked.plot(gfp='power-only', time_unit='s')
+    evoked.plot(gfp='rms', time_unit='s')
+    evoked.plot(gfp='rms-only', time_unit='s')
     plt.close('all')
 
     # Test invalid `gfp`

--- a/tutorials/evoked/plot_20_visualize_evoked.py
+++ b/tutorials/evoked/plot_20_visualize_evoked.py
@@ -75,7 +75,12 @@ evks['aud/left'].plot(exclude=[])
 # select channels to plot by name, index, or type. In the next plot we'll show
 # only magnetometer channels, and also color-code the channel traces by their
 # location by passing ``spatial_colors=True``. Finally, we'll superimpose a
-# trace of the :term:`global field power <GFP>` across channels:
+# trace of the root mean square (RMS) of the signal across channels by
+# passing ``gfp=True``. This parameter is called ``gfp`` for historical
+# reasons and behaves correctly for all supported channel types: for MEG data,
+# it will plot the RMS; while for EEG, it would plot the
+# `:term:`global field power <GFP>` (an average-referenced RMS), hence its
+# name:
 
 evks['aud/left'].plot(picks='mag', spatial_colors=True, gfp=True)
 

--- a/tutorials/evoked/plot_20_visualize_evoked.py
+++ b/tutorials/evoked/plot_20_visualize_evoked.py
@@ -79,7 +79,7 @@ evks['aud/left'].plot(exclude=[])
 # passing ``gfp=True``. This parameter is called ``gfp`` for historical
 # reasons and behaves correctly for all supported channel types: for MEG data,
 # it will plot the RMS; while for EEG, it would plot the
-# `:term:`global field power <GFP>` (an average-referenced RMS), hence its
+# :term:`global field power <GFP>` (an average-referenced RMS), hence its
 # name:
 
 evks['aud/left'].plot(picks='mag', spatial_colors=True, gfp=True)

--- a/tutorials/evoked/plot_eeg_erp.py
+++ b/tutorials/evoked/plot_eeg_erp.py
@@ -117,7 +117,7 @@ evoked_custom.plot_topomap(times=[0.1], size=3., title=title, time_unit='s')
 # Global field power :footcite:`Lehmann1980,Lehmann1984,Murray2008` is,
 # generally speaking, a measure of agreement of the signals picked up by all
 # sensors across the entire scalp: if all sensors have the same value at a
-# given timepoint, the GFP will be zero at that time point; if the signals
+# given time point, the GFP will be zero at that time point; if the signals
 # differ, the GFP will be non-zero at that time point. GFP
 # peaks may reflect "interesting" brain activity, warranting further
 # investigation. Mathematically, the GFP is the population standard
@@ -139,14 +139,14 @@ evoked_car.plot(gfp='only')
 ###############################################################################
 # As stated above, the GFP is the population standard deviation of the signal
 # across channels. To compute it manually, we can leverage
-# the fact that `evoked.data() <mne.Evoked.data>` is a NumPy array:
+# the fact that `evoked.data <mne.Evoked.data>` is a NumPy array:
 
 gfp = evoked_car.data.std(axis=0, ddof=0)
 
 # Reproducing the plot style from above:
 fig, ax = plt.subplots()
-ax.plot(evoked_car.times, gfp * 1e6, color='black')
-ax.fill_between(evoked_car.times, gfp * 1e6, color='lightgray')
+ax.plot(evoked_car.times, gfp * 1e6, color='lime')
+ax.fill_between(evoked_car.times, gfp * 1e6, color='lime', alpha=0.2)
 ax.set(xlabel='Time (s)', ylabel='GFP (µV)', title='EEG')
 
 ###############################################################################

--- a/tutorials/evoked/plot_eeg_erp.py
+++ b/tutorials/evoked/plot_eeg_erp.py
@@ -122,7 +122,7 @@ evoked_custom.plot_topomap(times=[0.1], size=3., title=title, time_unit='s')
 # investigation. Mathematically, the GFP is nothing but the population standard
 # deviation across all sensors, calculated separately for every time point.
 #
-# For visualization, you can simply use `mne.Evoked.plot` to add the GFP trace
+# For visualization, you can simply use `mne.Evoked.plot` and add the GFP trace
 # to the butterfly plot by passing ``gfp=True```. Let's also use spatial
 # coloring for the channel traces:
 

--- a/tutorials/evoked/plot_eeg_erp.py
+++ b/tutorials/evoked/plot_eeg_erp.py
@@ -122,9 +122,9 @@ evoked_custom.plot_topomap(times=[0.1], size=3., title=title, time_unit='s')
 # investigation. Mathematically, the GFP is nothing but the population standard
 # deviation across all sensors, calculated separately for every time point.
 #
-# For visualization, you can simply use `Evoked.plot` to add the GFP trace
-# to the butterfly plot by passing `gfp=True`. Let's also use spatial coloring
-# for the channel traces:
+# For visualization, you can simply use `mne.Evoked.plot` to add the GFP trace
+# to the butterfly plot by passing ``gfp=True```. Let's also use spatial
+# coloring for the channel traces:
 
 evoked_car.plot(gfp=True, spatial_colors=True)
 
@@ -136,9 +136,9 @@ evoked_no_ref.plot(gfp=True, spatial_colors=True)
 
 ###############################################################################
 # It is difficult to find out the absolute values of the GFP in the plots we
-# produced above. By passing `grp='only'`, the channel traces are removed, and
+# produced above. By passing ``gfp='only'``, the channel traces are removed, and
 # we can focues on the GFP entirely. Although we don't plot any channel traces,
-# we still pass `spatial_colors=True` to get the GFP in a nice black-and-gray
+# we still pass ``spatial_colors=True`` to get the GFP in a nice black-and-gray
 # color scheme – without this parameter, it would be bright-green.
 
 evoked_car.plot(gfp='only', spatial_colors=True)
@@ -146,7 +146,7 @@ evoked_car.plot(gfp='only', spatial_colors=True)
 ###############################################################################
 # **Calculating the GFP manually** is easy: as stated above, it's simply the
 # population standard deviation of the signal across channels. We can leverage
-# the fact that `Evoked.data` is a NumPy array:
+# the fact that `mne.Evoked.data` is a NumPy array:
 
 gfp = evoked_car.data.std(axis=0, ddof=0)
 

--- a/tutorials/evoked/plot_eeg_erp.py
+++ b/tutorials/evoked/plot_eeg_erp.py
@@ -122,22 +122,22 @@ evoked_custom.plot_topomap(times=[0.1], size=3., title=title, time_unit='s')
 # investigation. Mathematically, the GFP is nothing but the population standard
 # deviation across all sensors, calculated separately for every time point.
 #
-# For visualization, you can simply use `mne.Evoked.plot` and add the GFP trace
-# to the butterfly plot by passing ``gfp=True```. Let's also use spatial
-# coloring for the channel traces:
+# For visualization, you can simply use `evoked.plot() <mne.Evoked.plot>` and
+# add the GFP trace to the butterfly plot by passing ``gfp=True``. Let's also
+# use spatial coloring for the channel traces:
 
 evoked_car.plot(gfp=True, spatial_colors=True)
 
 ###############################################################################
-# We used the average-referenced evoked signal here, but MNE-Python the choice
-# of reference doesn't change the GFP.
+# We used the average-referenced evoked signal here, the choice of a different
+# reference won't change the GFP:
 
 evoked_no_ref.plot(gfp=True, spatial_colors=True)
 
 ###############################################################################
 # It is difficult to find out the absolute values of the GFP in the plots we
 # produced above. By passing ``gfp='only'``, the channel traces are removed,
-# and we can focues on the GFP entirely. Although we don't plot any channel
+# and we can focus on the GFP exclusively. Although we don't plot any channel
 # traces, we still pass ``spatial_colors=True`` to get the GFP in a nice
 # black-and-gray color scheme – without this parameter, it would be
 # bright-green.
@@ -147,12 +147,14 @@ evoked_car.plot(gfp='only', spatial_colors=True)
 ###############################################################################
 # **Calculating the GFP manually** is easy: as stated above, it's simply the
 # population standard deviation of the signal across channels. We can leverage
-# the fact that `mne.Evoked.data` is a NumPy array:
+# the fact that `evoked.data() <mne.Evoked.data>` is a NumPy array:
 
 gfp = evoked_car.data.std(axis=0, ddof=0)
 
 ###############################################################################
-# Let's try to manually reproduce the GFP plotting from above!
+# That's it!
+#
+# Finally, let's try to manually reproduce the GFP plot from above!
 
 fix, ax = plt.subplots()
 ax.plot(evoked_car.times, gfp * 1e6, color='black')

--- a/tutorials/evoked/plot_eeg_erp.py
+++ b/tutorials/evoked/plot_eeg_erp.py
@@ -116,52 +116,38 @@ evoked_custom.plot_topomap(times=[0.1], size=3., title=title, time_unit='s')
 #
 # Global field power :footcite:`Lehmann1980,Lehmann1984,Murray2008` is,
 # generally speaking, a measure of agreement of the signals picked up by all
-# sensors across the entire scalp: if all sensors produce the same signal,
-# the GFP will be zero; if the signals differ, the GFP will be non-zero. GFP
-# peaks may be indicative of "interesting" brain activity, warranting further
-# investigation. Mathematically, the GFP is nothing but the population standard
+# sensors across the entire scalp: if all sensors have the same value at a
+# given timepoint, the GFP will be zero at that time point; if the signals
+# differ, the GFP will be non-zero at that time point. GFP
+# peaks may reflect "interesting" brain activity, warranting further
+# investigation. Mathematically, the GFP is the population standard
 # deviation across all sensors, calculated separately for every time point.
 #
-# For visualization, you can simply use `evoked.plot() <mne.Evoked.plot>` and
-# add the GFP trace to the butterfly plot by passing ``gfp=True``. Let's also
-# use spatial coloring for the channel traces:
+# You can plot the GFP using `evoked.plot(gfp=True) <mne.Evoked.plot>`. The GFP
+# trace will be black if ``spatial_colors=True`` and green otherwise. The EEG
+# reference will not affect the GFP:
 
-evoked_car.plot(gfp=True, spatial_colors=True)
-
-###############################################################################
-# We used the average-referenced evoked signal here, the choice of a different
-# reference won't change the GFP:
-
-evoked_no_ref.plot(gfp=True, spatial_colors=True)
+for evk in (evoked_car, evoked_no_ref):
+    evk.plot(gfp=True, spatial_colors=True, ylim=dict(eeg=[-10, 10]))
 
 ###############################################################################
-# It is difficult to find out the absolute values of the GFP in the plots we
-# produced above. By passing ``gfp='only'``, the channel traces are removed,
-# and we can focus on the GFP exclusively. Although we don't plot any channel
-# traces, we still pass ``spatial_colors=True`` to get the GFP in a nice
-# black-and-gray color scheme – without this parameter, it would be
-# bright-green.
+# To plot the GFP by itself you can pass ``gfp='only'`` (this makes it easier
+# to read off the GFP data values, because the scale is aligned):
 
-evoked_car.plot(gfp='only', spatial_colors=True)
+evoked_car.plot(gfp='only')
 
 ###############################################################################
-# **Calculating the GFP manually** is easy: as stated above, it's simply the
-# population standard deviation of the signal across channels. We can leverage
+# As stated above, the GFP is the population standard deviation of the signal
+# across channels. To compute it manually, we can leverage
 # the fact that `evoked.data() <mne.Evoked.data>` is a NumPy array:
 
 gfp = evoked_car.data.std(axis=0, ddof=0)
 
-###############################################################################
-# That's it!
-#
-# Finally, let's try to manually reproduce the GFP plot from above!
-
-fix, ax = plt.subplots()
+# Reproducing the plot style from above:
+fig, ax = plt.subplots()
 ax.plot(evoked_car.times, gfp * 1e6, color='black')
 ax.fill_between(evoked_car.times, gfp * 1e6, color='lightgray')
-ax.set_xlabel('Time (s)')
-ax.set_ylabel('GFP (µV)')
-ax.set_title('EEG')
+ax.set(xlabel='Time (s)', ylabel('GFP (µV)', title='EEG')
 
 ###############################################################################
 # Evoked response averaged across channels by ROI

--- a/tutorials/evoked/plot_eeg_erp.py
+++ b/tutorials/evoked/plot_eeg_erp.py
@@ -147,7 +147,7 @@ gfp = evoked_car.data.std(axis=0, ddof=0)
 fig, ax = plt.subplots()
 ax.plot(evoked_car.times, gfp * 1e6, color='black')
 ax.fill_between(evoked_car.times, gfp * 1e6, color='lightgray')
-ax.set(xlabel='Time (s)', ylabel('GFP (µV)', title='EEG')
+ax.set(xlabel='Time (s)', ylabel='GFP (µV)', title='EEG')
 
 ###############################################################################
 # Evoked response averaged across channels by ROI

--- a/tutorials/evoked/plot_eeg_erp.py
+++ b/tutorials/evoked/plot_eeg_erp.py
@@ -136,10 +136,11 @@ evoked_no_ref.plot(gfp=True, spatial_colors=True)
 
 ###############################################################################
 # It is difficult to find out the absolute values of the GFP in the plots we
-# produced above. By passing ``gfp='only'``, the channel traces are removed, and
-# we can focues on the GFP entirely. Although we don't plot any channel traces,
-# we still pass ``spatial_colors=True`` to get the GFP in a nice black-and-gray
-# color scheme – without this parameter, it would be bright-green.
+# produced above. By passing ``gfp='only'``, the channel traces are removed,
+# and we can focues on the GFP entirely. Although we don't plot any channel
+# traces, we still pass ``spatial_colors=True`` to get the GFP in a nice
+# black-and-gray color scheme – without this parameter, it would be
+# bright-green.
 
 evoked_car.plot(gfp='only', spatial_colors=True)
 

--- a/tutorials/evoked/plot_eeg_erp.py
+++ b/tutorials/evoked/plot_eeg_erp.py
@@ -10,6 +10,8 @@ EEG processing and Event Related Potentials (ERPs)
 
 """
 
+import matplotlib.pyplot as plt
+
 import mne
 from mne.datasets import sample
 from mne.channels import combine_channels
@@ -109,6 +111,56 @@ evoked_custom.plot(titles=dict(eeg=title), time_unit='s')
 evoked_custom.plot_topomap(times=[0.1], size=3., title=title, time_unit='s')
 
 ###############################################################################
+# Global field power (GFP)
+# ------------------------
+#
+# Global field power :footcite:`Lehmann1980,Lehmann1984,Murray2008` is,
+# generally speaking, a measure of agreement of the signals picked up by all
+# sensors across the entire scalp: if all sensors produce the same signal,
+# the GFP will be zero; if the signals differ, the GFP will be non-zero. GFP
+# peaks may be indicative of "interesting" brain activity, warranting further
+# investigation. Mathematically, the GFP is nothing but the population standard
+# deviation across all sensors, calculated separately for every time point.
+#
+# For visualization, you can simply use `Evoked.plot` to add the GFP trace
+# to the butterfly plot by passing `gfp=True`. Let's also use spatial coloring
+# for the channel traces:
+
+evoked_car.plot(gfp=True, spatial_colors=True)
+
+###############################################################################
+# We used the average-referenced evoked signal here, but MNE-Python the choice
+# of reference doesn't change the GFP.
+
+evoked_no_ref.plot(gfp=True, spatial_colors=True)
+
+###############################################################################
+# It is difficult to find out the absolute values of the GFP in the plots we
+# produced above. By passing `grp='only'`, the channel traces are removed, and
+# we can focues on the GFP entirely. Although we don't plot any channel traces,
+# we still pass `spatial_colors=True` to get the GFP in a nice black-and-gray
+# color scheme – without this parameter, it would be bright-green.
+
+evoked_car.plot(gfp='only', spatial_colors=True)
+
+###############################################################################
+# **Calculating the GFP manually** is easy: as stated above, it's simply the
+# population standard deviation of the signal across channels. We can leverage
+# the fact that `Evoked.data` is a NumPy array:
+
+gfp = evoked_car.data.std(axis=0, ddof=0)
+
+###############################################################################
+# Let's try to manually reproduce the GFP plotting from above!
+
+fix, ax = plt.subplots()
+ax.plot(evoked_car.times, gfp * 1e6, color='black')
+ax.fill_between(evoked_car.times, gfp * 1e6, color='lightgray')
+ax.set_xlabel('Time (s)')
+ax.set_ylabel('GFP (µV)')
+ax.set_title('EEG')
+
+###############################################################################
 # Evoked response averaged across channels by ROI
 # -----------------------------------------------
 #
@@ -200,3 +252,9 @@ print(all_evokeds['left/auditory'])
 # Besides for explicit access, this can be used for example to set titles.
 for cond in all_evokeds:
     all_evokeds[cond].plot_joint(title=cond, **joint_kwargs)
+
+
+##############################################################################
+# References
+# ----------
+# .. footbibliography::


### PR DESCRIPTION
The reason for #8772 is simply that we always calculated the GFP incorrectly, i.e. without re-referencing sensor signals to average first. When doing that, I now correctly get a flat GFP (0 at all time points) for single-channel recordings:

<img width="439" alt="Screen Shot 2021-01-23 at 09 43 44" src="https://user-images.githubusercontent.com/2046265/105573681-92bbf580-5d5f-11eb-8cee-68bf5ab010d8.png">

This also means that since the introduction of this feature in 0.15 or so, our GFP plots haven't been correct in terms of absolute amplitude (which isn't too bad since it's difficult to judge the absolute amplitudes from the plot anyway)

Closes #8772, #8774

