### PR TITLE
MRG, BUG: fix IO or read_ica_eeglab

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -49,7 +49,7 @@ Bugs
 
 - Fix bug with :func:`mne.io.read_raw_nicolet` where header type values such as num_sample and duration_in_sec where not parsed properly (:gh:`8712` by `Alex Gramfort`_)
 
-- Fix bug with :func:`mne.preprocessing.read_ica_eeglab` with reading AMICA decompositions (:gh:`8780` by `Alex Gramfort`_ and `Eric Larson`_)
+- Fix bug with :func:`mne.preprocessing.read_ica_eeglab` when reading decompositions using PCA dimensionality reduction (:gh:`8780` by `Alex Gramfort`_ and `Eric Larson`_)
 
 - Fix bug with ``replace`` argument of :meth:`mne.Report.add_bem_to_section` and :meth:`mne.Report.add_slider_to_section` (:gh:`8723` by `Eric Larson`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -49,6 +49,8 @@ Bugs
 
 - Fix bug with :func:`mne.io.read_raw_nicolet` where header type values such as num_sample and duration_in_sec where not parsed properly (:gh:`8712` by `Alex Gramfort`_)
 
+- Fix bug with :func:`mne.preprocessing.read_ica_eeglab` with reading AMICA decompositions (:gh:`8780` by `Alex Gramfort`_ and `Eric Larson`_)
+
 - Fix bug with ``replace`` argument of :meth:`mne.Report.add_bem_to_section` and :meth:`mne.Report.add_slider_to_section` (:gh:`8723` by `Eric Larson`_)
 
 - Allow sEEG channel types in :meth:`mne.Evoked.plot_joint` (:gh:`8736` by `Daniel McCloy`_)

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -323,7 +323,7 @@ class RawEEGLAB(BaseRaw):
                             ' the .set file contains epochs.' % eeg.trials)
 
         last_samps = [eeg.pnts - 1]
-        info, eeg_montage, update_ch_names = _get_info(eeg, eog=eog)
+        info, eeg_montage, _ = _get_info(eeg, eog=eog)
 
         # read the data
         if isinstance(eeg.data, str):

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -53,8 +53,8 @@ from ..utils import (check_version, logger, check_fname, verbose,
                      compute_corr, _get_inst_data, _ensure_int,
                      copy_function_doc_to_method_doc, _pl, warn, Bunch,
                      _check_preload, _check_compensation_grade, fill_doc,
-                     _check_option, _PCA, int_like)
-from ..utils import _check_all_same_channel_names, verbose
+                     _check_option, _PCA, int_like,
+                     _check_all_same_channel_names)
 
 from ..fixes import _get_args, _safe_svd
 from ..filter import filter_data
@@ -2729,7 +2729,7 @@ def read_ica_eeglab(fname, *, verbose=None):
     use_check = linalg.pinv(eeg.icawinv)
     if not np.allclose(use, use_check, rtol=1e-6):
         warn('Mismatch between icawinv and icaweights @ icasphere from EEGLAB,'
-             'assuming icawinv is correct')
+             ' assuming icawinv is correct')
         use = use_check
     u, s, v = _safe_svd(use, full_matrices=False)
     ica.unmixing_matrix_ = u * s

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2728,8 +2728,9 @@ def read_ica_eeglab(fname, *, verbose=None):
     use = eeg.icaweights @ eeg.icasphere
     use_check = linalg.pinv(eeg.icawinv)
     if not np.allclose(use, use_check, rtol=1e-6):
-        warn('Mismatch between icawinv and icaweights @ icasphere from EEGLAB,'
-             ' assuming icawinv is correct')
+        warn('Mismatch between icawinv and icaweights @ icasphere from EEGLAB '
+             'possibly due to ICA component removal, assuming icawinv is '
+             'correct')
         use = use_check
     u, s, v = _safe_svd(use, full_matrices=False)
     ica.unmixing_matrix_ = u * s

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -1323,7 +1323,8 @@ def test_read_ica_eeglab_mismatch(tmpdir):
     data = loadmat(fname_orig)
     w = data['EEG']['icaweights'][0][0]
     w[:] = np.random.RandomState(0).randn(*w.shape)
-    savemat(str(fname), data)
+    savemat(str(fname), data, appendmat=False)
+    assert op.isfile(fname)
     with pytest.warns(RuntimeWarning, match='Mismatch.*removal.*icawinv.*'):
         ica = read_ica_eeglab(fname)
     _assert_ica_attributes(ica)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -6,6 +6,7 @@
 from itertools import product
 import os
 import os.path as op
+import shutil
 from unittest import SkipTest
 
 import pytest
@@ -13,6 +14,7 @@ import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose, assert_equal)
 from scipy import stats, linalg
+from scipy.io import loadmat, savemat
 import matplotlib.pyplot as plt
 
 from mne import (Epochs, read_events, pick_types, create_info, EpochsArray,
@@ -1309,6 +1311,32 @@ def test_read_ica_eeglab():
 
     assert_allclose(raw_cleaned_matlab.get_data(), raw_cleaned.get_data(),
                     rtol=1e-05, atol=1e-08)
+
+
+@testing.requires_testing_data
+def test_read_ica_eeglab_mismatch(tmpdir):
+    """Test read_ica_eeglab function when there is a mismatch."""
+    fname_orig = op.join(test_base_dir, "EEGLAB", "test_raw.set")
+    base = op.basename(fname_orig)[:-3]
+    shutil.copyfile(fname_orig[:-3] + 'fdt', tmpdir.join(base + 'fdt'))
+    fname = tmpdir.join(base)
+    data = loadmat(fname_orig)
+    w = data['EEG']['icaweights'][0][0]
+    w[:] = np.random.RandomState(0).randn(*w.shape)
+    savemat(str(fname), data)
+    with pytest.warns(RuntimeWarning, match='Mismatch.*removal.*icawinv.*'):
+        ica = read_ica_eeglab(fname)
+    _assert_ica_attributes(ica)
+    ica_correct = read_ica_eeglab(fname_orig)
+    attrs = [attr for attr in dir(ica_correct)
+             if attr.endswith('_') and not attr.startswith('_')]
+    assert 'mixing_matrix_' in attrs
+    assert 'unmixing_matrix_' in attrs
+    assert ica.labels_ == ica_correct.labels_ == {}
+    attrs.pop(attrs.index('labels_'))
+    for attr in attrs:
+        a, b = getattr(ica, attr), getattr(ica_correct, attr)
+        assert_allclose(a, b, rtol=1e-12, atol=1e-12, err_msg=attr)
 
 
 def _assert_ica_attributes(ica, data=None, limits=(1.0, 70)):

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -17,7 +17,8 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_path_like, _check_src_normal, _check_stc_units,
                     _check_pyqt5_version, _check_sphere, _check_time_format,
                     _check_freesurfer_home, _suggest, _require_version,
-                    _on_missing, int_like, _safe_input)
+                    _on_missing, int_like, _safe_input,
+                    _check_all_same_channel_names)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,


### PR DESCRIPTION
attempt to close #8755

my debug script using this branch.

```
from scipy import linalg
import matplotlib.pyplot as plt

import mne
from mne.viz.topomap import _find_topomap_coords

ica = mne.preprocessing.read_ica_eeglab('ICAamica_MNE_test.set')
# ica.info = raw.info
# ica._update_ica_names()
# ica.plot_components()

unmixing = ica.icaweights @ ica.icasphere
mixing = linalg.pinv(unmixing)

pos = _find_topomap_coords(ica.info, picks=None)
plt.close('all')
mne.viz.plot_topomap(mixing[:, 7], pos=pos)
plt.show()
```

here are the ICA topos I get using EEGLAB

<img width="755" alt="Screenshot 2021-01-24 at 15 20 30" src="https://user-images.githubusercontent.com/161052/105633240-bc584800-5e57-11eb-8739-f98be1914eb1.png">

It's quite different from what I get using ica.plot_components() or using mne.viz.plot_topomap manually
as above.

any idea @cbrnr ?
