### PR TITLE
MAINT: Fix doc date

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -82,7 +82,7 @@ Or, switch to documentation for the <a href="https://mne.tools/stable">current s
         <li><a href="https://www.au.dk/"><img class="institution" src="{{ pathto('_static/institution_logos/Aarhus.png', 1) }}" title="Aarhus Universitet" alt="Aarhus Universitet"/></a></li>
         <li><a href="https://www.uni-graz.at/"><img class="institution" src="{{ pathto('_static/institution_logos/Graz.jpg', 1) }}" title="Karl-Franzens-Universität Graz" alt="Karl-Franzens-Universität Graz"/></a></li>
       </ul>
-      <p class="text-center text-muted small">&copy; Copyright 2012-2020, MNE Developers. Last updated on 2020-03-27.</p>
+      <p class="text-center text-muted small">{{ copyright }}</p>
     </div></div></div>
   </footer>
   <script src="https://mne.tools/versionwarning.js"></script>

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -82,7 +82,7 @@ Or, switch to documentation for the <a href="https://mne.tools/stable">current s
         <li><a href="https://www.au.dk/"><img class="institution" src="{{ pathto('_static/institution_logos/Aarhus.png', 1) }}" title="Aarhus Universitet" alt="Aarhus Universitet"/></a></li>
         <li><a href="https://www.uni-graz.at/"><img class="institution" src="{{ pathto('_static/institution_logos/Graz.jpg', 1) }}" title="Karl-Franzens-Universität Graz" alt="Karl-Franzens-Universität Graz"/></a></li>
       </ul>
-      <p class="text-center text-muted small">{{ copyright }}</p>
+      <p class="text-center text-muted small">&copy; Copyright {{ copyright }}</p>
     </div></div></div>
   </footer>
   <script src="https://mne.tools/versionwarning.js"></script>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -106,9 +106,9 @@ master_doc = 'index'
 project = u'MNE'
 td = datetime.now(tz=timezone.utc)
 copyright = (
-    '© 2012-%(year)s, MNE Developers. Last updated '
+    '2012-%(year)s, MNE Developers. Last updated '
     '<time datetime="%(iso)s" class="localized">%(short)s</time>\n'
-    '<script type="text/javascript">$(function () { $("time.localized").each(function () { var el = $(this); el.text(new Date(el.attr("datetime")).toLocaleString([], {year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", timeZoneName: "short"})); }); } )</script>'  # noqa: E501
+    '<script type="text/javascript">$(function () { $("time.localized").each(function () { var el = $(this); el.text(new Date(el.attr("datetime")).toLocaleString([], {dateStyle: "medium", timeStyle: "long"})); }); } )</script>'  # noqa: E501
 ) % dict(year=td.year, iso=td.isoformat(),
          short=td.strftime('%Y-%m-%d %H:%M %Z'))
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from datetime import date
+from datetime import datetime, timezone
 from distutils.version import LooseVersion
 import gc
 import os
@@ -104,9 +104,13 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'MNE'
-td = date.today()
-copyright = u'2012-%s, MNE Developers. Last updated on %s' % (td.year,
-                                                              td.isoformat())
+td = datetime.now(tz=timezone.utc)
+copyright = (
+    '© 2012-%(year)s, MNE Developers. Last updated '
+    '<time datetime="%(iso)s" class="localized">%(short)s</time>\n'
+    '<script type="text/javascript">$(function () { $("time.localized").each(function () { var el = $(this); el.text(new Date(el.attr("datetime")).toLocaleString([], {year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", timeZoneName: "short"})); }); } )</script>'  # noqa: E501
+) % dict(year=td.year, iso=td.isoformat(),
+         short=td.strftime('%Y-%m-%d %H:%M %Z'))
 
 nitpicky = True
 nitpick_ignore = [


### PR DESCRIPTION
Back in https://github.com/mne-tools/mne-python/pull/7532 I broke the `Last updated` tag at the bottom of the website, and it has read "Last updated on 2020-03-27." ever since. With this PR I now get "Last updated 01/25/2021, 11:32 AM EST" and each person should get the equivalent datetime in their own timezone.