### PR TITLE
[MRG] ENH EGI MFF reader:  populate info['dig']

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -26,6 +26,8 @@ Enhancements
 
 - Add infant template MRI dataset downloader :func:`mne.datasets.fetch_infant_template` (:gh:`8738` by `Eric Larson`_ and `Christian O'Reilly`_)
 
+- Add digitizer information to :func:`mne.io.read_raw_mff` (:gh:`8789` by `Christian Brodbeck`_)
+
 - Speed up :func:`mne.inverse_sparse.tf_mixed_norm` using STFT/ISTFT linearity (:gh:`8697` by `Eric Larson`_)
 
 - `mne.Report.parse_folder` now processes supported non-FIFF files by default, too (:gh:`8744` by `Richard Höchenberger`_)

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -289,18 +289,16 @@ def _read_locs(filepath, chs, egi_info):
             ident = int(nr)
         dig_point = DigPoint({'kind': kind, 'ident': ident, 'r': loc,
                               'coord_frame': FIFF.FIFFV_COORD_HEAD})
+        dig_points.append(dig_point)
         if name in reference_names:
             dig_reference = dig_point
-        else:
-            dig_points.append(dig_point)
         # add location to channel entry
         id = np.flatnonzero(numbers == nr)
         if len(id) == 0:
             continue
         chs[id[0]]['loc'][:3] = loc
-    # Insert reference properly
+    # Insert reference location into channel location
     if dig_reference is not None:
-        dig_points.insert(0, dig_reference)
         for ch in chs:
             if ch['kind'] == FIFF.FIFFV_EEG_CH:
                 ch['loc'][3:6] = dig_reference['r']

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -287,8 +287,8 @@ def _read_locs(filepath, chs, egi_info):
             ident = dig_ident_map[name]
         else:
             ident = int(nr)
-        dig_point = DigPoint({'kind': kind, 'ident': ident, 'r': loc,
-                              'coord_frame': FIFF.FIFFV_COORD_HEAD})
+        dig_point = DigPoint(kind=kind, ident=ident, r=loc,
+                             coord_frame=FIFF.FIFFV_COORD_HEAD)
         dig_points.append(dig_point)
         if name in reference_names:
             dig_reference = dig_point

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -115,6 +115,7 @@ def test_io_egi_mff():
                            test_scaling=False,  # XXX probably some bug
                            )
     assert raw.info['sfreq'] == 1000.
+    assert len(raw.info['dig']) == 132  # 128 eeg + 1 ref + 3 cardinal points
 
     assert_equal('eeg' in raw, True)
     eeg_chan = [c for c in raw.ch_names if 'EEG' in c]
@@ -359,6 +360,7 @@ def test_io_egi_evokeds_mff(idx, cond, tmax, signals, bads):
     assert evoked_cond.info['nchan'] == 259
     assert evoked_cond.info['sfreq'] == 250.0
     assert not evoked_cond.info['custom_ref_applied']
+    assert len(evoked_cond.info['dig']) == 0  # coordinates.xml missing
 
 
 @requires_version('mffpy', '0.5.7')

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -115,7 +115,11 @@ def test_io_egi_mff():
                            test_scaling=False,  # XXX probably some bug
                            )
     assert raw.info['sfreq'] == 1000.
-    assert len(raw.info['dig']) == 132  # 128 eeg + 1 ref + 3 cardinal points
+    assert len(raw.info['dig']) == 132  # 1 ref + 128 eeg + 3 cardinal points
+    assert raw.info['dig'][0]['ident'] == 129  # reference channel nr
+    ref_loc = raw.info['dig'][0]['r']
+    for i in pick_types(raw.info, eeg=True):
+        assert_equal(raw.info['chs'][i]['loc'][3:6], ref_loc)
 
     assert_equal('eeg' in raw, True)
     eeg_chan = [c for c in raw.ch_names if 'EEG' in c]

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -115,9 +115,10 @@ def test_io_egi_mff():
                            test_scaling=False,  # XXX probably some bug
                            )
     assert raw.info['sfreq'] == 1000.
-    assert len(raw.info['dig']) == 132  # 1 ref + 128 eeg + 3 cardinal points
-    assert raw.info['dig'][0]['ident'] == 129  # reference channel nr
-    ref_loc = raw.info['dig'][0]['r']
+    assert len(raw.info['dig']) == 132  # 128 eeg + 1 ref + 3 cardinal points
+    assert raw.info['dig'][0]['ident'] == 1  # EEG channel E1
+    assert raw.info['dig'][128]['ident'] == 129  # Reference channel
+    ref_loc = raw.info['dig'][128]['r']
     for i in pick_types(raw.info, eeg=True):
         assert_equal(raw.info['chs'][i]['loc'][3:6], ref_loc)
 


### PR DESCRIPTION
#### Reference issue
Partly addresses #8038


#### What does this implement/fix?
Adds digitization points to `.info` for `read_raw_egi` and `read_evokeds_mff`
