### PR TITLE
[MRG] Coregistration-GUI:  use *.mff as digitization source

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -28,6 +28,8 @@ Enhancements
 
 - Add digitizer information to :func:`mne.io.read_raw_egi` (:gh:`8789` by `Christian Brodbeck`_)
 
+- Allow reading digitization from files other than ``*.fif`` in the coregistration GUI (:gh:`8790` by `Christian Brodbeck`_)
+
 - Speed up :func:`mne.inverse_sparse.tf_mixed_norm` using STFT/ISTFT linearity (:gh:`8697` by `Eric Larson`_)
 
 - `mne.Report.parse_folder` now processes supported non-FIFF files by default, too (:gh:`8744` by `Richard Höchenberger`_)

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -30,7 +30,7 @@ from ..coreg import (_is_mri_subject, _mri_subject_has_bem,
                      create_default_subject)
 from ..utils import get_config, set_config
 from ..viz._3d import _fiducial_coords
-from ..channels import read_dig_fif, DigMontage
+from ..channels import read_dig_fif
 
 
 fid_wildcard = "*.fif"

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -140,7 +140,7 @@ class FileOrDir(File):
     """Subclass File because *.mff files are actually directories."""
 
     def validate(self, object, name, value):
-        """Validates that a specified value is valid for this trait."""
+        """Validate that a specified value is valid for this trait."""
         value = os.fspath(value)
         validated_value = super(BaseFile, self).validate(object, name, value)
         if not self.exists:

--- a/mne/gui/tests/test_file_traits.py
+++ b/mne/gui/tests/test_file_traits.py
@@ -59,7 +59,7 @@ def test_fiducials_source():
 @testing.requires_testing_data
 @requires_mayavi
 @traits_test
-def test_inst_source(tmpdir):
+def test_digitization_source(tmpdir):
     """Test DigSource."""
     from mne.gui._file_traits import DigSource
     tempdir = str(tmpdir)
@@ -70,6 +70,7 @@ def test_inst_source(tmpdir):
     inst.file = inst_path
     assert inst.inst_dir == op.dirname(inst_path)
 
+    # FIFF
     lpa = array([[-7.13766068e-02, 0.00000000e+00, 5.12227416e-09]])
     nasion = array([[3.72529030e-09, 1.02605611e-01, 4.19095159e-09]])
     rpa = array([[7.52676800e-02, 0.00000000e+00, 5.58793545e-09]])
@@ -77,13 +78,30 @@ def test_inst_source(tmpdir):
     assert_allclose(inst.nasion, nasion)
     assert_allclose(inst.rpa, rpa)
 
-    montage = read_dig_fif(inst_path)  # test reading DigMontage
+    # DigMontage
+    montage = read_dig_fif(inst_path)
     montage_path = op.join(tempdir, 'temp_montage.fif')
     montage.save(montage_path)
     inst.file = montage_path
     assert_allclose(inst.lpa, lpa)
     assert_allclose(inst.nasion, nasion)
     assert_allclose(inst.rpa, rpa)
+
+    # EGI MFF
+    inst.file = op.join(data_path, 'EGI', 'test_egi.mff')
+    assert len(inst.points) == 0
+    assert len(inst.eeg_points) == 129
+    assert_allclose(inst.lpa * 1000, [[-67.1, 0.5, -37.1]], atol=0.1)
+    assert_allclose(inst.nasion * 1000, [[0.0, 103.6, -26.9]], atol=0.1)
+    assert_allclose(inst.rpa * 1000, [[67.1, 0.5, -37.1]], atol=0.1)
+
+    # CTF
+    inst.file = op.join(data_path, 'CTF', 'testdata_ctf.ds')
+    assert len(inst.points) == 0
+    assert len(inst.eeg_points) == 8
+    assert_allclose(inst.lpa * 1000, [[-74.3, 0.0, 0.0]], atol=0.1)
+    assert_allclose(inst.nasion * 1000, [[0.0, 117.7, 0.0]], atol=0.1)
+    assert_allclose(inst.rpa * 1000, [[84.9, -0.0, 0.0]], atol=0.1)
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
Depends on #8789.

This adds the capability to use `*.mff` files directly as digitization source to the coregistration GUI. I started on it for verifying the result of #8789, but it could be a useful feature since it obviates the need to convert to FIFF before doing coregistration. The screen-shot is `test_egi.mff`. 

<img width="1613" alt="image" src="https://user-images.githubusercontent.com/145771/105773527-06156100-5f32-11eb-834d-df86db0757ef.png">
