### PR TITLE
MRG, ENH: Add times to size

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -58,6 +58,8 @@ Bugs
 
 - Fix bug with ``replace`` argument of :meth:`mne.Report.add_bem_to_section` and :meth:`mne.Report.add_slider_to_section` (:gh:`8723` by `Eric Larson`_)
 
+- Fix bug where ``raw.times`` was not accounted for in size calculations of `mne.io.Raw` (:gh:`8795` by `Eric Larson`_)
+
 - Allow sEEG channel types in :meth:`mne.Evoked.plot_joint` (:gh:`8736` by `Daniel McCloy`_)
 
 - Function :func:`mne.set_bipolar_reference` was not working when passing ``Epochs`` constructed with some ``picks`` (:gh:`8728` by `Alex Gramfort`_)

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -553,10 +553,21 @@ def test_describe_print():
         raw.describe()
     s = f.getvalue().strip().split("\n")
     assert len(s) == 378
-    assert s[0] == "<Raw | test_raw.fif, 376 x 14400 (24.0 s), ~3.3 MB, data not loaded>"  # noqa
+    assert s[0] == "<Raw | test_raw.fif, 376 x 14400 (24.0 s), ~3.4 MB, data not loaded>"  # noqa
     assert s[1] == " ch  name      type  unit        min        Q1    median        Q3       max"  # noqa
     assert s[2] == "  0  MEG 0113  GRAD  fT/cm   -221.80    -38.57     -9.64     19.29    414.67"  # noqa
     assert s[-1] == "375  EOG 061   EOG   µV      -231.41    271.28    277.16    285.66    334.69"  # noqa
+
+
+def test_size():
+    """Test that our size includes some useful attributes."""
+    MB = 10
+    N = MB * 1024 * 1024
+    data = np.zeros((1, N))
+    info = create_info(1, 1000., 'eeg')
+    raw = RawArray(data, info)
+    want = MB * 2 * 8  # data and times (2) by 8 bytes per sample
+    assert f'~{want}.0 MB' in repr(raw)
 
 
 @requires_pandas

--- a/mne/utils/mixin.py
+++ b/mne/utils/mixin.py
@@ -50,6 +50,8 @@ class SizeMixin(object):
             size += object_size(self.data)
         elif hasattr(self, '_data'):
             size += object_size(self._data)
+        if hasattr(self, '_times'):
+            size += object_size(self._times)
         return size
 
     def __hash__(self):


### PR DESCRIPTION
Closes #8795.

As mentioned in #8795 alternatively we could compute `raw.times` on the fly but we'd have to be careful about performance regressions. To me it does not seem worth the risk.