### PR TITLE
FIX: fix overwrite in make_scalp_surfaces

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -74,6 +74,8 @@ Bugs
 
 - `mne.viz.plot_evoked` and `mne.Evoked.plot` now correctly plot global field power (GFP) for EEG data when ``gfp=True`` or ``gfp='only'`` is passed (used to plot RMS). For MEG data, we continue to plot the RMS, but now label it correctly as such (:gh:`8775` by `Richard Höchenberger`_)
 
+- Fix bug with :ref:`mne make_scalp_surfaces` where ``--overwrite`` was not functional (:gh:`8800` by `Yu-Han Luo`_)
+
 API changes
 ~~~~~~~~~~~
 

--- a/mne/commands/mne_make_scalp_surfaces.py
+++ b/mne/commands/mne_make_scalp_surfaces.py
@@ -112,7 +112,7 @@ def _run(subjects_dir, subject, force, overwrite, no_decimate, verbose=None):
     surf = mne.bem._surfaces_to_bem(
         [surf], [mne.io.constants.FIFF.FIFFV_BEM_SURF_ID_HEAD], [1],
         incomplete=incomplete, extra=msg)[0]
-    mne.write_bem_surfaces(dense_fname, surf)
+    mne.write_bem_surfaces(dense_fname, surf, overwrite=overwrite)
     levels = 'medium', 'sparse'
     tris = [] if no_decimate else [30000, 2500]
     if os.getenv('_MNE_TESTING_SCALP', 'false') == 'true':
@@ -131,7 +131,7 @@ def _run(subjects_dir, subject, force, overwrite, no_decimate, verbose=None):
             [dict(rr=points, tris=tris)],
             [mne.io.constants.FIFF.FIFFV_BEM_SURF_ID_HEAD], [1], rescale=False,
             incomplete=incomplete, extra=msg)
-        mne.write_bem_surfaces(dec_fname, dec_surf)
+        mne.write_bem_surfaces(dec_fname, dec_surf, overwrite=overwrite)
 
 
 mne.utils.run_command_if_main()


### PR DESCRIPTION
#### What does this implement/fix?
Currently, `overwrite` in `mne make_scalp_surfaces` is not passed to `mne.write_bem_surfaces`. Because the default of `overwrite` in `mne.write_bem_surfaces` changed to `False` now, `--overwrite` does not prevent `FileExistsError`.

For example, ```mne make_scalp_surfaces -s subject-346 -d subjects/ --force --overwrite --verbose``` gives:
```
1. Creating a dense scalp tessellation with mkheadsurf...
2. Creating subjects/subject-346/bem/subject-346-head-dense.fif ...
/home/ntubabylab/anaconda3/envs/mne/bin/mne:8: RuntimeWarning: Surface outer skin  has topological defects: 13 / 383510 vertices have fewer than three neighboring triangles [44385, 44387, 44389, 45198, 46031, 46033, 46861, 46862, 47708, 48546, 49428, 50338, 53081]

Consider using --force as an additional input parameter.
  sys.exit(main())
outer skin  CM is  10.24   5.95 -47.79 mm
/home/ntubabylab/anaconda3/envs/mne/bin/mne:8: RuntimeWarning: Surface outer skin  is not complete (sum of solid angles yielded 0.999793, should be 1.)
  sys.exit(main())
Surfaces passed the basic topology checks.
Traceback (most recent call last):
  File "/home/ntubabylab/anaconda3/envs/mne/bin/mne", line 8, in <module>
    sys.exit(main())
  File "/home/ntubabylab/anaconda3/envs/mne/lib/python3.8/site-packages/mne/commands/utils.py", line 107, in main
    cmd.run()
  File "/home/ntubabylab/anaconda3/envs/mne/lib/python3.8/site-packages/mne/commands/mne_make_scalp_surfaces.py", line 62, in run
    _run(subjects_dir, subject, options.force, options.overwrite,
  File "<decorator-gen-481>", line 22, in _run
  File "/home/ntubabylab/anaconda3/envs/mne/lib/python3.8/site-packages/mne/commands/mne_make_scalp_surfaces.py", line 115, in _run
    mne.write_bem_surfaces(dense_fname, surf)
  File "<decorator-gen-100>", line 24, in write_bem_surfaces
  File "/home/ntubabylab/anaconda3/envs/mne/lib/python3.8/site-packages/mne/bem.py", line 1546, in write_bem_surfaces
    fname = _check_fname(fname, overwrite=overwrite, name='fname')
  File "/home/ntubabylab/anaconda3/envs/mne/lib/python3.8/site-packages/mne/utils/check.py", line 157, in _check_fname
    raise FileExistsError('Destination file exists. Please use option '
FileExistsError: Destination file exists. Please use option "overwrite=True" to force overwriting.

```

#### Additional information
OS: Ubuntu 20.04
Python: 3.8.5
mne: 0.22.0
