### PR TITLE
MRG, ENH: Dont store raw.times

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,7 +34,7 @@ Enhancements
 
 - Speed up :func:`mne.inverse_sparse.tf_mixed_norm` using STFT/ISTFT linearity (:gh:`8697` by `Eric Larson`_)
 
-- Reduce memory consumption of `mne.io.Raw` and speed up epoching when thousands of events are present for `mne.Epochs` (:gh:`8800` by `Eric Larson`_)
+- Reduce memory consumption of `mne.io.Raw` and speed up epoching when thousands of events are present for `mne.Epochs` (:gh:`8801` by `Eric Larson`_)
 
 - `mne.Report.parse_folder` now processes supported non-FIFF files by default, too (:gh:`8744` by `Richard Höchenberger`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,6 +34,8 @@ Enhancements
 
 - Speed up :func:`mne.inverse_sparse.tf_mixed_norm` using STFT/ISTFT linearity (:gh:`8697` by `Eric Larson`_)
 
+- Reduce memory consumption of `mne.io.Raw` and speed up epoching when thousands of events are present for `mne.Epochs` (:gh:`8800` by `Eric Larson`_)
+
 - `mne.Report.parse_folder` now processes supported non-FIFF files by default, too (:gh:`8744` by `Richard Höchenberger`_)
 
 - `mne.Report` has gained a new method `~mne.Report.add_custom_css` for adding user-defined styles (:gh:`8762` by `Richard Höchenberger`_)

--- a/mne/baseline.py
+++ b/mne/baseline.py
@@ -61,7 +61,7 @@ def rescale(data, times, baseline, mode='mean', copy=True, picks=None,
     """
     if copy:
         data = data.copy()
-    if verbose:
+    if verbose is not False:
         msg = _log_rescale(baseline, mode)
         logger.info(msg)
     if baseline is None or data.shape[-1] == 0:

--- a/mne/baseline.py
+++ b/mne/baseline.py
@@ -59,9 +59,11 @@ def rescale(data, times, baseline, mode='mean', copy=True, picks=None,
     data_scaled: array
         Array of same shape as data after rescaling.
     """
-    data = data.copy() if copy else data
-    msg = _log_rescale(baseline, mode)
-    logger.info(msg)
+    if copy:
+        data = data.copy()
+    if verbose:
+        msg = _log_rescale(baseline, mode)
+        logger.info(msg)
     if baseline is None or data.shape[-1] == 0:
         return data
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -835,7 +835,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
 
         # Detrend
         if self.detrend is not None:
-            # We explitly detrend just data channels (not EMG, ECG, EOG which
+            # We explicitly detrend just data channels (not EMG, ECG, EOG which
             # are processed by baseline correction)
             use_picks = _pick_data_channels(self.info, exclude=())
             epoch[use_picks] = detrend(epoch[use_picks], self.detrend, axis=1)

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1491,7 +1491,6 @@ def apply_forward_raw(fwd, stc, info, start=None, stop=None,
     raw._first_samps = np.array([int(np.round(times[0] * sfreq))])
     raw._last_samps = np.array([raw.first_samp + raw._data.shape[1] - 1])
     raw._projector = None
-    raw._update_times()
     return raw
 
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -249,7 +249,6 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         self._dtype_ = dtype
         self.set_annotations(None)
         # If we have True or a string, actually do the preloading
-        self._update_times()
         if load_from_disk:
             self._preload_data(preload)
         self._init_kwargs = _get_argvalues()
@@ -498,7 +497,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             for descr in annot.description[overlaps]:
                 if descr.lower().startswith('bad'):
                     return descr
-        return self[picks, start:stop][0]
+        return self._getitem((picks, slice(start, stop)), return_times=False)
 
     @verbose
     def load_data(self, verbose=None):
@@ -538,12 +537,6 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         self.preload = True
         self._comp = None  # no longer needed
         self.close()
-
-    def _update_times(self):
-        """Update times."""
-        self._times = np.arange(self.n_times) / float(self.info['sfreq'])
-        # make it immutable
-        self._times.flags.writeable = False
 
     @property
     def _first_time(self):
@@ -772,14 +765,25 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             >>> data, times = raw[picks, t_idx[0]:t_idx[1]]  # doctest: +SKIP
 
         """  # noqa: E501
+        return self._getitem(item)
+
+    def _getitem(self, item, return_times=True):
         sel, start, stop = self._parse_get_set_params(item)
         if self.preload:
             data = self._data[sel, start:stop]
         else:
             data = self._read_segment(start=start, stop=stop, sel=sel,
                                       projector=self._projector)
-        times = self.times[start:stop]
-        return data, times
+
+        if return_times:
+            # Rather than compute the entire thing just compute the subset
+            # times = self.times[start:stop]
+            # stop can be None here so don't use it directly
+            times = np.arange(
+                start, start + data.shape[1]) / self.info['sfreq']
+            return data, times
+        else:
+            return data
 
     def __setitem__(self, item, value):
         """Set raw data content."""
@@ -1196,7 +1200,6 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         lowpass = self.info.get('lowpass')
         lowpass = np.inf if lowpass is None else lowpass
         self.info['lowpass'] = min(lowpass, sfreq / 2.)
-        self._update_times()
 
         # See the comment above why we ignore all errors here.
         if events is None:
@@ -1280,7 +1283,6 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         if self.preload:
             # slice and copy to avoid the reference to large array
             self._data = self._data[:, smin:smax + 1].copy()
-        self._update_times()
 
         if self.annotations.orig_time is None:
             self.annotations.onset -= tmin
@@ -1482,7 +1484,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
     @property
     def times(self):
         """Time points."""
-        return self._times
+        out = np.arange(self.n_times) / float(self.info['sfreq'])
+        out.flags['WRITEABLE'] = False
+        return out
 
     @property
     def n_times(self):
@@ -1625,7 +1629,6 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             self._raw_extras += r._raw_extras
             self._filenames += r._filenames
         assert annotations.orig_time == self.info['meas_date']
-        self._update_times()
         self.set_annotations(annotations)
         for edge_samp in edge_samps:
             onset = _sync_onset(self, (edge_samp) / self.info['sfreq'], True)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -779,8 +779,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             # Rather than compute the entire thing just compute the subset
             # times = self.times[start:stop]
             # stop can be None here so don't use it directly
-            times = np.arange(
-                start, start + data.shape[1]) / self.info['sfreq']
+            times = np.arange(start, start + data.shape[1], dtype=float)
+            times /= self.info['sfreq']
             return data, times
         else:
             return data
@@ -831,8 +831,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         start = 0 if start is None else start
         stop = min(self.n_times if stop is None else stop, self.n_times)
         if len(self.annotations) == 0 or reject_by_annotation is None:
-            data, times = self[picks, start:stop]
-            return (data, times) if return_times else data
+            return self._getitem(
+                (picks, slice(start, stop)), return_times=return_times)
         _check_option('reject_by_annotation', reject_by_annotation.lower(),
                       ['omit', 'nan'])
         onsets, ends = _annotations_starts_stops(self, ['BAD'])

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -47,7 +47,7 @@ from ..utils import (_check_fname, _check_pandas_installed, sizeof_fmt,
                      copy_function_doc_to_method_doc, _validate_type,
                      _check_preload, _get_argvalues, _check_option,
                      _build_data_frame, _convert_times, _scale_dataframe_data,
-                     _check_time_format)
+                     _check_time_format, _arange_div)
 from ..defaults import _handle_default
 from ..viz import plot_raw, plot_raw_psd, plot_raw_psd_topo, _RAW_CLIP_DEF
 from ..event import find_events, concatenate_events
@@ -1484,7 +1484,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
     @property
     def times(self):
         """Time points."""
-        out = np.arange(self.n_times) / float(self.info['sfreq'])
+        out = _arange_div(self.n_times, float(self.info['sfreq']))
         out.flags['WRITEABLE'] = False
         return out
 

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -982,19 +982,14 @@ _DATA_CH_TYPES_SPLIT = (
     'mag', 'grad', 'eeg', 'csd', 'seeg', 'ecog', 'dbs') + _FNIRS_CH_TYPES_SPLIT
 
 
-def _pick_data_channels(info, exclude='bads', with_ref_meg=True):
+def _pick_data_channels(info, exclude='bads', with_ref_meg=True,
+                        with_aux=False):
     """Pick only data channels."""
-    return pick_types(info, ref_meg=with_ref_meg, exclude=exclude,
-                      **_PICK_TYPES_DATA_DICT)
-
-
-def _pick_aux_channels(info, exclude='bads'):
-    """Pick only auxiliary channels.
-
-    Corresponds to EOG, ECG, EMG and BIO
-    """
-    return pick_types(info, meg=False, eog=True, ecg=True, emg=True, bio=True,
-                      ref_meg=False, exclude=exclude)
+    kwargs = _PICK_TYPES_DATA_DICT
+    if with_aux:
+        kwargs = kwargs.copy()
+        kwargs.update(eog=True, ecg=True, emg=True, bio=True)
+    return pick_types(info, ref_meg=with_ref_meg, exclude=exclude, **kwargs)
 
 
 def _pick_data_or_ica(info, exclude=()):

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -917,13 +917,11 @@ class ICA(ContainsMixin):
         start, stop = _check_start_stop(raw, start, stop)
         if add_channels is not None:
             raw_picked = raw.copy().pick_channels(add_channels)
-            data_, times_ = raw_picked[:, start:stop]
+            data_, _ = raw_picked[:, start:stop]
             data_ = np.r_[sources, data_]
         else:
             data_ = sources
-            _, times_ = raw[0, start:stop]
         out._data = data_
-        out._times = times_
         out._filenames = [None]
         out.preload = True
 
@@ -935,7 +933,6 @@ class ICA(ContainsMixin):
 
         out._projector = None
         self._export_info(out.info, raw, add_channels)
-        out._update_times()
 
         return out
 

--- a/mne/preprocessing/realign.py
+++ b/mne/preprocessing/realign.py
@@ -94,7 +94,6 @@ def realign_raw(raw, other, t_raw, t_other, verbose=None):
     sfreq_new = raw.info['sfreq'] * coef
     other.load_data().resample(sfreq_new, verbose=True)
     other.info['sfreq'] = raw.info['sfreq']
-    other._update_times()
 
     # 4. Crop the end of one of the recordings if necessary
     delta = raw.times[-1] - other.times[-1]

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -826,8 +826,11 @@ def test_ica_additional(method, tmpdir, short_raw_epochs):
     assert (eog_events.ndim == 2)
 
     # Test ica fiff export
+    assert raw.last_samp - raw.first_samp + 1 == raw.n_times
+    assert raw.n_times > 100
     ica_raw = ica.get_sources(raw, start=0, stop=100)
-    assert (ica_raw.last_samp - ica_raw.first_samp == 100)
+    assert ica_raw.n_times == 100
+    assert ica_raw.last_samp - ica_raw.first_samp + 1 == 100
     assert_equal(len(ica_raw._filenames), 1)  # API consistency
     ica_chans = [ch for ch in ica_raw.ch_names if 'ICA' in ch]
     assert (ica.n_components_ == len(ica_chans))

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -14,9 +14,8 @@ import pytest
 
 from mne import (SourceEstimate, VolSourceEstimate, MixedSourceEstimate,
                  SourceSpaces)
-from mne.fixes import has_numba
 from mne.parallel import _force_serial
-from mne.stats import cluster_level, ttest_ind_no_p, combine_adjacency
+from mne.stats import ttest_ind_no_p, combine_adjacency
 from mne.stats.cluster_level import (permutation_cluster_test, f_oneway,
                                      permutation_cluster_1samp_test,
                                      spatio_temporal_cluster_test,
@@ -24,22 +23,6 @@ from mne.stats.cluster_level import (permutation_cluster_test, f_oneway,
                                      ttest_1samp_no_p, summarize_clusters_stc)
 from mne.utils import (run_tests_if_main, catch_logging, check_version,
                        requires_sklearn)
-
-
-@pytest.fixture(scope="function", params=('Numba', 'NumPy'))
-def numba_conditional(monkeypatch, request):
-    """Test both code paths on machines that have Numba."""
-    assert request.param in ('Numba', 'NumPy')
-    if request.param == 'NumPy' and has_numba:
-        monkeypatch.setattr(
-            cluster_level, '_get_buddies', cluster_level._get_buddies_fallback)
-        monkeypatch.setattr(
-            cluster_level, '_get_selves', cluster_level._get_selves_fallback)
-        monkeypatch.setattr(
-            cluster_level, '_where_first', cluster_level._where_first_fallback)
-    if request.param == 'Numba' and not has_numba:
-        pytest.skip('Numba not installed')
-    yield request.param
 
 
 n_space = 50

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -983,7 +983,8 @@ def test_epochs_io_preload(tmpdir, preload):
     epochs_no_bl.save(temp_fname_no_bl, overwrite=True)
     epochs_read = read_epochs(temp_fname)
     epochs_no_bl_read = read_epochs(temp_fname_no_bl)
-    pytest.raises(ValueError, epochs.apply_baseline, baseline=[1, 2, 3])
+    with pytest.raises(ValueError, match='invalid'):
+        epochs.apply_baseline(baseline=[1, 2, 3])
     epochs_with_bl = epochs_no_bl_read.copy().apply_baseline(baseline)
     assert (isinstance(epochs_with_bl, BaseEpochs))
     assert (epochs_with_bl.baseline == (epochs_no_bl_read.tmin, baseline[1]))

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -219,7 +219,6 @@ def test_find_events():
     # Reset some data for ease of comparison
     raw._first_samps[0] = 0
     raw.info['sfreq'] = 1000
-    raw._update_times()
 
     stim_channel = 'STI 014'
     stim_channel_idx = pick_channels(raw.info['ch_names'],

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -2075,6 +2075,10 @@ class EpochsTFR(_BaseTFR, GetEpochsMixin):
         self.preload = True
         self.metadata = metadata
 
+    @property
+    def _detrend_picks(self):
+        return list()
+
     def __repr__(self):  # noqa: D105
         s = "time : [%f, %f]" % (self.times[0], self.times[-1])
         s += ", freq : [%f, %f]" % (self.freqs[0], self.freqs[-1])

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -61,7 +61,7 @@ from .numerics import (hashfunc, _compute_row_norms,
                        _mask_to_onsets_offsets, _array_equal_nan,
                        _julian_to_cal, _cal_to_julian, _dt_to_julian,
                        _julian_to_dt, _dt_to_stamp, _stamp_to_dt,
-                       _check_dt, _ReuseCycle)
+                       _check_dt, _ReuseCycle, _arange_div)
 from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
                     _prepare_write_metadata, _FakeNoPandas, ShiftTimeMixin)
 from .linalg import (_svd_lwork, _repeated_svd, _sym_mat_pow, sqrtm_sym,

--- a/mne/utils/mixin.py
+++ b/mne/utils/mixin.py
@@ -313,6 +313,7 @@ class GetEpochsMixin(object):
         :meth:`mne.Epochs.next`.
         """
         self._current = 0
+        self._current_detrend_picks = self._detrend_picks
         return self
 
     def __next__(self, return_event_id=False):
@@ -332,16 +333,17 @@ class GetEpochsMixin(object):
         """
         if self.preload:
             if self._current >= len(self._data):
-                raise StopIteration  # signal the end
+                self._stop_iter()
             epoch = self._data[self._current]
             self._current += 1
         else:
             is_good = False
             while not is_good:
                 if self._current >= len(self.events):
-                    raise StopIteration  # signal the end properly
+                    self._stop_iter()
                 epoch_noproj = self._get_epoch_from_raw(self._current)
-                epoch_noproj = self._detrend_offset_decim(epoch_noproj)
+                epoch_noproj = self._detrend_offset_decim(
+                    epoch_noproj, self._current_detrend_picks)
                 epoch = self._project_epoch(epoch_noproj)
                 self._current += 1
                 is_good, _ = self._is_good_epoch(epoch)
@@ -353,6 +355,11 @@ class GetEpochsMixin(object):
             return epoch
         else:
             return epoch, self.events[self._current - 1][-1]
+
+    def _stop_iter(self):
+        del self._current
+        del self._current_detrend_picks
+        raise StopIteration  # signal the end
 
     next = __next__  # originally for Python2, now b/c public
 

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -535,6 +535,7 @@ def test_reuse_cycle():
 @pytest.mark.parametrize('n', (0, 1, 10, 1000))
 @pytest.mark.parametrize('d', (0.0001, 1, 2.5, 1000))
 def test_arange_div(numba_conditional, n, d):
+    """Test Numba arange_div."""
     want = np.arange(n) / d
     got = numerics._arange_div(n, d)
     assert_allclose(got, want)

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -21,7 +21,7 @@ from mne.utils import (_get_inst_data, hashfunc,
                        _undo_scaling_array, _PCA, requires_sklearn,
                        _array_equal_nan, _julian_to_cal, _cal_to_julian,
                        _dt_to_julian, _julian_to_dt, grand_average,
-                       _ReuseCycle, requires_version)
+                       _ReuseCycle, requires_version, numerics)
 
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -530,3 +530,11 @@ def test_reuse_cycle():
         iterable.restore('a')
     assert ''.join(next(iterable) for _ in range(4)) == 'acde'
     assert ''.join(next(iterable) for _ in range(5)) == 'abcde'
+
+
+@pytest.mark.parametrize('n', (0, 1, 10, 1000))
+@pytest.mark.parametrize('d', (0.0001, 1, 2.5, 1000))
+def test_arange_div(numba_conditional, n, d):
+    want = np.arange(n) / d
+    got = numerics._arange_div(n, d)
+    assert_allclose(got, want)


### PR DESCRIPTION
Go back to creating `raw.times` on the fly when needed. On `master` this code:

<details>

```
import mne
mne.set_log_level("WARNING")


def read_raws(paths, preload):
    import gc
    out = list()
    for path in paths:
        out.append(mne.io.read_raw_edf(path, preload=preload))
        gc.collect()
    return out

paths = mne.datasets.sleep_physionet.age.fetch_data(
    subjects=range(1, 20), recording=[1])
paths, _ = zip(*paths)
raws = read_raws(paths, preload=False)
```

</details>

Produces with `mprof run mem.py && mprof plot`:

![Screenshot from 2021-01-28 08-03-30](https://user-images.githubusercontent.com/2365790/106142310-57467000-613f-11eb-9c76-e556ded4e3fe.png)

On this PR it produces:

![Screenshot from 2021-01-28 08-04-01](https://user-images.githubusercontent.com/2365790/106142354-64fbf580-613f-11eb-8ac0-18e34ddb25f2.png)

Moreover this code, which creates a ton of epochs (a variant of the case from #2126):

<details>

```
import numpy as np
import mne

def test():
    raw = mne.io.read_raw_fif(mne.datasets.sample.data_path() + '/MEG/sample/sample_audvis_raw.fif', preload=True)
    n_ev = 10000
    events = np.zeros((n_ev, 3), int)
    events[:, 2] = 1
    events[:, 0] = raw.first_samp + np.linspace(0, len(raw.times), n_ev + 2)[1:-1].round().astype(int)
    epochs = mne.Epochs(raw, events, preload=False, proj=False, baseline=None)
    epochs.average()


if __name__ == '__main__':
    import time
    t0 = time.time()
    test()
    print(time.time() - t0)
```

</details>

Takes 19.6 sec on `main` and 1.9 seconds on this PR. This speedup is mostly due to avoiding recomputing `picks` over and over again. So this PR has increased memory and CPU efficiency, hopefully.

Closes #8795
Closes #8745