### PR TITLE
MRG, ENH: Add warning about bad whitener conditioning

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -42,7 +42,7 @@ Enhancements
 
 - Add the ``silhouette`` parameter to :class:`mne.viz.Brain` to display sharp edges and improve perception (:gh:`8771` by `Guillaume Favelier`_)
 
-- Add warning to :func:`mne.compute_whitener` when an explicit ``rank`` parameter leads to a large increase in condition number (:gh:`8805` by `Eric Larson`_)
+- Add warning to :func:`mne.cov.compute_whitener` when an explicit ``rank`` parameter leads to a large increase in condition number (:gh:`8805` by `Eric Larson`_)
 
 - Add parameter ``align=True`` to `mne.viz.Brain.show_view` to make views relative to the closest canonical (MNI) axes rather than the native MRI surface RAS coordinates (:gh:`8794` by `Eric Larson`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -42,6 +42,8 @@ Enhancements
 
 - Add the ``silhouette`` parameter to :class:`mne.viz.Brain` to display sharp edges and improve perception (:gh:`8771` by `Guillaume Favelier`_)
 
+- Add warning to :func:`mne.compute_whitener` when an explicit ``rank`` parameter leads to a large increase in condition number (:gh:`8805` by `Eric Larson`_)
+
 - Add parameter ``align=True`` to `mne.viz.Brain.show_view` to make views relative to the closest canonical (MNI) axes rather than the native MRI surface RAS coordinates (:gh:`8794` by `Eric Larson`_)
 
 - Add ``auto_close`` to `mne.Report.add_figs_to_section` and `mne.Report.add_slider_to_section` to manage closing figures (:gh`8730` by `Guillaume Favelier`_)

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -38,7 +38,8 @@ from .rank import compute_rank
 from .utils import (check_fname, logger, verbose, check_version, _time_mask,
                     warn, copy_function_doc_to_method_doc, _pl,
                     _undo_scaling_cov, _scaled_array, _validate_type,
-                    _check_option, eigh, fill_doc, _on_missing)
+                    _check_option, eigh, fill_doc, _on_missing,
+                    _check_on_missing)
 from . import viz
 
 from .fixes import (BaseEstimator, EmpiricalCovariance, _logdet,
@@ -880,6 +881,7 @@ def compute_covariance(epochs, keep_sample_mean=True, tmin=None, tmax=None,
              'matrix may be inaccurate')
 
     orig = epochs[0].info['dev_head_t']
+    _check_on_missing(on_mismatch, 'on_mismatch')
     for ei, epoch in enumerate(epochs):
         epoch.info._check_consistency()
         if (orig is None) != (epoch.info['dev_head_t'] is None) or \

--- a/mne/rank.py
+++ b/mne/rank.py
@@ -13,8 +13,9 @@ from .io.pick import (_picks_by_type, pick_info, pick_channels_cov,
                       _picks_to_idx)
 from .io.proj import make_projector
 from .utils import (logger, _compute_row_norms, _pl, _validate_type,
-                    _apply_scaling_cov, _undo_scaling_cov, _check_option,
-                    _scaled_array, warn, _check_rank, _on_missing, verbose)
+                    _apply_scaling_cov, _undo_scaling_cov,
+                    _scaled_array, warn, _check_rank, _on_missing, verbose,
+                    _check_on_missing)
 
 
 @verbose
@@ -318,9 +319,7 @@ def compute_rank(inst, rank=None, scalings=None, info=None, tol='auto',
 
     rank = _check_rank(rank)
     scalings = _handle_default('scalings_cov_rank', scalings)
-    _validate_type(on_rank_mismatch, str, 'on_rank_mismatch')
-    _check_option('on_rank_mismatch', on_rank_mismatch,
-                  ('ignore', 'warn', 'raise'))
+    _check_on_missing(on_rank_mismatch, 'on_rank_mismatch')
 
     if isinstance(inst, Covariance):
         inst_type = 'covariance'

--- a/mne/rank.py
+++ b/mne/rank.py
@@ -412,12 +412,13 @@ def compute_rank(inst, rank=None, scalings=None, info=None, tol='auto',
                         ratio = s[this_rank - 1] / s[rank[ch_type] - 1]
                         if ratio > 100:
                             warn(f'The passed rank[{repr(ch_type)}]='
-                                 f'{rank[ch_type]} exceeds the rank estimated '
-                                 f'from the noise covariance ({this_rank}) '
-                                 'leading an increase in condition number by '
-                                 f'a factor of {ratio:0.1g}, this might '
-                                 'amplify noise during whitening by a factor '
-                                 f'of {np.sqrt(ratio):0.1g}')
+                                 f'{rank[ch_type]} exceeds the estimated rank '
+                                 f'of the noise covariance ({this_rank}) '
+                                 f'leading a potential increase in '
+                                 f'noise during whitening by a factor '
+                                 f'of {np.sqrt(ratio):0.1g}. Ensure that the '
+                                 f'rank correctly corresponds to that of the '
+                                 f'given noise covariance matrix.')
                         continue
             this_info_rank = _info_rank(info, ch_type, picks, 'info')
             logger.info('    %s: rank %d computed from %d data channel%s '

--- a/mne/rank.py
+++ b/mne/rank.py
@@ -349,6 +349,11 @@ def compute_rank(inst, rank=None, scalings=None, info=None, tol='auto',
     for ch_type, picks in picks_list:
         est_verbose = None
         if ch_type in rank:
+            # raise an error of user-supplied rank exceeds number of channels
+            if rank[ch_type] > len(picks):
+                raise ValueError(
+                    f'rank[{repr(ch_type)}]={rank[ch_type]} exceeds the number'
+                    f' of channels ({len(picks)})')
             # special case: if whitening a covariance, check the passed rank
             # against the estimated one
             est_verbose = False

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -801,7 +801,7 @@ def test_compute_whitener_rank():
     assert rank == 305
     assert compute_rank(cov, info=info, verbose=True) == dict(meg=rank)
     # this should emit a warning
-    with pytest.warns(RuntimeWarning, match='condition number'):
+    with pytest.warns(RuntimeWarning, match='exceeds the estimated'):
         _, _, rank = compute_whitener(cov, info, rank=dict(meg=306),
                                       return_rank=True)
     assert rank == 306

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -95,8 +95,8 @@ def test_cov_mismatch():
         compute_covariance([epochs, epochs_2], on_mismatch='ignore')
         with pytest.raises(RuntimeWarning, match='transform mismatch'):
             compute_covariance([epochs, epochs_2], on_mismatch='warn')
-        pytest.raises(ValueError, compute_covariance, epochs,
-                      on_mismatch='x')
+        with pytest.raises(ValueError, match='Invalid value'):
+            compute_covariance(epochs, on_mismatch='x')
     # This should work
     epochs.info['dev_head_t'] = None
     epochs_2.info['dev_head_t'] = None

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -29,8 +29,7 @@ from mne.io import read_raw_fif, RawArray, read_raw_ctf, read_info
 from mne.io.pick import _DATA_CH_TYPES_SPLIT, pick_info
 from mne.preprocessing import maxwell_filter
 from mne.rank import _compute_rank_int
-from mne.utils import (requires_sklearn, run_tests_if_main,
-                       catch_logging, assert_snr)
+from mne.utils import requires_sklearn, catch_logging, assert_snr
 
 base_dir = op.join(op.dirname(__file__), '..', 'io', 'tests', 'data')
 cov_fname = op.join(base_dir, 'test-cov.fif')
@@ -806,6 +805,3 @@ def test_compute_whitener_rank():
         _, _, rank = compute_whitener(cov, info, rank=dict(meg=306),
                                       return_rank=True)
     assert rank == 306
-
-
-run_tests_if_main()

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -17,7 +17,7 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_path_like, _check_src_normal, _check_stc_units,
                     _check_pyqt5_version, _check_sphere, _check_time_format,
                     _check_freesurfer_home, _suggest, _require_version,
-                    _on_missing, int_like, _safe_input,
+                    _on_missing, _check_on_missing, int_like, _safe_input,
                     _check_all_same_channel_names)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -706,6 +706,11 @@ def _suggest(val, options, cutoff=0.66):
         return ' Did you mean one of %r?' % (options,)
 
 
+def _check_on_missing(on_missing, name='on_missing'):
+    _validate_type(on_missing, str, name)
+    _check_option(name, on_missing, ['raise', 'warn', 'ignore'])
+
+
 def _on_missing(on_missing, msg, name='on_missing'):
     """Raise error or print warning with a message.
 
@@ -724,10 +729,9 @@ def _on_missing(on_missing, msg, name='on_missing'):
     ValueError
         When on_missing is 'raise'.
     """
-    _validate_type(on_missing, str, name)
+    _check_on_missing(on_missing, name)
     on_missing = 'raise' if on_missing == 'error' else on_missing
     on_missing = 'warn' if on_missing == 'warning' else on_missing
-    _check_option(name, on_missing, ['raise', 'warn', 'ignore'])
     if on_missing == 'raise':
         raise ValueError(msg)
     elif on_missing == 'warn':

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1006,10 +1006,12 @@ reduce_rank : bool
         Support for reducing rank in all modes (previously only supported
         ``pick='max_power'`` with weight normalization).
 """
-docdict['check_passed'] = """
-check_passed : bool
-    If True, sanity-check passed MEG values against computed ones (only used
-    for covariances; default False).
+docdict['on_rank_mismatch'] = """
+on_rank_mismatch : str
+    If an explicit MEG value is passed, what to do when it does not match
+    an empirically computed rank (only used for covariances).
+    Can be 'raise' to raise an error, 'warn' (default) to emit a warning, or
+    'ignore' to ignore.
 
     .. versionadded:: 0.23
 """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -874,7 +874,10 @@ extended_proj : list
 docdict['rank'] = """
 rank : None | 'info' | 'full' | dict
     This controls the rank computation that can be read from the
-    measurement info or estimated from the data.
+    measurement info or estimated from the data. When a noise covariance
+    is used for whitening, this should reflect the rank of that covariance,
+    otherwise amplification of noise components can occur in whitening (e.g.,
+    often during source localization).
 
     :data:`python:None`
         The rank will be estimated from the data after proper scaling of

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1003,6 +1003,13 @@ reduce_rank : bool
         Support for reducing rank in all modes (previously only supported
         ``pick='max_power'`` with weight normalization).
 """
+docdict['check_passed'] = """
+check_passed : bool
+    If True, sanity-check passed MEG values against computed ones (only used
+    for covariances; default False).
+
+    .. versionadded:: 0.23
+"""
 docdict['weight_norm'] = """
 weight_norm : str | None
     Can be:


### PR DESCRIPTION
Attempt to address https://mne.discourse.group/t/strange-source-activity-with-lcmv-beamformer-in-volume-source-space-empty-room-covariance/2549

@SophieHerbst @hoechenberger can you see if this warns when you try your beamforming script? If not can you send me an evoked file to use? This was my testing script since I didn't have one:

<details>

```
import mne
cov = mne.read_cov('data-cov.fif')
noise_cov = mne.read_cov('noise-cov.fif')
fwd = mne.read_forward_solution('FORWARD_ico-4_MEGonly_CEREB-fwd.fif')
info = fwd['info']
info.update(comps=[], projs=[])

filters = mne.beamformer.make_lcmv(
    info, fwd, cov, noise_cov=noise_cov, rank=dict(meg=73), verbose=True)
```

</details>

And it now produces for me a nice warning, which I line-wrap here:
```
Computing rank from covariance with rank={'meg': 73}
Computing rank from covariance with rank={'meg': 73}
Making LCMV beamformer with rank {'meg': 73}
Computing inverse operator with 306 channels.
    306 out of 306 channels remain after picking
Selected 306 channels
Whitening the forward solution.
Computing rank from covariance with rank={'meg': 73}
    Setting small MEG eigenvalues to zero (without PCA)
/home/larsoner/Desktop/COV/rep.py:8: RuntimeWarning: The passed rank['meg']=73 exceeds the rank
estimated from the noise covariance (72) leading an increase in condition number by a
factor of 5e+12, this might amplify noise during whitening by a factor of 2e+06
  filters = mne.beamformer.make_lcmv(
Creating the source covariance matrix
Adjusting source covariance matrix.
Computing beamformer filters for 39825 sources
Traceback (most recent call last):
  File "/home/larsoner/Desktop/COV/rep.py", line 8, in <module>
    filters = mne.beamformer.make_lcmv(
  File "<decorator-gen-360>", line 22, in make_lcmv
  File "/home/larsoner/python/mne-python/mne/beamformer/_lcmv.py", line 176, in make_lcmv
    W, max_power_ori = _compute_beamformer(
  File "/home/larsoner/python/mne-python/mne/beamformer/_compute_beamformer.py", line 240, in _compute_beamformer
    raise ValueError(
ValueError: Singular matrix detected when estimating spatial filters. Consider reducing the rank of the forward operator by using reduce_rank=True.
```
The error is also there for me on `main`.