### PR TITLE
MRG, ENH: Add support for other formats to browse_raw

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,6 +34,8 @@ Enhancements
 
 - Add option to control appearance of opaque inside surface of the head to :ref:`mne coreg` (:gh:`8793` by `Eric Larson`_)
 
+- Add support for non-FIF files in :ref:`mne browse_raw` using :func:`mne.io.read_raw` (:gh:`8806` by `Eric Larson`_)
+
 - Add :func:`mne.io.read_raw_nedf` for reading StarStim / enobio NEDF files (:gh:`8734` by `Tristan Stenner`_)
 
 - Add :meth:`raw.describe() <mne.io.Raw.describe>` to display (or return) descriptive statistics for each channel (:gh:`8760` by `Clemens Brunner`_)
@@ -55,6 +57,8 @@ Bugs
 - Fix bug with :meth:`mne.Report.add_bem_to_section` where ``n_jobs != 1`` would cause ``n_jobs`` subsets of MRI images in some orientations to be flipped (:gh:`8713` by `Eric Larson`_)
 
 - Fix bug with :meth:`raw.plot() <mne.io.Raw.plot>` where annotations didn't immediately appear when changing window duration (:gh:`8689` by `Daniel McCloy`_)
+
+- Fix bug with :meth:`raw.plot() <mne.io.Raw.plot>` where ``scalings='auto'`` did not compute scalings using the full range of data (:gh:`8806` by `Eric Larson`_)
 
 - Fix bug with :func:`mne.io.read_raw_nicolet` where header type values such as num_sample and duration_in_sec where not parsed properly (:gh:`8712` by `Alex Gramfort`_)
 

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 r"""Browse raw data.
 
+This uses :func:`mne.io.read_raw` so it supports the same formats
+(without keyword arguments).
+
 Examples
 --------
 .. code-block:: console
@@ -105,8 +108,10 @@ def run():
         parser.print_help()
         sys.exit(1)
 
-    raw = mne.io.read_raw_fif(raw_in, preload=preload,
-                              allow_maxshield=maxshield)
+    kwargs = dict(preload=preload)
+    if maxshield:
+        kwargs.update(allow_maxshield='yes')
+    raw = mne.io.read_raw(raw_in, **kwargs)
     if len(proj_in) > 0:
         projs = mne.read_proj(proj_in)
         raw.info['projs'] = projs

--- a/mne/io/_read_raw.py
+++ b/mne/io/_read_raw.py
@@ -42,8 +42,10 @@ supported = {".edf": read_raw_edf,
              ".bin": read_raw_artemis123,
              ".data": read_raw_nicolet,
              ".sqd": read_raw_kit,
+             ".con": read_raw_kit,
              ".ds": read_raw_ctf,
-             ".txt": read_raw_boxy}
+             ".txt": read_raw_boxy,
+}
 
 # known but unsupported file formats
 suggested = {".vmrk": partial(_read_unsupported, suggest=".vhdr"),

--- a/mne/io/_read_raw.py
+++ b/mne/io/_read_raw.py
@@ -27,24 +27,25 @@ def _read_unsupported(fname, **kwargs):
 
 
 # supported read file formats
-supported = {".edf": read_raw_edf,
-             ".bdf": read_raw_bdf,
-             ".gdf": read_raw_gdf,
-             ".vhdr": read_raw_brainvision,
-             ".fif": read_raw_fif,
-             ".fif.gz": read_raw_fif,
-             ".set": read_raw_eeglab,
-             ".cnt": read_raw_cnt,
-             ".mff": read_raw_egi,
-             ".nxe": read_raw_eximia,
-             ".hdr": read_raw_nirx,
-             ".mat": read_raw_fieldtrip,
-             ".bin": read_raw_artemis123,
-             ".data": read_raw_nicolet,
-             ".sqd": read_raw_kit,
-             ".con": read_raw_kit,
-             ".ds": read_raw_ctf,
-             ".txt": read_raw_boxy,
+supported = {
+    ".edf": read_raw_edf,
+    ".bdf": read_raw_bdf,
+    ".gdf": read_raw_gdf,
+    ".vhdr": read_raw_brainvision,
+    ".fif": read_raw_fif,
+    ".fif.gz": read_raw_fif,
+    ".set": read_raw_eeglab,
+    ".cnt": read_raw_cnt,
+    ".mff": read_raw_egi,
+    ".nxe": read_raw_eximia,
+    ".hdr": read_raw_nirx,
+    ".mat": read_raw_fieldtrip,
+    ".bin": read_raw_artemis123,
+    ".data": read_raw_nicolet,
+    ".sqd": read_raw_kit,
+    ".con": read_raw_kit,
+    ".ds": read_raw_ctf,
+    ".txt": read_raw_boxy,
 }
 
 # known but unsupported file formats

--- a/mne/io/tests/test_read_raw.py
+++ b/mne/io/tests/test_read_raw.py
@@ -5,11 +5,15 @@
 # License: BSD (3-clause)
 
 from pathlib import Path
+
 import pytest
+
 from mne.io import read_raw
+from mne.datasets import testing
 
 
 base = Path(__file__).parent.parent
+test_base = Path(testing.data_path(download=False))
 
 
 @pytest.mark.parametrize('fname', ['x.xxx', 'x'])
@@ -26,10 +30,14 @@ def test_read_raw_suggested(fname):
         read_raw(fname)
 
 
-@pytest.mark.parametrize('fname', [base / 'edf/tests/data/test.edf',
-                                   base / 'edf/tests/data/test.bdf',
-                                   base / 'brainvision/tests/data/test.vhdr',
-                                   base / 'kit/tests/data/test.sqd'])
+@pytest.mark.parametrize('fname', [
+    base / 'edf/tests/data/test.edf',
+    base / 'edf/tests/data/test.bdf',
+    base / 'brainvision/tests/data/test.vhdr',
+    base / 'kit/tests/data/test.sqd',
+    pytest.param(test_base / 'KIT/data_berlin.con',
+                 marks=testing._pytest_mark()),
+])
 def test_read_raw_supported(fname):
     """Test supported file types."""
     read_raw(fname)

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -707,5 +707,5 @@ def test_plot_sensors(raw):
 
 def test_scalings_int():
     """Test that auto scalings access samples using integers."""
-    raw = RawArray(np.zeros((1, 500)), create_info(1, 1000., 'eeg')
+    raw = RawArray(np.zeros((1, 500)), create_info(1, 1000., 'eeg'))
     raw.plot(scalings='auto')

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -14,8 +14,7 @@ import matplotlib.pyplot as plt
 from mne import read_events, pick_types, Annotations, create_info
 from mne.datasets import testing
 from mne.io import read_raw_fif, read_raw_ctf, RawArray
-from mne.utils import (run_tests_if_main, _dt_to_stamp, _click_ch_name,
-                       _close_event)
+from mne.utils import _dt_to_stamp, _click_ch_name, _close_event
 from mne.viz.utils import _fake_click
 from mne.annotations import _sync_onset
 from mne.viz import plot_raw, plot_sensors
@@ -706,4 +705,7 @@ def test_plot_sensors(raw):
         raw.plot_sensors()
 
 
-run_tests_if_main()
+def test_scalings_int():
+    """Test that auto scalings access samples using integers."""
+    raw = RawArray(np.zeros((1, 500)), create_info(1, 1000., 'eeg')
+    raw.plot(scalings='auto')

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1125,7 +1125,9 @@ def _compute_scalings(scalings, inst, remove_dc=False, duration=10):
             time_middle = np.mean(inst.times)
             tmin = np.clip(time_middle - n_secs / 2., inst.times.min(), None)
             tmax = np.clip(time_middle + n_secs / 2., None, inst.times.max())
-            data = inst._read_segment(tmin, tmax)
+            smin, smax = [
+                int(round(x * inst.info['sfreq'])) for x in (tmin, tmax)]
+            data = inst._read_segment(smin, smax)
         elif isinstance(inst, BaseEpochs):
             # Load a random subset of epochs up to 100mb in size
             n_epochs = 1e8 // (len(inst.ch_names) * len(inst.times) * 8)


### PR DESCRIPTION
1. Use `read_raw` rather than `read_raw_fif` in `browse_raw` to extend support to other formats
2. Add `.con` as a recognized KIT format name
3. Fix bug where `scalings='auto` would use the wrong sample range to compute auto scalings. It passed float times when it needed to pass int samples to `_read_segment`.