### PR TITLE
FIX missing Axes3D import in viz._3d._plot_mpl_stc

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -68,6 +68,8 @@ Bugs
 
 - Fix bug with :ref:`mne coreg` where nasion values were not updated when clicking (:gh:`8793` by `Eric Larson`_)
 
+- Fix bug with matplotlib-based 3D plotting where ``Axes3D`` were not properly initialized in :func:`mne.viz.plot_source_estimates` (:gh:`8811` by `Chris Bailey`_)
+
 - Allow sEEG channel types in :meth:`mne.Evoked.plot_joint` (:gh:`8736` by `Daniel McCloy`_)
 
 - Function :func:`mne.set_bipolar_reference` was not working when passing ``Epochs`` constructed with some ``picks`` (:gh:`8728` by `Alex Gramfort`_)

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -245,7 +245,7 @@ def plot_head_positions(pos, mode='traces', cmap='viridis', direction='z',
     else:  # mode == 'field':
         from matplotlib.colors import Normalize
         from mpl_toolkits.mplot3d.art3d import Line3DCollection
-        from mpl_toolkits.mplot3d import axes3d  # noqa: F401, analysis:ignore
+        from mpl_toolkits.mplot3d import Axes3D  # noqa: F401, analysis:ignore
         fig, ax = plt.subplots(1, subplot_kw=dict(projection='3d'))
 
         # First plot the trajectory as a colormap:
@@ -1488,6 +1488,7 @@ def _plot_mpl_stc(stc, subject=None, surface='inflated', hemi='lh',
                   transparent=True):
     """Plot source estimate using mpl."""
     import matplotlib.pyplot as plt
+    from mpl_toolkits.mplot3d import Axes3D  # noqa: F401, analysis:ignore
     from matplotlib import cm
     from matplotlib.widgets import Slider
     import nibabel as nib


### PR DESCRIPTION
#### Reference issue
Fixes #8810 .

#### What does this implement/fix?

Added the missing `from mpl_toolkits.mplot3d import Axes3`

#### Additional information

Note that I've also modified the same import in `plot_head_positions`:

```python
from mpl_toolkits.mplot3d import axes3d  # was this
from mpl_toolkits.mplot3d import Axes3  # surely should be this?
```

I found this while searching for the actual bug, and [remembered reading this](https://stackoverflow.com/questions/11529043/axes3d-vs-axes3d-matplotlib) recently.