### PR TITLE
MRG, FIX: Fix for NumPy deprecation

### DIFF
--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -208,12 +208,15 @@ def test_parse_annotation(tmpdir):
                                  samp=(len(annot) - 1) // 2,
                                  dtype_byte='This_parameter_is_not_used')
 
+    want_onset, want_duration, want_description = zip(
+        *[[180., 0., 'Lights off'], [180., 0., 'Close door'],
+          [180., 0., 'Lights off'], [180., 0., 'Close door'],
+          [3.14, 4.2, 'nothing'], [1800.2, 25.5, 'Apnea']])
     for tal_channel in [tal_channel_A, tal_channel_B]:
         onset, duration, description = _read_annotations_edf([tal_channel])
-        assert_equal(np.column_stack((onset, duration, description)),
-                     [[180., 0., 'Lights off'], [180., 0., 'Close door'],
-                      [180., 0., 'Lights off'], [180., 0., 'Close door'],
-                      [3.14, 4.2, 'nothing'], [1800.2, 25.5, 'Apnea']])
+        assert_allclose(onset, want_onset)
+        assert_allclose(duration, want_duration)
+        assert description == want_description
 
 
 def test_find_events_backward_compatibility():

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -79,6 +79,12 @@ def _make_xy_sfunc(func, ndim_output=False):
     return sfunc
 
 
+# Violate our assumption that the output is 1D so can't be used.
+# Could eventually be added but probably not worth the effort unless someone
+# requests it.
+_BLOCKLIST = {'somersd'}
+
+
 # makes score funcs attr accessible for users
 def get_score_funcs():
     """Get the score functions.
@@ -92,9 +98,11 @@ def get_score_funcs():
     from scipy.spatial import distance
     score_funcs = Bunch()
     xy_arg_dist_funcs = [(n, f) for n, f in vars(distance).items()
-                         if isfunction(f) and not n.startswith('_')]
+                         if isfunction(f) and not n.startswith('_') and
+                         n not in _BLOCKLIST]
     xy_arg_stats_funcs = [(n, f) for n, f in vars(stats).items()
-                          if isfunction(f) and not n.startswith('_')]
+                          if isfunction(f) and not n.startswith('_') and
+                          n not in _BLOCKLIST]
     score_funcs.update({n: _make_xy_sfunc(f)
                         for n, f in xy_arg_dist_funcs
                         if _get_args(f) == ['u', 'v']})

--- a/mne/utils/tests/test_testing.py
+++ b/mne/utils/tests/test_testing.py
@@ -1,13 +1,10 @@
 import os.path as op
-import os
 
 import numpy as np
 import pytest
-from numpy.testing import assert_equal
 
 from mne.datasets import testing
-from mne.utils import (_TempDir, _url_to_local_path, run_tests_if_main,
-                       buggy_mkl_svd)
+from mne.utils import (_TempDir, _url_to_local_path, buggy_mkl_svd)
 
 
 def test_buggy_mkl():
@@ -35,18 +32,18 @@ def test_tempdir():
     assert (not op.isdir(x))
 
 
-def test_datasets():
+def test_datasets(monkeypatch, tmpdir):
     """Test dataset config."""
     # gh-4192
-    data_path = testing.data_path(download=False)
-    os.environ['MNE_DATASETS_TESTING_PATH'] = op.dirname(data_path)
-    assert testing.data_path(download=False) == data_path
+    fake_path = tmpdir.mkdir('MNE-testing-data')
+    with open(fake_path.join('version.txt'), 'w') as fid:
+        fid.write('9999.9999')
+    monkeypatch.setenv('_MNE_FAKE_HOME_DIR', str(tmpdir))
+    monkeypatch.setenv('MNE_DATASETS_TESTING_PATH', str(tmpdir))
+    assert testing.data_path(download=False, verbose='debug') == str(fake_path)
 
 
 def test_url_to_local_path():
     """Test URL to local path."""
-    assert_equal(_url_to_local_path('http://google.com/home/why.html', '.'),
-                 op.join('.', 'home', 'why.html'))
-
-
-run_tests_if_main()
+    assert _url_to_local_path('http://google.com/home/why.html', '.') == \
+        op.join('.', 'home', 'why.html')

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -834,7 +834,7 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
         assert surfs['helmet']['coord_frame'] == FIFF.FIFFV_COORD_MRI
 
     # Brain:
-    brain = np.intersect1d(surfaces, ['brain', 'pial', 'white', 'inflated'])
+    brain = set(surfaces) & set(['brain', 'pial', 'white', 'inflated'])
     if len(brain) > 1:
         raise ValueError('Only one brain surface can be plotted. '
                          'Got %s.' % brain)

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1163,8 +1163,8 @@ class MNEBrowseFigure(MNEFigure):
 
     def _get_annotation_labels(self):
         """Get the unique labels in the raw object and added in the UI."""
-        labels = list(set(self.mne.inst.annotations.description))
-        return np.union1d(labels, self.mne.new_annotation_labels)
+        return sorted(set(self.mne.inst.annotations.description) |
+                      set(self.mne.new_annotation_labels))
 
     def _update_annotation_fig(self):
         """Draw or redraw the radio buttons and annotation labels."""
@@ -1296,16 +1296,13 @@ class MNEBrowseFigure(MNEFigure):
         """Set up colors for annotations; init some annotation vars."""
         raw = self.mne.inst
         segment_colors = getattr(self.mne, 'annotation_segment_colors', dict())
-        # sort the segments by start time
-        ann_order = raw.annotations.onset.argsort(axis=0)
-        descriptions = raw.annotations.description[ann_order]
-        color_keys = np.union1d(descriptions, self.mne.new_annotation_labels)
+        labels = self._get_annotation_labels()
         colors, red = _get_color_list(annotations=True)
         color_cycle = cycle(colors)
         for key, color in segment_colors.items():
-            if color != red and key in color_keys:
+            if color != red and key in labels:
                 next(color_cycle)
-        for idx, key in enumerate(color_keys):
+        for idx, key in enumerate(labels):
             if key in segment_colors:
                 continue
             elif key.lower().startswith('bad') or \
@@ -1315,7 +1312,6 @@ class MNEBrowseFigure(MNEFigure):
                 segment_colors[key] = next(color_cycle)
         self.mne.annotation_segment_colors = segment_colors
         # init a couple other annotation-related variables
-        labels = self._get_annotation_labels()
         self.mne.visible_annotations = {label: True for label in labels}
         self.mne.show_hide_annotation_checkboxes = None
 

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1294,7 +1294,6 @@ class MNEBrowseFigure(MNEFigure):
 
     def _setup_annotation_colors(self):
         """Set up colors for annotations; init some annotation vars."""
-        raw = self.mne.inst
         segment_colors = getattr(self.mne, 'annotation_segment_colors', dict())
         labels = self._get_annotation_labels()
         colors, red = _get_color_list(annotations=True)


### PR DESCRIPTION
Fixes for a NumPy dtype promotion deprecation that happens due to `union1d`. It's easy enough to work around using sets. Despite code comments about ordering based on time, `union1d` [always returns a sorted output](https://numpy.org/doc/stable/reference/generated/numpy.union1d.html):
```
>>> np.union1d(('a', 'c', 'b', 'b'), ('d',))
array(['a', 'b', 'c', 'd'], dtype='<U1')
```
So this PR maintains this behavior (and removes the errant comment) by using `sorted` and `set` directly.