### PR TITLE
MRG, BUG: Fix Epochs.reject_tmin, reject_tmax handling upon Epochs creation & cropping

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -100,6 +100,10 @@ Bugs
 
 - Fix bug with :func:`mne.viz.plot_topomap` when plotting gradiometers with a missing channel in a pair (:gh:`8817` by `Alex Gramfort`_)
 
+- :meth:`epochs.crop() <mne.Epochs.crop>` now also adjusts the ``reject_tmin`` and ``reject_tmax`` attributes if necessary  (:gh:`8821` by `Richard Höchenberger`_)
+
+- When creating `~mne.Epochs`, we now ensure that ``reject_tmin`` and ``reject_tmax`` cannot fall outside of the epochs' time interval anymore  (:gh:`8821` by `Richard Höchenberger`_)
+
 API changes
 ~~~~~~~~~~~
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -100,9 +100,9 @@ Bugs
 
 - Fix bug with :func:`mne.viz.plot_topomap` when plotting gradiometers with a missing channel in a pair (:gh:`8817` by `Alex Gramfort`_)
 
-- :meth:`epochs.crop() <mne.Epochs.crop>` now also adjusts the ``reject_tmin`` and ``reject_tmax`` attributes if necessary  (:gh:`8821` by `Richard Höchenberger`_)
+- :meth:`epochs.crop() <mne.Epochs.crop>` now also adjusts the ``reject_tmin`` and ``reject_tmax`` attributes if necessary (:gh:`8821` by `Richard Höchenberger`_)
 
-- When creating `~mne.Epochs`, we now ensure that ``reject_tmin`` and ``reject_tmax`` cannot fall outside of the epochs' time interval anymore  (:gh:`8821` by `Richard Höchenberger`_)
+- When creating `~mne.Epochs`, we now ensure that ``reject_tmin`` and ``reject_tmax`` cannot fall outside of the epochs' time interval anymore (:gh:`8821` by `Richard Höchenberger`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -518,21 +518,26 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         self._set_times(self._raw_times)
 
         # check reject_tmin and reject_tmax
-        if (reject_tmin is not None) and (np.isclose(reject_tmin, tmin)):
-            # potentially adjust for small deviations due to sampling freq
-            reject_tmin = self.tmin
-        elif (reject_tmin is not None) and (reject_tmin < tmin):
-            raise ValueError("reject_tmin needs to be None or >= tmin")
+        if reject_tmin is not None:
+            if (np.isclose(reject_tmin, tmin)):
+                # adjust for potential small deviations due to sampling freq
+                reject_tmin = self.tmin
+            elif reject_tmin < tmin:
+                raise ValueError(f'reject_tmin needs to be None or >= tmin '
+                                 f'(got {reject_tmin})')
 
-        if (reject_tmax is not None) and (np.isclose(reject_tmax, tmax)):
-            # potentially adjust for small deviations due to sampling freq
-            reject_tmax = self.tmax
-        elif (reject_tmax is not None) and (reject_tmax > tmax):
-            raise ValueError("reject_tmax needs to be None or <= tmax")
+        if reject_tmax is not None:
+            if (np.isclose(reject_tmax, tmax)):
+                # adjust for potential small deviations due to sampling freq
+                reject_tmax = self.tmax
+            elif reject_tmax > tmax:
+                raise ValueError(f'reject_tmax needs to be None or <= tmax '
+                                 f'(got {reject_tmax})')
 
         if (reject_tmin is not None) and (reject_tmax is not None):
             if reject_tmin >= reject_tmax:
-                raise ValueError('reject_tmin needs to be < reject_tmax')
+                raise ValueError(f'reject_tmin ({reject_tmin}) needs to be '
+                                 f' < reject_tmax ({reject_tmax})')
 
         self.reject_tmin = reject_tmin
         self.reject_tmax = reject_tmax
@@ -1575,12 +1580,14 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
 
         # Adjust rejection period
         if self.reject_tmin is not None and self.reject_tmin < self.tmin:
-            warn('reject_tmin is not in epochs time interval. reject_tmin is '
-                 'set to epochs.tmin')
+            logger.info(
+                f'reject_tmin is not in epochs time interval. '
+                f'Setting reject_tmin to epochs.tmin ({self.tmin} sec)')
             self.reject_tmin = self.tmin
         if self.reject_tmax is not None and self.reject_tmax > self.tmax:
-            warn('reject_tmax is not in epochs time interval. reject_tmax is '
-                 'set to epochs.tmax')
+            logger.info(
+                f'reject_tmax is not in epochs time interval. '
+                f'Setting reject_tmax to epochs.tmax ({self.tmax} sec)')
             self.reject_tmax = self.tmax
         return self
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1572,6 +1572,16 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         self._set_times(self.times[tmask])
         self._raw_times = self._raw_times[tmask]
         self._data = self._data[:, :, tmask]
+
+        # Adjust rejection period
+        if self.reject_tmin is not None and self.reject_tmin < self.tmin:
+            warn('reject_tmin is not in epochs time interval. reject_tmin is '
+                 'set to epochs.tmin')
+            self.reject_tmin = self.tmin
+        if self.reject_tmax is not None and self.reject_tmax > self.tmax:
+            warn('reject_tmax is not in epochs time interval. reject_tmax is '
+                 'set to epochs.tmax')
+            self.reject_tmax = self.tmax
         return self
 
     def copy(self):

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1616,6 +1616,7 @@ def test_crop(tmpdir):
     epochs.save(temp_fname)
     mne.read_epochs(temp_fname)
 
+
 def test_resample():
     """Test of resample of epochs."""
     raw, events, picks = _get_data()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1605,14 +1605,18 @@ def test_crop(tmpdir):
     epochs = Epochs(raw=raw, events=events[:5], event_id=event_id,
                     tmin=tmin, tmax=tmax, reject_tmin=tmin, reject_tmax=tmax)
     epochs.load_data()
-    with pytest.warns(RuntimeWarning, match='reject_tmin is not in.*interval'):
+    with catch_logging() as log:
         epochs.copy().crop(0, None)
-    with pytest.warns(RuntimeWarning, match='reject_tmax is not in.*interval'):
+    log = log.getvalue()
+    assert 'reject_tmin is not in' in log
+
+    with catch_logging() as log:
         epochs.copy().crop(None, 0.1)
+    log = log.getvalue()
+    assert 'reject_tmax is not in' in log
 
     # Cropping & I/O roundtrip
-    with pytest.warns(RuntimeWarning, match='not in.*interval'):
-        epochs.crop(0, 0.1)
+    epochs.crop(0, 0.1)
     epochs.save(temp_fname)
     mne.read_epochs(temp_fname)
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1605,20 +1605,19 @@ def test_crop(tmpdir):
     epochs = Epochs(raw=raw, events=events[:5], event_id=event_id,
                     tmin=tmin, tmax=tmax, reject_tmin=tmin, reject_tmax=tmax)
     epochs.load_data()
-    with catch_logging() as log:
-        epochs.copy().crop(0, None)
-    log = log.getvalue()
-    assert 'reject_tmin is not in' in log
+    epochs_cropped = epochs.copy().crop(0, None)
+    assert np.isclose(epochs_cropped.tmin, epochs_cropped.reject_tmin)
 
-    with catch_logging() as log:
-        epochs.copy().crop(None, 0.1)
-    log = log.getvalue()
-    assert 'reject_tmax is not in' in log
+    epochs_cropped = epochs.copy().crop(None, 0.1)
+    assert np.isclose(epochs_cropped.tmax, epochs_cropped.reject_tmax)
+    del epochs_cropped
 
     # Cropping & I/O roundtrip
     epochs.crop(0, 0.1)
     epochs.save(temp_fname)
-    mne.read_epochs(temp_fname)
+    epochs_read = mne.read_epochs(temp_fname)
+    assert np.isclose(epochs_read.tmin, epochs_read.reject_tmin)
+    assert np.isclose(epochs_read.tmax, epochs_read.reject_tmax)
 
 
 def test_resample():


### PR DESCRIPTION

- Adjust Epochs.reject_tmin, reject_tmax for time inaccuracies due to sfreq. Fixes #8814
- Adjust Epochs.reject_tmin, reject_tmax upon cropping. Fixes #8816