### PR TITLE
Ensure times at which chpi are fitted are valid samples

### DIFF
--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -858,8 +858,8 @@ def compute_chpi_amplitudes(raw, t_step_min=0.01, t_window='auto',
                 % (len(hpi['freqs']), len(fit_idxs), tmax - tmin))
     del tmin, tmax
     sin_fits = dict()
-    sin_fits['times'] = (fit_idxs + raw.first_samp -
-                         hpi['n_window'] / 2.) / raw.info['sfreq']
+    sin_fits['times'] = np.round(fit_idxs + raw.first_samp -
+                                 hpi['n_window'] / 2.) / raw.info['sfreq']
     sin_fits['proj'] = hpi['proj']
     sin_fits['slopes'] = np.empty(
         (len(sin_fits['times']),

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -479,6 +479,8 @@ def _run_maxwell_filter(
     logger.info(
         '    Processing %s data chunk%s' % (len(starts), _pl(starts)))
     for ii, (start, stop) in enumerate(zip(starts, stops)):
+        if start == stop:
+            continue  # Skip zero-length annotations
         tsss_valid = (stop - start) >= st_duration
         rel_times = raw_sss.times[start:stop]
         t_str = '%8.3f - %8.3f sec' % tuple(rel_times[[0, -1]])

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -487,6 +487,7 @@ def test_calculate_chpi_coil_locs_artemis():
     raw = read_raw_artemis123(art_fname, preload=True)
     times, cHPI_digs = _calculate_chpi_coil_locs(raw, verbose='debug')
 
+    assert len(np.setdiff1d(times, raw.times + raw.first_time)) == 0
     assert_allclose(times[5], 1.5, atol=1e-3)
     assert_allclose(cHPI_digs[5][0]['gof'], 0.995, atol=5e-3)
     assert_allclose(cHPI_digs[5][0]['r'],


### PR DESCRIPTION
I encountered this while maxfiltering 40 subjects. Some subjects failed, claiming `Head position time points must be greater than first sample offset, but found 500.0005 < 500`. A bit of a misleading error, as it was not the first time point that caused the problem, but the final time point.

When the continuous head position is fitted through `compute_chpi_amplitudes`, the first column of the result contains the times at which each fit was performed. However, these times were not necessarily aligned on the times of the original raw object, meaning some times fell in between two samples. This caused problems later on in `maxwell_filter` as a check is done whether the times are all valid, as the final timestamp can be slightly larger than the final timestamp of the raw object.

In this PR, `compute_chpi_amplitudes` is changed to always produce times that are aligned with those in the original raw object.