### PR TITLE
MRG, ENH: Speed up import by caching indented params

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -36,6 +36,8 @@ Enhancements
 
 - Reduce memory consumption of `mne.io.Raw` and speed up epoching when thousands of events are present for `mne.Epochs` (:gh:`8801` by `Eric Larson`_)
 
+- Speed up ``import mne`` by reducing function creation overhead (:gh:`8829` by `Eric Larson`_)
+
 - `mne.Report.parse_folder` now processes supported non-FIFF files by default, too (:gh:`8744` by `Richard Höchenberger`_)
 
 - `mne.Report` has gained a new method `~mne.Report.add_custom_css` for adding user-defined styles (:gh:`8762` by `Richard Höchenberger`_)

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -777,17 +777,17 @@ Code organization
 Importing
 ---------
 
-Import modules in this order:
+Import modules in this order, preferably alphabetized within each subsection:
 
-1. Python built-in (``os``, ``copy``, ``functools``, etc)
-2. standard scientific (``numpy as np``, ``scipy.signal``, etc)
-3. others
-4. MNE-Python imports (e.g., ``from .pick import pick_types``)
+1. Python built-in (``copy``, ``functools``, ``os``, etc.)
+2. NumPy (``numpy as np``) and, in test files, pytest (``pytest``)
+3. MNE-Python imports (e.g., ``from .pick import pick_types``)
 
 When importing from other parts of MNE-Python, use relative imports in the main
 codebase and absolute imports in tests, tutorials, and how-to examples. Imports
-for ``matplotlib`` and optional modules (``sklearn``, ``pandas``, etc.) should
-be nested (i.e., within a function or method, not at the top of a file).
+for ``matplotlib``, ``scipy``, and optional modules (``sklearn``, ``pandas``,
+etc.) should be nested (i.e., within a function or method, not at the top of a
+file). This helps reduce import time and limit hard requirements for using MNE.
 
 
 Return types

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -9,7 +9,6 @@
 from copy import deepcopy
 
 import numpy as np
-from scipy import linalg
 
 from ..cov import Covariance, make_ad_hoc_cov
 from ..forward.forward import is_fixed_orient, _restrict_forward_to_src_sel
@@ -377,7 +376,7 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
                         'matrix or using regularization.')
                 noise = loading_factor
             else:
-                noise, _ = linalg.eigh(Cm)
+                noise, _ = np.linalg.eigh(Cm)
                 noise = noise[-rank]
                 noise = max(noise, loading_factor)
             W /= np.sqrt(noise)

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -6,8 +6,8 @@
 # License: BSD (3-clause)
 
 import numpy as np
-from scipy import linalg
 
+from ..fixes import _safe_svd
 from ..forward import is_fixed_orient, convert_forward_solution
 from ..io.pick import pick_channels_evoked, pick_info, pick_channels_forward
 from ..inverse_sparse.mxne_inverse import _make_dipoles_sparse
@@ -47,6 +47,7 @@ def _apply_rap_music(data, info, times, forward, noise_cov, n_dipoles=2,
         selected active dipoles and their estimated orientation.
         Computed only if return_explained_data is True.
     """
+    from scipy import linalg
     info = pick_info(info, picks)
     del picks
     # things are much simpler if we avoid surface orientation
@@ -184,7 +185,7 @@ def _make_dipoles(times, poss, oris, sol, gof):
 
 def _compute_subcorr(G, phi_sig):
     """Compute the subspace correlation."""
-    Ug, Sg, Vg = linalg.svd(G, full_matrices=False)
+    Ug, Sg, Vg = _safe_svd(G, full_matrices=False)
     # Now we look at the actual rank of the forward fields
     # in G and handle the fact that it might be rank defficient
     # eg. when using MEG and a sphere model for which the
@@ -195,14 +196,14 @@ def _compute_subcorr(G, phi_sig):
     rank = max(rank, 2)  # rank cannot be 1
     Ug, Sg, Vg = Ug[:, :rank], Sg[:rank], Vg[:rank]
     tmp = np.dot(Ug.T.conjugate(), phi_sig)
-    Uc, Sc, _ = linalg.svd(tmp, full_matrices=False)
+    Uc, Sc, _ = _safe_svd(tmp, full_matrices=False)
     X = np.dot(Vg.T / Sg[None, :], Uc[:, 0])  # subcorr
-    return Sc[0], X / linalg.norm(X)
+    return Sc[0], X / np.linalg.norm(X)
 
 
 def _compute_proj(A):
     """Compute the orthogonal projection operation for a manifold vector A."""
-    U, _, _ = linalg.svd(A, full_matrices=False)
+    U, _, _ = _safe_svd(A, full_matrices=False)
     return np.identity(A.shape[0]) - np.dot(U, U.T.conjugate())
 
 

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -7,7 +7,6 @@
 
 import numpy as np
 
-from ..fixes import _safe_svd
 from ..forward import is_fixed_orient, convert_forward_solution
 from ..io.pick import pick_channels_evoked, pick_info, pick_channels_forward
 from ..inverse_sparse.mxne_inverse import _make_dipoles_sparse
@@ -185,7 +184,8 @@ def _make_dipoles(times, poss, oris, sol, gof):
 
 def _compute_subcorr(G, phi_sig):
     """Compute the subspace correlation."""
-    Ug, Sg, Vg = _safe_svd(G, full_matrices=False)
+    from scipy import linalg
+    Ug, Sg, Vg = linalg.svd(G, full_matrices=False)
     # Now we look at the actual rank of the forward fields
     # in G and handle the fact that it might be rank defficient
     # eg. when using MEG and a sphere model for which the
@@ -196,14 +196,15 @@ def _compute_subcorr(G, phi_sig):
     rank = max(rank, 2)  # rank cannot be 1
     Ug, Sg, Vg = Ug[:, :rank], Sg[:rank], Vg[:rank]
     tmp = np.dot(Ug.T.conjugate(), phi_sig)
-    Uc, Sc, _ = _safe_svd(tmp, full_matrices=False)
+    Uc, Sc, _ = linalg.svd(tmp, full_matrices=False)
     X = np.dot(Vg.T / Sg[None, :], Uc[:, 0])  # subcorr
     return Sc[0], X / np.linalg.norm(X)
 
 
 def _compute_proj(A):
     """Compute the orthogonal projection operation for a manifold vector A."""
-    U, _, _ = _safe_svd(A, full_matrices=False)
+    from scipy import linalg
+    U, _, _ = linalg.svd(A, full_matrices=False)
     return np.identity(A.shape[0]) - np.dot(U, U.T.conjugate())
 
 

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -32,7 +32,7 @@ from .transforms import _ensure_trans, apply_trans, Transform
 from .utils import (verbose, logger, run_subprocess, get_subjects_dir, warn,
                     _pl, _validate_type, _TempDir, _check_freesurfer_home,
                     _check_fname, has_nibabel, _check_option)
-from .fixes import einsum, _safe_svd
+from .fixes import einsum
 from .externals.h5io import write_hdf5, read_hdf5
 
 
@@ -633,6 +633,7 @@ def _fwd_eeg_get_multi_sphere_model_coeffs(m, n_terms):
 
 def _compose_linear_fitting_data(mu, u):
     """Get the linear fitting data."""
+    from scipy import linalg
     k1 = np.arange(1, u['nterms'])
     mu1ns = mu[0] ** k1
     # data to be fitted
@@ -640,7 +641,7 @@ def _compose_linear_fitting_data(mu, u):
     # model matrix
     M = u['w'][:-1, np.newaxis] * (mu[1:] ** k1[:, np.newaxis] -
                                    mu1ns[:, np.newaxis])
-    uu, sing, vv = _safe_svd(M, full_matrices=False)
+    uu, sing, vv = linalg.svd(M, full_matrices=False)
     ncomp = u['nfit'] - 1
     uu, sing, vv = uu[:, :ncomp], sing[:ncomp], vv[:ncomp]
     return y, uu, sing, vv

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -15,7 +15,6 @@ from copy import deepcopy
 from functools import partial
 
 import numpy as np
-from scipy import sparse
 
 from ..defaults import HEAD_SIZE_DEFAULT, _handle_default
 from ..transforms import _frame_to_str
@@ -1281,6 +1280,7 @@ def _ch_neighbor_adjacency(ch_names, neighbors):
     ch_adjacency : scipy.sparse matrix
         The adjacency matrix.
     """
+    from scipy import sparse
     if len(ch_names) != len(neighbors):
         raise ValueError('`ch_names` and `neighbors` must '
                          'have the same length')
@@ -1408,6 +1408,7 @@ def _compute_ch_adjacency(info, ch_type):
     ch_names : list
         The list of channel names present in adjacency matrix.
     """
+    from scipy import sparse
     from scipy.spatial import Delaunay
     from .. import spatial_tris_adjacency
     from ..channels.layout import _find_topomap_coords, _pair_grad_sensors

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -4,7 +4,6 @@
 
 import numpy as np
 from numpy.polynomial.legendre import legval
-from scipy import linalg
 
 from ..utils import logger, warn, verbose
 from ..io.meas_info import _simplify_info
@@ -105,7 +104,7 @@ def _make_interpolation_matrix(pos_from, pos_to, alpha=1e-5):
 
     C = np.vstack([np.hstack([G_from, np.ones((n_from, 1))]),
                    np.hstack([np.ones((1, n_from)), [[0]]])])
-    C_inv = linalg.pinv(C)
+    C_inv = np.linalg.pinv(C)
 
     interpolation = np.hstack([G_to_from, np.ones((n_to, 1))]) @ C_inv[:, :-1]
     assert interpolation.shape == (n_to, n_from)

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -82,6 +82,7 @@ def _make_interpolation_matrix(pos_from, pos_to, alpha=1e-5):
         Spherical splines for scalp potential and current density mapping.
         Electroencephalography Clinical Neurophysiology, Feb; 72(2):184-7.
     """
+    from scipy import linalg
     pos_from = pos_from.copy()
     pos_to = pos_to.copy()
     n_from = pos_from.shape[0]
@@ -104,7 +105,7 @@ def _make_interpolation_matrix(pos_from, pos_to, alpha=1e-5):
 
     C = np.vstack([np.hstack([G_from, np.ones((n_from, 1))]),
                    np.hstack([np.ones((1, n_from)), [[0]]])])
-    C_inv = np.linalg.pinv(C)
+    C_inv = linalg.pinv(C)
 
     interpolation = np.hstack([G_to_from, np.ones((n_to, 1))]) @ C_inv[:, :-1]
     assert interpolation.shape == (n_to, n_from)

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -22,7 +22,6 @@
 from functools import partial
 
 import numpy as np
-from scipy import linalg
 import itertools
 
 from .io.base import BaseRaw
@@ -487,7 +486,7 @@ def _setup_hpi_amplitude_fitting(info, t_window, remove_aliased=False,
     model += [np.sin(l_t), np.cos(l_t)]  # line freqs
     model += [slope, np.ones(slope.shape)]
     model = np.concatenate(model, axis=1)
-    inv_model = linalg.pinv(model)
+    inv_model = np.linalg.pinv(model)
     inv_model_reord = _reorder_inv_model(inv_model, len(hpi_freqs))
     proj, proj_op, meg_picks = _setup_ext_proj(info, ext_order)
 
@@ -508,6 +507,7 @@ def _reorder_inv_model(inv_model, n_freqs):
 
 
 def _setup_ext_proj(info, ext_order):
+    from scipy import linalg
     meg_picks = pick_types(info, meg=True, eeg=False, exclude='bads')
     info = pick_info(_simplify_info(info), meg_picks)  # makes a copy
     _, _, _, _, mag_or_fine = _get_mf_picks_fix_mags(
@@ -1095,7 +1095,7 @@ def filter_chpi(raw, include_line=True, t_step=0.01, t_window='auto',
             this_recon = recon
         else:  # first or last window
             model = hpi['model'][:this_len]
-            inv_model = linalg.pinv(model)
+            inv_model = np.linalg.pinv(model)
             this_recon = np.dot(model[:, :n_remove], inv_model[:n_remove]).T
         this_data = raw._data[meg_picks, time_sl]
         subt_pt = min(midpt + n_step, n_times)

--- a/mne/connectivity/spectral.py
+++ b/mne/connectivity/spectral.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from .utils import check_indices
 from ..utils import _check_option
-from ..fixes import _get_args, rfftfreq
+from ..fixes import _get_args, _import_fft
 from ..parallel import parallel_func
 from ..source_estimate import _BaseSourceEstimate
 from ..epochs import BaseEpochs
@@ -934,6 +934,7 @@ def _prepare_connectivity(epoch_block, tmin, tmax, fmin, fmax, sfreq, indices,
                           mode, fskip, n_bands,
                           cwt_freqs, faverage):
     """Check and precompute dimensions of results data."""
+    rfftfreq = _import_fft('rfftfreq')
     first_epoch = epoch_block[0]
 
     # get the data size and time scale

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -11,7 +11,6 @@ from math import log
 import os
 
 import numpy as np
-from scipy import linalg, sparse
 
 from .defaults import _EXTRAPOLATE_DEFAULT, _BORDER_DEFAULT, DEFAULTS
 from .io.write import start_file, end_file
@@ -42,7 +41,7 @@ from .utils import (check_fname, logger, verbose, check_version, _time_mask,
                     _check_on_missing)
 from . import viz
 
-from .fixes import (BaseEstimator, EmpiricalCovariance, _logdet,
+from .fixes import (BaseEstimator, EmpiricalCovariance, _logdet, _safe_svd,
                     empirical_covariance, log_likelihood)
 
 
@@ -1711,7 +1710,7 @@ def regularize(cov, info, mag=0.1, grad=0.1, eeg=0.1, exclude='bads',
                 P, ncomp, _ = make_projector(projs, this_ch_names)
                 if ncomp > 0:
                     # This adjustment ends up being redundant if rank is None:
-                    U = linalg.svd(P)[0][:, :-ncomp]
+                    U = _safe_svd(P)[0][:, :-ncomp]
                     logger.info('    Created an SSP operator for %s '
                                 '(dimension = %d)' % (desc, ncomp))
         else:
@@ -1934,6 +1933,7 @@ def whiten_evoked(evoked, noise_cov, picks=None, diag=None, rank=None,
 def _read_cov(fid, node, cov_kind, limited=False, verbose=None):
     """Read a noise covariance matrix."""
     #   Find all covariance matrices
+    from scipy import sparse
     covs = dir_tree_find(node, FIFF.FIFFB_MNE_COV)
     if len(covs) == 0:
         raise ValueError('No covariance matrices found')

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -41,7 +41,7 @@ from .utils import (check_fname, logger, verbose, check_version, _time_mask,
                     _check_on_missing)
 from . import viz
 
-from .fixes import (BaseEstimator, EmpiricalCovariance, _logdet, _safe_svd,
+from .fixes import (BaseEstimator, EmpiricalCovariance, _logdet,
                     empirical_covariance, log_likelihood)
 
 
@@ -1633,6 +1633,7 @@ def regularize(cov, info, mag=0.1, grad=0.1, eeg=0.1, exclude='bads',
     --------
     mne.compute_covariance
     """  # noqa: E501
+    from scipy import linalg
     cov = cov.copy()
     info._check_consistency()
     scalings = _handle_default('scalings_cov_rank', scalings)
@@ -1710,7 +1711,7 @@ def regularize(cov, info, mag=0.1, grad=0.1, eeg=0.1, exclude='bads',
                 P, ncomp, _ = make_projector(projs, this_ch_names)
                 if ncomp > 0:
                     # This adjustment ends up being redundant if rank is None:
-                    U = _safe_svd(P)[0][:, :-ncomp]
+                    U = linalg.svd(P)[0][:, :-ncomp]
                     logger.info('    Created an SSP operator for %s '
                                 '(dimension = %d)' % (desc, ncomp))
         else:

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 
-from .fixes import rfft, irfft
+from .fixes import _import_fft
 from .utils import (sizeof_fmt, logger, get_config, warn, _explain_exception,
                     verbose)
 
@@ -154,6 +154,7 @@ def _setup_cuda_fft_multiply_repeated(n_jobs, h, n_fft,
     -----
     This function is designed to be used with fft_multiply_repeated().
     """
+    rfft, irfft = _import_fft(('rfft', 'irfft'))
     cuda_dict = dict(n_fft=n_fft, rfft=rfft, irfft=irfft,
                      h_fft=rfft(h, n=n_fft))
     if n_jobs == 'cuda':
@@ -246,6 +247,7 @@ def _setup_cuda_fft_resample(n_jobs, W, new_len):
     -----
     This function is designed to be used with fft_resample().
     """
+    rfft, irfft = _import_fft(('rfft', 'irfft'))
     cuda_dict = dict(use_cuda=False, rfft=rfft, irfft=irfft)
     rfft_len_x = len(W) // 2 + 1
     # fold the window onto inself (should be symmetric) and truncate

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -10,7 +10,6 @@
 import copy as cp
 
 import numpy as np
-from scipy import linalg
 
 from .base import BaseEstimator
 from .mixin import TransformerMixin
@@ -160,6 +159,7 @@ class CSP(TransformerMixin, BaseEstimator):
         self : instance of CSP
             Returns the modified instance.
         """
+        from scipy import linalg
         self._check_Xy(X, y)
 
         self._classes = np.unique(y)
@@ -532,6 +532,7 @@ class CSP(TransformerMixin, BaseEstimator):
         return cov, weight
 
     def _decompose_covs(self, covs, sample_weights):
+        from scipy import linalg
         n_classes = len(covs)
         if n_classes == 2:
             eigen_values, eigen_vectors = linalg.eigh(covs[0], covs.sum(0))
@@ -761,6 +762,7 @@ class SPoC(CSP):
         self : instance of SPoC
             Returns the modified instance.
         """
+        from scipy import linalg
         self._check_Xy(X, y)
 
         if len(np.unique(y)) < 2:

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -169,6 +169,7 @@ class ReceptiveField(BaseEstimator):
         self : instance
             The instance so you can chain operations.
         """
+        from scipy import linalg
         if self.scoring not in _SCORERS.keys():
             raise ValueError('scoring must be one of %s, got'
                              '%s ' % (sorted(_SCORERS.keys()), self.scoring))
@@ -243,7 +244,7 @@ class ReceptiveField(BaseEstimator):
             # Inverse output covariance
             if y.ndim == 2 and y.shape[1] != 1:
                 y = y - y.mean(0, keepdims=True)
-                inv_Y = np.linalg.pinv(np.cov(y.T))
+                inv_Y = linalg.pinv(np.cov(y.T))
             else:
                 inv_Y = 1. / float(n_times * n_epochs - 1)
             del y

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -7,7 +7,6 @@
 import numbers
 
 import numpy as np
-from scipy import linalg
 
 from .base import get_coef, BaseEstimator, _check_estimator
 from .time_delaying_ridge import TimeDelayingRidge
@@ -244,7 +243,7 @@ class ReceptiveField(BaseEstimator):
             # Inverse output covariance
             if y.ndim == 2 and y.shape[1] != 1:
                 y = y - y.mean(0, keepdims=True)
-                inv_Y = linalg.pinv(np.cov(y.T))
+                inv_Y = np.linalg.pinv(np.cov(y.T))
             else:
                 inv_Y = 1. / float(n_times * n_epochs - 1)
             del y

--- a/mne/decoding/ssd.py
+++ b/mne/decoding/ssd.py
@@ -3,7 +3,7 @@
 # License: BSD (3-clause)
 
 import numpy as np
-from scipy.linalg import eigh
+
 from ..filter import filter_data
 from ..cov import _regularized_covariance
 from . import TransformerMixin, BaseEstimator
@@ -153,6 +153,7 @@ class SSD(BaseEstimator, TransformerMixin):
         self : instance of SSD
             Returns the modified instance.
         """
+        from scipy.linalg import eigh
         self._check_X(X)
         X_aux = X[..., self.picks_, :]
 

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -6,9 +6,10 @@ import os.path as op
 import pytest
 import numpy as np
 
+from numpy import einsum
+from numpy.fft import rfft, irfft
 from numpy.testing import assert_array_equal, assert_allclose, assert_equal
 
-from mne.fixes import einsum, rfft, irfft
 from mne.utils import requires_sklearn, run_tests_if_main
 from mne.decoding import ReceptiveField, TimeDelayingRidge
 from mne.decoding.receptive_field import (_delay_time_series, _SCORERS,

--- a/mne/decoding/time_delaying_ridge.py
+++ b/mne/decoding/time_delaying_ridge.py
@@ -6,7 +6,6 @@
 # License: BSD (3-clause)
 
 import numpy as np
-from scipy import linalg
 
 from .base import BaseEstimator
 from ..cuda import _setup_cuda_fft_multiply_repeated
@@ -146,6 +145,7 @@ def _toeplitz_dot(a, b):
 def _compute_reg_neighbors(n_ch_x, n_delays, reg_type, method='direct',
                            normed=False):
     """Compute regularization parameter from neighbors."""
+    from scipy import linalg
     from scipy.sparse.csgraph import laplacian
     known_types = ('ridge', 'laplacian')
     if isinstance(reg_type, str):
@@ -201,6 +201,7 @@ def _compute_reg_neighbors(n_ch_x, n_delays, reg_type, method='direct',
 def _fit_corrs(x_xt, x_y, n_ch_x, reg_type, alpha, n_ch_in):
     """Fit the model using correlation matrices."""
     # do the regularized solving
+    from scipy import linalg
     n_ch_out = x_y.shape[1]
     assert x_y.shape[0] % n_ch_x == 0
     n_delays = x_y.shape[0] // n_ch_x

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -7,13 +7,14 @@
 # License: Simplified BSD
 
 from copy import deepcopy
+import functools
 from functools import partial
 import re
 
 import numpy as np
-from scipy import linalg
 
 from .cov import read_cov, compute_whitener
+from .fixes import _safe_svd
 from .io.constants import FIFF
 from .io.pick import pick_types
 from .io.proj import make_projector, _needs_eeg_average_ref_proj
@@ -33,7 +34,7 @@ from .source_space import _make_volume_source_space, SourceSpaces
 from .parallel import parallel_func
 from .utils import (logger, verbose, _time_mask, warn, _check_fname,
                     check_fname, _pl, fill_doc, _check_option, ShiftTimeMixin,
-                    _svd_lwork, _repeated_svd, ddot, dgemv, dgemm)
+                    _svd_lwork, _repeated_svd, _get_blas_funcs)
 
 
 @fill_doc
@@ -713,6 +714,7 @@ def _dipole_forwards(fwd_data, whitener, rr, n_jobs=1):
     B_orig = B.copy()
 
     # Apply projection and whiten (cov has projections already)
+    _, _, dgemm = _get_ddot_dgemv_dgemm()
     B = dgemm(1., B, whitener.T)
 
     # column normalization doesn't affect our fitting, so skip for now
@@ -758,8 +760,14 @@ def _fit_eval(rd, B, B2, fwd_svd=None, fwd_data=None, whitener=None,
     return 1. - gof
 
 
+@functools.cache
+def _get_ddot_dgemv_dgemm():
+    return _get_blas_funcs(np.float64, ('dot', 'gemv', 'gemm'))
+
+
 def _dipole_gof(uu, sing, vv, B, B2):
     """Calculate the goodness of fit from the forward SVD."""
+    ddot, dgemv, _ = _get_ddot_dgemv_dgemm()
     ncomp = 3 if sing[2] / (sing[0] if sing[0] > 0 else 1.) > 0.2 else 2
     one = dgemv(1., vv[:ncomp], B)  # np.dot(vv[:ncomp], B)
     Bm2 = ddot(one, one)  # np.sum(one * one)
@@ -785,7 +793,7 @@ def _fit_Q(fwd_data, whitener, B, B2, B_orig, rd, ori=None):
         fwd_svd = None
     if ori is None:
         if fwd_svd is None:
-            fwd_svd = linalg.svd(fwd, full_matrices=False)
+            fwd_svd = _safe_svd(fwd, full_matrices=False)
         uu, sing, vv = fwd_svd
         gof, one = _dipole_gof(uu, sing, vv, B, B2)
         ncomp = len(one)
@@ -933,6 +941,7 @@ def _fit_confidence(rd, Q, ori, whitener, fwd_data):
     #
     # And then the confidence interval is the diagonal of C, scaled by 1.96
     # (for 95% confidence).
+    from scipy import linalg
     direction = np.empty((3, 3))
     # The coordinate system has the x axis aligned with the dipole orientation,
     direction[0] = ori
@@ -1212,7 +1221,7 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
             kind = 'rad'
         else:  # MEG-only
             # Use the minimum distance to the MEG sensors as the radius then
-            R = np.dot(linalg.inv(info['dev_head_t']['trans']),
+            R = np.dot(np.linalg.inv(info['dev_head_t']['trans']),
                        np.hstack([r0, [1.]]))[:3]  # r0 -> device
             R = R - [info['chs'][pick]['loc'][:3]
                      for pick in pick_types(info, meg=True, exclude=[])]
@@ -1350,7 +1359,7 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     guess_fwd, guess_fwd_orig, guess_fwd_scales = _dipole_forwards(
         fwd_data, whitener, guess_src['rr'], n_jobs=fit_n_jobs)
     # decompose ahead of time
-    guess_fwd_svd = [linalg.svd(fwd, overwrite_a=False, full_matrices=False)
+    guess_fwd_svd = [_safe_svd(fwd, full_matrices=False)
                      for fwd in np.array_split(guess_fwd,
                                                len(guess_src['rr']))]
     guess_data = dict(fwd=guess_fwd, fwd_svd=guess_fwd_svd,

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -760,7 +760,7 @@ def _fit_eval(rd, B, B2, fwd_svd=None, fwd_data=None, whitener=None,
     return 1. - gof
 
 
-@functools.cache
+@functools.lru_cache(None)
 def _get_ddot_dgemv_dgemm():
     return _get_blas_funcs(np.float64, ('dot', 'gemv', 'gemm'))
 

--- a/mne/externals/h5io/_h5io.py
+++ b/mne/externals/h5io/_h5io.py
@@ -388,7 +388,7 @@ def object_diff(a, b, pre=''):
     diffs : str
         A string representation of the differences.
     """
-
+    sparse = _import_sparse()
     try:
         from pandas import DataFrame, Series
     except ImportError:

--- a/mne/externals/h5io/_h5io.py
+++ b/mne/externals/h5io/_h5io.py
@@ -11,10 +11,6 @@ from shutil import rmtree
 from os import path as op
 
 import numpy as np
-try:
-    from scipy import sparse
-except ImportError:
-    sparse = None
 
 # Adapted from six
 PY3 = sys.version_info[0] == 3
@@ -23,6 +19,14 @@ string_types = str if PY3 else basestring  # noqa
 
 special_chars = {'{FWDSLASH}': '/'}
 tab_str = '----'
+
+
+def _import_sparse():
+    try:
+        from scipy import sparse
+    except ImportError:
+        sparse = None
+    return sparse
 
 
 ##############################################################################
@@ -126,6 +130,7 @@ def write_hdf5(fname, data, overwrite=False, compression=4,
 def _triage_write(key, value, root, comp_kw, where,
                   cleanup_data, slash='error', title=None,
                   use_json=False):
+    sparse = _import_sparse()
     if key != title and '/' in key:
         if slash == 'error':
             raise ValueError('Found a key with "/", '
@@ -274,6 +279,7 @@ def _triage_read(node, slash='ignore'):
     if slash not in ['ignore', 'replace']:
         raise ValueError("slash must be one of 'replace', 'ignore'")
     h5py = _check_h5py()
+    sparse = _import_sparse()
     type_str = node.attrs['TITLE']
     if isinstance(type_str, bytes):
         type_str = type_str.decode()

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -7,10 +7,10 @@ from functools import partial
 import numpy as np
 
 from .annotations import _annotations_starts_stops
+from .fixes import _import_fft
 from .io.pick import _picks_to_idx
 from .cuda import (_setup_cuda_fft_multiply_repeated, _fft_multiply_repeated,
                    _setup_cuda_fft_resample, _fft_resample, _smart_pad)
-from .fixes import irfft, ifftshift, fftfreq
 from .parallel import parallel_func, check_n_jobs
 from .time_frequency.multitaper import _mt_spectra, _compute_mt_params
 from .utils import (logger, verbose, sum_squared, warn, _pl,
@@ -1428,6 +1428,7 @@ def resample(x, up=1., down=1., npad=100, axis=-1, window='boxcar', n_jobs=1,
     up=up/down and down=1.
     """
     from scipy.signal import get_window
+    ifftshift, fftfreq = _import_fft(('ifftshift', 'fftfreq'))
     # check explicitly for backwards compatibility
     if not isinstance(axis, int):
         err = ("The axis parameter needs to be an integer (got %s). "
@@ -2255,6 +2256,7 @@ def design_mne_c_filter(sfreq, l_freq=None, h_freq=40.,
     4197 frequencies are directly constructed, with zeroes in the stop-band
     and ones in the passband, with squared cosine ramps in between.
     """
+    irfft = _import_fft('irfft')
     n_freqs = (4096 + 2 * 2048) // 2 + 1
     freq_resp = np.ones(n_freqs)
     l_freq = 0 if l_freq is None else float(l_freq)

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -157,9 +157,9 @@ def _import_fft(name):
     try:
         from scipy.fft import rfft  # noqa analysis:ignore
     except ImportError:
-        from numpy import fft
+        from numpy import fft  # noqa
     else:
-        from scipy.fft import fft
+        from scipy import fft  # noqa
     out = [getattr(fft, n) for n in name]
     if single:
         out = out[0]

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -148,7 +148,7 @@ def _read_geometry(filepath, read_metadata=False, read_stamp=False):
 ###############################################################################
 # Triaging FFT functions to get fast pocketfft (SciPy 1.4)
 
-@functools.cache
+@functools.lru_cache(None)
 def _import_fft(name):
     single = False
     if not isinstance(name, tuple):

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -12,17 +12,15 @@ at which the fix is no longer needed.
 #          Lars Buitinck <L.J.Buitinck@uva.nl>
 # License: BSD
 
-import inspect
 from distutils.version import LooseVersion
+import functools
+import inspect
 from math import log
 import os
 from pathlib import Path
 import warnings
 
 import numpy as np
-import scipy
-from scipy import linalg
-from scipy.linalg import LinAlgError
 
 
 ###############################################################################
@@ -49,6 +47,7 @@ def _safe_svd(A, **kwargs):
     #     https://software.intel.com/en-us/forums/intel-distribution-for-python/topic/628049  # noqa: E501
     # For SciPy 0.18 and up, we can work around it by using
     # lapack_driver='gesvd' instead.
+    from scipy import linalg
     if kwargs.get('overwrite_a', False):
         raise ValueError('Cannot set overwrite_a=True with this function')
     try:
@@ -61,6 +60,11 @@ def _safe_svd(A, **kwargs):
             return linalg.svd(A, lapack_driver='gesvd', **kwargs)
         else:
             raise
+
+
+def _csc_matrix_cast(x):
+    from scipy.sparse import csc_matrix
+    return csc_matrix(x)
 
 
 ###############################################################################
@@ -144,10 +148,20 @@ def _read_geometry(filepath, read_metadata=False, read_stamp=False):
 ###############################################################################
 # Triaging FFT functions to get fast pocketfft (SciPy 1.4)
 
-try:
-    from scipy.fft import fft, ifft, fftfreq, rfft, irfft, rfftfreq, ifftshift
-except ImportError:
-    from numpy.fft import fft, ifft, fftfreq, rfft, irfft, rfftfreq, ifftshift
+@functools.cache
+def _import_fft(name):
+    single = False
+    if not isinstance(name, tuple):
+        name = (name,)
+        single = True
+    try:
+        from scipy import fft
+    except ImportError:
+        from numpy import fft
+    out = [getattr(fft, n) for n in name]
+    if single:
+        out = out[0]
+    return out
 
 
 ###############################################################################
@@ -564,6 +578,7 @@ class EmpiricalCovariance(BaseEstimator):
             is computed.
 
         """
+        from scipy import linalg
         # covariance = check_array(covariance)
         # set covariance
         self.covariance_ = covariance
@@ -582,6 +597,7 @@ class EmpiricalCovariance(BaseEstimator):
             The precision matrix associated to the current covariance object.
 
         """
+        from scipy import linalg
         if self.store_precision:
             precision = self.precision_
         else:
@@ -677,6 +693,7 @@ class EmpiricalCovariance(BaseEstimator):
         `self` and `comp_cov` covariance estimators.
 
         """
+        from scipy import linalg
         # compute the error
         error = comp_cov - self.covariance_
         # compute the error norm
@@ -753,6 +770,7 @@ def log_likelihood(emp_cov, precision):
 
 def _logdet(A):
     """Compute the log det of a positive semidefinite matrix."""
+    from scipy import linalg
     vals = linalg.eigvalsh(A)
     # avoid negative (numerical errors) or zero (semi-definite matrix) values
     tol = vals.max() * vals.size * np.finfo(np.float64).eps

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -155,9 +155,11 @@ def _import_fft(name):
         name = (name,)
         single = True
     try:
-        from scipy import fft
+        from scipy.fft import rfft  # noqa analysis:ignore
     except ImportError:
         from numpy import fft
+    else:
+        from scipy.fft import fft
     out = [getattr(fft, n) for n in name]
     if single:
         out = out[0]

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -10,7 +10,6 @@ from copy import deepcopy
 
 import numpy as np
 
-from ..fixes import _safe_svd
 from ..io.constants import FWD, FIFF
 from ..bem import _check_origin
 from ..io.pick import pick_types, pick_info
@@ -106,7 +105,8 @@ def _compute_mapping_matrix(fmd, info):
 
 def _pinv_trunc(x, miss):
     """Compute pseudoinverse, truncating at most "miss" fraction of varexp."""
-    u, s, v = _safe_svd(x, full_matrices=False)
+    from scipy import linalg
+    u, s, v = linalg.svd(x, full_matrices=False)
 
     # Eigenvalue truncation
     varexp = np.cumsum(s)

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -9,8 +9,8 @@
 from copy import deepcopy
 
 import numpy as np
-from scipy import linalg
 
+from ..fixes import _safe_svd
 from ..io.constants import FWD, FIFF
 from ..bem import _check_origin
 from ..io.pick import pick_types, pick_info
@@ -106,7 +106,7 @@ def _compute_mapping_matrix(fmd, info):
 
 def _pinv_trunc(x, miss):
     """Compute pseudoinverse, truncating at most "miss" fraction of varexp."""
-    u, s, v = linalg.svd(x, full_matrices=False)
+    u, s, v = _safe_svd(x, full_matrices=False)
 
     # Eigenvalue truncation
     varexp = np.cumsum(s)

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -12,7 +12,6 @@ from copy import deepcopy
 import re
 
 import numpy as np
-from scipy import sparse
 
 import shutil
 import os
@@ -168,6 +167,7 @@ def _block_diag(A, n):
     bd : sparse matrix
         The block diagonal matrix
     """
+    from scipy import sparse
     if sparse.issparse(A):  # then make block sparse
         raise NotImplementedError('sparse reversal not implemented yet')
     ma, na = A.shape
@@ -583,6 +583,7 @@ def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
     fwd : Forward
         The modified forward solution.
     """
+    from scipy import sparse
     fwd = fwd.copy() if copy else fwd
 
     if force_fixed is True:

--- a/mne/gui/_kit2fiff_gui.py
+++ b/mne/gui/_kit2fiff_gui.py
@@ -8,10 +8,9 @@ from collections import Counter
 import os
 import queue
 import sys
+from threading import Thread
 
 import numpy as np
-from scipy.linalg import inv
-from threading import Thread
 
 from mayavi.core.ui.mayavi_scene import MayaviScene
 from mayavi.tools.mlab_scene_model import MlabSceneModel
@@ -204,7 +203,7 @@ class Kit2FiffModel(HasPrivateTraits):
 
     @cached_property
     def _get_head_dev_trans(self):
-        return inv(self.dev_head_trans)
+        return np.linalg.inv(self.dev_head_trans)
 
     @cached_property
     def _get_hsp(self):

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -3,10 +3,9 @@
 # License: Simplified BSD
 
 import numpy as np
-from scipy import linalg
 
+from ..fixes import _safe_svd
 from ..forward import is_fixed_orient
-
 from ..minimum_norm.inverse import _check_reference, _log_exp_var
 from ..utils import logger, verbose, warn
 from .mxne_inverse import (_check_ori, _make_sparse_stc, _prepare_gain,
@@ -59,10 +58,10 @@ def _gamma_map_opt(M, G, alpha, maxit=10000, tol=1e-6, update_mode=1,
     n_sensors, n_times = M.shape
 
     # apply normalization so the numerical values are sane
-    M_normalize_constant = linalg.norm(np.dot(M, M.T), ord='fro')
+    M_normalize_constant = np.linalg.norm(np.dot(M, M.T), ord='fro')
     M /= np.sqrt(M_normalize_constant)
     alpha /= M_normalize_constant
-    G_normalize_constant = linalg.norm(G, ord=np.inf)
+    G_normalize_constant = np.linalg.norm(G, ord=np.inf)
     G /= G_normalize_constant
 
     if n_sources % group_size != 0:
@@ -97,7 +96,7 @@ def _gamma_map_opt(M, G, alpha, maxit=10000, tol=1e-6, update_mode=1,
         CM = np.dot(G * gammas[np.newaxis, :], G.T)
         CM.flat[::n_sensors + 1] += alpha
         # Invert CM keeping symmetry
-        U, S, V = linalg.svd(CM, full_matrices=False)
+        U, S, V = _safe_svd(CM, full_matrices=False)
         S = S[np.newaxis, :]
         del CM
         CMinv = np.dot(U / (S + eps), U.T)

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -4,7 +4,6 @@
 
 import numpy as np
 
-from ..fixes import _safe_svd
 from ..forward import is_fixed_orient
 from ..minimum_norm.inverse import _check_reference, _log_exp_var
 from ..utils import logger, verbose, warn
@@ -46,6 +45,7 @@ def _gamma_map_opt(M, G, alpha, maxit=10000, tol=1e-6, update_mode=1,
     active_set : array, shape=(n_active,)
         Indices of active sources.
     """
+    from scipy import linalg
     G = G.copy()
     M = M.copy()
 
@@ -96,7 +96,7 @@ def _gamma_map_opt(M, G, alpha, maxit=10000, tol=1e-6, update_mode=1,
         CM = np.dot(G * gammas[np.newaxis, :], G.T)
         CM.flat[::n_sensors + 1] += alpha
         # Invert CM keeping symmetry
-        U, S, V = _safe_svd(CM, full_matrices=False)
+        U, S, _ = linalg.svd(CM, full_matrices=False)
         S = S[np.newaxis, :]
         del CM
         CMinv = np.dot(U / (S + eps), U.T)

--- a/mne/inverse_sparse/mxne_debiasing.py
+++ b/mne/inverse_sparse/mxne_debiasing.py
@@ -5,7 +5,6 @@
 
 from math import sqrt
 import numpy as np
-from scipy import linalg
 
 from ..utils import check_random_state, logger, verbose, fill_doc
 
@@ -38,13 +37,13 @@ def power_iteration_kron(A, C, max_iter=1000, tol=1e-3, random_state=0):
     AS_size = C.shape[0]
     rng = check_random_state(random_state)
     B = rng.randn(AS_size, AS_size)
-    B /= linalg.norm(B, 'fro')
+    B /= np.linalg.norm(B, 'fro')
     ATA = np.dot(A.T, A)
     CCT = np.dot(C, C.T)
     L0 = np.inf
     for _ in range(max_iter):
         Y = np.dot(np.dot(ATA, B), CCT)
-        L = linalg.norm(Y, 'fro')
+        L = np.linalg.norm(Y, 'fro')
 
         if abs(L - L0) < tol:
             break
@@ -121,14 +120,14 @@ def compute_bias(M, G, X, max_iter=1000, tol=1e-6, n_orient=1, verbose=None):
         dt = (t0 - 1.0) / t
         Y = D + dt * (D - D0)
 
-        Ddiff = linalg.norm(D - D0, np.inf)
+        Ddiff = np.linalg.norm(D - D0, np.inf)
 
         if Ddiff < tol:
             logger.info("Debiasing converged after %d iterations "
                         "max(|D - D0| = %e < %e)" % (i, Ddiff, tol))
             break
     else:
-        Ddiff = linalg.norm(D - D0, np.inf)
+        Ddiff = np.linalg.norm(D - D0, np.inf)
         logger.info("Debiasing did not converge after %d iterations! "
                     "max(|D - D0| = %e >= %e)" % (max_iter, Ddiff, tol))
     return D

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -4,11 +4,11 @@
 # License: Simplified BSD
 
 import numpy as np
-from scipy import linalg
 
 from ..source_estimate import SourceEstimate, _BaseSourceEstimate, _make_stc
 from ..minimum_norm.inverse import (combine_xyz, _prepare_forward,
                                     _check_reference, _log_exp_var)
+from ..fixes import _safe_svd
 from ..forward import is_fixed_orient
 from ..io.pick import pick_channels_evoked
 from ..io.proj import deactivate_proj
@@ -406,7 +406,7 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose='auto', depth=0.8,
     M = np.dot(whitener, M)
 
     if time_pca:
-        U, s, Vh = linalg.svd(M, full_matrices=False)
+        U, s, Vh = _safe_svd(M, full_matrices=False)
         if not isinstance(time_pca, bool) and isinstance(time_pca, int):
             U = U[:, :time_pca]
             s = s[:time_pca]

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -8,7 +8,6 @@ import numpy as np
 from ..source_estimate import SourceEstimate, _BaseSourceEstimate, _make_stc
 from ..minimum_norm.inverse import (combine_xyz, _prepare_forward,
                                     _check_reference, _log_exp_var)
-from ..fixes import _safe_svd
 from ..forward import is_fixed_orient
 from ..io.pick import pick_channels_evoked
 from ..io.proj import deactivate_proj
@@ -372,6 +371,7 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose='auto', depth=0.8,
        MEG/EEG Source Reconstruction", IEEE Transactions of Medical Imaging,
        Volume 35 (10), pp. 2218-2228, 2016.
     """
+    from scipy import linalg
     if not (0. <= alpha < 100.):
         raise ValueError('alpha must be in [0, 100). '
                          'Got alpha = %s' % alpha)
@@ -406,7 +406,7 @@ def mixed_norm(evoked, forward, noise_cov, alpha, loose='auto', depth=0.8,
     M = np.dot(whitener, M)
 
     if time_pca:
-        U, s, Vh = _safe_svd(M, full_matrices=False)
+        U, s, Vh = linalg.svd(M, full_matrices=False)
         if not isinstance(time_pca, bool) and isinstance(time_pca, int):
             U = U[:, :time_pca]
             s = s[:time_pca]

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -3,14 +3,19 @@
 #         Mathurin Massias <mathurin.massias@gmail.com>
 # License: Simplified BSD
 
+import functools
 from math import sqrt
 
 import numpy as np
-from scipy import linalg
 
 from .mxne_debiasing import compute_bias
-from ..utils import logger, verbose, sum_squared, warn, dgemm
+from ..utils import logger, verbose, sum_squared, warn, _get_blas_funcs
 from ..time_frequency._stft import stft_norm1, stft_norm2, stft, istft
+
+
+@functools.cache
+def _get_dgemm():
+    return _get_blas_funcs(np.float64, 'gemm')
 
 
 def groups_norm2(A, n_orient):
@@ -403,6 +408,7 @@ def _bcd(G, X, R, active_set, one_ovr_lc, n_orient, n_positions,
         alpha * (Lipschitz constants).
     """
     X_j_new = np.zeros_like(X[0:n_orient, :], order='C')
+    dgemm = _get_dgemm()
 
     for j, G_j_c in enumerate(list_G_j_c):
         idx = slice(j * n_orient, (j + 1) * n_orient)
@@ -534,11 +540,11 @@ def mixed_norm_solver(M, G, alpha, maxit=3000, tol=1e-8, verbose=None,
             lc = np.empty(n_positions)
             for j in range(n_positions):
                 G_tmp = G[:, (j * n_orient):((j + 1) * n_orient)]
-                lc[j] = linalg.norm(np.dot(G_tmp.T, G_tmp), ord=2)
+                lc[j] = np.linalg.norm(np.dot(G_tmp.T, G_tmp), ord=2)
     else:
         logger.info("Using proximal iterations")
         l21_solver = _mixed_norm_solver_prox
-        lc = 1.01 * linalg.norm(G, ord=2) ** 2
+        lc = 1.01 * np.linalg.norm(G, ord=2) ** 2
 
     if active_set_size is not None:
         E = list()
@@ -558,7 +564,7 @@ def mixed_norm_solver(M, G, alpha, maxit=3000, tol=1e-8, verbose=None,
             elif solver == 'cd':
                 lc_tmp = None
             else:
-                lc_tmp = 1.01 * linalg.norm(G[:, active_set], ord=2) ** 2
+                lc_tmp = 1.01 * np.linalg.norm(G[:, active_set], ord=2) ** 2
             X, as_, _ = l21_solver(M, G[:, active_set], alpha, lc_tmp,
                                    maxit=maxit, tol=tol, init=X_init,
                                    n_orient=n_orient, dgap_freq=dgap_freq)
@@ -707,8 +713,8 @@ def iterative_mixed_norm_solver(M, G, alpha, n_mxne_iter, maxit=3000,
             # Reapply weights to have correct unit
             X *= weights[_active_set][:, np.newaxis]
             weights = gprime(X)
-            p_obj = 0.5 * linalg.norm(M - np.dot(G[:, active_set], X),
-                                      'fro') ** 2. + alpha * np.sum(g(X))
+            p_obj = 0.5 * np.linalg.norm(M - np.dot(G[:, active_set], X),
+                                         'fro') ** 2. + alpha * np.sum(g(X))
             E.append(p_obj)
 
             # Check convergence
@@ -718,7 +724,7 @@ def iterative_mixed_norm_solver(M, G, alpha, n_mxne_iter, maxit=3000,
                 break
         else:
             active_set = np.zeros_like(active_set)
-            p_obj = 0.5 * linalg.norm(M) ** 2.
+            p_obj = 0.5 * np.linalg.norm(M) ** 2.
             E.append(p_obj)
             break
 
@@ -1186,7 +1192,7 @@ def _tf_mixed_norm_solver_bcd_(M, G, Z, active_set, candidates, alpha_space,
                 R += np.dot(G_j, X_j)
                 X_j_new += X_j
 
-            rows_norm = linalg.norm(X_j_new, 'fro')
+            rows_norm = np.linalg.norm(X_j_new, 'fro')
             if rows_norm <= alpha_space_lc[jj]:
                 if was_active:
                     Z[jj] = 0.0
@@ -1439,7 +1445,7 @@ def tf_mixed_norm_solver(M, G, alpha_space, alpha_time, wsize=64, tstep=4,
         lc = np.empty(n_positions)
         for j in range(n_positions):
             G_tmp = G[:, (j * n_orient):((j + 1) * n_orient)]
-            lc[j] = linalg.norm(np.dot(G_tmp.T, G_tmp), ord=2)
+            lc[j] = np.linalg.norm(np.dot(G_tmp.T, G_tmp), ord=2)
 
     logger.info("Using block coordinate descent with active set approach")
     X, Z, active_set, E, gap = _tf_mixed_norm_solver_bcd_active_set(
@@ -1538,7 +1544,7 @@ def iterative_tf_mixed_norm_solver(M, G, alpha_space, alpha_time,
         lc = np.empty(n_positions)
         for j in range(n_positions):
             G_tmp = G[:, (j * n_orient):((j + 1) * n_orient)]
-            lc[j] = linalg.norm(np.dot(G_tmp.T, G_tmp), ord=2)
+            lc[j] = np.linalg.norm(np.dot(G_tmp.T, G_tmp), ord=2)
 
     # space and time penalties, and inverse of their derivatives:
     def g_space(Z):
@@ -1587,7 +1593,7 @@ def iterative_tf_mixed_norm_solver(M, G, alpha_space, alpha_time,
             l21_penalty = np.sum(g_space(Z.copy()))
             l1_penalty = phi.norm(g_time(Z.copy()), ord=1).sum()
 
-            p_obj = (0.5 * linalg.norm(M - np.dot(G[:, active_set], X),
+            p_obj = (0.5 * np.linalg.norm(M - np.dot(G[:, active_set], X),
                      'fro') ** 2. + alpha_space * l21_penalty +
                      alpha_time * l1_penalty)
             E.append(p_obj)
@@ -1602,7 +1608,7 @@ def iterative_tf_mixed_norm_solver(M, G, alpha_space, alpha_time,
                     print('Convergence reached after %d reweightings!' % k)
                     break
         else:
-            p_obj = 0.5 * linalg.norm(M) ** 2.
+            p_obj = 0.5 * np.linalg.norm(M) ** 2.
             E.append(p_obj)
             logger.info('Iteration %d: as_size=%d, E=%f' % (
                         k + 1, active_set.sum() / n_orient, p_obj))

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -13,7 +13,7 @@ from ..utils import logger, verbose, sum_squared, warn, _get_blas_funcs
 from ..time_frequency._stft import stft_norm1, stft_norm2, stft, istft
 
 
-@functools.cache
+@functools.lru_cache(None)
 def _get_dgemm():
     return _get_blas_funcs(np.float64, 'gemm')
 

--- a/mne/io/compensator.py
+++ b/mne/io/compensator.py
@@ -1,5 +1,4 @@
 import numpy as np
-from scipy import linalg
 
 from .constants import FIFF
 
@@ -94,7 +93,7 @@ def make_compensator(info, from_, to, exclude_comp_chs=False):
     #   s_to   = (I - C2)*(I + C1)*s_from = (I + C1 - C2 - C2*C1)*s_from
     if from_ != 0:
         C1 = _make_compensator(info, from_)
-        comp_from_0 = linalg.inv(np.eye(info['nchan']) - C1)
+        comp_from_0 = np.linalg.inv(np.eye(info['nchan']) - C1)
     if to != 0:
         C2 = _make_compensator(info, to)
         comp_0_to = np.eye(info['nchan']) - C2

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -14,7 +14,6 @@ from math import sin, cos
 from os import SEEK_CUR, path as op
 
 import numpy as np
-from scipy import linalg
 
 from ..pick import pick_types
 from ...utils import (verbose, logger, warn, fill_doc, _check_option,
@@ -790,7 +789,7 @@ def get_kit_info(rawfile, allow_unknown_format, standardize_names=None,
             y = sin(theta) * sin(phi)
             z = cos(theta)
             vec_z = np.array([x, y, z])
-            vec_z /= linalg.norm(vec_z)
+            vec_z /= np.linalg.norm(vec_z)
             vec_x = np.zeros(vec_z.size, dtype=np.float64)
             if vec_z[1] < vec_z[2]:
                 if vec_z[0] < vec_z[1]:
@@ -802,7 +801,7 @@ def get_kit_info(rawfile, allow_unknown_format, standardize_names=None,
             else:
                 vec_x[2] = 1.0
             vec_x -= np.sum(vec_x * vec_z) * vec_z
-            vec_x /= linalg.norm(vec_x)
+            vec_x /= np.linalg.norm(vec_x)
             vec_y = np.cross(vec_z, vec_x)
             # transform to Neuromag like coordinate space
             vecs = np.vstack((ch['loc'][:3], vec_x, vec_y, vec_z))

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -15,7 +15,6 @@ import operator
 from textwrap import shorten
 
 import numpy as np
-from scipy import linalg
 
 from .pick import (channel_type, pick_channels, pick_info,
                    get_channel_type_constants)
@@ -1405,7 +1404,7 @@ def read_meas_info(fid, tree, clean_bads=False, verbose=None):
     info['dev_ctf_t'] = dev_ctf_t
     if dev_head_t is not None and ctf_head_t is not None and dev_ctf_t is None:
         from ..transforms import Transform
-        head_ctf_trans = linalg.inv(ctf_head_t['trans'])
+        head_ctf_trans = np.linalg.inv(ctf_head_t['trans'])
         dev_ctf_trans = np.dot(head_ctf_trans, info['dev_head_t']['trans'])
         info['dev_ctf_t'] = Transform('meg', 'ctf_head', dev_ctf_trans)
 

--- a/mne/io/open.py
+++ b/mne/io/open.py
@@ -9,7 +9,6 @@ from io import BytesIO, SEEK_SET
 from gzip import GzipFile
 
 import numpy as np
-from scipy import sparse
 
 from .tag import read_tag_info, read_tag, Tag, _call_dict_names
 from .tree import make_dir_tree, dir_tree_find
@@ -244,6 +243,7 @@ def _find_type(value, fmts=['FIFF_'], exclude=['FIFF_UNIT']):
 
 def _show_tree(fid, tree, indent, level, read_limit, max_str, tag_id):
     """Show FIFF tree."""
+    from scipy import sparse
     this_idt = indent * level
     next_idt = indent * (level + 1)
     # print block-level information

--- a/mne/io/proc_history.py
+++ b/mne/io/proc_history.py
@@ -4,7 +4,6 @@
 # License: Simplified BSD
 
 import numpy as np
-from scipy.sparse import csc_matrix
 
 from .open import read_tag, fiff_open
 from .tree import dir_tree_find
@@ -13,6 +12,7 @@ from .write import (start_block, end_block, write_int, write_float,
                     write_float_sparse, write_id)
 from .tag import find_tag
 from .constants import FIFF
+from ..fixes import _csc_matrix_cast
 from ..utils import warn, _check_fname
 
 _proc_keys = ['parent_file_id', 'block_id', 'parent_block_id',
@@ -153,7 +153,7 @@ _sss_ctc_ids = (FIFF.FIFF_BLOCK_ID,
                 FIFF.FIFF_CREATOR,
                 FIFF.FIFF_DECOUPLER_MATRIX)
 _sss_ctc_writers = (write_id, write_int, write_string, write_float_sparse)
-_sss_ctc_casters = (dict, np.array, str, csc_matrix)
+_sss_ctc_casters = (dict, np.array, str, _csc_matrix_cast)
 
 _sss_cal_keys = ('cal_chans', 'cal_corrs')
 _sss_cal_ids = (FIFF.FIFF_SSS_CAL_CHANS, FIFF.FIFF_SSS_CAL_CORRS)

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -18,7 +18,6 @@ from .pick import pick_types, pick_info
 from .write import (write_int, write_float, write_string, write_name_list,
                     write_float_matrix, end_block, start_block)
 from ..defaults import _BORDER_DEFAULT, _EXTRAPOLATE_DEFAULT
-from ..fixes import _safe_svd
 from ..utils import logger, verbose, warn, fill_doc, _validate_type
 
 
@@ -554,6 +553,7 @@ def _make_projector(projs, ch_names, bads=(), include_active=True,
     warning will be raised next time projectors are constructed with
     the given inputs. If inplace=True, no meaningful data are returned.
     """
+    from scipy import linalg
     nchan = len(ch_names)
     if nchan == 0:
         raise ValueError('No channel names specified')
@@ -635,7 +635,7 @@ def _make_projector(projs, ch_names, bads=(), include_active=True,
         return default_return
 
     # Reorthogonalize the vectors
-    U, S, V = _safe_svd(vecs[:, :nvec], full_matrices=False)
+    U, S, _ = linalg.svd(vecs[:, :nvec], full_matrices=False)
 
     # Throw away the linearly dependent guys
     nproj = np.sum((S / S[0]) > 1e-2)

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -10,7 +10,6 @@ from itertools import count
 from math import sqrt
 
 import numpy as np
-from scipy import linalg
 
 from .tree import dir_tree_find
 from .tag import find_tag
@@ -19,6 +18,7 @@ from .pick import pick_types, pick_info
 from .write import (write_int, write_float, write_string, write_name_list,
                     write_float_matrix, end_block, start_block)
 from ..defaults import _BORDER_DEFAULT, _EXTRAPOLATE_DEFAULT
+from ..fixes import _safe_svd
 from ..utils import logger, verbose, warn, fill_doc, _validate_type
 
 
@@ -635,7 +635,7 @@ def _make_projector(projs, ch_names, bads=(), include_active=True,
         return default_return
 
     # Reorthogonalize the vectors
-    U, S, V = linalg.svd(vecs[:, :nvec], full_matrices=False)
+    U, S, V = _safe_svd(vecs[:, :nvec], full_matrices=False)
 
     # Throw away the linearly dependent guys
     nproj = np.sum((S / S[0]) > 1e-2)

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -6,7 +6,6 @@
 
 from copy import deepcopy
 import numpy as np
-from scipy import linalg
 
 from .constants import FIFF
 from .meas_info import _check_ch_keys
@@ -127,7 +126,7 @@ def _apply_reference(inst, ref_from, ref_to=None, forward=None,
             # 4. Compute the forward (G) and average-reference it (Ga):
             Ga = G - np.mean(G, axis=0, keepdims=True)
             # 5. Compute the Ga_inv by SVD
-            Ga_inv = linalg.pinv(Ga, rcond=1e-6)
+            Ga_inv = np.linalg.pinv(Ga, rcond=1e-6)
             # 6. Compute Ra = (G @ Ga_inv) in eq (8) from G and Ga_inv
             Ra = G @ Ga_inv
             # 7-8. Compute Vp = Ra @ Va; then Vpa=average(Vp)

--- a/mne/io/reference.py
+++ b/mne/io/reference.py
@@ -51,6 +51,7 @@ def _apply_reference(inst, ref_from, ref_to=None, forward=None,
                      ch_type='auto'):
     """Apply a custom EEG referencing scheme."""
     # Check to see that data is preloaded
+    from scipy import linalg
     _check_preload(inst, "Applying a reference")
 
     ch_type = _get_ch_type(inst, ch_type)
@@ -126,7 +127,7 @@ def _apply_reference(inst, ref_from, ref_to=None, forward=None,
             # 4. Compute the forward (G) and average-reference it (Ga):
             Ga = G - np.mean(G, axis=0, keepdims=True)
             # 5. Compute the Ga_inv by SVD
-            Ga_inv = np.linalg.pinv(Ga, rcond=1e-6)
+            Ga_inv = linalg.pinv(Ga, rcond=1e-6)
             # 6. Compute Ra = (G @ Ga_inv) in eq (8) from G and Ga_inv
             Ra = G @ Ga_inv
             # 7-8. Compute Vp = Ra @ Va; then Vpa=average(Vp)

--- a/mne/io/tag.py
+++ b/mne/io/tag.py
@@ -7,7 +7,6 @@ from functools import partial
 import struct
 
 import numpy as np
-from scipy import sparse
 
 from .constants import (FIFF, _dig_kind_named, _dig_cardinal_named,
                         _ch_kind_named, _ch_coil_type_named, _ch_unit_named,
@@ -168,6 +167,7 @@ _matrix_bit_dtype = {
 
 def _read_matrix(fid, tag, shape, rlims, matrix_coding):
     """Read a matrix (dense or sparse) tag."""
+    from scipy import sparse
     matrix_coding = matrix_coding >> 16
 
     # This should be easy to implement (see _frombuffer_rows)

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -10,7 +10,6 @@ import time
 import uuid
 
 import numpy as np
-from scipy import linalg, sparse
 
 from .constants import FIFF
 from ..utils import logger, _file_like
@@ -368,7 +367,7 @@ def write_coord_trans(fid, trans):
     fid.write(np.array(move, dtype='>f4').tobytes())
 
     #   ...and its inverse
-    trans_inv = linalg.inv(trans['trans'])
+    trans_inv = np.linalg.inv(trans['trans'])
     rot = trans_inv[:3, :3]
     move = trans_inv[:3, 3]
     fid.write(np.array(rot, dtype='>f4').tobytes())
@@ -436,6 +435,7 @@ def write_float_sparse_ccs(fid, kind, mat):
 
 def write_float_sparse(fid, kind, mat, fmt='auto'):
     """Write a single-precision floating-point sparse matrix tag."""
+    from scipy import sparse
     from .tag import _matrix_coding_CCS, _matrix_coding_RCS
     if fmt == 'auto':
         fmt = 'csr' if isinstance(mat, sparse.csr_matrix) else 'csc'

--- a/mne/label.py
+++ b/mne/label.py
@@ -12,8 +12,8 @@ import copy as cp
 import re
 
 import numpy as np
-from scipy import linalg, sparse
 
+from .fixes import _safe_svd
 from .parallel import parallel_func, check_n_jobs
 from .source_estimate import (SourceEstimate, VolSourceEstimate,
                               _center_of_mass, extract_label_time_course,
@@ -1150,6 +1150,7 @@ def split_label(label, parts=2, subject=None, subjects_dir=None,
     projecting all label vertex coordinates onto this axis and dividing them at
     regular spatial intervals.
     """
+    from scipy import linalg
     label, subject, subjects_dir = _prep_label_split(label, subject,
                                                      subjects_dir)
 
@@ -1282,7 +1283,7 @@ def label_sign_flip(label, src):
     if len(ori) == 0:
         return np.array([], int)
 
-    _, _, Vh = linalg.svd(ori, full_matrices=False)
+    _, _, Vh = _safe_svd(ori, full_matrices=False)
 
     # The sign of Vh is ambiguous, so we should align to the max-positive
     # (outward) direction
@@ -2265,6 +2266,7 @@ def _check_values_labels(values, n_labels):
 
 
 def _labels_to_stc_surf(labels, values, tmin, tstep, subject):
+    from scipy import sparse
     subject = _check_labels_subject(labels, subject, 'subject')
     _check_values_labels(values, len(labels))
     vertices = dict(lh=[], rh=[])

--- a/mne/label.py
+++ b/mne/label.py
@@ -13,7 +13,6 @@ import re
 
 import numpy as np
 
-from .fixes import _safe_svd
 from .parallel import parallel_func, check_n_jobs
 from .source_estimate import (SourceEstimate, VolSourceEstimate,
                               _center_of_mass, extract_label_time_course,
@@ -1261,6 +1260,7 @@ def label_sign_flip(label, src):
     flip : array
         Sign flip vector (contains 1 or -1).
     """
+    from scipy import linalg
     if len(src) != 2:
         raise ValueError('Only source spaces with 2 hemisphers are accepted')
 
@@ -1283,7 +1283,7 @@ def label_sign_flip(label, src):
     if len(ori) == 0:
         return np.array([], int)
 
-    _, _, Vh = _safe_svd(ori, full_matrices=False)
+    _, _, Vh = linalg.svd(ori, full_matrices=False)
 
     # The sign of Vh is ambiguous, so we should align to the max-positive
     # (outward) direction

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -8,7 +8,6 @@
 from copy import deepcopy
 from math import sqrt
 import numpy as np
-from scipy import linalg
 
 from ._eloreta import _compute_eloreta
 from ..fixes import _safe_svd
@@ -528,6 +527,7 @@ def prepare_inverse_operator(orig, nave, lambda2, method='dSPM',
     inv : instance of InverseOperator
         Prepared inverse operator.
     """
+    from scipy import linalg
     if nave <= 0:
         raise ValueError('The number of averages should be positive')
 
@@ -1454,7 +1454,7 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
     # Adjusting Source Covariance matrix to make trace of G*R*G' equal
     # to number of sensors.
     logger.info('Adjusting source covariance matrix.')
-    trace_GRGT = linalg.norm(gain, ord='fro') ** 2
+    trace_GRGT = np.linalg.norm(gain, ord='fro') ** 2
     n_nzero = (noise_cov['eig'] > 0).sum()
     scale = np.sqrt(n_nzero / trace_GRGT)
     source_std *= scale

--- a/mne/minimum_norm/resolution_matrix.py
+++ b/mne/minimum_norm/resolution_matrix.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 import numpy as np
 
 from .. import pick_channels_forward, EvokedArray, SourceEstimate
-from ..fixes import _safe_svd
 from ..io.constants import FIFF
 from ..utils import logger, verbose
 from ..forward.forward import convert_forward_solution
@@ -197,6 +196,7 @@ def _normalise_psf_ctf(funcs, norm):
 
 def _summarise_psf_ctf(funcs, mode, n_comp, return_pca_vars):
     """Summarise PSFs/CTFs across vertices."""
+    from scipy import linalg
     s_var = None  # only computed for return_pca_vars=True
 
     if mode == 'maxval':  # pick PSF/CTF with maximum absolute value
@@ -225,7 +225,7 @@ def _summarise_psf_ctf(funcs, mode, n_comp, return_pca_vars):
 
     elif mode == 'pca':  # SVD across PSFs/CTFs
         # compute SVD of PSFs/CTFs across vertices
-        u, s, _ = _safe_svd(funcs, full_matrices=False)
+        u, s, _ = linalg.svd(funcs, full_matrices=False)
         funcs = u[:, :n_comp]
         # if explained variances for SVD components requested
         if return_pca_vars:

--- a/mne/minimum_norm/resolution_matrix.py
+++ b/mne/minimum_norm/resolution_matrix.py
@@ -7,9 +7,8 @@ from copy import deepcopy
 
 import numpy as np
 
-from scipy import linalg
-
 from .. import pick_channels_forward, EvokedArray, SourceEstimate
+from ..fixes import _safe_svd
 from ..io.constants import FIFF
 from ..utils import logger, verbose
 from ..forward.forward import convert_forward_solution
@@ -226,7 +225,7 @@ def _summarise_psf_ctf(funcs, mode, n_comp, return_pca_vars):
 
     elif mode == 'pca':  # SVD across PSFs/CTFs
         # compute SVD of PSFs/CTFs across vertices
-        u, s, _ = linalg.svd(funcs, full_matrices=False, compute_uv=True)
+        u, s, _ = _safe_svd(funcs, full_matrices=False)
         funcs = u[:, :n_comp]
         # if explained variances for SVD components requested
         if return_pca_vars:

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -7,7 +7,6 @@ import numpy as np
 
 from ..epochs import Epochs, make_fixed_length_events
 from ..evoked import EvokedArray
-from ..fixes import _safe_svd
 from ..io.constants import FIFF
 from ..io.pick import pick_info
 from ..source_estimate import _make_stc
@@ -28,6 +27,7 @@ def _prepare_source_params(inst, inverse_operator, label=None,
                            prepared=False, method_params=None,
                            use_cps=True, verbose=None):
     """Prepare inverse operator and params for spectral / TFR analysis."""
+    from scipy import linalg
     inv = _check_or_prepare(inverse_operator, nave, lambda2, method,
                             method_params, prepared)
 
@@ -48,7 +48,7 @@ def _prepare_source_params(inst, inverse_operator, label=None,
         inv, label, method, pick_ori, use_cps=use_cps)
 
     if pca:
-        U, s, Vh = _safe_svd(K, full_matrices=False)
+        U, s, Vh = linalg.svd(K, full_matrices=False)
         rank = np.sum(s > 1e-8 * s[0])
         K = s[:rank] * U[:, :rank]
         Vh = Vh[:rank]

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -4,10 +4,10 @@
 # License: BSD (3-clause)
 
 import numpy as np
-from scipy import linalg
 
 from ..epochs import Epochs, make_fixed_length_events
 from ..evoked import EvokedArray
+from ..fixes import _safe_svd
 from ..io.constants import FIFF
 from ..io.pick import pick_info
 from ..source_estimate import _make_stc
@@ -48,7 +48,7 @@ def _prepare_source_params(inst, inverse_operator, label=None,
         inv, label, method, pick_ori, use_cps=use_cps)
 
     if pca:
-        U, s, Vh = linalg.svd(K, full_matrices=False)
+        U, s, Vh = _safe_svd(K, full_matrices=False)
         rank = np.sum(s > 1e-8 * s[0])
         K = s[:rank] * U[:, :rank]
         Vh = Vh[:rank]

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -8,7 +8,6 @@ import os.path as op
 import warnings
 import copy
 import numpy as np
-from scipy import sparse, linalg
 
 from .fixes import _get_img_fdata
 from .parallel import parallel_func
@@ -270,6 +269,7 @@ def compute_source_morph(src, subject_from=None, subject_to='fsaverage',
 def _compute_sparse_morph(vertices_from, subject_from, subject_to,
                           subjects_dir=None):
     """Get nearest vertices from one subject to another."""
+    from scipy import sparse
     maps = read_morph_map(subject_to, subject_from, subjects_dir)
     cnt = 0
     vertices = list()
@@ -506,6 +506,7 @@ class SourceMorph(object):
         return self
 
     def _morph_vols(self, vols, mesg, subselect=True):
+        from scipy import sparse
         from dipy.align.reslice import reslice
         interp = self.src_data['interpolator'].tocsc()[
             :, np.concatenate(self._vol_vertices_from)]
@@ -533,7 +534,7 @@ class SourceMorph(object):
         src_shape = self.src_data['src_shape_full'][::-1]
         resamp_0 = _grid_interp(
             src_shape, self.pre_affine.codomain_shape,
-            linalg.inv(from_affine) @ self.pre_affine.codomain_grid2world)
+            np.linalg.inv(from_affine) @ self.pre_affine.codomain_grid2world)
         # reslice to match what was used during the morph
         # (brain.mgz and whatever was used to create the source space
         #  will not necessarily have the same domain/zooms)
@@ -541,7 +542,7 @@ class SourceMorph(object):
         # pre_affine.transform(img_real)
         resamp_1 = _grid_interp(
             self.pre_affine.codomain_shape, self.pre_affine.domain_shape,
-            linalg.inv(self.pre_affine.codomain_grid2world) @
+            np.linalg.inv(self.pre_affine.codomain_grid2world) @
             self.pre_affine.affine @
             self.pre_affine.domain_grid2world)
         resamp_0_1 = resamp_1 @ resamp_0
@@ -578,7 +579,7 @@ class SourceMorph(object):
                     if resamp_2 is None:
                         resamp_2 = _grid_interp(
                             img_real.shape, self.src_data['to_vox_map'][0],
-                            linalg.inv(affine) @
+                            np.linalg.inv(affine) @
                             self.src_data['to_vox_map'][1])
                     # Equivalent to:
                     # _resample_from_to(
@@ -1098,6 +1099,7 @@ def _compute_morph_matrix(subject_from, subject_to, vertices_from, vertices_to,
                           smooth=None, subjects_dir=None, warn=True,
                           xhemi=False):
     """Compute morph matrix."""
+    from scipy import sparse
     logger.info('Computing morph matrix...')
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
 
@@ -1134,6 +1136,7 @@ def _compute_morph_matrix(subject_from, subject_to, vertices_from, vertices_to,
 
 
 def _hemi_morph(tris, vertices_to, vertices_from, smooth, maps, warn):
+    from scipy import sparse
     if len(vertices_from) == 0:
         return sparse.csr_matrix((len(vertices_to), 0))
     e = mesh_edges(tris)
@@ -1230,6 +1233,7 @@ def grade_to_vertices(subject, grade, subjects_dir=None, n_jobs=1,
 
 
 def _surf_nearest(vertices, adj_mat):
+    from scipy import sparse
     from scipy.sparse.csgraph import dijkstra
     if not check_version('scipy', '1.3'):
         raise ValueError('scipy >= 1.3 is required to use nearest smoothing, '
@@ -1258,6 +1262,7 @@ def _csr_row_norm(data, row_norm):
 def _surf_upsampling_mat(idx_from, e, smooth, warn=True):
     """Upsample data on a subject's surface given mesh edges."""
     # we're in CSR format and it's to==from
+    from scipy import sparse
     assert isinstance(e, sparse.csr_matrix)
     n_tot = e.shape[0]
     assert e.shape == (n_tot, n_tot)

--- a/mne/preprocessing/_csd.py
+++ b/mne/preprocessing/_csd.py
@@ -14,8 +14,6 @@
 
 import numpy as np
 
-from scipy import linalg
-
 from .. import pick_types
 from ..utils import _validate_type, _ensure_int, _check_preload
 from ..io import BaseRaw
@@ -29,7 +27,7 @@ from ..channels.interpolation import _calc_g, _calc_h
 def _prepare_G(G, lambda2):
     G.flat[::len(G) + 1] += lambda2
     # compute the CSD
-    Gi = linalg.inv(G)
+    Gi = np.linalg.inv(G)
 
     TC = Gi.sum(0)
     sgi = np.sum(TC)  # compute sum total

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -17,7 +17,6 @@ import os
 import json
 
 import numpy as np
-from scipy import linalg
 
 from .ecg import (qrs_detector, _get_ecg_channel_index, _make_ecg,
                   create_ecg_epochs)
@@ -764,6 +763,7 @@ class ICA(ContainsMixin):
         self.current_fit = fit_type
 
     def _update_mixing_matrix(self):
+        from scipy import linalg
         self.mixing_matrix_ = linalg.pinv(self.unmixing_matrix_)
 
     def _update_ica_names(self):
@@ -1695,7 +1695,7 @@ class ICA(ContainsMixin):
         if self.noise_cov is None:  # revert standardization
             data *= self.pre_whitener_
         else:
-            data = np.dot(linalg.pinv(self.pre_whitener_, cond=1e-14), data)
+            data = np.linalg.pinv(self.pre_whitener_, rcond=1e-14) @ data
 
         return data
 
@@ -2692,6 +2692,7 @@ def read_ica_eeglab(fname, *, verbose=None):
     ica : instance of ICA
         An ICA object based on the information contained in the input file.
     """
+    from scipy import linalg
     eeg = _check_load_mat(fname, None)
     info, eeg_montage, _ = _get_info(eeg)
     info.set_montage(eeg_montage)

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -12,7 +12,6 @@ from math import factorial
 from os import path as op
 
 import numpy as np
-from scipy import linalg
 
 from .. import __version__
 from ..annotations import _annotations_starts_stops
@@ -33,7 +32,7 @@ from ..io import (_loc_to_coil_trans, _coil_trans_to_loc, BaseRaw, RawArray,
 from ..io.pick import pick_types, pick_info
 from ..utils import (verbose, logger, _clean_names, warn, _time_mask, _pl,
                      _check_option, _ensure_int, _validate_type, use_log_level)
-from ..fixes import _get_args, _safe_svd, einsum, bincount
+from ..fixes import _safe_svd, einsum, bincount
 from ..channels.channels import _get_T1T2_mag_inds, fix_mag_coil_types
 
 
@@ -840,6 +839,7 @@ def _get_decomp(trans, all_coils, cal, regularize, exp, ignore_ref,
                 coil_scale, grad_picks, mag_picks, good_mask, mag_or_fine,
                 bad_condition, t, mag_scale):
     """Get a decomposition matrix and pseudoinverse matrices."""
+    from scipy import linalg
     #
     # Fine calibration processing (point-like magnetometers and calib. coeffs)
     #
@@ -1545,9 +1545,7 @@ def _reset_meg_bads(info):
                     if info['ch_names'].index(bad) not in meg_picks]
 
 
-check_disable = dict()  # not available on really old versions of SciPy
-if 'check_finite' in _get_args(linalg.svd):
-    check_disable['check_finite'] = False
+check_disable = dict(check_finite=False)
 
 
 def _orth_overwrite(A):
@@ -1576,6 +1574,7 @@ def _overlap_projector(data_int, data_res, corr):
     # computation
 
     # we use np.linalg.norm instead of sp.linalg.norm here: ~2x faster!
+    from scipy import linalg
     n = np.linalg.norm(data_int)
     n = 1. if n == 0 else n  # all-zero data should gracefully continue
     data_int = _orth_overwrite((data_int / n).T)

--- a/mne/preprocessing/nirs/_beer_lambert_law.py
+++ b/mne/preprocessing/nirs/_beer_lambert_law.py
@@ -7,7 +7,6 @@
 import os.path as op
 
 import numpy as np
-from scipy import linalg
 
 from ...io import BaseRaw
 from ...io.constants import FIFF
@@ -42,7 +41,7 @@ def beer_lambert_law(raw, ppf=0.1):
     for ii in picks[::2]:
 
         EL = abs_coef * distances[ii] * ppf
-        iEL = linalg.pinv(EL)
+        iEL = np.linalg.pinv(EL)
 
         raw._data[[ii, ii + 1]] = iEL @ raw._data[[ii, ii + 1]] * 1e-3
 

--- a/mne/preprocessing/nirs/_beer_lambert_law.py
+++ b/mne/preprocessing/nirs/_beer_lambert_law.py
@@ -30,6 +30,7 @@ def beer_lambert_law(raw, ppf=0.1):
     raw : instance of Raw
         The modified raw instance.
     """
+    from scipy import linalg
     raw = raw.copy().load_data()
     _validate_type(raw, BaseRaw, 'raw')
 
@@ -41,7 +42,7 @@ def beer_lambert_law(raw, ppf=0.1):
     for ii in picks[::2]:
 
         EL = abs_coef * distances[ii] * ppf
-        iEL = np.linalg.pinv(EL)
+        iEL = linalg.pinv(EL)
 
         raw._data[[ii, ii + 1]] = iEL @ raw._data[[ii, ii + 1]] * 1e-3
 

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -6,7 +6,6 @@
 
 import re
 import numpy as np
-from scipy import linalg
 
 from ...io.pick import _picks_to_idx
 from ...utils import fill_doc
@@ -28,7 +27,7 @@ def source_detector_distances(info, picks=None):
         Array containing distances in meters.
         Of shape equal to number of channels, or shape of picks if supplied.
     """
-    dist = [linalg.norm(ch['loc'][3:6] - ch['loc'][6:9])
+    dist = [np.linalg.norm(ch['loc'][3:6] - ch['loc'][6:9])
             for ch in info['chs']]
     picks = _picks_to_idx(info, picks, exclude=[])
     return np.array(dist, float)[picks]

--- a/mne/preprocessing/otp.py
+++ b/mne/preprocessing/otp.py
@@ -7,7 +7,6 @@
 from functools import partial
 
 import numpy as np
-from scipy import linalg
 
 from .._ola import _COLA, _Storer
 from ..io.pick import _picks_to_idx
@@ -19,7 +18,7 @@ def _svd_cov(cov, data):
     """Use a covariance matrix to compute the SVD faster."""
     # This makes use of mathematical equivalences between PCA and SVD
     # on zero-mean data
-    s, u = linalg.eigh(cov)
+    s, u = np.linalg.eigh(cov)
     norm = np.ones((s.size,))
     mask = s > np.finfo(float).eps * s[-1]  # largest is last
     s = np.sqrt(s, out=s)

--- a/mne/preprocessing/xdawn.py
+++ b/mne/preprocessing/xdawn.py
@@ -5,7 +5,6 @@
 # License: BSD (3-clause)
 
 import numpy as np
-from scipy import linalg
 
 from .. import EvokedArray, Evoked
 from ..cov import Covariance, _regularized_covariance
@@ -59,6 +58,7 @@ def _least_square_evoked(epochs_data, events, tmin, sfreq):
     toeplitz : array, shape (n_class * n_components, n_channels)
         An concatenated array of toeplitz matrix for each event type.
     """
+    from scipy import linalg
     n_epochs, n_channels, n_times = epochs_data.shape
     tmax = tmin + n_times / float(sfreq)
 
@@ -143,6 +143,7 @@ def _fit_xdawn(epochs_data, y, n_components, reg=None, signal_cov=None,
     evokeds : array, shape (n_class, n_components, n_times)
         The independent evoked responses per condition.
     """
+    from scipy import linalg
     if not isinstance(epochs_data, np.ndarray) or epochs_data.ndim != 3:
         raise ValueError('epochs_data must be 3D ndarray')
 

--- a/mne/rank.py
+++ b/mne/rank.py
@@ -5,7 +5,6 @@
 # License: BSD (3-clause)
 
 import numpy as np
-from scipy import linalg
 
 from .defaults import _handle_default
 from .io.meas_info import _simplify_info
@@ -52,7 +51,7 @@ def estimate_rank(data, tol='auto', return_singular=False, norm=True,
         data = data.copy()  # operate on a copy
         norms = _compute_row_norms(data)
         data /= norms[:, np.newaxis]
-    s = linalg.svdvals(data)
+    s = np.linalg.svd(data, compute_uv=False)
     rank = _estimate_rank_from_s(s, tol, tol_kind)
     if return_singular is True:
         return rank, s

--- a/mne/rank.py
+++ b/mne/rank.py
@@ -47,11 +47,12 @@ def estimate_rank(data, tol='auto', return_singular=False, norm=True,
         If return_singular is True, the singular values that were
         thresholded to determine the rank are also returned.
     """
+    from scipy import linalg
     if norm:
         data = data.copy()  # operate on a copy
         norms = _compute_row_norms(data)
         data /= norms[:, np.newaxis]
-    s = np.linalg.svd(data, compute_uv=False)
+    s = linalg.svdvals(data)
     rank = _estimate_rank_from_s(s, tol, tol_kind)
     if return_singular is True:
         return rank, s

--- a/mne/simulation/metrics.py
+++ b/mne/simulation/metrics.py
@@ -4,7 +4,6 @@
 # License: BSD (3-clause)
 
 import numpy as np
-from scipy.linalg import norm
 
 from ..utils import _check_option
 
@@ -61,5 +60,5 @@ def source_estimate_quantification(stc1, stc2, metric='rms'):
     # Calculate correlation coefficient between matrix elements
     elif metric == 'cosine':
         score = 1. - (np.dot(data1.flatten(), data2.flatten()) /
-                      (norm(data1) * norm(data2)))
+                      (np.linalg.norm(data1) * np.linalg.norm(data2)))
     return score

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -16,7 +16,6 @@ from .baseline import rescale
 from .cov import Covariance
 from .evoked import _get_peak
 from .filter import resample
-from .fixes import _safe_svd
 from .io.constants import FIFF
 from .surface import (read_surface, _get_ico_surface, mesh_edges,
                       _project_onto_surface)
@@ -2835,7 +2834,8 @@ def _get_ico_tris(grade, verbose=None, return_surf=False):
 
 
 def _pca_flip(flip, data):
-    U, s, V = _safe_svd(data, full_matrices=False)
+    from scipy import linalg
+    U, s, V = linalg.svd(data, full_matrices=False)
     # determine sign-flip
     sign = np.sign(np.dot(U[:, 0], flip))
     # use average power in label for scaling

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -13,7 +13,6 @@ import os
 import os.path as op
 
 import numpy as np
-from scipy import sparse, linalg
 
 from .io.constants import FIFF
 from .io.meas_info import create_info, Info
@@ -1102,6 +1101,7 @@ def write_source_spaces(fname, src, overwrite=False, verbose=None):
 
 def _write_one_source_space(fid, this, verbose=None):
     """Write one source space."""
+    from scipy import sparse
     if this['type'] == 'surf':
         src_type = FIFF.FIFFV_MNE_SPACE_SURFACE
     elif this['type'] == 'vol':
@@ -2296,6 +2296,7 @@ def _src_vol_dims(s):
 def _add_interpolator(sp):
     """Compute a sparse matrix to interpolate the data into an MRI volume."""
     # extract transformation information from mri
+    from scipy import sparse
     mri_width, mri_height, mri_depth, nvox = _src_vol_dims(sp[0])
 
     #
@@ -2348,6 +2349,7 @@ def _add_interpolator(sp):
 
 def _grid_interp(from_shape, to_shape, trans, order=1, inuse=None):
     """Compute a grid-to-grid linear or nearest interpolation given."""
+    from scipy import sparse
     from_shape = np.array(from_shape, int)
     to_shape = np.array(to_shape, int)
     trans = np.array(trans, np.float64)  # to -> from
@@ -2649,6 +2651,7 @@ def add_source_space_distances(src, dist_limit=np.inf, n_jobs=1, verbose=None):
     the source space to disk, as the computed distances will automatically be
     stored along with the source space data for future use.
     """
+    from scipy.sparse import csr_matrix
     from scipy.sparse.csgraph import dijkstra
     n_jobs = check_n_jobs(n_jobs)
     src = _ensure_src(src)
@@ -2706,7 +2709,7 @@ def add_source_space_distances(src, dist_limit=np.inf, n_jobs=1, verbose=None):
             i, j = np.meshgrid(s['vertno'], s['vertno'])
             i = i.ravel()[idx]
             j = j.ravel()[idx]
-            s['dist'] = sparse.csr_matrix(
+            s['dist'] = csr_matrix(
                 (d, (i, j)), shape=(s['np'], s['np']), dtype=np.float32)
             s['dist_limit'] = np.array([dist_limit], np.float32)
 
@@ -3194,7 +3197,7 @@ def _get_src_nn(s, use_cps=True, vertices=None):
             #  Project out the surface normal and compute SVD
             nn[vp] = np.sum(
                 s['nn'][s['pinfo'][s['patch_inds'][p]], :], axis=0)
-        nn /= linalg.norm(nn, axis=-1, keepdims=True)
+        nn /= np.linalg.norm(nn, axis=-1, keepdims=True)
     else:
         nn = s['nn'][vertices, :]
     return nn

--- a/mne/stats/_adjacency.py
+++ b/mne/stats/_adjacency.py
@@ -5,7 +5,6 @@
 # License: Simplified BSD
 
 import numpy as np
-from scipy import sparse
 
 from ..utils import _validate_type, _check_option
 from ..utils.check import int_like
@@ -30,6 +29,7 @@ def combine_adjacency(*structure):
     adjacency : scipy.sparse.coo_matrix, shape (n_features, n_features)
         The adjacency matrix.
     """
+    from scipy import sparse
     structure = list(structure)
     for di, dim in enumerate(structure):
         name = f'structure[{di}]'

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -11,7 +11,6 @@
 # License: Simplified BSD
 
 import numpy as np
-from scipy import sparse
 
 from .parametric import f_oneway, ttest_1samp_no_p
 from ..parallel import parallel_func, check_n_jobs
@@ -283,6 +282,7 @@ def _get_clusters_st(x_in, neighbors, max_step=1):
 
 def _get_components(x_in, adjacency, return_list=True):
     """Get connected components from a mask and a adjacency matrix."""
+    from scipy import sparse
     if adjacency is False:
         components = np.arange(len(x_in))
     else:
@@ -502,6 +502,7 @@ def _find_clusters_1dir_parts(x, x_in, adjacency, max_step, partitions,
 
 def _find_clusters_1dir(x, x_in, adjacency, max_step, t_power, ndimage):
     """Actually call the clustering algorithm."""
+    from scipy import sparse
     if adjacency is None:
         labels, n_labels = ndimage.label(x_in)
 
@@ -583,6 +584,7 @@ def _pval_from_histogram(T, H0, tail):
 
 
 def _setup_adjacency(adjacency, n_tests, n_times):
+    from scipy import sparse
     if not sparse.issparse(adjacency):
         raise ValueError("If adjacency matrix is given, it must be a "
                          "SciPy sparse matrix.")
@@ -1370,6 +1372,7 @@ def _st_mask_from_s_inds(n_times, n_vertices, vertices, set_as=True):
 @verbose
 def _get_partitions_from_adjacency(adjacency, n_times, verbose=None):
     """Specify disjoint subsets (e.g., hemispheres) based on adjacency."""
+    from scipy import sparse
     if isinstance(adjacency, list):
         test = np.ones(len(adjacency))
         test_adj = np.zeros((len(adjacency), len(adjacency)), dtype='bool')

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -10,7 +10,6 @@ from inspect import isgenerator
 from collections import namedtuple
 
 import numpy as np
-from scipy import linalg, sparse
 
 from ..source_estimate import SourceEstimate
 from ..epochs import BaseEpochs
@@ -100,7 +99,7 @@ def linear_regression(inst, design_matrix, names=None):
 
 def _fit_lm(data, design_matrix, names):
     """Aux function."""
-    from scipy import stats
+    from scipy import stats, linalg
     n_samples = len(data)
     n_features = np.product(data.shape[1:])
     if design_matrix.ndim != 2:
@@ -242,6 +241,7 @@ def linear_regression_raw(raw, events, event_id=None, tmin=-.1, tmax=1,
            waveforms: II. Non-linear effects, overlap correction, and practical
            considerations. Psychophysiology, 52(2), 169-189.
     """
+    from scipy import linalg
     if isinstance(solver, str):
         if solver not in {"cholesky"}:
             raise ValueError("No such solver: {}".format(solver))
@@ -312,6 +312,7 @@ def _prepare_rerp_data(raw, events, picks=None, decim=1):
 def _prepare_rerp_preds(n_samples, sfreq, events, event_id=None, tmin=-.1,
                         tmax=1, covariates=None):
     """Build predictor matrix and metadata (e.g. condition time windows)."""
+    from scipy import sparse
     conds = list(event_id)
     if covariates is not None:
         conds += list(covariates)

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -18,7 +18,6 @@ import warnings
 from struct import pack
 
 import numpy as np
-from scipy.sparse import coo_matrix, csr_matrix, eye as speye
 
 from .io.constants import FIFF
 from .io.open import fiff_open
@@ -279,6 +278,7 @@ def _triangle_neighbors(tris, npts):
     # for ti, tri in enumerate(tris):
     #     for t in tri:
     #         neighbor_tri[t].append(ti)
+    from scipy.sparse import coo_matrix
     rows = tris.ravel()
     cols = np.repeat(np.arange(len(tris)), 3)
     data = np.ones(len(cols))
@@ -1483,6 +1483,7 @@ def _make_morph_map(subject_from, subject_to, subjects_dir, xhemi):
 def _make_morph_map_hemi(subject_from, subject_to, subjects_dir, reg_from,
                          reg_to):
     """Construct morph map for one hemisphere."""
+    from scipy.sparse import csr_matrix, eye as speye
     # add speedy short-circuit for self-maps
     if subject_from == subject_to and reg_from == reg_to:
         fname = op.join(subjects_dir, subject_from, 'surf', reg_from)
@@ -1656,6 +1657,7 @@ def mesh_edges(tris):
     edges : sparse matrix
         The adjacency matrix.
     """
+    from scipy.sparse import coo_matrix
     if np.max(tris) > len(np.unique(tris)):
         raise ValueError(
             'Cannot compute adjacency on a selection of triangles.')
@@ -1690,6 +1692,7 @@ def mesh_dist(tris, vert):
     dist_matrix : scipy.sparse.csr_matrix
         Sparse matrix with distances between adjacent vertices.
     """
+    from scipy.sparse import csr_matrix
     edges = mesh_edges(tris).tocoo()
 
     # Euclidean distances between neighboring vertices

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -16,6 +16,7 @@ import pytest
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_allclose, assert_equal, assert_array_less)
 import numpy as np
+from numpy.fft import rfft, rfftfreq
 import matplotlib.pyplot as plt
 import scipy.signal
 
@@ -28,7 +29,6 @@ from mne.baseline import rescale
 from mne.datasets import testing
 from mne.chpi import read_head_pos, head_pos_to_trans_rot_t
 from mne.event import merge_events
-from mne.fixes import rfft, rfftfreq
 from mne.io import RawArray, read_raw_fif
 from mne.io.constants import FIFF
 from mne.io.proj import _has_eeg_average_ref_proj

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -8,7 +8,7 @@ import pytest
 from scipy.signal import resample as sp_resample, butter, freqz, sosfreqz
 
 from mne import create_info
-from mne.fixes import fft, fftfreq
+from numpy.fft import fft, fftfreq
 from mne.io import RawArray, read_raw_fif
 from mne.io.pick import _DATA_CH_TYPES_SPLIT
 from mne.filter import (filter_data, resample, _resample_stim_channels,

--- a/mne/tests/test_import_nesting.py
+++ b/mne/tests/test_import_nesting.py
@@ -12,10 +12,21 @@ import mne
 
 out = set()
 
+# check scipy (Numba imports it to check the version)
+ok_scipy_submodules = set(['scipy', 'numpy',  # these appear in old scipy
+                           'version'])
+scipy_submodules = set(x.split('.')[1] for x in sys.modules.keys()
+                       if x.startswith('scipy.') and '__' not in x and
+                       not x.split('.')[1].startswith('_')
+                       and sys.modules[x] is not None)
+bad = scipy_submodules - ok_scipy_submodules
+if len(bad) > 0:
+    out |= {'scipy submodules: %s' % list(bad)}
+
 # check sklearn and others
 for x in sys.modules.keys():
     for key in ('sklearn', 'pandas', 'mayavi', 'pyvista', 'matplotlib',
-                'dipy', 'nibabel', 'cupy', 'picard', 'pyvistaqt', 'scipy'):
+                'dipy', 'nibabel', 'cupy', 'picard', 'pyvistaqt'):
         if x.startswith(key):
             x = '.'.join(x.split('.')[:2])
             out |= {x}

--- a/mne/tests/test_import_nesting.py
+++ b/mne/tests/test_import_nesting.py
@@ -12,24 +12,13 @@ import mne
 
 out = set()
 
-# check scipy
-ok_scipy_submodules = set(['scipy', 'numpy',  # these appear in old scipy
-                           'fftpack', 'lib', 'linalg', 'fft',
-                           'misc', 'sparse', 'version'])
-scipy_submodules = set(x.split('.')[1] for x in sys.modules.keys()
-                       if x.startswith('scipy.') and '__' not in x and
-                       not x.split('.')[1].startswith('_')
-                       and sys.modules[x] is not None)
-bad = scipy_submodules - ok_scipy_submodules
-if len(bad) > 0:
-    out |= {'scipy submodules: %s' % list(bad)}
-
 # check sklearn and others
 for x in sys.modules.keys():
     for key in ('sklearn', 'pandas', 'mayavi', 'pyvista', 'matplotlib',
-                'dipy', 'nibabel', 'cupy', 'picard', 'pyvistaqt'):
+                'dipy', 'nibabel', 'cupy', 'picard', 'pyvistaqt', 'scipy'):
         if x.startswith(key):
-            out |= {key}
+            x = '.'.join(x.split('.')[:2])
+            out |= {x}
 if len(out) > 0:
     print('\\nFound un-nested import(s) for %s' % (sorted(out),), end='')
 exit(len(out))

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -9,6 +9,7 @@ from shutil import copyfile
 import re
 
 import numpy as np
+from numpy.fft import fft
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_allclose, assert_equal, assert_array_less)
 import pytest
@@ -32,7 +33,7 @@ from mne import (stats, SourceEstimate, VectorSourceEstimate,
                  write_source_spaces)
 from mne.datasets import testing
 from mne.externals.h5io import write_hdf5
-from mne.fixes import fft, _get_img_fdata, nullcontext
+from mne.fixes import _get_img_fdata, nullcontext
 from mne.io import read_info
 from mne.io.constants import FIFF
 from mne.source_estimate import grade_to_tris, _get_vol_mask

--- a/mne/time_frequency/_stft.py
+++ b/mne/time_frequency/_stft.py
@@ -1,7 +1,7 @@
 from math import ceil
 import numpy as np
 
-from ..fixes import rfft, irfft, rfftfreq
+from ..fixes import _import_fft
 from ..utils import logger, verbose
 
 
@@ -34,6 +34,7 @@ def stft(x, wsize, tstep=None, verbose=None):
     istft
     stftfreq
     """
+    rfft = _import_fft('rfft')
     if not np.isrealobj(x):
         raise ValueError("x is not a real valued array")
 
@@ -118,6 +119,7 @@ def istft(X, tstep=None, Tx=None):
     stft
     """
     # Errors and warnings
+    irfft = _import_fft('irfft')
     X = np.asarray(X)
     if X.ndim < 2:
         raise ValueError(f'X must have ndim >= 2, got {X.ndim}')
@@ -195,6 +197,7 @@ def stftfreq(wsize, sfreq=None):  # noqa: D401
     stft
     istft
     """
+    rfftfreq = _import_fft('rfftfreq')
     freqs = rfftfreq(wsize)
     if sfreq is not None:
         freqs *= float(sfreq)

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -4,11 +4,11 @@
 # License : BSD 3-clause
 
 from copy import deepcopy
-import math
+
 import numpy as np
-from scipy import fftpack
 # XXX explore cuda optimization at some point.
 
+from ..fixes import _import_fft
 from ..io.pick import _pick_data_channels, pick_info
 from ..utils import verbose, warn, fill_doc, _validate_type
 from ..parallel import parallel_func, check_n_jobs
@@ -25,7 +25,7 @@ def _check_input_st(x_in, n_fft):
 
     if n_fft is None or (not _is_power_of_two(n_fft) and n_times > n_fft):
         # Compute next power of 2
-        n_fft = 2 ** int(math.ceil(math.log(n_times, 2)))
+        n_fft = 2 ** int(np.ceil(np.log2(n_times)))
     elif n_fft < n_times:
         raise ValueError("n_fft cannot be smaller than signal size. "
                          "Got %s < %s." % (n_fft, n_times))
@@ -42,7 +42,8 @@ def _check_input_st(x_in, n_fft):
 
 def _precompute_st_windows(n_samp, start_f, stop_f, sfreq, width):
     """Precompute stockwell Gaussian windows (in the freq domain)."""
-    tw = fftpack.fftfreq(n_samp, 1. / sfreq) / n_samp
+    fft, fftfreq = _import_fft(('fft', 'fftfreq'))
+    tw = fftfreq(n_samp, 1. / sfreq) / n_samp
     tw = np.r_[tw[:1], tw[1:][::-1]]
 
     k = width  # 1 for classical stowckwell transform
@@ -55,35 +56,37 @@ def _precompute_st_windows(n_samp, start_f, stop_f, sfreq, width):
             window = ((f / (np.sqrt(2. * np.pi) * k)) *
                       np.exp(-0.5 * (1. / k ** 2.) * (f ** 2.) * tw ** 2.))
         window /= window.sum()  # normalisation
-        windows[i_f] = fftpack.fft(window)
+        windows[i_f] = fft(window)
     return windows
 
 
 def _st(x, start_f, windows):
     """Compute ST based on Ali Moukadem MATLAB code (used in tests)."""
+    fft, ifft = _import_fft(('fft', 'ifft'))
     n_samp = x.shape[-1]
     ST = np.empty(x.shape[:-1] + (len(windows), n_samp), dtype=np.complex128)
     # do the work
-    Fx = fftpack.fft(x)
+    Fx = fft(x)
     XF = np.concatenate([Fx, Fx], axis=-1)
     for i_f, window in enumerate(windows):
         f = start_f + i_f
-        ST[..., i_f, :] = fftpack.ifft(XF[..., f:f + n_samp] * window)
+        ST[..., i_f, :] = ifft(XF[..., f:f + n_samp] * window)
     return ST
 
 
 def _st_power_itc(x, start_f, compute_itc, zero_pad, decim, W):
     """Aux function."""
+    fft, ifft = _import_fft(('fft', 'ifft'))
     n_samp = x.shape[-1]
     n_out = (n_samp - zero_pad)
     n_out = n_out // decim + bool(n_out % decim)
     psd = np.empty((len(W), n_out))
     itc = np.empty_like(psd) if compute_itc else None
-    X = fftpack.fft(x)
+    X = fft(x)
     XX = np.concatenate([X, X], axis=-1)
     for i_f, window in enumerate(W):
         f = start_f + i_f
-        ST = fftpack.ifft(XX[:, f:f + n_samp] * window)
+        ST = ifft(XX[:, f:f + n_samp] * window)
         if zero_pad > 0:
             TFR = ST[:, :-zero_pad:decim]
         else:
@@ -155,6 +158,7 @@ def tfr_array_stockwell(data, sfreq, fmin=None, fmax=None, n_fft=None,
     ----------
     .. footbibliography::
     """
+    fftfreq = _import_fft('fftfreq')
     _validate_type(data, np.ndarray, 'data')
     if data.ndim != 3:
         raise ValueError(
@@ -164,7 +168,7 @@ def tfr_array_stockwell(data, sfreq, fmin=None, fmax=None, n_fft=None,
     n_out = data.shape[2] // decim + bool(data.shape[-1] % decim)
     data, n_fft_, zero_pad = _check_input_st(data, n_fft)
 
-    freqs = fftpack.fftfreq(n_fft_, 1. / sfreq)
+    freqs = fftfreq(n_fft_, 1. / sfreq)
     if fmin is None:
         fmin = freqs[freqs > 0][0]
     if fmax is None:

--- a/mne/time_frequency/ar.py
+++ b/mne/time_frequency/ar.py
@@ -4,7 +4,6 @@
 # License: BSD (3-clause)
 
 import numpy as np
-from scipy import linalg
 
 from ..defaults import _handle_default
 from ..io.pick import _picks_to_idx, _picks_by_type, pick_info
@@ -16,6 +15,7 @@ def _yule_walker(X, order=1):
 
     Operates in-place.
     """
+    from scipy import linalg
     assert X.ndim == 2
     denom = X.shape[-1] - np.arange(order + 1)
     r = np.zeros(order + 1, np.float64)

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -10,7 +10,7 @@ import numbers
 
 import numpy as np
 from .tfr import _cwt_array, morlet, _get_nfft
-from ..fixes import rfftfreq
+from ..fixes import _import_fft
 from ..io.pick import pick_channels, _picks_to_idx
 from ..utils import (logger, verbose, warn, copy_function_doc_to_method_doc,
                      ProgressBar)
@@ -699,6 +699,7 @@ def csd_array_fourier(X, sfreq, t0=0, fmin=0, fmax=np.inf, tmin=None,
     csd_morlet
     csd_multitaper
     """
+    rfftfreq = _import_fft('rfftfreq')
     X, times, tmin, tmax, fmin, fmax = _prepare_csd_array(
         X, sfreq, t0, tmin, tmax, fmin, fmax)
 
@@ -846,6 +847,7 @@ def csd_array_multitaper(X, sfreq, t0=0, fmin=0, fmax=np.inf, tmin=None,
     csd_morlet
     csd_multitaper
     """
+    rfftfreq = _import_fft('rfftfreq')
     X, times, tmin, tmax, fmin, fmax = _prepare_csd_array(
         X, sfreq, t0, tmin, tmax, fmin, fmax)
 

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -6,7 +6,7 @@
 import operator
 import numpy as np
 
-from ..fixes import rfft, irfft, rfftfreq
+from ..fixes import _import_fft
 from ..parallel import parallel_func
 from ..utils import sum_squared, warn, verbose, logger, _check_option
 
@@ -62,6 +62,7 @@ def dpss_windows(N, half_nbw, Kmax, low_bias=True, interp_from=None,
     from scipy import interpolate
     from scipy.signal.windows import dpss as sp_dpss
     from ..filter import next_fast_len
+    rfft, irfft = _import_fft(('rfft', 'irfft'))
     # This np.int32 business works around a weird Windows bug, see
     # gh-5039 and https://github.com/scipy/scipy/pull/8608
     Kmax = np.int32(operator.index(Kmax))
@@ -299,6 +300,7 @@ def _mt_spectra(x, dpss, sfreq, n_fft=None):
     freqs : array
         The frequency points in Hz of the spectra
     """
+    rfft, rfftfreq = _import_fft(('rfft', 'rfftfreq'))
     if n_fft is None:
         n_fft = x.shape[-1]
 
@@ -410,6 +412,7 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
     -----
     .. versionadded:: 0.14.0
     """
+    rfftfreq = _import_fft('rfftfreq')
     _check_option('normalization', normalization, ['length', 'full'])
 
     # Reshape data so its 2-D for parallelization

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -11,15 +11,13 @@ Morlet code inspired by Matlab code from Sheraz Khan & Brainstorm & SPM
 
 from copy import deepcopy
 from functools import partial
-from math import sqrt
 
 import numpy as np
-from scipy import linalg
 
 from .multitaper import dpss_windows
 
 from ..baseline import rescale
-from ..fixes import fft, ifft
+from ..fixes import _import_fft
 from ..filter import next_fast_len
 from ..parallel import parallel_func
 from ..utils import (logger, verbose, _time_mask, _freq_mask, check_fname,
@@ -96,7 +94,7 @@ def morlet(sfreq, freqs, n_cycles=7.0, sigma=None, zero_mean=False):
             real_offset = np.exp(- 2 * (np.pi * f * sigma_t) ** 2)
             oscillation -= real_offset
         W = oscillation * gaussian_enveloppe
-        W /= sqrt(0.5) * linalg.norm(W.ravel())
+        W /= np.sqrt(0.5) * np.linalg.norm(W.ravel())
         Ws.append(W)
     return Ws
 
@@ -162,7 +160,7 @@ def _make_dpss(sfreq, freqs, n_cycles=7., time_bandwidth=4.0, zero_mean=False):
             if zero_mean:  # to make it zero mean
                 real_offset = Wk.mean()
                 Wk -= real_offset
-            Wk /= sqrt(0.5) * linalg.norm(Wk.ravel())
+            Wk /= np.sqrt(0.5) * np.linalg.norm(Wk.ravel())
 
             Wm.append(Wk)
 
@@ -219,6 +217,7 @@ def _cwt_gen(X, Ws, *, fsize=0, mode="same", decim=1, use_fft=True):
     out : array, shape (n_signals, n_freqs, n_time_decim)
         The time-frequency transform of the signals.
     """
+    fft, ifft = _import_fft(('fft', 'ifft'))
     _check_option('mode', mode, ['same', 'valid', 'full'])
     decim = _check_decim(decim)
     X = np.asarray(X)

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -12,7 +12,6 @@ import glob
 
 import numpy as np
 from copy import deepcopy
-from scipy import linalg
 
 from .fixes import einsum, jit, mean
 from .io.constants import FIFF
@@ -330,9 +329,9 @@ def rotation3d_align_z_axis(target_z_axis):
 
     # assert that r is a rotation matrix r^t * r = I and det(r) = 1
     assert(np.any((r.dot(r.T) - np.identity(3)) < 1E-12))
-    assert((linalg.det(r) - 1.0) < 1E-12)
+    assert((np.linalg.det(r) - 1.0) < 1E-12)
     # assert that r maps [0 0 1] on the device z axis (target_z_axis)
-    assert(linalg.norm(target_z_axis - r.dot([0, 0, 1])) < 1e-12)
+    assert(np.linalg.norm(target_z_axis - r.dot([0, 0, 1])) < 1e-12)
 
     return r
 
@@ -587,7 +586,7 @@ def invert_transform(trans):
     inv_trans : dict
         Inverse transform.
     """
-    return Transform(trans['to'], trans['from'], linalg.inv(trans['trans']))
+    return Transform(trans['to'], trans['from'], np.linalg.inv(trans['trans']))
 
 
 def transform_surface_to(surf, dest, trans, copy=False):
@@ -660,12 +659,12 @@ def get_ras_to_neuromag_trans(nasion, lpa, rpa):
                              "arrays of length 3.")
 
     right = rpa - lpa
-    right_unit = right / linalg.norm(right)
+    right_unit = right / np.linalg.norm(right)
 
     origin = lpa + np.dot(nasion - lpa, right_unit) * right_unit
 
     anterior = nasion - origin
-    anterior_unit = anterior / linalg.norm(anterior)
+    anterior_unit = anterior / np.linalg.norm(anterior)
 
     superior_unit = np.cross(right_unit, anterior_unit)
 
@@ -912,6 +911,7 @@ class _TPSWarp(object):
     """
 
     def fit(self, source, destination, reg=1e-3):
+        from scipy import linalg
         from scipy.spatial.distance import cdist
         assert source.shape[1] == destination.shape[1] == 3
         assert source.shape[0] == destination.shape[0]
@@ -1040,6 +1040,7 @@ class _SphericalSurfaceWarp(object):
         inst : instance of SphericalSurfaceWarp
             The warping object (for chaining).
         """
+        from scipy import linalg
         from .bem import _fit_sphere
         from .source_space import _check_spacing
         match_rr = _check_spacing(match, verbose=False)[2]['rr']
@@ -1383,6 +1384,7 @@ def _fit_matched_points(p, x, weights=None, scale=False):
 
 def _average_quats(quats, weights=None):
     """Average unit quaternions properly."""
+    from scipy import linalg
     assert quats.ndim == 2 and quats.shape[1] in (3, 4)
     if weights is None:
         weights = np.ones(quats.shape[0])

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -64,7 +64,7 @@ from .numerics import (hashfunc, _compute_row_norms,
                        _check_dt, _ReuseCycle, _arange_div)
 from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
                     _prepare_write_metadata, _FakeNoPandas, ShiftTimeMixin)
-from .linalg import (_svd_lwork, _repeated_svd, _sym_mat_pow, sqrtm_sym,
-                     dgesdd, dgemm, zgemm, dgemv, ddot, LinAlgError, eigh)
+from .linalg import (_svd_lwork, _repeated_svd, _sym_mat_pow, sqrtm_sym, eigh,
+                     _get_blas_funcs)
 from .dataframe import (_set_pandas_dtype, _scale_dataframe_data,
                         _convert_times, _build_data_frame)

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -13,6 +13,7 @@ import logging
 import os.path as op
 import warnings
 
+from .docs import fill_doc
 from ..externals.decorator import FunctionMaker
 
 
@@ -79,6 +80,7 @@ def verbose(function):
     Examples
     --------
     You can use the ``verbose`` argument to set the verbose level on the fly::
+
         >>> import mne
         >>> cov = mne.compute_raw_covariance(raw, verbose='WARNING')  # doctest: +SKIP
         >>> cov = mne.compute_raw_covariance(raw, verbose='INFO')  # doctest: +SKIP
@@ -88,7 +90,6 @@ def verbose(function):
     """  # noqa: E501
     # See https://decorator.readthedocs.io/en/latest/tests.documentation.html
     # #dealing-with-third-party-decorators
-    from .docs import fill_doc
     try:
         fill_doc(function)
     except TypeError:  # nothing to add

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -19,7 +19,6 @@ import warnings
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
-from scipy import linalg
 
 from ._logging import warn, ClosingStringIO
 from .numerics import object_diff
@@ -449,6 +448,7 @@ def assert_meg_snr(actual, desired, min_tol, med_tol=500., chpi_med_tol=500.,
 
 def assert_snr(actual, desired, tol):
     """Assert actual and desired arrays are within some SNR tolerance."""
+    from scipy import linalg
     with np.errstate(divide='ignore'):  # allow infinite
         snr = (linalg.norm(desired, ord='fro') /
                linalg.norm(desired - actual, ord='fro'))

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -12,10 +12,8 @@ import sys
 import warnings
 import webbrowser
 
-from .config import get_config
 from ..defaults import HEAD_SIZE_DEFAULT
-from ..externals.doccer import filldoc, unindent_dict
-from .check import _check_option
+from ..externals.doccer import indentcount_lines
 
 
 ##############################################################################
@@ -2093,9 +2091,54 @@ accept : bool
     If True (default False), accept the license terms of this dataset.
 """
 
-# Finalize
-docdict = unindent_dict(docdict)
-fill_doc = filldoc(docdict, unindent_params=False)
+docdict_indented = {}
+
+
+def fill_doc(f):
+    """Fill a docstring with docdict entries.
+
+    Parameters
+    ----------
+    f : callable
+        The function to fill the docstring of. Will be modified in place.
+
+    Returns
+    -------
+    f : callable
+        The function, potentially with an updated ``__doc__``.
+    """
+    docstring = f.__doc__
+    if not docstring:
+        return f
+    lines = docstring.splitlines()
+    # Find the minimum indent of the main docstring, after first line
+    if len(lines) < 2:
+        icount = 0
+    else:
+        icount = indentcount_lines(lines[1:])
+    # Insert this indent to dictionary docstrings
+    try:
+        indented = docdict_indented[icount]
+    except KeyError:
+        indent = ' ' * icount
+        docdict_indented[icount] = indented = {}
+        for name, dstr in docdict.items():
+            lines = dstr.splitlines()
+            try:
+                newlines = [lines[0]]
+                for line in lines[1:]:
+                    newlines.append(indent + line)
+                indented[name] = '\n'.join(newlines)
+            except IndexError:
+                indented[name] = dstr
+    try:
+        f.__doc__ = docstring % indented
+    except (TypeError, ValueError, KeyError) as exp:
+        funcname = f.__name__
+        funcname = docstring.split('\n')[0] if funcname is None else funcname
+        raise RuntimeError('Error documenting %s:\n%s'
+                           % (funcname, str(exp)))
+    return f
 
 
 ##############################################################################
@@ -2402,6 +2445,8 @@ def open_docs(kind=None, version=None):
         The default can be changed by setting the configuration value
         MNE_DOCS_VERSION.
     """
+    from .check import _check_option
+    from .config import get_config
     if kind is None:
         kind = get_config('MNE_DOCS_KIND', 'api')
     help_dict = dict(api='python_reference.html', tutorials='tutorials.html',

--- a/mne/utils/fetching.py
+++ b/mne/utils/fetching.py
@@ -7,8 +7,6 @@
 import os
 import shutil
 import time
-from urllib import parse, request
-from urllib.error import HTTPError, URLError
 
 from .progressbar import ProgressBar
 from .numerics import hashfunc
@@ -21,6 +19,8 @@ from ._logging import logger, verbose
 
 def _get_http(url, temp_file_name, initial_size, timeout, verbose_bool):
     """Safely (resume a) download to a file from http(s)."""
+    from urllib import request
+    from urllib.error import HTTPError, URLError
     # Actually do the reading
     response = None
     extra = ''
@@ -94,6 +94,7 @@ def _fetch_file(url, file_name, print_destination=True, resume=True,
     """
     # Adapted from NISL:
     # https://github.com/nisl/tutorial/blob/master/nisl/datasets.py
+    from urllib import parse
     if hash_ is not None and (not isinstance(hash_, str) or
                               len(hash_) != 32) and hash_type == 'md5':
         raise ValueError('Bad hash value given, should be a 32-character '
@@ -135,6 +136,7 @@ def _fetch_file(url, file_name, print_destination=True, resume=True,
 
 def _url_to_local_path(url, path):
     """Mirror a url path in a local destination (keeping folder structure)."""
+    from urllib import parse, request
     destination = parse.urlparse(url).path
     # First char should be '/', and it needs to be discarded
     if len(destination) < 2 or destination[0] != '/':

--- a/mne/utils/linalg.py
+++ b/mne/utils/linalg.py
@@ -22,49 +22,47 @@ inputs will be memcopied.
 #
 # License: BSD (3-clause)
 
-import numpy as np
-from scipy import linalg
-from scipy.linalg import LinAlgError
-from scipy._lib._util import _asarray_validated
+import functools
 
-_d = np.empty(0, np.float64)
-_z = np.empty(0, np.complex128)
-dgemm = linalg.get_blas_funcs('gemm', (_d,))
-zgemm = linalg.get_blas_funcs('gemm', (_z,))
-dgemv = linalg.get_blas_funcs('gemv', (_d,))
-ddot = linalg.get_blas_funcs('dot', (_d,))
-_I = np.cast['F'](1j)
+import numpy as np
+
+
+# For efficiency, names should be str or tuple of str, dtype a builtin
+# NumPy dtype
+
+@functools.cache
+def _get_blas_funcs(dtype, names):
+    from scipy import linalg
+    return linalg.get_blas_funcs(names, (np.empty(0, dtype),))
+
+
+@functools.cache
+def _get_lapack_funcs(dtype, names):
+    from scipy import linalg
+    assert dtype in (np.float64, np.complex128)
+    x = np.empty(0, dtype)
+    return linalg.get_lapack_funcs(names, (x,))
 
 
 ###############################################################################
 # linalg.svd and linalg.pinv2
-dgesdd, dgesdd_lwork = linalg.get_lapack_funcs(('gesdd', 'gesdd_lwork'), (_d,))
-zgesdd, zgesdd_lwork = linalg.get_lapack_funcs(('gesdd', 'gesdd_lwork'), (_z,))
-dgesvd, dgesvd_lwork = linalg.get_lapack_funcs(('gesvd', 'gesvd_lwork'), (_d,))
-zgesvd, zgesvd_lwork = linalg.get_lapack_funcs(('gesvd', 'gesvd_lwork'), (_z,))
-
 
 def _svd_lwork(shape, dtype=np.float64):
     """Set up SVD calculations on identical-shape float64/complex128 arrays."""
-    if dtype == np.float64:
-        gesdd_lwork, gesvd_lwork = dgesdd_lwork, dgesvd_lwork
-    else:
-        assert dtype == np.complex128
-        gesdd_lwork, gesvd_lwork = zgesdd_lwork, zgesvd_lwork
+    from scipy import linalg
+    gesdd_lwork, gesvd_lwork = _get_lapack_funcs(
+        dtype, ('gesdd_lwork', 'gesvd_lwork'))
     sdd_lwork = linalg.decomp_svd._compute_lwork(
         gesdd_lwork, *shape, compute_uv=True, full_matrices=False)
     svd_lwork = linalg.decomp_svd._compute_lwork(
         gesvd_lwork, *shape, compute_uv=True, full_matrices=False)
-    return (sdd_lwork, svd_lwork)
+    return sdd_lwork, svd_lwork
 
 
 def _repeated_svd(x, lwork, overwrite_a=False):
     """Mimic scipy.linalg.svd, avoid lwork and get_lapack_funcs overhead."""
-    if x.dtype == np.float64:
-        gesdd, gesvd = dgesdd, zgesdd
-    else:
-        assert x.dtype == np.complex128
-        gesdd, gesvd = zgesdd, zgesvd
+    gesdd, gesvd = _get_lapack_funcs(
+        x.dtype, ('gesdd', 'gesvd'))
     # this has to use overwrite_a=False in case we need to fall back to gesvd
     u, s, v, info = gesdd(x, compute_uv=True, lwork=lwork[0],
                           full_matrices=False, overwrite_a=False)
@@ -73,7 +71,7 @@ def _repeated_svd(x, lwork, overwrite_a=False):
         u, s, v, info = gesvd(x, compute_uv=True, lwork=lwork[1],
                               full_matrices=False, overwrite_a=overwrite_a)
     if info > 0:
-        raise LinAlgError("SVD did not converge")
+        raise np.linalg.LinAlgError("SVD did not converge")
     if info < 0:
         raise ValueError('illegal value in %d-th argument of internal gesdd'
                          % -info)
@@ -83,8 +81,17 @@ def _repeated_svd(x, lwork, overwrite_a=False):
 ###############################################################################
 # linalg.eigh
 
-dsyevd, = linalg.get_lapack_funcs(('syevd',), (_d,))
-zheevd, = linalg.get_lapack_funcs(('heevd',), (_z,))
+@functools.cache
+def _get_evd(dtype):
+    from scipy import linalg
+    x = np.empty(0, dtype)
+    if dtype == np.float64:
+        driver = 'syevd'
+    else:
+        assert dtype == np.complex128
+        driver = 'heevd'
+    evr, = linalg.get_lapack_funcs((driver,), (x,))
+    return evr, driver
 
 
 def eigh(a, overwrite_a=False, check_finite=True):
@@ -108,15 +115,13 @@ def eigh(a, overwrite_a=False, check_finite=True):
         The normalized eigenvector corresponding to the eigenvalue ``w[i]``
         is the column ``v[:, i]``.
     """
+    from scipy.linalg import LinAlgError
+    from scipy._lib._util import _asarray_validated
     # We use SYEVD, see https://github.com/scipy/scipy/issues/9212
     if check_finite:
         a = _asarray_validated(a, check_finite=check_finite)
-    if a.dtype == np.float64:
-        evr, driver = dsyevd, 'syevd'
-    else:
-        assert a.dtype == np.complex128
-        evr, driver = zheevd, 'heevd'
-    w, v, info = evr(a, lower=1, overwrite_a=overwrite_a)
+    evd, driver = _get_evd(a.dtype)
+    w, v, info = evd(a, lower=1, overwrite_a=overwrite_a)
     if info == 0:
         return w, v
     if info < 0:

--- a/mne/utils/linalg.py
+++ b/mne/utils/linalg.py
@@ -30,13 +30,13 @@ import numpy as np
 # For efficiency, names should be str or tuple of str, dtype a builtin
 # NumPy dtype
 
-@functools.cache
+@functools.lru_cache(None)
 def _get_blas_funcs(dtype, names):
     from scipy import linalg
     return linalg.get_blas_funcs(names, (np.empty(0, dtype),))
 
 
-@functools.cache
+@functools.lru_cache(None)
 def _get_lapack_funcs(dtype, names):
     from scipy import linalg
     assert dtype in (np.float64, np.complex128)
@@ -81,7 +81,7 @@ def _repeated_svd(x, lwork, overwrite_a=False):
 ###############################################################################
 # linalg.eigh
 
-@functools.cache
+@functools.lru_cache(None)
 def _get_evd(dtype):
     from scipy import linalg
     x = np.empty(0, dtype)

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -19,7 +19,6 @@ import sys
 from datetime import datetime, timedelta, timezone
 
 import numpy as np
-from scipy import sparse
 
 from ._logging import logger, warn, verbose
 from .check import check_random_state, _ensure_int, _validate_type
@@ -670,6 +669,7 @@ def object_size(x, memo=None):
     size : int
         The estimated size in bytes of the object.
     """
+    from scipy import sparse
     # Note: this will not process object arrays properly (since those only)
     # hold references
     if memo is None:
@@ -739,6 +739,7 @@ def object_diff(a, b, pre=''):
     diffs : str
         A string representation of the differences.
     """
+    from scipy import sparse
     out = ''
     if type(a) != type(b):
         # Deal with NamedInt and NamedFloat

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -18,7 +18,6 @@ from collections.abc import Iterable
 from functools import partial
 
 import numpy as np
-from scipy import linalg
 
 from ..defaults import DEFAULTS
 from ..fixes import einsum, _crop_colorbar, _get_img_fdata, _get_args
@@ -2043,7 +2042,7 @@ def _glass_brain_crosshairs(params, x, y, z):
 
 
 def _cut_coords_to_ijk(cut_coords, img):
-    ijk = apply_trans(linalg.inv(img.affine), cut_coords)
+    ijk = apply_trans(np.linalg.inv(img.affine), cut_coords)
     ijk = np.clip(np.round(ijk).astype(int), 0, np.array(img.shape[:3]) - 1)
     return ijk
 
@@ -3034,7 +3033,7 @@ def plot_sensors_connectivity(info, con, picks=None):
     con_nodes = list()
     con_val = list()
     for i, j in zip(ii, jj):
-        if linalg.norm(sens_loc[i] - sens_loc[j]) > min_dist:
+        if np.linalg.norm(sens_loc[i] - sens_loc[j]) > min_dist:
             con_nodes.append((i, j))
             con_val.append(con[i, j])
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -18,7 +18,6 @@ import traceback
 import warnings
 
 import numpy as np
-from scipy import sparse
 from collections import OrderedDict
 
 from .colormap import calculate_lut
@@ -1173,6 +1172,7 @@ class Brain(object):
 
     def _configure_picking(self):
         # get data for each hemi
+        from scipy import sparse
         for idx, hemi in enumerate(['vol', 'lh', 'rh']):
             hemi_data = self._data.get(hemi)
             if hemi_data is not None:
@@ -2813,6 +2813,7 @@ class Brain(object):
         n_steps : int
             Number of smoothing steps.
         """
+        from scipy import sparse
         from ...morph import _hemi_morph
         for hemi in ['lh', 'rh']:
             hemi_data = self._data.get(hemi)

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -21,7 +21,6 @@ from distutils.version import LooseVersion
 from collections import defaultdict
 
 import numpy as np
-from scipy import linalg
 
 from ..defaults import DEFAULTS
 from ..fixes import _get_img_fdata
@@ -117,9 +116,10 @@ def plot_cov(cov, info, exclude=(), colorbar=True, proj=False, show_svd=True,
     .. versionchanged:: 0.19
        Approximate ranks for each channel type are shown with red dashed lines.
     """
-    from ..cov import Covariance
     import matplotlib.pyplot as plt
     from matplotlib.colors import Normalize
+    from scipy import linalg
+    from ..cov import Covariance
 
     info, C, ch_names, idx_names = _index_info_cov(info, cov, exclude)
     del cov, exclude


### PR DESCRIPTION
So far 940 ms to 560 ms on my system by caching the indented versions of our docdict. It says 325 sec of this is importing numpy for me so not a ton left to be gained. I think there might be some other gains to be made for example by nesting scipy imports, though, so I'm at least going to try that.

Closes #8826