### PR TITLE
FIX: only delete visible annotation spans

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -86,6 +86,8 @@ Bugs
 
 - Allow sEEG channel types in :meth:`mne.Evoked.plot_joint` (:gh:`8736` by `Daniel McCloy`_)
 
+- Fix bug where hidden annotations could be deleted interactively in :meth:`mne.io.Raw.plot` windows (:gh:`8831` by `Daniel McCloy`_)
+
 - Function :func:`mne.set_bipolar_reference` was not working when passing ``Epochs`` constructed with some ``picks`` (:gh:`8728` by `Alex Gramfort`_)
 
 - Fix anonymization issue of FIF files after IO round trip (:gh:`8731` by `Alex Gramfort`_)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -18,7 +18,7 @@ import numpy as np
 from .utils import (_pl, check_fname, _validate_type, verbose, warn, logger,
                     _check_pandas_installed, _mask_to_onsets_offsets,
                     _DefaultEventParser, _check_dt, _stamp_to_dt, _dt_to_stamp,
-                    _check_fname)
+                    _check_fname, int_like)
 
 from .io.write import (start_block, end_block, write_float, write_name_list,
                        write_double, start_file)
@@ -257,7 +257,7 @@ class Annotations(object):
 
     def __getitem__(self, key):
         """Propagate indexing and slicing to the underlying numpy structure."""
-        if isinstance(key, int):
+        if isinstance(key, int_like):
             out_keys = ('onset', 'duration', 'description', 'orig_time')
             out_vals = (self.onset[key], self.duration[key],
                         self.description[key], self.orig_time)

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -794,7 +794,11 @@ class MNEBrowseFigure(MNEFigure):
                     start = _sync_onset(inst, inst.annotations.onset)
                     end = start + inst.annotations.duration
                     ann_idx = np.where((xdata > start) & (xdata < end))[0]
-                    inst.annotations.delete(ann_idx)  # only first one deleted
+                    for idx in sorted(ann_idx)[::-1]:
+                        # only remove visible annotation spans
+                        descr = inst.annotations[idx]['description']
+                        if self.mne.visible_annotations[descr]:
+                            inst.annotations.delete(idx)
                 self._remove_annotation_hover_line()
                 self._draw_annotations()
                 self.canvas.draw_idle()

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -539,6 +539,21 @@ def test_plot_annotations(raw):
     assert len(fig.mne.annotation_texts) == 1
 
 
+@pytest.mark.parametrize('hide_which', (0, 1))
+def test_remove_annotations(raw, hide_which):
+    # test right-click doesn't remove hidden annotation spans
+    ann = Annotations(onset=[2, 1], duration=[1, 3],
+                      description=['foo', 'bar'])
+    raw.set_annotations(ann)
+    assert len(raw.annotations) == 2
+    fig = raw.plot()
+    fig.canvas.key_press_event('a')  # start annotation mode
+    checkboxes = fig.mne.show_hide_annotation_checkboxes
+    checkboxes.set_active(hide_which)
+    _fake_click(fig, fig.mne.ax_main, (2.5, 0.1), xform='data', button=3)
+    assert len(raw.annotations) == 1
+
+
 @pytest.mark.parametrize('filtorder', (0, 2))  # FIR, IIR
 def test_plot_raw_filtered(filtorder, raw):
     """Test filtering of raw plots."""

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -541,7 +541,7 @@ def test_plot_annotations(raw):
 
 @pytest.mark.parametrize('hide_which', (0, 1))
 def test_remove_annotations(raw, hide_which):
-    # test right-click doesn't remove hidden annotation spans
+    """Test that right-click doesn't remove hidden annotation spans."""
     ann = Annotations(onset=[2, 1], duration=[1, 3],
                       description=['foo', 'bar'])
     raw.set_annotations(ann)

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -539,7 +539,7 @@ def test_plot_annotations(raw):
     assert len(fig.mne.annotation_texts) == 1
 
 
-@pytest.mark.parametrize('hide_which', (0, 1))
+@pytest.mark.parametrize('hide_which', ([], [0], [1], [0, 1]))
 def test_remove_annotations(raw, hide_which):
     """Test that right-click doesn't remove hidden annotation spans."""
     ann = Annotations(onset=[2, 1], duration=[1, 3],
@@ -549,9 +549,10 @@ def test_remove_annotations(raw, hide_which):
     fig = raw.plot()
     fig.canvas.key_press_event('a')  # start annotation mode
     checkboxes = fig.mne.show_hide_annotation_checkboxes
-    checkboxes.set_active(hide_which)
+    for which in hide_which:
+        checkboxes.set_active(which)
     _fake_click(fig, fig.mne.ax_main, (2.5, 0.1), xform='data', button=3)
-    assert len(raw.annotations) == 1
+    assert len(raw.annotations) == len(hide_which)
 
 
 @pytest.mark.parametrize('filtorder', (0, 2))  # FIR, IIR


### PR DESCRIPTION
issue raised on discourse: https://mne.discourse.group/t/annotation-editing-deletion-and-undo/2650/2

previously, right-clicking to remove an annotation would remove *all* annotation spans that overlap at the mouse position, *regardless of whether they were visible or hidden by the UI*.  Now it will remove only *visible* spans under the mouse cursor, meaning it is possible to remove only a specific span by hiding other overlapping ones first.