### PR TITLE
MAINT: Dont fail on coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,7 @@ coverage:
   status:
     patch:
       default:
+        informational: true
         target: 95%
         if_no_uploads: error
         if_not_found: success
@@ -15,6 +16,7 @@ coverage:
     project:
       default: false
       library:
+        informational: true
         target: 90%
         if_no_uploads: error
         if_not_found: success


### PR DESCRIPTION
I don't like that PRs have their status set as failed even when CIs are still running. And even once all are done running, codecov reporting can be iffy. This PR sets codecov just to be informational which will make it always green. This will mean we have to manually check the coverage reports, but we already have to do that when we're interested since we can't fully trust the output.

Closes #8776