### PR TITLE
MRG, ENH: write_head_bem for writing head surface files

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -56,6 +56,8 @@ Enhancements
 
 - Add ``auto_close`` to `mne.Report.add_figs_to_section` and `mne.Report.add_slider_to_section` to manage closing figures (:gh`8730` by `Guillaume Favelier`_)
 
+- Add :func:`mne.write_head_bem` to support writing head surface files (:gh:`8841` by `Yu-Han Luo`_)
+
 Bugs
 ~~~~
 - Fix bugs with `mne.io.read_raw_persyst` where multiple ``Comments`` with the same name are allowed, and ``Comments`` with a "," character are now allowed (:gh:`8311` and :gh:`8806` **by new contributor** |Andres Rodriguez|_ and `Adam Li`_)

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -140,6 +140,7 @@ File I/O
    write_labels_to_annot
    write_bem_solution
    write_bem_surfaces
+   write_head_bem
    write_cov
    write_events
    write_evokeds

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -36,7 +36,7 @@ from .io.reference import (set_eeg_reference, set_bipolar_reference,
                            add_reference_channels)
 from .io.what import what
 from .bem import (make_sphere_model, make_bem_model, make_bem_solution,
-                  read_bem_surfaces, write_bem_surfaces,
+                  read_bem_surfaces, write_bem_surfaces, write_head_bem,
                   read_bem_solution, write_bem_solution)
 from .cov import (read_cov, write_cov, Covariance, compute_raw_covariance,
                   compute_covariance, whiten_evoked, make_ad_hoc_cov)

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1246,6 +1246,8 @@ def read_bem_surfaces(fname, patch_stats=False, s_id=None, on_defects='raise',
         An error will be raised if it doesn't exist. If None, all
         surfaces are read and returned.
     %(on_defects)s
+
+        .. versionadded:: 0.23
     %(verbose)s
 
     Returns

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1579,11 +1579,10 @@ def write_head_bem(fname, rr, tris, on_defects='raise', overwrite=False,
         If True (default False), overwrite the file.
     %(verbose)s
     """
-    fname = _check_fname(fname, overwrite=overwrite, name='fname')
     surf = _surfaces_to_bem([dict(rr=rr, tris=tris)],
                             [FIFF.FIFFV_BEM_SURF_ID_HEAD], [1], rescale=False,
                             incomplete=on_defects)
-    write_bem_surfaces(fname, surf, overwrite=True)
+    write_bem_surfaces(fname, surf, overwrite=overwrite)
 
 
 def _write_bem_surfaces_block(fid, surfs):

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1569,8 +1569,8 @@ def write_head_bem(fname, rr, tris, on_defects='raise', overwrite=False,
     ----------
     fname : str
         Filename to write.
-    rr : array, shape=(n_vertices, 3)
-        Coordinate points.
+    rr : array, shape (n_vertices, 3)
+        Coordinate points in the MRI coordinate system.
     tris : ndarray of int, shape (n_tris, 3)
         Triangulation (each line contains indices for three points which
         together form a face).

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -14,7 +14,8 @@ from numpy.testing import assert_equal, assert_allclose
 
 from mne import (make_bem_model, read_bem_surfaces, write_bem_surfaces,
                  make_bem_solution, read_bem_solution, write_bem_solution,
-                 make_sphere_model, Transform, Info, write_surface)
+                 make_sphere_model, Transform, Info, write_surface,
+                 write_head_bem)
 from mne.preprocessing.maxfilter import fit_sphere_to_headshape
 from mne.io.constants import FIFF
 from mne.transforms import translation
@@ -37,7 +38,8 @@ fname_bem_sol_3 = op.join(subjects_dir, 'sample', 'bem',
                           'sample-320-320-320-bem-sol.fif')
 fname_bem_sol_1 = op.join(subjects_dir, 'sample', 'bem',
                           'sample-320-bem-sol.fif')
-
+fname_dense_head = op.join(subjects_dir, 'sample', 'bem',
+                           'sample-head-dense.fif')
 
 def _compare_bem_surfaces(surfs_1, surfs_2):
     """Compare BEM surfaces."""
@@ -385,6 +387,25 @@ def test_fit_sphere_to_headshape():
     info = Info(dig=dig[:6], dev_head_t=dev_head_t)
     pytest.raises(ValueError, fit_sphere_to_headshape, info, units='m')
     pytest.raises(TypeError, fit_sphere_to_headshape, 1, units='m')
+
+
+@testing.requires_testing_data
+def test_io_head_bem(tmpdir):
+    """Test reading and writing of defective head surfaces."""
+    head = read_bem_surfaces(fname_dense_head)[0]
+    fname_defect = op.join(str(tmpdir), 'temp-head-defect.fif')
+    head['tris'][0] = np.array([1, 2, 3])  # create defects
+
+    with pytest.raises(RuntimeError, match='topological defects:'):
+        write_head_bem(fname_defect, head['rr'], head['tris'])
+    with pytest.warns(RuntimeWarning, match='topological defects:'):
+        write_head_bem(fname_defect, head['rr'], head['tris'],
+                       on_defects='warn')
+    # test on_defects in read_bem_surfaces
+    with pytest.raises(RuntimeError, match='topological defects:'):
+        read_bem_surfaces(fname_defect)
+    with pytest.warns(RuntimeWarning, match='topological defects:'):
+        read_bem_surfaces(fname_defect, on_defects='warn')
 
 
 run_tests_if_main()

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -41,6 +41,7 @@ fname_bem_sol_1 = op.join(subjects_dir, 'sample', 'bem',
 fname_dense_head = op.join(subjects_dir, 'sample', 'bem',
                            'sample-head-dense.fif')
 
+
 def _compare_bem_surfaces(surfs_1, surfs_2):
     """Compare BEM surfaces."""
     names = ['id', 'nn', 'rr', 'coord_frame', 'tris', 'sigma', 'ntri', 'np']

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -394,14 +394,6 @@ def test_fit_sphere_to_headshape():
 def test_io_head_bem(tmpdir):
     """Test reading and writing of defective head surfaces."""
     head = read_bem_surfaces(fname_dense_head)[0]
-    fname_out = op.join(str(tmpdir), 'temp-head-out.fif')
-    write_head_bem(fname_out, head['rr'], head['tris'])
-    head_out = read_bem_surfaces(fname_out)[0]
-
-    assert head['id'] == head_out['id'] == FIFF.FIFFV_BEM_SURF_ID_HEAD
-    assert np.all(head['rr'] == head_out['rr'])
-    assert np.all(head['tris'] == head_out['tris'])
-
     fname_defect = op.join(str(tmpdir), 'temp-head-defect.fif')
     # create defects
     head['rr'][0] = np.array([-0.01487014, -0.04563854, -0.12660208])
@@ -416,7 +408,11 @@ def test_io_head_bem(tmpdir):
     with pytest.raises(RuntimeError, match='topological defects:'):
         read_bem_surfaces(fname_defect)
     with pytest.warns(RuntimeWarning, match='topological defects:'):
-        read_bem_surfaces(fname_defect, on_defects='warn')
+        head_defect = read_bem_surfaces(fname_defect, on_defects='warn')[0]
+
+    assert head['id'] == head_defect['id'] == FIFF.FIFFV_BEM_SURF_ID_HEAD
+    assert np.allclose(head['rr'], head_defect['rr'])
+    assert np.allclose(head['tris'], head_defect['tris'])
 
 
 run_tests_if_main()

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -394,8 +394,18 @@ def test_fit_sphere_to_headshape():
 def test_io_head_bem(tmpdir):
     """Test reading and writing of defective head surfaces."""
     head = read_bem_surfaces(fname_dense_head)[0]
+    fname_out = op.join(str(tmpdir), 'temp-head-out.fif')
+    write_head_bem(fname_out, head['rr'], head['tris'])
+    head_out = read_bem_surfaces(fname_out)[0]
+
+    assert head['id'] == head_out['id'] == FIFF.FIFFV_BEM_SURF_ID_HEAD
+    assert np.all(head['rr'] == head_out['rr'])
+    assert np.all(head['tris'] == head_out['tris'])
+
     fname_defect = op.join(str(tmpdir), 'temp-head-defect.fif')
-    head['tris'][0] = np.array([1, 2, 3])  # create defects
+    # create defects
+    head['rr'][0] = np.array([-0.01487014, -0.04563854, -0.12660208])
+    head['tris'][0] = np.array([21919, 21918, 21907])
 
     with pytest.raises(RuntimeError, match='topological defects:'):
         write_head_bem(fname_defect, head['rr'], head['tris'])

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2087,6 +2087,17 @@ docdict['compute_proj_ecg'] = f"""%(create_ecg_epochs)s {compute_proj_common}
 docdict['compute_proj_eog'] = f"""%(create_eog_epochs)s {compute_proj_common}
 """ % docdict
 
+# BEM
+docdict['on_defects'] = """
+on_defects : str
+    What to do if the surface is found to have topological defects. Can be
+    ``'raise'`` (default) to raise an error, or ``'warn'`` to emit a warning.
+    Note that a lot of computations in MNE-Python assume the surfaces to be
+    topologically correct, topological defects may still make other
+    computations (e.g., ``mne.make_bem_model`` and ``mne.make_bem_solution``)
+    fail irrespective of this parameter.
+"""
+
 # Other
 docdict['accept'] = """
 accept : bool

--- a/tutorials/source-modeling/plot_fix_bem_in_blender.py
+++ b/tutorials/source-modeling/plot_fix_bem_in_blender.py
@@ -162,10 +162,8 @@ coords, faces = mne.read_surface(op.join(bem_dir, 'outer_skin.surf'))
 # Make sure we are in the correct directory
 if 'flash' in bem_dir:
     bem_dir = op.join(subjects_dir, 'sample', 'bem')
-# Backup the original head file
-shutil.copy(op.join(bem_dir, 'sample-head.fif'),
-            op.join(bem_dir, 'sample-head_orig.fif'))
 
+# Remember to backup the original head file in advance!
 # Overwrite the original head file
 mne.write_head_bem(op.join(bem_dir, 'sample-head.fif'),
                    coords, faces, overwrite=True)
@@ -176,27 +174,33 @@ mne.write_head_bem(op.join(bem_dir, 'sample-head.fif'),
 #
 # We use :func:`mne.read_bem_surfaces` to read the head surface files. After
 # editing, we again output the head file with :func:`mne.write_head_bem`.
+# Here we use ``-head.fif`` for speed.
 
 # If ``-head-dense.fif`` does not exist, you need to run
 # ``mne make_scalp_surfaces`` first.
 # [0] because a list of surfaces is returned
 surf = mne.read_bem_surfaces(
-    op.join(bem_dir, 'sample-head-dense.fif'))[0]
+    op.join(bem_dir, 'sample-head.fif'))[0]
 
 # For consistency only
 coords = surf['rr']
 faces = surf['tris']
 
 # Write the head as an .obj file for editing
-mne.write_surface(op.join(conv_dir, 'sample-head-dense.obj'),
+mne.write_surface(op.join(conv_dir, 'sample-head.obj'),
                   coords, faces, overwrite=True)
 
-# After editing, read in the .obj file
-coords, faces = mne.read_surface(
-    op.join(conv_dir, 'sample-head-dense_fixed.obj'))
+# We use the same surface to simulate editing
+mne.write_surface(op.join(conv_dir, 'sample-head_fixed.obj'),
+                  coords, faces, overwrite=True)
 
+# Read in the .obj file
+coords, faces = mne.read_surface(
+    op.join(conv_dir, 'sample-head_fixed.obj'))
+
+# Remember to backup the original head file in advance!
 # Overwrite the original head file
-mne.write_head_bem(op.join(bem_dir, 'sample-head-dense.fif'),
+mne.write_head_bem(op.join(bem_dir, 'sample-head.fif'),
                    coords, faces, overwrite=True)
 
 ###############################################################################

--- a/tutorials/source-modeling/plot_fix_bem_in_blender.py
+++ b/tutorials/source-modeling/plot_fix_bem_in_blender.py
@@ -190,13 +190,10 @@ faces = surf['tris']
 mne.write_surface(op.join(conv_dir, 'sample-head.obj'),
                   coords, faces, overwrite=True)
 
-# We use the same surface to simulate editing
-mne.write_surface(op.join(conv_dir, 'sample-head_fixed.obj'),
-                  coords, faces, overwrite=True)
-
+# We use the same surface to simulate the fixed version here
 # Read in the .obj file
 coords, faces = mne.read_surface(
-    op.join(conv_dir, 'sample-head_fixed.obj'))
+    op.join(conv_dir, 'sample-head.obj'))
 
 # Remember to backup the original head file in advance!
 # Overwrite the original head file

--- a/tutorials/source-modeling/plot_fix_bem_in_blender.py
+++ b/tutorials/source-modeling/plot_fix_bem_in_blender.py
@@ -31,10 +31,7 @@ import mne
 
 data_path = mne.datasets.sample.data_path()
 subjects_dir = op.join(data_path, 'subjects')
-bem_dir = op.join(subjects_dir, 'sample', 'bem')
-# in case the sample surfaces are not in there
-if not op.exists(op.join(bem_dir, 'inner_skull.surf')):
-    bem_dir = op.join(bem_dir, 'flash')
+bem_dir = op.join(subjects_dir, 'sample', 'bem', 'flash')
 ###############################################################################
 # Exporting surfaces to Blender
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -139,8 +136,12 @@ shutil.copy(op.join(bem_dir, 'inner_skull.surf'),
 
 # Overwrite the original surface with the fixed version
 # In real study you should provide the correct metadata using ``volume_info=``
-mne.write_surface(op.join(bem_dir, 'inner_skull.surf'), coords, faces,
-                  overwrite=True)
+# This could be accomplished for example with:
+#
+# _, _, vol_info = mne.read_surface(op.join(bem_dir, 'inner_skull.surf'),
+#                                   read_metadata=True)
+# mne.write_surface(op.join(bem_dir, 'inner_skull.surf'), coords, faces,
+#                   volume_info=vol_info, overwrite=True)
 
 ###############################################################################
 # Editing the head surfaces
@@ -160,13 +161,13 @@ mne.write_surface(op.join(bem_dir, 'inner_skull.surf'), coords, faces,
 coords, faces = mne.read_surface(op.join(bem_dir, 'outer_skin.surf'))
 
 # Make sure we are in the correct directory
-if 'flash' in bem_dir:
-    bem_dir = op.join(subjects_dir, 'sample', 'bem')
+head_dir = op.dirname(bem_dir)
 
 # Remember to backup the original head file in advance!
 # Overwrite the original head file
-mne.write_head_bem(op.join(bem_dir, 'sample-head.fif'),
-                   coords, faces, overwrite=True)
+#
+# mne.write_head_bem(op.join(head_dir, 'sample-head.fif'), coords, faces,
+#                    overwrite=True)
 
 ###############################################################################
 # High-resolution head
@@ -179,8 +180,7 @@ mne.write_head_bem(op.join(bem_dir, 'sample-head.fif'),
 # If ``-head-dense.fif`` does not exist, you need to run
 # ``mne make_scalp_surfaces`` first.
 # [0] because a list of surfaces is returned
-surf = mne.read_bem_surfaces(
-    op.join(bem_dir, 'sample-head.fif'))[0]
+surf = mne.read_bem_surfaces(op.join(head_dir, 'sample-head.fif'))[0]
 
 # For consistency only
 coords = surf['rr']
@@ -190,15 +190,17 @@ faces = surf['tris']
 mne.write_surface(op.join(conv_dir, 'sample-head.obj'),
                   coords, faces, overwrite=True)
 
-# We use the same surface to simulate the fixed version here
+# Usually here you would go and edit your meshes.
+#
+# Here we just use the same surface as if it were fixed
 # Read in the .obj file
-coords, faces = mne.read_surface(
-    op.join(conv_dir, 'sample-head.obj'))
+coords, faces = mne.read_surface(op.join(conv_dir, 'sample-head.obj'))
 
 # Remember to backup the original head file in advance!
 # Overwrite the original head file
-mne.write_head_bem(op.join(bem_dir, 'sample-head.fif'),
-                   coords, faces, overwrite=True)
+#
+# mne.write_head_bem(op.join(head_dir, 'sample-head.fif'), coords, faces,
+#                    overwrite=True)
 
 ###############################################################################
 # That's it! You are ready to continue with your analysis pipeline (e.g.

--- a/tutorials/source-modeling/plot_fix_bem_in_blender.py
+++ b/tutorials/source-modeling/plot_fix_bem_in_blender.py
@@ -10,6 +10,11 @@ re-importing them.
 
 This tutorial is based on https://github.com/ezemikulan/blender_freesurfer by
 Ezequiel Mikulan.
+
+.. contents:: Page contents
+   :local:
+   :depth: 2
+
 """
 
 # Authors: Marijn van Vliet <w.m.vanvliet@gmail.com>
@@ -27,10 +32,12 @@ import mne
 data_path = mne.datasets.sample.data_path()
 subjects_dir = op.join(data_path, 'subjects')
 bem_dir = op.join(subjects_dir, 'sample', 'bem')
-
+# in case the sample surfaces are not in there
+if not op.exists(op.join(bem_dir, 'inner_skull.surf')):
+    bem_dir = op.join(bem_dir, 'flash')
 ###############################################################################
 # Exporting surfaces to Blender
-# -----------------------------
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # In this tutorial, we are working with the MNE-Sample set, for which the
 # surfaces have no issues. To demonstrate how to fix problematic surfaces, we
@@ -46,6 +53,8 @@ conv_dir = op.join(subjects_dir, 'sample', 'conv')
 os.makedirs(conv_dir, exist_ok=True)
 
 # Load the inner skull surface and create a problem
+# The metadata is empty in this example. In real study, we want to write the
+# original metadata to the fixed surface file. Set read_metadata=True to do so.
 coords, faces = mne.read_surface(op.join(bem_dir, 'inner_skull.surf'))
 coords[0] *= 1.1  # Move the first vertex outside the skull
 
@@ -61,7 +70,7 @@ mne.write_surface(op.join(conv_dir, 'outer_skull.obj'), coords, faces,
 
 ###############################################################################
 # Editing in Blender
-# ------------------
+# ^^^^^^^^^^^^^^^^^^
 #
 # We can now open Blender and import the surfaces. Go to *File > Import >
 # Wavefront (.obj)*. Navigate to the ``conv`` folder and select the file you
@@ -91,7 +100,7 @@ mne.write_surface(op.join(conv_dir, 'outer_skull.obj'), coords, faces,
 #    :alt: Editing surfaces in Blender
 #
 # Using the fixed surfaces in MNE-Python
-# --------------------------------------
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # In Blender, you can export a surface as an .obj file by selecting it and go
 # to *File > Export > Wavefront (.obj)*. You need to again select the *Y
@@ -118,7 +127,7 @@ mne.write_surface(op.join(conv_dir, 'inner_skull_fixed.obj'), coords, faces,
 # Back in Python, you can read the fixed .obj files and save them as
 # FreeSurfer .surf files. For the :func:`mne.make_bem_model` function to find
 # them, they need to be saved using their original names in the ``surf``
-# folder, e.g. ``surf/inner_skull.surf``. Be sure to first backup the original
+# folder, e.g. ``bem/inner_skull.surf``. Be sure to first backup the original
 # surfaces in case you make a mistake!
 
 # Read the fixed surface
@@ -129,8 +138,66 @@ shutil.copy(op.join(bem_dir, 'inner_skull.surf'),
             op.join(bem_dir, 'inner_skull_orig.surf'))
 
 # Overwrite the original surface with the fixed version
+# In real study you should provide the correct metadata using ``volume_info=``
 mne.write_surface(op.join(bem_dir, 'inner_skull.surf'), coords, faces,
                   overwrite=True)
+
+###############################################################################
+# Editing the head surfaces
+# ^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# Sometimes the head surfaces are faulty and require manual editing. We use
+# :func:`mne.write_head_bem` to convert the fixed surfaces to ``.fif`` files.
+#
+# Low-resolution head
+# ~~~~~~~~~~~~~~~~~~~
+#
+# For EEG forward modeling, it is possible that ``outer_skin.surf`` would be
+# manually edited. In that case, remember to save the fixed version of
+# ``-head.fif`` from the edited surface file for coregistration.
+
+# Load the fixed surface
+coords, faces = mne.read_surface(op.join(bem_dir, 'outer_skin.surf'))
+
+# Make sure we are in the correct directory
+if 'flash' in bem_dir:
+    bem_dir = op.join(subjects_dir, 'sample', 'bem')
+# Backup the original head file
+shutil.copy(op.join(bem_dir, 'sample-head.fif'),
+            op.join(bem_dir, 'sample-head_orig.fif'))
+
+# Overwrite the original head file
+mne.write_head_bem(op.join(bem_dir, 'sample-head.fif'),
+                   coords, faces, overwrite=True)
+
+###############################################################################
+# High-resolution head
+# ~~~~~~~~~~~~~~~~~~~~
+#
+# We use :func:`mne.read_bem_surfaces` to read the head surface files. After
+# editing, we again output the head file with :func:`mne.write_head_bem`.
+
+# If ``-head-dense.fif`` does not exist, you need to run
+# ``mne make_scalp_surfaces`` first.
+# [0] because a list of surfaces is returned
+surf = mne.read_bem_surfaces(
+    op.join(bem_dir, 'sample-head-dense.fif'))[0]
+
+# For consistency only
+coords = surf['rr']
+faces = surf['tris']
+
+# Write the head as an .obj file for editing
+mne.write_surface(op.join(conv_dir, 'sample-head-dense.obj'),
+                  coords, faces, overwrite=True)
+
+# After editing, read in the .obj file
+coords, faces = mne.read_surface(
+    op.join(conv_dir, 'sample-head-dense_fixed.obj'))
+
+# Overwrite the original head file
+mne.write_head_bem(op.join(bem_dir, 'sample-head-dense.fif'),
+                   coords, faces, overwrite=True)
 
 ###############################################################################
 # That's it! You are ready to continue with your analysis pipeline (e.g.


### PR DESCRIPTION
#### Reference issue
Discussed in #8825 .

#### What does this implement/fix?

- [X] `write_head_bem` for customized head surface
- [X] let `read_bem_surfaces` read in defective head surfaces, but warn
~~`fix_all_defects` (all credits to @christian-oreilly , just merge the codes into MNE-Python)~~
- [X] DOC
  - [X] `write_head_bem`
  - [X] `on_defects`
~~`fix_all_defects`~~
~~A tutorial/example to illustrate how to fix the topological defects~~

- [ ] `write_head_bem` for` mne make_scalp_surfaces`
- [X] Update: Editing BEM surfaces in Blender
- [ ] FAQ: My watershed BEM meshes look incorrect
- [X] `latest.inc`
