### PR TITLE
MRG, FIX: output_type for clustering

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -76,6 +76,8 @@ Bugs
 
 - Fix bug with :func:`mne.minimum_norm.make_inverse_operator` where ``depth`` was errantly restricted to be less than or equal to 1. (:gh:`8804` by `Eric Larson`_)
 
+- Fix bug with :func:`mne.stats.permutation_cluster_1samp_test` and related clustering functions when ``adjacency=None`` and ``out_type='indices'`` (:gh:`#8842` by `Eric Larson`_)
+
 - Fix bug with ``replace`` argument of :meth:`mne.Report.add_bem_to_section` and :meth:`mne.Report.add_slider_to_section` (:gh:`8723` by `Eric Larson`_)
 
 - Fix bug with `mne.viz.Brain` where non-inflated surfaces had an X-offset imposed by default (:gh:`8794` by `Eric Larson`_)

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1096,7 +1096,7 @@ def permutation_cluster_test(
         no points are excluded.
     %(clust_stepdown)s
     %(clust_power_f)s
-    %(clust_out_none)s
+    %(clust_out)s
     %(clust_disjoint)s
     %(clust_buffer)s
     %(verbose)s
@@ -1156,7 +1156,7 @@ def permutation_cluster_1samp_test(
         no points are excluded.
     %(clust_stepdown)s
     %(clust_power_t)s
-    %(clust_out_none)s
+    %(clust_out)s
     %(clust_disjoint)s
     %(clust_buffer)s
     %(verbose)s

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -557,11 +557,20 @@ def _cluster_indices_to_mask(components, n_tot):
     return components
 
 
-def _cluster_mask_to_indices(components):
+def _cluster_mask_to_indices(components, shape):
     """Convert to the old format of clusters, which were bool arrays."""
     for ci, c in enumerate(components):
-        if not isinstance(c, slice):
-            components[ci] = np.where(c)[0]
+        if isinstance(c, np.ndarray):  # mask
+            components[ci] = np.where(c.reshape(shape))
+        else:
+            assert isinstance(c, tuple), type(c)
+            c = list(c)  # tuple->list
+            for ii, cc in enumerate(c):
+                if isinstance(cc, slice):
+                    c[ii] = np.arange(cc.start, cc.stop)
+                else:
+                    c[ii] = np.where(cc)[0]
+            components[ci] = tuple(c)
     return components
 
 
@@ -918,7 +927,7 @@ def _permutation_cluster_test(X, threshold, n_permutations, tail, stat_fun,
     else:
         # ndimage outputs slices or boolean masks by default
         if out_type == 'indices':
-            clusters = _cluster_mask_to_indices(clusters)
+            clusters = _cluster_mask_to_indices(clusters, t_obs.shape)
 
     # convert our seed to orders
     # check to see if we can do an exact test

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -723,7 +723,7 @@ def test_output_equiv(shape, out_type, adjacency):
             assert isinstance(clu, tuple)
             for c in clu:
                 assert isinstance(c, np.ndarray)
-                assert c.dtype == int
+                assert c.dtype.kind == 'i'
             assert out_type == 'indices'
             got_mask[np.ix_(*clu)] = n
     assert_array_equal(got_mask, want_mask)

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -22,8 +22,7 @@ from mne.stats.cluster_level import (permutation_cluster_test, f_oneway,
                                      spatio_temporal_cluster_test,
                                      spatio_temporal_cluster_1samp_test,
                                      ttest_1samp_no_p, summarize_clusters_stc)
-from mne.utils import (run_tests_if_main, catch_logging, check_version,
-                       requires_sklearn)
+from mne.utils import catch_logging, check_version, requires_sklearn
 
 
 @pytest.fixture(scope="function", params=('Numba', 'NumPy'))
@@ -688,4 +687,43 @@ def test_tfce_thresholds(numba_conditional):
             data, tail=1, out_type='mask', threshold=dict(start=1, step=-0.5))
 
 
-run_tests_if_main()
+# 1D gives slices, 2D+ gives boolean masks
+@pytest.mark.parametrize('shape', ((11,), (11, 3), (11, 1, 2)))
+@pytest.mark.parametrize('out_type', ('mask', 'indices'))
+@pytest.mark.parametrize('adjacency', (None, 'sparse'))
+def test_output_equiv(shape, out_type, adjacency):
+    """Test equivalence of output types."""
+    rng = np.random.RandomState(0)
+    n_subjects = 10
+    data = rng.randn(n_subjects, *shape)
+    data -= data.mean(axis=0, keepdims=True)
+    data[:, 2:4] += 2
+    data[:, 6:9] += 2
+    want_mask = np.zeros(shape, int)
+    want_mask[2:4] = 1
+    want_mask[6:9] = 2
+    if adjacency is not None:
+        assert adjacency == 'sparse'
+        adjacency = combine_adjacency(*shape)
+    clusters = permutation_cluster_1samp_test(
+        X=data, n_permutations=1, adjacency=adjacency, out_type=out_type)[1]
+    got_mask = np.zeros_like(want_mask)
+    for n, clu in enumerate(clusters, 1):
+        if out_type == 'mask':
+            if len(shape) == 1 and adjacency is None:
+                assert isinstance(clu, tuple)
+                assert len(clu) == 1
+                assert isinstance(clu[0], slice)
+            else:
+                assert isinstance(clu, np.ndarray)
+                assert clu.dtype == bool
+                assert clu.shape == shape
+            got_mask[clu] = n
+        else:
+            assert isinstance(clu, tuple)
+            for c in clu:
+                assert isinstance(c, np.ndarray)
+                assert c.dtype == int
+            assert out_type == 'indices'
+            got_mask[np.ix_(*clu)] = n
+    assert_array_equal(got_mask, want_mask)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1753,22 +1753,15 @@ docdict['clust_power_t'] = docdict['clust_power'].format('t')
 docdict['clust_power_f'] = docdict['clust_power'].format('F')
 docdict['clust_out'] = """
 out_type : 'mask' | 'indices'
-    Output format of clusters. If ``'mask'``, returns boolean arrays the same
-    shape as the input data, with ``True`` values indicating locations that are
-    part of a cluster. If ``'indices'``, returns a list of lists, where each
-    sublist contains the indices of locations that together form a cluster.
-    Note that for large datasets, ``'indices'`` may use far less memory than
-    ``'mask'``. Default is ``'indices'``.
-"""
-docdict['clust_out_none'] = """
-out_type : 'mask' | 'indices'
-    Output format of clusters. If ``'mask'``, returns boolean arrays the same
-    shape as the input data, with ``True`` values indicating locations that are
-    part of a cluster. If ``'indices'``, returns a list of lists, where each
-    sublist contains the indices of locations that together form a cluster.
-    Note that for large datasets, ``'indices'`` may use far less memory than
-    ``'mask'``. The default translates to ``'mask'`` in version 0.21 but will
-    change to ``'indices'`` in version 0.22.
+    Output format of clusters within a list.
+    If ``'mask'``, returns a list of boolean arrays,
+    each with the same shape as the input data (or slices if the shape is 1D
+    and adjacency is None), with ``True`` values indicating locations that are
+    part of a cluster. If ``'indices'``, returns a list of tuple of ndarray,
+    where each ndarray contains the indices of locations that together form the
+    given cluster along the given dimension. Note that for large datasets,
+    ``'indices'`` may use far less memory than ``'mask'``.
+    Default is ``'indices'``.
 """
 docdict['clust_disjoint'] = """
 check_disjoint : bool


### PR DESCRIPTION
Closes #8836

New output on that example is correct:
```
Running initial clustering
Found 2 clusters
Permuting 49 times...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|  : 49/49 [00:00<00:00, 6809.61it/s]
Computing cluster p-values
Done.
[(slice(2, 4, None),), (slice(46, 49, None),)]
stat_fun(H1): min=-7.417671 max=4.199342
Running initial clustering
Found 2 clusters
Permuting 49 times...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|  : 49/49 [00:00<00:00, 8677.99it/s]
Computing cluster p-values
Done.
[(array([2, 3]),), (array([46, 47, 48]),)]
```