### PR TITLE
MRG, FIX: resampling MISC channels using raw.resample

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -66,7 +66,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Fix bug with `mne.io.Raw.resample` to allow passing ``stim_picks='misc'`` (:gh:`6801` **by new contributor** |Enrico Varano|_ and `Eric Larson`_)
+- Fix bug with `mne.io.Raw.resample` to allow passing ``stim_picks='misc'`` (:gh:`8844` **by new contributor** |Enrico Varano|_ and `Eric Larson`_)
 
 - Fix bugs with `mne.io.read_raw_persyst` where multiple ``Comments`` with the same name are allowed, and ``Comments`` with a "," character are now allowed (:gh:`8311` and :gh:`8806` **by new contributor** |Andres Rodriguez|_ and `Adam Li`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -20,6 +20,8 @@ Current (0.23.dev0)
 
 .. |Matt Sanderson| replace:: **Matt Sanderson**
 
+.. |Enrico Varano| replace:: **Enrico Varano**
+
 Enhancements
 ~~~~~~~~~~~~
 - Add dbs as new channel type for deep brain stimulation (DBS) recordings (:gh:`8739` **by new contributor** |Richard Koehler|_)
@@ -64,6 +66,8 @@ Enhancements
 
 Bugs
 ~~~~
+- Fix bug with `mne.io.Raw.resample` to allow passing ``stim_picks='misc'`` (:gh:`6801` **by new contributor** |Enrico Varano|_)
+
 - Fix bugs with `mne.io.read_raw_persyst` where multiple ``Comments`` with the same name are allowed, and ``Comments`` with a "," character are now allowed (:gh:`8311` and :gh:`8806` **by new contributor** |Andres Rodriguez|_ and `Adam Li`_)
 
 - Fix zen mode and scalebar toggling for :meth:`raw.plot() <mne.io.Raw.plot>` when using the ``macosx`` matplotlib backend (:gh:`8688` by `Daniel McCloy`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -66,7 +66,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Fix bug with `mne.io.Raw.resample` to allow passing ``stim_picks='misc'`` (:gh:`6801` **by new contributor** |Enrico Varano|_)
+- Fix bug with `mne.io.Raw.resample` to allow passing ``stim_picks='misc'`` (:gh:`6801` **by new contributor** |Enrico Varano|_ and `Eric Larson`_)
 
 - Fix bugs with `mne.io.read_raw_persyst` where multiple ``Comments`` with the same name are allowed, and ``Comments`` with a "," character are now allowed (:gh:`8311` and :gh:`8806` **by new contributor** |Andres Rodriguez|_ and `Adam Li`_)
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -355,3 +355,5 @@
 .. _Tristan Stenner: https://github.com/tstenner/
 
 .. _Andres Rodriguez: https://github.com/infinitejest/
+
+.. _Enrico Varano: https://github.com/enricovara/

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1152,6 +1152,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         if stim_picks is None:
             stim_picks = pick_types(self.info, meg=False, ref_meg=False,
                                     stim=True, exclude=[])
+        else:
+            stim_picks = _picks_to_idx(self.info, stim_picks, exclude=(), with_ref_meg=False)
+            
         stim_picks = np.asanyarray(stim_picks)
 
         kwargs = dict(up=sfreq, down=o_sfreq, npad=npad, window=window,

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1153,8 +1153,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             stim_picks = pick_types(self.info, meg=False, ref_meg=False,
                                     stim=True, exclude=[])
         else:
-            stim_picks = _picks_to_idx(self.info, stim_picks, exclude=(), with_ref_meg=False)
-            
+            stim_picks = _picks_to_idx(self.info, stim_picks, exclude=(),
+                                       with_ref_meg=False)
+
         stim_picks = np.asanyarray(stim_picks)
 
         kwargs = dict(up=sfreq, down=o_sfreq, npad=npad, window=window,

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1156,8 +1156,6 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             stim_picks = _picks_to_idx(self.info, stim_picks, exclude=(),
                                        with_ref_meg=False)
 
-        stim_picks = np.asanyarray(stim_picks)
-
         kwargs = dict(up=sfreq, down=o_sfreq, npad=npad, window=window,
                       n_jobs=n_jobs, pad=pad)
         ratio, n_news = zip(*(_resamp_ratio_len(sfreq, o_sfreq, old_len)

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1201,6 +1201,14 @@ def test_resample(tmpdir, preload, n, npad):
     assert len(raw) == 10
 
 
+def test_resample_stim():
+    """Test stim_picks argument."""
+    data = np.ones((2, 1000))
+    info = create_info(2, 1000., ('eeg', 'misc'))
+    raw = RawArray(data, info)
+    raw.resample(500., stim_picks='misc')
+
+
 @testing.requires_testing_data
 def test_hilbert():
     """Test computation of analytic signal using hilbert."""


### PR DESCRIPTION
Fixes an issue related to #6801 in `raw.resample`.

### Issue Description
Resampling MISC channels using `raw.resample` (mne.io.Raw.resample) by passing `stim_picks='misc'`, `stim_picks=None` or `stim_picks=stim_ch_name` was not possible.

### Examples
Using:
`raw_data.resample(Fs, npad='auto', window='boxcar', stim_picks='misc', n_jobs=1, events=None, pad='reflect_limited')`
yields an error:
> File "", line 24, in resample
> File "{envpath}/lib/python3.8/site-packages/mne/io/base.py", line 1166, in resample
> if len(stim_picks) > 0:
> TypeError: len() of unsized object

Using `stim_picks=ch_names` where ch_names is a list containing the misc channel names doesn't work either:
`raw_data.resample(Fs, npad='auto', window='boxcar', stim_picks=ch_names, n_jobs=1, events=None, pad='reflect_limited')`
yields:
> File "", line 24, in resample
> File "{envpath}/lib/python3.8/site-packages/mne/io/base.py", line 1168, in resample
> data_chunk[stim_picks], n_new, data_chunk.shape[1])
> IndexError: arrays used as indices must be of integer (or boolean) type

Using `stim_picks=None` called
`stim_picks = pick_types(self.info, meg=False, ref_meg=False, stim=True, exclude=[])`
behind the scenes, excluding MISC channels.

An unfriendly which required  importing `pick_types` from `mne.io.pick` was to pass `stim_picks=pick_types(raw_data.info, misc=True, exclude=[])`.

### Solution
This PR updates `mne/io/base.py` to allow flexibility for setups which record stimuli/auxiliary channels as `MISC` rather than `stim` without causing retro-compatibility issues. This also makes `raw.resample` behave consistently with other similar functions like `raw.filter`. 

### Additional information
If the `stim_picks` parameter is passed with anything but `None` it is now updated by
`stim_picks = _picks_to_idx(self.info, stim_picks, exclude=(), with_ref_meg=False)`
before it is updated by `stim_picks = np.asanyarray(stim_picks)` as before.

Another solution would have been to update `raw.resample` more aggressively by replacing the `stim_picks` parameter with a `picks` parameter that would function like the `picks` parameter in `raw.filter`. While more consistent, this would force existing users of `raw.resample` to review their code upon updating mne.