### PR TITLE
MRG, BUG: Raw.rename_channels() should update Raw._orig_units too

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -116,7 +116,7 @@ Bugs
 
 - When creating `~mne.Epochs`, we now ensure that ``reject_tmin`` and ``reject_tmax`` cannot fall outside of the epochs' time interval anymore (:gh:`8821` by `Richard Höchenberger`_)
 
-- :meth:`raw.rename_channels() <mne.Raw.rename_channels>` now also applies the new channel names to ``raw._orig_units``, if present (:gh:`8846` by `Richard Höchenberger`_)
+- :meth:`raw.rename_channels() <mne.io.Raw.rename_channels>` now also applies the new channel names to ``raw._orig_units``, if present (:gh:`8846` by `Richard Höchenberger`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -116,8 +116,6 @@ Bugs
 
 - When creating `~mne.Epochs`, we now ensure that ``reject_tmin`` and ``reject_tmax`` cannot fall outside of the epochs' time interval anymore (:gh:`8821` by `Richard Höchenberger`_)
 
-- :meth:`raw.rename_channels() <mne.io.Raw.rename_channels>` now also applies the new channel names to ``raw._orig_units``, if present (:gh:`8846` by `Richard Höchenberger`_)
-
 API changes
 ~~~~~~~~~~~
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -116,6 +116,8 @@ Bugs
 
 - When creating `~mne.Epochs`, we now ensure that ``reject_tmin`` and ``reject_tmax`` cannot fall outside of the epochs' time interval anymore (:gh:`8821` by `Richard Höchenberger`_)
 
+- :meth:`raw.rename_channels() <mne.Raw.rename_channels>` now also applies the new channel names to ``raw._orig_units``, if present (:gh:`8846` by `Richard Höchenberger`_)
+
 API changes
 ~~~~~~~~~~~
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -483,10 +483,6 @@ class SetChannelsMixin(MontageMixin):
             .. versionchanged:: 0.20
                Return the instance.
 
-            .. versionchanged:: 0.23
-               For `~mne.io.Raw` instances, ``_orig_units`` will be adjusted
-               if necessary.
-
         Notes
         -----
         .. versionadded:: 0.9.0

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -483,11 +483,33 @@ class SetChannelsMixin(MontageMixin):
             .. versionchanged:: 0.20
                Return the instance.
 
+            .. versionchanged:: 0.23
+               For `~mne.io.Raw` instances, ``_orig_units`` will be adjusted
+               if necessary.
+
         Notes
         -----
         .. versionadded:: 0.9.0
         """
+        from ..io import BaseRaw
+
+        ch_names_orig = list(self.info['ch_names'])
         rename_channels(self.info, mapping)
+
+        # Update self._orig_units for Raw
+        if isinstance(self, BaseRaw) and self._orig_units is not None:
+            if isinstance(mapping, dict):
+                new_names = [(ch_names_orig.index(ch_name), new_name)
+                             for ch_name, new_name in mapping.items()]
+            elif callable(mapping):
+                new_names = [(ci, mapping(ch_name))
+                             for ci, ch_name in enumerate(ch_names_orig)]
+
+            for c_ind, new_name in new_names:
+                old_name = ch_names_orig[c_ind]
+                self._orig_units[new_name] = self._orig_units[old_name]
+                del self._orig_units[old_name]
+
         return self
 
     @verbose

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -107,6 +107,15 @@ def test_rename_channels():
     rename_channels(info2, mapping)
     assert_array_equal(['EEG060', 'EEG060'], info2['bads'])
 
+    # test that keys in Raw._orig_units will be renamed, too
+    raw = read_raw_fif(raw_fname).crop(0, 0.1)
+    old, new = 'EEG 060', 'New'
+    raw._orig_units = {old: 'V'}
+
+    raw.rename_channels({old: new})
+    assert old not in raw._orig_units
+    assert new in raw._orig_units
+
 
 def test_set_channel_types():
     """Test set_channel_types."""


### PR DESCRIPTION
In `main`, calling `rename_channels()` on a `Raw` instance would not
adjust `Raw._orig_units`.

While you could argue that the original units were only specified for
the original channel names, I would say that this makes the units
simply useless after channels have been renamed ;) Therefore I
consider the current behavior a bug.

This PR makes it so that if `Raw._orig_units` exists, its keys are
adjusted such that they stay in sync with the new channel names.

Discovered while working on data with @MaelysSolal