### PR TITLE
MRG, MAINT: Clean up BEM surface code

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -94,6 +94,8 @@ Bugs
 
 - Fix bug with :func:`mne.stats.permutation_cluster_1samp_test` and related clustering functions when ``adjacency=None`` and ``out_type='indices'`` (:gh:`#8842` by `Eric Larson`_)
 
+- Fix bug with :func:`mne.viz.plot_alignment` where plotting a sphere model could ignore the ``brain`` argument (:gh:`8857` by `Eric Larson`_)
+- 
 - Fix bug with ``replace`` argument of :meth:`mne.Report.add_bem_to_section` and :meth:`mne.Report.add_slider_to_section` (:gh:`8723` by `Eric Larson`_)
 
 - Fix compatibility bugs with :mod:`mne_realtime` (:gh:`8845` by `Eric Larson`_)

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -8,6 +8,7 @@
 # The computations in this code were primarily derived from Matti Hämäläinen's
 # C code.
 
+from collections import OrderedDict
 from functools import partial
 import glob
 import os
@@ -27,11 +28,12 @@ from .io.tree import dir_tree_find
 from .io.open import fiff_open
 from .surface import (read_surface, write_surface, complete_surface_info,
                       _compute_nearest, _get_ico_surface, read_tri,
-                      _fast_cross_nd_sum, _get_solids)
+                      _fast_cross_nd_sum, _get_solids, _complete_sphere_surf)
 from .transforms import _ensure_trans, apply_trans, Transform
 from .utils import (verbose, logger, run_subprocess, get_subjects_dir, warn,
                     _pl, _validate_type, _TempDir, _check_freesurfer_home,
-                    _check_fname, has_nibabel, _check_option)
+                    _check_fname, has_nibabel, _check_option, path_like,
+                    _on_missing)
 from .fixes import einsum
 from .externals.h5io import write_hdf5, read_hdf5
 
@@ -176,8 +178,8 @@ def _fwd_bem_lin_pot_coeff(surfs):
         rr_ord = np.arange(nps[si_1])
         for si_2, surf2 in enumerate(surfs):
             logger.info("        %s (%d) -> %s (%d) ..." %
-                        (_surf_name[surf1['id']], nps[si_1],
-                         _surf_name[surf2['id']], nps[si_2]))
+                        (_bem_surf_name[surf1['id']], nps[si_1],
+                         _bem_surf_name[surf2['id']], nps[si_2]))
             tri_rr = surf2['rr'][surf2['tris']]
             tri_nn = surf2['tri_nn']
             tri_area = surf2['tri_area']
@@ -263,7 +265,7 @@ def _check_complete_surface(surf, copy=False, incomplete='raise', extra=''):
     if len(fewer) > 0:
         msg = ('Surface {} has topological defects: {:.0f} / {:.0f} vertices '
                'have fewer than three neighboring triangles [{}]{}'
-               .format(_surf_name[surf['id']], len(fewer), surf['ntri'],
+               .format(_bem_surf_name[surf['id']], len(fewer), surf['ntri'],
                        ', '.join(str(f) for f in fewer), extra))
         if incomplete == 'raise':
             raise RuntimeError(msg)
@@ -330,11 +332,7 @@ def make_bem_solution(surfs, verbose=None):
     .. versionadded:: 0.10.0
     """
     logger.info('Approximation method : Linear collocation\n')
-    if isinstance(surfs, str):
-        # Load the surfaces
-        logger.info('Loading surfaces...')
-        surfs = read_bem_surfaces(surfs)
-    bem = ConductorModel(is_sphere=False, surfs=surfs)
+    bem = _ensure_bem_surfaces(surfs)
     _add_gamma_multipliers(bem)
     if len(bem['surfs']) == 3:
         logger.info('Three-layer model surfaces loaded.')
@@ -420,35 +418,28 @@ def _assert_complete_surface(surf, incomplete='raise'):
     # Center of mass....
     cm = surf['rr'].mean(axis=0)
     logger.info('%s CM is %6.2f %6.2f %6.2f mm' %
-                (_surf_name[surf['id']],
+                (_bem_surf_name[surf['id']],
                  1000 * cm[0], 1000 * cm[1], 1000 * cm[2]))
     tot_angle = _get_solids(surf['rr'][surf['tris']], cm[np.newaxis, :])[0]
     prop = tot_angle / (2 * np.pi)
     if np.abs(prop - 1.0) > 1e-5:
-        msg = ('Surface %s is not complete (sum of solid angles '
-               'yielded %g, should be 1.)'
-               % (_surf_name[surf['id']], prop))
-        if incomplete == 'raise':
-            raise RuntimeError(msg)
-        else:
-            warn(msg)
-
-
-_surf_name = {
-    FIFF.FIFFV_BEM_SURF_ID_HEAD: 'outer skin ',
-    FIFF.FIFFV_BEM_SURF_ID_SKULL: 'outer skull',
-    FIFF.FIFFV_BEM_SURF_ID_BRAIN: 'inner skull',
-    FIFF.FIFFV_BEM_SURF_ID_UNKNOWN: 'unknown    ',
-}
+        msg = (f'Surface {_bem_surf_name[surf["id"]]} is not complete (sum of '
+               f'solid angles yielded {prop}, should be 1.)')
+        _on_missing(
+            incomplete, msg, name='incomplete', error_klass=RuntimeError)
 
 
 def _assert_inside(fro, to):
     """Check one set of points is inside a surface."""
     # this is "is_inside" in surface_checks.c
+    fro_name = _bem_surf_name[fro["id"]]
+    to_name = _bem_surf_name[to["id"]]
+    logger.info(
+        f'Checking that surface {fro_name} is inside surface {to_name} ...')
     tot_angle = _get_solids(to['rr'][to['tris']], fro['rr'])
     if (np.abs(tot_angle / (2 * np.pi) - 1.0) > 1e-5).any():
-        raise RuntimeError('Surface %s is not completely inside surface %s'
-                           % (_surf_name[fro['id']], _surf_name[to['id']]))
+        raise RuntimeError(
+            f'Surface {fro_name} is not completely inside surface {to_name}')
 
 
 def _check_surfaces(surfs, incomplete='raise'):
@@ -457,8 +448,6 @@ def _check_surfaces(surfs, incomplete='raise'):
         _assert_complete_surface(surf, incomplete=incomplete)
     # Then check the topology
     for surf_1, surf_2 in zip(surfs[:-1], surfs[1:]):
-        logger.info('Checking that %s surface is inside %s surface...' %
-                    (_surf_name[surf_2['id']], _surf_name[surf_1['id']]))
         _assert_inside(surf_2, surf_1)
 
 
@@ -466,10 +455,10 @@ def _check_surface_size(surf):
     """Check that the coordinate limits are reasonable."""
     sizes = surf['rr'].max(axis=0) - surf['rr'].min(axis=0)
     if (sizes < 0.05).any():
-        raise RuntimeError('Dimensions of the surface %s seem too small '
-                           '(%9.5f mm). Maybe the the unit of measure is '
-                           'meters instead of mm' %
-                           (_surf_name[surf['id']], 1000 * sizes.min()))
+        raise RuntimeError(
+            f'Dimensions of the surface {_bem_surf_name[surf["id"]]} seem too '
+            f'small ({1000 * sizes.min():9.5f}). Maybe the the unit of measure'
+            ' is meters instead of mm')
 
 
 def _check_thicknesses(surfs):
@@ -478,12 +467,11 @@ def _check_thicknesses(surfs):
         min_dist = _compute_nearest(surf_1['rr'], surf_2['rr'],
                                     return_dists=True)[1]
         min_dist = min_dist.min()
-        logger.info('Checking distance between %s and %s surfaces...' %
-                    (_surf_name[surf_1['id']], _surf_name[surf_2['id']]))
-        logger.info('Minimum distance between the %s and %s surfaces is '
-                    'approximately %6.1f mm' %
-                    (_surf_name[surf_1['id']], _surf_name[surf_2['id']],
-                     1000 * min_dist))
+        fro = _bem_surf_name[surf_1['id']]
+        to = _bem_surf_name[surf_2['id']]
+        logger.info(f'Checking distance between {fro} and {to} surfaces...')
+        logger.info(f'Minimum distance between the {fro} and {to} surfaces is '
+                    f'approximately {1000 * min_dist:6.1f} mm')
 
 
 def _surfaces_to_bem(surfs, ids, sigmas, ico=None, rescale=True,
@@ -1503,22 +1491,56 @@ def _add_gamma_multipliers(bem):
                     (sigma[1:] + sigma[:-1])[:, np.newaxis])
 
 
-_surf_dict = {'inner_skull': FIFF.FIFFV_BEM_SURF_ID_BRAIN,
-              'outer_skull': FIFF.FIFFV_BEM_SURF_ID_SKULL,
-              'head': FIFF.FIFFV_BEM_SURF_ID_HEAD}
+# In our BEM code we do not model the CSF so we assign the innermost surface
+# the id BRAIN. Our 4-layer sphere we model CSF (at least by default), so when
+# searching for and referring to surfaces we need to keep track of this.
+_sm_surf_dict = OrderedDict([
+    ('brain', FIFF.FIFFV_BEM_SURF_ID_BRAIN),
+    ('inner_skull', FIFF.FIFFV_BEM_SURF_ID_CSF),
+    ('outer_skull', FIFF.FIFFV_BEM_SURF_ID_SKULL),
+    ('head', FIFF.FIFFV_BEM_SURF_ID_HEAD),
+])
+_bem_surf_dict = {
+    'inner_skull': FIFF.FIFFV_BEM_SURF_ID_BRAIN,
+    'outer_skull': FIFF.FIFFV_BEM_SURF_ID_SKULL,
+    'head': FIFF.FIFFV_BEM_SURF_ID_HEAD,
+}
+_bem_surf_name = {
+    FIFF.FIFFV_BEM_SURF_ID_BRAIN: 'inner skull',
+    FIFF.FIFFV_BEM_SURF_ID_SKULL: 'outer skull',
+    FIFF.FIFFV_BEM_SURF_ID_HEAD: 'outer skin ',
+    FIFF.FIFFV_BEM_SURF_ID_UNKNOWN: 'unknown    ',
+}
+_sm_surf_name = {
+    FIFF.FIFFV_BEM_SURF_ID_BRAIN: 'brain',
+    FIFF.FIFFV_BEM_SURF_ID_CSF: 'csf',
+    FIFF.FIFFV_BEM_SURF_ID_SKULL: 'outer skull',
+    FIFF.FIFFV_BEM_SURF_ID_HEAD: 'outer skin ',
+    FIFF.FIFFV_BEM_SURF_ID_UNKNOWN: 'unknown    ',
+}
 
 
 def _bem_find_surface(bem, id_):
-    """Find surface from already-loaded BEM."""
+    """Find surface from already-loaded conductor model."""
+    if bem['is_sphere']:
+        _surf_dict = _sm_surf_dict
+        _name_dict = _sm_surf_name
+        kind = 'Sphere model'
+        tri = 'boundary'
+    else:
+        _surf_dict = _bem_surf_dict
+        _name_dict = _bem_surf_name
+        kind = 'BEM'
+        tri = 'triangulation'
     if isinstance(id_, str):
         name = id_
         id_ = _surf_dict[id_]
     else:
-        name = _surf_name[id_]
+        name = _name_dict[id_]
+    kind = 'Sphere model' if bem['is_sphere'] else 'BEM'
     idx = np.where(np.array([s['id'] for s in bem['surfs']]) == id_)[0]
     if len(idx) != 1:
-        raise RuntimeError('BEM model does not have the %s triangulation'
-                           % name.replace('_', ' '))
+        raise RuntimeError(f'{kind} does not have the {name} {tri}')
     return bem['surfs'][idx[0]]
 
 
@@ -2014,3 +2036,33 @@ def _symlink(src, dest, copy=False):
             copy = True
     if copy:
         shutil.copy(src, dest)
+
+
+def _ensure_bem_surfaces(bem, extra_allow=(), name='bem'):
+    # by default only allow path-like and list, but handle None and
+    # ConductorModel properly if need be. Always return a ConductorModel
+    # even though it's incomplete (and might have is_sphere=True).
+    assert all(extra in (None, ConductorModel) for extra in extra_allow)
+    allowed = ('path-like', list) + extra_allow
+    _validate_type(bem, allowed, name)
+    if isinstance(bem, path_like):
+        # Load the surfaces
+        logger.info(f'Loading BEM surfaces from {str(bem)}...')
+        bem = read_bem_surfaces(bem)
+        bem = ConductorModel(is_sphere=False, surfs=bem)
+    elif isinstance(bem, list):
+        for ii, this_surf in enumerate(bem):
+            _validate_type(this_surf, dict, f'{name}[{ii}]')
+    if isinstance(bem, list):
+        bem = ConductorModel(is_sphere=False, surfs=bem)
+    # add surfaces in the spherical case
+    if isinstance(bem, ConductorModel) and bem['is_sphere']:
+        bem = bem.copy()
+        bem['surfs'] = []
+        if len(bem['layers']) == 4:
+            for idx, id_ in enumerate(_sm_surf_dict.values()):
+                bem['surfs'].append(_complete_sphere_surf(
+                    bem, idx, 4, complete=False))
+                bem['surfs'][-1]['id'] = id_
+
+    return bem

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -457,7 +457,7 @@ def _check_surface_size(surf):
     if (sizes < 0.05).any():
         raise RuntimeError(
             f'Dimensions of the surface {_bem_surf_name[surf["id"]]} seem too '
-            f'small ({1000 * sizes.min():9.5f}). Maybe the the unit of measure'
+            f'small ({1000 * sizes.min():9.5f}). Maybe the unit of measure'
             ' is meters instead of mm')
 
 

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -28,7 +28,7 @@ from .forward._compute_forward import (_compute_forwards_meeg,
 
 from .surface import (transform_surface_to, _compute_nearest,
                       _points_outside_surface)
-from .bem import _bem_find_surface, _surf_name
+from .bem import _bem_find_surface, _bem_surf_name
 from .source_space import _make_volume_source_space, SourceSpaces
 from .parallel import parallel_func
 from .utils import (logger, verbose, _time_mask, warn, _check_fname,
@@ -729,7 +729,7 @@ def _make_guesses(surf, grid, exclude, mindist, n_jobs=1, verbose=None):
     """Make a guess space inside a sphere or BEM surface."""
     if 'rr' in surf:
         logger.info('Guess surface (%s) is in %s coordinates'
-                    % (_surf_name[surf['id']],
+                    % (_bem_surf_name[surf['id']],
                        _coord_frame_name(surf['coord_frame'])))
     else:
         logger.info('Making a spherical guess space with radius %7.1f mm...'

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -738,6 +738,13 @@ def read_surface(fname, read_metadata=False, return_dict=False,
     return ret
 
 
+def _read_mri_surface(fname):
+    surf = read_surface(fname, return_dict=True)[2]
+    surf['rr'] /= 1000.
+    surf.update(coord_frame=FIFF.FIFFV_COORD_MRI)
+    return surf
+
+
 def _read_wavefront_obj(fname):
     """Read a surface form a Wavefront .obj file.
 

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -102,7 +102,7 @@ def test_io_bem(tmpdir, ext):
     sol_read = read_bem_solution(temp_sol)
     _compare_bem_solutions(sol, sol_read)
     sol = read_bem_solution(fname_bem_sol_1)
-    with pytest.raises(RuntimeError, match='BEM model does not have'):
+    with pytest.raises(RuntimeError, match='BEM does not have.*triangulation'):
         _bem_find_surface(sol, 3)
 
 

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -18,7 +18,7 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_pyqt5_version, _check_sphere, _check_time_format,
                     _check_freesurfer_home, _suggest, _require_version,
                     _on_missing, _check_on_missing, int_like, _safe_input,
-                    _check_all_same_channel_names)
+                    _check_all_same_channel_names, path_like)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -323,6 +323,7 @@ class _IntLike(object):
 
 
 int_like = _IntLike()
+path_like = (str, Path)
 
 
 class _Callable(object):
@@ -334,7 +335,7 @@ class _Callable(object):
 _multi = {
     'str': (str,),
     'numeric': (np.floating, float, int_like),
-    'path-like': (str, Path),
+    'path-like': path_like,
     'int-like': (int_like,),
     'callable': (_Callable(),),
 }
@@ -348,6 +349,7 @@ except AttributeError:  # only on 3.6+
         pass
     else:
         _multi['path-like'] += (PathBase,)
+
 
 
 def _validate_type(item, types=None, item_name=None, type_name=None):
@@ -711,7 +713,7 @@ def _check_on_missing(on_missing, name='on_missing'):
     _check_option(name, on_missing, ['raise', 'warn', 'ignore'])
 
 
-def _on_missing(on_missing, msg, name='on_missing'):
+def _on_missing(on_missing, msg, name='on_missing', error_klass=None):
     """Raise error or print warning with a message.
 
     Parameters
@@ -730,10 +732,11 @@ def _on_missing(on_missing, msg, name='on_missing'):
         When on_missing is 'raise'.
     """
     _check_on_missing(on_missing, name)
+    error_klass = ValueError if error_klass is None else error_klass
     on_missing = 'raise' if on_missing == 'error' else on_missing
     on_missing = 'warn' if on_missing == 'warning' else on_missing
     if on_missing == 'raise':
-        raise ValueError(msg)
+        raise error_klass(msg)
     elif on_missing == 'warn':
         warn(msg)
     else:  # Ignore

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -351,7 +351,6 @@ except AttributeError:  # only on 3.6+
         _multi['path-like'] += (PathBase,)
 
 
-
 def _validate_type(item, types=None, item_name=None, type_name=None):
     """Validate that `item` is an instance of `types`.
 
@@ -714,23 +713,6 @@ def _check_on_missing(on_missing, name='on_missing'):
 
 
 def _on_missing(on_missing, msg, name='on_missing', error_klass=None):
-    """Raise error or print warning with a message.
-
-    Parameters
-    ----------
-    on_missing : 'raise' | 'warn' | 'ignore'
-        Whether to raise an error, print a warning or ignore. Valid keys are
-        'raise' | 'warn' | 'ignore'. Default is 'raise'. If on_missing is
-        'warn' it will proceed but warn, if 'ignore' it will proceed silently.
-    msg : str
-        Message to print along with the error or the warning. Ignore if
-        on_missing is 'ignore'.
-
-    Raises
-    ------
-    ValueError
-        When on_missing is 'raise'.
-    """
     _check_on_missing(on_missing, name)
     error_klass = ValueError if error_klass is None else error_klass
     on_missing = 'raise' if on_missing == 'error' else on_missing

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -282,10 +282,15 @@ def test_plot_alignment(tmpdir, renderer):
                    src=src, dig=True, surfaces=['brain', 'inner_skull',
                                                 'outer_skull', 'outer_skin'])
     sphere = make_sphere_model('auto', None, evoked.info)  # one layer
+    # if you ask for a brain surface with a 1-layer sphere model it's an error
+    with pytest.raises(RuntimeError, match='Sphere model does not have'):
+        fig = plot_alignment(subject='sample', subjects_dir=subjects_dir,
+                             surfaces=['brain'], bem=sphere)
+    # but you can ask for a specific brain surface, and
     # no info is permitted
     fig = plot_alignment(trans=trans_fname, subject='sample', meg=False,
                          coord_frame='mri', subjects_dir=subjects_dir,
-                         surfaces=['brain'], bem=sphere, show_axes=True)
+                         surfaces=['white'], bem=sphere, show_axes=True)
     renderer.backend._close_all()
     if renderer._get_3d_backend() == 'mayavi':
         import mayavi  # noqa: F401 analysis:ignore
@@ -303,7 +308,7 @@ def test_plot_alignment(tmpdir, renderer):
         plot_alignment(info_cube, meg='sensors', surfaces=(), dig=True)
 
     # one layer bem with skull surfaces:
-    with pytest.raises(ValueError, match='sphere conductor model must have'):
+    with pytest.raises(RuntimeError, match='Sphere model does not.*boundary'):
         plot_alignment(info=info, trans=trans_fname,
                        subject='sample', subjects_dir=subjects_dir,
                        surfaces=['brain', 'head', 'inner_skull'], bem=sphere)
@@ -320,7 +325,7 @@ def test_plot_alignment(tmpdir, renderer):
         plot_alignment(info=info, trans=trans_fname,
                        subject='sample', subjects_dir=subjects_dir,
                        surfaces=['white', 'pial'])
-    with pytest.raises(TypeError, match='all entries in surfaces must be'):
+    with pytest.raises(TypeError, match='surfaces.*must be'):
         plot_alignment(info=info, trans=trans_fname,
                        subject='sample', subjects_dir=subjects_dir,
                        surfaces=[1])

--- a/tutorials/sample-datasets/plot_brainstorm_phantom_elekta.py
+++ b/tutorials/sample-datasets/plot_brainstorm_phantom_elekta.py
@@ -87,7 +87,7 @@ epochs['1'].average().plot(time_unit='s')
 sphere = mne.make_sphere_model(r0=(0., 0., 0.), head_radius=0.08)
 
 mne.viz.plot_alignment(epochs.info, subject=subject, show_axes=True,
-                       bem=sphere, dig=True, surfaces='inner_skull')
+                       bem=sphere, dig=True, surfaces='head')
 
 ###############################################################################
 # Let's do some dipole fits. We first compute the noise covariance,

--- a/tutorials/source-modeling/plot_source_alignment.py
+++ b/tutorials/source-modeling/plot_source_alignment.py
@@ -343,7 +343,8 @@ sphere = mne.make_sphere_model(info=raw.info, r0='auto', head_radius='auto')
 src = mne.setup_volume_source_space(sphere=sphere, pos=10.)
 mne.viz.plot_alignment(
     raw.info, eeg='projected', bem=sphere, src=src, dig=True,
-    surfaces=['brain', 'outer_skin'], coord_frame='meg', show_axes=True)
+    surfaces=['brain', 'inner_skull', 'outer_skull', 'outer_skin'],
+    coord_frame='meg', show_axes=True)
 
 ###############################################################################
 # It is also possible to use :func:`mne.gui.coregistration`


### PR DESCRIPTION
In preparation for writing some BEM quality code, I wanted to have an `_ensure_bem_surfaces` function. This should simplify our handling of BEM surfaces, and in the process simplified `plot_alignment` by populating the `'surfs'` entry of the spherical ConductorModel dict. This ended up being a bugfix where on `main` you could do `plot_alignment(..., bem=sphere, surfaces='brain')` and have no surfaces show up if you had a 1-layer sphere model. This now raises an error because it seems like a user mistake. In the case where someone wants a FreeSurfer brain surface they can do `surfaces='pial'` explicitly if they want, but I assume this use case is rare.