### PR TITLE
MRG: Change resp channel unit to Volts

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -72,6 +72,8 @@ Enhancements
 
 - Add :func:`mne.write_head_bem` to support writing head surface files (:gh:`8841` by `Yu-Han Luo`_)
 
+- The signal of ``resp`` (respiratory) channels is now assumed to be in the unit Volt  (:gh:`8858` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 - Fix bug with `mne.connectivity.spectral_connectivity` where time axis in Epochs data object was dropped. (:gh:`8839` **by new contributor** |Anna Padee|_)

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -132,7 +132,7 @@ def test_set_channel_types():
     # Test changing type if in proj
     mapping = {'EEG 057': 'dbs', 'EEG 058': 'ecog', 'EEG 059': 'ecg',
                'EEG 060': 'eog', 'EOG 061': 'seeg', 'MEG 2441': 'eeg',
-               'MEG 2443': 'eeg', 'MEG 2442': 'hbo'}
+               'MEG 2443': 'eeg', 'MEG 2442': 'hbo', 'EEG 001': 'resp'}
     raw2 = read_raw_fif(raw_fname)
     raw2.info['bads'] = ['EEG 059', 'EEG 060', 'EOG 061']
     with pytest.raises(RuntimeError, match='type .* in projector "PCA-v1"'):
@@ -169,6 +169,12 @@ def test_set_channel_types():
     assert info['chs'][idx]['kind'] == FIFF.FIFFV_FNIRS_CH
     assert info['chs'][idx]['unit'] == FIFF.FIFF_UNIT_MOL
     assert info['chs'][idx]['coil_type'] == FIFF.FIFFV_COIL_FNIRS_HBO
+
+    # resp channel type
+    idx = pick_channels(raw.ch_names, ['EEG 001'])[0]
+    assert info['chs'][idx]['kind'] == FIFF.FIFFV_RESP_CH
+    assert info['chs'][idx]['unit'] == FIFF.FIFF_UNIT_V
+    assert info['chs'][idx]['coil_type'] == FIFF.FIFFV_COIL_NONE
 
     # Test meaningful error when setting channel type with unknown unit
     raw.info['chs'][0]['unit'] = 0.

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -58,10 +58,10 @@ def get_channel_type_constants(include_defaults=False):
                 eog=dict(kind=FIFF.FIFFV_EOG_CH, unit=FIFF.FIFF_UNIT_V),
                 emg=dict(kind=FIFF.FIFFV_EMG_CH, unit=FIFF.FIFF_UNIT_V),
                 ecg=dict(kind=FIFF.FIFFV_ECG_CH, unit=FIFF.FIFF_UNIT_V),
+                resp=dict(kind=FIFF.FIFFV_RESP_CH, unit=FIFF.FIFF_UNIT_V),
                 bio=dict(kind=FIFF.FIFFV_BIO_CH, unit=FIFF.FIFF_UNIT_V),
                 misc=dict(kind=FIFF.FIFFV_MISC_CH, unit=FIFF.FIFF_UNIT_V),
                 stim=dict(kind=FIFF.FIFFV_STIM_CH),
-                resp=dict(kind=FIFF.FIFFV_RESP_CH),
                 exci=dict(kind=FIFF.FIFFV_EXCI_CH),
                 syst=dict(kind=FIFF.FIFFV_SYST_CH),
                 ias=dict(kind=FIFF.FIFFV_IAS_CH),
@@ -971,12 +971,12 @@ _MEG_CH_TYPES_SPLIT = ('mag', 'grad', 'planar1', 'planar2')
 _FNIRS_CH_TYPES_SPLIT = ('hbo', 'hbr', 'fnirs_cw_amplitude',
                          'fnirs_fd_ac_amplitude', 'fnirs_fd_phase', 'fnirs_od')
 _DATA_CH_TYPES_ORDER_DEFAULT = (
-    'mag', 'grad', 'eeg', 'csd', 'eog', 'ecg', 'emg', 'ref_meg', 'misc',
-    'stim', 'resp', 'chpi', 'exci', 'ias', 'syst', 'seeg', 'bio', 'ecog',
+    'mag', 'grad', 'eeg', 'csd', 'eog', 'ecg', 'resp', 'emg', 'ref_meg',
+    'misc', 'stim', 'chpi', 'exci', 'ias', 'syst', 'seeg', 'bio', 'ecog',
     'dbs') + _FNIRS_CH_TYPES_SPLIT + ('whitened',)
 # Valid data types, ordered for consistency, used in viz/evoked.
 _VALID_CHANNEL_TYPES = (
-    'eeg', 'grad', 'mag', 'seeg', 'eog', 'ecg', 'emg', 'dipole', 'gof',
+    'eeg', 'grad', 'mag', 'seeg', 'eog', 'ecg', 'resp', 'emg', 'dipole', 'gof',
     'bio', 'ecog', 'dbs') + _FNIRS_CH_TYPES_SPLIT + ('misc', 'csd')
 _DATA_CH_TYPES_SPLIT = (
     'mag', 'grad', 'eeg', 'csd', 'seeg', 'ecog', 'dbs') + _FNIRS_CH_TYPES_SPLIT

--- a/tutorials/sample-datasets/plot_sleep.py
+++ b/tutorials/sample-datasets/plot_sleep.py
@@ -78,8 +78,8 @@ ALICE, BOB = 0, 1
 [alice_files, bob_files] = fetch_data(subjects=[ALICE, BOB], recording=[1])
 
 mapping = {'EOG horizontal': 'eog',
-           'Resp oro-nasal': 'misc',
-           'EMG submental': 'misc',
+           'Resp oro-nasal': 'resp',
+           'EMG submental': 'emg',
            'Temp rectal': 'misc',
            'Event marker': 'misc'}
 
@@ -90,7 +90,11 @@ raw_train.set_annotations(annot_train, emit_warning=False)
 raw_train.set_channel_types(mapping)
 
 # plot some data
-raw_train.plot(duration=60, scalings='auto')
+# scalings were chosen manually to allow for simultaneous visualization of
+# different channel types in this specific dataset
+raw_train.plot(start=60, duration=60,
+               scalings=dict(eeg=1e-4, resp=1e3, eog=1e-4, emg=1e-7,
+                             misc=1e-1))
 
 ##############################################################################
 # Extract 30s events from annotations


### PR DESCRIPTION
Respiratory channels contain an analog signal, monitoring the expansion of a chest strap / belt.
The signal is measured in Volts.

Scaling factors (µV, mV, V) depend on the specific amplifier system used, so we cannot provide a
sophisticated default scaling (and leave it at 1).

cc @MaelysSolal, @agramfort