### PR TITLE
MRG, BUG: Fix handling of times

### DIFF
--- a/examples/connectivity/plot_mne_inverse_psi_visual.py
+++ b/examples/connectivity/plot_mne_inverse_psi_visual.py
@@ -91,7 +91,7 @@ fmax = 20.
 tmin_con = 0.
 sfreq = epochs.info['sfreq']  # the sampling frequency
 
-psi, freqs, times, n_epochs, _ = phase_slope_index(
+psi, _, _, _, _ = phase_slope_index(
     comb_ts, mode='multitaper', indices=indices, sfreq=sfreq,
     fmin=fmin, fmax=fmax, tmin=tmin_con)
 

--- a/examples/connectivity/plot_sensor_connectivity.py
+++ b/examples/connectivity/plot_sensor_connectivity.py
@@ -13,7 +13,6 @@ are used which produces strong connectvitiy in the right occipital sensors.
 # License: BSD (3-clause)
 
 import mne
-from mne import io
 from mne.connectivity import spectral_connectivity
 from mne.datasets import sample
 from mne.viz import plot_sensors_connectivity
@@ -27,7 +26,7 @@ raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
 
 # Setup for reading the raw data
-raw = io.read_raw_fif(raw_fname)
+raw = mne.io.read_raw_fif(raw_fname)
 events = mne.read_events(event_fname)
 
 # Add a bad channel
@@ -44,7 +43,7 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax, picks=picks,
 
 # Compute connectivity for band containing the evoked response.
 # We exclude the baseline period
-fmin, fmax = 3., 9.
+fmin, fmax = 4., 9.
 sfreq = raw.info['sfreq']  # the sampling frequency
 tmin = 0.0  # exclude the baseline period
 epochs.load_data().pick_types(meg='grad')  # just keep MEG and no EOG now

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -354,9 +354,12 @@ def warn(message, category=RuntimeWarning, module='mne'):
             globals().get('__warningregistry__', {}))
     # To avoid a duplicate warning print, we only emit the logger.warning if
     # one of the handlers is a FileHandler. See gh-5592
+    # But it's also nice to be able to do:
+    # with mne.utils.use_log_level('warning', add_frames=3):
+    # so also check our add_frames attribute.
     if any(isinstance(h, logging.FileHandler) or getattr(h, '_mne_file_like',
                                                          False)
-           for h in logger.handlers):
+           for h in logger.handlers) or _filter.add_frames:
         logger.warning(message)
 
 


### PR DESCRIPTION
Follow-up to #8839 to fix CircleCI failures

- We need to be careful about inferring times in `spectral_connectivity` because data can for example arrive in `(ndarray, SourceEstimate)` pairs and in that case we should get the times from the SourceEstimate, not the ndarray.
- if there is a mismatch, we really only need to warn about it once, not on every epoch.
- if there is a mismatch, print at least some of the arrays so that users can see the mismatch.
- when using `mne.use_log_level('warn', add_frames=3):` actually have the frames printed so you can get an output that allows you to track the lines like:
```
/home/larsoner/python/mne-python/examples/connectivity/plot_mne_inverse_psi_visual.py:95: RuntimeWarning: time scales of input time series do not match
  psi, freqs, times, n_epochs, _ = phase_slope_index(
┌connectivity.spectral:794
├connectivity.spectral:952
├connectivity.spectral:499
└utils._logging:360 :           time scales of input time series do not match
/home/larsoner/python/mne-python/examples/connectivity/plot_mne_inverse_psi_visual.py:95: RuntimeWarning: time scales of input time series do not match
  psi, freqs, times, n_epochs, _ = phase_slope_index(
┌connectivity.effective:115
├connectivity.spectral:835
├connectivity.spectral:499
└utils._logging:360 :           time scales of input time series do not match
```
- no need for latest.inc update as it's a within-cycle bugfix