### PR TITLE
WIP, ENH: Make "verbose" decorator provide help for static type checkers like Pylance

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -74,6 +74,8 @@ Enhancements
 
 - The signal of ``resp`` (respiratory) channels is now assumed to be in the unit Volt  (:gh:`8858` by `Richard Höchenberger`_)
 
+- Static type checkers like Pylance (comes with VS Code) now display the parameters of many more functions correctly, largely improving overall usability for VS Code users (:gh:`8862` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 - Fix bug with `mne.connectivity.spectral_connectivity` where time axis in Epochs data object was dropped. (:gh:`8839` **by new contributor** |Anna Padee|_)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -689,6 +689,8 @@ numpydoc_xref_ignore = {
     # unlinkable
     'mayavi.mlab.pipeline.surface',
     'CoregFrame', 'Kit2FiffFrame', 'FiducialsFrame',
+    # type hint used in @verbose decorator
+    '_FuncT',
 }
 numpydoc_validate = True
 numpydoc_validation_checks = {'all'} | set(error_ignores)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -123,6 +123,7 @@ nitpick_ignore = [
     ("py:class", "an object providing a view on D's values"),
     ("py:class", "a shallow copy of D"),
     ("py:class", "(k, v), remove and return some (key, value) pair as a"),
+    ("py:class", "_FuncT"),  # type hint used in @verbose decorator
 ]
 for key in ('AcqParserFIF', 'BiHemiLabel', 'Dipole', 'DipoleFixed', 'Label',
             'MixedSourceEstimate', 'MixedVectorSourceEstimate', 'Report',
@@ -689,8 +690,6 @@ numpydoc_xref_ignore = {
     # unlinkable
     'mayavi.mlab.pipeline.surface',
     'CoregFrame', 'Kit2FiffFrame', 'FiducialsFrame',
-    # type hint used in @verbose decorator
-    '_FuncT',
 }
 numpydoc_validate = True
 numpydoc_validation_checks = {'all'} | set(error_ignores)

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -12,6 +12,7 @@ import sys
 import logging
 import os.path as op
 import warnings
+from typing import Any, Callable, TypeVar
 
 from .docs import fill_doc
 from ..externals.decorator import FunctionMaker
@@ -49,7 +50,13 @@ _filter = _FrameFilter()
 logger.addFilter(_filter)
 
 
-def verbose(function):
+# Provide help for static type checkers: see
+# https://github.com/microsoft/pyright/blob/8ca2c14a7a71a5f19db2082ecb531cb0f76b484d/docs/type-stubs.md#cleaning-up-generated-type-stubs  # noqa
+# point 3
+_FuncT = TypeVar('_FuncT', bound=Callable[..., Any])
+
+
+def verbose(function) -> Callable[[_FuncT], _FuncT]:
     """Verbose decorator to allow functions to override log-level.
 
     Parameters

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -50,13 +50,12 @@ _filter = _FrameFilter()
 logger.addFilter(_filter)
 
 
-# Provide help for static type checkers: see
-# https://github.com/microsoft/pyright/blob/8ca2c14a7a71a5f19db2082ecb531cb0f76b484d/docs/type-stubs.md#cleaning-up-generated-type-stubs  # noqa
-# point 3
+# Provide help for static type checkers:
+# https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
 _FuncT = TypeVar('_FuncT', bound=Callable[..., Any])
 
 
-def verbose(function) -> Callable[[_FuncT], _FuncT]:
+def verbose(function: _FuncT) -> _FuncT:
     """Verbose decorator to allow functions to override log-level.
 
     Parameters


### PR DESCRIPTION
The `@verbose` decorator used to "eat up" the parameters of the decorated
functions, leading to an awfully useless experience with Pylance in VS Code.

Thanks to @cbrnr's persitence, a Pylance dev pointed us to the correct
solution, which is implemented in this PR:
See https://github.com/microsoft/pylance-release/issues/346#issuecomment-777490280 

### `main`:
<img width="788" alt="Screen Shot 2021-02-11 at 19 49 42" src="https://user-images.githubusercontent.com/2046265/107684770-772f7500-6ca3-11eb-8adc-ecb3c7791028.png">

### this PR:
<img width="825" alt="Screen Shot 2021-02-11 at 19 49 23" src="https://user-images.githubusercontent.com/2046265/107684795-7f87b000-6ca3-11eb-8e93-7940ba446ade.png">

