### PR TITLE
MRG, BUG: Fix verbose

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -96,6 +96,8 @@ Bugs
 
 - Fix bug with :meth:`raw.plot() <mne.io.Raw.plot>` where ``scalings='auto'`` did not compute scalings using the full range of data (:gh:`8806` by `Eric Larson`_)
 
+- Fix bug with :meth:`mne.io.Raw.load_data` and :meth:`mne.Epochs.drop_bad` where ``verbose`` logging was not handled properly (:gh:`8884` by `Eric Larson`_)
+
 - Fix bug with :func:`mne.io.read_raw_nicolet` where header type values such as num_sample and duration_in_sec where not parsed properly (:gh:`8712` by `Alex Gramfort`_)
 
 - Fix bug with :func:`mne.preprocessing.read_ica_eeglab` when reading decompositions using PCA dimensionality reduction (:gh:`8780` by `Alex Gramfort`_ and `Eric Larson`_)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -804,7 +804,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                 reject_imax = idxs[-1]
             self._reject_time = slice(reject_imin, reject_imax)
 
-    @verbose
+    @verbose  # verbose is used by mne-realtime
     def _is_good_epoch(self, data, verbose=None):
         """Determine if epoch is good."""
         if isinstance(data, str):
@@ -1220,7 +1220,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                rej in (reject, flat)):
             raise ValueError('reject and flat, if strings, must be "existing"')
         self._reject_setup(reject, flat)
-        self._get_data(out=False)
+        self._get_data(out=False, verbose=verbose)
         return self
 
     def drop_log_stats(self, ignore=('IGNORED',)):
@@ -1414,7 +1414,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                     epoch = self._project_epoch(epoch_noproj)
 
                 epoch_out = epoch_noproj if self._do_delayed_proj else epoch
-                is_good, bad_tuple = self._is_good_epoch(epoch)
+                is_good, bad_tuple = self._is_good_epoch(
+                    epoch, verbose=verbose)
                 if not is_good:
                     assert isinstance(bad_tuple, tuple)
                     assert all(isinstance(x, str) for x in bad_tuple)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -523,8 +523,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             self._preload_data(True)
         return self
 
-    @verbose
-    def _preload_data(self, preload, verbose=None):
+    def _preload_data(self, preload):
         """Actually preload the data."""
         data_buffer = preload
         if isinstance(preload, (bool, np.bool_)) and not preload:

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -771,7 +771,8 @@ def _copy_preload_add_channels(raw, add_channels, copy, info):
             raw._data = out_data
         else:
             logger.info(msg + 'loading raw data from disk')
-            raw._preload_data(out_data[:len(raw.ch_names)], verbose=False)
+            with use_log_level(False):
+                raw._preload_data(out_data[:len(raw.ch_names)])
             raw._data = out_data
         assert raw.preload is True
         off = len(raw.ch_names)

--- a/mne/utils/tests/test_logging.py
+++ b/mne/utils/tests/test_logging.py
@@ -3,15 +3,18 @@ import os.path as op
 import re
 import warnings
 
+import numpy as np
 import pytest
 
-from mne import read_evokeds
+from mne import read_evokeds, Epochs
+from mne.io import read_raw_fif
 from mne.utils import (warn, set_log_level, set_log_file, filter_out_warnings,
                        verbose, _get_call_line, use_log_level, catch_logging,
                        logger)
 from mne.utils._logging import _frame_info
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
+fname_raw = op.join(base_dir, 'test_raw.fif')
 fname_evoked = op.join(base_dir, 'test-ave.fif')
 fname_log = op.join(base_dir, 'test-ave.log')
 fname_log_2 = op.join(base_dir, 'test-ave-2.log')
@@ -139,6 +142,33 @@ def test_logging_options(tmpdir):
     assert log.getvalue() == ''
 
 
+@pytest.mark.parametrize('verbose', (True, False))
+def test_verbose_method(verbose):
+    """Test for gh-8772."""
+    # raw
+    raw = read_raw_fif(fname_raw, verbose=verbose)
+    with catch_logging() as log:
+        raw.load_data(verbose=True)
+    log = log.getvalue()
+    assert 'Reading 0 ... 14399' in log
+    with catch_logging() as log:
+        raw.load_data(verbose=False)
+    log = log.getvalue()
+    assert log == ''
+    # epochs
+    events = np.array([[raw.first_samp + 200, 0, 1]], int)
+    epochs = Epochs(raw, events, verbose=verbose)
+    with catch_logging() as log:
+        epochs.drop_bad(verbose=True)
+    log = log.getvalue()
+    assert '0 bad epochs dropped' in log
+    epochs = Epochs(raw, events, verbose=verbose)
+    with catch_logging() as log:
+        epochs.drop_bad(verbose=False)
+    log = log.getvalue()
+    assert log == ''
+
+
 def test_warn(capsys):
     """Test the smart warn() function."""
     with pytest.warns(RuntimeWarning, match='foo'):
@@ -177,11 +207,34 @@ def test_verbose_strictness():
     class Okay:
 
         @verbose
-        def meth(self):  # allowed because it should just use self.verbose
-            pass
+        def meth_1(self):  # allowed because it should just use self.verbose
+            logger.info('meth_1')
+
+        @verbose
+        def meth_2(self, verbose=None):
+            logger.info('meth_2')
 
     o = Okay()
     with pytest.raises(RuntimeError, match=r'does not have self\.verbose'):
-        o.meth()  # should raise, no verbose attr yet
-    o.verbose = None
-    o.meth()
+        o.meth_1()  # should raise, no verbose attr yet
+    o.verbose = False
+    with catch_logging() as log:
+        o.meth_1()
+        o.meth_2()
+    log = log.getvalue()
+    assert log == ''
+    with catch_logging() as log:
+        o.meth_2(verbose=True)
+    log = log.getvalue()
+    assert 'meth_2' in log
+    o.verbose = True
+    with catch_logging() as log:
+        o.meth_1()
+        o.meth_2()
+    log = log.getvalue()
+    assert 'meth_1' in log
+    assert 'meth_2' in log
+    with catch_logging() as log:
+        o.meth_2(verbose=False)
+    log = log.getvalue()
+    assert log == ''


### PR DESCRIPTION
Closes #8872

@HanBnrd can you try it with your code?

Basically the fix is that for any methods that have `verbose`, we need to propagate `verbose` to any other method calls. We don't need to do this with functions, but we do with methods since when they are called with `verbose is None` they resort to using `self.verbose`.