### PR TITLE
MRG, ENH: Don't warn on _eeg.fif and _ieeg.fif suffixes

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -78,6 +78,8 @@ Enhancements
 
 - Support new EEGLAB file format (:gh:`8874` by `Clemens Brunner`_)
 
+- Reading and writing FIFF files whose filenames end with `_meg.fif.gz`, `_eeg.fif(.gz)`, and `_ieeg.fif(.gz)` doesn't emit a warning anymore; this improves interobaility with BIDS-formatted datasets (:gh:`8868` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 - Fix bug with `mne.connectivity.spectral_connectivity` where time axis in Epochs data object was dropped. (:gh:`8839` **by new contributor** |Anna Padee|_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -78,7 +78,7 @@ Enhancements
 
 - Support new EEGLAB file format (:gh:`8874` by `Clemens Brunner`_)
 
-- Reading and writing FIFF files whose filenames end with `_meg.fif.gz`, `_eeg.fif(.gz)`, and `_ieeg.fif(.gz)` doesn't emit a warning anymore; this improves interobaility with BIDS-formatted datasets (:gh:`8868` by `Richard Höchenberger`_)
+- Reading and writing FIFF files whose filenames end with ``_meg.fif.gz``, ``_eeg.fif(.gz)``, and ``_ieeg.fif(.gz)`` doesn't emit a warning anymore; this improves interobaility with BIDS-formatted datasets (:gh:`8868` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/mne/commands/mne_report.py
+++ b/mne/commands/mne_report.py
@@ -14,7 +14,8 @@ render follow the filename conventions defined by MNE:
 ============ ==============================================================
 Data object  Filename convention (ends with)
 ============ ==============================================================
-raw          -raw.fif(.gz), -raw_sss.fif(.gz), -raw_tsss.fif(.gz), _meg.fif
+raw          -raw.fif(.gz), -raw_sss.fif(.gz), -raw_tsss.fif(.gz),
+             _meg.fif(.gz), _eeg.fif(.gz), _ieeg.fif(.gz)
 events       -eve.fif(.gz)
 epochs       -epo.fif(.gz)
 evoked       -ave.fif(.gz)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1366,7 +1366,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         endings = ('raw.fif', 'raw_sss.fif', 'raw_tsss.fif',
                    '_meg.fif', '_eeg.fif', '_ieeg.fif')
         endings += tuple([f'{e}.gz' for e in endings])
-        check_fname(fname, 'raw', tuple(endings))
+        check_fname(fname, 'raw', endings)
 
         split_size = _get_split_size(split_size)
         if not self.preload and fname in self._filenames:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1304,8 +1304,12 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         fname : str
             File name of the new dataset. This has to be a new filename
             unless data have been preloaded. Filenames should end with
-            raw.fif, raw.fif.gz, raw_sss.fif, raw_sss.fif.gz, raw_tsss.fif,
-            raw_tsss.fif.gz, or _meg.fif.
+            ``raw.fif`` (common raw data), ``raw_sss.fif``
+            (Maxwell-filtered continuous data),
+            ``raw_tsss.fif`` (temporally signal-space-separated data),
+            ``_meg.fif`` (common MEG data), ``_eeg.fif`` (common EEG data),
+            or ``_ieeg.fif`` (common intracranial EEG data). You may also
+            append an additional ``.gz`` suffix to enable gzip compression.
         %(picks_all)s
         %(raw_tmin)s
         %(raw_tmax)s
@@ -1359,9 +1363,10 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         then save raw files for this reason.
         """
         fname = op.realpath(fname)
-        check_fname(fname, 'raw', ('raw.fif', 'raw_sss.fif', 'raw_tsss.fif',
-                                   'raw.fif.gz', 'raw_sss.fif.gz',
-                                   'raw_tsss.fif.gz', '_meg.fif'))
+        endings = ('raw.fif', 'raw_sss.fif', 'raw_tsss.fif',
+                   '_meg.fif', '_eeg.fif', '_ieeg.fif')
+        endings += tuple([f'{e}.gz' for e in endings])
+        check_fname(fname, 'raw', tuple(endings))
 
         split_size = _get_split_size(split_size)
         if not self.preload and fname in self._filenames:

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -138,9 +138,10 @@ class Raw(BaseRaw):
         #   Read in the whole file if preload is on and .fif.gz (saves time)
         if not _file_like(fname):
             if do_check_fname:
-                check_fname(fname, 'raw', (
-                    'raw.fif', 'raw_sss.fif', 'raw_tsss.fif', 'raw.fif.gz',
-                    'raw_sss.fif.gz', 'raw_tsss.fif.gz', '_meg.fif'))
+                endings = ('raw.fif', 'raw_sss.fif', 'raw_tsss.fif',
+                           '_meg.fif', '_eeg.fif', '_ieeg.fif')
+                endings += tuple([f'{e}.gz' for e in endings])
+                check_fname(fname, 'raw', tuple(endings))
             # filename
             fname = op.realpath(fname)
             ext = os.path.splitext(fname)[1].lower()

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -36,10 +36,11 @@ class Raw(BaseRaw):
     ----------
     fname : str | file-like
         The raw filename to load. For files that have automatically been split,
-        the split part will be automatically loaded. Filenames should end
-        with raw.fif, raw.fif.gz, raw_sss.fif, raw_sss.fif.gz, raw_tsss.fif,
-        raw_tsss.fif.gz, or _meg.fif. If a file-like object is provided,
-        preloading must be used.
+        the split part will be automatically loaded. Filenames not ending with
+        ``raw.fif``, ``raw_sss.fif``, ``raw_tsss.fif``, ``_meg.fif``,
+        ``_eeg.fif``,  or ``_ieeg.fif`` (with or without an optional additional
+        ``.gz`` extension) will generate a warning. If a file-like object is
+        provided, preloading must be used.
 
         .. versionchanged:: 0.18
            Support for file-like objects.

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -141,7 +141,7 @@ class Raw(BaseRaw):
                 endings = ('raw.fif', 'raw_sss.fif', 'raw_tsss.fif',
                            '_meg.fif', '_eeg.fif', '_ieeg.fif')
                 endings += tuple([f'{e}.gz' for e in endings])
-                check_fname(fname, 'raw', tuple(endings))
+                check_fname(fname, 'raw', endings)
             # filename
             fname = op.realpath(fname)
             ext = os.path.splitext(fname)[1].lower()

--- a/mne/report.py
+++ b/mne/report.py
@@ -51,6 +51,7 @@ for ext in SUPPORTED_READ_RAW_EXTENSIONS:
     if ext not in ('.bdf', '.edf', '.set', '.vhdr'):  # EEG-only formats
         RAW_EXTENSIONS.append(f'meg{ext}')
     RAW_EXTENSIONS.append(f'eeg{ext}')
+    RAW_EXTENSIONS.append(f'ieeg{ext}')
 
 # Processed data will always be in (gzipped) FIFF format
 VALID_EXTENSIONS = ('sss.fif', 'sss.fif.gz',

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -59,10 +59,17 @@ def test_check(tmpdir):
     if check_version('numpy', '1.17'):
         check_random_state(np.random.default_rng(0)).choice(1)
 
-    # _meg.fif is a valid ending and should not raise an error
-    new_fname = str(
-        tmpdir.join(op.basename(fname_raw).replace('_raw.', '_meg.')))
-    shutil.copyfile(fname_raw, new_fname)
+
+@testing.requires_testing_data
+@pytest.mark.parametrize('suffix',
+                         ('_meg.fif', '_eeg.fif', '_ieeg.fif',
+                          '_meg.fif.gz', '_eeg.fif.gz', '_ieeg.fif.gz'))
+def test_check_fname_suffixes(suffix, tmpdir):
+    """Test checking for valid filename suffixes."""
+    new_fname = str(tmpdir.join(op.basename(fname_raw)
+                                .replace('_raw.fif', suffix)))
+    raw = mne.io.read_raw_fif(fname_raw).crop(0, 0.1)
+    raw.save(new_fname)
     mne.io.read_raw_fif(new_fname)
 
 

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -5,7 +5,6 @@
 # License: BSD (3-clause)
 import os
 import os.path as op
-import shutil
 import sys
 
 import numpy as np

--- a/tutorials/misc/plot_report.py
+++ b/tutorials/misc/plot_report.py
@@ -25,7 +25,8 @@ import mne
 # ============== ==============================================================
 # Data object    Filename convention (ends with)
 # ============== ==============================================================
-# raw            -raw.fif(.gz), -raw_sss.fif(.gz), -raw_tsss.fif(.gz), _meg.fif
+# raw            -raw.fif(.gz), -raw_sss.fif(.gz), -raw_tsss.fif(.gz),
+#                _meg.fif(.gz), _eeg.fif(.gz), _ieeg.fif(.gz)
 # events         -eve.fif(.gz)
 # epochs         -epo.fif(.gz)
 # evoked         -ave.fif(.gz)


### PR DESCRIPTION
When writing or loading a FIFF file with an `_meg.fif` suffix, we
don't warn. This PR adds similar behavior for the
`_eeg.fif` and `_ieeg.fif` suffixes, which are used in BIDS.

It's a tiny change, so I don't think it warrants a changelog
entry.