### PR TITLE
Test abstract BaseEpochs class

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2826,7 +2826,7 @@ class EpochsFIF(BaseEpochs):
             # we also retain original baseline without re-applying baseline
             # correction (data is being baseline-corrected when written to
             # disk)
-            epoch = BaseEpochs(
+            epoch = super().__init__(
                 info, data, events, event_id, tmin, tmax,
                 baseline=None,
                 metadata=metadata, on_missing='ignore',

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -11,6 +11,7 @@
 #
 # License: BSD (3-clause)
 
+from abc import ABC, abstractmethod
 from collections import Counter
 from copy import deepcopy
 import json
@@ -314,7 +315,7 @@ def _handle_event_repeated(events, event_id, event_repeated, selection,
 @fill_doc
 class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                  SetChannelsMixin, InterpolationMixin, FilterMixin,
-                 TimeMixin, SizeMixin, GetEpochsMixin):
+                 TimeMixin, SizeMixin, GetEpochsMixin, ABC):
     """Abstract base class for Epochs-type classes.
 
     This class provides basic functionality and should never be instantiated
@@ -384,6 +385,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
     used as a constructor for Epochs objects (use instead :class:`mne.Epochs`).
     """
 
+    @abstractmethod
     @verbose
     def __init__(self, info, data, events, event_id=None, tmin=-0.2, tmax=0.5,
                  baseline=(None, 0), raw=None, picks=None, reject=None,


### PR DESCRIPTION
Fixes #8871.

One benefit of declaring `BaseEpochs` abstract is that the following code won't work anymore:

```python
import numpy as np
import mne


fs, n_chan = 256, 4
info = mne.create_info(n_chan, fs, "eeg")
data = np.random.rand(3, n_chan, 2 * fs + 1)
events = np.array([[100, 0, 1], [1000, 0, 1], [1200, 0, 2]])
epochs = mne.BaseEpochs(info, data, events, tmin=-1, tmax=1)
```

However, we'll have to wait and see if this breaks anything.