### PR TITLE
[WIP] Adding functionality for tfr_array_stft and tfr_stft

### DIFF
--- a/mne/time_frequency/__init__.py
+++ b/mne/time_frequency/__init__.py
@@ -10,5 +10,5 @@ from .csd import (CrossSpectralDensity, csd_fourier, csd_multitaper,
 from .ar import fit_iir_model_raw
 from .multitaper import (dpss_windows, psd_array_multitaper,
                          tfr_array_multitaper)
-from ._stft import stft, istft, stftfreq
+from ._stft import stft, istft, stftfreq, tfr_stft, tfr_array_stft
 from ._stockwell import tfr_stockwell, tfr_array_stockwell

--- a/mne/time_frequency/_stft.py
+++ b/mne/time_frequency/_stft.py
@@ -1,10 +1,132 @@
 from math import ceil
+from copy import deepcopy
 import numpy as np
 
+from ..io.pick import _pick_data_channels, pick_info
 from ..fixes import _import_fft
-from ..utils import logger, verbose
+from ..utils import logger, verbose, deprecated, fill_doc, _validate_type
+from .tfr import AverageTFR, _get_data
 
 
+@fill_doc
+def tfr_stft(inst, window_size, step_size=None, average=True, verbose=None):
+    """Compute STFT Short-Term Fourier Transform using a sine window.
+
+    Same computation as `~mne.time_frequency.tfr_array_stft`, but operates
+    on `~mne.Epochs`, `~mne.Evoked` or `~mne.io.Raw` objects instead of
+    :class:`NumPy arrays <numpy.ndarray>`.
+
+    Parameters
+    ----------
+    inst : Epochs | Evoked | Raw
+        The epochs or evoked object.
+    window_size : int
+        Length of the STFT window in samples (must be a multiple of 4).
+    step_size : int
+        Step between successive windows in samples (must be a multiple of 2,
+        a divider of ``window_size`` and smaller than ``window_size``/2)
+        (default: window_size/2).
+    %(tfr_average)s
+    %(verbose)s
+
+    Returns
+    -------
+    power : AverageTFR
+        The averaged power.
+    """
+    from ..epochs import BaseEpochs
+    from .tfr import EpochsTFR
+
+    # verbose dec is used b/c subfunctions are verbose
+    data = _get_data(inst, False)
+    picks = _pick_data_channels(inst.info)
+    info = pick_info(inst.info, picks)
+    data = data[:, picks, :]
+
+    # compute STFT on the numpy array
+    power, freqs, times = tfr_array_stft(
+        data, sfreq=info['sfreq'], window_size=window_size,
+        step_size=step_size, return_times=True,
+        verbose=verbose)
+
+    if average:
+        # how many epochs are we averaging
+        nave = len(data)
+        out = AverageTFR(info, power, times, freqs, nave, method='stft-power')
+    else:
+        if isinstance(inst, BaseEpochs):
+            meta = deepcopy(inst._metadata)
+            evs = deepcopy(inst.events)
+            ev_id = deepcopy(inst.event_id)
+        else:
+            # if the input is of class Evoked
+            meta = evs = ev_id = None
+        out = EpochsTFR(info, power, times, freqs, method='stft-power',
+                        events=evs, event_id=ev_id, metadata=meta)
+
+    return out
+
+
+def tfr_array_stft(data, sfreq, window_size, step_size=None,
+                   return_times=False, verbose=True):
+    """STFT Short-Term Fourier Transform using a sine window.
+
+    The transformation is designed to be a tight frame that can be
+    perfectly inverted. It only returns the positive frequencies.
+
+    Parameters
+    ----------
+    x : array, shape (n_epochs, n_channels, n_times)
+        Containing multi-channels signal.
+    window_size : int
+        Length of the STFT window in samples (must be a multiple of 4).
+    step_size : int
+        Step between successive windows in samples (must be a multiple of 2,
+        a divider of ``window_size`` and smaller than ``window_size``/2)
+        (default: window_size/2).
+    return_times : bool
+        Whether to return the time points of the STFT time-frequency
+        representation. Default is False.
+    %(n_jobs)s
+    %(verbose)s
+
+    Returns
+    -------
+    X : array, shape (n_channels, wsize // 2 + 1, n_step)
+        STFT coefficients for positive frequencies with
+        ``n_step = ceil(T / tstep)``.
+    freqs : array, shape (wsize // 2 + 1,)
+        STFT frequencies corresponding.
+
+    See Also
+    --------
+    istft
+    stftfreq
+    """
+    n_epochs, n_channels, n_signals = data.shape
+
+    power_list = []
+
+    for epochidx in range(n_epochs):
+        # compute STFT
+        power = _stft(data, window_size=window_size, step_size=step_size,
+                      verbose=verbose)
+        power_list.append(power)
+    power_list = np.array(power_list)
+
+    # compute frequencies associated with the STFT
+    freqs = stftfreq(wsize=window_size, sfreq=sfreq)
+
+    # compute time points in seconds
+    times = _stft_times(n_signals=n_signals, window_size=window_size,
+                        step_size=step_size, sfreq=sfreq)
+    if return_times:
+        return power_list, freqs, times
+    return power_list, freqs
+
+
+@deprecated('This function call for STFT is deprecated. Use instead '
+            '"tfr_array_stft", or "tfr_stft".')
 @verbose
 def stft(x, wsize, tstep=None, verbose=None):
     """STFT Short-Term Fourier Transform using a sine window.
@@ -34,35 +156,63 @@ def stft(x, wsize, tstep=None, verbose=None):
     istft
     stftfreq
     """
+    return _stft(x, window_size=wsize, step_size=tstep, verbose=verbose)
+
+
+def _stft_times(n_signals, window_size, step_size, sfreq):
+    """Compute time points in seconds of STFT."""
+    # Creates a [n,2] array that holds the sample range of each window that
+    # is used to index the raw data for a sliding window analysis
+    samples_start = np.arange(0, n_signals - window_size + 1.0, step_size).astype(int)
+    samples_end = np.arange(window_size, n_signals + 1, step_size).astype(int)
+
+    # compute window endpoints in samples and frequencies
+    samples_wins = np.append(
+        samples_start[:, np.newaxis], samples_end[:, np.newaxis], axis=1
+    )
+    second_wins = np.divide(samples_wins, sfreq)
+    second_points = np.mean(second_wins, axis=1)
+    return second_points
+
+
+def _stft(data, window_size, step_size, verbose):
     rfft = _import_fft('rfft')
-    if not np.isrealobj(x):
+    _validate_type(data, np.ndarray, 'data')
+    if not np.isrealobj(data):
         raise ValueError("x is not a real valued array")
 
-    if x.ndim == 1:
-        x = x[None, :]
+    if data.ndim == 1:
+        data = data[None, :]
 
-    n_signals, T = x.shape
-    wsize = int(wsize)
+    # XXX: do we want this?
+    # if data.ndim != 3:
+    #     raise ValueError(
+    #         'data must be 3D with shape (n_epochs, n_channels, n_times), '
+    #         f'got {data.shape}')
+
+    # get the data shape
+    n_signals, T = data.shape
+    window_size = int(window_size)
 
     # Errors and warnings
-    if wsize % 4:
+    if window_size % 4:
         raise ValueError('The window length must be a multiple of 4.')
 
-    if tstep is None:
-        tstep = wsize / 2
+    if step_size is None:
+        step_size = window_size / 2
 
-    tstep = int(tstep)
+    step_size = int(step_size)
 
-    if (wsize % tstep) or (tstep % 2):
+    if (window_size % step_size) or (step_size % 2):
         raise ValueError('The step size must be a multiple of 2 and a '
                          'divider of the window length.')
 
-    if tstep > wsize / 2:
+    if step_size > window_size / 2:
         raise ValueError('The step size must be smaller than half the '
                          'window length.')
 
-    n_step = int(ceil(T / float(tstep)))
-    n_freq = wsize // 2 + 1
+    n_step = int(ceil(T / float(step_size)))
+    n_freq = window_size // 2 + 1
     logger.info("Number of frequencies: %d" % n_freq)
     logger.info("Number of time steps: %d" % n_step)
 
@@ -72,24 +222,24 @@ def stft(x, wsize, tstep=None, verbose=None):
         return X
 
     # Defining sine window
-    win = np.sin(np.arange(.5, wsize + .5) / wsize * np.pi)
+    win = np.sin(np.arange(.5, window_size + .5) / window_size * np.pi)
     win2 = win ** 2
 
-    swin = np.zeros((n_step - 1) * tstep + wsize)
+    swin = np.zeros((n_step - 1) * step_size + window_size)
     for t in range(n_step):
-        swin[t * tstep:t * tstep + wsize] += win2
-    swin = np.sqrt(wsize * swin)
+        swin[t * step_size:t * step_size + window_size] += win2
+    swin = np.sqrt(window_size * swin)
 
     # Zero-padding and Pre-processing for edges
-    xp = np.zeros((n_signals, wsize + (n_step - 1) * tstep),
-                  dtype=x.dtype)
-    xp[:, (wsize - tstep) // 2: (wsize - tstep) // 2 + T] = x
-    x = xp
+    xp = np.zeros((n_signals, window_size + (n_step - 1) * step_size),
+                  dtype=data.dtype)
+    xp[:, (window_size - step_size) // 2: (window_size - step_size) // 2 + T] = data
+    data = xp
 
     for t in range(n_step):
         # Framing
-        wwin = win / swin[t * tstep: t * tstep + wsize]
-        frame = x[:, t * tstep: t * tstep + wsize] * wwin[None, :]
+        wwin = win / swin[t * step_size: t * step_size + window_size]
+        frame = data[:, t * step_size: t * step_size + window_size] * wwin[None, :]
         # FFT
         X[:, :, t] = rfft(frame)
 

--- a/mne/time_frequency/_stft.py
+++ b/mne/time_frequency/_stft.py
@@ -206,6 +206,8 @@ def _stft_times(n_signals, window_size, step_size, sfreq):
 
 
 def _stft(data, window_size, step_size, verbose):
+    # XXX: substitute for scipy implementation when
+    # their roundtrip is fixed
     rfft = _import_fft('rfft')
     _validate_type(data, np.ndarray, 'data')
     if not np.isrealobj(data):
@@ -242,13 +244,17 @@ def _stft(data, window_size, step_size, verbose):
     # Zero-padding and Pre-processing for edges
     xp = np.zeros((n_signals, window_size + (n_step - 1) * step_size),
                   dtype=data.dtype)
-    xp[:, (window_size - step_size) // 2: (window_size - step_size) // 2 + T] = data
+    data_start_idx = (window_size - step_size) // 2
+    data_end_idx = (window_size - step_size) // 2 + T
+    xp[:, data_start_idx: data_end_idx] = data
     data = xp
 
     for t in range(n_step):
         # Framing
         wwin = win / swin[t * step_size: t * step_size + window_size]
-        frame = data[:, t * step_size: t * step_size + window_size] * wwin[None, :]
+        start_idx = t * step_size
+        end_idx = t * step_size + window_size
+        frame = data[:, start_idx: end_idx] * wwin[None, :]
         # FFT
         X[:, :, t] = rfft(frame)
 

--- a/mne/time_frequency/tests/test_stft.py
+++ b/mne/time_frequency/tests/test_stft.py
@@ -39,7 +39,7 @@ def test_stft_api():
                  average=True)
 
     power = tfr_stft(epochs, window_size=window_size,
-                            average=True)
+                     average=True)
 
     assert (isinstance(power, AverageTFR))
     assert (np.log(power.data.max()) * 20 <= 0.0)
@@ -59,7 +59,8 @@ def test_stft_api():
     assert power.shape == (1, 1, len(freqs), times.size)
 
 
-@pytest.mark.filterwarnings('ignore:This function call for STFT is deprecated:DeprecationWarning')
+@pytest.mark.filterwarnings('ignore:This function call for '
+                            'STFT is deprecated:DeprecationWarning')
 @pytest.mark.parametrize('T', (127, 128, 255, 256, 1337))
 @pytest.mark.parametrize('wsize', (128, 256))
 @pytest.mark.parametrize('tstep', (4, 64))

--- a/mne/time_frequency/tests/test_stft.py
+++ b/mne/time_frequency/tests/test_stft.py
@@ -11,7 +11,8 @@ from numpy.testing import (assert_almost_equal, assert_array_almost_equal)
 
 from mne import read_events, Epochs
 from mne.io import read_raw_fif
-from mne.time_frequency import stft, istft, stftfreq, tfr_stft, tfr_array_stft, AverageTFR
+from mne.time_frequency import (stft, istft, stftfreq, tfr_stft,
+                                tfr_array_stft, AverageTFR)
 from mne.time_frequency._stft import stft_norm2
 
 


### PR DESCRIPTION
#### Reference issue
Closes: #8880 

Need to implement unit tests.

#### What does this implement/fix?
- Implements `tfr_array_stft` and `tfr_stft` which operate on numpy arrays and mne-python objects respectively.

- Deprecates `stft` in favor of `tfr_array_stft`.


#### Additional information
No parallelizations across channels because felt that could be saved for a later PR.
