### PR TITLE
MRG, ENH: Allow channel-specific annotations

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -38,6 +38,8 @@ Enhancements
 
 - Remove the 15-character limitation for channel names when writing to FIF format. If you need the old 15-character names, you can use something like ``raw.rename_channels({n: n[:13] for n in raw.ch_names}, allow_duplicates=True)``, by `Eric Larson`_ (:gh:`8346`)
 
+- Add channel-specific annotation support to :class:`mne.Annotations` via ``ch_names`` parameter (:gh:`8896` by `Eric Larson`_)
+
 - Add toggle-all button to :class:`mne.Report` HTML and ``width`` argument to :meth:`mne.Report.add_bem_to_section` (:gh:`8723` by `Eric Larson`_)
 
 - Add infant template MRI dataset downloader :func:`mne.datasets.fetch_infant_template` (:gh:`8738` by `Eric Larson`_ and `Christian O'Reilly`_)
@@ -113,7 +115,9 @@ Bugs
 - Fix bug with :func:`mne.stats.permutation_cluster_1samp_test` and related clustering functions when ``adjacency=None`` and ``out_type='indices'`` (:gh:`#8842` by `Eric Larson`_)
 
 - Fix bug with :func:`mne.viz.plot_alignment` where plotting a sphere model could ignore the ``brain`` argument (:gh:`8857` by `Eric Larson`_)
--
+
+- Fix bug with :meth:`mne.Annotations.save` where files could be overwritten accidentally, it can now be controlled via the ``overwrite`` argument (:gh:`8896` by `Eric Larson`_)
+
 - Fix bug with ``replace`` argument of :meth:`mne.Report.add_bem_to_section` and :meth:`mne.Report.add_slider_to_section` (:gh:`8723` by `Eric Larson`_)
 
 - Fix compatibility bugs with :mod:`mne_realtime` (:gh:`8845` by `Eric Larson`_)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -9,6 +9,7 @@ import os.path as op
 import re
 from copy import deepcopy
 from itertools import takewhile
+import json
 from collections import Counter
 from collections.abc import Iterable
 import warnings
@@ -18,10 +19,10 @@ import numpy as np
 from .utils import (_pl, check_fname, _validate_type, verbose, warn, logger,
                     _check_pandas_installed, _mask_to_onsets_offsets,
                     _DefaultEventParser, _check_dt, _stamp_to_dt, _dt_to_stamp,
-                    _check_fname, int_like)
+                    _check_fname, int_like, _check_option, fill_doc)
 
 from .io.write import (start_block, end_block, write_float, write_name_list,
-                       write_double, start_file)
+                       write_double, start_file, write_string)
 from .io.constants import FIFF
 from .io.open import fiff_open
 from .io.tree import dir_tree_find
@@ -32,7 +33,7 @@ from .io.tag import read_tag
 _datetime = datetime
 
 
-def _check_o_d_s(onset, duration, description):
+def _check_o_d_s_c(onset, duration, description, ch_names):
     onset = np.atleast_1d(np.array(onset, dtype=float))
     if onset.ndim != 1:
         raise ValueError('Onset must be a one dimensional array, got %s '
@@ -51,17 +52,41 @@ def _check_o_d_s(onset, duration, description):
     if description.ndim != 1:
         raise ValueError('Description must be a one dimensional array, '
                          'got %d.' % (description.ndim,))
-    if any(['{COLON}' in desc for desc in description]):
-        raise ValueError('The substring "{COLON}" '
-                         'in descriptions not supported.')
+    _prep_name_list(description, 'check', 'description')
 
-    if not (len(onset) == len(duration) == len(description)):
-        raise ValueError('Onset, duration and description must be '
-                         'equal in sizes, got %s, %s, and %s.'
-                         % (len(onset), len(duration), len(description)))
-    return onset, duration, description
+    # ch_names: convert to ndarray of tuples
+    _validate_type(ch_names, (None, tuple, list, np.ndarray), 'ch_names')
+    if ch_names is None:
+        ch_names = [()] * len(onset)
+    ch_names = list(ch_names)
+    for ai, ch in enumerate(ch_names):
+        _validate_type(ch, (list, tuple, None), f'ch_names[{ai}]')
+        if ch is None:
+            ch = ()
+        for cj, name in enumerate(ch):
+            _validate_type(name, str, 'ch_names[{ai}][{cj}]')
+        ch_names[ai] = tuple(ch)
+    ch_names = _ndarray_ch_names(ch_names)
+
+    if not (len(onset) == len(duration) == len(description) == len(ch_names)):
+        raise ValueError(
+            'Onset, duration, description, and ch_names must be '
+            f'equal in sizes, got {len(onset)}, {len(duration)}, '
+            f'{len(description)}, and {len(ch_names)}.')
+    return onset, duration, description, ch_names
 
 
+def _ndarray_ch_names(ch_names):
+    # np.array(..., dtype=object) if all entries are empty will give
+    # an empty array of shape (n_entries, 0) which is not helpful. So let's
+    # force it to give us an array of shape (n_entries,) full of empty
+    # tuples
+    out = np.empty(len(ch_names), dtype=object)
+    out[:] = ch_names
+    return out
+
+
+@fill_doc
 class Annotations(object):
     """Annotation object for annotating segments of raw data.
 
@@ -89,8 +114,11 @@ class Annotations(object):
         In general, ``raw.info['meas_date']`` (or None) can be used for syncing
         the annotations with raw data if their acquisiton is started at the
         same time. If it is a string, it should conform to the ISO8601 format.
-        More precisely to this '%Y-%m-%d %H:%M:%S.%f' particular case of the
-        ISO8601 format where the delimiter between date and time is ' '.
+        More precisely to this '%%Y-%%m-%%d %%H:%%M:%%S.%%f' particular case of
+        the ISO8601 format where the delimiter between date and time is ' '.
+    %(annot_ch_names)s
+
+        .. versionadded:: 0.23
 
     See Also
     --------
@@ -197,10 +225,10 @@ class Annotations(object):
     """  # noqa: E501
 
     def __init__(self, onset, duration, description,
-                 orig_time=None):  # noqa: D102
+                 orig_time=None, ch_names=None):  # noqa: D102
         self._orig_time = _handle_meas_date(orig_time)
-        self.onset, self.duration, self.description = _check_o_d_s(
-            onset, duration, description)
+        self.onset, self.duration, self.description, self.ch_names = \
+            _check_o_d_s_c(onset, duration, description, ch_names)
         self._sort()  # ensure we're sorted
 
     @property
@@ -215,6 +243,7 @@ class Annotations(object):
         return (np.array_equal(self.onset, other.onset) and
                 np.array_equal(self.duration, other.duration) and
                 np.array_equal(self.description, other.description) and
+                np.array_equal(self.ch_names, other.ch_names) and
                 self.orig_time == other.orig_time)
 
     def __repr__(self):
@@ -222,8 +251,9 @@ class Annotations(object):
         counter = Counter(self.description)
         kinds = ', '.join(['%s (%s)' % k for k in sorted(counter.items())])
         kinds = (': ' if len(kinds) > 0 else '') + kinds
-        s = ('Annotations | %s segment%s%s' %
-             (len(self.onset), _pl(len(self.onset)), kinds))
+        ch_specific = ', channel-specific' if self._any_ch_names() else ''
+        s = ('Annotations | %s segment%s%s%s' %
+             (len(self.onset), _pl(len(self.onset)), ch_specific, kinds))
         return '<' + shorten(s, width=77, placeholder=' ...') + '>'
 
     def __len__(self):
@@ -267,15 +297,20 @@ class Annotations(object):
             out_keys = ('onset', 'duration', 'description', 'orig_time')
             out_vals = (self.onset[key], self.duration[key],
                         self.description[key], self.orig_time)
+            if self._any_ch_names():
+                out_keys += ('ch_names',)
+                out_vals += (self.ch_names[key],)
             return OrderedDict(zip(out_keys, out_vals))
         else:
             key = list(key) if isinstance(key, tuple) else key
             return Annotations(onset=self.onset[key],
                                duration=self.duration[key],
                                description=self.description[key],
-                               orig_time=self.orig_time)
+                               orig_time=self.orig_time,
+                               ch_names=self.ch_names[key])
 
-    def append(self, onset, duration, description):
+    @fill_doc
+    def append(self, onset, duration, description, ch_names=None):
         """Add an annotated segment. Operates inplace.
 
         Parameters
@@ -288,6 +323,9 @@ class Annotations(object):
         description : str | array-like
             Description for the annotation. To reject epochs, use description
             starting with keyword 'bad'.
+        %(annot_ch_names)s
+
+            .. versionadded:: 0.23
 
         Returns
         -------
@@ -300,11 +338,12 @@ class Annotations(object):
         to not only ``list.append``, but also
         `list.extend <https://docs.python.org/3/library/stdtypes.html#mutable-sequence-types>`__.
         """  # noqa: E501
-        onset, duration, description = _check_o_d_s(
-            onset, duration, description)
+        onset, duration, description, ch_names = _check_o_d_s_c(
+            onset, duration, description, ch_names)
         self.onset = np.append(self.onset, onset)
         self.duration = np.append(self.duration, duration)
         self.description = np.append(self.description, description)
+        self.ch_names = np.append(self.ch_names, ch_names)
         self._sort()
         return self
 
@@ -330,6 +369,7 @@ class Annotations(object):
         self.onset = np.delete(self.onset, idx)
         self.duration = np.delete(self.duration, idx)
         self.description = np.delete(self.description, idx)
+        self.ch_names = np.delete(self.ch_names, idx)
 
     def to_data_frame(self):
         """Export annotations in tabular structure as a pandas DataFrame.
@@ -338,7 +378,8 @@ class Annotations(object):
         -------
         result : pandas.DataFrame
             Returns a pandas DataFrame with onset, duration, and
-            description columns.
+            description columns. A column named ch_names is added if any
+            annotations are channel-specific.
         """
         pd = _check_pandas_installed(strict=True)
         dt = _handle_meas_date(self.orig_time)
@@ -346,11 +387,18 @@ class Annotations(object):
             dt = _handle_meas_date(0)
         dt = dt.replace(tzinfo=None)
         onsets_dt = [dt + timedelta(seconds=o) for o in self.onset]
-        df = pd.DataFrame(dict(onset=onsets_dt, duration=self.duration,
-                               description=self.description))
+        df = dict(onset=onsets_dt, duration=self.duration,
+                  description=self.description)
+        if self._any_ch_names():
+            df.update(ch_names=self.ch_names)
+        df = pd.DataFrame(df)
         return df
 
-    def save(self, fname):
+    def _any_ch_names(self):
+        return any(len(ch) for ch in self.ch_names)
+
+    @verbose
+    def save(self, fname, *, overwrite=False, verbose=None):
         """Save annotations to FIF, CSV or TXT.
 
         Typically annotations get saved in the FIF file for raw data
@@ -362,10 +410,15 @@ class Annotations(object):
         ----------
         fname : str
             The filename to use.
+        %(overwrite)s
+
+            .. versionadded:: 0.23
+        %(verbose)s
         """
         check_fname(fname, 'annotations', ('-annot.fif', '-annot.fif.gz',
                                            '_annot.fif', '_annot.fif.gz',
                                            '.txt', '.csv'))
+        fname = _check_fname(fname, overwrite=overwrite)
         if fname.endswith(".txt"):
             _write_annotations_txt(fname, self)
         elif fname.endswith(".csv"):
@@ -383,6 +436,7 @@ class Annotations(object):
         self.onset = self.onset[order]
         self.duration = self.duration[order]
         self.description = self.description[order]
+        self.ch_names = self.ch_names[order]
 
     @verbose
     def crop(self, tmin=None, tmax=None, emit_warning=False, verbose=None):
@@ -427,10 +481,10 @@ class Annotations(object):
         absolute_tmax = _handle_meas_date(tmax)
         del tmin, tmax
 
-        onsets, durations, descriptions = [], [], []
+        onsets, durations, descriptions, ch_names = [], [], [], []
         out_of_bounds, clip_left_elem, clip_right_elem = [], [], []
-        for onset, duration, description in zip(
-                self.onset, self.duration, self.description):
+        for onset, duration, description, ch in zip(
+                self.onset, self.duration, self.description, self.ch_names):
             # if duration is NaN behave like a zero
             if np.isnan(duration):
                 duration = 0.
@@ -459,10 +513,12 @@ class Annotations(object):
                 onsets.append(
                     (absolute_onset - offset).total_seconds())
                 descriptions.append(description)
+                ch_names.append(ch)
         self.onset = np.array(onsets, float)
         self.duration = np.array(durations, float)
         assert (self.duration >= 0).all()
         self.description = np.array(descriptions, dtype=str)
+        self.ch_names = _ndarray_ch_names(ch_names)
 
         if emit_warning:
             omitted = np.array(out_of_bounds).sum()
@@ -489,7 +545,8 @@ def _combine_annotations(one, two, one_n_samples, one_first_samp,
     onset = np.concatenate([one.onset, two.onset + shift])
     duration = np.concatenate([one.duration, two.duration])
     description = np.concatenate([one.description, two.description])
-    return Annotations(onset, duration, description, one.orig_time)
+    ch_names = np.concatenate([one.ch_names, two.ch_names])
+    return Annotations(onset, duration, description, one.orig_time, ch_names)
 
 
 def _handle_meas_date(meas_date):
@@ -581,24 +638,46 @@ def _annotations_starts_stops(raw, kinds, name='skip_by_annotation',
     return onsets, ends
 
 
+def _prep_name_list(lst, operation, name='description'):
+    if operation == 'check':
+        if any(['{COLON}' in val for val in lst]):
+            raise ValueError(
+                f'The substring "{{COLON}}" in {name} not supported.')
+    elif operation == 'write':
+        # take a list of strings and return a sanitized string
+        return ':'.join(val.replace(':', '{COLON}') for val in lst)
+    else:
+        # take a sanitized string and return a list of strings
+        assert operation == 'read'
+        assert isinstance(lst, str)
+        if not len(lst):
+            return []
+        return [val.replace('{COLON}', ':') for val in lst.split(':')]
+
+
 def _write_annotations(fid, annotations):
     """Write annotations."""
     start_block(fid, FIFF.FIFFB_MNE_ANNOTATIONS)
     write_float(fid, FIFF.FIFF_MNE_BASELINE_MIN, annotations.onset)
     write_float(fid, FIFF.FIFF_MNE_BASELINE_MAX,
                 annotations.duration + annotations.onset)
-    # To allow : in description, they need to be replaced for serialization
-    # -> replace with "{COLON}". When read back in, replace it back with ":"
-    write_name_list(fid, FIFF.FIFF_COMMENT, [d.replace(':', '{COLON}') for d in
-                                             annotations.description])
+    write_name_list(fid, FIFF.FIFF_COMMENT, _prep_name_list(
+        annotations.description, 'write').split(':'))
     if annotations.orig_time is not None:
         write_double(fid, FIFF.FIFF_MEAS_DATE,
                      _dt_to_stamp(annotations.orig_time))
+    if annotations._any_ch_names():
+        write_string(fid, FIFF.FIFF_MNE_EPOCHS_DROP_LOG,
+                     json.dumps(tuple(annotations.ch_names)))
     end_block(fid, FIFF.FIFFB_MNE_ANNOTATIONS)
 
 
 def _write_annotations_csv(fname, annot):
-    annot.to_data_frame().to_csv(fname, index=False)
+    annot = annot.to_data_frame()
+    if 'ch_names' in annot:
+        annot['ch_names'] = [
+            _prep_name_list(ch, 'write') for ch in annot['ch_names']]
+    annot.to_csv(fname)
 
 
 def _write_annotations_txt(fname, annot):
@@ -607,10 +686,16 @@ def _write_annotations_txt(fname, annot):
         # for backward compat, we do not write tzinfo (assumed UTC)
         content += ("# orig_time : %s   \n"
                     % annot.orig_time.replace(tzinfo=None))
-    content += "# onset, duration, description\n"
-
-    data = np.array([annot.onset, annot.duration, annot.description],
-                    dtype=str).T
+    content += "# onset, duration, description"
+    data = [annot.onset, annot.duration, annot.description]
+    if annot._any_ch_names():
+        content += ', ch_names'
+        data.append([_prep_name_list(ch, 'write') for ch in annot.ch_names])
+    content += '\n'
+    data = np.array(data, dtype=str).T
+    assert data.ndim == 2
+    assert data.shape[0] == len(annot.onset)
+    assert data.shape[1] in (3, 4)
     with open(fname, 'wb') as fid:
         fid.write(content.encode())
         np.savetxt(fid, data, delimiter=',', fmt="%s")
@@ -673,10 +758,10 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None):
             annotations = _read_annotations_fif(fid, tree)
     elif name.endswith('txt'):
         orig_time = _read_annotations_txt_parse_header(fname)
-        onset, duration, description = _read_annotations_txt(fname)
+        onset, duration, description, ch_names = _read_annotations_txt(fname)
         annotations = Annotations(onset=onset, duration=duration,
-                                  description=description,
-                                  orig_time=orig_time)
+                                  description=description, orig_time=orig_time,
+                                  ch_names=ch_names)
 
     elif name.endswith('vmrk'):
         annotations = _read_annotations_brainvision(fname, sfreq=sfreq)
@@ -729,7 +814,7 @@ def _read_annotations_csv(fname):
         The annotations.
     """
     pd = _check_pandas_installed(strict=True)
-    df = pd.read_csv(fname)
+    df = pd.read_csv(fname, keep_default_na=False)
     orig_time = df['onset'].values[0]
     try:
         float(orig_time)
@@ -743,7 +828,11 @@ def _read_annotations_csv(fname):
     onset = (onset_dt - onset_dt[0]).dt.total_seconds()
     duration = df['duration'].values.astype(float)
     description = df['description'].values
-    return Annotations(onset, duration, description, orig_time)
+    ch_names = None
+    if 'ch_names' in df.columns:
+        ch_names = [_prep_name_list(val, 'read')
+                    for val in df['ch_names'].values]
+    return Annotations(onset, duration, description, orig_time, ch_names)
 
 
 def _read_brainstorm_annotations(fname, orig_time=None):
@@ -810,15 +899,23 @@ def _read_annotations_txt(fname):
         warnings.simplefilter("ignore")
         out = np.loadtxt(fname, delimiter=',',
                          dtype=np.bytes_, unpack=True)
+    ch_names = None
     if len(out) == 0:
         onset, duration, desc = [], [], []
     else:
-        onset, duration, desc = out
+        _check_option('text header', len(out), (3, 4))
+        if len(out) == 3:
+            onset, duration, desc = out
+        else:
+            onset, duration, desc, ch_names = out
 
     onset = [float(o.decode()) for o in np.atleast_1d(onset)]
     duration = [float(d.decode()) for d in np.atleast_1d(duration)]
     desc = [str(d.decode()).strip() for d in np.atleast_1d(desc)]
-    return onset, duration, desc
+    if ch_names is not None:
+        ch_names = [_prep_name_list(ch.decode().strip(), 'read')
+                    for ch in ch_names]
+    return onset, duration, desc, ch_names
 
 
 def _read_annotations_fif(fid, tree):
@@ -828,7 +925,7 @@ def _read_annotations_fif(fid, tree):
         annotations = None
     else:
         annot_data = annot_data[0]
-        orig_time = None
+        orig_time = ch_names = None
         onset, duration, description = list(), list(), list()
         for ent in annot_data['directory']:
             kind = ent.kind
@@ -841,21 +938,18 @@ def _read_annotations_fif(fid, tree):
                 duration = tag.data
                 duration = list() if duration is None else duration - onset
             elif kind == FIFF.FIFF_COMMENT:
-                description = tag.data.split(':')
-
-                # replace all "{COLON}" in FIF files with necessary
-                # : character
-                description = [d.replace('{COLON}', ':') for d in
-                               description]
+                description = _prep_name_list(tag.data, 'read')
             elif kind == FIFF.FIFF_MEAS_DATE:
                 orig_time = tag.data
                 try:
                     orig_time = float(orig_time)  # old way
                 except TypeError:
                     orig_time = tuple(orig_time)  # new way
+            elif kind == FIFF.FIFF_MNE_EPOCHS_DROP_LOG:
+                ch_names = tuple(tuple(x) for x in json.loads(tag.data))
         assert len(onset) == len(duration) == len(description)
         annotations = Annotations(onset, duration, description,
-                                  orig_time)
+                                  orig_time, ch_names)
     return annotations
 
 

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -459,8 +459,7 @@ class Beamformer(dict):
         fname : str
             The filename to use to write the HDF5 data.
             Should end in ``'-lcmv.h5'`` or ``'-dics.h5'``.
-        overwrite : bool
-            If True, overwrite the file (if it exists).
+        %(overwrite)s
         %(verbose)s
         """
         ending = '-%s.h5' % (self['kind'].lower(),)

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1036,8 +1036,7 @@ def make_watershed_bem(subject, subjects_dir=None, overwrite=False,
     subject : str
         Subject name.
     %(subjects_dir)s
-    overwrite : bool
-        Write over existing files.
+    %(overwrite)s
     volume : str
         Defaults to T1.
     atlas : bool
@@ -1558,8 +1557,7 @@ def write_bem_surfaces(fname, surfs, overwrite=False, verbose=None):
         Filename to write. Can end with ``.h5`` to write using HDF5.
     surfs : dict | list of dict
         The surfaces, or a single surface.
-    overwrite : bool
-        If True (default False), overwrite the file.
+    %(overwrite)s
     %(verbose)s
     """
     if isinstance(surfs, dict):
@@ -1592,8 +1590,7 @@ def write_head_bem(fname, rr, tris, on_defects='raise', overwrite=False,
         Triangulation (each line contains indices for three points which
         together form a face).
     %(on_defects)s
-    overwrite : bool
-        If True (default False), overwrite the file.
+    %(overwrite)s
     %(verbose)s
     """
     surf = _surfaces_to_bem([dict(rr=rr, tris=tris)],
@@ -1630,8 +1627,7 @@ def write_bem_solution(fname, bem, overwrite=False, verbose=None):
         The filename to use. Can end with ``.h5`` to write using HDF5.
     bem : instance of ConductorModel
         The BEM model with solution to save.
-    overwrite : bool
-        If True (default False), overwrite the file.
+    %(overwrite)s
     %(verbose)s
 
     See Also

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -114,17 +114,18 @@ class Dipole(object):
         s += ", tmax : %0.3f" % np.max(self.times)
         return "<Dipole | %s>" % s
 
-    def save(self, fname, overwrite=False):
+    @verbose
+    def save(self, fname, overwrite=False, *, verbose=None):
         """Save dipole in a .dip or .bdip file.
 
         Parameters
         ----------
         fname : str
             The name of the .dip or .bdip file.
-        overwrite : bool
-            If True, overwrite the file (if it exists).
+        %(overwrite)s
 
             .. versionadded:: 0.20
+        %(verbose_meth)s
 
         Notes
         -----

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1653,9 +1653,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
             will slightly differ due to the reduction in precision.
 
             .. versionadded:: 0.17
-        overwrite : bool
-            If True, the destination file (if it exists) will be overwritten.
-            If False (default), an error will be raised if the file exists.
+        %(overwrite)s
             To overwrite original file (the same one that was loaded),
             data must be preloaded upon reading. This defaults to True in 0.18
             but will change to False in 0.19.

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -707,8 +707,7 @@ def write_forward_solution(fname, fwd, overwrite=False, verbose=None):
         or -fwd.fif.gz.
     fwd : Forward
         Forward solution.
-    overwrite : bool
-        If True, overwrite destination file (if it exists).
+    %(overwrite)s
     %(verbose)s
 
     See Also
@@ -1738,12 +1737,9 @@ def _do_forward_solution(subject, meas, fname=None, src=None, spacing=None,
         If True, compute the gradient of the field with respect to the
         dipole coordinates as well (Default: False).
     mricoord : bool
-        If True, calculate in MRI coordinates (Default: False).
-    overwrite : bool
-        If True, the destination file (if it exists) will be overwritten.
-        If False (default), an error will be raised if the file exists.
-    subjects_dir : None | str
-        Override the SUBJECTS_DIR environment variable.
+        If True, calculate in MRI coordinates (Default: False)
+    %(overwrite)s
+    %(subjects_dir)s
     %(verbose)s
 
     See Also

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -611,7 +611,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """The filenames used."""
         return tuple(self._filenames)
 
-    def set_annotations(self, annotations, emit_warning=True):
+    @verbose
+    def set_annotations(self, annotations, emit_warning=True,
+                        on_missing='raise', *, verbose=None):
         """Setter for annotations.
 
         This setter checks if they are inside the data range.
@@ -622,7 +624,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             Annotations to set. If None, the annotations is defined
             but empty.
         emit_warning : bool
-            Whether to emit warnings when limiting or omitting annotations.
+            Whether to emit warnings when cropping or omitting annotations.
+        %(on_missing_ch_names)s
+        %(verbose_meth)s
 
         Returns
         -------
@@ -648,6 +652,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
             delta = 1. / self.info['sfreq']
             new_annotations = annotations.copy()
+            new_annotations._prune_ch_names(self.info, on_missing)
             if annotations.orig_time is None:
                 new_annotations.crop(0, self.times[-1] + delta,
                                      emit_warning=emit_warning)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1334,9 +1334,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             and neither complex data types nor real data stored as 'double'
             can be loaded with the MNE command-line tools. See raw.orig_format
             to determine the format the original data were stored in.
-        overwrite : bool
-            If True, the destination file (if it exists) will be overwritten.
-            If False (default), an error will be raised if the file exists.
+        %(overwrite)s
             To overwrite original file (the same one that was loaded),
             data must be preloaded upon reading.
         split_size : str | int

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -646,8 +646,7 @@ class SourceMorph(object):
         fname : str
             The stem of the file name. '-morph.h5' will be added if fname does
             not end with '.h5'.
-        overwrite : bool
-            If True, overwrite existing file.
+        %(overwrite)s
         %(verbose_meth)s
         """
         fname = _check_fname(fname, overwrite=overwrite, must_exist=False)

--- a/mne/preprocessing/maxfilter.py
+++ b/mne/preprocessing/maxfilter.py
@@ -84,8 +84,7 @@ def apply_maxfilter(in_fname, out_fname, origin=None, frame='device',
         Path to Cross-talk compensation file.
     mx_args : str
         Additional command line arguments to pass to MaxFilter.
-    overwrite : bool
-        Overwrite output file if it already exists.
+    %(overwrite)s
     %(verbose)s
 
     Returns

--- a/mne/report.py
+++ b/mne/report.py
@@ -1667,7 +1667,9 @@ class Report(object):
                 setattr(self, param, state[param])
         return state
 
-    def save(self, fname=None, open_browser=True, overwrite=False):
+    @verbose
+    def save(self, fname=None, open_browser=True, overwrite=False, *,
+             verbose=None):
         """Save the report and optionally open it in browser.
 
         Parameters
@@ -1682,8 +1684,8 @@ class Report(object):
         open_browser : bool
             When saving to HTML, open the rendered HTML file browser after
             saving if True. Defaults to True.
-        overwrite : bool
-            If True, overwrite report if it already exists. Defaults to False.
+        %(overwrite)s
+        %(verbose_meth)s
 
         Returns
         -------

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -321,16 +321,16 @@ class SourceSpaces(list):
             ss.append(deepcopy(s, memodict))
         return SourceSpaces(ss, info)
 
-    def save(self, fname, overwrite=False):
+    @verbose
+    def save(self, fname, overwrite=False, *, verbose=None):
         """Save the source spaces to a fif file.
 
         Parameters
         ----------
         fname : str
             File to write.
-        overwrite : bool
-            If True, the destination file (if it exists) will be overwritten.
-            If False (default), an error will be raised if the file exists.
+        %(overwrite)s
+        %(verbose_meth)s
         """
         write_source_spaces(fname, self, overwrite)
 
@@ -373,8 +373,7 @@ class SourceSpaces(list):
         use_lut : bool
             If True, assigns a numeric value to each source space that
             corresponds to a color on the freesurfer lookup table.
-        overwrite : bool
-            If True, overwrite the file if it exists.
+        %(overwrite)s
 
             .. versionadded:: 0.19
         %(verbose_meth)s
@@ -1063,9 +1062,7 @@ def write_source_spaces(fname, src, overwrite=False, verbose=None):
         -src.fif.gz.
     src : SourceSpaces
         The source spaces (as returned by read_source_spaces).
-    overwrite : bool
-        If True, the destination file (if it exists) will be overwritten.
-        If False (default), an error will be raised if the file exists.
+    %(overwrite)s
     %(verbose)s
 
     See Also

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -1039,8 +1039,9 @@ def _decimate_surface_spacing(surf, spacing):
     return surf
 
 
+@verbose
 def write_surface(fname, coords, faces, create_stamp='', volume_info=None,
-                  file_format='auto', overwrite=False):
+                  file_format='auto', overwrite=False, *, verbose=None):
     """Write a triangular Freesurfer surface mesh.
 
     Accepts the same data format as is returned by read_surface().
@@ -1079,8 +1080,8 @@ def write_surface(fname, coords, faces, create_stamp='', volume_info=None,
         file name. Defaults to 'auto'.
 
         .. versionadded:: 0.21.0
-    overwrite : bool
-        If True, overwrite the file if it exists.
+    %(overwrite)s
+    %(verbose)s
 
     See Also
     --------

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -995,15 +995,16 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin):
         rescale(self.data, self.times, baseline, mode, copy=False)
         return self
 
-    def save(self, fname, overwrite=False):
+    @verbose
+    def save(self, fname, overwrite=False, *, verbose=None):
         """Save TFR object to hdf5 file.
 
         Parameters
         ----------
         fname : str
             The file name, which should end with ``-tfr.h5``.
-        overwrite : bool
-            If True, overwrite file (if it exists). Defaults to False.
+        %(overwrite)s
+        %(verbose)s
 
         See Also
         --------
@@ -2258,7 +2259,8 @@ def _check_decim(decim):
 # i/o
 
 
-def write_tfrs(fname, tfr, overwrite=False):
+@verbose
+def write_tfrs(fname, tfr, overwrite=False, *, verbose=None):
     """Write a TFR dataset to hdf5.
 
     Parameters
@@ -2269,8 +2271,8 @@ def write_tfrs(fname, tfr, overwrite=False):
         The TFR dataset, or list of TFR datasets, to save in one file.
         Note. If .comment is not None, a name will be generated on the fly,
         based on the order in which the TFR objects are passed.
-    overwrite : bool
-        If True, overwrite file (if it exists). Defaults to False.
+    %(overwrite)s
+    %(verbose)s
 
     See Also
     --------

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -145,12 +145,13 @@ docdict['reject_by_annotation_raw'] = docdict['reject_by_annotation_all'] + """
     Has no effect if ``inst`` is not a :class:`mne.io.Raw` object.
 """
 docdict['annot_ch_names'] = """
-ch_names : array-like, shape (n_annotations,) | None
-    1D object array of tuples of channel names associated with the annotations.
-    Empty entries are assumed to be associated with all channels (i.e., with
-    the time slice itself). For example, this creates three annotations,
-    associating the first with all channels, the second with two channels,
-    and the third with a single channel::
+ch_names : list | None
+    List of lists of channel names associated with the annotations.
+    Empty entries are assumed to be associated with no specific channel,
+    i.e., with all channels or with the time slice itself. None (default) is
+    the same as passing all empty lists. For example, this creates three
+    annotations, associating the first with the time interval itself, the
+    second with two channels, and the third with a single channel::
 
         Annotations(onset=[0, 3, 10], duration=[1, 0.25, 0.5],
                     description=['Start', 'BAD_flux', 'BAD_noise'],

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -145,16 +145,16 @@ docdict['reject_by_annotation_raw'] = docdict['reject_by_annotation_all'] + """
     Has no effect if ``inst`` is not a :class:`mne.io.Raw` object.
 """
 docdict['annot_ch_names'] = """
-ch_names : array-like | None
-    Array-like of lists of channel names associated with the annotations.
-    Empty entries or entries with None are assumed to be associated with all
-    channels (i.e., with the time slice itself). For example, to create two
-    annotations, associating the second with two channels could be done
-    by using ``ch_names`` like::
+ch_names : array-like, shape (n_annotations,) | None
+    1D object array of tuples of channel names associated with the annotations.
+    Empty entries are assumed to be associated with all channels (i.e., with
+    the time slice itself). For example, this creates three annotations,
+    associating the first with all channels, the second with two channels,
+    and the third with a single channel::
 
         Annotations(onset=[0, 3, 10], duration=[1, 0.25, 0.5],
                     description=['Start', 'BAD_flux', 'BAD_noise'],
-                    ch_names=[[], ['MEG0111', 'MEG2563']])
+                    ch_names=[[], ['MEG0111', 'MEG2563'], ['MEG1443']])
 """
 
 # General plotting
@@ -1418,6 +1418,12 @@ on_missing : str
     %s channels have missing coordinates.
 
     .. versionadded:: 0.20.1
+""" % (_on_missing_base,)
+docdict['on_missing_ch_names'] = """
+on_missing : str
+    %s entries in ch_names are not present in the raw instance.
+
+    .. versionadded:: 0.23.0
 """ % (_on_missing_base,)
 docdict['rename_channels_mapping_duplicates'] = """
 mapping : dict | callable

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -144,6 +144,18 @@ reject_by_annotation : bool
 docdict['reject_by_annotation_raw'] = docdict['reject_by_annotation_all'] + """
     Has no effect if ``inst`` is not a :class:`mne.io.Raw` object.
 """
+docdict['annot_ch_names'] = """
+ch_names : array-like | None
+    Array-like of lists of channel names associated with the annotations.
+    Empty entries or entries with None are assumed to be associated with all
+    channels (i.e., with the time slice itself). For example, to create two
+    annotations, associating the second with two channels could be done
+    by using ``ch_names`` like::
+
+        Annotations(onset=[0, 3, 10], duration=[1, 0.25, 0.5],
+                    description=['Start', 'BAD_flux', 'BAD_noise'],
+                    ch_names=[[], ['MEG0111', 'MEG2563']])
+"""
 
 # General plotting
 docdict["show"] = """
@@ -2108,6 +2120,11 @@ on_defects : str
 docdict['accept'] = """
 accept : bool
     If True (default False), accept the license terms of this dataset.
+"""
+docdict['overwrite'] = """
+overwrite : bool
+    If True (default False), overwrite the destination file if it
+    exists.
 """
 
 docdict_indented = {}


### PR DESCRIPTION
Closes #5507

Removes some heavy, seemingly overkill parametrization of the `test_annotations.py` where the parameters were only used in a single function for example. Also makes an `overwrite` entry in `docdict`.

Todo:

- [x] Make `rename_channels` change the names in `annotations`
- [x] Make `drop_channels` drop channel names, and channel-specific annotations that no longer apply