### PR TITLE
backport #8898

### DIFF
--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -780,7 +780,7 @@ class MNEBrowseFigure(MNEFigure):
             # click in horizontal scrollbar
             elif event.inaxes == self.mne.ax_hscroll:
                 if self._check_update_hscroll_clicked(event):
-                    self._redraw()
+                    self._redraw(annotations=True)
             # click on proj button
             elif event.inaxes == self.mne.ax_proj:
                 self._toggle_proj_fig(event)


### PR DESCRIPTION
fix for raw.plot(): make annotations immediately visible when scrolling via click on scrubber bar