### PR TITLE
MRG, BUG: Fix bug with no picks

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -104,6 +104,8 @@ Bugs
 
 - Fix bug with :meth:`raw.plot() <mne.io.Raw.plot>` where ``scalings='auto'`` did not compute scalings using the full range of data (:gh:`8806` by `Eric Larson`_)
 
+- Fix bug with :meth:`raw.plot() <mne.io.Raw.plot>` where setting a ``lowpass`` could lead to non-data-channels not plotting (:gh:`8954` by `Eric Larson`_)
+
 - Fix bug with :meth:`mne.io.Raw.load_data` and :meth:`mne.Epochs.drop_bad` where ``verbose`` logging was not handled properly (:gh:`8884` by `Eric Larson`_)
 
 - Fix bug with :func:`mne.io.read_raw_nicolet` where header type values such as num_sample and duration_in_sec where not parsed properly (:gh:`8712` by `Alex Gramfort`_)

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1916,7 +1916,9 @@ class MNEBrowseFigure(MNEFigure):
             starts = np.maximum(starts[mask], start) - start
             stops = np.minimum(stops[mask], stop) - start
             for _start, _stop in zip(starts, stops):
-                _picks = np.where(np.in1d(picks, self.mne.picks_data))
+                _picks = np.where(np.in1d(picks, self.mne.picks_data))[0]
+                if len(_picks) == 0:
+                    break
                 this_data = data[_picks, _start:_stop]
                 if isinstance(self.mne.filter_coefs, np.ndarray):  # FIR
                     this_data = _overlap_add_filter(

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -2,10 +2,10 @@
 #
 # License: Simplified BSD
 
-import numpy as np
 import os.path as op
 import itertools
 
+import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 import matplotlib
@@ -569,7 +569,8 @@ def test_plot_raw_filtered(filtorder, raw):
     raw.plot(lowpass=40, clipping='transparent', filtorder=filtorder)
     raw.plot(highpass=1, clipping='clamp', filtorder=filtorder)
     raw.plot(lowpass=40, butterfly=True, filtorder=filtorder)
-    plt.close('all')
+    # shouldn't break if all shown are non-data
+    RawArray(np.zeros((1, 100)), create_info(1, 20., 'stim')).plot(lowpass=5)
 
 
 def test_plot_raw_psd(raw):


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File "/home/larsoner/python/matplotlib/lib/matplotlib/cbook/__init__.py", line 256, in process
    func(*args, **kwargs)
  File "/home/larsoner/python/mne-python/mne/viz/_figure.py", line 662, in _keypress
    self._redraw()
  File "/home/larsoner/python/mne-python/mne/viz/_figure.py", line 2122, in _redraw
    self._update_data()
  File "/home/larsoner/python/mne-python/mne/viz/_figure.py", line 1925, in _update_data
    this_data = _filtfilt(
  File "/home/larsoner/python/mne-python/mne/filter.py", line 433, in _filtfilt
    x, orig_shape, picks = _prep_for_filtering(x, copy, picks)
  File "/home/larsoner/python/mne-python/mne/filter.py", line 272, in _prep_for_filtering
    picks = _picks_to_idx(x.shape[-2], picks)
  File "/home/larsoner/python/mne-python/mne/io/pick.py", line 1061, in _picks_to_idx
    raise ValueError('No appropriate channels found for the given picks '
ValueError: No appropriate channels found for the given picks (None)
```
by short-circuiting the filter loop (over filterable time segments) when none of the currently shown channels are data channels.