### PR TITLE
CI, MAINT: fix pip pre

### DIFF
--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -519,8 +519,14 @@ def test_plot():
     fig.canvas.key_press_event(' ')
     fig.canvas.key_press_event('pagedown')
 
-    cbar = fig.get_axes()[0].CB  # Fake dragging with mouse.
-    ax = cbar.cbar.ax
+    # Fake dragging with mouse.
+    ax = None
+    for _ax in fig.axes:
+        if _ax.get_label() == '<colorbar>':
+            ax = _ax
+            break
+    if ax is None:
+        ax = fig.get_axes()[0].CB.cbar.ax
     _fake_click(fig, ax, (0.1, 0.1))
     _fake_click(fig, ax, (0.1, 0.2), kind='motion')
     _fake_click(fig, ax, (0.1, 0.3), kind='release')


### PR DESCRIPTION
```
__________________________________ test_plot __________________________________
mne\time_frequency\tests\test_tfr.py:522: in test_plot
    cbar = fig.get_axes()[0].CB  # Fake dragging with mouse.
E   AttributeError: 'AxesSubplot' object has no attribute 'CB'
```
This one: the order of elements in `fig.get_axes()` appears to have changed between matplotlib 3.3.x and 3.4rc1.  Long-term this would be avoided by having all 2D figures using the new figure classes (it would be easy to store pointers to specific AxesSubplots).  Short term I've added an ugly workaround to the test.


```
___________________________ test_plot_epochs_clicks ___________________________
mne\viz\tests\test_epochs.py:174: in test_plot_epochs_clicks
    assert first_ch in fig.mne.info['bads']
E   AssertionError: assert 'MEG 0113' in []
```
Here, clicking the channel names fires off **two** pick events in a row in MPL 3.4.rc1, effectively marking and then immediately unmarking the channel before a redraw happens. Upstream bug report: https://github.com/matplotlib/matplotlib/issues/19576

```
____________________________ test_plot_ica_sources ____________________________
mne\viz\tests\test_ica.py:233: in test_plot_ica_sources
    assert_array_equal(ica.exclude, [0])
E   AssertionError: 
E   Arrays are not equal
E   
E   (shapes (0,), (1,) mismatch)
E    x: array([], dtype=float64)
E    y: array([0])
```
This is caused by the same issue above (duplicate pick events)

```
___________________________ test_plot_raw_selection ___________________________
mne\viz\tests\test_raw.py:258: in test_plot_raw_selection
    assert sel_fig.lasso.ec[:, 0].sum() == 1   # one channel red
E   assert 0.0 == 1
E     +0.0
E     -1
```
This is caused by the same issue above (duplicate pick events)

```
_________________________ test_plot_raw_child_figures _________________________
mne\viz\tests\test_raw.py:332: in test_plot_raw_child_figures
    assert len(fig.mne.child_figs) == 1
E   assert 0 == 1
E     +0
E     -1
```
This is (probably) caused by the same issue above (duplicate pick events)

```
____________________________ test_plot_raw_traces _____________________________
mne\viz\tests\test_raw.py:393: in test_plot_raw_traces
    assert label in fig.mne.info['bads']
E   AssertionError: assert 'MEG 0112' in []
```
This is caused by the same issue above (duplicate pick events)


```
_________________________ test_plot_topo_image_epochs _________________________
mne\viz\tests\test_topo.py:240: in test_plot_topo_image_epochs
    assert num_figures_before + 1 == len(plt.get_fignums())
E   assert 2 == 1
E     +2
E     -1
```
cannot reproduce locally so far.  `git bisect` localizes this one to MPL commit https://github.com/matplotlib/matplotlib/commit/68498c634da803c447dbf0125fa7261ae81d61b4

```
_____________________________ test_plot_tfr_topo ______________________________
mne\viz\tests\test_topo.py:268: in test_plot_tfr_topo
    _fake_click(fig, fig.axes[0], (0.08, 0.65))
E   Failed: DID NOT WARN. No warnings of type (<class 'RuntimeWarning'>,) was emitted. The list of emitted warnings is: [].
```
cannot reproduce locally so far.  Probably caused by a different MPL commit than the one above.