### PR TITLE
MRG, ENH: macOS 11 compatiblity for STC plots

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -86,6 +86,8 @@ Enhancements
 
 - Reading and writing FIFF files whose filenames end with ``_meg.fif.gz``, ``_eeg.fif(.gz)``, and ``_ieeg.fif(.gz)`` doesn't emit a warning anymore; this improves interobaility with BIDS-formatted datasets (:gh:`8868` by `Richard Höchenberger`_)
 
+- macOS 11 compatibility for PyVista `~mne.SourceEstimate` plots (:gh:`8959` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 - Fix bug with `mne.connectivity.spectral_connectivity` where time axis in Epochs data object was dropped. (:gh:`8839` **by new contributor** |Anna Padee|_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -86,7 +86,7 @@ Enhancements
 
 - Reading and writing FIFF files whose filenames end with ``_meg.fif.gz``, ``_eeg.fif(.gz)``, and ``_ieeg.fif(.gz)`` doesn't emit a warning anymore; this improves interobaility with BIDS-formatted datasets (:gh:`8868` by `Richard Höchenberger`_)
 
-- macOS 11 compatibility for PyVista `~mne.SourceEstimate` plots (:gh:`8959` by `Richard Höchenberger`_)
+- macOS 11 compatibility for `~mne.SourceEstimate` plots (:gh:`8959` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -86,7 +86,7 @@ Enhancements
 
 - Reading and writing FIFF files whose filenames end with ``_meg.fif.gz``, ``_eeg.fif(.gz)``, and ``_ieeg.fif(.gz)`` doesn't emit a warning anymore; this improves interobaility with BIDS-formatted datasets (:gh:`8868` by `Richard Höchenberger`_)
 
-- macOS 11 compatibility for `~mne.SourceEstimate` plots (:gh:`8959` by `Richard Höchenberger`_)
+- On macOS, we now set the environment variable ``QT_MAC_WANTS_LAYER`` to ``"1"`` if it hasn't been set explicitly by the user, in order to ensure that `~mne.SourceEstimate` plots work on macOS 11 with older versions of Qt and PyQt (:gh:`8959` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -7,6 +7,8 @@
 #
 # License: Simplified BSD
 
+import sys
+import os
 from contextlib import contextmanager
 import importlib
 
@@ -111,6 +113,11 @@ def set_3d_backend(backend_name, verbose=None):
     if MNE_3D_BACKEND != backend_name:
         _reload_backend(backend_name)
         MNE_3D_BACKEND = backend_name
+
+    # Qt5 macOS 11 compatibility
+    if (backend_name == 'pyvista' and sys.platform == 'darwin' and
+            'QT_MAC_WANTS_LAYER' not in os.environ):
+        os.environ['QT_MAC_WANTS_LAYER'] = '1'
 
 
 def get_3d_backend():

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -115,8 +115,7 @@ def set_3d_backend(backend_name, verbose=None):
         MNE_3D_BACKEND = backend_name
 
     # Qt5 macOS 11 compatibility
-    if (backend_name == 'pyvista' and sys.platform == 'darwin' and
-            'QT_MAC_WANTS_LAYER' not in os.environ):
+    if sys.platform == 'darwin' and 'QT_MAC_WANTS_LAYER' not in os.environ:
         os.environ['QT_MAC_WANTS_LAYER'] = '1'
 
 


### PR DESCRIPTION
Sets `QT_MAC_WANTS_LAYER=1` for STC plots via PyVista / pyvistaqt.

Was required on my system with macOS 11.2.1, Qt 5.12.9, pyqt 5.12.3 (installed from `conda-forge`)

Previous fix via #8554 didn't cover STC plots.

cc @cbrnr, @GuillaumeFavelier