### PR TITLE
[MRG] Fix ica.plot_sources exception

### DIFF
--- a/examples/preprocessing/plot_run_ica.py
+++ b/examples/preprocessing/plot_run_ica.py
@@ -58,5 +58,5 @@ ica.plot_components(ecg_inds)
 ica.plot_properties(epochs, picks=ecg_inds)
 
 ###############################################################################
-# Plot the estimated source of detected ECG related components
+# Plot the estimated source of detected ECG related components:
 ica.plot_sources(raw, picks=ecg_inds)

--- a/mne/io/ctf/info.py
+++ b/mne/io/ctf/info.py
@@ -245,7 +245,7 @@ def _convert_channel_info(res4, t, use_eeg_pos):
                         warn('EEG electrode (%s) location omitted because of '
                              'missing HPI information' % ch['ch_name'])
                         ch['loc'].fill(np.nan)
-                        coord_frame = FIFF.FIFFV_COORD_CTF_HEAD
+                        coord_frame = FIFF.FIFFV_MNE_COORD_CTF_HEAD
                     else:
                         ch['loc'][:3] = apply_trans(
                             t['t_ctf_head_head'], ch['loc'][:3])

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -945,7 +945,7 @@ def _plot_sources(ica, inst, picks, exclude, start, stop, show, title, block,
     # create info
     info = create_info([ch_names[x] for x in picks], sfreq, ch_types=ch_types)
     info['meas_date'] = inst.info['meas_date']
-    info['bads'] = [ch_names[x] for x in exclude]
+    info['bads'] = [ch_names[x] for x in exclude if x in picks]
     if is_raw:
         inst_array = RawArray(data, info, inst.first_samp)
         inst_array.set_annotations(inst.annotations)

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -941,9 +941,10 @@ def _plot_sources(ica, inst, picks, exclude, start, stop, show, title, block,
         (picks, ica.n_components_ + np.arange(len(extra_picks))))
     ch_order = np.arange(len(picks))
     n_channels = min([20, len(picks)])
+    ch_names_picked = [ch_names[x] for x in picks]
 
     # create info
-    info = create_info([ch_names[x] for x in picks], sfreq, ch_types=ch_types)
+    info = create_info(ch_names_picked, sfreq, ch_types=ch_types)
     info['meas_date'] = inst.info['meas_date']
     info['bads'] = [ch_names[x] for x in exclude if x in picks]
     if is_raw:
@@ -984,7 +985,7 @@ def _plot_sources(ica, inst, picks, exclude, start, stop, show, title, block,
                   ica_inst=inst,
                   info=info,
                   # channels and channel order
-                  ch_names=np.array(ch_names),
+                  ch_names=np.array(ch_names_picked),
                   ch_types=np.array(ch_types),
                   ch_order=ch_order,
                   picks=picks,

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -231,7 +231,7 @@ def test_plot_ica_sources():
     _close_event(fig)
     assert len(plt.get_fignums()) == 0
     assert_array_equal(ica.exclude, [0])
-    # test when picks doesnt include exlude.
+    # test when picks does not include ica.exclude.
     fig = ica.plot_sources(raw, picks=[1])
     assert len(plt.get_fignums()) == 1
     plt.close('all')

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -231,6 +231,9 @@ def test_plot_ica_sources():
     _close_event(fig)
     assert len(plt.get_fignums()) == 0
     assert_array_equal(ica.exclude, [0])
+    # test when picks doesnt include exlude.
+    fig = ica.plot_sources(raw, picks=[1])
+    assert len(plt.get_fignums()) == 1
     plt.close('all')
 
     # dtype can change int->np.int64 after load, test it explicitly


### PR DESCRIPTION
#### What does this implement/fix?
```
ica.exclude = [0]
ica.plot_sources(raw, picks=[1, 2])
```
would raise an exception.

`RuntimeError: bad channel(s) ['ICA000'] marked do not exist in info`

Also fixed a typo in ctf.io

I don't think either of these have made it to release so no whats new.

closes #8966 
