### PR TITLE
MRG: FIX: TF_DICS mode 'cwt_morlet' can't take list of cycle numbers for d…

### DIFF
--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -679,11 +679,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
         raise ValueError('When using multitaper mode and specifying '
                          'multitaper transform bandwidth, one value must be '
                          'provided per frequency bin')
-<<<<<<< HEAD
     if isinstance(cwt_n_cycles, (int, float)):
-=======
-    if isinstance(cwt_n_cycles, [int, float]):
->>>>>>> Update mne/beamformer/_dics.py
         # create a list out of single values to match n_freq_bins
         n_cyc = cwt_n_cycles
         cwt_n_cycles = [n_cyc] * n_freq_bins

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -679,7 +679,11 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
         raise ValueError('When using multitaper mode and specifying '
                          'multitaper transform bandwidth, one value must be '
                          'provided per frequency bin')
+<<<<<<< HEAD
     if isinstance(cwt_n_cycles, (int, float)):
+=======
+    if isinstance(cwt_n_cycles, [int, float]):
+>>>>>>> Update mne/beamformer/_dics.py
         # create a list out of single values to match n_freq_bins
         n_cyc = cwt_n_cycles
         cwt_n_cycles = [n_cyc] * n_freq_bins

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -679,10 +679,10 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
         raise ValueError('When using multitaper mode and specifying '
                          'multitaper transform bandwidth, one value must be '
                          'provided per frequency bin')
-    if isinstance(cwt_n_cycles, int) or isinstance(cwt_n_cycles, float):
+    if isinstance(cwt_n_cycles, (int, float)):
         # create a list out of single values to match n_freq_bins
         n_cyc = cwt_n_cycles
-        cwt_n_cycles = [n_cyc for fb in range(n_freq_bins)]
+        cwt_n_cycles = [n_cyc] * n_freq_bins
 
     # Multiplying by 1e3 to avoid numerical issues, e.g. 0.3 // 0.05 == 5
     n_time_steps = int(((tmax - tmin) * 1e3) // (tstep * 1e3))

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -679,6 +679,10 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
         raise ValueError('When using multitaper mode and specifying '
                          'multitaper transform bandwidth, one value must be '
                          'provided per frequency bin')
+    if isinstance(cwt_n_cycles, int) or isinstance(cwt_n_cycles, float):
+        # create a list out of single values to match n_freq_bins
+        n_cyc = cwt_n_cycles
+        cwt_n_cycles = [n_cyc for fb in range(n_freq_bins)]
 
     # Multiplying by 1e3 to avoid numerical issues, e.g. 0.3 // 0.05 == 5
     n_time_steps = int(((tmax - tmin) * 1e3) // (tstep * 1e3))
@@ -703,6 +707,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
             freq_bin = frequencies[i_freq]
             fmin = np.min(freq_bin)
             fmax = np.max(freq_bin)
+            n_cycles = cwt_n_cycles[i_freq]
         else:
             fmin, fmax = freq_bins[i_freq]
             if n_ffts is None:
@@ -753,7 +758,7 @@ def tf_dics(epochs, forward, noise_csds, tmin, tmax, tstep, win_lengths,
                 elif mode == 'cwt_morlet':
                     csd = csd_morlet(
                         epochs, frequencies=freq_bin, tmin=win_tmin,
-                        tmax=win_tmax, n_cycles=cwt_n_cycles, decim=decim,
+                        tmax=win_tmax, n_cycles=n_cycles, decim=decim,
                         verbose=False)
                 else:
                     raise ValueError('Invalid mode, choose either '

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -679,9 +679,11 @@ def test_tf_dics(_load_forward):
     # Test if 'cwt_morlet' mode works with both fixed cycle numbers and lists
     # of cycle numbers
     tf_dics(epochs, fwd_surf, None, tmin, tmax, tstep,
-            win_lengths, frequencies=frequencies, mode='cwt_morlet',cwt_n_cycles=7)
+            win_lengths, frequencies=frequencies, mode='cwt_morlet',
+            cwt_n_cycles=7)
     tf_dics(epochs, fwd_surf, None, tmin, tmax, tstep,
-            win_lengths, frequencies=frequencies, mode='cwt_morlet',cwt_n_cycles=[5.,7.])
+            win_lengths, frequencies=frequencies, mode='cwt_morlet',
+            cwt_n_cycles=[5., 7.])
 
     # Test if subtracting evoked responses yields NaN's, since we only have one
     # epoch. Suppress division warnings.

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -676,6 +676,13 @@ def test_tf_dics(_load_forward):
                 win_lengths=win_lengths, freq_bins=freq_bins,
                 mode='multitaper', mt_bandwidths=[20])
 
+    # Test if 'cwt_morlet' mode works with both fixed cycle numbers and lists
+    # of cycle numbers
+    tf_dics(epochs, fwd_surf, None, tmin, tmax, tstep,
+            win_lengths, frequencies=frequencies, mode='cwt_morlet',cwt_n_cycles=7)
+    tf_dics(epochs, fwd_surf, None, tmin, tmax, tstep,
+            win_lengths, frequencies=frequencies, mode='cwt_morlet',cwt_n_cycles=[5.,7.])
+
     # Test if subtracting evoked responses yields NaN's, since we only have one
     # epoch. Suppress division warnings.
     assert len(epochs) == 1, len(epochs)


### PR DESCRIPTION
…ifferent frequency bins #8969


#### Reference issue
Fixes #8969


#### What does this implement/fix?
The tf_dics() function now works with mode 'cwt_morlet' both for fixed cycle numbers (single int or float) and lists of cycle numbers (one for each frequency bin specified). Lists did not work before, although the API stated otherwise.


#### Additional information
Any additional information you think is important.
