### PR TITLE
FIX: Brain Line2D

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1136,7 +1136,7 @@ class Brain(object):
         rms = np.linalg.norm(y, axis=0) / np.sqrt(len(y))
         del y
 
-        self.rms = self.mpl_canvas.axes.plot(
+        self.rms, = self.mpl_canvas.axes.plot(
             self._data['time'], rms,
             lw=3, label='RMS', zorder=3, color=self._fg_color,
             alpha=0.5, ls=':')


### PR DESCRIPTION
This PR fixes the issue with: 

```
Traceback (most recent call last):
  File "/home/circleci/project/mne/viz/_brain/_brain.py", line 50, in safe_event
    return fun(*args, **kwargs)
  File "/home/circleci/project/mne/viz/_brain/_brain.py", line 690, in _clean
    self.clear_glyphs()
  File "/home/circleci/project/mne/viz/_brain/_brain.py", line 1701, in clear_glyphs
    self.rms.remove()
TypeError: remove() takes exactly one argument (0 given)
```