### PR TITLE
MAINT: Skip matplotlib pre for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,14 +87,7 @@ jobs:
         - run:
             name: Get Python running
             command: |
-              python -m pip uninstall -y pydata-sphinx-theme
-              python -m pip install --user --upgrade --progress-bar off pip setuptools
-              python -m pip install --user --upgrade --progress-bar off --pre sphinx
-              python -m pip install --user --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
-              python -m pip install --user --progress-bar off https://github.com/pyvista/pyvista/zipball/master
-              python -m pip install --user --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
-              python -m pip uninstall -yq pysurfer mayavi
-              python -m pip install --user -e .
+              ./tools/circleci_dependencies.sh
 
         - save_cache:
             key: pip-cache

--- a/.github/workflows/linux_pip.yml
+++ b/.github/workflows/linux_pip.yml
@@ -1,4 +1,4 @@
-name: 'linux / pip'
+name: 'linux / pip-pre'
 on:
   push:
     branches:
@@ -22,7 +22,7 @@ jobs:
           commit-filter: '[skip ci];[ci skip];[skip github]'
           commit-filter-separator: ';'
 
-  # PIP + non-default stim channel + log level info
+  # PIP-pre + non-default stim channel + log level info
   job:
     needs: check_skip
     if: ${{ needs.check_skip.outputs.skip == 'false' }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -213,9 +213,6 @@ stages:
     # https://github.com/MicrosoftDocs/pipelines-anaconda
     # Qt 5.9 post-link failure:
     # https://github.com/ContinuumIO/anaconda-issues/issues/10949
-    - script: echo "##vso[task.prependpath]%CONDA%;%CONDA%\condabin;%CONDA%\Scripts;%CONDA%\Library\bin;%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem;"
-      condition: in(variables['TEST_MODE'], 'conda')
-      displayName: Add conda to PATH, deal with Qt 5.9 bug
     - bash: |
         set -e
         git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
@@ -223,33 +220,8 @@ stages:
       displayName: Install OpenGL
     - bash: |
         set -e
-        python -m pip install --upgrade pip setuptools
-        python -m pip install --upgrade numpy scipy vtk
-        python -m pip install --upgrade --use-deprecated=legacy-resolver --only-binary="numba,llvmlite" -r requirements.txt -r requirements_testing.txt
-        python -m pip install codecov
-      condition: eq(variables['TEST_MODE'], 'pip')
-      displayName: 'Install dependencies with pip'
-    - bash: |
-        set -e
-        python -m pip install --upgrade pip setuptools
-        python -m pip install --use-deprecated=legacy-resolver --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy
-        python -m pip install --use-deprecated=legacy-resolver --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" scipy pandas scikit-learn matplotlib h5py Pillow
-        python -m pip install --upgrade --only-binary vtk vtk;
-        python -m pip install https://github.com/pyvista/pyvista/zipball/master
-        python -m pip install https://github.com/pyvista/pyvistaqt/zipball/master
-        python -m pip install --use-deprecated=legacy-resolver --only-binary="numba,llvmlite" -r requirements.txt -r requirements_testing.txt codecov
-      condition: eq(variables['TEST_MODE'], 'pre-pip')
-      displayName: 'Install dependencies with pip --pre'
-    - powershell: |
-        Set-StrictMode -Version Latest
-        $ErrorActionPreference = "Stop"
-        $PSDefaultParameterValues['*:ErrorAction']='Stop'
-        conda update -n base -c defaults conda
-        conda env update --name base --file environment.yml
-        pip uninstall -yq mne
-        pip install -r requirements_testing.txt codecov
-      condition: eq(variables['TEST_MODE'], 'conda')
-      displayName: 'Install dependencies with conda'
+        ./tools/azure_dependencies.sh
+      displayName: 'Install dependencies'
     - script: python setup.py develop
       displayName: 'Install MNE-Python dev'
     - script: mne sys_info

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -213,6 +213,9 @@ stages:
     # https://github.com/MicrosoftDocs/pipelines-anaconda
     # Qt 5.9 post-link failure:
     # https://github.com/ContinuumIO/anaconda-issues/issues/10949
+    - script: echo "##vso[task.prependpath]%CONDA%;%CONDA%\condabin;%CONDA%\Scripts;%CONDA%\Library\bin;%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem;"
+      condition: in(variables['TEST_MODE'], 'conda')
+      displayName: Add conda to PATH, deal with Qt 5.9 bug
     - bash: |
         set -e
         git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,7 +198,7 @@ stages:
           TEST_MODE: 'pip'
           PYTHON_VERSION: '3.7'
         3.8 pip pre:
-          TEST_MODE: 'pre-pip'
+          TEST_MODE: 'pip-pre'
           PYTHON_VERSION: '3.8'
           OPENBLAS_CORETYPE: 'prescott'  # workaround for https://github.com/numpy/numpy/issues/16913
     steps:
@@ -207,7 +207,7 @@ stages:
         versionSpec: $(PYTHON_VERSION)
         architecture: $(PYTHON_ARCH)
         addToPath: true
-      condition: in(variables['TEST_MODE'], 'pip', 'pre-pip')
+      condition: in(variables['TEST_MODE'], 'pip', 'pip-pre')
       displayName: 'Get Python'
     # https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/anaconda
     # https://github.com/MicrosoftDocs/pipelines-anaconda

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -14,7 +14,7 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --upgrade pip setuptools
 	python -m pip install --use-deprecated=legacy-resolver --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy
 	python -m pip install --use-deprecated=legacy-resolver --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" scipy pandas scikit-learn h5py Pillow
-	python -m pip install --use-deprecated=legacy-resolver --upgrade --pre --only-binary matplotlib
+	python -m pip install --use-deprecated=legacy-resolver --upgrade --pre --only-binary ":all:" matplotlib
 	python -m pip install --upgrade --only-binary vtk vtk;
 	python -m pip install https://github.com/pyvista/pyvista/zipball/master
 	python -m pip install https://github.com/pyvista/pyvistaqt/zipball/master

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -ef
+
+if [ "${TEST_MODE}" == "conda" ]; then
+	echo "##vso[task.prependpath]%CONDA%;%CONDA%\condabin;%CONDA%\Scripts;%CONDA%\Library\bin;%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem;"
+	PATH="$PATH:$CONDA:$CONDA\condabin:$CONDA\Scripts:$CONDA\Library\bin:$SystemRoot\system32:$SystemRoot:$SystemRoot\System32\Wbem"
+	conda update -n base -c defaults conda
+	conda env update --name base --file environment.yml
+	pip uninstall -yq mne
+elif [ "${TEST_MODE}" == "pip" ]; then
+	python -m pip install --upgrade pip setuptools
+	python -m pip install --upgrade numpy scipy vtk
+	python -m pip install --use-deprecated=legacy-resolver --only-binary="numba,llvmlite" -r requirements.txt
+elif [ "${TEST_MODE}" == "pip-pre" ]; then
+	python -m pip install --upgrade pip setuptools
+	python -m pip install --use-deprecated=legacy-resolver --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy
+	python -m pip install --use-deprecated=legacy-resolver --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" scipy pandas scikit-learn h5py Pillow
+	python -m pip install --use-deprecated=legacy-resolver --upgrade --pre --only-binary matplotlib
+	python -m pip install --upgrade --only-binary vtk vtk;
+	python -m pip install https://github.com/pyvista/pyvista/zipball/master
+	python -m pip install https://github.com/pyvista/pyvistaqt/zipball/master
+	python -m pip install --use-deprecated=legacy-resolver --only-binary="numba,llvmlite" -r requirements.txt
+else
+	echo "Unknown run type ${TEST_MODE}"
+	exit 1
+fi
+python -m pip install -r requirements_testing.txt codecov

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -12,7 +12,7 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --upgrade pip setuptools
 	python -m pip install --use-deprecated=legacy-resolver --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy
 	python -m pip install --use-deprecated=legacy-resolver --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" scipy pandas scikit-learn h5py Pillow
-	python -m pip install --use-deprecated=legacy-resolver --upgrade --pre --only-binary ":all:" matplotlib
+	python -m pip install --use-deprecated=legacy-resolver --upgrade --only-binary ":all:" matplotlib
 	python -m pip install --upgrade --only-binary vtk vtk;
 	python -m pip install https://github.com/pyvista/pyvista/zipball/master
 	python -m pip install https://github.com/pyvista/pyvistaqt/zipball/master

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -2,7 +2,7 @@
 
 if [ "${TEST_MODE}" == "conda" ]; then
 	echo "##vso[task.prependpath]%CONDA%;%CONDA%\condabin;%CONDA%\Scripts;%CONDA%\Library\bin;%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem;"
-	PATH="$PATH:$CONDA:$CONDA\condabin:$CONDA\Scripts:$CONDA\Library\bin:$SystemRoot\system32:$SystemRoot:$SystemRoot\System32\Wbem"
+	export PATH="$CONDA:$CONDA\condabin:$CONDA\Scripts:$CONDA\Library\bin:$SystemRoot\system32:$SystemRoot:$SystemRoot\System32\Wbem:$PATH"
 	conda update -n base -c defaults conda
 	conda env update --name base --file environment.yml
 	pip uninstall -yq mne

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -1,8 +1,6 @@
 #!/bin/bash -ef
 
 if [ "${TEST_MODE}" == "conda" ]; then
-	echo "##vso[task.prependpath]%CONDA%;%CONDA%\condabin;%CONDA%\Scripts;%CONDA%\Library\bin;%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem;"
-	export PATH="$CONDA:$CONDA\condabin:$CONDA\Scripts:$CONDA\Library\bin:$SystemRoot\system32:$SystemRoot:$SystemRoot\System32\Wbem:$PATH"
 	conda update -n base -c defaults conda
 	conda env update --name base --file environment.yml
 	pip uninstall -yq mne

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ef
+
+python -m pip uninstall -y pydata-sphinx-theme
+python -m pip install --user --upgrade --progress-bar off pip setuptools
+python -m pip install --user --upgrade --progress-bar off --pre sphinx
+python -m pip install --user --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
+python -m pip install --user --progress-bar off https://github.com/pyvista/pyvista/zipball/master
+python -m pip install --user --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
+python -m pip uninstall -yq pysurfer mayavi
+python -m pip install --user -e .

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -4,7 +4,7 @@ if [ ! -z "$CONDA_ENV" ]; then
 	pip uninstall -yq mne
 elif [ ! -z "$CONDA_DEPENDENCIES" ]; then
 	conda install -y $CONDA_DEPENDENCIES
-else # pip 3.9 (missing statsmodels and dipy)
+else # pip --pre 3.9 (missing statsmodels and dipy)
 	python -m pip install --progress-bar off --upgrade "pip!=20.3.0" setuptools wheel
 	pip uninstall -yq numpy
 	pip install --progress-bar off --upgrade --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -11,7 +11,7 @@ else # pip --pre 3.9 (missing statsmodels and dipy)
 	pip install --use-deprecated=legacy-resolver --progress-bar off --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy
 	pip install --progress-bar off --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" pandas scikit-learn
 	# pip install --progress-bar off --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" matplotlib
-	pip install --progress-bar off --upgrade --pre --only-binary ":all:" matplotlib
+	pip install --progress-bar off --upgrade --only-binary ":all:" matplotlib
 	# built using vtk master branch on an Ubuntu 18.04.5 VM and uploaded to OSF:
 	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 	pip install vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -10,7 +10,8 @@ else # pip 3.9 (missing statsmodels and dipy)
 	pip install --progress-bar off --upgrade --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl
 	pip install --use-deprecated=legacy-resolver --progress-bar off --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy
 	pip install --progress-bar off --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" pandas scikit-learn
-	pip install --progress-bar off --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" matplotlib
+	# pip install --progress-bar off --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" matplotlib
+	pip install --progress-bar off --upgrade --pre --only-binary ":all:" matplotlib
 	# built using vtk master branch on an Ubuntu 18.04.5 VM and uploaded to OSF:
 	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 	pip install vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl


### PR DESCRIPTION
Two CIs being broken has been problematic, let's avoid `--pre` on the problematic library until it's fixed (https://github.com/matplotlib/matplotlib/issues/19576).

Also makes these sorts of changes easier in the future by consolidating dependencies a tiny bit, and making it so the the CI can reflect the change using a merge (which happens automatically when building) rather than requiring a rebase, which will be nice.