### PR TITLE
MAINT: Revert conda azure change

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,7 +224,18 @@ stages:
     - bash: |
         set -e
         ./tools/azure_dependencies.sh
-      displayName: 'Install dependencies'
+      condition: in(variables['TEST_MODE'], 'pip', 'pip-pre')
+      displayName: 'Install dependencies with pip'
+    - powershell: |
+        Set-StrictMode -Version Latest
+        $ErrorActionPreference = "Stop"
+        $PSDefaultParameterValues['*:ErrorAction']='Stop'
+        conda update -n base -c defaults conda
+        conda env update --name base --file environment.yml
+        pip uninstall -yq mne
+        pip install -r requirements_testing.txt codecov
+      condition: eq(variables['TEST_MODE'], 'conda')
+      displayName: 'Install dependencies with conda'
     - script: python setup.py develop
       displayName: 'Install MNE-Python dev'
     - script: mne sys_info

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -1,10 +1,6 @@
 #!/bin/bash -ef
 
-if [ "${TEST_MODE}" == "conda" ]; then
-	conda update -n base -c defaults conda
-	conda env update --name base --file environment.yml
-	pip uninstall -yq mne
-elif [ "${TEST_MODE}" == "pip" ]; then
+if [ "${TEST_MODE}" == "pip" ]; then
 	python -m pip install --upgrade pip setuptools
 	python -m pip install --upgrade numpy scipy vtk
 	python -m pip install --use-deprecated=legacy-resolver --only-binary="numba,llvmlite" -r requirements.txt


### PR DESCRIPTION
For some unknown reason #8973 caused timeouts in the windows 3.7 conda run. This PR reverts the conda commands to be in the YAML which is a bit annoying but should at least work. Probably some bash vs powershell issue...