### PR TITLE
MRG, DOC: fix link to install instructions

### DIFF
--- a/doc/overview/index.rst
+++ b/doc/overview/index.rst
@@ -8,8 +8,8 @@ Documentation overview
 .. note::
 
    If you haven't already installed Python and MNE-Python, here are the
-   :doc:`installation instructions <install/index>`, and some resources for
-   :doc:`learn_python`.
+   :ref:`installation instructions <install_python_and_mne_python>`, and some
+   resources for :doc:`learn_python`.
 
 
 The documentation for MNE-Python is divided into four main sections:


### PR DESCRIPTION
fixes a doc link that is currently resolving (wrongly) to https://docs.python.org/3/install/index.html