### PR TITLE
MRG, FIX: Fix rebuilding of all files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
               echo "export DISPLAY=:99" >> $BASH_ENV
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
               echo "export XDG_RUNTIME_DIR=/tmp/runtime-circleci" >> $BASH_ENV
+              echo "export MNE_FULL_DATE=true" >> $BASH_ENV
               source tools/get_minimal_commands.sh
               echo "export MNE_3D_BACKEND=pyvista" >> $BASH_ENV
               echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,9 +45,14 @@ sys.path.append(os.path.abspath(os.path.join(curdir, 'sphinxext')))
 
 project = 'MNE'
 td = datetime.now(tz=timezone.utc)
+
+# We need to triage which date type we use so that incremental builds work
+# (Sphinx looks at variable changes and rewrites all files if some change)
 copyright = (
     f'2012–{td.year}, MNE Developers. Last updated <time datetime="{td.isoformat()}" class="localized">{td.strftime("%Y-%m-%d %H:%M %Z")}</time>\n'  # noqa: E501
     '<script type="text/javascript">$(function () { $("time.localized").each(function () { var el = $(this); el.text(new Date(el.attr("datetime")).toLocaleString([], {dateStyle: "medium", timeStyle: "long"})); }); } )</script>')  # noqa: E501
+if os.getenv('MNE_FULL_DATE', 'false').lower() != 'true':
+    copyright = f'2012–{td.year}, MNE Developers. Last updated locally.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
The date changes that resolve the datetime locally are useful for end-users but bad for developers because it means that a sphinx config value changes on every run, which means that all files must be rewritten. On this PR CircleCI gets the full date, but locally we get a config var that just changes once a year, which seems like a good compromise.