### PR TITLE
WIP: Prototype of MultiPlotter

### DIFF
--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -34,7 +34,7 @@ class _QtDock(_AbstractDock):
         self.scroll.setWidgetResizable(True)
         self.dock.setAllowedAreas(Qt.LeftDockWidgetArea)
         self.dock.setFeatures(QDockWidget.NoDockWidgetFeatures)
-        self.plotter.app_window.addDockWidget(Qt.LeftDockWidgetArea, self.dock)
+        self.plotter._window.addDockWidget(Qt.LeftDockWidgetArea, self.dock)
         self.dock_layout = QVBoxLayout()
         widget.setLayout(self.dock_layout)
 
@@ -226,7 +226,7 @@ class _QtToolBar(_AbstractToolBar):
 
     def _tool_bar_initialize(self, name="default"):
         self.actions = dict()
-        self.tool_bar = self.plotter.app_window.addToolBar(name)
+        self.tool_bar = self.plotter._window.addToolBar(name)
 
     def _tool_bar_finalize(self):
         pass

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -34,7 +34,7 @@ class _QtDock(_AbstractDock):
         self.scroll.setWidgetResizable(True)
         self.dock.setAllowedAreas(Qt.LeftDockWidgetArea)
         self.dock.setFeatures(QDockWidget.NoDockWidgetFeatures)
-        self.plotter._window.addDockWidget(Qt.LeftDockWidgetArea, self.dock)
+        self.figure.plotter._window.addDockWidget(Qt.LeftDockWidgetArea, self.dock)
         self.dock_layout = QVBoxLayout()
         widget.setLayout(self.dock_layout)
 
@@ -226,7 +226,7 @@ class _QtToolBar(_AbstractToolBar):
 
     def _tool_bar_initialize(self, name="default"):
         self.actions = dict()
-        self.tool_bar = self.plotter._window.addToolBar(name)
+        self.tool_bar = self.figure.plotter._window.addToolBar(name)
 
     def _tool_bar_finalize(self):
         pass


### PR DESCRIPTION
I have been experimenting with the new PyVistaQt class MultiPlotter to bring proper SSAO and/or EDL to MNE on https://github.com/mne-tools/mne-python/pull/8771#issuecomment-765449184 (among other features like multiple toolbars, menu bars and multi-renderers). And I don't think it's reasonable to do that in one go.

This PR is far from being mergeable but I believe it could drive smaller PRs that can help with 3d backend refactoring in general. For instance:
- [ ] Separate the concepts of "plotter" and 3d "viewer"
- [ ] Get rid of `self.plotter` in `Brain` and use `self._renderer` instead
- [ ] Get rid of `self.plotter` in `_Renderer` and use `self.figure` instead
- [ ] Create proper `Renderer` bindings for `add_mesh` and `add_actor`
- [ ] Generic way to pick a 3d viewer
- [ ] Generic way to subplot
- [ ] Generic way to iterate through the 3d viewers