### PR TITLE
MNT: 3d viewer loc and idx

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -992,7 +992,7 @@ class Brain(object):
         if len(rends) > 1:
             def select_renderer(idx):
                 idx = int(idx)
-                loc = self.plotter.index_to_loc(idx)
+                loc = self._renderer._index_to_loc(idx)
                 self.plotter.subplot(*loc)
 
             self.callbacks["renderer"] = SmartCallBack(
@@ -1019,7 +1019,7 @@ class Brain(object):
         orientation_data = [None] * len(rends)
         for hemi in hemis_ref:
             for ri, ci, view in self._iter_views(hemi):
-                idx = self.plotter.loc_to_index((ri, ci))
+                idx = self._renderer._loc_to_index((ri, ci))
                 if view == 'flat':
                     _data = None
                 else:
@@ -1639,7 +1639,7 @@ class Brain(object):
 
         # from the picked renderer to the subplot coords
         rindex = self.plotter.renderers.index(self.picked_renderer)
-        row, col = self.plotter.index_to_loc(rindex)
+        row, col = self._renderer._index_to_loc(rindex)
 
         actors = list()
         spheres = list()

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -75,6 +75,7 @@ class _Figure(object):
         # multi_samples > 1 is broken on macOS + Intel Iris + volume rendering
         self.store['multi_samples'] = 1 if sys.platform == 'darwin' else 4
 
+        self._nrows, self._ncols = self.store["shape"]
         self._azimuth = self._elevation = None
 
     def build(self):
@@ -172,7 +173,6 @@ class _PyVistaRenderer(_AbstractRenderer):
                          smooth_shading=smooth_shading)
         self.font_family = "arial"
         self.tube_n_sides = 20
-        self.shape = shape
         antialias = _get_3d_option('antialias')
         self.antialias = antialias and not MNE_3D_BACKEND_TESTING
         if isinstance(fig, int):
@@ -249,9 +249,19 @@ class _PyVistaRenderer(_AbstractRenderer):
             _process_events(self.plotter)
             _process_events(self.plotter)
 
+    def _index_to_loc(self, idx):
+        _ncols = self.figure._ncols
+        row = idx // _ncols
+        col = idx % _ncols
+        return (row, col)
+
+    def _loc_to_index(self, loc):
+        _ncols = self.figure._ncols
+        return loc[0] * _ncols + loc[1]
+
     def subplot(self, x, y):
-        x = np.max([0, np.min([x, self.shape[0] - 1])])
-        y = np.max([0, np.min([y, self.shape[1] - 1])])
+        x = np.max([0, np.min([x, self.figure._nrows - 1])])
+        y = np.max([0, np.min([y, self.figure._ncols - 1])])
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)
             self.plotter.subplot(x, y)


### PR DESCRIPTION
This small PR should help with #8997. It refactors some `plotter` calls out of `Brain` and uses `self.figure` instead.