### PR TITLE
DOC: Correct `plot_epochs` doc

### DIFF
--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -658,7 +658,7 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
     title : str | None
         The title of the window. If None, epochs name will be displayed.
         Defaults to None.
-    events : None, array, shape (n_events, 3)
+    events : None | array, shape (n_events, 3)
         Events to show with vertical bars. You can use `~mne.viz.plot_events`
         as a legend for the colors. By default, the coloring scheme is the
         same. Defaults to ``None``.

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -659,11 +659,9 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
         The title of the window. If None, epochs name will be displayed.
         Defaults to None.
     events : None, array, shape (n_events, 3)
-        Events to show with vertical bars. If events are provided, the epoch
-        numbers are not shown to prevent overlap. You can toggle epoch
-        numbering through options (press 'o' key). You can use
-        `~mne.viz.plot_events` as a legend for the colors. By default, the
-        coloring scheme is the same.
+        Events to show with vertical bars. You can use `~mne.viz.plot_events`
+        as a legend for the colors. By default, the coloring scheme is the
+        same. Defaults to ``None``.
 
         .. warning::  If the epochs have been resampled, the events no longer
             align with the data.

--- a/tutorials/epochs/plot_10_epochs_overview.py
+++ b/tutorials/epochs/plot_10_epochs_overview.py
@@ -176,20 +176,17 @@ print(epochs.drop_log[-4:])
 # The :class:`~mne.Epochs` object can be visualized with its events (and
 # browsed interactively) using its :meth:`~mne.Epochs.plot` method:
 
-epochs.plot(n_epochs=10, events=epochs.events)
+epochs.plot(n_epochs=10)
 
 ###############################################################################
 # Notice that the individual epochs are sequentially numbered along the bottom
-# axis; the event ID associated with the epoch is marked on the top axis;
-# epochs are separated by vertical dashed lines; and a vertical solid green
-# line marks time=0 for each epoch (i.e., in this case, the stimulus onset
-# time for each trial). Epoch plots are interactive (similar to
-# :meth:`raw.plot() <mne.io.Raw.plot>`) and have many of the same interactive
-# controls as :class:`~mne.io.Raw` plots. Horizontal and vertical scrollbars
-# allow browsing through epochs or channels (respectively), and pressing
-# :kbd:`?` when the plot is focused will show a help screen with all the
-# available controls. See :ref:`tut-visualize-epochs` for more details (as well
-# as other ways of visualizing epoched data).
+# axis. Epoch plots are interactive (similar to :meth:`raw.plot()
+# <mne.io.Raw.plot>`) and have many of the same interactive controls as
+# :class:`~mne.io.Raw` plots. Horizontal and vertical scrollbars allow browsing
+# through epochs or channels (respectively), and pressing :kbd:`?` when the
+# plot is focused will show a help screen with all the available controls. See
+# :ref:`tut-visualize-epochs` for more details (as well as other ways of
+# visualizing epoched data).
 #
 #
 # .. _tut-section-subselect-epochs:

--- a/tutorials/epochs/plot_10_epochs_overview.py
+++ b/tutorials/epochs/plot_10_epochs_overview.py
@@ -180,7 +180,8 @@ epochs.plot(n_epochs=10)
 
 ###############################################################################
 # Notice that the individual epochs are sequentially numbered along the bottom
-# axis. Epoch plots are interactive (similar to :meth:`raw.plot()
+# axis and are separated by vertical dashed lines.
+# Epoch plots are interactive (similar to :meth:`raw.plot()
 # <mne.io.Raw.plot>`) and have many of the same interactive controls as
 # :class:`~mne.io.Raw` plots. Horizontal and vertical scrollbars allow browsing
 # through epochs or channels (respectively), and pressing :kbd:`?` when the

--- a/tutorials/epochs/plot_10_epochs_overview.py
+++ b/tutorials/epochs/plot_10_epochs_overview.py
@@ -173,10 +173,10 @@ print(epochs.drop_log[-4:])
 # Basic visualization of ``Epochs`` objects
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# The :class:`~mne.Epochs` object can be visualized (and browsed interactively)
-# using its :meth:`~mne.Epochs.plot` method:
+# The :class:`~mne.Epochs` object can be visualized with its events (and
+# browsed interactively) using its :meth:`~mne.Epochs.plot` method:
 
-epochs.plot(n_epochs=10)
+epochs.plot(n_epochs=10, events=epochs.events)
 
 ###############################################################################
 # Notice that the individual epochs are sequentially numbered along the bottom


### PR DESCRIPTION
#### Reference issue
Closes #8895.


#### What does this implement/fix?
1. Corrects the documentation of the `events` argument of `plot_epochs`.
2. Adds visualisation of event bars for the epochs plot in the tutorial.


#### Additional information
@drammock, following the discussion in the issue, I wasn't sure if you wanted me to update the tutorial as well, I can undo it if you prefer not to.

Additionally, I noticed when plotting the epochs with events in the tutorial that some do not have events (those before events 32), I'm not sure if that's normal?
![screenshot](https://user-images.githubusercontent.com/32393169/110237777-ba44d700-7f35-11eb-9c25-261664c173aa.png)
