### PR TITLE
MNT: menu_bar & status_bar

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -624,11 +624,9 @@ class Brain(object):
         # Direct access parameters:
         self.tool_bar = None
         if self.notebook:
-            self.main_menu = None
             self.status_bar = None
             self.interactor = None
         else:
-            self.main_menu = self.plotter.main_menu
             self.status_bar = self.window.statusBar()
             self.interactor = self.plotter.interactor
 
@@ -667,13 +665,13 @@ class Brain(object):
         self._configure_picking()
         self._configure_tool_bar()
         self._configure_dock()
+        self._configure_menu()
         if self.notebook:
             self._renderer.show()
             self.mpl_canvas.show()
         self.toggle_interface()
         if not self.notebook:
             self._configure_playback()
-            self._configure_menu()
             self._configure_status_bar()
 
             # show everything at the end
@@ -712,10 +710,10 @@ class Brain(object):
         if getattr(self.plotter, 'picker', None) is not None:
             self.plotter.picker = None
         # XXX end PyVista
-        for key in ('plotter', 'main_menu', 'window', 'tool_bar',
+        for key in ('plotter', 'window', 'dock', 'tool_bar', 'menu_bar',
                     'status_bar', 'interactor', 'mpl_canvas', 'time_actor',
-                    'picked_renderer', 'act_data_smooth', '_iren',
-                    'actions', 'widgets', 'geo', '_hemi_actors', '_data'):
+                    'picked_renderer', 'act_data_smooth',
+                    'actions', 'widgets', 'geo', '_data'):
             setattr(self, key, None)
 
     @contextlib.contextmanager
@@ -1463,17 +1461,19 @@ class Brain(object):
             self.plotter.add_key_event(key, partial(func, sign * _ARROW_MOVE))
 
     def _configure_menu(self):
-        # remove default picking menu
-        to_remove = list()
-        for action in self.main_menu.actions():
-            if action.text() == "Tools":
-                to_remove.append(action)
-        for action in to_remove:
-            self.main_menu.removeAction(action)
-
-        # add help menu
-        menu = self.main_menu.addMenu('Help')
-        menu.addAction('Show MNE key bindings\t?', self.help)
+        if self.notebook:
+            return
+        self._renderer._menu_initialize()
+        self._renderer._menu_add_submenu(
+            name="help",
+            desc="Help",
+        )
+        self._renderer._menu_add_button(
+            menu_name="help",
+            name="help",
+            desc="Show MNE key bindings\t?",
+            func=self.help,
+        )
 
     def _configure_status_bar(self):
         from PyQt5.QtWidgets import QLabel, QProgressBar

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1458,8 +1458,6 @@ class Brain(object):
             self.plotter.add_key_event(key, partial(func, sign * _ARROW_MOVE))
 
     def _configure_menu(self):
-        if self.notebook:
-            return
         self._renderer._menu_initialize(window=self.window)
         self._renderer._menu_add_submenu(
             name="help",
@@ -1473,13 +1471,12 @@ class Brain(object):
         )
 
     def _configure_status_bar(self):
-        if self.notebook:
-            return
         self._renderer._status_bar_initialize(window=self.window)
         self.status_msg = self._renderer._status_bar_add_label(
             self.default_status_bar_msg, stretch=1)
         self.status_progress = self._renderer._status_bar_add_progress_bar()
-        self.status_progress.hide()
+        if self.status_progress is not None:
+            self.status_progress.hide()
 
     def _on_mouse_move(self, vtk_picker, event):
         if self._mouse_no_mvt:

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -622,7 +622,6 @@ class Brain(object):
         self.keys = ('fmin', 'fmid', 'fmax')
 
         # Direct access parameters:
-        self.tool_bar = None
         if self.notebook:
             self.status_bar = None
             self.interactor = None

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1201,7 +1201,7 @@ class Brain(object):
         )
 
     def _configure_dock(self):
-        self._renderer._dock_initialize()
+        self._renderer._dock_initialize(window=self.window)
         self._configure_dock_playback_widget(name="Playback")
         self._configure_dock_orientation_widget(name="Orientation")
         self._configure_dock_colormap_widget(name="Color Limits")
@@ -1367,7 +1367,7 @@ class Brain(object):
 
     def _configure_tool_bar(self):
         self._renderer._tool_bar_load_icons()
-        self._renderer._tool_bar_initialize()
+        self._renderer._tool_bar_initialize(window=self.window)
         self._renderer._tool_bar_add_button(
             name="screenshot",
             desc="Take a screenshot",
@@ -1462,7 +1462,7 @@ class Brain(object):
     def _configure_menu(self):
         if self.notebook:
             return
-        self._renderer._menu_initialize()
+        self._renderer._menu_initialize(window=self.window)
         self._renderer._menu_add_submenu(
             name="help",
             desc="Help",

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -623,10 +623,8 @@ class Brain(object):
 
         # Direct access parameters:
         if self.notebook:
-            self.status_bar = None
             self.interactor = None
         else:
-            self.status_bar = self.window.statusBar()
             self.interactor = self.plotter.interactor
 
         # Derived parameters:
@@ -665,13 +663,13 @@ class Brain(object):
         self._configure_tool_bar()
         self._configure_dock()
         self._configure_menu()
+        self._configure_status_bar()
         if self.notebook:
             self._renderer.show()
             self.mpl_canvas.show()
         self.toggle_interface()
         if not self.notebook:
             self._configure_playback()
-            self._configure_status_bar()
 
             # show everything at the end
             with _qt_disable_paint(self.plotter):
@@ -1475,11 +1473,12 @@ class Brain(object):
         )
 
     def _configure_status_bar(self):
-        from PyQt5.QtWidgets import QLabel, QProgressBar
-        self.status_msg = QLabel(self.default_status_bar_msg)
-        self.status_progress = QProgressBar()
-        self.status_bar.layout().addWidget(self.status_msg, 1)
-        self.status_bar.layout().addWidget(self.status_progress, 0)
+        if self.notebook:
+            return
+        self._renderer._status_bar_initialize(window=self.window)
+        self.status_msg = self._renderer._status_bar_add_label(
+            self.default_status_bar_msg, stretch=1)
+        self.status_progress = self._renderer._status_bar_add_progress_bar()
         self.status_progress.hide()
 
     def _on_mouse_move(self, vtk_picker, event):

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -449,7 +449,7 @@ class _AbstractToolBar(ABC):
         pass
 
     @abstractmethod
-    def _tool_bar_initialize(self, name="default"):
+    def _tool_bar_initialize(self, window, name="default"):
         pass
 
     @abstractmethod
@@ -475,7 +475,7 @@ class _AbstractToolBar(ABC):
 
 class _AbstractDock(ABC):
     @abstractmethod
-    def _dock_initialize(self):
+    def _dock_initialize(self, window):
         pass
 
     @abstractmethod

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -528,3 +528,31 @@ class _AbstractDock(ABC):
     @abstractmethod
     def _dock_add_group_box(self, name, layout=None):
         pass
+
+
+class _AbstractMenuBar(ABC):
+    @abstractmethod
+    def _menu_initialize(self, window):
+        pass
+
+    @abstractmethod
+    def _menu_add_submenu(self, name, desc):
+        pass
+
+    @abstractmethod
+    def _menu_add_button(self, menu_name, name, desc, func):
+        pass
+
+
+class _AbstractStatusBar(ABC):
+    @abstractmethod
+    def _status_bar_initialize(self, window):
+        pass
+
+    @abstractmethod
+    def _status_bar_add_label(self, value, stretch=0):
+        pass
+
+    @abstractmethod
+    def _status_bar_add_progress_bar(self, stretch=0):
+        pass

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -9,7 +9,8 @@ from ipywidgets import (Button, Dropdown, FloatSlider, FloatText, HBox,
                         IntSlider, IntText, Text, VBox)
 
 from ...fixes import nullcontext
-from ._abstract import _AbstractDock, _AbstractToolBar
+from ._abstract import (_AbstractDock, _AbstractToolBar, _AbstractMenuBar,
+                        _AbstractStatusBar)
 from ._pyvista import _PyVistaRenderer, _close_all, _set_3d_view, _set_3d_title  # noqa: F401,E501, analysis:ignore
 
 
@@ -153,7 +154,30 @@ class _IpyToolBar(_AbstractToolBar):
         pass
 
 
-class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar):
+class _IpyMenuBar(_AbstractMenuBar):
+    def _menu_initialize(self, window):
+        pass
+
+    def _menu_add_submenu(self, name, desc):
+        pass
+
+    def _menu_add_button(self, menu_name, name, desc, func):
+        pass
+
+
+class _IpyStatusBar(_AbstractStatusBar):
+    def _status_bar_initialize(self, window):
+        pass
+
+    def _status_bar_add_label(self, value, stretch=0):
+        pass
+
+    def _status_bar_add_progress_bar(self, stretch=0):
+        pass
+
+
+class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
+                _IpyStatusBar):
     def __init__(self, *args, **kwargs):
         self.dock = None
         self.tool_bar = None

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -14,7 +14,7 @@ from ._pyvista import _PyVistaRenderer, _close_all, _set_3d_view, _set_3d_title 
 
 
 class _IpyDock(_AbstractDock):
-    def _dock_initialize(self):
+    def _dock_initialize(self, window):
         self.dock_width = 300
         self.dock = self.dock_layout = VBox()
         self.dock.layout.width = f"{self.dock_width}px"
@@ -124,7 +124,7 @@ class _IpyToolBar(_AbstractToolBar):
         self.icons["visibility_on"] = "eye"
         self.icons["visibility_off"] = "eye"
 
-    def _tool_bar_initialize(self, name="default"):
+    def _tool_bar_initialize(self, window, name="default"):
         self.actions = dict()
         self.tool_bar = HBox()
 

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -167,7 +167,7 @@ class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar):
 
     def _create_default_tool_bar(self):
         self._tool_bar_load_icons()
-        self._tool_bar_initialize()
+        self._tool_bar_initialize(window=None)
         self._tool_bar_add_button(
             name="screenshot",
             desc="Take a screenshot",

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -75,10 +75,10 @@ class _Figure(object):
             self.store['show'] = show
             self.store['title'] = title
             self.store['auto_update'] = False
-            self.store["menu_bar"] = False
-            self.store["toolbar"] = False
+            self.store['menu_bar'] = False
+            self.store['toolbar'] = False
 
-        self._nrows, self._ncols = self.store["shape"]
+        self._nrows, self._ncols = self.store['shape']
         self._azimuth = self._elevation = None
 
     def build(self):

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -64,15 +64,19 @@ class _Figure(object):
         self.notebook = notebook
 
         self.store = dict()
-        self.store['show'] = show
-        self.store['title'] = title
         self.store['window_size'] = size
         self.store['shape'] = shape
         self.store['off_screen'] = off_screen
         self.store['border'] = False
-        self.store['auto_update'] = False
         # multi_samples > 1 is broken on macOS + Intel Iris + volume rendering
         self.store['multi_samples'] = 1 if sys.platform == 'darwin' else 4
+
+        if not self.notebook:
+            self.store['show'] = show
+            self.store['title'] = title
+            self.store['auto_update'] = False
+            self.store["menu_bar"] = False
+            self.store["toolbar"] = False
 
         self._nrows, self._ncols = self.store["shape"]
         self._azimuth = self._elevation = None
@@ -80,12 +84,8 @@ class _Figure(object):
     def build(self):
         if self.notebook:
             plotter_class = Plotter
-            self.store.pop('show', None)
-            self.store.pop('title', None)
-            self.store.pop('auto_update', None)
         else:
             plotter_class = BackgroundPlotter
-            self.store["toolbar"] = False
 
         if self.plotter is None:
             if not self.notebook:

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -12,7 +12,7 @@ import pyvista
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import (QComboBox, QDockWidget, QDoubleSpinBox, QGroupBox,
-                             QHBoxLayout, QLabel, QToolButton,
+                             QHBoxLayout, QLabel, QToolButton, QMenuBar,
                              QSlider, QSpinBox, QVBoxLayout, QWidget,
                              QSizePolicy, QScrollArea, QStyle,
                              QStyleOptionSlider)
@@ -248,7 +248,23 @@ class _QtToolBar(_AbstractToolBar):
         self.tool_bar.addWidget(spacer)
 
 
-class _Renderer(_PyVistaRenderer, _QtDock, _QtToolBar):
+class _QtMenuBar():
+    def _menu_initialize(self):
+        self._menus = dict()
+        self._menu_actions = dict()
+        self.menu_bar = QMenuBar()
+        self.menu_bar.setNativeMenuBar(False)
+        self.tool_bar = self.plotter.app_window.setMenuBar(self.menu_bar)
+
+    def _menu_add_submenu(self, name, desc):
+        self._menus[name] = self.menu_bar.addMenu(desc)
+
+    def _menu_add_button(self, menu_name, name, desc, func):
+        menu = self._menus[menu_name]
+        self._menu_actions[name] = menu.addAction(desc, func)
+
+
+class _Renderer(_PyVistaRenderer, _QtDock, _QtToolBar, _QtMenuBar):
     pass
 
 

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -254,7 +254,7 @@ class _QtMenuBar():
         self._menu_actions = dict()
         self.menu_bar = QMenuBar()
         self.menu_bar.setNativeMenuBar(False)
-        self.tool_bar = self.plotter.app_window.setMenuBar(self.menu_bar)
+        self.plotter.app_window.setMenuBar(self.menu_bar)
 
     def _menu_add_submenu(self, name, desc):
         self._menus[name] = self.menu_bar.addMenu(desc)

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -14,7 +14,7 @@ from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import (QComboBox, QDockWidget, QDoubleSpinBox, QGroupBox,
                              QHBoxLayout, QLabel, QToolButton, QMenuBar,
                              QSlider, QSpinBox, QVBoxLayout, QWidget,
-                             QSizePolicy, QScrollArea, QStyle,
+                             QSizePolicy, QScrollArea, QStyle, QProgressBar,
                              QStyleOptionSlider)
 
 from ._pyvista import _PyVistaRenderer
@@ -264,7 +264,23 @@ class _QtMenuBar():
         self._menu_actions[name] = menu.addAction(desc, func)
 
 
-class _Renderer(_PyVistaRenderer, _QtDock, _QtToolBar, _QtMenuBar):
+class _QtStatusBar():
+    def _status_bar_initialize(self, window):
+        self.status_bar = window.statusBar()
+
+    def _status_bar_add_label(self, value, stretch=0):
+        widget = QLabel(value)
+        self.status_bar.layout().addWidget(widget, stretch)
+        return widget
+
+    def _status_bar_add_progress_bar(self, stretch=0):
+        widget = QProgressBar()
+        self.status_bar.layout().addWidget(widget, stretch)
+        return widget
+
+
+class _Renderer(_PyVistaRenderer, _QtDock, _QtToolBar, _QtMenuBar,
+                _QtStatusBar):
     pass
 
 

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -25,7 +25,7 @@ from ._utils import _init_qt_resources
 
 
 class _QtDock(_AbstractDock):
-    def _dock_initialize(self):
+    def _dock_initialize(self, window):
         self.dock = QDockWidget()
         self.scroll = QScrollArea(self.dock)
         self.dock.setWidget(self.scroll)
@@ -34,7 +34,7 @@ class _QtDock(_AbstractDock):
         self.scroll.setWidgetResizable(True)
         self.dock.setAllowedAreas(Qt.LeftDockWidgetArea)
         self.dock.setFeatures(QDockWidget.NoDockWidgetFeatures)
-        self.plotter.app_window.addDockWidget(Qt.LeftDockWidgetArea, self.dock)
+        window.addDockWidget(Qt.LeftDockWidgetArea, self.dock)
         self.dock_layout = QVBoxLayout()
         widget.setLayout(self.dock_layout)
 
@@ -224,9 +224,9 @@ class _QtToolBar(_AbstractToolBar):
         self.icons["visibility_on"] = QIcon(":/visibility_on.svg")
         self.icons["visibility_off"] = QIcon(":/visibility_off.svg")
 
-    def _tool_bar_initialize(self, name="default"):
+    def _tool_bar_initialize(self, window, name="default"):
         self.actions = dict()
-        self.tool_bar = self.plotter.app_window.addToolBar(name)
+        self.tool_bar = window.addToolBar(name)
 
     def _tool_bar_finalize(self):
         pass
@@ -249,12 +249,12 @@ class _QtToolBar(_AbstractToolBar):
 
 
 class _QtMenuBar():
-    def _menu_initialize(self):
+    def _menu_initialize(self, window):
         self._menus = dict()
         self._menu_actions = dict()
         self.menu_bar = QMenuBar()
         self.menu_bar.setNativeMenuBar(False)
-        self.plotter.app_window.setMenuBar(self.menu_bar)
+        window.setMenuBar(self.menu_bar)
 
     def _menu_add_submenu(self, name, desc):
         self._menus[name] = self.menu_bar.addMenu(desc)

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -20,7 +20,8 @@ from PyQt5.QtWidgets import (QComboBox, QDockWidget, QDoubleSpinBox, QGroupBox,
 from ._pyvista import _PyVistaRenderer
 from ._pyvista import (_close_all, _close_3d_figure, _check_3d_figure,  # noqa: F401,E501 analysis:ignore
                        _set_3d_view, _set_3d_title, _take_3d_screenshot)  # noqa: F401,E501 analysis:ignore
-from ._abstract import _AbstractDock, _AbstractToolBar
+from ._abstract import (_AbstractDock, _AbstractToolBar, _AbstractMenuBar,
+                        _AbstractStatusBar)
 from ._utils import _init_qt_resources
 
 
@@ -248,7 +249,7 @@ class _QtToolBar(_AbstractToolBar):
         self.tool_bar.addWidget(spacer)
 
 
-class _QtMenuBar():
+class _QtMenuBar(_AbstractMenuBar):
     def _menu_initialize(self, window):
         self._menus = dict()
         self._menu_actions = dict()
@@ -264,7 +265,7 @@ class _QtMenuBar():
         self._menu_actions[name] = menu.addAction(desc, func)
 
 
-class _QtStatusBar():
+class _QtStatusBar(_AbstractStatusBar):
     def _status_bar_initialize(self, window):
         self.status_bar = window.statusBar()
 


### PR DESCRIPTION
This PR disables the default menu bar created by PyVistaQt and uses the `_QtMenuBar` interface instead.

It also helps with https://github.com/mne-tools/mne-python/pull/8997