### PR TITLE
BUG: Fix extension

### DIFF
--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -262,7 +262,7 @@ class DigSource(HasPrivateTraits):
     """
 
     file = FileOrDir(exists=True,
-                     filter=[';'.join([f'*{ext}' for ext in supported])])
+                     filter=[' '.join([f'*{ext}' for ext in supported])])
 
     inst_fname = Property(Str, depends_on='file')
     inst_dir = Property(depends_on='file')


### PR DESCRIPTION
After #8790 opening the file dialog for dig source gives:
```
~/mne_data/MNE-sample-data/MEG/sample$ mne coreg -s sample -d ../../subjects
```
![Screenshot from 2021-03-09 15-54-09](https://user-images.githubusercontent.com/2365790/110536716-ca081b00-80ef-11eb-8e8f-e36800331142.png)

On this PR:

![Screenshot from 2021-03-09 15-54-38](https://user-images.githubusercontent.com/2365790/110536722-cc6a7500-80ef-11eb-90df-74dc7388f7a3.png)
