### PR TITLE
MRG, ENH: Slider triggers callback during dragging

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -105,6 +105,8 @@ Enhancements
 
 - `~mne.Epochs` metadata can now be generated automatically from events using `mne.epochs.make_metadata` (:gh:`8834` by `Richard Höchenberger`_)
 
+- Interactions with sliders in `mne.Report` will now continuously update the linked content (it was updated only on mouse button release before) (:gh:`9023` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 - Fix bug with :func:`mne.io.read_raw_kit` where missing marker coils were not handled (:gh:`8989` **by new contributor** |Judy D Zhu|_)

--- a/mne/report.py
+++ b/mne/report.py
@@ -479,13 +479,15 @@ slider_template = HTMLTemplate(u"""
                        max: {{maxvalue}},
                        step: {{step}},
                        value: {{startvalue}},
+                       animate: true,
                        create: function(event, ui) {
-                       $(".{{klass}}").hide();
-                       $("#{{klass}}-{{startvalue}}").show();},
-                       stop: function(event, ui) {
-                       var list_value = $("#{{slider_id}}").slider("value");
-                       $(".{{klass}}").hide();
-                       $("#{{klass}}-"+list_value).show();}
+                         $(".{{klass}}").hide();
+                         $("#{{klass}}-{{startvalue}}").show();
+                       },
+                       slide: function(event, ui) {
+                         $(".{{klass}}").hide();
+                         $("#{{klass}}-" + ui.value).show();
+                       }
                        })</script>
 """)
 

--- a/tutorials/misc/plot_report.py
+++ b/tutorials/misc/plot_report.py
@@ -190,7 +190,7 @@ fig = evoked.plot(show=False)
 # add the custom plot to the report:
 report.add_figs_to_section(fig, captions='Left Auditory', section='evoked')
 
-# Add a custom section with an evoked slider:
+# add a custom section with an evoked slider:
 figs = list()
 times = evoked.times[::30]
 for t in times:


### PR DESCRIPTION
The slider in the reports in `main` only triggers an update callback when the dragging action has ended. This PR makes
it such that the callback is emitted during slider movement, so one doesn't have to release the mouse button to see the results.

Also enables animations for clicking action.

This PR:

https://user-images.githubusercontent.com/2046265/110623479-2f661580-819d-11eb-86df-5c38b0cd0787.mov


`main`:

https://user-images.githubusercontent.com/2046265/110623434-1c534580-819d-11eb-8889-931c228ae1d0.mov

