### PR TITLE
MAINT: Disable inline comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,6 @@
 comment: false
+github_checks:  # too noisy, even though "a" interactively disables them
+  annotations: false
 
 codecov:
   notify:


### PR DESCRIPTION
It turns out you can disable the comments by pressing "a", but given how often they are false alarms and how much noise they add, I think it's better just to disable them.