### PR TITLE
MAINT: Remove pyface exclusion

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,9 +18,6 @@ dependencies:
 - joblib
 - psutil
 - numexpr
-- traits
-- pyface!=7.3.0
-- traitsui
 - imageio
 - tqdm
 - spyder-kernels>=1.10.0


### PR DESCRIPTION
After https://github.com/conda-forge/pyface-feedstock/pull/27 we shouldn't need to avoid this version of `pyface` anymore. In fact there is no real reason to list these since the `mayavi` dependency will already pull them in. Now `environment.yml` is closer to `requirements.txt`, too, which is nice.