### PR TITLE
MRG, MAINT: Cleaner split, fewer skips in _brain tests

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -3,6 +3,7 @@
 #
 # License: BSD (3-clause)
 
+from contextlib import contextmanager
 from distutils.version import LooseVersion
 import gc
 import os
@@ -265,26 +266,6 @@ def _bias_params(evoked, noise_cov, fwd):
     return evoked, fwd, noise_cov, data_cov, want
 
 
-@pytest.fixture(scope="module", params=[
-    "mayavi",
-    "pyvista",
-])
-def backend_name(request):
-    """Get the backend name."""
-    yield request.param
-
-
-@pytest.fixture
-def renderer(backend_name, garbage_collect):
-    """Yield the 3D backends."""
-    from mne.viz.backends.renderer import _use_test_3d_backend
-    _check_skip_backend(backend_name)
-    with _use_test_3d_backend(backend_name):
-        from mne.viz.backends import renderer
-        yield renderer
-        renderer.backend._close_all()
-
-
 @pytest.fixture
 def garbage_collect():
     """Garbage collect on exit."""
@@ -292,24 +273,57 @@ def garbage_collect():
     gc.collect()
 
 
-@pytest.fixture(scope="module", params=[
-    "pyvista",
-    "mayavi",
-])
-def backend_name_interactive(request):
-    """Get the backend name."""
-    yield request.param
-
-
-@pytest.fixture
-def renderer_interactive(backend_name_interactive):
+@pytest.fixture(params=["mayavi", "pyvista"])
+def renderer(request, garbage_collect):
     """Yield the 3D backends."""
-    from mne.viz.backends.renderer import _use_test_3d_backend
-    _check_skip_backend(backend_name_interactive)
-    with _use_test_3d_backend(backend_name_interactive, interactive=True):
-        from mne.viz.backends import renderer
+    with _use_backend(request.param, interactive=False) as renderer:
         yield renderer
-        renderer.backend._close_all()
+
+
+@pytest.fixture(params=["pyvista"])
+def renderer_pyvista(request, garbage_collect):
+    """Yield the PyVista backend."""
+    with _use_backend(request.param, interactive=False) as renderer:
+        yield renderer
+
+
+@pytest.fixture(params=["notebook"])
+def renderer_notebook(request):
+    """Yield the 3D notebook renderer."""
+    with _use_backend(request.param, interactive=False) as renderer:
+        yield renderer
+
+
+@pytest.fixture(scope="module", params=["pyvista"])
+def renderer_interactive_pyvista(request):
+    """Yield the interactive PyVista backend."""
+    with _use_backend(request.param, interactive=True) as renderer:
+        yield renderer
+
+
+@pytest.fixture(scope="module", params=["pyvista", "mayavi"])
+def renderer_interactive(request):
+    """Yield the interactive 3D backends."""
+    with _use_backend(request.param, interactive=True) as renderer:
+        if renderer._get_3d_backend() == 'mayavi':
+            with warnings.catch_warnings(record=True):
+                try:
+                    from surfer import Brain  # noqa: 401 analysis:ignore
+                except Exception:
+                    pytest.skip('Requires PySurfer')
+        yield renderer
+
+
+@contextmanager
+def _use_backend(backend_name, interactive):
+    from mne.viz.backends.renderer import _use_test_3d_backend
+    _check_skip_backend(backend_name)
+    with _use_test_3d_backend(backend_name, interactive=interactive):
+        from mne.viz.backends import renderer
+        try:
+            yield renderer
+        finally:
+            renderer.backend._close_all()
 
 
 def _check_skip_backend(name):
@@ -325,14 +339,6 @@ def _check_skip_backend(name):
             pytest.skip("Test skipped, requires imageio-ffmpeg")
     if not has_pyqt5():
         pytest.skip("Test skipped, requires PyQt5.")
-
-
-@pytest.fixture()
-def renderer_notebook():
-    """Verify that pytest_notebook is installed."""
-    from mne.viz.backends import renderer
-    with renderer._use_test_3d_backend('notebook'):
-        yield renderer
 
 
 @pytest.fixture(scope='session')
@@ -488,7 +494,12 @@ def download_is_error(monkeypatch):
 @pytest.fixture()
 def brain_gc(request):
     """Ensure that brain can be properly garbage collected."""
-    keys = ('renderer_interactive', 'renderer', 'renderer_notebook')
+    keys = (
+        'renderer_interactive',
+        'renderer_interactive_pysurfer',
+        'renderer',
+        'renderer_notebook',
+    )
     assert set(request.fixturenames) & set(keys) != set()
     for key in keys:
         if key in request.fixturenames:

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -499,6 +499,7 @@ def brain_gc(request):
         'renderer_interactive_pyvista',
         'renderer_interactive_pysurfer',
         'renderer',
+        'renderer_pyvista',
         'renderer_notebook',
     )
     assert set(request.fixturenames) & set(keys) != set()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -496,6 +496,7 @@ def brain_gc(request):
     """Ensure that brain can be properly garbage collected."""
     keys = (
         'renderer_interactive',
+        'renderer_interactive_pyvista',
         'renderer_interactive_pysurfer',
         'renderer',
         'renderer_notebook',

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -104,12 +104,10 @@ class TstVTKPicker(object):
         return np.array(self.GetPickPosition()) - (0, 0, 100)
 
 
-def test_layered_mesh(renderer_interactive):
+def test_layered_mesh(renderer_interactive_pyvista):
     """Test management of scalars/colormap overlay."""
-    if renderer_interactive._get_3d_backend() != 'pyvista':
-        pytest.skip('TimeViewer tests only supported on PyVista')
     mesh = _LayeredMesh(
-        renderer=renderer_interactive._get_renderer(size=(300, 300)),
+        renderer=renderer_interactive_pyvista._get_renderer(size=(300, 300)),
         vertices=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]]),
         triangles=np.array([[0, 1, 2], [1, 2, 3]]),
         normals=np.array([[0, 0, 1]] * 4),
@@ -136,10 +134,8 @@ def test_layered_mesh(renderer_interactive):
 
 
 @testing.requires_testing_data
-def test_brain_gc(renderer, brain_gc):
+def test_brain_gc(renderer_pyvista, brain_gc):
     """Test that a minimal version of Brain gets GC'ed."""
-    if renderer._get_3d_backend() != 'pyvista':
-        pytest.skip('TimeViewer tests only supported on PyVista')
     brain = Brain('fsaverage', 'both', 'inflated', subjects_dir=subjects_dir)
     brain.close()
 
@@ -157,10 +153,8 @@ def test_brain_routines(renderer, brain_gc):
 
 
 @testing.requires_testing_data
-def test_brain_init(renderer, tmpdir, pixel_ratio, brain_gc):
+def test_brain_init(renderer_pyvista, tmpdir, pixel_ratio, brain_gc):
     """Test initialization of the Brain instance."""
-    if renderer._get_3d_backend() != 'pyvista':
-        pytest.skip('TimeViewer tests only supported on PyVista')
     from mne.source_estimate import _BaseSourceEstimate
 
     class FakeSTC(_BaseSourceEstimate):
@@ -183,7 +177,7 @@ def test_brain_init(renderer, tmpdir, pixel_ratio, brain_gc):
         Brain(hemi=hemi, surf=surf, interaction=0, **kwargs)
     with pytest.raises(ValueError, match='interaction'):
         Brain(hemi=hemi, surf=surf, interaction='foo', **kwargs)
-    renderer.backend._close_all()
+    renderer_pyvista.backend._close_all()
 
     brain = Brain(hemi=hemi, surf=surf, size=size, title=title,
                   cortex=cortex, units='m',
@@ -332,8 +326,6 @@ def test_brain_init(renderer, tmpdir, pixel_ratio, brain_gc):
     assert path.isfile(fname)
     brain.show_view(view=dict(azimuth=180., elevation=90.))
     img = brain.screenshot(mode='rgb')
-    if renderer._get_3d_backend() == 'mayavi':
-        pixel_ratio = 1.  # no HiDPI when using the testing backend
     want_size = np.array([size[0] * pixel_ratio, size[1] * pixel_ratio, 3])
     assert_allclose(img.shape, want_size)
     brain.close()
@@ -343,10 +335,8 @@ def test_brain_init(renderer, tmpdir, pixel_ratio, brain_gc):
 @pytest.mark.skipif(os.getenv('CI_OS_NAME', '') == 'osx',
                     reason='Unreliable/segfault on macOS CI')
 @pytest.mark.parametrize('hemi', ('lh', 'rh'))
-def test_single_hemi(hemi, renderer_interactive, brain_gc):
+def test_single_hemi(hemi, renderer_interactive_pyvista, brain_gc):
     """Test single hemi support."""
-    if renderer_interactive._get_3d_backend() != 'pyvista':
-        pytest.skip('TimeViewer tests only supported on PyVista')
     stc = read_source_estimate(fname_stc)
     idx, order = (0, 1) if hemi == 'lh' else (1, -1)
     stc = SourceEstimate(
@@ -426,10 +416,8 @@ def tiny(tmpdir):
 
 
 @pytest.mark.filterwarnings('ignore:.*constrained_layout not applied.*:')
-def test_brain_screenshot(renderer_interactive, tmpdir, brain_gc):
+def test_brain_screenshot(renderer_interactive_pyvista, tmpdir, brain_gc):
     """Test time viewer screenshot."""
-    if renderer_interactive._get_3d_backend() != 'pyvista':
-        pytest.skip('TimeViewer tests only supported on PyVista')
     tiny_brain, ratio = tiny(tmpdir)
     img_nv = tiny_brain.screenshot(time_viewer=False)
     want = (_TINY_SIZE[1] * ratio, _TINY_SIZE[0] * ratio, 3)
@@ -453,10 +441,8 @@ def _assert_brain_range(brain, rng):
 
 @testing.requires_testing_data
 @pytest.mark.slowtest
-def test_brain_time_viewer(renderer_interactive, pixel_ratio, brain_gc):
+def test_brain_time_viewer(renderer_interactive_pyista, pixel_ratio, brain_gc):
     """Test time viewer primitives."""
-    if renderer_interactive._get_3d_backend() != 'pyvista':
-        pytest.skip('TimeViewer tests only supported on PyVista')
     with pytest.raises(ValueError, match="between 0 and 1"):
         _create_testing_brain(hemi='lh', show_traces=-1.0)
     with pytest.raises(ValueError, match="got unknown keys"):
@@ -547,12 +533,9 @@ def test_brain_time_viewer(renderer_interactive, pixel_ratio, brain_gc):
     pytest.param('mixed', marks=pytest.mark.slowtest),
 ])
 @pytest.mark.slowtest
-def test_brain_traces(renderer_interactive, hemi, src, tmpdir,
+def test_brain_traces(renderer_interactive_pyvista, hemi, src, tmpdir,
                       brain_gc):
     """Test brain traces."""
-    if renderer_interactive._get_3d_backend() != 'pyvista':
-        pytest.skip('Only PyVista supports traces')
-
     hemi_str = list()
     if src in ('surface', 'vector', 'mixed'):
         hemi_str.extend([hemi] if hemi in ('lh', 'rh') else ['lh', 'rh'])
@@ -742,10 +725,8 @@ something
 
 @testing.requires_testing_data
 @pytest.mark.slowtest
-def test_brain_linkviewer(renderer_interactive, brain_gc):
+def test_brain_linkviewer(renderer_interactive_pyvista, brain_gc):
     """Test _LinkViewer primitives."""
-    if renderer_interactive._get_3d_backend() != 'pyvista':
-        pytest.skip('Linkviewer only supported on PyVista')
     brain1 = _create_testing_brain(hemi='lh', show_traces=False)
     brain2 = _create_testing_brain(hemi='lh', show_traces='separate')
     brain1._times = brain1._times * 2

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -441,7 +441,8 @@ def _assert_brain_range(brain, rng):
 
 @testing.requires_testing_data
 @pytest.mark.slowtest
-def test_brain_time_viewer(renderer_interactive_pyista, pixel_ratio, brain_gc):
+def test_brain_time_viewer(renderer_interactive_pyvista, pixel_ratio,
+                           brain_gc):
     """Test time viewer primitives."""
     with pytest.raises(ValueError, match="between 0 and 1"):
         _create_testing_brain(hemi='lh', show_traces=-1.0)

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -10,7 +10,6 @@
 import os.path as op
 from pathlib import Path
 import sys
-import warnings
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
@@ -105,7 +104,6 @@ def test_plot_head_positions():
 @pytest.mark.slowtest
 def test_plot_sparse_source_estimates(renderer_interactive, brain_gc):
     """Test plotting of (sparse) source estimates."""
-    _check_skip_pysurfer(renderer_interactive)
     sample_src = read_source_spaces(src_fname)
 
     # dense version
@@ -382,7 +380,6 @@ def test_plot_alignment(tmpdir, renderer):
 @traits_test
 def test_process_clim_plot(renderer_interactive, brain_gc):
     """Test functionality for determining control points with stc.plot."""
-    _check_skip_pysurfer(renderer_interactive)
     sample_src = read_source_spaces(src_fname)
     kwargs = dict(subjects_dir=subjects_dir, smoothing_steps=1,
                   time_viewer=False, show_traces=False)
@@ -592,17 +589,6 @@ def test_snapshot_brain_montage(renderer):
     pytest.raises(ValueError, snapshot_brain_montage, None, info)
 
 
-def _check_skip_pysurfer(renderer):
-    is_pyvista = renderer._get_3d_backend() == 'pyvista'
-    if not is_pyvista:
-        with warnings.catch_warnings(record=True):
-            try:
-                from surfer import Brain  # noqa: 401 analysis:ignore
-            except Exception:
-                pytest.skip('Requires PySurfer')
-    return is_pyvista
-
-
 @pytest.mark.slowtest  # can be slow on OSX
 @testing.requires_testing_data
 @pytest.mark.parametrize('pick_ori', ('vector', None))
@@ -610,7 +596,8 @@ def _check_skip_pysurfer(renderer):
 def test_plot_source_estimates(renderer_interactive, all_src_types_inv_evoked,
                                pick_ori, kind, brain_gc):
     """Test plotting of scalar and vector source estimates."""
-    is_pyvista = _check_skip_pysurfer(renderer_interactive)
+    backend = renderer_interactive._get_3d_backend()
+    is_pyvista = backend != 'mayavi'
     invs, evoked = all_src_types_inv_evoked
     inv = invs[kind]
     with pytest.warns(None):  # PCA mag
@@ -626,7 +613,7 @@ def test_plot_source_estimates(renderer_interactive, all_src_types_inv_evoked,
                   )
     if pick_ori != 'vector':
         kwargs['surface'] = 'white'
-        kwargs['backend'] = renderer_interactive._get_3d_backend()
+        kwargs['backend'] = backend
     # Mayavi can't handle non-surface
     if kind != 'surface' and not is_pyvista:
         with pytest.raises(RuntimeError, match='PyVista'):
@@ -768,7 +755,6 @@ def test_brain_colorbar(orientation, diverging, lims):
 @traits_test
 def test_mixed_sources_plot_surface(renderer_interactive):
     """Test plot_surface() for mixed source space."""
-    _check_skip_pysurfer(renderer_interactive)
     src = read_source_spaces(fwd_fname2)
     N = np.sum([s['nuse'] for s in src])  # number of sources
 
@@ -811,7 +797,7 @@ def test_link_brains(renderer_interactive):
         subjects_dir=subjects_dir, colorbar=True,
         clim='auto'
     )
-    if renderer_interactive._get_3d_backend() != 'pyvista':
+    if renderer_interactive._get_3d_backend() == 'mayavi':
         with pytest.raises(NotImplementedError, match='backend is pyvista'):
             link_brains(brain)
     else:


### PR DESCRIPTION
This PR refactors `renderer_interactive` into two forms: one that includes mayavi (`renderer_interactive`) and makes it clear in the code that PySurfer is required, too; and another that just uses PyVista (`renderer_interactive_pyvista`). This makes it so that we don't get a bunch of unnecessary `skip` messages for tests that were never meant to be run on Mayavi/PySurfer.

This is a first step toward making it so that we can iterate over `'notebook'` as a backend type in the `renderer_interactive` tests. @GuillaumeFavelier feel free to review and merge if you and CIs are happy