### PR TITLE
Fixed bibtex references in plot_background_statistics

### DIFF
--- a/tutorials/discussions/plot_background_statistics.py
+++ b/tutorials/discussions/plot_background_statistics.py
@@ -41,9 +41,9 @@ print(__doc__)
 # some probability (e.g., p < 0.05). This probability is also called the
 # significance level :math:`\alpha`.
 # To think about what this means, let's follow the illustrative example from
-# :footcite:`RidgwayEtAl2012` and construct a toy dataset consisting of a 40 x 40 square with a
-# "signal" present in the center with white noise added and a Gaussian
-# smoothing kernel applied.
+# :footcite:`RidgwayEtAl2012` and construct a toy dataset consisting of a
+# 40 x 40 square with a "signal" present in the center with white noise added
+# and a Gaussian smoothing kernel applied.
 
 width = 40
 n_subjects = 10
@@ -168,7 +168,8 @@ plot_t_p(ts[-1], ps[-1], titles[-1], mccs[-1])
 # "Hat" variance adjustment
 # ~~~~~~~~~~~~~~~~~~~~~~~~~
 # The "hat" technique regularizes the variance values used in the t-test
-# calculation :footcite:`RidgwayEtAl2012` to compensate for implausibly small variances.
+# calculation :footcite:`RidgwayEtAl2012` to compensate for implausibly small
+# variances.
 ts.append(ttest_1samp_no_p(X, sigma=sigma))
 ps.append(stats.distributions.t.sf(np.abs(ts[-1]), len(X) - 1) * 2)
 titles.append(r'$\mathrm{t_{hat}}$')
@@ -482,7 +483,8 @@ plot_t_p(ts[-1], ps[-1], titles[-1], mccs[-1])
 # TFCE eliminates the free parameter initial ``threshold`` value that
 # determines which points are included in clustering by approximating
 # a continuous integration across possible threshold values with a standard
-# `Riemann sum <https://en.wikipedia.org/wiki/Riemann_sum>`__ :footcite:`SmithNichols2009`.
+# `Riemann sum <https://en.wikipedia.org/wiki/Riemann_sum>`__
+# :footcite:`SmithNichols2009`.
 # This requires giving a starting threshold ``start`` and a step
 # size ``step``, which in MNE is supplied as a dict.
 # The smaller the ``step`` and closer to 0 the ``start`` value,

--- a/tutorials/discussions/plot_background_statistics.py
+++ b/tutorials/discussions/plot_background_statistics.py
@@ -41,7 +41,7 @@ print(__doc__)
 # some probability (e.g., p < 0.05). This probability is also called the
 # significance level :math:`\alpha`.
 # To think about what this means, let's follow the illustrative example from
-# [1]_ and construct a toy dataset consisting of a 40 x 40 square with a
+# :footcite:`RidgwayEtAl2012` and construct a toy dataset consisting of a 40 x 40 square with a
 # "signal" present in the center with white noise added and a Gaussian
 # smoothing kernel applied.
 
@@ -168,7 +168,7 @@ plot_t_p(ts[-1], ps[-1], titles[-1], mccs[-1])
 # "Hat" variance adjustment
 # ~~~~~~~~~~~~~~~~~~~~~~~~~
 # The "hat" technique regularizes the variance values used in the t-test
-# calculation [1]_ to compensate for implausibly small variances.
+# calculation :footcite:`RidgwayEtAl2012` to compensate for implausibly small variances.
 ts.append(ttest_1samp_no_p(X, sigma=sigma))
 ps.append(stats.distributions.t.sf(np.abs(ts[-1]), len(X) - 1) * 2)
 titles.append(r'$\mathrm{t_{hat}}$')
@@ -460,7 +460,7 @@ plot_t_p(ts[-1], ps[-1], titles[-1], mccs[-1])
 # "Hat" variance adjustment
 # ~~~~~~~~~~~~~~~~~~~~~~~~~
 # This method can also be used in this context to correct for small
-# variances [1]_:
+# variances :footcite:`RidgwayEtAl2012`:
 titles.append(r'$\mathbf{C_{hat}}$')
 stat_fun_hat = partial(ttest_1samp_no_p, sigma=sigma)
 t_hat, clusters, p_values, H0 = permutation_cluster_1samp_test(
@@ -482,7 +482,7 @@ plot_t_p(ts[-1], ps[-1], titles[-1], mccs[-1])
 # TFCE eliminates the free parameter initial ``threshold`` value that
 # determines which points are included in clustering by approximating
 # a continuous integration across possible threshold values with a standard
-# `Riemann sum <https://en.wikipedia.org/wiki/Riemann_sum>`__ [2]_.
+# `Riemann sum <https://en.wikipedia.org/wiki/Riemann_sum>`__ :footcite:`SmithNichols2009`.
 # This requires giving a starting threshold ``start`` and a step
 # size ``step``, which in MNE is supplied as a dict.
 # The smaller the ``step`` and closer to 0 the ``start`` value,
@@ -652,12 +652,6 @@ plt.show()
 #
 # References
 # ----------
-# .. [1] Ridgway et al. 2012, "The problem of low variance voxels in
-#        statistical parametric mapping; a new hat avoids a 'haircut'",
-#        NeuroImage. 2012 Feb 1;59(3):2131-41.
-#
-# .. [2] Smith and Nichols 2009, "Threshold-free cluster enhancement:
-#        addressing problems of smoothing, threshold dependence, and
-#        localisation in cluster inference", NeuroImage 44 (2009) 83-98.
+# .. footbibliography::
 #
 # .. include:: ../../links.inc


### PR DESCRIPTION
#### Reference issue
Example: Fixes #8901.


#### What does this implement/fix?
Modified references to bibtex references in tutorials/discussions/plot_background_statistics.py
