### PR TITLE
FIX saving fif file with the wrong extension

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -115,7 +115,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Fix bug with restricting :func:`mne.io.base.save` saving options to .fif and .fif.gz extensions (:gh:`9062` by |Valerii Chirkov|_)
+- Fix bug with restricting :func:`mne.io.Raw.save` saving options to .fif and .fif.gz extensions (:gh:`9062` by |Valerii Chirkov|_)
 
 - Fix bug with :func:`mne.io.read_raw_kit` where missing marker coils were not handled (:gh:`8989` **by new contributor** |Judy D Zhu|_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -115,6 +115,8 @@ Enhancements
 
 Bugs
 ~~~~
+- Fix bug with restricting :func:`mne.io.base.save` saving options to .fif and .fif.gz extensions (:gh:`9062` by |Valerii Chirkov|_)
+
 - Fix bug with :func:`mne.io.read_raw_kit` where missing marker coils were not handled (:gh:`8989` **by new contributor** |Judy D Zhu|_)
 
 - Fix bug with `mne.connectivity.spectral_connectivity` where time axis in Epochs data object was dropped. (:gh:`8839` **by new contributor** |Anna Padee|_)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1369,7 +1369,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         endings = ('raw.fif', 'raw_sss.fif', 'raw_tsss.fif',
                    '_meg.fif', '_eeg.fif', '_ieeg.fif')
         endings += tuple([f'{e}.gz' for e in endings])
-        check_fname(fname, 'raw', endings)
+        endings_err = ('.fif', '.fif.gz')
+        check_fname(fname, 'raw', endings, endings_err=endings_err)
 
         split_size = _get_split_size(split_size)
         if not self.preload and fname in self._filenames:

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -260,12 +260,12 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
     out_fname = op.join(tempdir, 'test_raw.fif')
     raw = concatenate_raws([raw])
     raw.save(out_fname, tmax=raw.times[-1], overwrite=True, buffer_size_sec=1)
-    
+
     # Test saving with not correct extention
     out_fname_h5 = op.join(tempdir, 'test_raw.h5')
     with pytest.raises(IOError, match='raw must end with .fif or .fif.gz'):
         raw.save(out_fname_h5)
-    
+
     raw3 = read_raw_fif(out_fname)
     assert_named_constants(raw3.info)
     assert set(raw.info.keys()) == set(raw3.info.keys())

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -261,7 +261,7 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
     raw = concatenate_raws([raw])
     raw.save(out_fname, tmax=raw.times[-1], overwrite=True, buffer_size_sec=1)
 
-    # Test saving with not correct extention
+    # Test saving with not correct extension
     out_fname_h5 = op.join(tempdir, 'test_raw.h5')
     with pytest.raises(IOError, match='raw must end with .fif or .fif.gz'):
         raw.save(out_fname_h5)

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -260,6 +260,12 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
     out_fname = op.join(tempdir, 'test_raw.fif')
     raw = concatenate_raws([raw])
     raw.save(out_fname, tmax=raw.times[-1], overwrite=True, buffer_size_sec=1)
+    
+    # Test saving with not correct extention
+    out_fname_h5 = op.join(tempdir, 'test_raw.h5')
+    with pytest.raises(IOError, match='raw must end with .fif or .fif.gz'):
+        raw.save(out_fname_h5)
+    
     raw3 = read_raw_fif(out_fname)
     assert_named_constants(raw3.info)
     assert set(raw.info.keys()) == set(raw3.info.keys())


### PR DESCRIPTION
Fixes #8510.

Restrict saving options of the fif file to .fif and .fif.gz and add the test for this error raising.