### PR TITLE
convert references in mne/connectivity/envelope.py to use footcite / …

### DIFF
--- a/mne/connectivity/envelope.py
+++ b/mne/connectivity/envelope.py
@@ -64,7 +64,7 @@ def envelope_correlation(data, combine='mean', orthogonalize="pairwise",
     Notes
     -----
     This function computes the power envelope correlation between
-    orthogonalized signals [1]_ [2]_.
+    orthogonalized signals :footcite:`HippEtAl2012,KhanEtAl2018`.
 
     .. versionchanged:: 0.22
       Computations fixed for ``orthogonalize=True`` and diagonal entries are
@@ -72,12 +72,7 @@ def envelope_correlation(data, combine='mean', orthogonalize="pairwise",
 
     References
     ----------
-    .. [1] Hipp JF, Hawellek DJ, Corbetta M, Siegel M, Engel AK (2012)
-           Large-scale cortical correlation structure of spontaneous
-           oscillatory activity. Nature Neuroscience 15:884–890
-    .. [2] Khan S et al. (2018). Maturation trajectories of cortical
-           resting-state networks depend on the mediating frequency band.
-           Neuroimage 174:57–68
+    .. footbibliography::
     """
     _check_option('orthogonalize', orthogonalize, (False, 'pairwise'))
     from scipy.signal import hilbert


### PR DESCRIPTION
#### Reference issue
Example: Fixes #8913.


#### What does this implement/fix?
Convert references in mne/connectivity/envelope.py to use footcite / footbibliography.