### PR TITLE
DOC Bibtex fix for spatial_resolution.py

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1082,6 +1082,18 @@
   year = {2016}
 }
 
+@article{MolinsEtAl2008,
+  author = {Molins A, and Stufflebeam S. M., and Brown E. N., and Hämäläinen M. S.},
+  doi = {10.1016/j.neuroimage.2008.05.064},
+  journal = {Neuroimage},
+  number = {3},
+  pages = {1069-1077},
+  title = {Quantification of the benefit from integrating MEG and EEG data in
+           minimum l2-norm estimation},
+  volume = {42},
+  year = {2008}
+}
+
 @incollection{Montoya-MartinezEtAl2017,
   address = {{Cham}},
   author = {{Montoya-Martínez}, Jair and Cardoso, Jean-François and Gramfort, Alexandre},

--- a/mne/minimum_norm/spatial_resolution.py
+++ b/mne/minimum_norm/spatial_resolution.py
@@ -68,11 +68,11 @@ def resolution_metrics(resmat, src, function='psf', metric='peak_err',
     For details, see :footcite:`MolinsEtAl2008` :footcite:`HaukEtAl2019`.
 
     .. versionadded:: 0.20
-    
+
     References
     ----------
     .. footbibliography::
-    """    
+    """
     # Check if input options are valid
     metrics = ('peak_err', 'cog_err', 'sd_ext', 'maxrad_ext', 'peak_amp',
                'sum_amp')
@@ -327,8 +327,3 @@ def _rectify_resolution_matrix(resmat):
                     (shape[0], shape[1], resmat.shape[0], resmat.shape[1]))
 
     return resmat
-
-###############################################################################
-# References
-# ----------
-# .. footbibliography::

--- a/mne/minimum_norm/spatial_resolution.py
+++ b/mne/minimum_norm/spatial_resolution.py
@@ -65,19 +65,10 @@ def resolution_metrics(resmat, src, function='psf', metric='peak_err',
 
     Notes
     -----
-    For details, see [1]_ [2]_.
+    For details, see :footcite:`MolinsEtAl2008` :footcite:`HaukEtAl2019`.
 
     .. versionadded:: 0.20
-
-    References
-    ----------
-    .. [1] Molins A, Stufflebeam S M, Brown E N, Hämäläinen M S (2008).
-           Quantification of the benefit from integrating MEG and EEG data in
-           minimum l2-norm estimation. Neuroimage, 42(3):1069-77.
-    .. [2] Hauk O, Stenroos M, Treder M (2019). "Towards an Objective
-           Evaluation of EEG/MEG Source Estimation Methods: The Linear Tool
-           Kit", bioRxiv, doi: https://doi.org/10.1101/672956.
-    """
+    """    
     # Check if input options are valid
     metrics = ('peak_err', 'cog_err', 'sd_ext', 'maxrad_ext', 'peak_amp',
                'sum_amp')
@@ -332,3 +323,8 @@ def _rectify_resolution_matrix(resmat):
                     (shape[0], shape[1], resmat.shape[0], resmat.shape[1]))
 
     return resmat
+
+###############################################################################
+# References
+# ----------
+# .. footbibliography::

--- a/mne/minimum_norm/spatial_resolution.py
+++ b/mne/minimum_norm/spatial_resolution.py
@@ -44,13 +44,14 @@ def resolution_metrics(resmat, src, function='psf', metric='peak_err',
 
         Spatial-extent-based metrics:
 
-        - ``'sd_ext'`` spatial deviation (e.g. [1,2]_).
-        - ``'maxrad_ext'`` maximum radius to 50%% of max amplitude.
+        - ``'sd_ext'`` Spatial deviation
+          (e.g. :footcite:`MolinsEtAl2008,HaukEtAl2019`).
+        - ``'maxrad_ext'`` Maximum radius to 50%% of max amplitude.
 
         Amplitude-based metrics:
 
-        - ``'peak_amp'`` Ratio between absolute maximum amplitudes of peaks per
-            location and maximum peak across locations.
+        - ``'peak_amp'`` Ratio between absolute maximum amplitudes of peaks
+          per location and maximum peak across locations.
         - ``'sum_amp'`` Ratio between sums of absolute amplitudes.
 
     threshold : float

--- a/mne/minimum_norm/spatial_resolution.py
+++ b/mne/minimum_norm/spatial_resolution.py
@@ -65,7 +65,7 @@ def resolution_metrics(resmat, src, function='psf', metric='peak_err',
 
     Notes
     -----
-    For details, see :footcite:`MolinsEtAl2008` :footcite:`HaukEtAl2019`.
+    For details, see :footcite:`MolinsEtAl2008,HaukEtAl2019`.
 
     .. versionadded:: 0.20
 

--- a/mne/minimum_norm/spatial_resolution.py
+++ b/mne/minimum_norm/spatial_resolution.py
@@ -68,6 +68,10 @@ def resolution_metrics(resmat, src, function='psf', metric='peak_err',
     For details, see :footcite:`MolinsEtAl2008` :footcite:`HaukEtAl2019`.
 
     .. versionadded:: 0.20
+    
+    References
+    ----------
+    .. footbibliography::
     """    
     # Check if input options are valid
     metrics = ('peak_err', 'cog_err', 'sd_ext', 'maxrad_ext', 'peak_amp',


### PR DESCRIPTION
#### Reference issue
Example: Fixes #8925.

#### What does this implement/fix?
Adds footcite and footbibliography support for `resolution_metrics()` in _minimum_norm/spatial_resolution.py_.

#### Collaborator
@cmista