### PR TITLE
fix references in examples/visualization/plot_channel_epochs_image.py

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -481,6 +481,19 @@
   year = {2002}
 }
 
+@article{GramfortEtAl2010,
+  author = {Alexandre Gramfort and Renaud Keriven and Maureen Clerc},
+  title = {Graph-Based Variability Estimation in Single-Trial Event-Related Neural Responses},
+  journal = {{IEEE} Transactions on Biomedical Engineering},
+  doi = {10.1109/tbme.2009.2037139},
+  url = {https://doi.org/10.1109%2Ftbme.2009.2037139},
+  year = {2010},
+  publisher = {Institute of Electrical and Electronics Engineers ({IEEE})},
+  volume = {57},
+  number = {5},
+  pages = {1051--1061},
+}
+
 @incollection{GramfortEtAl2011,
   address = {{Berlin; Heidelberg}},
   author = {Gramfort, Alexandre and Strohmeier, Daniel and Haueisen, Jens and Hämäläinen, Matti S. and Kowalski, Matthieu},

--- a/examples/visualization/plot_channel_epochs_image.py
+++ b/examples/visualization/plot_channel_epochs_image.py
@@ -10,7 +10,7 @@ Two images are produced, one with a good channel and one with a channel
 that does not show any evoked field.
 
 It is also demonstrated how to reorder the epochs using a 1D spectral
-embedding as described in [1]_.
+embedding as described in :footcite:`GramfortEtAl2010`.
 """
 # Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #
@@ -75,7 +75,4 @@ mne.viz.plot_epochs_image(epochs, [good_pick, bad_pick], sigma=.5,
 ###############################################################################
 # References
 # ----------
-# .. [1] Graph-based variability estimation in single-trial event-related
-#        neural responses. A. Gramfort, R. Keriven, M. Clerc, 2010,
-#        Biomedical Engineering, IEEE Trans. on, vol. 57 (5), 1051-1061
-#        https://ieeexplore.ieee.org/document/5406156
+# .. footbibliography::


### PR DESCRIPTION



#### Reference issue
Fixes #8909.


#### What does this implement/fix?
add missing GramfortEtAl2010 reference in reference.bib because needed in /examples/visualization/plot_channel_epochs_image.py
