### PR TITLE
Fixed length epochs overlap

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -45,7 +45,7 @@ Current (0.23.dev0)
 
 Enhancements
 ~~~~~~~~~~~~
-- Add parameter ``overlap=0.`` to :func:`mne.epochs.make_fixed_length_epochs` to allow creating overlapping fixed length epochs (:gh:`9096` **by new contributor** |Silvia Cotroneo|_)
+- Add ``overlap`` parameter to :func:`mne.epochs.make_fixed_length_epochs` to allow creating overlapping fixed length epochs (:gh:`9096` **by new contributor** |Silvia Cotroneo|_)
 
 - Add :meth:`mne.Dipole.to_mni` for more convenient  dipole.pos to MNI conversion (:gh:`9043` **by new contributor** |Valerii Chirkov|_)
 
@@ -222,4 +222,3 @@ API changes
 - ``mne.read_selection`` has been deprecated in favor of `mne.read_vectorview_selection`. ``mne.read_selection`` will be removed in MNE-Python 0.24 (:gh:`8870` by `Richard Höchenberger`_)
 
 - ``mne.beamformer.tf_dics`` has been deprecated and will be removed in MNE-Python 0.24 (:gh:`9122` by `Britta Westner`_)
-

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -39,8 +39,12 @@ Current (0.23.dev0)
 
 .. |Matteo Anelli| replace:: **Matteo Anelli**
 
+.. |Silvia Cotroneo| replace:: **Silvia Cotroneo**
+
 Enhancements
 ~~~~~~~~~~~~
+- Add parameter ``overlap=0.`` to :func:`mne.epochs.make_fixed_length_epochs` to allow creating overlapping fixed length epochs (:gh:`9096` **by new contributor** |Silvia Cotroneo|_)
+
 - Add :meth:`mne.Dipole.to_mni` for more convenient  dipole.pos to MNI conversion (:gh:`9043` **by new contributor** |Valerii Chirkov|_)
 
 - Update citations in maxwell.py (:gh:`9043` **by new contributor** |Valerii Chirkov|_)

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -369,3 +369,5 @@
 .. _Valerii Chirkov: https://github.com/vagechirkov
 
 .. _Matteo Anelli: https://github.com/matteoanelli
+
+.. _Silvia Cotroneo: https://github.com/sfc-neuro

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3678,11 +3678,7 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
         Raw data to divide into segments.
     duration : float
         Duration of each epoch in seconds. Defaults to 1.
-    overlap : float
-        The overlap between epochs. Must be ``0 <= overlap < duration``.
-        Default is 0.
 
-        .. versionadded:: 0.23
     %(preload)s
     %(reject_by_annotation_epochs)s
 
@@ -3690,6 +3686,11 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
     %(proj_epochs)s
 
         .. versionadded:: 0.22.0
+     overlap : float
+        The overlap between epochs. Must be ``0 <= overlap < duration``.
+        Default is 0.
+
+        .. versionadded:: 0.23.0
     %(verbose)s
 
     Returns

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3668,8 +3668,8 @@ def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
 
 @verbose
 def make_fixed_length_epochs(raw, duration=1., preload=False,
-                             reject_by_annotation=True, proj=True,
-                             verbose=None, overlap=0.):
+                             reject_by_annotation=True, proj=True, overlap=0.,
+                             verbose=None):
     """Divide continuous raw data into equal-sized consecutive epochs.
 
     Parameters
@@ -3681,6 +3681,7 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
     overlap : float
         The overlap between epochs. Must be ``0 <= overlap < duration``.
         Default is 0.
+
         .. versionadded:: 0.23
     %(preload)s
     %(reject_by_annotation_epochs)s

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3685,7 +3685,7 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
     %(proj_epochs)s
 
         .. versionadded:: 0.22.0
-     overlap : float
+    overlap : float
         The overlap between epochs. Must be ``0 <= overlap < duration``.
         Default is 0.
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3667,9 +3667,9 @@ def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
 
 
 @verbose
-def make_fixed_length_epochs(raw, duration=1., overlap=0., preload=False,
+def make_fixed_length_epochs(raw, duration=1., preload=False,
                              reject_by_annotation=True, proj=True,
-                             verbose=None):
+                             verbose=None, overlap=0.):
     """Divide continuous raw data into equal-sized consecutive epochs.
 
     Parameters
@@ -3681,6 +3681,7 @@ def make_fixed_length_epochs(raw, duration=1., overlap=0., preload=False,
     overlap : float
         The overlap between epochs. Must be ``0 <= overlap < duration``.
         Default is 0.
+        .. versionadded:: 0.23
     %(preload)s
     %(reject_by_annotation_epochs)s
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3686,8 +3686,8 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
 
         .. versionadded:: 0.22.0
     overlap : float
-        The overlap between epochs. Must be ``0 <= overlap < duration``.
-        Default is 0.
+        The overlap between epochs, in seconds. Must be
+        ``0 <= overlap < duration``. Default is 0, i.e., no overlap.
 
         .. versionadded:: 0.23.0
     %(verbose)s

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3667,7 +3667,7 @@ def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
 
 
 @verbose
-def make_fixed_length_epochs(raw, duration=1., preload=False,
+def make_fixed_length_epochs(raw, duration=1., overlap=0., preload=False,
                              reject_by_annotation=True, proj=True,
                              verbose=None):
     """Divide continuous raw data into equal-sized consecutive epochs.
@@ -3678,6 +3678,9 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
         Raw data to divide into segments.
     duration : float
         Duration of each epoch in seconds. Defaults to 1.
+    overlap : float
+        The overlap between epochs. Must be ``0 <= overlap < duration``.
+        Default is 0.
     %(preload)s
     %(reject_by_annotation_epochs)s
 
@@ -3696,7 +3699,8 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
     -----
     .. versionadded:: 0.20
     """
-    events = make_fixed_length_events(raw, 1, duration=duration)
+    events = make_fixed_length_events(raw, 1, duration=duration,
+                                      overlap=overlap)
     delta = 1. / raw.info['sfreq']
     return Epochs(raw, events, event_id=[1], tmin=0, tmax=duration - delta,
                   baseline=None, preload=preload,

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3678,7 +3678,6 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
         Raw data to divide into segments.
     duration : float
         Duration of each epoch in seconds. Defaults to 1.
-
     %(preload)s
     %(reject_by_annotation_epochs)s
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -3255,18 +3255,14 @@ def test_make_fixed_length_epochs():
     assert len(epochs) > len(epochs_annot)
 
     # overlaps
-    epochs = make_fixed_length_epochs(raw, duration=1, preload=True)
-    assert len(epochs) > 10
-    epochs_ol = make_fixed_length_epochs(raw, duration=1, overlap=0.5,
-                                         preload=True)
-    assert len(epochs_ol) > 20
-    epochs_ol_2 = make_fixed_length_epochs(raw, duration=1, overlap=0.9,
-                                           preload=True)
-    assert len(epochs_ol_2) > 100
+    epochs = make_fixed_length_epochs(raw, duration=1)
+    assert len(epochs.events) > 10
+    epochs_ol = make_fixed_length_epochs(raw, duration=1, overlap=0.5)
+    assert len(epochs_ol.events) > 20
+    epochs_ol_2 = make_fixed_length_epochs(raw, duration=1, overlap=0.9)
+    assert len(epochs_ol_2.events) > 100
     assert_array_equal(epochs_ol_2.events[:, 0],
                        np.unique(epochs_ol_2.events[:, 0]))
-    with pytest.raises(ValueError, match='overlap must be'):
-        make_fixed_length_epochs(raw, duration=1.0, overlap=1.0)
     with pytest.raises(ValueError, match='overlap must be'):
         make_fixed_length_epochs(raw, duration=1, overlap=1.1)
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -3254,6 +3254,22 @@ def test_make_fixed_length_epochs():
     assert len(epochs_annot) > 10
     assert len(epochs) > len(epochs_annot)
 
+    # overlaps
+    epochs = make_fixed_length_epochs(raw, duration=1, preload=True)
+    assert len(epochs) > 10
+    epochs_ol = make_fixed_length_epochs(raw, duration=1, overlap=0.5,
+                                         preload=True)
+    assert len(epochs_ol) > 20
+    epochs_ol_2 = make_fixed_length_epochs(raw, duration=1, overlap=0.9,
+                                           preload=True)
+    assert len(epochs_ol_2) > 100
+    assert_array_equal(epochs_ol_2.events[:, 0],
+                       np.unique(epochs_ol_2.events[:, 0]))
+    with pytest.raises(ValueError, match='overlap must be'):
+        make_fixed_length_epochs(raw, duration=1.0, overlap=1.0)
+    with pytest.raises(ValueError, match='overlap must be'):
+        make_fixed_length_epochs(raw, duration=1, overlap=1.1)
+
 
 def test_epochs_huge_events(tmpdir):
     """Test epochs with event numbers that are too large."""


### PR DESCRIPTION
#### Reference issue
Fixes #8773.


#### What does this implement/fix?
Adds compatibility for the overlap parameter in the function make_fixed_length_epochs


#### Additional information
Tests were also added to test the new feature inspired by the pre-existing ones written for make_fixed_length_events.
