### PR TITLE
DOC: Added a note to decim parameter usage in tutorial code snippet

### DIFF
--- a/tutorials/time-freq/plot_sensors_time_frequency.py
+++ b/tutorials/time-freq/plot_sensors_time_frequency.py
@@ -139,8 +139,8 @@ print(psds_welch_unagg.shape)
 #
 # .. note::
 #       The ``decim`` parameter reduces the sampling rate of the time-frequency
-#       decomposition by the defined factor. This is usually done to reduce 
-#       memory usage. For more information refer to the documentation of 
+#       decomposition by the defined factor. This is usually done to reduce
+#       memory usage. For more information refer to the documentation of
 #       :func:`mne.time_frequency.tfr_morlet`
 #
 # define frequencies of interest (log-spaced)

--- a/tutorials/time-freq/plot_sensors_time_frequency.py
+++ b/tutorials/time-freq/plot_sensors_time_frequency.py
@@ -141,7 +141,7 @@ print(psds_welch_unagg.shape)
 #       The ``decim`` parameter reduces the sampling rate of the time-frequency
 #       decomposition by the defined factor. This is usually done to reduce
 #       memory usage. For more information refer to the documentation of
-#       :func:`mne.time_frequency.tfr_morlet`
+#       :func:`mne.time_frequency.tfr_morlet`.
 #
 # define frequencies of interest (log-spaced)
 freqs = np.logspace(*np.log10([6, 35]), num=8)

--- a/tutorials/time-freq/plot_sensors_time_frequency.py
+++ b/tutorials/time-freq/plot_sensors_time_frequency.py
@@ -136,7 +136,13 @@ print(psds_welch_unagg.shape)
 # To this we'll use the function :func:`mne.time_frequency.tfr_morlet`
 # but you can also use :func:`mne.time_frequency.tfr_multitaper`
 # or :func:`mne.time_frequency.tfr_stockwell`.
-
+#
+# .. note::
+#       The ``decim`` parameter reduces the sampling rate of the time-frequency
+#       decomposition by the defined factor. This is usually done to reduce 
+#       memory usage. For more information refer to the documentation of 
+#       :func:`mne.time_frequency.tfr_morlet`
+#
 # define frequencies of interest (log-spaced)
 freqs = np.logspace(*np.log10([6, 35]), num=8)
 n_cycles = freqs / 2.  # different number of cycle per frequency


### PR DESCRIPTION
#### Reference issue
Fixes #8990 .


#### What does this implement/fix?
Added a note before the code snippet to let the user know that the `decim` parameter reduces the sampling rate by the defined parameter. 

