### PR TITLE
BUG: Fixing Report multiprocessing

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -199,6 +199,8 @@ Bugs
 
 - Fix :func:`mne.read_dipole` yielding :class:`mne.Dipole` objects that could not be indexed (:gh:`8963` by `Marijn van Vliet`_)
 
+- Fix bug when setting n_jobs > 1 in :func:`mne.Report.parse_folder` (:gh:`9109` by `Martin Schulz`_)
+
 API changes
 ~~~~~~~~~~~
 - ``mne.read_selection`` has been deprecated in favor of `mne.read_vectorview_selection`. ``mne.read_selection`` will be removed in MNE-Python 0.24 (:gh:`8870` by `Richard Höchenberger`_)

--- a/mne/report.py
+++ b/mne/report.py
@@ -1659,7 +1659,7 @@ class Report(object):
         # Note: self._fname is not part of the state
         return (['baseline', 'cov_fname', 'fnames', 'html', 'include',
                  'image_format', 'info_fname', 'initial_id', 'raw_psd',
-                 '_sectionlabels', 'sections', '_sectionvars',
+                 '_sectionlabels', 'sections', '_sectionvars', 'projs',
                  '_sort_sections', 'subjects_dir', 'subject', 'title',
                  'verbose'],
                 ['data_path', 'lang', '_sort'])

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -627,7 +627,7 @@ def test_split_files(tmpdir, split_naming):
 
 
 def test_survive_pickle(tmpdir):
-    """Testing functionality of Report-Object after pickling"""
+    """Testing functionality of Report-Object after pickling."""
     tempdir = str(tmpdir)
     raw_fname_new = op.join(tempdir, 'temp_raw.fif')
     shutil.copyfile(raw_fname, raw_fname_new)
@@ -637,7 +637,7 @@ def test_survive_pickle(tmpdir):
     pickled_report = pickle.dumps(report)
     report = pickle.loads(pickled_report)
 
-    # Just test if no errors occur with
+    # Just test if no errors occur
     report.parse_folder(tempdir, render_bem=False)
     save_name = op.join(tempdir, 'report.html')
     report.save(fname=save_name, open_browser=False)

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -7,6 +7,7 @@
 import base64
 import copy
 import glob
+import pickle
 from io import BytesIO
 import os
 import os.path as op
@@ -623,6 +624,23 @@ def test_split_files(tmpdir, split_naming):
     report = Report()
     report.parse_folder(tmpdir, render_bem=False)
     assert len(report.fnames) == 1
+
+
+def test_survive_pickle(tmpdir):
+    """Testing functionality of Report-Object after pickling"""
+    tempdir = str(tmpdir)
+    raw_fname_new = op.join(tempdir, 'temp_raw.fif')
+    shutil.copyfile(raw_fname, raw_fname_new)
+
+    # Pickle report object to simulate multiprocessing with joblib
+    report = Report(info_fname=raw_fname_new)
+    pickled_report = pickle.dumps(report)
+    report = pickle.loads(pickled_report)
+
+    # Just test if no errors occur with
+    report.parse_folder(tempdir, render_bem=False)
+    save_name = op.join(tempdir, 'report.html')
+    report.save(fname=save_name, open_browser=False)
 
 
 run_tests_if_main()


### PR DESCRIPTION
#### Reference issue
Fixes #9101.


#### What does this implement/fix?
This fixes the bug appearing when calling Report().parse_folder() with n_jobs>1 by adding _projs_ to the list of pickled attributes in _get_state_params().

Solution suggested by @larsoner 