### PR TITLE
DOC: Improve documentation of Report-Class

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -117,6 +117,8 @@ Enhancements
 
 - `mne.viz.plot_drop_log` and :meth:`mne.Epochs.plot_drop_log` now omit displaying the subject name in the title if ``subject=None`` is passed (:gh:`9015` by `Richard Höchenberger`_)
 
+- Improve documentation of Report-Class (:gh:`9113` by `Martin Schulz`_)
+
 Bugs
 ~~~~
 - Fix bug with :func:`mne.Epochs.plot_image` where the ``x_label`` was different depending on the evoked parameter (:gh:`9115` **by new contributor** |Matteo Anelli|_)

--- a/mne/report.py
+++ b/mne/report.py
@@ -943,16 +943,46 @@ class Report(object):
 
     Attributes
     ----------
-    html : list
+    info_fname : None | str
+        Name of the file containing the info dictionary.
+    %(subjects_dir)s
+    subject : str | None
+        Subject name.
+    title : str
+        Title of the report.
+    cov_fname : None | str
+        Name of the file containing the noise covariance.
+    %(baseline_report)s
+        Defaults to ``None``, i.e. no baseline correction.
+    image_format : str
+        Default image format to use (default is 'png').
+        SVG uses vector graphics, so fidelity is higher but can increase
+        file size and browser image rendering time as well.
+
+        .. versionadded:: 0.15
+
+    raw_psd : bool | dict
+        If True, include PSD plots for raw files. Can be False (default) to
+        omit, True to plot, or a dict to pass as ``kwargs`` to
+        :meth:`mne.io.Raw.plot_psd`.
+
+        .. versionadded:: 0.17
+    projs : bool
+        Whether to include topographic plots of SSP projectors, if present in
+        the data. Defaults to ``False``.
+
+        .. versionadded:: 0.21
+    %(verbose)s
+    html : list of str
         Contains items of html-page.
-    fnames : list
+    include : list of str
+        Dictionary containing elements included in head.
+    fnames : list of str
         List of file names rendered.
-    sections : list
+    sections : list of str
         List of sections.
     lang : str
         language setting for the HTML file.
-    include : OrderedDict
-        Dictionary containing elements included in head.
 
     Notes
     -----
@@ -978,6 +1008,7 @@ class Report(object):
 
         self._initial_id = 0
         self.html = []
+        self.include = []
         self.fnames = []  # List of file names rendered
         self.sections = []  # List of sections
         self.lang = 'en-us'  # language setting for the HTML file

--- a/mne/report.py
+++ b/mne/report.py
@@ -945,7 +945,7 @@ class Report(object):
     ----------
     initial_id : int
         Counter for unique ids.
-    html : list
+    html : list of str
         Contains items of html-page.
     fnames : list
         List of file names rendered.

--- a/mne/report.py
+++ b/mne/report.py
@@ -941,6 +941,21 @@ class Report(object):
         .. versionadded:: 0.21
     %(verbose)s
 
+    Attributes
+    ----------
+    initial_id : int
+        Counter for unique ids.
+    html : list
+        Contains items of html-page.
+    fnames : list
+        List of file names rendered.
+    sections : list
+        List of sections.
+    lang : str
+        language setting for the HTML file.
+    include : OrderedDict
+        Dictionary containing elements included in head.
+
     Notes
     -----
     See :ref:`tut-report` for an introduction to using ``mne.Report``.

--- a/mne/report.py
+++ b/mne/report.py
@@ -943,9 +943,7 @@ class Report(object):
 
     Attributes
     ----------
-    initial_id : int
-        Counter for unique ids.
-    html : list of str
+    html : list
         Contains items of html-page.
     fnames : list
         List of file names rendered.
@@ -978,7 +976,7 @@ class Report(object):
         self.projs = projs
         self.verbose = verbose
 
-        self.initial_id = 0
+        self._initial_id = 0
         self.html = []
         self.fnames = []  # List of file names rendered
         self.sections = []  # List of sections
@@ -1021,8 +1019,8 @@ class Report(object):
 
     def _get_id(self):
         """Get id of plot."""
-        self.initial_id += 1
-        return self.initial_id
+        self._initial_id += 1
+        return self._initial_id
 
     def _validate_input(self, items, captions, section, comments=None):
         """Validate input."""
@@ -1673,7 +1671,7 @@ class Report(object):
         """
         # Note: self._fname is not part of the state
         return (['baseline', 'cov_fname', 'fnames', 'html', 'include',
-                 'image_format', 'info_fname', 'initial_id', 'raw_psd',
+                 'image_format', 'info_fname', '_initial_id', 'raw_psd',
                  '_sectionlabels', 'sections', '_sectionvars', 'projs',
                  '_sort_sections', 'subjects_dir', 'subject', 'title',
                  'verbose'],


### PR DESCRIPTION
#### Reference issue
Tackles #9038.


#### What does this implement/fix?
It was suggested by @jasmainak to change report.include to a dictionary to make manipulating the items in include easier should it be necessary.


#### Additional information
The dictionary is of type OrderedDict to maintain compatibility with Python 3.6.
