### PR TITLE
Fix BUG: epochs.plot_image(evoked=False) doesn't show time in seconds #88…

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -37,6 +37,8 @@ Current (0.23.dev0)
 
 .. |Valerii Chirkov| replace:: **Valerii Chirkov**
 
+.. |Matteo Anelli| replace:: **Matteo Anelli**
+
 Enhancements
 ~~~~~~~~~~~~
 - Update citations in maxwell.py (:gh:`9043` **by new contributor** |Valerii Chirkov|_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -115,6 +115,8 @@ Enhancements
 
 Bugs
 ~~~~
+- Fix bug with :func:`mne.Epochs.plot_image` where the x_label was different depending on the evoked parameter (:gh:`9115` **by new contributor** |Matteo Anelli|_)
+
 - Fix bug with restricting :func:`mne.io.Raw.save` saving options to .fif and .fif.gz extensions (:gh:`9062` by |Valerii Chirkov|_)
 
 - Fix bug with :func:`mne.io.read_raw_kit` where missing marker coils were not handled (:gh:`8989` **by new contributor** |Judy D Zhu|_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -115,7 +115,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Fix bug with :func:`mne.Epochs.plot_image` where the x_label was different depending on the evoked parameter (:gh:`9115` **by new contributor** |Matteo Anelli|_)
+- Fix bug with :func:`mne.Epochs.plot_image` where the ``x_label`` was different depending on the evoked parameter (:gh:`9115` **by new contributor** |Matteo Anelli|_)
 
 - Fix bug with restricting :func:`mne.io.Raw.save` saving options to .fif and .fif.gz extensions (:gh:`9062` by |Valerii Chirkov|_)
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -367,3 +367,5 @@
 .. _Judy D Zhu: https://github.com/JD-Zhu
 
 .. _Valerii Chirkov: https://github.com/vagechirkov
+
+.. _Matteo Anelli: https://github.com/matteoanelli

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -513,7 +513,7 @@ def _plot_epochs_image(image, style_axes=True, epochs=None, picks=None,
     # draw the image
     cmap = _setup_cmap(cmap, norm=norm)
     n_epochs = len(image)
-    extent = [1e3 * tmin, 1e3 * tmax, 0, n_epochs]
+    extent = [tmin, tmax, 0, n_epochs]
     im = ax_im.imshow(image, vmin=vmin, vmax=vmax, cmap=cmap[0], aspect='auto',
                       origin='lower', interpolation='nearest', extent=extent)
 
@@ -521,14 +521,16 @@ def _plot_epochs_image(image, style_axes=True, epochs=None, picks=None,
     if style_axes:
         ax_im.set_title(title)
         ax_im.set_ylabel('Epochs')
+        if not evoked:
+            ax_im.set_xlabel('Time (s)')
         ax_im.axis('auto')
         ax_im.axis('tight')
         ax_im.axvline(0, color='k', linewidth=1, linestyle='--')
 
     if overlay_times is not None:
-        ax_im.plot(1e3 * overlay_times, 0.5 + np.arange(n_epochs), 'k',
+        ax_im.plot(overlay_times, 0.5 + np.arange(n_epochs), 'k',
                    linewidth=2)
-        ax_im.set_xlim(1e3 * tmin, 1e3 * tmax)
+        ax_im.set_xlim(tmin, tmax)
 
     # draw the evoked
     if evoked:


### PR DESCRIPTION
#### Reference issue
Fixes #8887.


#### What does this implement/fix?
If evoked=False the plot now shows the x values in seconds. Additionally adapted the overlay_times accordingly.


#### Additional information
If evoked=False the plot wasn't plotting any x_label, therefore, it has been added.

Solved with @eort.
