### PR TITLE
WIP,ENH: Load Qt stylesheet

### DIFF
--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -189,6 +189,15 @@ class _PyVistaRenderer(_AbstractRenderer):
                 self.plotter.iren = None
 
         self.update_lighting()
+        self._load_default_style()
+
+    def _load_default_style(self):
+        try:
+            with open('data.txt', 'r') as f:
+                data = f.read()
+            self.figure.store["app"].setStyleSheet(data)
+        except FileNotFoundError:
+            pass
 
     @property
     def _all_plotters(self):

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -192,12 +192,9 @@ class _PyVistaRenderer(_AbstractRenderer):
         self._load_default_style()
 
     def _load_default_style(self):
-        try:
-            with open('data.txt', 'r') as f:
-                data = f.read()
-            self.figure.store["app"].setStyleSheet(data)
-        except FileNotFoundError:
-            pass
+        import qdarkstyle
+        self.figure.plotter.app_window.setStyleSheet(
+            qdarkstyle.load_stylesheet())
 
     @property
     def _all_plotters(self):


### PR DESCRIPTION
This PR follows the discussion in https://github.com/mne-tools/mne-python/pull/9000#issuecomment-791680922 and comes after the discussion with @marsipu. The goal is to load a stylesheet dynamically.

This is still work in progress. For now, it just loads a `data.txt` test file:

```
QLabel {
	color: green
}
```

For short, it gives full control over the style of all the `PyQt5` instances of `_PyVistaRenderer`.

![image](https://user-images.githubusercontent.com/18143289/111492125-b470a200-873c-11eb-9e5e-3f063be98fd2.png)

ToDo:

- [ ] The icon color should change with the theme
