### PR TITLE
Add optipng to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ doc/coverages
 doc/samples
 doc/*.dat
 doc/fil-result
+doc/optipng.exe
 cover
 *.html
 


### PR DESCRIPTION
#### What does this implement/fix?
Adds `optipng.exe` to the gitignore for Windows users.
