### PR TITLE
DOC: Fix bibtex citation in plot_brainstorm_phantom_ctf.py #8940.

### DIFF
--- a/tutorials/sample-datasets/plot_brainstorm_phantom_ctf.py
+++ b/tutorials/sample-datasets/plot_brainstorm_phantom_ctf.py
@@ -7,16 +7,13 @@ Brainstorm CTF phantom dataset tutorial
 =======================================
 
 Here we compute the evoked from raw for the Brainstorm CTF phantom
-tutorial dataset. For comparison, see [1]_ and:
+tutorial dataset. For comparison, see :footcite:`TadelEtAl2011` and:
 
     https://neuroimage.usc.edu/brainstorm/Tutorials/PhantomCtf
 
 References
 ----------
-.. [1] Tadel F, Baillet S, Mosher JC, Pantazis D, Leahy RM.
-       Brainstorm: A User-Friendly Application for MEG/EEG Analysis.
-       Computational Intelligence and Neuroscience, vol. 2011, Article ID
-       879716, 13 pages, 2011. doi:10.1155/2011/879716
+.. footbibliography::
 """
 
 # Authors: Eric Larson <larson.eric.d@gmail.com>


### PR DESCRIPTION

#### Reference issue
Fixes issue #8940. 


#### What does this implement/fix?
Adds bibtex citation in plot_brainstorm_phantom_ctf.py.

