### PR TITLE
DOC: Correcting logger info output for spectral connectivity function…

### DIFF
--- a/mne/connectivity/spectral.py
+++ b/mne/connectivity/spectral.py
@@ -921,8 +921,7 @@ def spectral_connectivity(data, method='coh', indices=None, sfreq=2 * np.pi,
 
     if indices is None:
         # return all-to-all connectivity matrices
-        logger.info('    assembling connectivity matrix '
-                    '(filling the upper triangular region of the matrix)')
+        logger.info('    assembling connectivity matrix')
         con_flat = con
         con = list()
         for this_con_flat in con_flat:


### PR DESCRIPTION
#### Reference issue
Fixes issue #8559 


#### What does this implement/fix?
I removed the logger output "filling upper triangle region of the matrix". Now it will just say "assembling connectivity matrix".
