### PR TITLE
Dark-mode to PyVista-Brain (pair-programmed with @GuillaumeFavelier)

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -147,7 +147,6 @@ Enhancements
 
 - :func:`mne.io.anonymize_info` now anonymizes also sex and hand fields when ``keep_his`` is ``False`` (:gh:`9103`, :gh:`9175` by |Rotem Falach|_ and `Richard Höchenberger`_)
 
-
 - Add parameter ``theme`` to :class:`mne.viz.Brain` for optional Dark-Mode (:gh:`9149` by `Martin Schulz`_, `Guillaume Favelier`_)
 
 Bugs

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -148,6 +148,8 @@ Enhancements
 - :func:`mne.io.anonymize_info` now anonymizes also sex and hand fields when ``keep_his`` is ``False`` (:gh:`9103`, :gh:`9175` by |Rotem Falach|_ and `Richard Höchenberger`_)
 
 
+- Add parameter ``theme`` to :class:`mne.viz.Brain` for optional Dark-Mode (:gh:`9149` by `Martin Schulz`_, `Guillaume Favelier`_)
+
 Bugs
 ~~~~
 - Fix bug with :func:`mne.viz.plot_evoked_topo` where ``ylim`` was only being applied to the first channel in the dataset (:gh:`9162` **by new contributor** |Ram Pari|_ )

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -149,6 +149,8 @@ intersphinx_mapping = {
     'dipy': ('https://dipy.org/documentation/1.2.0.', None),
     'mne_realtime': ('https://mne.tools/mne-realtime', None),
     'picard': ('https://pierreablin.github.io/picard/', None),
+    'qdarkstyle': ('https://github.com/ColinDuquesnoy/QDarkStyleSheet', None),
+    'darkdetect': ('https://github.com/albertosottile/darkdetect', None)
 }
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -149,8 +149,7 @@ intersphinx_mapping = {
     'dipy': ('https://dipy.org/documentation/1.2.0.', None),
     'mne_realtime': ('https://mne.tools/mne-realtime', None),
     'picard': ('https://pierreablin.github.io/picard/', None),
-    'qdarkstyle': ('https://github.com/ColinDuquesnoy/QDarkStyleSheet', None),
-    'darkdetect': ('https://github.com/albertosottile/darkdetect', None)
+    'qdarkstyle': ('https://qdarkstylesheet.readthedocs.io/en/latest', None)
 }
 
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -254,6 +254,11 @@ class Brain(object):
         Color of the foreground (will be used for colorbars and text).
         None (default) will use black or white depending on the value
         of ``background``.
+    theme : str | path-like
+        Can be "auto" (default), "light", or "dark" to use darkdetect
+        (required for auto mode) or qdarkstyle (required for dark mode)
+        to style the widgets. Automatic detection does not yet work on
+        Linux. Can also be a path-like to a custom style sheet.
     figure : list of Figure | None | int
         If None (default), a new window will be created with the appropriate
         views. For single view plots, the figure can be specified as int to
@@ -365,7 +370,7 @@ class Brain(object):
 
     def __init__(self, subject_id, hemi, surf, title=None,
                  cortex="classic", alpha=1.0, size=800, background="black",
-                 foreground=None, figure=None, subjects_dir=None,
+                 foreground=None, theme='auto', figure=None, subjects_dir=None,
                  views='auto', offset='auto', show_toolbar=False,
                  offscreen=False, interaction='trackball', units='mm',
                  view_layout='vertical', silhouette=False, show=True):
@@ -472,6 +477,7 @@ class Brain(object):
                                        fig=figure)
 
         self._renderer._window_initialize(self._clean)
+        self._renderer._window_set_theme(theme)
         self.plotter = self._renderer.plotter
 
         self._setup_canonical_rotation()

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -291,10 +291,9 @@ class Brain(object):
        brain's silhouette to display. If True, the default values are used
        and if False, no silhouette will be displayed. Defaults to False.
     theme : str | path-like
-        Can be "auto" (default), "light", or "dark" to use darkdetect
-        (required for auto mode) or qdarkstyle (required for dark mode)
-        to style the widgets. Automatic detection does not yet work on
-        Linux. Can also be a path-like to a custom style sheet.
+        Can be "auto" (default), "light", or "dark" or a path-like to a
+        custom stylesheet. For Dark-Mode and automatic Dark-Mode-Detection,
+        `qdarkstyle` respectively `darkdetect` is required.
     show : bool
         Display the window as soon as it is ready. Defaults to True.
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -293,7 +293,8 @@ class Brain(object):
     theme : str | path-like
         Can be "auto" (default), "light", or "dark" or a path-like to a
         custom stylesheet. For Dark-Mode and automatic Dark-Mode-Detection,
-        :mod:`qdarkstyle` respectively :mod:`darkdetect` is required.
+        :mod:`qdarkstyle` respectively and `darkdetect
+        <https://github.com/albertosottile/darkdetect>`__ is required.
     show : bool
         Display the window as soon as it is ready. Defaults to True.
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -422,6 +422,8 @@ class Brain(object):
         self._size = size if len(size) == 2 else size * 2  # 1-tuple to 2-tuple
         subjects_dir = get_subjects_dir(subjects_dir)
 
+        self.theme = theme
+
         self.time_viewer = False
         self._hemi = hemi
         self._units = units
@@ -1229,6 +1231,7 @@ class Brain(object):
 
     def _configure_tool_bar(self):
         self._renderer._tool_bar_load_icons()
+        self._renderer._tool_bar_set_theme(self.theme)
         self._renderer._tool_bar_initialize()
         self._renderer._tool_bar_add_screenshot_button(
             name="screenshot",

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -293,7 +293,7 @@ class Brain(object):
     theme : str | path-like
         Can be "auto" (default), "light", or "dark" or a path-like to a
         custom stylesheet. For Dark-Mode and automatic Dark-Mode-Detection,
-        `qdarkstyle` respectively `darkdetect` is required.
+        :mod:`qdarkstyle` respectively :mod:`darkdetect` is required.
     show : bool
         Display the window as soon as it is ready. Defaults to True.
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -254,11 +254,6 @@ class Brain(object):
         Color of the foreground (will be used for colorbars and text).
         None (default) will use black or white depending on the value
         of ``background``.
-    theme : str | path-like
-        Can be "auto" (default), "light", or "dark" to use darkdetect
-        (required for auto mode) or qdarkstyle (required for dark mode)
-        to style the widgets. Automatic detection does not yet work on
-        Linux. Can also be a path-like to a custom style sheet.
     figure : list of Figure | None | int
         If None (default), a new window will be created with the appropriate
         views. For single view plots, the figure can be specified as int to
@@ -295,6 +290,11 @@ class Brain(object):
        and ``decimate`` (level of decimation between 0 and 1 or None) of the
        brain's silhouette to display. If True, the default values are used
        and if False, no silhouette will be displayed. Defaults to False.
+    theme : str | path-like
+        Can be "auto" (default), "light", or "dark" to use darkdetect
+        (required for auto mode) or qdarkstyle (required for dark mode)
+        to style the widgets. Automatic detection does not yet work on
+        Linux. Can also be a path-like to a custom style sheet.
     show : bool
         Display the window as soon as it is ready. Defaults to True.
 
@@ -370,10 +370,11 @@ class Brain(object):
 
     def __init__(self, subject_id, hemi, surf, title=None,
                  cortex="classic", alpha=1.0, size=800, background="black",
-                 foreground=None, theme='auto', figure=None, subjects_dir=None,
+                 foreground=None, figure=None, subjects_dir=None,
                  views='auto', offset='auto', show_toolbar=False,
                  offscreen=False, interaction='trackball', units='mm',
-                 view_layout='vertical', silhouette=False, show=True):
+                 view_layout='vertical', silhouette=False, theme='auto',
+                 show=True):
         from ..backends.renderer import backend, _get_renderer
         from .._3d import _get_cmap
         from matplotlib.colors import colorConverter

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -761,5 +761,9 @@ class _AbstractWindow(ABC):
         pass
 
     @abstractmethod
+    def _window_set_theme(self, theme):
+        pass
+
+    @abstractmethod
     def _window_show(self, sz):
         pass

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -285,6 +285,9 @@ class _IpyWindow(_AbstractWindow):
     def _window_ensure_minimum_sizes(self, sz):
         yield
 
+    def _window_set_theme(self, theme):
+        pass
+
     def _window_show(self, sz):
         self.show()
 

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -516,6 +516,7 @@ def _detect_theme():
 
     return theme
 
+
 @contextmanager
 def _testing_context(interactive):
     from . import renderer

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -443,8 +443,9 @@ class _QtWindow(_AbstractWindow):
                 import darkdetect
             except ModuleNotFoundError:
                 logger.info('For automatic Dark-Mode-Detection '
-                            '"darkdetect" has to be installed! You can install '
-                            'it with `pip install qdarkdetect`')
+                            '"darkdetect" has to be installed!'
+                            'You can install it with'
+                            ' `pip install qdarkdetect`')
                 theme = 'light'
             else:
                 detected_theme = darkdetect.theme()

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -27,7 +27,7 @@ from ._abstract import (_AbstractDock, _AbstractToolBar, _AbstractMenuBar,
                         _AbstractWindow, _AbstractMplCanvas, _AbstractPlayback,
                         _AbstractBrainMplCanvas, _AbstractMplInterface)
 from ._utils import _init_qt_resources, _qt_disable_paint
-from ..utils import _save_ndarray_img
+from ..utils import _save_ndarray_img, logger
 
 
 class _QtLayout(_AbstractLayout):
@@ -439,14 +439,29 @@ class _QtWindow(_AbstractWindow):
 
     def _window_set_theme(self, theme):
         if theme == 'auto':
-            import darkdetect
-            detected_theme = darkdetect.theme()
-            if detected_theme is not None:
-                theme = detected_theme.lower()
+            try:
+                import darkdetect
+            except ModuleNotFoundError:
+                logger.info('For automatic Dark-Mode-Detection '
+                            '"darkdetect" has to be installed! You can install '
+                            'it with `pip install qdarkdetect`')
+                theme = 'light'
+            else:
+                detected_theme = darkdetect.theme()
+                if detected_theme is not None:
+                    theme = detected_theme.lower()
+                else:
+                    theme = 'light'
 
         if theme == 'dark':
-            import qdarkstyle
-            stylesheet = qdarkstyle.load_stylesheet()
+            try:
+                import qdarkstyle
+            except ModuleNotFoundError:
+                logger.info('For Dark-Mode "qdarkstyle" has to be installed! '
+                            'You can install it with `pip install qdarkstyle`')
+                stylesheet = None
+            else:
+                stylesheet = qdarkstyle.load_stylesheet()
         elif isfile(theme):
             with open(theme, 'r') as file:
                 stylesheet = file.read()

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -501,20 +501,9 @@ class _Renderer(_PyVistaRenderer, _QtDock, _QtToolBar, _QtMenuBar,
 def _detect_theme():
     try:
         import darkdetect
-    except ModuleNotFoundError:
-        logger.info('For automatic Dark-Mode-Detection '
-                    '"darkdetect" has to be installed!'
-                    'You can install it with'
-                    ' `pip install qdarkdetect`')
-        theme = 'light'
-    else:
-        detected_theme = darkdetect.theme()
-        if detected_theme is not None:
-            theme = detected_theme.lower()
-        else:
-            theme = 'light'
-
-    return theme
+        return darkdetect.theme().lower()
+    except Exception:
+        return 'light'
 
 
 @contextmanager

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -7,6 +7,7 @@
 
 from contextlib import contextmanager
 from functools import partial
+from os.path import isfile
 
 import pyvista
 
@@ -435,6 +436,24 @@ class _QtWindow(_AbstractWindow):
                 self.figure.plotter.window_size = (sz.width(), sz.height())
             self._process_events()
             self._process_events()
+
+    def _window_set_theme(self, theme):
+        if theme == 'auto':
+            import darkdetect
+            detected_theme = darkdetect.theme()
+            if detected_theme is not None:
+                theme = detected_theme.lower()
+
+        if theme == 'dark':
+            import qdarkstyle
+            stylesheet = qdarkstyle.load_stylesheet()
+        elif isfile(theme):
+            with open(theme, 'r') as file:
+                stylesheet = file.read()
+        else:
+            stylesheet = None
+
+        self._window.setStyleSheet(stylesheet)
 
     def _window_show(self, sz):
         with _qt_disable_paint(self._interactor):

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -7,7 +7,6 @@
 
 from contextlib import contextmanager
 from functools import partial
-from os.path import isfile
 
 import pyvista
 
@@ -463,7 +462,7 @@ class _QtWindow(_AbstractWindow):
                 stylesheet = None
             else:
                 stylesheet = qdarkstyle.load_stylesheet()
-        elif isfile(theme):
+        elif theme != 'light':
             with open(theme, 'r') as file:
                 stylesheet = file.read()
         else:

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -291,7 +291,7 @@ class _QtToolBar(_AbstractToolBar, _QtLayout):
             for icon_key in self.icons:
                 icon = self.icons[icon_key]
                 image = icon.pixmap(80).toImage()
-                image.invertPixels(mode=QImage.InvertRgba)
+                image.invertPixels(mode=QImage.InvertRgb)
                 self.icons[icon_key] = QIcon(QPixmap.fromImage(image))
 
 


### PR DESCRIPTION
This follows PR #9126.

#### What does this implement/fix?
Add a theme-parameter to Brain with PyVista-Renderer accepting 'dark', 'light' and 'auto'. Dark-Mode depends on [qdarkstyle](https://github.com/ColinDuquesnoy/QDarkStyleSheet) and the automatic detection works with [darkdetect](https://github.com/albertosottile/darkdetect).
