### PR TITLE
Fix interactive zoom in plot_epochs_image.py (evoked=True)

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -39,6 +39,8 @@ Current (0.23.dev0)
 
 .. |Matteo Anelli| replace:: **Matteo Anelli**
 
+.. |Maggie Clarke| replace:: **Maggie Clarke**
+
 Enhancements
 ~~~~~~~~~~~~
 - Add :meth:`mne.Dipole.to_mni` for more convenient  dipole.pos to MNI conversion (:gh:`9043` **by new contributor** |Valerii Chirkov|_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -119,6 +119,8 @@ Enhancements
 
 Bugs
 ~~~~
+- Fix bug with :func:`mne.Epochs.plot_image` allowing interactive zoom to work properly (:gh:`9152` by **by new contributor** |Maggie Clarke|_ and `Daniel McCloy`_)
+
 - Fix bug with :func:`mne.Epochs.plot_image` where the ``x_label`` was different depending on the evoked parameter (:gh:`9115` **by new contributor** |Matteo Anelli|_)
 
 - Fix bug with restricting :func:`mne.io.Raw.save` saving options to .fif and .fif.gz extensions (:gh:`9062` by |Valerii Chirkov|_)

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -370,6 +370,8 @@
 
 .. _Valerii Chirkov: https://github.com/vagechirkov
 
+.. _Maggie Clarke: https://github.com/mdclarke
+
 .. _Matteo Anelli: https://github.com/matteoanelli
 
 .. _Cora Kim: https://github.com/kimcoco

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -219,7 +219,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         ts_args['show_sensors'] = False
     vlines = [0] if (epochs.times[0] < 0 < epochs.times[-1]) else []
     ts_defaults = dict(colors={'cond': 'k'}, title='', show=False,
-                       truncate_yaxis='auto', truncate_xaxis=False,
+                       truncate_yaxis=False, truncate_xaxis=False,
                        vlines=vlines, legend=False)
     ts_defaults.update(**ts_args)
     ts_args = ts_defaults.copy()
@@ -349,14 +349,9 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
             ch_type = this_group_dict['ch_type']
             if not manual_ylims:
                 args = auto_ylims[ch_type]
-                func = max
                 if 'invert_y' in ts_args:
                     args = args[::-1]
-                    func = min
                 ax.set_ylim(*args)
-                yticks = np.array(ax.get_yticks())
-                top_tick = func(yticks)
-                ax.spines['left'].set_bounds(top_tick, args[0])
     plt_show(show)
     # impose deterministic order of returned objects
     return_order = np.array(sorted(group_by))
@@ -500,6 +495,8 @@ def _plot_epochs_image(image, style_axes=True, epochs=None, picks=None,
                        title=None, evoked=False, ts_args=None, combine=None,
                        combine_given=False, norm=False):
     """Plot epochs image. Helper function for plot_epochs_image."""
+    from matplotlib.ticker import AutoLocator
+
     if cmap is None:
         cmap = 'Reds' if norm else 'RdBu_r'
 
@@ -542,7 +539,11 @@ def _plot_epochs_image(image, style_axes=True, epochs=None, picks=None,
         ax['evoked'].lines[0].set_clip_on(True)
         ax['evoked'].collections[0].set_clip_on(True)
         ax['evoked'].get_shared_x_axes().join(ax['evoked'], ax_im)
-        
+        # fix the axes for proper updating during interactivity
+        loc = ax_im.xaxis.get_major_locator()
+        ax['evoked'].xaxis.set_major_locator(loc)
+        ax['evoked'].yaxis.set_major_locator(AutoLocator())
+
     # draw the colorbar
     if colorbar:
         from matplotlib.pyplot import colorbar as cbar

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -219,7 +219,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         ts_args['show_sensors'] = False
     vlines = [0] if (epochs.times[0] < 0 < epochs.times[-1]) else []
     ts_defaults = dict(colors={'cond': 'k'}, title='', show=False,
-                       truncate_yaxis='auto', truncate_xaxis=False,
+                       truncate_yaxis=False, truncate_xaxis=False,
                        vlines=vlines, legend=False)
     ts_defaults.update(**ts_args)
     ts_args = ts_defaults.copy()
@@ -531,7 +531,7 @@ def _plot_epochs_image(image, style_axes=True, epochs=None, picks=None,
         ax_im.plot(overlay_times, 0.5 + np.arange(n_epochs), 'k',
                    linewidth=2)
         ax_im.set_xlim(tmin, tmax)
-
+       
     # draw the evoked
     if evoked:
         from . import plot_compare_evokeds
@@ -544,8 +544,7 @@ def _plot_epochs_image(image, style_axes=True, epochs=None, picks=None,
         ax['evoked'].lines[0].set_clip_on(True)
         ax['evoked'].collections[0].set_clip_on(True)
         ax['evoked'].get_shared_x_axes().join(ax['evoked'], ax_im)
-        ax_im.set_xticks([])
-
+        
     # draw the colorbar
     if colorbar:
         from matplotlib.pyplot import colorbar as cbar

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -358,7 +358,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
                 top_tick = func(yticks)
                 ax.spines['left'].set_bounds(top_tick, args[0])
     plt_show(show)
-
+    
     # impose deterministic order of returned objects
     return_order = np.array(sorted(group_by))
     are_ch_types = np.in1d(return_order, _VALID_CHANNEL_TYPES)
@@ -540,7 +540,10 @@ def _plot_epochs_image(image, style_axes=True, epochs=None, picks=None,
         plot_compare_evokeds({'cond': list(epochs.iter_evoked(copy=False))},
                              picks=_picks, axes=ax['evoked'],
                              combine=pass_combine, **ts_args)
-        ax['evoked'].set_xlim(tmin, tmax)  # don't multiply by 1e3 here
+        ax['evoked'].set_xlim(tmin, tmax)
+        ax['evoked'].lines[0].set_clip_on(True)
+        ax['evoked'].collections[0].set_clip_on(True)
+        ax['evoked'].get_shared_x_axes().join(ax['evoked'], ax_im)
         ax_im.set_xticks([])
 
     # draw the colorbar

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -219,7 +219,7 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
         ts_args['show_sensors'] = False
     vlines = [0] if (epochs.times[0] < 0 < epochs.times[-1]) else []
     ts_defaults = dict(colors={'cond': 'k'}, title='', show=False,
-                       truncate_yaxis=False, truncate_xaxis=False,
+                       truncate_yaxis='auto', truncate_xaxis=False,
                        vlines=vlines, legend=False)
     ts_defaults.update(**ts_args)
     ts_args = ts_defaults.copy()
@@ -358,7 +358,6 @@ def plot_epochs_image(epochs, picks=None, sigma=0., vmin=None,
                 top_tick = func(yticks)
                 ax.spines['left'].set_bounds(top_tick, args[0])
     plt_show(show)
-    
     # impose deterministic order of returned objects
     return_order = np.array(sorted(group_by))
     are_ch_types = np.in1d(return_order, _VALID_CHANNEL_TYPES)
@@ -530,8 +529,7 @@ def _plot_epochs_image(image, style_axes=True, epochs=None, picks=None,
     if overlay_times is not None:
         ax_im.plot(overlay_times, 0.5 + np.arange(n_epochs), 'k',
                    linewidth=2)
-        ax_im.set_xlim(tmin, tmax)
-       
+        ax_im.set_xlim(tmin, tmax)      
     # draw the evoked
     if evoked:
         from . import plot_compare_evokeds

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -529,7 +529,7 @@ def _plot_epochs_image(image, style_axes=True, epochs=None, picks=None,
     if overlay_times is not None:
         ax_im.plot(overlay_times, 0.5 + np.arange(n_epochs), 'k',
                    linewidth=2)
-        ax_im.set_xlim(tmin, tmax)      
+        ax_im.set_xlim(tmin, tmax)
     # draw the evoked
     if evoked:
         from . import plot_compare_evokeds


### PR DESCRIPTION
#### Reference issue
Fixes #9108

#### What does this implement/fix?
Stops curve from extending outside of axis when interactively zooming, and shares axes between both subplots when `plot_epochs_image(evoked=True)`

Can test on `plot_epochs_image` :

```
import os
import mne

# read in sample data
sample_data_path = mne.datasets.sample.data_path()
raw_fname = os.path.join(sample_data_path, 'MEG', 'sample', 
                         'sample_audvis_filt-0-40_raw.fif')
raw = mne.io.read_raw_fif(raw_fname, verbose=False)
events_fname = os.path.join(sample_data_path, 'MEG', 'sample', 
                            'sample_audvis_filt-0-40_raw-eve.fif')
events = mne.read_events(events_fname)
event_dict = {'auditory/left': 1, 'auditory/right': 2, 'visual/left': 3,
              'visual/right': 4}
tmin, tmax = (-0.2, 0.5) 
baseline = (None, 0)     
epochs = mne.Epochs(raw, events, event_dict, tmin, tmax, proj=True,
                    baseline=baseline, preload=True)
# test plot
epochs.plot_image(picks='grad', evoked=True)
```