### PR TITLE
[DOC] Stc near sensors doc

### DIFF
--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -3227,7 +3227,8 @@ def stc_near_sensors(evoked, trans, subject, distance=0.01, mode='sum',
     mode : str
         Can be "sum" to do a linear sum of weights, "nearest" to
         use only the weight of the nearest sensor, or "single" to
-        do a distance-weight of the nearest sensor. See Notes.
+        do a distance-weight of the nearest sensor. Default is "sum".
+        See Notes.
     project : bool
         If True, project the electrodes to the nearest ``'pial`` surface
         vertex before computing distances. Only used when doing a

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -3226,8 +3226,7 @@ def stc_near_sensors(evoked, trans, subject, distance=0.01, mode='sum',
         Distance (m) defining the activation "ball" of the sensor.
     mode : str
         Can be "sum" to do a linear sum of weights, "nearest" to
-        use only the weight of the nearest sensor, or "zero" to use a
-        zero-order hold. See Notes.
+        use only the weight of the nearest sensor. See Notes.
     project : bool
         If True, project the electrodes to the nearest ``'pial`` surface
         vertex before computing distances. Only used when doing a

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -3226,7 +3226,8 @@ def stc_near_sensors(evoked, trans, subject, distance=0.01, mode='sum',
         Distance (m) defining the activation "ball" of the sensor.
     mode : str
         Can be "sum" to do a linear sum of weights, "nearest" to
-        use only the weight of the nearest sensor. See Notes.
+        use only the weight of the nearest sensor, or "single" to
+        do a distance-weight of the nearest sensor. See Notes.
     project : bool
         If True, project the electrodes to the nearest ``'pial`` surface
         vertex before computing distances. Only used when doing a
@@ -3263,10 +3264,10 @@ def stc_near_sensors(evoked, trans, subject, distance=0.01, mode='sum',
         1 and a sensor at ``distance`` meters away (or larger) gets weight 0.
         If ``distance`` is less than the distance between any two electrodes,
         this will be the same as ``'nearest'``.
-    - ``'weighted'``
+    - ``'single'``
         Same as ``'sum'`` except that only the nearest electrode is used,
         rather than summing across electrodes within the ``distance`` radius.
-        As as ``'nearest'`` for vertices with distance zero to the projected
+        As ``'nearest'`` for vertices with distance zero to the projected
         sensor.
     - ``'nearest'``
         The value is given by the value of the nearest sensor, up to a


### PR DESCRIPTION
#### Reference issue
Closes #8479.

#### What does this implement/fix?
- remove zero as value for `mode`
- add single as value for `mode`
- in Notes, change `weighted` to `single`

#### Additional information
I find it a little confusing that `sum` is a valid value for that keyword, but does not appear in the code. I guess it is just the default behavior? But the default value is not specified.  
