### PR TITLE
ENH: add _repr_html_ method in the classes Info and BaseRaw

### DIFF
--- a/mne/data/html_templates.py
+++ b/mne/data/html_templates.py
@@ -1,0 +1,88 @@
+from ..externals.tempita import Template
+
+
+raw_template = Template(u"""
+<li class="{{div_klass}}" id="{{id}}">
+<h4>{{caption}}</h4>
+<table class="table table-hover">
+    <tr>
+        <th>Measurement date</th>
+        {{if meas_date is not None}}
+        <td>{{meas_date}}</td>
+        {{else}}<td>Unknown</td>{{endif}}
+    </tr>
+    <tr>
+        <th>Experimenter</th>
+        {{if info['experimenter'] is not None}}
+        <td>{{info['experimenter']}}</td>
+        {{else}}<td>Unknown</td>{{endif}}
+    </tr>
+    <tr>
+        <th>Digitized points</th>
+        {{if info['dig'] is not None}}
+        <td>{{len(info['dig'])}} points</td>
+        {{else}}
+        <td>Not available</td>
+        {{endif}}
+    </tr>
+    <tr>
+        <th>Good channels</th>
+        <td>{{n_mag}} magnetometer, {{n_grad}} gradiometer,
+            and {{n_eeg}} EEG channels</td>
+    </tr>
+    <tr>
+        <th>Bad channels</th>
+        {{if info['bads'] is not None}}
+        <td>{{', '.join(info['bads'])}}</td>
+        {{else}}<td>None</td>{{endif}}
+    </tr>
+    <tr>
+        <th>EOG channels</th>
+        <td>{{eog}}</td>
+    </tr>
+    <tr>
+        <th>ECG channels</th>
+        <td>{{ecg}}</td>
+    <tr>
+        <th>Measurement time range</th>
+        <td>{{u'%0.2f' % tmin}} to {{u'%0.2f' % tmax}} sec.</td>
+    </tr>
+    <tr>
+        <th>Sampling frequency</th>
+        <td>{{u'%0.2f' % info['sfreq']}} Hz</td>
+    </tr>
+    <tr>
+        <th>Highpass</th>
+        <td>{{u'%0.2f' % info['highpass']}} Hz</td>
+    </tr>
+     <tr>
+        <th>Lowpass</th>
+        <td>{{u'%0.2f' % info['lowpass']}} Hz</td>
+    </tr>
+</table>
+</li>
+""")
+
+
+def _repr_raw_html(self, global_id='', caption='', tmin=0, tmax=0):
+    n_eeg = len(pick_types(self, meg=False, eeg=True))
+    n_grad = len(pick_types(self, meg='grad'))
+    n_mag = len(pick_types(self, meg='mag'))
+    pick_eog = pick_types(self, meg=False, eog=True)
+    if len(pick_eog) > 0:
+        eog = ', '.join(np.array(self['ch_names'])[pick_eog])
+    else:
+        eog = 'Not available'
+    pick_ecg = pick_types(self, meg=False, ecg=True)
+    if len(pick_ecg) > 0:
+        ecg = ', '.join(np.array(self['ch_names'])[pick_ecg])
+    else:
+        ecg = 'Not available'
+    meas_date = self['meas_date']
+    if meas_date is not None:
+        meas_date = meas_date.strftime("%B %d, %Y") + ' GMT'
+
+    return raw_template.substitute(
+        div_klass='raw', id=global_id, caption=caption, info=self,
+        meas_date=meas_date, n_eeg=n_eeg, n_grad=n_grad, n_mag=n_mag,
+        eog=eog, ecg=ecg, tmin=tmin, tmax=tmax)

--- a/mne/data/html_templates.py
+++ b/mne/data/html_templates.py
@@ -1,8 +1,7 @@
 from ..externals.tempita import Template
 
 
-raw_template = Template(u"""
-<li class="{{div_klass}}" id="{{id}}">
+info_template = Template(u"""
 <h4>{{caption}}</h4>
 <table class="table table-hover">
     <tr>
@@ -44,10 +43,6 @@ raw_template = Template(u"""
         <th>ECG channels</th>
         <td>{{ecg}}</td>
     <tr>
-        <th>Measurement time range</th>
-        <td>{{u'%0.2f' % tmin}} to {{u'%0.2f' % tmax}} sec.</td>
-    </tr>
-    <tr>
         <th>Sampling frequency</th>
         <td>{{u'%0.2f' % info['sfreq']}} Hz</td>
     </tr>
@@ -60,5 +55,13 @@ raw_template = Template(u"""
         <td>{{u'%0.2f' % info['lowpass']}} Hz</td>
     </tr>
 </table>
-</li>
+""")
+
+raw_template = Template(u"""
+{{info_repr[:-9]}}
+    <tr>
+        <th>Measurement time range</th>
+        <td>{{u'%0.2f' % tmin}} to {{u'%0.2f' % tmax}} sec.</td>
+    </tr>
+</table>
 """)

--- a/mne/data/html_templates.py
+++ b/mne/data/html_templates.py
@@ -57,7 +57,7 @@ info_template = Template("""
 </table>
 """)
 
-raw_template = Template(u"""
+raw_template = Template("""
 {{info_repr[:-9]}}
     <tr>
         <th>Measurement time range</th>

--- a/mne/data/html_templates.py
+++ b/mne/data/html_templates.py
@@ -62,27 +62,3 @@ raw_template = Template(u"""
 </table>
 </li>
 """)
-
-
-def _repr_raw_html(self, global_id='', caption='', tmin=0, tmax=0):
-    n_eeg = len(pick_types(self, meg=False, eeg=True))
-    n_grad = len(pick_types(self, meg='grad'))
-    n_mag = len(pick_types(self, meg='mag'))
-    pick_eog = pick_types(self, meg=False, eog=True)
-    if len(pick_eog) > 0:
-        eog = ', '.join(np.array(self['ch_names'])[pick_eog])
-    else:
-        eog = 'Not available'
-    pick_ecg = pick_types(self, meg=False, ecg=True)
-    if len(pick_ecg) > 0:
-        ecg = ', '.join(np.array(self['ch_names'])[pick_ecg])
-    else:
-        ecg = 'Not available'
-    meas_date = self['meas_date']
-    if meas_date is not None:
-        meas_date = meas_date.strftime("%B %d, %Y") + ' GMT'
-
-    return raw_template.substitute(
-        div_klass='raw', id=global_id, caption=caption, info=self,
-        meas_date=meas_date, n_eeg=n_eeg, n_grad=n_grad, n_mag=n_mag,
-        eog=eog, ecg=ecg, tmin=tmin, tmax=tmax)

--- a/mne/data/html_templates.py
+++ b/mne/data/html_templates.py
@@ -1,7 +1,7 @@
 from ..externals.tempita import Template
 
 
-info_template = Template(u"""
+info_template = Template("""
 <h4>{{caption}}</h4>
 <table class="table table-hover">
     <tr>

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -54,6 +54,7 @@ from ..event import find_events, concatenate_events
 from ..annotations import Annotations, _combine_annotations, _sync_onset
 from ..data.html_templates import raw_template
 
+
 class TimeMixin(object):
     """Class to add sfreq and time_as_index capabilities to certain classes."""
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -52,7 +52,7 @@ from ..defaults import _handle_default
 from ..viz import plot_raw, plot_raw_psd, plot_raw_psd_topo, _RAW_CLIP_DEF
 from ..event import find_events, concatenate_events
 from ..annotations import Annotations, _combine_annotations, _sync_onset
-
+from ..data.html_templates import raw_template
 
 class TimeMixin(object):
     """Class to add sfreq and time_as_index capabilities to certain classes."""
@@ -1675,6 +1675,13 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
              % (name, len(self.ch_names), self.n_times, self.times[-1],
                 size_str))
         return "<%s | %s>" % (self.__class__.__name__, s)
+
+    def _repr_html_(self, caption=None):
+        if not isinstance(caption, str):
+            caption = 'Raw'
+        return raw_template.substitute(
+            info_repr=self.info._repr_html_(caption=caption),
+            tmin=self.first_samp, tmax=self.last_samp)
 
     def add_events(self, events, stim_channel=None, replace=False):
         """Add events to stim channel.

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -809,7 +809,9 @@ class Info(dict, MontageMixin):
     def ch_names(self):
         return self['ch_names']
 
-    def _repr_html_(self, global_id='', caption='', tmin=0, tmax=0):
+    def _repr_html_(self, caption=None):
+        if not isinstance(caption, str):
+            caption = 'Info'
         n_eeg = len(pick_types(self, meg=False, eeg=True))
         n_grad = len(pick_types(self, meg='grad'))
         n_mag = len(pick_types(self, meg='mag'))
@@ -828,8 +830,8 @@ class Info(dict, MontageMixin):
             meas_date = meas_date.strftime("%B %d, %Y") + ' GMT'
 
         return info_template.substitute(
-            info=self, meas_date=meas_date, n_eeg=n_eeg, n_grad=n_grad,
-            n_mag=n_mag, eog=eog, ecg=ecg)
+            caption=caption, info=self, meas_date=meas_date, n_eeg=n_eeg,
+            n_grad=n_grad, n_mag=n_mag, eog=eog, ecg=ecg)
 
 
 def _simplify_info(info):

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -39,7 +39,7 @@ from ._digitization import (_format_dig_points, _dig_kind_proper, DigPoint,
                             _dig_kind_rev, _dig_kind_ints, _read_dig_fif)
 from ._digitization import write_dig as _dig_write_dig
 from .compensator import get_current_comp
-from ..data.html_templates import raw_template
+from ..data.html_templates import info_template
 
 b = bytes  # alias
 
@@ -827,10 +827,9 @@ class Info(dict, MontageMixin):
         if meas_date is not None:
             meas_date = meas_date.strftime("%B %d, %Y") + ' GMT'
 
-        return raw_template.substitute(
-            div_klass='raw', id=global_id, caption=caption, info=self,
-            meas_date=meas_date, n_eeg=n_eeg, n_grad=n_grad, n_mag=n_mag,
-            eog=eog, ecg=ecg, tmin=tmin, tmax=tmax)
+        return info_template.substitute(
+            info=self, meas_date=meas_date, n_eeg=n_eeg, n_grad=n_grad,
+            n_mag=n_mag, eog=eog, ecg=ecg)
 
 
 def _simplify_info(info):

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -809,7 +809,7 @@ class Info(dict, MontageMixin):
     def ch_names(self):
         return self['ch_names']
 
-    def _repr_html(self, global_id='', caption='', tmin=0, tmax=0):
+    def _repr_html_(self, global_id='', caption='', tmin=0, tmax=0):
         n_eeg = len(pick_types(self, meg=False, eeg=True))
         n_grad = len(pick_types(self, meg='grad'))
         n_mag = len(pick_types(self, meg='mag'))

--- a/mne/report.py
+++ b/mne/report.py
@@ -1899,8 +1899,9 @@ class Report(object):
         extra = '(MaxShield on)' if raw.info.get('maxshield', False) else ''
         caption = self._gen_caption(prefix='Raw', suffix=extra,
                                     fname=raw_fname, data_path=data_path)
-        html = raw.info._repr_html(global_id=global_id, caption=caption,
-                                   tmin=raw.first_samp, tmax=raw.last_samp)
+        html = """<li class="raw" id="%s">""" % (global_id)
+        html += raw._repr_html_(caption=caption)
+        html += "</li>"
 
         raw_psd = {} if self.raw_psd is True else self.raw_psd
         if isinstance(raw_psd, dict):

--- a/mne/report.py
+++ b/mne/report.py
@@ -813,69 +813,6 @@ repr_template = Template(u"""
 <hr></li>
 """)
 
-raw_template = Template(u"""
-<li class="{{div_klass}}" id="{{id}}">
-<h4>{{caption}}</h4>
-<table class="table table-hover">
-    <tr>
-        <th>Measurement date</th>
-        {{if meas_date is not None}}
-        <td>{{meas_date}}</td>
-        {{else}}<td>Unknown</td>{{endif}}
-    </tr>
-    <tr>
-        <th>Experimenter</th>
-        {{if info['experimenter'] is not None}}
-        <td>{{info['experimenter']}}</td>
-        {{else}}<td>Unknown</td>{{endif}}
-    </tr>
-    <tr>
-        <th>Digitized points</th>
-        {{if info['dig'] is not None}}
-        <td>{{len(info['dig'])}} points</td>
-        {{else}}
-        <td>Not available</td>
-        {{endif}}
-    </tr>
-    <tr>
-        <th>Good channels</th>
-        <td>{{n_mag}} magnetometer, {{n_grad}} gradiometer,
-            and {{n_eeg}} EEG channels</td>
-    </tr>
-    <tr>
-        <th>Bad channels</th>
-        {{if info['bads'] is not None}}
-        <td>{{', '.join(info['bads'])}}</td>
-        {{else}}<td>None</td>{{endif}}
-    </tr>
-    <tr>
-        <th>EOG channels</th>
-        <td>{{eog}}</td>
-    </tr>
-    <tr>
-        <th>ECG channels</th>
-        <td>{{ecg}}</td>
-    <tr>
-        <th>Measurement time range</th>
-        <td>{{u'%0.2f' % tmin}} to {{u'%0.2f' % tmax}} sec.</td>
-    </tr>
-    <tr>
-        <th>Sampling frequency</th>
-        <td>{{u'%0.2f' % info['sfreq']}} Hz</td>
-    </tr>
-    <tr>
-        <th>Highpass</th>
-        <td>{{u'%0.2f' % info['highpass']}} Hz</td>
-    </tr>
-     <tr>
-        <th>Lowpass</th>
-        <td>{{u'%0.2f' % info['lowpass']}} Hz</td>
-    </tr>
-</table>
-</li>
-""")
-
-
 toc_list = Template(u"""
 <li class="{{div_klass}}">
     {{if id}}
@@ -1959,31 +1896,11 @@ class Report(object):
         if raw_fname.endswith(('.fif', '.fif.gz')):
             kwargs['allow_maxshield'] = True
         raw = read_raw(**kwargs)
-
         extra = '(MaxShield on)' if raw.info.get('maxshield', False) else ''
         caption = self._gen_caption(prefix='Raw', suffix=extra,
                                     fname=raw_fname, data_path=data_path)
-        n_eeg = len(pick_types(raw.info, meg=False, eeg=True))
-        n_grad = len(pick_types(raw.info, meg='grad'))
-        n_mag = len(pick_types(raw.info, meg='mag'))
-        pick_eog = pick_types(raw.info, meg=False, eog=True)
-        if len(pick_eog) > 0:
-            eog = ', '.join(np.array(raw.info['ch_names'])[pick_eog])
-        else:
-            eog = 'Not available'
-        pick_ecg = pick_types(raw.info, meg=False, ecg=True)
-        if len(pick_ecg) > 0:
-            ecg = ', '.join(np.array(raw.info['ch_names'])[pick_ecg])
-        else:
-            ecg = 'Not available'
-        meas_date = raw.info['meas_date']
-        if meas_date is not None:
-            meas_date = meas_date.strftime("%B %d, %Y") + ' GMT'
-
-        html = raw_template.substitute(
-            div_klass='raw', id=global_id, caption=caption, info=raw.info,
-            meas_date=meas_date, n_eeg=n_eeg, n_grad=n_grad, n_mag=n_mag,
-            eog=eog, ecg=ecg, tmin=raw._first_time, tmax=raw._last_time)
+        html = raw.info._repr_html(global_id=global_id, caption=caption,
+                                   tmin=raw.first_samp, tmax=raw.last_samp)
 
         raw_psd = {} if self.raw_psd is True else self.raw_psd
         if isinstance(raw_psd, dict):

--- a/tutorials/intro/plot_30_info.py
+++ b/tutorials/intro/plot_30_info.py
@@ -181,6 +181,11 @@ eeg_indices = mne.pick_types(info, meg=False, eeg=True)
 print(mne.pick_info(info, eeg_indices)['nchan'])
 
 ###############################################################################
+# We can also get a nice HTML representation in IPython like:
+
+info
+
+###############################################################################
 # By default, :func:`~mne.pick_info` will make a copy of the original
 # :class:`~mne.Info` object before modifying it; if you want to modify it
 # in-place, include the parameter ``copy=False``.


### PR DESCRIPTION
Reference issue #6846.


Reuse `report.py` code in order to produce html reports within the Info class.

Here is the output of in the IPython notebook:

![image](https://user-images.githubusercontent.com/42982039/111775982-be67e180-88b1-11eb-8154-8a7a856fb147.png)
