### PR TITLE
BUG : Fixes Bug where ylim would only be applied to the first channel in plot_evoked_topo

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -45,6 +45,8 @@ Current (0.23.dev0)
 
 .. |Silvia Cotroneo| replace:: **Silvia Cotroneo**
 
+.. |Ram Pari| replace:: **Ram Pari**
+
 Enhancements
 ~~~~~~~~~~~~
 - Add different colors for each volume source space in :func:`mne.viz.plot_alignment` (:gh:`9043` **by new contributor** |Valerii Chirkov|_)
@@ -135,6 +137,8 @@ Enhancements
 
 Bugs
 ~~~~
+- Fix bug with :func:`mne.viz.plot_evoked_topo` where ``ylim`` was only being applied to the first channel in the dataset (:gh:`9162` **by new contributor** |Ram Pari|_ )
+
 - Fix bug with :func:`mne.Epochs.plot_image` where the ``x_label`` was different depending on the evoked parameter (:gh:`9115` **by new contributor** |Matteo Anelli|_)
 
 - Fix bug with restricting :func:`mne.io.Raw.save` saving options to .fif and .fif.gz extensions (:gh:`9062` by |Valerii Chirkov|_)

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -375,3 +375,5 @@
 .. _Cora Kim: https://github.com/kimcoco
 
 .. _Silvia Cotroneo: https://github.com/sfc-neuro
+
+.. _Ram Pari: https://github.com/ramkpari

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -230,12 +230,13 @@ def _plot_topo(info, times, show_func, click_func=None, layout=None,
                                     fig_facecolor=fig_facecolor,
                                     unified=unified, img=img, axes=axes)
 
-    # Converting the ylim to a list to avoid zip object exhaustion
+    # Temporarily converting the ylim to a list to avoid zip object exhaustion
     ylim_list = [list(t) for t in zip(*ylim)]
     for ax, ch_idx in my_topo_plot:
         if layout.kind == 'Vectorview-all' and ylim is not None:
             this_type = {'mag': 0, 'grad': 1}[channel_type(info, ch_idx)]
-            ylim_ = [v[this_type] if _check_vlim(v) else v for v in ylim_list]
+            ylim_ = zip(*ylim_list)
+            ylim_ = [v[this_type] if _check_vlim(v) else v for v in ylim_]
         else:
             ylim_ = ylim
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -230,7 +230,7 @@ def _plot_topo(info, times, show_func, click_func=None, layout=None,
                                     fig_facecolor=fig_facecolor,
                                     unified=unified, img=img, axes=axes)
 
-    # Coverting the ylim to a list to avoid zip object exhaustion
+    # Converting the ylim to a list to avoid zip object exhaustion
     ylim_list = list(ylim)
     for ax, ch_idx in my_topo_plot:
         if layout.kind == 'Vectorview-all' and ylim is not None:

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -231,7 +231,7 @@ def _plot_topo(info, times, show_func, click_func=None, layout=None,
                                     unified=unified, img=img, axes=axes)
 
     # Converting the ylim to a list to avoid zip object exhaustion
-    ylim_list = list(ylim)
+    ylim_list = [list(t) for t in zip(*ylim)]
     for ax, ch_idx in my_topo_plot:
         if layout.kind == 'Vectorview-all' and ylim is not None:
             this_type = {'mag': 0, 'grad': 1}[channel_type(info, ch_idx)]

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -230,10 +230,12 @@ def _plot_topo(info, times, show_func, click_func=None, layout=None,
                                     fig_facecolor=fig_facecolor,
                                     unified=unified, img=img, axes=axes)
 
+    # Coverting the ylim to a list to avoid zip object exhaustion
+    ylim_list = list(ylim)
     for ax, ch_idx in my_topo_plot:
         if layout.kind == 'Vectorview-all' and ylim is not None:
             this_type = {'mag': 0, 'grad': 1}[channel_type(info, ch_idx)]
-            ylim_ = [v[this_type] if _check_vlim(v) else v for v in ylim]
+            ylim_ = [v[this_type] if _check_vlim(v) else v for v in ylim_list]
         else:
             ylim_ = ylim
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -233,10 +233,10 @@ def _plot_topo(info, times, show_func, click_func=None, layout=None,
     # Temporarily converting the ylim to a list to avoid zip object exhaustion
     ylim_list = [list(t) for t in zip(*ylim)]
     for ax, ch_idx in my_topo_plot:
-        if layout.kind == 'Vectorview-all' and ylim is not None:
+        if layout.kind == 'Vectorview-all' and ylim_list is not None:
             this_type = {'mag': 0, 'grad': 1}[channel_type(info, ch_idx)]
-            ylim_ = zip(*ylim_list)
-            ylim_ = [v[this_type] if _check_vlim(v) else v for v in ylim_]
+            ylim = zip(*ylim_list)
+            ylim_ = [v[this_type] if _check_vlim(v) else v for v in ylim]
         else:
             ylim_ = ylim
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -231,7 +231,11 @@ def _plot_topo(info, times, show_func, click_func=None, layout=None,
                                     unified=unified, img=img, axes=axes)
 
     # Temporarily converting the ylim to a list to avoid zip object exhaustion
-    ylim_list = [list(t) for t in zip(*ylim)]
+    if ylim is not None:
+        ylim_list = [list(t) for t in zip(*ylim)]
+    else:
+        ylim_list = ylim
+
     for ax, ch_idx in my_topo_plot:
         if layout.kind == 'Vectorview-all' and ylim_list is not None:
             this_type = {'mag': 0, 'grad': 1}[channel_type(info, ch_idx)]


### PR DESCRIPTION
#### Reference issue
Fixed a bug where any ylim input parameters to function ``plot_evoked_topo`` would be ignored.  Mentioned here (https://github.com/mne-tools/mne-python/issues/8714#issuecomment-801339017)

The bug arose as a result of a zip object being exhausted after being applied to the first channel inside ``_plot_topo``

#### What does this implement/fix?
Added a temporary list outside the respective for loop to mitigate the zip object from being exhausted in the first iteration .

