### PR TITLE
MAINT: Move function

### DIFF
--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -20,6 +20,7 @@ import re
 import numpy as np
 
 from ..defaults import HEAD_SIZE_DEFAULT
+from ..source_space import get_mni_fiducials
 from ..viz import plot_montage
 from ..transforms import (apply_trans, get_ras_to_neuromag_trans, _sph_to_cart,
                           _topo_to_sph, _frame_to_str, Transform,
@@ -383,8 +384,6 @@ class DigMontage(object):
         and then use ``montage.get_native_head_t()`` to get the
         head <-> MRI transform.
         """
-        from ..coreg import get_mni_fiducials
-
         # get coordframe and fiducial coordinates
         montage_bunch = _get_data_as_dict_from_dig(self.dig)
 

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -21,9 +21,9 @@ import numpy as np
 from .io import read_fiducials, write_fiducials, read_info
 from .io.constants import FIFF
 from .label import read_label, Label
-from .source_space import (add_source_space_distances, read_source_spaces,
+from .source_space import (add_source_space_distances, read_source_spaces,  # noqa: E501,F401
                            write_source_spaces, _read_mri_info,
-                           get_mni_fiducials)  # noqa
+                           get_mni_fiducials)
 from .surface import read_surface, write_surface, _normalize_vectors
 from .bem import read_bem_surfaces, write_bem_surfaces
 from .transforms import (rotation, rotation3d, scaling, translation, Transform,

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -22,12 +22,13 @@ from .io import read_fiducials, write_fiducials, read_info
 from .io.constants import FIFF
 from .label import read_label, Label
 from .source_space import (add_source_space_distances, read_source_spaces,
-                           write_source_spaces, read_talxfm, _read_mri_info)
+                           write_source_spaces, _read_mri_info,
+                           get_mni_fiducials)  # noqa
 from .surface import read_surface, write_surface, _normalize_vectors
 from .bem import read_bem_surfaces, write_bem_surfaces
 from .transforms import (rotation, rotation3d, scaling, translation, Transform,
                          _read_fs_xfm, _write_fs_xfm, invert_transform,
-                         combine_transforms, apply_trans, _quat_to_euler,
+                         combine_transforms, _quat_to_euler,
                          _fit_matched_points)
 from .utils import (get_config, get_subjects_dir, logger, pformat, verbose,
                     warn, has_nibabel)
@@ -1218,51 +1219,3 @@ def _scale_xfm(subject_to, xfm_fname, mri_name, subject_from, scale,
                 F_mri_ras, 'ras', 'ras'),
             F_ras_mni, 'ras', 'mni_tal')
     _write_fs_xfm(fname_to, T_ras_mni['trans'], kind)
-
-
-@verbose
-def get_mni_fiducials(subject, subjects_dir=None, verbose=None):
-    """Estimate fiducials for a subject.
-
-    Parameters
-    ----------
-    %(subject)s
-    %(subjects_dir)s
-    %(verbose)s
-
-    Returns
-    -------
-    fids_mri : list
-        List of estimated fiducials (each point in a dict), in the order
-        LPA, nasion, RPA.
-
-    Notes
-    -----
-    This takes the ``fsaverage-fiducials.fif`` file included with MNE—which
-    contain the LPA, nasion, and RPA for the ``fsaverage`` subject—and
-    transforms them to the given FreeSurfer subject's MRI space.
-    The MRI of ``fsaverage`` is already in MNI Talairach space, so applying
-    the inverse of the given subject's MNI Talairach affine transformation
-    (``$SUBJECTS_DIR/$SUBJECT/mri/transforms/talairach.xfm``) is used
-    to estimate the subject's fiducial locations.
-
-    For more details about the coordinate systems and transformations involved,
-    see https://surfer.nmr.mgh.harvard.edu/fswiki/CoordinateSystems and
-    :ref:`plot_source_alignment`.
-    """
-    # Eventually we might want to allow using the MNI Talairach with-skull
-    # transformation rather than the standard brain-based MNI Talaranch
-    # transformation, and/or project the points onto the head surface
-    # (if available).
-    fname_fids_fs = os.path.join(os.path.dirname(__file__), 'data',
-                                 'fsaverage', 'fsaverage-fiducials.fif')
-
-    # Read fsaverage fiducials file and subject Talairach.
-    fids, coord_frame = read_fiducials(fname_fids_fs)
-    assert coord_frame == FIFF.FIFFV_COORD_MRI
-    if subject == 'fsaverage':
-        return fids  # special short-circuit for fsaverage
-    mni_mri_t = invert_transform(read_talxfm(subject, subjects_dir))
-    for f in fids:
-        f['r'] = apply_trans(mni_mri_t, f['r'])
-    return fids


### PR DESCRIPTION
Requested by @agramfort in https://github.com/mne-tools/mne-python/pull/9118#discussion_r596933282. It's purely a code move.

Unfortunately `mne.coreg.get_mni_fiducials` is public in the `mne.coreg` namespace:

https://mne.tools/dev/generated/mne.coreg.get_mni_fiducials.html

I'm not sure it's worth it to move its API page to a different namespace, but we could. @agramfort do you prefer we leave it, or move it to `mne.` or `mne.source_space.` or somewhere else?