### PR TITLE
MAINT: reduce tutorial memory usage

### DIFF
--- a/tutorials/epochs/plot_60_make_fixed_length_epochs.py
+++ b/tutorials/epochs/plot_60_make_fixed_length_epochs.py
@@ -18,12 +18,9 @@ the signal.
 
 import os
 import numpy as np
+import matplotlib.pyplot as plt
 import mne
 from mne.preprocessing import compute_proj_ecg
-import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1 import make_axes_locatable
-
-picks = ['mag', 'grad']
 
 sample_data_folder = mne.datasets.sample.data_path()
 sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
@@ -31,9 +28,15 @@ sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
 
 raw = mne.io.read_raw_fif(sample_data_raw_file)
 
-# Remove heart artifact for cleanliness of data
+###############################################################################
+# For this tutorial we'll crop and resample the raw data to a manageable size
+# for our web server to handle, ignore EEG channels, and remove the heartbeat
+# artifact so we don't get spurious correlations just because of that.
+
+raw.crop(tmax=150).resample(100).pick('meg')
 ecg_proj, _ = compute_proj_ecg(raw, ch_name='MEG 0511')  # No ECG chan
-ssp = raw.copy().apply_proj()
+raw.add_proj(ecg_proj)
+raw.apply_proj()
 
 ###############################################################################
 # To create fixed length epochs, we simply call the function and provide it
@@ -42,29 +45,15 @@ ssp = raw.copy().apply_proj()
 # overlap with raw data segments annotated as bad, whether or not to include
 # projectors, and finally whether or not to be verbose. Here, we choose a long
 # epoch duration (30 seconds). To conserve memory, we set ``preload`` to
-# ``False``. We elect to reject segments of data marked as bad, and we keep the
-# ecg projectors we created to suppress heart artifacts.
+# ``False``.
 
-epochs = mne.make_fixed_length_epochs(ssp, duration=30, preload=False,
-                                      reject_by_annotation=True, proj=True,
-                                      verbose=True)
+epochs = mne.make_fixed_length_epochs(raw, duration=30, preload=False)
 
 ###############################################################################
 # Characteristics of Fixed Length Epochs
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# A key characteristic of fixed length epochs is that they are generally
-# unsuitable for event-related analyses. Two quick visualizations will
-# illustrate why. First, we create a time series butterfly plot grouping
-# channels together by spatial region. Clear peaks of event-related activity
-# corresponding to stimuli onsets are seen in each 30-second epoch, but peak
-# timing is jittered across fixed-length epochs.
-
-# Visualize the fixed length epochs
-timeseries_plot = epochs.plot(n_epochs=5, picks=picks, group_by='selection',
-                              butterfly=True)
-
-###############################################################################
-# Next, we pick a single channel and create an image map of our fixed length
+# Fixed length epochs are generally unsuitable for event-related analyses. This
+# can be seen in an image map of our fixed length
 # epochs. When the epochs are averaged, as seen at the bottom of the plot,
 # misalignment between onsets of event-related activity results in noise.
 
@@ -89,44 +78,35 @@ event_related_plot = epochs.plot_image(picks=['MEG 1142'])
 # be applied after epoching.
 #
 # Let's examine the alpha band. We allow default values for filter parameters
-# (for more information on filtering, please see
-# :ref:`tut-filter-resample`).
+# (for more information on filtering, please see :ref:`tut-filter-resample`).
 
-alpha = epochs.copy().load_data().filter(l_freq=8, h_freq=12)
-
-# Compute envelope correlations in sensor space
-epoch_data = epochs.get_data(picks=['mag', 'grad'])
-corr_matrix = mne.connectivity.envelope_correlation(epoch_data, combine=None,
-                                                    orthogonalize='pairwise',
-                                                    log=False, absolute=True,
-                                                    verbose=True)
+epochs.load_data().filter(l_freq=8, h_freq=12)
+alpha_data = epochs.get_data()
 
 ###############################################################################
 # If desired, separate correlation matrices for each epoch can be obtained.
 # For envelope correlations, this is done by passing ``combine=None`` to the
 # envelope correlations function.
 
-# Plot correlation matrices from the first and last 30 second epochs of the
-# recording
+corr_matrix = mne.connectivity.envelope_correlation(alpha_data, combine=None)
+
+###############################################################################
+# Now we can plot correlation matrices. We'll compare the first and last
+# 30-second epochs of the recording:
+
 first_30 = corr_matrix[0]
 last_30 = corr_matrix[-1]
-c_matrices = [first_30, last_30]
+corr_matrices = [first_30, last_30]
+color_lims = np.percentile(np.array(corr_matrices), [5, 95])
 titles = ['First 30 Seconds', 'Last 30 Seconds']
 
-fig, axes = plt.subplots(nrows=1, ncols=2,
-                         gridspec_kw=dict(width_ratios=[92, 100]),
-                         figsize=(8, 8))
+fig, axes = plt.subplots(nrows=1, ncols=2)
 fig.suptitle('Correlation Matrices from First 30 Seconds and Last 30 Seconds')
-for ci, c_matrix in enumerate(c_matrices):
+for ci, corr_matrix in enumerate(corr_matrices):
     ax = axes[ci]
-    low_lim, high_lim = np.percentile(c_matrix, [5, 95])
-    mpbl = ax.imshow(c_matrix, clim=[low_lim, high_lim])
+    mpbl = ax.imshow(corr_matrix, clim=color_lims)
     ax.set_xlabel(titles[ci])
-plt.subplots_adjust(right=0.92)
-divider = make_axes_locatable(axes[1])
-cax = divider.append_axes("right", size="5%", pad=0.2)
-ticks = np.arange(0.01, 0.95, 0.01)
-cbar = plt.colorbar(mpbl, cax=cax, ax=axes, ticks=ticks)
-cbar.ax.tick_params(labelsize=7)
-cbar.set_label('Correlation Coefficient', size=7)
-plt.tight_layout()
+fig.subplots_adjust(right=0.8)
+cax = fig.add_axes([0.85, 0.2, 0.025, 0.6])
+cbar = fig.colorbar(ax.images[0], cax=cax)
+cbar.set_label('Correlation Coefficient')


### PR DESCRIPTION
#9156 added a tutorial that is very memory-hungry, and CircleCI can't handle building it.  This PR reduces build time / memory consumption on my machine from 167.38 sec  / 3563.6 MB before this PR to  23.90 sec / 244.5 MB after this PR.  Along the way I tightened up the text and code in a few places.
