### PR TITLE
ENH: Speed up plot_ica_properties

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -53,6 +53,8 @@ Current (0.23.dev0)
 
 Enhancements
 ~~~~~~~~~~~~
+- Speed up :func:`mne.viz.ica.plot_ica_properties` by refactoring (:gh:`9174` **by new contributor** |Valerii Chirkov|_)
+
 - Add ``apply_function`` method to epochs and evoked objects (:gh:`9088` **by new contributor** |Erica Peterson|_ and `Victoria Peterson`_)
 
 - New tutorial for function :func:`mne.make_fixed_length_epochs` (:gh:`9156` **by new contributor** |Erica Peterson|_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -53,7 +53,7 @@ Current (0.23.dev0)
 
 Enhancements
 ~~~~~~~~~~~~
-- Speed up :func:`mne.viz.ica.plot_ica_properties` by refactoring (:gh:`9174` **by new contributor** |Valerii Chirkov|_)
+- Speed up :func:`mne.viz.plot_ica_properties` by refactoring (:gh:`9174` **by new contributor** |Valerii Chirkov|_)
 
 - Add ``apply_function`` method to epochs and evoked objects (:gh:`9088` **by new contributor** |Erica Peterson|_ and `Victoria Peterson`_)
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -796,10 +796,11 @@ class ICA(ContainsMixin):
         if self.pca_mean_ is not None:
             data -= self.pca_mean_[:, None]
 
-        # Apply first PCA
-        pca_data = np.dot(self.pca_components_[:self.n_components_], data)
-        # Apply unmixing to low dimension PCA
-        sources = np.dot(self.unmixing_matrix_, pca_data)
+        # Apply unmixing
+        pca_data = np.dot(self.unmixing_matrix_,
+                          self.pca_components_[:self.n_components_])
+        # Apply PCA
+        sources = np.dot(pca_data, data)
         return sources
 
     def _transform_raw(self, raw, start, stop, reject_by_annotation=False):


### PR DESCRIPTION
@larsoner [suggestions](https://github.com/mne-tools/mne-python/pull/9134#issuecomment-803042712) in the PR #9134

 Line profiler output for `plot_ica_properties`:

Updated function (2.14214 s): 

<details>

```
Total time: 2.14214 s
File: /mne-python/mne/viz/ica.py
Function: plot_ica_properties at line 254

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   254                                           def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
   255                                                                   plot_std=True, topomap_args=None, image_args=None,
   256                                                                   psd_args=None, figsize=None, show=True, reject='auto',
   257                                                                   reject_by_annotation=True, *, verbose=None):
   322         1          0.0      0.0      0.0      from ..io.base import BaseRaw
   323         1          0.0      0.0      0.0      from ..epochs import BaseEpochs
   324         1          0.0      0.0      0.0      from ..preprocessing import ICA
   325         1          0.0      0.0      0.0      from ..io import RawArray
   326                                           
   327                                               # input checks and defaults
   328                                               # -------------------------
   329         1          0.0      0.0      0.0      _validate_type(inst, (BaseRaw, BaseEpochs), "inst", "Raw or Epochs")
   330         1          0.0      0.0      0.0      _validate_type(ica, ICA, "ica", "ICA")
   331         1          0.0      0.0      0.0      _validate_type(plot_std, (bool, 'numeric'), 'plot_std')
   332         1          0.0      0.0      0.0      if isinstance(plot_std, bool):
   333         1          0.0      0.0      0.0          num_std = 1. if plot_std else 0.
   334                                               else:
   335                                                   plot_std = True
   336         1          0.0      0.0      0.0      num_std = float(plot_std)
   337                                           
   338                                               # if no picks given - plot the first 5 components
   339         1          0.0      0.0      0.0      limit = min(5, ica.n_components_) if picks is None else len(ica.ch_names)
   340         1          0.0      0.0      0.0      picks = _picks_to_idx(ica.info, picks, 'all')[:limit]
   341         1          0.0      0.0      0.0      if axes is None:
   342         1          0.4      0.4     18.8          fig, axes = _create_properties_layout(figsize=figsize)
   343                                               else:
   344                                                   if len(picks) > 1:
   345                                                       raise ValueError('Only a single pick can be drawn '
   346                                                                        'to a set of axes.')
   347                                                   from .utils import _validate_if_list_of_axes
   348                                                   _validate_if_list_of_axes(axes, obligatory_len=5)
   349                                                   fig = axes[0].get_figure()
   350                                           
   351         1          0.0      0.0      0.0      psd_args = dict() if psd_args is None else psd_args
   352         1          0.0      0.0      0.0      topomap_args = dict() if topomap_args is None else topomap_args
   353         1          0.0      0.0      0.0      image_args = dict() if image_args is None else image_args
   354         1          0.0      0.0      0.0      image_args["ts_args"] = dict(truncate_xaxis=False, show_sensors=False)
   355         1          0.0      0.0      0.0      if plot_std:
   356         1          0.0      0.0      0.0          from ..stats.parametric import _parametric_ci
   357         1          0.0      0.0      0.0          image_args["ts_args"]["ci"] = _parametric_ci
   358                                               elif "ts_args" not in image_args or "ci" not in image_args["ts_args"]:
   359                                                   image_args["ts_args"]["ci"] = False
   360                                           
   361         5          0.0      0.0      0.0      for item_name, item in (("psd_args", psd_args),
   362         1          0.0      0.0      0.0                              ("topomap_args", topomap_args),
   363         1          0.0      0.0      0.0                              ("image_args", image_args)):
   364         3          0.0      0.0      0.0          _validate_type(item, dict, item_name, "dictionary")
   365         1          0.0      0.0      0.0      if dB is not None:
   366         1          0.0      0.0      0.0          _validate_type(dB, bool, "dB", "bool")
   367                                           
   368                                               # calculations
   369                                               # ------------
   370                                           
   371         1          0.0      0.0      0.0      if isinstance(inst, BaseRaw):
   372                                                   # when auto, delegate reject to the ica
   373         1          0.0      0.0      0.0          from ..epochs import make_fixed_length_epochs
   374                                           
   375         1          0.0      0.0      0.0          if reject == 'auto':
   376         1          0.0      0.0      0.0              reject = getattr(ica, 'reject_', None)
   377                                           
   378         1          0.0      0.0      0.0          if reject is None:
   379         1          0.0      0.0      0.0              drop_inds = None
   380         1          0.0      0.0      0.0              dropped_indices = []
   381                                                       # break up continuous signal into segments
   382         2          0.1      0.1      5.2              epochs_src = make_fixed_length_epochs(
   383         1          0.8      0.8     38.7                  ica.get_sources(inst),
   384         1          0.0      0.0      0.0                  duration=2,
   385         1          0.0      0.0      0.0                  preload=True,
   386         1          0.0      0.0      0.0                  reject_by_annotation=reject_by_annotation,
   387         1          0.0      0.0      0.0                  proj=False,
   388         1          0.0      0.0      0.0                  verbose=False)
   389                                                   else:
   390                                                       data = inst.get_data()
   391                                                       data, drop_inds = _reject_data_segments(data, ica.reject_,
   392                                                                                               flat=None, decim=None,
   393                                                                                               info=inst.info,
   394                                                                                               tstep=2.0)
   395                                                       inst_rejected = RawArray(data, inst.info)
   396                                                       # break up continuous signal into segments
   397                                                       epochs_src = make_fixed_length_epochs(
   398                                                           ica.get_sources(inst_rejected),
   399                                                           duration=2,
   400                                                           preload=True,
   401                                                           reject_by_annotation=reject_by_annotation,
   402                                                           proj=False,
   403                                                           verbose=False)
   404                                           
   405                                                       # getting dropped epochs indexes
   406                                                       dropped_indices = [(d[0] // len(epochs_src.times)) + 1
   407                                                                          for d in drop_inds]
   408                                           
   409         1          0.0      0.0      0.0          kind = "Segment"
   410                                               else:
   411                                                   drop_inds = None
   412                                                   epochs_src = ica.get_sources(inst)
   413                                                   dropped_indices = []
   414                                                   kind = "Epochs"
   415                                           
   416         1          0.0      0.0      0.0      data = epochs_src.get_data()
   417         1          0.0      0.0      0.0      ica_data = np.swapaxes(data[:, picks, :], 0, 1)
   418         1          0.0      0.0      0.0      dropped_src = ica_data
   419                                           
   420                                               # spectrum
   421         1          0.0      0.0      0.0      Nyquist = inst.info['sfreq'] / 2.
   422         1          0.0      0.0      0.0      lp = inst.info['lowpass']
   423         1          0.0      0.0      0.0      if 'fmax' not in psd_args:
   424         1          0.0      0.0      0.0          psd_args['fmax'] = min(lp * 1.25, Nyquist)
   425         1          0.0      0.0      0.0      plot_lowpass_edge = lp < Nyquist and (psd_args['fmax'] > lp)
   426         1          0.2      0.2     10.4      psds, freqs = psd_multitaper(epochs_src, picks=picks, **psd_args)
   427                                           
   428         1          0.0      0.0      0.0      def set_title_and_labels(ax, title, xlab, ylab):
   429                                                   if title:
   430                                                       ax.set_title(title)
   431                                                   if xlab:
   432                                                       ax.set_xlabel(xlab)
   433                                                   if ylab:
   434                                                       ax.set_ylabel(ylab)
   435                                                   ax.axis('auto')
   436                                                   ax.tick_params('both', labelsize=8)
   437                                                   ax.axis('tight')
   438                                           
   439                                               # plot
   440                                               # ----
   441         1          0.0      0.0      0.0      all_fig = list()
   442         2          0.0      0.0      0.0      for idx, pick in enumerate(picks):
   443                                           
   444                                                   # calculate component-specific spectrum stuff
   445         2          0.0      0.0      1.5          psd_ylabel, psds_mean, spectrum_std = _get_psd_label_and_std(
   446         1          0.0      0.0      0.0              psds[:, idx, :].copy(), dB, ica, num_std)
   447                                           
   448                                                   # if more than one component, spawn additional figures and axes
   449         1          0.0      0.0      0.0          if idx > 0:
   450                                                       fig, axes = _create_properties_layout(figsize=figsize)
   451                                           
   452                                                   # we reconstruct an epoch_variance with 0 where indexes where dropped
   453         1          0.0      0.0      0.0          epoch_var = np.var(ica_data[idx], axis=1)
   454         1          0.0      0.0      0.0          drop_var = np.var(dropped_src[idx], axis=1)
   455         1          0.0      0.0      0.0          drop_indices_corrected = \
   456         3          0.0      0.0      0.0              (dropped_indices -
   457         2          0.0      0.0      0.0               np.arange(len(dropped_indices))).astype(int)
   458         2          0.0      0.0      0.0          epoch_var = np.insert(arr=epoch_var,
   459         1          0.0      0.0      0.0                                obj=drop_indices_corrected,
   460         1          0.0      0.0      0.0                                values=drop_var[dropped_indices],
   461         1          0.0      0.0      0.0                                axis=0)
   462                                           
   463                                                   # the actual plot
   464         2          0.5      0.3     25.2          fig = _plot_ica_properties(
   465         1          0.0      0.0      0.0              pick, ica, inst, psds_mean, freqs, ica_data.shape[1],
   466         1          0.0      0.0      0.0              epoch_var, plot_lowpass_edge,
   467         1          0.0      0.0      0.0              epochs_src, set_title_and_labels, plot_std, psd_ylabel,
   468         1          0.0      0.0      0.0              spectrum_std, topomap_args, image_args, fig, axes, kind,
   469         1          0.0      0.0      0.0              dropped_indices)
   470         1          0.0      0.0      0.0          all_fig.append(fig)
   471                                           
   472         1          0.0      0.0      0.0      plt_show(show)
   473         1          0.0      0.0      0.0      return all_fig

```

</details>


Original function (9.39031 s): 

<details>

```

Total time: 9.39031 s
File: /mne-python/mne/viz/ica.py
Function: plot_ica_properties at line 254

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   254                                           def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
   255                                                                   plot_std=True, topomap_args=None, image_args=None,
   256                                                                   psd_args=None, figsize=None, show=True, reject='auto',
   257                                                                   reject_by_annotation=True, *, verbose=None):
   322         1          0.0      0.0      0.0      from ..io.base import BaseRaw
   323         1          0.0      0.0      0.0      from ..epochs import BaseEpochs
   324         1          0.0      0.0      0.0      from ..preprocessing import ICA
   325         1          0.0      0.0      0.0      from ..io import RawArray
   326                                           
   327                                               # input checks and defaults
   328                                               # -------------------------
   329         1          0.0      0.0      0.0      _validate_type(inst, (BaseRaw, BaseEpochs), "inst", "Raw or Epochs")
   330         1          0.0      0.0      0.0      _validate_type(ica, ICA, "ica", "ICA")
   331         1          0.0      0.0      0.0      _validate_type(plot_std, (bool, 'numeric'), 'plot_std')
   332         1          0.0      0.0      0.0      if isinstance(plot_std, bool):
   333         1          0.0      0.0      0.0          num_std = 1. if plot_std else 0.
   334                                               else:
   335                                                   plot_std = True
   336         1          0.0      0.0      0.0      num_std = float(plot_std)
   337                                           
   338                                               # if no picks given - plot the first 5 components
   339         1          0.0      0.0      0.0      limit = min(5, ica.n_components_) if picks is None else len(ica.ch_names)
   340         1          0.0      0.0      0.0      picks = _picks_to_idx(ica.info, picks, 'all')[:limit]
   341         1          0.0      0.0      0.0      if axes is None:
   342         1          0.4      0.4      4.1          fig, axes = _create_properties_layout(figsize=figsize)
   343                                               else:
   344                                                   if len(picks) > 1:
   345                                                       raise ValueError('Only a single pick can be drawn '
   346                                                                        'to a set of axes.')
   347                                                   from .utils import _validate_if_list_of_axes
   348                                                   _validate_if_list_of_axes(axes, obligatory_len=5)
   349                                                   fig = axes[0].get_figure()
   350                                           
   351         1          0.0      0.0      0.0      psd_args = dict() if psd_args is None else psd_args
   352         1          0.0      0.0      0.0      topomap_args = dict() if topomap_args is None else topomap_args
   353         1          0.0      0.0      0.0      image_args = dict() if image_args is None else image_args
   354         1          0.0      0.0      0.0      image_args["ts_args"] = dict(truncate_xaxis=False, show_sensors=False)
   355         1          0.0      0.0      0.0      if plot_std:
   356         1          0.0      0.0      0.0          from ..stats.parametric import _parametric_ci
   357         1          0.0      0.0      0.0          image_args["ts_args"]["ci"] = _parametric_ci
   358                                               elif "ts_args" not in image_args or "ci" not in image_args["ts_args"]:
   359                                                   image_args["ts_args"]["ci"] = False
   360                                           
   361         5          0.0      0.0      0.0      for item_name, item in (("psd_args", psd_args),
   362         1          0.0      0.0      0.0                              ("topomap_args", topomap_args),
   363         1          0.0      0.0      0.0                              ("image_args", image_args)):
   364         3          0.0      0.0      0.0          _validate_type(item, dict, item_name, "dictionary")
   365         1          0.0      0.0      0.0      if dB is not None:
   366         1          0.0      0.0      0.0          _validate_type(dB, bool, "dB", "bool")
   367                                           
   368                                               # calculations
   369                                               # ------------
   370                                           
   371         1          0.0      0.0      0.0      if isinstance(inst, BaseRaw):
   372                                                   # when auto, delegate reject to the ica
   373         1          0.0      0.0      0.0          if reject == 'auto':
   374         1          0.0      0.0      0.0              reject = getattr(ica, 'reject_', None)
   375                                                   else:
   376                                                       pass
   377                                           
   378         1          0.0      0.0      0.0          if reject is None:
   379         1          0.0      0.0      0.0              inst_rejected = inst
   380         1          0.0      0.0      0.0              drop_inds = None
   381                                                   else:
   382                                                       data = inst.get_data()
   383                                                       data, drop_inds = _reject_data_segments(data, ica.reject_,
   384                                                                                               flat=None, decim=None,
   385                                                                                               info=inst.info,
   386                                                                                               tstep=2.0)
   387                                                       inst_rejected = RawArray(data, inst.info)
   388                                           
   389                                                   # break up continuous signal into segments
   390         1          0.0      0.0      0.0          from ..epochs import make_fixed_length_epochs
   391         2          0.8      0.4      8.8          inst_rejected = make_fixed_length_epochs(
   392         1          0.0      0.0      0.0              inst_rejected,
   393         1          0.0      0.0      0.0              duration=2,
   394         1          0.0      0.0      0.0              preload=True,
   395         1          0.0      0.0      0.0              reject_by_annotation=reject_by_annotation,
   396         1          0.0      0.0      0.0              proj=False,
   397         1          0.0      0.0      0.0              verbose=False)
   398         2          0.8      0.4      8.2          inst = make_fixed_length_epochs(
   399         1          0.0      0.0      0.0              inst,
   400         1          0.0      0.0      0.0              duration=2,
   401         1          0.0      0.0      0.0              preload=True,
   402         1          0.0      0.0      0.0              reject_by_annotation=reject_by_annotation,
   403         1          0.0      0.0      0.0              proj=False,
   404         1          0.0      0.0      0.0              verbose=False)
   405         1          0.0      0.0      0.0          kind = "Segment"
   406                                               else:
   407                                                   drop_inds = None
   408                                                   inst_rejected = inst
   409                                                   kind = "Epochs"
   410                                           
   411         1          3.7      3.7     39.6      epochs_src = ica.get_sources(inst_rejected)
   412         1          0.0      0.0      0.0      data = epochs_src.get_data()
   413                                           
   414         1          0.0      0.0      0.0      ica_data = np.swapaxes(data[:, picks, :], 0, 1)
   415                                           
   416                                               # getting dropped epochs indexes
   417         1          0.0      0.0      0.0      if drop_inds is not None:
   418                                                   dropped_indices = [(d[0] // len(inst.times)) + 1
   419                                                                      for d in drop_inds]
   420                                               else:
   421         1          0.0      0.0      0.0          dropped_indices = []
   422                                           
   423                                               # getting ica sources from inst
   424         1          2.9      2.9     31.2      dropped_src = ica.get_sources(inst).get_data()
   425         1          0.0      0.0      0.0      dropped_src = np.swapaxes(dropped_src[:, picks, :], 0, 1)
   426                                           
   427                                               # spectrum
   428         1          0.0      0.0      0.0      Nyquist = inst.info['sfreq'] / 2.
   429         1          0.0      0.0      0.0      lp = inst.info['lowpass']
   430         1          0.0      0.0      0.0      if 'fmax' not in psd_args:
   431         1          0.0      0.0      0.0          psd_args['fmax'] = min(lp * 1.25, Nyquist)
   432         1          0.0      0.0      0.0      plot_lowpass_edge = lp < Nyquist and (psd_args['fmax'] > lp)
   433         1          0.2      0.2      2.3      psds, freqs = psd_multitaper(epochs_src, picks=picks, **psd_args)
   434                                           
   435         1          0.0      0.0      0.0      def set_title_and_labels(ax, title, xlab, ylab):
   436                                                   if title:
   437                                                       ax.set_title(title)
   438                                                   if xlab:
   439                                                       ax.set_xlabel(xlab)
   440                                                   if ylab:
   441                                                       ax.set_ylabel(ylab)
   442                                                   ax.axis('auto')
   443                                                   ax.tick_params('both', labelsize=8)
   444                                                   ax.axis('tight')
   445                                           
   446                                               # plot
   447                                               # ----
   448         1          0.0      0.0      0.0      all_fig = list()
   449         2          0.0      0.0      0.0      for idx, pick in enumerate(picks):
   450                                           
   451                                                   # calculate component-specific spectrum stuff
   452         2          0.0      0.0      0.3          psd_ylabel, psds_mean, spectrum_std = _get_psd_label_and_std(
   453         1          0.0      0.0      0.0              psds[:, idx, :].copy(), dB, ica, num_std)
   454                                           
   455                                                   # if more than one component, spawn additional figures and axes
   456         1          0.0      0.0      0.0          if idx > 0:
   457                                                       fig, axes = _create_properties_layout(figsize=figsize)
   458                                           
   459                                                   # we reconstruct an epoch_variance with 0 where indexes where dropped
   460         1          0.0      0.0      0.0          epoch_var = np.var(ica_data[idx], axis=1)
   461         1          0.0      0.0      0.0          drop_var = np.var(dropped_src[idx], axis=1)
   462         1          0.0      0.0      0.0          drop_indices_corrected = \
   463         3          0.0      0.0      0.0              (dropped_indices -
   464         2          0.0      0.0      0.0               np.arange(len(dropped_indices))).astype(int)
   465         2          0.0      0.0      0.0          epoch_var = np.insert(arr=epoch_var,
   466         1          0.0      0.0      0.0                                obj=drop_indices_corrected,
   467         1          0.0      0.0      0.0                                values=drop_var[dropped_indices],
   468         1          0.0      0.0      0.0                                axis=0)
   469                                           
   470                                                   # the actual plot
   471         2          0.5      0.3      5.5          fig = _plot_ica_properties(
   472         1          0.0      0.0      0.0              pick, ica, inst, psds_mean, freqs, ica_data.shape[1],
   473         1          0.0      0.0      0.0              epoch_var, plot_lowpass_edge,
   474         1          0.0      0.0      0.0              epochs_src, set_title_and_labels, plot_std, psd_ylabel,
   475         1          0.0      0.0      0.0              spectrum_std, topomap_args, image_args, fig, axes, kind,
   476         1          0.0      0.0      0.0              dropped_indices)
   477         1          0.0      0.0      0.0          all_fig.append(fig)
   478                                           
   479         1          0.0      0.0      0.0      plt_show(show)
   480         1          0.0      0.0      0.0      return all_fig

```

</details>

Full report:

<details>

```

Total time: 0.35128 s
File: /mne-python/mne/preprocessing/ica.py
Function: _transform at line 793

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   793                                               def _transform(self, data):
   794                                                   """Compute sources from data (operates inplace)."""
   795         1          0.2      0.2     46.0          data = self._pre_whiten(data)
   796         1          0.0      0.0      0.0          if self.pca_mean_ is not None:
   797         1          0.1      0.1     15.3              data -= self.pca_mean_[:, None]
   798                                           
   799                                                   # Apply unmixing
   800         2          0.0      0.0      0.0          pca_data = np.dot(self.unmixing_matrix_,
   801         1          0.0      0.0      0.0                            self.pca_components_[:self.n_components_])
   802                                                   # Apply PCA
   803         1          0.1      0.1     38.6          sources = np.dot(pca_data, data)
   804         1          0.0      0.0      0.0          return sources

Total time: 0.920839 s
File: /mne-python/mne/preprocessing/ica.py
Function: get_sources at line 879

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   879                                               def get_sources(self, inst, add_channels=None, start=None, stop=None):
   880                                                   """Estimate sources given the unmixing matrix.
   881                                           
   882                                                   This method will return the sources in the container format passed.
   883                                                   Typical usecases:
   884                                           
   885                                                   1. pass Raw object to use `raw.plot <mne.io.Raw.plot>` for ICA sources
   886                                                   2. pass Epochs object to compute trial-based statistics in ICA space
   887                                                   3. pass Evoked object to investigate time-locking in ICA space
   888                                           
   889                                                   Parameters
   890                                                   ----------
   891                                                   inst : instance of Raw, Epochs or Evoked
   892                                                       Object to compute sources from and to represent sources in.
   893                                                   add_channels : None | list of str
   894                                                       Additional channels  to be added. Useful to e.g. compare sources
   895                                                       with some reference. Defaults to None.
   896                                                   start : int | float | None
   897                                                       First sample to include. If float, data will be interpreted as
   898                                                       time in seconds. If None, the entire data will be used.
   899                                                   stop : int | float | None
   900                                                       Last sample to not include. If float, data will be interpreted as
   901                                                       time in seconds. If None, the entire data will be used.
   902                                           
   903                                                   Returns
   904                                                   -------
   905                                                   sources : instance of Raw, Epochs or Evoked
   906                                                       The ICA sources time series.
   907                                                   """
   908         1          0.0      0.0      0.0          if isinstance(inst, BaseRaw):
   909         2          0.1      0.0      8.2              _check_compensation_grade(self.info, inst.info, 'ICA', 'Raw',
   910         1          0.0      0.0      0.0                                        ch_names=self.ch_names)
   911         1          0.8      0.8     91.8              sources = self._sources_as_raw(inst, add_channels, start, stop)
   912                                                   elif isinstance(inst, BaseEpochs):
   913                                                       _check_compensation_grade(self.info, inst.info, 'ICA', 'Epochs',
   914                                                                                 ch_names=self.ch_names)
   915                                                       sources = self._sources_as_epochs(inst, add_channels, False)
   916                                                   elif isinstance(inst, Evoked):
   917                                                       _check_compensation_grade(self.info, inst.info, 'ICA', 'Evoked',
   918                                                                                 ch_names=self.ch_names)
   919                                                       sources = self._sources_as_evoked(inst, add_channels)
   920                                                   else:
   921                                                       raise ValueError('Data input must be of Raw, Epochs or Evoked '
   922                                                                        'type')
   923         1          0.0      0.0      0.0          return sources

Total time: 0.789254 s
File: /mne-python/mne/preprocessing/ica.py
Function: _sources_as_raw at line 925

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   925                                               def _sources_as_raw(self, raw, add_channels, start, stop):
   926                                                   """Aux method."""
   927                                                   # merge copied instance and picked data with sources
   928         1          0.0      0.0      0.0          start, stop = _check_start_stop(raw, start, stop)
   929         1          0.7      0.7     94.2          data_ = self._transform_raw(raw, start=start, stop=stop)
   930         1          0.0      0.0      0.0          assert data_.shape[1] == stop - start
   931         1          0.0      0.0      0.0          if raw.preload:  # get data and temporarily delete
   932         1          0.0      0.0      0.0              data = raw._data
   933         1          0.0      0.0      0.0              del raw._data
   934                                           
   935         1          0.0      0.0      5.5          out = raw.copy()  # copy and reappend
   936         1          0.0      0.0      0.0          if raw.preload:
   937         1          0.0      0.0      0.0              raw._data = data
   938                                           
   939                                                   # populate copied raw.
   940         1          0.0      0.0      0.0          if add_channels is not None and len(add_channels):
   941                                                       picks = pick_channels(raw.ch_names, add_channels)
   942                                                       data_ = np.concatenate([
   943                                                           data_, raw.get_data(picks, start=start, stop=stop)])
   944         1          0.0      0.0      0.0          out._data = data_
   945         1          0.0      0.0      0.0          out._filenames = [None]
   946         1          0.0      0.0      0.0          out.preload = True
   947         1          0.0      0.0      0.0          out._first_samps[:] = [out.first_samp + start]
   948         1          0.0      0.0      0.0          out._last_samps[:] = [out.first_samp + data_.shape[1] - 1]
   949         1          0.0      0.0      0.0          out._projector = None
   950         1          0.0      0.0      0.3          self._export_info(out.info, raw, add_channels)
   951                                           
   952         1          0.0      0.0      0.0          return out

Total time: 0.52161 s
File: /mne-python/mne/viz/ica.py
Function: _plot_ica_properties at line 122

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   122                                           def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
   123                                                                    epoch_var, plot_lowpass_edge, epochs_src,
   124                                                                    set_title_and_labels, plot_std, psd_ylabel,
   125                                                                    spectrum_std, topomap_args, image_args, fig, axes,
   126                                                                    kind, dropped_indices):
   127                                               """Plot ICA properties (helper)."""
   128         1          0.0      0.0      2.0      from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
   129         1          0.0      0.0      0.0      from scipy.stats import gaussian_kde
   130                                           
   131         1          0.0      0.0      0.0      topo_ax, image_ax, erp_ax, spec_ax, var_ax = axes
   132                                           
   133                                               # plotting
   134                                               # --------
   135                                               # component topomap
   136         1          0.1      0.1     19.7      _plot_ica_topomap(ica, pick, show=False, axes=topo_ax, **topomap_args)
   137                                           
   138                                               # image and erp
   139                                               # we create a new epoch with dropped rows
   140         1          0.0      0.0      0.0      epoch_data = epochs_src.get_data()
   141         2          0.0      0.0      3.3      epoch_data = np.insert(arr=epoch_data,
   142         3          0.0      0.0      0.0                             obj=(dropped_indices -
   143         2          0.0      0.0      0.0                                  np.arange(len(dropped_indices))).astype(int),
   144         1          0.0      0.0      0.0                             values=0.0,
   145         1          0.0      0.0      0.0                             axis=0)
   146         1          0.0      0.0      0.0      from ..epochs import EpochsArray
   147         2          0.0      0.0      3.5      epochs_src = EpochsArray(epoch_data, epochs_src.info, tmin=epochs_src.tmin,
   148         1          0.0      0.0      0.0                               verbose=0)
   149                                           
   150         3          0.2      0.1     39.9      plot_epochs_image(epochs_src, picks=pick, axes=[image_ax, erp_ax],
   151         1          0.0      0.0      0.0                        combine=None, colorbar=False, show=False,
   152         1          0.0      0.0      0.0                        **image_args)
   153                                           
   154                                               # spectrum
   155         1          0.0      0.0      0.3      spec_ax.plot(freqs, psds_mean, color='k')
   156         1          0.0      0.0      0.0      if plot_std:
   157         2          0.0      0.0      0.4          spec_ax.fill_between(freqs, psds_mean - spectrum_std[0],
   158         1          0.0      0.0      0.0                               psds_mean + spectrum_std[1],
   159         1          0.0      0.0      0.0                               color='k', alpha=.2)
   160         1          0.0      0.0      0.0      if plot_lowpass_edge:
   161         2          0.0      0.0      0.6          spec_ax.axvline(inst.info['lowpass'], lw=2, linestyle='--',
   162         1          0.0      0.0      0.0                          color='k', alpha=0.2)
   163                                           
   164                                               # epoch variance
   165         1          0.0      0.0      0.0      var_ax_divider = make_axes_locatable(var_ax)
   166         1          0.1      0.1     10.6      hist_ax = var_ax_divider.append_axes("right", size="33%", pad="2.5%")
   167         2          0.0      0.0      0.6      var_ax.scatter(range(len(epoch_var)), epoch_var, alpha=0.5,
   168         1          0.0      0.0      0.0                     facecolor=[0, 0, 0], lw=0)
   169                                               # rejected epochs in red
   170         2          0.0      0.0      0.7      var_ax.scatter(dropped_indices, epoch_var[dropped_indices],
   171         1          0.0      0.0      0.0                     alpha=1., facecolor=[1, 0, 0], lw=0)
   172                                               # compute percentage of dropped epochs
   173         1          0.0      0.0      0.0      var_percent = float(len(dropped_indices)) / float(len(epoch_var)) * 100.
   174                                           
   175                                               # histogram & histogram
   176         2          0.0      0.0      3.0      _, counts, _ = hist_ax.hist(epoch_var, orientation="horizontal",
   177         1          0.0      0.0      0.0                                  color="k", alpha=.5)
   178                                           
   179                                               # kde
   180         1          0.0      0.0      0.4      ymin, ymax = hist_ax.get_ylim()
   181         1          0.0      0.0      0.0      try:
   182         1          0.0      0.0      0.2          kde = gaussian_kde(epoch_var)
   183                                               except np.linalg.LinAlgError:
   184                                                   pass  # singular: happens when there is nothing plotted
   185                                               else:
   186         1          0.0      0.0      0.0          x = np.linspace(ymin, ymax, 50)
   187         1          0.0      0.0      0.1          kde_ = kde(x)
   188         1          0.0      0.0      0.0          kde_ /= kde_.max() or 1.
   189         1          0.0      0.0      0.0          kde_ *= hist_ax.get_xlim()[-1] * .9
   190         1          0.0      0.0      0.3          hist_ax.plot(kde_, x, color="k")
   191         1          0.0      0.0      0.0          hist_ax.set_ylim(ymin, ymax)
   192                                           
   193                                               # aesthetics
   194                                               # ----------
   195         1          0.0      0.0      0.1      topo_ax.set_title(ica._ica_names[pick])
   196                                           
   197         1          0.0      0.0      1.9      set_title_and_labels(image_ax, kind + ' image and ERP/ERF', [], kind)
   198                                           
   199                                               # erp
   200         1          0.0      0.0      2.6      set_title_and_labels(erp_ax, [], 'Time (s)', 'AU')
   201         1          0.0      0.0      0.0      erp_ax.spines["right"].set_color('k')
   202         1          0.0      0.0      0.1      erp_ax.set_xlim(epochs_src.times[[0, -1]])
   203                                               # remove half of yticks if more than 5
   204         1          0.0      0.0      0.1      yt = erp_ax.get_yticks()
   205         1          0.0      0.0      0.0      if len(yt) > 5:
   206                                                   erp_ax.yaxis.set_ticks(yt[::2])
   207                                           
   208                                               # remove xticks - erp plot shows xticks for both image and erp plot
   209         1          0.0      0.0      0.0      image_ax.xaxis.set_ticks([])
   210         1          0.0      0.0      0.1      yt = image_ax.get_yticks()
   211         1          0.0      0.0      3.7      image_ax.yaxis.set_ticks(yt[1:])
   212         1          0.0      0.0      0.0      image_ax.set_ylim([-0.5, n_trials + 0.5])
   213                                           
   214                                               # spectrum
   215         1          0.0      0.0      1.7      set_title_and_labels(spec_ax, 'Spectrum', 'Frequency (Hz)', psd_ylabel)
   216         1          0.0      0.0      0.0      spec_ax.yaxis.labelpad = 0
   217         1          0.0      0.0      0.0      spec_ax.set_xlim(freqs[[0, -1]])
   218         1          0.0      0.0      0.0      ylim = spec_ax.get_ylim()
   219         1          0.0      0.0      0.0      air = np.diff(ylim)[0] * 0.1
   220         1          0.0      0.0      0.0      spec_ax.set_ylim(ylim[0] - air, ylim[1] + air)
   221         1          0.0      0.0      0.3      image_ax.axhline(0, color='k', linewidth=.5)
   222                                           
   223                                               # epoch variance
   224         1          0.0      0.0      0.0      var_ax_title = 'Dropped segments: %.2f %%' % var_percent
   225         1          0.0      0.0      2.0      set_title_and_labels(var_ax, var_ax_title, kind, 'Variance (AU)')
   226                                           
   227         1          0.0      0.0      0.0      hist_ax.set_ylabel("")
   228         1          0.0      0.0      0.0      hist_ax.set_yticks([])
   229         1          0.0      0.0      1.8      set_title_and_labels(hist_ax, None, None, None)
   230                                           
   231         1          0.0      0.0      0.0      return fig

Total time: 2.245 s
File: /mne-python/mne/viz/ica.py
Function: plot_ica_properties at line 254

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   254                                           def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
   255                                                                   plot_std=True, topomap_args=None, image_args=None,
   256                                                                   psd_args=None, figsize=None, show=True, reject='auto',
   257                                                                   reject_by_annotation=True, *, verbose=None):
   258                                               """Display component properties.
   259                                           
   260                                               Properties include the topography, epochs image, ERP/ERF, power
   261                                               spectrum, and epoch variance.
   262                                           
   263                                               Parameters
   264                                               ----------
   265                                               ica : instance of mne.preprocessing.ICA
   266                                                   The ICA solution.
   267                                               inst : instance of Epochs or Raw
   268                                                   The data to use in plotting properties.
   269                                               %(picks_base)s the first five sources.
   270                                                   If more than one components were chosen in the picks,
   271                                                   each one will be plotted in a separate figure.
   272                                               axes : list of Axes | None
   273                                                   List of five matplotlib axes to use in plotting: [topomap_axis,
   274                                                   image_axis, erp_axis, spectrum_axis, variance_axis]. If None a new
   275                                                   figure with relevant axes is created. Defaults to None.
   276                                               dB : bool
   277                                                   Whether to plot spectrum in dB. Defaults to True.
   278                                               plot_std : bool | float
   279                                                   Whether to plot standard deviation/confidence intervals in ERP/ERF and
   280                                                   spectrum plots.
   281                                                   Defaults to True, which plots one standard deviation above/below for
   282                                                   the spectrum. If set to float allows to control how many standard
   283                                                   deviations are plotted for the spectrum. For example 2.5 will plot 2.5
   284                                                   standard deviation above/below.
   285                                                   For the ERP/ERF, by default, plot the 95 percent parametric confidence
   286                                                   interval is calculated. To change this, use ``ci`` in ``ts_args`` in
   287                                                   ``image_args`` (see below).
   288                                               topomap_args : dict | None
   289                                                   Dictionary of arguments to ``plot_topomap``. If None, doesn't pass any
   290                                                   additional arguments. Defaults to None.
   291                                               image_args : dict | None
   292                                                   Dictionary of arguments to ``plot_epochs_image``. If None, doesn't pass
   293                                                   any additional arguments. Defaults to None.
   294                                               psd_args : dict | None
   295                                                   Dictionary of arguments to ``psd_multitaper``. If None, doesn't pass
   296                                                   any additional arguments. Defaults to None.
   297                                               figsize : array-like, shape (2,) | None
   298                                                   Allows to control size of the figure. If None, the figure size
   299                                                   defaults to [7., 6.].
   300                                               show : bool
   301                                                   Show figure if True.
   302                                               reject : 'auto' | dict | None
   303                                                   Allows to specify rejection parameters used to drop epochs
   304                                                   (or segments if continuous signal is passed as inst).
   305                                                   If None, no rejection is applied. The default is 'auto',
   306                                                   which applies the rejection parameters used when fitting
   307                                                   the ICA object.
   308                                               %(reject_by_annotation_raw)s
   309                                           
   310                                                   .. versionadded:: 0.21.0
   311                                               %(verbose)s
   312                                           
   313                                               Returns
   314                                               -------
   315                                               fig : list
   316                                                   List of matplotlib figures.
   317                                           
   318                                               Notes
   319                                               -----
   320                                               .. versionadded:: 0.13
   321                                               """
   322         1          0.0      0.0      0.0      from ..io.base import BaseRaw
   323         1          0.0      0.0      0.0      from ..epochs import BaseEpochs
   324         1          0.0      0.0      0.0      from ..preprocessing import ICA
   325         1          0.0      0.0      0.0      from ..io import RawArray
   326                                           
   327                                               # input checks and defaults
   328                                               # -------------------------
   329         1          0.0      0.0      0.0      _validate_type(inst, (BaseRaw, BaseEpochs), "inst", "Raw or Epochs")
   330         1          0.0      0.0      0.0      _validate_type(ica, ICA, "ica", "ICA")
   331         1          0.0      0.0      0.0      _validate_type(plot_std, (bool, 'numeric'), 'plot_std')
   332         1          0.0      0.0      0.0      if isinstance(plot_std, bool):
   333         1          0.0      0.0      0.0          num_std = 1. if plot_std else 0.
   334                                               else:
   335                                                   plot_std = True
   336         1          0.0      0.0      0.0      num_std = float(plot_std)
   337                                           
   338                                               # if no picks given - plot the first 5 components
   339         1          0.0      0.0      0.0      limit = min(5, ica.n_components_) if picks is None else len(ica.ch_names)
   340         1          0.0      0.0      0.0      picks = _picks_to_idx(ica.info, picks, 'all')[:limit]
   341         1          0.0      0.0      0.0      if axes is None:
   342         1          0.4      0.4     19.3          fig, axes = _create_properties_layout(figsize=figsize)
   343                                               else:
   344                                                   if len(picks) > 1:
   345                                                       raise ValueError('Only a single pick can be drawn '
   346                                                                        'to a set of axes.')
   347                                                   from .utils import _validate_if_list_of_axes
   348                                                   _validate_if_list_of_axes(axes, obligatory_len=5)
   349                                                   fig = axes[0].get_figure()
   350                                           
   351         1          0.0      0.0      0.0      psd_args = dict() if psd_args is None else psd_args
   352         1          0.0      0.0      0.0      topomap_args = dict() if topomap_args is None else topomap_args
   353         1          0.0      0.0      0.0      image_args = dict() if image_args is None else image_args
   354         1          0.0      0.0      0.0      image_args["ts_args"] = dict(truncate_xaxis=False, show_sensors=False)
   355         1          0.0      0.0      0.0      if plot_std:
   356         1          0.0      0.0      0.0          from ..stats.parametric import _parametric_ci
   357         1          0.0      0.0      0.0          image_args["ts_args"]["ci"] = _parametric_ci
   358                                               elif "ts_args" not in image_args or "ci" not in image_args["ts_args"]:
   359                                                   image_args["ts_args"]["ci"] = False
   360                                           
   361         5          0.0      0.0      0.0      for item_name, item in (("psd_args", psd_args),
   362         1          0.0      0.0      0.0                              ("topomap_args", topomap_args),
   363         1          0.0      0.0      0.0                              ("image_args", image_args)):
   364         3          0.0      0.0      0.0          _validate_type(item, dict, item_name, "dictionary")
   365         1          0.0      0.0      0.0      if dB is not None:
   366         1          0.0      0.0      0.0          _validate_type(dB, bool, "dB", "bool")
   367                                           
   368                                               # calculations
   369                                               # ------------
   370                                           
   371         1          0.0      0.0      0.0      if isinstance(inst, BaseRaw):
   372                                                   # when auto, delegate reject to the ica
   373         1          0.0      0.0      0.0          from ..epochs import make_fixed_length_epochs
   374         1          0.0      0.0      0.0          if reject == 'auto':
   375         1          0.0      0.0      0.0              reject = getattr(ica, 'reject_', None)
   376         1          0.0      0.0      0.0          if reject is None:
   377         1          0.0      0.0      0.0              drop_inds = None
   378         1          0.0      0.0      0.0              dropped_indices = []
   379                                                       # break up continuous signal into segments
   380         2          0.1      0.1      5.1              epochs_src = make_fixed_length_epochs(
   381         1          0.9      0.9     41.0                  ica.get_sources(inst),
   382         1          0.0      0.0      0.0                  duration=2,
   383         1          0.0      0.0      0.0                  preload=True,
   384         1          0.0      0.0      0.0                  reject_by_annotation=reject_by_annotation,
   385         1          0.0      0.0      0.0                  proj=False,
   386         1          0.0      0.0      0.0                  verbose=False)
   387                                                   else:
   388                                                       data = inst.get_data()
   389                                                       data, drop_inds = _reject_data_segments(data, ica.reject_,
   390                                                                                               flat=None, decim=None,
   391                                                                                               info=inst.info,
   392                                                                                               tstep=2.0)
   393                                                       inst_rejected = RawArray(data, inst.info)
   394                                                       # break up continuous signal into segments
   395                                                       epochs_src = make_fixed_length_epochs(
   396                                                           ica.get_sources(inst_rejected),
   397                                                           duration=2,
   398                                                           preload=True,
   399                                                           reject_by_annotation=reject_by_annotation,
   400                                                           proj=False,
   401                                                           verbose=False)
   402                                                       # getting dropped epochs indexes
   403                                                       dropped_indices = [(d[0] // len(epochs_src.times)) + 1
   404                                                                          for d in drop_inds]
   405         1          0.0      0.0      0.0          kind = "Segment"
   406                                               else:
   407                                                   drop_inds = None
   408                                                   epochs_src = ica.get_sources(inst)
   409                                                   dropped_indices = []
   410                                                   kind = "Epochs"
   411                                           
   412         1          0.0      0.0      0.0      data = epochs_src.get_data()
   413         1          0.0      0.0      0.0      ica_data = np.swapaxes(data[:, picks, :], 0, 1)
   414         1          0.0      0.0      0.0      dropped_src = ica_data
   415                                           
   416                                               # spectrum
   417         1          0.0      0.0      0.0      Nyquist = inst.info['sfreq'] / 2.
   418         1          0.0      0.0      0.0      lp = inst.info['lowpass']
   419         1          0.0      0.0      0.0      if 'fmax' not in psd_args:
   420         1          0.0      0.0      0.0          psd_args['fmax'] = min(lp * 1.25, Nyquist)
   421         1          0.0      0.0      0.0      plot_lowpass_edge = lp < Nyquist and (psd_args['fmax'] > lp)
   422         1          0.2      0.2      9.6      psds, freqs = psd_multitaper(epochs_src, picks=picks, **psd_args)
   423                                           
   424         1          0.0      0.0      0.0      def set_title_and_labels(ax, title, xlab, ylab):
   425                                                   if title:
   426                                                       ax.set_title(title)
   427                                                   if xlab:
   428                                                       ax.set_xlabel(xlab)
   429                                                   if ylab:
   430                                                       ax.set_ylabel(ylab)
   431                                                   ax.axis('auto')
   432                                                   ax.tick_params('both', labelsize=8)
   433                                                   ax.axis('tight')
   434                                           
   435                                               # plot
   436                                               # ----
   437         1          0.0      0.0      0.0      all_fig = list()
   438         2          0.0      0.0      0.0      for idx, pick in enumerate(picks):
   439                                           
   440                                                   # calculate component-specific spectrum stuff
   441         2          0.0      0.0      1.5          psd_ylabel, psds_mean, spectrum_std = _get_psd_label_and_std(
   442         1          0.0      0.0      0.0              psds[:, idx, :].copy(), dB, ica, num_std)
   443                                           
   444                                                   # if more than one component, spawn additional figures and axes
   445         1          0.0      0.0      0.0          if idx > 0:
   446                                                       fig, axes = _create_properties_layout(figsize=figsize)
   447                                           
   448                                                   # we reconstruct an epoch_variance with 0 where indexes where dropped
   449         1          0.0      0.0      0.0          epoch_var = np.var(ica_data[idx], axis=1)
   450         1          0.0      0.0      0.0          drop_var = np.var(dropped_src[idx], axis=1)
   451         1          0.0      0.0      0.0          drop_indices_corrected = \
   452         3          0.0      0.0      0.0              (dropped_indices -
   453         2          0.0      0.0      0.0               np.arange(len(dropped_indices))).astype(int)
   454         2          0.0      0.0      0.0          epoch_var = np.insert(arr=epoch_var,
   455         1          0.0      0.0      0.0                                obj=drop_indices_corrected,
   456         1          0.0      0.0      0.0                                values=drop_var[dropped_indices],
   457         1          0.0      0.0      0.0                                axis=0)
   458                                           
   459                                                   # the actual plot
   460         2          0.5      0.3     23.3          fig = _plot_ica_properties(
   461         1          0.0      0.0      0.0              pick, ica, inst, psds_mean, freqs, ica_data.shape[1],
   462         1          0.0      0.0      0.0              epoch_var, plot_lowpass_edge,
   463         1          0.0      0.0      0.0              epochs_src, set_title_and_labels, plot_std, psd_ylabel,
   464         1          0.0      0.0      0.0              spectrum_std, topomap_args, image_args, fig, axes, kind,
   465         1          0.0      0.0      0.0              dropped_indices)
   466         1          0.0      0.0      0.0          all_fig.append(fig)
   467                                           
   468         1          0.0      0.0      0.0      plt_show(show)
   469         1          0.0      0.0      0.0      return all_fig

```

</details>


Example that I am using:

<details>

```python
import os
import mne

sample_data_folder = mne.datasets.sample.data_path()
sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
                                    'sample_audvis_raw.fif')
raw = mne.io.read_raw_fif(sample_data_raw_file, verbose=True, preload=True)
print(f"{raw} - sfreq = {raw.info.get('sfreq')}")
ica = mne.preprocessing.ICA(n_components=20, random_state=97, max_iter=800)
ica.fit(raw)
mne.viz.ica.plot_ica_properties(ica, raw, picks=[0], show=False)

```

</details>