### PR TITLE
BUG: Only use valid FIFF values for anonymization

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -143,7 +143,7 @@ Enhancements
 
 - Add :func:`mne.channels.DigMontage.add_estimated_fiducials` which will add LPA, RPA and Nasion fiducial points to the ``DigMontage`` object in ``mri`` coordinate frame (:gh:`9118` by `Adam Li`_)
 
-- :func:`mne.io.anonymize_info` now anonymizes also sex and hand fields when ``keep_his`` is ``False`` (:gh:`9103` by |Rotem Falach|_)
+- :func:`mne.io.anonymize_info` now anonymizes also sex and hand fields when ``keep_his`` is ``False`` (:gh:`9103`, :gh:`9175` by |Rotem Falach|_ and `Richard Höchenberger`_)
 
 
 Bugs

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -2205,6 +2205,7 @@ def anonymize_info(info, daysback=None, keep_his=False, verbose=None):
                                          tzinfo=datetime.timezone.utc)
     default_str = "mne_anonymize"
     default_subject_id = 0
+    default_sex = 0
     default_desc = ("Anonymized using a time shift"
                     " to preserve age at acquisition")
 
@@ -2251,14 +2252,15 @@ def anonymize_info(info, daysback=None, keep_his=False, verbose=None):
         if subject_info.get('id') is not None:
             subject_info['id'] = default_subject_id
         if keep_his:
-            logger.info('Not fully anonymizing info - keeping \'his_id\'')
+            logger.info('Not fully anonymizing info - keeping '
+                        'his_id, sex, and hand info')
         else:
             if subject_info.get('his_id') is not None:
                 subject_info['his_id'] = str(default_subject_id)
             if subject_info.get('sex') is not None:
-                subject_info['sex'] = default_str
+                subject_info['sex'] = default_sex
             if subject_info.get('hand') is not None:
-                subject_info['hand'] = default_str
+                del subject_info['hand']  # there's no "unknown" setting
 
         for key in ('last_name', 'first_name', 'middle_name'):
             if subject_info.get(key) is not None:

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -23,7 +23,7 @@ from mne.event import make_fixed_length_events
 from mne.datasets import testing
 from mne.io import (read_fiducials, write_fiducials, _coil_trans_to_loc,
                     _loc_to_coil_trans, read_raw_fif, read_info, write_info,
-                    meas_info, Projection)
+                    meas_info, Projection, BaseRaw)
 from mne.io.constants import FIFF
 from mne.io.write import _generate_meas_id, DATE_NONE
 from mne.io.meas_info import (Info, create_info, _merge_info,
@@ -540,8 +540,8 @@ def _test_anonymize_info(base_info):
     exp_info['subject_info']['last_name'] = default_str
     exp_info['subject_info']['id'] = default_subject_id
     exp_info['subject_info']['his_id'] = str(default_subject_id)
-    exp_info['subject_info']['sex'] = default_str
-    exp_info['subject_info']['hand'] = default_str
+    exp_info['subject_info']['sex'] = 0
+    del exp_info['subject_info']['hand']  # there's no "unknown" setting
 
     # this bday is 3653 days different. the change in day is due to a
     # different number of leap days between 1987 and 1977 than between
@@ -656,12 +656,37 @@ def test_anonymize(tmpdir):
     assert raw.first_samp == first_samp
     assert_allclose(raw.annotations.onset, expected_onset)
 
-    # Test instance method
+    # test mne.anonymize_info()
     events = read_events(event_name)
     epochs = Epochs(raw, events[:1], 2, 0., 0.1, baseline=None)
-
     _test_anonymize_info(raw.info.copy())
     _test_anonymize_info(epochs.info.copy())
+
+    # test instance methods & I/O roundtrip
+    for inst, keep_his in zip((raw, epochs), (True, False)):
+        inst = inst.copy()
+
+        subject_info = dict(his_id='Volunteer', sex=2, hand=1)
+        inst.info['subject_info'] = subject_info
+        inst.anonymize(keep_his=keep_his)
+
+        si = inst.info['subject_info']
+        if keep_his:
+            assert si == subject_info
+        else:
+            assert si['his_id'] == '0'
+            assert si['sex'] == 0
+            assert 'hand' not in si
+
+        # write to disk & read back
+        inst_type = 'raw' if isinstance(inst, BaseRaw) else 'epo'
+        fname = 'tmp_raw.fif' if inst_type == 'raw' else 'tmp_epo.fif'
+        out_path = tmpdir.join(fname)
+        inst.save(out_path, overwrite=True)
+        if inst_type == 'raw':
+            read_raw_fif(out_path)
+        else:
+            read_epochs(out_path)
 
     # test that annotations are correctly zeroed
     raw.anonymize()


### PR DESCRIPTION
GH-9103 improved anonymization when `keep_his=False`; however, it would break I/O roundtrips because handedness
and sex would be set to values that aren't supported by the FIFF specs.

This PR changes the behavior such that anonymization sets `sex = 0` (unknown) and entirely removes `hand`, as FIFF
doesn't specify an "unknown" handedness.

Also adds more testing coverage for Raw & Epochs I/O roundtrip after anonymization.

cc @Falach