### PR TITLE
MRG FIX: fNIRS picks for different types

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -244,6 +244,9 @@ Bugs
 
 - Fix bug with :func:`mne.Evoked.plot_image` where an incorrect clim parameter did not raise any error (:gh:`9115` **by new contributor** |Matteo Anelli|_)
 
+- Fix bug with :func:`mne.io.Raw.pick` where incorrect fnirs types were returned (:gh:`9178` by `Robert Luke`_)
+
+
 API changes
 ~~~~~~~~~~~
 - Introduced new ``'auto'`` settings for ``ICA.max_iter``. The old default ``max_iter=200`` will be removed in MNE-Python 0.24 (:gh:`9099` **by new contributor** |Cora Kim|_)

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -324,20 +324,20 @@ def _triage_fnirs_pick(ch, fnirs, warned):
     """Triage an fNIRS pick type."""
     if fnirs is True:
         return True
-    elif ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_HBO and fnirs == 'hbo':
+    elif ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_HBO and 'hbo' in fnirs:
         return True
-    elif ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_HBR and fnirs == 'hbr':
+    elif ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_HBR and 'hbr' in fnirs:
         return True
     elif ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_CW_AMPLITUDE and \
-            fnirs == 'fnirs_cw_amplitude':
+            'fnirs_cw_amplitude' in fnirs:
         return True
     elif ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_FD_AC_AMPLITUDE and \
-            fnirs == 'fnirs_fd_ac_amplitude':
+            'fnirs_fd_ac_amplitude' in fnirs:
         return True
     elif ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_FD_PHASE and \
-            fnirs == 'fnirs_fd_phase':
+            'fnirs_fd_phase' in fnirs:
         return True
-    elif ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_OD and fnirs == 'fnirs_od':
+    elif ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_OD and 'fnirs_od' in fnirs:
         return True
     return False
 
@@ -1141,8 +1141,10 @@ def _picks_str_to_idx(info, picks, exclude, with_ref_meg, return_kind,
                 extra_picks |= set(pick_types(
                     info, meg=use_meg, ref_meg=False, exclude=exclude))
         if len(fnirs) > 0 and not kwargs.get('fnirs', False):
-            # if it has two entries, it's both, otherwise it's just one
-            kwargs['fnirs'] = True if len(fnirs) == 2 else list(fnirs)[0]
+            if len(fnirs) == 1:
+                kwargs['fnirs'] = list(fnirs)[0]
+            else:
+                kwargs['fnirs'] = list(fnirs)
         picks_type = pick_types(info, exclude=exclude, **kwargs)
         if len(extra_picks) > 0:
             picks_type = sorted(set(picks_type) | set(extra_picks))

--- a/mne/preprocessing/nirs/__init__.py
+++ b/mne/preprocessing/nirs/__init__.py
@@ -8,7 +8,7 @@
 
 from .nirs import (short_channels, source_detector_distances,
                    _check_channels_ordered, _channel_frequencies,
-                   _fnirs_check_bads, _fnirs_spread_bads)
+                   _channel_chromophore, _fnirs_check_bads, _fnirs_spread_bads)
 from ._optical_density import optical_density
 from ._beer_lambert_law import beer_lambert_law
 from ._scalp_coupling_index import scalp_coupling_index

--- a/mne/preprocessing/nirs/__init__.py
+++ b/mne/preprocessing/nirs/__init__.py
@@ -8,7 +8,7 @@
 
 from .nirs import (short_channels, source_detector_distances,
                    _check_channels_ordered, _channel_frequencies,
-                   _channel_chromophore, _fnirs_check_bads, _fnirs_spread_bads)
+                   _fnirs_check_bads, _fnirs_spread_bads)
 from ._optical_density import optical_density
 from ._beer_lambert_law import beer_lambert_law
 from ._scalp_coupling_index import scalp_coupling_index

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -66,17 +66,6 @@ def _channel_frequencies(raw):
     return freqs
 
 
-def _channel_chromophore(raw):
-    """Return the chromophore of each channel."""
-    # Only valid for fNIRS data after conversion to haemoglobin
-    picks = _picks_to_idx(raw.info, ['hbo', 'hbr'],
-                          exclude=[], allow_empty=True)
-    chroma = []
-    for ii in picks:
-        chroma.append(raw.ch_names[ii].split(" ")[1])
-    return chroma
-
-
 def _check_channels_ordered(raw, freqs):
     """Check channels followed expected fNIRS format."""
     # Every second channel should be same SD pair

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -57,18 +57,32 @@ def short_channels(info, threshold=0.01):
 
 def _channel_frequencies(raw):
     """Return the light frequency for each channel."""
-    picks = _picks_to_idx(raw.info, 'fnirs', exclude=[], allow_empty=True)
+    # Only valid for fNIRS data before conversion to haemoglobin
+    picks = _picks_to_idx(raw.info, ['fnirs_cw_amplitude', 'fnirs_od'],
+                          exclude=[], allow_empty=True)
     freqs = np.empty(picks.size, int)
     for ii in picks:
         freqs[ii] = raw.info['chs'][ii]['loc'][9]
     return freqs
 
 
+def _channel_chromophore(raw):
+    """Return the chromophore of each channel."""
+    # Only valid for fNIRS data after conversion to haemoglobin
+    picks = _picks_to_idx(raw.info, ['hbo', 'hbr'],
+                          exclude=[], allow_empty=True)
+    chroma = []
+    for ii in picks:
+        chroma.append(raw.ch_names[ii].split(" ")[1])
+    return chroma
+
+
 def _check_channels_ordered(raw, freqs):
     """Check channels followed expected fNIRS format."""
     # Every second channel should be same SD pair
     # and have the specified light frequencies.
-    picks = _picks_to_idx(raw.info, 'fnirs', exclude=[], allow_empty=True)
+    picks = _picks_to_idx(raw.info, ['fnirs_cw_amplitude', 'fnirs_od'],
+                          exclude=[], allow_empty=True)
     if len(picks) % 2 != 0:
         raise ValueError(
             'NIRS channels not ordered correctly. An even number of NIRS '

--- a/mne/preprocessing/nirs/tests/test_nirs.py
+++ b/mne/preprocessing/nirs/tests/test_nirs.py
@@ -15,7 +15,7 @@ from mne.io import read_raw_nirx
 from mne.preprocessing.nirs import (optical_density, beer_lambert_law,
                                     _fnirs_check_bads, _fnirs_spread_bads,
                                     _check_channels_ordered,
-                                    _channel_frequencies, _channel_chromophore)
+                                    _channel_frequencies)
 from mne.io.pick import _picks_to_idx
 
 from mne.datasets import testing
@@ -167,8 +167,3 @@ def test_fnirs_channel_naming_and_order_readers(fname):
     assert_array_equal(freqs, [760, 850])
     picks = _check_channels_ordered(raw, freqs)
     assert len(picks) == len(raw.ch_names)  # as all fNIRS only data
-
-    # Check on haemoglobin data
-    raw = beer_lambert_law(raw)
-    freqs = np.unique(_channel_chromophore(raw))
-    assert_array_equal(freqs, ["hbo", "hbr"])

--- a/mne/preprocessing/nirs/tests/test_nirs.py
+++ b/mne/preprocessing/nirs/tests/test_nirs.py
@@ -35,7 +35,7 @@ def test_fnirs_picks():
     raw = read_raw_nirx(fname_nirx_15_0)
     picks = _picks_to_idx(raw.info, 'fnirs_cw_amplitude')
     assert len(picks) == len(raw.ch_names)
-    raw_subset = raw.copy().pick(picks=picks)
+    raw_subset = raw.copy().pick(picks='fnirs_cw_amplitude')
     for ch in raw_subset.info["chs"]:
         assert ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_CW_AMPLITUDE
 
@@ -52,7 +52,7 @@ def test_fnirs_picks():
     raw = optical_density(raw)
     picks = _picks_to_idx(raw.info, 'fnirs_od')
     assert len(picks) == len(raw.ch_names)
-    raw_subset = raw.copy().pick(picks=picks)
+    raw_subset = raw.copy().pick(picks='fnirs_od')
     for ch in raw_subset.info["chs"]:
         assert ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_OD
 
@@ -69,13 +69,13 @@ def test_fnirs_picks():
     raw = beer_lambert_law(raw)
     picks = _picks_to_idx(raw.info, 'hbo')
     assert len(picks) == len(raw.ch_names) / 2
-    raw_subset = raw.copy().pick(picks=picks)
+    raw_subset = raw.copy().pick(picks='hbo')
     for ch in raw_subset.info["chs"]:
         assert ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_HBO
 
     picks = _picks_to_idx(raw.info, ['hbr'])
     assert len(picks) == len(raw.ch_names) / 2
-    raw_subset = raw.copy().pick(picks=picks)
+    raw_subset = raw.copy().pick(picks=['hbr'])
     for ch in raw_subset.info["chs"]:
         assert ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_HBR
 

--- a/mne/preprocessing/nirs/tests/test_nirs.py
+++ b/mne/preprocessing/nirs/tests/test_nirs.py
@@ -7,11 +7,16 @@
 import os.path as op
 
 import pytest
+import numpy as np
+from numpy.testing import assert_array_equal
 
 from mne.datasets.testing import data_path
 from mne.io import read_raw_nirx
-from mne.preprocessing.nirs import optical_density, beer_lambert_law,\
-    _fnirs_check_bads, _fnirs_spread_bads
+from mne.preprocessing.nirs import (optical_density, beer_lambert_law,
+                                    _fnirs_check_bads, _fnirs_spread_bads,
+                                    _check_channels_ordered,
+                                    _channel_frequencies, _channel_chromophore)
+from mne.io.pick import _picks_to_idx
 
 from mne.datasets import testing
 
@@ -22,6 +27,51 @@ fname_nirx_15_2 = op.join(data_path(download=False),
 fname_nirx_15_2_short = op.join(data_path(download=False),
                                 'NIRx', 'nirscout',
                                 'nirx_15_2_recording_w_short')
+
+
+def test_fnirs_picks():
+    """Test picking of fnirs types after different conversions"""
+    raw = read_raw_nirx(fname_nirx_15_0)
+    picks = _picks_to_idx(raw.info, 'fnirs_cw_amplitude')
+    assert len(picks) == len(raw.ch_names)
+    picks = _picks_to_idx(raw.info, ['fnirs_cw_amplitude', 'fnirs_od'])
+    assert len(picks) == len(raw.ch_names)
+    picks = _picks_to_idx(raw.info, ['fnirs_cw_amplitude', 'fnirs_od', 'hbr'])
+    assert len(picks) == len(raw.ch_names)
+    pytest.raises(ValueError, _picks_to_idx, raw.info, 'fnirs_od')
+    pytest.raises(ValueError, _picks_to_idx, raw.info, 'hbo')
+    pytest.raises(ValueError, _picks_to_idx, raw.info, ['hbr'])
+    pytest.raises(ValueError, _picks_to_idx, raw.info, 'fnirs_fd_phase')
+    pytest.raises(ValueError, _picks_to_idx, raw.info, 'junk')
+
+    raw = optical_density(raw)
+    picks = _picks_to_idx(raw.info, 'fnirs_od')
+    assert len(picks) == len(raw.ch_names)
+    picks = _picks_to_idx(raw.info, ['fnirs_cw_amplitude', 'fnirs_od'])
+    assert len(picks) == len(raw.ch_names)
+    picks = _picks_to_idx(raw.info, ['fnirs_cw_amplitude', 'fnirs_od', 'hbr'])
+    assert len(picks) == len(raw.ch_names)
+    pytest.raises(ValueError, _picks_to_idx, raw.info, 'fnirs_cw_amplitude')
+    pytest.raises(ValueError, _picks_to_idx, raw.info, 'hbo')
+    pytest.raises(ValueError, _picks_to_idx, raw.info, 'hbr')
+    pytest.raises(ValueError, _picks_to_idx, raw.info, 'fnirs_fd_phase')
+    pytest.raises(ValueError, _picks_to_idx, raw.info, 'junk')
+
+    raw = beer_lambert_law(raw)
+    picks = _picks_to_idx(raw.info, 'hbo')
+    assert len(picks) == len(raw.ch_names) / 2
+    picks = _picks_to_idx(raw.info, ['hbr'])
+    assert len(picks) == len(raw.ch_names) / 2
+    picks = _picks_to_idx(raw.info, ['hbo', 'hbr'])
+    assert len(picks) == len(raw.ch_names)
+    picks = _picks_to_idx(raw.info, ['hbo', 'fnirs_od', 'hbr'])
+    assert len(picks) == len(raw.ch_names)
+    picks = _picks_to_idx(raw.info, ['hbo', 'fnirs_od'])
+    assert len(picks) == len(raw.ch_names) / 2
+    pytest.raises(ValueError, _picks_to_idx, raw.info, 'fnirs_cw_amplitude')
+    pytest.raises(ValueError, _picks_to_idx, raw.info, ['fnirs_od'])
+    pytest.raises(ValueError, _picks_to_idx, raw.info, 'junk')
+    pytest.raises(ValueError, _picks_to_idx, raw.info, 'fnirs_fd_phase')
 
 
 @testing.requires_testing_data
@@ -76,7 +126,49 @@ def test_fnirs_spread_bads(fname):
     # Test spreading multiple bads and on chroma data
     raw = beer_lambert_law(raw)
     raw.info['bads'] = [raw.ch_names[x] for x in [1, 8]]
-    print(raw.info['bads'])
     raw = _fnirs_spread_bads(raw)
-    print(raw.info['bads'])
     assert raw.info['bads'] == [raw.ch_names[x] for x in [0, 1, 8, 9]]
+
+
+@testing.requires_testing_data
+@pytest.mark.parametrize('fname', ([fname_nirx_15_2_short, fname_nirx_15_2,
+                                    fname_nirx_15_0]))
+def test_fnirs_channel_naming_and_order_readers(fname):
+    """Ensure fNIRS channel checking on standard readers"""
+    # fNIRS data requires specific channel naming and ordering.
+
+    # All standard readers should pass tests
+    raw = read_raw_nirx(fname)
+    freqs = np.unique(_channel_frequencies(raw))
+    assert_array_equal(freqs, [760, 850])
+
+    picks = _check_channels_ordered(raw, freqs)
+    assert len(picks) == len(raw.ch_names)  # as all fNIRS only data
+
+    # Check that dropped channels are detected
+    # For each source detector pair there must be two channels,
+    # removing one should throw an error.
+    raw_dropped = raw.copy().drop_channels(raw.ch_names[4])
+    with pytest.raises(ValueError, match='not ordered correctly'):
+        _check_channels_ordered(raw_dropped, freqs)
+
+    # The ordering must match the passed in argument
+    raw_names_reversed = raw.copy().ch_names
+    raw_names_reversed.reverse()
+    raw_reversed = raw.copy().pick_channels(raw_names_reversed, ordered=True)
+    with pytest.raises(ValueError, match='not ordered correctly'):
+        _check_channels_ordered(raw_reversed, freqs)
+    # So if we flip the second argument it should pass again
+    _check_channels_ordered(raw_reversed, [850, 760])
+
+    # Check on OD data
+    raw = optical_density(raw)
+    freqs = np.unique(_channel_frequencies(raw))
+    assert_array_equal(freqs, [760, 850])
+    picks = _check_channels_ordered(raw, freqs)
+    assert len(picks) == len(raw.ch_names)  # as all fNIRS only data
+
+    # Check on haemoglobin data
+    raw = beer_lambert_law(raw)
+    freqs = np.unique(_channel_chromophore(raw))
+    assert_array_equal(freqs, ["hbo", "hbr"])

--- a/mne/preprocessing/nirs/tests/test_nirs.py
+++ b/mne/preprocessing/nirs/tests/test_nirs.py
@@ -167,3 +167,7 @@ def test_fnirs_channel_naming_and_order_readers(fname):
     assert_array_equal(freqs, [760, 850])
     picks = _check_channels_ordered(raw, freqs)
     assert len(picks) == len(raw.ch_names)  # as all fNIRS only data
+
+    raw = beer_lambert_law(raw)
+    freqs = np.unique(_channel_frequencies(raw))
+    assert len(freqs) == 0

--- a/mne/preprocessing/nirs/tests/test_nirs.py
+++ b/mne/preprocessing/nirs/tests/test_nirs.py
@@ -19,6 +19,7 @@ from mne.preprocessing.nirs import (optical_density, beer_lambert_law,
 from mne.io.pick import _picks_to_idx
 
 from mne.datasets import testing
+from mne.io.constants import FIFF
 
 fname_nirx_15_0 = op.join(data_path(download=False),
                           'NIRx', 'nirscout', 'nirx_15_0_recording')
@@ -30,10 +31,14 @@ fname_nirx_15_2_short = op.join(data_path(download=False),
 
 
 def test_fnirs_picks():
-    """Test picking of fnirs types after different conversions"""
+    """Test picking of fnirs types after different conversions."""
     raw = read_raw_nirx(fname_nirx_15_0)
     picks = _picks_to_idx(raw.info, 'fnirs_cw_amplitude')
     assert len(picks) == len(raw.ch_names)
+    raw_subset = raw.copy().pick(picks=picks)
+    for ch in raw_subset.info["chs"]:
+        assert ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_CW_AMPLITUDE
+
     picks = _picks_to_idx(raw.info, ['fnirs_cw_amplitude', 'fnirs_od'])
     assert len(picks) == len(raw.ch_names)
     picks = _picks_to_idx(raw.info, ['fnirs_cw_amplitude', 'fnirs_od', 'hbr'])
@@ -47,6 +52,10 @@ def test_fnirs_picks():
     raw = optical_density(raw)
     picks = _picks_to_idx(raw.info, 'fnirs_od')
     assert len(picks) == len(raw.ch_names)
+    raw_subset = raw.copy().pick(picks=picks)
+    for ch in raw_subset.info["chs"]:
+        assert ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_OD
+
     picks = _picks_to_idx(raw.info, ['fnirs_cw_amplitude', 'fnirs_od'])
     assert len(picks) == len(raw.ch_names)
     picks = _picks_to_idx(raw.info, ['fnirs_cw_amplitude', 'fnirs_od', 'hbr'])
@@ -60,8 +69,16 @@ def test_fnirs_picks():
     raw = beer_lambert_law(raw)
     picks = _picks_to_idx(raw.info, 'hbo')
     assert len(picks) == len(raw.ch_names) / 2
+    raw_subset = raw.copy().pick(picks=picks)
+    for ch in raw_subset.info["chs"]:
+        assert ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_HBO
+
     picks = _picks_to_idx(raw.info, ['hbr'])
     assert len(picks) == len(raw.ch_names) / 2
+    raw_subset = raw.copy().pick(picks=picks)
+    for ch in raw_subset.info["chs"]:
+        assert ch['coil_type'] == FIFF.FIFFV_COIL_FNIRS_HBR
+
     picks = _picks_to_idx(raw.info, ['hbo', 'hbr'])
     assert len(picks) == len(raw.ch_names)
     picks = _picks_to_idx(raw.info, ['hbo', 'fnirs_od', 'hbr'])
@@ -134,7 +151,7 @@ def test_fnirs_spread_bads(fname):
 @pytest.mark.parametrize('fname', ([fname_nirx_15_2_short, fname_nirx_15_2,
                                     fname_nirx_15_0]))
 def test_fnirs_channel_naming_and_order_readers(fname):
-    """Ensure fNIRS channel checking on standard readers"""
+    """Ensure fNIRS channel checking on standard readers."""
     # fNIRS data requires specific channel naming and ordering.
 
     # All standard readers should pass tests


### PR DESCRIPTION
#### Reference issue
I was going to implement some new features raised in an issue from #9141 but found this bug along the way. 


#### What does this implement/fix?
When trying to pick a specific fNIRS type the function was returning all fNIRS types. Now it should just return the requested type.


#### Additional information
Once this bug is fixed I will add new functionality in a seperate PR