### PR TITLE
ENH: Traces dock widget

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -654,7 +654,7 @@ class Brain(object):
         self._configure_help()
         # show everything at the end
         self.toggle_interface()
-        self._renderer._window_show()
+        self._renderer.show()
 
         # sizes could change, update views
         for hemi in ('lh', 'rh'):

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -413,7 +413,7 @@ class Brain(object):
         if len(size) not in (1, 2):
             raise ValueError('"size" parameter must be an int or length-2 '
                              'sequence of ints.')
-        self._size = size if len(size) == 2 else size * 2  # 1-tuple to 2-tuple
+        size = size if len(size) == 2 else size * 2  # 1-tuple to 2-tuple
         subjects_dir = get_subjects_dir(subjects_dir)
 
         self.time_viewer = False
@@ -466,7 +466,7 @@ class Brain(object):
             offset = (surf == 'inflated')
         offset = None if (not offset or hemi != 'both') else 0.0
 
-        self._renderer = _get_renderer(name=self._title, size=self._size,
+        self._renderer = _get_renderer(name=self._title, size=size,
                                        bgcolor=background,
                                        shape=shape,
                                        fig=figure)
@@ -654,7 +654,7 @@ class Brain(object):
         self._configure_help()
         # show everything at the end
         self.toggle_interface()
-        self._renderer._window_show(self._size)
+        self._renderer._window_show()
 
         # sizes could change, update views
         for hemi in ('lh', 'rh'):
@@ -717,7 +717,7 @@ class Brain(object):
             self.visibility = value
 
         # update tool bar and dock
-        with self._renderer._window_ensure_minimum_sizes(self._size):
+        with self._renderer._window_ensure_minimum_sizes():
             if self.visibility:
                 self._renderer._dock_show()
                 self._renderer._tool_bar_update_button_icon(

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -478,8 +478,7 @@ class Brain(object):
                                        bgcolor=background,
                                        shape=shape,
                                        fig=figure)
-
-        self._renderer._window_initialize(self._clean)
+        self._renderer._window_close_connect(self._clean)
         self._renderer._window_set_theme(theme)
         self.plotter = self._renderer.plotter
 

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -378,7 +378,7 @@ def test_brain_save_movie(tmpdir, renderer, brain_gc):
     brain.close()
 
 
-_TINY_SIZE = (300, 250)
+_TINY_SIZE = (350, 300)
 
 
 def tiny(tmpdir):

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -757,9 +757,9 @@ class _AbstractWindow(ABC):
         pass
 
     @abstractmethod
-    def _window_ensure_minimum_sizes(self, sz):
+    def _window_ensure_minimum_sizes(self):
         pass
 
     @abstractmethod
-    def _window_show(self, sz):
+    def _window_show(self):
         pass

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -720,8 +720,16 @@ class _AbstractBrainMplCanvas(_AbstractMplCanvas):
 
 
 class _AbstractWindow(ABC):
+    def _window_initialize(self):
+        self._window = None
+        self._interactor = None
+        self._mplcanvas = None
+        self._show_traces = None
+        self._separate_canvas = None
+        self._interactor_fraction = None
+
     @abstractmethod
-    def _window_initialize(self, func=None):
+    def _window_close_connect(self, func):
         pass
 
     @abstractmethod

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -759,7 +759,3 @@ class _AbstractWindow(ABC):
     @abstractmethod
     def _window_ensure_minimum_sizes(self):
         pass
-
-    @abstractmethod
-    def _window_show(self):
-        pass

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -250,7 +250,6 @@ class _IpyWindow(_AbstractWindow):
         self._mplcanvas = None
         self._show_traces = None
         self._separate_canvas = None
-        self._splitter = None
         self._interactor_fraction = None
 
     def _window_get_dpi(self):

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -285,9 +285,6 @@ class _IpyWindow(_AbstractWindow):
     def _window_ensure_minimum_sizes(self):
         yield
 
-    def _window_show(self):
-        self.show()
-
 
 class _IpyWidget(_AbstractWidget):
     def set_value(self, value):

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -247,13 +247,8 @@ class _IpyBrainMplCanvas(_AbstractBrainMplCanvas, _IpyMplInterface):
 
 
 class _IpyWindow(_AbstractWindow):
-    def _window_initialize(self, func=None):
-        self._window = None
-        self._interactor = None
-        self._mplcanvas = None
-        self._show_traces = None
-        self._separate_canvas = None
-        self._interactor_fraction = None
+    def _window_close_connect(self, func):
+        pass
 
     def _window_get_dpi(self):
         return 96

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -282,10 +282,10 @@ class _IpyWindow(_AbstractWindow):
         pass
 
     @contextmanager
-    def _window_ensure_minimum_sizes(self, sz):
+    def _window_ensure_minimum_sizes(self):
         yield
 
-    def _window_show(self, sz):
+    def _window_show(self):
         self.show()
 
 

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -595,7 +595,6 @@ class _PyVistaRenderer(_AbstractRenderer):
 
     def show(self):
         self.plotter.show()
-        return self.scene()
 
     def close(self):
         _close_3d_figure(figure=self.figure)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -23,8 +23,7 @@ import vtk
 
 from ._abstract import _AbstractRenderer
 from ._utils import (_get_colormap_from_array, _alpha_blend_background,
-                     ALLOWED_QUIVER_MODES, _init_qt_resources,
-                     _qt_disable_paint)
+                     ALLOWED_QUIVER_MODES, _init_qt_resources)
 from ...fixes import _get_args
 from ...transforms import apply_trans
 from ...utils import copy_base_doc_to_subclass_doc, _check_option
@@ -210,35 +209,6 @@ class _PyVistaRenderer(_AbstractRenderer):
         now = datetime.now()
         dt_string = now.strftime("_%Y-%m-%d_%H-%M-%S")
         return "MNE" + dt_string + ".png"
-
-    @contextmanager
-    def _ensure_minimum_sizes(self):
-        sz = self.figure.store['window_size']
-        # plotter:            pyvista.plotting.qt_plotting.BackgroundPlotter
-        # plotter.interactor: vtk.qt.QVTKRenderWindowInteractor.QVTKRenderWindowInteractor -> QWidget  # noqa
-        # plotter.app_window: pyvista.plotting.qt_plotting.MainWindow -> QMainWindow  # noqa
-        # plotter.frame:      QFrame with QVBoxLayout with plotter.interactor as centralWidget  # noqa
-        # plotter.ren_win:    vtkXOpenGLRenderWindow
-        self.plotter.interactor.setMinimumSize(*sz)
-        try:
-            yield  # show
-        finally:
-            # 1. Process events
-            _process_events(self.plotter)
-            _process_events(self.plotter)
-            # 2. Get the window and interactor sizes that work
-            win_sz = self.plotter.app_window.size()
-            ren_sz = self.plotter.interactor.size()
-            # 3. Undo the min size setting and process events
-            self.plotter.interactor.setMinimumSize(0, 0)
-            _process_events(self.plotter)
-            _process_events(self.plotter)
-            # 4. Resize the window and interactor to the correct size
-            #    (not sure why, but this is required on macOS at least)
-            self.plotter.window_size = (win_sz.width(), win_sz.height())
-            self.plotter.interactor.resize(ren_sz.width(), ren_sz.height())
-            _process_events(self.plotter)
-            _process_events(self.plotter)
 
     def _index_to_loc(self, idx):
         _ncols = self.figure._ncols
@@ -625,11 +595,6 @@ class _PyVistaRenderer(_AbstractRenderer):
 
     def show(self):
         self.plotter.show()
-        if hasattr(self.plotter, "app_window"):
-            with _qt_disable_paint(self.plotter):
-                with self._ensure_minimum_sizes():
-                    self.plotter.app_window.show()
-            self.plotter.update()
         return self.scene()
 
     def close(self):

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -44,9 +44,8 @@ class _QtDock(_AbstractDock, _QtLayout):
     def _dock_initialize(self, window=None):
         window = self._window if window is None else window
         self.dock, self.dock_layout = _create_dock_widget(
-            self._window, "Controls", Qt.AllDockWidgetAreas,
-            Qt.LeftDockWidgetArea)
-        # window.setCorner(Qt.BottomLeftCorner, Qt.LeftDockWidgetArea)
+            self._window, "Controls", Qt.LeftDockWidgetArea)
+        window.setCorner(Qt.BottomLeftCorner, Qt.LeftDockWidgetArea)
 
     def _dock_finalize(self):
         self.dock.setMinimumSize(self.dock.sizeHint().width(), 0)
@@ -363,16 +362,6 @@ class _QtWindow(_AbstractWindow):
         self._window = self.figure.plotter.app_window
         self._window.setLocale(QLocale(QLocale.Language.English))
 
-        name = "Plot"
-        window = self._window
-        window.setCentralWidget(QLabel(""))
-        window.centralWidget().hide()
-        dock = QDockWidget()
-        dock.setWidget(self._interactor)
-        dock.setAllowedAreas(Qt.AllDockWidgetAreas)
-        dock.setTitleBarWidget(QLabel(name))
-        window.addDockWidget(Qt.TopDockWidgetArea, dock)
-
     def _window_close_connect(self, func):
         self._window.signal_close.connect(func)
 
@@ -400,8 +389,7 @@ class _QtWindow(_AbstractWindow):
     def _window_adjust_mplcanvas_layout(self):
         canvas = self._mplcanvas.canvas
         dock, dock_layout = _create_dock_widget(
-            self._window, "Traces", Qt.AllDockWidgetAreas,
-            Qt.BottomDockWidgetArea)
+            self._window, "Traces", Qt.BottomDockWidgetArea)
         dock_layout.addWidget(canvas)
 
     def _window_get_cursor(self):
@@ -501,16 +489,16 @@ class _Renderer(_PyVistaRenderer, _QtDock, _QtToolBar, _QtMenuBar,
         self.plotter.update()
 
 
-def _create_dock_widget(window, name, allowed_area, default_area):
+def _create_dock_widget(window, name, area):
     dock = QDockWidget()
     scroll = QScrollArea(dock)
     dock.setWidget(scroll)
     widget = QWidget(scroll)
     scroll.setWidget(widget)
     scroll.setWidgetResizable(True)
-    dock.setAllowedAreas(allowed_area)
+    dock.setAllowedAreas(area)
     dock.setTitleBarWidget(QLabel(name))
-    window.addDockWidget(default_area, dock)
+    window.addDockWidget(area, dock)
     dock_layout = QVBoxLayout()
     widget.setLayout(dock_layout)
     return dock, dock_layout

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -385,7 +385,7 @@ class _QtWindow(_AbstractWindow):
     def _window_adjust_mplcanvas_layout(self):
         canvas = self._mplcanvas.canvas
         dock, dock_layout = _create_dock_widget(
-            self._window, "Traces", Qt.BottomDockWidgetArea)
+            self._window, "Traces", Qt.BottomDockWidgetArea, False)
         dock_layout.addWidget(canvas)
 
     def _window_get_cursor(self):
@@ -454,7 +454,7 @@ class _Renderer(_PyVistaRenderer, _QtDock, _QtToolBar, _QtMenuBar,
         return self.scene()
 
 
-def _create_dock_widget(window, name, area):
+def _create_dock_widget(window, name, area, margin=True):
     dock = QDockWidget()
     scroll = QScrollArea(dock)
     dock.setWidget(scroll)
@@ -465,6 +465,8 @@ def _create_dock_widget(window, name, area):
     dock.setTitleBarWidget(QLabel(name))
     window.addDockWidget(area, dock)
     dock_layout = QVBoxLayout()
+    if not margin:
+        dock_layout.setContentsMargins(0, 0, 0, 0)
     widget.setLayout(dock_layout)
     return dock, dock_layout
 

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -44,8 +44,9 @@ class _QtDock(_AbstractDock, _QtLayout):
     def _dock_initialize(self, window=None):
         window = self._window if window is None else window
         self.dock, self.dock_layout = _create_dock_widget(
-            self._window, "Controls", Qt.LeftDockWidgetArea)
-        window.setCorner(Qt.BottomLeftCorner, Qt.LeftDockWidgetArea)
+            self._window, "Controls", Qt.AllDockWidgetAreas,
+            Qt.LeftDockWidgetArea)
+        # window.setCorner(Qt.BottomLeftCorner, Qt.LeftDockWidgetArea)
 
     def _dock_finalize(self):
         self.dock.setMinimumSize(self.dock.sizeHint().width(), 0)
@@ -362,6 +363,16 @@ class _QtWindow(_AbstractWindow):
         self._window = self.figure.plotter.app_window
         self._window.setLocale(QLocale(QLocale.Language.English))
 
+        name = "Plot"
+        window = self._window
+        window.setCentralWidget(QLabel(""))
+        window.centralWidget().hide()
+        dock = QDockWidget()
+        dock.setWidget(self._interactor)
+        dock.setAllowedAreas(Qt.AllDockWidgetAreas)
+        dock.setTitleBarWidget(QLabel(name))
+        window.addDockWidget(Qt.TopDockWidgetArea, dock)
+
     def _window_close_connect(self, func):
         self._window.signal_close.connect(func)
 
@@ -389,7 +400,8 @@ class _QtWindow(_AbstractWindow):
     def _window_adjust_mplcanvas_layout(self):
         canvas = self._mplcanvas.canvas
         dock, dock_layout = _create_dock_widget(
-            self._window, "Traces", Qt.BottomDockWidgetArea)
+            self._window, "Traces", Qt.AllDockWidgetAreas,
+            Qt.BottomDockWidgetArea)
         dock_layout.addWidget(canvas)
 
     def _window_get_cursor(self):
@@ -489,16 +501,16 @@ class _Renderer(_PyVistaRenderer, _QtDock, _QtToolBar, _QtMenuBar,
         self.plotter.update()
 
 
-def _create_dock_widget(window, name, area):
+def _create_dock_widget(window, name, allowed_area, default_area):
     dock = QDockWidget()
     scroll = QScrollArea(dock)
     dock.setWidget(scroll)
     widget = QWidget(scroll)
     scroll.setWidget(widget)
     scroll.setWidgetResizable(True)
-    dock.setAllowedAreas(area)
+    dock.setAllowedAreas(allowed_area)
     dock.setTitleBarWidget(QLabel(name))
-    window.addDockWidget(area, dock)
+    window.addDockWidget(default_area, dock)
     dock_layout = QVBoxLayout()
     widget.setLayout(dock_layout)
     return dock, dock_layout

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -501,6 +501,9 @@ def _create_dock_widget(window, name, area):
     window.addDockWidget(area, dock)
     dock_layout = QVBoxLayout()
     widget.setLayout(dock_layout)
+    # Fix resize grip size
+    # https://stackoverflow.com/a/65050468/2175965
+    dock.setStyleSheet("QDockWidget { margin: 4px; }")
     return dock, dock_layout
 
 

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -351,7 +351,6 @@ class _QtWindow(_AbstractWindow):
         self._mplcanvas = None
         self._show_traces = None
         self._separate_canvas = None
-        self._splitter = None
         self._interactor_fraction = None
         self._window.setLocale(QLocale(QLocale.Language.English))
         if func is not None:


### PR DESCRIPTION
This PR follows https://github.com/mne-tools/mne-python/pull/8997#issuecomment-802891396 and brings support for docked traces:

This is how it looks by default for me on `i3`:

![image](https://user-images.githubusercontent.com/18143289/111983411-65df5100-8b0a-11eb-8278-be69c6048ff3.png)

And the dock widgets can be detached/resized/reattached:

![image](https://user-images.githubusercontent.com/18143289/112287929-24c37a00-8c8d-11eb-8385-d86cf52d9f64.png)

*Locally, `Brain` testing works but I don't know how `macOS` CIs will react* :pray:

<details>

```py
import os
import mne
from mne.datasets import sample

data_path = sample.data_path()
sample_dir = os.path.join(data_path, 'MEG', 'sample')
subjects_dir = os.path.join(data_path, 'subjects')
fname_stc = os.path.join(sample_dir, 'sample_audvis-meg')
stc = mne.read_source_estimate(fname_stc, subject='sample')
initial_time = 0.096
brain = stc.plot(subjects_dir=subjects_dir, initial_time=initial_time,
                 clim=dict(kind='value', lims=[3, 6, 9]),
                 surface="white",
                 size=600,
                 background="white")

```
</details>