### PR TITLE
ENH: Add fast plotting ICA properties

### DIFF
--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -872,13 +872,13 @@ class MNEBrowseFigure(MNEFigure):
         fig = self._new_child_figure(figsize=(7, 6), fig_name=None,
                                      window_title=f'{ch_name} properties')
         fig, axes = _create_properties_layout(fig=fig)
-        if not hasattr(self, 'data_ica_properties'):
+        if not hasattr(self.mne, 'data_ica_properties'):
             # Precompute epoch sources only once
-            self.data_ica_properties = _prepare_data_ica_properties(
+            self.mne.data_ica_properties = _prepare_data_ica_properties(
                 self.mne.ica_inst, self.mne.ica)
         _fast_plot_ica_properties(
             self.mne.ica, self.mne.ica_inst, picks=pick, axes=axes,
-            precomputed_data=self.data_ica_properties)
+            precomputed_data=self.mne.data_ica_properties)
 
     def _create_epoch_image_fig(self, pick):
         """Show epochs image for the selected channel."""

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -873,6 +873,7 @@ class MNEBrowseFigure(MNEFigure):
                                      window_title=f'{ch_name} properties')
         fig, axes = _create_properties_layout(fig=fig)
         if not hasattr(self, 'data_ica_properties'):
+            # Precompute epoch sources only once
             self.data_ica_properties = _prepare_data_ica_properties(
                 self.mne.ica_inst, self.mne.ica)
         _fast_plot_ica_properties(

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -45,7 +45,8 @@ from collections import OrderedDict
 import numpy as np
 from matplotlib.figure import Figure
 from .epochs import plot_epochs_image
-from .ica import _create_properties_layout
+from .ica import (_create_properties_layout, _fast_plot_ica_properties,
+                  _prepare_data_ica_properties)
 from .utils import (plt_show, plot_sensors, _setup_plot_projector, _events_off,
                     _set_window_title, _merge_annotations, DraggableLine,
                     _get_color_list, logger, _validate_if_list_of_axes,
@@ -871,7 +872,12 @@ class MNEBrowseFigure(MNEFigure):
         fig = self._new_child_figure(figsize=(7, 6), fig_name=None,
                                      window_title=f'{ch_name} properties')
         fig, axes = _create_properties_layout(fig=fig)
-        self.mne.ica.plot_properties(self.mne.ica_inst, picks=pick, axes=axes)
+        if not hasattr(self, 'data_ica_properties'):
+            self.data_ica_properties = _prepare_data_ica_properties(
+                self.mne.ica_inst, self.mne.ica)
+        _fast_plot_ica_properties(
+            self.mne.ica, self.mne.ica_inst, picks=pick, axes=axes,
+            precomputed_data=self.data_ica_properties)
 
     def _create_epoch_image_fig(self, pick):
         """Show epochs image for the selected channel."""

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -319,14 +319,10 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
     -----
     .. versionadded:: 0.13
     """
-    from ..io.base import BaseRaw
-    from ..epochs import BaseEpochs
     from ..preprocessing import ICA
-    from ..io import RawArray
 
     # input checks and defaults
     # -------------------------
-    _validate_type(inst, (BaseRaw, BaseEpochs), "inst", "Raw or Epochs")
     _validate_type(ica, ICA, "ica", "ICA")
     _validate_type(plot_std, (bool, 'numeric'), 'plot_std')
     if isinstance(plot_std, bool):
@@ -368,48 +364,8 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
     # calculations
     # ------------
 
-    if isinstance(inst, BaseRaw):
-        # when auto, delegate reject to the ica
-        from ..epochs import make_fixed_length_epochs
-        if reject == 'auto':
-            reject = getattr(ica, 'reject_', None)
-        if reject is None:
-            drop_inds = None
-            dropped_indices = []
-            # break up continuous signal into segments
-            epochs_src = make_fixed_length_epochs(
-                ica.get_sources(inst),
-                duration=2,
-                preload=True,
-                reject_by_annotation=reject_by_annotation,
-                proj=False,
-                verbose=False)
-        else:
-            data = inst.get_data()
-            data, drop_inds = _reject_data_segments(data, ica.reject_,
-                                                    flat=None, decim=None,
-                                                    info=inst.info,
-                                                    tstep=2.0)
-            inst_rejected = RawArray(data, inst.info)
-            # break up continuous signal into segments
-            epochs_src = make_fixed_length_epochs(
-                ica.get_sources(inst_rejected),
-                duration=2,
-                preload=True,
-                reject_by_annotation=reject_by_annotation,
-                proj=False,
-                verbose=False)
-            # getting dropped epochs indexes
-            dropped_indices = [(d[0] // len(epochs_src.times)) + 1
-                               for d in drop_inds]
-        kind = "Segment"
-    else:
-        drop_inds = None
-        epochs_src = ica.get_sources(inst)
-        dropped_indices = []
-        kind = "Epochs"
-
-    data = epochs_src.get_data()
+    kind, dropped_indices, epochs_src, data = _prepare_data_ica_properties(
+        inst, ica, reject_by_annotation, reject)
     ica_data = np.swapaxes(data[:, picks, :], 0, 1)
     dropped_src = ica_data
 
@@ -467,6 +423,169 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
 
     plt_show(show)
     return all_fig
+
+
+def _fast_plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
+                              plot_std=True, topomap_args=None, reject='auto',
+                              image_args=None, psd_args=None, figsize=None,
+                              show=True, reject_by_annotation=True,
+                              precomputed_data=None):
+    from ..preprocessing import ICA
+
+    # input checks and defaults
+    # -------------------------
+    _validate_type(ica, ICA, "ica", "ICA")
+    _validate_type(plot_std, (bool, 'numeric'), 'plot_std')
+    if isinstance(plot_std, bool):
+        num_std = 1. if plot_std else 0.
+    else:
+        plot_std = True
+    num_std = float(plot_std)
+
+    # if no picks given - plot the first 5 components
+    limit = min(5, ica.n_components_) if picks is None else len(ica.ch_names)
+    picks = _picks_to_idx(ica.info, picks, 'all')[:limit]
+    if axes is None:
+        fig, axes = _create_properties_layout(figsize=figsize)
+    else:
+        if len(picks) > 1:
+            raise ValueError('Only a single pick can be drawn '
+                             'to a set of axes.')
+        from .utils import _validate_if_list_of_axes
+        _validate_if_list_of_axes(axes, obligatory_len=5)
+        fig = axes[0].get_figure()
+
+    psd_args = dict() if psd_args is None else psd_args
+    topomap_args = dict() if topomap_args is None else topomap_args
+    image_args = dict() if image_args is None else image_args
+    image_args["ts_args"] = dict(truncate_xaxis=False, show_sensors=False)
+    if plot_std:
+        from ..stats.parametric import _parametric_ci
+        image_args["ts_args"]["ci"] = _parametric_ci
+    elif "ts_args" not in image_args or "ci" not in image_args["ts_args"]:
+        image_args["ts_args"]["ci"] = False
+
+    for item_name, item in (("psd_args", psd_args),
+                            ("topomap_args", topomap_args),
+                            ("image_args", image_args)):
+        _validate_type(item, dict, item_name, "dictionary")
+    if dB is not None:
+        _validate_type(dB, bool, "dB", "bool")
+
+    # calculations
+    # ------------
+    if isinstance(precomputed_data, tuple):
+        kind, dropped_indices, epochs_src, data = precomputed_data
+    else:
+        kind, dropped_indices, epochs_src, data = _prepare_data_ica_properties(
+            inst, ica, reject_by_annotation, reject)
+    ica_data = np.swapaxes(data[:, picks, :], 0, 1)
+    dropped_src = ica_data
+
+    # spectrum
+    Nyquist = inst.info['sfreq'] / 2.
+    lp = inst.info['lowpass']
+    if 'fmax' not in psd_args:
+        psd_args['fmax'] = min(lp * 1.25, Nyquist)
+    plot_lowpass_edge = lp < Nyquist and (psd_args['fmax'] > lp)
+    psds, freqs = psd_multitaper(epochs_src, picks=picks, **psd_args)
+
+    def set_title_and_labels(ax, title, xlab, ylab):
+        if title:
+            ax.set_title(title)
+        if xlab:
+            ax.set_xlabel(xlab)
+        if ylab:
+            ax.set_ylabel(ylab)
+        ax.axis('auto')
+        ax.tick_params('both', labelsize=8)
+        ax.axis('tight')
+
+    # plot
+    # ----
+    all_fig = list()
+    for idx, pick in enumerate(picks):
+
+        # calculate component-specific spectrum stuff
+        psd_ylabel, psds_mean, spectrum_std = _get_psd_label_and_std(
+            psds[:, idx, :].copy(), dB, ica, num_std)
+
+        # if more than one component, spawn additional figures and axes
+        if idx > 0:
+            fig, axes = _create_properties_layout(figsize=figsize)
+
+        # we reconstruct an epoch_variance with 0 where indexes where dropped
+        epoch_var = np.var(ica_data[idx], axis=1)
+        drop_var = np.var(dropped_src[idx], axis=1)
+        drop_indices_corrected = \
+            (dropped_indices -
+             np.arange(len(dropped_indices))).astype(int)
+        epoch_var = np.insert(arr=epoch_var,
+                              obj=drop_indices_corrected,
+                              values=drop_var[dropped_indices],
+                              axis=0)
+
+        # the actual plot
+        fig = _plot_ica_properties(
+            pick, ica, inst, psds_mean, freqs, ica_data.shape[1],
+            epoch_var, plot_lowpass_edge,
+            epochs_src, set_title_and_labels, plot_std, psd_ylabel,
+            spectrum_std, topomap_args, image_args, fig, axes, kind,
+            dropped_indices)
+        all_fig.append(fig)
+
+    plt_show(show)
+    return all_fig
+
+
+def _prepare_data_ica_properties(inst, ica, reject_by_annotation=True,
+                                 reject='auto'):
+    from ..io.base import BaseRaw
+    from ..io import RawArray
+    from ..epochs import BaseEpochs
+
+    _validate_type(inst, (BaseRaw, BaseEpochs), "inst", "Raw or Epochs")
+    if isinstance(inst, BaseRaw):
+        # when auto, delegate reject to the ica
+        from ..epochs import make_fixed_length_epochs
+        if reject == 'auto':
+            reject = getattr(ica, 'reject_', None)
+        if reject is None:
+            drop_inds = None
+            dropped_indices = []
+            # break up continuous signal into segments
+            epochs_src = make_fixed_length_epochs(
+                ica.get_sources(inst),
+                duration=2,
+                preload=True,
+                reject_by_annotation=reject_by_annotation,
+                proj=False,
+                verbose=False)
+        else:
+            data = inst.get_data()
+            data, drop_inds = _reject_data_segments(data, ica.reject_,
+                                                    flat=None, decim=None,
+                                                    info=inst.info,
+                                                    tstep=2.0)
+            inst_rejected = RawArray(data, inst.info)
+            # break up continuous signal into segments
+            epochs_src = make_fixed_length_epochs(
+                ica.get_sources(inst_rejected),
+                duration=2,
+                preload=True,
+                reject_by_annotation=reject_by_annotation,
+                proj=False,
+                verbose=False)
+            # getting dropped epochs indexes
+            dropped_indices = [(d[0] // len(epochs_src.times)) + 1
+                               for d in drop_inds]
+        kind = "Segment"
+    else:
+        drop_inds = None
+        epochs_src = ica.get_sources(inst)
+        dropped_indices = []
+        kind = "Epochs"
+    return kind, dropped_indices, epochs_src, epochs_src.get_data()
 
 
 def _plot_ica_sources_evoked(evoked, picks, exclude, title, show, ica,

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -445,7 +445,7 @@ def _fast_plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
 
 def _prepare_data_ica_properties(inst, ica, reject_by_annotation=True,
                                  reject='auto'):
-    """Prepare Epochs sources to plot ICA properties
+    """Prepare Epochs sources to plot ICA properties.
 
     Parameters
     ----------

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -319,12 +319,14 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
     -----
     .. versionadded:: 0.13
     """
-    _fast_plot_ica_properties(ica, inst, picks=picks, axes=axes, dB=dB,
-                              plot_std=plot_std, topomap_args=topomap_args,
-                              image_args=image_args, psd_args=psd_args,
-                              figsize=figsize, show=show, reject=reject,
-                              reject_by_annotation=reject_by_annotation,
-                              verbose=verbose, precomputed_data=None)
+    return _fast_plot_ica_properties(ica, inst, picks=picks, axes=axes, dB=dB,
+                                     plot_std=plot_std,
+                                     topomap_args=topomap_args,
+                                     image_args=image_args, psd_args=psd_args,
+                                     figsize=figsize, show=show,
+                                     reject=reject,
+                                     reject_by_annotation=reject_by_annotation,
+                                     verbose=verbose, precomputed_data=None)
 
 
 def _fast_plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,


### PR DESCRIPTION
closes #9110 

@larsoner [suggestion](https://github.com/mne-tools/mne-python/pull/9134#issuecomment-803042712) in the PR #9134:

- precompute epochs ICA sources only once 

 Line profiler output for `_plot_ica_properties` and `_fast_plot_ica_properties`:

**Sample data**
<details>

```
<Raw | sample_audvis_raw.fif, 376 x 166800 (277.7 s), ~481.8 MB, data loaded> - sfreq = 600.614990234375

Total time: 0.539739 s
File: /mne-python/mne/viz/ica.py
Function: _plot_ica_properties at line 122

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   122                                           def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
   123                                                                    epoch_var, plot_lowpass_edge, epochs_src,
   124                                                                    set_title_and_labels, plot_std, psd_ylabel,
   125                                                                    spectrum_std, topomap_args, image_args, fig, axes,
   126                                                                    kind, dropped_indices):
   127                                               """Plot ICA properties (helper)."""
   128         1          0.0      0.0      2.0      from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
   129         1          0.0      0.0      0.0      from scipy.stats import gaussian_kde
   130                                           
   131         1          0.0      0.0      0.0      topo_ax, image_ax, erp_ax, spec_ax, var_ax = axes
   132                                           
   133                                               # plotting
   134                                               # --------
   135                                               # component topomap
   136         1          0.1      0.1     18.5      _plot_ica_topomap(ica, pick, show=False, axes=topo_ax, **topomap_args)
   137                                           
   138                                               # image and erp
   139                                               # we create a new epoch with dropped rows
   140         1          0.0      0.0      0.0      epoch_data = epochs_src.get_data()
   141         2          0.0      0.0      3.3      epoch_data = np.insert(arr=epoch_data,
   142         3          0.0      0.0      0.0                             obj=(dropped_indices -
   143         2          0.0      0.0      0.0                                  np.arange(len(dropped_indices))).astype(int),
   144         1          0.0      0.0      0.0                             values=0.0,
   145         1          0.0      0.0      0.0                             axis=0)
   146         1          0.0      0.0      0.0      from ..epochs import EpochsArray
   147         2          0.0      0.0      3.3      epochs_src = EpochsArray(epoch_data, epochs_src.info, tmin=epochs_src.tmin,
   148         1          0.0      0.0      0.0                               verbose=0)
   149                                           
   150         3          0.2      0.1     44.4      plot_epochs_image(epochs_src, picks=pick, axes=[image_ax, erp_ax],
   151         1          0.0      0.0      0.0                        combine=None, colorbar=False, show=False,
   152         1          0.0      0.0      0.0                        **image_args)
   153                                           
   154                                               # spectrum
   155         1          0.0      0.0      0.2      spec_ax.plot(freqs, psds_mean, color='k')
   156         1          0.0      0.0      0.0      if plot_std:
   157         2          0.0      0.0      0.3          spec_ax.fill_between(freqs, psds_mean - spectrum_std[0],
   158         1          0.0      0.0      0.0                               psds_mean + spectrum_std[1],
   159         1          0.0      0.0      0.0                               color='k', alpha=.2)
   160         1          0.0      0.0      0.0      if plot_lowpass_edge:
   161         2          0.0      0.0      0.6          spec_ax.axvline(inst.info['lowpass'], lw=2, linestyle='--',
   162         1          0.0      0.0      0.0                          color='k', alpha=0.2)
   163                                           
   164                                               # epoch variance
   165         1          0.0      0.0      0.0      var_ax_divider = make_axes_locatable(var_ax)
   166         1          0.0      0.0      8.9      hist_ax = var_ax_divider.append_axes("right", size="33%", pad="2.5%")
   167         2          0.0      0.0      0.6      var_ax.scatter(range(len(epoch_var)), epoch_var, alpha=0.5,
   168         1          0.0      0.0      0.0                     facecolor=[0, 0, 0], lw=0)
   169                                               # rejected epochs in red
   170         2          0.0      0.0      0.7      var_ax.scatter(dropped_indices, epoch_var[dropped_indices],
   171         1          0.0      0.0      0.0                     alpha=1., facecolor=[1, 0, 0], lw=0)
   172                                               # compute percentage of dropped epochs
   173         1          0.0      0.0      0.0      var_percent = float(len(dropped_indices)) / float(len(epoch_var)) * 100.
   174                                           
   175                                               # histogram & histogram
   176         2          0.0      0.0      2.8      _, counts, _ = hist_ax.hist(epoch_var, orientation="horizontal",
   177         1          0.0      0.0      0.0                                  color="k", alpha=.5)
   178                                           
   179                                               # kde
   180         1          0.0      0.0      0.3      ymin, ymax = hist_ax.get_ylim()
   181         1          0.0      0.0      0.0      try:
   182         1          0.0      0.0      0.1          kde = gaussian_kde(epoch_var)
   183                                               except np.linalg.LinAlgError:
   184                                                   pass  # singular: happens when there is nothing plotted
   185                                               else:
   186         1          0.0      0.0      0.0          x = np.linspace(ymin, ymax, 50)
   187         1          0.0      0.0      0.1          kde_ = kde(x)
   188         1          0.0      0.0      0.0          kde_ /= kde_.max() or 1.
   189         1          0.0      0.0      0.0          kde_ *= hist_ax.get_xlim()[-1] * .9
   190         1          0.0      0.0      0.2          hist_ax.plot(kde_, x, color="k")
   191         1          0.0      0.0      0.0          hist_ax.set_ylim(ymin, ymax)
   192                                           
   193                                               # aesthetics
   194                                               # ----------
   195         1          0.0      0.0      0.1      topo_ax.set_title(ica._ica_names[pick])
   196                                           
   197         1          0.0      0.0      1.8      set_title_and_labels(image_ax, kind + ' image and ERP/ERF', [], kind)
   198                                           
   199                                               # erp
   200         1          0.0      0.0      2.3      set_title_and_labels(erp_ax, [], 'Time (s)', 'AU')
   201         1          0.0      0.0      0.0      erp_ax.spines["right"].set_color('k')
   202         1          0.0      0.0      0.1      erp_ax.set_xlim(epochs_src.times[[0, -1]])
   203                                               # remove half of yticks if more than 5
   204         1          0.0      0.0      0.1      yt = erp_ax.get_yticks()
   205         1          0.0      0.0      0.0      if len(yt) > 5:
   206                                                   erp_ax.yaxis.set_ticks(yt[::2])
   207                                           
   208                                               # remove xticks - erp plot shows xticks for both image and erp plot
   209         1          0.0      0.0      0.0      image_ax.xaxis.set_ticks([])
   210         1          0.0      0.0      0.1      yt = image_ax.get_yticks()
   211         1          0.0      0.0      3.5      image_ax.yaxis.set_ticks(yt[1:])
   212         1          0.0      0.0      0.0      image_ax.set_ylim([-0.5, n_trials + 0.5])
   213                                           
   214                                               # spectrum
   215         1          0.0      0.0      1.7      set_title_and_labels(spec_ax, 'Spectrum', 'Frequency (Hz)', psd_ylabel)
   216         1          0.0      0.0      0.0      spec_ax.yaxis.labelpad = 0
   217         1          0.0      0.0      0.0      spec_ax.set_xlim(freqs[[0, -1]])
   218         1          0.0      0.0      0.0      ylim = spec_ax.get_ylim()
   219         1          0.0      0.0      0.0      air = np.diff(ylim)[0] * 0.1
   220         1          0.0      0.0      0.0      spec_ax.set_ylim(ylim[0] - air, ylim[1] + air)
   221         1          0.0      0.0      0.3      image_ax.axhline(0, color='k', linewidth=.5)
   222                                           
   223                                               # epoch variance
   224         1          0.0      0.0      0.0      var_ax_title = 'Dropped segments: %.2f %%' % var_percent
   225         1          0.0      0.0      1.9      set_title_and_labels(var_ax, var_ax_title, kind, 'Variance (AU)')
   226                                           
   227         1          0.0      0.0      0.0      hist_ax.set_ylabel("")
   228         1          0.0      0.0      0.0      hist_ax.set_yticks([])
   229         1          0.0      0.0      1.7      set_title_and_labels(hist_ax, None, None, None)
   230                                           
   231         1          0.0      0.0      0.0      return fig

Total time: 1.17649 s
File: /mne-python/mne/viz/ica.py
Function: _fast_plot_ica_properties at line 428

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   428                                           def _fast_plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
   429                                                                         plot_std=True, topomap_args=None, reject='auto',
   430                                                                         image_args=None, psd_args=None, figsize=None,
   431                                                                         show=True, reject_by_annotation=True,
   432                                                                         precomputed_data=None):
   433         1          0.0      0.0      0.0      from ..preprocessing import ICA
   434                                           
   435                                               # input checks and defaults
   436                                               # -------------------------
   437         1          0.0      0.0      0.0      _validate_type(ica, ICA, "ica", "ICA")
   438         1          0.0      0.0      0.0      _validate_type(plot_std, (bool, 'numeric'), 'plot_std')
   439         1          0.0      0.0      0.0      if isinstance(plot_std, bool):
   440         1          0.0      0.0      0.0          num_std = 1. if plot_std else 0.
   441                                               else:
   442                                                   plot_std = True
   443         1          0.0      0.0      0.0      num_std = float(plot_std)
   444                                           
   445                                               # if no picks given - plot the first 5 components
   446         1          0.0      0.0      0.0      limit = min(5, ica.n_components_) if picks is None else len(ica.ch_names)
   447         1          0.0      0.0      0.0      picks = _picks_to_idx(ica.info, picks, 'all')[:limit]
   448         1          0.0      0.0      0.0      if axes is None:
   449         1          0.4      0.4     32.8          fig, axes = _create_properties_layout(figsize=figsize)
   450                                               else:
   451                                                   if len(picks) > 1:
   452                                                       raise ValueError('Only a single pick can be drawn '
   453                                                                        'to a set of axes.')
   454                                                   from .utils import _validate_if_list_of_axes
   455                                                   _validate_if_list_of_axes(axes, obligatory_len=5)
   456                                                   fig = axes[0].get_figure()
   457                                           
   458         1          0.0      0.0      0.0      psd_args = dict() if psd_args is None else psd_args
   459         1          0.0      0.0      0.0      topomap_args = dict() if topomap_args is None else topomap_args
   460         1          0.0      0.0      0.0      image_args = dict() if image_args is None else image_args
   461         1          0.0      0.0      0.0      image_args["ts_args"] = dict(truncate_xaxis=False, show_sensors=False)
   462         1          0.0      0.0      0.0      if plot_std:
   463         1          0.0      0.0      0.0          from ..stats.parametric import _parametric_ci
   464         1          0.0      0.0      0.0          image_args["ts_args"]["ci"] = _parametric_ci
   465                                               elif "ts_args" not in image_args or "ci" not in image_args["ts_args"]:
   466                                                   image_args["ts_args"]["ci"] = False
   467                                           
   468         5          0.0      0.0      0.0      for item_name, item in (("psd_args", psd_args),
   469         1          0.0      0.0      0.0                              ("topomap_args", topomap_args),
   470         1          0.0      0.0      0.0                              ("image_args", image_args)):
   471         3          0.0      0.0      0.0          _validate_type(item, dict, item_name, "dictionary")
   472         1          0.0      0.0      0.0      if dB is not None:
   473         1          0.0      0.0      0.0          _validate_type(dB, bool, "dB", "bool")
   474                                           
   475                                               # calculations
   476                                               # ------------
   477         1          0.0      0.0      0.0      if isinstance(precomputed_data, tuple):
   478         1          0.0      0.0      0.0          kind, dropped_indices, epochs_src, data = precomputed_data
   479                                               else:
   480                                                   kind, dropped_indices, epochs_src, data = _prepare_data_ica_properties(
   481                                                       inst, ica, reject_by_annotation, reject)
   482         1          0.0      0.0      0.0      ica_data = np.swapaxes(data[:, picks, :], 0, 1)
   483         1          0.0      0.0      0.0      dropped_src = ica_data
   484                                           
   485                                               # spectrum
   486         1          0.0      0.0      0.0      Nyquist = inst.info['sfreq'] / 2.
   487         1          0.0      0.0      0.0      lp = inst.info['lowpass']
   488         1          0.0      0.0      0.0      if 'fmax' not in psd_args:
   489         1          0.0      0.0      0.0          psd_args['fmax'] = min(lp * 1.25, Nyquist)
   490         1          0.0      0.0      0.0      plot_lowpass_edge = lp < Nyquist and (psd_args['fmax'] > lp)
   491         1          0.2      0.2     18.2      psds, freqs = psd_multitaper(epochs_src, picks=picks, **psd_args)
   492                                           
   493         1          0.0      0.0      0.0      def set_title_and_labels(ax, title, xlab, ylab):
   494                                                   if title:
   495                                                       ax.set_title(title)
   496                                                   if xlab:
   497                                                       ax.set_xlabel(xlab)
   498                                                   if ylab:
   499                                                       ax.set_ylabel(ylab)
   500                                                   ax.axis('auto')
   501                                                   ax.tick_params('both', labelsize=8)
   502                                                   ax.axis('tight')
   503                                           
   504                                               # plot
   505                                               # ----
   506         1          0.0      0.0      0.0      all_fig = list()
   507         2          0.0      0.0      0.0      for idx, pick in enumerate(picks):
   508                                           
   509                                                   # calculate component-specific spectrum stuff
   510         2          0.0      0.0      2.8          psd_ylabel, psds_mean, spectrum_std = _get_psd_label_and_std(
   511         1          0.0      0.0      0.0              psds[:, idx, :].copy(), dB, ica, num_std)
   512                                           
   513                                                   # if more than one component, spawn additional figures and axes
   514         1          0.0      0.0      0.0          if idx > 0:
   515                                                       fig, axes = _create_properties_layout(figsize=figsize)
   516                                           
   517                                                   # we reconstruct an epoch_variance with 0 where indexes where dropped
   518         1          0.0      0.0      0.1          epoch_var = np.var(ica_data[idx], axis=1)
   519         1          0.0      0.0      0.0          drop_var = np.var(dropped_src[idx], axis=1)
   520         1          0.0      0.0      0.0          drop_indices_corrected = \
   521         3          0.0      0.0      0.0              (dropped_indices -
   522         2          0.0      0.0      0.0               np.arange(len(dropped_indices))).astype(int)
   523         2          0.0      0.0      0.0          epoch_var = np.insert(arr=epoch_var,
   524         1          0.0      0.0      0.0                                obj=drop_indices_corrected,
   525         1          0.0      0.0      0.0                                values=drop_var[dropped_indices],
   526         1          0.0      0.0      0.0                                axis=0)
   527                                           
   528                                                   # the actual plot
   529         2          0.5      0.3     46.1          fig = _plot_ica_properties(
   530         1          0.0      0.0      0.0              pick, ica, inst, psds_mean, freqs, ica_data.shape[1],
   531         1          0.0      0.0      0.0              epoch_var, plot_lowpass_edge,
   532         1          0.0      0.0      0.0              epochs_src, set_title_and_labels, plot_std, psd_ylabel,
   533         1          0.0      0.0      0.0              spectrum_std, topomap_args, image_args, fig, axes, kind,
   534         1          0.0      0.0      0.0              dropped_indices)
   535         1          0.0      0.0      0.0          all_fig.append(fig)
   536                                           
   537         1          0.0      0.0      0.0      plt_show(show)
   538         1          0.0      0.0      0.0      return all_fig

```

</details>

**Larger dataset**

<details>

```
<Raw | raw.fif, 346 x 1169000 (1169.0 s), ~3.02 GB, data loaded> - sfreq = 1000.0

Total time: 1.73026 s
File: /mne-python/mne/viz/ica.py
Function: _plot_ica_properties at line 122

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   122                                           def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
   123                                                                    epoch_var, plot_lowpass_edge, epochs_src,
   124                                                                    set_title_and_labels, plot_std, psd_ylabel,
   125                                                                    spectrum_std, topomap_args, image_args, fig, axes,
   126                                                                    kind, dropped_indices):
   127                                               """Plot ICA properties (helper)."""
   128         1          0.0      0.0      0.9      from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
   129         1          0.0      0.0      0.0      from scipy.stats import gaussian_kde
   130                                           
   131         1          0.0      0.0      0.0      topo_ax, image_ax, erp_ax, spec_ax, var_ax = axes
   132                                           
   133                                               # plotting
   134                                               # --------
   135                                               # component topomap
   136         1          0.2      0.2     10.8      _plot_ica_topomap(ica, pick, show=False, axes=topo_ax, **topomap_args)
   137                                           
   138                                               # image and erp
   139                                               # we create a new epoch with dropped rows
   140         1          0.0      0.0      0.0      epoch_data = epochs_src.get_data()
   141         2          0.2      0.1     12.0      epoch_data = np.insert(arr=epoch_data,
   142         3          0.0      0.0      0.0                             obj=(dropped_indices -
   143         2          0.0      0.0      0.0                                  np.arange(len(dropped_indices))).astype(int),
   144         1          0.0      0.0      0.0                             values=0.0,
   145         1          0.0      0.0      0.0                             axis=0)
   146         1          0.0      0.0      0.0      from ..epochs import EpochsArray
   147         2          0.1      0.0      3.4      epochs_src = EpochsArray(epoch_data, epochs_src.info, tmin=epochs_src.tmin,
   148         1          0.0      0.0      0.0                               verbose=0)
   149                                           
   150         3          0.9      0.3     50.0      plot_epochs_image(epochs_src, picks=pick, axes=[image_ax, erp_ax],
   151         1          0.0      0.0      0.0                        combine=None, colorbar=False, show=False,
   152         1          0.0      0.0      0.0                        **image_args)
   153                                           
   154                                               # spectrum
   155         1          0.0      0.0      0.4      spec_ax.plot(freqs, psds_mean, color='k')
   156         1          0.0      0.0      0.0      if plot_std:
   157         2          0.0      0.0      0.4          spec_ax.fill_between(freqs, psds_mean - spectrum_std[0],
   158         1          0.0      0.0      0.0                               psds_mean + spectrum_std[1],
   159         1          0.0      0.0      0.0                               color='k', alpha=.2)
   160         1          0.0      0.0      0.0      if plot_lowpass_edge:
   161         2          0.0      0.0      0.7          spec_ax.axvline(inst.info['lowpass'], lw=2, linestyle='--',
   162         1          0.0      0.0      0.0                          color='k', alpha=0.2)
   163                                           
   164                                               # epoch variance
   165         1          0.0      0.0      0.0      var_ax_divider = make_axes_locatable(var_ax)
   166         1          0.1      0.1      6.5      hist_ax = var_ax_divider.append_axes("right", size="33%", pad="2.5%")
   167         2          0.0      0.0      0.6      var_ax.scatter(range(len(epoch_var)), epoch_var, alpha=0.5,
   168         1          0.0      0.0      0.0                     facecolor=[0, 0, 0], lw=0)
   169                                               # rejected epochs in red
   170         2          0.0      0.0      0.3      var_ax.scatter(dropped_indices, epoch_var[dropped_indices],
   171         1          0.0      0.0      0.0                     alpha=1., facecolor=[1, 0, 0], lw=0)
   172                                               # compute percentage of dropped epochs
   173         1          0.0      0.0      0.0      var_percent = float(len(dropped_indices)) / float(len(epoch_var)) * 100.
   174                                           
   175                                               # histogram & histogram
   176         2          0.1      0.0      3.0      _, counts, _ = hist_ax.hist(epoch_var, orientation="horizontal",
   177         1          0.0      0.0      0.0                                  color="k", alpha=.5)
   178                                           
   179                                               # kde
   180         1          0.0      0.0      0.3      ymin, ymax = hist_ax.get_ylim()
   181         1          0.0      0.0      0.0      try:
   182         1          0.0      0.0      0.4          kde = gaussian_kde(epoch_var)
   183                                               except np.linalg.LinAlgError:
   184                                                   pass  # singular: happens when there is nothing plotted
   185                                               else:
   186         1          0.0      0.0      0.0          x = np.linspace(ymin, ymax, 50)
   187         1          0.0      0.0      0.4          kde_ = kde(x)
   188         1          0.0      0.0      0.0          kde_ /= kde_.max() or 1.
   189         1          0.0      0.0      0.0          kde_ *= hist_ax.get_xlim()[-1] * .9
   190         1          0.0      0.0      0.3          hist_ax.plot(kde_, x, color="k")
   191         1          0.0      0.0      0.0          hist_ax.set_ylim(ymin, ymax)
   192                                           
   193                                               # aesthetics
   194                                               # ----------
   195         1          0.0      0.0      0.1      topo_ax.set_title(ica._ica_names[pick])
   196                                           
   197         1          0.0      0.0      2.1      set_title_and_labels(image_ax, kind + ' image and ERP/ERF', [], kind)
   198                                           
   199                                               # erp
   200         1          0.0      0.0      1.4      set_title_and_labels(erp_ax, [], 'Time (s)', 'AU')
   201         1          0.0      0.0      0.0      erp_ax.spines["right"].set_color('k')
   202         1          0.0      0.0      0.1      erp_ax.set_xlim(epochs_src.times[[0, -1]])
   203                                               # remove half of yticks if more than 5
   204         1          0.0      0.0      0.1      yt = erp_ax.get_yticks()
   205         1          0.0      0.0      0.0      if len(yt) > 5:
   206                                                   erp_ax.yaxis.set_ticks(yt[::2])
   207                                           
   208                                               # remove xticks - erp plot shows xticks for both image and erp plot
   209         1          0.0      0.0      0.0      image_ax.xaxis.set_ticks([])
   210         1          0.0      0.0      0.0      yt = image_ax.get_yticks()
   211         1          0.0      0.0      2.5      image_ax.yaxis.set_ticks(yt[1:])
   212         1          0.0      0.0      0.0      image_ax.set_ylim([-0.5, n_trials + 0.5])
   213                                           
   214                                               # spectrum
   215         1          0.0      0.0      0.6      set_title_and_labels(spec_ax, 'Spectrum', 'Frequency (Hz)', psd_ylabel)
   216         1          0.0      0.0      0.0      spec_ax.yaxis.labelpad = 0
   217         1          0.0      0.0      0.0      spec_ax.set_xlim(freqs[[0, -1]])
   218         1          0.0      0.0      0.0      ylim = spec_ax.get_ylim()
   219         1          0.0      0.0      0.0      air = np.diff(ylim)[0] * 0.1
   220         1          0.0      0.0      0.0      spec_ax.set_ylim(ylim[0] - air, ylim[1] + air)
   221         1          0.0      0.0      0.1      image_ax.axhline(0, color='k', linewidth=.5)
   222                                           
   223                                               # epoch variance
   224         1          0.0      0.0      0.0      var_ax_title = 'Dropped segments: %.2f %%' % var_percent
   225         1          0.0      0.0      1.0      set_title_and_labels(var_ax, var_ax_title, kind, 'Variance (AU)')
   226                                           
   227         1          0.0      0.0      0.0      hist_ax.set_ylabel("")
   228         1          0.0      0.0      0.0      hist_ax.set_yticks([])
   229         1          0.0      0.0      1.3      set_title_and_labels(hist_ax, None, None, None)
   230                                           
   231         1          0.0      0.0      0.0      return fig

Total time: 4.20749 s
File: /mne-python/mne/viz/ica.py
Function: _fast_plot_ica_properties at line 428

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   428                                           def _fast_plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
   429                                                                         plot_std=True, topomap_args=None, reject='auto',
   430                                                                         image_args=None, psd_args=None, figsize=None,
   431                                                                         show=True, reject_by_annotation=True,
   432                                                                         precomputed_data=None):
   433         1          0.0      0.0      0.0      from ..preprocessing import ICA
   434                                           
   435                                               # input checks and defaults
   436                                               # -------------------------
   437         1          0.0      0.0      0.0      _validate_type(ica, ICA, "ica", "ICA")
   438         1          0.0      0.0      0.0      _validate_type(plot_std, (bool, 'numeric'), 'plot_std')
   439         1          0.0      0.0      0.0      if isinstance(plot_std, bool):
   440         1          0.0      0.0      0.0          num_std = 1. if plot_std else 0.
   441                                               else:
   442                                                   plot_std = True
   443         1          0.0      0.0      0.0      num_std = float(plot_std)
   444                                           
   445                                               # if no picks given - plot the first 5 components
   446         1          0.0      0.0      0.0      limit = min(5, ica.n_components_) if picks is None else len(ica.ch_names)
   447         1          0.0      0.0      0.0      picks = _picks_to_idx(ica.info, picks, 'all')[:limit]
   448         1          0.0      0.0      0.0      if axes is None:
   449         1          1.6      1.6     37.5          fig, axes = _create_properties_layout(figsize=figsize)
   450                                               else:
   451                                                   if len(picks) > 1:
   452                                                       raise ValueError('Only a single pick can be drawn '
   453                                                                        'to a set of axes.')
   454                                                   from .utils import _validate_if_list_of_axes
   455                                                   _validate_if_list_of_axes(axes, obligatory_len=5)
   456                                                   fig = axes[0].get_figure()
   457                                           
   458         1          0.0      0.0      0.0      psd_args = dict() if psd_args is None else psd_args
   459         1          0.0      0.0      0.0      topomap_args = dict() if topomap_args is None else topomap_args
   460         1          0.0      0.0      0.0      image_args = dict() if image_args is None else image_args
   461         1          0.0      0.0      0.0      image_args["ts_args"] = dict(truncate_xaxis=False, show_sensors=False)
   462         1          0.0      0.0      0.0      if plot_std:
   463         1          0.0      0.0      0.0          from ..stats.parametric import _parametric_ci
   464         1          0.0      0.0      0.0          image_args["ts_args"]["ci"] = _parametric_ci
   465                                               elif "ts_args" not in image_args or "ci" not in image_args["ts_args"]:
   466                                                   image_args["ts_args"]["ci"] = False
   467                                           
   468         5          0.0      0.0      0.0      for item_name, item in (("psd_args", psd_args),
   469         1          0.0      0.0      0.0                              ("topomap_args", topomap_args),
   470         1          0.0      0.0      0.0                              ("image_args", image_args)):
   471         3          0.0      0.0      0.0          _validate_type(item, dict, item_name, "dictionary")
   472         1          0.0      0.0      0.0      if dB is not None:
   473         1          0.0      0.0      0.0          _validate_type(dB, bool, "dB", "bool")
   474                                           
   475                                               # calculations
   476                                               # ------------
   477         1          0.0      0.0      0.0      if isinstance(precomputed_data, tuple):
   478         1          0.0      0.0      0.0          kind, dropped_indices, epochs_src, data = precomputed_data
   479                                               else:
   480                                                   kind, dropped_indices, epochs_src, data = _prepare_data_ica_properties(
   481                                                       inst, ica, reject_by_annotation, reject)
   482         1          0.0      0.0      0.1      ica_data = np.swapaxes(data[:, picks, :], 0, 1)
   483         1          0.0      0.0      0.0      dropped_src = ica_data
   484                                           
   485                                               # spectrum
   486         1          0.0      0.0      0.0      Nyquist = inst.info['sfreq'] / 2.
   487         1          0.0      0.0      0.0      lp = inst.info['lowpass']
   488         1          0.0      0.0      0.0      if 'fmax' not in psd_args:
   489         1          0.0      0.0      0.0          psd_args['fmax'] = min(lp * 1.25, Nyquist)
   490         1          0.0      0.0      0.0      plot_lowpass_edge = lp < Nyquist and (psd_args['fmax'] > lp)
   491         1          0.7      0.7     17.4      psds, freqs = psd_multitaper(epochs_src, picks=picks, **psd_args)
   492                                           
   493         1          0.0      0.0      0.0      def set_title_and_labels(ax, title, xlab, ylab):
   494                                                   if title:
   495                                                       ax.set_title(title)
   496                                                   if xlab:
   497                                                       ax.set_xlabel(xlab)
   498                                                   if ylab:
   499                                                       ax.set_ylabel(ylab)
   500                                                   ax.axis('auto')
   501                                                   ax.tick_params('both', labelsize=8)
   502                                                   ax.axis('tight')
   503                                           
   504                                               # plot
   505                                               # ----
   506         1          0.0      0.0      0.0      all_fig = list()
   507         2          0.0      0.0      0.0      for idx, pick in enumerate(picks):
   508                                           
   509                                                   # calculate component-specific spectrum stuff
   510         2          0.1      0.0      2.3          psd_ylabel, psds_mean, spectrum_std = _get_psd_label_and_std(
   511         1          0.0      0.0      0.1              psds[:, idx, :].copy(), dB, ica, num_std)
   512                                           
   513                                                   # if more than one component, spawn additional figures and axes
   514         1          0.0      0.0      0.0          if idx > 0:
   515                                                       fig, axes = _create_properties_layout(figsize=figsize)
   516                                           
   517                                                   # we reconstruct an epoch_variance with 0 where indexes where dropped
   518         1          0.0      0.0      0.1          epoch_var = np.var(ica_data[idx], axis=1)
   519         1          0.0      0.0      0.2          drop_var = np.var(dropped_src[idx], axis=1)
   520         1          0.0      0.0      0.0          drop_indices_corrected = \
   521         3          0.0      0.0      0.0              (dropped_indices -
   522         2          0.0      0.0      0.0               np.arange(len(dropped_indices))).astype(int)
   523         2          0.0      0.0      0.0          epoch_var = np.insert(arr=epoch_var,
   524         1          0.0      0.0      0.0                                obj=drop_indices_corrected,
   525         1          0.0      0.0      0.0                                values=drop_var[dropped_indices],
   526         1          0.0      0.0      0.0                                axis=0)
   527                                           
   528                                                   # the actual plot
   529         2          1.8      0.9     42.2          fig = _plot_ica_properties(
   530         1          0.0      0.0      0.0              pick, ica, inst, psds_mean, freqs, ica_data.shape[1],
   531         1          0.0      0.0      0.0              epoch_var, plot_lowpass_edge,
   532         1          0.0      0.0      0.0              epochs_src, set_title_and_labels, plot_std, psd_ylabel,
   533         1          0.0      0.0      0.0              spectrum_std, topomap_args, image_args, fig, axes, kind,
   534         1          0.0      0.0      0.0              dropped_indices)
   535         1          0.0      0.0      0.0          all_fig.append(fig)
   536                                           
   537         1          0.0      0.0      0.0      plt_show(show)
   538         1          0.0      0.0      0.0      return all_fig

Total time: 90.1535 s
File: /mne-python/mne/viz/ica.py
Function: _prepare_data_ica_properties at line 541

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   541                                           def _prepare_data_ica_properties(inst, ica, reject_by_annotation=True,
   542                                                                            reject='auto'):
   543         1          0.0      0.0      0.0      from ..io.base import BaseRaw
   544         1          0.0      0.0      0.0      from ..io import RawArray
   545         1          0.0      0.0      0.0      from ..epochs import BaseEpochs
   546                                           
   547         1          0.0      0.0      0.0      _validate_type(inst, (BaseRaw, BaseEpochs), "inst", "Raw or Epochs")
   548         1          0.0      0.0      0.0      if isinstance(inst, BaseRaw):
   549                                                   # when auto, delegate reject to the ica
   550         1          0.0      0.0      0.0          from ..epochs import make_fixed_length_epochs
   551         1          0.0      0.0      0.0          if reject == 'auto':
   552         1          0.0      0.0      0.0              reject = getattr(ica, 'reject_', None)
   553         1          0.0      0.0      0.0          if reject is None:
   554         1          0.0      0.0      0.0              drop_inds = None
   555         1          0.0      0.0      0.0              dropped_indices = []
   556                                                       # break up continuous signal into segments
   557         2          0.9      0.4      1.0              epochs_src = make_fixed_length_epochs(
   558         1         89.3     89.3     99.0                  ica.get_sources(inst),
   559         1          0.0      0.0      0.0                  duration=2,
   560         1          0.0      0.0      0.0                  preload=True,
   561         1          0.0      0.0      0.0                  reject_by_annotation=reject_by_annotation,
   562         1          0.0      0.0      0.0                  proj=False,
   563         1          0.0      0.0      0.0                  verbose=False)
   564                                                   else:
   565                                                       data = inst.get_data()
   566                                                       data, drop_inds = _reject_data_segments(data, ica.reject_,
   567                                                                                               flat=None, decim=None,
   568                                                                                               info=inst.info,
   569                                                                                               tstep=2.0)
   570                                                       inst_rejected = RawArray(data, inst.info)
   571                                                       # break up continuous signal into segments
   572                                                       epochs_src = make_fixed_length_epochs(
   573                                                           ica.get_sources(inst_rejected),
   574                                                           duration=2,
   575                                                           preload=True,
   576                                                           reject_by_annotation=reject_by_annotation,
   577                                                           proj=False,
   578                                                           verbose=False)
   579                                                       # getting dropped epochs indexes
   580                                                       dropped_indices = [(d[0] // len(epochs_src.times)) + 1
   581                                                                          for d in drop_inds]
   582         1          0.0      0.0      0.0          kind = "Segment"
   583                                               else:
   584                                                   drop_inds = None
   585                                                   epochs_src = ica.get_sources(inst)
   586                                                   dropped_indices = []
   587                                                   kind = "Epochs"
   588         1          0.0      0.0      0.0      return kind, dropped_indices, epochs_src, epochs_src.get_data()
```

</details>

`_prepare_data_ica_properties`  take 90s for the larger dataset, and `_fast_plot_ica_properties` takes about 4s.