### PR TITLE
MRG: Test fnirs channel structures for chromophore data

### DIFF
--- a/mne/preprocessing/nirs/_beer_lambert_law.py
+++ b/mne/preprocessing/nirs/_beer_lambert_law.py
@@ -12,7 +12,7 @@ from ...io import BaseRaw
 from ...io.constants import FIFF
 from ...utils import _validate_type
 from ..nirs import source_detector_distances, _channel_frequencies,\
-    _check_channels_ordered
+    _check_channels_ordered, _channel_chromophore
 
 
 def beer_lambert_law(raw, ppf=0.1):
@@ -55,6 +55,9 @@ def beer_lambert_law(raw, ppf=0.1):
             raw.rename_channels({
                 ch['ch_name']: '%s %s' % (ch['ch_name'][:-4], kind)})
 
+    # Validate the format of data after transformation is valid
+    chroma = np.unique(_channel_chromophore(raw))
+    _check_channels_ordered(raw, chroma)
     return raw
 
 

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -85,7 +85,7 @@ def _check_channels_ordered(raw, pair_vals):
     # All wavelength based fNIRS data.
     picks_wave = _picks_to_idx(raw.info, ['fnirs_cw_amplitude', 'fnirs_od'],
                                exclude=[], allow_empty=True)
-    # All chromaphore fNIRS data
+    # All chromophore fNIRS data
     picks_chroma = _picks_to_idx(raw.info, ['hbo', 'hbr'],
                                  exclude=[], allow_empty=True)
     # All continuous wave fNIRS data

--- a/mne/preprocessing/nirs/tests/test_nirs.py
+++ b/mne/preprocessing/nirs/tests/test_nirs.py
@@ -314,7 +314,7 @@ def test_fnirs_channel_naming_and_order_custom_optical_density():
 
 def test_fnirs_channel_naming_and_order_custom_chroma():
     """Ensure fNIRS channel checking on manually created data."""
-    data = np.random.normal(size=(6, 10))
+    data = np.random.RandomState(0).randn(6, 10)
 
     # Start with a correctly named raw intensity dataset
     # These are the steps required to build an fNIRS Raw object from scratch


### PR DESCRIPTION
#### Reference issue
Preparation for #9141 


#### What does this implement/fix?
Adds checking of fNIRs channel naming structure for data after transformation to chromophore.

Previously all testing was done on the raw data or after transformation to optical density. But with possibility of people creating their own data structures without the readers I have added additional error checking for the hbo/hbr data type.


#### Additional information
This is the last addition I have planned in preparation for #9141 
