### PR TITLE
MRG: Support µV in EDF files (in addition to uV)

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -19,6 +19,8 @@ Current (0.23.dev0)
 
 .. |New Contributor| replace:: **New Contributor**
 
+.. |Sumalyo Datta| replace:: **Sumalyo Datta**
+
 .. |Anna Padee| replace:: **Anna Padee**
 
 .. |Richard Koehler| replace:: **Richard Koehler**
@@ -157,6 +159,8 @@ Enhancements
 
 Bugs
 ~~~~
+- Fix bug with :func:`mne.io.read_raw_edf` where new symbols for interpreting data in microvolt was added (:gh:`9187` **by new contributor** |Sumalyo Datta|_ )
+
 - Fix bug with :func:`mne.viz.plot_compare_evokeds` did not check type of combine. (:gh:`9151` **by new contributor** |Matteo Anelli|_)
                                         
 - Fix bug with :func:`mne.viz.plot_evoked_topo` where ``ylim`` was only being applied to the first channel in the dataset (:gh:`9162` **by new contributor** |Ram Pari|_ )

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -159,7 +159,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Fix bug with :func:`mne.io.read_raw_edf` where new symbols for interpreting data in microvolt was added (:gh:`9187` **by new contributor** |Sumalyo Datta|_ )
+- Fix bug with :func:`mne.io.read_raw_edf` where µV was not correctly recognized (:gh:`9187` **by new contributor** |Sumalyo Datta|_)
 
 - Fix bug with :func:`mne.viz.plot_compare_evokeds` did not check type of combine. (:gh:`9151` **by new contributor** |Matteo Anelli|_)
                                         

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -383,3 +383,5 @@
 .. _Ram Pari: https://github.com/ramkpari
 
 .. _Erica Peterson: https://github.com/nordme
+
+.. _Sumalyo Datta: https://github.com/Sumalyo

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1452,4 +1452,3 @@ def _get_annotations_gdf(edf_info, sfreq):
         desc = events[2]
 
     return onset, duration, desc
-

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -615,6 +615,9 @@ def _read_edf_header(fname, exclude):
                 continue
             if unit == 'uV':
                 edf_info['units'].append(1e-6)
+            if unit == 'V':
+                warn('Unit given in file is Volts(V), please check file and/or adjust processing if necessary')
+                edf_info['units'].append(1)
             elif unit == 'mV':
                 edf_info['units'].append(1e-3)
             else:

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -616,11 +616,11 @@ def _read_edf_header(fname, exclude):
             if unit == 'uV':
                 edf_info['units'].append(1e-6)
             if unit == 'V':
-                warn('Unit given in file is Volts(V), please check file and/or adjust processing if necessary')
                 edf_info['units'].append(1)
             elif unit == 'mV':
                 edf_info['units'].append(1e-3)
             else:
+                warn('Unit not recognized, treated as Volts(V)')
                 edf_info['units'].append(1)
         edf_info['units'] = np.array(edf_info['units'], float)
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1452,4 +1452,4 @@ def _get_annotations_gdf(edf_info, sfreq):
         desc = events[2]
 
     return onset, duration, desc
-    
+

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -613,14 +613,14 @@ def _read_edf_header(fname, exclude):
         for i, unit in enumerate(units):
             if i in exclude:
                 continue
-            if unit == 'uV':
-                edf_info['units'].append(1e-6)
-            if unit == 'V':
+            elif unit == 'V':
                 edf_info['units'].append(1)
             elif unit == 'mV':
                 edf_info['units'].append(1e-3)
+            elif unit == 'uV':
+                edf_info['units'].append(1e-6)
             else:
-                warn('Unit not recognized, treated as Volts(V)')
+                warn(f'Unit "{unit}" not recognized, no scale used')
                 edf_info['units'].append(1)
         edf_info['units'] = np.array(edf_info['units'], float)
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -613,14 +613,11 @@ def _read_edf_header(fname, exclude):
         for i, unit in enumerate(units):
             if i in exclude:
                 continue
-            elif unit == 'V':
-                edf_info['units'].append(1)
+            if unit in ('uV', 'µV', 'µV'):
+                edf_info['units'].append(1e-6)
             elif unit == 'mV':
                 edf_info['units'].append(1e-3)
-            elif unit == 'uV':
-                edf_info['units'].append(1e-6)
             else:
-                warn(f'Unit "{unit}" not recognized, no scale used')
                 edf_info['units'].append(1)
         edf_info['units'] = np.array(edf_info['units'], float)
 
@@ -1455,3 +1452,4 @@ def _get_annotations_gdf(edf_info, sfreq):
         desc = events[2]
 
     return onset, duration, desc
+    


### PR DESCRIPTION
This shows a warning if edf file data is given in Volts as mentioned in the issue discussions. Though it interprets the data in Volts, it informs the data about a possible problem in scaling. Fixes #9186.