### PR TITLE
STY: website fixes

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -48,6 +48,7 @@ iframe.sg_report {
 /* gallery thumbnail size */
 .sphx-glr-thumbcontainer {
     min-width: 160px;
+    height: 250px;
 }
 
 /* ******************************** make HTML'd pandas dataframes scrollable */

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -45,6 +45,10 @@ iframe.sg_report {
     display: block;
     border-style: solid;
 }
+/* gallery thumbnail size */
+.sphx-glr-thumbcontainer {
+    min-width: 160px;
+}
 
 /* ******************************** make HTML'd pandas dataframes scrollable */
 output_html {


### PR DESCRIPTION
1. fixes the too-narrow thumbnail for MNE-Reports tutorial
2. fixes the too-short thumbnail container that causes tutorial title text to get hidden below the next row's image sometimes