### PR TITLE
Enable welcome bot

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,21 @@
+# Configuration for welcome - https://github.com/behaviorbot/welcome
+
+# Configuration for new-issue-welcome - https://github.com/behaviorbot/new-issue-welcome
+
+# Comment to be posted to on first time issues
+newIssueWelcomeComment: >
+  Hello! 👋 Thanks for opening your first issue here! ❤️ We will try to get back to you soon. 🚴🏽‍♂️
+
+# Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
+
+# Comment to be posted to on PRs from first time contributors in your repository
+newPRWelcomeComment: >
+  Hello! 👋  Thanks for opening your first pull request here! ❤️ We will try to get back to you soon. 🚴🏽‍♂️
+
+# Configuration for first-pr-merge - https://github.com/behaviorbot/first-pr-merge
+
+# Comment to be posted to on pull requests merged by a first time user
+firstPRMergeComment: >
+  🎉 Congrats on merging your first pull request! 🥳 Looking forward to seeing more from you in the future! 💪
+
+# It is recommended to include as many gifs and emojis as possible!

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -10,7 +10,7 @@ newIssueWelcomeComment: >
 
 # Comment to be posted to on PRs from first time contributors in your repository
 newPRWelcomeComment: >
-  Hello! 👋  Thanks for opening your first pull request here! ❤️ We will try to get back to you soon. 🚴🏽‍♂️
+  Hello! 👋 Thanks for opening your first pull request here! ❤️ We will try to get back to you soon. 🚴🏽‍♂️
 
 # Configuration for first-pr-merge - https://github.com/behaviorbot/first-pr-merge
 


### PR DESCRIPTION
As mentioned a while ago in https://github.com/mne-tools/mne-python/issues/8221#issuecomment-738695038,
here's an attempt to enable to "welcome bot" for this repo

https://github.com/apps/welcome

I've granted the bot the requested access rights to our repo (clicked the respective button), but I cannot verify whether this worked out properly, as I don't seem to have permissions to review access rights. 


cc @cbrnr @drammock 