### PR TITLE
add support for microvolt units

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -613,7 +613,8 @@ def _read_edf_header(fname, exclude):
         for i, unit in enumerate(units):
             if i in exclude:
                 continue
-            if unit in ('uV', 'µV', 'µV'):
+            if unit in ('\u03BCV','\u00B5V','uV'):
+                #unicode symbols for microvolt
                 edf_info['units'].append(1e-6)
             elif unit == 'mV':
                 edf_info['units'].append(1e-3)

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -613,8 +613,8 @@ def _read_edf_header(fname, exclude):
         for i, unit in enumerate(units):
             if i in exclude:
                 continue
-            if unit in ('\u03BCV','\u00B5V','uV'):
-                #unicode symbols for microvolt
+            # allow both μ (greek mu) and µ (micro symbol) codepoints
+            if unit in ('\u03BCV', '\u00B5V', 'uV'):
                 edf_info['units'].append(1e-6)
             elif unit == 'mV':
                 edf_info['units'].append(1e-3)


### PR DESCRIPTION
This PR explicitly uses Unicode characters to specify the different symbols for microvolt in mne.io.read_raw_edf in order to add support for the units