### PR TITLE
MRG: Check that fnirs types are not mixed

### DIFF
--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -93,8 +93,8 @@ def _check_channels_ordered(raw, pair_vals):
 
     if (len(picks_wave) > 0) & (len(picks_chroma) > 0):
         raise ValueError(
-            'MNE does not support a combination of raw, optical density'
-            ', and haemoglobin data in the same raw structure.')
+            'MNE does not support a combination of amplitude, optical '
+            'density, and haemoglobin data in the same raw structure.')
 
     if len(picks_cw) % 2 != 0:
         raise ValueError(

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -91,6 +91,11 @@ def _check_channels_ordered(raw, pair_vals):
     # All continuous wave fNIRS data
     picks_cw = np.hstack([picks_chroma, picks_wave])
 
+    if (len(picks_wave) > 0) & (len(picks_chroma) > 0):
+        raise ValueError(
+            'MNE does not support a combination of raw, optical density'
+            ', and haemoglobin data in the same raw structure.')
+
     if len(picks_cw) % 2 != 0:
         raise ValueError(
             'NIRS channels not ordered correctly. An even number of NIRS '

--- a/mne/preprocessing/nirs/tests/test_nirs.py
+++ b/mne/preprocessing/nirs/tests/test_nirs.py
@@ -311,6 +311,16 @@ def test_fnirs_channel_naming_and_order_custom_optical_density():
     raw.pick(picks=[0, 3, 1, 4, 2, 5])
     _check_channels_ordered(raw, [760, 850])
 
+    # Check that if you mix types you get an error
+    ch_names = ['S1_D1 hbo', 'S1_D1 hbr', 'S2_D1 hbo', 'S2_D1 hbr',
+                'S3_D1 hbo', 'S3_D1 hbr']
+    ch_types = np.tile(["hbo", "hbr"], 3)
+    info = create_info(ch_names=ch_names, ch_types=ch_types, sfreq=1.0)
+    raw2 = RawArray(data, info, verbose=True)
+    raw.add_channels([raw2])
+    with pytest.raises(ValueError, match='does not support a combination'):
+        _check_channels_ordered(raw, [760, 850])
+
 
 def test_fnirs_channel_naming_and_order_custom_chroma():
     """Ensure fNIRS channel checking on manually created data."""


### PR DESCRIPTION
#### Reference issue
None. Just general improvements to error throwing.


#### What does this implement/fix?
It does not make sense to have a combination of certain fnirs data types in the same raw object. For example you shouldn't have optical density and oxyhemoglobin data together. This just adds a check for that.

