### PR TITLE
CI: Cancel GH Actions jobs after 90 min max

### DIFF
--- a/.github/workflows/codespell_and_flake.yml
+++ b/.github/workflows/codespell_and_flake.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   style:
+    timeout-minutes: 90
     runs-on: ubuntu-20.04
     env:
       CODESPELL_DIRS: 'mne/ doc/ tutorials/ examples/'

--- a/.github/workflows/compat_minimal.yml
+++ b/.github/workflows/compat_minimal.yml
@@ -24,6 +24,7 @@ jobs:
 
   # Minimal (runs with and without testing data)
   job:
+    timeout-minutes: 90
     needs: check_skip
     if: ${{ needs.check_skip.outputs.skip == 'false' }}
     name: 'py3.7'

--- a/.github/workflows/compat_old.yml
+++ b/.github/workflows/compat_old.yml
@@ -24,6 +24,7 @@ jobs:
 
   # Old dependencies
   job:
+    timeout-minutes: 90
     needs: check_skip
     if: ${{ needs.check_skip.outputs.skip == 'false' }}
     name: 'py3.6'

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -24,6 +24,7 @@ jobs:
 
   # Linux
   job:
+    timeout-minutes: 90
     needs: check_skip
     if: ${{ needs.check_skip.outputs.skip == 'false' }}
     name: 'py3.8'

--- a/.github/workflows/linux_pip.yml
+++ b/.github/workflows/linux_pip.yml
@@ -24,6 +24,7 @@ jobs:
 
   # PIP-pre + non-default stim channel + log level info
   job:
+    timeout-minutes: 90
     needs: check_skip
     if: ${{ needs.check_skip.outputs.skip == 'false' }}
     name: 'py3.9'

--- a/.github/workflows/macos_conda.yml
+++ b/.github/workflows/macos_conda.yml
@@ -23,6 +23,7 @@ jobs:
           commit-filter-separator: ';'
 
   job:
+    timeout-minutes: 90
     needs: check_skip
     if: ${{ needs.check_skip.outputs.skip == 'false' }}
     name: 'py3.8'


### PR DESCRIPTION
In hope to prevent future stale CI jobs from blocking the queue again
Doesn't affect all jobs, only those where we've seen stalling