### PR TITLE
FIX: don't use op.realpath when reading raw

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -782,7 +782,7 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None):
     _validate_type(fname, 'path-like', 'fname')
     fname = _check_fname(
         fname, overwrite='read', must_exist=True,
-        allow_dir=str(fname).endswith('.ds'),  # allow_dir for CTF
+        need_dir=str(fname).endswith('.ds'),  # for CTF
         name='fname')
     name = op.basename(fname)
     if name.endswith(('fif', 'fif.gz')):

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -8,7 +8,7 @@ import datetime
 import calendar
 
 from .utils import _load_mne_locs, _read_pos
-from ...utils import logger, warn, verbose
+from ...utils import logger, warn, verbose, _check_fname
 from ..utils import _read_segments_file
 from ..base import BaseRaw
 from ..meas_info import _empty_info
@@ -308,6 +308,7 @@ class RawArtemis123(BaseRaw):
         from scipy.spatial.distance import cdist
         from ...chpi import (compute_chpi_amplitudes, compute_chpi_locs,
                              _fit_coil_order_dev_head_trans)
+        input_fname = _check_fname(input_fname, 'read', True, 'input_fname')
         fname, ext = op.splitext(input_fname)
         if ext == '.txt':
             input_fname = fname + '.bin'

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1394,7 +1394,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         or all forms of SSS). It is recommended not to concatenate and
         then save raw files for this reason.
         """
-        fname = op.realpath(fname)
+        fname = op.abspath(fname)
         endings = ('raw.fif', 'raw_sss.fif', 'raw_tsss.fif',
                    '_meg.fif', '_eeg.fif', '_ieeg.fif')
         endings += tuple([f'{e}.gz' for e in endings])

--- a/mne/io/boxy/boxy.py
+++ b/mne/io/boxy/boxy.py
@@ -9,7 +9,7 @@ import numpy as np
 from ..base import BaseRaw
 from ..meas_info import create_info
 from ..utils import _mult_cal_one
-from ...utils import logger, verbose, fill_doc
+from ...utils import logger, verbose, fill_doc, _check_fname
 from ...annotations import Annotations
 
 
@@ -65,6 +65,7 @@ class RawBOXY(BaseRaw):
         raw_extras = dict()
         raw_extras['offsets'] = list()  # keep track of our offsets
         sfreq = None
+        fname = _check_fname(fname, 'read', True, 'fname')
         with open(fname, 'r') as fid:
             line_num = 0
             i_line = fid.readline()

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -6,13 +6,12 @@
 # License: BSD (3-clause)
 
 import os
-import os.path as op
 
 import numpy as np
 
 from .._digitization import _format_dig_points
 from ...utils import (verbose, logger, _clean_names, fill_doc, _check_option,
-                      _validate_type)
+                      _check_fname)
 
 from ..base import BaseRaw
 from ..utils import _mult_cal_one, _blk_read_lims
@@ -91,13 +90,11 @@ class RawCTF(BaseRaw):
     def __init__(self, directory, system_clock='truncate', preload=False,
                  verbose=None, clean_names=False):  # noqa: D102
         # adapted from mne_ctf2fiff.c
-        _validate_type(directory, 'path-like', 'directory')
-        directory = str(directory)
+        directory = _check_fname(directory, 'read', True, 'directory',
+                                 need_dir=True)
         if not directory.endswith('.ds'):
             raise TypeError('directory must be a directory ending with ".ds", '
                             f'got {directory}')
-        if not op.isdir(directory):
-            raise ValueError('directory does not exist: "%s"' % directory)
         _check_option('system_clock', system_clock, ['ignore', 'truncate'])
         logger.info('ds directory : %s' % directory)
         res4 = _read_res4(directory)  # Read the magical res4 file

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -220,12 +220,14 @@ def test_read_ctf(tmpdir):
             assert_allclose(raw.annotations.onset, [2.15])
             assert_allclose(raw.annotations.duration, [0.0225])
 
-    pytest.raises(TypeError, read_raw_ctf, 1)
-    pytest.raises(ValueError, read_raw_ctf, ctf_fname_continuous + 'foo.ds')
+    with pytest.raises(TypeError, match='path-like'):
+        read_raw_ctf(1)
+    with pytest.raises(FileNotFoundError, match='does not exist'):
+        read_raw_ctf(ctf_fname_continuous + 'foo.ds')
     # test ignoring of system clock
     read_raw_ctf(op.join(ctf_dir, ctf_fname_continuous), 'ignore')
-    pytest.raises(ValueError, read_raw_ctf,
-                  op.join(ctf_dir, ctf_fname_continuous), 'foo')
+    with pytest.raises(ValueError, match='system_clock'):
+        read_raw_ctf(op.join(ctf_dir, ctf_fname_continuous), 'foo')
 
 
 @testing.requires_testing_data

--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -63,7 +63,7 @@ def _get_curry_file_structure(fname, required=()):
     """Store paths to a dict and check for required files."""
     _msg = "The following required files cannot be found: {0}.\nPlease make " \
            "sure all required files are located in the same directory as {1}."
-    _check_fname(fname, overwrite='read', must_exist=True)
+    fname = _check_fname(fname, 'read', True, 'fname')
 
     # we don't use os.path.splitext to also handle extensions like .cdt.dpa
     fname_base, ext = fname.split(".", maxsplit=1)

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -12,7 +12,7 @@ from ..utils import _read_segments_file, _find_channels
 from ..constants import FIFF
 from ..meas_info import create_info
 from ..base import BaseRaw
-from ...utils import logger, verbose, warn, fill_doc, Bunch
+from ...utils import logger, verbose, warn, fill_doc, Bunch, _check_fname
 from ...channels import make_dig_montage
 from ...epochs import BaseEpochs
 from ...event import read_events
@@ -22,7 +22,7 @@ from ...annotations import Annotations, read_annotations
 CAL = 1e-6
 
 
-def _check_fname(fname, dataname):
+def _check_eeglab_fname(fname, dataname):
     """Check whether the filename is valid.
 
     Check if the file extension is ``.fdt`` (older ``.dat`` being invalid) or
@@ -314,6 +314,7 @@ class RawEEGLAB(BaseRaw):
     @verbose
     def __init__(self, input_fname, eog=(),
                  preload=False, uint16_codec=None, verbose=None):  # noqa: D102
+        input_fname = _check_fname(input_fname, 'read', True, 'input_fname')
         eeg = _check_load_mat(input_fname, uint16_codec)
         if eeg.trials != 1:
             raise TypeError('The number of trials is %d. It must be 1 for raw'
@@ -325,7 +326,7 @@ class RawEEGLAB(BaseRaw):
 
         # read the data
         if isinstance(eeg.data, str):
-            data_fname = _check_fname(input_fname, eeg.data)
+            data_fname = _check_eeglab_fname(input_fname, eeg.data)
             logger.info('Reading %s' % data_fname)
 
             super(RawEEGLAB, self).__init__(
@@ -510,7 +511,7 @@ class EpochsEEGLAB(BaseEpochs):
                                  '(event id %i)' % (key, val))
 
         if isinstance(eeg.data, str):
-            data_fname = _check_fname(input_fname, eeg.data)
+            data_fname = _check_eeglab_fname(input_fname, eeg.data)
             with open(data_fname, 'rb') as data_fid:
                 data = np.fromfile(data_fid, dtype=np.float32)
                 data = data.reshape((eeg.nbchan, eeg.pnts, eeg.trials),

--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -14,7 +14,7 @@ from ..base import BaseRaw
 from ..utils import _read_segments_file, _create_chs
 from ..meas_info import _empty_info
 from ..constants import FIFF
-from ...utils import verbose, logger, warn, _validate_type
+from ...utils import verbose, logger, warn, _validate_type, _check_fname
 
 
 def _read_header(fid):
@@ -152,7 +152,6 @@ def read_raw_egi(input_fname, eog=None, misc=None,
     """
     _validate_type(input_fname, 'path-like', 'input_fname')
     input_fname = str(input_fname)
-
     if input_fname.endswith('.mff'):
         return _read_raw_egi_mff(input_fname, eog, misc, include,
                                  exclude, preload, channel_naming, verbose)
@@ -167,6 +166,7 @@ class RawEGI(BaseRaw):
     def __init__(self, input_fname, eog=None, misc=None,
                  include=None, exclude=None, preload=False,
                  channel_naming='E%d', verbose=None):  # noqa: D102
+        input_fname = _check_fname(input_fname, 'read', True, 'input_fname')
         if eog is None:
             eog = []
         if misc is None:

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -19,7 +19,7 @@ from ..meas_info import _empty_info, create_info
 from ..proj import setup_proj
 from ..utils import _create_chs, _mult_cal_one
 from ...annotations import Annotations
-from ...utils import verbose, logger, warn, _check_option
+from ...utils import verbose, logger, warn, _check_option, _check_fname
 from ...evoked import EvokedArray
 
 
@@ -398,6 +398,8 @@ class RawMff(BaseRaw):
                  include=None, exclude=None, preload=False,
                  channel_naming='E%d', verbose=None):
         """Init the RawMff class."""
+        input_fname = _check_fname(input_fname, 'read', True, 'input_fname',
+                                   need_dir=True)
         logger.info('Reading EGI MFF Header from %s...' % input_fname)
         egi_info = _read_header(input_fname)
         if eog is None:

--- a/mne/io/eximia/eximia.py
+++ b/mne/io/eximia/eximia.py
@@ -8,7 +8,7 @@ import os.path as op
 from ..base import BaseRaw
 from ..utils import _read_segments_file, _file_size
 from ..meas_info import create_info
-from ...utils import logger, verbose, warn, fill_doc
+from ...utils import logger, verbose, warn, fill_doc, _check_fname
 
 
 @fill_doc
@@ -52,6 +52,7 @@ class RawEximia(BaseRaw):
 
     @verbose
     def __init__(self, fname, preload=False, verbose=None):
+        fname = _check_fname(fname, 'read', True, 'fname')
         data_name = op.basename(fname)
         logger.info('Loading %s' % data_name)
         # Create vhdr and vmrk files so that we can use mne_brain_vision2fiff

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -144,7 +144,6 @@ class Raw(BaseRaw):
                 endings += tuple([f'{e}.gz' for e in endings])
                 check_fname(fname, 'raw', endings)
             # filename
-            fname = op.realpath(fname)
             ext = os.path.splitext(fname)[1].lower()
             whole_file = preload if '.gz' in ext else False
             del ext

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -25,7 +25,7 @@ from ...annotations import Annotations, _read_annotations_fif
 
 from ...event import AcqParserFIF
 from ...utils import (check_fname, logger, verbose, warn, fill_doc, _file_like,
-                      _on_missing)
+                      _on_missing, _check_fname)
 
 
 @fill_doc
@@ -75,13 +75,13 @@ class Raw(BaseRaw):
     def __init__(self, fname, allow_maxshield=False, preload=False,
                  on_split_missing='raise', verbose=None):  # noqa: D102
         raws = []
-        do_check_fname = not _file_like(fname)
+        do_check_ext = not _file_like(fname)
         next_fname = fname
         while next_fname is not None:
             raw, next_fname, buffer_size_sec = \
                 self._read_raw_file(next_fname, allow_maxshield,
-                                    preload, do_check_fname)
-            do_check_fname = False
+                                    preload, do_check_ext)
+            do_check_ext = False
             raws.append(raw)
             if next_fname is not None:
                 if not op.exists(next_fname):
@@ -132,18 +132,19 @@ class Raw(BaseRaw):
 
     @verbose
     def _read_raw_file(self, fname, allow_maxshield, preload,
-                       do_check_fname=True, verbose=None):
+                       do_check_ext=True, verbose=None):
         """Read in header information from a raw file."""
         logger.info('Opening raw data file %s...' % fname)
 
         #   Read in the whole file if preload is on and .fif.gz (saves time)
         if not _file_like(fname):
-            if do_check_fname:
+            if do_check_ext:
                 endings = ('raw.fif', 'raw_sss.fif', 'raw_tsss.fif',
                            '_meg.fif', '_eeg.fif', '_ieeg.fif')
                 endings += tuple([f'{e}.gz' for e in endings])
                 check_fname(fname, 'raw', endings)
             # filename
+            fname = _check_fname(fname, 'read', True, 'fname')
             ext = os.path.splitext(fname)[1].lower()
             whole_file = preload if '.gz' in ext else False
             del ext

--- a/mne/io/nedf/nedf.py
+++ b/mne/io/nedf/nedf.py
@@ -10,7 +10,7 @@ import numpy as np
 from ..base import BaseRaw
 from ..meas_info import create_info
 from ..utils import _mult_cal_one
-from ...utils import warn, verbose
+from ...utils import warn, verbose, _check_fname
 
 
 def _getsubnodetext(node, name):
@@ -131,6 +131,7 @@ class RawNedf(BaseRaw):
     """Raw object from NeuroElectrics nedf file."""
 
     def __init__(self, filename, preload=False, verbose=None):
+        filename = _check_fname(filename, 'read', True, 'filename')
         with open(filename, mode='rb') as fid:
             header = fid.read(_HDRLEN)
         header, dt, dt_last, n_samp, n_full = _parse_nedf_header(header)

--- a/mne/io/nihon/nihon.py
+++ b/mne/io/nihon/nihon.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import numpy as np
 
-from ...utils import fill_doc, logger, verbose, warn
+from ...utils import fill_doc, logger, verbose, warn, _check_fname
 from ..base import BaseRaw
 from ..meas_info import create_info
 from ...annotations import Annotations
@@ -308,6 +308,7 @@ class RawNihon(BaseRaw):
 
     @verbose
     def __init__(self, fname, preload=False, verbose=None):
+        fname = _check_fname(fname, 'read', True, 'fname')
         fname = _ensure_path(fname)
         data_name = fname.name
         logger.info('Loading %s' % data_name)

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -16,7 +16,8 @@ from ..constants import FIFF
 from ..meas_info import create_info, _format_dig_points
 from ...annotations import Annotations
 from ...transforms import apply_trans, _get_trans
-from ...utils import logger, verbose, fill_doc, warn
+from ...utils import (logger, verbose, fill_doc, warn, _check_fname,
+                      _validate_type)
 
 
 @fill_doc
@@ -69,12 +70,12 @@ class RawNIRX(BaseRaw):
         from ...externals.pymatreader import read_mat
         from ...coreg import get_mni_fiducials  # avoid circular import prob
         logger.info('Loading %s' % fname)
-
+        _validate_type(fname, 'path-like', 'fname')
+        fname = str(fname)
         if fname.endswith('.hdr'):
             fname = op.dirname(op.abspath(fname))
 
-        if not op.isdir(fname):
-            raise FileNotFoundError('The path you specified does not exist.')
+        fname = _check_fname(fname, 'read', True, 'fname', need_dir=True)
 
         # Check if required files exist and store names for later use
         files = dict()

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -46,7 +46,7 @@ def test_nirx_hdr_load():
 @requires_testing_data
 def test_nirx_missing_warn():
     """Test reading NIRX files when missing data."""
-    with pytest.raises(FileNotFoundError, match='The path you'):
+    with pytest.raises(FileNotFoundError, match='does not exist'):
         read_raw_nirx(fname_nirx_15_2_short + "1", preload=True)
 
 

--- a/mne/io/persyst/persyst.py
+++ b/mne/io/persyst/persyst.py
@@ -13,7 +13,7 @@ from ..constants import FIFF
 from ..meas_info import create_info
 from ..utils import _mult_cal_one
 from ...annotations import Annotations
-from ...utils import logger, verbose, fill_doc, warn
+from ...utils import logger, verbose, fill_doc, warn, _check_fname
 
 
 @fill_doc
@@ -65,6 +65,7 @@ class RawPersyst(BaseRaw):
 
     @verbose
     def __init__(self, fname, preload=False, verbose=None):
+        fname = _check_fname(fname, 'read', True, 'fname')
         logger.info('Loading %s' % fname)
 
         # make sure filename is the Lay file

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -10,7 +10,7 @@ from ..base import BaseRaw
 from ..meas_info import create_info
 from ..utils import _mult_cal_one
 from ...annotations import Annotations
-from ...utils import logger, verbose, fill_doc, warn
+from ...utils import logger, verbose, fill_doc, warn, _check_fname
 from ...utils.check import _require_version
 from ..constants import FIFF
 from .._digitization import _make_dig_points
@@ -69,6 +69,7 @@ class RawSNIRF(BaseRaw):
         from ...externals.pymatreader.utils import _import_h5py
         h5py = _import_h5py()
 
+        fname = _check_fname(fname, 'read', True, 'fname')
         logger.info('Loading %s' % fname)
 
         with h5py.File(fname, 'r') as dat:

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -35,7 +35,7 @@ def test_check(tmpdir):
     """Test checking functions."""
     pytest.raises(ValueError, check_random_state, 'foo')
     pytest.raises(TypeError, _check_fname, 1)
-    _check_fname(Path('./'))
+    _check_fname(Path('./foo'))
     fname = str(tmpdir.join('foo'))
     with open(fname, 'wb'):
         pass


### PR DESCRIPTION
closes #9221 

This one-line fix is almost certainly too simplistic and will probably break something, so I'm hoping for some intense scrutiny here.  Here's my understanding of the problem and solution(?):

1. `datalad` uses `git-annex` to manage large data files (`datalad` is the recommended access method for OpenNeuro, so it's really something we should support)
2. for split raw files, this poses a problem because when the first raw is loaded, we call `os.path.realpath()` on the filename, so something like `sub-01/ses-day1/meg/sub-01_ses-day1_task-AVLearn_run-01_part-01_meg.fif` becomes `/home/user/Desktop/test-datalad/ds002598/.git/annex/objects/Xz/5P/MD5E-s2146079382--dca9c1e4ee05b6b32bdcd4b5aef8c9bb.fif/MD5E-s2146079382--dca9c1e4ee05b6b32bdcd4b5aef8c9bb.fif`
3. that works fine for singleton raw files, but for split files, we determine whether it's split based on the original fname, but then go looking for the subsequent parts based on the `realpath`-transformed fname.

my solution is to just not call `realpath()`.  Doing so doesn't seem to hurt much as far as I can tell; I can still load sample data, and after creating a symlink on my desktop to a random `.fif` file on another drive, passing the symlink into `read_raw()` loads it just fine.

The only case I can think of where this will break something that previously worked, is if you had this:
```console
$ tree bar
bar
├── foo
│   ├── qux_part-01_meg.fif
│   └── qux_part-02_meg.fif
└── qux_part-01_meg.fif -> foo/qux_part-01_meg.fif
```
...and you tried to load the symlink in `bar`.  This would fail because now we would look for `...part-02...` in `bar/` instead of in `bar/foo/`.  But honestly that seems like an edge case that we shouldn't support anyway --- allowing users to access all parts of a split raw by providing a symlink to just the first part (when symlinks to the other parts aren't also present).