### PR TITLE
fix API parameter column width [skip github][skip azp]

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -8,6 +8,11 @@
 
 }
 
+/* ************************************************************ Sphinx fixes */
+dl.field-list {
+    grid-template-columns: auto 1fr;
+}
+
 /* ********************************************************** Sphinx-gallery */
 
 /* backreference links: restore hover decoration that SG removes */


### PR DESCRIPTION
closes #9222 

The CSS controlling this is inherited from sphinx.  It works the same on, e.g., [the pandas site](https://pandas.pydata.org/docs/reference/api/pandas.array.html) but is less of a problem there because their default font size is one px smaller than ours, and possibly also because their preferred font is Lato instead of Source Sans Pro (I think Lato is slightly lighter / has tighter spacing). This solution fixes the problem of the colon being wrapped even with full-width windows. It does not fix the problem of `Parameters:` becoming
```
Pa
ra
me
te
rs:
```
when the window is narrowed. For that, adjustments to the theme's media breakpoints would be required, and it should really be fixed in the theme rather than overridden here.