### PR TITLE
bugfix in eegbci.py

### DIFF
--- a/mne/datasets/eegbci/eegbci.py
+++ b/mne/datasets/eegbci/eegbci.py
@@ -182,5 +182,7 @@ def standardize(raw):
             std_name = std_name[:-1] + 'z'
         if std_name.startswith('FP'):
             std_name = 'Fp' + std_name[2:]
+        if std_name.endswith('H'):
+            std_name = std_name[:-1] + 'h'
         rename[name] = std_name
     raw.rename_channels(rename)


### PR DESCRIPTION
Bug fix
---
standardize() function corrected: 
The channel names in montage = mne.channels.make_standard_montage('standard_1005') are end with small h and not H.
