### PR TITLE
MAINT: Work around PyVista change

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1491,7 +1491,11 @@ class Brain(object):
         del mesh
 
         # from the picked renderer to the subplot coords
-        rindex = self._renderer._all_renderers.index(self.picked_renderer)
+        try:
+            lst = self._renderer._all_renderers._renderers
+        except AttributeError:
+            lst = self._renderer._all_renderers
+        rindex = lst.index(self.picked_renderer)
         row, col = self._renderer._index_to_loc(rindex)
 
         actors = list()

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -305,6 +305,7 @@ class _Renderer(_AbstractRenderer):
             vals = _alpha_blend_background(ctable, bgcolor)
             cbar_lut.table.from_array(vals)
             cmap.scalar_bar.lookup_table = cbar_lut
+        return bar
 
     def show(self):
         if self.fig is not None:

--- a/tutorials/source-modeling/plot_mne_dspm_source_localization.py
+++ b/tutorials/source-modeling/plot_mne_dspm_source_localization.py
@@ -40,7 +40,6 @@ epochs = mne.Epochs(raw, events, event_id, tmin, tmax, proj=True,
 ###############################################################################
 # Compute regularized noise covariance
 # ------------------------------------
-#
 # For more details see :ref:`tut_compute_covariance`.
 
 noise_cov = mne.compute_covariance(


### PR DESCRIPTION
Deal with the [CircleCI failures on main](https://app.circleci.com/pipelines/github/mne-tools/mne-python/7622/workflows/138e0f79-b04d-4fa3-ab02-74d4bea59ddf/jobs/26701/tests#failed-test-0) of the form:
```
Traceback (most recent call last):
  File "/home/circleci/project/mne/viz/_3d.py", line 1780, in plot_source_estimates
    return _plot_stc(
  File "/home/circleci/project/mne/viz/_3d.py", line 1958, in _plot_stc
    brain.setup_time_viewer(time_viewer=time_viewer,
  File "/home/circleci/project/mne/viz/_brain/_brain.py", line 658, in setup_time_viewer
    self._configure_dock()
  File "/home/circleci/project/mne/viz/_brain/_brain.py", line 1111, in _configure_dock
    self._configure_dock_trace_widget(name="Trace")
  File "/home/circleci/project/mne/viz/_brain/_brain.py", line 1088, in _configure_dock_trace_widget
    _set_annot('None')
  File "/home/circleci/project/mne/viz/_brain/_brain.py", line 1052, in _set_annot
    self._configure_vertex_time_course()
  File "/home/circleci/project/mne/viz/_brain/_brain.py", line 1201, in _configure_vertex_time_course
    self._add_vertex_glyph(hemi, mesh, vertex_id)
  File "/home/circleci/project/mne/viz/_brain/_brain.py", line 1494, in _add_vertex_glyph
    rindex = self._renderer._all_renderers.index(self.picked_renderer)
AttributeError: 'Renderers' object has no attribute 'index'
```
Looks like it's from https://github.com/pyvista/pyvista/pull/1242