### PR TITLE
MAINT: Add linkcheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,12 @@
 #   issues using "Rerun with SSH")
 
 version: 2.1
+
+_xvfb: &xvfb
+  name: Start Xvfb virtual framebuffer
+  command: |
+    /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1280x1024x24 -ac +extension GLX +render -noreset -nolisten tcp -nolisten unix
+
 jobs:
     build_docs:
       docker:
@@ -66,9 +72,7 @@ jobs:
               fi
 
         - run:
-            name: Spin up Xvfb
-            command: |
-              /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
+            <<: *xvfb
 
         # https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
         # https://github.com/golemfactory/golem/issues/1019
@@ -466,6 +470,8 @@ jobs:
                 echo "Skip detected, exiting job ${CIRCLE_JOB}."
                 circleci-agent step halt;
               fi
+        - run:
+            <<: *xvfb
         - restore_cache:
             keys:
               - pip-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,8 +366,6 @@ jobs:
                 echo "Skip detected, exiting job ${CIRCLE_JOB}."
                 circleci-agent step halt;
               fi
-        - run:
-            <<: *xvfb
         - restore_cache:
             keys:
               - pip-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
-# Tagging a commit with [circle front] will build the front page and perform test-doc.
-# Tagging a commit with [circle full] will build everything.
+# Tagging a commit with:
+# - [circle front] will build the front page and perform test-doc
+# - [circle full] will build everything
+# - [circle linkcheck] will run our linkcheck
+# - [circle interactive] will run our test suite (useful for debugging issues
+#   using "Rerun with SSH")
+
 version: 2
 jobs:
     build_docs:
@@ -21,6 +26,14 @@ jobs:
             key: source-cache
             paths:
               - ".git"
+        - run:
+            name: Check-skip
+            command: |
+              export COMMIT_MESSAGE=$(git log --format=oneline -n 1);
+              if [[ "$COMMIT_MESSAGE" == *"[skip circle]"* ]] || [[ "$COMMIT_MESSAGE" == *"[circle skip]"* ]]; then
+                echo "Skip detected, exiting job ${CIRCLE_JOB}."
+                circleci-agent step halt;
+              fi
         - run:
             name: Set BASH_ENV
             command: |
@@ -336,16 +349,28 @@ jobs:
     linkcheck:
       # there are a few files excluded from this for expediency, see Makefile
       docker:
-        - image: circleci/python:3.6-jessie
+        - image: circleci/python:3.9.2-buster
+      parameters:
+        scheduled:
+          type: string
+          default: "false"
       steps:
         - checkout
+        - run:
+            name: Check-skip
+            command: |
+              export COMMIT_MESSAGE=$(git log --format=oneline -n 1);
+              if [[ "$COMMIT_MESSAGE" != *"[circle linkcheck]"* ]] && [ "<< parameters.scheduled >>" != "true" ]; then
+                echo "Skip detected, exiting job ${CIRCLE_JOB}."
+                circleci-agent step halt;
+              fi
         - run:
             name: pip install dependencies
             command: |
                set -e;
                python -m pip install --user --progress-bar off numpy scipy matplotlib pillow
                python -m pip install --user -e .
-               python -m pip install --user --progress-bar off -r requirements_doc.txt
+               python -m pip install --user --progress-bar off -r requirements_doc.txt -r requirements_testing.txt
         - run:
             name: make linkcheck
             command: |
@@ -373,9 +398,25 @@ jobs:
             keys:
               - website-cache
         - run:
-            name: Fetch docs
+            name: Set BASH_ENV
             command: |
               set -e
+              echo "set -e" >> $BASH_ENV
+        # Don't try to deploy if nothing is there or not on the right branch
+        - run:
+            name: Check docs
+            command: |
+              if [ "${CIRCLE_BRANCH}" == "main" ] || [ "${CIRCLE_BRANCH}" == "maint/0.22" ]; then
+                echo "No deployment (build: ${CIRCLE_BRANCH}).";
+                circleci-agent step halt;
+              fi;
+              if [ ! -f /tmp/build/html/index.html ] && [ ! -f /tmp/build/html_stable/index.html ]; then
+                echo "No files found to upload (build: ${CIRCLE_BRANCH}).";
+                circleci-agent step halt;
+              fi;
+        - run:
+            name: Fetch docs
+            command: |
               mkdir -p ~/.ssh
               echo -e "Host *\nStrictHostKeyChecking no" > ~/.ssh/config
               chmod og= ~/.ssh/config
@@ -385,33 +426,28 @@ jobs:
         - run:
             name: Deploy docs
             command: |
-              set -e;
-              if [ "${CIRCLE_BRANCH}" == "main" ] || [ "${CIRCLE_BRANCH}" == "maint/0.22" ]; then
-                git config --global user.email "circle@mne.com";
-                git config --global user.name "Circle CI";
-                cd ~/mne-tools.github.io;
-                git checkout main
-                git remote -v
-                git fetch origin
-                git reset --hard origin/main
-                git clean -xdf
-                if [ "${CIRCLE_BRANCH}" == "main" ]; then
-                  echo "Deploying dev docs for ${CIRCLE_BRANCH}.";
-                  rm -Rf dev;
-                  cp -a /tmp/build/html dev;
-                  git add -A;
-                  git commit -m "CircleCI update of dev docs (${CIRCLE_BUILD_NUM}).";
-                else
-                  echo "Deploying stable docs for ${CIRCLE_BRANCH}.";
-                  rm -Rf stable;
-                  cp -a /tmp/build/html_stable stable;
-                  git add -A;
-                  git commit -m "CircleCI update of stable docs (${CIRCLE_BUILD_NUM}).";
-                fi;
-                git push origin main;
+              git config --global user.email "circle@mne.com";
+              git config --global user.name "Circle CI";
+              cd ~/mne-tools.github.io;
+              git checkout main
+              git remote -v
+              git fetch origin
+              git reset --hard origin/main
+              git clean -xdf
+              if [ "${CIRCLE_BRANCH}" == "main" ]; then
+                echo "Deploying dev docs for ${CIRCLE_BRANCH}.";
+                rm -Rf dev;
+                cp -a /tmp/build/html dev;
+                git add -A;
+                git commit -m "CircleCI update of dev docs (${CIRCLE_BUILD_NUM}).";
               else
-                echo "No deployment (build: ${CIRCLE_BRANCH}).";
-              fi
+                echo "Deploying stable docs for ${CIRCLE_BRANCH}.";
+                rm -Rf stable;
+                cp -a /tmp/build/html_stable stable;
+                git add -A;
+                git commit -m "CircleCI update of stable docs (${CIRCLE_BUILD_NUM}).";
+              fi;
+              git push origin main;
         - save_cache:
             key: website-cache
             paths:
@@ -420,16 +456,36 @@ jobs:
 
     interactive_test:
       docker:
-        - image: circleci/python:3.8.5-buster
+        - image: circleci/python:3.9.2-buster
       steps:
         - checkout
         - run:
+            name: Set BASH_ENV
+            command: |
+              set -e
+              echo "set -e" >> $BASH_ENV
+        - run:
+            name: Check-skip
+            command: |
+              export COMMIT_MESSAGE=$(git log --format=oneline -n 1);
+              if [[ "$COMMIT_MESSAGE" != *"[circle interactive_test]"* ]]; then
+                echo "Skip detected, exiting job ${CIRCLE_JOB}."
+                circleci-agent step halt;
+              fi
+        - run:
             name: Get Python running
             command: |
-              python -m pip install --user --upgrade --progress-bar off pip setuptools
-              python -m pip install -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" --pre numpy
-              python -m pip install -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" scipy pandas scikit-learn matplotlib h5py Pillow
-              python -m pip install -r requirements_testing.txt
+              python -m pip install --progress-bar off --upgrade "pip!=20.3.0" setuptools wheel
+              python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl
+              python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" --extra-index-url https://www.riverbankcomputing.com/pypi/simple numpy scipy pandas scikit-learn PyQt5
+              python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py pillow matplotlib
+              python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" numba llvmlite
+              wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
+              python -m pip install --progress-bar off vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
+              python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
+              python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
+              python -m pip install --progress-bar off --upgrade -r requirements_testing.txt
+              python -m pip install nitime
               python -m pip install --user -e .
 
         # Look at what we have and fail early if there is some library conflict
@@ -458,6 +514,8 @@ workflows:
   default:
     jobs:
       - build_docs
+      - linkcheck
+      - interactive_test
       - deploy:
           requires:
             - build_docs
@@ -466,11 +524,11 @@ workflows:
               only:
                 - main
                 - maint/0.22
-      # interactive_test
 
   weekly:
     jobs:
-      - linkcheck
+      - linkcheck:
+          scheduled: "true"
     triggers:
       - schedule:
           # "At 00:00 on Sunday" should be often enough

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@
 # - [circle front] will build the front page and perform test-doc
 # - [circle full] will build everything
 # - [circle linkcheck] will run our linkcheck
-# - [circle interactive] will run our test suite (useful for debugging issues
-#   using "Rerun with SSH")
+# - [circle interactive_test] will run our test suite (useful for debugging
+#   issues using "Rerun with SSH")
 
 version: 2.1
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 # - [circle interactive] will run our test suite (useful for debugging issues
 #   using "Rerun with SSH")
 
-version: 2
+version: 2.1
 jobs:
     build_docs:
       docker:
@@ -349,9 +349,6 @@ jobs:
     linkcheck:
       # there are a few files excluded from this for expediency, see Makefile
       parameters:
-        scheduled:
-          type: string
-          default: "false"
       docker:
         - image: circleci/python:3.9.2-buster
       steps:
@@ -363,8 +360,8 @@ jobs:
             name: Check-skip
             command: |
               export COMMIT_MESSAGE=$(git log --format=oneline -n 1);
-              if [[ "$COMMIT_MESSAGE" != *"[circle linkcheck]"* ]] && [ "<< parameters.scheduled >>" != "true" ]; then
-                echo "Skip detected, exiting job ${CIRCLE_JOB}."
+              if [[ "$COMMIT_MESSAGE" != *"[circle linkcheck]"* ]] && [ "$CIRCLE_WORKFLOW_ID" != "weekly" ]; then
+                echo "Skip detected, exiting job ${CIRCLE_JOB} with commit message '$COMMIT_MESSAGE' and CIRCLE_WORKFLOW_ID=$CIRCLE_WORKFLOW_ID."
                 circleci-agent step halt;
               fi
         - run:
@@ -515,8 +512,6 @@ jobs:
               pytest -m "not ultraslowtest" mne -xv
 
 workflows:
-  version: 2.1
-
   default:
     jobs:
       - build_docs
@@ -533,8 +528,7 @@ workflows:
 
   weekly:
     jobs:
-      - linkcheck:
-          scheduled: "true"
+      - linkcheck
     triggers:
       - schedule:
           # "At 00:00 on Sunday" should be often enough

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,6 +469,7 @@ jobs:
             command: |
               set -e
               echo "set -e" >> $BASH_ENV
+              echo "export OPENBLAS_NUM_THREADS=1" >> $BASH_ENV
               mkdir -p ~/mne_data
         - run:
             name: Check-skip
@@ -501,7 +502,7 @@ jobs:
         - run:
             name: pytest
             command: |
-              pytest -m "not ultraslowtest" mne -xv
+              pytest -m "not slowtest" mne -xv
 
 workflows:
   default:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,9 +373,6 @@ jobs:
         - restore_cache:
             keys:
               - pip-cache
-        - restore_cache:
-            keys:
-              - user-install-bin-cache
         - run:
             name: Get Python running
             command: |
@@ -491,9 +488,6 @@ jobs:
         - restore_cache:
             keys:
               - pip-cache
-        - restore_cache:
-            keys:
-              - user-install-bin-cache
         - run:
             name: Get Python running
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ version: 2.1
 _xvfb: &xvfb
   name: Start Xvfb virtual framebuffer
   command: |
-    sudo apt install xvfb
+    echo "export DISPLAY=:99" >> $BASH_ENV
     /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1280x1024x24 -ac +extension GLX +render -noreset -nolisten tcp -nolisten unix
 
 jobs:
@@ -46,7 +46,6 @@ jobs:
             command: |
               set -e
               echo "set -e" >> $BASH_ENV
-              echo "export DISPLAY=:99" >> $BASH_ENV
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
               echo "export XDG_RUNTIME_DIR=/tmp/runtime-circleci" >> $BASH_ENV
               echo "export MNE_FULL_DATE=true" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,6 +349,9 @@ jobs:
     linkcheck:
       # there are a few files excluded from this for expediency, see Makefile
       parameters:
+        scheduled:
+          type: string
+          default: "false"
       docker:
         - image: circleci/python:3.9.2-buster
       steps:
@@ -360,8 +363,8 @@ jobs:
             name: Check-skip
             command: |
               export COMMIT_MESSAGE=$(git log --format=oneline -n 1);
-              if [[ "$COMMIT_MESSAGE" != *"[circle linkcheck]"* ]] && [ "$CIRCLE_WORKFLOW_ID" != "weekly" ]; then
-                echo "Skip detected, exiting job ${CIRCLE_JOB} with commit message '$COMMIT_MESSAGE' and CIRCLE_WORKFLOW_ID=$CIRCLE_WORKFLOW_ID."
+              if [[ "$COMMIT_MESSAGE" != *"[circle linkcheck]"* ]] && [ "<< parameters.scheduled >>" != "true" ]; then
+                echo "Skip detected, exiting job ${CIRCLE_JOB}."
                 circleci-agent step halt;
               fi
         - run:
@@ -528,7 +531,8 @@ workflows:
 
   weekly:
     jobs:
-      - linkcheck
+      - linkcheck:
+          scheduled: "true"
     triggers:
       - schedule:
           # "At 00:00 on Sunday" should be often enough

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ version: 2.1
 _xvfb: &xvfb
   name: Start Xvfb virtual framebuffer
   command: |
+    sudo apt install xvfb
     /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1280x1024x24 -ac +extension GLX +render -noreset -nolisten tcp -nolisten unix
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,6 +369,22 @@ jobs:
                 circleci-agent step halt;
               fi
         - run:
+            <<: *xvfb
+        - restore_cache:
+            keys:
+              - pip-cache
+        - restore_cache:
+            keys:
+              - user-install-bin-cache
+        - run:
+            name: Get Python running
+            command: |
+              ./tools/circleci_dependencies.sh
+        - run:
+            name: Check installation
+            command: |
+              mne sys_info
+        - run:
             name: make linkcheck
             command: |
               make -C doc linkcheck
@@ -475,6 +491,9 @@ jobs:
         - restore_cache:
             keys:
               - pip-cache
+        - restore_cache:
+            keys:
+              - user-install-bin-cache
         - run:
             name: Get Python running
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,14 +66,6 @@ jobs:
               fi
 
         - run:
-            name: Install 3D rendering libraries \ PyQt5 dependencies \ graphviz \ optipng (for optimized images)
-            command: |
-              sudo apt-get install libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3 \
-                  libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 \
-                  graphviz \
-                  optipng
-
-        - run:
             name: Spin up Xvfb
             command: |
               /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
@@ -210,8 +202,7 @@ jobs:
         - run:
             name: make html
             command: |
-              cd doc;
-              PATTERN=$(cat ../pattern.txt) make $(cat ../build.txt);
+              PATTERN=$(cat ../pattern.txt) make -C doc $(cat ../build.txt);
         - run:
             name: Show profiling output
             when: always
@@ -360,6 +351,12 @@ jobs:
               - source-cache
         - checkout
         - run:
+            name: Set BASH_ENV
+            command: |
+              set -e
+              echo "set -e" >> $BASH_ENV
+              echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
+        - run:
             name: Check-skip
             command: |
               export COMMIT_MESSAGE=$(git log --format=oneline -n 1);
@@ -368,24 +365,14 @@ jobs:
                 circleci-agent step halt;
               fi
         - run:
-            name: pip install dependencies
-            command: |
-               set -e;
-               python -m pip install --user --progress-bar off numpy scipy matplotlib pillow
-               python -m pip install --user -e .
-               python -m pip install --user --progress-bar off -r requirements_doc.txt -r requirements_testing.txt
-        - run:
             name: make linkcheck
             command: |
-              set -e
-              cd doc
-              PATH=~/.local/bin:$PATH make linkcheck
+              make -C doc linkcheck
         - run:
             name: make linkcheck-grep
             when: always
             command: |
-              cd doc
-              make linkcheck-grep
+              make -C doc linkcheck-grep
         - store_artifacts:
             path: doc/_build/linkcheck
             destination: linkcheck
@@ -470,6 +457,7 @@ jobs:
             command: |
               set -e
               echo "set -e" >> $BASH_ENV
+              mkdir -p ~/mne_data
         - run:
             name: Check-skip
             command: |
@@ -478,37 +466,24 @@ jobs:
                 echo "Skip detected, exiting job ${CIRCLE_JOB}."
                 circleci-agent step halt;
               fi
+        - restore_cache:
+            keys:
+              - pip-cache
         - run:
             name: Get Python running
             command: |
-              python -m pip install --progress-bar off --upgrade "pip!=20.3.0" setuptools wheel
-              python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl
-              python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" --extra-index-url https://www.riverbankcomputing.com/pypi/simple numpy scipy pandas scikit-learn PyQt5
-              python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py pillow matplotlib
-              python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" numba llvmlite
-              wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
-              python -m pip install --progress-bar off vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
-              python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
-              python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
-              python -m pip install --progress-bar off --upgrade -r requirements_testing.txt
-              python -m pip install nitime
-              python -m pip install --user -e .
-
-        # Look at what we have and fail early if there is some library conflict
+              ./tools/circleci_dependencies.sh
         - run:
             name: Check installation
             command: |
-              which python
-              python -c "import numpy; numpy.show_config()"
-              python -c "from numpy._pytesttester import _show_numpy_info; _show_numpy_info()"
-
-        # Figure out if we should run a full, pattern, or noplot version
+              mne sys_info
+        - restore_cache:
+            keys:
+              - data-cache-testing
         - run:
             name: Get data
             command: |
               python -c "import mne; mne.datasets.testing.data_path(verbose=True)"
-
-        # Run doctest (if it's full or front) before building the docs
         - run:
             name: pytest
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,6 @@ jobs:
         - run:
             <<: *xvfb
 
-        # https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
-        # https://github.com/golemfactory/golem/issues/1019
-
         - run:
             name: Install fonts needed for diagrams
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,16 +351,19 @@ jobs:
       docker:
         - image: circleci/python:3.9.2-buster
       parameters:
-        scheduled:
+        was_scheduled:
           type: string
           default: "false"
       steps:
+        - restore_cache:
+            keys:
+              - source-cache
         - checkout
         - run:
             name: Check-skip
             command: |
               export COMMIT_MESSAGE=$(git log --format=oneline -n 1);
-              if [[ "$COMMIT_MESSAGE" != *"[circle linkcheck]"* ]] && [ "<< parameters.scheduled >>" != "true" ]; then
+              if [[ "$COMMIT_MESSAGE" != *"[circle linkcheck]"* ]] && [ "<< parameters.was_scheduled >>" != "true" ]; then
                 echo "Skip detected, exiting job ${CIRCLE_JOB}."
                 circleci-agent step halt;
               fi
@@ -458,6 +461,9 @@ jobs:
       docker:
         - image: circleci/python:3.9.2-buster
       steps:
+        - restore_cache:
+            keys:
+              - source-cache
         - checkout
         - run:
             name: Set BASH_ENV
@@ -528,7 +534,7 @@ workflows:
   weekly:
     jobs:
       - linkcheck:
-          scheduled: "true"
+          was_scheduled: "true"
     triggers:
       - schedule:
           # "At 00:00 on Sunday" should be often enough

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,12 +348,12 @@ jobs:
 
     linkcheck:
       # there are a few files excluded from this for expediency, see Makefile
-      docker:
-        - image: circleci/python:3.9.2-buster
       parameters:
-        was_scheduled:
+        scheduled:
           type: string
           default: "false"
+      docker:
+        - image: circleci/python:3.9.2-buster
       steps:
         - restore_cache:
             keys:
@@ -363,7 +363,7 @@ jobs:
             name: Check-skip
             command: |
               export COMMIT_MESSAGE=$(git log --format=oneline -n 1);
-              if [[ "$COMMIT_MESSAGE" != *"[circle linkcheck]"* ]] && [ "<< parameters.was_scheduled >>" != "true" ]; then
+              if [[ "$COMMIT_MESSAGE" != *"[circle linkcheck]"* ]] && [ "<< parameters.scheduled >>" != "true" ]; then
                 echo "Skip detected, exiting job ${CIRCLE_JOB}."
                 circleci-agent step halt;
               fi
@@ -515,7 +515,7 @@ jobs:
               pytest -m "not ultraslowtest" mne -xv
 
 workflows:
-  version: 2
+  version: 2.1
 
   default:
     jobs:
@@ -534,7 +534,7 @@ workflows:
   weekly:
     jobs:
       - linkcheck:
-          was_scheduled: "true"
+          scheduled: "true"
     triggers:
       - schedule:
           # "At 00:00 on Sunday" should be often enough

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -418,9 +418,8 @@ linkcheck_ignore = [  # will be compiled to regex
     'https://doi.org/10.1088/0031-9155/32/1/004',  # noqa Read timed out. (read timeout=15)
     'https://doi.org/10.1088/0031-9155/40/3/001',  # noqa Read timed out. (read timeout=15)
     'https://doi.org/10.1088/0031-9155/51/7/008',  # noqa Read timed out. (read timeout=15)
-    'https://doi.org/10.1088/0031-9155/57/7/1937'  # noqa Read timed out. (read timeout=15)
+    'https://doi.org/10.1088/0031-9155/57/7/1937',  # noqa Read timed out. (read timeout=15)
     'https://doi.org/10.1093/sleep/18.7.557',  # noqa 403 Client Error: Forbidden for url: https://academic.oup.com/sleep/article-lookup/doi/10.1093/sleep/18.7.557
-    'https://academic.oup.com/sleep/article-lookup/doi/10.1093/sleep/18.7.557',
     'https://doi.org/10.1162/089976699300016719',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/neco/article/11/2/417-441/6242
     'https://doi.org/10.1162/jocn.1993.5.2.162',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/jocn/article/5/2/162-176/3095
     'https://doi.org/10.1162/neco.1995.7.6.1129',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/neco/article/7/6/1129-1159/5909

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -144,9 +144,9 @@ intersphinx_mapping = {
     'patsy': ('https://patsy.readthedocs.io/en/latest', None),
     'pyvista': ('https://docs.pyvista.org', None),
     'imageio': ('https://imageio.readthedocs.io/en/latest', None),
-    # We need to stick with 1.4.0 for now:
+    # We need to stick with _public someplaces with 1.4.0:
     # https://github.com/dipy/dipy/issues/2290
-    'dipy': ('https://dipy.org/documentation/1.2.0.', None),
+    'dipy': ('https://dipy.org/documentation/1.4.0.', None),
     'mne_realtime': ('https://mne.tools/mne-realtime', None),
     'picard': ('https://pierreablin.github.io/picard/', None),
     'qdarkstyle': ('https://qdarkstylesheet.readthedocs.io/en/latest', None)
@@ -183,7 +183,7 @@ numpydoc_xref_aliases = {
     'Nifti2Image': 'nibabel.nifti2.Nifti2Image',
     'SpatialImage': 'nibabel.spatialimages.SpatialImage',
     # dipy
-    'dipy.align.Affinemap': 'dipy.align._public.AffineMap',
+    'dipy.align.AffineMap': 'dipy.align._public.AffineMap',
     'dipy.align.DiffeomorphicMap': 'dipy.align._public.DiffeomorphicMap',
     # MNE
     'Label': 'mne.Label', 'Forward': 'mne.Forward', 'Evoked': 'mne.Evoked',
@@ -456,6 +456,7 @@ nitpick_ignore = [
     ("py:class", "a shallow copy of D"),
     ("py:class", "(k, v), remove and return some (key, value) pair as a"),
     ("py:class", "_FuncT"),  # type hint used in @verbose decorator
+    ("py:class", "mne.utils._logging._FuncT"),
 ]
 for key in ('AcqParserFIF', 'BiHemiLabel', 'Dipole', 'DipoleFixed', 'Label',
             'MixedSourceEstimate', 'MixedVectorSourceEstimate', 'Report',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -420,6 +420,7 @@ linkcheck_ignore = [  # will be compiled to regex
     'https://doi.org/10.1088/0031-9155/51/7/008',  # noqa Read timed out. (read timeout=15)
     'https://doi.org/10.1088/0031-9155/57/7/1937'  # noqa Read timed out. (read timeout=15)
     'https://doi.org/10.1093/sleep/18.7.557',  # noqa 403 Client Error: Forbidden for url: https://academic.oup.com/sleep/article-lookup/doi/10.1093/sleep/18.7.557
+    'https://academic.oup.com/sleep/article-lookup/doi/10.1093/sleep/18.7.557',
     'https://doi.org/10.1162/089976699300016719',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/neco/article/11/2/417-441/6242
     'https://doi.org/10.1162/jocn.1993.5.2.162',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/jocn/article/5/2/162-176/3095
     'https://doi.org/10.1162/neco.1995.7.6.1129',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/neco/article/7/6/1129-1159/5909

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -144,9 +144,6 @@ intersphinx_mapping = {
     'patsy': ('https://patsy.readthedocs.io/en/latest', None),
     'pyvista': ('https://docs.pyvista.org', None),
     'imageio': ('https://imageio.readthedocs.io/en/latest', None),
-    # We need to stick with _public someplaces with 1.4.0:
-    # https://github.com/dipy/dipy/issues/2290
-    'dipy': ('https://dipy.org/documentation/1.4.0.', None),
     'mne_realtime': ('https://mne.tools/mne-realtime', None),
     'picard': ('https://pierreablin.github.io/picard/', None),
     'qdarkstyle': ('https://qdarkstylesheet.readthedocs.io/en/latest', None)
@@ -182,9 +179,6 @@ numpydoc_xref_aliases = {
     'Nifti1Image': 'nibabel.nifti1.Nifti1Image',
     'Nifti2Image': 'nibabel.nifti2.Nifti2Image',
     'SpatialImage': 'nibabel.spatialimages.SpatialImage',
-    # dipy
-    'dipy.align.AffineMap': 'dipy.align._public.AffineMap',
-    'dipy.align.DiffeomorphicMap': 'dipy.align._public.DiffeomorphicMap',
     # MNE
     'Label': 'mne.Label', 'Forward': 'mne.Forward', 'Evoked': 'mne.Evoked',
     'Info': 'mne.Info', 'SourceSpaces': 'mne.SourceSpaces',
@@ -250,6 +244,10 @@ numpydoc_xref_ignore = {
     # unlinkable
     'mayavi.mlab.pipeline.surface',
     'CoregFrame', 'Kit2FiffFrame', 'FiducialsFrame',
+    # dipy has resolution problems, wait for them to be solved, e.g.
+    # https://github.com/dipy/dipy/issues/2290
+    'dipy.align.AffineMap',
+    'dipy.align.DiffeomorphicMap',
 }
 numpydoc_validate = True
 numpydoc_validation_checks = {'all'} | set(error_ignores)
@@ -418,6 +416,9 @@ linkcheck_request_headers = dict(user_agent='Mozilla/5.0 (X11; Linux x86_64) App
 linkcheck_ignore = [  # will be compiled to regex
     r'https://datashare.is.ed.ac.uk/handle/10283/2189\?show=full',  # noqa Max retries exceeded with url: /handle/10283/2189?show=full (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1123)')))
     'https://doi.org/10.1088/0031-9155/32/1/004',  # noqa Read timed out. (read timeout=15)
+    'https://doi.org/10.1088/0031-9155/40/3/001',  # noqa Read timed out. (read timeout=15)
+    'https://doi.org/10.1088/0031-9155/51/7/008',  # noqa Read timed out. (read timeout=15)
+    'https://doi.org/10.1088/0031-9155/57/7/1937'  # noqa Read timed out. (read timeout=15)
     'https://doi.org/10.1093/sleep/18.7.557',  # noqa 403 Client Error: Forbidden for url: https://academic.oup.com/sleep/article-lookup/doi/10.1093/sleep/18.7.557
     'https://doi.org/10.1162/089976699300016719',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/neco/article/11/2/417-441/6242
     'https://doi.org/10.1162/jocn.1993.5.2.162',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/jocn/article/5/2/162-176/3095

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -182,6 +182,9 @@ numpydoc_xref_aliases = {
     'Nifti1Image': 'nibabel.nifti1.Nifti1Image',
     'Nifti2Image': 'nibabel.nifti2.Nifti2Image',
     'SpatialImage': 'nibabel.spatialimages.SpatialImage',
+    # dipy
+    'dipy.align.Affinemap': 'dipy.align._public.AffineMap',
+    'dipy.align.DiffeomorphicMap': 'dipy.align._public.DiffeomorphicMap',
     # MNE
     'Label': 'mne.Label', 'Forward': 'mne.Forward', 'Evoked': 'mne.Evoked',
     'Info': 'mne.Info', 'SourceSpaces': 'mne.SourceSpaces',
@@ -414,6 +417,7 @@ def append_attr_meth_examples(app, what, name, obj, options, lines):
 linkcheck_request_headers = dict(user_agent='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36')  # noqa: E501
 linkcheck_ignore = [  # will be compiled to regex
     r'https://datashare.is.ed.ac.uk/handle/10283/2189\?show=full',  # noqa Max retries exceeded with url: /handle/10283/2189?show=full (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1123)')))
+    'https://doi.org/10.1088/0031-9155/32/1/004',  # noqa Read timed out. (read timeout=15)
     'https://doi.org/10.1093/sleep/18.7.557',  # noqa 403 Client Error: Forbidden for url: https://academic.oup.com/sleep/article-lookup/doi/10.1093/sleep/18.7.557
     'https://doi.org/10.1162/089976699300016719',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/neco/article/11/2/417-441/6242
     'https://doi.org/10.1162/jocn.1993.5.2.162',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/jocn/article/5/2/162-176/3095

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -144,7 +144,7 @@ intersphinx_mapping = {
     'patsy': ('https://patsy.readthedocs.io/en/latest', None),
     'pyvista': ('https://docs.pyvista.org', None),
     'imageio': ('https://imageio.readthedocs.io/en/latest', None),
-    # We need to stick with 1.2.0 for now:
+    # We need to stick with 1.4.0 for now:
     # https://github.com/dipy/dipy/issues/2290
     'dipy': ('https://dipy.org/documentation/1.2.0.', None),
     'mne_realtime': ('https://mne.tools/mne-realtime', None),
@@ -411,15 +411,23 @@ def append_attr_meth_examples(app, what, name, obj, options, lines):
 
 # -- Other extension configuration -------------------------------------------
 
-linkcheck_ignore = [
-    'https://doi.org/10.1088/0031-9155/57/7/1937',  # noqa 403 Client Error: Forbidden for url: http://iopscience.iop.org/article/10.1088/0031-9155/57/7/1937/meta
-    'https://doi.org/10.1088/0031-9155/51/7/008',  # noqa 403 Client Error: Forbidden for url: https://iopscience.iop.org/article/10.1088/0031-9155/51/7/008
-    'https://sccn.ucsd.edu/wiki/.*',  # noqa HTTPSConnectionPool(host='sccn.ucsd.edu', port=443): Max retries exceeded with url: /wiki/Firfilt_FAQ (Caused by SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:847)'),))
-    'https://docs.python.org/dev/howto/logging.html',  # noqa ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
+linkcheck_request_headers = dict(user_agent='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36')  # noqa: E501
+linkcheck_ignore = [  # will be compiled to regex
+    r'https://datashare.is.ed.ac.uk/handle/10283/2189\?show=full',  # Max retries exceeded with url: /handle/10283/2189?show=full (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1123)')))
+    'https://doi.org/10.1093/sleep/18.7.557',  # noqa 403 Client Error: Forbidden for url: https://academic.oup.com/sleep/article-lookup/doi/10.1093/sleep/18.7.557
+    'https://doi.org/10.1162/089976699300016719',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/neco/article/11/2/417-441/6242
+    'https://doi.org/10.1162/jocn.1993.5.2.162',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/jocn/article/5/2/162-176/3095
+    'https://doi.org/10.1162/neco.1995.7.6.1129',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/neco/article/7/6/1129-1159/5909
+    'https://doi.org/10.1162/jocn_a_00405',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/jocn/article/25/9/1477-1492/27980
+    'https://doi.org/10.1167/15.6.4',  # noqa 403 Client Error: Forbidden for url: https://jov.arvojournals.org/article.aspx?doi=10.1167/15.6.4
+    'https://doi.org/10.7488/ds/1556',  # noqa Max retries exceeded with url: /handle/10283/2189 (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1122)')))
+    'https://imaging.mrc-cbu.cam.ac.uk/imaging/MniTalairach',  # noqa Max retries exceeded with url: /imaging/MniTalairach (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1122)')))
+    'https://www.nyu.edu/',  # noqa Max retries exceeded with url: / (Caused by SSLError(SSLError(1, '[SSL: DH_KEY_TOO_SMALL] dh key too small (_ssl.c:1122)')))
     'https://docs.python.org/3/library/.*',  # noqa ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
     'https://hal.archives-ouvertes.fr/hal-01848442/',  # noqa Sometimes: 503 Server Error: Service Unavailable for url: https://hal.archives-ouvertes.fr/hal-01848442/
 ]
 linkcheck_anchors = False  # saves a bit of time
+linkcheck_timeout = 15  # some can be quite slow
 
 # autodoc / autosummary
 autosummary_generate = True

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -419,6 +419,8 @@ linkcheck_ignore = [  # will be compiled to regex
     'https://doi.org/10.1088/0031-9155/40/3/001',  # noqa Read timed out. (read timeout=15)
     'https://doi.org/10.1088/0031-9155/51/7/008',  # noqa Read timed out. (read timeout=15)
     'https://doi.org/10.1088/0031-9155/57/7/1937',  # noqa Read timed out. (read timeout=15)
+    'https://doi.org/10.1088/0967-3334/22/4/305',  # noqa Read timed out. (read timeout=15)
+    'https://doi.org/10.1088/1741-2552/aacfe4',  # noqa Read timed out. (read timeout=15)
     'https://doi.org/10.1093/sleep/18.7.557',  # noqa 403 Client Error: Forbidden for url: https://academic.oup.com/sleep/article-lookup/doi/10.1093/sleep/18.7.557
     'https://doi.org/10.1162/089976699300016719',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/neco/article/11/2/417-441/6242
     'https://doi.org/10.1162/jocn.1993.5.2.162',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/jocn/article/5/2/162-176/3095

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -413,7 +413,7 @@ def append_attr_meth_examples(app, what, name, obj, options, lines):
 
 linkcheck_request_headers = dict(user_agent='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36')  # noqa: E501
 linkcheck_ignore = [  # will be compiled to regex
-    r'https://datashare.is.ed.ac.uk/handle/10283/2189\?show=full',  # Max retries exceeded with url: /handle/10283/2189?show=full (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1123)')))
+    r'https://datashare.is.ed.ac.uk/handle/10283/2189\?show=full',  # noqa Max retries exceeded with url: /handle/10283/2189?show=full (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1123)')))
     'https://doi.org/10.1093/sleep/18.7.557',  # noqa 403 Client Error: Forbidden for url: https://academic.oup.com/sleep/article-lookup/doi/10.1093/sleep/18.7.557
     'https://doi.org/10.1162/089976699300016719',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/neco/article/11/2/417-441/6242
     'https://doi.org/10.1162/jocn.1993.5.2.162',  # noqa 403 Client Error: Forbidden for url: https://direct.mit.edu/jocn/article/5/2/162-176/3095

--- a/doc/install/mne_c.rst
+++ b/doc/install/mne_c.rst
@@ -161,8 +161,8 @@ effect or you need a faster graphics adapter.
 Troubleshooting MNE-C installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If MNE-C can't find ``libxp.so.6``, download libxp6 from debian_ or `pkgs.org`_
-and install with ``dpkg`` or similar:
+If MNE-C can't find ``libxp.so.6``, download libxp6 from debian_ or similar and
+install it:
 
 .. code-block:: console
 
@@ -190,4 +190,3 @@ If you encounter other errors installing MNE-C, please post a message to the
 .. _XCode developer tools: https://developer.apple.com/xcode/
 .. _xquartz: https://www.xquartz.org/
 .. _debian: https://packages.debian.org/jessie/amd64/libxp6/download
-.. _pkgs.org: https://pkgs.org/download/libxp6

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -97,6 +97,7 @@ def pytest_configure(config):
     ignore:Unable to enable faulthandler.*:UserWarning
     ignore:Fetchers from the nilearn.*:FutureWarning
     ignore:SelectableGroups dict interface is deprecated\. Use select\.:DeprecationWarning
+    ignore:Call to deprecated class vtk.*:DeprecationWarning
     always:.*get_data.* is deprecated in favor of.*:DeprecationWarning
     always::ResourceWarning
     """  # noqa: E501

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -339,11 +339,11 @@ class SourceMorph(object):
         The volume MRI shape.
     affine : ndarray
         The volume MRI affine.
-    pre_affine : instance of dipy.align.imaffine.AffineMap
-        The :class:`dipy.align.imaffine.AffineMap` transformation that is
+    pre_affine : instance of dipy.align.AffineMap
+        The :class:`dipy.align.AffineMap` transformation that is
         applied before the before ``sdr_morph``.
-    sdr_morph : instance of dipy.align.imwarp.DiffeomorphicMap
-        The :class:`dipy.align.imwarp.DiffeomorphicMap` that applies the
+    sdr_morph : instance of dipy.align.DiffeomorphicMap
+        The :class:`dipy.align.DiffeomorphicMap` that applies the
         the symmetric diffeomorphic registration (SDR) morph.
     src_data : dict
         Additional source data necessary to perform morphing.

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -340,11 +340,10 @@ class SourceMorph(object):
     affine : ndarray
         The volume MRI affine.
     pre_affine : instance of dipy.align.AffineMap
-        The :class:`dipy.align.AffineMap` transformation that is
-        applied before the before ``sdr_morph``.
+        The transformation that is applied before the before ``sdr_morph``.
     sdr_morph : instance of dipy.align.DiffeomorphicMap
-        The :class:`dipy.align.DiffeomorphicMap` that applies the
-        the symmetric diffeomorphic registration (SDR) morph.
+        The class that applies the the symmetric diffeomorphic registration
+        (SDR) morph.
     src_data : dict
         Additional source data necessary to perform morphing.
     vol_morph_mat : scipy.sparse.csr_matrix | None

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -ef
 
-echo "Worknig around PyQt5 bugs"
+echo "Working around PyQt5 bugs"
+# https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
+# https://github.com/golemfactory/golem/issues/1019
 sudo apt-get install libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3 \
 	libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
 	libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 \
@@ -9,7 +11,7 @@ sudo ln -s /usr/lib/x86_64-linux-gnu/libxcb-util.so.0 /usr/lib/x86_64-linux-gnu/
 
 echo "Installing setuptools and sphinx"
 python -m pip install --progress-bar off --upgrade "pip!=20.3.0" setuptools wheel
-python -m pip install --user --upgrade --progress-bar off --pre sphinx
+python -m pip install --upgrade --progress-bar off --pre sphinx
 if [[ "$CIRCLE_JOB" == "interactive_test" ]]; then
 	echo "Installing latest dependencies for interactive_test"
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl
@@ -22,18 +24,18 @@ if [[ "$CIRCLE_JOB" == "interactive_test" ]]; then
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 	python -m pip install --progress-bar off --upgrade -r requirements_testing.txt
 	python -m pip install nitime
-	python -m pip install --user -e .
+	python -m pip install -e .
 elif [[ "$CIRCLE_JOB" == "linkcheck"* ]]; then
 	echo "Installing minimal linkcheck dependencies"
-	python -m pip install --user --progress-bar off numpy scipy matplotlib pillow pytest
-	python -m pip install --user -e .
-	python -m pip install --user --progress-bar off -r requirements_doc.txt
+	python -m pip install --progress-bar off numpy scipy matplotlib pillow pytest
+	python -m pip install -e .
+	python -m pip install --progress-bar off -r requirements_doc.txt
 else  # standard doc build
 	echo "Installing doc build dependencies"
 	python -m pip uninstall -y pydata-sphinx-theme
-	python -m pip install --user --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
-	python -m pip install --user --progress-bar off https://github.com/pyvista/pyvista/zipball/master
-	python -m pip install --user --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
+	python -m pip install --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
+	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
+	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 	python -m pip uninstall -yq pysurfer mayavi
-	python -m pip install --user -e .
+	python -m pip install -e .
 fi

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -23,7 +23,7 @@ if [[ "$CIRCLE_JOB" == "interactive_test" ]]; then
 	python -m pip install --progress-bar off --upgrade -r requirements_testing.txt
 	python -m pip install nitime
 	python -m pip install --user -e .
-elif [[ "$CIRCLE_JOB" == "linkcheck" ]]; then
+elif [[ "$CIRCLE_JOB" == "linkcheck"* ]]; then
 	echo "Installing minimal linkcheck dependencies"
 	python -m pip install --user --progress-bar off numpy scipy matplotlib pillow pytest
 	python -m pip install --user -e .

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -1,12 +1,39 @@
 #!/bin/bash -ef
 
-# Work around PyQt5 bug
+echo "Worknig around PyQt5 bugs"
+sudo apt-get install libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3 \
+	libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
+	libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 \
+	graphviz optipng
 sudo ln -s /usr/lib/x86_64-linux-gnu/libxcb-util.so.0 /usr/lib/x86_64-linux-gnu/libxcb-util.so.1
-python -m pip uninstall -y pydata-sphinx-theme
-python -m pip install --user --upgrade --progress-bar off pip setuptools
+
+echo "Installing setuptools and sphinx"
+python -m pip install --progress-bar off --upgrade "pip!=20.3.0" setuptools wheel
 python -m pip install --user --upgrade --progress-bar off --pre sphinx
-python -m pip install --user --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
-python -m pip install --user --progress-bar off https://github.com/pyvista/pyvista/zipball/master
-python -m pip install --user --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
-python -m pip uninstall -yq pysurfer mayavi
-python -m pip install --user -e .
+if [[ "$CIRCLE_JOB" == "interactive_test" ]]; then
+	echo "Installing latest dependencies for interactive_test"
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" --extra-index-url https://www.riverbankcomputing.com/pypi/simple numpy scipy pandas scikit-learn PyQt5
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py pillow matplotlib
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" numba llvmlite
+	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
+	python -m pip install --progress-bar off vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
+	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
+	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
+	python -m pip install --progress-bar off --upgrade -r requirements_testing.txt
+	python -m pip install nitime
+	python -m pip install --user -e .
+elif [[ "$CIRCLE_JOB" == "linkcheck" ]]; then
+	echo "Installing minimal linkcheck dependencies"
+	python -m pip install --user --progress-bar off numpy scipy matplotlib pillow pytest
+	python -m pip install --user -e .
+	python -m pip install --user --progress-bar off -r requirements_doc.txt
+else  # standard doc build
+	echo "Installing doc build dependencies"
+	python -m pip uninstall -y pydata-sphinx-theme
+	python -m pip install --user --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
+	python -m pip install --user --progress-bar off https://github.com/pyvista/pyvista/zipball/master
+	python -m pip install --user --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
+	python -m pip uninstall -yq pysurfer mayavi
+	python -m pip install --user -e .
+fi

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -5,13 +5,13 @@ if [ ! -z "$CONDA_ENV" ]; then
 elif [ ! -z "$CONDA_DEPENDENCIES" ]; then
 	conda install -y $CONDA_DEPENDENCIES
 else # pip --pre 3.9 (missing dipy in pre)
+	# Changes here should also go in the interactive_test CircleCI job
 	python -m pip install --progress-bar off --upgrade "pip!=20.3.0" setuptools wheel
 	pip uninstall -yq numpy
 	pip install --progress-bar off --upgrade --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl
 	pip install --progress-bar off --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" --extra-index-url https://www.riverbankcomputing.com/pypi/simple numpy scipy pandas scikit-learn PyQt5
-	pip install --progress-bar off --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py pillow
+	pip install --progress-bar off --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py pillow matplotlib
 	pip install --progress-bar off --upgrade --pre --only-binary ":all:" numba llvmlite
-	pip install --progress-bar off --upgrade --only-binary ":all:" matplotlib
 	# built using vtk master branch on an Ubuntu 18.04.5 VM and uploaded to OSF:
 	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 	pip install --progress-bar off vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl


### PR DESCRIPTION
Our linkcheck is failing:

https://app.circleci.com/pipelines/github/mne-tools/mne-python/7631/workflows/6438a1dc-962b-43f2-9018-69c546ee3e4f/jobs/26711

1. Add support for `[circle linkcheck]`
2. Add support for `[circle interactive_test]` (which would have helped @drammock recently to debug a matplotlib issue)
3. Add support for `[circle skip]` and `[skip circle]` to skip our doc build step (and interactive_test and linkcheck if they aren't explicitly requested)

Makes use of CircleCI job parameters and the magic `circleci-agent step halt` to kill a job early based on commit message conditionals.

Once the CircleCI gymnastics work, I'll need to actually check the links, but in theory once CIs come back green this should be good to go.