### PR TITLE
fix: error when passing axes to plot_compare_evokeds

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -272,6 +272,8 @@ Bugs
 
 - Fix bug with :func:`mne.io.Raw.pick` where incorrect fnirs types were returned (:gh:`9178` by `Robert Luke`_)
 
+- Fix bug when passing both axes and picks to `mne.viz.plot_compare_evokeds` (:gh:`9252` by `Daniel McCloy`_)
+
 - Improved string representation of `~mne.Epochs` containing multiple event types; improved (and more mathematically correct) ``evoked.comment`` in the `mne.combine_evoked` output; and better (and often more concise) legend labels in the figures created via `~mne.viz.plot_compare_evokeds` (:gh:`9027` by `Richard Höchenberger`_)
 
 - :func:`mne.preprocessing.find_ecg_events` now correctly handles situation where no ECG activity could be detected, and correctly returns an empty array of ECG events (:gh:`9236` by `Richard Höchenberger`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -280,9 +280,9 @@ Bugs
 
 API changes
 ~~~~~~~~~~~
-- `mne.viz.plot_sensors_connectivity` now allows setting the colorbar label via the ``cbar_label`` parameter (:gh:`9248` by `Daniel McCloy`_)
-
 - Introduced new ``'auto'`` settings for ``ICA.max_iter``. The old default ``max_iter=200`` will be removed in MNE-Python 0.24 (:gh:`9099` **by new contributor** |Cora Kim|_)
+
+- `mne.viz.plot_sensors_connectivity` now allows setting the colorbar label via the ``cbar_label`` parameter (:gh:`9248` by `Daniel McCloy`_)
 
 - ``mne.read_selection`` has been deprecated in favor of `mne.read_vectorview_selection`. ``mne.read_selection`` will be removed in MNE-Python 0.24 (:gh:`8870` by `Richard Höchenberger`_)
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -2251,7 +2251,8 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
         warn('Only {} channel in "picks"; cannot combine by method "{}".'
              .format(len(picks), combine))
     # `combine` defaults to GFP unless picked a single channel or axes='topo'
-    if combine is None and len(picks) > 1 and axes != 'topo':
+    do_topo = isinstance(axes, str) and axes == 'topo'
+    if combine is None and len(picks) > 1 and not do_topo:
         combine = 'gfp'
     # convert `combine` into callable (if None or str)
     combine_func = _make_combine_callable(combine)
@@ -2261,7 +2262,6 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
                               ch_names=ch_names, combine=combine)
 
     # setup axes
-    do_topo = (axes == 'topo')
     if do_topo:
         show_sensors = False
         if len(picks) > 70:


### PR DESCRIPTION
Currently this:

```py
mne.viz.plot_compare_evokeds(evoked, combine=None, picks=picks, axes=axs)
```

compares `axes` to a string, where `axes` is a list of matplotlib axes objects, and raises this:

```
ValueError                                Traceback (most recent call last)
<ipython-input-8-e36b566cce17> in <module>
----> 1 foo = mne.viz.plot_compare_evokeds({'mean': evoked}, combine=None, picks=picks, axes=axs)

/opt/mne/python/mne/viz/evoked.py in plot_compare_evokeds(evokeds, picks, colors, linestyles, styles, cmap, vlines, ci, truncate_yaxis, truncate_xaxis, ylim, invert_y, show_sensors, legend, split_legend, axes, title, show, combine, sphere)
   2252              .format(len(picks), combine))
   2253     # `combine` defaults to GFP unless picked a single channel or axes='topo'
-> 2254     if combine is None and len(picks) > 1 and axes != 'topo':
   2255         combine = 'gfp'
   2256     # convert `combine` into callable (if None or str)

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

This PR fixes it.
