### PR TITLE
MRG, ENH: Add projoff option

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -113,6 +113,8 @@ Enhancements
 
 - Add option to control appearance of opaque inside surface of the head to :ref:`mne coreg` (:gh:`8793` by `Eric Larson`_)
 
+- Add option to disable projection using ``--projoff`` in :ref:`mne browse_raw` (:gh:`9262` by `Eric Larson`_)
+
 - Add support for non-FIF files in :ref:`mne browse_raw` using :func:`mne.io.read_raw` (:gh:`8806` by `Eric Larson`_)
 
 - Add :func:`mne.io.read_raw_nedf` for reading StarStim / enobio NEDF files (:gh:`8734` by `Tristan Stenner`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -115,6 +115,8 @@ Enhancements
 
 - Add option to disable projection using ``--projoff`` in :ref:`mne browse_raw` (:gh:`9262` by `Eric Larson`_)
 
+- Add keypress to toggle projection using ``shift+j`` in :meth:`mne.io.Raw.plot` and :ref:`mne browse_raw` (:gh:`9262` by `Eric Larson`_)
+
 - Add support for non-FIF files in :ref:`mne browse_raw` using :func:`mne.io.read_raw` (:gh:`8806` by `Eric Larson`_)
 
 - Add :func:`mne.io.read_raw_nedf` for reading StarStim / enobio NEDF files (:gh:`8734` by `Tristan Stenner`_)

--- a/mne/commands/mne_browse_raw.py
+++ b/mne/commands/mne_browse_raw.py
@@ -34,6 +34,9 @@ def run():
     parser.add_option("--proj", dest="proj_in",
                       help="Projector file", metavar="FILE",
                       default='')
+    parser.add_option("--projoff", dest="proj_off",
+                      help="Disable all projectors",
+                      default=False, action="store_true")
     parser.add_option("--eve", dest="eve_in",
                       help="Events file", metavar="FILE",
                       default='')
@@ -87,6 +90,7 @@ def run():
     preload = options.preload
     show_options = options.show_options
     proj_in = options.proj_in
+    proj_off = options.proj_off
     eve_in = options.eve_in
     maxshield = options.maxshield
     highpass = options.highpass
@@ -131,7 +135,7 @@ def run():
     raw.plot(duration=duration, start=start, n_channels=n_channels,
              group_by=group_by, show_options=show_options, events=events,
              highpass=highpass, lowpass=lowpass, filtorder=filtorder,
-             clipping=clipping, verbose=verbose)
+             clipping=clipping, proj=not proj_off, verbose=verbose)
     plt.show(block=True)
 
 

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1385,8 +1385,8 @@ class MNEBrowseFigure(MNEFigure):
         for annot in self.mne.hscroll_annotations[::-1]:
             self.mne.ax_hscroll.collections.remove(annot)
             self.mne.hscroll_annotations.remove(annot)
-        for text in self.mne.annotation_texts[::-1]:
-            self.mne.ax_main.texts.remove(text)
+        for text in list(self.mne.annotation_texts):
+            text.remove()
             self.mne.annotation_texts.remove(text)
 
     def _draw_annotations(self):
@@ -1795,9 +1795,9 @@ class MNEBrowseFigure(MNEFigure):
     def _hide_scalebars(self):
         """Remove channel scale bars."""
         for bar in self.mne.scalebars.values():
-            self.mne.ax_main.lines.remove(bar)
+            bar.remove()
         for text in self.mne.scalebar_texts.values():
-            self.mne.ax_main.texts.remove(text)
+            text.remove()
         self.mne.scalebars = dict()
         self.mne.scalebar_texts = dict()
 
@@ -2029,7 +2029,7 @@ class MNEBrowseFigure(MNEFigure):
         # remove extra traces if needed
         extra_traces = self.mne.traces[n_picks:]
         for trace in extra_traces:
-            self.mne.ax_main.lines.remove(trace)
+            trace.remove()
         self.mne.traces = self.mne.traces[:n_picks]
 
         # check for bad epochs
@@ -2041,8 +2041,7 @@ class MNEBrowseFigure(MNEFigure):
             visible_bad_epochs = epoch_nums[
                 np.in1d(epoch_nums, self.mne.bad_epochs).nonzero()]
             while len(self.mne.epoch_traces):
-                _trace = self.mne.epoch_traces.pop(-1)
-                self.mne.ax_main.lines.remove(_trace)
+                self.mne.epoch_traces.pop(-1).remove()
             # handle custom epoch colors (for autoreject integration)
             if self.mne.epoch_colors is None:
                 # shape: n_traces × RGBA → n_traces × n_epochs × RGBA
@@ -2168,8 +2167,7 @@ class MNEBrowseFigure(MNEFigure):
             self.mne.event_lines = event_lines
             # create event labels
             while len(self.mne.event_texts):
-                text = self.mne.event_texts.pop()
-                self.mne.ax_main.texts.remove(text)
+                self.mne.event_texts.pop().remove()
             for _t, _n, _c in zip(this_event_times, this_event_nums, colors):
                 label = self.mne.event_id_rev.get(_n, _n)
                 this_text = self.mne.ax_main.annotate(

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -1379,11 +1379,11 @@ class MNEBrowseFigure(MNEFigure):
 
     def _clear_annotations(self):
         """Clear all annotations from the figure."""
-        for annot in self.mne.annotations[::-1]:
-            self.mne.ax_main.collections.remove(annot)
+        for annot in list(self.mne.annotations):
+            annot.remove()
             self.mne.annotations.remove(annot)
-        for annot in self.mne.hscroll_annotations[::-1]:
-            self.mne.ax_hscroll.collections.remove(annot)
+        for annot in list(self.mne.hscroll_annotations):
+            annot.remove()
             self.mne.hscroll_annotations.remove(annot)
         for text in list(self.mne.annotation_texts):
             text.remove()

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -306,6 +306,10 @@ def test_plot_raw_ssp_interaction(raw):
     _fake_click(ssp_fig, ssp_fig.mne.proj_all.ax, [0.5, 0.5])
     _fake_click(ssp_fig, ssp_fig.mne.proj_all.ax, [0.5, 0.5], kind='release')
     assert _proj_status(ax) == [True, False, False]
+    fig.canvas.key_press_event('J')
+    assert _proj_status(ax) == [True, True, True]
+    fig.canvas.key_press_event('J')
+    assert _proj_status(ax) == [True, False, False]
     # turn all on
     _fake_click(ssp_fig, ssp_fig.mne.proj_all.ax, [0.5, 0.5])  # all on
     _fake_click(ssp_fig, ssp_fig.mne.proj_all.ax, [0.5, 0.5], kind='release')


### PR DESCRIPTION
I prefer to browse data with projections off when looking for bad channels, and adding this `--projoff` option allows me to use a one-liner command and start immediately arrow-keying around to look for flux jumps:
```
mne browse_raw --allowmaxshield --lowpass 40 --duration 30 --projoff my_raw.fif
```

I also snuck in a fix for the matplotlib deprecations:
```
/usr/lib/python3.9/_collections_abc.py:1023: MatplotlibDeprecationWarning: 
The modification of the Axes.lines property was deprecated in Matplotlib 3.5 and will be removed two minor releases later. Use Artist.remove() instead.
  del self[self.index(value)]
/usr/lib/python3.9/_collections_abc.py:1023: MatplotlibDeprecationWarning: 
The modification of the Axes.texts property was deprecated in Matplotlib 3.5 and will be removed two minor releases later. Use Artist.remove() instead.
  del self[self.index(value)]
```
The 3.0.3 docs have `Artist.remove` so in theory this should be backward compatible with our minimal MPL dep.