### PR TITLE
[MRG] MAINT: make exclude optional so its backwards compatible with autoreject

### DIFF
--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -123,7 +123,9 @@ def _do_interp_dots(inst, interpolation, goods_idx, bads_idx):
 
 
 @verbose
-def _interpolate_bads_eeg(inst, origin, exclude, verbose=None):
+def _interpolate_bads_eeg(inst, origin, exclude=None, verbose=None):
+    if exclude is None:
+        exclude = list()
     bads_idx = np.zeros(len(inst.ch_names), dtype=bool)
     goods_idx = np.zeros(len(inst.ch_names), dtype=bool)
 


### PR DESCRIPTION
It looks like a recent change in MNE broke `autoreject` CIs. See here: https://github.com/autoreject/autoreject/pull/203/. Since it's still in the main branch, I propose to make a tiny fix so the CIs in autoreject become happy