### PR TITLE
ENH: Add support for missing dir

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -99,6 +99,8 @@ Enhancements
 
 - Add digitizer information to :func:`mne.io.read_raw_egi` (:gh:`8789` by `Christian Brodbeck`_)
 
+- Add support for reading some incomplete raw FIF files in :func:`mne.io.read_raw_fif` (:gh:`9268` by `Eric Larson`_)
+
 - Allow reading digitization from files other than ``*.fif`` in the coregistration GUI (:gh:`8790` by `Christian Brodbeck`_)
 
 - Speed up :func:`mne.inverse_sparse.tf_mixed_norm` using STFT/ISTFT linearity (:gh:`8697` by `Eric Larson`_)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2353,13 +2353,13 @@ def _check_raw_compatibility(raw):
     """Ensure all instances of Raw have compatible parameters."""
     for ri in range(1, len(raw)):
         if not isinstance(raw[ri], type(raw[0])):
-            raise ValueError('raw[%d] type must match' % ri)
-        if not raw[ri].info['nchan'] == raw[0].info['nchan']:
-            raise ValueError('raw[%d][\'info\'][\'nchan\'] must match' % ri)
-        if not raw[ri].info['bads'] == raw[0].info['bads']:
-            raise ValueError('raw[%d][\'info\'][\'bads\'] must match' % ri)
-        if not raw[ri].info['sfreq'] == raw[0].info['sfreq']:
-            raise ValueError('raw[%d][\'info\'][\'sfreq\'] must match' % ri)
+            raise ValueError(f'raw[{ri}] type must match')
+        for key in ('nchan', 'bads', 'sfreq'):
+            a, b = raw[ri].info[key], raw[0].info[key]
+            if a != b:
+                raise ValueError(
+                    f'raw[{ri}].info[{key}] must match:\n'
+                    f'{repr(a)} != {repr(b)}')
         if not set(raw[ri].info['ch_names']) == set(raw[0].info['ch_names']):
             raise ValueError('raw[%d][\'info\'][\'ch_names\'] must match' % ri)
         if not all(raw[ri]._cals == raw[0]._cals):

--- a/mne/io/tag.py
+++ b/mne/io/tag.py
@@ -457,6 +457,8 @@ def read_tag(fid, pos=None, shape=None, rlims=None):
     if pos is not None:
         fid.seek(pos, 0)
     tag = _read_tag_header(fid)
+    if tag is None:
+        return tag
     if tag.size > 0:
         matrix_coding = _is_matrix & tag.type
         if matrix_coding != 0:


### PR DESCRIPTION
This makes it so we at least get a nice warning about a corrupted file if the tag directory is missing. In real cases there is usually more than this and eventually we hit an error about channel information missing, but the warning now is much more informative than what we had before (something along the lines of "NoneType has no attribute pos").

I also improved an error message for raw concat incompatibility while I was messing around with some incompatible files.