### PR TITLE
MRG, ENH: Allow to pass multiple channels to find_eog_events(), create_eog_epochs()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -175,6 +175,8 @@ Enhancements
 
 - :meth:`mne.Epochs.equalize_event_counts` can now be called without providing a list of event names, and will equalize the counts of **all** event types present in the `~mne.Epochs` (:gh:`9261` by `Richard Höchenberger`_)
 
+- :func:`mne.preprocessing.find_eog_events` and :func:`mne.preprocessing.create_eog_epochs` now accept a list of channel names, allowing you to specify multiple EOG channels at once (:gh:`9269` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 - Fix bug with :func:`mne.io.read_raw_edf` where µV was not correctly recognized (:gh:`9187` **by new contributor** |Sumalyo Datta|_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -296,3 +296,5 @@ API changes
 - ``mne.beamformer.tf_dics`` has been deprecated and will be removed in MNE-Python 0.24 (:gh:`9122` by `Britta Westner`_)
 
 - Fitting `~mne.preprocessing.ICA` on baseline-corrected `~mne.Epochs`, and / or applying it on baseline-corrected `~mne.Epochs` or `~mne.Evoked` data will now display a warning. Users are advised to only baseline correct their data after cleaning is completed (:gh:`9033` by `Richard Höchenberger`_)
+
+- Supplying multiple channel names to `mne.preprocessing.find_eog_events` or `mne.preprocessing.compute_proj_eog` as a string of comma-separated channel names has been deprecated; please pass a list of channel names instead. Support for comma-separated strings will be removed in MNE-Python 0.24 (:gh:`9269` by `Richard Höchenberger`_)

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -135,11 +135,10 @@ def _get_eog_channel_index(ch_name, inst):
     # Ensure we have a list of channel names
     if isinstance(ch_name, str):
         if ',' in ch_name:
-            warn(DeprecationWarning,
-                 f'You supplied multiple EOG channel names, separated by a '
+            warn(f'You supplied multiple EOG channel names, separated by a '
                  f'comma: {ch_name}. We will stop supporting this in version '
                  f'0.24. Please pass a list of channels instead: '
-                 f'{ch_name.split(",")}')
+                 f'{ch_name.split(",")}', DeprecationWarning)
             ch_name = ch_name.split(',')
         else:
             ch_name = [ch_name]

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -132,7 +132,6 @@ def _find_eog_events(eog, event_id, l_freq, h_freq, sampling_rate, first_samp,
 
 def _get_eog_channel_index(ch_name, inst):
     """Get EOG channel indices."""
-
     # Ensure we have a list of channel names
     if isinstance(ch_name, str):
         if ',' in ch_name:  # backward-compat

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -139,7 +139,7 @@ def _get_eog_channel_index(ch_name, inst):
                               eog=True, ecg=False, emg=False, ref_meg=False,
                               exclude='bads')
         if not eog_inds:
-            warn('No EOG channel find. Trying with EEG 061 and EEG 062. '
+            warn('No EOG channel found. Trying with EEG 061 and EEG 062. '
                  'This functionality will be removed in version 0.24',
                  DeprecationWarning)
             eog_inds = pick_channels(inst.ch_names,

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from ._peak_finder import peak_finder
 from .. import pick_types, pick_channels
-from ..utils import logger, verbose, _pl
+from ..utils import logger, verbose, _pl, warn
 from ..filter import filter_data
 from ..epochs import Epochs
 
@@ -134,7 +134,12 @@ def _get_eog_channel_index(ch_name, inst):
     """Get EOG channel indices."""
     # Ensure we have a list of channel names
     if isinstance(ch_name, str):
-        if ',' in ch_name:  # backward-compat
+        if ',' in ch_name:
+            warn(DeprecationWarning,
+                 f'You supplied multiple EOG channel names, separated by a '
+                 f'comma: {ch_name}. We will stop supporting this in version '
+                 f'0.24. Please pass a list of channels instead: '
+                 f'{ch_name.split(",")}')
             ch_name = ch_name.split(',')
         else:
             ch_name = [ch_name]

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -138,13 +138,13 @@ def _get_eog_channel_index(ch_name, inst):
         eog_inds = pick_types(inst.info, meg=False, eeg=False, stim=False,
                               eog=True, ecg=False, emg=False, ref_meg=False,
                               exclude='bads')
-        if not eog_inds:
+        if eog_inds.size == 0:
             warn('No EOG channel found. Trying with EEG 061 and EEG 062. '
                  'This functionality will be removed in version 0.24',
                  DeprecationWarning)
             eog_inds = pick_channels(inst.ch_names,
                                      include=['EEG 061', 'EEG 062'])
-            if not eog_inds:
+            if eog_inds.size == 0:
                 raise ValueError('Could not find any EOG channels.')
 
         ch_names = [inst.ch_names[i] for i in eog_inds]

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -136,7 +136,7 @@ def _get_eog_channel_index(ch_name, inst):
     if isinstance(ch_name, str):
         if ',' in ch_name:
             warn(f'You supplied multiple EOG channel names, separated by a '
-                 f'comma: {ch_name}. We will stop supporting this in version '
+                 f'comma: {repr(ch_name)}. We will stop supporting this in version '
                  f'0.24. Please pass a list of channels instead: '
                  f'{ch_name.split(",")}', DeprecationWarning)
             ch_name = ch_name.split(',')

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -162,10 +162,8 @@ def _get_eog_channel_index(ch_name, inst):
 
     # ensure the specified channels are present in the data
     if ch_name is not None:
-        not_found = []
-        for ch_name in ch_names:
-            if ch_name not in inst.ch_names:
-                not_found.append(ch_name)
+        not_found = [ch_name for ch_name in ch_names
+                     if ch_name not in inst.ch_names]
         if not_found:
             raise ValueError(f'The specified EOG {_pl(not_found)} cannot be '
                              f'found: {", ".join(not_found)}')

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -165,8 +165,8 @@ def _get_eog_channel_index(ch_name, inst):
         not_found = [ch_name for ch_name in ch_names
                      if ch_name not in inst.ch_names]
         if not_found:
-            raise ValueError(f'The specified EOG {_pl(not_found)} cannot be '
-                             f'found: {", ".join(not_found)}')
+            raise ValueError(f'The specified EOG channel{_pl(not_found)} '
+                             f'cannot be found: {", ".join(not_found)}')
 
         eog_inds = pick_channels(inst.ch_names, include=ch_names)
 

--- a/mne/preprocessing/eog.py
+++ b/mne/preprocessing/eog.py
@@ -131,7 +131,7 @@ def _find_eog_events(eog, event_id, l_freq, h_freq, sampling_rate, first_samp,
 
 
 def _get_eog_channel_index(ch_name, inst):
-    """Get EOG channel indeces."""
+    """Get EOG channel indices."""
 
     # Ensure we have a list of channel names
     if isinstance(ch_name, str):

--- a/mne/preprocessing/tests/test_eog.py
+++ b/mne/preprocessing/tests/test_eog.py
@@ -20,13 +20,19 @@ def test_find_eog(ch_name):
     """Test find EOG peaks."""
     raw = read_raw_fif(raw_fname)
     raw.set_annotations(Annotations([14, 21], [1, 1], 'BAD_blink'))
-    events = find_eog_events(raw)
+
+    if ch_name is not None and ',' in ch_name:
+        with pytest.warns(DeprecationWarning, match='pass a list of channels'):
+            events = find_eog_events(raw, ch_name=ch_name)
+            return
+
+    events = find_eog_events(raw, ch_name=ch_name)
     assert len(events) == 4
     assert not all(events[:, 0] < 29000)
 
-    events = find_eog_events(raw, reject_by_annotation=True)
+    events = find_eog_events(raw, reject_by_annotation=True, ch_name=ch_name)
     assert all(events[:, 0] < 29000)
 
     # threshold option
-    events_thr = find_eog_events(raw, thresh=100e-6)
+    events_thr = find_eog_events(raw, thresh=100e-6, ch_name=ch_name)
     assert len(events_thr) == 5

--- a/mne/preprocessing/tests/test_eog.py
+++ b/mne/preprocessing/tests/test_eog.py
@@ -1,5 +1,7 @@
 import os.path as op
 
+import pytest
+
 from mne import Annotations
 from mne.io import read_raw_fif
 from mne.preprocessing.eog import find_eog_events
@@ -10,7 +12,11 @@ event_fname = op.join(data_path, 'test-eve.fif')
 proj_fname = op.join(data_path, 'test-proj.fif')
 
 
-def test_find_eog():
+@pytest.mark.parametrize('ch_name', (None,
+                                     'EOG 061',
+                                     'EEG 060,EOG 061',
+                                     ['EEG 060', 'EOG 061']))
+def test_find_eog(ch_name):
     """Test find EOG peaks."""
     raw = read_raw_fif(raw_fname)
     raw.set_annotations(Annotations([14, 21], [1, 1], 'BAD_blink'))

--- a/mne/preprocessing/tests/test_eog.py
+++ b/mne/preprocessing/tests/test_eog.py
@@ -12,19 +12,11 @@ event_fname = op.join(data_path, 'test-eve.fif')
 proj_fname = op.join(data_path, 'test-proj.fif')
 
 
-@pytest.mark.parametrize('ch_name', (None,
-                                     'EOG 061',
-                                     'EEG 060,EOG 061',
-                                     ['EEG 060', 'EOG 061']))
-def test_find_eog(ch_name):
+def test_find_eog():
     """Test find EOG peaks."""
+    ch_name = 'EOG 061'
     raw = read_raw_fif(raw_fname)
     raw.set_annotations(Annotations([14, 21], [1, 1], 'BAD_blink'))
-
-    if ch_name is not None and ',' in ch_name:
-        with pytest.warns(DeprecationWarning, match='pass a list of channels'):
-            events = find_eog_events(raw, ch_name=ch_name)
-            return
 
     events = find_eog_events(raw, ch_name=ch_name)
     assert len(events) == 4
@@ -36,3 +28,14 @@ def test_find_eog(ch_name):
     # threshold option
     events_thr = find_eog_events(raw, thresh=100e-6, ch_name=ch_name)
     assert len(events_thr) == 5
+
+    # test different ways to specify the EOG channel(s)
+    with pytest.warns(DeprecationWarning, match='pass a list of channels'):
+        events = find_eog_events(raw, ch_name='EEG 060,EOG 061')
+    assert len(events) == 4
+
+    events = find_eog_events(raw, ch_name=None)
+    assert len(events) == 4
+
+    events = find_eog_events(raw, ch_name=['EEG 060', 'EOG 061'])
+    assert len(events) == 4

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2223,12 +2223,12 @@ docdict['create_eog_epochs'] = """This function will:
 """
 docdict['eog_ch_name'] = """
 ch_name : str | list of str | None
-    The name of the channel(s) to use for EOG peak detection. If a **string,**
+    The name of the channel(s) to use for EOG peak detection. If a string,
     can be an arbitrary channel. This doesn't have to be a channel of
     ``eog`` type; it could, for example, also be an ordinary EEG channel
     that was placed close to the eyes, like ``Fp1`` or ``Fp2``.
 
-    Multiple channel names can be passed as a **list of strings.**
+    Multiple channel names can be passed as a list of strings.
 
     If ``None`` (default), use the channel(s) in ``raw`` with type ``eog``.
 """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2221,6 +2221,17 @@ docdict['create_eog_epochs'] = """This function will:
 
 #. Create `~mne.Epochs` around the eyeblinks.
 """
+docdict['eog_ch_name'] = """
+ch_name : str | list of str | None
+    The name of the channel(s) to use for EOG peak detection. If a **string,**
+    can be an arbitrary channel. This doesn't have to be a channel of
+    ``eog`` type; it could, for example, also be an ordinary EEG channel
+    that was placed close to the eyes, like ``Fp1`` or ``Fp2``.
+
+    Multiple channel names can be passed as a **list of strings.**
+
+    If ``None`` (default), use the channel(s) in ``raw`` with type ``eog``.
+"""
 
 # SSP
 docdict['compute_ssp'] = """This function aims to find those SSP vectors that


### PR DESCRIPTION
`find_eog_events()` and `create_eog_epochs()` now accept a list of channel names as a way to specify multiple EOG channels at once. Previously, one could only do that via an (undocumented!) concatenation of channel names, separated by commas, e.g. `'EEG 061,EEG 062'`.

Also reworks the docstring and adds more test cases.