### PR TITLE
FIX: Prepare for PyVista 0.30.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
 - spyder-kernels>=1.10.0
 - imageio-ffmpeg>=0.4.1
 - vtk>=9.0.1
-- pyvista>=0.24
+- pyvista>=0.24,<=0.29
 - pyvistaqt>=0.2.0
 - mayavi
 - PySurfer

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -686,7 +686,6 @@ class Brain(object):
             self._layered_meshes[hemi]._clean()
         self._clear_callbacks()
         self._clear_widgets()
-        self.plotter._key_press_event_callbacks.clear()
         if getattr(self, 'mpl_canvas', None) is not None:
             self.mpl_canvas.clear()
         if getattr(self, 'act_data_smooth', None) is not None:
@@ -1297,7 +1296,7 @@ class Brain(object):
 
     def _configure_shortcuts(self):
         # First, we remove the default bindings:
-        self.plotter._key_press_event_callbacks.clear()
+        self._clear_callbacks()
         # Then, we add our own:
         self.plotter.add_key_event("i", self.toggle_interface)
         self.plotter.add_key_event("s", self.apply_auto_scaling)
@@ -1690,6 +1689,12 @@ class Brain(object):
                             'widget', 'widgets'):
                     setattr(callback, key, None)
         self.callbacks.clear()
+        # Remove the default key binding
+        if getattr(self, "iren", None) is not None:
+            try:
+                self.plotter._key_press_event_callbacks.clear()
+            except AttributeError:
+                self.plotter.iren.clear_key_event_callbacks()
 
     def _clear_widgets(self):
         if not hasattr(self, 'widgets'):

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -341,8 +341,12 @@ class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
             self._create_default_tool_bar()
         display(self._tool_bar)
         # viewer
-        viewer = self.plotter.show(
-            use_ipyvtk=True, return_viewer=True)
+        try:
+            viewer = self.plotter.show(
+                use_ipyvtk=True, return_viewer=True)
+        except RuntimeError:
+            viewer = self.plotter.show(
+                backend="ipyvtk_simple", return_viewer=True)
         viewer.layout.width = None  # unlock the fixed layout
         # main widget
         if self._dock is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ nilearn
 xlrd
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1
-pyvista>=0.24
+pyvista>=0.24,<=0.29
 pyvistaqt>=0.2.0
 tqdm
 mffpy>=0.5.7

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -10,7 +10,7 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py Pillow
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all" vtk
 	python -m pip install --progress-bar off --upgrade --only-binary ":all" matplotlib
-	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
+	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/cb59a9ddfd97f5724f733bc226b41fb9ad4c9c5f
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 	python -m pip install --progress-bar off --upgrade --only-binary="numba,llvmlite" -r requirements.txt
 else

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -20,7 +20,6 @@ if [[ "$CIRCLE_JOB" == "interactive_test" ]]; then
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" numba llvmlite
 	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 	python -m pip install --progress-bar off vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
-	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 	python -m pip install --progress-bar off --upgrade -r requirements_testing.txt
 	python -m pip install nitime
@@ -34,7 +33,6 @@ else  # standard doc build
 	echo "Installing doc build dependencies"
 	python -m pip uninstall -y pydata-sphinx-theme
 	python -m pip install --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
-	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 	python -m pip uninstall -yq pysurfer mayavi
 	python -m pip install -e .

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -33,6 +33,7 @@ else  # standard doc build
 	echo "Installing doc build dependencies"
 	python -m pip uninstall -y pydata-sphinx-theme
 	python -m pip install --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
+	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/cb59a9ddfd97f5724f733bc226b41fb9ad4c9c5f
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 	python -m pip uninstall -yq pysurfer mayavi
 	python -m pip install -e .

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -15,7 +15,7 @@ else # pip --pre 3.9 (missing dipy in pre)
 	# built using vtk master branch on an Ubuntu 18.04.5 VM and uploaded to OSF:
 	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 	pip install --progress-bar off vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
-	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/5ee02e2f295f667e33f11e71946e774cca40256c
+	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/cb59a9ddfd97f5724f733bc226b41fb9ad4c9c5f
 	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 fi
 pip install --progress-bar off --upgrade -r requirements_testing.txt


### PR DESCRIPTION
On the latest version, the API for `_add_observer()` and `use_ipyvtk` have been modified. This PR tries to catch up to those changes. Changes are also necessary in PyVistaQt.

Follows https://github.com/mne-tools/mne-python/pull/9010#issuecomment-816740584