### PR TITLE
MRG ENH/BUG Add exclude parameter to plot_evoked_topo

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -59,6 +59,8 @@ Current (0.23.dev0)
 
 Enhancements
 ~~~~~~~~~~~~
+- Add exclude parameter to :func:`mne.viz.plot_evoked_topo` (:gh:`9278` by |Ram Pari|_)
+
 - Add CSV, TSV, and XYZ support to :func:`mne.channels.read_custom_montage` (:gh:`9203` **by new contributor** |Jack Zhang|_)
 
 - Add HTML representation for `~mne.Epochs` in Jupyter Notebooks (:gh:`9174` by |Valerii Chirkov|_)

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -414,7 +414,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                   border='none', ylim=None, scalings=None, title=None,
                   proj=False, vline=[0.0], fig_background=None,
                   merge_grads=False, legend=True, axes=None,
-                  background_color='w', noise_cov=None, exclude=None,
+                  background_color='w', noise_cov=None, exclude=('bads'),
                   show=True):
         """
         Notes

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -414,7 +414,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                   border='none', ylim=None, scalings=None, title=None,
                   proj=False, vline=[0.0], fig_background=None,
                   merge_grads=False, legend=True, axes=None,
-                  background_color='w', noise_cov=None, exclude=('bads'),
+                  background_color='w', noise_cov=None, exclude='bads',
                   show=True):
         """
         Notes

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -410,9 +410,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             sphere=sphere)
 
     @copy_function_doc_to_method_doc(plot_evoked_topo)
-    def plot_topo(self, layout=None, layout_scale=0.945, color=None,
-                  border='none', ylim=None, scalings=None, title=None,
-                  proj=False, vline=[0.0], fig_background=None,
+    def plot_topo(self, layout=None, exclude=None, layout_scale=0.945,
+                  color=None, border='none', ylim=None, scalings=None,
+                  title=None, proj=False, vline=[0.0], fig_background=None,
                   merge_grads=False, legend=True, axes=None,
                   background_color='w', noise_cov=None, show=True):
         """
@@ -421,9 +421,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         .. versionadded:: 0.10.0
         """
         return plot_evoked_topo(
-            self, layout=layout, layout_scale=layout_scale, color=color,
-            border=border, ylim=ylim, scalings=scalings, title=title,
-            proj=proj, vline=vline, fig_background=fig_background,
+            self, ,exclude=exclude, layout=layout, layout_scale=layout_scale,
+            color=color, border=border, ylim=ylim, scalings=scalings,
+            title=title, proj=proj, vline=vline, fig_background=fig_background,
             merge_grads=merge_grads, legend=legend, axes=axes,
             background_color=background_color, noise_cov=noise_cov, show=show)
 

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -410,10 +410,10 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             sphere=sphere)
 
     @copy_function_doc_to_method_doc(plot_evoked_topo)
-    def plot_topo(self, layout=None, exclude=None, layout_scale=0.945,
+    def plot_topo(self, layout=None, layout_scale=0.945,
                   color=None, border='none', ylim=None, scalings=None,
                   title=None, proj=False, vline=[0.0], fig_background=None,
-                  merge_grads=False, legend=True, axes=None,
+                  merge_grads=False, legend=True, axes=None, exclude=None,
                   background_color='w', noise_cov=None, show=True):
         """
         Notes
@@ -421,10 +421,10 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         .. versionadded:: 0.10.0
         """
         return plot_evoked_topo(
-            self, exclude=exclude, layout=layout, layout_scale=layout_scale,
+            self, layout=layout, layout_scale=layout_scale,
             color=color, border=border, ylim=ylim, scalings=scalings,
             title=title, proj=proj, vline=vline, fig_background=fig_background,
-            merge_grads=merge_grads, legend=legend, axes=axes,
+            merge_grads=merge_grads, legend=legend, axes=axes, exclude=exclude,
             background_color=background_color, noise_cov=noise_cov, show=show)
 
     @copy_function_doc_to_method_doc(plot_evoked_topomap)

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -421,7 +421,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         .. versionadded:: 0.10.0
         """
         return plot_evoked_topo(
-            self, ,exclude=exclude, layout=layout, layout_scale=layout_scale,
+            self, exclude=exclude, layout=layout, layout_scale=layout_scale,
             color=color, border=border, ylim=ylim, scalings=scalings,
             title=title, proj=proj, vline=vline, fig_background=fig_background,
             merge_grads=merge_grads, legend=legend, axes=axes,

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -410,11 +410,12 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             sphere=sphere)
 
     @copy_function_doc_to_method_doc(plot_evoked_topo)
-    def plot_topo(self, layout=None, layout_scale=0.945,
-                  color=None, border='none', ylim=None, scalings=None,
-                  title=None, proj=False, vline=[0.0], fig_background=None,
-                  merge_grads=False, legend=True, axes=None, exclude=None,
-                  background_color='w', noise_cov=None, show=True):
+    def plot_topo(self, layout=None, layout_scale=0.945, color=None,
+                  border='none', ylim=None, scalings=None, title=None,
+                  proj=False, vline=[0.0], fig_background=None,
+                  merge_grads=False, legend=True, axes=None,
+                  background_color='w', noise_cov=None, exclude=None,
+                  show=True):
         """
         Notes
         -----
@@ -424,8 +425,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             self, layout=layout, layout_scale=layout_scale,
             color=color, border=border, ylim=ylim, scalings=scalings,
             title=title, proj=proj, vline=vline, fig_background=fig_background,
-            merge_grads=merge_grads, legend=legend, axes=axes, exclude=exclude,
-            background_color=background_color, noise_cov=noise_cov, show=show)
+            merge_grads=merge_grads, legend=legend, axes=axes,
+            background_color=background_color, noise_cov=noise_cov,
+            exclude=exclude, show=show)
 
     @copy_function_doc_to_method_doc(plot_evoked_topomap)
     def plot_topomap(self, times="auto", ch_type=None, vmin=None,

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -843,7 +843,7 @@ def plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
         .. versionadded:: 0.16.0
     exclude : list of str | 'bads'
         Channels names to exclude from the plot. If 'bads', the
-        bad channels are excluded.
+        bad channels are excluded. If None, exclude is set to 'bads'.
     show : bool
         Show figure if True.
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -774,7 +774,7 @@ def plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
                      color=None, border='none', ylim=None, scalings=None,
                      title=None, proj=False, vline=[0.0], fig_background=None,
                      merge_grads=False, legend=True, axes=None,
-                     background_color='w', noise_cov=None, exclude=None,
+                     background_color='w', noise_cov=None, exclude=('bads'),
                      show=True):
     """Plot 2D topography of evoked responses.
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -842,7 +842,7 @@ def plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
 
         .. versionadded:: 0.16.0
     exclude : list of str | 'bads'
-        Channels names to exclude from being shown. If 'bads', the
+        Channels names to exclude from the plot. If 'bads', the
         bad channels are excluded.
     show : bool
         Show figure if True.

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -774,7 +774,7 @@ def plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
                      color=None, border='none', ylim=None, scalings=None,
                      title=None, proj=False, vline=[0.0], fig_background=None,
                      merge_grads=False, legend=True, axes=None,
-                     background_color='w', noise_cov=None, exclude=('bads'),
+                     background_color='w', noise_cov=None, exclude='bads',
                      show=True):
     """Plot 2D topography of evoked responses.
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -831,9 +831,6 @@ def plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
         See matplotlib documentation for more details.
     axes : instance of matplotlib Axes | None
         Axes to plot into. If None, axes will be created.
-    exclude : list of str | 'bads'
-        Channels names to exclude from being shown. If 'bads', the
-        bad channels are excluded.
     background_color : color
         Background color. Typically 'k' (black) or 'w' (white; default).
 
@@ -844,6 +841,9 @@ def plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
         Can be a string to load a covariance from disk.
 
         .. versionadded:: 0.16.0
+    exclude : list of str | 'bads'
+        Channels names to exclude from being shown. If 'bads', the
+        bad channels are excluded.
     show : bool
         Show figure if True.
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -843,7 +843,7 @@ def plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
         .. versionadded:: 0.16.0
     exclude : list of str | 'bads'
         Channels names to exclude from the plot. If 'bads', the
-        bad channels are excluded. If None, exclude is set to 'bads'.
+        bad channels are excluded. By default, exclude is set to 'bads'.
     show : bool
         Show figure if True.
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -770,9 +770,9 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
         time_unit=time_unit, sphere=sphere)
 
 
-def plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
-                     border='none', ylim=None, scalings=None, title=None,
-                     proj=False, vline=[0.0], fig_background=None,
+def plot_evoked_topo(evoked, exclude=None, layout=None, layout_scale=0.945,
+                     color=None, border='none', ylim=None, scalings=None,
+                     title=None, proj=False, vline=[0.0], fig_background=None,
                      merge_grads=False, legend=True, axes=None,
                      background_color='w', noise_cov=None, show=True):
     """Plot 2D topography of evoked responses.
@@ -784,6 +784,9 @@ def plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
     ----------
     evoked : list of Evoked | Evoked
         The evoked response to plot.
+    exclude : list of str | 'bads'
+        Channels names to exclude from being shown. If 'bads', the
+        bad channels are excluded.
     layout : instance of Layout | None
         Layout instance specifying sensor positions (does not need to
         be specified for Neuromag data). If possible, the correct layout is
@@ -870,7 +873,7 @@ def plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
             color = _get_color_list()
         color = color * ((len(evoked) % len(color)) + 1)
         color = color[:len(evoked)]
-    return _plot_evoked_topo(evoked=evoked, layout=layout,
+    return _plot_evoked_topo(evoked=evoked, exclude=exclude, layout=layout,
                              layout_scale=layout_scale, color=color,
                              border=border, ylim=ylim, scalings=scalings,
                              title=title, proj=proj, vline=vline,

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -773,8 +773,9 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
 def plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
                      color=None, border='none', ylim=None, scalings=None,
                      title=None, proj=False, vline=[0.0], fig_background=None,
-                     merge_grads=False, legend=True, axes=None, exclude=None,
-                     background_color='w', noise_cov=None, show=True):
+                     merge_grads=False, legend=True, axes=None,
+                     background_color='w', noise_cov=None, exclude=None,
+                     show=True):
     """Plot 2D topography of evoked responses.
 
     Clicking on the plot of an individual sensor opens a new figure showing

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -770,10 +770,10 @@ def plot_evoked(evoked, picks=None, exclude='bads', unit=True, show=True,
         time_unit=time_unit, sphere=sphere)
 
 
-def plot_evoked_topo(evoked, exclude=None, layout=None, layout_scale=0.945,
+def plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
                      color=None, border='none', ylim=None, scalings=None,
                      title=None, proj=False, vline=[0.0], fig_background=None,
-                     merge_grads=False, legend=True, axes=None,
+                     merge_grads=False, legend=True, axes=None, exclude=None,
                      background_color='w', noise_cov=None, show=True):
     """Plot 2D topography of evoked responses.
 
@@ -784,9 +784,6 @@ def plot_evoked_topo(evoked, exclude=None, layout=None, layout_scale=0.945,
     ----------
     evoked : list of Evoked | Evoked
         The evoked response to plot.
-    exclude : list of str | 'bads'
-        Channels names to exclude from being shown. If 'bads', the
-        bad channels are excluded.
     layout : instance of Layout | None
         Layout instance specifying sensor positions (does not need to
         be specified for Neuromag data). If possible, the correct layout is
@@ -833,6 +830,9 @@ def plot_evoked_topo(evoked, exclude=None, layout=None, layout_scale=0.945,
         See matplotlib documentation for more details.
     axes : instance of matplotlib Axes | None
         Axes to plot into. If None, axes will be created.
+    exclude : list of str | 'bads'
+        Channels names to exclude from being shown. If 'bads', the
+        bad channels are excluded.
     background_color : color
         Background color. Typically 'k' (black) or 'w' (white; default).
 
@@ -873,7 +873,7 @@ def plot_evoked_topo(evoked, exclude=None, layout=None, layout_scale=0.945,
             color = _get_color_list()
         color = color * ((len(evoked) % len(color)) + 1)
         color = color[:len(evoked)]
-    return _plot_evoked_topo(evoked=evoked, exclude=exclude, layout=layout,
+    return _plot_evoked_topo(evoked=evoked, layout=layout,
                              layout_scale=layout_scale, color=color,
                              border=border, ylim=ylim, scalings=scalings,
                              title=title, proj=proj, vline=vline,
@@ -882,8 +882,8 @@ def plot_evoked_topo(evoked, exclude=None, layout=None, layout_scale=0.945,
                              axis_facecolor=axis_facecolor,
                              font_color=font_color,
                              merge_channels=merge_grads,
-                             legend=legend, axes=axes, show=show,
-                             noise_cov=noise_cov)
+                             legend=legend, axes=axes, exclude=exclude,
+                             show=show, noise_cov=noise_cov)
 
 
 @fill_doc

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -183,7 +183,8 @@ def test_plot_topo():
 
     # Test exclude parameter
     fig = picked_evoked.plot_topo(exclude=['MEG 0112'])
-    assert len(fig.axes[0].collections) == 5
+    ch_count = len(picked_evoked.info['ch_names'])
+    assert len(fig.axes[0].collections) - 1 == (ch_count * 2) - 2
 
     # test plot_topo
     evoked.plot_topo()  # should auto-find layout

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -182,9 +182,11 @@ def test_plot_topo():
     plt.close('all')
 
     # Test exclude parameter
-    fig = picked_evoked.plot_topo(exclude=['MEG 0112'])
-    ch_count = len(picked_evoked.info['ch_names'])
-    assert len(fig.axes[0].collections) - 1 == (ch_count - 1) * 2
+    exclude = ['MEG 0112']
+    fig = picked_evoked.plot_topo(exclude=exclude)
+    n_axes_expected = len(picked_evoked.info['ch_names']) - len(exclude)
+    n_axes_found = len(fig.axes[0].lines)
+    assert n_axes_found == n_axes_expected
 
     # test plot_topo
     evoked.plot_topo()  # should auto-find layout

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -184,7 +184,7 @@ def test_plot_topo():
     # Test exclude parameter
     fig = picked_evoked.plot_topo(exclude=['MEG 0112'])
     ch_count = len(picked_evoked.info['ch_names'])
-    assert len(fig.axes[0].collections) - 1 == (ch_count - 1)*2
+    assert len(fig.axes[0].collections) - 1 == (ch_count - 1) * 2
 
     # test plot_topo
     evoked.plot_topo()  # should auto-find layout

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -184,7 +184,7 @@ def test_plot_topo():
     # Test exclude parameter
     fig = picked_evoked.plot_topo(exclude=['MEG 0112'])
     ch_count = len(picked_evoked.info['ch_names'])
-    assert len(fig.axes[0].collections) - 1 == (ch_count * 2) - 2
+    assert len(fig.axes[0].collections) - 1 == (ch_count - 1)*2
 
     # test plot_topo
     evoked.plot_topo()  # should auto-find layout

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -181,6 +181,10 @@ def test_plot_topo():
     evoked.pick_types(meg=True).plot_topo(noise_cov=cov)
     plt.close('all')
 
+    # Test exclude parameter
+    fig = picked_evoked.plot_topo(exclude=['MEG 0112'])
+    assert len(fig.axes[0].collections) == 5
+
     # test plot_topo
     evoked.plot_topo()  # should auto-find layout
     _line_plot_onselect(0, 200, ['mag', 'grad'], evoked.info, evoked.data,

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -563,12 +563,13 @@ def _erfimage_imshow_unified(bn, ch_idx, tmin, tmax, vmin, vmax, ylim=None,
                                 interpolation='nearest'))
 
 
-def _plot_evoked_topo(evoked, exclude=None, layout=None, layout_scale=0.945,
+def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
                       color=None, border='none', ylim=None, scalings=None,
                       title=None, proj=False, vline=(0.,), hline=(0.,),
                       fig_facecolor='k', fig_background=None,
                       axis_facecolor='k', font_color='w', merge_channels=False,
-                      legend=True, axes=None, show=True, noise_cov=None):
+                      legend=True, axes=None, exclude=None, show=True,
+                      noise_cov=None):
     """Plot 2D topography of evoked responses.
 
     Clicking on the plot of an individual sensor opens a new figure showing
@@ -578,9 +579,6 @@ def _plot_evoked_topo(evoked, exclude=None, layout=None, layout_scale=0.945,
     ----------
     evoked : list of Evoked | Evoked
         The evoked response to plot.
-    exclude : list of str | 'bads'
-        Channels names to exclude from being shown. If 'bads', the
-        bad channels are excluded.
     layout : instance of Layout | None
         Layout instance specifying sensor positions (does not need to
         be specified for Neuromag data). If possible, the correct layout is
@@ -635,6 +633,9 @@ def _plot_evoked_topo(evoked, exclude=None, layout=None, layout_scale=0.945,
         See matplotlib documentation for more details.
     axes : instance of matplotlib Axes | None
         Axes to plot into. If None, axes will be created.
+    exclude : list of str | 'bads'
+        Channels names to exclude from being shown. If 'bads', the
+        bad channels are excluded.
     show : bool
         Show figure if True.
     noise_cov : instance of Covariance | str | None
@@ -693,7 +694,6 @@ def _plot_evoked_topo(evoked, exclude=None, layout=None, layout_scale=0.945,
             ch['ch_name'] = ch['ch_name'][:-1] + 'X'
             chs.append(ch)
         info['chs'] = chs
-        info['bads'] = list()  # bads dropped on pair_grad_sensors
         info._update_redundant()
         info._check_consistency()
         new_picks = list()

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -563,12 +563,12 @@ def _erfimage_imshow_unified(bn, ch_idx, tmin, tmax, vmin, vmax, ylim=None,
                                 interpolation='nearest'))
 
 
-def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
-                      border='none', ylim=None, scalings=None, title=None,
-                      proj=False, vline=(0.,), hline=(0.,), fig_facecolor='k',
-                      fig_background=None, axis_facecolor='k', font_color='w',
-                      merge_channels=False, legend=True, axes=None, show=True,
-                      noise_cov=None):
+def _plot_evoked_topo(evoked, exclude=None, layout=None, layout_scale=0.945,
+                      color=None, border='none', ylim=None, scalings=None,
+                      title=None, proj=False, vline=(0.,), hline=(0.,),
+                      fig_facecolor='k', fig_background=None,
+                      axis_facecolor='k', font_color='w', merge_channels=False,
+                      legend=True, axes=None, show=True, noise_cov=None):
     """Plot 2D topography of evoked responses.
 
     Clicking on the plot of an individual sensor opens a new figure showing
@@ -578,6 +578,9 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945, color=None,
     ----------
     evoked : list of Evoked | Evoked
         The evoked response to plot.
+    exclude : list of str | 'bads'
+        Channels names to exclude from being shown. If 'bads', the
+        bad channels are excluded.
     layout : instance of Layout | None
         Layout instance specifying sensor positions (does not need to
         be specified for Neuromag data). If possible, the correct layout is

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -633,15 +633,15 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
         See matplotlib documentation for more details.
     axes : instance of matplotlib Axes | None
         Axes to plot into. If None, axes will be created.
+    noise_cov : instance of Covariance | str | None
+        Noise covariance used to whiten the data while plotting.
+        Whitened data channels names are shown in italic.
+        Can be a string to load a covariance from disk.
     exclude : list of str | 'bads'
         Channels names to exclude from being shown. If 'bads', the
         bad channels are excluded.
     show : bool
         Show figure if True.
-    noise_cov : instance of Covariance | str | None
-        Noise covariance used to whiten the data while plotting.
-        Whitened data channels names are shown in italic.
-        Can be a string to load a covariance from disk.
 
         .. versionadded:: 0.16.0
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -690,7 +690,7 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
             ch['ch_name'] = ch['ch_name'][:-1] + 'X'
             chs.append(ch)
         info['chs'] = chs
-        info['bads'] = list() # Bads handled by pair_grad_sensors
+        info['bads'] = list()   # Bads handled by pair_grad_sensors
         info._update_redundant()
         info._check_consistency()
         new_picks = list()

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -568,7 +568,7 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
                       title=None, proj=False, vline=(0.,), hline=(0.,),
                       fig_facecolor='k', fig_background=None,
                       axis_facecolor='k', font_color='w', merge_channels=False,
-                      legend=True, axes=None, exclude=('bads,), show=True,
+                      legend=True, axes=None, exclude=('bads'), show=True,
                       noise_cov=None):
     """Plot 2D topography of evoked responses.
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -568,7 +568,7 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
                       title=None, proj=False, vline=(0.,), hline=(0.,),
                       fig_facecolor='k', fig_background=None,
                       axis_facecolor='k', font_color='w', merge_channels=False,
-                      legend=True, axes=None, exclude=('bads'), show=True,
+                      legend=True, axes=None, exclude='bads', show=True,
                       noise_cov=None):
     """Plot 2D topography of evoked responses.
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -690,6 +690,7 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
             ch['ch_name'] = ch['ch_name'][:-1] + 'X'
             chs.append(ch)
         info['chs'] = chs
+        info['bads'] = list() # Bads handled by pair_grad_sensors
         info._update_redundant()
         info._check_consistency()
         new_picks = list()
@@ -705,7 +706,7 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
         y_label = 'RMS amplitude (%s)' % unit
 
     if layout is None:
-        layout = find_layout(info)
+        layout = find_layout(info, exclude=exclude)
 
     if not merge_channels:
         # XXX. at the moment we are committed to 1- / 2-sensor-types layouts

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -639,7 +639,7 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
         Can be a string to load a covariance from disk.
     exclude : list of str | 'bads'
         Channels names to exclude from being shown. If 'bads', the
-        bad channels are excluded. If None, exclude is set to 'bads'.
+        bad channels are excluded. By default, exclude is set to 'bads'.
     show : bool
         Show figure if True.
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -675,6 +675,10 @@ def _plot_evoked_topo(evoked, exclude=None, layout=None, layout_scale=0.945,
         evoked = [whiten_evoked(e, noise_cov) for e in evoked]
     else:
         evoked = [e.copy() for e in evoked]
+
+    if exclude is None:
+        exclude = ['bads']
+
     info = evoked[0].info
     ch_names = evoked[0].ch_names
     scalings = _handle_default('scalings', scalings)
@@ -682,7 +686,7 @@ def _plot_evoked_topo(evoked, exclude=None, layout=None, layout_scale=0.945,
         raise ValueError('All evoked.picks must be the same')
     ch_names = _clean_names(ch_names)
     if merge_channels:
-        picks = _pair_grad_sensors(info, topomap_coords=False)
+        picks = _pair_grad_sensors(info, topomap_coords=False, exclude=exclude)
         chs = list()
         for pick in picks[::2]:
             ch = info['chs'][pick]
@@ -724,15 +728,15 @@ def _plot_evoked_topo(evoked, exclude=None, layout=None, layout_scale=0.945,
                       ('hbo', 'hbr', 'fnirs_cw_amplitude', 'fnirs_od')]) > 0
         if is_meg:
             types_used = list(types_used)[::-1]  # -> restore kwarg order
-            picks = [pick_types(info, meg=kk, ref_meg=False, exclude=[])
+            picks = [pick_types(info, meg=kk, ref_meg=False, exclude=exclude)
                      for kk in types_used]
         elif is_nirs:
             types_used = list(types_used)[::-1]  # -> restore kwarg order
-            picks = [pick_types(info, fnirs=kk, ref_meg=False, exclude=[])
+            picks = [pick_types(info, fnirs=kk, ref_meg=False, exclude=exclude)
                      for kk in types_used]
         else:
             types_used_kwargs = {t: True for t in types_used}
-            picks = [pick_types(info, meg=False, exclude=[],
+            picks = [pick_types(info, meg=False, exclude=exclude,
                                 **types_used_kwargs)]
         assert isinstance(picks, list) and len(types_used) == len(picks)
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -639,7 +639,7 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
         Can be a string to load a covariance from disk.
     exclude : list of str | 'bads'
         Channels names to exclude from being shown. If 'bads', the
-        bad channels are excluded.
+        bad channels are excluded. If None, exclude is set to 'bads'.
     show : bool
         Show figure if True.
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -568,7 +568,7 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
                       title=None, proj=False, vline=(0.,), hline=(0.,),
                       fig_facecolor='k', fig_background=None,
                       axis_facecolor='k', font_color='w', merge_channels=False,
-                      legend=True, axes=None, exclude=None, show=True,
+                      legend=True, axes=None, exclude=('bads,), show=True,
                       noise_cov=None):
     """Plot 2D topography of evoked responses.
 
@@ -676,10 +676,6 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
         evoked = [whiten_evoked(e, noise_cov) for e in evoked]
     else:
         evoked = [e.copy() for e in evoked]
-
-    if exclude is None:
-        exclude = ['bads']
-
     info = evoked[0].info
     ch_names = evoked[0].ch_names
     scalings = _handle_default('scalings', scalings)


### PR DESCRIPTION
#### Reference issue
Fixes #9205 .


#### What does this implement/fix?
Adds an exclude parameter to `plot_evoked_topo`.

With the added exclude parameter, ylim's calculations are no longer affected by bad channels that aren't included in the actual plot.

