### PR TITLE
MRG: Use info for checking NIRS metadata, not raw

### DIFF
--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -210,7 +210,7 @@ def _interpolate_bads_nirs(inst, method='nearest', exclude=(), verbose=None):
 
     # Returns pick of all nirs and ensures channels are correctly ordered
     freqs = np.unique(_channel_frequencies(inst))
-    picks_nirs = _check_channels_ordered(inst, freqs)
+    picks_nirs = _check_channels_ordered(inst.info, freqs)
     if len(picks_nirs) == 0:
         return
 

--- a/mne/preprocessing/nirs/_beer_lambert_law.py
+++ b/mne/preprocessing/nirs/_beer_lambert_law.py
@@ -35,7 +35,7 @@ def beer_lambert_law(raw, ppf=0.1):
     _validate_type(raw, BaseRaw, 'raw')
 
     freqs = np.unique(_channel_frequencies(raw))
-    picks = _check_channels_ordered(raw, freqs)
+    picks = _check_channels_ordered(raw.info, freqs)
     abs_coef = _load_absorption(freqs)
     distances = source_detector_distances(raw.info)
 
@@ -57,7 +57,7 @@ def beer_lambert_law(raw, ppf=0.1):
 
     # Validate the format of data after transformation is valid
     chroma = np.unique(_channel_chromophore(raw))
-    _check_channels_ordered(raw, chroma)
+    _check_channels_ordered(raw.info, chroma)
     return raw
 
 

--- a/mne/preprocessing/nirs/_optical_density.py
+++ b/mne/preprocessing/nirs/_optical_density.py
@@ -28,7 +28,7 @@ def optical_density(raw):
     """
     raw = raw.copy().load_data()
     _validate_type(raw, BaseRaw, 'raw')
-    _check_channels_ordered(raw, np.unique(_channel_frequencies(raw)))
+    _check_channels_ordered(raw.info, np.unique(_channel_frequencies(raw)))
 
     picks = _picks_to_idx(raw.info, 'fnirs_cw_amplitude')
     data_means = np.mean(raw.get_data(), axis=1)

--- a/mne/preprocessing/nirs/_scalp_coupling_index.py
+++ b/mne/preprocessing/nirs/_scalp_coupling_index.py
@@ -50,7 +50,7 @@ def scalp_coupling_index(raw, l_freq=0.7, h_freq=1.5,
                            'should be run on optical density data.')
 
     freqs = np.unique(_channel_frequencies(raw))
-    picks = _check_channels_ordered(raw, freqs)
+    picks = _check_channels_ordered(raw.info, freqs)
 
     filtered_data = filter_data(raw._data, raw.info['sfreq'], l_freq, h_freq,
                                 picks=picks, verbose=verbose,

--- a/mne/preprocessing/nirs/_tddr.py
+++ b/mne/preprocessing/nirs/_tddr.py
@@ -43,7 +43,7 @@ def temporal_derivative_distribution_repair(raw, *, verbose=None):
     """
     raw = raw.copy().load_data()
     _validate_type(raw, BaseRaw, 'raw')
-    _check_channels_ordered(raw, np.unique(_channel_frequencies(raw)))
+    _check_channels_ordered(raw.info, np.unique(_channel_frequencies(raw)))
 
     if not len(pick_types(raw.info, fnirs='fnirs_od')):
         raise RuntimeError('TDDR should be run on optical density data.')

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -77,16 +77,16 @@ def _channel_chromophore(raw):
     return chroma
 
 
-def _check_channels_ordered(raw, pair_vals):
+def _check_channels_ordered(info, pair_vals):
     """Check channels follow expected fNIRS format."""
     # Every second channel should be same SD pair
     # and have the specified light frequencies.
 
     # All wavelength based fNIRS data.
-    picks_wave = _picks_to_idx(raw.info, ['fnirs_cw_amplitude', 'fnirs_od'],
+    picks_wave = _picks_to_idx(info, ['fnirs_cw_amplitude', 'fnirs_od'],
                                exclude=[], allow_empty=True)
     # All chromophore fNIRS data
-    picks_chroma = _picks_to_idx(raw.info, ['hbo', 'hbr'],
+    picks_chroma = _picks_to_idx(info, ['hbo', 'hbr'],
                                  exclude=[], allow_empty=True)
     # All continuous wave fNIRS data
     picks_cw = np.hstack([picks_chroma, picks_wave])
@@ -99,11 +99,11 @@ def _check_channels_ordered(raw, pair_vals):
     if len(picks_cw) % 2 != 0:
         raise ValueError(
             'NIRS channels not ordered correctly. An even number of NIRS '
-            f'channels is required. {len(raw.ch_names)} channels were'
-            f'provided: {raw.ch_names}')
+            f'channels is required. {len(info.ch_names)} channels were'
+            f'provided: {info.ch_names}')
 
     # Ensure wavelength info exists for waveform data
-    all_freqs = [raw.info["chs"][ii]["loc"][9] for ii in picks_wave]
+    all_freqs = [info["chs"][ii]["loc"][9] for ii in picks_wave]
     if np.any(np.isnan(all_freqs)):
         raise ValueError(
             'NIRS channels is missing wavelength information in the'
@@ -111,24 +111,24 @@ def _check_channels_ordered(raw, pair_vals):
 
     for ii in picks_cw[::2]:
         ch1_name_info = re.match(r'S(\d+)_D(\d+) (\d+)',
-                                 raw.info['chs'][ii]['ch_name'])
+                                 info['chs'][ii]['ch_name'])
         ch2_name_info = re.match(r'S(\d+)_D(\d+) (\d+)',
-                                 raw.info['chs'][ii + 1]['ch_name'])
+                                 info['chs'][ii + 1]['ch_name'])
 
         if bool(ch2_name_info) & bool(ch1_name_info):
 
-            if raw.info['chs'][ii]['loc'][9] != \
+            if info['chs'][ii]['loc'][9] != \
                     float(ch1_name_info.groups()[2]) or \
-                    raw.info['chs'][ii + 1]['loc'][9] != \
+                    info['chs'][ii + 1]['loc'][9] != \
                     float(ch2_name_info.groups()[2]):
                 raise ValueError(
                     'NIRS channels not ordered correctly. '
                     'Channel name and NIRS'
                     ' frequency do not match: %s -> %s & %s -> %s'
-                    % (raw.info['chs'][ii]['ch_name'],
-                       raw.info['chs'][ii]['loc'][9],
-                       raw.info['chs'][ii + 1]['ch_name'],
-                       raw.info['chs'][ii + 1]['loc'][9]))
+                    % (info['chs'][ii]['ch_name'],
+                       info['chs'][ii]['loc'][9],
+                       info['chs'][ii + 1]['ch_name'],
+                       info['chs'][ii + 1]['loc'][9]))
 
             first_value = int(ch1_name_info.groups()[2])
             second_value = int(ch2_name_info.groups()[2])
@@ -136,9 +136,9 @@ def _check_channels_ordered(raw, pair_vals):
 
         else:
             ch1_name_info = re.match(r'S(\d+)_D(\d+) (\w+)',
-                                     raw.info['chs'][ii]['ch_name'])
+                                     info['chs'][ii]['ch_name'])
             ch2_name_info = re.match(r'S(\d+)_D(\d+) (\w+)',
-                                     raw.info['chs'][ii + 1]['ch_name'])
+                                     info['chs'][ii + 1]['ch_name'])
 
             if bool(ch2_name_info) & bool(ch1_name_info):
 
@@ -152,14 +152,14 @@ def _check_channels_ordered(raw, pair_vals):
                         "NIRS channels have specified naming conventions."
                         "Chromophore data must be labeled either hbo or hbr."
                         "Failing channels are "
-                        f"{raw.info['chs'][ii]['ch_name']}, "
-                        f"{raw.info['chs'][ii + 1]['ch_name']}")
+                        f"{info['chs'][ii]['ch_name']}, "
+                        f"{info['chs'][ii + 1]['ch_name']}")
 
             else:
                 raise ValueError(
                     'NIRS channels have specified naming conventions.'
                     'The provided channel names can not be parsed.'
-                    f'Channels are {raw.ch_names}')
+                    f'Channels are {info.ch_names}')
 
         if (ch1_name_info.groups()[0] != ch2_name_info.groups()[0]) or \
            (ch1_name_info.groups()[1] != ch2_name_info.groups()[1]) or \


### PR DESCRIPTION
#### Reference issue
addresses https://github.com/mne-tools/mne-python/pull/9141#discussion_r610730226


#### What does this implement/fix?
Use the info field for checking NIRS metadata is stored correctly, not the raw structure.


#### Additional information
As suggested by @HanBnrd, and this should enable usage in functions that only have access to info, like set_montage.