### PR TITLE
MRG: Use info to get NIRS metadata, not raw

### DIFF
--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -209,7 +209,7 @@ def _interpolate_bads_nirs(inst, method='nearest', exclude=(), verbose=None):
         _check_channels_ordered
 
     # Returns pick of all nirs and ensures channels are correctly ordered
-    freqs = np.unique(_channel_frequencies(inst))
+    freqs = np.unique(_channel_frequencies(inst.info))
     picks_nirs = _check_channels_ordered(inst.info, freqs)
     if len(picks_nirs) == 0:
         return

--- a/mne/preprocessing/nirs/_beer_lambert_law.py
+++ b/mne/preprocessing/nirs/_beer_lambert_law.py
@@ -34,7 +34,7 @@ def beer_lambert_law(raw, ppf=0.1):
     raw = raw.copy().load_data()
     _validate_type(raw, BaseRaw, 'raw')
 
-    freqs = np.unique(_channel_frequencies(raw))
+    freqs = np.unique(_channel_frequencies(raw.info))
     picks = _check_channels_ordered(raw.info, freqs)
     abs_coef = _load_absorption(freqs)
     distances = source_detector_distances(raw.info)
@@ -56,7 +56,7 @@ def beer_lambert_law(raw, ppf=0.1):
                 ch['ch_name']: '%s %s' % (ch['ch_name'][:-4], kind)})
 
     # Validate the format of data after transformation is valid
-    chroma = np.unique(_channel_chromophore(raw))
+    chroma = np.unique(_channel_chromophore(raw.info))
     _check_channels_ordered(raw.info, chroma)
     return raw
 

--- a/mne/preprocessing/nirs/_optical_density.py
+++ b/mne/preprocessing/nirs/_optical_density.py
@@ -28,7 +28,8 @@ def optical_density(raw):
     """
     raw = raw.copy().load_data()
     _validate_type(raw, BaseRaw, 'raw')
-    _check_channels_ordered(raw.info, np.unique(_channel_frequencies(raw)))
+    _check_channels_ordered(raw.info,
+                            np.unique(_channel_frequencies(raw.info)))
 
     picks = _picks_to_idx(raw.info, 'fnirs_cw_amplitude')
     data_means = np.mean(raw.get_data(), axis=1)

--- a/mne/preprocessing/nirs/_scalp_coupling_index.py
+++ b/mne/preprocessing/nirs/_scalp_coupling_index.py
@@ -49,7 +49,7 @@ def scalp_coupling_index(raw, l_freq=0.7, h_freq=1.5,
         raise RuntimeError('Scalp coupling index '
                            'should be run on optical density data.')
 
-    freqs = np.unique(_channel_frequencies(raw))
+    freqs = np.unique(_channel_frequencies(raw.info))
     picks = _check_channels_ordered(raw.info, freqs)
 
     filtered_data = filter_data(raw._data, raw.info['sfreq'], l_freq, h_freq,

--- a/mne/preprocessing/nirs/_tddr.py
+++ b/mne/preprocessing/nirs/_tddr.py
@@ -43,7 +43,8 @@ def temporal_derivative_distribution_repair(raw, *, verbose=None):
     """
     raw = raw.copy().load_data()
     _validate_type(raw, BaseRaw, 'raw')
-    _check_channels_ordered(raw.info, np.unique(_channel_frequencies(raw)))
+    _check_channels_ordered(raw.info,
+                            np.unique(_channel_frequencies(raw.info)))
 
     if not len(pick_types(raw.info, fnirs='fnirs_od')):
         raise RuntimeError('TDDR should be run on optical density data.')

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -55,25 +55,24 @@ def short_channels(info, threshold=0.01):
     return source_detector_distances(info) < threshold
 
 
-def _channel_frequencies(raw):
+def _channel_frequencies(info):
     """Return the light frequency for each channel."""
     # Only valid for fNIRS data before conversion to haemoglobin
-    picks = _picks_to_idx(raw.info, ['fnirs_cw_amplitude', 'fnirs_od'],
+    picks = _picks_to_idx(info, ['fnirs_cw_amplitude', 'fnirs_od'],
                           exclude=[], allow_empty=True)
     freqs = np.empty(picks.size, int)
     for ii in picks:
-        freqs[ii] = raw.info['chs'][ii]['loc'][9]
+        freqs[ii] = info['chs'][ii]['loc'][9]
     return freqs
 
 
-def _channel_chromophore(raw):
+def _channel_chromophore(info):
     """Return the chromophore of each channel."""
     # Only valid for fNIRS data after conversion to haemoglobin
-    picks = _picks_to_idx(raw.info, ['hbo', 'hbr'],
-                          exclude=[], allow_empty=True)
+    picks = _picks_to_idx(info, ['hbo', 'hbr'], exclude=[], allow_empty=True)
     chroma = []
     for ii in picks:
-        chroma.append(raw.ch_names[ii].split(" ")[1])
+        chroma.append(info['ch_names'][ii].split(" ")[1])
     return chroma
 
 

--- a/mne/preprocessing/nirs/tests/test_nirs.py
+++ b/mne/preprocessing/nirs/tests/test_nirs.py
@@ -157,9 +157,9 @@ def test_fnirs_channel_naming_and_order_readers(fname):
 
     # All standard readers should pass tests
     raw = read_raw_nirx(fname)
-    freqs = np.unique(_channel_frequencies(raw))
+    freqs = np.unique(_channel_frequencies(raw.info))
     assert_array_equal(freqs, [760, 850])
-    chroma = np.unique(_channel_chromophore(raw))
+    chroma = np.unique(_channel_chromophore(raw.info))
     assert len(chroma) == 0
 
     picks = _check_channels_ordered(raw.info, freqs)
@@ -183,19 +183,19 @@ def test_fnirs_channel_naming_and_order_readers(fname):
 
     # Check on OD data
     raw = optical_density(raw)
-    freqs = np.unique(_channel_frequencies(raw))
+    freqs = np.unique(_channel_frequencies(raw.info))
     assert_array_equal(freqs, [760, 850])
-    chroma = np.unique(_channel_chromophore(raw))
+    chroma = np.unique(_channel_chromophore(raw.info))
     assert len(chroma) == 0
     picks = _check_channels_ordered(raw.info, freqs)
     assert len(picks) == len(raw.ch_names)  # as all fNIRS only data
 
     # Check on haemoglobin data
     raw = beer_lambert_law(raw)
-    freqs = np.unique(_channel_frequencies(raw))
+    freqs = np.unique(_channel_frequencies(raw.info))
     assert len(freqs) == 0
-    assert len(_channel_chromophore(raw)) == len(raw.ch_names)
-    chroma = np.unique(_channel_chromophore(raw))
+    assert len(_channel_chromophore(raw.info)) == len(raw.ch_names)
+    chroma = np.unique(_channel_chromophore(raw.info))
     assert_array_equal(chroma, ["hbo", "hbr"])
     picks = _check_channels_ordered(raw.info, chroma)
     assert len(picks) == len(raw.ch_names)
@@ -218,7 +218,7 @@ def test_fnirs_channel_naming_and_order_custom_raw():
     for idx, f in enumerate(freqs):
         raw.info["chs"][idx]["loc"][9] = f
 
-    freqs = np.unique(_channel_frequencies(raw))
+    freqs = np.unique(_channel_frequencies(raw.info))
     picks = _check_channels_ordered(raw.info, freqs)
     assert len(picks) == len(raw.ch_names)
     assert len(picks) == 6
@@ -291,7 +291,7 @@ def test_fnirs_channel_naming_and_order_custom_optical_density():
     for idx, f in enumerate(freqs):
         raw.info["chs"][idx]["loc"][9] = f
 
-    freqs = np.unique(_channel_frequencies(raw))
+    freqs = np.unique(_channel_frequencies(raw.info))
     picks = _check_channels_ordered(raw.info, freqs)
     assert len(picks) == len(raw.ch_names)
     assert len(picks) == 6
@@ -334,7 +334,7 @@ def test_fnirs_channel_naming_and_order_custom_chroma():
     info = create_info(ch_names=ch_names, ch_types=ch_types, sfreq=1.0)
     raw = RawArray(data, info, verbose=True)
 
-    chroma = np.unique(_channel_chromophore(raw))
+    chroma = np.unique(_channel_chromophore(raw.info))
     picks = _check_channels_ordered(raw.info, chroma)
     assert len(picks) == len(raw.ch_names)
     assert len(picks) == 6


### PR DESCRIPTION
#### Reference issue
Addresses https://github.com/mne-tools/mne-python/pull/9141#discussion_r610730226.


#### What does this implement/fix?
Use the info field to get NIRS frequencies and chromophores, not the raw structure.


#### Additional information
Extension of @rob-luke's work with #9280.
This should enable usage in functions that only have access to info, like set_montage.
