### PR TITLE
Better warning message for EDF files with annotations only

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -597,7 +597,9 @@ def _read_edf_header(fname, exclude):
         if record_length[0] == 0:
             record_length = record_length[0] = 1.
             warn('Header information is incorrect for record length. Default '
-                 'record length set to 1.')
+                 'record length set to 1.\nIt is possible that this file only'
+                 ' contains annotations and no signals. In that case, please '
+                 'use mne.read_annotations() to load these annotations.')
 
         nchan = int(_edf_str(fid.read(4)))
         channels = list(range(nchan))


### PR DESCRIPTION
Fixes #9271. The example file mentioned in #9271 contains only annotations and no signals. `mne.io.read_raw_edf` throws an error later in the pipeline. At least for this example file, `record_length[0] == 0` is `True`, so I just extended the warning message there. I don't know if this catches all possible annotations-only cases, but I'd go with YAGNI for now.