### PR TITLE
FIX: Prepare for PyVista 0.30.0 (part 2)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
 - spyder-kernels>=1.10.0
 - imageio-ffmpeg>=0.4.1
 - vtk>=9.0.1
-- pyvista>=0.24,<=0.29
+- pyvista>=0.24
 - pyvistaqt>=0.2.0
 - mayavi
 - PySurfer

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1692,8 +1692,10 @@ class Brain(object):
         # Remove the default key binding
         if getattr(self, "iren", None) is not None:
             try:
+                # pyvista<=0.30.0
                 self.plotter._key_press_event_callbacks.clear()
             except AttributeError:
+                # pyvista>=0.30.0
                 self.plotter.iren.clear_key_event_callbacks()
 
     def _clear_widgets(self):

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1692,7 +1692,7 @@ class Brain(object):
         # Remove the default key binding
         if getattr(self, "iren", None) is not None:
             try:
-                # pyvista<=0.30.0
+                # pyvista<0.30.0
                 self.plotter._key_press_event_callbacks.clear()
             except AttributeError:
                 # pyvista>=0.30.0

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1692,10 +1692,10 @@ class Brain(object):
         # Remove the default key binding
         if getattr(self, "iren", None) is not None:
             try:
-                # pyvista<0.30.0
+                # pyvista<0.3.0
                 self.plotter._key_press_event_callbacks.clear()
             except AttributeError:
-                # pyvista>=0.30.0
+                # pyvista>=0.3.0
                 self.plotter.iren.clear_key_event_callbacks()
 
     def _clear_widgets(self):

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -342,7 +342,7 @@ class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
         display(self._tool_bar)
         # viewer
         try:
-            # pyvista<=0.30.0
+            # pyvista<0.30.0
             viewer = self.plotter.show(
                 use_ipyvtk=True, return_viewer=True)
         except RuntimeError:

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -346,7 +346,7 @@ class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
                 use_ipyvtk=True, return_viewer=True)
         except RuntimeError:
             viewer = self.plotter.show(
-                backend="ipyvtk_simple", return_viewer=True)
+                jupyter_backend="ipyvtk_simple", return_viewer=True)
         viewer.layout.width = None  # unlock the fixed layout
         # main widget
         if self._dock is None:

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -342,9 +342,11 @@ class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
         display(self._tool_bar)
         # viewer
         try:
+            # pyvista<=0.30.0
             viewer = self.plotter.show(
                 use_ipyvtk=True, return_viewer=True)
         except RuntimeError:
+            # pyvista>=0.30.0
             viewer = self.plotter.show(
                 jupyter_backend="ipyvtk_simple", return_viewer=True)
         viewer.layout.width = None  # unlock the fixed layout

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -668,18 +668,13 @@ class _PyVistaRenderer(_AbstractRenderer):
                                  on_button_press,
                                  on_button_release,
                                  on_pick):
-        self.plotter.iren.AddObserver(
-            vtk.vtkCommand.RenderEvent,
-            on_mouse_move
-        )
-        self.plotter.iren.AddObserver(
-            vtk.vtkCommand.LeftButtonPressEvent,
-            on_button_press
-        )
-        self.plotter.iren.AddObserver(
-            vtk.vtkCommand.EndInteractionEvent,
-            on_button_release
-        )
+        try:
+            add_obs = self.plotter.iren.AddObserver
+        except AttributeError:
+            add_obs = self.plotter.iren.add_observer
+        add_obs(vtk.vtkCommand.RenderEvent, on_mouse_move)
+        add_obs(vtk.vtkCommand.LeftButtonPressEvent, on_button_press)
+        add_obs(vtk.vtkCommand.EndInteractionEvent, on_button_release)
         self.plotter.picker = vtk.vtkCellPicker()
         self.plotter.picker.AddObserver(
             vtk.vtkCommand.EndPickEvent,

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -669,8 +669,10 @@ class _PyVistaRenderer(_AbstractRenderer):
                                  on_button_release,
                                  on_pick):
         try:
+            # pyvista<=0.30.0
             add_obs = self.plotter.iren.AddObserver
         except AttributeError:
+            # pyvista>=0.30.0
             add_obs = self.plotter.iren.add_observer
         add_obs(vtk.vtkCommand.RenderEvent, on_mouse_move)
         add_obs(vtk.vtkCommand.LeftButtonPressEvent, on_button_press)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -669,7 +669,7 @@ class _PyVistaRenderer(_AbstractRenderer):
                                  on_button_release,
                                  on_pick):
         try:
-            # pyvista<=0.30.0
+            # pyvista<0.30.0
             add_obs = self.plotter.iren.AddObserver
         except AttributeError:
             # pyvista>=0.30.0

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -725,8 +725,10 @@ def test_plot_sensors_connectivity(renderer):
     fig = plot_sensors_connectivity(info=info, con=con, picks=picks)
     if renderer._get_3d_backend() == 'pyvista':
         try:
+            # pyvista<0.30.0
             title = fig.plotter.scalar_bar.GetTitle()
         except AttributeError:
+            # pyvista>=0.30.0
             title = list(fig.plotter.scalar_bars.values())[0].GetTitle()
     else:
         assert renderer._get_3d_backend() == 'mayavi'

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -724,7 +724,10 @@ def test_plot_sensors_connectivity(renderer):
 
     fig = plot_sensors_connectivity(info=info, con=con, picks=picks)
     if renderer._get_3d_backend() == 'pyvista':
-        title = fig.plotter.scalar_bar.GetTitle()
+        try:
+            title = fig.plotter.scalar_bar.GetTitle()
+        except AttributeError:
+            title = list(fig.plotter.scalar_bars.values())[0].GetTitle()
     else:
         assert renderer._get_3d_backend() == 'mayavi'
         # the last thing we add is the Tube, so we need to go

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ nilearn
 xlrd
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1
-pyvista>=0.24,<=0.29
+pyvista>=0.24
 pyvistaqt>=0.2.0
 tqdm
 mffpy>=0.5.7

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -10,7 +10,7 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py Pillow
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all" vtk
 	python -m pip install --progress-bar off --upgrade --only-binary ":all" matplotlib
-	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/cb59a9ddfd97f5724f733bc226b41fb9ad4c9c5f
+	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 	python -m pip install --progress-bar off --upgrade --only-binary="numba,llvmlite" -r requirements.txt
 else

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -20,6 +20,7 @@ if [[ "$CIRCLE_JOB" == "interactive_test" ]]; then
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" numba llvmlite
 	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 	python -m pip install --progress-bar off vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
+	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 	python -m pip install --progress-bar off --upgrade -r requirements_testing.txt
 	python -m pip install nitime
@@ -33,7 +34,7 @@ else  # standard doc build
 	echo "Installing doc build dependencies"
 	python -m pip uninstall -y pydata-sphinx-theme
 	python -m pip install --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
-	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/cb59a9ddfd97f5724f733bc226b41fb9ad4c9c5f
+	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 	python -m pip uninstall -yq pysurfer mayavi
 	python -m pip install -e .

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -15,7 +15,7 @@ else # pip --pre 3.9 (missing dipy in pre)
 	# built using vtk master branch on an Ubuntu 18.04.5 VM and uploaded to OSF:
 	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 	pip install --progress-bar off vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
-	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/cb59a9ddfd97f5724f733bc226b41fb9ad4c9c5f
+	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
 	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 fi
 pip install --progress-bar off --upgrade -r requirements_testing.txt


### PR DESCRIPTION
This PR brings the second wave of changes to adapt to PyVista 0.30.0 and PyVistaQt 0.3.0+

ToDo:
- [x] Revert Azure, Circle, `requirements.txt` and `environment.yml` to `pyvista/master` once https://github.com/pyvista/pyvistaqt/pull/95 is merged

Follows https://github.com/mne-tools/mne-python/pull/9274
Related to https://github.com/pyvista/pyvista/pull/1257