### PR TITLE
BUG: Fix bug with next without iter

### DIFF
--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1780,6 +1780,27 @@ def test_iter_evoked():
         assert_array_equal(x, y)
 
 
+@pytest.mark.parametrize('preload', (True, False))
+def test_iter_epochs(preload):
+    """Test iteration over epochs."""
+    raw, events, picks = _get_data()
+    epochs = Epochs(
+        raw, events[:5], event_id, tmin, tmax, picks=picks, preload=preload)
+    assert not hasattr(epochs, '_current_detrend_picks')
+    epochs_data = epochs.get_data()
+    data = list()
+    for _ in range(10):
+        try:
+            data.append(next(epochs))
+        except StopIteration:
+            break
+        else:
+            assert hasattr(epochs, '_current_detrend_picks')
+    assert not hasattr(epochs, '_current_detrend_picks')
+    data = np.array(data)
+    assert_allclose(data, epochs_data, atol=1e-20)
+
+
 def test_subtract_evoked():
     """Test subtraction of Evoked from Epochs."""
     raw, events, picks = _get_data()

--- a/mne/utils/mixin.py
+++ b/mne/utils/mixin.py
@@ -330,6 +330,8 @@ class GetEpochsMixin(object):
         event_id : int
             The event id. Only returned if ``return_event_id`` is ``True``.
         """
+        if not hasattr(self, '_current_detrend_picks'):
+            self.__iter__()  # ensure we're ready to iterate
         if self.preload:
             if self._current >= len(self._data):
                 self._stop_iter()


### PR DESCRIPTION
Closes #9295

I'm not 100% sure we should support just doing `next` like this since:
```
>>> x = [1, 2]
>>> next(x)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'list' object is not an iterator
>>> next(iter(x))
1
```
But I can live with the simple fix in this PR, and we used to support it, so why not if it saves some people some pain.