### PR TITLE
Introduce lower bounds for ExG peak detection thresholds

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -297,6 +297,8 @@ Bugs
 
 - Fix bug where ``backend='notebook'`` could not be used in :meth:`mne.SourceEstimate.plot` (:gh:`9305` by `Jean-Remi King`_)
 
+- `mne.preprocessing.find_eog_events`, `mne.preprocessing.find_ecg_events`, `mne.preprocessing.create_eog_epochs`, and `mne.preprocessing.create_ecg_epochs` now have better handling for situations where the signal is flat or the provided threshold value is too small due to floating point imprecisions (:gh:`xxx` by `Richard Höchenberger`_)
+
 - `mne.preprocessing.compute_proj_eog` and `mne.preprocessing.compute_proj_ecg` now return empty lists if no EOG or ECG events, respectively, could be found. Previously, we'd return ``None`` in these situations, which does not match the documented behavior of returning a list of projectors (:gh:`9277` by `Richard Höchenberger`_)
 
 API changes

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1246,7 +1246,7 @@ class ICA(ContainsMixin):
             The name of the channel to use for ECG peak detection.
             The argument is mandatory if the dataset contains no ECG
             channels.
-        threshold : float | str
+        threshold : float | 'auto'
             The value above which a feature is classified as outlier. If 'auto'
             and method is 'ctps', automatically compute the threshold. If
             'auto' and method is 'correlation', defaults to 3.0. The default

--- a/mne/preprocessing/tests/test_ssp.py
+++ b/mne/preprocessing/tests/test_ssp.py
@@ -63,11 +63,7 @@ def test_compute_proj_ecg(short_raw, average):
         projs, events, drop_log = compute_proj_ecg(
             raw, n_mag=2, n_grad=2, n_eeg=2, ch_name='MEG 1531', bads=[],
             average=average, avg_ref=True, no_proj=True, l_freq=None,
-            h_freq=None, tmax=dur_use, return_drop_log=True,
-            # XXX can be removed once
-            # XXX https://github.com/mne-tools/mne-python/issues/9273
-            # XXX has been resolved:
-            qrs_threshold=1e-15)
+            h_freq=None, tmax=dur_use, return_drop_log=True)
     assert projs == []
     assert len(events) == len(drop_log)
 


### PR DESCRIPTION
Fixes #9273

We set `100 * eps` as the lower bound.