### PR TITLE
maint: ignore jinja deprecation warning

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -771,6 +771,7 @@ def reset_warnings(gallery_conf, fname):
                 r'Converting `np\.character` to a dtype is deprecated',  # vtk
                 r'sphinx\.util\.smartypants is deprecated',
                 'is a deprecated alias for the builtin',  # NumPy
+                'the old name will be removed',  # Jinja, via sphinx
                 ):
         warnings.filterwarnings(  # deal with other modules having bad imports
             'ignore', message=".*%s.*" % key, category=DeprecationWarning)


### PR DESCRIPTION
works around the deprecation warning. I think there's also a theme error about `'meta'` being undefined which I didn't get to today.  @larsoner feel free to push here if you want, otherwise I'll pick it up tomorrow.