### PR TITLE
MAINT: Check name URLs

### DIFF
--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -1,10 +1,10 @@
 .. _Alex Gramfort: http://alexandre.gramfort.net
 
-.. _Martin Luessi: https://www.martinos.org/user/8245
+.. _Martin Luessi: https://github.com/mluessi
 
 .. _Yaroslav Halchenko: http://www.onerussian.com/
 
-.. _Daniel Strohmeier: http://www.tu-ilmenau.de/bmti/fachgebiete/biomedizinische-technik/dipl-ing-daniel-strohmeier/
+.. _Daniel Strohmeier: https://github.com/joewalter
 
 .. _Eric Larson: http://larsoner.com
 
@@ -38,7 +38,7 @@
 
 .. _Qunxi Dong: https://github.com/dongqunxi
 
-.. _Martin Billinger: https://github.com/kazemakase
+.. _Martin Billinger: https://github.com/mbillingr
 
 .. _Federico Raimondo: https://github.com/fraimondo
 
@@ -68,7 +68,7 @@
 
 .. _Yousra Bekhti: https://www.linkedin.com/pub/yousra-bekhti/56/886/421
 
-.. _Mark Wronkiewicz: http://ilabs.washington.edu/graduate-students/bio/i-labs-mark-wronkiewicz
+.. _Mark Wronkiewicz: https://ml.jpl.nasa.gov/people/wronkiewicz/wronkiewicz.html
 
 .. _Sébastien Marti: http://www.researchgate.net/profile/Sebastien_Marti
 
@@ -88,15 +88,15 @@
 
 .. _Jukka Nenonen: https://www.linkedin.com/pub/jukka-nenonen/28/b5a/684
 
-.. _Jussi Nurminen: https://scholar.google.fi/citations?user=R6CQz5wAAAAJ&hl=en
+.. _Jussi Nurminen: https://github.com/jjnurminen
 
-.. _Clemens Brunner: https://github.com/cle1109
+.. _Clemens Brunner: https://github.com/cbrnr
 
 .. _Asish Panda: https://github.com/kaichogami
 
-.. _Natalie Klein: http://www.stat.cmu.edu/people/students/neklein
+.. _Natalie Klein: http://natklein.weebly.com
 
-.. _Jon Houck: https://scholar.google.com/citations?user=DNoS05IAAAAJ&hl=en
+.. _Jon Houck: https://www.mrn.org/people/jon-m.-houck/principal-investigators
 
 .. _Pablo-Arias: https://github.com/Pablo-Arias
 
@@ -122,7 +122,7 @@
 
 .. _Antti Rantala: https://github.com/Odingod
 
-.. _Keith Doelling: http://science.keithdoelling.com
+.. _Keith Doelling: https://github.com/kdoelling1919
 
 .. _Paul Pasler: https://github.com/ppasler
 
@@ -130,7 +130,7 @@
 
 .. _Annalisa Pascarella: http://www.iac.rm.cnr.it/~pasca/
 
-.. _Luke Bloy: https://scholar.google.com/citations?hl=en&user=Ad_slYcAAAAJ&view_op=list_works&sortby=pubdate
+.. _Luke Bloy: https://imaging.research.chop.edu/people/dr-luke-bloy
 
 .. _Leonardo Barbosa: https://github.com/noreun
 
@@ -188,7 +188,7 @@
 
 .. _Thomas Hartmann: https://github.com/thht
 
-.. _Steven Gutstein: http://robust.cs.utep.edu/~gutstein
+.. _Steven Gutstein: http://vll.cs.utep.edu/team.html
 
 .. _Peter Molfese: https://github.com/pmolfese
 
@@ -232,9 +232,9 @@
 
 .. _Guillaume Favelier: https://github.com/GuillaumeFavelier
 
-.. _Katarina Slama: https://katarinaslama.github.io
+.. _Katarina Slama: https://github.com/katarinaslama
 
-.. _Bruno Nicenboim: http://nicenboim.org
+.. _Bruno Nicenboim: https://bnicenboim.github.io
 
 .. _Ivana Kojcic: https://github.com/ikojcic
 
@@ -288,7 +288,7 @@
 
 .. _Chun-Hui Li: https://github.com/iamsc
 
-.. _Christian O'Reilly: https://scholar.google.ca/citations?user=NllRAkwAAAAJ&hl=en
+.. _Christian O'Reilly: https://github.com/christian-oreilly
 
 .. _Yu-Han Luo: https://github.com/yh-luo
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -136,7 +136,7 @@
 
 .. _Erkka Heinila: https://github.com/Teekuningas
 
-.. _Andrea Brovelli: http://www.int.univ-amu.fr/_BROVELLI-Andrea_?lang=en
+.. _Andrea Brovelli: http://andrea-brovelli.net
 
 .. _Richard Höchenberger: https://github.com/hoechenberger
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -416,6 +416,7 @@ def append_attr_meth_examples(app, what, name, obj, options, lines):
 linkcheck_request_headers = dict(user_agent='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36')  # noqa: E501
 linkcheck_ignore = [  # will be compiled to regex
     r'https://datashare.is.ed.ac.uk/handle/10283/2189\?show=full',  # noqa Max retries exceeded with url: /handle/10283/2189?show=full (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1123)')))
+    'https://doi.org/10.1002/mds.870120629',  # Read timed out.
     'https://doi.org/10.1088/0031-9155/32/1/004',  # noqa Read timed out. (read timeout=15)
     'https://doi.org/10.1088/0031-9155/40/3/001',  # noqa Read timed out. (read timeout=15)
     'https://doi.org/10.1088/0031-9155/51/7/008',  # noqa Read timed out. (read timeout=15)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -87,6 +87,7 @@ extensions = [
     'gen_commands',
     'gh_substitutions',
     'mne_substitutions',
+    'gen_names',
     'sphinx_bootstrap_divs',
     'sphinxcontrib.bibtex',
     'sphinx_copybutton',

--- a/doc/sphinxext/gen_names.py
+++ b/doc/sphinxext/gen_names.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+import os
+from os import path as op
+
+
+def setup(app):
+    app.connect('builder-inited', generate_name_links_rst)
+
+
+def setup_module():
+    # HACK: Stop nosetests running setup() above
+    pass
+
+
+def generate_name_links_rst(app=None):
+    if 'linkcheck' not in str(app.builder).lower():
+        return
+    out_dir = op.abspath(op.join(op.dirname(__file__), '..', 'generated'))
+    if not op.isdir(out_dir):
+        os.mkdir(out_dir)
+    out_fname = op.join(out_dir, '_names.rst')
+    names_path = op.abspath(
+        op.join(os.path.dirname(__file__), '..', 'changes', 'names.inc'))
+    with open(out_fname, 'w', encoding='utf8') as fout:
+        fout.write(':orphan:\n\n')
+        with open(names_path, 'r') as fin:
+            for line in fin:
+                if line.startswith('.. _'):
+                    fout.write(f'- {line[4:]}')


### PR DESCRIPTION
Currently we don't check anyone's `names.inc` URLs but we should. This adds a little extension that outputs a `generated/_names.rst` when using the linkcheck builder.

I see some failures locally with the check so I'll push that first to make sure we see it on CIs, then I'll add another commit to fix them.