### PR TITLE
MAINT: Mark more tests as slow for macOS

### DIFF
--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -107,7 +107,12 @@ def _simulate_data(fwd, idx):  # Somewhere on the frontal lobe by default
     return epochs, evoked, csd, source_vertno, label, vertices, source_ind
 
 
-idx_param = pytest.mark.parametrize('idx', [0, 100, 200, 233])
+idx_param = pytest.mark.parametrize('idx', [
+    0,
+    pytest.param(100, marks=pytest.mark.slowtest),
+    200,
+    pytest.param(233, marks=pytest.mark.slowtest),
+])
 
 
 def _rand_csd(rng, info):
@@ -139,7 +144,10 @@ def _make_rand_csd(info, csd):
 @testing.requires_testing_data
 @requires_h5py
 @idx_param
-@pytest.mark.parametrize('whiten', (False, True))
+@pytest.mark.parametrize('whiten', [
+    pytest.param(False, marks=pytest.mark.slowtest),
+    True,
+])
 def test_make_dics(tmpdir, _load_forward, idx, whiten):
     """Test making DICS beamformer filters."""
     # We only test proper handling of parameters here. Testing the results is
@@ -707,6 +715,7 @@ def _cov_as_csd(cov, info):
 
 # Just test free ori here (assume fixed is same as LCMV if these are)
 # Changes here should be synced with test_lcmv.py
+@pytest.mark.slowtest
 @pytest.mark.parametrize(
     'reg, pick_ori, weight_norm, use_cov, depth, lower, upper, real_filter', [
         (0.05, None, 'unit-noise-gain-invariant', False, None, 26, 28, False),

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -549,8 +549,8 @@ def test_lcmv_ctf_comp():
 @pytest.mark.parametrize('proj, weight_norm', [
     (True, 'unit-noise-gain'),
     (False, 'unit-noise-gain'),
-    (True, None),
-    (True, 'nai'),
+    pytest.param(True, None, marks=pytest.mark.slowtest),
+    pytest.param(True, 'nai', marks=pytest.mark.slowtest),
 ])
 def test_lcmv_reg_proj(proj, weight_norm):
     """Test LCMV with and without proj."""
@@ -762,10 +762,10 @@ def test_orientation_max_power(bias_params_fixed, bias_params_free,
 
 
 @pytest.mark.parametrize('weight_norm, pick_ori', [
-    ('nai', 'max-power'),
+    pytest.param('nai', 'max-power', marks=pytest.mark.slowtest),
     ('unit-noise-gain', 'vector'),
     ('unit-noise-gain', 'max-power'),
-    ('unit-noise-gain', None),
+    pytest.param('unit-noise-gain', None, marks=pytest.mark.slowtest),
 ])
 def test_depth_does_not_matter(bias_params_free, weight_norm, pick_ori):
     """Test that depth weighting does not matter for normalized filters."""

--- a/mne/io/fieldtrip/fieldtrip.py
+++ b/mne/io/fieldtrip/fieldtrip.py
@@ -8,7 +8,8 @@ import numpy as np
 
 from .utils import _create_info, _set_tmin, _create_events, \
     _create_event_metadata, _validate_ft_struct
-from .. import RawArray
+from ...utils import _check_fname
+from ..array.array import RawArray
 from ...epochs import EpochsArray
 from ...evoked import EvokedArray
 
@@ -44,6 +45,7 @@ def read_raw_fieldtrip(fname, info, data_name='data'):
         A Raw Object containing the loaded data.
     """
     from ...externals.pymatreader import read_mat
+    fname = _check_fname(fname, overwrite='read', must_exist=True)
 
     ft_struct = read_mat(fname,
                          ignore_fields=['previous'],

--- a/mne/io/fieldtrip/tests/test_fieldtrip.py
+++ b/mne/io/fieldtrip/tests/test_fieldtrip.py
@@ -35,9 +35,12 @@ all_test_params_epochs = list(itertools.product(all_systems_epochs,
                                                 use_info))
 # just for speed we skip some slowest ones -- the coverage should still
 # be sufficient
-for key in [('CTF', 'v73', True), ('neuromag306', 'v73', False)]:
-    all_test_params_epochs.pop(all_test_params_epochs.index(key))
-    all_test_params_raw.pop(all_test_params_raw.index(key))
+for obj in (all_test_params_epochs, all_test_params_raw):
+    for key in [('CTF', 'v73', True), ('neuromag306', 'v73', False)]:
+        obj.pop(obj.index(key))
+    for ki, key in enumerate(obj):
+        if key[1] == 'v73':
+            obj[ki] = pytest.param(*obj[ki], marks=pytest.mark.slowtest)
 
 no_info_warning = {'expected_warning': RuntimeWarning,
                    'match': NOINFO_WARNING}

--- a/mne/viz/_brain/tests/test_notebook.py
+++ b/mne/viz/_brain/tests/test_notebook.py
@@ -34,6 +34,7 @@ def test_notebook_alignment(renderer_notebook, brain_gc, nbexec):
     assert fig.display is not None
 
 
+@pytest.mark.slowtest  # ~3 min on GitHub macOS
 @testing.requires_testing_data
 def test_notebook_interactive(renderer_notebook, brain_gc, nbexec):
     """Test interactive modes."""


### PR DESCRIPTION
On most PRs we end up waiting for the macOS CI to finish. This is probably really because it takes 20 minutes (!) to set up the conda env, but we might as well also cut our testing time down from the 30 minutes that it currently runs there. This PR does it without sacrificing much testing by skipping some tests that are mostly redundant once we've run them on one OS, so let's let Linux do the heavy lifting and make macOS and Windows (which both `pytest -m "not slowtest"`) a bit faster.