### PR TITLE
fix epochs vlines

### DIFF
--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -2135,6 +2135,9 @@ class MNEBrowseFigure(MNEFigure):
         """Redraw (convenience method for frequently grouped actions)."""
         if update_data:
             self._update_data()
+        if self.mne.vline_visible and self.mne.is_epochs:
+            # prevent flickering
+            _ = self._recompute_epochs_vlines(None)
         self._draw_traces()
         if annotations and not self.mne.is_epochs:
             self._draw_annotations()

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -478,8 +478,7 @@ class MNEBrowseFigure(MNEFigure):
                             self.mne.n_times / self.mne.info['sfreq'])
         # VLINE
         vline_color = (0., 0.75, 0.)
-        vline_kwargs = dict(visible=False, animated=True,
-                            zorder=self.mne.zorder['vline'])
+        vline_kwargs = dict(visible=False, zorder=self.mne.zorder['vline'])
         if self.mne.is_epochs:
             x = np.arange(self.mne.n_epochs)
             vline = ax_main.vlines(
@@ -569,10 +568,7 @@ class MNEBrowseFigure(MNEFigure):
         self.mne.zen_w *= old_width / new_width
         self.mne.zen_h *= old_height / new_height
         self.mne.fig_size_px = (new_width, new_height)
-        # for blitting
         self.canvas.draw_idle()
-        self.canvas.flush_events()
-        self.mne.bg = self.canvas.copy_from_bbox(self.bbox)
 
     def _hover(self, event):
         """Handle motion event when annotating."""
@@ -774,6 +770,7 @@ class MNEBrowseFigure(MNEFigure):
                                 self._toggle_bad_channel(idx)
                             return
                 self._show_vline(event.xdata)  # butterfly / not on data trace
+                self._redraw(update_data=False, annotations=False)
                 return
             # click in vertical scrollbar
             elif event.inaxes == self.mne.ax_vscroll:
@@ -806,8 +803,8 @@ class MNEBrowseFigure(MNEFigure):
                 self._remove_annotation_hover_line()
                 self._draw_annotations()
                 self.canvas.draw_idle()
-            elif event.inaxes == ax_main:  # hide green line
-                self._blit_vline(False)
+            elif event.inaxes == ax_main:
+                self._toggle_vline(False)
 
     def _pick(self, event):
         """Handle matplotlib pick events."""
@@ -1872,8 +1869,6 @@ class MNEBrowseFigure(MNEFigure):
         self._update_picks()
         self._update_trace_offsets()
         self._redraw(annotations=True)
-        if self.mne.vline_visible:
-            self._blit_vline(True)
         if self.mne.fig_selection is not None:
             self.mne.fig_selection._style_radio_buttons_butterfly()
 
@@ -2144,10 +2139,6 @@ class MNEBrowseFigure(MNEFigure):
         if annotations and not self.mne.is_epochs:
             self._draw_annotations()
         self.canvas.draw_idle()
-        self.canvas.flush_events()
-        self.mne.bg = self.canvas.copy_from_bbox(self.bbox)
-        if self.mne.vline_visible:
-            self._blit_vline(True)
 
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     # EVENT LINES AND MARKER LINES
@@ -2185,41 +2176,45 @@ class MNEBrowseFigure(MNEFigure):
                     textcoords='offset points', fontsize=8)
                 self.mne.event_texts.append(this_text)
 
+    def _recompute_epochs_vlines(self, xdata):
+        """Recompute vline x-coords for epochs plots (after scrolling, etc)."""
+        # special case: changed view duration w/ "home" or "end" key
+        # (no click event, hence no xdata)
+        if xdata is None:
+            xdata = np.array(self.mne.vline.get_segments())[0, 0, 0]
+        # compute the (continuous) times for the lines on each epoch
+        epoch_dur = np.diff(self.mne.boundary_times[:2])[0]
+        rel_time = xdata % epoch_dur
+        abs_time = self.mne.times[0]
+        xs = np.arange(self.mne.n_epochs) * epoch_dur + abs_time + rel_time
+        segs = np.array(self.mne.vline.get_segments())
+        # recreate segs from scratch in case view duration changed
+        # (i.e., handle case when n_segments != n_epochs)
+        segs = np.tile([[0.], [1.]], (len(xs), 1, 2))  # y values
+        segs[..., 0] = np.tile(xs[:, None], 2)         # x values
+        self.mne.vline.set_segments(segs)
+        return rel_time
+
     def _show_vline(self, xdata):
-        """Show the vertical line."""
+        """Show the vertical line(s)."""
         if self.mne.is_epochs:
             # special case: changed view duration w/ "home" or "end" key
             # (no click event, hence no xdata)
-            if xdata is None:
-                xdata = np.array(self.mne.vline.get_segments())[0, 0, 0]
-            # compute the (continuous) times for the lines on each epoch
-            epoch_dur = np.diff(self.mne.boundary_times[:2])[0]
-            rel_time = xdata % epoch_dur
-            abs_time = self.mne.times[0]
-            xs = np.arange(self.mne.n_epochs) * epoch_dur + abs_time + rel_time
-            segs = np.array(self.mne.vline.get_segments())
-            # handle changed view duration (n_segments != n_epochs)
-            if segs.shape[0] != len(xs):
-                segs = np.tile([[0.], [1.]], (len(xs), 1, 2))  # y values
-            segs[..., 0] = np.tile(xs[:, None], 2)
-            self.mne.vline.set_segments(segs)
+            rel_time = self._recompute_epochs_vlines(xdata)
             xdata = rel_time + self.mne.inst.times[0]  # for the text
         else:
             self.mne.vline.set_xdata(xdata)
             self.mne.vline_hscroll.set_xdata(xdata)
-        self.mne.vline_text.set_text(f'{xdata:0.2f}  ')
-        self._blit_vline(True)
+        self.mne.vline_text.set_text(f'{xdata:0.2f} s ')
+        self._toggle_vline(True)
 
-    def _blit_vline(self, visible):
-        """Restore or hide the vline after data change."""
-        self.canvas.restore_region(self.mne.bg)
+    def _toggle_vline(self, visible):
+        """Show or hide the vertical line(s)."""
         for artist in (self.mne.vline, self.mne.vline_hscroll,
                        self.mne.vline_text):
             if artist is not None:
                 artist.set_visible(visible)
                 self.draw_artist(artist)
-        self.canvas.blit()
-        self.canvas.flush_events()
         self.mne.vline_visible = visible
 
 

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -892,10 +892,6 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
     fig._update_data()
     fig._draw_traces()
 
-    # for blitting
-    fig.canvas.flush_events()
-    fig.mne.bg = fig.canvas.copy_from_bbox(fig.bbox)
-
     plt_show(show, block=block)
     return fig
 

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -1080,9 +1080,5 @@ def _plot_sources(ica, inst, picks, exclude, start, stop, show, title, block,
         fig._update_annotation_segments()
         fig._draw_annotations()
 
-    # for blitting
-    fig.canvas.flush_events()
-    fig.mne.bg = fig.canvas.copy_from_bbox(fig.bbox)
-
     plt_show(show, block=block)
     return fig

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -360,10 +360,6 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
     if show_options:
         fig._toggle_proj_fig()
 
-    # for blitting
-    fig.canvas.flush_events()
-    fig.mne.bg = fig.canvas.copy_from_bbox(fig.bbox)
-
     plt_show(show, block=block)
     return fig
 


### PR DESCRIPTION
closes #9276 (supersedes)

In order to get this fixed before release time, I've removed the blitting code.  This slows down vline drawing (esp. in butterfly mode, where it can take up to a few seconds) but at least now the bug is fixed.  I'll try to restore the blitting after release, when there is more time for testing.

@jasmainak can you test?