### PR TITLE
MRG, MAINT: Better split of reqs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE.txt
 include SECURITY.md
 include requirements.txt
 include requirements_testing.txt
+include requirements_testing_extra.txt
 include requirements_doc.txt
 include mne/__init__.py
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,7 +107,7 @@ stages:
     - bash: |
         set -e
         python -m pip install --upgrade pip setuptools
-        python -m pip install --upgrade numpy scipy vtk -r requirements.txt -r requirements_testing.txt codecov
+        python -m pip install --upgrade numpy scipy vtk -r requirements.txt -r requirements_testing.txt -r requirements_testing_extra.txt codecov
       displayName: 'Install dependencies with pip'
     - bash: source tools/get_testing_version.sh
       displayName: 'Get testing version'
@@ -146,7 +146,7 @@ stages:
         conda env update --file server_environment.yml
         pip uninstall -yq mne
         pip install -ve .
-        pip install pytest pytest-cov pytest-timeout pytest-sugar pytest-xdist flake8 codecov
+        pip install -r requirements_testing.txt -r requirements_testing_extra.txt codecov
         echo "##vso[task.setvariable variable=PATH]${PATH}"
         echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]${LD_LIBRARY_PATH}"
       displayName: 'Install dependencies'
@@ -233,7 +233,7 @@ stages:
         conda update -n base -c defaults conda
         conda env update --name base --file environment.yml
         pip uninstall -yq mne
-        pip install -r requirements_testing.txt codecov
+        pip install -r requirements_testing.txt -r requirements_testing_extra.txt codecov
       condition: eq(variables['TEST_MODE'], 'conda')
       displayName: 'Install dependencies with conda'
     - script: python setup.py develop

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# requirements for full MNE-Python functionality (other than raw/epochs export)
 numpy>=1.15.4
 scipy>=1.1.0
 matplotlib

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,7 +1,8 @@
+# requirements for building docs
 sphinx
 https://github.com/numpy/numpydoc/archive/main.zip
 pydata-sphinx-theme==0.6.1
-sphinx-gallery
+https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip
 sphinxcontrib-bibtex>=2.1.2
 memory_profiler
 neo

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,15 +1,13 @@
+# requirements for running tests (on top of environment.yml/requirements.txt)
 pytest!=4.6.0
 pytest-cov
 pytest-timeout
 pytest-harvest
-ipytest
 flake8
 flake8-array-spacing
-sphinx-gallery
 numpydoc
 codespell
 pydocstyle
 check-manifest
 twine
 wheel
-nbclient

--- a/requirements_testing_extra.txt
+++ b/requirements_testing_extra.txt
@@ -1,0 +1,4 @@
+# requirements for full testing (on top of environment.yml/requirements.txt)
+nitime
+nbclient
+sphinx-gallery

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -17,4 +17,4 @@ else
 	echo "Unknown run type ${TEST_MODE}"
 	exit 1
 fi
-python -m pip install -r requirements_testing.txt codecov
+python -m pip install -r requirements_testing.txt -r requirements_testing_extra.txt codecov

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -22,8 +22,7 @@ if [[ "$CIRCLE_JOB" == "interactive_test" ]]; then
 	python -m pip install --progress-bar off vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
-	python -m pip install --progress-bar off --upgrade -r requirements_testing.txt
-	python -m pip install nitime
+	python -m pip install --progress-bar off --upgrade -r requirements_testing.txt -r requirements_testing_extra.txt
 	python -m pip install -e .
 elif [[ "$CIRCLE_JOB" == "linkcheck"* ]]; then
 	echo "Installing minimal linkcheck dependencies"

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -20,5 +20,5 @@ else # pip --pre 3.9 (missing dipy in pre)
 fi
 pip install --progress-bar off --upgrade -r requirements_testing.txt
 if [ "${DEPS}" != "minimal" ]; then
-	pip install nitime
+	pip install --progress-bar off --upgrade -r requirements_testing_extra.txt
 fi


### PR DESCRIPTION
Inspired by #9192 I think we need a little bit more granularity in our test infrastructure, so:

1. Remove `ipytest`, it was errantly added
2. Make SG dep on the latest dev version (see https://github.com/sphinx-gallery/sphinx-gallery/issues/817#issuecomment-824925909, I think we should always use latest SG dev to catch bugs etc. -- we are good early users)
3. Split off some reqs into `requirements_testing_extra.txt`
4. Add comments to our `requirements_*` files to make it clearer why we have/need them
5. Update `azure-pipelines.yml` to include the `requirements_testing_extra.txt` installs

Overall I hope this makes things a bit more DRY and well defined. @drammock I know you've been disappointed with the structure of our requirements, can you see if you think this at least helps instead of making things worse?