### PR TITLE
DICS beamformer: deprecate the use of complex filter

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -316,3 +316,5 @@ API changes
 - Fitting `~mne.preprocessing.ICA` on baseline-corrected `~mne.Epochs`, and / or applying it on baseline-corrected `~mne.Epochs` or `~mne.Evoked` data will now display a warning. Users are advised to only baseline correct their data after cleaning is completed (:gh:`9033` by `Richard Höchenberger`_)
 
 - Supplying multiple channel names to `mne.preprocessing.find_eog_events` or `mne.preprocessing.compute_proj_eog` as a string of comma-separated channel names has been deprecated; please pass a list of channel names instead. Support for comma-separated strings will be removed in MNE-Python 0.24 (:gh:`9269` by `Richard Höchenberger`_)
+
+- The default in :func:`mne.beamformer.make_dics` of ``real_filter=False`` will change to ``real_filter=True`` in 0.24 (:gh:`9340` by `Britta Westner`_)

--- a/mne/beamformer/_dics.py
+++ b/mne/beamformer/_dics.py
@@ -27,7 +27,7 @@ from ._compute_beamformer import (_prepare_beamformer_input,
 @verbose
 def make_dics(info, forward, csd, reg=0.05, noise_csd=None, label=None,
               pick_ori=None, rank=None, weight_norm=None,
-              reduce_rank=False, depth=1., real_filter=False,
+              reduce_rank=False, depth=1., real_filter=None,
               inversion='matrix', verbose=None):
     """Compute a Dynamic Imaging of Coherent Sources (DICS) spatial filter.
 
@@ -74,7 +74,11 @@ def make_dics(info, forward, csd, reg=0.05, noise_csd=None, label=None,
     %(depth)s
     real_filter : bool
         If ``True``, take only the real part of the cross-spectral-density
-        matrices to compute real filters. Defaults to ``False``.
+        matrices to compute real filters.
+
+        .. versionchanged:: 0.23
+            Version 0.23 deprecated ``False`` as default for ``real_filter``.
+            With version 0.24, ``True`` will be the new default.
     %(bf_inversion)s
 
         .. versionchanged:: 0.21
@@ -172,6 +176,14 @@ def make_dics(info, forward, csd, reg=0.05, noise_csd=None, label=None,
     # remove bads so that equalize_channels only keeps all good
     info = pick_info(info, pick_channels(info['ch_names'], [], info['bads']))
     info, forward, csd = equalize_channels([info, forward, csd])
+
+    if real_filter is None:
+        depr_message = ('The current default of real_filter=False is '
+                        'deprecated and will be changed to real_filter=True '
+                        'in version 0.24. Set real_filter explicitly to '
+                        'avoid this warning.')
+        warn(depr_message, DeprecationWarning)
+        real_filter = False
 
     csd, noise_csd = _prepare_noise_csd(csd, noise_csd, real_filter)
 

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -140,6 +140,8 @@ def _make_rand_csd(info, csd):
     return noise_csd, rank
 
 
+@pytest.mark.filterwarnings('ignore:.*real_filter.*will be changed.*:'
+                            'DeprecationWarning')
 @pytest.mark.slowtest
 @testing.requires_testing_data
 @requires_h5py
@@ -334,6 +336,8 @@ def _fwd_dist(power, fwd, vertices, source_ind, tidx=1):
     return np.linalg.norm(rr_got - rr_want)
 
 
+@pytest.mark.filterwarnings('ignore:.*real_filter.*will be changed.*:'
+                            'DeprecationWarning')
 @idx_param
 @pytest.mark.parametrize('inversion, weight_norm', [
     ('single', None),
@@ -366,6 +370,8 @@ def test_apply_dics_csd(_load_forward, idx, inversion, weight_norm):
         assert power.data[source_ind, 1] > power.data[source_ind, 0]
 
 
+@pytest.mark.filterwarnings('ignore:.*real_filter.*will be changed.*:'
+                            'DeprecationWarning')
 @pytest.mark.parametrize('pick_ori', [None, 'normal', 'max-power'])
 @pytest.mark.parametrize('inversion', ['single', 'matrix'])
 @idx_param
@@ -417,6 +423,8 @@ def _nearest_vol_ind(fwd_vol, fwd, vertices, source_ind):
         fwd['src'][0]['rr'][vertices][source_ind][np.newaxis])[0]
 
 
+@pytest.mark.filterwarnings('ignore:.*real_filter.*will be changed.*:'
+                            'DeprecationWarning')
 @idx_param
 def test_real(_load_forward, idx):
     """Test using a real-valued filter."""
@@ -467,6 +475,8 @@ def test_real(_load_forward, idx):
         apply_dics_csd(csd, filters_vol)
 
 
+@pytest.mark.filterwarnings('ignore:.*real_filter.*will be changed.*:'
+                            'DeprecationWarning')
 @pytest.mark.filterwarnings("ignore:The use of several sensor types with the"
                             ":RuntimeWarning")
 @idx_param
@@ -575,6 +585,8 @@ def test_apply_dics_timeseries(_load_forward, idx):
 @pytest.mark.slowtest
 @testing.requires_testing_data
 @pytest.mark.filterwarnings('ignore:.*tf_dics is dep.*:DeprecationWarning')
+@pytest.mark.filterwarnings('ignore:.*real_filter.*will be changed.*:'
+                            'DeprecationWarning')
 def test_tf_dics(_load_forward):
     """Test 5D time-frequency beamforming based on DICS."""
     fwd_free, fwd_surf, fwd_fixed, _ = _load_forward
@@ -756,6 +768,8 @@ def test_localization_bias_free(bias_params_free, reg, pick_ori, weight_norm,
     assert lower <= perc <= upper
 
 
+@pytest.mark.filterwarnings('ignore:.*real_filter.*will be changed.*:'
+                            'DeprecationWarning')
 @testing.requires_testing_data
 @idx_param
 @pytest.mark.parametrize('whiten', (False, True))


### PR DESCRIPTION
As discussed in #9215, this PR implements the deprecation of `real_filter=False` in `make_dics`. Instead of using a complex filter by default, the filter should be real-valued.

