### PR TITLE
WIP,MNT: Migrate to ipyvtklink

### DIFF
--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -348,7 +348,8 @@ class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
         except RuntimeError:
             # pyvista>=0.30.0
             viewer = self.plotter.show(
-                jupyter_backend="ipyvtk_simple", return_viewer=True)
+                jupyter_backend="ipyvtklink", return_viewer=True)
+
         viewer.layout.width = None  # unlock the fixed layout
         # main widget
         if self._dock is None:


### PR DESCRIPTION
Starting from `0.30.0`, `pyvista` uses `ipyvtklink` instead of `ipyvtk_simple`. 

In `server_environment.yml`, `ipyvtk_simple` is still installed so I expect the CIs to come back green with 71792d6 but after the release, it will fail because `show()` will return a static image instead of the expected `Viewer` widget.

It's an item of https://github.com/mne-tools/mne-python/issues/8704