### PR TITLE
MRG: Add SNIRF support for 2D locations and NIRx files

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -187,6 +187,9 @@ Enhancements
 
 - Add support for setting montages on fNIRS data, with built in standard montages for Artinis OctaMon and Artinis Brite23 devices (:gh:`9141` by `Johann Benerradi`_, `Robert Luke`_ and `Eric Larson`_)
 
+- Enable support for reading SNIRF files with 2D optode positions (:gh:`9347` `Robert Luke`_)
+
+
 Bugs
 ~~~~
 - Fix bug with :func:`mne.viz.plot_evoked_topo` where set ylim parameters gets swapped across channel types. (:gh:`9207` by |Ram Pari|_)

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -735,16 +735,9 @@ def _set_montage_fnirs(info, montage):
     stored. This function modifies info['chs'][#]['loc'] and info['dig'] in
     place.
     """
-    from ..preprocessing.nirs import (_channel_frequencies,
-                                      _channel_chromophore,
-                                      _check_channels_ordered)
+    from ..preprocessing.nirs import _validate_nirs_info
     # Validate that the fNIRS info is correctly formatted
-    freqs = np.unique(_channel_frequencies(info))
-    if freqs.size > 0:
-        picks = _check_channels_ordered(info, freqs)
-    else:
-        picks = _check_channels_ordered(info,
-                                        np.unique(_channel_chromophore(info)))
+    picks = _validate_nirs_info(info)
 
     # Modify info['chs'][#]['loc'] in place
     num_ficiduals = len(montage.dig) - len(montage.ch_names)

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -254,7 +254,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.117', misc='0.9')
+    releases = dict(testing='0.118', misc='0.9')
     # And also update the "md5_hashes['testing']" variable below.
     # To update any other dataset, update the data archive itself (upload
     # an updated version) and update the md5 hash.
@@ -349,7 +349,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='12b75d1cb7df9dfb4ad73ed82f61094f',
         somato='32fd2f6c8c7eb0784a1de6435273c48b',
         spm='9f43f67150e3b694b523a21eb929ea75',
-        testing='d8df35b2e625e213769e97e719de205c',
+        testing='0ca196c6dc4966570e14151cdf7ad4a5',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         fnirs_motor='c4935d19ddab35422a69f3326a01fef8',
         opm='370ad1dcfd5c47e029e692c85358a374',

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1726,6 +1726,7 @@ def test_bad_acq(fname):
             assert tag == ent
 
 
+@testing.requires_testing_data
 @pytest.mark.skipif(sys.platform not in ('darwin', 'linux'),
                     reason='Needs proper symlinking')
 def test_split_symlink(tmpdir):

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -67,6 +67,8 @@ class RawSNIRF(BaseRaw):
     def __init__(self, fname, preload=False, verbose=None):
         _require_version('h5py', 'read raw SNIRF data')
         from ...externals.pymatreader.utils import _import_h5py
+        # Must be here due to circular import error
+        from ...preprocessing.nirs import _validate_nirs_info
         h5py = _import_h5py()
 
         fname = _check_fname(fname, 'read', True, 'fname')
@@ -107,18 +109,6 @@ class RawSNIRF(BaseRaw):
             if sampling_rate == 0:
                 warn("Unable to extract sample rate from SNIRF file.")
 
-            sources = np.array(dat.get('nirs/probe/sourceLabels'))
-            detectors = np.array(dat.get('nirs/probe/detectorLabels'))
-            sources = [s.decode('UTF-8') for s in sources]
-            detectors = [d.decode('UTF-8') for d in detectors]
-
-            # Extract source and detector locations
-            detPos3D = np.array(dat.get('nirs/probe/detectorPos3D'))
-            srcPos3D = np.array(dat.get('nirs/probe/sourcePos3D'))
-
-            assert len(sources) == srcPos3D.shape[0]
-            assert len(detectors) == detPos3D.shape[0]
-
             # Extract wavelengths
             fnirs_wavelengths = np.array(dat.get('nirs/probe/wavelengths'))
             fnirs_wavelengths = [int(w) for w in fnirs_wavelengths]
@@ -134,6 +124,63 @@ class RawSNIRF(BaseRaw):
             channels_idx = np.array(['measurementList' in n for n in channels])
             channels = channels[channels_idx]
             channels = sorted(channels, key=natural_keys)
+
+            # Source and detector labels are optional fields.
+            # Use S1, S2, S3, etc if not specified.
+            if 'sourceLabels' in dat['nirs/probe']:
+                sources = np.array(dat.get('nirs/probe/sourceLabels'))
+                sources = [s.decode('UTF-8') for s in sources]
+            else:
+                sources = np.unique([dat.get('nirs/data1/' + c +
+                                             '/sourceIndex')[0]
+                                     for c in channels])
+                sources = [f"S{s}" for s in sources]
+
+            if 'detectorLabels' in dat['nirs/probe']:
+                detectors = np.array(dat.get('nirs/probe/detectorLabels'))
+                detectors = [d.decode('UTF-8') for d in detectors]
+
+            else:
+                detectors = np.unique([dat.get('nirs/data1/' + c +
+                                               '/detectorIndex')[0]
+                                       for c in channels])
+                detectors = [f"D{d}" for d in detectors]
+
+            # Extract source and detector locations
+            # 3D positions are optional in SNIRF,
+            # but highly recommended in MNE.
+            if ('detectorPos3D' in dat['nirs/probe']) &\
+                    ('sourcePos3D' in dat['nirs/probe']):
+                # If 3D positions are available they are used even if 2D exists
+                detPos3D = np.array(dat.get('nirs/probe/detectorPos3D'))
+                srcPos3D = np.array(dat.get('nirs/probe/sourcePos3D'))
+            elif ('detectorPos2D' in dat['nirs/probe']) &\
+                    ('sourcePos2D' in dat['nirs/probe']):
+                warn('The data only contains 2D location information for the '
+                     'optode positions. '
+                     'It is highly recommended that data is used '
+                     'which contains 3D location information for the '
+                     'optode positions. With only 2D locations it can not be '
+                     'guaranteed that MNE functions will behave correctly '
+                     'and produce accurate results. If it is not possible to '
+                     'include 3D positions in your data, please consider '
+                     'using the set_montage() function.')
+
+                detPos2D = np.array(dat.get('nirs/probe/detectorPos2D'))
+                srcPos2D = np.array(dat.get('nirs/probe/sourcePos2D'))
+                # Set the third dimension to zero. See gh#9308
+                detPos3D = np.append(detPos2D,
+                                     np.zeros((detPos2D.shape[0], 1)), axis=1)
+                srcPos3D = np.append(srcPos2D,
+                                     np.zeros((srcPos2D.shape[0], 1)), axis=1)
+
+            else:
+                raise RuntimeError('No optode location information is '
+                                   'provided. MNE requires at least 2D '
+                                   'location information')
+
+            assert len(sources) == srcPos3D.shape[0]
+            assert len(detectors) == detPos3D.shape[0]
 
             chnames = []
             for chan in channels:
@@ -265,7 +312,8 @@ class RawSNIRF(BaseRaw):
             annot = Annotations([], [], [])
             for key in dat['nirs']:
                 if 'stim' in key:
-                    data = np.array(dat.get('/nirs/' + key + '/data'))
+                    data = np.atleast_2d(np.array(
+                        dat.get('/nirs/' + key + '/data')))
                     if data.size > 0:
                         annot.append(data[:, 0], 1.0, key[4:])
             self.set_annotations(annot)
@@ -277,6 +325,9 @@ class RawSNIRF(BaseRaw):
                 chans.append(idx)
                 chans.append(idx + num_chans // 2)
             self.pick(picks=chans)
+
+        # Validate that the fNIRS info is correctly formatted
+        _validate_nirs_info(self.info)
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a segment of data from a file."""

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -38,7 +38,7 @@ def read_raw_snirf(fname, preload=False, verbose=None):
     Returns
     -------
     raw : instance of RawSNIRF
-        A Raw object containing SNIRF data.
+        A Raw object containing fNIRS data.
 
     See Also
     --------

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -23,6 +23,10 @@ def read_raw_snirf(fname, preload=False, verbose=None):
 
     .. note:: This reader supports the .snirf file type only,
               not the .jnirs version.
+              Files with either 3D or 2D locations can be read.
+              However, we strongly recommend using 3D positions.
+              If 2D positions are used the behaviour of MNE functions
+              can not be guaranteed.
 
     Parameters
     ----------

--- a/mne/io/snirf/tests/test_snirf.py
+++ b/mne/io/snirf/tests/test_snirf.py
@@ -170,7 +170,8 @@ def test_snirf_nirsport2():
     assert_almost_equal(raw.info['sfreq'], 7.6, decimal=1)
 
     # Test channel naming
-    assert raw.info['ch_names'][:4] == ['S1_D1 760', 'S1_D1 850', 'S1_D3 760', 'S1_D3 850']
+    assert raw.info['ch_names'][:4] == ['S1_D1 760', 'S1_D1 850',
+                                        'S1_D3 760', 'S1_D3 850']
     assert raw.info['ch_names'][24:26] == ['S6_D4 760', 'S6_D4 850']
 
     # Test frequency encoding

--- a/mne/io/snirf/tests/test_snirf.py
+++ b/mne/io/snirf/tests/test_snirf.py
@@ -158,7 +158,6 @@ def test_snirf_nonstandard(tmpdir):
         f.create_dataset("nirs/metaDataTags/MNE_coordFrame", data=[1])
 
 
-
 @requires_testing_data
 @requires_h5py
 def test_snirf_nirsport2():

--- a/mne/io/snirf/tests/test_snirf.py
+++ b/mne/io/snirf/tests/test_snirf.py
@@ -40,7 +40,7 @@ nirx_nirsport2_103 = op.join(data_path(download=False),
                                     nirx_nirsport2_103,
                                     sfnirs_homer_103_153]))
 def test_basic_reading_and_min_process(fname):
-    """Test reading SNIRF files and minimum typical processing"""
+    """Test reading SNIRF files and minimum typical processing."""
     raw = read_raw_snirf(fname, preload=True)
     # SNIRF data can contain several types, so only apply appropriate functions
     if 'fnirs_cw_amplitude' in raw:

--- a/mne/io/snirf/tests/test_snirf.py
+++ b/mne/io/snirf/tests/test_snirf.py
@@ -16,7 +16,7 @@ from mne.preprocessing.nirs import (optical_density, beer_lambert_law,
 
 # SfNIRS files
 sfnirs_homer_103_wShort = op.join(data_path(download=False),
-                                  'snirf', 'SfNIRS', 'snirf_homer3', '1.0.3',
+                                  'SNIRF', 'SfNIRS', 'snirf_homer3', '1.0.3',
                                   'snirf_1_3_nirx_15_2_'
                                   'recording_w_short.snirf')
 sfnirs_homer_103_wShort_original = op.join(data_path(download=False),
@@ -24,12 +24,12 @@ sfnirs_homer_103_wShort_original = op.join(data_path(download=False),
                                            'nirx_15_2_recording_w_short')
 
 sfnirs_homer_103_153 = op.join(data_path(download=False),
-                               'snirf', 'SfNIRS', 'snirf_homer3', '1.0.3',
+                               'SNIRF', 'SfNIRS', 'snirf_homer3', '1.0.3',
                                'nirx_15_3_recording.snirf')
 
 # NIRx files
 nirx_nirsport2_103 = op.join(data_path(download=False),
-                             'snirf', 'NIRx', 'NIRSport2', '1.0.3',
+                             'SNIRF', 'NIRx', 'NIRSport2', '1.0.3',
                              '2021-04-23_005.snirf')
 
 

--- a/mne/preprocessing/nirs/__init__.py
+++ b/mne/preprocessing/nirs/__init__.py
@@ -8,7 +8,8 @@
 
 from .nirs import (short_channels, source_detector_distances,
                    _check_channels_ordered, _channel_frequencies,
-                   _fnirs_check_bads, _fnirs_spread_bads, _channel_chromophore)
+                   _fnirs_check_bads, _fnirs_spread_bads, _channel_chromophore,
+                   _validate_nirs_info)
 from ._optical_density import optical_density
 from ._beer_lambert_law import beer_lambert_law
 from ._scalp_coupling_index import scalp_coupling_index

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -172,6 +172,17 @@ def _check_channels_ordered(info, pair_vals):
     return picks_cw
 
 
+def _validate_nirs_info(info):
+    """Apply all checks to fNIRS info. Works on all continuous wave types."""
+    freqs = np.unique(_channel_frequencies(info))
+    if freqs.size > 0:
+        picks = _check_channels_ordered(info, freqs)
+    else:
+        picks = _check_channels_ordered(info,
+                                        np.unique(_channel_chromophore(info)))
+    return picks
+
+
 def _fnirs_check_bads(raw):
     """Check consistent labeling of bads across fnirs optodes."""
     # For an optode pair, if one component (light frequency or chroma) is

--- a/mne/preprocessing/nirs/tests/test_nirs.py
+++ b/mne/preprocessing/nirs/tests/test_nirs.py
@@ -31,6 +31,7 @@ fname_nirx_15_2_short = op.join(data_path(download=False),
                                 'nirx_15_2_recording_w_short')
 
 
+@testing.requires_testing_data
 def test_fnirs_picks():
     """Test picking of fnirs types after different conversions."""
     raw = read_raw_nirx(fname_nirx_15_0)

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -627,6 +627,7 @@ def test_split_files(tmpdir, split_naming):
     assert len(report.fnames) == 1
 
 
+@testing.requires_testing_data
 def test_survive_pickle(tmpdir):
     """Testing functionality of Report-Object after pickling."""
     tempdir = str(tmpdir)

--- a/tools/get_testing_version.sh
+++ b/tools/get_testing_version.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -ef
 
 TESTING_VERSION=`grep -o "testing='[0-9.]\+'" mne/datasets/utils.py | cut -d \' -f 2 | sed "s/\./-/g"`
-# This can be incremented to start fresh when the cache misbehaves
-TESTING_VERSION=${TESTING_VERSION}-1
+# This can be incremented to start fresh when the cache misbehaves, e.g.:
+# TESTING_VERSION=${TESTING_VERSION}-1
 if [ ! -z $GITHUB_ENV ]; then
 	echo "TESTING_VERSION="$TESTING_VERSION >> $GITHUB_ENV
 elif [ ! -z $AZURE_CI ]; then

--- a/tools/get_testing_version.sh
+++ b/tools/get_testing_version.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -ef
 
 TESTING_VERSION=`grep -o "testing='[0-9.]\+'" mne/datasets/utils.py | cut -d \' -f 2 | sed "s/\./-/g"`
+# This can be incremented to start fresh when the cache misbehaves
+TESTING_VERSION=${TESTING_VERSION}-1
 if [ ! -z $GITHUB_ENV ]; then
 	echo "TESTING_VERSION="$TESTING_VERSION >> $GITHUB_ENV
 elif [ ! -z $AZURE_CI ]; then


### PR DESCRIPTION
#### Reference issue
Closes #9338 mne-tools/mne-nirs#257 #9308.


#### What does this implement/fix?
This PR enables reading of SNIRF files from the NIRx vendor and it also enables reading of SNIRF files with 2D locations from the SfNIRS team.

Support for 2D locations was enabled by setting the z coordinate to 0.

Support for NIRx was enabled by not relying on the `sourceLabels` field in SNIRF. Which was optional in the spec, so I shouldn't have expected it to be there.


#### Additional information
People may wish to support no sensor location info, but they can do that in a future PR.

It may also be possible to do some fancy 2D to 3D conversion for data, but that would be significant work.

I wanted to use an exact copy of some code, so I turned it in to a function called `_validate_nirs_info`

Specifically validating and testing Artinis files will have to wait till someone can provide test data. However, I think this will achieve the 2D support they require.