### PR TITLE
BUG: Fix concat on Windows

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1229,7 +1229,7 @@ class Brain(object):
     def _configure_tool_bar(self):
         self._renderer._tool_bar_load_icons()
         self._renderer._tool_bar_set_theme(self.theme)
-        self._renderer._tool_bar_initialize()
+        self._renderer._tool_bar_initialize(name="Toolbar")
         self._renderer._tool_bar_add_file_button(
             name="screenshot",
             desc="Take a screenshot",

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2642,8 +2642,10 @@ class Brain(object):
                             facecolor=self._bg_color, edgecolor='none')
                 output.seek(0)
                 trace_img = imread(output, format='png')[:, :, :3]
-            img = concatenate_images(
-                [img, trace_img], bgcolor=self._brain_color[:3])
+                trace_img = np.clip(
+                    np.round(trace_img * 255), 0, 255).astype(np.uint8)
+            bgcolor = np.array(self._brain_color[:3]) / 255
+            img = concatenate_images([img, trace_img], bgcolor=bgcolor)
         return img
 
     @contextlib.contextmanager

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -391,7 +391,7 @@ class _QtWindow(_AbstractWindow):
 
     def _window_adjust_mplcanvas_layout(self):
         canvas = self._mplcanvas.canvas
-        dock, dock_layout = _create_dock_widget(
+        self._mpl_dock, dock_layout = _create_dock_widget(
             self._window, "Traces", Qt.BottomDockWidgetArea)
         dock_layout.addWidget(canvas)
 
@@ -414,10 +414,14 @@ class _QtWindow(_AbstractWindow):
         # plotter.frame:      QFrame with QVBoxLayout with plotter.interactor as centralWidget  # noqa
         # plotter.ren_win:    vtkXOpenGLRenderWindow
         self._interactor.setMinimumSize(*sz)
+        # Lines like this are useful for debugging these issues:
+        # print('*' * 80)
+        # print(0, self._interactor.app_window.size().height(), self._interactor.size().height(), self._mpl_dock.widget().height(), self._mplcanvas.canvas.size().height())  # noqa
         if adjust_mpl:
             mpl_h = int(round((sz[1] * self._interactor_fraction) /
                               (1 - self._interactor_fraction)))
             self._mplcanvas.canvas.setMinimumSize(sz[0], mpl_h)
+            self._mpl_dock.widget().setMinimumSize(sz[0], mpl_h)
         try:
             yield  # show
         finally:
@@ -431,11 +435,17 @@ class _QtWindow(_AbstractWindow):
             self._interactor.setMinimumSize(0, 0)
             if adjust_mpl:
                 self._mplcanvas.canvas.setMinimumSize(0, 0)
+                self._mpl_dock.widget().setMinimumSize(0, 0)
             self._process_events()
             self._process_events()
-            # 4. Resize the window and interactor to the correct size
+            # 4. Compute the extra height required for dock decorations and add
+            win_h = win_sz.height()
+            if adjust_mpl:
+                win_h += max(
+                    self._mpl_dock.widget().size().height() - mpl_h, 0)
+            # 5. Resize the window and interactor to the correct size
             #    (not sure why, but this is required on macOS at least)
-            self._interactor.window_size = (win_sz.width(), win_sz.height())
+            self._interactor.window_size = (win_sz.width(), win_h)
             self._interactor.resize(ren_sz.width(), ren_sz.height())
             self._process_events()
             self._process_events()
@@ -513,9 +523,12 @@ class _Renderer(_PyVistaRenderer, _QtDock, _QtToolBar, _QtMenuBar,
 
 
 def _create_dock_widget(window, name, area):
-    dock = QDockWidget()
+    # create dock widget
+    dock = QDockWidget(name)
+    # add scroll area
     scroll = QScrollArea(dock)
     dock.setWidget(scroll)
+    # give the scroll area a child widget
     widget = QWidget(scroll)
     scroll.setWidget(widget)
     scroll.setWidgetResizable(True)


### PR DESCRIPTION
Closes #9336

@crsegerie can you see if this fixes your problem? 

I was able to replicate on Windows. Basically I think the problem was that after our DPI calculations, the resulting size was something like `1406.99999999` instead of `1407`, so MPL made something with only 1406 pixels instead of 1407 and this broke things. We could try tweaking our DPI calculations, but it seems safer just to output a PNG then read it back, as this has the dimensions, then make use of our smart concat function to take care of any difference in dimension.

Okay with you @GuillaumeFavelier ?