### PR TITLE
make graphviz diagram a link

### DIFF
--- a/tutorials/preprocessing/40_artifact_correction_ica.py
+++ b/tutorials/preprocessing/40_artifact_correction_ica.py
@@ -136,9 +136,18 @@ raw.crop(tmax=60.)
 # parameters that control dimensionality at various stages are summarized in
 # the diagram below:
 #
+#
+# .. raw:: html
+#
+#    <a href="../../_images/graphviz-7483cb1cf41f06e2a4ef451b17f073dbe584ba30.png">
+#
 # .. graphviz:: ../../_static/diagrams/ica.dot
 #    :alt: Diagram of ICA procedure in MNE-Python
 #    :align: left
+#
+# .. raw:: html
+#
+#    </a>
 #
 # See the Notes section of the `~mne.preprocessing.ICA` documentation
 # for further details. Next we'll walk through an extended example that


### PR DESCRIPTION
closes #9223 

This is hackish because the graphviz-generated image has a dynamically generated filename like `../../_images/graphviz-7483cb1cf41f06e2a4ef451b17f073dbe584ba30.png`. It appears to be deterministic though (same filename on the live site as is generated for me locally), so as long as the diagram's source code remains the same (and possibly, as long as the same version of graphviz is in use?), the link should work.

I think the right way to do it would be for someone to enhance `sphinx.ext.graphviz` to add a new option `:href:` or `:link:` or similar that would cause an `<a>` tag to get generated that wraps around the `<img>` (instead of what's done here, which wraps around the `img` and 2 containing `div`s).  But I'm skeptical whether such an enhancement would be accepted upstream, since SVG output can have links on specific graph elements...  not sure how that would play out.