### PR TITLE
Add qdarkstyle, darkdetect to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,6 +25,8 @@ dependencies:
 - vtk>=9.0.1
 - pyvista>=0.24
 - pyvistaqt>=0.2.0
+- qdarkstyle
+- darkdetect
 - mayavi
 - PySurfer
 - dipy


### PR DESCRIPTION
I've added a darkdetect  package to conda-forge, so it's now trivial to include the packages we need for dark theme selection & automated theme switching in our official conda environment – should be done anyway so our CIs "see" this. Would be cool to get this merged before we make the official 0.23 announcement.