### PR TITLE
MRG: Add fNIRS to html output

### DIFF
--- a/mne/data/html_templates.py
+++ b/mne/data/html_templates.py
@@ -33,7 +33,7 @@ info_template = Template("""
     <tr>
         <th>Good channels</th>
         <td>{{n_mag}} magnetometer, {{n_grad}} gradiometer,
-            and {{n_eeg}} EEG channels</td>
+            {{n_eeg}} EEG channels, and {{n_fnirs}} fNIRS channels.</td>
     </tr>
     <tr>
         <th>Bad channels</th>

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -816,6 +816,7 @@ class Info(dict, MontageMixin):
         n_eeg = len(pick_types(self, meg=False, eeg=True))
         n_grad = len(pick_types(self, meg='grad'))
         n_mag = len(pick_types(self, meg='mag'))
+        n_fnirs = len(pick_types(self, meg=False, eeg=True, fnirs=True))
         pick_eog = pick_types(self, meg=False, eog=True)
         if len(pick_eog) > 0:
             eog = ', '.join(np.array(self['ch_names'])[pick_eog])
@@ -832,7 +833,7 @@ class Info(dict, MontageMixin):
 
         html += info_template.substitute(
             caption=caption, info=self, meas_date=meas_date, n_eeg=n_eeg,
-            n_grad=n_grad, n_mag=n_mag, eog=eog, ecg=ecg)
+            n_grad=n_grad, n_mag=n_mag, n_fnirs=n_fnirs, eog=eog, ecg=ecg)
         return html
 
 

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -816,7 +816,7 @@ class Info(dict, MontageMixin):
         n_eeg = len(pick_types(self, meg=False, eeg=True))
         n_grad = len(pick_types(self, meg='grad'))
         n_mag = len(pick_types(self, meg='mag'))
-        n_fnirs = len(pick_types(self, meg=False, eeg=True, fnirs=True))
+        n_fnirs = len(pick_types(self, meg=False, eeg=False, fnirs=True))
         pick_eog = pick_types(self, meg=False, eog=True)
         if len(pick_eog) > 0:
             eog = ', '.join(np.array(self['ch_names'])[pick_eog])

--- a/tutorials/preprocessing/70_fnirs_processing.py
+++ b/tutorials/preprocessing/70_fnirs_processing.py
@@ -6,7 +6,8 @@ Preprocessing functional near-infrared spectroscopy (fNIRS) data
 
 This tutorial covers how to convert functional near-infrared spectroscopy
 (fNIRS) data from raw measurements to relative oxyhaemoglobin (HbO) and
-deoxyhaemoglobin (HbR) concentration.
+deoxyhaemoglobin (HbR) concentration, view the average waveform, and
+topographic representation of the response.
 
 Here we will work with the :ref:`fNIRS motor data <fnirs-motor-dataset>`.
 """


### PR DESCRIPTION
#### Reference issue
None. But I really love these html outputs in notebooks, so cool.


#### What does this implement/fix?
Add fNIRS to the html output for raw.


#### Additional information
I follow #9172, but am unsure how to test this change. Can we merge without a test?


#### Alternative solution

If you don't want to add fNIRS channels as they are less common we could have an optional row using:
```
    {{if n_fnirs > 0}}
        <th>fNIRS channels</th>
        <td>{{n_fnirs}}</td>
    {{endif}}
```
I tested this locally and it works too, I could do the same for EOG and ECG too if you want.