### PR TITLE
WIP: Use nirx name field to populate his_id

### DIFF
--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -247,11 +247,13 @@ class RawNIRX(BaseRaw):
         #       "Additional Notes", "Contact Information" and this information
         #       is currently discarded
         # NIRStar does not record an id, or handedness by default
+        # The name field is used to populate the his_id variable.
         subject_info = {}
         if is_aurora:
             names = inf["subject"].split()
         else:
             names = inf['name'].split()
+        subject_info['his_id'] = "_".join(names)
         if len(names) > 0:
             subject_info['first_name'] = \
                 names[0].replace("\"", "")

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -252,7 +252,7 @@ class RawNIRX(BaseRaw):
         if is_aurora:
             names = inf["subject"].split()
         else:
-            names = inf['name'].split()
+            names = inf['name'].replace('"', "").split()
         subject_info['his_id'] = "_".join(names)
         if len(names) > 0:
             subject_info['first_name'] = \

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -282,7 +282,8 @@ def test_nirx_15_2_short():
     assert raw.info['subject_info'] == dict(sex=1, first_name="MNE",
                                             middle_name="Test",
                                             last_name="Recording",
-                                            birthday=(2014, 8, 23))
+                                            birthday=(2014, 8, 23),
+                                            his_id="MNE_Test_Recording")
 
     # Test distance between optodes matches values from
     # nirsite https://github.com/mne-tools/mne-testing-data/pull/51
@@ -372,7 +373,9 @@ def test_nirx_15_3_short():
     assert raw.info['subject_info'] == dict(birthday=(2020, 8, 18),
                                             sex=0,
                                             first_name="testMontage\\0A"
-                                                       "TestMontage")
+                                                       "TestMontage",
+                                            his_id="testMontage\\0A"
+                                                   "TestMontage")
 
     # Test distance between optodes matches values from
     # https://github.com/mne-tools/mne-testing-data/pull/72
@@ -470,7 +473,8 @@ def test_nirx_15_2():
 
     # Test info import
     assert raw.info['subject_info'] == dict(sex=1, first_name="TestRecording",
-                                            birthday=(1989, 10, 2))
+                                            birthday=(1989, 10, 2),
+                                            his_id="TestRecording")
 
     # Test trigger events
     assert_array_equal(raw.annotations.description, ['4.0', '6.0', '2.0'])
@@ -523,7 +527,8 @@ def test_nirx_15_0():
     assert raw.info['subject_info'] == {'birthday': (2004, 10, 27),
                                         'first_name': 'NIRX',
                                         'last_name': 'Test',
-                                        'sex': FIFF.FIFFV_SUBJ_SEX_UNKNOWN}
+                                        'sex': FIFF.FIFFV_SUBJ_SEX_UNKNOWN,
+                                        'his_id': "NIRX_Test"}
 
     # Test trigger events
     assert_array_equal(raw.annotations.description, ['1.0', '2.0', '2.0'])


### PR DESCRIPTION
#### Reference issue
None


#### What does this implement/fix?
Use the name field to populate the `subject_info['his_id']` field. This then prints nicely in the html _repr_.


#### Additional information
When starting a recording with a nirx devices the user is presented with a GUI screen and can enter age, gender, experiment type, and name. I always this name field to enter the participant ID, like P1, P2, etc. Can we use this field to populate the his_id variable in mne? The name is a free field text input, so I guess some labs could actually enter a participant name in here, but I think its more common to enter an ID. But this is probably lab variable, so close if it seems a bad idea. I just like the nice html printing of his_id.
