### PR TITLE
WIP: Add more checks to ensure fNIRS bads are set correctly for optode pairs

### DIFF
--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -196,17 +196,17 @@ def _fnirs_check_bads(info):
             raise RuntimeError('NIRS bad labelling is not consistent')
 
 
-def _fnirs_spread_bads(raw):
+def _fnirs_spread_bads(info):
     """Spread bad labeling across fnirs channels."""
-    # For an optode if any component (light frequency or chroma) is marked
+    # For an optode pair if any component (light frequency or chroma) is marked
     # as bad, then they all should be. This function will find any pairs marked
     # as bad and spread the bad marking to all components of the optode pair.
-    picks = _picks_to_idx(raw.info, 'fnirs', exclude=[])
+    picks = _picks_to_idx(info, 'fnirs', exclude=[])
     new_bads = list()
     for ii in picks[::2]:
-        bad_opto = set(raw.info['bads']).intersection(raw.ch_names[ii:ii + 2])
+        bad_opto = set(info['bads']).intersection(info.ch_names[ii:ii + 2])
         if len(bad_opto) > 0:
-            new_bads.extend(raw.ch_names[ii:ii + 2])
-    raw.info['bads'] = new_bads
+            new_bads.extend(info.ch_names[ii:ii + 2])
+    info['bads'] = new_bads
 
-    return raw
+    return info

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -169,6 +169,7 @@ def _check_channels_ordered(info, pair_vals):
                 ' as source detector pairs with alternating'
                 f' {error_word}: {pair_vals[0]} & {pair_vals[1]}')
 
+    _fnirs_check_bads(info)
     return picks_cw
 
 
@@ -183,14 +184,14 @@ def _validate_nirs_info(info):
     return picks
 
 
-def _fnirs_check_bads(raw):
+def _fnirs_check_bads(info):
     """Check consistent labeling of bads across fnirs optodes."""
     # For an optode pair, if one component (light frequency or chroma) is
     # marked as bad then they all should be. This function checks that all
     # optodes are marked bad consistently.
-    picks = _picks_to_idx(raw.info, 'fnirs', exclude=[])
+    picks = _picks_to_idx(info, 'fnirs', exclude=[])
     for ii in picks[::2]:
-        bad_opto = set(raw.info['bads']).intersection(raw.ch_names[ii:ii + 2])
+        bad_opto = set(info['bads']).intersection(info.ch_names[ii:ii + 2])
         if len(bad_opto) == 1:
             raise RuntimeError('NIRS bad labelling is not consistent')
 

--- a/mne/preprocessing/nirs/tests/test_nirs.py
+++ b/mne/preprocessing/nirs/tests/test_nirs.py
@@ -135,20 +135,20 @@ def test_fnirs_spread_bads(fname):
     # Test spreading upwards in frequency and on raw data
     raw = read_raw_nirx(fname)
     raw.info['bads'] = ['S1_D1 760']
-    raw = _fnirs_spread_bads(raw)
-    assert raw.info['bads'] == ['S1_D1 760', 'S1_D1 850']
+    info = _fnirs_spread_bads(raw.info)
+    assert info['bads'] == ['S1_D1 760', 'S1_D1 850']
 
     # Test spreading downwards in frequency and on od data
     raw = optical_density(raw)
     raw.info['bads'] = raw.ch_names[5:6]
-    raw = _fnirs_spread_bads(raw)
-    assert raw.info['bads'] == raw.ch_names[4:6]
+    info = _fnirs_spread_bads(raw.info)
+    assert info['bads'] == raw.ch_names[4:6]
 
     # Test spreading multiple bads and on chroma data
     raw = beer_lambert_law(raw)
     raw.info['bads'] = [raw.ch_names[x] for x in [1, 8]]
-    raw = _fnirs_spread_bads(raw)
-    assert raw.info['bads'] == [raw.ch_names[x] for x in [0, 1, 8, 9]]
+    info = _fnirs_spread_bads(raw.info)
+    assert info['bads'] == [info.ch_names[x] for x in [0, 1, 8, 9]]
 
 
 @testing.requires_testing_data

--- a/mne/preprocessing/nirs/tests/test_nirs.py
+++ b/mne/preprocessing/nirs/tests/test_nirs.py
@@ -100,29 +100,31 @@ def test_fnirs_check_bads(fname):
     """Test checking of bad markings."""
     # No bad channels, so these should all pass
     raw = read_raw_nirx(fname)
-    _fnirs_check_bads(raw)
+    _fnirs_check_bads(raw.info)
     raw = optical_density(raw)
-    _fnirs_check_bads(raw)
+    _fnirs_check_bads(raw.info)
     raw = beer_lambert_law(raw)
-    _fnirs_check_bads(raw)
+    _fnirs_check_bads(raw.info)
 
     # Mark pairs of bad channels, so these should all pass
     raw = read_raw_nirx(fname)
     raw.info['bads'] = raw.ch_names[0:2]
-    _fnirs_check_bads(raw)
+    _fnirs_check_bads(raw.info)
     raw = optical_density(raw)
-    _fnirs_check_bads(raw)
+    _fnirs_check_bads(raw.info)
     raw = beer_lambert_law(raw)
-    _fnirs_check_bads(raw)
+    _fnirs_check_bads(raw.info)
 
     # Mark single channel as bad, so these should all fail
     raw = read_raw_nirx(fname)
     raw.info['bads'] = raw.ch_names[0:1]
-    pytest.raises(RuntimeError, _fnirs_check_bads, raw)
-    raw = optical_density(raw)
-    pytest.raises(RuntimeError, _fnirs_check_bads, raw)
-    raw = beer_lambert_law(raw)
-    pytest.raises(RuntimeError, _fnirs_check_bads, raw)
+    pytest.raises(RuntimeError, _fnirs_check_bads, raw.info)
+    with pytest.raises(RuntimeError, match='bad labelling'):
+        raw = optical_density(raw)
+    pytest.raises(RuntimeError, _fnirs_check_bads, raw.info)
+    with pytest.raises(RuntimeError, match='bad labelling'):
+        raw = beer_lambert_law(raw)
+    pytest.raises(RuntimeError, _fnirs_check_bads, raw.info)
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
#### Reference issue
Now that users can create and modify their own fnirs data structures (#9141) this adds more checks that the data structure is correct. Follows #9184 #9185


#### What does this implement/fix?
fNIRS channels come in pairs (either multiple wavelengths or chromaphore). If one of the pairs is set to bad then they both should be (see similar discussion about saturation here: https://github.com/mne-tools/mne-python/pull/9348#issuecomment-832123559). An internal function already existed to check that the bids are spread correctly across pairs. Here I just add another usage of this function.

I also modify these bad checking/spreading functions to use info rather than raw. As the checking other nirs checking functions now operate on info as suggested by @HanBnrd.


