### PR TITLE
FIX: make epoch cropping idempotent

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -28,7 +28,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Fix bug with :meth:`mne.Epochs.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** `Jan Sosulski`_)
+- Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** `Jan Sosulski`_)
 
 
 API changes

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -28,7 +28,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Nothing yet
+- Fix bug with :meth:`mne.Epochs.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** `Jan Sosulski`_)
 
 
 API changes

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -389,3 +389,5 @@
 .. _Jack Zhang: https://github.com/jackz314
 
 .. _Felix Klotzsche: https://github.com/eioe
+
+.. _Jan Sosulski: https://jan-sosulski.de

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1638,6 +1638,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
             warn('tmax is not in epochs time interval. tmax is set to '
                  'epochs.tmax')
             tmax = self.tmax
+            include_tmax = True
 
         tmask = _time_mask(self.times, tmin, tmax, sfreq=self.info['sfreq'],
                            include_tmax=include_tmax)

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -334,6 +334,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             warn(f'tmax is not in Evoked time interval. tmax is set to '
                  f'evoked.tmax ({self.tmax:g} sec)')
             tmax = self.tmax
+            include_tmax = True
 
         mask = _time_mask(self.times, tmin, tmax, sfreq=self.info['sfreq'],
                           include_tmax=include_tmax)

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1621,6 +1621,14 @@ def test_crop(tmpdir):
     assert np.isclose(epochs_cropped.tmax, epochs_cropped.reject_tmax)
     del epochs_cropped
 
+    # Test that repeated cropping is idempotent
+    epoch_crop = epochs.copy()
+    epoch_crop.crop(None, 0.4, include_tmax=False)
+    n_times = len(epoch_crop.times)
+    with pytest.warns(RuntimeWarning, match='tmax is set to'):
+        epoch_crop.crop(None, 0.4, include_tmax=False)
+        assert len(epoch_crop.times) == n_times
+
     # Cropping & I/O roundtrip
     epochs.crop(0, 0.1)
     epochs.save(temp_fname)

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -680,6 +680,10 @@ def test_time_as_index_and_crop():
     assert_array_equal(evoked.time_as_index([-.1, .1], use_rounding=True),
                        [0, len(evoked.times) - 1])
     evoked.crop(evoked.tmin, evoked.tmax, include_tmax=False)
+    n_times = len(evoked.times)
+    with pytest.warns(RuntimeWarning, match='tmax is set to'):
+        evoked.crop(tmin, tmax, include_tmax=False)
+    assert len(evoked.times) == n_times
     assert_allclose(evoked.times[[0, -1]], [tmin, tmax - delta], atol=atol)
 
 


### PR DESCRIPTION
#### Reference issue
Fixes #9374 


#### What does this implement/fix?
Set `include_tmax=True` when `tmax` is larger than the epoch.


#### Additional Information
I think this cannot be sensibly done in the `_time_mask` function as we do not know whether `tmax` was set automatically or not in that function. However, I do now knot if `_time_mask` should do this kind of error handling or if it is up to the calling functions.