### PR TITLE
MNT: Use pyvistaqt 0.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ For full functionality, some functions require:
 - DIPY >= 1.0.0
 - Imageio >= 2.6.1
 - PyVista >= 0.30
-- pyvistaqt >= 0.4.0
+- pyvistaqt >= 0.4
 - mffpy >= 0.5.7
 
 Contributing to MNE-Python

--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ For full functionality, some functions require:
 - DIPY >= 1.0.0
 - Imageio >= 2.6.1
 - PyVista >= 0.30
-- pyvistaqt >= 0.3.0
+- pyvistaqt >= 0.4.0
 - mffpy >= 0.5.7
 
 Contributing to MNE-Python

--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,7 @@ dependencies:
 - imageio-ffmpeg>=0.4.1
 - vtk>=9.0.1
 - pyvista>=0.30
+- pyvistaqt>=0.4
 - qdarkstyle
 - darkdetect
 - mayavi
@@ -38,4 +39,3 @@ dependencies:
 - ipywidgets
 - pip:
   - ipyvtklink
-  - https://api.github.com/repos/pyvista/pyvistaqt/zipball/8eb40405b31ef815527a2620bc395cb9c5548377

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ xlrd
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1
 pyvista>=0.30
-https://api.github.com/repos/pyvista/pyvistaqt/zipball/8eb40405b31ef815527a2620bc395cb9c5548377
+pyvistaqt>=0.4
 tqdm
 mffpy>=0.5.7
 ipywidgets


### PR DESCRIPTION
This PR follows the release of `pyvistaqt 0.4.0`. No need to pin a master commit anymore.