### PR TITLE
MRG, ENH: Extend usability of stc_near_sensors

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -39,6 +39,8 @@ Enhancements
 
 - New function :func:`mne.label.find_pos_in_annot` to get atlas label for MRI coordinates.  (:gh:`9376` by **by new contributor** |Marian Dovgialo|_)
 
+- Add support for ``picks`` in :func:`mne.stc_near_sensors` (:gh:`9396` by `Eric Larson`_)
+
 Bugs
 ~~~~
 - Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** |Jan Sosulski|_)

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -306,7 +306,7 @@ class RawNIRX(BaseRaw):
                 info['chs'][ch_idx3]['loc'][3:6] = src_locs[src, :]
                 info['chs'][ch_idx3]['loc'][6:9] = det_locs[det, :]
                 info['chs'][ch_idx3]['loc'][:3] = midpoint
-                info['chs'][ch_idx3]['loc'][9] = fnirs_wavelengths[0]
+                info['chs'][ch_idx3]['loc'][9] = fnirs_wavelengths[ii]
                 info['chs'][ch_idx3]['coord_frame'] = FIFF.FIFFV_COORD_HEAD
 
         # Extract the start/stop numbers for samples in the CSV. In theory the

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -297,18 +297,17 @@ class RawNIRX(BaseRaw):
         for ch_idx2 in range(requested_channels.shape[0]):
             # Find source and store location
             src = int(requested_channels[ch_idx2, 0]) - 1
-            info['chs'][ch_idx2 * 2]['loc'][3:6] = src_locs[src, :]
-            info['chs'][ch_idx2 * 2 + 1]['loc'][3:6] = src_locs[src, :]
             # Find detector and store location
             det = int(requested_channels[ch_idx2, 1]) - 1
-            info['chs'][ch_idx2 * 2]['loc'][6:9] = det_locs[det, :]
-            info['chs'][ch_idx2 * 2 + 1]['loc'][6:9] = det_locs[det, :]
             # Store channel location as midpoint between source and detector.
             midpoint = (src_locs[src, :] + det_locs[det, :]) / 2
-            info['chs'][ch_idx2 * 2]['loc'][:3] = midpoint
-            info['chs'][ch_idx2 * 2 + 1]['loc'][:3] = midpoint
-            info['chs'][ch_idx2 * 2]['loc'][9] = fnirs_wavelengths[0]
-            info['chs'][ch_idx2 * 2 + 1]['loc'][9] = fnirs_wavelengths[1]
+            for ii in range(2):
+                ch_idx3 = ch_idx2 * 2 + ii
+                info['chs'][ch_idx3]['loc'][3:6] = src_locs[src, :]
+                info['chs'][ch_idx3]['loc'][6:9] = det_locs[det, :]
+                info['chs'][ch_idx3]['loc'][:3] = midpoint
+                info['chs'][ch_idx3]['loc'][9] = fnirs_wavelengths[0]
+                info['chs'][ch_idx3]['coord_frame'] = FIFF.FIFFV_COORD_HEAD
 
         # Extract the start/stop numbers for samples in the CSV. In theory the
         # sample bounds should just be 10 * the number of channels, but some

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -1272,9 +1272,15 @@ def _surf_upsampling_mat(idx_from, e, smooth, warn=True):
     _validate_type(smooth, ('int-like', str, None), 'smoothing steps')
     if smooth is not None:  # number of steps
         smooth = _ensure_int(smooth, 'smoothing steps')
-        if smooth < 1:
+        if smooth == 0:
+            return sparse.csc_matrix(
+                (np.ones(len(idx_from)),  # data, indices, indptr
+                 idx_from,
+                 np.arange(len(idx_from) + 1)),
+                shape=(e.shape[0], len(idx_from))).tocsr()
+        elif smooth < 0:
             raise ValueError(
-                'The number of smoothing operations has to be at least 1, got '
+                'The number of smoothing operations has to be at least 0, got '
                 f'{smooth}')
         smooth = smooth - 1
     # idx will gradually expand from idx_from -> np.arange(n_tot)

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -3297,7 +3297,7 @@ def stc_near_sensors(evoked, trans, subject, distance=0.01, mode='sum',
     _check_option('mode', mode, ('sum', 'single', 'nearest'))
 
     # create a copy of Evoked using ecog, seeg and dbs
-    evoked = evoked.copy().pick_types(ecog=True, seeg=True, dbs=True)
+    evoked = evoked.copy().pick_types(ecog=True, seeg=True, dbs=True, fnirs='hbo')
 
     # get channel positions that will be used to pinpoint where
     # in the Source space we will use the evoked data

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -671,7 +671,7 @@ def test_morph_stc_dense():
             spacing=6, subjects_dir=subjects_dir)
     del stc_to1
 
-    with pytest.raises(ValueError, match='smooth.* has to be at least 1'):
+    with pytest.raises(ValueError, match='smooth.* has to be at least 0'):
         compute_source_morph(
             stc_from, subject_from, subject_to, spacing=5, smooth=-1,
             subjects_dir=subjects_dir)

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1907,7 +1907,7 @@ class Brain(object):
         if smoothing_steps is None:
             smoothing_steps = 7
         elif smoothing_steps == 'nearest':
-            smoothing_steps = 0
+            smoothing_steps = -1
         elif isinstance(smoothing_steps, int):
             if smoothing_steps < 0:
                 raise ValueError('Expected value of `smoothing_steps` is'
@@ -2749,7 +2749,7 @@ class Brain(object):
                         'len(data) < nvtx (%s < %s): the vertices '
                         'parameter must not be None'
                         % (len(hemi_data), self.geo[hemi].x.shape[0]))
-                morph_n_steps = 'nearest' if n_steps == 0 else n_steps
+                morph_n_steps = 'nearest' if n_steps == -1 else n_steps
                 maps = sparse.eye(len(self.geo[hemi].coords), format='csr')
                 with use_log_level(False):
                     smooth_mat = _hemi_morph(

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -588,7 +588,7 @@ class Brain(object):
             raise ValueError("No data to visualize. See ``add_data``.")
         self.time_viewer = time_viewer
         self.orientation = list(_lh_views_dict.keys())
-        self.default_smoothing_range = [0, 15]
+        self.default_smoothing_range = [-1, 15]
 
         # Default configuration
         self.playback = False


### PR DESCRIPTION
I have some fNIRS collaborators who generate figures where the fNIRS electrodes are projected onto the nearest brain areas, like in ECoG:

![brain](https://user-images.githubusercontent.com/2365790/118316005-43433600-b4c4-11eb-885f-f6a4e5f66473.png)

or:

![brain](https://user-images.githubusercontent.com/2365790/118317284-d92b9080-b4c5-11eb-98dd-b12504a6d3b0.png)

Yes, I know the units on the colorbar are painful. :) But at least it's clear it's just a proximity-based projection and not actual inverse imaging!

This PR makes this possible by:

1. Adding a `picks` argument to `stc_near_sensors` so that fNIRS electrodes (HbO usually) can be used.
2. Adding a `smoothing_steps=0` meaning "no smoothing steps at all". Even `smoothing_steps=1` makes some smooth transitions where discrete ones are really desired. This caused me to shift "nearest" to -1 in the `brain` interface, which I think is fine.
3. Adding a `mode='weighted'` argument to `stc_near_sensors` that ensures that each STC vertex value is either zero, or a weighted sum of values from the sensors. This is more like what our smoothing/interpolation functions usually do. For example, if all sensors have a value of 1, all STC values are either 1 or 0. The default mode `"sum"` makes it so that some of these values can be greater than 1, which is a bit wacky (it's probably not a great default in this sense).

cc @rob-luke since you might be interested in this. Like I said it's not the greatest, but people do it (like in ECoG / sEEG) so I think it's probably worth having at least some way to do this.