### PR TITLE
[doc, minor] fix link

### DIFF
--- a/doc/overview/people.rst
+++ b/doc/overview/people.rst
@@ -41,4 +41,4 @@ Institutional Partners
 Document history
 ----------------
 
-https://github.com/mne-tools/mne/commits/main/doc/overview/people.rst
+https://github.com/mne-tools/mne-python/commits/main/doc/overview/people.rst


### PR DESCRIPTION
very minor typo fix to make a URL in our docs work again.