### PR TITLE
MNT: Reduce number of calls to _update

### DIFF
--- a/mne/morph.py
+++ b/mne/morph.py
@@ -1142,7 +1142,7 @@ def _hemi_morph(tris, vertices_to, vertices_from, smooth, maps, warn):
     e = mesh_edges(tris)
     e.data[e.data == 2] = 1
     n_vertices = e.shape[0]
-    e = e + sparse.eye(n_vertices)
+    e += sparse.eye(n_vertices, format='csr')
     if isinstance(smooth, str):
         _check_option('smooth', smooth, ('nearest',),
                       extra=' when used as a string.')

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1357,22 +1357,22 @@ def read_talxfm(subject, subjects_dir=None, verbose=None):
     return mri_mni_t
 
 
-def _read_mri_info(path, units='m', return_img=False):
+def _read_mri_info(path, units='m', return_img=False, use_nibabel=False):
     # This is equivalent but 100x slower, so only use nibabel if we need to
     # (later):
-    #
-    # import nibabel
-    # hdr = nibabel.load(path).header
-    # hdr = mgz.header
-    # n_orig = hdr.get_vox2ras()
-    # t_orig = hdr.get_vox2ras_tkr()
-    # dims = hdr.get_data_shape()
-    # zooms = hdr.get_zooms()[:3]
-    hdr = _get_mgz_header(path)
-    n_orig = hdr['vox2ras']
-    t_orig = hdr['vox2ras_tkr']
-    dims = hdr['dims']
-    zooms = hdr['zooms']
+    if use_nibabel:
+        import nibabel
+        hdr = nibabel.load(path).header
+        n_orig = hdr.get_vox2ras()
+        t_orig = hdr.get_vox2ras_tkr()
+        dims = hdr.get_data_shape()
+        zooms = hdr.get_zooms()[:3]
+    else:
+        hdr = _get_mgz_header(path)
+        n_orig = hdr['vox2ras']
+        t_orig = hdr['vox2ras_tkr']
+        dims = hdr['dims']
+        zooms = hdr['zooms']
 
     # extract the MRI_VOXEL to RAS (non-zero origin) transform
     vox_ras_t = Transform('mri_voxel', 'ras', n_orig)

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -2251,6 +2251,8 @@ def _vol_vertex(width, height, jj, kk, pp):
 
 def _get_mgz_header(fname):
     """Adapted from nibabel to quickly extract header info."""
+    fname = _check_fname(fname, overwrite='read', must_exist=True,
+                         name='MRI image')
     if not fname.endswith('.mgz'):
         raise IOError('Filename must end with .mgz')
     header_dtd = [('version', '>i4'), ('dims', '>i4', (4,)),

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1358,21 +1358,21 @@ def read_talxfm(subject, subjects_dir=None, verbose=None):
 
 
 def _read_mri_info(path, units='m', return_img=False):
-    if has_nibabel():
-        import nibabel
-        mgz = nibabel.load(path)
-        hdr = mgz.header
-        n_orig = hdr.get_vox2ras()
-        t_orig = hdr.get_vox2ras_tkr()
-        dims = hdr.get_data_shape()
-        zooms = hdr.get_zooms()[:3]
-    else:
-        mgz = None
-        hdr = _get_mgz_header(path)
-        n_orig = hdr['vox2ras']
-        t_orig = hdr['vox2ras_tkr']
-        dims = hdr['dims']
-        zooms = hdr['zooms']
+    # This is equivalent but 100x slower, so only use nibabel if we need to
+    # (later):
+    #
+    # import nibabel
+    # hdr = nibabel.load(path).header
+    # hdr = mgz.header
+    # n_orig = hdr.get_vox2ras()
+    # t_orig = hdr.get_vox2ras_tkr()
+    # dims = hdr.get_data_shape()
+    # zooms = hdr.get_zooms()[:3]
+    hdr = _get_mgz_header(path)
+    n_orig = hdr['vox2ras']
+    t_orig = hdr['vox2ras_tkr']
+    dims = hdr['dims']
+    zooms = hdr['zooms']
 
     # extract the MRI_VOXEL to RAS (non-zero origin) transform
     vox_ras_t = Transform('mri_voxel', 'ras', n_orig)
@@ -1395,7 +1395,8 @@ def _read_mri_info(path, units='m', return_img=False):
 
     out = (vox_ras_t, vox_mri_t, mri_ras_t, dims, zooms)
     if return_img:
-        out += (mgz,)
+        nibabel = _import_nibabel()
+        out += (nibabel.load(path),)
     return out
 
 

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -33,7 +33,7 @@ from .surface import (read_surface, _create_surf_spacing, _get_ico_surface,
                       _CheckInside)
 from .utils import (get_subjects_dir, check_fname, logger, verbose, fill_doc,
                     _ensure_int, check_version, _get_call_line, warn,
-                    _check_fname, _check_path_like, has_nibabel, _check_sphere,
+                    _check_fname, _check_path_like, _check_sphere,
                     _validate_type, _check_option, _is_numeric, _pl, _suggest,
                     object_size, sizeof_fmt)
 from .parallel import parallel_func, check_n_jobs

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -343,7 +343,7 @@ def _normal_orth(nn):
 
 @verbose
 def complete_surface_info(surf, do_neighbor_vert=False, copy=True,
-                          verbose=None):
+                          do_neighbor_tri=True, *, verbose=None):
     """Complete surface information.
 
     Parameters
@@ -351,9 +351,11 @@ def complete_surface_info(surf, do_neighbor_vert=False, copy=True,
     surf : dict
         The surface.
     do_neighbor_vert : bool
-        If True, add neighbor vertex information.
+        If True (default False), add neighbor vertex information.
     copy : bool
         If True (default), make a copy. If False, operate in-place.
+    do_neighbor_tri : bool
+        If True (default), compute triangle neighbors.
     %(verbose)s
 
     Returns
@@ -383,27 +385,28 @@ def complete_surface_info(surf, do_neighbor_vert=False, copy=True,
 
     #    Find neighboring triangles, accumulate vertex normals, normalize
     logger.info('    Triangle neighbors and vertex normals...')
-    surf['neighbor_tri'] = _triangle_neighbors(surf['tris'], surf['np'])
     surf['nn'] = _accumulate_normals(surf['tris'].astype(int),
                                      surf['tri_nn'], surf['np'])
     _normalize_vectors(surf['nn'])
 
     #   Check for topological defects
-    zero, fewer = list(), list()
-    for ni, n in enumerate(surf['neighbor_tri']):
-        if len(n) < 3:
-            if len(n) == 0:
-                zero.append(ni)
-            else:
-                fewer.append(ni)
-                surf['neighbor_tri'][ni] = np.array([], int)
-    if len(zero) > 0:
-        logger.info('    Vertices do not have any neighboring '
-                    'triangles: [%s]' % ', '.join(str(z) for z in zero))
-    if len(fewer) > 0:
-        logger.info('    Vertices have fewer than three neighboring '
-                    'triangles, removing neighbors: [%s]'
-                    % ', '.join(str(f) for f in fewer))
+    if do_neighbor_tri:
+        surf['neighbor_tri'] = _triangle_neighbors(surf['tris'], surf['np'])
+        zero, fewer = list(), list()
+        for ni, n in enumerate(surf['neighbor_tri']):
+            if len(n) < 3:
+                if len(n) == 0:
+                    zero.append(ni)
+                else:
+                    fewer.append(ni)
+                    surf['neighbor_tri'][ni] = np.array([], int)
+        if len(zero) > 0:
+            logger.info('    Vertices do not have any neighboring '
+                        'triangles: [%s]' % ', '.join(str(z) for z in zero))
+        if len(fewer) > 0:
+            logger.info('    Vertices have fewer than three neighboring '
+                        'triangles, removing neighbors: [%s]'
+                        % ', '.join(str(f) for f in fewer))
 
     #   Determine the neighboring vertices and fix errors
     if do_neighbor_vert is True:

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -56,6 +56,7 @@ def test_coregister_fiducials():
     assert_array_almost_equal(trans_est['trans'], trans['trans'])
 
 
+@requires_nibabel()
 @pytest.mark.slowtest  # can take forever on OSX Travis
 @testing.requires_testing_data
 @pytest.mark.parametrize('scale', (.9, [1, .2, .8]))

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -593,6 +593,7 @@ def test_head_to_mni():
     assert_allclose(coords_MNI, coords_MNI_2, atol=10.0)
 
 
+@requires_nibabel()
 @testing.requires_testing_data
 def test_vertex_to_mni_fs_nibabel(monkeypatch):
     """Test equivalence of vert_to_mni for nibabel and freesurfer."""
@@ -601,7 +602,10 @@ def test_vertex_to_mni_fs_nibabel(monkeypatch):
     vertices = rng.randint(0, 100000, n_check)
     hemis = rng.randint(0, 1, n_check)
     coords = vertex_to_mni(vertices, hemis, subject, subjects_dir)
-    monkeypatch.setattr(mne.source_space, 'has_nibabel', lambda: False)
+    read_mri = mne.source_space._read_mri_info
+    monkeypatch.setattr(
+        mne.source_space, '_read_mri_info',
+        lambda *args, **kwargs: read_mri(*args, use_nibabel=True, **kwargs))
     coords_2 = vertex_to_mni(vertices, hemis, subject, subjects_dir)
     # less than 0.1 mm error
     assert_allclose(coords, coords_2, atol=0.1)

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -293,6 +293,7 @@ def test_discrete_source_space(tmpdir):
     assert _get_src_type(src_new, None) == 'discrete'
 
 
+@requires_nibabel()
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_volume_source_space(tmpdir):

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -60,7 +60,7 @@ from .numerics import (hashfunc, _compute_row_norms,
                        _mask_to_onsets_offsets, _array_equal_nan,
                        _julian_to_cal, _cal_to_julian, _dt_to_julian,
                        _julian_to_dt, _dt_to_stamp, _stamp_to_dt,
-                       _check_dt, _ReuseCycle, _arange_div)
+                       _check_dt, _ReuseCycle, _arange_div, _hashable_ndarray)
 from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
                     _prepare_write_metadata, _FakeNoPandas, ShiftTimeMixin)
 from .linalg import (_svd_lwork, _repeated_svd, _sym_mat_pow, sqrtm_sym, eigh,

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -605,6 +605,18 @@ def grand_average(all_inst, interpolate_bads=True, drop_bads=True):
     return grand_average
 
 
+class _HashableNdarray(np.ndarray):
+    def __hash__(self):
+        return object_hash(self)
+
+    def __eq__(self, other):
+        return NotImplementedError  # defer to hash
+
+
+def _hashable_ndarray(x):
+    return x.view(_HashableNdarray)
+
+
 def object_hash(x, h=None):
     """Hash a reasonable python object.
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -529,18 +529,15 @@ class Brain(object):
 
         self.interaction = interaction
         self._closed = False
-
+        if show:
+            self.show()
         # update the views once the geometry is all set
-        with self._renderer._disabled_update():
-            for h in self._hemis:
-                for ri, ci, v in self._iter_views(h):
-                    self.show_view(v, row=ri, col=ci, hemi=h)
+        for h in self._hemis:
+            for ri, ci, v in self._iter_views(h):
+                self.show_view(v, row=ri, col=ci, hemi=h)
 
         if surf == 'flat':
             self._renderer.set_interaction("rubber_band_2d")
-
-        if show:
-            self._renderer.show()
 
     def _setup_canonical_rotation(self):
         from ...coreg import fit_matched_points, _trans_from_params
@@ -655,25 +652,27 @@ class Brain(object):
             self.separate_canvas = False
         del show_traces
 
-        with self._renderer._disabled_update():
-            self._configure_time_label()
-            self._configure_scalar_bar()
-            self._configure_shortcuts()
-            self._configure_picking()
-            self._configure_tool_bar()
-            self._configure_dock()
-            self._configure_menu()
-            self._configure_status_bar()
-            self._configure_playback()
-            self._configure_help()
-            # sizes could change, update views
-            for hemi in ('lh', 'rh'):
-                for ri, ci, v in self._iter_views(hemi):
-                    self.show_view(view=v, row=ri, col=ci)
-            self._renderer._process_events()
+        self._configure_time_label()
+        self._configure_scalar_bar()
+        self._configure_shortcuts()
+        self._configure_picking()
+        self._configure_tool_bar()
+        self._configure_dock()
+        self._configure_menu()
+        self._configure_status_bar()
+        self._configure_playback()
+        self._configure_help()
         # show everything at the end
+        self.toggle_interface()
         self._renderer.show()
 
+        # sizes could change, update views
+        for hemi in ('lh', 'rh'):
+            for ri, ci, v in self._iter_views(hemi):
+                self.show_view(view=v, row=ri, col=ci)
+        self._renderer._process_events()
+
+        self._renderer._update()
         # finally, show the MplCanvas
         if self.show_traces:
             self.mpl_canvas.show()

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1192,7 +1192,7 @@ class Brain(object):
             alpha=0.5, ls=':')
 
         # now plot the time line
-        self.plot_time_line()
+        self.plot_time_line(update=False)
 
         # then the picked points
         for idx, hemi in enumerate(['lh', 'rh', 'vol']):
@@ -1221,7 +1221,7 @@ class Brain(object):
             else:
                 mesh = self._layered_meshes[hemi]._polydata
             vertex_id = vertices[ind[0]]
-            self._add_vertex_glyph(hemi, mesh, vertex_id)
+            self._add_vertex_glyph(hemi, mesh, vertex_id, update=False)
 
     def _configure_picking(self):
         # get data for each hemi
@@ -1491,7 +1491,7 @@ class Brain(object):
         self._layered_meshes[hemi].remove_overlay(label.name)
         self.picked_patches[hemi].remove(label_id)
 
-    def _add_vertex_glyph(self, hemi, mesh, vertex_id):
+    def _add_vertex_glyph(self, hemi, mesh, vertex_id, update=True):
         if vertex_id in self.picked_points[hemi]:
             return
 
@@ -1499,7 +1499,7 @@ class Brain(object):
         if self.act_data_smooth[hemi][0] is None:
             return
         color = next(self.color_cycle)
-        line = self.plot_time_course(hemi, vertex_id, color)
+        line = self.plot_time_course(hemi, vertex_id, color, update=update)
         if hemi == 'vol':
             ijk = np.unravel_index(
                 vertex_id, np.array(mesh.GetDimensions()) - 1, order='F')
@@ -1599,7 +1599,7 @@ class Brain(object):
             self.rms = None
         self._renderer._update()
 
-    def plot_time_course(self, hemi, vertex_id, color):
+    def plot_time_course(self, hemi, vertex_id, color, update=True):
         """Plot the vertex time course.
 
         Parameters
@@ -1610,6 +1610,8 @@ class Brain(object):
             The vertex identifier in the mesh.
         color : matplotlib color
             The color of the time course.
+        update : bool
+            Force an update of the plot. Defaults to True.
 
         Returns
         -------
@@ -1658,10 +1660,11 @@ class Brain(object):
             lw=1.,
             color=color,
             zorder=4,
+            update=update,
         )
         return line
 
-    def plot_time_line(self):
+    def plot_time_line(self, update=True):
         """Add the time line to the MPL widget."""
         if self.mpl_canvas is None:
             return
@@ -1676,7 +1679,8 @@ class Brain(object):
                     lw=1,
                 )
             self.time_line.set_xdata(current_time)
-            self.mpl_canvas.update_plot()
+            if update:
+                self.mpl_canvas.update_plot()
 
     def _configure_help(self):
         pairs = [

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -529,15 +529,18 @@ class Brain(object):
 
         self.interaction = interaction
         self._closed = False
-        if show:
-            self.show()
+
         # update the views once the geometry is all set
-        for h in self._hemis:
-            for ri, ci, v in self._iter_views(h):
-                self.show_view(v, row=ri, col=ci, hemi=h)
+        with self._renderer._disabled_update():
+            for h in self._hemis:
+                for ri, ci, v in self._iter_views(h):
+                    self.show_view(v, row=ri, col=ci, hemi=h)
 
         if surf == 'flat':
             self._renderer.set_interaction("rubber_band_2d")
+
+        if show:
+            self._renderer.show()
 
     def _setup_canonical_rotation(self):
         from ...coreg import fit_matched_points, _trans_from_params
@@ -652,27 +655,25 @@ class Brain(object):
             self.separate_canvas = False
         del show_traces
 
-        self._configure_time_label()
-        self._configure_scalar_bar()
-        self._configure_shortcuts()
-        self._configure_picking()
-        self._configure_tool_bar()
-        self._configure_dock()
-        self._configure_menu()
-        self._configure_status_bar()
-        self._configure_playback()
-        self._configure_help()
+        with self._renderer._disabled_update():
+            self._configure_time_label()
+            self._configure_scalar_bar()
+            self._configure_shortcuts()
+            self._configure_picking()
+            self._configure_tool_bar()
+            self._configure_dock()
+            self._configure_menu()
+            self._configure_status_bar()
+            self._configure_playback()
+            self._configure_help()
+            # sizes could change, update views
+            for hemi in ('lh', 'rh'):
+                for ri, ci, v in self._iter_views(hemi):
+                    self.show_view(view=v, row=ri, col=ci)
+            self._renderer._process_events()
         # show everything at the end
-        self.toggle_interface()
         self._renderer.show()
 
-        # sizes could change, update views
-        for hemi in ('lh', 'rh'):
-            for ri, ci, v in self._iter_views(hemi):
-                self.show_view(view=v, row=ri, col=ci)
-        self._renderer._process_events()
-
-        self._renderer._update()
         # finally, show the MplCanvas
         if self.show_traces:
             self.mpl_canvas.show()

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -540,7 +540,8 @@ class Brain(object):
                         alpha=self._silhouette["alpha"],
                         decimate=self._silhouette["decimate"],
                     )
-                self._renderer.set_camera(**views_dicts[h][v])
+                self._renderer.set_camera(update=False, reset_camera=False,
+                                          **views_dicts[h][v])
 
         self.interaction = interaction
         self._closed = False
@@ -2009,7 +2010,8 @@ class Brain(object):
                               bgcolor=self._brain_color[:3])
                 kwargs.update(colorbar_kwargs or {})
                 self._scalar_bar = self._renderer.scalarbar(**kwargs)
-            self._renderer.set_camera(**views_dicts[hemi][v])
+            self._renderer.set_camera(
+                update=False, reset_camera=False, **views_dicts[hemi][v])
 
         # 4) update the scalar bar and opacity
         self.update_lut(alpha=alpha)
@@ -2306,7 +2308,7 @@ class Brain(object):
                 name=label_name,
             )
             if reset_camera:
-                self._renderer.set_camera(**views_dicts[hemi][v])
+                self._renderer.set_camera(update=False, **views_dicts[hemi][v])
             if self.time_viewer and self.show_traces \
                     and self.traces_mode == 'label':
                 label._color = orig_color

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2762,7 +2762,6 @@ class Brain(object):
         n_steps : int
             Number of smoothing steps.
         """
-        from scipy import sparse
         from ...morph import _hemi_morph
         for hemi in ['lh', 'rh']:
             hemi_data = self._data.get(hemi)
@@ -2776,12 +2775,11 @@ class Brain(object):
                         'parameter must not be None'
                         % (len(hemi_data), self.geo[hemi].x.shape[0]))
                 morph_n_steps = 'nearest' if n_steps == -1 else n_steps
-                maps = sparse.eye(len(self.geo[hemi].coords), format='csr')
                 with use_log_level(False):
                     smooth_mat = _hemi_morph(
                         self.geo[hemi].orig_faces,
                         np.arange(len(self.geo[hemi].coords)),
-                        vertices, morph_n_steps, maps, warn=False)
+                        vertices, morph_n_steps, maps=None, warn=False)
                 self._data[hemi]['smooth_mat'] = smooth_mat
         self.set_time_point(self._data['time_idx'])
         self._data['smoothing_steps'] = n_steps

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1665,7 +1665,13 @@ class Brain(object):
         return line
 
     def plot_time_line(self, update=True):
-        """Add the time line to the MPL widget."""
+        """Add the time line to the MPL widget.
+
+        Parameters
+        ----------
+        update : bool
+            Force an update of the plot. Defaults to True.
+        """
         if self.mpl_canvas is None:
             return
         if isinstance(self.show_traces, bool) and self.show_traces:
@@ -1677,6 +1683,7 @@ class Brain(object):
                     label='time',
                     color=self._fg_color,
                     lw=1,
+                    update=update,
                 )
             self.time_line.set_xdata(current_time)
             if update:
@@ -2413,7 +2420,7 @@ class Brain(object):
         self.add_annotation(self.annot, color="w", alpha=0.75)
 
         # now plot the time line
-        self.plot_time_line()
+        self.plot_time_line(update=False)
         self.mpl_canvas.update_plot()
 
         for hemi in self._hemis:

--- a/mne/viz/_brain/surface.py
+++ b/mne/viz/_brain/surface.py
@@ -131,7 +131,8 @@ class _Surface(object):
             else:
                 coords -= (np.min(x_) + self.offset) * self.x_dir
         surf = dict(rr=coords, tris=faces)
-        complete_surface_info(surf, copy=False, verbose=False)
+        complete_surface_info(
+            surf, copy=False, verbose=False, do_neighbor_tri=False)
         nn = surf['nn']
         self.coords = coords
         self.faces = faces

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -115,7 +115,8 @@ def test_layered_mesh(renderer_interactive_pyvista):
     assert not mesh._is_mapped
     mesh.map()
     assert mesh._is_mapped
-    assert mesh._cache is None
+    assert mesh._current_colors is None
+    assert mesh._cached_colors is None
     mesh.update()
     assert len(mesh._overlays) == 0
     mesh.add_overlay(
@@ -123,13 +124,27 @@ def test_layered_mesh(renderer_interactive_pyvista):
         colormap=np.array([(1, 1, 1, 1), (0, 0, 0, 0)]),
         rng=[0, 1],
         opacity=None,
-        name='test',
+        name='test1',
     )
-    assert mesh._cache is not None
+    assert mesh._current_colors is not None
+    assert mesh._cached_colors is None
     assert len(mesh._overlays) == 1
-    assert 'test' in mesh._overlays
-    mesh.remove_overlay('test')
-    assert len(mesh._overlays) == 0
+    assert 'test1' in mesh._overlays
+    mesh.add_overlay(
+        scalars=np.array([1, 0, 0, 1]),
+        colormap=np.array([(1, 1, 1, 1), (0, 0, 0, 0)]),
+        rng=[0, 1],
+        opacity=None,
+        name='test2',
+    )
+    assert mesh._current_colors is not None
+    assert mesh._cached_colors is not None
+    assert len(mesh._overlays) == 2
+    assert 'test2' in mesh._overlays
+    mesh.remove_overlay('test2')
+    assert 'test2' not in mesh._overlays
+    mesh.update()
+    assert len(mesh._overlays) == 1
     mesh._clean()
 
 

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -655,17 +655,19 @@ class _AbstractMplCanvas(ABC):
             self.canvas.mpl_connect(
                 event + '_event', getattr(self, 'on_' + event))
 
-    def plot(self, x, y, label, **kwargs):
+    def plot(self, x, y, label, update=True, **kwargs):
         """Plot a curve."""
         line, = self.axes.plot(
             x, y, label=label, **kwargs)
-        self.update_plot()
+        if update:
+            self.update_plot()
         return line
 
-    def plot_time_line(self, x, label, **kwargs):
+    def plot_time_line(self, x, label, update=True, **kwargs):
         """Plot the vertical line."""
         line = self.axes.axvline(x, label=label, **kwargs)
-        self.update_plot()
+        if update:
+            self.update_plot()
         return line
 
     def update_plot(self):

--- a/mne/viz/backends/_pysurfer_mayavi.py
+++ b/mne/viz/backends/_pysurfer_mayavi.py
@@ -316,10 +316,10 @@ class _Renderer(_AbstractRenderer):
 
     def set_camera(self, azimuth=None, elevation=None, distance=None,
                    focalpoint=None, roll=None, reset_camera=None,
-                   rigid=None):
+                   rigid=None, update=True):
         _set_3d_view(figure=self.fig, azimuth=azimuth,
                      elevation=elevation, distance=distance,
-                     focalpoint=focalpoint, roll=roll)
+                     focalpoint=focalpoint, roll=roll, update=update)
 
     def reset_camera(self):
         renderer = getattr(self.fig.scene, 'renderer', None)
@@ -454,13 +454,14 @@ def _close_all():
 
 
 def _set_3d_view(figure, azimuth, elevation, focalpoint, distance, roll=None,
-                 reset_camera=True):
+                 reset_camera=True, update=True):
     from mayavi import mlab
     with warnings.catch_warnings(record=True):  # traits
         with SilenceStdout():
             mlab.view(azimuth, elevation, distance,
                       focalpoint=focalpoint, figure=figure, roll=roll)
-            mlab.draw(figure)
+            if update:
+                mlab.draw(figure)
 
 
 def _set_3d_title(figure, title, size=40):

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -26,7 +26,7 @@ from ._utils import (_get_colormap_from_array, _alpha_blend_background,
                      ALLOWED_QUIVER_MODES, _init_qt_resources)
 from ...fixes import _get_args
 from ...transforms import apply_trans
-from ...utils import copy_base_doc_to_subclass_doc, _check_option, logger
+from ...utils import copy_base_doc_to_subclass_doc, _check_option
 
 
 with warnings.catch_warnings():
@@ -152,7 +152,6 @@ class _PyVistaRenderer(_AbstractRenderer):
         figure = _Figure(show=show, title=name, size=size, shape=shape,
                          background_color=bgcolor, notebook=notebook,
                          smooth_shading=smooth_shading)
-        self._to_update = True
         self.font_family = "arial"
         self.tube_n_sides = 20
         antialias = _get_3d_option('antialias')
@@ -205,10 +204,8 @@ class _PyVistaRenderer(_AbstractRenderer):
             renderer.hide_axes()
 
     def _update(self):
-        if self._to_update:
-            logger.debug('Update renderer')
-            for plotter in self._all_plotters:
-                plotter.update()
+        for plotter in self._all_plotters:
+            plotter.update()
 
     def _index_to_loc(self, idx):
         _ncols = self.figure._ncols
@@ -648,15 +645,6 @@ class _PyVistaRenderer(_AbstractRenderer):
     def remove_mesh(self, mesh_data):
         actor, _ = mesh_data
         self.plotter.remove_actor(actor)
-
-    @contextmanager
-    def _disabled_update(self):
-        to_update = self._to_update
-        self._to_update = False
-        try:
-            yield
-        finally:
-            self._to_update = to_update
 
     @contextmanager
     def _disabled_interaction(self):

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -26,7 +26,7 @@ from ._utils import (_get_colormap_from_array, _alpha_blend_background,
                      ALLOWED_QUIVER_MODES, _init_qt_resources)
 from ...fixes import _get_args
 from ...transforms import apply_trans
-from ...utils import copy_base_doc_to_subclass_doc, _check_option
+from ...utils import copy_base_doc_to_subclass_doc, _check_option, logger
 
 
 with warnings.catch_warnings():
@@ -152,6 +152,7 @@ class _PyVistaRenderer(_AbstractRenderer):
         figure = _Figure(show=show, title=name, size=size, shape=shape,
                          background_color=bgcolor, notebook=notebook,
                          smooth_shading=smooth_shading)
+        self._to_update = True
         self.font_family = "arial"
         self.tube_n_sides = 20
         antialias = _get_3d_option('antialias')
@@ -204,8 +205,10 @@ class _PyVistaRenderer(_AbstractRenderer):
             renderer.hide_axes()
 
     def _update(self):
-        for plotter in self._all_plotters:
-            plotter.update()
+        if self._to_update:
+            logger.debug('Update renderer')
+            for plotter in self._all_plotters:
+                plotter.update()
 
     def _index_to_loc(self, idx):
         _ncols = self.figure._ncols
@@ -645,6 +648,15 @@ class _PyVistaRenderer(_AbstractRenderer):
     def remove_mesh(self, mesh_data):
         actor, _ = mesh_data
         self.plotter.remove_actor(actor)
+
+    @contextmanager
+    def _disabled_update(self):
+        to_update = self._to_update
+        self._to_update = False
+        try:
+            yield
+        finally:
+            self._to_update = to_update
 
     @contextmanager
     def _disabled_interaction(self):

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -598,10 +598,10 @@ class _PyVistaRenderer(_AbstractRenderer):
 
     def set_camera(self, azimuth=None, elevation=None, distance=None,
                    focalpoint='auto', roll=None, reset_camera=True,
-                   rigid=None):
+                   rigid=None, update=True):
         _set_3d_view(self.figure, azimuth=azimuth, elevation=elevation,
                      distance=distance, focalpoint=focalpoint, roll=roll,
-                     reset_camera=reset_camera, rigid=rigid)
+                     reset_camera=reset_camera, rigid=rigid, update=update)
 
     def reset_camera(self):
         self.plotter.reset_camera()
@@ -930,7 +930,8 @@ def _get_camera_direction(focalpoint, position):
 
 
 def _set_3d_view(figure, azimuth=None, elevation=None, focalpoint='auto',
-                 distance=None, roll=None, reset_camera=True, rigid=None):
+                 distance=None, roll=None, reset_camera=True, rigid=None,
+                 update=True):
     rigid = np.eye(4) if rigid is None else rigid
     position = np.array(figure.plotter.camera_position[0])
     bounds = np.array(figure.plotter.renderer.ComputeVisiblePropBounds())
@@ -991,8 +992,9 @@ def _set_3d_view(figure, azimuth=None, elevation=None, focalpoint='auto',
     if roll is not None:
         figure.plotter.camera.SetRoll(figure.plotter.camera.GetRoll() + roll)
 
-    figure.plotter.update()
-    _process_events(figure.plotter)
+    if update:
+        figure.plotter.update()
+        _process_events(figure.plotter)
 
 
 def _set_3d_title(figure, title, size=16):


### PR DESCRIPTION
1) This PR reduces the amount of renderer updates. I modified the two main entry points: `__init__()` and `setup_time_viewer()`.
For now I use a context manager but if big chunks of code need to be nested maybe `enable/disable` functions are better, not sure.
I'm still trying to download 0.119 locally so testing is delayed but in the example that I use regularly, it went from 16 to 1.

2) I'll see how to reduce the amount of overlay updates next.
3) I'll also investigate why the window is so slow to setup (suggested in https://github.com/mne-tools/mne-python/pull/9407#issuecomment-844199125)

Closes https://github.com/mne-tools/mne-python/issues/8986