### PR TITLE
FIX : not disappearing vline in Raw/Epochs-Plot

### DIFF
--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -2218,7 +2218,7 @@ class MNEBrowseFigure(MNEFigure):
                 artist.set_visible(visible)
                 self.draw_artist(artist)
         self.mne.vline_visible = visible
-
+        self.canvas.draw_idle()
 
 class MNELineFigure(MNEFigure):
     """Interactive figure for non-scrolling line plots."""


### PR DESCRIPTION
#### What does this implement/fix?
The vertical green line appearing after a left-click inside the Raw/Epochs-Plot should disappear after a right-click somewhere in the plot, which is fixed by this PR.
