### PR TITLE
Fix error when reducing shown time-window while vline visible

### DIFF
--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -710,8 +710,6 @@ class MNEBrowseFigure(MNEFigure):
                 if self.mne.t_start + self.mne.duration > last_time:
                     self.mne.t_start = last_time - self.mne.duration
                 self._update_hscroll()
-                if key == 'end' and self.mne.vline_visible:  # prevent flicker
-                    self._toggle_vline(True)
                 self._redraw(annotations=True)
         elif key == '?':  # help window
             self._toggle_help_fig(event)

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -711,7 +711,7 @@ class MNEBrowseFigure(MNEFigure):
                     self.mne.t_start = last_time - self.mne.duration
                 self._update_hscroll()
                 if key == 'end' and self.mne.vline_visible:  # prevent flicker
-                    self._show_vline(None)
+                    self._toggle_vline(True)
                 self._redraw(annotations=True)
         elif key == '?':  # help window
             self._toggle_help_fig(event)

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -2200,10 +2200,9 @@ class MNEBrowseFigure(MNEFigure):
     def _show_vline(self, xdata):
         """Show the vertical line(s)."""
         if self.mne.is_epochs:
-            # special case: changed view duration w/ "home" or "end" key
-            # (no click event, hence no xdata)
+            # convert xdata to be epoch-relative (for the text)
             rel_time = self._recompute_epochs_vlines(xdata)
-            xdata = rel_time + self.mne.inst.times[0]  # for the text
+            xdata = rel_time + self.mne.inst.times[0]
         else:
             self.mne.vline.set_xdata(xdata)
             self.mne.vline_hscroll.set_xdata(xdata)


### PR DESCRIPTION
#### Reference issue
Example: Fixes #9413.


#### What does this implement/fix?
The error happening when changing the shown duration by pressing `End` is fixed.


#### Additional information
I am not sure, what the problem with the flickering was which motivated this line. I assumed that redrawing the vline was the intention, so I replaced `_show_vline` directly with `_toggle_vline`.
