### PR TITLE
MRG, MAINT: Updates for mffpy 6.3

### DIFF
--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -777,8 +777,12 @@ def read_evokeds_mff(fname, condition=None, channel_naming='E%d',
         raise ValueError('fname must be an MFF file with extension ".mff".')
     # Confirm the input MFF is averaged
     mff = mffpy.Reader(fname)
-    if mff.flavor != 'averaged':
-        raise ValueError(f'{fname} is a {mff.flavor} MFF file. '
+    try:
+        flavor = mff.mff_flavor
+    except AttributeError:  # < 6.3
+        flavor = mff.flavor
+    if flavor not in ('averaged', 'segmented'):  # old, new names
+        raise ValueError(f'{fname} is a {flavor} MFF file. '
                          'fname must be the path to an averaged MFF file.')
     # Check for categories.xml file
     if 'categories.xml' not in mff.directory.listdir():


### PR DESCRIPTION
Will self-merge if everything comes back green to get `main` back to green. @ephathaway does this look like the correct fix to you? Takes care of this deprecation warning:
```
mne/io/egi/tests/test_egi.py:325: in test_io_egi_evokeds_mff
    evokeds = read_evokeds_mff(egi_mff_evoked_fname)
<decorator-gen-206>:24: in read_evokeds_mff
    ???
mne/io/egi/egimff.py:785: in read_evokeds_mff
    raise ValueError(f'{fname} is a {mff.flavor} MFF file. '
../../.local/lib/python3.9/site-packages/mffpy/cached_property.py:36: in _cached_property
    ans = fn(self)
../../.local/lib/python3.9/site-packages/deprecated/classic.py:284: in wrapper_function
    warnings.warn(msg, category=category, stacklevel=_routine_stacklevel)
E   DeprecationWarning: Call to deprecated function (or staticmethod) flavor. (Use ".mff_flavor" instead) -- Deprecated since version 0.6.3.
```