### PR TITLE
MRG, ENH: Speed up brain test

### DIFF
--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2764,7 +2764,8 @@ def test_metadata(tmpdir):
     chs = ['a', 'b']
     info = create_info(chs, 1000)
     meta = np.array([[1.] * 5 + [3.] * 5,
-                     ['a'] * 2 + ['b'] * 3 + ['c'] * 3 + ['µ'] * 2]).T
+                     ['a'] * 2 + ['b'] * 3 + ['c'] * 3 + ['µ'] * 2],
+                    dtype='object').T
     meta = DataFrame(meta, columns=['num', 'letter'])
     meta['num'] = np.array(meta['num'], float)
     events = np.arange(meta.shape[0])

--- a/mne/viz/_brain/tests/test_notebook.py
+++ b/mne/viz/_brain/tests/test_notebook.py
@@ -51,6 +51,7 @@ def test_notebook_interactive(renderer_notebook, brain_gc, nbexec):
     subjects_dir = os.path.join(data_path, 'subjects')
     fname_stc = os.path.join(sample_dir, 'sample_audvis_trunc-meg')
     stc = mne.read_source_estimate(fname_stc, subject='sample')
+    stc.crop(0.1, 0.11)
     initial_time = 0.13
     mne.viz.set_3d_backend('notebook')
     brain_class = mne.viz.get_brain_class()


### PR DESCRIPTION
Takes the test from ~60 sec on my system to ~5 sec. I think it's due to rendering the movie.

It takes about 240 sec on CIs on `main`, let's see if it's better there, too.