### PR TITLE
FIX: brain save_movie

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -3138,11 +3138,6 @@ class Brain(object):
         %(brain_screenshot_time_viewer)s
         **kwargs : dict
             Specify additional options for :mod:`imageio`.
-
-        Returns
-        -------
-        dialog : object
-            The opened dialog is returned for testing purpose only.
         """
         if filename is None:
             filename = _generate_default_filename(".mp4")

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1261,7 +1261,8 @@ class Brain(object):
         self._renderer._tool_bar_add_file_button(
             name="movie",
             desc="Save movie...",
-            func=lambda: self.save_movie(
+            func=lambda filename: self.save_movie(
+                filename=filename,
                 time_dilation=(1. / self.playback_speed)),
             shortcut="ctrl+shift+s",
         )

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1261,7 +1261,8 @@ class Brain(object):
         self._renderer._tool_bar_add_file_button(
             name="movie",
             desc="Save movie...",
-            func=self.save_movie,
+            func=lambda: self.save_movie(
+                time_dilation=(1. / self.playback_speed)),
             shortcut="ctrl+shift+s",
         )
         self._renderer._tool_bar_add_button(
@@ -3081,12 +3082,9 @@ class Brain(object):
             self._renderer._window_new_cursor("WaitCursor"))
 
         try:
-            self._save_movie(
-                filename=filename,
-                time_dilation=(1. / self.playback_speed),
-                callback=frame_callback,
-                **kwargs
-            )
+            self._save_movie(filename, time_dilation, tmin, tmax,
+                             framerate, interpolation, codec,
+                             bitrate, frame_callback, time_viewer, **kwargs)
         except (Exception, KeyboardInterrupt):
             warn('Movie saving aborted:\n' + traceback.format_exc())
         finally:


### PR DESCRIPTION
This PR fixes parameter forwarding in the `save_movie()` method and also the `Save movie...` action in the tool bar.

**ToDo:**

- [x] Test generated movie duration against estimation given by time range and time dilation (suggested in https://github.com/mne-tools/mne-python/pull/9426#pullrequestreview-667897094)

Closes https://github.com/mne-tools/mne-python/issues/9425