### PR TITLE
MRG: Enable interpolation for all fNIRS types

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -47,6 +47,8 @@ Enhancements
 
 - Add projections when printing a :class:`mne.Info` in the notebook (:gh:`9403` by `Alex Gramfort`_)
 
+- Add support for interpolating oxy and deoxyhaemoglobin data types (:gh:`9431` by `Robert Luke`_)
+
 Bugs
 ~~~~
 - Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** |Jan Sosulski|_)

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -205,8 +205,7 @@ def _interpolate_bads_meeg(inst, mode='accurate', origin=(0., 0., 0.04),
 @verbose
 def _interpolate_bads_nirs(inst, method='nearest', exclude=(), verbose=None):
     from scipy.spatial.distance import pdist, squareform
-    from mne.preprocessing.nirs import _channel_frequencies,\
-        _validate_nirs_info
+    from mne.preprocessing.nirs import _validate_nirs_info
 
     # Returns pick of all nirs and ensures channels are correctly ordered
     picks_nirs = _validate_nirs_info(inst.info)

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -206,11 +206,10 @@ def _interpolate_bads_meeg(inst, mode='accurate', origin=(0., 0., 0.04),
 def _interpolate_bads_nirs(inst, method='nearest', exclude=(), verbose=None):
     from scipy.spatial.distance import pdist, squareform
     from mne.preprocessing.nirs import _channel_frequencies,\
-        _check_channels_ordered
+        _validate_nirs_info
 
     # Returns pick of all nirs and ensures channels are correctly ordered
-    freqs = np.unique(_channel_frequencies(inst.info))
-    picks_nirs = _check_channels_ordered(inst.info, freqs)
+    picks_nirs = _validate_nirs_info(inst.info)
     if len(picks_nirs) == 0:
         return
 

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -8,7 +8,8 @@ from itertools import compress
 from mne import io, pick_types, pick_channels, read_events, Epochs
 from mne.channels.interpolation import _make_interpolation_matrix
 from mne.datasets import testing
-from mne.preprocessing.nirs import optical_density, scalp_coupling_index
+from mne.preprocessing.nirs import (optical_density, scalp_coupling_index,
+                                    beer_lambert_law)
 from mne.datasets.testing import data_path
 from mne.io import read_raw_nirx
 from mne.io.proj import _has_eeg_average_ref_proj
@@ -303,3 +304,8 @@ def test_interpolation_nirs():
     raw_od.interpolate_bads()
     assert raw_od.info['bads'] == []
     assert bad_0_std_pre_interp > np.std(raw_od._data[bad_0])
+    raw_haemo = beer_lambert_law(raw_od)
+    raw_haemo.info['bads'] = raw_haemo.ch_names[2:4]
+    assert raw_haemo.info['bads'] == ['S1_D2 hbo', 'S1_D2 hbr']
+    raw_haemo.interpolate_bads()
+    assert raw_haemo.info['bads'] == []


### PR DESCRIPTION
#### What does this implement/fix?
Enables interpolation on all fNIRS types using the new and more generic `_validate_nirs_info` function.
