### PR TITLE
[MRG] change utils.logger.warning -> utils.warn

### DIFF
--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -22,8 +22,6 @@ import warnings
 
 import numpy as np
 
-from .utils import warn
-
 
 ###############################################################################
 # Misc
@@ -70,6 +68,7 @@ def _safe_svd(A, **kwargs):
     try:
         return linalg.svd(A, **kwargs)
     except np.linalg.LinAlgError as exp:
+        from .utils import warn
         if 'lapack_driver' in _get_args(linalg.svd):
             warn('SVD error (%s), attempting to use GESVD instead of GESDD'
                  % (exp,))
@@ -153,7 +152,7 @@ def _read_geometry(filepath, read_metadata=False, read_stamp=False):
     ret = (coords, faces)
     if read_metadata:
         if len(volume_info) == 0:
-            warn('No volume information contained in the file')
+            warnings.warn('No volume information contained in the file')
         ret += (volume_info,)
     if read_stamp:
         ret += (create_stamp,)
@@ -225,7 +224,7 @@ def _read_volume_info(fobj):
     if not np.array_equal(head, [20]):  # Read two bytes more
         head = np.concatenate([head, np.fromfile(fobj, '>i4', 2)])
         if not np.array_equal(head, [2, 0, 20]):
-            warn("Unknown extension code.")
+            warnings.warn("Unknown extension code.")
             return volume_info
 
     volume_info['head'] = head
@@ -258,7 +257,7 @@ def _serialize_volume_info(volume_info):
         if key == 'head':
             if not (np.array_equal(volume_info[key], [20]) or np.array_equal(
                     volume_info[key], [2, 0, 20])):
-                warn("Unknown extension code.")
+                warnings.warn("Unknown extension code.")
             strings.append(np.array(volume_info[key], dtype='>i4').tobytes())
         elif key in ('valid', 'filename'):
             val = volume_info[key]
@@ -548,7 +547,7 @@ def empirical_covariance(X, assume_centered=False):
         X = np.reshape(X, (1, -1))
 
     if X.shape[0] == 1:
-        warn("Only one sample available. "
+        warnings.warn("Only one sample available. "
                       "You may want to reshape your data array")
 
     if assume_centered:
@@ -880,7 +879,7 @@ def stable_cumsum(arr, axis=None, rtol=1e-05, atol=1e-08):
     expected = np.sum(arr, axis=axis, dtype=np.float64)
     if not np.all(np.isclose(out.take(-1, axis=axis), expected, rtol=rtol,
                              atol=atol, equal_nan=True)):
-        warn('cumsum was found to be unstable: '
+        warnings.warn('cumsum was found to be unstable: '
                       'its last element does not correspond to sum',
                       RuntimeWarning)
     return out

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -22,6 +22,8 @@ import warnings
 
 import numpy as np
 
+from .utils import warn
+
 
 ###############################################################################
 # Misc
@@ -68,7 +70,6 @@ def _safe_svd(A, **kwargs):
     try:
         return linalg.svd(A, **kwargs)
     except np.linalg.LinAlgError as exp:
-        from .utils import warn
         if 'lapack_driver' in _get_args(linalg.svd):
             warn('SVD error (%s), attempting to use GESVD instead of GESDD'
                  % (exp,))
@@ -152,7 +153,7 @@ def _read_geometry(filepath, read_metadata=False, read_stamp=False):
     ret = (coords, faces)
     if read_metadata:
         if len(volume_info) == 0:
-            warnings.warn('No volume information contained in the file')
+            warn('No volume information contained in the file')
         ret += (volume_info,)
     if read_stamp:
         ret += (create_stamp,)
@@ -224,7 +225,7 @@ def _read_volume_info(fobj):
     if not np.array_equal(head, [20]):  # Read two bytes more
         head = np.concatenate([head, np.fromfile(fobj, '>i4', 2)])
         if not np.array_equal(head, [2, 0, 20]):
-            warnings.warn("Unknown extension code.")
+            warn("Unknown extension code.")
             return volume_info
 
     volume_info['head'] = head
@@ -257,7 +258,7 @@ def _serialize_volume_info(volume_info):
         if key == 'head':
             if not (np.array_equal(volume_info[key], [20]) or np.array_equal(
                     volume_info[key], [2, 0, 20])):
-                warnings.warn("Unknown extension code.")
+                warn("Unknown extension code.")
             strings.append(np.array(volume_info[key], dtype='>i4').tobytes())
         elif key in ('valid', 'filename'):
             val = volume_info[key]
@@ -547,7 +548,7 @@ def empirical_covariance(X, assume_centered=False):
         X = np.reshape(X, (1, -1))
 
     if X.shape[0] == 1:
-        warnings.warn("Only one sample available. "
+        warn("Only one sample available. "
                       "You may want to reshape your data array")
 
     if assume_centered:
@@ -879,7 +880,7 @@ def stable_cumsum(arr, axis=None, rtol=1e-05, atol=1e-08):
     expected = np.sum(arr, axis=axis, dtype=np.float64)
     if not np.all(np.isclose(out.take(-1, axis=axis), expected, rtol=rtol,
                              atol=atol, equal_nan=True)):
-        warnings.warn('cumsum was found to be unstable: '
+        warn('cumsum was found to be unstable: '
                       'its last element does not correspond to sum',
                       RuntimeWarning)
     return out

--- a/mne/gui/_coreg_gui.py
+++ b/mne/gui/_coreg_gui.py
@@ -90,7 +90,7 @@ from ..transforms import (write_trans, read_trans, apply_trans, rotation,
 from ..coreg import fit_matched_points, scale_mri, _find_fiducials_files
 from ..viz.backends._pysurfer_mayavi import _toggle_mlab_render
 from ..viz._3d import _get_3d_option
-from ..utils import logger, set_config, _pl
+from ..utils import logger, set_config, _pl, warn
 from ._fiducials_gui import MRIHeadWithFiducialsModel, FiducialsPanel
 from ._file_traits import trans_wildcard, DigSource, SubjectSelectorPanel
 from ._viewer import (HeadViewController, PointObject, SurfaceObject,
@@ -895,7 +895,7 @@ class CoregFrameHandler(Handler):
             try:
                 info.object.save_config(size=size)
             except Exception as exc:
-                warnings.warn("Error saving GUI configuration:\n%s" % (exc,))
+                warn("Error saving GUI configuration:\n%s" % (exc,))
             return True
 
 

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -484,7 +484,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale):
         try:
             n_samples = cfg.getint(cinfostr, 'DataPoints')
         except configparser.NoOptionError:
-            logger.warning('No info on DataPoints found. Inferring number of '
+            warn('No info on DataPoints found. Inferring number of '
                            'samples from the data file size.')
             with open(data_fname, 'rb') as fid:
                 fid.seek(0, 2)

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -485,7 +485,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale):
             n_samples = cfg.getint(cinfostr, 'DataPoints')
         except configparser.NoOptionError:
             warn('No info on DataPoints found. Inferring number of '
-                           'samples from the data file size.')
+                 'samples from the data file size.')
             with open(data_fname, 'rb') as fid:
                 fid.seek(0, 2)
                 n_bytes = fid.tell()

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -512,7 +512,7 @@ def get_kit_info(rawfile, allow_unknown_format, standardize_names=None,
             version_string = "V%iR%03i" % (version, revision)
             if allow_unknown_format:
                 unsupported_format = True
-                logger.warning("Force loading KIT format %s", version_string)
+                warn("Force loading KIT format %s", version_string)
             else:
                 raise UnsupportedKITFormat(
                     version_string,

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -149,6 +149,12 @@ def run_subprocess(command, return_code=False, verbose=None, *args, **kwargs):
                     break
                 else:
                     err = err.decode('utf-8')
+                    # Leave this as logger.warning rather than warn(...) to
+                    # mirror the logger.info above for stdout. This function
+                    # is basically just a version of subprocess.call, and
+                    # shouldn't emit Python warnings due to stderr outputs
+                    # (the calling function can check for stderr output and
+                    # emit a warning if it wants).
                     logger.warning(err)
                     all_err += err
             if do_break:

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -123,7 +123,7 @@ def run_subprocess(command, return_code=False, verbose=None, *args, **kwargs):
     # non-blocking adapted from https://stackoverflow.com/questions/375427/non-blocking-read-on-a-subprocess-pipe-in-python#4896288  # noqa: E501
     out_q = Queue()
     err_q = Queue()
-    with running_subprocess(command, *args, **kwargs) as p:
+    with running_subprocess(command, *args, **kwargs) as p, p.stdout, p.stderr:
         out_t = Thread(target=_enqueue_output, args=(p.stdout, out_q))
         err_t = Thread(target=_enqueue_output, args=(p.stderr, err_q))
         out_t.daemon = True
@@ -149,12 +149,10 @@ def run_subprocess(command, return_code=False, verbose=None, *args, **kwargs):
                     break
                 else:
                     err = err.decode('utf-8')
-                    warn(err)
+                    logger.warning(err)
                     all_err += err
             if do_break:
                 break
-    p.stdout.close()
-    p.stderr.close()
     output = (all_out, all_err)
 
     if return_code:

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -149,7 +149,7 @@ def run_subprocess(command, return_code=False, verbose=None, *args, **kwargs):
                     break
                 else:
                     err = err.decode('utf-8')
-                    logger.warning(err)
+                    warn(err)
                     all_err += err
             if do_break:
                 break


### PR DESCRIPTION
closes #9432

A simple PR to improve consistency in the code base: using `mne.utils.warn`, instead of different warning calls.