### PR TITLE
[ENH] Add support for multiple datablocks in Nihon Kohden files

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -49,6 +49,8 @@ Enhancements
 
 - Add support for interpolating oxy and deoxyhaemoglobin data types (:gh:`9431` by `Robert Luke`_)
 
+- Add support for multiple datablocks (acquistions with pauses) in `mne.io.read_raw_nihon` (:gh:`9437` by `Fede Raimondo`_)
+
 Bugs
 ~~~~
 - Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** |Jan Sosulski|_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -49,7 +49,7 @@ Enhancements
 
 - Add support for interpolating oxy and deoxyhaemoglobin data types (:gh:`9431` by `Robert Luke`_)
 
-- Add support for multiple datablocks (acquistions with pauses) in `mne.io.read_raw_nihon` (:gh:`9437` by `Fede Raimondo`_)
+- Add support for multiple datablocks (acquistions with pauses) in :func:`mne.io.read_raw_nihon` (:gh:`9437` by `Fede Raimondo`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -49,7 +49,7 @@ Enhancements
 
 - Add support for interpolating oxy and deoxyhaemoglobin data types (:gh:`9431` by `Robert Luke`_)
 
-- Add support for multiple datablocks (acquistions with pauses) in :func:`mne.io.read_raw_nihon` (:gh:`9437` by `Fede Raimondo`_)
+- Add support for multiple datablocks (acquistions with pauses) in :func:`mne.io.read_raw_nihon` (:gh:`9437` by `Federico Raimondo`_)
 
 Bugs
 ~~~~

--- a/mne/io/nihon/nihon.py
+++ b/mne/io/nihon/nihon.py
@@ -215,20 +215,33 @@ def _read_nihon_header(fname):
     if header['n_ctlblocks'] != 1:
         raise NotImplementedError('I dont know how to read more than one '
                                   'control block for this type of file :(')
-    if header['controlblocks'][0]['n_datablocks'] != 1:
-        raise NotImplementedError('I dont know how to read more than one '
-                                  'data block for this type of file :(')
+    if header['controlblocks'][0]['n_datablocks'] > 1:
+        # Multiple blocks, check that they all have the same kind of data
+        datablocks = header['controlblocks'][0]['datablocks']
+        block_0 = datablocks[0]
+        for t_block in datablocks[1:]:
+            if block_0['n_channels'] != t_block['n_channels']:
+                raise ValueError(
+                    'Cannot read NK file with different number of channels '
+                    'in each datablock')
+            if block_0['channels'] != t_block['channels']:
+                raise ValueError(
+                    'Cannot read NK file with different channels in each '
+                    'datablock')
+            if block_0['sfreq'] != t_block['sfreq']:
+                raise ValueError(
+                    'Cannot read NK file with different sfreq in each '
+                    'datablock')
 
     return header
 
 
-def _read_nihon_annotations(fname, orig_time):
+def _read_nihon_annotations(fname):
     fname = _ensure_path(fname)
-    annotations = None
     log_fname = fname.with_suffix('.LOG')
     if not log_fname.exists():
         warn('No LOG file exists. Annotations will not be read')
-        return annotations
+        return dict(onset=[], duration=[], description=[])
     logger.info('Found LOG file, reading events.')
     with open(log_fname, 'r') as fid:
         version = np.fromfile(fid, '|S16', 1).astype('U16')[0]
@@ -266,8 +279,11 @@ def _read_nihon_annotations(fname, orig_time):
                 all_onsets.append(t_onset)
                 all_descriptions.append(t_desc)
 
-        annotations = Annotations(all_onsets, 0.0, all_descriptions, orig_time)
-    return annotations
+        annots = dict(
+            onset=all_onsets,
+            duration=[0] * len(all_onsets),
+            description=all_descriptions)
+    return annots
 
 
 def _map_ch_to_type(ch_name):
@@ -362,12 +378,25 @@ class RawNihon(BaseRaw):
             raw_extras=[raw_extras])
 
         # Get annotations from LOG file
-        annots = _read_nihon_annotations(fname, orig_time=info['meas_date'])
-        self.set_annotations(annots)
+        annots = _read_nihon_annotations(fname)
+
+        # Annotate acqusition skips
+        controlblock = self._header['controlblocks'][0]
+        cur_sample = 0
+        if controlblock['n_datablocks'] > 1:
+            for i_block in range(controlblock['n_datablocks'] - 1):
+                t_block = controlblock['datablocks'][i_block]
+                cur_sample = cur_sample + t_block['n_samples']
+                annots['onset'].append((cur_sample - 0.5) / t_block['sfreq'])
+                annots['duration'].append(0.0)
+                annots['description'].append('BAD_ACQ_SKIP')
+
+        annotations = Annotations(**annots, orig_time=info['meas_date'])
+        self.set_annotations(annotations)
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
-        # For now we assume one control block and one data block.
+        # For now we assume one control block
         header = self._raw_extras[fi]['header']
 
         # Get the original cal, offsets and gains
@@ -375,18 +404,50 @@ class RawNihon(BaseRaw):
         offsets = self._raw_extras[fi]['offsets']
         gains = self._raw_extras[fi]['gains']
 
-        datablock = header['controlblocks'][0]['datablocks'][0]
-        n_channels = datablock['n_channels'] + 1
-        datastart = (datablock['address'] + 0x27 +
-                     (datablock['n_channels'] * 10))
-        with open(self._filenames[fi], 'rb') as fid:
-            start_offset = datastart + start * n_channels * 2
-            to_read = (stop - start) * n_channels
-            fid.seek(start_offset)
-            block_data = np.fromfile(fid, '<u2', to_read) + 0x8000
-            block_data = block_data.astype(np.int16)
-            block_data = block_data.reshape(n_channels, -1, order='F')
-            block_data = block_data[:-1] * cal  # cast to float64
-            block_data += offsets
-            block_data *= gains
-            _mult_cal_one(data, block_data, idx, cals, mult)
+        # get the right datablock
+        datablocks = header['controlblocks'][0]['datablocks']
+        ends = np.cumsum([t['n_samples'] for t in datablocks])
+
+        start_block = np.where(start < ends)[0][0]
+        stop_block = np.where(stop <= ends)[0][0]
+
+        if start_block != stop_block:
+            # Recursive call for each block independently
+            new_start = start
+            sample_start = 0
+            for t_block_idx in range(start_block, stop_block + 1):
+                t_block = datablocks[t_block_idx]
+                if t_block == stop_block:
+                    # If its the last block, we stop on the last sample to read
+                    new_stop = stop
+                else:
+                    # Otherwise, stop on the last sample of the block
+                    new_stop = t_block['n_samples']
+                samples_to_read = new_stop - new_start
+                sample_stop = sample_start + samples_to_read
+
+                self._read_segment_file(
+                    data[:, sample_start:sample_stop], idx, fi,
+                    new_start, new_stop, cals, mult
+                )
+
+                # Update variables for next loop
+                sample_start = sample_stop
+                new_start = new_stop
+        else:
+            datablock = datablocks[start_block]
+
+            n_channels = datablock['n_channels'] + 1
+            datastart = (datablock['address'] + 0x27 +
+                        (datablock['n_channels'] * 10))
+            with open(self._filenames[fi], 'rb') as fid:
+                start_offset = datastart + start * n_channels * 2
+                to_read = (stop - start) * n_channels
+                fid.seek(start_offset)
+                block_data = np.fromfile(fid, '<u2', to_read) + 0x8000
+                block_data = block_data.astype(np.int16)
+                block_data = block_data.reshape(n_channels, -1, order='F')
+                block_data = block_data[:-1] * cal  # cast to float64
+                block_data += offsets
+                block_data *= gains
+                _mult_cal_one(data, block_data, idx, cals, mult)

--- a/mne/io/nihon/nihon.py
+++ b/mne/io/nihon/nihon.py
@@ -439,7 +439,7 @@ class RawNihon(BaseRaw):
 
             n_channels = datablock['n_channels'] + 1
             datastart = (datablock['address'] + 0x27 +
-                        (datablock['n_channels'] * 10))
+                         (datablock['n_channels'] * 10))
             with open(self._filenames[fi], 'rb') as fid:
                 start_offset = datastart + start * n_channels * 2
                 to_read = (stop - start) * n_channels

--- a/mne/io/nihon/nihon.py
+++ b/mne/io/nihon/nihon.py
@@ -422,7 +422,7 @@ class RawNihon(BaseRaw):
                     new_stop = stop
                 else:
                     # Otherwise, stop on the last sample of the block
-                    new_stop = t_block['n_samples']
+                    new_stop = t_block['n_samples'] + new_start
                 samples_to_read = new_stop - new_start
                 sample_stop = sample_start + samples_to_read
 
@@ -440,8 +440,14 @@ class RawNihon(BaseRaw):
             n_channels = datablock['n_channels'] + 1
             datastart = (datablock['address'] + 0x27 +
                          (datablock['n_channels'] * 10))
+
+            # Compute start offset based on the beggining of the block
+            rel_start = start
+            if start_block != 0:
+                rel_start = start - ends[start_block - 1]
+            start_offset = datastart + rel_start * n_channels * 2
+
             with open(self._filenames[fi], 'rb') as fid:
-                start_offset = datastart + start * n_channels * 2
                 to_read = (stop - start) * n_channels
                 fid.seek(start_offset)
                 block_data = np.fromfile(fid, '<u2', to_read) + 0x8000

--- a/mne/io/nihon/nihon.py
+++ b/mne/io/nihon/nihon.py
@@ -387,9 +387,14 @@ class RawNihon(BaseRaw):
             for i_block in range(controlblock['n_datablocks'] - 1):
                 t_block = controlblock['datablocks'][i_block]
                 cur_sample = cur_sample + t_block['n_samples']
-                annots['onset'].append((cur_sample - 0.5) / t_block['sfreq'])
+                cur_tpoint = (cur_sample - 0.5) / t_block['sfreq']
+                # Add annotations as in append raw
+                annots['onset'].append(cur_tpoint)
                 annots['duration'].append(0.0)
-                annots['description'].append('BAD_ACQ_SKIP')
+                annots['description'].append('BAD boundary')
+                annots['onset'].append(cur_tpoint)
+                annots['duration'].append(0.0)
+                annots['description'].append('EDGE boundary')
 
         annotations = Annotations(**annots, orig_time=info['meas_date'])
         self.set_annotations(annotations)

--- a/mne/io/nihon/nihon.py
+++ b/mne/io/nihon/nihon.py
@@ -441,7 +441,7 @@ class RawNihon(BaseRaw):
             datastart = (datablock['address'] + 0x27 +
                          (datablock['n_channels'] * 10))
 
-            # Compute start offset based on the beggining of the block
+            # Compute start offset based on the beginning of the block
             rel_start = start
             if start_block != 0:
                 rel_start = start - ends[start_block - 1]

--- a/mne/io/nihon/tests/test_nihon.py
+++ b/mne/io/nihon/tests/test_nihon.py
@@ -57,5 +57,5 @@ def test_nihon_eeg():
 
     msg = 'No LOG file exists. Annotations will not be read'
     with pytest.warns(RuntimeWarning, match=msg):
-        annot = _read_nihon_annotations(bad_fname, orig_time=None)
-        assert annot is None
+        annot = _read_nihon_annotations(bad_fname)
+        assert all(len(x) == 0 for _, x in annot.items())

--- a/mne/io/nihon/tests/test_nihon.py
+++ b/mne/io/nihon/tests/test_nihon.py
@@ -58,4 +58,4 @@ def test_nihon_eeg():
     msg = 'No LOG file exists. Annotations will not be read'
     with pytest.warns(RuntimeWarning, match=msg):
         annot = _read_nihon_annotations(bad_fname)
-        assert all(len(x) == 0 for _, x in annot.items())
+        assert all(len(x) == 0 for x in annot.values())


### PR DESCRIPTION
#### Reference issue
Fixes/Implements #9429.

#### What does this implement/fix?

Nihon Kohden reader was not tested using multiple datablocks (maybe due to only having continuous recordings? don't really know yet). This PR allows to read NK EEG files with multiple datablocks.

#### Additional information
Still needs to be tested against the corresponding EDF files.  PR is WIP.
