### PR TITLE
MRG, MAINT: Better mem usage and errors

### DIFF
--- a/examples/connectivity/mne_inverse_envelope_correlation.py
+++ b/examples/connectivity/mne_inverse_envelope_correlation.py
@@ -50,22 +50,23 @@ raw.apply_proj()
 cov = mne.compute_raw_covariance(raw)  # compute before band-pass of interest
 
 ##############################################################################
+# Compute the forward and inverse
+# -------------------------------
+
+src = mne.read_source_spaces(src)
+fwd = mne.make_forward_solution(raw.info, trans, src, bem)
+del src
+inv = make_inverse_operator(raw.info, fwd, cov)
+del fwd
+
+##############################################################################
 # Now we band-pass filter our data and create epochs.
 
 raw.filter(14, 30)
 events = mne.make_fixed_length_events(raw, duration=5.)
 epochs = mne.Epochs(raw, events=events, tmin=0, tmax=5.,
                     baseline=None, reject=dict(mag=8e-13), preload=True)
-del raw
-
-##############################################################################
-# Compute the forward and inverse
-# -------------------------------
-
-src = mne.read_source_spaces(src)
-fwd = mne.make_forward_solution(epochs.info, trans, src, bem)
-inv = make_inverse_operator(epochs.info, fwd, cov)
-del fwd, src
+del raw, projs_ecg, projs_eog
 
 ##############################################################################
 # Compute label time series and do envelope correlation
@@ -84,6 +85,7 @@ corr = envelope_correlation(label_ts, verbose=True)
 fig, ax = plt.subplots(figsize=(4, 4))
 ax.imshow(corr, cmap='viridis', clim=np.percentile(corr, [5, 95]))
 fig.tight_layout()
+del epochs, stcs, label_ts
 
 ##############################################################################
 # Compute the degree and plot it

--- a/examples/connectivity/mne_inverse_envelope_correlation_volume.py
+++ b/examples/connectivity/mne_inverse_envelope_correlation_volume.py
@@ -51,7 +51,8 @@ raw.filter(14, 30)
 events = mne.make_fixed_length_events(raw, duration=5.)
 epochs = mne.Epochs(raw, events=events, tmin=0, tmax=5.,
                     baseline=None, reject=dict(mag=8e-13), preload=True)
-del raw
+data_cov = mne.compute_covariance(epochs)
+del raw, projs_ecg, projs_eog
 
 ##############################################################################
 # Compute the forward and inverse
@@ -63,10 +64,9 @@ pos = 15.  # 1.5 cm is very broad, done here for speed!
 src = mne.setup_volume_source_space('bst_resting', pos, bem=bem,
                                     subjects_dir=subjects_dir, verbose=True)
 fwd = mne.make_forward_solution(epochs.info, trans, src, bem)
-data_cov = mne.compute_covariance(epochs)
 filters = make_lcmv(epochs.info, fwd, data_cov, 0.05, cov,
                     pick_ori='max-power', weight_norm='nai')
-del fwd
+del fwd, data_cov, cov
 
 ##############################################################################
 # Compute label time series and do envelope correlation
@@ -75,6 +75,7 @@ del fwd
 epochs.apply_hilbert()  # faster to do in sensor space
 stcs = apply_lcmv_epochs(epochs, filters, return_generator=True)
 corr = envelope_correlation(stcs, verbose=True)
+del stcs, epochs, filters
 
 ##############################################################################
 # Compute the degree and plot it

--- a/examples/inverse/psf_ctf_vertices.py
+++ b/examples/inverse/psf_ctf_vertices.py
@@ -56,6 +56,7 @@ sources = [1000]
 stc_psf = get_point_spread(rm_lor, forward['src'], sources, norm=True)
 
 stc_ctf = get_cross_talk(rm_lor, forward['src'], sources, norm=True)
+del rm_lor
 
 ##############################################################################
 # Visualize

--- a/examples/inverse/psf_ctf_vertices_lcmv.py
+++ b/examples/inverse/psf_ctf_vertices_lcmv.py
@@ -93,18 +93,17 @@ filters_post = make_lcmv(info, forward, cov_post, reg=0.05,
 # Compute resolution matrices for the two LCMV beamformers
 # --------------------------------------------------------
 
-rm_pre = make_lcmv_resolution_matrix(filters_pre, forward, info)
-
-rm_post = make_lcmv_resolution_matrix(filters_post, forward, info)
-
 # compute cross-talk functions (CTFs) for one target vertex
 sources = [3000]
-
-stc_pre = get_cross_talk(rm_pre, forward['src'], sources, norm=True)
-
-stc_post = get_cross_talk(rm_post, forward['src'], sources, norm=True)
 verttrue = [forward['src'][0]['vertno'][sources[0]]]  # pick one vertex
-del forward
+rm_pre = make_lcmv_resolution_matrix(filters_pre, forward, info)
+stc_pre = get_cross_talk(rm_pre, forward['src'], sources, norm=True)
+del rm_pre
+
+##############################################################################
+rm_post = make_lcmv_resolution_matrix(filters_post, forward, info)
+stc_post = get_cross_talk(rm_post, forward['src'], sources, norm=True)
+del rm_post
 
 ##############################################################################
 # Visualize

--- a/mne/label.py
+++ b/mne/label.py
@@ -2082,6 +2082,7 @@ def read_labels_from_annot(subject, parc='aparc', hemi='both',
     # now we are ready to create the labels
     n_read = 0
     labels = list()
+    orig_names = set()
     for fname, hemi in zip(annot_fname, hemis):
         # read annotation
         annot, ctab, label_names = _read_annot(fname)
@@ -2098,7 +2099,9 @@ def read_labels_from_annot(subject, parc='aparc', hemi='both',
             if len(vertices) == 0:
                 # label is not part of cortical surface
                 continue
-            name = label_name.decode() + '-' + hemi
+            label_name = label_name.decode()
+            orig_names.add(label_name)
+            name = f'{label_name}-{hemi}'
             if (regexp is not None) and not r_.match(name):
                 continue
             pos = vert_pos[vertices, :]
@@ -2116,7 +2119,9 @@ def read_labels_from_annot(subject, parc='aparc', hemi='both',
     if len(labels) == 0:
         msg = 'No labels found.'
         if regexp is not None:
-            msg += ' Maybe the regular expression %r did not match?' % regexp
+            orig_names = '\n'.join(sorted(orig_names))
+            msg += (f' Maybe the regular expression {repr(regexp)} did not '
+                    f'match any of:\n{orig_names}')
         raise RuntimeError(msg)
 
     return labels

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -499,9 +499,10 @@ def test_read_labels_from_annot(tmpdir):
                                    regexp='.*-.{4,}_.{3,3}-L',
                                    subjects_dir=subjects_dir)[0]
     assert (label.name == 'G_oc-temp_med-Lingual-lh')
-    pytest.raises(RuntimeError, read_labels_from_annot, 'sample', parc='aparc',
-                  annot_fname=annot_fname, regexp='JackTheRipper',
-                  subjects_dir=subjects_dir)
+    with pytest.raises(RuntimeError, match='did not match any of'):
+        read_labels_from_annot(
+            'sample', parc='aparc', annot_fname=annot_fname, regexp='foo',
+            subjects_dir=subjects_dir)
 
 
 @testing.requires_testing_data

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2436,6 +2436,7 @@ def _check_pysurfer_antialias(Brain):
 
 
 def _check_views(surf, views, hemi, stc=None, backend=None):
+    from ._brain.view import views_dicts
     from ..source_estimate import SourceEstimate
     _validate_type(views, (list, tuple, str), 'views')
     views = [views] if isinstance(views, str) else list(views)
@@ -2455,6 +2456,8 @@ def _check_views(surf, views, hemi, stc=None, backend=None):
     if (views == ['flat']) ^ (surf == 'flat'):  # exactly only one of the two
         raise ValueError('surface="flat" must be used with views="flat", got '
                          f'surface={repr(surf)} and views={repr(views)}')
+    for vi, v in enumerate(views):
+        _check_option(f'views[{vi}]', v, sorted(views_dicts[hemi]))
     return views
 
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2456,8 +2456,10 @@ def _check_views(surf, views, hemi, stc=None, backend=None):
     if (views == ['flat']) ^ (surf == 'flat'):  # exactly only one of the two
         raise ValueError('surface="flat" must be used with views="flat", got '
                          f'surface={repr(surf)} and views={repr(views)}')
+    _check_option('hemi', hemi, ('split', 'both', 'lh', 'rh', 'vol'))
+    use_hemi = 'lh' if hemi == 'split' else hemi
     for vi, v in enumerate(views):
-        _check_option(f'views[{vi}]', v, sorted(views_dicts[hemi]))
+        _check_option(f'views[{vi}]', v, sorted(views_dicts[use_hemi]))
     return views
 
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -395,13 +395,13 @@ class Brain(object):
         from .._3d import _get_cmap
         from matplotlib.colors import colorConverter
 
+        _validate_type(hemi, str, 'hemi')
+        hemi = self._check_hemi(hemi, extras=('both', 'split'))
         if hemi in ('both', 'split'):
             self._hemis = ('lh', 'rh')
-        elif hemi in ('lh', 'rh'):
-            self._hemis = (hemi, )
         else:
-            raise KeyError('hemi has to be either "lh", "rh", "split", '
-                           'or "both"')
+            assert hemi in ('lh', 'rh')
+            self._hemis = (hemi, )
         self._view_layout = _check_option('view_layout', view_layout,
                                           ('vertical', 'horizontal'))
 
@@ -421,9 +421,6 @@ class Brain(object):
         if isinstance(foreground, str):
             foreground = colorConverter.to_rgb(foreground)
         self._fg_color = foreground
-
-        if isinstance(views, str):
-            views = [views]
         views = _check_views(surf, views, hemi)
         col_dict = dict(lh=1, rh=1, both=1, split=2)
         shape = (len(views), col_dict[hemi])
@@ -3257,16 +3254,13 @@ class Brain(object):
 
     def _check_hemi(self, hemi, extras=()):
         """Check for safe single-hemi input, returns str."""
+        _validate_type(hemi, (None, str), 'hemi')
         if hemi is None:
             if self._hemi not in ['lh', 'rh']:
                 raise ValueError('hemi must not be None when both '
                                  'hemispheres are displayed')
-            else:
-                hemi = self._hemi
-        elif hemi not in ['lh', 'rh'] + list(extras):
-            extra = ' or None' if self._hemi in ['lh', 'rh'] else ''
-            raise ValueError('hemi must be either "lh" or "rh"' +
-                             extra + ", got " + str(hemi))
+            hemi = self._hemi
+        _check_option('hemi', hemi, ('lh', 'rh') + tuple(extras))
         return hemi
 
     def _check_hemis(self, hemi):

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -184,14 +184,18 @@ def test_brain_init(renderer_pyvista, tmpdir, pixel_ratio, brain_gc):
     kwargs = dict(subject_id=subject_id, subjects_dir=subjects_dir)
     with pytest.raises(ValueError, match='"size" parameter must be'):
         Brain(hemi=hemi, surf=surf, size=[1, 2, 3], **kwargs)
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError, match='.*hemi.*Allowed values.*'):
         Brain(hemi='foo', surf=surf, **kwargs)
+    with pytest.raises(ValueError, match='.*view.*Allowed values.*'):
+        Brain(hemi='lh', surf=surf, views='foo', **kwargs)
     with pytest.raises(TypeError, match='figure'):
         Brain(hemi=hemi, surf=surf, figure='foo', **kwargs)
     with pytest.raises(TypeError, match='interaction'):
         Brain(hemi=hemi, surf=surf, interaction=0, **kwargs)
     with pytest.raises(ValueError, match='interaction'):
         Brain(hemi=hemi, surf=surf, interaction='foo', **kwargs)
+    with pytest.raises(FileNotFoundError, match=r'lh\.whatever'):
+        Brain(subject_id, 'lh', 'whatever')
     renderer_pyvista.backend._close_all()
 
     brain = Brain(hemi=hemi, surf=surf, size=size, title=title,
@@ -204,10 +208,8 @@ def test_brain_init(renderer_pyvista, tmpdir, pixel_ratio, brain_gc):
     brain._hemi = 'foo'  # for testing: hemis
     with pytest.raises(ValueError, match='not be None'):
         brain._check_hemi(hemi=None)
-    with pytest.raises(ValueError, match='either "lh" or "rh"'):
+    with pytest.raises(ValueError, match='Invalid.*hemi.*Allowed'):
         brain._check_hemi(hemi='foo')
-    with pytest.raises(ValueError, match='either "lh" or "rh"'):
-        brain._check_hemis(hemi='foo')
     brain._hemi = hemi  # end testing: hemis
     with pytest.raises(ValueError, match='bool or positive'):
         brain._to_borders(None, None, 'foo')

--- a/tutorials/inverse/85_brainstorm_phantom_ctf.py
+++ b/tutorials/inverse/85_brainstorm_phantom_ctf.py
@@ -21,6 +21,8 @@ References
 # License: BSD (3-clause)
 
 import os.path as op
+import warnings
+
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -108,7 +110,10 @@ raw_erm = mne.preprocessing.maxwell_filter(raw_erm, coord_frame='meg',
 cov = mne.compute_raw_covariance(raw_erm)
 del raw_erm
 
-dip, residual = fit_dipole(evoked, cov, sphere, verbose=True)
+with warnings.catch_warnings(record=True):
+    # ignore warning about data rank exceeding that of info (75 > 71)
+    warnings.simplefilter('ignore')
+    dip, residual = fit_dipole(evoked, cov, sphere, verbose=True)
 
 ###############################################################################
 # Compare the actual position with the estimated one.


### PR DESCRIPTION
1. Fix problems with examples introduced by #9435
2. Reduce memory usage of envelope correlation examples that seem to keep killing CircleCI
3. Use more standard `_check_option` / `_validate_type` in `Brain` to give more informative messages for bad Brain args.