### PR TITLE
MRG: Add fnirs and snirf support to report

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -49,7 +49,7 @@ Enhancements
 
 - Add support for interpolating oxy and deoxyhaemoglobin data types (:gh:`9431` by `Robert Luke`_)
    
-- Add support for SNIRF files in :class:`mne.Report` types (:gh:`9443` by `Robert Luke`_)
+- Add support for SNIRF files in :class:`mne.Report` (:gh:`9443` by `Robert Luke`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -48,6 +48,8 @@ Enhancements
 - Add projections when printing a :class:`mne.Info` in the notebook (:gh:`9403` by `Alex Gramfort`_)
 
 - Add support for interpolating oxy and deoxyhaemoglobin data types (:gh:`9431` by `Robert Luke`_)
+   
+- Add support for SNIRF files in :class:`mne.Report` types (:gh:`9443` by `Robert Luke`_)
 
 Bugs
 ~~~~

--- a/mne/io/_read_raw.py
+++ b/mne/io/_read_raw.py
@@ -12,7 +12,7 @@ from . import (read_raw_edf, read_raw_bdf, read_raw_gdf, read_raw_brainvision,
                read_raw_fif, read_raw_eeglab, read_raw_cnt, read_raw_egi,
                read_raw_eximia, read_raw_nirx, read_raw_fieldtrip,
                read_raw_artemis123, read_raw_nicolet, read_raw_kit,
-               read_raw_ctf, read_raw_boxy)
+               read_raw_ctf, read_raw_boxy, read_raw_snirf)
 from ..utils import fill_doc
 
 
@@ -39,6 +39,7 @@ supported = {
     ".mff": read_raw_egi,
     ".nxe": read_raw_eximia,
     ".hdr": read_raw_nirx,
+    ".snirf": read_raw_snirf,
     ".mat": read_raw_fieldtrip,
     ".bin": read_raw_artemis123,
     ".data": read_raw_nicolet,

--- a/mne/report.py
+++ b/mne/report.py
@@ -340,7 +340,7 @@ def _iterate_files(report, fnames, info, cov, baseline, sfreq, on_error,
                                              data_path)
                 report_fname = fname
                 report_sectionlabel = 'evoked'
-            elif _endswith(fname, ['eve']):
+            elif _endswith(fname, 'eve'):
                 html = report._render_eve(fname, sfreq, image_format,
                                           data_path)
                 report_fname = fname

--- a/mne/report.py
+++ b/mne/report.py
@@ -53,6 +53,7 @@ for ext in SUPPORTED_READ_RAW_EXTENSIONS:
         RAW_EXTENSIONS.append(f'meg{ext}')
     RAW_EXTENSIONS.append(f'eeg{ext}')
     RAW_EXTENSIONS.append(f'ieeg{ext}')
+    RAW_EXTENSIONS.append(f'nirs{ext}')
 
 # Processed data will always be in (gzipped) FIFF format
 VALID_EXTENSIONS = ('sss.fif', 'sss.fif.gz',
@@ -258,7 +259,7 @@ def _get_toc_property(fname):
         div_klass = 'ssp'
         tooltip = fname
         text = op.basename(fname)
-    elif _endswith(fname, ['raw', 'sss', 'meg']):
+    elif _endswith(fname, ['raw', 'sss', 'meg', 'nirs']):
         div_klass = 'raw'
         tooltip = fname
         text = op.basename(fname)
@@ -314,7 +315,7 @@ def _iterate_files(report, fnames, info, cov, baseline, sfreq, on_error,
                     % op.join('...' + report.data_path[-20:],
                               fname))
         try:
-            if _endswith(fname, ['raw', 'sss', 'meg']):
+            if _endswith(fname, ['raw', 'sss', 'meg', 'nirs']):
                 html = report._render_raw(fname, data_path)
                 report_fname = fname
                 report_sectionlabel = 'raw'
@@ -339,7 +340,7 @@ def _iterate_files(report, fnames, info, cov, baseline, sfreq, on_error,
                                              data_path)
                 report_fname = fname
                 report_sectionlabel = 'evoked'
-            elif _endswith(fname, 'eve'):
+            elif _endswith(fname, ['eve']):
                 html = report._render_eve(fname, sfreq, image_format,
                                           data_path)
                 report_fname = fname

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -49,6 +49,8 @@ base_dir = op.realpath(op.join(op.dirname(__file__), '..', 'io', 'tests',
                                'data'))
 evoked_fname = op.join(base_dir, 'test-ave.fif')
 
+nirs_fname = op.join(data_dir, 'SNIRF', 'NIRx', 'NIRSport2', '1.0.3')
+
 
 def _get_example_figures():
     """Create two example figures."""
@@ -70,6 +72,7 @@ def test_render_report(renderer, tmpdir):
     proj_fname_new = op.join(tempdir, 'temp_ecg-proj.fif')
     fwd_fname_new = op.join(tempdir, 'temp_raw-fwd.fif')
     inv_fname_new = op.join(tempdir, 'temp_raw-inv.fif')
+    nirs_fname_new = op.join(tempdir, 'temp_raw-nirs.snirf')
     for a, b in [[raw_fname, raw_fname_new],
                  [raw_fname, raw_fname_new_bids],
                  [ms_fname, ms_fname_new],
@@ -77,7 +80,8 @@ def test_render_report(renderer, tmpdir):
                  [cov_fname, cov_fname_new],
                  [proj_fname, proj_fname_new],
                  [fwd_fname, fwd_fname_new],
-                 [inv_fname, inv_fname_new]]:
+                 [inv_fname, inv_fname_new],
+                 [nirs_fname, nirs_fname_new]]:
         shutil.copyfile(a, b)
 
     # create and add -epo.fif and -ave.fif files

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -110,6 +110,7 @@ def test_render_report(renderer, tmpdir):
 
     # Check correct paths and filenames
     fnames = glob.glob(op.join(tempdir, '*.fif'))
+    fnames.extend(glob.glob(op.join(tempdir, '*.snirf')))
     for fname in fnames:
         assert (op.basename(fname) in
                 [op.basename(x) for x in report.fnames])

--- a/mne/tests/test_report.py
+++ b/mne/tests/test_report.py
@@ -49,7 +49,8 @@ base_dir = op.realpath(op.join(op.dirname(__file__), '..', 'io', 'tests',
                                'data'))
 evoked_fname = op.join(base_dir, 'test-ave.fif')
 
-nirs_fname = op.join(data_dir, 'SNIRF', 'NIRx', 'NIRSport2', '1.0.3')
+nirs_fname = op.join(data_dir, 'SNIRF', 'NIRx', 'NIRSport2', '1.0.3',
+                     '2021-05-05_001.snirf')
 
 
 def _get_example_figures():


### PR DESCRIPTION
This is an issue as a PR, I have opened this for discussion.

#### What does this implement/fix?
Allows
```python
report = mne.Report()
report.parse_folder(path)
```
to read fNIRS files stored with the pattern `*-nirs.snirf` as defined in the draft BIDS standard https://bids-specification--802.org.readthedocs.build/en/802/04-modality-specific-files/10-functional-near-infrared-spectroscopy.html#fnirs-recording-data

#### Additional information
It seems report is currently used with fiff files, are we open to extending it to other file types?

Allowing the file pattern above will facilitate reading files in the BIDS format. The fNIRS BIDS specification has moved from a community feedback stage to draft proposal: https://github.com/bids-standard/bids-specification/pull/802 However, its not finalised (as I am the BEP lead it is extremely unlikely this file pattern will change, but I am trying to think of all possible issues here).