### PR TITLE
WIP: Reduce memory usage in doc build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -286,15 +286,30 @@ class Resetter(object):
             from pyvista import Plotter  # noqa
         except ImportError:
             Plotter = None  # noqa
+        try:
+            from pyvistaqt import BackgroundPlotter  # noqa
+        except ImportError:
+            BackgroundPlotter = None  # noqa
+        try:
+            from vtk import vtkPolyData  # noqa
+        except ImportError:
+            vtkPolyData = None  # noqa
+        from mne.viz.backends.renderer import backend
+        _Renderer = backend._Renderer if backend is not None else None
         reset_warnings(gallery_conf, fname)
         # in case users have interactive mode turned on in matplotlibrc,
         # turn it off here (otherwise the build can be very slow)
         plt.ioff()
         plt.rcParams['animation.embed_limit'] = 30.
         gc.collect()
-        # _assert_no_instances(Brain, 'running')  # calls gc.collect()
-        # if Plotter is not None:
-        #     _assert_no_instances(Plotter, 'running')
+        _assert_no_instances(Brain, 'Brain')  # calls gc.collect()
+        if Plotter is not None:
+            _assert_no_instances(Plotter, 'Plotter')
+        if BackgroundPlotter is not None:
+            _assert_no_instances(BackgroundPlotter, 'BackgroundPlotter')
+        if vtkPolyData is not None:
+            _assert_no_instances(vtkPolyData, 'vtkPolyData')
+        _assert_no_instances(_Renderer, '_Renderer')
         # This will overwrite some Sphinx printing but it's useful
         # for memory timestamps
         if os.getenv('SG_STAMP_STARTS', '').lower() == 'true':
@@ -309,38 +324,32 @@ gallery_dirs = ['auto_tutorials', 'auto_examples']
 os.environ['_MNE_BUILDING_DOC'] = 'true'
 scrapers = ('matplotlib',)
 try:
-    mlab = mne.utils._import_mlab()
-    # Do not pop up any mayavi windows while running the
-    # examples. These are very annoying since they steal the focus.
-    mlab.options.offscreen = True
-    # hack to initialize the Mayavi Engine
-    mlab.test_plot3d()
-    mlab.close()
+    mne.viz.set_3d_backend()
 except Exception:
-    pass
+    report_scraper = None
 else:
-    scrapers += ('mayavi',)
-try:
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning)
-        import pyvista
-    pyvista.OFF_SCREEN = False
-except Exception:
-    pass
-else:
-    scrapers += ('pyvista',)
-if any(x in scrapers for x in ('pyvista', 'mayavi')):
-    from traits.api import push_exception_handler
-    push_exception_handler(reraise_exceptions=True)
+    backend = mne.viz.get_3d_backend()
+    if backend == 'mayavi':
+        from traits.api import push_exception_handler
+        mlab = mne.utils._import_mlab()
+        # Do not pop up any mayavi windows while running the
+        # examples. These are very annoying since they steal the focus.
+        mlab.options.offscreen = True
+        # hack to initialize the Mayavi Engine
+        mlab.test_plot3d()
+        mlab.close()
+        scrapers += ('mayavi',)
+        push_exception_handler(reraise_exceptions=True)
+    elif backend in ('qt', 'notebook', 'pyvista'):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            import pyvista
+        pyvista.OFF_SCREEN = False
+        brain_scraper = mne.viz._brain._BrainScraper()
+        scrapers += (brain_scraper, 'pyvista')
     report_scraper = mne.report._ReportScraper()
     scrapers += (report_scraper,)
-else:
-    report_scraper = None
-if 'pyvista' in scrapers:
-    brain_scraper = mne.viz._brain._BrainScraper()
-    scrapers = list(scrapers)
-    scrapers.insert(scrapers.index('pyvista'), brain_scraper)
-    scrapers = tuple(scrapers)
+    del backend
 
 sphinx_gallery_conf = {
     'doc_module': ('mne',),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -324,7 +324,7 @@ gallery_dirs = ['auto_tutorials', 'auto_examples']
 os.environ['_MNE_BUILDING_DOC'] = 'true'
 scrapers = ('matplotlib',)
 try:
-    mne.viz.set_3d_backend()
+    mne.viz.set_3d_backend(mne.viz.get_3d_backend())
 except Exception:
     report_scraper = None
 else:
@@ -340,7 +340,7 @@ else:
         mlab.close()
         scrapers += ('mayavi',)
         push_exception_handler(reraise_exceptions=True)
-    elif backend in ('qt', 'notebook', 'pyvista'):
+    elif backend in ('notebook', 'pyvista'):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             import pyvista

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -324,38 +324,32 @@ gallery_dirs = ['auto_tutorials', 'auto_examples']
 os.environ['_MNE_BUILDING_DOC'] = 'true'
 scrapers = ('matplotlib',)
 try:
-    mlab = mne.utils._import_mlab()
-    # Do not pop up any mayavi windows while running the
-    # examples. These are very annoying since they steal the focus.
-    mlab.options.offscreen = True
-    # hack to initialize the Mayavi Engine
-    mlab.test_plot3d()
-    mlab.close()
+    mne.viz.set_3d_backend()
 except Exception:
-    pass
+    report_scraper = None
 else:
-    scrapers += ('mayavi',)
-try:
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning)
-        import pyvista
-    pyvista.OFF_SCREEN = False
-except Exception:
-    pass
-else:
-    scrapers += ('pyvista',)
-if any(x in scrapers for x in ('pyvista', 'mayavi')):
-    from traits.api import push_exception_handler
-    push_exception_handler(reraise_exceptions=True)
+    backend = mne.viz.get_3d_backend()
+    if backend == 'mayavi':
+        from traits.api import push_exception_handler
+        mlab = mne.utils._import_mlab()
+        # Do not pop up any mayavi windows while running the
+        # examples. These are very annoying since they steal the focus.
+        mlab.options.offscreen = True
+        # hack to initialize the Mayavi Engine
+        mlab.test_plot3d()
+        mlab.close()
+        scrapers += ('mayavi',)
+        push_exception_handler(reraise_exceptions=True)
+    elif backend in ('qt', 'notebook', 'pyvista'):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            import pyvista
+        pyvista.OFF_SCREEN = False
+        brain_scraper = mne.viz._brain._BrainScraper()
+        scrapers += (brain_scraper, 'pyvista')
     report_scraper = mne.report._ReportScraper()
     scrapers += (report_scraper,)
-else:
-    report_scraper = None
-if 'pyvista' in scrapers:
-    brain_scraper = mne.viz._brain._BrainScraper()
-    scrapers = list(scrapers)
-    scrapers.insert(scrapers.index('pyvista'), brain_scraper)
-    scrapers = tuple(scrapers)
+    del backend
 
 sphinx_gallery_conf = {
     'doc_module': ('mne',),

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -347,6 +347,12 @@ def _assert_no_instances(cls, when=''):
                         not inspect.isframe(r):
                     if isinstance(r, (list, dict)):
                         rep = f'len={len(r)}'
+                        r_ = gc.get_referrers(r)
+                        types = (x.__class__.__name__ for x in r_)
+                        types = "/".join(sorted(set(
+                            x for x in types if x is not None)))
+                        rep += f', {len(r_)} referrers: {types}'
+                        del r_
                     else:
                         rep = repr(r)[:100].replace('\n', ' ')
                     ref.append(f'{r.__class__.__name__}: {rep}')

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -193,11 +193,17 @@ class _PyVistaRenderer(_AbstractRenderer):
 
     @property
     def _all_plotters(self):
-        return [self.figure.plotter]
+        if self.figure.plotter is not None:
+            return [self.figure.plotter]
+        else:
+            return list()
 
     @property
     def _all_renderers(self):
-        return self.figure.plotter.renderers
+        if self.figure.plotter is not None:
+            return self.figure.plotter.renderers
+        else:
+            return list()
 
     def _hide_axes(self):
         for renderer in self._all_renderers:
@@ -1014,13 +1020,15 @@ def _check_3d_figure(figure):
 def _close_3d_figure(figure):
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=FutureWarning)
+        # copy the plotter locally because figure.plotter is modified
+        plotter = figure.plotter
         # close the window
-        figure.plotter.close()
-        _process_events(figure.plotter)
+        plotter.close()  # additional cleaning following signal_close
+        _process_events(plotter)
         # free memory and deregister from the scraper
-        figure.plotter.deep_clean()
-        del _ALL_PLOTTERS[figure.plotter._id_name]
-        _process_events(figure.plotter)
+        plotter.deep_clean()  # remove internal references
+        del _ALL_PLOTTERS[plotter._id_name]
+        _process_events(plotter)
 
 
 def _take_3d_screenshot(figure, mode='rgb', filename=None):

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -368,6 +368,11 @@ class _QtWindow(_AbstractWindow):
         self._interactor = self.figure.plotter.interactor
         self._window = self.figure.plotter.app_window
         self._window.setLocale(QLocale(QLocale.Language.English))
+        self._window.signal_close.connect(self._window_clean)
+
+    def _window_clean(self):
+        self.figure.plotter = None
+        self._interactor = None
 
     def _window_close_connect(self, func):
         self._window.signal_close.connect(func)

--- a/tutorials/forward/35_eeg_no_mri.py
+++ b/tutorials/forward/35_eeg_no_mri.py
@@ -77,11 +77,6 @@ fwd = mne.make_forward_solution(raw.info, trans=trans, src=src,
                                 bem=bem, eeg=True, mindist=5.0, n_jobs=1)
 print(fwd)
 
-# Use fwd to compute the sensitivity map for illustration purposes
-eeg_map = mne.sensitivity_map(fwd, ch_type='eeg', mode='fixed')
-brain = eeg_map.plot(time_label='EEG sensitivity', subjects_dir=subjects_dir,
-                     clim=dict(lims=[5, 50, 100]))
-
 ##############################################################################
 # From here on, standard inverse imaging methods can be used!
 #


### PR DESCRIPTION
CircleCI can't complete building because we're running out of memory (again), so I'm investigating why some things can't be cleaned up (again). Locally on this branch running some 3D examples I see that some vtkPolyData objects stick around:

<details>

```
$ PATTERN="\(35_eeg_no\|50_background_free\)" xvfb-run make html_dev-pattern-memory
...
Handler <function generate_gallery_rst at 0x7f474340db80> for event 'builder-inited' threw an exception (exception: 2 BackgroundPlotter:
dict: len=14, 3 referrers: dict/list
dict: len=14, 3 referrers: dict/list
dict: len=2, 5 referrers: dict/list
dict: len=55, 4 referrers: BackgroundPlotter/dict/list
QFrame: <PyQt5.QtWidgets.QFrame object at 0x7f4700c521f0>
method: <bound method QVTKRenderWindowInteractor.paintEvent of <pyvistaqt.plotting.BackgroundPlotter object 
method: <bound method QVTKRenderWindowInteractor.CursorChangedEvent of <pyvistaqt.plotting.BackgroundPlotter
method: <bound method QVTKRenderWindowInteractor.CreateTimer of <pyvistaqt.plotting.BackgroundPlotter object
method: <bound method QVTKRenderWindowInteractor.DestroyTimer of <pyvistaqt.plotting.BackgroundPlotter objec
```

</details>

@GuillaumeFavelier I'll keep looking into it this week, but feel free to have a look if you want and/or have ideas about what's causing this.