### PR TITLE
fix lingering hard-coded references

### DIFF
--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -53,11 +53,11 @@ def dpss_windows(N, half_nbw, Kmax, low_bias=True, interp_from=None,
 
     Notes
     -----
-    Tridiagonal form of DPSS calculation from:
+    Tridiagonal form of DPSS calculation from :footcite:`Slepian1978`.
 
-    Slepian, D. Prolate spheroidal wave functions, Fourier analysis, and
-    uncertainty V: The discrete case. Bell System Technical Journal,
-    Volume 57 (1978), 1371430
+    References
+    ----------
+    .. footbibliography::
     """
     from scipy import interpolate
     from scipy.signal.windows import dpss as sp_dpss

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -261,8 +261,9 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     """Compute the power spectral density (PSD) using multitapers.
 
     Calculates spectral density for orthogonal tapers, then averages them
-    together for each channel/epoch. See [1] for a description of the tapers
-    and [2] for the general method.
+    together for each channel/epoch. See :footcite:`Slepian1978` for a
+    description of the tapers and :footcite:`PercivalWalden1993` for the
+    general method.
 
     Parameters
     ----------
@@ -318,13 +319,7 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
 
     References
     ----------
-    .. [1] Slepian, D. "Prolate spheroidal wave functions, Fourier analysis,
-           and uncertainty V: The discrete case." Bell System Technical
-           Journal, vol. 57, 1978.
-
-    .. [2] Percival D.B. and Walden A.T. "Spectral Analysis for Physical
-           Applications: Multitaper and Conventional Univariate Techniques."
-           Cambridge University Press, 1993.
+    .. footbibliography::
     """
     # Prep data
     data, sfreq = _check_psd_data(inst, tmin, tmax, picks, proj)


### PR DESCRIPTION
I found a couple hard-coded refs today that slipped through the code sprint...  they weren't properly linked so my regex missed them.