### PR TITLE
MRG, ENH: Speed up TimeDelayingRidge.predict()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -59,7 +59,7 @@ Enhancements
 
 - Add new function :func:`mne.preprocessing.annotate_break` to automatically detect and mark "break" periods without any marked experimental events in the continuous data (:gh:`9445` by `Richard Höchenberger`_)
 
-- Speed up :func:`mne.decoding.time_delaying_ridge.predict` by switching to FFT-based convolution (:gh:`9458` by `Ross Maddox`_)
+- Speed up :meth:`mne.decoding.TimeDelayingRidge.predict` by switching to FFT-based convolution (:gh:`9458` by `Ross Maddox`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -59,6 +59,8 @@ Enhancements
 
 - Add new function :func:`mne.preprocessing.annotate_break` to automatically detect and mark "break" periods without any marked experimental events in the continuous data (:gh:`9445` by `Richard Höchenberger`_)
 
+- Speed up :func:`mne.decoding.TimeDelayingRidge.predict` by switching to FFT-based convolution (:gh:`9458` by `Ross Maddox`_)
+
 Bugs
 ~~~~
 - Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** |Jan Sosulski|_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -59,7 +59,7 @@ Enhancements
 
 - Add new function :func:`mne.preprocessing.annotate_break` to automatically detect and mark "break" periods without any marked experimental events in the continuous data (:gh:`9445` by `Richard Höchenberger`_)
 
-- Speed up :func:`mne.decoding.TimeDelayingRidge.predict` by switching to FFT-based convolution (:gh:`9458` by `Ross Maddox`_)
+- Speed up :func:`mne.decoding.time_delaying_ridge.predict` by switching to FFT-based convolution (:gh:`9458` by `Ross Maddox`_)
 
 Bugs
 ~~~~

--- a/mne/decoding/time_delaying_ridge.py
+++ b/mne/decoding/time_delaying_ridge.py
@@ -6,6 +6,7 @@
 # License: BSD (3-clause)
 
 import numpy as np
+from scipy.signal import fftconvolve
 
 from .base import BaseEstimator
 from ..cuda import _setup_cuda_fft_multiply_repeated
@@ -354,7 +355,7 @@ class TimeDelayingRidge(BaseEstimator):
         for ei in range(X.shape[1]):
             for oi in range(self.coef_.shape[0]):
                 for fi in range(self.coef_.shape[1]):
-                    temp = np.convolve(X[:, ei, fi], self.coef_[oi, fi])
+                    temp = fftconvolve(X[:, ei, fi], self.coef_[oi, fi])
                     temp = temp[max(-smin, 0):][:len(out) - offset]
                     out[offset:len(temp) + offset, ei, oi] += temp
         out += self.intercept_

--- a/mne/decoding/time_delaying_ridge.py
+++ b/mne/decoding/time_delaying_ridge.py
@@ -6,7 +6,6 @@
 # License: BSD (3-clause)
 
 import numpy as np
-from scipy.signal import fftconvolve
 
 from .base import BaseEstimator
 from ..cuda import _setup_cuda_fft_multiply_repeated
@@ -344,6 +343,8 @@ class TimeDelayingRidge(BaseEstimator):
         X : ndarray
             The predicted response.
         """
+        from scipy.signal import fftconvolve
+
         if X.ndim == 2:
             X = X[:, np.newaxis, :]
             singleton = True


### PR DESCRIPTION
Addresses #9455 by switching `np.convolve` to `fftconvolve` from `scipy.signal`. Speeds up `predict` function.

Closes #9455