### PR TITLE
DOC: add info about reading in digitization data from CTF dir

### DIFF
--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -57,6 +57,10 @@ def read_raw_ctf(directory, system_clock='truncate', preload=False,
     Notes
     -----
     .. versionadded:: 0.11
+    .. note:: To read in the Polhemus digitization data (for example, from
+              a .pos file), include the file in the CTF directory. The
+              points will then automatically be read into the `mne.io.Raw`
+              instace via `mne.io.read_raw_ctf`.
     """
     return RawCTF(directory, system_clock, preload=preload,
                   clean_names=clean_names, verbose=verbose)

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -60,7 +60,7 @@ def read_raw_ctf(directory, system_clock='truncate', preload=False,
     .. note:: To read in the Polhemus digitization data (for example, from
               a .pos file), include the file in the CTF directory. The
               points will then automatically be read into the `mne.io.Raw`
-              instace via `mne.io.read_raw_ctf`.
+              instance via `mne.io.read_raw_ctf`.
     """
     return RawCTF(directory, system_clock, preload=preload,
                   clean_names=clean_names, verbose=verbose)

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -57,10 +57,11 @@ def read_raw_ctf(directory, system_clock='truncate', preload=False,
     Notes
     -----
     .. versionadded:: 0.11
-    .. note:: To read in the Polhemus digitization data (for example, from
-              a .pos file), include the file in the CTF directory. The
-              points will then automatically be read into the `mne.io.Raw`
-              instance via `mne.io.read_raw_ctf`.
+
+    To read in the Polhemus digitization data (for example, from
+    a .pos file), include the file in the CTF directory. The
+    points will then automatically be read into the `mne.io.Raw`
+    instance via `mne.io.read_raw_ctf`.
     """
     return RawCTF(directory, system_clock, preload=preload,
                   clean_names=clean_names, verbose=verbose)

--- a/tutorials/io/60_ctf_bst_auditory.py
+++ b/tutorials/io/60_ctf_bst_auditory.py
@@ -91,7 +91,7 @@ raw_erm = read_raw_ctf(erm_fname)
 #   - 20 unused channels
 #
 # Notice also that the digitized electrode positions (stored in a .pos file)
-# were automatically loaded and added to the `mne.io.Raw` object.
+# were automatically loaded and added to the `~mne.io.Raw` object.
 #
 # The head tracking channels and the unused channels are marked as misc
 # channels. Here we define the EOG and ECG channels.

--- a/tutorials/io/60_ctf_bst_auditory.py
+++ b/tutorials/io/60_ctf_bst_auditory.py
@@ -90,6 +90,9 @@ raw_erm = read_raw_ctf(erm_fname)
 #   - 12 head tracking channels
 #   - 20 unused channels
 #
+# Notice also that the digitized electrode positions (stored in a .pos file)
+# were automatically loaded and added to the `mne.io.Raw` object.
+#
 # The head tracking channels and the unused channels are marked as misc
 # channels. Here we define the EOG and ECG channels.
 raw.set_channel_types({'HEOG': 'eog', 'VEOG': 'eog', 'ECG': 'ecg'})


### PR DESCRIPTION
There is no documentation that says that the Polhemus digitization `.pos` file can be read into a `mne.ioRaw` instance via `mne.io.read_raw_ctf` when the .pos file is placed in the CTF directory. 

#### Reference issue
Fixes #9452. 

#### What does this implement/fix?
- Added this info in the Notes of `mne.io.read_raw_ctf`. 
- Added this as a note in the CTF tutorial in the following section.

https://github.com/mne-tools/mne-python/blob/c0d431acf0307a8bf92ab01995397194563f6920/tutorials/io/60_ctf_bst_auditory.py#L76-L89
