### PR TITLE
MRG: Honor optode_frame argument in read_raw_snirf 

### DIFF
--- a/mne/io/snirf/tests/test_snirf.py
+++ b/mne/io/snirf/tests/test_snirf.py
@@ -192,15 +192,15 @@ def test_snirf_nirsport2():
 def test_snirf_coordframe():
     """Test reading SNIRF files."""
     raw = read_raw_snirf(nirx_nirsport2_103, optode_frame="head").\
-          info['chs'][3]['coord_frame']
+        info['chs'][3]['coord_frame']
     assert raw == FIFF.FIFFV_COORD_HEAD
 
     raw = read_raw_snirf(nirx_nirsport2_103, optode_frame="mri").\
-          info['chs'][3]['coord_frame']
+        info['chs'][3]['coord_frame']
     assert raw == FIFF.FIFFV_COORD_HEAD
 
     raw = read_raw_snirf(nirx_nirsport2_103, optode_frame="unknown").\
-          info['chs'][3]['coord_frame']
+        info['chs'][3]['coord_frame']
     assert raw == FIFF.FIFFV_COORD_UNKNOWN
 
 

--- a/mne/io/snirf/tests/test_snirf.py
+++ b/mne/io/snirf/tests/test_snirf.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose, assert_almost_equal
 import shutil
 import pytest
 
+import mne
 from mne.datasets.testing import data_path, requires_testing_data
 from mne.utils import requires_h5py
 from mne.io import read_raw_snirf, read_raw_nirx
@@ -184,6 +185,20 @@ def test_snirf_nirsport2():
     assert raw.info['chs'][1]['loc'][9] == 850
 
     assert sum(short_channels(raw.info)) == 16
+
+
+@requires_testing_data
+@requires_h5py
+def test_snirf_coordframe():
+    """Test reading SNIRF files."""
+    assert read_raw_snirf(nirx_nirsport2_103, optode_frame="unknown").\
+               info['chs'][10]['coord_frame'] == 0
+    assert read_raw_snirf(nirx_nirsport2_103, optode_frame="head").\
+               info['chs'][10]['coord_frame'] == 4
+    assert read_raw_snirf(nirx_nirsport2_103, optode_frame="asdf").\
+               info['chs'][10]['coord_frame'] == 0
+    assert read_raw_snirf(nirx_nirsport2_103, optode_frame="mri").\
+               info['chs'][10]['coord_frame'] == 4
 
 
 @requires_testing_data

--- a/mne/io/snirf/tests/test_snirf.py
+++ b/mne/io/snirf/tests/test_snirf.py
@@ -7,7 +7,6 @@ from numpy.testing import assert_allclose, assert_almost_equal
 import shutil
 import pytest
 
-import mne
 from mne.datasets.testing import data_path, requires_testing_data
 from mne.utils import requires_h5py
 from mne.io import read_raw_snirf, read_raw_nirx
@@ -192,13 +191,13 @@ def test_snirf_nirsport2():
 def test_snirf_coordframe():
     """Test reading SNIRF files."""
     assert read_raw_snirf(nirx_nirsport2_103, optode_frame="unknown").\
-               info['chs'][10]['coord_frame'] == 0
+        info['chs'][10]['coord_frame'] == 0
     assert read_raw_snirf(nirx_nirsport2_103, optode_frame="head").\
-               info['chs'][10]['coord_frame'] == 4
+        info['chs'][10]['coord_frame'] == 4
     assert read_raw_snirf(nirx_nirsport2_103, optode_frame="asdf").\
-               info['chs'][10]['coord_frame'] == 0
+        info['chs'][10]['coord_frame'] == 0
     assert read_raw_snirf(nirx_nirsport2_103, optode_frame="mri").\
-               info['chs'][10]['coord_frame'] == 4
+        info['chs'][10]['coord_frame'] == 4
 
 
 @requires_testing_data

--- a/mne/io/snirf/tests/test_snirf.py
+++ b/mne/io/snirf/tests/test_snirf.py
@@ -14,6 +14,7 @@ from mne.io.tests.test_raw import _test_raw_reader
 from mne.preprocessing.nirs import (optical_density, beer_lambert_law,
                                     short_channels, source_detector_distances)
 from mne.transforms import apply_trans, _get_trans
+from mne.io.constants import FIFF
 
 # SfNIRS files
 sfnirs_homer_103_wShort = op.join(data_path(download=False),
@@ -190,14 +191,17 @@ def test_snirf_nirsport2():
 @requires_h5py
 def test_snirf_coordframe():
     """Test reading SNIRF files."""
-    assert read_raw_snirf(nirx_nirsport2_103, optode_frame="unknown").\
-        info['chs'][10]['coord_frame'] == 0
-    assert read_raw_snirf(nirx_nirsport2_103, optode_frame="head").\
-        info['chs'][10]['coord_frame'] == 4
-    assert read_raw_snirf(nirx_nirsport2_103, optode_frame="asdf").\
-        info['chs'][10]['coord_frame'] == 0
-    assert read_raw_snirf(nirx_nirsport2_103, optode_frame="mri").\
-        info['chs'][10]['coord_frame'] == 4
+    raw = read_raw_snirf(nirx_nirsport2_103, optode_frame="head").\
+          info['chs'][3]['coord_frame']
+    assert raw == FIFF.FIFFV_COORD_HEAD
+
+    raw = read_raw_snirf(nirx_nirsport2_103, optode_frame="mri").\
+          info['chs'][3]['coord_frame']
+    assert raw == FIFF.FIFFV_COORD_HEAD
+
+    raw = read_raw_snirf(nirx_nirsport2_103, optode_frame="unknown").\
+          info['chs'][3]['coord_frame']
+    assert raw == FIFF.FIFFV_COORD_UNKNOWN
 
 
 @requires_testing_data


### PR DESCRIPTION
#### What does this implement/fix?
PR #9401 introduced the argument `optode_frame` to `read_raw_snirf`. This was being used to transform the coordinates of sensors, but was not being stored in `info['chs']`.  Also added a test.
