### PR TITLE
Add color normalization parameter to plot_topomap

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -71,6 +71,8 @@ Enhancements
 
 - Show multiple colors and linestyles for excluded components with :class:`mne.Evoked` in :meth:`mne.preprocessing.ICA.plot_sources` (:gh:`9444` by `Martin Schulz`_)
 
+- Add support for colormap normalization in :func:`mne.viz.plot_topomap` (:gh:`9468` by `Clemens Brunner`_)
+
 Bugs
 ~~~~
 - Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** |Jan Sosulski|_)

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -611,8 +611,8 @@ def test_plot_topomap_cnorm():
     else:
         from matplotlib.colors import DivergingNorm as TwoSlopeNorm
 
-    rng = np.random.default_rng(seed=42)
-    v = rng.uniform(low=-1, high=2.5, size=64)
+    np.random.seed(42)
+    v = np.random.uniform(low=-1, high=2.5, size=64)
     v[:3] = [-1, 0, 2.5]
 
     montage = make_standard_montage("biosemi64")

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -32,7 +32,7 @@ from mne.viz import plot_evoked_topomap, plot_projs_topomap, topomap
 from mne.viz.topomap import (_get_pos_outlines, _onselect, plot_topomap,
                              plot_arrowmap, plot_psds_topomap)
 from mne.viz.utils import _find_peaks, _fake_click
-from mne.utils import requires_sklearn
+from mne.utils import requires_sklearn, check_version
 
 
 data_dir = testing.data_path(download=False)
@@ -606,7 +606,10 @@ def test_plot_cov_topomap():
 
 def test_plot_topomap_cnorm():
     """Test colormap normalization."""
-    from matplotlib.colors import TwoSlopeNorm
+    if check_version("matplotlib", "3.2.0"):
+        from matplotlib.colors import TwoSlopeNorm
+    else:
+        from matplotlib.colors import DivergingNorm as TwoSlopeNorm
 
     rng = np.random.default_rng(seed=42)
     v = rng.uniform(low=-1, high=2.5, size=64)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -795,6 +795,11 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     for more details on colormap normalization.
     """
     sphere = _check_sphere(sphere)
+    if check_version("matplotlib", "3.2.0"):
+        from matplotlib.colors import TwoSlopeNorm
+    else:
+        from matplotlib.colors import DivergingNorm as TwoSlopeNorm
+    _validate_type(cnorm, (TwoSlopeNorm, None), 'cnorm')
     if cnorm is not None:
         if vmin is not None:
             warn(f"vmin={cnorm.vmin} is implicitly defined by cnorm, ignoring "

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -758,7 +758,7 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     %(topomap_border)s
     %(topomap_ch_type)s
 
-    ..versionadded:: 0.24.0
+        ..versionadded:: 0.24.0
     cnorm : matplotlib.colors.Normalize | None
         Colormap normalization, default None means linear normalization. If not
         None, ``vmin`` and ``vmax`` arguments are ignored. See Notes for more

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -788,9 +788,9 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
 
     Note that because we define ``vmin`` and ``vmax`` in the normalization,
     arguments ``vmin`` and ``vmax`` to ``plot_topomap`` will be ignored if a
-    normalization is provided.
-    See https://matplotlib.org/stable/tutorials/colors/colormapnorms.html for
-    more details on colormap normalization.
+    normalization is provided. See the
+    :doc:`matplotlib docs <matplotlib:tutorials/colors/colormapnorms>`
+    for more details on colormap normalization.
     """
     sphere = _check_sphere(sphere)
     if cnorm is not None:

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -958,7 +958,6 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
 
     # plot interpolated map
     if cnorm is None:
-        from matplotlib.colors import Normalize
         cnorm = Normalize(vmin=vmin, vmax=vmax)
     im = ax.imshow(Zi, cmap=cmap, origin='lower', aspect='equal',
                    extent=extent, interpolation=image_interp, norm=cnorm)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -690,7 +690,7 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
                  contours=6, image_interp='bilinear', show=True,
                  onselect=None, extrapolate=_EXTRAPOLATE_DEFAULT,
                  sphere=None, border=_BORDER_DEFAULT,
-                 ch_type='eeg'):
+                 ch_type='eeg', cnorm=None):
     """Plot a topographic map as image.
 
     Parameters
@@ -756,6 +756,8 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     %(topomap_sphere)s
     %(topomap_border)s
     %(topomap_ch_type)s
+    cnorm : matplotlib.colors.Normalize | None
+        Colormap normalization, default None means linear normalization.
 
     Returns
     -------
@@ -769,7 +771,7 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
                          names, show_names, mask, mask_params, outlines,
                          contours, image_interp, show,
                          onselect, extrapolate, sphere=sphere, border=border,
-                         ch_type=ch_type)[:2]
+                         ch_type=ch_type, cnorm=cnorm)[:2]
 
 
 def _setup_interp(pos, res, extrapolate, sphere, outlines, border):
@@ -828,7 +830,7 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
                   mask_params=None, outlines='head',
                   contours=6, image_interp='bilinear', show=True,
                   onselect=None, extrapolate=_EXTRAPOLATE_DEFAULT, sphere=None,
-                  border=_BORDER_DEFAULT, ch_type='eeg'):
+                  border=_BORDER_DEFAULT, ch_type='eeg', cnorm=None):
     import matplotlib.pyplot as plt
     from matplotlib.widgets import RectangleSelector
     data = np.asarray(data)
@@ -915,9 +917,13 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     patch_ = _get_patch(outlines, extrapolate, interp, ax)
 
     # plot interpolated map
-    im = ax.imshow(Zi, cmap=cmap, vmin=vmin, vmax=vmax, origin='lower',
-                   aspect='equal', extent=extent,
-                   interpolation=image_interp)
+    if cnorm is None:
+        im = ax.imshow(Zi, cmap=cmap, vmin=vmin, vmax=vmax, origin='lower',
+                       aspect='equal', extent=extent,
+                       interpolation=image_interp, norm=cnorm)
+    else:
+        im = ax.imshow(Zi, cmap=cmap, origin='lower', aspect='equal',
+                       extent=extent, interpolation=image_interp, norm=cnorm)
 
     # gh-1432 had a workaround for no contours here, but we'll remove it
     # because mpl has probably fixed it

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -26,7 +26,7 @@ from ..io.pick import (pick_types, _picks_by_type, pick_info, pick_channels,
                        _MEG_CH_TYPES_SPLIT)
 from ..utils import (_clean_names, _time_mask, verbose, logger, fill_doc,
                      _validate_type, _check_sphere, _check_option, _is_numeric,
-                     warn)
+                     warn, check_version)
 from .utils import (tight_layout, _setup_vmin_vmax, _prepare_trellis,
                     _check_delayed_ssp, _draw_proj_checkbox, figure_nobar,
                     plt_show, _process_times, DraggableColorbar,

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -764,6 +764,8 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         None, ``vmin`` and ``vmax`` arguments are ignored. See Notes for more
         details.
 
+        .. versionadded:: 0.24
+
     Returns
     -------
     im : matplotlib.image.AxesImage

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -786,9 +786,9 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         from matplotlib.colors import TwoSlopeNorm
         cnorm = TwoSlopeNorm(vmin=-1, vcenter=0, vmax=3)
 
-    Note that because we already defined ``vmin`` and ``vmax`` in the
-    normalization, arguments ``vmin`` and ``vmax`` are ignored if these are
-    also passed.
+    Note that because we define ``vmin`` and ``vmax`` in the normalization,
+    arguments ``vmin`` and ``vmax`` to ``plot_topomap`` will be ignored if a
+    normalization is provided.
     See https://matplotlib.org/stable/tutorials/colors/colormapnorms.html for
     more details on colormap normalization.
     """

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -871,6 +871,7 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
                   contours=6, image_interp='bilinear', show=True,
                   onselect=None, extrapolate=_EXTRAPOLATE_DEFAULT, sphere=None,
                   border=_BORDER_DEFAULT, ch_type='eeg', cnorm=None):
+    from matplotlib.colors import Normalize
     import matplotlib.pyplot as plt
     from matplotlib.widgets import RectangleSelector
     data = np.asarray(data)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -757,7 +757,9 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     %(topomap_border)s
     %(topomap_ch_type)s
     cnorm : matplotlib.colors.Normalize | None
-        Colormap normalization, default None means linear normalization.
+        Colormap normalization, default None means linear normalization. If not
+        None, ``vmin`` and ``vmax`` arguments are ignored. See Notes for more
+        details.
 
     Returns
     -------
@@ -765,6 +767,27 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         The interpolated data.
     cn : matplotlib.contour.ContourSet
         The fieldlines.
+
+    Notes
+    -----
+    The ``cnorm`` parameter can be used to implement custom colormap
+    normalization. By default, a linear mapping from vmin to vmax is used,
+    which correspond to the first and last colors in the colormap. This might
+    be undesired when vmin and vmax are not symmetrical around zero (or a value
+    that can be interpreted as some midpoint). For example, assume we want to
+    use the RdBu colormap (red to white to blue) for values ranging from -1 to
+    3, and 0 should be white. However, white corresponds to the midpoint in the
+    data by default, i.e. 1. Therefore, we use the following colormap
+    normalization ``cnorm`` and pass it as the the ``cnorm`` argument:
+
+        from matplotlib.colors import TwoSlopeNorm
+        cnorm = TwoSlopeNorm(vmin=-1, vcenter=0, vmax=3)
+
+    Note that because we already defined ``vmin`` and ``vmax`` in the
+    normalization, arguments ``vmin`` and ``vmax`` are ignored if these are
+    also passed.
+    See https://matplotlib.org/stable/tutorials/colors/colormapnorms.html for
+    more details on colormap normalization.
     """
     sphere = _check_sphere(sphere)
     return _plot_topomap(data, pos, vmin, vmax, cmap, sensors, res, axes,

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -757,6 +757,8 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     %(topomap_sphere)s
     %(topomap_border)s
     %(topomap_ch_type)s
+
+    ..versionadded:: 0.24.0
     cnorm : matplotlib.colors.Normalize | None
         Colormap normalization, default None means linear normalization. If not
         None, ``vmin`` and ``vmax`` arguments are ignored. See Notes for more


### PR DESCRIPTION
Fixes #9466. Things to do/discuss:

- I've named the parameter `cnorm` (for "color normalization"), because I think this better describes its purpose. It also avoids a name clash with an already existing local name `norm` (which has something to do with the L2 norm, not entirely sure). However, Matplotlib calls this parameter `norm`, so if we want to mimic their naming scheme we could also call our parameter `norm` instead.
- I need to add a test.
- When passing `cnorm`, simultaneously passing `vmin` and `vmax` is deprectated, because these are already defined in the normalizer. I've implemented a pretty blunt workaround, but we could instead define a default linear normalizer with `vmin` and `vmax` and then never pass these explicitly.