### PR TITLE
MRG, FIX: Allow multiple runs of Epochs.drop_bad() even if only using a subset of initial reject channels

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -85,6 +85,8 @@ Bugs
 
 - :func:`mne.concatenate_raws` now raises an exception if ``raw.info['dev_head_t']`` differs between files. This behavior can be controlled using the new ``on_mismatch`` parameter (:gh:`9438` by `Richard Höchenberger`_)
 
+- :meth:`mne.Epochs.drop_bad` now lets you reject multiple times, even when only specifying thresholds for a subset of the channel types used in a previous rejection run. Previously, this would raise an exception (:gh:`9484` by `Richard Höchenberger`_)
+
 API changes
 ~~~~~~~~~~~
 - Nothing yet

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -85,7 +85,7 @@ Bugs
 
 - :func:`mne.concatenate_raws` now raises an exception if ``raw.info['dev_head_t']`` differs between files. This behavior can be controlled using the new ``on_mismatch`` parameter (:gh:`9438` by `Richard Höchenberger`_)
 
-- :meth:`mne.Epochs.drop_bad` now lets you reject multiple times, even when only specifying thresholds for a subset of the channel types used in a previous rejection run. Previously, this would raise an exception (:gh:`9484` by `Richard Höchenberger`_)
+- Fixed bug in :meth:`mne.Epochs.drop_bad` where subsequent rejections failed if they only specified thresholds for a subset of the channel types used in a previous rejection (:gh:`9484` by `Richard Höchenberger`_).
 
 API changes
 ~~~~~~~~~~~

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -746,13 +746,29 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                    'previous ones')
         for key in set(reject.keys()).union(old_reject.keys()):
             old = old_reject.get(key, np.inf)
-            new = reject.get(key, np.inf)
+            if key in old_reject and key not in reject:
+                # The newly-passed `reject` parameter contains fewer channel
+                # types than the previous one. For the omitted channel types,
+                # simply re-use the old thresholds
+                new = old
+                reject[key] = new
+            else:
+                new = reject[key]
+
             if new > old:
                 raise ValueError(bad_msg.format(kind='reject', key=key,
                                                 new=new, old=old, op='>'))
         for key in set(flat.keys()).union(old_flat.keys()):
             old = old_flat.get(key, -np.inf)
-            new = flat.get(key, -np.inf)
+            if key in old_flat and key not in flat:
+                # The newly-passed `flat` parameter contains fewer channel
+                # types than the previous one. For the omitted channel types,
+                # simply re-use the old thresholds
+                new = old
+                flat[key] = new
+            else:
+                new = flat[key]
+
             if new < old:
                 raise ValueError(bad_msg.format(kind='flat', key=key,
                                                 new=new, old=old, op='<'))


### PR DESCRIPTION
Closes #9483