### PR TITLE
Use different subplot adjustment when plotting scores for a single channel

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -91,7 +91,7 @@ Bugs
 
 - Fixed bug in :meth:`mne.Epochs.drop_bad` where subsequent rejections failed if they only specified thresholds for a subset of the channel types used in a previous rejection (:gh:`9485` by `Richard Höchenberger`_).
 
-- In :func:`mne.viz.plot_ica_scores` and :methd:`mne.ICA.plot_scores`, the figure and axis titles no longer overlap when plotting only a single EOG or ECG channel (:gh:`9489` by `Richard Höchenberger`_).
+- In :func:`mne.viz.plot_ica_scores` and :meth:`mne.ICA.plot_scores`, the figure and axis titles no longer overlap when plotting only a single EOG or ECG channel (:gh:`9489` by `Richard Höchenberger`_).
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -91,6 +91,8 @@ Bugs
 
 - Fixed bug in :meth:`mne.Epochs.drop_bad` where subsequent rejections failed if they only specified thresholds for a subset of the channel types used in a previous rejection (:gh:`9485` by `Richard Höchenberger`_).
 
+- In :func:`mne.viz.plot_ica_scores` and :methd:`mne.ICA.plot_scores`, the figure and axis titles no longer overlap when plotting only a single EOG or ECG channel (:gh:`9489` by `Richard Höchenberger`_).
+
 API changes
 ~~~~~~~~~~~
 - Nothing yet

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -744,7 +744,9 @@ def plot_ica_scores(ica, scores, exclude=None, labels=None, axhline=None,
         ax.set_xlim(-0.6, len(this_scores) - 0.4)
 
     tight_layout(fig=fig)
-    fig.subplots_adjust(top=0.90)
+
+    adjust_top = 0.8 if len(fig.axes) == 1 else 0.9
+    fig.subplots_adjust(top=adjust_top)
     fig.canvas.draw()
     plt_show(show)
     return fig


### PR DESCRIPTION
This avoids overlap between axis title and suptitle.

First reported by @crsegerie at https://github.com/mne-tools/mne-bids-pipeline/issues/364

My solution feels a bit hacky but does the trick.


Demo:
```python
from pathlib import Path
import mne


sample_dir = Path(mne.datasets.sample.data_path())
sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'

raw = mne.io.read_raw_fif(sample_fname, preload=True).crop(60)

ica = mne.preprocessing.ICA(n_components=0.8, method='picard')
ica.fit(raw)

ecg_epochs = mne.preprocessing.create_ecg_epochs(raw)
idx, scores = ica.find_bads_ecg(ecg_epochs)
ica.plot_scores(scores=scores, exclude=idx, labels='ecg')
```

`main`:
<img width="454" alt="Screen Shot 2021-06-18 at 13 23 16" src="https://user-images.githubusercontent.com/2046265/122553761-653a5600-d038-11eb-84e9-bf7e37028ca7.png">

This PR:
<img width="454" alt="Screen Shot 2021-06-18 at 13 22 29" src="https://user-images.githubusercontent.com/2046265/122553781-6a97a080-d038-11eb-88a7-850c534a5520.png">
