### PR TITLE
FIX: Follow the changes of PyVista 0.31.2

### DIFF
--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -101,6 +101,7 @@ class _Figure(object):
                 _process_events(plotter)
                 kind = 'bigsur-' if platform.mac_ver()[0] >= '10.16' else ''
                 plotter.set_icon(f":/mne-{kind}icon.png")
+        self.plotter.iren.initialize()
         _process_events(self.plotter)
         _process_events(self.plotter)
         return self.plotter

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -101,7 +101,8 @@ class _Figure(object):
                 _process_events(plotter)
                 kind = 'bigsur-' if platform.mac_ver()[0] >= '10.16' else ''
                 plotter.set_icon(f":/mne-{kind}icon.png")
-        self.plotter.iren.initialize()
+        if self.plotter.iren is not None:
+            self.plotter.iren.initialize()
         _process_events(self.plotter)
         _process_events(self.plotter)
         return self.plotter


### PR DESCRIPTION
This PR fixes the error:

```
RuntimeError: Render window interactor must be initialized before processing events.
```

reported in https://github.com/mne-tools/mne-python/pull/9468#issuecomment-865685608