### PR TITLE
Update download URL to pyvista main branch

### DIFF
--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -10,7 +10,7 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py Pillow matplotlib
 	# we want --pre for VTK, but it breaks Azure as of 2021/06/14 (mayavi has problems with the 20210612 binary)
 	python -m pip install --progress-bar off --upgrade --only-binary ":all" vtk
-	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
+	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 	python -m pip install --progress-bar off --upgrade --only-binary="numba,llvmlite" -r requirements.txt
 else

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -33,7 +33,7 @@ else  # standard doc build
 	echo "Installing doc build dependencies"
 	python -m pip uninstall -y pydata-sphinx-theme
 	python -m pip install --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
-	python -m pip install --progress-bar off https://github.com/sphinx-gallery/sphinx-gallery/zipball/master https://github.com/pyvista/pyvista/zipball/master https://github.com/pyvista/pyvistaqt/zipball/master
+	python -m pip install --progress-bar off https://github.com/sphinx-gallery/sphinx-gallery/zipball/master https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/master
 	python -m pip uninstall -yq pysurfer mayavi
 	python -m pip install -e .
 fi

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -20,7 +20,7 @@ if [[ "$CIRCLE_JOB" == "interactive_test" ]]; then
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" numba llvmlite
 	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 	python -m pip install --progress-bar off vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
-	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
+	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 	python -m pip install --progress-bar off --upgrade -r requirements_testing.txt -r requirements_testing_extra.txt
 	python -m pip install -e .

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -15,7 +15,7 @@ else
 	# built using vtk master branch on an Ubuntu 18.04.5 VM and uploaded to OSF:
 	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 	pip install --progress-bar off vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
-	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/master
+	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
 	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
 	pip install --progress-bar off --pre mayavi imageio-ffmpeg xlrd mffpy
 fi


### PR DESCRIPTION
Because they changed `master` to `main` the download URL isn't working anymore (used in our CircleCI).