### PR TITLE
[WIP, ENH] Abstracted volume registration

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -73,7 +73,9 @@ Enhancements
 
 - Show multiple colors and linestyles for excluded components with :class:`mne.Evoked` in :meth:`mne.preprocessing.ICA.plot_sources` (:gh:`9444` by `Martin Schulz`_)
 
-- Added tutorial for how to processes image (CT and MR) files in order to localize electrode contacts for intracranial recordings :ref:`tut-ieeg-localize` (:gh`9484` by `Alex Rockhill`_)
+- Add functions for aligning MRI and CT data `mne.transforms.compute_volume_registration` and `mne.transforms.apply_volume_registration` (:gh:`9503` by `Alex Rockhill`_ and `Eric Larson`_)
+
+- Add tutorial for how to processes image (CT and MR) files in order to localize electrode contacts for intracranial recordings :ref:`tut-ieeg-localize` (:gh`9484` by `Alex Rockhill`_)
 
 - Add support for colormap normalization in :func:`mne.viz.plot_topomap` (:gh:`9468` by `Clemens Brunner`_)
 
@@ -93,8 +95,6 @@ Bugs
 
 - Fix bug with `mne.io.read_raw_fieldtrip` and `mne.read_epochs_fieldtrip` where channel positions were not set properly (:gh:`9447` by `Eric Larson`_)
 
-- Fix bug with `mne.Epochs.plot` where event lines were misplaced if epochs were overlapping in time (:gh:`9505` by `Daniel McCloy`_)
-
 - :func:`mne.concatenate_raws` now raises an exception if ``raw.info['dev_head_t']`` differs between files. This behavior can be controlled using the new ``on_mismatch`` parameter (:gh:`9438` by `Richard Höchenberger`_)
 
 - Fixed bug in :meth:`mne.Epochs.drop_bad` where subsequent rejections failed if they only specified thresholds for a subset of the channel types used in a previous rejection (:gh:`9485` by `Richard Höchenberger`_).
@@ -103,4 +103,4 @@ Bugs
 
 API changes
 ~~~~~~~~~~~
-- Nothing yet
+- In `mne.compute_source_morph`, the ``niter_affine`` and ``niter_sdr`` parameters have been replaced by ``niter`` and ``pipeline`` parameters for more consistent and finer-grained control of registration/warping steps and iteration (:gh:`9505` by `Alex Rockhill`_ and `Eric Larson`_)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -151,7 +151,9 @@ intersphinx_mapping = {
     'mne_realtime': ('https://mne.tools/mne-realtime', None),
     'picard': ('https://pierreablin.github.io/picard/', None),
     'qdarkstyle': ('https://qdarkstylesheet.readthedocs.io/en/latest', None),
-    'eeglabio': ('https://eeglabio.readthedocs.io/en/latest', None)
+    'eeglabio': ('https://eeglabio.readthedocs.io/en/latest', None),
+    'dipy': ('https://dipy.org/documentation/1.4.0./',
+             'https://dipy.org/documentation/1.4.0./objects.inv/')
 }
 
 
@@ -220,6 +222,9 @@ numpydoc_xref_aliases = {
     'EMS': 'mne.decoding.EMS', 'CSP': 'mne.decoding.CSP',
     'Beamformer': 'mne.beamformer.Beamformer',
     'Transform': 'mne.transforms.Transform',
+    # dipy
+    'dipy.align.AffineMap': 'dipy.align.imaffine.AffineMap',
+    'dipy.align.DiffeomorphicMap': 'dipy.align.imwarp.DiffeomorphicMap',
 }
 numpydoc_xref_ignore = {
     # words
@@ -251,8 +256,6 @@ numpydoc_xref_ignore = {
     'CoregFrame', 'Kit2FiffFrame', 'FiducialsFrame',
     # dipy has resolution problems, wait for them to be solved, e.g.
     # https://github.com/dipy/dipy/issues/2290
-    'dipy.align.AffineMap',
-    'dipy.align.DiffeomorphicMap',
 }
 numpydoc_validate = True
 numpydoc_validation_checks = {'all'} | set(error_ignores)

--- a/doc/mri.rst
+++ b/doc/mri.rst
@@ -18,9 +18,11 @@ Step by step instructions for using :func:`gui.coregistration`:
    gui.coregistration
    gui.fiducials
    create_default_subject
-   marching_cubes
    scale_mri
    scale_bem
    scale_labels
    scale_source_space
+   surface.marching_cubes
+   transforms.apply_volume_registration
+   transforms.compute_volume_registration
    voxel_neighbors

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -63,7 +63,7 @@ from .source_estimate import (read_source_estimate,
                               extract_label_time_course, stc_near_sensors)
 from .surface import (read_surface, write_surface, decimate_surface, read_tri,
                       get_head_surf, get_meg_helmet_surf, dig_mri_distances,
-                      marching_cubes, voxel_neighbors)
+                      voxel_neighbors)
 from .morph_map import read_morph_map
 from .morph import (SourceMorph, read_source_morph, grade_to_vertices,
                     compute_source_morph)

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -254,7 +254,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.121', misc='0.11')
+    releases = dict(testing='0.121', misc='0.13')
     # And also update the "md5_hashes['testing']" variable below.
     # To update any other dataset, update the data archive itself (upload
     # an updated version) and update the md5 hash.
@@ -345,7 +345,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
             bst_raw='fa2efaaec3f3d462b319bc24898f440c',
             bst_resting='70fc7bf9c3b97c4f2eab6260ee4a0430'),
         fake='3194e9f7b46039bb050a74f3e1ae9908',
-        misc='4c07fe4e3a068301417362e835c9af59',
+        misc='ab4be0b325f5896a28165ad177bda338',
         sample='12b75d1cb7df9dfb4ad73ed82f61094f',
         somato='32fd2f6c8c7eb0784a1de6435273c48b',
         spm='9f43f67150e3b694b523a21eb929ea75',

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -99,7 +99,14 @@ DEFAULTS = dict(
         alpha=None, resolution=1., surface_alpha=None, blending='mip',
         silhouette_alpha=None, silhouette_linewidth=2.),
     prefixes={'': 1e0, 'd': 1e1, 'c': 1e2, 'm': 1e3, 'µ': 1e6, 'u': 1e6,
-              'n': 1e9, 'p': 1e12, 'f': 1e15}
+              'n': 1e9, 'p': 1e12, 'f': 1e15},
+    transform_zooms=dict(
+        translation=None, rigid=None, affine=None, sdr=None),
+    transform_niter=dict(
+        translation=(100, 100, 10),
+        rigid=(100, 100, 10),
+        affine=(100, 100, 10),
+        sdr=(5, 5, 3)),
 )
 
 

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -19,7 +19,7 @@ from .source_space import SourceSpaces, _ensure_src, _grid_interp
 from .surface import mesh_edges, read_surface, _compute_nearest
 from .utils import (logger, verbose, check_version, get_subjects_dir,
                     warn as warn_, fill_doc, _check_option, _validate_type,
-                    BunchConst, _check_fname, warn, wrapped_stdout,
+                    BunchConst, wrapped_stdout, _check_fname, warn,
                     _ensure_int, ProgressBar, use_log_level)
 from .externals.h5io import read_hdf5, write_hdf5
 
@@ -1005,20 +1005,26 @@ def _interpolate_data(stc, morph, mri_resolution, mri_space, output):
 ###############################################################################
 # Morph for VolSourceEstimate
 
+def _compute_r2(a, b):
+    return 100 * (a.ravel() @ b.ravel()) / \
+        (np.linalg.norm(a) * np.linalg.norm(b))
+
+
 def _compute_morph_sdr(mri_from, mri_to, niter_affine, niter_sdr, zooms):
     """Get a matrix that morphs data from one subject to another."""
     from .transforms import (compute_volume_registration, _compute_r2,
                              _reslice_normalize)
     from dipy.align.imaffine import AffineMap
     from dipy.align import imwarp, metrics
-    niter = dict(translation=niter_affine, rigid=niter_affine,
-                 affine=niter_affine)
     pre_affine, sdr_morph = compute_volume_registration(
-        mri_from, mri_to, zooms=zooms, niter=niter, pipeline='affines')
+        mri_from, mri_to, zooms=zooms, pipeline='affines',
+        niter=dict(translation=niter_affine, rigid=niter_affine,
+                   affine=niter_affine))
     mri_from, from_affine = _reslice_normalize(mri_from, zooms)
-    mri_to, to_affine = _reslice_normalize(mri_to, zooms)
-    pre_affine = AffineMap(
-        pre_affine, mri_to.shape, to_affine, mri_from.shape, from_affine)
+    mri_to, affine = _reslice_normalize(mri_to, zooms)
+    shape = mri_to.shape
+    pre_affine = AffineMap(pre_affine, shape, affine,
+                           mri_from.shape, from_affine)
     if len(niter_sdr):
         mri_from_to = pre_affine.transform(mri_from)
         sdr = imwarp.SymmetricDiffeomorphicRegistration(
@@ -1030,7 +1036,7 @@ def _compute_morph_sdr(mri_from, mri_to, niter_affine, niter_sdr, zooms):
         mri_from_to = sdr_morph.transform(mri_from)
         logger.info(
             f'    R²:          {_compute_r2(mri_to, mri_from_to):6.1f}%')
-    return mri_to.shape, zooms, to_affine, pre_affine, sdr_morph
+    return shape, zooms, affine, pre_affine, sdr_morph
 
 
 def _compute_morph_matrix(subject_from, subject_to, vertices_from, vertices_to,

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -19,7 +19,7 @@ from .source_space import SourceSpaces, _ensure_src, _grid_interp
 from .surface import mesh_edges, read_surface, _compute_nearest
 from .utils import (logger, verbose, check_version, get_subjects_dir,
                     warn as warn_, fill_doc, _check_option, _validate_type,
-                    BunchConst, _check_fname, warn,
+                    BunchConst, _check_fname, warn, wrapped_stdout,
                     _ensure_int, ProgressBar, use_log_level)
 from .externals.h5io import read_hdf5, write_hdf5
 
@@ -1007,20 +1007,30 @@ def _interpolate_data(stc, morph, mri_resolution, mri_space, output):
 
 def _compute_morph_sdr(mri_from, mri_to, niter_affine, niter_sdr, zooms):
     """Get a matrix that morphs data from one subject to another."""
-    from .transforms import _compute_volume_registration
+    from .transforms import (_compute_volume_registration, _compute_r2,
+                             _reslice_normalize)
     from dipy.align.imaffine import AffineMap
-    pipeline = 'all' if niter_sdr else 'affines'
+    from dipy.align import imwarp, metrics
     niter = dict(translation=niter_affine, rigid=niter_affine,
-                 affine=niter_affine,
-                 sdr=niter_sdr if niter_sdr else (1,))
+                 affine=niter_affine)
     pre_affine, sdr_morph, to_shape, to_affine, from_shape, from_affine = \
         _compute_volume_registration(
-            mri_from, mri_to, zooms=zooms, niter=niter, pipeline=pipeline)
-    # Prevent the affine from being applied twice
-    if niter_sdr:
-        pre_affine = np.eye(4)
+            mri_from, mri_to, zooms=zooms, niter=niter, pipeline='affines')
     pre_affine = AffineMap(
         pre_affine, to_shape, to_affine, from_shape, from_affine)
+    if len(niter_sdr):
+        mri_from, from_affine = _reslice_normalize(mri_from, zooms)
+        mri_to, to_affine = _reslice_normalize(mri_to, zooms)
+        mri_from_to = pre_affine.transform(mri_from)
+        sdr = imwarp.SymmetricDiffeomorphicRegistration(
+            metrics.CCMetric(3), list(niter_sdr))
+        logger.info('Optimizing SDR:')
+        with wrapped_stdout(indent='    ', cull_newlines=True):
+            sdr_morph = sdr.optimize(mri_to, mri_from_to)
+        assert to_shape == tuple(sdr_morph.domain_shape)
+        mri_from_to = sdr_morph.transform(mri_from)
+        logger.info(
+            f'    R²:          {_compute_r2(mri_to, mri_from_to):6.1f}%')
     return to_shape, zooms, to_affine, pre_affine, sdr_morph
 
 

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -1009,17 +1009,15 @@ def _compute_morph_sdr(mri_from, mri_to, niter_affine, niter_sdr, zooms):
     """Get a matrix that morphs data from one subject to another."""
     from .transforms import _compute_volume_registration
     from dipy.align.imaffine import AffineMap
-    use_prealign = False
     pipeline = 'all' if niter_sdr else 'affines'
     niter = dict(translation=niter_affine, rigid=niter_affine,
                  affine=niter_affine,
                  sdr=niter_sdr if niter_sdr else (1,))
     pre_affine, sdr_morph, to_shape, to_affine, from_shape, from_affine = \
         _compute_volume_registration(
-            mri_from, mri_to, zooms=zooms, niter=niter, pipeline=pipeline,
-            use_prealign=use_prealign)
+            mri_from, mri_to, zooms=zooms, niter=niter, pipeline=pipeline)
     # Prevent the affine from being applied twice
-    if niter_sdr and use_prealign:
+    if niter_sdr:
         pre_affine = np.eye(4)
     pre_affine = AffineMap(
         pre_affine, to_shape, to_affine, from_shape, from_affine)

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -17,10 +17,9 @@ from .source_estimate import (
     _get_ico_tris)
 from .source_space import SourceSpaces, _ensure_src, _grid_interp
 from .surface import mesh_edges, read_surface, _compute_nearest
-from .transforms import _angle_between_quats, rot_to_quat
 from .utils import (logger, verbose, check_version, get_subjects_dir,
                     warn as warn_, fill_doc, _check_option, _validate_type,
-                    BunchConst, wrapped_stdout, _check_fname, warn,
+                    BunchConst, _check_fname, warn,
                     _ensure_int, ProgressBar, use_log_level)
 from .externals.h5io import read_hdf5, write_hdf5
 
@@ -1006,103 +1005,25 @@ def _interpolate_data(stc, morph, mri_resolution, mri_space, output):
 ###############################################################################
 # Morph for VolSourceEstimate
 
-def _compute_r2(a, b):
-    return 100 * (a.ravel() @ b.ravel()) / \
-        (np.linalg.norm(a) * np.linalg.norm(b))
-
-
-def _reslice_normalize(img, zooms):
-    from dipy.align.reslice import reslice
-    img_zooms = img.header.get_zooms()[:3]
-    img_affine = img.affine
-    img = _get_img_fdata(img)
-    if zooms is not None:
-        img, img_affine = reslice(img, img_affine, img_zooms, zooms)
-    img /= img.max()  # normalize
-    return img, img_affine
-
-
 def _compute_morph_sdr(mri_from, mri_to, niter_affine, niter_sdr, zooms):
     """Get a matrix that morphs data from one subject to another."""
-    with np.testing.suppress_warnings():
-        from dipy.align import imaffine, imwarp, metrics, transforms
-
-    logger.info('Computing nonlinear Symmetric Diffeomorphic Registration...')
-
-    # reslice mri_from to zooms
-    mri_from_orig = mri_from
-    mri_from, mri_from_affine = _reslice_normalize(mri_from, zooms)
-
-    # reslice mri_to to zooms
-    mri_to, affine = _reslice_normalize(mri_to, zooms)
-
-    # compute center of mass
-    c_of_mass = imaffine.transform_centers_of_mass(
-        mri_to, affine, mri_from, mri_from_affine)
-
-    # set up Affine Registration
-    affreg = imaffine.AffineRegistration(
-        metric=imaffine.MutualInformationMetric(nbins=32),
-        level_iters=list(niter_affine),
-        sigmas=[3.0, 1.0, 0.0],
-        factors=[4, 2, 1])
-
-    # translation
-    logger.info('Optimizing translation:')
-    with wrapped_stdout(indent='    ', cull_newlines=True):
-        translation = affreg.optimize(
-            mri_to, mri_from, transforms.TranslationTransform3D(), None,
-            affine, mri_from_affine, starting_affine=c_of_mass.affine)
-    mri_from_to = translation.transform(mri_from)
-    dist = np.linalg.norm(translation.affine[:3, 3])
-    logger.info(f'    Translation: {dist:6.1f} mm')
-    logger.info(f'    R²:          {_compute_r2(mri_to, mri_from_to):6.1f}%')
-
-    # rigid body transform (translation + rotation)
-    logger.info('Optimizing rigid-body:')
-    with wrapped_stdout(indent='    ', cull_newlines=True):
-        rigid = affreg.optimize(
-            mri_to, mri_from, transforms.RigidTransform3D(), None,
-            affine, mri_from_affine, starting_affine=translation.affine)
-    mri_from_to = rigid.transform(mri_from)
-    dist = np.linalg.norm(rigid.affine[:3, 3])
-    angle = np.rad2deg(_angle_between_quats(
-        np.zeros(3), rot_to_quat(rigid.affine[:3, :3])))
-
-    logger.info(f'    Translation: {dist:6.1f} mm')
-    logger.info(f'    Rotation:    {angle:6.1f}°')
-    logger.info(f'    R²:          {_compute_r2(mri_to, mri_from_to):6.1f}%')
-
-    # affine transform (translation + rotation + scaling)
-    logger.info('Optimizing full affine:')
-    with wrapped_stdout(indent='    ', cull_newlines=True):
-        pre_affine = affreg.optimize(
-            mri_to, mri_from, transforms.AffineTransform3D(), None,
-            affine, mri_from_affine, starting_affine=rigid.affine)
-    mri_from_to = pre_affine.transform(mri_from)
-    logger.info(
-        f'    R²:          {_compute_r2(mri_to, mri_from_to):6.1f}%')
-
-    # SDR
-    shape = tuple(pre_affine.domain_shape)
-    if len(niter_sdr):
-        sdr = imwarp.SymmetricDiffeomorphicRegistration(
-            metrics.CCMetric(3), list(niter_sdr))
-        logger.info('Optimizing SDR:')
-        with wrapped_stdout(indent='    ', cull_newlines=True):
-            sdr_morph = sdr.optimize(mri_to, pre_affine.transform(mri_from))
-        assert shape == tuple(sdr_morph.domain_shape)  # should be tuple of int
-        mri_from_to = sdr_morph.transform(mri_from_to)
-        logger.info(
-            f'    R²:          {_compute_r2(mri_to, mri_from_to):6.1f}%')
-    else:
-        sdr_morph = None
-
-    _debug_img(mri_from_orig.dataobj, mri_from_orig.affine, 'From')
-    _debug_img(mri_from, affine, 'From-reslice')
-    _debug_img(mri_from_to, affine, 'From-reslice')
-    _debug_img(mri_to, affine, 'To-reslice')
-    return shape, zooms, affine, pre_affine, sdr_morph
+    from .transforms import _compute_volume_registration
+    from dipy.align.imaffine import AffineMap
+    use_prealign = False
+    pipeline = 'all' if niter_sdr else 'affines'
+    niter = dict(translation=niter_affine, rigid=niter_affine,
+                 affine=niter_affine,
+                 sdr=niter_sdr if niter_sdr else (1,))
+    pre_affine, sdr_morph, to_shape, to_affine, from_shape, from_affine = \
+        _compute_volume_registration(
+            mri_from, mri_to, zooms=zooms, niter=niter, pipeline=pipeline,
+            use_prealign=use_prealign)
+    # Prevent the affine from being applied twice
+    if niter_sdr and use_prealign:
+        pre_affine = np.eye(4)
+    pre_affine = AffineMap(
+        pre_affine, to_shape, to_affine, from_shape, from_affine)
+    return to_shape, zooms, to_affine, pre_affine, sdr_morph
 
 
 def _compute_morph_matrix(subject_from, subject_to, vertices_from, vertices_to,

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -467,11 +467,11 @@ def test_volume_source_morph_basic(tmpdir):
 @testing.requires_testing_data
 @pytest.mark.parametrize(
     'subject_from, subject_to, lower, upper, dtype, morph_mat', [
-        ('sample', 'fsaverage', 5.9, 6.1, float, False),
+        ('sample', 'fsaverage', 10.0, 10.4, float, False),
         ('fsaverage', 'fsaverage', 0., 0.1, float, False),
         ('sample', 'sample', 0., 0.1, complex, False),
         ('sample', 'sample', 0., 0.1, float, True),  # morph_mat
-        ('sample', 'fsaverage', 10, 12, float, True),  # morph_mat
+        ('sample', 'fsaverage', 7.0, 7.4, float, True),  # morph_mat
     ])
 def test_volume_source_morph_round_trip(
         tmpdir, subject_from, subject_to, lower, upper, dtype, morph_mat,
@@ -554,7 +554,7 @@ def test_volume_source_morph_round_trip(
     # check that power is more or less preserved (labelizing messes with this)
     if morph_mat:
         if subject_to == 'fsaverage':
-            limits = (18, 18.5)
+            limits = (14.0, 14.2)
         else:
             limits = (7, 7.5)
     else:

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -554,7 +554,7 @@ def test_volume_source_morph_round_trip(
     # check that power is more or less preserved (labelizing messes with this)
     if morph_mat:
         if subject_to == 'fsaverage':
-            limits = (18, 18.5)
+            limits = (15, 18.5)
         else:
             limits = (7, 7.5)
     else:

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -467,11 +467,11 @@ def test_volume_source_morph_basic(tmpdir):
 @testing.requires_testing_data
 @pytest.mark.parametrize(
     'subject_from, subject_to, lower, upper, dtype, morph_mat', [
-        ('sample', 'fsaverage', 10.0, 10.4, float, False),
+        ('sample', 'fsaverage', 6.0, 11.0, float, False),  # was 5.9, 6.1
         ('fsaverage', 'fsaverage', 0., 0.1, float, False),
         ('sample', 'sample', 0., 0.1, complex, False),
         ('sample', 'sample', 0., 0.1, float, True),  # morph_mat
-        ('sample', 'fsaverage', 7.0, 7.4, float, True),  # morph_mat
+        ('sample', 'fsaverage', 9.0, 12.0, float, True),  # morph_mat; 10, 12
     ])
 def test_volume_source_morph_round_trip(
         tmpdir, subject_from, subject_to, lower, upper, dtype, morph_mat,
@@ -554,7 +554,7 @@ def test_volume_source_morph_round_trip(
     # check that power is more or less preserved (labelizing messes with this)
     if morph_mat:
         if subject_to == 'fsaverage':
-            limits = (14.0, 14.2)
+            limits = (18, 18.5)
         else:
             limits = (7, 7.5)
     else:

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -1803,7 +1803,7 @@ def test_scale_morph_labels(kind, scale, monkeypatch, tmpdir):
                 min_, max_ = 0.72, 0.75
             else:
                 # min_, max_ = 0.84, 0.855  # zooms='auto' values
-                min_, max_ = 0.61, 0.62
+                min_, max_ = 0.61, 0.63
             assert min_ < corr <= max_, scale
         else:
             assert_allclose(

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -1803,7 +1803,7 @@ def test_scale_morph_labels(kind, scale, monkeypatch, tmpdir):
                 min_, max_ = 0.72, 0.75
             else:
                 # min_, max_ = 0.84, 0.855  # zooms='auto' values
-                min_, max_ = 0.61, 0.63
+                min_, max_ = 0.60, 0.63
             assert min_ < corr <= max_, scale
         else:
             assert_allclose(

--- a/mne/tests/test_transforms.py
+++ b/mne/tests/test_transforms.py
@@ -11,7 +11,6 @@ from mne.datasets import testing
 from mne.fixes import _get_img_fdata
 from mne import read_trans, write_trans
 from mne.io import read_info
-from mne.morph import _compute_r2
 from mne.transforms import (invert_transform, _get_trans,
                             rotation, rotation3d, rotation_angles, _find_trans,
                             combine_transforms, apply_trans, translation,
@@ -23,7 +22,7 @@ from mne.transforms import (invert_transform, _get_trans,
                             rotation3d_align_z_axis, _read_fs_xfm,
                             _write_fs_xfm, _quat_real, _fit_matched_points,
                             _quat_to_euler, _euler_to_quat,
-                            _quat_to_affine)
+                            _quat_to_affine, _compute_r2)
 from mne.utils import requires_nibabel, requires_dipy
 
 data_path = testing.data_path(download=False)

--- a/mne/tests/test_transforms.py
+++ b/mne/tests/test_transforms.py
@@ -8,8 +8,10 @@ from numpy.testing import (assert_array_equal, assert_equal, assert_allclose,
 
 import mne
 from mne.datasets import testing
+from mne.fixes import _get_img_fdata
 from mne import read_trans, write_trans
 from mne.io import read_info
+from mne.morph import _compute_r2
 from mne.transforms import (invert_transform, _get_trans,
                             rotation, rotation3d, rotation_angles, _find_trans,
                             combine_transforms, apply_trans, translation,
@@ -22,11 +24,14 @@ from mne.transforms import (invert_transform, _get_trans,
                             _write_fs_xfm, _quat_real, _fit_matched_points,
                             _quat_to_euler, _euler_to_quat,
                             _quat_to_affine)
+from mne.utils import requires_nibabel, requires_dipy
 
 data_path = testing.data_path(download=False)
 fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_trunc-trans.fif')
 fname_eve = op.join(data_path, 'MEG', 'sample',
                     'sample_audvis_trunc_raw-eve.fif')
+subjects_dir = op.join(data_path, 'subjects')
+fname_t1 = op.join(subjects_dir, 'fsaverage', 'mri', 'T1.mgz')
 
 base_dir = op.join(op.dirname(__file__), '..', 'io', 'tests', 'data')
 fname_trans = op.join(base_dir, 'sample-audvis-raw-trans.txt')
@@ -507,3 +512,29 @@ def test_euler(quats):
     quat_rot = quat_to_rot(quats)
     euler_rot = np.array([rotation(*e)[:3, :3] for e in euler])
     assert_allclose(quat_rot, euler_rot, atol=1e-14)
+
+
+@requires_nibabel()
+@requires_dipy()
+@pytest.mark.slowtest
+@testing.requires_testing_data
+def test_volume_registration():
+    """Test volume registration."""
+    import nibabel as nib
+    from dipy.align import resample
+    T1 = nib.load(fname_t1)
+    affine = np.eye(4)
+    affine[0, 3] = 10
+    T1_resampled = resample(moving=T1.get_fdata(),
+                            static=T1.get_fdata(),
+                            moving_affine=T1.affine,
+                            static_affine=T1.affine,
+                            between_affine=np.linalg.inv(affine))
+    for pipeline in ('rigids', ('translation', 'sdr')):
+        reg_affine, sdr_morph = mne.transforms.compute_volume_registration(
+            T1_resampled, T1, pipeline=pipeline, zooms=10, niter=[5])
+        assert_allclose(affine, reg_affine, atol=0.25)
+        T1_aligned = mne.transforms.apply_volume_registration(
+            T1_resampled, T1, reg_affine, sdr_morph)
+        r2 = _compute_r2(_get_img_fdata(T1_aligned), _get_img_fdata(T1))
+        assert 99.9 < r2

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -1685,8 +1685,6 @@ def _compute_volume_registration(moving, static, pipeline, zooms, niter):
                                          static_affine, moving_affine,
                                          out_affine)
             moving_zoomed = sdr_morph.transform(moving_zoomed)
-            # sdr only works on zoomed resolution
-            r2 = _compute_r2(static_zoomed, moving_zoomed)
         else:
             with wrapped_stdout(indent='    ', cull_newlines=True):
                 moving_zoomed, reg_affine = affine_registration(
@@ -1711,7 +1709,7 @@ def _compute_volume_registration(moving, static, pipeline, zooms, niter):
                 logger.info(f'    Translation: {dist:6.1f} mm')
                 if step == 'rigid':
                     logger.info(f'    Rotation:    {angle:6.1f}°')
-            r2 = _compute_r2(_get_img_fdata(static), _get_img_fdata(moving))
+        r2 = _compute_r2(static_zoomed, moving_zoomed)
         logger.info(f'    R²:          {r2:6.1f}%')
     return (out_affine, sdr_morph, static_zoomed.shape, static_affine,
             moving_zoomed.shape, moving_affine)

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -1674,9 +1674,9 @@ def _compute_volume_registration(moving, static, pipeline, zooms, niter,
         # reslice image with zooms
         if i == 0 or zooms[step] != zooms[pipeline[i - 1]]:
             if zooms[step] is not None:
-                logger.info(f'Using original zooms for {step} ...')
-            else:
                 logger.info(f'Reslicing to zooms={zooms[step]} for {step} ...')
+            else:
+                logger.info(f'Using original zooms for {step} ...')
             static_zoomed, static_affine = _reslice_normalize(
                 static, zooms[step])
         # must be resliced every time because it is adjusted at every step

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -1636,14 +1636,8 @@ def compute_volume_registration(moving, static, pipeline='all', zooms=None,
         moving, static, pipeline, zooms, niter)[:2]
 
 
-# Only affects apply/compute, not morph code (change it in morph.py to affect
-# that code). This should eventually go away once we decide which is actually
-# better!
-_USE_PREALIGN = True
-
-
-def _compute_volume_registration(moving, static, pipeline, zooms, niter,
-                                 use_prealign=_USE_PREALIGN):
+def _compute_volume_registration(moving, static, pipeline, zooms, niter):
+    """Register affines and, optionally, do SDR."""
     _require_version('nibabel', 'SDR morph', '2.1.0')
     _require_version('dipy', 'SDR morph', '0.10.1')
     import nibabel as nib
@@ -1680,13 +1674,8 @@ def _compute_volume_registration(moving, static, pipeline, zooms, niter,
                 static, zooms[step])
         # must be resliced every time because it is adjusted at every step
         # sdr is uses the pre-alignment so start from orig
-        if step == 'sdr' and use_prealign:
-            to_move = moving_orig
-            prealign = out_affine
-        else:
-            to_move = moving
-            prealign = None
-        moving_zoomed, moving_affine = _reslice_normalize(to_move, zooms[step])
+        moving_zoomed, moving_affine = _reslice_normalize(
+            moving_orig if step == 'sdr' else moving, zooms[step])
         logger.info(f'Optimizing {step}:')
         if step == 'sdr':  # happens last
             sdr = imwarp.SymmetricDiffeomorphicRegistration(
@@ -1694,7 +1683,7 @@ def _compute_volume_registration(moving, static, pipeline, zooms, niter,
             with wrapped_stdout(indent='    ', cull_newlines=True):
                 sdr_morph = sdr.optimize(static_zoomed, moving_zoomed,
                                          static_affine, moving_affine,
-                                         prealign)
+                                         out_affine)
             moving_zoomed = sdr_morph.transform(moving_zoomed)
             # sdr only works on zoomed resolution
             r2 = _compute_r2(static_zoomed, moving_zoomed)
@@ -1758,36 +1747,24 @@ def apply_volume_registration(moving, static, reg_affine, sdr_morph=None,
     """
     _require_version('nibabel', 'SDR morph', '2.1.0')
     _require_version('dipy', 'SDR morph', '0.10.1')
-    from nibabel.spatialimages import SpatialImage
+    import nibabel as nib
     from dipy.align.imwarp import DiffeomorphicMap
     from dipy.align import resample
-    _validate_type(moving, SpatialImage, 'moving')
-    _validate_type(static, SpatialImage, 'static')
+    _validate_type(moving, nib.spatialimages.SpatialImage, 'moving')
+    _validate_type(static, nib.spatialimages.SpatialImage, 'static')
     _validate_type(reg_affine, np.ndarray, 'reg_affine')
     _check_option('reg_affine.shape', reg_affine.shape, ((4, 4),))
     _validate_type(sdr_morph, (DiffeomorphicMap, None), 'sdr_morph')
-    if _USE_PREALIGN:
-        if sdr_morph is None:
-            logger.info('Applying affine registration ...')
-            reg_img = resample(_get_img_fdata(moving), _get_img_fdata(static),
-                               moving.affine, static.affine, reg_affine)
-        else:
-            logger.info('Appling SDR warp ...')
-            reg_data = sdr_morph.transform(
-                _get_img_fdata(moving), interpolation=interpolation,
-                image_world2grid=np.linalg.inv(moving.affine),
-                out_shape=static.shape, out_grid2world=static.affine)
-            reg_img = SpatialImage(reg_data, static.affine)
-    else:
+    if sdr_morph is None:
         logger.info('Applying affine registration ...')
         reg_img = resample(_get_img_fdata(moving), _get_img_fdata(static),
                            moving.affine, static.affine, reg_affine)
-        if sdr_morph is not None:
-            logger.info('Appling SDR warp ...')
-            reg_data = sdr_morph.transform(
-                _get_img_fdata(reg_img), interpolation=interpolation,
-                image_world2grid=np.linalg.inv(reg_img.affine),
-                out_shape=static.shape, out_grid2world=static.affine)
-            reg_img = SpatialImage(reg_data, static.affine)
+    else:
+        logger.info('Appling SDR warp ...')
+        reg_data = sdr_morph.transform(
+            _get_img_fdata(moving), interpolation=interpolation,
+            image_world2grid=np.linalg.inv(moving.affine),
+            out_shape=static.shape, out_grid2world=static.affine)
+        reg_img = nib.Nifti1Image(reg_data, static.affine)
     logger.info('[done]')
     return reg_img

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -1632,12 +1632,6 @@ def compute_volume_registration(moving, static, pipeline='all', zooms=None,
 
     .. versionadded:: 0.24
     """
-    return _compute_volume_registration(
-        moving, static, pipeline, zooms, niter)[:2]
-
-
-def _compute_volume_registration(moving, static, pipeline, zooms, niter):
-    """Register affines and, optionally, do SDR."""
     _require_version('nibabel', 'SDR morph', '2.1.0')
     _require_version('dipy', 'SDR morph', '0.10.1')
     import nibabel as nib
@@ -1711,8 +1705,7 @@ def _compute_volume_registration(moving, static, pipeline, zooms, niter):
                     logger.info(f'    Rotation:    {angle:6.1f}°')
         r2 = _compute_r2(static_zoomed, moving_zoomed)
         logger.info(f'    R²:          {r2:6.1f}%')
-    return (out_affine, sdr_morph, static_zoomed.shape, static_affine,
-            moving_zoomed.shape, moving_affine)
+    return out_affine, sdr_morph
 
 
 @verbose

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2379,6 +2379,71 @@ ref_channels : str | list of str
     and its data is set to 0. This is useful for later re-referencing.
 """
 
+# Morphing
+docdict['reg_affine'] = """
+reg_affine : ndarray of float, shape (4, 4)
+    The affine that registers one volume to another.
+"""
+docdict['sdr_morph'] = """
+sdr_morph : instance of dipy.align.DiffeomorphicMap
+    The class that applies the the symmetric diffeomorphic registration
+    (SDR) morph.
+"""
+docdict['moving'] = """
+moving : instance of SpatialImage
+    The image to morph ("from" volume).
+"""
+docdict['static'] = """
+static : instance of SpatialImage
+    The image to align with ("to" volume).
+"""
+docdict['niter'] = """
+niter : dict | tuple | None
+    For each phase of the volume registration, ``niter`` is the number of
+    iterations per successive stage of optimization. If a tuple is
+    provided, it will be used for all steps (except center of mass, which does
+    not iterate). It should have length 3 to
+    correspond to ``sigmas=[3.0, 1.0, 0.0]`` and ``factors=[4, 2, 1]`` in
+    the pipeline (see :func:`dipy.align.affine_registration
+    <dipy.align._public.affine_registration>` for details).
+    If a dictionary is provided, number of iterations can be set for each
+    step as a key. Steps not in the dictionary will use the default value.
+    The default (None) is equivalent to::
+        niter=dict(translation=(100, 100, 10),
+                   rigid=(100, 100, 10),
+                   affine=(100, 100, 10),
+                   sdr=(5, 5, 3))
+"""
+docdict['pipeline'] = """
+pipeline : str | tuple
+    The volume registration steps to perform (a ``str`` for a single step,
+    or ``tuple`` for a set of sequential steps). The following steps can be
+    performed, and do so by matching mutual information between the images
+    (unless otherwise noted):
+    ``'translation'``
+        Translation.
+    ``'rigid'``
+        Rigid-body, i.e., rotation and translation.
+    ``'affine'``
+        A full affine transformation, which includes translation, rotation,
+        scaling, and shear.
+    ``'sdr'``
+        Symmetric diffeomorphic registration :footcite:`AvantsEtAl2008`, a
+        non-linear similarity-matching algorithm.
+    The following string shortcuts can also be used:
+    ``"all"`` (default)
+        All steps will be performed above in the order above, i.e.,
+        ``('translation', 'rigid', 'affine', 'sdr')``.
+    ``'rigids'``
+        The rigid steps (first two) will be performed, which registers
+        the volume without distorting its underlying structure, i.e.,
+        ``('translation', 'rigid')``. This is useful for
+        example when registering images from the same subject, such as
+        CT and MR images.
+    ``'affines'``
+        The affine steps (first three) will be performed, i.e., omitting
+        the SDR step.
+"""
 docdict_indented = {}
 
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2408,7 +2408,8 @@ niter : dict | tuple | None
     <dipy.align._public.affine_registration>` for details).
     If a dictionary is provided, number of iterations can be set for each
     step as a key. Steps not in the dictionary will use the default value.
-    The default (None) is equivalent to::
+    The default (None) is equivalent to:
+
         niter=dict(translation=(100, 100, 10),
                    rigid=(100, 100, 10),
                    affine=(100, 100, 10),
@@ -2420,26 +2421,34 @@ pipeline : str | tuple
     or ``tuple`` for a set of sequential steps). The following steps can be
     performed, and do so by matching mutual information between the images
     (unless otherwise noted):
+
     ``'translation'``
         Translation.
+
     ``'rigid'``
         Rigid-body, i.e., rotation and translation.
+
     ``'affine'``
         A full affine transformation, which includes translation, rotation,
         scaling, and shear.
+
     ``'sdr'``
         Symmetric diffeomorphic registration :footcite:`AvantsEtAl2008`, a
         non-linear similarity-matching algorithm.
+
     The following string shortcuts can also be used:
-    ``"all"`` (default)
+
+    ``'all'`` (default)
         All steps will be performed above in the order above, i.e.,
         ``('translation', 'rigid', 'affine', 'sdr')``.
+
     ``'rigids'``
         The rigid steps (first two) will be performed, which registers
         the volume without distorting its underlying structure, i.e.,
         ``('translation', 'rigid')``. This is useful for
         example when registering images from the same subject, such as
         CT and MR images.
+
     ``'affines'``
         The affine steps (first three) will be performed, i.e., omitting
         the SDR step.

--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -125,8 +125,8 @@ del CT_resampled
 # so we don't do a full affine registration (that includes shear) here.
 #
 # .. warning::
-#     You should use ``zooms=None`` to execute the example at full resolution
-#     This sped up the execution of the example but, as you can see, the
+#     You should use ``zooms=None`` to execute the example at full resolution.
+#     The execution of the example is faster but, as you can see, the
 #     alignment is slighly off because of it.
 
 reg_affine, _ = mne.transforms.compute_volume_registration(
@@ -253,15 +253,14 @@ plot_overlay(template_brain, subject_brain,
 # This aligns the two brains, preparing the subject's brain to be warped
 # to the template.
 #
-# .. warning:: We recommend using ``pipeline='all'`` and ``zooms=None```
-#              (default) for the highest accuracy. This example uses lower
-#              resolution for speed of execution and skips the full affine
-#              registration because it doesn't work very well on the zoomed,
-#              lower-resolution image. To deal with this coarseness, we also
-#              use a threshold of 0.8 for the CT electrodes contacts which
-#              allows them to bleed into the background, making them bigger.
-#              A threshold of 0.95, which more accurately represents their
-#              actual boundary, works better when ``zooms=None``.
+# .. warning:: We recommend using ``pipeline='all'`` and ``zooms=None``
+#              (default) for the highest accuracy. To execute this example
+#              faster, the resolution of the registration is downsampled and
+#              the full affine registration is skipped. To deal with this
+#              coarseness, we also use a threshold of 0.8 for the CT electrodes
+#              contacts which makes them bigger by bleeding into the
+#              background. A threshold of 0.95 more accurately represents
+#              their boundary so it should be used when ``zooms=None``.
 
 CT_thresh = 0.8  # 0.95 is better for zooms=None!
 pipeline = ('translation', 'rigid', 'sdr')

--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -127,7 +127,7 @@ del CT_resampled
 # .. warning::
 #     You should use ``zooms=None`` to execute the example at full resolution.
 #     The execution of the example is faster but, as you can see, the
-#     alignment is slighly off because of it.
+#     alignment is slightly off because of it.
 
 reg_affine, _ = mne.transforms.compute_volume_registration(
     CT_orig, T1, pipeline='rigids',

--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -260,7 +260,9 @@ plot_overlay(template_brain, subject_brain,
 # .. warning:: Here we use ``zooms=5``` just for speed, in general we recommend
 #              using ``zooms=None``` (default) for highest accuracy. To deal
 #              with this coarseness, we also use a threshold of 0.8 for the CT
-#              electrodes rather than 0.95.
+#              electrodes rather than 0.95. This coarse zoom and low threshold
+#              is useful for getting a quick view of the data, but finalized
+#              pipelines should use ``zooms=None`` instead!
 
 CT_thresh = 0.8  # 0.95 is better for zooms=None!
 reg_affine, sdr_morph = mne.transforms.compute_volume_registration(

--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -258,11 +258,13 @@ plot_overlay(template_brain, subject_brain,
 # to the template.
 #
 # .. warning:: Here we use ``zooms=5``` just for speed, in general we recommend
-#              using ``zooms=None``` (default) for highest accuracy.
+#              using ``zooms=None``` (default) for highest accuracy. To deal
+#              with this coarseness, we also use a threshold of 0.8 for the CT
+#              electrodes rather than 0.95.
 
+CT_thresh = 0.8  # 0.95 is better for zooms=None!
 reg_affine, sdr_morph = mne.transforms.compute_volume_registration(
-    subject_brain, template_brain, zooms=dict(
-        translation=5, rigid=5, affine=5, sdr=3), verbose=True)
+    subject_brain, template_brain, zooms=5, verbose=True)
 subject_brain_sdr = mne.transforms.apply_volume_registration(
     subject_brain, template_brain, reg_affine, sdr_morph)
 
@@ -288,7 +290,7 @@ ch_coords = mne.transforms.apply_trans(
 # into a 3D image where all the voxels over a threshold nearby
 # are labeled with an index
 CT_data = CT_aligned.get_fdata()
-thresh = np.quantile(CT_data, 0.8)
+thresh = np.quantile(CT_data, CT_thresh)
 elec_image = np.zeros(subject_brain.shape, dtype=int)
 for i, ch_coord in enumerate(ch_coords):
     # this looks up to a voxel away, it may be marked imperfectly

--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -29,9 +29,8 @@ import pandas as pd
 import matplotlib.pyplot as plt
 
 import nibabel as nib
-from dipy.align import (affine_registration, center_of_mass, translation,
-                        rigid, affine, resample)
-from dipy.align.reslice import reslice
+import nilearn.plotting
+from dipy.align import resample
 
 import mne
 from mne.datasets import fetch_fsaverage
@@ -71,7 +70,7 @@ fetch_fsaverage(subjects_dir=subjects_dir, verbose=True)  # downloads if needed
 #     ``256 x 256 x 256`` voxels.
 #
 # .. note::
-#     Using the ``--deface`` flag will create a defaced, anonymized T1 image
+#     Using the ``-deface`` flag will create a defaced, anonymized T1 image
 #     located at ``$MY_DATA_DIRECTORY/$SUBJECT/mri/orig_defaced.mgz``,
 #     which is helpful for when you publish your data. You can also use
 #     :func:`mne_bids.write_anat` and pass ``deface=True``.
@@ -111,89 +110,35 @@ def plot_overlay(image, compare, title, thresh=None):
 T1 = nib.load(op.join(misc_path, 'seeg', 'sample_seeg_T1.mgz'))
 CT_orig = nib.load(op.join(misc_path, 'seeg', 'sample_seeg_CT.mgz'))
 
-# resample to T1 shape
+# resample to T1's definition of world coordinates
 CT_resampled = resample(moving=CT_orig.get_fdata(),
                         static=T1.get_fdata(),
                         moving_affine=CT_orig.affine,
-                        static_affine=T1.affine,
-                        between_affine=None)
+                        static_affine=T1.affine)
 plot_overlay(T1, CT_resampled, 'Unaligned CT Overlaid on T1', thresh=0.95)
+del CT_resampled
 
 ###############################################################################
 # Now we need to align our CT image to the T1 image.
 #
-# .. code-block:: python
+# We want this to be a rigid transformation (just rotation + translation),
+# so we don't do a full affine registration (that includes shear) here.
+# We'll use (although not executed here because it's slow) the following call,
+# which uses coarser zooms for translation because it provides better
+# registration for these data::
 #
-#     # normalize intensities
-#     mri_to = T1.get_fdata().copy()
-#     mri_to /= mri_to.max()
-#     ct_from = CT_orig.get_fdata().copy()
-#     ct_from /= ct_from.max()
+#    reg_affine, _ = mne.transforms.compute_volume_registration(
+#         CT_orig, T1, pipeline='rigids',
+#         zooms=dict(translation=5.), verbose=True)
+#    print(reg_affine)
 #
-#     # downsample for speed
-#     zooms = (5, 5, 5)
-#     mri_to, affine_to = reslice(
-#         mri_to, affine=T1.affine,
-#         zooms=T1.header.get_zooms()[:3], new_zooms=zooms)
-#     ct_from, affine_from = reslice(
-#         ct_from, affine=CT_orig.affine,
-#         zooms=CT_orig.header.get_zooms()[:3], new_zooms=zooms)
-#
-#     # first optimize the translation on the zoomed images using
-#     # ``factors`` which looks at the image at different scales
-#     reg_affine = affine_registration(
-#         moving=ct_from,
-#         static=mri_to,
-#         moving_affine=affine_from,
-#         static_affine=affine_to,
-#         nbins=32,
-#         metric='MI',
-#         pipeline=[center_of_mass, translation],
-#         level_iters=[100, 100, 10],
-#         sigmas=[3.0, 1.0, 0.0],
-#         factors=[4, 2, 1])[1]
-#
-#     CT_translated = resample(moving=CT_orig.get_fdata(),
-#                              static=T1.get_fdata(),
-#                              moving_affine=CT_orig.affine,
-#                              static_affine=T1.affine,
-#                              between_affine=reg_affine)
-#
-#     # Now, fine-tune the registration
-#     reg_affine = affine_registration(
-#         moving=CT_translated.get_fdata(),
-#         static=T1.get_fdata(),
-#         moving_affine=CT_translated.affine,
-#         static_affine=T1.affine,
-#         nbins=32,
-#         metric='MI',
-#         pipeline=[rigid],
-#         level_iters=[100, 100, 10],
-#         sigmas=[3.0, 1.0, 0.0],
-#         factors=[4, 2, 1])[1]
-#
-#     CT_aligned = resample(moving=CT_translated.get_fdata(),
-#                           static=T1.get_fdata(),
-#                           moving_affine=CT_translated.affine,
-#                           static_affine=T1.affine,
-#                           between_affine=reg_affine)
-
-
-###############################################################################
-# The previous section takes several minutes to execute so the results are
-# presented here pre-computed for convenience.
-
-alignment_affine = np.array([
+# This is the resulting affine, which we then apply and plot:
+reg_affine = np.array([
     [0.99235816, -0.03412124, 0.11857915, -133.22262329],
     [0.04601133, 0.99402046, -0.09902669, -97.64542095],
     [-0.11449119, 0.10372593, 0.98799428, -84.39915646],
     [0., 0., 0., 1.]])
-CT_aligned = resample(moving=CT_orig.get_fdata(),
-                      static=T1.get_fdata(),
-                      moving_affine=CT_orig.affine,
-                      static_affine=T1.affine,
-                      between_affine=alignment_affine)
-
+CT_aligned = mne.transforms.apply_volume_registration(CT_orig, T1, reg_affine)
 plot_overlay(T1, CT_aligned, 'Aligned CT Overlaid on T1', thresh=0.95)
 
 ###############################################################################
@@ -227,6 +172,7 @@ for ax in axes:
                 color='white', arrowprops=dict(facecolor='white'))
 axes[2].set_title('CT aligned to MR')
 fig.tight_layout()
+del CT_data, T1
 
 ###############################################################################
 # Marking the Location of Each Electrode Contact
@@ -249,7 +195,7 @@ fig.tight_layout()
 # .. code-block:: bash
 #
 #     $ freeview $MISC_PATH/seeg/sample_seeg_T1.mgz \
-#       $MISC_PATH/seeg/sample_seeg_CT.mgz
+#           $MISC_PATH/seeg/sample_seeg_CT.mgz
 #
 # Now, we'll need the subject's brain segmented out from the rest of the T1
 # image from the freesurfer ``recon-all`` reconstruction. This is so that
@@ -258,7 +204,7 @@ fig.tight_layout()
 #
 # Let's plot the electrode contact locations on the subject's brain.
 
-# Load electrode positions from file
+# load electrode positions from file
 elec_df = pd.read_csv(op.join(misc_path, 'seeg', 'sample_seeg_electrodes.tsv'),
                       sep='\t', header=0, index_col=None)
 ch_names = elec_df['name'].tolist()
@@ -267,8 +213,9 @@ ch_coords = elec_df[['R', 'A', 'S']].to_numpy(dtype=float)
 # load the subject's brain
 subject_brain = nib.load(op.join(misc_path, 'seeg', 'sample_seeg_brain.mgz'))
 
-# Make brain surface from T1
-verts, triangles = mne.marching_cubes(subject_brain.get_fdata(), level=100)
+# make brain surface from T1
+verts, triangles = mne.surface.marching_cubes(
+    subject_brain.get_fdata(), level=100)
 # transform from voxels to surface RAS
 verts = mne.transforms.apply_trans(
     subject_brain.header.get_vox2ras_tkr(), verts) / 1000.  # to meters
@@ -279,7 +226,7 @@ renderer.mesh(*verts.T, triangles=triangles, color='gray',
               opacity=0.05, representation='surface')
 for ch_coord in ch_coords:
     renderer.sphere(center=tuple(ch_coord / 1000.), color='y', scale=0.005)
-view_kwargs = dict(azimuth=40, elevation=60)
+view_kwargs = dict(azimuth=60, elevation=100)
 mne.viz.set_3d_view(renderer.figure, focalpoint=(0, 0, 0), distance=0.3,
                     **view_kwargs)
 renderer.show()
@@ -308,64 +255,22 @@ plot_overlay(template_brain, subject_brain,
 ###############################################################################
 # Now, we'll register the affine of the subject's brain to the template brain.
 # This aligns the two brains, preparing the subject's brain to be warped
-# to the template.
-
-# normalize intensities
-mri_to = template_brain.get_fdata().copy()
-mri_to /= mri_to.max()
-mri_from = subject_brain.get_fdata().copy()
-mri_from /= mri_from.max()
-
-# downsample for speed
-zooms = (5, 5, 5)
-mri_to, affine_to = reslice(
-    mri_to, affine=template_brain.affine,
-    zooms=template_brain.header.get_zooms()[:3], new_zooms=zooms)
-mri_from, affine_from = reslice(
-    mri_from, affine=subject_brain.affine,
-    zooms=subject_brain.header.get_zooms()[:3], new_zooms=zooms)
-
-reg_affine = affine_registration(
-    moving=mri_from,
-    static=mri_to,
-    moving_affine=affine_from,
-    static_affine=affine_to,
-    nbins=32,
-    metric='MI',
-    pipeline=[center_of_mass, translation, rigid, affine],
-    level_iters=[100, 100, 10],
-    sigmas=[3.0, 1.0, 0.0],
-    factors=[4, 2, 1])[1]
-
-# Apply the transform to the subject brain to plot it
-subject_brain_aligned = resample(moving=subject_brain.get_fdata(),
-                                 static=template_brain.get_fdata(),
-                                 moving_affine=subject_brain.affine,
-                                 static_affine=template_brain.affine,
-                                 between_affine=reg_affine)
-plot_overlay(template_brain, subject_brain_aligned,
-             'Alignment with fsaverage after Affine Registration')
-
-###############################################################################
-# Next, we'll compute the symmetric diffeomorphic registration. This accounts
-# for differences in the shape and size of the subject's brain areas
-# compared to the template brain.
+# to the template. This is very slow so we have instead saved the resulting
+# warped images to disk, but this is the call that was used to create them::
 #
-# This takes several minutes, so it won't actually be executed in the
-# tutorial, instead, we'll just use pre-computed results for convenience.
+#    reg_affine, sdr_morph = mne.transforms.compute_volume_registration(
+#        subject_brain, template_brain, verbose=True)
+#    subject_brain_sdr = mne.transforms.apply_volume_registration(
+#        subject_brain, template_brain, reg_affine, sdr_morph)
 #
-# .. code-block:: python
-#
-#     from dipy.align.metrics import CCMetric
-#     from dipy.align.imwarp import SymmetricDiffeomorphicRegistration
-#     # Compute registration
-#     sdr = SymmetricDiffeomorphicRegistration(
-#         metric=CCMetric(3), level_iters=[10, 10, 5])
-#     mapping = sdr.optimize(static=template_brain.get_fdata(),
-#                            moving=subject_brain.get_fdata(),
-#                            static_grid2world=template_brain.affine,
-#                            moving_grid2world=subject_brain.affine,
-#                            prealign=reg_affine)
+# Here we just load the result:
+
+subject_brain_sdr = nib.load(
+    op.join(misc_path, 'seeg', 'sample_seeg_brain_in_fsaverage.mgz'))
+
+# apply the transform to the subject brain to plot it
+plot_overlay(template_brain, subject_brain_sdr,
+             'Alignment with fsaverage after SDR Registration')
 
 ###############################################################################
 # Finally, we'll apply the registrations to the electrode contact coordinates.
@@ -377,46 +282,74 @@ plot_overlay(template_brain, subject_brain_aligned,
 # the SDR transform. We can finally recover a position by averaging the
 # positions of all the voxels that had the contact's lookup number in
 # the warped image.
+
+# convert electrode positions from surface RAS to voxels
+ch_coords = mne.transforms.apply_trans(
+    np.linalg.inv(subject_brain.header.get_vox2ras_tkr()), ch_coords)
+# take channel coordinates and use the CT to transform them
+# into a 3D image where all the voxels over a threshold nearby
+# are labeled with an index
+CT_data = CT_aligned.get_fdata()
+thresh = np.quantile(CT_data, 0.95)
+elec_image = np.zeros(subject_brain.shape, dtype=int)
+for i, ch_coord in enumerate(ch_coords):
+    # this looks up to a voxel away, it may be marked imperfectly
+    volume = mne.voxel_neighbors(ch_coord, CT_data, thresh)
+    for voxel in volume:
+        if elec_image[voxel] != 0:
+            # some voxels ambiguous because the contacts are bridged on
+            # the CT so assign the voxel to the nearest contact location
+            dist_old = np.sqrt(
+                (ch_coords[elec_image[voxel] - 1] - voxel)**2).sum()
+            dist_new = np.sqrt((ch_coord - voxel)**2).sum()
+            if dist_new < dist_old:
+                elec_image[voxel] = i + 1
+        else:
+            elec_image[voxel] = i + 1
+
+# apply the mapping
+elec_image = nib.Nifti1Image(elec_image, subject_brain.affine)
+
+# ensure that each electrode contact was marked in at least one voxel
+assert set(np.arange(1, ch_coords.shape[0] + 1)).difference(
+    set(np.unique(elec_image.get_fdata()))) == set()
+
+del subject_brain, CT_aligned, CT_data  # not used anymore
+
+###############################################################################
+# Warp and plot the result. Again we don't compute the warp here, so we just
+# load the result from disk but this is the call to execute:
 #
-# .. code-block:: python
+#    warped_elec_image = mne.transforms.apply_volume_registration(
+#        elec_image, template_brain, reg_affine, sdr_morph,
+#        interpolation='nearest')
 #
-#     # convert electrode positions from surface RAS to voxels
-#     ch_coords = mne.transforms.apply_trans(
-#         np.linalg.inv(subject_brain.header.get_vox2ras_tkr()), ch_coords)
-#
-#     # Take channel coordinates and use the CT to transform them
-#     # into a 3D image where all the voxels over a threshold nearby
-#     # are labeled with an index
-#     CT_data = CT_aligned.get_fdata()
-#     thresh = np.quantile(CT_data, 0.95)
-#     elec_image = np.zeros(subject_brain.shape, dtype=int)
-#     for i, ch_coord in enumerate(ch_coords):
-#         # this looks up to a voxel away, it may be marked imperfectly
-#         volume = mne.voxel_neighbors(ch_coord, CT_data, thresh)
-#         for voxel in volume:
-#             if elec_image[voxel] != 0:
-#                 # some voxels ambiguous because the contacts are bridged on
-#                 # the CT so assign the voxel to the nearest contact location
-#                 dist_old = np.sqrt(
-#                     (ch_coords[elec_image[voxel] - 1] - voxel)**2).sum()
-#                 dist_new = np.sqrt((ch_coord - voxel)**2).sum()
-#                 if dist_new < dist_old:
-#                     elec_image[voxel] = i + 1
-#             else:
-#                 elec_image[voxel] = i + 1
-#
-#     # Apply the mapping
-#     warped_elec_image = mapping.transform(elec_image,
-#                                           interpolation='nearest')
-#
-#     # Recover the electrode contact positions as the center of mass
-#     for i in range(ch_coords.shape[0]):
-#         ch_coords[i] = np.array(
-#             np.where(warped_elec_image == i + 1)).mean(axis=1)
-#
-#     # Convert back to surface RAS but to the template surface RAS this time
-#     ch_coords = mne.transforms.apply_trans(
-#         template_brain.header.get_vox2ras_tkr(), ch_coords)
+# Again here we just load the result:
+
+warped_elec_image = nib.load(
+    op.join(misc_path, 'seeg', 'warped_elec_image.mgz'))
+
+# ensure that all the electrode contacts were warped to the template
+assert set(np.arange(1, ch_coords.shape[0] + 1)).difference(
+    set(np.unique(warped_elec_image.get_fdata()))) == set()
+
+fig, axes = plt.subplots(2, 1, figsize=(8, 8))
+nilearn.plotting.plot_glass_brain(elec_image, axes=axes[0], cmap='Dark2')
+fig.text(0.1, 0.65, 'Subject T1', rotation='vertical')
+nilearn.plotting.plot_glass_brain(warped_elec_image, axes=axes[1],
+                                  cmap='Dark2')
+fig.text(0.1, 0.25, 'fsaverage', rotation='vertical')
+fig.suptitle('Electrodes warped to fsaverage')
+
+# recover the electrode contact positions as the center of mass
+warped_elec_data = warped_elec_image.get_fdata()
+for val, ch_coord in enumerate(ch_coords, 1):
+    ch_coord[:] = np.array(
+        np.where(warped_elec_data == val), float).mean(axis=1)
+
+# convert back to surface RAS but to the template surface RAS this time
+ch_coords = mne.transforms.apply_trans(
+    template_brain.header.get_vox2ras_tkr(), ch_coords)
 
 ###############################################################################
 # We can now plot the result. You can compare this to the plot in
@@ -426,13 +359,7 @@ plot_overlay(template_brain, subject_brain_aligned,
 # SDR to warp the positions of the electrode contacts, the position in the
 # template brain is able to be more accurately estimated.
 
-# sphinx_gallery_thumbnail_number = 7
-
-# load pre-computed warped values
-elec_df = pd.read_csv(
-    op.join(misc_path, 'seeg', 'sample_seeg_electrodes_fsaverage.tsv'),
-    sep='\t', header=0, index_col=None)
-ch_coords = elec_df[['R', 'A', 'S']].to_numpy(dtype=float)
+# sphinx_gallery_thumbnail_number = 8
 
 # load electrophysiology data
 raw = mne.io.read_raw(op.join(misc_path, 'seeg', 'sample_seeg_ieeg.fif'))
@@ -441,7 +368,7 @@ lpa, nasion, rpa = mne.coreg.get_mni_fiducials(
     'fsaverage', subjects_dir=subjects_dir)
 lpa, nasion, rpa = lpa['r'], nasion['r'], rpa['r']
 
-# Create a montage with our new points
+# create a montage with our new points
 ch_pos = dict(zip(ch_names, ch_coords / 1000))  # mm -> m
 montage = mne.channels.make_dig_montage(
     ch_pos, coord_frame='mri', nasion=nasion, lpa=lpa, rpa=rpa)


### PR DESCRIPTION
This splits up https://github.com/mne-tools/mne-python/pull/9503 to just refactor the volume registration for CT/MR without combining it with the existing SDR morph for volume source estimates.

This won't work until https://github.com/mne-tools/mne-misc-data/pull/7 merges.

Needs
- [ ] Decide on  `_USE_PREALIGN` and equiv in morph.py : one should really work for both (differences are minor)
- [ ] Add back SourceMorph attribute updates from #9503