### PR TITLE
Update download URL to pyvistaqt main branch

### DIFF
--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -16,7 +16,7 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	# we want --pre for VTK, but it breaks Azure as of 2021/06/14 (mayavi has problems with the 20210612 binary)
 	python -m pip install --progress-bar off --upgrade --only-binary ":all" "vtk<=9.0.1"
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
-	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
+	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
 	python -m pip install --progress-bar off --upgrade --only-binary="numba,llvmlite" -r requirements.txt
 else
 	echo "Unknown run type ${TEST_MODE}"

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -22,7 +22,7 @@ if [[ "$CIRCLE_JOB" == "interactive_test" ]]; then
 	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 	python -m pip install --progress-bar off vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
-	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
+	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
 	python -m pip install --progress-bar off --upgrade -r requirements_testing.txt -r requirements_testing_extra.txt
 	python -m pip install -e .
 elif [[ "$CIRCLE_JOB" == "linkcheck"* ]]; then
@@ -34,7 +34,7 @@ else  # standard doc build
 	echo "Installing doc build dependencies"
 	python -m pip uninstall -y pydata-sphinx-theme
 	python -m pip install --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
-	python -m pip install --progress-bar off https://github.com/sphinx-gallery/sphinx-gallery/zipball/master https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/master
+	python -m pip install --progress-bar off https://github.com/sphinx-gallery/sphinx-gallery/zipball/master https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/main
 	python -m pip uninstall -yq pysurfer mayavi
 	python -m pip install -e .
 fi

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -28,7 +28,7 @@ else
 	echo "PyVista"
 	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
 	echo "pyvistaqt"
-	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/master
+	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
 	echo "imageio-ffmpeg, xlrd, mffpy"
 	pip install --progress-bar off --pre mayavi imageio-ffmpeg xlrd mffpy
 fi


### PR DESCRIPTION
Follows https://github.com/mne-tools/mne-python/pull/9497 and https://github.com/pyvista/pyvistaqt/pull/120, the PR updates the branch name of `pyvistaqt`.