### PR TITLE
MRG: Test get_montage on fNIRS data

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -105,6 +105,8 @@ Bugs
 
 - In :func:`mne.viz.plot_ica_scores` and :meth:`mne.preprocessing.ICA.plot_scores`, the figure and axis titles no longer overlap when plotting only a single EOG or ECG channel (:gh:`9489` by `Richard Höchenberger`_).
 
+- Ensure `mne.io.Raw.get_montage` works with SNIRF data (:gh:`9524` by `Robert Luke`_)
+
 API changes
 ~~~~~~~~~~~
 - Nothing yet

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -263,7 +263,7 @@ class ContainsMixin(object):
         # get the channel names and chs data structure
         ch_names, chs = self.info['ch_names'], self.info['chs']
         picks = pick_types(self.info, meg=False, eeg=True,
-                           seeg=True, ecog=True, dbs=True)
+                           seeg=True, ecog=True, dbs=True, fnirs=True)
 
         # channel positions from dig do not match ch_names one to one,
         # so use loc[:3] instead

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -138,6 +138,9 @@ def test_nirsport_v2():
     assert_allclose(
         np.diff(raw.annotations.onset), [2.3, 3.1], atol=0.1)
 
+    mon = raw.get_montage()
+    assert len(mon.dig) == 43
+
 
 @requires_testing_data
 @pytest.mark.filterwarnings('ignore:.*Extraction of measurement.*:')

--- a/mne/io/snirf/tests/test_snirf.py
+++ b/mne/io/snirf/tests/test_snirf.py
@@ -278,6 +278,9 @@ def test_snirf_nirsport2_w_positions():
     assert_allclose(
         mni_locs[34], [0.0828, -0.046, 0.0285], atol=allowed_dist_error)
 
+    mon = raw.get_montage()
+    assert len(mon.dig) == 43
+
 
 @requires_testing_data
 @requires_h5py


### PR DESCRIPTION
#### Reference issue
See https://mne.discourse.group/t/montage-either-not-saved-in-fif-or-not-read/3356

#### What does this implement/fix?
Ensures get_montage() works with fNIRS data

#### Additional information
* The NIRx reader already worked with get_montage, so I added a test to ensure it keeps working.
* Added info[dig] to the SNIRF reader. And added test that get_montage returns data.

I always find the digitisation stuff tricky, so please review critically (as always 😉)
