### PR TITLE
MRG, BUG: Deal with flats better in maxwell autobad

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -93,6 +93,8 @@ Bugs
 
 - Fix bug when computing rank from info for SSS data with only gradiometers or magnetometers (:gh:`9435` by `Alex Gramfort`_)
 
+- Fix bug with `mne.preprocessing.find_bad_channels_maxwell` where all-flat segments could lead to an error (:gh:`9531` by `Eric Larson`_)
+
 - Fix bug with `mne.io.Raw.set_montage` and related functions where the channel coordinate frame was not properly set to head (:gh:`9447` by `Eric Larson`_)
 
 - Fix bug with `mne.io.read_raw_fieldtrip` and `mne.read_epochs_fieldtrip` where channel positions were not set properly (:gh:`9447` by `Eric Larson`_)

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -2173,6 +2173,14 @@ def find_bad_channels_maxwell(
         chunk_flats = sorted(all_flats)
         these_picks = [pick for pick in good_meg_picks
                        if raw.ch_names[pick] not in chunk_flats]
+        if len(these_picks) == 0:
+            logger.info(f'            Flat ({len(chunk_flats):2d}): <all>')
+            warn('All-flat segment detected, all channels will be marked as '
+                 f'flat and processing will stop (t={t[0]:0.3f}). '
+                 'Consider using annotate_flat before calling this function '
+                 'with skip_by_annotation="bad_flat" (or similar) to properly '
+                 'process all segments.')
+            break  # no reason to continue
         # Bad pass
         chunk_noisy = list()
         params['st_duration'] = int(round(


### PR DESCRIPTION
Just add a test that things behave how we expect for #9479, and a warning to help people. We could maybe do something smarter than just quit, but I think it makes sense to just point people to `annotate_flat` so that they can fix things there instead. With this code a variant of the minimal example from #9479 works as expected:
```
import mne
raw = mne.io.read_raw_fif('sub-1011_ses-20190430_task-vid2_meg.fif').load_data()
raw.set_channel_types(dict(EEG061='eog', EEG062='eog'))
annot, _ = mne.preprocessing.annotate_flat(raw, bad_percent=100, verbose=True)
raw.set_annotations(annot)
mne.preprocessing.find_bad_channels_maxwell(
    raw, skip_by_annotation=('bad_flat',), verbose=True)
```
Closes #9479