### PR TITLE
[MRG] Make concatenate_epochs work with empty Epochs objects

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -115,6 +115,8 @@ Bugs
 
 - Fix bug in :func:`mne.viz.plot_topomap` (and related methods like :meth:`mne.Evoked.plot_topomap`) where large distances between electrodes (higher than head radius) would lead to an error (:gh:`9528` by `Mikołaj Magnuski`_).
 
+- Fix bug in :func:`mne.concatenate_epochs` when concatenating :class:`mne.Epochs` objects with 0 events (:gh:`9535` by `Marijn van Vliet`_)
+
 API changes
 ~~~~~~~~~~~
 - In `mne.compute_source_morph`, the ``niter_affine`` and ``niter_sdr`` parameters have been replaced by ``niter`` and ``pipeline`` parameters for more consistent and finer-grained control of registration/warping steps and iteration (:gh:`9505` by `Alex Rockhill`_ and `Eric Larson`_)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3340,9 +3340,6 @@ def _concatenate_epochs(epochs_list, with_data=True, add_offset=True, *,
         if epochs.baseline != baseline:
             raise ValueError('Baseline must be same for all epochs')
 
-        if len(epochs.events) == 0:
-            warn('One of the Epochs objects to concatenate was empty.')
-
         # compare event_id
         common_keys = list(set(event_id).intersection(set(epochs.event_id)))
         for key in common_keys:
@@ -3357,8 +3354,9 @@ def _concatenate_epochs(epochs_list, with_data=True, add_offset=True, *,
             epochs.drop_bad()
             offsets.append(len(epochs))
         evs = epochs.events.copy()
-        # add offset
-        if add_offset:
+        if len(epochs.events) == 0:
+            warn('One of the Epochs objects to concatenate was empty.')
+        elif add_offset:
             # We need to cast to a native Python int here to prevent an
             # overflow of a numpy int32 or int64 type.
             events_offset += int(np.max(evs[:, 0])) + shift

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3340,6 +3340,9 @@ def _concatenate_epochs(epochs_list, with_data=True, add_offset=True, *,
         if epochs.baseline != baseline:
             raise ValueError('Baseline must be same for all epochs')
 
+        if len(epochs.events) == 0:
+            warn('One of the Epochs objects to concatenate was empty.')
+
         # compare event_id
         common_keys = list(set(event_id).intersection(set(epochs.event_id)))
         for key in common_keys:
@@ -3356,12 +3359,9 @@ def _concatenate_epochs(epochs_list, with_data=True, add_offset=True, *,
         evs = epochs.events.copy()
         # add offset
         if add_offset:
-            if len(evs) == 0:
-                warn('One of the Epochs objects to concatenate was empty.')
-            else:
-                # We need to cast to a native Python int here to prevent an
-                # overflow of a numpy int32 or int64 type.
-                events_offset += int(np.max(evs[:, 0])) + shift
+            # We need to cast to a native Python int here to prevent an
+            # overflow of a numpy int32 or int64 type.
+            events_offset += int(np.max(evs[:, 0])) + shift
             if events_offset > INT32_MAX:
                 warn(f'Event number greater than {INT32_MAX} created, '
                      'events[:, 0] will be assigned consecutive increasing '

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3304,18 +3304,6 @@ def add_channels_epochs(epochs_list, verbose=None):
     return epochs
 
 
-def _update_offset(offset, events, shift):
-    if offset == 0:
-        return offset
-    offset = 0 if offset is None else offset
-    offset = np.int64(offset) + np.max(events[:, 0]) + shift
-    if offset > INT32_MAX:
-        warn(f'Event number greater than {INT32_MAX} created, events[:, 0] '
-             'will be assigned consecutive increasing integer values')
-        offset = 0
-    return offset
-
-
 def _concatenate_epochs(epochs_list, with_data=True, add_offset=True, *,
                         on_mismatch='raise'):
     """Auxiliary function for concatenating epochs."""
@@ -3341,7 +3329,8 @@ def _concatenate_epochs(epochs_list, with_data=True, add_offset=True, *,
     selection = out.selection
     # offset is the last epoch + tmax + 10 second
     shift = int((10 + tmax) * out.info['sfreq'])
-    events_offset = _update_offset(None, out.events, shift)
+    events_offset = 0
+    events_number_overflow = False
     for ii, epochs in enumerate(epochs_list[1:], 1):
         _ensure_infos_match(epochs.info, info, f'epochs[{ii}]',
                             on_mismatch=on_mismatch)
@@ -3367,9 +3356,19 @@ def _concatenate_epochs(epochs_list, with_data=True, add_offset=True, *,
         evs = epochs.events.copy()
         # add offset
         if add_offset:
-            evs[:, 0] += events_offset
-        # Update offset for the next iteration.
-        events_offset = _update_offset(events_offset, epochs.events, shift)
+            if len(evs) == 0:
+                warn('One of the Epochs objects to concatenate was empty.')
+            else:
+                # We need to cast to a native Python int here to prevent an
+                # overflow of a numpy int32 or int64 type.
+                events_offset += int(np.max(evs[:, 0])) + shift
+            if events_offset > INT32_MAX:
+                warn(f'Event number greater than {INT32_MAX} created, '
+                     'events[:, 0] will be assigned consecutive increasing '
+                     'integer values')
+                events_number_overflow = True
+            else:
+                evs[:, 0] += events_offset
         events.append(evs)
         selection = np.concatenate((selection, epochs.selection))
         drop_log = drop_log + epochs.drop_log
@@ -3377,7 +3376,7 @@ def _concatenate_epochs(epochs_list, with_data=True, add_offset=True, *,
         metadata.append(epochs.metadata)
     events = np.concatenate(events, axis=0)
     # check to see if we exceeded our maximum event offset
-    if events_offset == 0:
+    if events_number_overflow:
         events[:, 0] = np.arange(1, len(events) + 1)
 
     # Create metadata object (or make it None)

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2700,6 +2700,11 @@ def test_concatenate_epochs():
     with pytest.raises(ValueError, match='identical keys'):
         concatenate_epochs([epochs1, epochs2])
 
+    # check concatenating epochs where one of the objects is empty
+    epochs2 = epochs.copy()[:0]
+    with pytest.warns(RuntimeWarning, match='was empty'):
+        concatenate_epochs([epochs, epochs2])
+
 
 def test_concatenate_epochs_large():
     """Test concatenating epochs on large data."""


### PR DESCRIPTION
There was an edge case when concatenating Epochs and one (or more) of the `Epochs` objects was empty. See #9533.

fixes #9533