### PR TITLE
Improve scalings description in Raw.plot()

### DIFF
--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -78,6 +78,12 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
                  emg=1e-3, ref_meg=1e-12, misc=1e-3, stim=1,
                  resp=1, chpi=1e-4, whitened=1e2)
 
+        A particular scaling value ``s``corresponds to half of the visualized
+        signal range around zero (i.e. from ``0`` to ``+s`` or from ``0`` to
+        ``-s``). For example, the default scaling of ``20e-6`` (20µV) for EEG
+        signals means that the visualized range will be 40µV (20µV in the
+        positive direction and 20µV in the negative direction).
+
     remove_dc : bool
         If True remove DC component when plotting data.
     order : array of int | None

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -78,7 +78,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
                  emg=1e-3, ref_meg=1e-12, misc=1e-3, stim=1,
                  resp=1, chpi=1e-4, whitened=1e2)
 
-        A particular scaling value ``s``corresponds to half of the visualized
+        A particular scaling value ``s`` corresponds to half of the visualized
         signal range around zero (i.e. from ``0`` to ``+s`` or from ``0`` to
         ``-s``). For example, the default scaling of ``20e-6`` (20µV) for EEG
         signals means that the visualized range will be 40µV (20µV in the


### PR DESCRIPTION
I found it rather difficult to understand the `scalings` values used in `Raw.plot()`, because the description does not include any details. @drammock please feel free to revise/improve, I'm not really happy with it but cannot think of anything better right now. I think the key point is to explicitly mention that the visualized range is actually twice the scaling value.