### PR TITLE
MRG: Fix return type for raw.annotations.rename and add to tutorial

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -644,6 +644,7 @@ class Annotations(object):
         for old, new in mapping.items():
             self.description = [d.replace(old, new) for d in self.description]
 
+        self.description = np.array(self.description)
         return self
 
 

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1289,6 +1289,7 @@ def test_annotation_ch_names():
 def test_annotation_rename():
     """Test annotation renaming works."""
     a = Annotations([1, 2, 3], [5, 5, 8], ["a", "b", "c"])
+    assert isinstance(a.description, np.ndarray)
     assert len(a) == 3
     assert "a" in a.description
     assert "b" in a.description
@@ -1297,6 +1298,7 @@ def test_annotation_rename():
 
     a = Annotations([1, 2, 3], [5, 5, 8], ["a", "b", "c"])
     a.rename({"a": "new_name"})
+    assert isinstance(a.description, np.ndarray)
     assert len(a) == 3
     assert "a" not in a.description
     assert "new_name" in a.description
@@ -1314,6 +1316,7 @@ def test_annotation_rename():
 
     a = Annotations([1, 2, 3], [5, 5, 8], ["a", "b", "c"])
     a.rename({"b": "new_name", "c": "new name c"})
+    assert isinstance(a.description, np.ndarray)
     assert len(a) == 3
     assert "b" not in a.description
     assert "new_name" in a.description
@@ -1340,6 +1343,7 @@ def test_annotation_rename():
 def test_annotation_duration_setting():
     """Test annotation duration setting works."""
     a = Annotations([1, 2, 3], [5, 5, 8], ["a", "b", "c"])
+    assert isinstance(a.duration, np.ndarray)
     assert len(a) == 3
     assert a.duration[0] == 5
     assert a.duration[2] == 8
@@ -1358,6 +1362,7 @@ def test_annotation_duration_setting():
     assert a.duration[0] == 5
     assert a.duration[2] == 8
     a.set_durations(7.2)
+    assert isinstance(a.duration, np.ndarray)
     assert a.duration[0] == 7.2
     assert a.duration[2] == 7.2
     a.set_durations(2)

--- a/tutorials/preprocessing/70_fnirs_processing.py
+++ b/tutorials/preprocessing/70_fnirs_processing.py
@@ -34,7 +34,7 @@ raw_intensity.load_data()
 # stored as annotations. Second, we include information about the duration of
 # each stimulus, which was 5 seconds for all conditions in this experiment.
 # Third, we remove the trigger code 15, which signaled the start and end
-# of the experiment and is not relevant to analysis.
+# of the experiment and is not relevant to our analysis.
 
 raw_intensity.annotations.set_durations(5)
 raw_intensity.annotations.rename({'1.0': 'Control',

--- a/tutorials/preprocessing/70_fnirs_processing.py
+++ b/tutorials/preprocessing/70_fnirs_processing.py
@@ -31,9 +31,9 @@ raw_intensity.load_data()
 # ------------------------------------------------
 #
 # First, we attribute more meaningful names to the trigger codes which are
-# stored as annotations. Further, we include information about the duration of
+# stored as annotations. Second, we include information about the duration of
 # each stimulus, which was 5 seconds for all conditions in this experiment.
-# Further, we remove the trigger code 15, which signaled the start and end
+# Third, we remove the trigger code 15, which signaled the start and end
 # of the experiment and is not relevant to analysis.
 
 raw_intensity.annotations.set_durations(5)
@@ -41,7 +41,7 @@ raw_intensity.annotations.rename({'1.0': 'Control',
                                   '2.0': 'Tapping/Left',
                                   '3.0': 'Tapping/Right'})
 raw_intensity.annotations.delete(
-    np.where([d == '15.0' for d in raw_intensity.annotations.description]))
+    raw_intensity.annotations.description == '15.0')
 
 
 ###############################################################################

--- a/tutorials/preprocessing/70_fnirs_processing.py
+++ b/tutorials/preprocessing/70_fnirs_processing.py
@@ -27,6 +27,24 @@ raw_intensity.load_data()
 
 
 ###############################################################################
+# Providing more meaningful annotation information
+# ------------------------------------------------
+#
+# First, we attribute more meaningful names to the trigger codes which are
+# stored as annotations. Further, we include information about the duration of
+# each stimulus, which was 5 seconds for all conditions in this experiment.
+# Further, we remove the trigger code 15, which signaled the start and end
+# of the experiment and is not relevant to analysis.
+
+raw_intensity.annotations.set_durations(5)
+raw_intensity.annotations.rename({'1.0': 'Control',
+                                  '2.0': 'Tapping/Left',
+                                  '3.0': 'Tapping/Right'})
+raw_intensity.annotations.delete(
+    np.where([d == '15.0' for d in raw_intensity.annotations.description]))
+
+
+###############################################################################
 # View location of sensors over brain surface
 # -------------------------------------------
 #
@@ -153,10 +171,7 @@ fig.subplots_adjust(top=0.88)
 # First we extract the events of interest and visualise them to ensure they are
 # correct.
 
-events, _ = mne.events_from_annotations(raw_haemo, event_id={'1.0': 1,
-                                                             '2.0': 2,
-                                                             '3.0': 3})
-event_dict = {'Control': 1, 'Tapping/Left': 2, 'Tapping/Right': 3}
+events, event_dict = mne.events_from_annotations(raw_haemo)
 fig = mne.viz.plot_events(events, event_id=event_dict,
                           sfreq=raw_haemo.info['sfreq'])
 fig.subplots_adjust(right=0.7)  # make room for the legend


### PR DESCRIPTION
#### Reference issue
Following #9525 #9523


#### What does this implement/fix?
Demonstrate new annotation name and duration setting in a tutorial.


