### PR TITLE
DOC: use regexps for sphinx-copybutton

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -126,6 +126,9 @@ pygments_style = 'default'
 # A list of ignored prefixes for module index sorting.
 modindex_common_prefix = ['mne.']
 
+# -- Sphiny-Copybutton configuration -----------------------------------------
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True
 
 # -- Intersphinx configuration -----------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -126,7 +126,7 @@ pygments_style = 'default'
 # A list of ignored prefixes for module index sorting.
 modindex_common_prefix = ['mne.']
 
-# -- Sphiny-Copybutton configuration -----------------------------------------
+# -- Sphinx-Copybutton configuration -----------------------------------------
 copybutton_prompt_text = r">>> |\.\.\. |\$ "
 copybutton_prompt_is_regexp = True
 


### PR DESCRIPTION
We use https://sphinx-copybutton.readthedocs.io/en/latest/ in our docs. This PR makes use of sphinx-copybutton configurations to improve copying.

Namely, fields like this one:

```
$ make html
```

or like this one:

```
>>> 1+1
2
```

Will copy without the respective prompts (--> `make html` instead of `$ make html`), and can thus be directly pasted into the terminal / editor.

Examples for what will be improved:

- Python example blocks in the API docs, like here: https://mne.tools/stable/generated/mne.io.Raw.html
- Contributor docs, like here: https://mne.tools/stable/install/contributing.html#building-the-documentation