### PR TITLE
Add get_data method to Evoked

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -91,6 +91,8 @@ Enhancements
 
 - The ``exclude`` parameter in `mne.io.read_raw_edf`, `mne.io.read_raw_bdf`, and `mne.io.read_raw_gdf` now also accepts a regular expression (:gh:`9558` by `Clemens Brunner`_)
 
+- Add meth:`mne.Evoked.get_data` method to :class:`mne.Evoked` (:gh:`9555` by `Stefan Appelhoff`_)
+
 Bugs
 ~~~~
 - Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** |Jan Sosulski|_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -91,7 +91,7 @@ Enhancements
 
 - The ``exclude`` parameter in `mne.io.read_raw_edf`, `mne.io.read_raw_bdf`, and `mne.io.read_raw_gdf` now also accepts a regular expression (:gh:`9558` by `Clemens Brunner`_)
 
-- Add meth:`mne.Evoked.get_data` method to :class:`mne.Evoked` (:gh:`9555` by `Stefan Appelhoff`_)
+- Add :meth:`mne.Evoked.get_data` method to :class:`mne.Evoked` (:gh:`9555` by `Stefan Appelhoff`_)
 
 Bugs
 ~~~~

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -110,14 +110,8 @@ def test_interpolation_eeg(offset, avg_proj, ctol, atol, method):
     evoked_eeg_interp = evoked_eeg_2_bads.interpolate_bads(
         origin=(0., 0., 0.), exclude=['EEG 004'], **kw)
     assert evoked_eeg_interp.info['bads'] == ['EEG 004']
-    assert np.all(
-        evoked_eeg_interp.data[evoked_eeg_interp.ch_names.index('EEG 004'), :]
-        == 1e10
-    )
-    assert np.all(
-        evoked_eeg_interp.data[evoked_eeg_interp.ch_names.index('EEG 012'), :]
-        != 1e10
-    )
+    assert np.all(evoked_eeg_interp.get_data('EEG 004') == 1e10)
+    assert np.all(evoked_eeg_interp.get_data('EEG 012') != 1e10)
 
     # Now test without exclude parameter
     evoked_eeg_bad.info['bads'] = ['EEG 012']

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -158,6 +158,22 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """Set the data matrix."""
         self._data = data
 
+    def get_data(self, picks=None):
+        """Get evoked data as 2D array.
+
+        Parameters
+        ----------
+        %(picks_all)s
+
+        Returns
+        -------
+        data : ndarray, shape (n_channels, n_times)
+            A view on evoked data.
+        """
+        picks = _picks_to_idx(self.info, picks, "all", exclude=())
+        data = self.data[picks, :]
+        return data
+
     @verbose
     def apply_function(self, fun, picks=None, dtype=None, n_jobs=1,
                        verbose=None, **kwargs):

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -170,6 +170,10 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         -------
         data : ndarray, shape (n_channels, n_times)
             A view on evoked data.
+
+        Notes
+        -----
+        .. versionadded:: 0.24
         """
         picks = _picks_to_idx(self.info, picks, "all", exclude=())
         data = self.data[picks, :]

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -158,6 +158,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """Set the data matrix."""
         self._data = data
 
+    @fill_doc
     def get_data(self, picks=None):
         """Get evoked data as 2D array.
 

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -661,7 +661,7 @@ def test_bipolar_combinations():
     # check if reference channels have been kept correctly.
     assert (len(raw_test.ch_names) == len(a_channels) + len(ch_names))
     for idx, ch_label in enumerate(ch_names):
-        manual_ch = np.atleast_2d(raw_data[idx, :])
+        manual_ch = raw_data[np.newaxis, idx]
         assert_array_equal(raw_test.get_data(ch_label), manual_ch)
 
     # test bipolars with a channel in both list (anode & cathode).

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -661,9 +661,8 @@ def test_bipolar_combinations():
     # check if reference channels have been kept correctly.
     assert (len(raw_test.ch_names) == len(a_channels) + len(ch_names))
     for idx, ch_label in enumerate(ch_names):
-        manual_ch = raw_data[idx, :]
-        assert_array_equal(
-            raw_test._data[raw_test.ch_names.index(ch_label), :], manual_ch)
+        manual_ch = np.atleast_2d(raw_data[idx, :])
+        assert_array_equal(raw_test.get_data(ch_label), manual_ch)
 
     # test bipolars with a channel in both list (anode & cathode).
     raw_test = set_bipolar_reference(

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -30,6 +30,20 @@ raw_fname = op.join(base_dir, 'test_raw.fif')
 event_name = op.join(base_dir, 'test-eve.fif')
 
 
+def test_get_data():
+    """Test the get_data method for Evoked."""
+    evoked = read_evokeds(fname, 0)
+    d1 = evoked.get_data()
+    d2 = evoked.data
+    np.testing.assert_array_equal(d1, d2)
+
+    eeg_idxs = np.array([i == "eeg" for i in evoked.get_channel_types()])
+    np.testing.assert_array_equal(
+        evoked.data[eeg_idxs],
+        evoked.get_data(picks="eeg")
+    )
+
+
 def test_decim():
     """Test evoked decimation."""
     rng = np.random.RandomState(0)

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ release = egg_info -RDb ''
 doc-files = doc
 
 [flake8]
-exclude = __init__.py,*externals*,constants.py,fixes.py,resources.py
+exclude = __init__.py,*externals*,constants.py,fixes.py,resources.py,*doc/auto_examples*,*doc/_build*
 ignore = W503,W504,I100,I101,I201,N806,E201,E202,E221,E222,E241
 # We add A for the array-spacing plugin, and ignore the E ones it covers above
 select = A,E,F,W,C


### PR DESCRIPTION
fixes #9244 

working on #9553 I thought I'd give this a shot as well. Please let me know what I should add - I can add the `units` parameter here or in #9553, depending on which one gets merged earlier.

~EDIT: the tmin/tmax params from https://github.com/mne-tools/mne-python/issues/9548 could also be added here.~ better in #9556 

To Do
- [x] have somebody tell me what's missing, or if this is really all that was needed
- [x] add whatsnew