### PR TITLE
Accept regex for exclude in `read_raw_{e,b,g}df`

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -89,6 +89,8 @@ Enhancements
 
 - Add `mne.Annotations.set_durations` to set annotation durations (:gh:`9529` by `Robert Luke`_)
 
+- The ``exclude`` parameter in `mne.io.read_raw_edf`, `mne.io.read_raw_bdf`, and `mne.io.read_raw_gdf` now also accepts a regular expression (:gh:`9558` by `Clemens Brunner`_)
+
 Bugs
 ~~~~
 - Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** |Jan Sosulski|_)

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -512,3 +512,16 @@ def test_degenerate():
                  partial(_read_header, exclude=())):
         with pytest.raises(NotImplementedError, match='Only.*txt.*'):
             func(edf_txt_stim_channel_path)
+
+
+def test_exclude():
+    """Test exclude parameter."""
+    exclude = ["I1", "I2", "I3", "I4"]  # list of excluded channels
+
+    raw = read_raw_edf(edf_path, exclude=["I1", "I2", "I3", "I4"])
+    for ch in exclude:
+        assert ch not in raw.ch_names
+
+    raw = read_raw_edf(edf_path, exclude = "I[1-4]")
+    for ch in exclude:
+        assert ch not in raw.ch_names

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -522,6 +522,6 @@ def test_exclude():
     for ch in exclude:
         assert ch not in raw.ch_names
 
-    raw = read_raw_edf(edf_path, exclude = "I[1-4]")
+    raw = read_raw_edf(edf_path, exclude="I[1-4]")
     for ch in exclude:
         assert ch not in raw.ch_names

--- a/mne/io/edf/tests/test_gdf.py
+++ b/mne/io/edf/tests/test_gdf.py
@@ -132,3 +132,8 @@ def test_gdf_exclude_channels():
     raw = read_raw_gdf(gdf2_path + '.gdf', exclude=('Fp1', 'O1'))
     assert 'Fp1' not in raw.ch_names
     assert 'O1' not in raw.ch_names
+    raw = read_raw_gdf(gdf2_path + '.gdf', exclude=".+z$")
+    assert 'AFz' not in raw.ch_names
+    assert 'Cz' not in raw.ch_names
+    assert 'Pz' not in raw.ch_names
+    assert 'Oz' not in raw.ch_names

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -257,7 +257,7 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
 def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
                    bandwidth=None, adaptive=False, low_bias=True,
                    normalization='length', picks=None, proj=False,
-                   n_jobs=1, verbose=None):
+                   n_jobs=1, reject_by_annotation=False, verbose=None):
     """Compute the power spectral density (PSD) using multitapers.
 
     Calculates spectral density for orthogonal tapers, then averages them
@@ -294,6 +294,7 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     proj : bool
         Apply SSP projection vectors. If inst is ndarray this is not used.
     %(n_jobs)s
+    %(reject_by_annotation_raw)s
     %(verbose)s
 
     Returns
@@ -322,7 +323,8 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     .. footbibliography::
     """
     # Prep data
-    data, sfreq = _check_psd_data(inst, tmin, tmax, picks, proj)
+    data, sfreq = _check_psd_data(inst, tmin, tmax, picks, proj,
+                                  reject_by_annotation=reject_by_annotation)
     return psd_array_multitaper(data, sfreq, fmin=fmin, fmax=fmax,
                                 bandwidth=bandwidth, adaptive=adaptive,
                                 low_bias=low_bias, normalization=normalization,


### PR DESCRIPTION
So far the `exclude` parameter in `read_raw_{e,b,g}df` only accepts a list of channel names to be excluded. I think it would be nice if it also accepted a regex.