### PR TITLE
MRG, BUG: Fix behavior with constrained_layout=True

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -121,6 +121,8 @@ Bugs
 
 - Fix bug in :func:`mne.viz.plot_topomap` (and related methods like :meth:`mne.Evoked.plot_topomap`) where large distances between electrodes (higher than head radius) would lead to an error (:gh:`9528` by `Mikołaj Magnuski`_).
 
+- Fix bug in `mne.viz.plot_topomap` (and related methods) where passing ``axes`` that are part of a matplotlib figure that uses a constrained layout would emit warnings (:gh:`9558` by `Eric Larson`_)
+
 - Fix bug in :func:`mne.concatenate_epochs` when concatenating :class:`mne.Epochs` objects with 0 events (:gh:`9535` by `Marijn van Vliet`_)
 
 API changes

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -49,7 +49,8 @@ layout = read_layout('Vectorview-all')
 cov_fname = op.join(base_dir, 'test-cov.fif')
 
 
-def test_plot_topomap_interactive():
+@pytest.mark.parametrize('constrained_layout', (False, True))
+def test_plot_topomap_interactive(constrained_layout):
     """Test interactive topomap projection plotting."""
     evoked = read_evokeds(evoked_fname, baseline=(None, 0))[0]
     evoked.pick_types(meg='mag')
@@ -58,8 +59,8 @@ def test_plot_topomap_interactive():
     evoked.add_proj(compute_proj_evoked(evoked, n_mag=1))
 
     plt.close('all')
-    fig = plt.figure()
-    ax, canvas = fig.gca(), fig.canvas
+    fig, ax = plt.subplots(constrained_layout=constrained_layout)
+    canvas = fig.canvas
 
     kwargs = dict(vmin=-240, vmax=240, times=[0.1], colorbar=False, axes=ax,
                   res=8, time_unit='s')

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1017,7 +1017,8 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
             ax.text(p[0], p[1], ch_id, horizontalalignment='center',
                     verticalalignment='center', size='x-small')
 
-    plt.subplots_adjust(top=.95)
+    if not ax.figure.get_constrained_layout():
+        plt.subplots_adjust(top=.95)
 
     if onselect is not None:
         lim = ax.dataLim
@@ -1655,10 +1656,11 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
             raise RuntimeError(f'You must provide {want_axes} axes (one for '
                                f'each time{cbar_err}), got {len(axes)}.')
     # figure margins
-    side_margin = plt.rcParams['figure.subplot.wspace'] / (2 * want_axes)
-    top_margin = max((0.05 if title is None else 0.25), .2 / size)
-    fig.subplots_adjust(left=side_margin, right=1 - side_margin, bottom=0,
-                        top=1 - top_margin)
+    if not fig.get_constrained_layout():
+        side_margin = plt.rcParams['figure.subplot.wspace'] / (2 * want_axes)
+        top_margin = max((0.05 if title is None else 0.25), .2 / size)
+        fig.subplots_adjust(left=side_margin, right=1 - side_margin, bottom=0,
+                            top=1 - top_margin)
     # find first index that's >= (to rounding error) to each time point
     time_idx = [np.where(_time_mask(evoked.times, tmin=t, tmax=None,
                                     sfreq=evoked.info['sfreq']))[0][0]

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1240,15 +1240,15 @@ class DraggableColorbar(object):
 
     def connect(self):
         """Connect to all the events we need."""
-        self.cidpress = self.cbar.patch.figure.canvas.mpl_connect(
+        self.cidpress = self.cbar.ax.figure.canvas.mpl_connect(
             'button_press_event', self.on_press)
-        self.cidrelease = self.cbar.patch.figure.canvas.mpl_connect(
+        self.cidrelease = self.cbar.ax.figure.canvas.mpl_connect(
             'button_release_event', self.on_release)
-        self.cidmotion = self.cbar.patch.figure.canvas.mpl_connect(
+        self.cidmotion = self.cbar.ax.figure.canvas.mpl_connect(
             'motion_notify_event', self.on_motion)
-        self.keypress = self.cbar.patch.figure.canvas.mpl_connect(
+        self.keypress = self.cbar.ax.figure.canvas.mpl_connect(
             'key_press_event', self.key_press)
-        self.scroll = self.cbar.patch.figure.canvas.mpl_connect(
+        self.scroll = self.cbar.ax.figure.canvas.mpl_connect(
             'scroll_event', self.on_scroll)
 
     def on_press(self, event):
@@ -1330,7 +1330,7 @@ class DraggableColorbar(object):
         self.cbar.update_ticks()
         self.cbar.draw_all()
         self.mappable.set_norm(self.cbar.norm)
-        self.cbar.patch.figure.canvas.draw()
+        self.cbar.ax.figure.canvas.draw()
 
 
 class SelectFromCollection(object):


### PR DESCRIPTION
Fixes evoked.plot_topomap when passing axes from a fig created with `constrained_layout=True`