### PR TITLE
MRG, BUG: Fix MFF reading with skips

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -127,7 +127,9 @@ Bugs
 
 - Fix bug in :func:`mne.concatenate_epochs` when concatenating :class:`mne.Epochs` objects with 0 events (:gh:`9535` by `Marijn van Vliet`_)
 
-- Fix bug in :func:`mne.viz.Brain.screenshot` where the RGBA mode was not supported (:gh:`9561` by `Guillaume Favelier`_).
+- Fix bug in :func:`mne.viz.Brain.screenshot` where the RGBA mode was not supported (:gh:`9564` by `Guillaume Favelier`_).
+
+- Fix bug in :func:`mne.io.read_raw_egi` where reading data from a data segment that is part of an acquisition skip would lead to an error (:gh:`9565` by `Eric Larson`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2205,7 +2205,7 @@ def _write_raw_fid(raw, info, picks, fid, cals, part_idx, start, stop,
             logger.info('Skipping data chunk due to small buffer ... '
                         '[done]')
             break
-        logger.debug('Writing ...')
+        logger.debug(f'Writing FIF {first:6d} ... {last:6d} ...')
         _write_raw_buffer(fid, data, cals, fmt)
 
         pos = fid.tell()


### PR DESCRIPTION
On `main` the added test yields a variant of:
<details>

```
mne/io/egi/tests/test_egi.py:118: in test_egi_mff_pause_chunks
    raw.save(fname_temp)
<decorator-gen-192>:24: in save
    ???
mne/io/base.py:1449: in save
    _write_raw(fname, self, info, picks, fmt, data_type, reset_range,
mne/io/base.py:2108: in _write_raw
    final_fname = _write_raw_fid(
mne/io/base.py:2197: in _write_raw_fid
    data, times = raw[picks, first:last]
mne/io/base.py:773: in __getitem__
    return self._getitem(item)
mne/io/base.py:780: in _getitem
    data = self._read_segment(start=start, stop=stop, sel=sel,
<decorator-gen-185>:24: in _read_segment
    ???
mne/io/base.py:419: in _read_segment
    _ReadSegmentFileProtector(self)._read_segment_file(
mne/io/base.py:2037: in _read_segment_file
    return self.__raw.__class__._read_segment_file(
mne/io/egi/egimff.py:658: in _read_segment_file
    one[eeg_one, disk_use_idx[s_start:s_end]] = block_data[eeg_in]
E   ValueError: shape mismatch: value array of shape (257,250) could not be broadcast to indexing result of shape (257,0)
```

</details>

This PR fixes that, and by changing a `<` to `<=` makes a tiny efficiency gain where we don't accidentally read a buffer and then use zero samples from it.