### PR TITLE
matrix-based head decimation

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -43,6 +43,8 @@ Enhancements
 
 - Speed up BCD solver in :func:`mne.inverse_sparse.mixed_norm` by adding Anderson acceleration (:gh:`9481` by **new contributor** |Pierre-Antoine Bannier|_ and `Alex Gramfort`_)
 
+- Speed up point decimation in :func:`mne.io.read_raw_kit` by vectorization and use of :class:`sklearn.neighbors.BallTree` (:gh:`9568` by `Jean-Remi King`_ and `Eric Larson`_)
+
 - New function :func:`mne.chpi.get_chpi_info` to retrieve basic information about the cHPI system used when recording MEG data (:gh:`9369` by `Richard Höchenberger`_)
 
 - New namespace `mne.export` created to contain functions (such as `mne.export.export_raw` and `mne.export.export_epochs`) for exporting data to non-FIF formats (:gh:`9427` by `Eric Larson`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -43,7 +43,7 @@ Enhancements
 
 - Speed up BCD solver in :func:`mne.inverse_sparse.mixed_norm` by adding Anderson acceleration (:gh:`9481` by **new contributor** |Pierre-Antoine Bannier|_ and `Alex Gramfort`_)
 
-- Speed up point decimation in :func:`mne.io.read_raw_kit` by vectorization and use of :class:`sklearn.neighbors.BallTree` (:gh:`9568` by `Jean-Remi King`_ and `Eric Larson`_)
+- Speed up point decimation in :func:`mne.io.read_raw_kit` by vectorization and use of :class:`scipy.spatial.cKDTree` (:gh:`9568` by `Jean-Remi King`_ and `Eric Larson`_)
 
 - New function :func:`mne.chpi.get_chpi_info` to retrieve basic information about the cHPI system used when recording MEG data (:gh:`9369` by `Richard Höchenberger`_)
 

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -262,8 +262,8 @@ def _decimate_points(pts, res=10):
     out = list()
     for mi, mid in enumerate(mids):
         use_pts = pts[mid_idx == mi]
-        dists = cdist(use_pts, mid[np.newaxis])[:, 0]
-        if len(dists):
+        if len(use_pts):
+            dists = cdist(use_pts, mid[np.newaxis])[:, 0]
             idx = np.argmin(dists)
             pt = use_pts[idx]
             if np.abs(pt - mid).max() < res / 2:

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -232,22 +232,21 @@ def _decimate_points(pts, res=10):
 
     # for each voxel, select one point
     X, Y, Z = pts.T
-    out = np.empty((np.sum(H > 0), 3))
-    for i, (xbin, ybin, zbin) in enumerate(zip(*np.nonzero(H))):
-        x = xax[xbin]
-        y = yax[ybin]
-        z = zax[zbin]
-        xi = np.logical_and(X >= x, X < x + res)
-        yi = np.logical_and(Y >= y, Y < y + res)
-        zi = np.logical_and(Z >= z, Z < z + res)
-        idx = np.logical_and(zi, np.logical_and(yi, xi))
-        ipts = pts[idx]
-
-        mid = np.array([x, y, z]) + res / 2.
-        dist = cdist(ipts, [mid])
-        i_min = np.argmin(dist)
-        ipt = ipts[i_min]
-        out[i] = ipt
+    xbins, ybins, zbins = np.nonzero(H)
+    x = xax[xbins]
+    y = yax[ybins]
+    z = zax[zbins]
+    xi = (X[None] >= x[:, None]) * (X[None] < x[:, None] + res)
+    yi = (Y[None] >= y[:, None]) * (Y[None] < y[:, None] + res)
+    zi = (Z[None] >= z[:, None]) * (Z[None] < z[:, None] + res)
+    idx = xi * yi * zi
+    ipts = [pts[i] for i in idx]
+    ipts = list(filter(len, ipts))
+    mids = np.c_[x, y, z] + res / 2.
+    out = np.empty((len(ipts), 3))
+    for i, ipt in enumerate(ipts):
+        i_min = np.argmin(cdist(ipt, mids[[i]]))
+        out[i] = ipt[i_min]
 
     return out
 

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -262,13 +262,14 @@ def _decimate_points(pts, res=10):
     out = list()
     for mi, mid in enumerate(mids):
         use_pts = pts[mid_idx == mi]
-        if len(use_pts):
-            dists = cdist(use_pts, mid[np.newaxis])[:, 0]
-            idx = np.argmin(dists)
-            pt = use_pts[idx]
-            if np.abs(pt - mid).max() < res / 2:
-                out.append(pt)
+        if not len(use_pts):
+            out.append(
+                [np.inf] * 3)
+        else:
+            out.append(
+                use_pts[np.argmin(cdist(use_pts, mid[np.newaxis])[:, 0])])
     out = np.array(out, float).reshape(-1, 3)
+    out = out[np.abs(out - mids).max(axis=1) < res / 2.]
     # """
 
     return out


### PR DESCRIPTION
Head decimation can be *very* slow when the original file is highly resolved (e.g. from a laser scan) because it uses a loop.

This fixes it.