### PR TITLE
[MRG, ENH] Get annotation description from snirf stim name

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -31,9 +31,13 @@ Current (0.24.dev0)
 
 .. |Pierre-Antoine Bannier| replace:: **Pierre-Antoine Bannier**
 
+.. |Darin Erat Sleiter| replace:: **Darin Erat Sleiter**
+
 Enhancements
 ~~~~~~~~~~~~
 .. - Add something cool (:gh:`9192` **by new contributor** |New Contributor|_)
+
+- Get annotation descriptions from the name field of SNIRF stimulus groups when reading SNIRF files via `mne.io.read_raw_snirf` (:gh:`9575` **by new contributor** |Darin Erat Sleiter|_)
 
 - Add support for NIRSport and NIRSport2 devices to `mne.io.read_raw_nirx` (:gh:`9348` and :gh:`9401` **by new contributor** |David Julien|_, **new contributor** |Romain Derollepot|_, `Robert Luke`_, and `Eric Larson`_)
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -401,3 +401,5 @@
 .. _Marian Dovgialo: https://github.com/mdovgialo
 
 .. _Pierre-Antoine Bannier: https://github.com/PABannier
+
+.. _Darin Erat Sleiter: https://github.com/dsleiter

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -365,7 +365,8 @@ class RawSNIRF(BaseRaw):
                     data = np.atleast_2d(np.array(
                         dat.get('/nirs/' + key + '/data')))
                     if data.size > 0:
-                        annot.append(data[:, 0], 1.0, key[4:])
+                        desc = dat.get('/nirs/' + key + '/name')[0]
+                        annot.append(data[:, 0], 1.0, desc.decode('UTF-8'))
             self.set_annotations(annot)
 
             # Reorder channels to match expected ordering in MNE

--- a/mne/io/snirf/tests/test_snirf.py
+++ b/mne/io/snirf/tests/test_snirf.py
@@ -3,7 +3,7 @@
 #          simplified BSD-3 license
 
 import os.path as op
-from numpy.testing import assert_allclose, assert_almost_equal
+from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 import shutil
 import pytest
 
@@ -288,3 +288,12 @@ def test_snirf_standard():
     """Test standard operations."""
     _test_raw_reader(read_raw_snirf, fname=sfnirs_homer_103_wShort,
                      boundary_decimal=0)  # low fs
+
+
+@requires_testing_data
+@requires_h5py
+def test_annotation_description_from_stim_groups():
+    """Test annotation descriptions parsed from stim group names."""
+    raw = read_raw_snirf(nirx_nirsport2_103_2, preload=True)
+    expected_descriptions = ['1', '2', '6']
+    assert_equal(expected_descriptions, raw.annotations.description)


### PR DESCRIPTION
Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

#### Reference issue
Fixes #9571


#### What does this implement/fix?
Uses the 'name' field from SNIRF file stim groups as the description for Annotations rather than the index of the stim group.


#### Additional information
This is in response to https://github.com/mne-tools/mne-nirs/pull/326

This could be a breaking change for anyone who depends on annotation descriptions when reading from SNIRF files that have not been created from the update to the MNE-NIRS SNIRF writer. I'd like some guidance on whether or not I should implement a deprecation or not. I listed this as an ENH because it isn't obvious that this is a bug fix, but it is in response to a fix of what is a bug in the SNIRF writer in order to maintain consistency.


