### PR TITLE
[DO NOT MERGE]: Test workaround back

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,6 +207,7 @@ stages:
         3.8 pip pre:
           TEST_MODE: 'pip-pre'
           PYTHON_VERSION: '3.8'
+          OPENBLAS_CORETYPE: 'prescott'
     steps:
     - task: UsePythonVersion@0
       inputs:


### PR DESCRIPTION
Do not merge, just for testing the upstream NumPy fix.

We shouldn't need this workaround anymore, but it also shouldn't segfault if it's in there.