### PR TITLE
Add label to colorbar in GAT plot

### DIFF
--- a/tutorials/machine-learning/50_decoding.py
+++ b/tutorials/machine-learning/50_decoding.py
@@ -378,7 +378,8 @@ ax.set_ylabel('Training Time (s)')
 ax.set_title('Temporal generalization')
 ax.axvline(0, color='k')
 ax.axhline(0, color='k')
-plt.colorbar(im, ax=ax)
+cbar = plt.colorbar(im, ax=ax)
+cbar.set_label('AUC')
 
 # %%
 # Projecting sensor-space patterns to source space


### PR DESCRIPTION
This adds a label to the colorbar of the generalization across time (GAT) figure in the MVPA tutorial.