### PR TITLE
FIX variables not defined before assignment in BCD solver

### DIFF
--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -575,6 +575,7 @@ def mixed_norm_solver(M, G, alpha, maxit=3000, tol=1e-8, verbose=None,
     alpha_max = norm_l2inf(np.dot(G.T, M), n_orient, copy=False)
     logger.info("-- ALPHA MAX : %s" % alpha_max)
     alpha = float(alpha)
+    X = np.zeros((n_dipoles, n_times), dtype=G.dtype)
 
     has_sklearn = True
     try:
@@ -633,6 +634,7 @@ def mixed_norm_solver(M, G, alpha, maxit=3000, tol=1e-8, verbose=None,
                               np.arange(n_orient)[None, :]).ravel()
         active_set[new_active_idx] = True
         as_size = np.sum(active_set)
+        gap = np.inf
         for k in range(maxit):
             if solver == 'bcd':
                 lc_tmp = lc[active_set[::n_orient]]

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -653,7 +653,7 @@ def mixed_norm_solver(M, G, alpha, maxit=3000, tol=1e-8, verbose=None,
             highest_d_obj = max(d_obj, highest_d_obj)
             gap = p_obj - highest_d_obj
             E.append(p_obj)
-            logger.info("Iteration %d :: p_obj %f :: dgap %f ::"
+            logger.info("Iteration %d :: p_obj %f :: dgap %f :: "
                         "n_active_start %d :: n_active_end %d" % (
                             k + 1, p_obj, gap, as_size // n_orient,
                             np.sum(active_set) // n_orient))

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -128,9 +128,9 @@ def test_non_convergence():
     X[4] = -2
     M = np.dot(G, X)
 
-    # Impossible to converge with only 3 iterations and tol 1e-12
+    # Impossible to converge with only 1 iteration and tol 1e-12
     # In case of non-convegence, we test that no error is returned.
-    args = (M, G, alpha, 3, 1e-12)
+    args = (M, G, alpha, 1, 1e-12)
     with pytest.warns(None):  # CD
         mixed_norm_solver(*args, active_set_size=None, debias=True,
                           solver='prox')

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -15,6 +15,7 @@ from mne.inverse_sparse.mxne_optim import (mixed_norm_solver,
                                            norm_epsilon_inf, norm_epsilon,
                                            _Phi, _PhiT, dgap_l21l1)
 from mne.time_frequency._stft import stft_norm2
+from mne.utils import catch_logging
 
 
 def _generate_tf_data():
@@ -118,7 +119,7 @@ def test_l21_mxne():
 
 @pytest.mark.slowtest
 def test_non_convergence():
-    """Test non-convergence of MxNE solver to catch bugs."""
+    """Test non-convergence of MxNE solver to catch unexpected bugs."""
     n, p, t, alpha = 30, 40, 20, 1.
     rng = np.random.RandomState(0)
     G = rng.randn(n, p)
@@ -131,16 +132,11 @@ def test_non_convergence():
     # Impossible to converge with only 1 iteration and tol 1e-12
     # In case of non-convegence, we test that no error is returned.
     args = (M, G, alpha, 1, 1e-12)
-    with pytest.warns(None):  # CD
+    with catch_logging() as log:
         mixed_norm_solver(*args, active_set_size=None, debias=True,
-                          solver='prox')
-    with pytest.warns(None):  # CD
-        mixed_norm_solver(*args, active_set_size=None, debias=True,
-                          solver='cd', return_gap=True)
-    with pytest.warns(None):  # CD
-        mixed_norm_solver(M, G, alpha, maxit=1000, tol=1e-8,
-                          active_set_size=None, debias=True, solver='bcd',
-                          return_gap=True)
+                          solver='bcd', verbose=True)
+    log = log.getvalue()
+    assert 'Convergence reached' not in log
 
 
 def test_tf_mxne():


### PR DESCRIPTION
When running BCD solver, if the solver does not converge (fast enough), gap > tol. 

Yet, gap is only defined in the for scope and not in the else scope. This causes an UnboundLocalError.
Similar issue with X when carrying out debiasing.

I did a quick fix by defining the two variables in the function body. Tell me if the fix could be enhanced.