### PR TITLE
MRG, MAINT: Remove dead link

### DIFF
--- a/doc/overview/roadmap.rst
+++ b/doc/overview/roadmap.rst
@@ -107,8 +107,6 @@ as well as:
     Kymata atlas. The participants are healthy human adults listening to the
     radio and/or watching films, and the data is comprised of (averaged) EEG
     and MEG sensor data and source current reconstructions.
-- `BrainSignals <http://www.brainsignals.de>`__
-    A website that lists a number of MEG datasets available for download.
 - `BNCI Horizon <http://bnci-horizon-2020.eu/database/data-sets>`__
     BCI datasets.
 


### PR DESCRIPTION
http://www.brainsignals.de has been dead for two weeks now:

https://app.circleci.com/pipelines/github/mne-tools/mne-python/9115/workflows/99c1d733-2635-4541-914c-08e6ff1768a4/jobs/31207

From a quick look I couldn't find a replacement URL, so I'm just removing it unless anyone else knows the correct link.