### PR TITLE
MRG, ENH: Use discrete method

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -841,7 +841,7 @@ def reset_warnings(gallery_conf, fname):
     warnings.filterwarnings(
         'ignore', message='.*mne-realtime.*', category=DeprecationWarning)
 
-    # Because we use np.set_printoptions in some tutorials, but we only
+    # In case we use np.set_printoptions in any tutorials, we only
     # want it to affect those:
     np.set_printoptions(**_np_print_defaults)
 

--- a/doc/mri.rst
+++ b/doc/mri.rst
@@ -27,7 +27,6 @@ Step by step instructions for using :func:`gui.coregistration`:
    scale_bem
    scale_labels
    scale_source_space
-   surface.marching_cubes
    transforms.apply_volume_registration
    transforms.compute_volume_registration
    vertex_to_mni

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -104,9 +104,10 @@ class Transform(dict):
         self['trans'] = trans
 
     def __repr__(self):  # noqa: D105
-        return ('<Transform | %s->%s>\n%s'
-                % (_coord_frame_name(self['from']),
-                   _coord_frame_name(self['to']), self['trans']))
+        with np.printoptions(suppress=True):  # suppress scientific notation
+            return ('<Transform | %s->%s>\n%s'
+                    % (_coord_frame_name(self['from']),
+                       _coord_frame_name(self['to']), self['trans']))
 
     def __eq__(self, other, rtol=0., atol=0.):
         """Check for equality.

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2358,9 +2358,10 @@ class Brain(object):
         if not aseg.endswith('aseg'):
             raise RuntimeError(
                 f'`aseg` file path must end with "aseg", got {aseg}')
-        aseg_fname = _check_fname(op.join(self._subjects_dir, self._subject_id,
-                                          'mri', aseg + '.mgz'),
-                                  overwrite='read', must_exist=True)
+        aseg = _check_fname(op.join(self._subjects_dir, self._subject_id,
+                                    'mri', aseg + '.mgz'),
+                            overwrite='read', must_exist=True)
+        aseg_fname = aseg
         aseg = nib.load(aseg_fname)
         aseg_data = np.asarray(aseg.dataobj)
         vox_mri_t = aseg.header.get_vox2ras_tkr()
@@ -2383,14 +2384,13 @@ class Brain(object):
         elif not isinstance(colors, (list, tuple)):
             colors = [colors] * len(labels)  # make into list
         colors = [colorConverter.to_rgba(color, alpha) for color in colors]
-        aseg_vals = set(np.unique(aseg_data))
-        for label, color in zip(labels, colors):
-            val = lut[label]
-            if val not in aseg_vals:
-                warn(f'Value not found for label {repr(label)} in: '
-                     f'{aseg_fname}')
-            mask = (aseg_data == val)
-            verts, triangles = marching_cubes(mask, level=0.5, smooth=smooth)
+        surfs = marching_cubes(
+            aseg_data, [lut[label] for label in labels], smooth=smooth)
+        for label, color, (verts, triangles) in zip(labels, colors, surfs):
+            if len(verts) == 0:  # not in aseg vals
+                warn(f'Value {lut[label]} not found for label '
+                     f'{repr(label)} in: {aseg_fname}')
+                continue
             verts = apply_trans(vox_mri_t, verts)
             self._renderer.mesh(
                 *verts.T, triangles=triangles, color=color, opacity=alpha,

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -35,7 +35,7 @@ from .._3d import _process_clim, _handle_time, _check_views
 from ...externals.decorator import decorator
 from ...defaults import _handle_default
 from ..._freesurfer import vertex_to_mni, read_talxfm, read_freesurfer_lut
-from ...surface import mesh_edges, _mesh_borders
+from ...surface import mesh_edges, _mesh_borders, _marching_cubes
 from ...source_space import SourceSpaces
 from ...transforms import apply_trans, invert_transform
 from ...utils import (_check_option, logger, verbose, fill_doc, _validate_type,
@@ -2352,7 +2352,6 @@ class Brain(object):
         """
         import nibabel as nib
         from matplotlib.colors import colorConverter
-        from ...surface import marching_cubes
 
         # load anatomical segmentation image
         if not aseg.endswith('aseg'):
@@ -2384,7 +2383,7 @@ class Brain(object):
         elif not isinstance(colors, (list, tuple)):
             colors = [colors] * len(labels)  # make into list
         colors = [colorConverter.to_rgba(color, alpha) for color in colors]
-        surfs = marching_cubes(
+        surfs = _marching_cubes(
             aseg_data, [lut[label] for label in labels], smooth=smooth)
         for label, color, (verts, triangles) in zip(labels, colors, surfs):
             if len(verts) == 0:  # not in aseg vals

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -317,7 +317,6 @@ def test_brain_init(renderer_pyvista, tmpdir, pixel_ratio, brain_gc):
     brain.add_volume_labels(
         aseg='aseg', labels=('Brain-Stem', 'Left-Hippocampus',
                              'Left-Amygdala'))
-
     # add text
     brain.add_text(x=0, y=0, text='foo')
     brain.close()

--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -38,8 +38,6 @@ from dipy.align import resample
 import mne
 from mne.datasets import fetch_fsaverage
 
-np.set_printoptions(suppress=True)  # suppress scientific notation
-
 # paths to mne datasets - sample sEEG and FreeSurfer's fsaverage subject
 # which is in MNI space
 misc_path = mne.datasets.misc.data_path()

--- a/tutorials/clinical/20_seeg.py
+++ b/tutorials/clinical/20_seeg.py
@@ -44,8 +44,6 @@ import matplotlib.pyplot as plt
 import mne
 from mne.datasets import fetch_fsaverage
 
-np.set_printoptions(suppress=True)  # suppress scientific notation
-
 # paths to mne datasets - sample sEEG and FreeSurfer's fsaverage subject
 # which is in MNI space
 misc_path = mne.datasets.misc.data_path()
@@ -137,7 +135,7 @@ epochs.set_montage(montage)
 
 fig = mne.viz.plot_alignment(epochs.info, trans, 'fsaverage',
                              subjects_dir=subjects_dir, show_axes=True,
-                             surfaces=['pial', 'head'])
+                             surfaces=['pial', 'head'], coord_frame='mri')
 
 # %%
 # Let's also look at which regions of interest are nearby our electrode
@@ -171,7 +169,7 @@ labels = ('ctx-lh-caudalmiddlefrontal', 'ctx-lh-precentral',
 
 fig = mne.viz.plot_alignment(epochs.info.copy().pick_channels(picks), trans,
                              'fsaverage', subjects_dir=subjects_dir,
-                             surfaces=[])
+                             surfaces=[], coord_frame='mri')
 
 brain = mne.viz.Brain('fsaverage', alpha=0.1, cortex='low_contrast',
                       subjects_dir=subjects_dir, units='m', figure=fig)


### PR DESCRIPTION
@alexrockhill I also refactored the `set_printoptions` stuff to improve `Transform.__repr__` itself, but let me know if you had that context manager in there for another reason.

Todo:
- [x] Make `marching_cubes` private

Also the `20_seeg` had an incorrect coordinate frame slip in through `plot_alignment`:

![image](https://user-images.githubusercontent.com/2365790/126238626-fc6acfb2-ac78-47e2-bd82-a03d924edd12.png)

Now it looks more reasonable:

![image](https://user-images.githubusercontent.com/2365790/126241074-2ba9fc01-ed23-49c5-a32a-6ee2d41bbff3.png)
