### PR TITLE
[ENH, MRG] Update show_view API

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -113,6 +113,8 @@ Enhancements
 
 - Add :func:`mne.viz.Brain.add_volume_labels` to plot subcortical surfaces and other regions of interest (:gh:`9540` by `Alex Rockhill`_ and `Eric Larson`_)
 
+- Add split :func:`mne.viz.Brain.show_view` argument ``view`` into ``azimuth``, ``elevation`` and ``focalpoint`` for clearer view setting (:gh:`9596` by `Alex Rockhill`_)
+
 Bugs
 ~~~~
 - Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** |Jan Sosulski|_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -113,8 +113,6 @@ Enhancements
 
 - Add :func:`mne.viz.Brain.add_volume_labels` to plot subcortical surfaces and other regions of interest (:gh:`9540` by `Alex Rockhill`_ and `Eric Larson`_)
 
-- Add split :func:`mne.viz.Brain.show_view` argument ``view`` into ``azimuth``, ``elevation`` and ``focalpoint`` for clearer view setting (:gh:`9596` by `Alex Rockhill`_)
-
 Bugs
 ~~~~
 - Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** |Jan Sosulski|_)
@@ -160,3 +158,6 @@ Bugs
 API changes
 ~~~~~~~~~~~
 - In `mne.compute_source_morph`, the ``niter_affine`` and ``niter_sdr`` parameters have been replaced by ``niter`` and ``pipeline`` parameters for more consistent and finer-grained control of registration/warping steps and iteration (:gh:`9505` by `Alex Rockhill`_ and `Eric Larson`_)
+
+- Split :func:`mne.viz.Brain.show_view` argument ``view`` into ``azimuth``, ``elevation`` and ``focalpoint`` for clearer view setting and make the default for ``row`` and ``col`` apply to all rows and columns (:gh:`9596` by `Alex Rockhill`_)
+

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1654,6 +1654,33 @@ allow_duplicates : bool
 """
 
 # Brain plotting
+docdict["view"] = """
+view : str
+    The name of the view to show (e.g. "lateral"). Other arguments
+    take precedence and modify the camera starting from the ``view``.
+"""
+docdict["roll"] = """
+roll : float | None
+    The roll of the camera rendering the view in degrees.
+"""
+docdict["distance"] = """
+distance : float | None
+    The distance from the camera rendering the view to the focalpoint
+    in plot units (either m or mm).
+"""
+docdict["azimuth"] = """
+azimuth : float
+    The azimuthal angle of the camera rendering the view in degrees.
+"""
+docdict["elevation"] = """
+elevation : float
+    The The zenith angle of the camera rendering the view in degrees.
+"""
+docdict["focalpoint"] = """
+focalpoint : tuple, shape (3,) | None
+    The focal point of the camera rendering the view: (x, y, z) in
+    plot units (either m or mm).
+"""
 docdict["clim"] = """
 clim : str | dict
     Colorbar properties specification. If 'auto', set clim automatically

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2323,10 +2323,7 @@ class Brain(object):
 
         Parameters
         ----------
-        aseg : str
-            The anatomical segmentation file. Default ``aparc+aseg``. This may
-            be any anatomical segmentation file in the mri subdirectory of the
-            subject directory from the Freesurfer recon-all.
+        %(aseg)s
         labels : list
             Labeled regions of interest to plot. See
             :func:`mne.get_montage_volume_labels`
@@ -2463,7 +2460,7 @@ class Brain(object):
             self._renderer.set_camera(**views_dicts[hemi][v])
 
     def add_text(self, x, y, text, name=None, color=None, opacity=1.0,
-                 row=-1, col=-1, font_size=None, justification=None):
+                 row=None, col=None, font_size=None, justification=None):
         """Add a text to the visualization.
 
         Parameters
@@ -2482,10 +2479,10 @@ class Brain(object):
             background color).
         opacity : float
             Opacity of the text (default 1.0).
-        row : int
-            Row index of which brain to use.
-        col : int
-            Column index of which brain to use.
+        row : int | None
+            Row index of which brain to use. Default all rows.
+        col : int | None
+            Column index of which brain to use. Default all columns.
         font_size : float | None
             The font size to use.
         justification : str | None
@@ -2495,8 +2492,13 @@ class Brain(object):
         # are implemented
         # _check_option('name', name, [None])
 
-        self._renderer.text2d(x_window=x, y_window=y, text=text, color=color,
-                              size=font_size, justification=justification)
+        for h in self._hemis:
+            for ri, ci, v in self._iter_views(h):
+                if (row is None or row == ri) and (col is None or col == ci):
+                    self._renderer.subplot(ri, ci)
+                    self._renderer.text2d(x_window=x, y_window=y, text=text,
+                                          color=color, size=font_size,
+                                          justification=justification)
 
     def _configure_label_time_course(self):
         from ...label import read_labels_from_annot

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2026,9 +2026,9 @@ class Brain(object):
 
     def _iter_views(self, hemi):
         """Iterate over rows and columns that need to be added to."""
-        hemi_dict = dict(lh=[0], rh=[1], vol=[0])
+        hemi_dict = dict(lh=[0], rh=[0], vol=[0])
         if self._hemi == 'split':
-            hemi_dict.update(vol=[0, 1])
+            hemi_dict.update(rh=[1], vol=[0, 1])
         for vi, view in enumerate(self._views):
             view_dict = dict(lh=[vi], rh=[vi], vol=[vi])
             if self._hemi == 'split':
@@ -2664,6 +2664,7 @@ class Brain(object):
         ----------
         %(view)s
         %(roll)s
+        %(distance)s
         %(azimuth)s
         %(elevation)s
         %(focalpoint)s

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2689,7 +2689,7 @@ class Brain(object):
                 hemi = 'rh'
             else:
                 hemi = 'lh'
-        if isinstance(view, dict):  # deprecate at verion 0.25
+        if isinstance(view, dict):  # deprecate at version 0.25
             warn('`view` is a dict is deprecated, please use `azimuth` and '
                  '`elevation` as arguments directly to `show_view`',
                  DeprecationWarning)

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2661,8 +2661,8 @@ class Brain(object):
         Parameters
         ----------
         view : str
-            The name of the view to show (e.g. "lateral"). Takes precedence
-            over other arguments.
+            The name of the view to show (e.g. "lateral"). Other arguments
+            take precedence and modify starting from the ``view``.
         azimuth : float
             The azimuth angle of the camera rendering the view in degrees.
         elevation : float
@@ -2695,7 +2695,7 @@ class Brain(object):
         view_params = dict(azimuth=azimuth, elevation=elevation, roll=roll,
                            distance=distance, focalpoint=focalpoint)
         if view is not None:  # view string takes precedence
-            view_params.update(views_dicts[hemi].get(view))
+            view_params = dict(views_dicts[hemi].get(view), **view_params)
         xfm = self._rigid if align else None
         for h in self._hemis:
             for ri, ci, v in self._iter_views(h):

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2460,7 +2460,7 @@ class Brain(object):
             self._renderer.set_camera(**views_dicts[hemi][v])
 
     def add_text(self, x, y, text, name=None, color=None, opacity=1.0,
-                 row=None, col=None, font_size=None, justification=None):
+                 row=-1, col=-1, font_size=None, justification=None):
         """Add a text to the visualization.
 
         Parameters
@@ -2480,9 +2480,10 @@ class Brain(object):
         opacity : float
             Opacity of the text (default 1.0).
         row : int | None
-            Row index of which brain to use. Default all rows.
+            Row index of which brain to use. Default is the bottom row.
         col : int | None
-            Column index of which brain to use. Default all columns.
+            Column index of which brain to use. Default is the left-most
+            column.
         font_size : float | None
             The font size to use.
         justification : str | None
@@ -2658,8 +2659,8 @@ class Brain(object):
 
     @fill_doc
     def show_view(self, view=None, roll=None, distance=None,
-                  azimuth=None, elevation=None, focalpoint=None,
-                  row=None, col=None, hemi=None, align=True):
+                  row='deprecated', col='deprecated', hemi=None, align=True,
+                  azimuth=None, elevation=None, focalpoint=None):
         """Orient camera to display view.
 
         Parameters
@@ -2667,9 +2668,6 @@ class Brain(object):
         %(view)s
         %(roll)s
         %(distance)s
-        %(azimuth)s
-        %(elevation)s
-        %(focalpoint)s
         row : int | None
             The row to set. Default all rows.
         col : int | None
@@ -2681,6 +2679,9 @@ class Brain(object):
             directions (closest to MNI for the subject) rather than native MRI
             space. This helps when MRIs are not in standard orientation (e.g.,
             have large rotations).
+        %(azimuth)s
+        %(elevation)s
+        %(focalpoint)s
         """
         hemi = self._hemi if hemi is None else hemi
         if hemi == 'split':
@@ -2698,6 +2699,15 @@ class Brain(object):
             if elevation is None and 'elevation' in view:
                 elevation = view['elevation']
             view = None
+        if (row == 'deprecated' or col == 'deprecated') and \
+                len([_ for h in self._hemis for _ in self._iter_views(h)]) > 1:
+            warn('`row` and `col` default behavior is changing, in version '
+                 '0.25 the default behavior will be to apply `show_view` to '
+                 'all views', DeprecationWarning)
+        if row == 'deprecated':
+            row = None
+        if col == 'deprecated':
+            col = None
         view_params = dict(azimuth=azimuth, elevation=elevation, roll=roll,
                            distance=distance, focalpoint=focalpoint)
         if view is not None:  # view string takes precedence

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2689,7 +2689,7 @@ class Brain(object):
                 hemi = 'rh'
             else:
                 hemi = 'lh'
-        if isinstance(view, dict):
+        if isinstance(view, dict):  # deprecate at verion 0.25
             warn('`view` is a dict is deprecated, please use `azimuth` and '
                  '`elevation` as arguments directly to `show_view`',
                  DeprecationWarning)
@@ -2697,6 +2697,7 @@ class Brain(object):
                 azimuth = view['azimuth']
             if elevation is None and 'elevation' in view:
                 elevation = view['elevation']
+            view = None
         view_params = dict(azimuth=azimuth, elevation=elevation, roll=roll,
                            distance=distance, focalpoint=focalpoint)
         if view is not None:  # view string takes precedence

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2701,6 +2701,8 @@ class Brain(object):
         view_params = dict(azimuth=azimuth, elevation=elevation, roll=roll,
                            distance=distance, focalpoint=focalpoint)
         if view is not None:  # view string takes precedence
+            view_params = {param: val for param, val in view_params.items()
+                           if val is not None}  # no overwriting with None
             view_params = dict(views_dicts[hemi].get(view), **view_params)
         xfm = self._rigid if align else None
         for h in self._hemis:

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -567,7 +567,7 @@ def test_brain_time_viewer(renderer_interactive_pyvista, pixel_ratio,
     # (it keeps the window size and expands the 3D area when the interface
     # is toggled off)
     brain.toggle_interface(value=True)
-    brain.show_view(view=dict(azimuth=180., elevation=90.))
+    brain.show_view(azimuth=180., elevation=90.)
     img = brain.screenshot(mode='rgb')
     want_shape = np.array([300 * pixel_ratio, 300 * pixel_ratio, 3])
     assert_allclose(img.shape, want_shape)

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -340,12 +340,11 @@ def test_brain_init(renderer_pyvista, tmpdir, pixel_ratio, brain_gc):
     for a, b, p, color in zip(annots, borders, alphas, colors):
         brain.add_annotation(a, b, p, color=color)
 
-    view_args = dict(view=dict(focalpoint=(1e-5, 1e-5, 1e-5)),
-                     roll=1, distance=500)
+    view_args = dict(roll=1, distance=500, focalpoint=(1e-5, 1e-5, 1e-5))
     cam = brain._renderer.figure.plotter.camera
     previous_roll = cam.GetRoll()
     brain.show_view(**view_args)
-    assert np.allclose(cam.GetFocalPoint(), view_args["view"]["focalpoint"])
+    assert np.allclose(cam.GetFocalPoint(), view_args["focalpoint"])
     assert np.allclose(cam.GetDistance(), view_args["distance"])
     assert np.allclose(cam.GetRoll(), previous_roll + view_args["roll"])
     del view_args
@@ -358,12 +357,14 @@ def test_brain_init(renderer_pyvista, tmpdir, pixel_ratio, brain_gc):
     fp = np.array(
         brain._renderer.figure.plotter.renderer.ComputeVisiblePropBounds())
     fp = (fp[1::2] + fp[::2]) * 0.5
-    view_args = dict(azimuth=180., elevation=90., focalpoint='auto')
-    brain.show_view(view=view_args)
-    assert np.allclose(brain._renderer.figure._azimuth, view_args["azimuth"])
-    assert np.allclose(
-        brain._renderer.figure._elevation, view_args["elevation"])
-    assert np.allclose(cam.GetFocalPoint(), fp)
+    azimuth, elevation = 180., 90.
+    for view_args in (dict(azimuth=azimuth, elevation=elevation,
+                           focalpoint='auto'),
+                      dict(view='lateral', hemi='lh')):
+        brain.show_view(**view_args)
+        assert np.allclose(brain._renderer.figure._azimuth, azimuth)
+        assert np.allclose(brain._renderer.figure._elevation, elevation)
+        assert np.allclose(cam.GetFocalPoint(), fp)
     del view_args
     img = brain.screenshot(mode='rgba')
     want_size = np.array([size[0] * pixel_ratio, size[1] * pixel_ratio, 4])

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -344,9 +344,9 @@ def test_brain_init(renderer_pyvista, tmpdir, pixel_ratio, brain_gc):
     cam = brain._renderer.figure.plotter.camera
     previous_roll = cam.GetRoll()
     brain.show_view(**view_args)
-    assert np.allclose(cam.GetFocalPoint(), view_args["focalpoint"])
-    assert np.allclose(cam.GetDistance(), view_args["distance"])
-    assert np.allclose(cam.GetRoll(), previous_roll + view_args["roll"])
+    assert_allclose(cam.GetFocalPoint(), view_args["focalpoint"])
+    assert_allclose(cam.GetDistance(), view_args["distance"])
+    assert_allclose(cam.GetRoll(), previous_roll + view_args["roll"])
     del view_args
 
     with pytest.warns(DeprecationWarning, match='`view` is a dict'):

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -362,9 +362,9 @@ def test_brain_init(renderer_pyvista, tmpdir, pixel_ratio, brain_gc):
                            focalpoint='auto'),
                       dict(view='lateral', hemi='lh')):
         brain.show_view(**view_args)
-        assert np.allclose(brain._renderer.figure._azimuth, azimuth)
-        assert np.allclose(brain._renderer.figure._elevation, elevation)
-        assert np.allclose(cam.GetFocalPoint(), fp)
+        assert_allclose(brain._renderer.figure._azimuth, azimuth)
+        assert_allclose(brain._renderer.figure._elevation, elevation)
+        assert_allclose(cam.GetFocalPoint(), fp)
     del view_args
     img = brain.screenshot(mode='rgba')
     want_size = np.array([size[0] * pixel_ratio, size[1] * pixel_ratio, 4])

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -567,7 +567,9 @@ def test_brain_time_viewer(renderer_interactive_pyvista, pixel_ratio,
     # (it keeps the window size and expands the 3D area when the interface
     # is toggled off)
     brain.toggle_interface(value=True)
-    brain.show_view(azimuth=180., elevation=90.)
+    with pytest.warns(DeprecationWarning,
+                      match='`row` and `col` default behavior is changing'):
+        brain.show_view(azimuth=180., elevation=90.)
     img = brain.screenshot(mode='rgb')
     want_shape = np.array([300 * pixel_ratio, 300 * pixel_ratio, 3])
     assert_allclose(img.shape, want_shape)

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -349,6 +349,9 @@ def test_brain_init(renderer_pyvista, tmpdir, pixel_ratio, brain_gc):
     assert np.allclose(cam.GetRoll(), previous_roll + view_args["roll"])
     del view_args
 
+    with pytest.warns(DeprecationWarning, match='`view` is a dict'):
+        brain.show_view(view=dict(azimuth=180., elevation=90.))
+
     # image and screenshot
     fname = path.join(str(tmpdir), 'test.png')
     assert not path.isfile(fname)

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -14,7 +14,7 @@ import importlib
 
 from ._utils import VALID_3D_BACKENDS
 from ...utils import (logger, verbose, get_config, _check_option,
-                      _require_version)
+                      _require_version, fill_doc)
 
 MNE_3D_BACKEND = None
 MNE_3D_BACKEND_TESTING = False
@@ -205,6 +205,7 @@ def _use_test_3d_backend(backend_name, interactive=False):
         MNE_3D_BACKEND_TESTING = orig_testing
 
 
+@fill_doc
 def set_3d_view(figure, azimuth=None, elevation=None,
                 focalpoint=None, distance=None, roll=None,
                 reset_camera=True):
@@ -214,16 +215,11 @@ def set_3d_view(figure, azimuth=None, elevation=None,
     ----------
     figure : object
         The scene which is modified.
-    azimuth : float
-        The azimuthal angle of the view.
-    elevation : float
-        The zenith angle of the view.
-    focalpoint : tuple, shape (3,)
-        The focal point of the view: (x, y, z).
-    distance : float
-        The distance to the focal point.
-    roll : float
-        The view roll.
+    %(azimuth)s
+    %(elevation)s
+    %(focalpoint)s
+    %(distance)s
+    %(roll)s
     reset_camera : bool
        If True, reset the camera properties beforehand.
     """


### PR DESCRIPTION
Fixes #9597
Fixes #9595

So it looks like `focalpoint` was already an option as a keyword argument of `view` in `mne.viz.Brain.show_view`. I thought it would be helpful to pull all the arguments out of the keyword argument to be documented and explain clearly that if a string such as 'lateral' is passed, it will take precedence as that way seems clear to me. All the arguments could also all be keyword arguments of `view` as in `mne.viz.Brain.add_volume_labels(legend=...)`, that's an easy change, doesn't make a lot of sense to do it half and half. 

The other part that is changed is that if `hemi=None` then it is assigned to volume which is already in use as for volume data/as a catchall term. I think this makes it a bit cleaner and clearer what's going on with the views, to me at least.

Just an idea for how to make things a bit simpler hopefully.