### PR TITLE
MRG, BUG: Catch bad input to setup_volume_source_space

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -145,6 +145,8 @@ Bugs
 
 - Ensure `mne.io.Raw.get_montage` works with SNIRF data (:gh:`9524` by `Robert Luke`_)
 
+- Fix bug in :func:`mne.setup_volume_source_space` where non-finite positions could be used in a discrete source space (:gh:`9603` by `Eric Larson`_)
+
 - Fix bug in :func:`mne.viz.plot_topomap` (and related methods like :meth:`mne.Evoked.plot_topomap`) where large distances between electrodes (higher than head radius) would lead to an error (:gh:`9528` by `Mikołaj Magnuski`_).
 
 - Fix bug in `mne.viz.plot_topomap` (and related methods) where passing ``axes`` that are part of a matplotlib figure that uses a constrained layout would emit warnings (:gh:`9558` by `Eric Larson`_)
@@ -162,4 +164,3 @@ API changes
 - In `mne.compute_source_morph`, the ``niter_affine`` and ``niter_sdr`` parameters have been replaced by ``niter`` and ``pipeline`` parameters for more consistent and finer-grained control of registration/warping steps and iteration (:gh:`9505` by `Alex Rockhill`_ and `Eric Larson`_)
 
 - Split :func:`mne.viz.Brain.show_view` argument ``view`` into ``azimuth``, ``elevation`` and ``focalpoint`` for clearer view setting and make the default for ``row`` and ``col`` apply to all rows and columns (:gh:`9596` by `Alex Rockhill`_)
-

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -486,10 +486,11 @@ def src_volume_labels():
     """Create a 7mm source space with labels."""
     pytest.importorskip('nibabel')
     volume_labels = mne.get_volume_labels_from_aseg(fname_aseg)
-    src = mne.setup_volume_source_space(
-        'sample', 7., mri='aseg.mgz', volume_label=volume_labels,
-        add_interpolator=False, bem=fname_bem,
-        subjects_dir=subjects_dir)
+    with pytest.warns(RuntimeWarning, match='Found no usable.*Left-vessel.*'):
+        src = mne.setup_volume_source_space(
+            'sample', 7., mri='aseg.mgz', volume_label=volume_labels,
+            add_interpolator=False, bem=fname_bem,
+            subjects_dir=subjects_dir)
     lut, _ = mne.read_freesurfer_lut()
     assert len(volume_labels) == 46
     assert volume_labels[0] == 'Unknown'

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -306,8 +306,8 @@ def test_forward_mixed_source_space(tmpdir):
     vol_labels = rng.choice(label_names, 2)
     with pytest.warns(RuntimeWarning, match='Found no usable.*CC_Mid_Ant.*'):
         vol1 = setup_volume_source_space('sample', pos=20., mri=fname_aseg,
-                                        volume_label=vol_labels[0],
-                                        add_interpolator=False)
+                                         volume_label=vol_labels[0],
+                                         add_interpolator=False)
     vol2 = setup_volume_source_space('sample', pos=20., mri=fname_aseg,
                                      volume_label=vol_labels[1],
                                      add_interpolator=False)

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -304,9 +304,10 @@ def test_forward_mixed_source_space(tmpdir):
     # setup two volume source spaces
     label_names = get_volume_labels_from_aseg(fname_aseg)
     vol_labels = rng.choice(label_names, 2)
-    vol1 = setup_volume_source_space('sample', pos=20., mri=fname_aseg,
-                                     volume_label=vol_labels[0],
-                                     add_interpolator=False)
+    with pytest.warns(RuntimeWarning, match='Found no usable.*CC_Mid_Ant.*'):
+        vol1 = setup_volume_source_space('sample', pos=20., mri=fname_aseg,
+                                        volume_label=vol_labels[0],
+                                        add_interpolator=False)
     vol2 = setup_volume_source_space('sample', pos=20., mri=fname_aseg,
                                      volume_label=vol_labels[1],
                                      add_interpolator=False)

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1654,8 +1654,9 @@ def _make_discrete_source_space(pos, coord_frame='mri'):
     rr = np.array(pos['rr'], float)
     nn = np.array(pos['nn'], float)
     if not (rr.ndim == nn.ndim == 2 and nn.shape[0] == nn.shape[0] and
-            rr.shape[1] == nn.shape[1]):
-        raise RuntimeError('"rr" and "nn" must both be 2D arrays with '
+            rr.shape[1] == nn.shape[1] and np.isfinite(rr).all() and
+            np.isfinite(nn).all()):
+        raise RuntimeError('"rr" and "nn" must both be finite 2D arrays with '
                            'the same number of rows and 3 columns')
     npts = rr.shape[0]
     _normalize_vectors(nn)

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1773,6 +1773,10 @@ def _make_volume_source_space(surf, grid, exclude, mindist, mri=None,
             n_good = good.sum()
             logger.info('    Selected %d voxel%s from %s'
                         % (n_good, _pl(n_good), volume_label))
+            if n_good == 0:
+                warn('Found no usable vertices in volume label '
+                     f'{repr(volume_label)} (id={id_}) using a '
+                     f'{grid * 1000:0.1f} mm grid')
             # Update source info
             sp['inuse'][sp['vertno'][~good]] = False
             sp['vertno'] = sp['vertno'][good]

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -270,12 +270,16 @@ def test_discrete_source_space(tmpdir):
     _compare_source_spaces(src_c, src_c2)
 
     # now do MRI
-    pytest.raises(ValueError, setup_volume_source_space, 'sample',
-                  pos=pos_dict, mri=fname_mri)
+    with pytest.raises(ValueError, match='Cannot create interpolation'):
+        setup_volume_source_space('sample', pos=pos_dict, mri=fname_mri)
     assert repr(src_new).split('~')[0] == repr(src_c).split('~')[0]
     assert ' kB' in repr(src_new)
     assert src_new.kind == 'discrete'
     assert _get_src_type(src_new, None) == 'discrete'
+
+    with pytest.raises(RuntimeError, match='finite'):
+        setup_volume_source_space(
+            pos=dict(rr=[[0, 0, float('inf')]], nn=[[0, 1, 0]]))
 
 
 @requires_nibabel()

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -615,10 +615,11 @@ def test_source_space_exclusive_complete(src_volume_labels):
     for si, s in enumerate(src):
         assert_allclose(src_full[0]['rr'], s['rr'], atol=1e-6)
     # also check single_volume=True -- should be the same result
-    src_single = setup_volume_source_space(
-        src[0]['subject_his_id'], 7., 'aseg.mgz', bem=fname_bem,
-        volume_label=volume_labels, single_volume=True, add_interpolator=False,
-        subjects_dir=subjects_dir)
+    with pytest.warns(RuntimeWarning, match='Found no usable.*Left-vessel.*'):
+        src_single = setup_volume_source_space(
+            src[0]['subject_his_id'], 7., 'aseg.mgz', bem=fname_bem,
+            volume_label=volume_labels, single_volume=True,
+            add_interpolator=False, subjects_dir=subjects_dir)
     assert len(src_single) == 1
     assert 'Unknown+Left-Cerebral-White-Matter+Left-' in repr(src_single)
     assert_array_equal(src_full[0]['vertno'], src_single[0]['vertno'])


### PR DESCRIPTION
I did ~~a bad thing~~ two bad things in my code, and this would have made it clear sooner rather than later (when I got `np.nan` in my forward solution).