### PR TITLE
MRG: Make it clearer that certain ICA.fit() params only apply to Raw

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -117,6 +117,8 @@ Enhancements
 
 - Add :meth:`mne.channels.DigMontage.apply_trans` to apply a transform directly to a montage (:gh:`9601` by `Alex Rockhill`_)
 
+- :meth:`mne.preprocessing.ICA.fit` now emits a warning if any of the ``start``, ``stop``, ``reject``, and ``flat`` parameters are passed when performing ICA on `~mne.Epochs`. These parameters only have an effect on `~mne.io.Raw` data and were previously silently ignored in the case of `~mne.Epochs` (:gh:`9605` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 - Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** |Jan Sosulski|_)

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -502,9 +502,8 @@ class ICA(ContainsMixin):
                       `~mne.io.Raw` data. For `~mne.Epochs`, perform PTP
                       rejection via :meth:`~mne.Epochs.drop_bad`.
 
-            Valid keys are ``'grad'``, ``'mag'``, ``'eeg'``, ``'seeg'``,
-            ``'dbs'``, ``'ecog'``, ``'eog'``, ``'ecg'``, ``'hbo'``, ``'hbr'``,
-            and ``'emg'``.
+            Valid keys are all channel types present in the data. Values must
+            by integers or floats.
 
             If ``None``, no PTP-based rejection will be performed. Example::
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -485,13 +485,13 @@ class ICA(ContainsMixin):
             the first sample and to the last sample, respectively.
 
             .. note:: These parameters only have an effect if ``inst`` is
-                      `~mne.Raw` data.
+                      `~mne.io.Raw` data.
         decim : int | None
             Increment for selecting only each n-th sampling point. If ``None``,
             all samples  between ``start`` and ``stop`` (inclusive) are used.
 
             .. note:: This parameter only has an effect if ``inst`` is
-                      `~mne.Raw` data.
+                      `~mne.io.Raw` data.
         reject, flat : dict | None
             Rejection parameters based on peak-to-peak amplitude (PTP)
             in the continuous data. Signal periods exceeding the thresholds
@@ -499,8 +499,8 @@ class ICA(ContainsMixin):
             removed before fitting the ICA.
 
             .. note:: These parameters only have an effect if ``inst`` is
-                      `~mne.Raw` data. For `~mne.Epochs`, perform PTP rejection
-                      via :meth:`~mne.Epochs.drop_bad`.
+                      `~mne.io.Raw` data. For `~mne.Epochs`, perform PTP
+                      rejection via :meth:`~mne.Epochs.drop_bad`.
 
             Valid keys are ``'grad'``, ``'mag'``, ``'eeg'``, ``'seeg'``,
             ``'dbs'``, ``'ecog'``, ``'eog'``, ``'ecg'``, ``'hbo'``, ``'hbr'``,
@@ -519,7 +519,7 @@ class ICA(ContainsMixin):
             Length of data chunks for artifact rejection in seconds.
 
             .. note:: This parameter only has an effect if ``inst`` is
-                      `~mne.Raw` data.
+                      `~mne.io.Raw` data.
         %(reject_by_annotation_raw)s
 
             .. versionadded:: 0.14.0

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -479,38 +479,47 @@ class ICA(ContainsMixin):
             The data to be decomposed.
         %(picks_good_data_noref)s
             This selection remains throughout the initialized ICA solution.
-        start : int | float | None
-            First sample to include. If float, data will be interpreted as
-            time in seconds. If None, data will be used from the first sample.
-        stop : int | float | None
-            Last sample to not include. If float, data will be interpreted as
-            time in seconds. If None, data will be used to the last sample.
+        start, stop : int | float | None
+            First and last sample to include. If float, data will be
+            interpreted as time in seconds. If ``None``, data will be used from
+            the first sample and to the last sample, respectively.
+
+            .. note:: These parameters only have an effect if ``inst`` is
+                      `~mne.Raw` data.
         decim : int | None
-            Increment for selecting each nth time slice. If None, all samples
-            within ``start`` and ``stop`` are used.
-        reject : dict | None
-            Rejection parameters based on peak-to-peak amplitude.
-            Valid keys are 'grad', 'mag', 'eeg', 'seeg', 'dbs', 'ecog', 'eog',
-            'ecg', 'hbo', 'hbr'.
-            If reject is None then no rejection is done. Example::
+            Increment for selecting only each n-th sampling point. If ``None``,
+            all samples  between ``start`` and ``stop`` (inclusive) are used.
 
-                reject = dict(grad=4000e-13, # T / m (gradiometers)
-                              mag=4e-12, # T (magnetometers)
-                              eeg=40e-6, # V (EEG channels)
-                              eog=250e-6 # V (EOG channels)
-                              )
+            .. note:: This parameter only has an effect if ``inst`` is
+                      `~mne.Raw` data.
+        reject, flat : dict | None
+            Rejection parameters based on peak-to-peak amplitude (PTP)
+            in the continuous data. Signal periods exceeding the thresholds
+            in ``reject`` or less than the thresholds in ``flat`` will be
+            removed before fitting the ICA.
 
-            It only applies if ``inst`` is of type Raw.
-        flat : dict | None
-            Rejection parameters based on flatness of signal.
-            Valid keys are 'grad', 'mag', 'eeg', 'seeg', 'dbs', 'ecog', 'eog',
-            'ecg', 'hbo', 'hbr'.
-            Values are floats that set the minimum acceptable peak-to-peak
-            amplitude. If flat is None then no rejection is done.
-            It only applies if ``inst`` is of type Raw.
+            .. note:: These parameters only have an effect if ``inst`` is
+                      `~mne.Raw` data. For `~mne.Epochs`, perform PTP rejection
+                      via :meth:`~mne.Epochs.drop_bad`.
+
+            Valid keys are ``'grad'``, ``'mag'``, ``'eeg'``, ``'seeg'``,
+            ``'dbs'``, ``'ecog'``, ``'eog'``, ``'ecg'``, ``'hbo'``, ``'hbr'``,
+            and ``'emg'``.
+
+            If ``None``, no PTP-based rejection will be performed. Example::
+
+                reject = dict(
+                    grad=4000e-13, # T / m (gradiometers)
+                    mag=4e-12, # T (magnetometers)
+                    eeg=40e-6, # V (EEG channels)
+                    eog=250e-6 # V (EOG channels)
+                )
+                flat = None  # no rejection based on flatness
         tstep : float
             Length of data chunks for artifact rejection in seconds.
-            It only applies if ``inst`` is of type Raw.
+
+            .. note:: This parameter only has an effect if ``inst`` is
+                      `~mne.Raw` data.
         %(reject_by_annotation_raw)s
 
             .. versionadded:: 0.14.0
@@ -532,6 +541,19 @@ class ICA(ContainsMixin):
             warn('The epochs you passed to ICA.fit() were baseline-corrected. '
                  'However, we suggest to fit ICA only on data that has been '
                  'high-pass filtered, but NOT baseline-corrected.')
+
+        if not isinstance(inst, BaseRaw):
+            ignored_params = [
+                param_name for param_name, param_val in zip(
+                    ('start', 'stop', 'decim', 'reject', 'flat'),
+                    (start, stop, decim, reject, flat)
+                )
+                if param_val is not None
+            ]
+            if ignored_params:
+                warn(f'The following parameters passed to ICA.fit() will be '
+                     f'ignored, as they only affect raw data (and it appears '
+                     f'you passed epochs): {", ".join(ignored_params)}')
 
         picks = _picks_to_idx(inst.info, picks, allow_empty=False,
                               with_ref_meg=self.allow_ref_meg)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -1101,8 +1101,6 @@ def test_fit_params_epochs_vs_raw(param_name, param_val):
     ica = ICA(n_components=n_components, max_iter=max_iter, method=method)
 
     fit_params = {param_name: param_val}
-
-    ica.fit(inst=raw, **fit_params)  # should not warn
     with pytest.warns(RuntimeWarning, match='parameters.*will be ignored'):
         ica.fit(inst=epochs, **fit_params)
 

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -1101,7 +1101,7 @@ def test_fit_params_epochs_vs_raw(param_name, param_val):
     ica = ICA(n_components=n_components, max_iter=max_iter, method=method)
 
     fit_params = {param_name: param_val}
-    
+
     ica.fit(inst=raw, **fit_params)  # should not warn
     with pytest.warns(RuntimeWarning, match='parameters.*will be ignored'):
         ica.fit(inst=epochs, **fit_params)


### PR DESCRIPTION
Users tend to pass `reject` to `ICA.fit()` even when supplying an `Epochs` object. I'm trying to make it unmistakably clear that certain params only apply to `Raw`, and even emit warnings if "raw-only" params are passed together with `Epochs`. Also merged the docstrings for `start, stop` and `reject, flat`.

cc @drammock