### PR TITLE
MRG, BUG: Fix reading KIT data with fewer HPI coils

### DIFF
--- a/.github/workflows/compat_minimal.yml
+++ b/.github/workflows/compat_minimal.yml
@@ -55,7 +55,7 @@ jobs:
         run: ./tools/get_testing_version.sh
         name: 'Get testing version'
       - shell: bash -el {0}
-        run: MNE_SKIP_TESTING_DATASET_TESTS=true pytest -m "${CONDITION}" --tb=short --cov=mne --cov-report xml -vv -rfE mne/
+        run: MNE_SKIP_TESTING_DATASET_TESTS=true pytest -m "not ultraslowtest" --tb=short --cov=mne --cov-report xml -vv -rfE mne/
         name: Run tests with no testing data
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/compat_minimal.yml
+++ b/.github/workflows/compat_minimal.yml
@@ -27,7 +27,6 @@ jobs:
       MNE_FORCE_SERIAL: true
       MNE_LOGGING_LEVEL: 'warning'
       MNE_SKIP_NETWORK_TEST: 1
-      MNE_SKIP_TESTING_DATASET_TESTS: true
       OPENBLAS_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
       PYTHON_VERSION: '3.7'
@@ -55,6 +54,9 @@ jobs:
       - shell: bash -el {0}
         run: ./tools/get_testing_version.sh
         name: 'Get testing version'
+      - shell: bash -el {0}
+        run: MNE_SKIP_TESTING_DATASET_TESTS=true pytest -m "${CONDITION}" --tb=short --cov=mne --cov-report xml -vv -rfE mne/
+        name: Run tests with no testing data
       - uses: actions/cache@v2
         with:
           key: ${{ env.TESTING_VERSION }}

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -135,7 +135,7 @@ Bugs
 
 - Fix bug with `mne.io.read_raw_fieldtrip` and `mne.read_epochs_fieldtrip` where channel positions were not set properly (:gh:`9447` by `Eric Larson`_)
 
-- Fix bug with :func:`mne.io.read_raw_kit` where omitting HPI coils could lead to an AssertionError on reading (:gh:`9612` by `Eric Larson`_)
+- Fix bug with :func:`mne.io.read_raw_kit` where omitting HPI coils could lead to an :exc:`python:AssertionError` on reading (:gh:`9612` by `Eric Larson`_)
 
 - Fix bug with `mne.preprocessing.nirs.optical_density` where protection against zero values was not guaranteed (:gh:`9522` by `Eric Larson`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -135,6 +135,8 @@ Bugs
 
 - Fix bug with `mne.io.read_raw_fieldtrip` and `mne.read_epochs_fieldtrip` where channel positions were not set properly (:gh:`9447` by `Eric Larson`_)
 
+- Fix bug with :func:`mne.io.read_raw_kit` where omitting HPI coils could lead to an AssertionError on reading (:gh:`9612` by `Eric Larson`_)
+
 - Fix bug with `mne.preprocessing.nirs.optical_density` where protection against zero values was not guaranteed (:gh:`9522` by `Eric Larson`_)
 
 - :func:`mne.concatenate_raws` now raises an exception if ``raw.info['dev_head_t']`` differs between files. This behavior can be controlled using the new ``on_mismatch`` parameter (:gh:`9438` by `Richard Höchenberger`_)

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -254,7 +254,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.121', misc='0.18')
+    releases = dict(testing='0.122', misc='0.18')
     # And also update the "md5_hashes['testing']" variable below.
     # To update any other dataset, update the data archive itself (upload
     # an updated version) and update the md5 hash.
@@ -349,7 +349,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='12b75d1cb7df9dfb4ad73ed82f61094f',
         somato='32fd2f6c8c7eb0784a1de6435273c48b',
         spm='9f43f67150e3b694b523a21eb929ea75',
-        testing='570186827dfdc1d454675dab552441c6',
+        testing='3da5aacbed94282e69ed250fdecbb3e6',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         fnirs_motor='c4935d19ddab35422a69f3326a01fef8',
         opm='370ad1dcfd5c47e029e692c85358a374',

--- a/mne/io/artemis123/tests/test_artemis123.py
+++ b/mne/io/artemis123/tests/test_artemis123.py
@@ -55,6 +55,7 @@ def test_artemis_reader():
 
 
 @pytest.mark.timeout(60)
+@testing.requires_testing_data
 def test_dev_head_t():
     """Test dev_head_t computation for Artemis123."""
     # test a random selected point

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -104,6 +104,7 @@ def test_egi_mff_pause(fname, skip_times, event_times):
         assert skip == skip_times[ii]
 
 
+@requires_testing_data
 @pytest.mark.parametrize('fname', [
     egi_pause_fname,
     egi_eprime_pause_fname,

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -733,6 +733,7 @@ def get_kit_info(rawfile, allow_unknown_format, standardize_names=None,
             # coregistration
             fid.seek(cor_dir['offset'])
             mrk = np.zeros((elp.shape[0] - 3, 3))
+            meg_done = [True] * 5
             for _ in range(cor_dir['count']):
                 done = np.fromfile(fid, INT32, 1)[0]
                 fid.seek(16 * KIT.DOUBLE +  # meg_to_mri
@@ -743,12 +744,17 @@ def get_kit_info(rawfile, allow_unknown_format, standardize_names=None,
                     continue
                 assert marker_count >= len(mrk)
                 for mi in range(len(mrk)):
-                    mri_type, meg_type, mri_done, meg_done = \
+                    mri_type, meg_type, mri_done, this_meg_done = \
                         np.fromfile(fid, INT32, 4)
-                    assert meg_done
+                    meg_done[mi] = bool(this_meg_done)
                     fid.seek(3 * KIT.DOUBLE, SEEK_CUR)  # mri_pos
                     mrk[mi] = np.fromfile(fid, FLOAT64, 3)
                 fid.seek(256, SEEK_CUR)  # marker_file (char)
+            if not all(meg_done):
+                logger.info(f'Keeping {sum(meg_done)}/{len(meg_done)} HPI '
+                            'coils that were digitized')
+                elp = elp[[True] * 3 + meg_done]
+                mrk = mrk[meg_done]
             sqd.update(hsp=hsp, elp=elp, mrk=mrk)
 
     # precompute conversion factor for reading data

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -49,6 +49,8 @@ ricoh_systems_paths += [op.join(
     data_path, 'KIT', 'Example_RICOH160-1_10020-export_anonymyze.con')]
 ricoh_systems_paths += [op.join(
     data_path, 'KIT', 'Example_RICOH160-1_10021-export_anonymyze.con')]
+ricoh_systems_paths += [op.join(
+    data_path, 'KIT', '010409_Motor_task_coregist-export_tiny_1s.con')]
 berlin_path = op.join(data_path, 'KIT', 'data_berlin.con')
 
 
@@ -330,10 +332,13 @@ def test_decimate(tmpdir):
         'RICOH MEG System (10020) V3R000 RICOH160-1', 10020),
     (ricoh_systems_paths[2],
         'RICOH MEG System (10021) V3R000 RICOH160-1', 10021),
+    (ricoh_systems_paths[3],
+        'Yokogawa Electric Corporation/MEG device for infants/151-channel MEG '
+        'System (903) V2R004 PQ1151R', 903),
 ])
-def test_ricoh_systems(tmpdir, fname, desc, system_id):
-    """Test reading channel names and dig information from Ricoh systems."""
-    raw = read_raw_kit(fname, standardize_names=False)
+def test_raw_system_id(fname, desc, system_id):
+    """Test reading basics and system IDs."""
+    raw = _test_raw_reader(read_raw_kit, input_fname=fname)
     assert raw.info['description'] == desc
     assert raw.info['kit_system_id'] == system_id
 

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -308,6 +308,7 @@ def test_calculate_chpi_positions_vv():
         _calculate_chpi_positions(raw)
 
 
+@testing.requires_testing_data
 @pytest.mark.slowtest
 def test_calculate_chpi_snr():
     """Test cHPI SNR calculation."""

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -152,6 +152,7 @@ def plot_cov(cov, info, exclude=(), colorbar=True, proj=False, show_svd=True,
             from mpl_toolkits.axes_grid1 import make_axes_locatable
             divider = make_axes_locatable(axes[0, k])
             cax = divider.append_axes("right", size="5.5%", pad=0.05)
+            cax.grid(False)  # avoid mpl warning about auto-removal
             plt.colorbar(im, cax=cax, format='%.0e')
 
     fig_cov.subplots_adjust(0.04, 0.0, 0.98, 0.94, 0.2, 0.26)

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -249,6 +249,7 @@ def test_plot_csd():
     plot_csd(csd, mode='coh')  # Plot coherence
 
 
+@testing.requires_testing_data
 def test_plot_chpi_snr():
     """Test plotting cHPI SNRs."""
     raw = read_raw_fif(chpi_fif_fname, allow_maxshield='yes')

--- a/tools/github_actions_test.sh
+++ b/tools/github_actions_test.sh
@@ -8,12 +8,3 @@ else
 fi
 echo 'pytest -m "${CONDITION}" --tb=short --cov=mne --cov-report xml -vv ${USE_DIRS}'
 pytest -m "${CONDITION}" --tb=short --cov=mne --cov-report xml -vv ${USE_DIRS}
-
-# run the minimal one with the testing data as well
-if [ "${DEPS}" == "minimal" ]; then
-	export MNE_SKIP_TESTING_DATASET_TESTS=false;
-	python -c 'import mne; mne.datasets.testing.data_path(verbose=True)';
-fi;
-if [ "${DEPS}" == "minimal" ]; then
-	pytest -m "${CONDITION}" --tb=short --cov=mne -vv ${USE_DIRS};
-fi;


### PR DESCRIPTION
@Kyung-minAn can you try this with your data? It fixes the problem for me with `mne.io.read_raw_fif('010409_Motor_task_coregist-export_tiny_1s.con')`