### PR TITLE
MRG: Make viz.plot_alignment() continue on topological defects; make coreg display a suitable head surface even if it has topological defects

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -121,6 +121,8 @@ Enhancements
 
 - :func:`mne.viz.plot_alignment` now emits a warning (instead of aborting with an exception) if the surfaces contain topological defects (:gh:`9614` by `Richard Höchenberger`_)
 
+- The coregistration GUI can now display the head surface even if there are topological defects. Previously, a low-resolution head devoid of most facial features and hence unsuitable for coregistration was displayed (:gh:`9614` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 - Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** |Jan Sosulski|_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -119,6 +119,8 @@ Enhancements
 
 - :meth:`mne.preprocessing.ICA.fit` now emits a warning if any of the ``start``, ``stop``, ``reject``, and ``flat`` parameters are passed when performing ICA on `~mne.Epochs`. These parameters only have an effect on `~mne.io.Raw` data and were previously silently ignored in the case of `~mne.Epochs` (:gh:`9605` by `Richard Höchenberger`_)
 
+- :meth:`mne.viz.plot_alignment` now emits a warning (instead of aborting with an exception) if the surfaces contain topological defects (:gh:`9614` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 - Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** |Jan Sosulski|_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -121,7 +121,7 @@ Enhancements
 
 - :func:`mne.viz.plot_alignment` now emits a warning (instead of aborting with an exception) if the surfaces contain topological defects (:gh:`9614` by `Richard Höchenberger`_)
 
-- The coregistration GUI can now display the head surface even if there are topological defects. Previously, a low-resolution head devoid of most facial features and hence unsuitable for coregistration was displayed (:gh:`9614` by `Richard Höchenberger`_)
+- The coregistration GUI can now display the head surface even if there are topological defects. Previously, a low-resolution standard head unsuitable for individualized coregistration was displayed (:gh:`9614` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -119,7 +119,7 @@ Enhancements
 
 - :meth:`mne.preprocessing.ICA.fit` now emits a warning if any of the ``start``, ``stop``, ``reject``, and ``flat`` parameters are passed when performing ICA on `~mne.Epochs`. These parameters only have an effect on `~mne.io.Raw` data and were previously silently ignored in the case of `~mne.Epochs` (:gh:`9605` by `Richard Höchenberger`_)
 
-- :meth:`mne.viz.plot_alignment` now emits a warning (instead of aborting with an exception) if the surfaces contain topological defects (:gh:`9614` by `Richard Höchenberger`_)
+- :func:`mne.viz.plot_alignment` now emits a warning (instead of aborting with an exception) if the surfaces contain topological defects (:gh:`9614` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -190,7 +190,7 @@ class SurfaceSource(HasTraits):
             if self.file.endswith('.fif'):
                 bem = read_bem_surfaces(
                     self.file, on_defects='warn', verbose=False
-                    )[0]
+                )[0]
             else:
                 try:
                     bem = read_surface(self.file, return_dict=True)[2]

--- a/mne/gui/_file_traits.py
+++ b/mne/gui/_file_traits.py
@@ -188,7 +188,9 @@ class SurfaceSource(HasTraits):
         """Read the file."""
         if op.exists(self.file):
             if self.file.endswith('.fif'):
-                bem = read_bem_surfaces(self.file, verbose=False)[0]
+                bem = read_bem_surfaces(
+                    self.file, on_defects='warn', verbose=False
+                    )[0]
             else:
                 try:
                     bem = read_surface(self.file, return_dict=True)[2]

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2453,7 +2453,7 @@ docdict['compute_proj_eog'] = f"""%(create_eog_epochs)s {compute_proj_common}
 
 # BEM
 docdict['on_defects'] = """
-on_defects : str
+on_defects : 'raise' | 'warn'
     What to do if the surface is found to have topological defects. Can be
     ``'raise'`` (default) to raise an error, or ``'warn'`` to emit a warning.
     Note that a lot of computations in MNE-Python assume the surfaces to be

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -731,7 +731,9 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
                         logger.info('Using %s for head surface.'
                                     % (op.basename(fname),))
                         if op.splitext(fname)[-1] == '.fif':
-                            head_surf = read_bem_surfaces(fname)[0]
+                            head_surf = read_bem_surfaces(
+                                fname, on_defects='warn'
+                            )[0]
                         else:
                             head_surf = _read_mri_surface(fname)
                         break


### PR DESCRIPTION
I wanted to run `viz.plot_alignment()` and it crashed with an exception because there were a few topological defects (as is often the case with our data).

So now, I'm passing `on_defects='warn'` to the `read_bem_surfaces()` call inside `plot_alignment()`.

At first I made this parameter user-configurable, but then I thought, `plot_alignment()` is used when the user wants to see the data they have, so I felt it's not only okay, but expected to always pass `on_defects='warn'`.

Not sure how to test this, though – maybe it's okay as-is? I can confirm that this works for me.