### PR TITLE
MRG, DOC: Document 'ignore' on_defects value; make allowed on_missing values explicit

### DIFF
--- a/mne/bem.py
+++ b/mne/bem.py
@@ -267,12 +267,7 @@ def _check_complete_surface(surf, copy=False, incomplete='raise', extra=''):
                'have fewer than three neighboring triangles [{}]{}'
                .format(_bem_surf_name[surf['id']], len(fewer), surf['ntri'],
                        ', '.join(str(f) for f in fewer), extra))
-        if incomplete == 'raise':
-            raise RuntimeError(msg)
-        elif incomplete == 'ignore':
-            pass
-        else:
-            warn(msg)
+        _on_missing(on_missing=incomplete, msg=msg, name='on_defects')
     return surf
 
 

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -269,6 +269,8 @@ def _check_complete_surface(surf, copy=False, incomplete='raise', extra=''):
                        ', '.join(str(f) for f in fewer), extra))
         if incomplete == 'raise':
             raise RuntimeError(msg)
+        elif incomplete == 'ignore':
+            pass
         else:
             warn(msg)
     return surf

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -183,7 +183,7 @@ def test_bem_model_topology(tmpdir):
     # Now get past this error to reach gh-6127 (not enough neighbor tris)
     rr_bad = np.concatenate([rr, np.mean(rr, axis=0, keepdims=True)], axis=0)
     write_surface(outer_fname, rr_bad, tris, overwrite=True)
-    with pytest.raises(RuntimeError, match='Surface outer skull.*triangles'):
+    with pytest.raises(ValueError, match='Surface outer skull.*triangles'):
         make_bem_model('foo', None, subjects_dir=tmpdir)
 
 
@@ -399,13 +399,13 @@ def test_io_head_bem(tmpdir):
     head['rr'][0] = np.array([-0.01487014, -0.04563854, -0.12660208])
     head['tris'][0] = np.array([21919, 21918, 21907])
 
-    with pytest.raises(RuntimeError, match='topological defects:'):
+    with pytest.raises(ValueError, match='topological defects:'):
         write_head_bem(fname_defect, head['rr'], head['tris'])
     with pytest.warns(RuntimeWarning, match='topological defects:'):
         write_head_bem(fname_defect, head['rr'], head['tris'],
                        on_defects='warn')
     # test on_defects in read_bem_surfaces
-    with pytest.raises(RuntimeError, match='topological defects:'):
+    with pytest.raises(ValueError, match='topological defects:'):
         read_bem_surfaces(fname_defect)
     with pytest.warns(RuntimeWarning, match='topological defects:'):
         head_defect = read_bem_surfaces(fname_defect, on_defects='warn')[0]

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2458,7 +2458,7 @@ on_defects : 'raise' | 'warn' | 'ignore'
     {_on_missing_base} one or more defects are found.
     Note that a lot of computations in MNE-Python assume the surfaces to be
     topologically correct, topological defects may still make other
-    computations (e.g., ``mne.make_bem_model`` and ``mne.make_bem_solution``)
+    computations (e.g., `mne.make_bem_model` and `mne.make_bem_solution`)
     fail irrespective of this parameter.
 """
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1322,7 +1322,7 @@ stcs : instance of SourceEstimate | list of instances of SourceEstimate
 
 # Forward
 docdict['on_missing_fwd'] = """
-on_missing : str
+on_missing : 'raise' | 'warn' | 'ignore'
     %s ``stc`` has vertices that are not in ``fwd``.
 """ % (_on_missing_base,)
 docdict['dig_kinds'] = """
@@ -1618,7 +1618,7 @@ on_header_missing : str
     .. versionadded:: 0.22
 """ % (_on_missing_base,)
 docdict['on_missing_events'] = """
-on_missing : str
+on_missing : 'raise' | 'warn' | 'ignore'
     %s event numbers from ``event_id`` are missing from ``events``.
     When numbers from ``events`` are missing from ``event_id`` they will be
     ignored and a warning emitted; consider using ``verbose='error'`` in
@@ -1627,13 +1627,13 @@ on_missing : str
     .. versionadded:: 0.21
 """ % (_on_missing_base,)
 docdict['on_missing_montage'] = """
-on_missing : str
+on_missing : 'raise' | 'warn' | 'ignore'
     %s channels have missing coordinates.
 
     .. versionadded:: 0.20.1
 """ % (_on_missing_base,)
 docdict['on_missing_ch_names'] = """
-on_missing : str
+on_missing : 'raise' | 'warn' | 'ignore'
     %s entries in ch_names are not present in the raw instance.
 
     .. versionadded:: 0.23.0
@@ -2306,7 +2306,7 @@ raw : Raw object
     An instance of `~mne.io.Raw`.
 """
 docdict['epochs_on_missing'] = """
-on_missing : str
+on_missing : 'raise' | 'warn' | 'ignore'
     What to do if one or several event ids are not found in the recording.
     Valid keys are 'raise' | 'warn' | 'ignore'
     Default is 'raise'. If on_missing is 'warn' it will proceed but
@@ -2452,10 +2452,10 @@ docdict['compute_proj_eog'] = f"""%(create_eog_epochs)s {compute_proj_common}
 """ % docdict
 
 # BEM
-docdict['on_defects'] = """
-on_defects : 'raise' | 'warn'
-    What to do if the surface is found to have topological defects. Can be
-    ``'raise'`` (default) to raise an error, or ``'warn'`` to emit a warning.
+docdict['on_defects'] = f"""
+on_defects : 'raise' | 'warn' | 'ignore'
+    What to do if the surface is found to have topological defects.
+    {_on_missing_base} one or more defects are found.
     Note that a lot of computations in MNE-Python assume the surfaces to be
     topologically correct, topological defects may still make other
     computations (e.g., ``mne.make_bem_model`` and ``mne.make_bem_solution``)


### PR DESCRIPTION
This is a follow-up to #9614, where @larsoner pointed out that the `on_defects` param should support an `'ignore'` value too. I've made the required adjustments, and also search-and-replaced `on_missing : str` -> `on_missing : 'raise' | 'warn' | 'ignore'` in the entire docdict.