### PR TITLE
Fixes #9611 - Indexing error in Evoked.plot_topomap() when trying to mask channels.

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -33,6 +33,8 @@ Current (0.24.dev0)
 
 .. |Darin Erat Sleiter| replace:: **Darin Erat Sleiter**
 
+.. |Mathieu Scheltienne| replace:: **Mathieu Scheltienne**
+
 Enhancements
 ~~~~~~~~~~~~
 .. - Add something cool (:gh:`9192` **by new contributor** |New Contributor|_)
@@ -131,6 +133,8 @@ Bugs
 
 - Fix bug with `mne.io.read_raw_curry` to allow reading Curry 8 event files with '.cdt.ceo' extension (:gh:`9381` by **new contributor** |Xiaokai Xia|_ and `Daniel McCloy`_)
 
+- Fix bug in :func:`mne.viz.plot_topomap` and :func:`mne.viz.plot_evoked_topomap` where the use of the argument ``mask`` would lead to an error (:gh:`9628` **by new contributor** |Mathieu Scheltienne|_)
+
 - Fix bug with :func:`mne.io.read_raw_nihon` where latin-1 annotations could not be read (:gh:`9384` by `Alex Gramfort`_)
 
 - Fix bug when printing a :class:`mne.io.RawArray` in the notebook (:gh:`9404` by `Alex Gramfort`_)
@@ -172,8 +176,6 @@ Bugs
 - Fix bug in ::meth:`mne.preprocessing.ICA.find_bads_ecg` where passing ``start`` and ``stop`` lead to erroneous data windows depending on the combination of Raw, Epochs, Evoked, and the type (int, float, None) of ``start`` and ``stop`` (:gh:`9556` by `Stefan Appelhoff`_)
 
 - Fix bug in :func:`mne.viz.set_3d_backend` and :func:`mne.viz.get_3d_backend` where the PyVistaQt-based backend was ambiguously named ``'pyvista'`` instead of ``'pyvistaqt'``; use ``set_3d_backend('pyvistaqt')`` and expect ``'pyvistaqt'`` as the output of :func:`mne.viz.get_3d_backend` instead of ``'pyvista'``, and consider using ``get_3d_backend().startswith('pyvista')`` for example for backward-compatible conditionals (:gh:`9607` by `Guillaume Favelier`_)
-
-- Fix bug in :func:`mne.viz.plot_topomap` and :func:`mne.viz.plot_evoked_topomap` where the use of the argument ``mask`` would lead to an error (:gh:`9628` by **new contributor** |Mathieu Scheltienne|_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -173,7 +173,7 @@ Bugs
 
 - Fix bug in :func:`mne.viz.set_3d_backend` and :func:`mne.viz.get_3d_backend` where the PyVistaQt-based backend was ambiguously named ``'pyvista'`` instead of ``'pyvistaqt'``; use ``set_3d_backend('pyvistaqt')`` and expect ``'pyvistaqt'`` as the output of :func:`mne.viz.get_3d_backend` instead of ``'pyvista'``, and consider using ``get_3d_backend().startswith('pyvista')`` for example for backward-compatible conditionals (:gh:`9607` by `Guillaume Favelier`_)
 
-- Fix bug in :func:`mne.viz.plot_topomap` and :func:`mne.viz.plot_evoked_topomap` where the use of the argument `mask` would lead to an error (:gh:`9628` by **new contributor** |Mathieu Scheltienne|_)
+- Fix bug in :func:`mne.viz.plot_topomap` and :func:`mne.viz.plot_evoked_topomap` where the use of the argument ``mask`` would lead to an error (:gh:`9628` by **new contributor** |Mathieu Scheltienne|_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -173,6 +173,8 @@ Bugs
 
 - Fix bug in :func:`mne.viz.set_3d_backend` and :func:`mne.viz.get_3d_backend` where the PyVistaQt-based backend was ambiguously named ``'pyvista'`` instead of ``'pyvistaqt'``; use ``set_3d_backend('pyvistaqt')`` and expect ``'pyvistaqt'`` as the output of :func:`mne.viz.get_3d_backend` instead of ``'pyvista'``, and consider using ``get_3d_backend().startswith('pyvista')`` for example for backward-compatible conditionals (:gh:`9607` by `Guillaume Favelier`_)
 
+- Fix bug in :func:`mne.viz.plot_topomap` and :func:`mne.viz.plot_evoked_topomap` where the use of the argument `mask` would lead to an error (:gh:`9628` by **new contributor** |Mathieu Scheltienne|_)
+
 API changes
 ~~~~~~~~~~~
 - In `mne.compute_source_morph`, the ``niter_affine`` and ``niter_sdr`` parameters have been replaced by ``niter`` and ``pipeline`` parameters for more consistent and finer-grained control of registration/warping steps and iteration (:gh:`9505` by `Alex Rockhill`_ and `Eric Larson`_)

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -403,3 +403,5 @@
 .. _Pierre-Antoine Bannier: https://github.com/PABannier
 
 .. _Darin Erat Sleiter: https://github.com/dsleiter
+
+.. _Mathieu Scheltienne: https://github.com/mscheltienne

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -676,3 +676,16 @@ def test_topomap_mask():
     mask = np.zeros([len(evoked.ch_names), len(times)], dtype=bool)
     mask[20, :] = True
     evoked.plot_topomap(times=times, time_unit='s', mask=mask)
+    mask[:20, :] = True
+    evoked.plot_topomap(times=times, time_unit='s', mask=mask)
+
+    evoked = read_evokeds(evoked_fname)[0]
+    evoked.pick('grad')
+    evoked.apply_baseline((None, 0))
+
+    times = (0.090, 0.110)
+    mask = np.zeros([len(evoked.ch_names), len(times)], dtype=bool)
+    mask[20, :] = True
+    evoked.plot_topomap(times=times, time_unit='s', mask=mask)
+    mask[:20, :] = True
+    evoked.plot_topomap(times=times, time_unit='s', mask=mask)

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -664,3 +664,15 @@ def test_plot_topomap_cnorm():
     msg = "vmax=2.5 is implicitly defined by cnorm, ignoring vmax=10.*"
     with pytest.warns(RuntimeWarning, match=msg):
         plot_topomap(v, info, vmax=10, cnorm=cnorm)
+
+
+def test_topomap_mask():
+    """Test topomap with masking and time selection."""
+    evoked = read_evokeds(evoked_fname)[0]
+    evoked.pick('mag')
+    evoked.apply_baseline((None, 0))
+
+    times = (0.090, 0.110)
+    mask = np.zeros([len(evoked.ch_names), len(times)], dtype=bool)
+    mask[20, :] = True
+    evoked.plot_topomap(times=times, time_unit='s', mask=mask)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1691,8 +1691,9 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
     # apply mask if requested
     if mask is not None:
         if ch_type == 'grad':
-            mask_ = (mask[np.ix_(picks[::2], range(len(time_idx)))] |
-                     mask[np.ix_(picks[1::2], range(len(time_idx)))])
+            mask_ = (
+                mask[np.ix_(picks[::2], range(len(time_idx)))].astype(bool) |
+                mask[np.ix_(picks[1::2], range(len(time_idx)))].astype(bool))
         else:  # mag, eeg, planar1, planar2
             mask_ = mask[np.ix_(picks, range(len(time_idx)))]
     # set up colormap

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -990,7 +990,7 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     elif sensors and mask is not None:
         idx = np.where(mask)[0]
         ax.plot(pos_x[idx], pos_y[idx], **mask_params)
-        idx = np.where(~mask)[0]
+        idx = np.where(mask)[0]
         _topomap_plot_sensors(pos_x[idx], pos_y[idx], sensors=sensors, ax=ax)
     elif not sensors and mask is not None:
         idx = np.where(mask)[0]
@@ -1691,10 +1691,10 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
     # apply mask if requested
     if mask is not None:
         if ch_type == 'grad':
-            mask_ = (mask[np.ix_(picks[::2], time_idx)] |
-                     mask[np.ix_(picks[1::2], time_idx)])
+            mask_ = (mask[np.ix_(picks[::2], range(len(time_idx)))] |
+                     mask[np.ix_(picks[1::2], range(len(time_idx)))])
         else:  # mag, eeg, planar1, planar2
-            mask_ = mask[np.ix_(picks, time_idx)]
+            mask_ = mask[np.ix_(picks, range(len(time_idx)))]
     # set up colormap
     vlims = [_setup_vmin_vmax(data[:, i], vmin, vmax, norm=merge_channels)
              for i in range(n_times)]

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -990,7 +990,7 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     elif sensors and mask is not None:
         idx = np.where(mask)[0]
         ax.plot(pos_x[idx], pos_y[idx], **mask_params)
-        idx = np.where(mask)[0]
+        idx = np.where(~mask.astype(bool))[0]
         _topomap_plot_sensors(pos_x[idx], pos_y[idx], sensors=sensors, ax=ax)
     elif not sensors and mask is not None:
         idx = np.where(mask)[0]


### PR DESCRIPTION
#### Reference issue
Fixes #9611 - Indexing error in Evoked.plot_topomap() when trying to mask channels.

#### What does this implement/fix?
Fixes the IndexError raised and the failing bit-wise inversion.

#### Additional information
The bitwise OR for gradiometer sensors is failing, but as I don't know what the purpose of the selection of indices even vs odd is, I did not fix it yet.
