### PR TITLE
Update montage.py to make the mne.channels.read_dig_dat() to support the dat file of neuroscan 64 channels

### DIFF
--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -505,23 +505,40 @@ def read_dig_dat(fname):
         items = line.split()
         if not items:
             continue
-        elif len(items) != 5:
+        elif not (len(items) == 4 or len(items) == 5):
             raise ValueError(
                 "Error reading %s, line %s has unexpected number of entries:\n"
                 "%s" % (fname, i, line.rstrip()))
-        num = items[1]
-        if num == '67':
-            continue  # centroid
-        pos = np.array([float(item) for item in items[2:]])
-        if num == '78':
-            nasion = pos
-        elif num == '76':
-            lpa = pos
-        elif num == '82':
-            rpa = pos
-        else:
-            ch_names.append(items[0])
-            poss.append(pos)
+        
+        if len(items) == 5:
+            num = items[1]
+            if num == '67':
+                continue  # centroid
+            pos = np.array([float(item) for item in items[2:]])
+            if num == '78':
+                nasion = pos
+            elif num == '76':
+                lpa = pos
+            elif num == '82':
+                rpa = pos
+            else:
+                ch_names.append(items[0])
+                poss.append(pos)
+        elif len(items) == 4:
+            label = items[0]
+            if label == 'Centroid':
+                continue  # centroid
+            pos = np.array([float(item) for item in items[1:]])
+            if label == 'Nasion':
+                nasion = pos
+            elif label == 'Left':
+                lpa = pos
+            elif label == 'Right':
+                rpa = pos
+            else:
+                ch_names.append(items[0])
+                poss.append(pos) 
+                
     electrodes = _check_dupes_odict(ch_names, poss)
     return make_dig_montage(electrodes, nasion, lpa, rpa)
 


### PR DESCRIPTION
The mne.channels.read_dig_dat() function does not support the dat file of neuroscan 64 channels. I have solved the problem. The modified code of the read_dig_dat function is as follows:
```
def read_dig_dat(fname):
    r"""Read electrode positions from a ``*.dat`` file.

    .. Warning::
        This function was implemented based on ``*.dat`` files available from
        `Compumedics <https://compumedicsneuroscan.com/scan-acquire-
        configuration-files/>`__ and might not work as expected with novel
        files. If it does not read your files correctly please contact the
        mne-python developers.

    Parameters
    ----------
    fname : path-like
        File from which to read electrode locations.

    Returns
    -------
    montage : DigMontage
        The montage.

    See Also
    --------
    read_dig_captrak
    read_dig_dat
    read_dig_egi
    read_dig_fif
    read_dig_hpts
    read_dig_polhemus_isotrak
    make_dig_montage

    Notes
    -----
    ``*.dat`` files are plain text files and can be inspected and amended with
    a plain text editor.
    """
    from ._standard_montage_utils import _check_dupes_odict
    fname = _check_fname(fname, overwrite='read', must_exist=True)

    with open(fname, 'r') as fid:
        lines = fid.readlines()

    ch_names, poss = list(), list()
    nasion = lpa = rpa = None
    for i, line in enumerate(lines):
        items = line.split()
        if not items:
            continue
        elif not (len(items) == 4 or len(items) == 5):
            raise ValueError(
                "Error reading %s, line %s has unexpected number of entries:\n"
                "%s" % (fname, i, line.rstrip()))
        
        if len(items) == 5:
            num = items[1]
            if num == '67':
                continue  # centroid
            pos = np.array([float(item) for item in items[2:]])
            if num == '78':
                nasion = pos
            elif num == '76':
                lpa = pos
            elif num == '82':
                rpa = pos
            else:
                ch_names.append(items[0])
                poss.append(pos)
        elif len(items) == 4:
            label = items[0]
            if label == 'Centroid':
                continue  # centroid
            pos = np.array([float(item) for item in items[1:]])
            if label == 'Nasion':
                nasion = pos
            elif label == 'Left':
                lpa = pos
            elif label == 'Right':
                rpa = pos
            else:
                ch_names.append(items[0])
                poss.append(pos)            
    
    electrodes = _check_dupes_odict(ch_names, poss)
    return make_dig_montage(electrodes, nasion, lpa, rpa)

```