### PR TITLE
ENH #8991 - set_eeg_reference to multiple channel types

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -33,6 +33,8 @@ Current (0.24.dev0)
 
 .. |Darin Erat Sleiter| replace:: **Darin Erat Sleiter**
 
+.. |Mathieu Scheltienne| replace:: **Mathieu Scheltienne**
+
 Enhancements
 ~~~~~~~~~~~~
 .. - Add something cool (:gh:`9192` **by new contributor** |New Contributor|_)
@@ -46,6 +48,8 @@ Enhancements
 - Add support for SURE parameter selection in :func:`mne.inverse_sparse.mixed_norm` and make ``alpha`` parameter now default to ``'sure'`` (:gh:`9430` by **new contributor** |Pierre-Antoine Bannier|_ and `Alex Gramfort`_)
 
 - Speed up BCD solver in :func:`mne.inverse_sparse.mixed_norm` by adding Anderson acceleration (:gh:`9481` by **new contributor** |Pierre-Antoine Bannier|_ and `Alex Gramfort`_)
+
+- Add support for list of channel types for EEG/sEEG/ECoG/DBS referencing (:gh:`9637` **by new contributor** |Mathieu Scheltienne|_)
 
 - Speed up point decimation in :func:`mne.io.read_raw_kit` by vectorization and use of :class:`scipy.spatial.cKDTree` (:gh:`9568` by `Jean-Remi King`_ and `Eric Larson`_)
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -403,3 +403,5 @@
 .. _Pierre-Antoine Bannier: https://github.com/PABannier
 
 .. _Darin Erat Sleiter: https://github.com/dsleiter
+
+.. _Mathieu Scheltienne: https://github.com/mscheltienne

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -238,8 +238,12 @@ def test_set_eeg_reference():
         set_eeg_reference(raw, ['EEG 001'], True, True)
 
 
-@pytest.mark.parametrize('ch_type', ('auto', 'ecog', 'dbs', ['ecog', 'dbs']))
-def test_set_eeg_reference_ch_type(ch_type):
+@pytest.mark.parametrize('ch_type, msg',
+    [('auto', ('ECoG',)),
+     ('ecog', ('ECoG',)),
+     ('dbs', ('DBS',)),
+     (['ecog', 'dbs'], ('ECoG', 'DBS'))])
+def test_set_eeg_reference_ch_type(ch_type, msg):
     """Test setting EEG reference for ECoG or DBS."""
     # gh-6454
     # gh-8739 added DBS
@@ -255,12 +259,7 @@ def test_set_eeg_reference_ch_type(ch_type):
     with catch_logging() as log:
         reref, ref_data = set_eeg_reference(raw.copy(), ch_type=ch_type,
                                             verbose=True)
-    if isinstance(ch_type, str) and ch_type in ['auto', 'ecog']:
-        assert "Applying a custom ('ECoG',)" in log.getvalue()
-    elif isinstance(ch_type, str) and ch_type in ['dbs']:
-        assert "Applying a custom ('DBS',)" in log.getvalue()
-    elif isinstance(ch_type, list):
-        assert "Applying a custom ('ECoG', 'DBS')" in log.getvalue()
+    assert f"Applying a custom {msg}" in log.getvalue()
     assert reref.info['custom_ref_applied']  # gh-7350
     _test_reference(raw, reref, ref_data, ref_ch)
     with pytest.raises(ValueError, match='No channels supplied'):

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -239,10 +239,10 @@ def test_set_eeg_reference():
 
 
 @pytest.mark.parametrize('ch_type, msg',
-    [('auto', ('ECoG',)),
-     ('ecog', ('ECoG',)),
-     ('dbs', ('DBS',)),
-     (['ecog', 'dbs'], ('ECoG', 'DBS'))])
+                         [('auto', ('ECoG',)),
+                          ('ecog', ('ECoG',)),
+                          ('dbs', ('DBS',)),
+                          (['ecog', 'dbs'], ('ECoG', 'DBS'))])
 def test_set_eeg_reference_ch_type(ch_type, msg):
     """Test setting EEG reference for ECoG or DBS."""
     # gh-6454

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -249,7 +249,6 @@ def test_set_eeg_reference_ch_type(ch_type):
     raw = RawArray(data, create_info(ch_names, 1000., ['ecog'] * 2
                                      + ['dbs'] * 2 + ['misc']))
     if ch_type == 'auto':
-
         ref_ch = ch_names[:2]
     else:
         ref_ch = raw.copy().pick(picks=ch_type).ch_names
@@ -257,9 +256,9 @@ def test_set_eeg_reference_ch_type(ch_type):
         reref, ref_data = set_eeg_reference(raw.copy(), ch_type=ch_type,
                                             verbose=True)
     if ch_type in ['auto', 'ecog']:
-        assert 'Applying a custom ECoG' in log.getvalue()
+        assert "Applying a custom ('ECoG',)" in log.getvalue()
     else:
-        assert 'Applying a custom DBS' in log.getvalue()
+        assert "Applying a custom ('DBS',)" in log.getvalue()
     assert reref.info['custom_ref_applied']  # gh-7350
     _test_reference(raw, reref, ref_data, ref_ch)
     with pytest.raises(ValueError, match='No channels supplied'):

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -238,7 +238,7 @@ def test_set_eeg_reference():
         set_eeg_reference(raw, ['EEG 001'], True, True)
 
 
-@pytest.mark.parametrize('ch_type', ('auto', 'ecog', 'dbs'))
+@pytest.mark.parametrize('ch_type', ('auto', 'ecog', 'dbs', ['ecog', 'dbs']))
 def test_set_eeg_reference_ch_type(ch_type):
     """Test setting EEG reference for ECoG or DBS."""
     # gh-6454
@@ -255,10 +255,12 @@ def test_set_eeg_reference_ch_type(ch_type):
     with catch_logging() as log:
         reref, ref_data = set_eeg_reference(raw.copy(), ch_type=ch_type,
                                             verbose=True)
-    if ch_type in ['auto', 'ecog']:
+    if isinstance(ch_type, str) and ch_type in ['auto', 'ecog']:
         assert "Applying a custom ('ECoG',)" in log.getvalue()
-    else:
+    elif isinstance(ch_type, str) and ch_type in ['dbs']:
         assert "Applying a custom ('DBS',)" in log.getvalue()
+    elif isinstance(ch_type, list):
+        assert "Applying a custom ('ECoG', 'DBS')" in log.getvalue()
     assert reref.info['custom_ref_applied']  # gh-7350
     _test_reference(raw, reref, ref_data, ref_ch)
     with pytest.raises(ValueError, match='No channels supplied'):

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -856,7 +856,8 @@ projection : bool
     must be set to ``False`` (the default in this case).
 """
 docdict['set_eeg_reference_ch_type'] = """
-ch_type : 'auto' | 'eeg' | 'ecog' | 'seeg' | 'dbs'
+ch_type : list of str | str
+    Valid channel types are 'auto', 'eeg', 'ecog', 'seeg', 'dbs'.
     The name of the channel type to apply the reference to. If 'auto',
     the first channel type of eeg, ecog, seeg or dbs that is found (in that
     order) will be selected.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -857,10 +857,10 @@ projection : bool
 """
 docdict['set_eeg_reference_ch_type'] = """
 ch_type : list of str | str
-    Valid channel types are 'auto', 'eeg', 'ecog', 'seeg', 'dbs'.
-    The name of the channel type to apply the reference to. If 'auto',
-    the first channel type of eeg, ecog, seeg or dbs that is found (in that
-    order) will be selected.
+    The name of the channel type to apply the reference to.
+    Valid channel types are ``'auto'``, ``'eeg'``, ``'ecog'``, ``'seeg'``,
+    ``'dbs'``. If ``'auto'``, the first channel type of eeg, ecog, seeg or dbs
+    that is found (in that order) will be selected.
 
     .. versionadded:: 0.19
 """


### PR DESCRIPTION
#### Reference issue
ENH #8991 - set_eeg_reference to multiple channel types.

#### What does this implement/fix?
The function `_get_ch_type(inst, ch_type)` now accepts both a string or a list (or tuple) of channel types. Previously, the checked channel type would be returned as a string. Now, it returns a list of channel types, e.g.

```
    _get_ch_type(inst, 'auto')               -> ['eeg']
    _get_ch_type(inst, 'eeg')                -> ['eeg']
    _get_ch_type(inst, ['eeg'])              -> ['eeg']
    _get_ch_type(inst, ['eeg', 'seeg'])      -> ['eeg',  'seeg']
```

I have checked that the function` _get_ch_type` was not used outside `mne.io.reference.py` since I changed the output type.
Syntax is compatible with python 3.5+. 

#### Sample test code:

```
from pathlib import Path

import mne


sample_data_dir = Path(mne.datasets.sample.data_path())
fname = sample_data_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'
raw = mne.io.read_raw_fif(fname, preload=True)
raw.pick('eeg')

mapping={ch: 'seeg' for ch in raw.ch_names[-20:]}
raw.set_channel_types(mapping)

raw.set_eeg_reference(ref_channels='average', projection=False, ch_type=['eeg', 'seeg'])
```