### PR TITLE
ENH: Add support to more than 3 stcs in mne.viz.plot_sparse_source_estimates

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -51,6 +51,8 @@ Enhancements
 
 - Add support for list of channel types for EEG/sEEG/ECoG/DBS referencing (:gh:`9637` **by new contributor** |Mathieu Scheltienne|_)
 
+- Add support for more than 3 source estimates in :func:`mne.viz.plot_sparse_source_estimates` (:gh:`????` **by new contributor** |Pierre-Antoine Bannier|_)
+
 - Speed up point decimation in :func:`mne.io.read_raw_kit` by vectorization and use of :class:`scipy.spatial.cKDTree` (:gh:`9568` by `Jean-Remi King`_ and `Eric Larson`_)
 
 - New function :func:`mne.chpi.get_chpi_info` to retrieve basic information about the cHPI system used when recording MEG data (:gh:`9369` by `Richard Höchenberger`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -51,7 +51,7 @@ Enhancements
 
 - Add support for list of channel types for EEG/sEEG/ECoG/DBS referencing (:gh:`9637` **by new contributor** |Mathieu Scheltienne|_)
 
-- Add support for more than 3 source estimates in :func:`mne.viz.plot_sparse_source_estimates` (:gh:`????` **by new contributor** |Pierre-Antoine Bannier|_)
+- Add support for more than 3 source estimates in :func:`mne.viz.plot_sparse_source_estimates` (:gh:`9640` **by new contributor** |Pierre-Antoine Bannier|_)
 
 - Speed up point decimation in :func:`mne.io.read_raw_kit` by vectorization and use of :class:`scipy.spatial.cKDTree` (:gh:`9568` by `Jean-Remi King`_ and `Eric Larson`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -51,7 +51,7 @@ Enhancements
 
 - Add support for list of channel types for EEG/sEEG/ECoG/DBS referencing (:gh:`9637` **by new contributor** |Mathieu Scheltienne|_)
 
-- Add support for more than 3 source estimates in :func:`mne.viz.plot_sparse_source_estimates` (:gh:`9640` **by new contributor** |Pierre-Antoine Bannier|_)
+- Add support for more than 3 source estimates in :func:`mne.viz.plot_sparse_source_estimates` (:gh:`9640` **by new contributor** |Pierre-Antoine Bannier|_ and `Alex Gramfort`_)
 
 - Speed up point decimation in :func:`mne.io.read_raw_kit` by vectorization and use of :class:`scipy.spatial.cKDTree` (:gh:`9568` by `Jean-Remi King`_ and `Eric Larson`_)
 

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2600,6 +2600,25 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
     # Update the backend
     from .backends.renderer import _get_renderer
 
+    linestyles = [
+        ('solid',                 'solid'),
+        ('dotted',                'dotted'),
+        ('dashed',                'dashed'),
+        ('dashdot',               'dashdot'),
+        ('loosely dotted',        (0, (1, 10))),
+        ('dotted',                (0, (1, 1))),
+        ('densely dotted',        (0, (1, 1))),
+        ('loosely dashed',        (0, (5, 10))),
+        ('dashed',                (0, (5, 5))),
+        ('densely dashed',        (0, (5, 1))),
+        ('loosely dashdotted',    (0, (3, 10, 1, 10))),
+        ('dashdotted',            (0, (3, 5, 1, 5))),
+        ('densely dashdotted',    (0, (3, 1, 1, 1))),
+        ('dashdotdotted',         (0, (3, 5, 1, 5, 1, 5))),
+        ('loosely dashdotdotted', (0, (3, 10, 1, 10, 1, 10))),
+        ('densely dashdotdotted', (0, (3, 1, 1, 1, 1, 1)))
+    ]
+
     known_modes = ['cone', 'sphere']
     if not isinstance(modes, (list, tuple)) or \
             not all(mode in known_modes for mode in modes):
@@ -2613,8 +2632,8 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
     if colors is None:
         colors = _get_color_list()
 
-    linestyles = cycle(['-', '--', ':'])
-    linestyles = [next(linestyles) for _ in range(len(stcs))]
+    linestyles = cycle(linestyles)
+    linestyles = [next(linestyles)[1] for _ in range(len(stcs))]
 
     # Show 3D
     lh_points = src[0]['rr']

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2553,7 +2553,7 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
     src : dict
         The source space.
     stcs : instance of SourceEstimate or list of instances of SourceEstimate
-        The source estimates (up to 3).
+        The source estimates.
     colors : list
         List of colors.
     linewidth : int
@@ -2613,7 +2613,8 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
     if colors is None:
         colors = _get_color_list()
 
-    linestyles = ['-', '--', ':']
+    linestyles = cycle(['-', '--', ':'])
+    linestyles = [next(linestyles) for _ in range(len(stcs))]
 
     # Show 3D
     lh_points = src[0]['rr']

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -2602,8 +2602,8 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
 
     linestyles = [
         ('solid',                 'solid'),
-        ('dotted',                'dotted'),
         ('dashed',                'dashed'),
+        ('dotted',                'dotted'),
         ('dashdot',               'dashdot'),
         ('loosely dotted',        (0, (1, 10))),
         ('dotted',                (0, (1, 1))),


### PR DESCRIPTION
The goal of this PR is to add support to more than 3 secs in mne.viz.plot_sparse_source_estimates . 

To make a figure, I need to pass more than 3 source estimates to plot_sparse_source_estimates. I adapted the function to support more than 3 source estimates. The bottleneck is the limited number of line styles when plotting the activation intensity.