### PR TITLE
Improve documentation for argument `mask` and fix documentation for argument `ch_type` for topographic plots.

### DIFF
--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -308,15 +308,8 @@ class CSP(TransformerMixin, BaseEstimator):
             only significant sensors will be shown.
         title : str | None
             Title. If None (default), no title is displayed.
-        mask : ndarray of bool, shape (n_channels, n_times) | None
-            The channels to be marked as significant at a given time point.
-            Indices set to `True` will be considered. Defaults to None.
-        mask_params : dict | None
-            Additional plotting parameters for plotting significant sensors.
-            Default (None) equals::
-
-                dict(marker='o', markerfacecolor='w', markeredgecolor='k',
-                     linewidth=0, markersize=4)
+        %(topomap_mask)s
+        %(topomap_mask_params)s
         %(topomap_outlines)s
         contours : int | array of float
             The number of contour lines to draw. If 0, no contours will be

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -318,7 +318,7 @@ proj : bool | 'interactive' | 'reconstruct'
     .. versionchanged:: 0.21
        Support for 'reconstruct' was added.
 """
-docdict["topomap_ch_type"] = """
+docdict["evoked_topomap_ch_type"] = """
 ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg' | None
     The channel type to plot. For 'grad', the gradiometers are collected in
     pairs and the RMS for each pair is plotted.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -384,7 +384,7 @@ cbar_fmt : str
     String format for colorbar values.
 """
 docdict["topomap_mask"] = """
-mask : ndarray of bool, shape (n_channels, n_times) | None
+mask : ndarray of bool, shape (n_channels, n_samples) | None
     The channels to be marked as significant at a given time point.
     Indices set to ``True`` will be considered. Defaults to ``None``.
 """

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1499,7 +1499,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
         automatically by checking for local maxima in global field power. If
         "interactive", the time can be set interactively at run-time by using a
         slider.
-    %(topomap_ch_type)s
+    %(evoked_topomap_ch_type)s
     %(topomap_vmin_vmax)s
     %(topomap_cmap)s
     %(topomap_sensors)s

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -985,6 +985,7 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
                 col.set_clip_path(patch_)
 
     pos_x, pos_y = pos.T
+    mask = mask.astype(bool, copy=False) if mask is not None else None
     if sensors is not False and mask is None:
         _topomap_plot_sensors(pos_x, pos_y, sensors=sensors, ax=ax)
     elif sensors and mask is not None:
@@ -1690,6 +1691,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
             merge_channels = False
     # apply mask if requested
     if mask is not None:
+        mask = mask.astype(bool, copy=False)
         if ch_type == 'grad':
             mask_ = (mask[np.ix_(picks[::2], time_idx)] |
                      mask[np.ix_(picks[1::2], time_idx)])

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -728,15 +728,8 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         List of channel names. If None, channel names are not plotted.
     %(topomap_show_names)s
         If ``True``, a list of names must be provided (see ``names`` keyword).
-    mask : ndarray of bool, shape (n_channels, n_times) | None
-        The channels to be marked as significant at a given time point.
-        Indices set to ``True`` will be considered. Defaults to None.
-    mask_params : dict | None
-        Additional plotting parameters for plotting significant sensors.
-        Default (None) equals::
-
-           dict(marker='o', markerfacecolor='w', markeredgecolor='k',
-                linewidth=0, markersize=4)
+    %(topomap_mask)s
+    %(topomap_mask_params)s
     %(topomap_outlines)s
     contours : int | array of float
         The number of contour lines to draw. If 0, no contours will be drawn.
@@ -2518,15 +2511,8 @@ def plot_arrowmap(data, info_from, info_to=None, scale=3e-10, vmin=None,
         List of channel names. If None, channel names are not plotted.
     %(topomap_show_names)s
         If ``True``, a list of names must be provided (see ``names`` keyword).
-    mask : ndarray of bool, shape (n_channels, n_times) | None
-        The channels to be marked as significant at a given time point.
-        Indices set to ``True`` will be considered. Defaults to None.
-    mask_params : dict | None
-        Additional plotting parameters for plotting significant sensors.
-        Default (None) equals::
-
-            dict(marker='o', markerfacecolor='w', markeredgecolor='k',
-                 linewidth=0, markersize=4)
+    %(topomap_mask)s
+    %(topomap_mask_params)s
     %(topomap_outlines)s
     contours : int | array of float
         The number of contour lines to draw. If 0, no contours will be drawn.


### PR DESCRIPTION
#### Reference issue

Second attempt to properly solve issue #9611.

#### What does this implement/fix?

- [x] Support for non-bool mask array which would lead to error on the bitwise operations.
- [x] Update the docstring for the argument `mask`
- [ ] Add test for the mask argument
- [ ] Add example in the tutorial
- [ ] Update the changelog
- [ ] Fix the docstring for argument `ch_type`

#### Additional information

Per the discussion on issue #9611, the following tutorial could be updated with an example:
https://mne.tools/stable/auto_examples/visualization/evoked_topomap.html#sphx-glr-auto-examples-visualization-evoked-topomap-py
