### PR TITLE
FIX: Remove ambiguity in local filename check

### DIFF
--- a/mne/_freesurfer.py
+++ b/mne/_freesurfer.py
@@ -474,8 +474,9 @@ def _check_mri(mri, subject, subjects_dir):
         if not op.isfile(mri):
             raise FileNotFoundError(f'MRI file {mri!r} not found')
     if op.basename(mri) == mri:
-        raise IOError(f'Ambiguous filename - found {mri!r} in current folder.\n'
-                      'If this is correct prefix with relative or absolute path')
+        err = (f'Ambiguous filename - found {mri!r} in current folder.\n'
+               'If this is correct prefix name with relative or absolute path')
+        raise IOError(err)
     return mri
 
 

--- a/mne/_freesurfer.py
+++ b/mne/_freesurfer.py
@@ -463,6 +463,8 @@ def read_talxfm(subject, subjects_dir=None, verbose=None):
 def _check_mri(mri, subject, subjects_dir):
     """Check whether an mri exists in the Freesurfer subject directory."""
     _validate_type(mri, 'path-like', 'mri')
+    if op.isfile(mri) and op.basename(mri) != mri:
+        return mri
     if not op.isfile(mri):
         if subject is None:
             raise FileNotFoundError(
@@ -471,6 +473,9 @@ def _check_mri(mri, subject, subjects_dir):
         mri = op.join(subjects_dir, subject, 'mri', mri)
         if not op.isfile(mri):
             raise FileNotFoundError(f'MRI file {mri!r} not found')
+    if op.basename(mri) == mri:
+        raise IOError(f'Ambiguous filename - found {mri!r} in current folder.\n'
+                      'If this is correct prefix with relative or absolute path')
     return mri
 
 


### PR DESCRIPTION
#### Reference issue
Fixes #9639 


#### What does this implement/fix?
Prior to this fix, the _check_mri would proceed if it found the default mri (T1.mgz).  If the default filename happened to be in the calling directory, it would be returned from the function rather than performing the expected search of the freesurfer folder.

The fix does a check to confirm that if the file is found, it is not from the current path unless a relative or absolute path is provided.  The assumption being that having a relative or absolute path to the current directory was done with some intention rather than a coincidental default setting.

#### Additional information
It is possible that this could return a warning rather than an error.
