### PR TITLE
Followup #9647 - Improve documentation of the mask argument for topographic maps.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -246,7 +246,7 @@ numpydoc_xref_ignore = {
     'n_elp', 'n_pts', 'n_tris', 'n_nodes', 'n_nonzero', 'n_events_out',
     'n_segments', 'n_orient_inv', 'n_orient_fwd', 'n_orient', 'n_dipoles_lcmv',
     'n_dipoles_fwd', 'n_picks_ref', 'n_coords', 'n_meg', 'n_good_meg',
-    'n_moments',
+    'n_moments', 'n_patterns',
     # Undocumented (on purpose)
     'RawKIT', 'RawEximia', 'RawEGI', 'RawEEGLAB', 'RawEDF', 'RawCTF', 'RawBTi',
     'RawBrainVision', 'RawCurry', 'RawNIRX', 'RawGDF', 'RawSNIRF', 'RawBOXY',

--- a/examples/visualization/evoked_topomap.py
+++ b/examples/visualization/evoked_topomap.py
@@ -123,7 +123,7 @@ plt.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.88)
 
 # %%
 # We can also highlight specific channels by adding a mask, to e.g. mark
-# chanels exceeding a threshold at a given time:
+# channels exceeding a threshold at a given time:
 
 # Define a threshold and create the mask
 mask = evoked.data > 1e-13

--- a/examples/visualization/evoked_topomap.py
+++ b/examples/visualization/evoked_topomap.py
@@ -122,7 +122,19 @@ evoked.plot_topomap(0.1, ch_type='mag', show_names=True, colorbar=False,
 plt.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.88)
 
 # %%
-# We can also highlight specific channels by adding a mask:
+# We can also highlight specific channels by adding a mask, to e.g. mark
+# chanels exceeding a threshold at a given time:
+
+# Define a threshold and create the mask
+mask = evoked.data > 1e-13
+
+# Select times and plot
+times = (0.09, 0.1, 0.11)
+evoked.plot_topomap(times, ch_type='mag', time_unit='s', mask=mask,
+                    mask_params=dict(markersize=10, markerfacecolor='y'))
+
+#%%
+# Or by manually picking the channels to highlight at different times:
 
 times = (0.09, 0.1, 0.11)
 _times = np.searchsorted(evoked.times, times) - 1

--- a/examples/visualization/evoked_topomap.py
+++ b/examples/visualization/evoked_topomap.py
@@ -137,7 +137,7 @@ evoked.plot_topomap(times, ch_type='mag', time_unit='s', mask=mask,
 # Or by manually picking the channels to highlight at different times:
 
 times = (0.09, 0.1, 0.11)
-_times = np.searchsorted(evoked.times, times) - 1
+_times = ((np.abs(evoked.times - t)).argmin() for t in times)
 significant_channels = [
     ('MEG 0231', 'MEG 1611', 'MEG 1621', 'MEG 1631', 'MEG 1811'),
     ('MEG 2411', 'MEG 2421'),

--- a/examples/visualization/evoked_topomap.py
+++ b/examples/visualization/evoked_topomap.py
@@ -121,6 +121,23 @@ evoked.plot_topomap(0.1, ch_type='mag', show_names=True, colorbar=False,
                     time_unit='s')
 plt.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.88)
 
+# We can also highlight specific channels by adding a mask:
+
+times = (0.09, 0.1, 0.11)
+_times = np.searchsorted(evoked.times, times) - 1
+significant_channels = [
+    ('MEG 0231', 'MEG 1611', 'MEG 1621', 'MEG 1631', 'MEG 1811'),
+    ('MEG 2411', 'MEG 2421'),
+    ('MEG 1621')]
+_channels = [np.in1d(evoked.ch_names, ch) for ch in significant_channels]
+
+mask = np.zeros(evoked.data.shape, dtype='bool')
+for _chs, _time in zip(_channels, _times):
+    mask[_chs, _time] = True
+
+evoked.plot_topomap(times, ch_type='mag', time_unit='s', mask=mask,
+                    mask_params=dict(markersize=10, markerfacecolor='y'))
+
 # %%
 # Animating the topomap
 # ---------------------

--- a/examples/visualization/evoked_topomap.py
+++ b/examples/visualization/evoked_topomap.py
@@ -89,7 +89,7 @@ evoked.plot_topomap(times, ch_type='mag', cmap='Spectral_r', res=32,
 # the effect of extrapolation. There are three extrapolation modes:
 #
 # - ``extrapolate='local'`` extrapolates only to points close to the sensors.
-# - ``extrapolate='head'`` extrapolates out to the head head circle.
+# - ``extrapolate='head'`` extrapolates out to the head circle.
 # - ``extrapolate='box'`` extrapolates to a large box stretching beyond the
 #   head circle.
 #

--- a/examples/visualization/evoked_topomap.py
+++ b/examples/visualization/evoked_topomap.py
@@ -121,6 +121,7 @@ evoked.plot_topomap(0.1, ch_type='mag', show_names=True, colorbar=False,
                     time_unit='s')
 plt.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.88)
 
+# %%
 # We can also highlight specific channels by adding a mask:
 
 times = (0.09, 0.1, 0.11)

--- a/examples/visualization/evoked_topomap.py
+++ b/examples/visualization/evoked_topomap.py
@@ -133,7 +133,7 @@ times = (0.09, 0.1, 0.11)
 evoked.plot_topomap(times, ch_type='mag', time_unit='s', mask=mask,
                     mask_params=dict(markersize=10, markerfacecolor='y'))
 
-#%%
+# %%
 # Or by manually picking the channels to highlight at different times:
 
 times = (0.09, 0.1, 0.11)

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -308,7 +308,7 @@ class CSP(TransformerMixin, BaseEstimator):
             only significant sensors will be shown.
         title : str | None
             Title. If None (default), no title is displayed.
-        %(topomap_mask)s
+        %(patterns_topomap_mask)s
         %(topomap_mask_params)s
         %(topomap_outlines)s
         contours : int | array of float

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -384,9 +384,9 @@ cbar_fmt : str
     String format for colorbar values.
 """
 mask_base = """
-mask : ndarray of bool, shape %(shape)s | None
-    Array indicating channel%(shape-appendinx)s to highlight with a distrinct
-    plotting style%(example)s. Array elements set to ``True`` will be plotted
+mask : ndarray of bool, shape {shape} | None
+    Array indicating channel{shape-appendinx} to highlight with a distrinct
+    plotting style{example}. Array elements set to ``True`` will be plotted
     with the parameters given in ``mask_params``. Defaults to ``None``,
     equivalent to an array of all ``False`` elements.
 """
@@ -397,15 +397,16 @@ topomap_mask_dstr = {
 evoked_topomap_mask_dstr = {
     'shape': '(n_channels, n_times)',
     'shape-appendinx': '-time combinations',
-    'example': ' (useful for, e.g., marking which channels at which times ' +
+    'example': ' (useful for, e.g. marking which channels at which times ' +
                'a statistical test of the data reaches significance)'}
 patterns_topomap_mask_dstr = {
     'shape': '(n_channels, n_patterns)',
     'shape-appendinx': '-pattern combinations',
     'example': ''}
-docdict['topomap_mask'] = mask_base % topomap_mask_dstr
-docdict['evoked_topomap_mask'] = mask_base % evoked_topomap_mask_dstr
-docdict['patterns_topomap_mask'] = mask_base % patterns_topomap_mask_dstr
+docdict['topomap_mask'] = mask_base.format(**topomap_mask_dstr)
+docdict['evoked_topomap_mask'] = mask_base.format(**evoked_topomap_mask_dstr)
+docdict['patterns_topomap_mask'] = mask_base.format(
+    **patterns_topomap_mask_dstr)
 docdict["topomap_mask_params"] = """
 mask_params : dict | None
     Additional plotting parameters for plotting significant sensors.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -385,20 +385,20 @@ cbar_fmt : str
 """
 mask_base = """
 mask : ndarray of bool, shape {shape} | None
-    Array indicating channel{shape-appendinx} to highlight with a distrinct
+    Array indicating channel{shape_appendix} to highlight with a distrinct
     plotting style{example}. Array elements set to ``True`` will be plotted
     with the parameters given in ``mask_params``. Defaults to ``None``,
     equivalent to an array of all ``False`` elements.
 """
 topomap_mask_dstr = {
-    'shape': '(n_channels, )', 'shape-appendinx': '', 'example': ''}
+    'shape': '(n_channels, )', 'shape_appendix': '', 'example': ''}
 evoked_topomap_mask_dstr = {
-    'shape': '(n_channels, n_times)', 'shape-appendinx': '-time combinations',
+    'shape': '(n_channels, n_times)', 'shape_appendix': '-time combinations',
     'example': ' (useful for, e.g. marking which channels at which times ' +
                'a statistical test of the data reaches significance)'}
 patterns_topomap_mask_dstr = {
     'shape': '(n_channels, n_patterns)',
-    'shape-appendinx': '-pattern combinations', 'example': ''}
+    'shape_appendix': '-pattern combinations', 'example': ''}
 docdict['topomap_mask'] = mask_base.format(**topomap_mask_dstr)
 docdict['evoked_topomap_mask'] = mask_base.format(**evoked_topomap_mask_dstr)
 docdict['patterns_topomap_mask'] = mask_base.format(

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -396,8 +396,9 @@ evoked_topomap_mask_dstr = {
     'shape': '(n_channels, n_times)', 'shape-appendinx': '-time combinations',
     'example': ' (useful for, e.g. marking which channels at which times ' +
                'a statistical test of the data reaches significance)'}
-patterns_topomap_mask_dstr = {'shape': '(n_channels, n_patterns)',
-    'shape-appendinx': '-pattern combinations','example': ''}
+patterns_topomap_mask_dstr = {
+    'shape': '(n_channels, n_patterns)',
+    'shape-appendinx': '-pattern combinations', 'example': ''}
 docdict['topomap_mask'] = mask_base.format(**topomap_mask_dstr)
 docdict['evoked_topomap_mask'] = mask_base.format(**evoked_topomap_mask_dstr)
 docdict['patterns_topomap_mask'] = mask_base.format(

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -391,18 +391,13 @@ mask : ndarray of bool, shape {shape} | None
     equivalent to an array of all ``False`` elements.
 """
 topomap_mask_dstr = {
-    'shape': '(n_channels, )',
-    'shape-appendinx': '',
-    'example': ''}
+    'shape': '(n_channels, )', 'shape-appendinx': '', 'example': ''}
 evoked_topomap_mask_dstr = {
-    'shape': '(n_channels, n_times)',
-    'shape-appendinx': '-time combinations',
+    'shape': '(n_channels, n_times)', 'shape-appendinx': '-time combinations',
     'example': ' (useful for, e.g. marking which channels at which times ' +
                'a statistical test of the data reaches significance)'}
-patterns_topomap_mask_dstr = {
-    'shape': '(n_channels, n_patterns)',
-    'shape-appendinx': '-pattern combinations',
-    'example': ''}
+patterns_topomap_mask_dstr = {'shape': '(n_channels, n_patterns)',
+    'shape-appendinx': '-pattern combinations','example': ''}
 docdict['topomap_mask'] = mask_base.format(**topomap_mask_dstr)
 docdict['evoked_topomap_mask'] = mask_base.format(**evoked_topomap_mask_dstr)
 docdict['patterns_topomap_mask'] = mask_base.format(

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -385,13 +385,13 @@ cbar_fmt : str
 """
 mask_base = """
 mask : ndarray of bool, shape {shape} | None
-    Array indicating channel{shape_appendix} to highlight with a distrinct
+    Array indicating channel{shape_appendix} to highlight with a distinct
     plotting style{example}. Array elements set to ``True`` will be plotted
     with the parameters given in ``mask_params``. Defaults to ``None``,
     equivalent to an array of all ``False`` elements.
 """
 docdict['topomap_mask'] = mask_base.format(
-    shape='(n_channels, )', shape_appendix='', example='')
+    shape='(n_channels,)', shape_appendix='(s)', example='')
 docdict['evoked_topomap_mask'] = mask_base.format(
     shape='(n_channels, n_times)', shape_appendix='-time combinations',
     example=' (useful for, e.g. marking which channels at which times a '

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -385,8 +385,11 @@ cbar_fmt : str
 """
 docdict["topomap_mask"] = """
 mask : ndarray of bool, shape (n_channels, n_samples) | None
-    The channels to be marked as significant at a given time point.
-    Indices set to ``True`` will be considered. Defaults to ``None``.
+    Array indicating channel-time combinations to highlight with a distinct
+    plotting style (useful for, e.g., marking which channels at which times a
+    statistical test of the data reaches significance). Array elements set to
+    ``True`` will be plotted with the parameters given in ``mask_params``.
+    Defaults to ``None``, equivalent to an array of all ``False`` elements.
 """
 docdict["topomap_mask_params"] = """
 mask_params : dict | None

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -390,19 +390,15 @@ mask : ndarray of bool, shape {shape} | None
     with the parameters given in ``mask_params``. Defaults to ``None``,
     equivalent to an array of all ``False`` elements.
 """
-topomap_mask_dstr = {
-    'shape': '(n_channels, )', 'shape_appendix': '', 'example': ''}
-evoked_topomap_mask_dstr = {
-    'shape': '(n_channels, n_times)', 'shape_appendix': '-time combinations',
-    'example': ' (useful for, e.g. marking which channels at which times ' +
-               'a statistical test of the data reaches significance)'}
-patterns_topomap_mask_dstr = {
-    'shape': '(n_channels, n_patterns)',
-    'shape_appendix': '-pattern combinations', 'example': ''}
-docdict['topomap_mask'] = mask_base.format(**topomap_mask_dstr)
-docdict['evoked_topomap_mask'] = mask_base.format(**evoked_topomap_mask_dstr)
+docdict['topomap_mask'] = mask_base.format(
+    shape='(n_channels, )', shape_appendix='', example='')
+docdict['evoked_topomap_mask'] = mask_base.format(
+    shape='(n_channels, n_times)', shape_appendix='-time combinations',
+    example=' (useful for, e.g. marking which channels at which times a '
+            'statistical test of the data reaches significance)')
 docdict['patterns_topomap_mask'] = mask_base.format(
-    **patterns_topomap_mask_dstr)
+    shape='(n_channels, n_patterns)', shape_appendix='-pattern combinations',
+    example='')
 docdict["topomap_mask_params"] = """
 mask_params : dict | None
     Additional plotting parameters for plotting significant sensors.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -383,14 +383,29 @@ docdict["topomap_cbar_fmt"] = """
 cbar_fmt : str
     String format for colorbar values.
 """
-docdict["topomap_mask"] = """
-mask : ndarray of bool, shape (n_channels, n_samples) | None
-    Array indicating channel-time combinations to highlight with a distinct
-    plotting style (useful for, e.g., marking which channels at which times a
-    statistical test of the data reaches significance). Array elements set to
-    ``True`` will be plotted with the parameters given in ``mask_params``.
-    Defaults to ``None``, equivalent to an array of all ``False`` elements.
+mask_base = """
+mask : ndarray of bool, shape %(shape)s | None
+    Array indicating channel%(shape-appendinx)s to highlight with a distrinct
+    plotting style%(example)s. Array elements set to ``True`` will be plotted
+    with the parameters given in ``mask_params``. Defaults to ``None``,
+    equivalent to an array of all ``False`` elements.
 """
+topomap_mask_dstr = {
+    'shape': '(n_channels, )',
+    'shape-appendinx': '',
+    'example': ''}
+evoked_topomap_mask_dstr = {
+    'shape': '(n_channels, n_times)',
+    'shape-appendinx': '-time combinations',
+    'example': ''}
+patterns_topomap_mask_dstr = {
+    'shape': '(n_channels, n_patterns)',
+    'shape-appendinx': '-pattern combinations',
+    'example': ' (useful for, e.g., marking which channels at which times ' +
+               'a statistical test of the data reaches significance)'}
+docdict['topomap_mask'] = mask_base % topomap_mask_dstr
+docdict['evoked_topomap_mask'] = mask_base % evoked_topomap_mask_dstr
+docdict['patterns_topomap_mask'] = mask_base % patterns_topomap_mask_dstr
 docdict["topomap_mask_params"] = """
 mask_params : dict | None
     Additional plotting parameters for plotting significant sensors.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -397,12 +397,12 @@ topomap_mask_dstr = {
 evoked_topomap_mask_dstr = {
     'shape': '(n_channels, n_times)',
     'shape-appendinx': '-time combinations',
-    'example': ''}
+    'example': ' (useful for, e.g., marking which channels at which times ' +
+               'a statistical test of the data reaches significance)'}
 patterns_topomap_mask_dstr = {
     'shape': '(n_channels, n_patterns)',
     'shape-appendinx': '-pattern combinations',
-    'example': ' (useful for, e.g., marking which channels at which times ' +
-               'a statistical test of the data reaches significance)'}
+    'example': ''}
 docdict['topomap_mask'] = mask_base % topomap_mask_dstr
 docdict['evoked_topomap_mask'] = mask_base % evoked_topomap_mask_dstr
 docdict['patterns_topomap_mask'] = mask_base % patterns_topomap_mask_dstr

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1519,7 +1519,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
     %(show)s
     %(topomap_show_names)s
     %(title_None)s
-    %(topomap_mask)s
+    %(evoked_topomap_mask)s
     %(topomap_mask_params)s
     %(topomap_outlines)s
     %(topomap_contours)s

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -751,8 +751,6 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     %(topomap_sphere)s
     %(topomap_border)s
     %(topomap_ch_type)s
-
-        .. versionadded:: 0.24.0
     cnorm : matplotlib.colors.Normalize | None
         Colormap normalization, default None means linear normalization. If not
         None, ``vmin`` and ``vmax`` arguments are ignored. See Notes for more


### PR DESCRIPTION
#### Reference issue

Followup of PR #9647.

#### What does this implement/fix?

Example added using the argument `mask` to [_Plotting topographic maps of evoked data_](https://mne.tools/stable/auto_examples/visualization/evoked_topomap.html#sphx-glr-auto-examples-visualization-evoked-topomap-py). The example was created by @drammock on #9611.
Replace the docstring for `topomap_mask` with the proposition by @drammock on #9647.
Removed `.. versionadded:: 0.24.0` for argument `ch_type` in `mne.viz.plot_topomap()` introduced by b6a36089a963a97380488845491fe38e8d3b610b
