### PR TITLE
[MRG] Modifying Sleep Physionet docstrings

### DIFF
--- a/mne/datasets/sleep_physionet/_utils.py
+++ b/mne/datasets/sleep_physionet/_utils.py
@@ -61,7 +61,7 @@ def _data_path(path=None, force_update=False, update_path=None, verbose=None):
         Force update of the dataset even if a local copy exists.
     update_path : bool | None
         XXX Not implemented
-        If True, set the MNE_DATASETS_PHYSIONET_SLEEP_PATH in mne-python
+        If True, set the ``PHYSIONET_SLEEP_PATH`` in MNE-Python
         config to the given path. If None, the user is prompted.
     %(verbose)s
 

--- a/mne/datasets/sleep_physionet/_utils.py
+++ b/mne/datasets/sleep_physionet/_utils.py
@@ -53,13 +53,14 @@ def _data_path(path=None, force_update=False, update_path=None, verbose=None):
     path : None | str
         Location of where to look for the data storing location.
         If None, the environment variable or config parameter
-        ``MNE_DATASETS_PHYSIONET_SLEEP_PATH`` is used. If it doesn't exist, the
-        "~/mne_data" directory is used. If the dataset
-        is not found under the given path, the data
-        will be automatically downloaded to the specified folder.
+        ``PHYSIONET_SLEEP_PATH`` is used. If it doesn't exist, the "~/mne_data"
+        directory is used. If the dataset is not found under the given path,
+        the data will be automatically downloaded to the specified folder.
     force_update : bool
+        XXX Not implemented
         Force update of the dataset even if a local copy exists.
     update_path : bool | None
+        XXX Not implemented
         If True, set the MNE_DATASETS_PHYSIONET_SLEEP_PATH in mne-python
         config to the given path. If None, the user is prompted.
     %(verbose)s

--- a/mne/datasets/sleep_physionet/_utils.py
+++ b/mne/datasets/sleep_physionet/_utils.py
@@ -41,7 +41,7 @@ def _fetch_one(fname, hashsum, path, force_update, base_url):
 
 
 @verbose
-def _data_path(path=None, force_update=False, update_path=None, verbose=None):
+def _data_path(path=None, verbose=None):
     """Get path to local copy of EEG Physionet age Polysomnography dataset URL.
 
     This is a low-level function useful for getting a local copy of a
@@ -56,13 +56,6 @@ def _data_path(path=None, force_update=False, update_path=None, verbose=None):
         ``PHYSIONET_SLEEP_PATH`` is used. If it doesn't exist, the "~/mne_data"
         directory is used. If the dataset is not found under the given path,
         the data will be automatically downloaded to the specified folder.
-    force_update : bool
-        XXX Not implemented
-        Force update of the dataset even if a local copy exists.
-    update_path : bool | None
-        XXX Not implemented
-        If True, set the ``PHYSIONET_SLEEP_PATH`` in MNE-Python
-        config to the given path. If None, the user is prompted.
     %(verbose)s
 
     Returns

--- a/mne/datasets/sleep_physionet/age.py
+++ b/mne/datasets/sleep_physionet/age.py
@@ -17,8 +17,7 @@ BASE_URL = 'https://physionet.org/physiobank/database/sleep-edfx/sleep-cassette/
 
 @verbose
 def fetch_data(subjects, recording=(1, 2), path=None, force_update=False,
-               update_path=None, base_url=BASE_URL, on_missing='raise',
-               verbose=None):  # noqa: D301
+               base_url=BASE_URL, on_missing='raise', verbose=None):  # noqa: D301, E501
     """Get paths to local copies of PhysioNet Polysomnography dataset files.
 
     This will fetch data from the publicly available subjects from PhysioNet's
@@ -50,10 +49,6 @@ def fetch_data(subjects, recording=(1, 2), path=None, force_update=False,
         specified folder.
     force_update : bool
         Force update of the dataset even if a local copy exists.
-    update_path : bool | None
-        XXX Not implemented
-        If True, set the ``PHYSIONET_SLEEP_PATH`` in mne-python config to the
-        given path. If None, the user is prompted.
     base_url : str
         The URL root.
     on_missing : 'raise' | 'warn' | 'ignore'
@@ -96,7 +91,7 @@ def fetch_data(subjects, recording=(1, 2), path=None, force_update=False,
     psg_records = records[np.where(records['type'] == b'PSG')]
     hyp_records = records[np.where(records['type'] == b'Hypnogram')]
 
-    path = data_path(path=path, update_path=update_path)
+    path = data_path(path=path)
     params = [path, force_update, base_url]
 
     _check_subjects(

--- a/mne/datasets/sleep_physionet/age.py
+++ b/mne/datasets/sleep_physionet/age.py
@@ -44,15 +44,16 @@ def fetch_data(subjects, recording=(1, 2), path=None, force_update=False,
     path : None | str
         Location of where to look for the PhysioNet data storing location.
         If None, the environment variable or config parameter
-        ``MNE_DATASETS_PHYSIONET_SLEEP_PATH`` is used. If it doesn't exist, the
-        "~/mne_data" directory is used. If the Polysomnography dataset
-        is not found under the given path, the data
-        will be automatically downloaded to the specified folder.
+        ``PHYSIONET_SLEEP_PATH`` is used. If it doesn't exist, the "~/mne_data"
+        directory is used. If the Polysomnography dataset is not found under
+        the given path, the data will be automatically downloaded to the
+        specified folder.
     force_update : bool
         Force update of the dataset even if a local copy exists.
     update_path : bool | None
-        If True, set the MNE_DATASETS_EEGBCI_PATH in mne-python
-        config to the given path. If None, the user is prompted.
+        XXX Not implemented
+        If True, set the ``PHYSIONET_SLEEP_PATH`` in mne-python config to the
+        given path. If None, the user is prompted.
     base_url : str
         The URL root.
     on_missing : 'raise' | 'warn' | 'ignore'

--- a/mne/datasets/sleep_physionet/temazepam.py
+++ b/mne/datasets/sleep_physionet/temazepam.py
@@ -16,8 +16,8 @@ BASE_URL = 'https://physionet.org/physiobank/database/sleep-edfx/sleep-telemetry
 
 
 @verbose
-def fetch_data(subjects, *, path=None, force_update=False,
-               update_path=None, base_url=BASE_URL, verbose=None):
+def fetch_data(subjects, *, path=None, force_update=False, base_url=BASE_URL,
+               verbose=None):
     """Get paths to local copies of PhysioNet Polysomnography dataset files.
 
     This will fetch data from the publicly available subjects from PhysioNet's
@@ -36,15 +36,12 @@ def fetch_data(subjects, *, path=None, force_update=False,
     path : None | str
         Location of where to look for the PhysioNet data storing location.
         If None, the environment variable or config parameter
-        ``MNE_DATASETS_PHYSIONET_SLEEP_PATH`` is used. If it doesn't exist,
-        the "~/mne_data" directory is used. If the Polysomnography dataset
-        is not found under the given path, the data
-        will be automatically downloaded to the specified folder.
+        ``PHYSIONET_SLEEP_PATH`` is used. If it doesn't exist, the "~/mne_data"
+        directory is used. If the Polysomnography dataset is not found under
+        the given path, the data will be automatically downloaded to the
+        specified folder.
     force_update : bool
         Force update of the dataset even if a local copy exists.
-    update_path : bool | None
-        If True, set the MNE_DATASETS_EEGBCI_PATH in mne-python
-        config to the given path. If None, the user is prompted.
     base_url : str
         The base URL to download from.
     %(verbose)s
@@ -83,7 +80,7 @@ def fetch_data(subjects, *, path=None, force_update=False,
 
     _check_subjects(subjects, 22)
 
-    path = data_path(path=path, update_path=update_path)
+    path = data_path(path=path)
     params = [path, force_update, base_url]
 
     fnames = []

--- a/mne/datasets/sleep_physionet/tests/test_physionet.py
+++ b/mne/datasets/sleep_physionet/tests/test_physionet.py
@@ -86,18 +86,20 @@ def test_run_update_age_records(tmpdir):
 def test_sleep_physionet_age_missing_subjects(physionet_tmpdir, subject,
                                               download_is_error):
     """Test handling of missing subjects in Sleep Physionet age fetcher."""
-    params = {'path': physionet_tmpdir, 'update_path': False}
 
     with pytest.raises(
             ValueError, match='This dataset contains subjects 0 to 82'):
         age.fetch_data(
-            subjects=[subject], recording=[1], on_missing='raise', **params)
+            subjects=[subject], recording=[1], on_missing='raise',
+            path=physionet_tmpdir)
     with pytest.warns(RuntimeWarning,
                       match='This dataset contains subjects 0 to 82'):
         age.fetch_data(
-            subjects=[subject], recording=[1], on_missing='warn', **params)
+            subjects=[subject], recording=[1], on_missing='warn',
+            path=physionet_tmpdir)
     paths = age.fetch_data(
-        subjects=[subject], recording=[1], on_missing='ignore', **params)
+        subjects=[subject], recording=[1], on_missing='ignore',
+        path=physionet_tmpdir)
     assert paths == []
 
 
@@ -105,42 +107,42 @@ def test_sleep_physionet_age_missing_subjects(physionet_tmpdir, subject,
 def test_sleep_physionet_age_missing_recordings(physionet_tmpdir, subject,
                                                 recording, download_is_error):
     """Test handling of missing recordings in Sleep Physionet age fetcher."""
-    params = {'path': physionet_tmpdir, 'update_path': False}
 
     with pytest.raises(
             ValueError, match=f'Requested recording {recording} for subject'):
         age.fetch_data(subjects=[subject], recording=[recording],
-                       on_missing='raise', **params)
+                       on_missing='raise', path=physionet_tmpdir)
     with pytest.warns(RuntimeWarning,
                       match=f'Requested recording {recording} for subject'):
         age.fetch_data(subjects=[subject], recording=[recording],
-                       on_missing='warn', **params)
+                       on_missing='warn', path=physionet_tmpdir)
     paths = age.fetch_data(subjects=[subject], recording=[recording],
-                           on_missing='ignore', **params)
+                           on_missing='ignore', path=physionet_tmpdir)
     assert paths == []
 
 
 def test_sleep_physionet_age(physionet_tmpdir, monkeypatch, download_is_error):
     """Test Sleep Physionet URL handling."""
     # check download_is_error patching
-    params = {'path': physionet_tmpdir, 'update_path': False}
     with pytest.raises(AssertionError, match='Test should not download'):
-        age.fetch_data(subjects=[0], recording=[1], **params)
+        age.fetch_data(subjects=[0], recording=[1], path=physionet_tmpdir)
     # then patch
     my_func = _FakeFetch()
     monkeypatch.setattr(
         mne.datasets.sleep_physionet._utils, '_fetch_file', my_func)
 
-    paths = age.fetch_data(subjects=[0], recording=[1], **params)
+    paths = age.fetch_data(subjects=[0], recording=[1], path=physionet_tmpdir)
     assert_array_equal(_keep_basename_only(paths),
                        [['SC4001E0-PSG.edf', 'SC4001EC-Hypnogram.edf']])
 
-    paths = age.fetch_data(subjects=[0, 1], recording=[1], **params)
+    paths = age.fetch_data(subjects=[0, 1], recording=[1],
+                           path=physionet_tmpdir)
     assert_array_equal(_keep_basename_only(paths),
                        [['SC4001E0-PSG.edf', 'SC4001EC-Hypnogram.edf'],
                         ['SC4011E0-PSG.edf', 'SC4011EH-Hypnogram.edf']])
 
-    paths = age.fetch_data(subjects=[0], recording=[1, 2], **params)
+    paths = age.fetch_data(subjects=[0], recording=[1, 2],
+                           path=physionet_tmpdir)
     assert_array_equal(_keep_basename_only(paths),
                        [['SC4001E0-PSG.edf', 'SC4001EC-Hypnogram.edf'],
                         ['SC4002E0-PSG.edf', 'SC4002EC-Hypnogram.edf']])
@@ -191,9 +193,7 @@ def test_sleep_physionet_temazepam(physionet_tmpdir, monkeypatch):
     monkeypatch.setattr(
         mne.datasets.sleep_physionet._utils, '_fetch_file', my_func)
 
-    params = {'path': physionet_tmpdir, 'update_path': False}
-
-    paths = temazepam.fetch_data(subjects=[0], **params)
+    paths = temazepam.fetch_data(subjects=[0], path=physionet_tmpdir)
     assert_array_equal(_keep_basename_only(paths),
                        [['ST7011J0-PSG.edf', 'ST7011JP-Hypnogram.edf']])
 
@@ -207,4 +207,4 @@ def test_sleep_physionet_temazepam(physionet_tmpdir, monkeypatch):
 
     with pytest.raises(
             ValueError, match='This dataset contains subjects 0 to 21'):
-        paths = temazepam.fetch_data(subjects=[22], **params)
+        paths = temazepam.fetch_data(subjects=[22], path=physionet_tmpdir)

--- a/mne/datasets/sleep_physionet/tests/test_physionet.py
+++ b/mne/datasets/sleep_physionet/tests/test_physionet.py
@@ -86,7 +86,6 @@ def test_run_update_age_records(tmpdir):
 def test_sleep_physionet_age_missing_subjects(physionet_tmpdir, subject,
                                               download_is_error):
     """Test handling of missing subjects in Sleep Physionet age fetcher."""
-
     with pytest.raises(
             ValueError, match='This dataset contains subjects 0 to 82'):
         age.fetch_data(
@@ -107,7 +106,6 @@ def test_sleep_physionet_age_missing_subjects(physionet_tmpdir, subject,
 def test_sleep_physionet_age_missing_recordings(physionet_tmpdir, subject,
                                                 recording, download_is_error):
     """Test handling of missing recordings in Sleep Physionet age fetcher."""
-
     with pytest.raises(
             ValueError, match=f'Requested recording {recording} for subject'):
         age.fetch_data(subjects=[subject], recording=[recording],


### PR DESCRIPTION
Quick fix for #9654.

This PR updates the docstrings of `mne.datasets.sleep_physionet.age.fetch_data` and `mne.datasets.sleep_physionet._utils._data_path`  to reflect the actual environment variable name for the Sleep Physionet dataset. It also clarifies that the `update_path` argument is not currently used.