### PR TITLE
Fix plot compare evokeds

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -183,6 +183,8 @@ Bugs
 
 - Fix bug in :func:`mne.viz.set_3d_backend` and :func:`mne.viz.get_3d_backend` where the PyVistaQt-based backend was ambiguously named ``'pyvista'`` instead of ``'pyvistaqt'``; use ``set_3d_backend('pyvistaqt')`` and expect ``'pyvistaqt'`` as the output of :func:`mne.viz.get_3d_backend` instead of ``'pyvista'``, and consider using ``get_3d_backend().startswith('pyvista')`` for example for backward-compatible conditionals (:gh:`9607` by `Guillaume Favelier`_)
 
+- Fix bug in :func:`mne.viz.plot_compare_evokeds` where confidence bands were not drawn if only one condition was plotted (:gh:`9663` by `Daniel McCloy`_)
+
 - Fix bug where setting of a montage with fNIRS data got set to "unknown" coordinate frame when it should have been in "head" (:gh:`9630` by `Alex Rockhill`_)
 
 API changes

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -2361,8 +2361,11 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
         ci_dict = dict()
         for cond in conditions:
             this_evokeds = evokeds[cond]
-            # skip CIs when possible; assign ci_fun first to get arg checking
+            # assign ci_fun first to get arg checking
             ci_fun = _get_ci_function_pce(ci, do_topo=do_topo)
+            # for bootstrap or parametric CIs, skip when only 1 observation
+            if not callable(ci):
+                ci_fun = ci_fun if len(this_evokeds) > 1 else None
             res = _get_data_and_ci(this_evokeds, combine, c_func, picks=_picks,
                                    scaling=scalings, ci_fun=ci_fun)
             data_dict[cond] = res[0]

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -2363,7 +2363,6 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
             this_evokeds = evokeds[cond]
             # skip CIs when possible; assign ci_fun first to get arg checking
             ci_fun = _get_ci_function_pce(ci, do_topo=do_topo)
-            ci_fun = ci_fun if len(this_evokeds) > 1 else None
             res = _get_data_and_ci(this_evokeds, combine, c_func, picks=_picks,
                                    scaling=scalings, ci_fun=ci_fun)
             data_dict[cond] = res[0]

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -360,19 +360,18 @@ def test_plot_compare_evokeds():
         assert (yvals < ylim[1]).all()
         assert (yvals > ylim[0]).all()
     plt.close('all')
+
     # test other CI args
-    ci_types = (None, False, 0.5,
-                lambda x: np.stack([x.mean(axis=0) + 1, x.mean(axis=0) - 1]))
+    def ci_func(array):
+        return array.mean(axis=0, keepdims=True) * np.array([[0.5], [1.5]])
+
+    ci_types = (None, False, 0.5, ci_func)
     for _ci in ci_types:
         fig = plot_compare_evokeds({'cond': [blue, red, evoked]}, ci=_ci)[0]
         if _ci in ci_types[2:]:
             assert np.any([isinstance(coll, PolyCollection)
                            for coll in fig.axes[0].collections])
-
     # make sure we can get a CI even for single conditions
-    def ci_func(array):
-        return array.mean(axis=0, keepdims=True) * np.array([[0.5], [1.5]])
-
     fig = plot_compare_evokeds(evoked, picks='eeg', ci=ci_func)[0]
     assert np.any([isinstance(coll, PolyCollection)
                    for coll in fig.axes[0].collections])

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -17,6 +17,7 @@ import pytest
 import matplotlib.pyplot as plt
 from matplotlib import gridspec
 from matplotlib.cm import get_cmap
+from matplotlib.collections import PolyCollection
 
 import mne
 from mne import (read_events, Epochs, read_cov, compute_covariance,
@@ -360,9 +361,19 @@ def test_plot_compare_evokeds():
         assert (yvals > ylim[0]).all()
     plt.close('all')
     # test other CI args
-    for _ci in (None, False, 0.5,
-                lambda x: np.stack([x.mean(axis=0) + 1, x.mean(axis=0) - 1])):
-        plot_compare_evokeds({'cond': [blue, red, evoked]}, ci=_ci)
+    ci_types = (None, False, 0.5,
+                lambda x: np.stack([x.mean(axis=0) + 1, x.mean(axis=0) - 1]))
+    for _ci in ci_types:
+        fig = plot_compare_evokeds({'cond': [blue, red, evoked]}, ci=_ci)[0]
+        if _ci in ci_types[2:]:
+            assert np.any([isinstance(coll, PolyCollection)
+                           for coll in fig.axes[0].collections])
+    # make sure we can get a CI even for single conditions
+    ci_fnc = lambda d: d.mean(axis=0, keepdims=True) * np.array([[0.5], [1.5]])
+    fig = plot_compare_evokeds(evoked, picks='eeg', ci=ci_fnc)[0]
+    assert np.any([isinstance(coll, PolyCollection)
+                   for coll in fig.axes[0].collections])
+
     with pytest.raises(TypeError, match='"ci" must be None, bool, float or'):
         plot_compare_evokeds(evoked, ci='foo')
     # test sensor inset, legend location, and axis inversion & truncation

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -368,9 +368,12 @@ def test_plot_compare_evokeds():
         if _ci in ci_types[2:]:
             assert np.any([isinstance(coll, PolyCollection)
                            for coll in fig.axes[0].collections])
+
     # make sure we can get a CI even for single conditions
-    ci_fnc = lambda d: d.mean(axis=0, keepdims=True) * np.array([[0.5], [1.5]])
-    fig = plot_compare_evokeds(evoked, picks='eeg', ci=ci_fnc)[0]
+    def ci_func(array):
+        return array.mean(axis=0, keepdims=True) * np.array([[0.5], [1.5]])
+
+    fig = plot_compare_evokeds(evoked, picks='eeg', ci=ci_func)[0]
     assert np.any([isinstance(coll, PolyCollection)
                    for coll in fig.axes[0].collections])
 


### PR DESCRIPTION
as reported on the forum, `plot_compare_evokeds` is failing to draw confidence bands when only one condition is passed.

https://mne.discourse.group/t/plot-compare-evokeds-from-mne-evokedarray-confidence-intervals-and-ylim/3522/3

This adds a test that fails on main and passes on this PR.