### PR TITLE
MAINT: fix circle

### DIFF
--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -5,6 +5,7 @@ pydata-sphinx-theme>=0.6.3
 https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip
 sphinxcontrib-bibtex>=2.1.2
 memory_profiler
+https://github.com/drammock/python-quantities/archive/fix-backslash-escape.zip  # XXX until release 0.12.5 or higher; then can remove (neo will pull it in)
 neo
 seaborn
 sphinx_copybutton

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -4,9 +4,9 @@ https://github.com/numpy/numpydoc/archive/main.zip
 pydata-sphinx-theme>=0.6.3
 https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip
 sphinxcontrib-bibtex>=2.1.2
-memory_profiler
+memory_profiler==0.58
 https://github.com/drammock/python-quantities/archive/fix-backslash-escape.zip  # XXX until release 0.12.5 or higher; then can remove (neo will pull it in)
-neo
+neo==0.10
 seaborn
 sphinx_copybutton
 https://github.com/mne-tools/mne-bids/archive/main.zip

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -3,8 +3,8 @@
 echo "Working around PyQt5 bugs"
 # https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
 # https://github.com/golemfactory/golem/issues/1019
-sudo apt-get update
-sudo apt-get install libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3 \
+sudo apt update
+sudo apt install libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3 \
 	libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
 	libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 \
 	graphviz optipng

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -33,8 +33,7 @@ elif [[ "$CIRCLE_JOB" == "linkcheck"* ]]; then
 else  # standard doc build
 	echo "Installing doc build dependencies"
 	python -m pip uninstall -y pydata-sphinx-theme
-	python -m pip install --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
+	python -m pip install --upgrade --progress-bar off --only-binary matplotlib -r <(grep -Ev "mayavi|PySurfer" requirements.txt) -r requirements_testing.txt -r requirements_doc.txt
 	python -m pip install --progress-bar off https://github.com/sphinx-gallery/sphinx-gallery/zipball/master https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/main
-	python -m pip uninstall -yq pysurfer mayavi
 	python -m pip install -e .
 fi

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -19,7 +19,8 @@ else
 	echo "H5py, pillow, matplotlib"
 	pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py pillow matplotlib
 	echo "Numba, nilearn"
-	pip install --progress-bar off --upgrade --pre --only-binary ":all:" numba llvmlite nilearn
+	pip install --progress-bar off --upgrade --pre --only-binary ":all:" numba llvmlite
+    pip install --progress-bar off --upgrade git+git://github.com/nilearn/nilearn.git@54494926f393b18267fddfb6b56ee6ec648764b4  # XXX until release 0.8.1 or 0.9.0 comes out
 	echo "VTK"
 	# built using vtk master branch on an Ubuntu 18.04.5 VM and uploaded to OSF,
 	# can't use VTK's pre wheel because it breaks Mayavi (probably event processing)

--- a/tools/setup_xvfb.sh
+++ b/tools/setup_xvfb.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -ef
 
-sudo apt-get update
-sudo apt-get install -yqq libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0
+sudo apt update
+sudo apt install -yqq libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset


### PR DESCRIPTION
- workaround upstream bugs in nilearn & quantities
- when setting up circle, don't install mayavi & pysurfer only to uninstall them 2 lines later
- avoid building matplotlib from source when setting up circle
- use `apt` instead of `apt-get` (seems to fix problems due to recent debian-buster version bump, not sure why)