### PR TITLE
MAINT: more circle fixes

### DIFF
--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -6,7 +6,7 @@ https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip
 sphinxcontrib-bibtex>=2.1.2
 memory_profiler
 neo
-seaborn
+seaborn!=0.11.2
 sphinx_copybutton
 https://github.com/mne-tools/mne-bids/archive/main.zip
 pyxdf

--- a/tutorials/epochs/50_epochs_to_data_frame.py
+++ b/tutorials/epochs/50_epochs_to_data_frame.py
@@ -107,8 +107,8 @@ df.iloc[:5, :10]
 # Wide- versus long-format DataFrames
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# Another parameter, ``long_format``, determines whether each channel's data is
-# in a separate column of the :class:`~pandas.DataFrame`
+# Another parameter, ``long_format``, determines whether each channel's data
+# is in a separate column of the :class:`~pandas.DataFrame`
 # (``long_format=False``), or whether the measured values are pivoted into a
 # single ``'value'`` column with an extra indicator column for the channel name
 # (``long_format=True``). Passing ``long_format=True`` will also create an


### PR DESCRIPTION
something about seaborn 0.11.2 is making `tutorials/epochs/50_epochs_to_data_frame.py` time out.  I can reproduce locally and it happens on circle.  Nothing in the release notes points to an obvious culprit, so until someone has time to track it down, let's just avoid that version.