### PR TITLE
Removes circular_layout from connectivity deprecation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -274,7 +274,7 @@ numpydoc_validation_exclude = {  # set of regex
     r'mne\.utils\.deprecated',
     # deprecations
     r'mne\.connectivity\.degree', r'mne\.connectivity\.seed_target_indices',
-    r'mne\.viz\.circular_layout', r'mne\.viz\.plot_sensors_connectivity',
+    r'mne\.viz\.plot_sensors_connectivity',
     'plot_connectivity_circle',
 }
 

--- a/examples/inverse/psf_ctf_label_leakage.py
+++ b/examples/inverse/psf_ctf_label_leakage.py
@@ -27,7 +27,9 @@ from mne.minimum_norm import (read_inverse_operator,
                               make_inverse_resolution_matrix,
                               get_point_spread)
 
-from mne.viz import circular_layout, plot_connectivity_circle
+from mne.viz import circular_layout
+from mne_connectivity import plot_connectivity_circle
+
 
 print(__doc__)
 

--- a/examples/inverse/psf_ctf_label_leakage.py
+++ b/examples/inverse/psf_ctf_label_leakage.py
@@ -28,7 +28,7 @@ from mne.minimum_norm import (read_inverse_operator,
                               get_point_spread)
 
 from mne.viz import circular_layout
-from mne_connectivity import plot_connectivity_circle
+from mne_connectivity.viz import plot_connectivity_circle
 
 
 print(__doc__)

--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -16,7 +16,6 @@ from .utils import plt_show
 from ..utils import _validate_type, deprecated, CONNECTIVITY_DEPRECATION_MSG
 
 
-@deprecated(CONNECTIVITY_DEPRECATION_MSG)
 def circular_layout(node_names, node_order, start_pos=90, start_between=True,
                     group_boundaries=None, group_sep=10):
     """Create layout arranging nodes on a circle.


### PR DESCRIPTION
#### Reference issue
Fixes: https://github.com/mne-tools/mne-python/pull/9493


#### What does this implement/fix?
Keeps circular_layout function in mne-python and updates example to use mne-connectivity.

