### PR TITLE
Add setter for fiducial alignment strategy to Coregistration

### DIFF
--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1761,12 +1761,10 @@ class Coregistration(object):
 
         Parameters
         ----------
-
         match : 'nearest' | 'matched'
             Alignment strategy; ``'nearest'`` aligns anatomical landmarks to
             any point on the head surface; ``'matched'`` aligns to the fiducial
             points in the MRI.
-
         """
         if match not in self._icp_fid_matches:
             msg = (f'"match" must be one of {self._icp_fid_matches}, got '

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1760,6 +1760,11 @@ class Coregistration(object):
             Alignment strategy; ``'nearest'`` aligns anatomical landmarks to
             any point on the head surface; ``'matched'`` aligns to the fiducial
             points in the MRI.
+
+        Returns
+        -------
+        self : Coregistration
+            The modified Coregistration object.
         """
         _check_option('match', match, self._icp_fid_matches)
         self._icp_fid_match = match

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1726,10 +1726,10 @@ class Coregistration(object):
                 self._nearest_transformed_high_res_mri_idx_hsp])
             weights.append(np.full(len(head_pts[-1]), self._hsp_weight))
         for key in ('lpa', 'nasion', 'rpa'):
-            if getattr(self, '_has_%s_data' % key):
+            if getattr(self, f'_has_{key}_data'):
                 head_pts.append(self._dig_dict[key])
                 if self._icp_fid_match == 'matched':
-                    mri_pts.append(getattr(self, key))
+                    mri_pts.append(getattr(self, f'_{key}'))
                 else:
                     assert self._icp_fid_match == 'nearest'
                     mri_pts.append(self._processed_high_res_mri_points[
@@ -1755,6 +1755,24 @@ class Coregistration(object):
         if n_scale_params == 0:
             mri_pts *= self._scale  # not done in fit_matched_points
         return head_pts, mri_pts, weights
+
+    def set_fid_match(self, match):
+        """Set the strategy for fitting anatomical landmark (fiducial) points.
+
+        Parameters
+        ----------
+
+        match : 'nearest' | 'matched'
+            Alignment strategy; ``'nearest'`` aligns anatomical landmarks to
+            any point on the head surface; ``'matched'`` aligns to the fiducial
+            points in the MRI.
+
+        """
+        if match not in self._icp_fid_matches:
+            msg = (f'"match" must be one of {self._icp_fid_matches}, got '
+                   f'{match}')
+            raise ValueError(msg)
+        self._icp_fid_match = match
 
     @verbose
     def fit_icp(self, n_iterations=20, lpa_weight=1., nasion_weight=10.,

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1771,6 +1771,7 @@ class Coregistration(object):
                    f'{match}')
             raise ValueError(msg)
         self._icp_fid_match = match
+        return self
 
     @verbose
     def fit_icp(self, n_iterations=20, lpa_weight=1., nasion_weight=10.,

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -290,7 +290,7 @@ def test_get_mni_fiducials():
         ('uniform', [1., 1., 1.], 0., None, 'nearest'),
         ('3-axis', [1., 1., 1.], 0., 'auto', 'nearest'),
         ('uniform', [0.8, 0.8, 0.8], 0., 'auto', 'nearest'),
-        ('3-axis', [0.8, 1.2, 1.2], 0., 'auto', 'nearest')])
+        ('3-axis', [0.8, 1.2, 1.2], 0., 'auto', 'matched')])
 def test_coregistration(scale_mode, ref_scale, grow_hair, fiducials,
                         fid_match):
     """Test automated coregistration."""

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -282,15 +282,17 @@ def test_get_mni_fiducials():
 
 
 @testing.requires_testing_data
-@pytest.mark.parametrize('scale_mode,ref_scale,grow_hair,fiducials', [
-    (None, [1., 1., 1.], 0., None),
-    (None, [1., 1., 1.], 0., 'estimated'),
-    (None, [1., 1., 1.], 2., 'auto'),
-    ('uniform', [1., 1., 1.], 0., None),
-    ('3-axis', [1., 1., 1.], 0., 'auto'),
-    ('uniform', [0.8, 0.8, 0.8], 0., 'auto'),
-    ('3-axis', [0.8, 1.2, 1.2], 0., 'auto')])
-def test_coregistration(scale_mode, ref_scale, grow_hair, fiducials):
+@pytest.mark.parametrize(
+    'scale_mode,ref_scale,grow_hair,fiducials,fid_match', [
+        (None, [1., 1., 1.], 0., None, 'nearest'),
+        (None, [1., 1., 1.], 0., 'estimated', 'nearest'),
+        (None, [1., 1., 1.], 2., 'auto', 'nearest'),
+        ('uniform', [1., 1., 1.], 0., None, 'nearest'),
+        ('3-axis', [1., 1., 1.], 0., 'auto', 'nearest'),
+        ('uniform', [0.8, 0.8, 0.8], 0., 'auto', 'nearest'),
+        ('3-axis', [0.8, 1.2, 1.2], 0., 'auto', 'nearest')])
+def test_coregistration(scale_mode, ref_scale, grow_hair, fiducials,
+                        fid_match):
     """Test automated coregistration."""
     trans_fname = op.join(data_path, 'MEG', 'sample',
                           'sample_audvis_trunc-trans.fif')
@@ -307,6 +309,7 @@ def test_coregistration(scale_mode, ref_scale, grow_hair, fiducials):
     coreg = Coregistration(info, subject=subject, subjects_dir=subjects_dir,
                            fiducials=fiducials)
     assert np.allclose(coreg._last_parameters, coreg._parameters)
+    coreg.set_fid_match(fid_match)
     default_params = list(coreg._default_parameters)
     coreg.set_rotation(default_params[:3])
     coreg.set_translation(default_params[3:6])

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -35,5 +35,8 @@ else  # standard doc build
 	python -m pip uninstall -y pydata-sphinx-theme
 	python -m pip install --upgrade --progress-bar off --only-binary matplotlib -r <(grep -Ev "mayavi|PySurfer" requirements.txt) -r requirements_testing.txt -r requirements_doc.txt
 	python -m pip install --progress-bar off https://github.com/sphinx-gallery/sphinx-gallery/zipball/master https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/main
+	# deal with comparisons and escapes (https://app.circleci.com/pipelines/github/mne-tools/mne-python/9686/workflows/3fd32b47-3254-4812-8b9a-8bab0d646d18/jobs/32934)
+	python -m pip install --upgrade quantities
+	python -m pip install https://github.com/nilearn/nilearn/zipball/cb5329d89bad6554f036c84634702cb67eb7d5ea
 	python -m pip install -e .
 fi


### PR DESCRIPTION
- Allows `mne.coreg.Coregistration.set_fid_match`
- Fixes bug when `Coregistration._icp_fid_match` == `'matched'` (now looks for attribute `self._lpa` instead of `self.lpa`, which doesn't exist)