### PR TITLE
WIP,ENH: Coreg GUI

### DIFF
--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -26,7 +26,6 @@ from .io._digitization import _get_data_as_dict_from_dig
 # namespace, too)
 from ._freesurfer import (_read_mri_info, get_mni_fiducials,  # noqa: F401
                           estimate_head_mri_t)  # noqa: F401
-from .label import read_label, Label
 from .source_space import (add_source_space_distances, read_source_spaces,  # noqa: E501,F401
                            write_source_spaces)
 from .surface import (read_surface, write_surface, _normalize_vectors,
@@ -897,6 +896,7 @@ def scale_labels(subject_to, pattern=None, overwrite=False, subject_from=None,
     subjects_dir : None | str
         Override the SUBJECTS_DIR environment variable.
     """
+    from .label import read_label, Label
     subjects_dir, subject_from, scale, _ = _scale_params(
         subject_to, subject_from, scale, subjects_dir)
 

--- a/mne/viz/__init__.py
+++ b/mne/viz/__init__.py
@@ -33,3 +33,4 @@ from .backends.renderer import (set_3d_backend, get_3d_backend, use_3d_backend,
                                 get_brain_class)
 from . import backends
 from ._brain import Brain
+from ._coreg import CoregistrationUI

--- a/mne/viz/_coreg/__init__.py
+++ b/mne/viz/_coreg/__init__.py
@@ -1,0 +1,1 @@
+from ._coreg import CoregistrationUI

--- a/mne/viz/_coreg/_coreg.py
+++ b/mne/viz/_coreg/_coreg.py
@@ -1,0 +1,161 @@
+from ...coreg import Coregistration
+from ...viz import plot_alignment
+
+
+class CoregistrationUI(object):
+    def __init__(self, info, subject, subjects_dir, fids='auto'):
+        from ..backends.renderer import _get_renderer
+        self._info = info
+        self._subject = subject
+        self._subjects_dir = subjects_dir
+        self._fids = fids
+
+        self._widgets = dict()
+        self._coreg = Coregistration(info, subject, subjects_dir, fids)
+        self._renderer = _get_renderer()
+        self._renderer._window_close_connect(self._clean)
+        self._configure_dock()
+        self._renderer.show()
+
+        self._plot()
+
+    def _plot(self):
+        plot_alignment(self._info, trans=self._coreg.trans,
+                       subject=self._subject,
+                       subjects_dir=self._subjects_dir,
+                       surfaces=dict(head=0.4),
+                       dig=True, eeg=[], meg=False,
+                       coord_frame='meg', fig=self._renderer.figure)
+
+    def _configure_dock(self):
+        def noop(x):
+            del x
+
+        self._renderer._dock_initialize(name="Parameters", area="left")
+        layout = self._renderer._dock_add_group_box("MRI Subject")
+        self._widgets["subjects_dir"] = self._renderer._dock_add_file_button(
+            name="subjects_dir",
+            desc="Subjects Directory",
+            func=noop,
+            layout=layout,
+        )
+        self._widgets["subject"] = self._renderer._dock_add_combo_box(
+            name="Subject",
+            value="sample",
+            rng=["sample"],
+            callback=noop,
+            compact=True,
+            layout=layout
+        )
+
+        layout = self._renderer._dock_add_group_box("MRI Fiducials")
+        hlayout = self._renderer._dock_add_layout(vertical=False)
+        self._widgets["show_hsp"] = self._renderer._dock_add_check_box(
+            name="Show Head Shape Points",
+            value=False,
+            callback=noop,
+            layout=layout
+        )
+        digs = ["LPA", "Nasion", "RPA"]
+        self._renderer._dock_add_radio_buttons(
+            value=digs[0],
+            rng=digs,
+            callback=noop,
+            layout=layout,
+        )
+        for coord in ("X", "Y", "Z"):
+            name = f"dig_{coord}"
+            self._widgets[name] = self._renderer._dock_add_spin_box(
+                name=coord,
+                value=0.,
+                rng=[0., 1.],
+                callback=noop,
+                compact=True,
+                double=True,
+                layout=hlayout
+            )
+        self._renderer._layout_add_widget(layout, hlayout)
+
+        layout = self._renderer._dock_add_group_box("Digitization Source")
+        # self._widgets["fids_file"] = self._renderer._dock_file_button()
+        self._widgets["grow_hair"] = self._renderer._dock_add_spin_box(
+            name="Grow Hair",
+            value=0.0,
+            rng=[0.0, 10.0],
+            callback=noop,
+            layout=layout,
+        )
+        hlayout = self._renderer._dock_add_layout(vertical=False)
+        self._widgets["omit_distance"] = self._renderer._dock_add_spin_box(
+            name="Omit Distance",
+            value=0.0,
+            rng=[0.0, 10.0],
+            callback=noop,
+            layout=hlayout,
+        )
+        self._widgets["omit"] = self._renderer._dock_add_button(
+            name="Omit",
+            callback=noop,
+            layout=hlayout,
+        )
+        self._renderer._layout_add_widget(layout, hlayout)
+        self._renderer._dock_add_stretch()
+
+        self._renderer._dock_initialize(
+            name="Fitting Parameters", area="right")
+        layout = self._renderer._dock_add_group_box("Scaling")
+        self._widgets["scaling_mode"] = self._renderer._dock_add_combo_box(
+            name="Scaling Mode",
+            value="0",
+            rng=["0", "1", "3"],
+            callback=noop,
+            compact=True,
+            layout=layout,
+        )
+        hlayout = self._renderer._dock_add_group_box(
+            name="Scaling Parameters",
+            layout=layout
+        )
+        for coord in ("X", "Y", "Z"):
+            name = f"scaling_{coord}"
+            self._widgets[name] = self._renderer._dock_add_spin_box(
+                name=coord,
+                value=0.,
+                rng=[0., 1.],
+                callback=noop,
+                compact=True,
+                double=True,
+                layout=hlayout
+            )
+
+        hlayout = self._renderer._dock_add_group_box(
+            "Translation (t) and Rotation (r)")
+        for mode in ("t", "r"):
+            for coord in ("X", "Y", "Z"):
+                name = f"{mode}{coord}"
+                self._widgets[name] = self._renderer._dock_add_spin_box(
+                    name=name,
+                    value=0.,
+                    rng=[0., 1.],
+                    callback=noop,
+                    compact=True,
+                    double=True,
+                    layout=hlayout
+                )
+        hlayout = self._renderer._dock_add_layout(vertical=False)
+        self._renderer._dock_add_button(
+            name="Fit Fiducials",
+            callback=noop,
+            layout=hlayout,
+        )
+        self._renderer._dock_add_button(
+            name="Fit ICP",
+            callback=noop,
+            layout=hlayout,
+        )
+        layout = self._renderer._dock_layout
+        self._renderer._layout_add_widget(layout, hlayout)
+        self._renderer._dock_add_stretch()
+
+    def _clean(self):
+        self._renderer = None

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -488,7 +488,8 @@ class _AbstractToolBar(ABC):
 
 class _AbstractDock(ABC):
     @abstractmethod
-    def _dock_initialize(self, window=None):
+    def _dock_initialize(self, window=None, name="Controls",
+                         area="left"):
         pass
 
     @abstractmethod
@@ -504,7 +505,7 @@ class _AbstractDock(ABC):
         pass
 
     @abstractmethod
-    def _dock_add_stretch(self, layout):
+    def _dock_add_stretch(self, layout=None):
         pass
 
     @abstractmethod
@@ -529,6 +530,10 @@ class _AbstractDock(ABC):
         pass
 
     @abstractmethod
+    def _dock_add_check_box(self, name, value, callback, layout=None):
+        pass
+
+    @abstractmethod
     def _dock_add_spin_box(self, name, value, rng, callback,
                            compact=True, double=True, layout=None):
         pass
@@ -539,7 +544,16 @@ class _AbstractDock(ABC):
         pass
 
     @abstractmethod
+    def _dock_add_radio_buttons(self, value, rng, callback, vertical=True,
+                                layout=None):
+        pass
+
+    @abstractmethod
     def _dock_add_group_box(self, name, layout=None):
+        pass
+
+    @abstractmethod
+    def _dock_add_file_button(self, name, desc, func, layout=None):
         pass
 
 


### PR DESCRIPTION
This PR adds a `CoregistrationUI` class which acts as the the user interface for coregistration that relies on `pyvistaqt`.

This is still a work in progress, the UI components are not connected to `Coregistration` yet.

**Todo**
* the GUI API is not complete (radio buttons not ready, dock widgets to fetch files)
* multi-dock system needs rework (only temporary solution for now) *[ipywidget]*
* reuse of `plot_alignment()` temporarily but this is not viable long-term -> needs refactoring

**Known bugs**
* inconsistent behaviour of checkbox layout *[ipywidget]*
* because of `plot_alignment()`, there is a double plot after the one from coreg *[ipywidget]*

It's an item from https://github.com/mne-tools/mne-python/issues/8833

**Current status**
![image](https://user-images.githubusercontent.com/18143289/130419727-b7ce5074-f8b8-4223-a0d6-e053dadf25bc.png)
