### PR TITLE
MRG, MAINT: More complete coreg test and doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,9 @@ doc/auto_examples/
 doc/auto_tutorials/
 doc/modules/generated/
 doc/sphinxext/cachedir
+tutorials/intro/report.h5
 tutorials/misc/report.h5
+tutorials/io/fnirs.csv
 pip-log.txt
 .coverage*
 coverage.xml

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -956,8 +956,15 @@ def scale_mri(subject_from, subject_to, scale, overwrite=False,
 
     See Also
     --------
+    scale_bem : Add a scaled BEM to a scaled MRI.
     scale_labels : Add labels to a scaled MRI.
     scale_source_space : Add a source space to a scaled MRI.
+
+    Notes
+    -----
+    This function will automatically call :func:`scale_bem`,
+    :func:`scale_labels`, and :func:`scale_source_space` based on expected
+    filename patterns in the subject directory.
     """
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
     paths = _find_mri_paths(subject_from, skip_fiducials, subjects_dir)
@@ -1297,6 +1304,10 @@ class Coregistration(object):
     trans : instance of Transform
         MRI<->Head coordinate transformation.
 
+    See Also
+    --------
+    mne.scale_mri
+
     Notes
     -----
     Internal computation quantities parameters are in the following units:
@@ -1304,6 +1315,9 @@ class Coregistration(object):
     - rotation are in radians
     - translation are in m
     - scale are in scale proportion
+
+    If using a scale mode, the :func:`~mne.scale_mri` should be used
+    to create a surrogate MRI subject with the proper scale factors.
     """
 
     def __init__(self, info, subject, subjects_dir=None, fiducials='auto'):
@@ -1657,6 +1671,17 @@ class Coregistration(object):
         errs_nearest = self.compute_dig_mri_distances()
         logger.info(f'{prefix} median distance: '
                     f'{np.median(errs_nearest * 1000):6.2f} mm')
+
+    @property
+    def scale(self):
+        """Get the current scale factor.
+
+        Returns
+        -------
+        scale : ndarray, shape (3,)
+            The scale factors.
+        """
+        return self._scale.copy()
 
     @verbose
     def fit_fiducials(self, lpa_weight=1., nasion_weight=10., rpa_weight=1.,

--- a/tutorials/forward/25_automated_coreg.py
+++ b/tutorials/forward/25_automated_coreg.py
@@ -80,3 +80,13 @@ print(
     f"Distance between HSP and MRI (mean/min/max):\n{np.mean(dists):.2f} mm "
     f"/ {np.min(dists):.2f} mm / {np.max(dists):.2f} mm"
 )
+
+# %%
+# .. note:: The :class:`mne.coreg.Coregistration` class has the ability to
+#           compute MRI scale factors using
+#           :meth:`~mne.coreg.Coregistration.set_scale_mode` that is useful
+#           for creating surrogate MRI subjects, i.e., using a template MRI
+#           (such as one from :func:`mne.datasets.fetch_infant_template`)
+#           matched to a subject's head digitization. When scaling is desired,
+#           a scaled surrogate MRI should be created using
+#           :func:`mne.scale_mri`.


### PR DESCRIPTION
Closes #9673

@drammock I realized the problem with the snippet:
```py
raw_fname = os.path.join(data_root, subject, 'raw_fif', f'{subject}_raw.fif')
info = mne.io.read_info(raw_fname)
coreg = mne.coreg.Coregistration(
    info, subject=surrogate, subjects_dir=subjects_dir)
coreg.set_scale_mode('3-axis')
coreg._icp_fid_match = 'matched'
coreg.fit_icp(n_iterations=30)
mne.viz.plot_alignment(
    info, coreg.trans, subject=surrogate, subjects_dir=subjects_dir,
    surfaces=dict(head=0.9), dig=True, mri_fiducials=True, meg=False)
```
is that the `plot_alignment` call is made with `subject=surrogate`, but it needs to be made with `subject=surrogate_scaled`, where you have made a scaled MRI surrogate using `mne.coreg.scale_mri` ~~and then `mne.coreg.scale_bem`~~ using the `coreg._scale` (which ~~we should make public~~ I have made public via `.scale`).

This PR just so far just adds some documentation, plus a test that `mne coreg` does the same thing as `Coregistration` at least for one set of actions (no scale, then uniform, then 3-axis) that yields the same outputs. @drammock feel free to review and merge if you're happy with this explanation and you see that running `scale_mri` then running `plot_alignment` with the surrogate does the right thing for your data.

(TL;DR for @GuillaumeFavelier: the completeness test worked without needing any modifications to the code, so it looks like your adapted class was doing the right thing!)