### PR TITLE
WIP: Add CODEOWNERS?

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,16 +14,9 @@
 
 # Each line is a file pattern followed by one or more owners.
 
-# NIRS
-/mne/io/nirx/ @rob-luke
-/mne/io/nihon/ @rob-luke
-/mne/io/preprocessing/nirs/ @rob-luke
-
-
 # IO
 /mne/io/brainvision @sappelhoff
 /mne/export @sappelhoff
-
 
 # Beamforming
 /mne/beamformer/ @britta-wstnr


### PR DESCRIPTION
@mne-tools/mne-python-steering-committee members: have you disabled repo-wide notifications so you only get notified when pinged, or thought about doing so because you get too many MNE-Python notifications?

There is a potential solution: add yourself to `.github/CODEOWNERS`, giving you opt-in support for file- and directory-level control over which PRs you get pinged to review. For the last four months [in SciPy](https://github.com/scipy/scipy/blob/master/.github/CODEOWNERS) I have found this to be very effective to get emails about PRs I can help with and not get emails about PRs I can't (or don't want to).

I have opened this WIP PR just to show one hypothetical example -- let's say @rob-luke decides he's getting too many emails and only wants to hear about fNIRS-related stuff. He could add his name for fNIRS-related files as I've done here. If he then unsubscribes from MNE-Python as a whole (while keeping @-mentions enabled), GitHub will automatically ping him when people change fNIRS-specific code.

The only potential downside I see is that @rob-luke might miss an *issue* that gets opened about fNIRS, but the folks who triage most issues (like @hoechenberger, @drammock, @agramfort, @cbrnr, etc.) typically @-ping the appropriate people in these cases already anyway, so continuing this practice should mitigate this issue. And having names enumerated in `CODEOWNERS` makes it clear who wants to be pinged about what issues, too.