### PR TITLE
[MRG, BUG] Fixed bug with EDF channel types and minor bug where other types of channels were not written and bug where annotations were not written to correct scale

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -155,9 +155,9 @@ Enhancements
 
 - Add remove methods for mesh objects in :class:`mne.viz.Brain` (:gh:`9688` by `Alex Rockhill`_)
 
-- Reading EDF files via :func:`mne.io.read_raw_edf` now can infer channel type from the signal label in the EDF header (:gh:`9694` by `Adam Li`_)
-
 - Add ability to export EDF+ files using :func:`mne.export.export_raw` (:gh:`9643` by `Adam Li`_)
+
+- Reading EDF files via :func:`mne.io.read_raw_edf` now can infer channel type from the signal label in the EDF header (:gh:`9694` by `Adam Li`_)
 
 
 Bugs

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -155,6 +155,11 @@ Enhancements
 
 - Add remove methods for mesh objects in :class:`mne.viz.Brain` (:gh:`9688` by `Alex Rockhill`_)
 
+- Reading EDF files via :func:`mne.io.read_raw_edf` now can infer channel type from the signal label in the EDF header (:gh:`9694` by `Adam Li`_)
+
+- Add ability to export EDF+ files using :func:`mne.export.export_raw` (:gh:`9643` by `Adam Li`_)
+
+
 Bugs
 ~~~~
 - Fix bug in :meth:`mne.io.Raw.pick` and related functions when parameter list contains channels which are not in info instance (:gh:`9708` **by new contributor** |Evgeny Goldstein|_)

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -125,6 +125,7 @@ def pytest_configure(config):
     ignore:.*`np.typeDict` is a deprecated.*:DeprecationWarning
     ignore:.*Creating an ndarray from ragged.*:numpy.VisibleDeprecationWarning
     ignore:^Please use.*scipy\..*:DeprecationWarning
+    ignore:.*Found the following unknown channel type.*:RuntimeWarning
     always::ResourceWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -254,7 +254,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
     path = _get_path(path, key, name)
     # To update the testing or misc dataset, push commits, then make a new
     # release on GitHub. Then update the "releases" variable:
-    releases = dict(testing='0.122', misc='0.18')
+    releases = dict(testing='0.123', misc='0.18')
     # And also update the "md5_hashes['testing']" variable below.
     # To update any other dataset, update the data archive itself (upload
     # an updated version) and update the md5 hash.
@@ -349,7 +349,7 @@ def _data_path(path=None, force_update=False, update_path=True, download=True,
         sample='12b75d1cb7df9dfb4ad73ed82f61094f',
         somato='32fd2f6c8c7eb0784a1de6435273c48b',
         spm='9f43f67150e3b694b523a21eb929ea75',
-        testing='3da5aacbed94282e69ed250fdecbb3e6',
+        testing='db07710c0b94476f954f60926685b5b7',
         multimodal='26ec847ae9ab80f58f204d09e2c08367',
         fnirs_motor='c4935d19ddab35422a69f3326a01fef8',
         opm='370ad1dcfd5c47e029e692c85358a374',

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -58,17 +58,24 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
         stim_index = np.atleast_1d(stim_index.squeeze()).tolist()
         drop_chs.extend([raw.ch_names[idx] for idx in stim_index])
 
-    # add warning if any channel types are not voltage based
-    # note: we can write these other channels, such as 'misc'
-    # but they just won't work because EDF doesn't support
-    # the idea of a 'misc' channel
+    # Add warning if any channel types are not voltage based.
+    # Users are expected to only export data that is voltage based,
+    # such as EEG, ECoG, sEEG, etc.
+    # Non-voltage channels are dropped by the export function.
+    # Note: we can write these other channels, such as 'misc'
+    # but these are simply a "catch all" for unknown or undesired
+    # channels.
     voltage_types = list(units) + ['stim', 'misc']
-    if any([ch not in voltage_types for ch in orig_ch_types]):
+    non_voltage_ch = [ch not in voltage_types for ch in orig_ch_types]
+    if any(non_voltage_ch):
         warn('There are non-voltage channels that are not set as "misc". '
+             f'{non_voltage_ch}'
              'EDF only supports writing Voltage-based data. '
              'These channels will not be written to the EDF file. '
              'If you would still like these channels to be written, '
-             'set their channel type to "misc".')
+             'you can set their channel type to "misc", but they will '
+             'most likely not be written correctly. For example, EDF '
+             'does not support storing MEG channels.')
 
     ch_names = [ch for ch in raw.ch_names if ch not in drop_chs]
     ch_types = np.array(raw.get_channel_types(picks=ch_names))

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -69,6 +69,7 @@ def _export_raw(fname, raw, physical_range):
              'These channels will not be written correctly.')
 
     ch_names = [ch for ch in raw.ch_names if ch not in drop_chs]
+    ch_types = np.array(raw.get_channel_types(picks=ch_names))
     n_channels = len(ch_names)
     n_times = raw.n_times
 
@@ -101,7 +102,6 @@ def _export_raw(fname, raw, physical_range):
         ch_types_phys_max = dict()
         ch_types_phys_min = dict()
 
-        ch_types = np.array(raw.get_channel_types(picks=ch_names))
         for _type in np.unique(ch_types):
             _picks = np.nonzero(ch_types == _type)[0]
             _data = raw.get_data(units=units, picks=_picks)

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -107,8 +107,14 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
         for _type in np.unique(ch_types):
             _picks = np.nonzero(ch_types == _type)[0]
             _data = raw.get_data(units=units, picks=_picks)
+            if _type == 'ecog':
+                print(_data)
             ch_types_phys_max[_type] = _data.max()
             ch_types_phys_min[_type] = _data.min()
+        
+        from pprint import pprint
+        pprint(ch_types_phys_max)
+        pprint(ch_types_phys_min)
     else:
         # get the physical min and max of the data in uV
         # Physical ranges of the data in uV is usually set by the manufacturer
@@ -225,7 +231,10 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
             buf[:len(ch_data)] = ch_data
             err = hdl.writeSamples(buf)
             if err != 0:
-                raise RuntimeError(f"writeSamples() returned error: {err}")
+                print(ch_types[jdx])
+                print(jdx)
+                raise RuntimeError(f"writeSamples() for channel {ch_names[jdx]} "
+                                   f"returned error: {err}")
 
         # there was an incomplete datarecord
         if len(ch_data) != len(buf):

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -38,7 +38,7 @@ def _export_raw(fname, raw, physical_range):
     """
     # scale to save data in EDF
     phys_dims = 'uV'
-    
+
     # get EEG-related data in uV
     units = dict(eeg='uV', ecog='uV', seeg='uV', eog='uV', ecg='uV', emg='uV',
                  bio='uV', dbs='uV')

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -105,7 +105,7 @@ def _export_raw(fname, raw, physical_range):
             # XXX: not sure how to compare to get a robust check
             # - needs to account for maybe normalizing data onto
             # a consistent scale
-            # - then basically do hard-threshold check for 
+            # - then basically do hard-threshold check for
             # super outliers
             max_diffs = pdist(data_max)
             min_diffs = pdist(data_min)

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -30,7 +30,7 @@ def _try_to_set_value(header, key, value, channel_index=None):
                            f"{return_val}.")
 
 
-def _export_raw(fname, raw, physical_range):
+def _export_raw(fname, raw, physical_range, add_ch_type):
     """Export Raw objects to EDF files.
 
     TODO: if in future the Info object supports transducer or
@@ -132,7 +132,8 @@ def _export_raw(fname, raw, physical_range):
     # set channel data
     for idx, ch in enumerate(ch_names):
         ch_type = ch_types[idx]
-        signal_label = f'{ch_type.upper()} {ch}'
+        signal_label = f'{ch_type.upper()} ' if add_ch_type else ''
+        signal_label = signal_label + f'{ch}'
         if len(signal_label) > 16:
             raise RuntimeError(f'Signal label for {ch} ({ch_type}) is '
                                f'longer then 16 characters, which is not '

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -79,7 +79,8 @@ def _export_raw(fname, raw, physical_range):
     filter_str_info = f"HP:{highpass}Hz LP:{lowpass}Hz N:{linefreq}Hz"
 
     # get EEG-related data in uV
-    units = dict(eeg='uV', ecog='uV', seeg='uV', eog='uV', ecg='uV', emg='uV')
+    units = dict(eeg='uV', ecog='uV', seeg='uV', eog='uV', ecg='uV', emg='uV',
+                 bio='uV', dbs='uV')
 
     # get the entire dataset in uV
     data = raw.get_data(units=units, picks=ch_names)
@@ -89,7 +90,7 @@ def _export_raw(fname, raw, physical_range):
         ch_types_phys_max = dict()
         ch_types_phys_min = dict()
 
-        ch_types = np.array(raw.get_channel_types(picks=raw.ch_names))
+        ch_types = np.array(raw.get_channel_types(picks=ch_names))
         for _type in np.unique(ch_types):
             _picks = np.nonzero(ch_types == _type)[0]
             _data = raw.get_data(units=units, picks=_picks)
@@ -123,7 +124,6 @@ def _export_raw(fname, raw, physical_range):
             # take the channel type minimum and maximum
             ch_type = ch_types[idx]
             pmin, pmax = ch_types_phys_min[ch_type], ch_types_phys_max[ch_type]
-
         for key, val in [('PhysicalMaximum', pmax),
                          ('PhysicalMinimum', pmin),
                          ('DigitalMaximum', digital_max),

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -204,16 +204,19 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
         _try_to_set_value(hdl, 'DataRecordDuration', data_record_duration)
 
     # compute number of data records to loop over
-    n_blocks = n_times / out_sfreq
+    n_blocks = np.ceil(n_times / out_sfreq).astype(int)
 
     # increase the number of annotation signals if necessary
     n_annotations = len(raw.annotations)
-    if n_annotations > n_blocks:
-        n_annot_signals = np.ceil(n_annotations / n_blocks).astype(int)
-        hdl.setNumberOfAnnotationSignals(n_annot_signals)
+    if n_annotations is not None:
+        n_annot_chans = int(n_annotations / n_blocks)
+        if np.mod(n_annotations, n_blocks):
+            n_annot_chans += 1
+        if n_annot_chans > 1:
+            hdl.setNumberOfAnnotationSignals(n_annot_chans)
 
     # Write each data record sequentially
-    for idx in range(np.ceil(n_blocks).astype(int)):
+    for idx in range(n_blocks):
         end_samp = (idx + 1) * out_sfreq
         if end_samp > n_times:
             end_samp = n_times

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -4,8 +4,6 @@
 # License: BSD-3-Clause
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_array_almost_equal
-from scipy.spatial.distance import pdist
 
 from ..utils import _check_edflib_installed, warn
 _check_edflib_installed()
@@ -107,8 +105,8 @@ def _export_raw(fname, raw, physical_range):
             # a consistent scale
             # - then basically do hard-threshold check for
             # super outliers
-            max_diffs = pdist(data_max)
-            min_diffs = pdist(data_min)
+            # max_diffs = pdist(data_max)
+            # min_diffs = pdist(data_min)
 
             ch_types_phys_max[_type].append(data_max)
             ch_types_phys_min[_type].append(data_min)

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -62,11 +62,13 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
     # note: we can write these other channels, such as 'misc'
     # but they just won't work because EDF doesn't support
     # the idea of a 'misc' channel
-    voltage_types = list(units) + ['stim']
+    voltage_types = list(units) + ['stim', 'misc']
     if any([ch not in voltage_types for ch in orig_ch_types]):
-        warn('There are non-voltage channels. '
+        warn('There are non-voltage channels that are not set as "misc". '
              'EDF only supports writing Voltage-based data. '
-             'These channels will not be written correctly.')
+             'These channels will not be written to the EDF file. '
+             'If you would still like these channels to be written, '
+             'set their channel type to "misc".')
 
     ch_names = [ch for ch in raw.ch_names if ch not in drop_chs]
     ch_types = np.array(raw.get_channel_types(picks=ch_names))
@@ -183,7 +185,7 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
     # set measurement date
     meas_date = raw.info['meas_date']
     if meas_date:
-        subsecond = meas_date.microsecond / 100.
+        subsecond = int(meas_date.microsecond / 100)
         if hdl.setStartDateTime(year=meas_date.year, month=meas_date.month,
                                 day=meas_date.day, hour=meas_date.hour,
                                 minute=meas_date.minute,

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -4,6 +4,8 @@
 # License: BSD-3-Clause
 
 import numpy as np
+from numpy.testing import assert_allclose, assert_array_almost_equal
+from scipy.spatial.distance import pdist
 
 from ..utils import _check_edflib_installed, warn
 _check_edflib_installed()
@@ -94,8 +96,22 @@ def _export_raw(fname, raw, physical_range):
         for _type in np.unique(ch_types):
             _picks = np.nonzero(ch_types == _type)[0]
             _data = raw.get_data(units=units, picks=_picks)
-            ch_types_phys_max[_type] = _data.max()
-            ch_types_phys_min[_type] = _data.min()
+            data_max = _data.max(axis=1)
+            data_min = _data.min(axis=1)
+
+            # perform a check to see that all data ranges are
+            # within two decimal places away, else it is possible
+            # that the user incorrectly set channel groupings
+            # XXX: not sure how to compare to get a robust check
+            # - needs to account for maybe normalizing data onto
+            # a consistent scale
+            # - then basically do hard-threshold check for 
+            # super outliers
+            max_diffs = pdist(data_max)
+            min_diffs = pdist(data_min)
+
+            ch_types_phys_max[_type].append(data_max)
+            ch_types_phys_min[_type].append(data_min)
     else:
         # get the physical min and max of the data in uV
         # Physical ranges of the data in uV is usually set by the manufacturer

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -62,7 +62,7 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
     # note: we can write these other channels, such as 'misc'
     # but they just won't work because EDF doesn't support
     # the idea of a 'misc' channel
-    voltage_types = list(units.keys()) + ['stim']
+    voltage_types = list(units) + ['stim']
     if any([ch not in voltage_types for ch in orig_ch_types]):
         warn('There are non-voltage channels. '
              'EDF only supports writing Voltage-based data. '

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -206,6 +206,12 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
     # compute number of data records to loop over
     n_blocks = n_times / out_sfreq
 
+    # increase the number of annotation signals if necessary
+    n_annotations = len(raw.annotations)
+    if n_annotations > n_blocks:
+        n_annot_signals = np.ceil(n_annotations / n_blocks).astype(int)
+        hdl.setNumberOfAnnotationSignals(n_annot_signals)
+
     # Write each data record sequentially
     for idx in range(np.ceil(n_blocks).astype(int)):
         end_samp = (idx + 1) * out_sfreq
@@ -235,7 +241,6 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
                  f'so {(len(buf) - len(ch_data)) / sfreq} seconds of zeros '
                  'were appended to all channels when writing the final block.')
 
-    # XXX: improve the ability to write arbitrary number of annotations
     # write annotations
     if raw.annotations:
         for desc, onset, duration in zip(raw.annotations.description,

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -235,6 +235,7 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
                  f'so {(len(buf) - len(ch_data)) / sfreq} seconds of zeros '
                  'were appended to all channels when writing the final block.')
 
+    # XXX: improve the ability to write arbitrary number of annotations
     # write annotations
     if raw.annotations:
         for desc, onset, duration in zip(raw.annotations.description,

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -131,9 +131,16 @@ def _export_raw(fname, raw, physical_range):
 
     # set channel data
     for idx, ch in enumerate(ch_names):
+        ch_type = ch_types[idx]
+        signal_label = f'{ch_type.upper()} {ch}'
+        if len(signal_label) > 16:
+            raise RuntimeError(f'Signal label for {ch} ({ch_type}) is '
+                               f'longer then 16 characters, which is not '
+                               f'supported in EDF. Please shorten the channel '
+                               f'name before exporting to EDF.')
+
         if physical_range == 'auto':
             # take the channel type minimum and maximum
-            ch_type = ch_types[idx]
             pmin, pmax = ch_types_phys_min[ch_type], ch_types_phys_max[ch_type]
         for key, val in [('PhysicalMaximum', pmax),
                          ('PhysicalMinimum', pmin),
@@ -141,7 +148,7 @@ def _export_raw(fname, raw, physical_range):
                          ('DigitalMinimum', digital_min),
                          ('PhysicalDimension', phys_dims),
                          ('SampleFrequency', out_sfreq),
-                         ('SignalLabel', ch),
+                         ('SignalLabel', signal_label),
                          ('PreFilter', filter_str_info)]:
             _try_to_set_value(hdl, key, val, channel_index=idx)
 

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -132,8 +132,7 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
     # set channel data
     for idx, ch in enumerate(ch_names):
         ch_type = ch_types[idx]
-        signal_label = f'{ch_type.upper()} ' if add_ch_type else ''
-        signal_label = signal_label + f'{ch}'
+        signal_label = f'{ch_type.upper()} {ch}' if add_ch_type else ch
         if len(signal_label) > 16:
             raise RuntimeError(f'Signal label for {ch} ({ch_type}) is '
                                f'longer then 16 characters, which is not '

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -111,10 +111,6 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
                 print(_data)
             ch_types_phys_max[_type] = _data.max()
             ch_types_phys_min[_type] = _data.min()
-        
-        from pprint import pprint
-        pprint(ch_types_phys_max)
-        pprint(ch_types_phys_min)
     else:
         # get the physical min and max of the data in uV
         # Physical ranges of the data in uV is usually set by the manufacturer
@@ -233,8 +229,9 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
             if err != 0:
                 print(ch_types[jdx])
                 print(jdx)
-                raise RuntimeError(f"writeSamples() for channel {ch_names[jdx]} "
-                                   f"returned error: {err}")
+                raise RuntimeError(
+                    f"writeSamples() for channel{ch_names[jdx]} "
+                    f"returned error: {err}")
 
         # there was an incomplete datarecord
         if len(ch_data) != len(buf):

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -107,8 +107,6 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
         for _type in np.unique(ch_types):
             _picks = np.nonzero(ch_types == _type)[0]
             _data = raw.get_data(units=units, picks=_picks)
-            if _type == 'ecog':
-                print(_data)
             ch_types_phys_max[_type] = _data.max()
             ch_types_phys_min[_type] = _data.min()
     else:
@@ -227,8 +225,6 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
             buf[:len(ch_data)] = ch_data
             err = hdl.writeSamples(buf)
             if err != 0:
-                print(ch_types[jdx])
-                print(jdx)
                 raise RuntimeError(
                     f"writeSamples() for channel{ch_names[jdx]} "
                     f"returned error: {err}")

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -59,11 +59,14 @@ def _export_raw(fname, raw, physical_range):
         drop_chs.extend([raw.ch_names[idx] for idx in stim_index])
 
     # add warning if any channel types are not voltage based
+    # note: we can write these other channels, such as 'misc'
+    # but they just won't work because EDF doesn't support
+    # the idea of a 'misc' channel
     voltage_types = list(units.keys()) + ['stim']
     if any([ch not in voltage_types for ch in orig_ch_types]):
         warn('There are non-voltage channels. '
-             'EDF only supports writing Voltage-based data, and '
-             'these channels will be dropped.')
+             'EDF only supports writing Voltage-based data. '
+             'These channels will not be written correctly.')
 
     ch_names = [ch for ch in raw.ch_names if ch not in drop_chs]
     n_channels = len(ch_names)

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -240,6 +240,9 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
         for desc, onset, duration in zip(raw.annotations.description,
                                          raw.annotations.onset,
                                          raw.annotations.duration):
+            # annotations are written in terms of 100 microseconds
+            onset = onset * 10000
+            duration = duration * 10000
             if hdl.writeAnnotation(onset, duration, desc) != 0:
                 raise RuntimeError(f'writeAnnotation() returned an error '
                                    f'trying to write {desc} at {onset} '

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -135,7 +135,7 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
         signal_label = f'{ch_type.upper()} {ch}' if add_ch_type else ch
         if len(signal_label) > 16:
             raise RuntimeError(f'Signal label for {ch} ({ch_type}) is '
-                               f'longer then 16 characters, which is not '
+                               f'longer than 16 characters, which is not '
                                f'supported in EDF. Please shorten the channel '
                                f'name before exporting to EDF.')
 

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -10,8 +10,8 @@ from ..utils import verbose, logger, _validate_type
 
 
 @verbose
-def export_raw(fname, raw, fmt='auto', physical_range='auto', add_ch_type=False,
-               verbose=None):
+def export_raw(fname, raw, fmt='auto', physical_range='auto',
+               add_ch_type=False, verbose=None):
     """Export Raw to external formats.
 
     Supported formats: EEGLAB (set, uses :mod:`eeglabio`)

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -16,8 +16,8 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
 
     Supported formats:
 
-        - EEGLAB (set, uses :mod:`eeglabio`)
-        - EDF (edf, uses ``EDFlib-Python``)
+        - EEGLAB (.set, uses :mod:`eeglabio`)
+        - EDF (.edf, uses ``EDFlib-Python``)
 
     %(export_warning)s :meth:`mne.io.Raw.save` instead.
 

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -17,7 +17,6 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
     Supported formats:
         - EEGLAB (.set, uses :mod:`eeglabio`)
         - EDF (.edf, uses ``EDFlib-Python``)
-
     %(export_warning)s :meth:`mne.io.Raw.save` instead.
 
     Parameters

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -15,8 +15,10 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
     """Export Raw to external formats.
 
     Supported formats:
-    - EEGLAB (set, uses :mod:`eeglabio`)
-    - EDF (edf, uses ``EDFlib-Python``)
+
+        - EEGLAB (set, uses :mod:`eeglabio`)
+        - EDF (edf, uses ``EDFlib-Python``)
+
     %(export_warning)s :meth:`mne.io.Raw.save` instead.
 
     Parameters

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -10,7 +10,8 @@ from ..utils import verbose, logger, _validate_type
 
 
 @verbose
-def export_raw(fname, raw, fmt='auto', physical_range='auto', verbose=None):
+def export_raw(fname, raw, fmt='auto', physical_range='auto', add_ch_type=False,
+               verbose=None):
     """Export Raw to external formats.
 
     Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
@@ -23,6 +24,7 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto', verbose=None):
         The raw instance to export.
     %(export_params_fmt)s
     %(export_params_physical_range)s
+    %(export_params_add_ch_type)s
     %(verbose)s
 
     Notes
@@ -42,7 +44,7 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto', verbose=None):
         _export_raw(fname, raw)
     elif fmt == 'edf':
         from ._edf import _export_raw
-        _export_raw(fname, raw, physical_range)
+        _export_raw(fname, raw, physical_range, add_ch_type)
     elif fmt == 'brainvision':
         raise NotImplementedError('Export to BrainVision not implemented.')
 

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -14,8 +14,10 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
                add_ch_type=False, verbose=None):
     """Export Raw to external formats.
 
-    Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
-    %(export_warning)s
+    Supported formats:
+    - EEGLAB (set, uses :mod:`eeglabio`)
+    - EDF (edf, uses :mod:`EDFlib-Python`)
+    %(export_warning)s :meth:`mne.io.Raw.save` instead.
 
     Parameters
     ----------

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -15,7 +15,6 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
     """Export Raw to external formats.
 
     Supported formats:
-
         - EEGLAB (.set, uses :mod:`eeglabio`)
         - EDF (.edf, uses ``EDFlib-Python``)
 

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -16,7 +16,7 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
 
     Supported formats:
     - EEGLAB (set, uses :mod:`eeglabio`)
-    - EDF (edf, uses :mod:`EDFlib-Python`)
+    - EDF (edf, uses ``EDFlib-Python``)
     %(export_warning)s :meth:`mne.io.Raw.save` instead.
 
     Parameters

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -62,7 +62,7 @@ def test_integer_sfreq_edf(tmp_path):
     ch_names = np.arange(len(ch_types)).astype(str).tolist()
     info = create_info(ch_names, sfreq=1000,
                        ch_types=ch_types)
-    data = prng.random(size=(len(ch_names), 1000)) * 1e-5
+    data = rng.random(size=(len(ch_names), 1000)) * 1e-5
 
     # include subject info and measurement date
     subject_info = dict(first_name='mne', last_name='python',

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -107,7 +107,7 @@ def test_integer_sfreq_edf(tmp_path):
     # test that warning is raised if there are non-voltage based channels
     raw = RawArray(data, info)
     with pytest.warns(RuntimeWarning, match='The unit'):
-       raw.set_channel_types({'1': 'hbr'})
+        raw.set_channel_types({'1': 'hbr'})
     with pytest.warns(RuntimeWarning, match='There are non-voltage channels'):
         raw.export(temp_fname)
 

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -111,6 +111,16 @@ def test_integer_sfreq_edf(tmp_path):
     with pytest.warns(RuntimeWarning, match='There are non-voltage channels'):
         raw.export(temp_fname)
 
+    # the data should still match though
+    raw_read = read_raw_edf(temp_fname, preload=True)
+    raw.drop_channels('2')
+    assert raw.ch_names == raw_read.ch_names
+    orig_raw_len = len(raw)
+    assert_array_almost_equal(
+        raw.get_data(), raw_read.get_data()[:, :orig_raw_len], decimal=4)
+    assert_allclose(
+        raw.times, raw_read.times[:orig_raw_len], rtol=0, atol=1e-5)
+
 
 @pytest.mark.skipif(not _check_edflib_installed(strict=False),
                     reason='edflib-python not installed')

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -200,7 +200,7 @@ def test_rawarray_edf(tmp_path):
     raw = RawArray(data, info)
     with pytest.warns(RuntimeWarning, match='The unit'):
         raw.set_channel_types({'9': 'hbr'})
-    with pytest.warns(RuntimeWarning, match='There are non-voltage channels'):
+    with pytest.warns(RuntimeWarning, match='Non-voltage channels'):
         raw.export(temp_fname)
 
     # data should match up to the non-accepted channel

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -55,14 +55,14 @@ def test_export_raw_eeglab(tmpdir):
                     reason='edflib-python not installed')
 def test_integer_sfreq_edf(tmp_path):
     """Test saving a Raw array with integer sfreq to EDF."""
-    np.random.RandomState(12345)
+    prng = np.random.RandomState(12345)
     format = 'edf'
     ch_types = ['eeg', 'eeg', 'stim', 'ecog', 'seeg', 'eog', 'ecg', 'emg',
                 'dbs', 'bio']
     ch_names = np.arange(len(ch_types)).astype(str).tolist()
     info = create_info(ch_names, sfreq=1000,
                        ch_types=ch_types)
-    data = np.random.random(size=(len(ch_names), 1000)) * 1e-5
+    data = prng.random(size=(len(ch_names), 1000)) * 1e-5
 
     # include subject info and measurement date
     subject_info = dict(first_name='mne', last_name='python',

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -112,8 +112,9 @@ def test_export_edf_annotations(tmp_path):
     data = rng.random(size=(len(ch_names), 2000)) * 1.e-5
     raw = RawArray(data, info)
 
-    annotations = Annotations(onset=[0.01, 1.05], duration=[0, 0],
-                              description=['test1', 'test2'])
+    annotations = Annotations(
+        onset=[0.01, 0.05, 0.90, 1.05], duration=[0, 1, 0, 0],
+        description=['test1', 'test2', 'test3', 'test4'])
     raw.set_annotations(annotations)
 
     # export
@@ -123,6 +124,8 @@ def test_export_edf_annotations(tmp_path):
     # read in the file
     raw_read = read_raw_edf(temp_fname, preload=True)
     assert_array_equal(raw.annotations.onset, raw_read.annotations.onset)
+    assert_array_equal(raw.annotations.description,
+                       raw_read.annotations.description)
 
 
 @pytest.mark.skipif(not _check_edflib_installed(strict=False),

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -124,6 +124,7 @@ def test_export_edf_annotations(tmp_path):
     # read in the file
     raw_read = read_raw_edf(temp_fname, preload=True)
     assert_array_equal(raw.annotations.onset, raw_read.annotations.onset)
+    assert_array_equal(raw.annotations.duration, raw_read.annotations.duration)
     assert_array_equal(raw.annotations.description,
                        raw_read.annotations.description)
 

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -57,9 +57,11 @@ def test_integer_sfreq_edf(tmp_path):
     """Test saving a Raw array with integer sfreq to EDF."""
     np.random.RandomState(12345)
     format = 'edf'
-    info = create_info(['1', '2', '3'], sfreq=1000,
-                       ch_types=['eeg', 'eeg', 'stim'])
-    data = np.random.random(size=(3, 1000)) * 1e-6
+    ch_types = ['eeg', 'eeg', 'stim', 'ecog', 'seeg', 'eog', 'ecg', 'emg']
+    ch_names = np.arange(len(ch_types)).astype(str).tolist()
+    info = create_info(ch_names, sfreq=1000,
+                       ch_types=ch_types)
+    data = np.random.random(size=(len(ch_names), 1000)) * 1e-5
 
     # include subject info and measurement date
     subject_info = dict(first_name='mne', last_name='python',
@@ -74,7 +76,7 @@ def test_integer_sfreq_edf(tmp_path):
     raw_read = read_raw_edf(temp_fname, preload=True)
 
     # stim channel should be dropped
-    raw.drop_channels('3')
+    raw.drop_channels('2')
 
     assert raw.ch_names == raw_read.ch_names
     # only compare the original length, since extra zeros are appended

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -55,7 +55,7 @@ def test_export_raw_eeglab(tmpdir):
                     reason='edflib-python not installed')
 def test_integer_sfreq_edf(tmp_path):
     """Test saving a Raw array with integer sfreq to EDF."""
-    prng = np.random.RandomState(12345)
+    rng = np.random.RandomState(12345)
     format = 'edf'
     ch_types = ['eeg', 'eeg', 'stim', 'ecog', 'seeg', 'eog', 'ecg', 'emg',
                 'dbs', 'bio']

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -87,6 +87,11 @@ def test_integer_sfreq_edf(tmp_path):
     assert_allclose(
         raw.times, raw_read.times[:orig_raw_len], rtol=0, atol=1e-5)
 
+    # check channel types except for 'bio', which loses its type
+    orig_ch_types = raw.get_channel_types()
+    read_ch_types = raw_read.get_channel_types()
+    assert_array_equal(orig_ch_types[:-1], read_ch_types[:-1])
+
     # export now by hard-coding physical range
     raw.export(temp_fname, physical_range=(-3200, 3200))
 

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -57,7 +57,8 @@ def test_integer_sfreq_edf(tmp_path):
     """Test saving a Raw array with integer sfreq to EDF."""
     np.random.RandomState(12345)
     format = 'edf'
-    ch_types = ['eeg', 'eeg', 'stim', 'ecog', 'seeg', 'eog', 'ecg', 'emg']
+    ch_types = ['eeg', 'eeg', 'stim', 'ecog', 'seeg', 'eog', 'ecg', 'emg',
+                'dbs', 'bio']
     ch_names = np.arange(len(ch_types)).astype(str).tolist()
     info = create_info(ch_names, sfreq=1000,
                        ch_types=ch_types)

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -92,7 +92,7 @@ def test_integer_sfreq_edf(tmp_path):
     read_ch_types = raw_read.get_channel_types()
     assert_array_equal(orig_ch_types[:-1], read_ch_types[:-1])
 
-    # channel name can't be longer then 16 characters with the type added
+    # channel name can't be longer than 16 characters with the type added
     raw_bad = raw.copy()
     raw_bad.rename_channels({'1': 'abcdefghijklmnopqrstuvwxyz'})
     with pytest.raises(RuntimeError, match='Signal label'), \

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -158,6 +158,11 @@ def test_export_raw_edf(tmp_path, dataset, format):
     with pytest.raises(RuntimeError, match='The minimum'), \
             pytest.warns(RuntimeWarning, match='Data has a non-integer'):
         raw.export(temp_fname, physical_range=(0, 1e6))
+    raw_bad = raw.copy()
+    raw_bad.rename_channels({'1': 'abcdefghijklmnopqrs'})
+    with pytest.raises(RuntimeError, match='Signal label'), \
+            pytest.warns(RuntimeWarning, match='Data has a non-integer'):
+        raw_bad.export(temp_fname)
 
     if dataset == 'test':
         with pytest.warns(RuntimeWarning, match='Data has a non-integer'):

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -104,6 +104,13 @@ def test_integer_sfreq_edf(tmp_path):
     with pytest.raises(RuntimeError, match='Setting start date time'):
         raw.export(temp_fname)
 
+    # test that warning is raised if there are non-voltage based channels
+    raw = RawArray(data, info)
+    with pytest.warns(RuntimeWarning, match='The unit'):
+       raw.set_channel_types({'1': 'hbr'})
+    with pytest.warns(RuntimeWarning, match='There are non-voltage channels'):
+        raw.export(temp_fname)
+
 
 @pytest.mark.skipif(not _check_edflib_installed(strict=False),
                     reason='edflib-python not installed')

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -5,7 +5,6 @@
 # License: BSD-3-Clause
 
 from datetime import datetime, timezone
-from operator import add
 from mne.io import RawArray
 from mne.io.meas_info import create_info
 from pathlib import Path

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -54,9 +54,10 @@ def test_export_raw_eeglab(tmpdir):
 @pytest.mark.skipif(not _check_edflib_installed(strict=False),
                     reason='edflib-python not installed')
 def test_double_export_edf(tmp_path):
+    """Test exporting an EDF file multiple times."""
     rng = np.random.RandomState(123456)
     format = 'edf'
-    ch_types = ['eeg', 'eeg', 'stim', 'ecog', 'ecog', 'seeg', 
+    ch_types = ['eeg', 'eeg', 'stim', 'ecog', 'ecog', 'seeg',
                 'eog', 'ecg', 'emg', 'dbs', 'bio']
     ch_names = np.arange(len(ch_types)).astype(str).tolist()
     info = create_info(ch_names, sfreq=1000,

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -101,6 +101,7 @@ def test_double_export_edf(tmp_path):
 @pytest.mark.skipif(not _check_edflib_installed(strict=False),
                     reason='edflib-python not installed')
 def test_export_edf_annotations(tmp_path):
+    """Test that exporting EDF preserves annotations."""
     rng = np.random.RandomState(123456)
     format = 'edf'
     ch_types = ['eeg', 'eeg', 'stim', 'ecog', 'ecog', 'seeg',

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -13,7 +13,6 @@
 from contextlib import nullcontext
 from copy import deepcopy
 from datetime import timedelta
-from operator import add
 import os
 import os.path as op
 import shutil
@@ -1475,8 +1474,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                    split_size, split_naming, 0, None, overwrite)
 
     @verbose
-    def export(self, fname, fmt='auto', physical_range='auto', add_ch_type=False,
-               verbose=None):
+    def export(self, fname, fmt='auto', physical_range='auto',
+               add_ch_type=False, verbose=None):
         """Export Raw to external formats.
 
         Supported formats: EEGLAB (set, uses :mod:`eeglabio`)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -13,6 +13,7 @@
 from contextlib import nullcontext
 from copy import deepcopy
 from datetime import timedelta
+from operator import add
 import os
 import os.path as op
 import shutil
@@ -1474,7 +1475,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                    split_size, split_naming, 0, None, overwrite)
 
     @verbose
-    def export(self, fname, fmt='auto', physical_range='auto', verbose=None):
+    def export(self, fname, fmt='auto', physical_range='auto', add_ch_type=False,
+               verbose=None):
         """Export Raw to external formats.
 
         Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
@@ -1485,6 +1487,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(export_params_fname)s
         %(export_params_fmt)s
         %(export_params_physical_range)s
+        %(export_params_add_ch_type)s
         %(verbose)s
 
         Notes
@@ -1494,7 +1497,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """
         from ..export import export_raw
         export_raw(fname, self, fmt, physical_range=physical_range,
-                   verbose=verbose)
+                   add_ch_type=add_ch_type, verbose=verbose)
 
     def _tmin_tmax_to_start_stop(self, tmin, tmax):
         start = int(np.floor(tmin * self.info['sfreq']))

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -454,7 +454,7 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
             edf_info['units'][idx] = 1
         chs.append(chan_info)
 
-    # warn if channel type was not inferrable
+    # warn if channel type was not inferable
     if len(bad_map):
         bad_map = '\n'.join(f'{ch_name}: {ch_type}'
                             for ch_name, ch_type in bad_map.items())

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -447,10 +447,10 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
             edf_info['units'][idx] = 1
         chs.append(chan_info)
 
-    # warn if channel type was not inferable
+    # warn if channel type was not inferrable
     if len(bad_map):
-        bad_map = '\n'.join([f'{ch_name}: {ch_type}'
-                            for ch_name, ch_type in bad_map.items()])
+        bad_map = '\n'.join(f'{ch_name}: {ch_type}'
+                            for ch_name, ch_type in bad_map.items())
         warn(f'Found the following unknown channel type mapping(s), '
              f'setting the channel type to EEG:\n{bad_map}')
 
@@ -646,7 +646,6 @@ def _read_edf_header(fname, exclude):
         ch_labels = [fid.read(16).strip().decode('latin-1')
                      for ch in channels]
 
-        # ch_names = signal_labels.copy()
         # get channel names and optionally channel type
         # EDF specification contains 16 bytes that encode channel names,
         # optionally prefixed by a string representing channel type separated

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -643,7 +643,7 @@ def _read_edf_header(fname, exclude):
         channels = list(range(nchan))
 
         # read in 16 byte labels and strip any extra spaces at the end
-        signal_labels = [fid.read(16).strip().decode('latin-1')
+        ch_labels = [fid.read(16).strip().decode('latin-1')
                          for ch in channels]
 
         # ch_names = signal_labels.copy()
@@ -653,15 +653,15 @@ def _read_edf_header(fname, exclude):
         # by a space
         ch_names = []
         ch_types = []
-        for ch, new_label in enumerate(signal_labels):
+        for ch_idx, this_label in enumerate(signal_labels):
             # if no channel type, then we will default to eeg
             ch_type = None
-            ch_name = new_label
+            ch_name = this_label
 
             # space is found, so the prefix is the channel type. 'Annotations'
             # is also a keyword we search for
-            if new_label.count(' ') == 1 and ('Annotations' not in new_label):
-                ch_type, ch_name = new_label.split(' ')
+            if this_label.count(' ') == 1 and ('Annotations' not in this_label):
+                ch_type, ch_name = this_label.split(' ')
 
                 # channel types should be upper case for easy comparison
                 ch_type = ch_type.upper()

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -644,7 +644,7 @@ def _read_edf_header(fname, exclude):
 
         # read in 16 byte labels and strip any extra spaces at the end
         ch_labels = [fid.read(16).strip().decode('latin-1')
-                         for ch in channels]
+                     for ch in channels]
 
         # ch_names = signal_labels.copy()
         # get channel names and optionally channel type
@@ -653,14 +653,15 @@ def _read_edf_header(fname, exclude):
         # by a space
         ch_names = []
         ch_types = []
-        for ch_idx, this_label in enumerate(signal_labels):
+        for ch_idx, this_label in enumerate(ch_labels):
             # if no channel type, then we will default to eeg
             ch_type = None
             ch_name = this_label
 
             # space is found, so the prefix is the channel type. 'Annotations'
             # is also a keyword we search for
-            if this_label.count(' ') == 1 and ('Annotations' not in this_label):
+            if (this_label.count(' ') == 1) and \
+                    ('Annotations' not in this_label):
                 ch_type, ch_name = this_label.split(' ')
 
                 # channel types should be upper case for easy comparison

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -427,7 +427,7 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
         elif ch_type not in ch_type_mapping:
             bad_map[ch_name] = ch_type
 
-        # if user passes in explict mapping for eog, misc and stim
+        # if user passes in explicit mapping for eog, misc and stim
         # channels set them here
         if ch_name in eog or idx in eog or idx - nchan in eog:
             chan_info['coil_type'] = FIFF.FIFFV_COIL_NONE
@@ -447,12 +447,12 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
             edf_info['units'][idx] = 1
         chs.append(chan_info)
 
-    # warn if channel type was not inferrable
-    # if len(bad_map):
-    #     bad_map = '\n'.join([f'{ch_name}: {ch_type}'
-    #                         for ch_name, ch_type in bad_map.items()])
-    #     warn(f'Found the following unknown channel type mapping(s), '
-    #          f'setting the channel type to EEG:\n{bad_map}')
+    # warn if channel type was not inferable
+    if len(bad_map):
+        bad_map = '\n'.join([f'{ch_name}: {ch_type}'
+                            for ch_name, ch_type in bad_map.items()])
+        warn(f'Found the following unknown channel type mapping(s), '
+             f'setting the channel type to EEG:\n{bad_map}')
 
     edf_info['stim_channel_idxs'] = stim_channel_idxs
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -364,6 +364,7 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
 
     sel = edf_info['sel']  # selection of channels not excluded
     ch_names = edf_info['ch_names']  # of length len(sel)
+    ch_types = edf_info['ch_types']  # of length len(sel)
     n_samps = edf_info['n_samps'][sel]
     nchan = edf_info['nchan']
     physical_ranges = edf_info['physical_max'] - edf_info['physical_min']
@@ -384,6 +385,23 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
     chs = list()
     pick_mask = np.ones(len(ch_names))
 
+    # common channel type names mapped to internal ch types
+    ch_type_mapping = {
+        'EEG': FIFF.FIFFV_EEG_CH,
+        'SEEG': FIFF.FIFFV_SEEG_CH,
+        'ECOG': FIFF.FIFFV_ECOG_CH,
+        'DBS': FIFF.FIFFV_DBS_CH,
+        'EOG': FIFF.FIFFV_EOG_CH,
+        'ECG': FIFF.FIFFV_ECG_CH,
+        'EMG': FIFF.FIFFV_EMG_CH,
+        'SAO2': FIFF.FIFFV_BIO_CH,
+        'RESP': FIFF.FIFFV_RESP_CH,
+    }
+    if any([ch_type is None for ch_type in ch_types]):
+        warn('Not all channel types could be inferred when reading the EDF '
+             f'file: {fname}. You should check the channel types and set '
+             'them using `raw.set_channel_types`.')
+
     for idx, ch_name in enumerate(ch_names):
         chan_info = {}
         chan_info['cal'] = 1.
@@ -397,6 +415,18 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
         chan_info['coil_type'] = FIFF.FIFFV_COIL_EEG
         chan_info['kind'] = FIFF.FIFFV_EEG_CH
         chan_info['loc'] = np.zeros(12)
+
+        # if the edf info contained channel type information
+        # set it now
+        ch_type = ch_types[idx]
+        if ch_type is not None:
+            chan_info['kind'] = ch_type_mapping.get(ch_type)
+            if ch_type not in ['EEG', 'ECOG', 'SEEG', 'DBS']:
+                chan_info['coil_type'] = FIFF.FIFFV_COIL_NONE
+                pick_mask[idx] = False
+
+        # if user passes in explict mapping for eog, misc and stim
+        # channels set them here
         if ch_name in eog or idx in eog or idx - nchan in eog:
             chan_info['coil_type'] = FIFF.FIFFV_COIL_NONE
             chan_info['kind'] = FIFF.FIFFV_EOG_CH
@@ -602,7 +632,29 @@ def _read_edf_header(fname, exclude):
 
         nchan = int(_edf_str(fid.read(4)))
         channels = list(range(nchan))
-        ch_names = [fid.read(16).strip().decode('latin-1') for ch in channels]
+
+        # get channel names and optionally channel type
+        # EDF specification contains 16 bytes that encode channel names,
+        # optionally prefixed by a string representing channel type separated
+        # by a space
+        ch_names = []
+        ch_types = []
+        for ch in channels:
+            # read in 16 byte label and strip any extra spaces at the end
+            new_label = fid.read(16).strip().decode('latin-1')
+
+            # space is found, so the prefix is the channel type
+            if ' ' in new_label:
+                ch_type, ch_name = new_label.split(' ')
+
+                # channel types should be upper case for easy comparison
+                ch_type = ch_types.upper()
+            else:
+                # if no channel type, then we will default to eeg
+                ch_type = None
+                ch_name = new_label
+            ch_names.append(ch_name)
+            ch_types.append(ch_type)
         exclude = _find_exclude_idx(ch_names, exclude)
         tal_idx = _find_tal_idx(ch_names)
         exclude = np.concatenate([exclude, tal_idx])
@@ -646,7 +698,7 @@ def _read_edf_header(fname, exclude):
 
         # Populate edf_info
         edf_info.update(
-            ch_names=ch_names, data_offset=header_nbytes,
+            ch_names=ch_names, ch_types=ch_types, data_offset=header_nbytes,
             digital_max=digital_max, digital_min=digital_min,
             highpass=highpass, sel=sel, lowpass=lowpass, meas_date=meas_date,
             n_records=n_records, n_samps=n_samps, nchan=nchan,

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -47,7 +47,7 @@ edf_uneven_eeglab_path = op.join(data_dir, 'test_uneven_samp.mat')
 edf_stim_channel_path = op.join(data_dir, 'test_edf_stim_channel.edf')
 edf_txt_stim_channel_path = op.join(data_dir, 'test_edf_stim_channel.txt')
 
-data_path = testing.data_path(download=True)
+data_path = testing.data_path(download=False)
 edf_stim_resamp_path = op.join(data_path, 'EDF', 'test_edf_stim_resamp.edf')
 edf_overlap_annot_path = op.join(data_path, 'EDF',
                                  'test_edf_overlapping_annotations.edf')
@@ -537,7 +537,7 @@ def test_ch_types():
     ch_types = raw.get_channel_types()
     assert all([x in ch_types for x in ['eeg', 'ecg']])
 
-    # test certain channels were correctly detected as a channnel type
+    # test certain channels were correctly detected as a channel type
     test_ch_names = {"Fp1-Ref": "eeg", "P10-Ref": "eeg", "DC01": "eeg",
                      "ECG1": "ecg", "ECG2": "ecg"}
     assert all([raw.get_channel_types(picks=pick)[0] == ch_type

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -535,10 +535,10 @@ def test_ch_types():
 
     # get the channel types for all channels
     ch_types = raw.get_channel_types()
-    assert all([x in ch_types for x in ['eeg', 'ecg']])
+    assert all(x in ch_types for x in ['eeg', 'ecg'])
 
     # test certain channels were correctly detected as a channel type
     test_ch_names = {"Fp1-Ref": "eeg", "P10-Ref": "eeg", "DC01": "eeg",
                      "ECG1": "ecg", "ECG2": "ecg"}
-    assert all([raw.get_channel_types(picks=pick)[0] == ch_type
-                for pick, ch_type in test_ch_names.items()])
+    assert all(raw.get_channel_types(picks=pick)[0] == ch_type
+               for pick, ch_type in test_ch_names.items())

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -47,7 +47,7 @@ edf_uneven_eeglab_path = op.join(data_dir, 'test_uneven_samp.mat')
 edf_stim_channel_path = op.join(data_dir, 'test_edf_stim_channel.edf')
 edf_txt_stim_channel_path = op.join(data_dir, 'test_edf_stim_channel.txt')
 
-data_path = testing.data_path(download=False)
+data_path = testing.data_path(download=True)
 edf_stim_resamp_path = op.join(data_path, 'EDF', 'test_edf_stim_resamp.edf')
 edf_overlap_annot_path = op.join(data_path, 'EDF',
                                  'test_edf_overlapping_annotations.edf')
@@ -179,7 +179,7 @@ def test_edf_data_broken(tmpdir):
 
 def test_duplicate_channel_labels_edf():
     """Test reading edf file with duplicate channel names."""
-    EXPECTED_CHANNEL_NAMES = ['EEG F1-Ref-0', 'EEG F2-Ref', 'EEG F1-Ref-1']
+    EXPECTED_CHANNEL_NAMES = ['F1-Ref-0', 'F2-Ref', 'F1-Ref-1']
     with pytest.warns(RuntimeWarning, match='Channel names are not unique'):
         raw = read_raw_edf(duplicate_channel_labels_path, preload=False)
 
@@ -409,7 +409,7 @@ def test_bdf_multiple_annotation_channels():
 def test_edf_lowpass_zero():
     """Test if a lowpass filter of 0Hz is mapped to the Nyquist frequency."""
     raw = read_raw_edf(edf_stim_resamp_path)
-    assert raw.ch_names[100] == 'EEG LDAMT_01-REF'
+    assert raw.ch_names[100] == 'LDAMT_01-REF'
     assert len(raw.ch_names[100]) > 15
     assert_allclose(raw.info["lowpass"], raw.info["sfreq"] / 2)
 
@@ -535,10 +535,10 @@ def test_ch_types():
 
     # get the channel types for all channels
     ch_types = raw.get_channel_types()
-    assert all([x in ch_types for x in ['eeg', 'ecg', 'misc']])
+    assert all([x in ch_types for x in ['eeg', 'ecg']])
 
     # test certain channels were correctly detected as a channnel type
-    test_ch_names = {"Fp1-Ref": "eeg", "P10-Ref": "eeg", "dc01": "misc",
+    test_ch_names = {"Fp1-Ref": "eeg", "P10-Ref": "eeg", "DC01": "eeg",
                      "ECG1": "ecg", "ECG2": "ecg"}
     assert all([raw.get_channel_types(picks=pick)[0] == ch_type
                 for pick, ch_type in test_ch_names.items()])

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -58,6 +58,7 @@ bdf_multiple_annotations_path = op.join(data_path, 'BDF',
 test_generator_bdf = op.join(data_path, 'BDF', 'test_generator_2.bdf')
 test_generator_edf = op.join(data_path, 'EDF', 'test_generator_2.edf')
 edf_annot_sub_s_path = op.join(data_path, 'EDF', 'subsecond_starttime.edf')
+edf_chtypes_path = op.join(data_path, 'EDF', 'chtypes_edf.edf')
 
 eog = ['REOG', 'LEOG', 'IEOG']
 misc = ['EXG1', 'EXG5', 'EXG8', 'M1', 'M2']
@@ -525,3 +526,19 @@ def test_exclude():
     raw = read_raw_edf(edf_path, exclude="I[1-4]")
     for ch in exclude:
         assert ch not in raw.ch_names
+
+
+@testing.requires_testing_data
+def test_ch_types():
+    """Test reading of channel types from EDF channel label."""
+    raw = read_raw_edf(edf_chtypes_path)
+
+    # get the channel types for all channels
+    ch_types = raw.get_channel_types()
+    assert all([x in ch_types for x in ['eeg', 'ecg', 'misc']])
+
+    # test certain channels were correctly detected as a channnel type
+    test_ch_names = {"Fp1-Ref": "eeg", "P10-Ref": "eeg", "dc01": "misc",
+                     "ECG1": "ecg", "ECG2": "ecg"}
+    assert all([raw.get_channel_types(picks=pick)[0] == ch_type
+                for pick, ch_type in test_ch_names.items()])

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -410,7 +410,7 @@ def test_edf_lowpass_zero():
     """Test if a lowpass filter of 0Hz is mapped to the Nyquist frequency."""
     raw = read_raw_edf(edf_stim_resamp_path)
     assert raw.ch_names[100] == 'LDAMT_01-REF'
-    assert len(raw.ch_names[100]) > 15
+    assert len(raw.ch_names[100]) > 11
     assert_allclose(raw.info["lowpass"], raw.info["sfreq"] / 2)
 
 

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -410,7 +410,6 @@ def test_edf_lowpass_zero():
     """Test if a lowpass filter of 0Hz is mapped to the Nyquist frequency."""
     raw = read_raw_edf(edf_stim_resamp_path)
     assert raw.ch_names[100] == 'LDAMT_01-REF'
-    assert len(raw.ch_names[100]) > 11
     assert_allclose(raw.info["lowpass"], raw.info["sfreq"] / 2)
 
 

--- a/mne/io/nihon/tests/test_nihon.py
+++ b/mne/io/nihon/tests/test_nihon.py
@@ -26,7 +26,7 @@ def test_nihon_eeg():
     assert raw._data.shape == raw_edf._data.shape
     assert raw.info['sfreq'] == raw.info['sfreq']
     # ch names and order are switched in the EDF
-    edf_ch_names = {x: x.split(' ')[1].replace('-Ref', '')
+    edf_ch_names = {x: x.replace('-Ref', '')
                     for x in raw_edf.ch_names}
     raw_edf.rename_channels(edf_ch_names)
     assert raw.ch_names == raw_edf.ch_names

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2501,24 +2501,20 @@ physical_range : str | tuple
 """
 docdict['export_params_add_ch_type'] = """
 add_ch_type : bool
-    Whether to add the channel type of the channel currently set
-    (default is False) to the signal label. Only used for
-    exporting EDF files.
+    Whether to incorporate the channel type into the signal label (e.g. whether
+    to store channel "Fz" as "EEG Fz"). Only used for EDF format. Default is
+    ``False``.
 """
 docdict['export_eeglab_note'] = """
 For EEGLAB exports, channel locations are expanded to full EEGLAB format.
 For more details see :func:`eeglabio.utils.cart_to_eeglab`.
 """
 docdict['export_edf_note'] = """
-For EDF exports, only channels that are measured in terms of Voltage are
-supported. For example, 'eeg', 'ecog', 'seeg', 'bio', 'emg', 'eog',
-'ecg', 'dbs', and 'bio' data are supported. 'misc' channels are also
-allowed for a catch-all of "unknown" channel types. Channel types are able
-to be stored in the prefix of the signal label. For example, ``EEG Fz`` implies
-that ``Fz`` is an EEG channel and ``MISC E`` would imply ``E`` is a MISC
-channel. However, EDF files do not require the storage of channel types,
-so many writers do not export the channel type. This is because
-there is no standard way for specifying all channel types.
+For EDF exports, only channels measured in Volts are allowed; in MNE-Python
+this means channel types 'eeg', 'ecog', 'seeg', 'emg', 'eog', 'ecg', 'dbs',
+'bio', and 'misc'. Although this function supports storing channel types in the
+signal label (e.g. ``EEG Fz`` or ``MISC E``), other software may not support
+this (optional) feature of the EDF standard.
 
 If you want to set the channel types, then set the ``add_ch_type`` keyword.
 This will then for example take EEG channel ``Fz`` and export the
@@ -2527,7 +2523,7 @@ the channel types before exporting, you will need to call
 :attr:`raw.set_channel_types <mne.io.Raw.set_channel_types>`.
 
 In addition, EDF does not support storing a montage. You will need
-to store the montage separately and call :attr:`raw.set_montage
+to store the montage separately and call :attr:`raw.set_montage()
 <mne.io.Raw.set_montage>`.
 """
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2504,8 +2504,10 @@ For EEGLAB exports, channel locations are expanded to full EEGLAB format.
 For more details see :func:`eeglabio.utils.cart_to_eeglab`.
 """
 docdict['export_edf_note'] = """
-For EDF exports, only EEG, ECoG and sEEG data are supported. In
-addition, EDF does not support storing a montage.
+For EDF exports, only channels that are measured in terms of Voltage are
+supported. For example, 'eeg', 'ecog', 'seeg', 'bio', 'emg', 'eog',
+'ecg', 'dbs', 'bio' data are supported. In addition, EDF does not
+support storing a montage.
 """
 
 # Other

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2512,9 +2512,10 @@ For more details see :func:`eeglabio.utils.cart_to_eeglab`.
 docdict['export_edf_note'] = """
 For EDF exports, only channels measured in Volts are allowed; in MNE-Python
 this means channel types 'eeg', 'ecog', 'seeg', 'emg', 'eog', 'ecg', 'dbs',
-'bio', and 'misc'. Although this function supports storing channel types in the
-signal label (e.g. ``EEG Fz`` or ``MISC E``), other software may not support
-this (optional) feature of the EDF standard.
+'bio', and 'misc'. 'stim' channels are dropped. Although this function
+supports storing channel types in the signal label (e.g. ``EEG Fz`` or
+``MISC E``), other software may not support this (optional) feature of
+the EDF standard.
 
 If ``add_ch_type`` is True, then channel types are written based on what
 they are currently set in MNE-Python. One should double check that all

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2513,14 +2513,17 @@ docdict['export_edf_note'] = """
 For EDF exports, only channels that are measured in terms of Voltage are
 supported. For example, 'eeg', 'ecog', 'seeg', 'bio', 'emg', 'eog',
 'ecg', 'dbs', 'bio' data are supported. However, EDF files do not
-support the storage of channel types, so when re-reading the file
+require the storage of channel types, so when re-reading the file
 naively, you will only get 'eeg' types by default. For example, if you
-have 'misc' channels, they will be read back in as 'eeg' type.
-In order to properly set the channel types before exporting, you will
-need to call :attr:`raw.set_channel_types
-<mne.io.Raw.set_channel_types>`. In addition, EDF does not support
-storing a montage. You will need to store the montage separately and
-call :attr:`raw.set_montage <mne.io.Raw.set_montage>`.
+have 'misc' channels, they will be read back in as 'eeg' type. If you
+want to set the channel types, then set the ``add_ch_type`` keyword.
+This will then for example take EEG channel ``Fz1`` and export the
+signal label as ``EEG Fz1`` in the EDF file. In order to properly set
+the channel types before exporting, you will need to call
+:attr:`raw.set_channel_types <mne.io.Raw.set_channel_types>`.
+In addition, EDF does not support storing a montage. You will need
+to store the montage separately and call :attr:`raw.set_montage
+<mne.io.Raw.set_montage>`.
 """
 
 # Other

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2517,8 +2517,8 @@ require the storage of channel types, so when re-reading the file
 naively, you will only get 'eeg' types by default. For example, if you
 have 'misc' channels, they will be read back in as 'eeg' type. If you
 want to set the channel types, then set the ``add_ch_type`` keyword.
-This will then for example take EEG channel ``Fz1`` and export the
-signal label as ``EEG Fz1`` in the EDF file. In order to properly set
+This will then for example take EEG channel ``Fz`` and export the
+signal label as ``EEG Fz`` in the EDF file. In order to properly set
 the channel types before exporting, you will need to call
 :attr:`raw.set_channel_types <mne.io.Raw.set_channel_types>`.
 In addition, EDF does not support storing a montage. You will need

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2523,6 +2523,9 @@ their channels are set correctly. You can call
 :attr:`raw.set_channel_types <mne.io.Raw.set_channel_types>` to set
 channel types.
 
+Exporting EDF currently only supports the storage of one annotation
+per data record.
+
 In addition, EDF does not support storing a montage. You will need
 to store the montage separately and call :attr:`raw.set_montage()
 <mne.io.Raw.set_montage>`.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2508,11 +2508,13 @@ For EDF exports, only channels that are measured in terms of Voltage are
 supported. For example, 'eeg', 'ecog', 'seeg', 'bio', 'emg', 'eog',
 'ecg', 'dbs', 'bio' data are supported. However, EDF files do not
 support the storage of channel types, so when re-reading the file
-naively, you will only get 'eeg' types by default. You will need
-to call :attr:`raw.set_channel_types <mne.io.Raw.set_channel_types>`.
-In addition, EDF does not support storing a montage. You will need
-to store the montage separately and call :attr:`raw.set_montage
-<mne.io.Raw.set_montage>`.
+naively, you will only get 'eeg' types by default. For example, if you
+have 'misc' channels, they will be read back in as 'eeg' type.
+In order to properly set the channel types before exporting, you will
+need to call :attr:`raw.set_channel_types
+<mne.io.Raw.set_channel_types>`. In addition, EDF does not support
+storing a montage. You will need to store the montage separately and
+call :attr:`raw.set_montage <mne.io.Raw.set_montage>`.
 """
 
 # Other

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2523,9 +2523,6 @@ their channels are set correctly. You can call
 :attr:`raw.set_channel_types <mne.io.Raw.set_channel_types>` to set
 channel types.
 
-Exporting EDF currently only supports the storage of one annotation
-per data record.
-
 In addition, EDF does not support storing a montage. You will need
 to store the montage separately and call :attr:`raw.set_montage()
 <mne.io.Raw.set_montage>`.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2486,7 +2486,7 @@ fname : str
     Name of the output file.
 """
 docdict['export_params_fmt'] = """
-fmt : 'auto' | 'eeglab'
+fmt : 'auto' | 'eeglab' | 'edf'
     Format of the export. Defaults to ``'auto'``, which will infer the format
     from the filename extension. See supported formats above for more
     information.
@@ -2516,11 +2516,11 @@ this means channel types 'eeg', 'ecog', 'seeg', 'emg', 'eog', 'ecg', 'dbs',
 signal label (e.g. ``EEG Fz`` or ``MISC E``), other software may not support
 this (optional) feature of the EDF standard.
 
-If you want to set the channel types, then set the ``add_ch_type`` keyword.
-This will then for example take EEG channel ``Fz`` and export the
-signal label as ``EEG Fz`` in the EDF file. In order to properly set
-the channel types before exporting, you will need to call
-:attr:`raw.set_channel_types <mne.io.Raw.set_channel_types>`.
+If ``add_ch_type`` is True, then channel types are written based on what
+they are currently set in MNE-Python. One should double check that all
+their channels are set correctly. You can call
+:attr:`raw.set_channel_types <mne.io.Raw.set_channel_types>` to set
+channel types.
 
 In addition, EDF does not support storing a montage. You will need
 to store the montage separately and call :attr:`raw.set_montage()

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2513,11 +2513,12 @@ docdict['export_edf_note'] = """
 For EDF exports, only channels that are measured in terms of Voltage are
 supported. For example, 'eeg', 'ecog', 'seeg', 'bio', 'emg', 'eog',
 'ecg', 'dbs', and 'bio' data are supported. 'misc' channels are also
-written to allow for a catch-all of "unknown" channel types. Channel types are able
+allowed for a catch-all of "unknown" channel types. Channel types are able
 to be stored in the prefix of the signal label. For example, ``EEG Fz`` implies
 that ``Fz`` is an EEG channel and ``MISC E`` would imply ``E`` is a MISC
 channel. However, EDF files do not require the storage of channel types,
-so many writers do not actively export the channel type.
+so many writers do not export the channel type. This is because
+there is no standard way for specifying all channel types.
 
 If you want to set the channel types, then set the ``add_ch_type`` keyword.
 This will then for example take EEG channel ``Fz`` and export the

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2506,8 +2506,13 @@ For more details see :func:`eeglabio.utils.cart_to_eeglab`.
 docdict['export_edf_note'] = """
 For EDF exports, only channels that are measured in terms of Voltage are
 supported. For example, 'eeg', 'ecog', 'seeg', 'bio', 'emg', 'eog',
-'ecg', 'dbs', 'bio' data are supported. In addition, EDF does not
-support storing a montage.
+'ecg', 'dbs', 'bio' data are supported. However, EDF files do not
+support the storage of channel types, so when re-reading the file
+naively, you will only get 'eeg' types by default. You will need
+to call :attr:`raw.set_channel_types <mne.io.Raw.set_channel_types>`.
+In addition, EDF does not support storing a montage. You will need
+to store the montage separately and call :attr:`raw.set_montage
+<mne.io.Raw.set_montage>`.
 """
 
 # Other

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2512,15 +2512,19 @@ For more details see :func:`eeglabio.utils.cart_to_eeglab`.
 docdict['export_edf_note'] = """
 For EDF exports, only channels that are measured in terms of Voltage are
 supported. For example, 'eeg', 'ecog', 'seeg', 'bio', 'emg', 'eog',
-'ecg', 'dbs', 'bio' data are supported. However, EDF files do not
-require the storage of channel types, so when re-reading the file
-naively, you will only get 'eeg' types by default. For example, if you
-have 'misc' channels, they will be read back in as 'eeg' type. If you
-want to set the channel types, then set the ``add_ch_type`` keyword.
+'ecg', 'dbs', and 'bio' data are supported. 'misc' channels are also
+written to allow for a catch-all of "unknown" channel types. Channel types are able
+to be stored in the prefix of the signal label. For example, ``EEG Fz`` implies
+that ``Fz`` is an EEG channel and ``MISC E`` would imply ``E`` is a MISC
+channel. However, EDF files do not require the storage of channel types,
+so many writers do not actively export the channel type.
+
+If you want to set the channel types, then set the ``add_ch_type`` keyword.
 This will then for example take EEG channel ``Fz`` and export the
 signal label as ``EEG Fz`` in the EDF file. In order to properly set
 the channel types before exporting, you will need to call
 :attr:`raw.set_channel_types <mne.io.Raw.set_channel_types>`.
+
 In addition, EDF does not support storing a montage. You will need
 to store the montage separately and call :attr:`raw.set_montage
 <mne.io.Raw.set_montage>`.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2499,6 +2499,12 @@ physical_range : str | tuple
     If it is a 2-tuple of minimum and maximum limit, then those
     physical ranges will be used. Only used for exporting EDF files.
 """
+docdict['export_params_add_ch_type'] = """
+add_ch_type : bool
+    Whether to add the channel type of the channel currently set
+    (default is False) to the signal label. Only used for
+    exporting EDF files.
+"""
 docdict['export_eeglab_note'] = """
 For EEGLAB exports, channel locations are expanded to full EEGLAB format.
 For more details see :func:`eeglabio.utils.cart_to_eeglab`.


### PR DESCRIPTION
#### Reference issue
Follow up fix from #9643 where not all the relevant "Voltage/uVoltage" channels were added.

In addition, it will allow channel types to be written to EDF files, in accordance with: https://github.com/mne-tools/mne-python/pull/9694#issuecomment-908135503

Closes: #9704 
Closes: #9730

#### What does this implement/fix?
- Adds corresponding unit test that makes sure all voltage channels are covered in exporting EDF
- Allows channel types to be read in from EDF files via their signal labels
- Allows exporting channel types to EDF files
