### PR TITLE
[MRG] Make nihon file detect misc channels that have the dollar sign ($) in them

### DIFF
--- a/mne/io/nihon/nihon.py
+++ b/mne/io/nihon/nihon.py
@@ -288,7 +288,7 @@ def _read_nihon_annotations(fname):
 
 def _map_ch_to_type(ch_name):
     ch_type_pattern = OrderedDict([
-        ('stim', ('Mark',)), ('misc', ('DC', 'NA', 'Z')), ('bio', ('X',))])
+        ('stim', ('Mark',)), ('misc', ('DC', 'NA', 'Z', '$')), ('bio', ('X',))])
     for key, kinds in ch_type_pattern.items():
         if any(kind in ch_name for kind in kinds):
             return key

--- a/mne/io/nihon/tests/test_nihon.py
+++ b/mne/io/nihon/tests/test_nihon.py
@@ -59,3 +59,8 @@ def test_nihon_eeg():
     with pytest.warns(RuntimeWarning, match=msg):
         annot = _read_nihon_annotations(bad_fname)
         assert all(len(x) == 0 for x in annot.values())
+
+    # assert that channels with $ are 'misc'
+    picks = any([ch for ch in raw.ch_names if ch.startswith('$')])
+    ch_types = raw.get_channel_types(picks=picks)
+    assert all([ch == 'misc' for ch in ch_types])


### PR DESCRIPTION
#### Reference issue
Dollar signs indicate non-EEG channels and should be detected as such.


#### What does this implement/fix?
This will fix an underlying bug discovered in https://github.com/mne-tools/mne-bids/pull/866
where exporting EDF has a hidden behavior of getting totally screwed up if the physical ranges in a channel group is orders of magnitude bigger then they should be.

The fix to this is to:

1. have robust readers that can set channel types automatically
2. have users be cognizant of setting channel types before exporting
3. have a warning if some weird ranges are found during export of EDF

#### Additional information
I will make a PR for 3. separately.
