### PR TITLE
update auto-coreg tutorial

### DIFF
--- a/tutorials/forward/25_automated_coreg.py
+++ b/tutorials/forward/25_automated_coreg.py
@@ -82,6 +82,15 @@ print(
 )
 
 # %%
+# .. warning::
+#     Don't forget to save the resulting ``trans`` matrix!
+#
+#     .. code-block:: python
+#
+#         mne.write_trans('/path/to/filename-trans.fif', coreg.trans)
+
+
+# %%
 # .. note:: The :class:`mne.coreg.Coregistration` class has the ability to
 #           compute MRI scale factors using
 #           :meth:`~mne.coreg.Coregistration.set_scale_mode` that is useful


### PR DESCRIPTION
adds a reminder about saving `*-trans.fif` after performing automated coregistration.