### PR TITLE
BUG: Fix tolerances

### DIFF
--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -597,7 +597,10 @@ def test_describe_print():
         raw.describe()
     s = f.getvalue().strip().split("\n")
     assert len(s) == 378
-    assert s[0] == "<Raw | test_raw.fif, 376 x 14400 (24.0 s), ~3.3 MB, data not loaded>"  # noqa
+    # Can be 3.1, 3.3, etc.
+    assert re.match(
+        r'<Raw | test_raw.fif, 376 x 14400 (24\.0 s), '
+        r'~3\.. MB, data not loaded>', s[0]) is not None, s[0]
     assert s[1] == " ch  name      type  unit        min        Q1    median        Q3       max"  # noqa
     assert s[2] == "  0  MEG 0113  GRAD  fT/cm   -221.80    -38.57     -9.64     19.29    414.67"  # noqa
     assert s[-1] == "375  EOG 061   EOG   µV      -231.41    271.28    277.16    285.66    334.69"  # noqa

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -297,7 +297,7 @@ def test_object_size():
                               (0, 150, np.ones(0)),
                               (0, 150, np.int32(1)),
                               (150, 500, np.ones(20)),
-                              (50, 400, dict()),
+                              (30, 400, dict()),
                               (400, 1000, dict(a=np.ones(50))),
                               (200, 900, sparse.eye(20, format='csc')),
                               (200, 900, sparse.eye(20, format='csr'))):


### PR DESCRIPTION
Bump tolerances for some tests as pointed out by @Aniket-Pradhan . This PR is to `main` but if they pass when @Aniket-Pradhan tests the `maint/0.23` version (https://github.com/larsoner/mne-python/tree/bugfix) on Fedora, I'll merge this, backport the fix, and cut another bugfix 0.23 release.