### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -35,6 +35,8 @@ Current (0.24.dev0)
 
 .. |Mathieu Scheltienne| replace:: **Mathieu Scheltienne**
 
+.. |Tim Gates| replace:: **Tim Gates**
+
 Enhancements
 ~~~~~~~~~~~~
 .. - Add something cool (:gh:`9192` **by new contributor** |New Contributor|_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -151,6 +151,8 @@ Enhancements
 
 Bugs
 ~~~~
+- Fix a few typos (:gh:`9706` **by new contributor** |Tim Gates|_)
+
 - Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** |Jan Sosulski|_)
 
 - Fix bug with `mne.io.read_raw_curry` to allow reading Curry 8 event files with '.cdt.ceo' extension (:gh:`9381` by **new contributor** |Xiaokai Xia|_ and `Daniel McCloy`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -35,7 +35,7 @@ Current (0.24.dev0)
 
 .. |Mathieu Scheltienne| replace:: **Mathieu Scheltienne**
 
-.. |Tim Gates| replace:: **Tim Gates**
+.. |Timothy Gates| replace:: **Timothy Gates**
 
 Enhancements
 ~~~~~~~~~~~~
@@ -153,7 +153,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Fix a few typos (:gh:`9706` **by new contributor** |Tim Gates|_)
+- Fix a few typos (:gh:`9706` **by new contributor** |Timothy Gates|_)
 
 - Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** |Jan Sosulski|_)
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -406,4 +406,4 @@
 
 .. _Mathieu Scheltienne: https://github.com/mscheltienne
 
-.. _Tim Gates: https://github.com/timgates42
+.. _Timothy Gates: https://github.com/timgates42

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -405,3 +405,5 @@
 .. _Darin Erat Sleiter: https://github.com/dsleiter
 
 .. _Mathieu Scheltienne: https://github.com/mscheltienne
+
+.. _Tim Gates: https://github.com/timgates42

--- a/mne/decoding/tests/test_ssd.py
+++ b/mne/decoding/tests/test_ssd.py
@@ -292,7 +292,7 @@ def test_sorting():
 def test_return_filtered():
     """Test return filtered option."""
     # Check return_filtered
-    # Simulated more noise data and with broader freqquency than the desired
+    # Simulated more noise data and with broader frequency than the desired
     X, _, _ = simulate_data(SNR=0.9, freqs_sig=[4, 13])
     sf = 250
     n_channels = X.shape[0]

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2256,7 +2256,7 @@ def make_metadata(events, event_id, tmin, tmax, sfreq,
     The time window used for metadata generation need not correspond to the
     time window used to create the `~mne.Epochs`, to which the metadata will
     be attached; it may well be much shorter or longer, or not overlap at all,
-    if desired. The can be useful, for example, to include events that ccurred
+    if desired. The can be useful, for example, to include events that occurred
     before or after an epoch, e.g. during the inter-trial interval.
 
     .. versionadded:: 0.23

--- a/mne/io/constants.py
+++ b/mne/io/constants.py
@@ -312,7 +312,7 @@ FIFF.FIFF_SQUID_BIAS        = 701
 FIFF.FIFF_SQUID_OFFSET      = 702
 FIFF.FIFF_SQUID_GATE        = 703
 #
-# Aspect values used to save charactersitic curves of SQUIDs. (mjk)
+# Aspect values used to save characteristic curves of SQUIDs. (mjk)
 #
 FIFF.FIFFV_ASPECT_IFII_LOW  = 1100
 FIFF.FIFFV_ASPECT_IFII_HIGH = 1101

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -229,7 +229,7 @@ class Info(dict, MontageMixin):
     Attributes
     ----------
     acq_pars : str | None
-        MEG system acquition parameters.
+        MEG system acquisition parameters.
         See :class:`mne.AcqParserFIF` for details.
     acq_stim : str | None
         MEG system stimulus parameters.

--- a/tutorials/io/30_reading_fnirs_data.py
+++ b/tutorials/io/30_reading_fnirs_data.py
@@ -120,7 +120,7 @@ Custom Data Import
 Loading legacy data in CSV or TSV format
 ========================================
 
-.. warning:: This method is not supported and users are discoraged to use it.
+.. warning:: This method is not supported and users are discouraged to use it.
              You should convert your data to the
              `SNIRF <https://github.com/fNIRS/snirf>`_ format using the tools
              provided by the Society for functional Near-Infrared Spectroscopy,


### PR DESCRIPTION
There are small typos in:
- mne/decoding/tests/test_ssd.py
- mne/epochs.py
- mne/io/constants.py
- mne/io/meas_info.py
- tutorials/io/30_reading_fnirs_data.py

Fixes:
- Should read `frequency` rather than `freqquency`.
- Should read `discouraged` rather than `discoraged`.
- Should read `characteristic` rather than `charactersitic`.
- Should read `acquisition` rather than `acquition`.
- Should read `occurred` rather than `ccurred`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md