### PR TITLE
FIX: Read events from ceo file.

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -37,6 +37,8 @@ Current (0.24.dev0)
 
 .. |Timothy Gates| replace:: **Timothy Gates**
 
+.. |Reza Shoorangiz| replace:: **Reza Shoorangiz**
+
 Enhancements
 ~~~~~~~~~~~~
 .. - Add something cool (:gh:`9192` **by new contributor** |New Contributor|_)
@@ -157,7 +159,7 @@ Bugs
 
 - Fix bug with :meth:`mne.Epochs.crop` and :meth:`mne.Evoked.crop` when ``include_tmax=False``, where the last sample was always cut off, even when ``tmax > epo.times[-1]`` (:gh:`9378` **by new contributor** |Jan Sosulski|_)
 
-- Fix bug with `mne.io.read_raw_curry` to allow reading Curry 8 event files with '.cdt.ceo' extension (:gh:`9381` by **new contributor** |Xiaokai Xia|_ and `Daniel McCloy`_)
+- Fix bug with `mne.io.read_raw_curry` to allow reading Curry 7 and 8 event files with '.ceo' and '.cdt.ceo' extensions (:gh:`9381`, :gh:`9712` by **new contributor** |Xiaokai Xia|_, `Daniel McCloy`_, and **by new contributor** |Reza Shoorangiz|_)
 
 - Fix bug with :func:`mne.io.read_raw_nihon` where latin-1 annotations could not be read (:gh:`9384` by `Alex Gramfort`_)
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -407,3 +407,5 @@
 .. _Mathieu Scheltienne: https://github.com/mscheltienne
 
 .. _Timothy Gates: https://github.com/timgates42
+
+.. _Reza Shoorangiz: https://github.com/rezashr

--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -411,8 +411,8 @@ def _read_events_curry(fname):
     events : ndarray, shape (n_events, 3)
         The array of events.
     """
-    check_fname(fname, 'curry event', ('.cef', '.cdt.cef', '.cdt.ceo'),
-                endings_err=('.cef', '.cdt.cef', '.cdt.ceo'))
+    check_fname(fname, 'curry event', ('.cef', '.ceo', '.cdt.cef', '.cdt.ceo'),
+                endings_err=('.cef', '.ceo', '.cdt.cef', '.cdt.ceo'))
 
     events_dict = _read_curry_lines(fname, ["NUMBER_LIST"])
     # The first 3 column seem to contain the event information


### PR DESCRIPTION
#### Reference issue
Fixes #9380 
Improves #9381 

#### What does this implement/fix?
With #9381, 'ceo' files can be imported after renaming to 'cef'. This PR adds '.ceo' extension to event file extensions.