### PR TITLE
Fix ICA raising ValueError when bad channels are explicitly passed to `.fit` method.

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -25,7 +25,7 @@ from .infomax_ import infomax
 
 from ..cov import compute_whitener
 from .. import Covariance, Evoked
-from ..io.pick import (pick_types, pick_channels, pick_info,
+from ..io.pick import (channel_type, pick_types, pick_channels, pick_info,
                        _picks_to_idx, _get_channel_types, _DATA_CH_TYPES_SPLIT)
 from ..io.proj import make_projector
 from ..io.write import (write_double_matrix, write_string,
@@ -662,26 +662,8 @@ class ICA(ContainsMixin):
             pre_whitener = np.empty([len(data), 1])
             for ch_type in _DATA_CH_TYPES_SPLIT + ('eog', "ref_meg"):
                 if _contains_ch_type(info, ch_type):
-                    if ch_type == 'seeg':
-                        this_picks = pick_types(info, meg=False, seeg=True)
-                    elif ch_type == 'dbs':
-                        this_picks = pick_types(info, meg=False, dbs=True)
-                    elif ch_type == 'ecog':
-                        this_picks = pick_types(info, meg=False, ecog=True)
-                    elif ch_type == 'eeg':
-                        this_picks = pick_types(info, meg=False, eeg=True)
-                    elif ch_type in ('mag', 'grad'):
-                        this_picks = pick_types(info, meg=ch_type)
-                    elif ch_type == 'eog':
-                        this_picks = pick_types(info, meg=False, eog=True)
-                    elif ch_type in ('hbo', 'hbr'):
-                        this_picks = pick_types(info, meg=False, fnirs=ch_type)
-                    elif ch_type == 'ref_meg':
-                        this_picks = pick_types(info, meg=False, ref_meg=True)
-                    else:
-                        raise RuntimeError('Should not be reached.'
-                                           'Unsupported channel {}'
-                                           .format(ch_type))
+                    this_picks = [idx for idx in picks
+                                  if channel_type(info, idx) == ch_type]
                     pre_whitener[this_picks] = np.std(data[this_picks])
         else:
             pre_whitener, _ = compute_whitener(self.noise_cov, self.info)

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -575,6 +575,7 @@ class ICA(ContainsMixin):
 
         # filter out all the channels the raw wouldn't have initialized
         self.info = pick_info(inst.info, picks)
+        picks = np.arange(start=0, stop=len(picks))
 
         if self.info['comps']:
             self.info['comps'] = []

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -625,7 +625,7 @@ class ICA(ContainsMixin):
                                                           tstep)
 
         self.n_samples_ = data.shape[1]
-        self._fit(data, 'raw')
+        self._fit(data, 'raw', picks)
 
         return self
 
@@ -647,11 +647,11 @@ class ICA(ContainsMixin):
         # This will make at least one copy (one from hstack, maybe one
         # more from _pre_whiten)
         data = np.hstack(data)
-        self._fit(data, 'epochs')
+        self._fit(data, 'epochs', picks)
 
         return self
 
-    def _compute_pre_whitener(self, data):
+    def _compute_pre_whitener(self, data, picks):
         """Aux function."""
         data = self._do_proj(data, log_suffix='(pre-whitener computation)')
 
@@ -710,11 +710,11 @@ class ICA(ContainsMixin):
             data = self.pre_whitener_ @ data
         return data
 
-    def _fit(self, data, fit_type):
+    def _fit(self, data, fit_type, picks):
         """Aux function."""
         random_state = check_random_state(self.random_state)
         n_channels, n_samples = data.shape
-        self._compute_pre_whitener(data)
+        self._compute_pre_whitener(data, picks)
         data = self._pre_whiten(data)
 
         pca = _PCA(n_components=self._max_pca_components, whiten=True)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -932,6 +932,18 @@ def test_ica_additional(method, tmpdir, short_raw_epochs):
         with pytest.warns(RuntimeWarning, match='longer'):
             ica.find_bads_ecg(raw, threshold='auto')
 
+    # test passing picks including the marked bad channels
+    data = np.zeros((4, 160 * 10))
+    ch_names = [f'EEG{i+1}' for i in range(4)]
+    ch_types = ['eeg'] * len(ch_names)
+    info = create_info(ch_names, ch_types=ch_types, sfreq=160)
+    raw = RawArray(data, info)
+    raw.info['bads'] = ['EEG2']
+
+    picks = pick_types(raw.info, eeg=True, exclude=[])
+    ica = ICA(n_components=0.99, max_iter='auto')
+    ica.fit(raw, picks=picks, reject_by_annotation=True)
+
 
 @requires_sklearn
 @pytest.mark.slowtest


### PR DESCRIPTION
#### Reference issue
Fixes #9716 .

#### What does this implement/fix?
Added minimal test case.
Pass the argument picks from `.fit` all the way to `._compute_pre_whitener` that was ignoring it.
I removed the long list of `if/else` statements in favor of a simpler approach.

**Question**: for MEG sensors, was it necessary to select both `grad` and `mag` at the same time? When the `for` loop is set on either, it was picking `meg`, and thus both sensors at the same time.

I removed the `raise RuntimeError` in the `else`, as it can never be reached. The only path to `._compute_pre_whitener` is via `.fit` which has a call to `_check_for_unsupported_ica_channels`.

#### Additional information

It is not working currently, the error and traceback remain!

```
import mne
import numpy as np

CH_NUM = 4
FS = 160

data = np.zeros((CH_NUM, FS * 10))
ch_names = [f'EEG{i+1}' for i in range(CH_NUM)]
ch_types = ['eeg'] * len(ch_names)
info = mne.create_info(ch_names, ch_types=ch_types, sfreq=FS)
raw = mne.io.RawArray(data, info)
raw.info['bads'] = ['EEG2']

picks = mne.pick_types(raw.info, eeg=True, exclude=[])
ica = mne.preprocessing.ICA(n_components=0.99, max_iter='auto')
ica.fit(raw, picks=picks, reject_by_annotation=True)
```

```
Creating RawArray with float64 data, n_channels=4, n_times=1600
    Range : 0 ... 1599 =      0.000 ...     9.994 secs
Ready.
Fitting ICA to data using 4 channels (please be patient, this may take a while)
C:\Users\Mathieu\Downloads\issue9716.py:18: RuntimeWarning: The data has not been high-pass filtered. For good ICA performance, it should be high-pass filtered (e.g., with a 1.0 Hz lower bound) before fitting ICA.
  ica.fit(raw, picks=picks, reject_by_annotation=True)
c:\users\mathieu\documents\git\mne-python\mne\preprocessing\ica.py:690: RuntimeWarning: invalid value encountered in true_divide
  data /= self.pre_whitener_
Traceback (most recent call last):

  File "C:\Users\Mathieu\Downloads\issue9716.py", line 18, in <module>
    ica.fit(raw, picks=picks, reject_by_annotation=True)

  File "<decorator-gen-443>", line 24, in fit

  File "c:\users\mathieu\documents\git\mne-python\mne\preprocessing\ica.py", line 584, in fit
    self._fit_raw(inst, picks, start, stop, decim, reject, flat,

  File "c:\users\mathieu\documents\git\mne-python\mne\preprocessing\ica.py", line 628, in _fit_raw
    self._fit(data, 'raw', picks)

  File "c:\users\mathieu\documents\git\mne-python\mne\preprocessing\ica.py", line 703, in _fit
    data = pca.fit_transform(data.T)

  File "c:\users\mathieu\documents\git\mne-python\mne\utils\numerics.py", line 838, in fit_transform
    U, S, _ = self._fit(X)

  File "c:\users\mathieu\documents\git\mne-python\mne\utils\numerics.py", line 876, in _fit
    U, S, V = _safe_svd(X, full_matrices=False)

  File "c:\users\mathieu\documents\git\mne-python\mne\fixes.py", line 69, in _safe_svd
    return linalg.svd(A, **kwargs)

  File "C:\Users\Mathieu\Documents\pyvenv\mne\lib\site-packages\scipy\linalg\decomp_svd.py", line 108, in svd
    a1 = _asarray_validated(a, check_finite=check_finite)

  File "C:\Users\Mathieu\Documents\pyvenv\mne\lib\site-packages\scipy\_lib\_util.py", line 293, in _asarray_validated
    a = toarray(a)

  File "C:\Users\Mathieu\Documents\pyvenv\mne\lib\site-packages\numpy\lib\function_base.py", line 488, in asarray_chkfinite
    raise ValueError(

ValueError: array must not contain infs or NaNs
```
