### PR TITLE
Fix ICA raising ValueError when bad channels are explicitly passed to .fit method.

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -163,6 +163,8 @@ Bugs
 
 - Fix bug with `mne.io.read_raw_curry` to allow reading Curry 8 event files with '.cdt.ceo' extension (:gh:`9381` by **new contributor** |Xiaokai Xia|_ and `Daniel McCloy`_)
 
+- Fix bug with `mne.rank.compute_rank`, `mne.cov.compute_whitener` and `mne.preprocessing.ICA.fit` when explicit picks including bad channels are provided (:gh:`9719` **by new contributor** |Mathieu Scheltienne|_)
+
 - Fix bug with :func:`mne.io.read_raw_nihon` where latin-1 annotations could not be read (:gh:`9384` by `Alex Gramfort`_)
 
 - Fix bug when printing a :class:`mne.io.RawArray` in the notebook (:gh:`9404` by `Alex Gramfort`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -165,7 +165,7 @@ Bugs
 
 - Fix bug with `mne.io.read_raw_curry` to allow reading Curry 7 and 8 event files with '.ceo' and '.cdt.ceo' extensions (:gh:`9381`, :gh:`9712` by **new contributor** |Xiaokai Xia|_, `Daniel McCloy`_, and **by new contributor** |Reza Shoorangiz|_)
 
-- Fix bug with `mne.rank.compute_rank`, `mne.cov.compute_whitener` and `mne.preprocessing.ICA.fit` when explicit picks including bad channels are provided (:gh:`9719` **by new contributor** |Mathieu Scheltienne|_)
+- Fix bug with `mne.compute_rank`, `mne.cov.compute_whitener` and `mne.preprocessing.ICA.fit` when explicit picks including bad channels are provided (:gh:`9719` **by new contributor** |Mathieu Scheltienne|_)
 
 - Fix bug with :func:`mne.io.read_raw_nihon` where latin-1 annotations could not be read (:gh:`9384` by `Alex Gramfort`_)
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -1519,7 +1519,7 @@ def _smart_eigh(C, info, rank, scalings=None, projs=None,
     eigvec = np.zeros((n_chan, n_chan), dtype)
     mask = np.zeros(n_chan, bool)
     for ch_type, picks in _picks_by_type(info, meg_combined=True,
-                                         ref_meg=False, exclude='bads'):
+                                         ref_meg=False, exclude=[]):
         if len(picks) == 0:
             continue
         this_C = C[np.ix_(picks, picks)]

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -669,7 +669,8 @@ class ICA(ContainsMixin):
                 picks_ = pick_types(info, eog=True, exclude=[])
                 pre_whitener[picks_] = np.std(data[picks_])
         else:
-            pre_whitener, _ = compute_whitener(self.noise_cov, self.info)
+            pre_whitener, _ = compute_whitener(
+                self.noise_cov, self.info, picks=self.info.ch_names)
             assert data.shape[0] == pre_whitener.shape[1]
         self.pre_whitener_ = pre_whitener
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -830,7 +830,7 @@ class ICA(ContainsMixin):
         try:
             picks = _picks_to_idx(raw.info, self.ch_names, exclude=[])
             raise_ = False if len(picks) == len(self.ch_names) else True
-        except ValueError:
+        except RuntimeWarning:
             raise_ = True
             picks = list()
             for ch in self.ch_names:
@@ -858,7 +858,7 @@ class ICA(ContainsMixin):
             picks = _picks_to_idx(epochs.info, self.ch_names, exclude=[])
             # special case where epochs come picked but fit was 'unpicked'.
             raise_ = False if len(picks) == len(self.ch_names) else True
-        except ValueError:
+        except RuntimeWarning:
             raise_ = True
             picks = list()
             for ch in self.ch_names:
@@ -890,7 +890,7 @@ class ICA(ContainsMixin):
         try:
             picks = _picks_to_idx(evoked.info, self.ch_names, exclude=[])
             raise_ = False if len(picks) == len(self.ch_names) else True
-        except ValueError:
+        except RuntimeWarning:
             raise_ = True
             picks = list()
             for ch in self.ch_names:

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -663,26 +663,26 @@ class ICA(ContainsMixin):
             for ch_type in _DATA_CH_TYPES_SPLIT + ('eog', "ref_meg"):
                 if _contains_ch_type(info, ch_type):
                     if ch_type == 'seeg':
-                        this_picks = pick_types(info, meg=False, seeg=True)
+                        picks_ = pick_types(info, seeg=True, exclude=[])
                     elif ch_type == 'dbs':
-                        this_picks = pick_types(info, meg=False, dbs=True)
+                        picks_ = pick_types(info, dbs=True, exclude=[])
                     elif ch_type == 'ecog':
-                        this_picks = pick_types(info, meg=False, ecog=True)
+                        picks_ = pick_types(info, ecog=True, exclude=[])
                     elif ch_type == 'eeg':
-                        this_picks = pick_types(info, meg=False, eeg=True)
+                        picks_ = pick_types(info, eeg=True, exclude=[])
                     elif ch_type in ('mag', 'grad'):
-                        this_picks = pick_types(info, meg=ch_type)
+                        picks_ = pick_types(info, meg=ch_type, exclude=[])
                     elif ch_type == 'eog':
-                        this_picks = pick_types(info, meg=False, eog=True)
+                        picks_ = pick_types(info, eog=True, exclude=[])
                     elif ch_type in ('hbo', 'hbr'):
-                        this_picks = pick_types(info, meg=False, fnirs=ch_type)
+                        picks_ = pick_types(info, fnirs=ch_type, exclude=[])
                     elif ch_type == 'ref_meg':
-                        this_picks = pick_types(info, meg=False, ref_meg=True)
+                        picks_ = pick_types(info, ref_meg=True, exclude=[])
                     else:
                         raise RuntimeError('Should not be reached.'
                                            'Unsupported channel {}'
                                            .format(ch_type))
-                    pre_whitener[this_picks] = np.std(data[this_picks])
+                    pre_whitener[picks_] = np.std(data[picks_])
         else:
             pre_whitener, _ = compute_whitener(self.noise_cov, self.info)
             assert data.shape[0] == pre_whitener.shape[1]

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -830,8 +830,7 @@ class ICA(ContainsMixin):
 
         picks = _picks_to_idx(
             raw.info, self.ch_names, exclude=[], allow_empty=True)
-        raise_ = False if len(picks) == len(self.ch_names) else True
-        if raise_:
+        if len(picks) != len(self.ch_names):
             raise RuntimeError('Raw doesn\'t match fitted data: %i channels '
                                'fitted but %i channels supplied. \nPlease '
                                'provide Raw compatible with '
@@ -850,8 +849,7 @@ class ICA(ContainsMixin):
         picks = _picks_to_idx(
             epochs.info, self.ch_names, exclude=[], allow_empty=True)
         # special case where epochs come picked but fit was 'unpicked'.
-        raise_ = False if len(picks) == len(self.ch_names) else True
-        if raise_:
+        if len(picks) != len(self.ch_names):
             raise RuntimeError('Epochs don\'t match fitted data: %i channels '
                                'fitted but %i channels supplied. \nPlease '
                                'provide Epochs compatible with '
@@ -874,8 +872,7 @@ class ICA(ContainsMixin):
 
         picks = _picks_to_idx(
             evoked.info, self.ch_names, exclude=[], allow_empty=True)
-        raise_ = False if len(picks) == len(self.ch_names) else True
-        if raise_:
+        if len(picks) != len(self.ch_names):
             raise RuntimeError('Evoked doesn\'t match fitted data: %i channels'
                                ' fitted but %i channels supplied. \nPlease '
                                'provide Evoked compatible with '

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -842,7 +842,7 @@ class ICA(ContainsMixin):
             raise RuntimeError('No fit available. Please fit ICA.')
         start, stop = _check_start_stop(raw, start, stop)
 
-        picks = pick_types(raw.info, include=self.ch_names, exclude='bads',
+        picks = pick_types(raw.info, include=self.ch_names, exclude=[],
                            meg=False, ref_meg=False)
         if len(picks) != len(self.ch_names):
             raise RuntimeError('Raw doesn\'t match fitted data: %i channels '
@@ -860,7 +860,7 @@ class ICA(ContainsMixin):
         if not hasattr(self, 'mixing_matrix_'):
             raise RuntimeError('No fit available. Please fit ICA.')
 
-        picks = pick_types(epochs.info, include=self.ch_names, exclude='bads',
+        picks = pick_types(epochs.info, include=self.ch_names, exclude=[],
                            meg=False, ref_meg=False)
         # special case where epochs come picked but fit was 'unpicked'.
         if len(picks) != len(self.ch_names):
@@ -884,7 +884,7 @@ class ICA(ContainsMixin):
         if not hasattr(self, 'mixing_matrix_'):
             raise RuntimeError('No fit available. Please fit ICA.')
 
-        picks = pick_types(evoked.info, include=self.ch_names, exclude='bads',
+        picks = pick_types(evoked.info, include=self.ch_names, exclude=[],
                            meg=False, ref_meg=False)
 
         if len(picks) != len(self.ch_names):

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -827,17 +827,9 @@ class ICA(ContainsMixin):
             raise RuntimeError('No fit available. Please fit ICA.')
         start, stop = _check_start_stop(raw, start, stop)
 
-        try:
-            picks = _picks_to_idx(raw.info, self.ch_names, exclude=[])
-            raise_ = False if len(picks) == len(self.ch_names) else True
-        except RuntimeWarning:
-            raise_ = True
-            picks = list()
-            for ch in self.ch_names:
-                try:
-                    picks.extend(_picks_to_idx(raw.info, ch, exclude=[]))
-                except ValueError:
-                    pass
+        picks = _picks_to_idx(
+            raw.info, self.ch_names, exclude=[], allow_empty=True)
+        raise_ = False if len(picks) == len(self.ch_names) else True
         if raise_:
             raise RuntimeError('Raw doesn\'t match fitted data: %i channels '
                                'fitted but %i channels supplied. \nPlease '
@@ -854,18 +846,10 @@ class ICA(ContainsMixin):
         if not hasattr(self, 'mixing_matrix_'):
             raise RuntimeError('No fit available. Please fit ICA.')
 
-        try:
-            picks = _picks_to_idx(epochs.info, self.ch_names, exclude=[])
-            # special case where epochs come picked but fit was 'unpicked'.
-            raise_ = False if len(picks) == len(self.ch_names) else True
-        except RuntimeWarning:
-            raise_ = True
-            picks = list()
-            for ch in self.ch_names:
-                try:
-                    picks.extend(_picks_to_idx(epochs.info, ch, exclude=[]))
-                except ValueError:
-                    pass
+        picks = _picks_to_idx(
+            epochs.info, self.ch_names, exclude=[], allow_empty=True)
+        # special case where epochs come picked but fit was 'unpicked'.
+        raise_ = False if len(picks) == len(self.ch_names) else True
         if raise_:
             raise RuntimeError('Epochs don\'t match fitted data: %i channels '
                                'fitted but %i channels supplied. \nPlease '
@@ -887,17 +871,8 @@ class ICA(ContainsMixin):
         if not hasattr(self, 'mixing_matrix_'):
             raise RuntimeError('No fit available. Please fit ICA.')
 
-        try:
-            picks = _picks_to_idx(evoked.info, self.ch_names, exclude=[])
-            raise_ = False if len(picks) == len(self.ch_names) else True
-        except RuntimeWarning:
-            raise_ = True
-            picks = list()
-            for ch in self.ch_names:
-                try:
-                    picks.extend(_picks_to_idx(evoked.info, ch, exclude=[]))
-                except ValueError:
-                    pass
+        picks = _picks_to_idx(evoked.info, self.ch_names, exclude=[])
+        raise_ = False if len(picks) == len(self.ch_names) else True
         if raise_:
             raise RuntimeError('Evoked doesn\'t match fitted data: %i channels'
                                ' fitted but %i channels supplied. \nPlease '

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -842,9 +842,18 @@ class ICA(ContainsMixin):
             raise RuntimeError('No fit available. Please fit ICA.')
         start, stop = _check_start_stop(raw, start, stop)
 
-        picks = pick_types(raw.info, include=self.ch_names, exclude=[],
-                           meg=False, ref_meg=False)
-        if len(picks) != len(self.ch_names):
+        try:
+            picks = _picks_to_idx(raw.info, self.ch_names, exclude=[])
+            raise_ = False if len(picks) == len(self.ch_names) else True
+        except ValueError:
+            raise_ = True
+            picks = list()
+            for ch in self.ch_names:
+                try:
+                    picks.extend(_picks_to_idx(raw.info, ch, exclude=[]))
+                except ValueError:
+                    pass
+        if raise_:
             raise RuntimeError('Raw doesn\'t match fitted data: %i channels '
                                'fitted but %i channels supplied. \nPlease '
                                'provide Raw compatible with '
@@ -860,10 +869,19 @@ class ICA(ContainsMixin):
         if not hasattr(self, 'mixing_matrix_'):
             raise RuntimeError('No fit available. Please fit ICA.')
 
-        picks = pick_types(epochs.info, include=self.ch_names, exclude=[],
-                           meg=False, ref_meg=False)
-        # special case where epochs come picked but fit was 'unpicked'.
-        if len(picks) != len(self.ch_names):
+        try:
+            picks = _picks_to_idx(epochs.info, self.ch_names, exclude=[])
+            # special case where epochs come picked but fit was 'unpicked'.
+            raise_ = False if len(picks) == len(self.ch_names) else True
+        except ValueError:
+            raise_ = True
+            picks = list()
+            for ch in self.ch_names:
+                try:
+                    picks.extend(_picks_to_idx(epochs.info, ch, exclude=[]))
+                except ValueError:
+                    pass
+        if raise_:
             raise RuntimeError('Epochs don\'t match fitted data: %i channels '
                                'fitted but %i channels supplied. \nPlease '
                                'provide Epochs compatible with '
@@ -884,10 +902,18 @@ class ICA(ContainsMixin):
         if not hasattr(self, 'mixing_matrix_'):
             raise RuntimeError('No fit available. Please fit ICA.')
 
-        picks = pick_types(evoked.info, include=self.ch_names, exclude=[],
-                           meg=False, ref_meg=False)
-
-        if len(picks) != len(self.ch_names):
+        try:
+            picks = _picks_to_idx(evoked.info, self.ch_names, exclude=[])
+            raise_ = False if len(picks) == len(self.ch_names) else True
+        except ValueError:
+            raise_ = True
+            picks = list()
+            for ch in self.ch_names:
+                try:
+                    picks.extend(_picks_to_idx(evoked.info, ch, exclude=[]))
+                except ValueError:
+                    pass
+        if raise_:
             raise RuntimeError('Evoked doesn\'t match fitted data: %i channels'
                                ' fitted but %i channels supplied. \nPlease '
                                'provide Evoked compatible with '

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -871,7 +871,8 @@ class ICA(ContainsMixin):
         if not hasattr(self, 'mixing_matrix_'):
             raise RuntimeError('No fit available. Please fit ICA.')
 
-        picks = _picks_to_idx(evoked.info, self.ch_names, exclude=[])
+        picks = _picks_to_idx(
+            evoked.info, self.ch_names, exclude=[], allow_empty=True)
         raise_ = False if len(picks) == len(self.ch_names) else True
         if raise_:
             raise RuntimeError('Evoked doesn\'t match fitted data: %i channels'

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -933,16 +933,12 @@ def test_ica_additional(method, tmpdir, short_raw_epochs):
             ica.find_bads_ecg(raw, threshold='auto')
 
     # test passing picks including the marked bad channels
-    data = np.random.randn(4, 160 * 10)
-    ch_names = [f'EEG{i+1}' for i in range(4)]
-    ch_types = ['eeg'] * len(ch_names)
-    info = create_info(ch_names, ch_types=ch_types, sfreq=160)
-    raw = RawArray(data, info)
-    raw.info['bads'] = ['EEG2']
-
-    picks = pick_types(raw.info, eeg=True, exclude=[])
+    raw_ = raw.copy()
+    raw_.pick_types(eeg=True)
+    raw_.info['bads'] = [raw_.ch_names[0]]
+    picks = pick_types(raw_.info, eeg=True, exclude=[])
     ica = ICA(n_components=0.99, max_iter='auto')
-    ica.fit(raw, picks=picks, reject_by_annotation=True)
+    ica.fit(raw_, picks=picks, reject_by_annotation=True)
 
 
 @requires_sklearn

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -933,7 +933,7 @@ def test_ica_additional(method, tmpdir, short_raw_epochs):
             ica.find_bads_ecg(raw, threshold='auto')
 
     # test passing picks including the marked bad channels
-    data = np.zeros((4, 160 * 10))
+    data = np.random.randn(4, 160 * 10)
     ch_names = [f'EEG{i+1}' for i in range(4)]
     ch_types = ['eeg'] * len(ch_names)
     info = create_info(ch_names, ch_types=ch_types, sfreq=160)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -932,6 +932,18 @@ def test_ica_additional(method, tmpdir, short_raw_epochs):
         with pytest.warns(RuntimeWarning, match='longer'):
             ica.find_bads_ecg(raw, threshold='auto')
 
+    # test passing picks including the marked bad channels
+    data = np.zeros((4, 160 * 10))
+    ch_names = [f'EEG{i+1}' for i in range(4)]
+    ch_types = ['eeg'] * len(ch_names)
+    info = create_info(ch_names, ch_types=ch_types, sfreq=160)
+    raw = RawArray(data, info)
+    raw.info['bads'] = ['EEG2']
+
+    picks = pick_types(raw.info, eeg=True, exclude=[])
+    ica = ICA(n_components=0.99, max_iter='auto')
+    ica.fit(raw, picks=picks, reject_by_annotation=True)
+
 
 @requires_sklearn
 @pytest.mark.slowtest

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -705,7 +705,8 @@ def test_ica_additional(method, tmpdir, short_raw_epochs):
     assert_equal(ica_sorted.labels_, dict(blink=[3], think=[2]))
 
     # epochs extraction from raw fit
-    pytest.raises(RuntimeError, ica.get_sources, epochs)
+    with pytest.warns(RuntimeWarning, match='could not be picked'):
+        pytest.raises(RuntimeError, ica.get_sources, epochs)
 
     # test filtering
     ica_raw = ica.get_sources(raw)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -664,7 +664,8 @@ def test_ica_additional(method, tmpdir, short_raw_epochs):
     ica_different_channels = ICA(n_components=2, max_iter=1)
     with pytest.warns(Warning, match='converge'):
         ica_different_channels.fit(raw, picks=[2, 3, 4, 5])
-    pytest.raises(ValueError, corrmap, [ica_different_channels, ica], (0, 0))
+    with pytest.raises(ValueError, match='Not all ICA instances have the'):
+        corrmap([ica_different_channels, ica], (0, 0))
 
     # test warnings on bad filenames
     ica_badname = tmpdir.join('test-bad-name.fif.gz')
@@ -705,8 +706,9 @@ def test_ica_additional(method, tmpdir, short_raw_epochs):
     assert_equal(ica_sorted.labels_, dict(blink=[3], think=[2]))
 
     # epochs extraction from raw fit
-    with pytest.warns(RuntimeWarning, match='could not be picked'):
-        pytest.raises(RuntimeError, ica.get_sources, epochs)
+    with pytest.warns(RuntimeWarning, match='could not be picked'), \
+         pytest.raises(RuntimeError, match="match fitted data"):
+        ica.get_sources(epochs)
 
     # test filtering
     ica_raw = ica.get_sources(raw)
@@ -775,8 +777,8 @@ def test_ica_additional(method, tmpdir, short_raw_epochs):
     # check univariate stats
     scores = ica.score_sources(raw, start=0, stop=50, score_func=stats.skew)
     # check exception handling
-    pytest.raises(ValueError, ica.score_sources, raw,
-                  target=np.arange(1))
+    with pytest.raises(ValueError, match='Sources and target do not have'):
+        ica.score_sources(raw, target=np.arange(1))
 
     params = []
     params += [(None, -1, slice(2), [0, 1])]  # variance, kurtosis params
@@ -822,10 +824,10 @@ def test_ica_additional(method, tmpdir, short_raw_epochs):
                                     stop=epochs.times[-1])
 
     assert_equal(len(scores), ica.n_components_)
-    pytest.raises(ValueError, ica.find_bads_ecg, epochs.average(),
-                  method='ctps', threshold='auto')
-    pytest.raises(ValueError, ica.find_bads_ecg, raw,
-                  method='crazy-coupling')
+    with pytest.raises(ValueError, match='only Raw and Epochs input'):
+        ica.find_bads_ecg(epochs.average(), method='ctps', threshold='auto')
+    with pytest.raises(ValueError, match='not supported.'):
+        ica.find_bads_ecg(raw, method='crazy-coupling')
 
     with pytest.warns(RuntimeWarning, match='longer'):
         idx, scores = ica.find_bads_eog(raw)
@@ -863,8 +865,8 @@ def test_ica_additional(method, tmpdir, short_raw_epochs):
     scores = ica.score_sources(epochs, score_func=stats.skew)
 
     # check exception handling
-    pytest.raises(ValueError, ica.score_sources, epochs,
-                  target=np.arange(1))
+    with pytest.raises(ValueError, match='Sources and target do not have'):
+        ica.score_sources(epochs, target=np.arange(1))
 
     # ecg functionality
     ecg_scores = ica.score_sources(raw, target='MEG 1531',
@@ -1158,9 +1160,11 @@ def test_bad_channels(method, allow_ref_meg):
                 picks_bad2 = pick_types(inst.info, meg=True,
                                         **{str(ch): True})
 
-            pytest.raises(ValueError, ica.fit, inst, picks=picks_bad1)
-            pytest.raises(ValueError, ica.fit, inst, picks=picks_bad2)
-        pytest.raises(ValueError, ica.fit, inst, picks=[])
+            with pytest.raises(ValueError, match='Invalid channel type'):
+                ica.fit(inst, picks=picks_bad1)
+                ica.fit(inst, picks=picks_bad2)
+        with pytest.raises(ValueError, match='No appropriate channels found'):
+            ica.fit(inst, picks=[])
 
 
 @requires_sklearn

--- a/mne/rank.py
+++ b/mne/rank.py
@@ -322,6 +322,9 @@ def compute_rank(inst, rank=None, scalings=None, info=None, tol='auto',
         inst_type = 'covariance'
         if info is None:
             raise ValueError('info cannot be None if inst is a Covariance.')
+        # Reset bads as it's already taken into account in inst['names']
+        info = info.copy()
+        info['bads'] = []
         inst = pick_channels_cov(
             inst, set(inst['names']) & set(info['ch_names']), exclude=[])
         if info['ch_names'] != inst['names']:
@@ -344,7 +347,7 @@ def compute_rank(inst, rank=None, scalings=None, info=None, tol='auto',
 
     simple_info = _simplify_info(info)
     picks_list = _picks_by_type(info, meg_combined=True, ref_meg=False,
-                                exclude=[])
+                                exclude='bads')
     for ch_type, picks in picks_list:
         est_verbose = None
         if ch_type in rank:

--- a/mne/rank.py
+++ b/mne/rank.py
@@ -198,7 +198,7 @@ def _estimate_rank_meeg_cov(data, info, scalings, tol='auto',
         If return_singular is True, the singular values that were
         thresholded to determine the rank are also returned.
     """
-    picks_list = _picks_by_type(info)
+    picks_list = _picks_by_type(info, exclude=[])
     scalings = _handle_default('scalings_cov_rank', scalings)
     _apply_scaling_cov(data, picks_list, scalings)
     if data.shape[1] < data.shape[0]:
@@ -323,7 +323,7 @@ def compute_rank(inst, rank=None, scalings=None, info=None, tol='auto',
         if info is None:
             raise ValueError('info cannot be None if inst is a Covariance.')
         inst = pick_channels_cov(
-            inst, set(inst['names']) & set(info['ch_names']))
+            inst, set(inst['names']) & set(info['ch_names']), exclude=[])
         if info['ch_names'] != inst['names']:
             info = pick_info(info, [info['ch_names'].index(name)
                                     for name in inst['names']])
@@ -344,7 +344,7 @@ def compute_rank(inst, rank=None, scalings=None, info=None, tol='auto',
 
     simple_info = _simplify_info(info)
     picks_list = _picks_by_type(info, meg_combined=True, ref_meg=False,
-                                exclude='bads')
+                                exclude=[])
     for ch_type, picks in picks_list:
         est_verbose = None
         if ch_type in rank:

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -81,7 +81,7 @@ def test_compute_whitener(proj, pca):
     with pytest.warns(RuntimeWarning, match='Too few samples'):
         cov2 = compute_raw_covariance(raw, picks=picks)
         cov3 = compute_raw_covariance(raw, picks=None)
-    assert_array_equal(cov2['data'][1:, 1:], cov3['data'])
+    assert_allclose(cov2['data'][1:, 1:], cov3['data'])
     W2, _, C2 = compute_whitener(cov2, raw.info, pca=pca, return_colorer=True,
                                  picks=picks, verbose='error')
     W3, _, C3 = compute_whitener(cov3, raw.info, pca=pca, return_colorer=True,

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -81,6 +81,7 @@ def test_compute_whitener(proj, pca):
     with pytest.warns(RuntimeWarning, match='Too few samples'):
         cov2 = compute_raw_covariance(raw, picks=picks)
         cov3 = compute_raw_covariance(raw, picks=None)
+    assert (cov2['data'][1:, 1:] == cov3['data']).all()
     W2, _, C2 = compute_whitener(cov2, raw.info, pca=pca, return_colorer=True,
                                  picks=picks, verbose='error')
     W3, _, C3 = compute_whitener(cov3, raw.info, pca=pca, return_colorer=True,

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -81,13 +81,13 @@ def test_compute_whitener(proj, pca):
     with pytest.warns(RuntimeWarning, match='Too few samples'):
         cov2 = compute_raw_covariance(raw, picks=picks)
         cov3 = compute_raw_covariance(raw, picks=None)
-    assert (cov2['data'][1:, 1:] == cov3['data']).all()
+    assert_array_equal(cov2['data'][1:, 1:], cov3['data'])
     W2, _, C2 = compute_whitener(cov2, raw.info, pca=pca, return_colorer=True,
                                  picks=picks, verbose='error')
     W3, _, C3 = compute_whitener(cov3, raw.info, pca=pca, return_colorer=True,
                                  picks=None, verbose='error')
-    assert (W == W2).all()
-    assert (C == C2).all()
+    assert_array_equal(W, W2)
+    assert_array_equal(C, C2)
     n_channels = len(raw.ch_names) - len(raw.info['bads'])
     n_reduced = len(raw.ch_names) - len(raw.info['bads'])
     rank = n_channels - len(raw.info['projs'])

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -80,7 +80,7 @@ def test_compute_whitener(proj, pca):
     with pytest.warns(RuntimeWarning, match='Too few samples'):
         cov = compute_raw_covariance(raw, picks=picks)
     W2, _, C2 = compute_whitener(cov, raw.info, pca=pca, return_colorer=True,
-                               picks=picks, verbose='error')
+                                 picks=picks, verbose='error')
     assert (W == W2).all()
     assert (C == C2).all()
 

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -75,6 +75,15 @@ def test_compute_whitener(proj, pca):
         assert pca is False
         assert_allclose(round_trip, np.eye(n_channels), atol=0.05)
 
+    raw.info['bads'] = [raw.ch_names[0]]
+    picks = pick_types(raw.info, meg=True, eeg=True, exclude=[])
+    with pytest.warns(RuntimeWarning, match='Too few samples'):
+        cov = compute_raw_covariance(raw, picks=picks)
+    W2, _, C2 = compute_whitener(cov, raw.info, pca=pca, return_colorer=True,
+                               picks=picks, verbose='error')
+    assert (W == W2).all()
+    assert (C == C2).all()
+
 
 def test_cov_mismatch():
     """Test estimation with MEG<->Head mismatch."""

--- a/mne/tests/test_rank.py
+++ b/mne/tests/test_rank.py
@@ -264,8 +264,7 @@ def test_maxfilter_get_rank(n_proj, fname, rank_orig, meg, tol_kind, tol):
 
 
 def test_explicit_bads_pick():
-    """Test when bads channels are explicitly passed to picks and def ault
-    behavior with picks=None."""
+    """Test when bads channels are explicitly passed + default picks=None."""
     raw = read_raw_fif(raw_fname, preload=True)
     raw.pick_types(eeg=True, meg=True, ref_meg=True)
 

--- a/mne/tests/test_rank.py
+++ b/mne/tests/test_rank.py
@@ -289,7 +289,7 @@ def test_explicit_bads_pick():
     assert rank == dict(meg=303, eeg=60)
     assert raw.info['bads'] == ['EEG 002', 'EEG 012', 'EEG 015', 'MEG 0122']
 
-    assert (noise_cov_1['data'] == noise_cov_2['data']).all()
+    assert_array_equal(noise_cov_1['data'], noise_cov_2['data'])
     assert noise_cov_1['names'] == noise_cov_2['names']
 
     # Raw

--- a/mne/tests/test_rank.py
+++ b/mne/tests/test_rank.py
@@ -261,3 +261,18 @@ def test_maxfilter_get_rank(n_proj, fname, rank_orig, meg, tol_kind, tol):
     rank_new = _compute_rank_int(raw, 'info')
     assert rank_new == rank
     assert_array_equal(raw[:][0], data_orig)
+
+
+def test_explicit_bads_pick():
+    raw = read_raw_fif(raw_fname, preload=True)
+    raw.pick_types(eeg=True, meg=True, ref_meg=True)
+    picks = pick_types(raw.info, eeg=True, meg=True, ref_meg=True, exclude=[])
+    noise_cov_1 = compute_raw_covariance(raw, picks=picks)
+    rank_noise_cov_1 = compute_rank(noise_cov_1, info=raw.info)
+    raw.info['bads'] = ['EEG 002', 'EEG 012', 'EEG 015']
+    noise_cov_2 = compute_raw_covariance(raw, picks=picks)
+    rank_noise_cov_2 = compute_rank(noise_cov_2, info=raw.info)
+    assert (noise_cov_1['data'] == noise_cov_2['data']).all()
+    assert noise_cov_1['names'] == noise_cov_2['names']
+    assert rank_noise_cov_1['eeg'] == rank_noise_cov_2['eeg']
+    assert rank_noise_cov_1['meg'] == rank_noise_cov_2['meg']

--- a/mne/tests/test_rank.py
+++ b/mne/tests/test_rank.py
@@ -264,6 +264,7 @@ def test_maxfilter_get_rank(n_proj, fname, rank_orig, meg, tol_kind, tol):
 
 
 def test_explicit_bads_pick():
+    """Test when bads channels are explicitly passed to picks."""
     raw = read_raw_fif(raw_fname, preload=True)
     raw.pick_types(eeg=True, meg=True, ref_meg=True)
     picks = pick_types(raw.info, eeg=True, meg=True, ref_meg=True, exclude=[])

--- a/mne/tests/test_rank.py
+++ b/mne/tests/test_rank.py
@@ -269,7 +269,7 @@ def test_explicit_bads_pick():
     raw = read_raw_fif(raw_fname, preload=True)
     raw.pick_types(eeg=True, meg=True, ref_meg=True)
 
-    ## Covariance
+    # Covariance
     # Default picks=None
     raw.info['bads'] = list()
     noise_cov_1 = compute_raw_covariance(raw, picks=None)
@@ -293,7 +293,7 @@ def test_explicit_bads_pick():
     assert (noise_cov_1['data'] == noise_cov_2['data']).all()
     assert noise_cov_1['names'] == noise_cov_2['names']
 
-    ## Raw
+    # Raw
     raw.info['bads'] = list()
     rank = compute_rank(raw)
     assert rank == dict(meg=303, eeg=60)

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -266,14 +266,14 @@ def test_plot_ica_sources(raw_orig, browse_backend):
     # test error handling
     raw_ = raw.copy().load_data()
     raw_.drop_channels('MEG 0113')
-    with pytest.raises(RuntimeError, match="Raw doesn't match fitted data"):
-        with pytest.warns(RuntimeWarning, match='could not be picked'):
-            ica.plot_sources(inst=raw_)
+    with pytest.raises(RuntimeError, match="Raw doesn't match fitted data"), \
+         pytest.warns(RuntimeWarning, match='could not be picked'):
+        ica.plot_sources(inst=raw_)
     epochs_ = epochs.copy().load_data()
     epochs_.drop_channels('MEG 0113')
-    with pytest.raises(RuntimeError, match="Epochs don't match fitted data"):
-        with pytest.warns(RuntimeWarning, match='could not be picked'):
-            ica.plot_sources(inst=epochs_)
+    with pytest.raises(RuntimeError, match="Epochs don't match fitted data"), \
+         pytest.warns(RuntimeWarning, match='could not be picked'):
+        ica.plot_sources(inst=epochs_)
     del raw_
     del epochs_
 

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -264,13 +264,16 @@ def test_plot_ica_sources(raw_orig, browse_backend):
     raw.set_annotations(orig_annot)
 
     # test error handling
-    raw.info['bads'] = ['MEG 0113']
+    raw_ = raw.copy().load_data()
+    raw_.drop_channels('MEG 0113')
     with pytest.raises(RuntimeError, match="Raw doesn't match fitted data"):
-        ica.plot_sources(inst=raw)
-    epochs.info['bads'] = ['MEG 0113']
+        ica.plot_sources(inst=raw_)
+    epochs_ = epochs.copy().load_data()
+    epochs_.drop_channels('MEG 0113')
     with pytest.raises(RuntimeError, match="Epochs don't match fitted data"):
-        ica.plot_sources(inst=epochs)
-    epochs.info['bads'] = []
+        ica.plot_sources(inst=epochs_)
+    del raw_
+    del epochs_
 
     # test w/ epochs and evokeds
     ica.plot_sources(epochs)

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -267,11 +267,13 @@ def test_plot_ica_sources(raw_orig, browse_backend):
     raw_ = raw.copy().load_data()
     raw_.drop_channels('MEG 0113')
     with pytest.raises(RuntimeError, match="Raw doesn't match fitted data"):
-        ica.plot_sources(inst=raw_)
+        with pytest.warns(RuntimeWarning, match='could not be picked'):
+            ica.plot_sources(inst=raw_)
     epochs_ = epochs.copy().load_data()
     epochs_.drop_channels('MEG 0113')
     with pytest.raises(RuntimeError, match="Epochs don't match fitted data"):
-        ica.plot_sources(inst=epochs_)
+        with pytest.warns(RuntimeWarning, match='could not be picked'):
+            ica.plot_sources(inst=epochs_)
     del raw_
     del epochs_
 


### PR DESCRIPTION
#### Reference issue
Fix #9716.

#### What does this implement/fix?

The marked bad channels were excluded by default in method `._compute_pre_whitener()`. However, the channel picking, excluding the bad channels IF they were not explicitly provided, is already done in `.fit` when the attribute `self.info` is defined with an info instance based on the selection of picked channels. 

I added `exclude=[]` to every pick in the if/else statement in `._compute_pre_whitener()`. 
I removed `meg=False` (default argument) and renamed `this_picks` to `picks_` to shorten the lines.
