### PR TITLE
MRG, BUG: Fix hemi

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -460,6 +460,7 @@ linkcheck_ignore = [  # will be compiled to regex
     'https://www.nyu.edu/',  # noqa Max retries exceeded with url: / (Caused by SSLError(SSLError(1, '[SSL: DH_KEY_TOO_SMALL] dh key too small (_ssl.c:1122)')))
     'https://docs.python.org/3/library/.*',  # noqa ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
     'https://hal.archives-ouvertes.fr/hal-01848442.*',  # noqa Sometimes: 503 Server Error: Service Unavailable for url: https://hal.archives-ouvertes.fr/hal-01848442/
+    'http://www.cs.ucl.ac.uk/staff/d.barber/brml.*',  # noqa Sometimes: Read timed out
 ]
 linkcheck_anchors = False  # saves a bit of time
 linkcheck_timeout = 15  # some can be quite slow

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1875,7 +1875,6 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
         "colorbar": colorbar,
         "vector_alpha": vector_alpha,
         "scale_factor": scale_factor,
-        "verbose": False,
         "initial_time": initial_time,
         "transparent": transparent,
         "center": center,
@@ -1885,7 +1884,7 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
         "clim": clim,
         "src": src,
         "volume_options": volume_options,
-        "verbose": False,
+        "verbose": None,
     }
     if add_data_kwargs is not None:
         kwargs.update(add_data_kwargs)

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1806,6 +1806,8 @@ class Brain(object):
     def _remove(self, item, render=False):
         """Remove actors from the rendered scene."""
         if item in self._actors:
+            logger.debug(
+                f'Removing {len(self._actors[item])} {item} actor(s)')
             for actor in self._actors[item]:
                 self._renderer.plotter.remove_actor(actor)
             self._actors.pop(item)  # remove actor list
@@ -1927,8 +1929,6 @@ class Brain(object):
             if time_label_size < 0:
                 raise ValueError('time_label_size must be positive, got '
                                  f'{time_label_size}')
-
-        self.remove_data()  # remove any existing data
 
         hemi = self._check_hemi(hemi, extras=['vol'])
         stc, array, vertices = self._check_stc(hemi, array, vertices)

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -205,6 +205,7 @@ def test_brain_init(renderer_pyvistaqt, tmpdir, pixel_ratio, brain_gc):
     brain = Brain(hemi=hemi, surf=surf, size=size, title=title,
                   cortex=cortex, units='m',
                   silhouette=dict(decimate=0.95), **kwargs)
+    assert 'data' not in brain._actors
     with pytest.raises(TypeError, match='not supported'):
         brain._check_stc(hemi='lh', array=FakeSTC(), vertices=None)
     with pytest.raises(ValueError, match='add_data'):
@@ -290,6 +291,10 @@ def test_brain_init(renderer_pyvistaqt, tmpdir, pixel_ratio, brain_gc):
             brain.add_data(hemi_data[:, np.newaxis, np.newaxis],
                            fmin=fmin, hemi=h, fmax=fmax, colormap='hot',
                            vertices=hemi_vertices)
+    assert len(brain._actors['data']) == 4
+    brain.remove_data()
+    assert 'data' not in brain._actors
+
     # add label
     label = read_label(fname_label)
     with pytest.raises(ValueError, match="not a filename"):
@@ -707,9 +712,13 @@ def test_brain_traces(renderer_interactive_pyvistaqt, hemi, src, tmpdir,
     for current_hemi in hemi_str:
         assert len(picked_points[current_hemi]) == 1
     n_spheres = len(hemi_str)
+    n_actors = n_spheres
     if hemi == 'split' and src in ('mixed', 'volume'):
         n_spheres += 1
     assert len(spheres) == n_spheres
+
+    # test that there are actually enough actors
+    assert len(brain._actors['data']) == n_actors
 
     # test switching from 'vertex' to 'label'
     if src == 'surface':

--- a/tutorials/inverse/40_mne_fixed_free.py
+++ b/tutorials/inverse/40_mne_fixed_free.py
@@ -7,7 +7,8 @@ Computing various MNE solutions
 ===============================
 
 This example shows example fixed- and free-orientation source localizations
-produced by MNE, dSPM, sLORETA, and eLORETA.
+produced by the minimum-norm variants implemented in MNE-Python:
+MNE, dSPM, sLORETA, and eLORETA.
 """
 # Author: Eric Larson <larson.eric.d@gmail.com>
 #


### PR DESCRIPTION
Closes #9720

Fixes regression introduced by #9688 (specifically on [this line](https://github.com/mne-tools/mne-python/pull/9688/files#diff-4e3d2d919a60057d535ba733330d5b8338aa491d6392b3d1c4a1a3de7122e17eR1930)), adds a test that would have caught it, touches an example that is broken on `main`, and fixes a persistent `linkcheck` false alarm.