### PR TITLE
[BUG, MRG] Keep function globals

### DIFF
--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -131,7 +131,8 @@ def %(name)s(%(signature)s):\n
     evaldict = dict(
         _use_log_level_=use_log_level, _function_=function)
     fm = FunctionMaker(function, None, None, None, None, function.__module__)
-    attrs = dict(__wrapped__=function, __qualname__=function.__qualname__)
+    attrs = dict(__wrapped__=function, __qualname__=function.__qualname__,
+                 __globals__=function.__globals__)
     return fm.make(body, evaldict, addsource=True, **attrs)
 
 


### PR DESCRIPTION
It looks like when the verbose decorator is added, the `__globals__` are lost because they aren't added as attributes to the newly made function. This is to fix that.