### PR TITLE
fix EDF reader

### DIFF
--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -27,18 +27,6 @@ from .read import (read_int32, read_int16, read_float, read_double,
                    read_uint32, read_double_matrix, read_float_matrix,
                    read_int16_matrix, read_dev_header)
 
-FIFF_INFO_CHS_FIELDS = ('loc',
-                        'ch_name', 'unit_mul', 'coord_frame',
-                        'coil_type',
-                        'range', 'unit', 'cal',
-                        'scanno', 'kind', 'logno')
-
-FIFF_INFO_CHS_DEFAULTS = (np.array([0, 0, 0, 1] * 3, dtype='f4'),
-                          None, FIFF.FIFF_UNITM_NONE, FIFF.FIFFV_COORD_UNKNOWN,
-                          FIFF.FIFFV_COIL_NONE,
-                          1.0, FIFF.FIFF_UNIT_V, 1.0,
-                          None, FIFF.FIFFV_ECG_CH, None)
-
 FIFF_INFO_DIG_FIELDS = ('kind', 'ident', 'r', 'coord_frame')
 FIFF_INFO_DIG_DEFAULTS = (None, None, None, FIFF.FIFFV_COORD_HEAD)
 
@@ -47,6 +35,20 @@ BTI_WH2500_REF_GRAD = ('GxxA', 'GyyA', 'GyxA', 'GzaA', 'GzyA')
 
 dtypes = zip(list(range(1, 5)), ('>i2', '>i4', '>f4', '>f8'))
 DTYPES = {i: np.dtype(t) for i, t in dtypes}
+
+
+def instantiate_default_info_chs():
+    return dict(loc=np.array([0, 0, 0, 1] * 3, dtype='f4'),
+                ch_name=None,
+                unit_mul=FIFF.FIFF_UNITM_NONE,
+                coord_frame=FIFF.FIFFV_COORD_UNKNOWN,
+                coil_type=FIFF.FIFFV_COIL_NONE,
+                range=1.0,
+                unit=FIFF.FIFF_UNIT_V,
+                cal=1.0,
+                scanno=None,
+                kind=FIFF.FIFFV_ECG_CH,
+                logno=None)
 
 
 class _bytes_io_mock_context():
@@ -1134,7 +1136,7 @@ def _get_bti_info(pdf_fname, config_fname, head_shape_fname, rotation_x,
 
     logger.info('... Setting channel info structure.')
     for idx, (chan_4d, chan_neuromag) in enumerate(ch_mapping):
-        chan_info = dict(zip(FIFF_INFO_CHS_FIELDS, FIFF_INFO_CHS_DEFAULTS))
+        chan_info = instantiate_default_info_chs()
         chan_info['ch_name'] = chan_neuromag if rename_channels else chan_4d
         chan_info['logno'] = idx + BTI.FIFF_LOGNO
         chan_info['scanno'] = idx + 1

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -37,7 +37,8 @@ dtypes = zip(list(range(1, 5)), ('>i2', '>i4', '>f4', '>f8'))
 DTYPES = {i: np.dtype(t) for i, t in dtypes}
 
 
-def instantiate_default_info_chs():
+def _instantiate_default_info_chs():
+    """Populate entries in info['chs'] with default values."""
     return dict(loc=np.array([0, 0, 0, 1] * 3, dtype='f4'),
                 ch_name=None,
                 unit_mul=FIFF.FIFF_UNITM_NONE,
@@ -1136,7 +1137,7 @@ def _get_bti_info(pdf_fname, config_fname, head_shape_fname, rotation_x,
 
     logger.info('... Setting channel info structure.')
     for idx, (chan_4d, chan_neuromag) in enumerate(ch_mapping):
-        chan_info = instantiate_default_info_chs()
+        chan_info = _instantiate_default_info_chs()
         chan_info['ch_name'] = chan_neuromag if rename_channels else chan_4d
         chan_info['logno'] = idx + BTI.FIFF_LOGNO
         chan_info['scanno'] = idx + 1

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -404,11 +404,6 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
     }
     chs_without_types = list()
 
-    # montage is not able to be stored in EDF, so
-    # default to unknown locations for the channels
-    nan_arr = np.zeros(12)
-    nan_arr[:] = np.nan
-
     for idx, ch_name in enumerate(ch_names):
         chan_info = {}
         chan_info['cal'] = 1.
@@ -421,7 +416,8 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
         chan_info['coord_frame'] = FIFF.FIFFV_COORD_HEAD
         chan_info['coil_type'] = FIFF.FIFFV_COIL_EEG
         chan_info['kind'] = FIFF.FIFFV_EEG_CH
-        chan_info['loc'] = nan_arr
+        # montage can't be stored in EDF so channel locs are unknown:
+        chan_info['loc'] = np.full(12, np.nan)
 
         # if the edf info contained channel type information
         # set it now

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -402,7 +402,7 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
         'MISC': FIFF.FIFFV_MISC_CH,
         'SAO2': FIFF.FIFFV_BIO_CH,
     }
-    bad_map = dict()
+    chs_without_types = list()
 
     # montage is not able to be stored in EDF, so
     # default to unknown locations for the channels
@@ -432,7 +432,7 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
                 chan_info['coil_type'] = FIFF.FIFFV_COIL_NONE
                 pick_mask[idx] = False
         elif ch_type not in ch_type_mapping:
-            bad_map[ch_name] = ch_type
+            chs_without_types.append(ch_name)
 
         # if user passes in explicit mapping for eog, misc and stim
         # channels set them here
@@ -455,11 +455,10 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
         chs.append(chan_info)
 
     # warn if channel type was not inferable
-    if len(bad_map):
-        bad_map = '\n'.join(f'{ch_name}: {ch_type}'
-                            for ch_name, ch_type in bad_map.items())
-        warn(f'Found the following unknown channel type mapping(s), '
-             f'setting the channel type to EEG:\n{bad_map}')
+    if len(chs_without_types):
+        msg = ('Could not determine channel type of the following channels, '
+               f'they will be set as EEG:\n{", ".join(chs_without_types)}')
+        logger.info(msg)
 
     edf_info['stim_channel_idxs'] = stim_channel_idxs
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -427,9 +427,6 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
             if ch_type not in ['EEG', 'ECOG', 'SEEG', 'DBS']:
                 chan_info['coil_type'] = FIFF.FIFFV_COIL_NONE
                 pick_mask[idx] = False
-        elif ch_type not in ch_type_mapping:
-            chs_without_types.append(ch_name)
-
         # if user passes in explicit mapping for eog, misc and stim
         # channels set them here
         if ch_name in eog or idx in eog or idx - nchan in eog:
@@ -448,6 +445,8 @@ def _get_info(fname, stim_channel, eog, misc, exclude, preload):
             chan_info['ch_name'] = ch_name
             ch_names[idx] = chan_info['ch_name']
             edf_info['units'][idx] = 1
+        elif ch_type not in ch_type_mapping:
+            chs_without_types.append(ch_name)
         chs.append(chan_info)
 
     # warn if channel type was not inferable

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -234,6 +234,9 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
     else:
         raw = reader(**kwargs)
     assert_named_constants(raw.info)
+    # smoke test for gh #9743
+    ids = [id(ch['loc']) for ch in raw.info['chs']]
+    assert len(set(ids)) == len(ids)
 
     full_data = raw._data
     assert raw.__class__.__name__ in repr(raw)  # to test repr

--- a/tools/circleci_download.sh
+++ b/tools/circleci_download.sh
@@ -39,7 +39,7 @@ else
                 python -c "import mne; print(mne.datasets.eegbci.load_data(4, [3], update_path=True))";
             fi;
             if [[ $(cat $FNAME | grep -x ".*datasets.*sleep_physionet.*" | wc -l) -gt 0 ]]; then
-                python -c "import mne; print(mne.datasets.sleep_physionet.age.fetch_data([0, 1], recording=[1], update_path=True))";
+                python -c "import mne; print(mne.datasets.sleep_physionet.age.fetch_data([0, 1], recording=[1]))";
             fi;
             if [[ $(cat $FNAME | grep -x ".*datasets.*hf_sef.*" | wc -l) -gt 0 ]]; then
                 python -c "import mne; print(mne.datasets.hf_sef.data_path(update_path=True))";

--- a/tutorials/clinical/60_sleep.py
+++ b/tutorials/clinical/60_sleep.py
@@ -78,17 +78,11 @@ ALICE, BOB = 0, 1
 
 [alice_files, bob_files] = fetch_data(subjects=[ALICE, BOB], recording=[1])
 
-mapping = {'EOG horizontal': 'eog',
-           'Resp oro-nasal': 'resp',
-           'EMG submental': 'emg',
-           'Temp rectal': 'misc',
-           'Event marker': 'misc'}
-
-raw_train = mne.io.read_raw_edf(alice_files[0])
+raw_train = mne.io.read_raw_edf(alice_files[0], stim_channel='marker',
+                                misc=['rectal'])
 annot_train = mne.read_annotations(alice_files[1])
 
 raw_train.set_annotations(annot_train, emit_warning=False)
-raw_train.set_channel_types(mapping)
 
 # plot some data
 # scalings were chosen manually to allow for simultaneous visualization of
@@ -164,12 +158,12 @@ print(epochs_train)
 # Applying the same steps to the test data from Bob
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-raw_test = mne.io.read_raw_edf(bob_files[0])
+raw_test = mne.io.read_raw_edf(bob_files[0], stim_channel='marker',
+                               misc=['rectal'])
 annot_test = mne.read_annotations(bob_files[1])
 annot_test.crop(annot_test[1]['onset'] - 30 * 60,
                 annot_test[-2]['onset'] + 30 * 60)
 raw_test.set_annotations(annot_test, emit_warning=False)
-raw_test.set_channel_types(mapping)
 events_test, _ = mne.events_from_annotations(
     raw_test, event_id=annotation_desc_2_event_id, chunk_duration=30.)
 epochs_test = mne.Epochs(raw=raw_test, events=events_test, event_id=event_id,
@@ -259,8 +253,8 @@ def eeg_power_band(epochs):
 #
 # To answer the question of how well can we predict the sleep stages of Bob
 # from Alice's data and avoid as much boilerplate code as possible, we will
-# take advantage of two key features of sckit-learn:
-# `Pipeline`_ , and `FunctionTransformer`_.
+# take advantage of two key features of sckit-learn: `Pipeline`_ , and
+# `FunctionTransformer`_.
 #
 # Scikit-learn pipeline composes an estimator as a sequence of transforms
 # and a final estimator, while the FunctionTransformer converts a python

--- a/tutorials/preprocessing/40_artifact_correction_ica.py
+++ b/tutorials/preprocessing/40_artifact_correction_ica.py
@@ -467,8 +467,8 @@ del raw, ica, new_ica
 # an IC for exclusion on one subject, and then use that component as a
 # *template* for selecting which ICs to exclude from other subjects' data,
 # using `mne.preprocessing.corrmap` :footcite:`CamposViolaEtAl2009`.
-# The idea behind
-# `~mne.preprocessing.corrmap` is that the artifact patterns are similar
+# The idea behind `~mne.preprocessing.corrmap` is that the artifact patterns
+# are similar
 # enough across subjects that corresponding ICs can be identified by
 # correlating the ICs from each ICA solution with a common template, and
 # picking the ICs with the highest correlation strength.


### PR DESCRIPTION
- converts "missing channel type" warning to `logger.info`
- fixes bug where all channel `loc` fields in the info pointed to the same object in memory (so that when setting montage, all channels get the coords of whichever channel came last)
- updates sleep tutorial to reflect new channel name behavior
- fix the logic so that if user specifies `stim_channel` or `misc` args to `read_raw_edf` they don't get spurious warnings about unidentified channel types