### PR TITLE
MRG, ENH: Add cortex, fix sensors

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -133,6 +133,8 @@ Enhancements
 
 - Add :func:`mne.viz.Brain.add_volume_labels` to plot subcortical surfaces and other regions of interest (:gh:`9540` by `Alex Rockhill`_ and `Eric Larson`_)
 
+- Add custom cortex curvature colors in :class:`mne.viz.Brain` via the ``cortex`` argument (:gh:`9750` by `Eric Larson`_)
+
 - Add :meth:`mne.channels.DigMontage.apply_trans` to apply a transform directly to a montage (:gh:`9601` by `Alex Rockhill`_)
 
 - :meth:`mne.preprocessing.ICA.fit` now emits a warning if any of the ``start``, ``stop``, ``reject``, and ``flat`` parameters are passed when performing ICA on `~mne.Epochs`. These parameters only have an effect on `~mne.io.Raw` data and were previously silently ignored in the case of `~mne.Epochs` (:gh:`9605` by `Richard Höchenberger`_)

--- a/examples/visualization/eeg_on_scalp.py
+++ b/examples/visualization/eeg_on_scalp.py
@@ -28,3 +28,12 @@ fig = plot_alignment(raw.info, trans, subject='sample', dig=False,
                      coord_frame='head', subjects_dir=subjects_dir)
 # Set viewing angle
 set_3d_view(figure=fig, azimuth=135, elevation=80)
+
+# %%
+# A similar effect can be achieved using :class:`mne.viz.Brain`:
+
+brain = mne.viz.Brain(
+    'sample', 'both', 'pial', 'frontal', background='w',
+    subjects_dir=subjects_dir)
+brain.add_head()
+brain.add_sensors(raw.info, trans, meg=False, eeg=('original', 'projected'))

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -5,6 +5,7 @@
 
 import os.path as op
 import itertools as itt
+import sys
 
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_equal, assert_allclose)
@@ -87,7 +88,7 @@ def test_compute_whitener(proj, pca):
     W3, _, C3 = compute_whitener(cov3, raw.info, pca=pca, return_colorer=True,
                                  picks=None, verbose='error')
     # this tol is not great, but Windows needs it
-    rtol = 3e-5 if pca in (True, 'white') and proj is True else 1e-11
+    rtol = 3e-5 if sys.platform.startswith('win') else 1e-11
     assert_allclose(W, W2, rtol=rtol)
     assert_allclose(C, C2, rtol=rtol)
     n_channels = len(raw.ch_names) - len(raw.info['bads'])

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -20,7 +20,7 @@ from .check import (check_fname, check_version, check_random_state,
                     _on_missing, _check_on_missing, int_like, _safe_input,
                     _check_all_same_channel_names, path_like, _ensure_events,
                     _check_eeglabio_installed, _check_dict_keys,
-                    _check_edflib_installed)
+                    _check_edflib_installed, _to_rgb)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -826,3 +826,15 @@ def _ensure_events(events):
         raise ValueError(
             f'events must be of shape (N, 3), got {events.shape}')
     return events
+
+
+def _to_rgb(*args, name='color', alpha=False):
+    from matplotlib.colors import colorConverter
+    func = colorConverter.to_rgba if alpha else colorConverter.to_rgb
+    try:
+        return func(*args)
+    except ValueError:
+        args = args[0] if len(args) == 1 else args
+        raise ValueError(
+            f'Invalid RGB{"A" if alpha else ""} argument(s) for {name}: '
+            f'{repr(args)}') from None

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -41,7 +41,7 @@ from ..transforms import (apply_trans, rot_to_quat, combine_transforms,
 from ..utils import (get_subjects_dir, logger, _check_subject, verbose, warn,
                      has_nibabel, check_version, fill_doc, _pl, get_config,
                      _ensure_int, _validate_type, _check_option, deprecated,
-                     CONNECTIVITY_DEPRECATION_MSG)
+                     CONNECTIVITY_DEPRECATION_MSG, _to_rgb)
 from .utils import (mne_analyze_colormap, _get_color_list,
                     plt_show, tight_layout, figure_nobar, _check_time_unit)
 from ..bem import ConductorModel, _bem_find_surface, _ensure_bem_surfaces
@@ -2653,7 +2653,6 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
         The triangular mesh surface.
     """
     import matplotlib.pyplot as plt
-    from matplotlib.colors import ColorConverter
     # Update the backend
     from .backends.renderer import _get_renderer
 
@@ -2716,8 +2715,6 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
                for stc in stcs]
     unique_vertnos = np.unique(np.concatenate(vertnos).ravel())
 
-    color_converter = ColorConverter()
-
     renderer = _get_renderer(bgcolor=bgcolor, size=(600, 600), name=fig_name)
     surface = renderer.mesh(x=points[:, 0], y=points[:, 1],
                             z=points[:, 2], triangles=use_faces,
@@ -2759,7 +2756,7 @@ def plot_sparse_source_estimates(src, stcs, colors=None, linewidth=2,
         x, y, z = points[v]
         nx, ny, nz = normals[v]
         renderer.quiver3d(x=x, y=y, z=z, u=nx, v=ny, w=nz,
-                          color=color_converter.to_rgb(c),
+                          color=_to_rgb(c),
                           mode=mode, scale=scale_factor)
 
         for k in ind:
@@ -3172,8 +3169,6 @@ def _plot_dipole(ax, data, vox, idx, dipole, gridx, gridy, ori, coord_frame,
                  show_all, pos, color, highlight_color, title):
     """Plot dipoles."""
     import matplotlib.pyplot as plt
-    from matplotlib.colors import ColorConverter
-    color_converter = ColorConverter()
     xidx, yidx, zidx = np.round(vox[idx]).astype(int)
     xslice = data[xidx]
     yslice = data[:, yidx]
@@ -3182,8 +3177,9 @@ def _plot_dipole(ax, data, vox, idx, dipole, gridx, gridy, ori, coord_frame,
     ori = ori[idx]
     if color is None:
         color = 'y' if show_all else 'r'
-    color = np.array(color_converter.to_rgba(color))
-    highlight_color = np.array(color_converter.to_rgba(highlight_color))
+    color = np.array(_to_rgb(color, alpha=True))
+    highlight_color = np.array(_to_rgb(
+        highlight_color, name='highlight_color', alpha=True))
     if show_all:
         colors = np.repeat(color[np.newaxis], len(vox), axis=0)
         colors[idx] = highlight_color

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -199,6 +199,8 @@ def test_brain_init(renderer_pyvistaqt, tmpdir, pixel_ratio, brain_gc):
         Brain(subject_id, 'lh', 'whatever')
     with pytest.raises(ValueError, match='`surf` cannot be seghead'):
         Brain(hemi='lh', surf='seghead', **kwargs)
+    with pytest.raises(ValueError, match='RGB argument'):
+        Brain('sample', cortex='badcolor')
     Brain(subject_id, hemi=None, surf=None)  # test no surfaces
     renderer_pyvistaqt.backend._close_all()
 
@@ -420,7 +422,8 @@ def test_single_hemi(hemi, renderer_interactive_pyvistaqt, brain_gc):
         getattr(stc, f'{hemi}_data'), [stc.vertices[idx], []][::order],
         0, 1, 'sample')
     brain = stc.plot(
-        subjects_dir=subjects_dir, hemi='both', size=300)
+        subjects_dir=subjects_dir, hemi='both', size=300,
+        cortex='0.5')  # single cortex string arg
     brain.close()
 
     # test skipping when len(vertices) == 0
@@ -437,7 +440,8 @@ def test_brain_save_movie(tmpdir, renderer, brain_gc):
     if renderer._get_3d_backend() == "mayavi":
         pytest.skip('Save movie only supported on PyVista')
     from imageio_ffmpeg import count_frames_and_secs
-    brain = _create_testing_brain(hemi='lh', time_viewer=False)
+    brain = _create_testing_brain(hemi='lh', time_viewer=False,
+                                  cortex=['r', 'b'])  # custom binarized
     filename = str(op.join(tmpdir, "brain_test.mov"))
     for interactive_state in (False, True):
         # for coverage, we set interactivity

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -33,7 +33,8 @@ from .utils import (_draw_proj_checkbox, tight_layout, _check_delayed_ssp,
                     _plot_masked_image, _trim_ticks, _set_window_title,
                     _prop_kw)
 from ..utils import (logger, _clean_names, warn, _pl, verbose, _validate_type,
-                     _check_if_nan, _check_ch_locs, fill_doc, _is_numeric)
+                     _check_if_nan, _check_ch_locs, fill_doc, _is_numeric,
+                     _to_rgb)
 
 from .topo import _plot_evoked_topo
 from .topomap import (_prepare_topomap_plot, plot_topomap, _get_pos_outlines,
@@ -848,13 +849,11 @@ def plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
     fig : instance of matplotlib.figure.Figure
         Images of evoked responses at sensor locations.
     """
-    from matplotlib.colors import colorConverter
-
     if not type(evoked) in (tuple, list):
         evoked = [evoked]
 
-    dark_background = \
-        np.mean(colorConverter.to_rgb(background_color)) < 0.5
+    background_color = _to_rgb(background_color, name='background_color')
+    dark_background = np.mean(background_color) < 0.5
     if dark_background:
         fig_facecolor = background_color
         axis_facecolor = background_color

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -14,7 +14,7 @@ from itertools import cycle
 import numpy as np
 
 from ..io.pick import channel_type, pick_types
-from ..utils import _clean_names, warn, _check_option, Bunch, fill_doc
+from ..utils import _clean_names, warn, _check_option, Bunch, fill_doc, _to_rgb
 from ..channels.layout import _merge_ch_data, _pair_grad_sensors, find_layout
 from ..defaults import _handle_default
 from .utils import (_check_delayed_ssp, _get_color_list, _draw_proj_checkbox,
@@ -357,7 +357,6 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
                      labels=None):
     """Show time series on topo split across multiple axes."""
     import matplotlib.pyplot as plt
-    from matplotlib.colors import colorConverter
     picker_flag = False
     for data_, color_, times_ in zip(data, color, times):
         if not picker_flag:
@@ -421,11 +420,8 @@ def _plot_timeseries(ax, ch_idx, tmin, tmax, vmin, vmax, ylim, data, color,
 
     ax._cursorline = None
     # choose cursor color based on perceived brightness of background
-    try:
-        facecol = colorConverter.to_rgb(ax.get_facecolor())
-    except AttributeError:  # older MPL
-        facecol = colorConverter.to_rgb(ax.get_axis_bgcolor())
-    face_brightness = np.dot(facecol, np.array([299, 587, 114]))
+    facecol = _to_rgb(ax.get_facecolor())
+    face_brightness = np.dot(facecol, [299, 587, 114])
     ax._cursorcolor = 'white' if face_brightness < 150 else 'black'
 
     plt.connect('motion_notify_event', _cursor_vline)

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -39,7 +39,7 @@ from ..rank import compute_rank
 from ..io.proj import setup_proj
 from ..utils import (verbose, get_config, warn, _check_ch_locs, _check_option,
                      logger, fill_doc, _pl, _check_sphere, _ensure_int,
-                     _validate_type)
+                     _validate_type, _to_rgb)
 from ..transforms import apply_trans
 
 
@@ -2332,10 +2332,10 @@ def concatenate_images(images, axis=0, bgcolor='black', centered=True,
     img : ndarray
         The concatenated image.
     """
-    from matplotlib.colors import colorConverter
-    if isinstance(bgcolor, str):
-        func_name = 'to_rgb' if n_channels == 3 else 'to_rgba'
-        bgcolor = getattr(colorConverter, func_name)(bgcolor)
+    n_channels = _ensure_int(n_channels, 'n_channels')
+    _check_option('n_channels', n_channels, (3, 4))
+    alpha = True if n_channels == 4 else False
+    bgcolor = _to_rgb(bgcolor, name='bgcolor', alpha=alpha)
     bgcolor = np.asarray(bgcolor) * 255
     funcs = [np.sum, np.max]
     ret_shape = np.asarray([

--- a/tutorials/preprocessing/70_fnirs_processing.py
+++ b/tutorials/preprocessing/70_fnirs_processing.py
@@ -47,8 +47,8 @@ raw_intensity.annotations.delete(
 
 
 # %%
-# View location of sensors over brain surface
-# -------------------------------------------
+# Viewing location of sensors over brain surface
+# ----------------------------------------------
 #
 # Here we validate that the location of sources-detector pairs and channels
 # are in the expected locations. Source-detector pairs are shown as lines
@@ -58,10 +58,12 @@ raw_intensity.annotations.delete(
 
 subjects_dir = op.join(mne.datasets.sample.data_path(), 'subjects')
 
-brain = mne.viz.Brain('fsaverage', subjects_dir=subjects_dir, background="w")
-brain.add_sensors(raw_intensity.info, trans='fsaverage')
+brain = mne.viz.Brain(
+    'fsaverage', subjects_dir=subjects_dir, background='w', cortex='0.5')
+brain.add_sensors(
+    raw_intensity.info, trans='fsaverage',
+    fnirs=['channels', 'pairs', 'sources', 'detectors'])
 brain.show_view(azimuth=20, elevation=60, distance=400)
-
 
 # %%
 # Selecting channels appropriate for detecting neural responses


### PR DESCRIPTION
Closes #9744

1. Fixes bug introduced in #9585 (cc @alexrockhill) where fNIRS and projected EEG sensors were not scaled properly based on `units`
2. Fixes a bug where we iterated over some views twice (in the case of `hemi='both'`) when we should have just done it once -- this is fixed by iterating over `'vol'` as the hemi
3. Adds support for custom `cortex` color mappings in `mne.viz.Brain`, which is something I've wanted for a while and was necessary to restore this image from [stable](https://mne.tools/stable/auto_tutorials/preprocessing/70_fnirs_processing.html#view-location-of-sensors-over-brain-surface) while still using `mne.viz.Brain` instead of `plot_alignment`:

    ![](https://mne.tools/stable/_images/sphx_glr_70_fnirs_processing_001.png)

4. Streamlines the iteration over views by calling `.subplot` inside `_iter_views` rather than doing it manually each time (cc @GuillaumeFavelier )