### PR TITLE
Fix equalize event counts

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -229,6 +229,8 @@ Bugs
 
 - Raise error when no ``trans`` is provided to :func:`mne.viz.plot_alignment` when required instead of assuming identitiy head->mri transform (:gh:`9585` by `Alex Rockhill`_)
 
+- Fix bug where :meth:`mne.Epochs.equalize_event_counts` failed when only one good epoch existed for one of the event types (:gh:`9758` by `Daniel McCloy`_)
+
 - Fix bug where channels with a dollar sign ($) were not being labeled "misc" in :func:`mne.io.read_raw_nihon` (:gh:`9695` by `Adam Li`_)
 
 - Fix bug where :func:`mne.io.read_raw_persyst` was lower-casing events it found in the ``.lay`` file (:gh:`9746` by `Adam Li`_)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2830,8 +2830,12 @@ def _minimize_time_diff(t_shorter, t_longer):
     """Find a boolean mask to minimize timing differences."""
     from scipy.interpolate import interp1d
     keep = np.ones((len(t_longer)), dtype=bool)
-    if len(t_shorter) == 0:
+    # special case: length zero or one
+    if len(t_shorter) < 2:  # interp1d won't work
         keep.fill(False)
+        if len(t_shorter) == 1:
+            idx = np.argmin(np.abs(t_longer - t_shorter))
+            keep[idx] = True
         return keep
     scores = np.ones((len(t_longer)))
     x1 = np.arange(len(t_shorter))

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1994,8 +1994,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                          for id_ in event_ids]
             for ii, id_ in enumerate(event_ids):
                 if len(id_) == 0:
-                    raise KeyError(orig_ids[ii] + "not found in the "
-                                   "epoch object's event_id.")
+                    raise KeyError(f"{orig_ids[ii]} not found in the epoch "
+                                   "object's event_id.")
                 elif len({sub_id in ids for sub_id in id_}) != 1:
                     err = ("Don't mix hierarchical and regular event_ids"
                            " like in \'%s\'." % ", ".join(id_))

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -46,7 +46,7 @@ from .filter import detrend, FilterMixin, _check_fun
 from .parallel import parallel_func
 
 from .event import _read_events_fif, make_fixed_length_events
-from .fixes import _get_args, rng_uniform
+from .fixes import rng_uniform
 from .viz import (plot_epochs, plot_epochs_psd, plot_epochs_psd_topomap,
                   plot_epochs_image, plot_topo_image_epochs, plot_drop_log)
 from .utils import (_check_fname, check_fname, logger, verbose,
@@ -2836,10 +2836,7 @@ def _minimize_time_diff(t_shorter, t_longer):
     scores = np.ones((len(t_longer)))
     x1 = np.arange(len(t_shorter))
     # The first set of keep masks to test
-    kwargs = dict(copy=False, bounds_error=False)
-    # this is a speed tweak, only exists for certain versions of scipy
-    if 'assume_sorted' in _get_args(interp1d.__init__):
-        kwargs['assume_sorted'] = True
+    kwargs = dict(copy=False, bounds_error=False, assume_sorted=True)
     shorter_interp = interp1d(x1, t_shorter, fill_value=t_shorter[-1],
                               **kwargs)
     for ii in range(len(t_longer) - len(t_shorter)):

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2014,6 +2014,13 @@ def test_epoch_eq():
         epochs.equalize_event_counts([['a/x', 'a/y'], 'x'])
     with pytest.raises(KeyError, match='not found in the epoch object'):
         epochs.equalize_event_counts(["a/no_match", "b"])
+    # test equalization with only one epoch in each cond
+    epo = epochs[[0, 1, 5]]
+    assert len(epo['x']) == 2
+    assert len(epo['y']) == 1
+    epo_, drop_inds = epo.equalize_event_counts()
+    assert len(epo_) == 2
+    assert drop_inds.shape == (1,)
     # test equalization with no events of one type
     epochs.drop(np.arange(10))
     assert_equal(len(epochs['a/x']), 0)

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1973,7 +1973,8 @@ def test_epoch_eq():
     new_shapes = [epochs[key].events.shape[0] for key in ['a', 'b', 'c', 'd']]
     assert_equal(new_shapes[0] + new_shapes[1], new_shapes[2])
     assert_equal(new_shapes[3], old_shapes[3])
-    pytest.raises(KeyError, epochs.equalize_event_counts, [1, 'a'])
+    with pytest.raises(KeyError, match='keys must be strings, got'):
+        epochs.equalize_event_counts([1, 'a'])
 
     # now let's combine conditions
     old_shapes = new_shapes
@@ -1981,7 +1982,8 @@ def test_epoch_eq():
     new_shapes = [epochs[key].events.shape[0] for key in ['a', 'b', 'c', 'd']]
     assert_equal(old_shapes[0] + old_shapes[1], new_shapes[0] + new_shapes[1])
     assert_equal(new_shapes[0] + new_shapes[1], new_shapes[2] + new_shapes[3])
-    pytest.raises(ValueError, combine_event_ids, epochs, ['a', 'b'], {'ab': 1})
+    with pytest.raises(ValueError, match='value must not already exist'):
+        combine_event_ids(epochs, ['a', 'b'], {'ab': 1})
 
     combine_event_ids(epochs, ['a', 'b'], {'ab': np.int32(12)}, copy=False)
     caught = 0
@@ -2006,11 +2008,12 @@ def test_epoch_eq():
     es = [epochs.copy().equalize_event_counts(c)[0]
           for c in (cond1, cond2)]
     assert_array_equal(es[0].events[:, 0], es[1].events[:, 0])
-    cond1, cond2 = ['a', ['b', 'b/y']], [['a/x', 'a/y'], 'x']
-    for c in (cond1, cond2):  # error b/c tag and id mix/non-orthogonal tags
-        pytest.raises(ValueError, epochs.equalize_event_counts, c)
-    pytest.raises(KeyError, epochs.equalize_event_counts,
-                  ["a/no_match", "b"])
+    with pytest.raises(ValueError, match='mix hierarchical and regular'):
+        epochs.equalize_event_counts(['a', ['b', 'b/y']])
+    with pytest.raises(ValueError, match='overlapping. Provide an orthogonal'):
+        epochs.equalize_event_counts([['a/x', 'a/y'], 'x'])
+    with pytest.raises(KeyError, match='not found in the epoch object'):
+        epochs.equalize_event_counts(["a/no_match", "b"])
     # test equalization with no events of one type
     epochs.drop(np.arange(10))
     assert_equal(len(epochs['a/x']), 0)


### PR DESCRIPTION
I hit a corner case today where `epochs.equalize_event_counts()` was failing because the smallest event_id had only one epoch in it, which caused `interp1d` to error out (we already handle the edge case where it has zero).  This fixes that.