### PR TITLE
MRG, ENH: Use context manager, cleaner deps

### DIFF
--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -156,9 +156,9 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
             signal_label = f'{ch_type.upper()} {ch}' if add_ch_type else ch
             if len(signal_label) > 16:
                 raise RuntimeError(f'Signal label for {ch} ({ch_type}) is '
-                                f'longer than 16 characters, which is not '
-                                f'supported in EDF. Please shorten the channel '
-                                f'name before exporting to EDF.')
+                                   f'longer than 16 characters, which is not '
+                                   f'supported in EDF. Please shorten the '
+                                   f'channel name before exporting to EDF.')
 
             if physical_range == 'auto':
                 # take the channel type minimum and maximum

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -17,7 +17,6 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off --upgrade --only-binary ":all" "vtk<=9.0.1"
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
-	python -m pip install --progress-bar off pooch
 else
 	echo "Unknown run type ${TEST_MODE}"
 	exit 1

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -31,8 +31,6 @@ else
 	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
 	echo "imageio-ffmpeg, xlrd, mffpy"
 	pip install --progress-bar off --pre mayavi imageio-ffmpeg xlrd mffpy
-	echo "pooch"
-	pip install --progress-bar off pooch
 fi
 pip install --progress-bar off --upgrade -r requirements_testing.txt
 if [ "${DEPS}" != "minimal" ]; then


### PR DESCRIPTION
Use a context manager for closing EDFlib's class -- at some point we should make an upstream PR to add `__enter__` and `__exit__` to their class. I started out by making a private function to minimize the diff, but it ended up needing so many args/kwargs, it seemed better to just indent the whole thing. So this PR does that, and other than removing all `.close()`s (which are no longer needed because the context manager should take care of it), it removes `pooch` from explicit pip installation because it's in `requirements_testing.txt` already.