### PR TITLE
FIX: chronological order of concatenated epochs

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -237,6 +237,9 @@ Bugs
 
 - Fix bug where :func:`mne.io.read_raw_persyst` was lower-casing events it found in the ``.lay`` file (:gh:`9746` by `Adam Li`_)
 
+- Fix bug with :meth:`mne.Epochs.concatenate_epochs` where the concatenated events could end up in non-chronological order. (:gh:`9765` **by new contributor** |Jan Sosulski|_)
+
+
 API changes
 ~~~~~~~~~~~
 - In `mne.compute_source_morph`, the ``niter_affine`` and ``niter_sdr`` parameters have been replaced by ``niter`` and ``pipeline`` parameters for more consistent and finer-grained control of registration/warping steps and iteration (:gh:`9505` by `Alex Rockhill`_ and `Eric Larson`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -179,6 +179,8 @@ Bugs
 
 - Fix bug with `mne.compute_rank`, `mne.cov.compute_whitener` and `mne.preprocessing.ICA.fit` when explicit picks including bad channels are provided (:gh:`9719` **by new contributor** |Mathieu Scheltienne|_)
 
+- Fix bug with :func:`mne.concatenate_epochs` where the concatenated events could end up in non-chronological order. (:gh:`9765` **by new contributor** |Jan Sosulski|_)
+
 - Fix bug with :func:`mne.io.read_raw_nihon` where latin-1 annotations could not be read (:gh:`9384` by `Alex Gramfort`_)
 
 - Fix bug when printing a :class:`mne.io.RawArray` in the notebook (:gh:`9404` by `Alex Gramfort`_)
@@ -236,9 +238,6 @@ Bugs
 - Fix bug where channels with a dollar sign ($) were not being labeled "misc" in :func:`mne.io.read_raw_nihon` (:gh:`9695` by `Adam Li`_)
 
 - Fix bug where :func:`mne.io.read_raw_persyst` was lower-casing events it found in the ``.lay`` file (:gh:`9746` by `Adam Li`_)
-
-- Fix bug with :meth:`mne.Epochs.concatenate_epochs` where the concatenated events could end up in non-chronological order. (:gh:`9765` **by new contributor** |Jan Sosulski|_)
-
 
 API changes
 ~~~~~~~~~~~

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3364,8 +3364,7 @@ def _concatenate_epochs(epochs_list, with_data=True, add_offset=True, *,
     selection = out.selection
     # offset is the last epoch + tmax + 10 second
     shift = int((10 + tmax) * out.info['sfreq'])
-    events_offset = 0
-    events_number_overflow = False
+    events_overflow = False
     for ii, epochs in enumerate(epochs_list[1:], 1):
         _ensure_infos_match(epochs.info, info, f'epochs[{ii}]',
                             on_mismatch=on_mismatch)
@@ -3394,14 +3393,13 @@ def _concatenate_epochs(epochs_list, with_data=True, add_offset=True, *,
         elif add_offset:
             # We need to cast to a native Python int here to prevent an
             # overflow of a numpy int32 or int64 type.
-            events_offset += int(np.max(evs[:, 0])) + shift
-            if events_offset > INT32_MAX:
+            events_offset = int(np.max(events[-1][:, 0])) + shift
+            evs[:, 0] += events_offset
+            if not events_overflow and int(np.max(evs[:, 0])) > INT32_MAX:
                 warn(f'Event number greater than {INT32_MAX} created, '
                      'events[:, 0] will be assigned consecutive increasing '
                      'integer values')
-                events_number_overflow = True
-            else:
-                evs[:, 0] += events_offset
+                events_overflow = True
         events.append(evs)
         selection = np.concatenate((selection, epochs.selection))
         drop_log = drop_log + epochs.drop_log
@@ -3409,7 +3407,7 @@ def _concatenate_epochs(epochs_list, with_data=True, add_offset=True, *,
         metadata.append(epochs.metadata)
     events = np.concatenate(events, axis=0)
     # check to see if we exceeded our maximum event offset
-    if events_number_overflow:
+    if events_overflow:
         events[:, 0] = np.arange(1, len(events) + 1)
 
     # Create metadata object (or make it None)

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2764,6 +2764,14 @@ def test_concatenate_epochs():
     with pytest.warns(RuntimeWarning, match='was empty'):
         concatenate_epochs([epochs, epochs2])
 
+    # check concatenating epochs results are chronologically ordered
+    epochs2 = epochs.copy().load_data()
+    # Ensure first event is at 0
+    epochs2.events[:, 0] -= np.min(epochs2.events[:, 0])
+    with pytest.warns(RuntimeWarning, match='not chronologically ordered'):
+        concatenate_epochs([epochs, epochs2], add_offset=False)
+    concatenate_epochs([epochs, epochs2], add_offset=True)
+
 
 def test_concatenate_epochs_large():
     """Test concatenating epochs on large data."""


### PR DESCRIPTION
#### Reference issue
Fixes #9765 


#### What does this implement/fix?
Fix a bug in concatenate which could create epochs that are not ordered chronologically.