### PR TITLE
Expose Info keys as attributes with scikit-learn's Bunch syntax.

### DIFF
--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -552,7 +552,7 @@ class Info(dict, MontageMixin):
     """
 
     def __init__(self, *args, **kwargs):
-        super(Info, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         # Deal with h5io writing things as dict
         for key in ('dev_head_t', 'ctf_head_t', 'dev_ctf_t'):
             _format_trans(self, key)
@@ -577,6 +577,17 @@ class Info(dict, MontageMixin):
             pass
         else:
             self['meas_date'] = _ensure_meas_date_none_or_dt(meas_date)
+
+    def __setattr__(self, key, value):
+        """Set attributes."""
+        self[key] = value
+
+    def __getattr__(self, key):
+        """Get attributes."""
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(key)
 
     def copy(self):
         """Copy the instance.
@@ -813,10 +824,6 @@ class Info(dict, MontageMixin):
         sel = pick_channels(self.ch_names, ch_names, exclude=[],
                             ordered=ordered)
         return pick_info(self, sel, copy=False, verbose=False)
-
-    @property
-    def ch_names(self):
-        return self['ch_names']
 
     def _repr_html_(self, caption=None):
         """Summarize info for HTML representation."""


### PR DESCRIPTION
Following the discussion on #9752 and the quick testing in #9757 followed by a git CLI mess up; here is a clean version exposing the keys of Info as attributes in a similar way to Bunch. Instead of inheriting from Bunch; or changing the Bunch from MNE to the version of scikit-learn, I simply brought the methods `__setattr__` and `__getattr__` from scikit-learn's Bunch to the Info class.

As expected, this was very little work; and it definitely improves the usability of Info. However, does it actually help for future error checking?

------------------------------------------------

I still need to think a bit more about it, but is it actually possible to implement error checking for the first hierarchical layer of Info in `__setattr__` and/or `__getattr__` as discussed? For example, for `info.ch_names` the error checking would simply be a logger warning "Don't do that!! Use method X, Y, Z to modify the included channels". But how do we differentiate between user inputs that should be prevented and MNE inputs through e.g. `rename_channels`, `drop_channels`, ... that should go through? Both would in the end set the attribute of `Info` and pass through `__setattr__` and/or `__getattr__`.

The delimitation between public and private interfaces is not clear to me at the moment. If as I suspect it is not possible to add error checking in `__setattr__` and/or `__getattr__`, I have a proposition to be discussed. Before going any further, I will look into adding error checking through `__setattr__` and/or `__getattr__` as discussed.