### PR TITLE
Fix drop log

### DIFF
--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2349,6 +2349,9 @@ def test_drop_epochs():
     assert_array_equal(events[epochs[3:].selection], events1[[5, 6]])
     assert_array_equal(events[epochs['1'].selection], events1[[0, 1, 3, 5, 6]])
 
+    # After subset selection, drop log should be 0
+    assert_equal(epochs[0:1].drop_log_stats(), 0)
+
 
 def test_drop_epochs_mult():
     """Test that subselecting epochs or making less epochs is equivalent."""

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1957,7 +1957,7 @@ def test_epoch_eq():
     old_shapes = [epochs[key].events.shape[0] for key in ['a', 'b', 'c', 'd']]
     epochs.equalize_event_counts(['a', 'b'])
     # undo the eq logging
-    drop_log2 = tuple(() if log == ('EQUALIZED_COUNT',) else log
+    drop_log2 = tuple(log[:-1] if 'EQUALIZED_COUNT' in log else log
                       for log in epochs.drop_log)
     assert_equal(drop_log1, drop_log2)
 

--- a/mne/utils/mixin.py
+++ b/mne/utils/mixin.py
@@ -198,8 +198,10 @@ class GetEpochsMixin(object):
             key_selection = inst.selection[select]
             drop_log = list(inst.drop_log)
             if reason is not None:
-                for k in np.setdiff1d(inst.selection, key_selection):
-                    drop_log[k] = (reason,)
+                select_all = list(range(len(inst.drop_log)))
+                for k in np.setdiff1d(select_all, key_selection):
+                    if reason not in drop_log[k]:
+                        drop_log[k] += (reason,)
             inst.drop_log = tuple(drop_log)
             inst.selection = key_selection
             del drop_log


### PR DESCRIPTION
#### Reference issue
Fixes #9726 


#### What does this implement/fix?
Instead of adding `'IGNORED'` only to empty tuples in the drop log, this will append it to all drop log entries when slicing an epoch object to a subset.


#### Additional information
I fixed one epoch unit test, which was straight forward, however the second one that fails is `test_drop_epochs_mult` where there is a section I don't really get:

https://github.com/mne-tools/mne-python/blob/6c0006dfc73588927936b95a1ae364556a55fbc0/mne/tests/test_epochs.py#L2367-L2373

There are several comparisons to empty lists `[]` which, as far as I understand the drop log correctly, can never be true/false as the entries can only be empty tuples, not empty lists. I could take a stab at fixing this unit test as well, once I understand it correctly.

Also currently I assume that a drop reason should be present only once in a drop log entry, however, one could argue that multiples are okay, to e.g. reconstruct the order of subset selections if for some reason someone would be interested in this.

OT: Probably too big of a change, but using `'UNSELECTED'` or `'DESELECTED'` as a drop reason when slicing epochs would make the drop log explain more precisely why the epochs were dropped. One could then add `'IGNORED'` as a special case that incorporates `'UNSELECTED'` and other common reasons, or just use an enum.
