### PR TITLE
MRG: FIX: Specify exact array indicies for 3D landmark positions

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -239,6 +239,8 @@ Bugs
 
 - Fix bug where :func:`mne.io.read_raw_persyst` was lower-casing events it found in the ``.lay`` file (:gh:`9746` by `Adam Li`_)
 
+- Fix bug where :func:`mne.io.read_raw_snirf` was including the landmark index as a spatial coordinate (:gh:`9777` by `Robert luke`_)
+
 API changes
 ~~~~~~~~~~~
 - In `mne.compute_source_morph`, the ``niter_affine`` and ``niter_sdr`` parameters have been replaced by ``niter`` and ``pipeline`` parameters for more consistent and finer-grained control of registration/warping steps and iteration (:gh:`9505` by `Alex Rockhill`_ and `Eric Larson`_)

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -290,11 +290,11 @@ class RawSNIRF(BaseRaw):
                 extra_ps = dict()
                 for idx, dign in enumerate(digname):
                     if dign == b'LPA':
-                        lpa = diglocs[idx, :]
+                        lpa = diglocs[idx, :3]
                     elif dign == b'NASION':
-                        nasion = diglocs[idx, :]
+                        nasion = diglocs[idx, :3]
                     elif dign == b'RPA':
-                        rpa = diglocs[idx, :]
+                        rpa = diglocs[idx, :3]
                     else:
                         extra_ps[f'EEG{len(extra_ps) + 1:03d}'] = diglocs[idx]
                 info['dig'] = _make_dig_points(nasion=nasion, lpa=lpa, rpa=rpa,


### PR DESCRIPTION
#### Reference issue
Fixes https://github.com/mne-tools/mne-nirs/issues/393


#### What does this implement/fix?
The SNIRF specification has an optional 4th column in the 3D positions for landmarks. Previous vendor software did not use this column, and so we just took the whole array. But now the NIRx vendor appears (yet to be confirmed) that they are using this column. As such we need to address the first 3 array values not `:`.

I have a file from a user that now works with this fix. But it’s not appropriate to use as test data. 


#### Additional information
I have emailed NIRx to ask for a test file as I dont have access to one of these machines to provide test data. But if the change doesn't break old test data, and the change makes sense relative to the specification, then I suggest we can merge without test data, and I will add it when I get my hands on a reasonable test file.

#### Specification

Here is the relevant part of the specification taken from https://github.com/fNIRS/snirf/blob/master/snirf_specification.md#nirsiprobelandmarkpos3d


> This is a 2-D array storing the neurological landmark positions measurement from 3-D digitization and tracking systems to facilitate the registration and mapping of optical data to brain anatomy. This array should contain a minimum of 3 columns, representing the x, y and z coordinates (in LengthUnit units) of the digitized landmark positions. If a 4th column presents, it stores the index to the labels of the given landmark.
