### PR TITLE
Fix 9747 - Add ID arg to make_fixed_length_epochs to change the default value 1.

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -57,7 +57,7 @@ Enhancements
 
 - Add support for list of channel types for EEG/sEEG/ECoG/DBS referencing (:gh:`9637` **by new contributor** |Mathieu Scheltienne|_)
 
-- Add support for changing the default event id used by :func:`mne.epochs.make_fixed_length_epochs` (:gh:`9782` **by new contributor** |Mathieu Scheltienne|_)
+- Add support for changing the default event id used by :func:`mne.make_fixed_length_epochs` (:gh:`9782` **by new contributor** |Mathieu Scheltienne|_)
 
 - Add support for more than 3 source estimates in :func:`mne.viz.plot_sparse_source_estimates` (:gh:`9640` **by new contributor** |Pierre-Antoine Bannier|_ and `Alex Gramfort`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -57,6 +57,8 @@ Enhancements
 
 - Add support for list of channel types for EEG/sEEG/ECoG/DBS referencing (:gh:`9637` **by new contributor** |Mathieu Scheltienne|_)
 
+- Add support for changing the default event id used by :func:`mne.epochs.make_fixed_length_epochs` (:gh:`9782` **by new contributor** |Mathieu Scheltienne|_)
+
 - Add support for more than 3 source estimates in :func:`mne.viz.plot_sparse_source_estimates` (:gh:`9640` **by new contributor** |Pierre-Antoine Bannier|_ and `Alex Gramfort`_)
 
 - Show all good channel types and counts when printing a :class:`mne.Info` in the notebook (:gh:`9725` by `Valerii Chirkov`_ and `Eric Larson`_)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3679,8 +3679,6 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
     ----------
     raw : instance of Raw
         Raw data to divide into segments.
-    id : int
-        The id to use (default 1).
     duration : float
         Duration of each epoch in seconds. Defaults to 1.
     %(preload)s

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3670,9 +3670,9 @@ def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
 
 
 @verbose
-def make_fixed_length_epochs(raw, id=1, duration=1., preload=False,
+def make_fixed_length_epochs(raw, duration=1., preload=False,
                              reject_by_annotation=True, proj=True, overlap=0.,
-                             verbose=None):
+                             id=1, verbose=None):
     """Divide continuous raw data into equal-sized consecutive epochs.
 
     Parameters
@@ -3683,8 +3683,6 @@ def make_fixed_length_epochs(raw, id=1, duration=1., preload=False,
         The id to use (default 1).
     duration : float
         Duration of each epoch in seconds. Defaults to 1.
-
-        .. versionadded:: 0.24.0
     %(preload)s
     %(reject_by_annotation_epochs)s
 
@@ -3697,6 +3695,10 @@ def make_fixed_length_epochs(raw, id=1, duration=1., preload=False,
         ``0 <= overlap < duration``. Default is 0, i.e., no overlap.
 
         .. versionadded:: 0.23.0
+    id : int
+        The id to use (default 1).
+
+        .. versionadded:: 0.24.0
     %(verbose)s
 
     Returns

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3670,7 +3670,7 @@ def average_movements(epochs, head_pos=None, orig_sfreq=None, picks=None,
 
 
 @verbose
-def make_fixed_length_epochs(raw, duration=1., preload=False,
+def make_fixed_length_epochs(raw, id=1, duration=1., preload=False,
                              reject_by_annotation=True, proj=True, overlap=0.,
                              verbose=None):
     """Divide continuous raw data into equal-sized consecutive epochs.
@@ -3679,6 +3679,8 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
     ----------
     raw : instance of Raw
         Raw data to divide into segments.
+    id : int
+        The id to use (default 1).
     duration : float
         Duration of each epoch in seconds. Defaults to 1.
     %(preload)s
@@ -3704,10 +3706,10 @@ def make_fixed_length_epochs(raw, duration=1., preload=False,
     -----
     .. versionadded:: 0.20
     """
-    events = make_fixed_length_events(raw, 1, duration=duration,
+    events = make_fixed_length_events(raw, id=id, duration=duration,
                                       overlap=overlap)
     delta = 1. / raw.info['sfreq']
-    return Epochs(raw, events, event_id=[1], tmin=0, tmax=duration - delta,
+    return Epochs(raw, events, event_id=[id], tmin=0, tmax=duration - delta,
                   baseline=None, preload=preload,
                   reject_by_annotation=reject_by_annotation, proj=proj,
                   verbose=verbose)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3683,6 +3683,8 @@ def make_fixed_length_epochs(raw, id=1, duration=1., preload=False,
         The id to use (default 1).
     duration : float
         Duration of each epoch in seconds. Defaults to 1.
+
+        .. versionadded:: 0.24.0
     %(preload)s
     %(reject_by_annotation_epochs)s
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -3435,7 +3435,7 @@ def test_make_fixed_length_epochs():
         make_fixed_length_epochs(raw, duration=1, overlap=1.1)
 
     # id
-    epochs = make_fixed_length_epochs(raw, id=2, duration=1, preload=True)
+    epochs = make_fixed_length_epochs(raw, duration=1, preload=True, id=2)
     assert '2' in epochs.event_id and len(epochs.event_id) == 1
 
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -3434,6 +3434,10 @@ def test_make_fixed_length_epochs():
     with pytest.raises(ValueError, match='overlap must be'):
         make_fixed_length_epochs(raw, duration=1, overlap=1.1)
 
+    # id
+    epochs = make_fixed_length_epochs(raw, id=2, duration=1, preload=True)
+    assert '2' in epochs.event_id and len(epochs.event_id) == 1
+
 
 def test_epochs_huge_events(tmpdir):
     """Test epochs with event numbers that are too large."""


### PR DESCRIPTION
Tiny improvement fixing #9747.
I added a similar `id` argument for `make_fixed_length_epochs` as the one of `make_fixed_length_events`.

**Question:** to (more or less) match the argument order of `make_fixed_length_events`, I've placed `id` in second. 
Do you mind this type of change where user code with positional arguments might break, or do you always prefer to add new arguments to the end?

I'll change the order if needed.