### PR TITLE
MRG: Fix read_raw_brainvision() handling of comma-separated data files

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -175,6 +175,8 @@ Enhancements
 
 - Add full ECoG dataset to MNE-misc-data and demonstrate its use in :ref:`ex-electrode-pos-2d` and :ref:`tut-ieeg-localize` (:gh:`9784` by `Alex Rockhill`_)
 
+- `mne.io.read_raw_brainvision` now handles ASCII data with comma-separated values, as may be exported from BrainVision Analyzer (:gh:`9795` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 - Fix bug in :meth:`mne.io.Raw.pick` and related functions when parameter list contains channels which are not in info instance (:gh:`9708` **by new contributor** |Evgeny Goldstein|_)
@@ -250,8 +252,6 @@ Bugs
 - Fix bug where :func:`mne.io.read_raw_snirf` was including the landmark index as a spatial coordinate (:gh:`9777` by `Robert luke`_)
 
 - Fix bug where `mne.Annotations` were not appending channel names when being added together (:gh:`9780` by `Adam Li`_)
-
-- `mne.io.read_raw_brainvision` now handles ASCII data with comma-separated values correctly (:gh:`9795` by `Richard Höchenberger`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -251,6 +251,8 @@ Bugs
 
 - Fix bug where `mne.Annotations` were not appending channel names when being added together (:gh:`9780` by `Adam Li`_)
 
+- `mne.io.read_raw_brainvision` now handles ASCII data with comma-separated values correctly (:gh:`9795` by `Richard Höchenberger`_)
+
 API changes
 ~~~~~~~~~~~
 - In `mne.compute_source_morph`, the ``niter_affine`` and ``niter_sdr`` parameters have been replaced by ``niter`` and ``pipeline`` parameters for more consistent and finer-grained control of registration/warping steps and iteration (:gh:`9505` by `Alex Rockhill`_ and `Eric Larson`_)

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -126,8 +126,27 @@ class RawBrainVision(BaseRaw):
                 block = np.empty((n_data_ch, stop - start))
                 for ii in range(stop - start):
                     line = fid.readline().decode('ASCII')
-                    line = line.strip().replace(',', '.').split()
-                    block[:n_data_ch, ii] = [float(part) for part in line]
+                    line = line.strip()
+
+                    # Not sure why we special-handle the "," separator, but
+                    # let's just keep this here for historical and backward-
+                    # compat reasons
+                    if (isinstance(fmt, dict) and
+                            'decimalsymbol' in fmt and
+                            fmt['decimalsymbol'] != '.'):
+                        line = line.replace(',', '.')
+
+                    if ' ' in line:
+                        line_data = line.split()
+                    elif ',' in line:
+                        line_data = line.split(',')
+                    else:
+                        raise RuntimeError(
+                            'Unknown BrainVision data format encountered. '
+                            'Please contact the MNE-Python developers.'
+                        )
+
+                    block[:n_data_ch, ii] = [float(part) for part in line_data]
             _mult_cal_one(data, block, idx, cals, mult)
 
 

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -128,8 +128,8 @@ class RawBrainVision(BaseRaw):
                     line = fid.readline().decode('ASCII')
                     line = line.strip()
 
-                    # Not sure why we special-handle the "," separator, but
-                    # let's just keep this here for historical and backward-
+                    # Not sure why we special-handle the "," character here,
+                    # but let's just keep this for historical and backward-
                     # compat reasons
                     if (isinstance(fmt, dict) and
                             'decimalsymbol' in fmt and
@@ -139,6 +139,7 @@ class RawBrainVision(BaseRaw):
                     if ' ' in line:
                         line_data = line.split()
                     elif ',' in line:
+                        # likely exported from BrainVision Analyzer?
                         line_data = line.split(',')
                     else:
                         raise RuntimeError(

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -236,7 +236,8 @@ def test_vhdr_versions(tmpdir, header):
     assert_allclose(data_new, data_expected, atol=1e-15)
 
 
-def test_ascii(tmpdir):
+@pytest.mark.parametrize('data_sep', (b' ', b',', b';'))
+def test_ascii(tmpdir, data_sep):
     """Test ASCII BV reading."""
     raw = read_raw_brainvision(vhdr_path)
     ascii_vhdr_path = op.join(tmpdir, op.split(vhdr_path)[-1])
@@ -265,10 +266,16 @@ def test_ascii(tmpdir):
     # create the .dat file
     data, times = raw[:]
     with open(ascii_vhdr_path.replace('.vhdr', '.dat'), 'wb') as fid:
-        fid.write(b' '.join(ch_name.encode('ASCII')
-                            for ch_name in raw.ch_names) + b'\n')
+        fid.write(data_sep.join(ch_name.encode('ASCII')
+                                for ch_name in raw.ch_names) + b'\n')
         fid.write(b'\n'.join(b' '.join(b'%.3f' % dd for dd in d)
                              for d in data.T / raw._cals))
+
+    if data_sep == b';':
+        with pytest.raises(RuntimeError, match='Unknown.*data format'):
+            read_raw_brainvision(ascii_vhdr_path)
+        return
+
     raw = read_raw_brainvision(ascii_vhdr_path)
     data_new, times_new = raw[:]
     assert_allclose(data_new, data, atol=1e-15)

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -236,7 +236,7 @@ def test_vhdr_versions(tmpdir, header):
     assert_allclose(data_new, data_expected, atol=1e-15)
 
 
-@pytest.mark.parametrize('data_sep', (b' ', b',', b';'))
+@pytest.mark.parametrize('data_sep', (b' ', b',', b'+'))
 def test_ascii(tmpdir, data_sep):
     """Test ASCII BV reading."""
     raw = read_raw_brainvision(vhdr_path)


### PR DESCRIPTION
This fixes an issue reported on the forum:
https://mne.discourse.group/t/brainvision-raw-get-data-could-not-convert-string-to-float/3730
