### PR TITLE
MRG, BUG: Fix plot_alignment for OPMs

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -253,6 +253,8 @@ Bugs
 
 - Fix bug where :func:`mne.io.read_raw_persyst` was lower-casing events it found in the ``.lay`` file (:gh:`9746` by `Adam Li`_)
 
+- Fix bug with Qhull when plotting OPM sensors in :func:`mne.viz.plot_alignment` (:gh:`9799` by `Eric Larson`_)
+
 - Fix bug where :func:`mne.io.read_raw_snirf` was including the landmark index as a spatial coordinate (:gh:`9777` by `Robert luke`_)
 
 - Fix bug where `mne.Annotations` were not appending channel names when being added together (:gh:`9780` by `Adam Li`_)

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -247,7 +247,8 @@ def _download_all_example_data(verbose=True):
                    eegbci, multimodal, opm, hf_sef, mtrf, fieldtrip_cmc,
                    kiloword, phantom_4dbti, sleep_physionet, limo,
                    fnirs_motor, refmeg_noise, fetch_infant_template,
-                   fetch_fsaverage, ssvep, erp_core, epilepsy_ecog)
+                   fetch_fsaverage, ssvep, erp_core, epilepsy_ecog,
+                   fetch_phantom)
     sample_path = sample.data_path()
     testing.data_path()
     misc.data_path()
@@ -267,7 +268,8 @@ def _download_all_example_data(verbose=True):
     brainstorm.bst_raw.data_path(accept=True)
     brainstorm.bst_auditory.data_path(accept=True)
     brainstorm.bst_resting.data_path(accept=True)
-    brainstorm.bst_phantom_elekta.data_path(accept=True)
+    phantom_path = brainstorm.bst_phantom_elekta.data_path(accept=True)
+    fetch_phantom('otaniemi', subjects_dir=phantom_path)
     brainstorm.bst_phantom_ctf.data_path(accept=True)
     eegbci.load_data(1, [6, 10, 14], update_path=True)
     for subj in range(4):

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -845,7 +845,14 @@ def _ch_pos_in_coord_frame(info, to_cf_t, warn_meg=True, verbose=None):
         for type_name, type_slice in type_slices.items():
             if ch_type in _MEG_CH_TYPES_SPLIT + ('ref_meg',):
                 coil_trans = _loc_to_coil_trans(info['chs'][idx]['loc'])
-                coil = _create_meg_coils([info['chs'][idx]], acc='normal')[0]
+                # Here we prefer accurate geometry in case we need to
+                # ConvexHull the coil, we want true 3D geometry (and not, for
+                # example, a straight line / 1D geometry)
+                this_coil = [info['chs'][idx]]
+                try:
+                    coil = _create_meg_coils(this_coil, acc='accurate')[0]
+                except RuntimeError:  # we don't have an accurate one
+                    coil = _create_meg_coils(this_coil, acc='normal')[0]
                 # store verts as ch_coord
                 ch_coord, triangles = _sensor_shape(coil)
                 ch_coord = apply_trans(coil_trans, ch_coord)

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -349,7 +349,7 @@ def test_plot_alignment_basic(tmpdir, renderer, mixed_fwd_cov_evoked):
         import mayavi  # noqa: F401 analysis:ignore
         assert isinstance(fig, mayavi.core.scene.Scene)
     # 3D coil with no defined draw (ConvexHull)
-    info_cube = pick_info(info, [0])
+    info_cube = pick_info(info, np.arange(5))
     info['dig'] = None
     info_cube['chs'][0]['coil_type'] = 9999
     with pytest.raises(RuntimeError, match='coil definition not found'):
@@ -357,6 +357,12 @@ def test_plot_alignment_basic(tmpdir, renderer, mixed_fwd_cov_evoked):
     coil_def_fname = op.join(tempdir, 'temp')
     with open(coil_def_fname, 'w') as fid:
         fid.write(coil_3d)
+    # make sure our other OPMs can be plotted, too
+    for ii, kind in enumerate(('QUSPIN_ZFOPM_MAG', 'QUSPIN_ZFOPM_MAG2',
+                               'FIELDLINE_OPM_MAG_GEN1',
+                               'KERNEL_OPM_MAG_GEN1'), 1):
+        info_cube['chs'][ii]['coil_type'] = getattr(
+            FIFF, f'FIFFV_COIL_{kind}')
     with use_coil_def(coil_def_fname):
         plot_alignment(info_cube, meg='sensors', surfaces=(), dig=True)
 


### PR DESCRIPTION
The "normal" coil_def for OPMs is a line (1D), which makes Qhull angry, and thus breaks plot_alignment. The "accurate" geometry is a cube, so it works better.

An alternative is to detect dimension deficiency and work around it, but even that's a pain as we'd have to deal with 2D geometry (probably `Delaunay`) and 1D geometry (probably convert to a skinny tube). However, it's easy enough just to try to use accurate if available first -- it will be in all built-in cases we have in our own `coil_def.dat`, but we keep the fallback for users supplying their own `coil_def.dat`. If we hit the really rare corner case of a custom `coil_def.dat` plus dimension-deficient geometry we can fix it later, but hopefully YAGNI

I also added a `fetch_phantom` to `_download_all_example_data` that I forgot to have in a recent PR