### PR TITLE
[ENH] Add pooch sys info

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -47,7 +47,7 @@ Enhancements
 ~~~~~~~~~~~~
 .. - Add something cool (:gh:`9192` **by new contributor** |New Contributor|_)
 
-- Add `pooch` to system information reports (:gh `9798` **by new contributor** |Joshua Teves|_)
+- Add `pooch` to system information reports (:gh:`9801` **by new contributor** |Joshua Teves|_)
 
 - Get annotation descriptions from the name field of SNIRF stimulus groups when reading SNIRF files via `mne.io.read_raw_snirf` (:gh:`9575` **by new contributor** |Darin Erat Sleiter|_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -45,6 +45,8 @@ Enhancements
 ~~~~~~~~~~~~
 .. - Add something cool (:gh:`9192` **by new contributor** |New Contributor|_)
 
+- Add `pooch` to system information reports (:gh `9798` **by new contributor** |Joshua Teves|_)
+
 - Get annotation descriptions from the name field of SNIRF stimulus groups when reading SNIRF files via `mne.io.read_raw_snirf` (:gh:`9575` **by new contributor** |Darin Erat Sleiter|_)
 
 - Add support for NIRSport and NIRSport2 devices to `mne.io.read_raw_nirx` (:gh:`9348` and :gh:`9401` **by new contributor** |David Julien|_, **new contributor** |Romain Derollepot|_, `Robert Luke`_, and `Eric Larson`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -41,6 +41,8 @@ Current (0.24.dev0)
 
 .. |Evgeny Goldstein| replace:: **Evgeny Goldstein**
 
+.. |Joshua Teves| replace:: **Joshua Teves**
+
 Enhancements
 ~~~~~~~~~~~~
 .. - Add something cool (:gh:`9192` **by new contributor** |New Contributor|_)

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -411,3 +411,5 @@
 .. _Reza Shoorangiz: https://github.com/rezashr
 
 .. _Evgeny Goldstein: https://github.com/evgenygoldstein
+
+.. _Joshua Teves: https://github.com/jbteves

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -542,7 +542,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
     has_3d = False
     use_mod_names = ('mne', 'numpy', 'scipy', 'matplotlib', '', 'sklearn',
                      'numba', 'nibabel', 'nilearn', 'dipy', 'cupy', 'pandas',
-                     'mayavi', 'pyvista', 'vtk', 'PyQt5')
+                     'mayavi', 'pyvista', 'vtk', 'PyQt5', 'pooch')
     if dependencies == 'developer':
         use_mod_names += (
             '', 'sphinx', 'sphinx_gallery', 'numpydoc', 'pydata_sphinx_theme',

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -503,6 +503,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
         pyvista:       0.25.3 {pyvistaqt=0.1.1, OpenGL 3.3 (Core Profile) Mesa 18.3.6 via llvmpipe (LLVM 7.0, 256 bits)}
         vtk:           9.0.1
         PyQt5:         5.15.0
+        pooch:         v1.5.1
     """  # noqa: E501
     _validate_type(dependencies, str)
     _check_option('dependencies', dependencies, ('user', 'developer'))


### PR DESCRIPTION
#### Reference issue
Addresses comment in #9798 .


#### What does this implement/fix?
Adds pooch info to system report.


#### Additional information
Note: on local machine, `mne sys_info` does not display the additional pooch info, however `python -c "import mne; mne.sys_info()` does display it. It's unclear to me if this is the desired behavior.
