### PR TITLE
WIP: Add support for data from NIRx Aurora 2021.9 software

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -185,6 +185,8 @@ Enhancements
 
 - Add :func:`mne.preprocessing.ieeg.project_sensors_onto_brain` to project ECoG sensors onto the pial surface to compensate for brain shift (:gh:`9800` by `Alex Rockhill`_)
 
+- Add support for data acquired with NIRx devices using Aurora software version 2021.9 (:gh:`9800` by `Robert Luke`_)
+
 Bugs
 ~~~~
 - Fix bug in :meth:`mne.io.Raw.pick` and related functions when parameter list contains channels which are not in info instance (:gh:`9708` **by new contributor** |Evgeny Goldstein|_)

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -159,7 +159,8 @@ class RawNIRX(BaseRaw):
         # Check that the file format version is supported
         if is_aurora:
             # We may need to ease this requirement back
-            if hdr['GeneralInfo']['Version'] not in ['2021.4.0-34-ge9fdbbc8']:
+            if hdr['GeneralInfo']['Version'] not in ['2021.4.0-34-ge9fdbbc8',
+                                                     '2021.9.0-5-g3eb32851']:
                 warn("MNE has not been tested with Aurora version "
                      f"{hdr['GeneralInfo']['Version']}")
         else:
@@ -185,7 +186,8 @@ class RawNIRX(BaseRaw):
         meas_date = None
         # Several formats have been observed so we try each in turn
         for dt_code in ['"%a, %b %d, %Y""%H:%M:%S.%f"',
-                        '"%a, %d %b %Y""%H:%M:%S.%f"']:
+                        '"%a, %d %b %Y""%H:%M:%S.%f"',
+                        '%Y-%m-%d %H:%M:%S.%f']:
             try:
                 meas_date = dt.datetime.strptime(datetime_str, dt_code)
                 meas_date = meas_date.replace(tzinfo=dt.timezone.utc)
@@ -271,9 +273,10 @@ class RawNIRX(BaseRaw):
             subject_info['sex'] = FIFF.FIFFV_SUBJ_SEX_FEMALE
         else:
             subject_info['sex'] = FIFF.FIFFV_SUBJ_SEX_UNKNOWN
-        subject_info['birthday'] = (meas_date.year - int(inf['age']),
-                                    meas_date.month,
-                                    meas_date.day)
+        if inf['age'] != '':
+            subject_info['birthday'] = (meas_date.year - int(inf['age']),
+                                        meas_date.month,
+                                        meas_date.day)
 
         # Read information about probe/montage/optodes
         # A word on terminology used here:

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -51,17 +51,24 @@ nirsport2 = op.join(data_path(download=False), 'NIRx', 'nirsport_v2',
                     'aurora_recording _w_short_and_acc')
 nirsport2_snirf = op.join(data_path(download=False), 'SNIRF', 'NIRx',
                           'NIRSport2', '1.0.3', '2021-05-05_001.snirf')
+
 nirsport2_2021_9 = op.join(data_path(download=False), 'NIRx', 'nirsport_v2',
                     'aurora_2021_9')
-
+snirf_nirsport2_20219 = op.join(data_path(download=False),
+                                'SNIRF', 'NIRx', 'NIRSport2', '2021.9',
+                                '2021-10-01_002.snirf')
 
 @requires_h5py
 @requires_testing_data
 @pytest.mark.filterwarnings('ignore:.*Extraction of measurement.*:')
-def test_nirsport_v2_matches_snirf():
+@pytest.mark.parametrize('fname_nirx, fname_snirf', (
+        [nirsport2, nirsport2_snirf],
+        [nirsport2_2021_9, snirf_nirsport2_20219],
+))
+def test_nirsport_v2_matches_snirf(fname_nirx, fname_snirf):
     """Test NIRSport2 raw files return same data as snirf."""
-    raw = read_raw_nirx(nirsport2, preload=True)
-    raw_snirf = read_raw_snirf(nirsport2_snirf, preload=True)
+    raw = read_raw_nirx(fname_nirx, preload=True)
+    raw_snirf = read_raw_snirf(fname_snirf, preload=True)
 
     assert_allclose(raw._data, raw_snirf._data)
 
@@ -73,6 +80,7 @@ def test_nirsport_v2_matches_snirf():
     # This test fails as snirf encodes name incorrectly.
     # assert raw.info["subject_info"]["first_name"] ==
     # raw_snirf.info["subject_info"]["first_name"]
+
 
 
 @requires_testing_data

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -51,6 +51,8 @@ nirsport2 = op.join(data_path(download=False), 'NIRx', 'nirsport_v2',
                     'aurora_recording _w_short_and_acc')
 nirsport2_snirf = op.join(data_path(download=False), 'SNIRF', 'NIRx',
                           'NIRSport2', '1.0.3', '2021-05-05_001.snirf')
+nirsport2_2021_9 = op.join(data_path(download=False), 'NIRx', 'nirsport_v2',
+                    'aurora_2021_9')
 
 
 @requires_h5py
@@ -559,7 +561,8 @@ def test_nirx_15_0():
 @pytest.mark.parametrize('fname, boundary_decimal', (
     [fname_nirx_15_2_short, 1],
     [fname_nirx_15_2, 0],
-    [fname_nirx_15_0, 0]
+    [fname_nirx_15_2, 0],
+    [nirsport2_2021_9, 0]
 ))
 def test_nirx_standard(fname, boundary_decimal):
     """Test standard operations."""

--- a/mne/io/snirf/tests/test_snirf.py
+++ b/mne/io/snirf/tests/test_snirf.py
@@ -36,6 +36,11 @@ nirx_nirsport2_103 = op.join(data_path(download=False),
 nirx_nirsport2_103_2 = op.join(data_path(download=False),
                                'SNIRF', 'NIRx', 'NIRSport2', '1.0.3',
                                '2021-05-05_001.snirf')
+snirf_nirsport2_20219 = op.join(data_path(download=False),
+                             'SNIRF', 'NIRx', 'NIRSport2', '2021.9',
+                             '2021-10-01_002.snirf')
+nirx_nirsport2_20219 = op.join(data_path(download=False), 'NIRx', 'nirsport_v2',
+                           'aurora_2021_9')
 
 
 @requires_h5py
@@ -45,7 +50,8 @@ nirx_nirsport2_103_2 = op.join(data_path(download=False),
                                     nirx_nirsport2_103,
                                     sfnirs_homer_103_153,
                                     nirx_nirsport2_103,
-                                    nirx_nirsport2_103_2]))
+                                    nirx_nirsport2_103_2,
+                                    snirf_nirsport2_20219]))
 def test_basic_reading_and_min_process(fname):
     """Test reading SNIRF files and minimum typical processing."""
     raw = read_raw_snirf(fname, preload=True)
@@ -284,10 +290,16 @@ def test_snirf_nirsport2_w_positions():
 
 @requires_testing_data
 @requires_h5py
-def test_snirf_standard():
+@pytest.mark.parametrize('fname, boundary_decimal', (
+        [sfnirs_homer_103_wShort, 0],
+        [nirx_nirsport2_103, 0],
+        [nirx_nirsport2_103_2, 0],
+        [snirf_nirsport2_20219, 0],
+))
+def test_snirf_standard(fname, boundary_decimal):
     """Test standard operations."""
-    _test_raw_reader(read_raw_snirf, fname=sfnirs_homer_103_wShort,
-                     boundary_decimal=0)  # low fs
+    _test_raw_reader(read_raw_snirf, fname=fname,
+                     boundary_decimal=boundary_decimal)  # low fs
 
 
 @requires_testing_data

--- a/mne/preprocessing/nirs/tests/test_nirs.py
+++ b/mne/preprocessing/nirs/tests/test_nirs.py
@@ -31,15 +31,6 @@ fname_nirx_15_2_short = op.join(data_path(download=False),
                                 'nirx_15_2_recording_w_short')
 
 
-
-
-@testing.requires_testing_data
-def test_fnirs_pickst():
-    """Test picking of fnirs types after different conversions."""
-    raw = read_raw_nirx(fname_nirx_15_0)
-    raw.plot()
-
-
 @testing.requires_testing_data
 def test_fnirs_picks():
     """Test picking of fnirs types after different conversions."""

--- a/mne/preprocessing/nirs/tests/test_nirs.py
+++ b/mne/preprocessing/nirs/tests/test_nirs.py
@@ -31,6 +31,15 @@ fname_nirx_15_2_short = op.join(data_path(download=False),
                                 'nirx_15_2_recording_w_short')
 
 
+
+
+@testing.requires_testing_data
+def test_fnirs_pickst():
+    """Test picking of fnirs types after different conversions."""
+    raw = read_raw_nirx(fname_nirx_15_0)
+    raw.plot()
+
+
 @testing.requires_testing_data
 def test_fnirs_picks():
     """Test picking of fnirs types after different conversions."""


### PR DESCRIPTION
#### Reference issue
https://github.com/mne-tools/mne-testing-data/pull/89


#### What does this implement/fix?
The NIRx vendor has released their new acquisition software _Aurora 2021.9_. This software exports in two formats 1) their native format and 2) the community developed common SNIRF format.

A user already reported that SNIRF files from this software did not load with MNE (https://github.com/mne-tools/mne-nirs/issues/393) and I fixed the issue in https://github.com/mne-tools/mne-python/pull/9777. But we did not have any test data to confirm the issue was sufficiently resolved.

Since then, the vendor has kindly acquired some test data for us and emailed it to me (I don't have their newer devices that use the new software, my device is old and stuck with old software). They also sent the same data with the native file format.

The native file format has also changed.
1. The string used to encode dates has changed. 
2. And now the age field is optional. 


#### Additional information
Bit of a moving target 😢 these file formats.
