### PR TITLE
MRG, ENH: Add options to fit_dipole

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -181,6 +181,8 @@ Enhancements
 
 - Add full ECoG dataset to MNE-misc-data and demonstrate its use in :ref:`ex-electrode-pos-2d` and :ref:`tut-ieeg-localize` (:gh:`9784` by `Alex Rockhill`_)
 
+- Add options ``tol`` and ``accuracy`` to :func:`mne.fit_dipole` to control optimization (:gh:`9810` by `Eric Larson`_)
+
 - `mne.io.read_raw_brainvision` now handles ASCII data with comma-separated values, as may be exported from BrainVision Analyzer (:gh:`9795` by `Richard Höchenberger`_)
 
 - Add :func:`mne.preprocessing.ieeg.project_sensors_onto_brain` to project ECoG sensors onto the pial surface to compensate for brain shift (:gh:`9800` by `Alex Rockhill`_)

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -36,7 +36,7 @@ from .source_space import _make_volume_source_space, SourceSpaces
 from .parallel import parallel_func
 from .utils import (logger, verbose, _time_mask, warn, _check_fname,
                     check_fname, _pl, fill_doc, _check_option, ShiftTimeMixin,
-                    _svd_lwork, _repeated_svd, _get_blas_funcs)
+                    _svd_lwork, _repeated_svd, _get_blas_funcs, _validate_type)
 
 
 @fill_doc
@@ -899,14 +899,14 @@ def _fit_Q(fwd_data, whitener, B, B2, B_orig, rd, ori=None):
 
 
 def _fit_dipoles(fun, min_dist_to_inner_skull, data, times, guess_rrs,
-                 guess_data, fwd_data, whitener, ori, n_jobs, rank):
+                 guess_data, fwd_data, whitener, ori, n_jobs, rank, rhoend):
     """Fit a single dipole to the given whitened, projected data."""
     from scipy.optimize import fmin_cobyla
     parallel, p_fun, _ = parallel_func(fun, n_jobs)
     # parallel over time points
     res = parallel(p_fun(min_dist_to_inner_skull, B, t, guess_rrs,
                          guess_data, fwd_data, whitener,
-                         fmin_cobyla, ori, rank)
+                         fmin_cobyla, ori, rank, rhoend)
                    for B, t in zip(data.T, times))
     pos = np.array([r[0] for r in res])
     amp = np.array([r[1] for r in res])
@@ -1100,7 +1100,8 @@ def _sphere_constraint(rd, r0, R_adj):
 
 
 def _fit_dipole(min_dist_to_inner_skull, B_orig, t, guess_rrs,
-                guess_data, fwd_data, whitener, fmin_cobyla, ori, rank):
+                guess_data, fwd_data, whitener, fmin_cobyla, ori, rank,
+                rhoend):
     """Fit a single bit of data."""
     B = np.dot(whitener, B_orig)
 
@@ -1134,7 +1135,7 @@ def _fit_dipole(min_dist_to_inner_skull, B_orig, t, guess_rrs,
     # function we can use to ensure we stay inside the inner skull /
     # smallest sphere
     rd_final = fmin_cobyla(fun, x0, (constraint,), consargs=(),
-                           rhobeg=5e-2, rhoend=5e-5, disp=False)
+                           rhobeg=5e-2, rhoend=rhoend, disp=False)
 
     # simplex = _make_tetra_simplex() + x0
     # _simplex_minimize(simplex, 1e-4, 2e-4, fun)
@@ -1164,7 +1165,7 @@ def _fit_dipole(min_dist_to_inner_skull, B_orig, t, guess_rrs,
 
 def _fit_dipole_fixed(min_dist_to_inner_skull, B_orig, t, guess_rrs,
                       guess_data, fwd_data, whitener,
-                      fmin_cobyla, ori, rank):
+                      fmin_cobyla, ori, rank, rhoend):
     """Fit a data using a fixed position."""
     B = np.dot(whitener, B_orig)
     B2 = np.dot(B, B)
@@ -1190,7 +1191,8 @@ def _fit_dipole_fixed(min_dist_to_inner_skull, B_orig, t, guess_rrs,
 
 @verbose
 def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
-               pos=None, ori=None, rank=None, verbose=None):
+               pos=None, ori=None, rank=None, accuracy='normal', tol=5e-5,
+               verbose=None):
     """Fit a dipole.
 
     Parameters
@@ -1230,6 +1232,16 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     %(rank_None)s
 
         .. versionadded:: 0.20
+    accuracy : str
+        Can be "normal" (default) or "accurate", which gives the most accurate
+        coil definition but is typically not necessary for real-world data.
+
+        .. versionadded:: 0.24
+    tol : float
+        Final accuracy of the optimization (see ``rhoend`` argument of
+        :func:`scipy.optimize.fmin_cobyla`).
+
+        .. versionadded:: 0.24
     %(verbose)s
 
     Returns
@@ -1257,6 +1269,8 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     # are what is needed:
 
     evoked = evoked.copy()
+    _validate_type(accuracy, str, 'accuracy')
+    _check_option('accuracy', accuracy, ('accurate', 'normal'))
 
     # Determine if a list of projectors has an average EEG ref
     if _needs_eeg_average_ref_proj(evoked.info):
@@ -1322,7 +1336,6 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
                     % (1000 * r0[0], 1000 * r0[1], 1000 * r0[2], kind, R))
         inner_skull = dict(R=R, r0=r0)  # NB sphere model defined in head frame
         del R, r0
-    accurate = False  # can be an option later (shouldn't make big diff)
 
     # Deal with DipoleFixed cases here
     if pos is not None:
@@ -1362,8 +1375,7 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
         if guess_exclude > 0:
             logger.info('Guess exclude     : %6.1f mm'
                         % (1000 * guess_exclude,))
-        logger.info('Using %s MEG coil definitions.'
-                    % ("accurate" if accurate else "standard"))
+        logger.info(f'Using {accuracy} MEG coil definitions.')
         fit_n_jobs = n_jobs
     if isinstance(cov, str):
         logger.info('Noise covariance  : %s' % (cov,))
@@ -1382,7 +1394,7 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     if 'grad' in ch_types or 'mag' in ch_types:
         megcoils, compcoils, megnames, meg_info = \
             _prep_meg_channels(info, exclude='bads',
-                               accurate=accurate, verbose=verbose)
+                               accuracy=accuracy, verbose=verbose)
     if 'eeg' in ch_types:
         eegels, eegnames = _prep_eeg_channels(info, exclude='bads',
                                               verbose=verbose)
@@ -1462,7 +1474,7 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=1,
     fun = _fit_dipole_fixed if fixed_position else _fit_dipole
     out = _fit_dipoles(
         fun, min_dist_to_inner_skull, data, times, guess_src['rr'],
-        guess_data, fwd_data, whitener, ori, n_jobs, rank)
+        guess_data, fwd_data, whitener, ori, n_jobs, rank, tol)
     assert len(out) == 8
     if fixed_position and ori is not None:
         # DipoleFixed

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -1398,7 +1398,7 @@ def _write_evokeds(fname, evoked, check=True, *, on_mismatch='raise'):
         check_fname(fname, 'evoked', ('-ave.fif', '-ave.fif.gz',
                                       '_ave.fif', '_ave.fif.gz'))
 
-    if not isinstance(evoked, list):
+    if not isinstance(evoked, (list, tuple)):
         evoked = [evoked]
 
     warned = False

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -266,7 +266,7 @@ def _setup_bem(bem, bem_extra, neeg, mri_head_t, allow_none=False,
 
 
 @verbose
-def _prep_meg_channels(info, accurate=True, exclude=(), ignore_ref=False,
+def _prep_meg_channels(info, accuracy='accurate', exclude=(), ignore_ref=False,
                        head_frame=True, do_es=False, do_picking=True,
                        verbose=None):
     """Prepare MEG coil definitions for forward calculation.
@@ -274,9 +274,8 @@ def _prep_meg_channels(info, accurate=True, exclude=(), ignore_ref=False,
     Parameters
     ----------
     %(info_not_none)s
-    accurate : bool
-        If true (default) then use `accurate` coil definitions (more
-        integration points)
+    accuracy : str
+        Can be "normal" or "accurate" (default).
     exclude : list of str | str
         List of channels to exclude. If 'bads', exclude channels in
         info['bads']
@@ -301,7 +300,6 @@ def _prep_meg_channels(info, accurate=True, exclude=(), ignore_ref=False,
     meginfo : instance of Info
         Information subselected for just the set of MEG coils
     """
-    accuracy = 'accurate' if accurate else 'normal'
     info_extra = 'info'
     megnames, megcoils, compcoils = [], [], []
 

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -648,7 +648,7 @@ def _check_destination(destination, info, head_frame):
 def _prep_mf_coils(info, ignore_ref=True, verbose=None):
     """Get all coil integration information loaded and sorted."""
     coils, comp_coils = _prep_meg_channels(
-        info, accurate=True, head_frame=False,
+        info, head_frame=False,
         ignore_ref=ignore_ref, do_picking=False, verbose=False)[:2]
     mag_mask = _get_mag_mask(coils)
     if len(comp_coils) > 0:

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -344,7 +344,7 @@ def test_multipolar_bases():
     # Test our basis calculations
     info = read_info(raw_fname)
     with use_coil_def(elekta_def_fname):
-        coils = _prep_meg_channels(info, accurate=True, do_es=True)[0]
+        coils = _prep_meg_channels(info, do_es=True)[0]
     # Check against a known benchmark
     sss_data = loadmat(bases_fname)
     exp = dict(int_order=int_order, ext_order=ext_order)


### PR DESCRIPTION
When doing simulations, it's nice to be able to control 1) the convergence criterion of `fit_dipole`, and also 2) the accuracy of the coil definitions that are used. With the changes in this PR, I can get less than 0.1 mm error in simulations (without them, I'm stuck at 0.1 mm). Also when using a custom coil definition, it's nice to be able to specify that you want to use `'accurate'` definitions, for example, so if you only have this level of accuracy (which is the only one used by `make_forward_solution`) you don't have to duplicate your definition file.