### PR TITLE
Add warning for SNIRF files with != 2 wavelengths

### DIFF
--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -130,11 +130,12 @@ class RawSNIRF(BaseRaw):
             fnirs_wavelengths = np.array(dat.get('nirs/probe/wavelengths'))
             fnirs_wavelengths = [int(w) for w in fnirs_wavelengths]
             if len(fnirs_wavelengths) != 2:
-                raise RuntimeError(f'The data contains {len(fnirs_wavelengths)}'
+                raise RuntimeError(f'The data contains '
+                                   f'{len(fnirs_wavelengths)}'
                                    f' wavelengths: {fnirs_wavelengths}. '
                                    f'MNE only supports reading continuous'
                                    ' wave amplitude SNIRF files '
-                                   'with two wavelengths')
+                                   'with two wavelengths.')
 
             # Extract channels
             def atoi(text):


### PR DESCRIPTION
#### Reference issue
Throw more explicit warning when trying to read fNIRS data files with more than two wavelengths. See #9816 


#### What does this implement/fix?
Throw a more meaningful warning


#### Additional information
We don't have test data for this, and I imagine that in response to #9816 we will add support for >2 wavelengths. But in the meantime this might save other users being confused.
