### PR TITLE
MRG: Ensure plot_ica_sources() always plots traces of rejected ICs on top

### DIFF
--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -594,8 +594,10 @@ def _plot_ica_sources_evoked(evoked, picks, exclude, title, show, ica,
 
     for exc_label, ii in zip(exclude_labels, picks):
         color, style = label_props[ii]
+        # ensure traces of excluded components are plotted on top
+        zorder = 2 if exc_label is None else 10
         lines.extend(ax.plot(times, evoked.data[ii].T, picker=True,
-                             zorder=2, color=color, linestyle=style,
+                             zorder=zorder, color=color, linestyle=style,
                              label=exc_label))
         lines[-1].set_pickradius(3.)
 

--- a/tutorials/preprocessing/40_artifact_correction_ica.py
+++ b/tutorials/preprocessing/40_artifact_correction_ica.py
@@ -206,8 +206,7 @@ ecg_evoked.plot_joint()
 # `~mne.io.Raw` object around so we can apply the ICA solution to it
 # later.
 
-filt_raw = raw.copy()
-filt_raw.load_data().filter(l_freq=1., h_freq=None)
+filt_raw = raw.copy().load_data().filter(l_freq=1., h_freq=None)
 
 # %%
 # Fitting and plotting the ICA solution


### PR DESCRIPTION
This fixes a regression that I believe was introduced via  #9444. The below picture demonstrates the issue:


![](https://mne.tools/dev/_images/sphx_glr_40_artifact_correction_ica_019.png)
