### PR TITLE
MRG: Small improvements to labels in plot_ica_sources()

### DIFF
--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -590,7 +590,7 @@ def _plot_ica_sources_evoked(evoked, picks, exclude, title, show, ica,
         for label in exclude_labels:
             if label is None:
                 continue
-            elif ' - ' in label:
+            elif ' – ' in label:
                 unique_labels.add(label.split(' – ')[1])
             else:
                 unique_labels.add('')
@@ -602,7 +602,7 @@ def _plot_ica_sources_evoked(evoked, picks, exclude, title, show, ica,
         for label_idx, label in enumerate(exclude_labels):
             if label is not None:
                 color = cmap(col_lbs.index(label))
-                if ' - ' in label:
+                if ' – ' in label:
                     label_name = label.split(' – ')[1]
                 else:
                     label_name = ''

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -290,12 +290,19 @@ def test_plot_ica_sources(raw_orig, browse_backend):
                 [line.get_xdata()[0], line.get_ydata()[0]], 'data')
     _fake_click(fig, ax,
                 [ax.get_xlim()[0], ax.get_ylim()[1]], 'data')
+
     # plot with bad channels excluded
     ica.exclude = [0]
     ica.plot_sources(evoked)
-    ica.labels_ = dict(eog=[0])
-    ica.labels_['eog/0/crazy-channel'] = [0]
+
+    # pretend find_bads_eog() yielded some results
+    ica.labels_ = {
+        'eog': [0],
+        'eog/0/crazy-channel': [0]
+    }
     ica.plot_sources(evoked)  # now with labels
+
+    # pass an invalid inst
     with pytest.raises(ValueError, match='must be of Raw or Epochs type'):
         ica.plot_sources('meeow')
 


### PR DESCRIPTION
Don't add a trailing dash to legend labels if there's no additional text to add. 

MWE:
```python
# %%
from pathlib import Path
import mne


root_dir = Path(mne.datasets.sample.data_path())
meg_dir = root_dir / 'MEG' / 'sample'
raw_path = meg_dir / 'sample_audvis_filt-0-40_raw.fif'

raw = mne.io.read_raw(raw_path, preload=True)
raw_filt = raw.copy().filter(l_freq=1, h_freq=None)

ica = mne.preprocessing.ICA(n_components=15, max_iter='auto', random_state=97)
ica.fit(raw_filt)
ica.exclude = [0, 1]

eog_evoked = mne.preprocessing.create_eog_epochs(raw).average()
eog_evoked.apply_baseline(baseline=(None, -0.2))

ica.plot_sources(inst=eog_evoked)
```

On `main` (look at the legend):
![main](https://user-images.githubusercontent.com/2046265/136666688-98c638d1-0a3b-4d2e-9e5c-32605f02d1a2.png)

This PR:
![pr](https://user-images.githubusercontent.com/2046265/136666692-8738d487-5574-401c-85a4-b39c5cd9ab1b.png)
