### PR TITLE
MRG: Don't preload epochs during Report generation

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -183,7 +183,7 @@ Enhancements
 
 - Add options ``tol`` and ``accuracy`` to :func:`mne.fit_dipole` to control optimization (:gh:`9810` by `Eric Larson`_)
 
-- Completely revamp the `~mne.Report` experience: new HTML layout, many new methods, more flexibility; the functionality is demonstrated in :ref:`tut-report` (:gh:`9754`, :gh:`9828` by `Richard Höchenberger`_, `Eric Larson`_, and `Alex Gramfort`_)
+- Completely revamp the `~mne.Report` experience: new HTML layout, many new methods, more flexibility; the functionality is demonstrated in :ref:`tut-report` (:gh:`9754`, :gh:`9828`, :gh:`9847` by `Richard Höchenberger`_, `Eric Larson`_, and `Alex Gramfort`_)
 
 - Add basic HTML representations of `~mne.Forward` and `~mne.minimum_norm.InverseOperator` instances for a nicer Jupyter experience (:gh:`9754` by `Richard Höchenberger`_)
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -3351,7 +3351,7 @@ class Report(object):
             fname = epochs.filename
         else:
             fname = epochs
-            epochs = read_epochs(fname)
+            epochs = read_epochs(fname, preload=False)
 
         # Summary table
         dom_id = self._get_dom_id()
@@ -3398,7 +3398,6 @@ class Report(object):
 
             fig = epochs.plot_psd(fmax=fmax, show=False)
             tight_layout(fig=fig)
-
             img = _fig_to_img(fig=fig, image_format=image_format)
             psd_img_html = _html_image_element(
                 img=img, id=dom_id, div_klass='epochs', img_klass='epochs',


### PR DESCRIPTION
This may reduce the memory footprint by up to a couple 100 MBs for long experiments.