### PR TITLE
MRG: In Report, close ICA properties figures after use

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -183,7 +183,7 @@ Enhancements
 
 - Add options ``tol`` and ``accuracy`` to :func:`mne.fit_dipole` to control optimization (:gh:`9810` by `Eric Larson`_)
 
-- Completely revamp the `~mne.Report` experience: new HTML layout, many new methods, more flexibility; the functionality is demonstrated in :ref:`tut-report` (:gh:`9754`, :gh:`9828`, :gh:`9847` by `Richard Höchenberger`_, `Eric Larson`_, and `Alex Gramfort`_)
+- Completely revamp the `~mne.Report` experience: new HTML layout, many new methods, more flexibility; the functionality is demonstrated in :ref:`tut-report` (:gh:`9754`, :gh:`9828`, :gh:`9847`, :gh:`9860` by `Richard Höchenberger`_, `Eric Larson`_, and `Alex Gramfort`_)
 
 - Add basic HTML representations of `~mne.Forward` and `~mne.minimum_norm.InverseOperator` instances for a nicer Jupyter experience (:gh:`9754` by `Richard Höchenberger`_)
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -451,6 +451,7 @@ def _plot_ica_properties_as_arrays(*, ica, inst, picks, n_jobs):
             buff.seek(0)
             fig_array = plt.imread(buff, format='png')
 
+        plt.close(fig)
         return fig_array
 
     use_jobs = min(n_jobs, max(1, len(picks)))


### PR DESCRIPTION
On `main`, figures created through the properties plots remain unclosed. The fix is simple: close them. 😁