### PR TITLE
TYPO: vrmk -> vmrk

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -811,7 +811,7 @@ def _write_annotations_txt(fname, annot):
 def read_annotations(fname, sfreq='auto', uint16_codec=None):
     r"""Read annotations from a file.
 
-    This function reads a .fif, .fif.gz, .vrmk, .edf, .txt, .csv .cnt, .cef,
+    This function reads a .fif, .fif.gz, .vmrk, .edf, .txt, .csv .cnt, .cef,
     or .set file and makes an :class:`mne.Annotations` object.
 
     Parameters
@@ -825,7 +825,7 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None):
         ``sfreq`` is omitted. If set to 'auto' then the ``sfreq`` is taken
         from the respective info file of the same name with according file
         extension (\*.vhdr for brainvision; \*.dap for Curry 7; \*.cdt.dpa for
-        Curry 8). So data.vrmk looks for sfreq in data.vhdr, data.cef looks in
+        Curry 8). So data.vmrk looks for sfreq in data.vhdr, data.cef looks in
         data.dap and data.cdt.cef looks in data.cdt.dpa.
     uint16_codec : str | None
         This parameter is only used in EEGLAB (\*.set) and omitted otherwise.

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -260,9 +260,9 @@ def _read_vmrk(fname):
 
 
 def _read_annotations_brainvision(fname, sfreq='auto'):
-    """Create Annotations from BrainVision vrmk.
+    """Create Annotations from BrainVision vmrk.
 
-    This function reads a .vrmk file and makes an
+    This function reads a .vmrk file and makes an
     :class:`mne.Annotations` object.
 
     Parameters
@@ -275,7 +275,7 @@ def _read_annotations_brainvision(fname, sfreq='auto'):
         files are in samples. If set to 'auto' then
         the sfreq is taken from the .vhdr file that
         has the same name (without file extension). So
-        data.vrmk looks for sfreq in data.vhdr.
+        data.vmrk looks for sfreq in data.vhdr.
 
     Returns
     -------


### PR DESCRIPTION
Just fixing a repeated typo here.