### PR TITLE
fix dead link [ci skip]

### DIFF
--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -190,7 +190,7 @@
 
 .. _Thomas Hartmann: https://github.com/thht
 
-.. _Steven Gutstein: http://vll.cs.utep.edu/people.html
+.. _Steven Gutstein: https://github.com/smgutstein
 
 .. _Peter Molfese: https://github.com/pmolfese
 


### PR DESCRIPTION
fixes one linkcheck problem. the other is the perennial problem that the Paris-Saclay CDS website has an expired certificate (for more than a year). I finally broke down and emailed their webmaster about it.