### PR TITLE
[BUG, MRG] Fix infinite recursion bug in `get_montage_volume_labels`

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -315,7 +315,7 @@ Bugs
 
 - Fix channel locations with ``NaN`` values causing all channel locations not to be plotted in :func:`mne.viz.Brain.add_sensors` (:gh:`9911` by `Alex Rockhill`_)
 
-- Fix infinite loop bug in :func:`mne.surface.get_montage_volume_labels` (:gh:`XXX` by `Alex Rockhill`_)
+- Fix infinite loop bug in :func:`mne.surface.get_montage_volume_labels` (:gh:`9907` by `Alex Rockhill`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -313,7 +313,9 @@ Bugs
 
 - In :meth:`mne.Epochs.plot_psd_topomap`, the data is now scaled to match the output of :meth:`mne.Epochs.plot_psd` (:gh:`9873` by `Richard Höchenberger`_)
 
-- Fix channel locations with ``NaN`` values causing all channel locations not to be plotted in :func:`mne.viz.Brain.add_sensors` (:gh:`9908` by `Alex Rockhill`_)
+- Fix channel locations with ``NaN`` values causing all channel locations not to be plotted in :func:`mne.viz.Brain.add_sensors` (:gh:`9911` by `Alex Rockhill`_)
+
+- Fix infinite loop bug in :func:`mne.surface.get_montage_volume_labels` (:gh:`XXX` by `Alex Rockhill`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -315,7 +315,7 @@ Bugs
 
 - Fix channel locations with ``NaN`` values causing all channel locations not to be plotted in :func:`mne.viz.Brain.add_sensors` (:gh:`9911` by `Alex Rockhill`_)
 
-- Fix infinite loop bug in :func:`mne.surface.get_montage_volume_labels` (:gh:`9907` by `Alex Rockhill`_)
+- Fix infinite loop bug in :func:`mne.get_montage_volume_labels` (:gh:`9907` by `Alex Rockhill`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -1922,7 +1922,7 @@ _VOXELS_MAX = 100  # define constant to avoid runtime issues
 
 @fill_doc
 def get_montage_volume_labels(montage, subject, subjects_dir=None,
-                              aseg='aparc+aseg', dist=5):
+                              aseg='aparc+aseg', dist=2):
     """Get regions of interest near channels from a Freesurfer parcellation.
 
     .. note:: This is applicable for channels inside the brain

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -2080,5 +2080,5 @@ def _voxel_neighbors(seed, image, thresh=None, max_peak_dist=1,
             if len(voxels) > voxels_max:
                 break
             next_neighbors = next_neighbors.union(voxel_neighbors)
-        neighbors = next_neighbors
+        neighbors = next_neighbors.difference(voxels)
     return voxels


### PR DESCRIPTION
`get_montage_volume_labels` can enter an infinite recursion because the voxel neighbors on every step are not removed, causing it to go from one voxel to the neighbor and back. This fixes that.