### PR TITLE
add version JSON

### DIFF
--- a/doc/_static/versions.json
+++ b/doc/_static/versions.json
@@ -1,0 +1,46 @@
+[
+    {
+        "name": "v0.24 (devel)",
+        "version": "dev"
+    },
+    {
+        "name": "v0.23 (stable)",
+        "version": "stable"
+    },
+    {
+        "version": "0.22"
+    },
+    {
+        "version": "0.21"
+    },
+    {
+        "version": "0.20"
+    },
+    {
+        "version": "0.19"
+    },
+    {
+        "version": "0.18"
+    },
+    {
+        "version": "0.17"
+    },
+    {
+        "version": "0.16"
+    },
+    {
+        "version": "0.15"
+    },
+    {
+        "version": "0.14"
+    },
+    {
+        "version": "0.13"
+    },
+    {
+        "version": "0.12"
+    },
+    {
+        "version": "0.11"
+    }
+]


### PR DESCRIPTION
This PR adds one file, `doc/_static/versions.json`.  Currently it will just sit there unused, but I want to test out if https://github.com/pydata/pydata-sphinx-theme/pull/436 will work for us out-of-the-box, so I need the JSON file to already be living at `https://mne.tools/dev/_static/versions.json` for the test to work.