### PR TITLE
MRG: Small improvements to ICA documentation.

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -270,10 +270,9 @@ class ICA(ContainsMixin):
     .. versionchanged:: 0.23
         Warn if `~mne.Epochs` were baseline-corrected.
 
-    .. note:: If you intend to clean fit ICA on `~mne.Epochs`, it is
-              recommended to high-pass filter, but **not** baseline correct the
-              data for good ICA performance. A warning will be emitted
-              otherwise.
+    .. note:: If you intend to fit ICA on `~mne.Epochs`, it is  recommended to
+              high-pass filter, but **not** baseline correct the data for good
+              ICA performance. A warning will be emitted otherwise.
 
     A trailing ``_`` in an attribute name signifies that the attribute was
     added to the object during fitting, consistent with standard scikit-learn


### PR DESCRIPTION
It took me 5 minutes to find the line specifying what arguments were allowed in `fit_params` for ICA.. Would you mind if we copy it directly in the argument description?

Also in the note line 271, I think there is a typo. I changed `If you intend to clean fit ICA on` to `If you intend to fit ICA on`.