### PR TITLE
fix plot_compare_evokeds topo legend axes placement

### DIFF
--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -2351,14 +2351,49 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
                 sphere=sphere)
 
         layout = find_layout(info)
-        # shift everything to the right by 15% of one axes width
-        layout.pos[:, 0] += layout.pos[0, 2] * .15
-        layout.pos[:, 1] += layout.pos[0, 3] * .15
+        # make sure everything fits nicely. our figsize is (18, 14) so margins
+        # of 0.25 inch seem OK
+        w_margin = 0.25 / 18
+        h_margin = 0.25 / 14
+        axes_width = layout.pos[0, 2]
+        axes_height = layout.pos[0, 3]
+        left_edge = layout.pos[:, 0].min()
+        right_edge = layout.pos[:, 0].max() + axes_width
+        bottom_edge = layout.pos[:, 1].min()
+        top_edge = layout.pos[:, 1].max() + axes_height
+        # compute scale. Use less of vertical height (leave room for title)
+        w_scale = (0.95 - 2 * w_margin) / (right_edge - left_edge)
+        h_scale = (0.9 - 2 * h_margin) / (top_edge - bottom_edge)
+        # apply tranformation
+        layout.pos[:, 0] = ((layout.pos[:, 0] - left_edge) * w_scale
+                            + w_margin + 0.025)
+        layout.pos[:, 1] = ((layout.pos[:, 1] - bottom_edge) * h_scale
+                            + h_margin + 0.025)
+        # make sure there is room for a legend axis (sometimes not if only a
+        # few channels were picked)
+        data_lefts = layout.pos[:, 0]
+        data_bottoms = layout.pos[:, 1]
+        legend_left = data_lefts.max()
+        legend_bottom = data_bottoms.min()
+        overlap = np.any(np.logical_and(
+            np.logical_and(
+                data_lefts <= legend_left,
+                legend_left <= (data_lefts + axes_width)),
+            np.logical_and(
+                data_bottoms <= legend_bottom,
+                legend_bottom <= (data_bottoms + axes_height)
+            )
+        ))
+        right_edge = legend_left + axes_width
+        n_columns = (right_edge - data_lefts.min()) / axes_width
+        scale_factor = n_columns / (n_columns + 1)
+        if overlap:
+            layout.pos[:, [0, 2]] *= scale_factor
         # `axes` will be a list of (axis_object, channel_index) tuples
         axes = list(iter_topography(
             info, layout=layout, on_pick=click_func,
             fig=fig, fig_facecolor='w', axis_facecolor='w',
-            axis_spinecolor='k', layout_scale=.925, legend=True))
+            axis_spinecolor='k', layout_scale=None, legend=True))
         picks = list(picks)
     del info
 

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -2364,7 +2364,7 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
         # compute scale. Use less of vertical height (leave room for title)
         w_scale = (0.95 - 2 * w_margin) / (right_edge - left_edge)
         h_scale = (0.9 - 2 * h_margin) / (top_edge - bottom_edge)
-        # apply tranformation
+        # apply transformation
         layout.pos[:, 0] = ((layout.pos[:, 0] - left_edge) * w_scale
                             + w_margin + 0.025)
         layout.pos[:, 1] = ((layout.pos[:, 1] - bottom_edge) * h_scale

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -81,8 +81,18 @@ def _legend_axis(pos):
     """Add a legend axis to the bottom right."""
     import matplotlib.pyplot as plt
     left, bottom = pos[:, 0].max(), pos[:, 1].min()
+    # check if legend axis overlaps a data axis
+    overlaps = False
+    for _pos in pos:
+        h_overlap = (_pos[0] <= left <= (_pos[0] + _pos[2]))
+        v_overlap = (_pos[1] <= bottom <= (_pos[1] + _pos[3]))
+        if h_overlap and v_overlap:
+            overlaps = True
+            break
+    if overlaps:
+        left += 1.2 * _pos[2]
     wid, hei = pos[-1, 2:]
-    return plt.axes([left, bottom + .05, wid, hei])
+    return plt.axes([left, bottom, wid, hei])
 
 
 def _iter_topography(info, layout, on_pick, fig, fig_facecolor='k',


### PR DESCRIPTION
closes #9923 

Here are some figures to show how this changes behavior. I've made the figure facecolor gray to more clearly show its edges (for those of you who don't use GitHub dark mode 😎):

### EEG
**main:**
![main_eeg](https://user-images.githubusercontent.com/1810515/139514267-854085c7-d0c6-4fae-942f-c26ec7025e16.png)

**this PR:**
![pr_eeg](https://user-images.githubusercontent.com/1810515/139514281-486139c4-f5b7-4c55-b231-6ff4d95128eb.png)

### MAG
**main:**
![main_mag](https://user-images.githubusercontent.com/1810515/139514319-8b27a70a-570d-4514-a5dc-77eb9a6c0a34.png)

**this PR:**
![pr_mag](https://user-images.githubusercontent.com/1810515/139514314-6e70ff38-7f68-4e68-bbee-44029e03cbea.png)


### GRAD
**main:**
![main_grad](https://user-images.githubusercontent.com/1810515/139514311-8b2a39aa-7dc5-4418-af06-485aba2750c3.png)

**this PR:**
![pr_grad](https://user-images.githubusercontent.com/1810515/139514308-f2bc78ba-1bf6-45b9-8044-c74b20a00042.png)

### JUST A FEW PICKS (this is what originally revealed the bug)
**main:**
![main_issue](https://user-images.githubusercontent.com/1810515/139514305-38b975ac-66a2-49c2-a28b-a2d43bde37e5.png)

**this PR:**
![pr_issue](https://user-images.githubusercontent.com/1810515/139514300-d00f9f54-6e6c-484a-b341-16379ffc9680.png)


