### PR TITLE
Coreg fixes

### DIFF
--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1368,14 +1368,17 @@ class Coregistration(object):
                 dig=self._info['dig'],
                 exclude_ref_channel=False
             )
-            # adjustments
-            self._dig_dict['rpa'] = np.array([self._dig_dict['rpa']], float)
-            self._dig_dict['nasion'] = \
-                np.array([self._dig_dict['nasion']], float)
-            self._dig_dict['lpa'] = np.array([self._dig_dict['lpa']], float)
-            if self._dig_dict['hpi'] is None:
-                self._dig_dict['hpi'] = np.zeros((1, 3))
-                self._hpi_weight = 0
+            # adjustments:
+            # set weights to 0 for None input
+            # convert fids to float arrays
+            for k, w_atr in zip(['nasion', 'lpa', 'rpa', 'hsp', 'hpi'],
+                                ['_nasion_weight', '_lpa_weight',
+                                 '_rpa_weight', '_hsp_weight', '_hpi_weight']):
+                if self._dig_dict[k] is None:
+                    self._dig_dict[k] = np.zeros((0, 3))
+                    setattr(self, w_atr, 0)
+                elif k in ['rpa', 'nasion', 'lpa']:
+                    self._dig_dict[k] = np.array([self._dig_dict[k]], float)
 
     def _setup_bem(self):
         # find high-res head model (if possible)

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1373,6 +1373,9 @@ class Coregistration(object):
             self._dig_dict['nasion'] = \
                 np.array([self._dig_dict['nasion']], float)
             self._dig_dict['lpa'] = np.array([self._dig_dict['lpa']], float)
+            if self._dig_dict['hpi'] is None:
+                self._dig_dict['hpi'] = np.zeros((1, 3))
+                self._hpi_weight = 0
 
     def _setup_bem(self):
         # find high-res head model (if possible)

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -304,7 +304,7 @@ class RawSNIRF(BaseRaw):
                         rpa = diglocs[idx, :3]
                     else:
                         extra_ps[f'EEG{len(extra_ps) + 1:03d}'] = \
-                            diglocs[idx]
+                            diglocs[idx, :3]
                 dig = _make_dig_points(
                     nasion=nasion, lpa=lpa, rpa=rpa, hpi=hpi,
                     dig_ch_pos=extra_ps,

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -451,7 +451,7 @@ def test_coreg_class_gui_match():
     'drop_point_kind', (FIFF.FIFFV_POINT_CARDINAL, FIFF.FIFFV_POINT_HPI,
                         FIFF.FIFFV_POINT_EXTRA, FIFF.FIFFV_POINT_EEG))
 def test_coreg_class_init(drop_point_kind):
-    """Test that Coregistration can be instantiation with various digs."""
+    """Test that Coregistration can be instantiated with various digs."""
     fiducials, _ = read_fiducials(fid_fname)
     info = read_info(raw_fname)
 

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -22,6 +22,7 @@ from mne.io.constants import FIFF
 from mne.utils import (requires_nibabel, modified_env, check_version,
                        catch_logging)
 from mne.source_space import write_source_spaces
+from mne.channels import DigMontage
 
 data_path = testing.data_path(download=False)
 subjects_dir = os.path.join(data_path, 'subjects')
@@ -443,3 +444,27 @@ def test_coreg_class_gui_match():
         [0, 0, 0, 1]]
     assert_allclose(coreg.scale, want_scale, atol=5e-4)
     assert_allclose(coreg.trans['trans'], want_trans, atol=1e-6)
+
+
+@testing.requires_testing_data
+@pytest.mark.parametrize(
+    'drop_point_kind', (FIFF.FIFFV_POINT_CARDINAL, FIFF.FIFFV_POINT_HPI,
+                        FIFF.FIFFV_POINT_EXTRA, FIFF.FIFFV_POINT_EEG))
+def test_coreg_class_init(drop_point_kind):
+    """Test that Coregistration can be instantiation with various digs."""
+    fiducials, _ = read_fiducials(fid_fname)
+    info = read_info(raw_fname)
+
+    dig_list = []
+    eeg_chans = []
+    for pt in info['dig']:
+        if pt['kind'] != drop_point_kind:
+            dig_list.append(pt)
+            if pt['kind'] == FIFF.FIFFV_POINT_EEG:
+                eeg_chans.append(f"EEG {pt['ident']:03d}")
+
+    this_info = info.copy()
+    this_info.set_montage(DigMontage(dig=dig_list, ch_names=eeg_chans),
+                          on_missing='ignore')
+    Coregistration(this_info, subject='sample',
+                   subjects_dir=subjects_dir, fiducials=fiducials)

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1032,7 +1032,7 @@ def _orient_glyphs(pts, surf):
 
 def _plot_glyphs(renderer, loc, color, scale, opacity=1, mode="cylinder",
                  orient_glyphs=False, surf=None, backface_culling=False):
-    if orient_glyphs:
+    if orient_glyphs and len(loc) > 0:
         defaults = DEFAULTS['coreg']
         scalars, vectors = _orient_glyphs(loc, surf)
         x, y, z = loc.T


### PR DESCRIPTION
Handle two issues I raised in #8833,
1) support for `info['dig']` missing some types of dig points
2) support loading from instances only containing `dig` objects.

~~still needs `latest.inc`~~ hasn't been released so no need.