### PR TITLE
Attempt to make "verbose" docstring more use-friendly

### DIFF
--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -66,10 +66,7 @@ class ReceptiveField(BaseEstimator):
         duration. Only used if ``estimator`` is float or None.
 
         .. versionadded:: 0.18
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see
-        :func:`mne.verbose` and :ref:`Logging documentation <tut-logging>`
-        for more).
+    %(verbose)s
 
     Attributes
     ----------

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -11,9 +11,10 @@ import numpy as np
 from .base import get_coef, BaseEstimator, _check_estimator
 from .time_delaying_ridge import TimeDelayingRidge
 from ..fixes import is_regressor
-from ..utils import _validate_type, verbose
+from ..utils import _validate_type, verbose, fill_doc
 
 
+@fill_doc
 class ReceptiveField(BaseEstimator):
     """Fit a receptive field model.
 

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -1557,9 +1557,7 @@ def iterative_tf_mixed_norm_solver(M, G, alpha_space, alpha_time,
         The number of orientation (1 : fixed or 3 : free or loose).
     dgap_freq : int or np.inf
         The duality gap is evaluated every dgap_freq iterations.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut-logging>` for more).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -78,9 +78,10 @@ def verbose(function: _FuncT) -> _FuncT:
     -----
     This decorator is used to set the verbose level during a function or method
     call, such as :func:`mne.compute_covariance`. The `verbose` keyword
-    argument can be 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL', True (an
-    alias for 'INFO'), or False (an alias for 'WARNING'). To set the global
-    verbosity level for all functions, use :func:`mne.set_log_level`.
+    argument can be ``'debug'``, ``'info'``, ``'warning'``, ``'error'``,
+    ``'critical``', ``True`` (an alias for ``'info'``), or ``False`` (an alias
+    for ``'warning'``). To set the global verbosity level for all functions,
+    use :func:`mne.set_log_level`.
 
     This function also serves as a docstring filler.
 
@@ -89,8 +90,8 @@ def verbose(function: _FuncT) -> _FuncT:
     You can use the ``verbose`` argument to set the verbose level on the fly::
 
         >>> import mne
-        >>> cov = mne.compute_raw_covariance(raw, verbose='WARNING')  # doctest: +SKIP
-        >>> cov = mne.compute_raw_covariance(raw, verbose='INFO')  # doctest: +SKIP
+        >>> cov = mne.compute_raw_covariance(raw, verbose='warning')  # doctest: +SKIP
+        >>> cov = mne.compute_raw_covariance(raw, verbose='info')  # doctest: +SKIP
         Using up to 49 segments
         Number of samples used : 5880
         [done]

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -24,10 +24,20 @@ docdict = dict()
 
 # Verbose
 docdict['verbose'] = """
-verbose : bool | str | int | None
-    If not None, override default verbose level (see :func:`mne.verbose`
-    and :ref:`Logging documentation <python:tut-logging>` for more).
-    If used, it should be passed as a keyword-argument only."""
+verbose : bool | 'debug' | 'info' | 'warning' | 'error' | 'critical' | int | None
+    Controls the verbosity of the generated logging output. Logging messages
+    below the specified level will not be emitted. For example, if you specify
+    ``verbose='warning'``, all ``debug`` and ``info`` messages will be hidden.
+
+    You may also pass a boolean, where ``True`` is an alias for ``'info'`` and
+    ``False`` is an alias for ``'warning'``. See also :func:`mne.verbose`.
+
+    If ``None``, use the default logging level.
+
+    Integers are accepted for consistency with the underlying Python logging
+    system.
+
+    If used, it should be passed as a keyword-argument only."""  # noqa: E501
 docdict['verbose_meth'] = (docdict['verbose'] + ' Defaults to self.verbose.')
 
 # Preload

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -24,20 +24,14 @@ docdict = dict()
 
 # Verbose
 docdict['verbose'] = """
-verbose : bool | 'debug' | 'info' | 'warning' | 'error' | 'critical' | int | None
-    Controls the verbosity of the generated logging output. Logging messages
-    below the specified level will not be emitted. For example, if you specify
-    ``verbose='warning'``, all ``debug`` and ``info`` messages will be hidden.
+verbose : bool | str | int | None
+    Controls the verbosity of the generated logging output. If ``True``, sets
+    the log level to ``INFO``, and if ``False``, sets it to ``WARNING``. If
+    ``None``, use the default logging level. Accepts all
+    `Python logging levels <https://docs.python.org/3/library/logging.html#logging-levels>`_
+    (case ignored).
 
-    You may also pass a boolean, where ``True`` is an alias for ``'info'`` and
-    ``False`` is an alias for ``'warning'``. See also :func:`mne.verbose`.
-
-    If ``None``, use the default logging level.
-
-    Integers are accepted for consistency with the underlying Python logging
-    system.
-
-    If used, it should be passed as a keyword-argument only."""  # noqa: E501
+    Should only be passed as a keyword argument."""  # noqa: E501
 docdict['verbose_meth'] = (docdict['verbose'] + ' Defaults to self.verbose.')
 
 # Preload


### PR DESCRIPTION
The docstring for the `verbose` kwargs was quite technical and, therefore, cryptic. I tried to make it more approachable for users.

Also replaced the upper-case log levels with lower-case names in the examples.

The docstring is longer now, but I think it will be much more helpful.