### PR TITLE
[MAINT, MRG] Better test for `mne.surface._voxel_neighbors`

### DIFF
--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -7,7 +7,6 @@ import os.path as op
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose, assert_equal
-from scipy.stats import multivariate_normal
 
 from mne import (read_surface, write_surface, decimate_surface, pick_types,
                  dig_mri_distances, get_montage_volume_labels)

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -7,6 +7,7 @@ import os.path as op
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose, assert_equal
+from scipy.stats import multivariate_normal
 
 from mne import (read_surface, write_surface, decimate_surface, pick_types,
                  dig_mri_distances, get_montage_volume_labels)
@@ -286,13 +287,13 @@ def test_get_montage_volume_labels():
 
 def test_voxel_neighbors():
     """Test finding points above a threshold near a seed location."""
-    image = np.zeros((10, 10, 10))
-    image[4:7, 4:7, 4:7] = 3
-    image[5, 5, 5] = 4
+    locs = np.array(np.meshgrid(*[np.linspace(-1, 1, 101)] * 3))
+    image = 1 - np.linalg.norm(locs, axis=0)
+    true_volume = set([tuple(coord) for coord in
+                       np.array(np.where(image > 0.95)).T])
     volume = _voxel_neighbors(
-        (5.5, 5.1, 4.9), image, thresh=2, max_peak_dist=1, use_relative=False)
-    true_volume = set([(5, 4, 5), (5, 5, 4), (5, 5, 5), (6, 5, 5),
-                       (5, 6, 5), (5, 5, 6), (4, 5, 5)])
+        np.array([-0.3, 0.6, 0.5]) + (np.array(image.shape[0]) - 1) / 2,
+        image, thresh=0.95, use_relative=False)
     assert volume.difference(true_volume) == set()
     assert true_volume.difference(volume) == set()
 


### PR DESCRIPTION
Fixes https://github.com/mne-tools/mne-python/pull/9940 leftovers.

This is much more thorough and has a more realistic use-case for the algorithm (i.e. previously cube contours of integer type were used but now the intensities are more reasonably normally distributed (the problem with the cube contours is that the corners were the same intensity as the sides when they should be farther from the origin of the intensity) and are continuous floating point numbers).