### PR TITLE
[ENH, MRG] Add local maxima button to ieeg locate GUI

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -24,7 +24,7 @@ Enhancements
 ~~~~~~~~~~~~
 .. - Add something cool (:gh:`9192` **by new contributor** |New Contributor|_)
 
-- Nothing yet
+- Added show local maxima toggling button to :func:`mne.gui.locate_ieeg` (:gh:XXX by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -24,7 +24,7 @@ Enhancements
 ~~~~~~~~~~~~
 .. - Add something cool (:gh:`9192` **by new contributor** |New Contributor|_)
 
-- Added show local maxima toggling button to :func:`mne.gui.locate_ieeg` (:gh:XXX by `Alex Rockhill`_)
+- Add show local maxima toggling button to :func:`mne.gui.locate_ieeg` (:gh:`9952` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -773,6 +773,7 @@ class IntracranialElectrodeLocator(QMainWindow):
         self._radius = np.round(self._radius_slider.value()).astype(int)
         if self._toggle_show_max_button.text() == 'Hide Maxima':
             self._update_ct_maxima()
+            self._update_ct_images()
         else:
             self._ct_maxima = None  # signals ct max is out-of-date
         self._update_ch_images(draw=True)

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -8,6 +8,7 @@
 import os.path as op
 import numpy as np
 from functools import partial
+from scipy.ndimage import maximum_filter
 
 from matplotlib.colors import LinearSegmentedColormap
 
@@ -115,12 +116,14 @@ class IntracranialElectrodeLocator(QMainWindow):
         self._info = info
         self._verbose = verbose
 
+        # channel plotting default parameters
+        self._ch_alpha = 0.5
+        self._radius = int(_CH_PLOT_SIZE // 100)  # starting 1/100 of image
+
         # load imaging data
         self._subject_dir = _check_subject_dir(subject, subjects_dir)
         self._load_image_data(aligned_ct)
 
-        self._ch_alpha = 0.5
-        self._radius = int(_CH_PLOT_SIZE // 100)  # starting 1/200 of image
         # initialize channel data
         self._ch_index = 0
         # load data, apply trans
@@ -206,6 +209,7 @@ class IntracranialElectrodeLocator(QMainWindow):
                              f'MRI shape={self._mri_data.shape}, '
                              f'CT affine={vox_ras_t} and '
                              f'MRI affine={self._vox_ras_t}')
+        self._ct_maxima = None  # don't compute until turned on
 
         if op.exists(op.join(self._subject_dir, 'surf', 'lh.seghead')):
             self._head = _read_mri_surface(
@@ -484,7 +488,12 @@ class IntracranialElectrodeLocator(QMainWindow):
         """Make a bar at the bottom with information in it."""
         hbox = QHBoxLayout()
 
-        hbox.addStretch(10)
+        hbox.addStretch(7)
+
+        self._toggle_show_max_button = QPushButton('Show Maxima')
+        self._toggle_show_max_button.released.connect(
+            self._toggle_show_max)
+        hbox.addWidget(self._toggle_show_max_button)
 
         self._intensity_label = QLabel('')  # update later
         hbox.addWidget(self._intensity_label)
@@ -725,6 +734,10 @@ class IntracranialElectrodeLocator(QMainWindow):
             ct_data[ct_data < self._ct_min_slider.value()] = np.nan
             ct_data[ct_data > self._ct_max_slider.value()] = np.nan
             self._images['ct'][axis].set_data(ct_data)
+            if 'local_max' in self._images:
+                ct_max_data = np.take(
+                    self._ct_maxima, self._current_slice[axis], axis=axis).T
+                self._images['local_max'][axis].set_data(ct_max_data)
             if draw:
                 self._draw(axis)
 
@@ -758,6 +771,10 @@ class IntracranialElectrodeLocator(QMainWindow):
     def _update_radius(self):
         """Update channel plot radius."""
         self._radius = np.round(self._radius_slider.value()).astype(int)
+        if self._toggle_show_max_button.text() == 'Hide Maxima':
+            self._update_ct_maxima()
+        else:
+            self._ct_maxima = None  # signals ct max is out-of-date
         self._update_ch_images(draw=True)
         self._plot_3d_ch_pos(render=True)
         self._ch_list.setFocus()  # remove focus from 3d plotter
@@ -804,6 +821,36 @@ class IntracranialElectrodeLocator(QMainWindow):
             "'+'/'-': zoom\nleft/right arrow: left/right\n"
             "up/down arrow: superior/inferior\n"
             "page up/page down arrow: anterior/posterior")
+
+    def _update_ct_maxima(self):
+        """Compute the maximum voxels based on the current radius."""
+        self._ct_maxima = maximum_filter(
+            self._ct_data, (self._radius,) * 3) == self._ct_data
+        self._ct_maxima[self._ct_data <= np.median(self._ct_data)] = \
+            False
+        self._ct_maxima = np.where(self._ct_maxima, 1, np.nan)  # transparent
+
+    def _toggle_show_max(self):
+        """Toggle whether to color local maxima differently."""
+        if self._toggle_show_max_button.text() == 'Show Maxima':
+            self._toggle_show_max_button.setText('Hide Maxima')
+            # happens on initiation or if the radius is changed with it off
+            if self._ct_maxima is None:  # otherwise don't recompute
+                self._update_ct_maxima()
+            self._images['local_max'] = list()
+            for axis in range(3):
+                ct_max_data = np.take(self._ct_maxima,
+                                      self._current_slice[axis], axis=axis).T
+                self._images['local_max'].append(
+                    self._figs[axis].axes[0].imshow(
+                        ct_max_data, cmap='autumn', aspect='auto',
+                        vmin=0, vmax=1))
+        else:
+            for img in self._images['local_max']:
+                img.remove()
+            self._images.pop('local_max')
+            self._toggle_show_max_button.setText('Show Maxima')
+        self._draw()
 
     def _toggle_show_brain(self):
         """Toggle whether the brain/MRI is being shown."""

--- a/mne/gui/tests/test_ieeg_locate_gui.py
+++ b/mne/gui/tests/test_ieeg_locate_gui.py
@@ -186,5 +186,6 @@ def test_ieeg_elec_locate_gui_display(_locate_ieeg, _fake_CT_coords):
     # test buttons
     gui._toggle_show_brain()
     assert 'mri' in gui._images
+    assert 'local_max' not in gui._images
     gui._toggle_show_max()
     assert 'local_max' in gui._images

--- a/mne/gui/tests/test_ieeg_locate_gui.py
+++ b/mne/gui/tests/test_ieeg_locate_gui.py
@@ -182,3 +182,9 @@ def test_ieeg_elec_locate_gui_display(_locate_ieeg, _fake_CT_coords):
     ct_sum_before = np.nansum(gui._images['ct'][0].get_array().data)
     gui._ct_min_slider.setValue(500)
     assert np.nansum(gui._images['ct'][0].get_array().data) < ct_sum_before
+
+    # test buttons
+    gui._toggle_show_brain()
+    assert 'mri' in gui._images
+    gui._toggle_show_max()
+    assert 'local_max' in gui._images


### PR DESCRIPTION
This adds the capability to show in yellow which voxel is a local maxima (see below). This functionality is very useful for bridged electrodes where otherwise, the intensity values would have to be looked at carefully and/or the color scale changed (which has the added detriment of making it hard to see the context outside of the electrode) in order to determine the center of intensity of the electrode contact with assurance. This coordinates nicely with our method of warping which uses voxels monotonically decreasing from the local maximum (at least until Dipy finishes their PR https://github.com/dipy/dipy/pull/2369 to make it so that points can be warped). Lastly, the maximum computation is done efficiently only whenever the radius changes and the local maxima showing is turned on (it uses the radius to determine how far to count as local).

<img width="844" alt="Screen Shot 2021-11-03 at 6 20 24 PM" src="https://user-images.githubusercontent.com/13473576/140241351-e2b5a053-348e-4021-ad33-6a3e830eb2c5.png">