### PR TITLE
MAINT: Bump mne-connectivity

### DIFF
--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -10,5 +10,5 @@ seaborn!=0.11.2
 sphinx_copybutton
 mne-bids
 pyxdf
-mne-connectivity
+https://github.com/mne-tools/mne-connectivity/archive/main.zip
 pytest

--- a/tutorials/epochs/60_make_fixed_length_epochs.py
+++ b/tutorials/epochs/60_make_fixed_length_epochs.py
@@ -20,8 +20,8 @@ create 30 second epochs that allow us to perform non-event-related analyses of
 the signal.
 
 .. note::
-    Starting in version 0.25, all functions in the ``mne.connectivity``
-    sub-module will be housed in a separate package called
+    Starting in version 1.0, all functions in the ``mne.connectivity``
+    sub-module are housed in a separate package called
     :mod:`mne-connectivity <mne_connectivity>`. Download it by  running:
 
     .. code-block:: console


### PR DESCRIPTION
`main` failed [last night](https://app.circleci.com/pipelines/github/mne-tools/mne-python/11252/workflows/5d9bd225-bb87-4141-876d-b91e8b56d7fd/jobs/37753) because of deps, https://github.com/mne-tools/mne-connectivity/pull/52 fixes it so use that in our doc builds