### PR TITLE
FIX: Respect env var

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -28,7 +28,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Nothing yet
+- Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSE_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1524,7 +1524,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
              show_first_samp=False, proj=True, group_by='type',
              butterfly=False, decim='auto', noise_cov=None, event_id=None,
              show_scrollbars=True, show_scalebars=True, time_format='float',
-             precompute='auto', use_opengl=True, verbose=None):
+             precompute='auto', use_opengl=None, verbose=None):
         return plot_raw(self, events, duration, start, n_channels, bgcolor,
                         color, bad_color, event_color, scalings, remove_dc,
                         order, show_options, title, show, block, highpass,

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1529,11 +1529,12 @@ precompute : bool | str
 """
 
 docdict['use_opengl'] = """
-use_opengl : bool
+use_opengl : bool | None
     Whether to use OpenGL when rendering the plot (requires ``pyopengl``).
     May increase performance, but effect is dependent on system CPU and
-    graphics hardware. Only works if using the pyQtGraph backend. Default is
-    ``True``.
+    graphics hardware. Only works if using the PyQtGraph backend. Default is
+    None, which will use False unless the user configuration variable
+    ``MNE_BROWSE_USE_OPENGL`` is set to ``'true'``, see :func:`mne.set_config`.
 
     .. versionadded:: 0.24
 """

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -36,7 +36,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
              proj=True, group_by='type', butterfly=False, decim='auto',
              noise_cov=None, event_id=None, show_scrollbars=True,
              show_scalebars=True, time_format='float',
-             precompute='auto', use_opengl=True, verbose=None):
+             precompute='auto', use_opengl=None, verbose=None):
     """Plot raw data.
 
     Parameters
@@ -316,6 +316,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
         raise TypeError(f'title must be None or a string, got a {type(title)}')
 
     # gather parameters and initialize figure
+    _validate_type(use_opengl, (bool, None), 'use_opengl')
     params = dict(inst=raw,
                   info=info,
                   # channels and channel order


### PR DESCRIPTION
I realized that #9955 wasn't quite enough. The logic for handling `None` will be implemented by mne-qt-browser. In the meantime (until I can make a PR there and cut a new release today) it will act like False, which should be okay. But let's make sure the CIs agree.