### PR TITLE
MRG, MAINT: Use all conda-forge

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -248,7 +248,7 @@ stages:
     - bash: |
         set -e
         conda remove -c conda-forge --force -yq mne
-        rm /Conda/Scripts/mne.exe
+        rm /Miniconda/Scripts/mne.exe
       condition: eq(variables['TEST_MODE'], 'conda')
       displayName: Remove old MNE
     - script: pip install -e .
@@ -313,7 +313,7 @@ stages:
         conda remove -c conda-forge --force -yq mne
         echo $PATH
         which mne
-        rm /c/Conda/Scripts/mne.exe
+        rm /c/Miniconda/Scripts/mne.exe
       displayName: Remove old MNE
     - script: pip install -e .
       displayName: Install dev MNE

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -248,7 +248,7 @@ stages:
     - bash: |
         set -e
         conda remove -c conda-forge --force -yq mne
-        rm /Miniconda/Scripts/mne.exe
+        rm /c/Miniconda/Scripts/mne.exe
       condition: eq(variables['TEST_MODE'], 'conda')
       displayName: Remove old MNE
     - script: pip install -e .
@@ -311,8 +311,6 @@ stages:
     - bash: |
         set -e
         conda remove -c conda-forge --force -yq mne
-        echo $PATH
-        which mne
         rm /c/Miniconda/Scripts/mne.exe
       displayName: Remove old MNE
     - script: pip install -e .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -248,7 +248,7 @@ stages:
     - script: conda remove -c conda-forge --force -yq mne
       condition: eq(variables['TEST_MODE'], 'conda')
       displayName: Remove old MNE
-    - script: pip install -e .
+    - script: pip install --user -e .
       displayName: 'Install MNE-Python dev'
     - script: pip install --progress-bar off -e .[test] codecov
       condition: eq(variables['TEST_MODE'], 'conda')
@@ -307,7 +307,7 @@ stages:
       displayName: Add graphviz dot
     - script: conda remove -c conda-forge --force -yq mne
       displayName: Remove old MNE
-    - script: pip install -e .
+    - script: pip install --user -e .
       displayName: Install dev MNE
     - script: pip install --progress-bar off -r requirements_doc.txt
       displayName: Install documentation dependencies

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -245,10 +245,13 @@ stages:
     - script: conda env update --name base --file environment.yml
       condition: eq(variables['TEST_MODE'], 'conda')
       displayName: Setup MNE environment
-    - script: conda remove -c conda-forge --force -yq mne
+    - bash: |
+        set -e
+        conda remove -c conda-forge --force -yq mne
+        rm /Conda/Scripts/mne.exe
       condition: eq(variables['TEST_MODE'], 'conda')
       displayName: Remove old MNE
-    - script: pip install --user -e .
+    - script: pip install -e .
       displayName: 'Install MNE-Python dev'
     - script: pip install --progress-bar off -e .[test] codecov
       condition: eq(variables['TEST_MODE'], 'conda')
@@ -305,9 +308,14 @@ stages:
       displayName: Setup MNE environment
     - script: conda install -c conda-forge graphviz
       displayName: Add graphviz dot
-    - script: conda remove -c conda-forge --force -yq mne
+    - bash: |
+        set -e
+        conda remove -c conda-forge --force -yq mne
+        echo $PATH
+        which mne
+        rm /c/Conda/Scripts/mne.exe
       displayName: Remove old MNE
-    - script: pip install --user -e .
+    - script: pip install -e .
       displayName: Install dev MNE
     - script: pip install --progress-bar off -r requirements_doc.txt
       displayName: Install documentation dependencies

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -245,7 +245,7 @@ stages:
     - script: conda env update --name base --file environment.yml
       condition: eq(variables['TEST_MODE'], 'conda')
       displayName: Setup MNE environment
-    - script: conda remove -c conda-forge -yq mne
+    - script: conda remove -c conda-forge --force -yq mne
       condition: eq(variables['TEST_MODE'], 'conda')
       displayName: Remove old MNE
     - script: pip install -e .
@@ -305,7 +305,7 @@ stages:
       displayName: Setup MNE environment
     - script: conda install -c conda-forge graphviz
       displayName: Add graphviz dot
-    - script: conda remove -c conda-forge -yq mne
+    - script: conda remove -c conda-forge --force -yq mne
       displayName: Remove old MNE
     - script: pip install -e .
       displayName: Install dev MNE

--- a/environment.yml
+++ b/environment.yml
@@ -40,6 +40,5 @@ dependencies:
 - mffpy>=0.5.7
 - ipywidgets
 - pooch
-- pip:
-  - ipyvtklink
-  - mne-qt-browser
+- ipyvtklink
+- mne-qt-browser


### PR DESCRIPTION
Now that there is a mne-qt-browser conda-forge package (and ipyvtklink has been up for a while) we shouldn't need `pip`