### PR TITLE
fix missing connectivity image on homepage tile

### DIFF
--- a/doc/_templates/homepage.html
+++ b/doc/_templates/homepage.html
@@ -5,7 +5,7 @@
       <div class="col-12 col-sm-6 col-lg-4 my-2">
         <div class="card frontpage-gallery">
           <a href="{{ item.url }}">
-            <img class="card-img" src="{{ pathto('_images/' + item.img, 1) }}" alt="{{ item.alt }}">
+            <img class="card-img" src="{{ item.img if item.img.startswith('http') else pathto('_images/' + item.img, 1) }}" alt="{{ item.alt }}">
             <div class="card-img-overlay px-3 py-1">
               <p class="lead mb-1 fadeout">{{ item.title }}</p>
               <p class="card-text fadeout">{{ item.text }}</p>


### PR DESCRIPTION
not sure when this crept in but due to the recent release now it's in both stable and dev sites, so I'm marking as backport candidate.