### PR TITLE
MRG, BUG: Fix regression with report due to bbox_inches

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -30,6 +30,8 @@ Bugs
 ~~~~
 - Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSE_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)
 
+- Fix bug with :class:`mne.report.Report` where figures were saved with ``bbox_inches='tight'``, which led to inconsistent sizes in sliders (:gh:`9966` by `Eric Larson`_)
+
 API changes
 ~~~~~~~~~~~
 - Nothing yet

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -30,7 +30,7 @@ Bugs
 ~~~~
 - Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSE_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)
 
-- Fix bug with :class:`mne.report.Report` where figures were saved with ``bbox_inches='tight'``, which led to inconsistent sizes in sliders (:gh:`9966` by `Eric Larson`_)
+- Fix bug with :class:`mne.Report` where figures were saved with ``bbox_inches='tight'``, which led to inconsistent sizes in sliders (:gh:`9966` by `Eric Larson`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -310,8 +310,7 @@ def _fig_to_img(fig, *, image_format='png', auto_close=True):
             message='.*Axes that are not compatible with tight_layout.*',
             category=UserWarning
         )
-        fig.savefig(output, format=image_format, dpi=fig.get_dpi(),
-                    bbox_inches='tight')
+        fig.savefig(output, format=image_format, dpi=fig.get_dpi())
 
     if auto_close:
         plt.close(fig)
@@ -456,8 +455,7 @@ def _plot_ica_properties_as_arrays(*, ica, inst, picks, n_jobs):
 
         with io.BytesIO() as buff:
             fig.savefig(
-                buff, format='png', dpi=fig.get_dpi(), bbox_inches='tight',
-                pad_inches=0
+                buff, format='png', dpi=fig.get_dpi(), pad_inches=0,
             )
             buff.seek(0)
             fig_array = plt.imread(buff, format='png')
@@ -2805,7 +2803,6 @@ class Report(object):
             fig.savefig(
                 buff, format='png',
                 dpi=fig.get_dpi(),
-                bbox_inches='tight',
                 pad_inches=0
             )
             plt.close(fig)


### PR DESCRIPTION
We shouldn't force `bbox_inches='tight'`. The effect is generally small, and if it's big, then people should fix their figures not to waste space. Here's an example of a bad effect (jumping around) on `main`:

![Peek 2021-11-05 11-00](https://user-images.githubusercontent.com/2365790/140532966-760cfad2-c9bc-4429-a61d-3fa0667b8b21.gif)

And it's fixed on this PR (and was fine before the big refactor):

![Peek 2021-11-05 11-06](https://user-images.githubusercontent.com/2365790/140533009-9d2f98a1-cd38-4d77-93af-e3f8c9b9c3c9.gif)


