### PR TITLE
MRG: Add "interaction" param to CoregistrationUI

### DIFF
--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -134,7 +134,6 @@ def coregistration(tabbed=False, split=True, width=None, inst=None,
         'project_eeg': project_eeg,
         'scale_by_distance': scale_by_distance,
         'mark_inside': mark_inside,
-        'interaction': interaction,
         'scale': scale,
         'advanced_rendering': advanced_rendering,
     }
@@ -145,7 +144,7 @@ def coregistration(tabbed=False, split=True, width=None, inst=None,
             to_raise = val is not None
         if to_raise:
             warn(f"The parameter {key} is not supported with"
-                    " the pyvistaqt 3d backend. It will be ignored.")
+                  " the pyvistaqt 3d backend. It will be ignored.")
     config = get_config(home_dir=os.environ.get('_MNE_FAKE_HOME_DIR'))
     if guess_mri_subject is None:
         guess_mri_subject = config.get(

--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -82,12 +82,13 @@ def coregistration(tabbed=False, split=True, width=None, inst=None,
         different color.
 
         .. versionadded:: 0.16
-    interaction : str | None
-        Can be 'terrain' (default None), use terrain-style interaction (where
-        "up" is the Z/superior direction), or 'trackball' to use
-        orientationless interactions.
+    %(scene_interaction_None)s
+        Defaults to ``'terrain'``.
 
         .. versionadded:: 0.16
+        .. versionchanged:: 1.0
+           Default interaction mode if ``None`` and no config setting found
+           changed from ``'trackball'`` to ``'terrain'``.
     scale : float | None
         The scaling for the scene.
 
@@ -177,7 +178,7 @@ def coregistration(tabbed=False, split=True, width=None, inst=None,
         scale_by_distance = (config.get('MNE_COREG_SCALE_BY_DISTANCE', '') ==
                              'true')
     if interaction is None:
-        interaction = config.get('MNE_COREG_INTERACTION', 'trackball')
+        interaction = config.get('MNE_COREG_INTERACTION', 'terrain')
     if mark_inside is None:
         mark_inside = config.get('MNE_COREG_MARK_INSIDE', '') == 'true'
     if scale is None:
@@ -196,7 +197,7 @@ def coregistration(tabbed=False, split=True, width=None, inst=None,
         info_file=inst, subject=subject, subjects_dir=subjects_dir,
         head_resolution=head_high_res, orient_glyphs=orient_to_surface,
         trans=trans, size=(width, height), show=show, standalone=standalone,
-        verbose=verbose
+        interaction=interaction, verbose=verbose
     )
 
 

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -71,6 +71,10 @@ class CoregistrationUI(HasTraits):
         Display the window as soon as it is ready. Defaults to True.
     standalone : bool
         If True, start the Qt application event loop. Default to False.
+    %(scene_interaction)s
+        Defaults to ``'terrain'``.
+
+        .. versionadded:: 1.0
     %(verbose)s
     """
 
@@ -95,7 +99,8 @@ class CoregistrationUI(HasTraits):
                  head_transparency=None, hpi_coils=None,
                  head_shape_points=None, eeg_channels=None, orient_glyphs=None,
                  sensor_opacity=None, trans=None, size=None, bgcolor=None,
-                 show=True, standalone=False, verbose=None):
+                 show=True, standalone=False, interaction='terrain',
+                 verbose=None):
         from ..viz.backends.renderer import _get_renderer
 
         def _get_default(var, val):
@@ -156,6 +161,7 @@ class CoregistrationUI(HasTraits):
         self._renderer = _get_renderer(
             size=self._defaults["size"], bgcolor=self._defaults["bgcolor"])
         self._renderer._window_close_connect(self._clean)
+        self._renderer.set_interaction(interaction)
 
         # setup the model
         self._info = info

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1906,6 +1906,25 @@ views : str | list
     Using multiple views (list) is not supported for mpl backend.
 """
 
+# Coregistration
+scene_interaction_common = """\
+    How interactions with the scene via an input device (e.g., mouse or
+    trackpad) modify the camera position. If ``'terrain'``, one axis is
+    fixed, enabling "turntable-style" rotations. If ``'trackball'``,
+    movement along all axes is possible, which provides more freedom of
+    movement, but you may incidentally perform unintentional rotations along
+    some axes.
+"""
+docdict['scene_interaction'] = f"""
+interaction : 'trackball' | 'terrain'
+{scene_interaction_common}
+"""
+docdict['scene_interaction_None'] = f"""
+interaction : 'trackball' | 'terrain' | None
+{scene_interaction_common}
+If ``None``, the setting stored in the MNE-Python configuration file is used.
+"""
+
 # STC label time course
 docdict['eltc_labels'] = """
 labels : Label | BiHemiLabel | list | tuple | str

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1913,7 +1913,7 @@ scene_interaction_common = """\
     fixed, enabling "turntable-style" rotations. If ``'trackball'``,
     movement along all axes is possible, which provides more freedom of
     movement, but you may incidentally perform unintentional rotations along
-    some axes.
+    some axes.\
 """
 docdict['scene_interaction'] = f"""
 interaction : 'trackball' | 'terrain'
@@ -1922,7 +1922,8 @@ interaction : 'trackball' | 'terrain'
 docdict['scene_interaction_None'] = f"""
 interaction : 'trackball' | 'terrain' | None
 {scene_interaction_common}
-If ``None``, the setting stored in the MNE-Python configuration file is used.
+    If ``None``, the setting stored in the MNE-Python configuration file is
+    used.
 """
 
 # STC label time course

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -695,7 +695,7 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
     # initialize figure
     renderer = _get_renderer(fig, name=f'Sensor alignment: {subject}',
                              bgcolor=(0.5, 0.5, 0.5), size=(800, 800))
-    renderer.set_interaction('terrain')
+    renderer.set_interaction(interaction)
 
     # plot head
     _, _, head_surf = _plot_head_surface(

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -497,9 +497,7 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
         If ``None``, creates a new 600x600 pixel figure with black background.
 
         .. versionadded:: 0.16
-    interaction : str
-        Can be "trackball" (default) or "terrain", i.e. a turntable-style
-        camera.
+    %(scene_interaction)s
 
         .. versionadded:: 0.16
     %(verbose)s
@@ -697,8 +695,7 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
     # initialize figure
     renderer = _get_renderer(fig, name=f'Sensor alignment: {subject}',
                              bgcolor=(0.5, 0.5, 0.5), size=(800, 800))
-    if interaction == 'terrain':
-        renderer.set_interaction('terrain')
+    renderer.set_interaction('terrain')
 
     # plot head
     _, _, head_surf = _plot_head_surface(


### PR DESCRIPTION
This adds an `interaction` kwarg to `CoregistrationUI`. `mne.gui.coregistration()` in `main` simply ignores its `interaction` parameter and doesn't pass it to `CoregistrationUI`. This PR fixes this behavior.

Following a recent conversation with @larsoner, this also changes the default interaction style to `'terrain'`.

In the `'terrain'` interaction mode, zooming by scrolling up/down with the mouse doesn't work for me on macOS, so this needs to be fixed.

```python
# %%
import mne

mne.gui.coregistration(interaction='trackball')  # behaves like `main`
```
https://user-images.githubusercontent.com/2046265/140620892-741b4d4a-72f8-4102-a7e2-9e8f7fcc5bc2.mov


```python
# %%
import mne

mne.gui.coregistration(interaction='terrain')  # new default
```
https://user-images.githubusercontent.com/2046265/140620903-d60ec482-7c43-4ef5-bf31-7f423817b4c8.mov


cc @agramfort 