### PR TITLE
MRG: Add argument overwrite to export for raws and epochs to match save.

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -36,7 +36,6 @@ Bugs
 
 - Add argument ``overwrite`` to :func:`mne.export.export_raw` and :func:`mne.export.export_epochs` (:gh:`9975` by `Mathieu Scheltienne`_)
 
-
 API changes
 ~~~~~~~~~~~
 - Nothing yet

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -26,6 +26,8 @@ Enhancements
 
 - Add show local maxima toggling button to :func:`mne.gui.locate_ieeg` (:gh:`9952` by `Alex Rockhill`_)
 
+- Add argment ``overwrite`` to :func:`mne.export.export_raw` and :func:`mne.export.export_epochs` (:gh:`9975` by `Mathieu Scheltienne`_)
+
 Bugs
 ~~~~
 - Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSE_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -26,8 +26,6 @@ Enhancements
 
 - Add show local maxima toggling button to :func:`mne.gui.locate_ieeg` (:gh:`9952` by `Alex Rockhill`_)
 
-- Add argment ``overwrite`` to :func:`mne.export.export_raw` and :func:`mne.export.export_epochs` (:gh:`9975` by `Mathieu Scheltienne`_)
-
 Bugs
 ~~~~
 - Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSE_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)
@@ -35,6 +33,9 @@ Bugs
 - Fix bug with :class:`mne.Report` where figures were saved with ``bbox_inches='tight'``, which led to inconsistent sizes in sliders (:gh:`9966` by `Eric Larson`_)
 
 - Fix bug in :func:`mne.make_forward_solution` where sensor-sphere geometry check was incorrect (:gh:`9968` by `Eric Larson`_)
+
+- Add argument ``overwrite`` to :func:`mne.export.export_raw` and :func:`mne.export.export_epochs` (:gh:`9975` by `Mathieu Scheltienne`_)
+
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -38,7 +38,7 @@ Bugs
 
 - Fix bug in :func:`mne.make_forward_solution` where sensor-sphere geometry check was incorrect (:gh:`9968` by `Eric Larson`_)
 
-- Add argument ``overwrite`` to :func:`mne.export.export_raw` and :func:`mne.export.export_epochs` (:gh:`9975` by `Mathieu Scheltienne`_)
+- Add argument ``overwrite`` to :func:`mne.export.export_raw`, :func:`mne.export.export_epochs`, :func:`mne.export.export_evokeds` and :func:`mne.export.export_evokeds_mff` (:gh:`9975` by `Mathieu Scheltienne`_)
 
 - :func:`mne.gui.coregistration` and the ``mne coreg`` command didn't respect the ``inspect`` parameter (:gh:`9972` by `Richard Höchenberger`_)
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1926,7 +1926,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         %(export_params_fmt)s
         %(overwrite)s
 
-        .. versionadded:: 1.0
+            .. versionadded:: 1.0
         %(verbose)s
 
         Notes

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1934,7 +1934,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         %(export_eeglab_note)s
         """
         from .export import export_epochs
-        export_epochs(fname, self, fmt, overwrite, verbose)
+        export_epochs(fname, self, fmt, overwrite=overwrite, verbose=verbose)
 
     def equalize_event_counts(self, event_ids=None, method='mintime'):
         """Equalize the number of trials in each condition.

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1914,7 +1914,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                         split_naming, overwrite)
 
     @verbose
-    def export(self, fname, fmt='auto', verbose=None):
+    def export(self, fname, fmt='auto', overwrite=False, verbose=None):
         """Export Epochs to external formats.
 
         Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
@@ -1924,6 +1924,9 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         ----------
         %(export_params_fname)s
         %(export_params_fmt)s
+        %(overwrite)s
+
+        .. versionadded:: 1.0
         %(verbose)s
 
         Notes
@@ -1931,7 +1934,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         %(export_eeglab_note)s
         """
         from .export import export_epochs
-        export_epochs(fname, self, fmt, verbose)
+        export_epochs(fname, self, fmt, overwrite, verbose)
 
     def equalize_event_counts(self, event_ids=None, method='mintime'):
         """Equalize the number of trials in each condition.

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1914,7 +1914,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                         split_naming, overwrite)
 
     @verbose
-    def export(self, fname, fmt='auto', overwrite=False, verbose=None):
+    def export(self, fname, fmt='auto', *, overwrite=False, verbose=None):
         """Export Epochs to external formats.
 
         Supported formats: EEGLAB (set, uses :mod:`eeglabio`)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1926,7 +1926,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         %(export_params_fmt)s
         %(overwrite)s
 
-            .. versionadded:: 1.0
+            .. versionadded:: 0.24.1
         %(verbose)s
 
         Notes

--- a/mne/export/_eeglab.py
+++ b/mne/export/_eeglab.py
@@ -27,7 +27,7 @@ def _export_raw(fname, raw):
                    raw.annotations.onset,
                    raw.annotations.duration]
     eeglabio.raw.export_set(
-        fname, data=raw.get_data(picks=ch_names), sfreq=raw.info['sfreq'],
+        str(fname), data=raw.get_data(picks=ch_names), sfreq=raw.info['sfreq'],
         ch_names=ch_names, ch_locs=cart_coords, annotations=annotations)
 
 
@@ -42,7 +42,7 @@ def _export_epochs(fname, epochs):
     cart_coords = _get_als_coords_from_chs(epochs.info['chs'], drop_chs)
 
     eeglabio.epochs.export_set(
-        fname, data=epochs.get_data(picks=ch_names),
+        str(fname), data=epochs.get_data(picks=ch_names),
         sfreq=epochs.info['sfreq'], events=epochs.events,
         tmin=epochs.tmin, tmax=epochs.tmax, ch_names=ch_names,
         event_id=epochs.event_id, ch_locs=cart_coords)

--- a/mne/export/_eeglab.py
+++ b/mne/export/_eeglab.py
@@ -27,7 +27,7 @@ def _export_raw(fname, raw):
                    raw.annotations.onset,
                    raw.annotations.duration]
     eeglabio.raw.export_set(
-        str(fname), data=raw.get_data(picks=ch_names), sfreq=raw.info['sfreq'],
+        fname, data=raw.get_data(picks=ch_names), sfreq=raw.info['sfreq'],
         ch_names=ch_names, ch_locs=cart_coords, annotations=annotations)
 
 
@@ -42,7 +42,7 @@ def _export_epochs(fname, epochs):
     cart_coords = _get_als_coords_from_chs(epochs.info['chs'], drop_chs)
 
     eeglabio.epochs.export_set(
-        str(fname), data=epochs.get_data(picks=ch_names),
+        fname, data=epochs.get_data(picks=ch_names),
         sfreq=epochs.info['sfreq'], events=epochs.events,
         tmin=epochs.tmin, tmax=epochs.tmax, ch_names=ch_names,
         event_id=epochs.event_id, ch_locs=cart_coords)

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -55,13 +55,9 @@ def export_evokeds_mff(fname, evoked, history=None, *, overwrite=False,
     # Initialize writer
     # Future changes: conditions based on version or mffpy requirement if
     # https://github.com/BEL-Public/mffpy/pull/92 is merged and released.
-    try:
-        fname = _check_fname(fname, overwrite=False)
-    except FileExistsError:
-        if overwrite:
-            shutil.rmtree(fname)
-        else:
-            raise
+    fname = _check_fname(fname, overwrite=overwrite)
+    if op.exists(fname):
+        os.remove(fname) if op.isfile(fname) else shutil.rmtree(fname)
     writer = mffpy.Writer(fname)
     current_time = pytz.utc.localize(datetime.datetime.utcnow())
     writer.addxml('fileInfo', recordTime=current_time)

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -62,7 +62,7 @@ def export_evokeds_mff(fname, evoked, history=None, overwrite=False, *,
             os.remove(fname)
         else:
             raise
-    else:
+    finally:
         writer = mffpy.Writer(fname)
     current_time = pytz.utc.localize(datetime.datetime.utcnow())
     writer.addxml('fileInfo', recordTime=current_time)

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -53,8 +53,8 @@ def export_evokeds_mff(fname, evoked, history=None, overwrite=False, *,
     sampling_rate = int(info['sfreq'])
 
     # Initialize writer
-    # Conditions to be changed based on version if
-    # https://github.com/BEL-Public/mffpy/pull/92 is merged and release.
+    # Future changes: conditions based on version or mffpy requirement if
+    # https://github.com/BEL-Public/mffpy/pull/92 is merged and released.
     try:
         fname = _check_fname(fname, overwrite=False)
     except FileExistsError:

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -3,7 +3,7 @@
 #
 # License: BSD-3-Clause
 
-import os
+import shutil
 import datetime
 
 import numpy as np
@@ -59,7 +59,7 @@ def export_evokeds_mff(fname, evoked, history=None, overwrite=False, *,
         fname = _check_fname(fname, overwrite=False)
     except FileExistsError:
         if overwrite:
-            os.remove(fname)
+            shutil.rmtree(fname)
         else:
             raise
     finally:

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -62,8 +62,7 @@ def export_evokeds_mff(fname, evoked, history=None, overwrite=False, *,
             shutil.rmtree(fname)
         else:
             raise
-    finally:
-        writer = mffpy.Writer(fname)
+    writer = mffpy.Writer(fname)
     current_time = pytz.utc.localize(datetime.datetime.utcnow())
     writer.addxml('fileInfo', recordTime=current_time)
     try:

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -3,8 +3,10 @@
 #
 # License: BSD-3-Clause
 
+import os
 import shutil
 import datetime
+import os.path as op
 
 import numpy as np
 

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -14,7 +14,7 @@ from ..utils import verbose, _check_fname
 
 
 @verbose
-def export_evokeds_mff(fname, evoked, history=None, overwrite=False, *,
+def export_evokeds_mff(fname, evoked, history=None, *, overwrite=False,
                        verbose=None):
     """Export evoked dataset to MFF.
 

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -95,7 +95,7 @@ def export_epochs(fname, epochs, fmt='auto', *, overwrite=False, verbose=None):
 
 
 @verbose
-def export_evokeds(fname, evoked, fmt='auto', overwrite=False, verbose=None):
+def export_evokeds(fname, evoked, fmt='auto', *, overwrite=False, verbose=None):
     """Export evoked dataset to external formats.
 
     This function is a wrapper for format-specific export functions. The export

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -29,7 +29,7 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
     %(export_params_add_ch_type)s
     %(overwrite)s
 
-    .. versionadded:: 1.0
+        .. versionadded:: 1.0
     %(verbose)s
 
     Notes
@@ -70,7 +70,7 @@ def export_epochs(fname, epochs, fmt='auto', overwrite=False, verbose=None):
     %(export_params_fmt)s
     %(overwrite)s
 
-    .. versionadded:: 1.0
+        .. versionadded:: 1.0
     %(verbose)s
 
     Notes

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -95,7 +95,8 @@ def export_epochs(fname, epochs, fmt='auto', *, overwrite=False, verbose=None):
 
 
 @verbose
-def export_evokeds(fname, evoked, fmt='auto', *, overwrite=False, verbose=None):
+def export_evokeds(fname, evoked, fmt='auto', *, overwrite=False,
+                   verbose=None):
     """Export evoked dataset to external formats.
 
     This function is a wrapper for format-specific export functions. The export

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -56,7 +56,7 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
 
 
 @verbose
-def export_epochs(fname, epochs, fmt='auto', overwrite=False, verbose=None):
+def export_epochs(fname, epochs, fmt='auto', *, overwrite=False, verbose=None):
     """Export Epochs to external formats.
 
     Supported formats: EEGLAB (set, uses :mod:`eeglabio`)

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -29,7 +29,7 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
     %(export_params_add_ch_type)s
     %(overwrite)s
 
-        .. versionadded:: 1.0
+        .. versionadded:: 0.24.1
     %(verbose)s
 
     Notes
@@ -70,7 +70,7 @@ def export_epochs(fname, epochs, fmt='auto', overwrite=False, verbose=None):
     %(export_params_fmt)s
     %(overwrite)s
 
-        .. versionadded:: 1.0
+        .. versionadded:: 0.24.1
     %(verbose)s
 
     Notes

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -95,7 +95,7 @@ def export_epochs(fname, epochs, fmt='auto', overwrite=False, verbose=None):
 
 
 @verbose
-def export_evokeds(fname, evoked, fmt='auto', verbose=None):
+def export_evokeds(fname, evoked, fmt='auto', overwrite=False, verbose=None):
     """Export evoked dataset to external formats.
 
     This function is a wrapper for format-specific export functions. The export
@@ -117,6 +117,9 @@ def export_evokeds(fname, evoked, fmt='auto', verbose=None):
         Format of the export. Defaults to ``'auto'``, which will infer the
         format from the filename extension. See supported formats above for
         more information.
+    %(overwrite)s
+
+        .. versionadded:: 0.24.1
     %(verbose)s
 
     See Also
@@ -128,6 +131,7 @@ def export_evokeds(fname, evoked, fmt='auto', verbose=None):
     -----
     .. versionadded:: 0.24
     """
+    fname = _check_fname(fname, overwrite=overwrite)
     supported_export_formats = {
         'mff': ('mff',),
         'eeglab': ('set',),
@@ -142,7 +146,7 @@ def export_evokeds(fname, evoked, fmt='auto', verbose=None):
     logger.info(f'Exporting evoked dataset to {fname}...')
 
     if fmt == 'mff':
-        export_evokeds_mff(fname, evoked)
+        export_evokeds_mff(fname, evoked, overwrite=overwrite)
     elif fmt == 'eeglab':
         raise NotImplementedError('Export to EEGLAB not implemented.')
     elif fmt == 'edf':

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -11,7 +11,7 @@ from ..utils import verbose, logger, _validate_type, _check_fname
 
 @verbose
 def export_raw(fname, raw, fmt='auto', physical_range='auto',
-               add_ch_type=False, overwrite=False, verbose=None):
+               add_ch_type=False, *, overwrite=False, verbose=None):
     """Export Raw to external formats.
 
     Supported formats:

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -56,7 +56,7 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
 
 
 @verbose
-def export_epochs(fname, epochs, fmt='auto', verbose=None):
+def export_epochs(fname, epochs, fmt='auto', overwrite=False, verbose=None):
     """Export Epochs to external formats.
 
     Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
@@ -68,12 +68,16 @@ def export_epochs(fname, epochs, fmt='auto', verbose=None):
     epochs : instance of Epochs
         The epochs to export.
     %(export_params_fmt)s
+    %(overwrite)s
+
+    .. versionadded:: 1.0
     %(verbose)s
 
     Notes
     -----
     %(export_eeglab_note)s
     """
+    fname = _check_fname(fname, overwrite=overwrite)
     supported_export_formats = {
         'eeglab': ('set',),
         'edf': ('edf',),

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -6,12 +6,12 @@
 import os.path as op
 
 from ._egimff import export_evokeds_mff
-from ..utils import verbose, logger, _validate_type
+from ..utils import verbose, logger, _validate_type, _check_fname
 
 
 @verbose
 def export_raw(fname, raw, fmt='auto', physical_range='auto',
-               add_ch_type=False, verbose=None):
+               add_ch_type=False, overwrite=False, verbose=None):
     """Export Raw to external formats.
 
     Supported formats:
@@ -27,6 +27,9 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
     %(export_params_fmt)s
     %(export_params_physical_range)s
     %(export_params_add_ch_type)s
+    %(overwrite)s
+
+    .. versionadded:: 1.0
     %(verbose)s
 
     Notes
@@ -34,6 +37,7 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
     %(export_eeglab_note)s
     %(export_edf_note)s
     """
+    fname = _check_fname(fname, overwrite=overwrite)
     supported_export_formats = {  # format : extensions
         'eeglab': ('set',),
         'edf': ('edf',),

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -51,6 +51,11 @@ def test_export_raw_eeglab(tmp_path):
     assert_allclose(raw.times, raw_read.times)
     assert_allclose(raw.get_data(), raw_read.get_data())
 
+    # test overwrite
+    with pytest.raises(FileExistsError, match='Destination file exists'):
+        raw.export(temp_fname, overwrite=False)
+    raw.export(temp_fname, overwrite=True)
+
 
 @pytest.mark.skipif(not _check_edflib_installed(strict=False),
                     reason='edflib-python not installed')
@@ -312,6 +317,11 @@ def test_export_epochs_eeglab(tmp_path, preload):
     assert epochs.event_id.keys() == epochs_read.event_id.keys()  # just keys
     assert_allclose(epochs.times, epochs_read.times)
     assert_allclose(epochs.get_data(), epochs_read.get_data())
+
+    # test overwrite
+    with pytest.raises(FileExistsError, match='Destination file exists'):
+        epochs.export(temp_fname, overwrite=False)
+    epochs.export(temp_fname, overwrite=True)
 
 
 @requires_version('mffpy', '0.5.7')

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -83,7 +83,7 @@ def test_double_export_edf(tmp_path):
 
     # export again
     raw_read.load_data()
-    raw_read.export(temp_fname, add_ch_type=True)
+    raw_read.export(temp_fname, add_ch_type=True, overwrite=True)
     raw_read = read_raw_edf(temp_fname, preload=True)
 
     # stim channel should be dropped
@@ -185,28 +185,28 @@ def test_rawarray_edf(tmp_path):
     raw_bad.rename_channels({'1': 'abcdefghijklmnopqrstuvwxyz'})
     with pytest.raises(RuntimeError, match='Signal label'), \
             pytest.warns(RuntimeWarning, match='Data has a non-integer'):
-        raw_bad.export(temp_fname)
+        raw_bad.export(temp_fname, overwrite=True)
 
     # include bad birthday that is non-EDF compliant
     bad_info = info.copy()
     bad_info['subject_info']['birthday'] = (1700, 1, 20)
     raw = RawArray(data, bad_info)
     with pytest.raises(RuntimeError, match='Setting patient birth date'):
-        raw.export(temp_fname)
+        raw.export(temp_fname, overwrite=True)
 
     # include bad measurement date that is non-EDF compliant
     raw = RawArray(data, info)
     meas_date = datetime(year=1984, month=1, day=1, tzinfo=timezone.utc)
     raw.set_meas_date(meas_date)
     with pytest.raises(RuntimeError, match='Setting start date time'):
-        raw.export(temp_fname)
+        raw.export(temp_fname, overwrite=True)
 
     # test that warning is raised if there are non-voltage based channels
     raw = RawArray(data, info)
     with pytest.warns(RuntimeWarning, match='The unit'):
         raw.set_channel_types({'9': 'hbr'})
     with pytest.warns(RuntimeWarning, match='Non-voltage channels'):
-        raw.export(temp_fname)
+        raw.export(temp_fname, overwrite=True)
 
     # data should match up to the non-accepted channel
     raw_read = read_raw_edf(temp_fname, preload=True)

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -365,6 +365,20 @@ def test_export_evokeds_to_mff(tmp_path, fmt, do_history):
         assert ave_exported.comment == ave.comment
         assert_allclose(ave_exported.times, ave.times)
 
+    # test overwrite
+    with pytest.raises(FileExistsError, match='Destination file exists'):
+        if do_history:
+            export_evokeds_mff(export_fname, evoked, history=history,
+                               overwrite=False)
+        else:
+            export_evokeds(export_fname, evoked, overwrite=False)
+
+    if do_history:
+        export_evokeds_mff(export_fname, evoked, history=history,
+                           overwrite=True)
+    else:
+        export_evokeds(export_fname, evoked, overwrite=True)
+
 
 @requires_version('mffpy', '0.5.7')
 @testing.requires_testing_data

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -326,6 +326,9 @@ def test_export_epochs_eeglab(tmp_path, preload):
         epochs.export(temp_fname, overwrite=False)
     epochs.export(temp_fname, overwrite=True)
 
+    # test pathlib.Path files
+    epochs.export(Path(temp_fname), overwrite=True)
+
 
 @requires_version('mffpy', '0.5.7')
 @testing.requires_testing_data

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -56,6 +56,9 @@ def test_export_raw_eeglab(tmp_path):
         raw.export(temp_fname, overwrite=False)
     raw.export(temp_fname, overwrite=True)
 
+    # test pathlib.Path files
+    raw.export(Path(temp_fname), overwrite=True)
+
 
 @pytest.mark.skipif(not _check_edflib_installed(strict=False),
                     reason='edflib-python not installed')

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1492,7 +1492,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(export_params_add_ch_type)s
         %(overwrite)s
 
-            .. versionadded:: 1.0
+            .. versionadded:: 0.24.1
         %(verbose)s
 
         Notes

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1478,7 +1478,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
     @verbose
     def export(self, fname, fmt='auto', physical_range='auto',
-               add_ch_type=False, overwrite=False, verbose=None):
+               add_ch_type=False, *, overwrite=False, verbose=None):
         """Export Raw to external formats.
 
         Supported formats: EEGLAB (set, uses :mod:`eeglabio`)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1492,7 +1492,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(export_params_add_ch_type)s
         %(overwrite)s
 
-        .. versionadded:: 1.0
+            .. versionadded:: 1.0
         %(verbose)s
 
         Notes

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1478,7 +1478,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
     @verbose
     def export(self, fname, fmt='auto', physical_range='auto',
-               add_ch_type=False, verbose=None):
+               add_ch_type=False, overwrite=False, verbose=None):
         """Export Raw to external formats.
 
         Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
@@ -1490,6 +1490,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(export_params_fmt)s
         %(export_params_physical_range)s
         %(export_params_add_ch_type)s
+        %(overwrite)s
+
+        .. versionadded:: 1.0
         %(verbose)s
 
         Notes
@@ -1499,7 +1502,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """
         from ..export import export_raw
         export_raw(fname, self, fmt, physical_range=physical_range,
-                   add_ch_type=add_ch_type, verbose=verbose)
+                   add_ch_type=add_ch_type, overwrite=overwrite,
+                   verbose=verbose)
 
     def _tmin_tmax_to_start_stop(self, tmin, tmax):
         start = int(np.floor(tmin * self.info['sfreq']))


### PR DESCRIPTION
I have to do a couple of I/O roundtrips to EEGLAB, and I could use an `overwrite` argument, set to False by default, for the export methods as in `inst.save` to prevent unintentional exports.

For `inst.save`, when overwrite was added, it was first initialized to True for one version and then changed to False.

> This defaults to True in 0.18 but will change to False in 0.19.
> New in version 0.18.

If you agree with the addition of this argument, do you want to follow the same path?