### PR TITLE
[MAINT, MRG] Fix Dipy link

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -155,8 +155,8 @@ intersphinx_mapping = {
     'picard': ('https://pierreablin.github.io/picard/', None),
     'qdarkstyle': ('https://qdarkstylesheet.readthedocs.io/en/latest', None),
     'eeglabio': ('https://eeglabio.readthedocs.io/en/latest', None),
-    'dipy': ('https://dipy.org/documentation/1.4.0./',
-             'https://dipy.org/documentation/1.4.0./objects.inv/'),
+    'dipy': ('https://dipy.org/documentation/latest/documentation',
+             'https://dipy.org/documentation/latest/objects.inv/'),
     'pooch': ('https://www.fatiando.org/pooch/latest/', None),
 }
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -155,8 +155,8 @@ intersphinx_mapping = {
     'picard': ('https://pierreablin.github.io/picard/', None),
     'qdarkstyle': ('https://qdarkstylesheet.readthedocs.io/en/latest', None),
     'eeglabio': ('https://eeglabio.readthedocs.io/en/latest', None),
-    'dipy': ('https://dipy.org/documentation/latest/documentation',
-             'https://dipy.org/documentation/latest/objects.inv/'),
+    'dipy': ('https://dipy.org/documentation/latest',
+             'https://dipy.org/documentation/latest/objects.inv'),
     'pooch': ('https://www.fatiando.org/pooch/latest/', None),
 }
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -155,8 +155,8 @@ intersphinx_mapping = {
     'picard': ('https://pierreablin.github.io/picard/', None),
     'qdarkstyle': ('https://qdarkstylesheet.readthedocs.io/en/latest', None),
     'eeglabio': ('https://eeglabio.readthedocs.io/en/latest', None),
-    'dipy': ('https://dipy.org/documentation/latest',
-             'https://dipy.org/documentation/latest/objects.inv'),
+    'dipy': ('https://dipy.org/documentation/latest/',
+             'https://dipy.org/documentation/latest/objects.inv/'),
     'pooch': ('https://www.fatiando.org/pooch/latest/', None),
 }
 


### PR DESCRIPTION
Related to https://github.com/dipy/dipy/issues/2483. This will keep the documentation link to `Dipy` from going out of date every release.