### PR TITLE
MNT: mne-qt-browser config and doc

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -32,7 +32,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSE_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)
+- Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSER_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)
 
 - Fix bug with :class:`mne.Report` where figures were saved with ``bbox_inches='tight'``, which led to inconsistent sizes in sliders (:gh:`9966` by `Eric Larson`_)
 

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -68,9 +68,9 @@ def set_memmap_min_size(memmap_min_size):
 # List the known configuration values
 known_config_types = (
     'MNE_3D_OPTION_ANTIALIAS',
-    'MNE_BROWSE_RAW_SIZE',
-    'MNE_BROWSE_BACKEND',
-    'MNE_BROWSE_USE_OPENGL',
+    'MNE_BROWSER_SIZE',
+    'MNE_BROWSER_BACKEND',
+    'MNE_BROWSER_USE_OPENGL',
     'MNE_CACHE_DIR',
     'MNE_COREG_ADVANCED_RENDERING',
     'MNE_COREG_COPY_ANNOT',

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -68,7 +68,7 @@ def set_memmap_min_size(memmap_min_size):
 # List the known configuration values
 known_config_types = (
     'MNE_3D_OPTION_ANTIALIAS',
-    'MNE_BROWSER_SIZE',
+    'MNE_BROWSE_RAW_SIZE',
     'MNE_BROWSER_BACKEND',
     'MNE_BROWSER_USE_OPENGL',
     'MNE_CACHE_DIR',

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1525,7 +1525,7 @@ precompute : bool | str
     processor thread, instead of window-by-window during scrolling. The default
     ``'auto'`` compares available RAM space to the expected size of the
     precomputed data, and precomputes only if enough RAM is available. ``True``
-    and ``'auto'`` only work if using the pyQtGraph backend.
+    and ``'auto'`` only work if using the PyQtGraph backend.
 
     .. versionadded:: 0.24
 """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1536,7 +1536,7 @@ use_opengl : bool | None
     May increase performance, but effect is dependent on system CPU and
     graphics hardware. Only works if using the PyQtGraph backend. Default is
     None, which will use False unless the user configuration variable
-    ``MNE_BROWSE_USE_OPENGL`` is set to ``'true'``, see :func:`mne.set_config`.
+    ``MNE_BROWSER_USE_OPENGL`` is set to ``'true'``, see :func:`mne.set_config`.
 
     .. versionadded:: 0.24
 """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1536,7 +1536,7 @@ use_opengl : bool | None
     May increase performance, but effect is dependent on system CPU and
     graphics hardware. Only works if using the PyQtGraph backend. Default is
     None, which will use False unless the user configuration variable
-    ``MNE_BROWSER_USE_OPENGL`` is set to ``'true'``, 
+    ``MNE_BROWSER_USE_OPENGL`` is set to ``'true'``,
     see :func:`mne.set_config`.
 
     .. versionadded:: 0.24

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1536,7 +1536,8 @@ use_opengl : bool | None
     May increase performance, but effect is dependent on system CPU and
     graphics hardware. Only works if using the PyQtGraph backend. Default is
     None, which will use False unless the user configuration variable
-    ``MNE_BROWSER_USE_OPENGL`` is set to ``'true'``, see :func:`mne.set_config`.
+    ``MNE_BROWSER_USE_OPENGL`` is set to ``'true'``, 
+    see :func:`mne.set_config`.
 
     .. versionadded:: 0.24
 """

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -22,7 +22,7 @@ from ..io.pick import _DATA_CH_TYPES_SPLIT
 from .backends._utils import VALID_BROWSE_BACKENDS
 from .utils import _get_color_list, _setup_plot_projector
 
-MNE_BROWSE_BACKEND = None
+MNE_BROWSER_BACKEND = None
 backend = None
 
 
@@ -406,7 +406,7 @@ class BrowserBase(ABC):
                                     for ch in self.mne.info['bads']]
         # write window size to config
         str_size = ','.join([str(i) for i in self._get_size()])
-        set_config('MNE_BROWSE_RAW_SIZE', str_size, set_env=False)
+        set_config('MNE_BROWSER_SIZE', str_size, set_env=False)
         # Clean up child figures (don't pop(), child figs remove themselves)
         while len(self.mne.child_figs):
             fig = self.mne.child_figs[-1]
@@ -677,25 +677,25 @@ def set_browser_backend(backend_name, verbose=None):
 
     .. versionadded:: 0.24
     """
-    global MNE_BROWSE_BACKEND
-    old_backend_name = MNE_BROWSE_BACKEND
+    global MNE_BROWSER_BACKEND
+    old_backend_name = MNE_BROWSER_BACKEND
     backend_name = _check_browser_backend_name(backend_name)
-    if MNE_BROWSE_BACKEND != backend_name:
+    if MNE_BROWSER_BACKEND != backend_name:
         _load_backend(backend_name)
-        MNE_BROWSE_BACKEND = backend_name
+        MNE_BROWSER_BACKEND = backend_name
 
     return old_backend_name
 
 
 def _init_browser_backend():
-    global MNE_BROWSE_BACKEND
+    global MNE_BROWSER_BACKEND
 
-    # check if MNE_BROWSE_BACKEND is not None and valid or get it from config
-    loaded_backend = (MNE_BROWSE_BACKEND or
-                      get_config(key='MNE_BROWSE_BACKEND', default=None))
+    # check if MNE_BROWSER_BACKEND is not None and valid or get it from config
+    loaded_backend = (MNE_BROWSER_BACKEND or
+                      get_config(key='MNE_BROWSER_BACKEND', default=None))
     if loaded_backend is not None:
         set_browser_backend(loaded_backend)
-        return MNE_BROWSE_BACKEND
+        return MNE_BROWSER_BACKEND
     else:
         errors = dict()
         # Try import of valid browser backends
@@ -705,14 +705,14 @@ def _init_browser_backend():
             except ImportError as exc:
                 errors[name] = str(exc)
             else:
-                MNE_BROWSE_BACKEND = name
+                MNE_BROWSER_BACKEND = name
                 break
         else:
             raise RuntimeError(
                 'Could not load any valid 2D backend:\n' +
                 '\n'.join(f'{key}: {val}' for key, val in errors.items()))
 
-        return MNE_BROWSE_BACKEND
+        return MNE_BROWSER_BACKEND
 
 
 def get_browser_backend():

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -406,7 +406,7 @@ class BrowserBase(ABC):
                                     for ch in self.mne.info['bads']]
         # write window size to config
         str_size = ','.join([str(i) for i in self._get_size()])
-        set_config('MNE_BROWSER_SIZE', str_size, set_env=False)
+        set_config('MNE_BROWSE_RAW_SIZE', str_size, set_env=False)
         # Clean up child figures (don't pop(), child figs remove themselves)
         while len(self.mne.child_figs):
             fig = self.mne.child_figs[-1]

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -180,7 +180,8 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
 
     Returns
     -------
-    fig : instance of matplotlib.figure.Figure | ``PyQt5.QtWidgets.QMainWindow``
+    fig : instance of matplotlib.figure.Figure |
+          ``PyQt5.QtWidgets.QMainWindow``
         Browser instance.
 
     Notes

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -180,8 +180,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
 
     Returns
     -------
-    fig : instance of matplotlib.figure.Figure |
-          ``PyQt5.QtWidgets.QMainWindow``
+    fig : matplotlib.figure.Figure | ``PyQt5.QtWidgets.QMainWindow``
         Browser instance.
 
     Notes

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -180,8 +180,8 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
 
     Returns
     -------
-    fig : instance of matplotlib.figure.Figure | QWidget
-        Raw traces.
+    fig : instance of matplotlib.figure.Figure | ``PyQt5.QtWidgets.QMainWindow``
+        Browser instance.
 
     Notes
     -----

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -180,7 +180,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
 
     Returns
     -------
-    fig : instance of matplotlib.figure.Figure
+    fig : instance of matplotlib.figure.Figure | QWidget
         Raw traces.
 
     Notes

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -834,15 +834,15 @@ def test_plot_sensors(raw):
 @pytest.mark.parametrize('cfg_value', (None, '0.1,0.1'))
 def test_min_window_size(raw, cfg_value, browser_backend):
     """Test minimum window plot size."""
-    old_cfg = get_config('MNE_BROWSER_SIZE')
-    set_config('MNE_BROWSER_SIZE', cfg_value)
+    old_cfg = get_config('MNE_BROWSE_RAW_SIZE')
+    set_config('MNE_BROWSE_RAW_SIZE', cfg_value)
     fig = raw.plot()
     # For an unknown reason, the Windows-CI is a bit off
     # (on local Windows 10 the size is exactly as expected).
     atol = 0 if not os.name == 'nt' else 0.2
     # 8 × 8 inches is default minimum size.
     assert_allclose(fig._get_size(), (8, 8), atol=atol)
-    set_config('MNE_BROWSER_SIZE', old_cfg)
+    set_config('MNE_BROWSE_RAW_SIZE', old_cfg)
 
 
 def test_scalings_int(browser_backend):

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -834,15 +834,15 @@ def test_plot_sensors(raw):
 @pytest.mark.parametrize('cfg_value', (None, '0.1,0.1'))
 def test_min_window_size(raw, cfg_value, browser_backend):
     """Test minimum window plot size."""
-    old_cfg = get_config('MNE_BROWSE_RAW_SIZE')
-    set_config('MNE_BROWSE_RAW_SIZE', cfg_value)
+    old_cfg = get_config('MNE_BROWSER_SIZE')
+    set_config('MNE_BROWSER_SIZE', cfg_value)
     fig = raw.plot()
     # For an unknown reason, the Windows-CI is a bit off
     # (on local Windows 10 the size is exactly as expected).
     atol = 0 if not os.name == 'nt' else 0.2
     # 8 × 8 inches is default minimum size.
     assert_allclose(fig._get_size(), (8, 8), atol=atol)
-    set_config('MNE_BROWSE_RAW_SIZE', old_cfg)
+    set_config('MNE_BROWSER_SIZE', old_cfg)
 
 
 def test_scalings_int(browser_backend):

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -505,7 +505,7 @@ def _simplify_float(label):
 
 def _get_figsize_from_config():
     """Get default / most recent figure size from config."""
-    figsize = get_config('MNE_BROWSER_SIZE')
+    figsize = get_config('MNE_BROWSE_RAW_SIZE')
     if figsize is not None:
         figsize = figsize.split(',')
         figsize = tuple([float(s) for s in figsize])

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -131,7 +131,6 @@ def _show_browser(show=True, block=True, fig=None, **kwargs):
     else:
         from qtpy.QtWidgets import QApplication
         app = QApplication.instance() or QApplication(sys.argv)
-        app.setApplicationName('MNE-Python')
         if show:
             fig.show()
         # If block=False, a Qt-Event-Loop has to be started

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -505,7 +505,7 @@ def _simplify_float(label):
 
 def _get_figsize_from_config():
     """Get default / most recent figure size from config."""
-    figsize = get_config('MNE_BROWSE_RAW_SIZE')
+    figsize = get_config('MNE_BROWSER_SIZE')
     if figsize is not None:
         figsize = figsize.split(',')
         figsize = tuple([float(s) for s in figsize])


### PR DESCRIPTION
#### What does this implement/fix?
This renames mne-qt-browser related config-variables for consistency:

MNE_BROWSE_BACKEND -> MNE_BROWSER_BACKEND
MNE_BROWSE_USE_OPENGL -> MNE_BROWSER_USE_OPENGL
~~MNE_BROWSE_RAW_SIZE -> MNE_BROWSER_SIZE~~
