### PR TITLE
Fix #9983 - Typo in docstring of pad for resampling methods.

### DIFF
--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -308,6 +308,7 @@ def _fft_resample(x, new_len, npads, to_removes, cuda_dict=None,
     cuda_dict : dict
         Dictionary constructed using setup_cuda_multiply_repeated().
     %(pad)s
+        The default is ``'reflect_limited'``.
 
         .. versionadded:: 0.15
 

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -5,7 +5,7 @@
 import numpy as np
 
 from .utils import (sizeof_fmt, logger, get_config, warn, _explain_exception,
-                    verbose)
+                    verbose, fill_doc)
 
 
 _cuda_capable = False
@@ -289,6 +289,7 @@ def _cuda_irfft_get(x, n, axis=-1):
     return cupy.fft.irfft(x, n=n, axis=axis).get()
 
 
+@fill_doc
 def _fft_resample(x, new_len, npads, to_removes, cuda_dict=None,
                   pad='reflect_limited'):
     """Do FFT resampling with a filter function (possibly using CUDA).
@@ -306,11 +307,7 @@ def _fft_resample(x, new_len, npads, to_removes, cuda_dict=None,
         Number of samples to remove after resampling.
     cuda_dict : dict
         Dictionary constructed using setup_cuda_multiply_repeated().
-    pad : str
-        The type of padding to use. Supports all :func:`np.pad` ``mode``
-        options. Can also be "reflect_limited" (default), which pads with a
-        reflected version of each vector mirrored on the first and last values
-        of the vector, followed by zeros.
+    %(pad)s
 
         .. versionadded:: 0.15
 

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -1937,8 +1937,6 @@ class FilterMixin(object):
 
             .. versionadded:: 0.16.
         %(pad-fir)s
-            The default is ``'edge'``, which pads with the edge values of each
-            vector.
         %(verbose_meth)s
 
         Returns

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -772,7 +772,6 @@ def filter_data(data, sfreq, l_freq, h_freq, picks=None, filter_length='auto',
     %(fir_window)s
     %(fir_design)s
     %(pad-fir)s
-        The default is ``'reflect_limited'``.
 
         .. versionadded:: 0.15
     %(verbose)s
@@ -1402,8 +1401,7 @@ def resample(x, up=1., down=1., npad=100, axis=-1, window='boxcar', n_jobs=1,
         Axis along which to resample (default is the last axis).
     %(window-resample)s
     %(n_jobs-cuda)s
-    %(pad-fir)s
-        The default is ``'reflect_limited'``.
+    %(pad)s
 
         .. versionadded:: 0.15
     %(verbose)s
@@ -2030,7 +2028,7 @@ class FilterMixin(object):
         %(npad)s
         %(window-resample)s
         %(n_jobs-cuda)s
-        %(pad-fir)s
+        %(pad)s
             The default is ``'edge'``, which pads with the edge values of each
             vector.
 

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -772,6 +772,7 @@ def filter_data(data, sfreq, l_freq, h_freq, picks=None, filter_length='auto',
     %(fir_window)s
     %(fir_design)s
     %(pad-fir)s
+        The default is ``'reflect_limited'``.
 
         .. versionadded:: 0.15
     %(verbose)s
@@ -1121,6 +1122,7 @@ def notch_filter(x, Fs, freqs, filter_length='auto', notch_widths=None,
     %(fir_window)s
     %(fir_design)s
     %(pad-fir)s
+        The default is ``'reflect_limited'``.
     %(verbose)s
 
     Returns
@@ -1402,6 +1404,7 @@ def resample(x, up=1., down=1., npad=100, axis=-1, window='boxcar', n_jobs=1,
     %(window-resample)s
     %(n_jobs-cuda)s
     %(pad)s
+        The default is ``'reflect_limited'``.
 
         .. versionadded:: 0.15
     %(verbose)s
@@ -1934,6 +1937,8 @@ class FilterMixin(object):
 
             .. versionadded:: 0.16.
         %(pad-fir)s
+            The default is ``'edge'``, which pads with the edge values of each
+            vector.
         %(verbose_meth)s
 
         Returns

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1076,7 +1076,6 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(fir_window)s
         %(fir_design)s
         %(pad-fir)s
-            The default is ``'reflect_limited'``.
 
             .. versionadded:: 0.15
         %(verbose_meth)s
@@ -1160,7 +1159,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             An optional event matrix. When specified, the onsets of the events
             are resampled jointly with the data. NB: The input events are not
             modified, but a new array is returned with the raw instead.
-        %(pad-fir)s
+        %(pad)s
             The default is ``'reflect_limited'``.
 
             .. versionadded:: 0.15

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1076,7 +1076,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(fir_window)s
         %(fir_design)s
         %(pad-fir)s
-            The default is ``'reflect_limited'``.
+            The default is ``'reflect_limited'``
 
             .. versionadded:: 0.15
         %(verbose_meth)s

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1076,6 +1076,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(fir_window)s
         %(fir_design)s
         %(pad-fir)s
+            The default is ``'reflect_limited'``.
 
             .. versionadded:: 0.15
         %(verbose_meth)s

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1076,7 +1076,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(fir_window)s
         %(fir_design)s
         %(pad-fir)s
-            The default is ``'reflect_limited'``
+            The default is ``'reflect_limited'``.
 
             .. versionadded:: 0.15
         %(verbose_meth)s

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -733,7 +733,7 @@ fir_window : str
 docdict['pad'] = """
 pad : str
     The type of padding to use. Supports all :func:`numpy.pad` ``mode``
-    options. Can also be "reflect_limited" (default), which pads with a
+    options. Can also be "reflect_limited", which pads with a
     reflected version of each vector mirrored on the first and last values
     of the vector, followed by zeros.
 """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -733,7 +733,7 @@ fir_window : str
 docdict['pad'] = """
 pad : str
     The type of padding to use. Supports all :func:`numpy.pad` ``mode``
-    options. Can also be "reflect_limited", which pads with a
+    options. Can also be ``"reflect_limited"``, which pads with a
     reflected version of each vector mirrored on the first and last values
     of the vector, followed by zeros.
 """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -730,13 +730,15 @@ fir_window : str
 
     .. versionadded:: 0.15
 """
-docdict['pad-fir'] = """
+docdict['pad'] = """
 pad : str
     The type of padding to use. Supports all :func:`numpy.pad` ``mode``
-    options. Can also be "reflect_limited", which pads with a
-    reflected version of each vector mirrored on the first and last
-    values of the vector, followed by zeros. Only used for ``method='fir'``.
+    options. Can also be "reflect_limited" (default), which pads with a
+    reflected version of each vector mirrored on the first and last values
+    of the vector, followed by zeros.
 """
+docdict['pad-fir'] = docdict['pad'].rstrip() + \
+    " Only used for ``method='fir'``."
 docdict['method-fir'] = """
 method : str
     'fir' will use overlap-add FIR filtering, 'iir' will use IIR


### PR DESCRIPTION
Fix #9983.

I added a new entry to the docdict: `pad` replacing the previous `pad-fir` for resampling methods.
The docdict entry `pad-fir` is now created by appending to the entry `pad`.