### PR TITLE
[DOC, MRG] Fix ieeg localization tutorial capitalization to match other tutorials

### DIFF
--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -3,7 +3,7 @@
 .. _tut-ieeg-localize:
 
 ========================================
-Locating Intracranial Electrode Contacts
+Locating intracranial electrode contacts
 ========================================
 
 Analysis of intracranial electrophysiology recordings typically involves


### PR DESCRIPTION
Just makes the capitalization match.