### PR TITLE
MRG: Make check_version() use _compare_version() internally

### DIFF
--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -723,7 +723,7 @@ def _check_pyqt5_version():
     except Exception:
         version = 'unknown'
     else:
-        if LooseVersion(version) >= LooseVersion('5.10'):
+        if _compare_version(version, '>=', '5.10'):
             bad = False
     bad &= sys.platform == 'darwin'
     if bad:

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -7,7 +7,6 @@
 import importlib
 from builtins import input  # no-op here but facilitates testing
 from difflib import get_close_matches
-from distutils.version import LooseVersion
 import operator
 import os
 import os.path as op
@@ -18,7 +17,7 @@ import numbers
 
 import numpy as np
 
-from ..fixes import _median_complex
+from ..fixes import _median_complex, _compare_version
 from ._logging import warn, logger
 
 
@@ -88,8 +87,10 @@ def check_version(library, min_version='0.0'):
     except ImportError:
         ok = False
     else:
-        if min_version and \
-                LooseVersion(library.__version__) < LooseVersion(min_version):
+        if (
+            min_version and
+            _compare_version(library.__version__, '<', min_version)
+        ):
             ok = False
     return ok
 


### PR DESCRIPTION
Get rid of `LooseVersion` usage here.

Tiny step toward resolving #9894