### PR TITLE
MRG: Add support to retrieve channel type from ['chanlocs']['type'] with EEGLAB reader

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -44,7 +44,7 @@ Bugs
 
 - Fix incorrect projection of source space onto white matter surface instead of pial in :ref:`tut-working-with-ecog` (:gh:`9980` by `Alex Rockhill`_)
 
-- Add channel type support when reading from EEGLAB ``.set`` format with :func:`mne.io.read_raw_eeglab` and :func:`mne.io.read_epochs_eeglab` (:gh:`9990` by `Mathieu Scheltienne`_)
+- Fix channel type support when reading from EEGLAB ``.set`` format with :func:`mne.io.read_raw_eeglab` and :func:`mne.read_epochs_eeglab` (:gh:`9990` by `Mathieu Scheltienne`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -44,6 +44,8 @@ Bugs
 
 - Fix incorrect projection of source space onto white matter surface instead of pial in :ref:`tut-working-with-ecog` (:gh:`9980` by `Alex Rockhill`_)
 
+- Add channel type support when reading from EEGLAB ``.set`` format with :func:`mne.io.read_raw_eeglab` and :func:`mne.io.read_epochs_eeglab` (:gh:`9990` by `Mathieu Scheltienne`_)
+
 API changes
 ~~~~~~~~~~~
 - Nothing yet

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -108,7 +108,7 @@ def _eeg_has_montage_information(eeg):
 def _get_montage_information(eeg, get_pos):
     """Get channel name, type and montage information from ['chanlocs']."""
     ch_names, ch_types, pos_ch_names, pos = list(), list(), list(), list()
-    unknown_types = set()
+    unknown_types = dict()
     for chanloc in eeg.chanlocs:
         # channel name
         ch_names.append(chanloc['labels'])
@@ -121,7 +121,10 @@ def _get_montage_information(eeg, get_pos):
             if try_type in _PICK_TYPES_KEYS:
                 ch_type = try_type
             else:
-                unknown_types.add(try_type)
+                if try_type in unknown_types:
+                    unknown_types[try_type].append(chanloc['labels'])
+                else:
+                    unknown_types[try_type] = [chanloc['labels']]
         ch_types.append(ch_type)
 
         # channel loc
@@ -136,8 +139,9 @@ def _get_montage_information(eeg, get_pos):
 
     # warn if unknown types were provided
     if len(unknown_types):
-        warn('Unknown types found, setting as type EEG: %s'
-             % sorted(unknown_types))
+        warn('Unknown types found, setting as type EEG:\n' +\
+             '\n'.join([f'{key}: {sorted(unknown_types[key])}'
+                        for key in sorted(unknown_types)]))
 
     if pos_ch_names:
         montage = make_dig_montage(

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -113,16 +113,13 @@ def _get_montage_information(eeg, get_pos):
         ch_names.append(chanloc['labels'])
 
         # channel type
-        if 'type' in chanloc:
-            ch_type = chanloc['type']
-            if isinstance(ch_type, str) and 0 < len(ch_type):
-                ch_type = ch_type.strip().lower()
-                ch_types.append(ch_type if ch_type in _PICK_TYPES_KEYS
-                                else 'eeg')
-            else:
-                ch_types.append('eeg')  # guarantee same size as ch_names
-        else:
-            ch_types.append('eeg')  # guarantee same size as ch_names
+        ch_type = 'eeg'
+        try_type = chanloc.get('type', None)
+        if isinstance(try_type, str):
+            try_type = try_type.strip().lower()
+            if try_type in _PICK_TYPES_KEYS:
+                ch_type = try_type
+        ch_types.append(ch_type)
 
         # channel loc
         if get_pos:

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -108,6 +108,7 @@ def _eeg_has_montage_information(eeg):
 def _get_montage_information(eeg, get_pos):
     """Get channel name, type and montage information from ['chanlocs']."""
     ch_names, ch_types, pos_ch_names, pos = list(), list(), list(), list()
+    unknown_types = set()
     for chanloc in eeg.chanlocs:
         # channel name
         ch_names.append(chanloc['labels'])
@@ -119,6 +120,8 @@ def _get_montage_information(eeg, get_pos):
             try_type = try_type.strip().lower()
             if try_type in _PICK_TYPES_KEYS:
                 ch_type = try_type
+            else:
+                unknown_types.add(try_type)
         ch_types.append(ch_type)
 
         # channel loc
@@ -130,6 +133,11 @@ def _get_montage_information(eeg, get_pos):
             if not np.any(np.isnan(locs)):
                 pos_ch_names.append(chanloc['labels'])
                 pos.append(locs)
+
+    # warn if unknown types were provided
+    if len(unknown_types):
+        warn('Unknown types found, setting as type EEG: %s'
+             % sorted(unknown_types))
 
     if pos_ch_names:
         montage = make_dig_montage(

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -146,8 +146,7 @@ def _get_montage_information(eeg, get_pos):
     if pos_ch_names:
         montage = make_dig_montage(
             ch_pos=dict(zip(ch_names, np.array(pos))),
-            coord_frame='head',
-        )
+            coord_frame='head')
     else:
         montage = None
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -139,7 +139,7 @@ def _get_montage_information(eeg, get_pos):
 
     # warn if unknown types were provided
     if len(unknown_types):
-        warn('Unknown types found, setting as type EEG:\n' +\
+        warn('Unknown types found, setting as type EEG:\n' +
              '\n'.join([f'{key}: {sorted(unknown_types[key])}'
                         for key in sorted(unknown_types)]))
 

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -450,7 +450,6 @@ def test_get_montage_info_with_ch_type():
     mat['EEG']['chanlocs'] = _dol_to_lod(mat['EEG']['chanlocs'])
     mat['EEG'] = Bunch(**mat['EEG'])
     ch_names, ch_types, montage = _get_montage_information(mat['EEG'], False)
-    assert len(ch_names) == len(ch_types)
-    assert n == len(ch_names)
+    assert len(ch_names) == len(ch_types) == n
     assert ch_types == ['eeg'] * (n - 2) + ['eog'] + ['stim']
     assert montage is None

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -453,3 +453,13 @@ def test_get_montage_info_with_ch_type():
     assert len(ch_names) == len(ch_types) == n
     assert ch_types == ['eeg'] * (n - 2) + ['eog'] + ['stim']
     assert montage is None
+
+    # test unknown type warning
+    mat = read_mat(raw_fname_onefile_mat, uint16_codec=None)
+    n = len(mat['EEG']['chanlocs']['labels'])
+    mat['EEG']['chanlocs']['type'] = ['eeg'] * (n - 2) + ['eog'] + ['unknown']
+    mat['EEG']['chanlocs'] = _dol_to_lod(mat['EEG']['chanlocs'])
+    mat['EEG'] = Bunch(**mat['EEG'])
+    with pytest.warns(RuntimeWarning, match='Unknown types found'):
+        ch_names, ch_types, montage = \
+            _get_montage_information(mat['EEG'], False)

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -446,11 +446,11 @@ def test_get_montage_info_with_ch_type():
     """Test that the channel types are properly returned."""
     mat = read_mat(raw_fname_onefile_mat, uint16_codec=None)
     n = len(mat['EEG']['chanlocs']['labels'])
-    mat['EEG']['chanlocs']['type'] = ['eeg'] * (n-2) + ['eog'] + ['stim']
+    mat['EEG']['chanlocs']['type'] = ['eeg'] * (n - 2) + ['eog'] + ['stim']
     mat['EEG']['chanlocs'] = _dol_to_lod(mat['EEG']['chanlocs'])
     mat['EEG'] = Bunch(**mat['EEG'])
     ch_names, ch_types, montage = _get_montage_information(mat['EEG'], False)
     assert len(ch_names) == len(ch_types)
     assert n == len(ch_names)
-    assert ch_types == ['eeg'] * (n-2) + ['eog'] + ['stim']
+    assert ch_types == ['eeg'] * (n - 2) + ['eog'] + ['stim']
     assert montage is None


### PR DESCRIPTION
Following #9989, a quick proposition to read channel types with EEGLAB reader.

In the reader, the data is read in a variable named `eeg` since EEGLAB is mostly focused on EEG datasets. However, in practice it does support more data types; and I could rename left and right this variable to e.g. `data` to make the code a bit more general if you want. 