### PR TITLE
[BUG, MRG] Revisit affine registration

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -46,6 +46,8 @@ Bugs
 
 - Fix channel type support when reading from EEGLAB ``.set`` format with :func:`mne.io.read_raw_eeglab` and :func:`mne.read_epochs_eeglab` (:gh:`9990` by `Mathieu Scheltienne`_)
 
+- Fix suboptimal alignment using :func:`mne.transforms.compute_volume_registration` (:gh:`9991` by `Alex Rockhill`_)
+
 API changes
 ~~~~~~~~~~~
 - Nothing yet

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -466,11 +466,11 @@ def test_volume_source_morph_basic(tmp_path):
 @testing.requires_testing_data
 @pytest.mark.parametrize(
     'subject_from, subject_to, lower, upper, dtype, morph_mat', [
-        ('sample', 'fsaverage', 10.0, 10.4, float, False),
+        ('sample', 'fsaverage', 5.9, 6.1, float, False),
         ('fsaverage', 'fsaverage', 0., 0.1, float, False),
         ('sample', 'sample', 0., 0.1, complex, False),
         ('sample', 'sample', 0., 0.1, float, True),  # morph_mat
-        ('sample', 'fsaverage', 7.0, 7.4, float, True),  # morph_mat
+        ('sample', 'fsaverage', 10, 12, float, True),  # morph_mat
     ])
 def test_volume_source_morph_round_trip(
         tmp_path, subject_from, subject_to, lower, upper, dtype, morph_mat,
@@ -553,7 +553,7 @@ def test_volume_source_morph_round_trip(
     # check that power is more or less preserved (labelizing messes with this)
     if morph_mat:
         if subject_to == 'fsaverage':
-            limits = (14.0, 14.2)
+            limits = (18, 18.5)
         else:
             limits = (7, 7.5)
     else:
@@ -866,7 +866,6 @@ def test_mixed_source_morph(_mixed_morph_srcs, vector):
 
     # Now actually morph
     stc_fs = morph.apply(stc)
-    img = stc_fs.volume().as_volume(src_fs, mri_resolution=False)
     vol_info = _get_mri_info_data(fname_aseg_fs, data=True)
     rrs = np.concatenate([src_fs[2]['rr'][sp['vertno']] for sp in src_fs[2:]])
     n_want = np.in1d(_get_atlas_values(vol_info, rrs), ids).sum()
@@ -874,7 +873,7 @@ def test_mixed_source_morph(_mixed_morph_srcs, vector):
         stc_fs.volume().as_volume(src, mri_resolution=False)
     img = _get_img_fdata(
         stc_fs.volume().as_volume(src_fs, mri_resolution=False))
-    assert img.astype(bool).sum() == n_want  # correct number of voxels
+    assert img.astype(bool).sum() > n_want * 0.5 # most voxels get mapped
 
     # Morph separate parts and compare to morphing the entire one
     stc_fs_surf = morph.apply(stc.surface())

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -873,7 +873,7 @@ def test_mixed_source_morph(_mixed_morph_srcs, vector):
         stc_fs.volume().as_volume(src, mri_resolution=False)
     img = _get_img_fdata(
         stc_fs.volume().as_volume(src_fs, mri_resolution=False))
-    assert img.astype(bool).sum() > n_want * 0.5 # most voxels get mapped
+    assert img.astype(bool).sum() > n_want * 0.5  # most voxels get mapped
 
     # Morph separate parts and compare to morphing the entire one
     stc_fs_surf = morph.apply(stc.surface())

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -873,7 +873,7 @@ def test_mixed_source_morph(_mixed_morph_srcs, vector):
         stc_fs.volume().as_volume(src, mri_resolution=False)
     img = _get_img_fdata(
         stc_fs.volume().as_volume(src_fs, mri_resolution=False))
-    assert img.astype(bool).sum() > n_want * 0.5  # most voxels get mapped
+    assert img.astype(bool).sum() == n_want  # correct number of voxels
 
     # Morph separate parts and compare to morphing the entire one
     stc_fs_surf = morph.apply(stc.surface())

--- a/mne/tests/test_transforms.py
+++ b/mne/tests/test_transforms.py
@@ -533,7 +533,7 @@ def test_volume_registration():
     for pipeline in ('rigids', ('translation', 'sdr')):
         reg_affine, sdr_morph = mne.transforms.compute_volume_registration(
             T1_resampled, T1, pipeline=pipeline, zooms=10, niter=[5])
-        assert_allclose(affine, reg_affine, atol=0.25)
+        assert_allclose(affine, reg_affine, atol=0.01)
         T1_aligned = mne.transforms.apply_volume_registration(
             T1_resampled, T1, reg_affine, sdr_morph)
         r2 = _compute_r2(_get_img_fdata(T1_aligned), _get_img_fdata(T1))

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -1664,7 +1664,7 @@ def _compute_volume_registration(moving, static, pipeline, zooms, niter):
     import nibabel as nib
     with np.testing.suppress_warnings():
         from dipy.align import (affine_registration, center_of_mass,
-                                translation, rigid, affine, resample,
+                                translation, rigid, affine,
                                 imwarp, metrics)
 
     # input validation

--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -418,11 +418,7 @@ plot_overlay(template_brain, subject_brain,
 # to the template.
 #
 # .. warning:: Here we use ``zooms=4`` just for speed, in general we recommend
-#              using ``zooms=None``` (default) for highest accuracy. To deal
-#              with this coarseness, we also use a threshold of 0.1 for the CT
-#              electrodes rather than 0.5. This coarse zoom and low threshold
-#              is useful for getting a quick view of the data, but finalized
-#              pipelines should use ``zooms=None`` instead!
+#              using ``zooms=None`` (default) for highest accuracy!
 
 reg_affine, sdr_morph = mne.transforms.compute_volume_registration(
     subject_brain, template_brain, zooms=4, verbose=True)
@@ -451,9 +447,8 @@ del subject_brain, template_brain
 montage = raw.get_montage()
 montage.apply_trans(subj_trans)
 
-# higher thresh such as 0.5 (default) works when `zooms=None`
 montage_warped, elec_image, warped_elec_image = mne.warp_montage_volume(
-    montage, CT_aligned, reg_affine, sdr_morph, thresh=0.1,
+    montage, CT_aligned, reg_affine, sdr_morph, thresh=0.5,
     subject_from='sample_seeg', subjects_dir_from=op.join(misc_path, 'seeg'),
     subject_to='fsaverage', subjects_dir_to=subjects_dir)
 

--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -417,7 +417,7 @@ plot_overlay(template_brain, subject_brain,
 # This aligns the two brains, preparing the subject's brain to be warped
 # to the template.
 #
-# .. warning:: Here we use ``zooms=5`` just for speed, in general we recommend
+# .. warning:: Here we use ``zooms=4`` just for speed, in general we recommend
 #              using ``zooms=None``` (default) for highest accuracy. To deal
 #              with this coarseness, we also use a threshold of 0.1 for the CT
 #              electrodes rather than 0.5. This coarse zoom and low threshold
@@ -425,7 +425,7 @@ plot_overlay(template_brain, subject_brain,
 #              pipelines should use ``zooms=None`` instead!
 
 reg_affine, sdr_morph = mne.transforms.compute_volume_registration(
-    subject_brain, template_brain, zooms=5, verbose=True)
+    subject_brain, template_brain, zooms=4, verbose=True)
 subject_brain_sdr = mne.transforms.apply_volume_registration(
     subject_brain, template_brain, reg_affine, sdr_morph)
 


### PR DESCRIPTION
The affine registration of the CT with the MR wasn't working optimally, alignments were slightly off, thanks for reporting @leosunpsy.

So I went back and looked and it looks like the `Dipy` method was to use the pre-alignment affines as we had at one point. I'm not sure why that wasn't working but it seems to work just fine now.