### PR TITLE
MRG: Issue warning when exporting with unapplied projectors and improve docstring

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -30,6 +30,8 @@ Enhancements
 
 - Add an alternate, manual procedure for aligning a CT to an MR procedure to :ref:`tut-ieeg-localize` (:gh:`9978` by `Alex Rockhill`_)
 
+- Improve docstring of export functions :func:`mne.export.export_raw`, :func:`mne.export.export_epochs`, :func:`mne.export.export_evokeds`, :func:`mne.export.export_evokeds_mff` and issue a warning when there are unapplied projectors (:gh:`....` by `Mathieu Scheltienne`_)
+
 Bugs
 ~~~~
 - Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSE_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -30,7 +30,7 @@ Enhancements
 
 - Add an alternate, manual procedure for aligning a CT to an MR procedure to :ref:`tut-ieeg-localize` (:gh:`9978` by `Alex Rockhill`_)
 
-- Improve docstring of export functions :func:`mne.export.export_raw`, :func:`mne.export.export_epochs`, :func:`mne.export.export_evokeds`, :func:`mne.export.export_evokeds_mff` and issue a warning when there are unapplied projectors (:gh:`....` by `Mathieu Scheltienne`_)
+- Improve docstring of export functions :func:`mne.export.export_raw`, :func:`mne.export.export_epochs`, :func:`mne.export.export_evokeds`, :func:`mne.export.export_evokeds_mff` and issue a warning when there are unapplied projectors (:gh:`9994` by `Mathieu Scheltienne`_)
 
 Bugs
 ~~~~

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1919,6 +1919,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
 
         Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
         %(export_warning)s :meth:`save` instead.
+        %(export_warning_proj)s :meth:`apply_proj`.
 
         Parameters
         ----------

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1918,6 +1918,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         """Export Epochs to external formats.
 
         Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
+
         %(export_warning)s
 
         Parameters
@@ -1932,6 +1933,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         Notes
         -----
         .. versionadded:: 0.24
+
         %(export_warning_note_epochs)s
         %(export_eeglab_note)s
         """

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1918,8 +1918,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         """Export Epochs to external formats.
 
         Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
-        %(export_warning)s :meth:`save` instead.
-        %(export_warning_proj)s :meth:`apply_proj`.
+        %(export_warning)s
 
         Parameters
         ----------
@@ -1932,6 +1931,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
 
         Notes
         -----
+        .. versionadded:: 0.24
+        %(export_warning_note_epochs)s
         %(export_eeglab_note)s
         """
         from .export import export_epochs

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -42,6 +42,7 @@ def export_evokeds_mff(fname, evoked, history=None, *, overwrite=False,
     Notes
     -----
     .. versionadded:: 0.24
+
     %(export_warning_note_evoked)s
 
     Only EEG channels are written to the output file.

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -21,7 +21,6 @@ def export_evokeds_mff(fname, evoked, history=None, *, overwrite=False,
     """Export evoked dataset to MFF.
 
     %(export_warning)s :func:`mne.write_evokeds` instead.
-
     .. warning::
         Export does not apply projector. Unapplied projectors will be lost.
         Consider using :meth:`mne.Evoked.apply_proj` before exporting.

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -55,7 +55,7 @@ def export_evokeds_mff(fname, evoked, history=None, *, overwrite=False,
     sampling_rate = int(info['sfreq'])
 
     # check for unapplied projectors
-    if any(not proj['active'] for proj in evoked.info['projs']):
+    if any(not proj['active'] for proj in evoked[0].info['projs']):
         warn('Evoked instance has unapplied projectors. Consider applying '
              'them before exporting with evoked.apply_proj().')
 

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -20,8 +20,7 @@ def export_evokeds_mff(fname, evoked, history=None, *, overwrite=False,
                        verbose=None):
     """Export evoked dataset to MFF.
 
-    %(export_warning)s :func:`mne.write_evokeds` instead.
-    %(export_warning_proj)s :meth:`mne.Evoked.apply_proj`.
+    %(export_warning)s
 
     Parameters
     ----------
@@ -43,6 +42,7 @@ def export_evokeds_mff(fname, evoked, history=None, *, overwrite=False,
     Notes
     -----
     .. versionadded:: 0.24
+    %(export_warning_note_evoked)s
 
     Only EEG channels are written to the output file.
     ``info['device_info']['type']`` must be a valid MFF recording device

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -21,6 +21,7 @@ def export_evokeds_mff(fname, evoked, history=None, *, overwrite=False,
     """Export evoked dataset to MFF.
 
     %(export_warning)s :func:`mne.write_evokeds` instead.
+
     .. warning::
         Export does not apply projector. Unapplied projectors will be lost.
         Consider using :meth:`mne.Evoked.apply_proj` before exporting.

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -21,9 +21,7 @@ def export_evokeds_mff(fname, evoked, history=None, *, overwrite=False,
     """Export evoked dataset to MFF.
 
     %(export_warning)s :func:`mne.write_evokeds` instead.
-    .. warning::
-        Export does not apply projector. Unapplied projectors will be lost.
-        Consider using :meth:`mne.Evoked.apply_proj` before exporting.
+    %(export_warning_proj)s :meth:`mne.Evoked.apply_proj`.
 
     Parameters
     ----------

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from ..io.egi.egimff import _import_mffpy
 from ..io.pick import pick_types, pick_channels
-from ..utils import verbose, _check_fname
+from ..utils import verbose, warn, _check_fname
 
 
 @verbose
@@ -53,6 +53,11 @@ def export_evokeds_mff(fname, evoked, history=None, *, overwrite=False,
         raise ValueError('Sampling frequency must be a whole number. '
                          f'sfreq: {info["sfreq"]}')
     sampling_rate = int(info['sfreq'])
+
+    # check for unapplied projectors
+    if any(not proj['active'] for proj in evoked.info['projs']):
+        warn('Evoked instance has unapplied projectors. Consider applying '
+             'them before exporting with evoked.apply_proj().')
 
     # Initialize writer
     # Future changes: conditions based on version or mffpy requirement if

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -20,6 +20,11 @@ def export_evokeds_mff(fname, evoked, history=None, *, overwrite=False,
                        verbose=None):
     """Export evoked dataset to MFF.
 
+    %(export_warning)s :func:`mne.write_evokeds` instead.
+    .. warning::
+        Export does not apply projector. Unapplied projectors will be lost.
+        Consider using :meth:`mne.Evoked.apply_proj` before exporting.
+
     Parameters
     ----------
     %(export_params_fname)s

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -17,6 +17,7 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
     Supported formats:
         - EEGLAB (.set, uses :mod:`eeglabio`)
         - EDF (.edf, uses ``EDFlib-Python``)
+
     %(export_warning)s
 
     Parameters
@@ -35,6 +36,7 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
     Notes
     -----
     .. versionadded:: 0.24
+
     %(export_warning_note_raw)s
     %(export_eeglab_note)s
     %(export_edf_note)s
@@ -67,6 +69,7 @@ def export_epochs(fname, epochs, fmt='auto', *, overwrite=False, verbose=None):
     """Export Epochs to external formats.
 
     Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
+
     %(export_warning)s
 
     Parameters
@@ -83,6 +86,7 @@ def export_epochs(fname, epochs, fmt='auto', *, overwrite=False, verbose=None):
     Notes
     -----
     .. versionadded:: 0.24
+
     %(export_warning_note_epochs)s
     %(export_eeglab_note)s
     """
@@ -119,6 +123,7 @@ def export_evokeds(fname, evoked, fmt='auto', *, overwrite=False,
 
     Supported formats
         MFF (mff, uses :func:`mne.export.export_evokeds_mff`)
+
     %(export_warning)s
 
     Parameters
@@ -145,6 +150,7 @@ def export_evokeds(fname, evoked, fmt='auto', *, overwrite=False,
     Notes
     -----
     .. versionadded:: 0.24
+
     %(export_warning_note_evoked)s
     """
     fname = _check_fname(fname, overwrite=overwrite)

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -18,9 +18,7 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
         - EEGLAB (.set, uses :mod:`eeglabio`)
         - EDF (.edf, uses ``EDFlib-Python``)
     %(export_warning)s :meth:`mne.io.Raw.save` instead.
-    .. warning::
-        Export does not apply projector. Unapplied projectors will be lost.
-        Consider using :meth:`mne.io.Raw.apply_proj` before exporting.
+    %(export_warning_proj)s :meth:`mne.io.Raw.apply_proj`.
 
     Parameters
     ----------
@@ -69,9 +67,7 @@ def export_epochs(fname, epochs, fmt='auto', *, overwrite=False, verbose=None):
 
     Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
     %(export_warning)s :meth:`mne.Epochs.save` instead.
-    .. warning::
-        Export does not apply projector. Unapplied projectors will be lost.
-        Consider using :meth:`mne.Epochs.apply_proj` before exporting.
+    %(export_warning_proj)s :meth:`mne.Epochs.apply_proj`.
 
     Parameters
     ----------
@@ -122,9 +118,7 @@ def export_evokeds(fname, evoked, fmt='auto', *, overwrite=False,
     Supported formats
         MFF (mff, uses :func:`mne.export.export_evokeds_mff`)
     %(export_warning)s :func:`mne.write_evokeds` instead.
-    .. warning::
-        Export does not apply projector. Unapplied projectors will be lost.
-        Consider using :meth:`mne.Evoked.apply_proj` before exporting.
+    %(export_warning_proj)s :meth:`mne.Evoked.apply_proj`.
 
     Parameters
     ----------

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -6,7 +6,7 @@
 import os.path as op
 
 from ._egimff import export_evokeds_mff
-from ..utils import verbose, logger, _validate_type, _check_fname
+from ..utils import logger, verbose, warn, _check_fname, _validate_type
 
 
 @verbose
@@ -44,6 +44,11 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
         'brainvision': ('eeg', 'vmrk', 'vhdr',)
     }
     fmt = _infer_check_export_fmt(fmt, fname, supported_export_formats)
+
+    # check for unapplied projectors
+    if any(not proj['active'] for proj in raw.info['projs']):
+        warn('Raw instance has unapplied projectors. Consider applying '
+             'them before exporting with raw.apply_proj().')
 
     if fmt == 'eeglab':
         from ._eeglab import _export_raw
@@ -84,6 +89,11 @@ def export_epochs(fname, epochs, fmt='auto', *, overwrite=False, verbose=None):
         'brainvision': ('eeg', 'vmrk', 'vhdr',)
     }
     fmt = _infer_check_export_fmt(fmt, fname, supported_export_formats)
+
+    # check for unapplied projectors
+    if any(not proj['active'] for proj in epochs.info['projs']):
+        warn('Epochs instance has unapplied projectors. Consider applying '
+             'them before exporting with epochs.apply_proj().')
 
     if fmt == 'eeglab':
         from ._eeglab import _export_epochs

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -17,8 +17,7 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
     Supported formats:
         - EEGLAB (.set, uses :mod:`eeglabio`)
         - EDF (.edf, uses ``EDFlib-Python``)
-    %(export_warning)s :meth:`mne.io.Raw.save` instead.
-    %(export_warning_proj)s :meth:`mne.io.Raw.apply_proj`.
+    %(export_warning)s
 
     Parameters
     ----------
@@ -35,6 +34,8 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
 
     Notes
     -----
+    .. versionadded:: 0.24
+    %(export_warning_note_raw)s
     %(export_eeglab_note)s
     %(export_edf_note)s
     """
@@ -66,8 +67,7 @@ def export_epochs(fname, epochs, fmt='auto', *, overwrite=False, verbose=None):
     """Export Epochs to external formats.
 
     Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
-    %(export_warning)s :meth:`mne.Epochs.save` instead.
-    %(export_warning_proj)s :meth:`mne.Epochs.apply_proj`.
+    %(export_warning)s
 
     Parameters
     ----------
@@ -82,6 +82,8 @@ def export_epochs(fname, epochs, fmt='auto', *, overwrite=False, verbose=None):
 
     Notes
     -----
+    .. versionadded:: 0.24
+    %(export_warning_note_epochs)s
     %(export_eeglab_note)s
     """
     fname = _check_fname(fname, overwrite=overwrite)
@@ -117,8 +119,7 @@ def export_evokeds(fname, evoked, fmt='auto', *, overwrite=False,
 
     Supported formats
         MFF (mff, uses :func:`mne.export.export_evokeds_mff`)
-    %(export_warning)s :func:`mne.write_evokeds` instead.
-    %(export_warning_proj)s :meth:`mne.Evoked.apply_proj`.
+    %(export_warning)s
 
     Parameters
     ----------
@@ -144,6 +145,7 @@ def export_evokeds(fname, evoked, fmt='auto', *, overwrite=False,
     Notes
     -----
     .. versionadded:: 0.24
+    %(export_warning_note_evoked)s
     """
     fname = _check_fname(fname, overwrite=overwrite)
     supported_export_formats = {

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -18,6 +18,9 @@ def export_raw(fname, raw, fmt='auto', physical_range='auto',
         - EEGLAB (.set, uses :mod:`eeglabio`)
         - EDF (.edf, uses ``EDFlib-Python``)
     %(export_warning)s :meth:`mne.io.Raw.save` instead.
+    .. warning::
+        Export does not apply projector. Unapplied projectors will be lost.
+        Consider using :meth:`mne.io.Raw.apply_proj` before exporting.
 
     Parameters
     ----------
@@ -65,7 +68,10 @@ def export_epochs(fname, epochs, fmt='auto', *, overwrite=False, verbose=None):
     """Export Epochs to external formats.
 
     Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
-    %(export_warning)s
+    %(export_warning)s :meth:`mne.Epochs.save` instead.
+    .. warning::
+        Export does not apply projector. Unapplied projectors will be lost.
+        Consider using :meth:`mne.Epochs.apply_proj` before exporting.
 
     Parameters
     ----------
@@ -116,6 +122,9 @@ def export_evokeds(fname, evoked, fmt='auto', *, overwrite=False,
     Supported formats
         MFF (mff, uses :func:`mne.export.export_evokeds_mff`)
     %(export_warning)s :func:`mne.write_evokeds` instead.
+    .. warning::
+        Export does not apply projector. Unapplied projectors will be lost.
+        Consider using :meth:`mne.Evoked.apply_proj` before exporting.
 
     Parameters
     ----------

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -37,8 +37,8 @@ def test_export_raw_eeglab(tmp_path):
     """Test saving a Raw instance to EEGLAB's set format."""
     fname = (Path(__file__).parent.parent.parent /
              "io" / "tests" / "data" / "test_raw.fif")
-    raw = read_raw_fif(fname)
-    raw.load_data()
+    raw = read_raw_fif(fname, preload=True)
+    raw.apply_proj()
     temp_fname = op.join(str(tmp_path), 'test.set')
     raw.export(temp_fname)
     raw.drop_channels([ch for ch in ['epoc']
@@ -58,6 +58,12 @@ def test_export_raw_eeglab(tmp_path):
 
     # test pathlib.Path files
     raw.export(Path(temp_fname), overwrite=True)
+
+    # test warning with unapplied projectors
+    raw = read_raw_fif(fname, preload=True)
+    with pytest.warns(RuntimeWarning,
+                      match='Raw instance has unapplied projectors.'):
+        raw.export(temp_fname, overwrite=True)
 
 
 @pytest.mark.skipif(not _check_edflib_installed(strict=False),
@@ -328,6 +334,12 @@ def test_export_epochs_eeglab(tmp_path, preload):
 
     # test pathlib.Path files
     epochs.export(Path(temp_fname), overwrite=True)
+
+    # test warning with unapplied projectors
+    epochs = Epochs(raw, events, preload=preload, proj=False)
+    with pytest.warns(RuntimeWarning,
+                      match='Epochs instance has unapplied projectors.'):
+        epochs.export(Path(temp_fname), overwrite=True)
 
 
 @requires_version('mffpy', '0.5.7')

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1483,6 +1483,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
         %(export_warning)s :meth:`save` instead.
+        %(export_warning_proj)s :meth:`apply_proj`.
 
         Parameters
         ----------

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1482,8 +1482,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """Export Raw to external formats.
 
         Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
-        %(export_warning)s :meth:`save` instead.
-        %(export_warning_proj)s :meth:`apply_proj`.
+        %(export_warning)s
 
         Parameters
         ----------
@@ -1498,6 +1497,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         Notes
         -----
+        .. versionadded:: 0.24
+        %(export_warning_note_raw)s
         %(export_eeglab_note)s
         %(export_edf_note)s
         """

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1482,6 +1482,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """Export Raw to external formats.
 
         Supported formats: EEGLAB (set, uses :mod:`eeglabio`)
+
         %(export_warning)s
 
         Parameters
@@ -1498,6 +1499,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         Notes
         -----
         .. versionadded:: 0.24
+
         %(export_warning_note_raw)s
         %(export_eeglab_note)s
         %(export_edf_note)s

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2629,8 +2629,8 @@ add_ch_type : bool
     to store channel "Fz" as "EEG Fz"). Only used for EDF format. Default is
     ``False``.
 """
-docdict['export_warning_note'] = """
-Export to external format may not preserve all the information from the
+docdict['export_warning_note'] = \
+"""Export to external format may not preserve all the information from the
 instance. To save in native MNE format (``.fif``) without information loss,
 use :meth:`mne.{0}.save` instead.
 Export does not apply projector(s). Unapplied projector(s) will be lost.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2606,6 +2606,11 @@ docdict['export_warning'] = """
     the info will be preserved in the external format. To save in native MNE
     format (``.fif``) without information loss, use
 """
+docdict['export_warning_proj'] = """
+.. warning::
+    Export does not apply projector. Unapplied projectors will be lost.
+    Consider applying projectors before exporting with
+"""
 docdict['export_params_fname'] = """
 fname : str
     Name of the output file.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2600,7 +2600,7 @@ on_defects : 'raise' | 'warn' | 'ignore'
 """
 
 # Export
-docdict['export_warning'] = """
+docdict['export_warning'] = """\
 .. warning::
     Since we are exporting to external formats, there's no guarantee that all
     the info will be preserved in the external format. See Notes for details.
@@ -2629,8 +2629,8 @@ add_ch_type : bool
     to store channel "Fz" as "EEG Fz"). Only used for EDF format. Default is
     ``False``.
 """
-docdict['export_warning_note'] = \
-"""Export to external format may not preserve all the information from the
+docdict['export_warning_note'] = """\
+Export to external format may not preserve all the information from the
 instance. To save in native MNE format (``.fif``) without information loss,
 use :meth:`mne.{0}.save` instead.
 Export does not apply projector(s). Unapplied projector(s) will be lost.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2635,8 +2635,7 @@ instance. To save in native MNE format (``.fif``) without information loss,
 use :meth:`mne.{0}.save` instead.
 Export does not apply projector(s). Unapplied projector(s) will be lost.
 Consider applying projector(s) before exporting with
-:meth:`mne.{0}.apply_proj`.
-"""
+:meth:`mne.{0}.apply_proj`."""
 docdict['export_warning_note_raw'] = \
     docdict['export_warning_note'].format('io.Raw')
 docdict['export_warning_note_epochs'] = \

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2603,13 +2603,7 @@ on_defects : 'raise' | 'warn' | 'ignore'
 docdict['export_warning'] = """
 .. warning::
     Since we are exporting to external formats, there's no guarantee that all
-    the info will be preserved in the external format. To save in native MNE
-    format (``.fif``) without information loss, use
-"""
-docdict['export_warning_proj'] = """
-.. warning::
-    Export does not apply projector. Unapplied projectors will be lost.
-    Consider applying projectors before exporting with
+    the info will be preserved in the external format. See Notes for details.
 """
 docdict['export_params_fname'] = """
 fname : str
@@ -2635,6 +2629,20 @@ add_ch_type : bool
     to store channel "Fz" as "EEG Fz"). Only used for EDF format. Default is
     ``False``.
 """
+docdict['export_warning_note'] = """
+Export to external format may not preserve all the information from the
+instance. To save in native MNE format (``.fif``) without information loss,
+use :meth:`mne.{0}.save` instead.
+Export does not apply projector(s). Unapplied projector(s) will be lost.
+Consider applying projector(s) before exporting with
+:meth:`mne.{0}.apply_proj`.
+"""
+docdict['export_warning_note_raw'] = \
+    docdict['export_warning_note'].format('io.Raw')
+docdict['export_warning_note_epochs'] = \
+    docdict['export_warning_note'].format('Epochs')
+docdict['export_warning_note_evoked'] = \
+    docdict['export_warning_note'].format('Evoked')
 docdict['export_eeglab_note'] = """
 For EEGLAB exports, channel locations are expanded to full EEGLAB format.
 For more details see :func:`eeglabio.utils.cart_to_eeglab`.


### PR DESCRIPTION
I added a warning when exporting with unapplied projectors to all 4 export functions:
- mne.export.export_raw
- mne.export.export_epochs
- mne.export.export_evokeds
- mne.export.export_evokeds_mff

I added this warning in their docstrings:

```
.. warning::
        Export does not apply projector. Unapplied projectors will be lost.
        Consider using :meth:`mne.io.Raw.apply_proj` before exporting.
```

Test for warning when exporting evoked with unapplied proj is missing because I didn't have any good idea on how to add a projector to the EGI evoked instance loaded.