### PR TITLE
MRG, CI: Better cancellation policy

### DIFF
--- a/.github/workflows/codespell_and_flake.yml
+++ b/.github/workflows/codespell_and_flake.yml
@@ -1,8 +1,9 @@
 name: 'codespell_and_flake'
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 # https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types#pullrequestevent
+# workflow name, PR number (empty on push), push ref (empty on PR)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true
 on:
   push:

--- a/.github/workflows/compat_minimal.yml
+++ b/.github/workflows/compat_minimal.yml
@@ -1,6 +1,6 @@
 name: 'compat / minimal'
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true
 on:
   push:

--- a/.github/workflows/compat_old.yml
+++ b/.github/workflows/compat_old.yml
@@ -1,6 +1,6 @@
 name: 'compat / old'
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true
 on:
   push:

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -1,6 +1,6 @@
 name: 'linux / conda'
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true
 on:
   push:

--- a/.github/workflows/linux_pip.yml
+++ b/.github/workflows/linux_pip.yml
@@ -1,6 +1,6 @@
 name: 'linux / pip-pre'
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true
 on:
   push:

--- a/.github/workflows/macos_conda.yml
+++ b/.github/workflows/macos_conda.yml
@@ -1,6 +1,6 @@
 name: 'macos / conda'
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true
 on:
   push:


### PR DESCRIPTION
This just adjusts our auto-cancellation policy to include the event.ref so that pushes to `main` and `maint/0.24` don't cancel each other.