### PR TITLE
CI: Unpin Sphinx

### DIFF
--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,5 +1,5 @@
 # requirements for building docs
-sphinx!=4.1.0, !=4.3.0
+sphinx!=4.1.0
 https://github.com/numpy/numpydoc/archive/main.zip
 pydata-sphinx-theme>=0.6.3
 https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip


### PR DESCRIPTION
With https://github.com/pydata/pydata-sphinx-theme/issues/508 and the corresponding release in theory we shouldn't need the pin