### PR TITLE
MRG: Don't overwrite Report.fname upon saving

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -36,6 +36,8 @@ Bugs
 
 - Fix bug with :class:`mne.Report` where figures were saved with ``bbox_inches='tight'``, which led to inconsistent sizes in sliders (:gh:`9966` by `Eric Larson`_)
 
+- When opening a saved report and saving it to a different filename again, don't change ``Report.fname`` to avoid a regression when using :func:`~mne.open_report` as a context manager (:gh:`9998` by `Marijn van Vliet`_)
+
 - Fix bug in :func:`mne.make_forward_solution` where sensor-sphere geometry check was incorrect (:gh:`9968` by `Eric Larson`_)
 
 - Add argument ``overwrite`` to :func:`mne.export.export_raw`, :func:`mne.export.export_epochs`, :func:`mne.export.export_evokeds` and :func:`mne.export.export_evokeds_mff` (:gh:`9975` by `Mathieu Scheltienne`_)

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -2437,7 +2437,8 @@ class Report(object):
         if open_browser and not is_hdf5 and not building_doc:
             webbrowser.open_new_tab('file://' + fname)
 
-        self.fname = fname
+        if self.fname is None:
+            self.fname = fname
         return fname
 
     def __enter__(self):

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -705,7 +705,8 @@ class Report(object):
         return (
             'baseline', 'cov_fname', 'include', '_content', 'image_format',
             'info_fname', '_dom_id', 'raw_psd', 'projs',
-            'subjects_dir', 'subject', 'title', 'data_path', 'lang', 'verbose'
+            'subjects_dir', 'subject', 'title', 'data_path', 'lang', 'verbose',
+            'fname'
         )
 
     def _get_dom_id(self):


### PR DESCRIPTION
When calling `mne.Report.save()`, we don't want to overwrite the existing `report.fname` attribute, as it breaks this pattern (which I happen to use a lot):

```python
with open_report('report.h5') as report:
    report.add_figure(fig)
    report.save('report.html')  # save HTML version
# End of context block. Report is saved to report.h5
```

I like to keep both an `.h5` and `.html` version of the report. Before this PR, saving to HTML will overwrite `report.fname` and hence at the end of the context it gets saved as HTML again, instead of the HDF5 file that was used when opening the report.