### PR TITLE
Robust fif channel renaming of long channels names

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -40,6 +40,8 @@ Bugs
 
 - Fix bug in :func:`mne.make_forward_solution` where sensor-sphere geometry check was incorrect (:gh:`9968` by `Eric Larson`_)
 
+- Use single char alphanumeric suffix when renaming long channel names (over 15-characters) when writing to FIF format. (:gh:`10002` by `Luke Bloy`_)
+
 - Add argument ``overwrite`` to :func:`mne.export.export_raw`, :func:`mne.export.export_epochs`, :func:`mne.export.export_evokeds` and :func:`mne.export.export_evokeds_mff` (:gh:`9975` by `Mathieu Scheltienne`_)
 
 - :func:`mne.gui.coregistration` and the ``mne coreg`` command didn't respect the ``inspect`` parameter (:gh:`9972` by `Richard Höchenberger`_)

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -109,6 +109,7 @@ def _get_valid_units():
 @verbose
 def _unique_channel_names(ch_names, max_length=None, verbose=None):
     """Ensure unique channel names."""
+    suffixes = tuple('abcdefghijklmnopqrstuvwxyz')
     if max_length is not None:
         ch_names[:] = [name[:max_length] for name in ch_names]
     unique_ids = np.unique(ch_names, return_index=True)[1]
@@ -129,14 +130,17 @@ def _unique_channel_names(ch_names, max_length=None, verbose=None):
             n_keep = min(len(ch_stem), n_keep)
             ch_stem = ch_stem[:n_keep]
             for idx, ch_idx in enumerate(overlaps):
-                ch_name = ch_stem + '-%s' % idx
+                # try idx first, then loop through lower case chars
+                for suffix in (idx,) + suffixes:
+                    ch_name = ch_stem + '-%s' % suffix
+                    if ch_name not in ch_names:
+                        break
                 if ch_name not in ch_names:
                     ch_names[ch_idx] = ch_name
                 else:
-                    raise ValueError('Adding a running number for a '
+                    raise ValueError('Adding a single alphanumeric for a '
                                      'duplicate resulted in another '
                                      'duplicate name %s' % ch_name)
-
     return ch_names
 
 

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -14,6 +14,7 @@ import datetime
 from io import BytesIO
 import operator
 from textwrap import shorten
+import string
 
 import numpy as np
 
@@ -109,7 +110,7 @@ def _get_valid_units():
 @verbose
 def _unique_channel_names(ch_names, max_length=None, verbose=None):
     """Ensure unique channel names."""
-    suffixes = tuple('abcdefghijklmnopqrstuvwxyz')
+    suffixes = tuple(string.ascii_lowercase)
     if max_length is not None:
         ch_names[:] = [name[:max_length] for name in ch_names]
     unique_ids = np.unique(ch_names, return_index=True)[1]

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -140,10 +140,6 @@ def test_duplicate_name_correction():
     info = create_info(['A', 'A', 'A'], 1000., verbose='error')
     assert info['ch_names'] == ['A-0', 'A-1', 'A-2']
 
-    # When running number is not possible
-    with pytest.raises(ValueError, match='Adding a running number'):
-        create_info(['A', 'A', 'A-0'], 1000., verbose='error')
-
 
 def test_fiducials_io(tmp_path):
     """Test fiducials i/o."""

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -13,6 +13,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 from scipy import sparse
+import string
 
 from mne import (Epochs, read_events, pick_info, pick_types, Annotations,
                  read_evokeds, make_forward_solution, make_sphere_model,
@@ -140,9 +141,16 @@ def test_duplicate_name_correction():
     info = create_info(['A', 'A', 'A'], 1000., verbose='error')
     assert info['ch_names'] == ['A-0', 'A-1', 'A-2']
 
-    # When running number is not possible
+    # When running number is not possible but alpha numeric is
     info = create_info(['A', 'A', 'A-0'], 1000., verbose='error')
     assert info['ch_names'] == ['A-a', 'A-1', 'A-0']
+
+    # When a single addition is not sufficient
+    with pytest.raises(ValueError, match='Adding a single alphanumeric'):
+        ch_n = ['A', 'A']
+        # add all options for first duplicate channel (0)
+        ch_n.extend([f'{ch_n[0]}-{c}' for c in string.ascii_lowercase + '0'])
+        create_info(ch_n, 1000., verbose='error')
 
 
 def test_fiducials_io(tmp_path):

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -140,6 +140,10 @@ def test_duplicate_name_correction():
     info = create_info(['A', 'A', 'A'], 1000., verbose='error')
     assert info['ch_names'] == ['A-0', 'A-1', 'A-2']
 
+    # When running number is not possible
+    info = create_info(['A', 'A', 'A-0'], 1000., verbose='error')
+    assert info['ch_names'] == ['A-a', 'A-1', 'A-0']
+
 
 def test_fiducials_io(tmp_path):
     """Test fiducials i/o."""


### PR DESCRIPTION
I have some workflows the store source space label time courses in `Raw` instances.

The current renaming scheme (https://github.com/mne-tools/mne-python/blob/main/mne/io/meas_info.py#L110) works for most atlases but fails for `aparc_sub`, depending on the ordering of duplicated channels.

<details>
  <summary>Minimal working example</summary>

  ```
  from mne import create_info
  from mne.io import write_info
  
  ch_names = ['supramarginal_1-lh',
              'supramarginal_1-rh',
              'supramarginal_10-lh',
              'supramarginal_2-lh',
              'supramarginal_2-rh',
              'supramarginal_3-lh',
              'supramarginal_3-rh',
              'supramarginal_4-lh',
              'supramarginal_4-rh',
              'supramarginal_5-lh',
              'supramarginal_5-rh',
              'supramarginal_6-lh',
              'supramarginal_6-rh',
              'supramarginal_7-lh',
              'supramarginal_7-rh',
              'supramarginal_8-lh',
              'supramarginal_8-rh',
              'supramarginal_9-lh',
              'supramarginal_9-rh']
  
  info = create_info(ch_names, 1000., verbose='error')
  write_info('tmp-info.fif', info)
  ```
</details>

This PR extends the renaming strategy to first append a digit (current approach) and if that fails to generate a unique `ch_name` tries to append a lower case letter.
