### PR TITLE
MRG: API doc & glossary improvements

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -176,7 +176,6 @@ numpydoc_xref_aliases = {
     # Matplotlib
     'colormap': ':doc:`colormap <matplotlib:tutorials/colors/colormaps>`',
     'color': ':doc:`color <matplotlib:api/colors_api>`',
-    'collections': ':doc:`collections <matplotlib:api/collections_api>`',
     'Axes': 'matplotlib.axes.Axes',
     'Figure': 'matplotlib.figure.Figure',
     'Axes3D': 'mpl_toolkits.mplot3d.axes3d.Axes3D',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -171,10 +171,12 @@ numpydoc_xref_param_type = True
 numpydoc_xref_aliases = {
     # Python
     'file-like': ':term:`file-like <python:file object>`',
+    'path-like': ':term:`path-like`',
+    'array-like': ':term:`array-like`',
     # Matplotlib
     'colormap': ':doc:`colormap <matplotlib:tutorials/colors/colormaps>`',
     'color': ':doc:`color <matplotlib:api/colors_api>`',
-    'collection': ':doc:`collections <matplotlib:api/collections_api>`',
+    'collections': ':doc:`collections <matplotlib:api/collections_api>`',
     'Axes': 'matplotlib.axes.Axes',
     'Figure': 'matplotlib.figure.Figure',
     'Axes3D': 'mpl_toolkits.mplot3d.axes3d.Axes3D',

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -21,6 +21,13 @@ general neuroimaging concepts. If you think a term is missing, please consider
         object class and :ref:`tut-annotations`
         for a tutorial on how to manipulate such objects.
 
+    array-like
+        Something that acts like – or can be converted to – a
+        :class:`NumPy array <numpy.ndarray>`.
+        This includes (but is not limited to) an
+        :class:`array <numpy.ndarray>` (obviously), a `list`, and a
+        `tuple`.
+
     beamformer
         Beamformer is a popular source estimation approach that uses a set of
         spatial filters (beamformer weights) to compute time courses of sources
@@ -277,6 +284,10 @@ general neuroimaging concepts. If you think a term is missing, please consider
         practice estimated from baseline periods or empty room measurements.
         The matrix also provides a noise model that can be used for subsequent analysis
         like source imaging.
+
+    path-like
+        Something that acts like a path in a file system. This can be a `str`
+        or a `pathlib.Path`.
 
     pick
         An integer that is the index of a channel in the measurement info.

--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -209,7 +209,7 @@ def locate_ieeg(info, trans, aligned_ct, subject=None, subjects_dir=None,
     ----------
     %(info_not_none)s
     %(trans_not_none)s
-    aligned_ct : str | pathlib.Path | nibabel.spatialimages.SpatialImage
+    aligned_ct : path-like | nibabel.spatialimages.SpatialImage
         The CT image that has been aligned to the Freesurfer T1. Path-like
         inputs and nibabel image objects are supported.
     %(subject)s

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -1646,7 +1646,7 @@ class Report(object):
             The title of the element(s) to remove.
 
             .. versionadded:: 0.24.0
-        tags : collection of str | None
+        tags : array-like of str | None
              If supplied, restrict the operation to elements with the supplied
              tags.
 
@@ -1750,7 +1750,7 @@ class Report(object):
 
         Parameters
         ----------
-        code : str | pathlib.Path
+        code : path-like
             The code to add to the report as a string, or the path to a file
             as a `pathlib.Path` object.
 
@@ -1813,7 +1813,7 @@ class Report(object):
 
         Parameters
         ----------
-        fig : matplotlib.figure.Figure | PyVista renderer | array | collection of matplotlib.figure.Figure | collection of PyVista renderer | collection of array
+        fig : matplotlib.figure.Figure | PyVista renderer | array | array-like of matplotlib.figure.Figure | array-like of PyVista renderer | array-like of array
             One or more figures to add to the report. All figures must be an
             instance of :class:`matplotlib.figure.Figure`,
             PyVista renderer, or :class:`numpy.ndarray`. If
@@ -1821,7 +1821,7 @@ class Report(object):
             that can be navigated using buttons and a slider element.
         title : str
             The title corresponding to the figure(s).
-        caption : str | collection of str | None
+        caption : str | array-like of str | None
             The caption(s) to add to the figure(s).
         %(report_image_format)s
         %(report_tags)s

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -1775,7 +1775,7 @@ def warp_montage_volume(montage, base_image, reg_affine, sdr_morph,
     ----------
     montage : instance of mne.channels.DigMontage
         The montage object containing the channels.
-    base_image : str | pathlib.Path | nibabel.spatialimages.SpatialImage
+    base_image : path-like | nibabel.spatialimages.SpatialImage
         Path to a volumetric scan (e.g. CT) of the subject. Can be in any
         format readable by nibabel. Can also be a nibabel image object.
         Local extrema (max or min) should be nearby montage channel locations.
@@ -1786,11 +1786,11 @@ def warp_montage_volume(montage, base_image, reg_affine, sdr_morph,
     subject_to : str
         The name of the subject to use as a template to morph to
         (e.g. 'fsaverage').
-    subjects_dir_from : str | pathlib.Path | None
+    subjects_dir_from : path-like | None
         The path to the Freesurfer ``recon-all`` directory for the
         ``subject_from`` subject. The ``SUBJECTS_DIR`` environment
         variable will be used when ``None``.
-    subjects_dir_to : str | pathlib.Path | None
+    subjects_dir_to : path-like | None
         The path to the Freesurfer ``recon-all`` directory for the
         ``subject_to`` subject. ``subject_dir_from`` will be used
         when ``None``.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1393,7 +1393,7 @@ trans : str | dict | instance of Transform | None
        Support for 'fsaverage' argument.
 """ % (_trans_base,)
 docdict['subjects_dir'] = """
-subjects_dir : str | pathlib.Path | None
+subjects_dir : path-like | None
     The path to the directory containing the FreeSurfer subjects
     reconstructions. If ``None``, defaults to the ``SUBJECTS_DIR`` environment
     variable.
@@ -2334,7 +2334,7 @@ image_format : 'png' | 'svg' | 'gif' | None
     instantiation.
 """
 docdict['report_tags'] = """
-tags : collection of str
+tags : array-like of str
     Tags to add for later interactive filtering.
 """
 docdict['report_replace'] = """


### PR DESCRIPTION
came up in https://github.com/mne-tools/mne-bids/pull/910#pullrequestreview-805508282

- Add `path-like` and `array-like` to the glossary
- Replace occurrences of `str | pathlib.Path` with `path-like`
- Replace occurences of `collection` with array-like
- <strike>Fix alias for Matplotlib's `collections` (must be plural, was singular)</strike >
