### PR TITLE
Add argument overwrite to ICA.save()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -32,6 +32,8 @@ Enhancements
 
 - Improve docstring of export functions :func:`mne.export.export_raw`, :func:`mne.export.export_epochs`, :func:`mne.export.export_evokeds`, :func:`mne.export.export_evokeds_mff` and issue a warning when there are unapplied projectors (:gh:`9994` by `Mathieu Scheltienne`_)
 
+- Add argument ``overwrite`` to `mne.preprocessing.ICA.save` to check for existing files (:gh:`xxxx` by `Mathieu Scheltienne`_)
+
 Bugs
 ~~~~
 - Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSE_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -32,7 +32,7 @@ Enhancements
 
 - Improve docstring of export functions :func:`mne.export.export_raw`, :func:`mne.export.export_epochs`, :func:`mne.export.export_evokeds`, :func:`mne.export.export_evokeds_mff` and issue a warning when there are unapplied projectors (:gh:`9994` by `Mathieu Scheltienne`_)
 
-- Add argument ``overwrite`` to `mne.preprocessing.ICA.save` to check for existing files (:gh:`xxxx` by `Mathieu Scheltienne`_)
+- Add argument ``overwrite`` to `mne.preprocessing.ICA.save` to check for existing files (:gh:`10004` by `Mathieu Scheltienne`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -32,8 +32,6 @@ Enhancements
 
 - Improve docstring of export functions :func:`mne.export.export_raw`, :func:`mne.export.export_epochs`, :func:`mne.export.export_evokeds`, :func:`mne.export.export_evokeds_mff` and issue a warning when there are unapplied projectors (:gh:`9994` by `Mathieu Scheltienne`_)
 
-- Add argument ``overwrite`` to `mne.preprocessing.ICA.save` to check for existing files (:gh:`10004` by `Mathieu Scheltienne`_)
-
 Bugs
 ~~~~
 - Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSE_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)
@@ -55,6 +53,8 @@ Bugs
 - Fix suboptimal alignment using :func:`mne.transforms.compute_volume_registration` (:gh:`9991` by `Alex Rockhill`_)
 
 - Only warn if header is missing in BrainVision files instead of raising an error (:gh:`10001` by `Clemens Brunner`_)
+
+- Add argument ``overwrite`` to `mne.preprocessing.ICA.save` to check for existing file (:gh:`10004` by `Mathieu Scheltienne`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -49,7 +49,7 @@ from ..viz.topomap import _plot_corrmap
 
 from ..channels.channels import _contains_ch_type, ContainsMixin
 from ..io.write import start_file, end_file, write_id
-from ..utils import (check_version, logger, check_fname, verbose,
+from ..utils import (check_version, logger, check_fname, _check_fname, verbose,
                      _reject_data_segments, check_random_state, _validate_type,
                      compute_corr, _get_inst_data, _ensure_int,
                      copy_function_doc_to_method_doc, _pl, warn, Bunch,
@@ -1869,7 +1869,7 @@ class ICA(ContainsMixin):
         return data
 
     @verbose
-    def save(self, fname, verbose=None):
+    def save(self, fname, *, overwrite=False, verbose=None):
         """Store ICA solution into a fiff file.
 
         Parameters
@@ -1877,6 +1877,9 @@ class ICA(ContainsMixin):
         fname : str
             The absolute path of the file name to save the ICA solution into.
             The file name should end with -ica.fif or -ica.fif.gz.
+        %(overwrite)s
+
+            .. versionadded:: 1.0
         %(verbose_meth)s
 
         Returns
@@ -1893,6 +1896,7 @@ class ICA(ContainsMixin):
 
         check_fname(fname, 'ICA', ('-ica.fif', '-ica.fif.gz',
                                    '_ica.fif', '_ica.fif.gz'))
+        fname = _check_fname(fname, overwrite=overwrite)
 
         logger.info('Writing ICA solution to %s...' % fname)
         fid = start_file(fname)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -758,7 +758,7 @@ def test_ica_additional(method, tmp_path, short_raw_epochs):
     ica_read.n_pca_components = 4
 
     ica.exclude = []
-    ica.save(test_ica_fname)
+    ica.save(test_ica_fname, overwrite=True)  # also testing overwrite
     ica_read = read_ica(test_ica_fname)
     for attr in ['mixing_matrix_', 'unmixing_matrix_', 'pca_components_',
                  'pca_mean_', 'pca_explained_variance_',
@@ -971,7 +971,7 @@ def test_ica_cov(method, cov, tmp_path, short_raw_epochs):
     for exclude in [[], [0], np.array([1, 2, 3])]:
         ica.exclude = exclude
         ica.labels_ = {'foo': [0]}
-        ica.save(test_ica_fname)
+        ica.save(test_ica_fname, overwrite=True)
         ica_read = read_ica(test_ica_fname)
         assert (list(ica.exclude) == ica_read.exclude)
         assert_equal(ica.labels_, ica_read.labels_)


### PR DESCRIPTION
Adding a check + overwrite argument to ``ICA.save()`` to avoid overwriting existing ICAs.