### PR TITLE
MRG, MAINT: Update testing for datasets

### DIFF
--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -441,7 +441,7 @@ not require a deprecation cycle.
 
 Note that any new API elements should be added to the main reference;
 classes, functions, methods, and attributes cannot be cross-referenced unless
-they are included in the :doc:`python_reference`
+they are included in the :ref:`api_reference`
 (:file:`doc/python_reference.rst`).
 
 
@@ -923,7 +923,7 @@ down the road. Here are the guidelines:
   for backports or maintenance bugfixes to the current stable version).
 
 - Don't forget to include in your PR a brief description of the change in the
-  :doc:`changelog <whats_new>` (:file:`doc/whats_new.rst`).
+  :ref:`changelog <whats_new>` (:file:`doc/whats_new.rst`).
 
 - Our community uses the following commit tags and conventions:
 

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -66,7 +66,7 @@ def pytest_configure(config):
         config.addinivalue_line('markers', marker)
 
     # Fixtures
-    for fixture in ('matplotlib_config',):
+    for fixture in ('matplotlib_config', 'close_all', 'check_verbose'):
         config.addinivalue_line('usefixtures', fixture)
 
     # Warnings
@@ -633,6 +633,7 @@ def src_volume_labels():
 
 
 def _fail(*args, **kwargs):
+    __tracebackhide__ = True
     raise AssertionError('Test should not download')
 
 

--- a/mne/datasets/sleep_physionet/_utils.py
+++ b/mne/datasets/sleep_physionet/_utils.py
@@ -92,13 +92,12 @@ def _update_sleep_temazepam_records(fname=TEMAZEPAM_SLEEP_RECORDS):
     tmp = _TempDir()
 
     # Download subjects info.
-    fname = 'ST-subjects.xls'
-    subjects_fname = op.join(tmp, fname)
+    subjects_fname = op.join(tmp, 'ST-subjects.xls')
     pooch.retrieve(
         url=TEMAZEPAM_RECORDS_URL,
         known_hash=f"sha1:{TEMAZEPAM_RECORDS_URL_SHA1}",
         path=tmp,
-        fname=fname
+        fname=op.basename(subjects_fname)
     )
 
     # Load and Massage the checksums.
@@ -158,13 +157,12 @@ def _update_sleep_age_records(fname=AGE_SLEEP_RECORDS):
     tmp = _TempDir()
 
     # Download subjects info.
-    fname = 'SC-subjects.xls'
-    subjects_fname = op.join(tmp, fname)
+    subjects_fname = op.join(tmp, 'SC-subjects.xls')
     pooch.retrieve(
         url=AGE_RECORDS_URL,
         known_hash=f"sha1:{AGE_RECORDS_URL_SHA1}",
         path=tmp,
-        fname=fname
+        fname=op.basename(subjects_fname)
     )
 
     # Load and Massage the checksums.

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -2015,11 +2015,13 @@ def plot_compare_evokeds(evokeds, picks=None, colors=None,
         indicating steps or percentiles (respectively) along the colormap. If
         ``cmap`` is ``None``, list elements or dict values of ``colors`` must
         be :class:`ints <int>` or valid :doc:`matplotlib colors
-        <tutorials/colors/colors>`; lists are cycled through sequentially,
+        <matplotlib:tutorials/colors/colors>`; lists are cycled through
+        sequentially,
         while dicts must have keys matching the keys or conditions of an
         ``evokeds`` dict (see Notes for details). If ``None``, the current
-        :doc:`matplotlib color cycle <gallery/color/color_cycle_default>` is
-        used. Defaults to ``None``.
+        :doc:`matplotlib color cycle
+        <matplotlib:gallery/color/color_cycle_default>`
+        is used. Defaults to ``None``.
     linestyles : list | dict | None
         Styles to use when plotting the ERP/F lines. If a :class:`list` or
         :class:`dict`, elements must be valid :doc:`matplotlib linestyles

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -642,7 +642,7 @@ def plot_events(events, sfreq=None, first_samp=0, color=None, event_id=None,
         Dictionary of event_id integers as keys and colors as values. If None,
         colors are automatically drawn from a default list (cycled through if
         number of events longer than list of default colors). Color can be any
-        valid :doc:`matplotlib color <tutorials/colors/colors>`.
+        valid :doc:`matplotlib color <matplotlib:tutorials/colors/colors>`.
     event_id : dict | None
         Dictionary of event labels (e.g. 'aud_l') as keys and their associated
         event_id values. Labels are used to plot a legend. If None, no legend


### PR DESCRIPTION
A few fixes:

1. We errantly started to override the `fname` argument in [#9742](https://github.com/mne-tools/mne-python/pull/9742/files#diff-f5e016349dc0d44312eaaff21e34539015b5355b621f200cb99910a56dcb2820R95), which manifested as `SC-subjects.xls` and `ST-subjects.xls` appearing in whatever directory the tests were being run from, which was annoying because `git status` would show them as untracked files.
2. Fixes some path problems on Sphinx 5 using `:doc:`, matplotlib ones fixed by prepending `matplotlib:` and the MNE ones (which should probably work but don't, unclear what the problem is) just worked around using `:ref:` which points to the same place effectively.
3. Fixes our usage of autouse figures. I don't think the `plt.close('all')` one was actually being used until now, so this could perhaps help with memory usage and/or speed (or it might not matter, but it's still cleaner).