### PR TITLE
MRG: Fix warning in KIT reader

### DIFF
--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -513,7 +513,7 @@ def get_kit_info(rawfile, allow_unknown_format, standardize_names=None,
             version_string = "V%iR%03i" % (version, revision)
             if allow_unknown_format:
                 unsupported_format = True
-                warn("Force loading KIT format %s", version_string)
+                warn("Force loading KIT format %s" % version_string)
             else:
                 raise UnsupportedKITFormat(
                     version_string,

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -3,7 +3,6 @@
 # License: BSD-3-Clause
 
 import os.path as op
-from shutil import copyfile
 
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -150,6 +150,7 @@ def test_data(tmp_path):
     assert_array_equal(find_events(raw), [[91, 0, 2]])
 
 
+@requires_testing_data
 def test_unknown_format(tmp_path):
     """Test our warning about an unknown format."""
     fname = tmp_path / op.basename(ricoh_path)

--- a/mne/io/kit/tests/test_kit.py
+++ b/mne/io/kit/tests/test_kit.py
@@ -3,6 +3,7 @@
 # License: BSD-3-Clause
 
 import os.path as op
+from shutil import copyfile
 
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
@@ -18,6 +19,7 @@ from mne.transforms import apply_trans
 from mne.utils import assert_dig_allclose
 from mne.io import read_raw_fif, read_raw_kit, read_epochs_kit
 from mne.io.constants import FIFF
+from mne.io.kit.kit import get_kit_info
 from mne.io.kit.coreg import read_sns
 from mne.io.kit.constants import KIT
 from mne.io.tests.test_raw import _test_raw_reader
@@ -147,6 +149,28 @@ def test_data(tmp_path):
     assert_equal(raw.info['chs'][160]['kind'], FIFF.FIFFV_EEG_CH)
     assert_equal(raw.info['chs'][160]['coil_type'], FIFF.FIFFV_COIL_EEG)
     assert_array_equal(find_events(raw), [[91, 0, 2]])
+
+
+def test_unknown_format(tmp_path):
+    """Test our warning about an unknown format."""
+    fname = tmp_path / op.basename(ricoh_path)
+    _, kit_info = get_kit_info(ricoh_path, allow_unknown_format=False)
+    n_before = kit_info['dirs'][KIT.DIR_INDEX_SYSTEM]['offset']
+    with open(fname, 'wb') as fout:
+        with open(ricoh_path, 'rb') as fin:
+            fout.write(fin.read(n_before))
+            version, revision = np.fromfile(fin, '<i4', 2)
+            assert version > 2  # good
+            version = 1  # bad
+            np.array([version, revision], '<i4').tofile(fout)
+            fout.write(fin.read())
+    with pytest.raises(ValueError, match='SQD file format V1R000 is not offi'):
+        read_raw_kit(fname)
+    # it's not actually an old file, so it actually raises an exception later
+    # about an unknown datatype
+    with pytest.raises(Exception):
+        with pytest.warns(RuntimeWarning, match='Force loading'):
+            read_raw_kit(fname, allow_unknown_format=True)
 
 
 def _assert_sinusoid(data, t, freq, amp, msg):


### PR DESCRIPTION
The issue was raised on the discourse forum [here](https://mne.discourse.group/t/unable-to-load-data-with-mne-io-read-raw-kit/3983/2). This line is not covered by test cases.
As far as I can tell with this simple regex match `warn\(['"].*['"],.*\)`, it's the only place where this syntax for `logger.warning` was used.