### PR TITLE
[MRG, MAINT] Fix constant

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -60,6 +60,8 @@ Bugs
 
 - :class:`mne.Report` now raises an exception if invalid tags were passed (:gh:`9970` by `Richard Höchenberger`_)
 
+- Fix bug in :func:`mne.get_montage_volume_labels` that set the maximum number of voxels to be included too low causing unwanted capping of the included voxel labels (:gh:`10021` by `Alex Rockhill`_)
+
 API changes
 ~~~~~~~~~~~
 - Nothing yet

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -1925,7 +1925,7 @@ def warp_montage_volume(montage, base_image, reg_affine, sdr_morph,
     return montage_warped, image_from, image_to
 
 
-_VOXELS_MAX = 1024  # define constant to avoid runtime issues
+_VOXELS_MAX = 3 ** 8  # define constant to avoid runtime issues
 
 
 @fill_doc

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -1958,6 +1958,9 @@ def get_montage_volume_labels(montage, subject, subjects_dir=None,
     _validate_type(montage, DigMontage, 'montage')
     _validate_type(dist, (int, float), 'dist')
 
+    if dist < 0 or dist > 10:
+        raise ValueError('`dist` must be between 0 and 10')
+
     aseg, aseg_data = _get_aseg(aseg, subject, subjects_dir)
 
     # read freesurfer lookup table

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -1925,7 +1925,7 @@ def warp_montage_volume(montage, base_image, reg_affine, sdr_morph,
     return montage_warped, image_from, image_to
 
 
-_VOXELS_MAX = 100  # define constant to avoid runtime issues
+_VOXELS_MAX = 1024  # define constant to avoid runtime issues
 
 
 @fill_doc

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -1925,7 +1925,7 @@ def warp_montage_volume(montage, base_image, reg_affine, sdr_morph,
     return montage_warped, image_from, image_to
 
 
-_VOXELS_MAX = 3 ** 8  # define constant to avoid runtime issues
+_VOXELS_MAX = 1000  # define constant to avoid runtime issues
 
 
 @fill_doc

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -282,6 +282,8 @@ def test_get_montage_volume_labels():
                        match='Coordinate frame not supported'):
         get_montage_volume_labels(
             fail_montage, 'sample', subjects_dir, aseg='aseg')
+    with pytest.raises(ValueError, match='between 0 and 10'):
+        get_montage_volume_labels(montage, 'sample', subjects_dir, dist=11)
 
 
 def test_voxel_neighbors():


### PR DESCRIPTION
In using this code on my own data, I realized that 100 voxels is a very small amount in a 256 x 256 x 256 image and you are likely to want at least a few more for context when using `mne.get_montage_volume_labels`. I guess this could be changed to a parameter but I think it's better not to have to deal with. If it were done away with altogether though it could cause runtime issues.