### PR TITLE
add nitime to intersphinx; deduplicate some docstrings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -142,6 +142,7 @@ intersphinx_mapping = {
     'joblib': ('https://joblib.readthedocs.io/en/latest', None),
     'nibabel': ('https://nipy.org/nibabel', None),
     'nilearn': ('http://nilearn.github.io', None),
+    'nitime': ('https://nipy.org/nitime/', None),
     'surfer': ('https://pysurfer.github.io/', None),
     'mne_bids': ('https://mne.tools/mne-bids/stable', None),
     'mne-connectivity': ('https://mne.tools/mne-connectivity/stable', None),

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -350,10 +350,7 @@ class PSDEstimator(TransformerMixin):
         bandwidth.
     n_jobs : int
         Number of parallel jobs to use (only used if adaptive=True).
-    normalization : str
-        Either "full" or "length" (default). If "full", the PSD will
-        be normalized by the sampling rate as well as the length of
-        the signal (as in nitime package).
+    %(normalization)s
     %(verbose)s
 
     See Also

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -385,10 +385,7 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
     low_bias : bool
         Only use tapers with more than 90%% spectral concentration within
         bandwidth.
-    normalization : str
-        Either "full" or "length" (default). If "full", the PSD will
-        be normalized by the sampling rate as well as the length of
-        the signal (as in nitime package).
+    %(normalization)s
     %(n_jobs)s
     %(verbose)s
 

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -287,10 +287,7 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     low_bias : bool
         Only use tapers with more than 90%% spectral concentration within
         bandwidth.
-    normalization : str
-        Either "full" or "length" (default). If "full", the PSD will
-        be normalized by the sampling rate as well as the length of
-        the signal (as in nitime package).
+    %(normalization)s
     %(picks_good_data_noref)s
     proj : bool
         Apply SSP projection vectors. If inst is ndarray this is not used.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1247,7 +1247,7 @@ weight_norm : str | None
         The Neural Activity Index :footcite:`VanVeenEtAl1997` will be computed,
         which simply scales all values from ``'unit-noise-gain'`` by a fixed
         value.
-    - ``'unit-noise-gain-invariante'``
+    - ``'unit-noise-gain-invariant'``
         Compute a rotation-invariant normalization using the matrix square
         root. This differs from ``'unit-noise-gain'`` only when
         ``pick_ori='vector'``, creating a solution that:

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1608,6 +1608,12 @@ docdict["plot_psd_spatial_colors"] = """
 spatial_colors : bool
     Whether to use spatial colors. Only used when ``average=False``.
 """
+docdict['normalization'] = """\
+normalization : 'full' | 'length'
+    Normalization strategy. If "full", the PSD will be normalized by the
+    sampling rate as well as the length of the signal (as in :mod:`nitime`).
+    Default is `'length'`.\
+"""
 
 # plot_projs_topomap
 docdict["proj_topomap_kwargs"] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1611,8 +1611,8 @@ spatial_colors : bool
 docdict['normalization'] = """\
 normalization : 'full' | 'length'
     Normalization strategy. If "full", the PSD will be normalized by the
-    sampling rate as well as the length of the signal (as in :mod:`nitime`).
-    Default is ``'length'``.\
+    sampling rate as well as the length of the signal (as in
+    :ref:`Nitime <nitime:users-guide>`). Default is ``'length'``.\
 """
 
 # plot_projs_topomap

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1612,7 +1612,7 @@ docdict['normalization'] = """\
 normalization : 'full' | 'length'
     Normalization strategy. If "full", the PSD will be normalized by the
     sampling rate as well as the length of the signal (as in :mod:`nitime`).
-    Default is `'length'`.\
+    Default is ``'length'``.\
 """
 
 # plot_projs_topomap

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -952,10 +952,7 @@ def plot_epochs_psd(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     low_bias : bool
         Only use tapers with more than 90%% spectral concentration within
         bandwidth.
-    normalization : str
-        Either "full" or "length" (default). If "full", the PSD will
-        be normalized by the sampling rate as well as the length of
-        the signal (as in nitime package).
+    %(normalization)s
     %(plot_psd_picks_good_data)s
     ax : instance of Axes | None
         Axes to plot into. If None, axes will be created.

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1865,10 +1865,7 @@ def plot_epochs_psd_topomap(epochs, bands=None,
     low_bias : bool
         Only use tapers with more than 90%% spectral concentration within
         bandwidth.
-    normalization : str
-        Either "full" or "length" (default). If "full", the PSD will
-        be normalized by the sampling rate as well as the length of
-        the signal (as in nitime package).
+    %(normalization)s
     ch_type : 'mag' | 'grad' | 'planar1' | 'planar2' | 'eeg' | None
         The channel type to plot. For 'grad', the gradiometers are collected in
         pairs and the mean for each pair is plotted. If None, then first


### PR DESCRIPTION
follow-up to #10030, I realized too late that all those docstrings were identical.

@guiomar FYI, this PR does what I would have suggested you do in #10030 if I had thought of it before merging:

1. make `nitime` into a link that goes to their documentation; this is possible because both packages use `sphinx` to build their docs so we can use intersphinx to cross-link to their module
2. since all 5 instances of the `normalization` docstring entry were identical, I've abstracted them out into our `docdict` so that in future we only need to change it in one place.