### PR TITLE
Add pick_types to info

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,6 +34,8 @@ Enhancements
 
 - Add support for reading haemoglobin fNIRS data to :func:`mne.io.read_raw_snirf` (:gh:`9929` by `Robert Luke`_)
 
+- Add :meth:`~mne.io.Info.pick_types` to Info instances (:gh:`xxxx` by `Mathieu Scheltienne`_)
+
 Bugs
 ~~~~
 - Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSER_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,7 +34,7 @@ Enhancements
 
 - Add support for reading haemoglobin fNIRS data to :func:`mne.io.read_raw_snirf` (:gh:`9929` by `Robert Luke`_)
 
-- Add :meth:`~mne.io.Info.pick_types` to Info instances (:gh:`xxxx` by `Mathieu Scheltienne`_)
+- Add :meth:`~mne.io.Info.pick_types` to Info instances (:gh:`10035` by `Mathieu Scheltienne`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,7 +34,7 @@ Enhancements
 
 - Add support for reading haemoglobin fNIRS data to :func:`mne.io.read_raw_snirf` (:gh:`9929` by `Robert Luke`_)
 
-- Add `~mne.io.Info.pick_types` to Info instances (:gh:`10035` by `Mathieu Scheltienne`_)
+- Add `~mne.Info.pick_types` to Info instances (:gh:`10035` by `Mathieu Scheltienne`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,7 +34,7 @@ Enhancements
 
 - Add support for reading haemoglobin fNIRS data to :func:`mne.io.read_raw_snirf` (:gh:`9929` by `Robert Luke`_)
 
-- Add :meth:`~mne.io.Info.pick_types` to Info instances (:gh:`10035` by `Mathieu Scheltienne`_)
+- Add `~mne.io.Info.pick_types` to Info instances (:gh:`10035` by `Mathieu Scheltienne`_)
 
 Bugs
 ~~~~

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -684,68 +684,11 @@ class UpdateChannelsMixin(object):
                    seeg=False, dipole=False, gof=False, bio=False,
                    ecog=False, fnirs=False, csd=False, dbs=False, include=(),
                    exclude='bads', selection=None, verbose=None):
-        """Pick some channels by type and names.
+        """%(pick_types_header)s
 
         Parameters
         ----------
-        meg : bool | str
-            If True include MEG channels. If string it can be 'mag', 'grad',
-            'planar1' or 'planar2' to select only magnetometers, all
-            gradiometers, or a specific type of gradiometer.
-        eeg : bool
-            If True include EEG channels.
-        stim : bool
-            If True include stimulus channels.
-        eog : bool
-            If True include EOG channels.
-        ecg : bool
-            If True include ECG channels.
-        emg : bool
-            If True include EMG channels.
-        ref_meg : bool | str
-            If True include CTF / 4D reference channels. If 'auto', reference
-            channels are included if compensations are present and ``meg`` is
-            not False. Can also be the string options for the ``meg``
-            parameter.
-        misc : bool
-            If True include miscellaneous analog channels.
-        resp : bool
-            If ``True`` include respiratory channels.
-        chpi : bool
-            If True include continuous HPI coil channels.
-        exci : bool
-            Flux excitation channel used to be a stimulus channel.
-        ias : bool
-            Internal Active Shielding data (maybe on Triux only).
-        syst : bool
-            System status channel information (on Triux systems only).
-        seeg : bool
-            Stereotactic EEG channels.
-        dipole : bool
-            Dipole time course channels.
-        gof : bool
-            Dipole goodness of fit channels.
-        bio : bool
-            Bio channels.
-        ecog : bool
-            Electrocorticography channels.
-        fnirs : bool | str
-            Functional near-infrared spectroscopy channels. If True include all
-            fNIRS channels. If False (default) include none. If string it can
-            be 'hbo' (to include channels measuring oxyhemoglobin) or 'hbr' (to
-            include channels measuring deoxyhemoglobin).
-        csd : bool
-            EEG-CSD channels.
-        dbs : bool
-            Deep brain stimulation channels.
-        include : list of str
-            List of additional channels to include. If empty do not include
-            any.
-        exclude : list of str | str
-            List of channels to exclude. If 'bads' (default), exclude channels
-            in ``info['bads']``.
-        selection : list of str
-            Restrict sensor channels (MEG, EEG) to this list of channel names.
+        %(pick_types_parameters)s
         %(verbose_meth)s
 
         Returns

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -684,7 +684,7 @@ class UpdateChannelsMixin(object):
                    seeg=False, dipole=False, gof=False, bio=False,
                    ecog=False, fnirs=False, csd=False, dbs=False, include=(),
                    exclude='bads', selection=None, verbose=None):
-        """%(pick_types_header)s
+        """Pick some channels by type and names.
 
         Parameters
         ----------

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1040,7 +1040,7 @@ class Info(dict, MontageMixin):
                    seeg=False, dipole=False, gof=False, bio=False,
                    ecog=False, fnirs=False, csd=False, dbs=False, include=(),
                    exclude='bads', selection=None, verbose=None):
-        """%(pick_types_header)s
+        """Pick some channels by type and names.
 
         Parameters
         ----------

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1033,74 +1033,18 @@ class Info(dict, MontageMixin):
                             ordered=ordered)
         return pick_info(self, sel, copy=False, verbose=False)
 
+    @fill_doc
     def pick_types(self, meg=False, eeg=False, stim=False, eog=False,
                    ecg=False, emg=False, ref_meg='auto', misc=False,
                    resp=False, chpi=False, exci=False, ias=False, syst=False,
                    seeg=False, dipole=False, gof=False, bio=False,
                    ecog=False, fnirs=False, csd=False, dbs=False, include=(),
                    exclude='bads', selection=None, verbose=None):
-        """Pick some channels by type and names.
+        """%(pick_types_header)s
 
         Parameters
         ----------
-        meg : bool | str
-            If True include MEG channels. If string it can be 'mag', 'grad',
-            'planar1' or 'planar2' to select only magnetometers, all
-            gradiometers, or a specific type of gradiometer.
-        eeg : bool
-            If True include EEG channels.
-        stim : bool
-            If True include stimulus channels.
-        eog : bool
-            If True include EOG channels.
-        ecg : bool
-            If True include ECG channels.
-        emg : bool
-            If True include EMG channels.
-        ref_meg : bool | str
-            If True include CTF / 4D reference channels. If 'auto', reference
-            channels are included if compensations are present and ``meg`` is
-            not False. Can also be the string options for the ``meg``
-            parameter.
-        misc : bool
-            If True include miscellaneous analog channels.
-        resp : bool
-            If ``True`` include respiratory channels.
-        chpi : bool
-            If True include continuous HPI coil channels.
-        exci : bool
-            Flux excitation channel used to be a stimulus channel.
-        ias : bool
-            Internal Active Shielding data (maybe on Triux only).
-        syst : bool
-            System status channel information (on Triux systems only).
-        seeg : bool
-            Stereotactic EEG channels.
-        dipole : bool
-            Dipole time course channels.
-        gof : bool
-            Dipole goodness of fit channels.
-        bio : bool
-            Bio channels.
-        ecog : bool
-            Electrocorticography channels.
-        fnirs : bool | str
-            Functional near-infrared spectroscopy channels. If True include all
-            fNIRS channels. If False (default) include none. If string it can
-            be 'hbo' (to include channels measuring oxyhemoglobin) or 'hbr' (to
-            include channels measuring deoxyhemoglobin).
-        csd : bool
-            EEG-CSD channels.
-        dbs : bool
-            Deep brain stimulation channels.
-        include : list of str
-            List of additional channels to include. If empty do not include
-            any.
-        exclude : list of str | str
-            List of channels to exclude. If 'bads' (default), exclude channels
-            in ``info['bads']``.
-        selection : list of str
-            Restrict sensor channels (MEG, EEG) to this list of channel names.
+        %(pick_types_parameters)s
         %(verbose_meth)s
 
         Returns

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1033,6 +1033,100 @@ class Info(dict, MontageMixin):
                             ordered=ordered)
         return pick_info(self, sel, copy=False, verbose=False)
 
+    def pick_types(self, meg=False, eeg=False, stim=False, eog=False,
+                   ecg=False, emg=False, ref_meg='auto', misc=False,
+                   resp=False, chpi=False, exci=False, ias=False, syst=False,
+                   seeg=False, dipole=False, gof=False, bio=False,
+                   ecog=False, fnirs=False, csd=False, dbs=False, include=(),
+                   exclude='bads', selection=None, verbose=None):
+        """Pick some channels by type and names.
+
+        Parameters
+        ----------
+        meg : bool | str
+            If True include MEG channels. If string it can be 'mag', 'grad',
+            'planar1' or 'planar2' to select only magnetometers, all
+            gradiometers, or a specific type of gradiometer.
+        eeg : bool
+            If True include EEG channels.
+        stim : bool
+            If True include stimulus channels.
+        eog : bool
+            If True include EOG channels.
+        ecg : bool
+            If True include ECG channels.
+        emg : bool
+            If True include EMG channels.
+        ref_meg : bool | str
+            If True include CTF / 4D reference channels. If 'auto', reference
+            channels are included if compensations are present and ``meg`` is
+            not False. Can also be the string options for the ``meg``
+            parameter.
+        misc : bool
+            If True include miscellaneous analog channels.
+        resp : bool
+            If ``True`` include respiratory channels.
+        chpi : bool
+            If True include continuous HPI coil channels.
+        exci : bool
+            Flux excitation channel used to be a stimulus channel.
+        ias : bool
+            Internal Active Shielding data (maybe on Triux only).
+        syst : bool
+            System status channel information (on Triux systems only).
+        seeg : bool
+            Stereotactic EEG channels.
+        dipole : bool
+            Dipole time course channels.
+        gof : bool
+            Dipole goodness of fit channels.
+        bio : bool
+            Bio channels.
+        ecog : bool
+            Electrocorticography channels.
+        fnirs : bool | str
+            Functional near-infrared spectroscopy channels. If True include all
+            fNIRS channels. If False (default) include none. If string it can
+            be 'hbo' (to include channels measuring oxyhemoglobin) or 'hbr' (to
+            include channels measuring deoxyhemoglobin).
+        csd : bool
+            EEG-CSD channels.
+        dbs : bool
+            Deep brain stimulation channels.
+        include : list of str
+            List of additional channels to include. If empty do not include
+            any.
+        exclude : list of str | str
+            List of channels to exclude. If 'bads' (default), exclude channels
+            in ``info['bads']``.
+        selection : list of str
+            Restrict sensor channels (MEG, EEG) to this list of channel names.
+        %(verbose_meth)s
+
+        Returns
+        -------
+        info : instance of Info.
+            The modified Info object.
+
+        See Also
+        --------
+        pick_channels
+
+        Notes
+        -----
+        Operates in-place.
+
+        .. versionadded:: 1.0.0
+        """
+        sel = pick_types(
+            self, meg=meg, eeg=eeg, stim=stim, eog=eog, ecg=ecg, emg=emg,
+            ref_meg=ref_meg, misc=misc, resp=resp, chpi=chpi, exci=exci,
+            ias=ias, syst=syst, seeg=seeg, dipole=dipole, gof=gof, bio=bio,
+            ecog=ecog, fnirs=fnirs, dbs=dbs, include=include, exclude=exclude,
+            selection=selection)
+
+        return pick_info(self, sel, copy=False, verbose=False)
+
     @property
     def ch_names(self):
         return self['ch_names']

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -372,68 +372,12 @@ def pick_types(info, meg=False, eeg=False, stim=False, eog=False, ecg=False,
                exci=False, ias=False, syst=False, seeg=False, dipole=False,
                gof=False, bio=False, ecog=False, fnirs=False, csd=False,
                dbs=False, include=(), exclude='bads', selection=None):
-    """Pick channels by type and names.
+    """%(pick_types_header)s
 
     Parameters
     ----------
     %(info_not_none)s
-    meg : bool | str
-        If True include MEG channels. If string it can be 'mag', 'grad',
-        'planar1' or 'planar2' to select only magnetometers, all gradiometers,
-        or a specific type of gradiometer.
-    eeg : bool
-        If True include EEG channels.
-    stim : bool
-        If True include stimulus channels.
-    eog : bool
-        If True include EOG channels.
-    ecg : bool
-        If True include ECG channels.
-    emg : bool
-        If True include EMG channels.
-    ref_meg : bool | str
-        If True include CTF / 4D reference channels. If 'auto', reference
-        channels are included if compensations are present and ``meg`` is not
-        False. Can also be the string options for the ``meg`` parameter.
-    misc : bool
-        If True include miscellaneous analog channels.
-    resp : bool
-        If True include response-trigger channel. For some MEG systems this
-        is separate from the stim channel.
-    chpi : bool
-        If True include continuous HPI coil channels.
-    exci : bool
-        Flux excitation channel used to be a stimulus channel.
-    ias : bool
-        Internal Active Shielding data (maybe on Triux only).
-    syst : bool
-        System status channel information (on Triux systems only).
-    seeg : bool
-        Stereotactic EEG channels.
-    dipole : bool
-        Dipole time course channels.
-    gof : bool
-        Dipole goodness of fit channels.
-    bio : bool
-        Bio channels.
-    ecog : bool
-        Electrocorticography channels.
-    fnirs : bool | str
-        Functional near-infrared spectroscopy channels. If True include all
-        fNIRS channels. If False (default) include none. If string it can be
-        'hbo' (to include channels measuring oxyhemoglobin) or 'hbr' (to
-        include channels measuring deoxyhemoglobin).
-    csd : bool
-        Current source density channels.
-    dbs : bool
-        Deep brain stimulation channels.
-    include : list of str
-        List of additional channels to include. If empty do not include any.
-    exclude : list of str | str
-        List of channels to exclude. If 'bads' (default), exclude channels
-        in ``info['bads']``.
-    selection : list of str
-        Restrict sensor channels (MEG, EEG) to this list of channel names.
+    %(pick_types_parameters)s
 
     Returns
     -------

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -372,7 +372,7 @@ def pick_types(info, meg=False, eeg=False, stim=False, eog=False, ecg=False,
                exci=False, ias=False, syst=False, seeg=False, dipole=False,
                gof=False, bio=False, ecog=False, fnirs=False, csd=False,
                dbs=False, include=(), exclude='bads', selection=None):
-    """%(pick_types_header)s
+    """Pick some channels by type and names.
 
     Parameters
     ----------

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -1069,5 +1069,5 @@ def test_pick_info():
     info.pick_types(eeg=True)
     assert info.ch_names == ['EEG1']
     info['bads'] = ['EEG1']
-    with pytest.raises(ValueError, 'No channels match the selection.'):
+    with pytest.raises(ValueError, match='No channels match the selection.'):
         info.pick_types(eeg=True, exclude='bads')

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -1059,3 +1059,15 @@ def test_info_bad():
             info[key] = info[key]
     with pytest.raises(ValueError, match='between meg<->head'):
         info['dev_head_t'] = Transform('mri', 'head', np.eye(4))
+
+
+def test_pick_info():
+    """Test method to pick subsets of channels from Info."""
+    info = create_info(('EEG1', 'EEG2', 'EOG1'), 1000., ('eeg', 'eeg', 'eog'))
+    info.pick_channels(('EEG1', 'EOG1'))
+    assert info.ch_names == ['EEG1', 'EOG1']
+    info.pick_types(eeg=True)
+    assert info.ch_names == ['EEG1']
+    info['bads'] = ['EEG1']
+    with pytest.raises(ValueError, 'No channels match the selection.'):
+        info.pick_types(eeg=True, exclude='bads')

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -23,7 +23,7 @@ from ..externals.decorator import FunctionMaker
 docdict = dict()
 
 # Verbose
-docdict['verbose'] = """
+docdict['verbose'] = """\
 verbose : bool | str | int | None
     Control verbosity of the logging output. If ``None``, use the default
     verbosity level. See the :ref:`logging documentation <tut-logging>` and
@@ -627,7 +627,7 @@ picks : int | list of int | slice | None
 
 # Pick types
 docdict['pick_types_header'] = 'Pick some channels by type and names.'
-docdict['pick_types_parameters'] = """
+docdict['pick_types_parameters'] = """\
 meg : bool | str
     If True include MEG channels. If string it can be 'mag', 'grad',
     'planar1' or 'planar2' to select only magnetometers, all
@@ -685,8 +685,7 @@ exclude : list of str | str
     List of channels to exclude. If 'bads' (default), exclude channels
     in ``info['bads']``.
 selection : list of str
-    Restrict sensor channels (MEG, EEG) to this list of channel names.
-"""
+    Restrict sensor channels (MEG, EEG) to this list of channel names."""
 
 # Units
 docdict['units'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -23,7 +23,7 @@ from ..externals.decorator import FunctionMaker
 docdict = dict()
 
 # Verbose
-docdict['verbose'] = """\
+docdict['verbose'] = """
 verbose : bool | str | int | None
     Control verbosity of the logging output. If ``None``, use the default
     verbosity level. See the :ref:`logging documentation <tut-logging>` and

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -625,6 +625,69 @@ picks : int | list of int | slice | None
     Indices of the ICA components to visualize.
 """
 
+# Pick types
+docdict['pick_types_header'] = 'Pick some channels by type and names.'
+docdict['pick_types_parameters'] = """
+meg : bool | str
+    If True include MEG channels. If string it can be 'mag', 'grad',
+    'planar1' or 'planar2' to select only magnetometers, all
+    gradiometers, or a specific type of gradiometer.
+eeg : bool
+    If True include EEG channels.
+stim : bool
+    If True include stimulus channels.
+eog : bool
+    If True include EOG channels.
+ecg : bool
+    If True include ECG channels.
+emg : bool
+    If True include EMG channels.
+ref_meg : bool | str
+    If True include CTF / 4D reference channels. If 'auto', reference
+    channels are included if compensations are present and ``meg`` is
+    not False. Can also be the string options for the ``meg``
+    parameter.
+misc : bool
+    If True include miscellaneous analog channels.
+resp : bool
+    If ``True`` include respiratory channels.
+chpi : bool
+    If True include continuous HPI coil channels.
+exci : bool
+    Flux excitation channel used to be a stimulus channel.
+ias : bool
+    Internal Active Shielding data (maybe on Triux only).
+syst : bool
+    System status channel information (on Triux systems only).
+seeg : bool
+    Stereotactic EEG channels.
+dipole : bool
+    Dipole time course channels.
+gof : bool
+    Dipole goodness of fit channels.
+bio : bool
+    Bio channels.
+ecog : bool
+    Electrocorticography channels.
+fnirs : bool | str
+    Functional near-infrared spectroscopy channels. If True include all
+    fNIRS channels. If False (default) include none. If string it can
+    be 'hbo' (to include channels measuring oxyhemoglobin) or 'hbr' (to
+    include channels measuring deoxyhemoglobin).
+csd : bool
+    EEG-CSD channels.
+dbs : bool
+    Deep brain stimulation channels.
+include : list of str
+    List of additional channels to include. If empty do not include
+    any.
+exclude : list of str | str
+    List of channels to exclude. If 'bads' (default), exclude channels
+    in ``info['bads']``.
+selection : list of str
+    Restrict sensor channels (MEG, EEG) to this list of channel names.
+"""
+
 # Units
 docdict['units'] = """
 units : str | dict | None

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -626,7 +626,6 @@ picks : int | list of int | slice | None
 """
 
 # Pick types
-docdict['pick_types_header'] = 'Pick some channels by type and names.'
 docdict['pick_types_parameters'] = """\
 meg : bool | str
     If True include MEG channels. If string it can be 'mag', 'grad',


### PR DESCRIPTION
I don't see why this method should be missing from Info (plus I actually encountered a case where I would have liked to have it). Docstrings are almost identical.. but not quite, which is why I didn't copy it with the decorator.