### PR TITLE
Revert change to fNIRS tutorial

### DIFF
--- a/tutorials/preprocessing/70_fnirs_processing.py
+++ b/tutorials/preprocessing/70_fnirs_processing.py
@@ -135,7 +135,7 @@ raw_od.info['bads'] = list(compress(raw_od.ch_names, sci < 0.5))
 # Next we convert the optical density data to haemoglobin concentration using
 # the modified Beer-Lambert law.
 
-raw_haemo = mne.preprocessing.nirs.beer_lambert_law(raw_od, ppf=6)
+raw_haemo = mne.preprocessing.nirs.beer_lambert_law(raw_od, ppf=0.1)
 raw_haemo.plot(n_channels=len(raw_haemo.ch_names),
                duration=500, show_scrollbars=False)
 


### PR DESCRIPTION
In #9843 I initially changed the default value of the beer lambert law, but then we had to leave it the same for a depreciation cycle. Somehow this change snuck through, this causes all the plots to have no data in the tutorial as reported at https://mne.discourse.group/t/fnirs-tutorial-does-not-display-visualization

in the coming weeks I will complete the transition to the new default. Can we back port this PR?