### PR TITLE
decim is actually used for epochs

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -565,9 +565,6 @@ class ICA(ContainsMixin):
         decim : int | None
             Increment for selecting only each n-th sampling point. If ``None``,
             all samples  between ``start`` and ``stop`` (inclusive) are used.
-
-            .. note:: This parameter only has an effect if ``inst`` is
-                      `~mne.io.Raw` data.
         reject, flat : dict | None
             Rejection parameters based on peak-to-peak amplitude (PTP)
             in the continuous data. Signal periods exceeding the thresholds


### PR DESCRIPTION
see https://github.com/mne-tools/mne-python/blob/main/mne/preprocessing/ica.py#L720