### PR TITLE
Limit output of __repr__ of mne.BaseEpochs and mne.Evoked to improve performance

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -36,6 +36,8 @@ Enhancements
 
 - Add ``fill_hole_size`` keyword argument to :func:`mne.viz.Brain.add_volume_labels` to close holes in the mesh (:gh:`10024` by `Alex Rockhill`_)
 
+- Changed `mne.Epochs` and `mne.Evoked` to have a more concise `__repr__` to improve interactive MNE usage in Python Interactive Console, IDEs, and debuggers when many events are handled. (:gh:`10042` by `Jan Sosulski`_)
+
 Bugs
 ~~~~
 - Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSER_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -36,7 +36,7 @@ Enhancements
 
 - Add ``fill_hole_size`` keyword argument to :func:`mne.viz.Brain.add_volume_labels` to close holes in the mesh (:gh:`10024` by `Alex Rockhill`_)
 
-- Changed `mne.Epochs` and `mne.Evoked` to have a more concise `__repr__` to improve interactive MNE usage in Python Interactive Console, IDEs, and debuggers when many events are handled. (:gh:`10042` by `Jan Sosulski`_)
+- Changed :class:`mne.Epochs` and :class:`mne.Evoked` to have a more concise ``__repr__`` to improve interactive MNE usage in Python Interactive Console, IDEs, and debuggers when many events are handled. (:gh:`10042` by `Jan Sosulski`_)
 
 Bugs
 ~~~~

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1643,7 +1643,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         """Last time point."""
         return self.times[-1]
 
-    def __repr__(self):
+    def __repr__(self, events_limit=10):
         """Build string representation."""
         s = ' %s events ' % len(self.events)
         s += '(all good)' if self._bad_dropped else '(good & bad)'
@@ -1661,10 +1661,14 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         s += ', ~%s' % (sizeof_fmt(self._size),)
         s += ', data%s loaded' % ('' if self.preload else ' not')
         s += ', with metadata' if self.metadata is not None else ''
+
         counts = ['%r: %i' % (k, sum(self.events[:, 2] == v))
-                  for k, v in sorted(self.event_id.items())]
+                  for k, v in sorted(self.event_id.items())[:events_limit]]
         if len(self.event_id) > 0:
             s += ',' + '\n '.join([''] + counts)
+        if len(self.event_id) > events_limit:
+            not_shown_events = len(self.event_id) - events_limit + 1
+            s += f"\n 'and {not_shown_events} more events ...'"
         class_name = self.__class__.__name__
         class_name = 'Epochs' if class_name == 'BaseEpochs' else class_name
         return '<%s | %s>' % (class_name, s)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1643,7 +1643,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         """Last time point."""
         return self.times[-1]
 
-    def __repr__(self, limit_events=10):
+    def __repr__(self):
         """Build string representation."""
         s = ' %s events ' % len(self.events)
         s += '(all good)' if self._bad_dropped else '(good & bad)'
@@ -1661,13 +1661,13 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         s += ', ~%s' % (sizeof_fmt(self._size),)
         s += ', data%s loaded' % ('' if self.preload else ' not')
         s += ', with metadata' if self.metadata is not None else ''
-
+        max_events = 10
         counts = ['%r: %i' % (k, sum(self.events[:, 2] == v))
-                  for k, v in sorted(self.event_id.items())[:limit_events]]
+                  for k, v in sorted(self.event_id.items())[:max_events]]
         if len(self.event_id) > 0:
             s += ',' + '\n '.join([''] + counts)
-        if limit_events is not None and len(self.event_id) > limit_events:
-            not_shown_events = len(self.event_id) - limit_events + 1
+        if len(self.event_id) > max_events:
+            not_shown_events = len(self.event_id) - max_events + 1
             s += f"\n 'and {not_shown_events} more events ...'"
         class_name = self.__class__.__name__
         class_name = 'Epochs' if class_name == 'BaseEpochs' else class_name

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1663,12 +1663,12 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         s += ', with metadata' if self.metadata is not None else ''
         max_events = 10
         counts = ['%r: %i' % (k, sum(self.events[:, 2] == v))
-                  for k, v in sorted(self.event_id.items())[:max_events]]
+                  for k, v in list(self.event_id.items())[:max_events]]
         if len(self.event_id) > 0:
             s += ',' + '\n '.join([''] + counts)
         if len(self.event_id) > max_events:
             not_shown_events = len(self.event_id) - max_events
-            s += f"\n 'and {not_shown_events} more events ...'"
+            s += f"\n and {not_shown_events} more events ..."
         class_name = self.__class__.__name__
         class_name = 'Epochs' if class_name == 'BaseEpochs' else class_name
         return '<%s | %s>' % (class_name, s)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1667,7 +1667,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         if len(self.event_id) > 0:
             s += ',' + '\n '.join([''] + counts)
         if len(self.event_id) > max_events:
-            not_shown_events = len(self.event_id) - max_events + 1
+            not_shown_events = len(self.event_id) - max_events
             s += f"\n 'and {not_shown_events} more events ...'"
         class_name = self.__class__.__name__
         class_name = 'Epochs' if class_name == 'BaseEpochs' else class_name

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1643,7 +1643,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         """Last time point."""
         return self.times[-1]
 
-    def __repr__(self, events_limit=10):
+    def __repr__(self, limit_events=10):
         """Build string representation."""
         s = ' %s events ' % len(self.events)
         s += '(all good)' if self._bad_dropped else '(good & bad)'
@@ -1663,11 +1663,11 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         s += ', with metadata' if self.metadata is not None else ''
 
         counts = ['%r: %i' % (k, sum(self.events[:, 2] == v))
-                  for k, v in sorted(self.event_id.items())[:events_limit]]
+                  for k, v in sorted(self.event_id.items())[:limit_events]]
         if len(self.event_id) > 0:
             s += ',' + '\n '.join([''] + counts)
-        if len(self.event_id) > events_limit:
-            not_shown_events = len(self.event_id) - events_limit + 1
+        if limit_events is not None and len(self.event_id) > limit_events:
+            not_shown_events = len(self.event_id) - limit_events + 1
             s += f"\n 'and {not_shown_events} more events ...'"
         class_name = self.__class__.__name__
         class_name = 'Epochs' if class_name == 'BaseEpochs' else class_name

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -304,7 +304,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         max_comment_length = 1000
         if len(self.comment) > max_comment_length:
             comment = self.comment[:max_comment_length]
-            comment += "...rest hidden. See .comment for the full description"
+            comment += "..."
         else:
             comment = self.comment
         s = "'%s' (%s, N=%s)" % (comment, self.kind, self.nave)

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -300,9 +300,10 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         fname = _check_fname(fname=fname, overwrite=True)
         write_evokeds(fname, self)
 
-    def __repr__(self, limit_comment=1000):  # noqa: D105
-        if limit_comment is not None and len(self.comment) > limit_comment:
-            comment = self.comment[:limit_comment]
+    def __repr__(self):  # noqa: D105
+        max_comment_length = 1000
+        if len(self.comment) > max_comment_length:
+            comment = self.comment[:max_comment_length]
             comment += "...rest hidden. See .comment for the full description"
         else:
             comment = self.comment

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -300,10 +300,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         fname = _check_fname(fname=fname, overwrite=True)
         write_evokeds(fname, self)
 
-    def __repr__(self):  # noqa: D105
-        limit_comment_chars = 1000
-        if len(self.comment) > limit_comment_chars:
-            comment = self.comment[:limit_comment_chars]
+    def __repr__(self, limit_comment=1000):  # noqa: D105
+        if limit_comment is not None and len(self.comment) > limit_comment:
+            comment = self.comment[:limit_comment]
             comment += "...rest hidden. See .comment for the full description"
         else:
             comment = self.comment

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -301,7 +301,13 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         write_evokeds(fname, self)
 
     def __repr__(self):  # noqa: D105
-        s = "'%s' (%s, N=%s)" % (self.comment, self.kind, self.nave)
+        limit_comment_chars = 1000
+        if len(self.comment) > limit_comment_chars:
+            comment = self.comment[:limit_comment_chars]
+            comment += "...rest hidden. See .comment for the full description"
+        else:
+            comment = self.comment
+        s = "'%s' (%s, N=%s)" % (comment, self.kind, self.nave)
         s += ", %0.5g – %0.5g sec" % (self.times[0], self.times[-1])
         s += ', baseline '
         if self.baseline is None:


### PR DESCRIPTION
#### Reference issue
Closes #10042 .


#### What does this implement/fix?
Reduce the size and load of `__repr__` output/calculations. This function is called frequently in debuggers, IDEs and interactive python consoles to describe the currently available variables / objects. When handling epochs with many events, the current implementation leads to sluggish IDE performance / printing an object to console takes very long. You can still obtain the old behaviour by explicitly calling `__repr__(limit_events=None)`.

I also changed evoked to not show comments longer than 1000 chars. Evoked does not do excessive computations in `__repr__`, as such, the performance is not impacted. But the resulting output is still extremely long. You can still obtain the old behaviour by explicitly calling `__repr__(limit_comment=None)`. Additionally the whole comment is always available in `evoked.comment`.

Note that old behaviour is only available when explicitly calling `__repr__`. Implicit calls by IDEs debuggers etc. will always use the new limited output.

#### Additional Information

I am not sure why the dict_keys are first `sorted` for `BaseEpochs` object representation but not when converting to a comment for use in `Evoked`:

https://github.com/mne-tools/mne-python/blob/34ca144db4adab33d576bb60db1d7e8661b1082f/mne/epochs.py#L1664-L1665

https://github.com/mne-tools/mne-python/blob/34ca144db4adab33d576bb60db1d7e8661b1082f/mne/epochs.py#L1115-L1117

