### PR TITLE
Add back pooch to sys_info; pin pooch min version

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -66,6 +66,8 @@ Bugs
 
 - Fix bug in :func:`mne.get_montage_volume_labels` that set the maximum number of voxels to be included too low causing unwanted capping of the included voxel labels (:gh:`10021` by `Alex Rockhill`_)
 
+- :func:`~mne.sys_info` output now contains the installed version of ``pooch``, too; this output had been accidentally removed previously (:gh:`10047` by `Richard Höchenberger`_)
+
 API changes
 ~~~~~~~~~~~
 - Nothing yet

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -474,9 +474,9 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
         Can be None to use :data:`sys.stdout`.
     show_paths : bool
         If True, print paths for each module.
-    dependencies : str
-        Can be "user" (default) to show user-relevant dependencies, or
-        "developer" to additionally show developer dependencies.
+    dependencies : 'user' | 'developer'
+        Show dependencies relevant for users (default) or for developers
+        (i.e., output includes additional dependencies).
 
         .. versionadded:: 0.24
 
@@ -548,7 +548,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
     use_mod_names = ('mne', 'numpy', 'scipy', 'matplotlib', '', 'sklearn',
                      'numba', 'nibabel', 'nilearn', 'dipy', 'cupy', 'pandas',
                      'pyvista', 'pyvistaqt', 'ipyvtklink', 'vtk',
-                     'PyQt5', 'ipympl', 'mne_qt_browser')
+                     'PyQt5', 'ipympl', 'mne_qt_browser', 'pooch')
     if dependencies == 'developer':
         use_mod_names += (
             '', 'sphinx', 'sphinx_gallery', 'numpydoc', 'pydata_sphinx_theme',

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,5 @@ tqdm
 mffpy>=0.5.7
 ipywidgets
 ipyvtklink
-pooch
+pooch >= 1.5
 mne-qt-browser

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,5 @@ tqdm
 mffpy>=0.5.7
 ipywidgets
 ipyvtklink
-pooch >= 1.5
+pooch>=1.5
 mne-qt-browser


### PR DESCRIPTION
It appears that #9886 accidentally removed `pooch` from the `sys_info` output.

I also specify a lower version requirement for `pooch` (1.5+) after a user [reported](https://mne.discourse.group/t/issue-in-loading-data-in-overview-of-meg-eeg-with-mne-python/4042/) an issue with an outdated version on the forum.

