### PR TITLE
MNT: Centralize initialization of Qt-Application

### DIFF
--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -327,28 +327,29 @@ class BrowserBase(ABC):
             data[_picks, _start:_stop] = this_data
 
     def _process_data(self, data, start, stop, picks,
-                      signals=None):
+                      thread=None):
         """Update self.mne.data after user interaction."""
         # apply projectors
         if self.mne.projector is not None:
-            if signals:
-                signals.processText.emit('Applying Projectors...')
+            # thread is the loading-thread only available in pyqtgraph-backend
+            if thread:
+                thread.processText.emit('Applying Projectors...')
             data = self.mne.projector @ data
         # get only the channels we're displaying
         data = data[picks]
         # remove DC
         if self.mne.remove_dc:
-            if signals:
-                signals.processText.emit('Removing DC...')
+            if thread:
+                thread.processText.emit('Removing DC...')
             data -= data.mean(axis=1, keepdims=True)
         # apply filter
         if self.mne.filter_coefs is not None:
-            if signals:
-                signals.processText.emit('Apply Filter...')
+            if thread:
+                thread.processText.emit('Apply Filter...')
             self._apply_filter(data, start, stop, picks)
         # scale the data for display in a 1-vertical-axis-unit slot
-        if signals:
-            signals.processText.emit('Scale Data...')
+        if thread:
+            thread.processText.emit('Scale Data...')
         this_names = self.mne.ch_names[picks]
         this_types = self.mne.ch_types[picks]
         stims = this_types == 'stim'

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -14,7 +14,6 @@ Actual implementation of _Renderer and _Projection classes.
 from contextlib import contextmanager
 from distutils.version import LooseVersion
 import os
-import platform
 import sys
 import warnings
 
@@ -23,7 +22,7 @@ import vtk
 
 from ._abstract import _AbstractRenderer
 from ._utils import (_get_colormap_from_array, _alpha_blend_background,
-                     ALLOWED_QUIVER_MODES, _init_mne_qtapp, _init_qt_resources)
+                     ALLOWED_QUIVER_MODES, _init_mne_qtapp)
 from ...fixes import _get_args, _point_data, _cell_data
 from ...transforms import apply_trans
 from ...utils import copy_base_doc_to_subclass_doc, _check_option

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -23,7 +23,7 @@ import vtk
 
 from ._abstract import _AbstractRenderer
 from ._utils import (_get_colormap_from_array, _alpha_blend_background,
-                     ALLOWED_QUIVER_MODES, _init_qt_resources)
+                     ALLOWED_QUIVER_MODES, _init_mne_qtapp, _init_qt_resources)
 from ...fixes import _get_args, _point_data, _cell_data
 from ...transforms import apply_trans
 from ...utils import copy_base_doc_to_subclass_doc, _check_option
@@ -88,19 +88,12 @@ class _Figure(object):
 
         if self.plotter is None:
             if not self.notebook:
-                from PyQt5.QtWidgets import QApplication
-                app = QApplication.instance()
-                if app is None:
-                    app = QApplication(["MNE"])
+                app = _init_mne_qtapp(enable_icon=hasattr(plotter_class,
+                                                          'set_icon'))
                 self.store['app'] = app
             plotter = plotter_class(**self.store)
             plotter.background_color = self.background_color
             self.plotter = plotter
-            if not self.notebook and hasattr(plotter_class, 'set_icon'):
-                _init_qt_resources()
-                _process_events(plotter)
-                kind = 'bigsur-' if platform.mac_ver()[0] >= '10.16' else ''
-                plotter.set_icon(f":/mne-{kind}icon.png")
         if self.plotter.iren is not None:
             self.plotter.iren.initialize()
         _process_events(self.plotter)

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -135,10 +135,13 @@ def _init_mne_qtapp(enable_icon=True, pg_app=False):
 
     # Fix from cbrnr/mnelab for app name in menu bar
     if sys.platform.startswith("darwin"):
-        # set bundle name on macOS (app name shown in the menu bar)
-        from Foundation import NSBundle
-        bundle = NSBundle.mainBundle()
-        info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
-        info["CFBundleName"] = app_name
+        try:
+            # set bundle name on macOS (app name shown in the menu bar)
+            from Foundation import NSBundle
+            bundle = NSBundle.mainBundle()
+            info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
+            info["CFBundleName"] = app_name
+        except ModuleNotFoundError:
+            pass
 
     return app

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -113,22 +113,32 @@ def _init_mne_qtapp(enable_icon=True, pg_app=False):
     app: ``PyQt5.QtWidgets.QApplication``
         Instance of QApplication.
     """
-    from PyQt5.QtCore import Qt
     from PyQt5.QtWidgets import QApplication
     from PyQt5.QtGui import QIcon
 
+    app_name = 'MNE-Python'
+    organization_name = 'MNE'
+
     if pg_app:
         from pyqtgraph import mkQApp
-        app = mkQApp('MNE-Python')
+        app = mkQApp(app_name)
     else:
-        app = QApplication.instance() or QApplication(sys.argv or ['MNE'])
-        app.setApplicationName('MNE-Python')
-    app.setOrganizationName('MNE')
+        app = QApplication.instance() or QApplication(sys.argv or [app_name])
+        app.setApplicationName(app_name)
+    app.setOrganizationName(organization_name)
 
     if enable_icon:
         # Set icon
         _init_qt_resources()
         kind = 'bigsur-' if platform.mac_ver()[0] >= '10.16' else ''
         app.setWindowIcon(QIcon(f":/mne-{kind}icon.png"))
+
+    # Fix from cbrnr/mnelab for app name in menu bar
+    if sys.platform.startswith("darwin"):
+        # set bundle name on macOS (app name shown in the menu bar)
+        from Foundation import NSBundle
+        bundle = NSBundle.mainBundle()
+        info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
+        info["CFBundleName"] = app_name
 
     return app

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -6,7 +6,8 @@
 #          Guillaume Favelier <guillaume.favelier@gmail.com>
 #
 # License: Simplified BSD
-
+import platform
+import sys
 from contextlib import contextmanager
 import numpy as np
 import collections.abc
@@ -93,3 +94,41 @@ def _qt_disable_paint(widget):
         yield
     finally:
         widget.paintEvent = paintEvent
+
+
+def _init_mne_qtapp(enable_icon=True, pg_app=False):
+    """Get QApplication-instance for MNE-Python.
+
+    Parameter
+    ---------
+    enable_icon: bool
+        If to set an MNE-icon for the app.
+    pg_app: bool
+        If to create the QApplication with pyqtgraph. For an until know
+        undiscovered reason the pyqtgraph-browser won't show without
+        mkQApp from pyqtgraph.
+
+    Returns
+    -------
+    app: ``PyQt5.QtWidgets.QApplication``
+        Instance of QApplication.
+    """
+    from PyQt5.QtCore import Qt
+    from PyQt5.QtWidgets import QApplication
+    from PyQt5.QtGui import QIcon
+
+    if pg_app:
+        from pyqtgraph import mkQApp
+        app = mkQApp('MNE-Python')
+    else:
+        app = QApplication.instance() or QApplication(sys.argv or ['MNE'])
+        app.setApplicationName('MNE-Python')
+    app.setOrganizationName('MNE')
+
+    if enable_icon:
+        # Set icon
+        _init_qt_resources()
+        kind = 'bigsur-' if platform.mac_ver()[0] >= '10.16' else ''
+        app.setWindowIcon(QIcon(f":/mne-{kind}icon.png"))
+
+    return app

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -119,6 +119,21 @@ def _init_mne_qtapp(enable_icon=True, pg_app=False):
     app_name = 'MNE-Python'
     organization_name = 'MNE'
 
+    # Fix from cbrnr/mnelab for app name in menu bar
+    # This has to come *before* the creation of the QApplication to work.
+    # It also only affects the title bar, not the application dock.
+    # There seems to be no way to change the application dock from "python"
+    # at runtime.
+    if sys.platform.startswith("darwin"):
+        try:
+            # set bundle name on macOS (app name shown in the menu bar)
+            from Foundation import NSBundle
+            bundle = NSBundle.mainBundle()
+            info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
+            info["CFBundleName"] = app_name
+        except ModuleNotFoundError:
+            pass
+
     if pg_app:
         from pyqtgraph import mkQApp
         app = mkQApp(app_name)
@@ -132,16 +147,5 @@ def _init_mne_qtapp(enable_icon=True, pg_app=False):
         _init_qt_resources()
         kind = 'bigsur-' if platform.mac_ver()[0] >= '10.16' else ''
         app.setWindowIcon(QIcon(f":/mne-{kind}icon.png"))
-
-    # Fix from cbrnr/mnelab for app name in menu bar
-    if sys.platform.startswith("darwin"):
-        try:
-            # set bundle name on macOS (app name shown in the menu bar)
-            from Foundation import NSBundle
-            bundle = NSBundle.mainBundle()
-            info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
-            info["CFBundleName"] = app_name
-        except ModuleNotFoundError:
-            pass
 
     return app

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -11,7 +11,6 @@
 #          Daniel McCloy <dan@mccloy.info>
 #
 # License: Simplified BSD
-import sys
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import partial

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -129,14 +129,13 @@ def _show_browser(show=True, block=True, fig=None, **kwargs):
     if backend == 'matplotlib':
         plt_show(show, block=block, **kwargs)
     else:
-        from qtpy.QtWidgets import QApplication
-        app = QApplication.instance() or QApplication(sys.argv)
+        from PyQt5.QtWidgets import QApplication
         if show:
             fig.show()
         # If block=False, a Qt-Event-Loop has to be started
         # somewhere else in the calling code.
         if block:
-            app.exec()
+            QApplication.instance().exec()
 
 
 def tight_layout(pad=1.2, h_pad=None, w_pad=None, fig=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pyqt5>=5.10,<5.14; platform_system == "Darwin"
 pyqt5>=5.10,!=5.15.2,!=5.15.3; platform_system == "Linux"
 pyqt5>=5.10,!=5.15.3; platform_system == "Windows"
 pyqt5-sip
+pyobjc-framework-Cocoa>=5.2.0; platform_system=="Darwin"
 sip
 scikit-learn
 nibabel

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -28,7 +28,7 @@ else
 	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
 	echo "imageio-ffmpeg, xlrd, mffpy"
 	pip install --progress-bar off --pre imageio-ffmpeg xlrd mffpy
-	if [ "$OSTYPE" == "darwin"]; then
+	if [ "$OSTYPE" == "darwin"* ]; then
 	  echo "pyobjc-framework-Cocoa"
 	  pip install --progress-bar off pyobjc-framework-Cocoa>=5.2.0
   fi

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -28,6 +28,10 @@ else
 	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
 	echo "imageio-ffmpeg, xlrd, mffpy"
 	pip install --progress-bar off --pre imageio-ffmpeg xlrd mffpy
+	if [ "$OSTYPE" == "darwin"]; then
+	  echo "pyobjc-framework-Cocoa"
+	  pip install --progress-bar off pyobjc-framework-Cocoa>=5.2.0
+  fi
 fi
 pip install --progress-bar off --upgrade -r requirements_testing.txt
 if [ "${DEPS}" != "minimal" ]; then


### PR DESCRIPTION
#### Reference issue
This fixes mne-tools/mne-qt-browser#23.


#### What does this implement/fix?
This centralizes the redundant initialization of a QApplication currently needed for both the pyvista and the pyqtgraph-backend and fixes the missing app-name for macOS.


#### Additional information
For some unidentified reason, `PyQtGraphBrowser.show()` fails with a SegmentationFault if QApplication is not created with `mkQApp`. I tried around a lot but since I couldn't identify the reason, I left `mkQApp` in here for the pyqtgraph case.
