### PR TITLE
MRG, MAINT: Make subclassing easier

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -966,23 +966,11 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
             (n_channels, n_time).
             Note that due to file type limitations, the kind for all
             these will be "average".
-        by_event_type : bool
-            When ``False`` (the default) all epochs are averaged and a single
-            :class:`Evoked` object is returned. When ``True``, epochs are first
-            grouped by event type (as specified using the ``event_id``
-            parameter) and a list is returned containing a separate
-            :class:`Evoked` object for each event type. The ``.comment``
-            attribute is set to the label of the event type.
-
-            .. versionadded:: 0.24.0
+        %(by_event_type)s
 
         Returns
         -------
-        evoked : instance of Evoked | list of Evoked
-            The averaged epochs. When ``by_event_type=True`` was specified, a
-            list is returned containing a separate :class:`Evoked` object
-            for each event type. The list has the same order as the event types
-            as specified in the ``event_id`` dictionary.
+        %(by_event_type_returns_average)s
 
         Notes
         -----
@@ -1022,23 +1010,11 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         Parameters
         ----------
         %(picks_all_data)s
-        by_event_type : bool
-            When ``False`` (the default) all epochs are averaged and a single
-            :class:`Evoked` object is returned. When ``True``, epochs are first
-            grouped by event type (as specified using the ``event_id``
-            parameter) and a list is returned containing a separate
-            :class:`Evoked` object for each event type. The ``.comment``
-            attribute is set to the label of the event type.
-
-            .. versionadded:: 0.24.0
+        %(by_event_type)s
 
         Returns
         -------
-        std_err : instance of Evoked | list of Evoked
-            The standard error over epochs. When ``by_event_type=True`` was
-            specified, a list is returned containing a separate :class:`Evoked`
-            object for each event type. The list has the same order as the
-            event types as specified in the ``event_id`` dictionary.
+        %(by_event_type_returns_stderr)s
         """
         return self.average(picks=picks, method="std",
                             by_event_type=by_event_type)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2435,6 +2435,32 @@ event_repeated : str
 
     .. versionadded:: 0.19
 """
+docdict['by_event_type'] = """
+by_event_type : bool
+    When ``False`` (the default) all epochs are processed together and a single
+    :class:`~mne.Evoked` object is returned. When ``True``, epochs are first
+    grouped by event type (as specified using the ``event_id`` parameter) and a
+    list is returned containing a separate :class:`~mne.Evoked` object for each
+    event type. The ``.comment`` attribute is set to the label of the event
+    type.
+
+    .. versionadded:: 0.24.0
+"""
+_by_event_type_return_base = """\
+When ``by_event_type=True`` was specified, a list is returned containing a
+    separate :class:`~mne.Evoked` object for each event type. The list has the
+    same order as the event types as specified in the ``event_id``
+    dictionary."""
+docdict['by_event_type_returns_average'] = f"""
+evoked : instance of Evoked | list of Evoked
+    The averaged epochs.
+    {_by_event_type_return_base}
+"""
+docdict['by_event_type_returns_stderr'] = f"""
+std_err : instance of Evoked | list of Evoked
+    The standard error over epochs.
+    {_by_event_type_return_base}
+"""
 docdict['epochs_raw'] = """
 raw : Raw object
     An instance of `~mne.io.Raw`.


### PR DESCRIPTION
In https://github.com/mne-tools/mne-realtime/pull/35 I'm discovering that our use of
```
:class:`Evoked`
```
rather than the fully qualified
```
:class:`mne.Evoked`
```
[is problematic](https://app.circleci.com/pipelines/github/mne-tools/mne-realtime/132/workflows/e419408e-f4f8-41d5-a6ad-a885b8ad600b/jobs/149) for subclasses like RtEpochs. This changes our docstrings to be more DRY but more importantly uses
```
:class:`~mne.Evoked`
```
which will render the same way as `main` but make subclasses in other modules like `mne-realtime` work properly.

Will merge once I verify by eye that things look and work the same so that https://github.com/mne-tools/mne-realtime/pull/35 can get in and we can cut a release of mne-realtime.