### PR TITLE
DOC: add bad_acq_skip annotation behaviour

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -236,7 +236,6 @@ class Annotations(object):
     ``BAD_ACQ_SKIP`` annotation leads to specific reading/writing file
     behaviours. See :meth:`mne.io.read_raw_fif` and
     :meth:`Raw.save() <mne.io.Raw.save>` notes for details.
-
     """  # noqa: E501
 
     def __init__(self, onset, duration, description,

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -230,6 +230,13 @@ class Annotations(object):
              n                        |      |
              e                        +------+
          orig_time                 onset[0]'
+
+    **Specific annotation**
+
+    ``BAD_ACQ_SKIP`` annotation leads to specific reading/writing file
+    behaviours. See :meth:`mne.io.read_raw_fif` and
+    :meth:`Raw.save() <mne.io.Raw.save>` notes for details.
+
     """  # noqa: E501
 
     def __init__(self, onset, duration, description,

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1416,6 +1416,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         work properly on a saved concatenated file (e.g., probably some
         or all forms of SSS). It is recommended not to concatenate and
         then save raw files for this reason.
+
+        Samples annotated ``BAD_ACQ_SKIP`` are not stored in order to optimize
+        memory. Whatever values, they will be loaded as 0s when reading file.
         """
         endings = ('raw.fif', 'raw_sss.fif', 'raw_tsss.fif',
                    '_meg.fif', '_eeg.fif', '_ieeg.fif')

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -474,7 +474,6 @@ def read_raw_fif(fname, allow_maxshield=False, preload=False,
     ``BAD_ACQ_SKIP`` are **skipped**. They are removed from ``raw.times`` and
     ``raw.n_times`` parameters but ``raw.first_samp`` and ``raw.first_time``
     are updated accordingly.
-
     """
     return Raw(fname=fname, allow_maxshield=allow_maxshield,
                preload=preload, verbose=verbose,

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -469,6 +469,12 @@ def read_raw_fif(fname, allow_maxshield=False, preload=False,
     Notes
     -----
     .. versionadded:: 0.9.0
+
+    When reading a FIF file, note that the first N seconds annotated
+    ``BAD_ACQ_SKIP`` are **skipped**. They are removed from ``raw.times`` and
+    ``raw.n_times`` parameters but ``raw.first_samp`` and ``raw.first_time``
+    are updated accordingly.
+
     """
     return Raw(fname=fname, allow_maxshield=allow_maxshield,
                preload=preload, verbose=verbose,


### PR DESCRIPTION
#### Reference issue
Closes #10037.


#### What does this implement/fix?
The changes add documentation about the specific behaviour of ``BAD_ACQ_SIP`` annotation in reading/writing file:
- when saving to FIF file, samples annotated ``BAD_ACQ_SKIP`` are not stored and will be loaded as 0s when reading back
- the first N samples annotated ``BAD_ACQ_SKIP`` are skipped when reading FIF file