### PR TITLE
MRG: Docstring improvement adding more details to what the events array is.

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -38,6 +38,8 @@ Enhancements
 
 - Changed :class:`mne.Epochs` and :class:`mne.Evoked` to have a more concise ``__repr__`` to improve interactive MNE usage in Python Interactive Console, IDEs, and debuggers when many events are handled. (:gh:`10042` by `Jan Sosulski`_)
 
+- Improve docstring of ``events`` arguments and cross-referencing to :term:`events` (:gh:`10056` by `Mathieu Scheltienne`_)
+
 Bugs
 ~~~~
 - Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSER_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)
@@ -73,3 +75,5 @@ Bugs
 API changes
 ~~~~~~~~~~~
 - ``mne.Info.pick_channels`` has been deprecated. Use ``inst.pick_channels`` to pick channels from Raw|Epochs|Evoked. Use :func:`mne.pick_info` to pick channels from :class:`mne.Info` (:gh:`10039` by `Mathieu Scheltienne`_)
+
+- Argument ``event_list`` has been deprecated in favor of ``events`` in :func:`mne.write_events` (:gh:`10056` by `Mathieu Scheltienne`_)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -248,7 +248,7 @@ numpydoc_xref_ignore = {
     'n_elp', 'n_pts', 'n_tris', 'n_nodes', 'n_nonzero', 'n_events_out',
     'n_segments', 'n_orient_inv', 'n_orient_fwd', 'n_orient', 'n_dipoles_lcmv',
     'n_dipoles_fwd', 'n_picks_ref', 'n_coords', 'n_meg', 'n_good_meg',
-    'n_moments', 'n_patterns',
+    'n_moments', 'n_patterns', 'n_new_events',
     # Undocumented (on purpose)
     'RawKIT', 'RawEximia', 'RawEGI', 'RawEEGLAB', 'RawEDF', 'RawCTF', 'RawBTi',
     'RawBrainVision', 'RawCurry', 'RawNIRX', 'RawGDF', 'RawSNIRF', 'RawBOXY',

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -121,8 +121,8 @@ general neuroimaging concepts. If you think a term is missing, please consider
         included. The last column contains the event integer code. The second
         column contains the signal value of the immediately preceding sample,
         and reflects the fact that event arrays sometimes come directly from
-        analg voltage channels, AKA "trigger channels" or "stim channels". In
-        most cases, the second column is equal to zeros and can be ignored.
+        analog voltage channels, AKA "trigger channels" or "stim channels". In
+        most cases, the second column is all zeros and can be ignored.
         Event arrays can be created with :func:`mne.make_fixed_length_events`,
         :func:`mne.read_events`, and :func:`mne.find_events`.
 

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -114,15 +114,17 @@ general neuroimaging concepts. If you think a term is missing, please consider
         a narrative overview.
 
     events
-        Events correspond to specific time points in raw data; e.g.,
-        triggers, experimental condition events, etc. MNE represents events with
-        integers that are stored in numpy arrays of shape (n_events, 3), with
-        time (represented as an integer sample number) in the first column and
-        integer event code in the last column (the middle column represents the
-        signal value of the immediately previous sample, and reflects the
-        fact that event arrays sometimes come directly from analog voltage
-        channels, AKA "trigger channels" or "stim channels"). In most
-        situations the middle column can safely be set to all zeros and ignored.
+        Events correspond to specific time points in raw data; e.g., triggers,
+        experimental condition events, etc. MNE represents events with integers
+        that are stored in numpy arrays of shape (n_events, 3). The first
+        column contains the event time in samples with :term:`first_samp`
+        included. The last column contains the event integer code. The second
+        column contains the signal value of the immediately preceding sample,
+        and reflects the fact that event arrays sometimes come directly from
+        analg voltage channels, AKA "trigger channels" or "stim channels". In
+        most cases, the second column is equal to zeros and can be ignored.
+        Event arrays can be created with :func:`mne.make_fixed_length_events`,
+        :func:`mne.read_events`, and :func:`mne.find_events`.
 
     evoked
         Evoked data are obtained by averaging epochs. Typically, an evoked object

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -162,7 +162,8 @@ general neuroimaging concepts. If you think a term is missing, please consider
         consistency it is present in all :class:`~io.Raw` objects
         regardless of the source of the data. In other words,
         :attr:`~io.Raw.first_samp` will be ``0`` in :class:`~io.Raw`
-        objects loaded from non-VectorView data files.
+        objects loaded from non-VectorView data files. See also
+        :term:`last_samp`.
 
     forward
     forward solution
@@ -223,6 +224,15 @@ general neuroimaging concepts. If you think a term is missing, please consider
         a region of interest (ROI) in the literature. Labels can be defined
         anatomically (based on physical structure of the cortex) or functionally
         (based on cortical response to specific stimuli).
+
+    last_samp
+        The :attr:`~io.Raw.last_samp` attribute of :class:`~io.Raw`
+        objects is an integer representing the number of time samples that
+        passed between the onset of the hardware acquisition system and the
+        time when data stopped to be recorded to disk. This approach to sample
+        numbering is a peculiarity of VectorView MEG systems, but for
+        consistency it is present in all :class:`~io.Raw` objects
+        regardless of the source of the data. See also :term:`first_samp`.
 
     layout
         A :class:`~channels.Layout` gives sensor positions in 2

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1167,7 +1167,7 @@ def events_from_annotations(raw, event_id="auto",
                             regexp=r'^(?![Bb][Aa][Dd]|[Ee][Dd][Gg][Ee]).*$',
                             use_rounding=True, chunk_duration=None,
                             verbose=None):
-    """Get events and event_id from an Annotations object.
+    """Get :term:`events` and ``event_id`` from an Annotations object.
 
     Parameters
     ----------
@@ -1212,10 +1212,9 @@ def events_from_annotations(raw, event_id="auto",
 
     Returns
     -------
-    events : ndarray, shape (n_events, 3)
-        The events.
+    %(events)s
     event_id : dict
-        The event_id variable that can be passed to Epochs.
+        The event_id variable that can be passed to `mne.Epochs`.
 
     See Also
     --------

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1220,7 +1220,7 @@ def events_from_annotations(raw, event_id="auto",
     -------
     %(events)s
     event_id : dict
-        The event_id variable that can be passed to `mne.Epochs`.
+        The event_id variable that can be passed to :class:`~mne.Epochs`.
 
     See Also
     --------

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -342,7 +342,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
     data : ndarray | None
         If ``None``, data will be read from the Raw object. If ndarray, must be
         of shape (n_epochs, n_channels, n_times).
-    %(epochs_events_event_id)s
+    %(events_epochs)s
+    %(event_id)s
     %(epochs_tmin_tmax)s
     %(baseline_epochs)s
         Defaults to ``(None, 0)``, i.e. beginning of the the data until

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2486,7 +2486,8 @@ class Epochs(BaseEpochs):
     Parameters
     ----------
     %(epochs_raw)s
-    %(epochs_events_event_id)s
+    %(events_epochs)s
+    %(event_id)s
     %(epochs_tmin_tmax)s
     %(baseline_epochs)s
         Defaults to ``(None, 0)``, i.e. beginning of the the data until

--- a/mne/event.py
+++ b/mne/event.py
@@ -230,7 +230,9 @@ def read_events(filename, include=None, exclude=None, mask=None,
     Returns
     -------
     events: array, shape (n_events, 3)
-        The list of events.
+        The array of events. The first column contains the event time in
+        samples, with ``first_samp`` included. The second column contains
+        [...]. The third column contains the event id.
     event_id : dict
         Dictionary of ``{str: int}`` mappings of event IDs.
 
@@ -312,7 +314,9 @@ def write_events(filename, event_list):
         Note that new format event files do not contain
         the "time" column (used to be the second column).
     event_list : array, shape (n_events, 3)
-        The list of events.
+        The array of events. The first column contains the event time in
+        samples, with ``first_samp`` included. The second column contains
+        [...]. The third column contains the event id.
 
     See Also
     --------

--- a/mne/event.py
+++ b/mne/event.py
@@ -229,7 +229,7 @@ def read_events(filename, include=None, exclude=None, mask=None,
 
     Returns
     -------
-    events: array, shape (n_events, 3)
+    events : array, shape (n_events, 3)
         The array of events. The first column contains the event time in
         samples, with ``first_samp`` included. The second column contains
         [...]. The third column contains the event id.

--- a/mne/event.py
+++ b/mne/event.py
@@ -298,7 +298,6 @@ def read_events(filename, include=None, exclude=None, mask=None,
     return out
 
 
-@fill_doc
 def write_events(filename, event_list):
     """Write :term:`events` to file.
 
@@ -311,7 +310,8 @@ def write_events(filename, event_list):
         .txt) events are written as plain text.
         Note that new format event files do not contain
         the "time" column (used to be the second column).
-    %(events)s
+    event_list : array, shape (n_events, 3)
+        The list of events.
 
     See Also
     --------

--- a/mne/event.py
+++ b/mne/event.py
@@ -298,7 +298,8 @@ def read_events(filename, include=None, exclude=None, mask=None,
     return out
 
 
-def write_events(filename, event_list):
+@verbose
+def write_events(filename, events, *,  event_list=None, verbose=None):
     """Write :term:`events` to file.
 
     Parameters
@@ -310,13 +311,21 @@ def write_events(filename, event_list):
         .txt) events are written as plain text.
         Note that new format event files do not contain
         the "time" column (used to be the second column).
+    %(events)s
     event_list : array, shape (n_events, 3)
-        The list of events.
+        Deprecated, use argument events instead.
+    %(verbose)s
 
     See Also
     --------
     read_events
     """
+    if event_list is not None:
+        warn('Argument "event_list" is deprecated, use "events" instead.',
+             DeprecationWarning)
+        events = event_list
+    del event_list
+
     check_fname(filename, 'events', ('.eve', '-eve.fif', '-eve.fif.gz',
                                      '-eve.lst', '-eve.txt', '_eve.fif',
                                      '_eve.fif.gz', '_eve.lst', '_eve.txt'))
@@ -327,13 +336,13 @@ def write_events(filename, event_list):
         fid = start_file(filename)
 
         start_block(fid, FIFF.FIFFB_MNE_EVENTS)
-        write_int(fid, FIFF.FIFF_MNE_EVENT_LIST, event_list.T)
+        write_int(fid, FIFF.FIFF_MNE_EVENT_LIST, events.T)
         end_block(fid, FIFF.FIFFB_MNE_EVENTS)
 
         end_file(fid)
     else:
         f = open(filename, 'w')
-        for e in event_list:
+        for e in events:
             f.write('%6d %6d %3d\n' % tuple(e))
         f.close()
 

--- a/mne/event.py
+++ b/mne/event.py
@@ -21,13 +21,13 @@ from .io.write import write_int, start_block, start_file, end_block, end_file
 from .io.pick import pick_channels
 
 
+@fill_doc
 def pick_events(events, include=None, exclude=None, step=False):
-    """Select some events.
+    """Select some :term:`events`.
 
     Parameters
     ----------
-    events : ndarray
-        Array as returned by mne.find_events.
+    %(events)s
     include : int | list | None
         A event id to include or a list of them.
         If None all events are included.
@@ -191,7 +191,7 @@ def _read_events_fif(fid, tree):
 @verbose
 def read_events(filename, include=None, exclude=None, mask=None,
                 mask_type='and', return_event_id=False, verbose=None):
-    """Read events from fif or text file.
+    """Read :term:`events` from fif or text file.
 
     See :ref:`tut-events-vs-annotations` and :ref:`tut-event-arrays`
     for more information about events.
@@ -229,10 +229,7 @@ def read_events(filename, include=None, exclude=None, mask=None,
 
     Returns
     -------
-    events : array, shape (n_events, 3)
-        The array of events. The first column contains the event time in
-        samples, with ``first_samp`` included. The second column contains
-        [...]. The third column contains the event id.
+    %(events)s
     event_id : dict
         Dictionary of ``{str: int}`` mappings of event IDs.
 
@@ -301,8 +298,9 @@ def read_events(filename, include=None, exclude=None, mask=None,
     return out
 
 
+@fill_doc
 def write_events(filename, event_list):
-    """Write events to file.
+    """Write :term:`events` to file.
 
     Parameters
     ----------
@@ -313,10 +311,7 @@ def write_events(filename, event_list):
         .txt) events are written as plain text.
         Note that new format event files do not contain
         the "time" column (used to be the second column).
-    event_list : array, shape (n_events, 3)
-        The array of events. The first column contains the event time in
-        samples, with ``first_samp`` included. The second column contains
-        [...]. The third column contains the event id.
+    %(events)s
 
     See Also
     --------
@@ -542,7 +537,7 @@ def find_events(raw, stim_channel=None, output='onset',
                 consecutive='increasing', min_duration=0,
                 shortest_event=2, mask=None, uint_cast=False,
                 mask_type='and', initial_event=False, verbose=None):
-    """Find events from raw file.
+    """Find :term:`events` from raw file.
 
     See :ref:`tut-events-vs-annotations` and :ref:`tut-event-arrays`
     for more information about events.
@@ -601,13 +596,7 @@ def find_events(raw, stim_channel=None, output='onset',
 
     Returns
     -------
-    events : array, shape = (n_events, 3)
-        All events that were found. The first column contains the event time
-        in samples and the third column contains the event id. For output =
-        'onset' or 'step', the second column contains the value of the stim
-        channel immediately before the event/step. For output = 'offset',
-        the second column contains the value of the stim channel after the
-        event offset.
+    %(events)s
 
     See Also
     --------
@@ -761,7 +750,7 @@ def _mask_trigs(events, mask, mask_type):
 
 
 def merge_events(events, ids, new_id, replace_events=True):
-    """Merge a set of events.
+    """Merge a set of :term:`events`.
 
     Parameters
     ----------
@@ -821,13 +810,13 @@ def merge_events(events, ids, new_id, replace_events=True):
     return events_out
 
 
+@fill_doc
 def shift_time_events(events, ids, tshift, sfreq):
-    """Shift an event.
+    """Shift a set of :term:`events`.
 
     Parameters
     ----------
-    events : array, shape=(n_events, 3)
-        The events.
+    %(events)s
     ids : ndarray of int | None
         The ids of events to shift.
     tshift : float
@@ -838,7 +827,7 @@ def shift_time_events(events, ids, tshift, sfreq):
 
     Returns
     -------
-    new_events : array
+    new_events : array of int, shape (n_new_events, 3)
         The new events.
     """
     events = events.copy()
@@ -851,9 +840,10 @@ def shift_time_events(events, ids, tshift, sfreq):
     return events
 
 
+@fill_doc
 def make_fixed_length_events(raw, id=1, start=0, stop=None, duration=1.,
                              first_samp=True, overlap=0.):
-    """Make a set of events separated by a fixed duration.
+    """Make a set of :term:`events` separated by a fixed duration.
 
     Parameters
     ----------
@@ -869,10 +859,10 @@ def make_fixed_length_events(raw, id=1, start=0, stop=None, duration=1.,
     duration : float
         The duration to separate events by (in seconds).
     first_samp : bool
-        If True (default), times will have ``raw.first_samp`` added to them, as
+        If True (default), times will have :term:`first_samp` added to them, as
         in :func:`mne.find_events`. This behavior is not desirable if the
         returned events will be combined with event times that already
-        have ``raw.first_samp`` added to them, e.g. event times that come
+        have :term:`first_samp` added to them, e.g. event times that come
         from :func:`mne.find_events`.
     overlap : float
         The overlap between events (in seconds).
@@ -882,8 +872,7 @@ def make_fixed_length_events(raw, id=1, start=0, stop=None, duration=1.,
 
     Returns
     -------
-    new_events : array
-        The new events.
+    %(events)s
     """
     from .io.base import BaseRaw
     _validate_type(raw, BaseRaw, "raw")
@@ -929,7 +918,7 @@ def concatenate_events(events, first_samps, last_samps):
     Parameters
     ----------
     events : list of array
-        List of event arrays, typically each extracted from a
+        List of :term:`events` arrays, typically each extracted from a
         corresponding raw file that is being concatenated.
     first_samps : list or array of int
         First sample numbers of the raw files concatenated.

--- a/mne/event.py
+++ b/mne/event.py
@@ -865,7 +865,7 @@ def make_fixed_length_events(raw, id=1, start=0, stop=None, duration=1.,
     duration : float
         The duration to separate events by (in seconds).
     first_samp : bool
-        If True (default), times will have raw.first_samp added to them, as
+        If True (default), times will have ``raw.first_samp`` added to them, as
         in :func:`mne.find_events`. This behavior is not desirable if the
         returned events will be combined with event times that already
         have ``raw.first_samp`` added to them, e.g. event times that come

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1289,9 +1289,10 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """Crop raw data file.
 
         Limit the data from the raw file to go between specific times. Note
-        that the new tmin is assumed to be t=0 for all subsequently called
-        functions (e.g., time_as_index, or Epochs). New first_samp and
-        last_samp are set accordingly.
+        that the new ``tmin`` is assumed to be ``t=0`` for all subsequently
+        called functions (e.g., :meth:`~mne.io.Raw.time_as_index`, or
+        `mne.Epochs`). New ``first_samp`` and ``last_samp`` are set
+        accordingly.
 
         Thus function operates in-place on the instance.
         Use :meth:`mne.io.Raw.copy` if operation on a copy is desired.

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -608,14 +608,14 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             times to indices. This can help avoid non-unique indices.
         origin : datetime | float | int | None
             Time reference for times. If None, ``times`` are assumed to be
-            relative to ``first_samp``.
+            relative to :term:`first_samp`.
 
             .. versionadded:: 0.17.0
 
         Returns
         -------
         index : ndarray
-            Indices relative to ``first_samp`` corresponding to the times
+            Indices relative to :term:`first_samp` corresponding to the times
             supplied.
         """
         origin = _handle_meas_date(origin)
@@ -1291,7 +1291,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         Limit the data from the raw file to go between specific times. Note
         that the new ``tmin`` is assumed to be ``t=0`` for all subsequently
         called functions (e.g., :meth:`~mne.io.Raw.time_as_index`, or
-        `mne.Epochs`). New :term:`first_samp` and ``last_samp`` are set
+        `mne.Epochs`). New :term:`first_samp` and :term:`last_samp` are set
         accordingly.
 
         Thus function operates in-place on the instance.

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1291,8 +1291,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         Limit the data from the raw file to go between specific times. Note
         that the new ``tmin`` is assumed to be ``t=0`` for all subsequently
         called functions (e.g., :meth:`~mne.io.Raw.time_as_index`, or
-        `mne.Epochs`). New :term:`first_samp` and :term:`last_samp` are set
-        accordingly.
+        :class:`~mne.Epochs`). New :term:`first_samp` and :term:`last_samp`
+        are set accordingly.
 
         Thus function operates in-place on the instance.
         Use :meth:`mne.io.Raw.copy` if operation on a copy is desired.

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1291,7 +1291,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         Limit the data from the raw file to go between specific times. Note
         that the new ``tmin`` is assumed to be ``t=0`` for all subsequently
         called functions (e.g., :meth:`~mne.io.Raw.time_as_index`, or
-        `mne.Epochs`). New ``first_samp`` and ``last_samp`` are set
+        `mne.Epochs`). New :term:`first_samp` and ``last_samp`` are set
         accordingly.
 
         Thus function operates in-place on the instance.

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -930,18 +930,8 @@ def read_epochs_kit(input_fname, events, event_id=None, mrk=None, elp=None,
     ----------
     input_fname : str
         Path to the sqd file.
-    events : array, shape (n_events, 3)
-        The events typically returned by the read_events function.
-        If some events don't match the events of interest as specified
-        by event_id, they will be marked as 'IGNORED' in the drop log.
-    event_id : int | list of int | dict | None
-        The id of the event to consider. If dict,
-        the keys can later be used to access associated events. Example:
-        dict(auditory=1, visual=3). If int, a dict will be created with
-        the id as string. If a list, all events with the IDs specified
-        in the list are used. If None, all events will be used with
-        and a dict is created with string integer names corresponding
-        to the event id integers.
+    %(events_epochs)s
+    %(event_id)s
     mrk : None | str | array_like, shape (5, 3) | list of str or array_like
         Marker points representing the location of the marker coils with
         respect to the MEG Sensors, or path to a marker file.

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -330,7 +330,7 @@ class SourceSimulator(object):
         If None, it is computed using existing events and waveform lengths.
     first_samp : int
         First sample from which the simulation takes place, as an integer.
-        Comparable to the ``first_samp`` property of `~mne.io.Raw` objects.
+        Comparable to the :term:`first_samp` property of `~mne.io.Raw` objects.
         Default is 0.
 
     Attributes

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2386,8 +2386,10 @@ reject_tmin, reject_tmax : float | None
 """
 docdict['epochs_events_event_id'] = """
 events : array of int, shape (n_events, 3)
-    The events typically returned by the read_events function.
-    If some events don't match the events of interest as specified
+    The array of events returned by `mne.read_events` or `mne.find_events`. The
+    first column contains the event time in samples, with ``first_samp``
+    included. The second column contains [...]. The third column contains the
+    event id. If some events don't match the events of interest as specified
     by event_id, they will be marked as 'IGNORED' in the drop log.
 event_id : int | list of int | dict | None
     The id of the event to consider. If dict,

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2384,23 +2384,22 @@ reject_tmin, reject_tmax : float | None
     .. note:: This parameter controls the time period used in conjunction with
               both, ``reject`` and ``flat``.
 """
-docdict['epochs_events_event_id'] = """
+docdict['events'] = """
 events : array of int, shape (n_events, 3)
-    The array of events returned by `mne.read_events`, `mne.find_events` or
-    `mne.make_fixed_length_events`. The first column contains the event time in
-    samples, with ``first_samp`` included. The second column contains [...].
-    The third column contains the event id. If some events don't match the
-    events of interest as specified by event_id, they will be marked as
-    'IGNORED' in the drop log.
+    The array of :term:`events`. The first column contains the event time in
+    samples, with :term:`first_samp` included. The third column contains the
+    event id."""
+docdict['events_epochs'] = """%s
+    If some events don’t match the events of interest as specified by event_id,
+    they will be marked as ‘IGNORED’ in the drop log.""" % docdict['events']
+docdict['event_id'] = """
 event_id : int | list of int | dict | None
-    The id of the event to consider. If dict,
-    the keys can later be used to access associated events. Example:
-    dict(auditory=1, visual=3). If int, a dict will be created with
-    the id as string. If a list, all events with the IDs specified
-    in the list are used. If None, all events will be used with
-    and a dict is created with string integer names corresponding
-    to the event id integers.
-"""
+    The id of the :term:`events` to consider. If dict, the keys can later be
+    used to access associated :term:`events`. Example:
+    dict(auditory=1, visual=3). If int, a dict will be created with the id as
+    string. If a list, all :term:`events` with the IDs specified in the list
+    are used. If None, all :term:`events` will be used and a dict is created
+    with string integer names corresponding to the event id integers."""
 docdict['epochs_preload'] = """
     Load all epochs from disk when creating the object
     or wait before accessing each epoch (more memory

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -182,11 +182,12 @@ standardize_names : bool
 
 docdict['event_color'] = """
 event_color : color object | dict | None
-    Color(s) to use for events. To show all events in the same color, pass any
-    matplotlib-compatible color. To color events differently, pass a `dict`
-    that maps event names or integer event numbers to colors (must include
-    entries for *all* events, or include a "fallback" entry with key ``-1``).
-    If ``None``, colors are chosen from the current Matplotlib color cycle.
+    Color(s) to use for :term:`events`. To show all :term:`events` in the same
+    color, pass any matplotlib-compatible color. To color events differently,
+    pass a `dict` that maps event names or integer event numbers to colors
+    (must include entries for *all* events, or include a "fallback" entry with
+    key ``-1``). If ``None``, colors are chosen from the current Matplotlib
+    color cycle.
 """
 
 docdict['browse_group_by'] = """
@@ -1699,8 +1700,8 @@ on_header_missing : str
 """ % (_on_missing_base,)
 docdict['on_missing_events'] = """
 on_missing : 'raise' | 'warn' | 'ignore'
-    %s event numbers from ``event_id`` are missing from ``events``.
-    When numbers from ``events`` are missing from ``event_id`` they will be
+    %s event numbers from ``event_id`` are missing from :term:`events`.
+    When numbers from :term:`events` are missing from ``event_id`` they will be
     ignored and a warning emitted; consider using ``verbose='error'`` in
     this case.
 
@@ -2391,7 +2392,7 @@ events : array of int, shape (n_events, 3)
     event id."""
 docdict['events_epochs'] = """%s
     If some events don’t match the events of interest as specified by event_id,
-    they will be marked as ‘IGNORED’ in the drop log.""" % docdict['events']
+    they will be marked as ``IGNORED`` in the drop log.""" % docdict['events']
 docdict['event_id'] = """
 event_id : int | list of int | dict | None
     The id of the :term:`events` to consider. If dict, the keys can later be
@@ -2432,7 +2433,7 @@ docdict['epochs_event_repeated'] = """
 event_repeated : str
     How to handle duplicates in ``events[:, 0]``. Can be ``'error'``
     (default), to raise an error, 'drop' to only retain the row occurring
-    first in the ``events``, or ``'merge'`` to combine the coinciding
+    first in the :term:`events`, or ``'merge'`` to combine the coinciding
     events (=duplicates) into a new event (see Notes for details).
 
     .. versionadded:: 0.19

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2386,11 +2386,12 @@ reject_tmin, reject_tmax : float | None
 """
 docdict['epochs_events_event_id'] = """
 events : array of int, shape (n_events, 3)
-    The array of events returned by `mne.read_events` or `mne.find_events`. The
-    first column contains the event time in samples, with ``first_samp``
-    included. The second column contains [...]. The third column contains the
-    event id. If some events don't match the events of interest as specified
-    by event_id, they will be marked as 'IGNORED' in the drop log.
+    The array of events returned by `mne.read_events`, `mne.find_events` or
+    `mne.make_fixed_length_events`. The first column contains the event time in
+    samples, with ``first_samp`` included. The second column contains [...].
+    The third column contains the event id. If some events don't match the
+    events of interest as specified by event_id, they will be marked as
+    'IGNORED' in the drop log.
 event_id : int | list of int | dict | None
     The id of the event to consider. If dict,
     the keys can later be used to access associated events. Example:

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2391,7 +2391,7 @@ events : array of int, shape (n_events, 3)
     samples, with :term:`first_samp` included. The third column contains the
     event id."""
 docdict['events_epochs'] = """%s
-    If some events don’t match the events of interest as specified by event_id,
+    If some events don't match the events of interest as specified by event_id,
     they will be marked as ``IGNORED`` in the drop log.""" % docdict['events']
 docdict['event_id'] = """
 event_id : int | list of int | dict | None

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -624,12 +624,11 @@ def _get_bem_plotting_surfaces(bem_path):
 def plot_events(events, sfreq=None, first_samp=0, color=None, event_id=None,
                 axes=None, equal_spacing=True, show=True, on_missing='raise',
                 verbose=None):
-    """Plot events to get a visual display of the paradigm.
+    """Plot :term:`events` to get a visual display of the paradigm.
 
     Parameters
     ----------
-    events : array, shape (n_events, 3)
-        The events.
+    %(events)s
     sfreq : float | None
         The sample frequency. If None, data will be displayed in samples (not
         seconds).


### PR DESCRIPTION
After some _stupid_ trouble to create fix length epochs by passing a numpy array of events in #10055 I think the docstring for `events : array of int, shape (n_events, 3)` could be improved a bit and made more consistent across the doc. 

I do realize now that users are not supposed to create this array manually, as I did, but instead use one of the MNE functions. Still, some details on what this array contains would be beneficial. For now, the only function with details is [`mne.find_events`](https://mne.tools/stable/generated/mne.find_events.html?highlight=find_events#mne.find_events).

I started generalizing the docstring to all entries of events I could think of. If you agree with the idea and the docstring, I'll finish this PR a bit later.