### PR TITLE
Fix EDF channel type detection

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -38,6 +38,8 @@ Enhancements
 
 - Changed :class:`mne.Epochs` and :class:`mne.Evoked` to have a more concise ``__repr__`` to improve interactive MNE usage in Python Interactive Console, IDEs, and debuggers when many events are handled. (:gh:`10042` by `Jan Sosulski`_)
 
+- Add ``infer_type`` argument to :func:`mne.io.read_raw_edf` and :func:`mne.io.read_raw_bdf` to automatically infer channel types from channel labels (:gh:`10058` by `Clemens Brunner`_)
+
 Bugs
 ~~~~
 - Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSER_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)
@@ -69,6 +71,8 @@ Bugs
 - Fix bug in :func:`mne.get_montage_volume_labels` that set the maximum number of voxels to be included too low causing unwanted capping of the included voxel labels (:gh:`10021` by `Alex Rockhill`_)
 
 - :func:`~mne.sys_info` output now contains the installed version of ``pooch``, too; this output had been accidentally removed previously (:gh:`10047` by `Richard Höchenberger`_)
+
+- Fix automatic channel type detection from channel labels in :func:`mne.io.read_raw_edf` and :func:`mne.io.read_raw_bdf` (and disable this functionality from :func:`mne.io.read_raw_gdf`) (:gh:`10058` by `Clemens Brunner`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -72,28 +72,25 @@ def test_double_export_edf(tmp_path):
     """Test exporting an EDF file multiple times."""
     rng = np.random.RandomState(123456)
     format = 'edf'
-    ch_types = ['eeg', 'eeg', 'stim', 'ecog', 'ecog', 'seeg',
-                'eog', 'ecg', 'emg', 'dbs', 'bio']
-    ch_names = np.arange(len(ch_types)).astype(str).tolist()
-    info = create_info(ch_names, sfreq=1000,
-                       ch_types=ch_types)
-    data = rng.random(size=(len(ch_names), 1000)) * 1.e-5
+    ch_types = ['eeg', 'eeg', 'stim', 'ecog', 'ecog', 'seeg', 'eog', 'ecg',
+                'emg', 'dbs', 'bio']
+    info = create_info(len(ch_types), sfreq=1000, ch_types=ch_types)
+    data = rng.random(size=(len(ch_types), 1000)) * 1e-5
 
     # include subject info and measurement date
-    subject_info = dict(first_name='mne', last_name='python',
-                        birthday=(1992, 1, 20), sex=1, hand=3)
-    info['subject_info'] = subject_info
+    info['subject_info'] = dict(first_name='mne', last_name='python',
+                                birthday=(1992, 1, 20), sex=1, hand=3)
     raw = RawArray(data, info)
 
     # export once
-    temp_fname = op.join(str(tmp_path), f'test.{format}')
+    temp_fname = tmp_path / f'test.{format}'
     raw.export(temp_fname, add_ch_type=True)
-    raw_read = read_raw_edf(temp_fname, preload=True)
+    raw_read = read_raw_edf(temp_fname, infer_types=True, preload=True)
 
     # export again
     raw_read.load_data()
     raw_read.export(temp_fname, add_ch_type=True, overwrite=True)
-    raw_read = read_raw_edf(temp_fname, preload=True)
+    raw_read = read_raw_edf(temp_fname, infer_types=True, preload=True)
 
     # stim channel should be dropped
     raw.drop_channels('2')

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -167,7 +167,7 @@ def test_rawarray_edf(tmp_path):
     temp_fname = op.join(str(tmp_path), f'test.{format}')
 
     raw.export(temp_fname, add_ch_type=True)
-    raw_read = read_raw_edf(temp_fname, preload=True)
+    raw_read = read_raw_edf(temp_fname, infer_types=True, preload=True)
 
     # stim channel should be dropped
     raw.drop_channels('2')
@@ -251,8 +251,7 @@ def test_export_raw_edf(tmp_path, dataset, format):
         raw = read_raw_fif(fname)
 
     # only test with EEG channels
-    raw.pick_types(eeg=True, ecog=True, seeg=True,
-                   eog=True, ecg=True, emg=True)
+    raw.pick_types(eeg=True, ecog=True, seeg=True)
     raw.load_data()
     orig_ch_names = raw.ch_names
     temp_fname = op.join(str(tmp_path), f'test.{format}')
@@ -266,9 +265,8 @@ def test_export_raw_edf(tmp_path, dataset, format):
         raw.export(temp_fname, physical_range=(0, 1e6))
 
     if dataset == 'test':
-        orig_ch_names = [ch.split(' ')[1] for ch in raw.ch_names]
         with pytest.warns(RuntimeWarning, match='Data has a non-integer'):
-            raw.export(temp_fname, add_ch_type=False)
+            raw.export(temp_fname)
     elif dataset == 'misc':
         with pytest.warns(RuntimeWarning, match='EDF format requires'):
             raw.export(temp_fname)

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -84,7 +84,7 @@ class RawEDF(BaseRaw):
         modified. If False, do not infer types and assume all channels are of
         type 'EEG'.
 
-    .. versionadded:: 1.0
+        .. versionadded:: 1.0
     %(preload)s
     %(verbose)s
 
@@ -1283,7 +1283,7 @@ def read_raw_edf(input_fname, eog=None, misc=None, stim_channel='auto',
         modified. If False, do not infer types and assume all channels are of
         type 'EEG'.
 
-    .. versionadded:: 1.0
+        .. versionadded:: 1.0
     %(preload)s
     %(verbose)s
 
@@ -1392,7 +1392,7 @@ def read_raw_bdf(input_fname, eog=None, misc=None, stim_channel='auto',
         modified. If False, do not infer types and assume all channels are of
         type 'EEG'.
 
-    .. versionadded:: 1.0
+        .. versionadded:: 1.0
     %(preload)s
     %(verbose)s
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -214,7 +214,7 @@ class RawGDF(BaseRaw):
         logger.info('Extracting EDF parameters from {}...'.format(input_fname))
         input_fname = os.path.abspath(input_fname)
         info, edf_info, orig_units = _get_info(input_fname, stim_channel, eog,
-                                               misc, exclude, preload)
+                                               misc, exclude, True, preload)
         logger.info('Creating raw.info structure...')
 
         # Raw attributes

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -84,7 +84,7 @@ class RawEDF(BaseRaw):
         modified. If False, do not infer types and assume all channels are of
         type 'EEG'.
 
-        .. versionadded:: 1.0
+        .. versionadded:: 0.24.1
     %(preload)s
     %(verbose)s
 
@@ -1283,7 +1283,7 @@ def read_raw_edf(input_fname, eog=None, misc=None, stim_channel='auto',
         modified. If False, do not infer types and assume all channels are of
         type 'EEG'.
 
-        .. versionadded:: 1.0
+        .. versionadded:: 0.24.1
     %(preload)s
     %(verbose)s
 
@@ -1392,7 +1392,7 @@ def read_raw_bdf(input_fname, eog=None, misc=None, stim_channel='auto',
         modified. If False, do not infer types and assume all channels are of
         type 'EEG'.
 
-        .. versionadded:: 1.0
+        .. versionadded:: 0.24.1
     %(preload)s
     %(verbose)s
 

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -183,7 +183,8 @@ def test_duplicate_channel_labels_edf():
     """Test reading edf file with duplicate channel names."""
     EXPECTED_CHANNEL_NAMES = ['F1-Ref-0', 'F2-Ref', 'F1-Ref-1']
     with pytest.warns(RuntimeWarning, match='Channel names are not unique'):
-        raw = read_raw_edf(duplicate_channel_labels_path, preload=False)
+        raw = read_raw_edf(duplicate_channel_labels_path, infer_types=True,
+                           preload=False)
 
     assert raw.ch_names == EXPECTED_CHANNEL_NAMES
 
@@ -531,7 +532,7 @@ def test_hp_lp_reversed(fname, lo, hi, warns, monkeypatch):
 def test_degenerate():
     """Test checking of some bad inputs."""
     for func in (read_raw_edf, read_raw_bdf, read_raw_gdf,
-                 partial(_read_header, exclude=())):
+                 partial(_read_header, exclude=(), infer_types=False)):
         with pytest.raises(NotImplementedError, match='Only.*txt.*'):
             func(edf_txt_stim_channel_path)
 
@@ -552,14 +553,37 @@ def test_exclude():
 @testing.requires_testing_data
 def test_ch_types():
     """Test reading of channel types from EDF channel label."""
-    raw = read_raw_edf(edf_chtypes_path)
+    raw = read_raw_edf(edf_chtypes_path)  # infer_types=False
 
-    # get the channel types for all channels
-    ch_types = raw.get_channel_types()
-    assert all(x in ch_types for x in ['eeg', 'ecg'])
+    labels = ['EEG Fp1-Ref', 'EEG Fp2-Ref', 'EEG F3-Ref', 'EEG F4-Ref',
+              'EEG C3-Ref', 'EEG C4-Ref', 'EEG P3-Ref', 'EEG P4-Ref',
+              'EEG O1-Ref', 'EEG O2-Ref', 'EEG F7-Ref', 'EEG F8-Ref',
+              'EEG T7-Ref', 'EEG T8-Ref', 'EEG P7-Ref', 'EEG P8-Ref',
+              'EEG Fz-Ref', 'EEG Cz-Ref', 'EEG Pz-Ref', 'POL E', 'POL PG1',
+              'POL PG2', 'EEG A1-Ref', 'EEG A2-Ref', 'POL T1', 'POL T2',
+              'ECG ECG1', 'ECG ECG2', 'EEG F9-Ref', 'EEG T9-Ref', 'EEG P9-Ref',
+              'EEG F10-Ref', 'EEG T10-Ref', 'EEG P10-Ref', 'SaO2 X9',
+              'SaO2 X10', 'POL DC01', 'POL DC02', 'POL DC03', 'POL DC04',
+              'POL $A1', 'POL $A2']
 
-    # test certain channels were correctly detected as a channel type
-    test_ch_names = {"Fp1-Ref": "eeg", "P10-Ref": "eeg", "DC01": "eeg",
-                     "ECG1": "ecg", "ECG2": "ecg"}
-    assert all(raw.get_channel_types(picks=pick)[0] == ch_type
-               for pick, ch_type in test_ch_names.items())
+    # by default all types are 'eeg'
+    assert(all(t == 'eeg' for t in raw.get_channel_types()))
+    assert raw.ch_names == labels
+
+    raw = read_raw_edf(edf_chtypes_path, infer_types=True)
+
+    labels = ['Fp1-Ref', 'Fp2-Ref', 'F3-Ref', 'F4-Ref', 'C3-Ref', 'C4-Ref',
+              'P3-Ref', 'P4-Ref', 'O1-Ref', 'O2-Ref', 'F7-Ref', 'F8-Ref',
+              'T7-Ref', 'T8-Ref', 'P7-Ref', 'P8-Ref', 'Fz-Ref', 'Cz-Ref',
+              'Pz-Ref', 'POL E', 'POL PG1', 'POL PG2', 'A1-Ref', 'A2-Ref',
+              'POL T1', 'POL T2', 'ECG1', 'ECG2', 'F9-Ref', 'T9-Ref', 'P9-Ref',
+              'F10-Ref', 'T10-Ref', 'P10-Ref', 'X9', 'X10', 'POL DC01',
+              'POL DC02', 'POL DC03', 'POL DC04', 'POL $A1', 'POL $A2']
+    types = ['eeg', 'eeg', 'eeg', 'eeg', 'eeg', 'eeg', 'eeg', 'eeg', 'eeg',
+             'eeg', 'eeg', 'eeg', 'eeg', 'eeg', 'eeg', 'eeg', 'eeg', 'eeg',
+             'eeg', 'eeg', 'eeg', 'eeg', 'eeg', 'eeg', 'eeg', 'eeg', 'ecg',
+             'ecg', 'eeg', 'eeg', 'eeg', 'eeg', 'eeg', 'eeg', 'bio', 'bio',
+             'eeg', 'eeg', 'eeg', 'eeg', 'eeg', 'eeg']
+
+    assert raw.get_channel_types() == types
+    assert raw.ch_names == labels

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -181,10 +181,9 @@ def test_edf_data_broken(tmp_path):
 
 def test_duplicate_channel_labels_edf():
     """Test reading edf file with duplicate channel names."""
-    EXPECTED_CHANNEL_NAMES = ['F1-Ref-0', 'F2-Ref', 'F1-Ref-1']
+    EXPECTED_CHANNEL_NAMES = ['EEG F1-Ref-0', 'EEG F2-Ref', 'EEG F1-Ref-1']
     with pytest.warns(RuntimeWarning, match='Channel names are not unique'):
-        raw = read_raw_edf(duplicate_channel_labels_path, infer_types=True,
-                           preload=False)
+        raw = read_raw_edf(duplicate_channel_labels_path, preload=False)
 
     assert raw.ch_names == EXPECTED_CHANNEL_NAMES
 
@@ -432,7 +431,7 @@ def test_bdf_multiple_annotation_channels():
 def test_edf_lowpass_zero():
     """Test if a lowpass filter of 0Hz is mapped to the Nyquist frequency."""
     raw = read_raw_edf(edf_stim_resamp_path)
-    assert raw.ch_names[100] == 'LDAMT_01-REF'
+    assert raw.ch_names[100] == 'EEG LDAMT_01-REF'
     assert_allclose(raw.info["lowpass"], raw.info["sfreq"] / 2)
 
 

--- a/mne/io/nihon/tests/test_nihon.py
+++ b/mne/io/nihon/tests/test_nihon.py
@@ -26,7 +26,7 @@ def test_nihon_eeg():
     assert raw._data.shape == raw_edf._data.shape
     assert raw.info['sfreq'] == raw.info['sfreq']
     # ch names and order are switched in the EDF
-    edf_ch_names = {x: x.replace('-Ref', '')
+    edf_ch_names = {x: x.split(' ')[1].replace('-Ref', '')
                     for x in raw_edf.ch_names}
     raw_edf.rename_channels(edf_ch_names)
     assert raw.ch_names == raw_edf.ch_names


### PR DESCRIPTION
Fixes #10053. The current implementation was broken, because it did not check if a prefix (anything before a space) was valid. This is problematic for channel names containing spaces.

In addition, I've added a new `infer_types` parameter, which by default is `False`. I think this is the better choice, because in general EDF does not impose any structure on channel names.

To do:
- [x] Add test
- [x] Add changelog entry
- [x] Decide when to roll out this change (version 1.0 or in the next backport?)