### PR TITLE
MRG: Mention that tmin/tmax are included in the epochs

### DIFF
--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2372,7 +2372,8 @@ topomap_kwargs : dict | None
 docdict['epochs_tmin_tmax'] = """
 tmin, tmax : float
     Start and end time of the epochs in seconds, relative to the time-locked
-    event. Defaults to -0.2 and 0.5, respectively.
+    event. The samples corresponding to the start and end time are included.
+    Defaults to -0.2 and 0.5, respectively.
 """
 docdict['epochs_reject_tmin_tmax'] = """
 reject_tmin, reject_tmax : float | None


### PR DESCRIPTION
A small docstring change to mention that the samples corresponding to `tmin` and `tmax` are included in the Epochs.
I got a little surprise today when 4 seconds epochs sampled at 512 Hz had 4096 samples.

Or maybe I got it all wrong :man_shrugging: