### PR TITLE
FIX: 3d figures with sphinx on GitHub Actions

### DIFF
--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -174,8 +174,8 @@ class _PyVistaRenderer(_AbstractRenderer):
             self.figure = fig
 
         # Enable off_screen if sphinx-gallery or testing
-        if pyvista.OFF_SCREEN:
-            self.figure.store['off_screen'] = True
+        # if pyvista.OFF_SCREEN:
+        #     self.figure.store['off_screen'] = True
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -183,8 +183,8 @@ class _PyVistaRenderer(_AbstractRenderer):
                 self.tube_n_sides = 3
                 # smooth_shading=True fails on MacOS CIs
                 self.figure.smooth_shading = False
-            # with _disabled_depth_peeling():
-            self.plotter = self.figure.build()
+            with _disabled_depth_peeling():
+                self.plotter = self.figure.build()
             self._hide_axes()
             # self._enable_aa()
 

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -177,16 +177,16 @@ class _PyVistaRenderer(_AbstractRenderer):
         # if pyvista.OFF_SCREEN:
         #     self.figure.store['off_screen'] = True
 
-        # with warnings.catch_warnings():
-        #     warnings.filterwarnings("ignore", category=FutureWarning)
-        #     if MNE_3D_BACKEND_TESTING:
-        #         self.tube_n_sides = 3
-        #         # smooth_shading=True fails on MacOS CIs
-        #         self.figure.smooth_shading = False
-        #     with _disabled_depth_peeling():
-        #         self.plotter = self.figure.build()
-        #     self._hide_axes()
-        #     self._enable_aa()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            if MNE_3D_BACKEND_TESTING:
+                self.tube_n_sides = 3
+                # smooth_shading=True fails on MacOS CIs
+                self.figure.smooth_shading = False
+            with _disabled_depth_peeling():
+                self.plotter = self.figure.build()
+            self._hide_axes()
+            self._enable_aa()
 
         # # FIX: https://github.com/pyvista/pyvistaqt/pull/68
         # if LooseVersion(pyvista.__version__) >= '0.27.0':
@@ -194,8 +194,6 @@ class _PyVistaRenderer(_AbstractRenderer):
         #         self.plotter.iren = None
 
         # self.update_lighting()
-
-        self.plotter = self.figure.build()
 
     @property
     def _all_plotters(self):

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -186,7 +186,7 @@ class _PyVistaRenderer(_AbstractRenderer):
             # with _disabled_depth_peeling():
             self.plotter = self.figure.build()
             self._hide_axes()
-            self._enable_aa()
+            # self._enable_aa()
 
         # FIX: https://github.com/pyvista/pyvistaqt/pull/68
         if LooseVersion(pyvista.__version__) >= '0.27.0':

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -174,8 +174,8 @@ class _PyVistaRenderer(_AbstractRenderer):
             self.figure = fig
 
         # Enable off_screen if sphinx-gallery or testing
-        # if pyvista.OFF_SCREEN:
-        #     self.figure.store['off_screen'] = True
+        if pyvista.OFF_SCREEN:
+            self.figure.store['off_screen'] = True
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -151,10 +151,6 @@ class _PyVistaRenderer(_AbstractRenderer):
     def __init__(self, fig=None, size=(600, 600), bgcolor='black',
                  name="PyVista Scene", show=False, shape=(1, 1),
                  notebook=None, smooth_shading=True):
-        self.figure = _Figure()
-        self.plotter = self.figure.build()
-        return
-
         from .renderer import MNE_3D_BACKEND_TESTING
         from .._3d import _get_3d_option
         figure = _Figure(show=show, title=name, size=size, shape=shape,
@@ -178,8 +174,8 @@ class _PyVistaRenderer(_AbstractRenderer):
             self.figure = fig
 
         # Enable off_screen if sphinx-gallery or testing
-        if pyvista.OFF_SCREEN:
-            self.figure.store['off_screen'] = True
+        # if pyvista.OFF_SCREEN:
+        #     self.figure.store['off_screen'] = True
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -186,7 +186,7 @@ class _PyVistaRenderer(_AbstractRenderer):
             with _disabled_depth_peeling():
                 self.plotter = self.figure.build()
             self._hide_axes()
-            # self._enable_aa()
+            self._enable_aa()
 
         # FIX: https://github.com/pyvista/pyvistaqt/pull/68
         if LooseVersion(pyvista.__version__) >= '0.27.0':
@@ -658,6 +658,8 @@ class _PyVistaRenderer(_AbstractRenderer):
         # For Mayavi we have an "on activated" event or so, we should look into
         # using this for Azure at some point, too.
         if os.getenv('AZURE_CI_WINDOWS', 'false').lower() == 'true':
+            return
+        if os.getenv('GITHUB_ACTIONS', 'false').lower() == 'true':
             return
         if self.figure.is_active():
             if sys.platform != 'darwin':

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -151,7 +151,8 @@ class _PyVistaRenderer(_AbstractRenderer):
     def __init__(self, fig=None, size=(600, 600), bgcolor='black',
                  name="PyVista Scene", show=False, shape=(1, 1),
                  notebook=None, smooth_shading=True):
-        self.plotter = BackgroundPlotter(line_smoothing=True)
+        self.figure = _Figure()
+        self.plotter = self.figure.build()
         return
 
         from .renderer import MNE_3D_BACKEND_TESTING

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -183,8 +183,8 @@ class _PyVistaRenderer(_AbstractRenderer):
                 self.tube_n_sides = 3
                 # smooth_shading=True fails on MacOS CIs
                 self.figure.smooth_shading = False
-            with _disabled_depth_peeling():
-                self.plotter = self.figure.build()
+            # with _disabled_depth_peeling():
+            self.plotter = self.figure.build()
             # self._hide_axes()
             # self._enable_aa()
 

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -173,9 +173,9 @@ class _PyVistaRenderer(_AbstractRenderer):
         else:
             self.figure = fig
 
-        # # Enable off_screen if sphinx-gallery or testing
-        # if pyvista.OFF_SCREEN:
-        #     self.figure.store['off_screen'] = True
+        # Enable off_screen if sphinx-gallery or testing
+        if pyvista.OFF_SCREEN:
+            self.figure.store['off_screen'] = True
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)
@@ -185,15 +185,15 @@ class _PyVistaRenderer(_AbstractRenderer):
                 self.figure.smooth_shading = False
             # with _disabled_depth_peeling():
             self.plotter = self.figure.build()
-            # self._hide_axes()
-            # self._enable_aa()
+            self._hide_axes()
+            self._enable_aa()
 
-        # # FIX: https://github.com/pyvista/pyvistaqt/pull/68
-        # if LooseVersion(pyvista.__version__) >= '0.27.0':
-        #     if not hasattr(self.plotter, "iren"):
-        #         self.plotter.iren = None
+        # FIX: https://github.com/pyvista/pyvistaqt/pull/68
+        if LooseVersion(pyvista.__version__) >= '0.27.0':
+            if not hasattr(self.plotter, "iren"):
+                self.plotter.iren = None
 
-        # self.update_lighting()
+        self.update_lighting()
 
     @property
     def _all_plotters(self):

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -173,27 +173,29 @@ class _PyVistaRenderer(_AbstractRenderer):
         else:
             self.figure = fig
 
-        # Enable off_screen if sphinx-gallery or testing
+        # # Enable off_screen if sphinx-gallery or testing
         # if pyvista.OFF_SCREEN:
         #     self.figure.store['off_screen'] = True
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=FutureWarning)
-            if MNE_3D_BACKEND_TESTING:
-                self.tube_n_sides = 3
-                # smooth_shading=True fails on MacOS CIs
-                self.figure.smooth_shading = False
-            with _disabled_depth_peeling():
-                self.plotter = self.figure.build()
-            self._hide_axes()
-            self._enable_aa()
+        # with warnings.catch_warnings():
+        #     warnings.filterwarnings("ignore", category=FutureWarning)
+        #     if MNE_3D_BACKEND_TESTING:
+        #         self.tube_n_sides = 3
+        #         # smooth_shading=True fails on MacOS CIs
+        #         self.figure.smooth_shading = False
+        #     with _disabled_depth_peeling():
+        #         self.plotter = self.figure.build()
+        #     self._hide_axes()
+        #     self._enable_aa()
 
-        # FIX: https://github.com/pyvista/pyvistaqt/pull/68
-        if LooseVersion(pyvista.__version__) >= '0.27.0':
-            if not hasattr(self.plotter, "iren"):
-                self.plotter.iren = None
+        # # FIX: https://github.com/pyvista/pyvistaqt/pull/68
+        # if LooseVersion(pyvista.__version__) >= '0.27.0':
+        #     if not hasattr(self.plotter, "iren"):
+        #         self.plotter.iren = None
 
-        self.update_lighting()
+        # self.update_lighting()
+
+        self.plotter = self.figure.build()
 
     @property
     def _all_plotters(self):

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -185,8 +185,8 @@ class _PyVistaRenderer(_AbstractRenderer):
                 self.figure.smooth_shading = False
             with _disabled_depth_peeling():
                 self.plotter = self.figure.build()
-            self._hide_axes()
-            self._enable_aa()
+            # self._hide_axes()
+            # self._enable_aa()
 
         # # FIX: https://github.com/pyvista/pyvistaqt/pull/68
         # if LooseVersion(pyvista.__version__) >= '0.27.0':

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -151,6 +151,9 @@ class _PyVistaRenderer(_AbstractRenderer):
     def __init__(self, fig=None, size=(600, 600), bgcolor='black',
                  name="PyVista Scene", show=False, shape=(1, 1),
                  notebook=None, smooth_shading=True):
+        self.plotter = BackgroundPlotter(line_smoothing=True)
+        return
+
         from .renderer import MNE_3D_BACKEND_TESTING
         from .._3d import _get_3d_option
         figure = _Figure(show=show, title=name, size=size, shape=shape,


### PR DESCRIPTION
Starting from https://github.com/mne-tools/mne-nirs/pull/297 and https://github.com/ja-che/hidimstat/pull/25#issuecomment-868573462, we did not have much success displaying `pyvista`/`pyvistaqt` 3d figures on GitHub Actions with sphinx. So I opened https://github.com/GuillaumeFavelier/pyvista_github_actions to experiment further. I share my results in https://github.com/GuillaumeFavelier/pyvista_github_actions/issues/1#issuecomment-982536626

For short, this is necessary to build a doc with `mne-python`/`pyvista`/`pyvistaqt`/`sphinx-gallery` on GitHub Actions.