### PR TITLE
MAINT: Only do nightly full builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,7 +502,7 @@ workflows:
 
   nightly:
     jobs:
-      - build_docs
+      - build_docs:
           scheduled: "true"
       - deploy:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -510,7 +510,7 @@ workflows:
       - schedule:
           # "At 00:00" (once a day) should be enough "0 0 * * *",
           # But for testing at first, let's do once an hour
-          cron: "10 * * * *"
+          cron: "15 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@
 # - [circle front] will build the front page and perform test-doc
 # - [circle full] will build everything
 # - [circle linkcheck] will run our linkcheck
-# - [circle interactive_test] will run our test suite (useful for debugging
-#   issues using "Rerun with SSH")
+# - [circle deploy] on a main or maint/* commit will try to immediately build
+#   and deploy docs rather than waiting for the nightly build
 
 version: 2.1
 
@@ -498,7 +498,6 @@ workflows:
     jobs:
       - build_docs
       - linkcheck
-      - interactive_test
 
   nightly:
     jobs:
@@ -511,7 +510,7 @@ workflows:
       - schedule:
           # "At 00:00" (once a day) should be enough "0 0 * * *",
           # But for testing at first, let's do once an hour
-          cron: "0 * * * *"
+          cron: "10 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,10 @@ _xvfb: &xvfb
 
 jobs:
     build_docs:
+      parameters:
+        scheduled:
+          type: string
+          default: "false"
       machine:
         image: ubuntu-2004:202111-01
       steps:
@@ -25,6 +29,7 @@ jobs:
         - run:
             name: Complete checkout
             command: |
+              set -e
               if ! git remote -v | grep upstream; then
                 git remote add upstream https://github.com/mne-tools/mne-python.git
               fi
@@ -37,11 +42,49 @@ jobs:
         - run:
             name: Check-skip
             command: |
+              set -e
               export COMMIT_MESSAGE=$(git log --format=oneline -n 1);
               if [[ -v CIRCLE_PULL_REQUEST ]] && ([[ "$COMMIT_MESSAGE" == *"[skip circle]"* ]] || [[ "$COMMIT_MESSAGE" == *"[circle skip]"* ]]); then
                 echo "Skip detected, exiting job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}."
                 circleci-agent step halt;
               fi
+        - run:
+            name: Merge with upstream and triage run
+            command: |
+              set -e
+              echo $(git log -1 --pretty=%B) | tee gitlog.txt
+              echo ${CI_PULL_REQUEST//*pull\//} | tee merge.txt
+              if [[ $(cat merge.txt) != "" ]]; then
+                echo "Merging $(cat merge.txt)";
+                git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
+              else
+                if [ "$CIRCLE_BRANCH" == "main" ]; then
+                  KIND=dev
+                else:
+                  KIND=stable
+                fi
+                export COMMIT_MESSAGE=$(git log --format=oneline -n 1);
+                if [[ "$COMMIT_MESSAGE" == *"[circle deploy]"* ]]; then
+                  echo "Forced deployed build detected";
+                elif [ "<< parameters.scheduled >>" != "true" ]; then
+                  echo "Waiting until scheduled run to build ${KIND} docs, exiting job ${CIRCLE_JOB}."
+                  circleci-agent step halt;
+                else
+                  echo "Scheduled full build detected, checking if it's required."
+                  wget https://mne.tools/${KIND}/_version.txt;
+                  REMOTE_VERSION=$(cat _version.txt)
+                  THIS_VERSION=$(git rev-parse HEAD)
+                  echo "Current ${KIND} SHA: ${REMOTE_VERSION}"
+                  echo "This    ${KIND} SHA: ${THIS_VERSION}"
+                  if [[ "${THIS_VERSION}" != "${REMOTE_VERSION}" ]]; then
+                    echo "Rebuild required."
+                  else
+                    echo "Rebuild skipped."
+                    circleci-agent step halt;
+                  fi
+                fi
+              fi
+
         - run:
             name: Set BASH_ENV
             command: |
@@ -66,16 +109,6 @@ jobs:
             name: check neuromag2ft
             command: |
               neuromag2ft --version
-
-        - run:
-            name: Merge with upstream
-            command: |
-              echo $(git log -1 --pretty=%B) | tee gitlog.txt
-              echo ${CI_PULL_REQUEST//*pull\//} | tee merge.txt
-              if [[ $(cat merge.txt) != "" ]]; then
-                echo "Merging $(cat merge.txt)";
-                git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
-              fi
 
         - run:
             <<: *xvfb
@@ -400,8 +433,8 @@ jobs:
 
 
     deploy:
-      docker:
-        - image: circleci/python:3.8.5-buster
+      machine:
+        image: ubuntu-2004:202111-01
       steps:
         - attach_workspace:
             at: /tmp/build
@@ -460,64 +493,25 @@ jobs:
             paths:
               - ~/mne_data/MNE-visual_92_categories-data
 
-
-    interactive_test:
-      docker:
-        - image: circleci/python:3.9.2-buster
-      steps:
-        - restore_cache:
-            keys:
-              - source-cache
-        - checkout
-        - run:
-            name: Set BASH_ENV
-            command: |
-              set -e
-              echo "set -e" >> $BASH_ENV
-              echo "export OPENBLAS_NUM_THREADS=1" >> $BASH_ENV
-              mkdir -p ~/mne_data
-        - run:
-            name: Check-skip
-            command: |
-              export COMMIT_MESSAGE=$(git log --format=oneline -n 1);
-              if [[ "$COMMIT_MESSAGE" != *"[circle interactive_test]"* ]]; then
-                echo "Skip detected, exiting job ${CIRCLE_JOB}."
-                circleci-agent step halt;
-              fi
-        - run:
-            <<: *xvfb
-        - restore_cache:
-            keys:
-              - pip-cache
-        - run:
-            name: Get Python running
-            command: |
-              ./tools/circleci_dependencies.sh
-        - run:
-            name: Check installation
-            command: |
-              mne sys_info -pd
-        - restore_cache:
-            keys:
-              - data-cache-testing
-        - run:
-            name: Get data
-            command: |
-              python -c "import mne; mne.datasets.testing.data_path(verbose=True)"
-        - run:
-            name: pytest
-            command: |
-              pytest -m "not slowtest" mne -xv
-
 workflows:
   default:
     jobs:
       - build_docs
       - linkcheck
       - interactive_test
+
+  nightly:
+    jobs:
+      - build_docs
+          scheduled: "true"
       - deploy:
           requires:
             - build_docs
+    triggers:
+      - schedule:
+          # "At 00:00" (once a day) should be enough "0 0 * * *",
+          # But for testing at first, let's do once an hour
+          cron: "0 * * * *"
           filters:
             branches:
               only:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,7 +25,7 @@ from numpydoc import docscrape
 import mne
 from mne.tests.test_docstring_parameters import error_ignores
 from mne.utils import (linkcode_resolve, # noqa, analysis:ignore
-                       _assert_no_instances, sizeof_fmt)
+                       _assert_no_instances, sizeof_fmt, run_subprocess)
 from mne.viz import Brain  # noqa
 
 if LooseVersion(sphinx_gallery.__version__) < LooseVersion('0.2'):
@@ -1145,6 +1145,23 @@ def make_redirects(app, exception):
         f'Added {len(custom_redirects):3d} HTML custom redirects')
 
 
+
+def make_version(app, exception):
+    """Make a text file with the git version."""
+    if not (isinstance(app.builder,
+                       sphinx.builders.html.StandaloneHTMLBuilder) and
+            exception is None):
+        return
+    logger = sphinx.util.logging.getLogger('mne')
+    try:
+        stdout, _ = run_subprocess(['git', 'rev-parse', 'head'])
+    except Exception:
+        return
+    with open(os.path.join(app.outdir, '_version.txt'), 'w') as fid:
+        fid.write(stdout)
+    logger.info(f'Added "{stdout.rstrip()}" > _version.txt')
+
+
 # -- Connect our handlers to the main Sphinx app ---------------------------
 
 def setup(app):
@@ -1158,3 +1175,4 @@ def setup(app):
     sphinx_logger.info(
         f'Building documentation for MNE {release} ({mne.__file__})')
     app.connect('build-finished', make_redirects)
+    app.connect('build-finished', make_version)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1145,7 +1145,6 @@ def make_redirects(app, exception):
         f'Added {len(custom_redirects):3d} HTML custom redirects')
 
 
-
 def make_version(app, exception):
     """Make a text file with the git version."""
     if not (isinstance(app.builder,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1153,8 +1153,9 @@ def make_version(app, exception):
         return
     logger = sphinx.util.logging.getLogger('mne')
     try:
-        stdout, _ = run_subprocess(['git', 'rev-parse', 'head'])
-    except Exception:
+        stdout, _ = run_subprocess(['git', 'rev-parse', 'HEAD'], verbose=False)
+    except Exception as exc:
+        logger.warning(f'Failed to write _version.txt: {exc}')
         return
     with open(os.path.join(app.outdir, '_version.txt'), 'w') as fid:
         fid.write(stdout)

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -15,18 +15,7 @@ fi
 echo "Installing setuptools and sphinx"
 python -m pip install --progress-bar off --upgrade "pip!=20.3.0" setuptools wheel
 python -m pip install --upgrade --progress-bar off --pre sphinx
-if [[ "$CIRCLE_JOB" == "interactive_test" ]]; then
-	echo "Installing latest dependencies for interactive_test"
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" --extra-index-url https://www.riverbankcomputing.com/pypi/simple numpy scipy pandas scikit-learn PyQt5
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py pillow matplotlib
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" numba llvmlite
-	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
-	python -m pip install --progress-bar off vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
-	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
-	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
-	python -m pip install --progress-bar off --upgrade -e .[test]
-elif [[ "$CIRCLE_JOB" == "linkcheck"* ]]; then
+if [[ "$CIRCLE_JOB" == "linkcheck"* ]]; then
 	echo "Installing minimal linkcheck dependencies"
 	python -m pip install --progress-bar off numpy scipy matplotlib pillow pytest
 	python -m pip install --progress-bar off -r requirements_doc.txt

--- a/tutorials/clinical/20_seeg.py
+++ b/tutorials/clinical/20_seeg.py
@@ -131,12 +131,12 @@ for elec in electrodes:
 # Now, let's the electrodes and a few regions of interest that the contacts
 # of the electrode are proximal to.
 
-picks = [ch_name for ch_name in epochs.ch_names if
+picks = [ii for ii, ch_name in enumerate(epochs.ch_names) if
          any([elec in ch_name for elec in electrodes])]
 labels = ('ctx-lh-caudalmiddlefrontal', 'ctx-lh-precentral',
           'ctx-lh-superiorfrontal', 'Left-Putamen')
 
-fig = mne.viz.plot_alignment(epochs.info.copy().pick_channels(picks), trans,
+fig = mne.viz.plot_alignment(mne.pick_info(epochs.info, picks), trans,
                              'fsaverage', subjects_dir=subjects_dir,
                              surfaces=[], coord_frame='mri')
 


### PR DESCRIPTION
Now that we are paying for CircleCI builds, it would be nice to cut down our usage a bit. One way to do this is to only build `dev` and `maint/0.24` nightly, and only if they have changed. So this PR:

1. Makes it so that each build creates a `_build/html/_version.txt` that contains the SHA of the commit.
2. It quits on non-PR builds if it sees that it's not a scheduled build, unless there is a `[circle deploy]` in the commit line (hopefully we will only rarely need this, but it could come in handy around release time)
3. If it is a scheduled build, compares https://mne.tools/stable/_version.txt or https://mne.tools/dev/_version.txt (I put dummy ones in there manually for now) to the current commit number, and quits if the version numbers match.
4. Gets rid of "interactive_test", we don't really use it, and when we need something like it, it's probably easy enough to SSH in and venv manually now.
5. Fixes a [failure](https://app.circleci.com/pipelines/github/mne-tools/mne-python/11690/workflows/489499a3-3a5d-4e2a-93e7-07d8ae8773d8/jobs/39099) due to `pick_channels` deprecation

For now I have the schedule actually set to every hour in order to allow me to debug more easily. Once it this is merged, I'll push directly to `main` to make it work, then reset to `"0 0 * * *"` to make it nightly rather than hourly. Then I'll backport to `maint/0.24`, and hopefully things will work smoothly from there!