### PR TITLE
MRG: Fix permutation_cluster_1samp_test for 2D data when using TFCE

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -76,7 +76,7 @@ Bugs
 
 - Fix automatic channel type detection from channel labels in :func:`mne.io.read_raw_edf` and :func:`mne.io.read_raw_bdf` (and disable this functionality from :func:`mne.io.read_raw_gdf`) (:gh:`10058` by `Clemens Brunner`_)
 
-- Fix :func:`~mne.stats.permutation_cluster_1samp_test` to properly handle 2-demensional data in combination with TFCE (:gh:`10073` by `Richard Höchenberger`_)
+- Fix :func:`~mne.stats.permutation_cluster_1samp_test` to properly handle 2-dimensional data in combination with TFCE (:gh:`10073` by `Richard Höchenberger`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -76,6 +76,8 @@ Bugs
 
 - Fix automatic channel type detection from channel labels in :func:`mne.io.read_raw_edf` and :func:`mne.io.read_raw_bdf` (and disable this functionality from :func:`mne.io.read_raw_gdf`) (:gh:`10058` by `Clemens Brunner`_)
 
+- :func:`~mne.stats.permutation_cluster_1samp_test` couldn't handle 2-demensional data in combination with TFCE and crashed with an error message (:gh:`10073` by `Richard Höchenberger`_)
+
 API changes
 ~~~~~~~~~~~
 - ``mne.Info.pick_channels`` has been deprecated. Use ``inst.pick_channels`` to pick channels from Raw|Epochs|Evoked. Use :func:`mne.pick_info` to pick channels from :class:`mne.Info` (:gh:`10039` by `Mathieu Scheltienne`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -76,7 +76,7 @@ Bugs
 
 - Fix automatic channel type detection from channel labels in :func:`mne.io.read_raw_edf` and :func:`mne.io.read_raw_bdf` (and disable this functionality from :func:`mne.io.read_raw_gdf`) (:gh:`10058` by `Clemens Brunner`_)
 
-- :func:`~mne.stats.permutation_cluster_1samp_test` couldn't handle 2-demensional data in combination with TFCE and crashed with an error message (:gh:`10073` by `Richard Höchenberger`_)
+- Fix :func:`~mne.stats.permutation_cluster_1samp_test` to properly handle 2-demensional data in combination with TFCE (:gh:`10073` by `Richard Höchenberger`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -562,6 +562,8 @@ def _cluster_mask_to_indices(components, shape):
     for ci, c in enumerate(components):
         if isinstance(c, np.ndarray):  # mask
             components[ci] = np.where(c.reshape(shape))
+        elif isinstance(c, slice):
+            components[ci] = np.arange(c.start, c.stop)
         else:
             assert isinstance(c, tuple), type(c)
             c = list(c)  # tuple->list

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -651,29 +651,11 @@ def test_permutation_test_H0(numba_conditional):
         assert_equal(len(h0), 2 ** (7 - (tail == 0)))  # exact test
 
 
-def _gen_tfce_data(n_dims):
-    rng = np.random.RandomState(0)
-
-    if n_dims == 2:
-        data = rng.randn(7, 10)
-    elif n_dims == 3:
-        data = rng.randn(7, 10, 1)
-    else:
-        raise ValueError('Only 2D and 3D arrays supported in the test')
-
-    data -= 0.5
-    return data
-
-
-@pytest.mark.parametrize(
-    'data',
-    (
-        _gen_tfce_data(n_dims=3),
-        _gen_tfce_data(n_dims=2)
-    )
-)
-def test_tfce_thresholds(numba_conditional, data):
+def test_tfce_thresholds(numba_conditional):
     """Test TFCE thresholds."""
+    rng = np.random.RandomState(0)
+    data = rng.randn(7, 10, 1) - 0.5
+
     # if tail==-1, step must also be negative
     with pytest.raises(ValueError, match='must be < 0 for tail == -1'):
         permutation_cluster_1samp_test(
@@ -687,7 +669,8 @@ def test_tfce_thresholds(numba_conditional, data):
         permutation_cluster_1samp_test(
             data, tail=1, out_type='mask', threshold=dict(start=1, step=-0.5))
 
-    # Should work with 2D and 3D data
+    # Should work with 2D data too
+    data = rng.randn(7, 10) - 0.5
     permutation_cluster_1samp_test(
         X=data,
         threshold=dict(start=0, step=0.2)

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -670,11 +670,8 @@ def test_tfce_thresholds(numba_conditional):
             data, tail=1, out_type='mask', threshold=dict(start=1, step=-0.5))
 
     # Should work with 2D data too
-    data = rng.randn(7, 10) - 0.5
-    permutation_cluster_1samp_test(
-        X=data,
-        threshold=dict(start=0, step=0.2)
-    )
+    permutation_cluster_1samp_test(X=data[..., 0],
+                                   threshold=dict(start=0, step=0.2))
 
 
 # 1D gives slices, 2D+ gives boolean masks


### PR DESCRIPTION
Please see the added test case for a 2D NumPy array. This fails on `main` with:

```python
-> 1205     return _permutation_cluster_test(
   1206         X=[X], threshold=threshold, n_permutations=n_permutations, tail=tail,
   1207         stat_fun=stat_fun, adjacency=adjacency, n_jobs=n_jobs, seed=seed,

~/Development/mne-python/mne/stats/cluster_level.py in _permutation_cluster_test(X, threshold, n_permutations, tail, stat_fun, adjacency, n_jobs, seed, max_step, exclude, step_down_p, t_power, out_type, check_disjoint, buffer_size)
    929         # ndimage outputs slices or boolean masks by default
    930         if out_type == 'indices':
--> 931             clusters = _cluster_mask_to_indices(clusters, t_obs.shape)
    932 
    933     # convert our seed to orders

~/Development/mne-python/mne/stats/cluster_level.py in _cluster_mask_to_indices(components, shape)
    564             components[ci] = np.where(c.reshape(shape))
    565         else:
--> 566             assert isinstance(c, tuple), type(c)
    567             c = list(c)  # tuple->list
    568             for ii, cc in enumerate(c):

AssertionError: <class 'slice'>
```

Was reported by @shirllim