### PR TITLE
fix: do not write trailing whitespace in annotations.txt

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -797,8 +797,7 @@ def _write_annotations_txt(fname, annot):
     content = "# MNE-Annotations\n"
     if annot.orig_time is not None:
         # for backward compat, we do not write tzinfo (assumed UTC)
-        content += ("# orig_time : %s   \n"
-                    % annot.orig_time.replace(tzinfo=None))
+        content += f"# orig_time : {annot.orig_time.replace(tzinfo=None)}\n"
     content += "# onset, duration, description"
     data = [annot.onset, annot.duration, annot.description]
     if annot._any_ch_names():


### PR DESCRIPTION
This is a minor PR to fix annoying whitespace.

I noticed this because I often track annotation files in git, and a pre-commit hook changed my files to auto-remove trailing whitespace.

reading annotation txt files should be unaffected, because that whitespace is stripped anyhow: https://github.com/mne-tools/mne-python/blob/b97da4357f9ffb584eef5949c958187b3a7cc566/mne/annotations.py#L997