### PR TITLE
MRG, ENH: Implement lru_cache for smooth_mat

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -40,6 +40,8 @@ Enhancements
 
 - Improve docstring of ``events`` arguments and cross-referencing to :term:`events` (:gh:`10056` by `Mathieu Scheltienne`_)
 
+- Speed up repeated surface-smoothing operation (e.g., in repeated calls to :meth:`stc.plot() <mne.SourceEstimate.plot>`) (:gh:`10077` by `Eric Larson`_)
+
 - Add ``infer_type`` argument to :func:`mne.io.read_raw_edf` and :func:`mne.io.read_raw_bdf` to automatically infer channel types from channel labels (:gh:`10058` by `Clemens Brunner`_)
 
 Bugs

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -19,7 +19,7 @@ from .source_space import SourceSpaces, _ensure_src, _grid_interp
 from .surface import mesh_edges, read_surface, _compute_nearest
 from .utils import (logger, verbose, check_version, get_subjects_dir,
                     warn as warn_, fill_doc, _check_option, _validate_type,
-                    BunchConst, _check_fname, warn,
+                    BunchConst, _check_fname, warn, _custom_lru_cache,
                     _ensure_int, ProgressBar, use_log_level)
 from .externals.h5io import read_hdf5, write_hdf5
 
@@ -1074,7 +1074,11 @@ def _hemi_morph(tris, vertices_to, vertices_from, smooth, maps, warn):
                       extra=' when used as a string.')
         mm = _surf_nearest(vertices_from, e).tocsr()
     else:
-        mm = _surf_upsampling_mat(vertices_from, e, smooth, warn=warn)
+        mm, n_missing, n_iter = _surf_upsampling_mat(vertices_from, e, smooth)
+        if n_missing and warn:
+            warn_(f'{n_missing}/{e.shape[0]} vertices not included in '
+                  'smoothing, consider increasing the number of steps')
+        logger.info(f'    {n_iter} smooth iterations done.')
     assert mm.shape == (n_vertices, len(vertices_from))
     if maps is not None:
         mm = maps[vertices_to] * mm
@@ -1158,6 +1162,8 @@ def grade_to_vertices(subject, grade, subjects_dir=None, n_jobs=1,
     return vertices
 
 
+# Takes ~20 ms to hash, ~100 ms to compute (5x speedup)
+@_custom_lru_cache(20)
 def _surf_nearest(vertices, adj_mat):
     from scipy import sparse
     from scipy.sparse.csgraph import dijkstra
@@ -1185,7 +1191,12 @@ def _csr_row_norm(data, row_norm):
     data.data /= np.where(row_norm, row_norm, 1).repeat(np.diff(data.indptr))
 
 
-def _surf_upsampling_mat(idx_from, e, smooth, warn=True):
+# upsamplers are generally not very big (< 1 MB), and users might have a lot
+# For 5 smoothing steps for example:
+# smoothing_steps=5 takes ~20 ms to hash, ~100 ms to compute (5x speedup)
+# smoothing_steps=None takes ~20 ms to hash, ~400 ms to compute (20x speedup)
+@_custom_lru_cache(20)
+def _surf_upsampling_mat(idx_from, e, smooth):
     """Upsample data on a subject's surface given mesh edges."""
     # we're in CSR format and it's to==from
     from scipy import sparse
@@ -1236,11 +1247,9 @@ def _surf_upsampling_mat(idx_from, e, smooth, warn=True):
         if k == smooth or (smooth is None and len(idx) == n_tot):
             break  # last iteration / done
     assert data.shape == (n_tot, len(idx_from))
-    if len(idx) != n_tot and warn:
-        warn_(f'{n_tot-len(idx)}/{n_tot} vertices not included in smoothing, '
-              'consider increasing the number of steps')
-    logger.info(f'    {k + 1} smooth iterations done.')
-    return data
+    n_missing = n_tot - len(idx)
+    n_iter = k + 1
+    return data, n_missing, n_iter
 
 
 def _sparse_argmax_nnz_row(csr_mat):

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -61,7 +61,8 @@ from .numerics import (hashfunc, _compute_row_norms,
                        _mask_to_onsets_offsets, _array_equal_nan,
                        _julian_to_cal, _cal_to_julian, _dt_to_julian,
                        _julian_to_dt, _dt_to_stamp, _stamp_to_dt,
-                       _check_dt, _ReuseCycle, _arange_div, _hashable_ndarray)
+                       _check_dt, _ReuseCycle, _arange_div, _hashable_ndarray,
+                       _custom_lru_cache)
 from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
                     _prepare_write_metadata, _FakeNoPandas, ShiftTimeMixin)
 from .linalg import (_svd_lwork, _repeated_svd, _sym_mat_pow, sqrtm_sym, eigh,

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -21,7 +21,9 @@ from mne.utils import (_get_inst_data, hashfunc,
                        _undo_scaling_array, _PCA, requires_sklearn,
                        _array_equal_nan, _julian_to_cal, _cal_to_julian,
                        _dt_to_julian, _julian_to_dt, grand_average,
-                       _ReuseCycle, requires_version, numerics)
+                       _ReuseCycle, requires_version, numerics,
+                       _custom_lru_cache)
+from mne.utils.numerics import _LRU_CACHES, _LRU_CACHE_MAXSIZES
 
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -539,3 +541,50 @@ def test_arange_div(numba_conditional, n, d):
     want = np.arange(n) / d
     got = numerics._arange_div(n, d)
     assert_allclose(got, want)
+
+
+def test_custom_lru_cache():
+    """Test our _custom_lru_cache implementation."""
+    n_calls = [0, 0]
+    start_size = len(_LRU_CACHES)
+
+    @_custom_lru_cache(2)
+    def my_fun(*args):
+        n_calls[0] += 1
+        return ', '.join(arg.__class__.__name__ for arg in args)
+
+    assert len(_LRU_CACHES) == start_size + 1
+    fun_hash = list(_LRU_CACHES)[-1]
+    assert _LRU_CACHE_MAXSIZES[fun_hash] == 2
+
+    @_custom_lru_cache(1)
+    def my_fun_2(*args):
+        n_calls[1] += 1
+        return ', '.join(arg.__class__.__name__ for arg in args)
+
+    assert len(_LRU_CACHES) == start_size + 2
+    fun_2_hash = list(_LRU_CACHES)[-1]
+    assert _LRU_CACHE_MAXSIZES[fun_2_hash] == 1
+
+    assert n_calls == [0, 0]
+    assert my_fun(1, 2, 3) == 'int, int, int'
+    assert n_calls == [1, 0]
+    assert my_fun_2(1, 2, 3.) == 'int, int, float'
+    assert n_calls == [1, 1]
+    # repeated calls use cached version
+    assert my_fun(1, 2, 3) == 'int, int, int'
+    assert n_calls == [1, 1]
+    assert my_fun_2(1, 2, 3.) == 'int, int, float'
+    assert n_calls == [1, 1]
+    assert len(_LRU_CACHES[fun_hash]) == 1
+    assert len(_LRU_CACHES[fun_2_hash]) == 1
+    assert my_fun(1, np.array([2]), 3) == 'int, ndarray, int'
+    assert n_calls == [2, 1]
+    assert len(_LRU_CACHES[fun_hash]) == 2
+    assert my_fun_2(1, sparse.eye(1, format='csc')) == 'int, csc_matrix'
+    assert n_calls == [2, 2]
+    assert len(_LRU_CACHES[fun_2_hash]) == 1  # other got popped
+    # we could add support for this eventually, but don't bother for now
+    with pytest.raises(RuntimeError, match='Unsupported sparse type'):
+        my_fun_2(1, sparse.eye(1, format='coo'))
+    assert n_calls == [2, 2]  # never did any computation


### PR DESCRIPTION
For a long time I've wished that our `smoothing_steps` operations could be faster. Working on #10071 made me even more motiviated to do it. I found a way to do it by implementing a custom `lru_cache` mechanism that operates at the level of smoothing matrices.

`@functools.lru_cache` requires that all arguments are hashable. In theory rather than using our own LRU implementation we could maybe make a `_hashable_csr_matrix` like we have `_hashable_ndarray` and pass these lightweight wrappers to standard `@functools.lru_cache()`-decorated functions, but there is no `csr_mat.view(...)` equivalent of [ndarray.view](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.view.html), and I can't think of a clean way to override the `__hash__` and `__eq__` methods of `csr_matrix` like we do [for `ndarray`](https://github.com/mne-tools/mne-python/blob/01da5a32ac1a80cf0cc42684f154597595608ea0/mne/utils/numerics.py#L608-L617). This is also an implementation detail that we can change later, though. I think the unit tests I have for `_custom_lru_cache` verify things are working properly from the user point of view.

Local testing also confirms things work:

- For `smoothing_steps=None` in the `vector_solution.py` example with sample data on my macOS laptop, it takes 400 ms to compute the smoothing mat, and only 20 ms to hash the args and shortcut (i.e., 20x speedup for subsequent plotting calls, at least on the smoothing part)
- For smoothing_steps=5, the ratio is still pretty good (100 ms vs 20 ms, i.e., 5x speedup).