### PR TITLE
MRG: Add scrollbar to report tag dropdown menu

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -82,6 +82,8 @@ Bugs
 
 - Fix bug that appears during automatic calculation of the colormap of `mne.viz.Brain` when data values of ``fmin`` and ``fmax`` are too close (:gh:`10074` by `Guillaume Favelier`_)
 
+- We now display a scrollbar in the tags dropdown of a `~mne.Report` if many tags have been added, granting access to all tags instead of "hiding" them below the bottom of the page (:gh:`10082` by `Richard Höchenberger`_)
+
 API changes
 ~~~~~~~~~~~
 - ``mne.Info.pick_channels`` has been deprecated. Use ``inst.pick_channels`` to pick channels from Raw|Epochs|Evoked. Use :func:`mne.pick_info` to pick channels from :class:`mne.Info` (:gh:`10039` by `Mathieu Scheltienne`_)

--- a/mne/report/templates/header.html
+++ b/mne/report/templates/header.html
@@ -29,7 +29,7 @@
           Filter by tags
         </button>
 
-        <ul class="dropdown-menu dropdown-menu-end shadow-sm overflow-auto" aria-labelledby="show-hide-tags">
+        <ul class="dropdown-menu dropdown-menu-end shadow-sm vh-100 overflow-auto" aria-labelledby="show-hide-tags">
           <li>
             <label class="dropdown-item" id="selectAllTagsCheckboxLabel">
               <input class="form-check-input me-1" type="checkbox" value="" checked>


### PR DESCRIPTION
Fixes #10046

We still have an overlap between the dropdown and the "status bar" at the bottom, but this can be addressed in a followup PR.

<img width="165" alt="Screen Shot 2021-12-03 at 11 35 44" src="https://user-images.githubusercontent.com/2046265/144588481-598e2a0c-243f-4807-8406-880f4d1dc77e.png">
