### PR TITLE
doc: clarify ica.apply include and exclude params

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1666,10 +1666,15 @@ class ICA(ContainsMixin):
             in-place.
         include : array_like of int
             The indices referring to columns in the ummixing matrix. The
-            components to be kept.
+            components to be kept. If ``None`` (default), all components
+            will be included (minus those defined in ``ica.exclude``
+            and the `exclude` parameter, see below).
         exclude : array_like of int
             The indices referring to columns in the ummixing matrix. The
-            components to be zeroed out.
+            components to be zeroed out. If ``None`` (default) or an
+            empty list, only components from ``ica.exclude`` will be
+            excluded. Else, the union of `exclude` and ``ica.exclude``
+            will be excluded.
         %(n_pca_components_apply)s
         start : int | float | None
             First sample to include. If float, data will be interpreted as

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1668,12 +1668,12 @@ class ICA(ContainsMixin):
             The indices referring to columns in the ummixing matrix. The
             components to be kept. If ``None`` (default), all components
             will be included (minus those defined in ``ica.exclude``
-            and the `exclude` parameter, see below).
+            and the ``exclude`` parameter, see below).
         exclude : array_like of int
             The indices referring to columns in the ummixing matrix. The
             components to be zeroed out. If ``None`` (default) or an
             empty list, only components from ``ica.exclude`` will be
-            excluded. Else, the union of `exclude` and ``ica.exclude``
+            excluded. Else, the union of ``exclude`` and ``ica.exclude``
             will be excluded.
         %(n_pca_components_apply)s
         start : int | float | None


### PR DESCRIPTION
That's how I understand it (and the code looks like it in the source and when running it) ... so I thought I'd add this to the docstring to clear things up.

The relevant things happen here:
https://github.com/mne-tools/mne-python/blob/c3ff05c05c7bfcf765249f27a517803f27f48b4e/mne/preprocessing/ica.py#L1796-L1801

where `_check_exclude` does this (either union of `ica.exclude` and `exclude`, or just `ica.exclude`, if `exclude` is "n/a"):
https://github.com/mne-tools/mne-python/blob/c3ff05c05c7bfcf765249f27a517803f27f48b4e/mne/preprocessing/ica.py#L1726-L1731

`include` is handled a few lines below in `_pick_sources`:
https://github.com/mne-tools/mne-python/blob/c3ff05c05c7bfcf765249f27a517803f27f48b4e/mne/preprocessing/ica.py#L1820-L1824

i.e., all are `included` if `None` ... else the specific selection specified ... and then idxs are removed from it using `exclude` as previously triaged
