### PR TITLE
Fast annotation from mask

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -24,6 +24,8 @@ Enhancements
 ~~~~~~~~~~~~
 .. - Add something cool (:gh:`9192` **by new contributor** |New Contributor|_)
 
+- Implement fast annotation from mask in artifact_detection.py (:gh:`10089` **by new contributor** `Senwen Deng`_)
+
 - Fix some unused variables in time_frequency_erds.py example (:gh:`10076` **by new contributor** `Jan Zerfowski`_)
 
 - Add show local maxima toggling button to :func:`mne.gui.locate_ieeg` (:gh:`9952` by `Alex Rockhill`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -24,7 +24,7 @@ Enhancements
 ~~~~~~~~~~~~
 .. - Add something cool (:gh:`9192` **by new contributor** |New Contributor|_)
 
-- Implement fast annotation from mask in artifact_detection.py (:gh:`10089` **by new contributor** `Senwen Deng`_)
+- Speed up :func:`mne.preprocessing.annotate_muscle_zscore`, :func:`mne.preprocessing.annotate_movement`, and :func:`mne.preprocessing.annotate_nan` through better annotation creation (:gh:`10089` **by new contributor** `Senwen Deng`_)
 
 - Fix some unused variables in time_frequency_erds.py example (:gh:`10076` **by new contributor** `Jan Zerfowski`_)
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -419,3 +419,5 @@
 .. _Riessarius Stargardsky: https://github.com/Riessarius
 
 .. _Jan Zerfowski: https://github.com/jzerfowski
+
+.. _Senwen Deng: https://snwn.de

--- a/mne/preprocessing/artifact_detection.py
+++ b/mne/preprocessing/artifact_detection.py
@@ -327,18 +327,17 @@ def _annotations_from_mask(times, mask, annot_name):
     midpoint_index = find_peaks(mask_tf)[0]
     onsets_index = midpoint_index - mask_tf[midpoint_index].astype(int) + 1
     ends_index = midpoint_index + mask_tf[midpoint_index].astype(int) - 1
-    
-    # Ensure onsets_index >= 0, otherwise the duration starts from the beginning
+    # Ensure onsets_index >= 0,
+    # otherwise the duration starts from the beginning
     onsets_index[onsets_index < 0] = 0
-    # Ensure ends_index < len(times), otherwise the duration is to the end of times
+    # Ensure ends_index < len(times),
+    # otherwise the duration is to the end of times
     ends_index[ends_index >= len(times)] = len(times) - 1
-
     onsets = times[onsets_index]
     ends = times[ends_index]
     durations = ends - onsets
-    desc = [annot_name]*len(durations)
+    desc = [annot_name] * len(durations)
     return Annotations(onsets, durations, desc)
-
 
 
 @verbose

--- a/mne/preprocessing/artifact_detection.py
+++ b/mne/preprocessing/artifact_detection.py
@@ -330,7 +330,8 @@ def _annotations_from_mask(times, mask, annot_name):
     # rear, then subtracting in index
     ins_mask_tf = np.concatenate((np.zeros(1), mask_tf, np.zeros(1)))
     left_midpt_index = find_peaks(ins_mask_tf)[0] - 1
-    right_midpt_index = np.flip(len(times) - find_peaks(ins_mask_tf[::-1])[0])
+    right_midpt_index = np.flip(len(ins_mask_tf) - 1 - find_peaks(
+        ins_mask_tf[::-1])[0]) - 1
     onsets_index = left_midpt_index - mask_tf[left_midpt_index].astype(int) + 1
     ends_index = right_midpt_index + mask_tf[right_midpt_index].astype(int)
     # Ensure onsets_index >= 0,

--- a/mne/preprocessing/artifact_detection.py
+++ b/mne/preprocessing/artifact_detection.py
@@ -339,7 +339,12 @@ def _annotations_from_mask(times, mask, annot_name):
     onsets_index[onsets_index < 0] = 0
     # Ensure ends_index < len(times),
     # otherwise the duration is to the end of times
-    ends_index[ends_index >= len(times)] = len(times) - 1
+    if len(times) == len(mask):
+        ends_index[ends_index >= len(times)] = len(times) - 1
+    # To be consistent with the original code,
+    # possibly a bug in tests code
+    else:
+        ends_index[ends_index >= len(mask)] = len(mask)
     onsets = times[onsets_index]
     ends = times[ends_index]
     durations = ends - onsets


### PR DESCRIPTION
#### Reference issue
Enhancement #10088.


#### What does this implement/fix?
The function `_annotations_from_mask` in [mne/preprocessing/artifact_detection.py](mne/preprocessing/artifact_detection.py)
is rewritten to avoid the use of any for loop, which could be very time-consuming
when the number of components is large.


#### Additional information
This new implementation does not require any additional package.
