### PR TITLE
FIX: Honor read_raw_bti's eog_ch parameter

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -48,6 +48,8 @@ Enhancements
 
 Bugs
 ~~~~
+- Teach :func:`mne.io.read_raw_bti` to use its ``eog_ch`` parameter (:gh:`10093` **by new contributor** `Adina Wagner`_)
+
 - Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSER_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)
 
 - Fix bug with :class:`mne.Report` where figures were saved with ``bbox_inches='tight'``, which led to inconsistent sizes in sliders (:gh:`9966` by `Eric Larson`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -48,7 +48,10 @@ Enhancements
 
 Bugs
 ~~~~
-- Teach :func:`mne.io.read_raw_bti` to use its ``eog_ch`` parameter (:gh:`10093` **by new contributor** `Adina Wagner`_)
+
+.. |Adina Wagter| replace:: **Adina Wagner**
+
+- Teach :func:`mne.io.read_raw_bti` to use its ``eog_ch`` parameter (:gh:`10093` **by new contributor** |Adina Wagner|_)
 
 - Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSER_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -49,7 +49,7 @@ Enhancements
 Bugs
 ~~~~
 
-.. |Adina Wagter| replace:: **Adina Wagner**
+.. |Adina Wagner| replace:: **Adina Wagner**
 
 - Teach :func:`mne.io.read_raw_bti` to use its ``eog_ch`` parameter (:gh:`10093` **by new contributor** |Adina Wagner|_)
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -419,3 +419,5 @@
 .. _Riessarius Stargardsky: https://github.com/Riessarius
 
 .. _Jan Zerfowski: https://github.com/jzerfowski
+
+.. _Adina Wagner: https://github.com/adswa

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -1194,7 +1194,7 @@ def _get_bti_info(pdf_fname, config_fname, head_shape_fname, rotation_x,
             chan_info['kind'] = FIFF.FIFFV_STIM_CH
         elif chan_4d == 'TRIGGER':
             chan_info['kind'] = FIFF.FIFFV_STIM_CH
-        elif chan_4d.startswith('EOG'):
+        elif chan_4d.startswith('EOG') or chan_4d in eog_ch:
             chan_info['kind'] = FIFF.FIFFV_EOG_CH
         elif chan_4d == ecg_ch:
             chan_info['kind'] = FIFF.FIFFV_ECG_CH

--- a/mne/io/bti/tests/test_bti.py
+++ b/mne/io/bti/tests/test_bti.py
@@ -355,3 +355,12 @@ def test_nan_trans():
 def test_bti_ch_data(fname, preload):
     """Test for gh-6048."""
     read_raw_bti(fname, preload=preload)  # used to fail with ascii decode err
+
+
+@testing.requires_testing_data
+def test_bti_set_eog():
+    """Check that EOG channels can be set (gh-10092)."""
+    raw = read_raw_bti(fname_sim,
+                       preload=False,
+                       eog_ch=('X65', 'X67', 'X69', 'X66', 'X68'))
+    assert_equal(len(pick_types(raw.info, eog=True)), 5)


### PR DESCRIPTION
This fixes #10092 at least partially. In my original issue, ``read_raw_bti()``'s ``eog_ch`` parameter was ignored. This change should allow EOG channels to now be selected with it. 

