### PR TITLE
MRG, MAINT: Remove unnecessary version checks

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,7 +17,6 @@ from datetime import datetime, timezone
 import numpy as np
 import matplotlib
 import sphinx
-import sphinx_gallery
 from sphinx_gallery.sorting import FileNameSortKey, ExplicitOrder
 from numpydoc import docscrape
 
@@ -25,12 +24,7 @@ import mne
 from mne.tests.test_docstring_parameters import error_ignores
 from mne.utils import (linkcode_resolve, # noqa, analysis:ignore
                        _assert_no_instances, sizeof_fmt, run_subprocess)
-from mne.fixes import _compare_version
 from mne.viz import Brain  # noqa
-
-if _compare_version(sphinx_gallery.__version__, '<', '0.2'):
-    raise ImportError('Must have at least version 0.2 of sphinx-gallery, got '
-                      f'{sphinx_gallery.__version__}')
 
 matplotlib.use('agg')
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -41,7 +41,7 @@ from .utils import (check_fname, logger, verbose, check_version, _time_mask,
 from . import viz
 
 from .fixes import (BaseEstimator, EmpiricalCovariance, _logdet,
-                    empirical_covariance, log_likelihood, _compare_version)
+                    empirical_covariance, log_likelihood)
 
 
 def _check_covs_algebra(cov1, cov2):
@@ -1016,14 +1016,6 @@ def _eigvec_subspace(eig, eigvec, mask):
     return eig, eigvec
 
 
-def _get_iid_kwargs():
-    import sklearn
-    kwargs = dict()
-    if _compare_version(sklearn.__version__, '<', '0.22'):
-        kwargs['iid'] = False
-    return kwargs
-
-
 def _compute_covariance_auto(data, method, info, method_params, cv,
                              scalings, n_jobs, stop_early, picks_list, rank):
     """Compute covariance auto mode."""
@@ -1109,7 +1101,7 @@ def _compute_covariance_auto(data, method, info, method_params, cv,
                 tuned_parameters = [{'shrinkage': shrinkage}]
                 shrinkages = []
                 gs = GridSearchCV(ShrunkCovariance(**mp),
-                                  tuned_parameters, cv=cv, **_get_iid_kwargs())
+                                  tuned_parameters, cv=cv)
                 for ch_type, picks in sub_picks_list:
                     gs.fit(data_[:, picks])
                     shrinkages.append((ch_type, gs.best_estimator_.shrinkage,

--- a/mne/datasets/sleep_physionet/_utils.py
+++ b/mne/datasets/sleep_physionet/_utils.py
@@ -12,7 +12,6 @@ from ...utils import (verbose, _TempDir, _check_pandas_installed,
                       _on_missing)
 from ...utils.check import _soft_import
 from ..utils import _get_path
-from ...fixes import _compare_version
 
 AGE_SLEEP_RECORDS = op.join(op.dirname(__file__), 'age_records.csv')
 TEMAZEPAM_SLEEP_RECORDS = op.join(op.dirname(__file__),
@@ -109,8 +108,7 @@ def _update_sleep_temazepam_records(fname=TEMAZEPAM_SLEEP_RECORDS):
 
     # Load and massage the data.
     data = pd.read_excel(subjects_fname, header=[0, 1])
-    if _compare_version(pd.__version__, '>=', '0.24.0'):
-        data = data.set_index(('Subject - age - sex', 'Nr'))
+    data = data.set_index(('Subject - age - sex', 'Nr'))
     data.index.name = 'subject'
     data.columns.names = [None, None]
     data = (data.set_index([('Subject - age - sex', 'Age'),
@@ -131,10 +129,7 @@ def _update_sleep_temazepam_records(fname=TEMAZEPAM_SLEEP_RECORDS):
     data = data.set_index(['id', 'subject', 'age', 'sex', 'drug',
                            'lights off', 'night nr', 'record type']).unstack()
     data.columns = [l1 + '_' + l2 for l1, l2 in data.columns]
-    if _compare_version(pd.__version__, '<' '0.21.0'):
-        data = data.reset_index().drop(labels=['id'], axis=1)
-    else:
-        data = data.reset_index().drop(columns=['id'])
+    data = data.reset_index().drop(columns=['id'])
 
     data['sex'] = (data.sex.astype('category')
                        .cat.rename_categories({1: 'male', 2: 'female'}))
@@ -188,10 +183,7 @@ def _update_sleep_age_records(fname=AGE_SLEEP_RECORDS):
                                      .str.split('.', expand=True)[0]
                                      .astype('category'))
 
-    if _compare_version(pd.__version__, '<', '0.21.0'):
-        data = data.reset_index().drop(labels=['id'], axis=1)
-    else:
-        data = data.reset_index().drop(columns=['id'])
+    data = data.reset_index().drop(columns=['id'])
     data = data[['subject', 'night', 'record type', 'age', 'sex', 'lights off',
                  'sha', 'fname']]
 

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -7,7 +7,6 @@
 from copy import deepcopy
 import os.path as op
 import shutil
-from unittest import SkipTest
 
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
@@ -24,7 +23,6 @@ from mne.datasets import testing
 from mne.utils import check_version, Bunch
 from mne.annotations import events_from_annotations, read_annotations
 from mne.externals.pymatreader import read_mat
-from mne.fixes import _compare_version
 
 base_dir = op.join(testing.data_path(download=False), 'EEGLAB')
 
@@ -220,11 +218,6 @@ def test_io_set_raw_more(tmp_path):
     # In theory this should work and be simpler, but there is an obscure
     # SciPy writing bug that pops up sometimes:
     # nopos_chanlocs = np.array(chanlocs[['labels', 'Z']])
-
-    if _compare_version(np.__version__, '==', '1.14.0'):
-        # There is a bug in 1.14.0 (or maybe with SciPy 1.0.0?) that causes
-        # this write to fail!
-        raise SkipTest('Need to fix bug in NumPy 1.14.0!')
 
     # test reading channel names but not positions when there is no X (only Z)
     # field in the EEG.chanlocs structure

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from .channels.channels import _get_meg_system
 from .fixes import (_serialize_volume_info, _get_read_geometry, jit,
-                    prange, bincount, _compare_version)
+                    prange, bincount)
 from .io.constants import FIFF
 from .io.pick import pick_types
 from .parallel import parallel_func
@@ -1100,7 +1100,7 @@ def write_surface(fname, coords, faces, create_stamp='', volume_info=None,
     if file_format == 'freesurfer':
         try:
             import nibabel as nib
-            has_nibabel = _compare_version(nib.__version__, '>', '2.1.0')
+            has_nibabel = True
         except ImportError:
             has_nibabel = False
         if has_nibabel:

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -41,7 +41,6 @@ from mne.epochs import (
 from mne.utils import (requires_pandas, object_diff,
                        catch_logging, _FakeNoPandas,
                        assert_meg_snr, check_version, _dt_to_stamp)
-from mne.fixes import _compare_version
 
 data_path = testing.data_path(download=False)
 fname_raw_testing = op.join(data_path, 'MEG', 'sample',
@@ -3106,9 +3105,6 @@ def assert_metadata_equal(got, exp):
         assert isinstance(exp, pandas.DataFrame)
         assert isinstance(got, pandas.DataFrame)
         assert set(got.columns) == set(exp.columns)
-        if _compare_version(pandas.__version__, '<', '0.25'):
-            # Old Pandas does not necessarily order them properly
-            got = got[exp.columns]
         check = (got == exp)
         assert check.all().all()
 

--- a/mne/time_frequency/tests/test_multitaper.py
+++ b/mne/time_frequency/tests/test_multitaper.py
@@ -6,7 +6,6 @@ from mne.time_frequency import psd_multitaper
 from mne.time_frequency.multitaper import dpss_windows
 from mne.utils import requires_nitime
 from mne.io import RawArray
-from mne.fixes import _compare_version
 from mne import create_info
 
 
@@ -47,8 +46,7 @@ def test_multitaper_psd():
         raw = RawArray(data, info)
         pytest.raises(ValueError, psd_multitaper, raw, sfreq,
                       normalization='foo')
-        ni_5 = _compare_version(ni.__version__, '>=', '0.5')
-        norm = 'full' if ni_5 else 'length'
+        norm = 'full'
         for adaptive, n_jobs in zip((False, True, True), (1, 1, 2)):
             psd, freqs = psd_multitaper(raw, adaptive=adaptive,
                                         n_jobs=n_jobs,

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -107,13 +107,6 @@ def requires_module(function, name, call=None):
     return pytest.mark.skipif(skip, reason=reason)(function)
 
 
-_pandas_call = """
-import pandas
-version = pandas.__version__
-if _compare_version(version, '<', '0.8.0'):
-    raise ImportError
-"""
-
 _mne_call = """
 if not has_mne_c():
     raise ImportError
@@ -129,7 +122,7 @@ if 'NEUROMAG2FT_ROOT' not in os.environ:
     raise ImportError
 """
 
-requires_pandas = partial(requires_module, name='pandas', call=_pandas_call)
+requires_pandas = partial(requires_module, name='pandas')
 requires_pylsl = partial(requires_module, name='pylsl')
 requires_sklearn = partial(requires_module, name='sklearn')
 requires_mne = partial(requires_module, name='MNE-C', call=_mne_call)

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -37,7 +37,6 @@ from ..io.pick import _picks_by_type
 from ..filter import estimate_ringing_samples
 from .utils import (tight_layout, _get_color_list, _prepare_trellis, plt_show,
                     _figure_agg, _validate_type)
-from ..fixes import _compare_version
 
 
 def _index_info_cov(info, cov, exclude):
@@ -761,14 +760,10 @@ def plot_events(events, sfreq=None, first_samp=0, color=None, event_id=None,
 
 def _get_presser(fig):
     """Get our press callback."""
-    import matplotlib
     callbacks = fig.canvas.callbacks.callbacks['button_press_event']
     func = None
     for key, val in callbacks.items():
-        if _compare_version(matplotlib.__version__, '>=', '3'):
-            func = val()
-        else:
-            func = val.func
+        func = val()
         if func.__class__.__name__ == 'partial':
             break
         else:

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -39,7 +39,6 @@ from ..utils import (verbose, get_config, _check_ch_locs, _check_option,
                      logger, fill_doc, _pl, _check_sphere, _ensure_int,
                      _validate_type, _to_rgb, warn)
 from ..transforms import apply_trans
-from ..fixes import _compare_version
 
 
 _channel_type_prettyprint = {'eeg': "EEG channel", 'grad': "Gradiometer",
@@ -1406,11 +1405,6 @@ class SelectFromCollection(object):
 
     def __init__(self, ax, collection, ch_names, alpha_other=0.5,
                  linewidth_other=0.5, alpha_selected=1, linewidth_selected=1):
-        from matplotlib import __version__
-        if _compare_version(__version__, '<', '1.2.1'):
-            raise ImportError('Interactive selection not possible for '
-                              'matplotlib versions < 1.2.1. Upgrade '
-                              'matplotlib.')
         from matplotlib.widgets import LassoSelector
         self.canvas = ax.figure.canvas
         self.collection = collection


### PR DESCRIPTION
By looking at our [min version list](https://github.com/mne-tools/mne-python) and now (thanks to @hoechenberger 
in #10091) just being able to do `git grep _compare_version` I was able to remove a number of comparisons that are no longer necessary based on our min required versions.