### PR TITLE
[MRG] ENH: add verbose param to load_bad_channels, log info

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -48,6 +48,8 @@ Enhancements
 
 - Speed up repeated surface-smoothing operation (e.g., in repeated calls to :meth:`stc.plot() <mne.SourceEstimate.plot>`) (:gh:`10077` by `Eric Larson`_)
 
+- Add ``verbose`` parameter to :func:`mne.io.Raw.load_bad_channels` and log information on how bad channels are updated (:gh:`10102` by `Stefan Appelhoff`_)
+
 - Add ``infer_type`` argument to :func:`mne.io.read_raw_edf` and :func:`mne.io.read_raw_bdf` to automatically infer channel types from channel labels (:gh:`10058` by `Clemens Brunner`_)
 
 Bugs

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1646,21 +1646,18 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             count_diff = len(bad_names) - len(new_bads)
 
             if count_diff > 0:
+                msg = (f'{count_diff} bad channels from:'
+                       f'\n{bad_file}\nnot found in:\n{self.filenames[0]}')
                 if not force:
-                    raise ValueError(
-                        f'Bad channels from:\n{bad_file}\n not found '
-                        f'in:\n{self.filenames[0]}'
-                        )
+                    raise ValueError(msg)
                 else:
-                    logger.warning(
-                        f'{count_diff} bad channels from:'
-                        f'\n{bad_file}\nnot found in:\n{self.filenames[0]}'
-                    )
+                    logger.warning(msg)
 
         if prev_bads != new_bads:
-            logger.info(f'Updating bads: {prev_bads} -> {new_bads}')
+            logger.info(f'Updating bad channels: {prev_bads} -> {new_bads}')
             self.info['bads'] = new_bads
-
+        else:
+            logger.info(f'No channels updated. Bads are: {prev_bads}')
 
     @fill_doc
     def append(self, raws, preload=None):

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1615,7 +1615,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """
         return self.n_times
 
-    def load_bad_channels(self, bad_file=None, force=False):
+    @verbose
+    def load_bad_channels(self, bad_file=None, force=False, verbose=None):
         """Mark channels as bad from a text file.
 
         This function operates mostly in the style of the C function
@@ -1632,26 +1633,34 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             Whether or not to force bad channel marking (of those
             that exist) if channels are not found, instead of
             raising an error.
+        %(verbose)s
         """
+        prev_bads = self.info['bads']
+        new_bads = []
         if bad_file is not None:
             # Check to make sure bad channels are there
             names = frozenset(self.info['ch_names'])
             with open(bad_file) as fid:
                 bad_names = [line for line in fid.read().splitlines() if line]
-            names_there = [ci for ci in bad_names if ci in names]
-            count_diff = len(bad_names) - len(names_there)
+            new_bads = [ci for ci in bad_names if ci in names]
+            count_diff = len(bad_names) - len(new_bads)
 
             if count_diff > 0:
                 if not force:
-                    raise ValueError('Bad channels from:\n%s\n not found '
-                                     'in:\n%s' % (bad_file,
-                                                  self.filenames[0]))
+                    raise ValueError(
+                        f'Bad channels from:\n{bad_file}\n not found '
+                        f'in:\n{self.filenames[0]}'
+                        )
                 else:
-                    warn('%d bad channels from:\n%s\nnot found in:\n%s'
-                         % (count_diff, bad_file, self.filenames[0]))
-            self.info['bads'] = names_there
-        else:
-            self.info['bads'] = []
+                    logger.warning(
+                        f'{count_diff} bad channels from:'
+                        f'\n{bad_file}\nnot found in:\n{self.filenames[0]}'
+                    )
+
+        if prev_bads != new_bads:
+            logger.info(f'Updating bads: {prev_bads} -> {new_bads}')
+            self.info['bads'] = new_bads
+
 
     @fill_doc
     def append(self, raws, preload=None):

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1646,7 +1646,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             count_diff = len(bad_names) - len(new_bads)
 
             if count_diff > 0:
-                msg = (f'{count_diff} bad channels from:'
+                msg = (f'{count_diff} bad channel(s) from:'
                        f'\n{bad_file}\nnot found in:\n{self.filenames[0]}')
                 if not force:
                     raise ValueError(msg)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1651,7 +1651,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                 if not force:
                     raise ValueError(msg)
                 else:
-                    logger.warning(msg)
+                    warn(msg)
 
         if prev_bads != new_bads:
             logger.info(f'Updating bad channels: {prev_bads} -> {new_bads}')

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1625,14 +1625,14 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         Parameters
         ----------
-        bad_file : str
-            File name of the text file containing bad channels
-            If bad_file = None, bad channels are cleared, but this
-            is more easily done directly as raw.info['bads'] = [].
+        bad_file : path-like | None
+            File name of the text file containing bad channels.
+            If ``None`` (default), bad channels are cleared, but this
+            is more easily done directly with ``raw.info['bads'] = []``.
         force : bool
             Whether or not to force bad channel marking (of those
             that exist) if channels are not found, instead of
-            raising an error.
+            raising an error. Defaults to ``False``.
         %(verbose)s
         """
         prev_bads = self.info['bads']

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -574,7 +574,7 @@ def test_load_bad_channels(tmp_path):
 
     # Test forcing the bad case
     with pytest.warns(RuntimeWarning, match='1 bad channel'):
-        raw.load_bad_channels(bad_file_wrong, force=True, verbose=None)
+        raw.load_bad_channels(bad_file_wrong, force=True)
 
     # write it out, read it in, and check
     raw.save(tmp_path / 'foo_raw.fif', overwrite=True)

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -573,7 +573,8 @@ def test_load_bad_channels(tmp_path):
     pytest.raises(ValueError, raw.load_bad_channels, bad_file_wrong)
 
     # Test forcing the bad case
-    raw.load_bad_channels(bad_file_wrong, force=True, verbose=None)
+    with pytest.warns(RuntimeWarning, match='1 bad channel'):
+        raw.load_bad_channels(bad_file_wrong, force=True, verbose=None)
 
     # write it out, read it in, and check
     raw.save(tmp_path / 'foo_raw.fif', overwrite=True)

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -573,9 +573,9 @@ def test_load_bad_channels(tmp_path):
     pytest.raises(ValueError, raw.load_bad_channels, bad_file_wrong)
 
     # Test forcing the bad case
-    with pytest.warns(RuntimeWarning, match='1 bad channel'):
-        raw.load_bad_channels(bad_file_wrong, force=True)
-        # write it out, read it in, and check
+    raw.load_bad_channels(bad_file_wrong, force=True, verbose=None)
+
+    # write it out, read it in, and check
     raw.save(tmp_path / 'foo_raw.fif', overwrite=True)
     raw_new = read_raw_fif(tmp_path / 'foo_raw.fif')
     assert correct_bads == raw_new.info['bads']


### PR DESCRIPTION
I was just using this function and thought that it would be good to have it log about the updates.

I also turned a `warnings.warn` into a `logger.warn` ... however that meant I had to remove a `    with pytest.warns(RuntimeWarning, match='1 bad channel'):` from the test. Is there a way to keep this `with pytest.warns` with the `logger.info`?

Also, should `load_bad_channels` maybe return `self` (i.e., the raw instance)? Similar to `set_annotations` and many other functions?