### PR TITLE
Remove pin on server environment

### DIFF
--- a/server_environment.yml
+++ b/server_environment.yml
@@ -15,7 +15,7 @@ dependencies:
 - pyvista>=0.32
 - nilearn
 - nibabel
-- nbformat <5.1  # XXX remove pinning once https://github.com/jupyter/nbformat/issues/206 has been fixed
+- nbformat
 - nbclient
 - mffpy>=0.5.7
 - pooch


### PR DESCRIPTION
I was giving a shot to this on one of our servers, and the pin is not needed anymore. https://github.com/jupyter/nbformat/issues/206 has been fixed.