### PR TITLE
MRG: Speed up browse figure creation if scalings are provided

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -52,6 +52,11 @@ Enhancements
 
 - Add ``infer_type`` argument to :func:`mne.io.read_raw_edf` and :func:`mne.io.read_raw_bdf` to automatically infer channel types from channel labels (:gh:`10058` by `Clemens Brunner`_)
 
+- Reduce the time it takes to generate a `~mne.io.Raw`, `~mne.Epochs`, or `~mne.preprocessing.ICA` figure if a ``scalings`` parameter is provided. This also speeds up butterfly plot generation in :meth:`mne.Report.add_raw` (:gh:`10109` by `Richard Höchenberger`_ and `Eric Larson`_)
+
+- :meth:`mne.Report.add_raw` gained a new ``scalings`` parameter to provide custom data scalings for the butterfly plots (:gh:`10109` by `Richard Höchenberger`_)
+
+
 Bugs
 ~~~~
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -52,7 +52,7 @@ Enhancements
 
 - Add ``infer_type`` argument to :func:`mne.io.read_raw_edf` and :func:`mne.io.read_raw_bdf` to automatically infer channel types from channel labels (:gh:`10058` by `Clemens Brunner`_)
 
-- Reduce the time it takes to generate a `~mne.io.Raw`, `~mne.Epochs`, or `~mne.preprocessing.ICA` figure if a ``scalings`` parameter is provided. This also speeds up butterfly plot generation in :meth:`mne.Report.add_raw` (:gh:`10109` by `Richard Höchenberger`_ and `Eric Larson`_)
+- Reduce the time it takes to generate a :class:`mne.io.Raw`, :class:`~mne.Epochs`, or :class:`~mne.preprocessing.ICA` figure if a ``scalings`` parameter is provided. This also speeds up butterfly plot generation in :meth:`mne.Report.add_raw` (:gh:`10109` by `Richard Höchenberger`_ and `Eric Larson`_)
 
 - :meth:`mne.Report.add_raw` gained a new ``scalings`` parameter to provide custom data scalings for the butterfly plots (:gh:`10109` by `Richard Höchenberger`_)
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -172,6 +172,28 @@ tmax : float
     End time of the raw data to use in seconds (cannot exceed data duration).
 """
 
+# Scaling of traces in plots
+docdict['scalings'] = """
+scalings : 'auto' | dict | None
+    Scaling factors for the traces. If a dictionary where any
+    value is ``'auto'``, the scaling factor is set to match the 99.5th
+    percentile of the respective data. If ``'auto'``, all scalings (for all
+    channel types) are set to ``'auto'``. If any values are ``'auto'`` and the
+    data is not preloaded, a subset up to 100 MB will be loaded. If ``None``,
+    defaults to::
+
+        dict(mag=1e-12, grad=4e-11, eeg=20e-6, eog=150e-6, ecg=5e-4,
+             emg=1e-3, ref_meg=1e-12, misc=1e-3, stim=1,
+             resp=1, chpi=1e-4, whitened=1e2)
+
+    .. note::
+        A particular scaling value ``s`` corresponds to half of the visualized
+        signal range around zero (i.e. from ``0`` to ``+s`` or from ``0`` to
+        ``-s``). For example, the default scaling of ``20e-6`` (20µV) for EEG
+        signals means that the visualized range will be 40 µV (20 µV in the
+        positive direction and 20 µV in the negative direction).
+"""
+
 # Raw
 docdict['standardize_names'] = """
 standardize_names : bool
@@ -2364,9 +2386,7 @@ stc_plot_kwargs : dict
 """
 docdict['topomap_kwargs'] = """
 topomap_kwargs : dict | None
-    Keyword arguments to pass to topomap functions (
-    :func:`mne.viz.plot_evoked_topomap`, :func:`mne.viz.plot_projs_topomap`,
-    etc.).
+    Keyword arguments to pass to the topomap-generating functions.
 """
 
 # Epochs

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -652,17 +652,7 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
     epochs : instance of Epochs
         The epochs object.
     %(picks_good_data)s
-    scalings : dict | 'auto' | None
-        Scaling factors for the traces. If any fields in scalings are 'auto',
-        the scaling factor is set to match the 99.5th percentile of a subset of
-        the corresponding data. If scalings == 'auto', all scalings fields are
-        set to 'auto'. If any fields are 'auto' and data is not preloaded,
-        a subset of epochs up to 100 Mb will be loaded. If None, defaults to::
-
-            dict(mag=1e-12, grad=4e-11, eeg=20e-6, eog=150e-6, ecg=5e-4,
-                 emg=1e-3, ref_meg=1e-12, misc=1e-3, stim=1, resp=1, chpi=1e-4,
-                 whitened=10.)
-
+    %(scalings)s
     n_epochs : int
         The number of epochs per view. Defaults to 20.
     n_channels : int

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -69,23 +69,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
         Color to make bad channels.
     %(event_color)s
         Defaults to ``'cyan'``.
-    scalings : 'auto' | dict | None
-        Scaling factors for the traces. If any fields in scalings are 'auto',
-        the scaling factor is set to match the 99.5th percentile of a subset of
-        the corresponding data. If scalings == 'auto', all scalings fields are
-        set to 'auto'. If any fields are 'auto' and data is not preloaded, a
-        subset of times up to 100mb will be loaded. If None, defaults to::
-
-            dict(mag=1e-12, grad=4e-11, eeg=20e-6, eog=150e-6, ecg=5e-4,
-                 emg=1e-3, ref_meg=1e-12, misc=1e-3, stim=1,
-                 resp=1, chpi=1e-4, whitened=1e2)
-
-        A particular scaling value ``s`` corresponds to half of the visualized
-        signal range around zero (i.e. from ``0`` to ``+s`` or from ``0`` to
-        ``-s``). For example, the default scaling of ``20e-6`` (20µV) for EEG
-        signals means that the visualized range will be 40µV (20µV in the
-        positive direction and 20µV in the negative direction).
-
+    %(scalings)s
     remove_dc : bool
         If True remove DC component when plotting data.
     order : array of int | None

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1162,6 +1162,11 @@ def _compute_scalings(scalings, inst, remove_dc=False, duration=10):
     if not isinstance(inst, (BaseRaw, BaseEpochs)):
         raise ValueError('Must supply either Raw or Epochs')
 
+    # If there are no "auto" scalings, we can return early!
+    if all([scalings[ch_type] != 'auto'
+            for ch_type in set(inst.get_channel_types())]):
+        return scalings
+
     ch_types = channel_indices_by_type(inst.info)
     ch_types = {i_type: i_ixs
                 for i_type, i_ixs in ch_types.items() if len(i_ixs) != 0}

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1165,7 +1165,7 @@ def _compute_scalings(scalings, inst, remove_dc=False, duration=10):
         raise ValueError('Must supply either Raw or Epochs')
 
     for key, value in scalings.items():
-        if value != 'auto' and not isinstance(value, float):
+        if not (isinstance(value, str) and value == 'auto'):
             try:
                 scalings[key] = float(value)
             except Exception:

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1158,19 +1158,33 @@ def _compute_scalings(scalings, inst, remove_dc=False, duration=10):
     """
     from ..io.base import BaseRaw
     from ..epochs import BaseEpochs
+
+    scalings = deepcopy(scalings)
     scalings = _handle_default('scalings_plot_raw', scalings)
     if not isinstance(inst, (BaseRaw, BaseEpochs)):
         raise ValueError('Must supply either Raw or Epochs')
 
+    for key, value in scalings.items():
+        if isinstance(value, str) and value != 'auto':
+            try:
+                scalings[key] = float(value)
+            except Exception:
+                raise ValueError(
+                    f'scalings must be "auto" or float, got '
+                    f'scalings[{key!r}]={value!r} which could not be '
+                    f'converted to float'
+                )
+
     # If there are no "auto" scalings, we can return early!
-    if all([scalings[ch_type] != 'auto'
-            for ch_type in set(inst.get_channel_types())]):
+    if all(
+        [scalings[ch_type] != 'auto'
+         for ch_type in inst.get_channel_types(unique=True)]
+    ):
         return scalings
 
     ch_types = channel_indices_by_type(inst.info)
     ch_types = {i_type: i_ixs
                 for i_type, i_ixs in ch_types.items() if len(i_ixs) != 0}
-    scalings = deepcopy(scalings)
 
     if inst.preload is False:
         if isinstance(inst, BaseRaw):
@@ -1196,15 +1210,7 @@ def _compute_scalings(scalings, inst, remove_dc=False, duration=10):
         data = inst._data.swapaxes(0, 1).reshape([len(inst.ch_names), -1])
     # Iterate through ch types and update scaling if ' auto'
     for key, value in scalings.items():
-        if key not in ch_types:
-            continue
-        if not (isinstance(value, str) and value == 'auto'):
-            try:
-                scalings[key] = float(value)
-            except Exception:
-                raise ValueError(
-                    f'scalings must be "auto" or float, got scalings[{key!r}]='
-                    f'{value!r} which could not be converted to float')
+        if (key not in ch_types or value != 'auto'):
             continue
         this_data = data[ch_types[key]]
         if remove_dc and (this_data.shape[1] / inst.info["sfreq"] >= duration):

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -19,7 +19,6 @@ import webbrowser
 import tempfile
 import math
 import numpy as np
-from copy import deepcopy
 import warnings
 from datetime import datetime
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1159,7 +1159,6 @@ def _compute_scalings(scalings, inst, remove_dc=False, duration=10):
     from ..io.base import BaseRaw
     from ..epochs import BaseEpochs
 
-    scalings = deepcopy(scalings)
     scalings = _handle_default('scalings_plot_raw', scalings)
     if not isinstance(inst, (BaseRaw, BaseEpochs)):
         raise ValueError('Must supply either Raw or Epochs')

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1165,7 +1165,7 @@ def _compute_scalings(scalings, inst, remove_dc=False, duration=10):
         raise ValueError('Must supply either Raw or Epochs')
 
     for key, value in scalings.items():
-        if isinstance(value, str) and value != 'auto':
+        if value != 'auto' and not isinstance(value, float):
             try:
                 scalings[key] = float(value)
             except Exception:


### PR DESCRIPTION
This avoids loading data from disk or performing calculations if we don't actually need to calculate `scalings` parameters.

Also adds a `scalings` parameter to `Report.add_raw()`.


Performance improvements:

```
this branch: 2.17 s ± 214 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
main:        4.07 s ± 625 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

with the following code:
```python
# %%
from pathlib import Path
import mne

sample_dir = Path(mne.datasets.sample.data_path())
sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'

raw = mne.io.read_raw_fif(sample_fname, verbose=False)
# raw.pick([0])
raw.pick_channels(['MEG 0111', 'MEG 0112', 'EEG 001', 'ECG 001', 'STI 014'])
report = mne.Report()

# %%
%timeit report.add_raw(raw=raw, title='foo', psd=False, replace=True)
```

x-ref #10107