### PR TITLE
BUG: Fix bug with morph speedup

### DIFF
--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -214,7 +214,8 @@ def test_surface_source_morph_shortcut():
     """Test that our shortcut for smooth=0 works."""
     stc = mne.read_source_estimate(fname_smorph)
     morph_identity = compute_source_morph(
-        stc, 'sample', 'sample', spacing=stc.vertices, smooth=0)
+        stc, 'sample', 'sample', spacing=stc.vertices, smooth=0,
+        subjects_dir=subjects_dir)
     stc_back = morph_identity.apply(stc)
     assert_allclose(stc_back.data, stc.data, rtol=1e-4)
     abs_sum = morph_identity.morph_mat - speye(len(stc.data), format='csc')


### PR DESCRIPTION
After #10077 we can have this happen when `smoothing_steps=0` (meaning, "do no smoothing"):
```
mne/morph.py:248: in compute_source_morph
    morph_mat = _compute_morph_matrix(
mne/morph.py:1040: in _compute_morph_matrix
    morpher.append(_hemi_morph(
mne/morph.py:1077: in _hemi_morph
    mm, n_missing, n_iter = _surf_upsampling_mat(vertices_from, e, smooth)
E   ValueError: too many values to unpack (expected 3)
```
This PR fixes the shortcut definition so that this doesn't happen.