### PR TITLE
MRG: Omit annotations in raw butterfly plots in Report

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -52,10 +52,11 @@ Enhancements
 
 - Add ``infer_type`` argument to :func:`mne.io.read_raw_edf` and :func:`mne.io.read_raw_bdf` to automatically infer channel types from channel labels (:gh:`10058` by `Clemens Brunner`_)
 
-- Reduce the time it takes to generate a :class:`mne.io.Raw`, :class:`~mne.Epochs`, or :class:`~mne.preprocessing.ICA` figure if a ``scalings`` parameter is provided. This also speeds up butterfly plot generation in :meth:`mne.Report.add_raw` (:gh:`10109` by `Richard Höchenberger`_ and `Eric Larson`_)
+- Reduce the time it takes to generate a :class:`mne.io.Raw`, :class:`~mne.Epochs`, or :class:`~mne.preprocessing.ICA` figure if a ``scalings`` parameter is provided (:gh:`10109` by `Richard Höchenberger`_ and `Eric Larson`_)
 
 - :meth:`mne.Report.add_raw` gained a new ``scalings`` parameter to provide custom data scalings for the butterfly plots (:gh:`10109` by `Richard Höchenberger`_)
 
+- Drastically speed up butterfly plot generation in :meth:`mne.Report.add_raw`. We now don't plot annotations anymore; however, we feel that the speed improvements justify this change, also considering the annotations were of limited use in the displayed one-second time slices anyway (:gh:`10114` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -2545,8 +2545,12 @@ class Report(object):
 
         return html
 
-    def _render_raw_butterfly_segments(self, *, raw: BaseRaw, image_format,
-                                       tags):
+    def _render_raw_butterfly_segments(
+        self, *, raw: BaseRaw, image_format, tags
+    ):
+        orig_annotations = raw.annotations.copy()
+        raw.set_annotations(None)
+
         # Pick 10 1-second time slices
         times = np.linspace(raw.times[0], raw.times[-1], 12)[1:-1]
         figs = []
@@ -2557,6 +2561,9 @@ class Report(object):
             fig = raw.plot(butterfly=True, show_scrollbars=False, start=tmin,
                            duration=duration, show=False)
             figs.append(fig)
+
+        raw.set_annotations(orig_annotations)
+        del orig_annotations
 
         captions = [f'Segment {i+1} of {len(figs)}'
                     for i in range(len(figs))]


### PR DESCRIPTION
This drastically reduced butterfly plotting for me locally with a test dataset (8 runs of MEG), by more than 35%
(145 seconds instead of 227)

Should only go in after #10109 has been merged.


x-ref #10107

Todo:
- [x] Add changelog entry


cc @agramfort 