### PR TITLE
MRG: Allow butterfly parameter of Report.add_raw() to accept number of segments to plot

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -56,6 +56,8 @@ Enhancements
 
 - :meth:`mne.Report.add_raw` gained a new ``scalings`` parameter to provide custom data scalings for the butterfly plots (:gh:`10109` by `Richard Höchenberger`_)
 
+- :meth:`mne.Report.add_raw` gained a new parameter ``butterfly_segment_count`` to adjust the number of one-second segments to plot (:gh:`10115` by `Richard Höchenberger`_)
+
 - Drastically speed up butterfly plot generation in :meth:`mne.Report.add_raw`. We now don't plot annotations anymore; however, we feel that the speed improvements justify this change, also considering the annotations were of limited use in the displayed one-second time slices anyway (:gh:`10114` by `Richard Höchenberger`_)
 
 Bugs

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -56,7 +56,7 @@ Enhancements
 
 - :meth:`mne.Report.add_raw` gained a new ``scalings`` parameter to provide custom data scalings for the butterfly plots (:gh:`10109` by `Richard Höchenberger`_)
 
-- :meth:`mne.Report.add_raw` gained a new parameter ``butterfly_segment_count`` to adjust the number of one-second segments to plot (:gh:`10115` by `Richard Höchenberger`_)
+- :meth:`mne.Report.add_raw` gained a new parameter ``n_butterfly_segments`` to adjust the number of one-second segments to plot (:gh:`10115` by `Richard Höchenberger`_)
 
 - Drastically speed up butterfly plot generation in :meth:`mne.Report.add_raw`. We now don't plot annotations anymore; however, we feel that the speed improvements justify this change, also considering the annotations were of limited use in the displayed one-second time slices anyway (:gh:`10114`, :gh:`10116` by `Richard Höchenberger`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -56,7 +56,7 @@ Enhancements
 
 - :meth:`mne.Report.add_raw` gained a new ``scalings`` parameter to provide custom data scalings for the butterfly plots (:gh:`10109` by `Richard Höchenberger`_)
 
-- :meth:`mne.Report.add_raw` gained a new parameter ``n_butterfly_segments`` to adjust the number of one-second segments to plot (:gh:`10115` by `Richard Höchenberger`_)
+- The ``butterfly`` parameter of :meth:`mne.Report.add_raw` now also accepts numbers to specify how many segments to plot (:gh:`10115` by `Richard Höchenberger`_)
 
 - Drastically speed up butterfly plot generation in :meth:`mne.Report.add_raw`. We now don't plot annotations anymore; however, we feel that the speed improvements justify this change, also considering the annotations were of limited use in the displayed one-second time slices anyway (:gh:`10114`, :gh:`10116` by `Richard Höchenberger`_)
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -981,8 +981,7 @@ class Report(object):
     @fill_doc
     def add_raw(
         self, raw, title, *, psd=None, projs=None, butterfly=True,
-        n_butterfly_segments=10, scalings=None, tags=('raw',),
-        replace=False, topomap_kwargs=None
+        scalings=None, tags=('raw',), replace=False, topomap_kwargs=None
     ):
         """Add `~mne.io.Raw` objects to the report.
 
@@ -997,15 +996,12 @@ class Report(object):
             passed when initializing the `~mne.Report`. If ``None``, use
             ``raw_psd`` from `~mne.Report` creation.
         %(report_projs)s
-        butterfly : bool
-            Whether to add butterfly plots of the data. Multiple equally-spaced
-            1-second segments will be plotted. The number of segments can be
-            adjusted via ``n_butterfly_segments``. Can be useful to spot
-            segments marked as "bad" and problematic channels.
-        n_butterfly_segments : int
-            The number of equally-spaced 1-second segments to plot if
-            ``butterfly=True``. Larger numbers may take a considerable amount
-            of time if the data contains many sensors.
+        butterfly : bool | int
+            Whether to add butterfly plots of the data. Can be useful to
+            spot problematic channels. If ``True``, 10 equally-spaced 1-second
+            segments will be plotted. If an integer, specifies the number of
+            1-second segments to plot. Larger numbers may take a considerable
+            amount of time if the data contains many sensors.
         %(scalings)s
         %(report_tags)s
         %(report_replace)s
@@ -1030,8 +1026,7 @@ class Report(object):
             raw=raw,
             add_psd=add_psd,
             add_projs=add_projs,
-            add_butterfly=butterfly,
-            n_butterfly_segments=n_butterfly_segments,
+            butterfly=butterfly,
             butterfly_scalings=scalings,
             image_format=self.image_format,
             tags=tags,
@@ -2615,9 +2610,8 @@ class Report(object):
 
         return html
 
-    def _render_raw(self, *, raw, add_psd, add_projs, add_butterfly,
-                    butterfly_scalings, n_butterfly_segments,
-                    image_format, tags, topomap_kwargs):
+    def _render_raw(self, *, raw, add_psd, add_projs, butterfly,
+                    butterfly_scalings, image_format, tags, topomap_kwargs):
         """Render raw."""
         if isinstance(raw, BaseRaw):
             fname = raw.filenames[0]
@@ -2639,7 +2633,8 @@ class Report(object):
         )
 
         # Butterfly plot
-        if add_butterfly:
+        if butterfly:
+            n_butterfly_segments = 10 if butterfly is True else butterfly
             butterfly_imgs_html = self._render_raw_butterfly_segments(
                 raw=raw, scalings=butterfly_scalings,
                 n_segments=n_butterfly_segments,

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -981,7 +981,7 @@ class Report(object):
     @fill_doc
     def add_raw(
         self, raw, title, *, psd=None, projs=None, butterfly=True,
-        butterfly_segment_count=10, scalings=None, tags=('raw',),
+        n_butterfly_segments=10, scalings=None, tags=('raw',),
         replace=False, topomap_kwargs=None
     ):
         """Add `~mne.io.Raw` objects to the report.
@@ -1000,9 +1000,9 @@ class Report(object):
         butterfly : bool
             Whether to add butterfly plots of the data. Multiple equally-spaced
             1-second segments will be plotted. The number of segments can be
-            adjusted via ``butterfly_segment_count``. Can be useful to spot
+            adjusted via ``n_butterfly_segments``. Can be useful to spot
             segments marked as "bad" and problematic channels.
-        butterfly_segment_count : int
+        n_butterfly_segments : int
             The number of equally-spaced 1-second segments to plot if
             ``butterfly=True``. Larger numbers may take a considerable amount
             of time if the data contains many sensors.
@@ -1031,7 +1031,7 @@ class Report(object):
             add_psd=add_psd,
             add_projs=add_projs,
             add_butterfly=butterfly,
-            butterfly_segment_count=butterfly_segment_count,
+            n_butterfly_segments=n_butterfly_segments,
             butterfly_scalings=scalings,
             image_format=self.image_format,
             tags=tags,
@@ -2568,11 +2568,11 @@ class Report(object):
         return html
 
     def _render_raw_butterfly_segments(
-        self, *, raw: BaseRaw, segment_count, scalings, image_format, tags
+        self, *, raw: BaseRaw, n_segments, scalings, image_format, tags
     ):
-        # Pick segment_count + 2 equally-spaced 1-second time slices, but omit
-        # the first and last slice, so we end up with segment_count slices
-        n = segment_count + 2
+        # Pick n_segments + 2 equally-spaced 1-second time slices, but omit
+        # the first and last slice, so we end up with n_segments slices
+        n = n_segments + 2
         times = np.linspace(raw.times[0], raw.times[-1], n)[1:-1]
         t_starts = np.array([max(t - 0.5, 0) for t in times])
         t_stops = np.array([min(t + 0.5, raw.times[-1]) for t in times])
@@ -2616,7 +2616,7 @@ class Report(object):
         return html
 
     def _render_raw(self, *, raw, add_psd, add_projs, add_butterfly,
-                    butterfly_scalings, butterfly_segment_count,
+                    butterfly_scalings, n_butterfly_segments,
                     image_format, tags, topomap_kwargs):
         """Render raw."""
         if isinstance(raw, BaseRaw):
@@ -2642,7 +2642,7 @@ class Report(object):
         if add_butterfly:
             butterfly_imgs_html = self._render_raw_butterfly_segments(
                 raw=raw, scalings=butterfly_scalings,
-                segment_count=butterfly_segment_count,
+                n_segments=n_butterfly_segments,
                 image_format=image_format, tags=tags
             )
         else:

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -1001,7 +1001,8 @@ class Report(object):
             spot problematic channels. If ``True``, 10 equally-spaced 1-second
             segments will be plotted. If an integer, specifies the number of
             1-second segments to plot. Larger numbers may take a considerable
-            amount of time if the data contains many sensors.
+            amount of time if the data contains many sensors. You can disable
+            butterfly plots altogether by passing ``False``.
         %(scalings)s
         %(report_tags)s
         %(report_replace)s

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -705,6 +705,8 @@ def test_manual_report_2d(tmp_path, invisible_fig):
 
     r.add_raw(raw=raw, title='my raw data', tags=('raw',), psd=True,
               projs=False)
+    r.add_raw(raw=raw, title='my raw data 2', psd=False, projs=False,
+              butterfly=1)
     r.add_events(events=events_fname, title='my events',
                  sfreq=raw.info['sfreq'])
     r.add_epochs(epochs=epochs, title='my epochs', tags=('epochs',), psd=False,


### PR DESCRIPTION
The parameter `butterfly` allows users to specify how many 1-second segments to display as butterfly plots. We keep the previous default number (10 segments).

Performance implications:
@agramfort and I were struggling with the long run time on `main`, so I decided to reduce the number of plotted segments to 50% for our specific use case.

```
10 segments: 12.1 s ± 761 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
 5 segments: 6.29 s ± 132 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
MWE:
```python
# %%
from pathlib import Path
import mne


sample_dir = Path(mne.datasets.sample.data_path())
sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'

raw = mne.io.read_raw_fif(sample_fname, preload=True)
raw.crop(tmax=60)
r = mne.Report()

# %%
%timeit r.add_raw(raw=raw, title='foo', butterfly=10)

# %%
%timeit r.add_raw(raw=raw, title='foo', butterfly=5)
```

x-ref #10107