### PR TITLE
MRG: In Report.add_raw(), re-use the existing figure when creating butterfly plots of slices

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -56,7 +56,7 @@ Enhancements
 
 - :meth:`mne.Report.add_raw` gained a new ``scalings`` parameter to provide custom data scalings for the butterfly plots (:gh:`10109` by `Richard Höchenberger`_)
 
-- Drastically speed up butterfly plot generation in :meth:`mne.Report.add_raw`. We now don't plot annotations anymore; however, we feel that the speed improvements justify this change, also considering the annotations were of limited use in the displayed one-second time slices anyway (:gh:`10114` by `Richard Höchenberger`_)
+- Drastically speed up butterfly plot generation in :meth:`mne.Report.add_raw`. We now don't plot annotations anymore; however, we feel that the speed improvements justify this change, also considering the annotations were of limited use in the displayed one-second time slices anyway (:gh:`10114`, :gh:`10116` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -2576,6 +2576,7 @@ class Report(object):
                 fig.mne.t_start = start
                 fig.mne.duration = duration
                 fig._update_hscroll()
+                fig._redraw(annotations=False)
                 figs.append(fig)
         except Exception:
             raise

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -12,7 +12,7 @@ plots of data before and after each preprocessing step, epoch rejection
 statistics, MRI slices with overlaid BEM shells, all the way up to plots of
 estimated cortical activity.
 
-Compared to a Jupyter notebook, `mne.Report` is easier to deploy (the HTML
+Compared to a Jupyter notebook, `mne.Report` is easier to deploy (the HTMLf
 pages it generates are self-contained and do not require a running Python
 environment) but less flexible (you can't change code and re-run something
 directly within the browser). This tutorial covers the basics of building a
@@ -81,8 +81,8 @@ subjects_dir = data_path / 'subjects'
 # equally-spaced 1-second segments of the data:
 #
 # .. warning::
-#    In the following example, we crop the raw data and crop to 60 seconds
-#    just to speed up processing, this is not usually recommended!
+#    In the following example, we crop the raw data to 60 seconds just to speed
+#    up processing, this is not usually recommended!
 
 raw_path = sample_dir / 'sample_audvis_filt-0-40_raw.fif'
 raw = mne.io.read_raw(raw_path)


### PR DESCRIPTION
Performance changes **EDIT I've updated the numbers after adding dde9732**

```
main: 12.3 s ± 294 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
pr:   6.98 s ± 429 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Because we're re-using the same figure, I could also get rid of the explicit `scalings` pre-calculation.


MWE:
```python
# %%
from pathlib import Path
import mne


sample_dir = Path(mne.datasets.sample.data_path())
sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'

raw = mne.io.read_raw_fif(sample_fname, preload=True)
raw.crop(tmax=60)
r = mne.Report()

# %%
%timeit r.add_raw(raw=raw, title='foo')
```

x-ref #10107
