### PR TITLE
BUG: Time alignments between RAW and annotate_* funcs

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -101,7 +101,7 @@ Bugs
 
 - Fix channel grouping error when using "butterfly mode" with :meth:`mne.io.Raw.plot` (:gh:`10087` by `Daniel McCloy`_)
 
-- Fix inconsistent behavior of ``mne.preprocessing.annotate_*`` functions by making them all return :class:`mne.Annotations` objects with the ``orig_time`` attribute set to ``raw.info["meas_time"]`` (:gh:`10067` by `Stefan Appelhoff`_)
+- Fix inconsistent behavior of ``mne.preprocessing.annotate_*`` functions by making them all return :class:`mne.Annotations` objects with the ``orig_time`` attribute set to ``raw.info["meas_time"]`` (:gh:`10067` and :gh:`10118` by `Stefan Appelhoff`_, `Eric Larson`_, and `Alex Gramfort`_)
 
 - Fix bug that appears during automatic calculation of the colormap of `mne.viz.Brain` when data values of ``fmin`` and ``fmax`` are too close (:gh:`10074` by `Guillaume Favelier`_)
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1344,3 +1344,11 @@ def annotations_from_events(events, sfreq, event_desc=None, first_samp=0,
                          orig_time=orig_time)
 
     return annots
+
+
+def _adjust_onset_meas_date(annot, raw):
+    """Adjust the annotation onsets based on raw meas_date."""
+    # If there is a non-None meas date, then the onset should take into
+    # account the first_samp / first_time.
+    if raw.info['meas_date'] is not None:
+        annot.onset += raw.first_time

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -578,7 +578,10 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
     @property
     def first_samp(self):
-        """The first data sample."""
+        """The first data sample.
+
+        See :term:`first_samp`.
+        """
         return self._first_samps[0]
 
     @property

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -202,7 +202,7 @@ def test_nirsport_v1_w_sat():
 @pytest.mark.filterwarnings('ignore:.*Extraction of measurement.*:')
 @requires_testing_data
 @pytest.mark.parametrize('preload', (True, False))
-@pytest.mark.parametrize('meas_date', (None, "raw"))
+@pytest.mark.parametrize('meas_date', (None, "misct"))
 def test_nirsport_v1_w_bad_sat(preload, meas_date):
     """Test NIRSport1 file with NaNs."""
     fname = nirsport1_w_fullsat
@@ -221,7 +221,7 @@ def test_nirsport_v1_w_bad_sat(preload, meas_date):
     assert np.isnan(data_nan).any()
     assert not np.allclose(raw_nan.get_data(), data)
     raw_nan_annot = raw_ignore.copy()
-    if meas_date != "raw":
+    if meas_date is None:
         raw.set_meas_date(None)
         raw_nan.set_meas_date(None)
         raw_nan_annot.set_meas_date(None)

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -202,7 +202,7 @@ def test_nirsport_v1_w_sat():
 @pytest.mark.filterwarnings('ignore:.*Extraction of measurement.*:')
 @requires_testing_data
 @pytest.mark.parametrize('preload', (True, False))
-@pytest.mark.parametrize('meas_date', (None, "misct"))
+@pytest.mark.parametrize('meas_date', (None, "orig"))
 def test_nirsport_v1_w_bad_sat(preload, meas_date):
     """Test NIRSport1 file with NaNs."""
     fname = nirsport1_w_fullsat

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -202,7 +202,8 @@ def test_nirsport_v1_w_sat():
 @pytest.mark.filterwarnings('ignore:.*Extraction of measurement.*:')
 @requires_testing_data
 @pytest.mark.parametrize('preload', (True, False))
-def test_nirsport_v1_w_bad_sat(preload):
+@pytest.mark.parametrize('meas_date', (None, "raw"))
+def test_nirsport_v1_w_bad_sat(preload, meas_date):
     """Test NIRSport1 file with NaNs."""
     fname = nirsport1_w_fullsat
     raw = read_raw_nirx(fname, preload=preload)
@@ -220,6 +221,10 @@ def test_nirsport_v1_w_bad_sat(preload):
     assert np.isnan(data_nan).any()
     assert not np.allclose(raw_nan.get_data(), data)
     raw_nan_annot = raw_ignore.copy()
+    if meas_date != "raw":
+        raw.set_meas_date(None)
+        raw_nan.set_meas_date(None)
+        raw_nan_annot.set_meas_date(None)
     nan_annots = annotate_nan(raw_nan)
     assert nan_annots.orig_time == raw_nan.info["meas_date"]
     raw_nan_annot.set_annotations(nan_annots)

--- a/mne/preprocessing/annotate_nan.py
+++ b/mne/preprocessing/annotate_nan.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 
-from ..annotations import Annotations
+from ..annotations import Annotations, _adjust_onset_meas_date
 from ..utils import verbose
 from .artifact_detection import _annotations_from_mask
 
@@ -26,13 +26,12 @@ def annotate_nan(raw, *, verbose=None):
     """
     data, times = raw.get_data(return_times=True)
     onsets, durations, ch_names = list(), list(), list()
-    first_time = raw.first_time if raw.info["meas_date"] else 0
     for row, ch_name in zip(data, raw.ch_names):
-        annot = _annotations_from_mask(
-            times + first_time, np.isnan(row), 'BAD_NAN')
+        annot = _annotations_from_mask(times, np.isnan(row), 'BAD_NAN')
         onsets.extend(annot.onset)
         durations.extend(annot.duration)
         ch_names.extend([[ch_name]] * len(annot))
     annot = Annotations(onsets, durations, 'BAD_NAN', ch_names=ch_names,
                         orig_time=raw.info['meas_date'])
+    _adjust_onset_meas_date(annot, raw)
     return annot

--- a/mne/preprocessing/annotate_nan.py
+++ b/mne/preprocessing/annotate_nan.py
@@ -26,8 +26,10 @@ def annotate_nan(raw, *, verbose=None):
     """
     data, times = raw.get_data(return_times=True)
     onsets, durations, ch_names = list(), list(), list()
+    first_time = raw.first_time if raw.info["meas_date"] else 0
     for row, ch_name in zip(data, raw.ch_names):
-        annot = _annotations_from_mask(times, np.isnan(row), 'BAD_NAN')
+        annot = _annotations_from_mask(
+            times + first_time, np.isnan(row), 'BAD_NAN')
         onsets.extend(annot.onset)
         durations.extend(annot.duration)
         ch_names.extend([[ch_name]] * len(annot))

--- a/mne/preprocessing/artifact_detection.py
+++ b/mne/preprocessing/artifact_detection.py
@@ -463,11 +463,6 @@ def annotate_break(raw, events=None,
             logger.info(f'Ignoring annotations with descriptions starting '
                         f'with: {", ".join(ignore)}')
     else:
-        # XXX: I think a bug is hiding here with regard to first_samp
-        #      We should extend the test to work on events and see if
-        #      it breaks here.
-        #      "annotations_from_events" takes a "first_samp" param,
-        #      but this is not being passed here!
         annotations = annotations_from_events(
             events=events,
             sfreq=raw.info['sfreq'],

--- a/mne/preprocessing/artifact_detection.py
+++ b/mne/preprocessing/artifact_detection.py
@@ -575,4 +575,9 @@ def annotate_break(raw, events=None,
                 f'data ({round(total_break_dur, 1):.1f} sec) have been marked '
                 f'as a break.\n')
 
+    if raw.info["meas_date"] is None:
+        # If there is no meas date then the onset should not take into
+        # account the first_samp / first_time.
+        break_annotations.onset -= raw.first_time
+
     return break_annotations

--- a/mne/preprocessing/artifact_detection.py
+++ b/mne/preprocessing/artifact_detection.py
@@ -116,7 +116,8 @@ def annotate_muscle_zscore(raw, threshold=4, ch_type=None, min_length_good=0.1,
         if len(l_idx) < min_samps:
             art_mask[l_idx] = True
 
-    annot = _annotations_from_mask(raw_copy.times, art_mask, 'BAD_muscle',
+    annot = _annotations_from_mask(raw_copy.times + raw.first_time,
+                                   art_mask, 'BAD_muscle',
                                    orig_time=raw.info['meas_date'])
 
     return annot, scores_muscle
@@ -166,7 +167,7 @@ def annotate_movement(raw, pos, rotation_velocity_limit=None,
     hp_ts = pos[:, 0].copy()
     orig_time = raw.info['meas_date']
     if orig_time is None:
-        hp_ts -= raw.first_samp / sfreq
+        hp_ts -= raw.first_time
     dt = np.diff(hp_ts)
     hp_ts = np.concatenate([hp_ts, [hp_ts[-1] + 1. / sfreq]])
 

--- a/mne/preprocessing/artifact_detection.py
+++ b/mne/preprocessing/artifact_detection.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from ..io.base import BaseRaw
 from ..annotations import (Annotations, _annotations_starts_stops,
-                           annotations_from_events)
+                           annotations_from_events, _adjust_onset_meas_date)
 from ..transforms import (quat_to_rot, _average_quats, _angle_between_quats,
                           apply_trans, _quat_to_affine)
 from ..filter import filter_data
@@ -116,10 +116,10 @@ def annotate_muscle_zscore(raw, threshold=4, ch_type=None, min_length_good=0.1,
         if len(l_idx) < min_samps:
             art_mask[l_idx] = True
 
-    annot = _annotations_from_mask(raw_copy.times + raw.first_time,
+    annot = _annotations_from_mask(raw_copy.times,
                                    art_mask, 'BAD_muscle',
                                    orig_time=raw.info['meas_date'])
-
+    _adjust_onset_meas_date(annot, raw)
     return annot, scores_muscle
 
 
@@ -164,13 +164,10 @@ def annotate_movement(raw, pos, rotation_velocity_limit=None,
     compute_average_dev_head_t
     """
     sfreq = raw.info['sfreq']
-    hp_ts = pos[:, 0].copy()
-    orig_time = raw.info['meas_date']
-    if orig_time is None:
-        hp_ts -= raw.first_time
+    hp_ts = pos[:, 0].copy() - raw.first_time
     dt = np.diff(hp_ts)
     hp_ts = np.concatenate([hp_ts, [hp_ts[-1] + 1. / sfreq]])
-
+    orig_time = raw.info['meas_date']
     annot = Annotations([], [], [], orig_time=orig_time)
 
     # Annotate based on rotational velocity
@@ -250,6 +247,7 @@ def annotate_movement(raw, pos, rotation_velocity_limit=None,
                     % (bad_pct, len(onsets), mean_distance_limit, disp.max()))
         annot += _annotations_from_mask(
             hp_ts, bad_mask, 'BAD_mov_dist', orig_time=orig_time)
+    _adjust_onset_meas_date(annot, raw)
     return annot, disp
 
 
@@ -508,15 +506,16 @@ def annotate_break(raw, events=None,
             merged_intervals.append(interval)
 
     merged_intervals = np.array(merged_intervals)
+    merged_intervals -= raw.first_time  # work in zero-based time
 
     # Now extract the actual break periods
     break_onsets = []
     break_durations = []
 
     # Handle the time period up until the first annotation
-    if (raw.first_time < merged_intervals[0][0] and
-            merged_intervals[0][0] - raw.first_time >= min_break_duration):
-        onset = raw.first_time  # don't add t_start_after_previous here
+    if (0 < merged_intervals[0][0] and
+            merged_intervals[0][0] >= min_break_duration):
+        onset = 0  # don't add t_start_after_previous here
         offset = merged_intervals[0][0] - t_stop_before_next
         duration = offset - onset
         break_onsets.append(onset)
@@ -536,10 +535,10 @@ def annotate_break(raw, events=None,
         break_durations.append(duration)
 
     # Handle the time period after the last annotation
-    if (raw._last_time > merged_intervals[-1][1] and
-            raw._last_time - merged_intervals[-1][1] >= min_break_duration):
+    if (raw.times[-1] > merged_intervals[-1][1] and
+            raw.times[-1] - merged_intervals[-1][1] >= min_break_duration):
         onset = merged_intervals[-1][1] + t_start_after_previous
-        offset = raw._last_time  # don't subtract t_stop_before_next here
+        offset = raw.times[-1]  # don't subtract t_stop_before_next here
         duration = offset - onset
         break_onsets.append(onset)
         break_durations.append(duration)
@@ -555,9 +554,7 @@ def annotate_break(raw, events=None,
     # Log some info
     n_breaks = len(break_annotations)
     break_times = [
-        f'{round(o - raw.first_time, 1):.1f} – '
-        f'{round(o+d - raw.first_time, 1):.1f} sec '
-        f'[{round(d, 1):.1f} sec]'
+        f'{o:.1f} – {o+d:.1f} sec [{d:.1f} sec]'
         for o, d in zip(break_annotations.onset,
                         break_annotations.duration)
     ]
@@ -569,10 +566,6 @@ def annotate_break(raw, events=None,
                 f'In total, {round(100 * fraction_breaks, 1):.1f}% of the '
                 f'data ({round(total_break_dur, 1):.1f} sec) have been marked '
                 f'as a break.\n')
-
-    if raw.info["meas_date"] is None:
-        # If there is no meas date then the onset should not take into
-        # account the first_samp / first_time.
-        break_annotations.onset -= raw.first_time
+    _adjust_onset_meas_date(break_annotations, raw)
 
     return break_annotations

--- a/mne/preprocessing/artifact_detection.py
+++ b/mne/preprocessing/artifact_detection.py
@@ -463,6 +463,11 @@ def annotate_break(raw, events=None,
             logger.info(f'Ignoring annotations with descriptions starting '
                         f'with: {", ".join(ignore)}')
     else:
+        # XXX: I think a bug is hiding here with regard to first_samp
+        #      We should extend the test to work on events and see if
+        #      it breaks here.
+        #      "annotations_from_events" takes a "first_samp" param,
+        #      but this is not being passed here!
         annotations = annotations_from_events(
             events=events,
             sfreq=raw.info['sfreq'],

--- a/mne/preprocessing/flat.py
+++ b/mne/preprocessing/flat.py
@@ -4,7 +4,8 @@
 
 import numpy as np
 
-from ..annotations import _annotations_starts_stops, Annotations
+from ..annotations import (_annotations_starts_stops, Annotations,
+                           _adjust_onset_meas_date)
 from ..io import BaseRaw
 from ..io.pick import _picks_to_idx
 from ..utils import (_validate_type, verbose, logger, _pl,
@@ -98,11 +99,9 @@ def annotate_flat(raw, bad_percent=5., min_duration=0.005, picks=None,
                    (': %s' % (bads,)) if bads else ''))
     bads = [bad for bad in bads if bad not in raw.info['bads']]
     starts, stops = np.array(starts), np.array(stops)
-    if raw.info['meas_date'] is not None:
-        onsets = (starts + raw.first_samp) / raw.info['sfreq']
-    else:
-        onsets = starts / raw.info['sfreq']
+    onsets = starts / raw.info['sfreq']
     durations = (stops - starts) / raw.info['sfreq']
     annot = Annotations(onsets, durations, ['BAD_flat'] * len(onsets),
                         orig_time=raw.info['meas_date'])
+    _adjust_onset_meas_date(annot, raw)
     return annot, bads

--- a/mne/preprocessing/flat.py
+++ b/mne/preprocessing/flat.py
@@ -98,7 +98,10 @@ def annotate_flat(raw, bad_percent=5., min_duration=0.005, picks=None,
                    (': %s' % (bads,)) if bads else ''))
     bads = [bad for bad in bads if bad not in raw.info['bads']]
     starts, stops = np.array(starts), np.array(stops)
-    onsets = (starts + raw.first_samp) / raw.info['sfreq']
+    if raw.info['meas_date'] is not None:
+        onsets = (starts + raw.first_samp) / raw.info['sfreq']
+    else:
+        onsets = starts / raw.info['sfreq']
     durations = (stops - starts) / raw.info['sfreq']
     annot = Annotations(onsets, durations, ['BAD_flat'] * len(onsets),
                         orig_time=raw.info['meas_date'])

--- a/mne/preprocessing/tests/test_annotate_nan.py
+++ b/mne/preprocessing/tests/test_annotate_nan.py
@@ -1,0 +1,49 @@
+# Author: Stefan Appelhoff <stefan.appelhoff@mailbox.org>
+#
+# License: BSD-3-Clause
+
+import os.path as op
+
+import numpy as np
+from numpy.testing import assert_array_equal
+import pytest
+
+import mne
+from mne.preprocessing import annotate_nan
+
+
+base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
+raw_fname = op.join(base_dir, 'test_raw.fif')
+
+@pytest.mark.parametrize('meas_date', (None, 'orig'))
+def test_annotate_nan(meas_date):
+    """Tests automatic NaN annotation generation."""
+    # Load data
+    raw = mne.io.read_raw_fif(raw_fname)
+    sfreq = 100
+    raw.resample(sfreq)
+    if meas_date is None:
+        raw.set_meas_date(None)
+
+    # No Nans, annotate returns empty annots
+    assert not np.isnan(raw._data).any()
+    annot_nan = annotate_nan(raw)
+    assert len(annot_nan) == 0
+
+    # but orig_time should be meas_date
+    assert annot_nan.orig_time == raw.info["meas_date"]
+
+    # insert block of NaN from 1s to 3s for one channel
+    nan_ch_idx = 0
+    raw._data[nan_ch_idx, 1*sfreq:3*sfreq] = np.nan
+
+    # annotate_nan accurately finds this
+    annot_nan = annotate_nan(raw)
+    assert_array_equal(annot_nan.onset, np.array([1]))
+    assert_array_equal(annot_nan.duration, np.array([2]))
+    assert_array_equal(annot_nan.description, np.array(['BAD_NAN']))
+    assert annot_nan.ch_names[0] == (raw.ch_names[nan_ch_idx],)
+
+    # Set the NaN annotations to the raw object
+    raw.set_annotations(annot_nan)
+

--- a/mne/preprocessing/tests/test_annotate_nan.py
+++ b/mne/preprocessing/tests/test_annotate_nan.py
@@ -15,6 +15,7 @@ from mne.preprocessing import annotate_nan
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
 
+
 @pytest.mark.parametrize('meas_date', (None, 'orig'))
 def test_annotate_nan(meas_date):
     """Tests automatic NaN annotation generation."""
@@ -35,15 +36,15 @@ def test_annotate_nan(meas_date):
 
     # insert block of NaN from 1s to 3s for one channel
     nan_ch_idx = 0
-    raw._data[nan_ch_idx, 1*sfreq:3*sfreq] = np.nan
+    raw._data[nan_ch_idx, 1 * sfreq:3 * sfreq] = np.nan
 
     # annotate_nan accurately finds this
     annot_nan = annotate_nan(raw)
     assert_array_equal(annot_nan.onset, np.array([1]))
     assert_array_equal(annot_nan.duration, np.array([2]))
     assert_array_equal(annot_nan.description, np.array(['BAD_NAN']))
+    assert len(annot_nan.ch_names) == 1
     assert annot_nan.ch_names[0] == (raw.ch_names[nan_ch_idx],)
 
     # Set the NaN annotations to the raw object
     raw.set_annotations(annot_nan)
-

--- a/mne/preprocessing/tests/test_annotate_nan.py
+++ b/mne/preprocessing/tests/test_annotate_nan.py
@@ -40,7 +40,10 @@ def test_annotate_nan(meas_date):
 
     # annotate_nan accurately finds this
     annot_nan = annotate_nan(raw)
-    assert_array_equal(annot_nan.onset, np.array([1]))
+    onset = np.array([1.])
+    if raw.info["meas_date"]:
+        onset += raw.first_time
+    assert_array_equal(annot_nan.onset, onset)
     assert_array_equal(annot_nan.duration, np.array([2]))
     assert_array_equal(annot_nan.description, np.array(['BAD_NAN']))
     assert len(annot_nan.ch_names) == 1

--- a/mne/preprocessing/tests/test_artifact_detection.py
+++ b/mne/preprocessing/tests/test_artifact_detection.py
@@ -84,7 +84,7 @@ def test_muscle_annotation():
     annot_muscle, scores = annotate_muscle_zscore(raw, ch_type='mag',
                                                   threshold=10)
     assert annot_muscle.orig_time == raw.info["meas_date"]
-    onset = annot_muscle.onset * raw.info['sfreq']
+    onset = annot_muscle.onset * raw.info['sfreq'] - raw.first_samp
     onset = onset.astype(int)
     assert_array_equal(scores[onset].astype(int), np.array([23, 10]))
     assert annot_muscle.duration.size == 2
@@ -101,18 +101,21 @@ def test_muscle_annotation_without_meeg_data():
         annotate_muscle_zscore(raw, threshold=10)
 
 
-@pytest.mark.parametrize('meas_date', (None, "raw"))
+@pytest.mark.parametrize('meas_date', (None, "misc"))
 @testing.requires_testing_data
 def test_annotate_breaks(meas_date):
     """Test annotate_breaks."""
     raw = read_raw_fif(raw_fname, allow_maxshield='yes')
-    if meas_date != "raw":
+    if meas_date is None:
         raw.set_meas_date(None)
 
     annots = Annotations(onset=[12, 15, 16, 20, 21],
                          duration=[1, 1, 1, 2, 0.5],
                          description=['test'],
                          orig_time=raw.info['meas_date'])
+
+    if raw.info['meas_date'] is None:
+        annots.onset -= raw.first_time
 
     raw.set_annotations(annots)
 

--- a/mne/preprocessing/tests/test_artifact_detection.py
+++ b/mne/preprocessing/tests/test_artifact_detection.py
@@ -132,6 +132,9 @@ def test_annotate_breaks(meas_date):
         ]
     )
 
+    if raw.info['meas_date'] is None:
+        expected_onsets -= raw.first_time
+
     expected_durations = np.array(
         [
             12 - raw.first_time - t_stop_before_next,
@@ -156,7 +159,10 @@ def test_annotate_breaks(meas_date):
 
     # try setting the annotations, this should not omit anything
     raw.set_annotations(break_annots)
-    raw.set_annotations(raw.annotations + break_annots)
+    current_annotations = raw.annotations
+    if raw.info['meas_date'] is None:
+        current_annotations.onset -= raw.first_time
+    raw.set_annotations(current_annotations + break_annots)
 
     # reset before next test
     raw.set_annotations(annots)
@@ -180,7 +186,10 @@ def test_annotate_breaks(meas_date):
 
     # try setting the annotations, this should not omit anything
     raw.set_annotations(break_annots)
-    raw.set_annotations(raw.annotations + break_annots)
+    current_annotations = raw.annotations
+    if raw.info['meas_date'] is None:
+        current_annotations.onset -= raw.first_time
+    raw.set_annotations(current_annotations + break_annots)
 
     # Restore annotations for next test
     raw.set_annotations(annots)
@@ -220,12 +229,18 @@ def test_annotate_breaks(meas_date):
         t_stop_before_next=t_stop_before_next
     )
 
+    if raw.info['meas_date'] is None:
+        expected_onsets -= raw.first_time
+
     assert_allclose(break_annots.onset, expected_onsets)
     assert_allclose(break_annots.duration, expected_durations)
 
     # try setting the annotations, this should not omit anything
     raw.set_annotations(break_annots)
-    raw.set_annotations(raw.annotations + break_annots)
+    current_annotations = raw.annotations
+    if raw.info['meas_date'] is None:
+        current_annotations.onset -= raw.first_time
+    raw.set_annotations(current_annotations + break_annots)
 
     # reset before next test
     raw.set_annotations(annots)

--- a/mne/preprocessing/tests/test_artifact_detection.py
+++ b/mne/preprocessing/tests/test_artifact_detection.py
@@ -101,10 +101,14 @@ def test_muscle_annotation_without_meeg_data():
         annotate_muscle_zscore(raw, threshold=10)
 
 
+@pytest.mark.parametrize('meas_date', (None, "raw"))
 @testing.requires_testing_data
-def test_annotate_breaks():
+def test_annotate_breaks(meas_date):
     """Test annotate_breaks."""
     raw = read_raw_fif(raw_fname, allow_maxshield='yes')
+    if meas_date != "raw":
+        raw.set_meas_date(None)
+
     annots = Annotations(onset=[12, 15, 16, 20, 21],
                          duration=[1, 1, 1, 2, 0.5],
                          description=['test'],

--- a/mne/preprocessing/tests/test_artifact_detection.py
+++ b/mne/preprocessing/tests/test_artifact_detection.py
@@ -88,6 +88,7 @@ def test_muscle_annotation():
     onset = onset.astype(int)
     assert_array_equal(scores[onset].astype(int), np.array([23, 10]))
     assert annot_muscle.duration.size == 2
+    raw.set_annotations(annot_muscle)
 
 
 @testing.requires_testing_data

--- a/mne/preprocessing/tests/test_artifact_detection.py
+++ b/mne/preprocessing/tests/test_artifact_detection.py
@@ -101,7 +101,7 @@ def test_muscle_annotation_without_meeg_data():
         annotate_muscle_zscore(raw, threshold=10)
 
 
-@pytest.mark.parametrize('meas_date', (None, "misc"))
+@pytest.mark.parametrize('meas_date', (None, "orig"))
 @testing.requires_testing_data
 def test_annotate_breaks(meas_date):
     """Test annotate_breaks."""

--- a/mne/preprocessing/tests/test_artifact_detection.py
+++ b/mne/preprocessing/tests/test_artifact_detection.py
@@ -154,6 +154,13 @@ def test_annotate_breaks(meas_date):
     assert all(description == 'BAD_break'
                for description in break_annots.description)
 
+    # try setting the annotations, this should not omit anything
+    raw.set_annotations(break_annots)
+    raw.set_annotations(raw.annotations + break_annots)
+
+    # reset before next test
+    raw.set_annotations(annots)
+
     # `ignore` parameter should be respected
     raw.annotations.description[0] = 'BAD_'
     break_annots = annotate_break(
@@ -171,7 +178,12 @@ def test_annotate_breaks(meas_date):
         list(expected_durations[2:])
     )
 
-    # Restore annotation description
+    # try setting the annotations, this should not omit anything
+    raw.set_annotations(break_annots)
+    raw.set_annotations(raw.annotations + break_annots)
+
+    # Restore annotations for next test
+    raw.set_annotations(annots)
     raw.annotations.description[0] = 'test'
 
     # Test with events
@@ -210,6 +222,13 @@ def test_annotate_breaks(meas_date):
 
     assert_allclose(break_annots.onset, expected_onsets)
     assert_allclose(break_annots.duration, expected_durations)
+
+    # try setting the annotations, this should not omit anything
+    raw.set_annotations(break_annots)
+    raw.set_annotations(raw.annotations + break_annots)
+
+    # reset before next test
+    raw.set_annotations(annots)
 
     # Not finding any break periods
     break_annots = annotate_break(

--- a/mne/preprocessing/tests/test_flat.py
+++ b/mne/preprocessing/tests/test_flat.py
@@ -2,6 +2,7 @@
 #
 # License: BSD-3-Clause
 
+import datetime
 import os.path as op
 import numpy as np
 import pytest
@@ -13,21 +14,23 @@ from mne.preprocessing import annotate_flat
 
 data_path = testing.data_path(download=False)
 skip_fname = op.join(data_path, 'misc', 'intervalrecording_raw.fif')
+date = datetime.datetime(2021, 12, 10, 7, 52, 24, 405305,
+                         tzinfo=datetime.timezone.utc)
 
 
+@pytest.mark.parametrize('meas_date', (None, date))
 @pytest.mark.parametrize('first_samp', (0, 10000))
-def test_annotate_flat(first_samp):
+def test_annotate_flat(meas_date, first_samp):
     """Test marking flat segments."""
     # Test if ECG analysis will work on data that is not preloaded
     n_ch, n_times = 11, 1000
     data = np.random.RandomState(0).randn(n_ch, n_times)
     assert not (np.diff(data, axis=-1) == 0).any()  # nothing flat at first
     info = create_info(n_ch, 1000., 'eeg')
-    with info._unlock():
-        info['meas_date'] = (1, 2)
     # test first_samp != for gh-6295
     raw = RawArray(data, info, first_samp=first_samp)
     raw.info['bads'] = [raw.ch_names[-1]]
+    raw.set_meas_date(meas_date)
 
     #
     # First make a channel flat the whole time

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1247,27 +1247,31 @@ def test_mf_skips():
 @testing.requires_testing_data
 @pytest.mark.parametrize(
     ('fname', 'bads', 'annot', 'add_ch', 'ignore_ref', 'want_bads',
-     'return_scores', 'h_freq'), [
+     'return_scores', 'h_freq', 'meas_date'), [
         # Neuromag data tested against MF
-        (sample_fname, [], False, False, False, ['MEG 2443'], False, None),
+        (sample_fname, [], False, False, False, ['MEG 2443'], False, None,
+         'raw'),
         # add 0111 to test picking, add annot to test it, and prepend chs for
         # idx
         (sample_fname, ['MEG 0111'], True, True, False, ['MEG 2443'], False,
-         None),
+         None, 'raw'),
         # CTF data seems to be sensitive to linalg lib (?) because some
         # channels are very close to the limit, so we just check that one shows
         # up
         (ctf_fname_continuous, [], False, False, False, {'BR1-4304'}, False,
-         None),
+         None, 'raw'),
         # faked
         (ctf_fname_continuous, [], False, False, True, ['MLC24-4304'], False,
-         None),
+         None, 'raw'),
         # For `return_scores=True`
         (sample_fname, ['MEG 0111'], True, True, False, ['MEG 2443'], True,
-         50)
+         50, 'raw'),
+        (sample_fname, ['MEG 0111'], True, True, False, ['MEG 2443'], True,
+         50, None),
     ])
 def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
-                                   want_bads, return_scores, h_freq):
+                                   want_bads, return_scores, h_freq,
+                                   meas_date):
     """Test automatic bad channel detection."""
     if fname.endswith('.ds'):
         raw = read_raw_ctf(fname).load_data()
@@ -1276,6 +1280,10 @@ def test_find_bad_channels_maxwell(fname, bads, annot, add_ch, ignore_ref,
         raw = read_raw_fif(fname)
         raw.fix_mag_coil_types().load_data().pick_types(meg=True, exclude=())
         flat_idx = 1
+    if meas_date is None:
+        raw.set_meas_date(None)
+    else:
+        assert meas_date == 'raw'
     raw.filter(None, 40)
     raw.info['bads'] = bads
     raw._data[flat_idx] = 0  # MaxFilter didn't have this but doesn't affect it


### PR DESCRIPTION
intended to fix the failures from https://github.com/mne-tools/mne-python/pull/10067#issuecomment-989791374

The first commit adds a line to a test, which should run ... but which will make the test fail.

The failures most likely have to do with some weird interaction between `raw._first_time` / `raw.first_samp` and the `annotations.orig_time`.

https://dev.azure.com/mne-tools/mne-python/_build/results?buildId=17167&view=logs&j=dded70eb-633c-5c42-e995-a7f8d1f99d91&t=8394206f-a00b-5cb7-44ca-464c9d5f9e25&l=3010


I don't know yet how it could be solved, help would be appreciated.