### PR TITLE
MRG: Make psd param of Report.add_epochs() accept floats as durations

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -56,6 +56,8 @@ Enhancements
 
 - :meth:`mne.Report.add_raw` gained a new ``scalings`` parameter to provide custom data scalings for the butterfly plots (:gh:`10109` by `Richard Höchenberger`_)
 
+- :meth:`mne.Report.add_epochs` gained a new ``psd_signal_duration`` parameter to limit the amount of data used for PSD calculation (:gh:`10119` by `Richard Höchenberger`_)
+
 - Drastically speed up butterfly plot generation in :meth:`mne.Report.add_raw`. We now don't plot annotations anymore; however, we feel that the speed improvements justify this change, also considering the annotations were of limited use in the displayed one-second time slices anyway (:gh:`10114` by `Richard Höchenberger`_)
 
 Bugs

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -56,7 +56,7 @@ Enhancements
 
 - :meth:`mne.Report.add_raw` gained a new ``scalings`` parameter to provide custom data scalings for the butterfly plots (:gh:`10109` by `Richard Höchenberger`_)
 
-- :meth:`mne.Report.add_epochs` gained a new ``psd_signal_duration`` parameter to limit the amount of data used for PSD calculation (:gh:`10119` by `Richard Höchenberger`_)
+- The ``psd`` parameter of :meth:`mne.Report.add_epochs` now also accepts numbers to specify the signal duration used for PSD calculation (:gh:`10119` by `Richard Höchenberger`_)
 
 - Drastically speed up butterfly plot generation in :meth:`mne.Report.add_raw`. We now don't plot annotations anymore; however, we feel that the speed improvements justify this change, also considering the annotations were of limited use in the displayed one-second time slices anyway (:gh:`10114`, :gh:`10116` by `Richard Höchenberger`_)
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -839,8 +839,7 @@ class Report(object):
             If a float, the duration of data to use for creation of PSD plots,
             in seconds. PSD will be calculated on as many epochs as required to
             cover at least this duration. Epochs will be picked across the
-            entire time range in equally-spaced distance. If ``None``, use all
-            epochs.
+            entire time range in equally-spaced distance.
 
             .. note::
               In rare edge cases, we may not be able to create a grid of

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -3180,10 +3180,10 @@ class Report(object):
             else:  # Only a subset of epochs
                 epoch_duration = epochs.tmax - epochs.tmin
                 signal_duration = len(epochs) * epoch_duration
-                num_of_epochs_required = int(
+                n_epochs_required = int(
                     np.ceil(psd_signal_duration / epoch_duration)
                 )
-                if num_of_epochs_required > len(epochs):
+                if n_epochs_required > len(epochs):
                     raise ValueError(
                         f'You requested to calculate PSD on a duration of '
                         f'{psd_signal_duration:.3f} sec, but all your epochs '
@@ -3192,11 +3192,11 @@ class Report(object):
                 epochs_idx = np.arange(
                     start=0,
                     stop=len(epochs),
-                    step=len(epochs) // num_of_epochs_required
+                    step=len(epochs) // n_epochs_required
                 )
                 # We may have more epochs than necessary due to the floor();
                 # simply drop the last few ones in this case
-                epochs_idx = epochs_idx[:num_of_epochs_required]
+                epochs_idx = epochs_idx[:n_epochs_required]
                 epochs_for_psd = epochs[epochs_idx]
 
             dom_id = self._get_dom_id()

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -849,7 +849,6 @@ class Report(object):
               equally-spaced epochs that cover the entire requested time range.
               In these situations, a warning will be emitted, informing you
               about the duration that's actually being used.
-
         %(report_projs)s
         %(report_tags)s
         %(report_replace)s

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -3192,17 +3192,18 @@ class Report(object):
                     f'are only {signal_duration:.3f} sec long'
                 )
 
-            epochs_idx = np.arange(
-                start=0,
-                stop=len(epochs),
-                step=int(np.floor(len(epochs) / num_of_epochs_required))
-            )
-            # We may have more epochs than necessary due to the floor(); simply
-            # drop the last few ones in this case
-            epochs_idx = epochs_idx[:num_of_epochs_required]
-
             if psd_signal_duration is None:
-                assert len(epochs_idx) == len(epochs)
+                epochs_for_psd = epochs  # Avoid creating a copy
+            else:
+                epochs_idx = np.arange(
+                    start=0,
+                    stop=len(epochs),
+                    step=int(np.floor(len(epochs) / num_of_epochs_required))
+                )
+                # We may have more epochs than necessary due to the floor();
+                # simply drop the last few ones in this case
+                epochs_idx = epochs_idx[:num_of_epochs_required]
+                epochs_for_psd = epochs[epochs_idx]
 
             dom_id = self._get_dom_id()
             if epochs.info['lowpass'] is not None:
@@ -3213,13 +3214,14 @@ class Report(object):
             else:
                 fmax = np.inf
 
-            fig = epochs[epochs_idx].plot_psd(fmax=fmax, show=False)
+            fig = epochs_for_psd.plot_psd(fmax=fmax, show=False)
             img = _fig_to_img(fig=fig, image_format=image_format)
             psd_img_html = _html_image_element(
                 img=img, id=dom_id, div_klass='epochs', img_klass='epochs',
                 show=True, image_format=image_format, title='PSD',
                 caption=None, tags=tags
             )
+            del epochs_for_psd
         else:
             psd_img_html = ''
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -3177,7 +3177,7 @@ class Report(object):
         if add_psd:
             epoch_duration = epochs.tmax - epochs.tmin
             signal_duration = len(epochs) * epoch_duration
-            if psd_signal_duration is None:
+            if psd_signal_duration is None:  # pick entire time range
                 psd_signal_duration = signal_duration
             num_of_epochs_required = int(
                 np.ceil(psd_signal_duration / epoch_duration)
@@ -3197,8 +3197,8 @@ class Report(object):
                 stop=len(epochs),
                 step=int(np.floor(len(epochs) / num_of_epochs_required))
             )
-            # We may have more than necessary due to the floor(); simply drop
-            # the last few ones in this case
+            # We may have more epochs than necessary due to the floor(); simply
+            # drop the last few ones in this case
             epochs_idx = epochs_idx[:num_of_epochs_required]
 
             if psd_signal_duration is None:

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -3192,7 +3192,7 @@ class Report(object):
                 epochs_idx = np.arange(
                     start=0,
                     stop=len(epochs),
-                    step=int(np.floor(len(epochs) / num_of_epochs_required))
+                    step=len(epochs) // num_of_epochs_required
                 )
                 # We may have more epochs than necessary due to the floor();
                 # simply drop the last few ones in this case

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -843,6 +843,13 @@ class Report(object):
             cover at least this duration. Epochs will be picked across the
             entire time range in equally-spaced distance. If ``None``, use all
             epochs.
+
+            .. note::
+              In rare edge cases, we may not be able to create a grid of
+              equally-spaced epochs that cover the entire requested time range.
+              In these situations, a warning will be emitted, informing you
+              about the duration that's actually being used.
+
         %(report_projs)s
         %(report_tags)s
         %(report_replace)s
@@ -3094,6 +3101,70 @@ class Report(object):
         )
         return html, dom_id
 
+    def _epochs_psd_img_html(
+        self, *, epochs, add_psd, psd_signal_duration, image_format, tags
+    ):
+        if add_psd:
+            epoch_duration = epochs.tmax - epochs.tmin
+
+            if psd_signal_duration is None:  # Entire time range -> all epochs
+                epochs_for_psd = epochs  # Avoid creating a copy
+            else:  # Only a subset of epochs
+                signal_duration = len(epochs) * epoch_duration
+                n_epochs_required = int(
+                    np.ceil(psd_signal_duration / epoch_duration)
+                )
+                if n_epochs_required > len(epochs):
+                    raise ValueError(
+                        f'You requested to calculate PSD on a duration of '
+                        f'{psd_signal_duration:.3f} sec, but all your epochs '
+                        f'are only {signal_duration:.1f} sec long'
+                    )
+                epochs_idx = np.round(
+                    np.linspace(
+                        start=0,
+                        stop=len(epochs) - 1,
+                        num=n_epochs_required
+                    )
+                ).astype(int)
+                # Edge case: there might be duplicate indices due to rounding?
+                epochs_idx_unique = np.unique(epochs_idx)
+                if len(epochs_idx_unique) != len(epochs_idx):
+                    duration = round(
+                        len(epochs_idx_unique) * epoch_duration, 1
+                    )
+                    warn(f'Using {len(epochs_idx_unique)} epochs, only '
+                         f'covering {duration:.1f} sec of data')
+                    del duration
+
+                epochs_for_psd = epochs[epochs_idx_unique]
+
+            dom_id = self._get_dom_id()
+            if epochs.info['lowpass'] is not None:
+                fmax = epochs.info['lowpass'] + 15
+                # Must not exceed half the sampling frequency
+                if fmax > 0.5 * epochs.info['sfreq']:
+                    fmax = np.inf
+            else:
+                fmax = np.inf
+
+            fig = epochs_for_psd.plot_psd(fmax=fmax, show=False)
+            img = _fig_to_img(fig=fig, image_format=image_format)
+            duration = round(epoch_duration * len(epochs_for_psd), 1)
+            caption = (
+                f'PSD calculated from {len(epochs_for_psd)} epochs '
+                f'({duration:.1f} sec)'
+            )
+            psd_img_html = _html_image_element(
+                img=img, id=dom_id, div_klass='epochs', img_klass='epochs',
+                show=True, image_format=image_format, title='PSD',
+                caption=caption, tags=tags
+            )
+        else:
+            psd_img_html = ''
+
+        return psd_img_html
+
     def _render_epochs(self, *, epochs, add_psd, psd_signal_duration,
                        add_projs, image_format, tags, topomap_kwargs):
         """Render epochs."""
@@ -3173,52 +3244,11 @@ class Report(object):
         else:
             drop_log_img_html = ''
 
-        # PSD
-        if add_psd:
-            if psd_signal_duration is None:  # Entire time range -> all epochs
-                epochs_for_psd = epochs  # Avoid creating a copy
-            else:  # Only a subset of epochs
-                epoch_duration = epochs.tmax - epochs.tmin
-                signal_duration = len(epochs) * epoch_duration
-                n_epochs_required = int(
-                    np.ceil(psd_signal_duration / epoch_duration)
-                )
-                if n_epochs_required > len(epochs):
-                    raise ValueError(
-                        f'You requested to calculate PSD on a duration of '
-                        f'{psd_signal_duration:.3f} sec, but all your epochs '
-                        f'are only {signal_duration:.3f} sec long'
-                    )
-                epochs_idx = np.arange(
-                    start=0,
-                    stop=len(epochs),
-                    step=len(epochs) // n_epochs_required
-                )
-                # We may have more epochs than necessary due to the floor();
-                # simply drop the last few ones in this case
-                epochs_idx = epochs_idx[:n_epochs_required]
-                epochs_for_psd = epochs[epochs_idx]
-
-            dom_id = self._get_dom_id()
-            if epochs.info['lowpass'] is not None:
-                fmax = epochs.info['lowpass'] + 15
-                # Must not exceed half the sampling frequency
-                if fmax > 0.5 * epochs.info['sfreq']:
-                    fmax = np.inf
-            else:
-                fmax = np.inf
-
-            fig = epochs_for_psd.plot_psd(fmax=fmax, show=False)
-            img = _fig_to_img(fig=fig, image_format=image_format)
-            psd_img_html = _html_image_element(
-                img=img, id=dom_id, div_klass='epochs', img_klass='epochs',
-                show=True, image_format=image_format, title='PSD',
-                caption=None, tags=tags
-            )
-            del epochs_for_psd
-        else:
-            psd_img_html = ''
-
+        psd_img_html = self._epochs_psd_img_html(
+            epochs=epochs, add_psd=add_psd,
+            psd_signal_duration=psd_signal_duration, image_format=image_format,
+            tags=tags
+        )
         ssp_projs_html = self._ssp_projs_html(
             add_projs=add_projs, info=epochs, image_format=image_format,
             tags=tags, topomap_kwargs=topomap_kwargs

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -3175,26 +3175,20 @@ class Report(object):
 
         # PSD
         if add_psd:
-            epoch_duration = epochs.tmax - epochs.tmin
-            signal_duration = len(epochs) * epoch_duration
-            if psd_signal_duration is None:  # pick entire time range
-                psd_signal_duration = signal_duration
-            num_of_epochs_required = int(
-                np.ceil(psd_signal_duration / epoch_duration)
-            )
-            if (
-                psd_signal_duration is not None and
-                num_of_epochs_required > len(epochs)
-            ):
-                raise ValueError(
-                    f'You requested to calculate PSD on a duration of '
-                    f'{psd_signal_duration:.3f} sec, but all your epochs '
-                    f'are only {signal_duration:.3f} sec long'
-                )
-
-            if psd_signal_duration is None:
+            if psd_signal_duration is None:  # Entire time range -> all epochs
                 epochs_for_psd = epochs  # Avoid creating a copy
-            else:
+            else:  # Only a subset of epochs
+                epoch_duration = epochs.tmax - epochs.tmin
+                signal_duration = len(epochs) * epoch_duration
+                num_of_epochs_required = int(
+                    np.ceil(psd_signal_duration / epoch_duration)
+                )
+                if num_of_epochs_required > len(epochs):
+                    raise ValueError(
+                        f'You requested to calculate PSD on a duration of '
+                        f'{psd_signal_duration:.3f} sec, but all your epochs '
+                        f'are only {signal_duration:.3f} sec long'
+                    )
                 epochs_idx = np.arange(
                     start=0,
                     stop=len(epochs),

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -3165,7 +3165,7 @@ class Report(object):
             duration = round(epoch_duration * len(epochs_for_psd), 1)
             caption = (
                 f'PSD calculated from {len(epochs_for_psd)} epochs '
-                f'({duration:.1f} sec)'
+                f'({duration:.1f} sec).'
             )
             psd_img_html = _html_image_element(
                 img=img, id=dom_id, div_klass='epochs', img_klass='epochs',

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -710,14 +710,16 @@ def test_manual_report_2d(tmp_path, invisible_fig):
     r.add_epochs(epochs=epochs, title='my epochs', tags=('epochs',), psd=False,
                  projs=False)
     r.add_epochs(epochs=epochs, title='my epochs 2', tags=('epochs',),
-                 psd=True, psd_signal_duration=1, projs=False)
+                 psd=1, projs=False)
+    r.add_epochs(epochs=epochs, title='my epochs 2', tags=('epochs',),
+                 psd=True, projs=False)
 
     with pytest.raises(
         ValueError,
         match='requested to calculate PSD on a duration'
     ):
         r.add_epochs(epochs=epochs, title='my epochs 2', tags=('epochs',),
-                     psd=True, psd_signal_duration=100000000, projs=False)
+                     psd=100000000, projs=False)
 
     r.add_evokeds(evokeds=evoked, noise_cov=cov_fname,
                   titles=['my evoked 1'], tags=('evoked',), projs=False,

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -709,6 +709,8 @@ def test_manual_report_2d(tmp_path, invisible_fig):
                  sfreq=raw.info['sfreq'])
     r.add_epochs(epochs=epochs, title='my epochs', tags=('epochs',), psd=False,
                  projs=False)
+    r.add_epochs(epochs=epochs, title='my epochs 2', tags=('epochs',),
+                 psd=True, psd_signal_duration=1, projs=False)
     r.add_evokeds(evokeds=evoked, noise_cov=cov_fname,
                   titles=['my evoked 1'], tags=('evoked',), projs=False,
                   n_time_points=2)

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -711,6 +711,14 @@ def test_manual_report_2d(tmp_path, invisible_fig):
                  projs=False)
     r.add_epochs(epochs=epochs, title='my epochs 2', tags=('epochs',),
                  psd=True, psd_signal_duration=1, projs=False)
+
+    with pytest.raises(
+        ValueError,
+        match='requested to calculate PSD on a duration'
+    ):
+        r.add_epochs(epochs=epochs, title='my epochs 2', tags=('epochs',),
+                     psd=True, psd_signal_duration=100000000, projs=False)
+
     r.add_evokeds(evokeds=evoked, noise_cov=cov_fname,
                   titles=['my evoked 1'], tags=('evoked',), projs=False,
                   n_time_points=2)

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -60,8 +60,10 @@ def _check_psd_data(inst, tmin, tmax, picks, proj, reject_by_annotation=False):
     from ..epochs import BaseEpochs
     from ..evoked import Evoked
     if not isinstance(inst, (BaseEpochs, BaseRaw, Evoked)):
-        raise ValueError('epochs must be an instance of Epochs, Raw, or'
-                         'Evoked. Got type {}'.format(type(inst)))
+        raise ValueError(
+            f'inst must be an instance of Epochs, Raw, or Evoked. Got '
+            f'{type(inst)}'
+        )
 
     time_mask = _time_mask(inst.times, tmin, tmax, sfreq=inst.info['sfreq'])
     picks = _picks_to_idx(inst.info, picks, 'data', with_ref_meg=False)

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -86,7 +86,7 @@ subjects_dir = data_path / 'subjects'
 
 raw_path = sample_dir / 'sample_audvis_filt-0-40_raw.fif'
 raw = mne.io.read_raw(raw_path)
-raw.pick_types(eeg=True, eog=True).crop(tmax=60).load_data()
+raw.pick_types(eeg=True, eog=True, stim=True).crop(tmax=60).load_data()
 
 report = mne.Report(title='Raw example')
 # This method also accepts a path, e.g., raw=raw_path
@@ -102,7 +102,7 @@ report.save('report_raw.html', overwrite=True)
 # is used to generate a meaningful time axis.
 
 events_path = sample_dir / 'sample_audvis_filt-0-40_raw-eve.fif'
-events = mne.read_events(events_path)
+events = mne.find_events(raw=raw)
 sfreq = raw.info['sfreq']
 
 report = mne.Report(title='Events example')


### PR DESCRIPTION
The new parameter allows users to specify which duration of the signal to use for PSD calculation. We will then pick N equally-spaced epochs such that we cover this duration (or slightly more, due to the fixed duration of invidiual epochs).

Still WIP because I haven't really tested it with "real" data yet; but with `sample`, it can already speed up things significantly if I only use 30 seconds of data; the resulting PSD figure looks pretty much unchanged. So this could be a huge gain with only minor drawbacks.

The existing defaults from `main` are not changed; if the parameter is `None`, we continue defaulting to using all epochs for PSD calculation.

Will provide some benchmark results later.

Would like to hear what you think about this approach in general (i.e., only picking a subset of data for PSD).
@larsoner @cbrnr 


Todo:

- [x] provide benchmarks
- [x] add changelog entry
- [x] add test


x-ref #10107