### PR TITLE
MAINT: Deal with pytest upgrade

### DIFF
--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -431,9 +431,7 @@ def test_real(_load_forward, idx):
                              real_filter=True, inversion='single')
     # Also test here that no warings are thrown - implemented to check whether
     # src should not be None warning occurs:
-    with pytest.warns(None) as w:
-        power, f = apply_dics_csd(csd, filters_real)
-    assert len(w) == 0
+    power, f = apply_dics_csd(csd, filters_real)
 
     assert f == [10, 20]
     dist = _fwd_dist(power, fwd_surf, vertices, source_ind)
@@ -506,9 +504,7 @@ def test_apply_dics_timeseries(_load_forward, idx):
     # Sanity checks on the resulting STC after applying DICS on epochs.
     # Also test here that no warnings are thrown - implemented to check whether
     # src should not be None warning occurs
-    with pytest.warns(None) as w:
-        stcs = apply_dics_epochs(epochs, filters)
-    assert len(w) == 0
+    stcs = apply_dics_epochs(epochs, filters)
 
     assert isinstance(stcs, list)
     assert len(stcs) == 1

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -24,7 +24,8 @@ from mne.io.constants import FIFF
 from mne.minimum_norm import make_inverse_operator, apply_inverse
 from mne.minimum_norm.tests.test_inverse import _assert_free_ori_match
 from mne.simulation import simulate_evoked
-from mne.utils import object_diff, requires_h5py, catch_logging
+from mne.utils import (object_diff, requires_h5py, catch_logging,
+                       _record_warnings)
 
 
 data_path = testing.data_path(download=False)
@@ -692,7 +693,7 @@ def test_localization_bias_free(bias_params_free, reg, pick_ori, weight_norm,
     if not use_cov:
         evoked.pick_types(meg='grad')
         noise_cov = None
-    with pytest.warns(None):  # rank deficiency of data_cov
+    with _record_warnings():  # rank deficiency of data_cov
         filters = make_lcmv(evoked.info, fwd, data_cov, reg,
                             noise_cov, pick_ori=pick_ori,
                             weight_norm=weight_norm,

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -13,6 +13,7 @@ from mne.preprocessing.nirs import (optical_density, scalp_coupling_index,
 from mne.datasets.testing import data_path
 from mne.io import read_raw_nirx
 from mne.io.proj import _has_eeg_average_ref_proj
+from mne.utils import _record_warnings
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
@@ -161,7 +162,7 @@ def test_interpolation_eeg(offset, avg_proj, ctol, atol, method):
     raw_few.del_proj()
     raw_few.info['bads'] = [raw_few.ch_names[-1]]
     orig_data = raw_few[1][0]
-    with pytest.warns(None) as w:
+    with _record_warnings() as w:
         raw_few.interpolate_bads(reset_bads=False, **kw)
     assert len([ww for ww in w if 'more than' not in str(ww.message)]) == 0
     new_data = raw_few[1][0]

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -29,7 +29,7 @@ from mne.channels import (get_builtin_montages, DigMontage, read_dig_dat,
                           read_polhemus_fastscan, read_dig_localite,
                           read_dig_hpts)
 from mne.channels.montage import transform_to_head, _check_get_coord_frame
-from mne.utils import assert_dig_allclose
+from mne.utils import assert_dig_allclose, _record_warnings
 from mne.bem import _fit_sphere
 from mne.io.constants import FIFF
 from mne.io._digitization import (_format_dig_points,
@@ -461,7 +461,7 @@ def test_montage_readers(
         for key in ('coord_frame', 'ident', 'kind'):
             assert isinstance(d1[key], int)
             assert isinstance(d2[key], int)
-    with pytest.warns(None) as w:
+    with _record_warnings() as w:
         xform = compute_native_head_t(dig_montage)
     assert xform['to'] == FIFF.FIFFV_COORD_HEAD
     assert xform['from'] == FIFF.FIFFV_COORD_UNKNOWN

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
+import glob
 import os
 from os import path as op
 import shutil
-import glob
 
 import numpy as np
 import pytest
@@ -24,7 +24,7 @@ from mne.datasets import testing
 from mne.io import read_raw_fif, read_info
 from mne.utils import (requires_mne, requires_vtk, requires_freesurfer,
                        requires_nibabel, ArgvSetter, modified_env,
-                       _stamp_to_dt)
+                       _stamp_to_dt, _record_warnings)
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
@@ -48,7 +48,7 @@ def test_browse_raw():
     """Test mne browse_raw."""
     check_usage(mne_browse_raw)
     with ArgvSetter(('--raw', raw_fname)):
-        with pytest.warns(None):  # mpl show warning sometimes
+        with _record_warnings():  # mpl show warning
             mne_browse_raw.run()
 
 
@@ -109,7 +109,7 @@ def test_compute_proj_exg(tmp_path, fun):
     shutil.copyfile(raw_fname, use_fname)
     with ArgvSetter(('-i', use_fname, '--bad=' + bad_fname,
                      '--rej-eeg', '150')):
-        with pytest.warns(None):  # samples, sometimes
+        with _record_warnings():  # samples, sometimes
             fun.run()
     fnames = glob.glob(op.join(tempdir, '*proj.fif'))
     assert len(fnames) == 1
@@ -195,7 +195,7 @@ def test_report(tmp_path):
     shutil.copyfile(raw_fname, use_fname)
     with ArgvSetter(('-p', tempdir, '-i', use_fname, '-d', subjects_dir,
                      '-s', 'sample', '--no-browser', '-m', '30')):
-        with pytest.warns(None):  # contour levels
+        with _record_warnings():  # contour levels
             mne_report.run()
     fnames = glob.glob(op.join(tempdir, '*.html'))
     assert len(fnames) == 1

--- a/mne/decoding/tests/test_search_light.py
+++ b/mne/decoding/tests/test_search_light.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_equal
 import pytest
 
-from mne.utils import requires_sklearn
+from mne.utils import requires_sklearn, _record_warnings
 from mne.fixes import _get_args
 from mne.decoding.search_light import SlidingEstimator, GeneralizingEstimator
 from mne.decoding.transformer import Vectorizer
@@ -30,7 +30,7 @@ def test_search_light():
     from sklearn.linear_model import Ridge, LogisticRegression
     from sklearn.pipeline import make_pipeline
     from sklearn.metrics import roc_auc_score, make_scorer
-    with pytest.warns(None):  # NumPy module import
+    with _record_warnings():  # NumPy module import
         from sklearn.ensemble import BaggingClassifier
     from sklearn.base import is_classifier
 

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -4,6 +4,7 @@
 # License: Simplified BSD
 
 import os.path as op
+
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_allclose,
                            assert_array_less, assert_array_equal)
@@ -21,7 +22,7 @@ from mne.inverse_sparse.mxne_optim import norm_l2inf
 from mne.minimum_norm import apply_inverse, make_inverse_operator
 from mne.minimum_norm.tests.test_inverse import \
     assert_var_exp_log, assert_stc_res
-from mne.utils import assert_stcs_equal, catch_logging
+from mne.utils import assert_stcs_equal, catch_logging, _record_warnings
 from mne.dipole import Dipole
 from mne.source_estimate import VolSourceEstimate
 from mne.simulation import simulate_sparse_stc, simulate_evoked
@@ -80,7 +81,7 @@ def test_mxne_inverse_standard(forward):
     # MxNE tests
     alpha = 70  # spatial regularization parameter
 
-    with pytest.warns(None):  # CD
+    with _record_warnings():  # CD
         stc_cd = mixed_norm(evoked_l21, forward, cov, alpha, loose=loose,
                             depth=depth, maxit=300, tol=1e-8,
                             active_set_size=10, weights=stc_dspm,
@@ -96,17 +97,18 @@ def test_mxne_inverse_standard(forward):
     assert stc_bcd.vertices[1][0] in label.vertices
 
     # vector
-    with pytest.warns(None):  # no convergence
+    with _record_warnings():  # no convergence
         stc = mixed_norm(evoked_l21, forward, cov, alpha, loose=1, maxit=2)
-    with pytest.warns(None):  # no convergence
+    with _record_warnings():  # no convergence
         stc_vec = mixed_norm(evoked_l21, forward, cov, alpha, loose=1, maxit=2,
                              pick_ori='vector')
     assert_stcs_equal(stc_vec.magnitude(), stc)
-    with pytest.warns(None), pytest.raises(ValueError, match='pick_ori='):
+    with _record_warnings(), \
+            pytest.raises(ValueError, match='pick_ori='):
         mixed_norm(evoked_l21, forward, cov, alpha, loose=0, maxit=2,
                    pick_ori='vector')
 
-    with pytest.warns(None), catch_logging() as log:  # CD
+    with _record_warnings(), catch_logging() as log:  # CD
         dips = mixed_norm(evoked_l21, forward, cov, alpha, loose=loose,
                           depth=depth, maxit=300, tol=1e-8, active_set_size=10,
                           weights=stc_dspm, weights_min=weights_min,
@@ -118,7 +120,7 @@ def test_mxne_inverse_standard(forward):
     assert_var_exp_log(log.getvalue(), 51, 53)  # 51.8
 
     # Single time point things should match
-    with pytest.warns(None), catch_logging() as log:
+    with _record_warnings(), catch_logging() as log:
         dips = mixed_norm(evoked_l21.copy().crop(0.081, 0.081),
                           forward, cov, alpha, loose=loose,
                           depth=depth, maxit=300, tol=1e-8, active_set_size=10,
@@ -128,7 +130,7 @@ def test_mxne_inverse_standard(forward):
     gof = sum(dip.gof[0] for dip in dips)  # these are now partial exp vars
     assert_allclose(gof, 37.9, atol=0.1)
 
-    with pytest.warns(None), catch_logging() as log:
+    with _record_warnings(), catch_logging() as log:
         stc, res = mixed_norm(evoked_l21, forward, cov, alpha, loose=loose,
                               depth=depth, maxit=300, tol=1e-8,
                               weights=stc_dspm,  # gh-6382
@@ -141,7 +143,7 @@ def test_mxne_inverse_standard(forward):
     assert_stc_res(evoked_l21, stc, forward, res)
 
     # irMxNE tests
-    with pytest.warns(None), catch_logging() as log:  # CD
+    with _record_warnings(), catch_logging() as log:  # CD
         stc, residual = mixed_norm(
             evoked_l21, forward, cov, alpha, n_mxne_iter=5, loose=0.0001,
             depth=depth, maxit=300, tol=1e-8, active_set_size=10,

--- a/mne/inverse_sparse/tests/test_mxne_optim.py
+++ b/mne/inverse_sparse/tests/test_mxne_optim.py
@@ -15,7 +15,7 @@ from mne.inverse_sparse.mxne_optim import (mixed_norm_solver,
                                            norm_epsilon_inf, norm_epsilon,
                                            _Phi, _PhiT, dgap_l21l1)
 from mne.time_frequency._stft import stft_norm2
-from mne.utils import catch_logging
+from mne.utils import catch_logging, _record_warnings
 
 
 def _generate_tf_data():
@@ -47,13 +47,13 @@ def test_l21_mxne():
     M = np.dot(G, X)
 
     args = (M, G, alpha, 1000, 1e-8)
-    with pytest.warns(None):  # CD
+    with _record_warnings():  # CD
         X_hat_cd, active_set, _, gap_cd = mixed_norm_solver(
             *args, active_set_size=None,
             debias=True, solver='cd', return_gap=True)
     assert_array_less(gap_cd, 1e-8)
     assert_array_equal(np.where(active_set)[0], [0, 4])
-    with pytest.warns(None):  # CD
+    with _record_warnings():  # CD
         X_hat_bcd, active_set, E, gap_bcd = mixed_norm_solver(
             M, G, alpha, maxit=1000, tol=1e-8, active_set_size=None,
             debias=True, solver='bcd', return_gap=True)
@@ -61,17 +61,17 @@ def test_l21_mxne():
     assert_array_equal(np.where(active_set)[0], [0, 4])
     assert_allclose(X_hat_bcd, X_hat_cd, rtol=1e-2)
 
-    with pytest.warns(None):  # CD
+    with _record_warnings():  # CD
         X_hat_cd, active_set, _ = mixed_norm_solver(
             *args, active_set_size=2, debias=True, solver='cd')
     assert_array_equal(np.where(active_set)[0], [0, 4])
-    with pytest.warns(None):  # CD
+    with _record_warnings():  # CD
         X_hat_bcd, active_set, _ = mixed_norm_solver(
             *args, active_set_size=2, debias=True, solver='bcd')
     assert_array_equal(np.where(active_set)[0], [0, 4])
     assert_allclose(X_hat_bcd, X_hat_cd, rtol=1e-2)
 
-    with pytest.warns(None):  # CD
+    with _record_warnings():  # CD
         X_hat_bcd, active_set, _ = mixed_norm_solver(
             *args, active_set_size=2, debias=True, n_orient=2, solver='bcd')
     assert_array_equal(np.where(active_set)[0], [0, 1, 4, 5])
@@ -83,7 +83,7 @@ def test_l21_mxne():
     assert_array_equal(np.where(active_set)[0], [0, 1, 4, 5])
     assert_allclose(X_hat_bcd, X_hat_cd, rtol=1e-2)
 
-    with pytest.warns(None):  # CD
+    with _record_warnings():  # CD
         X_hat_bcd, active_set, _ = mixed_norm_solver(
             *args, active_set_size=2, debias=True, n_orient=5, solver='bcd')
     assert_array_equal(np.where(active_set)[0], [0, 1, 2, 3, 4])
@@ -124,7 +124,7 @@ def test_tf_mxne():
 
     M, G, active_set = _generate_tf_data()
 
-    with pytest.warns(None):  # CD
+    with _record_warnings():  # CD
         X_hat_tf, active_set_hat_tf, E, gap_tfmxne = tf_mixed_norm_solver(
             M, G, alpha_space, alpha_time, maxit=200, tol=1e-8, verbose=True,
             n_orient=1, tstep=4, wsize=32, return_gap=True)
@@ -252,29 +252,29 @@ def test_iterative_reweighted_mxne():
     X[4] = -2
     M = np.dot(G, X)
 
-    with pytest.warns(None):  # CD
+    with _record_warnings():  # CD
         X_hat_l21, _, _ = mixed_norm_solver(
             M, G, alpha, maxit=1000, tol=1e-8, verbose=False, n_orient=1,
             active_set_size=None, debias=False, solver='bcd')
-    with pytest.warns(None):  # CD
+    with _record_warnings():  # CD
         X_hat_bcd, active_set, _ = iterative_mixed_norm_solver(
             M, G, alpha, 1, maxit=1000, tol=1e-8, active_set_size=None,
             debias=False, solver='bcd')
     assert_allclose(X_hat_bcd, X_hat_l21, rtol=1e-3)
 
-    with pytest.warns(None):  # CD
+    with _record_warnings():  # CD
         X_hat_bcd, active_set, _ = iterative_mixed_norm_solver(
             M, G, alpha, 5, maxit=1000, tol=1e-8, active_set_size=2,
             debias=True, solver='bcd')
     assert_array_equal(np.where(active_set)[0], [0, 4])
-    with pytest.warns(None):  # CD
+    with _record_warnings():  # CD
         X_hat_cd, active_set, _ = iterative_mixed_norm_solver(
             M, G, alpha, 5, maxit=1000, tol=1e-8, active_set_size=None,
             debias=True, solver='cd')
     assert_array_equal(np.where(active_set)[0], [0, 4])
     assert_array_almost_equal(X_hat_bcd, X_hat_cd, 5)
 
-    with pytest.warns(None):  # CD
+    with _record_warnings():  # CD
         X_hat_bcd, active_set, _ = iterative_mixed_norm_solver(
             M, G, alpha, 5, maxit=1000, tol=1e-8, active_set_size=2,
             debias=True, n_orient=2, solver='bcd')

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -21,7 +21,8 @@ from mne.io.compensator import get_current_comp
 from mne.io.ctf.constants import CTF
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.tests.test_annotations import _assert_annotations_equal
-from mne.utils import _clean_names, catch_logging, _stamp_to_dt
+from mne.utils import (_clean_names, catch_logging, _stamp_to_dt,
+                       _record_warnings)
 from mne.datasets import testing, spm_face, brainstorm
 from mne.io.constants import FIFF
 
@@ -105,7 +106,8 @@ def test_read_ctf(tmp_path):
     use_fnames = [op.join(ctf_dir, c) for c in ctf_fnames]
     for fname in use_fnames:
         raw_c = read_raw_fif(fname + '_raw.fif', preload=True)
-        with pytest.warns(None):  # sometimes matches "MISC channel"
+        # sometimes matches "MISC channel"
+        with _record_warnings():
             raw = read_raw_ctf(fname)
 
         # check info match

--- a/mne/io/curry/tests/test_curry.py
+++ b/mne/io/curry/tests/test_curry.py
@@ -5,12 +5,12 @@
 #
 # License: BSD-3-Clause
 
-import os.path as op
-import numpy as np
-from shutil import copyfile
 from datetime import datetime, timezone
+import os.path as op
+from shutil import copyfile
 
 import pytest
+import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
 from mne.annotations import events_from_annotations
@@ -22,7 +22,7 @@ from mne.io.constants import FIFF
 from mne.io.edf import read_raw_bdf
 from mne.io.bti import read_raw_bti
 from mne.io.curry import read_raw_curry
-from mne.utils import check_version, catch_logging
+from mne.utils import check_version, catch_logging, _record_warnings
 from mne.annotations import read_annotations
 from mne.io.curry.curry import (_get_curry_version, _get_curry_file_structure,
                                 _read_events_curry, FILE_EXTENSIONS)
@@ -70,7 +70,7 @@ def bdf_curry_ref():
 @pytest.mark.parametrize('preload', [True, False])
 def test_read_raw_curry(fname, tol, preload, bdf_curry_ref):
     """Test reading CURRY files."""
-    with pytest.warns(None) as wrn:
+    with _record_warnings() as wrn:
         raw = read_raw_curry(fname, preload=preload)
 
     if not check_version('numpy', '1.16') and preload and fname.endswith(

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -23,7 +23,7 @@ import pytest
 from mne import pick_types, Annotations
 from mne.annotations import events_from_annotations, read_annotations
 from mne.datasets import testing
-from mne.utils import requires_pandas
+from mne.utils import requires_pandas, _record_warnings
 from mne.io import read_raw_edf, read_raw_bdf, read_raw_fif, edf, read_raw_gdf
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.edf.edf import (_get_edf_default_event_id, _read_annotations_edf,
@@ -285,9 +285,9 @@ def test_to_data_frame(fname):
 def test_read_raw_edf_stim_channel_input_parameters():
     """Test edf raw reader deprecation."""
     _MSG = "`read_raw_edf` is not supposed to trigger a deprecation warning"
-    with pytest.warns(None) as recwarn:
+    with _record_warnings() as recwarn:
         read_raw_edf(edf_path)
-    assert all([w.category != DeprecationWarning for w in recwarn.list]), _MSG
+    assert all([w.category != DeprecationWarning for w in recwarn]), _MSG
 
     for invalid_stim_parameter in ['EDF Annotations', 'BDF Annotations']:
         with pytest.raises(ValueError,

--- a/mne/io/fieldtrip/tests/test_fieldtrip.py
+++ b/mne/io/fieldtrip/tests/test_fieldtrip.py
@@ -4,15 +4,18 @@
 #
 # License: BSD-3-Clause
 
-import mne
-import os.path
-import pytest
+from contextlib import nullcontext
 import copy
 import itertools
+import os.path
+
+import pytest
 import numpy as np
+
+import mne
 from mne.datasets import testing
 from mne.io.fieldtrip.utils import NOINFO_WARNING, _create_events
-from mne.utils import _check_pandas_installed, requires_h5py
+from mne.utils import _check_pandas_installed, requires_h5py, _record_warnings
 from mne.io.fieldtrip.tests.helpers import (check_info_fields, get_data_paths,
                                             get_raw_data, get_epochs,
                                             get_evoked, _has_h5py,
@@ -60,10 +63,10 @@ def test_read_evoked(cur_system, version, use_info):
     mne_avg = get_evoked(cur_system)
     if use_info:
         info = get_raw_info(cur_system)
-        pytestwarning = {'expected_warning': None}
+        ctx = nullcontext()
     else:
         info = None
-        pytestwarning = no_info_warning
+        ctx = pytest.warns(**no_info_warning)
 
     cur_fname = os.path.join(test_data_folder_ft,
                              'averaged_%s.mat' % (version,))
@@ -72,7 +75,7 @@ def test_read_evoked(cur_system, version, use_info):
             mne.io.read_evoked_fieldtrip(cur_fname, info)
         return
 
-    with pytest.warns(**pytestwarning):
+    with ctx:
         avg_ft = mne.io.read_evoked_fieldtrip(cur_fname, info)
 
     mne_data = mne_avg.data[:, :-1]
@@ -102,10 +105,10 @@ def test_read_epochs(cur_system, version, use_info, monkeypatch):
     mne_epoched = get_epochs(cur_system)
     if use_info:
         info = get_raw_info(cur_system)
-        pytestwarning = {'expected_warning': None}
+        ctx = nullcontext()
     else:
         info = None
-        pytestwarning = no_info_warning
+        ctx = pytest.warns(**no_info_warning)
 
     cur_fname = os.path.join(test_data_folder_ft,
                              'epoched_%s.mat' % (version,))
@@ -114,11 +117,11 @@ def test_read_epochs(cur_system, version, use_info, monkeypatch):
             with pytest.raises(ImportError):
                 mne.io.read_epochs_fieldtrip(cur_fname, info)
             return
-        with pytest.warns(**pytestwarning):
+        with ctx:
             epoched_ft = mne.io.read_epochs_fieldtrip(cur_fname, info)
         assert isinstance(epoched_ft.metadata, pandas.DataFrame)
     else:
-        with pytest.warns(None) as warn_record:
+        with _record_warnings() as warn_record:
             if version == 'v73' and not _has_h5py():
                 with pytest.raises(ImportError):
                     mne.io.read_epochs_fieldtrip(cur_fname, info)
@@ -126,8 +129,8 @@ def test_read_epochs(cur_system, version, use_info, monkeypatch):
             epoched_ft = mne.io.read_epochs_fieldtrip(cur_fname, info)
             assert epoched_ft.metadata is None
             assert_warning_in_record(pandas_not_found_warning_msg, warn_record)
-            if pytestwarning['expected_warning'] is not None:
-                assert_warning_in_record(pytestwarning['match'], warn_record)
+            if info is None:
+                assert_warning_in_record(NOINFO_WARNING, warn_record)
 
     mne_data = mne_epoched.get_data()[:, :, :-1]
     ft_data = epoched_ft.get_data()
@@ -162,10 +165,13 @@ def test_raw(cur_system, version, use_info):
     raw_fiff_mne = get_raw_data(cur_system, drop_extra_chs=True)
     if use_info:
         info = get_raw_info(cur_system)
-        pytestwarning = {'expected_warning': None}
+        if cur_system in ('BTI', 'eximia'):
+            ctx = pytest.warns(RuntimeWarning, match='cannot be found in')
+        else:
+            ctx = nullcontext()
     else:
         info = None
-        pytestwarning = no_info_warning
+        ctx = pytest.warns(**no_info_warning)
 
     cur_fname = os.path.join(test_data_folder_ft,
                              'raw_%s.mat' % (version,))
@@ -174,7 +180,7 @@ def test_raw(cur_system, version, use_info):
         with pytest.raises(ImportError):
             mne.io.read_raw_fieldtrip(cur_fname, info)
         return
-    with pytest.warns(**pytestwarning):
+    with ctx:
         raw_fiff_ft = mne.io.read_raw_fieldtrip(cur_fname, info)
 
     if cur_system == 'BTI' and not use_info:

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -31,7 +31,7 @@ from mne import (concatenate_events, find_events, equalize_channels,
                  compute_proj_raw, pick_types, pick_channels, create_info,
                  pick_info)
 from mne.utils import (requires_pandas, assert_object_equal, _dt_to_stamp,
-                       requires_mne, run_subprocess,
+                       requires_mne, run_subprocess, _record_warnings,
                        assert_and_remove_boundary_annot)
 from mne.annotations import Annotations
 
@@ -98,7 +98,7 @@ def test_acq_skip(tmp_path):
     assert_allclose(raw_read[:][0], raw[:][0], atol=1e-17)
     # Saving with a bad buffer length emits warning
     raw.pick_channels(raw.ch_names[:2])
-    with pytest.warns(None) as w:
+    with _record_warnings() as w:
         raw.save(fname, buffer_size_sec=0.5, overwrite=True)
     assert len(w) == 0
     with pytest.warns(RuntimeWarning, match='did not fit evenly'):

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -38,7 +38,7 @@ from mne.minimum_norm import (make_inverse_operator, write_inverse_operator,
                               read_inverse_operator, apply_inverse)
 from mne.io._digitization import _write_dig_points, _make_dig_points, DigPoint
 from mne.transforms import Transform
-from mne.utils import catch_logging, assert_object_equal
+from mne.utils import catch_logging, assert_object_equal, _record_warnings
 
 fiducials_fname = op.join(op.dirname(__file__), '..', '..', 'data',
                           'fsaverage', 'fsaverage-fiducials.fif')
@@ -652,7 +652,7 @@ def _test_anonymize_info(base_info):
         new_info = anonymize_info(base_info.copy(), daysback=delta_t_2.days)
     assert_object_equal(new_info, exp_info_3)
 
-    with pytest.warns(None):  # meas_date is None
+    with _record_warnings():  # meas_date is None
         new_info = anonymize_info(base_info.copy())
     assert_object_equal(new_info, exp_info_3)
 
@@ -996,7 +996,7 @@ def test_channel_name_limit(tmp_path, monkeypatch, fname):
     #
     # forward
     #
-    with pytest.warns(None):  # not enough points for CTF
+    with _record_warnings():  # not enough points for CTF
         sphere = make_sphere_model('auto', 'auto', evoked.info)
     src = setup_volume_source_space(
         pos=dict(rr=[[0, 0, 0.04]], nn=[[0, 1., 0.]]))

--- a/mne/io/tests/test_reference.py
+++ b/mne/io/tests/test_reference.py
@@ -7,8 +7,8 @@
 from contextlib import nullcontext
 import itertools
 import os.path as op
-import numpy as np
 
+import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose, assert_equal
 import pytest
 
@@ -24,7 +24,7 @@ from mne.io.constants import FIFF
 from mne.io.proj import _has_eeg_average_ref_proj, Projection
 from mne.io.reference import _apply_reference
 from mne.datasets import testing
-from mne.utils import catch_logging
+from mne.utils import catch_logging, _record_warnings
 
 base_dir = op.join(op.dirname(__file__), 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
@@ -613,7 +613,7 @@ def test_add_reorder(n_ref):
     assert len(raw.ch_names) == 60
     chs = ['EEG %03d' % (60 + ii) for ii in range(1, n_ref)] + ['EEG 000']
     with pytest.raises(RuntimeError, match='preload'):
-        with pytest.warns(None):  # ignore multiple warning
+        with _record_warnings():  # ignore multiple warning
             add_reference_channels(raw, chs, copy=False)
     raw.load_data()
     if n_ref == 1:

--- a/mne/io/tests/test_what.py
+++ b/mne/io/tests/test_what.py
@@ -11,7 +11,7 @@ from mne import what, create_info
 from mne.datasets import testing
 from mne.io import RawArray
 from mne.preprocessing import ICA
-from mne.utils import requires_sklearn
+from mne.utils import requires_sklearn, _record_warnings
 
 data_path = testing.data_path(download=False)
 
@@ -25,7 +25,7 @@ def test_what(tmp_path, verbose_debug):
     ica = ICA(max_iter=1)
     raw = RawArray(np.random.RandomState(0).randn(3, 10),
                    create_info(3, 1000., 'eeg'))
-    with pytest.warns(None):  # convergence sometimes
+    with _record_warnings():  # convergence sometimes
         ica.fit(raw)
     fname = op.join(str(tmp_path), 'x-ica.fif')
     ica.save(fname)

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -31,7 +31,7 @@ from mne.minimum_norm import (apply_inverse, read_inverse_operator,
                               make_inverse_operator, apply_inverse_cov,
                               write_inverse_operator, prepare_inverse_operator,
                               compute_rank_inverse, INVERSE_METHODS)
-from mne.utils import catch_logging
+from mne.utils import catch_logging, _record_warnings
 
 test_path = testing.data_path(download=False)
 s_path = op.join(test_path, 'MEG', 'sample')
@@ -599,7 +599,7 @@ def test_orientation_prior(bias_params_free, method, looses, vmin, vmax,
 def assert_stc_res(evoked, stc, forward, res, atol=1e-20):
     """Assert that orig == residual + estimate."""
     __tracebackhide__ = True
-    with pytest.warns(None):  # could be all positive or large values
+    with _record_warnings():  # all positive or large values
         estimated = apply_forward(forward, stc, evoked.info)
     meg, eeg = 'meg' in estimated, 'eeg' in estimated
     evoked = evoked.copy().pick_types(meg=meg, eeg=eeg, exclude=())

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -1019,16 +1019,16 @@ def test_ica_twice(method):
     n_components = 0.99
     n_pca_components = 0.9999
     if method == 'fastica':
-        ctx = _record_warnings()  # convergence, sometimes
+        ctx = _record_warnings  # convergence, sometimes
     else:
-        ctx = nullcontext()
+        ctx = nullcontext
     ica1 = ICA(n_components=n_components, method=method)
 
-    with ctx:
+    with ctx():
         ica1.fit(raw, picks=picks, decim=3)
     raw_new = ica1.apply(raw, n_pca_components=n_pca_components)
     ica2 = ICA(n_components=n_components, method=method)
-    with ctx:
+    with ctx():
         ica2.fit(raw_new, picks=picks, decim=3)
     assert_equal(ica1.n_components_, ica2.n_components_)
 

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -30,7 +30,7 @@ from mne.preprocessing.maxwell import (
     _sh_real_to_complex, _sh_negate, _bases_complex_to_real, _trans_sss_basis,
     _bases_real_to_complex, _prep_mf_coils)
 from mne.rank import _get_rank_sss, _compute_rank_int, compute_rank
-from mne.utils import (assert_meg_snr, catch_logging,
+from mne.utils import (assert_meg_snr, catch_logging, _record_warnings,
                        object_diff, buggy_mkl_svd, use_log_level)
 
 io_path = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -1091,7 +1091,7 @@ def test_shielding_factor(tmp_path):
             for line in fid:
                 fid_out.write(' '.join(line.strip().split(' ')[:14]) + '\n')
     with get_n_projected() as counts:
-        with pytest.warns(None):  # SVD convergence sometimes
+        with _record_warnings():  # SVD convergence sometimes
             raw_sss = maxwell_filter(raw_erm, calibration=temp_fname,
                                      cross_talk=ctc_fname, st_duration=1.,
                                      coord_frame='meg', regularize='in')
@@ -1134,7 +1134,7 @@ def test_all():
                mf_head_origin)
     for ii, rf in enumerate(raw_fnames):
         raw = read_crop(rf, (0., 1.))
-        with pytest.warns(None):  # sometimes the fit is bad
+        with _record_warnings():  # sometimes the fit is bad
             sss_py = maxwell_filter(
                 raw, calibration=fine_cals[ii], cross_talk=ctcs[ii],
                 st_duration=st_durs[ii], coord_frame=coord_frames[ii],

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -21,7 +21,8 @@ from mne.stats.cluster_level import (permutation_cluster_test, f_oneway,
                                      spatio_temporal_cluster_test,
                                      spatio_temporal_cluster_1samp_test,
                                      ttest_1samp_no_p, summarize_clusters_stc)
-from mne.utils import catch_logging, check_version, requires_sklearn
+from mne.utils import (catch_logging, check_version, requires_sklearn,
+                       _record_warnings)
 
 
 n_space = 50
@@ -249,7 +250,7 @@ def test_cluster_permutation_t_test(numba_conditional, stat_fun):
 
         # test with 2 jobs and buffer_size enabled
         buffer_size = condition1.shape[1] // 10
-        with pytest.warns(None):  # sometimes "independently"
+        with _record_warnings():  # sometimes "independently"
             T_obs_neg_buff, _, cluster_p_values_neg_buff, _ = \
                 permutation_cluster_1samp_test(
                     -condition1, n_permutations=100, tail=-1, out_type='mask',
@@ -381,7 +382,7 @@ def test_cluster_permutation_with_adjacency(numba_conditional):
                 X1d_3, adjacency=adjacency, threshold=dict(me='hello'))
 
         # too extreme a start threshold
-        with pytest.warns(None) as w:
+        with _record_warnings() as w:
             spatio_temporal_func(X1d_3, adjacency=adjacency,
                                  threshold=dict(start=10, step=1))
         if not did_warn:
@@ -410,7 +411,8 @@ def test_cluster_permutation_with_adjacency(numba_conditional):
             spatio_temporal_func(
                 X1d_3, adjacency=adjacency, threshold=[])
         with pytest.raises(ValueError, match='Invalid value for the \'tail\''):
-            with pytest.warns(None):  # sometimes ignoring tail
+            # sometimes ignoring tail
+            with _record_warnings():
                 spatio_temporal_func(
                     X1d_3, adjacency=adjacency, tail=2)
 

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -21,10 +21,10 @@ import mne
 from mne import (create_info, read_annotations, annotations_from_events,
                  events_from_annotations)
 from mne import Epochs, Annotations
-from mne.utils import (requires_version,
-                       catch_logging, requires_pandas)
-from mne.utils import (assert_and_remove_boundary_annot, _raw_annot,
-                       _dt_to_stamp, _stamp_to_dt, check_version)
+from mne.utils import (requires_version, catch_logging, requires_pandas,
+                       assert_and_remove_boundary_annot, _raw_annot,
+                       _dt_to_stamp, _stamp_to_dt, check_version,
+                       _record_warnings)
 from mne.io import read_raw_fif, RawArray, concatenate_raws
 from mne.annotations import (_sync_onset, _handle_meas_date,
                              _read_annotations_txt_parse_header)
@@ -587,14 +587,14 @@ def test_annotations_crop():
     assert_array_equal(a_.duration, a.duration)
 
     # cropping with left shifted window
-    with pytest.warns(None) as w:
+    with _record_warnings() as w:
         a_ = a.copy().crop(tmin=0, tmax=4.2)
     assert_array_equal(a_.onset, [1., 2., 3., 4.])
     assert_allclose(a_.duration, [3.2, 2.2, 1.2, 0.2])
     assert len(w) == 0
 
     # cropping with right shifted window
-    with pytest.warns(None) as w:
+    with _record_warnings() as w:
         a_ = a.copy().crop(tmin=17.8, tmax=22)
     assert_array_equal(a_.onset, [17.8, 17.8])
     assert_allclose(a_.duration, [0.2, 1.2])
@@ -606,7 +606,7 @@ def test_annotations_crop():
     assert_array_equal(a_.duration, [0, 1, 1, 1, 1, 1, 1, 1, 1])
 
     # cropping with out-of-bounds window
-    with pytest.warns(None) as w:
+    with _record_warnings() as w:
         a_ = a.copy().crop(tmin=42, tmax=100)
     assert_array_equal(a_.onset, [])
     assert_array_equal(a_.duration, [])

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -20,7 +20,7 @@ from mne.coreg import (fit_matched_points, create_default_subject, scale_mri,
 from mne.io import read_fiducials, read_info
 from mne.io.constants import FIFF
 from mne.utils import (requires_nibabel, modified_env, check_version,
-                       catch_logging)
+                       catch_logging, _record_warnings)
 from mne.source_space import write_source_spaces
 from mne.channels import DigMontage
 
@@ -111,7 +111,7 @@ def test_scale_mri(tmp_path, few_surfaces, scale):
 
     # scale fsaverage
     write_source_spaces(path % 'ico-0', src, overwrite=True)
-    with pytest.warns(None):  # sometimes missing nibabel
+    with _record_warnings():  # sometimes missing nibabel
         scale_mri('fsaverage', 'flachkopf', scale, True,
                   subjects_dir=tempdir, verbose='debug')
     assert _is_mri_subject('flachkopf', tempdir), "Scaling failed"

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -30,7 +30,8 @@ from mne.io import read_raw_fif, RawArray, read_raw_ctf, read_info
 from mne.io.pick import _DATA_CH_TYPES_SPLIT, pick_info
 from mne.preprocessing import maxwell_filter
 from mne.rank import _compute_rank_int
-from mne.utils import requires_sklearn, catch_logging, assert_snr
+from mne.utils import (requires_sklearn, catch_logging, assert_snr,
+                       _record_warnings)
 
 base_dir = op.join(op.dirname(__file__), '..', 'io', 'tests', 'data')
 cov_fname = op.join(base_dir, 'test-cov.fif')
@@ -271,7 +272,7 @@ def test_cov_estimation_on_raw(method, tmp_path):
     # The pure-string uses the more efficient numpy-based method, the
     # the list gets triaged to compute_covariance (should be equivalent
     # but use more memory)
-    with pytest.warns(None):  # can warn about EEG ref
+    with _record_warnings():  # can warn about EEG ref
         cov = compute_raw_covariance(
             raw, tstep=None, method=method, rank='full',
             method_params=method_params)
@@ -294,7 +295,7 @@ def test_cov_estimation_on_raw(method, tmp_path):
         assert_snr(cov.data, other.data, 1e6)
 
     # tstep=0.2 (default)
-    with pytest.warns(None):  # can warn about EEG ref
+    with _record_warnings():  # can warn about EEG ref
         cov = compute_raw_covariance(raw, method=method, rank='full',
                                      method_params=method_params)
     assert_equal(cov.nfree, cov_mne.nfree - 120)  # cutoff some samples
@@ -326,7 +327,7 @@ def test_cov_estimation_on_raw(method, tmp_path):
     pytest.raises(ValueError, compute_raw_covariance, raw, tstep=None,
                   method='empirical', reject=dict(eog=200e-6))
     # but this should work
-    with pytest.warns(None):  # sklearn
+    with _record_warnings():  # sklearn
         cov = compute_raw_covariance(
             raw.copy().crop(0, 10.), tstep=None, method=method,
             reject=dict(eog=1000e-6), method_params=method_params,
@@ -639,7 +640,7 @@ def _cov_rank(cov, info, proj=True):
     # ignore warnings about rank mismatches: sometimes we will intentionally
     # violate the computed/info assumption, such as when using SSS with
     # `rank='full'`
-    with pytest.warns(None):
+    with _record_warnings():
         return _compute_rank_int(cov, info=info, proj=proj)
 
 

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -21,7 +21,8 @@ from mne import (read_dipole, read_forward_solution,
 from mne.dipole import get_phantom_dipoles, _BDIP_ERROR_KEYS
 from mne.simulation import simulate_evoked
 from mne.datasets import testing
-from mne.utils import requires_mne, run_subprocess, requires_nibabel
+from mne.utils import (requires_mne, run_subprocess, requires_nibabel,
+                       _record_warnings)
 from mne.proj import make_eeg_average_ref_proj
 
 from mne.io import read_raw_fif, read_raw_ctf
@@ -460,7 +461,7 @@ def test_confidence(tmp_path):
 def test_bdip(fname_dip_, fname_bdip_, tmp_path):
     """Test bdip I/O."""
     # use text as veridical
-    with pytest.warns(None):  # ignored fields
+    with _record_warnings():  # ignored fields
         dip = read_dipole(fname_dip_)
     # read binary
     orig_size = os.stat(fname_bdip_).st_size

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -4,12 +4,11 @@ import os.path as op
 from pkgutil import walk_packages
 import re
 import sys
-from unittest import SkipTest
 
 import pytest
 
 import mne
-from mne.utils import requires_numpydoc, _pl
+from mne.utils import requires_numpydoc, _pl, _record_warnings
 
 public_modules = [
     # the list of modules users need to access for all functionality
@@ -132,7 +131,7 @@ def test_docstring_parameters():
         if name not in ('mne', 'mne.gui'):
             extra = name.split('.')[1]
             assert hasattr(mne, extra)
-        with pytest.warns(None):  # traits warnings
+        with _record_warnings():  # traits warnings
             module = __import__(name, globals())
         for submod in name.split('.')[1:]:
             module = getattr(module, submod)
@@ -167,7 +166,7 @@ def test_tabs():
         if not ispkg and modname not in tab_ignores:
             # mod = importlib.import_module(modname)  # not py26 compatible!
             try:
-                with pytest.warns(None):
+                with _record_warnings():
                     __import__(modname)
             except Exception:  # can't import properly
                 continue
@@ -250,7 +249,7 @@ def test_documented():
     doc_dir = op.abspath(op.join(op.dirname(__file__), '..', '..', 'doc'))
     doc_file = op.join(doc_dir, 'python_reference.rst')
     if not op.isfile(doc_file):
-        raise SkipTest('Documentation file not found: %s' % doc_file)
+        pytest.skip('Documentation file not found: %s' % doc_file)
     api_files = (
         'covariance', 'creating_from_arrays', 'datasets',
         'decoding', 'events', 'file_io', 'forward', 'inverse', 'logging',
@@ -271,7 +270,7 @@ def test_documented():
 
     missing = []
     for name in public_modules:
-        with pytest.warns(None):  # traits warnings
+        with _record_warnings():  # traits warnings
             module = __import__(name, globals())
         for submod in name.split('.')[1:]:
             module = getattr(module, submod)

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -29,7 +29,8 @@ from mne.label import (Label, _blend_colors, label_sign_flip, _load_vert_pos,
 from mne.source_space import SourceSpaces
 from mne.source_estimate import mesh_edges
 from mne.surface import _mesh_borders
-from mne.utils import requires_sklearn, get_subjects_dir, check_version
+from mne.utils import (requires_sklearn, get_subjects_dir, check_version,
+                       _record_warnings)
 
 
 data_path = testing.data_path(download=False)
@@ -270,7 +271,7 @@ def test_label_fill_restrict(fname):
         # Check that we can auto-fill patch info quickly for one condition
         for s in src:
             s['nearest'] = None
-        with pytest.warns(None):
+        with _record_warnings():
             label_src = label_src.fill(src)
     else:
         label_src = label_src.fill(src)
@@ -781,13 +782,13 @@ def test_morph():
     verts = [np.arange(10242), np.arange(10242)]
     for hemi in ['lh', 'rh']:
         label.hemi = hemi
-        with pytest.warns(None):  # morph map maybe missing
+        with _record_warnings():  # morph map maybe missing
             label.morph(None, 'fsaverage', 5, verts, subjects_dir, 2)
     pytest.raises(TypeError, label.morph, None, 1, 5, verts,
                   subjects_dir, 2)
     pytest.raises(TypeError, label.morph, None, 'fsaverage', 5.5, verts,
                   subjects_dir, 2)
-    with pytest.warns(None):  # morph map maybe missing
+    with _record_warnings():  # morph map maybe missing
         label.smooth(subjects_dir=subjects_dir)  # make sure this runs
 
 

--- a/mne/tests/test_line_endings.py
+++ b/mne/tests/test_line_endings.py
@@ -4,7 +4,6 @@
 # License: BSD-3-Clause
 
 import os
-from unittest import SkipTest
 from os import path as op
 import sys
 
@@ -31,7 +30,7 @@ skip_files = (
 def _assert_line_endings(dir_):
     """Check line endings for a directory."""
     if sys.platform == 'win32':
-        raise SkipTest('Skipping line endings check on Windows')
+        pytest.skip('Skipping line endings check on Windows')
     report = list()
     good_exts = ('.py', '.dat', '.sel', '.lout', '.css', '.js', '.lay', '.txt',
                  '.elc', '.csd', '.sfp', '.json', '.hpts', '.vmrk', '.vhdr',

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -27,7 +27,8 @@ from mne.minimum_norm import (apply_inverse, read_inverse_operator,
 from mne.source_space import _add_interpolator, _grid_interp
 from mne.transforms import quat_to_rot
 from mne.utils import (requires_nibabel, check_version, requires_version,
-                       requires_dipy, requires_h5py, catch_logging)
+                       requires_dipy, requires_h5py, catch_logging,
+                       _record_warnings)
 from mne.fixes import _get_args
 
 # Setup paths
@@ -193,7 +194,7 @@ def test_surface_source_morph_round_trip(smooth, lower, upper, n_warn, dtype):
         with pytest.raises(ValueError, match='required to use nearest'):
             morph = compute_source_morph(stc, 'sample', 'fsaverage', **kwargs)
         return
-    with pytest.warns(None) as w:
+    with _record_warnings() as w:
         morph = compute_source_morph(stc, 'sample', 'fsaverage', **kwargs)
     w = [ww for ww in w if 'vertices not included' in str(ww.message)]
     assert len(w) == n_warn

--- a/mne/tests/test_morph_map.py
+++ b/mne/tests/test_morph_map.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_allclose
 from scipy import sparse
 
 from mne.datasets import testing
-from mne.utils import catch_logging
+from mne.utils import catch_logging, _record_warnings
 from mne import read_morph_map
 
 data_path = testing.data_path(download=False)
@@ -54,7 +54,7 @@ def test_make_morph_maps(tmp_path):
             assert_allclose(diff, np.zeros_like(diff), atol=1e-3, rtol=0)
 
     # This will also trigger creation, but it's trivial
-    with pytest.warns(None):
+    with _record_warnings():
         mmap = read_morph_map('sample', 'sample', subjects_dir=tempdir)
     for mm in mmap:
         assert (mm - sparse.eye(mm.shape[0], mm.shape[0])).sum() == 0

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -20,6 +20,7 @@ from mne.preprocessing import maxwell_filter
 from mne.proj import (read_proj, write_proj, make_eeg_average_ref_proj,
                       _has_eeg_average_ref_proj)
 from mne.rank import _compute_rank_int
+from mne.utils import _record_warnings
 
 base_dir = op.join(op.dirname(__file__), '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
@@ -87,7 +88,7 @@ def test_bad_proj():
 
 def _check_warnings(raw, events, picks=None, count=3):
     """Count warnings."""
-    with pytest.warns(None) as w:
+    with _record_warnings() as w:
         Epochs(raw, events, dict(aud_l=1, vis_l=3),
                -0.2, 0.5, picks=picks, preload=True, proj=True)
     assert len(w) == count

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -6,8 +6,8 @@ from contextlib import nullcontext
 from copy import deepcopy
 import os
 import os.path as op
-from shutil import copyfile
 import re
+from shutil import copyfile
 
 import numpy as np
 from numpy.fft import fft
@@ -45,7 +45,8 @@ from mne.minimum_norm import (read_inverse_operator, apply_inverse,
                               apply_inverse_epochs, make_inverse_operator)
 from mne.label import read_labels_from_annot, label_sign_flip
 from mne.utils import (requires_pandas, requires_sklearn, catch_logging,
-                       requires_h5py, requires_nibabel, requires_version)
+                       requires_h5py, requires_nibabel, requires_version,
+                       _record_warnings)
 from mne.io import read_raw_fif
 
 data_path = testing.data_path(download=False)
@@ -252,15 +253,15 @@ def test_save_vol_stc_as_nifti(tmp_path):
 
     stc.save_as_volume(vol_fname, src,
                        dest='surf', mri_resolution=False)
-    with pytest.warns(None):  # nib<->numpy
+    with _record_warnings():  # nib<->numpy
         img = nib.load(str(vol_fname))
     assert (img.shape == src[0]['shape'] + (len(stc.times),))
 
-    with pytest.warns(None):  # nib<->numpy
+    with _record_warnings():  # nib<->numpy
         t1_img = nib.load(fname_t1)
     stc.save_as_volume(tmp_path / 'stc.nii.gz', src,
                        dest='mri', mri_resolution=True)
-    with pytest.warns(None):  # nib<->numpy
+    with _record_warnings():  # nib<->numpy
         img = nib.load(str(vol_fname))
     assert (img.shape == t1_img.shape + (len(stc.times),))
     assert_allclose(img.affine, t1_img.affine, atol=1e-5)
@@ -886,7 +887,7 @@ def test_extract_label_time_course_volume(
             assert_allclose(_varexp(label_tc, label_tc), 1.)
             ve = _varexp(stc_back.data, stcs[0].data)
             assert 0.83 < ve < 0.85
-            with pytest.warns(None):  # ignore warnings about no output
+            with _record_warnings():  # ignore no output
                 label_tc_rt = extract_label_time_course(
                     stc_back, labels, src=src, mri_resolution=mri_res,
                     allow_empty=True)

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -22,7 +22,7 @@ from mne import (read_source_spaces, write_source_spaces,
                  read_bem_solution, read_freesurfer_lut,
                  read_trans)
 from mne.fixes import _get_img_fdata
-from mne.utils import (requires_nibabel, run_subprocess,
+from mne.utils import (requires_nibabel, run_subprocess, _record_warnings,
                        modified_env, requires_mne, check_version)
 from mne.surface import _accumulate_normals, _triangle_neighbors
 from mne.source_estimate import _get_src_type
@@ -452,7 +452,7 @@ def test_setup_source_space(tmp_path):
 
     # ico 5 (fsaverage) - write to temp file
     src = read_source_spaces(fname_ico)
-    with pytest.warns(None):  # sklearn equiv neighbors
+    with _record_warnings():  # sklearn equiv neighbors
         src_new = setup_source_space('fsaverage', spacing='ico5',
                                      subjects_dir=subjects_dir, add_dist=False)
     _compare_source_spaces(src, src_new, mode='approx')
@@ -464,7 +464,7 @@ def test_setup_source_space(tmp_path):
     # oct-6 (sample) - auto filename + IO
     src = read_source_spaces(fname)
     temp_name = tmp_path / 'temp-src.fif'
-    with pytest.warns(None):  # sklearn equiv neighbors
+    with _record_warnings():  # sklearn equiv neighbors
         src_new = setup_source_space('sample', spacing='oct6',
                                      subjects_dir=subjects_dir, add_dist=False)
         write_source_spaces(temp_name, src_new, overwrite=True)

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -21,7 +21,8 @@ from mne.surface import (_compute_nearest, _tessellate_sphere, fast_cross_3d,
                          _voxel_neighbors, warp_montage_volume)
 from mne.transforms import _get_trans, compute_volume_registration, apply_trans
 from mne.utils import (requires_vtk, catch_logging, object_diff,
-                       requires_freesurfer, requires_nibabel, requires_dipy)
+                       requires_freesurfer, requires_nibabel, requires_dipy,
+                       _record_warnings)
 
 data_path = testing.data_path(download=False)
 subjects_dir = op.join(data_path, 'subjects')
@@ -125,11 +126,11 @@ def test_io_surface(tmp_path):
     fname_tri = op.join(data_path, 'subjects', 'sample', 'bem',
                         'inner_skull.surf')
     for fname in (fname_quad, fname_tri):
-        with pytest.warns(None):  # no volume info
+        with _record_warnings():  # no volume info
             pts, tri, vol_info = read_surface(fname, read_metadata=True)
         write_surface(op.join(tempdir, 'tmp'), pts, tri, volume_info=vol_info,
                       overwrite=True)
-        with pytest.warns(None):  # no volume info
+        with _record_warnings():  # no volume info
             c_pts, c_tri, c_vol_info = read_surface(op.join(tempdir, 'tmp'),
                                                     read_metadata=True)
         assert_array_equal(pts, c_pts)

--- a/mne/time_frequency/tests/test_multitaper.py
+++ b/mne/time_frequency/tests/test_multitaper.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_array_almost_equal
 
 from mne.time_frequency import psd_multitaper
 from mne.time_frequency.multitaper import dpss_windows
-from mne.utils import requires_nitime
+from mne.utils import requires_nitime, _record_warnings
 from mne.io import RawArray
 from mne import create_info
 
@@ -18,7 +18,7 @@ def test_dpss_windows():
     Kmax = int(2 * half_nbw)
 
     dpss, eigs = dpss_windows(N, half_nbw, Kmax, low_bias=False)
-    with pytest.warns(None):  # conversions
+    with _record_warnings():  # conversions
         dpss_ni, eigs_ni = ni.algorithms.dpss_windows(N, half_nbw, Kmax)
 
     assert_array_almost_equal(dpss, dpss_ni)
@@ -26,7 +26,7 @@ def test_dpss_windows():
 
     dpss, eigs = dpss_windows(N, half_nbw, Kmax, interp_from=200,
                               low_bias=False)
-    with pytest.warns(None):  # conversions
+    with _record_warnings():  # conversions
         dpss_ni, eigs_ni = ni.algorithms.dpss_windows(N, half_nbw, Kmax,
                                                       interp_from=200)
 
@@ -51,7 +51,7 @@ def test_multitaper_psd():
             psd, freqs = psd_multitaper(raw, adaptive=adaptive,
                                         n_jobs=n_jobs,
                                         normalization=norm)
-            with pytest.warns(None):  # nitime integers
+            with _record_warnings():  # nitime integers
                 freqs_ni, psd_ni, _ = ni.algorithms.spectral.multi_taper_psd(
                     data, sfreq, adaptive=adaptive, jackknife=False)
             assert_array_almost_equal(psd, psd_ni, decimal=4)

--- a/mne/time_frequency/tests/test_stockwell.py
+++ b/mne/time_frequency/tests/test_stockwell.py
@@ -20,6 +20,7 @@ from mne.time_frequency._stockwell import (tfr_stockwell, _st,
                                            _st_power_itc)
 
 from mne.time_frequency import AverageTFR, tfr_array_stockwell
+from mne.utils import _record_warnings
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
@@ -42,7 +43,7 @@ def test_stockwell_check_input():
 
     for last_dim in (127, 128):
         data = np.zeros((2, 10, last_dim))
-        with pytest.warns(None):  # n_fft sometimes
+        with _record_warnings():  # n_fft sometimes
             x_in, n_fft, zero_pad = _check_input_st(data, None)
 
         assert_equal(x_in.shape, (2, 10, 128))

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -31,7 +31,7 @@ from .docs import (copy_function_doc_to_method_doc, copy_doc, linkcode_resolve,
 from .fetching import _url_to_local_path
 from ._logging import (verbose, logger, set_log_level, set_log_file,
                        use_log_level, catch_logging, warn, filter_out_warnings,
-                       wrapped_stdout, _get_call_line,
+                       wrapped_stdout, _get_call_line, _record_warnings,
                        ClosingStringIO)
 from .misc import (run_subprocess, _pl, _clean_names, pformat, _file_like,
                    _explain_exception, _get_argvalues, sizeof_fmt,

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -299,6 +299,15 @@ class catch_logging(object):
         set_log_file(None)
 
 
+@contextlib.contextmanager
+def _record_warnings():
+    # this is a helper that mostly acts like pytest.warns(None) did before
+    # pytest 7
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        yield w
+
+
 class WrapStdOut(object):
     """Dynamically wrap to sys.stdout.
 
@@ -399,28 +408,6 @@ def filter_out_warnings(warn_record, category=None, match=None):
 
     match : str | None
         text or regex that matches the error message to filter out
-
-    Examples
-    --------
-    This can be used as::
-
-        >>> import pytest
-        >>> import warnings
-        >>> from mne.utils import filter_out_warnings
-        >>> with pytest.warns(None) as recwarn:
-        ...     warnings.warn("value must be 0 or None", UserWarning)
-        >>> filter_out_warnings(recwarn, match=".* 0 or None")
-        >>> assert len(recwarn.list) == 0
-
-        >>> with pytest.warns(None) as recwarn:
-        ...     warnings.warn("value must be 42", UserWarning)
-        >>> filter_out_warnings(recwarn, match=r'.* must be \d+$')
-        >>> assert len(recwarn.list) == 0
-
-        >>> with pytest.warns(None) as recwarn:
-        ...     warnings.warn("this is not here", UserWarning)
-        >>> filter_out_warnings(recwarn, match=r'.* must be \d+$')
-        >>> assert len(recwarn.list) == 1
     """
     regexp = re.compile('.*' if match is None else match)
     is_category = [w.category == category if category is not None else True

--- a/mne/utils/tests/test_linalg.py
+++ b/mne/utils/tests/test_linalg.py
@@ -8,7 +8,8 @@ from numpy.testing import assert_allclose, assert_array_equal
 from scipy import linalg
 import pytest
 
-from mne.utils import _sym_mat_pow, _reg_pinv, requires_version
+from mne.utils import (_sym_mat_pow, _reg_pinv, requires_version,
+                       _record_warnings)
 from mne.fixes import _compare_version
 
 
@@ -41,7 +42,7 @@ def test_pos_semidef_inv(ndim, dtype, n, deficient, reduce_rank, psdef, func):
     if deficient:
         vec = np.ones(n) / np.sqrt(n)
         proj -= np.outer(vec, vec)
-    with pytest.warns(None):  # intentionally discard imag
+    with _record_warnings():  # intentionally discard imag
         mat = mat.astype(dtype)
     # now make it conjugate symmetric or positive semi-definite
     if psdef:

--- a/mne/utils/tests/test_testing.py
+++ b/mne/utils/tests/test_testing.py
@@ -15,7 +15,8 @@ def test_buggy_mkl():
     def foo(a, b):
         raise np.linalg.LinAlgError('SVD did not converge')
     with pytest.warns(RuntimeWarning, match='convergence error'):
-        pytest.raises(SkipTest, foo, 1, 2)
+        with pytest.raises(SkipTest):
+            foo(1, 2)
 
     @buggy_mkl_svd
     def bar(c, d, e):

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -34,7 +34,7 @@ from mne.viz import (plot_sparse_source_estimates, plot_source_estimates,
                      plot_brain_colorbar, link_brains, mne_analyze_colormap)
 from mne.viz._3d import _process_clim, _linearize_map, _get_map_ticks
 from mne.viz.utils import _fake_click
-from mne.utils import requires_nibabel, catch_logging
+from mne.utils import requires_nibabel, catch_logging, _record_warnings
 from mne.datasets import testing
 from mne.source_space import read_source_spaces
 from mne.transforms import Transform
@@ -91,7 +91,7 @@ def test_plot_head_positions():
     pos = np.random.RandomState(0).randn(4, 10)
     pos[:, 0] = np.arange(len(pos))
     destination = (0., 0., 0.04)
-    with pytest.warns(None):  # old MPL will cause a warning
+    with _record_warnings():  # old MPL will cause a warning
         plot_head_positions(pos)
         plot_head_positions(pos, mode='field', info=info,
                             destination=destination)
@@ -668,7 +668,7 @@ def test_plot_source_estimates(renderer_interactive, all_src_types_inv_evoked,
     backend = renderer_interactive._get_3d_backend()
     invs, evoked = all_src_types_inv_evoked
     inv = invs[kind]
-    with pytest.warns(None):  # PCA mag
+    with _record_warnings():  # PCA mag
         stc = apply_inverse(evoked, inv, pick_ori=pick_ori)
     stc.data[1] *= -1  # make it signed
     meth_key = 'plot_3d' if isinstance(stc, _BaseVolSourceEstimate) else 'plot'

--- a/mne/viz/tests/test_3d_mpl.py
+++ b/mne/viz/tests/test_3d_mpl.py
@@ -17,7 +17,7 @@ from mne import (read_forward_solution, VolSourceEstimate, SourceEstimate,
                  VolVectorSourceEstimate, compute_source_morph)
 from mne.datasets import testing
 from mne.utils import (requires_dipy, requires_nibabel, requires_version,
-                       catch_logging)
+                       catch_logging, _record_warnings)
 from mne.viz import plot_volume_source_estimates
 from mne.viz.utils import _fake_click
 
@@ -57,7 +57,8 @@ def test_plot_volume_source_estimates(mode, stype, init_t, want_t,
     else:
         assert stype == 's'
         stc = VolSourceEstimate(data, vertices, 1, 1)
-    with pytest.warns(None):  # sometimes get scalars/index warning
+    # sometimes get scalars/index warning
+    with _record_warnings():
         with catch_logging() as log:
             fig = stc.plot(
                 sample_src, subject='sample', subjects_dir=subjects_dir,
@@ -104,7 +105,8 @@ def test_plot_volume_source_estimates_morph():
     morph = compute_source_morph(sample_src, 'sample', 'fsaverage', zooms=5,
                                  subjects_dir=subjects_dir)
     initial_pos = (-0.05, -0.01, -0.006)
-    with pytest.warns(None):  # sometimes get scalars/index warning
+    # sometimes get scalars/index warning
+    with _record_warnings():
         with catch_logging() as log:
             stc.plot(morph, subjects_dir=subjects_dir, mode='glass_brain',
                      initial_pos=initial_pos, verbose=True)

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -14,7 +14,8 @@ from mne import (read_events, Epochs, read_cov, pick_types, Annotations,
                  make_fixed_length_events)
 from mne.io import read_raw_fif
 from mne.preprocessing import ICA, create_ecg_epochs, create_eog_epochs
-from mne.utils import requires_sklearn, _click_ch_name, catch_logging
+from mne.utils import (requires_sklearn, _click_ch_name, catch_logging,
+                       _record_warnings)
 from mne.viz.ica import _create_properties_layout, plot_ica_properties
 from mne.viz.utils import _fake_click
 
@@ -188,7 +189,8 @@ def test_plot_ica_properties():
     with pytest.warns(UserWarning, match='did not converge'):
         ica.fit(epochs)
     epochs._data[0] = 0
-    with pytest.warns(None):  # Usually UserWarning: Infinite value .* for epo
+    # Usually UserWarning: Infinite value .* for epo
+    with _record_warnings():
         ica.plot_properties(epochs, **topoargs)
     plt.close('all')
 

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -12,12 +12,11 @@ import matplotlib
 import matplotlib.pyplot as plt
 
 from mne import pick_types, Annotations, create_info
-from mne.datasets import testing
-from mne.utils import get_config, set_config
-from mne.io import RawArray
-from mne.utils import _dt_to_stamp
-from mne.viz.utils import _fake_click
 from mne.annotations import _sync_onset
+from mne.datasets import testing
+from mne.io import RawArray
+from mne.utils import get_config, set_config, _dt_to_stamp, _record_warnings
+from mne.viz.utils import _fake_click
 from mne.viz import plot_raw, plot_sensors
 
 
@@ -554,7 +553,7 @@ def test_plot_raw_meas_date(raw, browser_backend):
     annot = Annotations([1 + raw.first_samp / raw.info['sfreq']], [5], ['bad'])
     with pytest.warns(RuntimeWarning, match='outside data range'):
         raw.set_annotations(annot)
-    with pytest.warns(None):  # sometimes projection
+    with _record_warnings():  # sometimes projection
         raw.plot(group_by='position', order=np.arange(8))
     fig = raw.plot()
     for key in ['down', 'up', 'escape']:
@@ -566,7 +565,7 @@ def test_plot_raw_nan(raw, browser_backend):
     raw._data[:] = np.nan
     # this should (at least) not die, the output should pretty clearly show
     # that there is a problem so probably okay to just plot something blank
-    with pytest.warns(None):
+    with _record_warnings():
         raw.plot(scalings='auto')
 
 

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -6,8 +6,8 @@
 #
 # License: Simplified BSD
 
-import os.path as op
 from collections import namedtuple
+import os.path as op
 
 import numpy as np
 import pytest
@@ -19,6 +19,7 @@ from mne import (read_events, Epochs, pick_channels_evoked, read_cov,
 from mne.channels import read_layout
 from mne.io import read_raw_fif
 from mne.time_frequency.tfr import AverageTFR
+from mne.utils import _record_warnings
 
 from mne.viz import (plot_topo_image_epochs, _get_presser,
                      mne_analyze_colormap, plot_evoked_topo)
@@ -290,7 +291,7 @@ def test_plot_tfr_topo():
     # one timesample
     tfr = AverageTFR(epochs.info, data[:, :, [0]], epochs.times[[1]],
                      freqs, nave)
-    with pytest.warns(None):  # matplotlib equal left/right
+    with _record_warnings():  # matplotlib equal left/right
         tfr.plot([4], baseline=None, vmax=14., show=False, yscale='linear')
 
     # one frequency bin, log scale required: as it doesn't make sense

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -ef
 
+EXTRA_ARGS=""
 if [ "${TEST_MODE}" == "pip" ]; then
 	python -m pip install --upgrade pip setuptools wheel
 	python -m pip install --upgrade --only-binary ":all:" numpy scipy vtk
@@ -18,8 +19,9 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off --upgrade --pre --only-binary "vtk" vtk
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
+	EXTRA_ARGS="--pre"
 else
 	echo "Unknown run type ${TEST_MODE}"
 	exit 1
 fi
-python -m pip install .[test] codecov
+python -m pip install $EXTRA_ARGS .[test] codecov

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -1,27 +1,29 @@
 #!/bin/bash -ef
 
+STD_ARGS="--progress-bar off --upgrade"
+EXTRA_ARGS=""
 if [ ! -z "$CONDA_ENV" ]; then
 	pip uninstall -yq mne
 elif [ ! -z "$CONDA_DEPENDENCIES" ]; then
 	conda install -y $CONDA_DEPENDENCIES
 else
 	# Changes here should also go in the interactive_test CircleCI job
-	python -m pip install --progress-bar off --upgrade pip setuptools wheel
+	python -m pip install $STD_ARGS pip setuptools wheel
 	echo "Numpy"
 	pip uninstall -yq numpy
 	echo "Date utils"
 	# https://pip.pypa.io/en/latest/user_guide/#possible-ways-to-reduce-backtracking-occurring
-	pip install --progress-bar off --upgrade --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl six
+	pip install $STD_ARGS --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl six
 	echo "PyQt5"
-	pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt5 PyQt5-sip PyQt5-Qt5
+	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt5 PyQt5-sip PyQt5-Qt5
 	echo "NumPy/SciPy/pandas etc."
-	pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy pandas "scikit-learn>=0.24.2" statsmodels dipy
+	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy pandas "scikit-learn>=0.24.2" statsmodels dipy
 	echo "H5py, pillow, matplotlib"
-	pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py pillow matplotlib
+	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py pillow matplotlib
 	echo "nilearn"
-	pip install --progress-bar off --upgrade --pre --only-binary ":all:" https://github.com/nilearn/nilearn/zipball/main
+	pip install $STD_ARGS --pre --only-binary ":all:" https://github.com/nilearn/nilearn/zipball/main
 	echo "VTK"
-	pip install --progress-bar off --upgrade --pre --only-binary "vtk" vtk
+	pip install $STD_ARGS --pre --only-binary "vtk" vtk
 	echo "PyVista"
 	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
 	echo "pyvistaqt"
@@ -31,9 +33,10 @@ else
 	if [ "$OSTYPE" == "darwin"* ]; then
 	  echo "pyobjc-framework-Cocoa"
 	  pip install --progress-bar off pyobjc-framework-Cocoa>=5.2.0
-  fi
+	fi
+	EXTRA_ARGS="--pre"
 fi
-pip install --progress-bar off --upgrade -r requirements_testing.txt
+pip install $STD_ARGS $EXTRA_ARGS -r requirements_testing.txt
 if [ "${DEPS}" != "minimal" ]; then
-	pip install --progress-bar off --upgrade -r requirements_testing_extra.txt
+	pip install $STD_ARGS $EXTRA_ARGS -r requirements_testing_extra.txt
 fi


### PR DESCRIPTION
Pytest 7 deprecates `pytest.warns(None)`, so let's just use `catch_warnings(record=True)` plus `warnings.simplefilter('always')` using a little wrapper to get the same behavior.

This PR updates the `pip-pre` CIs to install our testing reqs with `--pre`, so we'll see if we have anything else to fix!