### PR TITLE
Clarify which NIRx devices we support

### DIFF
--- a/tutorials/io/30_reading_fnirs_data.py
+++ b/tutorials/io/30_reading_fnirs_data.py
@@ -84,7 +84,7 @@ The NIRx device stores data directly to a directory with multiple file types,
 MNE-Python extracts the appropriate information from each file.
 MNE-Python only supports NIRx files recorded with NIRStar
 version 15.0 and above.
-MNE-Python supports reading data from NIRScout and NIRSport 1 devices.
+MNE-Python supports reading data from NIRScout and NIRSport devices.
 
 
 .. _import-hitachi:


### PR DESCRIPTION
#### Reference issue
A user noted that we explicitly only supported NIRx NIRScout and NIRSport 1 devices https://mne.discourse.group/t/interpolation-of-bad-channels-in-fnirs-data/4100/6

However, we actually support all NIRSport devices #9401

#### What does this implement/fix?

Modified text

