### PR TITLE
MRG: Limit max width of figures we auto-create in mne.Report – Reduce report file size

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -62,6 +62,8 @@ Enhancements
 
 - Drastically speed up butterfly plot generation in :meth:`mne.Report.add_raw`. We now don't plot annotations anymore; however, we feel that the speed improvements justify this change, also considering the annotations were of limited use in the displayed one-second time slices anyway (:gh:`10114`, :gh:`10116` by `Richard Höchenberger`_)
 
+- In :class:`mne.Report`, limit the width of automatically generated figures to a maximum of 850 pixels to reduce file size and memory consumption (:gh:`10126` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -1464,9 +1464,7 @@ class Report(object):
         title = 'ICA component properties'
         # Only render a slider if we have more than 1 component.
         if len(figs) == 1:
-            fig = figs[0]
-            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
-            img = _fig_to_img(fig=fig, image_format=image_format)
+            img = _fig_to_img(fig=figs[0], image_format=image_format)
             dom_id = self._get_dom_id()
             properties_html = _html_image_element(
                 img=img, div_klass='ica', img_klass='ica',

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -321,7 +321,7 @@ def _check_tags(tags) -> Tuple[str]:
 
 
 def _constrain_fig_resolution(fig, width):
-    """Limit the resolution (DPI) of a figure
+    """Limit the resolution (DPI) of a figure.
 
     Parameters
     ----------

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -104,6 +104,8 @@ template_dir = Path(__file__).parent / 'templates'
 JAVASCRIPT = (html_include_dir / 'report.js').read_text(encoding='utf-8')
 CSS = (html_include_dir / 'report.sass').read_text(encoding='utf-8')
 
+MAX_IMG_WIDTH = 850  # in pixels
+
 
 def _get_ch_types(inst):
     return [ch_type for ch_type in _DATA_CH_TYPES_SPLIT if ch_type in inst]
@@ -317,6 +319,25 @@ def _check_tags(tags) -> Tuple[str]:
 ###############################################################################
 # PLOTTING FUNCTIONS
 
+
+def _constrain_fig_resolution(fig, width):
+    """Limit the resolution (DPI) of a figure
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure whose DPI to adjust.
+    width : int
+        The max. allowed width, in pixels.
+
+    Returns
+    -------
+    Nothing, alters the figure's properties in-place.
+    """
+    dpi = min(fig.get_dpi(), MAX_IMG_WIDTH / fig.get_size_inches()[0])
+    fig.set_dpi(dpi)
+
+
 def _fig_to_img(fig, *, image_format='png', auto_close=True):
     """Plot figure and create a binary image."""
     # fig can be ndarray, mpl Figure, PyVista Figure
@@ -324,6 +345,7 @@ def _fig_to_img(fig, *, image_format='png', auto_close=True):
     from matplotlib.figure import Figure
     if isinstance(fig, np.ndarray):
         fig = _ndarray_to_fig(fig)
+        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
     elif not isinstance(fig, Figure):
         from ..viz.backends.renderer import backend, MNE_3D_BACKEND_TESTING
         backend._check_3d_figure(figure=fig)
@@ -335,10 +357,13 @@ def _fig_to_img(fig, *, image_format='png', auto_close=True):
         if auto_close:
             backend._close_3d_figure(figure=fig)
         fig = _ndarray_to_fig(img)
+        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
 
     output = BytesIO()
-    logger.debug('Saving figure %s with dpi %s'
-                 % (fig.get_size_inches(), fig.get_dpi()))
+    logger.debug(
+        f'Saving figure with dimension {fig.get_size_inches()} inches with '
+        f'{fig.get_dpi()} dpi'
+    )
 
     with warnings.catch_warnings():
         warnings.filterwarnings(
@@ -464,7 +489,6 @@ def _itv(function, fig, **kwargs):
                               subjects_dir=kwargs['subjects_dir'])
 
     img = _fig_to_img(images, image_format='png')
-
     caption = (f'Average distance from {len(dists)} digitized points to '
                f'head: {1e3 * np.mean(dists):.2f} mm')
 
@@ -488,10 +512,12 @@ def _plot_ica_properties_as_arrays(*, ica, inst, picks, n_jobs):
         figs = ica.plot_properties(inst=inst, picks=pick, show=False)
         assert len(figs) == 1
         fig = figs[0]
-
+        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
         with io.BytesIO() as buff:
             fig.savefig(
-                buff, format='png', dpi=fig.get_dpi(), pad_inches=0,
+                buff,
+                format='png',
+                pad_inches=0,
             )
             buff.seek(0)
             fig_array = plt.imread(buff, format='png')
@@ -1392,6 +1418,7 @@ class Report(object):
         fig = ica.plot_overlay(inst=inst_, show=False)
         del inst_
         tight_layout(fig=fig)
+        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
         img = _fig_to_img(fig, image_format=image_format)
         dom_id = self._get_dom_id()
         overlay_html = _html_image_element(
@@ -1437,7 +1464,9 @@ class Report(object):
         title = 'ICA component properties'
         # Only render a slider if we have more than 1 component.
         if len(figs) == 1:
-            img = _fig_to_img(fig=figs[0], image_format=image_format)
+            fig = figs[0]
+            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+            img = _fig_to_img(fig=fig, image_format=image_format)
             dom_id = self._get_dom_id()
             properties_html = _html_image_element(
                 img=img, div_klass='ica', img_klass='ica',
@@ -1455,6 +1484,7 @@ class Report(object):
     def _render_ica_artifact_sources(self, *, ica, inst, artifact_type,
                                      image_format, tags):
         fig = ica.plot_sources(inst=inst, show=False)
+        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
         img = _fig_to_img(fig, image_format=image_format)
         dom_id = self._get_dom_id()
         html = _html_image_element(
@@ -1467,6 +1497,7 @@ class Report(object):
     def _render_ica_artifact_scores(self, *, ica, scores, artifact_type,
                                     image_format, tags):
         fig = ica.plot_scores(scores=scores, title=None, show=False)
+        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
         img = _fig_to_img(fig, image_format=image_format)
         dom_id = self._get_dom_id()
         html = _html_image_element(
@@ -1496,7 +1527,9 @@ class Report(object):
 
         title = 'ICA component topographies'
         if len(figs) == 1:
-            img = _fig_to_img(fig=figs[0], image_format=image_format)
+            fig = figs[0]
+            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+            img = _fig_to_img(fig=fig, image_format=image_format)
             dom_id = self._get_dom_id()
             topographies_html = _html_image_element(
                 img=img, div_klass='ica', img_klass='ica',
@@ -2600,6 +2633,7 @@ class Report(object):
                 butterfly=True, show_scrollbars=False, start=t_starts[0],
                 duration=durations[0], scalings=scalings, show=False
             )
+            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
             images = [_fig_to_img(fig=fig, image_format=image_format)]
 
             for start, duration in zip(t_starts[1:], durations[1:]):
@@ -2671,6 +2705,7 @@ class Report(object):
 
             fig = raw.plot_psd(fmax=fmax, show=False, **add_psd)
             tight_layout(fig=fig)
+            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
 
             img = _fig_to_img(fig, image_format=image_format)
             psd_img_html = _html_image_element(
@@ -2743,6 +2778,7 @@ class Report(object):
         # number-of-channel-types conditions...
         fig.set_size_inches((6, 4))
         tight_layout(fig=fig)
+        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
         img = _fig_to_img(fig=fig, image_format=image_format)
 
         dom_id = self._get_dom_id()
@@ -2849,6 +2885,7 @@ class Report(object):
                     topomap_args=topomap_kwargs,
                 )
 
+            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
             img = _fig_to_img(fig=fig, image_format=image_format)
             title = f'Time course ({_handle_default("titles")[ch_type]})'
             dom_id = self._get_dom_id()
@@ -2896,11 +2933,12 @@ class Report(object):
             ch_type_ax_map[ch_type][0].set_title(ch_type)
 
         tight_layout(fig=fig)
+        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
 
         with BytesIO() as buff:
             fig.savefig(
-                buff, format='png',
-                dpi=fig.get_dpi(),
+                buff,
+                format='png',
                 pad_inches=0
             )
             plt.close(fig)
@@ -3014,6 +3052,7 @@ class Report(object):
                 ax[idx].set_xlabel(None)
 
         tight_layout(fig=fig)
+        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
         img = _fig_to_img(fig=fig, image_format=image_format)
         title = 'Global field power'
         html = _html_image_element(
@@ -3039,6 +3078,7 @@ class Report(object):
             show=False
         )
         tight_layout(fig=fig)
+        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
         img = _fig_to_img(fig=fig, image_format=image_format)
         title = 'Whitened'
 
@@ -3100,7 +3140,7 @@ class Report(object):
             first_samp=first_samp,
             show=False
         )
-
+        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
         img = _fig_to_img(
             fig=fig,
             image_format=image_format,
@@ -3168,6 +3208,7 @@ class Report(object):
                 fmax = np.inf
 
             fig = epochs_for_psd.plot_psd(fmax=fmax, show=False)
+            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
             img = _fig_to_img(fig=fig, image_format=image_format)
             duration = round(epoch_duration * len(epochs_for_psd), 1)
             caption = (
@@ -3216,6 +3257,7 @@ class Report(object):
 
             assert len(figs) == 1
             fig = figs[0]
+            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
             img = _fig_to_img(fig=fig, image_format=image_format)
             if ch_type in ('mag', 'grad'):
                 title_start = 'ERF image'
@@ -3254,6 +3296,7 @@ class Report(object):
             else:
                 fig = epochs.plot_drop_log(subject=self.subject, show=False)
                 tight_layout(fig=fig)
+                _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
                 img = _fig_to_img(fig=fig, image_format=image_format)
                 drop_log_img_html = _html_image_element(
                     img=img, id=dom_id, div_klass='epochs', img_klass='epochs',
@@ -3292,8 +3335,9 @@ class Report(object):
         )
 
         for fig, title in zip(figs, titles):
-            dom_id = self._get_dom_id()
+            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
             img = _fig_to_img(fig=fig, image_format=image_format)
+            dom_id = self._get_dom_id()
             html = _html_image_element(
                 img=img, id=dom_id, div_klass='covariance',
                 img_klass='covariance', title=title, caption=None,

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -5,12 +5,12 @@ Getting started with :class:`mne.Report`
 ========================================
 
 `mne.Report` is a way to create interactive HTML summaries of your data. These
-reports can show many different visualizations of one or multiple subject's
-data. A common use case is creating diagnostic summaries to check data quality
-at different stages in the processing pipeline. The report can show things like
-plots of data before and after each preprocessing step, epoch rejection
-statistics, MRI slices with overlaid BEM shells, all the way up to plots of
-estimated cortical activity.
+reports can show many different visualizations for one or multiple
+participants. A common use case is creating diagnostic summaries to check data
+quality at different stages in the processing pipeline. The report can show
+things like plots of data before and after each preprocessing step, epoch
+rejection statistics, MRI slices with overlaid BEM shells, all the way up to
+plots of estimated cortical activity.
 
 Compared to a Jupyter notebook, `mne.Report` is easier to deploy (the HTML
 pages it generates are self-contained and do not require a running Python


### PR DESCRIPTION
The max. width of auto-generated figures is now 850 pixels. For user-supplied figures, the existing resolution is preserved.

It doesn't change processing speed on my laptop, however there's a significant impact on file size. Running the `intro/70_report.py` tutorial, the cumulated size of the generated reports is:

```
main: 51 MB
pr:   31 MB
```
so this is a reduction of 40%. The quality of the embedded figures seems only minimally worse on my screen, and definitely sufficient for a summary report.