### PR TITLE
BUG: Add some missing overwrites

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -115,6 +115,8 @@ Bugs
 
 - Creating :class:`mne.Epochs` now provides clearer logging (less ambiguous, no duplicates) when the ``preload`` and/or ``metadata`` parameters are set (:gh:`10112` by `Stefan Appelhoff`_)
 
+- Fix functions by adding missing ``overwrite`` parameters: :func:`mne.write_events`, :func:`mne.write_cov`, :func:`mne.write_evokeds`, :meth:`mne.SourceEstimate.save`, :func:`mne.minimum_norm.write_inverse_operator`, :func:`mne.write_proj`, and related methods (:gh:`10127` by `Eric Larson`_)
+
 - Remove repeated logging output when overwriting an existing `~mne.io.Raw` file (:gh:`10095` by `Richard Höchenberger`_ and `Stefan Appelhoff`_)
 
 API changes

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -310,14 +310,16 @@ class Resetter(object):
         plt.rcParams['animation.embed_limit'] = 30.
         gc.collect()
         when = 'mne/conf.py:Resetter.__call__'
-        _assert_no_instances(Brain, when)  # calls gc.collect()
-        if Plotter is not None:
-            _assert_no_instances(Plotter, when)
-        if BackgroundPlotter is not None:
-            _assert_no_instances(BackgroundPlotter, when)
-        if vtkPolyData is not None:
-            _assert_no_instances(vtkPolyData, when)
-        _assert_no_instances(_Renderer, when)
+        if os.getenv('MNE_SKIP_INSTANCE_ASSERTIONS', 'false') not in \
+                ('true', '1'):
+            _assert_no_instances(Brain, when)  # calls gc.collect()
+            if Plotter is not None:
+                _assert_no_instances(Plotter, when)
+            if BackgroundPlotter is not None:
+                _assert_no_instances(BackgroundPlotter, when)
+            if vtkPolyData is not None:
+                _assert_no_instances(vtkPolyData, when)
+            _assert_no_instances(_Renderer, when)
         # This will overwrite some Sphinx printing but it's useful
         # for memory timestamps
         if os.getenv('SG_STAMP_STARTS', '').lower() == 'true':
@@ -821,6 +823,8 @@ def reset_warnings(gallery_conf, fname):
         'ignore', '.*invalid escape sequence.*', lineno=281)  # mne-conn
     warnings.filterwarnings(
         'ignore', '.*"is not" with a literal.*', module='nilearn')
+    warnings.filterwarnings(  # scikit-learn FastICA whiten=True deprecation
+        'ignore', r'.*From version 1\.3 whiten.*')
     for key in ('HasTraits', r'numpy\.testing', 'importlib', r'np\.loads',
                 'Using or importing the ABCs from',  # internal modules on 3.7
                 r"it will be an error for 'np\.bool_'",  # ndimage

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -20,9 +20,8 @@ import numpy as np
 
 from .io.constants import FIFF, FWD
 from .io._digitization import _dig_kind_dict, _dig_kind_rev, _dig_kind_ints
-from .io.write import (start_file, start_block, write_float, write_int,
-                       write_float_matrix, write_int_matrix, end_block,
-                       end_file)
+from .io.write import (start_and_end_file, start_block, write_float, write_int,
+                       write_float_matrix, write_int_matrix, end_block)
 from .io.tag import find_tag
 from .io.tree import dir_tree_find
 from .io.open import fiff_open
@@ -1560,12 +1559,11 @@ def write_bem_surfaces(fname, surfs, overwrite=False, verbose=None):
     if fname.endswith('.h5'):
         write_hdf5(fname, dict(surfs=surfs), overwrite=True)
     else:
-        with start_file(fname) as fid:
+        with start_and_end_file(fname) as fid:
             start_block(fid, FIFF.FIFFB_BEM)
             write_int(fid, FIFF.FIFF_BEM_COORD_FRAME, surfs[0]['coord_frame'])
             _write_bem_surfaces_block(fid, surfs)
             end_block(fid, FIFF.FIFFB_BEM)
-            end_file(fid)
 
 
 @verbose
@@ -1637,7 +1635,7 @@ def write_bem_solution(fname, bem, overwrite=False, verbose=None):
 
 def _write_bem_solution_fif(fname, bem):
     _check_bem_size(bem['surfs'])
-    with start_file(fname) as fid:
+    with start_and_end_file(fname) as fid:
         start_block(fid, FIFF.FIFFB_BEM)
         # Coordinate frame (mainly for backward compatibility)
         write_int(fid, FIFF.FIFF_BEM_COORD_FRAME,
@@ -1652,7 +1650,6 @@ def _write_bem_solution_fif(fname, bem):
             write_float_matrix(fid, FIFF.FIFF_BEM_POT_SOLUTION,
                                bem['solution'])
         end_block(fid, FIFF.FIFFB_BEM)
-        end_file(fid)
 
 
 # #############################################################################

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -215,16 +215,19 @@ class DigMontage(object):
         rename_channels(temp_info, mapping, allow_duplicates)
         self.ch_names = temp_info['ch_names']
 
-    def save(self, fname):
+    @verbose
+    def save(self, fname, *, overwrite=False, verbose=None):
         """Save digitization points to FIF.
 
         Parameters
         ----------
         fname : str
             The filename to use. Should end in .fif or .fif.gz.
+        %(overwrite)s
+        %(verbose)s
         """
         coord_frame = _check_get_coord_frame(self.dig)
-        write_dig(fname, self.dig, coord_frame)
+        write_dig(fname, self.dig, coord_frame, overwrite=overwrite)
 
     def __iadd__(self, other):
         """Add two DigMontages in place.

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1089,7 +1089,7 @@ def test_set_montage_mgh(rename):
 # XXX: this does not check ch_names + it cannot work because of write_dig
 def _check_roundtrip(montage, fname, coord_frame='head'):
     """Check roundtrip writing."""
-    montage.save(fname)
+    montage.save(fname, overwrite=True)
     montage_read = read_dig_fif(fname=fname)
 
     assert_equal(repr(montage), repr(montage_read))

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1016,7 +1016,7 @@ def scale_mri(subject_from, subject_to, scale, overwrite=False,
         for pt in pts:
             pt['r'] = pt['r'] * scale
         dest = fname.format(subject=subject_to, subjects_dir=subjects_dir)
-        write_fiducials(dest, pts, cframe, verbose=False)
+        write_fiducials(dest, pts, cframe, overwrite=True, verbose=False)
 
     logger.debug('MRIs [nibabel]')
     os.mkdir(mri_dirname.format(subjects_dir=subjects_dir,

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -7,12 +7,11 @@
 from copy import deepcopy
 import itertools as itt
 from math import log
-import os
 
 import numpy as np
 
 from .defaults import _EXTRAPOLATE_DEFAULT, _BORDER_DEFAULT, DEFAULTS
-from .io.write import start_file, end_file
+from .io.write import start_and_end_file
 from .io.proj import (make_projector, _proj_equal, activate_proj,
                       _check_projs, _needs_eeg_average_ref_proj,
                       _has_eeg_average_ref_proj, _read_proj, _write_proj)
@@ -142,28 +141,24 @@ class Covariance(dict):
         """Number of degrees of freedom."""
         return self['nfree']
 
-    def save(self, fname):
+    @verbose
+    def save(self, fname, *, overwrite=False, verbose=None):
         """Save covariance matrix in a FIF file.
 
         Parameters
         ----------
         fname : str
             Output filename.
+        %(overwrite)s
+
+            .. versionadded:: 1.0
+        %(verbose)s
         """
         check_fname(fname, 'covariance', ('-cov.fif', '-cov.fif.gz',
                                           '_cov.fif', '_cov.fif.gz'))
-        # TODO: Add `overwrite` param to method signature
-        fname = _check_fname(fname=fname, overwrite=True)
-        fid = start_file(fname)
-
-        try:
+        fname = _check_fname(fname=fname, overwrite=overwrite)
+        with start_and_end_file(fname) as fid:
             _write_cov(fid, self)
-        except Exception:
-            fid.close()
-            os.remove(fname)
-            raise
-
-        end_file(fid)
 
     def copy(self):
         """Copy the Covariance object.
@@ -1367,7 +1362,8 @@ class _ShrunkCovariance(BaseEstimator):
 ###############################################################################
 # Writing
 
-def write_cov(fname, cov):
+@verbose
+def write_cov(fname, cov, *, overwrite=False, verbose=None):
     """Write a noise covariance matrix.
 
     Parameters
@@ -1376,12 +1372,16 @@ def write_cov(fname, cov):
         The name of the file. It should end with -cov.fif or -cov.fif.gz.
     cov : Covariance
         The noise covariance matrix.
+    %(overwrite)s
+
+        .. versionadded:: 1.0
+    %(verbose)s
 
     See Also
     --------
     read_cov
     """
-    cov.save(fname)
+    cov.save(fname, overwrite=overwrite, verbose=verbose)
 
 
 ###############################################################################

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -21,7 +21,7 @@ import os.path as op
 import numpy as np
 
 from .io.utils import _construct_bids_filename
-from .io.write import (start_file, start_block, end_file, end_block,
+from .io.write import (start_and_end_file, start_block, end_block,
                        write_int, write_float, write_float_matrix,
                        write_double_matrix, write_complex_float_matrix,
                        write_complex_double_matrix, write_id, write_string,
@@ -105,7 +105,7 @@ def _save_split(epochs, fname, part_idx, n_parts, fmt, split_naming,
     else:
         next_idx = None
 
-    with start_file(fname) as fid:
+    with start_and_end_file(fname) as fid:
         _save_part(fid, epochs, fmt, n_parts, next_fname, next_idx)
 
 
@@ -202,7 +202,6 @@ def _save_part(fid, epochs, fmt, n_parts, next_fname, next_idx):
     end_block(fid, FIFF.FIFFB_MNE_EPOCHS)
     end_block(fid, FIFF.FIFFB_PROCESSED_DATA)
     end_block(fid, FIFF.FIFFB_MEAS)
-    end_file(fid)
 
 
 def _event_id_string(event_id):

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -37,7 +37,7 @@ from .io.meas_info import (read_meas_info, write_meas_info,
                            _read_extended_ch_info, _rename_list,
                            _ensure_infos_match)
 from .io.proj import ProjMixin
-from .io.write import (start_file, start_block, end_file, end_block,
+from .io.write import (start_and_end_file, start_block, end_block,
                        write_int, write_string, write_float_matrix,
                        write_id, write_float, write_complex_float_matrix)
 from .io.base import TimeMixin, _check_maxshield, _get_ch_factors
@@ -278,7 +278,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         return self
 
-    def save(self, fname):
+    @verbose
+    def save(self, fname, *, overwrite=False, verbose=None):
         """Save evoked data to a file.
 
         Parameters
@@ -286,6 +287,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         fname : str
             The name of the file, which should end with ``-ave.fif(.gz)`` or
             ``_ave.fif(.gz)``.
+        %(overwrite)s
+        %(verbose)s
 
         Notes
         -----
@@ -296,9 +299,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             Information on baseline correction will be stored with the data,
             and will be restored when reading again via `mne.read_evokeds`.
         """
-        # TODO: Add `overwrite` param to method signature
-        fname = _check_fname(fname=fname, overwrite=True)
-        write_evokeds(fname, self)
+        write_evokeds(fname, self, overwrite=overwrite)
 
     def __repr__(self):  # noqa: D105
         max_comment_length = 1000
@@ -1373,7 +1374,8 @@ def _read_evoked(fname, condition=None, kind='average', allow_maxshield=False):
 
 
 @verbose
-def write_evokeds(fname, evoked, *, on_mismatch='raise', verbose=None):
+def write_evokeds(fname, evoked, *, on_mismatch='raise', overwrite=False,
+                  verbose=None):
     """Write an evoked dataset to a file.
 
     Parameters
@@ -1385,6 +1387,9 @@ def write_evokeds(fname, evoked, *, on_mismatch='raise', verbose=None):
         Note that the measurement info from the first evoked instance is used,
         so be sure that information matches.
     %(on_info_mismatch)s
+    %(overwrite)s
+
+        .. versionadded:: 1.0
     %(verbose)s
 
         .. versionadded:: 0.24
@@ -1400,25 +1405,25 @@ def write_evokeds(fname, evoked, *, on_mismatch='raise', verbose=None):
         `~mne.Evoked` object, and will be restored when reading the data again
         via `mne.read_evokeds`.
     """
-    _write_evokeds(fname, evoked, on_mismatch=on_mismatch)
+    _write_evokeds(fname, evoked, on_mismatch=on_mismatch, overwrite=overwrite)
 
 
-def _write_evokeds(fname, evoked, check=True, *, on_mismatch='raise'):
+def _write_evokeds(fname, evoked, check=True, *, on_mismatch='raise',
+                   overwrite=False):
     """Write evoked data."""
     from .dipole import DipoleFixed  # avoid circular import
 
+    fname = _check_fname(fname=fname, overwrite=overwrite)
     if check:
         check_fname(fname, 'evoked', ('-ave.fif', '-ave.fif.gz',
                                       '_ave.fif', '_ave.fif.gz'))
-    # TODO: Add `overwrite` param to method signature
-    fname = _check_fname(fname=fname, overwrite=True)
 
     if not isinstance(evoked, (list, tuple)):
         evoked = [evoked]
 
     warned = False
     # Create the file and save the essentials
-    with start_file(fname) as fid:
+    with start_and_end_file(fname) as fid:
 
         start_block(fid, FIFF.FIFFB_MEAS)
         write_id(fid, FIFF.FIFF_BLOCK_ID)
@@ -1487,7 +1492,6 @@ def _write_evokeds(fname, evoked, check=True, *, on_mismatch='raise'):
 
         end_block(fid, FIFF.FIFFB_PROCESSED_DATA)
         end_block(fid, FIFF.FIFFB_MEAS)
-        end_file(fid)
 
 
 def _get_peak(data, times, tmin=None, tmax=None, mode='abs'):

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -32,7 +32,7 @@ from ..io.pick import (pick_channels_forward, pick_info, pick_channels,
                        pick_types)
 from ..io.write import (write_int, start_block, end_block,
                         write_coord_trans, write_name_list,
-                        write_string, start_file, end_file, write_id)
+                        write_string, start_and_end_file, write_id)
 from ..io.base import BaseRaw
 from ..evoked import Evoked, EvokedArray
 from ..epochs import BaseEpochs
@@ -752,7 +752,11 @@ def write_forward_solution(fname, fwd, overwrite=False, verbose=None):
 
     # check for file existence and expand `~` if present
     fname = _check_fname(fname, overwrite)
-    fid = start_file(fname)
+    with start_and_end_file(fname) as fid:
+        _write_forward_solution(fid, fwd)
+
+
+def _write_forward_solution(fid, fwd):
     start_block(fid, FIFF.FIFFB_MNE)
 
     #
@@ -887,7 +891,6 @@ def write_forward_solution(fname, fwd, overwrite=False, verbose=None):
         end_block(fid, FIFF.FIFFB_MNE_FORWARD_SOLUTION)
 
     end_block(fid, FIFF.FIFFB_MNE)
-    end_file(fid)
 
 
 def is_fixed_orient(forward, orig=False):

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -28,7 +28,7 @@ from .tag import (read_tag, find_tag, _ch_coord_dict, _update_ch_info_named,
 from .proj import (_read_proj, _write_proj, _uniquify_projs, _normalize_proj,
                    _proj_equal, Projection)
 from .ctf_comp import _read_ctf_comp, write_ctf_comp
-from .write import (start_file, end_file, start_block, end_block,
+from .write import (start_and_end_file, start_block, end_block,
                     write_string, write_dig_points, write_float, write_int,
                     write_coord_trans, write_ch_info, write_name_list,
                     write_julian, write_float_matrix, write_id, DATE_NONE)
@@ -40,7 +40,7 @@ from ..utils import (logger, verbose, warn, object_diff, _validate_type,
                      _check_option, _on_missing, _check_on_missing, fill_doc)
 from ._digitization import (_format_dig_points, _dig_kind_proper, DigPoint,
                             _dig_kind_rev, _dig_kind_ints, _read_dig_fif)
-from ._digitization import write_dig as _dig_write_dig
+from ._digitization import write_dig
 from .compensator import get_current_comp
 from ..data.html_templates import info_template
 from ..defaults import _handle_default
@@ -1156,8 +1156,8 @@ def read_fiducials(fname, verbose=None):
 
 
 @verbose
-def write_fiducials(fname, pts, coord_frame=FIFF.FIFFV_COORD_UNKNOWN,
-                    verbose=None):
+def write_fiducials(fname, pts, coord_frame=FIFF.FIFFV_COORD_UNKNOWN, *,
+                    overwrite=False, verbose=None):
     """Write fiducials to a fiff file.
 
     Parameters
@@ -1170,27 +1170,12 @@ def write_fiducials(fname, pts, coord_frame=FIFF.FIFFV_COORD_UNKNOWN,
     coord_frame : int
         The coordinate frame of the points (one of
         mne.io.constants.FIFF.FIFFV_COORD_...).
+    %(overwrite)s
+
+        .. versionadded:: 1.0
     %(verbose)s
     """
-    _dig_write_dig(fname, pts, coord_frame)
-
-
-def write_dig(fname, pts, coord_frame=None):
-    """Write digitization data to a FIF file.
-
-    Parameters
-    ----------
-    fname : str
-        Destination file name.
-    pts : iterator of dict
-        Iterator through digitizer points. Each point is a dictionary with
-        the keys 'kind', 'ident' and 'r'.
-    coord_frame : int | str | None
-        If all the points have the same coordinate frame, specify the type
-        here. Can be None (default) if the points could have varying
-        coordinate frames.
-    """
-    return _dig_write_dig(fname, pts, coord_frame=coord_frame)
+    write_dig(fname, pts, coord_frame, overwrite=overwrite)
 
 
 @verbose
@@ -2078,11 +2063,10 @@ def write_info(fname, info, data_type=None, reset_range=True):
     reset_range : bool
         If True, info['chs'][k]['range'] will be set to unity.
     """
-    with start_file(fname) as fid:
+    with start_and_end_file(fname) as fid:
         start_block(fid, FIFF.FIFFB_MEAS)
         write_meas_info(fid, info, data_type, reset_range)
         end_block(fid, FIFF.FIFFB_MEAS)
-        end_file(fid)
 
 
 @verbose

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -172,7 +172,8 @@ def test_fiducials_io(tmp_path):
 
     # test safeguards
     pts[0]['coord_frame'] += 1
-    pytest.raises(ValueError, write_fiducials, temp_fname, pts, coord_frame)
+    with pytest.raises(ValueError, match='coord_frame entries that are incom'):
+        write_fiducials(temp_fname, pts, coord_frame, overwrite=True)
 
 
 def test_info():

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -3,6 +3,7 @@
 #
 # License: BSD-3-Clause
 
+from contextlib import contextmanager
 from gzip import GzipFile
 import os.path as op
 import re
@@ -331,6 +332,14 @@ def start_file(fname, id_=None):
     write_int(fid, FIFF.FIFF_DIR_POINTER, -1)
     write_int(fid, FIFF.FIFF_FREE_LIST, -1)
     return fid
+
+
+@contextmanager
+def start_and_end_file(fname, id_=None):
+    """Start and (if successfully written) close the file."""
+    with start_file(fname, id_=id_) as fid:
+        yield fid
+        end_file(fid)  # we only hit this line if the yield does not err
 
 
 def check_fiff_length(fid, close=True):

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -184,7 +184,7 @@ def _compare_inverses_approx(inv_1, inv_2, evoked, rtol, atol,
                         err_msg='%s: %s' % (method, corr))
 
 
-def _compare_io(inv_op, out_file_ext='.fif', tempdir=None):
+def _compare_io(inv_op, *, out_file_ext='.fif', tempdir):
     """Compare inverse IO."""
     if out_file_ext == '.fif':
         out_file = op.join(tempdir, 'test-inv.fif')
@@ -195,7 +195,7 @@ def _compare_io(inv_op, out_file_ext='.fif', tempdir=None):
     out_file = Path(out_file)
     # Test io operations
     inv_init = copy.deepcopy(inv_op)
-    write_inverse_operator(out_file, inv_op)
+    write_inverse_operator(out_file, inv_op, overwrite=True)
     read_inv_op = read_inverse_operator(out_file)
     _compare(inv_init, read_inv_op)
     _compare(inv_init, inv_op)
@@ -841,7 +841,7 @@ def test_io_inverse_operator(tmp_path):
     assert (x)
     assert (isinstance(inverse_operator['noise_cov'], Covariance))
     # just do one example for .gz, as it should generalize
-    _compare_io(inverse_operator, '.gz', tempdir)
+    _compare_io(inverse_operator, out_file_ext='.gz', tempdir=tempdir)
 
     # test warnings on bad filenames
     inv_badname = op.join(tempdir, 'test-bad-name.fif.gz')

--- a/mne/morph_map.py
+++ b/mne/morph_map.py
@@ -17,8 +17,8 @@ from .io.constants import FIFF
 from .io.open import fiff_open
 from .io.tag import find_tag
 from .io.tree import dir_tree_find
-from .io.write import (start_block, end_block, write_string, start_file,
-                       write_float_sparse_rcs, write_int, end_file)
+from .io.write import (start_block, end_block, write_string,
+                       start_and_end_file, write_float_sparse_rcs, write_int)
 from .surface import (read_surface, _triangle_neighbors, _compute_nearest,
                       _normalize_vectors, _get_tri_supp_geom,
                       _find_nearest_tri_pts)
@@ -136,12 +136,14 @@ def _read_morph_map(fname, subject_from, subject_to):
 def _write_morph_map(fname, subject_from, subject_to, mmap_1, mmap_2):
     """Write a morph map to disk."""
     try:
-        fid = start_file(fname)
+        with start_and_end_file(fname) as fid:
+            _write_morph_map_(fid, subject_from, subject_to, mmap_1, mmap_2)
     except Exception as exp:
         warn('Could not write morph-map file "%s" (error: %s)'
              % (fname, exp))
-        return
 
+
+def _write_morph_map_(fid, subject_from, subject_to, mmap_1, mmap_2):
     assert len(mmap_1) == 2
     hemis = [FIFF.FIFFV_MNE_SURF_LEFT_HEMI, FIFF.FIFFV_MNE_SURF_RIGHT_HEMI]
     for m, hemi in zip(mmap_1, hemis):
@@ -161,7 +163,6 @@ def _write_morph_map(fname, subject_from, subject_to, mmap_1, mmap_2):
             write_int(fid, FIFF.FIFF_MNE_HEMI, hemi)
             write_float_sparse_rcs(fid, FIFF.FIFF_MNE_MORPH_MAP, m)
             end_block(fid, FIFF.FIFFB_MNE_MORPH_MAP)
-    end_file(fid)
 
 
 def _make_morph_map(subject_from, subject_to, subjects_dir, xhemi):

--- a/mne/preprocessing/artifact_detection.py
+++ b/mne/preprocessing/artifact_detection.py
@@ -327,7 +327,7 @@ def compute_average_dev_head_t(raw, pos):
 
 def _annotations_from_mask(times, mask, annot_name, orig_time=None):
     """Construct annotations from boolean mask of the data."""
-    from scipy.ndimage.morphology import distance_transform_edt
+    from scipy.ndimage import distance_transform_edt
     from scipy.signal import find_peaks
     mask_tf = distance_transform_edt(mask)
     # Overcome the shortcoming of find_peaks

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 from typing import Optional, List
 
 import math
-import os
 import json
 
 import numpy as np
@@ -48,7 +47,7 @@ from ..viz.ica import plot_ica_properties
 from ..viz.topomap import _plot_corrmap
 
 from ..channels.channels import _contains_ch_type, ContainsMixin
-from ..io.write import start_file, end_file, write_id
+from ..io.write import start_and_end_file, write_id
 from ..utils import (check_version, logger, check_fname, _check_fname, verbose,
                      _reject_data_segments, check_random_state, _validate_type,
                      compute_corr, _get_inst_data, _ensure_int,
@@ -1901,16 +1900,8 @@ class ICA(ContainsMixin):
         fname = _check_fname(fname, overwrite=overwrite)
 
         logger.info('Writing ICA solution to %s...' % fname)
-        fid = start_file(fname)
-
-        try:
+        with start_and_end_file(fname) as fid:
             _write_ica(fid, self)
-            end_file(fid)
-        except Exception:
-            end_file(fid)
-            os.remove(fname)
-            raise
-
         return self
 
     def copy(self):

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -5,12 +5,12 @@
 import numpy as np
 
 from .epochs import Epochs
-from .utils import check_fname, logger, verbose, _check_option
+from .utils import check_fname, logger, verbose, _check_option, _check_fname
 from .io.open import fiff_open
 from .io.pick import pick_types, pick_types_forward
 from .io.proj import (Projection, _has_eeg_average_ref_proj, _read_proj,
                       make_projector, make_eeg_average_ref_proj, _write_proj)
-from .io.write import start_file, end_file
+from .io.write import start_and_end_file
 from .event import make_fixed_length_events
 from .parallel import parallel_func
 from .cov import _check_n_samples
@@ -48,7 +48,8 @@ def read_proj(fname, verbose=None):
     return projs
 
 
-def write_proj(fname, projs):
+@verbose
+def write_proj(fname, projs, *, overwrite=False, verbose=None):
     """Write projections to a FIF file.
 
     Parameters
@@ -56,20 +57,24 @@ def write_proj(fname, projs):
     fname : str
         The name of file containing the projections vectors. It should end with
         -proj.fif or -proj.fif.gz.
-
     projs : list
         The list of projection vectors.
+    %(overwrite)s
+
+        .. versionadded:: 1.0
+    %(verbose)s
+
+        .. versionadded:: 1.0
 
     See Also
     --------
     read_proj
     """
+    fname = _check_fname(fname, overwrite=overwrite)
     check_fname(fname, 'projection', ('-proj.fif', '-proj.fif.gz',
                                       '_proj.fif', '_proj.fif.gz'))
-
-    with start_file(fname) as fid:
+    with start_and_end_file(fname) as fid:
         _write_proj(fid, projs)
-        end_file(fid)
 
 
 @verbose

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -1668,7 +1668,7 @@ def _marching_cubes(image, level, smooth=0, fill_hole_size=None):
                      vtkWindowedSincPolyDataFilter, vtkDiscreteFlyingEdges3D,
                      vtkGeometryFilter, vtkDataSetAttributes, VTK_DOUBLE)
     from vtk.util import numpy_support
-    from scipy.ndimage.morphology import binary_dilation
+    from scipy.ndimage import binary_dilation
     _validate_type(smooth, 'numeric', smooth)
     smooth = float(smooth)
     if not 0 <= smooth < 1:

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -205,7 +205,7 @@ def test_ad_hoc_cov(tmp_path):
     assert_array_almost_equal(cov['data'], cov2['data'])
     std = dict(grad=2e-13, mag=10e-15, eeg=0.1e-6)
     cov = make_ad_hoc_cov(evoked.info, std)
-    cov.save(out_fname)
+    cov.save(out_fname, overwrite=True)
     assert 'Covariance' in repr(cov)
     cov2 = read_cov(out_fname)
     assert_array_almost_equal(cov['data'], cov2['data'])
@@ -241,11 +241,11 @@ def test_io_cov(tmp_path):
     cov_sel = pick_channels_cov(cov, exclude=cov['bads'])
     assert cov_sel['dim'] == (len(cov['data']) - len(cov['bads']))
     assert cov_sel['data'].shape == (cov_sel['dim'], cov_sel['dim'])
-    cov_sel.save(tmp_path / 'test-cov.fif')
+    cov_sel.save(tmp_path / 'test-cov.fif', overwrite=True)
 
     cov2 = read_cov(cov_gz_fname)
     assert_array_almost_equal(cov.data, cov2.data)
-    cov2.save(tmp_path / 'test-cov.fif.gz')
+    cov2.save(tmp_path / 'test-cov.fif.gz', overwrite=True)
     cov2 = read_cov(tmp_path / 'test-cov.fif.gz')
     assert_array_almost_equal(cov.data, cov2.data)
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1432,7 +1432,7 @@ def test_evoked_io_from_epochs(tmp_path):
                     picks=picks, baseline=baseline, decim=5)
     evoked = epochs.average()
     assert_allclose(evoked.baseline, baseline)
-    evoked.save(fname_temp)
+    evoked.save(fname_temp, overwrite=True)
     evoked2 = read_evokeds(fname_temp)[0]
     assert_allclose(evoked.data, evoked2.data, rtol=1e-4, atol=1e-20)
     assert_allclose(evoked.times, evoked2.times, rtol=1e-4, atol=1e-20)
@@ -1458,14 +1458,14 @@ def test_evoked_io_from_epochs(tmp_path):
     for picks in (None, 'all'):
         evoked = epochs.average(picks)
         evokeds.append(evoked)
-        evoked.save(fname_temp)
+        evoked.save(fname_temp, overwrite=True)
         evoked2 = read_evokeds(fname_temp)[0]
         start = 1 if picks is None else 0
         for ev in (evoked, evoked2):
             assert ev.ch_names == epochs.ch_names[start:]
             assert_allclose(ev.data, epochs.get_data().mean(0)[start:])
     with pytest.raises(ValueError, match='.*nchan.* must match'):
-        write_evokeds(fname_temp, evokeds)
+        write_evokeds(fname_temp, evokeds, overwrite=True)
 
 
 def test_evoked_standard_error(tmp_path):

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -139,7 +139,7 @@ def test_io_events(tmp_path):
     # Test old format text file IO
     events2 = read_events(fname_old_txt)
     assert_array_almost_equal(events, events2)
-    write_events(fname_temp, events)
+    write_events(fname_temp, events, overwrite=True)
     events2 = read_events(fname_temp)
     assert_array_almost_equal(events, events2)
 
@@ -156,19 +156,19 @@ def test_io_events(tmp_path):
     # test reading file with mask=None
     events2 = events.copy()
     events2[:, -1] = range(events2.shape[0])
-    write_events(fname_temp, events2)
+    write_events(fname_temp, events2, overwrite=True)
     events3 = read_events(fname_temp, mask=None)
     assert_array_almost_equal(events2, events3)
 
     # Test binary file IO for 1 event
     events = read_events(fname_1)  # Use as the new gold standard
-    write_events(fname_temp, events)
+    write_events(fname_temp, events, overwrite=True)
     events2 = read_events(fname_temp)
     assert_array_almost_equal(events, events2)
 
     # Test text file IO for 1 event
     fname_temp = tmp_path / 'events.eve'
-    write_events(fname_temp, events)
+    write_events(fname_temp, events, overwrite=True)
     events2 = read_events(fname_temp)
     assert_array_almost_equal(events, events2)
 

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -228,7 +228,7 @@ def test_io_evoked(tmp_path):
     aves1 = read_evokeds(fname)[1::2]
     aves2 = read_evokeds(fname, [1, 3])
     aves3 = read_evokeds(fname, ['Right Auditory', 'Right visual'])
-    write_evokeds(tmp_path / 'evoked-ave.fif', aves1)
+    write_evokeds(tmp_path / 'evoked-ave.fif', aves1, overwrite=True)
     aves4 = read_evokeds(tmp_path / 'evoked-ave.fif')
     for aves in [aves2, aves3, aves4]:
         for [av1, av2] in zip(aves1, aves):
@@ -287,20 +287,21 @@ def test_shift_time_evoked(tmp_path):
     tempdir = str(tmp_path)
     # Shift backward
     ave = read_evokeds(fname, 0).shift_time(-0.1, relative=True)
-    write_evokeds(op.join(tempdir, 'evoked-ave.fif'), ave)
+    fname_temp = op.join(tempdir, 'evoked-ave.fif')
+    write_evokeds(fname_temp, ave)
 
     # Shift forward twice the amount
-    ave_bshift = read_evokeds(op.join(tempdir, 'evoked-ave.fif'), 0)
+    ave_bshift = read_evokeds(fname_temp, 0)
     ave_bshift.shift_time(0.2, relative=True)
-    write_evokeds(op.join(tempdir, 'evoked-ave.fif'), ave_bshift)
+    write_evokeds(fname_temp, ave_bshift, overwrite=True)
 
     # Shift backward again
-    ave_fshift = read_evokeds(op.join(tempdir, 'evoked-ave.fif'), 0)
+    ave_fshift = read_evokeds(fname_temp, 0)
     ave_fshift.shift_time(-0.1, relative=True)
-    write_evokeds(op.join(tempdir, 'evoked-ave.fif'), ave_fshift)
+    write_evokeds(fname_temp, ave_fshift, overwrite=True)
 
     ave_normal = read_evokeds(fname, 0)
-    ave_relative = read_evokeds(op.join(tempdir, 'evoked-ave.fif'), 0)
+    ave_relative = read_evokeds(fname_temp, 0)
 
     assert_allclose(ave_normal.data, ave_relative.data, atol=1e-16, rtol=1e-3)
     assert_array_almost_equal(ave_normal.times, ave_relative.times, 8)
@@ -311,9 +312,9 @@ def test_shift_time_evoked(tmp_path):
     # Absolute time shift
     ave = read_evokeds(fname, 0)
     ave.shift_time(-0.3, relative=False)
-    write_evokeds(op.join(tempdir, 'evoked-ave.fif'), ave)
+    write_evokeds(fname_temp, ave, overwrite=True)
 
-    ave_absolute = read_evokeds(op.join(tempdir, 'evoked-ave.fif'), 0)
+    ave_absolute = read_evokeds(fname_temp, 0)
 
     assert_allclose(ave_normal.data, ave_absolute.data, atol=1e-16, rtol=1e-3)
     assert_equal(ave_absolute.first, int(-0.3 * ave.info['sfreq']))
@@ -331,14 +332,14 @@ def test_shift_time_evoked(tmp_path):
     # should shift by 0 samples
     ave.shift_time(1e-6)
     assert_array_equal(first_last, np.array([ave.first, ave.last]))
-    write_evokeds(op.join(tempdir, 'evoked-ave.fif'), ave)
-    ave_loaded = read_evokeds(op.join(tempdir, 'evoked-ave.fif'), 0)
+    write_evokeds(fname_temp, ave, overwrite=True)
+    ave_loaded = read_evokeds(fname_temp, 0)
     assert_array_almost_equal(ave.times, ave_loaded.times, 8)
     # should shift by 57 samples
     ave.shift_time(57. / ave.info['sfreq'])
     assert_array_equal(first_last + 57, np.array([ave.first, ave.last]))
-    write_evokeds(op.join(tempdir, 'evoked-ave.fif'), ave)
-    ave_loaded = read_evokeds(op.join(tempdir, 'evoked-ave.fif'), 0)
+    write_evokeds(fname_temp, ave, overwrite=True)
+    ave_loaded = read_evokeds(fname_temp, 0)
     assert_array_almost_equal(ave.times, ave_loaded.times, 8)
 
 
@@ -358,14 +359,15 @@ def test_evoked_resample(tmp_path):
     sfreq_normal = ave.info['sfreq']
     ave.resample(2 * sfreq_normal, npad=100)
     assert ave.info['lowpass'] == orig_lp
-    write_evokeds(op.join(tempdir, 'evoked-ave.fif'), ave)
-    ave_up = read_evokeds(op.join(tempdir, 'evoked-ave.fif'), 0)
+    fname_temp = op.join(tempdir, 'evoked-ave.fif')
+    write_evokeds(fname_temp, ave)
+    ave_up = read_evokeds(fname_temp, 0)
 
     # compare it to the original
     ave_normal = read_evokeds(fname, 0)
 
     # and compare the original to the downsampled upsampled version
-    ave_new = read_evokeds(op.join(tempdir, 'evoked-ave.fif'), 0)
+    ave_new = read_evokeds(fname_temp, 0)
     ave_new.resample(sfreq_normal, npad=100)
     assert ave.info['lowpass'] == orig_lp
 

--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -224,7 +224,7 @@ def test_compute_proj_epochs(tmp_path):
     with pytest.raises(TypeError, match='projs'):
         write_proj(fname, 'foo')
     with pytest.raises(TypeError, match=r'projs\[0\] must be .*'):
-        write_proj(fname, ['foo'])
+        write_proj(fname, ['foo'], overwrite=True)
 
 
 @pytest.mark.slowtest

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -12,7 +12,7 @@ import numpy as np
 from .tfr import _cwt_array, morlet, _get_nfft
 from ..io.pick import pick_channels, _picks_to_idx
 from ..utils import (logger, verbose, warn, copy_function_doc_to_method_doc,
-                     ProgressBar)
+                     ProgressBar, _check_fname)
 from ..viz.misc import plot_csd
 from ..time_frequency.multitaper import (_compute_mt_params, _mt_spectra,
                                          _csd_from_mt, _psd_from_mt_adaptive)
@@ -442,7 +442,8 @@ class CrossSpectralDensity(object):
             projs=self.projs,
         )
 
-    def save(self, fname):
+    @verbose
+    def save(self, fname, *, overwrite=False, verbose=None):
         """Save the CSD to an HDF5 file.
 
         Parameters
@@ -450,6 +451,12 @@ class CrossSpectralDensity(object):
         fname : str
             The name of the file to save the CSD to. The extension '.h5' will
             be appended if the given filename doesn't have it already.
+        %(overwrite)s
+
+            .. versionadded:: 1.0
+        %(verbose)s
+
+            .. versionadded:: 1.0
 
         See Also
         --------
@@ -458,8 +465,9 @@ class CrossSpectralDensity(object):
         if not fname.endswith('.h5'):
             fname += '.h5'
 
-        # TODO: Add `overwrite` param to method signature
-        write_hdf5(fname, self.__getstate__(), overwrite=True, title='conpy')
+        fname = _check_fname(fname, overwrite=overwrite)
+        write_hdf5(fname, self.__getstate__(), overwrite=True,
+                   title='conpy')
 
     def copy(self):
         """Return copy of the CrossSpectralDensity object.

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -17,7 +17,7 @@ from .fixes import jit, mean, _get_img_fdata
 from .io.constants import FIFF
 from .io.open import fiff_open
 from .io.tag import read_tag
-from .io.write import start_file, end_file, write_coord_trans
+from .io.write import start_and_end_file, write_coord_trans
 from .defaults import _handle_default
 from .utils import (check_fname, logger, verbose, _ensure_int, _validate_type,
                     _path_like, get_subjects_dir, fill_doc, _check_fname,
@@ -558,7 +558,8 @@ def read_trans(fname, return_all=False, verbose=None):
     return trans if return_all else trans[0]
 
 
-def write_trans(fname, trans):
+@verbose
+def write_trans(fname, trans, *, overwrite=False, verbose=None):
     """Write a -trans.fif file.
 
     Parameters
@@ -567,6 +568,8 @@ def write_trans(fname, trans):
         The name of the file, which should end in '-trans.fif'.
     trans : dict
         Trans file data, as returned by read_trans.
+    %(overwrite)s
+    %(verbose)s
 
     See Also
     --------
@@ -574,11 +577,9 @@ def write_trans(fname, trans):
     """
     check_fname(fname, 'trans', ('-trans.fif', '-trans.fif.gz',
                                  '_trans.fif', '_trans.fif.gz'))
-    # TODO: Add `overwrite` param to method signature
-    fname = _check_fname(fname=fname, overwrite=True)
-    fid = start_file(fname)
-    write_coord_trans(fid, trans)
-    end_file(fid)
+    fname = _check_fname(fname=fname, overwrite=overwrite)
+    with start_and_end_file(fname) as fid:
+        write_coord_trans(fid, trans)
 
 
 def invert_transform(trans):


### PR DESCRIPTION
1. Add `overwrite=False` to a number of public functions (currently implemented as a bugfix, but if it's too annoying we could have a deprecation cycle)
2. Change the pattern:
    ```
    with start_file(fname) as fid:
        ...
        end_file(fid)
    ```
    to a cleaner `with start_and_end_file(fid)` context manager.
3. Add a few context-managed file openings in places we had less safe `fid.close`s instead.
4. Add support for `MNE_SKIP_INSTANCE_ASSERTIONS=1 make html_dev`, which I needed locally to skip the PyVista/Brain assertion checks in our doc build (it's not great that I have to do this, but it's useful to have the option in place in case what needs to be checked is just that the doc build can complete)
5. Fix some scipy.ndimage imports to use main namespace rather than "morphology"
6. Add a skip for sklearn's deprecation for `whiten=True` in `FastICA` (it's changing but shouldn't really affect our example that uses it directly)