### PR TITLE
MRG: Reduce dimensions of Evoked topoplots in Report & limit Report figure resolution to 100 DPI

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -62,7 +62,7 @@ Enhancements
 
 - Drastically speed up butterfly plot generation in :meth:`mne.Report.add_raw`. We now don't plot annotations anymore; however, we feel that the speed improvements justify this change, also considering the annotations were of limited use in the displayed one-second time slices anyway (:gh:`10114`, :gh:`10116` by `Richard Höchenberger`_)
 
-- In :class:`mne.Report`, limit the width of automatically generated figures to a maximum of 850 pixels to reduce file size and memory consumption (:gh:`10126` by `Richard Höchenberger`_)
+- In :class:`mne.Report`, limit the width of automatically generated figures to a maximum of 850 pixels, and the resolution to 100 DPI to reduce file size and memory consumption (:gh:`10126`, :gh:`xxx` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -62,7 +62,7 @@ Enhancements
 
 - Drastically speed up butterfly plot generation in :meth:`mne.Report.add_raw`. We now don't plot annotations anymore; however, we feel that the speed improvements justify this change, also considering the annotations were of limited use in the displayed one-second time slices anyway (:gh:`10114`, :gh:`10116` by `Richard Höchenberger`_)
 
-- In :class:`mne.Report`, limit the width of automatically generated figures to a maximum of 850 pixels, and the resolution to 100 DPI to reduce file size and memory consumption (:gh:`10126`, :gh:`xxx` by `Richard Höchenberger`_)
+- In :class:`mne.Report`, limit the width of automatically generated figures to a maximum of 850 pixels, and the resolution to 100 DPI to reduce file size and memory consumption (:gh:`10126`, :gh:`10129` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -321,7 +321,7 @@ def _check_tags(tags) -> Tuple[str]:
 # PLOTTING FUNCTIONS
 
 
-def _constrain_fig_resolution(fig, *, max_width, max_dpi):
+def _constrain_fig_resolution(fig, *, max_width, max_res):
     """Limit the resolution (DPI) of a figure.
 
     Parameters
@@ -330,14 +330,14 @@ def _constrain_fig_resolution(fig, *, max_width, max_dpi):
         The figure whose DPI to adjust.
     max_width : int
         The max. allowed width, in pixels.
-    max_dpi : int
+    max_res : int
         The max. allowed resolution, in DPI.
 
     Returns
     -------
     Nothing, alters the figure's properties in-place.
     """
-    dpi = min(max_dpi, max_width / fig.get_size_inches()[0])
+    dpi = min(max_res, max_width / fig.get_size_inches()[0])
     fig.set_dpi(dpi)
 
 
@@ -349,7 +349,7 @@ def _fig_to_img(fig, *, image_format='png', auto_close=True):
     if isinstance(fig, np.ndarray):
         fig = _ndarray_to_fig(fig)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
         )
     elif not isinstance(fig, Figure):
         from ..viz.backends.renderer import backend, MNE_3D_BACKEND_TESTING
@@ -363,7 +363,7 @@ def _fig_to_img(fig, *, image_format='png', auto_close=True):
             backend._close_3d_figure(figure=fig)
         fig = _ndarray_to_fig(img)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
         )
 
     output = BytesIO()
@@ -520,7 +520,7 @@ def _plot_ica_properties_as_arrays(*, ica, inst, picks, n_jobs):
         assert len(figs) == 1
         fig = figs[0]
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
         )
         with io.BytesIO() as buff:
             fig.savefig(
@@ -1428,7 +1428,7 @@ class Report(object):
         del inst_
         tight_layout(fig=fig)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
         )
         img = _fig_to_img(fig, image_format=image_format)
         dom_id = self._get_dom_id()
@@ -1494,7 +1494,7 @@ class Report(object):
                                      image_format, tags):
         fig = ica.plot_sources(inst=inst, show=False)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
         )
         img = _fig_to_img(fig, image_format=image_format)
         dom_id = self._get_dom_id()
@@ -1509,7 +1509,7 @@ class Report(object):
                                     image_format, tags):
         fig = ica.plot_scores(scores=scores, title=None, show=False)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
         )
         img = _fig_to_img(fig, image_format=image_format)
         dom_id = self._get_dom_id()
@@ -1542,7 +1542,7 @@ class Report(object):
         if len(figs) == 1:
             fig = figs[0]
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
             )
             img = _fig_to_img(fig=fig, image_format=image_format)
             dom_id = self._get_dom_id()
@@ -2649,7 +2649,7 @@ class Report(object):
                 duration=durations[0], scalings=scalings, show=False
             )
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
             )
             images = [_fig_to_img(fig=fig, image_format=image_format)]
 
@@ -2723,7 +2723,7 @@ class Report(object):
             fig = raw.plot_psd(fmax=fmax, show=False, **add_psd)
             tight_layout(fig=fig)
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
             )
 
             img = _fig_to_img(fig, image_format=image_format)
@@ -2798,7 +2798,7 @@ class Report(object):
         fig.set_size_inches((6, 4))
         tight_layout(fig=fig)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
         )
         img = _fig_to_img(fig=fig, image_format=image_format)
 
@@ -2907,7 +2907,7 @@ class Report(object):
                 )
 
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
             )
             img = _fig_to_img(fig=fig, image_format=image_format)
             title = f'Time course ({_handle_default("titles")[ch_type]})'
@@ -2943,7 +2943,7 @@ class Report(object):
             figsize=(2.5 * len(ch_types), 2)
         )
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
         )
         ch_type_ax_map = dict(
             zip(ch_types,
@@ -3080,7 +3080,7 @@ class Report(object):
 
         tight_layout(fig=fig)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
         )
         img = _fig_to_img(fig=fig, image_format=image_format)
         title = 'Global field power'
@@ -3108,7 +3108,7 @@ class Report(object):
         )
         tight_layout(fig=fig)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
         )
         img = _fig_to_img(fig=fig, image_format=image_format)
         title = 'Whitened'
@@ -3172,7 +3172,7 @@ class Report(object):
             show=False
         )
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
         )
         img = _fig_to_img(
             fig=fig,
@@ -3242,7 +3242,7 @@ class Report(object):
 
             fig = epochs_for_psd.plot_psd(fmax=fmax, show=False)
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
             )
             img = _fig_to_img(fig=fig, image_format=image_format)
             duration = round(epoch_duration * len(epochs_for_psd), 1)
@@ -3293,7 +3293,7 @@ class Report(object):
             assert len(figs) == 1
             fig = figs[0]
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
             )
             img = _fig_to_img(fig=fig, image_format=image_format)
             if ch_type in ('mag', 'grad'):
@@ -3334,7 +3334,7 @@ class Report(object):
                 fig = epochs.plot_drop_log(subject=self.subject, show=False)
                 tight_layout(fig=fig)
                 _constrain_fig_resolution(
-                    fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+                    fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
                 )
                 img = _fig_to_img(fig=fig, image_format=image_format)
                 drop_log_img_html = _html_image_element(
@@ -3375,7 +3375,7 @@ class Report(object):
 
         for fig, title in zip(figs, titles):
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
             )
             img = _fig_to_img(fig=fig, image_format=image_format)
             dom_id = self._get_dom_id()

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -104,7 +104,7 @@ template_dir = Path(__file__).parent / 'templates'
 JAVASCRIPT = (html_include_dir / 'report.js').read_text(encoding='utf-8')
 CSS = (html_include_dir / 'report.sass').read_text(encoding='utf-8')
 
-MAX_IMG_DPI = 100  # in dots per inch
+MAX_IMG_RES = 100  # in dots per inch
 MAX_IMG_WIDTH = 850  # in pixels
 
 
@@ -349,7 +349,7 @@ def _fig_to_img(fig, *, image_format='png', auto_close=True):
     if isinstance(fig, np.ndarray):
         fig = _ndarray_to_fig(fig)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
         )
     elif not isinstance(fig, Figure):
         from ..viz.backends.renderer import backend, MNE_3D_BACKEND_TESTING
@@ -363,7 +363,7 @@ def _fig_to_img(fig, *, image_format='png', auto_close=True):
             backend._close_3d_figure(figure=fig)
         fig = _ndarray_to_fig(img)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
         )
 
     output = BytesIO()
@@ -520,7 +520,7 @@ def _plot_ica_properties_as_arrays(*, ica, inst, picks, n_jobs):
         assert len(figs) == 1
         fig = figs[0]
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
         )
         with io.BytesIO() as buff:
             fig.savefig(
@@ -1428,7 +1428,7 @@ class Report(object):
         del inst_
         tight_layout(fig=fig)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
         )
         img = _fig_to_img(fig, image_format=image_format)
         dom_id = self._get_dom_id()
@@ -1494,7 +1494,7 @@ class Report(object):
                                      image_format, tags):
         fig = ica.plot_sources(inst=inst, show=False)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
         )
         img = _fig_to_img(fig, image_format=image_format)
         dom_id = self._get_dom_id()
@@ -1509,7 +1509,7 @@ class Report(object):
                                     image_format, tags):
         fig = ica.plot_scores(scores=scores, title=None, show=False)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
         )
         img = _fig_to_img(fig, image_format=image_format)
         dom_id = self._get_dom_id()
@@ -1542,7 +1542,7 @@ class Report(object):
         if len(figs) == 1:
             fig = figs[0]
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
             )
             img = _fig_to_img(fig=fig, image_format=image_format)
             dom_id = self._get_dom_id()
@@ -2649,7 +2649,7 @@ class Report(object):
                 duration=durations[0], scalings=scalings, show=False
             )
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
             )
             images = [_fig_to_img(fig=fig, image_format=image_format)]
 
@@ -2723,7 +2723,7 @@ class Report(object):
             fig = raw.plot_psd(fmax=fmax, show=False, **add_psd)
             tight_layout(fig=fig)
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
             )
 
             img = _fig_to_img(fig, image_format=image_format)
@@ -2798,7 +2798,7 @@ class Report(object):
         fig.set_size_inches((6, 4))
         tight_layout(fig=fig)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
         )
         img = _fig_to_img(fig=fig, image_format=image_format)
 
@@ -2907,7 +2907,7 @@ class Report(object):
                 )
 
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
             )
             img = _fig_to_img(fig=fig, image_format=image_format)
             title = f'Time course ({_handle_default("titles")[ch_type]})'
@@ -2943,7 +2943,7 @@ class Report(object):
             figsize=(2.5 * len(ch_types), 2)
         )
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
         )
         ch_type_ax_map = dict(
             zip(ch_types,
@@ -3080,7 +3080,7 @@ class Report(object):
 
         tight_layout(fig=fig)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
         )
         img = _fig_to_img(fig=fig, image_format=image_format)
         title = 'Global field power'
@@ -3108,7 +3108,7 @@ class Report(object):
         )
         tight_layout(fig=fig)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
         )
         img = _fig_to_img(fig=fig, image_format=image_format)
         title = 'Whitened'
@@ -3172,7 +3172,7 @@ class Report(object):
             show=False
         )
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
         )
         img = _fig_to_img(
             fig=fig,
@@ -3242,7 +3242,7 @@ class Report(object):
 
             fig = epochs_for_psd.plot_psd(fmax=fmax, show=False)
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
             )
             img = _fig_to_img(fig=fig, image_format=image_format)
             duration = round(epoch_duration * len(epochs_for_psd), 1)
@@ -3293,7 +3293,7 @@ class Report(object):
             assert len(figs) == 1
             fig = figs[0]
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
             )
             img = _fig_to_img(fig=fig, image_format=image_format)
             if ch_type in ('mag', 'grad'):
@@ -3334,7 +3334,7 @@ class Report(object):
                 fig = epochs.plot_drop_log(subject=self.subject, show=False)
                 tight_layout(fig=fig)
                 _constrain_fig_resolution(
-                    fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+                    fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
                 )
                 img = _fig_to_img(fig=fig, image_format=image_format)
                 drop_log_img_html = _html_image_element(
@@ -3375,7 +3375,7 @@ class Report(object):
 
         for fig, title in zip(figs, titles):
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_DPI
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
             )
             img = _fig_to_img(fig=fig, image_format=image_format)
             dom_id = self._get_dom_id()

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -104,6 +104,7 @@ template_dir = Path(__file__).parent / 'templates'
 JAVASCRIPT = (html_include_dir / 'report.js').read_text(encoding='utf-8')
 CSS = (html_include_dir / 'report.sass').read_text(encoding='utf-8')
 
+MAX_IMG_DPI = 100  # in dots per inch
 MAX_IMG_WIDTH = 850  # in pixels
 
 
@@ -320,21 +321,23 @@ def _check_tags(tags) -> Tuple[str]:
 # PLOTTING FUNCTIONS
 
 
-def _constrain_fig_resolution(fig, width):
+def _constrain_fig_resolution(fig, *, max_width, max_dpi):
     """Limit the resolution (DPI) of a figure.
 
     Parameters
     ----------
     fig : matplotlib.figure.Figure
         The figure whose DPI to adjust.
-    width : int
+    max_width : int
         The max. allowed width, in pixels.
+    max_dpi : int
+        The max. allowed resolution, in DPI.
 
     Returns
     -------
     Nothing, alters the figure's properties in-place.
     """
-    dpi = min(fig.get_dpi(), MAX_IMG_WIDTH / fig.get_size_inches()[0])
+    dpi = min(max_dpi, max_width / fig.get_size_inches()[0])
     fig.set_dpi(dpi)
 
 
@@ -345,7 +348,9 @@ def _fig_to_img(fig, *, image_format='png', auto_close=True):
     from matplotlib.figure import Figure
     if isinstance(fig, np.ndarray):
         fig = _ndarray_to_fig(fig)
-        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+        _constrain_fig_resolution(
+            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+        )
     elif not isinstance(fig, Figure):
         from ..viz.backends.renderer import backend, MNE_3D_BACKEND_TESTING
         backend._check_3d_figure(figure=fig)
@@ -357,7 +362,9 @@ def _fig_to_img(fig, *, image_format='png', auto_close=True):
         if auto_close:
             backend._close_3d_figure(figure=fig)
         fig = _ndarray_to_fig(img)
-        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+        _constrain_fig_resolution(
+            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+        )
 
     output = BytesIO()
     logger.debug(
@@ -512,7 +519,9 @@ def _plot_ica_properties_as_arrays(*, ica, inst, picks, n_jobs):
         figs = ica.plot_properties(inst=inst, picks=pick, show=False)
         assert len(figs) == 1
         fig = figs[0]
-        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+        _constrain_fig_resolution(
+            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+        )
         with io.BytesIO() as buff:
             fig.savefig(
                 buff,
@@ -1418,7 +1427,9 @@ class Report(object):
         fig = ica.plot_overlay(inst=inst_, show=False)
         del inst_
         tight_layout(fig=fig)
-        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+        _constrain_fig_resolution(
+            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+        )
         img = _fig_to_img(fig, image_format=image_format)
         dom_id = self._get_dom_id()
         overlay_html = _html_image_element(
@@ -1482,7 +1493,9 @@ class Report(object):
     def _render_ica_artifact_sources(self, *, ica, inst, artifact_type,
                                      image_format, tags):
         fig = ica.plot_sources(inst=inst, show=False)
-        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+        _constrain_fig_resolution(
+            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+        )
         img = _fig_to_img(fig, image_format=image_format)
         dom_id = self._get_dom_id()
         html = _html_image_element(
@@ -1495,7 +1508,9 @@ class Report(object):
     def _render_ica_artifact_scores(self, *, ica, scores, artifact_type,
                                     image_format, tags):
         fig = ica.plot_scores(scores=scores, title=None, show=False)
-        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+        _constrain_fig_resolution(
+            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+        )
         img = _fig_to_img(fig, image_format=image_format)
         dom_id = self._get_dom_id()
         html = _html_image_element(
@@ -1526,7 +1541,9 @@ class Report(object):
         title = 'ICA component topographies'
         if len(figs) == 1:
             fig = figs[0]
-            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+            _constrain_fig_resolution(
+                fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            )
             img = _fig_to_img(fig=fig, image_format=image_format)
             dom_id = self._get_dom_id()
             topographies_html = _html_image_element(
@@ -2631,7 +2648,9 @@ class Report(object):
                 butterfly=True, show_scrollbars=False, start=t_starts[0],
                 duration=durations[0], scalings=scalings, show=False
             )
-            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+            _constrain_fig_resolution(
+                fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            )
             images = [_fig_to_img(fig=fig, image_format=image_format)]
 
             for start, duration in zip(t_starts[1:], durations[1:]):
@@ -2703,7 +2722,9 @@ class Report(object):
 
             fig = raw.plot_psd(fmax=fmax, show=False, **add_psd)
             tight_layout(fig=fig)
-            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+            _constrain_fig_resolution(
+                fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            )
 
             img = _fig_to_img(fig, image_format=image_format)
             psd_img_html = _html_image_element(
@@ -2776,7 +2797,9 @@ class Report(object):
         # number-of-channel-types conditions...
         fig.set_size_inches((6, 4))
         tight_layout(fig=fig)
-        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+        _constrain_fig_resolution(
+            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+        )
         img = _fig_to_img(fig=fig, image_format=image_format)
 
         dom_id = self._get_dom_id()
@@ -2883,7 +2906,9 @@ class Report(object):
                     topomap_args=topomap_kwargs,
                 )
 
-            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+            _constrain_fig_resolution(
+                fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            )
             img = _fig_to_img(fig=fig, image_format=image_format)
             title = f'Time course ({_handle_default("titles")[ch_type]})'
             dom_id = self._get_dom_id()
@@ -2912,8 +2937,13 @@ class Report(object):
 
         fig, ax = plt.subplots(
             1, len(ch_types) * 2,
-            gridspec_kw={'width_ratios': [8, 0.5] * len(ch_types)},
-            figsize=(4 * len(ch_types), 3.5)
+            gridspec_kw={
+                'width_ratios': [8, 0.5] * len(ch_types)
+            },
+            figsize=(2.5 * len(ch_types), 2)
+        )
+        _constrain_fig_resolution(
+            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
         )
         ch_type_ax_map = dict(
             zip(ch_types,
@@ -2931,7 +2961,6 @@ class Report(object):
             ch_type_ax_map[ch_type][0].set_title(ch_type)
 
         tight_layout(fig=fig)
-        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
 
         with BytesIO() as buff:
             fig.savefig(
@@ -3050,7 +3079,9 @@ class Report(object):
                 ax[idx].set_xlabel(None)
 
         tight_layout(fig=fig)
-        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+        _constrain_fig_resolution(
+            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+        )
         img = _fig_to_img(fig=fig, image_format=image_format)
         title = 'Global field power'
         html = _html_image_element(
@@ -3076,7 +3107,9 @@ class Report(object):
             show=False
         )
         tight_layout(fig=fig)
-        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+        _constrain_fig_resolution(
+            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+        )
         img = _fig_to_img(fig=fig, image_format=image_format)
         title = 'Whitened'
 
@@ -3138,7 +3171,9 @@ class Report(object):
             first_samp=first_samp,
             show=False
         )
-        _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+        _constrain_fig_resolution(
+            fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+        )
         img = _fig_to_img(
             fig=fig,
             image_format=image_format,
@@ -3206,7 +3241,9 @@ class Report(object):
                 fmax = np.inf
 
             fig = epochs_for_psd.plot_psd(fmax=fmax, show=False)
-            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+            _constrain_fig_resolution(
+                fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            )
             img = _fig_to_img(fig=fig, image_format=image_format)
             duration = round(epoch_duration * len(epochs_for_psd), 1)
             caption = (
@@ -3255,7 +3292,9 @@ class Report(object):
 
             assert len(figs) == 1
             fig = figs[0]
-            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+            _constrain_fig_resolution(
+                fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            )
             img = _fig_to_img(fig=fig, image_format=image_format)
             if ch_type in ('mag', 'grad'):
                 title_start = 'ERF image'
@@ -3294,7 +3333,9 @@ class Report(object):
             else:
                 fig = epochs.plot_drop_log(subject=self.subject, show=False)
                 tight_layout(fig=fig)
-                _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+                _constrain_fig_resolution(
+                    fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+                )
                 img = _fig_to_img(fig=fig, image_format=image_format)
                 drop_log_img_html = _html_image_element(
                     img=img, id=dom_id, div_klass='epochs', img_klass='epochs',
@@ -3333,7 +3374,9 @@ class Report(object):
         )
 
         for fig, title in zip(figs, titles):
-            _constrain_fig_resolution(fig, width=MAX_IMG_WIDTH)
+            _constrain_fig_resolution(
+                fig, max_width=MAX_IMG_WIDTH, max_dpi=MAX_IMG_DPI
+            )
             img = _fig_to_img(fig=fig, image_format=image_format)
             dom_id = self._get_dom_id()
             html = _html_image_element(

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -81,8 +81,8 @@ subjects_dir = data_path / 'subjects'
 # equally-spaced 1-second segments of the data:
 #
 # .. warning::
-#    In the following example, we crop the raw data to 60 seconds just to speed
-#    up processing, this is not usually recommended!
+#    In the following example, we crop the raw data to 60 seconds merely to
+#    speed up processing; this is not usually recommended!
 
 raw_path = sample_dir / 'sample_audvis_filt-0-40_raw.fif'
 raw = mne.io.read_raw(raw_path)


### PR DESCRIPTION
This reduces file size by about 10% (from 19 to 17 MB) on my system with the following MWE:

```python
# %%
from pathlib import Path
import mne


sample_dir = Path(mne.datasets.sample.data_path())
sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'

raw = mne.io.read_raw_fif(sample_fname)
raw.crop(tmax=60)

events = mne.find_events(raw, stim_channel='STI 014')
event_id = {'auditory/left': 1, 'auditory/right': 2, 'visual/left': 3,
            'visual/right': 4, 'face': 5, 'buttonpress': 32}

epochs = mne.Epochs(raw, events=events, event_id=event_id,
                    tmin=-0.2, tmax=0.5, baseline=(None, 0),
                    preload=True)
evokeds = epochs.average(by_event_type=True)

# %%
r = mne.Report()
r.add_evokeds(
    evokeds=evokeds,
    titles=epochs.event_id.keys()
)
r.save('/tmp/report.html', overwrite=True)
```