### PR TITLE
MRG, BUG: Fix smoothing and metrics for zooms

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -119,6 +119,8 @@ Bugs
 
 - Fix functions by adding missing ``overwrite`` parameters: :func:`mne.write_events`, :func:`mne.write_cov`, :func:`mne.write_evokeds`, :meth:`mne.SourceEstimate.save`, :func:`mne.minimum_norm.write_inverse_operator`, :func:`mne.write_proj`, and related methods (:gh:`10127` by `Eric Larson`_)
 
+- Fix bug with :func:`mne.transforms.compute_volume_registration` and :func:`mne.compute_source_morph` (volumetric) where the smoothing factors were not scaled based on ``zooms`` (:gh:`10132` by `Eric Larson`_)
+
 - Remove repeated logging output when overwriting an existing `~mne.io.Raw` file (:gh:`10095` by `Richard Höchenberger`_ and `Stefan Appelhoff`_)
 
 API changes

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -125,6 +125,7 @@ def pytest_configure(config):
     ignore:.*Passing a schema to Validator.*:DeprecationWarning
     ignore:.*Found the following unknown channel type.*:RuntimeWarning
     ignore:.*np\.MachAr.*:DeprecationWarning
+    ignore:.*Passing unrecognized arguments to super.*:DeprecationWarning
     always::ResourceWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -30,7 +30,7 @@ from .transforms import (transform_surface_to, _pol_to_cart, _cart_to_sph,
 from .utils import (logger, verbose, get_subjects_dir, warn, _check_fname,
                     _check_option, _ensure_int, _TempDir, run_subprocess,
                     _check_freesurfer_home, _hashable_ndarray, fill_doc,
-                    _validate_type, _require_version)
+                    _validate_type, _require_version, _pl)
 
 
 ###############################################################################
@@ -1765,7 +1765,8 @@ def _warn_missing_chs(info, dig_image, after_warp, verbose=None):
         set(np.unique(np.array(dig_image.dataobj))))
     missing_ch = [info.ch_names[idx - 1] for idx in missing]
     if missing_ch and verbose != 'error':
-        warn('Channels ' + ', '.join(missing_ch) + ' were not assigned '
+        warn(f'Channel{_pl(missing_ch)} '
+             f'{", ".join(repr(ch) for ch in missing_ch)} not assigned '
              'voxels' + (' after applying SDR warp' if after_warp else ''))
 
 

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -1767,7 +1767,8 @@ def _warn_missing_chs(info, dig_image, after_warp, verbose=None):
     if missing_ch and verbose != 'error':
         warn(f'Channel{_pl(missing_ch)} '
              f'{", ".join(repr(ch) for ch in missing_ch)} not assigned '
-             'voxels' + (' after applying SDR warp' if after_warp else ''))
+             'voxels ' +
+             (f' after applying {after_warp}' if after_warp else ''))
 
 
 @verbose
@@ -1921,7 +1922,9 @@ def warp_montage_volume(montage, base_image, reg_affine, sdr_morph,
         image_from, template_brain, reg_affine, sdr_morph,
         interpolation='nearest')
 
-    _warn_missing_chs(montage, image_to, after_warp=True)
+    after_warp = \
+        'SDR warp' if sdr_morph is not None else 'affine transformation'
+    _warn_missing_chs(montage, image_to, after_warp=after_warp)
 
     # recover the contact positions as the center of mass
     warped_data = np.asanyarray(image_to.dataobj)

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -1813,7 +1813,7 @@ def test_scale_morph_labels(kind, scale, monkeypatch, tmp_path):
                 min_, max_ = 0.72, 0.76
             else:
                 # min_, max_ = 0.84, 0.855  # zooms='auto' values
-                min_, max_ = 0.54, 0.63
+                min_, max_ = 0.46, 0.63
             assert min_ < corr <= max_, scale
         else:
             assert_allclose(

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -1791,7 +1791,7 @@ def test_scale_morph_labels(kind, scale, monkeypatch, tmp_path):
         want_affine = np.eye(4)
         want_affine.ravel()[::5][:3] = 1. / np.array(scale, float)
         # just a scaling (to within 1% if zooms=None, 20% with zooms=10)
-        assert_allclose(want_affine[:, :3], got_affine[:, :3], atol=2e-1)
+        assert_allclose(want_affine[:, :3], got_affine[:, :3], atol=0.4)
         assert got_affine[3, 3] == 1.
         # little translation (to within `limit` mm)
         move = np.linalg.norm(got_affine[:3, 3])

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -1810,10 +1810,10 @@ def test_scale_morph_labels(kind, scale, monkeypatch, tmp_path):
                 min_, max_ = 0.57, 0.67
             elif scale == 1:
                 # min_, max_ = 0.85, 0.875  # zooms='auto' values
-                min_, max_ = 0.72, 0.75
+                min_, max_ = 0.72, 0.76
             else:
                 # min_, max_ = 0.84, 0.855  # zooms='auto' values
-                min_, max_ = 0.61, 0.63
+                min_, max_ = 0.54, 0.63
             assert min_ < corr <= max_, scale
         else:
             assert_allclose(

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -317,10 +317,11 @@ def test_warp_montage_volume():
         op.join(subjects_dir, 'sample', 'mri', 'brain.mgz'))
     template_brain = nib.load(
         op.join(subjects_dir, 'fsaverage', 'mri', 'brain.mgz'))
+    zooms = dict(translation=10, rigid=10, sdr=10)
     reg_affine, sdr_morph = compute_volume_registration(
-        subject_brain, template_brain, zooms=5,
-        niter=dict(translation=[5, 5, 5], rigid=[5, 5, 5],
-                   sdr=[3, 3, 3]), pipeline=('translation', 'rigid', 'sdr'))
+        subject_brain, template_brain, zooms=zooms,
+        niter=[3, 3, 3],
+        pipeline=('translation', 'rigid', 'sdr'))
     # make an info object with three channels with positions
     ch_coords = np.array([[-8.7040273, 17.99938754, 10.29604017],
                           [-14.03007764, 19.69978401, 12.07236939],
@@ -372,8 +373,7 @@ def test_warp_montage_volume():
     for i in range(len(montage.ch_names)):
         assert np.linalg.norm(
             np.array(np.where(np.array(image_to.dataobj) == i + 1)
-                     ).mean(axis=1) - ground_truth_warped_voxels[i]) < 5
-
+                     ).mean(axis=1) - ground_truth_warped_voxels[i]) < 8
     # test inputs
     with pytest.raises(ValueError, match='`thresh` must be between 0 and 1'):
         warp_montage_volume(
@@ -402,5 +402,4 @@ def test_warp_montage_volume():
         rpa=rpa['r'], coord_frame='mri')
     with pytest.warns(RuntimeWarning, match='not assigned'):
         warp_montage_volume(doubled_montage, CT, reg_affine,
-                            sdr_morph, 'sample',
-                            subjects_dir_from=subjects_dir)
+                            None, 'sample', subjects_dir_from=subjects_dir)

--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -39,7 +39,7 @@ from dipy.align import resample
 import mne
 from mne.datasets import fetch_fsaverage
 
-# paths to mne datasets - sample sEEG and FreeSurfer's fsaverage subject
+# paths to mne datasets: sample sEEG and FreeSurfer's fsaverage subject,
 # which is in MNI space
 misc_path = mne.datasets.misc.data_path()
 sample_path = mne.datasets.sample.data_path()
@@ -420,7 +420,7 @@ plot_overlay(template_brain, subject_brain,
 # .. warning:: Here we use custom ``zooms`` just for speed, in general we
 #              recommend using ``zooms=None`` (default) for highest accuracy!
 
-zooms = dict(translation=4, rigid=4, affine=6, sdr=6)
+zooms = dict(translation=10, rigid=10, affine=10, sdr=5)
 reg_affine, sdr_morph = mne.transforms.compute_volume_registration(
     subject_brain, template_brain, zooms=zooms, verbose=True)
 subject_brain_sdr = mne.transforms.apply_volume_registration(


### PR DESCRIPTION
Fix a bug in `compute_volume_registration` where the smoothing was the same regardless of `zooms`. The units are voxels so we should divide by the zooms to keep the effective smoothing radius. Same for the CCMetric.