### PR TITLE
[MRG] ENH: add verbose param to to_data_frame methods

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2076,7 +2076,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
     @verbose
     def to_data_frame(self, picks=None, index=None,
                       scalings=None, copy=True, long_format=False,
-                      time_format='ms', verbose=None):
+                      time_format='ms', *, verbose=None):
         """Export data in tabular structure as a pandas DataFrame.
 
         Channels are converted to columns in the DataFrame. By default,

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2074,7 +2074,6 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         return self, indices
 
     @verbose
-    @fill_doc
     def to_data_frame(self, picks=None, index=None,
                       scalings=None, copy=True, long_format=False,
                       time_format='ms', verbose=None):

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2095,9 +2095,9 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         %(df_copy)s
         %(df_longform_epo)s
         %(df_time_format)s
-        %(verbose)s
 
             .. versionadded:: 0.20
+        %(verbose)s
 
         Returns
         -------

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2073,10 +2073,11 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         # actually remove the indices
         return self, indices
 
+    @verbose
     @fill_doc
     def to_data_frame(self, picks=None, index=None,
                       scalings=None, copy=True, long_format=False,
-                      time_format='ms'):
+                      time_format='ms', verbose=None):
         """Export data in tabular structure as a pandas DataFrame.
 
         Channels are converted to columns in the DataFrame. By default,
@@ -2095,6 +2096,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         %(df_copy)s
         %(df_longform_epo)s
         %(df_time_format)s
+        %(verbose)s
 
             .. versionadded:: 0.20
 
@@ -2130,7 +2132,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         assert all(len(mdx) == len(mindex[0]) for mdx in mindex)
         # build DataFrame
         df = _build_data_frame(self, data, picks, long_format, mindex, index,
-                               default_index=['condition', 'epoch', 'time'])
+                               default_index=['condition', 'epoch', 'time'],
+                               verbose=verbose)
         return df
 
     def as_type(self, ch_type='grad', mode='fast'):

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2131,8 +2131,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         assert all(len(mdx) == len(mindex[0]) for mdx in mindex)
         # build DataFrame
         df = _build_data_frame(self, data, picks, long_format, mindex, index,
-                               default_index=['condition', 'epoch', 'time'],
-                               verbose=verbose)
+                               default_index=['condition', 'epoch', 'time'])
         return df
 
     def as_type(self, ch_type='grad', mode='fast'):

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -779,7 +779,6 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         return out
 
     @verbose
-    @fill_doc
     def to_data_frame(self, picks=None, index=None,
                       scalings=None, copy=True, long_format=False,
                       time_format='ms', verbose=None):

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -826,7 +826,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         mindex.append(('time', times))
         # build DataFrame
         df = _build_data_frame(self, data, picks, long_format, mindex, index,
-                               default_index=['time'], verbose=verbose)
+                               default_index=['time'])
         return df
 
 

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -797,9 +797,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(df_copy)s
         %(df_longform_raw)s
         %(df_time_format)s
-        %(verbose)s
 
             .. versionadded:: 0.20
+        %(verbose)s
 
         Returns
         -------

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -778,10 +778,11 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         return out
 
+    @verbose
     @fill_doc
     def to_data_frame(self, picks=None, index=None,
                       scalings=None, copy=True, long_format=False,
-                      time_format='ms'):
+                      time_format='ms', verbose=None):
         """Export data in tabular structure as a pandas DataFrame.
 
         Channels are converted to columns in the DataFrame. By default,
@@ -797,6 +798,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(df_copy)s
         %(df_longform_raw)s
         %(df_time_format)s
+        %(verbose)s
 
             .. versionadded:: 0.20
 
@@ -825,7 +827,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         mindex.append(('time', times))
         # build DataFrame
         df = _build_data_frame(self, data, picks, long_format, mindex, index,
-                               default_index=['time'])
+                               default_index=['time'], verbose=verbose)
         return df
 
 

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -781,7 +781,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
     @verbose
     def to_data_frame(self, picks=None, index=None,
                       scalings=None, copy=True, long_format=False,
-                      time_format='ms', verbose=None):
+                      time_format='ms', *, verbose=None):
         """Export data in tabular structure as a pandas DataFrame.
 
         Channels are converted to columns in the DataFrame. By default,

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1841,7 +1841,6 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         return int(np.ceil(buffer_size_sec * self.info['sfreq']))
 
     @verbose
-    @fill_doc
     def to_data_frame(self, picks=None, index=None,
                       scalings=None, copy=True, start=None, stop=None,
                       long_format=False, time_format='ms',

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1867,9 +1867,9 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             of the Raw object. ``None`` (the default) uses the last sample.
         %(df_longform_raw)s
         %(df_time_format_raw)s
-        %(verbose)s
 
             .. versionadded:: 0.20
+        %(verbose)s
 
         Returns
         -------

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1843,7 +1843,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
     @verbose
     def to_data_frame(self, picks=None, index=None,
                       scalings=None, copy=True, start=None, stop=None,
-                      long_format=False, time_format='ms',
+                      long_format=False, time_format='ms', *,
                       verbose=None):
         """Export data in tabular structure as a pandas DataFrame.
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1896,7 +1896,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         mindex.append(('time', times))
         # build DataFrame
         df = _build_data_frame(self, data, picks, long_format, mindex, index,
-                               default_index=['time'], verbose=verbose)
+                               default_index=['time'])
         return df
 
     def describe(self, data_frame=False):

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1840,10 +1840,12 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         buffer_size_sec = float(buffer_size_sec)
         return int(np.ceil(buffer_size_sec * self.info['sfreq']))
 
+    @verbose
     @fill_doc
     def to_data_frame(self, picks=None, index=None,
                       scalings=None, copy=True, start=None, stop=None,
-                      long_format=False, time_format='ms'):
+                      long_format=False, time_format='ms',
+                      verbose=None):
         """Export data in tabular structure as a pandas DataFrame.
 
         Channels are converted to columns in the DataFrame. By default, an
@@ -1866,6 +1868,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             of the Raw object. ``None`` (the default) uses the last sample.
         %(df_longform_raw)s
         %(df_time_format_raw)s
+        %(verbose)s
 
             .. versionadded:: 0.20
 
@@ -1894,7 +1897,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         mindex.append(('time', times))
         # build DataFrame
         df = _build_data_frame(self, data, picks, long_format, mindex, index,
-                               default_index=['time'])
+                               default_index=['time'], verbose=verbose)
         return df
 
     def describe(self, data_frame=False):

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1199,9 +1199,11 @@ class _BaseSourceEstimate(TimeMixin):
 
         return stcs
 
+    @verbose
     @fill_doc
     def to_data_frame(self, index=None, scalings=None,
-                      long_format=False, time_format='ms'):
+                      long_format=False, time_format='ms',
+                      verbose=None):
         """Export data in tabular structure as a pandas DataFrame.
 
         Vertices are converted to columns in the DataFrame. By default,
@@ -1215,6 +1217,7 @@ class _BaseSourceEstimate(TimeMixin):
         %(df_scalings)s
         %(df_longform_stc)s
         %(df_time_format)s
+        %(verbose)s
 
             .. versionadded:: 0.20
 
@@ -1251,7 +1254,8 @@ class _BaseSourceEstimate(TimeMixin):
         # build DataFrame
         df = _build_data_frame(self, data, None, long_format, mindex, index,
                                default_index=default_index,
-                               col_names=col_names, col_kind='source')
+                               col_names=col_names, col_kind='source',
+                               verbose=verbose)
         return df
 
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1216,9 +1216,9 @@ class _BaseSourceEstimate(TimeMixin):
         %(df_scalings)s
         %(df_longform_stc)s
         %(df_time_format)s
-        %(verbose)s
 
             .. versionadded:: 0.20
+        %(verbose)s
 
         Returns
         -------

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1201,7 +1201,7 @@ class _BaseSourceEstimate(TimeMixin):
 
     @verbose
     def to_data_frame(self, index=None, scalings=None,
-                      long_format=False, time_format='ms',
+                      long_format=False, time_format='ms', *,
                       verbose=None):
         """Export data in tabular structure as a pandas DataFrame.
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1253,8 +1253,7 @@ class _BaseSourceEstimate(TimeMixin):
         # build DataFrame
         df = _build_data_frame(self, data, None, long_format, mindex, index,
                                default_index=default_index,
-                               col_names=col_names, col_kind='source',
-                               verbose=verbose)
+                               col_names=col_names, col_kind='source')
         return df
 
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1200,7 +1200,6 @@ class _BaseSourceEstimate(TimeMixin):
         return stcs
 
     @verbose
-    @fill_doc
     def to_data_frame(self, index=None, scalings=None,
                       long_format=False, time_format='ms',
                       verbose=None):

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1018,7 +1018,6 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin):
         write_tfrs(fname, self, overwrite=overwrite)
 
     @verbose
-    @fill_doc
     def to_data_frame(self, picks=None, index=None, long_format=False,
                       time_format='ms', verbose=None):
         """Export data in tabular structure as a pandas DataFrame.

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1039,9 +1039,9 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin):
             Defaults to ``None``.
         %(df_longform_epo)s
         %(df_time_format)s
-        %(verbose)s
 
             .. versionadded:: 0.23
+        %(verbose)s
 
         Returns
         -------

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1089,7 +1089,7 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin):
         else:
             default_index = ['freq', 'time']
         df = _build_data_frame(self, data, picks, long_format, mindex, index,
-                               default_index=default_index, verbose=verbose)
+                               default_index=default_index)
         return df
 
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1019,7 +1019,7 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin):
 
     @verbose
     def to_data_frame(self, picks=None, index=None, long_format=False,
-                      time_format='ms', verbose=None):
+                      time_format='ms', *, verbose=None):
         """Export data in tabular structure as a pandas DataFrame.
 
         Channels are converted to columns in the DataFrame. By default,

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1017,9 +1017,10 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin):
         """
         write_tfrs(fname, self, overwrite=overwrite)
 
+    @verbose
     @fill_doc
     def to_data_frame(self, picks=None, index=None, long_format=False,
-                      time_format='ms'):
+                      time_format='ms', verbose=None):
         """Export data in tabular structure as a pandas DataFrame.
 
         Channels are converted to columns in the DataFrame. By default,
@@ -1039,6 +1040,7 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin):
             Defaults to ``None``.
         %(df_longform_epo)s
         %(df_time_format)s
+        %(verbose)s
 
             .. versionadded:: 0.23
 
@@ -1088,7 +1090,7 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin):
         else:
             default_index = ['freq', 'time']
         df = _build_data_frame(self, data, picks, long_format, mindex, index,
-                               default_index=default_index)
+                               default_index=default_index, verbose=verbose)
         return df
 
 

--- a/mne/utils/dataframe.py
+++ b/mne/utils/dataframe.py
@@ -87,5 +87,5 @@ def _build_data_frame(inst, data, picks, long_format, mindex, index,
         # convert channel/vertex/ch_type columns to factors
         to_factor = [c for c in df.columns.tolist()
                      if c not in ('time', 'value')]
-        _set_pandas_dtype(df, to_factor, 'category', verbose)
+        _set_pandas_dtype(df, to_factor, 'category')
     return df

--- a/mne/utils/dataframe.py
+++ b/mne/utils/dataframe.py
@@ -6,11 +6,12 @@
 
 import numpy as np
 
-from ._logging import logger
+from ._logging import logger, verbose
 from ..defaults import _handle_default
 
 
-def _set_pandas_dtype(df, columns, dtype):
+@verbose
+def _set_pandas_dtype(df, columns, dtype, verbose=None):
     """Try to set the right columns to dtype."""
     for column in columns:
         df[column] = df[column].astype(dtype)
@@ -46,8 +47,10 @@ def _convert_times(inst, times, time_format):
     return times
 
 
+@verbose
 def _build_data_frame(inst, data, picks, long_format, mindex, index,
-                      default_index, col_names=None, col_kind='channel'):
+                      default_index, col_names=None, col_kind='channel',
+                      verbose=None):
     """Build DataFrame from MNE-object-derived data array."""
     # private function; pandas already checked in calling function
     from pandas import DataFrame
@@ -84,5 +87,5 @@ def _build_data_frame(inst, data, picks, long_format, mindex, index,
         # convert channel/vertex/ch_type columns to factors
         to_factor = [c for c in df.columns.tolist()
                      if c not in ('time', 'value')]
-        _set_pandas_dtype(df, to_factor, 'category')
+        _set_pandas_dtype(df, to_factor, 'category', verbose)
     return df


### PR DESCRIPTION
When calling `.to_data_frame` on a number of objects in a loop, the output can get quite verbose. Here I add the `verbose` decorator to the function calls where appropriate (I hope).

The logging that gets too spammy happens in `_set_pandas_dtype`.