### PR TITLE
MRG: Fix scaling issue in Report.add_trans()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -60,7 +60,7 @@ Enhancements
 
 - Drastically speed up butterfly plot generation in :meth:`mne.Report.add_raw`. We now don't plot annotations anymore; however, we feel that the speed improvements justify this change, also considering the annotations were of limited use in the displayed one-second time slices anyway (:gh:`10114`, :gh:`10116` by `Richard Höchenberger`_)
 
-- In :class:`mne.Report`, limit the width of automatically generated figures to a maximum of 850 pixels (450 pixels for :class:`mne.SourceEstimate` plots), and the resolution to 100 DPI to reduce file size, memory consumption, and – in some cases like :meth:`mne.Report.add_stc` – processing time (:gh:`10126`, :gh:`10129`, :gh:`10135`, :gh:`xxx` by `Richard Höchenberger`_)
+- In :class:`mne.Report`, limit the width of automatically generated figures to a maximum of 850 pixels (450 pixels for :class:`mne.SourceEstimate` plots), and the resolution to 100 DPI to reduce file size, memory consumption, and – in some cases like :meth:`mne.Report.add_stc` – processing time (:gh:`10126`, :gh:`10129`, :gh:`10135`, :gh:`10142` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -60,7 +60,7 @@ Enhancements
 
 - Drastically speed up butterfly plot generation in :meth:`mne.Report.add_raw`. We now don't plot annotations anymore; however, we feel that the speed improvements justify this change, also considering the annotations were of limited use in the displayed one-second time slices anyway (:gh:`10114`, :gh:`10116` by `Richard Höchenberger`_)
 
-- In :class:`mne.Report`, limit the width of automatically generated figures to a maximum of 850 pixels (450 pixels for :class:`mne.SourceEstimate` plots), and the resolution to 100 DPI to reduce file size, memory consumption, and – in some cases like :meth:`mne.Report.add_stc` – processing time (:gh:`10126`, :gh:`10129`, :gh:`10135` by `Richard Höchenberger`_)
+- In :class:`mne.Report`, limit the width of automatically generated figures to a maximum of 850 pixels (450 pixels for :class:`mne.SourceEstimate` plots), and the resolution to 100 DPI to reduce file size, memory consumption, and – in some cases like :meth:`mne.Report.add_stc` – processing time (:gh:`10126`, :gh:`10129`, :gh:`10135`, :gh:`xxx` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -458,11 +458,9 @@ def _iterate_trans_views(function, **kwargs):
     from ..viz.backends.renderer import backend
     try:
         try:
-            return _itv(
-                function, fig, surfaces={'head-dense': 1.}, **kwargs
-            )
+            return _itv(function, fig, surfaces=['head-dense'], **kwargs)
         except IOError:
-            return _itv(function, fig, surfaces={'head': 1.}, **kwargs)
+            return _itv(function, fig, surfaces=['head'], **kwargs)
     finally:
         backend._close_3d_figure(fig)
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -458,9 +458,11 @@ def _iterate_trans_views(function, **kwargs):
     from ..viz.backends.renderer import backend
     try:
         try:
-            return _itv(function, fig, surfaces=['head-dense'], **kwargs)
+            return _itv(
+                function, fig, surfaces={'head-dense': 1.}, **kwargs
+            )
         except IOError:
-            return _itv(function, fig, surfaces=['head'], **kwargs)
+            return _itv(function, fig, surfaces={'head': 1.}, **kwargs)
     finally:
         backend._close_3d_figure(fig)
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2298,12 +2298,12 @@ def _figure_agg(**kwargs):
     return fig
 
 
-def _ndarray_to_fig(img):
+def _ndarray_to_fig(img, dpi=100):
     """Convert to MPL figure, adapted from matplotlib.image.imsave."""
-    dpi = 100
     figsize = np.array(img.shape[:2][::-1]) / dpi
     fig = _figure_agg(dpi=dpi, figsize=figsize, frameon=False)
-    fig.figimage(img, resize=True)
+    ax = fig.add_axes([0, 0, 1, 1])
+    ax.imshow(img)
     return fig
 
 

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -287,11 +287,11 @@ report.save('report_mri_and_bem.html', overwrite=True)
 # Adding coregistration
 # ^^^^^^^^^^^^^^^^^^^^^
 #
-# The ``head -> mri`` transformation (obtained by "coregistration") can be
-# visualized via :meth:`mne.Report.add_trans`. The method expects the
-# transformation either as a `~mne.transforms.Transform` object or as a path to
-# a ``trans.fif`` file, the FreeSurfer subject name and subjects directory, and
-# a title.
+# The sensor alignment (``head -> mri`` transformation obtained by
+# "coregistration") can be visualized via :meth:`mne.Report.add_trans`. The
+# method expects the transformation either as a `~mne.transforms.Transform`
+# object or as a path to a ``trans.fif`` file, the FreeSurfer subject name and
+# subjects directory, and a title.
 
 trans_path = sample_dir / 'sample_audvis_raw-trans.fif'
 


### PR DESCRIPTION
We observed that the figure created by `Report.add_trans()` was cropped. I narrowed this down to the `_ndarray_to_fig()` function, which uses `Figure.figimage()`, which seems to later interfere with our attempts to scale / adjust resolution of the figure.

My fix is to not use `Figure.figimage()` anymore, and instead add an axes that spans across the entire figure, and use `imshow()`.

With these changes, things seem to be looking good again.

It could be that this issue was introduced through #10129, but I haven't invested much time to actually verify this hypothesis.