### PR TITLE
Clarify supported software versions for NIRx reader

### DIFF
--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -87,7 +87,9 @@ saturated : str
     .. versionadded:: 0.24
 """
 docdict['nirx_notes'] = """\
-This function has only been tested with NIRScout and NIRSport1 devices.
+This function has only been tested with NIRScout and NIRSport devices,
+and with the NIRStar software version 15 and above and Aurora software
+2021 and above.
 
 The NIRSport device can detect if the amplifier is saturated.
 Starting from NIRStar 14.2, those saturated values are replaced by NaNs

--- a/tutorials/io/30_reading_fnirs_data.py
+++ b/tutorials/io/30_reading_fnirs_data.py
@@ -83,7 +83,7 @@ NIRx recordings can be read in using :func:`mne.io.read_raw_nirx`.
 The NIRx device stores data directly to a directory with multiple file types,
 MNE-Python extracts the appropriate information from each file.
 MNE-Python only supports NIRx files recorded with NIRStar
-version 15.0 and above.
+version 15.0 and above and Aurora version 2021 and above.
 MNE-Python supports reading data from NIRScout and NIRSport devices.
 
 


### PR DESCRIPTION
#### Reference issue
After reading the issue #10147 I noticed that the tutorial specified we only support NIRx files above a certain version, but the documentation for the reader did not. Also, in #9401 and #9808 we added support for data acquired with the Aurora software, so I add that to the docs too



#### What does this implement/fix?
Clarified the vendor versions that we support reading data from. The two software use different versioning schemes, so that's a bit confusing.

