### PR TITLE
fix matplotlib intersphinx urls

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -131,7 +131,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'numpy': ('https://numpy.org/devdocs', None),
     'scipy': ('https://scipy.github.io/devdocs', None),
-    'matplotlib': ('https://matplotlib.org', None),
+    'matplotlib': ('https://matplotlib.org/stable', None),
     'sklearn': ('https://scikit-learn.org/stable', None),
     'numba': ('https://numba.pydata.org/numba-doc/latest', None),
     'joblib': ('https://joblib.readthedocs.io/en/latest', None),


### PR DESCRIPTION
follow-up to #10136 which passed CircleCI at the time but now fails.  Not sure if it was an upstream change or what, but this fixes it and appears not to break anything else while we're at it.
