### PR TITLE
[MAINT, MRG] Update warning filter

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -126,6 +126,7 @@ def pytest_configure(config):
     ignore:.*Found the following unknown channel type.*:RuntimeWarning
     ignore:.*np\.MachAr.*:DeprecationWarning
     ignore:.*Passing unrecognized arguments to super.*:DeprecationWarning
+    ignore:.*distutils Version classes are deprecated.*:DeprecationWarning
     always::ResourceWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):


### PR DESCRIPTION
Fixes warnings from ~~`nibabel`~~ `nilearn`. closes #10158 