### PR TITLE
Fix issue #9383

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -480,7 +480,8 @@ class Annotations(object):
         self.ch_names = self.ch_names[order]
 
     @verbose
-    def crop(self, tmin=None, tmax=None, emit_warning=False, verbose=None, include_tmax=True):
+    def crop(self, tmin=None, tmax=None, emit_warning=False,
+             verbose=None, include_tmax=True):
         """Remove all annotation that are outside of [tmin, tmax].
 
         The method operates inplace.
@@ -495,6 +496,7 @@ class Annotations(object):
             Whether to emit warnings when limiting or omitting annotations.
             Defaults to False.
         %(verbose_meth)s
+        %(include_tmax)s
 
         Returns
         -------
@@ -544,8 +546,10 @@ class Annotations(object):
                 clip_left_elem.append(absolute_onset < absolute_tmin)
                 if clip_left_elem[-1]:
                     absolute_onset = absolute_tmin
-                clip_right_elem.append(absolute_offset > absolute_tmax if include_tmax else
-                                    absolute_offset >= absolute_tmax)
+                if include_tmax:
+                    clip_right_elem.append(absolute_offset > absolute_tmax)
+                else:
+                    clip_right_elem.append(absolute_offset >= absolute_tmax)
                 if clip_right_elem[-1]:
                     absolute_offset = absolute_tmax
                 if clip_left_elem[-1] or clip_right_elem[-1]:

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -480,7 +480,7 @@ class Annotations(object):
         self.ch_names = self.ch_names[order]
 
     @verbose
-    def crop(self, tmin=None, tmax=None, emit_warning=False, verbose=None):
+    def crop(self, tmin=None, tmax=None, emit_warning=False, verbose=None, include_tmax=True):
         """Remove all annotation that are outside of [tmin, tmax].
 
         The method operates inplace.
@@ -533,7 +533,8 @@ class Annotations(object):
             absolute_onset = timedelta(0, onset) + offset
             absolute_offset = absolute_onset + timedelta(0, duration)
             out_of_bounds.append(
-                absolute_onset > absolute_tmax or
+                (absolute_onset > absolute_tmax if include_tmax else
+                 absolute_onset >= absolute_tmax) or
                 absolute_offset < absolute_tmin)
             if out_of_bounds[-1]:
                 clip_left_elem.append(False)
@@ -543,7 +544,8 @@ class Annotations(object):
                 clip_left_elem.append(absolute_onset < absolute_tmin)
                 if clip_left_elem[-1]:
                     absolute_onset = absolute_tmin
-                clip_right_elem.append(absolute_offset > absolute_tmax)
+                clip_right_elem.append(absolute_offset > absolute_tmax if include_tmax else
+                                    absolute_offset >= absolute_tmax)
                 if clip_right_elem[-1]:
                     absolute_offset = absolute_tmax
                 if clip_left_elem[-1] or clip_right_elem[-1]:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -651,7 +651,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
     @verbose
     def set_annotations(self, annotations, emit_warning=True,
-                        on_missing='raise', *, verbose=None, include_tmax=True):
+                        on_missing='raise', *, verbose=None,
+                        include_tmax=True):
         """Setter for annotations.
 
         This setter checks if they are inside the data range.

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -665,6 +665,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             Whether to emit warnings when cropping or omitting annotations.
         %(on_missing_ch_names)s
         %(verbose_meth)s
+        %(include_tmax)s
 
         Returns
         -------
@@ -692,16 +693,18 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             new_annotations = annotations.copy()
             new_annotations._prune_ch_names(self.info, on_missing)
             if annotations.orig_time is None:
-                # note that (self.times[-1] + delta) might be equal to the original
-                # end time of the cropping of the raw
+                # note that (self.times[-1]+delta) might be equal to
+                # the original end_time of the cropping of the raw
                 new_annotations.crop(0, self.times[-1] + delta,
-                                     emit_warning=emit_warning, include_tmax=include_tmax)
+                                     emit_warning=emit_warning,
+                                     include_tmax=include_tmax)
                 new_annotations.onset += self._first_time
             else:
                 tmin = meas_date + timedelta(0, self._first_time)
                 tmax = tmin + timedelta(seconds=self.times[-1] + delta)
                 new_annotations.crop(tmin=tmin, tmax=tmax,
-                                     emit_warning=emit_warning, include_tmax=include_tmax)
+                                     emit_warning=emit_warning,
+                                     include_tmax=include_tmax)
                 new_annotations.onset -= (
                     meas_date - new_annotations.orig_time).total_seconds()
             new_annotations._orig_time = meas_date
@@ -1352,7 +1355,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         if self.annotations.orig_time is None:
             self.annotations.onset -= tmin
         # now call setter to filter out annotations outside of interval
-        self.set_annotations(self.annotations, emit_warning=False, include_tmax=include_tmax)
+        self.set_annotations(self.annotations, emit_warning=False,
+                             include_tmax=include_tmax)
 
         return self
 

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -270,6 +270,7 @@ def test_crop(tmp_path):
         assert_allclose(getattr(raw_copied.annotations, attr),
                         getattr(raw_loaded.annotations, attr))
 
+
 def test_crop_raw_with_annotations():
     # generate a sample dataset from noise
     n_channels = 2
@@ -277,27 +278,28 @@ def test_crop_raw_with_annotations():
     length_seconds = 60
 
     info = mne.create_info(n_channels, sfreq=sampling_freq,
-                            ch_types=['eeg', 'eeg'])
-    data =  np.random.randn(n_channels, sampling_freq * length_seconds)
+                           ch_types=['eeg', 'eeg'])
+    data = np.random.randn(n_channels, sampling_freq * length_seconds)
     simulated_raw = mne.io.RawArray(data, info)
 
     # insert annotations at 0, 10, 20, and 30 seconds
     annotations = mne.Annotations(onset=[0, 10, 20, 30],
-                                duration=[0, 0, 0, 0],
-                                description=['test'] * 4)
+                                  duration=[0, 0, 0, 0],
+                                  description=['test'] * 4)
     simulated_raw.set_annotations(annotations)
 
     # crop a copy of the data, setting 'include_tmax' to False,
     # (up to but not including 20 seconds)
     simulated_cropped = simulated_raw.copy().crop(tmin=0, tmax=20,
-                                             include_tmax=False)
+                                                  include_tmax=False)
     # issue #9383
     # final timestamp is 19.998, which is correct (data is at 500 Hz,
     # we wanted up to but not including 20 seconds)
     # print('Final time is {}'.format(simulated_cropped.times[-1]))
     # but the annotation that occurs at the 20 second point is retained
     # print(simulated_cropped.annotations[-1])
-    # include_tmax set when cropping raw should be passed down into set_annotations
+    # include_tmax set when cropping raw should be passed down
+    # into the set_annotations method
     assert_equal(len(simulated_cropped.annotations), 2)
 
 


### PR DESCRIPTION
Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

#### Reference issue
Fixes #9383.


#### What does this implement/fix?
This PR fixes the following issue: cropping data retains annotations that are outside the maximum range of data by 1 sample.


#### Additional information
As mentioned in #9383, set_annotations will ignore the include_tmax parameter passed into the crop method and thus causing this problem.
