### PR TITLE
MRG, DOC: Clarify lambda/SNR

### DIFF
--- a/doc/_includes/inverse.rst
+++ b/doc/_includes/inverse.rst
@@ -156,8 +156,8 @@ distribution.
 
 A convenient choice for the source-covariance matrix :math:`R` is such that
 :math:`\text{trace}(\tilde{G} R \tilde{G}^\top) / \text{trace}(I) = 1`. With this
-choice we can approximate :math:`\lambda^2 \sim 1/SNR`, where SNR is the
-(power) signal-to-noise ratio of the whitened data.
+choice we can approximate :math:`\lambda^2 \sim 1/rm{SNR}^2`, where SNR is the
+(amplitude) signal-to-noise ratio of the whitened data.
 
 .. note::
    The definition of the signal to noise-ratio/ :math:`\lambda^2` relationship

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1705,7 +1705,7 @@ def estimate_snr(evoked, inv, verbose=None):
         \tilde{M} = R^\frac{1}{2}V\Gamma U^T
 
     The values in the diagonal matrix :math:`\Gamma` are expressed in terms
-    of the chosen regularization :math:`\lambda\approx\frac{1}{\rm{SNR}^2}`
+    of the chosen regularization :math:`\lambda^2 \sim 1/\rm{SNR}^2`
     and singular values :math:`\lambda_k` as:
 
     .. math::


### PR DESCRIPTION
Closes #10149

Make everything consistent by just talking about SNR of amplitudes, and correct an error in `estimate_snr`