### PR TITLE
adds link to MNE-ARI package to preinstall page

### DIFF
--- a/doc/install/pre_install.rst
+++ b/doc/install/pre_install.rst
@@ -63,6 +63,8 @@ MNE-Python, including packages for:
   the Bayesian algorithm SESAME (`sesameeg`_)
 - GLM and group level analysis of near-infrared spectroscopy data (`mne-nirs`_)
 - M/EEG inverse solutions using artificial neural networks (`ESINet`_)
+- All-Resolutions Inference (ARI) for statically valid circular inference
+and effect localization (`MNE-ARI`_)
 
 
 What should I install?
@@ -107,3 +109,4 @@ Help with installation is available through the `MNE Forum`_. See the
 .. _sesameeg: https://pybees.github.io/sesameeg
 .. _mne-nirs: https://github.com/mne-tools/mne-nirs
 .. _ESINet: https://github.com/LukeTheHecker/ESINet
+.. _MNE-ARI: https://github.com/john-veillette/mne_ari

--- a/doc/install/pre_install.rst
+++ b/doc/install/pre_install.rst
@@ -63,7 +63,7 @@ MNE-Python, including packages for:
   the Bayesian algorithm SESAME (`sesameeg`_)
 - GLM and group level analysis of near-infrared spectroscopy data (`mne-nirs`_)
 - M/EEG inverse solutions using artificial neural networks (`ESINet`_)
-- All-Resolutions Inference (ARI) for statically valid circular inference
+- All-Resolutions Inference (ARI) for statistically valid circular inference
 and effect localization (`MNE-ARI`_)
 
 


### PR DESCRIPTION
#### Reference issue
n/a

#### What does this implement/fix?
Just adds a link to my new [MNE-ARI](https://github.com/john-veillette/mne_ari) to the pre-install page. The package implements the methods in [Rosenblatt et al. (2018)](https://doi.org/10.1016/j.neuroimage.2018.07.060) and [Andreella et al. (2020)](https://arxiv.org/abs/2012.00368). 

#### Additional information
Nothing comes to mind but I'm happy to field questions!
