### PR TITLE
FIX - allow datasets without headshape dig to be coregistered in report

### DIFF
--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -490,15 +490,18 @@ def _itv(function, fig, **kwargs):
          np.concatenate(images[3:], axis=1)],
         axis=0)
 
-    dists = dig_mri_distances(info=kwargs['info'],
-                              trans=kwargs['trans'],
-                              subject=kwargs['subject'],
-                              subjects_dir=kwargs['subjects_dir'],
-                              on_defects='ignore')
-
+    try:
+        dists = dig_mri_distances(info=kwargs['info'],
+                                  trans=kwargs['trans'],
+                                  subject=kwargs['subject'],
+                                  subjects_dir=kwargs['subjects_dir'],
+                                  on_defects='ignore')
+        caption = (f'Average distance from {len(dists)} digitized points to '
+                   f'head: {1e3 * np.mean(dists):.2f} mm')
+    except BaseException as e:
+        caption = ('Distances could not be calculated from digitized points')
+        warn(e)
     img = _fig_to_img(images, image_format='png')
-    caption = (f'Average distance from {len(dists)} digitized points to '
-               f'head: {1e3 * np.mean(dists):.2f} mm')
 
     return img, caption
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -502,7 +502,7 @@ def _itv(function, fig, **kwargs):
         caption = (f'Average distance from {len(dists)} digitized points to '
                    f'head: {1e3 * np.mean(dists):.2f} mm')
     except BaseException as e:
-        caption = ('Distances could not be calculated from digitized points')
+        caption = 'Distances could not be calculated from digitized points'
         warn(f'{caption}: {e}')
     img = _fig_to_img(images, image_format='png')
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -454,7 +454,10 @@ def _get_bem_contour_figs_as_arrays(
 def _iterate_trans_views(function, **kwargs):
     """Auxiliary function to iterate over views in trans fig."""
     from ..viz import create_3d_figure
-    fig = create_3d_figure((800, 800), bgcolor=(0.5, 0.5, 0.5))
+    from ..viz.backends.renderer import MNE_3D_BACKEND_TESTING
+    # TODO: Eventually maybe we should expose the size option?
+    size = (80, 80) if MNE_3D_BACKEND_TESTING else (800, 800)
+    fig = create_3d_figure(size, bgcolor=(0.5, 0.5, 0.5))
     from ..viz.backends.renderer import backend
     try:
         try:
@@ -500,7 +503,7 @@ def _itv(function, fig, **kwargs):
                    f'head: {1e3 * np.mean(dists):.2f} mm')
     except BaseException as e:
         caption = ('Distances could not be calculated from digitized points')
-        warn(e)
+        warn(f'{caption}: {e}')
     img = _fig_to_img(images, image_format='png')
 
     return img, caption

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -22,7 +22,7 @@ from matplotlib import pyplot as plt
 from mne import Epochs, read_events, read_evokeds, read_cov, pick_channels_cov
 from mne.report import report as report_mod
 from mne.report.report import CONTENT_ORDER
-from mne.io import read_raw_fif
+from mne.io import read_raw_fif, read_info
 from mne.datasets import testing
 from mne.report import Report, open_report, _ReportScraper, report
 from mne.utils import requires_nibabel, Bunch, requires_h5py, requires_sklearn
@@ -827,8 +827,20 @@ def test_manual_report_2d(tmp_path, invisible_fig):
 def test_manual_report_3d(tmp_path, renderer):
     """Simulate adding 3D sections."""
     r = Report(title='My Report')
-    r.add_trans(trans=trans_fname, info=raw_fname, title='my coreg',
-                subject='sample', subjects_dir=subjects_dir)
+    info = read_info(raw_fname)
+    with info._unlock():
+        dig, info['dig'] = info['dig'], info['dig'][:7]
+    add_kwargs = dict(trans=trans_fname, info=info, subject='sample',
+                      subjects_dir=subjects_dir)
+    with pytest.warns(RuntimeWarning, match='could not be calculated'):
+        r.add_trans(title='coreg no dig', **add_kwargs)
+    with info._unlock():
+        info['dig'] = dig
+    # TODO: We should probably speed this up. We could expose an arg to allow\
+    # use of sparse rather than dense head, and also possibly an arg to specify
+    # which views to actually show. Both of these could probably be useful to
+    # end-users, too.
+    r.add_trans(title='my coreg', **add_kwargs)
     r.add_bem(subject='sample', subjects_dir=subjects_dir, title='my bem',
               decim=100)
     r.add_inverse_operator(

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -829,14 +829,14 @@ def test_manual_report_3d(tmp_path, renderer):
     r = Report(title='My Report')
     info = read_info(raw_fname)
     with info._unlock():
-        dig, info['dig'] = info['dig'], info['dig'][:7]
+        dig, info['dig'] = info['dig'], []
     add_kwargs = dict(trans=trans_fname, info=info, subject='sample',
                       subjects_dir=subjects_dir)
     with pytest.warns(RuntimeWarning, match='could not be calculated'):
         r.add_trans(title='coreg no dig', **add_kwargs)
     with info._unlock():
         info['dig'] = dig
-    # TODO: We should probably speed this up. We could expose an arg to allow\
+    # TODO: We should probably speed this up. We could expose an arg to allow
     # use of sparse rather than dense head, and also possibly an arg to specify
     # which views to actually show. Both of these could probably be useful to
     # end-users, too.


### PR DESCRIPTION

#### What does this implement/fix?
If data is acquired without a headshape, the report will error during the coregistration.  The distance measurement calculation will fail because the headshape can't be evaluated.


#### Additional information
Our lab currently does not collect a headshape, but rather uses localized fiducials with vitamin E capsules on the MRI.  Running data through the mne-bids-pipeline fails during report generation.
