### PR TITLE
MRG: Add drop_log_ignore parameter to Report.add_epochs()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -68,6 +68,8 @@ Enhancements
 
 - :func:`mne.get_head_surf` and :func:`mne.dig_mri_distances` gained a new parameter, ``on_defects``, controlling how to handle surfaces with topological defects (:gh:`10175` by `Richard Höchenberger`_)
 
+- :meth:`mne.Report.add_epochs` gained a new parameter, ``drop_log_ignore``, to control which drop reasons to omit when creating the drop log plot (:gh:`xxx` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -68,7 +68,7 @@ Enhancements
 
 - :func:`mne.get_head_surf` and :func:`mne.dig_mri_distances` gained a new parameter, ``on_defects``, controlling how to handle surfaces with topological defects (:gh:`10175` by `Richard Höchenberger`_)
 
-- :meth:`mne.Report.add_epochs` gained a new parameter, ``drop_log_ignore``, to control which drop reasons to omit when creating the drop log plot (:gh:`xxx` by `Richard Höchenberger`_)
+- :meth:`mne.Report.add_epochs` gained a new parameter, ``drop_log_ignore``, to control which drop reasons to omit when creating the drop log plot (:gh:`10182` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -866,8 +866,8 @@ class Report(object):
 
     @fill_doc
     def add_epochs(
-        self, epochs, title, *, psd=True, projs=None, tags=('epochs',),
-        replace=False, topomap_kwargs=None
+        self, epochs, title, *, psd=True, projs=None, topomap_kwargs=None,
+        drop_log_ignore=('IGNORED',), tags=('epochs',), replace=False
     ):
         """Add `~mne.Epochs` to the report.
 
@@ -892,9 +892,13 @@ class Report(object):
             If ``True``, add PSD plots based on all ``epochs``. If ``False``,
             do not add PSD plots.
         %(report_projs)s
+        %(topomap_kwargs)s
+        drop_log_ignore : array-like of str
+            The drop reasons to ignore when creating the drop log bar plot.
+            All epochs for which a drop reason listed here appears in
+            ``epochs.drop_log`` will be excluded from the drop log plot.
         %(report_tags)s
         %(report_replace)s
-        %(topomap_kwargs)s
 
         Notes
         -----
@@ -908,9 +912,10 @@ class Report(object):
             epochs=epochs,
             psd=psd,
             add_projs=add_projs,
+            topomap_kwargs=topomap_kwargs,
+            drop_log_ignore=drop_log_ignore,
             tags=tags,
             image_format=self.image_format,
-            topomap_kwargs=topomap_kwargs,
         )
         (repr_html, metadata_html, erp_imgs_html, drop_log_html, psd_html,
          ssp_projs_html) = htmls
@@ -3352,8 +3357,10 @@ class Report(object):
         )
         return metadata_html
 
-    def _render_epochs(self, *, epochs, psd, add_projs, image_format, tags,
-                       topomap_kwargs):
+    def _render_epochs(
+        self, *, epochs, psd, add_projs, topomap_kwargs, drop_log_ignore,
+        image_format, tags
+    ):
         """Render epochs."""
         if isinstance(epochs, BaseEpochs):
             fname = epochs.filename
@@ -3431,7 +3438,9 @@ class Report(object):
                     id=dom_id, div_klass='epochs', title=title, tags=tags
                 )
             else:
-                fig = epochs.plot_drop_log(subject=self.subject, show=False)
+                fig = epochs.plot_drop_log(
+                    subject=self.subject, ignore=drop_log_ignore, show=False
+                )
                 tight_layout(fig=fig)
                 _constrain_fig_resolution(
                     fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -3431,7 +3431,7 @@ class Report(object):
         if epochs._bad_dropped:
             title = 'Drop log'
             dom_id = self._get_dom_id()
-            if epochs.drop_log_stats() == 0:  # No drops
+            if epochs.drop_log_stats(ignore=drop_log_ignore) == 0:  # No drops
                 drop_log_img_html = _html_element(
                     html='No epochs exceeded the rejection thresholds. '
                          'Nothing was dropped.',


### PR DESCRIPTION
This allows uers to specify which drop reasons to ignore during creation of the drop log figure.

I want to make use of this in the MNE-BIDS-Pipeline (where, for now, I'd like to not exclude **any** drop reasons from the figure; so I need a way override the current default, hence this PR)