### PR TITLE
MRG: Include absolute numbers in drop log plot

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -70,6 +70,8 @@ Enhancements
 
 - :meth:`mne.Report.add_epochs` gained a new parameter, ``drop_log_ignore``, to control which drop reasons to omit when creating the drop log plot (:gh:`10182` by `Richard Höchenberger`_)
 
+- :meth:`mne.Epochs.plot_drop_log` now also includes the absolute number of epochs dropped in the title (:gh:`10186` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1268,7 +1268,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         return _drop_log_stats(self.drop_log, ignore)
 
     @copy_function_doc_to_method_doc(plot_drop_log)
-    def plot_drop_log(self, threshold=0, n_max_plot=20, subject='Unknown subj',
+    def plot_drop_log(self, threshold=0, n_max_plot=20, subject=None,
                       color=(0.9, 0.9, 0.9), width=0.8, ignore=('IGNORED',),
                       show=True):
         if not self._bad_dropped:

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -561,7 +561,7 @@ def _plot_epochs_image(image, style_axes=True, epochs=None, picks=None,
     return fig
 
 
-def plot_drop_log(drop_log, threshold=0, n_max_plot=20, subject='Unknown subj',
+def plot_drop_log(drop_log, threshold=0, n_max_plot=20, subject=None,
                   color='lightgray', width=0.8, ignore=('IGNORED',),
                   show=True):
     """Show the channel stats based on a drop_log from Epochs.
@@ -581,6 +581,9 @@ def plot_drop_log(drop_log, threshold=0, n_max_plot=20, subject='Unknown subj',
 
         .. versionchanged:: 0.23
            Added support for ``None``.
+
+        .. versionchanged:: 1.0
+           Defaults to ``None``.
     color : tuple | str
         Color to use for the bars.
     width : float
@@ -602,12 +605,18 @@ def plot_drop_log(drop_log, threshold=0, n_max_plot=20, subject='Unknown subj',
         logger.info('Percent dropped epochs < supplied threshold; not '
                     'plotting drop log.')
         return
+    absolute = len([x for x in drop_log if len(x)
+                    if not any(y in ignore for y in x)])
+    n_epochs_before_drop = len([x for x in drop_log
+                                if not any(y in ignore for y in x)])
+
     scores = Counter([ch for d in drop_log for ch in d if ch not in ignore])
     ch_names = np.array(list(scores.keys()))
     counts = np.array(list(scores.values()))
     # init figure, handle easy case (no drops)
     fig, ax = plt.subplots()
-    title = f'{percent:.1f}% of all epochs rejected'
+    title = (f'{absolute} of {n_epochs_before_drop} epochs removed '
+             f'({percent:.1f}%)')
     if subject is not None:
         title = f'{subject}: {title}'
     ax.set_title(title)
@@ -626,7 +635,7 @@ def plot_drop_log(drop_log, threshold=0, n_max_plot=20, subject='Unknown subj',
     ax.set_xticks(x)
     ax.set_xticklabels(ch_names[order[:n_bars]], rotation=45, size=10,
                        horizontalalignment='right')
-    ax.set_ylabel('% of epochs rejected')
+    ax.set_ylabel('% of epochs removed')
     ax.grid(axis='y')
     tight_layout(pad=1, fig=fig)
     plt_show(show)


### PR DESCRIPTION
- absolute numbers in addition to relative numbers
- change wording from "rejected" to "removed"
- by default omit the subject name instead of printing `Unknown subj`

old:
![old](https://user-images.githubusercontent.com/2046265/148545715-1dc79c3e-0d07-4a49-b70c-e8e97e9f7298.png)

new:
![new](https://user-images.githubusercontent.com/2046265/148545729-3b86e75e-6de4-4271-a46b-92e3c24a51ec.png)

MWE:
```python
# %%
from pathlib import Path
import mne


sample_dir = Path(mne.datasets.sample.data_path())
sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'

raw = mne.io.read_raw_fif(sample_fname)
raw.crop(tmax=60)

events = mne.find_events(raw, stim_channel='STI 014')
event_id = {'auditory/left': 1, 'auditory/right': 2, 'visual/left': 3,
            'visual/right': 4, 'face': 5, 'buttonpress': 32}

epochs = mne.Epochs(raw, events=events, event_id=event_id,
                    tmin=-0.2, tmax=0.5, baseline=(None, 0),
                    preload=True)

epochs = epochs['left']
epochs.drop(range(10))

epochs.plot_drop_log()
```

WIP:
- [ ] changelog entry
