### PR TITLE
ENH: add helmet view option in coreg

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -74,6 +74,8 @@ Enhancements
 
 - Annotations from a :class:`~mne.io.Raw` object are now preserved by the :class:`~mne.Epochs` constructor and are supported when saving Epochs (:gh:`9969` and :gh:`10019` by `Adam Li`_)
 
+- Add a button to display the MEG helmet in the coregistration GUI (:gh:`10200` but `Guillaume Favelier`_)
+
 Bugs
 ~~~~
 

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -18,8 +18,8 @@ from ..io._read_raw import supported as raw_supported_types
 from ..coreg import Coregistration, _is_mri_subject
 from ..viz._3d import (_plot_head_surface, _plot_head_fiducials,
                        _plot_head_shape_points, _plot_mri_fiducials,
-                       _plot_hpi_coils, _plot_sensors)
-from ..transforms import (read_trans, write_trans, _ensure_trans,
+                       _plot_hpi_coils, _plot_sensors, _plot_helmet)
+from ..transforms import (read_trans, write_trans, _ensure_trans, _get_trans,
                           rotation_angles, _get_transforms_to_coord_frame)
 from ..utils import (get_subjects_dir, check_fname, _check_fname, fill_doc,
                      warn, verbose, logger)
@@ -105,6 +105,7 @@ class CoregistrationUI(HasTraits):
     _eeg_channels = Bool()
     _head_resolution = Bool()
     _head_transparency = Bool()
+    _helmet = Bool()
     _grow_hair = Float()
     _scale_mode = Unicode()
     _icp_fid_match = Unicode()
@@ -154,6 +155,7 @@ class CoregistrationUI(HasTraits):
             eeg_channels=_get_default(eeg_channels, True),
             head_resolution=_get_default(head_resolution, True),
             head_transparency=_get_default(head_transparency, False),
+            helmet=False,
             head_opacity=0.5,
             sensor_opacity=_get_default(sensor_opacity, 1.0),
             fiducials=("LPA", "Nasion", "RPA"),
@@ -213,6 +215,7 @@ class CoregistrationUI(HasTraits):
         self._set_eeg_channels(self._defaults["eeg_channels"])
         self._set_head_resolution(self._defaults["head_resolution"])
         self._set_head_transparency(self._defaults["head_transparency"])
+        self._set_helmet(self._defaults["helmet"])
         self._set_grow_hair(self._defaults["grow_hair"])
         self._set_omit_hsp_distance(self._defaults["omit_hsp_distance"])
         self._set_icp_n_iterations(self._defaults["icp_n_iterations"])
@@ -323,6 +326,9 @@ class CoregistrationUI(HasTraits):
 
     def _set_head_transparency(self, state):
         self._head_transparency = bool(state)
+
+    def _set_helmet(self, state):
+        self._helmet = bool(state)
 
     def _set_grow_hair(self, value):
         self._grow_hair = value
@@ -497,6 +503,10 @@ class CoregistrationUI(HasTraits):
         self._actors["head"].GetProperty().SetOpacity(self._head_opacity)
         self._renderer._update()
 
+    @observe("_helmet")
+    def _helmet_changed(self, change=None):
+        self._update_plot("helmet")
+
     @observe("_grow_hair")
     def _grow_hair_changed(self, change=None):
         self._coreg.set_grow_hair(self._grow_hair)
@@ -533,6 +543,7 @@ class CoregistrationUI(HasTraits):
             hpi=self._add_hpi_coils,
             eeg=self._add_eeg_channels,
             head_fids=self._add_head_fiducials,
+            helmet=self._add_helmet,
         )
         with self._redraw_mutex:
             logger.debug(f'Redrawing {self._redraws_pending}')
@@ -632,6 +643,7 @@ class CoregistrationUI(HasTraits):
             'head', 'mri_fids',  # MRI first
             'hair',  # then hair
             'hsp', 'hpi', 'eeg', 'head_fids',  # then dig
+            'helmet',
         )
         if changes == 'all':
             changes = list(all_keys)
@@ -827,6 +839,15 @@ class CoregistrationUI(HasTraits):
             res = "high" if self._head_resolution else "low"
             self._surfaces["head"].points = \
                 self._coreg._get_processed_mri_points(res)
+
+    def _add_helmet(self):
+        if self._helmet:
+            head_mri_t = _get_trans(self._coreg.trans, 'head', 'mri')[0]
+            helmet_actor, _, _ = _plot_helmet(
+                self._renderer, self._info, head_mri_t)
+        else:
+            helmet_actor = None
+        self._update_actor("helmet", helmet_actor)
 
     def _fit_fiducials(self):
         if not self._lock_fids:
@@ -1042,6 +1063,13 @@ class CoregistrationUI(HasTraits):
             value=self._head_resolution,
             callback=self._set_head_resolution,
             tooltip="Enable/Disable high resolution head surface",
+            layout=layout
+        )
+        self._widgets["helmet"] = self._renderer._dock_add_check_box(
+            name="Show helmet",
+            value=self._helmet,
+            callback=self._set_helmet,
+            tooltip="Enable/Disable helmet",
             layout=layout
         )
         self._renderer._dock_add_stretch()

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -151,6 +151,9 @@ def test_coreg_gui_pyvista(tmp_path, renderer_interactive_pyvistaqt):
     assert coreg._grow_hair == 0.1
 
     # visualization
+    assert not coreg._helmet
+    coreg._set_helmet(True)
+    assert coreg._helmet
     assert coreg._orient_glyphs
     assert coreg._scale_by_distance
     assert coreg._mark_inside


### PR DESCRIPTION
This PR adds a checkbox to display the helmet in the Coregistration GUI interface.

![image](https://user-images.githubusercontent.com/18143289/149364164-473367cd-e744-4c63-bb31-797cf98cba04.png)

The diff is relatively short and the feature can be useful as far as I understand.

It's part of #8833