### PR TITLE
[ENH, MRG] Add marching cubes CT if recon not done

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -74,7 +74,9 @@ Enhancements
 
 - Annotations from a :class:`~mne.io.Raw` object are now preserved by the :class:`~mne.Epochs` constructor and are supported when saving Epochs (:gh:`9969` and :gh:`10019` by `Adam Li`_)
 
-- Add a button to display the MEG helmet in the coregistration GUI (:gh:`10200` but `Guillaume Favelier`_)
+- Add a button to display the MEG helmet in the coregistration GUI (:gh:`10200` by `Guillaume Favelier`_)
+
+- Add marching cubes display of head if :func:`mne.make_scalp_surfaces` has not computed or the recon-all hasn't finished (:gh:`XXX` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -76,7 +76,7 @@ Enhancements
 
 - Add a button to display the MEG helmet in the coregistration GUI (:gh:`10200` by `Guillaume Favelier`_)
 
-- Add marching cubes display of head if :func:`mne.make_scalp_surfaces` has not computed or the recon-all hasn't finished (:gh:`10202` by `Alex Rockhill`_)
+- Add marching cubes display of head if :func:`mne.bem.make_scalp_surfaces` has not computed or the recon-all hasn't finished (:gh:`10202` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -76,7 +76,7 @@ Enhancements
 
 - Add a button to display the MEG helmet in the coregistration GUI (:gh:`10200` by `Guillaume Favelier`_)
 
-- Add marching cubes display of head if :func:`mne.make_scalp_surfaces` has not computed or the recon-all hasn't finished (:gh:`XXX` by `Alex Rockhill`_)
+- Add marching cubes display of head if :func:`mne.make_scalp_surfaces` has not computed or the recon-all hasn't finished (:gh:`10202` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -330,6 +330,8 @@ class IntracranialElectrodeLocator(QMainWindow):
                 'button_release_event', partial(self._on_click, axis))
         # add head and brain in mm (convert from m)
         if self._head is None:
+            logger.info('Using marching cubes on CT for the '
+                        '3D visualization panel')
             rr, tris = _marching_cubes(np.where(
                 self._ct_data < np.quantile(self._ct_data, 0.95), 0, 1),
                 [1])[0]

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -220,8 +220,9 @@ class IntracranialElectrodeLocator(QMainWindow):
                 op.join(self._subject_dir, 'surf', 'lh.seghead'))
             assert _frame_to_str[self._head['coord_frame']] == 'mri'
         else:
-            warn('`seghead` not found, skipping head plot, see '
-                 ':ref:`mne.bem.make_scalp_surfaces` to add the head')
+            warn('`seghead` not found, using marching cubes on CT for '
+                 'head plot, use :ref:`mne.bem.make_scalp_surfaces` '
+                 'to add the scalp surface instead of skull from the CT')
             self._head = None
         if op.exists(op.join(self._subject_dir, 'surf', 'lh.pial')):
             self._lh = _read_mri_surface(

--- a/mne/gui/tests/test_ieeg_locate_gui.py
+++ b/mne/gui/tests/test_ieeg_locate_gui.py
@@ -138,10 +138,9 @@ def test_ieeg_elec_locate_gui_display(_locate_ieeg, _fake_CT_coords):
     aligned_ct, coords = _fake_CT_coords
     trans = mne.read_trans(fname_trans)
 
-    # test no seghead
-    with catch_logging() as log:
-        # fsaverage doesn't have seghead, will use CT
-        with pytest.warns(RuntimeWarning, match='`seghead` not found'):
+    # test no seghead, fsaverage doesn't have seghead
+    with pytest.warns(RuntimeWarning, match='`seghead` not found'):
+        with catch_logging() as log:
             _locate_ieeg(raw.info, trans, aligned_ct, subject='fsaverage',
                          subjects_dir=subjects_dir)
     log = log.getvalue()

--- a/mne/gui/tests/test_ieeg_locate_gui.py
+++ b/mne/gui/tests/test_ieeg_locate_gui.py
@@ -10,7 +10,7 @@ import pytest
 
 import mne
 from mne.datasets import testing
-from mne.utils import requires_nibabel, requires_version, catch_logging
+from mne.utils import requires_nibabel, requires_version
 from mne.viz.utils import _fake_click
 
 data_path = testing.data_path(download=False)
@@ -140,11 +140,8 @@ def test_ieeg_elec_locate_gui_display(_locate_ieeg, _fake_CT_coords):
 
     # test no seghead, fsaverage doesn't have seghead
     with pytest.warns(RuntimeWarning, match='`seghead` not found'):
-        with catch_logging() as log:
-            _locate_ieeg(raw.info, trans, aligned_ct, subject='fsaverage',
-                         subjects_dir=subjects_dir)
-    log = log.getvalue()
-    assert 'Using marching cubes' in log
+        _locate_ieeg(raw.info, trans, aligned_ct, subject='fsaverage',
+                     subjects_dir=subjects_dir)
 
     # test functions
     with pytest.warns(RuntimeWarning, match='`pial` surface not found'):


### PR DESCRIPTION
In the case that the user has not run `make_scalp_surfaces` which also may happen when the recon isn't finished (i.e. trying to get the localization done soon after), if the recon is started the `talairach.xfm` file is made fairly quickly (so you can get a `trans` with the estimation) as is the T1 so the whole GUI works (other than the pial surfaces). The 3D rendered scene isn't very useful without the surfaces but the CT can quickly be made (~0.5 s) into a surface with marching cubes which can serve the same purpose as the seghead as far as orienting.

Here's what it looks like:

<img width="1280" alt="Screen Shot 2022-01-13 at 11 27 09 PM" src="https://user-images.githubusercontent.com/13473576/149468154-9ce07e60-f07c-4382-9e9b-82282274ba22.png">

