### PR TITLE
FIX: helmet

### DIFF
--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -844,7 +844,8 @@ class CoregistrationUI(HasTraits):
         if self._helmet:
             head_mri_t = _get_trans(self._coreg.trans, 'head', 'mri')[0]
             helmet_actor, _, _ = _plot_helmet(
-                self._renderer, self._info, head_mri_t)
+                self._renderer, self._info, self._to_cf_t, head_mri_t,
+                self._coord_frame)
         else:
             helmet_actor = None
         self._update_actor("helmet", helmet_actor)

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -699,8 +699,8 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
 
     # plot helmet
     if 'helmet' in meg and pick_types(info, meg=True).size > 0:
-        _, _, src_surf = _plot_helmet(renderer, info, head_mri_t)
-        assert src_surf['coord_frame'] == FIFF.FIFFV_COORD_MRI
+        _, _, src_surf = _plot_helmet(
+            renderer, info, to_cf_t, head_mri_t, coord_frame)
 
     # plot surfaces
     if brain and 'lh' not in surfs:  # one layer sphere
@@ -901,9 +901,13 @@ def _plot_head_surface(renderer, head, subject, subjects_dir, bem,
     return actor, dst_surf, src_surf
 
 
-def _plot_helmet(renderer, info, head_mri_t, alpha=0.25, color=None):
+def _plot_helmet(renderer, info, to_cf_t, head_mri_t, coord_frame,
+                 alpha=0.25, color=None):
     color = DEFAULTS['coreg']['helmet_color'] if color is None else color
     src_surf = get_meg_helmet_surf(info, head_mri_t)
+    assert src_surf['coord_frame'] == FIFF.FIFFV_COORD_MRI
+    src_surf = transform_surface_to(
+        src_surf, coord_frame, [to_cf_t['mri'], to_cf_t['head']], copy=True)
     actor, dst_surf = renderer.surface(
         surface=src_surf, color=color, opacity=alpha,
         backface_culling=False)


### PR DESCRIPTION
This PR fixes the bug introduced in #10200 

main | PR
--|--
![image](https://user-images.githubusercontent.com/18143289/149501779-ad070181-f1e9-438f-878b-e71264654f68.png) |  ![image](https://user-images.githubusercontent.com/18143289/149501926-8759ab27-c05c-4899-b6ab-773df50c44f9.png)

<details>

```py
import os.path as op
import mne
from mne.io import read_info


data_path = mne.datasets.sample.data_path()
subjects_dir = op.join(data_path, 'subjects')
subject = 'sample'

fname_raw = op.join(data_path, 'MEG', subject, subject + '_audvis_raw.fif')
fname_trans = op.join(data_path, 'MEG', subject, f'{subject}_audvis_raw-trans.fif')

trans = mne.read_trans(fname_trans)
info = read_info(fname_raw)

mne.viz.plot_alignment(
    info=info,
    trans=trans,
    subject='sample',
    subjects_dir=subjects_dir,
    coord_frame='meg'
)
```

</details>