### PR TITLE
add function to reflow param entries

### DIFF
--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 import inspect
 import os
 import os.path as op
+import re
 import sys
 import warnings
 import webbrowser
@@ -15,6 +16,16 @@ import webbrowser
 from ..defaults import HEAD_SIZE_DEFAULT
 from ..externals.doccer import indentcount_lines
 from ..externals.decorator import FunctionMaker
+
+
+def reflow_param_docstring(docstring, has_first_line=True, width=75):
+    maxsplit = docstring.count('\n') - 1 if has_first_line else -1
+    merged = ' '.join(line.strip() for line in
+                      docstring.rsplit('\n', maxsplit=maxsplit))
+    reflowed = '\n    '.join(re.findall(fr'.{{1,{width}}}(?:\s+|$)', merged))
+    if has_first_line:
+        reflowed = reflowed.replace('\n    \n', '\n', 1)
+    return reflowed
 
 
 ##############################################################################
@@ -642,7 +653,8 @@ docdict['picks_all'] = f'{picks_base} all channels. {reminder}'
 docdict['picks_all_data'] = f'{picks_base} all data channels. {reminder}'
 docdict['picks_good_data'] = f'{picks_base} good data channels. {reminder}'
 docdict['picks_all_data_noref'] = f'{picks_base} all data channels {noref}'
-docdict['picks_good_data_noref'] = f'{picks_base} good data channels {noref}'
+docdict['picks_good_data_noref'] = reflow_param_docstring(
+    f'{picks_base} good data channels {noref}')
 docdict['picks_nostr'] = f"""picks : list | slice | None
     {picks_intro} None (default) will pick all channels. {reminder_nostr}"""
 docdict['picks_ica'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -18,7 +18,7 @@ from ..externals.doccer import indentcount_lines
 from ..externals.decorator import FunctionMaker
 
 
-def reflow_param_docstring(docstring, has_first_line=True, width=75):
+def _reflow_param_docstring(docstring, has_first_line=True, width=75):
     maxsplit = docstring.count('\n') - 1 if has_first_line else -1
     merged = ' '.join(line.strip() for line in
                       docstring.rsplit('\n', maxsplit=maxsplit))
@@ -636,7 +636,7 @@ picks_header = 'picks : str | list | slice | None'
 picks_intro = ('Channels to include. Slices and lists of integers will be '
                'interpreted as channel indices.')
 _reminder = ("Note that channels in ``info['bads']`` *will be included* if "
-             "their {}indices are explicitly provided.\n")
+             "their {}indices are explicitly provided.")
 reminder = _reminder.format('names or ')
 reminder_nostr = _reminder.format('')
 noref = f'(excluding reference MEG channels). {reminder}'
@@ -653,7 +653,7 @@ docdict['picks_all'] = f'{picks_base} all channels. {reminder}'
 docdict['picks_all_data'] = f'{picks_base} all data channels. {reminder}'
 docdict['picks_good_data'] = f'{picks_base} good data channels. {reminder}'
 docdict['picks_all_data_noref'] = f'{picks_base} all data channels {noref}'
-docdict['picks_good_data_noref'] = reflow_param_docstring(
+docdict['picks_good_data_noref'] = _reflow_param_docstring(
     f'{picks_base} good data channels {noref}')
 docdict['picks_nostr'] = f"""picks : list | slice | None
     {picks_intro} None (default) will pick all channels. {reminder_nostr}"""


### PR DESCRIPTION
I've often been annoyed by some of our more complicated docstrings (the ones *partially* shared and thus built up via f-strings) because they end up with really bad line breaks in the terminal. This adds a small function to re-flow a docstring parameter entry so that it looks right in a terminal, and applies it to (so far only one) parameter as a proof of concept.  Here's `docdict['picks_good_data_noref']` on main:
![main](https://user-images.githubusercontent.com/1810515/149597715-af5688f5-b2b5-4b3a-8adb-8e0a709cb333.png)

and here it is on this PR:
![PR](https://user-images.githubusercontent.com/1810515/149597721-ad6c0ed4-0053-482f-af23-d1a896ebbeaf.png)

