### PR TITLE
[ENH, MRG] Add lines to stereo electrodes in the ieeg location GUI

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -80,6 +80,8 @@ Enhancements
 
 - The default interaction style of :func:`mne.gui.coregistration` and :func:`mne.viz.plot_alignment` has been changed to ``'terrain'``, which keeps one axis fixed and should make interactions with the 3D scene more predictable (:gh:`9972`, :gh:`10206` by `Richard Höchenberger`_)
 
+- Add lines in 3D and on the maximum intensity projection when more than two electrode contacts are selected to aid in identifying that contact (:gh:`10XXX` by `Alex Rockhill`_)
+
 Bugs
 ~~~~
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -80,9 +80,9 @@ Enhancements
 
 - The default interaction style of :func:`mne.gui.coregistration` and :func:`mne.viz.plot_alignment` has been changed to ``'terrain'``, which keeps one axis fixed and should make interactions with the 3D scene more predictable (:gh:`9972`, :gh:`10206` by `Richard Höchenberger`_)
 
-- Added plotting points to represent contacts on the max intensity projection plot for :func:`mne.gui.locate_ieeg` (:gh:`10XXX` by `Alex Rockhill`_)
+- Added plotting points to represent contacts on the max intensity projection plot for :func:`mne.gui.locate_ieeg` (:gh:`10212` by `Alex Rockhill`_)
 
-- Add lines in 3D and on the maximum intensity projection when more than two electrode contacts are selected to aid in identifying that contact for :func:`mne.gui.locate_ieeg` (:gh:`10XXX` by `Alex Rockhill`_)
+- Add lines in 3D and on the maximum intensity projection when more than two electrode contacts are selected to aid in identifying that contact for :func:`mne.gui.locate_ieeg` (:gh:`10212` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -80,7 +80,9 @@ Enhancements
 
 - The default interaction style of :func:`mne.gui.coregistration` and :func:`mne.viz.plot_alignment` has been changed to ``'terrain'``, which keeps one axis fixed and should make interactions with the 3D scene more predictable (:gh:`9972`, :gh:`10206` by `Richard Höchenberger`_)
 
-- Add lines in 3D and on the maximum intensity projection when more than two electrode contacts are selected to aid in identifying that contact (:gh:`10XXX` by `Alex Rockhill`_)
+- Added plotting points to represent contacts on the max intensity projection plot for :func:`mne.gui.locate_ieeg` (:gh:`10XXX` by `Alex Rockhill`_)
+
+- Add lines in 3D and on the maximum intensity projection when more than two electrode contacts are selected to aid in identifying that contact for :func:`mne.gui.locate_ieeg` (:gh:`10XXX` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -389,7 +389,7 @@ class IntracranialElectrodeLocator(QMainWindow):
             self._3d_chs[name] = self._renderer.sphere(
                 tuple(self._chs[name]), scale=1,
                 color=_CMAP(self._groups[name])[:3], opacity=self._ch_alpha)[0]
-            # The actor scale is managed differently than the glpyh scale
+            # The actor scale is managed differently than the glyph scale
             # in order not to recreate objects, we use the actor scale
             self._3d_chs[name].SetOrigin(self._chs[name])
             self._3d_chs[name].SetScale(self._radius * _RADIUS_SCALAR)

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -864,6 +864,20 @@ class IntracranialElectrodeLocator(QMainWindow):
                     self._figs[axis].axes[0].imshow(
                         ct_mip_data, cmap='gray', aspect='auto',
                         vmin=ct_min, vmax=ct_max))
+                # add channel circles
+                xy_idx = [0, 1, 2]
+                xy_idx.remove(axis)
+                xs = list()
+                ys = list()
+                colors = list()
+                for name, ras in self._chs.items():
+                    xyz = apply_trans(self._ras_vox_t, ras)
+                    xs.append(xyz[xy_idx[0]])
+                    ys.append(xyz[xy_idx[1]])
+                    colors.append(_CMAP(self._groups[name]))
+                self._images['mip'].append(
+                    self._figs[axis].axes[0].scatter(
+                        xs, ys, color=colors, s=self._radius / 5))
         else:
             for img in self._images['mip']:
                 img.remove()

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -38,7 +38,7 @@ _ZOOM_STEP_SIZE = 5
 _RADIUS_SCALAR = 0.4
 _TUBE_SCALAR = 0.1
 _BOLT_SCALAR = 30  # mm
-_CH_MENU_WIDTH = 30 if platform.system() == 'Windows' else 15
+_CH_MENU_WIDTH = 30 if platform.system() == 'Windows' else 10
 
 # 20 colors generated to be evenly spaced in a cube, worked better than
 # matplotlib color cycle

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -38,7 +38,7 @@ _ZOOM_STEP_SIZE = 5
 _RADIUS_SCALAR = 0.4
 _TUBE_SCALAR = 0.1
 _BOLT_SCALAR = 30  # mm
-_CH_MENU_WIDTH = 30 if platform.system() == 'Windows' else 10
+_CH_MENU_WIDTH = 50 if platform.system() == 'Windows' else 10
 
 # 20 colors generated to be evenly spaced in a cube, worked better than
 # matplotlib color cycle

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -797,6 +797,9 @@ class IntracranialElectrodeLocator(QMainWindow):
             self._update_ct_images()
         else:
             self._ct_maxima = None  # signals ct max is out-of-date
+        if self._toggle_show_mip_button.text() == 'Show Max Intensity Proj':
+            for points in self._images['mip_scatter']:
+                points.set_sizes([self._radius / 5])
         self._update_ch_images(draw=True)
         self._plot_3d_ch_pos(render=True)
         self._ch_list.setFocus()  # remove focus from 3d plotter
@@ -857,6 +860,7 @@ class IntracranialElectrodeLocator(QMainWindow):
         if self._toggle_show_mip_button.text() == 'Show Max Intensity Proj':
             self._toggle_show_mip_button.setText('Hide Max Intensity Proj')
             self._images['mip'] = list()
+            self._images['mip_scatter'] = list()
             ct_min, ct_max = np.nanmin(self._ct_data), np.nanmax(self._ct_data)
             for axis in range(3):
                 ct_mip_data = np.max(self._ct_data, axis=axis).T
@@ -875,13 +879,14 @@ class IntracranialElectrodeLocator(QMainWindow):
                     xs.append(xyz[xy_idx[0]])
                     ys.append(xyz[xy_idx[1]])
                     colors.append(_CMAP(self._groups[name]))
-                self._images['mip'].append(
+                self._images['mip_scatter'].append(
                     self._figs[axis].axes[0].scatter(
                         xs, ys, color=colors, s=self._radius / 5))
         else:
-            for img in self._images['mip']:
+            for img in self._images['mip'] + self._images['mip_scatter']:
                 img.remove()
             self._images.pop('mip')
+            self._images.pop('mip_scatter')
             self._toggle_show_mip_button.setText('Show Max Intensity Proj')
         self._draw()
 

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -9,7 +9,6 @@ import os.path as op
 import numpy as np
 from functools import partial
 from scipy.ndimage import maximum_filter
-from scipy.spatial.distance import cdist
 
 from matplotlib.colors import LinearSegmentedColormap
 
@@ -38,6 +37,7 @@ _ZOOM_STEP_SIZE = 5
 _RADIUS_SCALAR = 0.4
 _TUBE_SCALAR = 0.1
 _BOLT_SCALAR = 30  # mm
+_CH_MENU_WIDTH = 50
 
 # 20 colors generated to be evenly spaced in a cube, worked better than
 # matplotlib color cycle
@@ -164,8 +164,8 @@ class IntracranialElectrodeLocator(QMainWindow):
         self._ch_list = QListView()
         self._ch_list.setSelectionMode(Qt.QAbstractItemView.SingleSelection)
         max_ch_name_len = max([len(name) for name in self._chs])
-        self._ch_list.setMinimumWidth(max_ch_name_len * 10)
-        self._ch_list.setMaximumWidth(max_ch_name_len * 10)
+        self._ch_list.setMinimumWidth(max_ch_name_len * _CH_MENU_WIDTH)
+        self._ch_list.setMaximumWidth(max_ch_name_len * _CH_MENU_WIDTH)
         self._set_ch_names()
 
         # Plots
@@ -572,7 +572,7 @@ class IntracranialElectrodeLocator(QMainWindow):
         insert_idx = np.argmax(np.linalg.norm(pos * np.array([1, 0.8, 1]),
                                               axis=1))
         # second, find the farthest point from the insertion
-        target_idx = np.argmax(cdist(pos, pos)[insert_idx])
+        target_idx = np.argmax(np.linalg.norm(pos[insert_idx] - pos, axis=1))
         # third, make a unit vector and to add to the insertion for the bolt
         elec_v = pos[insert_idx] - pos[target_idx]
         elec_v /= np.linalg.norm(elec_v)

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -579,7 +579,7 @@ class IntracranialElectrodeLocator(QMainWindow):
         if not only_2D:
             self._lines[group] = self._renderer.tube(
                 [pos[target_idx]], [pos[insert_idx] + elec_v * _BOLT_SCALAR],
-                radius=self._radius * _TUBE_SCALAR, color=_CMAP(group))[0]
+                radius=self._radius * _TUBE_SCALAR, color=_CMAP(group)[:3])[0]
         if self._toggle_show_mip_button.text() == 'Hide Max Intensity Proj':
             target_vox = apply_trans(self._ras_vox_t, pos[target_idx])
             insert_vox = apply_trans(self._ras_vox_t,

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -579,7 +579,7 @@ class IntracranialElectrodeLocator(QMainWindow):
         if not only_2D:
             self._lines[group] = self._renderer.tube(
                 [pos[target_idx]], [pos[insert_idx] + elec_v * _BOLT_SCALAR],
-                radius=self._radius * _TUBE_SCALAR, color=_CMAP(group))
+                radius=self._radius * _TUBE_SCALAR, color=_CMAP(group))[0]
         if self._toggle_show_mip_button.text() == 'Hide Max Intensity Proj':
             target_vox = apply_trans(self._ras_vox_t, pos[target_idx])
             insert_vox = apply_trans(self._ras_vox_t,

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -38,7 +38,7 @@ _ZOOM_STEP_SIZE = 5
 _RADIUS_SCALAR = 0.4
 _TUBE_SCALAR = 0.1
 _BOLT_SCALAR = 30  # mm
-_CH_MENU_WIDTH = 50 if platform.system() == 'Windows' else 10
+_CH_MENU_WIDTH = 30 if platform.system() == 'Windows' else 10
 
 # 20 colors generated to be evenly spaced in a cube, worked better than
 # matplotlib color cycle

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -9,6 +9,7 @@ import os.path as op
 import numpy as np
 from functools import partial
 from scipy.ndimage import maximum_filter
+import platform
 
 from matplotlib.colors import LinearSegmentedColormap
 
@@ -37,7 +38,7 @@ _ZOOM_STEP_SIZE = 5
 _RADIUS_SCALAR = 0.4
 _TUBE_SCALAR = 0.1
 _BOLT_SCALAR = 30  # mm
-_CH_MENU_WIDTH = 15
+_CH_MENU_WIDTH = 30 if platform.system() == 'Windows' else 15
 
 # 20 colors generated to be evenly spaced in a cube, worked better than
 # matplotlib color cycle

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -37,7 +37,7 @@ _ZOOM_STEP_SIZE = 5
 _RADIUS_SCALAR = 0.4
 _TUBE_SCALAR = 0.1
 _BOLT_SCALAR = 30  # mm
-_CH_MENU_WIDTH = 50
+_CH_MENU_WIDTH = 15
 
 # 20 colors generated to be evenly spaced in a cube, worked better than
 # matplotlib color cycle

--- a/mne/gui/tests/test_ieeg_locate_gui.py
+++ b/mne/gui/tests/test_ieeg_locate_gui.py
@@ -128,12 +128,14 @@ def test_locate_scraper(_locate_ieeg, _fake_CT_coords, tmp_path):
 @testing.requires_testing_data
 def test_ieeg_elec_locate_gui_display(_locate_ieeg, _fake_CT_coords):
     """Test that the intracranial location GUI displays properly."""
-    raw = mne.io.read_raw_fif(raw_path)
+    raw = mne.io.read_raw_fif(raw_path, preload=True)
     raw.pick_types(eeg=True)
     ch_dict = {'EEG 001': 'LAMY 1', 'EEG 002': 'LAMY 2',
                'EEG 003': 'LSTN 1', 'EEG 004': 'LSTN 2'}
     raw.pick_channels(list(ch_dict.keys()))
     raw.rename_channels(ch_dict)
+    raw.set_eeg_reference('average')
+    raw.set_channel_types({name: 'seeg' for name in raw.ch_names})
     raw.set_montage(None)
     aligned_ct, coords = _fake_CT_coords
     trans = mne.read_trans(fname_trans)
@@ -153,13 +155,20 @@ def test_ieeg_elec_locate_gui_display(_locate_ieeg, _fake_CT_coords):
 
     gui._ras[:] = coords[0]  # start in the right position
     gui._move_cursors_to_pos()
-    for coord in coords:
+    gui._mark_ch()
+    assert not gui._lines and not gui._lines_2D  # no lines for one contact
+    for coord in coords[1:]:
         coord_vox = mne.transforms.apply_trans(gui._ras_vox_t, coord)
         _fake_click(gui._figs[2], gui._figs[2].axes[0],
                     coord_vox[:-1], xform='data', kind='release')
         assert_allclose(coord, gui._ras, atol=3)  # clicks are a bit off
+        gui._mark_ch()
+
+    # ensure a 3D line was made for each group
+    assert len(gui._lines) == 2
 
     # test snap to center
+    gui._ch_index = 0
     gui._ras[:] = coords[0]  # move to first position
     gui._move_cursors_to_pos()
     gui._mark_ch()
@@ -167,9 +176,10 @@ def test_ieeg_elec_locate_gui_display(_locate_ieeg, _fake_CT_coords):
     gui._snap_button.click()
     assert gui._snap_button.text() == 'Off'
     # now make sure no snap happens
+    gui._ch_index = 0
     gui._ras[:] = coords[1] + 1
     gui._mark_ch()
-    assert_allclose(coords[1] + 1, gui._chs['LAMY 2'], atol=0.01)
+    assert_allclose(coords[1] + 1, gui._chs['LAMY 1'], atol=0.01)
     # check that it turns back on
     gui._snap_button.click()
     assert gui._snap_button.text() == 'On'
@@ -202,3 +212,5 @@ def test_ieeg_elec_locate_gui_display(_locate_ieeg, _fake_CT_coords):
     assert 'mip' not in gui._images
     gui._toggle_show_mip()
     assert 'mip' in gui._images
+    assert 'mip_chs' in gui._images
+    assert len(gui._lines_2D) == 1  # LAMY only has one contact

--- a/mne/gui/tests/test_ieeg_locate_gui.py
+++ b/mne/gui/tests/test_ieeg_locate_gui.py
@@ -151,7 +151,8 @@ def test_ieeg_elec_locate_gui_display(_locate_ieeg, _fake_CT_coords):
     # test functions
     with pytest.warns(RuntimeWarning, match='`pial` surface not found'):
         gui = _locate_ieeg(raw.info, trans, aligned_ct,
-                           subject=subject, subjects_dir=subjects_dir)
+                           subject=subject, subjects_dir=subjects_dir,
+                           verbose=True)
 
     gui._ras[:] = coords[0]  # start in the right position
     gui._move_cursors_to_pos()


### PR DESCRIPTION
This makes it easier to visualize which electrode is which and is consistent with the surgical plans for our ieeg data which look like this: <img width="1132" alt="Screen Shot 2022-01-16 at 7 03 44 PM" src="https://user-images.githubusercontent.com/13473576/149701840-782e7dfc-f384-48bf-835a-42c51304d612.png">. 

You can test with the same script as here: https://github.com/mne-tools/mne-python/pull/10185

This is what it looks like:
<img width="1280" alt="Screen Shot 2022-01-16 at 7 05 29 PM" src="https://user-images.githubusercontent.com/13473576/149701991-3f80454c-3f3e-4fec-848f-894f18363fee.png">

A nice improvement I think!

Note, it doesn't try and do anything for ECoG grids, I think those are easy enough to disambiguate.


 