### PR TITLE
MRG: Use actual push button widgets for push buttons in Coreg UI

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -80,7 +80,7 @@ Enhancements
 
 - The default interaction style of :func:`mne.gui.coregistration` and :func:`mne.viz.plot_alignment` has been changed to ``'terrain'``, which keeps one axis fixed and should make interactions with the 3D scene more predictable (:gh:`9972`, :gh:`10206` by `Richard Höchenberger`_)
 
-- :func:`mne.gui.coregistration` now uses the proper widget style for push buttons, making for a more native feel of the application (:gh:`xxx` by `Richard Höchenberger`_ and `Guillaume Favelier`_)
+- :func:`mne.gui.coregistration` now uses the proper widget style for push buttons, making for a more native feel of the application (:gh:`10220` by `Richard Höchenberger`_ and `Guillaume Favelier`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -80,6 +80,8 @@ Enhancements
 
 - The default interaction style of :func:`mne.gui.coregistration` and :func:`mne.viz.plot_alignment` has been changed to ``'terrain'``, which keeps one axis fixed and should make interactions with the 3D scene more predictable (:gh:`9972`, :gh:`10206` by `Richard Höchenberger`_)
 
+- :func:`mne.gui.coregistration` now uses the proper widget style for push buttons, making for a more native feel of the application (:gh:`xxx` by `Richard Höchenberger`_ and `Guillaume Favelier`_)
+
 Bugs
 ~~~~
 

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -1192,12 +1192,14 @@ class CoregistrationUI(HasTraits):
             tooltip="Exclude the head shape points that are far away from "
                     "the MRI head",
             layout=omit_hsp_layout,
+            style='pushbutton',
         )
         self._widgets["reset_omit"] = self._renderer._dock_add_button(
             name="Reset",
             callback=self._reset_omit_hsp_filter,
             tooltip="Reset all excluded head shape points",
             layout=omit_hsp_layout,
+            style='pushbutton',
         )
         self._renderer._layout_add_widget(dig_source_layout, omit_hsp_layout)
 
@@ -1267,6 +1269,7 @@ class CoregistrationUI(HasTraits):
             callback=self._fits_fiducials,
             tooltip="Find rotation and translation to fit all 3 fiducials",
             layout=fit_scale_layout,
+            style='pushbutton',
         )
         self._widgets["fits_icp"] = self._renderer._dock_add_button(
             name="Fit ICP with scaling",
@@ -1274,6 +1277,7 @@ class CoregistrationUI(HasTraits):
             tooltip="Find MRI scaling, translation, and rotation to match the "
                     "head shape points",
             layout=fit_scale_layout,
+            style='pushbutton',
         )
         self._renderer._layout_add_widget(
             scale_params_layout, fit_scale_layout)
@@ -1290,6 +1294,7 @@ class CoregistrationUI(HasTraits):
             callback=self._start_worker,
             tooltip="Save scaled anatomy",
             layout=subject_to_layout,
+            style='pushbutton',
         )
         self._renderer._layout_add_widget(
             mri_scaling_layout, subject_to_layout)
@@ -1323,6 +1328,7 @@ class CoregistrationUI(HasTraits):
             callback=self._fit_fiducials,
             tooltip="Find rotation and translation to fit all 3 fiducials",
             layout=fit_layout,
+            style='pushbutton',
         )
         self._widgets["fit_icp"] = self._renderer._dock_add_button(
             name="Fit ICP",
@@ -1330,6 +1336,7 @@ class CoregistrationUI(HasTraits):
             tooltip="Find MRI scaling, translation, and rotation to match the "
                     "head shape points",
             layout=fit_layout,
+            style='pushbutton',
         )
         self._renderer._layout_add_widget(param_layout, fit_layout)
         trans_layout = self._renderer._dock_add_group_box("Transform")
@@ -1356,6 +1363,7 @@ class CoregistrationUI(HasTraits):
             callback=self._reset,
             tooltip="Reset all the parameters affecting the coregistration",
             layout=save_trans_layout,
+            style='pushbutton',
         )
         self._renderer._layout_add_widget(trans_layout, save_trans_layout)
 
@@ -1422,6 +1430,7 @@ class CoregistrationUI(HasTraits):
             callback=self._reset_fitting_parameters,
             tooltip="Reset all the fitting parameters to default value",
             layout=fitting_options_layout,
+            style='pushbutton',
         )
         self._renderer._dock_add_stretch()
 

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -1192,14 +1192,12 @@ class CoregistrationUI(HasTraits):
             tooltip="Exclude the head shape points that are far away from "
                     "the MRI head",
             layout=omit_hsp_layout,
-            style='pushbutton',
         )
         self._widgets["reset_omit"] = self._renderer._dock_add_button(
             name="Reset",
             callback=self._reset_omit_hsp_filter,
             tooltip="Reset all excluded head shape points",
             layout=omit_hsp_layout,
-            style='pushbutton',
         )
         self._renderer._layout_add_widget(dig_source_layout, omit_hsp_layout)
 
@@ -1269,7 +1267,6 @@ class CoregistrationUI(HasTraits):
             callback=self._fits_fiducials,
             tooltip="Find rotation and translation to fit all 3 fiducials",
             layout=fit_scale_layout,
-            style='pushbutton',
         )
         self._widgets["fits_icp"] = self._renderer._dock_add_button(
             name="Fit ICP with scaling",
@@ -1277,7 +1274,6 @@ class CoregistrationUI(HasTraits):
             tooltip="Find MRI scaling, translation, and rotation to match the "
                     "head shape points",
             layout=fit_scale_layout,
-            style='pushbutton',
         )
         self._renderer._layout_add_widget(
             scale_params_layout, fit_scale_layout)
@@ -1294,7 +1290,6 @@ class CoregistrationUI(HasTraits):
             callback=self._start_worker,
             tooltip="Save scaled anatomy",
             layout=subject_to_layout,
-            style='pushbutton',
         )
         self._renderer._layout_add_widget(
             mri_scaling_layout, subject_to_layout)
@@ -1328,7 +1323,6 @@ class CoregistrationUI(HasTraits):
             callback=self._fit_fiducials,
             tooltip="Find rotation and translation to fit all 3 fiducials",
             layout=fit_layout,
-            style='pushbutton',
         )
         self._widgets["fit_icp"] = self._renderer._dock_add_button(
             name="Fit ICP",
@@ -1336,7 +1330,6 @@ class CoregistrationUI(HasTraits):
             tooltip="Find MRI scaling, translation, and rotation to match the "
                     "head shape points",
             layout=fit_layout,
-            style='pushbutton',
         )
         self._renderer._layout_add_widget(param_layout, fit_layout)
         trans_layout = self._renderer._dock_add_group_box("Transform")
@@ -1363,7 +1356,6 @@ class CoregistrationUI(HasTraits):
             callback=self._reset,
             tooltip="Reset all the parameters affecting the coregistration",
             layout=save_trans_layout,
-            style='pushbutton',
         )
         self._renderer._layout_add_widget(trans_layout, save_trans_layout)
 
@@ -1430,7 +1422,6 @@ class CoregistrationUI(HasTraits):
             callback=self._reset_fitting_parameters,
             tooltip="Reset all the fitting parameters to default value",
             layout=fitting_options_layout,
-            style='pushbutton',
         )
         self._renderer._dock_add_stretch()
 

--- a/mne/gui/tests/test_gui_api.py
+++ b/mne/gui/tests/test_gui_api.py
@@ -47,8 +47,21 @@ def test_gui_api(renderer_notebook, nbexec):
     widget.update()
     widget.set_enabled(False)
 
-    # button
-    widget = renderer._dock_add_button('', mock)
+    # ToolButton
+    widget = renderer._dock_add_button(
+        name='',
+        callback=mock,
+        style='toolbutton'
+    )
+    with _check_widget_trigger(widget, mock, None, None, get_value=False):
+        widget.set_value(True)
+
+    # PushButton
+    widget = renderer._dock_add_button(
+        name='',
+        callback=mock,
+        style='pushbutton'
+    )
     with _check_widget_trigger(widget, mock, None, None, get_value=False):
         widget.set_value(True)
 

--- a/mne/gui/tests/test_gui_api.py
+++ b/mne/gui/tests/test_gui_api.py
@@ -59,8 +59,7 @@ def test_gui_api(renderer_notebook, nbexec):
     # PushButton
     widget = renderer._dock_add_button(
         name='',
-        callback=mock,
-        style='pushbutton'
+        callback=mock
     )
     with _check_widget_trigger(widget, mock, None, None, get_value=False):
         widget.set_value(True)

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1064,6 +1064,7 @@ class Brain(object):
             name="↺",
             callback=self.restore_user_scaling,
             layout=hlayout,
+            style='toolbutton',
         )
         for key, char, val in (("fminus", "➖", 1.2 ** -0.25),
                                ("fplus", "➕", 1.2 ** 0.25)):
@@ -1075,6 +1076,7 @@ class Brain(object):
                 name=char,
                 callback=self.callbacks[key],
                 layout=hlayout,
+                style='toolbutton',
             )
         self._renderer._layout_add_widget(layout, hlayout)
 

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -532,7 +532,9 @@ class _AbstractDock(ABC):
         pass
 
     @abstractmethod
-    def _dock_add_button(self, name, callback, tooltip=None, layout=None):
+    def _dock_add_button(
+        self, name, callback, style='pushbutton', tooltip=None, layout=None
+    ):
         pass
 
     @abstractmethod

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -71,7 +71,8 @@ class _IpyDock(_AbstractDock, _IpyLayout):
         self._layout_add_widget(layout, widget)
         return _IpyWidget(widget)
 
-    def _dock_add_button(self, name, callback, tooltip=None, layout=None):
+    def _dock_add_button(self, name, callback, style=None, tooltip=None,
+                         layout=None):
         layout = self._dock_layout if layout is None else layout
         kwargs = dict(description=name)
         if tooltip is not None:

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -18,7 +18,7 @@ from PyQt5.QtWidgets import (QComboBox, QDockWidget, QDoubleSpinBox, QGroupBox,
                              QSizePolicy, QScrollArea, QStyle, QProgressBar,
                              QStyleOptionSlider, QLayout, QCheckBox,
                              QButtonGroup, QRadioButton, QLineEdit,
-                             QFileDialog)
+                             QFileDialog, QPushButton)
 
 from ._pyvista import _PyVistaRenderer
 from ._pyvista import (_close_all, _close_3d_figure, _check_3d_figure,  # noqa: F401,E501 analysis:ignore
@@ -29,7 +29,7 @@ from ._abstract import (_AbstractDock, _AbstractToolBar, _AbstractMenuBar,
                         _AbstractBrainMplCanvas, _AbstractMplInterface,
                         _AbstractWidgetList)
 from ._utils import _init_qt_resources, _qt_disable_paint
-from ..utils import logger
+from ..utils import logger, _check_option
 
 
 class _QtLayout(_AbstractLayout):
@@ -83,14 +83,28 @@ class _QtDock(_AbstractDock, _QtLayout):
         self._layout_add_widget(layout, widget)
         return _QtWidget(widget)
 
-    def _dock_add_button(self, name, callback, tooltip=None, layout=None):
-        layout = self._dock_layout if layout is None else layout
-        # If we want one with text instead of an icon, we should use
-        # QPushButton(name)
-        widget = QToolButton()
+    def _dock_add_button(
+        self, name, callback, style='pushbutton', tooltip=None, layout=None
+    ):
+        _check_option(
+            parameter='style',
+            value=style,
+            allowed_values=('toolbutton', 'pushbutton')
+        )
+        if style == 'toolbutton':
+            widget = QToolButton()
+            widget.setText(name)
+        else:
+            widget = QPushButton(name)
+            # Don't change text color upon button press
+            widget.setStyleSheet(
+                'QPushButton:pressed {color: none;}'
+            )
+
         _set_widget_tooltip(widget, tooltip)
         widget.clicked.connect(callback)
-        widget.setText(name)
+
+        layout = self._dock_layout if layout is None else layout
         self._layout_add_widget(layout, widget)
         return _QtWidget(widget)
 
@@ -608,7 +622,7 @@ class _QtWidgetList(_AbstractWidgetList):
 
 class _QtWidget(_AbstractWidget):
     def set_value(self, value):
-        if isinstance(self._widget, (QRadioButton, QToolButton)):
+        if isinstance(self._widget, (QRadioButton, QToolButton, QPushButton)):
             self._widget.click()
         else:
             if hasattr(self._widget, "setValue"):


### PR DESCRIPTION
On my macOS machine:

|`main`|PR|
|-------|----|
| <img width="341" alt="Screen Shot 2022-01-19 at 12 27 40" src="https://user-images.githubusercontent.com/2046265/150121772-068a64fc-a796-45f2-b5b7-78b57d4033a3.png"> |  <img width="386" alt="Screen Shot 2022-01-19 at 12 27 08" src="https://user-images.githubusercontent.com/2046265/150121791-9395d3b4-ed33-4ff9-9e54-2a33499081ef.png"> |

