### PR TITLE
Use packaging.version in _compare_version

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -125,6 +125,7 @@ def pytest_configure(config):
     ignore:.*Found the following unknown channel type.*:RuntimeWarning
     ignore:.*np\.MachAr.*:DeprecationWarning
     ignore:.*Passing unrecognized arguments to super.*:DeprecationWarning
+    # present in nilearn v 0.8.1, fixed in nilearn main
     ignore:.*distutils Version classes are deprecated.*:DeprecationWarning
     ignore:.*pandas\.Int64Index is deprecated.*:FutureWarning
     always::ResourceWarning

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -47,14 +47,8 @@ def _compare_version(version_a, operator, version_b):
     bool
         The result of the version comparison.
     """
-    try:
-        from pkg_resources import parse_version as parse
-    except ImportError:
-        from distutils.version import LooseVersion as parse
-
-    with warnings.catch_warnings(record=True):
-        warnings.simplefilter('ignore')
-        return eval(f'parse("{version_a}") {operator} parse("{version_b}")')
+    from packaging.version import parse
+    return eval(f'parse("{version_a}") {operator} parse("{version_b}")')
 
 
 ###############################################################################

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -48,7 +48,9 @@ def _compare_version(version_a, operator, version_b):
         The result of the version comparison.
     """
     from packaging.version import parse
-    return eval(f'parse("{version_a}") {operator} parse("{version_b}")')
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter('ignore')
+        return eval(f'parse("{version_a}") {operator} parse("{version_b}")')
 
 
 ###############################################################################


### PR DESCRIPTION
Fixes #10197. Do we want to move the function to a different module?