### PR TITLE
MRG: Make Coregistration work with topologically defective surfaces

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -82,6 +82,8 @@ Enhancements
 
 - :func:`mne.gui.coregistration` now uses the proper widget style for push buttons, making for a more native feel of the application (:gh:`10220` by `Richard Höchenberger`_ and `Guillaume Favelier`_)
 
+- :class:`mne.coreg.Coregistration`, :func:`mne.coreg.scale_bem`, and :func:`mne.coreg.scale_mri` gained a new parameter, ``on_defects``, controlling how to handle topological defects (:gh:`10230`, by `Richard Höchenberger`_)
+
 - Added plotting points to represent contacts on the max intensity projection plot for :func:`mne.gui.locate_ieeg` (:gh:`10212` by `Alex Rockhill`_)
 
 - Add lines in 3D and on the maximum intensity projection when more than two electrode contacts are selected to aid in identifying that contact for :func:`mne.gui.locate_ieeg` (:gh:`10212` by `Alex Rockhill`_)
@@ -150,8 +152,6 @@ Bugs
 - :meth:`mne.Report.add_trans` now allows you to add sensor alignment plots for head surfaces that have topological defects (:gh:`10175` by `Richard Höchenberger`_)
 
 - :meth:`mne.Report.add_trans` now also works if no digitization points are present in the data (:gh:`10176` by `Jeff Stout`_)
-
-- :class:`mne.coreg.Coregistration`, :func:`mne.coreg.scale_bem`, and :func:`mne.coreg.scale_mri` gained a new parameter, ``on_defects``, controlling how to handle topological defects (:gh:`10230`, by `Richard Höchenberger`_)
 
 - :func:`mne.gui.coregistration` now works with surfaces containing topological defects (:gh:`10230`, by `Richard Höchenberger`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -151,6 +151,10 @@ Bugs
 
 - :meth:`mne.Report.add_trans` now also works if no digitization points are present in the data (:gh:`10176` by `Jeff Stout`_)
 
+- :class:`mne.coreg.Coregistration`, :func:`mne.coreg.scale_bem`, and :func:`mne.coreg.scale_mri` gained a new parameter, ``on_defects``, controlling how to handle topological defects (:gh:`xxx`, by `Richard Höchenberger`_)
+
+- :func:`mne.gui.coregistration` now works with surfaces containing topological defects (:gh:`xxx`, by `Richard Höchenberger`_)
+
 API changes
 ~~~~~~~~~~~
 - ``mne.Info.pick_channels`` has been deprecated. Use ``inst.pick_channels`` to pick channels from :class:`~mne.io.Raw`, :class:`~mne.Epochs`, and :class:`~mne.Evoked`. Use :func:`mne.pick_info` to pick channels from :class:`mne.Info` (:gh:`10039` by `Mathieu Scheltienne`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -151,9 +151,9 @@ Bugs
 
 - :meth:`mne.Report.add_trans` now also works if no digitization points are present in the data (:gh:`10176` by `Jeff Stout`_)
 
-- :class:`mne.coreg.Coregistration`, :func:`mne.coreg.scale_bem`, and :func:`mne.coreg.scale_mri` gained a new parameter, ``on_defects``, controlling how to handle topological defects (:gh:`xxx`, by `Richard Höchenberger`_)
+- :class:`mne.coreg.Coregistration`, :func:`mne.coreg.scale_bem`, and :func:`mne.coreg.scale_mri` gained a new parameter, ``on_defects``, controlling how to handle topological defects (:gh:`10230`, by `Richard Höchenberger`_)
 
-- :func:`mne.gui.coregistration` now works with surfaces containing topological defects (:gh:`xxx`, by `Richard Höchenberger`_)
+- :func:`mne.gui.coregistration` now works with surfaces containing topological defects (:gh:`10230`, by `Richard Höchenberger`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -82,7 +82,7 @@ Enhancements
 
 - :func:`mne.gui.coregistration` now uses the proper widget style for push buttons, making for a more native feel of the application (:gh:`10220` by `Richard Höchenberger`_ and `Guillaume Favelier`_)
 
-- :class:`mne.coreg.Coregistration`, :func:`mne.coreg.scale_bem`, and :func:`mne.coreg.scale_mri` gained a new parameter, ``on_defects``, controlling how to handle topological defects (:gh:`10230`, by `Richard Höchenberger`_)
+- :class:`mne.coreg.Coregistration`, :func:`mne.scale_bem`, and :func:`mne.scale_mri` gained a new parameter, ``on_defects``, controlling how to handle topological defects (:gh:`10230`, by `Richard Höchenberger`_)
 
 - Added plotting points to represent contacts on the max intensity projection plot for :func:`mne.gui.locate_ieeg` (:gh:`10212` by `Alex Rockhill`_)
 

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -830,7 +830,7 @@ def _scale_params(subject_to, subject_from, scale, subjects_dir):
 
 @verbose
 def scale_bem(subject_to, bem_name, subject_from=None, scale=None,
-              subjects_dir=None, on_defects='raise', *, verbose=None):
+              subjects_dir=None, *, on_defects='raise', verbose=None):
     """Scale a bem file.
 
     Parameters

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -830,7 +830,7 @@ def _scale_params(subject_to, subject_from, scale, subjects_dir):
 
 @verbose
 def scale_bem(subject_to, bem_name, subject_from=None, scale=None,
-              subjects_dir=None, on_defects='raise', verbose=None):
+              subjects_dir=None, on_defects='raise', *, verbose=None):
     """Scale a bem file.
 
     Parameters
@@ -1331,7 +1331,7 @@ class Coregistration(object):
     to create a surrogate MRI subject with the proper scale factors.
     """
 
-    def __init__(self, info, subject, subjects_dir=None, fiducials='auto',
+    def __init__(self, info, subject, subjects_dir=None, fiducials='auto', *,
                  on_defects='raise'):
         _validate_type(info, (Info, None), 'info')
         self._info = info

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -933,7 +933,7 @@ def scale_labels(subject_to, pattern=None, overwrite=False, subject_from=None,
 @verbose
 def scale_mri(subject_from, subject_to, scale, overwrite=False,
               subjects_dir=None, skip_fiducials=False, labels=True,
-              annot=False, on_defects='raise', verbose=None):
+              annot=False, *, on_defects='raise', verbose=None):
     """Create a scaled copy of an MRI subject.
 
     Parameters

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -830,7 +830,7 @@ def _scale_params(subject_to, subject_from, scale, subjects_dir):
 
 @verbose
 def scale_bem(subject_to, bem_name, subject_from=None, scale=None,
-              subjects_dir=None, verbose=None):
+              subjects_dir=None, on_defects='raise', verbose=None):
     """Scale a bem file.
 
     Parameters
@@ -849,6 +849,9 @@ def scale_bem(subject_to, bem_name, subject_from=None, scale=None,
         otherwise it is read from subject_to's config file.
     subjects_dir : None | str
         Override the SUBJECTS_DIR environment variable.
+    %(on_defects)s
+
+        .. versionadded:: 1.0
     %(verbose)s
     """
     subjects_dir, subject_from, scale, uniform = \
@@ -862,7 +865,7 @@ def scale_bem(subject_to, bem_name, subject_from=None, scale=None,
     if os.path.exists(dst):
         raise IOError("File already exists: %s" % dst)
 
-    surfs = read_bem_surfaces(src)
+    surfs = read_bem_surfaces(src, on_defects=on_defects)
     for surf in surfs:
         surf['rr'] *= scale
         if not uniform:
@@ -930,7 +933,7 @@ def scale_labels(subject_to, pattern=None, overwrite=False, subject_from=None,
 @verbose
 def scale_mri(subject_from, subject_to, scale, overwrite=False,
               subjects_dir=None, skip_fiducials=False, labels=True,
-              annot=False, verbose=None):
+              annot=False, on_defects='raise', verbose=None):
     """Create a scaled copy of an MRI subject.
 
     Parameters
@@ -952,6 +955,9 @@ def scale_mri(subject_from, subject_to, scale, overwrite=False,
         Also scale all labels (default True).
     annot : bool
         Copy ``*.annot`` files to the new location (default False).
+    %(on_defects)s
+
+        .. versionadded:: 1.0
     %(verbose)s
 
     See Also
@@ -1005,7 +1011,7 @@ def scale_mri(subject_from, subject_to, scale, overwrite=False,
     logger.debug('BEM files [in m]')
     for bem_name in paths['bem']:
         scale_bem(subject_to, bem_name, subject_from, scale, subjects_dir,
-                  verbose=False)
+                  on_defects=on_defects, verbose=False)
 
     logger.debug('fiducials [in m]')
     for fname in paths['fid']:
@@ -1260,11 +1266,13 @@ def _scale_xfm(subject_to, xfm_fname, mri_name, subject_from, scale,
     _write_fs_xfm(fname_to, T_ras_mni['trans'], kind)
 
 
-def _read_surface(filename):
+def _read_surface(filename, *, on_defects):
     bem = dict()
     if filename is not None and op.exists(filename):
         if filename.endswith('.fif'):
-            bem = read_bem_surfaces(filename, verbose=False)[0]
+            bem = read_bem_surfaces(
+                filename, on_defects=on_defects, verbose=False
+            )[0]
         else:
             try:
                 bem = read_surface(filename, return_dict=True)[2]
@@ -1298,6 +1306,9 @@ class Coregistration(object):
         template. If set to 'auto', one tries to find the fiducials
         in a file with the canonical name (``bem/{subject}-fiducials.fif``)
         and if abstent one falls back to 'estimated'. Defaults to 'auto'.
+    %(on_defects)s
+
+        .. versionadded:: 1.0
 
     Attributes
     ----------
@@ -1320,12 +1331,14 @@ class Coregistration(object):
     to create a surrogate MRI subject with the proper scale factors.
     """
 
-    def __init__(self, info, subject, subjects_dir=None, fiducials='auto'):
+    def __init__(self, info, subject, subjects_dir=None, fiducials='auto',
+                 on_defects='raise'):
         _validate_type(info, (Info, None), 'info')
         self._info = info
         self._subject = _check_subject(subject, subject)
         self._subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
         self._scale_mode = None
+        self._on_defects = on_defects
 
         self._rot_trans = None
         self._default_parameters = \
@@ -1390,10 +1403,14 @@ class Coregistration(object):
             raise RuntimeError("No standard head model was "
                                f"found for subject {self._subject}")
         if high_res_path is not None:
-            self._bem_high_res = _read_surface(high_res_path)
+            self._bem_high_res = _read_surface(
+                high_res_path, on_defects=self._on_defects
+            )
             logger.info(f'Using high resolution head model in {high_res_path}')
         else:
-            self._bem_high_res = _read_surface(low_res_path)
+            self._bem_high_res = _read_surface(
+                low_res_path, on_defects=self._on_defects
+            )
             logger.info(f'Using low resolution head model in {low_res_path}')
         if low_res_path is None:
             # This should be very rare!
@@ -1408,7 +1425,9 @@ class Coregistration(object):
             self._bem_low_res = complete_surface_info(
                 dict(rr=rr, tris=tris), copy=False, verbose=False)
         else:
-            self._bem_low_res = _read_surface(low_res_path)
+            self._bem_low_res = _read_surface(
+                low_res_path, on_defects=self._on_defects
+            )
 
     def _setup_fiducials(self, fids):
         _validate_type(fids, (str, dict, list))

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -212,7 +212,10 @@ class CoregistrationUI(HasTraits):
         self._info = info
         self._fiducials = fiducials
         self._coreg = Coregistration(
-            self._info, subject, subjects_dir, fiducials)
+            info=self._info, subject=subject, subjects_dir=subjects_dir,
+            fiducials=fiducials,
+            on_defects='ignore'  # safe due to interactive visual inspection
+        )
         fid_accurate = self._coreg._fid_accurate
         for fid in self._defaults["weights"].keys():
             setattr(self, f"_{fid}_weight", self._defaults["weights"][fid])
@@ -1023,9 +1026,13 @@ class CoregistrationUI(HasTraits):
         # save the scaled MRI
         try:
             self._display_message(f"Scaling {self._subject_to}...")
-            scale_mri(self._subject, self._subject_to, self._coreg._scale,
-                      True, self._subjects_dir, self._skip_fiducials,
-                      self._scale_labels, self._copy_annots)
+            scale_mri(
+                subject_from=self._subject, subject_to=self._subject_to,
+                scale=self._coreg._scale, overwrite=True,
+                subjects_dir=self._subjects_dir,
+                skip_fiducials=self._skip_fiducials, labels=self._scale_labels,
+                annot=self._copy_annots, on_defects='ignore'
+            )
         except Exception:
             logger.error(f"Error scaling {self._subject_to}")
             bem_names = []


### PR DESCRIPTION
- Make `mne.coreg.Coregistration` work with BEM surfaces that have topological defects by adding `on_defects` parameters to the respective functions.
- Make `mne.gui.coregistration` work with surfaces with topological defects by default.

This fixes issues that surfaced while working with @SophieHerbst 