### PR TITLE
BUG: Fix iEEG example

### DIFF
--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -317,6 +317,7 @@ subj_trans = mne.coreg.estimate_head_mri_t(
 
 # load electrophysiology data to find channel locations for
 # (the channels are already located in the example)
+
 raw = mne.io.read_raw(op.join(misc_path, 'seeg', 'sample_seeg_ieeg.fif'))
 
 gui = mne.gui.locate_ieeg(raw.info, subj_trans, CT_aligned,


### PR DESCRIPTION
@alexrockhill it looks like #10226 broke CircleCI on `main`: https://app.circleci.com/pipelines/github/mne-tools/mne-python/12480/workflows/433a19c3-afd5-4150-bf1b-8f48d9d88278/jobs/40780
```
generating gallery for auto_tutorials/clinical... [ 25%] 10_ieeg_localize.py
1981.1 s : 2.20 GB    
WARNING: /home/circleci/project/tutorials/clinical/10_ieeg_localize.py failed to execute correctly: Traceback (most recent call last):
  File "/home/circleci/python_env/lib/python3.8/site-packages/sphinx_gallery/scrapers.py", line 379, in save_figures
    rst = scraper(block, block_vars, gallery_conf)
  File "/home/circleci/project/mne/gui/__init__.py", line 267, in __call__
    plotter.screenshot(img_fname)
  File "/home/circleci/python_env/lib/python3.8/site-packages/pyvista/plotting/plotting.py", line 3912, in screenshot
    raise RuntimeError('This plotter is closed and unable to save a screenshot.')
RuntimeError: This plotter is closed and unable to save a screenshot.
```
This first commit should come back red for CircleCI, then I'll push one that should fix it (at least it does locally).