### PR TITLE
Change CoregistrationUI status bar text color to black

### DIFF
--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -426,6 +426,7 @@ class _QtStatusBar(_AbstractStatusBar, _QtLayout):
 
     def _status_bar_add_label(self, value, stretch=0):
         widget = QLabel(value)
+        widget.setStyleSheet("QLabel { color: black; }")
         self._layout_add_widget(self._status_bar_layout, widget, stretch)
         return _QtWidget(widget)
 


### PR DESCRIPTION
Somehow Qt applies a weird color scheme to the status bar on macOS and the text color is white by default, which makes it barely readable. This PR changes the text color to black.

|`main` | PR |
|---|----|
| <img width="245" alt="Screen Shot 2022-01-24 at 09 44 53" src="https://user-images.githubusercontent.com/2046265/150750096-faa8d4aa-7b26-4a43-88db-42fc3445ce93.png"> | <img width="245" alt="Screen Shot 2022-01-24 at 09 44 34" src="https://user-images.githubusercontent.com/2046265/150750137-331f0499-7b1a-4476-9423-9065e6866708.png">|


cc @GuillaumeFavelier @agramfort 