### PR TITLE
MRG: Rework CoregistrationUI fiducial I/O widgets & add save button

### DIFF
--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1369,6 +1369,8 @@ class Coregistration(object):
 
         self._setup_digs()
         self._setup_bem()
+
+        self._fid_filename = None
         self._setup_fiducials(fiducials)
         self.reset()
 
@@ -1449,6 +1451,7 @@ class Coregistration(object):
                 logger.info(f'Using fiducials from: {fid_filename}.')
                 fids, _ = read_fiducials(fid_filename)
                 fid_accurate = True
+                self._fid_filename = fid_filename
             else:
                 fids = 'estimated'
 

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -285,14 +285,14 @@ class CoregistrationUI(HasTraits):
 
         if fid_accurate:
             assert self.coreg._fid_filename is not None
-            # _set_fiducials_file() calls _update_mri_fiducials_label()
+            # _set_fiducials_file() calls _update_fiducials_label()
             # internally
             self._set_fiducials_file(self.coreg._fid_filename)
         else:
             self._set_head_resolution('high')
             self._forward_widget_command('high_res_head', "set_value", True)
             self._set_lock_fids(True)  # hack to make the dig disappear
-            self._update_mri_fiducials_label()
+            self._update_fiducials_label()
             self._update_fiducials()
 
         self._set_lock_fids(fid_accurate)
@@ -338,7 +338,7 @@ class CoregistrationUI(HasTraits):
         self._fiducials_file = fname
         self.coreg._setup_fiducials(fids)
         self._update_distance_estimation()
-        self._update_mri_fiducials_label()
+        self._update_fiducials_label()
         self._update_fiducials()
         self._reset()
 
@@ -1230,7 +1230,7 @@ class CoregistrationUI(HasTraits):
             subjects = ['']
         return sorted(subjects)
 
-    def _update_mri_fiducials_label(self):
+    def _update_fiducials_label(self):
         if self._fiducials_file is None:
             text = (
                 '<p><strong>No custom MRI fiducials loaded!</strong></p>'
@@ -1285,7 +1285,7 @@ class CoregistrationUI(HasTraits):
         )
         # Add MRI fiducials I/O widgets
         self._widgets['mri_fiducials_label'] = self._renderer._dock_add_label(
-            value='',  # Will be filled via _update_mri_fiducials_label()
+            value='',  # Will be filled via _update_fiducials_label()
             layout=mri_fiducials_layout,
             selectable=True
         )

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -500,7 +500,7 @@ class CoregistrationUI(HasTraits):
         self.coreg._subjects_dir = self._subjects_dir
         subjects = self._get_subjects()
 
-        if self._subject not in subjects:
+        if self._subject not in subjects:  # Just pick the first available one
             self._subject = subjects[0]
 
         self._reset()

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -546,7 +546,6 @@ class CoregistrationUI(HasTraits):
             self._forward_widget_command(fits_widgets, "set_enabled", False)
             self._display_message("Placing MRI fiducials - "
                                   f"{self._current_fiducial.upper()}")
-            self._forward_widget_command('save_mri_fids', 'set_enabled', False)
 
         self._set_sensors_visibility(self._lock_fids)
         self._forward_widget_command("lock_fids", "set_value", self._lock_fids)

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -903,7 +903,7 @@ class CoregistrationUI(HasTraits):
         method : str
             The method to invoke.
         values : object | array-like
-            The value(s) to pass to the method(s).
+            The value(s) to pass to the method.
         """
         if isinstance(widget_names, str):
             widget_names = [widget_names]

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -1317,9 +1317,6 @@ class CoregistrationUI(HasTraits):
                     "must be locked first!",
             layout=mri_fiducials_button_layout,
         )
-        # Disable save button until fiducials are locked.
-        self._forward_widget_command('save_mri_fids', 'set_enabled', False)
-
         self._widgets["lock_fids"] = self._renderer._dock_add_check_box(
             name="Lock fiducials",
             value=self._lock_fids,

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -529,7 +529,8 @@ class CoregistrationUI(HasTraits):
     def _lock_fids_changed(self, change=None):
         locked_widgets = ["sX", "sY", "sZ", "tX", "tY", "tZ",
                           "rX", "rY", "rZ", "project_eeg",
-                          "fit_fiducials", "fit_icp"]
+                          "fit_fiducials", "fit_icp",
+                          "save_mri_fids"]
         fits_widgets = ["fits_fiducials", "fits_icp"]
         fid_widgets = ["fid_X", "fid_Y", "fid_Z", "fids_file", "fids"]
         if self._lock_fids:
@@ -538,7 +539,6 @@ class CoregistrationUI(HasTraits):
             self._scale_mode_changed()
             self._display_message()
             self._update_distance_estimation()
-            self._forward_widget_command('save_mri_fids', 'set_enabled', True)
         else:
             self._old_head_opacity = self._head_opacity
             self._head_opacity = 1.0

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -284,10 +284,10 @@ class CoregistrationUI(HasTraits):
         self._redraw()  # we need the elements to be present now
 
         if fid_accurate:
-            assert self._coreg._fid_filename is not None
+            assert self.coreg._fid_filename is not None
             # _set_fiducials_file() calls _update_mri_fiducials_label()
             # internally
-            self._set_fiducials_file(self._coreg._fid_filename)
+            self._set_fiducials_file(self.coreg._fid_filename)
         else:
             self._set_head_resolution('high')
             self._forward_widget_command('high_res_head', "set_value", True)
@@ -1196,7 +1196,7 @@ class CoregistrationUI(HasTraits):
             assert self._fiducials_file == fid_fname.format(
                 subjects_dir=self._subjects_dir, subject=self._subject
             )
-            assert self._coreg._fid_accurate is True
+            assert self.coreg._fid_accurate is True
             text = (
                 f'<p><strong>MRI fiducials (diamonds) loaded from '
                 f'standard location:</strong></p>'

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -326,7 +326,7 @@ class CoregistrationUI(HasTraits):
     def _set_lock_fids(self, state):
         self._lock_fids = bool(state)
 
-    def _set_fiducials_file(self, fname, log=True):
+    def _set_fiducials_file(self, fname):
         if fname is None:
             fids = 'auto'
         else:
@@ -352,10 +352,9 @@ class CoregistrationUI(HasTraits):
             self._forward_widget_command(
                 'reload_mri_fids', 'set_enabled', True
             )
-            if log:
-                self._display_message(
-                    f"Loading MRI fiducials from {fname}... Done!"
-                )
+            self._display_message(
+                f"Loading MRI fiducials from {fname}... Done!"
+            )
 
     def _set_current_fiducial(self, fid):
         self._current_fiducial = fid.lower()
@@ -1195,8 +1194,8 @@ class CoregistrationUI(HasTraits):
         write_fiducials(
             fname=fname, pts=dig_montage.dig, coord_frame='mri', overwrite=True
         )
+        self._set_fiducials_file(fname)
         self._display_message(f"Saving {fname}... Done!")
-        self._set_fiducials_file(fname, log=False)
 
     def _save_trans(self, fname):
         write_trans(fname, self.coreg.trans, overwrite=True)

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -884,13 +884,28 @@ class CoregistrationUI(HasTraits):
         self._update_parameters()
         self._update_distance_estimation()
 
-    def _forward_widget_command(self, names, command, value):
-        names = [names] if not isinstance(names, list) else names
-        value = list(value) if isinstance(value, np.ndarray) else value
-        for idx, name in enumerate(names):
-            val = value[idx] if isinstance(value, list) else value
+    def _forward_widget_command(self, widget_names, method, values):
+        """Invoke a method of one or more widgets if the widgets exist.
+
+        Parameters
+        ----------
+        widget_names : str | list of str
+            The widget names to operate on.
+        method : str
+            The method to invoke.
+        values : str | list of str
+            The value(s) to pass to the method(s).
+        """
+        if not isinstance(widget_names, list):
+            widget_names = [widget_names]
+
+        values = list(values) if isinstance(values, np.ndarray) else values
+        assert len(widget_names) == len(values)
+        for idx, name in enumerate(widget_names):
+            val = values[idx] if isinstance(values, list) else values
             if name in self._widgets:
-                getattr(self._widgets[name], command)(val)
+                meth = getattr(self._widgets[name], method)
+                meth(val)
 
     def _set_sensors_visibility(self, state):
         sensors = ["head_fiducials", "hpi_coils", "head_shape_points",


### PR DESCRIPTION
This is the last remaining bit of the #10237 rework, incorporating suggestions and feedback I've meanwhile received.

Closes #10237

I've removed the `_fiducials_file` traitlet as it's not needed anymore. I've moved its functionality to other methods.


https://user-images.githubusercontent.com/2046265/150946042-5513b999-ba82-460f-a427-49019e842037.mov

- Saving only allowed once fiducials are locked
- Reloding fiducials automatically locks fiducials

There's a bug related to the digpoints still showing even though the fiducials are unlocked. I've left an extensive comment in the source. This is probably something that needs to be solved in a separate PR unless @GuillaumeFavelier has an immediate idea? At any rate, I don't think this PR introduced this problem 😅

cc @agramfort 