### PR TITLE
Allow QLabel widget text content to be selectable

### DIFF
--- a/mne/gui/tests/test_gui_api.py
+++ b/mne/gui/tests/test_gui_api.py
@@ -46,6 +46,7 @@ def test_gui_api(renderer_notebook, nbexec):
     widget = renderer._dock_add_label('', align=True)
     widget.update()
     widget.set_enabled(False)
+    widget = renderer._dock_add_label('', align=False, selectable=True)
 
     # ToolButton
     widget = renderer._dock_add_button(

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -528,7 +528,9 @@ class _AbstractDock(ABC):
         pass
 
     @abstractmethod
-    def _dock_add_label(self, value, align=False, layout=None):
+    def _dock_add_label(
+        self, value, align=False, layout=None, selectable=False
+    ):
         pass
 
     @abstractmethod

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -65,7 +65,9 @@ class _IpyDock(_AbstractDock, _IpyLayout):
     def _dock_add_layout(self, vertical=True):
         return VBox() if vertical else HBox()
 
-    def _dock_add_label(self, value, align=False, layout=None):
+    def _dock_add_label(
+        self, value, align=False, layout=None, selectable=False
+    ):
         layout = self._dock_layout if layout is None else layout
         widget = Text(value=value, disabled=True)
         self._layout_add_widget(layout, widget)

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -75,13 +75,17 @@ class _QtDock(_AbstractDock, _QtLayout):
         layout = QVBoxLayout() if vertical else QHBoxLayout()
         return layout
 
-    def _dock_add_label(self, value, align=False, layout=None):
+    def _dock_add_label(
+        self, value, align=False, layout=None, selectable=False
+    ):
         layout = self._dock_layout if layout is None else layout
         widget = QLabel()
         if align:
             widget.setAlignment(Qt.AlignCenter)
         widget.setText(value)
         widget.setWordWrap(True)
+        if selectable:
+            widget.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self._layout_add_widget(layout, widget)
         return _QtWidget(widget)
 


### PR DESCRIPTION
Factored out from #10242 to make life easier for @GuillaumeFavelier