### PR TITLE
MRG: In Report, move epochs drop log farther up

### DIFF
--- a/mne/html_templates/report/epochs.html.jinja
+++ b/mne/html_templates/report/epochs.html.jinja
@@ -17,9 +17,9 @@
     aria-labelledby="accordion-header-{{ id }}">
     <div class="accordion-body">
       {{ repr | safe }}
+      {{ drop_log | safe }}
       {{ metadata | safe }}
       {{ erp_imgs | safe }}
-      {{ drop_log | safe }}
       {{ psd | safe }}
       {{ ssp_projs | safe }}
     </div>


### PR DESCRIPTION
I found myself constantly having to scroll down to the drop log before even looking at the epochs metadata. I therefore figured the drop log should be rendered above the metadata.

cc @agramfort