### PR TITLE
In Report, limit max. image height to 600 pixels

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -60,7 +60,7 @@ Enhancements
 
 - Drastically speed up butterfly plot generation in :meth:`mne.Report.add_raw`. We now don't plot annotations anymore; however, we feel that the speed improvements justify this change, also considering the annotations were of limited use in the displayed one-second time slices anyway (:gh:`10114`, :gh:`10116` by `Richard Höchenberger`_)
 
-- In :class:`mne.Report`, limit the width of automatically generated figures to a maximum of 850 pixels (450 pixels for :class:`mne.SourceEstimate` plots), and the resolution to 100 DPI to reduce file size, memory consumption, and – in some cases like :meth:`mne.Report.add_stc` – processing time (:gh:`10126`, :gh:`10129`, :gh:`10135`, :gh:`10142` by `Richard Höchenberger`_)
+- In :class:`mne.Report`, limit the size of automatically generated figures to a maximum width of 850 and a height of 600 pixels (450 pixels width and height for :class:`mne.SourceEstimate` plots), and the resolution to 100 DPI to reduce file size, memory consumption, and – in some cases like :meth:`mne.Report.add_stc` – processing time (:gh:`10126`, :gh:`10129`, :gh:`10135`, :gh:`10142`, :gh:`10248` by `Richard Höchenberger`_)
 
 - :class:`~mne.Epochs` metadata tables are now included in :class:`mne.Report` (:gh:`10166` by `Richard Höchenberger`_)
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -357,7 +357,7 @@ def _fig_to_img(fig, *, image_format='png', auto_close=True):
             backend._close_3d_figure(figure=fig)
         fig = _ndarray_to_fig(img)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH,  max_height=MAX_IMG_HEIGHT,
+            fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
             max_res=MAX_IMG_RES
         )
 
@@ -522,7 +522,8 @@ def _plot_ica_properties_as_arrays(*, ica, inst, picks, n_jobs):
         assert len(figs) == 1
         fig = figs[0]
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+            fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+            max_res=MAX_IMG_RES
         )
         with io.BytesIO() as buff:
             fig.savefig(
@@ -1437,7 +1438,8 @@ class Report(object):
         del inst_
         tight_layout(fig=fig)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+            fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+            max_res=MAX_IMG_RES
         )
         img = _fig_to_img(fig, image_format=image_format)
         dom_id = self._get_dom_id()
@@ -1503,7 +1505,8 @@ class Report(object):
                                      image_format, tags):
         fig = ica.plot_sources(inst=inst, show=False)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+            fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+            max_res=MAX_IMG_RES
         )
         img = _fig_to_img(fig, image_format=image_format)
         dom_id = self._get_dom_id()
@@ -1518,7 +1521,8 @@ class Report(object):
                                     image_format, tags):
         fig = ica.plot_scores(scores=scores, title=None, show=False)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+            fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+            max_res=MAX_IMG_RES
         )
         img = _fig_to_img(fig, image_format=image_format)
         dom_id = self._get_dom_id()

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -1551,7 +1551,8 @@ class Report(object):
         if len(figs) == 1:
             fig = figs[0]
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+                fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+                max_res=MAX_IMG_RES
             )
             img = _fig_to_img(fig=fig, image_format=image_format)
             dom_id = self._get_dom_id()

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -102,7 +102,7 @@ CSS = (html_include_dir / 'report.sass').read_text(encoding='utf-8')
 
 MAX_IMG_RES = 100  # in dots per inch
 MAX_IMG_WIDTH = 850  # in pixels
-
+MAX_IMG_HEIGHT = 600  # in pixels
 
 def _get_ch_types(inst):
     return [ch_type for ch_type in _DATA_CH_TYPES_SPLIT if ch_type in inst]
@@ -307,7 +307,7 @@ def _check_tags(tags) -> Tuple[str]:
 # PLOTTING FUNCTIONS
 
 
-def _constrain_fig_resolution(fig, *, max_width, max_res):
+def _constrain_fig_resolution(fig, *, max_width, max_height, max_res):
     """Limit the resolution (DPI) of a figure.
 
     Parameters
@@ -316,6 +316,8 @@ def _constrain_fig_resolution(fig, *, max_width, max_res):
         The figure whose DPI to adjust.
     max_width : int
         The max. allowed width, in pixels.
+    max_width : int
+        The max. allowed height, in pixels.
     max_res : int
         The max. allowed resolution, in DPI.
 
@@ -323,7 +325,11 @@ def _constrain_fig_resolution(fig, *, max_width, max_res):
     -------
     Nothing, alters the figure's properties in-place.
     """
-    dpi = min(max_res, max_width / fig.get_size_inches()[0])
+    dpi = min(
+        max_res,
+        max_width / fig.get_size_inches()[0],
+        max_height / fig.get_size_inches()[1],
+    )
     fig.set_dpi(dpi)
 
 
@@ -335,7 +341,8 @@ def _fig_to_img(fig, *, image_format='png', auto_close=True):
     if isinstance(fig, np.ndarray):
         fig = _ndarray_to_fig(fig)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+            fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+            max_res=MAX_IMG_RES
         )
     elif not isinstance(fig, Figure):
         from ..viz.backends.renderer import backend, MNE_3D_BACKEND_TESTING
@@ -349,7 +356,8 @@ def _fig_to_img(fig, *, image_format='png', auto_close=True):
             backend._close_3d_figure(figure=fig)
         fig = _ndarray_to_fig(img)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+            fig, max_width=MAX_IMG_WIDTH,  max_height=MAX_IMG_HEIGHT,
+            max_res=MAX_IMG_RES
         )
 
     output = BytesIO()
@@ -2656,7 +2664,8 @@ class Report(object):
                 duration=durations[0], scalings=scalings, show=False
             )
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+                fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+                max_res=MAX_IMG_RES
             )
             images = [_fig_to_img(fig=fig, image_format=image_format)]
 
@@ -2730,7 +2739,8 @@ class Report(object):
             fig = raw.plot_psd(fmax=fmax, show=False, **add_psd)
             tight_layout(fig=fig)
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+                fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+                max_res=MAX_IMG_RES
             )
 
             img = _fig_to_img(fig, image_format=image_format)
@@ -2805,7 +2815,8 @@ class Report(object):
         fig.set_size_inches((6, 4))
         tight_layout(fig=fig)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+            fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+            max_res=MAX_IMG_RES
         )
         img = _fig_to_img(fig=fig, image_format=image_format)
 
@@ -2914,7 +2925,8 @@ class Report(object):
                 )
 
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+                fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+                max_res=MAX_IMG_RES
             )
             img = _fig_to_img(fig=fig, image_format=image_format)
             title = f'Time course ({_handle_default("titles")[ch_type]})'
@@ -2950,7 +2962,8 @@ class Report(object):
             figsize=(2.5 * len(ch_types), 2)
         )
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+            fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+            max_res=MAX_IMG_RES
         )
         ch_type_ax_map = dict(
             zip(ch_types,
@@ -3087,7 +3100,8 @@ class Report(object):
 
         tight_layout(fig=fig)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+            fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+            max_res=MAX_IMG_RES
         )
         img = _fig_to_img(fig=fig, image_format=image_format)
         title = 'Global field power'
@@ -3115,7 +3129,8 @@ class Report(object):
         )
         tight_layout(fig=fig)
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+            fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+            max_res=MAX_IMG_RES
         )
         img = _fig_to_img(fig=fig, image_format=image_format)
         title = 'Whitened'
@@ -3179,7 +3194,8 @@ class Report(object):
             show=False
         )
         _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+            fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+            max_res=MAX_IMG_RES
         )
         img = _fig_to_img(
             fig=fig,
@@ -3249,7 +3265,8 @@ class Report(object):
 
             fig = epochs_for_psd.plot_psd(fmax=fmax, show=False)
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+                fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+                max_res=MAX_IMG_RES
             )
             img = _fig_to_img(fig=fig, image_format=image_format)
             duration = round(epoch_duration * len(epochs_for_psd), 1)
@@ -3387,7 +3404,8 @@ class Report(object):
             assert len(figs) == 1
             fig = figs[0]
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+                fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+                max_res=MAX_IMG_RES
             )
             img = _fig_to_img(fig=fig, image_format=image_format)
             if ch_type in ('mag', 'grad'):
@@ -3430,7 +3448,8 @@ class Report(object):
                 )
                 tight_layout(fig=fig)
                 _constrain_fig_resolution(
-                    fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+                    fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+                    max_res=MAX_IMG_RES
                 )
                 img = _fig_to_img(fig=fig, image_format=image_format)
                 drop_log_img_html = _html_image_element(
@@ -3471,7 +3490,8 @@ class Report(object):
 
         for fig, title in zip(figs, titles):
             _constrain_fig_resolution(
-                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+                fig, max_width=MAX_IMG_WIDTH, max_height=MAX_IMG_HEIGHT,
+                max_res=MAX_IMG_RES
             )
             img = _fig_to_img(fig=fig, image_format=image_format)
             dom_id = self._get_dom_id()
@@ -3580,6 +3600,7 @@ class Report(object):
                     _constrain_fig_resolution(
                         fig,
                         max_width=stc_plot_kwargs['size'][0],
+                        max_height=stc_plot_kwargs['size'][1],
                         max_res=MAX_IMG_RES
                     )
                     figs.append(fig)
@@ -3609,11 +3630,13 @@ class Report(object):
                     _constrain_fig_resolution(
                         fig_lh,
                         max_width=stc_plot_kwargs['size'][0],
+                        max_height=stc_plot_kwargs['size'][1],
                         max_res=MAX_IMG_RES
                     )
                     _constrain_fig_resolution(
                         fig_rh,
                         max_width=stc_plot_kwargs['size'][0],
+                        max_height=stc_plot_kwargs['size'][0],
                         max_res=MAX_IMG_RES
                     )
                     figs.append(brain_lh)

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -104,6 +104,7 @@ MAX_IMG_RES = 100  # in dots per inch
 MAX_IMG_WIDTH = 850  # in pixels
 MAX_IMG_HEIGHT = 600  # in pixels
 
+
 def _get_ch_types(inst):
     return [ch_type for ch_type in _DATA_CH_TYPES_SPLIT if ch_type in inst]
 

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -82,7 +82,8 @@ subjects_dir = data_path / 'subjects'
 #
 # .. warning::
 #    In the following example, we crop the raw data to 60 seconds merely to
-#    speed up processing; this is not usually recommended!
+#    speed up processing for the sake of this tutorial; this is not usually
+#    recommended!
 
 raw_path = sample_dir / 'sample_audvis_filt-0-40_raw.fif'
 raw = mne.io.read_raw(raw_path)


### PR DESCRIPTION
For some plots I ended up with images of >1000 pixels of height, which wouldn't fit on my screen. To avoid having to scroll (and to reduce report size!), I'm now limiting max. height to 600 pixels.