### PR TITLE
Add MNE subpackages to sys_info()

### DIFF
--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -549,7 +549,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
                      'numba', 'nibabel', 'nilearn', 'dipy', 'cupy', 'pandas',
                      'pyvista', 'pyvistaqt', 'ipyvtklink', 'vtk',
                      'PyQt5', 'ipympl', 'pooch', 'mne_bids', 'mne_nirs',
-                     'mne_connectivity', 'mne_qt_browser')
+                     'mne_features', 'mne_connectivity', 'mne_qt_browser')
     if dependencies == 'developer':
         use_mod_names += (
             '', 'sphinx', 'sphinx_gallery', 'numpydoc', 'pydata_sphinx_theme',

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -548,11 +548,12 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
     use_mod_names = ('mne', 'numpy', 'scipy', 'matplotlib', '', 'sklearn',
                      'numba', 'nibabel', 'nilearn', 'dipy', 'cupy', 'pandas',
                      'pyvista', 'pyvistaqt', 'ipyvtklink', 'vtk',
-                     'PyQt5', 'ipympl', 'mne_qt_browser', 'pooch')
+                     'PyQt5', 'ipympl', 'pooch', 'mne_bids', 'mne_nirs',
+                     'mne_connectivity', 'mne_qt_browser')
     if dependencies == 'developer':
         use_mod_names += (
             '', 'sphinx', 'sphinx_gallery', 'numpydoc', 'pydata_sphinx_theme',
-            'mne_bids', 'pytest', 'nbclient')
+            'pytest', 'nbclient')
     for mod_name in use_mod_names:
         if mod_name == '':
             out += '\n'

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -548,8 +548,8 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
     use_mod_names = ('mne', 'numpy', 'scipy', 'matplotlib', '', 'sklearn',
                      'numba', 'nibabel', 'nilearn', 'dipy', 'cupy', 'pandas',
                      'pyvista', 'pyvistaqt', 'ipyvtklink', 'vtk',
-                     'PyQt5', 'ipympl', 'pooch', 'mne_bids', 'mne_nirs',
-                     'mne_features', 'mne_connectivity', 'mne_qt_browser')
+                     'PyQt5', 'ipympl', 'pooch', '', 'mne_bids', 'mne_nirs',
+                     'mne_features', 'mne_qt_browser', 'mne_connectivity')
     if dependencies == 'developer':
         use_mod_names += (
             '', 'sphinx', 'sphinx_gallery', 'numpydoc', 'pydata_sphinx_theme',


### PR DESCRIPTION
#### Reference issue
This is an issue as PR.


#### What does this implement/fix?
My immediate go-to when I have issues or help someone else is `mne.sys_info()`. Often in my case however, issues are caused by incompatibilities between various MNE sub packages (which I define as python packages hosted within the mne-tools organisation that aren't MNE-Python). I see that the sub package `mne_qt_browser` has been added to sys_info (but I guess this is because there are plans to merge it to MNE-Python in the future). And `mne_bids` was already included.

Can we add the other sub packages to the sys info output? E.g. NIRS, Connectivity, Features

#### Additional information
I also moved `mne_bids` from developer to user dependencies, as I think its commonly used by non developers too. 

I wasn't sure if mne-bids-pipeline fitted in to this scope and should be added too? Or if its more a tool in itself.
