### PR TITLE
DOC: Add hint about tutorials/examples with plots

### DIFF
--- a/examples/README.txt
+++ b/examples/README.txt
@@ -8,7 +8,7 @@ examples are a useful way to discover new analysis or plotting ideas, or to see
 how a particular technique you’ve read about can be applied using MNE-Python.
 
 .. note::
-    If tutorial-scripts contain plots and are run locally, using the
+    If example-scripts contain plots and are run locally, using the
     interactive interactive flag with ``python -i tutorial_script.py``
     keeps them open.
 

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -7,6 +7,11 @@ explanations seen in the tutorials, and do not follow any specific order. These
 examples are a useful way to discover new analysis or plotting ideas, or to see
 how a particular technique you’ve read about can be applied using MNE-Python.
 
+.. note::
+    If tutorial-scripts contain plots and are run locally, using the
+    interactive interactive flag with ``python -i tutorial_script.py``
+    keeps them open.
+
 .. warning::
 
    These examples sometimes use simulations or shortcuts (such as intentionally

--- a/tutorials/README.txt
+++ b/tutorials/README.txt
@@ -10,3 +10,8 @@ through in order without encountering any cases where background
 knowledge is assumed and unexplained. More experienced users (i.e., those with
 significant experience analyzing EEG/MEG signals with different software) can
 probably skip around to just the topics they need without too much trouble.
+
+.. note::
+    If tutorial-scripts contain plots and are run locally, using the
+    interactive interactive flag with ``python -i tutorial_script.py``
+    keeps them open.


### PR DESCRIPTION
#### What does this implement/fix?
This PR adds hints about how to keep plots open when running tutorial/example-scripts locally.
