### PR TITLE
API: Remove class-level verbose attribute

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -183,7 +183,7 @@ API changes
 
 - ``mne.preprocessing.annotate_flat`` has been deprecated in favor of :func`mne.preprocessing.annotate_amplitude`, that covers both minimum and maximum peak-to-peak variation. (:gh:`10143` by `Mathieu Scheltienne`_)
 
-- The ``verbose`` attribute of classes (e.g., :class:`mne.io.Raw`, `mne.io.Epochs`, etc.) has been deprecated. Explicitly pass ``verbose`` to methods as necessary instead. (:gh:`10267` by `Eric Larson`_)
+- The ``verbose`` attribute of classes (e.g., :class:`mne.io.Raw`, `mne.Epochs`, etc.) has been deprecated. Explicitly pass ``verbose`` to methods as necessary instead. (:gh:`10267` by `Eric Larson`_)
 
 Dependencies
 ~~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -183,6 +183,8 @@ API changes
 
 - ``mne.preprocessing.annotate_flat`` has been deprecated in favor of :func`mne.preprocessing.annotate_amplitude`, that covers both minimum and maximum peak-to-peak variation. (:gh:`10143` by `Mathieu Scheltienne`_)
 
+- The ``verbose`` attribute of classes (e.g., :class:`mne.io.Raw`, `mne.io.Epochs`, etc.) has been deprecated. Explicitly pass ``verbose`` to methods as necessary instead. (:gh:`10267` by `Eric Larson`_)
+
 Dependencies
 ~~~~~~~~~~~~
 Numerous external dependencies that used to be bundled with MNE-Python are now

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -230,7 +230,7 @@ numpydoc_xref_ignore = {
     # words
     'instance', 'instances', 'of', 'default', 'shape', 'or',
     'with', 'length', 'pair', 'matplotlib', 'optional', 'kwargs', 'in',
-    'dtype', 'object', 'self.verbose',
+    'dtype', 'object',
     # shapes
     'n_vertices', 'n_faces', 'n_channels', 'm', 'n', 'n_events', 'n_colors',
     'n_times', 'obj', 'n_chan', 'n_epochs', 'n_picks', 'n_ch_groups',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -512,7 +512,7 @@ for key in ('AcqParserFIF', 'BiHemiLabel', 'Dipole', 'DipoleFixed', 'Label',
             'preprocessing.ICA', 'preprocessing.Xdawn',
             'simulation.SourceSimulator',
             'time_frequency.CrossSpectralDensity',
-            'utils.deprecated',
+            'utils.deprecated', 'use_log_level',
             'viz.ClickableImage'):
     nitpick_ignore.append(('py:obj', f'mne.{key}.__hash__'))
 suppress_warnings = ['image.nonlocal_uri']  # we intentionally link outside

--- a/doc/logging.rst
+++ b/doc/logging.rst
@@ -15,6 +15,7 @@ Logging and Configuration
    set_config
    set_cache_dir
    sys_info
+   use_log_level
    verbose
 
 :py:mod:`mne.utils`:

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -21,7 +21,8 @@ from ._version import __version__
 # have to import verbose first since it's needed by many things
 from .utils import (set_log_level, set_log_file, verbose, set_config,
                     get_config, get_config_path, set_cache_dir,
-                    set_memmap_min_size, grand_average, sys_info, open_docs)
+                    set_memmap_min_size, grand_average, sys_info, open_docs,
+                    use_log_level)
 from .io.pick import (pick_types, pick_channels,
                       pick_channels_regexp, pick_channels_forward,
                       pick_types_forward, pick_channels_cov,

--- a/mne/_ola.py
+++ b/mne/_ola.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 
-from .utils import _ensure_int, verbose, logger
+from .utils import _ensure_int, verbose, logger, _VerboseDep
 
 
 ###############################################################################
@@ -218,7 +218,7 @@ def _check_store(store):
     return store
 
 
-class _COLA(object):
+class _COLA(_VerboseDep):
     r"""Constant overlap-add processing helper.
 
     Parameters
@@ -263,7 +263,7 @@ class _COLA(object):
 
     @verbose
     def __init__(self, process, store, n_total, n_samples, n_overlap,
-                 sfreq, window='hann', tol=1e-10, verbose=None):
+                 sfreq, window='hann', tol=1e-10, *, verbose=None):
         from scipy.signal import get_window
         n_samples = _ensure_int(n_samples, 'n_samples')
         n_overlap = _ensure_int(n_overlap, 'n_overlap')
@@ -310,7 +310,6 @@ class _COLA(object):
         if delta > 0:
             logger.info('    The final %0.3f sec will be lumped into the '
                         'final window' % (delta / sfreq,))
-        self.verbose = verbose
 
     @property
     def _in_offset(self):
@@ -318,7 +317,7 @@ class _COLA(object):
         return self.starts[self._idx] + self._in_buffers[0].shape[-1]
 
     @verbose
-    def feed(self, *datas, **kwargs):
+    def feed(self, *datas, verbose=None, **kwargs):
         """Pass in a chunk of data."""
         # Append to our input buffer
         if self._in_buffers is None:

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -502,7 +502,7 @@ class Annotations(object):
         emit_warning : bool
             Whether to emit warnings when limiting or omitting annotations.
             Defaults to False.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -593,7 +593,7 @@ class Annotations(object):
             seconds e.g. ``{'ShortStimulus' : 3, 'LongStimulus' : 12}``.
             Alternatively, if a number is provided, then all annotations
             durations are set to the single provided value.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -633,7 +633,7 @@ class Annotations(object):
         mapping : dict
             A dictionary mapping the old description to a new description,
             e.g. {'1.0' : 'Control', '2.0' : 'Stimulus'}.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------

--- a/mne/beamformer/resolution_matrix.py
+++ b/mne/beamformer/resolution_matrix.py
@@ -63,19 +63,6 @@ def _get_matrix_from_lcmv(filters, forward, info, max_ori_out='signed',
                           verbose=None):
     """Get inverse matrix for LCMV beamformer.
 
-    Parameters
-    ----------
-    filters : instance of Beamformer
-        LCMV spatial filter.
-    forward : instance of Forward
-        The forward solution.
-    %(info_not_none)s Used to compute the LCMV filters.
-    max_ori_out : str
-        As for beamformer.apply_lcmv(). Default 'signed'.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see mne.verbose() and
-        Logging documentation for more).
-
     Returns
     -------
     invmat : array, shape (n_dipoles, n_channels)

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -331,7 +331,7 @@ class SetChannelsMixin(MontageMixin):
         %(set_eeg_reference_projection)s
         %(set_eeg_reference_ch_type)s
         %(set_eeg_reference_forward)s
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -407,7 +407,7 @@ class SetChannelsMixin(MontageMixin):
         mapping : dict
             A dictionary mapping a channel to a sensor type (str), e.g.,
             ``{'EEG061': 'eog'}``.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -486,7 +486,7 @@ class SetChannelsMixin(MontageMixin):
         Parameters
         ----------
         %(rename_channels_mapping_duplicates)s
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -573,7 +573,7 @@ class SetChannelsMixin(MontageMixin):
         show : bool
             Show figure if True. Defaults to True.
         %(topomap_sphere_auto)s
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -751,7 +751,7 @@ class UpdateChannelsMixin(object):
             in ``info['bads']``.
         selection : list of str
             Restrict sensor channels (MEG, EEG) to this list of channel names.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -1156,7 +1156,7 @@ class InterpolationMixin(object):
         exclude : list | tuple
             The channels to exclude from interpolation. If excluded a bad
             channel will stay in bads.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -1804,14 +1804,12 @@ def combine_channels(inst, groups, method='mean', keep_stim=False,
     info = create_info(sfreq=inst.info['sfreq'], ch_names=new_ch_names,
                        ch_types=new_ch_types)
     if isinstance(inst, BaseRaw):
-        combined_inst = RawArray(new_data, info, first_samp=inst.first_samp,
-                                 verbose=inst.verbose)
+        combined_inst = RawArray(new_data, info, first_samp=inst.first_samp)
     elif isinstance(inst, BaseEpochs):
         combined_inst = EpochsArray(new_data, info, events=inst.events,
-                                    tmin=inst.times[0], verbose=inst.verbose)
+                                    tmin=inst.times[0])
     elif isinstance(inst, Evoked):
-        combined_inst = EvokedArray(new_data, info, tmin=inst.times[0],
-                                    verbose=inst.verbose)
+        combined_inst = EvokedArray(new_data, info, tmin=inst.times[0])
 
     return combined_inst
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -36,7 +36,7 @@ from .utils import (check_fname, logger, verbose, check_version, _time_mask,
                     warn, copy_function_doc_to_method_doc, _pl,
                     _undo_scaling_cov, _scaled_array, _validate_type,
                     _check_option, eigh, fill_doc, _on_missing,
-                    _check_on_missing, _check_fname)
+                    _check_on_missing, _check_fname, _VerboseDep)
 from . import viz
 
 from .fixes import (BaseEstimator, EmpiricalCovariance, _logdet,
@@ -64,7 +64,7 @@ def _get_tslice(epochs, tmin, tmax):
 
 
 @fill_doc
-class Covariance(dict):
+class Covariance(dict, _VerboseDep):
     """Noise covariance matrix.
 
     .. warning:: This class should not be instantiated directly, but
@@ -91,7 +91,7 @@ class Covariance(dict):
         The method used to compute the covariance.
     loglik : float
         The log likelihood.
-    %(verbose_meth)s
+    %(verbose)s
 
     Attributes
     ----------
@@ -112,8 +112,9 @@ class Covariance(dict):
     read_cov
     """
 
+    @verbose
     def __init__(self, data, names, bads, projs, nfree, eig=None, eigvec=None,
-                 method=None, loglik=None, verbose=None):
+                 method=None, loglik=None, *, verbose=None):
         """Init of covariance."""
         diag = (data.ndim == 1)
         projs = _check_projs(projs)
@@ -124,7 +125,6 @@ class Covariance(dict):
             self['method'] = method
         if loglik is not None:
             self['loglik'] = loglik
-        self.verbose = verbose
 
     @property
     def data(self):

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -11,11 +11,11 @@ import numpy as np
 from .base import get_coef, BaseEstimator, _check_estimator
 from .time_delaying_ridge import TimeDelayingRidge
 from ..fixes import is_regressor
-from ..utils import _validate_type, verbose, fill_doc
+from ..utils import _validate_type, verbose, fill_doc, _VerboseDep
 
 
 @fill_doc
-class ReceptiveField(BaseEstimator):
+class ReceptiveField(BaseEstimator, _VerboseDep):
     """Fit a receptive field model.
 
     This allows you to fit an encoding model (stimulus to brain) or a decoding
@@ -117,7 +117,6 @@ class ReceptiveField(BaseEstimator):
         self.patterns = patterns
         self.n_jobs = n_jobs
         self.edge_correction = edge_correction
-        self.verbose = verbose
 
     def __repr__(self):  # noqa: D105
         s = "tmin, tmax : (%.3f, %.3f), " % (self.tmin, self.tmax)
@@ -151,7 +150,6 @@ class ReceptiveField(BaseEstimator):
                 y = y.reshape(-1, y.shape[-1], order='F')
         return X, y
 
-    @verbose
     def fit(self, X, y):
         """Fit a receptive field model.
 

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -9,11 +9,11 @@ from .base import BaseEstimator, _check_estimator
 from ..fixes import _get_check_scoring
 from ..parallel import parallel_func
 from ..utils import (_validate_type, array_split_idx, ProgressBar,
-                     verbose, fill_doc)
+                     verbose, fill_doc, _VerboseDep)
 
 
 @fill_doc
-class SlidingEstimator(BaseEstimator, TransformerMixin):
+class SlidingEstimator(BaseEstimator, TransformerMixin, _VerboseDep):
     """Search Light.
 
     Fit, predict and score a series of models to each subset of the dataset
@@ -33,14 +33,14 @@ class SlidingEstimator(BaseEstimator, TransformerMixin):
         List of fitted scikit-learn estimators (one per task).
     """
 
-    def __init__(self, base_estimator, scoring=None, n_jobs=1,
+    @verbose
+    def __init__(self, base_estimator, scoring=None, n_jobs=1, *,
                  verbose=None):  # noqa: D102
         _check_estimator(base_estimator)
         self._estimator_type = getattr(base_estimator, "_estimator_type", None)
         self.base_estimator = base_estimator
         self.n_jobs = n_jobs
         self.scoring = scoring
-        self.verbose = verbose
 
         _validate_type(self.n_jobs, 'int', 'n_jobs')
 
@@ -51,7 +51,6 @@ class SlidingEstimator(BaseEstimator, TransformerMixin):
             repr_str += ', fitted with %i estimators' % len(self.estimators_)
         return repr_str + '>'
 
-    @verbose  # to use class value
     def fit(self, X, y, **fit_params):
         """Fit a series of independent estimators to the dataset.
 
@@ -120,7 +119,6 @@ class SlidingEstimator(BaseEstimator, TransformerMixin):
         """  # noqa: E501
         return self.fit(X, y, **fit_params).transform(X)
 
-    @verbose  # to use the class value
     def _transform(self, X, method):
         """Aux. function to make parallel predictions/transformation."""
         self._check_Xy(X)
@@ -431,7 +429,6 @@ class GeneralizingEstimator(SlidingEstimator):
             repr_str += ', fitted with %i estimators>' % len(self.estimators_)
         return repr_str
 
-    @verbose  # use class value
     def _transform(self, X, method):
         """Aux. function to make parallel predictions/transformation."""
         self._check_Xy(X)
@@ -531,7 +528,6 @@ class GeneralizingEstimator(SlidingEstimator):
         """  # noqa: E501
         return self._transform(X, 'decision_function')
 
-    @verbose  # to use class value
     def score(self, X, y):
         """Score each of the estimators on the tested dimensions.
 

--- a/mne/decoding/time_frequency.py
+++ b/mne/decoding/time_frequency.py
@@ -6,11 +6,11 @@ import numpy as np
 from .mixin import TransformerMixin
 from .base import BaseEstimator
 from ..time_frequency.tfr import _compute_tfr, _check_tfr_param
-from ..utils import fill_doc, _check_option
+from ..utils import fill_doc, _check_option, verbose, _VerboseDep
 
 
 @fill_doc
-class TimeFrequency(TransformerMixin, BaseEstimator):
+class TimeFrequency(TransformerMixin, BaseEstimator, _VerboseDep):
     """Time frequency transformer.
 
     Time-frequency transform of times series along the last axis.
@@ -59,10 +59,10 @@ class TimeFrequency(TransformerMixin, BaseEstimator):
     mne.time_frequency.tfr_multitaper
     """
 
+    @verbose
     def __init__(self, freqs, sfreq=1.0, method='morlet', n_cycles=7.0,
                  time_bandwidth=None, use_fft=True, decim=1, output='complex',
-                 n_jobs=1, verbose=None):  # noqa: D102
-        """Init TimeFrequency transformer."""
+                 n_jobs=1, *, verbose=None):  # noqa: D102
         freqs, sfreq, _, n_cycles, time_bandwidth, decim = \
             _check_tfr_param(freqs, sfreq, method, True, n_cycles,
                              time_bandwidth, use_fft, decim, output)
@@ -77,7 +77,6 @@ class TimeFrequency(TransformerMixin, BaseEstimator):
         self.output = _check_option('output', output,
                                     ['complex', 'power', 'phase'])
         self.n_jobs = n_jobs
-        self.verbose = verbose
 
     def fit_transform(self, X, y=None):
         """Time-frequency transform of times series along the last axis.
@@ -138,8 +137,7 @@ class TimeFrequency(TransformerMixin, BaseEstimator):
         # Compute time-frequency
         Xt = _compute_tfr(X, self.freqs, self.sfreq, self.method,
                           self.n_cycles, True, self.time_bandwidth,
-                          self.use_fft, self.decim, self.output, self.n_jobs,
-                          self.verbose)
+                          self.use_fft, self.decim, self.output, self.n_jobs)
 
         # Back to original shape
         if not shape:

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -13,7 +13,8 @@ from .base import BaseEstimator
 from .. import pick_types
 from ..filter import filter_data, _triage_filter_params
 from ..time_frequency.psd import psd_array_multitaper
-from ..utils import fill_doc, _check_option, _validate_type
+from ..utils import (fill_doc, _check_option, _validate_type, verbose,
+                     _VerboseDep)
 from ..io.pick import (pick_info, _pick_data_channels, _picks_by_type,
                        _picks_to_idx)
 from ..cov import _check_scalings_user
@@ -329,7 +330,7 @@ class Vectorizer(TransformerMixin):
 
 
 @fill_doc
-class PSDEstimator(TransformerMixin):
+class PSDEstimator(TransformerMixin, _VerboseDep):
     """Compute power spectral density (PSD) using a multi-taper method.
 
     Parameters
@@ -358,9 +359,10 @@ class PSDEstimator(TransformerMixin):
     mne.time_frequency.psd_multitaper
     """
 
+    @verbose
     def __init__(self, sfreq=2 * np.pi, fmin=0, fmax=np.inf, bandwidth=None,
                  adaptive=False, low_bias=True, n_jobs=1,
-                 normalization='length', verbose=None):  # noqa: D102
+                 normalization='length', *, verbose=None):  # noqa: D102
         self.sfreq = sfreq
         self.fmin = fmin
         self.fmax = fmax
@@ -368,7 +370,6 @@ class PSDEstimator(TransformerMixin):
         self.adaptive = adaptive
         self.low_bias = low_bias
         self.n_jobs = n_jobs
-        self.verbose = verbose
         self.normalization = normalization
 
     def fit(self, epochs_data, y):
@@ -417,7 +418,7 @@ class PSDEstimator(TransformerMixin):
 
 
 @fill_doc
-class FilterEstimator(TransformerMixin):
+class FilterEstimator(TransformerMixin, _VerboseDep):
     """Estimator to filter RtEpochs.
 
     Applies a zero-phase low-pass, high-pass, band-pass, or band-stop
@@ -470,7 +471,7 @@ class FilterEstimator(TransformerMixin):
 
     def __init__(self, info, l_freq, h_freq, picks=None, filter_length='auto',
                  l_trans_bandwidth='auto', h_trans_bandwidth='auto', n_jobs=1,
-                 method='fir', iir_params=None, fir_design='firwin',
+                 method='fir', iir_params=None, fir_design='firwin', *,
                  verbose=None):  # noqa: D102
         self.info = info
         self.l_freq = l_freq
@@ -766,11 +767,12 @@ class TemporalFilter(TransformerMixin):
     mne.filter.filter_data
     """
 
+    @verbose
     def __init__(self, l_freq=None, h_freq=None, sfreq=1.0,
                  filter_length='auto', l_trans_bandwidth='auto',
                  h_trans_bandwidth='auto', n_jobs=1, method='fir',
                  iir_params=None, fir_window='hamming', fir_design='firwin',
-                 verbose=None):  # noqa: D102
+                 *, verbose=None):  # noqa: D102
         self.l_freq = l_freq
         self.h_freq = h_freq
         self.sfreq = sfreq
@@ -782,7 +784,6 @@ class TemporalFilter(TransformerMixin):
         self.iir_params = iir_params
         self.fir_window = fir_window
         self.fir_design = fir_design
-        self.verbose = verbose
 
         if not isinstance(self.n_jobs, int) and self.n_jobs == 'cuda':
             raise ValueError('n_jobs must be int or "cuda", got %s instead.'
@@ -843,6 +844,5 @@ class TemporalFilter(TransformerMixin):
                         h_trans_bandwidth=self.h_trans_bandwidth,
                         n_jobs=self.n_jobs, method=self.method,
                         iir_params=self.iir_params, copy=False,
-                        fir_window=self.fir_window, fir_design=self.fir_design,
-                        verbose=self.verbose)
+                        fir_window=self.fir_window, fir_design=self.fir_design)
         return X.reshape(shape)

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -36,11 +36,12 @@ from .source_space import _make_volume_source_space, SourceSpaces
 from .parallel import parallel_func
 from .utils import (logger, verbose, _time_mask, warn, _check_fname,
                     check_fname, _pl, fill_doc, _check_option, ShiftTimeMixin,
-                    _svd_lwork, _repeated_svd, _get_blas_funcs, _validate_type)
+                    _svd_lwork, _repeated_svd, _get_blas_funcs, _validate_type,
+                    _VerboseDep)
 
 
 @fill_doc
-class Dipole(object):
+class Dipole(_VerboseDep):
     u"""Dipole class for sequential dipole fits.
 
     .. note:: This class should usually not be instantiated directly,
@@ -99,7 +100,7 @@ class Dipole(object):
     @verbose
     def __init__(self, times, pos, amplitude, ori, gof,
                  name=None, conf=None, khi2=None, nfree=None,
-                 verbose=None):  # noqa: D102
+                 *, verbose=None):  # noqa: D102
         self.times = np.array(times)
         self.pos = np.array(pos)
         self.amplitude = np.array(amplitude)
@@ -112,7 +113,6 @@ class Dipole(object):
                 self.conf[key] = np.array(value)
         self.khi2 = np.array(khi2) if khi2 is not None else None
         self.nfree = np.array(nfree) if nfree is not None else None
-        self.verbose = verbose
 
     def __repr__(self):  # noqa: D105
         s = "n_times : %s" % len(self.times)
@@ -131,7 +131,7 @@ class Dipole(object):
         %(overwrite)s
 
             .. versionadded:: 0.20
-        %(verbose_meth)s
+        %(verbose)s
 
         Notes
         -----
@@ -249,7 +249,7 @@ class Dipole(object):
             background.
 
             .. versionadded:: 0.14.0
-        %(verbose_meth)s
+        %(verbose)s
         %(dipole_locs_fig_title)s
 
             .. versionadded:: 0.21.0
@@ -428,7 +428,7 @@ def _read_dipole_fixed(fname):
 
 
 @fill_doc
-class DipoleFixed(ShiftTimeMixin):
+class DipoleFixed(ShiftTimeMixin, _VerboseDep):
     """Dipole class for fixed-position dipole fits.
 
     .. note:: This class should usually not be instantiated directly,
@@ -466,7 +466,7 @@ class DipoleFixed(ShiftTimeMixin):
 
     @verbose
     def __init__(self, info, data, times, nave, aspect_kind,
-                 comment='', verbose=None):  # noqa: D102
+                 comment='', *, verbose=None):  # noqa: D102
         self.info = info
         self.nave = nave
         self._aspect_kind = aspect_kind
@@ -474,7 +474,6 @@ class DipoleFixed(ShiftTimeMixin):
         self.comment = comment
         self.times = times
         self.data = data
-        self.verbose = verbose
         self.preload = True
         self._update_first_last()
 
@@ -513,7 +512,7 @@ class DipoleFixed(ShiftTimeMixin):
             The name of the .fif file. Must end with ``'.fif'`` or
             ``'.fif.gz'`` to make it explicit that the file contains
             dipole information in FIF format.
-        %(verbose_meth)s
+        %(verbose)s
         """
         check_fname(fname, 'DipoleFixed', ('-dip.fif', '-dip.fif.gz',
                                            '_dip.fif', '_dip.fif.gz',),

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -22,7 +22,7 @@ from .utils import (check_fname, logger, verbose, _time_mask, warn, sizeof_fmt,
                     fill_doc, _check_option, ShiftTimeMixin, _build_data_frame,
                     _check_pandas_installed, _check_pandas_index_arguments,
                     _convert_times, _scale_dataframe_data, _check_time_format,
-                    _check_preload, _check_fname)
+                    _check_preload, _check_fname, _VerboseDep)
 from .viz import (plot_evoked, plot_evoked_topomap, plot_evoked_field,
                   plot_evoked_image, plot_evoked_topo)
 from .viz.evoked import plot_evoked_white, plot_evoked_joint
@@ -62,7 +62,7 @@ _aspect_rev = {val: key for key, val in _aspect_dict.items()}
 @fill_doc
 class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
              InterpolationMixin, FilterMixin, TimeMixin, SizeMixin,
-             ShiftTimeMixin):
+             ShiftTimeMixin, _VerboseDep):
     """Evoked data.
 
     Parameters
@@ -114,7 +114,6 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
     baseline : None | tuple of length 2
          This attribute reflects whether the data has been baseline-corrected
          (it will be a ``tuple`` then) or not (it will be ``None``).
-    %(verbose)s
 
     Notes
     -----
@@ -123,7 +122,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
     @verbose
     def __init__(self, fname, condition=None, proj=True,
-                 kind='average', allow_maxshield=False,
+                 kind='average', allow_maxshield=False, *,
                  verbose=None):  # noqa: D102
         _validate_type(proj, bool, "'proj'")
         # Read the requested data
@@ -132,7 +131,6 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             self.data, self.baseline = _read_evoked(fname, condition, kind,
                                                     allow_maxshield)
         self._update_first_last()
-        self.verbose = verbose
         self.preload = True
         # project and baseline correct
         if proj:
@@ -206,7 +204,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(picks_all_data_noref)s
         %(applyfun_dtype)s
         %(n_jobs)s
-        %(verbose_meth)s
+        %(verbose)s
         %(kwarg_fun)s
 
         Returns
@@ -250,7 +248,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(baseline_evoked)s
             Defaults to ``(None, 0)``, i.e. beginning of the the data until
             time point zero.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -355,7 +353,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         tmax : float | None
             End time of selection in seconds.
         %(include_tmax)s
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -397,7 +395,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         ----------
         %(decim)s
         %(decim_offset)s
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -566,7 +564,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(topomap_extrapolate)s
 
             .. versionadded:: 0.22
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -895,7 +893,7 @@ class EvokedArray(Evoked):
 
     @verbose
     def __init__(self, data, info, tmin=0., comment='', nave=1, kind='average',
-                 baseline=None, verbose=None):  # noqa: D102
+                 baseline=None, *, verbose=None):  # noqa: D102
         dtype = np.complex128 if np.iscomplexobj(data) else np.float64
         data = np.asanyarray(data, dtype=dtype)
 
@@ -919,7 +917,6 @@ class EvokedArray(Evoked):
         self.kind = kind
         self.comment = comment
         self.picks = None
-        self.verbose = verbose
         self.preload = True
         self._projector = None
         _validate_type(self.kind, "str", "kind")
@@ -930,7 +927,7 @@ class EvokedArray(Evoked):
 
         self.baseline = baseline
         if self.baseline is not None:  # omit log msg if not baselining
-            self.apply_baseline(self.baseline, verbose=self.verbose)
+            self.apply_baseline(self.baseline)
 
 
 def _get_entries(fid, evoked_node, allow_maxshield=False):

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -1877,7 +1877,7 @@ class FilterMixin(object):
             instead of FIR/IIR filtering. This parameter is thus used to
             determine the length of the window over which a 5th-order
             polynomial smoothing is used.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -1958,7 +1958,7 @@ class FilterMixin(object):
 
             .. versionadded:: 0.16.
         %(pad-fir)s
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -2057,7 +2057,7 @@ class FilterMixin(object):
             vector.
 
             .. versionadded:: 0.15
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -2118,7 +2118,7 @@ class FilterMixin(object):
             will be padded with zeros before computing Hilbert, then cut back
             to original length. If None, n == self.n_times. If 'auto',
             the next highest fast FFT length will be use.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -47,7 +47,7 @@ from ..utils import (_check_fname, _check_pandas_installed, sizeof_fmt,
                      copy_function_doc_to_method_doc, _validate_type,
                      _check_preload, _get_argvalues, _check_option,
                      _build_data_frame, _convert_times, _scale_dataframe_data,
-                     _check_time_format, _arange_div)
+                     _check_time_format, _arange_div, _VerboseDep)
 from ..defaults import _handle_default
 from ..viz import plot_raw, plot_raw_psd, plot_raw_psd_topo, _RAW_CLIP_DEF
 from ..event import find_events, concatenate_events
@@ -121,7 +121,8 @@ class TimeMixin(object):
 
 @fill_doc
 class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
-              InterpolationMixin, TimeMixin, SizeMixin, FilterMixin):
+              InterpolationMixin, TimeMixin, SizeMixin, FilterMixin,
+              _VerboseDep):
     """Base class for Raw data.
 
     Parameters
@@ -187,7 +188,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                  filenames=(None,), raw_extras=(None,),
                  orig_format='double', dtype=np.float64,
                  buffer_size_sec=1., orig_units=None,
-                 verbose=None):  # noqa: D102
+                 *, verbose=None):  # noqa: D102
         # wait until the end to preload data, but triage here
         if isinstance(preload, np.ndarray):
             # some functions (e.g., filtering) only work w/64-bit data
@@ -226,7 +227,6 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         if len(bad) > 0:
             raise ValueError('Bad cals for channels %s'
                              % {ii: self.ch_names[ii] for ii in bad})
-        self.verbose = verbose
         self._cals = cals
         self._raw_extras = list(dict() if r is None else r for r in raw_extras)
         for r in self._raw_extras:
@@ -303,7 +303,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         ----------
         grade : int
             CTF gradient compensation level.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -361,7 +361,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             to store the data.
         projector : array
             SSP operator to apply to the data.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -539,7 +539,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         Parameters
         ----------
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -663,7 +663,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         emit_warning : bool
             Whether to emit warnings when cropping or omitting annotations.
         %(on_missing_ch_names)s
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -864,7 +864,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             ignored if the ``stop`` parameter is defined.
 
             .. versionadded:: 0.24.0
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -990,7 +990,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(applyfun_chwise)s
 
             .. versionadded:: 0.18
-        %(verbose_meth)s
+        %(verbose)s
         %(kwarg_fun)s
 
         Returns
@@ -1081,7 +1081,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             The default is ``'reflect_limited'``.
 
             .. versionadded:: 0.15
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -1166,7 +1166,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             The default is ``'reflect_limited'``.
 
             .. versionadded:: 0.15
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -1409,7 +1409,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(split_naming)s
 
             .. versionadded:: 0.17
-        %(verbose_meth)s
+        %(verbose)s
 
         Notes
         -----

--- a/mne/io/curry/tests/test_curry.py
+++ b/mne/io/curry/tests/test_curry.py
@@ -87,12 +87,12 @@ def test_read_raw_curry(fname, tol, preload, bdf_curry_ref):
         assert_array_equal([ch[field] for ch in raw.info['chs']],
                            [ch[field] for ch in bdf_curry_ref.info['chs']])
 
-    raw.verbose = 'error'  # don't emit warnings about slow reading
-    assert_allclose(raw.get_data(), bdf_curry_ref.get_data(), atol=tol)
+    assert_allclose(raw.get_data(verbose='error'),
+                    bdf_curry_ref.get_data(), atol=tol)
 
     picks, start, stop = ["C3", "C4"], 200, 800
     assert_allclose(
-        raw.get_data(picks=picks, start=start, stop=stop),
+        raw.get_data(picks=picks, start=start, stop=stop, verbose='error'),
         bdf_curry_ref.get_data(picks=picks, start=start, stop=stop),
         rtol=tol)
     assert raw.info['dev_head_t'] is None

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -314,7 +314,6 @@ class Raw(BaseRaw):
                     float(raw.last_samp) / info['sfreq']))
 
         raw.info = info
-        raw.verbose = verbose
 
         logger.info('Ready.')
 

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -159,7 +159,7 @@ class MontageMixin(object):
         %(match_case)s
         %(match_alias)s
         %(on_missing_montage)s
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -120,7 +120,7 @@ class ProjMixin(object):
             List with projection vectors.
         remove_existing : bool
             Remove the projection vectors currently in the file.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -136,7 +136,7 @@ class ProjMixin(object):
                              'something else.')
 
         # mark proj as inactive, as they have not been applied
-        projs = deactivate_proj(projs, copy=True, verbose=self.verbose)
+        projs = deactivate_proj(projs, copy=True)
         if remove_existing:
             # we cannot remove the proj if they are active
             if any(p['active'] for p in self.info['projs']):
@@ -159,7 +159,7 @@ class ProjMixin(object):
 
         Parameters
         ----------
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -205,7 +205,7 @@ class ProjMixin(object):
             return self
 
         _projector, info = setup_proj(deepcopy(self.info), add_eeg_ref=False,
-                                      activate=True, verbose=self.verbose)
+                                      activate=True)
         # let's not raise a RuntimeError here, otherwise interactive plotting
         if _projector is None:  # won't be fun.
             logger.info('The projections don\'t apply to these data.'

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1354,7 +1354,7 @@ def apply_inverse_cov(cov, info, inverse_operator, nave=1, lambda2=1 / 9,
     # Reshape back to (n_src, ..., 1)
     sol.shape = stc.data.shape[:-1] + (1,)
     stc = stc.__class__(
-        sol, stc.vertices, stc.tmin, stc.tstep, stc.subject, stc.verbose)
+        sol, stc.vertices, stc.tmin, stc.tstep, stc.subject)
     if combine:  # combine the three directions
         logger.info('    Combining the current components...')
         np.sqrt(stc.data, out=stc.data)

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -22,7 +22,7 @@ from .utils import (logger, verbose, check_version, get_subjects_dir,
                     warn as warn_, fill_doc, _check_option, _validate_type,
                     BunchConst, _check_fname, warn, _custom_lru_cache,
                     _ensure_int, ProgressBar, use_log_level,
-                    _import_h5io_funcs)
+                    _import_h5io_funcs, _VerboseDep)
 
 
 @verbose
@@ -293,11 +293,11 @@ _SOURCE_MORPH_ATTRIBUTES = [  # used in writing
     'subject_from', 'subject_to', 'kind', 'zooms', 'niter_affine', 'niter_sdr',
     'spacing', 'smooth', 'xhemi', 'morph_mat', 'vertices_to',
     'shape', 'affine', 'pre_affine', 'sdr_morph', 'src_data',
-    'vol_morph_mat', 'verbose']
+    'vol_morph_mat']
 
 
 @fill_doc
-class SourceMorph(object):
+class SourceMorph(_VerboseDep):
     """Morph source space data from one subject to another.
 
     .. note:: This class should not be instantiated directly.
@@ -361,11 +361,12 @@ class SourceMorph(object):
     .. footbibliography::
     """
 
+    @verbose
     def __init__(self, subject_from, subject_to, kind, zooms,
                  niter_affine, niter_sdr, spacing, smooth, xhemi,
                  morph_mat, vertices_to, shape,
                  affine, pre_affine, sdr_morph, src_data,
-                 vol_morph_mat, verbose=None):
+                 vol_morph_mat, *, verbose=None):
         # universal
         self.subject_from = subject_from
         self.subject_to = subject_to
@@ -388,7 +389,6 @@ class SourceMorph(object):
         # used by both
         self.src_data = src_data
         self.vol_morph_mat = vol_morph_mat
-        self.verbose = verbose
         # compute vertices_to here (partly for backward compat and no src
         # provided)
         if vertices_to is None or len(vertices_to) == 0 and kind == 'volume':
@@ -433,7 +433,7 @@ class SourceMorph(object):
         mri_space : bool | None
             Whether the image to world registration should be in mri space. The
             default (None) is mri_space=mri_resolution.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -474,7 +474,7 @@ class SourceMorph(object):
 
         Parameters
         ----------
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -647,7 +647,7 @@ class SourceMorph(object):
             The stem of the file name. '-morph.h5' will be added if fname does
             not end with '.h5'.
         %(overwrite)s
-        %(verbose_meth)s
+        %(verbose)s
         """
         _, write_hdf5 = _import_h5io_funcs()
         fname = _check_fname(fname, overwrite=overwrite, must_exist=False)

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -54,7 +54,7 @@ from ..utils import (logger, check_fname, _check_fname, verbose,
                      copy_function_doc_to_method_doc, _pl, warn, Bunch,
                      _check_preload, _check_compensation_grade, fill_doc,
                      _check_option, _PCA, int_like, _require_version,
-                     _check_all_same_channel_names)
+                     _check_all_same_channel_names, _VerboseDep)
 
 from ..fixes import _get_args, _safe_svd
 from ..filter import filter_data
@@ -136,7 +136,7 @@ _KNOWN_ICA_METHODS = ('fastica', 'infomax', 'picard')
 
 
 @fill_doc
-class ICA(ContainsMixin):
+class ICA(ContainsMixin, _VerboseDep):
     u"""Data decomposition using Independent Component Analysis (ICA).
 
     This object estimates independent components from :class:`mne.io.Raw`,
@@ -396,7 +396,6 @@ class ICA(ContainsMixin):
                     'supported')
 
         self.current_fit = 'unfitted'
-        self.verbose = verbose
         self.n_components = n_components
         # In newer ICAs this should always be None, but keep it for
         # backward compat with older versions of MNE that used it
@@ -590,7 +589,7 @@ class ICA(ContainsMixin):
         %(reject_by_annotation_raw)s
 
             .. versionadded:: 0.14.0
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -1133,7 +1132,7 @@ class ICA(ContainsMixin):
         %(reject_by_annotation_all)s
 
             .. versionadded:: 0.14.0
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -1330,7 +1329,7 @@ class ICA(ContainsMixin):
 
             .. versionadded:: 0.14.0
         %(measure)s
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -1466,7 +1465,7 @@ class ICA(ContainsMixin):
 
             .. versionadded:: 0.21
         %(measure)s
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -1616,7 +1615,7 @@ class ICA(ContainsMixin):
 
             .. versionadded:: 0.14.0
         %(measure)s
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -1682,7 +1681,7 @@ class ICA(ContainsMixin):
         stop : int | float | None
             Last sample to not include. If float, data will be interpreted as
             time in seconds. If None, data will be used to the last sample.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -1882,7 +1881,7 @@ class ICA(ContainsMixin):
         %(overwrite)s
 
             .. versionadded:: 1.0
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -2913,7 +2913,7 @@ class Report(_VerboseDep):
                      f'create joint plot')
                 continue
 
-            with use_log_level(level=False):
+            with use_log_level(False):
                 fig = evoked.copy().pick(ch_type, verbose=False).plot_joint(
                     ts_args=dict(gfp=True),
                     title=None,

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -3387,7 +3387,7 @@ class Report(_VerboseDep):
         epochs.load_data()
 
         for ch_type in ch_types:
-            with use_log_level(level=False):
+            with use_log_level(False):
                 figs = epochs.copy().pick(ch_type, verbose=False).plot_image(
                     show=False
                 )

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -40,7 +40,7 @@ from ..proj import read_proj
 from .._freesurfer import _reorient_image, _mri_orientation
 from ..utils import (logger, verbose, get_subjects_dir, warn, _ensure_int,
                      fill_doc, _check_option, _validate_type, _safe_input,
-                     _path_like, use_log_level, _check_fname,
+                     _path_like, use_log_level, _check_fname, _VerboseDep,
                      _check_ch_locs, _import_h5io_funcs)
 from ..viz import (plot_events, plot_alignment, plot_cov, plot_projs_topomap,
                    plot_compare_evokeds, set_3d_view, get_3d_backend)
@@ -626,7 +626,7 @@ def _check_image_format(rep, image_format):
 
 
 @fill_doc
-class Report(object):
+class Report(_VerboseDep):
     r"""Object for rendering HTML.
 
     Parameters
@@ -710,9 +710,11 @@ class Report(object):
     .. versionadded:: 0.8.0
     """
 
+    @verbose
     def __init__(self, info_fname=None, subjects_dir=None,
                  subject=None, title=None, cov_fname=None, baseline=None,
-                 image_format='png', raw_psd=False, projs=False, verbose=None):
+                 image_format='png', raw_psd=False, projs=False, *,
+                 verbose=None):
         self.info_fname = str(info_fname) if info_fname is not None else None
         self.cov_fname = str(cov_fname) if cov_fname is not None else None
         self.baseline = baseline
@@ -723,7 +725,6 @@ class Report(object):
         self.title = title
         self.image_format = _check_image_format(None, image_format)
         self.projs = projs
-        self.verbose = verbose
 
         self._dom_id = 0
         self._content = []
@@ -772,7 +773,7 @@ class Report(object):
         return (
             'baseline', 'cov_fname', 'include', '_content', 'image_format',
             'info_fname', '_dom_id', 'raw_psd', 'projs',
-            'subjects_dir', 'subject', 'title', 'data_path', 'lang', 'verbose',
+            'subjects_dir', 'subject', 'title', 'data_path', 'lang',
             'fname'
         )
 
@@ -2336,7 +2337,7 @@ class Report(object):
         %(topomap_kwargs)s
 
             .. versionadded:: 0.24.0
-        %(verbose_meth)s
+        %(verbose)s
         """
         _validate_type(data_path, 'path-like', 'data_path')
         data_path = str(data_path)
@@ -2504,7 +2505,7 @@ class Report(object):
             -> bem -> forward-solution -> inverse-operator -> source-estimate.
 
             .. versionadded:: 0.24.0
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -243,7 +243,6 @@ def simulate_raw(info, stc=None, trans=None, src=None, bem=None, head_pos=None,
     .. footbibliography::
     """  # noqa: E501
     _validate_type(info, Info, 'info')
-    raw_verbose = verbose
 
     if len(pick_types(info, meg=False, stim=True)) == 0:
         event_ch = None
@@ -331,8 +330,7 @@ def simulate_raw(info, stc=None, trans=None, src=None, bem=None, head_pos=None,
     raw_data = np.concatenate(raw_datas, axis=-1)
     raw = RawArray(raw_data, info, first_samp=first_samp, verbose=False)
     raw.set_annotations(raw.annotations)
-    raw.verbose = raw_verbose
-    logger.info('Done')
+    logger.info('[done]')
     return raw
 
 

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -136,7 +136,7 @@ class SourceSpaces(list):
             produced during coregistration. If trans is None, an identity
             matrix is assumed. This is only needed when the source space is in
             head coordinates.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -277,7 +277,7 @@ class SourceSpaces(list):
         fname : str
             File to write.
         %(overwrite)s
-        %(verbose_meth)s
+        %(verbose)s
         """
         write_source_spaces(fname, self, overwrite=overwrite)
 
@@ -323,7 +323,7 @@ class SourceSpaces(list):
         %(overwrite)s
 
             .. versionadded:: 0.19
-        %(verbose_meth)s
+        %(verbose)s
 
         Notes
         -----

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -67,7 +67,7 @@ def _real_vec_stc():
 
 def test_sourcemorph_consistency():
     """Test SourceMorph class consistency."""
-    assert _get_args(SourceMorph.__init__)[1:] == \
+    assert _get_args(SourceMorph.__init__)[1:-1] == \
         mne.morph._SOURCE_MORPH_ATTRIBUTES
 
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -990,7 +990,7 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin):
             - dividing by the mean of baseline values, taking the log, and
               dividing by the standard deviation of log baseline values
               ('zlogratio')
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -1297,7 +1297,7 @@ class AverageTFR(_BaseTFR):
             :func:`mne.viz.plot_topomap` for more details.
 
             .. versionadded:: 0.24
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------
@@ -1489,7 +1489,7 @@ class AverageTFR(_BaseTFR):
             to style the image. ``axes`` and ``show`` are ignored. Beyond that,
             if ``None``, no customizable arguments will be passed.
             Defaults to ``None``.
-        %(verbose_meth)s
+        %(verbose)s
 
         Returns
         -------

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -34,7 +34,7 @@ from .fetching import _url_to_local_path
 from ._logging import (verbose, logger, set_log_level, set_log_file,
                        use_log_level, catch_logging, warn, filter_out_warnings,
                        wrapped_stdout, _get_call_line, _record_warnings,
-                       ClosingStringIO)
+                       ClosingStringIO, _VerboseDep)
 from .misc import (run_subprocess, _pl, _clean_names, pformat, _file_like,
                    _explain_exception, _get_argvalues, sizeof_fmt,
                    running_subprocess, _DefaultEventParser,

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -124,18 +124,41 @@ def %(name)s(%(signature)s):\n
     return fm.make(body, evaldict, addsource=True, **attrs)
 
 
-class use_log_level(object):
-    """Context handler for logging level.
+class use_log_level:
+    """Context manager for logging level.
 
     Parameters
     ----------
     level : int
         The level to use.
     add_frames : int | None
-        Number of stack frames to include.
+        Number of stack frames to include in logging. This is useful
+        for developers.
+
+    See Also
+    --------
+    mne.verbose
+
+    Notes
+    -----
+    See the :ref:`logging documentation <tut-logging>` for details.
+
+    Examples
+    --------
+    >>> from mne import use_log_level
+    >>> from mne.utils import logger
+    >>> with use_log_level(False):
+    ...     # Most MNE logger messages are "info" level, False makes them not
+    ...     # print:
+    ...     logger.info('This message will not be printed')
+    >>> with use_log_level(True):
+    ...     # Using verbose=True in functions, methods, or this context manager
+    ...     # will ensure they are printed
+    ...     logger.info('This message will be printed!')
+    This message will be printed!
     """
 
-    def __init__(self, level, add_frames=None):  # noqa: D102
+    def __init__(self, level, *, add_frames=None):  # noqa: D102
         self.level = level
         self.add_frames = add_frames
         self.old_frames = _filter.add_frames
@@ -469,6 +492,7 @@ class _VerboseDep:
     @verbose.setter
     def verbose(self, v):
         warn('The verbose class attribute has been deprecated in 1.0 and will '
-             'be removed in 1.1, the value {v} will be ignored. Pass verbose '
-             'to methods as required to change log levels instead',
-             DeprecationWarning)
+             f'be removed in 1.1, the value {repr(v)} will be ignored. Pass '
+             'verbose to methods as required or use the '
+             'mne.utils.use_log_level context manager to change log levels '
+             'instead', DeprecationWarning)

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -170,6 +170,7 @@ class use_log_level:
         set_log_level(self._old_level, add_frames=add_frames)
 
 
+@fill_doc
 def set_log_level(verbose=None, return_old_level=False, add_frames=None):
     """Set the logging level.
 

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -157,16 +157,17 @@ class use_log_level:
     """
 
     def __init__(self, verbose, *, add_frames=None):  # noqa: D102
-        self.level = level
-        self.add_frames = add_frames
-        self.old_frames = _filter.add_frames
+        self._level = verbose
+        self._add_frames = add_frames
+        self._old_frames = _filter.add_frames
 
     def __enter__(self):  # noqa: D105
-        self.old_level = set_log_level(self.level, True, self.add_frames)
+        self._old_level = set_log_level(
+            self._level, return_old_level=True, add_frames=self._add_frames)
 
     def __exit__(self, *args):  # noqa: D105
-        add_frames = self.old_frames if self.add_frames is not None else None
-        set_log_level(self.old_level, add_frames=add_frames)
+        add_frames = self._old_frames if self._add_frames is not None else None
+        set_log_level(self._old_level, add_frames=add_frames)
 
 
 def set_log_level(verbose=None, return_old_level=False, add_frames=None):

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -124,13 +124,13 @@ def %(name)s(%(signature)s):\n
     return fm.make(body, evaldict, addsource=True, **attrs)
 
 
+@fill_doc
 class use_log_level:
     """Context manager for logging level.
 
     Parameters
     ----------
-    level : int
-        The level to use.
+    %(verbose)s
     add_frames : int | None
         Number of stack frames to include in logging. This is useful
         for developers.
@@ -158,7 +158,7 @@ class use_log_level:
     This message will be printed!
     """
 
-    def __init__(self, level, *, add_frames=None):  # noqa: D102
+    def __init__(self, verbose, *, add_frames=None):  # noqa: D102
         self.level = level
         self.add_frames = add_frames
         self.old_frames = _filter.add_frames

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -131,9 +131,7 @@ class use_log_level:
     Parameters
     ----------
     %(verbose)s
-    add_frames : int | None
-        Number of stack frames to include in logging. This is useful
-        for developers.
+    %(add_frames)s
 
     See Also
     --------
@@ -185,10 +183,7 @@ def set_log_level(verbose=None, return_old_level=False, add_frames=None):
         it doesn't exist, defaults to INFO.
     return_old_level : bool
         If True, return the old verbosity level.
-    add_frames : int | None
-        If int, enable (>=1) or disable (0) the printing of stack frame
-        information using formatting. Default (None) does not change the
-        formatting. This can add overhead so is meant only for debugging.
+    %(add_frames)s
 
     Returns
     -------

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -40,6 +40,12 @@ verbose : bool | str | int | None
     verbosity level. See the :ref:`logging documentation <tut-logging>` and
     :func:`mne.verbose` for details. Should only be passed as a keyword
     argument."""
+docdict['add_frames'] = """
+add_frames : int | None
+    If int, enable (>=1) or disable (0) the printing of stack frame
+    information using formatting. Default (None) does not change the
+    formatting. This can add overhead so is meant only for debugging.
+"""
 
 # Preload
 docdict['preload'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -40,7 +40,6 @@ verbose : bool | str | int | None
     verbosity level. See the :ref:`logging documentation <tut-logging>` and
     :func:`mne.verbose` for details. Should only be passed as a keyword
     argument."""
-docdict['verbose_meth'] = (docdict['verbose'] + ' Defaults to self.verbose.')
 
 # Preload
 docdict['preload'] = """

--- a/mne/utils/tests/test_logging.py
+++ b/mne/utils/tests/test_logging.py
@@ -10,7 +10,7 @@ from mne import read_evokeds, Epochs, create_info
 from mne.io import read_raw_fif, RawArray
 from mne.utils import (warn, set_log_level, set_log_file, filter_out_warnings,
                        verbose, _get_call_line, use_log_level, catch_logging,
-                       logger, check)
+                       logger, check, _VerboseDep)
 from mne.utils._logging import _frame_info
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -222,22 +222,14 @@ def test_verbose_strictness():
     with pytest.raises(RuntimeError, match='does not accept'):
         bad_verbose()
 
-    class Okay:
-
-        @verbose
-        def meth_1(self):  # allowed because it should just use self.verbose
-            logger.info('meth_1')
+    class Okay(_VerboseDep):
 
         @verbose
         def meth_2(self, verbose=None):
             logger.info('meth_2')
 
     o = Okay()
-    with pytest.raises(RuntimeError, match=r'does not have self\.verbose'):
-        o.meth_1()  # should raise, no verbose attr yet
-    o.verbose = False
     with catch_logging() as log:
-        o.meth_1()
         o.meth_2()
     log = log.getvalue()
     assert log == ''
@@ -245,13 +237,12 @@ def test_verbose_strictness():
         o.meth_2(verbose=True)
     log = log.getvalue()
     assert 'meth_2' in log
-    o.verbose = True
-    with catch_logging() as log:
-        o.meth_1()
-        o.meth_2()
-    log = log.getvalue()
-    assert 'meth_1' in log
-    assert 'meth_2' in log
+    with pytest.deprecated_call(match='will be removed'):
+        assert o.verbose is None
+    with pytest.deprecated_call(match='ignored'):
+        o.verbose = False
+    with pytest.deprecated_call(match='will be removed'):
+        assert o.verbose is None
     with catch_logging() as log:
         o.meth_2(verbose=False)
     log = log.getvalue()

--- a/mne/utils/tests/test_logging.py
+++ b/mne/utils/tests/test_logging.py
@@ -230,7 +230,7 @@ def test_verbose_strictness():
 
     o = Okay()
     with catch_logging() as log:
-        o.meth_2()
+        o.meth_2(verbose=False)
     log = log.getvalue()
     assert log == ''
     with catch_logging() as log:

--- a/tutorials/intro/50_configure_mne.py
+++ b/tutorials/intro/50_configure_mne.py
@@ -206,9 +206,12 @@ raw = mne.io.read_raw_kit(kit_data_path, verbose='info')
 # This time, we got a few messages about extracting information from the file,
 # converting that information into the MNE-Python :class:`~mne.Info` format,
 # etc. Finally, if we request ``debug``-level information, we get even more
-# detail:
+# detail -- and we do so this time using the :func:`mne.use_log_level` context
+# manager, which is another way to accomplish the same thing as passing
+# ``verbose='debug'``:
 
-raw = mne.io.read_raw_kit(kit_data_path, verbose='debug')
+with mne.use_log_level('debug'):
+    raw = mne.io.read_raw_kit(kit_data_path)
 
 # %%
 # We've been passing string values to the ``verbose`` parameter, but we can see


### PR DESCRIPTION
Hey @mne-tools/mne-python-steering-committee (and anyone else who sees this who is interested), please vote on this proposal if you have an opinion (other than +0). We're aiming to decide on this and get it in for 1.0, i.e., within the next couple of weeks.

When we first implemented `verbose` support, we decided to make it so that *classes* had a `inst.verbose` property that would be used during method calls if `verbose` was not passed to the method call itself (https://github.com/mne-tools/mne-python/pull/167#issuecomment-9910684). However, it recently became clear that there are some drawbacks:

1. This was never fully realized, since this behavior only occurred when a given method had a `verbose` decorator. Not all methods do -- even some that `logger.info` or `warn` -- so the behavior is inconsistent.
2. Even if we add `@verbose` decorators to all methods, we end up with a difference between how a given function works -- even if it operates exclusively on a `raw` instance -- and how a method of that class behaves.
3. This behavior is not well documented or known.
4. This behavior is a surprising to at least some people (I even forget about it sometimes!).
5. It makes our code's behavior more implicit than explicit.
6. It makes our code more complex because we have to pass around and respect this parameter.

So overall I'm +1 for removing this behavior. This PR is a proposal to do that by removing (via deprecation) the `inst.verbose` attribute from all MNE classes that have it. We could go in the other direction by documenting the behavior better to deal with point (3), and regardless of what we decide about removing `inst.verbose` we probably do want to add `@verbose` decorators to all methods that can emit `logger` messages, so point (1) above is a bit moot -- but points 2/4/5/6 are not worth the marginal usability gains from having an `inst.verbose`.

The one place this might get a bit tricky is in `decoding` where the sliding estimators have `# to make use of class value` explicitly, but in this case people should maybe use `with mne.use_log_level(False):` or so in their code (again, more explicit).