### PR TITLE
MRG: When picking a directory via the Qt UI button, don't show files in the picker, only directories

### DIFF
--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -244,7 +244,8 @@ class _QtDock(_AbstractDock, _QtLayout):
         def callback():
             if is_directory:
                 name = QFileDialog.getExistingDirectory(
-                    directory=initial_directory
+                    directory=initial_directory,
+                    options=QFileDialog.ShowDirsOnly
                 )
             elif save:
                 name = QFileDialog.getSaveFileName(


### PR DESCRIPTION
This seemingly currently has no effect on macOS when using the native widgets, but it should make a difference on Windows and Linux.

@GuillaumeFavelier could you test this on Linux please?