### PR TITLE
MRG: Add get_tooltip(), set_tooltip() methods to GUI widgets

### DIFF
--- a/mne/gui/tests/test_gui_api.py
+++ b/mne/gui/tests/test_gui_api.py
@@ -250,6 +250,18 @@ def test_gui_api(renderer_notebook, nbexec):
     renderer._tool_bar_set_theme(theme='dark')
     # --- END: tool bar ---
 
+    # --- BEGIN: tooltips ---
+    widget = renderer._dock_add_button(
+        name='',
+        callback=mock,
+        tooltip='foo'
+    )
+    assert widget.get_tooltip() == 'foo'
+    # Change it …
+    widget.set_tooltip('bar')
+    assert widget.get_tooltip() == 'bar'
+    # --- END: tooltips ---
+
     renderer.show()
     renderer.close()
 

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -692,6 +692,14 @@ class _AbstractWidget(ABC):
     def update(self, repaint=True):
         pass
 
+    @abstractmethod
+    def get_tooltip(self):
+        pass
+
+    @abstractmethod
+    def set_tooltip(self, tooltip: str):
+        pass
+
 
 class _AbstractMplInterface(ABC):
     @abstractmethod

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -446,6 +446,14 @@ class _IpyWidget(_AbstractWidget):
     def update(self, repaint=True):
         pass
 
+    def get_tooltip(self):
+        assert hasattr(self._widget, 'tooltip')
+        return self._widget.tooltip
+
+    def set_tooltip(self, tooltip):
+        assert hasattr(self._widget, 'tooltip')
+        self._widget.tooltip = tooltip
+
 
 class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
                 _IpyStatusBar, _IpyWindow, _IpyPlayback):

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -685,6 +685,14 @@ class _QtWidget(_AbstractWidget):
         if repaint:
             self._widget.repaint()
 
+    def get_tooltip(self):
+        assert hasattr(self._widget, 'toolTip')
+        return self._widget.toolTip()
+
+    def set_tooltip(self, tooltip):
+        assert hasattr(self._widget, 'setToolTip')
+        self._widget.setToolTip(tooltip)
+
 
 class _Renderer(_PyVistaRenderer, _QtDock, _QtToolBar, _QtMenuBar,
                 _QtStatusBar, _QtWindow, _QtPlayback):


### PR DESCRIPTION
This adds `.get_tooltip()` and `.set_tooltip()` methods to Qt and notebook widgets.

At first I had added a more sophisticated handling for widgets that don't support tooltips, raising an exception; but while writing the tests, I figured that apparently all widgets we currently support in fact *do* allow for tooltips, so I'm now using some simple `assert` statements to help us prevent silent future bugs.

This should be ready to go, @GuillaumeFavelier