### PR TITLE
MRG: Log all CoregistrationUI statusbar messages via logger.info() too

### DIFF
--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -855,6 +855,8 @@ class CoregistrationUI(HasTraits):
         self._forward_widget_command(
             'status_message', 'update', None, input_value=False
         )
+        if msg:
+            logger.info(msg)
 
     def _follow_fiducial_view(self):
         fid = self._current_fiducial.lower()


### PR DESCRIPTION
This makes it such that all messages we display on the status bar will also be sent to our logger (log level "info"). We had discussed adding some kind of logging system to the GUI in the past, and this here is just a very straightforward (cheap?) way to get some basic logging.

WDYT @GuillaumeFavelier @agramfort?