### PR TITLE
BUG: Fix bug extracting meas_date

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -173,6 +173,8 @@ Bugs
 
 - :func:`mne.gui.coregistration` now works with surfaces containing topological defects (:gh:`10230`, by `Richard Höchenberger`_)
 
+- Fix bug with :func:`mne.io.read_raw_nirx` being unable to read measurement dates recorded on systems with German (de_DE), French (fr_FR), and Italian (it_IT) locales (:gh:`10277` by `Eric Larson`_)
+
 - :func:`mne.read_trans` now correctly expands ``~`` in the provided path to the user's home directory (:gh:`10265`, by `Richard Höchenberger`_)
 
 API changes

--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -87,7 +87,7 @@ I agree to the following:
 # respective repos, and make a new release of the dataset on GitHub. Then
 # update the checksum in the MNE_DATASETS dict below, and change version
 # here:                  ↓↓↓↓↓         ↓↓↓
-RELEASES = dict(testing='0.128', misc='0.23')
+RELEASES = dict(testing='0.129', misc='0.23')
 TESTING_VERSIONED = f'mne-testing-data-{RELEASES["testing"]}'
 MISC_VERSIONED = f'mne-misc-data-{RELEASES["misc"]}'
 
@@ -111,7 +111,7 @@ MNE_DATASETS = dict()
 # Testing and misc are at the top as they're updated most often
 MNE_DATASETS['testing'] = dict(
     archive_name=f'{TESTING_VERSIONED}.tar.gz',  # 'mne-testing-data',
-    hash='md5:88c04e31fd496f394fa96fe7cdd70217',
+    hash='md5:6847ad93bc025d2f553112baa25ad2a6',
     url=('https://codeload.github.com/mne-tools/mne-testing-data/'
          f'tar.gz/{RELEASES["testing"]}'),
     folder_name='MNE-testing-data',

--- a/mne/io/nirx/_localized_abbr.py
+++ b/mne/io/nirx/_localized_abbr.py
@@ -1,11 +1,11 @@
+"""Localizations for meas_date extraction."""
 # Authors: Eric Larson <larson.eric.d@gmail.com>
 #
 # License: BSD-3-Clause
 
 # This file was generated on 2021/01/31 on an Ubuntu system.
-# I got "unsupported locale setting" on Ubuntu because I use localepurge. So
-# I had to use "sudo locale-gen de_DE" etc. then "sudo update-locale", then
-# this worked:
+# When getting "unsupported locale setting" on Ubuntu (e.g., with localepurge),
+# use "sudo locale-gen de_DE" etc. then "sudo update-locale".
 
 """
 import datetime

--- a/mne/io/nirx/_localized_abbr.py
+++ b/mne/io/nirx/_localized_abbr.py
@@ -1,0 +1,60 @@
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD-3-Clause
+
+# This file was generated on 2021/01/31 on an Ubuntu system.
+# I got "unsupported locale setting" on Ubuntu because I use localepurge. So
+# I had to use "sudo locale-gen de_DE" etc. then "sudo update-locale", then
+# this worked:
+
+"""
+import datetime
+import locale
+print('_localized_abbr = {')
+for loc in ('en_US.utf8', 'de_DE', 'fr_FR', 'it_IT'):
+    print(f'    {repr(loc)}: {{')
+    print('        "month": {', end='')
+    month_abbr = set()
+    for month in range(1, 13):  # Month as locale’s abbreviated name
+        locale.setlocale(locale.LC_TIME, "en_US.utf8")
+        dt = datetime.datetime(year=2000, month=month, day=1)
+        val = dt.strftime("%b").lower()
+        locale.setlocale(locale.LC_TIME, loc)
+        key = dt.strftime("%b").lower()
+        month_abbr.add(key)
+        print(f'{repr(key)}: {repr(val)}, ', end='')
+    print('},  # noqa')
+    print('        "weekday": {', end='')
+    weekday_abbr = set()
+    for day in range(1, 8):  # Weekday as locale’s abbreviated name.
+        locale.setlocale(locale.LC_TIME, "en_US.utf8")
+        dt = datetime.datetime(year=2000, month=1, day=day)
+        val = dt.strftime("%a").lower()
+        locale.setlocale(locale.LC_TIME, loc)
+        key = dt.strftime("%a").lower()
+        assert key not in weekday_abbr, key
+        weekday_abbr.add(key)
+        print(f'{repr(key)}: {repr(val)}, ', end='')
+    print('},  # noqa')
+    print('    },')
+print('}\n')
+"""
+
+_localized_abbr = {
+    'en_US.utf8': {
+        "month": {'jan': 'jan', 'feb': 'feb', 'mar': 'mar', 'apr': 'apr', 'may': 'may', 'jun': 'jun', 'jul': 'jul', 'aug': 'aug', 'sep': 'sep', 'oct': 'oct', 'nov': 'nov', 'dec': 'dec', },  # noqa
+        "weekday": {'sat': 'sat', 'sun': 'sun', 'mon': 'mon', 'tue': 'tue', 'wed': 'wed', 'thu': 'thu', 'fri': 'fri', },  # noqa
+    },
+    'de_DE': {
+        "month": {'jan': 'jan', 'feb': 'feb', 'mär': 'mar', 'apr': 'apr', 'mai': 'may', 'jun': 'jun', 'jul': 'jul', 'aug': 'aug', 'sep': 'sep', 'okt': 'oct', 'nov': 'nov', 'dez': 'dec', },  # noqa
+        "weekday": {'sa': 'sat', 'so': 'sun', 'mo': 'mon', 'di': 'tue', 'mi': 'wed', 'do': 'thu', 'fr': 'fri', },  # noqa
+    },
+    'fr_FR': {
+        "month": {'janv.': 'jan', 'févr.': 'feb', 'mars': 'mar', 'avril': 'apr', 'mai': 'may', 'juin': 'jun', 'juil.': 'jul', 'août': 'aug', 'sept.': 'sep', 'oct.': 'oct', 'nov.': 'nov', 'déc.': 'dec', },  # noqa
+        "weekday": {'sam.': 'sat', 'dim.': 'sun', 'lun.': 'mon', 'mar.': 'tue', 'mer.': 'wed', 'jeu.': 'thu', 'ven.': 'fri', },  # noqa
+    },
+    'it_IT': {
+        "month": {'gen': 'jan', 'feb': 'feb', 'mar': 'mar', 'apr': 'apr', 'mag': 'may', 'giu': 'jun', 'lug': 'jul', 'ago': 'aug', 'set': 'sep', 'ott': 'oct', 'nov': 'nov', 'dic': 'dec', },  # noqa
+        "weekday": {'sab': 'sat', 'dom': 'sun', 'lun': 'mon', 'mar': 'tue', 'mer': 'wed', 'gio': 'thu', 'ven': 'fri', },  # noqa
+    },
+}


### PR DESCRIPTION
Closes #10147

Turns out that localized dates is a pain in Python, and solving it in a general way requires a lot of work and/or additional dependencies. This implements a simpler solution: use a script to make a dict of translations and try them all. It's quick to execute, and easy enough to generate the dict of translations that we need.

@mlrocca feel free to try this branch (or just wait until it's merged into `main` and try that), it should fix your bug.

@rob-luke feel free to review and merge if you're happy