### PR TITLE
ENH: coreg UI (part II)

### DIFF
--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -1473,7 +1473,7 @@ class CoregistrationUI(HasTraits):
             self._widgets[name] = self._renderer._dock_add_spin_box(
                 name=name,
                 value=attr[coords.index(coord)] * 1e2,
-                rng=[-1e3, 1e3],
+                rng=[1., 1e2],
                 callback=partial(
                     self._set_parameter,
                     mode_name="scale",
@@ -1481,7 +1481,8 @@ class CoregistrationUI(HasTraits):
                 ),
                 compact=True,
                 double=True,
-                tooltip=f"Set the {coord} scaling parameter",
+                step=1,
+                tooltip=f"Set the {coord} scaling parameter (in %)",
                 layout=scale_params_layout,
             )
 
@@ -1524,10 +1525,12 @@ class CoregistrationUI(HasTraits):
             for mode, mode_name in (("t", "Translation"), ("r", "Rotation")):
                 name = f"{mode}{coord}"
                 attr = getattr(self.coreg, f"_{mode_name.lower()}")
+                rng = [-360, 360] if mode_name == "Rotation" else [-100, 100]
+                unit = "°" if mode_name == "Rotation" else "mm"
                 self._widgets[name] = self._renderer._dock_add_spin_box(
                     name=name,
                     value=attr[coords.index(coord)] * 1e3,
-                    rng=[-1e3, 1e3],
+                    rng=np.array(rng),
                     callback=partial(
                         self._task_set_parameter,
                         mode_name=mode_name.lower(),
@@ -1536,7 +1539,8 @@ class CoregistrationUI(HasTraits):
                     compact=True,
                     double=True,
                     step=1,
-                    tooltip=f"Set the {coord} {mode_name.lower()} parameter",
+                    tooltip=f"Set the {coord} {mode_name.lower()}"
+                            f" parameter (in {unit})",
                     layout=coord_layout
                 )
             self._renderer._layout_add_widget(param_layout, coord_layout)

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -1364,6 +1364,7 @@ class CoregistrationUI(HasTraits):
                 ),
                 compact=True,
                 double=True,
+                step=1,
                 tooltip=f"Set the {coord} fiducial coordinate",
                 layout=fiducial_coords_layout,
             )

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -451,6 +451,10 @@ class CoregistrationUI(HasTraits):
     def _set_parameter(self, value, mode_name, coord):
         if self._params_locked:
             return
+        if mode_name == "scale" and self._scale_mode == "uniform":
+            with self._lock(params=True):
+                self._forward_widget_command(
+                    ["sY", "sZ"], "set_value", value)
         with self._parameter_mutex:
             self. _set_parameter_safe(value, mode_name, coord)
         self._update_plot("sensors")
@@ -468,7 +472,10 @@ class CoregistrationUI(HasTraits):
             params[mode_name][idx] = value / 1e3
         else:
             assert mode_name == "scale"
-            params[mode_name][idx] = value / 1e2
+            if self._scale_mode == "uniform":
+                params[mode_name][:] = value / 1e2
+            else:
+                params[mode_name][idx] = value / 1e2
             self._update_plot("head")
         self.coreg._update_params(
             rot=params["rotation"],
@@ -660,6 +667,8 @@ class CoregistrationUI(HasTraits):
                                          mode is not None)
             self._forward_widget_command("fits_fiducials", "set_enabled",
                                          mode not in (None, "3-axis"))
+        if self._scale_mode == "uniform":
+            self._forward_widget_command(["sY", "sZ"], "set_enabled", False)
 
     @observe("_icp_fid_match")
     def _icp_fid_match_changed(self, change=None):


### PR DESCRIPTION
This small PR extracted from #10224:

- improves the user experience with `scale_mode = 'uniform'`
- fixes the range, increment and tooltip of the coordinate spin boxes

main | PR
--|--
![image](https://user-images.githubusercontent.com/18143289/151953511-1f8c751a-39cd-411a-87e6-abdc7523a1de.png) | ![image](https://user-images.githubusercontent.com/18143289/151953677-b2866966-ef74-40c4-8b5d-7b65ef079eb9.png)
