### PR TITLE
ENH: return complex multitaper output per taper

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -24,6 +24,8 @@ Current (1.0.dev0)
 Enhancements
 ~~~~~~~~~~~~
 
+- :func:`mne.time_frequency.tfr_array_multitaper` can now return results for ``output='phase'`` instead of an error (:gh:`10281` by `Mikołaj Magnuski`)
+
 - Speed up :func:`mne.preprocessing.annotate_muscle_zscore`, :func:`mne.preprocessing.annotate_movement`, and :func:`mne.preprocessing.annotate_nan` through better annotation creation (:gh:`10089` by :newcontrib:`Senwen Deng`)
 
 - Fix some unused variables in time_frequency_erds.py example (:gh:`10076` by :newcontrib:`Jan Zerfowski`)
@@ -102,6 +104,8 @@ Enhancements
 
 Bugs
 ~~~~
+
+- :func:`mne.time_frequency.tfr_array_multitaper` now returns results per taper when ``output='complex'`` (:gh:`10281` by `Mikołaj Magnuski`)
 
 - Teach :func:`mne.io.read_raw_bti` to use its ``eog_ch`` parameter (:gh:`10093` by :newcontrib:`Adina Wagner`)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -24,11 +24,11 @@ Current (1.0.dev0)
 Enhancements
 ~~~~~~~~~~~~
 
-- :func:`mne.time_frequency.tfr_array_multitaper` can now return results for ``output='phase'`` instead of an error (:gh:`10281` by `Mikołaj Magnuski`)
-
 - Speed up :func:`mne.preprocessing.annotate_muscle_zscore`, :func:`mne.preprocessing.annotate_movement`, and :func:`mne.preprocessing.annotate_nan` through better annotation creation (:gh:`10089` by :newcontrib:`Senwen Deng`)
 
 - Fix some unused variables in time_frequency_erds.py example (:gh:`10076` by :newcontrib:`Jan Zerfowski`)
+
+- :func:`mne.time_frequency.tfr_array_multitaper` can now return results for ``output='phase'`` instead of an error (:gh:`10281` by `Mikołaj Magnuski`_)
 
 - Add show local maxima toggling button to :func:`mne.gui.locate_ieeg` (:gh:`9952` by `Alex Rockhill`_)
 
@@ -105,9 +105,9 @@ Enhancements
 Bugs
 ~~~~
 
-- :func:`mne.time_frequency.tfr_array_multitaper` now returns results per taper when ``output='complex'`` (:gh:`10281` by `Mikołaj Magnuski`)
-
 - Teach :func:`mne.io.read_raw_bti` to use its ``eog_ch`` parameter (:gh:`10093` by :newcontrib:`Adina Wagner`)
+
+- :func:`mne.time_frequency.tfr_array_multitaper` now returns results per taper when ``output='complex'`` (:gh:`10281` by `Mikołaj Magnuski`_)
 
 - Fix default of :func:`mne.io.Raw.plot` to be ``use_opengl=None``, which will act like False unless ``MNE_BROWSER_USE_OPENGL=true`` is set in the user configuration (:gh:`9957` by `Eric Larson`_)
 

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -494,9 +494,9 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
             is done after the convolutions.
     output : str, default 'complex'
 
-        * 'complex' : single trial complex.
+        * 'complex' : single trial per taper complex values.
         * 'power' : single trial power.
-        * 'phase' : single trial phase.
+        * 'phase' : single trial per taper phase.
         * 'avg_power' : average of single trial power.
         * 'itc' : inter-trial coherence.
         * 'avg_power_itc' : average of single trial power and inter-trial
@@ -510,10 +510,12 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
     -------
     out : array
         Time frequency transform of epoch_data. If output is in ['complex',
-        'phase', 'power'], then shape of out is (n_epochs, n_chans, n_freqs,
-        n_times), else it is (n_chans, n_freqs, n_times). If output is
-        'avg_power_itc', the real values code for 'avg_power' and the
-        imaginary values code for the 'itc': out = avg_power + i * itc.
+        'phase'], then the shape of ``out`` is ``(n_epochs, n_chans, n_tapers,
+        n_freqs, n_times)``; if output is 'power', the shape of ``out`` is
+        ``(n_epochs, n_chans, n_freqs, n_times)``, else it is ``(n_chans,
+        n_freqs, n_times)``. If output is 'avg_power_itc', the real values
+        in ``out`` contain the average power and the imaginary values contain
+        the ITC: ``out = avg_power + i * itc``.
 
     See Also
     --------

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -509,13 +509,13 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
     Returns
     -------
     out : array
-        Time frequency transform of epoch_data. If output is in ['complex',
-        'phase'], then the shape of ``out`` is ``(n_epochs, n_chans, n_tapers,
-        n_freqs, n_times)``; if output is 'power', the shape of ``out`` is
-        ``(n_epochs, n_chans, n_freqs, n_times)``, else it is ``(n_chans,
-        n_freqs, n_times)``. If output is 'avg_power_itc', the real values
-        in ``out`` contain the average power and the imaginary values contain
-        the ITC: ``out = avg_power + i * itc``.
+        Time frequency transform of epoch_data. If ``output in ['complex',
+        'phase']``, then the shape of ``out`` is ``(n_epochs, n_chans,
+        n_tapers, n_freqs, n_times)``; if output is 'power', the shape of
+        ``out`` is ``(n_epochs, n_chans, n_freqs, n_times)``, else it is
+        ``(n_chans, n_freqs, n_times)``. If output is 'avg_power_itc', the real
+        values in ``out`` contain the average power and the imaginary values
+        contain the ITC: ``out = avg_power + i * itc``.
 
     See Also
     --------

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -131,7 +131,8 @@ def test_time_frequency():
     # computed within the method.
     assert_allclose(epochs_amplitude_2.data**2, epochs_power_picks.data)
 
-    # complex test for multitaper case
+    # test that averaging power across tapers when multitaper with
+    # output='complex' gives the same as output='power'
     epoch_data = epochs.get_data()
     multitaper_power = tfr_array_multitaper(
         epoch_data, epochs.info['sfreq'], freqs, n_cycles,

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -141,8 +141,6 @@ def test_time_frequency():
         epoch_data, epochs.info['sfreq'], freqs, n_cycles,
         output="complex")
 
-    print(multitaper_complex.shape)
-    print(multitaper_power.shape)
     taper_dim = 2
     power_from_complex = (multitaper_complex * multitaper_complex.conj()
                           ).real.mean(axis=taper_dim)

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -731,7 +731,11 @@ def test_compute_tfr():
         out = func(data, sfreq=sfreq, freqs=freqs, use_fft=use_fft,
                    zero_mean=zero_mean, n_cycles=2., output=output)
         # Check shapes
-        shape = np.r_[data.shape[:2], len(freqs), data.shape[2]]
+        if func == tfr_array_multitaper and output == 'complex':
+            n_tapers = 3
+            shape = np.r_[data.shape[:2], n_tapers, len(freqs), data.shape[2]]
+        else:
+            shape = np.r_[data.shape[:2], len(freqs), data.shape[2]]
         if ('avg' in output) or ('itc' in output):
             assert_array_equal(shape[1:], out.shape)
         else:

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -721,17 +721,12 @@ def test_compute_tfr():
         (tfr_array_multitaper, tfr_array_morlet), (False, True), (False, True),
         ('complex', 'power', 'phase',
          'avg_power_itc', 'avg_power', 'itc')):
-        # Check exception
-        if (func == tfr_array_multitaper) and (output == 'phase'):
-            pytest.raises(NotImplementedError, func, data, sfreq=sfreq,
-                          freqs=freqs, output=output)
-            continue
 
         # Check runs
         out = func(data, sfreq=sfreq, freqs=freqs, use_fft=use_fft,
                    zero_mean=zero_mean, n_cycles=2., output=output)
         # Check shapes
-        if func == tfr_array_multitaper and output == 'complex':
+        if func == tfr_array_multitaper and output in ['complex', 'phase']:
             n_tapers = 3
             shape = np.r_[data.shape[:2], n_tapers, len(freqs), data.shape[2]]
         else:
@@ -766,9 +761,6 @@ def test_compute_tfr():
     # No time_bandwidth param in morlet
     pytest.raises(ValueError, _compute_tfr, data, freqs, sfreq,
                   method='morlet', time_bandwidth=1)
-    # No phase in multitaper XXX Check ?
-    pytest.raises(NotImplementedError, _compute_tfr, data, freqs, sfreq,
-                  method='multitaper', output='phase')
 
     # Inter-trial coherence tests
     out = _compute_tfr(data, freqs, sfreq, output='itc', n_cycles=2.)

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -802,14 +802,17 @@ def test_compute_tfr_correct(method, decim):
     sfreq = 1000.
     t = np.arange(1000) / sfreq
     f = 50.
-    data = np.sin(2 * np.pi * 50. * t)
+    data = np.sin(2 * np.pi * f * t)
     data *= np.hanning(data.size)
     data = data[np.newaxis, np.newaxis]
-    freqs = np.arange(10, 111, 10)
+    freqs = np.arange(10, 111, 4)
     assert f in freqs
+
+    # previous n_cycles=2 gives weird results for multitaper
+    n_cycles = freqs * 0.25
     tfr = _compute_tfr(data, freqs, sfreq, method=method, decim=decim,
-                       n_cycles=2)[0, 0]
-    assert freqs[np.argmax(np.abs(tfr).mean(-1))] == f
+                       n_cycles=n_cycles, output='power')[0, 0]
+    assert freqs[np.argmax(tfr.mean(-1))] == f
 
 
 def test_averaging_epochsTFR():

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -131,6 +131,22 @@ def test_time_frequency():
     # computed within the method.
     assert_allclose(epochs_amplitude_2.data**2, epochs_power_picks.data)
 
+    # complex test for multitaper case
+    epoch_data = epochs.get_data()
+    multitaper_power = tfr_array_multitaper(
+        epoch_data, epochs.info['sfreq'], freqs, n_cycles,
+        output="power")
+    multitaper_complex = tfr_array_multitaper(
+        epoch_data, epochs.info['sfreq'], freqs, n_cycles,
+        output="complex")
+
+    print(multitaper_complex.shape)
+    print(multitaper_power.shape)
+    taper_dim = 2
+    power_from_complex = (multitaper_complex * multitaper_complex.conj()
+                          ).real.mean(axis=taper_dim)
+    assert_allclose(power_from_complex, multitaper_power)
+
     print(itc)  # test repr
     print(itc.ch_names)  # test property
     itc += power  # test add

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -784,10 +784,11 @@ def test_compute_tfr():
         _decim = slice(None, None, decim) if isinstance(decim, int) else decim
         n_time = len(np.arange(data.shape[2])[_decim])
         shape = np.r_[data.shape[:2], len(freqs), n_time]
+
         for method in ('multitaper', 'morlet'):
             # Single trials
             out = _compute_tfr(data, freqs, sfreq, method=method, decim=decim,
-                               n_cycles=2.)
+                               output='power', n_cycles=2.)
             assert_array_equal(shape, out.shape)
             # Averages
             out = _compute_tfr(data, freqs, sfreq, method=method, decim=decim,

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -331,14 +331,13 @@ def _compute_tfr(epoch_data, freqs, sfreq=1.0, method='morlet',
     -------
     out : array
         Time frequency transform of epoch_data. If output is in ['complex',
-        'phase', 'power'], then shape of ``ou``t is ``(n_epochs, n_chans,
+        'phase', 'power'], then shape of ``out`` is ``(n_epochs, n_chans,
         n_freqs, n_times)``, else it is ``(n_chans, n_freqs, n_times)``.
-        However, using multitaper method with at least 2 tapers and output
-        ``'complex'`` or ``'phase'`` results in shape of ``out`` being
-        ``(n_epochs, n_chans, n_tapers, n_freqs, n_times)``. If output is
-        ``'avg_power_itc'``, the real values in the ``output`` contain
-        average power' and the imaginary values contain the ITC:
-        ``out = avg_power + i * itc``.
+        However, using multitaper method and output ``'complex'`` or
+        ``'phase'`` results in shape of ``out`` being ``(n_epochs, n_chans,
+        n_tapers, n_freqs, n_times)``. If output is ``'avg_power_itc'``, the
+        real values in the ``output`` contain average power' and the imaginary
+        values contain the ITC: ``out = avg_power + i * itc``.
     """
     # Check data
     epoch_data = np.asarray(epoch_data)

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -564,7 +564,8 @@ def _time_frequency_loop(X, Ws, output, use_fft, mode, decim):
         tfrs /= n_epochs
 
     # Normalization by number of taper
-    tfrs /= len(Ws)
+    if n_tapers > 1 and output not in ['complex', 'phase']:
+        tfrs /= len(Ws)
     return tfrs
 
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -331,10 +331,14 @@ def _compute_tfr(epoch_data, freqs, sfreq=1.0, method='morlet',
     -------
     out : array
         Time frequency transform of epoch_data. If output is in ['complex',
-        'phase', 'power'], then shape of out is (n_epochs, n_chans, n_freqs,
-        n_times), else it is (n_chans, n_freqs, n_times). If output is
-        'avg_power_itc', the real values code for 'avg_power' and the
-        imaginary values code for the 'itc': out = avg_power + i * itc
+        'phase', 'power'], then shape of ``ou``t is ``(n_epochs, n_chans,
+        n_freqs, n_times)``, else it is ``(n_chans, n_freqs, n_times)``.
+        However, using multitaper method with at least 2 tapers and output
+        ``'complex'`` or ``'phase'`` results in shape of ``out`` being
+        ``(n_epochs, n_chans, n_tapers, n_freqs, n_times)``. If output is
+        ``'avg_power_itc'``, the real values in the ``output`` contain
+        average power' and the imaginary values contain the ITC:
+        ``out = avg_power + i * itc``.
     """
     # Check data
     epoch_data = np.asarray(epoch_data)

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -381,7 +381,7 @@ def _compute_tfr(epoch_data, freqs, sfreq=1.0, method='morlet',
 
     if ('avg_' in output) or ('itc' in output):
         out = np.empty((n_chans, n_freqs, n_times), dtype)
-    elif output == 'complex' and n_tapers > 1:
+    elif output in ['complex', 'phase'] and n_tapers > 1:
         out = np.empty((n_chans, n_tapers, n_epochs, n_freqs, n_times), dtype)
     else:
         out = np.empty((n_chans, n_epochs, n_freqs, n_times), dtype)
@@ -518,7 +518,7 @@ def _time_frequency_loop(X, Ws, output, use_fft, mode, decim):
     n_freqs = len(Ws[0])
     if ('avg_' in output) or ('itc' in output):
         tfrs = np.zeros((n_freqs, n_times), dtype=dtype)
-    elif output == 'complex' and n_tapers > 1:
+    elif output in ['complex', 'phase'] and n_tapers > 1:
         tfrs = np.zeros((n_tapers, n_epochs, n_freqs, n_times),
                         dtype=dtype)
     else:
@@ -553,7 +553,7 @@ def _time_frequency_loop(X, Ws, output, use_fft, mode, decim):
             # Stack or add
             if ('avg_' in output) or ('itc' in output):
                 tfrs += tfr
-            elif output == 'complex' and n_tapers > 1:
+            elif output in ['complex', 'phase'] and n_tapers > 1:
                 tfrs[taper_idx, epoch_idx] += tfr
             else:
                 tfrs[epoch_idx] += tfr

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -565,7 +565,7 @@ def _time_frequency_loop(X, Ws, output, use_fft, mode, decim):
 
     # Normalization by number of taper
     if n_tapers > 1 and output not in ['complex', 'phase']:
-        tfrs /= len(Ws)
+        tfrs /= n_tapers
     return tfrs
 
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -402,7 +402,7 @@ def _compute_tfr(epoch_data, freqs, sfreq=1.0, method='morlet',
 
     if ('avg_' not in output) and ('itc' not in output):
         # This is to enforce that the first dimension is for epochs
-        if output == 'complex' and n_tapers > 1:
+        if output in ['complex', 'phase'] and n_tapers > 1:
             out = out.transpose(2, 0, 1, 3, 4)
         else:
             out = out.transpose(1, 0, 2, 3)
@@ -433,11 +433,6 @@ def _check_tfr_param(freqs, sfreq, method, zero_mean, n_cycles,
         raise ValueError('zero_mean should be of type bool, got %s. instead'
                          % type(zero_mean))
     freqs = np.asarray(freqs)
-
-    if (method == 'multitaper') and (output == 'phase'):
-        raise NotImplementedError(
-            'This function is not optimized to compute the phase using the '
-            'multitaper method. Use np.angle of the complex output instead.')
 
     # Check n_cycles
     if isinstance(n_cycles, (int, float)):


### PR DESCRIPTION
#### Reference issue
Fixes #8722.


#### What does this implement/fix?
Changes multitaper time-frequency to return per-taper Fourier coefficients when `output == 'complex'`. So far the coefficients were averaged across tapers which is not correct. This change should also allow users to calculate connectivity measures per taper and average across tapers (this is what we do correctly now for ITC).


#### Additional information
Currently the output has the following shape: `(n_epochs, n_channels, n_tapers, n_freqs, n_times)`
This could be changed if you think a different output structure will work better.

To see how this PR works, you can try the script below (based on code provided by @chapochn in #8722; I will reshape this code into a test later this week):
```python
import numpy as np
import mne.time_frequency as tfr

signal = np.zeros(1000)
signal[500:] = 1

# %% compute power and complex output with 2 tapers
tfr_out1 = tfr.tfr_array_multitaper([[signal]], sfreq=100, freqs=[20],
                                    time_bandwidth=3, output='complex')
tfr_out2 = tfr.tfr_array_multitaper([[signal]], sfreq=100, freqs=[20],
                                    time_bandwidth=3, output='power')

# %% confirm that we can get the power from complex output
taper_dim = 2
tfr1_pwr = (np.abs(tfr_out1) ** 2).mean(axis=taper_dim)
print(np.allclose(tfr1_pwr, tfr_out2))
print(tfr_out1.shape, tfr_out2.shape)
```

#### TODOs:
- [x] update failing tests
- [x] add one more test (based on the code snippet)
- [x] return results per taper also for `output='phase'`
- [x] whats new
- [x] ~~disable `output='complex'` for normal (non-array) tfr multitaper?~~  complex or phase results seem to not be available through `tfr_multitaper`
