### PR TITLE
FIX: notebook 3d backend

### DIFF
--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -33,9 +33,10 @@ class _IpyLayout(_AbstractLayout):
         # Fix columns
         if self._layout_max_width is not None and isinstance(widget, HBox):
             children = widget.children
-            width = int(self._layout_max_width / len(children))
-            for child in children:
-                child.layout.width = f"{width}px"
+            if len(children) > 0:
+                width = int(self._layout_max_width / len(children))
+                for child in children:
+                    child.layout.width = f"{width}px"
 
 
 class _IpyDock(_AbstractDock, _IpyLayout):


### PR DESCRIPTION
This small PR fixes an issue with the `notebook` 3d backend:

```
~/source/mne-python/mne/gui/_coreg.py in __init__(self, info_file, subject, subjects_dir, fiducials, head_resolution, head_opacity, hpi_coils, head_shape_points, eeg_channels, orient_glyphs, scale_by_distance, mark_inside, sensor_opacity, trans, size, bgcolor, show, block, interaction, project_eeg, head_transparency, standalone, verbose)
    270         self._reset_fitting_parameters()
    271         self._configure_status_bar()
--> 272         self._configure_dock()
    273         self._configure_picking()
    274 

~/source/mne-python/mne/gui/_coreg.py in _configure_dock(self)
   1329             vertical=False
   1330         )
-> 1331         self._renderer._layout_add_widget(
   1332             layout=mri_fiducials_layout,
   1333             widget=mri_fiducials_button_layout

~/source/mne-python/mne/viz/backends/_notebook.py in _layout_add_widget(self, layout, widget, stretch)
     34         if self._layout_max_width is not None and isinstance(widget, HBox):
     35             children = widget.children
---> 36             width = int(self._layout_max_width / len(children))
     37             for child in children:
     38                 child.layout.width = f"{width}px"

ZeroDivisionError: division by zero
```