### PR TITLE
MNT: test coreg UI with notebook 3d backend

### DIFF
--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -310,7 +310,7 @@ class CoregistrationUI(HasTraits):
             self._renderer.plotter.add_callback(
                 self._redraw, self._refresh_rate_ms)
         self._renderer.plotter.show_axes()
-        if block:
+        if block and self._renderer._kind != 'notebook':
             _qt_app_exec(self._renderer.figure.store["app"])
 
     def _set_subjects_dir(self, subjects_dir):

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -225,6 +225,7 @@ def test_coreg_gui_pyvista(tmp_path, renderer_interactive_pyvistaqt):
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_coreg_gui_notebook(renderer_notebook, nbexec):
+    """Test coregistration ui in a notebook."""
     import os
     import mne
     from mne.datasets import testing

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -222,6 +222,8 @@ def test_coreg_gui_pyvista(tmp_path, renderer_interactive_pyvistaqt):
     assert isinstance(coreg.coreg, Coregistration)
 
 
+@pytest.mark.slowtest
+@testing.requires_testing_data
 def test_coreg_gui_notebook(renderer_notebook, nbexec):
     import os
     import mne

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -225,7 +225,7 @@ def test_coreg_gui_pyvista(tmp_path, renderer_interactive_pyvistaqt):
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_coreg_gui_notebook(renderer_notebook, nbexec):
-    """Test coregistration ui in a notebook."""
+    """Test the coregistration UI in a notebook."""
     import os
     import mne
     from mne.datasets import testing

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -220,3 +220,14 @@ def test_coreg_gui_pyvista(tmp_path, renderer_interactive_pyvistaqt):
     coreg.close()
     # Coregistration instance should survive
     assert isinstance(coreg.coreg, Coregistration)
+
+
+def test_coreg_gui_notebook(renderer_notebook, nbexec):
+    import os
+    import mne
+    from mne.datasets import testing
+    from mne.gui import coregistration
+    mne.viz.set_3d_backend('notebook')  # set the 3d backend
+    data_path = testing.data_path()
+    subjects_dir = os.path.join(data_path, 'subjects')
+    coregistration(subject='sample', subjects_dir=subjects_dir)


### PR DESCRIPTION
This PR adds testing of the coreg UI with the `notebook` 3d backend. It's a very basic test for now. 

The notebook app was hanging when loading `trans` locally, I'll add it to #8833:

> - [ ] the app hangs when loading trans (ipywidgets)