### PR TITLE
ENH: Better logic and message

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -175,6 +175,8 @@ Bugs
 
 - Fix bug with :func:`mne.io.read_raw_nirx` being unable to read measurement dates recorded on systems with German (de_DE), French (fr_FR), and Italian (it_IT) locales (:gh:`10277` by `Eric Larson`_)
 
+- Fix bug with projector normalization checks that were too sensitive, and improve warning (:gh:`10292` by `Eric Larson`_)
+
 - :func:`mne.read_trans` now correctly expands ``~`` in the provided path to the user's home directory (:gh:`10265`, by `Richard Höchenberger`_)
 
 API changes

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -589,7 +589,7 @@ def _all_src_types_inv_evoked(_evoked_cov_sphere, _all_src_types_fwd):
     invs = dict()
     for kind, fwd in _all_src_types_fwd.items():
         assert fwd['src'].kind == kind
-        with pytest.warns(RuntimeWarning, match='has magnitude'):
+        with pytest.warns(RuntimeWarning, match='has been reduced'):
             invs[kind] = mne.minimum_norm.make_inverse_operator(
                 evoked.info, fwd, cov)
     return invs, evoked

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -125,6 +125,7 @@ def pytest_configure(config):
     ignore:.*Found the following unknown channel type.*:RuntimeWarning
     ignore:.*np\.MachAr.*:DeprecationWarning
     ignore:.*Passing unrecognized arguments to super.*:DeprecationWarning
+    ignore:.*numpy.ndarray size changed.*:
     # present in nilearn v 0.8.1, fixed in nilearn main
     ignore:.*distutils Version classes are deprecated.*:DeprecationWarning
     ignore:.*pandas\.Int64Index is deprecated.*:FutureWarning

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -732,7 +732,7 @@ class Info(dict, MontageMixin):
             self['chs'] = _dict_unpack(self['chs'], _CH_CAST)
         for pi, proj in enumerate(self.get('projs', [])):
             if not isinstance(proj, Projection):
-                self['projs'][pi] = Projection(proj)
+                self['projs'][pi] = Projection(**proj)
         # Old files could have meas_date as tuple instead of datetime
         try:
             meas_date = self['meas_date']

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -975,6 +975,12 @@ class Info(dict, MontageMixin):
                 if self.get(key) is not None:
                     self[key] = float(self[key])
 
+        for pi, proj in enumerate(self.get('projs', [])):
+            _validate_type(proj, Projection, f'info["projs"][{pi}]')
+            for key in ('kind', 'active', 'desc', 'data', 'explained_var'):
+                if key not in proj:
+                    raise RuntimeError(f'Projection incomplete, missing {key}')
+
         # Ensure info['chs'] has immutable entries (copies much faster)
         for ci, ch in enumerate(self['chs']):
             _check_ch_keys(ch, ci)

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -10,10 +10,10 @@ from itertools import count
 
 import numpy as np
 
-from .tree import dir_tree_find
-from .tag import find_tag, _rename_list
 from .constants import FIFF
 from .pick import pick_types, pick_info
+from .tag import find_tag, _rename_list
+from .tree import dir_tree_find
 from .write import (write_int, write_float, write_string, write_name_list,
                     write_float_matrix, end_block, start_block)
 from ..defaults import _BORDER_DEFAULT, _EXTRAPOLATE_DEFAULT
@@ -25,11 +25,17 @@ class Projection(dict):
 
     A basic class to proj a meaningful print for projection vectors.
     """
+    def __init__(self, *, data, desc='', kind=FIFF.FIFFV_PROJ_ITEM_FIELD,
+                 active=False, explained_var=None):
+        super().__init__(desc=desc, kind=kind, active=active, data=data,
+                         explained_var=explained_var)
 
     def __repr__(self):  # noqa: D105
         s = "%s" % self['desc']
         s += ", active : %s" % self['active']
         s += f", n_channels : {len(self['data']['col_names'])}"
+        if self['explained_var'] is not None:
+            s += f', exp. var : {self["explained_var"] * 100:0.2f}%'
         return "<Projection | %s>" % s
 
     # speed up info copy by taking advantage of mutability
@@ -621,7 +627,7 @@ def _make_projector(projs, ch_names, bads=(), include_active=True,
                             'On the other hand, if you know that all channels '
                             'were good during SSP computation, you can safely '
                             'use info.normalize_proj() to suppress this '
-                            'warning.')
+                            'warning during projection.')
                     this_vecs[:, v] /= psize
                     nonzero += 1
             # If doing "inplace" mode, "fix" the projectors to only operate

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -24,6 +24,22 @@ class Projection(dict):
     """Projection vector.
 
     A basic class to proj a meaningful print for projection vectors.
+
+    .. warning:: This class is generally not meant to be instantiated
+                 directly, use ``compute_proj_*`` functions instead.
+
+    Parameters
+    ----------
+    data : dict
+        The data dictionary.
+    desc : str
+        The projector description.
+    kind : int
+        The projector kind.
+    active : bool
+        Whether or not the projector has been applied.
+    explained_var : float | None
+        The explained variance (proportion).
     """
 
     def __init__(self, *, data, desc='', kind=FIFF.FIFFV_PROJ_ITEM_FIELD,

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -25,6 +25,7 @@ class Projection(dict):
 
     A basic class to proj a meaningful print for projection vectors.
     """
+
     def __init__(self, *, data, desc='', kind=FIFF.FIFFV_PROJ_ITEM_FIELD,
                  active=False, explained_var=None):
         super().__init__(desc=desc, kind=kind, active=active, data=data,

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -806,7 +806,7 @@ def make_eeg_average_ref_proj(info, activate=True, verbose=None):
         raise ValueError('Cannot create EEG average reference projector '
                          '(no EEG data found)')
     vec = np.ones((1, n_eeg))
-    vec /= n_eeg
+    vec /= np.sqrt(n_eeg)
     explained_var = None
     eeg_proj_data = dict(col_names=eeg_names, row_names=None,
                          data=vec, nrow=1, ncol=n_eeg)

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -597,7 +597,7 @@ def _make_projector(projs, ch_names, bads=(), include_active=True,
 
             # Rescale for better detection of small singular values
             for v in range(p['data']['nrow']):
-                psize = np.linalg.norm(this_vecs[:, v], axis=0)
+                psize = np.linalg.norm(this_vecs[:, v])
                 if psize > 0:
                     orig_n = p['data']['data'].any(axis=0).sum()
                     # Average ref still works if channels are removed

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -617,12 +617,11 @@ def _make_projector(projs, ch_names, bads=(), include_active=True,
                             'or related functions) with the bad channels '
                             'properly marked, because computing SSP with bad '
                             'channels present in the data but unmarked is '
-                            'dangerous as it can bias PCA during SSP '
-                            'computation. '
-                            'On the other hand, if all channels were good '
-                            'during SSP computation and channels are now '
-                            'just being subselected, you can safely use '
-                            'info.normalize_proj() to suppress this warning.')
+                            'dangerous (it can bias the PCA used by SSP). '
+                            'On the other hand, if you know that all channels '
+                            'were good during SSP computation, you can safely '
+                            'use info.normalize_proj() to suppress this '
+                            'warning.')
                     this_vecs[:, v] /= psize
                     nonzero += 1
             # If doing "inplace" mode, "fix" the projectors to only operate

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -234,6 +234,10 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
             this_proj = other_raw.info['projs'][0]['data']
             assert this_proj['col_names'] == col_names
             assert this_proj['data'].shape == proj['data']['data'].shape
+            assert_allclose(
+                np.linalg.norm(proj['data']['data']), 1., atol=1e-6)
+            assert_allclose(
+                np.linalg.norm(this_proj['data']), 1., atol=1e-6)
             assert_allclose(this_proj['data'], proj['data']['data'])
             proj = other_raw.apply_proj().get_data()
             assert_allclose(proj[picks], data_load_apply_get, atol=1e-10)

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -139,7 +139,7 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
             other_raw.info, meg=meg, eeg=eeg, fnirs=fnirs)
         col_names = [other_raw.ch_names[pick] for pick in picks]
         proj = np.ones((1, len(picks)))
-        proj /= proj.shape[1]
+        proj /= np.sqrt(proj.shape[1])
         proj = Projection(
             data=dict(data=proj, nrow=1, row_names=None,
                       col_names=col_names, ncol=len(picks)),

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -1121,10 +1121,10 @@ def test_inverse_mixed(all_src_types_inv_evoked):
                         ('volume', mne.VolVectorSourceEstimate),
                         ('mixed', mne.MixedVectorSourceEstimate)]:
         assert invs[kind]['src'].kind == kind
-        with pytest.warns(RuntimeWarning, match='has magnitude'):
+        with pytest.warns(RuntimeWarning, match='has been reduced'):
             stc = apply_inverse(evoked, invs[kind])
         assert isinstance(stc, klass._scalar_class)
-        with pytest.warns(RuntimeWarning, match='has magnitude'):
+        with pytest.warns(RuntimeWarning, match='has been reduced'):
             stc_vec = apply_inverse(evoked, invs[kind], pick_ori='vector')
         stcs[kind] = stc_vec
         assert isinstance(stc_vec, klass)

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from .epochs import Epochs
 from .utils import check_fname, logger, verbose, _check_option, _check_fname
+from .io.constants import FIFF
 from .io.open import fiff_open
 from .io.pick import pick_types, pick_types_forward
 from .io.proj import (Projection, _has_eeg_average_ref_proj, _read_proj,
@@ -134,8 +135,9 @@ def _compute_proj(data, info, n_grad, n_mag, n_eeg, desc_prefix,
                              data=u[np.newaxis, :], nrow=1, ncol=u.size)
             this_desc = "%s-%s-PCA-%02d" % (desc, desc_prefix, k + 1)
             logger.info("Adding projection: %s" % this_desc)
-            proj = Projection(active=False, data=proj_data,
-                              desc=this_desc, kind=1, explained_var=var)
+            proj = Projection(
+                active=False, data=proj_data, desc=this_desc,
+                kind=FIFF.FIFFV_PROJ_ITEM_FIELD, explained_var=var)
             projs.append(proj)
 
     return projs


### PR DESCRIPTION
A concrete proposal for #10286:

1. Make the check depend on a 10%+ reduction in projector norm, which is better than looking for a 10% channel count reduction, and 
2. Improve the warning to make it clear that this can be problematic, or not

An alternative idea of adding a `suppress_proj_warning` or so has also been suggested, but I'm -1 on that because I think there are probably dozens of places we'd need to add it (i.e., anywhere that we apply proj -- creating epochs, creating evoked, plotting functions, cov computation, inv computation, ...).

Another alternative is to try to infer a possible problem during `compute_proj_*`, but I think that's going to be even more difficult given that some legitimate interference patterns are concentrated on a few channels. Warning later is admittedly a bit more annoying, but it also leverages additional information (i.e., that the user has potentially marked channels as bad now) that we don't have during the initial SSP computation. So I think the doc update here is enough to take care of the problem well enough.

@jasmainak would this have saved you some pain?

We could adapt my little example from #10286 into an example or tutorial, but I think it's a bit overkill...

Closes #10286