### PR TITLE
[MRG] Implement map_surface parameter for Brain.add_foci

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -100,6 +100,8 @@ Enhancements
 
 - The new convenience function :func:`mne.event.match_event_names` allows for straightforward checking if a specific event name or a group of events is present in a collection of event names (:gh:`10233` by `Richard Höchenberger`_)
 
+- The ``map_surface`` parameter of :meth:`mne.viz.Brain.add_foci` now works and allows you to add foci to a rendering of a brain that are positioned at the vertex of the mesh closest to the given coordinates (:gh:`10299` by `Marijn van Vliet`_)
+
 Bugs
 ~~~~
 

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2616,11 +2616,18 @@ class Brain(object):
 
         if self._units == 'm':
             scale_factor = scale_factor / 1000.
+
+        # List of foci that will be stored in the Brain._data dictionary
+        data_foci = list(self._data[hemi].get('foci', list()))
+
         for _, _, v in self._iter_views(hemi):
             self._renderer.sphere(center=coords, color=color,
                                   scale=(10. * scale_factor),
                                   opacity=alpha, resolution=resolution)
             self._renderer.set_camera(**views_dicts[hemi][v])
+            data_foci.append(coords)
+
+        self._data[hemi]['foci'] = np.vstack(data_foci)
 
     @verbose
     def add_sensors(self, info, trans, meg=None, eeg='original', fnirs=True,

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2617,17 +2617,17 @@ class Brain(object):
         if self._units == 'm':
             scale_factor = scale_factor / 1000.
 
-        # List of foci that will be stored in the Brain._data dictionary
-        data_foci = list(self._data[hemi].get('foci', list()))
-
         for _, _, v in self._iter_views(hemi):
             self._renderer.sphere(center=coords, color=color,
                                   scale=(10. * scale_factor),
                                   opacity=alpha, resolution=resolution)
             self._renderer.set_camera(**views_dicts[hemi][v])
-            data_foci.append(coords)
 
-        self._data[hemi]['foci'] = np.vstack(data_foci)
+        # Store the foci in the Brain._data dictionary
+        data_foci = coords
+        if 'foci' in self._data[hemi]:
+            data_foci = np.vstack((self._data[hemi]['foci'], data_foci))
+        self._data[hemi]['foci'] = data_foci
 
     @verbose
     def add_sensors(self, info, trans, meg=None, eeg='original', fnirs=True,

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -700,13 +700,10 @@ def test_brain_traces(renderer_interactive_pyvistaqt, hemi, src, tmp_path,
     assert hasattr(brain, "_spheres")
     assert brain._scalar_bar.GetNumberOfLabels() == 3
 
-    # add foci should work for volumes
-    if src == 'surface':
-        hemi = 'lh'
-    else:
-        hemi = 'vol'
-    brain.add_foci([[0, 0, 0]], hemi=hemi)
-    assert_array_equal(brain._data[hemi]['foci'], [[0, 0, 0]])
+    # add foci should work for 'lh', 'rh' and 'vol'
+    for current_hemi in hemi_str:
+        brain.add_foci([[0, 0, 0]], hemi=current_hemi)
+        assert_array_equal(brain._data[current_hemi]['foci'], [[0, 0, 0]])
 
     # test points picked by default
     picked_points = brain.get_picked_points()

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -701,8 +701,14 @@ def test_brain_traces(renderer_interactive_pyvistaqt, hemi, src, tmp_path,
     assert brain._scalar_bar.GetNumberOfLabels() == 3
 
     # add foci should work for volumes
-    brain.add_foci([[0, 0, 0]], hemi='lh' if src == 'surface' else 'vol')
-    assert_array_equal(brain._data['lh']['foci'], [[0, 0, 0]])
+    if src == 'surface':
+        hemi = 'lh'
+    else:
+        hemi = 'vol'
+    brain.add_foci([[0, 0, 0]], hemi=hemi)
+    if not np.array_equal(brain._data[hemi]['foci'], [[0, 0, 0]]):
+        breakpoint()
+    assert_array_equal(brain._data[hemi]['foci'], [[0, 0, 0]])
 
     # test points picked by default
     picked_points = brain.get_picked_points()

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -706,8 +706,6 @@ def test_brain_traces(renderer_interactive_pyvistaqt, hemi, src, tmp_path,
     else:
         hemi = 'vol'
     brain.add_foci([[0, 0, 0]], hemi=hemi)
-    if not np.array_equal(brain._data[hemi]['foci'], [[0, 0, 0]]):
-        breakpoint()
     assert_array_equal(brain._data[hemi]['foci'], [[0, 0, 0]])
 
     # test points picked by default

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -1013,7 +1013,7 @@ def _create_testing_brain(hemi, surf='inflated', src='surface',
     return brain_data
 
 
-def test_foci_mapping(tmp_path):
+def test_foci_mapping(tmp_path, renderer_interactive_pyvistaqt):
     """Test mapping foci to the surface."""
     tiny_brain, _ = tiny(tmp_path)
     foci_coords = tiny_brain.geo['lh'].coords[:2] + 0.01

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -702,6 +702,7 @@ def test_brain_traces(renderer_interactive_pyvistaqt, hemi, src, tmp_path,
 
     # add foci should work for volumes
     brain.add_foci([[0, 0, 0]], hemi='lh' if src == 'surface' else 'vol')
+    assert_array_equal(brain._data['lh']['foci'], [[0, 0, 0]])
 
     # test points picked by default
     picked_points = brain.get_picked_points()
@@ -1010,3 +1011,12 @@ def _create_testing_brain(hemi, surf='inflated', src='surface',
         clim=clim, src=sample_src,
         **kwargs)
     return brain_data
+
+
+def test_foci_mapping(tmp_path):
+    """Test mapping foci to the surface."""
+    tiny_brain, _ = tiny(tmp_path)
+    foci_coords = tiny_brain.geo['lh'].coords[:2] + 0.01
+    tiny_brain.add_foci(foci_coords, map_surface='white')
+    assert_array_equal(tiny_brain._data['lh']['foci'],
+                       tiny_brain.geo['lh'].coords[:2])


### PR DESCRIPTION
When adding foci to a plotted brain, the `map_surface` parameter allows the user to project them onto a mesh. This was not implemented in the latest master yet, so I copied over [the relevant code from PySurfer](https://github.com/nipy/PySurfer/blob/master/surfer/viz.py#L1688-L1697). Seems to work nicely. Needs a test maybe?

