### PR TITLE
FIX: notebook label HTML support

### DIFF
--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager, nullcontext
 from IPython.display import display
 from ipywidgets import (Button, Dropdown, FloatSlider, BoundedFloatText, HBox,
                         IntSlider, IntText, Text, VBox, IntProgress, Play,
-                        Checkbox, RadioButtons, jsdlink)
+                        Checkbox, RadioButtons, HTML, jsdlink)
 
 from ._abstract import (_AbstractDock, _AbstractToolBar, _AbstractMenuBar,
                         _AbstractStatusBar, _AbstractLayout, _AbstractWidget,
@@ -70,7 +70,7 @@ class _IpyDock(_AbstractDock, _IpyLayout):
         self, value, *, align=False, layout=None, selectable=False
     ):
         layout = self._dock_layout if layout is None else layout
-        widget = Text(value=value, disabled=True)
+        widget = HTML(value=value, disabled=True)
         self._layout_add_widget(layout, widget)
         return _IpyWidget(widget)
 


### PR DESCRIPTION
This small PR adds HTML support to `notebook`'s dock labels.

main | PR
--|--
![image](https://user-images.githubusercontent.com/18143289/152554073-6a5bf86b-d22b-4c06-ba8d-743f11881902.png) | ![image](https://user-images.githubusercontent.com/18143289/152553886-53e1d0a1-8a55-4bd8-bc2d-f672b1d41866.png)
