### PR TITLE
ENH: collapsible group box

### DIFF
--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -726,15 +726,7 @@ class CoregistrationUI(HasTraits):
 
     def _on_button_release(self, vtk_picker, event):
         if self._mouse_no_mvt > 0:
-            if self._renderer._kind == "notebook":
-                w, h = self._renderer._window_get_size()
-                event = self._renderer.figure.display.logged_events[-1]
-                x = event["offsetX"]
-                offset_y = round(event["clientY"] - event["boundingRectTop"])
-                scale_y = h / self._renderer._canvas_height
-                y = h - round(offset_y * scale_y)
-            else:
-                x, y = vtk_picker.GetEventPosition()
+            x, y = vtk_picker.GetEventPosition()
             # XXX: internal plotter/renderer should not be exposed
             plotter = self._renderer.figure.plotter
             picked_renderer = self._renderer.figure.plotter.renderer

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -726,7 +726,15 @@ class CoregistrationUI(HasTraits):
 
     def _on_button_release(self, vtk_picker, event):
         if self._mouse_no_mvt > 0:
-            x, y = vtk_picker.GetEventPosition()
+            if self._renderer._kind == "notebook":
+                w, h = self._renderer._window_get_size()
+                event = self._renderer.figure.display.logged_events[-1]
+                x = event["offsetX"]
+                offset_y = round(event["clientY"] - event["boundingRectTop"])
+                scale_y = h / self._renderer._canvas_height
+                y = h - round(offset_y * scale_y)
+            else:
+                x, y = vtk_picker.GetEventPosition()
             # XXX: internal plotter/renderer should not be exposed
             plotter = self._renderer.figure.plotter
             picked_renderer = self._renderer.figure.plotter.renderer

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -1290,10 +1290,17 @@ class CoregistrationUI(HasTraits):
         )
 
     def _configure_dock(self):
+        if self._renderer._kind == 'notebook':
+            collapse = True  # collapsible and collapsed
+        else:
+            collapse = None  # not collapsible
         self._renderer._dock_initialize(
             name="Input", area="left", max_width="350px"
         )
-        mri_subject_layout = self._renderer._dock_add_group_box("MRI Subject")
+        mri_subject_layout = self._renderer._dock_add_group_box(
+            name="MRI Subject",
+            collapse=collapse,
+        )
         self._widgets["subjects_dir"] = self._renderer._dock_add_file_button(
             name="subjects_dir",
             desc="Load",
@@ -1316,7 +1323,8 @@ class CoregistrationUI(HasTraits):
         )
 
         mri_fiducials_layout = self._renderer._dock_add_group_box(
-            "MRI Fiducials"
+            name="MRI Fiducials",
+            collapse=collapse,
         )
         # Add MRI fiducials I/O widgets
         self._widgets['mri_fiducials_label'] = self._renderer._dock_add_label(
@@ -1387,8 +1395,10 @@ class CoregistrationUI(HasTraits):
         self._renderer._layout_add_widget(
             mri_fiducials_layout, fiducial_coords_layout)
 
-        dig_source_layout = \
-            self._renderer._dock_add_group_box("Info source with digitization")
+        dig_source_layout = self._renderer._dock_add_group_box(
+            name="Info source with digitization",
+            collapse=collapse,
+        )
         self._widgets["info_file"] = self._renderer._dock_add_file_button(
             name="info_file",
             desc="Load",
@@ -1431,8 +1441,10 @@ class CoregistrationUI(HasTraits):
         )
         self._renderer._layout_add_widget(dig_source_layout, omit_hsp_layout)
 
-        view_options_layout = \
-            self._renderer._dock_add_group_box("View Options")
+        view_options_layout = self._renderer._dock_add_group_box(
+            name="View Options",
+            collapse=collapse,
+        )
         self._widgets["helmet"] = self._renderer._dock_add_check_box(
             name="Show MEG helmet",
             value=self._helmet,
@@ -1461,8 +1473,10 @@ class CoregistrationUI(HasTraits):
         self._renderer._dock_initialize(
             name="Parameters", area="right", max_width="350px"
         )
-        mri_scaling_layout = \
-            self._renderer._dock_add_group_box(name="MRI Scaling")
+        mri_scaling_layout = self._renderer._dock_add_group_box(
+            name="MRI Scaling",
+            collapse=collapse,
+        )
         self._widgets["scaling_mode"] = self._renderer._dock_add_combo_box(
             name="Scaling Mode",
             value=self._defaults["scale_mode"],
@@ -1529,7 +1543,9 @@ class CoregistrationUI(HasTraits):
         self._renderer._layout_add_widget(
             mri_scaling_layout, subject_to_layout)
         param_layout = self._renderer._dock_add_group_box(
-            "Translation (t) and Rotation (r)")
+            name="Translation (t) and Rotation (r)",
+            collapse=collapse,
+        )
         for coord in coords:
             coord_layout = self._renderer._dock_add_layout(vertical=False)
             for mode, mode_name in (("t", "Translation"), ("r", "Rotation")):
@@ -1571,7 +1587,9 @@ class CoregistrationUI(HasTraits):
         )
         self._renderer._layout_add_widget(param_layout, fit_layout)
         trans_layout = self._renderer._dock_add_group_box(
-            "HEAD <> MRI Transform")
+            name="HEAD <> MRI Transform",
+            collapse=collapse,
+        )
         save_trans_layout = self._renderer._dock_add_layout(vertical=False)
         self._widgets["save_trans"] = self._renderer._dock_add_file_button(
             name="save_trans",
@@ -1602,8 +1620,10 @@ class CoregistrationUI(HasTraits):
         )
         self._renderer._layout_add_widget(trans_layout, save_trans_layout)
 
-        fitting_options_layout = \
-            self._renderer._dock_add_group_box("Fitting Options")
+        fitting_options_layout = self._renderer._dock_add_group_box(
+            name="Fitting Options",
+            collapse=collapse,
+        )
         self._widgets["fit_label"] = self._renderer._dock_add_label(
             value="",
             layout=fitting_options_layout,

--- a/mne/gui/tests/test_gui_api.py
+++ b/mne/gui/tests/test_gui_api.py
@@ -184,7 +184,8 @@ def test_gui_api(renderer_notebook, nbexec):
 
     renderer._dock_initialize(name='', area='right')
     renderer._dock_named_layout(name='')
-    renderer._dock_add_group_box(name='')
+    for collapse in (None, True, False):
+        renderer._dock_add_group_box(name='', collapse=collapse)
     renderer._dock_add_stretch()
     renderer._dock_add_layout()
     renderer._dock_finalize()

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -571,7 +571,7 @@ class _AbstractDock(ABC):
         pass
 
     @abstractmethod
-    def _dock_add_group_box(self, name, *, layout=None):
+    def _dock_add_group_box(self, name, *, collapse=None, layout=None):
         pass
 
     @abstractmethod

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -516,7 +516,7 @@ class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
         if self.figure.display is not None:
             self.figure.display.update_canvas()
 
-    def _create_default_tool_bar(self):
+    def _display_default_tool_bar(self):
         self._tool_bar_load_icons()
         self._tool_bar_initialize()
         self._tool_bar_add_file_button(
@@ -524,6 +524,7 @@ class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
             desc="Take a screenshot",
             func=self.screenshot,
         )
+        display(self._tool_bar)
 
     def show(self):
         # menu bar
@@ -533,7 +534,7 @@ class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
         if self._tool_bar is not None:
             display(self._tool_bar)
         else:
-            self._create_default_tool_bar()
+            self._display_default_tool_bar()
         # viewer
         viewer = self.plotter.show(
             jupyter_backend="ipyvtklink", return_viewer=True)

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -28,13 +28,12 @@ class _IpyLayout(_AbstractLayout):
         if not isinstance(widget, Play):
             widget.layout.min_width = "0px"
         if isinstance(layout, Accordion):
-            children = list(layout._vbox.children)
-            children.append(widget)
-            layout._vbox.children = tuple(children)
+            box = layout.children[0]
         else:
-            children = list(layout.children)
-            children.append(widget)
-            layout.children = tuple(children)
+            box = layout
+        children = list(box.children)
+        children.append(widget)
+        box.children = tuple(children)
         # Fix columns
         if self._layout_max_width is not None and isinstance(widget, HBox):
             children = widget.children
@@ -183,7 +182,6 @@ class _IpyDock(_AbstractDock, _IpyLayout):
                 hlayout.selected_index = None
             else:
                 hlayout.selected_index = 0
-            hlayout._vbox = vbox
         self._layout_add_widget(layout, hlayout)
         return hlayout
 

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -172,7 +172,7 @@ class _IpyDock(_AbstractDock, _IpyLayout):
     def _dock_add_group_box(self, name, *, collapse=None, layout=None):
         layout = self._dock_layout if layout is None else layout
         if collapse is None:
-            hlayout = VBox([Text(name)])
+            hlayout = VBox([HTML("<strong>" + name + "</strong>")])
         else:
             assert isinstance(collapse, bool)
             vbox = VBox()

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -10,7 +10,6 @@ from IPython.display import display
 from ipywidgets import (Button, Dropdown, FloatSlider, BoundedFloatText, HBox,
                         IntSlider, IntText, Text, VBox, IntProgress, Play,
                         Checkbox, RadioButtons, HTML, Accordion, jsdlink)
-from ipyevents import Event
 
 from ._abstract import (_AbstractDock, _AbstractToolBar, _AbstractMenuBar,
                         _AbstractStatusBar, _AbstractLayout, _AbstractWidget,
@@ -510,8 +509,6 @@ class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
         self._menu_bar = None
         self._tool_bar = None
         self._status_bar = None
-        self._event_manager = Event()
-        self._canvas_height = None
         kwargs["notebook"] = True
         super().__init__(*args, **kwargs)
 
@@ -529,23 +526,6 @@ class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
         )
         display(self._tool_bar)
 
-    def _dom_event_callback(self, event):
-        if "boundingRectHeight" in event and self._canvas_height is None:
-            self._canvas_height = event["boundingRectHeight"]
-
-    def _configure_event_manager(self, source):
-        allowed_events = [
-            "mouseenter",
-            "mouseleave",
-            "mousedown",
-            "mouseup",
-            "mousemove",
-        ]
-        self._event_manager.watched_events = allowed_events
-        self._event_manager.source = source
-        self._event_manager.on_dom_event(
-            self._dom_event_callback)
-
     def show(self):
         # menu bar
         if self._menu_bar is not None:
@@ -559,9 +539,6 @@ class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
         viewer = self.plotter.show(
             jupyter_backend="ipyvtklink", return_viewer=True)
         viewer.layout.width = None  # unlock the fixed layout
-        viewer.layout.object_fit = 'contain'  # respect the aspect ratio
-        viewer.layout.object_position = 'top'
-        self._configure_event_manager(viewer)
         rendering_row = list()
         if self._docks is not None and "left" in self._docks:
             rendering_row.append(self._docks["left"][0])

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -540,6 +540,7 @@ class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
         viewer = self.plotter.show(
             jupyter_backend="ipyvtklink", return_viewer=True)
         viewer.layout.width = None  # unlock the fixed layout
+        viewer.layout.object_fit = 'contain'
         rendering_row = list()
         if self._docks is not None and "left" in self._docks:
             rendering_row.append(self._docks["left"][0])

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -540,7 +540,7 @@ class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
         viewer = self.plotter.show(
             jupyter_backend="ipyvtklink", return_viewer=True)
         viewer.layout.width = None  # unlock the fixed layout
-        viewer.layout.object_fit = 'contain'
+        viewer.layout.object_fit = 'contain'  # respect the aspect ratio
         rendering_row = list()
         if self._docks is not None and "left" in self._docks:
             rendering_row.append(self._docks["left"][0])

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -205,7 +205,7 @@ class _QtDock(_AbstractDock, _QtLayout):
         self._layout_add_widget(layout, group_layout)
         return _QtWidgetList(group)
 
-    def _dock_add_group_box(self, name, *, layout=None):
+    def _dock_add_group_box(self, name, *, collapse=None, layout=None):
         layout = self._dock_layout if layout is None else layout
         hlayout = QVBoxLayout()
         widget = QGroupBox(name)


### PR DESCRIPTION
This PR adds support for collapsible group boxes for the `notebook` 3d backend. Here is an example with coreg:

main | PR
--|--
![image](https://user-images.githubusercontent.com/18143289/152564896-e895f048-0d50-4c8b-9197-546061ed21f0.png) | ![image](https://user-images.githubusercontent.com/18143289/152564800-c008569c-5e0f-4442-951c-26055696542f.png)

*I know the main render view still appears stretched, there might be way to fix its size somehow*


It's an item of #8833