### PR TITLE
Addressed bug in the assignment of info['meas_date'] from a rawMFF object.

### DIFF
--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -213,11 +213,11 @@ def _read_header(input_fname):
         version = np.fromfile(fid, np.int32, 1)[0]
     # Proposed change
     # the  line of code just below parses the string  in
-    # mff['date'] as a datetime object localised in UTC
+    # mff_hdr['date'] as a datetime object localised in UTC
     # You can delete this comment after reviewing.
     time_n = (datetime.datetime.strptime(
-              mff_hdr['date'], '%Y-%m-%dT%H:%M:%S.%f%z').astimezone(datetime.timezone.utc)
-             )
+              mff_hdr['date'], '%Y-%m-%dT%H:%M:%S.%f%z')
+              .astimezone(datetime.timezone.utc))
     info = dict(
         version=version,
         year=int(time_n.strftime('%Y')),
@@ -452,11 +452,13 @@ class RawMff(BaseRaw):
             event_codes = []
         import calendar
         info = _empty_info(egi_info['sfreq'])
-        #assigning tzinfo below isnt strictly necessary, but for the sake of being explicitly clear about the timezone:
+        # assigning tzinfo below isnt strictly necessary,
+        # but for the sake of being explicitly clear about the timezone:
         my_time = datetime.datetime(
             egi_info['year'], egi_info['month'], egi_info['day'],
-            egi_info['hour'], egi_info['minute'], egi_info['second'], tzinfo=datetime.timezone.utc)
-        #timetuple() would also  return the same value as utctimetuple()
+            egi_info['hour'], egi_info['minute'], egi_info['second'],
+            tzinfo=datetime.timezone.utc)
+        # timetuple() would also  return the same value as utctimetuple()
         my_timestamp = calendar.timegm(my_time.utctimetuple())
         info['meas_date'] = _ensure_meas_date_none_or_dt((my_timestamp, 0))
         info['device_info'] = dict(type=egi_info['device'])


### PR DESCRIPTION
Example: Fixes #10256.
https://github.com/mne-tools/mne-python/issues/10256



#### What does this implement/fix?
the `mktime()` function on line 459 of `egimff.py` assumes the `timetuple` passed in is in local time. But since a timetuple() doesn't contain timezone information (there isn't any timezone field in a timetuple), `mktime()` has to assume that the timezone is the local time. This can create unexpected results depending on the time zone of the machine reading in the data (as I demonstrated in issue 10256).

Eric Larson also stated that read_egi_raw() should detect the time zone offset, and remove it to get to UTC, and store the offset in info['utc_offset'].

I amended the code on lines ~221/222, to parse the timestamp provided by EGI ( `mff_hdr['date']` ) and return a datetime object in UTC. 

- On lines ~456-460, I replaced the `mktime()` function with `calendar.gmtime()`, to read in the timetuple, which is  now in UTC. note that as opposed to `mktime()`, `calendar.gmtime` always assumes the passed in timetuple() is in UTC.


#### Additional information

1. I tested my code on both the computers that I used to report my issue (10256). I also tested out my code on MFF files that were recorded during and outside of daylight savings time, and info['meas_date'] returned the correct time stamp each time. Basically, as long as EGI properly assigned the UTC offset in their timestamp string, according to the users geographic location and accounting for DST if needed, the code will work without issues. to be sure of this, I checked several MFF files that were collected in different regions during and outside of DST, and EGI assigned the correct  UTC offset each time.


1. To me, It would seem that just  returning `time_n` (our datetime object generated on line 218) from the `mff_hdr` function, and assigning info['meas_date'] to `time_n` , would be the simpler approach. This way, the milliseconds information is preserved in info['meas_date'] (timetuples don't contain a milliseconds field, so this information currently gets lost on line 459). However, I wasn't sure if the previous developers had a reason for their approach, which was to return certain directives of `time_n` out of the `mff_hdr` function, then create a new datetime object from those directives, then convert the new datetime object into a POSIX time stamp, and finally convert that POSIX timestamp back into a final datetime object.

2. Eric Larson mentioned that read_egi_raw() should return a value `info['utc_offset']`. Even before I amended any code, info['utc_offset'] always returned a `NoneType` for me. I'm not sure where in the code this object is assigned, but we could easily retrieve the utc_offset with:

`datetime.datetime.strptime(mff_hdr[date],'%Y-%m-%dT%H:%M:%S.%f%z').strftime('%z')`, which for example returns `-0800`, when `mff_hdr['date']` = '2019-08-29T12:41:01.414000-08:00'
