### PR TITLE
[ENH, MRG] PSD multitaper per taper

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -28,6 +28,8 @@ Enhancements
 
 - Fix some unused variables in time_frequency_erds.py example (:gh:`10076` by :newcontrib:`Jan Zerfowski`)
 
+- :func:`mne.time_frequency.psd_array_multitaper` can now return complex results per-taper when specifying ``output='complex'`` (:gh:`10307` by `Mikołaj Magnuski`_)
+
 - :func:`mne.time_frequency.tfr_array_multitaper` can now return results for ``output='phase'`` instead of an error (:gh:`10281` by `Mikołaj Magnuski`_)
 
 - Add show local maxima toggling button to :func:`mne.gui.locate_ieeg` (:gh:`9952` by `Alex Rockhill`_)

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -388,11 +388,9 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
     %(normalization)s
     output : str
         The format of the returned ``psds`` array. Can be either ``'complex'``
-        or ``'power'``. If ``'power'`` and normalization is ``'full'``, the
-        power spectral density (per Hz) is returned. If ``'power'`` and
-        normalization is ``'length'``, the power spectral density (per sample)
-        is returned. If ``output='complex'``, the complex fourier
-        coefficients are returned per taper.
+        or ``'power'``. If ``'power'``, the power spectral density is returned.
+         If ``output='complex'``, the complex fourier coefficients are returned
+         per taper.
     %(n_jobs)s
     %(verbose)s
 

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -437,7 +437,7 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
     n_freqs = len(freqs)
 
     if output == 'complex':
-        psd = np.zeros((x.shape[0], n_tapers, n_freqs))
+        psd = np.zeros((x.shape[0], n_tapers, n_freqs), dtype='complex')
     else:
         psd = np.zeros((x.shape[0], n_freqs))
 
@@ -455,7 +455,7 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
                 parallel, my_psd_from_mt_adaptive, n_jobs = \
                     parallel_func(_psd_from_mt_adaptive, n_splits)
                 out = parallel(my_psd_from_mt_adaptive(x, eigvals, freq_mask)
-                            for x in np.array_split(x_mt, n_splits))
+                               for x in np.array_split(x_mt, n_splits))
                 psd[start:stop] = np.concatenate(out)
         else:
             psd[start:stop] = x_mt[:, :, freq_mask]

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -389,8 +389,8 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
     output : str
         The format of the returned ``psds`` array. Can be either ``'complex'``
         or ``'power'``. If ``'power'``, the power spectral density is returned.
-         If ``output='complex'``, the complex fourier coefficients are returned
-         per taper.
+        If ``output='complex'``, the complex fourier coefficients are returned
+        per taper.
     %(n_jobs)s
     %(verbose)s
 

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -386,14 +386,21 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
         Only use tapers with more than 90%% spectral concentration within
         bandwidth.
     %(normalization)s
+    output : str
+        The format of the returned ``psds`` array. Can be either ``'complex'``
+        or ``'power'``. If ``'power'`` and normalization is ``'full'``, the
+        power spectral density (per Hz) is returned. If ``'power'`` and
+        normalization is ``'length'``, the power spectral density (per sample)
+        is returned. If ``output='complex'``, the complex fourier
+        coefficients are returned per taper.
     %(n_jobs)s
     %(verbose)s
 
     Returns
     -------
-    psds : ndarray, shape (..., n_freqs) or
-        The power spectral densities. All dimensions up to the last will
-        be the same as input.
+    psds : ndarray, shape (..., n_freqs) or (..., n_tapers, n_freqs)
+        The power spectral densities. All dimensions up to the last (or the
+        last two if ``output='complex'``) will be the same as input.
     freqs : array
         The frequency points in Hz of the PSD.
 

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -458,7 +458,6 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
                             for x in np.array_split(x_mt, n_splits))
                 psd[start:stop] = np.concatenate(out)
         else:
-            print('data shape:', dshape, 'x_mt shape:', x_mt.shape)
             psd[start:stop] = x_mt[:, :, freq_mask]
 
     if normalization == 'full':

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -401,6 +401,9 @@ def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
         last two if ``output='complex'``) will be the same as input.
     freqs : array
         The frequency points in Hz of the PSD.
+    weights : ndarray
+        The weights used for averaging across tapers. Only returned if
+        ``output='complex'``.
 
     See Also
     --------

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -120,7 +120,6 @@ def test_psd():
     psd, freq = psd_array_multitaper(
         raw._data[:4, :500], raw.info['sfreq'], output='power')
     assert psd_complex.ndim == 3  # channels x tapers x freqs
-    print(weights.shape)
     psd_from_complex = _psd_from_mt(psd_complex, weights)
     assert_allclose(psd_from_complex, psd)
 

--- a/mne/time_frequency/tests/test_psd.py
+++ b/mne/time_frequency/tests/test_psd.py
@@ -7,7 +7,9 @@ import pytest
 from mne import pick_types, Epochs, read_events
 from mne.io import RawArray, read_raw_fif
 from mne.utils import catch_logging
-from mne.time_frequency import psd_welch, psd_multitaper, psd_array_welch
+from mne.time_frequency import (psd_welch, psd_array_welch, psd_multitaper,
+                                psd_array_multitaper)
+from mne.time_frequency.multitaper import _psd_from_mt
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
@@ -111,6 +113,16 @@ def test_psd():
         psd_welch(raw, proj=False, **kws_psd)
     with pytest.raises(ValueError, match='No frequencies found'):
         psd_array_welch(np.zeros((1, 1000)), 1000., fmin=10, fmax=1)
+
+    # -- psd_array_multitaper --
+    psd_complex, freq, weights = psd_array_multitaper(
+        raw._data[:4, :500], raw.info['sfreq'], output='complex')
+    psd, freq = psd_array_multitaper(
+        raw._data[:4, :500], raw.info['sfreq'], output='power')
+    assert psd_complex.ndim == 3  # channels x tapers x freqs
+    print(weights.shape)
+    psd_from_complex = _psd_from_mt(psd_complex, weights)
+    assert_allclose(psd_from_complex, psd)
 
     # -- Epochs/Evoked --
     events = read_events(event_fname)


### PR DESCRIPTION
#### Reference issue
Continuation of my previos PR (#10281).

#### What does this implement/fix?
This time per taper results can be obtained from `psd_array_multitaper` as well.

#### Additional information
This required adding an `output` arg to `psd_array_multitaper`, when `output='complex'` the `psd` array has tapers dimension. I also return `weights` in that case as well, but I'm not sure about this - the weights are generally marginally different from 1, so returning weights might not be needed (and it is not done in the `tfr_array_multitaper`, which does not use any weights, assuming they are all 1). However, weights might be useful at least for testing to check that we can get the same power results from complex output.

#### Remainging tasks
- [x] decide whether to return the weights or not
- [x] add test
- [x] update whats new
