### PR TITLE
[ENH]: Raise pyqtgraph-browser like matplotlib

### DIFF
--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -138,10 +138,14 @@ def _show_browser(show=True, block=True, fig=None, **kwargs):
     if backend == 'matplotlib':
         plt_show(show, block=block, **kwargs)
     else:
+        from matplotlib import rcParams
         from PyQt5.QtWidgets import QApplication
         from .backends._utils import _qt_app_exec
         if show:
             fig.show()
+            if rcParams['figure.raise_window']:
+                fig.activateWindow()
+                fig.raise_()
         # If block=False, a Qt-Event-Loop has to be started
         # somewhere else in the calling code.
         if block:


### PR DESCRIPTION
#### Reference issue
This should fix mne-tools/mne-qt-browser#34.

#### What does this implement/fix?
Depending on `matplotlib.rcParams['figure.raise_window']`, pyqtgraph-browser raise to the front like matplotlib-browser as suggested by @mscheltienne .