### PR TITLE
MAINT: Add paths for mne-nirs

### DIFF
--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -135,6 +135,8 @@ known_config_types = (
 # These allow for partial matches, e.g. 'MNE_STIM_CHANNEL_1' is okay key
 known_config_wildcards = (
     'MNE_STIM_CHANNEL',
+    'MNE_DATASETS_FNIRS',
+    'MNE_NIRS',
 )
 
 
@@ -279,7 +281,7 @@ def set_config(key, value, home_dir=None, set_env=True):
         value = str(value)
 
     if key not in known_config_types and not \
-            any(k in key for k in known_config_wildcards):
+            any(key.startswith(k) for k in known_config_wildcards):
         warn('Setting non-standard config type: "%s"' % key)
 
     # Read all previous values


### PR DESCRIPTION
Just adds some paths useful for MNE-NIRS (see https://github.com/mne-tools/mne-nirs/pull/444 and https://github.com/mne-tools/mne-nirs/blob/83ad54d018f2a3ed3e4e4ab3111a5541520dd3ae/mne_nirs/conftest.py#L14-L17 ). This makes the checking less strict than it could be by adding config vars one by one, but it makes maintenance at the MNE-Python end easier because we just use the (improved) wildcard support here to allow any `MNE_NIRS*` and `MNE_DATASETS_FNIRS*`, so we don't need a PR here any time mne-nirs wants to add a new config var.