### PR TITLE
FIX: set background color in raw.plot()

### DIFF
--- a/mne/viz/_mpl_figure.py
+++ b/mne/viz/_mpl_figure.py
@@ -363,6 +363,8 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
         # this only gets shown in zen mode
         self.mne.zen_xlabel = ax_main.set_xlabel(xlabel)
         self.mne.zen_xlabel.set_visible(not self.mne.scrollbars_visible)
+        # make sure background color of the axis is set
+        ax_main.set_facecolor(kwargs['bgcolor'])
 
         # SCROLLBARS
         ax_hscroll = div.append_axes(position='bottom',

--- a/mne/viz/_mpl_figure.py
+++ b/mne/viz/_mpl_figure.py
@@ -364,7 +364,8 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
         self.mne.zen_xlabel = ax_main.set_xlabel(xlabel)
         self.mne.zen_xlabel.set_visible(not self.mne.scrollbars_visible)
         # make sure background color of the axis is set
-        ax_main.set_facecolor(kwargs['bgcolor'])
+        if 'bgcolor' in kwargs:
+            ax_main.set_facecolor(kwargs['bgcolor'])
 
         # SCROLLBARS
         ax_hscroll = div.append_axes(position='bottom',

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -345,6 +345,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
                   scrollbars_visible=show_scrollbars,
                   scalebars_visible=show_scalebars,
                   window_title=title,
+                  bgcolor=bgcolor,
                   # pyqtgraph-specific
                   precompute=precompute,
                   use_opengl=use_opengl)


### PR DESCRIPTION
#### Reference issue
Example: Fixes #10314.


#### What does this implement/fix?
`bgcolor` argument was ignored by raw plotter.

```python
import os.path as op
import mne

pth = op.join(mne.datasets.sample.data_path(), 'MEG', 'sample')
fname = 'sample_audvis_raw.fif'
raw = mne.io.read_raw(op.join(pth, fname))
raw.plot(bgcolor='red')
```
on main branch the `bgcolor` does not lead to any observable effects. Now it looks like this:
<img src=https://user-images.githubusercontent.com/8452354/153425087-cfac244f-73cd-446f-96d3-97c574410b09.png width="70%">


#### TODOs:
- [ ] add test
- [ ] whats new
- [ ] check if other plotters need this change?
