### PR TITLE
MNT: License of the material design icons

### DIFF
--- a/mne/icons/README.rst
+++ b/mne/icons/README.rst
@@ -20,4 +20,4 @@ To automatically generate the resource file in ``mne/icons``:
 These Material design icons are provided by Google under the `Apache 2.0`_ license.
 
 
-   .. _Apache 2.0: https://github.com/google/material-design-icons/blob/master/LICENSE
+.. _Apache 2.0: https://github.com/google/material-design-icons/blob/master/LICENSE


### PR DESCRIPTION
As @marsipu and I realized, the google material design icons used in the brain app's tool bar (`plot_stc`) are licensed under apache 2.0. This PR refers to the license.

cc @larsoner 