### PR TITLE
MNT: Depth-peeling 3d option

### DIFF
--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -225,7 +225,6 @@ class CoregistrationUI(HasTraits):
         # setup the window
         self._renderer = _get_renderer(
             size=self._defaults["size"], bgcolor=self._defaults["bgcolor"])
-        self._renderer._enable_depth_peeling()
         self._renderer._window_close_connect(self._clean)
         self._renderer.set_interaction(interaction)
         self._renderer._status_bar_initialize()

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -225,7 +225,7 @@ class CoregistrationUI(HasTraits):
         # setup the window
         self._renderer = _get_renderer(
             size=self._defaults["size"], bgcolor=self._defaults["bgcolor"])
-        self._renderer.enable_depth_peeling()
+        self._renderer._enable_depth_peeling()
         self._renderer._window_close_connect(self._clean)
         self._renderer.set_interaction(interaction)
         self._renderer._status_bar_initialize()

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -68,6 +68,7 @@ def set_memmap_min_size(memmap_min_size):
 # List the known configuration values
 known_config_types = (
     'MNE_3D_OPTION_ANTIALIAS',
+    'MNE_3D_OPTION_DEPTH_PEELING',
     'MNE_BROWSE_RAW_SIZE',
     'MNE_BROWSER_BACKEND',
     'MNE_BROWSER_USE_OPENGL',

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -3293,16 +3293,17 @@ def set_3d_options(antialias=None, depth_peeling=None):
     Parameters
     ----------
     antialias : bool | None
-        If not None, set the default full-screen anti-aliasing setting.
+        If bool, whether to enable or disable full-screen anti-aliasing.
         False is useful when renderers have problems (such as software
-        MESA renderers). This option can also be controlled using an
-        environment variable, e.g., ``MNE_3D_OPTION_ANTIALIAS=false``.
+        MESA renderers). If None, use the default  setting. This option
+        can also be controlled using an environment variable, e.g.,
+        ``MNE_3D_OPTION_ANTIALIAS=false``.
     depth_peeling : bool | None
-        If not None, set the default setting for accurate transparency.
+        If bool, whether to enable or disable accurate transparency.
         False is useful when renderers have problems (for instance
-        while X forwarding on remote servers). This option can also be
-        controlled using an environment variable, e.g.,
-        ``MNE_3D_OPTION_DEPTH_PEELING=false``.
+        while X forwarding on remote servers). If None, use the default
+        setting. This option can also be controlled using an environment
+        variable, e.g., ``MNE_3D_OPTION_DEPTH_PEELING=false``.
 
     Notes
     -----

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -3291,10 +3291,10 @@ def plot_brain_colorbar(ax, clim, colormap='auto', transparent=True,
 
 
 _3d_options = dict()
-_3d_default = dict(antialias='true')
+_3d_default = dict(antialias='true', depth_peeling='true')
 
 
-def set_3d_options(antialias=None):
+def set_3d_options(antialias=None, depth_peeling=None):
     """Set 3D rendering options.
 
     Parameters
@@ -3304,6 +3304,12 @@ def set_3d_options(antialias=None):
         False is useful when renderers have problems (such as software
         MESA renderers). This option can also be controlled using an
         environment variable, e.g., ``MNE_3D_OPTION_ANTIALIAS=false``.
+    depth_peeling : bool | None
+        If not None, set the default setting for accurate transparency.
+        False is useful when renderers have problems (such as crashes
+        while X forwarding on remote servers). This option can also be
+        controlled using an environment variable, e.g.,
+        ``MNE_3D_OPTION_DEPTH_PEELING=false``.
 
     Notes
     -----
@@ -3311,6 +3317,8 @@ def set_3d_options(antialias=None):
     """
     if antialias is not None:
         _3d_options['antialias'] = str(bool(antialias)).lower()
+    if depth_peeling is not None:
+        _3d_options['depth_peeling'] = str(bool(depth_peeling)).lower()
 
 
 def _get_3d_option(key):

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -3303,7 +3303,7 @@ def set_3d_options(antialias=None, depth_peeling=None):
     antialias : bool | None
         If bool, whether to enable or disable full-screen anti-aliasing.
         False is useful when renderers have problems (such as software
-        MESA renderers). If None, use the default  setting. This option
+        MESA renderers). If None, use the default setting. This option
         can also be controlled using an environment variable, e.g.,
         ``MNE_3D_OPTION_ANTIALIAS=false``.
     depth_peeling : bool | None

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -12,7 +12,6 @@
 
 from itertools import cycle
 import os.path as op
-import sys
 import warnings
 from collections.abc import Iterable
 from functools import partial
@@ -2035,12 +2034,6 @@ def _plot_stc(stc, subject, surface, hemi, colormap, time_label,
         use_kwargs.update(hemi='vol')
         brain.add_data(**use_kwargs)
     del kwargs
-
-    need_peeling = (brain_alpha < 1.0 and
-                    sys.platform != 'darwin' and
-                    vec)
-    if need_peeling:
-        brain.enable_depth_peeling()
 
     if time_viewer:
         brain.setup_time_viewer(time_viewer=time_viewer,

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -15,6 +15,8 @@ import os.path as op
 import warnings
 from collections.abc import Iterable
 from functools import partial
+from dataclasses import dataclass
+from typing import Optional
 
 import numpy as np
 
@@ -3283,8 +3285,14 @@ def plot_brain_colorbar(ax, clim, colormap='auto', transparent=True,
     return cbar
 
 
-_3d_options = dict()
-_3d_default = dict(antialias='true', depth_peeling='true')
+@dataclass()
+class _3d_Options:
+    antialias: Optional[str]
+    depth_peeling: Optional[str]
+
+
+_3d_options = _3d_Options(antialias=None, depth_peeling=None)
+_3d_default = _3d_Options(antialias='true', depth_peeling='true')
 
 
 def set_3d_options(antialias=None, depth_peeling=None):
@@ -3310,16 +3318,17 @@ def set_3d_options(antialias=None, depth_peeling=None):
     .. versionadded:: 0.21.0
     """
     if antialias is not None:
-        _3d_options['antialias'] = str(bool(antialias)).lower()
+        _3d_options.antialias = str(bool(antialias)).lower()
     if depth_peeling is not None:
-        _3d_options['depth_peeling'] = str(bool(depth_peeling)).lower()
+        _3d_options.depth_peeling = str(bool(depth_peeling)).lower()
 
 
 def _get_3d_option(key):
-    try:
-        opt = _3d_options[key]
-    except KeyError:
-        opt = get_config(f'MNE_3D_OPTION_{key.upper()}', _3d_default[key])
+    _validate_type(key, 'str', 'key')
+    opt = getattr(_3d_options, key)
+    if opt is None:
+        default_value = getattr(_3d_default, key)
+        opt = get_config(f'MNE_3D_OPTION_{key.upper()}', default_value)
     opt = opt.lower()
     _check_option(f'3D option {key}', opt, ('true', 'false'))
     return opt == 'true'

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -3306,7 +3306,7 @@ def set_3d_options(antialias=None, depth_peeling=None):
         environment variable, e.g., ``MNE_3D_OPTION_ANTIALIAS=false``.
     depth_peeling : bool | None
         If not None, set the default setting for accurate transparency.
-        False is useful when renderers have problems (such as crashes
+        False is useful when renderers have problems (for instance
         while X forwarding on remote servers). This option can also be
         controlled using an environment variable, e.g.,
         ``MNE_3D_OPTION_DEPTH_PEELING=false``.

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -3690,8 +3690,7 @@ class Brain(object):
     @deprecated('enable_depth_peeling is deprecated and will be '
                 'removed in 1.1')
     def enable_depth_peeling(self):
-        """Enable depth peeling.
-        """
+        """Enable depth peeling."""
         self._renderer._enable_depth_peeling()
 
     def get_picked_points(self):

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -3690,7 +3690,8 @@ class Brain(object):
     @deprecated('enable_depth_peeling is deprecated and will be '
                 'removed in 1.1')
     def enable_depth_peeling(self):
-        """Enable depth peeling."""
+        """Enable depth peeling.
+        """
         self._renderer._enable_depth_peeling()
 
     def get_picked_points(self):

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -3691,7 +3691,7 @@ class Brain(object):
 
     def enable_depth_peeling(self):
         """Enable depth peeling."""
-        self._renderer.enable_depth_peeling()
+        self._renderer._enable_depth_peeling()
 
     def get_picked_points(self):
         """Return the vertices of the picked points.

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -27,7 +27,8 @@ from .callback import (ShowView, TimeCallBack, SmartCallBack,
                        UpdateLUT, UpdateColorbarScale)
 
 from ..utils import (_show_help_fig, _get_color_list, concatenate_images,
-                     _generate_default_filename, _save_ndarray_img, safe_event)
+                     _generate_default_filename, _save_ndarray_img, safe_event,
+                     deprecated)
 from .._3d import (_process_clim, _handle_time, _check_views,
                    _handle_sensor_types, _plot_sensors)
 from ...defaults import _handle_default, DEFAULTS
@@ -391,8 +392,6 @@ class Brain(object):
        | :meth:`show_view`                   | ✓            | ✓             |
        +-------------------------------------+--------------+---------------+
        | TimeViewer                          | ✓            | ✓             |
-       +-------------------------------------+--------------+---------------+
-       | :meth:`enable_depth_peeling`        |              | ✓             |
        +-------------------------------------+--------------+---------------+
        | :meth:`get_picked_points`           |              | ✓             |
        +-------------------------------------+--------------+---------------+
@@ -3689,6 +3688,8 @@ class Brain(object):
             show[keep_idx] = 1
             label *= show
 
+    @deprecated('enable_depth_peeling is deprecated and will be '
+                'removed in 1.1')
     def enable_depth_peeling(self):
         """Enable depth peeling."""
         self._renderer._enable_depth_peeling()

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -27,8 +27,7 @@ from .callback import (ShowView, TimeCallBack, SmartCallBack,
                        UpdateLUT, UpdateColorbarScale)
 
 from ..utils import (_show_help_fig, _get_color_list, concatenate_images,
-                     _generate_default_filename, _save_ndarray_img, safe_event,
-                     deprecated)
+                     _generate_default_filename, _save_ndarray_img, safe_event)
 from .._3d import (_process_clim, _handle_time, _check_views,
                    _handle_sensor_types, _plot_sensors)
 from ...defaults import _handle_default, DEFAULTS
@@ -43,7 +42,7 @@ from ...source_space import SourceSpaces
 from ...transforms import (apply_trans, invert_transform, _get_trans,
                            _get_transforms_to_coord_frame)
 from ...utils import (_check_option, logger, verbose, fill_doc, _validate_type,
-                      use_log_level, Bunch, _ReuseCycle, warn,
+                      use_log_level, Bunch, _ReuseCycle, warn, deprecated,
                       get_subjects_dir, _check_fname, _to_rgb)
 
 

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -446,11 +446,6 @@ class _AbstractRenderer(ABC):
         pass
 
     @abstractclassmethod
-    def enable_depth_peeling(self):
-        """Enable depth peeling."""
-        pass
-
-    @abstractclassmethod
     def remove_mesh(self, mesh_data):
         """Remove the given mesh from the scene.
 

--- a/tutorials/clinical/20_seeg.py
+++ b/tutorials/clinical/20_seeg.py
@@ -147,7 +147,6 @@ brain = mne.viz.Brain('fsaverage', alpha=0.1, cortex='low_contrast',
                       subjects_dir=subjects_dir, units='m', figure=fig)
 brain.add_volume_labels(aseg='aparc+aseg', labels=labels)
 brain.show_view(azimuth=120, elevation=90, distance=0.25)
-brain.enable_depth_peeling()
 
 # %%
 # Next, we'll get the epoch data and plot its amplitude over time.

--- a/tutorials/inverse/60_visualize_stc.py
+++ b/tutorials/inverse/60_visualize_stc.py
@@ -163,7 +163,6 @@ brain = mne.viz.Brain('sample', hemi='both', surf='pial', alpha=0.5,
                       cortex='low_contrast', subjects_dir=subjects_dir)
 brain.add_volume_labels(aseg='aparc+aseg', labels=labels)
 brain.show_view(azimuth=250, elevation=40, distance=400)
-brain.enable_depth_peeling()
 
 # %%
 # And we can project these label time courses back to their original

--- a/tutorials/io/30_reading_fnirs_data.py
+++ b/tutorials/io/30_reading_fnirs_data.py
@@ -267,5 +267,4 @@ brain = mne.viz.Brain('fsaverage', subjects_dir=subjects_dir,
                       alpha=0.5, cortex='low_contrast')
 brain.add_head()
 brain.add_sensors(raw.info, trans='fsaverage')
-brain.enable_depth_peeling()
 brain.show_view(azimuth=90, elevation=90, distance=500)


### PR DESCRIPTION
This PR adds a 3d option to control depth peeling to address issues with X forwarding.

It is still work in progress:
- should depth peeling be enabled by default?
- should it be disabled on CircleCI?

In another PR, I plan to refactor the properties of `_PyVistaRenderer` and move them into `_Figure` where I think they should live (the `store` attribute serves this purpose).

cc @hoechenberger 