### PR TITLE
BUG: Fix bug with scaling and fids for standard montages

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -187,6 +187,8 @@ Bugs
 
 - :func:`mne.find_events` now uses ``first_samp`` and not ``0`` for initial event when using ``initial_value`` (:gh:`10289`, by `Alex Gramfort`_)
 
+- Fix bug with :func:`mne.channels.make_standard_montage` for ``'standard*'``, ``'mgh*'``, and ``'artinis*'`` montages where the points were incorrectly scaled and fiducials incorrectly set away from the correct values for use with the ``fsaverage`` subject (:gh:`10324` by `Eric Larson`_)
+
 - Fix plotting bug in :ref:`ex-electrode-pos-2d` and make view look more natural in :ref:`ex-movement-detect` (:gh:`10313`, by `Alex Rockhill`_)
 
 API changes

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -15,7 +15,6 @@ from collections import OrderedDict
 from copy import deepcopy
 import os.path as op
 import re
-from git import HEAD
 
 import numpy as np
 

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -15,6 +15,7 @@ from collections import OrderedDict
 from copy import deepcopy
 import os.path as op
 import re
+from git import HEAD
 
 import numpy as np
 
@@ -1483,16 +1484,19 @@ def compute_native_head_t(montage):
     return Transform(coord_frame, 'head', native_head_t)
 
 
-def make_standard_montage(kind, head_size=HEAD_SIZE_DEFAULT):
+def make_standard_montage(kind, head_size='auto'):
     """Read a generic (built-in) montage.
 
     Parameters
     ----------
     kind : str
         The name of the montage to use. See notes for valid kinds.
-    head_size : float
+    head_size : float | None | str
         The head size (radius, in meters) to use for spherical montages.
-        Defaults to 95mm.
+        Can be None to not scale the read sizes. ``'auto'`` (default) will
+        use 95mm for all montages except the ``'standard*'``, ``'mgh*'``, and
+        ``'artinis*'``, which are already in fsaverage's MRI coordinates
+        (same as MNI).
 
     Returns
     -------
@@ -1566,7 +1570,15 @@ def make_standard_montage(kind, head_size=HEAD_SIZE_DEFAULT):
     .. versionadded:: 0.19.0
     """
     from ._standard_montage_utils import standard_montage_look_up_table
+    _validate_type(kind, str, 'kind')
     _check_option('kind', kind, _BUILT_IN_MONTAGES)
+    _validate_type(head_size, ('numeric', str, None), 'head_size')
+    if isinstance(head_size, str):
+        _check_option('head_size', head_size, ('auto',), extra='when str')
+        if kind.startswith(('standard', 'mgh', 'artinis')):
+            head_size = None
+        else:
+            head_size = HEAD_SIZE_DEFAULT
     return standard_montage_look_up_table[kind](head_size=head_size)
 
 

--- a/mne/channels/tests/test_standard_montage.py
+++ b/mne/channels/tests/test_standard_montage.py
@@ -174,7 +174,7 @@ def test_set_montage_artinis_basic():
     assert_array_almost_equal(raw.info['chs'][0]['loc'][:3],
                               [0.054243, 0.081884, 0.054544])
     assert_array_almost_equal(raw.info['chs'][8]['loc'][:3],
-                              [-0.03013 , 0.105097, 0.055894])
+                              [-0.03013, 0.105097, 0.055894])
     assert_array_almost_equal(raw.info['chs'][12]['loc'][:3],
                               [-0.055681, 0.086566, 0.055858])
     assert_array_almost_equal(raw_od.info['chs'][12]['loc'][:3],

--- a/mne/channels/tests/test_standard_montage.py
+++ b/mne/channels/tests/test_standard_montage.py
@@ -29,10 +29,11 @@ def test_standard_montages_have_fids(kind):
     for k, v in fids.items():
         assert v is not None, k
     for d in montage.dig:
-        if kind == 'artinis-octamon' or kind == 'artinis-brite23':
-            assert d['coord_frame'] == FIFF.FIFFV_COORD_MRI
+        if kind.startswith(('artinis', 'standard', 'mgh')):
+            want = FIFF.FIFFV_COORD_MRI
         else:
-            assert d['coord_frame'] == FIFF.FIFFV_COORD_UNKNOWN
+            want = FIFF.FIFFV_COORD_UNKNOWN
+        assert d['coord_frame'] == want
 
 
 def test_standard_montage_errors():
@@ -142,12 +143,11 @@ def test_set_montage_artinis_fsaverage(kind):
     assert trans['from'] == trans_fs['from']
     translation = 1000 * np.linalg.norm(trans['trans'][:3, 3] -
                                         trans_fs['trans'][:3, 3])
-    # TODO: This is actually quite big...
-    assert 15 < translation < 18  # mm
+    assert 0 < translation < 1  # mm
     rotation = np.rad2deg(
         _angle_between_quats(rot_to_quat(trans['trans'][:3, :3]),
                              rot_to_quat(trans_fs['trans'][:3, :3])))
-    assert 3 < rotation < 7  # degrees
+    assert 0 < rotation < 1  # degrees
 
 
 def test_set_montage_artinis_basic():
@@ -172,15 +172,15 @@ def test_set_montage_artinis_basic():
 
     # Check a known location
     assert_array_almost_equal(raw.info['chs'][0]['loc'][:3],
-                              [0.0616, 0.075398, 0.07347])
+                              [0.054243, 0.081884, 0.054544])
     assert_array_almost_equal(raw.info['chs'][8]['loc'][:3],
-                              [-0.033875,  0.101276,  0.077291])
+                              [-0.03013 , 0.105097, 0.055894])
     assert_array_almost_equal(raw.info['chs'][12]['loc'][:3],
-                              [-0.062749,  0.080417,  0.074884])
+                              [-0.055681, 0.086566, 0.055858])
     assert_array_almost_equal(raw_od.info['chs'][12]['loc'][:3],
-                              [-0.062749,  0.080417,  0.074884])
+                              [-0.055681, 0.086566, 0.055858])
     assert_array_almost_equal(raw_hb.info['chs'][12]['loc'][:3],
-                              [-0.062749,  0.080417,  0.074884])
+                              [-0.055681, 0.086566, 0.055858])
     # Check that locations are identical for a pair of channels (all elements
     # except the 10th which is the wavelength if not hbo and hbr type)
     assert_array_almost_equal(raw.info['chs'][0]['loc'][:9],
@@ -200,11 +200,11 @@ def test_set_montage_artinis_basic():
                   raw.info['chs'][0]['loc'][:9])
     # Check a known location
     assert_array_almost_equal(raw.info['chs'][0]['loc'][:3],
-                              [0.085583, 0.036275, 0.089426])
+                              [0.068931, 0.046201, 0.072055])
     assert_array_almost_equal(raw.info['chs'][8]['loc'][:3],
-                              [0.069555, 0.078579, 0.069305])
+                              [0.055196, 0.082757, 0.052165])
     assert_array_almost_equal(raw.info['chs'][12]['loc'][:3],
-                              [0.044861, 0.100952, 0.065175])
+                              [0.033592, 0.102607, 0.047423])
     # Check that locations are identical for a pair of channels (all elements
     # except the 10th which is the wavelength if not hbo and hbr type)
     assert_array_almost_equal(raw.info['chs'][0]['loc'][:9],

--- a/tutorials/forward/35_eeg_no_mri.py
+++ b/tutorials/forward/35_eeg_no_mri.py
@@ -58,7 +58,8 @@ new_names = dict(
     for ch_name in raw.ch_names)
 raw.rename_channels(new_names)
 
-# Read and set the EEG electrode locations:
+# Read and set the EEG electrode locations, which are already in fsaverage's
+# space (MNI space) for standard_1020:
 montage = mne.channels.make_standard_montage('standard_1005')
 raw.set_montage(montage)
 raw.set_eeg_reference(projection=True)  # needed for inverse modeling


### PR DESCRIPTION
Closes #10321

The difference is subtle, but it's there:

| Main | PR |
| ------ | ----- |
| ![Screenshot from 2022-02-11 10-48-02](https://user-images.githubusercontent.com/2365790/153625894-5d2aceab-fabc-47f0-b880-3d1d19989db5.png) | ![Screenshot from 2022-02-11 10-47-07](https://user-images.githubusercontent.com/2365790/153625833-ffaf461c-2b7f-43f1-bc44-5a1358422ed6.png) |
| ![Screenshot from 2022-02-11 10-48-09](https://user-images.githubusercontent.com/2365790/153625898-a2aaf4cb-0d52-4353-8e80-3c6b29351469.png) | ![Screenshot from 2022-02-11 10-47-21](https://user-images.githubusercontent.com/2365790/153625835-8ded0e88-bcd1-44d3-ba12-c31ceeec7080.png) |
| ![montage_projected](https://user-images.githubusercontent.com/2365790/153626343-ed4b79a4-4c29-48a8-95ae-5879741a11ed.png) | ![montage_projected](https://user-images.githubusercontent.com/2365790/153626531-92c32ca3-d0f6-4a22-a56f-3fbb7b398f26.png) |

And this last one is in better agreement with HOMER by eye (note the anterior shift in this PR).


 