### PR TITLE
MNT: Warn about insufficient version for qt-backend for Epochs and ICA

### DIFF
--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -623,7 +623,7 @@ def _get_browser(**kwargs):
             logger.info(f'You set the browser-backend to "qt" but your'
                         f' current version {mne_qt_browser.__version__}'
                         f' of mne-qt-browser is too low for {inst_str}.'
-                        f'Update with "pip install --upgrade mne-qt-browser".'
+                        f'Update with pip or conda.'
                         f'Defaults to matplotlib.')
             with use_browser_backend('matplotlib'):
                 # Initialize Browser

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -607,11 +607,30 @@ def _get_browser(**kwargs):
     figsize = kwargs.setdefault('figsize', _get_figsize_from_config())
     if figsize is None or np.any(np.array(figsize) < 8):
         kwargs['figsize'] = (8, 8)
-    # Initialize browser backend
-    _init_browser_backend()
 
-    # Initialize Browser
-    browser = backend._init_browser(**kwargs)
+    # Initialize browser backend
+    backend_name = get_browser_backend()
+    # Check mne-qt-browser compatibilty
+    if backend_name == 'qt':
+        import mne_qt_browser
+        from .. import BaseEpochs
+        from ..fixes import _compare_version
+        is_ica = kwargs.get('ica', False)
+        is_epochs = isinstance(kwargs.get('inst', False), BaseEpochs)
+        not_compat = _compare_version(mne_qt_browser.__version__, '<', '0.2.0')
+        inst_str = 'ICA' if is_ica else 'Epochs'
+        if not_compat and (is_ica or is_epochs):
+            logger.info(f'You set the browser-backend to "qt" but your'
+                        f' current version {mne_qt_browser.__version__}'
+                        f' of mne-qt-browser is too low for {inst_str}.'
+                        f'Update with "pip install --upgrade mne-qt-browser".'
+                        f'Defaults to matplotlib.')
+        with use_browser_backend('matplotlib'):
+            # Initialize Browser
+            browser = backend._init_browser(**kwargs)
+    else:
+        # Initialize Browser
+        browser = backend._init_browser(**kwargs)
 
     return browser
 

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -610,7 +610,7 @@ def _get_browser(**kwargs):
 
     # Initialize browser backend
     backend_name = get_browser_backend()
-    # Check mne-qt-browser compatibilty
+    # Check mne-qt-browser compatibility
     if backend_name == 'qt':
         import mne_qt_browser
         from .. import BaseEpochs

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -625,12 +625,13 @@ def _get_browser(**kwargs):
                         f' of mne-qt-browser is too low for {inst_str}.'
                         f'Update with "pip install --upgrade mne-qt-browser".'
                         f'Defaults to matplotlib.')
-        with use_browser_backend('matplotlib'):
-            # Initialize Browser
-            browser = backend._init_browser(**kwargs)
-    else:
-        # Initialize Browser
-        browser = backend._init_browser(**kwargs)
+            with use_browser_backend('matplotlib'):
+                # Initialize Browser
+                browser = backend._init_browser(**kwargs)
+                return browser
+
+    # Initialize Browser
+    browser = backend._init_browser(**kwargs)
 
     return browser
 


### PR DESCRIPTION
#### What does this implement/fix?
The "qt"-backend stems from [mne-qt-browser](https://github.com/mne-tools/mne-qt-browser) and will only support plotting Epochs and ICA from `version>=0.2.0` on. This PR adds a warning, an instruction on how to update the version of mne-qt-browser and defaults to matplotlib if the version is not sufficient.
