### PR TITLE
WIP,MNT: disable 3d options during testing

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -439,35 +439,35 @@ def browser_backend(request, garbage_collect):
 
 
 @pytest.fixture(params=["pyvistaqt"])
-def renderer(request, garbage_collect):
+def renderer(request, options_3d, garbage_collect):
     """Yield the 3D backends."""
     with _use_backend(request.param, interactive=False) as renderer:
         yield renderer
 
 
 @pytest.fixture(params=["pyvistaqt"])
-def renderer_pyvistaqt(request, garbage_collect):
+def renderer_pyvistaqt(request, options_3d, garbage_collect):
     """Yield the PyVista backend."""
     with _use_backend(request.param, interactive=False) as renderer:
         yield renderer
 
 
 @pytest.fixture(params=["notebook"])
-def renderer_notebook(request):
+def renderer_notebook(request, options_3d):
     """Yield the 3D notebook renderer."""
     with _use_backend(request.param, interactive=False) as renderer:
         yield renderer
 
 
 @pytest.fixture(scope="module", params=["pyvistaqt"])
-def renderer_interactive_pyvistaqt(request):
+def renderer_interactive_pyvistaqt(request, options_3d):
     """Yield the interactive PyVista backend."""
     with _use_backend(request.param, interactive=True) as renderer:
         yield renderer
 
 
 @pytest.fixture(scope="module", params=["pyvistaqt"])
-def renderer_interactive(request):
+def renderer_interactive(request, options_3d):
     """Yield the interactive 3D backends."""
     with _use_backend(request.param, interactive=True) as renderer:
         yield renderer
@@ -650,6 +650,13 @@ def download_is_error(monkeypatch):
     """Prevent downloading by raising an error when it's attempted."""
     import pooch
     monkeypatch.setattr(pooch, 'retrieve', _fail)
+
+
+@pytest.fixture(scope='function')
+def options_3d(monkeypatch):
+    """Disable advanced 3d rendering."""
+    monkeypatch.setenv('MNE_3D_OPTION_ANTIALIAS', 'false')
+    monkeypatch.setenv('MNE_3D_OPTION_DEPTH_PEELING', 'false')
 
 
 @pytest.fixture()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -14,6 +14,7 @@ import shutil
 import sys
 import warnings
 import pytest
+from unittest import mock
 
 import numpy as np
 
@@ -653,11 +654,15 @@ def download_is_error(monkeypatch):
 
 
 @pytest.fixture(scope='module')
-def options_3d(monkeypatch):
+def options_3d():
     """Disable advanced 3d rendering."""
-    monkeypatch.setenv("MNE_3D_OPTION_ANTIALIAS", "false")
-    monkeypatch.setenv("MNE_3D_OPTION_DEPTH_PEELING", "false")
-    yield
+    with mock.patch.dict(
+        os.environ, {
+            "MNE_3D_OPTION_ANTIALIAS": "false",
+            "MNE_3D_OPTION_DEPTH_PEELING": "false",
+        }
+    ):
+        yield
 
 
 @pytest.fixture()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -14,7 +14,6 @@ import shutil
 import sys
 import warnings
 import pytest
-from unittest import mock
 
 import numpy as np
 
@@ -654,15 +653,11 @@ def download_is_error(monkeypatch):
 
 
 @pytest.fixture(scope='module')
-def options_3d():
+def options_3d(monkeypatch):
     """Disable advanced 3d rendering."""
-    with mock.patch.dict(
-        os.environ, {
-            "MNE_3D_OPTION_ANTIALIAS": "false",
-            "MNE_3D_OPTION_DEPTH_PEELING": "false",
-        }
-    ):
-        yield
+    monkeypatch.setenv("MNE_3D_OPTION_ANTIALIAS", "false")
+    monkeypatch.setenv("MNE_3D_OPTION_DEPTH_PEELING", "false")
+    yield
 
 
 @pytest.fixture()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -652,7 +652,7 @@ def download_is_error(monkeypatch):
     monkeypatch.setattr(pooch, 'retrieve', _fail)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def options_3d(monkeypatch):
     """Disable advanced 3d rendering."""
     monkeypatch.setenv("MNE_3D_OPTION_ANTIALIAS", "false")

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -652,7 +652,7 @@ def download_is_error(monkeypatch):
     monkeypatch.setattr(pooch, 'retrieve', _fail)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='module')
 def options_3d(monkeypatch):
     """Disable advanced 3d rendering."""
     monkeypatch.setenv("MNE_3D_OPTION_ANTIALIAS", "false")

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -653,6 +653,9 @@ def download_is_error(monkeypatch):
     monkeypatch.setattr(pooch, 'retrieve', _fail)
 
 
+# We can't use monkeypatch because its scope (function-level) conflicts with
+# the requests fixture (module-level), so we live with a module-scoped version
+# that uses mock
 @pytest.fixture(scope='module')
 def options_3d():
     """Disable advanced 3d rendering."""

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -14,6 +14,7 @@ import shutil
 import sys
 import warnings
 import pytest
+from unittest import mock
 
 import numpy as np
 
@@ -652,11 +653,16 @@ def download_is_error(monkeypatch):
     monkeypatch.setattr(pooch, 'retrieve', _fail)
 
 
-@pytest.fixture(scope='function')
-def options_3d(monkeypatch):
+@pytest.fixture(scope='module')
+def options_3d():
     """Disable advanced 3d rendering."""
-    monkeypatch.setenv('MNE_3D_OPTION_ANTIALIAS', 'false')
-    monkeypatch.setenv('MNE_3D_OPTION_DEPTH_PEELING', 'false')
+    with mock.patch.dict(
+        os.environ, {
+            "MNE_3D_OPTION_ANTIALIAS": "false",
+            "MNE_3D_OPTION_DEPTH_PEELING": "false",
+        }
+    ):
+        yield
 
 
 @pytest.fixture()

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -19,8 +19,8 @@ from mne.coreg import (fit_matched_points, create_default_subject, scale_mri,
                        coregister_fiducials, get_mni_fiducials, Coregistration)
 from mne.io import read_fiducials, read_info
 from mne.io.constants import FIFF
-from mne.utils import (requires_nibabel, modified_env, check_version,
-                       catch_logging, _record_warnings)
+from mne.utils import (requires_nibabel, check_version, catch_logging,
+                       _record_warnings)
 from mne.source_space import write_source_spaces
 from mne.channels import DigMontage
 
@@ -33,10 +33,10 @@ trans_fname = op.join(data_path, 'MEG', 'sample',
 
 
 @pytest.fixture
-def few_surfaces():
+def few_surfaces(monkeypatch):
     """Set the _MNE_FEW_SURFACES env var."""
-    with modified_env(_MNE_FEW_SURFACES='true'):
-        yield
+    monkeypatch.setenv('_MNE_FEW_SURFACES', 'true')
+    yield
 
 
 def test_coregister_fiducials():

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -23,7 +23,7 @@ from mne import (read_source_spaces, write_source_spaces,
                  read_trans)
 from mne.fixes import _get_img_fdata
 from mne.utils import (requires_nibabel, run_subprocess, _record_warnings,
-                       modified_env, requires_mne, check_version)
+                       requires_mne, check_version)
 from mne.surface import _accumulate_normals, _triangle_neighbors
 from mne.source_estimate import _get_src_type
 from mne.source_space import (get_volume_labels_from_src,
@@ -489,23 +489,24 @@ def test_setup_source_space(tmp_path):
 @pytest.mark.slowtest
 @pytest.mark.timeout(60)
 @pytest.mark.parametrize('spacing', [2, 7])
-def test_setup_source_space_spacing(tmp_path, spacing):
+def test_setup_source_space_spacing(tmp_path, spacing, monkeypatch):
     """Test setting up surface source spaces using a given spacing."""
     copytree(op.join(subjects_dir, 'sample'), tmp_path / 'sample')
     args = [] if spacing == 7 else ['--spacing', str(spacing)]
-    with modified_env(SUBJECTS_DIR=str(tmp_path), SUBJECT='sample'):
-        run_subprocess(['mne_setup_source_space'] + args)
+    monkeypatch.setenv('SUBJECTS_DIR', str(tmp_path))
+    monkeypatch.setenv('SUBJECT', 'sample')
+    run_subprocess(['mne_setup_source_space'] + args)
     src = read_source_spaces(
         tmp_path / 'sample' / 'bem' / ('sample-%d-src.fif' % spacing)
     )
-    src_new = setup_source_space('sample', spacing=spacing, add_dist=False,
-                                 subjects_dir=subjects_dir)
+    # No need to pass subjects_dir here because we've setenv'ed it
+    src_new = setup_source_space('sample', spacing=spacing, add_dist=False)
     _compare_source_spaces(src, src_new, mode='approx', nearest=True)
     # Degenerate conditions
     with pytest.raises(TypeError, match='spacing must be.*got.*float.*'):
-        setup_source_space('sample', 7., subjects_dir=subjects_dir)
+        setup_source_space('sample', 7.)
     with pytest.raises(ValueError, match='spacing must be >= 2, got 1'):
-        setup_source_space('sample', 1, subjects_dir=subjects_dir)
+        setup_source_space('sample', 1)
 
 
 @testing.requires_testing_data

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -291,17 +291,25 @@ class catch_logging(object):
     This will remove all other logging handlers, and return the handler to
     stdout when complete.
     """
+    def __init__(self, verbose=None):
+        self.verbose = verbose
 
     def __enter__(self):  # noqa: D105
+        if self.verbose is not None:
+            self._ctx = use_log_level(self.verbose)
+        else:
+            self._ctx = contextlib.nullcontext()
         self._data = ClosingStringIO()
         self._lh = logging.StreamHandler(self._data)
         self._lh.setFormatter(logging.Formatter('%(message)s'))
         self._lh._mne_file_like = True  # monkey patch for warn() use
         _remove_close_handlers(logger)
         logger.addHandler(self._lh)
+        self._ctx.__enter__()
         return self._data
 
     def __exit__(self, *args):  # noqa: D105
+        self._ctx.__exit__(*args)
         logger.removeHandler(self._lh)
         set_log_file(None)
 

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -291,6 +291,7 @@ class catch_logging(object):
     This will remove all other logging handlers, and return the handler to
     stdout when complete.
     """
+
     def __init__(self, verbose=None):
         self.verbose = verbose
 

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -449,6 +449,9 @@ def modified_env(**d):
     **kwargs : dict
         The key/value pairs of environment variables to replace.
     """
+    warn('modified_env is deprecated and will be removed in 1.1. In tests, '
+         'use monkeypatch from pytest instead. In subprocess calls, pass '
+         'modified environments directly.', DeprecationWarning)
     orig_env = dict()
     for key, val in d.items():
         orig_env[key] = os.getenv(key)

--- a/mne/utils/tests/test_testing.py
+++ b/mne/utils/tests/test_testing.py
@@ -1,10 +1,17 @@
+# -*- coding: utf-8 -*-
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD-3-Clause
+
+import os
 import os.path as op
 
 import numpy as np
 import pytest
 
 from mne.datasets import testing
-from mne.utils import (_TempDir, _url_to_local_path, buggy_mkl_svd)
+from mne.utils import (_TempDir, _url_to_local_path, buggy_mkl_svd,
+                       modified_env)
 
 
 def test_buggy_mkl():
@@ -49,3 +56,20 @@ def test_url_to_local_path():
     """Test URL to local path."""
     assert _url_to_local_path('http://google.com/home/why.html', '.') == \
         op.join('.', 'home', 'why.html')
+
+
+@pytest.mark.filterwarnings('ignore:.*monkeypatch.*:DeprecationWarning')
+def test_modified_env(monkeypatch):
+    """Test modified_env."""
+    monkeypatch.setenv('_MNE_1', 'true')
+    monkeypatch.setenv('_MNE_2', 'truer')
+    assert os.getenv('_MNE_1') == 'true'
+    assert os.getenv('_MNE_2') == 'truer'
+    assert os.getenv('_MNE_3') is None
+    with modified_env(_MNE_1='false', _MNE_2=None, _MNE_3='falsest'):
+        assert os.getenv('_MNE_1') == 'false'
+        assert os.getenv('_MNE_2') is None
+        assert os.getenv('_MNE_3') == 'falsest'
+    assert os.getenv('_MNE_1') == 'true'
+    assert os.getenv('_MNE_2') == 'truer'
+    assert os.getenv('_MNE_3') is None

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -151,10 +151,8 @@ class _PyVistaRenderer(_AbstractRenderer):
                          smooth_shading=smooth_shading)
         self.font_family = "arial"
         self.tube_n_sides = 20
-        self.antialias = _get_3d_option('antialias') and \
-            not MNE_3D_BACKEND_TESTING
-        self.depth_peeling = _get_3d_option('depth_peeling') and \
-            not MNE_3D_BACKEND_TESTING
+        self.antialias = _get_3d_option('antialias')
+        self.depth_peeling = _get_3d_option('depth_peeling')
         if isinstance(fig, int):
             saved_fig = _FIGURES.get(fig)
             # Restore only active plotter


### PR DESCRIPTION
This PR follows https://github.com/mne-tools/mne-python/pull/10319#discussion_r804679165 and introduces a `pytest.fixture` called `options_3d` to disable advanced 3d rendering options.

I tried setting `scope='session'` but I got the following error:

```
_______________________________________________________________ ERROR at setup of test_3d_functions[pyvistaqt] _______________________________________________________________
ScopeMismatch: You tried to access the 'function' scoped fixture 'monkeypatch' with a 'session' scoped request object, involved factories
mne/conftest.py:655:  def options_3d(monkeypatch)
../anaconda3/envs/mne-py38/lib/python3.8/site-packages/_pytest/monkeypatch.py:29:  def monkeypatch() -> Generator[ForwardRef('MonkeyPatch'), NoneType, NoneType]
```

cc @larsoner 