### PR TITLE
BUG: Fix bug with closing and resizing

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -193,6 +193,8 @@ Bugs
 
 - Fix bug with :func:`mne.channels.make_standard_montage` for ``'standard*'``, ``'mgh*'``, and ``'artinis*'`` montages where the points were incorrectly scaled and fiducials incorrectly set away from the correct values for use with the ``fsaverage`` subject (:gh:`10324` by `Eric Larson`_)
 
+- Fix bug with :meth:`mne.Report.add_figure` where figures generated externally were closed and possibly resized during render (:gh:`10342` by `Eric Larson`_)
+
 - Fix plotting bug in :ref:`ex-electrode-pos-2d` and make view look more natural in :ref:`ex-movement-detect` (:gh:`10313`, by `Alex Rockhill`_)
 
 - Fix a bug in :func:`mne.gui.locate_ieeg` where 2D lines on slice plots failed to update and were shown when not in maximum projection mode (:gh:`10335`, by `Alex Rockhill`_)

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -327,16 +327,20 @@ def _constrain_fig_resolution(fig, *, max_width, max_res):
     fig.set_dpi(dpi)
 
 
-def _fig_to_img(fig, *, image_format='png', auto_close=True):
+def _fig_to_img(fig, *, image_format='png', own_figure=True):
     """Plot figure and create a binary image."""
     # fig can be ndarray, mpl Figure, PyVista Figure
     import matplotlib.pyplot as plt
     from matplotlib.figure import Figure
     if isinstance(fig, np.ndarray):
+        # In this case, we are creating the fig, so we might as well
+        # auto-close in all cases
         fig = _ndarray_to_fig(fig)
-        _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
-        )
+        if own_figure:
+            _constrain_fig_resolution(
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+            )
+        own_figure = True  # close the figure we just created
     elif not isinstance(fig, Figure):
         from ..viz.backends.renderer import backend, MNE_3D_BACKEND_TESTING
         backend._check_3d_figure(figure=fig)
@@ -345,12 +349,14 @@ def _fig_to_img(fig, *, image_format='png', auto_close=True):
         else:  # Testing mode
             img = np.zeros((2, 2, 3))
 
-        if auto_close:
+        if own_figure:
             backend._close_3d_figure(figure=fig)
         fig = _ndarray_to_fig(img)
-        _constrain_fig_resolution(
-            fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
-        )
+        if own_figure:
+            _constrain_fig_resolution(
+                fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES
+            )
+        own_figure = True  # close the fig we just created
 
     output = BytesIO()
     logger.debug(
@@ -366,7 +372,7 @@ def _fig_to_img(fig, *, image_format='png', auto_close=True):
         )
         fig.savefig(output, format=image_format, dpi=fig.get_dpi())
 
-    if auto_close:
+    if own_figure:
         plt.close(fig)
     output = output.getvalue()
     return (output.decode('utf-8') if image_format == 'svg' else
@@ -1976,7 +1982,8 @@ class Report(_VerboseDep):
 
         assert figs
         if len(figs) == 1:
-            img = _fig_to_img(fig=figs[0], image_format=image_format)
+            img = _fig_to_img(fig=figs[0], image_format=image_format,
+                              own_figure=False)
             dom_id = self._get_dom_id()
             html = _html_image_element(
                 img=img, div_klass='custom-image', img_klass='custom-image',
@@ -1986,7 +1993,8 @@ class Report(_VerboseDep):
         else:
             html, dom_id = self._render_slider(
                 figs=figs, imgs=None, title=title, captions=captions,
-                start_idx=0, image_format=image_format, tags=tags
+                start_idx=0, image_format=image_format, tags=tags,
+                own_figure=False
             )
 
         self._add_or_replace(
@@ -2123,7 +2131,7 @@ class Report(_VerboseDep):
         )
 
     def _render_slider(self, *, figs, imgs, title, captions, start_idx,
-                       image_format, tags, klass=''):
+                       image_format, tags, klass='', own_figure=True):
         if figs is not None and imgs is not None:
             raise ValueError('Must only provide either figs or imgs')
 
@@ -2137,10 +2145,10 @@ class Report(_VerboseDep):
                 f'Number of captions ({len(captions)}) must be equal to the '
                 f'number of images ({len(imgs)})'
             )
-        elif figs:
-            imgs = [_fig_to_img(fig=fig, image_format=image_format)
+        elif figs:  # figs can be None if imgs is provided
+            imgs = [_fig_to_img(fig=fig, image_format=image_format,
+                                own_figure=own_figure)
                     for fig in figs]
-
         dom_id = self._get_dom_id()
         html = _html_slider_element(
             id=dom_id,

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -356,16 +356,22 @@ def test_report_raw_psd_and_date(tmp_path):
 @testing.requires_testing_data
 def test_render_add_sections(renderer, tmp_path):
     """Test adding figures/images to section."""
+    from pyvista.plotting import plotting
     tempdir = str(tmp_path)
     report = Report(subjects_dir=subjects_dir)
     # Check add_figure functionality
+    plt.close('all')
+    assert len(plt.get_fignums()) == 0
     fig = plt.plot([1, 2], [1, 2])[0].figure
+    assert len(plt.get_fignums()) == 1
 
     report.add_figure(fig=fig, title='evoked response', image_format='svg')
     assert 'caption' not in report._content[-1].html
+    assert len(plt.get_fignums()) == 1
 
     report.add_figure(fig=fig, title='evoked with caption', caption='descr')
     assert 'caption' in report._content[-1].html
+    assert len(plt.get_fignums()) == 1
 
     # Check add_image with png
     img_fname = op.join(tempdir, 'testimage.png')
@@ -377,10 +383,14 @@ def test_render_add_sections(renderer, tmp_path):
 
     evoked = read_evokeds(evoked_fname, condition='Left Auditory',
                           baseline=(-0.2, 0.0))
+    n_before = len(plotting._ALL_PLOTTERS)
     fig = plot_alignment(evoked.info, trans_fname, subject='sample',
                          subjects_dir=subjects_dir)
+    n_after = n_before + 1
+    assert n_after == len(plotting._ALL_PLOTTERS)
 
     report.add_figure(fig=fig, title='random image')
+    assert n_after == len(plotting._ALL_PLOTTERS)  # not closed
     assert (repr(report))
     fname = op.join(str(tmp_path), 'test.html')
     report.save(fname, open_browser=False)


### PR DESCRIPTION
Closes #10169

If a user passes an `ndarray` (pixels), a PyVista figure, or mpl Figure to `add_figure`, we shouldn't:

1. Resize it (wasn't happening for mpl, but was for ndarray and PyVista)
2. Close it

We should trust that the user has resized to the size they want and not close the figure on them (they should be in charge of doing so)