### PR TITLE
MNT: Smooth shading 3d option

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -663,6 +663,7 @@ def options_3d():
         os.environ, {
             "MNE_3D_OPTION_ANTIALIAS": "false",
             "MNE_3D_OPTION_DEPTH_PEELING": "false",
+            "MNE_3D_OPTION_SMOOTH_SHADING": "false",
         }
     ):
         yield

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -69,6 +69,7 @@ def set_memmap_min_size(memmap_min_size):
 known_config_types = (
     'MNE_3D_OPTION_ANTIALIAS',
     'MNE_3D_OPTION_DEPTH_PEELING',
+    'MNE_3D_OPTION_SMOOTH_SHADING',
     'MNE_BROWSE_RAW_SIZE',
     'MNE_BROWSER_BACKEND',
     'MNE_BROWSER_USE_OPENGL',

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -3289,13 +3289,22 @@ def plot_brain_colorbar(ax, clim, colormap='auto', transparent=True,
 class _3d_Options:
     antialias: Optional[str]
     depth_peeling: Optional[str]
+    smooth_shading: Optional[str]
 
 
-_3d_options = _3d_Options(antialias=None, depth_peeling=None)
-_3d_default = _3d_Options(antialias='true', depth_peeling='true')
+_3d_options = _3d_Options(
+    antialias=None,
+    depth_peeling=None,
+    smooth_shading=None,
+)
+_3d_default = _3d_Options(
+    antialias='true',
+    depth_peeling='true',
+    smooth_shading='true',
+)
 
 
-def set_3d_options(antialias=None, depth_peeling=None):
+def set_3d_options(antialias=None, depth_peeling=None, smooth_shading=None):
     """Set 3D rendering options.
 
     Parameters
@@ -3312,6 +3321,12 @@ def set_3d_options(antialias=None, depth_peeling=None):
         while X forwarding on remote servers). If None, use the default
         setting. This option can also be controlled using an environment
         variable, e.g., ``MNE_3D_OPTION_DEPTH_PEELING=false``.
+    smooth_shading : bool | None
+        If bool, whether to enable or disable smooth color transitions
+        between polygons. False is useful on certain configurations
+        where this type of shading is not supported or for performance
+        reasons. This option can also be controlled using an environment
+        variable, e.g., ``MNE_3D_OPTION_SMOOTH_SHADING=false``.
 
     Notes
     -----
@@ -3321,6 +3336,8 @@ def set_3d_options(antialias=None, depth_peeling=None):
         _3d_options.antialias = str(bool(antialias)).lower()
     if depth_peeling is not None:
         _3d_options.depth_peeling = str(bool(depth_peeling)).lower()
+    if smooth_shading is not None:
+        _3d_options.smooth_shading = str(bool(smooth_shading)).lower()
 
 
 def _get_3d_option(key):

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -143,7 +143,6 @@ class _PyVistaRenderer(_AbstractRenderer):
     def __init__(self, fig=None, size=(600, 600), bgcolor='black',
                  name="PyVista Scene", show=False, shape=(1, 1),
                  notebook=None, smooth_shading=True):
-        from .renderer import MNE_3D_BACKEND_TESTING
         from .._3d import _get_3d_option
         _require_version('pyvista', 'use 3D rendering', '0.32')
         figure = _Figure(show=show, title=name, size=size, shape=shape,
@@ -153,6 +152,8 @@ class _PyVistaRenderer(_AbstractRenderer):
         self.tube_n_sides = 20
         self.antialias = _get_3d_option('antialias')
         self.depth_peeling = _get_3d_option('depth_peeling')
+        # smooth_shading=True fails on MacOS CIs
+        self.smooth_shading = _get_3d_option('smooth_shading')
         if isinstance(fig, int):
             saved_fig = _FIGURES.get(fig)
             # Restore only active plotter
@@ -172,10 +173,6 @@ class _PyVistaRenderer(_AbstractRenderer):
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)
-            if MNE_3D_BACKEND_TESTING:
-                self.tube_n_sides = 3
-                # smooth_shading=True fails on MacOS CIs
-                self.figure.smooth_shading = False
             # pyvista theme may enable depth peeling by default so
             # we disable it initially to better control the value afterwards
             with _disabled_depth_peeling():
@@ -302,7 +299,7 @@ class _PyVistaRenderer(_AbstractRenderer):
                 rgba=rgba, opacity=opacity, cmap=colormap,
                 backface_culling=backface_culling,
                 rng=[vmin, vmax], show_scalar_bar=False,
-                smooth_shading=self.figure.smooth_shading,
+                smooth_shading=self.smooth_shading,
                 interpolate_before_map=interpolate_before_map,
                 style=representation, line_width=line_width, **kwargs,
             )
@@ -370,7 +367,7 @@ class _PyVistaRenderer(_AbstractRenderer):
                 rng=[vmin, vmax],
                 cmap=colormap,
                 opacity=opacity,
-                smooth_shading=self.figure.smooth_shading
+                smooth_shading=self.smooth_shading
             )
             return actor, contour
 
@@ -426,7 +423,7 @@ class _PyVistaRenderer(_AbstractRenderer):
                 self.plotter,
                 mesh=glyph, color=color, opacity=opacity,
                 backface_culling=backface_culling,
-                smooth_shading=self.figure.smooth_shading
+                smooth_shading=self.smooth_shading
             )
             return actor, glyph
 
@@ -454,7 +451,7 @@ class _PyVistaRenderer(_AbstractRenderer):
                     color=color,
                     show_scalar_bar=False,
                     cmap=cmap,
-                    smooth_shading=self.figure.smooth_shading,
+                    smooth_shading=self.smooth_shading,
                 )
         return actor, tube
 


### PR DESCRIPTION
This PR adds an option to control smooth shading to be complete with the other 'advanced rendering' options.
It also effectively removes `MNE_3D_BACKEND_TESTING` from `_PyVistaRenderer`.