### PR TITLE
Fix colorbar scaling in ERDS example

### DIFF
--- a/examples/time_frequency/time_frequency_erds.py
+++ b/examples/time_frequency/time_frequency_erds.py
@@ -106,7 +106,7 @@ for event in event_ids:
         if ch != 0:
             ax.set_ylabel("")
             ax.set_yticklabels("")
-    fig.colorbar(axes[0].images[-1], cax=axes[-1])
+    fig.colorbar(axes[0].images[-1], cax=axes[-1]).ax.set_yscale("linear")
     fig.suptitle(f"ERDS ({event})")
     plt.show()
 


### PR DESCRIPTION
The latest Matplotlib version scales the colorbar logarithmically for a `TwoSlopeNorm`. This is used in the ERDS maps example and doesn't look nice at all. This PR sets the colorbar scale to linear (how it used to be).