### PR TITLE
ENH: add Shift_JIS mu in _read_edf_header

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -113,6 +113,8 @@ Enhancements
 Bugs
 ~~~~
 
+- Add Shift_JIST mu in :func:`mne.io.edf.read_raw_edf` (:gh:`10356` by :newcontrib:`Michiru Kaneda`)
+
 - Teach :func:`mne.io.read_raw_bti` to use its ``eog_ch`` parameter (:gh:`10093` by :newcontrib:`Adina Wagner`)
 
 - :func:`mne.time_frequency.tfr_array_multitaper` now returns results per taper when ``output='complex'`` (:gh:`10281` by `Mikołaj Magnuski`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -113,7 +113,7 @@ Enhancements
 Bugs
 ~~~~
 
-- Add Shift_JIST mu in :func:`mne.io.edf.read_raw_edf` (:gh:`10356` by :newcontrib:`Michiru Kaneda`)
+- Add Shift_JIST mu in :func:`mne.io.read_raw_edf` (:gh:`10356` by :newcontrib:`Michiru Kaneda`)
 
 - Teach :func:`mne.io.read_raw_bti` to use its ``eog_ch`` parameter (:gh:`10093` by :newcontrib:`Adina Wagner`)
 

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -423,3 +423,5 @@
 .. _Adina Wagner: https://github.com/adswa
 
 .. _Senwen Deng: https://snwn.de
+
+.. _Michiru Kaneda: https://github.com/rcmdnk

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -691,8 +691,8 @@ def _read_edf_header(fname, exclude, infer_types):
         for i, unit in enumerate(units):
             if i in exclude:
                 continue
-            # allow both μ (greek mu) and µ (micro symbol) codepoints
-            if unit in ('\u03BCV', '\u00B5V', 'uV'):
+            # allow μ (greek mu), µ (micro symbol) and μ (sjis mu) codepoints
+            if unit in ('\u03BCV', '\u00B5V', '\x83\xCAV', 'uV'):
                 edf_info['units'].append(1e-6)
             elif unit == 'mV':
                 edf_info['units'].append(1e-3)

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -53,6 +53,7 @@ def _check_orig_units(orig_units):
         remap_dict = dict()
         remap_dict['uv'] = 'µV'
         remap_dict['μv'] = 'µV'  # greek letter mu vs micro sign. use micro
+        remap_dict['\x83\xeav'] = 'µV'  # for shift-jis mu, use micro
         if unit.lower() in remap_dict:
             orig_units_remapped[ch_name] = remap_dict[unit.lower()]
             continue


### PR DESCRIPTION
#### What does this implement/fix?
In some EDF files created in Japan, Shift_JIS mu (`\x83\xCA`) is used in the header for the unit.
This change allows to read the unit correctly and assign the correct scale.