### PR TITLE
ENH: Use Qt backend for doc build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
               echo "export MNE_3D_OPTION_ANTIALIAS=false" >> $BASH_ENV
               source tools/get_minimal_commands.sh
               echo "export MNE_3D_BACKEND=pyvistaqt" >> $BASH_ENV
-              echo "export MNE_BROWSER_BACKEND=matplotlib" >> $BASH_ENV
+              echo "export MNE_BROWSER_BACKEND=qt" >> $BASH_ENV
               echo "export MNE_BROWSER_PRECOMPUTE=false" >> $BASH_ENV
               echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
               echo "source ~/python_env/bin/activate" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,6 @@ jobs:
               source tools/get_minimal_commands.sh
               echo "export MNE_3D_BACKEND=pyvistaqt" >> $BASH_ENV
               echo "export MNE_BROWSER_BACKEND=qt" >> $BASH_ENV
-              echo "export MNE_SKIP_INSTANCE_ASSERTIONS='brain,backgroundplotter,plotter,vtkpolydata,_renderer'" >> $BASH_ENV
               echo "export MNE_BROWSER_PRECOMPUTE=false" >> $BASH_ENV
               echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
               echo "source ~/python_env/bin/activate" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
               source tools/get_minimal_commands.sh
               echo "export MNE_3D_BACKEND=pyvistaqt" >> $BASH_ENV
               echo "export MNE_BROWSER_BACKEND=qt" >> $BASH_ENV
-               echo "export MNE_SKIP_INSTANCE_ASSERTIONS='brain,backgroundpotter,plotter,vtkpolydata,_renderer'" >> $BASH_ENV
+              echo "export MNE_SKIP_INSTANCE_ASSERTIONS='brain,backgroundpotter,plotter,vtkpolydata,_renderer'" >> $BASH_ENV
               echo "export MNE_BROWSER_PRECOMPUTE=false" >> $BASH_ENV
               echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
               echo "source ~/python_env/bin/activate" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ jobs:
               source tools/get_minimal_commands.sh
               echo "export MNE_3D_BACKEND=pyvistaqt" >> $BASH_ENV
               echo "export MNE_BROWSER_BACKEND=qt" >> $BASH_ENV
+               echo "export MNE_SKIP_INSTANCE_ASSERTIONS='brain,backgroundpotter,plotter,vtkpolydata,_renderer'" >> $BASH_ENV
               echo "export MNE_BROWSER_PRECOMPUTE=false" >> $BASH_ENV
               echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
               echo "source ~/python_env/bin/activate" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
               source tools/get_minimal_commands.sh
               echo "export MNE_3D_BACKEND=pyvistaqt" >> $BASH_ENV
               echo "export MNE_BROWSER_BACKEND=qt" >> $BASH_ENV
-              echo "export MNE_SKIP_INSTANCE_ASSERTIONS='brain,backgroundpotter,plotter,vtkpolydata,_renderer'" >> $BASH_ENV
+              echo "export MNE_SKIP_INSTANCE_ASSERTIONS='brain,backgroundplotter,plotter,vtkpolydata,_renderer'" >> $BASH_ENV
               echo "export MNE_BROWSER_PRECOMPUTE=false" >> $BASH_ENV
               echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
               echo "source ~/python_env/bin/activate" >> $BASH_ENV

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -830,6 +830,10 @@ def reset_warnings(gallery_conf, fname):
         'ignore', r'.*From version 1\.3 whiten.*')
     warnings.filterwarnings(  # seaborn -> pandas
         'ignore', '.*iteritems is deprecated and will be.*')
+    warnings.filterwarnings(  # PyOpenGL for macOS
+        'ignore', '.*PyOpenGL was not found.*')
+    warnings.filterwarnings(  # macOS Epochs
+        'ignore', '.*Plotting epochs on MacOS.*')
     for key in ('HasTraits', r'numpy\.testing', 'importlib', r'np\.loads',
                 'Using or importing the ABCs from',  # internal modules on 3.7
                 r"it will be an error for 'np\.bool_'",  # ndimage

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -295,7 +295,7 @@ class Resetter(object):
     def __repr__(self):
         return f'<{self.__class__.__name__}>'
 
-    def __call__(self, gallery_conf, fname):
+    def __call__(self, gallery_conf, fname, when):
         import matplotlib.pyplot as plt
         try:
             from pyvista import Plotter  # noqa
@@ -309,6 +309,10 @@ class Resetter(object):
             from vtk import vtkPolyData  # noqa
         except ImportError:
             vtkPolyData = None  # noqa
+        try:
+            from mne_qt_browser._pg_figure import PyQtGraphBrowser
+        except ImportError:
+            PyQtGraphBrowser = None
         from mne.viz.backends.renderer import backend
         _Renderer = backend._Renderer if backend is not None else None
         reset_warnings(gallery_conf, fname)
@@ -317,24 +321,36 @@ class Resetter(object):
         plt.ioff()
         plt.rcParams['animation.embed_limit'] = 30.
         gc.collect()
-        when = 'mne/conf.py:Resetter.__call__'
-        if os.getenv('MNE_SKIP_INSTANCE_ASSERTIONS', 'false') not in \
-                ('true', '1'):
-            _assert_no_instances(Brain, when)  # calls gc.collect()
-            if Plotter is not None:
+        when = f'mne/conf.py:Resetter.__call__:{when}:{fname}'
+        # Support stuff like
+        # MNE_SKIP_INSTANCE_ASSERTIONS="Brain,Plotter,BackgroundPlotter,vtkPolyData,_Renderer" make html_dev-memory  # noqa: E501
+        # to just test PyQtGraphBrowser
+        skips = os.getenv('MNE_SKIP_INSTANCE_ASSERTIONS', '').lower()
+        prefix = ''
+        if skips not in ('true', '1'):
+            prefix = 'Clean '
+            skips = skips.split(',')
+            if 'brain' not in skips:
+                _assert_no_instances(Brain, when)  # calls gc.collect()
+            if Plotter is not None and 'plotter' not in skips:
                 _assert_no_instances(Plotter, when)
-            if BackgroundPlotter is not None:
+            if BackgroundPlotter is not None and \
+                    'backgroundplotter' not in skips:
                 _assert_no_instances(BackgroundPlotter, when)
-            if vtkPolyData is not None:
+            if vtkPolyData is not None and 'vtkpolydata' not in skips:
                 _assert_no_instances(vtkPolyData, when)
-            _assert_no_instances(_Renderer, when)
+            if '_renderer' not in skips:
+                _assert_no_instances(_Renderer, when)
+            if PyQtGraphBrowser is not None and \
+                    'PyQtGraphBrowser' not in skips:
+                _assert_no_instances(PyQtGraphBrowser, when)
         # This will overwrite some Sphinx printing but it's useful
         # for memory timestamps
         if os.getenv('SG_STAMP_STARTS', '').lower() == 'true':
             import psutil
             process = psutil.Process(os.getpid())
             mem = sizeof_fmt(process.memory_info().rss)
-            print(f'{time.time() - self.t0:6.1f} s : {mem}'.ljust(22))
+            print(f'{prefix}{time.time() - self.t0:6.1f} s : {mem}'.ljust(22))
 
 
 examples_dirs = ['../tutorials', '../examples']
@@ -418,6 +434,7 @@ sphinx_gallery_conf = {
     'min_reported_time': 1.,
     'abort_on_example_error': False,
     'reset_modules': ('matplotlib', Resetter()),  # called w/each script
+    'reset_modules_order': 'both',
     'image_scrapers': scrapers,
     'show_memory': not sys.platform.startswith('win'),
     'line_numbers': False,  # messes with style

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -327,7 +327,7 @@ class Resetter(object):
         # to just test PyQtGraphBrowser
         skips = os.getenv('MNE_SKIP_INSTANCE_ASSERTIONS', '').lower()
         prefix = ''
-        if skips not in ('true', '1'):
+        if skips not in ('true', '1', 'all'):
             prefix = 'Clean '
             skips = skips.split(',')
             if 'brain' not in skips:
@@ -342,7 +342,7 @@ class Resetter(object):
             if '_renderer' not in skips:
                 _assert_no_instances(_Renderer, when)
             if PyQtGraphBrowser is not None and \
-                    'PyQtGraphBrowser' not in skips:
+                    'pyqtgraphbrowser' not in skips:
                 _assert_no_instances(PyQtGraphBrowser, when)
         # This will overwrite some Sphinx printing but it's useful
         # for memory timestamps

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -320,6 +320,13 @@ class Resetter(object):
         # turn it off here (otherwise the build can be very slow)
         plt.ioff()
         plt.rcParams['animation.embed_limit'] = 30.
+        # neo holds on to an exception, which in turn holds a stack frame,
+        # which will keep alive the global vars during SG execution
+        try:
+            import neo
+            neo.io.stimfitio.STFIO_ERR = None
+        except Exception:
+            pass
         gc.collect()
         when = f'mne/conf.py:Resetter.__call__:{when}:{fname}'
         # Support stuff like

--- a/mne/viz/_scraper.py
+++ b/mne/viz/_scraper.py
@@ -48,6 +48,8 @@ class _PyQtGraphScraper:
                 img_fnames.append(next(block_vars['image_path_iterator']))
                 fig.savefig(img_fnames[-1])
             gui.close()
+            del gui, pixmap
+        assert len(mne_qt_browser._browser_instances) == 0
         if not len(img_fnames):
             return ''
         for _ in range(2):

--- a/mne/viz/_scraper.py
+++ b/mne/viz/_scraper.py
@@ -49,7 +49,6 @@ class _PyQtGraphScraper:
                 fig.savefig(img_fnames[-1])
             gui.close()
             del gui, pixmap
-        assert len(mne_qt_browser._browser_instances) == 0
         if not len(img_fnames):
             return ''
         for _ in range(2):

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -23,9 +23,8 @@ else  # standard doc build
 	echo "Installing doc build dependencies"
 	python -m pip uninstall -y pydata-sphinx-theme
 	python -m pip install --upgrade --progress-bar off --only-binary "numpy,scipy,matplotlib,pandas,statsmodels" -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
-	python -m pip install --upgrade --progress-bar off https://github.com/larsoner/mne-qt-browser/zipball/disconnect
-	python -m pip uninstall -y sphinx-gallery
-	python -m pip install --upgrade --progress-bar off https://github.com/sphinx-gallery/sphinx-gallery/zipball/master https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/main
+	python -m pip uninstall -yq sphinx-gallery mne-qt-browser
+	python -m pip install --upgrade --progress-bar off https://github.com/mne-tools/mne-qt-browser/zipball/main https://github.com/sphinx-gallery/sphinx-gallery/zipball/master https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/main
 	# deal with comparisons and escapes (https://app.circleci.com/pipelines/github/mne-tools/mne-python/9686/workflows/3fd32b47-3254-4812-8b9a-8bab0d646d18/jobs/32934)
 	python -m pip install --upgrade quantities
 fi

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -24,7 +24,7 @@ else  # standard doc build
 	python -m pip uninstall -y pydata-sphinx-theme
 	python -m pip install --upgrade --progress-bar off --only-binary "numpy,scipy,matplotlib,pandas,statsmodels" -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
 	python -m pip install --upgrade --progress-bar off https://github.com/larsoner/mne-qt-browser/zipball/disconnect
-	python -m pip install --progress-bar off https://github.com/sphinx-gallery/sphinx-gallery/zipball/master https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/main
+	python -m pip install --progress-bar off https://github.com/larsoner/sphinx-gallery/zipball/del https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/main
 	# deal with comparisons and escapes (https://app.circleci.com/pipelines/github/mne-tools/mne-python/9686/workflows/3fd32b47-3254-4812-8b9a-8bab0d646d18/jobs/32934)
 	python -m pip install --upgrade quantities
 fi

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -23,7 +23,7 @@ else  # standard doc build
 	echo "Installing doc build dependencies"
 	python -m pip uninstall -y pydata-sphinx-theme
 	python -m pip install --upgrade --progress-bar off --only-binary "numpy,scipy,matplotlib,pandas,statsmodels" -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
-	python -m pip install --upgrade --progress-bar off https://github.com/mne-tools/mne-qt-browser/zipball/main
+	python -m pip install --upgrade --progress-bar off https://github.com/larsoner/mne-qt-browser/zipball/disconnect
 	python -m pip install --progress-bar off https://github.com/sphinx-gallery/sphinx-gallery/zipball/master https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/main
 	# deal with comparisons and escapes (https://app.circleci.com/pipelines/github/mne-tools/mne-python/9686/workflows/3fd32b47-3254-4812-8b9a-8bab0d646d18/jobs/32934)
 	python -m pip install --upgrade quantities

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -24,8 +24,8 @@ else  # standard doc build
 	python -m pip uninstall -y pydata-sphinx-theme
 	python -m pip install --upgrade --progress-bar off --only-binary "numpy,scipy,matplotlib,pandas,statsmodels" -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
 	python -m pip install --upgrade --progress-bar off https://github.com/larsoner/mne-qt-browser/zipball/disconnect
-        python -m pip uninstall -y sphinx-gallery
-	python -m pip install --upgrade --progress-bar off https://github.com/larsoner/sphinx-gallery/zipball/del https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/main
+	python -m pip uninstall -y sphinx-gallery
+	python -m pip install --upgrade --progress-bar off https://github.com/sphinx-gallery/sphinx-gallery/zipball/master https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/main
 	# deal with comparisons and escapes (https://app.circleci.com/pipelines/github/mne-tools/mne-python/9686/workflows/3fd32b47-3254-4812-8b9a-8bab0d646d18/jobs/32934)
 	python -m pip install --upgrade quantities
 fi

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -24,6 +24,7 @@ else  # standard doc build
 	python -m pip uninstall -y pydata-sphinx-theme
 	python -m pip install --upgrade --progress-bar off --only-binary "numpy,scipy,matplotlib,pandas,statsmodels" -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
 	python -m pip install --upgrade --progress-bar off https://github.com/larsoner/mne-qt-browser/zipball/disconnect
+        python -m pip uninstall -y sphinx-gallery
 	python -m pip install --upgrade --progress-bar off https://github.com/larsoner/sphinx-gallery/zipball/del https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/main
 	# deal with comparisons and escapes (https://app.circleci.com/pipelines/github/mne-tools/mne-python/9686/workflows/3fd32b47-3254-4812-8b9a-8bab0d646d18/jobs/32934)
 	python -m pip install --upgrade quantities

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -24,7 +24,7 @@ else  # standard doc build
 	python -m pip uninstall -y pydata-sphinx-theme
 	python -m pip install --upgrade --progress-bar off --only-binary "numpy,scipy,matplotlib,pandas,statsmodels" -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
 	python -m pip install --upgrade --progress-bar off https://github.com/larsoner/mne-qt-browser/zipball/disconnect
-	python -m pip install --progress-bar off https://github.com/larsoner/sphinx-gallery/zipball/del https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/main
+	python -m pip install --upgrade --progress-bar off https://github.com/larsoner/sphinx-gallery/zipball/del https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/main
 	# deal with comparisons and escapes (https://app.circleci.com/pipelines/github/mne-tools/mne-python/9686/workflows/3fd32b47-3254-4812-8b9a-8bab0d646d18/jobs/32934)
 	python -m pip install --upgrade quantities
 fi

--- a/tutorials/epochs/20_visualize_epochs.py
+++ b/tutorials/epochs/20_visualize_epochs.py
@@ -26,8 +26,8 @@ raw = mne.io.read_raw_fif(sample_data_raw_file, verbose=False).crop(tmax=120)
 # To create the `~mne.Epochs` data structure, we'll extract the event
 # IDs stored in the :term:`stim channel`, map those integer event IDs to more
 # descriptive condition labels using an event dictionary, and pass those to the
-# `~mne.Epochs` constructor, along with the `~mne.io.Raw` data
-# and the desired temporal limits of our epochs, ``tmin`` and ``tmax`` (for a
+# `~mne.Epochs` constructor, along with the `~mne.io.Raw` data and the
+# desired temporal limits of our epochs, ``tmin`` and ``tmax`` (for a
 # detailed explanation of these steps, see :ref:`tut-epochs-class`).
 
 events = mne.find_events(raw, stim_channel='STI 014')

--- a/tutorials/intro/10_overview.py
+++ b/tutorials/intro/10_overview.py
@@ -14,7 +14,6 @@ tutorials address each of these topics in greater detail.
 
 We begin by importing the necessary Python modules:
 """
-
 # %%
 
 import os

--- a/tutorials/intro/15_inplace.py
+++ b/tutorials/intro/15_inplace.py
@@ -12,8 +12,8 @@ computations. However, it can lead to unexpected results if you're not aware
 that it's happening. This tutorial provides a few examples of in-place
 processing, and how and when to avoid it.
 
-As usual we'll start by importing the modules we need and
-loading some :ref:`example data <sample-dataset>`:
+As usual we'll start by importing the modules we need and loading some
+:ref:`example data <sample-dataset>`:
 """
 
 # %%

--- a/tutorials/intro/15_inplace.py
+++ b/tutorials/intro/15_inplace.py
@@ -81,8 +81,8 @@ print(f'after picking, it has {original_raw.info["nchan"]} channels.')
 # sphinx_gallery_thumbnail_number=2
 rereferenced_raw, ref_data = mne.set_eeg_reference(original_raw, ['EEG 003'],
                                                    copy=True)
-original_raw.plot()
-rereferenced_raw.plot()
+fig_orig = original_raw.plot()
+fig_reref = rereferenced_raw.plot()
 
 # %%
 # Another example is the picking function `mne.pick_info`, which operates on


### PR DESCRIPTION
@marsipu I can see the gc failure with the following in the `doc` folder:
```
$ make clean && PATTERN=15_inplace MNE_SKIP_INSTANCE_ASSERTIONS="brain,_Renderer,Plotter,BackgroundPlotter,vtkPolyData" make html_dev-pattern-memory
loading intersphinx inventory from https://www.fatiando.org/pooch/latest/objects.inv...
intersphinx inventory has moved: https://dipy.org/documentation/latest/objects.inv/ -> https://dipy.org/documentation/1.4.1./objects.inv/
generating gallery...
Using Sphinx-Gallery to convert rst text blocks to markdown for .ipynb files.
Clean    8.8 s : 442.5 MBto_tutorials/intro... [ 28%] 15_inplace.py                                                                                                                 

Traceback (most recent call last):
  File "/home/larsoner/python/sphinx/sphinx/events.py", line 101, in emit
    results.append(listener.handler(self.app, *args))
  File "/home/larsoner/python/sphinx-gallery/sphinx_gallery/gen_gallery.py", line 464, in generate_gallery_rst
    generate_dir_rst(src_dir, target_dir, gallery_conf,
  File "/home/larsoner/python/sphinx-gallery/sphinx_gallery/gen_rst.py", line 399, in generate_dir_rst
    intro, title, cost = generate_file_rst(
  File "/home/larsoner/python/sphinx-gallery/sphinx_gallery/gen_rst.py", line 1030, in generate_file_rst
    clean_modules(gallery_conf, fname, 'after')
  File "/home/larsoner/python/sphinx-gallery/sphinx_gallery/scrapers.py", line 596, in clean_modules
    reset_module(gallery_conf, fname, when=when)
  File "/home/larsoner/python/mne-python/doc/conf.py", line 346, in __call__
    _assert_no_instances(PyQtGraphBrowser, when)
  File "/home/larsoner/python/mne-python/mne/utils/misc.py", line 368, in _assert_no_instances
    assert n == 0, f'\n{n} {cls.__name__} @ {when}:\n' + '\n'.join(ref)
AssertionError: 
1 PyQtGraphBrowser @ mne/conf.py:Resetter.__call__:after:15_inplace.py:
dict: len=16, 8 referrers: dict/frame/list/module
dict: len=2, 4 referrers: LoadThread/dict/list
method: <bound method PyQtGraphBrowser.change_duration of <mne_qt_browser._pg_figure.PyQtGraphBrowser object
method: <bound method PyQtGraphBrowser.change_duration of <mne_qt_browser._pg_figure.PyQtGraphBrowser object
method: <bound method PyQtGraphBrowser.change_nchan of <mne_qt_browser._pg_figure.PyQtGraphBrowser object at
method: <bound method PyQtGraphBrowser.change_nchan of <mne_qt_browser._pg_figure.PyQtGraphBrowser object at
method: <bound method PyQtGraphBrowser.scale_all of <mne_qt_browser._pg_figure.PyQtGraphBrowser object at 0x
method: <bound method PyQtGraphBrowser.scale_all of <mne_qt_browser._pg_figure.PyQtGraphBrowser object at 0x
dict: len=5, 4 referrers: AnnotationDock/dict/list
...
```
It gives us at least some debugging leads on what could be causing `gc` not to be able to collect the `PyQtGraphBrowser` instances.