### PR TITLE
BUG: Fix datetime conversion for timin/tmax=None cases in Annotations.crop

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -113,7 +113,7 @@ Enhancements
 Bugs
 ~~~~
 
-- Fix datetime conversion for tmin/tmax=None cases in :func:`mne.Annotations.crop`. Allow the use of float and None simultaneously for :func:`mne.Annotations.crop`. (:gh:`10361` by `Michiru Kaneda`_)
+- Fix datetime conversion for tmin/tmax=None cases in :meth:`mne.Annotations.crop`. Allow the use of float and None simultaneously for :meth:`mne.Annotations.crop`. (:gh:`10361` by `Michiru Kaneda`_)
 
 - Add Shift_JIST mu in :func:`mne.io.read_raw_edf` (:gh:`10356` by :newcontrib:`Michiru Kaneda`)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -113,6 +113,8 @@ Enhancements
 Bugs
 ~~~~
 
+- Fix datetime conversion for tmin/tmax=None cases in :func:`mne.Annotations.crop`. Allow the use of float and None simultaneously for :func:`mne.Annotations.crop. (:gh:`10361` by `Michiru Kaneda`)
+
 - Add Shift_JIST mu in :func:`mne.io.read_raw_edf` (:gh:`10356` by :newcontrib:`Michiru Kaneda`)
 
 - Teach :func:`mne.io.read_raw_bti` to use its ``eog_ch`` parameter (:gh:`10093` by :newcontrib:`Adina Wagner`)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -113,7 +113,7 @@ Enhancements
 Bugs
 ~~~~
 
-- Fix datetime conversion for tmin/tmax=None cases in :func:`mne.Annotations.crop`. Allow the use of float and None simultaneously for :func:`mne.Annotations.crop. (:gh:`10361` by `Michiru Kaneda`)
+- Fix datetime conversion for tmin/tmax=None cases in :func:`mne.Annotations.crop`. Allow the use of float and None simultaneously for :func:`mne.Annotations.crop`. (:gh:`10361` by `Michiru Kaneda`_)
 
 - Add Shift_JIST mu in :func:`mne.io.read_raw_edf` (:gh:`10356` by :newcontrib:`Michiru Kaneda`)
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -516,9 +516,10 @@ class Annotations(object):
         else:
             offset = self.orig_time
         if tmin is None:
-            tmin = timedelta(self.onset.min()) + offset
+            tmin = timedelta(seconds=self.onset.min()) + offset
         if tmax is None:
-            tmax = timedelta((self.onset + self.duration).max()) + offset
+            tmax = timedelta(
+                seconds=(self.onset + self.duration).max()) + offset
         for key, val in [('tmin', tmin), ('tmax', tmax)]:
             _validate_type(val, ('numeric', _datetime), key,
                            'numeric, datetime, or None')

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -523,13 +523,14 @@ class Annotations(object):
         for key, val in [('tmin', tmin), ('tmax', tmax)]:
             _validate_type(val, ('numeric', _datetime), key,
                            'numeric, datetime, or None')
-        if tmin > tmax:
-            raise ValueError('tmax should be greater than or equal to tmin '
-                             '(%s < %s).' % (tmax, tmin))
-        logger.debug('Cropping annotations to: %s - %s' % (tmin, tmax))
         absolute_tmin = _handle_meas_date(tmin)
         absolute_tmax = _handle_meas_date(tmax)
         del tmin, tmax
+        if absolute_tmin > absolute_tmax:
+            raise ValueError('tmax should be greater than or equal to tmin '
+                             '(%s < %s).' % (absolute_tmin, absolute_tmax))
+        logger.debug('Cropping annotations %s - %s' % (absolute_tmin,
+                                                       absolute_tmax))
 
         onsets, durations, descriptions, ch_names = [], [], [], []
         out_of_bounds, clip_left_elem, clip_right_elem = [], [], []

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1166,6 +1166,17 @@ def test_crop_when_negative_orig_time(windows_like_datetime):
     assert crop_annot.orig_time == orig_dt  # orig_time does not change
 
 
+def test_crop_with_none(windows_like_datetime):
+    """Test cropping with None in arguments."""
+    orig_time_stamp = 100
+    annot = Annotations(description='foo', onset=np.arange(5, 10, 1),
+                        duration=[1], orig_time=orig_time_stamp)
+    annot.crop(tmin=None, tmax=None)
+    assert len(annot) == 5
+    annot.crop(tmin=(7.5+orig_time_stamp), tmax=None)
+    assert len(annot) == 3
+
+
 def test_allow_nan_durations():
     """Deal with "n/a" strings in BIDS events with nan durations."""
     raw = RawArray(data=np.empty([2, 10], dtype=np.float64),

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1173,7 +1173,7 @@ def test_crop_with_none(windows_like_datetime):
                         duration=[1], orig_time=orig_time_stamp)
     annot.crop(tmin=None, tmax=None)
     assert len(annot) == 5
-    annot.crop(tmin=(7.5+orig_time_stamp), tmax=None)
+    annot.crop(tmin=(7.5 + orig_time_stamp), tmax=None)
     assert len(annot) == 3
 
 


### PR DESCRIPTION
#### What does this implement/fix?
In [Annotations.crop](https://github.com/mne-tools/mne-python/blob/ad095ba6e0e5b97ddbbb0def3846fa8551add30d/mne/annotations.py#L491) function,
onset values must be passed as `seconds` instead of `dates` (first argument).

Another change allows passing float and None at the same time.
Currently, if tmin or tmax is None, the value is obtained as datetime and it can not be compared with float.
By calculating `absolute` values before checking `tmin > tmax`, float can be used with None.


#### Additional information
In most cases, this bug does not affect 
because original annotations data has tmin=0, and too large tmax just allow all period.