### PR TITLE
BUG: fix stim_channel/misc usage in Sleep stage classification tutorial

### DIFF
--- a/tutorials/clinical/60_sleep.py
+++ b/tutorials/clinical/60_sleep.py
@@ -78,8 +78,8 @@ ALICE, BOB = 0, 1
 
 [alice_files, bob_files] = fetch_data(subjects=[ALICE, BOB], recording=[1])
 
-raw_train = mne.io.read_raw_edf(alice_files[0], stim_channel='marker',
-                                misc=['rectal'])
+raw_train = mne.io.read_raw_edf(alice_files[0], stim_channel='Event marker',
+                                misc=['Temp rectal'])
 annot_train = mne.read_annotations(alice_files[1])
 
 raw_train.set_annotations(annot_train, emit_warning=False)
@@ -158,8 +158,8 @@ print(epochs_train)
 # Applying the same steps to the test data from Bob
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-raw_test = mne.io.read_raw_edf(bob_files[0], stim_channel='marker',
-                               misc=['rectal'])
+raw_test = mne.io.read_raw_edf(bob_files[0], stim_channel='Event marker',
+                               misc=['Temp rectal'])
 annot_test = mne.read_annotations(bob_files[1])
 annot_test.crop(annot_test[1]['onset'] - 30 * 60,
                 annot_test[-2]['onset'] + 30 * 60)


### PR DESCRIPTION
#### Reference issue
Fixes #10360.


#### What does this implement/fix?
Fix arguments (stim_channel, misc) of [read_raw_edf](https://mne.tools/stable/generated/mne.io.read_raw_edf.html?highlight=read_raw_edf#mne.io.read_raw_edf) in the [Sleep stage classification](https://mne.tools/stable/auto_tutorials/clinical/60_sleep.html#tut-sleep-stage-classif) tutorial.