### PR TITLE
DOC: Improve CSS

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -50,11 +50,6 @@ iframe.sg_report {
     display: block;
     border-style: solid;
 }
-/* gallery thumbnail size */
-.sphx-glr-thumbcontainer {
-    min-width: 160px;
-    height: 250px;
-}
 
 /* ******************************** make HTML'd pandas dataframes scrollable */
 table.dataframe {

--- a/tutorials/epochs/40_autogenerate_metadata.py
+++ b/tutorials/epochs/40_autogenerate_metadata.py
@@ -1,8 +1,8 @@
 """
 .. _tut-autogenerate-metadata:
 
-Auto-generating ``Epochs`` metadata
-===================================
+Auto-generating Epochs metadata
+===============================
 
 This tutorial shows how to auto-generate metadata for `~mne.Epochs`, based on
 events via `mne.epochs.make_metadata`.

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -1,22 +1,23 @@
 """
 .. _tut-report:
 
-Getting started with :class:`mne.Report`
-========================================
+Getting started with mne.Report
+===============================
 
-`mne.Report` is a way to create interactive HTML summaries of your data. These
-reports can show many different visualizations for one or multiple
+:class:`mne.Report` is a way to create interactive HTML summaries of your data.
+These reports can show many different visualizations for one or multiple
 participants. A common use case is creating diagnostic summaries to check data
 quality at different stages in the processing pipeline. The report can show
 things like plots of data before and after each preprocessing step, epoch
 rejection statistics, MRI slices with overlaid BEM shells, all the way up to
 plots of estimated cortical activity.
 
-Compared to a Jupyter notebook, `mne.Report` is easier to deploy (the HTML
-pages it generates are self-contained and do not require a running Python
+Compared to a Jupyter notebook, :class:`mne.Report` is easier to deploy (the
+HTML pages it generates are self-contained and do not require a running Python
 environment) but less flexible (you can't change code and re-run something
 directly within the browser). This tutorial covers the basics of building a
-`~mne.Report`. As usual, we'll start by importing the modules and data we need:
+:class:`~mne.Report`. As usual, we'll start by importing the modules and data
+we need:
 """
 
 # %%

--- a/tutorials/inverse/10_stc_class.py
+++ b/tutorials/inverse/10_stc_class.py
@@ -1,11 +1,11 @@
 """
 .. _tut-source-estimate-class:
 
-The :class:`SourceEstimate <mne.SourceEstimate>` data structure
-===============================================================
+The SourceEstimate data structure
+=================================
 
-
-Source estimates, commonly referred to as STC (Source Time Courses),
+Source estimates, commonly referred to as
+:term:`STC (Source Time Courses) <stc>`,
 are obtained from source localization methods.
 Source localization method solve the so-called 'inverse problem'.
 MNE provides different methods for solving it:

--- a/tutorials/inverse/30_mne_dspm_loreta.py
+++ b/tutorials/inverse/30_mne_dspm_loreta.py
@@ -1,8 +1,8 @@
 """
 .. _tut-inverse-methods:
 
-Source localization with MNE/dSPM/sLORETA/eLORETA
-=================================================
+Source localization with MNE, dSPM, sLORETA, and eLORETA
+========================================================
 
 The aim of this tutorial is to teach you how to compute and apply a linear
 minimum-norm inverse method on evoked/raw/epochs data.


### PR DESCRIPTION
Minor tweaks from browsing our docs

1. Now that sphinx-gallery uses better HTML for the thumbnails, our own `style.css` tweaks are actually detrimental -- they force a minimum height when it's not necessary.
2. Having `/`-separated MNE/dSPM/... makes an example title overflow
3. Having `:class:` markup on the titles makes them look bad on the main page

All three problems are visible here:

<img width="1150" alt="Screen Shot 2022-02-20 at 4 50 09 PM" src="https://user-images.githubusercontent.com/2365790/154872603-356c8a07-58cc-49b3-9852-6776db5d749b.png">

This PR fixes them:

<img width="1150" alt="Screen Shot 2022-02-20 at 4 57 43 PM" src="https://user-images.githubusercontent.com/2365790/154872930-4cb86f3f-f005-4307-aa6e-b43d58f929ec.png">

