### PR TITLE
FIX: coreg status bar

### DIFF
--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -232,7 +232,6 @@ class CoregistrationUI(HasTraits):
             size=self._defaults["size"], bgcolor=self._defaults["bgcolor"])
         self._renderer._window_close_connect(self._close_callback)
         self._renderer.set_interaction(interaction)
-        self._renderer._status_bar_initialize()
 
         # coregistration model setup
         self._immediate_redraw = (self._renderer._kind != 'qt')
@@ -272,7 +271,6 @@ class CoregistrationUI(HasTraits):
 
         # configure UI
         self._reset_fitting_parameters()
-        self._configure_status_bar()
         self._configure_dock()
         self._configure_picking()
 
@@ -304,6 +302,8 @@ class CoregistrationUI(HasTraits):
         # must be done last
         if show:
             self._renderer.show()
+        # this must be setup once the window is shown
+        self._configure_status_bar()
         # update the view once shown
         views = {True: dict(azimuth=90, elevation=90),  # front
                  False: dict(azimuth=180, elevation=90)}  # left
@@ -1707,6 +1707,7 @@ class CoregistrationUI(HasTraits):
         self._renderer._dock_add_stretch()
 
     def _configure_status_bar(self):
+        self._renderer._status_bar_initialize()
         self._widgets['status_message'] = self._renderer._status_bar_add_label(
             "", stretch=1
         )


### PR DESCRIPTION
On Windows, `_configure_status_bar()` must be called once the window is displayed.

This PR fixes:

```
Traceback (most recent call last):
  File "C:\Users\guillaume\mne-python\1.0.0_0\Scripts\mne-script.py", line 33, in <module>
    sys.exit(load_entry_point('mne', 'console_scripts', 'mne')())
  File "c:\users\guillaume\source\mne-python\mne\commands\utils.py", line 107, in main
    cmd.run()
  File "c:\users\guillaume\source\mne-python\mne\commands\mne_coreg.py", line 85, in run
    mne.gui.coregistration(
  File "<decorator-gen-556>", line 12, in coregistration
  File "c:\users\guillaume\source\mne-python\mne\gui\__init__.py", line 193, in coregistration
    return CoregistrationUI(
  File "<decorator-gen-568>", line 12, in __init__
  File "c:\users\guillaume\source\mne-python\mne\gui\_coreg.py", line 275, in __init__
    self._configure_status_bar()
  File "c:\users\guillaume\source\mne-python\mne\gui\_coreg.py", line 1710, in _configure_status_bar
    self._widgets['status_message'] = self._renderer._status_bar_add_label(
  File "c:\users\guillaume\source\mne-python\mne\viz\backends\_qt.py", line 492, in _status_bar_add_label
    self._layout_add_widget(self._status_bar_layout, widget, stretch)
  File "c:\users\guillaume\source\mne-python\mne\viz\backends\_qt.py", line 82, in _layout_add_widget
    layout.addWidget(widget, stretch)
RuntimeError: wrapped C/C++ object of type QHBoxLayout has been deleted
``` 