### PR TITLE
DOC: Adapt annotation-tutorials to the qt-backend

### DIFF
--- a/tutorials/preprocessing/20_rejecting_bad_data.py
+++ b/tutorials/preprocessing/20_rejecting_bad_data.py
@@ -49,25 +49,18 @@ events = mne.read_events(events_file)
 # existing annotation labels can be selected for use.
 
 fig = raw.plot()
-fig.fake_keypress('a')
+fig.fake_keypress('a')  # Simulates user pressing 'a' on the keyboard.
 
 # %%
-# .. sidebar:: Annotating good spans
-#
-#     The default "BAD\_" prefix for new labels can be removed simply by
-#     pressing the backspace key four times before typing your custom
-#     annotation label.
-#
-# You can see that default annotation label is "BAD\_"; this can be edited
-# prior to pressing the "Add label" button to customize the label. The intent
-# is that users can annotate with as many or as few labels as makes sense for
-# their research needs, but that annotations marking spans that should be
-# excluded from the analysis pipeline should all begin with "BAD" or "bad"
-# (e.g., "bad_cough", "bad-eyes-closed", "bad door slamming", etc). When this
-# practice is followed, many processing steps in MNE-Python will automatically
-# exclude the "bad"-labelled spans of data; this behavior is controlled by a
-# parameter ``reject_by_annotation`` that can be found in many MNE-Python
-# functions or class constructors, including:
+# You can see that you need to add a description first to start with
+# marking spans (Push the button "Add Description" and enter the description).
+# You can use any description you like, but annotations marking spans that
+# should be excluded from the analysis pipeline should all begin with "BAD" or
+# "bad" (e.g., "bad_cough", "bad-eyes-closed", "bad door slamming", etc). When
+# this practice is followed, many processing steps in MNE-Python will
+# automatically exclude the "bad"-labelled spans of data; this behavior is
+# controlled by a parameter ``reject_by_annotation`` that can be found in many
+# MNE-Python functions or class constructors, including:
 #
 # - creation of epoched data from continuous data (:class:`mne.Epochs`)
 # - many methods of the independent components analysis class

--- a/tutorials/raw/30_annotate_raw.py
+++ b/tutorials/raw/30_annotate_raw.py
@@ -129,21 +129,32 @@ fig = raw.plot(start=2, duration=6)
 # Annotations can also be added to a `~mne.io.Raw` object interactively
 # by clicking-and-dragging the mouse in the plot window. To do this, you must
 # first enter "annotation mode" by pressing :kbd:`a` while the plot window is
-# focused; this will bring up the annotation controls window:
+# focused; this will bring up the annotation controls:
 
 fig = raw.plot(start=2, duration=6)
 fig.fake_keypress('a')
 
 # %%
-# The colored rings are clickable, and determine which existing label will be
+# The drop-down-menu on the left determines which existing label will be
 # created by the next click-and-drag operation in the main plot window. New
-# annotation descriptions can be added by typing the new description,
-# clicking the :guilabel:`Add label` button; the new description will be added
-# to the list of descriptions and automatically selected.
+# annotation descriptions can be added by clicking the :guilabel:`Add
+# description` button; the new description will be added to the list of
+# descriptions and automatically selected.
+# The following functions relate to which description is currently selected in
+# the drop-down-menu:
+# With :guilabel:`Remove description` you can remove description
+# including the annotations.
+# With :guilabel:`Edit description` you can edit
+# the description of either only one annotation (the one currently selected)
+# or all annotations of a description.
+# With :guilabel:`Set Visible` you can show or hide descriptions.
 #
 # During interactive annotation it is also possible to adjust the start and end
 # times of existing annotations, by clicking-and-dragging on the left or right
-# edges of the highlighting rectangle corresponding to that annotation.
+# edges of the highlighting rectangle corresponding to that annotation. When
+# an annotation is selected (the background of the label at the bottom changes
+# to darker) the values for start and stop are visible in two spinboxes and
+# can also be edited there.
 #
 # .. warning::
 #


### PR DESCRIPTION
#### What does this implement/fix?
This adapts the following tutorials to the qt-backend:
https://mne.tools/dev/auto_tutorials/raw/30_annotate_raw.html?highlight=annotate_raw#annotating-raw-objects-interactively
https://mne.tools/dev/auto_tutorials/preprocessing/20_rejecting_bad_data.html?highlight=rejecting_bad#annotating-bad-spans-of-data
