### PR TITLE
[ENH, MRG] Add dipole plotting to mne.viz.Brain

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -110,6 +110,8 @@ Enhancements
 
 - :meth:`mne.preprocessing.ICA.plot_sources()` is now also supported by the ``qt`` backend (:gh:`10330` by `Martin Schulz`_)
 
+- Added :meth:`mne.viz.Brain.add_dipole` and :meth:`mne.viz.Brain.add_forward` to plot dipoles on a brain (:gh:`10373` by `Alex Rockhill`_)
+
 Bugs
 ~~~~
 

--- a/examples/visualization/brain.py
+++ b/examples/visualization/brain.py
@@ -104,17 +104,22 @@ brain.show_view(distance=500)  # move back to show sensors
 # -------------------
 #
 # Dipole modeling as in :ref:`tut-dipole-orientations` can be plotted on the
-# brain as well. And, we can add taking a static image of the brain using
-# ``screenshot``, which will allow us to add a colorbar. This is useful
-# for figures in publications.
+# brain as well.
 
 brain = mne.viz.Brain('sample', subjects_dir=subjects_dir, **brain_kwargs)
 dip = mne.read_dipole(op.join(sample_dir, 'sample_audvis_set1.dip'))
 cmap = plt.get_cmap('YlOrRd')
 colors = [cmap(gof / dip.gof.max()) for gof in dip.gof]
 brain.add_dipole(dip, trans, colors=colors, scales=list(dip.amplitude * 1e8))
-brain.show_view(azimuth=-20, elevation=60, distance=500)
-img = brain.screenshot()
+brain.show_view(azimuth=-20, elevation=60, distance=300)
+img = brain.screenshot()  # for next section
+
+# %%
+# Create a screenshot for exporting the brain image
+# -------------------------------------------------
+# Also, we can a static image of the brain using ``screenshot`` (above),
+# which will allow us to add a colorbar. This is useful for figures in
+# publications.
 
 fig, ax = plt.subplots()
 ax.imshow(img)

--- a/examples/visualization/brain.py
+++ b/examples/visualization/brain.py
@@ -21,6 +21,7 @@ In this example, we'll show how to use :class:`mne.viz.Brain`.
 
 import os.path as op
 import matplotlib.pyplot as plt
+import matplotlib as mpl
 
 import mne
 from mne.datasets import sample
@@ -99,15 +100,26 @@ brain.add_sensors(evoked.info, trans)
 brain.show_view(distance=500)  # move back to show sensors
 
 # %%
-# Create a screenshot for exporting the brain image
-# -------------------------------------------------
+# Add current dipoles
+# -------------------
 #
-# For publication you may wish to take a static image of the brain,
-# for this use ``screenshot``.
+# Dipole modeling as in :ref:`tut-dipole-orientations` can be plotted on the
+# brain as well. And, we can add taking a static image of the brain using
+# ``screenshot``, which will allow us to add a colorbar. This is useful
+# for figures in publications.
 
 brain = mne.viz.Brain('sample', subjects_dir=subjects_dir, **brain_kwargs)
+dip = mne.read_dipole(op.join(sample_dir, 'sample_audvis_set1.dip'))
+cmap = plt.get_cmap('YlOrRd')
+colors = [cmap(gof / dip.gof.max()) for gof in dip.gof]
+brain.add_dipole(dip, trans, colors=colors, scales=list(dip.amplitude * 1e8))
+brain.show_view(azimuth=-20, elevation=60, distance=500)
 img = brain.screenshot()
+
 fig, ax = plt.subplots()
 ax.imshow(img)
 ax.axis('off')
-fig.suptitle('Brain')
+cax = fig.add_axes([0.9, 0.1, 0.05, 0.8])
+fig.colorbar(mpl.cm.ScalarMappable(
+    norm=mpl.colors.Normalize(vmin=0, vmax=dip.gof.max()), cmap=cmap), cax=cax)
+fig.suptitle('Dipole Fits Scaled by Amplitude and Colored by GOF')

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -558,8 +558,7 @@ def read_dipole(fname, verbose=None):
 
     Returns
     -------
-    dipole : instance of Dipole or DipoleFixed
-        The dipole.
+    %(dipole)s
 
     See Also
     --------

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -656,10 +656,7 @@ def make_forward_dipole(dipole, bem, info, trans=None, n_jobs=1, verbose=None):
 
     Parameters
     ----------
-    dipole : instance of Dipole
-        Dipole object containing position, orientation and amplitude of
-        one or more dipoles. Multiple simultaneous dipoles may be defined by
-        assigning them identical times.
+    %(dipole)s
     bem : str | dict
         The BEM filename (str) or a loaded sphere model (dict).
     info : instance of Info

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1832,7 +1832,7 @@ focalpoint : tuple, shape (3,) | None
     The focal point of the camera rendering the view: (x, y, z) in
     plot units (either m or mm).
 """
-docdict["matplotlib_color"] = """
+docdict["color_matplotlib"] = """
 color : color
     A list of anything matplotlib accepts: string, RGB, hex, etc.
 """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1201,6 +1201,14 @@ tol_kind : str
     .. versionadded:: 0.21.0
 """
 
+# Dipole
+docdict['dipole'] = """
+dipole : instance of Dipole
+    Dipole object containing position, orientation and amplitude of
+    one or more dipoles. Multiple simultaneous dipoles may be defined by
+    assigning them identical times.
+"""
+
 # Inverses
 docdict['depth'] = """
 depth : None | float | dict
@@ -1823,6 +1831,14 @@ docdict["focalpoint"] = """
 focalpoint : tuple, shape (3,) | None
     The focal point of the camera rendering the view: (x, y, z) in
     plot units (either m or mm).
+"""
+docdict["matplotlib_color"] = """
+color : color
+    A list of anything matplotlib accepts: string, RGB, hex, etc.
+"""
+docdict["alpha"] = """
+alpha : float in [0, 1]
+    Alpha level to control opacity.
 """
 docdict["clim"] = """
 clim : str | dict

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1803,6 +1803,11 @@ allow_duplicates : bool
 """
 
 # Brain plotting
+docdict["fwd"] = """
+fwd : instance of Forward
+    The forward solution. If present, the orientations of the dipoles
+    present in the forward solution are displayed.
+"""
 docdict["view"] = """
 view : str | None
     The name of the view to show (e.g. "lateral"). Other arguments

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -460,9 +460,7 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
            Defaults to ``'auto'``.
     %(meg)s
     %(eeg)s
-    fwd : instance of Forward
-        The forward solution. If present, the orientations of the dipoles
-        present in the forward solution are displayed.
+    %(fwd)s
     dig : bool | 'fiducials'
         If True, plot the digitization points; 'fiducials' to plot fiducial
         points only.
@@ -788,7 +786,8 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
                     backface_culling=True)
 
     if fwd is not None:
-        _plot_forward(renderer, fwd, to_cf_t[fwd_frame])
+        _plot_forward(renderer, fwd,
+                      to_cf_t[_frame_to_str[fwd['coord_frame']]])
 
     renderer.set_camera(azimuth=90, elevation=90,
                         distance=0.6, focalpoint=(0., 0., 0.))
@@ -1107,8 +1106,8 @@ def _plot_head_shape_points(renderer, info, to_cf_t, opacity=0.25,
     return actor
 
 
-def _plot_forward(renderer, fwd, fwd_trans, fwd_scale=1, color=None,
-                  scale=1.5e-3, alpha=1):
+def _plot_forward(renderer, fwd, fwd_trans, fwd_scale=1, scale=1.5e-3,
+                  alpha=1):
     from ..forward import Forward
     _validate_type(fwd, [Forward])
     n_dipoles = fwd['source_rr'].shape[0]
@@ -1120,13 +1119,11 @@ def _plot_forward(renderer, fwd, fwd_trans, fwd_scale=1, color=None,
     # update coordinate frame
     fwd_rr = apply_trans(fwd_trans, fwd_rr) * fwd_scale
     fwd_nn = apply_trans(fwd_trans, fwd_nn, move=False)
-    if color is None:
-        red = (1.0, 0.0, 0.0)
-        green = (0.0, 1.0, 0.0)
-        blue = (0.0, 0.0, 1.0)
-        color = (red, green, blue)
+    red = (1.0, 0.0, 0.0)
+    green = (0.0, 1.0, 0.0)
+    blue = (0.0, 0.0, 1.0)
     actors = list()
-    for ori, color in zip(range(fwd_nn.shape[1]), color):
+    for ori, color in zip(range(fwd_nn.shape[1]), (red, green, blue)):
         actor, _ = renderer.quiver3d(
             *fwd_rr.T, *fwd_nn[:, ori].T,
             color=color, mode='arrow', scale_mode='scalar',

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -346,11 +346,14 @@ def test_brain_init(renderer_pyvistaqt, tmp_path, pixel_ratio, brain_gc):
     # add dipole
     dip = Dipole(times=[0], pos=[[-0.06439933, 0.00733009, 0.06280205]],
                  amplitude=[3e-8], ori=[[0, 1, 0]], gof=50)
-    brain.add_dipole(dip, fname_trans, colors='blue', scale=5, alpha=0.5)
+    brain.add_dipole(dip, fname_trans, colors='blue', scales=5, alpha=0.5)
     brain.remove_dipole()
 
     with pytest.raises(ValueError, match='The number of colors'):
         brain.add_dipole(dip, fname_trans, colors=['red', 'blue'])
+
+    with pytest.raises(ValueError, match='The number of scales'):
+        brain.add_dipole(dip, fname_trans, scales=[1, 2])
 
     fwd = read_forward_solution(fname_fwd)
     brain.add_forward(fwd, fname_trans, alpha=0.5, scale=10)

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -19,7 +19,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 from mne import (read_source_estimate, read_evokeds, read_cov,
                  read_forward_solution, pick_types_forward,
                  SourceEstimate, MixedSourceEstimate, write_surface,
-                 VolSourceEstimate, vertex_to_mni)
+                 VolSourceEstimate, vertex_to_mni, Dipole)
 from mne.minimum_norm import apply_inverse, make_inverse_operator
 from mne.source_space import (read_source_spaces,
                               setup_volume_source_space)
@@ -342,6 +342,12 @@ def test_brain_init(renderer_pyvistaqt, tmp_path, pixel_ratio, brain_gc):
     info['chs'][0]['coord_frame'] = 99
     with pytest.raises(RuntimeError, match='must be "meg", "head" or "mri"'):
         brain.add_sensors(info, trans=fname_trans)
+
+    # add dipole
+    dip = Dipole(times=[0], pos=[[-0.06439933, 0.00733009, 0.06280205]],
+                 amplitude=[3e-8], ori=[[0, 1, 0]], gof=50)
+    brain.add_dipole(dip, fname_trans, color='red', scale=5, alpha=0.5)
+    brain.remove_dipole()
 
     # add text
     brain.add_text(x=0, y=0, text='foo')

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -349,6 +349,21 @@ def test_brain_init(renderer_pyvistaqt, tmp_path, pixel_ratio, brain_gc):
     brain.add_dipole(dip, fname_trans, color='red', scale=5, alpha=0.5)
     brain.remove_dipole()
 
+    with pytest.raises(ValueError, match='The number of colors'):
+        brain.add_dipole(dip, fname_trans, color=['red', 'blue'])
+
+    fwd = read_forward_solution(fname_fwd)
+    brain.add_dipole(fwd, fname_trans)
+    brain.remove_dipole()
+
+    # fake incorrect coordinate frame
+    fwd['coord_frame'] = 99
+    with pytest.raises(RuntimeError, match='must be "head" or "mri"'):
+        brain.add_dipole(fwd, fname_trans)
+    fwd['coord_frame'] = 2003
+    with pytest.raises(RuntimeError, match='must be "head" or "mri"'):
+        brain.add_dipole(fwd, fname_trans)
+
     # add text
     brain.add_text(x=0, y=0, text='foo')
     with pytest.raises(ValueError, match='already exists'):

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -346,23 +346,23 @@ def test_brain_init(renderer_pyvistaqt, tmp_path, pixel_ratio, brain_gc):
     # add dipole
     dip = Dipole(times=[0], pos=[[-0.06439933, 0.00733009, 0.06280205]],
                  amplitude=[3e-8], ori=[[0, 1, 0]], gof=50)
-    brain.add_dipole(dip, fname_trans, color='red', scale=5, alpha=0.5)
+    brain.add_dipole(dip, fname_trans, colors='blue', scale=5, alpha=0.5)
     brain.remove_dipole()
 
     with pytest.raises(ValueError, match='The number of colors'):
-        brain.add_dipole(dip, fname_trans, color=['red', 'blue'])
+        brain.add_dipole(dip, fname_trans, colors=['red', 'blue'])
 
     fwd = read_forward_solution(fname_fwd)
-    brain.add_dipole(fwd, fname_trans)
-    brain.remove_dipole()
+    brain.add_forward(fwd, fname_trans, alpha=0.5, scale=10)
+    brain.remove_forward()
 
     # fake incorrect coordinate frame
     fwd['coord_frame'] = 99
     with pytest.raises(RuntimeError, match='must be "head" or "mri"'):
-        brain.add_dipole(fwd, fname_trans)
+        brain.add_forward(fwd, fname_trans)
     fwd['coord_frame'] = 2003
     with pytest.raises(RuntimeError, match='must be "head" or "mri"'):
-        brain.add_dipole(fwd, fname_trans)
+        brain.add_forward(fwd, fname_trans)
 
     # add text
     brain.add_text(x=0, y=0, text='foo')

--- a/tutorials/inverse/35_dipole_orientations.py
+++ b/tutorials/inverse/35_dipole_orientations.py
@@ -45,7 +45,6 @@ trans_fname = meg_path / 'sample_audvis_raw-trans.fif'
 # intervals on the cortex, determined by the ``spacing`` parameter. The source
 # space does not define the orientation for these dipoles.
 
-
 lh = fwd['src'][0]  # Visualize the left hemisphere
 verts = lh['rr']  # The vertices of the source space
 tris = lh['tris']  # Groups of three vertices that form triangles


### PR DESCRIPTION
This adds the plotting of dipoles similar to `mne.viz.plot_alignment` to `mne.viz.Brain`. I just extended it to support plotting the forward model as well:

<img width="780" alt="Screen Shot 2022-02-21 at 11 29 09 AM" src="https://user-images.githubusercontent.com/13473576/155016131-8f1f7ec1-d064-4734-b937-a835ff82648c.png">

I touched `tutorials/inverse/35_dipole_orientations.py` so if this messed things up (especially scale) for `plot_alignment` we can fix that.