### PR TITLE
FIX: Bump deps

### DIFF
--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -12,9 +12,9 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl six cycler kiwisolver pyparsing patsy
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt5 PyQt5-sip PyQt5-Qt5
 	# SciPy Windows build is missing from conda nightly builds, and statsmodels does not work
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" "numpy<1.23.dev0+730"
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps scipy statsmodels
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" pandas scikit-learn dipy
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps scipy
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" pandas scikit-learn dipy statsmodels
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py Pillow matplotlib
 	python -m pip install --progress-bar off --upgrade --pre --only-binary "vtk" vtk
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -19,7 +19,7 @@ else
 	echo "NumPy/SciPy/pandas etc."
 	# TODO: Currently missing dipy for 3.10 https://github.com/dipy/dipy/issues/2489
 	# TODO: Revert this and Azure once https://github.com/numpy/numpy/pull/21054 is merged and a new wheel is out
-	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" "numpy<1.23.dev0+730" scipy pandas "scikit-learn>=0.24.2" statsmodels
+	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy pandas scikit-learn statsmodels
 	echo "H5py, pillow, matplotlib"
 	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py pillow matplotlib
 	# We don't install Numba here because it forces an old NumPy version


### PR DESCRIPTION
Let's see if we can lose the NumPy pins, and use nightly-built statsmodels on Windows.