### PR TITLE
ENH: Bounds around brain

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,6 +34,10 @@ Enhancements
 
 - Add show local maxima toggling button to :func:`mne.gui.locate_ieeg` (:gh:`9952` by `Alex Rockhill`_)
 
+- Show boundaries in :func:`mne.gui.locate_ieeg` (:gh:`10379` by `Eric Larson`_)
+
+- Add argument ``cval`` to :func:`mne.transforms.apply_volume_registration` to set interpolation values outside the image domain (:gh:`10379` by `Eric Larson`_)
+
 - Improve docstring of :class:`mne.Info` and add attributes that were not covered (:gh:`9922` by `Mathieu Scheltienne`_)
 
 - Add an alternate, manual procedure for aligning a CT to an MR procedure to :ref:`tut-ieeg-localize` (:gh:`9978` by `Alex Rockhill`_)

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -1059,7 +1059,6 @@ class IntracranialElectrodeLocator(QMainWindow):
 
     def _on_click(self, event, axis):
         """Move to view on MRI and CT on click."""
-        logger.info('clicked')
         if event.inaxes is self._figs[axis].axes[0]:
             # Data coordinates are voxel coordinates
             pos = (event.xdata, event.ydata)

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -286,7 +286,7 @@ class IntracranialElectrodeLocator(QMainWindow):
             # to bottom-left corner centered (all coords positive).
             if np.isnan(ras).any():
                 continue
-            xyz = apply_trans(self._ras_vox_t, ras)
+            xyz = apply_trans(self._ras_vox_t, ras) + 0.5
             # check if closest to that voxel
             dist = np.linalg.norm(xyz - self._current_slice)
             if proj or dist < self._radius:

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -730,7 +730,7 @@ class IntracranialElectrodeLocator(QMainWindow):
             self._update_moved()  # resets RAS label
             return
         if text_kind == 'vox':
-            vox = vals.round().astype(int)
+            vox = vals
             ras = apply_trans(self._vox_ras_t, vox)
         else:
             assert text_kind == 'ras'

--- a/mne/gui/tests/test_ieeg_locate_gui.py
+++ b/mne/gui/tests/test_ieeg_locate_gui.py
@@ -10,7 +10,9 @@ import pytest
 
 import mne
 from mne.datasets import testing
-from mne.utils import requires_nibabel, requires_version, catch_logging
+from mne.transforms import apply_trans
+from mne.utils import (requires_nibabel, requires_version, catch_logging,
+                       use_log_level)
 from mne.viz.utils import _fake_click
 
 data_path = testing.data_path(download=False)
@@ -30,8 +32,7 @@ def _fake_CT_coords(skull_size=5, contact_size=2):
         op.join(subjects_dir, subject, 'mri', 'brain.mgz'))
     verts = mne.read_surface(
         op.join(subjects_dir, subject, 'bem', 'outer_skull.surf'))[0]
-    verts = mne.transforms.apply_trans(
-        np.linalg.inv(brain.header.get_vox2ras_tkr()), verts)
+    verts = apply_trans(np.linalg.inv(brain.header.get_vox2ras_tkr()), verts)
     x, y, z = np.array(brain.shape).astype(int) // 2
     coords = [(x, y - 14, z), (x - 10, y - 15, z),
               (x - 20, y - 16, z + 1), (x - 30, y - 16, z + 1)]
@@ -55,8 +56,7 @@ def _fake_CT_coords(skull_size=5, contact_size=2):
             1000 - np.linalg.norm(np.array(np.meshgrid(
                 *[range(-contact_size, contact_size + 1)] * 3)), axis=0)
     ct = nib.MGHImage(ct_data, brain.affine)
-    coords = mne.transforms.apply_trans(
-        ct.header.get_vox2ras_tkr(), np.array(coords))
+    coords = apply_trans(ct.header.get_vox2ras_tkr(), np.array(coords))
     return ct, coords
 
 
@@ -154,15 +154,20 @@ def test_ieeg_elec_locate_gui_display(_locate_ieeg, _fake_CT_coords):
                            subject=subject, subjects_dir=subjects_dir,
                            verbose=True)
 
-    gui._ras[:] = coords[0]  # start in the right position
-    gui._move_cursors_to_pos()
+    with pytest.raises(ValueError, match='read-only'):
+        gui._ras[:] = coords[0]  # start in the right position
+    gui._set_ras(coords[0])
     gui._mark_ch()
     assert not gui._lines and not gui._lines_2D  # no lines for one contact
-    for coord in coords[1:]:
-        coord_vox = mne.transforms.apply_trans(gui._ras_vox_t, coord)
-        _fake_click(gui._figs[2], gui._figs[2].axes[0],
-                    coord_vox[:-1], xform='data', kind='release')
-        assert_allclose(coord, gui._ras, atol=3)  # clicks are a bit off
+    for ci, coord in enumerate(coords[1:], 1):
+        coord_vox = apply_trans(gui._ras_vox_t, coord)
+        with use_log_level('debug'):
+            _fake_click(gui._figs[2], gui._figs[2].axes[0],
+                        coord_vox[:-1], xform='data', kind='release')
+        assert_allclose(coord[:2], gui._ras[:2], atol=0.1,
+                        err_msg=f'coords[{ci}][:2]')
+        assert_allclose(coord[2], gui._ras[2], atol=2,
+                        err_msg=f'coords[{ci}][2]')
         gui._mark_ch()
 
     # ensure a 3D line was made for each group
@@ -170,15 +175,14 @@ def test_ieeg_elec_locate_gui_display(_locate_ieeg, _fake_CT_coords):
 
     # test snap to center
     gui._ch_index = 0
-    gui._ras[:] = coords[0]  # move to first position
-    gui._move_cursors_to_pos()
+    gui._set_ras(coords[0])  # move to first position
     gui._mark_ch()
     assert_allclose(coords[0], gui._chs['LAMY 1'], atol=0.2)
     gui._snap_button.click()
     assert gui._snap_button.text() == 'Off'
     # now make sure no snap happens
     gui._ch_index = 0
-    gui._ras[:] = coords[1] + 1
+    gui._set_ras(coords[1] + 1)
     gui._mark_ch()
     assert_allclose(coords[1] + 1, gui._chs['LAMY 1'], atol=0.01)
     # check that it turns back on

--- a/mne/tests/test_transforms.py
+++ b/mne/tests/test_transforms.py
@@ -530,14 +530,17 @@ def test_volume_registration():
                             moving_affine=T1.affine,
                             static_affine=T1.affine,
                             between_affine=np.linalg.inv(affine))
-    for pipeline in ('rigids', ('translation', 'sdr')):
+    for pipeline, cval in zip(('rigids', ('translation', 'sdr')), (0., '1%')):
         reg_affine, sdr_morph = mne.transforms.compute_volume_registration(
             T1_resampled, T1, pipeline=pipeline, zooms=10, niter=[5])
         assert_allclose(affine, reg_affine, atol=0.01)
         T1_aligned = mne.transforms.apply_volume_registration(
-            T1_resampled, T1, reg_affine, sdr_morph)
+            T1_resampled, T1, reg_affine, sdr_morph, cval=cval)
         r2 = _compute_r2(_get_img_fdata(T1_aligned), _get_img_fdata(T1))
         assert 99.9 < r2
+    with pytest.raises(ValueError, match='cval'):
+        mne.transforms.apply_volume_registration(
+            T1_resampled, T1, reg_affine, sdr_morph, cval='bad')
 
     # check that all orders of the pipeline work
     for pipeline_len in range(1, 5):

--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -196,7 +196,10 @@ reg_affine = np.array([
     [0.04374389, 0.99439665, -0.09623816, -97.58320673],
     [-0.11233068, 0.10061512, 0.98856381, -84.45551601],
     [0., 0., 0., 1.]])
-CT_aligned = mne.transforms.apply_volume_registration(CT_orig, T1, reg_affine)
+# use a cval='1%' here to make the values outside the domain of the CT
+# the same as the background level during interpolation
+CT_aligned = mne.transforms.apply_volume_registration(
+    CT_orig, T1, reg_affine, cval='1%')
 plot_overlay(T1, CT_aligned, 'Aligned CT Overlaid on T1', thresh=0.95)
 del CT_orig
 
@@ -359,7 +362,7 @@ reg_affine = np.array([
     [0., 0., 0., 1.]])
 # align CT
 CT_aligned_ecog = mne.transforms.apply_volume_registration(
-    CT_orig_ecog, T1_ecog, reg_affine)
+    CT_orig_ecog, T1_ecog, reg_affine, cval='1%')
 
 raw_ecog = mne.io.read_raw(op.join(misc_path, 'ecog', 'sample_ecog_ieeg.fif'))
 # use estimated `trans` which was used when the locations were found previously


### PR DESCRIPTION
Closes #9755

When working on that, I found a bunch of small stuff that I thought should be fixed:

1. Add `cval` arg to `apply_volume_registration` so that you can choose what value to use/assume outside the bounds of the image domain during interpolation. (Naming chosen to match `scipy.ndimage` convention, but we could change it.) For the CT image the background value is -1024, and passing `cval='1%'` uses the first percentile of the image data (which is -1024).
2. Refactor iEEG GUI to be much more DRY by:

    1. Routing all `self._ras` changes through a `self._update_ras(ras)` that does clipping to valid (in-image) values only
    2. Using a `self._vox` property to avoid repeated `apply_trans(...).round().astype(int)`
    3. Making `self._current_slice` a property as well

    This should also help ensure that these variables remain fully in sync.
3. Change behavior of iEEG GUI crosshairs: they should always be fixed to the domain of the image and not change with zoom
4. Add bounding box to image domain
5. Fix bug where clicking outside the image would lead to an error (now it snaps to the closest in-image location, thanks `_update_ras`!)
6. Fix bug where the images were plotted with extent `(0, img.shape[dim])` instead of `(-0.5, img.shape[dim] - 0.5)`. This reflects the fact that the voxel coordinates are for the *center* of each voxel, so the first voxel should occupy the limits `(-0.5, 0.5)` and not `(0, 1)` in the image. If the last voxel is 255 (`img.shape[dim] == 256`), its data should occupy `(254.5, 255.5)`. Hence a domain of `(-0.5, 255.5)` is correct while `(0, 256)` is off by 0.5.

`main` after one click shows the bad cval effect as well as the weird/incorrect bounds of the crosshairs:

![Screenshot from 2022-02-22 11-09-55](https://user-images.githubusercontent.com/2365790/155182258-760017a4-dbf8-4d20-abb4-72382dbfbdd3.png)

This PR after the same click shows a fixed cval and the crosshairs limited and fixed to the bounds of the domain:

![Screenshot from 2022-02-22 11-57-30](https://user-images.githubusercontent.com/2365790/155182289-e7c07b8a-d5aa-4f92-8f93-a20b39eae559.png)

Testing can be done with this little snippet:

<details>

```
# Minimal script to test the iEEG GUI

import os.path as op
import numpy as np
import nibabel as nib
import mne
misc_path = mne.datasets.misc.data_path(verbose=True)
raw = mne.io.read_raw(op.join(misc_path, 'seeg', 'sample_seeg_ieeg.fif'))
subj_trans = mne.coreg.estimate_head_mri_t(
    'sample_seeg', op.join(misc_path, 'seeg'))
reg_affine = np.array([
    [0.99270756, -0.03243313, 0.11610254, -133.094156],
    [0.04374389, 0.99439665, -0.09623816, -97.58320673],
    [-0.11233068, 0.10061512, 0.98856381, -84.45551601],
    [0., 0., 0., 1.]])
T1 = nib.load(op.join(misc_path, 'seeg', 'sample_seeg', 'mri', 'T1.mgz'))
CT_orig = nib.load(op.join(misc_path, 'seeg', 'sample_seeg_CT.mgz'))
CT_aligned = mne.transforms.apply_volume_registration(
    CT_orig, T1, reg_affine, cval='1%', verbose=True)
nib.save(CT_aligned, 'CT_aligned.nii')
CT_aligned = nib.load('CT_aligned.nii')
gui = mne.gui.locate_ieeg(raw.info, subj_trans, CT_aligned,
                          subject='sample_seeg',
                          subjects_dir=op.join(misc_path, 'seeg'))
```

</details>

Tutorial images also get updated

| main | PR |
| --- | --- |
| ![](https://mne.tools/dev/_images/sphx_glr_10_ieeg_localize_004.png) | ![sphx_glr_10_ieeg_localize_004](https://user-images.githubusercontent.com/2365790/155185749-ca4dcf56-b850-479f-83ea-781db64ea745.png) |
| ![](https://mne.tools/dev/_images/sphx_glr_10_ieeg_localize_005.png) | ![sphx_glr_10_ieeg_localize_005](https://user-images.githubusercontent.com/2365790/155185811-3c569402-38d1-45b6-884d-b7b0e2f4613c.png) |
| ![](https://mne.tools/dev/_images/sphx_glr_10_ieeg_localize_006.png) | ![sphx_glr_10_ieeg_localize_006](https://user-images.githubusercontent.com/2365790/155185954-985b356e-9a4b-4061-88be-aee7b8a354ab.png) |

