### PR TITLE
Add cortivision to list of fNIRS data that MNE can read

### DIFF
--- a/tutorials/io/30_reading_fnirs_data.py
+++ b/tutorials/io/30_reading_fnirs_data.py
@@ -40,7 +40,7 @@ The Shared Near Infrared Spectroscopy Format
 is designed by the fNIRS community in an effort to facilitate
 sharing and analysis of fNIRS data. And is the official format of the
 Society for functional near-infrared spectroscopy (SfNIRS).
-The manafacturers NIRx, Kernel, and Cortivision export data in the SNIRF
+The manufacturers NIRx, Kernel, and Cortivision export data in the SNIRF
 format, and these files can be imported in to MNE.
 SNIRF is the preferred format for reading data in to MNE-Python.
 Data stored in the SNIRF format can be read in

--- a/tutorials/io/30_reading_fnirs_data.py
+++ b/tutorials/io/30_reading_fnirs_data.py
@@ -40,6 +40,8 @@ The Shared Near Infrared Spectroscopy Format
 is designed by the fNIRS community in an effort to facilitate
 sharing and analysis of fNIRS data. And is the official format of the
 Society for functional near-infrared spectroscopy (SfNIRS).
+The manafacturers NIRx, Kernel, and Cortivision export data in the SNIRF
+format, and these files can be imported in to MNE.
 SNIRF is the preferred format for reading data in to MNE-Python.
 Data stored in the SNIRF format can be read in
 using :func:`mne.io.read_raw_snirf`.


### PR DESCRIPTION
#### What does this implement/fix?
Adds a list of fNIRS manufacturers whose data we can import using the SNIRF format.

The primary aim of the PR was to indicate that MNE can read @cortivision files correctly. Previously, our docs did not state that MNE can read cortivision files. Now, hopefully, if someone googles `fNIRS cortivision processing` then MNE will be in the results.

