### PR TITLE
FIX: close_connect

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -80,7 +80,7 @@ html-noplot:
 	@echo "Build finished. The HTML pages are in _build/html_stable."
 
 html_dev-front:
-	@PATTERN="\(plot_mne_dspm_source_localization.py\|plot_receptive_field.py\|plot_mne_inverse_label_connectivity.py\|plot_sensors_decoding.py\|plot_stats_cluster_spatio_temporal.py\|plot_20_visualize_evoked.py\)" make html_dev-pattern;
+	@PATTERN="\(30_mne_dspm_loreta.py\|50_decoding.py\|30_strf.py\|20_cluster_1samp_spatiotemporal.py\|20_visualize_evoked.py\)" make html_dev-pattern;
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) _build/dirhtml

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -6,14 +6,14 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+from datetime import datetime, timezone
+import faulthandler
 import gc
 import os
 import subprocess
 import sys
 import time
 import warnings
-from datetime import datetime, timezone
-import faulthandler
 
 import numpy as np
 import matplotlib
@@ -732,6 +732,7 @@ html_context = {
              size=xxl),
     ],
     # \u00AD is an optional hyphen (not rendered unless needed)
+    # If these are changed, the Makefile should be updated, too
     'carousel': [
         dict(title='Source Estimation',
              text='Distributed, sparse, mixed-norm, beam\u00ADformers, dipole fitting, and more.',  # noqa E501

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -179,7 +179,6 @@ class CoregistrationUI(HasTraits):
         self._mri_fids_modified = False
         self._mri_scale_modified = False
         self._accept_close_event = True
-        self._auto_cleanup = True
         self._fid_colors = tuple(
             DEFAULTS['coreg'][f'{key}_color'] for key in
             ('lpa', 'nasion', 'rpa'))
@@ -231,7 +230,8 @@ class CoregistrationUI(HasTraits):
         # setup the window
         self._renderer = _get_renderer(
             size=self._defaults["size"], bgcolor=self._defaults["bgcolor"])
-        self._renderer._window_close_connect(self._close_callback)
+        self._renderer._window_close_connect(self._clean)
+        self._renderer._window_close_connect(self._close_callback, after=False)
         self._renderer.set_interaction(interaction)
 
         # coregistration model setup
@@ -1717,10 +1717,6 @@ class CoregistrationUI(HasTraits):
             'status_message', 'hide', value=None, input_value=False
         )
 
-    def _set_automatic_cleanup(self, state):
-        """Enable/Disable automatic cleanup (for testing purposes only)."""
-        self._auto_cleanup = state
-
     def _clean(self):
         self._renderer = None
         self._widgets.clear()
@@ -1792,7 +1788,4 @@ class CoregistrationUI(HasTraits):
                 modal=not MNE_3D_BACKEND_TESTING,
             )
             self._widgets["close_dialog"].show()
-
-        if self._accept_close_event and self._auto_cleanup:
-            self._clean()
         return self._accept_close_event

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -1718,6 +1718,8 @@ class CoregistrationUI(HasTraits):
         )
 
     def _clean(self):
+        if not self._accept_close_event:
+            return
         self._renderer = None
         self._widgets.clear()
         self._actors.clear()

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -223,8 +223,9 @@ def test_coreg_gui_pyvista(tmp_path, renderer_interactive_pyvistaqt):
     assert not coreg._trans_modified
     assert op.isfile(tmp_trans)
 
+    # first, disable auto cleanup
+    coreg._renderer._window_close_disconnect(after=True)
     # test _close_callback()
-    coreg._set_automatic_cleanup(False)
     coreg.close()
     coreg._widgets['close_dialog'].trigger('Discard')  # do not save
     coreg._clean()  # finally, cleanup internal structures

--- a/mne/gui/tests/test_gui_api.py
+++ b/mne/gui/tests/test_gui_api.py
@@ -334,7 +334,15 @@ def test_gui_api(renderer_notebook, nbexec):
     # --- END: dialog ---
 
     renderer.show()
+
+    renderer._window_close_connect(lambda: mock('first'), after=False)
+    renderer._window_close_connect(lambda: mock('last'))
+    old_call_count = mock.call_count
     renderer.close()
+    if renderer._kind == 'qt':
+        assert mock.call_count == old_call_count + 2
+        assert mock.call_args_list[-1].args == ('last',)
+        assert mock.call_args_list[-2].args == ('first',)
 
 
 def test_gui_api_qt(renderer_interactive_pyvistaqt):

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -326,6 +326,14 @@ def _file_like(obj):
     return all(callable(getattr(obj, name, None)) for name in ('read', 'seek'))
 
 
+def _fullname(obj):
+    klass = obj.__class__
+    module = klass.__module__
+    if module == 'builtins':
+        return klass.__qualname__
+    return module + '.' + klass.__qualname__
+
+
 def _assert_no_instances(cls, when=''):
     __tracebackhide__ = True
     n = 0
@@ -350,14 +358,15 @@ def _assert_no_instances(cls, when=''):
                     if isinstance(r, (list, dict)):
                         rep = f'len={len(r)}'
                         r_ = gc.get_referrers(r)
-                        types = (x.__class__.__name__ for x in r_)
+                        types = (_fullname(x) for x in r_)
                         types = "/".join(sorted(set(
                             x for x in types if x is not None)))
                         rep += f', {len(r_)} referrers: {types}'
                         del r_
                     else:
                         rep = repr(r)[:100].replace('\n', ' ')
-                    ref.append(f'{r.__class__.__name__}: {rep}')
+                    name = _fullname(r)
+                    ref.append(f'{name}: {rep}')
                     count += 1
                 del r
             del rr

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -745,7 +745,7 @@ class Brain(object):
         for renderer in self._renderer._all_renderers:
             renderer.RemoveAllLights()
         # app_window cannot be set to None because it is used in __del__
-        for key in ('lighting', 'interactor'):
+        for key in ('lighting', 'interactor', '_RenderWindow'):
             setattr(self.plotter, key, None)
         # Qt LeaveEvent requires _Iren so we use _FakeIren instead of None
         # to resolve the ref to vtkGenericRenderWindowInteractor

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -844,7 +844,11 @@ class _AbstractWindow(ABC):
         self._interactor_fraction = None
 
     @abstractmethod
-    def _window_close_connect(self, func):
+    def _window_close_connect(self, func, *, after=True):
+        pass
+
+    @abstractmethod
+    def _window_close_disconnect(self, after=True):
         pass
 
     @abstractmethod

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -388,7 +388,10 @@ class _IpyBrainMplCanvas(_AbstractBrainMplCanvas, _IpyMplInterface):
 
 
 class _IpyWindow(_AbstractWindow):
-    def _window_close_connect(self, func):
+    def _window_close_connect(self, func, *, after=True):
+        pass
+
+    def _window_close_disconnect(self, after=True):
         pass
 
     def _window_get_dpi(self):

--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -189,7 +189,7 @@ del CT_resampled
 #    reg_affine, _ = mne.transforms.compute_volume_registration(
 #         CT_orig, T1, pipeline='rigids', zooms=dict(translation=5)))
 #
-# And instead we just hard-code the resulting 4x4 matrix:
+# Instead we just hard-code the resulting 4x4 matrix:
 
 reg_affine = np.array([
     [0.99270756, -0.03243313, 0.11610254, -133.094156],

--- a/tutorials/preprocessing/70_fnirs_processing.py
+++ b/tutorials/preprocessing/70_fnirs_processing.py
@@ -338,7 +338,7 @@ mne.viz.plot_evoked_topo(epochs['Left'].average(picks='hbo'), color='b',
 mne.viz.plot_evoked_topo(epochs['Right'].average(picks='hbo'), color='r',
                          axes=axes, legend=False)
 
-# Tidy the legend.
+# Tidy the legend:
 leg_lines = [line for line in axes.lines if line.get_c() == 'b'][:1]
 leg_lines.append([line for line in axes.lines if line.get_c() == 'r'][0])
 fig.legend(leg_lines, ['Left', 'Right'], loc='lower right')


### PR DESCRIPTION
Some functions need to be called before the closing event (i.e: dialog, ...etc) and some after (qt object cleanup). This PR adds a bit of flexibility to the GUI API to do just that. 

Locally, it solves the issue with doc building.
<details>

```
Traceback (most recent call last):
  File "/home/guillaume/source/anaconda3/envs/mne-py38/lib/python3.8/site-packages/sphinx/events.py", line 101, in emit
    results.append(listener.handler(self.app, *args))
  File "/home/guillaume/source/sphinx-gallery/sphinx_gallery/gen_gallery.py", line 464, in generate_gallery_rst
    generate_dir_rst(src_dir, target_dir, gallery_conf,
  File "/home/guillaume/source/sphinx-gallery/sphinx_gallery/gen_rst.py", line 399, in generate_dir_rst
    intro, title, cost = generate_file_rst(
  File "/home/guillaume/source/sphinx-gallery/sphinx_gallery/gen_rst.py", line 1031, in generate_file_rst
    clean_modules(gallery_conf, fname, 'after')
  File "/home/guillaume/source/sphinx-gallery/sphinx_gallery/scrapers.py", line 596, in clean_modules
    reset_module(gallery_conf, fname, when=when)
  File "/home/guillaume/source/mne-python/doc/conf.py", line 341, in __call__
    _assert_no_instances(Brain, when)  # calls gc.collect()
  File "/home/guillaume/source/mne-python/mne/utils/misc.py", line 368, in _assert_no_instances
    assert n == 0, f'\n{n} {cls.__name__} @ {when}:\n' + '\n'.join(ref)
AssertionError: 
4 Brain @ mne/conf.py:Resetter.__call__:after:10_ieeg_localize.py:
Brain._cleaned = True
method: <bound method Brain._clean of <mne.viz._brain._brain.Brain object at 0x7f6987b9c460>>
Brain._cleaned = True
method: <bound method Brain._clean of <mne.viz._brain._brain.Brain object at 0x7f698d666b80>>
Brain._cleaned = True
method: <bound method Brain._clean of <mne.viz._brain._brain.Brain object at 0x7f6987b0f520>>
Brain._cleaned = True
method: <bound method Brain._clean of <mne.viz._brain._brain.Brain object at 0x7f698d6665e0>>

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/guillaume/source/anaconda3/envs/mne-py38/lib/python3.8/site-packages/sphinx/cmd/build.py", line 276, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/home/guillaume/source/anaconda3/envs/mne-py38/lib/python3.8/site-packages/sphinx/application.py", line 270, in __init__
    self._init_builder()
  File "/home/guillaume/source/anaconda3/envs/mne-py38/lib/python3.8/site-packages/sphinx/application.py", line 328, in _init_builder
    self.events.emit('builder-inited')
  File "/home/guillaume/source/anaconda3/envs/mne-py38/lib/python3.8/site-packages/sphinx/events.py", line 109, in emit
    raise ExtensionError(__("Handler %r for event %r threw an exception") %
sphinx.errors.ExtensionError: Handler <function generate_gallery_rst at 0x7f69f256de50> for event 'builder-inited' threw an exception (exception: 
4 Brain @ mne/conf.py:Resetter.__call__:after:10_ieeg_localize.py:
Brain._cleaned = True
method: <bound method Brain._clean of <mne.viz._brain._brain.Brain object at 0x7f6987b9c460>>
Brain._cleaned = True
method: <bound method Brain._clean of <mne.viz._brain._brain.Brain object at 0x7f698d666b80>>
Brain._cleaned = True
method: <bound method Brain._clean of <mne.viz._brain._brain.Brain object at 0x7f6987b0f520>>
Brain._cleaned = True
method: <bound method Brain._clean of <mne.viz._brain._brain.Brain object at 0x7f698d6665e0>>)

Extension error (sphinx_gallery.gen_gallery):
Handler <function generate_gallery_rst at 0x7f69f256de50> for event 'builder-inited' threw an exception (exception: 
4 Brain @ mne/conf.py:Resetter.__call__:after:10_ieeg_localize.py:
Brain._cleaned = True
method: <bound method Brain._clean of <mne.viz._brain._brain.Brain object at 0x7f6987b9c460>>
Brain._cleaned = True
method: <bound method Brain._clean of <mne.viz._brain._brain.Brain object at 0x7f698d666b80>>
Brain._cleaned = True
method: <bound method Brain._clean of <mne.viz._brain._brain.Brain object at 0x7f6987b0f520>>
Brain._cleaned = True
method: <bound method Brain._clean of <mne.viz._brain._brain.Brain object at 0x7f698d6665e0>>)
make: *** [Makefile:60: html_dev-pattern] Error 2
```

</details>

The issue with Brain was related to `_RenderWindow` not being reset, indeed a regression from #10305
cc @larsoner 