### PR TITLE
[DOC, MRG] Fix misleading colorbar in cluster permutation example

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -219,6 +219,8 @@ Bugs
 
 - Fix a bug in :func:`mne.gui.locate_ieeg` where 2D lines on slice plots failed to update and were shown when not in maximum projection mode (:gh:`10335`, by `Alex Rockhill`_)
 
+- Fix misleading color scale in :ref:`tut-power-cluster-perm` for the plotting of cluster T-statistics (:gh:`10393` by `Alex Rockhill`_)
+
 API changes
 ~~~~~~~~~~~
 - The default browser for :meth:`raw.plot() <mne.io.Raw.plot>`, :meth:`epochs.plot() <mne.Epochs.plot>`, and :meth:`ica.plot_sources() <mne.preprocessing.ICA.plot_sources>` has been changed to the ``'qt'`` backend on systems where `mne_qt_browser <https://github.com/mne-tools/mne-qt-browser>`__ is installed. To change back to matplotlib within a session, you can use :func:`mne.viz.set_browser_backend('matplotlib') <mne.viz.set_browser_backend>`. To set it permanently on your system, you can use :func:`mne.set_config('MNE_BROWSER_BACKEND', 'matplotlib') <mne.set_config>` (:gh:`9960` by `Martin Schulz`_ and `Eric Larson`_)

--- a/tutorials/stats-sensor-space/50_cluster_between_time_freq.py
+++ b/tutorials/stats-sensor-space/50_cluster_between_time_freq.py
@@ -106,33 +106,39 @@ T_obs, clusters, cluster_p_values, H0 = \
 # -------------------------
 
 times = 1e3 * epochs_condition_1.times  # change unit to ms
-evoked_condition_1 = epochs_condition_1.average()
-evoked_condition_2 = epochs_condition_2.average()
 
-plt.figure()
-plt.subplots_adjust(0.12, 0.08, 0.96, 0.94, 0.2, 0.43)
+fig, (ax, ax2) = plt.subplots(2, 1, figsize=(6, 4))
+fig.subplots_adjust(0.12, 0.08, 0.96, 0.94, 0.2, 0.43)
 
-plt.subplot(2, 1, 1)
+# Compute the difference in evoked to determine which was greater
+# since we used a two-tailed t-test
+evoked_power_1 = epochs_power_1.mean(axis=0)
+evoked_power_2 = epochs_power_2.mean(axis=0)
+evoked_power_contrast = evoked_power_1 - evoked_power_2
+signs = np.sign(evoked_power_contrast)
+
 # Create new stats image with only significant clusters
 T_obs_plot = np.nan * np.ones_like(T_obs)
 for c, p_val in zip(clusters, cluster_p_values):
     if p_val <= 0.05:
-        T_obs_plot[c] = T_obs[c]
+        T_obs_plot[c] = T_obs[c] * signs[c]
 
-plt.imshow(T_obs,
-           extent=[times[0], times[-1], freqs[0], freqs[-1]],
-           aspect='auto', origin='lower', cmap='gray')
-plt.imshow(T_obs_plot,
-           extent=[times[0], times[-1], freqs[0], freqs[-1]],
-           aspect='auto', origin='lower', cmap='RdBu_r')
+ax.imshow(T_obs,
+          extent=[times[0], times[-1], freqs[0], freqs[-1]],
+          aspect='auto', origin='lower', cmap='gray')
+max_T = np.nanmax(abs(T_obs_plot))
+ax.imshow(T_obs_plot,
+          extent=[times[0], times[-1], freqs[0], freqs[-1]],
+          aspect='auto', origin='lower', cmap='RdBu_r',
+          vmin=-max_T, vmax=max_T)
 
-plt.xlabel('Time (ms)')
-plt.ylabel('Frequency (Hz)')
-plt.title('Induced power (%s)' % ch_name)
+ax.set_xlabel('Time (ms)')
+ax.set_ylabel('Frequency (Hz)')
+ax.set_title(f'Induced power ({ch_name})')
 
-ax2 = plt.subplot(2, 1, 2)
+# plot evoked
+evoked_condition_1 = epochs_condition_1.average()
+evoked_condition_2 = epochs_condition_2.average()
 evoked_contrast = mne.combine_evoked([evoked_condition_1, evoked_condition_2],
                                      weights=[1, -1])
 evoked_contrast.plot(axes=ax2, time_unit='s')
-
-plt.show()

--- a/tutorials/stats-sensor-space/50_cluster_between_time_freq.py
+++ b/tutorials/stats-sensor-space/50_cluster_between_time_freq.py
@@ -1,4 +1,8 @@
+# -*- coding: utf-8 -*-
 """
+
+.. _tut-power-cluster-perm:
+
 =========================================================================
 Non-parametric between conditions cluster statistic on single trial power
 =========================================================================


### PR DESCRIPTION
In the example I changed, the T-statistic for the significant clusters was plotted with no `vmin` or `vmax` arguments to `imshow` with a diverging (`RdBu_r`) colormap. The T-statistic is strictly positive so I think this is misleading as it colored significant but smaller T values blue and significant and larger T values red. The intent was, as far as I can tell, to plot decreases power in blue and increases in red, so I made a change to multiply the T statistic by the sign of the difference in means of the two conditions.

cc @agramfort since you're listed as the author and hopefully I didn't mess things up :)