### PR TITLE
ENH: Add use_orig_time option to mne.Annotations.crop

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -118,6 +118,8 @@ Enhancements
 
 - Made anterior/posterior slice scrolling in :func:`mne.gui.locate_ieeg` possible for users without page up and page down buttons by allowing angle bracket buttons to be used (:gh:`10384` by `Alex Rockhill`_)
 
+- Add use_orig_time option to :meth:`mne.Annotations.crop`. (:gh:`10396` by `Michiru Kaneda`_)
+
 Bugs
 ~~~~
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -24,6 +24,8 @@ Current (1.0.dev0)
 Enhancements
 ~~~~~~~~~~~~
 
+- Add ``use_orig_time`` option to :meth:`mne.Annotations.crop`. (:gh:`10396` by :newcontrib:`Michiru Kaneda`)
+
 - Speed up :func:`mne.preprocessing.annotate_muscle_zscore`, :func:`mne.preprocessing.annotate_movement`, and :func:`mne.preprocessing.annotate_nan` through better annotation creation (:gh:`10089` by :newcontrib:`Senwen Deng`)
 
 - Fix some unused variables in time_frequency_erds.py example (:gh:`10076` by :newcontrib:`Jan Zerfowski`)
@@ -118,12 +120,10 @@ Enhancements
 
 - Made anterior/posterior slice scrolling in :func:`mne.gui.locate_ieeg` possible for users without page up and page down buttons by allowing angle bracket buttons to be used (:gh:`10384` by `Alex Rockhill`_)
 
-- Add use_orig_time option to :meth:`mne.Annotations.crop`. (:gh:`10396` by `Michiru Kaneda`_)
-
 Bugs
 ~~~~
 
-- Fix datetime conversion for tmin/tmax=None cases in :meth:`mne.Annotations.crop`. Allow the use of float and None simultaneously for :meth:`mne.Annotations.crop`. (:gh:`10361` by `Michiru Kaneda`_)
+- Fix datetime conversion for tmin/tmax=None cases in :meth:`mne.Annotations.crop`. Allow the use of float and None simultaneously for :meth:`mne.Annotations.crop`. (:gh:`10361` by :newcontrib:`Michiru Kaneda`)
 
 - Add Shift_JIST mu in :func:`mne.io.read_raw_edf` (:gh:`10356` by :newcontrib:`Michiru Kaneda`)
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -488,7 +488,8 @@ class Annotations(object):
         self.ch_names = self.ch_names[order]
 
     @verbose
-    def crop(self, tmin=None, tmax=None, emit_warning=False, verbose=None):
+    def crop(self, tmin=None, tmax=None, emit_warning=False,
+             use_orig_time=True, verbose=None):
         """Remove all annotation that are outside of [tmin, tmax].
 
         The method operates inplace.
@@ -502,6 +503,9 @@ class Annotations(object):
         emit_warning : bool
             Whether to emit warnings when limiting or omitting annotations.
             Defaults to False.
+        use_orig_time : bool
+            Whether to use orig_time as an offset.
+            Defaults to True.
         %(verbose)s
 
         Returns
@@ -511,7 +515,7 @@ class Annotations(object):
         """
         if len(self) == 0:
             return self  # no annotations, nothing to do
-        if self.orig_time is None:
+        if not use_orig_time or self.orig_time is None:
             offset = _handle_meas_date(0)
         else:
             offset = self.orig_time

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1177,6 +1177,15 @@ def test_crop_with_none(windows_like_datetime):
     assert len(annot) == 3
 
 
+def test_crop_wo_orig_time(windows_like_datetime):
+    """Test cropping without orig_time."""
+    orig_time_stamp = 100
+    annot = Annotations(description='foo', onset=np.arange(5, 10, 1),
+                        duration=[1], orig_time=orig_time_stamp)
+    annot.crop(tmin=(7.5), tmax=None, use_orig_time=False)
+    assert len(annot) == 3
+
+
 def test_allow_nan_durations():
     """Deal with "n/a" strings in BIDS events with nan durations."""
     raw = RawArray(data=np.empty([2, 10], dtype=np.float64),


### PR DESCRIPTION
#### What does this implement/fix?
[mne.Annotations.crop](https://mne.tools/stable/generated/mne.Annotations.html#mne.Annotations.crop) can accept both `float` and `datetime` types for `tmin` and `tmax`.

If the Annotations object does not have the `orig_time` parameter, float values correspond to `onset` values in the Annotations object.

If `orig_time` exists, users need to obtain unix time of orig_time and add it to onset values.

`use_orig_time=False` allows to use `onset` values directly even if `orig_time` exists.

