### PR TITLE
ENH: dialog button id

### DIFF
--- a/mne/gui/tests/test_gui_api.py
+++ b/mne/gui/tests/test_gui_api.py
@@ -319,7 +319,7 @@ def test_gui_api(renderer_notebook, nbexec):
             assert mock.call_args.args == (button,)
 
         # buttons list empty means OK button (default)
-        button = 'OK'
+        button = 'Ok'
         widget = renderer._dialog_warning(
             title='',
             text='',

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -626,7 +626,7 @@ class _AbstractPlayback(ABC):
 class _AbstractDialog(ABC):
     @abstractmethod
     def _dialog_warning(self, title, text, info_text, callback, *,
-                        modal=True, window=None):
+                        buttons=[], modal=True, window=None):
         pass
 
 

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -21,7 +21,7 @@ from ._pyvista import _PyVistaRenderer, _close_all, _set_3d_view, _set_3d_title 
 
 class _IpyDialog(_AbstractDialog):
     def _dialog_warning(self, title, text, info_text, callback, *,
-                        modal=True, window=None):
+                        buttons=[], modal=True, window=None):
         pass
 
 


### PR DESCRIPTION
This PR refactors Qt dialog button management and switches from using `button.text()` (which is platform/desktop dependant) to using the [Qt standard button enum value](https://doc.qt.io/qt-5/qmessagebox.html#StandardButton-enum) (called `button_id` in the PR).

It's an item of https://github.com/mne-tools/mne-python/pull/10378