### PR TITLE
ENH: Autodetect mesa and disable antialiasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,6 @@ jobs:
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
               echo "export XDG_RUNTIME_DIR=/tmp/runtime-circleci" >> $BASH_ENV
               echo "export MNE_FULL_DATE=true" >> $BASH_ENV
-              echo "export MNE_3D_OPTION_ANTIALIAS=false" >> $BASH_ENV
               source tools/get_minimal_commands.sh
               echo "export MNE_3D_BACKEND=pyvistaqt" >> $BASH_ENV
               echo "export MNE_BROWSER_BACKEND=qt" >> $BASH_ENV

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -217,6 +217,8 @@ Bugs
 
 - Fix plotting bug in :ref:`ex-electrode-pos-2d` and make view look more natural in :ref:`ex-movement-detect` (:gh:`10313`, by `Alex Rockhill`_)
 
+- Fix bug with blank 3D rendering with MESA software rendering (:gh:`10400` by `Eric Larson`_)
+
 - Fix a bug in :func:`mne.gui.locate_ieeg` where 2D lines on slice plots failed to update and were shown when not in maximum projection mode (:gh:`10335`, by `Alex Rockhill`_)
 
 - Fix baseline removal using ``remove_dc=True`` in :meth:`raw.plot() <mne.io.Raw.plot>` for data containing ``np.nan`` (:gh:`10392` by `Clemens Brunner`_)

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -670,7 +670,7 @@ class _PyVistaRenderer(_AbstractRenderer):
             # MESA (could use GPUInfo / _get_gpu_info here, but it takes
             # > 700 ms to make a new window + report capabilities!)
             # CircleCI's is: "Mesa 20.0.8 via llvmpipe (LLVM 10.0.0, 256 bits)"
-            gpu_info = self.renderer.ReportCapabilities()
+            gpu_info = self.plotter.ren_win.ReportCapabilities()
             gpu_info = re.findall("OpenGL renderer string:(.+)\n", gpu_info)
             bad_system |= 'mesa' in ' '.join(gpu_info).lower().split()
             if not bad_system:


### PR DESCRIPTION
Closes #10391

We actually *shouldn't* use `_get_gpu_info` from #10385 because it takes 740 ms on my powerful workstation, which is too much. So instead we'll just use the already-opened renderer to call `plotter.ren_win.ReportCapabilities()`, which takes a negligible amount of time (< 1 ms).