### PR TITLE
[BUG, ENH, MRG] Tename clustering that uses F-tests to F_obs and refactor to allow time-frequency spatiotemporal clusters

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -229,9 +229,9 @@ Bugs
 
 - Fix baseline removal using ``remove_dc=True`` in :meth:`raw.plot() <mne.io.Raw.plot>` for data containing ``np.nan`` (:gh:`10392` by `Clemens Brunner`_)
 
-- Fix misleading color scale in :ref:`tut-timefreq-twoway-anova` for plotting F-stats (:gh:`10401` by `Alex Rockhill_`)
+- Fix misleading color scale in :ref:`tut-timefreq-twoway-anova` for plotting F-stats (:gh:`10401` by `Alex Rockhill`_)
 
-- Fix misleading ``T_obs`` return name for :func:`mne.stats.spatiotemporal_cluster_test` when the default returns an F-statistic (:gh:`10401` by `Alex Rockhill`_)
+- Fix misleading ``T_obs`` return name for :func:`mne.stats.spatio_temporal_cluster_test` when the default returns an F-statistic (:gh:`10401` by `Alex Rockhill`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -120,6 +120,8 @@ Enhancements
 
 - Made anterior/posterior slice scrolling in :func:`mne.gui.locate_ieeg` possible for users without page up and page down buttons by allowing angle bracket buttons to be used (:gh:`10384` by `Alex Rockhill`_)
 
+- Add support for passing time-frequency data to :func:`mne.stats.spatio_temporal_cluster_test` and :func:`mne.stats.spatio_temporal_cluster_1samp_test` and added an example to :ref:`tut-cluster-spatiotemporal-sensor` (:gh:`10384` by `Alex Rockhill`_)
+
 Bugs
 ~~~~
 
@@ -223,9 +225,13 @@ Bugs
 
 - Fix a bug in :func:`mne.gui.locate_ieeg` where 2D lines on slice plots failed to update and were shown when not in maximum projection mode (:gh:`10335`, by `Alex Rockhill`_)
 
-- Fix misleading color scale in :ref:`tut-cluster-tfr` for the plotting of cluster T-statistics (:gh:`10393` by `Alex Rockhill`_)
+- Fix misleading color scale in :ref:`tut-power-cluster-perm` for the plotting of cluster F-statistics (:gh:`10393` by `Alex Rockhill`_)
 
 - Fix baseline removal using ``remove_dc=True`` in :meth:`raw.plot() <mne.io.Raw.plot>` for data containing ``np.nan`` (:gh:`10392` by `Clemens Brunner`_)
+
+- Fix misleading color scale in :ref:`tut-timefreq-twoway-anova` for plotting F-stats (:gh:`10401` by `Alex Rockhill_`)
+
+- Fix misleading ``T_obs`` return name for :func:`mne.stats.spatiotemporal_cluster_test` when the default returns an F-statistic (:gh:`10401` by `Alex Rockhill`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -225,7 +225,7 @@ Bugs
 
 - Fix a bug in :func:`mne.gui.locate_ieeg` where 2D lines on slice plots failed to update and were shown when not in maximum projection mode (:gh:`10335`, by `Alex Rockhill`_)
 
-- Fix misleading color scale in :ref:`tut-power-cluster-perm` for the plotting of cluster F-statistics (:gh:`10393` by `Alex Rockhill`_)
+- Fix misleading color scale in :ref:`tut-cluster-tfr` for the plotting of cluster F-statistics (:gh:`10393` by `Alex Rockhill`_)
 
 - Fix baseline removal using ``remove_dc=True`` in :meth:`raw.plot() <mne.io.Raw.plot>` for data containing ``np.nan`` (:gh:`10392` by `Clemens Brunner`_)
 

--- a/examples/time_frequency/time_frequency_erds.py
+++ b/examples/time_frequency/time_frequency_erds.py
@@ -176,8 +176,7 @@ g = sns.FacetGrid(df_mean, col='condition', col_order=['hands', 'feet'],
 g = (g.map(sns.violinplot, 'channel', 'value', 'band', n_boot=10,
            palette='deep', order=['C3', 'Cz', 'C4'],
            hue_order=freq_bands_of_interest,
-           linewidth=0.5)
-      .add_legend(ncol=4, loc='lower center'))
+           linewidth=0.5).add_legend(ncol=4, loc='lower center'))
 
 g.map(plt.axhline, **axline_kw)
 g.set_axis_labels("", "ERDS (%)")

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1266,28 +1266,18 @@ def spatio_temporal_cluster_1samp_test(
     ----------
     .. footbibliography::
     """
-    out_reshape = (X.shape[1],)  # 1D data shape
-    if X.ndim > 3:
-        out_reshape = X.shape[1:-1]
-        X = X.reshape(X.shape[0], np.prod(X.shape[1:-1]), X.shape[-1])
-    n_samples, n_times, n_vertices = X.shape
     # convert spatial_exclude before passing on if necessary
     if spatial_exclude is not None:
-        exclude = _st_mask_from_s_inds(n_times, n_vertices,
-                                       spatial_exclude, True)
+        exclude = _st_mask_from_s_inds(
+            np.prod(X.shape[1:-1]), X.shape[-1], spatial_exclude, True)
     else:
         exclude = None
-    t_obs, clusters, cluster_pv, H0 = permutation_cluster_1samp_test(
+    return permutation_cluster_1samp_test(
         X, threshold=threshold, stat_fun=stat_fun, tail=tail,
         n_permutations=n_permutations, adjacency=adjacency,
         n_jobs=n_jobs, seed=seed, max_step=max_step, exclude=exclude,
         step_down_p=step_down_p, t_power=t_power, out_type=out_type,
         check_disjoint=check_disjoint, buffer_size=buffer_size)
-    t_obs = np.squeeze(t_obs.reshape((*out_reshape, X.shape[-1])))
-    clusters = [c.reshape((*out_reshape, X.shape[-1])) if out_type == 'mask'
-                else (*np.unravel_index(c[0], out_reshape), c[1])
-                for c in clusters]
-    return t_obs, clusters, cluster_pv, H0
 
 
 @verbose
@@ -1346,29 +1336,18 @@ def spatio_temporal_cluster_test(
     ----------
     .. footbibliography::
     """
-    out_reshape = (X[0].shape[1],)  # 1D data shape
-    if X[0].ndim > 3:
-        out_reshape = X[0].shape[1:-1]
-        X = [x.reshape(x.shape[0], np.prod(x.shape[1:-1]), x.shape[-1])
-             for x in X]
-    n_samples, n_times, n_vertices = X[0].shape
     # convert spatial_exclude before passing on if necessary
     if spatial_exclude is not None:
-        exclude = _st_mask_from_s_inds(n_times, n_vertices,
-                                       spatial_exclude, True)
+        exclude = _st_mask_from_s_inds(
+            np.prod(X[0].shape[1:-1]), X[0].shape[-1], spatial_exclude, True)
     else:
         exclude = None
-    F_obs, clusters, cluster_pv, H0 = permutation_cluster_test(
+    return permutation_cluster_test(
         X, threshold=threshold, stat_fun=stat_fun, tail=tail,
         n_permutations=n_permutations, adjacency=adjacency,
         n_jobs=n_jobs, seed=seed, max_step=max_step, exclude=exclude,
         step_down_p=step_down_p, t_power=t_power, out_type=out_type,
         check_disjoint=check_disjoint, buffer_size=buffer_size)
-    F_obs = np.squeeze(F_obs.reshape((*out_reshape, X[0].shape[-1])))
-    clusters = [c.reshape((*out_reshape, X.shape[-1])) if out_type == 'mask'
-                else (*np.unravel_index(c[0], out_reshape), c[1])
-                for c in clusters]
-    return F_obs, clusters, cluster_pv, H0
 
 
 def _st_mask_from_s_inds(n_times, n_vertices, vertices, set_as=True):

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1106,7 +1106,7 @@ def permutation_cluster_test(
 
     Returns
     -------
-    F_obs : array, shape (n_tests,)
+    F_obs : array, shape (p[, q])
         Statistic (F by default) observed for all variables.
     clusters : list
         List type defined by out_type above.
@@ -1166,7 +1166,7 @@ def permutation_cluster_1samp_test(
 
     Returns
     -------
-    t_obs : array, shape (n_tests,)
+    t_obs : array, shape (p[, q])
         T-statistic observed for all variables.
     clusters : list
         List type defined by out_type above.
@@ -1250,7 +1250,7 @@ def spatio_temporal_cluster_1samp_test(
 
     Returns
     -------
-    t_obs : array, shape (n_times * n_vertices,)
+    t_obs : array, shape (n_times, n_vertices)
         T-statistic observed for all variables.
     clusters : list
         List type defined by out_type above.
@@ -1319,8 +1319,8 @@ def spatio_temporal_cluster_test(
 
     Returns
     -------
-    t_obs : array, shape (n_times * n_vertices,)
-        Statistic (t by default) observed for all variables.
+    F_obs : array, shape (n_times, n_vertices)
+        Statistic (F by default) observed for all variables.
     clusters : list
         List type defined by out_type above.
     cluster_pv: array

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1253,7 +1253,7 @@ def spatio_temporal_cluster_1samp_test(
 
     Returns
     -------
-    t_obs : array, shape (n_times, n_vertices)
+    t_obs : array, shape (p[, q], n_vertices)
         T-statistic observed for all variables.
     clusters : list
         List type defined by out_type above.
@@ -1333,7 +1333,7 @@ def spatio_temporal_cluster_test(
 
     Returns
     -------
-    F_obs : array, shape (n_times, n_vertices)
+    F_obs : array, shape (p[, q], n_vertices)
         Statistic (F by default) observed for all variables.
     clusters : list
         List type defined by out_type above.

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -1266,7 +1266,7 @@ def spatio_temporal_cluster_1samp_test(
     ----------
     .. footbibliography::
     """
-    out_reshape = (-1,)
+    out_reshape = (X.shape[1],)  # 1D data shape
     if X.ndim > 3:
         out_reshape = X.shape[1:-1]
         X = X.reshape(X.shape[0], np.prod(X.shape[1:-1]), X.shape[-1])
@@ -1284,6 +1284,9 @@ def spatio_temporal_cluster_1samp_test(
         step_down_p=step_down_p, t_power=t_power, out_type=out_type,
         check_disjoint=check_disjoint, buffer_size=buffer_size)
     t_obs = np.squeeze(t_obs.reshape((*out_reshape, X.shape[-1])))
+    clusters = [c.reshape((*out_reshape, X.shape[-1])) if out_type == 'mask'
+                else (*np.unravel_index(c[0], out_reshape), c[1])
+                for c in clusters]
     return t_obs, clusters, cluster_pv, H0
 
 
@@ -1343,9 +1346,9 @@ def spatio_temporal_cluster_test(
     ----------
     .. footbibliography::
     """
-    out_reshape = (-1,)
+    out_reshape = (X[0].shape[1],)  # 1D data shape
     if X[0].ndim > 3:
-        out_reshape = X[0].shape[2:-1]
+        out_reshape = X[0].shape[1:-1]
         X = [x.reshape(x.shape[0], np.prod(x.shape[1:-1]), x.shape[-1])
              for x in X]
     n_samples, n_times, n_vertices = X[0].shape
@@ -1362,6 +1365,9 @@ def spatio_temporal_cluster_test(
         step_down_p=step_down_p, t_power=t_power, out_type=out_type,
         check_disjoint=check_disjoint, buffer_size=buffer_size)
     F_obs = np.squeeze(F_obs.reshape((*out_reshape, X[0].shape[-1])))
+    clusters = [c.reshape((*out_reshape, X.shape[-1])) if out_type == 'mask'
+                else (*np.unravel_index(c[0], out_reshape), c[1])
+                for c in clusters]
     return F_obs, clusters, cluster_pv, H0
 
 

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -407,11 +407,13 @@ def f_mway_rm(data, factor_levels, effects='all',
                  (df1 * np.sum(np.sum(v * v, axis=2), axis=1)))
             eps = v
         df1, df2 = np.zeros(n_obs) + df1, np.zeros(n_obs) + df2
+
         if correction:
             # numerical imprecision can cause eps=0.99999999999999989
             # even with a single category, so never let our degrees of
             # freedom drop below 1.
             df1, df2 = [np.maximum(d[None, :] * eps, 1.) for d in (df1, df2)]
+
         if return_pvals:
             pvals = f(df1, df2).sf(fvals)
         else:

--- a/mne/stats/parametric.py
+++ b/mne/stats/parametric.py
@@ -385,9 +385,11 @@ def f_mway_rm(data, factor_levels, effects='all',
         out_reshape = data.shape[2:]
         data = data.reshape(
             data.shape[0], data.shape[1], np.prod(data.shape[2:]))
+
     effect_picks, _ = _map_effects(len(factor_levels), effects)
     n_obs = data.shape[2]
     n_replications = data.shape[0]
+
     # put last axis in front to 'iterate' over mass univariate instances.
     data = np.rollaxis(data, 2)
     fvalues, pvalues = [], []
@@ -406,8 +408,8 @@ def f_mway_rm(data, factor_levels, effects='all',
             v = (np.array([np.trace(vv) for vv in v]) ** 2 /
                  (df1 * np.sum(np.sum(v * v, axis=2), axis=1)))
             eps = v
-        df1, df2 = np.zeros(n_obs) + df1, np.zeros(n_obs) + df2
 
+        df1, df2 = np.zeros(n_obs) + df1, np.zeros(n_obs) + df2
         if correction:
             # numerical imprecision can cause eps=0.99999999999999989
             # even with a single category, so never let our degrees of

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -645,6 +645,7 @@ def test_permutation_test_H0(numba_conditional):
         assert_equal(len(h0), min(n_permutations, 64))
         assert isinstance(clust[0], tuple)  # sets of indices
     for tail, thresh in zip((-1, 0, 1), (-0.1, 0.1, 0.1)):
+        print(data.shape, '\n' * 10)
         t, clust, p, h0 = spatio_temporal_cluster_1samp_test(
             data, threshold=thresh, seed=rng, tail=tail, out_type='mask')
         assert isinstance(clust[0], np.ndarray)  # bool mask

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -361,6 +361,7 @@ def test_cluster_permutation_with_adjacency(numba_conditional):
         out_adjacency_5 = spatio_temporal_func(
             X1d_3, n_permutations=50, adjacency=adjacency,
             max_step=1, threshold=1.67)
+
         # clusters could be in a different order
         sums_4 = [np.sum(out_adjacency_4[0][a])
                   for a in out_adjacency_4[1]]

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -645,7 +645,6 @@ def test_permutation_test_H0(numba_conditional):
         assert_equal(len(h0), min(n_permutations, 64))
         assert isinstance(clust[0], tuple)  # sets of indices
     for tail, thresh in zip((-1, 0, 1), (-0.1, 0.1, 0.1)):
-        print(data.shape, '\n' * 10)
         t, clust, p, h0 = spatio_temporal_cluster_1samp_test(
             data, threshold=thresh, seed=rng, tail=tail, out_type='mask')
         assert isinstance(clust[0], np.ndarray)  # bool mask

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -361,7 +361,6 @@ def test_cluster_permutation_with_adjacency(numba_conditional):
         out_adjacency_5 = spatio_temporal_func(
             X1d_3, n_permutations=50, adjacency=adjacency,
             max_step=1, threshold=1.67)
-
         # clusters could be in a different order
         sums_4 = [np.sum(out_adjacency_4[0][a])
                   for a in out_adjacency_4[1]]

--- a/mne/stats/tests/test_parametric.py
+++ b/mne/stats/tests/test_parametric.py
@@ -90,6 +90,12 @@ def test_f_twoway_rm():
         assert (fvals_ >= 0).all()
         assert fvals_.size == n_effects
 
+    # check time-frequency input
+    n_subj, n_freqs, n_times, n_levels = (5, 10, 101, 4)
+    data = rng.random_sample([n_subj, n_levels, n_freqs, n_times])
+    fvals, pvals = f_mway_rm(data, _effects[n_levels])
+    assert fvals.shape[1:] == pvals.shape[1:] == (n_freqs, n_times)
+
     data = rng.random_sample([n_subj, n_levels, 1])
     pytest.raises(ValueError, f_mway_rm, data, _effects[n_levels],
                   effects='C', correction=correction)

--- a/tutorials/stats-sensor-space/50_cluster_between_time_freq.py
+++ b/tutorials/stats-sensor-space/50_cluster_between_time_freq.py
@@ -100,7 +100,7 @@ epochs_power_2 = tfr_epochs_2.data[:, 0, :, :]  # only 1 channel as 3D matrix
 # Compute statistic
 # -----------------
 threshold = 6.0
-T_obs, clusters, cluster_p_values, H0 = \
+F_obs, clusters, cluster_p_values, H0 = \
     permutation_cluster_test([epochs_power_1, epochs_power_2], out_type='mask',
                              n_permutations=100, threshold=threshold, tail=0)
 
@@ -113,27 +113,27 @@ times = 1e3 * epochs_condition_1.times  # change unit to ms
 fig, (ax, ax2) = plt.subplots(2, 1, figsize=(6, 4))
 fig.subplots_adjust(0.12, 0.08, 0.96, 0.94, 0.2, 0.43)
 
-# Compute the difference in evoked to determine which was greater
-# since we used a two-tailed t-test
+# Compute the difference in evoked to determine which was greater since
+# we used a 1-way ANOVA which tested for a difference in population means
 evoked_power_1 = epochs_power_1.mean(axis=0)
 evoked_power_2 = epochs_power_2.mean(axis=0)
 evoked_power_contrast = evoked_power_1 - evoked_power_2
 signs = np.sign(evoked_power_contrast)
 
 # Create new stats image with only significant clusters
-T_obs_plot = np.nan * np.ones_like(T_obs)
+F_obs_plot = np.nan * np.ones_like(F_obs)
 for c, p_val in zip(clusters, cluster_p_values):
     if p_val <= 0.05:
-        T_obs_plot[c] = T_obs[c] * signs[c]
+        F_obs_plot[c] = F_obs[c] * signs[c]
 
-ax.imshow(T_obs,
+ax.imshow(F_obs,
           extent=[times[0], times[-1], freqs[0], freqs[-1]],
           aspect='auto', origin='lower', cmap='gray')
-max_T = np.nanmax(abs(T_obs_plot))
-ax.imshow(T_obs_plot,
+max_F = np.nanmax(abs(F_obs_plot))
+ax.imshow(F_obs_plot,
           extent=[times[0], times[-1], freqs[0], freqs[-1]],
           aspect='auto', origin='lower', cmap='RdBu_r',
-          vmin=-max_T, vmax=max_T)
+          vmin=-max_F, vmax=max_F)
 
 ax.set_xlabel('Time (ms)')
 ax.set_ylabel('Frequency (Hz)')

--- a/tutorials/stats-sensor-space/75_cluster_ftest_spatiotemporal.py
+++ b/tutorials/stats-sensor-space/75_cluster_ftest_spatiotemporal.py
@@ -109,7 +109,7 @@ cluster_stats = spatio_temporal_cluster_test(X, n_permutations=1000,
                                              n_jobs=1, buffer_size=None,
                                              adjacency=adjacency)
 
-T_obs, clusters, p_values, _ = cluster_stats
+F_obs, clusters, p_values, _ = cluster_stats
 good_cluster_inds = np.where(p_values < p_accept)[0]
 
 # %%
@@ -135,7 +135,7 @@ for i_clu, clu_idx in enumerate(good_cluster_inds):
     time_inds = np.unique(time_inds)
 
     # get topography for F stat
-    f_map = T_obs[time_inds, ...].mean(axis=0)
+    f_map = F_obs[time_inds, ...].mean(axis=0)
 
     # get signals at the sensors contributing to the cluster
     sig_times = epochs.times[time_inds]

--- a/tutorials/stats-sensor-space/75_cluster_ftest_spatiotemporal.py
+++ b/tutorials/stats-sensor-space/75_cluster_ftest_spatiotemporal.py
@@ -27,7 +27,6 @@ the possible interpretation of "significant" clusters.
 import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
-from scipy import stats
 
 import mne
 from mne.stats import spatio_temporal_cluster_test, combine_adjacency
@@ -227,8 +226,9 @@ tfr_adjacency = combine_adjacency(
 # large cluster). For a more principled method of setting this parameter,
 # threshold-free cluster enhancement may be used or the p-value may be set with
 #
-# .. code-block::
+# .. code-block:: python
 #
+#     from scipy import stats
 #     n_comparisons = len(X)  # L auditory vs L visual stimulus
 #     n_conditions = X[0].shape[0]  # 55 epochs per comparison
 #     threshold = stats.distributions.f.ppf(

--- a/tutorials/stats-sensor-space/75_cluster_ftest_spatiotemporal.py
+++ b/tutorials/stats-sensor-space/75_cluster_ftest_spatiotemporal.py
@@ -18,6 +18,7 @@ the possible interpretation of "significant" clusters.
 """
 # Authors: Denis Engemann <denis.engemann@gmail.com>
 #          Jona Sassenhagen <jona.sassenhagen@gmail.com>
+#          Alex Rockhill <aprockhill@mailbox.org>
 #
 # License: BSD-3-Clause
 
@@ -32,6 +33,7 @@ from mne.stats import spatio_temporal_cluster_test
 from mne.datasets import sample
 from mne.channels import find_ch_adjacency
 from mne.viz import plot_compare_evokeds
+from mne.time_frequency import tfr_morlet
 
 print(__doc__)
 
@@ -75,11 +77,13 @@ adjacency, ch_names = find_ch_adjacency(epochs.info, ch_type='mag')
 
 print(type(adjacency))  # it's a sparse matrix!
 
-plt.imshow(adjacency.toarray(), cmap='gray', origin='lower',
-           interpolation='nearest')
-plt.xlabel('{} Magnetometers'.format(len(ch_names)))
-plt.ylabel('{} Magnetometers'.format(len(ch_names)))
-plt.title('Between-sensor adjacency')
+fig, ax = plt.subplots(figsize=(5, 4))
+ax.imshow(adjacency.toarray(), cmap='gray', origin='lower',
+          interpolation='nearest')
+ax.set_xlabel('{} Magnetometers'.format(len(ch_names)))
+ax.set_ylabel('{} Magnetometers'.format(len(ch_names)))
+ax.set_title('Between-sensor adjacency')
+fig.tight_layout()
 
 # %%
 # Compute permutation statistic
@@ -181,6 +185,104 @@ for i_clu, clu_idx in enumerate(good_cluster_inds):
     mne.viz.tight_layout(fig=fig)
     fig.subplots_adjust(bottom=.05)
     plt.show()
+
+# %%
+# Permutation statistic for time-frequencies
+# ------------------------------------------
+#
+# Let's do the same thing with the time-frequency decomposition of the data
+# (see :ref:`tut-sensors-time-freq` for a tutorial and
+# :ref:`ex-tfr-comparison` for a comparison of time-frequency methods) to
+# show how cluster permutations can be done on higher-dimensional data.
+
+decim = 4
+freqs = np.arange(7, 30, 3)  # define frequencies of interest
+n_cycles = freqs / freqs[0]
+
+epochs_power = list()
+for condition in [epochs[k] for k in ('Aud/L', 'Vis/L')]:
+    this_tfr = tfr_morlet(condition, freqs, n_cycles=n_cycles,
+                          decim=decim, average=False, return_itc=False)
+    this_tfr.apply_baseline(mode='ratio', baseline=(None, 0))
+    epochs_power.append(this_tfr.data)
+
+# transpose again to (epochs, frequencies, times, vertices)
+X = [np.transpose(x, (0, 2, 3, 1)) for x in epochs_power]
+
+# set cluster threshold
+threshold = 6.0  # default threshold for time-frequency
+
+# run statistic
+cluster_stats = spatio_temporal_cluster_test(X, n_permutations=1000,
+                                             threshold=threshold, tail=1,
+                                             n_jobs=1, buffer_size=None,
+                                             adjacency=adjacency)
+
+F_obs, clusters, p_values, _ = cluster_stats
+good_cluster_inds = np.where(p_values < p_accept)[0]
+
+for i_clu, clu_idx in enumerate(good_cluster_inds):
+    # unpack cluster information, get unique indices
+    freq_inds, time_inds, space_inds = clusters[clu_idx]
+    ch_inds = np.unique(space_inds)
+    time_inds = np.unique(time_inds)
+    freq_inds = np.atleast_2d(np.unique(freq_inds))
+
+    # get topography for F stat
+    f_map = F_obs[freq_inds, time_inds, ...].mean(axis=(0, 1))
+
+    # get signals at the sensors contributing to the cluster
+    sig_times = epochs.times[time_inds]
+
+    # initialize figure
+    fig, ax_topo = plt.subplots(1, 1, figsize=(10, 3))
+
+    # create spatial mask
+    mask = np.zeros((f_map.shape[0], 1), dtype=bool)
+    mask[ch_inds, :] = True
+
+    # plot average test statistic and mark significant sensors
+    f_evoked = mne.EvokedArray(f_map[:, np.newaxis], epochs.info, tmin=0)
+    f_evoked.plot_topomap(times=0, mask=mask, axes=ax_topo, cmap='Reds',
+                          vmin=np.min, vmax=np.max, show=False,
+                          colorbar=False, mask_params=dict(markersize=10))
+    image = ax_topo.images[0]
+
+    # create additional axes (for ERF and colorbar)
+    divider = make_axes_locatable(ax_topo)
+
+    # add axes for colorbar
+    ax_colorbar = divider.append_axes('right', size='5%', pad=0.05)
+    plt.colorbar(image, cax=ax_colorbar)
+    ax_topo.set_xlabel(
+        'Averaged F-map ({:0.3f} - {:0.3f} s)'.format(*sig_times[[0, -1]]))
+
+    # add new axis for spectrogram
+    ax_spec = divider.append_axes('right', size='300%', pad=1.2)
+    title = 'Cluster #{0}, {1} spectrogram'.format(i_clu + 1, len(ch_inds))
+    if len(ch_inds) > 1:
+        title += " (max over channels)"
+    F_obs_plot = F_obs[..., ch_inds].max(axis=-1)
+    F_obs_plot_sig = np.zeros(F_obs_plot.shape) * np.nan
+    F_obs_plot_sig[freq_inds, time_inds] = F_obs_plot[freq_inds, time_inds]
+
+    for f_image, cmap in zip([F_obs_plot, F_obs_plot_sig], ['gray', 'autumn']):
+        c = ax_spec.imshow(f_image, cmap=cmap, aspect='auto', origin='lower',
+                           extent=[epochs.times[0], epochs.times[-1],
+                                   freqs[0], freqs[-1]])
+    ax_spec.set_xlabel('Time (ms)')
+    ax_spec.set_ylabel('Frequency (Hz)')
+    ax_spec.set_title(title)
+
+    # add another colorbar
+    ax_colorbar2 = divider.append_axes('right', size='5%', pad=0.05)
+    plt.colorbar(c, cax=ax_colorbar2)
+    ax_colorbar2.set_ylabel('F-stat')
+
+    # clean up viz
+    mne.viz.tight_layout(fig=fig)
+    fig.subplots_adjust(bottom=.05)
+
 
 # %%
 # Exercises

--- a/tutorials/stats-sensor-space/75_cluster_ftest_spatiotemporal.py
+++ b/tutorials/stats-sensor-space/75_cluster_ftest_spatiotemporal.py
@@ -250,11 +250,11 @@ cluster_stats = spatio_temporal_cluster_test(
 # but they are difficult to combine. We will plot topomaps with the clustered
 # sensors colored in white adjacent to spectrograms in order to provide a
 # visualization of the results. This is a dimensionally limited view, however.
-# Each sensor has its own signficiant time-frequencies, but, in order to
+# Each sensor has its own significant time-frequencies, but, in order to
 # display a single spectrogram, all the time-frequencies that are significant
 # for any sensor in the cluster are plotted as significant. This is a
 # difficulty inherent to visualizing high-dimensional data and should be taken
-# into consideration when interpretting results.
+# into consideration when interpreting results.
 F_obs, clusters, p_values, _ = cluster_stats
 good_cluster_inds = np.where(p_values < p_accept)[0]
 

--- a/tutorials/stats-source-space/20_cluster_1samp_spatiotemporal.py
+++ b/tutorials/stats-source-space/20_cluster_1samp_spatiotemporal.py
@@ -106,7 +106,7 @@ tstep = condition1.tstep * 1000  # convert to milliseconds
 #     which is large.
 n_vertices_sample, n_times = condition1.data.shape
 n_subjects = 6
-print('Simulating data for %d subjects.' % n_subjects)
+print(f'Simulating data for {n_subjects} subjects.')
 
 #    Let's make sure our results replicate, so set the seed.
 np.random.seed(0)

--- a/tutorials/stats-source-space/30_cluster_ftest_spatiotemporal.py
+++ b/tutorials/stats-source-space/30_cluster_ftest_spatiotemporal.py
@@ -88,7 +88,7 @@ p_threshold = 0.001
 f_threshold = stats.distributions.f.ppf(1. - p_threshold / 2.,
                                         n_subjects1 - 1, n_subjects2 - 1)
 print('Clustering.')
-T_obs, clusters, cluster_p_values, H0 = clu =\
+F_obs, clusters, cluster_p_values, H0 = clu =\
     spatio_temporal_cluster_test(
         X, adjacency=adjacency, n_jobs=1, n_permutations=n_permutations,
         threshold=f_threshold, buffer_size=None)

--- a/tutorials/stats-source-space/60_cluster_rmANOVA_spatiotemporal.py
+++ b/tutorials/stats-source-space/60_cluster_rmANOVA_spatiotemporal.py
@@ -219,7 +219,7 @@ f_thresh = f_threshold_mway_rm(n_subjects, factor_levels, effects, pthresh)
 n_permutations = 50  # ... run way fewer permutations (reduces sensitivity)
 
 print('Clustering.')
-T_obs, clusters, cluster_p_values, H0 = clu = \
+F_obs, clusters, cluster_p_values, H0 = clu = \
     spatio_temporal_cluster_test(X, adjacency=adjacency, n_jobs=1,
                                  threshold=f_thresh, stat_fun=stat_fun,
                                  n_permutations=n_permutations,

--- a/tutorials/stats-source-space/70_cluster_rmANOVA_time_freq.py
+++ b/tutorials/stats-source-space/70_cluster_rmANOVA_time_freq.py
@@ -248,4 +248,4 @@ fig.tight_layout()
 # or low power, which is likely appropriate given the highly correlated nature
 # of this data. This is the most likely explanation for why one cluster was
 # preserved by the cluster permutation correction, but no time-frequencies
-# were signficant using the FDR correction.
+# were significant using the FDR correction.

--- a/tutorials/stats-source-space/70_cluster_rmANOVA_time_freq.py
+++ b/tutorials/stats-source-space/70_cluster_rmANOVA_time_freq.py
@@ -120,10 +120,9 @@ n_times = len(times)
 # Now we'll assemble the data matrix and swap axes so the trial replications
 # are the first dimension and the conditions are the second dimension.
 data = np.swapaxes(np.asarray(epochs_power), 1, 0)
-# reshape last two dimensions in one mass-univariate observation-vector
-data = data.reshape(n_replications, n_conditions, n_freqs * n_times)
 
-# so we have replications * conditions * observations:
+# so we have replications x conditions x observations
+# where the time-frequency observations are freqs x times:
 print(data.shape)
 
 # %%
@@ -152,23 +151,25 @@ fvals, pvals = f_mway_rm(data, factor_levels, effects=effects)
 
 effect_labels = ['modality', 'location', 'modality by location']
 
+fig, axes = plt.subplots(3, 1, figsize=(6, 6))
+
 # let's visualize our effects by computing f-images
-for effect, sig, effect_label in zip(fvals, pvals, effect_labels):
-    plt.figure()
+for effect, sig, effect_label, ax in zip(fvals, pvals, effect_labels, axes):
     # show naive F-values in gray
-    plt.imshow(effect.reshape(8, 211), cmap=plt.cm.gray, extent=[times[0],
-               times[-1], freqs[0], freqs[-1]], aspect='auto',
-               origin='lower')
-    # create mask for significant Time-frequency locations
+    ax.imshow(effect.reshape(8, 211), cmap=plt.cm.gray,
+              extent=[times[0], times[-1], freqs[0], freqs[-1]],
+              aspect='auto', origin='lower')
+    # create mask for significant time-frequency locations
     effect[sig >= 0.05] = np.nan
-    plt.imshow(effect.reshape(8, 211), cmap='RdBu_r', extent=[times[0],
-               times[-1], freqs[0], freqs[-1]], aspect='auto',
-               origin='lower')
-    plt.colorbar()
-    plt.xlabel('Time (ms)')
-    plt.ylabel('Frequency (Hz)')
-    plt.title(r"Time-locked response for '%s' (%s)" % (effect_label, ch_name))
-    plt.show()
+    c = ax.imshow(effect.reshape(8, 211), cmap='RdBu_r',
+                  extent=[times[0], times[-1], freqs[0], freqs[-1]],
+                  aspect='auto', origin='lower')
+    fig.colorbar(c, ax=ax)
+    ax.set_xlabel('Time (ms)')
+    ax.set_ylabel('Frequency (Hz)')
+    ax.set_title(f'Time-locked response for "{effect_label}" ({ch_name})')
+
+fig.tight_layout()
 
 # %%
 # Account for multiple comparisons using FDR versus permutation clustering test
@@ -199,7 +200,7 @@ f_thresh = f_threshold_mway_rm(n_replications, factor_levels, effects,
                                pthresh)
 tail = 1  # f-test, so tail > 0
 n_permutations = 256  # Save some time (the test won't be too sensitive ...)
-T_obs, clusters, cluster_p_values, h0 = mne.stats.permutation_cluster_test(
+F_obs, clusters, cluster_p_values, h0 = mne.stats.permutation_cluster_test(
     epochs_power, stat_fun=stat_fun, threshold=f_thresh, tail=tail, n_jobs=1,
     n_permutations=n_permutations, buffer_size=None, out_type='mask')
 
@@ -207,40 +208,36 @@ T_obs, clusters, cluster_p_values, h0 = mne.stats.permutation_cluster_test(
 # Create new stats image with only significant clusters:
 
 good_clusters = np.where(cluster_p_values < .05)[0]
-T_obs_plot = T_obs.copy()
-T_obs_plot[~clusters[np.squeeze(good_clusters)]] = np.nan
+F_obs_plot = F_obs.copy()
+F_obs_plot[~clusters[np.squeeze(good_clusters)]] = np.nan
 
-plt.figure()
-for f_image, cmap in zip([T_obs, T_obs_plot], [plt.cm.gray, 'RdBu_r']):
-    plt.imshow(f_image, cmap=cmap, extent=[times[0], times[-1],
-               freqs[0], freqs[-1]], aspect='auto',
-               origin='lower')
-plt.xlabel('Time (ms)')
-plt.ylabel('Frequency (Hz)')
-plt.title("Time-locked response for 'modality by location' (%s)\n"
-          " cluster-level corrected (p <= 0.05)" % ch_name)
-plt.show()
+fig, ax = plt.subplots(figsize=(4, 4))
+for f_image, cmap in zip([F_obs, F_obs_plot], [plt.cm.gray, 'RdBu_r']):
+    ax.imshow(f_image, cmap=cmap, aspect='auto', origin='lower',
+              extent=[times[0], times[-1], freqs[0], freqs[-1]])
+ax.set_xlabel('Time (ms)')
+ax.set_ylabel('Frequency (Hz)')
+ax.set_title(f'Time-locked response for "modality by location" ({ch_name})\n'
+             'cluster-level corrected (p <= 0.05)')
 
 # %%
 # Now using FDR:
 
 mask, _ = fdr_correction(pvals[2])
-T_obs_plot2 = T_obs.copy()
-T_obs_plot2[~mask.reshape(T_obs_plot.shape)] = np.nan
+F_obs_plot2 = F_obs.copy()
+F_obs_plot2[~mask.reshape(F_obs_plot.shape)] = np.nan
 
-plt.figure()
-for f_image, cmap in zip([T_obs, T_obs_plot2], [plt.cm.gray, 'RdBu_r']):
+fig, ax = plt.subplots(figsize=(4, 4))
+for f_image, cmap in zip([F_obs, F_obs_plot2], [plt.cm.gray, 'RdBu_r']):
     if np.isnan(f_image).all():
         continue  # nothing to show
-    plt.imshow(f_image, cmap=cmap, extent=[times[0], times[-1],
-               freqs[0], freqs[-1]], aspect='auto',
-               origin='lower')
+    ax.imshow(f_image, cmap=cmap, aspect='auto', origin='lower',
+              extent=[times[0], times[-1], freqs[0], freqs[-1]])
 
-plt.xlabel('Time (ms)')
-plt.ylabel('Frequency (Hz)')
-plt.title("Time-locked response for 'modality by location' (%s)\n"
-          " FDR corrected (p <= 0.05)" % ch_name)
-plt.show()
+ax.set_xlabel('Time (ms)')
+ax.set_ylabel('Frequency (Hz)')
+ax.set_title(f'Time-locked response for "modality by location" ({ch_name})\n'
+             'FDR corrected (p <= 0.05)')
 
 # %%
 # Both cluster level and FDR correction help get rid of

--- a/tutorials/stats-source-space/70_cluster_rmANOVA_time_freq.py
+++ b/tutorials/stats-source-space/70_cluster_rmANOVA_time_freq.py
@@ -24,6 +24,7 @@ comparisons using False Discovery Rate correction.
 # Authors: Denis Engemann <denis.engemann@gmail.com>
 #          Eric Larson <larson.eric.d@gmail.com>
 #          Alexandre Gramfort <alexandre.gramfort@inria.fr>
+#          Alex Rockhill <aprockhill@mailbox.org>
 #
 # License: BSD-3-Clause
 
@@ -160,7 +161,7 @@ for effect, sig, effect_label, ax in zip(fvals, pvals, effect_labels, axes):
               extent=[times[0], times[-1], freqs[0], freqs[-1]])
     # create mask for significant time-frequency locations
     effect[sig >= 0.05] = np.nan
-    c = ax.imshow(effect, cmap='hot', aspect='auto', origin='lower',
+    c = ax.imshow(effect, cmap='autumn', aspect='auto', origin='lower',
                   extent=[times[0], times[-1], freqs[0], freqs[-1]])
     fig.colorbar(c, ax=ax)
     ax.set_xlabel('Time (ms)')
@@ -210,7 +211,7 @@ F_obs_plot = F_obs.copy()
 F_obs_plot[~clusters[np.squeeze(good_clusters)]] = np.nan
 
 fig, ax = plt.subplots(figsize=(6, 4))
-for f_image, cmap in zip([F_obs, F_obs_plot], ['gray', 'hot']):
+for f_image, cmap in zip([F_obs, F_obs_plot], ['gray', 'autumn']):
     c = ax.imshow(f_image, cmap=cmap, aspect='auto', origin='lower',
                   extent=[times[0], times[-1], freqs[0], freqs[-1]])
 
@@ -229,7 +230,7 @@ F_obs_plot2 = F_obs.copy()
 F_obs_plot2[~mask.reshape(F_obs_plot.shape)] = np.nan
 
 fig, ax = plt.subplots(figsize=(6, 4))
-for f_image, cmap in zip([F_obs, F_obs_plot2], ['gray', 'hot']):
+for f_image, cmap in zip([F_obs, F_obs_plot2], ['gray', 'autumn']):
     c = ax.imshow(f_image, cmap=cmap, aspect='auto', origin='lower',
                   extent=[times[0], times[-1], freqs[0], freqs[-1]])
 


### PR DESCRIPTION
Cleans up leftovers from https://github.com/mne-tools/mne-python/pull/10393.

So the first thing was that the default test was an F-test for the non-1-sample tests and so it should be called `F_obs` which gets output. That was actually done for the spatiotemporal but not the regular cluster test already so I made that consistent.

The next thing is that it really wasn't hard at all to add support for an arbitrary array shape of features (i.e. (times,) or (times, frequencies) or even (times, frequencies, whatever else)). Not that people should be using more than time-frequency dimensions, but its more general written this way. I do think spatiotemporal time-frequency clustering should be supported directly (rather than collapsing the time-frequency array before passing it as an argument) and this PR adds that.