### PR TITLE
Add support for reading SNIRF files with optical density data

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -122,6 +122,8 @@ Enhancements
 
 - Add support for passing time-frequency data to :func:`mne.stats.spatio_temporal_cluster_test` and :func:`mne.stats.spatio_temporal_cluster_1samp_test` and added an example to :ref:`tut-cluster-spatiotemporal-sensor` (:gh:`10384` by `Alex Rockhill`_)
 
+- Add support for reading optical density fNIRS data to :func:`mne.io.read_raw_snirf` (:gh:`10408` by `Robert Luke`_)   
+
 Bugs
 ~~~~
 

--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -111,7 +111,7 @@ MNE_DATASETS = dict()
 # Testing and misc are at the top as they're updated most often
 MNE_DATASETS['testing'] = dict(
     archive_name=f'{TESTING_VERSIONED}.tar.gz',  # 'mne-testing-data',
-    hash='md5:b2bf6517c3d457b70cb5519ce8ab70a7',
+    hash='md5:a0485db88965b4b3c0277d95b6035e88',
     url=('https://codeload.github.com/mne-tools/mne-testing-data/'
          f'tar.gz/{RELEASES["testing"]}'),
     folder_name='MNE-testing-data',

--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -87,7 +87,7 @@ I agree to the following:
 # respective repos, and make a new release of the dataset on GitHub. Then
 # update the checksum in the MNE_DATASETS dict below, and change version
 # here:                  ↓↓↓↓↓         ↓↓↓
-RELEASES = dict(testing='0.130', misc='0.23')
+RELEASES = dict(testing='0.131', misc='0.23')
 TESTING_VERSIONED = f'mne-testing-data-{RELEASES["testing"]}'
 MISC_VERSIONED = f'mne-misc-data-{RELEASES["misc"]}'
 

--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -87,7 +87,7 @@ I agree to the following:
 # respective repos, and make a new release of the dataset on GitHub. Then
 # update the checksum in the MNE_DATASETS dict below, and change version
 # here:                  ↓↓↓↓↓         ↓↓↓
-RELEASES = dict(testing='0.131', misc='0.23')
+RELEASES = dict(testing='0.132', misc='0.23')
 TESTING_VERSIONED = f'mne-testing-data-{RELEASES["testing"]}'
 MISC_VERSIONED = f'mne-misc-data-{RELEASES["misc"]}'
 
@@ -111,7 +111,7 @@ MNE_DATASETS = dict()
 # Testing and misc are at the top as they're updated most often
 MNE_DATASETS['testing'] = dict(
     archive_name=f'{TESTING_VERSIONED}.tar.gz',  # 'mne-testing-data',
-    hash='md5:a0485db88965b4b3c0277d95b6035e88',
+    hash='md5:2ff8bcd18053af3ee0587dce9d6ab516',
     url=('https://codeload.github.com/mne-tools/mne-testing-data/'
          f'tar.gz/{RELEASES["testing"]}'),
     folder_name='MNE-testing-data',

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -252,9 +252,6 @@ class RawSNIRF(BaseRaw):
                     chnames.append(ch_name)
                     ch_types.append(dt_id)
 
-            # Translate between SNIRF processed names and MNE type names
-            # ch_types = [a.replace("dod", "fnirs_od") for a in ch_types]
-
             # Create mne structure
             info = create_info(chnames,
                                sampling_rate,

--- a/mne/io/snirf/tests/test_snirf.py
+++ b/mne/io/snirf/tests/test_snirf.py
@@ -46,6 +46,10 @@ kernel_hb = op.join(testing_path, 'SNIRF', 'Kernel', 'Flow50',
 
 h5py = pytest.importorskip('h5py')  # module-level
 
+# Fieldtrip
+ft_od = op.join(testing_path, 'SNIRF', 'FieldTrip',
+                    '220307_opticaldensity.snirf')
+
 
 @requires_testing_data
 @pytest.mark.filterwarnings('ignore:.*contains 2D location.*:')
@@ -284,6 +288,23 @@ def test_snirf_nirsport2_w_positions():
 
     mon = raw.get_montage()
     assert len(mon.dig) == 43
+
+
+@requires_testing_data
+def test_snirf_fieldtrip_od():
+    """Test reading FieldTrip SNIRF files with optical density data."""
+    raw = read_raw_snirf(ft_od, preload=True)
+
+    # Test data import
+    assert raw._data.shape == (72, 500)
+    assert raw.copy().pick('fnirs')._data.shape == (72, 500)
+    assert raw.copy().pick('fnirs_od')._data.shape == (72, 500)
+    with pytest.raises(ValueError, match='not be interpreted as channel'):
+        raw.copy().pick('hbo')
+    with pytest.raises(ValueError, match='not be interpreted as channel'):
+        raw.copy().pick('hbr')
+
+    assert_allclose(raw.info['sfreq'], 50)
 
 
 @requires_testing_data

--- a/mne/io/snirf/tests/test_snirf.py
+++ b/mne/io/snirf/tests/test_snirf.py
@@ -48,7 +48,7 @@ h5py = pytest.importorskip('h5py')  # module-level
 
 # Fieldtrip
 ft_od = op.join(testing_path, 'SNIRF', 'FieldTrip',
-                    '220307_opticaldensity.snirf')
+                '220307_opticaldensity.snirf')
 
 
 @requires_testing_data

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -261,6 +261,7 @@ def test_marching_cubes(dtype, value, smooth):
 
 
 @requires_nibabel()
+@testing.requires_testing_data
 def test_get_montage_volume_labels():
     """Test finding ROI labels near montage channel locations."""
     ch_coords = np.array([[-8.7040273, 17.99938754, 10.29604017],


### PR DESCRIPTION
#### Background
Continuous-wave fNIRS data can be acquired in the "raw" type, then converted to optical density, then converted to haemoglobin. As such, each of these data types is supported in MNE already. Some devices (namely [Artinis](https://www.artinis.com)) save the data directly as optical density, removing the burden of the first processing step from the end-user.

The [SNIRF file format](https://github.com/fNIRS/snirf/blob/master/snirf_specification.md#appendix) provides a mechanism for storing data in optical density form. MNE already supports reading the data as "raw" or "haemoglobin", but not in optical density form. This PR adds support for reading the data in this middle form, optical density, or MNE type `fnirs_od`. 


#### What does this implement/fix?
Adds the ability to read optical density fNIRS data stored in the SNIRF file type.


#### Additional information
* The data I have is kindly provided by @helenacockx and is exported from FieldTrip.
* I do not think any manufacturer exports data in SNIRF format with this data type.
* Artinis export data in their propriety format, and we can not read it. They provide their users with a converter, but I don't have access to it.

FYI: @larsoner @robertoostenveld 

#### TODO

- [x] Get some test data. Smaller files for rapid testing
- [x] Add tests
