### PR TITLE
ENH: Add theme to raw.plot, etc.

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -120,6 +120,8 @@ Enhancements
 
 - Made anterior/posterior slice scrolling in :func:`mne.gui.locate_ieeg` possible for users without page up and page down buttons by allowing angle bracket buttons to be used (:gh:`10384` by `Alex Rockhill`_)
 
+- Add support for ``theme='auto'`` for automatic dark-mode support in :meth:`raw.plot() <mne.io.Raw.plot>` and related functions and methods when using the ``'qt'`` backend (:gh:`10417` by `Eric Larson`_)
+
 - Add support for passing time-frequency data to :func:`mne.stats.spatio_temporal_cluster_test` and :func:`mne.stats.spatio_temporal_cluster_1samp_test` and added an example to :ref:`tut-cluster-spatiotemporal-sensor` (:gh:`10384` by `Alex Rockhill`_)
 
 Bugs

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1163,7 +1163,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
              order=None, show=True, block=False, decim='auto', noise_cov=None,
              butterfly=False, show_scrollbars=True, show_scalebars=True,
              epoch_colors=None, event_id=None, group_by='type',
-             precompute=None, use_opengl=None):
+             precompute=None, use_opengl=None, *, theme='auto'):
         return plot_epochs(self, picks=picks, scalings=scalings,
                            n_epochs=n_epochs, n_channels=n_channels,
                            title=title, events=events, event_color=event_color,
@@ -1173,7 +1173,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                            show_scalebars=show_scalebars,
                            epoch_colors=epoch_colors, event_id=event_id,
                            group_by=group_by, precompute=precompute,
-                           use_opengl=use_opengl)
+                           use_opengl=use_opengl, theme=theme)
 
     @copy_function_doc_to_method_doc(plot_epochs_psd)
     def plot_psd(self, fmin=0, fmax=np.inf, tmin=None, tmax=None,

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1547,7 +1547,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
              show_first_samp=False, proj=True, group_by='type',
              butterfly=False, decim='auto', noise_cov=None, event_id=None,
              show_scrollbars=True, show_scalebars=True, time_format='float',
-             precompute=None, use_opengl=None, verbose=None):
+             precompute=None, use_opengl=None, *, theme='auto', verbose=None):
         return plot_raw(self, events, duration, start, n_channels, bgcolor,
                         color, bad_color, event_color, scalings, remove_dc,
                         order, show_options, title, show, block, highpass,
@@ -1556,7 +1556,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                         event_id=event_id, show_scrollbars=show_scrollbars,
                         show_scalebars=show_scalebars, time_format=time_format,
                         precompute=precompute, use_opengl=use_opengl,
-                        verbose=verbose)
+                        theme=theme, verbose=verbose)
 
     @verbose
     @copy_function_doc_to_method_doc(plot_raw_psd)

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1962,13 +1962,14 @@ class ICA(ContainsMixin, _VerboseDep):
                      stop=None, title=None, show=True, block=False,
                      show_first_samp=False, show_scrollbars=True,
                      time_format='float', precompute=None,
-                     use_opengl=None):
+                     use_opengl=None, *, theme='auto'):
         return plot_ica_sources(self, inst=inst, picks=picks,
                                 start=start, stop=stop, title=title, show=show,
                                 block=block, show_first_samp=show_first_samp,
                                 show_scrollbars=show_scrollbars,
                                 time_format=time_format,
-                                precompute=precompute, use_opengl=use_opengl)
+                                precompute=precompute, use_opengl=use_opengl,
+                                theme=theme)
 
     @copy_function_doc_to_method_doc(plot_ica_scores)
     def plot_scores(self, scores, exclude=None, labels=None, axhline=None,

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3001,6 +3001,19 @@ tail : int
     the distribution.
 """
 
+docdict['theme'] = """
+theme : str | path-like
+    Can be "auto" (default), "light", or "dark" or a path-like to a
+    custom stylesheet. For Dark-Mode and automatic Dark-Mode-Detection,
+    :mod:`qdarkstyle` `darkdetect
+    <https://github.com/albertosottile/darkdetect>`__, respectively,
+    are required.
+"""
+
+docdict['theme_pg'] = """{theme}\
+    Only supported by the ``'qt'`` backend.
+""".format(theme=docdict['theme'])
+
 docdict['thresh'] = """
 thresh : None or float
     Not supported yet.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3005,9 +3005,9 @@ docdict['theme'] = """
 theme : str | path-like
     Can be "auto" (default), "light", or "dark" or a path-like to a
     custom stylesheet. For Dark-Mode and automatic Dark-Mode-Detection,
-    :mod:`qdarkstyle` `darkdetect
-    <https://github.com/albertosottile/darkdetect>`__, respectively,
-    are required.
+    :mod:`qdarkstyle` and
+    `darkdetect <https://github.com/albertosottile/darkdetect>`__,
+    respectively, are required.
 """
 
 docdict['theme_pg'] = """{theme}\

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -313,11 +313,7 @@ class Brain(object):
        and ``decimate`` (level of decimation between 0 and 1 or None) of the
        brain's silhouette to display. If True, the default values are used
        and if False, no silhouette will be displayed. Defaults to False.
-    theme : str | path-like
-        Can be "auto" (default), "light", or "dark" or a path-like to a
-        custom stylesheet. For Dark-Mode and automatic Dark-Mode-Detection,
-        :mod:`qdarkstyle` respectively and `darkdetect
-        <https://github.com/albertosottile/darkdetect>`__ is required.
+    %(theme)s
     show : bool
         Display the window as soon as it is ready. Defaults to True.
     block : bool

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -649,8 +649,6 @@ def _get_browser(show, block, **kwargs):
                 return fig
 
     # Initialize Browser
-    if 'splash' in _get_args(backend._init_browser):
-        kwargs['splash'] = True if show else False
     fig = backend._init_browser(**kwargs)
     _show_browser(show=show, block=block, fig=fig)
 

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -17,7 +17,6 @@ import numpy as np
 from .. import verbose, get_config, set_config
 from ..annotations import _sync_onset
 from ..defaults import _handle_default
-from ..fixes import _get_args
 from ..utils import logger, _validate_type, _check_option
 from ..io.pick import _DATA_CH_TYPES_SPLIT
 from .backends._utils import VALID_BROWSE_BACKENDS

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -623,6 +623,7 @@ def _get_browser(show, block, **kwargs):
     figsize = kwargs.setdefault('figsize', _get_figsize_from_config())
     if figsize is None or np.any(np.array(figsize) < 8):
         kwargs['figsize'] = (8, 8)
+    kwargs['splash'] = True if show else False
 
     # Initialize browser backend
     backend_name = get_browser_backend()

--- a/mne/viz/_mpl_figure.py
+++ b/mne/viz/_mpl_figure.py
@@ -2220,7 +2220,7 @@ def _patched_canvas(fig):
         fig.canvas = old_canvas
 
 
-def _init_browser(splash=False, **kwargs):
+def _init_browser(**kwargs):
     """Instantiate a new MNE browse-style figure."""
     from mne.io import BaseRaw
     fig = _figure(toolbar=False, FigureClass=MNEBrowseFigure, **kwargs)

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -649,7 +649,8 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
                 order=None, show=True, block=False, decim='auto',
                 noise_cov=None, butterfly=False, show_scrollbars=True,
                 show_scalebars=True, epoch_colors=None, event_id=None,
-                group_by='type', precompute=None, use_opengl=None):
+                group_by='type', precompute=None, use_opengl=None, *,
+                theme='auto'):
     """Visualize epochs.
 
     Bad epochs can be marked with a left click on top of the epoch. Bad
@@ -733,6 +734,9 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
     %(group_by_browse)s
     %(precompute)s
     %(use_opengl)s
+    %(theme_pg)s
+
+        .. verionadded:: 1.0
 
     Returns
     -------

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -736,7 +736,7 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
     %(use_opengl)s
     %(theme_pg)s
 
-        .. verionadded:: 1.0
+        .. versionadded:: 1.0
 
     Returns
     -------

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -31,7 +31,7 @@ def plot_ica_sources(ica, inst, picks=None, start=None,
                      stop=None, title=None, show=True, block=False,
                      show_first_samp=False, show_scrollbars=True,
                      time_format='float', precompute=None,
-                     use_opengl=None):
+                     use_opengl=None, *, theme='auto'):
     """Plot estimated latent sources given the unmixing matrix.
 
     Typical usecases:
@@ -69,6 +69,9 @@ def plot_ica_sources(ica, inst, picks=None, start=None,
     %(time_format)s
     %(precompute)s
     %(use_opengl)s
+    %(theme_pg)s
+
+        .. versionadded:: 1.0
 
     Returns
     -------
@@ -96,7 +99,7 @@ def plot_ica_sources(ica, inst, picks=None, start=None,
                             show_first_samp=show_first_samp,
                             show_scrollbars=show_scrollbars,
                             time_format=time_format, precompute=precompute,
-                            use_opengl=use_opengl)
+                            use_opengl=use_opengl, theme=theme)
     elif isinstance(inst, Evoked):
         if start is not None or stop is not None:
             inst = inst.copy().crop(start, stop)
@@ -957,7 +960,7 @@ def _plot_ica_overlay_evoked(evoked, evoked_cln, title, show):
 
 def _plot_sources(ica, inst, picks, exclude, start, stop, show, title, block,
                   show_scrollbars, show_first_samp, time_format,
-                  precompute, use_opengl):
+                  precompute, use_opengl, *, theme='auto'):
     """Plot the ICA components as a RawArray or EpochsArray."""
     from ._figure import _get_browser
     from .. import EpochsArray, BaseEpochs

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -35,7 +35,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
              proj=True, group_by='type', butterfly=False, decim='auto',
              noise_cov=None, event_id=None, show_scrollbars=True,
              show_scalebars=True, time_format='float',
-             precompute=None, use_opengl=None, verbose=None):
+             precompute=None, use_opengl=None, *, theme='auto', verbose=None):
     """Plot raw data.
 
     Parameters
@@ -159,6 +159,9 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
     %(time_format)s
     %(precompute)s
     %(use_opengl)s
+    %(theme_pg)s
+
+        .. versionadded:: 1.0
     %(verbose)s
 
     Returns


### PR DESCRIPTION
1. Add `theme='auto'` to `raw.plot` and related methods that should work with the PyQtGraph backend once https://github.com/mne-tools/mne-qt-browser/pull/66 is merged
2. Fix handling of partially supported kwargs, like `splash`. We don't actually need to check if it's in the `kwargs`, since it just gets put in `self.mne.splash` for example. This can then be used (or not) by each backend.