### PR TITLE
TST: Add tests for interior check

### DIFF
--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1484,8 +1484,8 @@ class Coregistration(object):
         self.fiducials = dig_montage
 
     def _update_params(self, rot=None, tra=None, sca=None,
-                       force_update_omitted=False):
-        if force_update_omitted:
+                       force_update=False):
+        if force_update and tra is None:
             tra = self._translation
         rot_changed = False
         if rot is not None:
@@ -1578,7 +1578,7 @@ class Coregistration(object):
             The modified Coregistration object.
         """
         self._grow_hair = value
-        self._update_params(self._rotation, self._translation, self._scale)
+        self._update_params(force_update=True)
         return self
 
     def set_rotation(self, rot):
@@ -1976,7 +1976,7 @@ class Coregistration(object):
                     "distance >= %.3f m.", n_excluded, distance)
         # set the filter
         self._extra_points_filter = mask
-        self._update_params(force_update_omitted=True)
+        self._update_params(force_update=True)
         return self
 
     def compute_dig_mri_distances(self):

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -18,7 +18,8 @@ from mne import (read_forward_solution, write_forward_solution,
                  get_volume_labels_from_aseg)
 from mne.surface import _get_ico_surface
 from mne.transforms import Transform
-from mne.utils import requires_mne, requires_nibabel, run_subprocess
+from mne.utils import (requires_mne, requires_nibabel, run_subprocess,
+                       catch_logging)
 from mne.forward._make_forward import _create_meg_coils, make_forward_dipole
 from mne.forward._compute_forward import _magnetic_dipole_field_vec
 from mne.forward import Forward, _do_forward_solution, use_coil_def
@@ -223,8 +224,11 @@ def test_make_forward_solution_kit(tmp_path):
 @testing.requires_testing_data
 def test_make_forward_solution():
     """Test making M-EEG forward solution from python."""
-    fwd_py = make_forward_solution(fname_raw, fname_trans, fname_src,
-                                   fname_bem, mindist=5.)
+    with catch_logging() as log:
+        fwd_py = make_forward_solution(fname_raw, fname_trans, fname_src,
+                                       fname_bem, mindist=5., verbose=True)
+    log = log.getvalue()
+    assert 'Total 258/258 points inside the surface' in log
     assert (isinstance(fwd_py, Forward))
     fwd = read_forward_solution(fname_meeg)
     assert (isinstance(fwd, Forward))

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1035,7 +1035,7 @@ def _get_nearest(nearest, check_inside, project_to_trans, proj_rr):
 
 def _orient_glyphs(pts, surf, project_to_surface=False, mark_inside=False):
     rr = surf["rr"]
-    check_inside = _CheckInside(surf)
+    check_inside = _CheckInside(surf, verbose=False)
     nearest = _DistanceQuery(rr)
     project_to_trans = np.eye(4)
     inv_trans = np.linalg.inv(project_to_trans)


### PR DESCRIPTION
cc @GuillaumeFavelier . If I do:
```
$ mne coreg -s sample -d subjects --fif MEG/sample/sample_audvis_raw.fif
```
then click "lock fiducials" then "Fit ICP", it does 10+ iterations, each of which says it only takes 50 ms.

I also tried removing the `@verbose` and replacing it with `@profile`, creating the script `coreg.py` with the contents:
```
import mne
mne.gui.coregistration(
    subject='sample', subjects_dir='./subjects',
    inst='MEG/sample/sample_audvis_raw.fif')
```
then running:
```
$ kernprof -lbv coreg.py
```
and I get:
```
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   684        21     457627.0  21791.8     42.1          del_outside = self.del_tri.find_simplex(rr) < 0
...
   696        21     602924.0  28710.7     55.5          solid_outside = _points_outside_surface(rr, self.surf, n_jobs)
```
Suggesting that these changes don't have a big effect on the outcome :(

But at least I think this testing framework might make it easy to see if we're helping or not. Maybe you can see which of these two is slow on Windows?
