### PR TITLE
FIX: linux_conda job

### DIFF
--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -14,6 +14,7 @@ jobs:
   py39:
     timeout-minutes: 90
     runs-on: ubuntu-20.04
+    name: py3.9
     defaults:
       run:
         shell: bash

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -11,7 +11,7 @@ on:
       - '*'
 
 jobs:
-  py3.9:
+  py39:
     timeout-minutes: 90
     runs-on: ubuntu-20.04
     defaults:


### PR DESCRIPTION
The workflow could not even start because the name is invalid. This PR fixes it and sorry for the delay.

```
The workflow is not valid. .github/workflows/linux_conda.yml (Line: 14, Col: 3): The identifier 'py3.9' is invalid. 
```