### PR TITLE
MAINT: Update deps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -168,9 +168,9 @@ stages:
         3.7 pip:
           TEST_MODE: 'pip'
           PYTHON_VERSION: '3.7'
-        3.9 pip pre:
+        3.10 pip pre:
           TEST_MODE: 'pip-pre'
-          PYTHON_VERSION: '3.9'
+          PYTHON_VERSION: '3.10'
     steps:
     - task: UsePythonVersion@0
       inputs:

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -136,6 +136,8 @@ def pytest_configure(config):
     # Jupyter notebook stuff
     ignore:.*unclosed context <zmq\.asyncio\.*:ResourceWarning
     ignore:.*unclosed event loop <.*:ResourceWarning
+    # https://github.com/dipy/dipy/pull/2558
+    ignore:.*starting_affine overwritten by centre_of_mass transform.*:
     # TODO: This is indicative of a problem
     ignore:.*Matplotlib is currently using agg.*:
     """  # noqa: E501

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -76,11 +76,14 @@ def requires_dipy():
         from dipy.align.reslice import reslice  # noqa, analysis:ignore
         from dipy.align.imaffine import AffineMap  # noqa, analysis:ignore
         from dipy.align.imwarp import DiffeomorphicMap  # noqa, analysis:ignore
-    except Exception:
+    except Exception as exc:
         have = False
+        why = str(exc)
     else:
+        why = ''
         have = True
-    return pytest.mark.skipif(not have, reason='Requires dipy >= 0.10.1')
+    return pytest.mark.skipif(
+        not have, reason=f'Requires dipy >= 0.10.1, got: {why}')
 
 
 def requires_version(library, min_version='0.0'):

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -17,7 +17,7 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" pandas scikit-learn dipy statsmodels
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py Pillow matplotlib
 	# Until VTK comes out with a 3.10 wheel, we need to use PyVista's
-	python -m pip install --progress-bar off --upgrade --pre --only-binary https://github.com/pyvista/pyvista-wheels/raw/blob/3b70f3933bc246b035354b172a0459ffc96b0343/vtk-9.1.0.dev0-cp310-cp310-win_amd64.whl
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" https://github.com/pyvista/pyvista-wheels/raw/blob/3b70f3933bc246b035354b172a0459ffc96b0343/vtk-9.1.0.dev0-cp310-cp310-win_amd64.whl
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
 	EXTRA_ARGS="--pre"

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -11,12 +11,13 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off --upgrade pip setuptools wheel
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl six cycler kiwisolver pyparsing patsy
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt5 PyQt5-sip PyQt5-Qt5
-	# SciPy Windows build is missing from conda nightly builds, and statsmodels does not work
+	# SciPy Windows build is missing from conda nightly builds
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps scipy
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" pandas scikit-learn dipy statsmodels
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py Pillow matplotlib
-	python -m pip install --progress-bar off --upgrade --pre --only-binary "vtk" vtk
+	# Until VTK comes out with a 3.10 wheel, we need to use PyVista's
+	python -m pip install --progress-bar off --upgrade --pre --only-binary https://github.com/pyvista/pyvista-wheels/raw/blob/3b70f3933bc246b035354b172a0459ffc96b0343/vtk-9.1.0.dev0-cp310-cp310-win_amd64.whl
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
 	EXTRA_ARGS="--pre"

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -17,7 +17,7 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" pandas scikit-learn dipy statsmodels
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py Pillow matplotlib
 	# Until VTK comes out with a 3.10 wheel, we need to use PyVista's
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" https://github.com/pyvista/pyvista-wheels/raw/blob/3b70f3933bc246b035354b172a0459ffc96b0343/vtk-9.1.0.dev0-cp310-cp310-win_amd64.whl
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" https://github.com/pyvista/pyvista-wheels/raw/3b70f3933bc246b035354b172a0459ffc96b0343/vtk-9.1.0.dev0-cp310-cp310-win_amd64.whl
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
 	EXTRA_ARGS="--pre"

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -17,9 +17,7 @@ else
 	echo "PyQt5"
 	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt5 PyQt5-sip PyQt5-Qt5
 	echo "NumPy/SciPy/pandas etc."
-	# TODO: Currently missing dipy for 3.10 https://github.com/dipy/dipy/issues/2489
-	# TODO: Revert this and Azure once https://github.com/numpy/numpy/pull/21054 is merged and a new wheel is out
-	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy pandas scikit-learn statsmodels
+	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy pandas scikit-learn statsmodels dipy
 	echo "H5py, pillow, matplotlib"
 	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py pillow matplotlib
 	# We don't install Numba here because it forces an old NumPy version


### PR DESCRIPTION
Dipy has 3.10 wheels on scipy-nightly, let's use them. And I think we can bump windows --pre to 3.10 if we use VTK's wheel. Let's see...