### PR TITLE
[ENH, MRG] Refactor `ContainsMixin` and `MontageMixin`

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -19,23 +19,20 @@ from functools import partial
 import numpy as np
 
 from ..defaults import HEAD_SIZE_DEFAULT, _handle_default
-from ..transforms import _frame_to_str
 from ..utils import (verbose, logger, warn,
                      _check_preload, _validate_type, fill_doc, _check_option,
                      _get_stim_channel, _check_fname, _check_dict_keys)
-from ..io.compensator import get_current_comp
 from ..io.constants import FIFF
 from ..io.meas_info import (anonymize_info, Info, MontageMixin, create_info,
                             _rename_comps)
 from ..io.pick import (channel_type, pick_info, pick_types, _picks_by_type,
                        _check_excludes_includes, _contains_ch_type,
                        channel_indices_by_type, pick_channels, _picks_to_idx,
-                       _get_channel_types, get_channel_type_constants,
+                       get_channel_type_constants,
                        _pick_data_channels)
 from ..io.tag import _rename_list
 from ..io.write import DATE_NONE
 from ..io.proj import setup_proj
-from ..io._digitization import _get_data_as_dict_from_dig
 
 
 def _get_meg_system(info):
@@ -189,102 +186,6 @@ def equalize_channels(instances, copy=True, verbose=None):
         logger.info('Channels have been re-ordered.')
 
     return equalized_instances
-
-
-class ContainsMixin(object):
-    """Mixin class for Raw, Evoked, Epochs."""
-
-    def __contains__(self, ch_type):
-        """Check channel type membership.
-
-        Parameters
-        ----------
-        ch_type : str
-            Channel type to check for. Can be e.g. 'meg', 'eeg', 'stim', etc.
-
-        Returns
-        -------
-        in : bool
-            Whether or not the instance contains the given channel type.
-
-        Examples
-        --------
-        Channel type membership can be tested as::
-
-            >>> 'meg' in inst  # doctest: +SKIP
-            True
-            >>> 'seeg' in inst  # doctest: +SKIP
-            False
-
-        """
-        if ch_type == 'meg':
-            has_ch_type = (_contains_ch_type(self.info, 'mag') or
-                           _contains_ch_type(self.info, 'grad'))
-        else:
-            has_ch_type = _contains_ch_type(self.info, ch_type)
-        return has_ch_type
-
-    @property
-    def compensation_grade(self):
-        """The current gradient compensation grade."""
-        return get_current_comp(self.info)
-
-    @fill_doc
-    def get_channel_types(self, picks=None, unique=False, only_data_chs=False):
-        """Get a list of channel type for each channel.
-
-        Parameters
-        ----------
-        %(picks_all)s
-        unique : bool
-            Whether to return only unique channel types. Default is ``False``.
-        only_data_chs : bool
-            Whether to ignore non-data channels. Default is ``False``.
-
-        Returns
-        -------
-        channel_types : list
-            The channel types.
-        """
-        return _get_channel_types(self.info, picks=picks, unique=unique,
-                                  only_data_chs=only_data_chs)
-
-    @fill_doc
-    def get_montage(self):
-        """Get a DigMontage from instance.
-
-        Returns
-        -------
-        %(montage)s
-        """
-        from ..channels.montage import make_dig_montage
-        if self.info['dig'] is None:
-            return None
-        # obtain coord_frame, and landmark coords
-        # (nasion, lpa, rpa, hsp, hpi) from DigPoints
-        montage_bunch = _get_data_as_dict_from_dig(self.info['dig'])
-        coord_frame = _frame_to_str.get(montage_bunch.coord_frame)
-
-        # get the channel names and chs data structure
-        ch_names, chs = self.info['ch_names'], self.info['chs']
-        picks = pick_types(self.info, meg=False, eeg=True, seeg=True,
-                           ecog=True, dbs=True, fnirs=True, exclude=[])
-
-        # channel positions from dig do not match ch_names one to one,
-        # so use loc[:3] instead
-        ch_pos = {ch_names[ii]: chs[ii]['loc'][:3] for ii in picks}
-
-        # create montage
-        montage = make_dig_montage(
-            ch_pos=ch_pos,
-            coord_frame=coord_frame,
-            nasion=montage_bunch.nasion,
-            lpa=montage_bunch.lpa,
-            rpa=montage_bunch.rpa,
-            hsp=montage_bunch.hsp,
-            hpi=montage_bunch.hpi,
-        )
-        return montage
 
 
 channel_type_constants = get_channel_type_constants()

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -15,8 +15,7 @@ from numpy.testing import assert_array_equal, assert_equal, assert_allclose
 
 from mne.channels import (rename_channels, read_ch_adjacency, combine_channels,
                           find_ch_adjacency, make_1020_channel_selections,
-                          read_custom_montage, equalize_channels,
-                          make_standard_montage)
+                          read_custom_montage, equalize_channels)
 from mne.channels.channels import (_ch_neighbor_adjacency,
                                    _compute_ch_adjacency)
 from mne.io import (read_info, read_raw_fif, read_raw_ctf, read_raw_bti,

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -522,16 +522,3 @@ def test_combine_channels():
         combine_channels(raw, warn2)
         combine_channels(raw_ch_bad, warn3, drop_bad=True)
     assert len(record) == 3
-
-
-def test_get_montage():
-    """Test ContainsMixin.get_montage()."""
-    ch_names = make_standard_montage('standard_1020').ch_names
-    sfreq = 512
-    data = np.zeros((len(ch_names), sfreq * 2))
-    raw = RawArray(data, create_info(ch_names, sfreq, 'eeg'))
-    raw.set_montage('standard_1020')
-
-    assert len(raw.get_montage().ch_names) == len(ch_names)
-    raw.info['bads'] = [ch_names[0]]
-    assert len(raw.get_montage().ch_names) == len(ch_names)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -27,7 +27,7 @@ from .io.write import (start_and_end_file, start_block, end_block,
                        write_complex_double_matrix, write_id, write_string,
                        _get_split_size, _NEXT_FILE_BUFFER, INT32_MAX)
 from .io.meas_info import (read_meas_info, write_meas_info, _merge_info,
-                           _ensure_infos_match)
+                           _ensure_infos_match, ContainsMixin)
 from .io.open import fiff_open, _get_next_fname
 from .io.tree import dir_tree_find
 from .io.tag import read_tag, read_tag_info
@@ -41,7 +41,7 @@ from .io.base import BaseRaw, TimeMixin, _get_ch_factors
 from .bem import _check_origin
 from .evoked import EvokedArray, _check_decim
 from .baseline import rescale, _log_rescale, _check_baseline
-from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
+from .channels.channels import (UpdateChannelsMixin,
                                 SetChannelsMixin, InterpolationMixin)
 from .filter import detrend, FilterMixin, _check_fun
 from .parallel import parallel_func

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -12,7 +12,7 @@ from copy import deepcopy
 import numpy as np
 
 from .baseline import rescale, _log_rescale, _check_baseline
-from .channels.channels import (ContainsMixin, UpdateChannelsMixin,
+from .channels.channels import (UpdateChannelsMixin,
                                 SetChannelsMixin, InterpolationMixin)
 from .channels.layout import _merge_ch_data, _pair_grad_sensors
 from .defaults import _EXTRAPOLATE_DEFAULT, _BORDER_DEFAULT
@@ -33,7 +33,7 @@ from .io.open import fiff_open
 from .io.tag import read_tag
 from .io.tree import dir_tree_find
 from .io.pick import pick_types, _picks_to_idx, _FNIRS_CH_TYPES_SPLIT
-from .io.meas_info import (read_meas_info, write_meas_info,
+from .io.meas_info import (ContainsMixin, read_meas_info, write_meas_info,
                            _read_extended_ch_info, _rename_list,
                            _ensure_infos_match)
 from .io.proj import ProjMixin

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -24,11 +24,10 @@ from .constants import FIFF
 from .utils import _construct_bids_filename, _check_orig_units
 from .pick import (pick_types, pick_channels, pick_info, _picks_to_idx,
                    channel_type)
-from .meas_info import write_meas_info, _ensure_infos_match
+from .meas_info import write_meas_info, _ensure_infos_match, ContainsMixin
 from .proj import setup_proj, activate_proj, _proj_equal, ProjMixin
-from ..channels.channels import (ContainsMixin, UpdateChannelsMixin,
-                                 SetChannelsMixin, InterpolationMixin,
-                                 _unit2human)
+from ..channels.channels import (UpdateChannelsMixin, SetChannelsMixin,
+                                 InterpolationMixin, _unit2human)
 from .compensator import set_current_comp, make_compensator
 from .write import (start_and_end_file, start_block, end_block,
                     write_dau_pack16, write_float, write_double,

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -18,8 +18,8 @@ import string
 
 import numpy as np
 
-from .pick import (channel_type, pick_channels, pick_info,
-                   get_channel_type_constants, pick_types)
+from .pick import (channel_type, pick_channels, pick_info, _get_channel_types,
+                   get_channel_type_constants, pick_types, _contains_ch_type)
 from .constants import FIFF, _coord_frame_named
 from .open import fiff_open
 from .tree import dir_tree_find
@@ -34,14 +34,14 @@ from .write import (start_and_end_file, start_block, end_block,
                     write_julian, write_float_matrix, write_id, DATE_NONE)
 from .proc_history import _read_proc_history, _write_proc_history
 from ..transforms import (invert_transform, Transform, _coord_frame_name,
-                          _ensure_trans)
+                          _ensure_trans, _frame_to_str)
 from ..utils import (logger, verbose, warn, object_diff, _validate_type,
                      _stamp_to_dt, _dt_to_stamp, _pl, _is_numeric, deprecated,
                      _check_option, _on_missing, _check_on_missing, fill_doc,
                      _check_fname)
 from ._digitization import (_format_dig_points, _dig_kind_proper, DigPoint,
                             _dig_kind_rev, _dig_kind_ints, _read_dig_fif)
-from ._digitization import write_dig
+from ._digitization import write_dig, _get_data_as_dict_from_dig
 from .compensator import get_current_comp
 from ..defaults import _handle_default
 
@@ -147,7 +147,45 @@ def _unique_channel_names(ch_names, max_length=None, verbose=None):
 
 
 class MontageMixin(object):
-    """Mixin for Montage setting."""
+    """Mixin for Montage getting and setting."""
+
+    @fill_doc
+    def get_montage(self):
+        """Get a DigMontage from instance.
+
+        Returns
+        -------
+        %(montage)s
+        """
+        from ..channels.montage import make_dig_montage
+        info = self if isinstance(self, Info) else self.info
+        if info['dig'] is None:
+            return None
+        # obtain coord_frame, and landmark coords
+        # (nasion, lpa, rpa, hsp, hpi) from DigPoints
+        montage_bunch = _get_data_as_dict_from_dig(info['dig'])
+        coord_frame = _frame_to_str.get(montage_bunch.coord_frame)
+
+        # get the channel names and chs data structure
+        ch_names, chs = info['ch_names'], self.info['chs']
+        picks = pick_types(info, meg=False, eeg=True, seeg=True,
+                           ecog=True, dbs=True, fnirs=True, exclude=[])
+
+        # channel positions from dig do not match ch_names one to one,
+        # so use loc[:3] instead
+        ch_pos = {ch_names[ii]: chs[ii]['loc'][:3] for ii in picks}
+
+        # create montage
+        montage = make_dig_montage(
+            ch_pos=ch_pos,
+            coord_frame=coord_frame,
+            nasion=montage_bunch.nasion,
+            lpa=montage_bunch.lpa,
+            rpa=montage_bunch.rpa,
+            hsp=montage_bunch.hsp,
+            hpi=montage_bunch.hpi,
+        )
+        return montage
 
     @verbose
     def set_montage(self, montage, match_case=True, match_alias=False,
@@ -184,6 +222,68 @@ class MontageMixin(object):
         info = self if isinstance(self, Info) else self.info
         _set_montage(info, montage, match_case, match_alias, on_missing)
         return self
+
+
+class ContainsMixin(object):
+    """Mixin class for Raw, Evoked, Epochs and Info."""
+
+    def __contains__(self, ch_type):
+        """Check channel type membership.
+
+        Parameters
+        ----------
+        ch_type : str
+            Channel type to check for. Can be e.g. 'meg', 'eeg', 'stim', etc.
+
+        Returns
+        -------
+        in : bool
+            Whether or not the instance contains the given channel type.
+
+        Examples
+        --------
+        Channel type membership can be tested as::
+
+            >>> 'meg' in inst  # doctest: +SKIP
+            True
+            >>> 'seeg' in inst  # doctest: +SKIP
+            False
+
+        """
+        info = self if isinstance(self, Info) else self.info
+        if ch_type == 'meg':
+            has_ch_type = (_contains_ch_type(info, 'mag') or
+                           _contains_ch_type(info, 'grad'))
+        else:
+            has_ch_type = _contains_ch_type(info, ch_type)
+        return has_ch_type
+
+    @property
+    def compensation_grade(self):
+        """The current gradient compensation grade."""
+        info = self if isinstance(self, Info) else self.info
+        return get_current_comp(info)
+
+    @fill_doc
+    def get_channel_types(self, picks=None, unique=False, only_data_chs=False):
+        """Get a list of channel type for each channel.
+
+        Parameters
+        ----------
+        %(picks_all)s
+        unique : bool
+            Whether to return only unique channel types. Default is ``False``.
+        only_data_chs : bool
+            Whether to ignore non-data channels. Default is ``False``.
+
+        Returns
+        -------
+        channel_types : list
+            The channel types.
+        """
+        info = self if isinstance(self, Info) else self.info
+        return _get_channel_types(info, picks=picks, unique=unique,
+                                  only_data_chs=only_data_chs)
 
 
 def _format_trans(obj, key):
@@ -253,7 +353,7 @@ def _check_helium_info(helium_info):
     return helium_info
 
 
-class Info(dict, MontageMixin):
+class Info(dict, MontageMixin, ContainsMixin):
     """Measurement information.
 
     This data structure behaves like a dictionary. It contains all metadata

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -167,7 +167,7 @@ class MontageMixin(object):
         coord_frame = _frame_to_str.get(montage_bunch.coord_frame)
 
         # get the channel names and chs data structure
-        ch_names, chs = info['ch_names'], self.info['chs']
+        ch_names, chs = info['ch_names'], info['chs']
         picks = pick_types(info, meg=False, eeg=True, seeg=True,
                            ecog=True, dbs=True, fnirs=True, exclude=[])
 

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -26,7 +26,7 @@ from mne.event import make_fixed_length_events
 from mne.datasets import testing
 from mne.io import (read_fiducials, write_fiducials, _coil_trans_to_loc,
                     _loc_to_coil_trans, read_raw_fif, read_info, write_info,
-                    meas_info, Projection, BaseRaw, read_raw_ctf)
+                    meas_info, Projection, BaseRaw, read_raw_ctf, RawArray)
 from mne.io.constants import FIFF
 from mne.io.write import _generate_meas_id, DATE_NONE
 from mne.io.meas_info import (Info, create_info, _merge_info,
@@ -1066,3 +1066,16 @@ def test_info_pick_channels():
     info = create_info(2, 1000., 'eeg')
     with pytest.deprecated_call(match='use inst.pick_channels instead.'):
         info.pick_channels(['0'])
+
+
+def test_get_montage():
+    """Test ContainsMixin.get_montage()."""
+    ch_names = make_standard_montage('standard_1020').ch_names
+    sfreq = 512
+    data = np.zeros((len(ch_names), sfreq * 2))
+    raw = RawArray(data, create_info(ch_names, sfreq, 'eeg'))
+    raw.set_montage('standard_1020')
+
+    assert len(raw.get_montage().ch_names) == len(ch_names)
+    raw.info['bads'] = [ch_names[0]]
+    assert len(raw.get_montage().ch_names) == len(ch_names)

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -1079,3 +1079,11 @@ def test_get_montage():
     assert len(raw.get_montage().ch_names) == len(ch_names)
     raw.info['bads'] = [ch_names[0]]
     assert len(raw.get_montage().ch_names) == len(ch_names)
+
+    # test info
+    raw = RawArray(data, create_info(ch_names, sfreq, 'eeg'))
+    raw.set_montage('standard_1020')
+
+    assert len(raw.info.get_montage().ch_names) == len(ch_names)
+    raw.info['bads'] = [ch_names[0]]
+    assert len(raw.info.get_montage().ch_names) == len(ch_names)

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -35,7 +35,7 @@ from ..io.write import (write_double_matrix, write_string,
 from ..io.tree import dir_tree_find
 from ..io.open import fiff_open
 from ..io.tag import read_tag
-from ..io.meas_info import write_meas_info, read_meas_info
+from ..io.meas_info import write_meas_info, read_meas_info, ContainsMixin
 from ..io.constants import FIFF
 from ..io.base import BaseRaw
 from ..io.eeglab.eeglab import _get_info, _check_load_mat
@@ -46,7 +46,7 @@ from ..viz import (plot_ica_components, plot_ica_scores,
 from ..viz.ica import plot_ica_properties
 from ..viz.topomap import _plot_corrmap
 
-from ..channels.channels import _contains_ch_type, ContainsMixin
+from ..channels.channels import _contains_ch_type
 from ..io.write import start_and_end_file, write_id
 from ..utils import (logger, check_fname, _check_fname, verbose,
                      _reject_data_segments, check_random_state, _validate_type,

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -27,11 +27,11 @@ from ..utils import (logger, verbose, _time_mask, _freq_mask, check_fname,
                      _check_pandas_index_arguments, _check_time_format,
                      _convert_times, _build_data_frame, warn,
                      _import_h5io_funcs)
-from ..channels.channels import ContainsMixin, UpdateChannelsMixin
+from ..channels.channels import UpdateChannelsMixin
 from ..channels.layout import _merge_ch_data, _pair_grad_sensors
 from ..io.pick import (pick_info, _picks_to_idx, channel_type, _pick_inst,
                        _get_channel_types)
-from ..io.meas_info import Info
+from ..io.meas_info import Info, ContainsMixin
 from ..viz.utils import (figure_nobar, plt_show, _setup_cmap,
                          _connection_line, _prepare_joint_axes,
                          _setup_vmin_vmax, _set_title_multiple_electrodes)


### PR DESCRIPTION
Fixes issue for https://github.com/mne-tools/mne-bids/pull/983.

This seems a lot more natural to me. It would be nice if an `Info` object could `get_montage` and allow why not `__contains__` and `get_channel_types` while we're at it, those both operate on the `info`.