### PR TITLE
[TEST] Playing around with fixed dipole orientation in a discrete source space

### DIFF
--- a/doc/inverse.rst
+++ b/doc/inverse.rst
@@ -82,6 +82,7 @@ Inverse Solutions
    Dipole
    DipoleFixed
    fit_dipole
+   concatenate_dipoles
 
 :py:mod:`mne.dipole`:
 

--- a/examples/inverse/multi_dipole_model.py
+++ b/examples/inverse/multi_dipole_model.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+"""
+=================================================================
+Computing source timecourses with an XFit-like multi-dipole model
+=================================================================
+
+MEGIN's XFit program offers a "guided ECD modeling" interface, where multiple
+dipoles can be fitted by manually selecting subsets of sensors and time ranges.
+Then, source timecourses can be computed using a multi-dipole model. The
+advantage of using a multi-dipole model over fitting each dipole in isolation,
+is that when a source is picked up by more than one dipole, a multi-dipole can
+prevent spatial leakage. This example shows how to build a multi-dipole model
+for estimating source timecourses for evokeds or single epochs.
+
+The XFit program is the recommended approach for obtaining dipole fits because
+it offers a convenient interface for it. These dipoles can then be imported
+into MNE-Python by using the :func:`mne.read_dipole` function for building and
+applying the multi-dipole model. However, this example will also demonstrate
+how to perform guided ECD modeling using only MNE-Python functionality.
+"""
+# Author: Marijn van Vliet <w.m.vanvliet@gmail.com>
+#
+# License: BSD-3-Clause
+
+###############################################################################
+# Importing everything and setting up the data paths for the MNE-Sample
+# dataset.
+import mne
+from mne.datasets import sample
+from mne.channels import read_vectorview_selection
+from mne.minimum_norm import (make_inverse_operator, apply_inverse,
+                              apply_inverse_epochs)
+import matplotlib.pyplot as plt
+import numpy as np
+
+data_path = sample.data_path()
+meg_path = data_path / 'MEG' / 'sample'
+raw_fname = meg_path / 'sample_audvis_raw.fif'
+cov_fname = meg_path / 'sample_audvis-shrunk-cov.fif'
+bem_dir = data_path / 'subjects' / 'sample' / 'bem'
+bem_fname =  bem_dir / 'sample-5120-5120-5120-bem-sol.fif'
+
+###############################################################################
+# Read the MEG data from the audvis experiment. Make epochs and evokeds for the
+# left and right auditory conditions.
+raw = mne.io.read_raw_fif(raw_fname)
+raw = raw.pick_types(meg=True, eog=True, stim=True)
+info = raw.info
+
+# Create epochs for auditory events
+events = mne.find_events(raw)
+event_id = dict(right=1, left=2)
+epochs = mne.Epochs(raw, events, event_id,
+                    tmin=-0.1, tmax=0.3, baseline=(None, 0),
+                    reject=dict(mag=4e-12, grad=4000e-13, eog=150e-6))
+
+# Create evokeds for left and right auditory stimulation
+evoked_left = epochs['left'].average()
+evoked_right = epochs['right'].average()
+
+###############################################################################
+# Guided dipole modeling, meaning fitting dipoles to a manually selected subset
+# of sensors as a manually chosen time, can now be performed in MEGINs XFit on
+# the evokeds we computed above. However, it is possible to do it completely
+# in MNE-Python.
+
+# Setup conductor model
+cov = mne.read_cov(cov_fname)
+bem = mne.read_bem_solution(bem_fname)
+
+# Fit two dipoles at t=80ms. The first dipole is fitted using only the sensors
+# on the right side of the helmet. The second dipole is fitted using only the
+# sensors on the left side of the helmet.
+picks_left = read_vectorview_selection('Left', info=info)
+evoked_fit_left = evoked_left.copy().crop(0.08, 0.08)
+evoked_fit_left.pick_channels(picks_left)
+dip_left, _ = mne.fit_dipole(evoked_fit_left, cov, bem)
+
+picks_right = read_vectorview_selection('Right', info=info)
+evoked_fit_right = evoked_right.copy().crop(0.08, 0.08)
+evoked_fit_right.pick_channels(picks_right)
+dip_right, _ = mne.fit_dipole(evoked_fit_right, cov, bem)
+
+###############################################################################
+# Now that we have the location and orientations of the dipoles, compute the
+# full timecourses using MNE, assigning activity to both dipoles at the same
+# time while preventing leakage between the two. We use a very low ``lambda``
+# value to ensure both dipoles are fully used.
+
+# Collect the dipoles in a single `Dipole` object and compute a forward model
+dips = mne.concatenate_dipoles([dip_left, dip_right])
+fwd, _ = mne.make_forward_dipole(dips, bem, info)
+
+# Apply MNE inverse
+inv = make_inverse_operator(info, fwd, cov, fixed=True, depth=0)
+stc_left = apply_inverse(evoked_left, inv, method='MNE', lambda2=1E-6)
+stc_right = apply_inverse(evoked_right, inv, method='MNE', lambda2=1E-6)
+
+# Plot the timecourses of the resulting source estimate
+fig, axes = plt.subplots(nrows=2, sharex=True, sharey=True)
+axes[0].plot(stc_left.times, stc_left.data.T)
+axes[0].set_title('Left auditory stimulation')
+axes[0].legend(['Dipole 1', 'Dipole 2'])
+axes[1].plot(stc_right.times, stc_right.data.T)
+axes[1].set_title('Right auditory stimulation')
+axes[1].set_xlabel('Time (s)')
+fig.supylabel('Dipole amplitude')
+
+# We can also fit the timecourses to single epochs. Here, we do it for each
+# experimental condition separately.
+stcs_left = apply_inverse_epochs(epochs['left'], inv, lambda2=1E-6,
+                                 method='MNE')
+stcs_right = apply_inverse_epochs(epochs['right'], inv, lambda2=1E-6,
+                                  method='MNE')
+
+###############################################################################
+# To summarize and visualize the single-epoch dipole amplitudes, we will create
+# a detailed plot of the mean amplitude of the dipoles during different
+# experimental conditions.
+
+# Summarize the single epoch timecourses by computing the mean amplitude from
+# 60-90ms.
+amplitudes_left = []
+amplitudes_right = []
+for stc in stcs_left:
+    amplitudes_left.append(stc.crop(0.06, 0.09).mean().data)
+for stc in stcs_right:
+    amplitudes_right.append(stc.crop(0.06, 0.09).mean().data)
+amplitudes = np.vstack([amplitudes_left, amplitudes_right])
+
+# Visualize the epoch-by-epoch dipole ampltudes in a detailed figure.
+n = len(amplitudes)
+n_left = len(amplitudes_left)
+mean_left = np.mean(amplitudes_left, axis=0)
+mean_right = np.mean(amplitudes_right, axis=0)
+
+fig = plt.figure()
+plt.scatter(np.arange(n), amplitudes[:, 0], label='Dipole 1')
+plt.scatter(np.arange(n), amplitudes[:, 1], label='Dipole 2')
+transition_point = n_left - 0.5
+plt.plot([0, transition_point], [mean_left[0], mean_left[0]], color='C0')
+plt.plot([0, transition_point], [mean_left[1], mean_left[1]], color='C1')
+plt.plot([transition_point, n], [mean_right[0], mean_right[0]], color='C0')
+plt.plot([transition_point, n], [mean_right[1], mean_right[1]], color='C1')
+plt.axvline(transition_point, color='black')
+plt.xlabel('Epochs')
+plt.ylabel('Dipole amplitude')
+plt.suptitle('Single epoch dipole amplitudes')
+fig.text(0.30, 0.9, 'Left auditory stimulation', ha='center')
+fig.text(0.70, 0.9, 'Right auditory stimulation', ha='center')
+plt.legend()

--- a/examples/inverse/multi_dipole_model.py
+++ b/examples/inverse/multi_dipole_model.py
@@ -25,6 +25,8 @@ how to perform guided ECD modeling using only MNE-Python functionality.
 ###############################################################################
 # Importing everything and setting up the data paths for the MNE-Sample
 # dataset.
+import warnings
+
 import mne
 from mne.datasets import sample
 from mne.channels import read_vectorview_selection
@@ -69,17 +71,22 @@ cov = mne.read_cov(cov_fname)
 bem = mne.read_bem_solution(bem_fname)
 
 # Fit two dipoles at t=80ms. The first dipole is fitted using only the sensors
-# on the right side of the helmet. The second dipole is fitted using only the
-# sensors on the left side of the helmet.
+# on the left side of the helmet. The second dipole is fitted using only the
+# sensors on the right side of the helmet.
 picks_left = read_vectorview_selection('Left', info=info)
 evoked_fit_left = evoked_left.copy().crop(0.08, 0.08)
 evoked_fit_left.pick_channels(picks_left)
-dip_left, _ = mne.fit_dipole(evoked_fit_left, cov, bem)
 
 picks_right = read_vectorview_selection('Right', info=info)
 evoked_fit_right = evoked_right.copy().crop(0.08, 0.08)
 evoked_fit_right.pick_channels(picks_right)
-dip_right, _ = mne.fit_dipole(evoked_fit_right, cov, bem)
+
+# Fitting the dipoles with a subset of sensors currently generates warnings
+# regarding the projections. We will ignore these for now.
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    dip_left, _ = mne.fit_dipole(evoked_fit_left, cov, bem)
+    dip_right, _ = mne.fit_dipole(evoked_fit_right, cov, bem)
 
 ###############################################################################
 # Now that we have the location and orientations of the dipoles, compute the

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -93,7 +93,8 @@ from .transforms import (read_trans, write_trans,
                          transform_surface_to, Transform)
 from .proj import (read_proj, write_proj, compute_proj_epochs,
                    compute_proj_evoked, compute_proj_raw, sensitivity_map)
-from .dipole import read_dipole, Dipole, DipoleFixed, fit_dipole
+from .dipole import (read_dipole, Dipole, DipoleFixed, fit_dipole,
+                     concatenate_dipoles)
 from .channels import (equalize_channels, rename_channels, find_layout,
                        read_vectorview_selection)
 from .report import Report, open_report

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -1598,7 +1598,7 @@ def concatenate_dipoles(dipoles):
 
     Notes
     -----
-    .. versionadded:: 1.0
+    .. versionadded:: 1.1
     """
     times, pos, amplitude, ori, gof = [], [], [], [], []
     for dipole in dipoles:

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -1583,8 +1583,23 @@ def get_phantom_dipoles(kind='vectorview'):
     return pos, ori
 
 
-def _concatenate_dipoles(dipoles):
-    """Concatenate a list of dipoles."""
+def concatenate_dipoles(dipoles):
+    """Concatenate a list of dipoles.
+
+    Parameters
+    ----------
+    dipoles : list of Dipole
+        The dipoles to concatenate.
+
+    Returns
+    -------
+    dip : Dipole
+        A single Dipole object containing all the dipoles.
+
+    Notes
+    -----
+    .. versionadded:: 1.0
+    """
     times, pos, amplitude, ori, gof = [], [], [], [], []
     for dipole in dipoles:
         times.append(dipole.times)
@@ -1592,7 +1607,6 @@ def _concatenate_dipoles(dipoles):
         amplitude.append(dipole.amplitude)
         ori.append(dipole.ori)
         gof.append(dipole.gof)
-
     return Dipole(np.concatenate(times), np.concatenate(pos),
                   np.concatenate(amplitude), np.concatenate(ori),
                   np.concatenate(gof), name=None)

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1025,10 +1025,6 @@ def _triage_loose(src, loose, fixed='auto'):
     del fixed
 
     for key, this_loose in loose.items():
-        if key != 'surface' and this_loose != 1:
-            raise ValueError(
-                'loose parameter has to be 1 or "auto" for non-surface '
-                f'source spaces, got loose["{key}"] = {this_loose}')
         if not 0 <= this_loose <= 1:
             raise ValueError(
                 f'loose ({key}) must be between 0 and 1, got {this_loose}')

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1025,6 +1025,10 @@ def _triage_loose(src, loose, fixed='auto'):
     del fixed
 
     for key, this_loose in loose.items():
+        if key == 'volume' and this_loose != 1:
+            raise ValueError(
+                'loose parameter has to be 1 or "auto" for volume '
+                f'source spaces, got loose["{key}"] = {this_loose}')
         if not 0 <= this_loose <= 1:
             raise ValueError(
                 f'loose ({key}) must be between 0 and 1, got {this_loose}')

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -61,8 +61,9 @@ def _prepare_weights(forward, gain, source_weighting, weights, weights_min):
 def _prepare_gain(forward, info, noise_cov, pca, depth, loose, rank,
                   weights=None, weights_min=None):
     depth = _check_depth(depth, 'depth_sparse')
+    fixed = is_fixed_orient(forward)
     forward, gain_info, gain, _, _, source_weighting, _, _, whitener = \
-        _prepare_forward(forward, info, noise_cov, 'auto', loose, rank, pca,
+        _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
                          use_cps=True, **depth)
 
     if weights is None:

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1406,7 +1406,7 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
     # put the forward solution in correct orientation
     # (delaying for the case of fixed ori with depth weighting if
     # allow_fixed_depth is True)
-    if loose.get('surface', 1.) == 0. and len(loose) == 1:
+    if list(loose.values()) == [0.]:
         if not is_fixed_orient(forward):
             if allow_fixed_depth:
                 # can convert now
@@ -1442,7 +1442,7 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
             rank=rank)
 
     # Deal with fixed orientation forward / inverse
-    if loose.get('surface', 1.) == 0. and len(loose) == 1:
+    if list(loose.values()) == [0.]:
         orient_prior = None
         if not is_fixed_orient(forward):
             if depth_prior is not None:

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -512,6 +512,7 @@ def test_bdip(fname_dip_, fname_bdip_, tmp_path):
 
 @testing.requires_testing_data
 def test_concatenate_dipoles():
+    """Test concatenating dipoles."""
     dips1 = read_dipole(fname_dip)
     dips2 = concatenate_dipoles([dips1[:5], dips1[5:]])
     assert_array_equal(dips1.times, dips2.times)

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -17,7 +17,8 @@ from mne import (read_dipole, read_forward_solution,
                  transform_surface_to, make_sphere_model, pick_types,
                  pick_info, EvokedArray, read_source_spaces, make_ad_hoc_cov,
                  make_forward_solution, Dipole, DipoleFixed, Epochs,
-                 make_fixed_length_events, Evoked, head_to_mni)
+                 make_fixed_length_events, Evoked, head_to_mni,
+                 concatenate_dipoles)
 from mne.dipole import get_phantom_dipoles, _BDIP_ERROR_KEYS
 from mne.simulation import simulate_evoked
 from mne.datasets import testing
@@ -507,3 +508,13 @@ def test_bdip(fname_dip_, fname_bdip_, tmp_path):
         # Test whether indexing works
         this_bdip0 = this_bdip[0]
         _check_dipole(this_bdip0, 1)
+
+@testing.requires_testing_data
+def test_concatenate_dipoles():
+    dips1 = read_dipole(fname_dip)
+    dips2 = concatenate_dipoles([dips1[:5], dips1[5:]])
+    assert_array_equal(dips1.times, dips2.times)
+    assert_array_equal(dips1.pos, dips2.pos)
+    assert_array_equal(dips1.amplitude, dips2.amplitude)
+    assert_array_equal(dips1.ori, dips2.ori)
+    assert_array_equal(dips1.gof, dips2.gof)

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -509,6 +509,7 @@ def test_bdip(fname_dip_, fname_bdip_, tmp_path):
         this_bdip0 = this_bdip[0]
         _check_dipole(this_bdip0, 1)
 
+
 @testing.requires_testing_data
 def test_concatenate_dipoles():
     dips1 = read_dipole(fname_dip)

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -3051,8 +3051,8 @@ def _plot_dipole_mri_orthoview(dipole, trans, subject, subjects_dir=None,
     _check_option('coord_frame', coord_frame, ['head', 'mri'])
 
     if not isinstance(dipole, Dipole):
-        from ..dipole import _concatenate_dipoles
-        dipole = _concatenate_dipoles(dipole)
+        from ..dipole import concatenate_dipoles
+        dipole = concatenate_dipoles(dipole)
     if idx == 'gof':
         idx = np.argmax(dipole.gof)
     elif idx == 'amplitude':


### PR DESCRIPTION
Trying to see what it takes to perform MxNE using a source space that consists of two dipoles with fixed orientation. Currently, MNE doesn't support forward models with fixed orientation that are not of type `'surface'`. In this PR I'm disabling these checks and see what happens.

Here is some example code that creates such a forward model and attempts to perform MxNE source estimation with it:

```python
import mne
import numpy as np
import matplotlib.pyplot as plt

# Read phantom data
data_path = mne.datasets.brainstorm.bst_phantom_elekta.data_path(verbose=True)
raw = mne.io.read_raw_fif(f'{data_path}/kojak_all_200nAm_pp_no_chpi_no_ms_raw.fif')
events = mne.find_events(raw, 'STI201')

# Extract evoked data for 2 dipoles
epochs = mne.Epochs(raw, events, [1, 17], tmin=-0.1, tmax=0.1, baseline=(-0.1, -0.05))
evoked_dip1 = epochs['1'].average()
evoked_dip2 = epochs['17'].average()

# Create an evoked with both dipole active at the same time
evoked = evoked_dip1.copy()
evoked.data += evoked_dip2.data

# Fit two dipoles
cov = mne.compute_covariance(epochs, tmax=-0.05)
bem = mne.make_sphere_model(r0=[0, 0, 0], head_radius=0.08)
dip1, _ = mne.fit_dipole(evoked_dip1.copy().crop(0.035, 0.035), cov, bem)
dip2, _ = mne.fit_dipole(evoked_dip2.copy().crop(0.035, 0.035), cov, bem)

# Collect the dipoles in a single `Dipole` object
dips = mne.Dipole(
    times=np.hstack((dip1.times, dip2.times)),
    pos=np.vstack((dip1.pos, dip2.pos)),
    ori=np.vstack((dip1.ori, dip2.ori)),
    amplitude=np.hstack((dip1.amplitude, dip2.amplitude)),
    gof=np.hstack((dip1.gof, dip2.gof)),
    name=None,
    conf=None,
    khi2=np.hstack((dip1.khi2, dip2.khi2)),
    nfree=dip1.nfree,
)

# Compute dipole timecourses using MxNE
fwd, _ = mne.make_forward_dipole(dips, bem, evoked.info)
stc = mne.inverse_sparse.mixed_norm(evoked, fwd, cov)

# Plot the timecourses
plt.plot(evoked.times, stc.data.T)
```