### PR TITLE
[MAINT] fix ref link

### DIFF
--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -356,7 +356,8 @@ def plot_channel_labels_circle(labels, colors=None, picks=None, **kwargs):
     picks : list | tuple
         The channels to consider.
     **kwargs : kwargs
-        Keyword arguments for ``plot_connectivity_circle``.
+        Keyword arguments for
+        :func:`mne_connectivity.viz.plot_connectivity_circle`.
 
     Returns
     -------


### PR DESCRIPTION
This fixes the last suboptimal bit of `mne.viz.circle.py` where there wasn't a reference for the keyword arguments. Needs https://github.com/mne-tools/mne-connectivity/pull/88 so that the arguments are up-to-date.