### PR TITLE
BUG: Fix ICP update bug

### DIFF
--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -1933,11 +1933,11 @@ class Coregistration(object):
                 self._update_params(rot=est[:3], tra=est[3:6], sca=est[6:9])
             angle, move, scale = self._changes
             self._log_dig_mri_distance(f'  ICP {iteration + 1:2d} ')
+            if callback is not None:
+                callback(iteration, n_iterations)
             if angle <= self._icp_angle and move <= self._icp_distance and \
                     all(scale <= self._icp_scale):
                 break
-            if callback is not None:
-                callback(iteration, n_iterations)
         self._log_dig_mri_distance('End      ')
         return self
 

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -940,14 +940,17 @@ class CoregistrationUI(HasTraits):
     def _update_parameters(self):
         with self._lock(plot=True, params=True):
             # rotation
-            self._forward_widget_command(["rX", "rY", "rZ"], "set_value",
-                                         np.rad2deg(self.coreg._rotation))
+            deg = np.rad2deg(self.coreg._rotation)
+            logger.debug(f'  Rotation:    {deg}')
+            self._forward_widget_command(["rX", "rY", "rZ"], "set_value", deg)
             # translation
-            self._forward_widget_command(["tX", "tY", "tZ"], "set_value",
-                                         self.coreg._translation * 1e3)
+            mm = self.coreg._translation * 1e3
+            logger.debug(f'  Translation: {mm}')
+            self._forward_widget_command(["tX", "tY", "tZ"], "set_value", mm)
             # scale
-            self._forward_widget_command(["sX", "sY", "sZ"], "set_value",
-                                         self.coreg._scale * 1e2)
+            sc = self.coreg._scale * 1e2
+            logger.debug(f'  Scale:       {sc}')
+            self._forward_widget_command(["sX", "sY", "sZ"], "set_value", sc)
 
     def _reset(self, keep_trans=False):
         """Refresh the scene, and optionally reset transformation & scaling.
@@ -1566,7 +1569,7 @@ class CoregistrationUI(HasTraits):
             self._widgets[name] = self._renderer._dock_add_spin_box(
                 name=name,
                 value=attr[coords.index(coord)] * 1e2,
-                rng=[1., 1e2],
+                rng=[1., 10000.],  # percent
                 callback=partial(
                     self._set_parameter,
                     mode_name="scale",
@@ -1742,7 +1745,7 @@ class CoregistrationUI(HasTraits):
             self._widgets[name] = self._renderer._dock_add_spin_box(
                 name=fid,
                 value=getattr(self, f"_{fid_lower}_weight"),
-                rng=[1., 100.],
+                rng=[0., 100.],
                 callback=partial(self._set_point_weight, point=fid_lower),
                 compact=True,
                 double=True,

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -147,7 +147,7 @@ def test_coreg_gui_pyvista_basic(tmp_path, renderer_interactive_pyvistaqt,
     with catch_logging() as log:
         coreg = coregistration(inst=raw_path, subject='sample',
                                head_high_res=False,  # for speed
-                               subjects_dir=subjects_dir, verbose=True)
+                               subjects_dir=subjects_dir, verbose='debug')
     log = log.getvalue()
     assert 'Total 16/78 points inside the surface' in log
     coreg._set_fiducials_file(fid_fname)
@@ -162,12 +162,16 @@ def test_coreg_gui_pyvista_basic(tmp_path, renderer_interactive_pyvistaqt,
     assert_allclose(coreg.coreg._scale,
                     np.array([97.46, 97.46, 97.46]) * 1e-2,
                     atol=1e-3)
+    shown_scale = [coreg._widgets[f's{x}'].get_value() for x in 'XYZ']
+    assert_allclose(shown_scale, coreg.coreg._scale * 100, atol=1e-2)
     coreg._set_icp_fid_match("nearest")
     coreg._set_scale_mode("3-axis")
     coreg._fits_icp()
     assert_allclose(coreg.coreg._scale,
                     np.array([104.43, 101.47, 125.78]) * 1e-2,
                     atol=1e-3)
+    shown_scale = [coreg._widgets[f's{x}'].get_value() for x in 'XYZ']
+    assert_allclose(shown_scale, coreg.coreg._scale * 100, atol=1e-2)
     coreg._set_scale_mode("None")
     coreg._set_icp_fid_match("matched")
     assert coreg._mri_scale_modified
@@ -226,7 +230,7 @@ def test_coreg_gui_pyvista_basic(tmp_path, renderer_interactive_pyvistaqt,
     log = log.getvalue()
     assert 'Total 6/78 points inside the surface' in log
     norm = np.linalg.norm(coreg._head_geo['rr'])  # what's used for inside
-    assert_allclose(norm, 5.947604, atol=1e-3)
+    assert_allclose(norm, 5.949288, atol=1e-3)
     coreg._set_grow_hair(20.0)
     with catch_logging() as log:
         coreg._redraw()


### PR DESCRIPTION
Fixes two bugs:

1. The `callback` in ICP should be called before the `break` (otherwise the last/final iteration is not reflected)
2. The GUI should not limit the scale to `<=100` (percent) but rather something much higher like 10000. This makes the updates work properly:

   https://user-images.githubusercontent.com/2365790/158857774-591a9d51-9e0f-40fe-bfdf-d1b2d61ec30c.mp4

 