### PR TITLE
[MAINT] Fix colorbar

### DIFF
--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -126,7 +126,7 @@ def _plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
                               node_edgecolor='black', linewidth=1.5,
                               colormap='hot', vmin=None, vmax=None,
                               colorbar=True, title=None,
-                              colorbar_size=0.2, colorbar_pos=(-0.3, 0.1),
+                              colorbar_size=None, colorbar_pos=None,
                               fontsize_title=12, fontsize_names=8,
                               fontsize_colorbar=8, padding=6.,
                               ax=None, interactive=True,
@@ -321,9 +321,12 @@ def _plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
         sm = plt.cm.ScalarMappable(cmap=colormap,
                                    norm=plt.Normalize(vmin, vmax))
         sm.set_array(np.linspace(vmin, vmax))
-        cb = plt.colorbar(sm, ax=ax, use_gridspec=False,
-                          shrink=colorbar_size,
-                          anchor=colorbar_pos)
+        colorbar_kwargs = dict()
+        if colorbar_size is not None:
+            colorbar_kwargs.update(shrink=colorbar_size)
+        if colorbar_pos is not None:
+            colorbar_kwargs.update(anchor=colorbar_pos)
+        cb = fig.colorbar(sm, ax=ax, **colorbar_kwargs)
         cb_yticks = plt.getp(cb.ax.axes, 'yticklabels')
         cb.ax.tick_params(labelsize=fontsize_colorbar)
         plt.setp(cb_yticks, color=textcolor)


### PR DESCRIPTION
Okay, one last fix with the changes. Before, `fig.tight_layout` didn't work and so the title overlapped the text. When I let `ax` be passed directly, it allowed `fig.tight_layout` but the colorbar didn't work with it. This allows the previous functionality of specifying the position of the colorbar, but makes the default not have overlapping text with `fig.tight_layout`.