### PR TITLE
FIX: notebook checkbox layout

### DIFF
--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -1731,13 +1731,13 @@ class CoregistrationUI(HasTraits):
             filter='Head->MRI transformation (*-trans.fif *_trans.fif)',
             initial_directory=str(Path(self._info_file).parent),
         )
+        self._renderer._layout_add_widget(trans_layout, save_trans_layout)
         self._widgets["reset_trans"] = self._renderer._dock_add_button(
-            name="Reset",
+            name="Reset Parameters",
             callback=self._reset,
             tooltip="Reset all the parameters affecting the coregistration",
-            layout=save_trans_layout,
+            layout=trans_layout,
         )
-        self._renderer._layout_add_widget(trans_layout, save_trans_layout)
 
         fitting_options_layout = self._renderer._dock_add_group_box(
             name="Fitting Options",

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -196,7 +196,7 @@ class _IpyDock(_AbstractDock, _IpyLayout):
         if self._docks is None:
             self._docks = dict()
         current_dock = VBox()
-        self._dock_width = 300
+        self._dock_width = 302
         self._dock = self._dock_layout = current_dock
         self._dock.layout.width = f"{self._dock_width}px"
         self._layout_initialize(self._dock_width)
@@ -268,10 +268,12 @@ class _IpyDock(_AbstractDock, _IpyLayout):
         widget = Checkbox(
             value=value,
             description=name,
+            indent=False,
             disabled=False
         )
+        hbox = HBox([widget])  # fix stretching to the right
         widget.observe(_generate_callback(callback), names='value')
-        self._layout_add_widget(layout, widget)
+        self._layout_add_widget(layout, hbox)
         return _IpyWidget(widget)
 
     def _dock_add_spin_box(self, name, value, rng, callback, *,


### PR DESCRIPTION
This PR fixes the layout of checkboxes on the `notebook` 3d backend and adjusts the size of the dock. It also changes the 'Reset' button of the coreg app to 'Reset Parameters' and moves it to its own line.

backend\branch | main | PR
--|--|--
notebook | ![image](https://user-images.githubusercontent.com/18143289/159722541-b0691256-9e17-4b8b-861b-5a602c73ff3b.png) | ![image](https://user-images.githubusercontent.com/18143289/159721725-e928c95d-6f95-4ca3-a6ae-9647aceab754.png)
pyvistaqt | ![image](https://user-images.githubusercontent.com/18143289/159722177-2d3eda5a-85b0-44dc-9fdd-49b40b40ba94.png) | ![image](https://user-images.githubusercontent.com/18143289/159722003-5aa57986-d9cd-4848-8b11-ea933e21adcf.png)

It's an item of #8833
