### PR TITLE
Fix error in filtering documentation

### DIFF
--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -879,7 +879,7 @@ _DEFAULT_ALIM = (-80, 10)
 def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
                 flim=None, fscale='log', alim=_DEFAULT_ALIM, show=True,
                 compensate=False, plot=('time', 'magnitude', 'delay'),
-                axes=None):
+                axes=None, *, dlim=None):
     """Plot properties of a filter.
 
     Parameters
@@ -932,6 +932,11 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
         Defaults to ``None``.
 
         .. versionadded:: 0.21.0
+    dlim : None | tuple
+        The y-axis delay limits (sec) to use (default:
+        ``(-tmax / 2., tmax / 2.)``).
+
+        .. versionadded:: 1.1.0
 
     Returns
     -------
@@ -1036,8 +1041,9 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
                          % (len(axes), len(plot)))
 
     t = np.arange(len(h))
-    dlim = np.abs(t).max() / 2.
-    dlim = [-dlim, dlim]
+    if dlim is None:
+        dlim = np.abs(t).max() / 2.
+        dlim = [-dlim, dlim]
     if compensate:
         n_shift = (len(h) - 1) // 2
         t -= n_shift

--- a/tutorials/preprocessing/25_background_filtering.py
+++ b/tutorials/preprocessing/25_background_filtering.py
@@ -57,7 +57,7 @@ filters have a transfer function that is given by:
 
     H(z) &= \frac{b_0 + b_1 z^{-1} + b_2 z^{-2} + \ldots + b_M z^{-M}}
                  {1 + a_1 z^{-1} + a_2 z^{-2} + \ldots + a_N z^{-M}} \\
-         &= \frac{\sum_{k=0}^Mb_kz^{-k}}{\sum_{k=1}^Na_kz^{-k}}
+         &= \frac{\sum_{k=0}^Mb_kz^{-k}}{1 + \sum_{k=1}^Na_kz^{-k}}
 
 In the time domain, the numerator coefficients :math:`b_k` and denominator
 coefficients :math:`a_k` can be used to obtain our output data
@@ -66,16 +66,16 @@ coefficients :math:`a_k` can be used to obtain our output data
 .. math::
    :label: summations
 
-    y(n) &= b_0 x(n) + b_1 x(n-1) + \ldots + b_M x(n-M)
-            - a_1 y(n-1) - a_2 y(n - 2) - \ldots - a_N y(n - N)\\
+    y(n) &= b_0 x(n) + \ldots + b_M x(n-M)
+            - a_1 y(n-1) - \ldots - a_N y(n - N)\\
          &= \sum_{k=0}^M b_k x(n-k) - \sum_{k=1}^N a_k y(n-k)
 
 In other words, the output at time :math:`n` is determined by a sum over
 
-    1. the numerator coefficients :math:`b_k`, which get multiplied by
-       the previous input values :math:`x(n-k)`, and
-    2. the denominator coefficients :math:`a_k`, which get multiplied by
-       the previous output values :math:`y(n-k)`.
+1. the numerator coefficients :math:`b_k`, which get multiplied by
+    the previous input values :math:`x(n-k)`, and
+2. the denominator coefficients :math:`a_k`, which get multiplied by
+    the previous output values :math:`y(n-k)`.
 
 Note that these summations correspond to (1) a weighted `moving average`_ and
 (2) an autoregression_.

--- a/tutorials/preprocessing/25_background_filtering.py
+++ b/tutorials/preprocessing/25_background_filtering.py
@@ -81,7 +81,7 @@ Note that these summations correspond to (1) a weighted `moving average`_ and
 Filters are broken into two classes based on these coefficients: FIR_ (finite
 impulse response) and IIR_ (infinite impulse response) filters.
 FIR filters use a finite number of numerator
-coefficients :math:`b_k` (:math:`a_k=0 \forall k`), and thus each output
+coefficients :math:`b_k` (where :math:`a_k=0\qquad \forall k`), and thus each output
 value :math:`y(n)` depends only on the :math:`M` previous input values.
 IIR filters depend on the previous input and output values, and thus can have
 effectively infinitely long impulse responses.
@@ -91,7 +91,7 @@ FIR and IIR filters have different pros and cons:
 
 * A causal FIR filter can be linear-phase -- i.e., the same time delay across all frequencies -- whereas a causal IIR filter cannot. The phase and group delay characteristics are also usually better for FIR filters.
 * IIR filters can generally have a steeper cutoff than an FIR filter of equivalent order.
-* IIR filters are generally less numerically stable, in part due to accumulating error (due to its recursive calculations).
+* IIR filters are generally less numerically stable, in part due to accumulating error (due to recursive calculations).
 
 In MNE-Python we default to using FIR filtering. As noted in Widmann *et al.*
 (2015) :footcite:`WidmannEtAl2015`:

--- a/tutorials/preprocessing/25_background_filtering.py
+++ b/tutorials/preprocessing/25_background_filtering.py
@@ -73,9 +73,9 @@ coefficients :math:`a_k` can be used to obtain our output data
 In other words, the output at time :math:`n` is determined by a sum over
 
 1. the numerator coefficients :math:`b_k`, which get multiplied by the previous
-input values :math:`x(n-k)`, and
+   input values :math:`x(n-k)`, and
 2. the denominator coefficients :math:`a_k`, which get multiplied by the
-previous output values :math:`y(n-k)`.
+   previous output values :math:`y(n-k)`.
 
 Note that these summations correspond to (1) a weighted `moving average`_ and
 (2) an autoregression_.

--- a/tutorials/preprocessing/25_background_filtering.py
+++ b/tutorials/preprocessing/25_background_filtering.py
@@ -78,24 +78,20 @@ In other words, the output at time :math:`n` is determined by a sum over
 Note that these summations correspond to (1) a weighted `moving average`_ and
 (2) an autoregression_.
 
-Filters are broken into two classes: FIR_ (finite impulse response) and
-IIR_ (infinite impulse response) based on these coefficients.
+Filters are broken into two classes based on these coefficients: FIR_ (finite
+impulse response) and IIR_ (infinite impulse response) filters.
 FIR filters use a finite number of numerator
-coefficients :math:`b_k` (:math:`\forall k, a_k=0`), and thus each output
-value of :math:`y(n)` depends only on the :math:`M` previous input values.
+coefficients :math:`b_k` (:math:`a_k=0 \forall k`), and thus each output
+value :math:`y(n)` depends only on the :math:`M` previous input values.
 IIR filters depend on the previous input and output values, and thus can have
-effectively infinite impulse responses.
+effectively infinitely long impulse responses.
 
 As outlined in Parks & Burrus (1987) :footcite:`ParksBurrus1987`,
-FIR and IIR have different trade-offs:
+FIR and IIR filters have different pros and cons:
 
-    * A causal FIR filter can be linear-phase -- i.e., the same time delay
-      across all frequencies -- whereas a causal IIR filter cannot. The phase
-      and group delay characteristics are also usually better for FIR filters.
-    * IIR filters can generally have a steeper cutoff than an FIR filter of
-      equivalent order.
-    * IIR filters are generally less numerically stable, in part due to
-      accumulating error (due to its recursive calculations).
+* A causal FIR filter can be linear-phase -- i.e., the same time delay across all frequencies -- whereas a causal IIR filter cannot. The phase and group delay characteristics are also usually better for FIR filters.
+* IIR filters can generally have a steeper cutoff than an FIR filter of equivalent order.
+* IIR filters are generally less numerically stable, in part due to accumulating error (due to its recursive calculations).
 
 In MNE-Python we default to using FIR filtering. As noted in Widmann *et al.*
 (2015) :footcite:`WidmannEtAl2015`:
@@ -103,7 +99,7 @@ In MNE-Python we default to using FIR filtering. As noted in Widmann *et al.*
     Despite IIR filters often being considered as computationally more
     efficient, they are recommended only when high throughput and sharp
     cutoffs are required
-    (Ifeachor and Jervis, 2002 :footcite:`IfeachorJervis2002`, p. 321)...
+    (Ifeachor and Jervis, 2002 :footcite:`IfeachorJervis2002`, p. 321).
     FIR filters are easier to control, are always stable, have a
     well-defined passband, can be corrected to zero-phase without
     additional computations, and can be converted to minimum-phase.
@@ -113,11 +109,11 @@ In MNE-Python we default to using FIR filtering. As noted in Widmann *et al.*
 When designing a filter (FIR or IIR), there are always trade-offs that
 need to be considered, including but not limited to:
 
-    1. Ripple in the pass-band
-    2. Attenuation of the stop-band
-    3. Steepness of roll-off
-    4. Filter order (i.e., length for FIR filters)
-    5. Time-domain ringing
+1. Ripple in the pass-band
+2. Attenuation of the stop-band
+3. Steepness of roll-off
+4. Filter order (i.e., length for FIR filters)
+5. Time-domain ringing
 
 In general, the sharper something is in frequency, the broader it is in time,
 and vice-versa. This is a fundamental time-frequency trade-off, and it will
@@ -179,8 +175,8 @@ plot_ideal_filter(freq, gain, ax, title='Ideal %s Hz lowpass' % f_p, flim=flim)
 # (and thus infinite time) to represent. So although this filter has ideal
 # frequency suppression, it has poor time-domain characteristics.
 #
-# Let's try to naïvely make a brick-wall filter of length 0.1 s, and look
-# at the filter itself in the time domain and the frequency domain:
+# Let's try to naïvely make a brick-wall (sinc) filter of length 0.1 s, and
+# look at the filter itself in the time domain and the frequency domain:
 
 n = int(round(0.1 * sfreq))
 n -= n % 2 - 1  # make it odd
@@ -219,12 +215,10 @@ plot_filter(h, sfreq, freq, gain, 'Sinc (10.0 s)', flim=flim, compensate=True)
 # Fortunately, there are multiple established methods to design FIR filters
 # based on desired response characteristics. These include:
 #
-#     1. The Remez_ algorithm (:func:`scipy.signal.remez`, `MATLAB firpm`_)
-#     2. Windowed FIR design (:func:`scipy.signal.firwin2`,
-#        :func:`scipy.signal.firwin`, and `MATLAB fir2`_)
-#     3. Least squares designs (:func:`scipy.signal.firls`, `MATLAB firls`_)
-#     4. Frequency-domain design (construct filter in Fourier
-#        domain and use an :func:`IFFT <numpy.fft.ifft>` to invert it)
+# 1. The Remez_ algorithm (:func:`scipy.signal.remez`)
+# 2. Windowed FIR design (:func:`scipy.signal.firwin2`, :func:`scipy.signal.firwin`)  # noqa
+# 3. Least squares design (:func:`scipy.signal.firls`)
+# 4. Frequency-domain design (construct filter in Fourier domain and use an :func:`IFFT <numpy.fft.ifft>` to invert it)  # noqa
 #
 # .. note:: Remez and least squares designs have advantages when there are
 #           "do not care" regions in our frequency response. However, we want
@@ -238,8 +232,8 @@ plot_filter(h, sfreq, freq, gain, 'Sinc (10.0 s)', flim=flim, compensate=True)
 #
 # If we relax our frequency-domain filter requirements a little bit, we can
 # use these functions to construct a lowpass filter that instead has a
-# *transition band*, or a region between the pass frequency :math:`f_p`
-# and stop frequency :math:`f_s`, e.g.:
+# *transition band*, a region between the pass frequency :math:`f_p`
+# and stop frequency :math:`f_s`:
 
 trans_bandwidth = 10  # 10 Hz transition band
 f_s = f_p + trans_bandwidth  # = 50 Hz
@@ -350,7 +344,7 @@ x += rng.randn(len(x)) / 1000.
 x += np.sin(2. * np.pi * 60. * np.arange(len(x)) / sfreq) / 2000.
 
 # %%
-# Filter it with a shallow cutoff, linear-phase FIR (which allows us to
+# Let's filter it with a shallow cutoff, linear-phase FIR (which allows us to
 # compensate for the constant filter delay):
 
 transition_band = 0.25 * f_p
@@ -364,14 +358,14 @@ x_v16 = np.convolve(h, x)
 # this is the linear->zero phase, causal-to-non-causal conversion / shift
 x_v16 = x_v16[len(h) // 2:]
 
-plot_filter(h, sfreq, freq, gain, 'MNE-Python 0.16 default', flim=flim,
+plot_filter(h, sfreq, freq, gain, 'MNE-Python ≥0.16 default', flim=flim,
             compensate=True)
 
 # %%
-# Filter it with a different design method ``fir_design="firwin2"``, and also
-# compensate for the constant filter delay. This method does not produce
-# quite as sharp a transition compared to ``fir_design="firwin"``, despite
-# being twice as long:
+# Now let's filter it with a different design method ``fir_design="firwin2"``,
+# and also compensate for the constant filter delay. This method does not
+# produce quite as sharp a transition compared to ``fir_design="firwin"``,
+# despite being twice as long:
 
 transition_band = 0.25 * f_p
 f_s = f_p + transition_band
@@ -407,7 +401,7 @@ h = mne.filter.create_filter(x, sfreq, l_freq=None, h_freq=f_p,
 x_v13 = np.convolve(np.convolve(h, x)[::-1], h)[::-1][len(h) - 1:-len(h) - 1]
 # the effective h is one that is applied to the time-reversed version of itself
 h_eff = np.convolve(h, h[::-1])
-plot_filter(h_eff, sfreq, freq, gain, 'MNE-Python 0.13 default', flim=flim,
+plot_filter(h_eff, sfreq, freq, gain, 'MNE-Python ≤0.13 default', flim=flim,
             compensate=True)
 
 # %%
@@ -466,8 +460,8 @@ def plot_signal(x, offset):
 
 
 yscale = 30
-yticklabels = ['Original', 'Noisy', 'FIR-firwin (0.16)', 'FIR-firwin2 (0.14)',
-               'FIR-steep (0.13)', 'FIR-steep (MNE-C)', 'Minimum-phase']
+yticklabels = ['Original', 'Noisy', 'FIR-firwin (≥0.16)', 'FIR-firwin2 (0.14)',
+               'FIR-steep (≤0.13)', 'FIR-steep (MNE-C)', 'Minimum-phase']
 yticks = -np.arange(len(yticklabels)) / yscale
 plot_signal(x_orig, offset=yticks[0])
 plot_signal(x, offset=yticks[1])
@@ -503,7 +497,7 @@ plt.show()
 #
 # Often the default IIR filter is a `Butterworth filter`_, which is designed
 # to have a *maximally flat pass-band*. Let's look at a few filter orders,
-# i.e., a few different number of coefficients used and therefore steepness
+# i.e., a few different numbers of coefficients used and therefore steepness
 # of the filter:
 #
 # .. note:: Notice that the group delay (which is related to the phase) of
@@ -626,11 +620,8 @@ plt.show()
 # :footcite:`WidmannSchroger2012` that the problematic low-pass filters from
 # VanRullen (2011) :footcite:`VanRullen2011`:
 #
-#    1. Used a least-squares design (like :func:`scipy.signal.firls`) that
-#       included "do-not-care" transition regions, which can lead to
-#       uncontrolled behavior.
-#    2. Had a filter length that was independent of the transition bandwidth,
-#       which can cause excessive ringing and signal distortion.
+# 1. Used a least-squares design (like :func:`scipy.signal.firls`) that included "do-not-care" transition regions, which can lead to uncontrolled behavior.  # noqa
+# 2. Had a filter length that was independent of the transition bandwidth, which can cause excessive ringing and signal distortion.  # noqa
 #
 # .. _tut-filtering-hp-problems:
 #
@@ -658,10 +649,10 @@ plt.show()
 #    "The simulated component is a single-cycle cosine wave with an amplitude
 #    of 5µV [sic], onset of 500 ms poststimulus, and duration of 800 ms. The
 #    simulated component was embedded in 20 s of zero values to avoid
-#    filtering edge effects... Distortions [were] caused by 2 Hz low-pass
-#    and high-pass filters... No visible distortion to the original
-#    waveform [occurred] with 30 Hz low-pass and 0.01 Hz high-pass filters...
-#    Filter frequencies correspond to the half-amplitude (-6 dB) cutoff
+#    filtering edge effects. [...] Distortions [were] caused by 2 Hz low-pass
+#    and high-pass filters. [...] No visible distortion to the original
+#    waveform [occurred] with 30 Hz low-pass and 0.01 Hz high-pass filters.
+#    [...] Filter frequencies correspond to the half-amplitude (-6 dB) cutoff
 #    (12 dB/octave roll-off)."
 #
 # .. note:: This simulated signal contains energy not just within the
@@ -711,11 +702,11 @@ plt.show()
 # %%
 # Similarly, in a P300 paradigm reported by
 # Kappenman & Luck (2010) :footcite:`KappenmanLuck2010`,
-# they found that applying a 1 Hz high-pass decreased the probability of
+# they found that applying a 1&nbsp;Hz high-pass decreased the probability of
 # finding a significant difference in the N100 response, likely because
 # the P300 response was smeared (and inverted) in time by the high-pass
 # filter such that it tended to cancel out the increased N100. However,
-# they nonetheless note that some high-passing can still be useful to deal
+# they nonetheless noted that some high-passing can still be useful to deal
 # with drifts in the data.
 #
 # Even though these papers generally advise a 0.1 Hz or lower frequency for
@@ -797,10 +788,8 @@ baseline_plot(x)
 # perhaps even the application of baseline correction, depend on the
 # characteristics of the data being investigated, especially when it comes to:
 #
-#    1. The frequency content of the underlying evoked activity relative
-#       to the filtering parameters.
-#    2. The validity of the assumption of no consistent evoked activity
-#       in the baseline period.
+# 1. The frequency content of the underlying evoked activity relative to the filtering parameters.  # noqa
+# 2. The validity of the assumption of no consistent evoked activity in the baseline period.  # noqa
 #
 # We thus recommend carefully applying baseline correction and/or high-pass
 # values based on the characteristics of the data to be analyzed.
@@ -895,9 +884,9 @@ baseline_plot(x)
 # -----------------
 # MNE-C by default uses:
 #
-#    1. 5 Hz transition band for low-pass filters.
-#    2. 3-sample transition band for high-pass filters.
-#    3. Filter length of 8197 samples.
+# 1. 5 Hz transition band for low-pass filters.
+# 2. 3-sample transition band for high-pass filters.
+# 3. Filter length of 8197 samples.
 #
 # The filter is designed in the frequency domain, creating a linear-phase
 # filter such that the delay is compensated for as is done with the MNE-Python
@@ -945,7 +934,7 @@ baseline_plot(x)
 # 7. Direction of computation (one-pass forward/reverse, or two-pass forward
 #    and reverse)
 #
-# In the following, we will address how to deal with these parameters in MNE:
+# In the following, we will address how to deal with these parameters in MNE.
 #
 #
 # Filter type
@@ -963,13 +952,13 @@ baseline_plot(x)
 # with ``h_freq = 40``, the filter function will provide a transition
 # bandwidth that depends on the ``h_trans_bandwidth`` argument. The desired
 # half-amplitude  cutoff of the lowpass FIR filter is then at
-# ``h_freq + transition_bandwidth/2.``.
+# ``h_freq + transition_bandwidth/2``.
 #
 # Filter length (order) and transition bandwidth (roll-off)
 # ---------------------------------------------------------
 # In the :ref:`tut-filtering-in-python` section, we have already talked about
 # the default filter lengths and transition bandwidths that are used when no
-# custom values are specified using the respective filter function's arguments.
+# custom values are specified using the respective filter function arguments.
 #
 # If you want to find out about the filter length and transition bandwidth that
 # were used through the 'auto' setting, you can use
@@ -1000,8 +989,8 @@ filter_length = fir_coefs.shape[0]
 # Passband ripple and stopband attenuation
 # ----------------------------------------
 #
-# When use standard :func:`scipy.signal.firwin` design (as for FIR filters in
-# MNE), the passband ripple and stopband attenuation are dependent upon the
+# When using the standard :func:`scipy.signal.firwin` design (as for FIR
+# filters in MNE), the passband ripple and stopband attenuation depend on the
 # window used in design. For standard windows the values are listed in this
 # table (see Ifeachor & Jervis (2002) :footcite:`IfeachorJervis2002`, p. 357):
 #
@@ -1026,7 +1015,7 @@ filter_length = fir_coefs.shape[0]
 #    By default, a symmetric linear-phase FIR filter is constructed.
 #    If ``phase='zero'`` (default), the delay of this filter
 #    is compensated for. If ``phase=='zero-double'``, then this filter
-#    is applied twice, once forward, and once backward. If 'minimum',
+#    is applied twice, once forward, and once backward. If ``'minimum'``,
 #    then a minimum-phase, causal filter will be used.
 #
 #
@@ -1034,12 +1023,12 @@ filter_length = fir_coefs.shape[0]
 # =======
 #
 # When filtering, there are always trade-offs that should be considered.
-# One important trade-off is between time-domain characteristics (like ringing)
-# and frequency-domain attenuation characteristics (like effective transition
-# bandwidth). Filters with sharp frequency cutoffs can produce outputs that
-# ring for a long time when they operate on signals with frequency content
-# in the transition band. In general, therefore, the wider a transition band
-# that can be tolerated, the better behaved the filter will be in the time
+# One important trade-off is balancing time-domain characteristics (like
+# ringing) and frequency-domain attenuation characteristics (like effective
+# transition bandwidth). Filters with sharp frequency cutoffs can produce
+# outputs that ring for a long time when they operate on signals with frequency
+# content in the transition band. In general, therefore, the wider a transition
+# band that can be tolerated, the better behaved the filter will be in the time
 # domain.
 #
 # References
@@ -1052,9 +1041,6 @@ filter_length = fir_coefs.shape[0]
 # .. _moving average: https://en.wikipedia.org/wiki/Moving_average
 # .. _autoregression: https://en.wikipedia.org/wiki/Autoregressive_model
 # .. _Remez: https://en.wikipedia.org/wiki/Remez_algorithm
-# .. _matlab firpm: https://www.mathworks.com/help/signal/ref/firpm.html
-# .. _matlab fir2: https://www.mathworks.com/help/signal/ref/fir2.html
-# .. _matlab firls: https://www.mathworks.com/help/signal/ref/firls.html
 # .. _Butterworth filter: https://en.wikipedia.org/wiki/Butterworth_filter
 # .. _eeglab filtering faq: https://sccn.ucsd.edu/wiki/Firfilt_FAQ
 # .. _ftbp: http://www.fieldtriptoolbox.org/reference/ft_preproc_bandpassfilter

--- a/tutorials/preprocessing/25_background_filtering.py
+++ b/tutorials/preprocessing/25_background_filtering.py
@@ -72,10 +72,8 @@ coefficients :math:`a_k` can be used to obtain our output data
 
 In other words, the output at time :math:`n` is determined by a sum over
 
-1. the numerator coefficients :math:`b_k`, which get multiplied by the previous
-   input values :math:`x(n-k)`, and
-2. the denominator coefficients :math:`a_k`, which get multiplied by the
-   previous output values :math:`y(n-k)`.
+1. the numerator coefficients :math:`b_k`, which get multiplied by the previous input values :math:`x(n-k)`, and
+2. the denominator coefficients :math:`a_k`, which get multiplied by the previous output values :math:`y(n-k)`.
 
 Note that these summations correspond to (1) a weighted `moving average`_ and
 (2) an autoregression_.
@@ -130,7 +128,7 @@ FIR Filters
 
 First, we will focus on FIR filters, which are the default filters used by
 MNE-Python.
-"""
+"""  # noqa
 
 # %%
 # Designing FIR filters

--- a/tutorials/preprocessing/25_background_filtering.py
+++ b/tutorials/preprocessing/25_background_filtering.py
@@ -72,8 +72,10 @@ coefficients :math:`a_k` can be used to obtain our output data
 
 In other words, the output at time :math:`n` is determined by a sum over
 
-1. the numerator coefficients :math:`b_k`, which get multiplied by the previous input values :math:`x(n-k)`, and
-2. the denominator coefficients :math:`a_k`, which get multiplied by the previous output values :math:`y(n-k)`.
+1. the numerator coefficients :math:`b_k`, which get multiplied by the previous
+   input values :math:`x(n-k)`, and
+2. the denominator coefficients :math:`a_k`, which get multiplied by the
+   previous output values :math:`y(n-k)`.
 
 Note that these summations correspond to (1) a weighted `moving average`_ and
 (2) an autoregression_.
@@ -81,17 +83,21 @@ Note that these summations correspond to (1) a weighted `moving average`_ and
 Filters are broken into two classes based on these coefficients: FIR_ (finite
 impulse response) and IIR_ (infinite impulse response) filters.
 FIR filters use a finite number of numerator
-coefficients :math:`b_k` (where :math:`a_k=0\qquad \forall k`), and thus each output
-value :math:`y(n)` depends only on the :math:`M` previous input values.
+coefficients :math:`b_k` (where :math:`a_k=0\qquad \forall k`), and thus each
+output value :math:`y(n)` depends only on the :math:`M` previous input values.
 IIR filters depend on the previous input and output values, and thus can have
 effectively infinitely long impulse responses.
 
 As outlined in Parks & Burrus (1987) :footcite:`ParksBurrus1987`,
 FIR and IIR filters have different pros and cons:
 
-* A causal FIR filter can be linear-phase -- i.e., the same time delay across all frequencies -- whereas a causal IIR filter cannot. The phase and group delay characteristics are also usually better for FIR filters.
-* IIR filters can generally have a steeper cutoff than an FIR filter of equivalent order.
-* IIR filters are generally less numerically stable, in part due to accumulating error (due to recursive calculations).
+* A causal FIR filter can be linear-phase -- i.e., the same time delay across
+  all frequencies -- whereas a causal IIR filter cannot. The phase and group
+  delay characteristics are also usually better for FIR filters.
+* IIR filters can generally have a steeper cutoff than an FIR filter of
+  equivalent order.
+* IIR filters are generally less numerically stable, in part due to
+  accumulating error (due to recursive calculations).
 
 In MNE-Python we default to using FIR filtering. As noted in Widmann *et al.*
 (2015) :footcite:`WidmannEtAl2015`:
@@ -124,7 +130,7 @@ FIR Filters
 
 First, we will focus on FIR filters, which are the default filters used by
 MNE-Python.
-"""  # noqa
+"""
 
 # %%
 # Designing FIR filters
@@ -223,7 +229,7 @@ plot_filter(h, sfreq, freq, gain, 'Sinc (10.0 s)', compensate=True, **kwargs)
 #    :func:`scipy.signal.firwin`)
 # 3. Least squares design (:func:`scipy.signal.firls`)
 # 4. Frequency-domain design (construct filter in Fourier domain and use an
-#    :func:`IFFT <numpy.fft.ifft>` to invert it)  # noqa
+#    :func:`IFFT <numpy.fft.ifft>` to invert it)
 #
 # .. note:: Remez and least squares designs have advantages when there are
 #           "do not care" regions in our frequency response. However, we want
@@ -635,8 +641,11 @@ plt.show()
 # :footcite:`WidmannSchroger2012` that the problematic low-pass filters from
 # VanRullen (2011) :footcite:`VanRullen2011`:
 #
-# 1. Used a least-squares design (like :func:`scipy.signal.firls`) that included "do-not-care" transition regions, which can lead to uncontrolled behavior.  # noqa
-# 2. Had a filter length that was independent of the transition bandwidth, which can cause excessive ringing and signal distortion.  # noqa
+# 1. Used a least-squares design (like :func:`scipy.signal.firls`) that
+#    included "do-not-care" transition regions, which can lead to uncontrolled
+#    behavior.
+# 2. Had a filter length that was independent of the transition bandwidth,
+#    which can cause excessive ringing and signal distortion.
 #
 # .. _tut-filtering-hp-problems:
 #
@@ -803,8 +812,10 @@ baseline_plot(x)
 # perhaps even the application of baseline correction, depend on the
 # characteristics of the data being investigated, especially when it comes to:
 #
-# 1. The frequency content of the underlying evoked activity relative to the filtering parameters.  # noqa
-# 2. The validity of the assumption of no consistent evoked activity in the baseline period.  # noqa
+# 1. The frequency content of the underlying evoked activity relative to the
+#    filtering parameters.
+# 2. The validity of the assumption of no consistent evoked activity in the
+#    baseline period.
 #
 # We thus recommend carefully applying baseline correction and/or high-pass
 # values based on the characteristics of the data to be analyzed.

--- a/tutorials/preprocessing/25_background_filtering.py
+++ b/tutorials/preprocessing/25_background_filtering.py
@@ -72,10 +72,10 @@ coefficients :math:`a_k` can be used to obtain our output data
 
 In other words, the output at time :math:`n` is determined by a sum over
 
-1. the numerator coefficients :math:`b_k`, which get multiplied by
-    the previous input values :math:`x(n-k)`, and
-2. the denominator coefficients :math:`a_k`, which get multiplied by
-    the previous output values :math:`y(n-k)`.
+1. the numerator coefficients :math:`b_k`, which get multiplied by the previous
+input values :math:`x(n-k)`, and
+2. the denominator coefficients :math:`a_k`, which get multiplied by the
+previous output values :math:`y(n-k)`.
 
 Note that these summations correspond to (1) a weighted `moving average`_ and
 (2) an autoregression_.


### PR DESCRIPTION
There is an error in the transfer function equation (a 1 term is missing in the denominator). I suggest to remove the second version with sum signs altogether, because the first version contains all information and is just as easy to read.

<img width="510" alt="Screen Shot 2022-03-25 at 08 48 40" src="https://user-images.githubusercontent.com/4377312/160077601-b863b915-9d4c-4c6f-9fee-c9ad25459ed1.png">
