### PR TITLE
ENH: load icon

### DIFF
--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -1419,6 +1419,7 @@ class CoregistrationUI(HasTraits):
             desc="Load",
             func=self._set_subjects_dir,
             is_directory=True,
+            icon=True,
             tooltip="Load the path to the directory containing the "
                     "FreeSurfer subjects",
             layout=subjects_dir_layout,
@@ -1528,6 +1529,7 @@ class CoregistrationUI(HasTraits):
             name="info_file",
             desc="Load",
             func=self._set_info_file,
+            icon=True,
             tooltip="Load the FIFF file with digitization data for "
                     "coregistration",
             layout=info_file_layout,

--- a/mne/gui/tests/test_gui_api.py
+++ b/mne/gui/tests/test_gui_api.py
@@ -208,7 +208,6 @@ def test_gui_api(renderer_notebook, nbexec):
         name="default",
         window=None,
     )
-    renderer._tool_bar_load_icons()
 
     # button
     assert 'reset' not in renderer.actions

--- a/mne/icons/dark/actions/folder.svg
+++ b/mne/icons/dark/actions/folder.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="18px" viewBox="0 0 24 24" width="18px" fill="#FFFFFF"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M9.17 6l2 2H20v10H4V6h5.17M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"/></svg>

--- a/mne/icons/light/actions/folder.svg
+++ b/mne/icons/light/actions/folder.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="18px" viewBox="0 0 24 24" width="18px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M9.17 6l2 2H20v10H4V6h5.17M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"/></svg>

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1280,7 +1280,6 @@ class Brain(object):
         )
 
     def _configure_tool_bar(self):
-        self._renderer._tool_bar_load_icons()
         self._renderer._tool_bar_initialize(name="Toolbar")
         self._renderer._tool_bar_add_file_button(
             name="screenshot",

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -488,10 +488,6 @@ class _AbstractRenderer(ABC):
 
 class _AbstractToolBar(ABC):
     @abstractmethod
-    def _tool_bar_load_icons(self):
-        pass
-
-    @abstractmethod
     def _tool_bar_initialize(self, name="default", window=None):
         pass
 
@@ -555,7 +551,8 @@ class _AbstractDock(ABC):
 
     @abstractmethod
     def _dock_add_button(
-        self, name, callback, *, style='pushbutton', tooltip=None, layout=None
+        self, name, callback, *, style='pushbutton', icon=None, tooltip=None,
+        layout=None
     ):
         pass
 
@@ -602,7 +599,7 @@ class _AbstractDock(ABC):
     @abstractmethod
     def _dock_add_file_button(
         self, name, desc, func, *, filter=None, initial_directory=None,
-        save=False, is_directory=False, tooltip=None, layout=None
+        save=False, is_directory=False, icon=False, tooltip=None, layout=None
     ):
         pass
 
@@ -863,12 +860,17 @@ class _AbstractBrainMplCanvas(_AbstractMplCanvas):
 
 class _AbstractWindow(ABC):
     def _window_initialize(self):
+        self._icons = dict()
         self._window = None
         self._interactor = None
         self._mplcanvas = None
         self._show_traces = None
         self._separate_canvas = None
         self._interactor_fraction = None
+
+    @abstractmethod
+    def _window_load_icons(self):
+        pass
 
     @abstractmethod
     def _window_close_connect(self, func, *, after=True):

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -225,14 +225,20 @@ class _IpyDock(_AbstractDock, _IpyLayout):
         self._layout_add_widget(layout, widget)
         return _IpyWidget(widget)
 
-    def _dock_add_button(self, name, callback, *, style=None, tooltip=None,
-                         layout=None):
+    def _dock_add_button(
+        self, name, callback, *, style='pushbutton', icon=None, tooltip=None,
+        layout=None
+    ):
         layout = self._dock_layout if layout is None else layout
-        kwargs = dict(description=name)
+        kwargs = dict()
+        if style == 'pushbutton':
+            kwargs["description"] = name
         if tooltip is not None:
             kwargs["tooltip"] = tooltip
         widget = Button(**kwargs)
         widget.on_click(lambda x: callback())
+        if icon is not None:
+            widget.icon = icon
         self._layout_add_widget(layout, widget)
         return _IpyWidget(widget)
 
@@ -345,7 +351,7 @@ class _IpyDock(_AbstractDock, _IpyLayout):
 
     def _dock_add_file_button(
         self, name, desc, func, *, filter=None, initial_directory=None,
-        save=False, is_directory=False, tooltip=None, layout=None
+        save=False, is_directory=False, icon=False, tooltip=None, layout=None
     ):
         layout = self._dock_layout if layout is None else layout
 
@@ -354,11 +360,16 @@ class _IpyDock(_AbstractDock, _IpyLayout):
             self._file_picker.connect(func)
             self._file_picker.show()
 
+        if icon:
+            kwargs = dict(style='toolbutton', icon='folder')
+        else:
+            kwargs = dict()
         widget = self._dock_add_button(
             name=desc,
             callback=callback,
             tooltip=tooltip,
             layout=layout,
+            **kwargs
         )
         return widget
 
@@ -371,20 +382,6 @@ def _generate_callback(callback, to_float=False):
 
 
 class _IpyToolBar(_AbstractToolBar, _IpyLayout):
-    def _tool_bar_load_icons(self):
-        self.icons = dict()
-        self.icons["help"] = "question"
-        self.icons["play"] = None
-        self.icons["pause"] = None
-        self.icons["reset"] = "history"
-        self.icons["scale"] = "magic"
-        self.icons["clear"] = "trash"
-        self.icons["movie"] = "video-camera"
-        self.icons["restore"] = "replay"
-        self.icons["screenshot"] = "camera"
-        self.icons["visibility_on"] = "eye"
-        self.icons["visibility_off"] = "eye"
-
     def _tool_bar_initialize(self, name="default", window=None):
         self.actions = dict()
         self._tool_bar = self._tool_bar_layout = HBox()
@@ -393,7 +390,7 @@ class _IpyToolBar(_AbstractToolBar, _IpyLayout):
     def _tool_bar_add_button(self, name, desc, func, *, icon_name=None,
                              shortcut=None):
         icon_name = name if icon_name is None else icon_name
-        icon = self.icons[icon_name]
+        icon = self._icons[icon_name]
         if icon is None:
             return
         widget = Button(tooltip=desc, icon=icon)
@@ -402,7 +399,7 @@ class _IpyToolBar(_AbstractToolBar, _IpyLayout):
         self.actions[name] = widget
 
     def _tool_bar_update_button_icon(self, name, icon_name):
-        self.actions[name].icon = self.icons[icon_name]
+        self.actions[name].icon = self._icons[icon_name]
 
     def _tool_bar_add_text(self, name, value, placeholder):
         widget = Text(value=value, placeholder=placeholder)
@@ -520,6 +517,25 @@ class _IpyBrainMplCanvas(_AbstractBrainMplCanvas, _IpyMplInterface):
 
 
 class _IpyWindow(_AbstractWindow):
+    def _window_initialize(self):
+        super()._window_initialize()
+        self._window_load_icons()
+
+    def _window_load_icons(self):
+        # from: https://fontawesome.com/icons
+        self._icons["help"] = "question"
+        self._icons["play"] = None
+        self._icons["pause"] = None
+        self._icons["reset"] = "history"
+        self._icons["scale"] = "magic"
+        self._icons["clear"] = "trash"
+        self._icons["movie"] = "video-camera"
+        self._icons["restore"] = "replay"
+        self._icons["screenshot"] = "camera"
+        self._icons["visibility_on"] = "eye"
+        self._icons["visibility_off"] = "eye"
+        self._icons["folder"] = "folder"
+
     def _window_close_connect(self, func, *, after=True):
         pass
 
@@ -657,13 +673,13 @@ class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
         self._file_picker = _FilePicker(rows=10)
         kwargs["notebook"] = True
         super().__init__(*args, **kwargs)
+        self._window_initialize()
 
     def _update(self):
         if self.figure.display is not None:
             self.figure.display.update_canvas()
 
     def _display_default_tool_bar(self):
-        self._tool_bar_load_icons()
         self._tool_bar_initialize()
         self._tool_bar_add_file_button(
             name="screenshot",

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -137,7 +137,8 @@ class _QtDock(_AbstractDock, _QtLayout):
         return _QtWidget(widget)
 
     def _dock_add_button(
-        self, name, callback, *, style='pushbutton', tooltip=None, layout=None
+        self, name, callback, *, style='pushbutton', icon=None, tooltip=None,
+        layout=None
     ):
         _check_option(
             parameter='style',
@@ -153,6 +154,8 @@ class _QtDock(_AbstractDock, _QtLayout):
             widget.setStyleSheet(
                 'QPushButton:pressed {color: none;}'
             )
+        if icon is not None:
+            widget.setIcon(self._icons[icon])
 
         _set_widget_tooltip(widget, tooltip)
         widget.clicked.connect(callback)
@@ -271,7 +274,7 @@ class _QtDock(_AbstractDock, _QtLayout):
 
     def _dock_add_file_button(
         self, name, desc, func, *, filter=None, initial_directory=None,
-        save=False, is_directory=False, tooltip=None, layout=None
+        save=False, is_directory=False, icon=False, tooltip=None, layout=None
     ):
         layout = self._dock_layout if layout is None else layout
 
@@ -296,11 +299,16 @@ class _QtDock(_AbstractDock, _QtLayout):
                 return
             func(name)
 
+        if icon:
+            kwargs = dict(style='toolbutton', icon='folder')
+        else:
+            kwargs = dict()
         button_widget = self._dock_add_button(
             name=desc,
             callback=callback,
             tooltip=tooltip,
             layout=layout,
+            **kwargs
         )
         return button_widget  # It's already a _QtWidget instance
 
@@ -379,20 +387,6 @@ class QFloatSlider(QSlider):
 
 
 class _QtToolBar(_AbstractToolBar, _QtLayout):
-    def _tool_bar_load_icons(self):
-        self.icons = dict()
-        self.icons["help"] = QIcon.fromTheme("help")
-        self.icons["play"] = QIcon.fromTheme("play")
-        self.icons["pause"] = QIcon.fromTheme("pause")
-        self.icons["reset"] = QIcon.fromTheme("reset")
-        self.icons["scale"] = QIcon.fromTheme("scale")
-        self.icons["clear"] = QIcon.fromTheme("clear")
-        self.icons["movie"] = QIcon.fromTheme("movie")
-        self.icons["restore"] = QIcon.fromTheme("restore")
-        self.icons["screenshot"] = QIcon.fromTheme("screenshot")
-        self.icons["visibility_on"] = QIcon.fromTheme("visibility_on")
-        self.icons["visibility_off"] = QIcon.fromTheme("visibility_off")
-
     def _tool_bar_initialize(self, name="default", window=None):
         self.actions = dict()
         window = self._window if window is None else window
@@ -402,13 +396,13 @@ class _QtToolBar(_AbstractToolBar, _QtLayout):
     def _tool_bar_add_button(self, name, desc, func, *, icon_name=None,
                              shortcut=None):
         icon_name = name if icon_name is None else icon_name
-        icon = self.icons[icon_name]
+        icon = self._icons[icon_name]
         self.actions[name] = self._tool_bar.addAction(icon, desc, func)
         if shortcut is not None:
             self.actions[name].setShortcut(shortcut)
 
     def _tool_bar_update_button_icon(self, name, icon_name):
-        self.actions[name].setIcon(self.icons[icon_name])
+        self.actions[name].setIcon(self._icons[icon_name])
 
     def _tool_bar_add_text(self, name, value, placeholder):
         pass
@@ -516,6 +510,7 @@ class _QtWindow(_AbstractWindow):
         super()._window_initialize()
         self._interactor = self.figure.plotter.interactor
         self._window = self.figure.plotter.app_window
+        self._window_load_icons()
         self._window_set_theme()
         self._window.setLocale(QLocale(QLocale.Language.English))
         self._window.signal_close.connect(self._window_clean)
@@ -542,6 +537,20 @@ class _QtWindow(_AbstractWindow):
             for callback in self._window_after_close_callbacks:
                 callback()
         self._window.closeEvent = closeEvent
+
+    def _window_load_icons(self):
+        self._icons["help"] = QIcon.fromTheme("help")
+        self._icons["play"] = QIcon.fromTheme("play")
+        self._icons["pause"] = QIcon.fromTheme("pause")
+        self._icons["reset"] = QIcon.fromTheme("reset")
+        self._icons["scale"] = QIcon.fromTheme("scale")
+        self._icons["clear"] = QIcon.fromTheme("clear")
+        self._icons["movie"] = QIcon.fromTheme("movie")
+        self._icons["restore"] = QIcon.fromTheme("restore")
+        self._icons["screenshot"] = QIcon.fromTheme("screenshot")
+        self._icons["visibility_on"] = QIcon.fromTheme("visibility_on")
+        self._icons["visibility_off"] = QIcon.fromTheme("visibility_off")
+        self._icons["folder"] = QIcon.fromTheme("folder")
 
     def _window_clean(self):
         self.figure._plotter = None


### PR DESCRIPTION
This PR refactors icon loading in the GUI API and replaces the "Load" buttons by a :file_folder:  icon in the coreg app.

light theme | dark theme
--|--
![image](https://user-images.githubusercontent.com/18143289/160094033-e37b324c-42f6-485a-a822-f31234110cd7.png)| ![image](https://user-images.githubusercontent.com/18143289/160094095-85b5f8fe-a192-474a-9137-6f2a3692ff94.png)

It makes for a subtle change:

backend\branch | main | PR
--|--|--
notebook | ![image](https://user-images.githubusercontent.com/18143289/160094745-8b6d96f5-ed87-4cc0-98e9-a83db2f71caf.png) | ![image](https://user-images.githubusercontent.com/18143289/160093472-e594968f-121d-42e1-bd03-d8c1aafeaed3.png)
qt | ![image](https://user-images.githubusercontent.com/18143289/160094601-cf4e22c8-a3a5-473d-94c5-1e9e788efae9.png) | ![image](https://user-images.githubusercontent.com/18143289/160093603-64498072-2b90-49ec-a009-8660a81cbbf7.png)

This PR cannot be merged before https://github.com/mne-tools/mne-python/pull/10456
It's an item of #8833