### PR TITLE
[minor] Update docs of montage.plot(show_names)

### DIFF
--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -18,8 +18,8 @@ def plot_montage(montage, scale_factor=20, show_names=True, kind='topomap',
     scale_factor : float
         Determines the size of the points.
     show_names : bool | list
-        Whether to display all channel names. If an array, only the channel
-        names in the array are shown. Defaults to True.
+        Whether to display all channel names. If a list, only the channel
+        names in the list are shown. Defaults to True.
     kind : str
         Whether to plot the montage as '3d' or 'topomap' (default).
     show : bool

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -18,7 +18,8 @@ def plot_montage(montage, scale_factor=20, show_names=True, kind='topomap',
     scale_factor : float
         Determines the size of the points.
     show_names : bool | list
-        Whether to display all channel names. If an array, only the channel names in the array are shown. Defaults to True.
+        Whether to display all channel names. If an array, only the channel 
+        names in the array are shown. Defaults to True.
     kind : str
         Whether to plot the montage as '3d' or 'topomap' (default).
     show : bool

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -18,7 +18,7 @@ def plot_montage(montage, scale_factor=20, show_names=True, kind='topomap',
     scale_factor : float
         Determines the size of the points.
     show_names : bool | list
-        Whether to display all channel names. If an array, only the channel 
+        Whether to display all channel names. If an array, only the channel
         names in the array are shown. Defaults to True.
     kind : str
         Whether to plot the montage as '3d' or 'topomap' (default).

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -17,8 +17,8 @@ def plot_montage(montage, scale_factor=20, show_names=True, kind='topomap',
         The montage to visualize.
     scale_factor : float
         Determines the size of the points.
-    show_names : bool
-        Whether to show the channel names.
+    show_names : bool | list
+        Whether to display all channel names. If an array, only the channel names in the array are shown. Defaults to True.
     kind : str
         Whether to plot the montage as '3d' or 'topomap' (default).
     show : bool


### PR DESCRIPTION
When playing around with `raw.plot_sensors` and `montage.plot` I figured that the docstrings are not accurate.

`raw.plot_sensors()` takes either a bool or a list of channel names, this is also possible in `montage.plot()`

I thought this should also be reflected in the docstring