### PR TITLE
FIX: broken link

### DIFF
--- a/tutorials/preprocessing/25_background_filtering.py
+++ b/tutorials/preprocessing/25_background_filtering.py
@@ -1059,4 +1059,4 @@ filter_length = fir_coefs.shape[0]
 # .. _matlab firls: https://www.mathworks.com/help/signal/ref/firls.html
 # .. _Butterworth filter: https://en.wikipedia.org/wiki/Butterworth_filter
 # .. _eeglab filtering faq: https://sccn.ucsd.edu/wiki/Firfilt_FAQ
-# .. _ftbp: https://www.fieldtriptoolbox.org/reference/preproc/ft_preproc_bandpassfilter
+# .. _ftbp: https://www.fieldtriptoolbox.org/reference/preproc/ft_preproc_bandpassfilter  # noqa

--- a/tutorials/preprocessing/25_background_filtering.py
+++ b/tutorials/preprocessing/25_background_filtering.py
@@ -1059,4 +1059,4 @@ filter_length = fir_coefs.shape[0]
 # .. _matlab firls: https://www.mathworks.com/help/signal/ref/firls.html
 # .. _Butterworth filter: https://en.wikipedia.org/wiki/Butterworth_filter
 # .. _eeglab filtering faq: https://sccn.ucsd.edu/wiki/Firfilt_FAQ
-# .. _ftbp: http://www.fieldtriptoolbox.org/reference/ft_preproc_bandpassfilter
+# .. _ftbp: https://www.fieldtriptoolbox.org/reference/preproc/ft_preproc_bandpassfilter


### PR DESCRIPTION
This very PR fixes:

```
[broken] http://www.fieldtriptoolbox.org/reference/ft_preproc_bandpassfilter: 404 Client Error: Not Found for url: https://github.com/fieldtrip/fieldtrip/blob/release/ft_preproc_bandpassfilter.m
```

The line with the updated URL is  > 80 characters (88), is that okay?