### PR TITLE
MRG: Fix command for headless installation

### DIFF
--- a/doc/install/advanced.rst
+++ b/doc/install/advanced.rst
@@ -91,7 +91,7 @@ Download the `server environment file`_ and use it to create the conda
 environment::
 
     curl --remote-name https://raw.githubusercontent.com/mne-tools/mne-python/main/server_environment.yml
-    conda create --name=mne --file=server_environment.yml
+    conda env create -f server_environment.yml
 
 Using the development version
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -273,4 +273,3 @@ line for ``pip uninstall -y vtk``.
 .. _`pyvista`: https://docs.pyvista.org/
 .. _`X server`: https://en.wikipedia.org/wiki/X_Window_System
 .. _`xvfb`: https://en.wikipedia.org/wiki/Xvfb
-


### PR DESCRIPTION
The command `conda create --name=mne --file=server_environment.yml` does not work, as pointed out here: https://github.com/conda/conda/issues/6827#issuecomment-365614464
I am not a conda user, so I might be mistaken, but I think I've changed it correctly.
