### PR TITLE
Improve ERP tutorial

### DIFF
--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -2,9 +2,9 @@
 """
 .. _tut-erp:
 
-===============================
-Event Related Potentials (ERPs)
-===============================
+==============================================
+EEG analysis - Event-Related Potentials (ERPs)
+==============================================
 
 This tutorial shows how to perform standard ERP analyses in MNE-Python. Most of
 the material here is covered in other tutorials too, but for convenience the
@@ -76,9 +76,9 @@ channel_renaming_dict = {name: name.replace(' 0', '').lower()
                          for name in raw.ch_names}
 _ = raw.rename_channels(channel_renaming_dict)  # happens in-place
 
-# The assignment to a temporary name ``_`` (the ``_ = `` part) is included here
-# to suppress automatic printing of the ``raw`` object. You do not have to do
-# this in your interactive analysis.
+# .. note:: The assignment to a temporary name ``_`` (the ``_ = `` part) is
+#           included here to suppress automatic printing of the ``raw`` object.
+#           You do not have to do this in your interactive analysis.
 
 # %%
 # Channel locations
@@ -295,8 +295,8 @@ ax.fill_between(l_aud.times, gfp * 1e6, color='lime', alpha=0.2)
 ax.set(xlabel='Time (s)', ylabel='GFP (µV)', title='EEG')
 
 # %%
-# Analyzing regions of interest
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# Averaging across channels with regions of interest (ROIs)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # Since our sample data contains responses to left and right auditory and
 # visual stimuli, we may want to compare left versus right regions of interest

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -24,7 +24,6 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import mne
-from mne.viz.utils import tight_layout
 
 root = mne.datasets.sample.data_path() / 'MEG' / 'sample'
 raw_file = root / 'sample_audvis_filt-0-40_raw.fif'
@@ -539,7 +538,7 @@ print_peak_measures(ch_roi, bad_tmin, bad_tmax, bad_lat_roi, bad_amp_roi)
 # maximum or minimum in the searched time window. Visual inspection will always
 # help you to convince yourself that the returned values are actual peaks.
 
-fig, axs = plt.subplots(nrows=2, ncols=1)
+fig, axs = plt.subplots(nrows=2, ncols=1, layout='tight')
 words = (('Bad', 'missing'), ('Good', 'finding'))
 times = (np.array([bad_tmin, bad_tmax]), np.array([good_tmin, good_tmax]))
 colors = ('C1', 'C0')
@@ -550,7 +549,6 @@ for ix, ax in enumerate(axs):
     ax.plot(lat_roi * 1e3, amp_roi * 1e6, marker='*', color='C6')
     ax.axvspan(*(times[ix] * 1e3), facecolor=colors[ix], alpha=0.3)
     ax.set_xlim(-50, 150)  # Show zoomed in around peak
-tight_layout(fig=fig)
 
 # %%
 # Mean Amplitude

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -2,9 +2,9 @@
 """
 .. _tut-erp:
 
-==================================================
-EEG processing and Event Related Potentials (ERPs)
-==================================================
+===============================
+Event Related Potentials (ERPs)
+===============================
 
 This tutorial shows how to perform standard ERP analyses in MNE-Python. Most of
 the material here is covered in other tutorials too, but for convenience the
@@ -25,6 +25,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import mne
+from mne.viz.utils import tight_layout
 
 sample_data_folder = mne.datasets.sample.data_path()
 sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
@@ -73,7 +74,11 @@ raw.info
 
 channel_renaming_dict = {name: name.replace(' 0', '').lower()
                          for name in raw.ch_names}
-raw.rename_channels(channel_renaming_dict)  # happens in-place
+_ = raw.rename_channels(channel_renaming_dict)  # happens in-place
+
+# The assignment to a temporary name ``_`` (the ``_ = `` part) is included here
+# to suppress automatic printing of the ``raw`` object. You do not have to do
+# this in your interactive analysis.
 
 # %%
 # Channel locations
@@ -141,7 +146,7 @@ for proj in (False, True):
 # data, see :ref:`tut-filter-resample`. Here, we'll apply a simple high-pass
 # filter for illustration:
 
-raw.filter(l_freq=0.1, h_freq=None)
+_ = raw.filter(l_freq=0.1, h_freq=None)
 
 # %%
 # Evoked responses: epoching and averaging
@@ -290,8 +295,8 @@ ax.fill_between(l_aud.times, gfp * 1e6, color='lime', alpha=0.2)
 ax.set(xlabel='Time (s)', ylabel='GFP (µV)', title='EEG')
 
 # %%
-# Analyzing regions of interest (averaging across channels)
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# Analyzing regions of interest
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # Since our sample data contains responses to left and right auditory and
 # visual stimuli, we may want to compare left versus right regions of interest
@@ -541,6 +546,7 @@ for ix, ax in enumerate(axs):
     ax.plot(lat_roi * 1e3, amp_roi * 1e6, marker='*', color='C6')
     ax.axvspan(*(times[ix] * 1e3), facecolor=colors[ix], alpha=0.3)
     ax.set_xlim(-50, 150)  # Show zoomed in around peak
+tight_layout(fig)
 
 # %%
 # Mean Amplitude

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -26,8 +26,6 @@ import matplotlib.pyplot as plt
 import mne
 from mne.viz.utils import tight_layout
 
-mne.viz.set_browser_backend('matplotlib')  # nicer static plots for the docs
-
 root = mne.datasets.sample.data_path() / 'MEG' / 'sample'
 raw_file = root / 'sample_audvis_filt-0-40_raw.fif'
 raw = mne.io.read_raw_fif(raw_file, preload=False)
@@ -125,8 +123,9 @@ fig = raw.plot_sensors('3d')
 # raw data by plotting it with and without the projector applied:
 
 for proj in (False, True):
-    fig = raw.plot(n_channels=5, proj=proj, scalings=dict(eeg=50e-6),
-                   show_scrollbars=False)
+    with mne.viz.set_browser_backend('matplotlib'):
+        fig = raw.plot(n_channels=5, proj=proj, scalings=dict(eeg=50e-6),
+                       show_scrollbars=False)
     fig.subplots_adjust(top=0.9)  # make room for title
     ref = 'Average' if proj else 'No'
     fig.suptitle(f'{ref} reference', size='xx-large', weight='bold')

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -146,7 +146,7 @@ for proj in (False, True):
 # data, see :ref:`tut-filter-resample`. Here, we'll apply a simple high-pass
 # filter for illustration:
 
-_ = raw.filter(l_freq=0.1, h_freq=None)
+raw.filter(l_freq=0.1, h_freq=None)
 
 # %%
 # Evoked responses: epoching and averaging

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -14,9 +14,8 @@ links to other tutorials where more detailed information is given.
 As usual we'll start by importing the modules we need and loading some example
 data. Instead of parsing the events from the raw data's :term:`stim channel`
 (like we do in :ref:`this tutorial <tut-events-vs-annotations>`), we'll load
-the events from an external events file. Finally, to speed up computations so
-our documentation server can handle them, we'll crop the raw data from ~4.5
-minutes down to 90 seconds.
+the events from an external events file. Finally, to speed up computations
+we'll crop the raw data from ~4.5 minutes down to 90 seconds.
 """
 
 # %%
@@ -48,7 +47,7 @@ events = events[events[:, 0] <= raw.last_samp]
 # :ref:`tut-set-eeg-ref` tutorial for more info about when you may want to do
 # this). We'll discuss how to do each of these below.
 #
-# Since this is a combined EEG+MEG dataset, let's start by restricting the data
+# Since this is a combined EEG/MEG dataset, let's start by restricting the data
 # to just the EEG and EOG channels. This will cause the other projectors saved
 # in the file (which apply only to magnetometer channels) to be removed. By
 # looking at the measurement info we can see that we now have 59 EEG channels
@@ -61,33 +60,34 @@ raw.info
 # Channel names and types
 # ^^^^^^^^^^^^^^^^^^^^^^^
 #
-# In practice it's quite common to have some channels labelled as EEG that are
+# In practice it is quite common to have some channels labeled as EEG that are
 # actually EOG channels. `~mne.io.Raw` objects have a
-# `~mne.io.Raw.set_channel_types` method that you can use to change a channel
-# that is labeled as ``eeg`` into an ``eog`` type. You can also rename channels
+# `~mne.io.Raw.set_channel_types` method that can be used to change a channel
+# that is mislabeled as ``eeg`` to ``eog``. You can also rename channels
 # using the `~mne.io.Raw.rename_channels` method. Detailed examples of both of
-# these methods can be found in the tutorial :ref:`tut-raw-class`. In this data
-# the channel types are all correct already, so for now we'll just rename the
-# channels to remove a space and a leading zero in the channel names, and
-# convert to lowercase:
+# these methods can be found in the tutorial :ref:`tut-raw-class`.
+#
+# In our data set, all channel types are already correct. Therefore, we'll only
+# remove a space and a leading zero in the channel names and convert to
+# lowercase:
 
 channel_renaming_dict = {name: name.replace(' 0', '').lower()
                          for name in raw.ch_names}
-_ = raw.rename_channels(channel_renaming_dict)  # happens in-place
+raw.rename_channels(channel_renaming_dict)  # happens in-place
 
 # %%
 # Channel locations
 # ^^^^^^^^^^^^^^^^^
 #
-# The tutorial :ref:`tut-sensor-locations` describes MNE-Python's handling of
-# sensor positions in great detail. To briefly summarize: MNE-Python
-# distinguishes :term:`montages <montage>` (which contain sensor positions in
-# 3D: ``x``, ``y``, ``z``, in meters) from :term:`layouts <layout>` (which
-# define 2D arrangements of sensors for plotting approximate overhead diagrams
-# of sensor positions). Additionally, montages may specify *idealized* sensor
-# positions (based on, e.g., an idealized spherical headshape model) or they
-# may contain *realistic* sensor positions obtained by digitizing the 3D
-# locations of the sensors when placed on the actual subject's head.
+# The tutorial :ref:`tut-sensor-locations` describes how sensor locations are
+# handled in great detail. To briefly summarize: MNE-Python distinguishes
+# :term:`montages <montage>` (which contain 3D sensor locations ``x``, ``y``,
+# and ``z``, in meters) from :term:`layouts <layout>` (which define 2D sensor
+# arrangements for plotting schematic sensor location diagrams). Additionally,
+# montages may specify *idealized* sensor locations (based on, e.g., an
+# idealized spherical head model), or they may contain *realistic* sensor
+# locations obtained by digitizing the 3D locations of the sensors when placed
+# on a real person's head.
 #
 # This dataset has realistic digitized 3D sensor locations saved as part of the
 # ``.fif`` file, so we can view the sensor locations in 2D or 3D using the
@@ -97,25 +97,25 @@ raw.plot_sensors(show_names=True)
 fig = raw.plot_sensors('3d')
 
 # %%
-# If you're working with a standard montage like the `10-20 <ten_twenty_>`_
-# system, you can add sensor locations to the data like this:
-# ``raw.set_montage('standard_1020')``.  See :ref:`tut-sensor-locations` for
-# info on what other standard montages are built-in to MNE-Python.
+# If you're working with a standard montage like the `10–20 <ten_twenty_>`_
+# system, you can add sensor locations to the data with
+# ``raw.set_montage('standard_1020')`` (see :ref:`tut-sensor-locations` for
+# information on other standard montages included with MNE-Python).
 #
 # If you have digitized realistic sensor locations, there are dedicated
-# functions for loading those digitization files into MNE-Python; see
+# functions for loading those digitization files into MNE-Python (see
 # :ref:`reading-dig-montages` for discussion and :ref:`dig-formats` for a list
-# of supported formats. Once loaded, the digitized sensor locations can be
+# of supported formats). Once loaded, the digitized sensor locations can be
 # added to the data by passing the loaded montage object to
-# ``raw.set_montage()``.
+# `~mne.io.Raw.set_montage`.
 #
 #
 # Setting the EEG reference
 # ^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# As mentioned above, this data already has an EEG common average reference
-# added as a :term:`projector`. We can view the effect of this on the raw data
-# by plotting with and without the projector applied:
+# As mentioned, this data already has an EEG common average reference
+# added as a :term:`projector`. We can view the effect of this projector on the
+# raw data by plotting it with and without the projector applied:
 
 for proj in (False, True):
     with mne.viz.use_browser_backend('matplotlib'):
@@ -129,7 +129,7 @@ for proj in (False, True):
 # `mne.set_eeg_reference` (which by default operates on a *copy* of the data)
 # or the `raw.set_eeg_reference() <mne.io.Raw.set_eeg_reference>` method (which
 # always modifies the data in-place). The tutorial :ref:`tut-set-eeg-ref` shows
-# several examples of this.
+# several examples.
 #
 #
 # Filtering
@@ -150,8 +150,9 @@ raw.filter(l_freq=0.1, h_freq=None)
 # The general process for extracting evoked responses from continuous data is
 # to use the `~mne.Epochs` constructor, and then average the resulting epochs
 # to create an `~mne.Evoked` object. In MNE-Python, events are represented as
-# a :class:`NumPy array <numpy.ndarray>` of sample numbers and integer event
-# codes. The event codes are stored in the last column of the events array:
+# a :class:`NumPy array <numpy.ndarray>` containing event latencies (in
+# samples) and integer event codes. The event codes are stored in the last
+# column of the events array:
 
 np.unique(events[:, -1])
 
@@ -159,17 +160,17 @@ np.unique(events[:, -1])
 # The :ref:`tut-event-arrays` tutorial discusses event arrays in more detail.
 # Integer event codes are mapped to more descriptive text using a Python
 # :class:`dictionary <dict>` usually called ``event_id``. This mapping is
-# determined by your experiment code (i.e., it reflects which event codes you
-# chose to use to represent different experimental events or conditions). For
-# the :ref:`sample-dataset` data has the following mapping:
+# determined by your experiment (i.e., it reflects which event codes you chose
+# to represent different experimental events or conditions). The
+# :ref:`sample-dataset` data uses the following mapping:
 
 event_dict = {'auditory/left': 1, 'auditory/right': 2, 'visual/left': 3,
               'visual/right': 4, 'face': 5, 'buttonpress': 32}
 
 # %%
-# Now we can extract epochs from the continuous data. An interactive plot
-# allows you to click on epochs to mark them as "bad" and drop them from the
-# analysis (it is not interactive on the documentation website, but will be
+# Now we can proceed to epoch the continuous data. An interactive plot allows
+# us to click on epochs to mark them as "bad" and drop them from the
+# analysis (it is not interactive on this documentation website, but will be
 # when you run `epochs.plot() <mne.Epochs.plot>` in a Python console).
 
 epochs = mne.Epochs(raw, events, event_id=event_dict, tmin=-0.3, tmax=0.7,
@@ -177,63 +178,62 @@ epochs = mne.Epochs(raw, events, event_id=event_dict, tmin=-0.3, tmax=0.7,
 fig = epochs.plot(events=events)
 
 # %%
-# It is also possible to automatically drop epochs, when first creating them or
-# later on, by providing maximum peak-to-peak signal value thresholds (pass to
-# the `~mne.Epochs` constructor as the ``reject`` parameter; see
+# It is also possible to automatically drop epochs (either when first creating
+# them or later on) by providing maximum peak-to-peak signal value thresholds
+# (passed to `~mne.Epochs` as the ``reject`` parameter; see
 # :ref:`tut-reject-epochs-section` for details).  You can also do this after
 # the epochs are already created, using the `~mne.Epochs.drop_bad` method:
 
-reject_criteria = dict(eeg=100e-6,  # 100 µV
-                       eog=200e-6)  # 200 µV
-_ = epochs.drop_bad(reject=reject_criteria)
+reject_criteria = dict(eeg=100e-6, eog=200e-6)  # 100 µV, 200 µV
+epochs.drop_bad(reject=reject_criteria)
 
 # %%
-# Next we generate a barplot of which channels contributed most to epochs
-# getting rejected. If one channel is responsible for lots of epoch rejections,
+# Next, we generate a barplot of which channels contributed most to epochs
+# getting rejected. If one channel is responsible for many epoch rejections,
 # it may be worthwhile to mark that channel as "bad" in the `~mne.io.Raw`
-# object and then re-run epoching (fewer channels w/ more good epochs may be
+# object and then re-run epoching (fewer channels with more good epochs may be
 # preferable to keeping all channels but losing many epochs). See
-# :ref:`tut-bad-channels` for more info.
+# :ref:`tut-bad-channels` for more information.
 
 epochs.plot_drop_log()
 
 # %%
-# Another way in which epochs can be automatically dropped is if the event
-# around which the epoch is formed is too close to the start or end of the
-# `~mne.io.Raw` object (e.g., if the epoch's ``tmax`` would be past the end of
-# the file; this is the cause of the "TOO_SHORT" entry in the
-# `~mne.Epochs.plot_drop_log` plot above). Epochs may also be automatically
-# dropped if the `~mne.io.Raw` object contains :term:`annotations` that begin
-# with either ``bad`` or ``edge`` ("edge" annotations are automatically
-# inserted when concatenating two separate `~mne.io.Raw` objects together). See
-# :ref:`tut-reject-data-spans` for more information about annotation-based
-# epoch rejection.
+# Epochs can also be dropped automatically if the event around which the epoch
+# is created is too close to the start or end of the `~mne.io.Raw` object
+# (e.g., if the epoch would extend past the end of the recording; this is the
+# cause for the "TOO_SHORT" entry in the `~mne.Epochs.plot_drop_log` plot).
 #
-# Now that we've dropped the bad epochs, let's look at our evoked responses for
-# some conditions we care about. Here the `~mne.Epochs.average` method will
-# create an `~mne.Evoked` object, which we can then plot. Notice that we
-# select which condition we want to average using the square-bracket indexing
-# (like a :class:`dictionary <dict>`); that returns a smaller epochs object
-# containing just the epochs from that condition, to which we then apply the
-# `~mne.Epochs.average` method:
+# Epochs may also be dropped automatically if the `~mne.io.Raw` object contains
+# :term:`annotations` that begin with either ``bad`` or ``edge`` ("edge"
+# annotations are automatically inserted when concatenating two or more
+# `~mne.io.Raw` objects). See :ref:`tut-reject-data-spans` for more information
+# on annotation-based epoch rejection.
+#
+# Now that we've dropped all bad epochs, let's look at our evoked responses for
+# some conditions we care about. Here, the `~mne.Epochs.average` method will
+# create an `~mne.Evoked` object, which we can then plot. Notice that we select
+# which condition we want to average using square-bracket indexing (like for a
+# :class:`dictionary <dict>`). This returns a subset with only the desired
+# epochs, which we then average:
 
 l_aud = epochs['auditory/left'].average()
 l_vis = epochs['visual/left'].average()
 
 # %%
 # These `~mne.Evoked` objects have their own interactive plotting method
-# (though again, it won't be interactive on the documentation website):
-# click-dragging a span of time will generate a scalp field topography for that
-# time span. Here we also demonstrate built-in color-coding the channel traces
-# by location:
+# (though again, it won't be interactive on the documentation website).
+# Clicking and dragging a span of time will generate a topography of scalp
+# potentials for the selected time segment. Here, we also demonstrate built-in
+# color-coding the channel traces by location:
 
 fig1 = l_aud.plot()
 fig2 = l_vis.plot(spatial_colors=True)
 
 # %%
 # Scalp topographies can also be obtained non-interactively with the
-# `~mne.Evoked.plot_topomap` method. Here we display topomaps of the average
-# field in 50 ms time windows centered at -200 ms, 100 ms, and 400 ms.
+# `~mne.Evoked.plot_topomap` method. Here, we display topomaps of the average
+# evoked potential in 50 ms time windows centered at -200 ms, 100 ms, and
+# 400 ms.
 
 l_aud.plot_topomap(times=[-0.2, 0.1, 0.4], average=0.05)
 
@@ -242,9 +242,9 @@ l_aud.plot_topomap(times=[-0.2, 0.1, 0.4], average=0.05)
 # `~mne.Evoked.plot_topomap` for details.
 #
 # There is also a built-in method for combining "butterfly" plots of the
-# signals with scalp topographies, called `~mne.Evoked.plot_joint`. Like
-# `~mne.Evoked.plot_topomap` you can specify times for the scalp topographies
-# or you can let the method choose times automatically, as is done here:
+# signals with scalp topographies, called `~mne.Evoked.plot_joint`. Like in
+# `~mne.Evoked.plot_topomap`, you can specify times for the scalp topographies
+# or you can let the method choose times automatically as shown here:
 
 l_aud.plot_joint()
 
@@ -255,7 +255,7 @@ l_aud.plot_joint()
 # Global field power :footcite:`Lehmann1980,Lehmann1984,Murray2008` is,
 # generally speaking, a measure of agreement of the signals picked up by all
 # sensors across the entire scalp: if all sensors have the same value at a
-# given time point, the GFP will be zero at that time point; if the signals
+# given time point, the GFP will be zero at that time point. If the signals
 # differ, the GFP will be non-zero at that time point. GFP
 # peaks may reflect "interesting" brain activity, warranting further
 # investigation. Mathematically, the GFP is the population standard
@@ -270,16 +270,16 @@ for evk in (l_aud, l_vis):
     evk.plot(gfp=True, spatial_colors=True, ylim=dict(eeg=[-12, 12]))
 
 # %%
-# To plot the GFP by itself you can pass ``gfp='only'`` (this makes it easier
+# To plot the GFP by itself, you can pass ``gfp='only'`` (this makes it easier
 # to read off the GFP data values, because the scale is aligned):
 
 l_aud.plot(gfp='only')
 
 # %%
-# As stated above, the GFP is the population standard deviation of the signal
+# The GFP is the population standard deviation of the signal
 # across channels. To compute it manually, we can leverage the fact that
 # `evoked.data <mne.Evoked.data>` is a :class:`NumPy array <numpy.ndarray>`,
-# and verify by plotting it using matplotlib commands:
+# and verify by plotting it using plain Matplotlib commands:
 
 gfp = l_aud.data.std(axis=0, ddof=0)
 
@@ -290,14 +290,14 @@ ax.fill_between(l_aud.times, gfp * 1e6, color='lime', alpha=0.2)
 ax.set(xlabel='Time (s)', ylabel='GFP (µV)', title='EEG')
 
 # %%
-# Analyzing regions of interest (ROIs): averaging across channels
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# Analyzing regions of interest (averaging across channels)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# Since our sample data is responses to left and right auditory and visual
-# stimuli, we may want to compare left versus right ROIs. To average across
-# channels in a region of interest, we first find the channel indices we want.
-# Looking back at the 2D sensor plot above, we might choose the following for
-# left and right ROIs:
+# Since our sample data contains responses to left and right auditory and
+# visual stimuli, we may want to compare left versus right regions of interest
+# (ROIs). To average across channels in a given ROI, we first find the relevant
+# channel indices. Revisiting the 2D sensor plot above, we might choose the
+# following channels for left and right ROIs, respectively:
 
 left = ['eeg17', 'eeg18', 'eeg25', 'eeg26']
 right = ['eeg23', 'eeg24', 'eeg34', 'eeg35']
@@ -306,7 +306,8 @@ left_ix = mne.pick_channels(l_aud.info['ch_names'], include=left)
 right_ix = mne.pick_channels(l_aud.info['ch_names'], include=right)
 
 # %%
-# Now we can create a new Evoked with 2 virtual channels (one for each ROI):
+# Now we can create a new Evoked object with two virtual channels (one for each
+# ROI):
 roi_dict = dict(left_ROI=left_ix, right_ROI=right_ix)
 roi_evoked = mne.channels.combine_channels(l_aud, roi_dict, method='mean')
 print(roi_evoked.info['ch_names'])
@@ -316,9 +317,9 @@ roi_evoked.plot()
 # Comparing conditions
 # ^^^^^^^^^^^^^^^^^^^^
 #
-# If we wanted to compare our auditory and visual stimuli, a useful function is
-# `mne.viz.plot_compare_evokeds`. By default this will combine all channels in
-# each evoked object using global field power (or RMS for MEG channels); here
+# If we wanted to contrast auditory to visual stimuli, a useful function is
+# `mne.viz.plot_compare_evokeds`. By default, this function will combine all
+# channels in each evoked object using GFP (or RMS for MEG channels); here
 # instead we specify to combine by averaging, and restrict it to a subset of
 # channels by passing ``picks``:
 
@@ -327,9 +328,9 @@ picks = [f'eeg{n}' for n in range(10, 15)]
 mne.viz.plot_compare_evokeds(evokeds, picks=picks, combine='mean')
 
 # %%
-# We can also easily get confidence intervals by treating each epoch as a
+# We can also generate confidence intervals by treating each epoch as a
 # separate observation using the `~mne.Epochs.iter_evoked` method. A confidence
-# interval across subjects could also be obtained, by passing a list of
+# interval across subjects could also be obtained by passing a list of
 # `~mne.Evoked` objects (one per subject) to the
 # `~mne.viz.plot_compare_evokeds` function.
 
@@ -339,7 +340,7 @@ mne.viz.plot_compare_evokeds(evokeds, combine='mean', picks=picks)
 
 # %%
 # We can also compare conditions by subtracting one `~mne.Evoked` object from
-# another using the `mne.combine_evoked` function (this function also allows
+# another using the `mne.combine_evoked` function (this function also supports
 # pooling of epochs without subtraction).
 
 aud_minus_vis = mne.combine_evoked([l_aud, l_vis], weights=[1, -1])
@@ -349,9 +350,10 @@ aud_minus_vis.plot_joint()
 # .. warning::
 #
 #     The code above yields an **equal-weighted difference**. If you have
-#     imbalanced trial numbers, you might want to equalize the number of events
-#     per condition first by using `epochs.equalize_event_counts()
-#     <mne.Epochs.equalize_event_counts>` before averaging.
+#     different numbers of epochs per condition, you might want to equalize the
+#     number of events per condition first by using
+#     `epochs.equalize_event_counts() <mne.Epochs.equalize_event_counts>`
+#     before averaging.
 #
 #
 # Grand averages
@@ -377,7 +379,7 @@ list(event_dict)
 epochs['auditory'].average()
 
 # %%
-# see :ref:`tut-section-subselect-epochs` for details.
+# See :ref:`tut-section-subselect-epochs` for more details on that.
 #
 # The tutorials :ref:`tut-epochs-class` and :ref:`tut-evoked-class` have many
 # more details about working with the `~mne.Epochs` and `~mne.Evoked` classes.
@@ -409,10 +411,10 @@ epochs['auditory'].average()
 #
 # Peak measures can be obtained using the :meth:`~mne.Evoked.get_peak` method.
 # There are two important things to point out about
-# :meth:`~mne.Evoked.get_peak` method. First, it finds the strongest peak
+# :meth:`~mne.Evoked.get_peak`. First, it finds the strongest peak
 # looking across **all channels** of the selected type that are available in
 # the :class:`~mne.Evoked` object. As a consequence, if you want to restrict
-# the search for the peak to a group of channels or a single channel, you
+# the search to a group of channels or a single channel, you
 # should first use the :meth:`~mne.Evoked.pick` or
 # :meth:`~mne.Evoked.pick_channels` methods. Second, the
 # :meth:`~mne.Evoked.get_peak` method can find different types of peaks using
@@ -435,8 +437,8 @@ epochs['auditory'].average()
 
 # Define a function to print out the channel (ch) containing the
 # peak latency (lat; in msec) and amplitude (amp, in µV), with the
-# time range (tmin and tmax) that were searched.
-# This function will be used throughout the remainder of the tutorial
+# time range (tmin and tmax) that was searched.
+# This function will be used throughout the remainder of the tutorial.
 def print_peak_measures(ch, tmin, tmax, lat, amp):
     print(f'Channel: {ch}')
     print(f'Time Window: {tmin * 1e3:.3f} - {tmax * 1e3:.3f} ms')
@@ -486,7 +488,7 @@ print_peak_measures(ch_roi, good_tmin, good_tmax, lat_roi, amp_roi)
 #
 # Peak measures are very susceptible to high frequency noise in the
 # signal (for discussion, see :footcite:`Luck2014`). Specifically, high
-# frequency noise positively bias peak amplitude measures. This bias can
+# frequency noise positively biases peak amplitude measures. This bias can
 # confound comparisons across conditions where ERPs differ in the level of high
 # frequency noise, such as when the conditions differ in the number of trials
 # contributing to the ERP. One way to avoid this is to apply a non-causal
@@ -498,14 +500,12 @@ print_peak_measures(ch_roi, good_tmin, good_tmax, lat_roi, amp_roi)
 # measures for effects of interest :footcite:`Rousselet2012,VanRullen2011`.
 #
 # If using peak measures, it is critical to visually inspect the data to
-# make sure the selected time window actually contains a peak
-# (:meth:`~mne.Evoked.get_peak` will always identify a peak).
-# Visual inspection allows to easily verify whether the automatically found
-# peak is correct. The :meth:`~mne.Evoked.get_peak` detects the maximum or
-# minimum voltage in the specified time range and returns the latency and
-# amplitude of this peak. There is no guarantee that this method will return
-# an actual peak. Instead, it may return a value on the rising or falling edge
-# of the peak we are trying to find.
+# make sure the selected time window actually contains a peak. The
+# meth:`~mne.Evoked.get_peak` method detects the maximum or minimum voltage in
+# the specified time range and returns the latency and amplitude of this peak.
+# There is no guarantee that this method will return an actual peak. Instead,
+# it may return a value on the rising or falling edge of a peak we are trying
+# to find.
 #
 # The following example demonstrates why visual inspection is crucial. Below,
 # we use a known bad time window (.095 to .135 s) to search for a peak in
@@ -522,14 +522,13 @@ print_peak_measures(ch_roi, bad_tmin, bad_tmax, bad_lat_roi, bad_amp_roi)
 
 # %%
 # If all we had were the above values, it would be unclear if they are truly
-# identifying a peak or just a the falling or rising edge of one. However, it
-# becomes clear that the .095 to .135 s time window is misses the peak on
-# ``eeg59``. This is shown in the bottom panel where we see the bad time window
-# (highlighted in orange) misses the peak (the pink star). In contrast, the
-# time window defined initially (.08 to .12 s; highlighted in blue) returns
-# an actual peak instead of a just a maximal or minimal value in the searched
-# time window. Visual inspection will always help you to convince yourself the
-# data returned are actual peaks.
+# identifying a peak in the ERP. In fact, the .095 to .135 s time window
+# actually does not contain the true peak, which is shown in the top panel
+# below. The bad time window (highlighted in orange) does not contain the true
+# peak (the pink star). In contrast, the time window defined initially (.08 to
+# .12 s; highlighted in blue) returns an actual peak instead of a just a
+# maximum or minimum in the searched time window. Visual inspection will always
+# help you to convince yourself that the returned values are actual peaks.
 
 fig, axs = plt.subplots(nrows=2, ncols=1)
 words = (('Bad', 'missing'), ('Good', 'finding'))
@@ -550,18 +549,20 @@ for ix, ax in enumerate(axs):
 # Another common practice in ERP studies is to define a component (or effect)
 # as the mean amplitude within a specified time window. One advantage of this
 # approach is that it is less sensitive to high frequency noise (compared to
-# peak amplitude measures) because averaging over a time window acts like a
-# low-pass filter (see discussion in the above section
+# peak amplitude measures), because averaging over a time window acts as a
+# low-pass filter (see discussion in the previous section
 # `Peak latency and amplitude`_).
 #
 # When using mean amplitude measures, selecting the time window based on
 # the effect of interest (e.g., the difference between two conditions) can
-# inflate the likelihood of finding false positives in your results because
-# this approach is circular :footcite:`LuckGaspelin2017`. There are other, and
+# inflate the likelihood of finding false positives in your
+# results:footcite:`LuckGaspelin2017`. There are other, and
 # better, ways to identify a time window to use for extracting mean amplitude
-# measures. First, you can use *a priori* time window based on prior research.
-# A second way is to define a time window from an independent condition or set
-# of trials not used in the analysis (e.g., a "localizer"). A third approach is
+# measures. First, you can use an *a priori* time window based on prior
+# research.
+# A second option is to define a time window from an independent condition or
+# set of trials not used in the analysis (e.g., a "localizer"). A third
+# approach is
 # to define a time window using the across-condition grand average. This latter
 # approach is not circular because the across-condition mean and condition
 # difference are independent of one another. The issues discussed above also
@@ -569,15 +570,15 @@ for ix, ax in enumerate(axs):
 #
 # The following example demonstrates how to pull out the mean amplitude
 # from the left visual condition (i.e., the ``l_vis`` :class:`~mne.Evoked`
-# object) using from selected channels and time windows. Stimulating the
-# left visual field is increases neural activity visual cortex of the
+# object) from selected channels and time windows. Stimulating the
+# left visual field increases neural activity of visual cortex in the
 # contralateral (i.e., right) hemisphere. We can test this by examining the
 # amplitude of the ERP for left visual field stimulation over right
 # (contralateral) and left (ipsilateral) channels. The channels used for this
 # analysis are ``eeg54`` and ``eeg57`` (left hemisphere), and ``eeg59`` and
 # ``eeg55`` (right hemisphere). The time window used is .08 (``good_tmin``)
-# to .12 s (``good_tmax``) as it corresponds to when P100 typically occurs. The
-# P100 is sensitive to left and right visual field stimulation. The mean
+# to .12 s (``good_tmax``) as it corresponds to when the P100 typically occurs.
+# The P100 is sensitive to left and right visual field stimulation. The mean
 # amplitude is extracted from the above four channels and stored in a
 # :class:`pandas.DataFrame`.
 
@@ -601,15 +602,15 @@ mean_amp_roi_df = pd.DataFrame({
 print(mean_amp_roi_df.groupby('hemisphere').mean())
 
 # %%
-# As demonstrated in the above example, the mean amplitude was higher and
+# As demonstrated in this example, the mean amplitude was higher and
 # positive in right compared to left hemisphere channels. It should be
-# reiterated that both that spatial and temporal window you use should be
-# determined in an independent manner (e.g., defined *a priori* from prior
+# reiterated that both spatial and temporal windows used in the analysis should
+# be determined in an independent manner (e.g., defined *a priori* from prior
 # research, a "localizer" or another independent condition) and not based
 # on the data you will use to test your hypotheses.
 #
-# The above example can be modified to extract the the mean amplitude
-# from all channels and store the resulting output in
+# The example can be modified to extract the mean amplitude
+# from all channels and store the resulting output in a 
 # :class:`pandas.DataFrame`. This can be useful for statistical analyses
 # conducted in other programming languages.
 

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -59,11 +59,11 @@ raw.info
 # ^^^^^^^^^^^^^^^^^^^^^^^
 #
 # In practice it is quite common to have some channels labeled as EEG that are
-# actually EOG channels. `~mne.io.Raw` objects have a
-# `~mne.io.Raw.set_channel_types` method that can be used to change a channel
-# that is mislabeled as ``eeg`` to ``eog``.
+# actually EOG channels. :class:`~mne.io.Raw` objects have a
+# :meth:`~mne.io.Raw.set_channel_types` method that can be used to change a
+# channel that is mislabeled as ``eeg`` to ``eog``.
 #
-# You can also rename channels using the `~mne.io.Raw.rename_channels` method.
+# You can also rename channels using :meth:`~mne.io.Raw.rename_channels`.
 # Detailed examples of both of these methods can be found in the tutorial
 # :ref:`tut-raw-class`.
 #
@@ -96,7 +96,7 @@ _ = raw.rename_channels(channel_renaming_dict)  # happens in-place
 #
 # This dataset has realistic digitized 3D sensor locations saved as part of the
 # ``.fif`` file, so we can view the sensor locations in 2D or 3D using the
-# `~mne.io.Raw.plot_sensors` method:
+# :meth:`~mne.io.Raw.plot_sensors` method:
 
 raw.plot_sensors(show_names=True)
 fig = raw.plot_sensors('3d')
@@ -112,7 +112,7 @@ fig = raw.plot_sensors('3d')
 # :ref:`reading-dig-montages` for discussion and :ref:`dig-formats` for a list
 # of supported formats). Once loaded, the digitized sensor locations can be
 # added to the data by passing the loaded montage object to
-# `~mne.io.Raw.set_montage`.
+# :meth:`~mne.io.Raw.set_montage`.
 #
 #
 # Setting the EEG reference
@@ -132,10 +132,10 @@ for proj in (False, True):
 
 # %%
 # The referencing scheme can be changed with the function
-# `mne.set_eeg_reference` (which by default operates on a *copy* of the data)
-# or the `raw.set_eeg_reference() <mne.io.Raw.set_eeg_reference>` method (which
-# always modifies the data in-place). The tutorial :ref:`tut-set-eeg-ref` shows
-# several examples.
+# :func:`mne.set_eeg_reference` (which by default operates on a *copy* of the
+# data) or the :meth:`raw.set_eeg_reference() <mne.io.Raw.set_eeg_reference>`
+# method (which always modifies the data *in-place*). The tutorial
+# :ref:`tut-set-eeg-ref` shows several examples.
 #
 #
 # Filtering
@@ -154,11 +154,11 @@ raw.filter(l_freq=0.1, h_freq=None)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # The general process for extracting evoked responses from continuous data is
-# to use the `~mne.Epochs` constructor, and then average the resulting epochs
-# to create an `~mne.Evoked` object. In MNE-Python, events are represented as
-# a :class:`NumPy array <numpy.ndarray>` containing event latencies (in
-# samples) and integer event codes. The event codes are stored in the last
-# column of the events array:
+# to use the :class:`~mne.Epochs` constructor, and then average the resulting
+# epochs to create an :class:`~mne.Evoked` object. In MNE-Python, events are
+# represented as a :class:`NumPy array <numpy.ndarray>` containing event
+# latencies (in samples) and integer event codes. The event codes are stored in
+# the last column of the events array:
 
 np.unique(events[:, -1])
 
@@ -186,9 +186,9 @@ fig = epochs.plot(events=events)
 # %%
 # It is also possible to automatically drop epochs (either when first creating
 # them or later on) by providing maximum peak-to-peak signal value thresholds
-# (passed to `~mne.Epochs` as the ``reject`` parameter; see
+# (passed to :class:`~mne.Epochs` as the ``reject`` parameter; see
 # :ref:`tut-reject-epochs-section` for details).  You can also do this after
-# the epochs are already created, using the `~mne.Epochs.drop_bad` method:
+# the epochs are already created using :meth:`~mne.Epochs.drop_bad`:
 
 reject_criteria = dict(eeg=100e-6, eog=200e-6)  # 100 µV, 200 µV
 epochs.drop_bad(reject=reject_criteria)
@@ -196,37 +196,38 @@ epochs.drop_bad(reject=reject_criteria)
 # %%
 # Next, we generate a barplot of which channels contributed most to epochs
 # getting rejected. If one channel is responsible for many epoch rejections,
-# it may be worthwhile to mark that channel as "bad" in the `~mne.io.Raw`
-# object and then re-run epoching (fewer channels with more good epochs may be
-# preferable to keeping all channels but losing many epochs). See
-# :ref:`tut-bad-channels` for more information.
+# it may be worthwhile to mark that channel as "bad" in the
+# :class:`~mne.io.Raw` object and then re-run epoching (fewer channels with
+# more good epochs may be preferable to keeping all channels but losing many
+# epochs). See :ref:`tut-bad-channels` for more information.
 
 epochs.plot_drop_log()
 
 # %%
 # Epochs can also be dropped automatically if the event around which the epoch
-# is created is too close to the start or end of the `~mne.io.Raw` object
-# (e.g., if the epoch would extend past the end of the recording; this is the
-# cause for the "TOO_SHORT" entry in the `~mne.Epochs.plot_drop_log` plot).
+# is created is too close to the start or end of the :class:`~mne.io.Raw`
+# object (e.g., if the epoch would extend past the end of the recording; this
+# is the cause for the "TOO_SHORT" entry in the
+# :meth:`~mne.Epochs.plot_drop_log` plot).
 #
-# Epochs may also be dropped automatically if the `~mne.io.Raw` object contains
-# :term:`annotations` that begin with either ``bad`` or ``edge`` ("edge"
-# annotations are automatically inserted when concatenating two or more
-# `~mne.io.Raw` objects). See :ref:`tut-reject-data-spans` for more information
-# on annotation-based epoch rejection.
+# Epochs may also be dropped automatically if the :class:`~mne.io.Raw` object
+# contains :term:`annotations` that begin with either ``bad`` or ``edge``
+# ("edge" annotations are automatically inserted when concatenating two or more
+# :class:`~mne.io.Raw` objects). See :ref:`tut-reject-data-spans` for more
+# information on annotation-based epoch rejection.
 #
 # Now that we've dropped all bad epochs, let's look at our evoked responses for
-# some conditions we care about. Here, the `~mne.Epochs.average` method will
-# create an `~mne.Evoked` object, which we can then plot. Notice that we select
-# which condition we want to average using square-bracket indexing (like for a
-# :class:`dictionary <dict>`). This returns a subset with only the desired
-# epochs, which we then average:
+# some conditions we care about. Here, the :meth:`~mne.Epochs.average` method
+# will create an :class:`~mne.Evoked` object, which we can then plot. Notice
+# that we select which condition we want to average using square-bracket
+# indexing (like for a :class:`dictionary <dict>`). This returns a subset with
+# only the desired epochs, which we then average:
 
 l_aud = epochs['auditory/left'].average()
 l_vis = epochs['visual/left'].average()
 
 # %%
-# These `~mne.Evoked` objects have their own interactive plotting method
+# These :class:`~mne.Evoked` objects have their own interactive plotting method
 # (though again, it won't be interactive on the documentation website).
 # Clicking and dragging a span of time will generate a topography of scalp
 # potentials for the selected time segment. Here, we also demonstrate built-in
@@ -237,20 +238,21 @@ fig2 = l_vis.plot(spatial_colors=True)
 
 # %%
 # Scalp topographies can also be obtained non-interactively with the
-# `~mne.Evoked.plot_topomap` method. Here, we display topomaps of the average
-# evoked potential in 50 ms time windows centered at -200 ms, 100 ms, and
-# 400 ms.
+# :meth:`~mne.Evoked.plot_topomap` method. Here, we display topomaps of the
+# average evoked potential in 50 ms time windows centered at -200 ms, 100 ms,
+# and 400 ms.
 
 l_aud.plot_topomap(times=[-0.2, 0.1, 0.4], average=0.05)
 
 # %%
 # Considerable customization of these plots is possible, see the docstring of
-# `~mne.Evoked.plot_topomap` for details.
+# :meth:`~mne.Evoked.plot_topomap` for details.
 #
-# There is also a built-in method for combining "butterfly" plots of the
-# signals with scalp topographies, called `~mne.Evoked.plot_joint`. Like in
-# `~mne.Evoked.plot_topomap`, you can specify times for the scalp topographies
-# or you can let the method choose times automatically as shown here:
+# There is also a built-in method for combining butterfly plots of the signals
+# with scalp topographies called :meth:`~mne.Evoked.plot_joint`. Like in
+# :meth:`~mne.Evoked.plot_topomap`, you can specify times for the scalp
+# topographies or you can let the method choose times automatically as shown
+# here:
 
 l_aud.plot_joint()
 
@@ -324,8 +326,8 @@ roi_evoked.plot()
 # ^^^^^^^^^^^^^^^^^^^^
 #
 # If we wanted to contrast auditory to visual stimuli, a useful function is
-# `mne.viz.plot_compare_evokeds`. By default, this function will combine all
-# channels in each evoked object using GFP (or RMS for MEG channels); here
+# :func:`mne.viz.plot_compare_evokeds`. By default, this function will combine
+# all channels in each evoked object using GFP (or RMS for MEG channels); here
 # instead we specify to combine by averaging, and restrict it to a subset of
 # channels by passing ``picks``:
 
@@ -335,19 +337,19 @@ mne.viz.plot_compare_evokeds(evokeds, picks=picks, combine='mean')
 
 # %%
 # We can also generate confidence intervals by treating each epoch as a
-# separate observation using the `~mne.Epochs.iter_evoked` method. A confidence
+# separate observation using :meth:`~mne.Epochs.iter_evoked`. A confidence
 # interval across subjects could also be obtained by passing a list of
-# `~mne.Evoked` objects (one per subject) to the
-# `~mne.viz.plot_compare_evokeds` function.
+# :class:`~mne.Evoked` objects (one per subject) to the
+# :func:`~mne.viz.plot_compare_evokeds` function.
 
 evokeds = dict(auditory=list(epochs['auditory/left'].iter_evoked()),
                visual=list(epochs['visual/left'].iter_evoked()))
 mne.viz.plot_compare_evokeds(evokeds, combine='mean', picks=picks)
 
 # %%
-# We can also compare conditions by subtracting one `~mne.Evoked` object from
-# another using the `mne.combine_evoked` function (this function also supports
-# pooling of epochs without subtraction).
+# We can also compare conditions by subtracting one :class:`~mne.Evoked` object
+# from another using the :func:`mne.combine_evoked` function (this function
+# also supports pooling of epochs without subtraction).
 
 aud_minus_vis = mne.combine_evoked([l_aud, l_vis], weights=[1, -1])
 aud_minus_vis.plot_joint()
@@ -366,8 +368,8 @@ aud_minus_vis.plot_joint()
 # ^^^^^^^^^^^^^^
 #
 # To compute grand averages across conditions (or subjects), you can pass a
-# list of `~mne.Evoked` objects to `mne.grand_average`. The result is another
-# `~mne.Evoked` object.
+# list of :class:`~mne.Evoked` objects to :func:`mne.grand_average`. The result
+# is another :class:`~mne.Evoked` object.
 
 grand_average = mne.grand_average([l_aud, l_vis])
 print(grand_average)
@@ -388,7 +390,8 @@ epochs['auditory'].average()
 # See :ref:`tut-section-subselect-epochs` for more details on that.
 #
 # The tutorials :ref:`tut-epochs-class` and :ref:`tut-evoked-class` have many
-# more details about working with the `~mne.Epochs` and `~mne.Evoked` classes.
+# more details about working with the :class:`~mne.Epochs` and
+# :class:`~mne.Evoked` classes.
 
 # %%
 # Amplitude and latency measures

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -546,7 +546,7 @@ for ix, ax in enumerate(axs):
     ax.plot(lat_roi * 1e3, amp_roi * 1e6, marker='*', color='C6')
     ax.axvspan(*(times[ix] * 1e3), facecolor=colors[ix], alpha=0.3)
     ax.set_xlim(-50, 150)  # Show zoomed in around peak
-tight_layout(fig)
+tight_layout(fig=fig)
 
 # %%
 # Mean Amplitude

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -76,6 +76,7 @@ channel_renaming_dict = {name: name.replace(' 0', '').lower()
                          for name in raw.ch_names}
 _ = raw.rename_channels(channel_renaming_dict)  # happens in-place
 
+#
 # .. note:: The assignment to a temporary name ``_`` (the ``_ = `` part) is
 #           included here to suppress automatic printing of the ``raw`` object.
 #           You do not have to do this in your interactive analysis.

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -79,6 +79,7 @@ _ = raw.rename_channels(channel_renaming_dict)  # happens in-place
 # .. note:: The assignment to a temporary name ``_`` (the ``_ = `` part) is
 #           included here to suppress automatic printing of the ``raw`` object.
 #           You do not have to do this in your interactive analysis.
+#
 
 # %%
 # Channel locations
@@ -295,8 +296,8 @@ ax.fill_between(l_aud.times, gfp * 1e6, color='lime', alpha=0.2)
 ax.set(xlabel='Time (s)', ylabel='GFP (µV)', title='EEG')
 
 # %%
-# Averaging across channels with regions of interest (ROIs)
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# Averaging across channels with regions of interest
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # Since our sample data contains responses to left and right auditory and
 # visual stimuli, we may want to compare left versus right regions of interest

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -181,7 +181,7 @@ event_dict = {'auditory/left': 1, 'auditory/right': 2, 'visual/left': 3,
 
 epochs = mne.Epochs(raw, events, event_id=event_dict, tmin=-0.3, tmax=0.7,
                     preload=True)
-fig = epochs.plot(events=events, show_scrollbars=False)
+fig = epochs.plot(events=events)
 
 # %%
 # It is also possible to automatically drop epochs (either when first creating
@@ -436,7 +436,7 @@ epochs['auditory'].average()
 # The following example demonstrates how to find the first positive peak in the
 # ERP (i.e., the P100) for the left visual condition (i.e., the
 # ``l_vis`` :class:`~mne.Evoked` object). The time window used to search for
-# the peak ranges from .08 to .12 s. This time window was selected because it
+# the peak ranges from 0.08 to 0.12 s. This time window was selected because it
 # is when P100 typically occurs. Note that all ``'eeg'`` channels are submitted
 # to the :meth:`~mne.Evoked.get_peak` method.
 
@@ -453,7 +453,7 @@ def print_peak_measures(ch, tmin, tmax, lat, amp):
 
 
 # Get peak amplitude and latency from a good time window that contains the peak
-good_tmin, good_tmax = .08, .12
+good_tmin, good_tmax = 0.08, 0.12
 ch, lat, amp = l_vis.get_peak(ch_type='eeg', tmin=good_tmin, tmax=good_tmax,
                               mode='pos', return_amplitude=True)
 
@@ -514,11 +514,11 @@ print_peak_measures(ch_roi, good_tmin, good_tmax, lat_roi, amp_roi)
 # to find.
 #
 # The following example demonstrates why visual inspection is crucial. Below,
-# we use a known bad time window (.095 to .135 s) to search for a peak in
+# we use a known bad time window (0.095 to 0.135 s) to search for a peak in
 # channel ``eeg59``.
 
 # Get BAD peak measures
-bad_tmin, bad_tmax = .095, .135
+bad_tmin, bad_tmax = 0.095, 0.135
 ch_roi, bad_lat_roi, bad_amp_roi = l_vis_roi.get_peak(
     mode='pos', tmin=bad_tmin, tmax=bad_tmax, return_amplitude=True)
 
@@ -528,11 +528,11 @@ print_peak_measures(ch_roi, bad_tmin, bad_tmax, bad_lat_roi, bad_amp_roi)
 
 # %%
 # If all we had were the above values, it would be unclear if they are truly
-# identifying a peak in the ERP. In fact, the .095 to .135 s time window
+# identifying a peak in the ERP. In fact, the 0.095 to 0.135 s time window
 # actually does not contain the true peak, which is shown in the top panel
 # below. The bad time window (highlighted in orange) does not contain the true
-# peak (the pink star). In contrast, the time window defined initially (.08 to
-# .12 s; highlighted in blue) returns an actual peak instead of a just a
+# peak (the pink star). In contrast, the time window defined initially (0.08 to
+# 0.12 s; highlighted in blue) returns an actual peak instead of a just a
 # maximum or minimum in the searched time window. Visual inspection will always
 # help you to convince yourself that the returned values are actual peaks.
 
@@ -563,7 +563,7 @@ tight_layout(fig=fig)
 # When using mean amplitude measures, selecting the time window based on
 # the effect of interest (e.g., the difference between two conditions) can
 # inflate the likelihood of finding false positives in your
-# results:footcite:`LuckGaspelin2017`. There are other, and
+# results :footcite:`LuckGaspelin2017`. There are other, and
 # better, ways to identify a time window to use for extracting mean amplitude
 # measures. First, you can use an *a priori* time window based on prior
 # research.
@@ -583,8 +583,9 @@ tight_layout(fig=fig)
 # amplitude of the ERP for left visual field stimulation over right
 # (contralateral) and left (ipsilateral) channels. The channels used for this
 # analysis are ``eeg54`` and ``eeg57`` (left hemisphere), and ``eeg59`` and
-# ``eeg55`` (right hemisphere). The time window used is .08 (``good_tmin``)
-# to .12 s (``good_tmax``) as it corresponds to when the P100 typically occurs.
+# ``eeg55`` (right hemisphere). The time window used is 0.08 (``good_tmin``)
+# to 0.12 s (``good_tmax``) as it corresponds to when the P100 typically
+# occurs.
 # The P100 is sensitive to left and right visual field stimulation. The mean
 # amplitude is extracted from the above four channels and stored in a
 # :class:`pandas.DataFrame`.

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -20,24 +20,21 @@ we'll crop the raw data from ~4.5 minutes down to 90 seconds.
 
 # %%
 
-import os
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import mne
 from mne.viz.utils import tight_layout
 
-sample_data_folder = mne.datasets.sample.data_path()
-sample_data_raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
-                                    'sample_audvis_filt-0-40_raw.fif')
-raw = mne.io.read_raw_fif(sample_data_raw_file, preload=False)
+root = mne.datasets.sample.data_path() / 'MEG' / 'sample'
+raw_file = root / 'sample_audvis_filt-0-40_raw.fif'
+raw = mne.io.read_raw_fif(raw_file, preload=False)
 
-sample_data_events_file = os.path.join(sample_data_folder, 'MEG', 'sample',
-                                       'sample_audvis_filt-0-40_raw-eve.fif')
-events = mne.read_events(sample_data_events_file)
+events_file = root / 'sample_audvis_filt-0-40_raw-eve.fif'
+events = mne.read_events(events_file)
 
-raw.crop(tmax=90)  # in seconds; happens in-place
-# discard events >90 seconds (not strictly necessary: avoids some warnings)
+raw.crop(tmax=90)  # in seconds (happens in-place)
+# discard events >90 seconds (not strictly necessary, but avoids some warnings)
 events = events[events[:, 0] <= raw.last_samp]
 
 # %%

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -77,13 +77,12 @@ channel_renaming_dict = {name: name.replace(' 0', '').lower()
                          for name in raw.ch_names}
 _ = raw.rename_channels(channel_renaming_dict)  # happens in-place
 
-#
+# %%
 # .. note::
 #     The assignment to a temporary name ``_`` (the ``_ = `` part) is included
 #     here to suppress automatic printing of the ``raw`` object. You do not
 #     have to do this in your interactive analysis.
-
-# %%
+#
 # Channel locations
 # ^^^^^^^^^^^^^^^^^
 #

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -26,6 +26,8 @@ import matplotlib.pyplot as plt
 import mne
 from mne.viz.utils import tight_layout
 
+mne.viz.set_browser_backend('matplotlib')  # nicer static plots for the docs
+
 root = mne.datasets.sample.data_path() / 'MEG' / 'sample'
 raw_file = root / 'sample_audvis_filt-0-40_raw.fif'
 raw = mne.io.read_raw_fif(raw_file, preload=False)
@@ -124,8 +126,8 @@ fig = raw.plot_sensors('3d')
 # raw data by plotting it with and without the projector applied:
 
 for proj in (False, True):
-    with mne.viz.use_browser_backend('matplotlib'):
-        fig = raw.plot(n_channels=5, proj=proj, scalings=dict(eeg=50e-6))
+    fig = raw.plot(n_channels=5, proj=proj, scalings=dict(eeg=50e-6),
+                   show_scrollbars=False)
     fig.subplots_adjust(top=0.9)  # make room for title
     ref = 'Average' if proj else 'No'
     fig.suptitle(f'{ref} reference', size='xx-large', weight='bold')
@@ -181,7 +183,7 @@ event_dict = {'auditory/left': 1, 'auditory/right': 2, 'visual/left': 3,
 
 epochs = mne.Epochs(raw, events, event_id=event_dict, tmin=-0.3, tmax=0.7,
                     preload=True)
-fig = epochs.plot(events=events)
+fig = epochs.plot(events=events, show_scrollbars=False)
 
 # %%
 # It is also possible to automatically drop epochs (either when first creating

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -77,7 +77,7 @@ _ = raw.rename_channels(channel_renaming_dict)  # happens in-place
 
 # %%
 # .. note::
-#     The assignment to a temporary name ``_`` (the ``_ = `` part) is included
+#     The assignment to a temporary name ``_`` (the ``_ =`` part) is included
 #     here to suppress automatic printing of the ``raw`` object. You do not
 #     have to do this in your interactive analysis.
 #
@@ -123,7 +123,7 @@ fig = raw.plot_sensors('3d')
 # raw data by plotting it with and without the projector applied:
 
 for proj in (False, True):
-    with mne.viz.set_browser_backend('matplotlib'):
+    with mne.viz.use_browser_backend('matplotlib'):
         fig = raw.plot(n_channels=5, proj=proj, scalings=dict(eeg=50e-6),
                        show_scrollbars=False)
     fig.subplots_adjust(top=0.9)  # make room for title

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -632,8 +632,9 @@ mean_amp_all_df = pd.DataFrame({
 mean_amp_all_df['tmin'] = good_tmin
 mean_amp_all_df['tmax'] = good_tmax
 mean_amp_all_df['condition'] = 'Left/Visual'
-print(mean_amp_all_df.head())
-print(mean_amp_all_df.tail())
+with pd.option_context('display.max_columns', None):
+    print(mean_amp_all_df.head())
+    print(mean_amp_all_df.tail())
 
 
 # %%

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -610,7 +610,7 @@ print(mean_amp_roi_df.groupby('hemisphere').mean())
 # on the data you will use to test your hypotheses.
 #
 # The example can be modified to extract the mean amplitude
-# from all channels and store the resulting output in a 
+# from all channels and store the resulting output in a
 # :class:`pandas.DataFrame`. This can be useful for statistical analyses
 # conducted in other programming languages.
 

--- a/tutorials/evoked/30_eeg_erp.py
+++ b/tutorials/evoked/30_eeg_erp.py
@@ -61,9 +61,11 @@ raw.info
 # In practice it is quite common to have some channels labeled as EEG that are
 # actually EOG channels. `~mne.io.Raw` objects have a
 # `~mne.io.Raw.set_channel_types` method that can be used to change a channel
-# that is mislabeled as ``eeg`` to ``eog``. You can also rename channels
-# using the `~mne.io.Raw.rename_channels` method. Detailed examples of both of
-# these methods can be found in the tutorial :ref:`tut-raw-class`.
+# that is mislabeled as ``eeg`` to ``eog``.
+#
+# You can also rename channels using the `~mne.io.Raw.rename_channels` method.
+# Detailed examples of both of these methods can be found in the tutorial
+# :ref:`tut-raw-class`.
 #
 # In our data set, all channel types are already correct. Therefore, we'll only
 # remove a space and a leading zero in the channel names and convert to
@@ -74,10 +76,10 @@ channel_renaming_dict = {name: name.replace(' 0', '').lower()
 _ = raw.rename_channels(channel_renaming_dict)  # happens in-place
 
 #
-# .. note:: The assignment to a temporary name ``_`` (the ``_ = `` part) is
-#           included here to suppress automatic printing of the ``raw`` object.
-#           You do not have to do this in your interactive analysis.
-#
+# .. note::
+#     The assignment to a temporary name ``_`` (the ``_ = `` part) is included
+#     here to suppress automatic printing of the ``raw`` object. You do not
+#     have to do this in your interactive analysis.
 
 # %%
 # Channel locations


### PR DESCRIPTION
I tried to streamline the [ERP tutorial](https://mne.tools/stable/auto_tutorials/evoked/30_eeg_erp.html) a bit, after which it hopefully reads a bit better.

Two questions:
- Screenshots of `Raw.plot()` or `Epochs.plot()` should use the `matplotlib` backend I think because it looks better in non-interactive documents.
- Do we not append () to methods and functions? If so, should I prepend `:meth:` (or :func:) in this tutorial?

[Before](https://mne.tools/stable/auto_tutorials/evoked/30_eeg_erp.html) vs. [after](https://output.circle-artifacts.com/output/job/b2394614-3553-438a-b7e2-c8f1ee0365fa/artifacts/0/dev/auto_tutorials/evoked/30_eeg_erp.html)