### PR TITLE
Use a `float` default value for `fmin`-param in `mne.time_frequency.psd_array_multitaper`

### DIFF
--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -362,7 +362,7 @@ def _compute_mt_params(n_times, sfreq, bandwidth, low_bias, adaptive,
 
 
 @verbose
-def psd_array_multitaper(x, sfreq, fmin=0, fmax=np.inf, bandwidth=None,
+def psd_array_multitaper(x, sfreq, fmin=0.0, fmax=np.inf, bandwidth=None,
                          adaptive=False, low_bias=True, normalization='length',
                          output='power', n_jobs=1, verbose=None):
     """Compute power spectral density (PSD) using a multi-taper method.


### PR DESCRIPTION
Fixes #10469.

This is a really tiny, nitpicky fix. 
If anyone wants more more text here please comment and I will expand the description.