### PR TITLE
BUG: Fix add_figure for MNEQtBrowser

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -27,7 +27,7 @@ Enhancements
 
 Bugs
 ~~~~
-- None yet
+- Fix bug where plots produced using the ``'qt'`` / ``mne_qt_browser`` backend could not be added using :meth:`mne.Report.add_figure` (:gh:`10485` by `Eric Larson`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -260,8 +260,7 @@ numpydoc_xref_ignore = {
     # unlinkable
     'CoregistrationUI',
     'IntracranialElectrodeLocator',
-    # TODO: fix the Renderer return type of create_3d_figure(scene=False)
-    'Renderer',
+    'mne_qt_browser.figure.MNEQtBrowser',
 }
 numpydoc_validate = True
 numpydoc_validation_checks = {'all'} | set(error_ignores)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -349,6 +349,12 @@ class Resetter(object):
                 _assert_no_instances(_Renderer, when)
             if PyQtGraphBrowser is not None and \
                     'pyqtgraphbrowser' not in skips:
+                # Ensure any manual fig.close() events get properly handled
+                from mne_qt_browser._pg_figure import QApplication
+                inst = QApplication.instance()
+                if inst is not None:
+                    for _ in range(2):
+                        inst.processEvents()
                 _assert_no_instances(PyQtGraphBrowser, when)
         # This will overwrite some Sphinx printing but it's useful
         # for memory timestamps

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -19,10 +19,11 @@ import numpy as np
 import pytest
 from matplotlib import pyplot as plt
 
-from mne import Epochs, read_events, read_evokeds, read_cov, pick_channels_cov
+from mne import (Epochs, read_events, read_evokeds, read_cov,
+                 pick_channels_cov, create_info)
 from mne.report import report as report_mod
 from mne.report.report import CONTENT_ORDER
-from mne.io import read_raw_fif, read_info
+from mne.io import read_raw_fif, read_info, RawArray
 from mne.datasets import testing
 from mne.report import Report, open_report, _ReportScraper, report
 from mne.utils import (requires_nibabel, Bunch, requires_version,
@@ -207,6 +208,23 @@ def test_render_report(renderer_pyvistaqt, tmp_path, invisible_fig):
 
     with pytest.raises(TypeError, match='It seems you passed a path'):
         report.add_figure(fig='foo', title='title')
+    with pytest.raises(TypeError, match='.*MNEQtBrowser.*Figure3D.*got.*'):
+        report.add_figure(fig=1., title='title')
+
+
+def test_render_mne_qt_browser(tmp_path, browser_backend):
+    """Test adding a mne_qt_browser (and matplotlib) raw plot."""
+    report = Report()
+    info = create_info(1, 1000., 'eeg')
+    data = np.zeros((1, 1000))
+    raw = RawArray(data, info)
+    fig = raw.plot()
+    name = fig.__class__.__name__
+    if browser_backend.name == 'matplotlib':
+        assert 'MNEBrowseFigure' in name
+    else:
+        assert 'MNEQtBrowser' in name or 'PyQtGraphBrowser' in name
+    report.add_figure(fig, title='raw')
 
 
 @testing.requires_testing_data

--- a/mne/utils/_bunch.py
+++ b/mne/utils/_bunch.py
@@ -26,10 +26,10 @@ class Bunch(dict):
 class BunchConst(Bunch):
     """Class to prevent us from re-defining constants (DRY)."""
 
-    def __setattr__(self, attr, val):  # noqa: D105
-        if attr != '__dict__' and hasattr(self, attr):
-            raise AttributeError('Attribute "%s" already set' % attr)
-        super().__setattr__(attr, val)
+    def __setitem__(self, key, val):  # noqa: D105
+        if key != '__dict__' and key in self:
+            raise AttributeError(f'Attribute {repr(key)} already set')
+        super().__setitem__(key, val)
 
 
 ###############################################################################

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -15,6 +15,7 @@ import webbrowser
 
 from decorator import FunctionMaker
 
+from ._bunch import BunchConst
 from ..defaults import HEAD_SIZE_DEFAULT
 
 
@@ -38,7 +39,7 @@ def _reflow_param_docstring(docstring, has_first_line=True, width=75):
 # are alphabetized (you can look up by the name of the argument). This way
 # the same ``docdict`` entries are easier to reuse.
 
-docdict = dict()
+docdict = BunchConst()
 
 # %%
 # A
@@ -359,6 +360,11 @@ docdict['brain_kwargs'] = """
 brain_kwargs : dict | None
     Additional arguments to the :class:`mne.viz.Brain` constructor (e.g.,
     ``dict(silhouette=True)``).
+"""
+
+docdict['browser'] = """
+fig : matplotlib.figure.Figure | mne_qt_browser.figure.MNEQtBrowser
+    Browser instance.
 """
 
 docdict['buffer_size_clust'] = """

--- a/mne/viz/_scraper.py
+++ b/mne/viz/_scraper.py
@@ -82,7 +82,7 @@ def _mne_qt_browser_screenshot(browser, inst=None, return_type='pixmap'):
         img = img.convertToFormat(img.Format_RGBA8888)
         ptr = img.bits()
         ptr.setsize(img.height() * img.width() * 4)
-        data = np.frombuffer(ptr, dtype=np.uint8)
+        data = np.frombuffer(ptr, dtype=np.uint8).copy()
         data.shape = (img.height(), img.width(), 4)
         return data / 255.
     else:

--- a/mne/viz/_scraper.py
+++ b/mne/viz/_scraper.py
@@ -2,6 +2,10 @@
 #
 # License: Simplified BSD
 
+from contextlib import contextmanager
+
+import numpy as np
+
 from ..utils import _pl
 
 
@@ -13,7 +17,6 @@ class _PyQtGraphScraper:
     def __call__(self, block, block_vars, gallery_conf):
         import mne_qt_browser
         from sphinx_gallery.scrapers import figure_rst
-        from PyQt5.QtWidgets import QApplication
         if gallery_conf['builder_name'] != 'html':
             return ''
         img_fnames = list()
@@ -29,15 +32,7 @@ class _PyQtGraphScraper:
             gui._scraped = True  # monkey-patch but it's easy enough
             n_plot += 1
             img_fnames.append(next(block_vars['image_path_iterator']))
-            if getattr(gui, 'load_thread', None) is not None:
-                if gui.load_thread.isRunning():
-                    gui.load_thread.wait(30000)
-            if inst is None:
-                inst = QApplication.instance()
-            # processEvents to make sure our progressBar is updated
-            for _ in range(2):
-                inst.processEvents()
-            pixmap = gui.grab()
+            pixmap, inst = _mne_qt_browser_screenshot(gui, inst)
             pixmap.save(img_fnames[-1])
             # child figures
             for fig in gui.mne.child_figs:
@@ -56,3 +51,39 @@ class _PyQtGraphScraper:
         return figure_rst(
             img_fnames, gallery_conf['src_dir'],
             f'Raw plot{_pl(n_plot)}')
+
+
+@contextmanager
+def _screenshot_mode(browser):
+    browser.mne.toolbar.setVisible(False)
+    browser.statusBar().setVisible(False)
+    try:
+        yield
+    finally:
+        browser.mne.toolbar.setVisible(True)
+        browser.statusBar().setVisible(True)
+
+
+def _mne_qt_browser_screenshot(browser, inst=None, return_type='pixmap'):
+    from mne_qt_browser._pg_figure import QApplication
+    if getattr(browser, 'load_thread', None) is not None:
+        if browser.load_thread.isRunning():
+            browser.load_thread.wait(30000)
+    if inst is None:
+        inst = QApplication.instance()
+    # processEvents to make sure our progressBar is updated
+    with _screenshot_mode(browser):
+        for _ in range(2):
+            inst.processEvents()
+        pixmap = browser.grab()
+    assert return_type in ('pixmap', 'ndarray')
+    if return_type == 'ndarray':
+        img = pixmap.toImage()
+        img = img.convertToFormat(img.Format_RGBA8888)
+        ptr = img.bits()
+        ptr.setsize(img.height() * img.width() * 4)
+        data = np.frombuffer(ptr, dtype=np.uint8)
+        data.shape = (img.height(), img.width(), 4)
+        return data / 255.
+    else:
+        return pixmap, inst

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -26,7 +26,7 @@ from ._utils import (_get_colormap_from_array, _alpha_blend_background,
 from ...fixes import _get_args, _point_data, _cell_data, _compare_version
 from ...transforms import apply_trans
 from ...utils import (copy_base_doc_to_subclass_doc, _check_option,
-                      _require_version)
+                      _require_version, _validate_type)
 
 
 with warnings.catch_warnings():
@@ -1050,8 +1050,7 @@ def _set_3d_title(figure, title, size=16):
 
 
 def _check_3d_figure(figure):
-    if not isinstance(figure, PyVistaFigure):
-        raise TypeError('figure must be an instance of PyVistaFigure.')
+    _validate_type(figure, PyVistaFigure, 'figure')
 
 
 def _close_3d_figure(figure):

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -299,7 +299,7 @@ def create_3d_figure(size, bgcolor=(0, 0, 0), smooth_shading=True,
 
     Returns
     -------
-    figure : instance of Figure3D or Renderer
+    figure : instance of Figure3D or ``Renderer``
         The requested empty figure or renderer, depending on ``scene``.
     """
     renderer = _get_renderer(

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -740,8 +740,7 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
 
     Returns
     -------
-    fig : instance of matplotlib.figure.Figure
-        The figure.
+    %(browser)s
 
     Notes
     -----

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -75,8 +75,7 @@ def plot_ica_sources(ica, inst, picks=None, start=None,
 
     Returns
     -------
-    fig : instance of Figure
-        The figure.
+    %(browser)s
 
     Notes
     -----

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -166,8 +166,7 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
 
     Returns
     -------
-    fig : matplotlib.figure.Figure | ``PyQt5.QtWidgets.QMainWindow``
-        Browser instance.
+    %(browser)s
 
     Notes
     -----

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -196,7 +196,7 @@ def tight_layout(pad=1.2, h_pad=None, w_pad=None, fig=None):
                 if hasattr(fig, 'set_layout_engine'):
                     fig.set_layout_engine('tight', **kwargs)
                 else:
-                    fig.set_tight_layout(**kwargs)
+                    fig.set_tight_layout(kwargs)
         except Exception:
             warn('Matplotlib function "tight_layout" is not supported.'
                  ' Skipping subplot adjustment.')

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -184,15 +184,19 @@ def tight_layout(pad=1.2, h_pad=None, w_pad=None, fig=None):
 
     fig.canvas.draw()
     constrained = fig.get_constrained_layout()
+    kwargs = dict(pad=pad, h_pad=h_pad, w_pad=w_pad)
     if constrained:
         return  # no-op
     try:  # see https://github.com/matplotlib/matplotlib/issues/2654
         with warnings.catch_warnings(record=True) as ws:
-            fig.tight_layout(pad=pad, h_pad=h_pad, w_pad=w_pad)
+            fig.tight_layout(**kwargs)
     except Exception:
         try:
             with warnings.catch_warnings(record=True) as ws:
-                fig.set_tight_layout(dict(pad=pad, h_pad=h_pad, w_pad=w_pad))
+                if hasattr(fig, 'set_layout_engine'):
+                    fig.set_layout_engine('tight', **kwargs)
+                else:
+                    fig.set_tight_layout(**kwargs)
         except Exception:
             warn('Matplotlib function "tight_layout" is not supported.'
                  ' Skipping subplot adjustment.')

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -427,6 +427,7 @@ report.add_figure(
     image_format='PNG'
 )
 report.save('report_custom_figure.html', overwrite=True)
+plt.close(fig)
 
 # %%
 # The :meth:`mne.Report.add_figure` method can add multiple figures at once. In
@@ -458,9 +459,16 @@ for angle in rotation_angles:
     figs.append(fig)
     captions.append(f'Rotation angle: {round(angle, 1)}°')
 
+# can also be a MNEQtBrowser instance
+figs.append(raw.plot())
+captions.append('... plus a raw data plot')
+
 report = mne.Report(title='Multiple figures example')
 report.add_figure(fig=figs, title='Fun with figures! 🥳', caption=captions)
 report.save('report_custom_figures.html', overwrite=True)
+for fig in figs[:-1]:
+    plt.close(fig)
+figs[-1].close()
 
 # %%
 # Adding image files

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -469,6 +469,7 @@ report.save('report_custom_figures.html', overwrite=True)
 for fig in figs[:-1]:
     plt.close(fig)
 figs[-1].close()
+del figs
 
 # %%
 # Adding image files


### PR DESCRIPTION
Closes https://github.com/mne-tools/mne-qt-browser/issues/77

Locally:
```
import mne
raw = mne.io.read_raw_fif(mne.datasets.sample.data_path() / 'MEG' / 'sample' / 'sample_audvis_raw.fif')
report = mne.Report()
report.add_figure(raw.plot(), title='Raw plot')
report.save('test.html', overwrite=True)
```

Now produces:

![Screenshot from 2022-04-01 16-00-37](https://user-images.githubusercontent.com/2365790/161334095-34f2c516-dcb8-476e-be3f-fd7b09661aa5.png)

Note I cut out the statusbar and toolbar to at least move toward what @cbrnr was looking for.

For the overview bar, I think we should do that separately, if at all. It probably adds enough information in some examples (e.g., annot/event timing) that we want to keep it. If someone's motivated, it's easy enough to implement custom code-block parsing that would allow us to move to a "scrape only if a `# sphinx_gallery_include_overview_bar` comment present" functionality where the overview bar is turned off during scraping unless this opt-in comment is included in a given code block. Finding the right places to include it might be a lot of work, but it's one way to go if someone is motivated at some point.