### PR TITLE
MRG: Fix passing of argument theme for raw.plot()

### DIFF
--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -351,7 +351,8 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
                   bgcolor=bgcolor,
                   # Qt-specific
                   precompute=precompute,
-                  use_opengl=use_opengl)
+                  use_opengl=use_opengl,
+                  theme=theme)
 
     fig = _get_browser(show=show, block=block, **params)
 


### PR DESCRIPTION
Fix #10486 on my windows computer.
It probably also fixes it on my macOS (can't remember if I did set the config variable or not..), but I can't test until Monday. 