### PR TITLE
Set open/close browser log messages to debug

### DIFF
--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -67,7 +67,7 @@ class BrowserBase(ABC):
             raise TypeError('Expected an instance of Raw, Epochs, or ICA, '
                             f'got {type(inst)}.')
 
-        logger.info(f'Opening {self.mne.instance_type}-browser...')
+        logger.debug(f'Opening {self.mne.instance_type} browser...')
 
         self.mne.ica_type = None
         if self.mne.instance_type == 'ica':
@@ -394,7 +394,7 @@ class BrowserBase(ABC):
 
     def _close(self, event):
         """Handle close events (via keypress or window [x])."""
-        logger.info(f'Closing {self.mne.instance_type}-browser...')
+        logger.debug(f'Closing {self.mne.instance_type} browser...')
         # write out bad epochs (after converting epoch numbers to indices)
         if self.mne.instance_type == 'epochs':
             bad_ixs = np.in1d(self.mne.inst.selection,


### PR DESCRIPTION
I don't think that the messages currently logged at the info level related to opening and closing a raw/epochs browser are really informative for users. If at all, they should be demoted to debug level messages, which is what I've done here.