### PR TITLE
MAINT: Standardize tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,7 +111,7 @@ stages:
     - bash: |
         set -e
         python -m pip install --progress-bar off --upgrade pip setuptools wheel codecov
-        python -m pip install --progress-bar off mne-qt-browser[opengl] vtk
+        python -m pip install --progress-bar off mne-qt-browser[opengl] vtk scikit-learn
         python -m pip uninstall -yq mne
         python -m pip install --progress-bar off --upgrade -e .[test]
       displayName: 'Install dependencies with pip'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,7 +111,7 @@ stages:
     - bash: |
         set -e
         python -m pip install --progress-bar off --upgrade pip setuptools wheel codecov
-        python -m pip install --progress-bar off mne-qt-browser[opengl] vtk scikit-learn pytest-error-for-skips
+        python -m pip install --progress-bar off mne-qt-browser[opengl] vtk scikit-learn pytest-error-for-skips python-picard
         python -m pip uninstall -yq mne
         python -m pip install --progress-bar off --upgrade -e .[test]
       displayName: 'Install dependencies with pip'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,7 +111,7 @@ stages:
     - bash: |
         set -e
         python -m pip install --progress-bar off --upgrade pip setuptools wheel codecov
-        python -m pip install --progress-bar off mne-qt-browser[opengl] vtk scikit-learn
+        python -m pip install --progress-bar off mne-qt-browser[opengl] vtk scikit-learn pytest-error-for-skips
         python -m pip uninstall -yq mne
         python -m pip install --progress-bar off --upgrade -e .[test]
       displayName: 'Install dependencies with pip'
@@ -126,7 +126,7 @@ stages:
       displayName: 'Cache testing data'
     - script: python -c "import mne; mne.datasets.testing.data_path(verbose=True)"
       displayName: 'Get test data'
-    - script: pytest -m "ultraslowtest or pgtest" --tb=short --cov=mne --cov-report=xml --cov-report=html -vv mne
+    - script: pytest --error-for-skips -m "ultraslowtest or pgtest" --tb=short --cov=mne --cov-report=xml --cov-report=html -vv mne
       displayName: 'slow and mne-qt-browser tests'
     # Coverage
     - bash: bash <(curl -s https://codecov.io/bash)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,7 @@ stages:
       displayName: 'Test minimal commands'
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.8'
+        versionSpec: '3.9'
         architecture: 'x64'
         addToPath: true
       displayName: 'Get Python'
@@ -111,7 +111,7 @@ stages:
     - bash: |
         set -e
         python -m pip install --progress-bar off --upgrade pip setuptools wheel codecov
-        python -m pip install --progress-bar off mne-qt-browser[opengl]
+        python -m pip install --progress-bar off mne-qt-browser[opengl] vtk
         python -m pip uninstall -yq mne
         python -m pip install --progress-bar off --upgrade -e .[test]
       displayName: 'Install dependencies with pip'

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -38,6 +38,7 @@ fname_fwd_vol = op.join(data_path, 'MEG', 'sample',
 fname_event = op.join(data_path, 'MEG', 'sample',
                       'sample_audvis_trunc_raw-eve.fif')
 fname_label = op.join(data_path, 'MEG', 'sample', 'labels', 'Aud-lh.label')
+ctf_fname = op.join(data_path, 'CTF', 'somMDYO-18av.ds')
 
 reject = dict(grad=4000e-13, mag=4e-12)
 
@@ -523,9 +524,7 @@ def test_lcmv_cov(weight_norm, pick_ori):
 @testing.requires_testing_data
 def test_lcmv_ctf_comp():
     """Test interpolation with compensated CTF data."""
-    ctf_dir = op.join(testing.data_path(download=False), 'CTF')
-    raw_fname = op.join(ctf_dir, 'somMDYO-18av.ds')
-    raw = mne.io.read_raw_ctf(raw_fname, preload=True)
+    raw = mne.io.read_raw_ctf(ctf_fname, preload=True)
     raw.pick(raw.ch_names[:70])
 
     events = mne.make_fixed_length_events(raw, duration=0.2)[:2]

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -307,8 +307,6 @@ def test_1020_selection():
 @testing.requires_testing_data
 def test_find_ch_adjacency():
     """Test computing the adjacency matrix."""
-    data_path = testing.data_path()
-
     raw = read_raw_fif(raw_fname, preload=True)
     sizes = {'mag': 828, 'grad': 1700, 'eeg': 384}
     nchans = {'mag': 102, 'grad': 204, 'eeg': 60}
@@ -327,13 +325,13 @@ def test_find_ch_adjacency():
     raw.pick_types(meg='mag')
     find_ch_adjacency(raw.info, None)
 
-    bti_fname = op.join(data_path, 'BTi', 'erm_HFH', 'c,rfDC')
-    bti_config_name = op.join(data_path, 'BTi', 'erm_HFH', 'config')
+    bti_fname = op.join(testing_path, 'BTi', 'erm_HFH', 'c,rfDC')
+    bti_config_name = op.join(testing_path, 'BTi', 'erm_HFH', 'config')
     raw = read_raw_bti(bti_fname, bti_config_name, None)
     _, ch_names = find_ch_adjacency(raw.info, 'mag')
     assert 'A1' in ch_names
 
-    ctf_fname = op.join(data_path, 'CTF', 'testdata_ctf_short.ds')
+    ctf_fname = op.join(testing_path, 'CTF', 'testdata_ctf_short.ds')
     raw = read_raw_ctf(ctf_fname)
     _, ch_names = find_ch_adjacency(raw.info, 'mag')
     assert 'MLC11' in ch_names
@@ -349,7 +347,7 @@ def test_find_ch_adjacency():
 @testing.requires_testing_data
 def test_neuromag122_adjacency():
     """Test computing the adjacency matrix of Neuromag122-Data."""
-    nm122_fname = op.join(testing.data_path(), 'misc',
+    nm122_fname = op.join(testing_path, 'misc',
                           'neuromag122_test_file-raw.fif')
     raw = read_raw_fif(nm122_fname, preload=True)
     conn, ch_names = find_ch_adjacency(raw.info, 'grad')

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -32,6 +32,8 @@ raw_fname = op.join(base_dir, 'test_raw.fif')
 eve_fname = op.join(base_dir, 'test-eve.fif')
 fname_kit_157 = op.join(io_dir, 'kit', 'tests', 'data', 'test.sqd')
 
+testing_path = testing.data_path(download=False)
+
 
 @pytest.mark.parametrize('preload', (True, False))
 @pytest.mark.parametrize('proj', (True, False))
@@ -277,9 +279,8 @@ def test_get_set_sensor_positions():
 @testing.requires_testing_data
 def test_1020_selection():
     """Test making a 10/20 selection dict."""
-    base_dir = op.join(testing.data_path(download=False), 'EEGLAB')
-    raw_fname = op.join(base_dir, 'test_raw.set')
-    loc_fname = op.join(base_dir, 'test_chans.locs')
+    raw_fname = op.join(testing_path, 'EEGLAB', 'test_raw.set')
+    loc_fname = op.join(testing_path, 'EEGLAB', 'test_chans.locs')
     raw = read_raw_eeglab(raw_fname, preload=True)
     montage = read_custom_montage(loc_fname)
     raw = raw.rename_channels(dict(zip(raw.ch_names, montage.ch_names)))

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -10,7 +10,6 @@ from mne.channels.interpolation import _make_interpolation_matrix
 from mne.datasets import testing
 from mne.preprocessing.nirs import (optical_density, scalp_coupling_index,
                                     beer_lambert_law)
-from mne.datasets.testing import data_path
 from mne.io import read_raw_nirx
 from mne.io.proj import _has_eeg_average_ref_proj
 from mne.utils import _record_warnings, requires_version
@@ -19,6 +18,8 @@ base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
 event_name = op.join(base_dir, 'test-eve.fif')
 raw_fname_ctf = op.join(base_dir, 'test_ctf_raw.fif')
+
+testing_path = testing.data_path(download=False)
 
 event_id, tmin, tmax = 1, -0.2, 0.5
 event_id_2 = 2
@@ -273,8 +274,7 @@ def test_interpolate_meg_ctf():
 @testing.requires_testing_data
 def test_interpolation_ctf_comp():
     """Test interpolation with compensated CTF data."""
-    ctf_dir = op.join(testing.data_path(download=False), 'CTF')
-    raw_fname = op.join(ctf_dir, 'somMDYO-18av.ds')
+    raw_fname = op.join(testing_path, 'CTF', 'somMDYO-18av.ds')
     raw = io.read_raw_ctf(raw_fname, preload=True)
     raw.info['bads'] = [raw.ch_names[5], raw.ch_names[-5]]
     raw.interpolate_bads(mode='fast', origin=(0., 0., 0.04))
@@ -285,7 +285,7 @@ def test_interpolation_ctf_comp():
 @testing.requires_testing_data
 def test_interpolation_nirs():
     """Test interpolating bad nirs channels."""
-    fname = op.join(data_path(download=False),
+    fname = op.join(testing_path,
                     'NIRx', 'nirscout', 'nirx_15_2_recording_w_overlap')
     raw_intensity = read_raw_nirx(fname, preload=False)
     raw_od = optical_density(raw_intensity)

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -29,7 +29,10 @@ from mne.utils import (requires_mne, requires_vtk, requires_freesurfer,
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
 raw_fname = op.join(base_dir, 'test_raw.fif')
 
-subjects_dir = op.join(testing.data_path(download=False), 'subjects')
+testing_path = testing.data_path(download=False)
+subjects_dir = op.join(testing_path, 'subjects')
+bem_model_fname = op.join(testing_path, 'subjects',
+                          'sample', 'bem', 'sample-320-320-320-bem.fif')
 
 
 def check_usage(module, force_help=False):
@@ -305,7 +308,6 @@ def test_setup_source_space(tmp_path):
     """Test mne setup_source_space."""
     check_usage(mne_setup_source_space, force_help=True)
     # Using the sample dataset
-    subjects_dir = op.join(testing.data_path(download=False), 'subjects')
     use_fname = op.join(tmp_path, "sources-src.fif")
     # Test  command
     with ArgvSetter(('--src', use_fname, '-d', subjects_dir,
@@ -335,7 +337,6 @@ def test_setup_forward_model(tmp_path):
     """Test mne setup_forward_model."""
     check_usage(mne_setup_forward_model, force_help=True)
     # Using the sample dataset
-    subjects_dir = op.join(testing.data_path(download=False), 'subjects')
     use_fname = op.join(tmp_path, "model-bem.fif")
     # Test  command
     with ArgvSetter(('--model', use_fname, '-d', subjects_dir, '--homog',
@@ -353,8 +354,6 @@ def test_mne_prepare_bem_model(tmp_path):
     """Test mne setup_source_space."""
     check_usage(mne_prepare_bem_model, force_help=True)
     # Using the sample dataset
-    bem_model_fname = op.join(testing.data_path(download=False), 'subjects',
-                              'sample', 'bem', 'sample-320-320-320-bem.fif')
     bem_solution_fname = op.join(tmp_path, "bem_solution-bem-sol.fif")
     # Test  command
     with ArgvSetter(('--bem', bem_model_fname, '--sol', bem_solution_fname,

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -131,7 +131,8 @@ def test_kit2fiff():
     check_usage(mne_kit2fiff, force_help=True)
 
 
-@pytest.mark.slowtest  # slow on Travis OSX
+@pytest.mark.slowtest
+@pytest.mark.ultraslowtest
 @requires_vtk
 @testing.requires_testing_data
 def test_make_scalp_surfaces(tmp_path, monkeypatch):

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -703,12 +703,11 @@ def options_3d():
         yield
 
 
-@pytest.fixture(scope='session')
-def protect_config():
+@pytest.fixture()
+def protect_config(tmp_path, monkeypatch):
     """Protect ~/.mne."""
-    temp = _TempDir()
-    with mock.patch.dict(os.environ, {"_MNE_FAKE_HOME_DIR": temp}):
-        yield
+    monkeypatch.setenv("_MNE_FAKE_HOME_DIR", str(tmp_path))
+    yield
 
 
 @pytest.fixture()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -26,7 +26,7 @@ from mne.fixes import has_numba, _compare_version
 from mne.io import read_raw_fif, read_raw_ctf
 from mne.stats import cluster_level
 from mne.utils import (_pl, _assert_no_instances, numerics, Bunch,
-                       _check_qt_version, _TempDir)
+                       _check_qt_version)
 
 # data from sample dataset
 from mne.viz._figure import use_browser_backend

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -703,11 +703,12 @@ def options_3d():
         yield
 
 
-@pytest.fixture()
-def protect_config(tmp_path, monkeypatch):
+@pytest.fixture(scope='session')
+def protect_config():
     """Protect ~/.mne."""
-    monkeypatch.setenv("_MNE_FAKE_HOME_DIR", str(tmp_path))
-    yield
+    temp = _TempDir()
+    with mock.patch.dict(os.environ, {"_MNE_FAKE_HOME_DIR": temp}):
+        yield
 
 
 @pytest.fixture()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -26,7 +26,7 @@ from mne.fixes import has_numba, _compare_version
 from mne.io import read_raw_fif, read_raw_ctf
 from mne.stats import cluster_level
 from mne.utils import (_pl, _assert_no_instances, numerics, Bunch,
-                       _check_qt_version)
+                       _check_qt_version, _TempDir)
 
 # data from sample dataset
 from mne.viz._figure import use_browser_backend

--- a/mne/datasets/misc/__init__.py
+++ b/mne/datasets/misc/__init__.py
@@ -1,3 +1,3 @@
 """MNE misc dataset."""
 
-from ._misc import data_path
+from ._misc import data_path, _pytest_mark

--- a/mne/datasets/misc/_misc.py
+++ b/mne/datasets/misc/_misc.py
@@ -4,7 +4,7 @@
 # License: BSD Style.
 
 from ...utils import verbose
-from ..utils import _data_path_doc, _download_mne_dataset
+from ..utils import has_dataset, _data_path_doc, _download_mne_dataset
 
 
 @verbose
@@ -14,6 +14,12 @@ def data_path(path=None, force_update=False, update_path=True,
         name='misc', processor='untar', path=path,
         force_update=force_update, update_path=update_path,
         download=download)
+
+
+def _pytest_mark():
+    import pytest
+    return pytest.mark.skipif(
+        not has_dataset(name='misc'), reason='Requires misc dataset')
 
 
 data_path.__doc__ = _data_path_doc.format(name='misc',

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -29,6 +29,7 @@ fname_evoked = op.join(base_dir, 'test-ave.fif')
 
 data_path = testing.data_path(download=False)
 egi_evoked_fname = op.join(data_path, 'EGI', 'test_egi_evoked.mff')
+misc_path = misc.data_path(download=False)
 
 
 @requires_version('pymatreader')
@@ -240,7 +241,8 @@ def test_rawarray_edf(tmp_path):
 @pytest.mark.parametrize(
     ['dataset', 'format'], [
         ['test', 'edf'],
-        pytest.param('misc', 'edf', marks=pytest.mark.slowtest),
+        pytest.param('misc', 'edf', marks=[pytest.mark.slowtest,
+                                           misc._pytest_mark()]),
     ])
 def test_export_raw_edf(tmp_path, dataset, format):
     """Test saving a Raw instance to EDF format."""
@@ -248,7 +250,7 @@ def test_export_raw_edf(tmp_path, dataset, format):
         fname = _resource_path('mne.io.tests.data', 'test_raw.fif')
         raw = read_raw_fif(fname)
     elif dataset == 'misc':
-        fname = op.join(misc.data_path(), 'ecog', 'sample_ecog_ieeg.fif')
+        fname = op.join(misc_path, 'ecog', 'sample_ecog_ieeg.fif')
         raw = read_raw_fif(fname)
 
     # only test with EEG channels

--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -146,7 +146,7 @@ def coregistration(tabbed=False, split=True, width=None, inst=None,
         if val is not None:
             warn(f'{key} is deprecated and will be removed in 1.1.',
                  DeprecationWarning)
-    config = get_config(home_dir=os.environ.get('_MNE_FAKE_HOME_DIR'))
+    config = get_config()
     if guess_mri_subject is None:
         guess_mri_subject = config.get(
             'MNE_COREG_GUESS_MRI_SUBJECT', 'true') == 'true'

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -282,6 +282,6 @@ def test_coreg_gui_notebook(renderer_notebook, nbexec):
     from mne.datasets import testing
     from mne.gui import coregistration
     mne.viz.set_3d_backend('notebook')  # set the 3d backend
-    data_path = testing.data_path()
+    data_path = testing.data_path(download=False)
     subjects_dir = os.path.join(data_path, 'subjects')
     coregistration(subject='sample', subjects_dir=subjects_dir)

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -282,6 +282,7 @@ def test_coreg_gui_notebook(renderer_notebook, nbexec):
     from mne.datasets import testing
     from mne.gui import coregistration
     mne.viz.set_3d_backend('notebook')  # set the 3d backend
-    data_path = testing.data_path(download=False)
+    with mne.utils.modified_env(_MNE_FAKE_HOME_DIR=None):
+        data_path = testing.data_path(download=False)
     subjects_dir = os.path.join(data_path, 'subjects')
     coregistration(subject='sample', subjects_dir=subjects_dir)

--- a/mne/gui/tests/test_coreg_gui.py
+++ b/mne/gui/tests/test_coreg_gui.py
@@ -2,7 +2,6 @@
 #
 # License: BSD-3-Clause
 
-import os
 import os.path as op
 
 import pytest
@@ -106,7 +105,7 @@ def test_coreg_gui_pyvista_basic(tmp_path, renderer_interactive_pyvistaqt,
     """Test that using CoregistrationUI matches mne coreg."""
     from mne.gui import coregistration
     from mne.gui._coreg import CoregistrationUI
-    config = get_config(home_dir=os.environ.get('_MNE_FAKE_HOME_DIR'))
+    config = get_config()
     # the sample subject in testing has MRI fids
     assert op.isfile(op.join(
         subjects_dir, 'sample', 'bem', 'sample-fiducials.fif'))

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -37,6 +37,7 @@ somato_fname = op.join(
     brainstorm.bst_raw.data_path(download=False), 'MEG', 'bst_raw',
     'subj001_somatosensory_20111109_01_AUX-f.ds'
 )
+spm_path = spm_face.data_path(download=False)
 
 block_sizes = {
     ctf_fname_continuous: 12000,
@@ -269,8 +270,7 @@ def test_rawctf_clean_names():
 @spm_face.requires_spm_data
 def test_read_spm_ctf():
     """Test CTF reader with omitted samples."""
-    data_path = spm_face.data_path()
-    raw_fname = op.join(data_path, 'MEG', 'spm',
+    raw_fname = op.join(spm_path, 'MEG', 'spm',
                         'SPM_CTF_MEG_example_faces1_3D.ds')
     raw = read_raw_ctf(raw_fname)
     extras = raw._raw_extras[0]

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -333,7 +333,6 @@ def test_eeglab_read_annotations():
 @testing.requires_testing_data
 def test_eeglab_event_from_annot():
     """Test all forms of obtaining annotations."""
-    base_dir = op.join(testing.data_path(download=False), 'EEGLAB')
     raw_fname_mat = op.join(base_dir, 'test_raw.set')
     raw_fname = raw_fname_mat
     event_id = {'rt': 1, 'square': 2}

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -25,7 +25,8 @@ from mne.datasets.testing import data_path, requires_testing_data
 base_dir = op.join(op.dirname(op.abspath(__file__)), 'data')
 egi_fname = op.join(base_dir, 'test_egi.raw')
 egi_txt_fname = op.join(base_dir, 'test_egi.txt')
-egi_path = op.join(data_path(download=False), 'EGI')
+testing_path = data_path(download=False)
+egi_path = op.join(testing_path, 'EGI')
 egi_mff_fname = op.join(egi_path, 'test_egi.mff')
 egi_mff_pns_fname = op.join(egi_path, 'test_egi_pns.mff')
 egi_pause_fname = op.join(egi_path, 'test_egi_multiepoch_paused.mff')
@@ -257,7 +258,7 @@ def test_io_egi_pns_mff(tmp_path):
         'Resp_Effort_Abdomen',
         'EMGLeg'
     ]
-    egi_fname_mat = op.join(data_path(), 'EGI', 'test_egi_pns.mat')
+    egi_fname_mat = op.join(testing_path, 'EGI', 'test_egi_pns.mat')
     mc = sio.loadmat(egi_fname_mat)
     for ch_name, ch_idx, mat_name in zip(pns_names, pns_chans, mat_names):
         print('Testing {}'.format(ch_name))
@@ -281,14 +282,14 @@ def test_io_egi_pns_mff(tmp_path):
 @pytest.mark.parametrize('preload', (True, False))
 def test_io_egi_pns_mff_bug(preload):
     """Test importing EGI MFF with PNS data (BUG)."""
-    egi_fname_mff = op.join(data_path(), 'EGI', 'test_egi_pns_bug.mff')
+    egi_fname_mff = op.join(testing_path, 'EGI', 'test_egi_pns_bug.mff')
     with pytest.warns(RuntimeWarning, match='EGI PSG sample bug'):
         raw = read_raw_egi(egi_fname_mff, include=None, preload=preload,
                            verbose='warning')
     assert len(raw.annotations) == 1
     assert_allclose(raw.annotations.duration, [0.004])
     assert_allclose(raw.annotations.onset, [13.948])
-    egi_fname_mat = op.join(data_path(), 'EGI', 'test_egi_pns.mat')
+    egi_fname_mat = op.join(testing_path, 'EGI', 'test_egi_pns.mat')
     mc = sio.loadmat(egi_fname_mat)
     pns_chans = pick_types(raw.info, ecg=True, bio=True, emg=True)
     pns_names = ['Resp. Temperature'[:15],
@@ -321,11 +322,10 @@ def test_io_egi_pns_mff_bug(preload):
 @requires_testing_data
 def test_io_egi_crop_no_preload():
     """Test crop non-preloaded EGI MFF data (BUG)."""
-    egi_fname_mff = op.join(data_path(), 'EGI', 'test_egi.mff')
-    raw = read_raw_egi(egi_fname_mff, preload=False)
+    raw = read_raw_egi(egi_mff_fname, preload=False)
     raw.crop(17.5, 20.5)
     raw.load_data()
-    raw_preload = read_raw_egi(egi_fname_mff, preload=True)
+    raw_preload = read_raw_egi(egi_mff_fname, preload=True)
     raw_preload.crop(17.5, 20.5)
     raw_preload.load_data()
     assert_allclose(raw._data, raw_preload._data)

--- a/mne/io/eximia/tests/test_eximia.py
+++ b/mne/io/eximia/tests/test_eximia.py
@@ -10,17 +10,19 @@ from mne.io import read_raw_eximia
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.datasets.testing import data_path, requires_testing_data
 
+testing_path = data_path(download=False)
+
 
 @requires_testing_data
 def test_eximia_nxe():
     """Test reading Eximia NXE files."""
-    fname = op.join(data_path(), 'eximia', 'test_eximia.nxe')
+    fname = op.join(testing_path, 'eximia', 'test_eximia.nxe')
     raw = read_raw_eximia(fname, preload=True)
     assert 'RawEximia' in repr(raw)
     _test_raw_reader(read_raw_eximia, fname=fname,
                      test_scaling=False,  # XXX probably a scaling problem
                      )
-    fname_mat = op.join(data_path(), 'eximia', 'test_eximia.mat')
+    fname_mat = op.join(testing_path, 'eximia', 'test_eximia.mat')
     mc = sio.loadmat(fname_mat)
     m_data = mc['data']
     m_header = mc['header']

--- a/mne/io/fieldtrip/tests/helpers.py
+++ b/mne/io/fieldtrip/tests/helpers.py
@@ -47,6 +47,8 @@ pandas_not_found_warning_msg = 'The Pandas library is not installed. Not ' \
                                'returning the original trialinfo matrix as ' \
                                'metadata.'
 
+testing_path = mne.datasets.testing.data_path(download=False)
+
 
 def _remove_ignored_ch_fields(info):
     if 'chs' in info:
@@ -84,10 +86,7 @@ def _remove_bad_dig_fields(info):
 
 def get_data_paths(system):
     """Return common paths for all tests."""
-    test_data_folder_ft = os.path.join(mne.datasets.testing.data_path(),
-                                       'fieldtrip/ft_test_data', system)
-
-    return test_data_folder_ft
+    return testing_path / 'fieldtrip' / 'ft_test_data' / system
 
 
 def get_cfg_local(system):
@@ -103,8 +102,7 @@ def get_raw_info(system):
     """Return the info dict of the raw data."""
     cfg_local = get_cfg_local(system)
 
-    raw_data_file = os.path.join(mne.datasets.testing.data_path(),
-                                 cfg_local['file_name'])
+    raw_data_file = os.path.join(testing_path, cfg_local['file_name'])
     reader_function = system_to_reader_fn_dict[system]
 
     info = reader_function(raw_data_file, preload=False).info
@@ -117,8 +115,7 @@ def get_raw_data(system, drop_extra_chs=False):
     """Find, load and process the raw data."""
     cfg_local = get_cfg_local(system)
 
-    raw_data_file = os.path.join(mne.datasets.testing.data_path(),
-                                 cfg_local['file_name'])
+    raw_data_file = os.path.join(testing_path, cfg_local['file_name'])
     reader_function = system_to_reader_fn_dict[system]
 
     raw_data = reader_function(raw_data_file, preload=True)

--- a/mne/io/fieldtrip/tests/test_fieldtrip.py
+++ b/mne/io/fieldtrip/tests/test_fieldtrip.py
@@ -47,6 +47,7 @@ no_info_warning = {'expected_warning': RuntimeWarning,
                    'match': NOINFO_WARNING}
 
 pymatreader = pytest.importorskip('pymatreader')  # module-level
+testing_path = mne.datasets.testing.data_path(download=False)
 
 
 @pytest.mark.slowtest
@@ -233,7 +234,7 @@ def test_create_events():
 @pytest.mark.parametrize('version', all_versions)
 def test_one_channel_elec_bug(version):
     """Test if loading data having only one elec in the elec field works."""
-    fname = os.path.join(mne.datasets.testing.data_path(), 'fieldtrip',
+    fname = os.path.join(testing_path, 'fieldtrip',
                          'one_channel_elec_bug_data_%s.mat' % (version, ))
 
     with pytest.warns(**no_info_warning):
@@ -287,9 +288,7 @@ def test_with_missing_channels():
 @pytest.mark.filterwarnings('ignore: Cannot guess the correct type')
 def test_throw_error_on_non_uniform_time_field():
     """Test if an error is thrown when time fields are not uniform."""
-    fname = os.path.join(mne.datasets.testing.data_path(),
-                         'fieldtrip',
-                         'not_uniform_time.mat')
+    fname = os.path.join(testing_path, 'fieldtrip', 'not_uniform_time.mat')
 
     with pytest.raises(RuntimeError, match='Loading data with non-uniform '
                                            'times per epoch is not supported'):
@@ -300,9 +299,7 @@ def test_throw_error_on_non_uniform_time_field():
 @pytest.mark.filterwarnings('ignore: Importing FieldTrip data without an info')
 def test_throw_error_when_importing_old_ft_version_data():
     """Test if an error is thrown if the data was saved with an old version."""
-    fname = os.path.join(mne.datasets.testing.data_path(),
-                         'fieldtrip',
-                         'old_version.mat')
+    fname = os.path.join(testing_path, 'fieldtrip', 'old_version.mat')
 
     with pytest.raises(RuntimeError, match='This file was created with '
                                            'an old version of FieldTrip. You '

--- a/mne/io/nihon/tests/test_nihon.py
+++ b/mne/io/nihon/tests/test_nihon.py
@@ -1,27 +1,28 @@
 # -*- coding: utf-8 -*-
 # Authors: Federico Raimondo  <federaimondo@gmail.com>
 #          simplified BSD-3 license
-from pathlib import Path
 
 import pytest
 from numpy.testing import assert_array_almost_equal
 
 from mne.io import read_raw_nihon, read_raw_edf
 from mne.io.tests.test_raw import _test_raw_reader
-from mne.datasets.testing import data_path, requires_testing_data
+from mne.datasets import testing
 from mne.io.nihon.nihon import (_read_nihon_header, _read_nihon_metadata,
                                 _read_nihon_annotations)
 from mne.io.nihon import nihon
 
+data_path = testing.data_path(download=False)
 
-@requires_testing_data
+
+@testing.requires_testing_data
 def test_nihon_eeg():
     """Test reading Nihon Kohden EEG files."""
-    fname = Path(data_path()) / 'NihonKohden' / 'MB0400FU.EEG'
+    fname = data_path / 'NihonKohden' / 'MB0400FU.EEG'
     raw = read_raw_nihon(fname.as_posix(), preload=True)
     assert 'RawNihon' in repr(raw)
     _test_raw_reader(read_raw_nihon, fname=fname, test_scaling=False)
-    fname_edf = Path(data_path()) / 'NihonKohden' / 'MB0400FU.EDF'
+    fname_edf = data_path / 'NihonKohden' / 'MB0400FU.EDF'
     raw_edf = read_raw_edf(fname_edf, preload=True)
 
     assert raw._data.shape == raw_edf._data.shape
@@ -49,7 +50,7 @@ def test_nihon_eeg():
     with pytest.raises(ValueError, match='Not a valid Nihon Kohden EEG file'):
         raw = _read_nihon_header(fname_edf)
 
-    bad_fname = Path(data_path()) / 'eximia' / 'text_eximia.nxe'
+    bad_fname = data_path / 'eximia' / 'text_eximia.nxe'
 
     msg = 'No PNT file exists. Metadata will be blank'
     with pytest.warns(RuntimeWarning, match=msg):
@@ -70,10 +71,10 @@ def test_nihon_eeg():
     assert all(ch == 'misc' for ch in ch_types)
 
 
-@requires_testing_data
+@testing.requires_testing_data
 def test_nihon_duplicate_channels(monkeypatch):
     """Test deduplication of channel names."""
-    fname = Path(data_path()) / 'NihonKohden' / 'MB0400FU.EEG'
+    fname = data_path / 'NihonKohden' / 'MB0400FU.EEG'
 
     def return_channel_duplicates(fname):
         ch_names = nihon._default_chan_labels

--- a/mne/io/persyst/tests/test_persyst.py
+++ b/mne/io/persyst/tests/test_persyst.py
@@ -15,11 +15,12 @@ from mne.datasets.testing import data_path, requires_testing_data
 from mne.io import read_raw_persyst
 from mne.io.tests.test_raw import _test_raw_reader
 
+testing_path = data_path(download=False)
 fname_lay = op.join(
-    data_path(download=False), 'Persyst',
+    testing_path, 'Persyst',
     'sub-pt1_ses-02_task-monitor_acq-ecog_run-01_clip2.lay')
 fname_dat = op.join(
-    data_path(download=False), 'Persyst',
+    testing_path, 'Persyst',
     'sub-pt1_ses-02_task-monitor_acq-ecog_run-01_clip2.dat')
 
 

--- a/mne/preprocessing/nirs/tests/test_beer_lambert_law.py
+++ b/mne/preprocessing/nirs/tests/test_beer_lambert_law.py
@@ -15,11 +15,12 @@ from mne.preprocessing.nirs import optical_density, beer_lambert_law
 from mne.utils import _validate_type, requires_version
 from mne.datasets import testing
 
-fname_nirx_15_0 = op.join(data_path(download=False),
+testing_path = data_path(download=False)
+fname_nirx_15_0 = op.join(testing_path,
                           'NIRx', 'nirscout', 'nirx_15_0_recording')
-fname_nirx_15_2 = op.join(data_path(download=False),
+fname_nirx_15_2 = op.join(testing_path,
                           'NIRx', 'nirscout', 'nirx_15_2_recording')
-fname_nirx_15_2_short = op.join(data_path(download=False),
+fname_nirx_15_2_short = op.join(testing_path,
                                 'NIRx', 'nirscout',
                                 'nirx_15_2_recording_w_short')
 
@@ -82,7 +83,7 @@ def test_beer_lambert_v_matlab():
     raw = beer_lambert_law(raw, ppf=0.121)
     raw._data *= 1e6  # Scale to uM for comparison to MATLAB
 
-    matlab_fname = op.join(data_path(download=False),
+    matlab_fname = op.join(testing_path,
                            'NIRx', 'nirscout', 'validation',
                            'nirx_15_0_recording_bl.mat')
     matlab_data = read_mat(matlab_fname)

--- a/mne/preprocessing/tests/test_eeglab_infomax.py
+++ b/mne/preprocessing/tests/test_eeglab_infomax.py
@@ -14,11 +14,12 @@ from mne.utils import random_permutation
 from mne.datasets import testing
 
 base_dir = op.join(op.dirname(__file__), 'data')
+testing_path = testing.data_path(download=False)
 
 
 def generate_data_for_comparing_against_eeglab_infomax(ch_type, random_state):
     """Generate data."""
-    data_dir = op.join(testing.data_path(download=False), 'MEG', 'sample')
+    data_dir = op.join(testing_path, 'MEG', 'sample')
     raw_fname = op.join(data_dir, 'sample_audvis_trunc_raw.fif')
 
     raw = read_raw_fif(raw_fname, preload=True)

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -487,10 +487,7 @@ def test_maxwell_filter_additional(tmp_path):
     # TODO: Future tests integrate with mne/io/tests/test_proc_history
 
     # Load testing data (raw, SSS std origin, SSS non-standard origin)
-    data_path = op.join(testing.data_path(download=False))
-
     file_name = 'test_move_anon'
-
     raw_fname = op.join(data_path, 'SSS', file_name + '_raw.fif')
 
     # Use 2.0 seconds of data to get stable cov. estimate

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -73,7 +73,7 @@ def test_scale_mri(tmp_path, few_surfaces, scale):
     # create fsaverage using the testing "fsaverage" instead of the FreeSurfer
     # one
     tempdir = str(tmp_path)
-    fake_home = testing.data_path()
+    fake_home = data_path
     create_default_subject(subjects_dir=tempdir, fs_home=fake_home,
                            verbose=True)
     assert _is_mri_subject('fsaverage', tempdir), "Creating fsaverage failed"
@@ -86,7 +86,7 @@ def test_scale_mri(tmp_path, few_surfaces, scale):
 
     # copy MRI file from sample data (shouldn't matter that it's incorrect,
     # so here choose a small one)
-    path_from = op.join(testing.data_path(), 'subjects', 'sample', 'mri',
+    path_from = op.join(fake_home, 'subjects', 'sample', 'mri',
                         'T1.mgz')
     path_to = op.join(tempdir, 'fsaverage', 'mri', 'orig.mgz')
     copyfile(path_from, path_to)
@@ -171,7 +171,7 @@ def test_scale_mri_xfm(tmp_path, few_surfaces):
     """Test scale_mri transforms and MRI scaling."""
     # scale fsaverage
     tempdir = str(tmp_path)
-    fake_home = testing.data_path()
+    fake_home = data_path
     # add fsaverage
     create_default_subject(subjects_dir=tempdir, fs_home=fake_home,
                            verbose=True)

--- a/mne/viz/_brain/tests/test_notebook.py
+++ b/mne/viz/_brain/tests/test_notebook.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.skipif(
 def test_notebook_alignment(renderer_notebook, brain_gc, nbexec):
     """Test plot alignment in a notebook."""
     import mne
-    data_path = mne.datasets.testing.data_path()
+    data_path = mne.datasets.testing.data_path(download=False)
     raw_fname = data_path / 'MEG' / 'sample' / 'sample_audvis_trunc_raw.fif'
     subjects_dir = data_path / 'subjects'
     subject = 'sample'
@@ -46,7 +46,7 @@ def test_notebook_interactive(renderer_notebook, brain_gc, nbexec):
     import matplotlib.pyplot as plt
     import mne
     from mne.datasets import testing
-    data_path = testing.data_path()
+    data_path = testing.data_path(download=False)
     sample_dir = os.path.join(data_path, 'MEG', 'sample')
     subjects_dir = os.path.join(data_path, 'subjects')
     fname_stc = os.path.join(sample_dir, 'sample_audvis_trunc-meg')

--- a/mne/viz/_brain/tests/test_notebook.py
+++ b/mne/viz/_brain/tests/test_notebook.py
@@ -20,7 +20,8 @@ pytestmark = pytest.mark.skipif(
 def test_notebook_alignment(renderer_notebook, brain_gc, nbexec):
     """Test plot alignment in a notebook."""
     import mne
-    data_path = mne.datasets.testing.data_path(download=False)
+    with mne.utils.modified_env(_MNE_FAKE_HOME_DIR=None):
+        data_path = mne.datasets.testing.data_path(download=False)
     raw_fname = data_path / 'MEG' / 'sample' / 'sample_audvis_trunc_raw.fif'
     subjects_dir = data_path / 'subjects'
     subject = 'sample'
@@ -46,7 +47,8 @@ def test_notebook_interactive(renderer_notebook, brain_gc, nbexec):
     import matplotlib.pyplot as plt
     import mne
     from mne.datasets import testing
-    data_path = testing.data_path(download=False)
+    with mne.utils.modified_env(_MNE_FAKE_HOME_DIR=None):
+        data_path = testing.data_path(download=False)
     sample_dir = os.path.join(data_path, 'MEG', 'sample')
     subjects_dir = os.path.join(data_path, 'subjects')
     fname_stc = os.path.join(sample_dir, 'sample_audvis_trunc-meg')

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -198,8 +198,6 @@ def test_set_3d_backend_bad(monkeypatch, tmp_path):
     monkeypatch.setattr('mne.viz.backends.renderer._reload_backend', fail)
     monkeypatch.setattr(
         'mne.viz.backends.renderer.MNE_3D_BACKEND', None)
-    # avoid using the config
-    monkeypatch.setenv('_MNE_FAKE_HOME_DIR', str(tmp_path))
     match = 'Could not load any valid 3D.*\npyvistaqt: .*'
     assert get_3d_backend() is None
     with pytest.raises(RuntimeError, match=match):

--- a/mne/viz/conftest.py
+++ b/mne/viz/conftest.py
@@ -15,6 +15,10 @@ from mne.io import read_raw_nirx
 from mne.preprocessing.nirs import optical_density, beer_lambert_law
 
 
+fname_nirx = op.join(data_path(download=False),
+                     'NIRx', 'nirscout', 'nirx_15_2_recording_w_overlap')
+
+
 @pytest.fixture()
 def fnirs_evoked():
     """Create an fnirs evoked structure."""
@@ -33,9 +37,7 @@ def fnirs_evoked():
 @pytest.fixture(params=[_pytest_param()])
 def fnirs_epochs():
     """Create an fnirs epoch structure."""
-    fname = op.join(data_path(download=False),
-                    'NIRx', 'nirscout', 'nirx_15_2_recording_w_overlap')
-    raw_intensity = read_raw_nirx(fname, preload=False)
+    raw_intensity = read_raw_nirx(fname_nirx, preload=False)
     raw_od = optical_density(raw_intensity)
     raw_haemo = beer_lambert_law(raw_od, ppf=6.)
     evts, _ = events_from_annotations(raw_haemo, event_id={'1.0': 1})

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -167,7 +167,7 @@ def test_plot_epochs_keypresses(epochs_full, browser_backend):
     # test keys
     keys = ('pagedown', 'down', 'up', 'down', 'right', 'left', '-', '+', '=',
             'd', 'd', 'pageup', 'home', 'shift+right', 'end', 'shift+left',
-            'z', 'z', 's', 's', 'f11', '?', 'h', 'j', 'b')
+            'z', 'z', 's', 's', '?', 'h', 'j', 'b')
     for key in keys * 2:  # test twice → once in normal, once in butterfly view
         fig._fake_keypress(key)
     fig._fake_click([x, y], xform='data', button=3)  # remove vlines
@@ -364,9 +364,10 @@ def test_plot_epochs_ctf(raw_ctf, browser_backend):
 
     # test butterfly
     fig = epochs.plot(butterfly=True)
+    # leave fullscreen testing to Raw / _figure abstraction (too annoying here)
     keys = ('b', 'b', 'pagedown', 'down', 'up', 'down', 'right', 'left', '-',
             '+', '=', 'd', 'd', 'pageup', 'home', 'end', 'z', 'z', 's', 's',
-            'f11', '?', 'h', 'j')
+            '?', 'h', 'j')
     for key in keys:
         fig._fake_keypress(key)
     fig._fake_scroll(0.5, 0.5, -0.5)  # scroll down

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -38,6 +38,8 @@ cov_fname = op.join(base_dir, 'test-cov.fif')
 event_name = op.join(base_dir, 'test-eve.fif')
 event_id, tmin, tmax = 1, -0.1, 0.1
 
+ctf_fname = testing.data_path(download=False) / 'CTF' / 'testdata_ctf.ds'
+
 # Use a subset of channels for plotting speed
 # make sure we have a magnetometer and a pair of grad pairs for topomap.
 default_picks = (0, 1, 2, 3, 4, 6, 7, 61, 122, 183, 244, 305,
@@ -492,10 +494,7 @@ def test_plot_compare_evokeds_neuromag122():
 @testing.requires_testing_data
 def test_plot_ctf():
     """Test plotting of CTF evoked."""
-    ctf_dir = op.join(testing.data_path(download=False), 'CTF')
-    raw_fname = op.join(ctf_dir, 'testdata_ctf.ds')
-
-    raw = mne.io.read_raw_ctf(raw_fname, preload=True)
+    raw = mne.io.read_raw_ctf(ctf_fname, preload=True)
     events = np.array([[200, 0, 1]])
     event_id = 1
     tmin, tmax = -0.1, 0.5  # start and end of an epoch in sec.

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -411,8 +411,7 @@ def test_plot_instance_components(browser_backend):
     ica.exclude = [0]
     fig = ica.plot_sources(raw, title='Components')
     keys = ('home', 'home', 'end', 'down', 'up', 'right', 'left', '-', '+',
-            '=', 'd', 'd', 'pageup', 'pagedown', 'z', 'z', 's', 's', 'f11',
-            'b')
+            '=', 'd', 'd', 'pageup', 'pagedown', 'z', 'z', 's', 's', 'b')
     for key in keys:
         fig._fake_keypress(key)
     x = fig.mne.traces[0].get_xdata()[0]

--- a/tools/github_actions_download.sh
+++ b/tools/github_actions_download.sh
@@ -2,4 +2,5 @@
 
 if [ "${DEPS}" != "minimal" ]; then
 	python -c 'import mne; mne.datasets.testing.data_path(verbose=True)';
+	python -c "import mne; mne.datasets.misc.data_path(verbose=True)";
 fi


### PR DESCRIPTION
While working on https://github.com/mne-tools/mne-qt-browser/pull/105 I kept getting unexpected errors on CIs. The first time I ran the tests locally on my macOS machine, I could replicate the issue. The second time, however, I could not. I realized this was because the `MNE_BROWSE_RAW_SIZE` config var on my system was being overwritten (!). This PR fixes this by:

1. Setting the `_MNE_CONFIG_FAKE_HOME_DIR` at the `session` level to prevent overwriting people's config vars
2. Setting the `MNE_BROWSE_RAW_SIZE` to standardize browser sizes across all systems. This should make things more repeatable in testing across different people's systems (which could otherwise have different MNE_BROWSE_RAW_SIZE). In an ideal world, this value would not matter, but in practice our `_fake_click`s are not so well generalized to arbitrary window sizes.
3. Monkey-patching the native to-fullscreen methods for the two backends so that fullscreen mode is never called. This helps with testing on macOS a bit, where the fullscreen mode messes with focus a bit. (I think we can trust `mpl` and `Qt` to test their own fullscreen methods.)
4. Removing fullscreen keypress tests from epochs and ica, leaving for raw. Again I think we can trust our own abstraction here so we don't have to monkeypatch in three places.

 