### PR TITLE
ENH: Use HiDPI splash screen on HiDPI screens

### DIFF
--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -116,7 +116,7 @@ def _init_mne_qtapp(enable_icon=True, pg_app=False, splash=False):
         string.
     """
     from qtpy.QtCore import Qt
-    from qtpy.QtGui import QIcon, QPixmap
+    from qtpy.QtGui import QIcon, QPixmap, QGuiApplication
     from qtpy.QtWidgets import QApplication, QSplashScreen
     app_name = 'MNE-Python'
     organization_name = 'MNE'
@@ -154,8 +154,10 @@ def _init_mne_qtapp(enable_icon=True, pg_app=False, splash=False):
 
     out = app
     if splash:
-        qsplash = QSplashScreen(
-            QPixmap(f"{icons_path}/mne_splash.png"), Qt.WindowStaysOnTopHint)
+        pixmap = QPixmap(f"{icons_path}/mne_splash.png")
+        pixmap.setDevicePixelRatio(
+            QGuiApplication.primaryScreen().devicePixelRatio())
+        qsplash = QSplashScreen(pixmap, Qt.WindowStaysOnTopHint)
         if isinstance(splash, str):
             alignment = int(Qt.AlignBottom | Qt.AlignHCenter)
             qsplash.showMessage(


### PR DESCRIPTION
This makes the splash screen about half the size on macOS, but I think it still looks good. And this way, it's displayed in HiDPI mode, which I think looks better.

| main | PR |
| -- | -- |
| <img width="558" alt="Screen Shot 2022-04-07 at 6 17 42 PM" src="https://user-images.githubusercontent.com/2365790/162328676-a5a4eaa4-795c-4744-81d6-68c9f1d686f1.png"> | <img width="302" alt="Screen Shot 2022-04-07 at 6 16 49 PM" src="https://user-images.githubusercontent.com/2365790/162328692-1298aba0-d0f4-42e9-aaeb-df3533e7ab19.png"> |
 