### PR TITLE
MAINT: Dont use ABC

### DIFF
--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -6,7 +6,7 @@
 #
 # License: Simplified BSD
 import importlib
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from collections import OrderedDict
 from contextlib import contextmanager
 from copy import deepcopy
@@ -35,7 +35,9 @@ class BrowserParams:
         vars(self).update(**kwargs)
 
 
-class BrowserBase(ABC):
+# Do not make this an ABC for PySide6 compat:
+# https://askpythonquestions.com/2022/01/07/pyside6-shiboken-and-abcmeta-bug
+class BrowserBase:
     """A base class containing for the 2D browser.
 
     This class contains all backend-independent attributes and methods.


### PR DESCRIPTION
Working on https://github.com/mne-tools/mne-qt-browser/pull/104 on PySide6 + macOS I hit a bug where PySide6 does not play nicely with ABC:

https://askpythonquestions.com/2022/01/07/pyside6-shiboken-and-abcmeta-bug

I don't think we *need* the BrowserBase to be an ABC subclass, even if it's nice to have it that way. Given that it breaks PySide6 (which seems to be the preferred framework going forward), it seems worth it to remove it here.