### PR TITLE
MRG: Updates for qtpy in mne-qt-browser

### DIFF
--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -137,6 +137,7 @@ def test_kit2fiff():
 @testing.requires_testing_data
 def test_make_scalp_surfaces(tmp_path, monkeypatch):
     """Test mne make_scalp_surfaces."""
+    pytest.importorskip('nibabel')
     check_usage(mne_make_scalp_surfaces)
     has = 'SUBJECTS_DIR' in os.environ
     # Copy necessary files to avoid FreeSurfer call

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -779,25 +779,26 @@ def _check_stc_units(stc, threshold=1e-7):  # 100 nAm threshold for warning
              % (1e9 * max_cur))
 
 
-def _check_qt_version(api='PyQt5'):
+def _check_qt_version(*, return_api=False):
+    """Check if Qt is installed."""
     try:
-        if api in ('PyQt5', 'PyQt6'):
-            qt_mod = import_module(f'{api}.QtCore')
-            version = qt_mod.PYQT_VERSION_STR
-        else:
-            assert api in ('PySide2', 'PySide6')
-            qt_mod = import_module(api)
-            version = qt_mod.__version__
+        from qtpy import QtCore, API_NAME as api
     except Exception:
-        version = 'unknown'
+        api = version = None
     else:
+        try:  # pyside
+            version = QtCore.__version__
+        except AttributeError:
+            version = QtCore.QT_VERSION_STR
         if sys.platform == 'darwin' and api in ('PyQt5', 'PySide2'):
             if not _compare_version(version, '>=', '5.10'):
                 warn(f'macOS users should use {api} >= 5.10 for GUIs, '
                      f'got {version}. Please upgrade e.g. with:\n\n'
                      f'    pip install "{api}>=5.10,<5.14"\n')
-
-    return version
+    if return_api:
+        return version, api
+    else:
+        return version
 
 
 def _check_sphere(sphere, info=None, sphere_units='m'):

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -532,7 +532,8 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
         pandas:        1.0.5
         pyvista:       0.25.3 {pyvistaqt=0.1.1, OpenGL 3.3 (Core Profile) Mesa 18.3.6 via llvmpipe (LLVM 7.0, 256 bits)}
         vtk:           9.0.1
-        qtpy:          2.0.1 {PyQt5=5.15.0}
+        qtpy:          2.0.1 {PySide6=6.2.4}
+        pyqtgraph:     0.12.4
         pooch:         v1.5.1
     """  # noqa: E501
     _validate_type(dependencies, str)
@@ -574,8 +575,9 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
     use_mod_names = ('mne', 'numpy', 'scipy', 'matplotlib', '', 'sklearn',
                      'numba', 'nibabel', 'nilearn', 'dipy', 'cupy', 'pandas',
                      'pyvista', 'pyvistaqt', 'ipyvtklink', 'vtk',
-                     'qtpy', 'ipympl', 'pooch', '', 'mne_bids', 'mne_nirs',
-                     'mne_features', 'mne_qt_browser', 'mne_connectivity')
+                     'qtpy', 'ipympl', 'pyqtgraph', 'pooch', '', 'mne_bids',
+                     'mne_nirs', 'mne_features', 'mne_qt_browser',
+                     'mne_connectivity')
     if dependencies == 'developer':
         use_mod_names += (
             '', 'sphinx', 'sphinx_gallery', 'numpydoc', 'pydata_sphinx_theme',
@@ -606,15 +608,8 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
             if mod_name == 'numpy':
                 out(f' {{{libs}}}')
             elif mod_name == 'qtpy':
-                qt_msg = ' {'
-                for api in ('PyQt5', 'PyQt6', 'PySide2', 'PySide6'):
-                    version = _check_qt_version(api)
-                    if version != 'unknown':
-                        if qt_msg[-1] != '{':
-                            qt_msg += ', '
-                        qt_msg += f'{api}={version}'
-                qt_msg += '}'
-                out(qt_msg)
+                version, api = _check_qt_version(return_api=True)
+                out(f' {{{api}={version}}}')
             elif mod_name == 'matplotlib':
                 out(f' {{backend={mod.get_backend()}}}')
             elif mod_name == 'pyvista':

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -261,12 +261,11 @@ QToolBar::handle:vertical {
 }
 """ % dict(icons_path=icons_path)
         else:
-            # Here we are on non-macOS, or on macOS but our sys theme does not
-            # match the requested theme
+            # Here we are on non-macOS (or on macOS but our sys theme does not
+            # match the requested theme)
             if api in ('PySide6', 'PyQt6'):
-                if (theme == system_theme == 'light'):
-                    pass  # this should already be correct on all systems
-                if orig_theme != 'auto':
+                if orig_theme != 'auto' and not \
+                        (theme == system_theme == 'light'):
                     warn(f'Setting theme={repr(theme)} is not yet supported '
                          f'for {api} in qdarkstyle, it will be ignored')
             else:

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -264,6 +264,8 @@ QToolBar::handle:vertical {
             # Here we are on non-macOS, or on macOS but our sys theme does not
             # match the requested theme
             if api in ('PySide6', 'PyQt6'):
+                if (theme == system_theme == 'light'):
+                    pass  # this should already be correct on all systems
                 if orig_theme != 'auto':
                     warn(f'Setting theme={repr(theme)} is not yet supported '
                          f'for {api} in qdarkstyle, it will be ignored')

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -320,6 +320,6 @@ def _pixmap_to_ndarray(pixmap):
     count = img.height() * img.width() * 4
     if hasattr(ptr, 'setsize'):  # PyQt
         ptr.setsize(count)
-    data = np.frombuffer(ptr, dtype=np.uint8).copy()
+    data = np.frombuffer(ptr, dtype=np.uint8, count=count).copy()
     data.shape = (img.height(), img.width(), 4)
     return data / 255.

--- a/mne/viz/backends/tests/_utils.py
+++ b/mne/viz/backends/tests/_utils.py
@@ -31,17 +31,6 @@ def has_pyvistaqt():
         return False
 
 
-def has_qt():
-    """Check if Qt is installed."""
-    for api in ('PyQt5', 'PyQt6', 'PySide2', 'PySide6'):
-        try:
-            __import__(api)
-            return True
-        except ImportError:
-            pass
-    return False
-
-
 def has_imageio_ffmpeg():
     """Check if imageio-ffmpeg is installed."""
     try:

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -240,8 +240,8 @@ def test_plot_ica_sources(raw_orig, browser_backend, monkeypatch):
     assert_array_equal(ica.exclude, [1])
     fig._fake_keypress(fig.mne.close_key)
     fig._close_event()
-    assert_array_equal(ica.exclude, [0])
     assert browser_backend._get_n_figs() == 0
+    assert_array_equal(ica.exclude, [0])
     # test when picks does not include ica.exclude.
     ica.plot_sources(raw, picks=[1])
     assert browser_backend._get_n_figs() == 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,5 @@ mffpy>=0.5.7
 ipywidgets
 ipyvtklink
 mne-qt-browser
+darkdetect
+qdarkstyle


### PR DESCRIPTION
For qtpy support in mne-qt-browser, we need to update our testing infrastructure in MNE-Python, since our checks currently look to see if PyQt5 is installed.

I also added `pyqtgraph` to `mne sys_info`.