### PR TITLE
WIP: Add dark detection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,5 @@ mffpy>=0.5.7
 ipywidgets
 ipyvtklink
 mne-qt-browser
+darkdetect
+qdarkstyle


### PR DESCRIPTION
Pointed out by @alexrockhill our examples complain about darkdetect. Let's add it to `requirements.txt`, which should get picked up by CircleCI.