### PR TITLE
Avoid lowpass=0 in brainvision data

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -37,7 +37,7 @@ Bugs
 
 - Retain epochs metadata when using :func:`mne.channels.combine_channels` (:gh:`10504` by `Clemens Brunner`_)
 
-- Fix bug in :meth:`mne.io.brainvision._get_vhdr_info` when BrainVision data are acquired with V-Amp and disabled lowpass filter is marked with value 0 (:gh:`10517` by `Alessandro Tonin`_)
+- Fix bug in :func:`mne.io.read_raw_brainvision` when BrainVision data are acquired with the Brain Products "V-Amp" amplifier and disabled lowpass filter is marked with value ``0`` (:gh:`10517` by `Alessandro Tonin`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -37,6 +37,8 @@ Bugs
 
 - Retain epochs metadata when using :func:`mne.channels.combine_channels` (:gh:`10504` by `Clemens Brunner`_)
 
+- Fix bug in :meth:`mne.io.brainvision._get_vhdr_info` when BrainVision data are acquired with V-Amp and disabled lowpass filter is marked with value 0 (:gh:`10517` by `Alessandro Tonin`_)
+
 API changes
 ~~~~~~~~~~~
 - None yet

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -725,7 +725,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale):
         if len(lowpass) == 0:
             pass
         elif len(set(lowpass)) == 1:
-            if lowpass[0] in ('NaN', 'Off'):
+            if lowpass[0] in ('NaN', 'Off', '0'):
                 pass  # Placeholder for future use. Lowpass set in _empty_info
             else:
                 info['lowpass'] = float(lowpass[0])
@@ -738,7 +738,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale):
             if lp_s:
                 # We convert channels with disabled filters to having
                 # infinitely relaxed / no filters
-                lowpass = [float(filt) if filt not in ('NaN', 'Off')
+                lowpass = [float(filt) if filt not in ('NaN', 'Off', '0')
                            else 0.0 for filt in lowpass]
                 info['lowpass'] = np.min(np.array(lowpass, dtype=np.float64))
                 try:
@@ -760,7 +760,7 @@ def _get_vhdr_info(vhdr_fname, eog, misc, scale):
             else:
                 # We convert channels with disabled filters to having
                 # infinitely relaxed / no filters
-                lowpass = [float(filt) if filt not in ('NaN', 'Off')
+                lowpass = [float(filt) if filt not in ('NaN', 'Off', '0')
                            else np.Inf for filt in lowpass]
                 info['lowpass'] = np.max(np.array(lowpass, dtype=np.float64))
 


### PR DESCRIPTION
#### Reference issue
Example: Fixes #10516 .


#### What does this implement/fix?
If in the header high cutoff is 0, then the lowpass filter is considered as disabled.
