### PR TITLE
Starts GradientRemover integration

### DIFF
--- a/mne/preprocessing/GradientRemover.py
+++ b/mne/preprocessing/GradientRemover.py
@@ -1,0 +1,250 @@
+import mne
+import numpy as np
+from scipy.signal import detrend
+
+class GradientRemover:
+    """A class to remove gradients from EEG data using a template approach.
+    """
+    def __init__(self, eeg_data, tr_events, window=(4, 4)):
+        """Constructor for the gradient remover
+
+        Parameters
+        ----------
+        eeg_data: np.ndarray
+            The raw EEG data to perform gradient correction on.
+            Expected in shape (channels, time_points).
+        tr_events: np.ndarray
+            The sample numbers for when TRs begin. The array may be a
+            subset of an mne find_events that is a shape (N, 3), or a
+            1-dimensional array of sample numbers. TRs must be perfectly
+            spaced in time.
+        window: int or tuple[int, int]
+            The window to use for templates. Must be either an even integer
+            to indicate the total size, with an even number of TRs
+            templated before and after, OR a tuple containing the number of
+            TRs to use in the template before the current TR and then the
+            number of TRs to use in the template after the current TR. For
+            example, (4, 0) would use 4 TRs before the current and 0 after.
+            Default (4, 4).
+
+        Raises
+        ------
+        ValueError if any inputs are invalid.
+        TypeError if any inputs are the wrong type.
+        """
+        self._window = GradientRemover._valid_window(window)
+        self._tr_events = GradientRemover._valid_tr_events(tr_events)
+        if self._tr_events[-1] > eeg_data.shape[1]:
+            raise ValueError(
+                f"Last TR event is sample {self._tr_events[-1]} but "
+                f"eeg data only contains {eeg_data.shape[1]} samples. "
+                "Please check your tr event markers."
+            )
+        self._data = eeg_data
+        # Get weights for template
+        window_total = self.window[0] + self.window[1]
+        self._weight_before = self.window[0] / window_total
+        self._weight_after = self.window[1] / window_total
+        # Lazy evaluation
+        self._corrected = None 
+
+    @property
+    def corrected(self):
+        if self._corrected:
+            return self._corrected
+        else:
+            return self.correct()
+    @property
+    def raw(self):
+        return self._raw
+
+    @property
+    def window(self):
+        return self._window
+
+    @property
+    def tr_spacing(self):
+        return self._tr_events[1] - self._tr_events[0]
+
+    @property
+    def n_tr(self):
+        return len(self._tr_events)
+
+    @property
+    def n_channels(self):
+        return len(self._data)
+
+    def get_tr(self, n):
+        """Get the uncorrected data at a given TR
+
+        Parameters
+        ----------
+        n: int
+           The TR to get the uncorrected data at (0-indexed).
+
+        Returns
+        -------
+        np.ndarray of shape (channels, tr_timepoints) representing the
+        uncorrected data at the given TR.
+
+        Raises
+        ------
+        ValueError if an invalid TR index is supplied.
+        """
+        this_start, this_end = self._tr_bounds(n)
+        return self._data[:, this_start:this_end]
+
+    def get_tr_detrended(self, n):
+        """Get the detrended data at a given TR
+
+        Parameters
+        ----------
+        n: int
+           The TR to get the detrended data at (0-indexed).
+
+        Returns
+        -------
+        np.ndarray of shape (channels, tr_timepoints) representing the
+        detrended data at the given TR.
+
+        Raises
+        ------
+        ValueError if an invalid TR index is supplied.
+        """
+        return detrend(self.get_tr(n))
+
+    def get_tr_template(self, n):
+        """Get the gradient template data at a given TR
+
+        Parameters
+        ----------
+        n: int
+           The TR to get the template data at (0-indexed).
+
+        Returns
+        -------
+        np.ndarray of shape (channels, tr_timepoints) representing the
+        template data at the given TR.
+
+        Raises
+        ------
+        ValueError if an invalid TR index is supplied.
+        """
+        self._check_valid_tr(n)
+        if n < self.window[0] or n > (self.n_tr - self.window[1]):
+            return np.zeros((self.n_channels, self.tr_spacing))
+        if self.window[0]:
+            before = self._get_tr_template_part(n - self.window[0], n)
+        else:
+            before = 0
+        if self.window[1]:
+            after = self._get_tr_template_part(n + 1, n + self.window[1] - 1)
+        else:
+            after = 0
+        return self._weight_before * before + self._weight_after * after
+
+    def _get_tr_template_part(self, start, stop):
+        return np.mean(
+            np.asarray(
+                [self.get_tr_detrended(tr) for tr in range(start, stop)]
+            ),
+            axis=0
+        )
+
+    def get_tr_corrected(self, n):
+        """Get the gradient-corrected data at a given TR
+
+        Parameters
+        ----------
+        n: int
+           The TR to get the corrected data at (0-indexed).
+
+        Returns
+        -------
+        np.ndarray of shape (channels, tr_timepoints) representing the
+        template data at the given TR.
+
+        Raises
+        ------
+        ValueError if an invalid TR index is supplied.
+        """
+        detrended = self.get_tr_detrended(n)
+        template = self.get_tr_template(n)
+        return detrended - template
+
+    def correct(self):
+        """Generate the gradient-corrected data."""
+        corrected = self._data.copy()
+        for tr in range(self.n_tr):
+            this_start, this_end = self._tr_bounds(tr)
+            corrected[:, this_start:this_end] = self.get_tr_corrected(tr)
+        self._corrected = corrected
+        return corrected
+
+    def _valid_window(window):
+        if isinstance(window, int):
+            if not window % 2 == 0:
+                raise ValueError(
+                    f"Integer windows must be even (received {window})."
+                )
+            window = (window // 2, window // 2)
+        elif isinstance(window, tuple):
+            if not len(window) == 2:
+                raise ValueError(
+                    "Tuple windows must contain 2 elements "
+                    f"(received {window})."
+                )
+        else:
+            raise TypeError(
+                "Window must be a positive, even integer or a tuple of "
+                "size 2 containing a positive integer."
+                "(Received {window})."
+            )
+        if window[0] < 0 or window[1] < 0:
+            raise ValueError(
+                "Window must contain a positive integer. "
+                f"(Received {window})."
+            )
+        if window[0] == 0 and window[1] == 0:
+            raise ValueError(
+                "Window must contain a positive integer. "
+                f"(Received {window})."
+            )
+        return window
+
+    def _valid_tr_events(tr_events):
+        # Check to make sure TRs are evenly spaced
+        if len(tr_events.shape) == 2:
+            if tr_events.shape[1] == 3:
+                tr_events = tr_events[:, 0]
+            else:
+                raise ValueError(
+                    "TRs must be a 1D array or a (N, 3) ndarray from mne. "
+                    f"Received array of shape {tr_events.shape}."
+                )
+        elif len(tr_events.shape) != 1:
+            raise ValueError(
+                "TRs must be a 1D array or a (N, 3) ndarray from mne. "
+                f"Received array of shape {tr_events.shape}."
+            )
+        unique = np.unique(np.diff(tr_events))
+        if len(unique) != 1:
+            raise ValueError(
+                "TR spacings are not consistent; the following unique "
+                f"distances were present: {unique}."
+            )
+        return tr_events
+
+    def _check_valid_tr(self, n):
+        if n < 0 or n >= self.n_tr:
+            raise ValueError(
+                f"Index {n} not in TR range [0, {self.n_tr - 1}]"
+            )
+
+    def _tr_bounds(self, n):
+        self._check_valid_tr(n)
+        offset = self._tr_events[0]
+        length = self.tr_spacing
+        this_start = offset + n * length
+        this_end = offset + (n + 1) * length
+        return (this_start, this_end)

--- a/mne/preprocessing/__init__.py
+++ b/mne/preprocessing/__init__.py
@@ -34,3 +34,4 @@ from .annotate_nan import annotate_nan
 from .interpolate import equalize_bads
 from . import ieeg
 from ._css import cortical_signal_suppression
+from .GradientRemover import GradientRemover

--- a/mne/tests/test_GradientRemover.py
+++ b/mne/tests/test_GradientRemover.py
@@ -1,0 +1,93 @@
+import pytest
+import numpy as np
+from mne.preprocessing import GradientRemover
+
+def n_trs():
+    return 10
+
+def tr_code():
+    return 1
+
+def samps_per_tr():
+    return 100
+
+def sample_trs():
+    return np.asarray([x * samps_per_tr() for x in range(n_trs())])
+
+def sample_trs_longform():
+    return np.asarray(
+        [[samps_per_tr(), 0, tr_code()] for x in range(n_trs())]
+    )
+
+def sample_data():
+    return np.zeros((256, n_trs() * samps_per_tr()))
+
+
+def test_window_validity():
+    """Tests for window validity"""
+    data = sample_data()
+    trs = sample_trs()
+    # Odd numbers are not valid
+    with pytest.raises(ValueError, match=r"Integer windows must be even"):
+        GradientRemover(data, trs, 5)
+    # Windows should have exactly 2 elements as a tuple 
+    with pytest.raises(ValueError, match=r"Tuple windows must contain"):
+        GradientRemover(data, trs, (2, 2, 2))
+    # Windows should be a tuple of integers or an integer
+    with pytest.raises(TypeError, match=r"Window must be a positive"):
+        GradientRemover(data, trs, None)
+    # Windows should only have positive values
+    with pytest.raises(ValueError, match=r"Window must contain"):
+        GradientRemover(data, trs, (-1, 1))
+    with pytest.raises(ValueError, match=r"Window must contain"):
+        GradientRemover(data, trs, (1, -1))
+    # Windows should have at least one nonzero value
+    with pytest.raises(ValueError, match=r"Window must contain"):
+        GradientRemover(data, trs, (0, 0))
+
+    # Passing a valid window should result in storing a valid window
+    gr = GradientRemover(data, trs, (2, 2))
+    assert gr.window == (2, 2)
+    gr = GradientRemover(data, trs, 4)
+    assert gr.window == (2, 2)
+
+
+def test_tr_events_validity():
+    """Tests to ensure that tr_events is valid"""
+    data = sample_data()
+    trs = sample_trs()
+
+    # We should get a sensible error message for incorrectly sized arrays
+    with pytest.raises(ValueError, match=r"TRs must be a 1D array or"):
+        GradientRemover(data, np.asarray([[1, 2], [1, 2]]))
+
+    # Mangle the second TR of valid TRs
+    trs[1] = trs[1] + 1 # Short form
+    with pytest.raises(ValueError, match=r"TR spacings are not"):
+        GradientRemover(data, trs)
+    trs = sample_trs_longform()
+    trs[1, 0] = trs[1, 0] + 1 # Long form
+    with pytest.raises(ValueError, match=r"TR spacings are not"):
+        GradientRemover(data, trs)
+    # Make sure the correct spacing is found
+    trs = sample_trs()
+    gr = GradientRemover(data, trs)
+    assert gr.tr_spacing == samps_per_tr()
+    # Make sure the correct number of events are present
+    # (Okay this is probably needless but I'd like to make sure)
+    assert gr.n_tr == n_trs()
+
+
+def test_get_tr():
+    gr = GradientRemover(sample_data(), sample_trs())
+    
+    # Make sure negative index triggers error
+    with pytest.raises(ValueError, match=r"Index -1"):
+        gr.get_tr(-1)
+
+    # Make sure too big of an index triggers error
+    with pytest.raises(ValueError, match=r"Index"):
+        gr.get_tr(len(sample_trs()) + 1)
+
+    # Smoke test for early testing; consider removing
+    assert gr.get_tr(0).shape[1] == gr.tr_spacing


### PR DESCRIPTION
Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

#### Reference issue
Example: Fixes #10466 


#### What does this implement/fix?
Adds a preprocessing GradientRemover class that can be used to perform MRI-EEG gradient artifact correction with templates.


#### Additional information
I just added my local, functional code to mne, I'm sure that there are some things that you'd like me to change to better integrate into the code base. All ears on other improvements to be made. I'm also not sure the best way to provide data with example corrections. One note is that I left `get_tr_*` functions in there so that you can quickly view a few sample corrections without performing correction on the whole data set; a normal user would almost certainly never use them. Tests check for validity of arguments and certain failure modes, rather than validate template behavior.
