### PR TITLE
Fix line noise at wrong frequencies

### DIFF
--- a/examples/preprocessing/muscle_detection.py
+++ b/examples/preprocessing/muscle_detection.py
@@ -56,7 +56,7 @@ raw.resample(300, npad="auto")
 #     detecting muscle artifacts. See :ref:`tut-section-line-noise` for an
 #     example.
 
-raw.notch_filter([50, 100])
+raw.notch_filter([60, 120])
 
 # %%
 


### PR DESCRIPTION
Line noise was set at the wrong frequencies, see here https://neuroimage.usc.edu/brainstorm/Tutorials/Auditory#Power_line_contamination.