### PR TITLE
WIP: Copy BEM surfaces by default (don't symlink)

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -43,6 +43,6 @@ Bugs
 
 - Fix reading of fiducial locations in :func:`mne.io.read_raw_eeglab` (:gh:`10521` by `Alex Gramfort`_)
 
-API changes
-~~~~~~~~~~~
-- None yet
+API and behavior changes
+~~~~~~~~~~~~~~~~~~~~~~~~
+- When creating BEM surfaces via :func:`mne.bem.make_watershed_bem` and :func:`mne.bem.make_flash_bem`, the ``copy`` parameter now defaults to ``True``. This means that instead of creating symbolic links inside the FreeSurfer subject's ``bem`` folder, we now create "actual" files. This should avoid troubles when sharing files across different operating systems and file systems (:gh:`10531` by `Richard Höchenberger`_)

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1018,7 +1018,7 @@ def _check_origin(origin, info, coord_frame='head', disp=False):
 @verbose
 def make_watershed_bem(subject, subjects_dir=None, overwrite=False,
                        volume='T1', atlas=False, gcaatlas=False, preflood=None,
-                       show=False, copy=False, T1=None, brainmask='ws.mgz',
+                       show=False, copy=True, T1=None, brainmask='ws.mgz',
                        verbose=None):
     """Create BEM surfaces using the FreeSurfer watershed algorithm.
 
@@ -1042,10 +1042,11 @@ def make_watershed_bem(subject, subjects_dir=None, overwrite=False,
         .. versionadded:: 0.12
 
     copy : bool
-        If True (default False), use copies instead of symlinks for surfaces
+        If True (default), use copies instead of symlinks for surfaces
         (if they do not already exist).
 
         .. versionadded:: 0.18
+        .. versionchanged:: 1.1 Use copies instead of symlinks.
     T1 : bool | None
         If True, pass the ``-T1`` flag.
         By default (None), this takes the same value as ``gcaatlas``.
@@ -1837,7 +1838,7 @@ def convert_flash_mris(subject, flash30=True, convert=True, unwarp=False,
 
 @verbose
 def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
-                   flash_path=None, copy=False, verbose=None):
+                   flash_path=None, copy=True, verbose=None):
     """Create 3-Layer BEM model from prepared flash MRI images.
 
     Parameters
@@ -1855,10 +1856,11 @@ def make_flash_bem(subject, overwrite=False, show=True, subjects_dir=None,
 
         .. versionadded:: 0.13.0
     copy : bool
-        If True (default False), use copies instead of symlinks for surfaces
+        If True (default), use copies instead of symlinks for surfaces
         (if they do not already exist).
 
         .. versionadded:: 0.18
+        .. versionchanged:: 1.1 Use copies instead of symlinks.
     %(verbose)s
 
     See Also


### PR DESCRIPTION
Several (all?) Windows users attending a workshop @agramfort and I hosted yesterday were running into issues when working with BEM surfaces we had shared with them as part of a FreeSurfer subjects directory.

The reason was that transferring the symlinks turned out to be problematic, and thus, users ended up with invalid files. They had to manually copy over the BEM surfaces from the `bem/flash` or `bem/watershed` (?) directories to `bem/` and rename them.

Since our collaborators are working in highly heterogenous settings (macOS, Linux, Windows), this is indeed a huge problem for data sharing, and it's not obvious at all to a common user WHY things are not working as expected.

I therefore here propose an API change without deprecation cycle, changing the default value of the `make_*_bem()` functions' `copy` parameter from `False` to `True`, to always create a copy by default (and not a symlink).

I'd further like to propose we change our sample data accordingly, getting rid of the symbolic links for the BEM surfaces there as well.

I'm happy to discuss this at today's office hour.

cc @agramfort
