### PR TITLE
MRG: Add "verbose" parameter to pick_channels() method

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -25,6 +25,8 @@ Enhancements
 ~~~~~~~~~~~~
 - Add support for ``overview_mode`` in :meth:`raw.plot() <mne.io.Raw.plot>` and related functions/methods (:gh:`10501` by `Eric Larson`_)
 
+- The ``pick_channels`` method gained a ``verbose`` parameter, allowing e.g. to suppress messages about removed projectors (:gh:`10544` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 - Fix bug in :func:`mne.io.read_raw_brainvision` when BrainVision data are acquired with the Brain Products "V-Amp" amplifier and disabled lowpass filter is marked with value ``0`` (:gh:`10517` by :newcontrib:`Alessandro Tonin`)

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -692,7 +692,8 @@ class UpdateChannelsMixin(object):
 
         return self
 
-    def pick_channels(self, ch_names, ordered=False):
+    @verbose
+    def pick_channels(self, ch_names, ordered=False, verbose=None):
         """Pick some channels.
 
         Parameters
@@ -704,6 +705,9 @@ class UpdateChannelsMixin(object):
             the modified instance matches the order of ``ch_names``.
 
             .. versionadded:: 0.20.0
+        %(verbose)s
+
+            .. versionadded:: 1.1
 
         Returns
         -------

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -693,7 +693,7 @@ class UpdateChannelsMixin(object):
         return self
 
     @verbose
-    def pick_channels(self, ch_names, ordered=False, verbose=None):
+    def pick_channels(self, ch_names, ordered=False, *, verbose=None):
         """Pick some channels.
 
         Parameters


### PR DESCRIPTION
This allows to e.g. to suppress messages about removed projectors.