### PR TITLE
CI: Avoid bad PySide6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,7 +110,7 @@ stages:
     - bash: |
         set -e
         python -m pip install --progress-bar off --upgrade pip setuptools wheel codecov
-        python -m pip install --progress-bar off mne-qt-browser[opengl] vtk scikit-learn pytest-error-for-skips python-picard PySide6 qtpy
+        python -m pip install --progress-bar off mne-qt-browser[opengl] vtk scikit-learn pytest-error-for-skips python-picard "PySide6!=6.3.0" qtpy
         python -m pip uninstall -yq mne
         python -m pip install --progress-bar off --upgrade -e .[test]
       displayName: 'Install dependencies with pip'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ h5io
 packaging
 pymatreader
 qtpy
-pyside6
+PySide6!=6.3.0
 pyobjc-framework-Cocoa>=5.2.0; platform_system=="Darwin"
 sip
 scikit-learn


### PR DESCRIPTION
6.3.0 came out April 16th, so I'm guessing that's what's causing our Qt failures. Let's find out!