### PR TITLE
MAINT: Respect activation

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -221,7 +221,10 @@ def matplotlib_config():
     # functionality)
     plt.ioff()
     plt.rcParams['figure.dpi'] = 100
-    plt.rcParams['figure.raise_window'] = False
+    try:
+        plt.rcParams['figure.raise_window'] = False
+    except KeyError:  # MPL < 3.3
+        pass
     # Make sure that we always reraise exceptions in handlers
     orig = cbook.CallbackRegistry
 

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -145,6 +145,8 @@ def pytest_configure(config):
     ignore:.*starting_affine overwritten by centre_of_mass transform.*:
     # TODO: This is indicative of a problem
     ignore:.*Matplotlib is currently using agg.*:
+    # qdarkstyle
+    ignore:.*Setting theme=.*:RuntimeWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()
@@ -219,7 +221,7 @@ def matplotlib_config():
     # functionality)
     plt.ioff()
     plt.rcParams['figure.dpi'] = 100
-
+    plt.rcParams['figure.raise_window'] = False
     # Make sure that we always reraise exceptions in handlers
     orig = cbook.CallbackRegistry
 

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -33,7 +33,10 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import pyvista
     from pyvista import Plotter, PolyData, Line, close_all, UnstructuredGrid
-    from pyvistaqt import BackgroundPlotter  # noqa
+    try:
+        from pyvistaqt import BackgroundPlotter  # noqa
+    except ImportError:
+        from pyvista import BackgroundPlotter
     from pyvista.plotting.plotting import _ALL_PLOTTERS
 VTK9 = _compare_version(getattr(vtk, 'VTK_VERSION', '9.0'), '>=', '9.0')
 

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 import weakref
 
 import pyvista
-from pyvistaqt.plotting import FileDialog
+from pyvistaqt.plotting import FileDialog, MainWindow
 
 from qtpy.QtCore import Qt, Signal, QLocale, QObject
 from qtpy.QtGui import QIcon, QCursor
@@ -877,3 +877,15 @@ def _testing_context(interactive):
         pyvista.OFF_SCREEN = orig_offscreen
         renderer.MNE_3D_BACKEND_TESTING = orig_testing
         renderer.MNE_3D_BACKEND_INTERACTIVE = orig_interactive
+
+
+# In theory we should be able to do this later (e.g., in _pyvista.py when
+# initializing), but at least on Qt6 this has to be done earlier. So let's do
+# it immediately upon instantiation of the QMainWindow class.
+# TODO: This should eventually allow us to handle
+# https://github.com/mne-tools/mne-python/issues/9182
+
+class _MNEMainWindow(MainWindow):
+    def __init__(self, parent=None, title=None, size=None):
+        super().__init__(parent, title, size)
+        self.setAttribute(Qt.WA_ShowWithoutActivating, True)

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -160,6 +160,7 @@ def _init_mne_qtapp(enable_icon=True, pg_app=False, splash=False):
         pixmap.setDevicePixelRatio(
             QGuiApplication.primaryScreen().devicePixelRatio())
         qsplash = QSplashScreen(pixmap, Qt.WindowStaysOnTopHint)
+        qsplash.setAttribute(Qt.WA_ShowWithoutActivating, True)
         if isinstance(splash, str):
             alignment = int(Qt.AlignBottom | Qt.AlignHCenter)
             qsplash.showMessage(


### PR DESCRIPTION
On gnome-shell in Linux, running `pytest mne/viz` is really annoying because of focus stealing. This makes our code respect the current code path for deciding whether or not to activate a window when it's shown (using `rcParams`). This in turn can be easily controlled in `conftest` to always be False.