### PR TITLE
MRG: Add error checking to prevent the creation of montage with invalid [x, y, z]

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -45,6 +45,8 @@ Bugs
 
 - Fix reading of fiducial locations in :func:`mne.io.read_raw_eeglab` (:gh:`10521` by `Alex Gramfort`_)
 
+- Prevent creation of montage with invalid ``[x, y, z]`` coordinates with :func:`mne.channels.make_dig_montage` (:gh:`10547` by `Mathieu Scheltienne`_)
+
 API and behavior changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - When creating BEM surfaces via :func:`mne.bem.make_watershed_bem` and :func:`mne.bem.make_flash_bem`, the ``copy`` parameter now defaults to ``True``. This means that instead of creating symbolic links inside the FreeSurfer subject's ``bem`` folder, we now create "actual" files. This should avoid troubles when sharing files across different operating systems and file systems (:gh:`10531` by `Richard Höchenberger`_)

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1654,3 +1654,12 @@ def test_read_dig_localite(tmp_path):
     s = '<DigMontage | 0 extras (headshape), 0 HPIs, 3 fiducials, 15 channels>'
     assert repr(montage) == s
     assert montage.ch_names == [f'ch{i:02}' for i in range(1, 16)]
+
+
+def test_make_wrong_dig_montage():
+    """Test that a montage with non numeric is not possible."""
+    with pytest.raises(ValueError, match="a 1D array of floats [x, y, z]."):
+        montage = make_dig_montage(ch_pos={'A1': ['0', '0', '0']})
+
+    with pytest.raises(TypeError, match="instance of ndarray, list, or tuple"):
+        montage = make_dig_montage(ch_pos={'A1': 5})

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1659,7 +1659,7 @@ def test_read_dig_localite(tmp_path):
 def test_make_wrong_dig_montage():
     """Test that a montage with non numeric is not possible."""
     with pytest.raises(ValueError, match="a 1D array of floats [x, y, z]."):
-        montage = make_dig_montage(ch_pos={'A1': ['0', '0', '0']})
+        make_dig_montage(ch_pos={'A1': ['0', '0', '0']})
 
     with pytest.raises(TypeError, match="instance of ndarray, list, or tuple"):
-        montage = make_dig_montage(ch_pos={'A1': 5})
+        make_dig_montage(ch_pos={'A1': 5})

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1658,7 +1658,7 @@ def test_read_dig_localite(tmp_path):
 
 def test_make_wrong_dig_montage():
     """Test that a montage with non numeric is not possible."""
-    with pytest.raises(RuntimeError, match="a 1D array of floats"):
+    with pytest.raises(RuntimeError, match="a 1D array of 3 floats"):
         make_dig_montage(ch_pos={'A1': ['0', '0', '0']})
 
     with pytest.raises(TypeError, match="instance of ndarray, list, or tuple"):

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1658,7 +1658,7 @@ def test_read_dig_localite(tmp_path):
 
 def test_make_wrong_dig_montage():
     """Test that a montage with non numeric is not possible."""
-    with pytest.raises(ValueError, match="a 1D array of floats [x, y, z]."):
+    with pytest.raises(RuntimeError, match="a 1D array of floats [x, y, z]."):
         make_dig_montage(ch_pos={'A1': ['0', '0', '0']})
 
     with pytest.raises(TypeError, match="instance of ndarray, list, or tuple"):

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1658,8 +1658,8 @@ def test_read_dig_localite(tmp_path):
 
 def test_make_wrong_dig_montage():
     """Test that a montage with non numeric is not possible."""
-    with pytest.raises(RuntimeError, match="a 1D array of 3 floats"):
-        make_dig_montage(ch_pos={'A1': ['0', '0', '0']})
-
+    make_dig_montage(ch_pos={'A1': ['0', '0', '0']})  # converted to floats
+    with pytest.raises(ValueError, match="could not convert string to float"):
+        make_dig_montage(ch_pos={'A1': ['a', 'b', 'c']})
     with pytest.raises(TypeError, match="instance of ndarray, list, or tuple"):
         make_dig_montage(ch_pos={'A1': 5})

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1658,7 +1658,7 @@ def test_read_dig_localite(tmp_path):
 
 def test_make_wrong_dig_montage():
     """Test that a montage with non numeric is not possible."""
-    with pytest.raises(RuntimeError, match="a 1D array of floats [x, y, z]."):
+    with pytest.raises(RuntimeError, match="a 1D array of floats"):
         make_dig_montage(ch_pos={'A1': ['0', '0', '0']})
 
     with pytest.raises(TypeError, match="instance of ndarray, list, or tuple"):

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -438,7 +438,7 @@ def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
                     dig_ch_pos[key] = value
                 if value.shape != (3, ) or value.dtype != float:
                     raise ValueError("The position should be a 1D array of "
-                                      "floats [x, y, z].")
+                                     "floats [x, y, z].")
                 idents.append(int(key[-3:]))
         except ValueError:  # and if any conversion fails, simply use arange
             idents = np.arange(1, len(dig_ch_pos) + 1)

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -425,14 +425,14 @@ def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
                         'kind': FIFF.FIFFV_POINT_EXTRA,
                         'coord_frame': coord_frame})
     if dig_ch_pos is not None:
-        try:  # use the last 3 as int if possible (e.g., EEG001->1)
-            idents = []
-            for key in dig_ch_pos:
-                _validate_type(key, str, 'dig_ch_pos')
-                idents.append(int(key[-3:]))
-        except ValueError:  # and if any conversion fails, simply use arange
-            idents = np.arange(1, len(dig_ch_pos) + 1)
+        idents = []
+        use_arange = False
         for key, value in dig_ch_pos.items():
+            _validate_type(key, str, 'dig_ch_pos')
+            try:
+                idents.append(int(key[-3:]))
+            except ValueError:
+                use_arange = True
             _validate_type(value, (np.ndarray, list, tuple), 'dig_ch_pos')
             value = np.array(value, dtype=float)
             dig_ch_pos[key] = value
@@ -440,6 +440,8 @@ def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
                 raise RuntimeError(
                     "The position should be a 1D array of 3 floats. "
                     f"Provided shape {value.shape}.")
+        if use_arange:
+            idents = np.arange(1, len(dig_ch_pos) + 1)
         for key, ident in zip(dig_ch_pos, idents):
             dig.append({'r': dig_ch_pos[key], 'ident': int(ident),
                         'kind': FIFF.FIFFV_POINT_EEG,

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -433,10 +433,10 @@ def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
                 if isinstance(value, (list, tuple)):
                     value = np.array(value)
                     dig_ch_pos[key] = value
-                if value.dtype == int:
-                    value = value.astype(np.float32)
+                if value.dtype == int or value.dtype == np.float32:
+                    value = value.astype(np.float64)
                     dig_ch_pos[key] = value
-                if value.shape != (3, ) or value.dtype != float:
+                if value.shape != (3, ) or value.dtype != np.float64:
                     raise RuntimeError("The position should be a 1D array of "
                                        "floats [x, y, z].")
                 idents.append(int(key[-3:]))

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -433,8 +433,9 @@ def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
                 value = np.array(value, dtype=float)
                 dig_ch_pos[key] = value
                 if value.shape != (3, ):
-                    raise RuntimeError("The position should be a 1D array of "
-                                       "floats [x, y, z].")
+                    raise RuntimeError(
+                        "The position should be a 1D array of 3 floats. "
+                        f"Provided shape {value.shape}.")
                 idents.append(int(key[-3:]))
         except ValueError:  # and if any conversion fails, simply use arange
             idents = np.arange(1, len(dig_ch_pos) + 1)

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -427,8 +427,18 @@ def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
     if dig_ch_pos is not None:
         try:  # use the last 3 as int if possible (e.g., EEG001->1)
             idents = []
-            for key in dig_ch_pos:
+            for key, value in dig_ch_pos.items():
                 _validate_type(key, str, 'dig_ch_pos')
+                _validate_type(value, (np.ndarray, list, tuple), 'dig_ch_pos')
+                if isinstance(value, (list, tuple)):
+                    value = np.array(value)
+                    dig_ch_pos[key] = value
+                if value.dtype == int:
+                    value = value.astype(np.float32)
+                    dig_ch_pos[key] = value
+                if value.shape != (3, ) or value.dtype != float:
+                    raise ValueError("The position should be a 1D array of "
+                                      "floats [x, y, z].")
                 idents.append(int(key[-3:]))
         except ValueError:  # and if any conversion fails, simply use arange
             idents = np.arange(1, len(dig_ch_pos) + 1)

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -437,8 +437,8 @@ def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
                     value = value.astype(np.float32)
                     dig_ch_pos[key] = value
                 if value.shape != (3, ) or value.dtype != float:
-                    raise ValueError("The position should be a 1D array of "
-                                     "floats [x, y, z].")
+                    raise RuntimeError("The position should be a 1D array of "
+                                       "floats [x, y, z].")
                 idents.append(int(key[-3:]))
         except ValueError:  # and if any conversion fails, simply use arange
             idents = np.arange(1, len(dig_ch_pos) + 1)

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -427,18 +427,19 @@ def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
     if dig_ch_pos is not None:
         try:  # use the last 3 as int if possible (e.g., EEG001->1)
             idents = []
-            for key, value in dig_ch_pos.items():
+            for key in dig_ch_pos:
                 _validate_type(key, str, 'dig_ch_pos')
-                _validate_type(value, (np.ndarray, list, tuple), 'dig_ch_pos')
-                value = np.array(value, dtype=float)
-                dig_ch_pos[key] = value
-                if value.shape != (3, ):
-                    raise RuntimeError(
-                        "The position should be a 1D array of 3 floats. "
-                        f"Provided shape {value.shape}.")
                 idents.append(int(key[-3:]))
         except ValueError:  # and if any conversion fails, simply use arange
             idents = np.arange(1, len(dig_ch_pos) + 1)
+        for key, value in dig_ch_pos.items():
+            _validate_type(value, (np.ndarray, list, tuple), 'dig_ch_pos')
+            value = np.array(value, dtype=float)
+            dig_ch_pos[key] = value
+            if value.shape != (3, ):
+                raise RuntimeError(
+                    "The position should be a 1D array of 3 floats. "
+                    f"Provided shape {value.shape}.")
         for key, ident in zip(dig_ch_pos, idents):
             dig.append({'r': dig_ch_pos[key], 'ident': int(ident),
                         'kind': FIFF.FIFFV_POINT_EEG,

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -430,13 +430,9 @@ def _make_dig_points(nasion=None, lpa=None, rpa=None, hpi=None,
             for key, value in dig_ch_pos.items():
                 _validate_type(key, str, 'dig_ch_pos')
                 _validate_type(value, (np.ndarray, list, tuple), 'dig_ch_pos')
-                if isinstance(value, (list, tuple)):
-                    value = np.array(value)
-                    dig_ch_pos[key] = value
-                if value.dtype == int or value.dtype == np.float32:
-                    value = value.astype(np.float64)
-                    dig_ch_pos[key] = value
-                if value.shape != (3, ) or value.dtype != np.float64:
+                value = np.array(value, dtype=float)
+                dig_ch_pos[key] = value
+                if value.shape != (3, ):
                     raise RuntimeError("The position should be a 1D array of "
                                        "floats [x, y, z].")
                 idents.append(int(key[-3:]))


### PR DESCRIPTION
Before, both lines below would not raise.

```
montage = make_dig_montage(ch_pos={'A1': ['0', '0', '0']})
montage = make_dig_montage(ch_pos={'A1': 5})
```

The first one, in particular, is problematic, in case you read [x, y, z] values from a file and forget to convert from str to float (definitely never happened to me 🙈).

After, both raise an error at creation and I also added a conversion to a float array at an earlier stage for the [x, y, z].