### PR TITLE
MRG: Correct documented default number of CV splits in cross_val_multiscore()

### DIFF
--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -382,7 +382,7 @@ def cross_val_multiscore(estimator, X, y=None, groups=None, scoring=None,
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
-        - None, to use the default 3-fold cross validation,
+        - None, to use the default 5-fold cross validation,
         - integer, to specify the number of folds in a ``(Stratified)KFold``,
         - An object to be used as a cross-validation generator.
         - An iterable yielding train, test splits.


### PR DESCRIPTION
We're actually using 5 splits and have been for quite a while now, but this bit of the docs hasn't been updated.

