### PR TITLE
[ENH, MRG] Add keypresses to ICA to toggle topomap channel type and psd scale

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -39,7 +39,7 @@ Enhancements
 
 - The new function :func:`mne.preprocessing.maxwell_filter_prepare_emptyroom` simplifies the preconditioning of an empty-room recording for our Maxwell filtering operations (:gh:`10533` by `Richard Höchenberger`_ and `Eric Larson`_)
 
-- Add keyboard shortcuts to toggle :meth:`mne.preprocessing.ICA.plot_properties` topomap channel types ('t') and power spectral density log-scale ('l') (:gh:`XX` by `Alex Rockhill`_)
+- Add keyboard shortcuts to toggle :meth:`mne.preprocessing.ICA.plot_properties` topomap channel types ('t') and power spectral density log-scale ('l') (:gh:`10557` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -39,6 +39,8 @@ Enhancements
 
 - The new function :func:`mne.preprocessing.maxwell_filter_prepare_emptyroom` simplifies the preconditioning of an empty-room recording for our Maxwell filtering operations (:gh:`10533` by `Richard Höchenberger`_ and `Eric Larson`_)
 
+- Add keyboard shortcuts to toggle :meth:`mne.preprocessing.ICA.plot_properties` topomap channel types ('t') and power spectral density log-scale ('l') (:gh:`XX` by `Alex Rockhill`_)
+
 Bugs
 ~~~~
 - Fix bug in :func:`mne.io.read_raw_brainvision` when BrainVision data are acquired with the Brain Products "V-Amp" amplifier and disabled lowpass filter is marked with value ``0`` (:gh:`10517` by :newcontrib:`Alessandro Tonin`)

--- a/examples/preprocessing/muscle_ica.py
+++ b/examples/preprocessing/muscle_ica.py
@@ -70,12 +70,11 @@ ica.plot_sources(raw)
 # ICA component 13 is a textbook example of what muscle artifact looks like.
 # The focus of the topomap for this component is right on the temporalis
 # muscle near the ears. There is also a minimum in the power spectrum at around
-# 10 Hz, then a maximum at around 25 Hz, then a slow linear dropoff (relative
-# to non-muscle components) in non-log-log units (this slope is positive in
-# log-log units) this is a very typical pattern for muscle artifact.
+# 10 Hz, then a maximum at around 25 Hz, generally resulting in a positive
+# slope in log-log units; this is a very typical pattern for muscle artifact.
 
 muscle_idx = [6, 7, 8, 9, 10, 11, 12, 13, 14]
-ica.plot_properties(raw, picks=muscle_idx)
+ica.plot_properties(raw, picks=muscle_idx, log_scale=True)
 
 # first, remove blinks and heartbeat to compare
 blink_idx = [0]
@@ -109,7 +108,7 @@ for sub in (1, 2):
     ica.fit(raw)
     ica.plot_sources(raw)
     muscle_idx_auto, scores = ica.find_bads_muscle(raw)
-    ica.plot_properties(raw, picks=muscle_idx_auto)
+    ica.plot_properties(raw, picks=muscle_idx_auto, log_scale=True)
     ica.plot_scores(scores, exclude=muscle_idx_auto)
 
     print(f'Manually found muscle artifact ICA components:      {muscle_idx}\n'

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2045,11 +2045,13 @@ class ICA(ContainsMixin, _VerboseDep):
 
     @copy_function_doc_to_method_doc(plot_ica_properties)
     def plot_properties(self, inst, picks=None, axes=None, dB=True,
-                        plot_std=True, topomap_args=None, image_args=None,
-                        psd_args=None, figsize=None, show=True, reject='auto',
-                        reject_by_annotation=True, *, verbose=None):
+                        plot_std=True, log_scale=False, topomap_args=None,
+                        image_args=None, psd_args=None, figsize=None,
+                        show=True, reject='auto', reject_by_annotation=True,
+                        *, verbose=None):
         return plot_ica_properties(self, inst, picks=picks, axes=axes,
                                    dB=dB, plot_std=plot_std,
+                                   log_scale=log_scale,
                                    topomap_args=topomap_args,
                                    image_args=image_args, psd_args=psd_args,
                                    figsize=figsize, show=show, reject=reject,

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -117,39 +117,6 @@ def plot_ica_sources(ica, inst, picks=None, start=None,
     return fig
 
 
-def _set_scale(ax, scale):
-    """Set the scale of a matplotlib axis."""
-    ax.set_xscale(scale)
-    ax.set_yscale(scale)
-    ax.relim()
-    ax.autoscale()
-
-
-def _plot_ica_properties_on_press(event, ica, pick, topomap_args):
-    """Handle keypress events for ica properties plot."""
-    import matplotlib.pyplot as plt
-    fig = event.canvas.figure
-    if event.key == 'escape':
-        plt.close(fig)
-    if event.key in ('t', 'l'):
-        ax_labels = [ax.get_label() for ax in fig.axes]
-        if event.key == 't':
-            ax = fig.axes[ax_labels.index('topomap')]
-            ax.clear()
-            ch_types = list(set(ica.get_channel_types()))
-            ch_type = \
-                ch_types[(ch_types.index(ax._ch_type) + 1) % len(ch_types)]
-            _plot_ica_topomap(ica, pick, ch_type=ch_type, show=False,
-                              axes=ax, **topomap_args)
-            ax._ch_type = ch_type
-            del ax
-        elif event.key == 'l':
-            ax = fig.axes[ax_labels.index('spectrum')]
-            _set_scale(ax, 'linear' if ax.get_xscale() == 'log' else 'log')
-            del ax
-        fig.canvas.draw()
-
-
 def _create_properties_layout(figsize=None, fig=None):
     """Create main figure and axes layout used by plot_ica_properties."""
     import matplotlib.pyplot as plt
@@ -262,6 +229,13 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
     image_ax.yaxis.set_ticks(yt[1:])
     image_ax.set_ylim([-0.5, n_trials + 0.5])
 
+    def _set_scale(ax, scale):
+        """Set the scale of a matplotlib axis."""
+        ax.set_xscale(scale)
+        ax.set_yscale(scale)
+        ax.relim()
+        ax.autoscale()
+
     # spectrum
     set_title_and_labels(spec_ax, 'Spectrum', 'Frequency (Hz)', psd_ylabel)
     spec_ax.yaxis.labelpad = 0
@@ -280,6 +254,29 @@ def _plot_ica_properties(pick, ica, inst, psds_mean, freqs, n_trials,
     hist_ax.set_ylabel("")
     hist_ax.set_yticks([])
     set_title_and_labels(hist_ax, None, None, None)
+
+    def _plot_ica_properties_on_press(event, ica, pick, topomap_args):
+        """Handle keypress events for ica properties plot."""
+        import matplotlib.pyplot as plt
+        fig = event.canvas.figure
+        if event.key == 'escape':
+            plt.close(fig)
+        if event.key in ('t', 'l'):
+            ax_labels = [ax.get_label() for ax in fig.axes]
+            if event.key == 't':
+                ax = fig.axes[ax_labels.index('topomap')]
+                ax.clear()
+                ch_types = list(set(ica.get_channel_types()))
+                ch_type = \
+                    ch_types[(ch_types.index(ax._ch_type) + 1) % len(ch_types)]
+                _plot_ica_topomap(ica, pick, ch_type=ch_type, show=False,
+                                  axes=ax, **topomap_args)
+                ax._ch_type = ch_type
+            elif event.key == 'l':
+                ax = fig.axes[ax_labels.index('spectrum')]
+                _set_scale(ax, 'linear' if ax.get_xscale() == 'log' else 'log')
+            del ax
+            fig.canvas.draw()
 
     # add keypress event handler
     fig.canvas.mpl_connect(

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -142,9 +142,11 @@ def _plot_ica_properties_on_press(event, ica, pick, topomap_args):
             _plot_ica_topomap(ica, pick, ch_type=ch_type, show=False,
                               axes=ax, **topomap_args)
             ax._ch_type = ch_type
+            del ax
         elif event.key == 'l':
             ax = fig.axes[ax_labels.index('spectrum')]
             _set_scale(ax, 'linear' if ax.get_xscale() == 'log' else 'log')
+            del ax
         fig.canvas.draw()
 
 

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -104,7 +104,7 @@ def test_plot_ica_components():
 
     topomap_ax = c_fig.axes[labels.index('topomap')]
     title = topomap_ax.get_title()
-    assert (lbl == title)
+    assert (lbl.split(' ')[0] == title.split(' ')[0])
 
     ica.info = None
     with pytest.raises(RuntimeError, match='fit the ICA'):

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -157,7 +157,6 @@ def test_plot_ica_properties():
 
     # test topomap change type
     ax = fig.axes[ax_labels.index('topomap')]
-    print(ax)
     assert ax.get_title() == 'ICA001 (mag)'
     fig.canvas.key_press_event('t')
     assert ax.get_title() == 'ICA001 (grad)'

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -146,10 +146,32 @@ def test_plot_ica_properties():
     assert raw.ch_names[0] == 'MEG 0113'
     assert 'Interpolation mode local to mean' in log, log
     ica.plot_properties(epochs, picks=1, dB=False, plot_std=1.5, **topoargs)
-    ica.plot_properties(epochs, picks=1, image_args={'sigma': 1.5},
-                        topomap_args={'res': 4, 'colorbar': True},
-                        psd_args={'fmax': 65.}, plot_std=False,
-                        figsize=[4.5, 4.5], reject=reject)
+    fig = ica.plot_properties(epochs, picks=1, image_args={'sigma': 1.5},
+                              topomap_args={'res': 4, 'colorbar': True},
+                              psd_args={'fmax': 65.}, plot_std=False,
+                              log_scale=True, figsize=[4.5, 4.5],
+                              reject=reject)[0]
+
+    # test keypresses
+    ax_labels = [ax.get_label() for ax in fig.axes]
+
+    # test topomap change type
+    ax = fig.axes[ax_labels.index('topomap')]
+    print(ax)
+    assert ax.get_title() == 'ICA001 (mag)'
+    fig.canvas.key_press_event('t')
+    assert ax.get_title() == 'ICA001 (grad)'
+    fig.canvas.key_press_event('t')
+    assert ax.get_title() == 'ICA001 (mag)'
+
+    # test log scale
+    ax = fig.axes[ax_labels.index('spectrum')]
+    assert ax.get_xscale() == 'log'
+    fig.canvas.key_press_event('l')
+    assert ax.get_xscale() == 'linear'
+    fig.canvas.key_press_event('l')
+    assert ax.get_xscale() == 'log'
+
     plt.close('all')
 
     with pytest.raises(TypeError, match='must be an instance'):

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1052,7 +1052,10 @@ def _plot_ica_topomap(ica, idx=0, ch_type=None, res=64,
     if merge_channels:
         data, names = _merge_ch_data(data, ch_type, names)
 
-    axes.set_title(ica._ica_names[idx], fontsize=12)
+    topo_title = ica._ica_names[idx]
+    if len(set(ica.get_channel_types())) > 1:
+        topo_title += f' ({ch_type})'
+    axes.set_title(topo_title, fontsize=12)
     vmin_, vmax_ = _setup_vmin_vmax(data, vmin, vmax)
     im = plot_topomap(
         data.ravel(), pos, vmin=vmin_, vmax=vmax_, res=res, axes=axes,

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1230,7 +1230,10 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
     titles = list()
     for ii, data_, ax in zip(picks, data, axes):
         kwargs = dict(color='gray') if ii in ica.exclude else dict()
-        titles.append(ax.set_title(ica._ica_names[ii], fontsize=12, **kwargs))
+        comp_title = ica._ica_names[ii]
+        if len(set(ica.get_channel_types())) > 1:
+            comp_title += f' ({ch_type})'
+        titles.append(ax.set_title(comp_title, fontsize=12, **kwargs))
         if merge_channels:
             data_, names_ = _merge_ch_data(data_, ch_type, names.copy())
         vmin_, vmax_ = _setup_vmin_vmax(data_, vmin, vmax)
@@ -1262,7 +1265,7 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
         # title was pressed -> identify the IC
         if title_pressed is not None:
             label = title_pressed.get_text()
-            ic = int(label[-3:])
+            ic = int(label.split(' ')[0][-3:])
             # add or remove IC from exclude depending on current state
             if ic in ica.exclude:
                 ica.exclude.remove(ic)
@@ -1280,7 +1283,7 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
             if event.inaxes is not None:
                 label = event.inaxes.get_label()
                 if label.startswith('ICA'):
-                    ic = int(label[-3:])
+                    ic = int(label.split(' ')[0][-3:])
                     ica.plot_properties(inst, picks=ic, show=True,
                                         plot_std=plot_std,
                                         topomap_args=topomap_args,


### PR DESCRIPTION
The topomap for `ICA.plot_properties` defaults to the first on the list of channel types, usually `mag`. I think, especially when this is popped out in the `ICA.plot_sources` figure, it would be super helpful to be able to toggle the type of channel shown in the topomap. I threw in log scaling as well although now that I'm writing this, maybe just the parameter is sufficient, although you can't easily pass the parameter in `ICA.plot_sources` so maybe I'll leave it in and see what other people think and remove it if it's not popular. The thing that I haven't figured out is how to inform the user of this functionality. I think a help button would probably be fine but wanted to see what others think, maybe just add it to the text of the tutorial would work as well.