### PR TITLE
ignore nan values when transforming 3d coords into colours

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -61,7 +61,7 @@ Bugs
 - Fix bug in :func:`mne.io.read_raw_bti` where EEG, EMG, and H/VEOG channels were not detected properly, and many non-ECG channels were called ECG. The logic has been improved, and any channels of unknown type are now labeled as ``misc`` (:gh:`11102` by `Eric Larson`_)
 - Fix bug in :func:`mne.viz.plot_topomap` when providing ``sphere="eeglab"`` (:gh:`11081` by `Mathieu Scheltienne`_)
 - The string and HTML representation of :class:`mne.preprocessing.ICA` reported incorrect values for the explained variance. This information has been removed from the representations, and should instead be retrieved via the new :meth:`~mne.preprocessing.ICA.get_explained_variance_ratio` method (:gh:`11141` by `Richard Höchenberger`_)
-- Fix bug in :func:`mne.Evoked.plot` and related methods where a ``np.nan`` location value in any channel causes spatial colours to fail (:gh:`6870` by `Simeon Wong`_)
+- Fix bug in :meth:`mne.Evoked.plot` and related methods where a ``np.nan`` location value in any channel causes spatial colours to fail (:gh:`6870` by `Simeon Wong`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -61,7 +61,7 @@ Bugs
 - Fix bug in :func:`mne.io.read_raw_bti` where EEG, EMG, and H/VEOG channels were not detected properly, and many non-ECG channels were called ECG. The logic has been improved, and any channels of unknown type are now labeled as ``misc`` (:gh:`11102` by `Eric Larson`_)
 - Fix bug in :func:`mne.viz.plot_topomap` when providing ``sphere="eeglab"`` (:gh:`11081` by `Mathieu Scheltienne`_)
 - The string and HTML representation of :class:`mne.preprocessing.ICA` reported incorrect values for the explained variance. This information has been removed from the representations, and should instead be retrieved via the new :meth:`~mne.preprocessing.ICA.get_explained_variance_ratio` method (:gh:`11141` by `Richard Höchenberger`_)
-- Fix bug in :func:`mne.viz._rgb` where a nan location value in any channel causes spatial colours to fail (:gh:`6870` by `Simeon Wong`_)
+- Fix bug in :func:`mne.viz.plot_topomap` and related methods where a ``np.nan`` location value in any channel causes spatial colours to fail (:gh:`6870` by `Simeon Wong`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -61,7 +61,7 @@ Bugs
 - Fix bug in :func:`mne.io.read_raw_bti` where EEG, EMG, and H/VEOG channels were not detected properly, and many non-ECG channels were called ECG. The logic has been improved, and any channels of unknown type are now labeled as ``misc`` (:gh:`11102` by `Eric Larson`_)
 - Fix bug in :func:`mne.viz.plot_topomap` when providing ``sphere="eeglab"`` (:gh:`11081` by `Mathieu Scheltienne`_)
 - The string and HTML representation of :class:`mne.preprocessing.ICA` reported incorrect values for the explained variance. This information has been removed from the representations, and should instead be retrieved via the new :meth:`~mne.preprocessing.ICA.get_explained_variance_ratio` method (:gh:`11141` by `Richard Höchenberger`_)
-- Fix bug in :func:`mne.viz.plot_topomap` and related methods where a ``np.nan`` location value in any channel causes spatial colours to fail (:gh:`6870` by `Simeon Wong`_)
+- Fix bug in :func:`mne.Evoked.plot` and related methods where a ``np.nan`` location value in any channel causes spatial colours to fail (:gh:`6870` by `Simeon Wong`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -61,6 +61,7 @@ Bugs
 - Fix bug in :func:`mne.io.read_raw_bti` where EEG, EMG, and H/VEOG channels were not detected properly, and many non-ECG channels were called ECG. The logic has been improved, and any channels of unknown type are now labeled as ``misc`` (:gh:`11102` by `Eric Larson`_)
 - Fix bug in :func:`mne.viz.plot_topomap` when providing ``sphere="eeglab"`` (:gh:`11081` by `Mathieu Scheltienne`_)
 - The string and HTML representation of :class:`mne.preprocessing.ICA` reported incorrect values for the explained variance. This information has been removed from the representations, and should instead be retrieved via the new :meth:`~mne.preprocessing.ICA.get_explained_variance_ratio` method (:gh:`11141` by `Richard Höchenberger`_)
+- Fix bug in :func:`mne.viz._rgb` where a nan location value in any channel causes spatial colours to fail (:gh:`6870` by `Simeon Wong`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -168,8 +168,8 @@ def _topo_closed(events, ax, lines, fill):
 def _rgb(x, y, z):
     """Transform x, y, z values into RGB colors."""
     rgb = np.array([x, y, z]).T
-    rgb -= rgb.min(0)
-    rgb /= np.maximum(rgb.max(0), 1e-16)  # avoid div by zero
+    rgb -= np.nanmin(rgb, 0)
+    rgb /= np.maximum(np.nanmax(rgb, 0), 1e-16)  # avoid div by zero
     return rgb
 
 

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -182,6 +182,13 @@ def test_plot_evoked():
     with pytest.raises(ValueError, match='must be reshapable into a 2D array'):
         fig = evoked.plot(time_unit='s', highlight=0.1)
 
+    # test butterfly plot handling of nan location values
+    evoked = _get_epochs().load_data().average('grad')  # reload data
+    evoked.info['chs'][0]['loc'][:] = np.nan  # erase spatial location info
+    fig = evoked.plot(time_unit='s', spatial_colors=True)  # plot evoked with topography
+    line_clr = [x.get_color() for x in fig.axes[0].get_lines()]  # get line colors
+    assert not np.all(np.isnan(line_clr) & (line_clr == 0))  # confirm not all lines are black / nan
+
 
 def test_constrained_layout():
     """Test that we handle constrained layouts correctly."""

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -182,12 +182,12 @@ def test_plot_evoked():
     with pytest.raises(ValueError, match='must be reshapable into a 2D array'):
         fig = evoked.plot(time_unit='s', highlight=0.1)
 
-    # test butterfly plot handling of nan location values
+    # set one channel location to nan, confirm spatial_colors still works
     evoked = _get_epochs().load_data().average('grad')  # reload data
-    evoked.info['chs'][0]['loc'][:] = np.nan  # erase spatial location info
-    fig = evoked.plot(time_unit='s', spatial_colors=True)  # plot evoked with topography
-    line_clr = [x.get_color() for x in fig.axes[0].get_lines()]  # get line colors
-    assert not np.all(np.isnan(line_clr) & (line_clr == 0))  # confirm not all lines are black / nan
+    evoked.info['chs'][0]['loc'][:] = np.nan 
+    fig = evoked.plot(time_unit='s', spatial_colors=True)
+    line_clr = [x.get_color() for x in fig.axes[0].get_lines()]
+    assert not np.all(np.isnan(line_clr) & (line_clr == 0))  
 
 
 def test_constrained_layout():

--- a/mne/viz/tests/test_evoked.py
+++ b/mne/viz/tests/test_evoked.py
@@ -184,10 +184,10 @@ def test_plot_evoked():
 
     # set one channel location to nan, confirm spatial_colors still works
     evoked = _get_epochs().load_data().average('grad')  # reload data
-    evoked.info['chs'][0]['loc'][:] = np.nan 
+    evoked.info['chs'][0]['loc'][:] = np.nan
     fig = evoked.plot(time_unit='s', spatial_colors=True)
     line_clr = [x.get_color() for x in fig.axes[0].get_lines()]
-    assert not np.all(np.isnan(line_clr) & (line_clr == 0))  
+    assert not np.all(np.isnan(line_clr) & (line_clr == 0))
 
 
 def test_constrained_layout():


### PR DESCRIPTION
…for spatial_colors feature

#### Reference issue
Fixes #6870


#### What does this implement/fix?
Evoked butterfly plots with spatial_colors=True will plot all traces in black when any of the DigMontage coordinates are nan. The expected behaviour is that sensors with nan coordinates will be in black, while the remaining traces will be coloured.

This fix uses `np.nanmin` and `np.nanmax` instead of `np.amin` and `np.amax` when transforming x,y,z coordinates into colours, resulting in the expected behaviour.


#### Additional information

