### PR TITLE
FIX: Qt toolbar

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -65,6 +65,8 @@ Bugs
 
 - Fix bug in coregistration GUI that prevented it from starting up if only a high-resolution head model was available (:gh:`10543` by `Richard Höchenberger`_)
 
+- Fix bug in the :class:`mne.viz.Brain` tool bar that prevented the buttons to call the corresponding feature (:gh:`10560` by `Guillaume Favelier`_)
+
 API and behavior changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - When creating BEM surfaces via :func:`mne.bem.make_watershed_bem` and :func:`mne.bem.make_flash_bem`, the ``copy`` parameter now defaults to ``True``. This means that instead of creating symbolic links inside the FreeSurfer subject's ``bem`` folder, we now create "actual" files. This should avoid troubles when sharing files across different operating systems and file systems (:gh:`10531` by `Richard Höchenberger`_)

--- a/mne/gui/tests/test_gui_api.py
+++ b/mne/gui/tests/test_gui_api.py
@@ -157,7 +157,7 @@ def test_gui_api(renderer_notebook, nbexec, n_warn=0):
         rng=['foo', 'bar'],
         callback=mock,
     )
-    with _check_widget_trigger(widget, mock, 'foo', 'bar', get_value=False):
+    with _check_widget_trigger(widget, mock, None, None, get_value=False):
         widget.set_value(1, 'bar')
     assert widget.get_value(0) == 'foo'
     assert widget.get_value(1) == 'bar'
@@ -253,7 +253,7 @@ def test_gui_api(renderer_notebook, nbexec, n_warn=0):
         func=mock,
         shortcut=None,
     )
-    assert 'help' in renderer.actions
+    renderer.actions['help'].trigger()
 
     # play button
     assert 'play' not in renderer.actions

--- a/mne/viz/_brain/_linkviewer.py
+++ b/mne/viz/_brain/_linkviewer.py
@@ -134,7 +134,7 @@ class _LinkViewer(object):
     def link_widgets(self, name, callback, signal_type, actions=False):
         for brain in self.brains:
             if actions:
-                widget = brain._renderer.actions[name]
+                widget = brain._renderer.actions[name]._action
             else:
                 widget = brain.widgets[name].widget
             if widget is not None:

--- a/mne/viz/_brain/tests/test_notebook.py
+++ b/mne/viz/_brain/tests/test_notebook.py
@@ -109,7 +109,6 @@ def test_notebook_interactive(renderer_notebook, brain_gc, nbexec):
 def test_notebook_button_counts(renderer_notebook, brain_gc, nbexec):
     """Test button counts."""
     import mne
-    from ipywidgets import Button
     mne.viz.set_3d_backend('notebook')
     rend = mne.viz.create_3d_figure(size=(100, 100), scene=False)
     fig = rend.scene()
@@ -120,8 +119,9 @@ def test_notebook_button_counts(renderer_notebook, brain_gc, nbexec):
     total_number_of_buttons = sum(
         '_field' not in k for k in rend.actions.keys())
     number_of_buttons = 0
-    for action in rend.actions.values():
-        if isinstance(action, Button):
+    for widget in rend.actions.values():
+        if hasattr(widget, '_action'):
+            action = widget._action
             action.click()
             number_of_buttons += 1
     assert number_of_buttons == total_number_of_buttons

--- a/mne/viz/_brain/tests/test_notebook.py
+++ b/mne/viz/_brain/tests/test_notebook.py
@@ -120,8 +120,8 @@ def test_notebook_button_counts(renderer_notebook, brain_gc, nbexec):
         '_field' not in k for k in rend.actions.keys())
     number_of_buttons = 0
     for widget in rend.actions.values():
-        if hasattr(widget, '_action'):
-            action = widget._action
+        action = widget._action
+        if hasattr(action, "click"):
             action.click()
             number_of_buttons += 1
     assert number_of_buttons == total_number_of_buttons

--- a/mne/viz/_brain/tests/test_notebook.py
+++ b/mne/viz/_brain/tests/test_notebook.py
@@ -109,6 +109,7 @@ def test_notebook_interactive(renderer_notebook, brain_gc, nbexec):
 def test_notebook_button_counts(renderer_notebook, brain_gc, nbexec):
     """Test button counts."""
     import mne
+    from ipywidgets import Button
     mne.viz.set_3d_backend('notebook')
     rend = mne.viz.create_3d_figure(size=(100, 100), scene=False)
     fig = rend.scene()
@@ -121,7 +122,7 @@ def test_notebook_button_counts(renderer_notebook, brain_gc, nbexec):
     number_of_buttons = 0
     for widget in rend.actions.values():
         action = widget._action
-        if hasattr(action, "click"):
+        if isinstance(action, Button):
             action.click()
             number_of_buttons += 1
     assert number_of_buttons == total_number_of_buttons

--- a/mne/viz/_brain/tests/test_notebook.py
+++ b/mne/viz/_brain/tests/test_notebook.py
@@ -120,10 +120,10 @@ def test_notebook_button_counts(renderer_notebook, brain_gc, nbexec):
     total_number_of_buttons = sum(
         '_field' not in k for k in rend.actions.keys())
     number_of_buttons = 0
-    for widget in rend.actions.values():
-        action = widget._action
-        if isinstance(action, Button):
-            action.click()
+    for action in rend.actions.values():
+        widget = action._action
+        if isinstance(widget, Button):
+            widget.click()
             number_of_buttons += 1
     assert number_of_buttons == total_number_of_buttons
     assert fig.display is not None

--- a/mne/viz/_brain/tests/test_notebook.py
+++ b/mne/viz/_brain/tests/test_notebook.py
@@ -88,8 +88,9 @@ def test_notebook_interactive(renderer_notebook, brain_gc, nbexec):
         # play is not a button widget, it does not have a click() method
         number_of_buttons = 1
         for action in brain._renderer.actions.values():
-            if isinstance(action, Button):
-                action.click()
+            widget = action._action
+            if isinstance(widget, Button):
+                widget.click()
                 number_of_buttons += 1
         assert number_of_buttons == total_number_of_buttons
         assert os.path.isfile(movie_path)

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -735,6 +735,14 @@ class _AbstractAction(ABC):
     def trigger(self):
         pass
 
+    @abstractmethod
+    def set_icon(self):
+        pass
+
+    @abstractmethod
+    def set_shortcut(self):
+        pass
+
 
 class _AbstractMplInterface(ABC):
     @abstractmethod

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -427,7 +427,7 @@ class _IpyToolBar(_AbstractToolBar, _IpyLayout):
     def _tool_bar_add_play_button(self, name, desc, func, *, shortcut=None):
         widget = Play(interval=500)
         self._layout_add_widget(self._tool_bar_layout, widget)
-        self.actions[name] = widget
+        self.actions[name] = _IpyAction(widget)
         return _IpyWidget(widget)
 
 

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -396,10 +396,10 @@ class _IpyToolBar(_AbstractToolBar, _IpyLayout):
         widget = Button(tooltip=desc, icon=icon)
         widget.on_click(lambda x: func())
         self._layout_add_widget(self._tool_bar_layout, widget)
-        self.actions[name] = widget
+        self.actions[name] = _IpyAction(widget)
 
     def _tool_bar_update_button_icon(self, name, icon_name):
-        self.actions[name].icon = self._icons[icon_name]
+        self.actions[name].set_icon(self._icons[icon_name])
 
     def _tool_bar_add_text(self, name, value, placeholder):
         widget = Text(value=value, placeholder=placeholder)
@@ -658,7 +658,16 @@ class _IpyWidget(_AbstractWidget):
 
 class _IpyAction(_AbstractAction):
     def trigger(self):
-        self._action()
+        if callable(self._action):
+            self._action()
+        else:  # standard Button widget
+            self._action.click()
+
+    def set_icon(self, icon):
+        self._action.icon = icon
+
+    def set_shortcut(self, shortcut):
+        pass
 
 
 class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -404,7 +404,7 @@ class _IpyToolBar(_AbstractToolBar, _IpyLayout):
     def _tool_bar_add_text(self, name, value, placeholder):
         widget = Text(value=value, placeholder=placeholder)
         self._layout_add_widget(self._tool_bar_layout, widget)
-        self.actions[name] = widget
+        self.actions[name] = _IpyAction(widget)
 
     def _tool_bar_add_spacer(self):
         pass

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -401,13 +401,13 @@ class _QtToolBar(_AbstractToolBar, _QtLayout):
                              shortcut=None):
         icon_name = name if icon_name is None else icon_name
         icon = self._icons[icon_name]
-        self.actions[name] = self._tool_bar.addAction(
-            icon, desc, func)
+        self.actions[name] = _QtAction(self._tool_bar.addAction(
+            icon, desc, func))
         if shortcut is not None:
-            self.actions[name].setShortcut(shortcut)
+            self.actions[name].set_shortcut(shortcut)
 
     def _tool_bar_update_button_icon(self, name, icon_name):
-        self.actions[name].setIcon(self._icons[icon_name])
+        self.actions[name].set_icon(self._icons[icon_name])
 
     def _tool_bar_add_text(self, name, value, placeholder):
         pass
@@ -796,6 +796,12 @@ class _QtDialogWidget(_QtWidget):
 class _QtAction(_AbstractAction):
     def trigger(self):
         self._action.trigger()
+
+    def set_icon(self, icon):
+        self._action.setIcon(icon)
+
+    def set_shortcut(self, shortcut):
+        self._action.setShortcut(shortcut)
 
 
 class _Renderer(_PyVistaRenderer, _QtDock, _QtToolBar, _QtMenuBar,

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -425,7 +425,7 @@ class _QtToolBar(_AbstractToolBar, _QtLayout):
             if weakself is None:
                 return
             return FileDialog(
-                weakself.app_window,
+                weakself._window,
                 callback=func,
             )
 


### PR DESCRIPTION
This PR fixes Qt toolbar callbacks (*e.g.* in `Brain`):

```
Using pyvistaqt 3d backend.


Traceback (most recent call last):
  File "/home/guillaume/source/mne-python/mne/viz/backends/_qt.py", line 428, in callback
    weakself.app_window,
AttributeError: '_Renderer' object has no attribute 'app_window'
```

It also adds a test to avoid regression and does simple refactoring of 'actions' (Qt name for callables which can have an icon and shortcut).