### PR TITLE
MAINT: Add export functions to env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -45,3 +45,5 @@ dependencies:
 - ipyvtklink
 - mne-qt-browser
 - pymatreader
+- eeglabio
+- edflib-python


### PR DESCRIPTION
This should fail until eeglabio finishes building on conda-forge and lands on the CDNs. I'll restart the CIs in a few hours then hopefully merge when green!

This shouldn't have a big impact on CIs since these are already in `requirements_testing_extra.txt`, but any users who use `environment.yml` should hopefully benefit.