### PR TITLE
ENH: Add head_source option

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -37,7 +37,7 @@ Enhancements
 
 - Add example of Xfit-style ECD modeling using multiple dipoles (:gh:`10464` by `Marijn van Vliet`_)
 
-- Add ``head_source`` argument to :func:`mne.make_field_maps` to allow selecting which head source to use (:gh:`10568` by `Eric Larson`)_
+- Add ``head_source`` argument to :func:`mne.make_field_map` to allow selecting which head source to use (:gh:`10568` by `Eric Larson`_)
 
 - It is now possible to compute inverse solutions with restricted source orientations using discrete forward models (:gh:`10464` by `Marijn van Vliet`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -37,6 +37,8 @@ Enhancements
 
 - Add example of Xfit-style ECD modeling using multiple dipoles (:gh:`10464` by `Marijn van Vliet`_)
 
+- Add ``head_source`` argument to :func:`mne.make_field_maps` to allow selecting which head source to use (:gh:`10568` by `Eric Larson`)_
+
 - It is now possible to compute inverse solutions with restricted source orientations using discrete forward models (:gh:`10464` by `Marijn van Vliet`_)
 
 - The new function :func:`mne.preprocessing.maxwell_filter_prepare_emptyroom` simplifies the preconditioning of an empty-room recording for our Maxwell filtering operations (:gh:`10533` by `Richard Höchenberger`_ and `Eric Larson`_)

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -385,7 +385,8 @@ def _make_surface_mapping(info, surf, ch_type='meg', trans=None, mode='fast',
 @verbose
 def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
                    ch_type=None, mode='fast', meg_surf='helmet',
-                   origin=(0., 0., 0.04), n_jobs=1, verbose=None):
+                   origin=(0., 0., 0.04), n_jobs=1, *,
+                   head_source=('bem', 'head'), verbose=None):
     """Compute surface maps used for field display in 3D.
 
     Parameters
@@ -420,6 +421,11 @@ def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
 
         .. versionadded:: 0.11
     %(n_jobs)s
+    head_source : str | list of str
+        Head source(s) to use. See the ``source`` option of
+        :func:`mne.get_head_surf` for more information.
+
+        .. versionadded:: 1.1
     %(verbose)s
 
     Returns
@@ -459,7 +465,8 @@ def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
         if this_type == 'meg' and meg_surf == 'helmet':
             surf = get_meg_helmet_surf(info, trans)
         else:
-            surf = get_head_surf(subject, subjects_dir=subjects_dir)
+            surf = get_head_surf(
+                subject, source=head_source, subjects_dir=subjects_dir)
         surfs.append(surf)
 
     surf_maps = list()

--- a/mne/io/open.py
+++ b/mne/io/open.py
@@ -140,19 +140,20 @@ def _fiff_open(fname, fid, preload):
     tag = read_tag_info(fid)
 
     #   Check that this looks like a fif file
+    prefix = f'file {repr(fname)} does not'
     if tag.kind != FIFF.FIFF_FILE_ID:
-        raise ValueError('file does not start with a file id tag')
+        raise ValueError(f'{prefix} start with a file id tag')
 
     if tag.type != FIFF.FIFFT_ID_STRUCT:
-        raise ValueError('file does not start with a file id tag')
+        raise ValueError(f'{prefix} start with a file id tag')
 
     if tag.size != 20:
-        raise ValueError('file does not start with a file id tag')
+        raise ValueError(f'{prefix} start with a file id tag')
 
     tag = read_tag(fid)
 
     if tag.kind != FIFF.FIFF_DIR_POINTER:
-        raise ValueError('file does not have a directory pointer')
+        raise ValueError(f'{prefix} have a directory pointer')
 
     #   Read or create the directory tree
     logger.debug('    Creating tag directory for %s...' % fname)

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -404,9 +404,10 @@ def plot_evoked_field(evoked, surf_maps, time=None, time_label='t = %0.0f ms',
                          polygon_offset=-1)
 
         # And the field lines on top
-        renderer.contour(surface=surf, scalars=data, contours=n_contours,
-                         vmin=-vmax, vmax=vmax, opacity=alpha,
-                         colormap=colormap_lines)
+        if n_contours > 0:
+            renderer.contour(surface=surf, scalars=data, contours=n_contours,
+                             vmin=-vmax, vmax=vmax, opacity=alpha,
+                             colormap=colormap_lines)
 
     if time_label is not None:
         if '%' in time_label:

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -156,8 +156,8 @@ def test_plot_evoked_field(renderer):
         with pytest.warns(RuntimeWarning, match='projection'):
             maps = make_field_map(evoked, trans_fname, subject='sample',
                                   subjects_dir=subjects_dir, n_jobs=1,
-                                  ch_type=t, n_contours=n_contours)
-        evoked.plot_field(maps, time=0.1)
+                                  ch_type=t)
+        evoked.plot_field(maps, time=0.1, n_contours=n_contours)
 
 
 def _assert_n_actors(fig, renderer, n_actors):

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -152,11 +152,11 @@ def test_plot_evoked_field(renderer):
     evoked = read_evokeds(evoked_fname, condition='Left Auditory',
                           baseline=(-0.2, 0.0))
     evoked = pick_channels_evoked(evoked, evoked.ch_names[::10])  # speed
-    for t in ['meg', None]:
+    for t, n_contours in zip(['meg', None], [21, 0]):
         with pytest.warns(RuntimeWarning, match='projection'):
             maps = make_field_map(evoked, trans_fname, subject='sample',
                                   subjects_dir=subjects_dir, n_jobs=1,
-                                  ch_type=t)
+                                  ch_type=t, n_contours=n_contours)
         evoked.plot_field(maps, time=0.1)
 
 


### PR DESCRIPTION
No need to add a test here I think because it's just a pass-through argument, and tests of `get_head_surface` should be sufficient to test arg validity.

I also improved a few error messages in `mne/io/open.py` that helped me know which file was actually problematic.