### PR TITLE
MNT: dialog box icon

### DIFF
--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -717,7 +717,7 @@ class CoregistrationUI(HasTraits):
         for name, buttons in zip(
                 ["overwrite_subject", "overwrite_subject_exit"],
                 [["Yes", "No"], ["Yes", "Discard", "Cancel"]]):
-            self._widgets[name] = self._renderer._dialog_warning(
+            self._widgets[name] = self._renderer._dialog_create(
                 title="CoregistrationUI",
                 text="The name of the output subject used to "
                      "save the scaled anatomy already exists.",
@@ -1863,7 +1863,7 @@ class CoregistrationUI(HasTraits):
                 if self._subject_to:
                     self._save_subject(exit_mode=True)
                 else:
-                    dialog = self._renderer._dialog_warning(
+                    dialog = self._renderer._dialog_create(
                         title="CoregistrationUI",
                         text="The name of the output subject used to "
                              "save the scaled anatomy is not set.",
@@ -1893,7 +1893,7 @@ class CoregistrationUI(HasTraits):
             if self._mri_scale_modified:
                 text += "<li>scaled subject MRI</li>"
             text += "</ul>"
-            self._widgets["close_dialog"] = self._renderer._dialog_warning(
+            self._widgets["close_dialog"] = self._renderer._dialog_create(
                 title="CoregistrationUI",
                 text=text,
                 info_text="Do you want to save?",

--- a/mne/gui/tests/test_gui_api.py
+++ b/mne/gui/tests/test_gui_api.py
@@ -319,7 +319,7 @@ def test_gui_api(renderer_notebook, nbexec, n_warn=0):
     if renderer._kind == 'qt':
         # warning
         buttons = ["Save", "Cancel"]
-        widget = renderer._dialog_warning(
+        widget = renderer._dialog_create(
             title='',
             text='',
             info_text='',
@@ -335,7 +335,7 @@ def test_gui_api(renderer_notebook, nbexec, n_warn=0):
 
         # buttons list empty means OK button (default)
         button = 'Ok'
-        widget = renderer._dialog_warning(
+        widget = renderer._dialog_create(
             title='',
             text='',
             info_text='',

--- a/mne/gui/tests/test_gui_api.py
+++ b/mne/gui/tests/test_gui_api.py
@@ -340,6 +340,7 @@ def test_gui_api(renderer_notebook, nbexec, n_warn=0):
             text='',
             info_text='',
             callback=mock,
+            icon='NoIcon',
             modal=False,
         )
         widget.show()

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -645,8 +645,8 @@ class _AbstractPlayback(ABC):
 
 class _AbstractDialog(ABC):
     @abstractmethod
-    def _dialog_warning(self, title, text, info_text, callback, *,
-                        buttons=[], modal=True, window=None):
+    def _dialog_create(self, title, text, info_text, callback, *,
+                       icon='Warning', buttons=[], modal=True, window=None):
         pass
 
 

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -161,8 +161,8 @@ class _FilePicker:
 
 
 class _IpyDialog(_AbstractDialog):
-    def _dialog_warning(self, title, text, info_text, callback, *,
-                        buttons=[], modal=True, window=None):
+    def _dialog_create(self, title, text, info_text, callback, *,
+                       icon='Warning', buttons=[], modal=True, window=None):
         pass
 
 

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -35,13 +35,26 @@ from ..utils import _check_option, safe_event, get_config
 
 
 class _QtDialog(_AbstractDialog):
-    def _dialog_warning(self, title, text, info_text, callback, *,
-                        buttons=[], modal=True, window=None):
+    # from QMessageBox.StandardButtons
+    supported_button_names = [
+        "Ok", "Open", "Save", "Cancel", "Close", "Discard", "Apply",
+        "Reset", "RestoreDefaults", "Help", "SaveAll", "Yes",
+        "YesToAll", "No", "NoToAll", "Abort", "Retry", "Ignore"
+    ]
+    # from QMessageBox.Icon
+    supported_icon_names = [
+        "NoIcon", "Question", "Information", "Warning", "Critical"
+    ]
+
+    def _dialog_create(self, title, text, info_text, callback, *,
+                       icon='Warning', buttons=[], modal=True, window=None):
         window = self._window if window is None else window
         widget = QMessageBox(window)
         widget.setWindowTitle(title)
         widget.setText(text)
-        widget.setIcon(QMessageBox.Warning)
+        # icon is one of _QtDialog.supported_icon_names
+        icon_id = getattr(QMessageBox, icon)
+        widget.setIcon(icon_id)
         widget.setInformativeText(info_text)
 
         if not buttons:
@@ -49,7 +62,7 @@ class _QtDialog(_AbstractDialog):
 
         button_ids = list()
         for button in buttons:
-            # button is one of QMessageBox.StandardButtons
+            # button is one of _QtDialog.supported_button_names
             button_id = getattr(QMessageBox, button)
             button_ids.append(button_id)
         standard_buttons = default_button = button_ids[0]
@@ -61,12 +74,7 @@ class _QtDialog(_AbstractDialog):
         @safe_event
         def func(button):
             button_id = widget.standardButton(button)
-            supported_button_names = [
-                "Ok", "Open", "Save", "Cancel", "Close", "Discard", "Apply",
-                "Reset", "RestoreDefaults", "Help", "SaveAll", "Yes",
-                "YesToAll", "No", "NoToAll", "Abort", "Retry", "Ignore"
-            ]
-            for button_name in supported_button_names:
+            for button_name in _QtDialog.supported_button_names:
                 if button_id == getattr(QMessageBox, button_name):
                     widget.setCursor(QCursor(Qt.WaitCursor))
                     try:


### PR DESCRIPTION
This small PR allows setting the Qt dialog box icon (instead of using only :warning: ). The default remains `'Warning'` though.

It's part of https://github.com/mne-tools/mne-python/pull/10565