### PR TITLE
MNT: dock area

### DIFF
--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -95,10 +95,7 @@ class _QtDock(_AbstractDock, _QtLayout):
     def _dock_initialize(self, window=None, name="Controls",
                          area="left", max_width=None):
         window = self._window if window is None else window
-        qt_area = list(area.lower())
-        qt_area[0] = qt_area[0].upper()
-        qt_area = ''.join(qt_area)
-        qt_area = getattr(Qt, qt_area + 'DockWidgetArea')
+        qt_area = getattr(Qt, f'{area.capitalize()}DockWidgetArea')
         self._dock, self._dock_layout = _create_dock_widget(
             window, name, qt_area, max_width=max_width
         )

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -95,10 +95,12 @@ class _QtDock(_AbstractDock, _QtLayout):
     def _dock_initialize(self, window=None, name="Controls",
                          area="left", max_width=None):
         window = self._window if window is None else window
-        qt_area = Qt.LeftDockWidgetArea if area == "left" \
-            else Qt.RightDockWidgetArea
+        qt_area = list(area.lower())
+        qt_area[0] = qt_area[0].upper()
+        qt_area = ''.join(qt_area)
+        qt_area = getattr(Qt, qt_area + 'DockWidgetArea')
         self._dock, self._dock_layout = _create_dock_widget(
-            self._window, name, qt_area, max_width=max_width
+            window, name, qt_area, max_width=max_width
         )
         if area == "left":
             window.setCorner(Qt.BottomLeftCorner, Qt.LeftDockWidgetArea)


### PR DESCRIPTION
This small PR allows setting dock areas other than 'left' and 'right' (namely 'top' and 'bottom').

Here is a small code snippet to try:

<details>

```py
from mne.viz.backends.renderer import _get_renderer

renderer = _get_renderer()
for area in ['top', 'bottom', 'left', 'right']:
    renderer._dock_initialize(area=area)  # <---- new parameter here
    renderer._dock_add_button(area, lambda x: None)
renderer.show()
```

</details>

It's a part of https://github.com/mne-tools/mne-python/pull/10565