### PR TITLE
[ENH, MRG] More intuitive colormaps for EEG bridging tutorial

### DIFF
--- a/examples/preprocessing/eeg_bridging.py
+++ b/examples/preprocessing/eeg_bridging.py
@@ -35,6 +35,7 @@ https://psychophysiology.cpmc.columbia.edu/software/eBridge/tutorial.html.
 
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.colors import LinearSegmentedColormap
 
 import mne
 
@@ -236,13 +237,25 @@ for sub, (bridged_idx, ed_matrix) in ed_data.items():
 # 04-modality-specific-files/03-electroencephalography.html\
 # #electrodes-description-_electrodestsv>`_ file.
 # Since the impedances are not stored for this dataset, we will fake
-# them to demonstrate how they would be plotted.
+# them to demonstrate how they would be plotted. Here, the impedances
+# are plotted as is typical at the end of a setup; most channels are
+# good but there are a few that need to have their impedance lowered.
+# The impedances should ideally all be less than 25 KOhm before
+# starting an experiment when using active systems and less than 5 KOhm
+# when using a passive system.
 
 rng = np.random.default_rng(11)  # seed for reproducibility
 raw = raw_data[1]
-impedances = rng.random((len(raw.ch_names,))) * 10
+# typically impedances < 25 kOhm are acceptable for active systems and
+# impedances < 5 kOhm are desirable for a passive system
+impedances = rng.random((len(raw.ch_names,))) * 30
+impedances[10] = 80  # set a few bad impendances
+impedances[25] = 99
+cmap = LinearSegmentedColormap.from_list(name='impedance_cmap',
+                                         colors=['g', 'y', 'r'], N=256)
 fig, ax = plt.subplots(figsize=(5, 5))
-im, cn = mne.viz.plot_topomap(impedances, raw.info, axes=ax)
+im, cn = mne.viz.plot_topomap(impedances, raw.info, axes=ax,
+                              cmap=cmap, vmin=25, vmax=75)
 ax.set_title('Electrode Impendances')
 cax = fig.colorbar(im, ax=ax)
 cax.set_label(r'Impedance (k$\Omega$)')

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -964,7 +964,7 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     norm = min(data) >= 0
     vmin, vmax = _setup_vmin_vmax(data, vmin, vmax, norm)
     if cmap is None:
-        cmap = 'Reds' if norm else 'RdBu_r'
+        cmap = plt.get_cmap('Reds' if norm else 'RdBu_r')
     elif isinstance(cmap, str):
         cmap = plt.get_cmap(cmap)
 

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -964,7 +964,9 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     norm = min(data) >= 0
     vmin, vmax = _setup_vmin_vmax(data, vmin, vmax, norm)
     if cmap is None:
-        cmap = plt.get_cmap('Reds' if norm else 'RdBu_r')
+        cmap = 'Reds' if norm else 'RdBu_r'
+    elif isinstance(cmap, str):
+        cmap = plt.get_cmap(cmap)
 
     outlines = _make_head_outlines(sphere, pos, outlines, (0., 0.))
     assert isinstance(outlines, dict)
@@ -2687,6 +2689,7 @@ def plot_bridged_electrodes(info, bridged_idx, ed_matrix, title=None,
     else:
         topomap_args = topomap_args.copy()  # don't change original
     topomap_args.setdefault('image_interp', 'voronoi')
+    topomap_args.setdefault('cmap', 'summer_r')
     topomap_args.setdefault('names', info.ch_names)
     topomap_args.setdefault('show_names', True)
     topomap_args.setdefault('contours', False)


### PR DESCRIPTION
After thinking about it, https://github.com/mne-tools/mne-python/pull/10571 used the default colormaps which didn't represent the data well based on our intuitive associations with colors. This sets high distances to green and low to yellow for the bridging and has a typical green, yellow, red impedance topoplot.