### PR TITLE
[ENH, MRG] Add interpolate bridged electrodes function

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -51,8 +51,7 @@ Enhancements
 
 - Add ``'voronoi'`` as an option for the ``image_interp`` argument in :func:`mne.viz.plot_topomap` to plot a topomap without interpolation using a Voronoi parcelation (:gh:`10571` by `Alex Rockhill`_)
 
-- Add :func:`mne.preprocessing.interpolate_bridged_electrodes` to use the spatially smeared signal to get a
-better interpolation rather than dropping those channels (:gh:`10587` by `Alex Rockhill`_)
+- Add :func:`mne.preprocessing.interpolate_bridged_electrodes` to use the spatially smeared signal to get a better interpolation rather than dropping those channels (:gh:`10587` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -51,6 +51,9 @@ Enhancements
 
 - Add ``'voronoi'`` as an option for the ``image_interp`` argument in :func:`mne.viz.plot_topomap` to plot a topomap without interpolation using a Voronoi parcelation (:gh:`10571` by `Alex Rockhill`_)
 
+- Add :func:`mne.preprocessing.interpolate_bridged_electrodes` to use the spatially smeared signal to get a
+better interpolation rather than dropping those channels (:gh:`` by `Alex Rockhill`_)
+
 Bugs
 ~~~~
 - Make ``color`` parameter check in in :func:`mne.viz.plot_evoked_topo` consistent (:gh:`10217` by :newcontrib:`T. Wang` and `Stefan Appelhoff`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -52,7 +52,7 @@ Enhancements
 - Add ``'voronoi'`` as an option for the ``image_interp`` argument in :func:`mne.viz.plot_topomap` to plot a topomap without interpolation using a Voronoi parcelation (:gh:`10571` by `Alex Rockhill`_)
 
 - Add :func:`mne.preprocessing.interpolate_bridged_electrodes` to use the spatially smeared signal to get a
-better interpolation rather than dropping those channels (:gh:`` by `Alex Rockhill`_)
+better interpolation rather than dropping those channels (:gh:`10587` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/doc/preprocessing.rst
+++ b/doc/preprocessing.rst
@@ -91,6 +91,7 @@ Projections:
    ica_find_ecg_events
    ica_find_eog_events
    infomax
+   interpolate_bridged_electrodes
    equalize_bads
    maxwell_filter
    maxwell_filter_prepare_emptyroom

--- a/examples/preprocessing/eeg_bridging.py
+++ b/examples/preprocessing/eeg_bridging.py
@@ -16,13 +16,14 @@ spatial smearing. An algorithm has been developed to detect electrode
 bridging :footcite:`TenkeKayser2001`, which has been implemented in EEGLAB
 :footcite:`DelormeMakeig2004`. Unfortunately, there is not a lot to be
 done about electrode brigding once the data has been collected as far as
-preprocessing. Therefore, the recommendation is to check for electrode
-bridging early in data collection and address the problem. Or, if the data
-has already been collected, quantify the extent of the bridging so as not
-to introduce bias into the data from this effect and exclude subjects with
-bridging that might effect the outcome of a study. Preventing electrode
-bridging is ideal but awareness of the problem at least will mitigate its
-potential as a confound to a study. This tutorial follows
+preprocessing other than interpolating bridged channels. Therefore, our
+recommendation is to check for electrode bridging early in data collection
+and address the problem. Or, if the data has already been collected, quantify
+the extent of the bridging so as not to introduce bias into the data from this
+effect and exclude subjects with bridging that might effect the outcome of a
+study. Preventing electrode bridging is ideal but awareness of the problem at
+least will mitigate its potential as a confound to a study. This tutorial
+follows
 https://psychophysiology.cpmc.columbia.edu/software/eBridge/tutorial.html.
 """
 # Authors: Alex Rockhill <aprockhill@mailbox.org>
@@ -222,6 +223,22 @@ for sub, (bridged_idx, ed_matrix) in ed_data.items():
     mne.viz.plot_bridged_electrodes(
         raw_data[sub].info, bridged_idx, ed_matrix,
         title=f'Subject {sub} Bridged Electrodes', topomap_args=dict(vmax=5))
+
+# %%
+# For subjects with many bridged channels like Subject 6 shown in the example
+# above, it is advisable to exclude the subject. This because EEG recording
+# montage will not be comparable with the other subjects. And, if we tried to
+# interpole, the interpolation would depend on other channels which are also
+# bridged in that case. However, for subjects with only a few bridged channels,
+# those channels can be interpolated. Since the bridged data is still
+# biological (i.e. it is recording the subject's brain), it's just spatially
+# smeared, we can use :func:`mne.preprocessing.interpolate_bridged_electrodes`
+# to make a virtual channel midway between the two bridged channels
+# to aid in interpolation.
+
+# use subject 2, only one bridged electrode pair
+raw = mne.preprocessing.interpolate_bridged_channels(
+    raw_data[2], bridged_idx=ed_data[2][1])
 
 # %%
 # The Relationship Between Bridging and Impedances

--- a/examples/preprocessing/eeg_bridging.py
+++ b/examples/preprocessing/eeg_bridging.py
@@ -306,7 +306,7 @@ raw = raw.add_channels([mne.io.RawArray(
     mne.create_info([f'{ch0} comp', f'{ch1} comp',
                      f'{ch0} comp diff', f'{ch1} comp diff'],
                     raw.info['sfreq'], 'eeg'), raw.first_samp)])
-raw.plot(scalings=dict(eeg=2e-4))
+raw.plot(scalings=dict(eeg=7e-5))
 
 # %%
 # The Relationship Between Bridging and Impedances

--- a/examples/preprocessing/eeg_bridging.py
+++ b/examples/preprocessing/eeg_bridging.py
@@ -237,8 +237,9 @@ for sub, (bridged_idx, ed_matrix) in ed_data.items():
 # to aid in interpolation.
 
 # use subject 2, only one bridged electrode pair
-raw = mne.preprocessing.interpolate_bridged_channels(
-    raw_data[2], bridged_idx=ed_data[2][1])
+bridged_idx = ed_data[2][0]
+raw = mne.preprocessing.interpolate_bridged_electrodes(
+    raw_data[2], bridged_idx=bridged_idx)
 
 # %%
 # The Relationship Between Bridging and Impedances

--- a/examples/preprocessing/eeg_bridging.py
+++ b/examples/preprocessing/eeg_bridging.py
@@ -239,7 +239,74 @@ for sub, (bridged_idx, ed_matrix) in ed_data.items():
 # use subject 2, only one bridged electrode pair
 bridged_idx = ed_data[2][0]
 raw = mne.preprocessing.interpolate_bridged_electrodes(
-    raw_data[2], bridged_idx=bridged_idx)
+    raw_data[2].copy(), bridged_idx=bridged_idx)
+
+# %%
+# Let's make sure that our virtual channel aided the interpolation. We can do
+# this by simulating a bridge to make sure that we recover the original data
+# better with the virtual channel method. If we make two channels nearly the
+# same to simulate a bridged electrode but save the original data, we can
+# compare the two interpolation methods. As we can see, the virtual channel
+# recovers the original data more slightly closely. However, as shown in the
+# plots, there is still residual signal for both methods implying that it is
+# there is still a loss of data compared to unbridged channels.
+
+raw = raw_data[2].copy()
+
+# pick two channels to simulate being bridged
+idx0, idx1 = 9, 10
+ch0, ch1 = raw.ch_names[idx0], raw.ch_names[idx1]
+bridged_idx_simulated = [(idx0, idx1)]
+# get the original data to compare to
+data_orig = raw_data[2].get_data(picks=(idx0, idx1))
+
+# simulate a bridge between the two channels by taking their mean and adding
+# some noise
+rng = np.random.default_rng(11)  # seed for reproducibility
+raw_sim = raw.copy()  # raw with simulated electrode bridge
+# remove channels with original data
+raw_sim = raw_sim.drop_channels([ch0, ch1])
+bridged_data = np.tile(np.mean(data_orig, axis=0), (2, 1))  # copy mean
+# add separate noise for each channel
+bridged_data[0] += 1e-7 * rng.normal(size=raw.times.size)
+bridged_data[1] += 1e-7 * rng.normal(size=raw.times.size)
+# add back simulated data
+raw_sim = raw_sim.add_channels([mne.io.RawArray(
+    bridged_data, mne.create_info([ch0, ch1], raw.info['sfreq'], 'eeg'),
+    raw.first_samp)])
+raw_sim.set_montage(montage)  # add back channel positions
+
+# use virtual channel method
+raw_virtual = mne.preprocessing.interpolate_bridged_electrodes(
+    raw_sim.copy(), bridged_idx=bridged_idx_simulated)
+data_virtual = raw_virtual.get_data(picks=(idx0, idx1))
+
+# set bads to be bridged electrodes to interpolate without a virtual channel
+raw_comp = raw_sim.copy()
+raw_comp.info['bads'] = [raw_sim.ch_names[idx0], raw_sim.ch_names[idx1]]
+raw_comp.interpolate_bads()
+data_comp = raw_comp.get_data(picks=(idx0, idx1))
+
+# compute variance of residuals
+print('Variance of residual (interpolated data - original data)\n\n'
+      'With adding virtual channel:                         {}\n'
+      'Compared to interpolation only using other channels: {}'
+      ''.format(np.mean(np.var(data_virtual - data_orig, axis=1)),
+                np.mean(np.var(data_comp - data_orig, axis=1))))
+
+# plot results
+raw = raw.pick_channels([ch0, ch1])
+raw = raw.add_channels([mne.io.RawArray(
+    np.concatenate([data_virtual, data_virtual - data_orig]),
+    mne.create_info([f'{ch0} virtual', f'{ch1} virtual',
+                     f'{ch0} virtual diff', f'{ch1} virtual diff'],
+                    raw.info['sfreq'], 'eeg'), raw.first_samp)])
+raw = raw.add_channels([mne.io.RawArray(
+    np.concatenate([data_comp, data_comp - data_orig]),
+    mne.create_info([f'{ch0} comp', f'{ch1} comp',
+                     f'{ch0} comp diff', f'{ch1} comp diff'],
+                    raw.info['sfreq'], 'eeg'), raw.first_samp)])
+raw.plot(scalings=dict(eeg=2e-4))
 
 # %%
 # The Relationship Between Bridging and Impedances

--- a/mne/preprocessing/__init__.py
+++ b/mne/preprocessing/__init__.py
@@ -30,6 +30,6 @@ from ._regress import regress_artifact
 from ._fine_cal import (compute_fine_calibration, read_fine_calibration,
                         write_fine_calibration)
 from .annotate_nan import annotate_nan
-from .interpolate import equalize_bads
+from .interpolate import equalize_bads, interpolate_bridged_electrodes
 from . import ieeg
 from ._css import cortical_signal_suppression

--- a/mne/preprocessing/_csd.py
+++ b/mne/preprocessing/_csd.py
@@ -18,12 +18,14 @@ import numpy as np
 from .. import pick_types
 from ..utils import (_validate_type, _ensure_int, _check_preload, verbose,
                      logger)
-from ..io import BaseRaw
+from ..io import BaseRaw, RawArray
+from ..io.meas_info import create_info
 from ..io.constants import FIFF
-from ..epochs import BaseEpochs, make_fixed_length_epochs
-from ..evoked import Evoked
+from ..epochs import BaseEpochs, make_fixed_length_epochs, EpochsArray
+from ..evoked import Evoked, EvokedArray
 from ..bem import fit_sphere_to_headshape
 from ..channels.interpolation import _calc_g, _calc_h
+from ..transforms import _sph_to_cart, _cart_to_sph
 
 
 def _prepare_G(G, lambda2):
@@ -296,3 +298,79 @@ def compute_bridged_electrodes(inst, lm_cutoff=16, epoch_threshold=0.5,
                 bridged_idx.append((picks[i], picks[j]))
 
     return bridged_idx, ed_matrix
+
+
+def interpolate_bridged_electrodes(inst, bridged_idx):
+    """Interpolate bridged electrode pairs.
+
+    Because bridged electrodes contain brain signal, it's just that the
+    signal is spatially smeared between the two electrodes, we can
+    make a virtual channel midway between the bridged pairs and use
+    that to aid in interpolation rather than completely discarding the
+    data from the two channels.
+
+    Parameters
+    ----------
+    inst : instance of Epochs, Evoked, or Raw
+        The data object with channels that are to be interpolated.
+    bridged_idx : list of tuple
+        The indices of channels marked as bridged with each bridged
+        pair stored as a tuple.
+
+    Returns
+    -------
+    inst : instance of Epochs, Evoked, or Raw
+        The modified data object.
+    """
+    _validate_type(inst, (BaseRaw, BaseEpochs, Evoked))
+    montage = inst.get_montage()
+    if montage is None:
+        raise RuntimeError('No channel positions found in ``inst``')
+    pos = montage.get_positions()
+    if pos['coord_frame'] != 'head':
+        raise RuntimeError('Montage channel positions must be in ``head``'
+                           'got {}'.format(pos['coord_frame']))
+    ch_pos = pos['ch_pos']
+    # store bads orig to put back at the end
+    bads_orig = inst.info['bads']
+    inst.info['bads'] = list()
+
+    # make virtual channels
+    virtual_chs = dict()
+    data = inst.get_data()
+    for idx0, idx1 in bridged_idx:
+        ch0 = inst.ch_names[idx0]
+        ch1 = inst.ch_names[idx1]
+        inst.info['bads'].append([ch for ch in (ch0, ch1) if
+                                  ch not in inst.info['bads']])
+        # compute midway position in spherical coordinates in "head"
+        # (more accurate than cutting though the scalp by using cartesian)
+        pos0 = _cart_to_sph(ch_pos[ch0])
+        pos1 = _cart_to_sph(ch_pos[ch1])
+        pos_virtual = _sph_to_cart((pos0 + pos1) / 2)
+        virtual_info = create_info(
+            [f'{ch0}-{ch1} virtual'], inst.info['sfreq'], 'eeg')
+        virtual_info['chs'][0]['loc'][:3] = pos_virtual
+        if isinstance(inst, BaseRaw):
+            virtual_ch = RawArray(data[idx0:idx0 + 1], virtual_info,
+                                  first_samp=inst.first_samp)
+        elif isinstance(inst, BaseEpochs):
+            virtual_ch = EpochsArray(data[:, idx0:idx0 + 1], virtual_info,
+                                     tmin=inst.tmin)
+        else:  # evoked
+            virtual_ch = EvokedArray(data[idx0:idx0 + 1], virtual_info,
+                                     tmin=inst.tmin, nave=inst.nave,
+                                     kind=inst.kind)
+        virtual_chs[f'{ch0}-{ch1} virtual'] = virtual_ch
+
+    # add the virtual channels
+    inst.add_channels(list(virtual_chs.values()))
+
+    # use the virtual channels to interpolate
+    inst.interpolate_bads()
+
+    # drop virtual channels
+    inst.drop_channels(list(virtual_chs.keys()))
+
+    inst.info['bads'] = bads_orig
+    return inst

--- a/mne/preprocessing/interpolate.py
+++ b/mne/preprocessing/interpolate.py
@@ -124,15 +124,17 @@ def interpolate_bridged_electrodes(inst, bridged_idx):
             [f'{ch0}-{ch1} virtual'], inst.info['sfreq'], 'eeg')
         virtual_info['chs'][0]['loc'][:3] = pos_virtual
         if isinstance(inst, BaseRaw):
-            virtual_ch = RawArray(data[idx0:idx0 + 1], virtual_info,
-                                  first_samp=inst.first_samp)
+            virtual_ch = RawArray(
+                (data[idx0:idx0 + 1] + data[idx1:idx1 + 1]) / 2,
+                virtual_info, first_samp=inst.first_samp)
         elif isinstance(inst, BaseEpochs):
-            virtual_ch = EpochsArray(data[:, idx0:idx0 + 1], virtual_info,
-                                     tmin=inst.tmin)
+            virtual_ch = EpochsArray(
+                (data[:, idx0:idx0 + 1] + data[:, idx1:idx1 + 1]) / 2,
+                virtual_info, tmin=inst.tmin)
         else:  # evoked
-            virtual_ch = EvokedArray(data[idx0:idx0 + 1], virtual_info,
-                                     tmin=inst.tmin, nave=inst.nave,
-                                     kind=inst.kind)
+            virtual_ch = EvokedArray(
+                (data[idx0:idx0 + 1] + data[idx1:idx1 + 1]) / 2,
+                virtual_info, tmin=inst.tmin, nave=inst.nave, kind=inst.kind)
         virtual_chs[f'{ch0}-{ch1} virtual'] = virtual_ch
 
     # add the virtual channels

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -721,8 +721,8 @@ def _cart_to_sph(cart):
     sph_pts : ndarray, shape (n_points, 3)
         Array containing points in spherical coordinates (rad, azimuth, polar)
     """
-    assert cart.ndim == 2 and cart.shape[1] == 3
     cart = np.atleast_2d(cart)
+    assert cart.ndim == 2 and cart.shape[1] == 3
     out = np.empty((len(cart), 3))
     out[:, 0] = np.sqrt(np.sum(cart * cart, axis=1))
     norm = np.where(out[:, 0] > 0, out[:, 0], 1)  # protect against / 0
@@ -746,8 +746,8 @@ def _sph_to_cart(sph_pts):
         Array containing points in Cartesian coordinates (x, y, z)
 
     """
-    assert sph_pts.ndim == 2 and sph_pts.shape[1] == 3
     sph_pts = np.atleast_2d(sph_pts)
+    assert sph_pts.ndim == 2 and sph_pts.shape[1] == 3
     cart_pts = np.empty((len(sph_pts), 3))
     cart_pts[:, 2] = sph_pts[:, 0] * np.cos(sph_pts[:, 2])
     xy = sph_pts[:, 0] * np.sin(sph_pts[:, 2])


### PR DESCRIPTION
Follow-up to https://github.com/mne-tools/mne-python/pull/10571.

I thought it would be nice instead of just dropping bridged electrodes to use them in the interpolation. This just makes a virtual channel halfway between bridged electrodes and then interpolates with the aid of the virtual channel before dropping it. I thought this would be one last nice thing to add.