### PR TITLE
add adjustment of the topographic layout parameters

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -737,7 +737,9 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         If an array, the values represent the levels for the contours. The
         values are in µV for EEG, fT for magnetometers and fT/m for
         gradiometers. Defaults to 6.
-    %(image_interp_topomap)s
+    image_interp : str
+        The image interpolation to be used. All matplotlib options are
+        accepted.
     show : bool
         Show figure if True.
     onselect : callable | None
@@ -830,41 +832,6 @@ def _setup_interp(pos, res, extrapolate, sphere, outlines, border):
     interp = _GridData(pos, extrapolate, clip_origin, clip_radius, border)
     extent = (xmin, xmax, ymin, ymax)
     return extent, Xi, Yi, interp
-
-
-_VORONOI_CIRCLE_RES = 100
-
-
-def _voronoi_topomap(data, pos, outlines, ax, cmap, norm, extent, res):
-    """Make a Voronoi diagram on a topomap."""
-    from scipy.spatial import Voronoi
-    # we need an image axis object so first empty image to plot over
-    im = ax.imshow(np.zeros((res, res)) * np.nan, cmap=cmap,
-                   origin='lower', aspect='equal', extent=extent,
-                   norm=norm)
-    rx, ry = outlines['clip_radius']
-    cx, cy = outlines.get('clip_origin', (0., 0.))
-    # add points on the circle to make boundaries, expand out to
-    # ensure regions extend to the edge of the topomap
-    vor = Voronoi(np.concatenate(
-        [pos, [(rx * 1.5 * np.cos(2 * np.pi / _VORONOI_CIRCLE_RES * t),
-                ry * 1.5 * np.sin(2 * np.pi / _VORONOI_CIRCLE_RES * t))
-               for t in range(_VORONOI_CIRCLE_RES)]]))
-    for point_idx, region_idx in enumerate(
-            vor.point_region[:-_VORONOI_CIRCLE_RES]):
-        if -1 in vor.regions[region_idx]:
-            continue
-        polygon = list()
-        for i in vor.regions[region_idx]:
-            x, y = vor.vertices[i]
-            if (x - cx)**2 / rx**2 + (y - cy)**2 / ry**2 < 1:
-                polygon.append((x, y))
-            else:
-                x *= rx / np.linalg.norm(vor.vertices[i])
-                y *= ry / np.linalg.norm(vor.vertices[i])
-                polygon.append((x, y))
-        ax.fill(*zip(*polygon), color=cmap(norm(data[point_idx])))
-    return im
 
 
 def _get_patch(outlines, extrapolate, interp, ax):
@@ -964,9 +931,7 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     norm = min(data) >= 0
     vmin, vmax = _setup_vmin_vmax(data, vmin, vmax, norm)
     if cmap is None:
-        cmap = plt.get_cmap('Reds' if norm else 'RdBu_r')
-    elif isinstance(cmap, str):
-        cmap = plt.get_cmap(cmap)
+        cmap = 'Reds' if norm else 'RdBu_r'
 
     outlines = _make_head_outlines(sphere, pos, outlines, (0., 0.))
     assert isinstance(outlines, dict)
@@ -985,17 +950,11 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     # plot outline
     patch_ = _get_patch(outlines, extrapolate, interp, ax)
 
-    # get colormap normalization
+    # plot interpolated map
     if cnorm is None:
         cnorm = Normalize(vmin=vmin, vmax=vmax)
-
-    # plot interpolated map
-    if image_interp == 'voronoi':
-        im = _voronoi_topomap(data, pos=pos, outlines=outlines, ax=ax,
-                              cmap=cmap, norm=cnorm, extent=extent, res=res)
-    else:
-        im = ax.imshow(Zi, cmap=cmap, origin='lower', aspect='equal',
-                       extent=extent, interpolation=image_interp, norm=cnorm)
+    im = ax.imshow(Zi, cmap=cmap, origin='lower', aspect='equal',
+                   extent=extent, interpolation=image_interp, norm=cnorm)
 
     # gh-1432 had a workaround for no contours here, but we'll remove it
     # because mpl has probably fixed it
@@ -1093,10 +1052,7 @@ def _plot_ica_topomap(ica, idx=0, ch_type=None, res=64,
     if merge_channels:
         data, names = _merge_ch_data(data, ch_type, names)
 
-    topo_title = ica._ica_names[idx]
-    if len(set(ica.get_channel_types())) > 1:
-        topo_title += f' ({ch_type})'
-    axes.set_title(topo_title, fontsize=12)
+    axes.set_title(ica._ica_names[idx], fontsize=12)
     vmin_, vmax_ = _setup_vmin_vmax(data, vmin, vmax)
     im = plot_topomap(
         data.ravel(), pos, vmin=vmin_, vmax=vmax_, res=res, axes=axes,
@@ -1171,7 +1127,9 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
         values for the contour thresholds (may sometimes be inaccurate, use
         array for accuracy). If an array, the values represent the levels for
         the contours. Defaults to 6.
-    %(image_interp_topomap)s
+    image_interp : str
+        The image interpolation to be used. All matplotlib options are
+        accepted.
     inst : Raw | Epochs | None
         To be able to see component properties after clicking on component
         topomap you need to pass relevant data - instances of Raw or Epochs
@@ -1269,10 +1227,7 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
     titles = list()
     for ii, data_, ax in zip(picks, data, axes):
         kwargs = dict(color='gray') if ii in ica.exclude else dict()
-        comp_title = ica._ica_names[ii]
-        if len(set(ica.get_channel_types())) > 1:
-            comp_title += f' ({ch_type})'
-        titles.append(ax.set_title(comp_title, fontsize=12, **kwargs))
+        titles.append(ax.set_title(ica._ica_names[ii], fontsize=12, **kwargs))
         if merge_channels:
             data_, names_ = _merge_ch_data(data_, ch_type, names.copy())
         vmin_, vmax_ = _setup_vmin_vmax(data_, vmin, vmax)
@@ -1304,7 +1259,7 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
         # title was pressed -> identify the IC
         if title_pressed is not None:
             label = title_pressed.get_text()
-            ic = int(label.split(' ')[0][-3:])
+            ic = int(label[-3:])
             # add or remove IC from exclude depending on current state
             if ic in ica.exclude:
                 ica.exclude.remove(ic)
@@ -1322,7 +1277,7 @@ def plot_ica_components(ica, picks=None, ch_type=None, res=64,
             if event.inaxes is not None:
                 label = event.inaxes.get_label()
                 if label.startswith('ICA'):
-                    ic = int(label.split(' ')[0][-3:])
+                    ic = int(label[-3:])
                     ica.plot_properties(inst, picks=ic, show=True,
                                         plot_std=plot_std,
                                         topomap_args=topomap_args,
@@ -1884,7 +1839,7 @@ def plot_epochs_psd_topomap(epochs, bands=None,
                             tmin=None, tmax=None, proj=False,
                             bandwidth=None, adaptive=False, low_bias=True,
                             normalization='length', ch_type=None,
-                            cmap=None, agg_fun=None, dB=False, n_jobs=None,
+                            cmap=None, agg_fun=None, dB=False, n_jobs=1,
                             normalize=False, cbar_fmt='auto',
                             outlines='head', axes=None, show=True,
                             sphere=None, vlim=(None, None), verbose=None):
@@ -2441,7 +2396,7 @@ def _set_contour_locator(vmin, vmax, contours):
 
 
 def _plot_corrmap(data, subjs, indices, ch_type, ica, label, show, outlines,
-                  cmap, contours, template=False, sphere=None):
+                  cmap, contours, template=False, sphere=None, fig_adjust=dict()):
     """Customize ica.plot_components for corrmap."""
     if not template:
         title = 'Detected components'
@@ -2471,8 +2426,10 @@ def _plot_corrmap(data, subjs, indices, ch_type, ica, label, show, outlines,
     data = data[:, data_picks]
 
     # prepare data for iteration
-    fig, axes, _, _ = _prepare_trellis(len(picks), ncols=5)
-    fig.suptitle(title)
+    if 'ncols' in fig_adjust.keys():
+        fig, axes, _, _ = _prepare_trellis(len(picks), ncols=fig_adjust['ncols'])
+    else:
+        fig, axes, _, _ = _prepare_trellis(len(picks), ncols=5)    fig.suptitle(title)
 
     for ii, data_, ax, subject, idx in zip(picks, data, axes, subjs, indices):
         if template:
@@ -2488,6 +2445,21 @@ def _plot_corrmap(data, subjs, indices, ch_type, ica, label, show, outlines,
                      contours=contours, show=False, image_interp='bilinear')[0]
         _hide_frame(ax)
     tight_layout(fig=fig)
+    
+    default_fig_adjust = dict(left=None, bottom=None, right=None, top=0.8, wspace=None, hspace=None)
+    if fig_adjust:
+        """Adjust the topomap layout parameters"""
+        for key in fig_adjust:
+            if key in default_fig_adjust:
+                default_fig_adjust[key] = fig_adjust[key]
+
+    fig.subplots_adjust(left=default_fig_adjust['left'],
+                        bottom=default_fig_adjust['bottom'],
+                        right=default_fig_adjust['right'],
+                        top=default_fig_adjust['top'],
+                        wspace=default_fig_adjust['wspace'],
+                        hspace=default_fig_adjust['hspace'])
+                        
     fig.subplots_adjust(top=0.8)
     fig.canvas.draw()
     plt_show(show)
@@ -2657,73 +2629,4 @@ def plot_arrowmap(data, info_from, info_to=None, scale=3e-10, vmin=None,
         tight_layout(fig=fig)
     plt_show(show)
 
-    return fig
-
-
-@fill_doc
-def plot_bridged_electrodes(info, bridged_idx, ed_matrix, title=None,
-                            topomap_args=None):
-    """Topoplot electrode distance matrix with bridged electrodes connected.
-
-    Parameters
-    ----------
-    %(info_not_none)s
-    bridged_idx : list of tuple
-        The indices of channels marked as bridged with each bridged
-        pair stored as a tuple.
-    ed_matrix : ndarray of float, shape (n_channels, n_channels)
-        The electrical distance matrix for each pair of EEG electrodes.
-    title : str
-        A title to add to the plot.
-    topomap_args : dict | None
-        Arguments to pass to :func:`mne.viz.plot_topomap`.
-
-    Returns
-    -------
-    fig : instance of matplotlib.figure.Figure
-        The topoplot figure handle.
-    """
-    import matplotlib.pyplot as plt
-    if topomap_args is None:
-        topomap_args = dict()
-    else:
-        topomap_args = topomap_args.copy()  # don't change original
-    topomap_args.setdefault('image_interp', 'voronoi')
-    topomap_args.setdefault('cmap', 'summer_r')
-    topomap_args.setdefault('names', info.ch_names)
-    topomap_args.setdefault('show_names', True)
-    topomap_args.setdefault('contours', False)
-    if 'axes' not in topomap_args:
-        fig, ax = plt.subplots()
-        topomap_args['axes'] = ax
-    else:
-        fig = None
-    # handle colorbar here instead of in plot_topomap
-    colorbar = topomap_args.pop('colorbar') if \
-        'colorbar' in topomap_args else True
-    # use sphere to find positions
-    sphere = topomap_args['sphere'] if 'sphere' in topomap_args else None
-    picks = pick_types(info, eeg=True)
-    if ed_matrix.shape[1:] != (picks.size, picks.size):
-        raise RuntimeError(
-            f'Expected {(ed_matrix.shape[0], picks.size, picks.size)} '
-            f'shaped `ed_matrix`, got {ed_matrix.shape}')
-    # fill in lower triangular
-    ed_matrix = ed_matrix.copy()
-    tril_idx = np.tril_indices(picks.size)
-    for epo_idx in range(ed_matrix.shape[0]):
-        ed_matrix[epo_idx][tril_idx] = ed_matrix[epo_idx].T[tril_idx]
-    elec_dists = np.median(np.nanmin(ed_matrix, axis=1), axis=0)
-    pos = _find_topomap_coords(info, picks, sphere=sphere)
-    im, cn = plot_topomap(elec_dists, info, **topomap_args)
-    fig = im.figure if fig is None else fig
-    # add bridged connections
-    for idx0, idx1 in bridged_idx:
-        im.axes.plot([pos[idx0][0], pos[idx1][0]],
-                     [pos[idx0][1], pos[idx1][1]], color='r')
-    if title is not None:
-        im.axes.set_title(title)
-    if colorbar:
-        cax = fig.colorbar(im)
-        cax.set_label(r'Electrical Distance ($\mu$$V^2$)')
     return fig


### PR DESCRIPTION
When using the mne.preprocessing.corrmap method, it is not convenient to modify the number of columns and drawing parameters of the topographic map, as shown in the following two pictures:

The result displayed by the original code:

![detected components of type blink-1](https://user-images.githubusercontent.com/46664890/166465901-3d599895-4304-4f1b-956b-9e34e4dd612c.png)

Add results for column parameters only:

![detected components of type blink-2](https://user-images.githubusercontent.com/46664890/166465909-a0e7d3c3-47fc-442e-b644-bee9ba1a587f.png)

So I added parameter fig_adjuct to corrmap and _plot_corrmap function, which makes it easy for us to adjust the parameters freely. The example results are as follows:

example 1: When set fig_adjust = dict(ncols=3, top=0.8, hspace=0.3)

![detected components of type blink](https://user-images.githubusercontent.com/46664890/166464312-07c8af88-6b5d-48e6-9c74-7c84f75ad496.png)

example 2: When set fig_adjust = dict(ncols=2, left=0.1, hspace=0.3, wspace=0.8)

![detected components of type blink-3](https://user-images.githubusercontent.com/46664890/166468051-8b9978ee-33e0-4114-b5dc-0cd021980f70.png)
