### PR TITLE
MRG: Fix dev documentation warning

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -129,13 +129,6 @@ h5.card-header::before {
     margin-top: 0px;
 }
 
-/* ************************************************* dev version warning bar */
-.devbar {
-    /* body top padding minus navbar height; */
-    /*might be possible to calc from theme variables */
-    margin-top: -20px;
-}
-
 /* ******************************************************** version dropdown */
 .dropdown {
     padding: 0 .5rem;  /* match other items in the hamburger menu */


### PR DESCRIPTION
`main`:
<img width="846" alt="Screen Shot 2022-05-04 at 21 36 58" src="https://user-images.githubusercontent.com/2046265/166812600-473cda7f-342d-4f37-bbdc-c940e9b4763b.png">


PR:
<img width="846" alt="Screen Shot 2022-05-04 at 21 36 53" src="https://user-images.githubusercontent.com/2046265/166812640-d2b4ae99-ac3c-4450-9314-672f329272fc.png">

**Must not be backported!**