### PR TITLE
MRG: Display averaged time period in Evoked topomap title

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -55,6 +55,8 @@ Enhancements
 
 - Add :func:`mne.preprocessing.interpolate_bridged_electrodes` to use the spatially smeared signal to get a better interpolation rather than dropping those channels (:gh:`10587` by `Alex Rockhill`_)
 
+- :func:`mne.viz.plot_evoked_topomap` and :meth:`mne.Evoked.plot_topomap` now display the time range the map was averaged over if ``average`` was passed (:gh:`10606` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 - Make ``color`` parameter check in in :func:`mne.viz.plot_evoked_topo` consistent (:gh:`10217` by :newcontrib:`T. Wang` and `Stefan Appelhoff`_)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -235,10 +235,11 @@ average : bool, default True
 
 docdict['average_topomap'] = """
 average : float | None
-    The time window around a given time to be used for averaging (seconds).
-    For example, 0.01 would translate into window that starts 5 ms before
-    and ends 5 ms after a given time point. Defaults to None, which means
-    no averaging.
+    The time window (in seconds) around a given time point to be used for
+    averaging. For example, 0.2 would translate into a time window that starts
+    0.1 s before and ends 0.1 s after the given time point. If the time window
+    exceeds the duration of the data, it will be clipped. If ``None``
+    (default), no averaging will take place.
 """
 
 docdict['axes_psd_topo'] = """

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -333,6 +333,20 @@ def test_plot_topomap_basic(monkeypatch):
     assert_equal(texts[0], 'Custom')
     plt.close('all')
 
+    # Test averaging
+    averaging_times = [ev_bad.times[0], times[0], ev_bad.times[-1]]
+    p = plt_topomap(averaging_times, ch_type='eeg', average=0.01)
+
+    expected_ax_titles = (
+        '-0.200 – -0.195 s',  # clipped on the left
+        '0.095 – 0.105 s',    # full range
+        '0.494 – 0.499 s'     # clipped on the right
+    )
+    for idx, expected_title in enumerate(expected_ax_titles):
+        assert p.axes[idx].get_title() == expected_title
+
+    del averaging_times, expected_ax_titles, expected_title
+
     # delaunay triangulation warning
     plt_topomap(times, ch_type='mag')
     # projs have already been applied

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1708,6 +1708,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
                 for t in times]
     # do averaging if requested
     avg_err = '"average" must be `None` or a positive number of seconds'
+    averaged_times = []
     if average is None:
         data = data[np.ix_(picks, time_idx)]
     elif not _is_numeric(average):
@@ -1723,6 +1724,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
                                                      iter_times + ave_time)):
             my_range = (tmin_ < evoked.times) & (evoked.times < tmax_)
             data_[:, ii] = data[picks][:, my_range].mean(-1)
+            averaged_times.append(evoked.times[my_range])
         data = data_
     # apply scalings and merge channels
     data *= scaling
@@ -1767,7 +1769,16 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
         if cn is not None:
             contours_.append(cn)
         if time_format != '':
-            axes[ax_idx].set_title(time_format % (time * scaling_time))
+            if average is None:
+                axes_title = time_format % (time * scaling_time)
+            else:
+                tmin_, tmax_ = averaged_times[idx][0], averaged_times[idx][-1]
+                from_time = time_format % (tmin_ * scaling_time)
+                from_time = from_time.split(' ')[0]  # Remove unit
+                to_time = time_format % (tmax_ * scaling_time)
+                axes_title = f'{from_time} – {to_time}'
+                del from_time, to_time, tmin_, tmax_
+            axes[ax_idx].set_title(axes_title)
 
     if interactive:
         axes.append(plt.subplot(gs[1, :-1]))


### PR DESCRIPTION
Also improve the documentation and mention that the time windows for averaging actually get clipped at the "ends" of the data.


`main` | this PR
---|---
![old](https://user-images.githubusercontent.com/2046265/167132626-580039ac-231a-4006-a8e1-9843aed2950b.png) | ![new](https://user-images.githubusercontent.com/2046265/167132639-a7072158-553f-4fc6-a257-afea561ba4c1.png)
![joint_old](https://user-images.githubusercontent.com/2046265/167133971-fd76d595-83dc-46c4-a1d6-b5f22557d959.png) | ![joint_new](https://user-images.githubusercontent.com/2046265/167133990-37c845d8-bcfc-400a-8ebb-c8c6c2a630f3.png)

```python
# %%
from pathlib import Path
import mne


sample_dir = Path(mne.datasets.sample.data_path())
sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'

raw = mne.io.read_raw_fif(sample_fname)
raw.crop(tmax=60)

events = mne.find_events(raw, stim_channel='STI 014')
event_id = {'auditory/left': 1, 'auditory/right': 2, 'visual/left': 3,
            'visual/right': 4, 'face': 5, 'buttonpress': 32}

epochs = mne.Epochs(raw, events=events, event_id=event_id,
                    tmin=-0.2, tmax=0.5, baseline=(None, 0),
                    preload=True)

evoked = epochs.average()
evoked.plot_topomap(average=0.1);
evoked.plot_joint(topomap_args=dict(average=0.1));
```
