### PR TITLE
minor, doc: fix subplot titles in tutorial

### DIFF
--- a/tutorials/stats-sensor-space/75_cluster_ftest_spatiotemporal.py
+++ b/tutorials/stats-sensor-space/75_cluster_ftest_spatiotemporal.py
@@ -158,6 +158,9 @@ for i_clu, clu_idx in enumerate(good_cluster_inds):
                           colorbar=False, mask_params=dict(markersize=10))
     image = ax_topo.images[0]
 
+    # remove the title that would otherwise say "0.000 s"
+    ax_topo.set_title("")
+
     # create additional axes (for ERF and colorbar)
     divider = make_axes_locatable(ax_topo)
 


### PR DESCRIPTION
seen in https://mne.tools/stable/auto_tutorials/stats-sensor-space/75_cluster_ftest_spatiotemporal.html#find-the-fieldtrip-neighbor-definition-to-setup-sensor-adjacency

The topoplots have a title "0.000 s" that does not make sense in this case and should be removed:

![image](https://user-images.githubusercontent.com/9084751/167150373-61cb6ee5-3cb4-49f0-85fd-ac8ee2108e39.png)
