### PR TITLE
MRG: Allow to pass array of "average" values to plot_evoked_topomap()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -57,6 +57,8 @@ Enhancements
 
 - :func:`mne.viz.plot_evoked_topomap` and :meth:`mne.Evoked.plot_topomap` now display the time range the map was averaged over if ``average`` was passed (:gh:`10606` by `Richard Höchenberger`_)
 
+- :func:`mne.viz.plot_evoked_topomap` and :meth:`mne.Evoked.plot_topomap` can now average the topographic maps across different time periods for each time point. To do this, pass a list of periods via the ``average`` parameter (:gh:`10610` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 - Make ``color`` parameter check in in :func:`mne.viz.plot_evoked_topo` consistent (:gh:`10217` by :newcontrib:`T. Wang` and `Stefan Appelhoff`_)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -233,15 +233,6 @@ average : bool, default True
     .. versionadded:: 0.13.0
 """
 
-docdict['average_topomap'] = """
-average : float | None
-    The time window (in seconds) around a given time point to be used for
-    averaging. For example, 0.2 would translate into a time window that starts
-    0.1 s before and ends 0.1 s after the given time point. If the time window
-    exceeds the duration of the data, it will be clipped. If ``None``
-    (default), no averaging will take place.
-"""
-
 docdict['axes_psd_topo'] = """
 axes : list of Axes | None
     List of axes to plot consecutive topographies to. If ``None`` the axes

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -333,7 +333,7 @@ def test_plot_topomap_basic(monkeypatch):
     assert_equal(texts[0], 'Custom')
     plt.close('all')
 
-    # Test averaging
+    # Test averaging with a scalar input
     averaging_times = [ev_bad.times[0], times[0], ev_bad.times[-1]]
     p = plt_topomap(averaging_times, ch_type='eeg', average=0.01)
 
@@ -341,6 +341,19 @@ def test_plot_topomap_basic(monkeypatch):
         '-0.200 – -0.195 s',  # clipped on the left
         '0.095 – 0.105 s',    # full range
         '0.494 – 0.499 s'     # clipped on the right
+    )
+    for idx, expected_title in enumerate(expected_ax_titles):
+        assert p.axes[idx].get_title() == expected_title
+
+    # Test averging with an array-like input
+    averaging_durations = [0.01, 0.02, None]
+    p = plt_topomap(
+        averaging_times, ch_type='eeg', average=averaging_durations
+    )
+    expected_ax_titles = (
+        '-0.200 – -0.195 s',  # clipped on the left
+        '0.090 – 0.110 s',    # full range
+        '0.499 s'             # No averaging
     )
     for idx, expected_title in enumerate(expected_ax_titles):
         assert p.axes[idx].get_title() == expected_title

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -358,6 +358,13 @@ def test_plot_topomap_basic(monkeypatch):
     for idx, expected_title in enumerate(expected_ax_titles):
         assert p.axes[idx].get_title() == expected_title
 
+    # Test averaging with array-like input, but n_times != n_average
+    averaging_durations = [0.01, 0.02]
+    with pytest.raises(ValueError, match='3 time points.*2 periods'):
+        plt_topomap(
+            averaging_times, ch_type='eeg', average=averaging_durations
+        )
+
     del averaging_times, expected_ax_titles, expected_title
 
     # delaunay triangulation warning

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -297,9 +297,9 @@ def test_plot_topomap_basic(monkeypatch):
     plt_topomap(times, ch_type='grad', mask=mask, show_names=True,
                 mask_params={'marker': 'x'})
     plt.close('all')
-    with pytest.raises(ValueError, match='number of seconds; got -'):
+    with pytest.raises(ValueError, match='number of seconds.* got -'):
         plt_topomap(times, ch_type='eeg', average=-1e3)
-    with pytest.raises(TypeError, match='number of seconds; got type'):
+    with pytest.raises(TypeError, match='number of seconds.* got type'):
         plt_topomap(times, ch_type='eeg', average='x')
 
     p = plt_topomap(times, ch_type='grad', image_interp='bilinear',

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -345,7 +345,7 @@ def test_plot_topomap_basic(monkeypatch):
     for idx, expected_title in enumerate(expected_ax_titles):
         assert p.axes[idx].get_title() == expected_title
 
-    # Test averging with an array-like input
+    # Test averaging with an array-like input
     averaging_durations = [0.01, 0.02, None]
     p = plt_topomap(
         averaging_times, ch_type='eeg', average=averaging_durations

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1580,6 +1580,9 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
         Different time windows (one per time point) can be provided by
         passing an ``array-like`` object (e.g., ``[0.1, 0.2, 0.3]``). If
         ``None`` (default), no averaging will take place.
+
+        .. versionchanged:: 1.1
+           Support for ``array-like`` input.
     %(axes_topomap)s
     %(extrapolate_topomap)s
 

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1572,6 +1572,7 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
     %(mask_params_topomap)s
     %(outlines_topomap)s
     %(contours_topomap)s
+    %(image_interp_topomap)s
     average : float | array-like of float, shape (n_times,) | None
         The time window (in seconds) around a given time point to be used for
         averaging. For example, 0.2 would translate into a time window that

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1793,7 +1793,9 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
     for average_idx, (time, this_average) in enumerate(
         zip(times, average)
     ):
-        adjust_for_cbar = colorbar and ncols is not None and average_idx >= ncols - 1
+        adjust_for_cbar = (colorbar and
+                           ncols is not None and
+                           average_idx >= ncols - 1)
         ax_idx = average_idx + 1 if adjust_for_cbar else average_idx
         tp, cn, interp = _plot_topomap(
             data[:, average_idx], pos, axes=axes[ax_idx],
@@ -1806,7 +1808,8 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
             if this_average is None:
                 axes_title = time_format % (time * scaling_time)
             else:
-                tmin_, tmax_ = averaged_times[average_idx][0], averaged_times[average_idx][-1]
+                tmin_ = averaged_times[average_idx][0]
+                tmax_ = averaged_times[average_idx][-1]
                 from_time = time_format % (tmin_ * scaling_time)
                 from_time = from_time.split(' ')[0]  # Remove unit
                 to_time = time_format % (tmax_ * scaling_time)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1725,12 +1725,12 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
         data = data[np.ix_(picks, time_idx)]
     else:
         if _is_numeric(average):
-            average = np.array([average])
-        else:
+            average = np.array([average] * n_times)
+        elif np.array(average).ndim == 0:
             # It should be an array-like object
+            raise TypeError(f'{avg_err}; got type: {type(average)}.')
+        else:
             average = np.array(average)
-            if average.size == 0:
-                raise ValueError(f'{avg_err}; got {average}.')
 
         data_ = np.zeros((len(picks), len(time_idx)))
 
@@ -1741,9 +1741,11 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
                 (_is_numeric(this_average) and this_average <= 0) or
                 (not _is_numeric(this_average) and this_average is not None)
             ):
-                raise ValueError(
-                    f'{avg_err}; got "{this_average}" in {average}'
-                )
+                if len(average) == 1:
+                    msg = f'{avg_err}; got {this_average}'
+                else:
+                    msg = f'{avg_err}; got {this_average} in {average}'
+                raise ValueError(msg)
 
             if this_average is None:
                 data_[:, average_idx] = data[picks][:, this_time_idx]

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1732,6 +1732,13 @@ def plot_evoked_topomap(evoked, times="auto", ch_type=None,
         else:
             average = np.array(average)
 
+        if len(average) != n_times:
+            raise ValueError(
+                f'You requested to plot topographic maps for {n_times} time '
+                f'points, but provided {len(average)} periods for '
+                f'averaging. The number of time points and averaging periods '
+                f'must be equal.'
+            )
         data_ = np.zeros((len(picks), len(time_idx)))
 
         for average_idx, (this_average, this_time, this_time_idx) in enumerate(

--- a/tutorials/evoked/20_visualize_evoked.py
+++ b/tutorials/evoked/20_visualize_evoked.py
@@ -99,8 +99,17 @@ evks['aud/left'].plot_topomap(ch_type='mag', times=times, colorbar=True)
 
 # %%
 
-fig = evks['aud/left'].plot_topomap(ch_type='mag', times=0.09, average=0.1)
-fig.text(0.5, 0.05, 'average from 40-140 ms', ha='center')
+fig = evks['aud/left'].plot_topomap(ch_type='mag', times=times, average=0.1)
+
+# %%
+# It is also possible to pass different time durations to average over for each
+# time point. Passing a value of ``None`` will disable averaging for that
+# time point:
+
+averaging_durations = [0.01, 0.02, 0.03, None, None]
+fig = evks['aud/left'].plot_topomap(
+    ch_type='mag', times=times, average=averaging_durations
+)
 
 # %%
 # Additional examples of plotting scalp topographies can be found in


### PR DESCRIPTION
We can now do things like:

```python
evoked.plot_topomap(average=[0.1, 0.2, None, 0.1])
```
to produce

![output](https://user-images.githubusercontent.com/2046265/167221841-66c9ef15-4a58-4cfc-a979-48fa28ce775f.png)

This comes in handy e.g. when plotting topographies for different time periods that were found to be significant e.g. using a cluster-based permutation test.

MWE:
```python
# %%
from pathlib import Path
import mne


sample_dir = Path(mne.datasets.sample.data_path())
sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'

raw = mne.io.read_raw_fif(sample_fname)
raw.crop(tmax=60)

events = mne.find_events(raw, stim_channel='STI 014')
event_id = {'auditory/left': 1, 'auditory/right': 2, 'visual/left': 3,
            'visual/right': 4, 'face': 5, 'buttonpress': 32}

epochs = mne.Epochs(raw, events=events, event_id=event_id,
                    tmin=-0.2, tmax=0.5, baseline=(None, 0),
                    preload=True)

evoked = epochs.average()

# %%
evoked.plot_topomap(average=[0.1, 0.2, None, 0.1])
```

- [x] Enforce `len(average) == len(times)`
- [x] Add tests
- [x] Add changelog entry