### PR TITLE
[MRG] FIX: snirf length units

### DIFF
--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -441,18 +441,18 @@ def _get_timeunit_scaling(time_unit):
         return scalings[time_unit]
     else:
         raise RuntimeError(f'The time unit {time_unit} is not supported by '
-                           'MNE. Please report this error as a GitHub'
+                           'MNE. Please report this error as a GitHub '
                            'issue to inform the developers.')
 
 
 def _get_lengthunit_scaling(length_unit):
     """MNE expects distance in m, return required scaling."""
-    scalings = {'cm': 100, 'mm': 1000}
+    scalings = {'m': 1, 'cm': 100, 'mm': 1000}
     if length_unit in scalings:
         return scalings[length_unit]
     else:
-        raise RuntimeError(f'The time unit {length_unit} is not supported by '
-                           'MNE. Please report this error as a GitHub'
+        raise RuntimeError(f'The length unit {length_unit} is not supported '
+                           'by MNE. Please report this error as a GitHub '
                            'issue to inform the developers.')
 
 


### PR DESCRIPTION
I noticed this because the mne-bids CI failed. These are probably reasonable fixes, wdyt @rob-luke?

https://github.com/mne-tools/mne-bids/runs/6338742975?check_suite_focus=true#step:15:400