### PR TITLE
Drop EEG rejection thresholds when replacing EEG with CSD channels

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -92,7 +92,7 @@ Bugs
 
 - Fix bug in the :class:`mne.viz.Brain` tool bar that prevented the buttons to call the corresponding feature (:gh:`10560` by `Guillaume Favelier`_)
 
-- Fix issue with saving epochs once :func:`mne.preprocessing.compute_current_source_density` has been used if a rejection threshold was used first (:gh:`10619` by `Alex Rockhill`_ and `Richard Höchenberger`_)
+- Fix issue with saving epochs once :func:`~mne.preprocessing.compute_current_source_density` has been used if a rejection threshold was used first (:gh:`10619` by `Alex Rockhill`_ and `Richard Höchenberger`_)
 
 API and behavior changes
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -92,6 +92,8 @@ Bugs
 
 - Fix bug in the :class:`mne.viz.Brain` tool bar that prevented the buttons to call the corresponding feature (:gh:`10560` by `Guillaume Favelier`_)
 
+- Fix issue with saving epochs once :func:`mne.preprocessing.compute_current_source_density` has been used if a rejection threshold was used first (:gh:`10619` by `Alex Rockhill`_ and `Richard Höchenberger`_)
+
 API and behavior changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - When creating BEM surfaces via :func:`mne.bem.make_watershed_bem` and :func:`mne.bem.make_flash_bem`, the ``copy`` parameter now defaults to ``True``. This means that instead of creating symbolic links inside the FreeSurfer subject's ``bem`` folder, we now create "actual" files. This should avoid troubles when sharing files across different operating systems and file systems (:gh:`10531` by `Richard Höchenberger`_)

--- a/mne/preprocessing/_csd.py
+++ b/mne/preprocessing/_csd.py
@@ -178,15 +178,11 @@ def compute_current_source_density(inst, sphere='auto', lambda2=1e-5,
                                       unit=FIFF.FIFF_UNIT_V_M2)
 
     # Remove rejection thresholds for EEG
-    if inst.reject is not None and 'eeg' in inst.reject:
-        del inst.reject['eeg']
-        if not inst.reject:  # Set it to None if nothing's left
-            inst.reject = None
-
-    if inst.flat is not None and 'eeg' in inst.flat:
-        del inst.flat['eeg']
-        if not inst.flat:  # Set it to None if nothing's left
-            inst.flat = None
+    if isinstance(inst, BaseEpochs):
+        inst.reject = None if inst.reject is None else \
+            {k: v for k, v in inst.reject.items() if k != 'eeg'}
+        inst.flat = None if inst.flat is None else \
+            {k: v for k, v in inst.flat.items() if k != 'eeg'}
 
     return inst
 

--- a/mne/preprocessing/_csd.py
+++ b/mne/preprocessing/_csd.py
@@ -176,6 +176,18 @@ def compute_current_source_density(inst, sphere='auto', lambda2=1e-5,
     for pick in picks:
         inst.info['chs'][pick].update(coil_type=FIFF.FIFFV_COIL_EEG_CSD,
                                       unit=FIFF.FIFF_UNIT_V_M2)
+
+    # Remove rejection thresholds for EEG
+    if inst.reject is not None and 'eeg' in inst.reject:
+        del inst.reject['eeg']
+        if not inst.reject:  # Set it to None if nothing's left
+            inst.reject = None
+
+    if inst.flat is not None and 'eeg' in inst.flat:
+        del inst.flat['eeg']
+        if not inst.flat:  # Set it to None if nothing's left
+            inst.flat = None
+
     return inst
 
 

--- a/mne/preprocessing/tests/test_csd.py
+++ b/mne/preprocessing/tests/test_csd.py
@@ -17,7 +17,8 @@ from scipy.io import loadmat
 from scipy import linalg
 
 from mne.channels import make_dig_montage
-from mne import create_info, EvokedArray, pick_types, Epochs
+from mne import (create_info, EvokedArray, pick_types, Epochs, find_events,
+                 read_epochs)
 from mne.io import read_raw_fif, RawArray
 from mne.io.constants import FIFF
 from mne.utils import object_diff
@@ -184,6 +185,19 @@ def test_csd_fif():
         ch.update(coil_type=FIFF.FIFFV_COIL_EEG, unit=FIFF.FIFF_UNIT_V)
         raw_csd._data[pick] = raw._data[pick]
     assert object_diff(raw.info, raw_csd.info) == ''
+
+
+def test_csd_epochs(tmp_path):
+    """Test making epochs, saving to disk and loading."""
+    raw = read_raw_fif(raw_fname)
+    raw.pick_types(eeg=True, stim=True).load_data()
+    events = find_events(raw)
+    epochs = Epochs(raw, events, reject=dict(eeg=1e-4), preload=True)
+    epochs = compute_current_source_density(epochs)
+    epo_fname = tmp_path / 'test_csd_epo.fif'
+    epochs.save(epo_fname)
+    epochs2 = read_epochs(epo_fname, preload=True)
+    assert_allclose(epochs._data, epochs2._data)
 
 
 def test_compute_bridged_electrodes():


### PR DESCRIPTION
This is an attempt to fix the issue reported at https://mne.discourse.group/t/saving-epoch-error-no-eeg-channel-found

WIP:
- [x] tests
- [x] changelog
- [ ] update docstring to explain we're removing rejection thresholds for EEG