### PR TITLE
MRG: Update installer links to point to 1.0.2_1

### DIFF
--- a/doc/install/installers_platform_selector.html
+++ b/doc/install/installers_platform_selector.html
@@ -29,7 +29,7 @@
     <div id="collapseMac" class="collapse" aria-labelledby="mac" data-parent="#downloadAccordion">
       <div class="card-body">
         <a class="btn btn-primary font-weight-bold shadow-sm mt-3 mb-3" role="button"
-          href="https://github.com/mne-tools/mne-installers/releases/download/v1.0.2/MNE-Python-1.0.2_1-macOS_Intel.pkg">
+          href="https://github.com/mne-tools/mne-installers/releases/download/v1.0.3/MNE-Python-1.0.3_0-macOS_Intel.pkg">
           <i class="fa fa-cloud-download-alt"></i>&ensp;Download for macOS
         </a>
         <p class="small"><strong>Supported platforms:</strong> macOS 10.15 (Catalina) and newer (Intel and Apple Silicon)</p>
@@ -48,12 +48,12 @@
     <div id="collapseLinux" class="collapse" aria-labelledby="linux" data-parent="#downloadAccordion">
       <div class="card-body">
         <a class="btn btn-primary font-weight-bold shadow-sm mt-3 mb-3" role="button"
-          href="https://github.com/mne-tools/mne-installers/releases/download/v1.0.2/MNE-Python-1.0.2_1-Linux.sh">
+          href="https://github.com/mne-tools/mne-installers/releases/download/v1.0.3/MNE-Python-1.0.3_0-Linux.sh">
           <i class="fa fa-cloud-download-alt"></i>&ensp;Download for Linux
         </a>
         <p class="small"><strong>Supported platforms:</strong> Ubuntu 18.04 (Bionic Beaver) and newer
         </p>
-        <p>Run the installer in a terminal via: <div class="highlight highlight-console"><pre><span class="gp">$ </span>sh ./MNE-Python-1.0.2_1-Linux.sh</pre></div></p>
+        <p>Run the installer in a terminal via: <div class="highlight highlight-console"><pre><span class="gp">$ </span>sh ./MNE-Python-1.0.3_0-Linux.sh</pre></div></p>
       </div>
     </div>
   </div>
@@ -69,7 +69,7 @@
     <div id="collapseWindows" class="collapse" aria-labelledby="windows" data-parent="#downloadAccordion">
       <div class="card-body">
         <a class="btn btn-primary font-weight-bold shadow-sm mt-3 mb-3" role="button"
-          href="https://github.com/mne-tools/mne-installers/releases/download/v1.0.2/MNE-Python-1.0.2_1-Windows.exe">
+          href="https://github.com/mne-tools/mne-installers/releases/download/v1.0.3/MNE-Python-1.0.3_0-Windows.exe">
           <i class="fa fa-cloud-download-alt"></i>&ensp;Download for Windows
         </a>
         <p class="small"><strong>Supported platforms:</strong> Windows 10 and newer</p>

--- a/doc/install/installers_platform_selector.html
+++ b/doc/install/installers_platform_selector.html
@@ -29,7 +29,7 @@
     <div id="collapseMac" class="collapse" aria-labelledby="mac" data-parent="#downloadAccordion">
       <div class="card-body">
         <a class="btn btn-primary font-weight-bold shadow-sm mt-3 mb-3" role="button"
-          href="https://github.com/mne-tools/mne-installers/releases/download/v1.0.2/MNE-Python-1.0.2_0-macOS_Intel.pkg">
+          href="https://github.com/mne-tools/mne-installers/releases/download/v1.0.2/MNE-Python-1.0.2_1-macOS_Intel.pkg">
           <i class="fa fa-cloud-download-alt"></i>&ensp;Download for macOS
         </a>
         <p class="small"><strong>Supported platforms:</strong> macOS 10.15 (Catalina) and newer (Intel and Apple Silicon)</p>
@@ -48,12 +48,12 @@
     <div id="collapseLinux" class="collapse" aria-labelledby="linux" data-parent="#downloadAccordion">
       <div class="card-body">
         <a class="btn btn-primary font-weight-bold shadow-sm mt-3 mb-3" role="button"
-          href="https://github.com/mne-tools/mne-installers/releases/download/v1.0.2/MNE-Python-1.0.2_0-Linux.sh">
+          href="https://github.com/mne-tools/mne-installers/releases/download/v1.0.2/MNE-Python-1.0.2_1-Linux.sh">
           <i class="fa fa-cloud-download-alt"></i>&ensp;Download for Linux
         </a>
         <p class="small"><strong>Supported platforms:</strong> Ubuntu 18.04 (Bionic Beaver) and newer
         </p>
-        <p>Run the installer in a terminal via: <div class="highlight highlight-console"><pre><span class="gp">$ </span>sh ./MNE-Python-1.0.2_0-Linux.sh</pre></div></p>
+        <p>Run the installer in a terminal via: <div class="highlight highlight-console"><pre><span class="gp">$ </span>sh ./MNE-Python-1.0.2_1-Linux.sh</pre></div></p>
       </div>
     </div>
   </div>
@@ -69,7 +69,7 @@
     <div id="collapseWindows" class="collapse" aria-labelledby="windows" data-parent="#downloadAccordion">
       <div class="card-body">
         <a class="btn btn-primary font-weight-bold shadow-sm mt-3 mb-3" role="button"
-          href="https://github.com/mne-tools/mne-installers/releases/download/v1.0.2/MNE-Python-1.0.2_0-Windows.exe">
+          href="https://github.com/mne-tools/mne-installers/releases/download/v1.0.2/MNE-Python-1.0.2_1-Windows.exe">
           <i class="fa fa-cloud-download-alt"></i>&ensp;Download for Windows
         </a>
         <p class="small"><strong>Supported platforms:</strong> Windows 10 and newer</p>


### PR DESCRIPTION
The new installers include pqdm and MNE-ICALabel (for Linux and macOS)