### PR TITLE
CI: Fix conda [skip azp] [skip circle]

### DIFF
--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -46,6 +46,9 @@ jobs:
       - shell: bash -el {0}
         run: ./tools/github_actions_install.sh
         name: 'Install MNE'
+      - shell: bash -el {}
+        run: LIBGL_DEBUG=verbose python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
+        name: 'Check Qt GL'
       - shell: bash -el {0}
         run: ./tools/github_actions_infos.sh
         name: 'Show infos'

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -24,8 +24,6 @@ jobs:
       MKL_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
       PYTHON_VERSION: '3.10'
-      MESA_GL_VERSION_OVERRIDE: '4.5FC'
-      MESA_GLES_VERSION_OVERRIDE: '3.2'
     steps:
       - uses: actions/checkout@v2
       - run: ./tools/setup_xvfb.sh
@@ -49,16 +47,7 @@ jobs:
         name: 'Install MNE'
       - shell: bash -el {0}
         run: |
-          unset MESA_GL_VERSION_OVERRIDE
-          unset MESA_GLES_VERSION_OVERRIDE
-          glxinfo
-        name: glxinfo original
-      - shell: bash -el {0}
-        run: glxinfo
-        name: glxinfo updated
-      - shell: bash -el {0}
-        run: |
-          QT_DEBUG_PLUGINS=1 QT_QPA_PLATFORM=xcb LIBGL_DEBUG=verbose LD_DEBUG=libs python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
+          QT_QPA_PLATFORM=xcb LIBGL_DEBUG=verbose LD_DEBUG=libs python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
         name: 'Check Qt GL'
       - shell: bash -el {0}
         run: ./tools/github_actions_infos.sh

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -11,9 +11,9 @@ on:
       - '*'
 
 jobs:
-  py39:
+  py310:
     runs-on: ubuntu-20.04
-    name: 'linux conda 3.9'
+    name: 'linux conda 3.10'
     defaults:
       run:
         shell: bash
@@ -23,7 +23,8 @@ jobs:
       MNE_LOGGING_LEVEL: 'warning'
       MKL_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
-      PYTHON_VERSION: '3.9'
+      PYTHON_VERSION: '3.10'
+      MESA_GL_VERSION_OVERRIDE: '4.5FC'
     steps:
       - uses: actions/checkout@v2
       - run: ./tools/setup_xvfb.sh

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -47,7 +47,9 @@ jobs:
         run: ./tools/github_actions_install.sh
         name: 'Install MNE'
       - shell: bash -el {0}
-        run: LIBGL_DEBUG=verbose LD_DEBUG=libs python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
+        run: |
+          sudo apt remove -y libegl1
+          LIBGL_DEBUG=verbose LD_DEBUG=libs python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
         name: 'Check Qt GL'
       - shell: bash -el {0}
         run: ./tools/github_actions_infos.sh

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -25,6 +25,7 @@ jobs:
       PYTHONUNBUFFERED: '1'
       PYTHON_VERSION: '3.10'
       MESA_GL_VERSION_OVERRIDE: '4.5FC'
+      MESA_GLES_VERSION_OVERRIDE: '3.2'
     steps:
       - uses: actions/checkout@v2
       - run: ./tools/setup_xvfb.sh
@@ -46,6 +47,15 @@ jobs:
       - shell: bash -el {0}
         run: ./tools/github_actions_install.sh
         name: 'Install MNE'
+      - shell: bash -el {0}
+        run: |
+          unset MESA_GL_VERSION_OVERRIDE
+          unset MESA_GLES_VERSION_OVERRIDE
+          glxinfo
+        name: glxinfo original
+      - shell: bash -el {0}
+        run: glxinfo
+        name: glxinfo updated
       - shell: bash -el {0}
         run: |
           QT_DEBUG_PLUGINS=1 QT_QPA_PLATFORM=xcb LIBGL_DEBUG=verbose LD_DEBUG=libs python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -48,7 +48,6 @@ jobs:
         name: 'Install MNE'
       - shell: bash -el {0}
         run: |
-          sudo apt remove -y libegl1
           LIBGL_DEBUG=verbose LD_DEBUG=libs python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
         name: 'Check Qt GL'
       - shell: bash -el {0}

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -48,7 +48,7 @@ jobs:
         name: 'Install MNE'
       - shell: bash -el {0}
         run: |
-          LIBGL_DEBUG=verbose LD_DEBUG=libs python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
+          QT_DEBUG_PLUGINS=1 LIBGL_DEBUG=verbose LD_DEBUG=libs python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
         name: 'Check Qt GL'
       - shell: bash -el {0}
         run: ./tools/github_actions_infos.sh

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -47,7 +47,7 @@ jobs:
         run: ./tools/github_actions_install.sh
         name: 'Install MNE'
       - shell: bash -el {0}
-        run: LIBGL_DEBUG=verbose python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
+        run: LIBGL_DEBUG=verbose LD_DEBUG=libs python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
         name: 'Check Qt GL'
       - shell: bash -el {0}
         run: ./tools/github_actions_infos.sh

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -48,7 +48,7 @@ jobs:
         name: 'Install MNE'
       - shell: bash -el {0}
         run: |
-          QT_DEBUG_PLUGINS=1 LIBGL_DEBUG=verbose LD_DEBUG=libs python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
+          QT_DEBUG_PLUGINS=1 QT_QPA_PLATFORM=xcb LIBGL_DEBUG=verbose LD_DEBUG=libs python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
         name: 'Check Qt GL'
       - shell: bash -el {0}
         run: ./tools/github_actions_infos.sh

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -46,7 +46,7 @@ jobs:
       - shell: bash -el {0}
         run: ./tools/github_actions_install.sh
         name: 'Install MNE'
-      - shell: bash -el {}
+      - shell: bash -el {0}
         run: LIBGL_DEBUG=verbose python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
         name: 'Check Qt GL'
       - shell: bash -el {0}

--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,7 @@ dependencies:
 - nilearn
 - python-picard
 - qtpy
-- pyqt!=5.15.3
+- pyqt!=5.15.3,!=5.15.4
 - mne
 - mffpy>=0.5.7
 - ipywidgets

--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,7 @@ dependencies:
 - nilearn
 - python-picard
 - qtpy
-- pyqt
+- pyqt!=5.15.3,!=5.15.4
 - mne
 - mffpy>=0.5.7
 - ipywidgets

--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,7 @@ dependencies:
 - nilearn
 - python-picard
 - qtpy
-- pyqt!=5.15.3,!=5.15.4
+- pyqt
 - mne
 - mffpy>=0.5.7
 - ipywidgets

--- a/tools/setup_xvfb.sh
+++ b/tools/setup_xvfb.sh
@@ -11,5 +11,5 @@ done
 
 # This also includes the libraries necessary for PyQt5/PyQt6
 sudo apt update
-sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libicu
+sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libicu-dev
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset

--- a/tools/setup_xvfb.sh
+++ b/tools/setup_xvfb.sh
@@ -11,5 +11,5 @@ done
 
 # This also includes the libraries necessary for PyQt5/PyQt6
 sudo apt update
-sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1
+sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libicu70
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset

--- a/tools/setup_xvfb.sh
+++ b/tools/setup_xvfb.sh
@@ -11,5 +11,5 @@ done
 
 # This also includes the libraries necessary for PyQt5/PyQt6
 sudo apt update
-sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libicu70
+sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libicu
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset

--- a/tools/setup_xvfb.sh
+++ b/tools/setup_xvfb.sh
@@ -11,5 +11,5 @@ done
 
 # This also includes the libraries necessary for PyQt5/PyQt6
 sudo apt update
-sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6
+sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset

--- a/tools/setup_xvfb.sh
+++ b/tools/setup_xvfb.sh
@@ -11,5 +11,5 @@ done
 
 # This also includes the libraries necessary for PyQt5/PyQt6
 sudo apt update
-sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libicu-dev
+sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset


### PR DESCRIPTION
No idea why but on our 3.9-conda builds we get a deficient OpenGL version:
```
pyvista:             0.34.0 {OpenGL 3.1 Mesa 21.2.6 via llvmpipe (LLVM 12.0.0, 256 bits)}
```
Compared to the one we get from 3.10 pip:
```
pyvista:             0.35.dev0 {OpenGL 4.5 (Core Profile) Mesa 21.2.6 via llvmpipe (LLVM 12.0.0, 256 bits)}
```
This PR bumps to 3.10 and sets `MESA_GL_VERSION_OVERRIDE`