### PR TITLE
BUG: Keep IPython in Spyder accessible after MNEQtBrowser closes

### DIFF
--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -180,6 +180,8 @@ def _qt_app_exec(app):
     if is_python_signal_handler:
         signal.signal(signal.SIGINT, signal.SIG_DFL)
     try:
+        # Make IPython Console accessible again in Spyder
+        app.lastWindowClosed.connect(app.quit)
         app.exec_()
     finally:
         # reset the SIGINT exception handler


### PR DESCRIPTION
#### What does this implement/fix?
In Spyder, the IPython Console used to stay inaccessible after a MNEQtBrowser-instance with `raw.plot(block=True)` has been closed. This connects `lastWindowClosed` with the termination of the `QApplication`-instance, which seems to be necessary to make the console accessible again in Spyder.