### PR TITLE
Use less memory when loading EDF file

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -300,7 +300,8 @@ def _read_segment_file(data, idx, fi, start, stop, raw_extras, filenames,
             one = np.zeros((len(orig_sel), d_eidx - d_sidx), dtype=data.dtype)
             for ii, ci in enumerate(read_sel):
                 # This now has size (n_chunks_read, n_samp[ci])
-                ch_data = many_chunk[:, ch_offsets[ci]:ch_offsets[ci + 1]]
+                ch_data = many_chunk[:,
+                                     ch_offsets[ci]:ch_offsets[ci + 1]].copy()
 
                 if ci in tal_idx:
                     tal_data.append(ch_data)


### PR DESCRIPTION
Fixes #10634. We need to read through the whole file when annotations are present. However, we accidentally prevented garbage collection in a loop, which led to extremely high memory usage. Because we read annotations when `preload=False`, this is a problem even when the user does not actually want to load the data. I've fixed this by creating an explicit copy of the subarray in the loop.