### PR TITLE
Pick also bad channels when selecting T1T2 mag indices

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -71,7 +71,7 @@ Enhancements
 Bugs
 ~~~~
 
-- Pick also bad channels when selecting T1T2 mag indices (:gh:`10639` by :newcontrib:`Matti Toivonen`_)
+- Pick also bad channels when selecting T1T2 magnetometers in :func:`mne.preprocessing.maxwell_filter` (:gh:`10639` by :newcontrib:`Matti Toivonen`)
 
 - Make ``color`` parameter check in in :func:`mne.viz.plot_evoked_topo` consistent (:gh:`10217` by :newcontrib:`T. Wang` and `Stefan Appelhoff`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -70,6 +70,9 @@ Enhancements
 
 Bugs
 ~~~~
+
+- Pick also bad channels when selecting T1T2 mag indices (:gh:`10639` by :newcontrib:`Matti Toivonen`_)
+
 - Make ``color`` parameter check in in :func:`mne.viz.plot_evoked_topo` consistent (:gh:`10217` by :newcontrib:`T. Wang` and `Stefan Appelhoff`_)
 
 - Fix bug in :func:`mne.io.read_raw_brainvision` when BrainVision data are acquired with the Brain Products "V-Amp" amplifier and disabled lowpass filter is marked with value ``0`` (:gh:`10517` by :newcontrib:`Alessandro Tonin`)

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -445,3 +445,5 @@
 .. _T. Wang: https://github.com/twang5
 
 .. _Samuel Powell: https://github.com/samuelpowell
+
+.. _Matti Toivonen: https://github.com/mattitoi

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1458,7 +1458,7 @@ def fix_mag_coil_types(info, use_cal=False):
     for ii in old_mag_inds:
         info['chs'][ii]['coil_type'] = FIFF.FIFFV_COIL_VV_MAG_T3
     logger.info('%d of %d magnetometer types replaced with T3.' %
-                (len(old_mag_inds), len(pick_types(info, meg='mag'))))
+                (len(old_mag_inds), len(pick_types(info, meg='mag', exclude=[]))))
     info._check_consistency()
 
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1458,7 +1458,8 @@ def fix_mag_coil_types(info, use_cal=False):
     for ii in old_mag_inds:
         info['chs'][ii]['coil_type'] = FIFF.FIFFV_COIL_VV_MAG_T3
     logger.info('%d of %d magnetometer types replaced with T3.' %
-                (len(old_mag_inds), len(pick_types(info, meg='mag', exclude=[]))))
+                (len(old_mag_inds),
+                 len(pick_types(info, meg='mag', exclude=[]))))
     info._check_consistency()
 
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1464,7 +1464,7 @@ def fix_mag_coil_types(info, use_cal=False):
 
 def _get_T1T2_mag_inds(info, use_cal=False):
     """Find T1/T2 magnetometer coil types."""
-    picks = pick_types(info, meg='mag')
+    picks = pick_types(info, meg='mag', exclude=[])
     old_mag_inds = []
     # From email exchanges, systems with the larger T2 coil only use the cal
     # value of 2.09e-11. Newer T3 magnetometers use 4.13e-11 or 1.33e-10

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -114,7 +114,7 @@ def test_fix_types():
     ):
         raw = read_raw_fif(fname)
         raw.info["bads"] =  bads
-        mag_picks = pick_types(raw.info, meg='mag')
+        mag_picks = pick_types(raw.info, meg='mag', exclude=[])
         other_picks = np.setdiff1d(np.arange(len(raw.ch_names)), mag_picks)
         # we don't actually have any files suffering from this problem, so
         # fake it

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -107,9 +107,13 @@ def test_acq_skip(tmp_path):
 
 def test_fix_types():
     """Test fixing of channel types."""
-    for fname, change in ((hp_fif_fname, True), (test_fif_fname, False),
-                          (ctf_fname, False)):
+    for fname, change, bads in (
+        (hp_fif_fname, True, ["MEG0111"]),
+        (test_fif_fname, False, []),
+        (ctf_fname, False, [])
+    ):
         raw = read_raw_fif(fname)
+        raw.info["bads"] =  bads
         mag_picks = pick_types(raw.info, meg='mag')
         other_picks = np.setdiff1d(np.arange(len(raw.ch_names)), mag_picks)
         # we don't actually have any files suffering from this problem, so


### PR DESCRIPTION
If exclude="bads" (default),
channels marked as bad will not be included.
This will lead to coil type not being fixed
in call to mne.preprocessing.maxwell_filter
3022 (FIFFV_COIL_VV_MAG_T1)to 3024 (FIFFV_COIL_VV_MAG_T3).

#### What does this implement/fix?

`mne.preprocessing.maxwell_filter` fixes the coil type of magnetometers from `3022 (FIFFV_COIL_VV_MAG_T1)` to `3024 (FIFFV_COIL_VV_MAG_T3)`. However, the coil type is not fixed for channels marked as bad. This is because `exclude` argument is `bads` by default for `pick_types`-function.

#### Additional information

Tests run only for `mne/preprocessing/tests/test_maxwell.py`.

```bash
>pytest mne/preprocessing/tests/test_maxwell.py
=========================================================================== test session starts ===========================================================================
platform win32 -- Python 3.10.4, pytest-7.1.1, pluggy-1.0.0
rootdir: C:\Users\matti.toivonen\src\mne-python, configfile: setup.cfg
plugins: cov-3.0.0, harvest-1.10.3, timeout-2.1.0
collected 42 items

mne\preprocessing\tests\test_maxwell.py ..........................................                                                                                   [100%]


========================================================================= slowest 20 test modules =========================================================================
99.98s total   mne/preprocessing/tests/test_maxwell.py


---------------------------------------------- generated xml file: C:\Users\matti.toivonen\src\mne-python\junit-results.xml -----------------------------------------------
========================================================================== slowest 20 durations ===========================================================================
17.04s call     mne/preprocessing/tests/test_maxwell.py::test_shielding_factor
16.42s call     mne/preprocessing/tests/test_maxwell.py::test_spatiotemporal
13.69s call     mne/preprocessing/tests/test_maxwell.py::test_movement_compensation
8.12s call     mne/preprocessing/tests/test_maxwell.py::test_find_bads_maxwell_flat
4.25s call     mne/preprocessing/tests/test_maxwell.py::test_triux
4.12s call     mne/preprocessing/tests/test_maxwell.py::test_all
3.68s call     mne/preprocessing/tests/test_maxwell.py::test_find_bad_channels_maxwell[C:\\Users\\matti.toivonen\\mne_data\\MNE-testing-data\\CTF\\testdata_ctf.ds-bads2-False-False-False-want_bads2-False-None-raw]
3.57s call     mne/preprocessing/tests/test_maxwell.py::test_spatiotemporal_only
2.74s call     mne/preprocessing/tests/test_maxwell.py::test_other_systems
1.92s call     mne/preprocessing/tests/test_maxwell.py::test_basic
1.43s call     mne/preprocessing/tests/test_maxwell.py::test_find_bad_channels_maxwell[C:\\Users\\matti.toivonen\\mne_data\\MNE-testing-data\\MEG\\sample\\sample_audvis_trunc_raw.fif-bads0-False-False-False-want_bads0-False-None-raw]
1.37s call     mne/preprocessing/tests/test_maxwell.py::test_find_bad_channels_maxwell[C:\\Users\\matti.toivonen\\mne_data\\MNE-testing-data\\CTF\\testdata_ctf.ds-bads3-False-False-True-want_bads3-False-None-raw]
1.36s call     mne/preprocessing/tests/test_maxwell.py::test_find_bad_channels_maxwell[C:\\Users\\matti.toivonen\\mne_data\\MNE-testing-data\\MEG\\sample\\sample_audvis_trunc_raw.fif-bads5-True-True-False-want_bads5-True-50-None]
1.28s call     mne/preprocessing/tests/test_maxwell.py::test_find_bad_channels_maxwell[C:\\Users\\matti.toivonen\\mne_data\\MNE-testing-data\\MEG\\sample\\sample_audvis_trunc_raw.fif-bads4-True-True-False-want_bads4-True-50-raw]
1.25s call     mne/preprocessing/tests/test_maxwell.py::test_find_bad_channels_maxwell[C:\\Users\\matti.toivonen\\mne_data\\MNE-testing-data\\MEG\\sample\\sample_audvis_trunc_raw.fif-bads1-True-True-False-want_bads1-False-None-raw]
1.18s call     mne/preprocessing/tests/test_maxwell.py::test_cross_talk
1.14s call     mne/preprocessing/tests/test_maxwell.py::test_esss[bads0-in]
1.12s call     mne/preprocessing/tests/test_maxwell.py::test_fine_calibration
1.10s call     mne/preprocessing/tests/test_maxwell.py::test_mf_skips
1.08s call     mne/preprocessing/tests/test_maxwell.py::test_esss[bads1-in]
===================================================================== 42 passed in 100.96s (0:01:40) ======================================================================

```
