### PR TITLE
MNT: Add key press callback in GUI API

### DIFF
--- a/mne/gui/tests/test_gui_api.py
+++ b/mne/gui/tests/test_gui_api.py
@@ -349,6 +349,15 @@ def test_gui_api(renderer_notebook, nbexec, n_warn=0):
         assert mock.call_args.args == (button,)
     # --- END: dialog ---
 
+    # --- BEGIN: keypress ---
+    renderer._keypress_initialize()
+    renderer._keypress_add('a', mock)
+    # keypress is not supported yet on notebook
+    if renderer._kind == 'qt':
+        with _check_widget_trigger(None, mock, '', '', get_value=False):
+            renderer._keypress_trigger('a')
+    # --- END: keypress ---
+
     renderer.show()
 
     renderer._window_close_connect(lambda: mock('first'), after=False)

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -643,6 +643,20 @@ class _AbstractPlayback(ABC):
         pass
 
 
+class _AbstractKeyPress(ABC):
+    @abstractmethod
+    def _keypress_initialize(self, widget):
+        pass
+
+    @abstractmethod
+    def _keypress_add(self, shortcut, callback):
+        pass
+
+    @abstractmethod
+    def _keypress_trigger(self, shortcut):
+        pass
+
+
 class _AbstractDialog(ABC):
     @abstractmethod
     def _dialog_create(self, title, text, info_text, callback, *,

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -645,7 +645,7 @@ class _AbstractPlayback(ABC):
 
 class _AbstractKeyPress(ABC):
     @abstractmethod
-    def _keypress_initialize(self, widget):
+    def _keypress_initialize(self, widget=None):
         pass
 
     @abstractmethod

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -162,7 +162,7 @@ class _FilePicker:
 
 
 class _IpyKeyPress(_AbstractKeyPress):
-    def _keypress_initialize(self, widget):
+    def _keypress_initialize(self, widget=None):
         pass
 
     def _keypress_add(self, shortcut, callback):

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -17,7 +17,8 @@ from ._abstract import (_AbstractDock, _AbstractToolBar, _AbstractMenuBar,
                         _AbstractStatusBar, _AbstractLayout, _AbstractWidget,
                         _AbstractWindow, _AbstractMplCanvas, _AbstractPlayback,
                         _AbstractBrainMplCanvas, _AbstractMplInterface,
-                        _AbstractWidgetList, _AbstractAction, _AbstractDialog)
+                        _AbstractWidgetList, _AbstractAction, _AbstractDialog,
+                        _AbstractKeyPress)
 from ._pyvista import _PyVistaRenderer, _close_all, _set_3d_view, _set_3d_title  # noqa: F401,E501, analysis:ignore
 
 
@@ -158,6 +159,17 @@ class _FilePicker:
             self._selected_dir, self._file_selector.value
         )
         self._filename.value = self._file_selector.value
+
+
+class _IpyKeyPress(_AbstractKeyPress):
+    def _keypress_initialize(self, widget):
+        pass
+
+    def _keypress_add(self, shortcut, callback):
+        pass
+
+    def _keypress_trigger(self, shortcut):
+        pass
 
 
 class _IpyDialog(_AbstractDialog):
@@ -671,7 +683,8 @@ class _IpyAction(_AbstractAction):
 
 
 class _Renderer(_PyVistaRenderer, _IpyDock, _IpyToolBar, _IpyMenuBar,
-                _IpyStatusBar, _IpyWindow, _IpyPlayback, _IpyDialog):
+                _IpyStatusBar, _IpyWindow, _IpyPlayback, _IpyDialog,
+                _IpyKeyPress):
     _kind = 'notebook'
 
     def __init__(self, *args, **kwargs):

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -50,7 +50,8 @@ class _QtKeyPress(_AbstractKeyPress):
         page_down=Qt.Key_PageDown,
     )
 
-    def _keypress_initialize(self, widget):
+    def _keypress_initialize(self, widget=None):
+        widget = self._window if widget is None else widget
         self._widget_id = _QtKeyPress._widget_id
         _QtKeyPress._widget_id += 1
         _QtKeyPress._callbacks[self._widget_id] = dict()


### PR DESCRIPTION
This PR adds support for widget key press event. It only works with the `pyvistaqt` 3d backend for now but it could be possible to use `ipyevent` for the `notebook` 3d backend for example.

Here is a code snippet to try:

```py
from mne.viz.backends.renderer import _get_renderer

renderer = _get_renderer()
renderer._keypress_initialize(renderer._interactor)
renderer._keypress_add('a', lambda: print("foo"))
renderer.show()
```

It's an item of https://github.com/mne-tools/mne-python/pull/10565