### PR TITLE
MNT: window and layout in GUI API

### DIFF
--- a/mne/gui/tests/test_gui_api.py
+++ b/mne/gui/tests/test_gui_api.py
@@ -33,6 +33,8 @@ def test_gui_api(renderer_notebook, nbexec, n_warn=0):
     else:
         backend = 'qt'
     renderer = mne.viz.backends.renderer._get_renderer(size=(300, 300))
+
+    # theme
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         renderer._window_set_theme('/does/not/exist')
@@ -44,6 +46,16 @@ def test_gui_api(renderer_notebook, nbexec, n_warn=0):
     with mne.utils._record_warnings() as w:
         renderer._window_set_theme('dark')
     assert len(w) == n_warn
+
+    # window without 3d plotter
+    if backend == 'qt':
+        window = renderer._window_create()
+        widget = renderer._window_create()
+        central_layout = renderer._layout_create(orientation='grid')
+        renderer._layout_add_widget(central_layout, widget, row=0, col=0)
+        renderer._window_initialize(window=window,
+                                    central_layout=central_layout,
+                                    theme_support=False)
 
     from unittest.mock import Mock
     mock = Mock()

--- a/mne/gui/tests/test_gui_api.py
+++ b/mne/gui/tests/test_gui_api.py
@@ -54,8 +54,7 @@ def test_gui_api(renderer_notebook, nbexec, n_warn=0):
         central_layout = renderer._layout_create(orientation='grid')
         renderer._layout_add_widget(central_layout, widget, row=0, col=0)
         renderer._window_initialize(window=window,
-                                    central_layout=central_layout,
-                                    theme_support=False)
+                                    central_layout=central_layout)
 
     from unittest.mock import Mock
     mock = Mock()

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -656,7 +656,12 @@ class _AbstractLayout(ABC):
         pass
 
     @abstractmethod
-    def _layout_add_widget(self, layout, widget, stretch=0):
+    def _layout_add_widget(self, layout, widget, stretch=0,
+                           *, row=None, col=None):
+        pass
+
+    @abstractmethod
+    def _layout_create(self, orientation='vertical'):
         pass
 
 
@@ -867,7 +872,8 @@ class _AbstractBrainMplCanvas(_AbstractMplCanvas):
 
 
 class _AbstractWindow(ABC):
-    def _window_initialize(self):
+    def _window_initialize(self, window=None, central_layout=None,
+                           theme_support=True):
         self._icons = dict()
         self._window = None
         self._interactor = None
@@ -934,6 +940,10 @@ class _AbstractWindow(ABC):
 
     @abstractmethod
     def _window_set_theme(self, theme):
+        pass
+
+    @abstractmethod
+    def _window_create(self):
         pass
 
 

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -886,8 +886,7 @@ class _AbstractBrainMplCanvas(_AbstractMplCanvas):
 
 
 class _AbstractWindow(ABC):
-    def _window_initialize(self, window=None, central_layout=None,
-                           theme_support=True):
+    def _window_initialize(self, window=None, central_layout=None):
         self._icons = dict()
         self._window = None
         self._interactor = None

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -11,7 +11,7 @@ from IPython.display import display
 from ipywidgets import (Button, Dropdown, FloatSlider, BoundedFloatText, HBox,
                         IntSlider, IntText, Text, VBox, IntProgress, Play,
                         Checkbox, RadioButtons, HTML, Accordion, jsdlink,
-                        Layout, Select)
+                        Layout, Select, GridBox)
 
 from ._abstract import (_AbstractDock, _AbstractToolBar, _AbstractMenuBar,
                         _AbstractStatusBar, _AbstractLayout, _AbstractWidget,
@@ -170,7 +170,8 @@ class _IpyLayout(_AbstractLayout):
     def _layout_initialize(self, max_width):
         self._layout_max_width = max_width
 
-    def _layout_add_widget(self, layout, widget, stretch=0):
+    def _layout_add_widget(self, layout, widget, stretch=0,
+                           *, row=None, col=None):
         widget.layout.margin = "2px 0px 2px 0px"
         if not isinstance(widget, Play):
             widget.layout.min_width = "0px"
@@ -188,6 +189,16 @@ class _IpyLayout(_AbstractLayout):
                 width = int(self._layout_max_width / len(children))
                 for child in children:
                     child.layout.width = f"{width}px"
+
+    def _layout_create(self, orientation='vertical'):
+        if orientation == 'vertical':
+            layout = VBox()
+        elif orientation == 'horizontal':
+            layout = HBox()
+        else:
+            assert orientation == 'grid'
+            layout = GridBox()
+        return layout
 
 
 class _IpyDock(_AbstractDock, _IpyLayout):
@@ -517,7 +528,8 @@ class _IpyBrainMplCanvas(_AbstractBrainMplCanvas, _IpyMplInterface):
 
 
 class _IpyWindow(_AbstractWindow):
-    def _window_initialize(self):
+    def _window_initialize(self, window=None, central_layout=None,
+                           theme_support=True):
         super()._window_initialize()
         self._window_load_icons()
 
@@ -579,6 +591,10 @@ class _IpyWindow(_AbstractWindow):
 
     def _window_set_theme(self, theme):
         pass
+
+    def _window_create(self):
+        pass
+        # XXX: this could be a VBox if _Renderer.show is refactored
 
 
 class _IpyWidgetList(_AbstractWidgetList):

--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -540,8 +540,7 @@ class _IpyBrainMplCanvas(_AbstractBrainMplCanvas, _IpyMplInterface):
 
 
 class _IpyWindow(_AbstractWindow):
-    def _window_initialize(self, window=None, central_layout=None,
-                           theme_support=True):
+    def _window_initialize(self, window=None, central_layout=None):
         super()._window_initialize()
         self._window_load_icons()
 

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -586,10 +586,8 @@ class _QtBrainMplCanvas(_AbstractBrainMplCanvas, _QtMplInterface):
 
 
 class _QtWindow(_AbstractWindow):
-    def _window_initialize(self, window=None, central_layout=None,
-                           theme_support=True):
+    def _window_initialize(self, window=None, central_layout=None):
         super()._window_initialize()
-        self._window_theme_support = theme_support
         self._interactor = self.figure.plotter.interactor
         if window is None:
             self._window = self.figure.plotter.app_window
@@ -743,8 +741,6 @@ class _QtWindow(_AbstractWindow):
             self._process_events()
 
     def _window_set_theme(self, theme=None):
-        if not self._window_theme_support:
-            return
         if theme is None:
             default_theme = _qt_detect_theme()
         else:


### PR DESCRIPTION
This PR refactors `_QtWindow`:
* adds support for custom central layout
* adds `_window_create` to spawn a window 'without pyvista support' (instance of `_MNEMainWindow`)
* ~adds the option `theme_support` to opt-out from automatic theming~

and `_QtLayout`:
* adds support for grid layout

Here is a code snippet to try:

```py
from mne.viz.backends.renderer import _get_renderer

renderer = _get_renderer()
renderer.show()

window = renderer._window_create()
window.show()
```

Further consideration:
* With more refactoring it should be possible to use `_get_renderer()` to spawn `_MNEMainWindow` instead of using `_PyVistaRenderer`. This more important matter is about about having a GUI API which does not depends on `pyvista`.

It's an item of https://github.com/mne-tools/mne-python/pull/10565