### PR TITLE
WIP, ENH: Automatic theme switching on macOS

### DIFF
--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -955,11 +955,10 @@ def _testing_context(interactive):
 class _DiscardEventFilter(QObject):
     def __init__(self, event_name):
         super().__init__()
-        self._event_name = event_name
+        self._event_type = getattr(QEvent, event_name)
 
     def eventFilter(self, obj, ev):
-        event_type = getattr(QEvent, self._event_name)
-        if ev.type() == event_type:
+        if ev.type() == self._event_type:
             ev.accept()
             return True
         else:

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -918,7 +918,13 @@ def _create_dock_widget(window, name, area, *, max_width=None):
 
 def _set_window_theme(window, theme):
     stylesheet = _qt_get_stylesheet(theme)
+    # The setStyleSheet() function triggers a PaletteChange event so we
+    # need to filter out the newly created one to avoid ending in an
+    # infinite loop.
+    event_filter = _DiscardEventFilter('PaletteChange')
+    window.installEventFilter(event_filter)
     window.setStyleSheet(stylesheet)
+    window.removeEventFilter(event_filter)
     if _qt_is_dark(window):
         QIcon.setThemeName('dark')
     else:
@@ -973,13 +979,7 @@ class _MNEMainWindow(MainWindow):
 
     def _filter_palette_change(self, ev):
         theme = get_config('MNE_3D_OPTION_THEME', 'auto')
-        # The setStyleSheet() function triggers a PaletteChange event so we
-        # need to filter out the newly created one to avoid ending in an
-        # infinite loop.
-        event_filter = _DiscardEventFilter('PaletteChange')
-        self.installEventFilter(event_filter)
         _set_window_theme(self, theme)
-        self.removeEventFilter(event_filter)
 
     def event(self, ev):
         """Catch system events."""

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -11,7 +11,7 @@ import weakref
 import pyvista
 from pyvistaqt.plotting import FileDialog, MainWindow
 
-from qtpy.QtCore import Qt, Signal, QLocale, QObject
+from qtpy.QtCore import Qt, Signal, QLocale, QObject, QEvent
 from qtpy.QtGui import QIcon, QCursor
 from qtpy.QtWidgets import (QComboBox, QDockWidget, QDoubleSpinBox, QGroupBox,
                             QHBoxLayout, QLabel, QToolButton, QMenuBar,
@@ -723,12 +723,7 @@ class _QtWindow(_AbstractWindow):
         else:
             default_theme = theme
         theme = get_config('MNE_3D_OPTION_THEME', default_theme)
-        stylesheet = _qt_get_stylesheet(theme)
-        self._window.setStyleSheet(stylesheet)
-        if _qt_is_dark(self._window):
-            QIcon.setThemeName('dark')
-        else:
-            QIcon.setThemeName('light')
+        _set_window_theme(self._window, theme)
 
 
 class _QtWidgetList(_AbstractWidgetList):
@@ -921,6 +916,15 @@ def _create_dock_widget(window, name, area, *, max_width=None):
     return dock, dock_layout
 
 
+def _set_window_theme(window, theme):
+    stylesheet = _qt_get_stylesheet(theme)
+    window.setStyleSheet(stylesheet)
+    if _qt_is_dark(window):
+        QIcon.setThemeName('dark')
+    else:
+        QIcon.setThemeName('light')
+
+
 @contextmanager
 def _testing_context(interactive):
     from . import renderer
@@ -952,3 +956,18 @@ class _MNEMainWindow(MainWindow):
     def __init__(self, parent=None, title=None, size=None):
         super().__init__(parent, title, size)
         self.setAttribute(Qt.WA_ShowWithoutActivating, True)
+        self._palette_lock = False  # prevent palette change loop
+
+    def _filter_palette_change(self, ev):
+        if self._palette_lock:
+            return
+        self._palette_lock = True
+        theme = get_config('MNE_3D_OPTION_THEME', 'auto')
+        _set_window_theme(self, theme)
+        self._palette_lock = False
+
+    def event(self, ev):
+        """Catch system events."""
+        if ev.type() == QEvent.PaletteChange:  # detect theme switches
+            self._filter_palette_change(ev)
+        return super().event(ev)

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -946,7 +946,7 @@ def _testing_context(interactive):
         renderer.MNE_3D_BACKEND_INTERACTIVE = orig_interactive
 
 
-class _EventFilter(QObject):
+class _DiscardEventFilter(QObject):
     def __init__(self, event_name):
         super().__init__()
         self._event_name = event_name
@@ -976,7 +976,7 @@ class _MNEMainWindow(MainWindow):
         # The setStyleSheet() function triggers a PaletteChange event so we
         # need to filter out the newly created one to avoid ending in an
         # infinite loop.
-        event_filter = _EventFilter('PaletteChange')
+        event_filter = _DiscardEventFilter('PaletteChange')
         self.installEventFilter(event_filter)
         _set_window_theme(self, theme)
         self.removeEventFilter(event_filter)

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -956,7 +956,8 @@ class _EventFilter(QObject):
         if ev.type() == event_type:
             ev.accept()
             return True
-        return False
+        else:
+            return False
 
 
 # In theory we should be able to do this later (e.g., in _pyvista.py when
@@ -971,11 +972,12 @@ class _MNEMainWindow(MainWindow):
         self.setAttribute(Qt.WA_ShowWithoutActivating, True)
 
     def _filter_palette_change(self, ev):
-        # _setStyleSheet triggers a PaletteChange event so we need to filter
-        # out the newly created one to avoid ending in an infinite loop
+        theme = get_config('MNE_3D_OPTION_THEME', 'auto')
+        # The setStyleSheet() function triggers a PaletteChange event so we
+        # need to filter out the newly created one to avoid ending in an
+        # infinite loop.
         event_filter = _EventFilter('PaletteChange')
         self.installEventFilter(event_filter)
-        theme = get_config('MNE_3D_OPTION_THEME', 'auto')
         _set_window_theme(self, theme)
         self.removeEventFilter(event_filter)
 

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -976,12 +976,9 @@ class _MNEMainWindow(MainWindow):
         super().__init__(parent, title, size)
         self.setAttribute(Qt.WA_ShowWithoutActivating, True)
 
-    def _filter_palette_change(self, ev):
-        theme = get_config('MNE_3D_OPTION_THEME', 'auto')
-        _set_window_theme(self, theme)
-
     def event(self, ev):
         """Catch system events."""
         if ev.type() == QEvent.PaletteChange:  # detect theme switches
-            self._filter_palette_change(ev)
+            theme = get_config('MNE_3D_OPTION_THEME', 'auto')
+            _set_window_theme(self, theme)
         return super().event(ev)


### PR DESCRIPTION
This PR comes from https://github.com/mne-tools/mne-python/pull/10565#issuecomment-1132764545 and adds support for automatic theme switching on macOS. It is a draft until it has been tested on macOS.

### How to test?

On a macOS machine, plot any 3d figure (alignment, stc, coreg, ...etc) then switch the system theme.

### Expected result

The window, the widgets and the icons should follow the new theme.

---

Closes #9182