### PR TITLE
MRG: In find_bad_channels_maxwell(), do not filter data if existing lowpass filter frequency is equal to the one requested

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -112,6 +112,8 @@ Bugs
 
 - Reduce memory usage when loading an EDF file with ``preload=False`` (:gh:`10638` by `Clemens Brunner`_)
 
+- In :func:`mne.preprocessing.find_bad_channels_maxwell`, do not re-filter the data if a low-pass filter with the requested frequency has already been applied (:gh:`xxx` by `Richard Höchenberger`_)
+
 API and behavior changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - When creating BEM surfaces via :func:`mne.bem.make_watershed_bem` and :func:`mne.bem.make_flash_bem`, the ``copy`` parameter now defaults to ``True``. This means that instead of creating symbolic links inside the FreeSurfer subject's ``bem`` folder, we now create "actual" files. This should avoid troubles when sharing files across different operating systems and file systems (:gh:`10531` by `Richard Höchenberger`_)

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -2215,11 +2215,12 @@ def find_bad_channels_maxwell(
     .. versionadded:: 0.20
     """
     if h_freq is not None:
-        if raw.info.get('lowpass') and raw.info['lowpass'] < h_freq:
+        if raw.info.get('lowpass') and raw.info['lowpass'] <= h_freq:
+            freq_loc = 'below' if raw.info['lowpass'] < h_freq else 'equal to'
             msg = (f'The input data has already been low-pass filtered with a '
                    f'{raw.info["lowpass"]} Hz cutoff frequency, which is '
-                   f'below the requested cutoff of {h_freq} Hz. Not applying '
-                   f'low-pass filter.')
+                   f'{freq_loc} the requested cutoff of {h_freq} Hz. Not '
+                   f'applying low-pass filter.')
             logger.info(msg)
         else:
             logger.info(f'Applying low-pass filter with {h_freq} Hz cutoff '


### PR DESCRIPTION
We used to not re-filter only if the already-applied filter hfreq was smaller than what was requested, but actually to correct comparison is `<=`.