### PR TITLE
Support NIRx Aurora 2021.9.6 files

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -77,6 +77,8 @@ Enhancements
 
 - Add :meth:`mne.viz.Brain.get_view` to get the current camera parameters such that they can be passed to :meth:`mne.viz.Brain.show_view` (:gh:`10661` by `Alex Rockhill`_)
 
+- Added support for Aurora version 2021.9.0.6 to :func:`mne.io.read_raw_nirx` (:gh:`10668` by `Robert Luke`_)
+
 Bugs
 ~~~~
 

--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -87,7 +87,7 @@ I agree to the following:
 # respective repos, and make a new release of the dataset on GitHub. Then
 # update the checksum in the MNE_DATASETS dict below, and change version
 # here:                  ↓↓↓↓↓         ↓↓↓
-RELEASES = dict(testing='0.135', misc='0.23')
+RELEASES = dict(testing='0.136', misc='0.23')
 TESTING_VERSIONED = f'mne-testing-data-{RELEASES["testing"]}'
 MISC_VERSIONED = f'mne-misc-data-{RELEASES["misc"]}'
 

--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -111,7 +111,7 @@ MNE_DATASETS = dict()
 # Testing and misc are at the top as they're updated most often
 MNE_DATASETS['testing'] = dict(
     archive_name=f'{TESTING_VERSIONED}.tar.gz',  # 'mne-testing-data',
-    hash='md5:db40791e786fa776e8717cf50b43b0ec',
+    hash='md5:30c0b518f3bf5264f04e42b543c3a92a',
     url=('https://codeload.github.com/mne-tools/mne-testing-data/'
          f'tar.gz/{RELEASES["testing"]}'),
     folder_name='MNE-testing-data',

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -516,8 +516,7 @@ def _convert_fnirs_to_head(trans, fro, to, src_locs, det_locs, ch_locs):
 
 
 def _determine_tri_idxs(trigger):
-    """Determine which indices in tri file represent
-    the frame index and description."""
+    """Determine tri file indexes for frame and description."""
     if len(trigger) == 12:
         # Aurora version 2021.9.6 or greater
         trigger_frame_idx = 7

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -50,6 +50,8 @@ nirsport2 = op.join(
     testing_path, 'NIRx', 'nirsport_v2', 'aurora_recording _w_short_and_acc')
 nirsport2_2021_9 = op.join(
     testing_path, 'NIRx', 'nirsport_v2', 'aurora_2021_9')
+nirsport2_2021_9_6 = op.join(
+    testing_path, 'NIRx', 'nirsport_v2', 'aurora_2021_9_6')
 
 
 def test_nirsport_v2_matches_snirf(nirx_snirf):
@@ -523,6 +525,15 @@ def test_nirx_15_2():
     assert 'fnirs_od' not in raw
     picks = pick_types(raw.info, fnirs='fnirs_cw_amplitude')
     assert len(picks) > 0
+
+
+@requires_testing_data
+def test_nirx_aurora_2021_9_6():
+    """Test reading NIRX files."""
+    raw = read_raw_nirx(nirsport2_2021_9_6, preload=True)
+    assert len(raw.annotations) == 3
+    assert raw.annotations.description[0] == "1.0"
+    assert raw.annotations.description[2] == "3.0"
 
 
 @requires_testing_data


### PR DESCRIPTION
#### What does this implement/fix?

The fNIRS vendor NIRx released a new version of their acquisition software "2021.9.0.6".
This version changed the way they store triggers in the `.tri` file.
This PR enables reading of the new trigger file format.

#### Additional information
Associated testing data and description of file format change is at https://github.com/mne-tools/mne-testing-data/pull/97
Testing data version and hash will be updated when merged.