### PR TITLE
BUG: Restore mouse wheel zoom for terrain

### DIFF
--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -307,7 +307,10 @@ class _PyVistaRenderer(_AbstractRenderer):
         else:
             for renderer in self._all_renderers:
                 renderer.disable_parallel_projection()
-            getattr(self.plotter, f'enable_{interaction}_style')()
+            kwargs = dict()
+            if interaction == 'terrain':
+                kwargs['mouse_wheel_zooms'] = True
+            getattr(self.plotter, f'enable_{interaction}_style')(**kwargs)
 
     def legend(self, labels, border=False, size=0.1, face='triangle',
                loc='upper left'):


### PR DESCRIPTION
At some point we had it so that the scroll wheel zoomed in terrain mode but lost it. This puts it back. You can test easily with:
```
mne.viz.plot_alignment(subject='fsaverage', surfaces='head', coord_frame='mri')
```