### PR TITLE
add another date format to CTF

### DIFF
--- a/mne/io/ctf/info.py
+++ b/mne/io/ctf/info.py
@@ -73,7 +73,7 @@ def _pick_isotrak_and_hpi_coils(res4, coils, t):
 
 def _convert_time(date_str, time_str):
     """Convert date and time strings to float time."""
-    for fmt in ("%d/%m/%Y", "%d-%b-%Y", "%a, %b %d, %Y"):
+    for fmt in ("%Y/%m/%d", "%d/%m/%Y", "%d-%b-%Y", "%a, %b %d, %Y"):
         try:
             date = strptime(date_str.strip(), fmt)
         except ValueError:


### PR DESCRIPTION
I encountered adatestring in format `%Y/%m/%d` while loading a CTF file from openneuro.

Would it be possible to add it to the pool of recognized datestrings?

I don't think this will have any side-effects.