### PR TITLE
added instructions to pip install missing dependencies

### DIFF
--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -330,11 +330,12 @@ def _soft_import(name, purpose, strict=True):
         functionality the package provides to MNE-Python.
     strict : bool
         Whether to raise an error if module import fails.
-    pip_name : str
-        The PyPI package name if it does not match the module name.
     """
-    # If PyPI package name matches import namespace
-    # pip_name = name if pip_name is None else pip_name
+    # so that error msg lines are aligned
+    def indent(x):
+        return x.rjust(len(x) + 14)
+
+    # Mapping import namespaces to their pypi package name
     pip_name = dict(
         sklearn='scikit-learn',
         EDFlib='EDFlib-Python',
@@ -350,9 +351,14 @@ def _soft_import(name, purpose, strict=True):
         return mod
     except (ImportError, ModuleNotFoundError):
         if strict:
-            raise RuntimeError(f'For {purpose} to work, the {name} module is '
-                               'needed, but it could not be imported. '
-                               f'pip install {pip_name} and try again.')
+            raise RuntimeError(
+                f'For {purpose} to work, the {name} module is needed, ' +
+                'but it could not be imported.\n' +
+                '\n'.join((indent('use the following installation method '
+                                  'appropriate for your environment:'),
+                           indent(f"'pip install {pip_name}'"),
+                           indent(f"'conda install -c conda-forge {pip_name}'")
+                           )))
         else:
             return False
 

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -169,13 +169,18 @@ def _get_3d_backend():
                     MNE_3D_BACKEND = name
                     break
             else:
-                pip_name_map = {'pyvistaqt': 'pyvistaqt',
-                                'notebook': 'ipywidgets'}
+
                 raise RuntimeError(
-                    'Could not load any valid 3D backend,'
-                    ' please install one of the following backends:\n' +
-                    "\n".join(f'{key}: {val} - pip install {pip_name_map[key]}'
-                              for key, val in errors.items()))
+                    'Could not load any valid 3D backend\n' +
+                    "\n".join(f'{key}: {val}' for key, val in errors.items()) +
+                    "\n".join(('\n\n install pyvistaqt, using pip or conda:',
+                               "'pip install pyvistaqt'",
+                               "'conda install -c conda-forge pyvistaqt'",
+                               '\n or install ipywidgets, ' +
+                               'if using a notebook backend',
+                               "'pip install ipywidgets'",
+                               "'conda install -c conda-forge ipywidgets'")))
+
         else:
             MNE_3D_BACKEND = _check_3d_backend_name(MNE_3D_BACKEND)
             _reload_backend(MNE_3D_BACKEND)


### PR DESCRIPTION
Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

#### Reference issue
10562


#### What does this implement/fix?
Made revisions to `_soft_import()` in `mne.utils.check` to give more verbose instructions to install a missing MNE optional dependency.

I also added a line to `_get_3d_backend` in `mne.viz.backends.renderer` to give more verbose pip install instructions in the error message that is returned if both MNE Valid 3D backends (pyvistaqt or ipywidgets for notebook) are missing.. I've run into this missing 3D backend dependency error message when running `mne.viz.plot_alignments()` 


#### Additional information
Any additional information you think is important.
