### PR TITLE
Improve ICA docstrings following #10557

### DIFF
--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -316,6 +316,9 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
     Properties include the topography, epochs image, ERP/ERF, power
     spectrum, and epoch variance.
 
+    .. note::
+       You can cycle between different channel types by pressing :kbd:`T`.
+
     Parameters
     ----------
     ica : instance of mne.preprocessing.ICA
@@ -343,7 +346,13 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
         interval is calculated. To change this, use ``ci`` in ``ts_args`` in
         ``image_args`` (see below).
     log_scale : bool
-        Whether to use a log scale to plot the spectrum. Defaults to False.
+        Whether to use a logarithmic frequency axis to plot the spectrum.
+        Defaults to ``False``.
+
+        .. note::
+           You can interactively toggle this setting by pressing :kbd:`L`.
+
+        .. versionadded:: 1.1
     topomap_args : dict | None
         Dictionary of arguments to ``plot_topomap``. If None, doesn't pass any
         additional arguments. Defaults to None.

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -326,7 +326,6 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
         .. note::
            You can interactively cycle through topographic maps for different
            channel types by pressing :kbd:`T`.
-
     picks : str | list | slice | None
         Components to include. Slices and lists of integers will be interpreted
         as component indices. ``None`` (default) will use the first five

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -316,15 +316,17 @@ def plot_ica_properties(ica, inst, picks=None, axes=None, dB=True,
     Properties include the topography, epochs image, ERP/ERF, power
     spectrum, and epoch variance.
 
-    .. note::
-       You can cycle between different channel types by pressing :kbd:`T`.
-
     Parameters
     ----------
     ica : instance of mne.preprocessing.ICA
         The ICA solution.
     inst : instance of Epochs or Raw
         The data to use in plotting properties.
+
+        .. note::
+           You can interactively cycle through topographic maps for different
+           channel types by pressing :kbd:`T`.
+
     picks : str | list | slice | None
         Components to include. Slices and lists of integers will be interpreted
         as component indices. ``None`` (default) will use the first five


### PR DESCRIPTION
This is a followup of #10557 and adds the following improvements to the docstrings:

- Mentions newly-introduced keyboard shortcuts
- Adds a `versionadded` tag for the new `log_scale` kwarg

Following some user confusion voiced at https://mne.discourse.group/t/how-to-plot-ica-component-properties-in-log-log-scale

cc @alexrockhill