### PR TITLE
MRG: Fix sign checks in Evoked.get_peak()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -122,7 +122,7 @@ Bugs
 
 - In :func:`mne.preprocessing.find_bad_channels_maxwell`, do not re-filter the data if a low-pass filter with the requested frequency has already been applied (:gh:`10664` by `Richard Höchenberger`_)
 
-- Fix a problem in :meth:`mne.Evoked.get_peak`, where under certain circumstances the ``mode`` parameters ``'pos'`` and ``'neg'`` were not honored when ``tmin`` and/or ``tmax`` were passed as well `(:gh:`10686` by `Richard Höchenberger`_)
+- Fix a problem in :meth:`mne.Evoked.get_peak`, where under certain circumstances the ``mode`` parameters ``'pos'`` and ``'neg'`` were not honored when ``tmin`` and/or ``tmax`` were passed as well (:gh:`10686` by `Richard Höchenberger`_)
 
 - :func:`mne.read_evokeds` now correctly expands ``~`` in the provided path to the user's home directory (:gh:`10685` by `Richard Höchenberger`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -120,7 +120,9 @@ Bugs
 
 - Reduce memory usage when loading an EDF file with ``preload=False`` (:gh:`10638` by `Clemens Brunner`_)
 
-- In :func:`mne.preprocessing.find_bad_channels_maxwell`, do not re-filter the data if a low-pass filter with the requested frequency has already been applied (:gh:`xxx` by `Richard Höchenberger`_)
+- In :func:`mne.preprocessing.find_bad_channels_maxwell`, do not re-filter the data if a low-pass filter with the requested frequency has already been applied (:gh:`10664` by `Richard Höchenberger`_)
+
+- Fix a problem in :meth:`mne.Evoked.get_peak`, where under certain circumstances the ``mode`` parameters ``'pos'`` and ``'neg'`` were not honored when ``tmin`` and/or ``tmax`` were passed as well `(:gh:`10686` by `Richard Höchenberger`_)
 
 API and behavior changes
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -1552,11 +1552,11 @@ def _get_peak(data, times, tmin=None, tmax=None, mode='abs'):
 
     maxfun = np.argmax
     if mode == 'pos':
-        if not np.any(data > 0):
+        if not np.any(data[~mask] > 0):
             raise ValueError('No positive values encountered. Cannot '
                              'operate in pos mode.')
     elif mode == 'neg':
-        if not np.any(data < 0):
+        if not np.any(data[~mask] < 0):
             raise ValueError('No negative values encountered. Cannot '
                              'operate in neg mode.')
         maxfun = np.argmin

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -341,6 +341,7 @@ def test_export_epochs_eeglab(tmp_path, preload):
         epochs.export(Path(temp_fname), overwrite=True)
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 @requires_version('mffpy', '0.5.7')
 @testing.requires_testing_data
 @pytest.mark.parametrize('fmt', ('auto', 'mff'))
@@ -397,6 +398,7 @@ def test_export_evokeds_to_mff(tmp_path, fmt, do_history):
         export_evokeds(export_fname, evoked, overwrite=True)
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 @requires_version('mffpy', '0.5.7')
 @testing.requires_testing_data
 def test_export_to_mff_no_device():
@@ -407,6 +409,7 @@ def test_export_to_mff_no_device():
         export_evokeds('output.mff', evoked)
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 @requires_version('mffpy', '0.5.7')
 def test_export_to_mff_incompatible_sfreq():
     """Test non-whole number sampling frequency throws ValueError."""

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -331,6 +331,7 @@ def test_io_egi_crop_no_preload():
     assert_allclose(raw._data, raw_preload._data)
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 @requires_version('mffpy', '0.5.7')
 @requires_testing_data
 @pytest.mark.parametrize('idx, cond, tmax, signals, bads', [
@@ -393,6 +394,7 @@ def test_io_egi_evokeds_mff(idx, cond, tmax, signals, bads):
     assert evoked_cond.info['device_info']['type'] == 'HydroCel GSN 256 1.0'
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 @requires_version('mffpy', '0.5.7')
 @requires_testing_data
 def test_read_evokeds_mff_bad_input():

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -485,13 +485,24 @@ def test_evoked_proj():
 def test_get_peak():
     """Test peak getter."""
     evoked = read_evokeds(fname, condition=0, proj=True)
-    pytest.raises(ValueError, evoked.get_peak, ch_type='mag', tmin=1)
-    pytest.raises(ValueError, evoked.get_peak, ch_type='mag', tmax=0.9)
-    pytest.raises(ValueError, evoked.get_peak, ch_type='mag', tmin=0.02,
-                  tmax=0.01)
-    pytest.raises(ValueError, evoked.get_peak, ch_type='mag', mode='foo')
-    pytest.raises(RuntimeError, evoked.get_peak, ch_type=None, mode='foo')
-    pytest.raises(ValueError, evoked.get_peak, ch_type='misc', mode='foo')
+
+    with pytest.raises(ValueError):
+        evoked.get_peak(ch_type='mag', tmin=1)
+
+    with pytest.raises(ValueError):
+        evoked.get_peak(ch_type='mag', tmax=0.9)
+
+    with pytest.raises(ValueError):
+        evoked.get_peak(ch_type='mag', tmin=0.02, tmax=0.01)
+
+    with pytest.raises(ValueError):
+        evoked.get_peak(ch_type='mag', mode='foo')
+
+    with pytest.raises(RuntimeError):
+        evoked.get_peak(ch_type=None, mode='foo')
+
+    with pytest.raises(ValueError):
+        evoked.get_peak(ch_type='misc', mode='foo')
 
     ch_name, time_idx = evoked.get_peak(ch_type='mag')
     assert (ch_name in evoked.ch_names)
@@ -504,8 +515,9 @@ def test_get_peak():
     assert_equal(ch_name, 'MEG 1421')
     assert_allclose(max_amp, 7.17057e-13, rtol=1e-5)
 
-    pytest.raises(ValueError, evoked.get_peak, ch_type='mag',
-                  merge_grads=True)
+    with pytest.raises(ValueError):
+        evoked.get_peak(ch_type='mag', merge_grads=True)
+
     ch_name, time_idx = evoked.get_peak(ch_type='grad', merge_grads=True)
     assert_equal(ch_name, 'MEG 244X')
 
@@ -529,8 +541,11 @@ def test_get_peak():
     assert_equal(time_idx, 2)
     assert_allclose(max_amp, 2.)
 
-    pytest.raises(ValueError, _get_peak, data + 1e3, times, mode='neg')
-    pytest.raises(ValueError, _get_peak, data - 1e3, times, mode='pos')
+    with pytest.raises(ValueError):
+        _get_peak(data + 1e3, times, mode='neg')
+
+    with pytest.raises(ValueError):
+        _get_peak(data - 1e3, times, mode='pos')
 
 
 def test_drop_channels_mixin():

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -486,22 +486,22 @@ def test_get_peak():
     """Test peak getter."""
     evoked = read_evokeds(fname, condition=0, proj=True)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='tmin.*must be <= tmax'):
         evoked.get_peak(ch_type='mag', tmin=1)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='tmax.*is out of bounds'):
         evoked.get_peak(ch_type='mag', tmax=0.9)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='tmin.*must be <= tmax'):
         evoked.get_peak(ch_type='mag', tmin=0.02, tmax=0.01)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid.*'mode' parameter"):
         evoked.get_peak(ch_type='mag', mode='foo')
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match='Multiple data channel types'):
         evoked.get_peak(ch_type=None, mode='foo')
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Channel type.*not found'):
         evoked.get_peak(ch_type='misc', mode='foo')
 
     ch_name, time_idx = evoked.get_peak(ch_type='mag')
@@ -515,8 +515,11 @@ def test_get_peak():
     assert_equal(ch_name, 'MEG 1421')
     assert_allclose(max_amp, 7.17057e-13, rtol=1e-5)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='must be "grad" for merge_grads'):
         evoked.get_peak(ch_type='mag', merge_grads=True)
+
+    with pytest.raises(ValueError, match='Negative mode.*does not make sense'):
+        evoked.get_peak(ch_type='grad', merge_grads=True, mode='neg')
 
     ch_name, time_idx = evoked.get_peak(ch_type='grad', merge_grads=True)
     assert_equal(ch_name, 'MEG 244X')
@@ -541,10 +544,10 @@ def test_get_peak():
     assert_equal(time_idx, 2)
     assert_allclose(max_amp, 2.)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='No negative values'):
         _get_peak(data + 1e3, times, mode='neg')
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='No positive values'):
         _get_peak(data - 1e3, times, mode='pos')
 
 

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -1150,7 +1150,7 @@ def test_get_peak(kind, vector, n_times):
     with pytest.raises(ValueError, match='out of bounds'):
         stc.get_peak(tmax=90)
     with pytest.raises(ValueError,
-                       match='smaller or equal' if n_times > 1 else 'out of'):
+                       match='must be <=' if n_times > 1 else 'out of'):
         stc.get_peak(tmin=0.002, tmax=0.001)
 
     vert_idx, time_idx = stc.get_peak()


### PR DESCRIPTION
We didn't apply the temporal mask to the data when checking if all values are either positive or negative, and hence these checks didn't always fire when they were supposed to.

This issue was reported on the forum:
https://mne.discourse.group/t/get-peak-mode-pos-also-gives-negative-values/4931
