### PR TITLE
MNT: mffpy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -40,7 +40,7 @@ dependencies:
 - qtpy
 - pyqt!=5.15.3,!=5.15.4
 - mne
-- mffpy>=0.5.7
+- mffpy>=0.5.7,<0.7.3
 - ipywidgets
 - ipyvtklink
 - mne-qt-browser

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ imageio-ffmpeg>=0.4.1
 traitlets
 pyvista>=0.32
 pyvistaqt>=0.4
-mffpy>=0.5.7
+mffpy>=0.5.7,<0.7.3
 ipywidgets
 ipyvtklink
 mne-qt-browser

--- a/server_environment.yml
+++ b/server_environment.yml
@@ -16,7 +16,7 @@ dependencies:
 - nibabel
 - nbformat
 - nbclient
-- mffpy>=0.5.7
+- mffpy>=0.5.7,<0.7.3
 - pooch
 - pip:
   - mne

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -22,7 +22,7 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" https://github.com/pyvista/pyvista-wheels/raw/3b70f3933bc246b035354b172a0459ffc96b0343/vtk-9.1.0.dev0-cp310-cp310-win_amd64.whl
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
-	python -m pip install --progress-bar off imageio-ffmpeg xlrd mffpy python-picard patsy
+	python -m pip install --progress-bar off imageio-ffmpeg xlrd "mffpy<0.7.3" python-picard patsy
 	EXTRA_ARGS="--pre"
 else
 	echo "Unknown run type ${TEST_MODE}"

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -35,7 +35,7 @@ else
 	echo "pyvistaqt"
 	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
 	echo "imageio-ffmpeg, xlrd, mffpy, python-picard"
-	pip install --progress-bar off --pre imageio-ffmpeg xlrd mffpy python-picard patsy
+	pip install --progress-bar off --pre imageio-ffmpeg xlrd "mffpy<0.7.3" python-picard patsy
 	if [ "$OSTYPE" == "darwin"* ]; then
 	  echo "pyobjc-framework-Cocoa"
 	  pip install --progress-bar off pyobjc-framework-Cocoa>=5.2.0


### PR DESCRIPTION
I think there is an issue with the new release of `mffpy 0.7.3`:

```
=================================== FAILURES ===================================
____________________ test_export_evokeds_to_mff[True-auto] _____________________
/usr/share/miniconda/envs/mne/lib/python3.10/site-packages/mffpy/cached_property.py:34: in _cached_property
    return getattr(self, cached_name)
E   AttributeError: 'Categories' object has no attribute '_cached_categories'

During handling of the above exception, another exception occurred:
mne/export/tests/test_export.py:350: in test_export_evokeds_to_mff
    evoked = read_evokeds_mff(egi_evoked_fname)
<decorator-gen-239>:12: in read_evokeds_mff
    ???
mne/io/egi/egimff.py:811: in read_evokeds_mff
    categories = mff.categories.categories
/usr/share/miniconda/envs/mne/lib/python3.10/site-packages/mffpy/cached_property.py:36: in _cached_property
    ans = fn(self)
/usr/share/miniconda/envs/mne/lib/python3.10/site-packages/mffpy/xml_files.py:920: in categories
    return dict(self._parse_cat(cat) for cat in self.findall('cat'))
/usr/share/miniconda/envs/mne/lib/python3.10/site-packages/mffpy/xml_files.py:920: in <genexpr>
    return dict(self._parse_cat(cat) for cat in self.findall('cat'))
/usr/share/miniconda/envs/mne/lib/python3.10/site-packages/mffpy/xml_files.py:938: in _parse_cat
    name = self.find('name', cat_el).text
/usr/share/miniconda/envs/mne/lib/python3.10/site-packages/mffpy/xml_files.py:133: in find
    root = root or self.root
src/lxml/etree.pyx:1190: in lxml.etree._Element.__nonzero__
    ???
E   FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
```

Without knowing exactly how to fix the issue, this PR suggests to pin the package.