### PR TITLE
Retain baseline after combining channels

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -130,6 +130,8 @@ Bugs
 
 - :func:`mne.read_evokeds`, :func:`mne.channels.read_custom_montage`, :func:`mne.channels.read_dig_hpts`, :func:`mne.channels.read_dig_polhemus_isotrak`, and :func:`mne.channels.read_polhemus_fastscan` now correctly expand ``~`` in the provided path to the user's home directory (:gh:`10685`, :gh:`10688` by `Richard Höchenberger`_)
 
+- Combining channels of :class:`mne.Epochs` or :class:`mne.Evoked` objects now properly retains baseline information (:gh:`10703` by `Clemens Brunner`_)
+
 API and behavior changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - When creating BEM surfaces via :func:`mne.bem.make_watershed_bem` and :func:`mne.bem.make_flash_bem`, the ``copy`` parameter now defaults to ``True``. This means that instead of creating symbolic links inside the FreeSurfer subject's ``bem`` folder, we now create "actual" files. This should avoid troubles when sharing files across different operating systems and file systems (:gh:`10531` by `Richard Höchenberger`_)

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1793,6 +1793,7 @@ def combine_channels(inst, groups, method='mean', keep_stim=False,
     new_data = np.swapaxes(new_data, 0, ch_axis)
     info = create_info(sfreq=inst.info['sfreq'], ch_names=new_ch_names,
                        ch_types=new_ch_types)
+    # create new instances and make sure to copy important attributes
     if isinstance(inst, BaseRaw):
         combined_inst = RawArray(new_data, info, first_samp=inst.first_samp)
     elif isinstance(inst, BaseEpochs):

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1797,11 +1797,12 @@ def combine_channels(inst, groups, method='mean', keep_stim=False,
         combined_inst = RawArray(new_data, info, first_samp=inst.first_samp)
     elif isinstance(inst, BaseEpochs):
         combined_inst = EpochsArray(new_data, info, events=inst.events,
-                                    tmin=inst.times[0])
+                                    tmin=inst.times[0], baseline=inst.baseline)
         if inst.metadata is not None:
             combined_inst.metadata = inst.metadata.copy()
     elif isinstance(inst, Evoked):
-        combined_inst = EvokedArray(new_data, info, tmin=inst.times[0])
+        combined_inst = EvokedArray(new_data, info, tmin=inst.times[0],
+                                    baseline=inst.baseline)
 
     return combined_inst
 

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -456,7 +456,6 @@ def test_equalize_channels():
     assert epochs is epochs2
 
 
-def test_combine_channels():
     """Test channel combination on Raw, Epochs, and Evoked."""
     raw = read_raw_fif(raw_fname, preload=True)
     raw_ch_bad = read_raw_fif(raw_fname, preload=True)
@@ -469,7 +468,9 @@ def test_combine_channels():
     combine_channels(raw, good)
     combined_epochs = combine_channels(epochs, good)
     assert_array_equal(combined_epochs.events, epochs.events)
-    combine_channels(evoked, good)
+    assert epochs.baseline == combined_epochs.baseline
+    combined_evoked = combine_channels(evoked, good)
+    assert evoked.baseline == combined_evoked.baseline
     combine_channels(raw, good, drop_bad=True)
     combine_channels(raw_ch_bad, good, drop_bad=True)
 

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -456,6 +456,7 @@ def test_equalize_channels():
     assert epochs is epochs2
 
 
+def test_combine_channels():
     """Test channel combination on Raw, Epochs, and Evoked."""
     raw = read_raw_fif(raw_fname, preload=True)
     raw_ch_bad = read_raw_fif(raw_fname, preload=True)


### PR DESCRIPTION
As discussed [here](https://mne.discourse.group/t/when-is-baseline-correction-applied/4986), this PR retains baseline information after using `mne.channels.combine_channels()` on `Epochs` or `Evoked`.