### PR TITLE
Plot sensors omit nan channels

### DIFF
--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -763,7 +763,7 @@ def _auto_topomap_coords(info, picks, ignore_overlap, to_sphere, sphere):
         locs3d = np.array([eeg_ch_locs[ch['ch_name']] for ch in chs])
 
     # Sometimes we can get nans
-    locs3d[~np.isfinite(locs3d)] = 0.
+    no_pos_chs = (~np.isfinite(locs3d)).any(axis=1)
 
     # Duplicate points cause all kinds of trouble during visualization
     dist = pdist(locs3d)
@@ -788,6 +788,10 @@ def _auto_topomap_coords(info, picks, ignore_overlap, to_sphere, sphere):
         out += sphere[:2]
     else:
         out = _pol_to_cart(_cart_to_sph(locs3d))
+
+    # retain NaNs after transformations
+    if (no_pos_chs).any():
+        out[no_pos_chs, :] = np.nan
     return out
 
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1106,6 +1106,16 @@ def _plot_sensors(pos, info, picks, colors, bads, ch_names, title, show_names,
 
         pos, outlines = _get_pos_outlines(info, picks, sphere,
                                           to_sphere=to_sphere)
+
+        # avoid matplotlib warnings due to NaN positions - omit these channels
+        no_pos_chs = (~np.isfinite(pos)).any(axis=1)
+        if any(no_pos_chs):
+            good_idx = np.where(~no_pos_chs)[0]
+            pos = pos[good_idx]
+            ch_names = [ch_names[ch_idx] for ch_idx in good_idx]
+            colors = [colors[ch_idx] for ch_idx in good_idx]
+            edgecolors = [edgecolors[ch_idx] for ch_idx in good_idx]
+
         _draw_outlines(ax, outlines)
         pts = ax.scatter(pos[:, 0], pos[:, 1], picker=True, clip_on=False,
                          c=colors, edgecolors=edgecolors, s=pointsize,


### PR DESCRIPTION
Currently sensors without position are shown at `(0, 0)` position when using `mne.viz.plot_sensors` - this can leads to multiple channels being at the same location (look at the middle part below):
![image](https://user-images.githubusercontent.com/8452354/171863251-c9bb9422-fc36-4f9d-a1b7-96a9d489bb0e.png)

but in general it may be confusing to plot channels without know position as if they were at the Cz location.
This is an attempt to fix that - I'll see what I break as a consequence. :)

TODO:
- [ ] fix things that I broke
- [ ] test
- [ ] whats new
- [ ] add warning when channel positions are missing?
