### PR TITLE
Fix coreg tutorial typos

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -818,6 +818,16 @@
   year = {2016}
 }
 
+@article{HouckClaus2020,
+	author = {Houck, Jon M. and Claus, Eric D.},
+	doi = {10.1371/journal.pone.0232100},
+	journal = {PLOS ONE},
+	pages = {e0232100},
+	title = {A comparison of automated and manual co-registration for magnetoencephalography},
+	volume = {15},
+	year = {2020}
+}
+
 @article{Hyvarinen1999,
   author = {Hyvärinen, Aapo},
   doi = {10.1109/72.761722},

--- a/tutorials/forward/25_automated_coreg.py
+++ b/tutorials/forward/25_automated_coreg.py
@@ -7,7 +7,9 @@ Using an automated approach to coregistration
 =============================================
 
 This example shows how to use the coregistration functions to perform an
-automated MEG-MRI coregistration via scripting.
+automated MEG-MRI coregistration via scripting. Generally the results of
+this approach are consistent with those obtained from manual
+coregistration :footcite:`HouckClaus2020`
 
 .. warning:: The quality of the coregistration depends heavily upon the
              quality of the head shape points (HSP) collected during subject
@@ -31,7 +33,7 @@ data_path = mne.datasets.sample.data_path()
 subjects_dir = data_path / 'subjects'
 subject = 'sample'
 
-fname_raw = data_path / 'MEG' / subject / f'{subject}_audvis_raw.fif'
+fname_raw = data_path + '/MEG/' + subject + f'/{subject}_audvis_raw.fif'
 info = read_info(fname_raw)
 plot_kwargs = dict(subject=subject, subjects_dir=subjects_dir,
                    surfaces="head-dense", dig=True, eeg=[],
@@ -107,3 +109,8 @@ print(
 #           matched to a subject's head digitization. When scaling is desired,
 #           a scaled surrogate MRI should be created using
 #           :func:`mne.scale_mri`.
+
+# %%
+# References
+# ----------
+# .. footbibliography::

--- a/tutorials/forward/25_automated_coreg.py
+++ b/tutorials/forward/25_automated_coreg.py
@@ -30,7 +30,7 @@ from mne.io import read_info
 
 
 data_path = mne.datasets.sample.data_path()
-subjects_dir = data_path / 'subjects'
+subjects_dir = data_path + '/subjects'
 subject = 'sample'
 
 fname_raw = data_path + '/MEG/' + subject + f'/{subject}_audvis_raw.fif'

--- a/tutorials/forward/25_automated_coreg.py
+++ b/tutorials/forward/25_automated_coreg.py
@@ -28,7 +28,7 @@ import mne
 from mne.coreg import Coregistration
 from mne.io import read_info
 
-data_path = Path(mne.datasets.sample.data_path())
+data_path = mne.datasets.sample.data_path()
 # data_path and all paths built from it are `pathlib.Path`_ objects
 subjects_dir = data_path / 'subjects'
 subject = 'sample'

--- a/tutorials/forward/25_automated_coreg.py
+++ b/tutorials/forward/25_automated_coreg.py
@@ -23,13 +23,13 @@ coregistration :footcite:`HouckClaus2020`.
 # License: BSD-3-Clause
 
 import numpy as np
-from pathlib import Path
 
 import mne
 from mne.coreg import Coregistration
 from mne.io import read_info
 
 data_path = Path(mne.datasets.sample.data_path())
+# data_path and all paths built from it are `pathlib.Path`_ objects
 subjects_dir = data_path / 'subjects'
 subject = 'sample'
 
@@ -109,6 +109,10 @@ print(
 #           matched to a subject's head digitization. When scaling is desired,
 #           a scaled surrogate MRI should be created using
 #           :func:`mne.scale_mri`.
+#
+# .. LINKS
+#
+# .. _`pathlib.Path`: https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module
 
 # %%
 # References

--- a/tutorials/forward/25_automated_coreg.py
+++ b/tutorials/forward/25_automated_coreg.py
@@ -9,7 +9,7 @@ Using an automated approach to coregistration
 This example shows how to use the coregistration functions to perform an
 automated MEG-MRI coregistration via scripting. Generally the results of
 this approach are consistent with those obtained from manual
-coregistration :footcite:`HouckClaus2020`
+coregistration :footcite:`HouckClaus2020`.
 
 .. warning:: The quality of the coregistration depends heavily upon the
              quality of the head shape points (HSP) collected during subject
@@ -23,17 +23,17 @@ coregistration :footcite:`HouckClaus2020`
 # License: BSD-3-Clause
 
 import numpy as np
+from pathlib import Path
 
 import mne
 from mne.coreg import Coregistration
 from mne.io import read_info
 
-
-data_path = mne.datasets.sample.data_path()
-subjects_dir = data_path + '/subjects'
+data_path = Path(mne.datasets.sample.data_path())
+subjects_dir = data_path / 'subjects'
 subject = 'sample'
 
-fname_raw = data_path + '/MEG/' + subject + f'/{subject}_audvis_raw.fif'
+fname_raw = data_path / 'MEG' / subject / f'{subject}_audvis_raw.fif'
 info = read_info(fname_raw)
 plot_kwargs = dict(subject=subject, subjects_dir=subjects_dir,
                    surfaces="head-dense", dig=True, eeg=[],

--- a/tutorials/forward/25_automated_coreg.py
+++ b/tutorials/forward/25_automated_coreg.py
@@ -29,7 +29,7 @@ from mne.coreg import Coregistration
 from mne.io import read_info
 
 data_path = mne.datasets.sample.data_path()
-# data_path and all paths built from it are `pathlib.Path`_ objects
+# data_path and all paths built from it are pathlib.Path objects
 subjects_dir = data_path / 'subjects'
 subject = 'sample'
 
@@ -109,10 +109,6 @@ print(
 #           matched to a subject's head digitization. When scaling is desired,
 #           a scaled surrogate MRI should be created using
 #           :func:`mne.scale_mri`.
-#
-# .. LINKS
-#
-# .. _`pathlib.Path`: https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module
 
 # %%
 # References


### PR DESCRIPTION
#### Reference issue
Minor cleanup, no issue

#### What does this implement/fix?
I noticed a few minor typos (e.g., slashes not quoted) and have addressed. Copy-and-paste into python should now work for this one. Also added a cite for the paper that assessed the reliability of the method.
