### PR TITLE
MAINT: Deal with nibabel deprecation

### DIFF
--- a/mne/surface.py
+++ b/mne/surface.py
@@ -2025,7 +2025,7 @@ def warp_montage_volume(montage, base_image, reg_affine, sdr_morph,
                 image_from[voxel] = i + 1
 
     # apply the mapping
-    image_from = nib.Nifti1Image(image_from, fs_from_img.affine)
+    image_from = nib.spatialimages.SpatialImage(image_from, fs_from_img.affine)
     _warn_missing_chs(montage, image_from, after_warp=False)
 
     template_brain = nib.load(

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -381,7 +381,8 @@ def test_warp_montage_volume():
             montage, CT, reg_affine, sdr_morph, 'sample', thresh=11.)
     with pytest.raises(ValueError, match='subject folder is incorrect'):
         warp_montage_volume(
-            montage, CT, reg_affine, sdr_morph, subject_from='foo')
+            montage, CT, reg_affine, sdr_morph, subject_from='foo',
+            subjects_dir_from=subjects_dir)
     CT_unaligned = nib.Nifti1Image(CT_data, template_brain.affine)
     with pytest.raises(RuntimeError, match='not aligned to Freesurfer'):
         warp_montage_volume(montage, CT_unaligned, reg_affine,


### PR DESCRIPTION
Take care of pip-pre failures like https://github.com/mne-tools/mne-python/runs/6766628211?check_suite_focus=true by using a generic SpatialImage rather than Nifti1Image