### PR TITLE
CI: Add style conditional

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,7 +77,7 @@ stages:
 
 - stage: Test
   condition: and(succeeded(), eq(dependencies.Check.outputs['Skip.result.start_main'], 'true'))
-  dependsOn: Check
+  dependsOn: ['Check', 'Style']
   variables:
     AZURE_CI: 'true'
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,9 @@ stages:
         python -m pip install --progress-bar off --upgrade pip setuptools wheel
         python -m pip install --progress-bar off -r requirements_base.txt -r requirements_hdf5.txt -r requirements_testing.txt
       displayName: Install dependencies
-      condition: always()
+    - bash: |
+        make flake
+      displayName: make flake
     - bash: |
         make pydocstyle
       displayName: make pydocstyle
@@ -62,6 +64,7 @@ stages:
     - bash: |
         make docstring
       displayName: make docstring
+      condition: always()
     - bash: |
         make nesting
       displayName: make nesting
@@ -77,7 +80,7 @@ stages:
 
 - stage: Test
   condition: and(succeeded(), eq(dependencies.Check.outputs['Skip.result.start_main'], 'true'))
-  dependsOn: ['Check', 'Style']
+  dependsOn: ['Style', 'Check']
   variables:
     AZURE_CI: 'true'
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,9 @@ stages:
         make flake
       displayName: make flake
     - bash: |
+        make codespell-error
+      displayName: make codespell
+    - bash: |
         make pydocstyle
       displayName: make pydocstyle
       condition: always()

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -244,7 +244,7 @@ class Annotations(object):
     ``BAD_ACQ_SKIP`` annotation leads to specific reading/writing file
     behaviours. See :meth:`mne.io.read_raw_fif` and
     :meth:`Raw.save() <mne.io.Raw.save>` notes for details.
-    """
+    """  # noqa: E501
 
     def __init__(self, onset, duration, description,
                  orig_time=None, ch_names=None):  # noqa: D102

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -244,7 +244,7 @@ class Annotations(object):
     ``BAD_ACQ_SKIP`` annotation leads to specific reading/writing file
     behaviours. See :meth:`mne.io.read_raw_fif` and
     :meth:`Raw.save() <mne.io.Raw.save>` notes for details.
-    """  # noqa: E501
+    """
 
     def __init__(self, onset, duration, description,
                  orig_time=None, ch_names=None):  # noqa: D102


### PR DESCRIPTION
One easy step from #10704: make Azure steps depend on the style step succeeding. This first commit adds a style error, so hopefully what we see is red CI with only Azure running the style tests, not everything. Then I'll push a commit to remove the style error, then hopefully we see all green Azure.