### PR TITLE
fix recent docdict mistakes

### DIFF
--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2245,14 +2245,14 @@ pick_ori : None | "normal"
 _picks_types = 'str | list | slice | None'
 _picks_header = f'picks : {_picks_types}'
 _picks_desc = 'Channels to include.'
-_picks_int = ('Channels to include. Slices and lists of integers will be '
-              'interpreted as channel indices.')
+_picks_int = ('Slices and lists of integers will be interpreted as channel '
+              'indices.')
 _picks_str = """In lists, channel *type* strings
     (e.g., ``['meg', 'eeg']``) will pick channels of those
     types, channel *name* strings (e.g., ``['MEG0111', 'MEG2623']``
     will pick the given channels. Can also be the string values
     "all" to pick all channels, or "data" to pick :term:`data channels`.
-    None (default) will pick')"""
+    None (default) will pick"""
 _reminder = ("Note that channels in ``info['bads']`` *will be included* if "
              "their {}indices are explicitly provided.")
 reminder = _reminder.format('names or ')
@@ -2260,14 +2260,18 @@ reminder_nostr = _reminder.format('')
 noref = f'(excluding reference MEG channels). {reminder}'
 picks_base = f"""{_picks_header}
     {_picks_desc} {_picks_int} {_picks_str}"""
-docdict['picks_all'] = f'{picks_base} all channels. {reminder}'
-docdict['picks_all_data'] = f'{picks_base} all data channels. {reminder}'
-docdict['picks_all_data_noref'] = f'{picks_base} all data channels {noref}'
-docdict['picks_base'] = picks_base      # couple places (e.g., BaseEpochs)
-docdict['picks_good_data'] = f'{picks_base} good data channels. {reminder}'
+docdict['picks_all'] = _reflow_param_docstring(
+    f'{picks_base} all channels. {reminder}')
+docdict['picks_all_data'] = _reflow_param_docstring(
+    f'{picks_base} all data channels. {reminder}')
+docdict['picks_all_data_noref'] = _reflow_param_docstring(
+    f'{picks_base} all data channels {noref}')
+docdict['picks_base'] = _reflow_param_docstring(picks_base)
+docdict['picks_good_data'] = _reflow_param_docstring(
+    f'{picks_base} good data channels. {reminder}')
 docdict['picks_good_data_noref'] = _reflow_param_docstring(
     f'{picks_base} good data channels {noref}')
-docdict['picks_header'] = _picks_header  # these get reused as stubs in a
+docdict['picks_header'] = _picks_header
 docdict['picks_ica'] = """
 picks : int | list of int | slice | None
     Indices of the ICA components to visualize.


### PR DESCRIPTION
#10722 introduced a few mistakes into the docdict. This fixes them, and also uses the `_reflow_param_docstring()` function to make them look nice in the terminal (see example below).

on main:

```py
In [1]: import mne
In [2]: mne.io.Raw.pick?
Signature: mne.io.Raw.pick(self, picks, exclude=(), *, verbose=None)
Docstring:
Pick a subset of channels.

Parameters
----------
picks : str | list | slice | None
    Channels to include. Channels to include. Slices and lists of integers will be interpreted as channel indices. In lists, channel *type* strings
    (e.g., ``['meg', 'eeg']``) will pick channels of those
    types, channel *name* strings (e.g., ``['MEG0111', 'MEG2623']``
    will pick the given channels. Can also be the string values
    "all" to pick all channels, or "data" to pick :term:`data channels`.
    None (default) will pick') all channels. Note that channels in ``info['bads']`` *will be included* if their names or indices are explicitly provided.

[... rest of docstring omitted]
```


on this branch:

```py
In [1]: import mne
In [2]: mne.io.Raw.pick?
Signature: mne.io.Raw.pick(self, picks, exclude=(), *, verbose=None)
Docstring:
Pick a subset of channels.

Parameters
----------
picks : str | list | slice | None
    Channels to include. Slices and lists of integers will be interpreted as 
    channel indices. In lists, channel *type* strings (e.g., ``['meg', 
    'eeg']``) will pick channels of those types, channel *name* strings (e.g., 
    ``['MEG0111', 'MEG2623']`` will pick the given channels. Can also be the 
    string values "all" to pick all channels, or "data" to pick :term:`data 
    channels`. None (default) will pick all channels. Note that channels in 
    ``info['bads']`` *will be included* if their names or indices are 
    explicitly provided.

[... rest of docstring omitted]
```
