### PR TITLE
MRG: In Report, remove black border appearing on figures created from NumPy arrays

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -144,6 +144,7 @@ Bugs
 
 - Combining channels of :class:`mne.Epochs` or :class:`mne.Evoked` objects now properly retains baseline information (:gh:`10703` by `Clemens Brunner`_)
 
+- In :class:`mne.Report`, some figures would have an undesired border added to the edges; this has now been resolved (:gh:`10730` by `Richard Höchenberger`_)
 
 API and behavior changes
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -2331,8 +2331,8 @@ def _figure_agg(**kwargs):
 def _ndarray_to_fig(img, dpi=100):
     """Convert to MPL figure, adapted from matplotlib.image.imsave."""
     figsize = np.array(img.shape[:2][::-1]) / dpi
-    fig = _figure_agg(dpi=dpi, figsize=figsize, frameon=False)
-    ax = fig.add_axes([0, 0, 1, 1])
+    fig = _figure_agg(dpi=dpi, figsize=figsize)
+    ax = fig.add_axes([0, 0, 1, 1], frame_on=False)
     ax.imshow(img)
     return fig
 

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -459,10 +459,10 @@ plt.close(fig_1)
 plt.close(fig_2)
 
 # %%
-# The :meth:`mne.Report.add_figure` method can add multiple figures at once. In
-# this case, a slider will appear, allowing users to intuitively browse the
-# figures. To make this work, you need to provide a collection of figures,
-# a title, and optionally a collection of captions.
+# The :meth:`mne.Report.add_figure` method can also add multiple figures at
+# once. In this case, a slider will appear, allowing users to intuitively
+# browse the figures. To make this work, you need to provide a collection o
+# figures, a title, and optionally a collection of captions.
 #
 # In the following example, we will read the MNE logo as a Matplotlib figure
 # and rotate it with different angles. Each rotated figure and its respective


### PR DESCRIPTION
`main`:
<img width="660" alt="Screen Shot 2022-06-10 at 12 18 59" src="https://user-images.githubusercontent.com/2046265/173045548-f10c09ba-c1f7-40d8-b5ca-8184c8f6498a.png">

PR:
<img width="660" alt="Screen Shot 2022-06-10 at 12 19 13" src="https://user-images.githubusercontent.com/2046265/173045575-f00d8849-52b2-488b-9886-c2e4ee34126e.png">

MWE:
```python
# %%
from pathlib import Path
import mne


sample_dir = Path(mne.datasets.sample.data_path())
sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'

raw = mne.io.read_raw_fif(sample_fname)
raw.crop(tmax=60)

events = mne.find_events(raw, stim_channel='STI 014')
event_id = {'auditory/left': 1, 'auditory/right': 2, 'visual/left': 3,
            'visual/right': 4, 'face': 5, 'buttonpress': 32}

epochs = mne.Epochs(raw, events=events, event_id=event_id,
                    tmin=-0.2, tmax=0.5, baseline=(None, 0),
                    preload=True)
evoked = epochs.average()
evoked.pick_types(eeg=True)

r = mne.Report(title='Test Report')
r.add_evokeds(
    evokeds=evoked,
    titles='Evoked Responses',
    projs=False,
    n_time_points=1,
)
r.save('/tmp/test.html', overwrite=True)
```