### PR TITLE
MRG: Add "descriptions=False" kwarg to get_builtin_montages, and use get_builtin_montages in sensor location tutorial

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -93,6 +93,8 @@ Enhancements
 
 - All functions and methods that plot topographic maps for EEG (2D projections of the EEG sensor locations) now accept the parameter value ``sphere='eeglab'`` to lay out the sensors with respect to the head circle in a similar way to how EEGLAB does, i.e., T7/T8 and Fpz/Oz are placed directly on the circle for template montages (:gh:`10572` by `Richard Höchenberger`_)
 
+- :func:`mne.channels.get_builtin_montages` gaines a new parameter, ``descriptions``, which allows to retrieve the descriptions of the montages in addition to their names (:gh:`10373` by `Richard Höchenberger`_)
+
 Bugs
 ~~~~
 

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -177,7 +177,7 @@ def _check_get_coord_frame(dig):
 
 
 def get_builtin_montages(*, descriptions=False):
-    """"Get a list of all standard montages shipping with MNE-Python.
+    """Get a list of all standard montages shipping with MNE-Python.
 
     The names of the montages can be passed to :func:`make_standard_montage`.
 

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -176,7 +176,7 @@ def _check_get_coord_frame(dig):
     return _frame_to_str[dig_coord_frames.pop()] if dig_coord_frames else None
 
 
-def get_builtin_montages(descriptions=False):
+def get_builtin_montages(*, descriptions=False):
     """"Get a list of all standard montages shipping with MNE-Python.
 
     The names of the montages can be passed to :func:`make_standard_montage`.

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -12,6 +12,7 @@
 # License: Simplified BSD
 
 from collections import OrderedDict
+from dataclasses import dataclass
 from copy import deepcopy
 import os.path as op
 import re
@@ -41,18 +42,128 @@ from ..utils import (warn, copy_function_doc_to_method_doc, _pl, verbose,
 from ._dig_montage_utils import _read_dig_montage_egi
 from ._dig_montage_utils import _parse_brainvision_dig_montage
 
-_BUILT_IN_MONTAGES = [
-    'EGI_256',
-    'GSN-HydroCel-128', 'GSN-HydroCel-129', 'GSN-HydroCel-256',
-    'GSN-HydroCel-257', 'GSN-HydroCel-32', 'GSN-HydroCel-64_1.0',
-    'GSN-HydroCel-65_1.0',
-    'biosemi128', 'biosemi16', 'biosemi160', 'biosemi256',
-    'biosemi32', 'biosemi64',
-    'easycap-M1', 'easycap-M10',
-    'mgh60', 'mgh70',
-    'standard_1005', 'standard_1020', 'standard_alphabetic',
-    'standard_postfixed', 'standard_prefixed', 'standard_primed',
-    'artinis-octamon', 'artinis-brite23'
+
+@dataclass
+class _BuiltinStandardMontage:
+    name: str
+    description: str
+
+
+_BUILTIN_STANDARD_MONTAGES = [
+    _BuiltinStandardMontage(
+        name='standard_1005',
+        description='Electrodes are named and positioned according to the '
+                    'international 10-05 system (343+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='standard_1020',
+        description='Electrodes are named and positioned according to the '
+                    'international 10-20 system (94+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='standard_alphabetic',
+        description='Electrodes are named with LETTER-NUMBER combinations '
+                    '(A1, B2, F4, …) (65+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='standard_postfixed',
+        description='Electrodes are named according to the international '
+                    '10-20 system using postfixes for intermediate positions '
+                    '(100+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='standard_prefixed',
+        description='Electrodes are named according to the international '
+                    '10-20 system using prefixes for intermediate positions '
+                    '(74+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='standard_primed',
+        description="Electrodes are named according to the international "
+                    "10-20 system using prime marks (' and '') for "
+                    "intermediate positions (100+3 locations)",
+    ),
+    _BuiltinStandardMontage(
+        name='biosemi16',
+        description='BioSemi cap with 16 electrodes (16+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='biosemi32',
+        description='BioSemi cap with 32 electrodes (32+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='biosemi64',
+        description='BioSemi cap with 64 electrodes (64+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='biosemi128',
+        description='BioSemi cap with 128 electrodes (128+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='biosemi160',
+        description='BioSemi cap with 160 electrodes (160+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='biosemi256',
+        description='BioSemi cap with 256 electrodes (256+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='easycap-M1',
+        description='EasyCap with 10-05 electrode names (74 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='easycap-M10',
+        description='EasyCap with numbered electrodes (61 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='EGI_256',
+        description='Geodesic Sensor Net (256 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='GSN-HydroCel-32',
+        description='HydroCel Geodesic Sensor Net and Cz (33+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='GSN-HydroCel-64_1.0',
+        description='HydroCel Geodesic Sensor Net (64+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='GSN-HydroCel-65_1.0',
+        description='HydroCel Geodesic Sensor Net and Cz (65+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='GSN-HydroCel-128',
+        description='HydroCel Geodesic Sensor Net (128+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='GSN-HydroCel-129',
+        description='HydroCel Geodesic Sensor Net and Cz (129+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='GSN-HydroCel-256',
+        description='HydroCel Geodesic Sensor Net (256+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='GSN-HydroCel-257',
+        description='HydroCel Geodesic Sensor Net and Cz (257+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='mgh60',
+        description='The (older) 60-channel cap used at MGH (60+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='mgh70',
+        description='The (newer) 70-channel BrainVision cap used at MGH '
+                    '(70+3 locations)',
+    ),
+    _BuiltinStandardMontage(
+        name='artinis-octamon',
+        description='Artinis OctaMon fNIRS (8 sources, 2 detectors)',
+    ),
+    _BuiltinStandardMontage(
+        name='artinis-brite23',
+        description='Artinis Brite23 fNIRS (11 sources, 7 detectors)',
+    )
 ]
 
 
@@ -65,16 +176,35 @@ def _check_get_coord_frame(dig):
     return _frame_to_str[dig_coord_frames.pop()] if dig_coord_frames else None
 
 
-def get_builtin_montages():
-    """Get a list of all builtin montages.
+def get_builtin_montages(descriptions=False):
+    """"Get a list of all standard montages shipping with MNE-Python.
+
+    The names of the montages can be passed to :func:`make_standard_montage`.
+
+    Parameters
+    ----------
+    descriptions : bool
+        Whether to return not only the montage names, but also their
+        corresponding descriptions. If ``True``, a list of tuples is returned,
+        where the first tuple element is the montage name and the second is
+        the montage description.
+
+        .. versionadded:: 1.1
 
     Returns
     -------
-    montages : list
-        Names of all builtin montages that can be used by
-        :func:`make_standard_montage`.
+    montages : list of str | list of tuple
+        If ``descriptions=False``, the names of all builtin montages that can
+        be used by :func:`make_standard_montage`.
+
+        If ``descriptions=True``, a list of tuples ``(name, description)``.
     """
-    return _BUILT_IN_MONTAGES
+    if descriptions:
+        return [
+            (m.name, m.description) for m in _BUILTIN_STANDARD_MONTAGES
+        ]
+    else:
+        return [m.name for m in _BUILTIN_STANDARD_MONTAGES]
 
 
 def make_dig_montage(ch_pos=None, nasion=None, lpa=None, rpa=None,
@@ -924,7 +1054,10 @@ def _set_montage(info, montage, match_case=True, match_alias=False,
             ch['loc'] = np.full(12, np.nan)
         return
     if isinstance(montage, str):  # load builtin montage
-        _check_option('montage', montage, _BUILT_IN_MONTAGES)
+        _check_option(
+            parameter='montage', value=montage,
+            allowed_values=[m.name for m in _BUILTIN_STANDARD_MONTAGES]
+        )
         montage = make_standard_montage(montage)
 
     mnt_head = _get_montage_in_head(montage)
@@ -1488,12 +1621,16 @@ def compute_native_head_t(montage):
 
 
 def make_standard_montage(kind, head_size='auto'):
-    """Read a generic (built-in) montage.
+    """Read a generic (built-in) standard montage that ships with MNE-Python.
 
     Parameters
     ----------
     kind : str
-        The name of the montage to use. See notes for valid kinds.
+        The name of the montage to use.
+
+        .. note::
+            You can retrieve the names of all
+            built-in montages via :func:`mne.channels.get_builtin_montages`.
     head_size : float | None | str
         The head size (radius, in meters) to use for spherical montages.
         Can be None to not scale the read sizes. ``'auto'`` (default) will
@@ -1519,62 +1656,14 @@ def make_standard_montage(kind, head_size='auto'):
     :func:`read_dig_fif`, :func:`read_dig_polhemus_isotrak`,
     :func:`read_dig_hpts` or made with :func:`make_dig_montage`.
 
-    Valid ``kind`` arguments are:
-
-    ===================   =====================================================
-    Kind                  Description
-    ===================   =====================================================
-    standard_1005         Electrodes are named and positioned according to the
-                          international 10-05 system (343+3 locations)
-    standard_1020         Electrodes are named and positioned according to the
-                          international 10-20 system (94+3 locations)
-    standard_alphabetic   Electrodes are named with LETTER-NUMBER combinations
-                          (A1, B2, F4, ...) (65+3 locations)
-    standard_postfixed    Electrodes are named according to the international
-                          10-20 system using postfixes for intermediate
-                          positions (100+3 locations)
-    standard_prefixed     Electrodes are named according to the international
-                          10-20 system using prefixes for intermediate
-                          positions (74+3 locations)
-    standard_primed       Electrodes are named according to the international
-                          10-20 system using prime marks (' and '') for
-                          intermediate positions (100+3 locations)
-
-    biosemi16             BioSemi cap with 16 electrodes (16+3 locations)
-    biosemi32             BioSemi cap with 32 electrodes (32+3 locations)
-    biosemi64             BioSemi cap with 64 electrodes (64+3 locations)
-    biosemi128            BioSemi cap with 128 electrodes (128+3 locations)
-    biosemi160            BioSemi cap with 160 electrodes (160+3 locations)
-    biosemi256            BioSemi cap with 256 electrodes (256+3 locations)
-
-    easycap-M1            EasyCap with 10-05 electrode names (74 locations)
-    easycap-M10           EasyCap with numbered electrodes (61 locations)
-
-    EGI_256               Geodesic Sensor Net (256 locations)
-
-    GSN-HydroCel-32       HydroCel Geodesic Sensor Net and Cz (33+3 locations)
-    GSN-HydroCel-64_1.0   HydroCel Geodesic Sensor Net (64+3 locations)
-    GSN-HydroCel-65_1.0   HydroCel Geodesic Sensor Net and Cz (65+3 locations)
-    GSN-HydroCel-128      HydroCel Geodesic Sensor Net (128+3 locations)
-    GSN-HydroCel-129      HydroCel Geodesic Sensor Net and Cz (129+3 locations)
-    GSN-HydroCel-256      HydroCel Geodesic Sensor Net (256+3 locations)
-    GSN-HydroCel-257      HydroCel Geodesic Sensor Net and Cz (257+3 locations)
-
-    mgh60                 The (older) 60-channel cap used at
-                          MGH (60+3 locations)
-    mgh70                 The (newer) 70-channel BrainVision cap used at
-                          MGH (70+3 locations)
-
-    artinis-octamon       Artinis OctaMon fNIRS (8 sources, 2 detectors)
-
-    artinis-brite23       Artinis Brite23 fNIRS (11 sources, 7 detectors)
-    ===================   =====================================================
-
     .. versionadded:: 0.19.0
     """
     from ._standard_montage_utils import standard_montage_look_up_table
     _validate_type(kind, str, 'kind')
-    _check_option('kind', kind, _BUILT_IN_MONTAGES)
+    _check_option(
+        parameter='kind', value=kind,
+        allowed_values=[m.name for m in _BUILTIN_STANDARD_MONTAGES]
+    )
     _validate_type(head_size, ('numeric', str, None), 'head_size')
     if isinstance(head_size, str):
         _check_option('head_size', head_size, ('auto',), extra='when str')

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -5,7 +5,7 @@
 
 from contextlib import nullcontext
 from itertools import chain
-import os
+from pathlib import Path
 import os.path as op
 import shutil
 
@@ -29,7 +29,9 @@ from mne.channels import (get_builtin_montages, DigMontage, read_dig_dat,
                           read_dig_polhemus_isotrak, compute_native_head_t,
                           read_polhemus_fastscan, read_dig_localite,
                           read_dig_hpts)
-from mne.channels.montage import transform_to_head, _check_get_coord_frame
+from mne.channels.montage import (
+    transform_to_head, _check_get_coord_frame, _BUILTIN_STANDARD_MONTAGES
+)
 from mne.utils import assert_dig_allclose, _record_warnings
 from mne.bem import _fit_sphere
 from mne.io.constants import FIFF
@@ -148,27 +150,14 @@ def test_fiducials():
 
 def test_documented():
     """Test that standard montages are documented."""
-    docs = make_standard_montage.__doc__
-    lines = [line[4:] for line in docs.splitlines()]
-    start = stop = None
-    for li, line in enumerate(lines):
-        if line.startswith('====') and li < len(lines) - 2 and \
-                lines[li + 1].startswith('Kind') and\
-                lines[li + 2].startswith('===='):
-            start = li + 3
-        elif start is not None and li > start and line.startswith('===='):
-            stop = li
-            break
-    assert (start is not None)
-    assert (stop is not None)
-    kinds = [line.split(' ')[0] for line in lines[start:stop]]
-    kinds = [kind for kind in kinds if kind != '']
-    montages = os.listdir(op.join(op.dirname(_mne_file), 'channels', 'data',
-                                  'montages'))
-    montages = sorted(op.splitext(m)[0] for m in montages)
-    assert_equal(len(set(montages)), len(montages))
-    assert_equal(len(set(kinds)), len(kinds), err_msg=str(sorted(kinds)))
-    assert_equal(set(montages), set(kinds))
+    montage_dir = Path(_mne_file).parent / 'channels' / 'data' / 'montages'
+    montage_files = Path(montage_dir).glob('*')
+    montage_names = [f.stem for f in montage_files]
+
+    assert len(montage_names) == len(_BUILTIN_STANDARD_MONTAGES)
+    assert set(montage_names) ==  set(
+        [m.name for m in _BUILTIN_STANDARD_MONTAGES]
+    )
 
 
 @pytest.mark.parametrize('reader, file_content, expected_dig, ext, warning', [

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1561,8 +1561,15 @@ def test_read_dig_hpts():
 
 def test_get_builtin_montages():
     """Test help function to obtain builtin montages."""
-    EXPECTED_NUM = 26
-    assert len(get_builtin_montages()) == EXPECTED_NUM
+    EXPECTED_COUNT = 26
+
+    montages = get_builtin_montages()
+    assert len(montages) == EXPECTED_COUNT
+
+    montages_with_descriptions = get_builtin_montages(descriptions=True)
+    assert len(montages_with_descriptions) == EXPECTED_COUNT
+    for montage_with_description in montages_with_descriptions:
+        assert len(montage_with_description) == 2
 
 
 @testing.requires_testing_data

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -155,7 +155,7 @@ def test_documented():
     montage_names = [f.stem for f in montage_files]
 
     assert len(montage_names) == len(_BUILTIN_STANDARD_MONTAGES)
-    assert set(montage_names) ==  set(
+    assert set(montage_names) == set(
         [m.name for m in _BUILTIN_STANDARD_MONTAGES]
     )
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1856,9 +1856,9 @@ docdict['montage'] = """
 montage : None | str | DigMontage
     A montage containing channel positions. If a string or
     :class:`~mne.channels.DigMontage` is
-    specified, the existing channel information will be updated with the channel
-    positions in from montage. Valid strings are the names of the built-in
-    montages that ship with MNE-Python; you can list those via
+    specified, the existing channel information will be updated with the
+    channel positions in from montage. Valid strings are the names of the
+    built-in montages that ship with MNE-Python; you can list those via
     :func:`mne.channels.get_builtin_montages`.
     You may also want to consult the documentation of
     :class:`mne.channels.DigMontage` for additional information.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1857,7 +1857,7 @@ montage : None | str | DigMontage
     A montage containing channel positions. If a string or
     :class:`~mne.channels.DigMontage` is
     specified, the existing channel information will be updated with the
-    channel positions in from montage. Valid strings are the names of the
+    channel positions from the montage. Valid strings are the names of the
     built-in montages that ship with MNE-Python; you can list those via
     :func:`mne.channels.get_builtin_montages`.
     You may also want to consult the documentation of

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1854,11 +1854,16 @@ mode : None | 'mean' | 'max' | 'svd'
 
 docdict['montage'] = """
 montage : None | str | DigMontage
-    A montage containing channel positions. If str or DigMontage is
-    specified, the channel info will be updated with the channel
-    positions. Default is None. For valid :class:`str` values see documentation
-    of :func:`mne.channels.make_standard_montage`. See also the documentation
-    of :class:`mne.channels.DigMontage` for more information.
+    A montage containing channel positions. If a string or
+    :class:`~mne.channels.DigMontage` is
+    specified, the existing channel information will be updated with the channel
+    positions in from montage. Valid strings are the names of the built-in
+    montages that ship with MNE-Python; you can list those via
+    :func:`mne.channels.get_builtin_montages`.
+    You may also want to consult the documentation of
+    :class:`mne.channels.DigMontage` for additional information.
+    If ``None`` (default), the channel positions will be removed from the
+    :class:`~mne.Info`.
 """
 
 docdict['montage_types'] = """EEG/sEEG/ECoG/DBS/fNIRS"""

--- a/tutorials/intro/40_sensor_locations.py
+++ b/tutorials/intro/40_sensor_locations.py
@@ -58,17 +58,12 @@ import mne
 # `~mne.io.Raw` object upon loading. EEG electrode locations are much more
 # variable because of differences in head shape. Idealized montages
 # (":term:`template montages <template montage>`") for many EEG systems are
-# included in MNE-Python; these files are stored in your ``mne-python``
-# directory in the :file:`mne/channels/data/montages` folder:
+# included in MNE-Python, and you can get an overview of them by using
+# :func:`mne.channels.get_builtin_montages`:
 
-montage_dir = Path(mne.__file__).parent / 'channels' / 'data' / 'montages'
-montages = sorted(path.name for path in montage_dir.iterdir())
-print(
-    '\n'
-    'BUILT-IN MONTAGES\n'
-    '================='
-)
-print('\n'.join(montages))
+builtin_montages = mne.channels.get_builtin_montages(descriptions=True)
+for montage_name, montage_description in builtin_montages:
+    print(f'🧠 {montage_name}: {montage_description}')
 
 # %%
 # These built-in EEG montages can be loaded with


### PR DESCRIPTION
The motivation was to make it easier for users to programmtically find out which standard montages are available.

WIP:

- [x] tests
- [x] changelog
