### PR TITLE
Automatically selects EEG channels when plotting bridged electrodes on topomap

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -150,6 +150,8 @@ Bugs
 
 - In :class:`mne.Report`, some figures would have an undesired border added to the edges; this has now been resolved (:gh:`10730` by `Richard Höchenberger`_)
 
+- Automatically selects EEG channels when plotting bridged electrodes with :func:`mne.viz.plot_bridged_electrodes` (:gh:`` by `Mathieu Scheltienne`_)
+
 API and behavior changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - When creating BEM surfaces via :func:`mne.bem.make_watershed_bem` and :func:`mne.bem.make_flash_bem`, the ``copy`` parameter now defaults to ``True``. This means that instead of creating symbolic links inside the FreeSurfer subject's ``bem`` folder, we now create "actual" files. This should avoid troubles when sharing files across different operating systems and file systems (:gh:`10531` by `Richard Höchenberger`_)

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -22,11 +22,12 @@ from mne import (read_evokeds, read_proj, make_fixed_length_events, Epochs,
 from mne.io.proj import make_eeg_average_ref_proj, Projection
 from mne.io import read_raw_fif, read_info, RawArray
 from mne.io.constants import FIFF
-from mne.io.pick import pick_info, channel_indices_by_type
+from mne.io.pick import pick_info, channel_indices_by_type, _picks_to_idx
 from mne.io.compensator import get_current_comp
 from mne.channels import (read_layout, make_dig_montage, make_standard_montage,
                           find_ch_adjacency)
 from mne.datasets import testing
+from mne.preprocessing import compute_bridged_electrodes
 from mne.time_frequency.tfr import AverageTFR
 
 from mne.viz import plot_evoked_topomap, plot_projs_topomap, topomap
@@ -729,6 +730,13 @@ def test_plot_bridged_electrodes():
 
     with pytest.raises(RuntimeError, match='Expected'):
         plot_bridged_electrodes(info, bridged_idx, np.zeros((5, 6, 7)))
+
+    # test with multiple channel types
+    raw = read_raw_fif(raw_fname, preload=True)
+    picks = _picks_to_idx(raw.info, "eeg")
+    raw._data[picks[0]] = raw._data[picks[1]]  # artificially bridge electrodes
+    bridged_idx, ed_matrix = compute_bridged_electrodes(raw)
+    plot_bridged_electrodes(raw.info, bridged_idx, ed_matrix)
 
 
 def test_plot_ch_adjacency():

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2726,9 +2726,10 @@ def plot_bridged_electrodes(info, bridged_idx, ed_matrix, title=None,
     %(info_not_none)s
     bridged_idx : list of tuple
         The indices of channels marked as bridged with each bridged
-        pair stored as a tuple.
+        pair stored as a tuple. See notes for additional information.
     ed_matrix : ndarray of float, shape (n_channels, n_channels)
         The electrical distance matrix for each pair of EEG electrodes.
+        See notes for additional information.
     title : str
         A title to add to the plot.
     topomap_args : dict | None
@@ -2738,6 +2739,11 @@ def plot_bridged_electrodes(info, bridged_idx, ed_matrix, title=None,
     -------
     fig : instance of matplotlib.figure.Figure
         The topoplot figure handle.
+
+    Notes
+    -----
+    See also :func:`mne.preprocessing.compute_bridged_electrodes` to determine
+    ``bridged_idx`` and ``ed_matrix``.
     """
     import matplotlib.pyplot as plt
     if topomap_args is None:


### PR DESCRIPTION
I was testing a bit with the new bridged electrode detection feature introduced in #10571 and I ran into a couple of issues with the plot on topographic maps.

As for `compute_bridged_electrodes`, `plot_bridged_electrodes` should automatically selects the EEG channels. There was an attempt here: https://github.com/mne-tools/mne-python/blob/5944b870f3d2d1803c0563e73792855f004d8932/mne/viz/topomap.py#L2762 but it was not enough to prevent the function from raising a ValueError due to multiple channel types in the `info` when creating the topographic map.

Snippet that raises on main:

```
from mne.datasets import sample
from mne.io import read_raw_fif
from mne.io.pick import _picks_to_idx
from mne.preprocessing import compute_bridged_electrodes
from mne.viz import plot_bridged_electrodes


directory = sample.data_path() / "MEG" / "sample"
fname = directory / "sample_audvis_raw.fif"
raw = read_raw_fif(fname, preload=True)

# artificially bridge electrodes
picks = _picks_to_idx(raw.info, "eeg")
raw._data[picks[0]] = raw._data[picks[1]]

# determine and plot bridged electrodes
bridged_idx, ed_matrix = compute_bridged_electrodes(raw)  # copy and pick EEG
plot_bridged_electrodes(raw.info, bridged_idx, ed_matrix,
                        title='Bridged Electrodes', topomap_args=dict(vmax=5))
```