### PR TITLE
WIP: Enable line profiling during pytest

### DIFF
--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -102,6 +102,10 @@ def verbose(function: _FuncT) -> _FuncT:
     except TypeError:  # nothing to add
         pass
 
+    try:
+        use_function = profile(function)
+    except Exception:
+        use_function = function
     # Anything using verbose should have `verbose=None` in the signature.
     # This code path will raise an error if this is not the case.
     body = """\
@@ -117,7 +121,7 @@ def %(name)s(%(signature)s):\n
     else:
         return _function_(%(shortsignature)s)"""
     evaldict = dict(
-        _use_log_level_=use_log_level, _function_=function)
+        _use_log_level_=use_log_level, _function_=use_function)
     fm = FunctionMaker(function, None, None, None, None, function.__module__)
     attrs = dict(__wrapped__=function, __qualname__=function.__qualname__,
                  __globals__=function.__globals__)

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -103,7 +103,7 @@ def verbose(function: _FuncT) -> _FuncT:
         pass
 
     try:
-        use_function = profile(function)
+        use_function = profile(function)  # noqa: F821
     except Exception:
         use_function = function
     # Anything using verbose should have `verbose=None` in the signature.

--- a/tools/pytest_profile.py
+++ b/tools/pytest_profile.py
@@ -1,0 +1,105 @@
+# Adapted from line-profiler (BSD)
+
+import builtins
+import inspect
+import linecache
+import os
+import sys
+import line_profiler
+
+import numpy as np
+from pytest import console_main
+
+
+def main():
+    prof = line_profiler.LineProfiler()
+    builtins.__dict__['profile'] = prof
+
+    # Make sure the script's directory is on sys.path instead of just
+    # kernprof.py's.
+    retval = 1
+    try:
+        try:
+            sys.argv[:] = ['pytest'] + sys.argv[1:]
+            retval = console_main()
+        except KeyboardInterrupt:
+            pass
+        except SystemExit as exc:
+            retval = exc.code
+    finally:
+        lstats = prof.get_stats()
+        stats = lstats.timings
+        unit = lstats.unit
+        stream = sys.stdout
+        stream.write('Determining timing results...\n')
+        total_times = list()
+        keys = list()
+        min_time = 1. / unit
+        for key, val in stats.items():
+            total_time = sum(t[2] for t in val) if len(val) else 0.
+            if total_time >= min_time:
+                keys.append(key)
+                total_times.append(total_time)
+        if len(keys) == 0:
+            stream.write(f'No functions that tool longer than {min_time} s')
+            return retval
+        order = np.argsort(total_times)[::-1]
+        items = [(ii, total_times[idx]) + keys[idx] + (stats[keys[idx]],)
+                 for ii, idx in enumerate(order)]
+        template = '%6s %9s %12s %8s %8s  %-s'
+        all_time = np.sum(total_times)
+        del total_times
+        scalar = unit / 1e-6
+        for ii, total_time, filename, start_lineno, func_name, timings in \
+                items:
+            d = {}
+            total_time = 0.0
+            linenos = []
+            for lineno, nhits, time in timings:
+                total_time += time
+                linenos.append(lineno)
+
+            stream.write(
+                '*' * 120 +
+                f'\n#{ii + 1}. {func_name}: {total_time * unit:g} s '
+                f'({100 * total_time / all_time:0.2f}%)\n')
+            if os.path.exists(filename):
+                stream.write(f'In {filename} @ {start_lineno}\n')
+                if os.path.exists(filename):
+                    # Clear the cache to ensure that we get up-to-date results.
+                    linecache.clearcache()
+                all_lines = linecache.getlines(filename)
+                sublines = inspect.getblock(all_lines[start_lineno - 1:])
+            else:
+                stream.write('\n')
+                stream.write(f'Could not find file {filename}\n')
+                stream.write('Are you sure you are running this program from the same directory\n')
+                stream.write('that you ran the profiler from?\n')
+                stream.write("Continuing without the function's contents.\n")
+                # Fake empty lines so we can see the timings, if not the code.
+                nlines = max(linenos) - min(min(linenos), start_lineno) + 1
+                sublines = [''] * nlines
+            for lineno, nhits, time in timings:
+                d[lineno] = (nhits,
+                            '%5.1f' % (time * scalar),
+                            '%5.1f' % (float(time) * scalar / nhits),
+                            '%5.1f' % (100 * time / total_time) )
+            linenos = range(start_lineno, start_lineno + len(sublines))
+            empty = ('', '', '', '')
+            header = template % ('Line #', 'Hits', 'Time', 'Per Hit', '% Time',
+                                'Line Contents')
+            stream.write(header)
+            stream.write('\n')
+            for lineno, line in zip(linenos, sublines):
+                nhits, time, per_hit, percent = d.get(lineno, empty)
+                txt = template % (lineno, nhits, time, per_hit, percent,
+                                line.rstrip('\n').rstrip('\r'))
+                if percent and float(percent) > 1:
+                    stream.write(txt)
+                    stream.write('\n')
+            stream.write('\n')
+    return retval
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Todo:

- [ ] Make tests pass when using the script (init_kwargs has problems currently)

Should help with #10704. Use cProfile -- adapting kernprof/line_profiler code -- to:

1. Run `pytest`
2. Print -- in order of most slow -- any `mne` functions that are 1) decorated with `verbose` (which is a lot of them) and 2) take at least 1 sec during the tests
3. For each printed function, print any lines that take >= 1% of the execution time

Locally I get for example  this output, first what we have in `main`:
```
$ python tools/pytest_profile.py -m "not ultraslowtest" mne/tests/
```

<details>
<summary>Output in main (unchanged)</summary>

```
...
=================================================================== slowest 20 test modules ====================================================================
70.83s total   mne/tests/test_rank.py
63.40s total   mne/tests/test_epochs.py
44.12s total   mne/tests/test_chpi.py
36.02s total   mne/tests/test_cov.py
34.45s total   mne/tests/test_coreg.py

...

===================================================================== slowest 20 durations =====================================================================
12.34s call     mne/tests/test_chpi.py::test_calculate_chpi_coil_locs_artemis
9.89s call     mne/tests/test_dipole.py::test_min_distance_fit_dipole
8.99s call     mne/tests/test_chpi.py::test_calculate_chpi_positions_vv
6.70s call     mne/tests/test_chpi.py::test_calculate_chpi_snr
6.55s call     mne/tests/test_morph_map.py::test_make_morph_maps

...

==================================================== 3 failed, 1316 passed, 8 skipped in 425.58s (0:07:05) =====================================================
```

</details>

Followed by the new stuff:
```
Determining timing results...
************************************************************************************************************************
#1. estimate_rank: 51.49 s (8.13%)
In /Users/larsoner/python/mne-python/mne/rank.py @ 20
Line #      Hits         Time  Per Hit   % Time  Line Contents
    55       428   51460041.0 120233.7     99.9      s = linalg.svdvals(data)

************************************************************************************************************************
#2. compute_rank: 27.1928 s (4.29%)
In /Users/larsoner/python/mne-python/mne/rank.py @ 274
Line #      Hits         Time  Per Hit   % Time  Line Contents
   331        36     301137.0   8364.9      1.1              info = pick_info(info, [info['ch_names'].index(name)
   349       640    1813007.0   2832.8      6.7      picks_list = _picks_by_type(info, meg_combined=True, ref_meg=False,
   371       387    1062395.0   2745.2      3.9              proj_op, n_proj, _ = make_projector(info['projs'], ch_names)
   396       100     517988.0   5179.9      1.9                      data = np.dot(proj_op, data)
   397       200   14004223.0  70021.1     51.5                  this_rank = _estimate_rank_meeg_signals(
   398       100    1036220.0  10362.2      3.8                      data, pick_info(simple_info, picks), scalings, tol, False,
   407       181     299240.0   1653.3      1.1                          data = np.dot(np.dot(proj_op, data), proj_op.T)
   409       406    5392994.0  13283.2     19.8                      this_rank, sing = _estimate_rank_meeg_cov(
   410       203    1994200.0   9823.6      7.3                          data, pick_info(simple_info, picks), scalings, tol,

************************************************************************************************************************
#3. __init__: 21.3033 s (3.36%)
In /Users/larsoner/python/mne-python/mne/epochs.py @ 396
Line #      Hits         Time  Per Hit   % Time  Line Contents
   444      1108     234287.0    211.5      1.1                  self.drop_log = tuple(
   493       836    3273015.0   3915.1     15.4          info._check_consistency()
   496       835    7461610.0   8936.1     35.0          self.info = pick_info(info, self.picks)
   568       822    1945175.0   2366.4      9.1          self._reject_setup(reject, flat)
   581      1628    1713347.0   1052.4      8.0          self._projector, self.info = setup_proj(self.info, False,
   586       150    5240456.0  34936.4     24.6              self.load_data()  # this will do the projection
   593       106     363208.0   3426.5      1.7                  self._data[ii] = np.dot(self._projector, epoch)
   598       814     515145.0    632.9      2.4          self._check_consistency()

...

************************************************************************************************************************
#92. compute_vol_morph_mat: 1.03483 s (0.16%)
In /Users/larsoner/python/mne-python/mne/morph.py @ 471
Line #      Hits         Time  Per Hit   % Time  Line Contents
   505         4    1034560.0 258640.0    100.0          self.vol_morph_mat = self._morph_vols(None, 'Vertex')

************************************************************************************************************************
#93. filter: 1.02517 s (0.16%)
In /Users/larsoner/python/mne-python/mne/filter.py @ 1922
Line #      Hits         Time  Per Hit   % Time  Line Contents
  2008       146      88870.0    608.7      8.7          update_info, picks = _filt_check_picks(self.info, picks,
  2023       174     928367.0   5335.4     90.6              filter_data(
```
I think across these three types of profiling output, it might be easier to find slow things to optimize.

I think this could probably be merged as-is and iterated over. The only change to core code is a `try/except` that should add negligible time (I hope).