### PR TITLE
MAINT: Work around GH download failures

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -162,6 +162,8 @@ def pytest_configure(config):
     ignore:.*Matplotlib is currently using agg.*:
     # qdarkstyle
     ignore:.*Setting theme=.*:RuntimeWarning
+    # scikit-learn using this arg
+    ignore:.*The 'sym_pos' keyword is deprecated.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -110,10 +110,14 @@ MNE_DATASETS = dict()
 
 # Testing and misc are at the top as they're updated most often
 MNE_DATASETS['testing'] = dict(
-    archive_name=f'{TESTING_VERSIONED}.tar.gz',  # 'mne-testing-data',
-    hash='md5:30c0b518f3bf5264f04e42b543c3a92a',
-    url=('https://codeload.github.com/mne-tools/mne-testing-data/'
-         f'tar.gz/{RELEASES["testing"]}'),
+    # TODO: Revert this once GH allows us to download again
+    # archive_name=f'{TESTING_VERSIONED}.tar.gz',
+    # hash='md5:30c0b518f3bf5264f04e42b543c3a92a',
+    # url=('https://codeload.github.com/mne-tools/mne-testing-data/'
+    #      f'tar.gz/{RELEASES["testing"]}'),
+    archive_name='mne-testing-data.tar.gz',
+    hash='md5:c805a5fed8ca46f723e7eec828d90824',
+    url='https://osf.io/dqfgy/download?version=1',  # 0.136
     folder_name='MNE-testing-data',
     config_key='MNE_DATASETS_TESTING_PATH',
 )

--- a/mne/decoding/time_delaying_ridge.py
+++ b/mne/decoding/time_delaying_ridge.py
@@ -208,7 +208,6 @@ def _fit_corrs(x_xt, x_y, n_ch_x, reg_type, alpha, n_ch_in):
     reg = _compute_reg_neighbors(n_ch_x, n_delays, reg_type)
     mat = x_xt + alpha * reg
     # From sklearn
-    kwargs = dict()
     try:
         # Note: we must use overwrite_a=False in order to be able to
         #       use the fall-back solution below in case a LinAlgError

--- a/mne/decoding/time_delaying_ridge.py
+++ b/mne/decoding/time_delaying_ridge.py
@@ -208,11 +208,12 @@ def _fit_corrs(x_xt, x_y, n_ch_x, reg_type, alpha, n_ch_in):
     reg = _compute_reg_neighbors(n_ch_x, n_delays, reg_type)
     mat = x_xt + alpha * reg
     # From sklearn
+    kwargs = dict()
     try:
         # Note: we must use overwrite_a=False in order to be able to
         #       use the fall-back solution below in case a LinAlgError
         #       is raised
-        w = linalg.solve(mat, x_y, sym_pos=True, overwrite_a=False)
+        w = linalg.solve(mat, x_y, overwrite_a=False, assume_a='pos')
     except np.linalg.LinAlgError:
         warn('Singular matrix in solving dual problem. Using '
              'least-squares solution instead.')

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -308,7 +308,7 @@ def _firwin_design(N, freq, gain, window, sfreq):
                                  % (N, transition * sfreq / 2., this_N))
             # Construct a lowpass
             this_h = firwin(this_N, (prev_freq + this_freq) / 2.,
-                            window=window, pass_zero=True, nyq=freq[-1])
+                            window=window, pass_zero=True, fs=freq[-1] * 2)
             assert this_h.shape == (this_N,)
             offset = (N - this_N) // 2
             if this_gain == 0:

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -248,7 +248,7 @@ def linear_regression_raw(raw, events, event_id=None, tmin=-.1, tmax=1,
         if solver == 'cholesky':
             def solver(X, y):
                 a = (X.T * X).toarray()  # dot product of sparse matrices
-                return linalg.solve(a, X.T * y, sym_pos=True,
+                return linalg.solve(a, X.T * y, assume_a='pos',
                                     overwrite_a=True, overwrite_b=True).T
     elif callable(solver):
         pass


### PR DESCRIPTION
I manually made a 0.136 tarball because I can't download it from GH, let's see if I did it correctly. If not, I can work to fix it.

Hopefully we can revert this very soon, but even if we can't, we could sustain this way of doing things at least until we run out of osf.io space. In the meantime, we should really have CIs working right around release time...