### PR TITLE
unify style of sidebars & SG-buttons w/ sphinx-design

### DIFF
--- a/doc/_includes/forward.rst
+++ b/doc/_includes/forward.rst
@@ -21,12 +21,13 @@ MEG/EEG and MRI coordinate systems
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. sidebar:: Coordinate systems in MNE-Python
+    :class: sd-card sd-shadow-sm
 
-   In some MNE-Python objects (e.g., :class:`~mne.Forward`,
-   :class:`~mne.SourceSpaces`, etc), information about the coordinate frame is
-   encoded as a constant integer value. The meaning of those integers is
-   determined `in the source code
-   <https://github.com/mne-tools/mne-python/blob/main/mne/io/constants.py#L186-L197>`__.
+    In some MNE-Python objects (e.g., :class:`~mne.Forward`,
+    :class:`~mne.SourceSpaces`, etc), information about the coordinate frame is
+    encoded as a constant integer value. The meaning of those integers is
+    determined `in the source code
+    <https://github.com/mne-tools/mne-python/blob/main/mne/io/constants.py#L186-L197>`__.
 
 The coordinate systems used in MNE software (and FreeSurfer) and their
 relationships are depicted in :ref:`coordinate_system_figure`. Except for the
@@ -684,13 +685,14 @@ EEG forward solution in the sphere model
 ----------------------------------------
 
 .. sidebar:: Sphere-model examples in MNE-Python
+    :class: sd-card sd-shadow-sm
 
-   For examples of using the sphere model when computing the forward model
-   (using :func:`mne.make_forward_solution`), see :ref:`Brainstorm CTF phantom
-   dataset tutorial <plt_brainstorm_phantom_ctf_eeg_sphere_geometry>`,
-   :ref:`Brainstorm Elekta phantom dataset tutorial
-   <plt_brainstorm_phantom_elekta_eeg_sphere_geometry>`, and
-   :ref:`tut-source-alignment-without-mri`.
+    For examples of using the sphere model when computing the forward model
+    (using :func:`mne.make_forward_solution`), see :ref:`Brainstorm CTF phantom
+    dataset tutorial <plt_brainstorm_phantom_ctf_eeg_sphere_geometry>`,
+    :ref:`Brainstorm Elekta phantom dataset tutorial
+    <plt_brainstorm_phantom_elekta_eeg_sphere_geometry>`, and
+    :ref:`tut-source-alignment-without-mri`.
 
 When the sphere model is employed, the computation of the EEG solution can be
 substantially accelerated by using approximation methods described by Mosher

--- a/doc/_includes/morph.rst
+++ b/doc/_includes/morph.rst
@@ -24,11 +24,12 @@ Why morphing?
 ~~~~~~~~~~~~~
 
 .. sidebar:: Morphing examples in MNE-Python
+    :class: sd-card sd-shadow-sm
 
-   Examples of morphing in MNE-Python include :ref:`this tutorial
-   <tut-mne-fixed-free>` on surface source estimation or these examples on
-   :ref:`surface <ex-morph-surface>` and :ref:`volumetric <ex-morph-volume>`
-   source estimation.
+    Examples of morphing in MNE-Python include :ref:`this tutorial
+    <tut-mne-fixed-free>` on surface source estimation or these examples on
+    :ref:`surface <ex-morph-surface>` and :ref:`volumetric <ex-morph-volume>`
+    source estimation.
 
 Modern neuroimaging techniques, such as source reconstruction or fMRI analyses,
 make use of advanced mathematical models and hardware to map brain activity

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -5,7 +5,6 @@
     --pst-font-family-base: 'Source Sans Pro', var(--pst-font-family-base-system);
     --pst-font-family-heading: var(--pst-font-family-base);
     --pst-font-family-monospace: 'Source Code Pro', var(--pst-font-family-monospace-system);
-
 }
 
 html[data-theme="light"] {
@@ -15,8 +14,17 @@ html[data-theme="light"] {
     --mne-color-twitter: #55acee;
     --pst-color-border-rgba: rgba(0, 0, 0, 0.125);
     --pst-color-background-rgba: rgba(0, 0, 0, 0.03);
-    --pst-color-info-rgba: #007bff18;
+    --pst-color-primary-rgba: rgba(69, 157, 185, 0.2);
+    --pst-color-secondary-rgba: rgba(238, 144, 64, 0.2);
     --copybtn-opacity: 0.75;
+    /* sphinx-gallery overrides */
+    --sg-download-a-background-color: var(--pst-color-primary);
+    --sg-download-a-background-image: unset;
+    --sg-download-a-border-color: var(--pst-color-border-rgba);
+    --sg-download-a-color: #fff;
+    --sg-download-a-hover-background-color: var(--pst-color-secondary);
+    --sg-download-a-hover-box-shadow-1: none;
+    --sg-download-a-hover-box-shadow-2: none;
 }
 html[data-theme="dark"] {
     --mne-color-github: #fff;
@@ -25,8 +33,17 @@ html[data-theme="dark"] {
     --mne-color-twitter: #55acee;
     --pst-color-border-rgba: rgba(201, 201, 201, 0.25);
     --pst-color-background-rgba: rgba(255, 255, 255, 0.08);
-    --pst-color-info-rgba: #407dbf18;
+    --pst-color-primary-rgba: rgba(69, 157, 185, 0.3);
+    --pst-color-secondary-rgba: rgba(238, 144, 64, 0.3);
     --copybtn-opacity: 0.25;
+    /* sphinx-gallery overrides */
+    --sg-download-a-background-color: var(--pst-color-primary);
+    --sg-download-a-background-image: unset;
+    --sg-download-a-border-color: var(--pst-color-border-rgba);
+    --sg-download-a-color: #fff;
+    --sg-download-a-hover-background-color: var(--pst-color-secondary);
+    --sg-download-a-hover-box-shadow-1: none;
+    --sg-download-a-hover-box-shadow-2: none;
 }
 
 /* ************************************************************ Sphinx fixes */
@@ -59,9 +76,9 @@ p.sphx-glr-signature {
 }
 /* script/notebook download buttons */
 .sphx-glr-download a.download {
-    background-image: none;
-    background-color: var(--pst-color-info-rgba);
-    border-color: rgb(var(--pst-color-info));
+    /* ↓↓↓↓↓↓↓ these two rules copied from sphinx-design */
+    box-shadow: 0 .125rem .25rem var(--sd-color-shadow) !important;
+    transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
 }
 /* Report embedding */
 iframe.sg_report {
@@ -92,16 +109,8 @@ div[id^="examples-using-"] h2 {
 /* ******************************************* in-text sidebar callout boxes */
 div.sidebar,
 aside.sidebar {
-    margin: 0 0 0.5em 1em;
-    padding: 7px;
-    width: 40%;
-    float: right;
-    clear: right;
-    overflow-x: auto;
-    /* above copied from div.sidebar in basic.css; below are our overrides */
-    background-color: var(--pst-color-info-rgba);
-    border: 1px solid rgb(var(--pst-color-info));
-    border-radius: 4px;
+    background-color: var(--pst-color-primary-rgba);
+    border-color: rgb(var(--pst-color-info));
 }
 
 /* **************************************************************** homepage */

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -94,6 +94,7 @@ Configuring git
 ~~~~~~~~~~~~~~~
 
 .. sidebar:: Git GUI alternative
+    :class: sd-card sd-shadow-sm
 
     `GitHub desktop`_ is a GUI alternative to command line git that some users
     appreciate; it is available for |windows| Windows and |apple| MacOS.
@@ -155,15 +156,16 @@ into a terminal and you should see ::
 If you don't see this or something similar:
 
 .. sidebar:: If you get:
+    :class: sd-card sd-shadow-sm
 
-   *bash: conda: command not found*
+    *bash: conda: command not found*
 
-   you need to add
+    you need to add
 
-   - :file:`{path_to_Anaconda}`
-   - :file:`{path_to_Anaconda}\\Scripts`
+    - :file:`{path_to_Anaconda}`
+    - :file:`{path_to_Anaconda}\\Scripts`
 
-   to Windows-PATH.
+    to Windows-PATH.
 
 - For Linux/MacOS, get `GNU Make`_
 - For Windows, you can install make for git BASH (which comes with `git for Windows`_):
@@ -203,6 +205,7 @@ Creating the virtual environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. sidebar:: Supported Python environments
+    :class: sd-card sd-shadow-sm
 
     We strongly recommend the `Anaconda`_ or `Miniconda`_ environment managers
     for Python. Other setups are possible but are not officially supported by
@@ -340,6 +343,7 @@ feature, you should first synchronize your local ``main`` branch with the
     $ git checkout -b new-feature-x  # create local branch "new-feature-x" and check it out
 
 .. sidebar:: Alternative
+    :class: sd-card sd-shadow-sm
 
     You can save some typing by using ``git pull upstream/main`` to replace
     the ``fetch`` and ``merge`` lines above.
@@ -826,6 +830,7 @@ Running the test suite
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. sidebar:: pytest flags
+    :class: sd-card sd-shadow-sm
 
     The ``-x`` flag exits the pytest run when any test fails; this can speed
     up debugging when running all tests in a file or module.

--- a/doc/install/mne_tools_suite.rst
+++ b/doc/install/mne_tools_suite.rst
@@ -36,6 +36,7 @@ There is also a growing ecosystem of other Python packages that work alongside
 MNE-Python, including packages for:
 
 .. sidebar:: Something missing?
+    :class: sd-card sd-shadow-sm
 
     If you know of a package that is related but not listed here, feel free to
     :ref:`make a pull request <contributing>` to add it to this list.

--- a/doc/overview/datasets_index.rst
+++ b/doc/overview/datasets_index.rst
@@ -4,6 +4,7 @@ Datasets Overview
 #################
 
 .. sidebar:: Contributing datasets to MNE-Python
+    :class: sd-card sd-shadow-sm
 
     Do not hesitate to contact MNE-Python developers on the
     `MNE Forum <https://mne.discourse.group>`_ to discuss the possibility of


### PR DESCRIPTION
This PR:

- makes the sphinx-gallery generated "download notebook" buttons look like other buttons on our site
- styles the `.. sidebar::` directive to use the theme colors & sphinx-design shadows