### PR TITLE
[ENH, MRG] Abstract slice browser

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -164,7 +164,6 @@ def pytest_configure(config):
     ignore:.*Setting theme=.*:RuntimeWarning
     # scikit-learn using this arg
     ignore:.*The 'sym_pos' keyword is deprecated.*:DeprecationWarning
-    ignore:is obsoleted by Node:PendingDeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -164,7 +164,7 @@ def pytest_configure(config):
     ignore:.*Setting theme=.*:RuntimeWarning
     # scikit-learn using this arg
     ignore:.*The 'sym_pos' keyword is deprecated.*:DeprecationWarning
-    ignore:.*is obsoleted by Node.*:PendingDeprecationWarning
+    ignore:is obsoleted by Node:PendingDeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -164,6 +164,7 @@ def pytest_configure(config):
     ignore:.*Setting theme=.*:RuntimeWarning
     # scikit-learn using this arg
     ignore:.*The 'sym_pos' keyword is deprecated.*:DeprecationWarning
+    ignore:.*nodes.Node.traverse() is obsoleted by Node.findall().*:PendingDeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -164,7 +164,7 @@ def pytest_configure(config):
     ignore:.*Setting theme=.*:RuntimeWarning
     # scikit-learn using this arg
     ignore:.*The 'sym_pos' keyword is deprecated.*:DeprecationWarning
-    ignore:.*nodes\.Node\.traverse() is obsoleted by Node\.findall().*:PendingDeprecationWarning
+    ignore:.*nodes\.Node\.traverse() is obsoleted by Node\.findall().*
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -164,7 +164,7 @@ def pytest_configure(config):
     ignore:.*Setting theme=.*:RuntimeWarning
     # scikit-learn using this arg
     ignore:.*The 'sym_pos' keyword is deprecated.*:DeprecationWarning
-    ignore:.*nodes\.Node\.traverse.*:PendingDeprecationWarning
+    ignore:.*is obsoleted by Node.*:PendingDeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -164,7 +164,7 @@ def pytest_configure(config):
     ignore:.*Setting theme=.*:RuntimeWarning
     # scikit-learn using this arg
     ignore:.*The 'sym_pos' keyword is deprecated.*:DeprecationWarning
-    ignore:.*nodes\.Node\.traverse() is obsoleted by Node\.findall().*
+    ignore:.*nodes\.Node\.traverse.*:PendingDeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -164,7 +164,7 @@ def pytest_configure(config):
     ignore:.*Setting theme=.*:RuntimeWarning
     # scikit-learn using this arg
     ignore:.*The 'sym_pos' keyword is deprecated.*:DeprecationWarning
-    ignore:.*nodes.Node.traverse() is obsoleted by Node.findall().*:PendingDeprecationWarning
+    ignore:.*nodes\.Node\.traverse() is obsoleted by Node\.findall().*:PendingDeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne/gui/_core.py
+++ b/mne/gui/_core.py
@@ -1,0 +1,483 @@
+# -*- coding: utf-8 -*-
+"""Shared GUI classes and functions."""
+
+# Authors: Alex Rockhill <aprockhill@mailbox.org>
+#
+# License: BSD (3-clause)
+
+import os
+import os.path as op
+import numpy as np
+from functools import partial
+
+from qtpy import QtCore
+from qtpy.QtCore import Slot
+from qtpy.QtWidgets import (QMainWindow, QGridLayout,
+                            QVBoxLayout, QHBoxLayout, QLabel,
+                            QMessageBox, QWidget, QPlainTextEdit)
+
+from matplotlib import patheffects
+from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.figure import Figure
+from matplotlib.patches import Rectangle
+
+from .._freesurfer import _import_nibabel
+from ..viz.backends.renderer import _get_renderer
+from ..viz.utils import safe_event
+from ..surface import _read_mri_surface, _marching_cubes
+from ..transforms import apply_trans, _frame_to_str
+from ..utils import logger, _check_fname, verbose, warn, get_subjects_dir
+
+_IMG_LABELS = [['I', 'P'], ['I', 'L'], ['P', 'L']]
+_ZOOM_STEP_SIZE = 5
+
+
+@verbose
+def _load_image(img, verbose=None):
+    """Load data from a 3D image file (e.g. CT, MR)."""
+    nib = _import_nibabel('use GUI')
+    if not isinstance(img, nib.spatialimages.SpatialImage):
+        logger.info(f'Loading {img}')
+        _check_fname(img, overwrite='read', must_exist=True)
+        img = nib.load(img)
+    # get data
+    orig_data = np.array(img.dataobj).astype(np.float32)
+    # reorient data to RAS
+    ornt = nib.orientations.axcodes2ornt(
+        nib.orientations.aff2axcodes(img.affine)).astype(int)
+    ras_ornt = nib.orientations.axcodes2ornt('RAS')
+    ornt_trans = nib.orientations.ornt_transform(ornt, ras_ornt)
+    img_data = nib.orientations.apply_orientation(orig_data, ornt_trans)
+    orig_mgh = nib.MGHImage(orig_data, img.affine)
+    aff_trans = nib.orientations.inv_ornt_aff(ornt_trans, img.shape)
+    vox_ras_t = np.dot(orig_mgh.header.get_vox2ras_tkr(), aff_trans)
+    return img_data, vox_ras_t
+
+
+def _make_slice_plot(width=4, height=4, dpi=300):
+    fig = Figure(figsize=(width, height), dpi=dpi)
+    canvas = FigureCanvas(fig)
+    ax = fig.subplots()
+    fig.subplots_adjust(bottom=0, left=0, right=1, top=1, wspace=0, hspace=0)
+    ax.set_facecolor('k')
+    # clean up excess plot text, invert
+    ax.invert_yaxis()
+    ax.set_xticks([])
+    ax.set_yticks([])
+    return canvas, fig
+
+
+class SliceBrowser(QMainWindow):
+    """Navigate between slices of an MRI, CT, etc. image."""
+
+    _xy_idx = (
+        (1, 2),
+        (0, 2),
+        (0, 1),
+    )
+
+    def __init__(self, base_image=None, subject=None, subjects_dir=None,
+                 verbose=None):
+        """GUI for browsing slices of anatomical images."""
+        # initialize QMainWindow class
+        super(SliceBrowser, self).__init__()
+
+        self._verbose = verbose
+        # if bad/None subject, will raise an informative error when loading MRI
+        subject = os.environ.get('SUBJECT') if subject is None else subject
+        subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
+        self._subject_dir = op.join(subjects_dir, subject)
+        self._load_image_data(base_image=base_image)
+
+        # GUI design
+
+        # Main plots: make one plot for each view; sagittal, coronal, axial
+        self._plt_grid = QGridLayout()
+        self._figs = list()
+        for i in range(3):
+            canvas, fig = _make_slice_plot()
+            self._plt_grid.addWidget(canvas, i // 2, i % 2)
+            self._figs.append(fig)
+        self._renderer = _get_renderer(
+            name='Slice Browser', size=(400, 400), bgcolor='w')
+        self._plt_grid.addWidget(self._renderer.plotter, 1, 1)
+
+        self._set_ras([0., 0., 0.], update_plots=False)
+
+        self._plot_images()
+
+        self._configure_ui()
+
+    def _configure_ui(self):
+        bottom_hbox = self._configure_status_bar()
+
+        # Put everything together
+        plot_ch_hbox = QHBoxLayout()
+        plot_ch_hbox.addLayout(self._plt_grid)
+
+        main_vbox = QVBoxLayout()
+        main_vbox.addLayout(plot_ch_hbox)
+        main_vbox.addLayout(bottom_hbox)
+
+        central_widget = QWidget()
+        central_widget.setLayout(main_vbox)
+        self.setCentralWidget(central_widget)
+
+    def _load_image_data(self, base_image=None):
+        """Get image data to display and transforms to/from vox/RAS."""
+        # allows recon-all not to be finished (T1 made in a few minutes)
+        mri_img = 'brain' if op.isfile(op.join(
+            self._subject_dir, 'mri', 'brain.mgz')) else 'T1'
+        self._mri_data, self._vox_ras_t = _load_image(
+            op.join(self._subject_dir, 'mri', f'{mri_img}.mgz'))
+        self._ras_vox_t = np.linalg.inv(self._vox_ras_t)
+
+        self._voxel_sizes = np.array(self._mri_data.shape)
+
+        # We need our extents to land the centers of each pixel on the voxel
+        # number. This code assumes 1mm isotropic...
+        img_delta = 0.5
+        self._img_extents = list(
+            [-img_delta, self._voxel_sizes[idx[0]] - img_delta,
+             -img_delta, self._voxel_sizes[idx[1]] - img_delta]
+            for idx in self._xy_idx)
+
+        # ready alternate base image if provided, otherwise use brain/T1
+        if base_image is None:
+            self._base_data = self._mri_data
+        else:
+            self._base_data, vox_ras_t = _load_image(base_image)
+            if self._mri_data.shape != self._base_data.shape or \
+                    not np.allclose(self._vox_ras_t, vox_ras_t, rtol=1e-6):
+                raise ValueError('Base image is not aligned to MRI, got '
+                                 f'Base shape={self._base_data.shape}, '
+                                 f'MRI shape={self._mri_data.shape}, '
+                                 f'Base affine={vox_ras_t} and '
+                                 f'MRI affine={self._vox_ras_t}')
+
+        if op.exists(op.join(self._subject_dir, 'surf', 'lh.seghead')):
+            self._head = _read_mri_surface(
+                op.join(self._subject_dir, 'surf', 'lh.seghead'))
+            assert _frame_to_str[self._head['coord_frame']] == 'mri'
+        else:
+            warn('`seghead` not found, using marching cubes on CT for '
+                 'head plot, use :ref:`mne.bem.make_scalp_surfaces` '
+                 'to add the scalp surface instead of skull from the CT')
+            self._head = None
+        if op.exists(op.join(self._subject_dir, 'surf', 'lh.pial')):
+            self._lh = _read_mri_surface(
+                op.join(self._subject_dir, 'surf', 'lh.pial'))
+            assert _frame_to_str[self._lh['coord_frame']] == 'mri'
+            self._rh = _read_mri_surface(
+                op.join(self._subject_dir, 'surf', 'rh.pial'))
+            assert _frame_to_str[self._rh['coord_frame']] == 'mri'
+        else:
+            warn('`pial` surface not found, skipping adding to 3D '
+                 'plot. This indicates the Freesurfer recon-all '
+                 'has not finished or has been modified and '
+                 'these files have been deleted.')
+            self._lh = self._rh = None
+
+    def _plot_images(self):
+        """Use the MRI or CT to make plots."""
+        # Plot sagittal (0), coronal (1) or axial (2) view
+        self._images = dict(base=list(), cursor_v=list(), cursor_h=list(),
+                            bounds=list())
+        img_min = np.nanmin(self._base_data)
+        img_max = np.nanmax(self._base_data)
+        text_kwargs = dict(fontsize='medium', weight='bold', color='#66CCEE',
+                           family='monospace', ha='center', va='center',
+                           path_effects=[patheffects.withStroke(
+                               linewidth=4, foreground="k", alpha=0.75)])
+        xyz = apply_trans(self._ras_vox_t, self._ras)
+        for axis in range(3):
+            plot_x_idx, plot_y_idx = self._xy_idx[axis]
+            fig = self._figs[axis]
+            ax = fig.axes[0]
+            img_data = np.take(self._base_data, self._current_slice[axis],
+                               axis=axis).T
+            self._images['base'].append(ax.imshow(
+                img_data, cmap='gray', aspect='auto', zorder=1,
+                vmin=img_min, vmax=img_max))
+            img_extent = self._img_extents[axis]  # x0, x1, y0, y1
+            w, h = np.diff(np.array(img_extent).reshape(2, 2), axis=1)[:, 0]
+            self._images['bounds'].append(Rectangle(
+                img_extent[::2], w, h, edgecolor='w', facecolor='none',
+                alpha=0.25, lw=0.5, zorder=1.5))
+            ax.add_patch(self._images['bounds'][-1])
+            v_x = (xyz[plot_x_idx],) * 2
+            v_y = img_extent[2:4]
+            self._images['cursor_v'].append(ax.plot(
+                v_x, v_y, color='lime', linewidth=0.5, alpha=0.5, zorder=8)[0])
+            h_y = (xyz[plot_y_idx],) * 2
+            h_x = img_extent[0:2]
+            self._images['cursor_h'].append(ax.plot(
+                h_x, h_y, color='lime', linewidth=0.5, alpha=0.5, zorder=8)[0])
+            # label axes
+            self._figs[axis].text(0.5, 0.05, _IMG_LABELS[axis][0],
+                                  **text_kwargs)
+            self._figs[axis].text(0.05, 0.5, _IMG_LABELS[axis][1],
+                                  **text_kwargs)
+            self._figs[axis].axes[0].axis(img_extent)
+            self._figs[axis].canvas.mpl_connect(
+                'scroll_event', self._on_scroll)
+            self._figs[axis].canvas.mpl_connect(
+                'button_release_event', partial(self._on_click, axis=axis))
+        # add head and brain in mm (convert from m)
+        if self._head is None:
+            logger.info('Using marching cubes on CT for the '
+                        '3D visualization panel')
+            rr, tris = _marching_cubes(np.where(
+                self._base_data < np.quantile(self._base_data, 0.95), 0, 1),
+                [1])[0]
+            rr = apply_trans(self._vox_ras_t, rr)
+            self._renderer.mesh(
+                *rr.T, triangles=tris, color='gray', opacity=0.2,
+                reset_camera=False, render=False)
+        else:
+            self._renderer.mesh(
+                *self._head['rr'].T * 1000, triangles=self._head['tris'],
+                color='gray', opacity=0.2, reset_camera=False, render=False)
+        if self._lh is not None and self._rh is not None:
+            self._renderer.mesh(
+                *self._lh['rr'].T * 1000, triangles=self._lh['tris'],
+                color='white', opacity=0.2, reset_camera=False, render=False)
+            self._renderer.mesh(
+                *self._rh['rr'].T * 1000, triangles=self._rh['tris'],
+                color='white', opacity=0.2, reset_camera=False, render=False)
+        self._renderer.set_camera(azimuth=90, elevation=90, distance=300,
+                                  focalpoint=tuple(self._ras))
+        # update plots
+        self._draw()
+        self._renderer._update()
+
+    def _configure_status_bar(self, hbox=None):
+        """Make a bar at the bottom with information in it."""
+        hbox = QHBoxLayout() if hbox is None else hbox
+
+        self._intensity_label = QLabel('')  # update later
+        hbox.addWidget(self._intensity_label)
+
+        VOX_label = QLabel('VOX =')
+        self._VOX_textbox = QPlainTextEdit('')  # update later
+        self._VOX_textbox.setMaximumHeight(25)
+        self._VOX_textbox.setMaximumWidth(125)
+        self._VOX_textbox.focusOutEvent = self._update_VOX
+        self._VOX_textbox.textChanged.connect(self._check_update_VOX)
+        hbox.addWidget(VOX_label)
+        hbox.addWidget(self._VOX_textbox)
+
+        RAS_label = QLabel('RAS =')
+        self._RAS_textbox = QPlainTextEdit('')  # update later
+        self._RAS_textbox.setMaximumHeight(25)
+        self._RAS_textbox.setMaximumWidth(200)
+        self._RAS_textbox.focusOutEvent = self._update_RAS
+        self._RAS_textbox.textChanged.connect(self._check_update_RAS)
+        hbox.addWidget(RAS_label)
+        hbox.addWidget(self._RAS_textbox)
+        self._update_moved()  # update text now
+        return hbox
+
+    def _update_camera(self, render=False):
+        """Update the camera position."""
+        self._renderer.set_camera(
+            # needs fix, distance moves when focal point updates
+            distance=self._renderer.plotter.camera.distance * 0.9,
+            focalpoint=tuple(self._ras),
+            reset_camera=False)
+
+    def _on_scroll(self, event):
+        """Process mouse scroll wheel event to zoom."""
+        self._zoom(event.step, draw=True)
+
+    def _zoom(self, sign=1, draw=False):
+        """Zoom in on the image."""
+        delta = _ZOOM_STEP_SIZE * sign
+        for axis, fig in enumerate(self._figs):
+            xmid = self._images['cursor_v'][axis].get_xdata()[0]
+            ymid = self._images['cursor_h'][axis].get_ydata()[0]
+            xmin, xmax = fig.axes[0].get_xlim()
+            ymin, ymax = fig.axes[0].get_ylim()
+            xwidth = (xmax - xmin) / 2 - delta
+            ywidth = (ymax - ymin) / 2 - delta
+            if xwidth <= 0 or ywidth <= 0:
+                return
+            fig.axes[0].set_xlim(xmid - xwidth, xmid + xwidth)
+            fig.axes[0].set_ylim(ymid - ywidth, ymid + ywidth)
+            if draw:
+                self._figs[axis].canvas.draw()
+
+    @Slot()
+    def _update_RAS(self, event):
+        """Interpret user input to the RAS textbox."""
+        text = self._RAS_textbox.toPlainText()
+        ras = self._convert_text(text, 'ras')
+        if ras is not None:
+            self._set_ras(ras)
+
+    @Slot()
+    def _update_VOX(self, event):
+        """Interpret user input to the RAS textbox."""
+        text = self._VOX_textbox.toPlainText()
+        ras = self._convert_text(text, 'vox')
+        if ras is not None:
+            self._set_ras(ras)
+
+    def _convert_text(self, text, text_kind):
+        text = text.replace('\n', '')
+        vals = text.split(',')
+        if len(vals) != 3:
+            vals = text.split(' ')  # spaces also okay as in freesurfer
+        vals = [var.lstrip().rstrip() for var in vals]
+        try:
+            vals = np.array([float(var) for var in vals]).reshape(3)
+        except Exception:
+            self._update_moved()  # resets RAS label
+            return
+        if text_kind == 'vox':
+            vox = vals
+            ras = apply_trans(self._vox_ras_t, vox)
+        else:
+            assert text_kind == 'ras'
+            ras = vals
+            vox = apply_trans(self._ras_vox_t, ras)
+        wrong_size = any(var < 0 or var > n - 1 for var, n in
+                         zip(vox, self._voxel_sizes))
+        if wrong_size:
+            self._update_moved()  # resets RAS label
+            return
+        return ras
+
+    @property
+    def _ras(self):
+        return self._ras_safe
+
+    def _set_ras(self, ras, update_plots=True):
+        ras = np.asarray(ras, dtype=float)
+        assert ras.shape == (3,)
+        msg = ', '.join(f'{x:0.2f}' for x in ras)
+        logger.debug(f'Trying RAS:  ({msg}) mm')
+        # clip to valid
+        vox = apply_trans(self._ras_vox_t, ras)
+        vox = np.array([
+            np.clip(d, 0, self._voxel_sizes[ii] - 1)
+            for ii, d in enumerate(vox)])
+        # transform back, make write-only
+        self._ras_safe = apply_trans(self._vox_ras_t, vox)
+        self._ras_safe.flags['WRITEABLE'] = False
+        msg = ', '.join(f'{x:0.2f}' for x in self._ras_safe)
+        logger.debug(f'Setting RAS: ({msg}) mm')
+        if update_plots:
+            self._move_cursors_to_pos()
+
+    @property
+    def _vox(self):
+        return apply_trans(self._ras_vox_t, self._ras)
+
+    @property
+    def _current_slice(self):
+        return self._vox.round().astype(int)
+
+    @Slot()
+    def _check_update_RAS(self):
+        """Check whether the RAS textbox is done being edited."""
+        if '\n' in self._RAS_textbox.toPlainText():
+            self._update_RAS(event=None)
+
+    @Slot()
+    def _check_update_VOX(self):
+        """Check whether the VOX textbox is done being edited."""
+        if '\n' in self._VOX_textbox.toPlainText():
+            self._update_VOX(event=None)
+
+    def _draw(self, axis=None):
+        """Update the figures with a draw call."""
+        for axis in (range(3) if axis is None else [axis]):
+            self._figs[axis].canvas.draw()
+
+    def _update_base_images(self, axis=None, draw=False):
+        """Update the base images."""
+        for axis in range(3) if axis is None else [axis]:
+            img_data = np.take(self._base_data, self._current_slice[axis],
+                               axis=axis).T
+            self._images['base'][axis].set_data(img_data)
+            if draw:
+                self._draw(axis)
+
+    def _update_images(self, axis=None, draw=True):
+        """Update CT and channel images when general changes happen."""
+        self._update_base_images(axis=axis)
+        if draw:
+            self._draw(axis)
+
+    def _move_cursors_to_pos(self):
+        """Move the cursors to a position."""
+        for axis in range(3):
+            x, y = self._vox[list(self._xy_idx[axis])]
+            self._images['cursor_v'][axis].set_xdata([x, x])
+            self._images['cursor_h'][axis].set_ydata([y, y])
+        self._zoom(0)  # doesn't actually zoom just resets view to center
+        self._update_images(draw=True)
+        self._update_moved()
+
+    def _show_help(self):
+        """Show the help menu."""
+        QMessageBox.information(
+            self, 'Help',
+            "Help:\n"
+            "'+'/'-': zoom\nleft/right arrow: left/right\n"
+            "up/down arrow: superior/inferior\n"
+            "left angle bracket/right angle bracket: anterior/posterior")
+
+    def _key_press_event(self, event):
+        """Execute functions when the user presses a key."""
+        if event.key() == 'escape':
+            self.close()
+
+        if event.text() == 'h':
+            self._show_help()
+
+        if event.text() in ('=', '+', '-'):
+            self._zoom(sign=-2 * (event.text() == '-') + 1, draw=True)
+
+        # Changing slices
+        if event.key() in (QtCore.Qt.Key_Up, QtCore.Qt.Key_Down,
+                           QtCore.Qt.Key_Left, QtCore.Qt.Key_Right,
+                           QtCore.Qt.Key_Comma, QtCore.Qt.Key_Period,
+                           QtCore.Qt.Key_PageUp, QtCore.Qt.Key_PageDown):
+            ras = np.array(self._ras)
+            if event.key() in (QtCore.Qt.Key_Up, QtCore.Qt.Key_Down):
+                ras[2] += 2 * (event.key() == QtCore.Qt.Key_Up) - 1
+            elif event.key() in (QtCore.Qt.Key_Left, QtCore.Qt.Key_Right):
+                ras[0] += 2 * (event.key() == QtCore.Qt.Key_Right) - 1
+            else:
+                ras[1] += 2 * (event.key() == QtCore.Qt.Key_PageUp or
+                               event.key() == QtCore.Qt.Key_Period) - 1
+            self._set_ras(ras)
+
+    def _on_click(self, event, axis):
+        """Move to view on MRI and CT on click."""
+        if event.inaxes is self._figs[axis].axes[0]:
+            # Data coordinates are voxel coordinates
+            pos = (event.xdata, event.ydata)
+            logger.info(f'Clicked {"XYZ"[axis]} ({axis}) axis at pos {pos}')
+            xyz = self._vox
+            xyz[list(self._xy_idx[axis])] = pos
+            logger.debug(f'Using voxel  {list(xyz)}')
+            ras = apply_trans(self._vox_ras_t, xyz)
+            self._set_ras(ras)
+
+    def _update_moved(self):
+        """Update when cursor position changes."""
+        self._RAS_textbox.setPlainText('{:.2f}, {:.2f}, {:.2f}'.format(
+            *self._ras))
+        self._VOX_textbox.setPlainText('{:3d}, {:3d}, {:3d}'.format(
+            *self._current_slice))
+        self._intensity_label.setText('intensity = {:.2f}'.format(
+            self._base_data[tuple(self._current_slice)]))
+
+    @safe_event
+    def closeEvent(self, event):
+        """Clean up upon closing the window."""
+        self._renderer.plotter.close()
+        self.close()

--- a/mne/gui/_ieeg_locate_gui.py
+++ b/mne/gui/_ieeg_locate_gui.py
@@ -5,39 +5,27 @@
 #
 # License: BSD (3-clause)
 
-import os.path as op
 import numpy as np
-from functools import partial
 import platform
 
 from scipy.ndimage import maximum_filter
 
 from qtpy import QtCore, QtGui
 from qtpy.QtCore import Slot, Signal
-from qtpy.QtWidgets import (QMainWindow, QGridLayout,
-                            QVBoxLayout, QHBoxLayout, QLabel,
+from qtpy.QtWidgets import (QVBoxLayout, QHBoxLayout, QLabel,
                             QMessageBox, QWidget, QAbstractItemView,
                             QListView, QSlider, QPushButton,
-                            QComboBox, QPlainTextEdit)
+                            QComboBox)
 
-from matplotlib import patheffects
-from matplotlib.backends.backend_qt5agg import FigureCanvas
 from matplotlib.colors import LinearSegmentedColormap
-from matplotlib.figure import Figure
-from matplotlib.patches import Rectangle
 
-from .._freesurfer import _import_nibabel
-from ..viz.backends.renderer import _get_renderer
-from ..viz.utils import safe_event
-from ..surface import _read_mri_surface, _voxel_neighbors, _marching_cubes
-from ..transforms import (apply_trans, _frame_to_str, _get_trans,
-                          invert_transform)
-from ..utils import logger, _check_fname, _validate_type, verbose, warn
+from ._core import SliceBrowser
+from ..surface import _voxel_neighbors
+from ..transforms import apply_trans, _get_trans, invert_transform
+from ..utils import logger, _validate_type, verbose
 from .. import pick_types
 
-_IMG_LABELS = [['I', 'P'], ['I', 'L'], ['P', 'L']]
 _CH_PLOT_SIZE = 1024
-_ZOOM_STEP_SIZE = 5
 _RADIUS_SCALAR = 0.4
 _TUBE_SCALAR = 0.1
 _BOLT_SCALAR = 30  # mm
@@ -57,28 +45,6 @@ _CMAP = LinearSegmentedColormap.from_list(
     'ch_colors', _UNIQUE_COLORS, N=_N_COLORS)
 
 
-def _load_image(img, name, verbose=True):
-    """Load data from a 3D image file (e.g. CT, MR)."""
-    nib = _import_nibabel('use iEEG GUI')
-    if not isinstance(img, nib.spatialimages.SpatialImage):
-        if verbose:
-            logger.info(f'Loading {img}')
-        _check_fname(img, overwrite='read', must_exist=True, name=name)
-        img = nib.load(img)
-    # get data
-    orig_data = np.array(img.dataobj).astype(np.float32)
-    # reorient data to RAS
-    ornt = nib.orientations.axcodes2ornt(
-        nib.orientations.aff2axcodes(img.affine)).astype(int)
-    ras_ornt = nib.orientations.axcodes2ornt('RAS')
-    ornt_trans = nib.orientations.ornt_transform(ornt, ras_ornt)
-    img_data = nib.orientations.apply_orientation(orig_data, ornt_trans)
-    orig_mgh = nib.MGHImage(orig_data, img.affine)
-    aff_trans = nib.orientations.inv_ornt_aff(ornt_trans, img.shape)
-    vox_ras_t = np.dot(orig_mgh.header.get_vox2ras_tkr(), aff_trans)
-    return img_data, vox_ras_t
-
-
 class ComboBox(QComboBox):
     """Dropdown menu that emits a click when popped up."""
 
@@ -90,27 +56,8 @@ class ComboBox(QComboBox):
         super(ComboBox, self).showPopup()
 
 
-def _make_slice_plot(width=4, height=4, dpi=300):
-    fig = Figure(figsize=(width, height), dpi=dpi)
-    canvas = FigureCanvas(fig)
-    ax = fig.subplots()
-    fig.subplots_adjust(bottom=0, left=0, right=1, top=1, wspace=0, hspace=0)
-    ax.set_facecolor('k')
-    # clean up excess plot text, invert
-    ax.invert_yaxis()
-    ax.set_xticks([])
-    ax.set_yticks([])
-    return canvas, fig
-
-
-class IntracranialElectrodeLocator(QMainWindow):
+class IntracranialElectrodeLocator(SliceBrowser):
     """Locate electrode contacts using a coregistered MRI and CT."""
-
-    _xy_idx = (
-        (1, 2),
-        (0, 2),
-        (0, 1),
-    )
 
     def __init__(self, info, trans, aligned_ct, subject=None,
                  subjects_dir=None, groups=None, show=True, verbose=None):
@@ -120,9 +67,6 @@ class IntracranialElectrodeLocator(QMainWindow):
                   obtained from the image header. Images will be resampled to
                   dimensions [256, 256, 256] for display.
         """
-        # initialize QMainWindow class
-        super(IntracranialElectrodeLocator, self).__init__()
-
         if not info.ch_names:
             raise ValueError('No channels found in `info` to locate')
 
@@ -135,10 +79,6 @@ class IntracranialElectrodeLocator(QMainWindow):
         self._ch_alpha = 0.5
         self._radius = int(_CH_PLOT_SIZE // 100)  # starting 1/100 of image
 
-        # load imaging data
-        self._subject_dir = op.join(subjects_dir, subject)
-        self._load_image_data(aligned_ct)
-
         # initialize channel data
         self._ch_index = 0
         # load data, apply trans
@@ -148,63 +88,25 @@ class IntracranialElectrodeLocator(QMainWindow):
         self._chs = {name: apply_trans(self._head_mri_t, ch['loc'][:3]) * 1000
                      for name, ch in zip(info.ch_names, info['chs'])}
         self._ch_names = list(self._chs.keys())
-        # set current position
-        if np.isnan(self._chs[self._ch_names[self._ch_index]]).any():
-            ras = [0., 0., 0.]
-        else:
-            ras = self._chs[self._ch_names[self._ch_index]]
-        self._set_ras(ras, update_plots=False)
         self._group_channels(groups)
 
-        # GUI design
+        # Initialize GUI
+        super(IntracranialElectrodeLocator, self).__init__(
+            base_image=aligned_ct, subject=subject, subjects_dir=subjects_dir)
 
-        # Main plots: make one plot for each view; sagittal, coronal, axial
-        plt_grid = QGridLayout()
-        plts = [_make_slice_plot(), _make_slice_plot(), _make_slice_plot()]
-        self._figs = [plts[0][1], plts[1][1], plts[2][1]]
-        plt_grid.addWidget(plts[0][0], 0, 0)
-        plt_grid.addWidget(plts[1][0], 0, 1)
-        plt_grid.addWidget(plts[2][0], 1, 0)
-        self._renderer = _get_renderer(
-            name='IEEG Locator', size=(400, 400), bgcolor='w')
-        plt_grid.addWidget(self._renderer.plotter)
+        # set current position as current contact location if exists
+        if not np.isnan(self._chs[self._ch_names[self._ch_index]]).any():
+            self._set_ras(self._chs[self._ch_names[self._ch_index]],
+                          update_plots=False)
 
-        # Channel selector
-        self._ch_list = QListView()
-        self._ch_list.setSelectionMode(QAbstractItemView.SingleSelection)
-        max_ch_name_len = max([len(name) for name in self._chs])
-        self._ch_list.setMinimumWidth(max_ch_name_len * _CH_MENU_WIDTH)
-        self._ch_list.setMaximumWidth(max_ch_name_len * _CH_MENU_WIDTH)
-        self._set_ch_names()
-
-        # Plots
-        self._plot_images()
-
-        # Menus
-        button_hbox = self._get_button_bar()
-        slider_hbox = self._get_slider_bar()
-        bottom_hbox = self._get_bottom_bar()
+        # add plots of contacts on top
+        self._plot_ch_images()
 
         # Add lines
         self._lines = dict()
         self._lines_2D = dict()
         for group in set(self._groups.values()):
             self._update_lines(group)
-
-        # Put everything together
-        plot_ch_hbox = QHBoxLayout()
-        plot_ch_hbox.addLayout(plt_grid)
-        plot_ch_hbox.addWidget(self._ch_list)
-
-        main_vbox = QVBoxLayout()
-        main_vbox.addLayout(button_hbox)
-        main_vbox.addLayout(slider_hbox)
-        main_vbox.addLayout(plot_ch_hbox)
-        main_vbox.addLayout(bottom_hbox)
-
-        central_widget = QWidget()
-        central_widget.setLayout(main_vbox)
-        self.setCentralWidget(central_widget)
 
         # ready for user
         self._move_cursors_to_pos()
@@ -213,64 +115,48 @@ class IntracranialElectrodeLocator(QMainWindow):
         if show:
             self.show()
 
-    def _load_image_data(self, ct):
-        """Get MRI and CT data to display and transforms to/from vox/RAS."""
-        # allows recon-all not to be finished (T1 made in a few minutes)
-        mri_img = 'brain' if op.isfile(op.join(
-            self._subject_dir, 'mri', 'brain.mgz')) else 'T1'
-        self._mri_data, self._vox_ras_t = _load_image(
-            op.join(self._subject_dir, 'mri', f'{mri_img}.mgz'),
-            'MRI Image', verbose=self._verbose)
-        self._ras_vox_t = np.linalg.inv(self._vox_ras_t)
-
-        self._voxel_sizes = np.array(self._mri_data.shape)
-        # We need our extents to land the centers of each pixel on the voxel
-        # number. This code assumes 1mm isotropic...
-        img_delta = 0.5
-        self._img_extents = list(
-            [-img_delta, self._voxel_sizes[idx[0]] - img_delta,
-             -img_delta, self._voxel_sizes[idx[1]] - img_delta]
-            for idx in self._xy_idx)
-        ch_deltas = list(img_delta * (self._voxel_sizes[ii] / _CH_PLOT_SIZE)
-                         for ii in range(3))
-        self._ch_extents = list(
-            [-ch_delta, self._voxel_sizes[idx[0]] - ch_delta,
-             -ch_delta, self._voxel_sizes[idx[1]] - ch_delta]
-            for idx, ch_delta in zip(self._xy_idx, ch_deltas))
-
-        # ready ct
-        self._ct_data, vox_ras_t = _load_image(ct, 'CT', verbose=self._verbose)
-        if self._mri_data.shape != self._ct_data.shape or \
-                not np.allclose(self._vox_ras_t, vox_ras_t, rtol=1e-6):
-            raise ValueError('CT is not aligned to MRI, got '
-                             f'CT shape={self._ct_data.shape}, '
-                             f'MRI shape={self._mri_data.shape}, '
-                             f'CT affine={vox_ras_t} and '
-                             f'MRI affine={self._vox_ras_t}')
+    def _configure_ui(self):
+        # data is loaded for an abstract base image, associate with ct
+        self._ct_data = self._base_data
+        self._images['ct'] = self._images['base']
         self._ct_maxima = None  # don't compute until turned on
 
-        if op.exists(op.join(self._subject_dir, 'surf', 'lh.seghead')):
-            self._head = _read_mri_surface(
-                op.join(self._subject_dir, 'surf', 'lh.seghead'))
-            assert _frame_to_str[self._head['coord_frame']] == 'mri'
-        else:
-            warn('`seghead` not found, using marching cubes on CT for '
-                 'head plot, use :ref:`mne.bem.make_scalp_surfaces` '
-                 'to add the scalp surface instead of skull from the CT')
-            self._head = None
-        if op.exists(op.join(self._subject_dir, 'surf', 'lh.pial')):
-            self._lh = _read_mri_surface(
-                op.join(self._subject_dir, 'surf', 'lh.pial'))
-            assert _frame_to_str[self._lh['coord_frame']] == 'mri'
-            self._rh = _read_mri_surface(
-                op.join(self._subject_dir, 'surf', 'rh.pial'))
-            assert _frame_to_str[self._rh['coord_frame']] == 'mri'
-        else:
-            warn('`pial` surface not found, skipping adding to 3D '
-                 'plot. This indicates the Freesurfer recon-all '
-                 'has not finished or has been modified and '
-                 'these files have been deleted.')
-            self._lh = self._rh = None
+        toolbar = self._configure_toolbar()
+        slider_bar = self._configure_sliders()
+        status_bar = self._configure_status_bar()
+        self._ch_list = self._configure_channel_sidebar()  # need for updating
+
+        plot_layout = QHBoxLayout()
+        plot_layout.addLayout(self._plt_grid)
+        plot_layout.addWidget(self._ch_list)
+
+        main_vbox = QVBoxLayout()
+        main_vbox.addLayout(toolbar)
+        main_vbox.addLayout(slider_bar)
+        main_vbox.addLayout(plot_layout)
+        main_vbox.addLayout(status_bar)
+
+        central_widget = QWidget()
+        central_widget.setLayout(main_vbox)
+        self.setCentralWidget(central_widget)
+
+    def _configure_channel_sidebar(self):
+        """Configure the sidebar to select channels/contacts."""
+        ch_list = QListView()
+        ch_list.setSelectionMode(QAbstractItemView.SingleSelection)
+        max_ch_name_len = max([len(name) for name in self._chs])
+        ch_list.setMinimumWidth(max_ch_name_len * _CH_MENU_WIDTH)
+        ch_list.setMaximumWidth(max_ch_name_len * _CH_MENU_WIDTH)
+        self._ch_list_model = QtGui.QStandardItemModel(ch_list)
+        for name in self._ch_names:
+            self._ch_list_model.appendRow(QtGui.QStandardItem(name))
+            self._color_list_item(name=name)
+        ch_list.setModel(self._ch_list_model)
+        ch_list.clicked.connect(self._go_to_ch)
+        ch_list.setCurrentIndex(
+            self._ch_list_model.index(self._ch_index, 0))
+        ch_list.keyPressEvent = self._key_press_event
+        return ch_list
 
     def _make_ch_image(self, axis, proj=False):
         """Make a plot to display the channel locations."""
@@ -319,92 +205,25 @@ class IntracranialElectrodeLocator(QMainWindow):
                     self._mri_head_t, self._chs[name] / 1000)  # mm->m
                 ch['loc'] = loc
 
-    def _plot_images(self):
-        """Use the MRI and CT to make plots."""
-        # Plot sagittal (0), coronal (1) or axial (2) view
-        self._images = dict(ct=list(), chs=list(), ct_bounds=list(),
-                            cursor_v=list(), cursor_h=list())
-        ct_min, ct_max = np.nanmin(self._ct_data), np.nanmax(self._ct_data)
-        text_kwargs = dict(fontsize='medium', weight='bold', color='#66CCEE',
-                           family='monospace', ha='center', va='center',
-                           path_effects=[patheffects.withStroke(
-                               linewidth=4, foreground="k", alpha=0.75)])
-        xyz = apply_trans(self._ras_vox_t, self._ras)
+    def _plot_ch_images(self):
+        img_delta = 0.5
+        ch_deltas = list(img_delta * (self._voxel_sizes[ii] / _CH_PLOT_SIZE)
+                         for ii in range(3))
+        self._ch_extents = list(
+            [-ch_delta, self._voxel_sizes[idx[0]] - ch_delta,
+             -ch_delta, self._voxel_sizes[idx[1]] - ch_delta]
+            for idx, ch_delta in zip(self._xy_idx, ch_deltas))
+        self._images['chs'] = list()
         for axis in range(3):
-            plot_x_idx, plot_y_idx = self._xy_idx[axis]
             fig = self._figs[axis]
             ax = fig.axes[0]
-            ct_data = np.take(self._ct_data, self._current_slice[axis],
-                              axis=axis).T
-            self._images['ct'].append(ax.imshow(
-                ct_data, cmap='gray', aspect='auto', zorder=1,
-                vmin=ct_min, vmax=ct_max))
-            img_extent = self._img_extents[axis]  # x0, x1, y0, y1
-            w, h = np.diff(np.array(img_extent).reshape(2, 2), axis=1)[:, 0]
-            self._images['ct_bounds'].append(Rectangle(
-                img_extent[::2], w, h, edgecolor='w', facecolor='none',
-                alpha=0.25, lw=0.5, zorder=1.5))
-            ax.add_patch(self._images['ct_bounds'][-1])
             self._images['chs'].append(ax.imshow(
                 self._make_ch_image(axis), aspect='auto',
                 extent=self._ch_extents[axis], zorder=3,
                 cmap=_CMAP, alpha=self._ch_alpha, vmin=0, vmax=_N_COLORS))
-            v_x = (xyz[plot_x_idx],) * 2
-            v_y = img_extent[2:4]
-            self._images['cursor_v'].append(ax.plot(
-                v_x, v_y, color='lime', linewidth=0.5, alpha=0.5, zorder=8)[0])
-            h_y = (xyz[plot_y_idx],) * 2
-            h_x = img_extent[0:2]
-            self._images['cursor_h'].append(ax.plot(
-                h_x, h_y, color='lime', linewidth=0.5, alpha=0.5, zorder=8)[0])
-            # label axes
-            self._figs[axis].text(0.5, 0.05, _IMG_LABELS[axis][0],
-                                  **text_kwargs)
-            self._figs[axis].text(0.05, 0.5, _IMG_LABELS[axis][1],
-                                  **text_kwargs)
-            self._figs[axis].axes[0].axis(img_extent)
-            self._figs[axis].canvas.mpl_connect(
-                'scroll_event', self._on_scroll)
-            self._figs[axis].canvas.mpl_connect(
-                'button_release_event', partial(self._on_click, axis=axis))
-        # add head and brain in mm (convert from m)
-        if self._head is None:
-            logger.info('Using marching cubes on CT for the '
-                        '3D visualization panel')
-            rr, tris = _marching_cubes(np.where(
-                self._ct_data < np.quantile(self._ct_data, 0.95), 0, 1),
-                [1])[0]
-            rr = apply_trans(self._vox_ras_t, rr)
-            self._renderer.mesh(
-                *rr.T, triangles=tris, color='gray', opacity=0.2,
-                reset_camera=False, render=False)
-        else:
-            self._renderer.mesh(
-                *self._head['rr'].T * 1000, triangles=self._head['tris'],
-                color='gray', opacity=0.2, reset_camera=False, render=False)
-        if self._lh is not None and self._rh is not None:
-            self._renderer.mesh(
-                *self._lh['rr'].T * 1000, triangles=self._lh['tris'],
-                color='white', opacity=0.2, reset_camera=False, render=False)
-            self._renderer.mesh(
-                *self._rh['rr'].T * 1000, triangles=self._rh['tris'],
-                color='white', opacity=0.2, reset_camera=False, render=False)
         self._3d_chs = dict()
         for name in self._chs:
             self._plot_3d_ch(name)
-        self._renderer.set_camera(azimuth=90, elevation=90, distance=300,
-                                  focalpoint=tuple(self._ras))
-        # update plots
-        self._draw()
-        self._renderer._update()
-
-    def _update_camera(self, render=False):
-        """Update the camera position."""
-        self._renderer.set_camera(
-            # needs fix, distance moves when focal point updates
-            distance=self._renderer.plotter.camera.distance * 0.9,
-            focalpoint=tuple(self._ras),
-            reset_camera=False)
 
     def _plot_3d_ch(self, name, render=False):
         """Plot a single 3D channel."""
@@ -422,7 +241,7 @@ class IntracranialElectrodeLocator(QMainWindow):
         if render:
             self._renderer._update()
 
-    def _get_button_bar(self):
+    def _configure_toolbar(self):
         """Make a bar with buttons for user interactions."""
         hbox = QHBoxLayout()
 
@@ -476,7 +295,7 @@ class IntracranialElectrodeLocator(QMainWindow):
 
         return hbox
 
-    def _get_slider_bar(self):
+    def _configure_sliders(self):
         """Make a bar with sliders on it."""
 
         def make_label(name):
@@ -529,9 +348,8 @@ class IntracranialElectrodeLocator(QMainWindow):
         slider_hbox.addLayout(ct_slider_vbox)
         return slider_hbox
 
-    def _get_bottom_bar(self):
-        """Make a bar at the bottom with information in it."""
-        hbox = QHBoxLayout()
+    def _configure_status_bar(self, hbox=None):
+        hbox = QHBoxLayout() if hbox is None else hbox
 
         hbox.addStretch(3)
 
@@ -548,25 +366,14 @@ class IntracranialElectrodeLocator(QMainWindow):
         self._intensity_label = QLabel('')  # update later
         hbox.addWidget(self._intensity_label)
 
-        VOX_label = QLabel('VOX =')
-        self._VOX_textbox = QPlainTextEdit('')  # update later
-        self._VOX_textbox.setMaximumHeight(25)
-        self._VOX_textbox.setMaximumWidth(125)
-        self._VOX_textbox.focusOutEvent = self._update_VOX
-        self._VOX_textbox.textChanged.connect(self._check_update_VOX)
-        hbox.addWidget(VOX_label)
-        hbox.addWidget(self._VOX_textbox)
-
-        RAS_label = QLabel('RAS =')
-        self._RAS_textbox = QPlainTextEdit('')  # update later
-        self._RAS_textbox.setMaximumHeight(25)
-        self._RAS_textbox.setMaximumWidth(200)
-        self._RAS_textbox.focusOutEvent = self._update_RAS
-        self._RAS_textbox.textChanged.connect(self._check_update_RAS)
-        hbox.addWidget(RAS_label)
-        hbox.addWidget(self._RAS_textbox)
-        self._update_moved()  # update text now
+        # add SliceBrowser navigation items
+        super(IntracranialElectrodeLocator, self)._configure_status_bar(
+            hbox=hbox)
         return hbox
+
+    def _move_cursors_to_pos(self):
+        super(IntracranialElectrodeLocator, self)._move_cursors_to_pos()
+        self._ch_list.setFocus()  # remove focus from text edit
 
     def _group_channels(self, groups):
         """Automatically find a group based on the name of the channel."""
@@ -638,18 +445,6 @@ class IntracranialElectrodeLocator(QMainWindow):
                     color=_CMAP(group), linewidth=0.25, zorder=7)[0])
             self._lines_2D[group] = lines_2D
 
-    def _set_ch_names(self):
-        """Add the channel names to the selector."""
-        self._ch_list_model = QtGui.QStandardItemModel(self._ch_list)
-        for name in self._ch_names:
-            self._ch_list_model.appendRow(QtGui.QStandardItem(name))
-            self._color_list_item(name=name)
-        self._ch_list.setModel(self._ch_list_model)
-        self._ch_list.clicked.connect(self._go_to_ch)
-        self._ch_list.setCurrentIndex(
-            self._ch_list_model.index(self._ch_index, 0))
-        self._ch_list.keyPressEvent = self._key_press_event
-
     def _select_group(self):
         """Change the group label to the selection."""
         group = self._group_selector.currentIndex()
@@ -665,27 +460,6 @@ class IntracranialElectrodeLocator(QMainWindow):
         self._group_selector.setStyleSheet(
             'background-color: rgb({:d},{:d},{:d})'.format(*rgb))
         self._group_selector.update()
-
-    def _on_scroll(self, event):
-        """Process mouse scroll wheel event to zoom."""
-        self._zoom(event.step, draw=True)
-
-    def _zoom(self, sign=1, draw=False):
-        """Zoom in on the image."""
-        delta = _ZOOM_STEP_SIZE * sign
-        for axis, fig in enumerate(self._figs):
-            xmid = self._images['cursor_v'][axis].get_xdata()[0]
-            ymid = self._images['cursor_h'][axis].get_ydata()[0]
-            xmin, xmax = fig.axes[0].get_xlim()
-            ymin, ymax = fig.axes[0].get_ylim()
-            xwidth = (xmax - xmin) / 2 - delta
-            ywidth = (ymax - ymin) / 2 - delta
-            if xwidth <= 0 or ywidth <= 0:
-                return
-            fig.axes[0].set_xlim(xmid - xwidth, xmid + xwidth)
-            fig.axes[0].set_ylim(ymid - ywidth, ymid + ywidth)
-            if draw:
-                self._figs[axis].canvas.draw()
 
     def _update_ch_selection(self):
         """Update which channel is selected."""
@@ -709,91 +483,6 @@ class IntracranialElectrodeLocator(QMainWindow):
         """Increment the current channel selection index."""
         self._ch_index = (self._ch_index + 1) % len(self._ch_names)
         self._update_ch_selection()
-
-    @Slot()
-    def _update_RAS(self, event):
-        """Interpret user input to the RAS textbox."""
-        text = self._RAS_textbox.toPlainText()
-        ras = self._convert_text(text, 'ras')
-        if ras is not None:
-            self._set_ras(ras)
-
-    @Slot()
-    def _update_VOX(self, event):
-        """Interpret user input to the RAS textbox."""
-        text = self._VOX_textbox.toPlainText()
-        ras = self._convert_text(text, 'vox')
-        if ras is not None:
-            self._set_ras(ras)
-
-    def _convert_text(self, text, text_kind):
-        text = text.replace('\n', '')
-        vals = text.split(',')
-        if len(vals) != 3:
-            vals = text.split(' ')  # spaces also okay as in freesurfer
-        vals = [var.lstrip().rstrip() for var in vals]
-        try:
-            vals = np.array([float(var) for var in vals]).reshape(3)
-        except Exception:
-            self._update_moved()  # resets RAS label
-            return
-        if text_kind == 'vox':
-            vox = vals
-            ras = apply_trans(self._vox_ras_t, vox)
-        else:
-            assert text_kind == 'ras'
-            ras = vals
-            vox = apply_trans(self._ras_vox_t, ras)
-        wrong_size = any(var < 0 or var > n - 1 for var, n in
-                         zip(vox, self._voxel_sizes))
-        if wrong_size:
-            self._update_moved()  # resets RAS label
-            return
-        return ras
-
-    @property
-    def _ras(self):
-        return self._ras_safe
-
-    def _set_ras(self, ras, update_plots=True):
-        ras = np.asarray(ras, dtype=float)
-        assert ras.shape == (3,)
-        msg = ', '.join(f'{x:0.2f}' for x in ras)
-        logger.debug(f'Trying RAS:  ({msg}) mm')
-        # clip to valid
-        vox = apply_trans(self._ras_vox_t, ras)
-        vox = np.array([
-            np.clip(d, 0, self._voxel_sizes[ii] - 1)
-            for ii, d in enumerate(vox)])
-        # transform back, make write-only
-        self._ras_safe = apply_trans(self._vox_ras_t, vox)
-        self._ras_safe.flags['WRITEABLE'] = False
-        msg = ', '.join(f'{x:0.2f}' for x in self._ras_safe)
-        logger.debug(f'Setting RAS: ({msg}) mm')
-        if update_plots:
-            self._move_cursors_to_pos()
-
-    @property
-    def _vox(self):
-        return apply_trans(self._ras_vox_t, self._ras)
-
-    @property
-    def _current_slice(self):
-        return self._vox.round().astype(int)
-
-    @Slot()
-    def _check_update_RAS(self):
-        """Check whether the RAS textbox is done being edited."""
-        if '\n' in self._RAS_textbox.toPlainText():
-            self._update_RAS(event=None)
-            self._ch_list.setFocus()  # remove focus from text edit
-
-    @Slot()
-    def _check_update_VOX(self):
-        """Check whether the VOX textbox is done being edited."""
-        if '\n' in self._VOX_textbox.toPlainText():
-            self._update_VOX(event=None)
-            self._ch_list.setFocus()  # remove focus from text edit
 
     def _color_list_item(self, name=None):
         """Color the item in the view list for easy id of marked channels."""
@@ -861,11 +550,6 @@ class IntracranialElectrodeLocator(QMainWindow):
         self._next_ch()
         self._ch_list.setFocus()
 
-    def _draw(self, axis=None):
-        """Update the figures with a draw call."""
-        for axis in (range(3) if axis is None else [axis]):
-            self._figs[axis].canvas.draw()
-
     def _update_ch_images(self, axis=None, draw=False):
         """Update the channel image(s)."""
         for axis in range(3) if axis is None else [axis]:
@@ -906,11 +590,9 @@ class IntracranialElectrodeLocator(QMainWindow):
 
     def _update_images(self, axis=None, draw=True):
         """Update CT and channel images when general changes happen."""
-        self._update_ct_images(axis=axis)
         self._update_ch_images(axis=axis)
         self._update_mri_images(axis=axis)
-        if draw:
-            self._draw(axis)
+        super()._update_images()
 
     def _update_ct_scale(self):
         """Update CT min slider value."""
@@ -947,16 +629,6 @@ class IntracranialElectrodeLocator(QMainWindow):
             actor.GetProperty().SetOpacity(self._ch_alpha)
         self._renderer._update()
         self._ch_list.setFocus()  # remove focus from 3d plotter
-
-    def _move_cursors_to_pos(self):
-        """Move the cursors to a position."""
-        for axis in range(3):
-            x, y = self._vox[list(self._xy_idx[axis])]
-            self._images['cursor_v'][axis].set_xdata([x, x])
-            self._images['cursor_h'][axis].set_ydata([y, y])
-        self._zoom(0)  # doesn't actually zoom just resets view to center
-        self._update_images(draw=True)
-        self._update_moved()
 
     def _show_help(self):
         """Show the help menu."""
@@ -1055,11 +727,7 @@ class IntracranialElectrodeLocator(QMainWindow):
 
     def _key_press_event(self, event):
         """Execute functions when the user presses a key."""
-        if event.key() == 'escape':
-            self.close()
-
-        if event.text() == 'h':
-            self._show_help()
+        super(IntracranialElectrodeLocator, self)._key_press_event(event)
 
         if event.text() == 'm':
             self._mark_ch()
@@ -1069,48 +737,3 @@ class IntracranialElectrodeLocator(QMainWindow):
 
         if event.text() == 'b':
             self._toggle_show_brain()
-
-        if event.text() in ('=', '+', '-'):
-            self._zoom(sign=-2 * (event.text() == '-') + 1, draw=True)
-
-        # Changing slices
-        if event.key() in (QtCore.Qt.Key_Up, QtCore.Qt.Key_Down,
-                           QtCore.Qt.Key_Left, QtCore.Qt.Key_Right,
-                           QtCore.Qt.Key_Comma, QtCore.Qt.Key_Period,
-                           QtCore.Qt.Key_PageUp, QtCore.Qt.Key_PageDown):
-            ras = np.array(self._ras)
-            if event.key() in (QtCore.Qt.Key_Up, QtCore.Qt.Key_Down):
-                ras[2] += 2 * (event.key() == QtCore.Qt.Key_Up) - 1
-            elif event.key() in (QtCore.Qt.Key_Left, QtCore.Qt.Key_Right):
-                ras[0] += 2 * (event.key() == QtCore.Qt.Key_Right) - 1
-            else:
-                ras[1] += 2 * (event.key() == QtCore.Qt.Key_PageUp or
-                               event.key() == QtCore.Qt.Key_Period) - 1
-            self._set_ras(ras)
-
-    def _on_click(self, event, axis):
-        """Move to view on MRI and CT on click."""
-        if event.inaxes is self._figs[axis].axes[0]:
-            # Data coordinates are voxel coordinates
-            pos = (event.xdata, event.ydata)
-            logger.info(f'Clicked {"XYZ"[axis]} ({axis}) axis at pos {pos}')
-            xyz = self._vox
-            xyz[list(self._xy_idx[axis])] = pos
-            logger.debug(f'Using voxel  {list(xyz)}')
-            ras = apply_trans(self._vox_ras_t, xyz)
-            self._set_ras(ras)
-
-    def _update_moved(self):
-        """Update when cursor position changes."""
-        self._RAS_textbox.setPlainText('{:.2f}, {:.2f}, {:.2f}'.format(
-            *self._ras))
-        self._VOX_textbox.setPlainText('{:3d}, {:3d}, {:3d}'.format(
-            *self._current_slice))
-        self._intensity_label.setText('intensity = {:.2f}'.format(
-            self._ct_data[tuple(self._current_slice)]))
-
-    @safe_event
-    def closeEvent(self, event):
-        """Clean up upon closing the window."""
-        self._renderer.plotter.close()
-        self.close()

--- a/mne/gui/tests/test_core_gui.py
+++ b/mne/gui/tests/test_core_gui.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# Authors: Alex Rockhill <aprockhill@mailbox.org>
+#
+# License: BSD-3-clause
+
+import os.path as op
+import numpy as np
+from numpy.testing import assert_allclose
+
+import pytest
+
+from mne.datasets import testing
+from mne.utils import requires_nibabel, catch_logging, use_log_level
+from mne.viz.utils import _fake_click
+
+data_path = testing.data_path(download=False)
+subject = 'sample'
+subjects_dir = op.join(data_path, 'subjects')
+
+
+@pytest.fixture
+def _slice_browser(renderer_interactive_pyvistaqt):
+    from qtpy.QtWidgets import QApplication
+    from mne.gui._core import SliceBrowser
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication(["Slice Browser"])
+    # Use a fixture to create these classes so we can ensure that they
+    # are closed at the end of the test
+    guis = list()
+
+    def fun(*args, **kwargs):
+        guis.append(SliceBrowser(*args, **kwargs))
+        return guis[-1]
+
+    yield fun
+
+    for gui in guis:
+        try:
+            gui.close()
+        except Exception:
+            pass
+
+
+@requires_nibabel()
+def test_slice_browser_io(_slice_browser):
+    """Test the input/output of the slice browser GUI."""
+    import nibabel as nib
+    with pytest.raises(ValueError, match='Base image is not aligned to MRI'):
+        _slice_browser(nib.MGHImage(
+            np.ones((96, 96, 96), dtype=np.float32), np.eye(4)),
+            subject=subject, subjects_dir=subjects_dir)
+
+
+@testing.requires_testing_data
+def test_slice_browser_display(_slice_browser):
+    """Test that the slice browser GUI displays properly."""
+    # test no seghead, fsaverage doesn't have seghead
+    with pytest.warns(RuntimeWarning, match='`seghead` not found'):
+        with catch_logging() as log:
+            _slice_browser(subject='fsaverage', subjects_dir=subjects_dir,
+                           verbose=True)
+    log = log.getvalue()
+    assert 'using marching cubes' in log
+
+    # test functions
+    with pytest.warns(RuntimeWarning, match='`pial` surface not found'):
+        gui = _slice_browser(subject=subject, subjects_dir=subjects_dir)
+
+    # test RAS
+    gui._RAS_textbox.setPlainText('10 10 10\n')
+    assert_allclose(gui._ras, [10, 10, 10])
+
+    # test vox
+    gui._VOX_textbox.setPlainText('150, 150, 150\n')
+    assert_allclose(gui._ras, [23, 22, 23])
+
+    # test click
+    with use_log_level('debug'):
+        _fake_click(gui._figs[2], gui._figs[2].axes[0],
+                    [137, 140], xform='data', kind='release')
+    assert_allclose(gui._ras, [10, 12, 23])

--- a/mne/gui/tests/test_ieeg_locate_gui.py
+++ b/mne/gui/tests/test_ieeg_locate_gui.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Authors: Alex Rockhill <aprockhill@mailbox.org>
 #
 # License: BSD-3-clause
@@ -11,8 +12,7 @@ import pytest
 import mne
 from mne.datasets import testing
 from mne.transforms import apply_trans
-from mne.utils import (requires_nibabel, requires_version, catch_logging,
-                       use_log_level)
+from mne.utils import requires_nibabel, requires_version, use_log_level
 from mne.viz.utils import _fake_click
 
 data_path = testing.data_path(download=False)
@@ -60,7 +60,6 @@ def _fake_CT_coords(skull_size=5, contact_size=2):
     return ct, coords
 
 
-@requires_nibabel()
 @pytest.fixture
 def _locate_ieeg(renderer_interactive_pyvistaqt):
     # Use a fixture to create these classes so we can ensure that they
@@ -89,11 +88,7 @@ def test_ieeg_elec_locate_gui_io(_locate_ieeg):
     trans = mne.transforms.Transform('head', 'mri')
     with pytest.raises(ValueError,
                        match='No channels found in `info` to locate'):
-        _locate_ieeg(info, aligned_ct, subject, subjects_dir)
-    info = mne.create_info(['test'], 1000, ['seeg'])
-    with pytest.raises(ValueError, match='CT is not aligned to MRI'):
-        _locate_ieeg(info, trans, aligned_ct, subject=subject,
-                     subjects_dir=subjects_dir)
+        _locate_ieeg(info, trans, aligned_ct, subject, subjects_dir)
 
 
 @requires_version('sphinx_gallery')
@@ -140,15 +135,6 @@ def test_ieeg_elec_locate_gui_display(_locate_ieeg, _fake_CT_coords):
     aligned_ct, coords = _fake_CT_coords
     trans = mne.read_trans(fname_trans)
 
-    # test no seghead, fsaverage doesn't have seghead
-    with pytest.warns(RuntimeWarning, match='`seghead` not found'):
-        with catch_logging() as log:
-            _locate_ieeg(raw.info, trans, aligned_ct, subject='fsaverage',
-                         subjects_dir=subjects_dir, verbose=True)
-    log = log.getvalue()
-    assert 'Using marching cubes' in log
-
-    # test functions
     with pytest.warns(RuntimeWarning, match='`pial` surface not found'):
         gui = _locate_ieeg(raw.info, trans, aligned_ct,
                            subject=subject, subjects_dir=subjects_dir,


### PR DESCRIPTION
The goal is to abstract the slice browsing for the other GUI that does time-frequency viewing on a volumetric source estimates. Here is a working version of the slice browser itself:

```
import os.path as op

import numpy as np
import matplotlib.pyplot as plt

import nibabel as nib
import nilearn.plotting
from dipy.align import resample

import mne
from mne.datasets import fetch_fsaverage
from mne.gui._core import SliceBrowser

# paths to mne datasets: sample sEEG and FreeSurfer's fsaverage subject,
# which is in MNI space
misc_path = mne.datasets.misc.data_path()
sample_path = mne.datasets.sample.data_path()
subjects_dir = op.join(sample_path, 'subjects')

# use mne-python's fsaverage data
fetch_fsaverage(subjects_dir=subjects_dir, verbose=True)  # downloads if needed

# GUI requires pyvista backend
mne.viz.set_3d_backend('pyvistaqt')

T1 = nib.load(op.join(misc_path, 'seeg', 'sample_seeg', 'mri', 'T1.mgz'))
CT_orig = nib.load(op.join(misc_path, 'seeg', 'sample_seeg_CT.mgz'))
reg_affine = np.array([
    [0.99270756, -0.03243313, 0.11610254, -133.094156],
    [0.04374389, 0.99439665, -0.09623816, -97.58320673],
    [-0.11233068, 0.10061512, 0.98856381, -84.45551601],
    [0., 0., 0., 1.]])
CT_aligned = mne.transforms.apply_volume_registration(CT_orig, T1, reg_affine)
subj_trans = mne.coreg.estimate_head_mri_t(
    'sample_seeg', op.join(misc_path, 'seeg'))
raw = mne.io.read_raw(op.join(misc_path, 'seeg', 'sample_seeg_ieeg.fif'))

# launch
from qtpy.QtWidgets import QApplication
# get application
app = QApplication.instance()
if app is None:
    app = QApplication(["Slice Browser"])
gui = mne.gui._core.SliceBrowser(CT_aligned, subject='sample_seeg',
                                 subjects_dir=op.join(misc_path, 'seeg'))
gui.show()
```

Here's what it looks like, which would be inserted into any GUI and then the extra visualization is added on the top/bottom/sides:

<img width="846" alt="Screen Shot 2022-06-15 at 4 43 09 PM" src="https://user-images.githubusercontent.com/13473576/173960197-398c2931-bee4-4e7d-b077-c3ee2083f1dc.png">

I was thinking for the TFR viewer the spectrograms/time courses could either be to the side split 50/50 with a smaller slice-browser as in here ![image](https://user-images.githubusercontent.com/13473576/173960281-b8efd3f1-0060-4133-b23e-40a32add315e.png) or between the bottom bar and the slices. Testing changing the window size, keeping proportionality handles much better making the slice browser horizontally narrower so I think option 1 will probably look better. Then buttons to change from power to ITC to time course could be in that panel on the right as well as changing vmin/vmax etc.

I need to:
- [x] Handle CT + MRI vs MRI alone more gracefully
- [x] Reintegrate it with the `ieeg_locate` GUI
- [ ] Take the edits from https://github.com/mne-tools/mne-python/pull/10565 that can be applied to the slice browser and add them in (EDIT: this will be done more slowly in steps per discussion https://github.com/mne-tools/mne-python/issues/10779)