### PR TITLE
MAINT: Better error when missing a file

### DIFF
--- a/mne/io/ctf/eeg.py
+++ b/mne/io/ctf/eeg.py
@@ -22,8 +22,8 @@ _cardinal_dict = dict(nasion=FIFF.FIFFV_POINT_NASION,
 def _read_eeg(directory):
     """Read the .eeg file."""
     # Missing file is ok
-    fname = _make_ctf_name(directory, 'eeg', raise_error=False)
-    if fname is None:
+    fname, found = _make_ctf_name(directory, 'eeg', raise_error=False)
+    if not found:
         logger.info('    Separate EEG position data file not present.')
         return
     eeg = dict(labels=list(), kinds=list(), ids=list(), rr=list(), np=0,

--- a/mne/io/ctf/hc.py
+++ b/mne/io/ctf/hc.py
@@ -64,8 +64,8 @@ def _read_one_coil_point(fid):
 
 def _read_hc(directory):
     """Read the hc file to get the HPI info and to prepare for coord trans."""
-    fname = _make_ctf_name(directory, 'hc', raise_error=False)
-    if fname is None:
+    fname, found = _make_ctf_name(directory, 'hc', raise_error=False)
+    if not found:
         logger.info('    hc data not present')
         return None
     s = list()

--- a/mne/io/ctf/res4.py
+++ b/mne/io/ctf/res4.py
@@ -16,12 +16,12 @@ from .constants import CTF
 def _make_ctf_name(directory, extra, raise_error=True):
     """Make a CTF name."""
     fname = op.join(directory, op.basename(directory)[:-3] + '.' + extra)
+    found = True
     if not op.isfile(fname):
         if raise_error:
             raise IOError('Standard file %s not found' % fname)
-        else:
-            return None
-    return fname
+        found = False
+    return fname, found
 
 
 def _read_double(fid, n=1):
@@ -99,7 +99,7 @@ def _read_comp_coeff(fid, d):
 def _read_res4(dsdir):
     """Read the magical res4 file."""
     # adapted from read_res4.c
-    name = _make_ctf_name(dsdir, 'res4')
+    name, _ = _make_ctf_name(dsdir, 'res4')
     res = dict()
     with open(name, 'rb') as fid:
         # Read the fields

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -26,7 +26,7 @@ from mne.utils import (_clean_names, catch_logging, _stamp_to_dt,
 from mne.datasets import testing, spm_face, brainstorm
 from mne.io.constants import FIFF
 
-ctf_dir = op.join(testing.data_path(download=False), 'CTF')
+ctf_dir = testing.data_path(download=False) / 'CTF'
 ctf_fname_continuous = 'testdata_ctf.ds'
 ctf_fname_1_trial = 'testdata_ctf_short.ds'
 ctf_fname_2_trials = 'testdata_ctf_pseudocontinuous.ds'
@@ -403,6 +403,17 @@ def _bad_res4_grad_comp(dsdir):
             ch['grad_order_no'] = 1
             break
     return res
+
+
+def test_missing_res4(tmp_path):
+    """Test that res4 missing is handled gracefully."""
+    use_ds = tmp_path / ctf_fname_continuous
+    shutil.copytree(ctf_dir / ctf_fname_continuous,
+                    tmp_path / ctf_fname_continuous)
+    read_raw_ctf(use_ds)
+    os.remove(use_ds / (ctf_fname_continuous[:-2] + 'meg4'))
+    with pytest.raises(IOError, match='could not find the following'):
+        read_raw_ctf(use_ds)
 
 
 @testing.requires_testing_data

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -405,6 +405,7 @@ def _bad_res4_grad_comp(dsdir):
     return res
 
 
+@testing.requires_testing_data
 def test_missing_res4(tmp_path):
     """Test that res4 missing is handled gracefully."""
     use_ds = tmp_path / ctf_fname_continuous


### PR DESCRIPTION
Currently when a `.meg4` file cannot be found a cryptic error message is given:
```
UnboundLocalError: local variable 'first_samps' referenced before assignment
```
This raises a proper error like:
```
Could not find any data, could not find the following files: ['testdata_ctf.meg4'], and the following files had no valid samples: []
```
No need for a `latest.inc` here I think since it just improves an error message.