### PR TITLE
FIX: Remove most warning skips

### DIFF
--- a/.github/workflows/compat_old.yml
+++ b/.github/workflows/compat_old.yml
@@ -24,6 +24,7 @@ jobs:
       OPENBLAS_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
       PYTHON_VERSION: '3.7'
+      MNE_IGNORE_WARNINGS_IN_TESTS: 'true'
     steps:
       - uses: actions/checkout@v3
       - run: ./tools/setup_xvfb.sh

--- a/examples/decoding/decoding_unsupervised_spatial_filter.py
+++ b/examples/decoding/decoding_unsupervised_spatial_filter.py
@@ -63,7 +63,8 @@ ev.plot(show=False, window_title="PCA", time_unit='s')
 
 ##############################################################################
 # Transform data with ICA computed on the raw epochs (no averaging)
-ica = UnsupervisedSpatialFilter(FastICA(30), average=False)
+ica = UnsupervisedSpatialFilter(
+    FastICA(30, whiten='unit-variance'), average=False)
 ica_data = ica.fit_transform(X)
 ev1 = mne.EvokedArray(np.mean(ica_data, axis=0),
                       mne.create_info(30, epochs.info['sfreq'],

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -282,7 +282,6 @@ def test_read_ch_adjacency(tmp_path):
 
 def _download_ft_neighbors(target_dir):
     """Download the known neighbors from FieldTrip."""
-
     # The entire FT repository is larger than a GB, so we'll just download
     # the few files we need.
     def _download_one_ft_neighbor(

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -282,14 +282,15 @@ def test_read_ch_adjacency(tmp_path):
 
 def _download_ft_neighbors(target_dir):
     """Download the known neighbors from FieldTrip."""
-    import pooch
-    pooch.get_logger().setLevel('ERROR')  # reduce verbosity
 
     # The entire FT repository is larger than a GB, so we'll just download
     # the few files we need.
     def _download_one_ft_neighbor(
         neighbor: _BuiltinChannelAdjacency
     ):
+        # Log level setting must happen inside the job to work properly
+        import pooch
+        pooch.get_logger().setLevel('ERROR')  # reduce verbosity
         fname = neighbor.fname
         url = neighbor.source_url
 

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -264,7 +264,7 @@ def test_watershed_bem(tmp_path):
         assert_allclose(vol_info['cras'], Pxyz_c, **kwargs)
 
 
-@pytest.mark.timeout(120)  # took ~70 sec locally
+@pytest.mark.timeout(180)  # took ~70 sec locally
 @pytest.mark.slowtest
 @pytest.mark.ultraslowtest
 @requires_freesurfer

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -105,6 +105,8 @@ def pytest_configure(config):
     ignore:Passing unrecognized arguments to super.*:DeprecationWarning
     # notebook tests
     ignore:There is no current event loop:DeprecationWarning
+    # ignore if joblib is missing
+    ignore:joblib not installed.*:RuntimeWarning
     # TODO: This is indicative of a problem
     ignore:.*Matplotlib is currently using agg.*:
     # qdarkstyle

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -105,6 +105,7 @@ def pytest_configure(config):
     ignore:Passing unrecognized arguments to super.*:DeprecationWarning
     # notebook tests
     ignore:There is no current event loop:DeprecationWarning
+    ignore:unclosed <socket\.socket:ResourceWarning
     # ignore if joblib is missing
     ignore:joblib not installed.*:RuntimeWarning
     # TODO: This is indicative of a problem

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -115,6 +115,8 @@ def pytest_configure(config):
     ignore:.*Setting theme=.*:RuntimeWarning
     # scikit-learn using this arg
     ignore:.*The 'sym_pos' keyword is deprecated.*:DeprecationWarning
+    # Should be removable by 2022/07/08, SciPy savemat issue
+    ignore:.*elementwise comparison failed; returning scalar in.*:FutureWarning
     """.format(first_kind)  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -101,6 +101,8 @@ def pytest_configure(config):
     ignore:Passing unrecognized arguments to super.*:DeprecationWarning
     # notebook tests
     ignore:There is no current event loop:DeprecationWarning
+    # old NumPy/SciPy checks
+    ignore:numpy\.ufunc size changed.*:RuntimeWarning
     # TODO: This is indicative of a problem
     ignore:.*Matplotlib is currently using agg.*:
     # qdarkstyle

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -106,6 +106,7 @@ def pytest_configure(config):
     # notebook tests
     ignore:There is no current event loop:DeprecationWarning
     ignore:unclosed <socket\.socket:ResourceWarning
+    ignore:unclosed event loop <:ResourceWarning
     # ignore if joblib is missing
     ignore:joblib not installed.*:RuntimeWarning
     # TODO: This is indicative of a problem

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -95,21 +95,23 @@ def pytest_configure(config):
     #   we should remove them from here.
     # - This list should also be considered alongside reset_warnings in
     #   doc/conf.py.
+    if os.getenv('MNE_IGNORE_WARNINGS_IN_TESTS', '') != 'true':
+        first_kind = 'error'
+    else:
+        first_kind = 'always'
     warning_lines = r"""
-    error::
+    {0}::
     # matplotlib->traitlets (notebook)
     ignore:Passing unrecognized arguments to super.*:DeprecationWarning
     # notebook tests
     ignore:There is no current event loop:DeprecationWarning
-    # old NumPy/SciPy checks
-    ignore:numpy\.ufunc size changed.*:RuntimeWarning
     # TODO: This is indicative of a problem
     ignore:.*Matplotlib is currently using agg.*:
     # qdarkstyle
     ignore:.*Setting theme=.*:RuntimeWarning
     # scikit-learn using this arg
     ignore:.*The 'sym_pos' keyword is deprecated.*:DeprecationWarning
-    """  # noqa: E501
+    """.format(first_kind)  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()
         if warning_line and not warning_line.startswith('#'):

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -97,67 +97,10 @@ def pytest_configure(config):
     #   doc/conf.py.
     warning_lines = r"""
     error::
-    ignore:.*deprecated and ignored since IPython.*:DeprecationWarning
-    ignore::ImportWarning
-    ignore:the matrix subclass:PendingDeprecationWarning
-    ignore:numpy.dtype size changed:RuntimeWarning
-    ignore:.*takes no parameters:DeprecationWarning
-    ignore:joblib not installed:RuntimeWarning
-    ignore:Using a non-tuple sequence for multidimensional indexing:FutureWarning
-    ignore:using a non-integer number instead of an integer will result in an error:DeprecationWarning
-    ignore:Importing from numpy.testing.decorators is deprecated:DeprecationWarning
-    ignore:np.loads is deprecated, use pickle.loads instead:DeprecationWarning
-    ignore:The oldnumeric module will be dropped:DeprecationWarning
-    ignore:Collection picker None could not be converted to float:UserWarning
-    ignore:covariance is not positive-semidefinite:RuntimeWarning
-    ignore:Can only plot ICA components:RuntimeWarning
-    ignore:Matplotlib is building the font cache using fc-list:UserWarning
-    ignore:Using or importing the ABCs from 'collections':DeprecationWarning
-    ignore:`formatargspec` is deprecated:DeprecationWarning
-    # This is only necessary until sklearn updates their wheels for NumPy 1.16
-    ignore:numpy.ufunc size changed:RuntimeWarning
-    ignore:.*mne-realtime.*:DeprecationWarning
-    ignore:.*imp.*:DeprecationWarning
-    ignore:Exception creating Regex for oneOf.*:SyntaxWarning
-    ignore:scipy\.gradient is deprecated.*:DeprecationWarning
-    ignore:The sklearn.*module.*deprecated.*:FutureWarning
-    ignore:.*rich_compare.*metadata.*deprecated.*:DeprecationWarning
-    ignore:.*In future, it will be an error for 'np.bool_'.*:DeprecationWarning
-    ignore:.*`np.bool` is a deprecated alias.*:DeprecationWarning
-    ignore:.*`np.int` is a deprecated alias.*:DeprecationWarning
-    ignore:.*`np.float` is a deprecated alias.*:DeprecationWarning
-    ignore:.*`np.object` is a deprecated alias.*:DeprecationWarning
-    ignore:.*`np.long` is a deprecated alias:DeprecationWarning
-    ignore:.*Converting `np\.character` to a dtype is deprecated.*:DeprecationWarning
-    ignore:.*sphinx\.util\.smartypants is deprecated.*:
-    ignore:.*pandas\.util\.testing is deprecated.*:
-    ignore:.*tostring.*is deprecated.*:DeprecationWarning
-    ignore:.*QDesktopWidget\.availableGeometry.*:DeprecationWarning
-    ignore:Unable to enable faulthandler.*:UserWarning
-    ignore:Fetchers from the nilearn.*:FutureWarning
-    ignore:SelectableGroups dict interface is deprecated\. Use select\.:DeprecationWarning
-    always:.*get_data.* is deprecated in favor of.*:DeprecationWarning
-    ignore:.*rcParams is deprecated.*global_theme.*:DeprecationWarning
-    ignore:.*distutils\.sysconfig module is deprecated.*:DeprecationWarning
-    ignore:.*numpy\.dual is deprecated.*:DeprecationWarning
-    ignore:.*`np.typeDict` is a deprecated.*:DeprecationWarning
-    ignore:.*Creating an ndarray from ragged.*:numpy.VisibleDeprecationWarning
-    ignore:^Please use.*scipy\..*:DeprecationWarning
-    ignore:.*Passing a schema to Validator.*:DeprecationWarning
-    ignore:.*Found the following unknown channel type.*:RuntimeWarning
-    ignore:.*np\.MachAr.*:DeprecationWarning
-    ignore:.*Passing unrecognized arguments to super.*:DeprecationWarning
-    ignore:.*numpy.ndarray size changed.*:
-    ignore:.*There is no current event loop.*:DeprecationWarning
-    # present in nilearn v 0.8.1, fixed in nilearn main
-    ignore:.*distutils Version classes are deprecated.*:DeprecationWarning
-    ignore:.*pandas\.Int64Index is deprecated.*:FutureWarning
-    always::ResourceWarning
-    # Jupyter notebook stuff
-    ignore:.*unclosed context <zmq\.asyncio\.*:ResourceWarning
-    ignore:.*unclosed event loop <.*:ResourceWarning
-    # https://github.com/dipy/dipy/pull/2558
-    ignore:.*starting_affine overwritten by centre_of_mass transform.*:
+    # matplotlib->traitlets (notebook)
+    ignore:Passing unrecognized arguments to super.*:DeprecationWarning
+    # notebook tests
+    ignore:There is no current event loop:DeprecationWarning
     # TODO: This is indicative of a problem
     ignore:.*Matplotlib is currently using agg.*:
     # qdarkstyle

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -46,9 +46,6 @@ montage_path = op.join(base_dir, 'test_chans.locs')
 
 
 pymatreader = pytest.importorskip('pymatreader')  # module-level
-# https://gitlab.com/obob/pymatreader/-/issues/13
-filt_warn = pytest.mark.filterwarnings(  # scipy.io.savemat + pymatreader
-    'ignore:.*returning scalar instead.*:FutureWarning')
 
 
 @testing.requires_testing_data
@@ -104,7 +101,6 @@ def test_io_set_raw(fname):
 
 
 @testing.requires_testing_data
-@filt_warn
 def test_io_set_raw_more(tmp_path):
     """Test importing EEGLAB .set files."""
     tmp_path = str(tmp_path)
@@ -281,7 +277,6 @@ def test_io_set_epochs_events(tmp_path):
 
 
 @testing.requires_testing_data
-@filt_warn
 def test_degenerate(tmp_path):
     """Test some degenerate conditions."""
     # test if .dat file raises an error
@@ -381,9 +376,8 @@ def one_chanpos_fname(tmp_path_factory):
         )
     })
 
-    with _record_warnings():  # savemat
-        io.savemat(file_name=fname, mdict=file_conent, appendmat=False,
-                   oned_as='row')
+    io.savemat(file_name=fname, mdict=file_conent, appendmat=False,
+               oned_as='row')
 
     return fname
 

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -20,7 +20,7 @@ from mne.io import read_raw_eeglab
 from mne.io.eeglab.eeglab import _get_montage_information, _dol_to_lod
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.datasets import testing
-from mne.utils import Bunch, _record_warnings
+from mne.utils import Bunch
 from mne.annotations import events_from_annotations, read_annotations
 
 base_dir = op.join(testing.data_path(download=False), 'EEGLAB')

--- a/mne/io/nirx/tests/test_nirx.py
+++ b/mne/io/nirx/tests/test_nirx.py
@@ -261,7 +261,7 @@ def test_nirx_dat_warn(tmp_path):
     os.rename(tmp_path / "data" / "NIRS-2019-08-23_001.dat",
               tmp_path / "data" / "NIRS-2019-08-23_001.tmp")
     fname = tmp_path / "data" / "NIRS-2019-08-23_001.hdr"
-    with pytest.raises(RuntimeWarning, match='A single dat'):
+    with pytest.warns(RuntimeWarning, match='A single dat'):
         read_raw_nirx(fname, preload=True)
 
 

--- a/mne/preprocessing/_csd.py
+++ b/mne/preprocessing/_csd.py
@@ -288,9 +288,7 @@ def compute_bridged_electrodes(inst, lm_cutoff=16, epoch_threshold=0.5,
 
     # kernel density estimation
     kde = gaussian_kde(ed_flat[ed_flat < lm_cutoff])
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            'ignore', 'invalid value encountered in true_divide')
+    with np.errstate(invalid='ignore'):
         local_minimum = float(minimize_scalar(
             lambda x: kde(x) if x < lm_cutoff and x > 0 else np.inf).x)
     logger.info(f'Local minimum {local_minimum} found')

--- a/mne/preprocessing/_csd.py
+++ b/mne/preprocessing/_csd.py
@@ -12,7 +12,6 @@
 # License: Relicensed under BSD-3-Clause and adapted with
 #          permission from authors of original GPL code
 
-import warnings
 import numpy as np
 
 from .. import pick_types

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -2797,7 +2797,7 @@ def compute_distance_to_sensors(src, info, picks=None, trans=None,
 
     # get vertex position in same coordinates as for sensors below
     src_pos = np.vstack([
-        apply_trans(src_trans, s['rr'][s['inuse'].astype(np.bool)])
+        apply_trans(src_trans, s['rr'][s['inuse'].astype(bool)])
         for s in src
     ])
 

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -569,7 +569,8 @@ def test_annotation_concat():
     assert_equal(len(c), 6)
 
     # c should have updated channel names
-    assert_array_equal(c.ch_names, [('1',), ('2',), (), (), ('3',), ()])
+    want_names = np.array([('1',), ('2',), (), (), ('3',), ()], dtype='O')
+    assert_array_equal(c.ch_names, want_names)
 
     # test += operator (modifies a in place)
     a += b

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -116,7 +116,7 @@ def test_cov_mismatch():
             epochs_2.info['dev_head_t'] = None
         pytest.raises(ValueError, compute_covariance, [epochs, epochs_2])
         compute_covariance([epochs, epochs_2], on_mismatch='ignore')
-        with pytest.raises(RuntimeWarning, match='transform mismatch'):
+        with pytest.warns(RuntimeWarning, match='transform mismatch'):
             compute_covariance([epochs, epochs_2], on_mismatch='warn')
         with pytest.raises(ValueError, match='Invalid value'):
             compute_covariance(epochs, on_mismatch='x')

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -1150,7 +1150,7 @@ def plot_ideal_filter(freq, gain, axes=None, title='', flim=None, fscale='log',
         >>> from mne.viz import plot_ideal_filter
         >>> freq = [0, 1, 40, 50]
         >>> gain = [0, 1, 1, 0]
-        >>> plot_ideal_filter(freq, gain, flim=(0.1, 100))  #doctest: +ELLIPSIS
+        >>> plot_ideal_filter(freq, gain, flim=(0.1, 100))  #doctest: +SKIP
         <...Figure...>
     """
     import matplotlib.pyplot as plt

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -180,7 +180,7 @@ def _proj_click(idx, fig, browse_backend):
         # (also see comment in test_plot_raw_selection).
         ssp_fig._proj_changed(not fig.mne.projs_on[idx], idx)
         # Update Checkbox
-        ssp_fig.checkboxes[idx].setChecked(fig.mne.projs_on[idx])
+        ssp_fig.checkboxes[idx].setChecked(bool(fig.mne.projs_on[idx]))
 
 
 def _proj_click_all(fig, browse_backend):

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -711,4 +711,4 @@ N1 ERP component</li>
 """
 
 report.add_html(title='Hypothesis', html=my_html)
-report.save('report_add_html.html')
+report.save('report_add_html.html', overwrite=True)

--- a/tutorials/preprocessing/25_background_filtering.py
+++ b/tutorials/preprocessing/25_background_filtering.py
@@ -261,7 +261,7 @@ plot_ideal_filter(freq, gain, ax, title=title, flim=flim)
 # gradual slope through the transition region, but a *much* cleaner time
 # domain signal. Here again for the 1 s filter:
 
-h = signal.firwin2(n, freq, gain, nyq=nyq)
+h = signal.firwin2(n, freq, gain, fs=sfreq)
 plot_filter(h, sfreq, freq, gain, 'Windowed 10 Hz transition (1.0 s)',
             compensate=True, **kwargs)
 
@@ -273,7 +273,7 @@ plot_filter(h, sfreq, freq, gain, 'Windowed 10 Hz transition (1.0 s)',
 # sphinx_gallery_thumbnail_number = 7
 
 n = int(round(sfreq * 0.5)) + 1
-h = signal.firwin2(n, freq, gain, nyq=nyq)
+h = signal.firwin2(n, freq, gain, fs=sfreq)
 plot_filter(h, sfreq, freq, gain, 'Windowed 10 Hz transition (0.5 s)',
             compensate=True, **kwargs)
 
@@ -282,7 +282,7 @@ plot_filter(h, sfreq, freq, gain, 'Windowed 10 Hz transition (0.5 s)',
 # our effective stop frequency gets pushed out past 60 Hz:
 
 n = int(round(sfreq * 0.2)) + 1
-h = signal.firwin2(n, freq, gain, nyq=nyq)
+h = signal.firwin2(n, freq, gain, fs=sfreq)
 plot_filter(h, sfreq, freq, gain, 'Windowed 10 Hz transition (0.2 s)',
             compensate=True, **kwargs)
 
@@ -293,7 +293,7 @@ plot_filter(h, sfreq, freq, gain, 'Windowed 10 Hz transition (0.2 s)',
 trans_bandwidth = 25
 f_s = f_p + trans_bandwidth
 freq = [0, f_p, f_s, nyq]
-h = signal.firwin2(n, freq, gain, nyq=nyq)
+h = signal.firwin2(n, freq, gain, fs=sfreq)
 plot_filter(h, sfreq, freq, gain, 'Windowed 50 Hz transition (0.2 s)',
             compensate=True, **kwargs)
 


### PR DESCRIPTION
We shouldn't need some warning skips I put in recently as they should have been fixed by https://github.com/scipy/scipy/pull/16393 .

While we're at it, I figured we should see how many other warning skips we can remove completely. Tests pass locally for me with these changes, but I expect some issues with the old/compat builds.

There is a list in `doc/conf.py` that should be updated, too, but I'll do that in a separate PR. I'll iterate locally on that one first to save CircleCI some time.

Closes #10837