### PR TITLE
MRG: Change orig_format for EGI, BrainVision ASCII and artemis123 recordings to "single"

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -178,7 +178,7 @@ Bugs
 
 - Correctly report the number of available projections when printing measurement info in a Jupyter notebook (:gh:`10471` by `Clemens Brunner`_)
 
-- Fix value set in ``raw.orig_format`` for readers of BrainVision (ASCII format) and EGI files (:gh:`10851` by `Mathieu Scheltienne`_)
+- Fix value set in ``raw.orig_format`` for readers of BrainVision (ASCII format), EGI and Artemis123 files (:gh:`10851` by `Mathieu Scheltienne`_)
 
 
 API and behavior changes

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -178,6 +178,8 @@ Bugs
 
 - Correctly report the number of available projections when printing measurement info in a Jupyter notebook (:gh:`10471` by `Clemens Brunner`_)
 
+- Fix value set in ``raw.orig_format`` for readers of BrainVision (ASCII format) and EGI files (:gh:`10851` by `Mathieu Scheltienne`_)
+
 
 API and behavior changes
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -326,7 +326,7 @@ class RawArtemis123(BaseRaw):
 
         super(RawArtemis123, self).__init__(
             info, preload, filenames=[input_fname], raw_extras=[header_info],
-            last_samps=last_samps, orig_format=np.float32,
+            last_samps=last_samps, orig_format="single",
             verbose=verbose)
 
         if add_head_trans:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -239,6 +239,10 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                         % self._read_comp_grade)
         self._comp = None
         self._filenames = list(filenames)
+        _validate_type(orig_format, str, "orig_format")
+        _check_option(
+            "orig_format", orig_format, ("double", "single", "int", "short")
+        )
         self.orig_format = orig_format
         # Sanity check and set original units, if provided by the reader:
 

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -92,11 +92,12 @@ class RawBrainVision(BaseRaw):
                 offsets = None
                 n_samples = n_samples // (dtype_bytes * n_data_ch)
 
+        orig_format = "single" if isinstance(fmt, dict) else fmt
         raw_extras = dict(
             offsets=offsets, fmt=fmt, order=order, n_samples=n_samples)
         super(RawBrainVision, self).__init__(
             info, last_samps=[n_samples - 1], filenames=[data_fname],
-            orig_format=fmt, preload=preload, verbose=verbose,
+            orig_format=orig_format, preload=preload, verbose=verbose,
             raw_extras=[raw_extras], orig_units=orig_units)
 
         self.set_montage(montage)

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -294,6 +294,7 @@ def test_ascii(tmp_path, data_sep):
         return
 
     raw = read_raw_brainvision(ascii_vhdr_path)
+    assert isinstance(raw.orig_format, str)
     data_new, times_new = raw[:]
     assert_allclose(data_new, data, atol=1e-15)
     assert_allclose(times_new, times)

--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -258,8 +258,8 @@ class RawEGI(BaseRaw):
         info['chs'] = chs
         info._unlocked = False
         info._update_redundant()
-        orig_format = egi_info['orig_format'] \
-            if egi_info['orig_format'] != "float" else "single"
+        orig_format = egi_info["orig_format"] \
+            if egi_info["orig_format"] != "float" else "single"
         super(RawEGI, self).__init__(
             info, preload, orig_format=orig_format,
             filenames=[input_fname], last_samps=[egi_info['n_samples'] - 1],

--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -258,8 +258,10 @@ class RawEGI(BaseRaw):
         info['chs'] = chs
         info._unlocked = False
         info._update_redundant()
+        orig_format = egi_info['orig_format'] \
+            if egi_info['orig_format'] != "float" else "single"
         super(RawEGI, self).__init__(
-            info, preload, orig_format=egi_info['orig_format'],
+            info, preload, orig_format=orig_format,
             filenames=[input_fname], last_samps=[egi_info['n_samples'] - 1],
             raw_extras=[egi_info], verbose=verbose)
 

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -548,7 +548,7 @@ class RawMff(BaseRaw):
         self._raw_extras = [egi_info]
 
         super(RawMff, self).__init__(
-            info, preload=preload, orig_format='float', filenames=[file_bin],
+            info, preload=preload, orig_format='single', filenames=[file_bin],
             first_samps=first_samps, last_samps=last_samps,
             raw_extras=[egi_info], verbose=verbose)
 

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -548,7 +548,7 @@ class RawMff(BaseRaw):
         self._raw_extras = [egi_info]
 
         super(RawMff, self).__init__(
-            info, preload=preload, orig_format='single', filenames=[file_bin],
+            info, preload=preload, orig_format="single", filenames=[file_bin],
             first_samps=first_samps, last_samps=last_samps,
             raw_extras=[egi_info], verbose=verbose)
 

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -129,6 +129,7 @@ def test_io_egi_mff():
     """Test importing EGI MFF simple binary files."""
     raw = read_raw_egi(egi_mff_fname, include=None)
     assert ('RawMff' in repr(raw))
+    assert raw.orig_format == "single"
     include = ['DIN1', 'DIN2', 'DIN3', 'DIN4', 'DIN5', 'DIN7']
     raw = _test_raw_reader(read_raw_egi, input_fname=egi_mff_fname,
                            include=include, channel_naming='EEG %03d',
@@ -198,7 +199,7 @@ def test_io_egi():
                            )
 
     assert 'eeg' in raw
-
+    assert raw.orig_format == "single"
     eeg_chan = [c for c in raw.ch_names if c.startswith('E')]
     assert len(eeg_chan) == 256
     picks = pick_types(raw.info, eeg=True)


### PR DESCRIPTION
Closes #10848.

I'm, 99% sure the `dtype` for EGI recordings is `float32`, and that seems coherent with the code in MNE (`'<f4'` and in `mffpy`). Instead of setting the `.orig_format` attribute to `"float"`, it now sets the attribute to `"single"`.
EDIT: I've checked the specification, it is float32.

The QT browser is compatible with `"single", "double", "int", and "short"`: https://github.com/mne-tools/mne-qt-browser/blob/d9c23703658abfc56113cdaff8470952bf3100b1/mne_qt_browser/_pg_figure.py#L3853-L3856

I added a check of the `orig_format` value in `BaseRaw.__init__`, let's see if other readers provide a different value.