### PR TITLE
BUG: Fix bug on CTF + Windows

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -124,6 +124,8 @@ Bugs
 
 - Fix bug in :func:`mne.io.read_raw_bti` where unknown electrode locations were not handled properly (:gh:`10662` by `Eric Larson`_)
 
+- Fix bug in :func:`mne.io.read_raw_ctf` on Windows where large files could not be read (:gh:`10866` by `Eric Larson`_)
+
 - Rendering issues with recent MESA releases can be avoided by setting the new environment variable``MNE_3D_OPTION_MULTI_SAMPLES=1`` or using :func:`mne.viz.set_3d_options` (:gh:`10513` by `Eric Larson`_)
 
 - Fix behavior for the ``pyvista`` 3D renderer's ``quiver3D`` function so that default arguments plot a glyph in ``arrow`` mode (:gh:`10493` by `Alex Rockhill`_)

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -182,8 +182,11 @@ class RawCTF(BaseRaw):
                 samp_offset = (bi + trial_start_idx) * si['res4_nsamp']
                 n_read = min(si['n_samp_tot'] - samp_offset, si['block_size'])
                 # read the chunk of data
-                pos = CTF.HEADER_SIZE
-                pos += samp_offset * si['n_chan'] * 4
+                # have to be careful on Windows and make sure we are using
+                # 64-bit integers here
+                with np.errstate(over='raise'):
+                    pos = np.int64(CTF.HEADER_SIZE)
+                    pos += np.int64(samp_offset) * si['n_chan'] * 4
                 fid.seek(pos, 0)
                 this_data = np.fromfile(fid, '>i4',
                                         count=si['n_chan'] * n_read)


### PR DESCRIPTION
Fix an overflow error that prevents reading large files on Windows. No new test added because we'd need a file > 4 GB and I'm not sure how to mock one.