### PR TITLE
Relax the type checking for the cnorm paramter of plot_topomap

### DIFF
--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -687,7 +687,7 @@ def test_plot_topomap_cnorm():
         from matplotlib.colors import TwoSlopeNorm
     else:
         from matplotlib.colors import DivergingNorm as TwoSlopeNorm
-    from matplotlib.colors import CenteredNorm
+    from matplotlib.colors import PowerNorm
 
     rng = np.random.default_rng(42)
     v = rng.uniform(low=-1, high=2.5, size=64)
@@ -711,7 +711,7 @@ def test_plot_topomap_cnorm():
         plot_topomap(v, info, vmax=10, cnorm=cnorm)
 
     # try another subclass of mpl.colors.Normalize
-    plot_topomap(v, info, cnorm=CenteredNorm())
+    plot_topomap(v, info, cnorm=PowerNorm(0.5))
 
 
 def test_plot_bridged_electrodes():

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -687,6 +687,7 @@ def test_plot_topomap_cnorm():
         from matplotlib.colors import TwoSlopeNorm
     else:
         from matplotlib.colors import DivergingNorm as TwoSlopeNorm
+    from matplotlib.colors import CenteredNorm
 
     rng = np.random.default_rng(42)
     v = rng.uniform(low=-1, high=2.5, size=64)
@@ -708,6 +709,9 @@ def test_plot_topomap_cnorm():
     msg = "vmax=2.5 is implicitly defined by cnorm, ignoring vmax=10.*"
     with pytest.warns(RuntimeWarning, match=msg):
         plot_topomap(v, info, vmax=10, cnorm=cnorm)
+
+    # try another subclass of mpl.colors.Normalize
+    plot_topomap(v, info, cnorm=CenteredNorm())
 
 
 def test_plot_bridged_electrodes():

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -28,7 +28,7 @@ from ..io.pick import (pick_types, _picks_by_type, pick_info, pick_channels,
                        _MEG_CH_TYPES_SPLIT)
 from ..utils import (_clean_names, _time_mask, verbose, logger, fill_doc,
                      _validate_type, _check_sphere, _check_option, _is_numeric,
-                     warn, check_version)
+                     warn)
 from .utils import (tight_layout, _setup_vmin_vmax, _prepare_trellis,
                     _check_delayed_ssp, _draw_proj_checkbox, figure_nobar,
                     plt_show, _process_times, DraggableColorbar,

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -793,11 +793,8 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     for more details on colormap normalization.
     """
     sphere = _check_sphere(sphere)
-    if check_version("matplotlib", "3.2.0"):
-        from matplotlib.colors import TwoSlopeNorm
-    else:
-        from matplotlib.colors import DivergingNorm as TwoSlopeNorm
-    _validate_type(cnorm, (TwoSlopeNorm, None), 'cnorm')
+    from matplotlib.colors import Normalize
+    _validate_type(cnorm, (Normalize, None), 'cnorm')
     if cnorm is not None:
         if vmin is not None:
             warn(f"vmin={cnorm.vmin} is implicitly defined by cnorm, ignoring "


### PR DESCRIPTION
`mne.viz.plot_topomap` takes a `cnorm` parameter to allow one to pass a [`matplotlib.colors.Normalize`](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.Normalize.html#matplotlib.colors.Normalize) object to control how the colormap is applied to the values. Common use cases is to force the 0 to be at the center of the colormap. Before, only `TwoSlopeNorm` was allowed, but there is no reason not to accept all subclasses of `Normalize` here.

closes #10871 
