### PR TITLE
fix contrib guide

### DIFF
--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -886,12 +886,16 @@ all the documentation and additionally execute just your example or tutorial
 you expect).
 
 .. note::
-   On Windows, to use the pattern approach, use the following two lines:
+   If you are using a *Windows command shell*, to use the pattern approach,
+   use the following two lines:
 
    .. code-block:: python
 
-      set PATTERN={<REGEX_TO_SELECT_MY_TUTORIAL>}
+      set PATTERN=<REGEX_TO_SELECT_MY_TUTORIAL>
       make html_dev-pattern
+
+    If you are on Windows but using the `git BASH`_ shell, use the same two
+    commands but replace ``set`` with ``export``.
 
 After either of these commands completes, ``make show`` will open the
 locally-rendered documentation site in your browser. Additional ``make``
@@ -1017,7 +1021,6 @@ it can serve as a useful example of what to expect from the PR review process.
 .. git installation
 
 .. _the .dmg installer: https://git-scm.com/download/mac
-.. _git for Windows: https://gitforwindows.org/
 .. _official Linux instructions: https://git-scm.com/download/linux
 .. _more detailed instructions and alternatives: https://www.atlassian.com/git/tutorials/install-git
 .. _Windows subsystem for Linux: https://docs.microsoft.com/en-us/windows/wsl/about
@@ -1027,8 +1030,6 @@ it can serve as a useful example of what to expect from the PR review process.
 
 .. github help pages
 
-.. _GitHub Help: https://help.github.com
-.. _GitHub learning lab: https://lab.github.com/
 .. _fork: https://help.github.com/en/articles/fork-a-repo
 .. _clone: https://help.github.com/en/articles/cloning-a-repository
 .. _push: https://help.github.com/en/articles/pushing-to-a-remote

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -894,8 +894,8 @@ you expect).
       > set PATTERN=<REGEX_TO_SELECT_MY_TUTORIAL>
       > make html_dev-pattern
 
-    If you are on Windows but using the `git BASH`_ shell, use the same two
-    commands but replace ``set`` with ``export``.
+   If you are on Windows but using the `git BASH`_ shell, use the same two
+   commands but replace ``set`` with ``export``.
 
 After either of these commands completes, ``make show`` will open the
 locally-rendered documentation site in your browser. Additional ``make``

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -889,10 +889,10 @@ you expect).
    If you are using a *Windows command shell*, to use the pattern approach,
    use the following two lines:
 
-   .. code-block:: python
+   .. code-block:: doscon
 
-      set PATTERN=<REGEX_TO_SELECT_MY_TUTORIAL>
-      make html_dev-pattern
+      > set PATTERN=<REGEX_TO_SELECT_MY_TUTORIAL>
+      > make html_dev-pattern
 
     If you are on Windows but using the `git BASH`_ shell, use the same two
     commands but replace ``set`` with ``export``.

--- a/doc/links.inc
+++ b/doc/links.inc
@@ -132,7 +132,10 @@
 .. _git: https://git-scm.com/
 .. _github: https://github.com
 .. _GitHub Help: https://help.github.com
+.. _GitHub learning lab: https://lab.github.com/
 .. _pro git book: https://git-scm.com/book/
+.. _git bash: https://gitforwindows.org/
+.. _git for Windows: https://gitforwindows.org/
 .. _git clone: http://schacon.github.com/git/git-clone.html
 .. _git checkout: https://schacon.github.io/git/git-checkout.html
 .. _git commit: https://schacon.github.io/git/git-commit.html


### PR DESCRIPTION
updates our guidance on using `make` in windows.

I started to deduplicate the links on that page with `links.inc` but will leave that for another PR.