### PR TITLE
Use np.linalg.multi_dot instead of multiple np.dot routines

### DIFF
--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -547,7 +547,7 @@ class CSP(TransformerMixin, BaseEstimator):
             aa, bb = 0, 0
             for (cov, prob) in zip(covs, class_probas):
                 tmp = np.linalg.multi_dot([eigen_vectors[:, jj].T, cov,
-                    eigen_vectors[:, jj]])
+                                          eigen_vectors[:, jj]])
                 aa += prob * np.log(np.sqrt(tmp))
                 bb += prob * (tmp ** 2 - 1)
             mi = - (aa + (3.0 / 16) * (bb ** 2))
@@ -561,7 +561,7 @@ class CSP(TransformerMixin, BaseEstimator):
 
         for ii in range(eigen_vectors.shape[1]):
             tmp = np.linalg.multi_dot([eigen_vectors[:, ii].T, mean_cov,
-                eigen_vectors[:, ii]])
+                                      eigen_vectors[:, ii]])
             eigen_vectors[:, ii] /= np.sqrt(tmp)
         return eigen_vectors
 

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -546,8 +546,8 @@ class CSP(TransformerMixin, BaseEstimator):
         for jj in range(eigen_vectors.shape[1]):
             aa, bb = 0, 0
             for (cov, prob) in zip(covs, class_probas):
-                tmp = np.dot(np.dot(eigen_vectors[:, jj].T, cov),
-                             eigen_vectors[:, jj])
+                tmp = np.linalg.multi_dot([eigen_vectors[:, jj].T, cov,
+                             eigen_vectors[:, jj]])
                 aa += prob * np.log(np.sqrt(tmp))
                 bb += prob * (tmp ** 2 - 1)
             mi = - (aa + (3.0 / 16) * (bb ** 2))
@@ -560,8 +560,8 @@ class CSP(TransformerMixin, BaseEstimator):
         mean_cov = np.average(covs, axis=0, weights=sample_weights)
 
         for ii in range(eigen_vectors.shape[1]):
-            tmp = np.dot(np.dot(eigen_vectors[:, ii].T, mean_cov),
-                         eigen_vectors[:, ii])
+            tmp = np.linalg.multi_dot([eigen_vectors[:, ii].T, mean_cov,
+                         eigen_vectors[:, ii]])
             eigen_vectors[:, ii] /= np.sqrt(tmp)
         return eigen_vectors
 

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -547,7 +547,7 @@ class CSP(TransformerMixin, BaseEstimator):
             aa, bb = 0, 0
             for (cov, prob) in zip(covs, class_probas):
                 tmp = np.linalg.multi_dot([eigen_vectors[:, jj].T, cov,
-                             eigen_vectors[:, jj]])
+                    eigen_vectors[:, jj]])
                 aa += prob * np.log(np.sqrt(tmp))
                 bb += prob * (tmp ** 2 - 1)
             mi = - (aa + (3.0 / 16) * (bb ** 2))
@@ -561,7 +561,7 @@ class CSP(TransformerMixin, BaseEstimator):
 
         for ii in range(eigen_vectors.shape[1]):
             tmp = np.linalg.multi_dot([eigen_vectors[:, ii].T, mean_cov,
-                         eigen_vectors[:, ii]])
+                eigen_vectors[:, ii]])
             eigen_vectors[:, ii] /= np.sqrt(tmp)
         return eigen_vectors
 

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -271,7 +271,7 @@ def test_ajd():
     A /= np.atleast_2d(np.sqrt(np.sum(A ** 2, 1))).T
     covmats = np.empty((n_times, n_channels, n_channels))
     for i in range(n_times):
-        covmats[i] = np.linalg.multi_dot([A, np.diag(diags[i]), A.T])
+        np.linalg.multi_dot([A, np.diag(diags[i]), A.T], out=covmats[i])
     V, D = _ajd_pham(covmats)
     # Results obtained with original matlab implementation
     V_matlab = [[-3.507280775058041, -5.498189967306344, 7.720624541198574],

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -271,7 +271,7 @@ def test_ajd():
     A /= np.atleast_2d(np.sqrt(np.sum(A ** 2, 1))).T
     covmats = np.empty((n_times, n_channels, n_channels))
     for i in range(n_times):
-        covmats[i] = np.dot(np.dot(A, np.diag(diags[i])), A.T)
+        covmats[i] = np.linalg.multi_dot([A, np.diag(diags[i]), A.T])
     V, D = _ajd_pham(covmats)
     # Results obtained with original matlab implementation
     V_matlab = [[-3.507280775058041, -5.498189967306344, 7.720624541198574],

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -271,7 +271,7 @@ def test_ajd():
     A /= np.atleast_2d(np.sqrt(np.sum(A ** 2, 1))).T
     covmats = np.empty((n_times, n_channels, n_channels))
     for i in range(n_times):
-        covmats[i]=np.linalg.multi_dot([A, np.diag(diags[i]), A.T])
+        covmats[i] = np.linalg.multi_dot([A, np.diag(diags[i]), A.T])
     V, D = _ajd_pham(covmats)
     # Results obtained with original matlab implementation
     V_matlab = [[-3.507280775058041, -5.498189967306344, 7.720624541198574],

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -271,7 +271,7 @@ def test_ajd():
     A /= np.atleast_2d(np.sqrt(np.sum(A ** 2, 1))).T
     covmats = np.empty((n_times, n_channels, n_channels))
     for i in range(n_times):
-        np.linalg.multi_dot([A, np.diag(diags[i]), A.T], out=covmats[i])
+        covmats[i]=np.linalg.multi_dot([A, np.diag(diags[i]), A.T])
     V, D = _ajd_pham(covmats)
     # Results obtained with original matlab implementation
     V_matlab = [[-3.507280775058041, -5.498189967306344, 7.720624541198574],

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -99,8 +99,7 @@ def _gamma_map_opt(M, G, alpha, maxit=10000, tol=1e-6, update_mode=1,
         U, S, _ = linalg.svd(CM, full_matrices=False)
         S = S[np.newaxis, :]
         del CM
-        CMinv = np.dot(U / (S + eps), U.T)
-        CMinvG = np.dot(CMinv, G)
+        CMinvG = np.linalg.multi_dot([U / (S + eps), U.T, G])
         A = np.dot(CMinvG.T, M)  # mult. w. Diag(gamma) in gamma update
 
         if update_mode == 1:

--- a/mne/inverse_sparse/mxne_debiasing.py
+++ b/mne/inverse_sparse/mxne_debiasing.py
@@ -42,7 +42,7 @@ def power_iteration_kron(A, C, max_iter=1000, tol=1e-3, random_state=0):
     CCT = np.dot(C, C.T)
     L0 = np.inf
     for _ in range(max_iter):
-        Y = np.dot(np.dot(ATA, B), CCT)
+        Y = np.linalg.multi_dot([ATA, B, CCT])
         L = np.linalg.norm(Y, 'fro')
 
         if abs(L - L0) < tol:

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -896,9 +896,10 @@ class ICA(ContainsMixin):
             data -= self.pca_mean_[:, None]
 
         # Apply unmixing and PCA
-        sources = np.linalg.multi_dot([self.unmixing_matrix_,
-                           self.pca_components_[:self.n_components_],
-                           data])
+        sources = np.linalg.multi_dot(
+            [self.unmixing_matrix_,
+             self.pca_components_[: self.n_components_], data]
+        )
         return sources
 
     def _transform_raw(self, raw, start, stop, reject_by_annotation=False):

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -897,8 +897,8 @@ class ICA(ContainsMixin):
 
         # Apply unmixing and PCA
         sources = np.linalg.multi_dot([self.unmixing_matrix_,
-                                      self.pca_components_[:self.n_components_],
-                                      data])
+                           self.pca_components_[:self.n_components_],
+                           data])
         return sources
 
     def _transform_raw(self, raw, start, stop, reject_by_annotation=False):

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -897,7 +897,7 @@ class ICA(ContainsMixin):
 
         # Apply unmixing and PCA
         sources = np.linalg.multi_dot([self.unmixing_matrix_,
-                          self.pca_components_[:self.n_components_], data])
+                                      self.pca_components_[:self.n_components_], data])
         return sources
 
     def _transform_raw(self, raw, start, stop, reject_by_annotation=False):

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -897,7 +897,7 @@ class ICA(ContainsMixin):
 
         # Apply unmixing and PCA
         sources = np.linalg.multi_dot([self.unmixing_matrix_,
-                                      self.pca_components_[:self.n_components_], 
+                                      self.pca_components_[:self.n_components_],
                                       data])
         return sources
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -895,11 +895,9 @@ class ICA(ContainsMixin):
         if self.pca_mean_ is not None:
             data -= self.pca_mean_[:, None]
 
-        # Apply unmixing
-        pca_data = np.dot(self.unmixing_matrix_,
-                          self.pca_components_[:self.n_components_])
-        # Apply PCA
-        sources = np.dot(pca_data, data)
+        # Apply unmixing and PCA
+        sources = np.linalg.multi_dot([self.unmixing_matrix_,
+                          self.pca_components_[:self.n_components_], data])
         return sources
 
     def _transform_raw(self, raw, start, stop, reject_by_annotation=False):

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -897,7 +897,8 @@ class ICA(ContainsMixin):
 
         # Apply unmixing and PCA
         sources = np.linalg.multi_dot([self.unmixing_matrix_,
-                                      self.pca_components_[:self.n_components_], data])
+                                      self.pca_components_[:self.n_components_], 
+                                      data])
         return sources
 
     def _transform_raw(self, raw, start, stop, reject_by_annotation=False):


### PR DESCRIPTION
#### Reference issue
Not a reported issue


#### What does this implement/fix?
It is more succinct and effective to refactor code to use `np.linalg.multi_dot` rather than numerous `np.dot` routines.
What do you think about this change?


