### PR TITLE
DOC: Clean up Forward and SourceSpaces

### DIFF
--- a/doc/_templates/autosummary/class_no_inherited_members.rst
+++ b/doc/_templates/autosummary/class_no_inherited_members.rst
@@ -1,0 +1,13 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :special-members: __contains__,__getitem__,__iter__,__len__,__add__,__sub__,__mul__,__div__,__neg__
+   :members:
+   :no-inherited-members:
+
+.. _sphx_glr_backreferences_{{ fullname }}:
+
+.. minigallery:: {{ fullname }}
+    :add-heading:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -171,6 +171,10 @@ intersphinx_mapping = {
 # Define what extra methods numpydoc will document
 docscrape.ClassDoc.extra_public_methods = mne.utils._doc_special_members
 numpydoc_class_members_toctree = False
+numpydoc_show_inherited_class_members = {
+    'mne.SourceSpaces': False,
+    'mne.Forward': False,
+}
 numpydoc_attributes_as_param_list = True
 numpydoc_xref_param_type = True
 numpydoc_xref_aliases = {

--- a/doc/forward.rst
+++ b/doc/forward.rst
@@ -6,9 +6,14 @@ Forward Modeling
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/class_no_inherited_members.rst
 
    Forward
    SourceSpaces
+
+.. autosummary::
+   :toctree: generated/
+
    add_source_space_distances
    apply_forward
    apply_forward_raw

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,6 +1,6 @@
 # requirements for building docs
 sphinx!=4.1.0
-https://github.com/larsoner/numpydoc/archive/inherited.zip
+https://github.com/numpy/numpydoc/archive/main.zip
 https://github.com/pydata/pydata-sphinx-theme/archive/cf8b113a496eb458587c0778a423e40c7c1aa22d.zip
 https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip
 sphinxcontrib-bibtex>=2.1.2

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,6 +1,6 @@
 # requirements for building docs
 sphinx!=4.1.0
-https://github.com/numpy/numpydoc/archive/main.zip
+https://github.com/larsoner/numpydoc/archive/inherited.zip
 https://github.com/pydata/pydata-sphinx-theme/archive/cf8b113a496eb458587c0778a423e40c7c1aa22d.zip
 https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip
 sphinxcontrib-bibtex>=2.1.2


### PR DESCRIPTION
Needs https://github.com/numpy/numpydoc/pull/415. Removes super class stuff we don't want to document.

Perhaps we want this for `Info`, too, but there it's not so simple because we want the methods from some subclasses but not others.