### PR TITLE
MAINT: Always use latest main of pydata-sphinx-theme

### DIFF
--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,7 +1,7 @@
 # requirements for building docs
 sphinx!=4.1.0
 https://github.com/numpy/numpydoc/archive/main.zip
-https://github.com/pydata/pydata-sphinx-theme/archive/cf8b113a496eb458587c0778a423e40c7c1aa22d.zip
+https://github.com/pydata/pydata-sphinx-theme/archive/main.zip
 https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip
 sphinxcontrib-bibtex>=2.1.2
 memory_profiler


### PR DESCRIPTION
@drammock I think I'd rather do this on CircleCI so that we see problems (and get fixes) early.

If you don't like this approach, another option would be to update this pin to another commit, make sure it's okay, then in the `dev` build only use latest `main`. But hopefully pydata-sphinx-theme is stable enough that we can just stick with `main`...?