### PR TITLE
Improve documentation of picks for IC

### DIFF
--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2288,7 +2288,10 @@ docdict['picks_good_data_noref'] = _reflow_param_docstring(
 docdict['picks_header'] = _picks_header
 docdict['picks_ica'] = """
 picks : int | list of int | slice | None
-    Indices of the ICA components to visualize.
+    Indices of the ICA components to visualize. If an integer, represents the
+    indice of the IC to pick. If a list of int or slice, represents the list of
+    indices of the ICs to pick. The indices are 0-indexed, so ``pick=1`` will
+    pick the second IC: ``ICA001``.
 """
 docdict['picks_nostr'] = f"""picks : list | slice | None
     {_picks_desc} {_picks_int}

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2288,9 +2288,10 @@ docdict['picks_good_data_noref'] = _reflow_param_docstring(
 docdict['picks_header'] = _picks_header
 docdict['picks_ica'] = """
 picks : int | list of int | slice | None
-    Indices of the ICA components to visualize. If an integer, represents the
-    indice of the IC to pick. If a list of int or slice, represents the list of
-    indices of the ICs to pick. The indices are 0-indexed, so ``pick=1`` will
+    Indices of the independent components (ICs) to visualize.
+    If an integer, represents the index of the IC to pick.
+    Multiple ICs can be selected using a list of int or a slice.
+    The indices are 0-indexed, so ``picks=1`` will
     pick the second IC: ``ICA001``.
 """
 docdict['picks_nostr'] = f"""picks : list | slice | None


### PR DESCRIPTION
Following #10934 and #10936
Anand and I got confused with the docstring of `picks_ica`: an int would pick only one IC and I thought at the beginning it would pick up to this IC.

Does this look better in your opinion?