### PR TITLE
[ENH, MRG] Add decimate to EpochsTFR object

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -109,6 +109,8 @@ Enhancements
 
 - Add :func:`mne.read_evoked_besa` for reading evokeds from BESA ``.avr`` and ``.mul`` files. (:gh:`10892` by `Marijn van Vliet`_)
 
+- Add :meth:`mne.time_frequency.EpochsTFR.decimate` to reduce size of time-frequency epochs objects (:gh:`10940` by `Alex Rockhill`_)
+
 Bugs
 ~~~~
 - Fix bug in :func:`mne.export.export_raw` to ignore None value in filenames attribute of :class:`mne.io.RawArray` (:gh:`10927` by :newcontrib:`Reza Nasri`)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -39,7 +39,7 @@ from .io.pick import (channel_indices_by_type, channel_type,
 from .io.proj import setup_proj, ProjMixin
 from .io.base import BaseRaw, TimeMixin, _get_ch_factors
 from .bem import _check_origin
-from .evoked import EvokedArray, _check_decim
+from .evoked import EvokedArray
 from .baseline import rescale, _log_rescale, _check_baseline
 from .channels.channels import (UpdateChannelsMixin,
                                 SetChannelsMixin, InterpolationMixin)
@@ -55,7 +55,7 @@ from .utils import (_check_fname, check_fname, logger, verbose,
                     _time_mask, check_random_state, warn, _pl,
                     sizeof_fmt, SizeMixin, copy_function_doc_to_method_doc,
                     _check_pandas_installed,
-                    _check_preload, GetEpochsMixin,
+                    _check_preload, GetEpochsMixin, EpochsTimesMixin,
                     _prepare_read_metadata, _prepare_write_metadata,
                     _check_event_id, _gen_events, _check_option,
                     _check_combine, ShiftTimeMixin, _build_data_frame,
@@ -340,7 +340,8 @@ def _handle_event_repeated(events, event_id, event_repeated, selection,
 @fill_doc
 class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
                  SetChannelsMixin, InterpolationMixin, FilterMixin,
-                 TimeMixin, SizeMixin, GetEpochsMixin, EpochAnnotationsMixin):
+                 TimeMixin, SizeMixin, GetEpochsMixin, EpochAnnotationsMixin,
+                 EpochsTimesMixin):
     """Abstract base class for `~mne.Epochs`-type classes.
 
     .. warning:: This class provides basic functionality and should never be
@@ -648,60 +649,6 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         self._raw_times = self.times
         assert self._data.shape[-1] == len(self.times)
         self._raw = None  # shouldn't need it anymore
-        return self
-
-    @verbose
-    def decimate(self, decim, offset=0, verbose=None):
-        """Decimate the epochs.
-
-        Parameters
-        ----------
-        %(decim)s
-        %(offset_decim)s
-        %(verbose)s
-
-        Returns
-        -------
-        epochs : instance of Epochs
-            The decimated Epochs object.
-
-        See Also
-        --------
-        mne.Evoked.decimate
-        mne.Epochs.resample
-        mne.io.Raw.resample
-
-        Notes
-        -----
-        %(decim_notes)s
-
-        If ``decim`` is 1, this method does not copy the underlying data.
-
-        .. versionadded:: 0.10.0
-
-        References
-        ----------
-        .. footbibliography::
-        """
-        decim, offset, new_sfreq = _check_decim(self.info, decim, offset)
-        start_idx = int(round(-self._raw_times[0] * (self.info['sfreq'] *
-                                                     self._decim)))
-        self._decim *= decim
-        i_start = start_idx % self._decim + offset
-        decim_slice = slice(i_start, None, self._decim)
-        with self.info._unlock():
-            self.info['sfreq'] = new_sfreq
-        if self.preload:
-            if decim != 1:
-                self._data = self._data[:, :, decim_slice].copy()
-                self._raw_times = self._raw_times[decim_slice].copy()
-            else:
-                self._data = np.ascontiguousarray(self._data)
-            self._decim_slice = slice(None)
-            self._decim = 1
-        else:
-            self._decim_slice = decim_slice
-        self._set_times(self._raw_times[self._decim_slice])
         return self
 
     @verbose
@@ -1647,31 +1594,9 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin, ShiftTimeMixin,
         return self
 
     @property
-    def times(self):
-        """Time vector in seconds."""
-        return self._times_readonly
-
-    def _set_times(self, times):
-        """Set self._times_readonly (and make it read only)."""
-        # naming used to indicate that it shouldn't be
-        # changed directly, but rather via this method
-        self._times_readonly = times.copy()
-        self._times_readonly.flags['WRITEABLE'] = False
-
-    @property
-    def tmin(self):
-        """First time point."""
-        return self.times[0]
-
-    @property
     def filename(self):
         """The filename."""
         return self._filename
-
-    @property
-    def tmax(self):
-        """Last time point."""
-        return self.times[-1]
 
     def __repr__(self):
         """Build string representation."""

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -419,6 +419,21 @@ def test_crop():
     assert tfr.data.shape[-2] == 2
 
 
+def test_decim():
+    """Test TFR decimation."""
+    data = np.zeros((3, 3, 3, 1000))
+    times = np.linspace(0, 1, 1000)
+    freqs = np.array([.10, .20, .30])
+    info = mne.create_info(['MEG 001', 'MEG 002', 'MEG 003'], 1000.,
+                           ['mag', 'mag', 'mag'])
+    with info._unlock():
+        info['lowpass'] = 100
+    tfr = EpochsTFR(info, data=data, times=times, freqs=freqs)
+    tfr.decimate(3)
+    assert tfr.times.size == 1000 // 3 + 1
+    assert tfr.data.shape == ((3, 3, 3, 1000 // 3 + 1))
+
+
 @requires_version('h5io')
 @requires_pandas
 def test_io(tmp_path):

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -20,13 +20,13 @@ from ..baseline import rescale
 from ..filter import next_fast_len
 from ..parallel import parallel_func
 from ..utils import (logger, verbose, _time_mask, _freq_mask, check_fname,
-                     sizeof_fmt, GetEpochsMixin, _prepare_read_metadata,
-                     fill_doc, _prepare_write_metadata, _check_event_id,
-                     _gen_events, SizeMixin, _is_numeric, _check_option,
-                     _validate_type, _check_combine, _check_pandas_installed,
-                     _check_pandas_index_arguments, _check_time_format,
-                     _convert_times, _build_data_frame, warn,
-                     _import_h5io_funcs)
+                     sizeof_fmt, GetEpochsMixin, EpochsTimesMixin,
+                     _prepare_read_metadata, fill_doc, _prepare_write_metadata,
+                     _check_event_id, _gen_events, SizeMixin, _is_numeric,
+                     _check_option, _validate_type, _check_combine,
+                     _check_pandas_installed, _check_pandas_index_arguments,
+                     _check_time_format, _convert_times, _build_data_frame,
+                     warn, _import_h5io_funcs)
 from ..channels.channels import UpdateChannelsMixin
 from ..channels.layout import _merge_ch_data, _pair_grad_sensors
 from ..io.pick import (pick_info, _picks_to_idx, channel_type, _pick_inst,
@@ -2092,7 +2092,7 @@ class AverageTFR(_BaseTFR):
 
 
 @fill_doc
-class EpochsTFR(_BaseTFR, GetEpochsMixin):
+class EpochsTFR(_BaseTFR, GetEpochsMixin, EpochsTimesMixin):
     """Container for Time-Frequency data on epochs.
 
     Can for example store induced power at sensor level.
@@ -2217,7 +2217,9 @@ class EpochsTFR(_BaseTFR, GetEpochsMixin):
             (len(dl) == 0 for dl in drop_log))
         event_id = _check_event_id(event_id, events)
         self.data = data
-        self.times = np.array(times, dtype=float)
+        self._set_times(np.array(times, dtype=float))
+        self._raw_times = self.times.copy()
+        self._decim = 1
         self.freqs = np.array(freqs, dtype=float)
         self.events = events
         self.event_id = event_id

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -2218,7 +2218,7 @@ class EpochsTFR(_BaseTFR, GetEpochsMixin, EpochsTimesMixin):
         event_id = _check_event_id(event_id, events)
         self.data = data
         self._set_times(np.array(times, dtype=float))
-        self._raw_times = self.times.copy()
+        self._raw_times = self.times.copy()  # needed for decimate
         self._decim = 1
         self.freqs = np.array(freqs, dtype=float)
         self.events = events

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -2323,7 +2323,7 @@ class EpochsTFR(_BaseTFR, GetEpochsMixin, EpochsTimesMixin):
                              events=self.events, event_id=self.event_id)
         else:
             self.data = data
-            self.times = times
+            self._set_times(times)
             self.freqs = freqs
             return self
 

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -66,8 +66,9 @@ from .numerics import (hashfunc, _compute_row_norms,
                        _julian_to_dt, _dt_to_stamp, _stamp_to_dt,
                        _check_dt, _ReuseCycle, _arange_div, _hashable_ndarray,
                        _custom_lru_cache)
-from .mixin import (SizeMixin, GetEpochsMixin, _prepare_read_metadata,
-                    _prepare_write_metadata, _FakeNoPandas, ShiftTimeMixin)
+from .mixin import (SizeMixin, GetEpochsMixin, EpochsTimesMixin,
+                    _prepare_read_metadata, _prepare_write_metadata,
+                    _FakeNoPandas, ShiftTimeMixin)
 from .linalg import (_svd_lwork, _repeated_svd, _sym_mat_pow, sqrtm_sym, eigh,
                      _get_blas_funcs)
 from .dataframe import (_set_pandas_dtype, _scale_dataframe_data,


### PR DESCRIPTION
Fixes memory failures here https://github.com/mne-tools/mne-python/pull/10920. 

I just needed the decimate method but while I was changing that, it made sense to add in `tmin` and `tmax` and to mak `times` readonly as in `Epochs`.