### PR TITLE
fix _ensure_events for numpy 1.24

### DIFF
--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -996,13 +996,26 @@ def _safe_input(msg, *, alt=None, use=None):
 
 
 def _ensure_events(events):
-    events_type = type(events)
-    with warnings.catch_warnings(record=True):
-        warnings.simplefilter('ignore')  # deprecation for object array
-        events = np.asarray(events)
+    err_msg = f'events should be a NumPy array of integers, got {type(events)}'
+    if check_version('numpy', '1.24'):
+        # NumPy >= 1.24 raises ValueError
+        try:
+            events = np.asarray(events)
+        except ValueError as np_err:
+            if np_err.startswith(
+                    'setting an array element with a sequence. The requested '
+                    'array has an inhomogeneous shape'):
+                raise TypeError(err_msg)
+            else:
+                raise
+    else:
+        # NumPy < 1.24 gives VisibleDeprecationWarning
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter('ignore')
+            events = np.asarray(events)
+    # now that we're sure that events is an array...
     if not np.issubdtype(events.dtype, np.integer):
-        raise TypeError('events should be a NumPy array of integers, '
-                        f'got {events_type}')
+        raise TypeError(err_msg)
     if events.ndim != 2 or events.shape[1] != 3:
         raise ValueError(
             f'events must be of shape (N, 3), got {events.shape}')

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -1002,7 +1002,7 @@ def _ensure_events(events):
         try:
             events = np.asarray(events)
         except ValueError as np_err:
-            if np_err.startswith(
+            if str(np_err).startswith(
                     'setting an array element with a sequence. The requested '
                     'array has an inhomogeneous shape'):
                 raise TypeError(err_msg)


### PR DESCRIPTION
should address the CI failures seen in #10930, i.e. https://dev.azure.com/mne-tools/mne-python/_build/results?buildId=20750&view=logs&j=305851a9-a7bb-55db-0042-7e2b6f48aa1c&t=77eb5bf7-3205-5b54-06c6-183c8195d846&l=3208

closes #10943 