### PR TITLE
FIX: ctf data can sometimes have no date time.

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -139,6 +139,8 @@ Bugs
 
 - Fix bug in :func:`mne.io.read_raw_ctf` on Windows where large files could not be read (:gh:`10866` by `Eric Larson`_)
 
+- Fix bug in :func:`mne.io.read_raw_ctf` where invalid measurement dates were not handled properly (:gh:`10957` by `Jean-Remi King`_ and `Eric Larson`_)
+
 - Rendering issues with recent MESA releases can be avoided by setting the new environment variable``MNE_3D_OPTION_MULTI_SAMPLES=1`` or using :func:`mne.viz.set_3d_options` (:gh:`10513` by `Eric Larson`_)
 
 - Fix behavior for the ``pyvista`` 3D renderer's ``quiver3D`` function so that default arguments plot a glyph in ``arrow`` mode (:gh:`10493` by `Alex Rockhill`_)

--- a/mne/io/ctf/info.py
+++ b/mne/io/ctf/info.py
@@ -76,7 +76,8 @@ def _convert_time(date_str, time_str):
     if date_str == time_str == '':
         date_str = '01/01/1970'
         time_str = '00:00:00'
-        logger.info('No date or time found, setting to the epoch (1970/01/01)')
+        logger.info('No date or time found, setting to the start of the '
+                    'POSIX epoch (1970/01/01 midnight)')
 
     for fmt in ("%d/%m/%Y", "%d-%b-%Y", "%a, %b %d, %Y", "%Y/%m/%d"):
         try:

--- a/mne/io/ctf/info.py
+++ b/mne/io/ctf/info.py
@@ -74,9 +74,9 @@ def _pick_isotrak_and_hpi_coils(res4, coils, t):
 def _convert_time(date_str, time_str):
     """Convert date and time strings to float time."""
     if date_str == time_str == '':
-        date_str = '01/01/2000'
+        date_str = '01/01/1970'
         time_str = '00:00:00'
-        logger.info('No date or time found')
+        logger.info('No date or time found, setting to the epoch (1970/01/01)')
 
     for fmt in ("%d/%m/%Y", "%d-%b-%Y", "%a, %b %d, %Y", "%Y/%m/%d"):
         try:

--- a/mne/io/ctf/info.py
+++ b/mne/io/ctf/info.py
@@ -73,6 +73,11 @@ def _pick_isotrak_and_hpi_coils(res4, coils, t):
 
 def _convert_time(date_str, time_str):
     """Convert date and time strings to float time."""
+    if date_str == time_str == '':
+        date_str = '01/01/1000'
+        time_str = '00:00:00'
+        logger.info('No date or time found')
+
     for fmt in ("%d/%m/%Y", "%d-%b-%Y", "%a, %b %d, %Y", "%Y/%m/%d"):
         try:
             date = strptime(date_str.strip(), fmt)

--- a/mne/io/ctf/info.py
+++ b/mne/io/ctf/info.py
@@ -74,7 +74,7 @@ def _pick_isotrak_and_hpi_coils(res4, coils, t):
 def _convert_time(date_str, time_str):
     """Convert date and time strings to float time."""
     if date_str == time_str == '':
-        date_str = '01/01/1000'
+        date_str = '01/01/2000'
         time_str = '00:00:00'
         logger.info('No date or time found')
 

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -444,6 +444,7 @@ def test_read_ctf_mag_bad_comp(tmp_path, monkeypatch):
         read_raw_ctf(path)
 
 
+@testing.requires_testing_data
 def test_invalid_meas_date(monkeypatch):
     """Test handling of invalid meas_date."""
     def _convert_time_bad(date_str, time_str):


### PR DESCRIPTION
I encountered a bug when reading a CTF dataset with an empty string in the `res4['data_date']` and  `res4['data_time']` fields.

This sets the field to January 1st of the year 1001 (earlier make a date parsing bug)