### PR TITLE
Support UTF8 EDF annotations

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -206,6 +206,8 @@ Bugs
 
 - Fix documentation bug in ``ica.plot_sources`` to specify that ``picks`` keyword argument is for picking ICA components to plot (:gh:`10936` by `Adam Li`_)
 
+- Annotations contained in EDF files are correctly read as UTF-8 according to the EDF specification (:gh:`10963` by `Clemens Brunner`_)
+
 API and behavior changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - When creating BEM surfaces via :func:`mne.bem.make_watershed_bem` and :func:`mne.bem.make_flash_bem`, the ``copy`` parameter now defaults to ``True``. This means that instead of creating symbolic links inside the FreeSurfer subject's ``bem`` folder, we now create "actual" files. This should avoid troubles when sharing files across different operating systems and file systems (:gh:`10531` by `Richard Höchenberger`_)

--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -87,7 +87,7 @@ I agree to the following:
 # respective repos, and make a new release of the dataset on GitHub. Then
 # update the checksum in the MNE_DATASETS dict below, and change version
 # here:                  ↓↓↓↓↓         ↓↓↓
-RELEASES = dict(testing='0.137', misc='0.23')
+RELEASES = dict(testing='0.138', misc='0.23')
 TESTING_VERSIONED = f'mne-testing-data-{RELEASES["testing"]}'
 MISC_VERSIONED = f'mne-misc-data-{RELEASES["misc"]}'
 
@@ -111,7 +111,7 @@ MNE_DATASETS = dict()
 # Testing and misc are at the top as they're updated most often
 MNE_DATASETS['testing'] = dict(
     archive_name=f'{TESTING_VERSIONED}.tar.gz',
-    hash='md5:134ef384e7b305ebc5785c7f6ef7c637',
+    hash='md5:9aaaef3481a92cbdb04a9ada8ddfe1cd',
     url=('https://codeload.github.com/mne-tools/mne-testing-data/'
          f'tar.gz/{RELEASES["testing"]}'),
     # In case we ever have to resort to osf.io again...

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1587,7 +1587,7 @@ def _read_annotations_edf(annotations):
                 tals.extend(np.uint8([this_chan % 256, this_chan // 256])
                             .flatten('F'))
 
-        triggers = re.findall(pat, tals.decode('uft8'))
+        triggers = re.findall(pat, tals.decode('utf8'))
 
     events = []
     offset = 0.

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1587,10 +1587,7 @@ def _read_annotations_edf(annotations):
                 tals.extend(np.uint8([this_chan % 256, this_chan // 256])
                             .flatten('F'))
 
-        # use of latin-1 because characters are only encoded for the first 256
-        # code points and utf-8 can triggers an "invalid continuation byte"
-        # error
-        triggers = re.findall(pat, tals.decode('latin-1'))
+        triggers = re.findall(pat, tals.decode('uft8'))
 
     events = []
     offset = 0.

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -61,6 +61,7 @@ test_generator_bdf = op.join(data_path, 'BDF', 'test_generator_2.bdf')
 test_generator_edf = op.join(data_path, 'EDF', 'test_generator_2.edf')
 edf_annot_sub_s_path = op.join(data_path, 'EDF', 'subsecond_starttime.edf')
 edf_chtypes_path = op.join(data_path, 'EDF', 'chtypes_edf.edf')
+edf_utf8_annotations = op.join(data_path, 'EDF', 'test_utf8_annotations.edf')
 
 eog = ['REOG', 'LEOG', 'IEOG']
 misc = ['EXG1', 'EXG5', 'EXG8', 'M1', 'M2']
@@ -340,6 +341,13 @@ def test_read_annotations(fname, recwarn):
     """Test IO of annotations from edf and bdf files via regexp."""
     annot = read_annotations(fname)
     assert len(annot.onset) == 2
+
+
+def test_read_utf8_annotations():
+    """Test if UTF8 annotations can be read."""
+    raw = read_raw_edf(edf_utf8_annotations)
+    assert raw.annotations[0]['description'] == 'RECORD START'
+    assert raw.annotations[1]['description'] == '仰卧'
 
 
 def test_edf_prefilter_parse():

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -343,6 +343,7 @@ def test_read_annotations(fname, recwarn):
     assert len(annot.onset) == 2
 
 
+@testing.requires_testing_data
 def test_read_utf8_annotations():
     """Test if UTF8 annotations can be read."""
     raw = read_raw_edf(edf_utf8_annotations)


### PR DESCRIPTION
Fixes #10960. The [EDF standard](https://www.edfplus.info/specs/edfplus.html#annotation) mandates that annotations are encoded as UTF8 (we used `latin-1`). I am a bit hesitant to make this change though, because of the comment in this section:

> `use of latin-1 because characters are only encoded for the first 256 code points and utf-8 can triggers an "invalid continuation byte" error`

However, if all tests pass we should probably be fine.