### PR TITLE
BUG: Fix bug with normal return

### DIFF
--- a/mne/surface.py
+++ b/mne/surface.py
@@ -334,7 +334,9 @@ def _project_onto_surface(rrs, surf, project_rrs=False, return_nn=False,
             surf_geom = _get_tri_supp_geom(surf)
             nn = _accumulate_normals(surf['tris'].astype(int), surf_geom['nn'],
                                      len(surf['rr']))
-            out += (nn[idx],)
+            nn = nn[idx]
+            _normalize_vectors(nn)
+            out += (nn,)
     return out
 
 

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -9,25 +9,22 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose, assert_equal
 
 from mne import (read_surface, write_surface, decimate_surface, pick_types,
-                 dig_mri_distances, get_montage_volume_labels, read_trans,
-                 create_info)
-from mne.channels import make_dig_montage, make_standard_montage
-from mne.coreg import get_mni_fiducials, fit_matched_points
+                 dig_mri_distances, get_montage_volume_labels)
+from mne.channels import make_dig_montage
+from mne.coreg import get_mni_fiducials
 from mne.datasets import testing
-from mne.io import read_info, RawArray
+from mne.io import read_info
 from mne.io.constants import FIFF
-from mne.io._digitization import _get_fid_coords
 from mne.surface import (_compute_nearest, _tessellate_sphere, fast_cross_3d,
                          get_head_surf, read_curvature, get_meg_helmet_surf,
                          _normal_orth, _read_patch, _marching_cubes,
                          _voxel_neighbors, warp_montage_volume,
                          _project_onto_surface, _get_ico_surface)
 from mne.transforms import (_get_trans, compute_volume_registration,
-                            transform_surface_to, apply_trans)
+                            apply_trans)
 from mne.utils import (catch_logging, object_diff,
                        requires_freesurfer, requires_nibabel, requires_dipy,
                        _record_warnings)
-from mne.bem import read_bem_surfaces
 
 
 data_path = testing.data_path(download=False)

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -21,7 +21,7 @@ from mne.surface import (_compute_nearest, _tessellate_sphere, fast_cross_3d,
                          get_head_surf, read_curvature, get_meg_helmet_surf,
                          _normal_orth, _read_patch, _marching_cubes,
                          _voxel_neighbors, warp_montage_volume,
-                         _project_onto_surface)
+                         _project_onto_surface, _get_ico_surface)
 from mne.transforms import (_get_trans, compute_volume_registration,
                             transform_surface_to, apply_trans)
 from mne.utils import (catch_logging, object_diff,
@@ -417,31 +417,25 @@ def test_warp_montage_volume():
 @pytest.mark.parametrize('ret_nn', (False, True))
 @pytest.mark.parametrize('method', ('accurate', 'nearest'))
 def test_project_onto_surface(method, ret_nn):
-    """Test _project_onto_surface (gh )."""
-    trans = read_trans(
-        data_path / 'MEG' / 'sample' / 'sample_audvis_trunc-trans.fif')
-    surf = read_bem_surfaces(
-        data_path / 'subjects' / 'sample' / 'bem' / 'sample-head.fif')[0]
-    head_surf = transform_surface_to(
-        surf=surf, dest='mri', trans=_get_trans(trans, 'head', 'mri'),
-        copy=True)
-    # set up the raw
-    montage = make_standard_montage('GSN-HydroCel-129')
-    info = create_info(montage.ch_names, 100, ch_types='eeg')
-    raw = RawArray(np.zeros((len(montage.ch_names), 100)), info)
-    raw.set_montage(montage)
-    # get MRI fiducials
-    mri_fiducials = get_mni_fiducials('sample', data_path / 'subjects')
-    mri_fids, frame = _get_fid_coords(mri_fiducials)
-    mri_fid_loc = np.array(list(mri_fids.values()))
-    # get montage fiducials
-    cap_fids, frame = _get_fid_coords(raw.info['dig'])
-    cap_fid_loc = np.array(list(cap_fids.values()))
-    # make & apply coreg transform to eeg channel locs
-    fit_trans = fit_matched_points(
-        cap_fid_loc, mri_fid_loc, out='trans', scale=True)
-    eeg_loc = apply_trans(fit_trans, raw._get_channel_positions())
+    """Test _project_onto_surface (gh-10930)."""
+    locs = np.random.default_rng(0).normal(size=(10, 3))
+    locs *= 2 / np.linalg.norm(locs, axis=1)[:, None]  # lie on a sphere rad=2
+    surf = _get_ico_surface(3)
+    assert len(surf['rr']) == 642
+    assert_allclose(np.linalg.norm(surf['rr'], axis=1), 1., rtol=1e-3)  # unit
     # project
     weights, tri_idx, *out = _project_onto_surface(
-        eeg_loc, head_surf, project_rrs=True, return_nn=ret_nn, method=method)
+        locs, surf, project_rrs=True, return_nn=ret_nn, method=method)
+    locs /= 2.  # back to unit
+    assert_allclose(np.linalg.norm(locs, axis=1), 1., rtol=1e-5)
     assert len(out) == 2 if ret_nn else 1
+    # for a sphere, both the rr (out[0]) and nn (out[1], if exists) should
+    # both be very similar to each other and to our unit-length `locs`
+    for kind, comp in zip(('rr', 'nn'), out):
+        assert_allclose(
+            np.linalg.norm(comp, axis=1), 1., atol=0.05,
+            err_msg=f'{kind} not unit vectors for {method}')
+        cos = np.sum(locs * comp, axis=1)
+        assert_allclose(
+            cos, 1., atol=0.05,  # ico > 3 would be even better tol
+            err_msg=f'{kind} not in same direction as locs for {method}')


### PR DESCRIPTION
Following #10930 I noticed a slowdown in tests:
```
14.56s call     mne/tests/test_surface.py::test_project_onto_surface[accurate-False]
```
My goal was to speed this up, but in so doing I improved the test to actually sanity check the returned values (by making use of our unit sphere surfaces) and found a bug with the normal vector return value.

No need for `latest.inc` update since this is a private function