### PR TITLE
BUG: Fix bug with TemporalFilter

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -205,6 +205,8 @@ Bugs
 
 - When reading EGI MFF files, channel names are no longer ignored and reference channel information is properly incorporated (:gh:`10898` by `Scott Huberty`_ and `Daniel McCloy`_)
 
+- Fix bug in :class:`mne.decoding.TemporalFilter` where filter parameters were not handled properly (:gh:`10968` by `Eric Larson`_)
+- 
 - Fix documentation bug in ``ica.plot_sources`` to specify that ``picks`` keyword argument is for picking ICA components to plot (:gh:`10936` by `Adam Li`_)
 
 - Annotations contained in EDF files are correctly read as UTF-8 according to the EDF specification (:gh:`10963` by `Clemens Brunner`_)

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -240,3 +240,11 @@ def test_temporal_filter():
     filt = TemporalFilter(l_freq=25., h_freq=50., sfreq=1000.,
                           filter_length=150, fir_design='firwin2')
     assert_equal(filt.fit_transform(X).shape, X.shape)
+
+
+def test_bad_triage():
+    """Test for gh-10924."""
+    filt = TemporalFilter(l_freq=8, h_freq=60, sfreq=160.)
+    # Used to fail with "ValueError: Effective band-stop frequency (135.0) is
+    # too high (maximum based on Nyquist is 80.0)"
+    filt.fit_transform(np.zeros((1, 1, 481)))

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -14,7 +14,7 @@ from mne import io, read_events, Epochs, pick_types
 from mne.decoding import (Scaler, FilterEstimator, PSDEstimator, Vectorizer,
                           UnsupervisedSpatialFilter, TemporalFilter)
 from mne.defaults import DEFAULTS
-from mne.utils import requires_sklearn, check_version
+from mne.utils import requires_sklearn, check_version, use_log_level
 
 tmin, tmax = -0.2, 0.5
 event_id = dict(aud_l=1, vis_l=3)
@@ -247,4 +247,5 @@ def test_bad_triage():
     filt = TemporalFilter(l_freq=8, h_freq=60, sfreq=160.)
     # Used to fail with "ValueError: Effective band-stop frequency (135.0) is
     # too high (maximum based on Nyquist is 80.0)"
-    filt.fit_transform(np.zeros((1, 1, 481)))
+    with use_log_level('error'):  # errant warning on old SciPy
+        filt.fit_transform(np.zeros((1, 1, 481)))

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -239,7 +239,8 @@ def test_temporal_filter():
     X = np.random.rand(101, 500)
     filt = TemporalFilter(l_freq=25., h_freq=50., sfreq=1000.,
                           filter_length=150, fir_design='firwin2')
-    assert_equal(filt.fit_transform(X).shape, X.shape)
+    with use_log_level('error'):  # warning about transition bandwidth
+        assert_equal(filt.fit_transform(X).shape, X.shape)
 
 
 def test_bad_triage():
@@ -247,5 +248,4 @@ def test_bad_triage():
     filt = TemporalFilter(l_freq=8, h_freq=60, sfreq=160.)
     # Used to fail with "ValueError: Effective band-stop frequency (135.0) is
     # too high (maximum based on Nyquist is 80.0)"
-    with use_log_level('error'):  # errant warning on old SciPy
-        filt.fit_transform(np.zeros((1, 1, 481)))
+    filt.fit_transform(np.zeros((1, 1, 481)))

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -11,7 +11,7 @@ from .mixin import TransformerMixin
 from .base import BaseEstimator
 
 from .. import pick_types
-from ..filter import filter_data, _triage_filter_params
+from ..filter import filter_data
 from ..time_frequency.psd import psd_array_multitaper
 from ..utils import fill_doc, _check_option, _validate_type, verbose
 from ..io.pick import (pick_info, _pick_data_channels, _picks_by_type,
@@ -828,15 +828,6 @@ class TemporalFilter(TransformerMixin):
 
         shape = X.shape
         X = X.reshape(-1, shape[-1])
-        (X, self.sfreq, self.l_freq, self.h_freq, self.l_trans_bandwidth,
-         self.h_trans_bandwidth, self.filter_length, _, self.fir_window,
-         self.fir_design) = \
-            _triage_filter_params(X, self.sfreq, self.l_freq, self.h_freq,
-                                  self.l_trans_bandwidth,
-                                  self.h_trans_bandwidth, self.filter_length,
-                                  self.method, phase='zero',
-                                  fir_window=self.fir_window,
-                                  fir_design=self.fir_design)
         X = filter_data(X, self.sfreq, self.l_freq, self.h_freq,
                         filter_length=self.filter_length,
                         l_trans_bandwidth=self.l_trans_bandwidth,


### PR DESCRIPTION
Closes #10924

The bug turned out to be that the *outputs* were used incorrectly. The `l_stop` and `h_stop` that are returned by `_triage_filter_params` were assumed to be the `l_trans_bandwidth` and `h_trans_bandwidth`. We can avoid this just by not calling the function twice.