### PR TITLE
use pathlib (and sort imports) in last few examples

### DIFF
--- a/examples/simulation/simulated_raw_data_using_subject_anatomy.py
+++ b/examples/simulation/simulated_raw_data_using_subject_anatomy.py
@@ -21,8 +21,6 @@ using dynamic statistical parametric mapping (dSPM) inverse operator.
 
 # %%
 
-import os.path as op
-
 import numpy as np
 
 import mne
@@ -30,34 +28,41 @@ from mne.datasets import sample
 
 print(__doc__)
 
+# %%
 # In this example, raw data will be simulated for the sample subject, so its
 # information needs to be loaded. This step will download the data if it not
 # already on your machine. Subjects directory is also set so it doesn't need
 # to be given to functions.
-data_path = sample.data_path()
-subjects_dir = op.join(data_path, 'subjects')
-subject = 'sample'
-meg_path = op.join(data_path, 'MEG', subject)
 
+data_path = sample.data_path()
+subjects_dir = data_path / 'subjects'
+subject = 'sample'
+meg_path = data_path / 'MEG' / subject
+
+# %%
 # First, we get an info structure from the sample subject.
-fname_info = op.join(meg_path, 'sample_audvis_raw.fif')
+
+fname_info = meg_path / 'sample_audvis_raw.fif'
 info = mne.io.read_info(fname_info)
 tstep = 1 / info['sfreq']
 
+# %%
 # To simulate sources, we also need a source space. It can be obtained from the
 # forward solution of the sample subject.
-fwd_fname = op.join(meg_path, 'sample_audvis-meg-eeg-oct-6-fwd.fif')
+
+fwd_fname = meg_path / 'sample_audvis-meg-eeg-oct-6-fwd.fif'
 fwd = mne.read_forward_solution(fwd_fname)
 src = fwd['src']
 
+# %%
 # To simulate raw data, we need to define when the activity occurs using events
 # matrix and specify the IDs of each event.
 # Noise covariance matrix also needs to be defined.
 # Here, both are loaded from the sample dataset, but they can also be specified
 # by the user.
 
-fname_event = op.join(meg_path, 'sample_audvis_raw-eve.fif')
-fname_cov = op.join(meg_path, 'sample_audvis-cov.fif')
+fname_event = meg_path / 'sample_audvis_raw-eve.fif'
+fname_cov = meg_path / 'sample_audvis-cov.fif'
 
 events = mne.read_events(fname_event)
 noise_cov = mne.read_cov(fname_cov)

--- a/examples/simulation/source_simulator.py
+++ b/examples/simulation/source_simulator.py
@@ -18,8 +18,6 @@ introduction and only highlights the simplest use case.
 
 # %%
 
-import os.path as op
-
 import numpy as np
 
 import mne
@@ -27,25 +25,28 @@ from mne.datasets import sample
 
 print(__doc__)
 
+# %%
 # For this example, we will be using the information of the sample subject.
 # This will download the data if it not already on your machine. We also set
 # the subjects directory so we don't need to give it to functions.
 data_path = sample.data_path()
-subjects_dir = op.join(data_path, 'subjects')
+subjects_dir = data_path / 'subjects'
 subject = 'sample'
 
+# %%
 # First, we get an info structure from the test subject.
-evoked_fname = op.join(data_path, 'MEG', subject, 'sample_audvis-ave.fif')
+evoked_fname = data_path / 'MEG' / subject / 'sample_audvis-ave.fif'
 info = mne.io.read_info(evoked_fname)
 tstep = 1. / info['sfreq']
 
+# %%
 # To simulate sources, we also need a source space. It can be obtained from the
 # forward solution of the sample subject.
-fwd_fname = op.join(data_path, 'MEG', subject,
-                    'sample_audvis-meg-eeg-oct-6-fwd.fif')
+fwd_fname = data_path / 'MEG' / subject / 'sample_audvis-meg-eeg-oct-6-fwd.fif'
 fwd = mne.read_forward_solution(fwd_fname)
 src = fwd['src']
 
+# %%
 # To select a region to activate, we use the caudal middle frontal to grow
 # a region of interest.
 selected_label = mne.read_labels_from_annot(
@@ -56,11 +57,13 @@ label = mne.label.select_sources(
     subject, selected_label, location=location, extent=extent,
     subjects_dir=subjects_dir)
 
+# %%
 # Define the time course of the activity for each source of the region to
 # activate. Here we use a sine wave at 18 Hz with a peak amplitude
 # of 10 nAm.
 source_time_series = np.sin(2. * np.pi * 18. * np.arange(100) * tstep) * 10e-9
 
+# %%
 # Define when the activity occurs using events. The first column is the sample
 # of the event, the second is not used, and the third is the event id. Here the
 # events occur every 200 samples.
@@ -69,12 +72,14 @@ events = np.zeros((n_events, 3), int)
 events[:, 0] = 100 + 200 * np.arange(n_events)  # Events sample.
 events[:, 2] = 1  # All events have the sample id.
 
+# %%
 # Create simulated source activity. Here we use a SourceSimulator whose
 # add_data method is key. It specified where (label), what
 # (source_time_series), and when (events) an event type will occur.
 source_simulator = mne.simulation.SourceSimulator(src, tstep=tstep)
 source_simulator.add_data(label, source_time_series, events)
 
+# %%
 # Project the source time series to sensor space and add some noise. The source
 # simulator can be given directly to the simulate_raw function.
 raw = mne.simulation.simulate_raw(info, source_simulator, forward=fwd)
@@ -82,6 +87,7 @@ cov = mne.make_ad_hoc_cov(raw.info)
 mne.simulation.add_noise(raw, cov, iir_filter=[0.2, -0.2, 0.04])
 raw.plot()
 
+# %%
 # Plot evoked data to get another view of the simulated raw data.
 events = mne.find_events(raw)
 epochs = mne.Epochs(raw, events, 1, tmin=-0.05, tmax=0.2)

--- a/examples/time_frequency/source_power_spectrum_opm.py
+++ b/examples/time_frequency/source_power_spectrum_opm.py
@@ -30,30 +30,25 @@ Preprocessing
 
 # %%
 
-import os.path as op
-
-from mne.filter import next_fast_len
-
 import mne
-
+from mne.filter import next_fast_len
 
 print(__doc__)
 
 data_path = mne.datasets.opm.data_path()
 subject = 'OPM_sample'
 
-subjects_dir = op.join(data_path, 'subjects')
-bem_dir = op.join(subjects_dir, subject, 'bem')
-bem_fname = op.join(subjects_dir, subject, 'bem',
-                    subject + '-5120-5120-5120-bem-sol.fif')
-src_fname = op.join(bem_dir, '%s-oct6-src.fif' % subject)
+subjects_dir = data_path / 'subjects'
+bem_dir = subjects_dir / subject / 'bem'
+bem_fname = bem_dir / f'{subject}-5120-5120-5120-bem-sol.fif'
+src_fname = bem_dir / f'{subject}-oct6-src.fif'
 vv_fname = data_path / 'MEG' / 'SQUID' / 'SQUID_resting_state.fif'
 vv_erm_fname = data_path / 'MEG' / 'SQUID' / 'SQUID_empty_room.fif'
 vv_trans_fname = data_path / 'MEG' / 'SQUID' / 'SQUID-trans.fif'
 opm_fname = data_path / 'MEG' / 'OPM' / 'OPM_resting_state_raw.fif'
 opm_erm_fname = data_path / 'MEG' / 'OPM' / 'OPM_empty_room_raw.fif'
 opm_trans = mne.transforms.Transform('head', 'mri')  # use identity transform
-opm_coil_def_fname = op.join(data_path, 'MEG', 'OPM', 'coil_def.dat')
+opm_coil_def_fname = data_path / 'MEG' / 'OPM' / 'coil_def.dat'
 
 ##############################################################################
 # Load data, resample. We will store the raw objects in dicts with entries

--- a/examples/time_frequency/time_frequency_global_field_power.py
+++ b/examples/time_frequency/time_frequency_global_field_power.py
@@ -44,14 +44,12 @@ References
 # License: BSD-3-Clause
 
 # %%
-import os.path as op
-
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 import mne
-from mne.datasets import somato
 from mne.baseline import rescale
+from mne.datasets import somato
 from mne.stats import bootstrap_confidence_interval
 
 # %%
@@ -59,8 +57,8 @@ from mne.stats import bootstrap_confidence_interval
 data_path = somato.data_path()
 subject = '01'
 task = 'somato'
-raw_fname = op.join(data_path, 'sub-{}'.format(subject), 'meg',
-                    'sub-{}_task-{}_meg.fif'.format(subject, task))
+raw_fname = (data_path / f'sub-{subject}' / 'meg' /
+             f'sub-{subject}_task-{task}_meg.fif')
 
 # let's explore some frequency bands
 iter_freqs = [

--- a/examples/visualization/3d_to_2d.py
+++ b/examples/visualization/3d_to_2d.py
@@ -23,21 +23,23 @@ on the image.
 # License: BSD-3-Clause
 
 # %%
-from mne.io.fiff.raw import read_raw_fif
+from os.path import dirname
+from pathlib import Path
+
 import numpy as np
 from matplotlib import pyplot as plt
-from os import path as op
 
 import mne
+from mne.io.fiff.raw import read_raw_fif
 from mne.viz import ClickableImage  # noqa: F401
-from mne.viz import (plot_alignment, snapshot_brain_montage, set_3d_view)
+from mne.viz import plot_alignment, set_3d_view, snapshot_brain_montage
 
 misc_path = mne.datasets.misc.data_path()
-ecog_data_fname = op.join(misc_path, 'ecog', 'sample_ecog_ieeg.fif')
-subjects_dir = op.join(misc_path, 'ecog')
+subjects_dir = misc_path / 'ecog'
+ecog_data_fname = subjects_dir / 'sample_ecog_ieeg.fif'
 
 # We've already clicked and exported
-layout_path = op.join(op.dirname(mne.__file__), 'data', 'image')
+layout_path = Path(dirname(mne.__file__)) / 'data' / 'image'
 layout_name = 'custom_layout.lout'
 
 # %%
@@ -117,7 +119,7 @@ ax.set_axis_off()
 # # Generate a layout from our clicks and normalize by the image
 # print('Generating and saving layout...')
 # lt = click.to_layout()
-# lt.save(op.join(layout_path, layout_name))  # save if we want
+# lt.save(layout_path / layout_name)  # save if we want
 
 # # We've already got the layout, load it
 lt = mne.channels.read_layout(layout_name, path=layout_path, scale=False)

--- a/examples/visualization/brain.py
+++ b/examples/visualization/brain.py
@@ -20,9 +20,9 @@ In this example, we'll show how to use :class:`mne.viz.Brain`.
 # being presented auditory and visual stimuli to display the functionality
 # of :class:`mne.viz.Brain` for plotting data on a brain.
 
-import os.path as op
 import matplotlib.pyplot as plt
-import matplotlib as mpl
+from matplotlib.cm import ScalarMappable
+from matplotlib.colors import Normalize
 
 import mne
 from mne.datasets import sample
@@ -30,8 +30,8 @@ from mne.datasets import sample
 print(__doc__)
 
 data_path = sample.data_path()
-subjects_dir = op.join(data_path, 'subjects')
-sample_dir = op.join(data_path, 'MEG', 'sample')
+subjects_dir = data_path / 'subjects'
+sample_dir = data_path / 'MEG' / 'sample'
 
 # %%
 # Add source information
@@ -42,7 +42,7 @@ sample_dir = op.join(data_path, 'MEG', 'sample')
 brain_kwargs = dict(alpha=0.1, background='white', cortex='low_contrast')
 brain = mne.viz.Brain('sample', subjects_dir=subjects_dir, **brain_kwargs)
 
-stc = mne.read_source_estimate(op.join(sample_dir, 'sample_audvis-meg'))
+stc = mne.read_source_estimate(sample_dir / 'sample_audvis-meg')
 stc.crop(0.09, 0.1)
 
 kwargs = dict(fmin=stc.data.min(), fmax=stc.data.max(), alpha=0.25,
@@ -95,8 +95,8 @@ brain.add_head(alpha=0.5)
 # the sensor positions can be displayed as well.
 
 brain = mne.viz.Brain('sample', subjects_dir=subjects_dir, **brain_kwargs)
-evoked = mne.read_evokeds(op.join(sample_dir, 'sample_audvis-ave.fif'))[0]
-trans = mne.read_trans(op.join(sample_dir, 'sample_audvis_raw-trans.fif'))
+evoked = mne.read_evokeds(sample_dir / 'sample_audvis-ave.fif')[0]
+trans = mne.read_trans(sample_dir / 'sample_audvis_raw-trans.fif')
 brain.add_sensors(evoked.info, trans)
 brain.show_view(distance=500)  # move back to show sensors
 
@@ -108,7 +108,7 @@ brain.show_view(distance=500)  # move back to show sensors
 # brain as well.
 
 brain = mne.viz.Brain('sample', subjects_dir=subjects_dir, **brain_kwargs)
-dip = mne.read_dipole(op.join(sample_dir, 'sample_audvis_set1.dip'))
+dip = mne.read_dipole(sample_dir / 'sample_audvis_set1.dip')
 cmap = plt.get_cmap('YlOrRd')
 colors = [cmap(gof / dip.gof.max()) for gof in dip.gof]
 brain.add_dipole(dip, trans, colors=colors, scales=list(dip.amplitude * 1e8))
@@ -126,6 +126,6 @@ fig, ax = plt.subplots()
 ax.imshow(img)
 ax.axis('off')
 cax = fig.add_axes([0.9, 0.1, 0.05, 0.8])
-fig.colorbar(mpl.cm.ScalarMappable(
-    norm=mpl.colors.Normalize(vmin=0, vmax=dip.gof.max()), cmap=cmap), cax=cax)
+norm = Normalize(vmin=0, vmax=dip.gof.max())
+fig.colorbar(ScalarMappable(norm=norm, cmap=cmap), cax=cax)
 fig.suptitle('Dipole Fits Scaled by Amplitude and Colored by GOF')

--- a/examples/visualization/meg_sensors.py
+++ b/examples/visualization/meg_sensors.py
@@ -14,15 +14,17 @@ Show sensor layouts of different MEG systems.
 
 # %%
 
-import os.path as op
+from pathlib import Path
 
 import mne
-from mne.io import read_raw_fif, read_raw_ctf, read_raw_bti, read_raw_kit
-from mne.io import read_raw_artemis123
 from mne.datasets import sample, spm_face, testing
+from mne.io import (read_raw_artemis123, read_raw_bti, read_raw_ctf,
+                    read_raw_fif, read_raw_kit)
 from mne.viz import plot_alignment, set_3d_title
 
 print(__doc__)
+
+root_path = Path(mne.__file__).parent.absolute()
 
 # %%
 # Neuromag
@@ -48,10 +50,10 @@ set_3d_title(figure=fig, title='CTF 275')
 # BTi
 # ---
 
-bti_path = op.abspath(op.dirname(mne.__file__)) + '/io/bti/tests/data/'
-raw = read_raw_bti(op.join(bti_path, 'test_pdf_linux'),
-                   op.join(bti_path, 'test_config_linux'),
-                   op.join(bti_path, 'test_hs_linux'))
+bti_path = root_path / 'io' / 'bti' / 'tests' / 'data'
+raw = read_raw_bti(bti_path / 'test_pdf_linux',
+                   bti_path / 'test_config_linux',
+                   bti_path / 'test_hs_linux')
 fig = plot_alignment(raw.info, meg=('helmet', 'sensors', 'ref'), **kwargs)
 set_3d_title(figure=fig, title='Magnes 3600wh')
 
@@ -59,8 +61,8 @@ set_3d_title(figure=fig, title='Magnes 3600wh')
 # KIT
 # ---
 
-kit_path = op.abspath(op.dirname(mne.__file__)) + '/io/kit/tests/data/'
-raw = read_raw_kit(op.join(kit_path, 'test.sqd'))
+kit_path = root_path / 'io' / 'kit' / 'tests' / 'data'
+raw = read_raw_kit(kit_path / 'test.sqd')
 fig = plot_alignment(raw.info, meg=('helmet', 'sensors'), **kwargs)
 set_3d_title(figure=fig, title='KIT')
 

--- a/examples/visualization/mne_helmet.py
+++ b/examples/visualization/mne_helmet.py
@@ -11,16 +11,14 @@ This tutorial shows how to make the MNE helmet + brain image.
 
 # %%
 
-import os.path as op
 import mne
 
 sample_path = mne.datasets.sample.data_path()
-subjects_dir = op.join(sample_path, 'subjects')
-fname_evoked = op.join(sample_path, 'MEG', 'sample', 'sample_audvis-ave.fif')
-fname_inv = op.join(sample_path, 'MEG', 'sample',
-                    'sample_audvis-meg-oct-6-meg-inv.fif')
-fname_trans = op.join(sample_path, 'MEG', 'sample',
-                      'sample_audvis_raw-trans.fif')
+subjects_dir = sample_path / 'subjects'
+fname_evoked = sample_path / 'MEG' / 'sample' / 'sample_audvis-ave.fif'
+fname_inv = (sample_path / 'MEG' / 'sample' /
+             'sample_audvis-meg-oct-6-meg-inv.fif')
+fname_trans = sample_path / 'MEG' / 'sample' / 'sample_audvis_raw-trans.fif'
 inv = mne.minimum_norm.read_inverse_operator(fname_inv)
 evoked = mne.read_evokeds(fname_evoked, baseline=(None, 0),
                           proj=True, verbose=False, condition='Left Auditory')

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -22,7 +22,7 @@ from ..transforms import (transform_surface_to, read_trans, _find_trans,
 from ._make_forward import _create_meg_coils, _create_eeg_els, _read_coil_defs
 from ._lead_dots import (_do_self_dots, _do_surface_dots, _get_legen_table,
                          _do_cross_dots)
-from ..utils import logger, verbose, _check_option, _reg_pinv, _pl
+from ..utils import logger, verbose, _check_option, _reg_pinv, _pl, path_like
 from ..epochs import EpochsArray, BaseEpochs
 from ..evoked import Evoked, EvokedArray
 
@@ -450,7 +450,7 @@ def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
         raise RuntimeError('No data available for mapping.')
 
     if trans is not None:
-        if isinstance(trans, str):
+        if isinstance(trans, path_like):
             trans = read_trans(trans)
         trans = _ensure_trans(trans, 'head', 'mri')
 

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -14,7 +14,7 @@ from itertools import count
 
 import numpy as np
 
-from ...utils import logger, verbose, _stamp_to_dt
+from ...utils import logger, verbose, _stamp_to_dt, path_like
 from ...transforms import (combine_transforms, invert_transform,
                            Transform)
 from .._digitization import _make_bti_dig_points
@@ -67,7 +67,7 @@ class _bytes_io_mock_context():
 
 def _bti_open(fname, *args, **kwargs):
     """Handle BytesIO."""
-    if isinstance(fname, str):
+    if isinstance(fname, path_like):
         return open(fname, *args, **kwargs)
     elif isinstance(fname, BytesIO):
         return _bytes_io_mock_context(fname)


### PR DESCRIPTION
This should take care of the last few cases of `op.join` in our examples. While at it I  applied `isort` to the imports in those files.