### PR TITLE
TST: Loosen test_make_eeg_average_ref_proj bound

### DIFF
--- a/mne/tests/test_proj.py
+++ b/mne/tests/test_proj.py
@@ -338,7 +338,7 @@ def test_make_eeg_average_ref_proj():
     reref = raw.copy()
     reref.add_proj(car)
     reref.apply_proj()
-    assert_array_almost_equal(reref._data[eeg].mean(axis=0), 0, decimal=19)
+    assert_array_almost_equal(reref._data[eeg].mean(axis=0), 0, decimal=18)
 
     # Error when custom reference has already been applied
     with raw.info._unlock():


### PR DESCRIPTION
Loosening one bound from 19 to 18 decimal places fixes a test failure when using Netlib BLAS on x86_64; see https://github.com/mne-tools/mne-python/issues/10985#issuecomment-1201968450 and the following comments.

#### Reference issue
See https://github.com/mne-tools/mne-python/issues/10985#issuecomment-1201968450; but this does not fix or close the issue in which that comment appears.


#### What does this implement/fix?
Slightly loosens a very strict test bound to allow for implementation differences.

Fixes the following failure on `x86_64` when numpy is using (flexiblas with) Netlib BLAS backend:

```
________________________ test_make_eeg_average_ref_proj ________________________
mne/tests/test_proj.py:341: in test_make_eeg_average_ref_proj
    assert_array_almost_equal(reref._data[eeg].mean(axis=0), 0, decimal=19)
E   AssertionError: 
E   Arrays are not almost equal to 19 decimals
E   
E   Mismatched elements: 11 / 14400 (0.0764%)
E   Max absolute difference: 1.8973538e-19
E   Max relative difference: inf
E    x: array([4.4017478825648476e-20, 5.3052496929694344e-20,
E          4.4440995299275626e-20, ..., 4.5344497109680210e-20,
E          4.2408116225865306e-20, 5.2346636140315759e-20])
E    y: array(0)
----------------------------- Captured stdout call -----------------------------
Opening raw data file /builddir/build/BUILD/mne-python-1.0.3/mne/tests/../io/tests/data/test_raw.fif...
    Read a total of 3 projection items:
        PCA-v1 (1 x 102)  idle
        PCA-v2 (1 x 102)  idle
        PCA-v3 (1 x 102)  idle
    Range : 25800 ... 40199 =     42.956 ...    66.930 secs
Ready.
Reading 0 ... 14399  =      0.000 ...    23.974 secs...
Adding average EEG reference projection.
1 projection items deactivated
Created an SSP operator (subspace dimension = 4)
4 projection items activated
```

#### Additional information
PR suggested by @larsoner in https://github.com/mne-tools/mne-python/issues/10985#issuecomment-1202630197.
