### PR TITLE
Add annotations support for exporting epochs to eeglab format

### DIFF
--- a/mne/export/_eeglab.py
+++ b/mne/export/_eeglab.py
@@ -42,11 +42,17 @@ def _export_epochs(fname, epochs):
     ch_names = [ch for ch in epochs.ch_names if ch not in drop_chs]
     cart_coords = _get_als_coords_from_chs(epochs.info['chs'], drop_chs)
 
+    if len(epochs.annotations) > 0:
+        annot = [epochs.annotations.description, epochs.annotations.onset,
+                 epochs.annotations.duration]
+    else:
+        annot = None
+
     eeglabio.epochs.export_set(
         fname, data=epochs.get_data(picks=ch_names),
         sfreq=epochs.info['sfreq'], events=epochs.events,
         tmin=epochs.tmin, tmax=epochs.tmax, ch_names=ch_names,
-        event_id=epochs.event_id, ch_locs=cart_coords)
+        event_id=epochs.event_id, ch_locs=cart_coords, annotations=annot)
 
 
 def _get_als_coords_from_chs(chs, drop_chs=None):


### PR DESCRIPTION
#### Reference issue
N/A


#### What does this implement/fix?
Adds support for annotations when exporting epochs to eeglab (set) format. Based on updates to the [eeglabio](https://github.com/jackz314/eeglabio) package.


#### Additional information
Annotations will be converted and merged with the events array in eeglab, this behavior is consistent with when exporting raw data to eeglab. 

#### Breaking changes
users with the older version of eeglabio and the updated version of mne would have to update eeglabio to `>=0.0.2`, since the `annotations` field doesn't exist in older versions.