### PR TITLE
CI: Dont check for dev0 in maint branches [skip actions] [skip circle]

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,8 +184,15 @@ stages:
         set -e
         which mne
         mne sys_info -pd
-        mne sys_info -pd | grep "^mne: .*dev0.*$"
+        if [[ "${BRANCHNAME}" == 'maint/'* ]]; then
+          echo "Not checking for "dev" in name for maint branch"
+        else
+          echo "Checking for dev0 in name"
+          mne sys_info -pd | grep "^mne: .*dev0.*$"
+        fi
       displayName: Print config
+      env:
+        BRANCHNAME: $(Build.SourceBranch)
     - bash: source tools/get_testing_version.sh
       displayName: 'Get testing version'
     - task: Cache@2


### PR DESCRIPTION
Helps with #11002

This will still make the one commit to `main` that bumps to non `dev0` fail, though. @drammock I could easily add a `[azp ignore dev]` commit tag awareness or something, is this worth it?