### PR TITLE
Use `scipy.io.loadmat()` fallback for EEGLAB reader

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -23,7 +23,7 @@ Current (1.2.dev0)
 
 Enhancements
 ~~~~~~~~~~~~
-- None yet
+- EEGLAB files (saved as MAT versions less than v7.3) can now be imported with :func:`mne.io.read_raw_eeglab` without the optional dependency ``pymatreader`` (:gh:`11006` by `Clemens Brunner`_)
 
 Bugs
 ~~~~

--- a/mne/io/eeglab/_eeglab.py
+++ b/mne/io/eeglab/_eeglab.py
@@ -71,7 +71,7 @@ def _check_for_scipy_mat_struct(data):  # taken from pymatreader.utils
     return data
 
 
-def readmat(fname, uint16_codec=None):
+def _readmat(fname, uint16_codec=None):
     try:
         read_mat = _import_pymatreader_funcs('EEGLAB I/O')
     except RuntimeError:  # pymatreader not installed

--- a/mne/io/eeglab/_eeglab.py
+++ b/mne/io/eeglab/_eeglab.py
@@ -1,0 +1,82 @@
+import numpy as np
+
+from ...utils import _import_pymatreader_funcs
+
+
+def _todict_from_np_struct(data):  # taken from pymatreader.utils
+    data_dict = {}
+
+    for cur_field_name in data.dtype.names:
+        try:
+            n_items = len(data[cur_field_name])
+            cur_list = []
+
+            for idx in np.arange(n_items):
+                cur_value = data[cur_field_name].item(idx)
+                cur_value = _check_for_scipy_mat_struct(cur_value)
+                cur_list.append(cur_value)
+
+            data_dict[cur_field_name] = cur_list
+        except TypeError:
+            cur_value = data[cur_field_name].item(0)
+            cur_value = _check_for_scipy_mat_struct(cur_value)
+            data_dict[cur_field_name] = cur_value
+
+    return data_dict
+
+
+def _handle_scipy_ndarray(data):  # taken from pymatreader.utils
+    try:
+        from scipy.io.matlab import MatlabFunction
+    except ImportError:  # scipy < 1.8
+        from scipy.io.matlab.mio5 import MatlabFunction
+
+    if data.dtype == np.dtype('object') and not \
+            isinstance(data, MatlabFunction):
+        as_list = []
+        for element in data:
+            as_list.append(_check_for_scipy_mat_struct(element))
+        data = as_list
+    elif isinstance(data.dtype.names, tuple):
+        data = _todict_from_np_struct(data)
+        data = _check_for_scipy_mat_struct(data)
+
+    if isinstance(data, np.ndarray):
+        data = np.array(data)
+
+    return data
+
+
+def _check_for_scipy_mat_struct(data):  # taken from pymatreader.utils
+    """Convert all scipy.io.matlab.mio5_params.mat_struct elements."""
+    try:
+        from scipy.io.matlab import MatlabOpaque
+    except ImportError:  # scipy < 1.8
+        from scipy.io.matlab.mio5_params import MatlabOpaque
+
+    if isinstance(data, dict):
+        for key in data:
+            data[key] = _check_for_scipy_mat_struct(data[key])
+
+    if isinstance(data, MatlabOpaque):
+        try:
+            if data[0][2] == b'string':
+                return None
+        except IndexError:
+            pass
+
+    if isinstance(data, np.ndarray):
+        data = _handle_scipy_ndarray(data)
+
+    return data
+
+
+def readmat(fname, uint16_codec=None):
+    try:
+        read_mat = _import_pymatreader_funcs('EEGLAB I/O')
+    except RuntimeError:  # pymatreader not installed
+        from scipy.io import loadmat
+        eeg = loadmat(fname, squeeze_me=True, mat_dtype=False)
+        return _check_for_scipy_mat_struct(eeg)
+    else:
+        return read_mat(fname, uint16_codec=uint16_codec)

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -8,6 +8,7 @@ import os.path as op
 
 import numpy as np
 
+from scipy.io import loadmat
 try:
     from scipy.io.matlab import MatlabOpaque, MatlabFunction
 except ImportError:  # scipy < 1.8
@@ -124,7 +125,6 @@ def _check_load_mat(fname, uint16_codec):
     try:
         read_mat = _import_pymatreader_funcs('EEGLAB I/O')
     except RuntimeError:  # pymatreader not installed
-        from scipy.io import loadmat
         eeg = loadmat(fname, squeeze_me=True, mat_dtype=False)
         eeg = _check_for_scipy_mat_struct(eeg)
     else:

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -8,7 +8,7 @@ import os.path as op
 
 import numpy as np
 
-from ._eeglab import readmat
+from ._eeglab import _readmat
 from ..pick import _PICK_TYPES_KEYS
 from ..utils import _read_segments_file, _find_channels
 from ..constants import FIFF
@@ -57,7 +57,7 @@ def _check_eeglab_fname(fname, dataname):
 
 def _check_load_mat(fname, uint16_codec):
     """Check if the mat struct contains 'EEG'."""
-    eeg = readmat(fname, uint16_codec=uint16_codec)
+    eeg = _readmat(fname, uint16_codec=uint16_codec)
     if 'ALLEEG' in eeg:
         raise NotImplementedError(
             'Loading an ALLEEG array is not supported. Please contact'

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -8,13 +8,13 @@ import os.path as op
 
 import numpy as np
 
+from ._eeglab import readmat
 from ..pick import _PICK_TYPES_KEYS
 from ..utils import _read_segments_file, _find_channels
 from ..constants import FIFF
 from ..meas_info import create_info
 from ..base import BaseRaw
-from ...utils import (logger, verbose, warn, fill_doc, Bunch, _check_fname,
-                      _import_pymatreader_funcs)
+from ...utils import logger, verbose, warn, fill_doc, Bunch, _check_fname
 from ...channels import make_dig_montage
 from ...epochs import BaseEpochs
 from ...event import read_events
@@ -22,74 +22,6 @@ from ...annotations import Annotations, read_annotations
 
 # just fix the scaling for now, EEGLAB doesn't seem to provide this info
 CAL = 1e-6
-
-
-def _todict_from_np_struct(data):  # taken from pymatreader.utils
-    data_dict = {}
-
-    for cur_field_name in data.dtype.names:
-        try:
-            n_items = len(data[cur_field_name])
-            cur_list = []
-
-            for idx in np.arange(n_items):
-                cur_value = data[cur_field_name].item(idx)
-                cur_value = _check_for_scipy_mat_struct(cur_value)
-                cur_list.append(cur_value)
-
-            data_dict[cur_field_name] = cur_list
-        except TypeError:
-            cur_value = data[cur_field_name].item(0)
-            cur_value = _check_for_scipy_mat_struct(cur_value)
-            data_dict[cur_field_name] = cur_value
-
-    return data_dict
-
-
-def _handle_scipy_ndarray(data):  # taken from pymatreader.utils
-    try:
-        from scipy.io.matlab import MatlabFunction
-    except ImportError:  # scipy < 1.8
-        from scipy.io.matlab.mio5 import MatlabFunction
-
-    if data.dtype == np.dtype('object') and not \
-            isinstance(data, MatlabFunction):
-        as_list = []
-        for element in data:
-            as_list.append(_check_for_scipy_mat_struct(element))
-        data = as_list
-    elif isinstance(data.dtype.names, tuple):
-        data = _todict_from_np_struct(data)
-        data = _check_for_scipy_mat_struct(data)
-
-    if isinstance(data, np.ndarray):
-        data = np.array(data)
-
-    return data
-
-
-def _check_for_scipy_mat_struct(data):  # taken from pymatreader.utils
-    """Convert all scipy.io.matlab.mio5_params.mat_struct elements."""
-    try:
-        from scipy.io.matlab import MatlabOpaque
-    except ImportError:  # scipy < 1.8
-        from scipy.io.matlab.mio5_params import MatlabOpaque
-
-    if isinstance(data, dict):
-        for key in data:
-            data[key] = _check_for_scipy_mat_struct(data[key])
-
-    if isinstance(data, MatlabOpaque):
-        try:
-            if data[0][2] == b'string':
-                return None
-        except IndexError:
-            pass
-
-    if isinstance(data, np.ndarray):
-        data = _handle_scipy_ndarray(data)
-
-    return data
 
 
 def _check_eeglab_fname(fname, dataname):
@@ -125,14 +57,7 @@ def _check_eeglab_fname(fname, dataname):
 
 def _check_load_mat(fname, uint16_codec):
     """Check if the mat struct contains 'EEG'."""
-    try:
-        read_mat = _import_pymatreader_funcs('EEGLAB I/O')
-    except RuntimeError:  # pymatreader not installed
-        from scipy.io import loadmat
-        eeg = loadmat(fname, squeeze_me=True, mat_dtype=False)
-        eeg = _check_for_scipy_mat_struct(eeg)
-    else:
-        eeg = read_mat(fname, uint16_codec=uint16_codec)
+    eeg = readmat(fname, uint16_codec=uint16_codec)
     if 'ALLEEG' in eeg:
         raise NotImplementedError(
             'Loading an ALLEEG array is not supported. Please contact'

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -57,8 +57,11 @@ def _check_eeglab_fname(fname, dataname):
 
 def _check_load_mat(fname, uint16_codec):
     """Check if the mat struct contains 'EEG'."""
-    read_mat = _import_pymatreader_funcs('EEGLAB I/O')
-    eeg = read_mat(fname, uint16_codec=uint16_codec)
+    try:
+        read_mat = _import_pymatreader_funcs('EEGLAB I/O')
+    except RuntimeError:
+        from scipy.io import loadmat as read_mat
+    eeg = read_mat(fname, uint16_codec=uint16_codec, simplify_cells=True)
     if 'ALLEEG' in eeg:
         raise NotImplementedError(
             'Loading an ALLEEG array is not supported. Please contact'

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -59,9 +59,11 @@ def _check_load_mat(fname, uint16_codec):
     """Check if the mat struct contains 'EEG'."""
     try:
         read_mat = _import_pymatreader_funcs('EEGLAB I/O')
-    except RuntimeError:
-        from scipy.io import loadmat as read_mat
-    eeg = read_mat(fname, uint16_codec=uint16_codec, simplify_cells=True)
+    except RuntimeError:  # pymatreader not installed
+        from scipy.io import loadmat
+        eeg = loadmat(fname, simplify_cells=True)
+    else:
+        eeg = read_mat(fname, uint16_codec=uint16_codec)
     if 'ALLEEG' in eeg:
         raise NotImplementedError(
             'Loading an ALLEEG array is not supported. Please contact'

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -7,12 +7,6 @@
 import os.path as op
 
 import numpy as np
-from scipy.io import loadmat
-try:
-    from scipy.io.matlab import MatlabOpaque, MatlabFunction
-except ImportError:  # scipy < 1.8
-    from scipy.io.matlab.mio5_params import MatlabOpaque
-    from scipy.io.matlab.mio5 import MatlabFunction
 
 from ..pick import _PICK_TYPES_KEYS
 from ..utils import _read_segments_file, _find_channels
@@ -53,6 +47,11 @@ def _todict_from_np_struct(data):  # taken from pymatreader.utils
 
 
 def _handle_scipy_ndarray(data):  # taken from pymatreader.utils
+    try:
+        from scipy.io.matlab import MatlabFunction
+    except ImportError:  # scipy < 1.8
+        from scipy.io.matlab.mio5 import MatlabFunction
+
     if data.dtype == np.dtype('object') and not \
             isinstance(data, MatlabFunction):
         as_list = []
@@ -71,6 +70,11 @@ def _handle_scipy_ndarray(data):  # taken from pymatreader.utils
 
 def _check_for_scipy_mat_struct(data):  # taken from pymatreader.utils
     """Convert all scipy.io.matlab.mio5_params.mat_struct elements."""
+    try:
+        from scipy.io.matlab import MatlabOpaque
+    except ImportError:  # scipy < 1.8
+        from scipy.io.matlab.mio5_params import MatlabOpaque
+
     if isinstance(data, dict):
         for key in data:
             data[key] = _check_for_scipy_mat_struct(data[key])
@@ -124,6 +128,7 @@ def _check_load_mat(fname, uint16_codec):
     try:
         read_mat = _import_pymatreader_funcs('EEGLAB I/O')
     except RuntimeError:  # pymatreader not installed
+        from scipy.io import loadmat
         eeg = loadmat(fname, squeeze_me=True, mat_dtype=False)
         eeg = _check_for_scipy_mat_struct(eeg)
     else:

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -7,7 +7,6 @@
 import os.path as op
 
 import numpy as np
-
 from scipy.io import loadmat
 try:
     from scipy.io.matlab import MatlabOpaque, MatlabFunction

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -8,6 +8,12 @@ import os.path as op
 
 import numpy as np
 
+try:
+    from scipy.io.matlab import MatlabOpaque, MatlabFunction
+except ImportError:  # scipy < 1.8
+    from scipy.io.matlab.mio5_params import MatlabOpaque
+    from scipy.io.matlab.mio5 import MatlabFunction
+
 from ..pick import _PICK_TYPES_KEYS
 from ..utils import _read_segments_file, _find_channels
 from ..constants import FIFF
@@ -22,6 +28,64 @@ from ...annotations import Annotations, read_annotations
 
 # just fix the scaling for now, EEGLAB doesn't seem to provide this info
 CAL = 1e-6
+
+
+def _todict_from_np_struct(data):  # taken from pymatreader.utils
+    data_dict = {}
+
+    for cur_field_name in data.dtype.names:
+        try:
+            n_items = len(data[cur_field_name])
+            cur_list = []
+
+            for idx in np.arange(n_items):
+                cur_value = data[cur_field_name].item(idx)
+                cur_value = _check_for_scipy_mat_struct(cur_value)
+                cur_list.append(cur_value)
+
+            data_dict[cur_field_name] = cur_list
+        except TypeError:
+            cur_value = data[cur_field_name].item(0)
+            cur_value = _check_for_scipy_mat_struct(cur_value)
+            data_dict[cur_field_name] = cur_value
+
+    return data_dict
+
+
+def _handle_scipy_ndarray(data):  # taken from pymatreader.utils
+    if data.dtype == np.dtype('object') and not \
+            isinstance(data, MatlabFunction):
+        as_list = []
+        for element in data:
+            as_list.append(_check_for_scipy_mat_struct(element))
+        data = as_list
+    elif isinstance(data.dtype.names, tuple):
+        data = _todict_from_np_struct(data)
+        data = _check_for_scipy_mat_struct(data)
+
+    if isinstance(data, np.ndarray):
+        data = np.array(data)
+
+    return data
+
+
+def _check_for_scipy_mat_struct(data):  # taken from pymatreader.utils
+    """Convert all scipy.io.matlab.mio5_params.mat_struct elements."""
+    if isinstance(data, dict):
+        for key in data:
+            data[key] = _check_for_scipy_mat_struct(data[key])
+
+    if isinstance(data, MatlabOpaque):
+        try:
+            if data[0][2] == b'string':
+                return None
+        except IndexError:
+            pass
+
+    if isinstance(data, np.ndarray):
+        data = _handle_scipy_ndarray(data)
+
+    return data
 
 
 def _check_eeglab_fname(fname, dataname):
@@ -61,7 +125,8 @@ def _check_load_mat(fname, uint16_codec):
         read_mat = _import_pymatreader_funcs('EEGLAB I/O')
     except RuntimeError:  # pymatreader not installed
         from scipy.io import loadmat
-        eeg = loadmat(fname, simplify_cells=True)
+        eeg = loadmat(fname, squeeze_me=True, mat_dtype=False)
+        eeg = _check_for_scipy_mat_struct(eeg)
     else:
         eeg = read_mat(fname, uint16_codec=uint16_codec)
     if 'ALLEEG' in eeg:

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -17,8 +17,8 @@ from scipy import io
 from mne import write_events, read_epochs_eeglab
 from mne.channels import read_custom_montage
 from mne.io import read_raw_eeglab
-from mne.io.eeglab.eeglab import (_get_montage_information, _dol_to_lod,
-                                  _check_for_scipy_mat_struct)
+from mne.io.eeglab.eeglab import _get_montage_information, _dol_to_lod
+from mne.io.eeglab._eeglab import readmat
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.datasets import testing
 from mne.utils import Bunch, _check_pymatreader_installed
@@ -448,8 +448,7 @@ def test_read_single_epoch():
 @testing.requires_testing_data
 def test_get_montage_info_with_ch_type():
     """Test that the channel types are properly returned."""
-    mat = io.loadmat(raw_fname_onefile_mat, squeeze_me=True, mat_dtype=False)
-    mat = _check_for_scipy_mat_struct(mat)
+    mat = readmat(raw_fname_onefile_mat)
     n = len(mat['EEG']['chanlocs']['labels'])
     mat['EEG']['chanlocs']['type'] = ['eeg'] * (n - 2) + ['eog'] + ['stim']
     mat['EEG']['chanlocs'] = _dol_to_lod(mat['EEG']['chanlocs'])
@@ -460,8 +459,7 @@ def test_get_montage_info_with_ch_type():
     assert montage is None
 
     # test unknown type warning
-    mat = io.loadmat(raw_fname_onefile_mat, squeeze_me=True, mat_dtype=False)
-    mat = _check_for_scipy_mat_struct(mat)
+    mat = readmat(raw_fname_onefile_mat)
     n = len(mat['EEG']['chanlocs']['labels'])
     mat['EEG']['chanlocs']['type'] = ['eeg'] * (n - 2) + ['eog'] + ['unknown']
     mat['EEG']['chanlocs'] = _dol_to_lod(mat['EEG']['chanlocs'])

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -18,7 +18,7 @@ from mne import write_events, read_epochs_eeglab
 from mne.channels import read_custom_montage
 from mne.io import read_raw_eeglab
 from mne.io.eeglab.eeglab import _get_montage_information, _dol_to_lod
-from mne.io.eeglab._eeglab import readmat
+from mne.io.eeglab._eeglab import _readmat
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.datasets import testing
 from mne.utils import Bunch, _check_pymatreader_installed
@@ -448,7 +448,7 @@ def test_read_single_epoch():
 @testing.requires_testing_data
 def test_get_montage_info_with_ch_type():
     """Test that the channel types are properly returned."""
-    mat = readmat(raw_fname_onefile_mat)
+    mat = _readmat(raw_fname_onefile_mat)
     n = len(mat['EEG']['chanlocs']['labels'])
     mat['EEG']['chanlocs']['type'] = ['eeg'] * (n - 2) + ['eog'] + ['stim']
     mat['EEG']['chanlocs'] = _dol_to_lod(mat['EEG']['chanlocs'])
@@ -459,7 +459,7 @@ def test_get_montage_info_with_ch_type():
     assert montage is None
 
     # test unknown type warning
-    mat = readmat(raw_fname_onefile_mat)
+    mat = _readmat(raw_fname_onefile_mat)
     n = len(mat['EEG']['chanlocs']['labels'])
     mat['EEG']['chanlocs']['type'] = ['eeg'] * (n - 2) + ['eog'] + ['unknown']
     mat['EEG']['chanlocs'] = _dol_to_lod(mat['EEG']['chanlocs'])

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -45,9 +45,6 @@ epochs_h5_fnames = [epochs_fname_h5, epochs_fname_onefile_h5]
 montage_path = op.join(base_dir, 'test_chans.locs')
 
 
-pymatreader = pytest.importorskip('pymatreader')  # module-level
-
-
 @testing.requires_testing_data
 @pytest.mark.parametrize('fname', [
     raw_fname_mat,

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -21,7 +21,7 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_all_same_channel_names, path_like, _ensure_events,
                     _check_eeglabio_installed, _check_pybv_installed,
                     _check_edflib_installed, _to_rgb, _soft_import,
-                    _check_dict_keys,
+                    _check_dict_keys, _check_pymatreader_installed,
                     _import_h5py, _import_h5io_funcs,
                     _import_pymatreader_funcs)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -386,7 +386,11 @@ def _check_pybv_installed(strict=True):
 
 def _check_pymatreader_installed(strict=True):
     """Aux function."""
-    return _soft_import('pymatreader', 'pymatreader', strict=strict)
+    return _soft_import(
+        'pymatreader',
+        'loading v7.3 (HDF5) .MAT files',
+        strict=strict
+    )
 
 
 def _check_pandas_index_arguments(index, valid):

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -384,6 +384,11 @@ def _check_pybv_installed(strict=True):
     return _soft_import('pybv', 'exporting to BrainVision', strict=strict)
 
 
+def _check_pymatreader_installed(strict=True):
+    """Aux function."""
+    return _soft_import('pymatreader', 'pymatreader', strict=strict)
+
+
 def _check_pandas_index_arguments(index, valid):
     """Check pandas index arguments."""
     if index is None:


### PR DESCRIPTION
Fixes #11005. Tests need to be adapted to test HDF5 and non-HDF5 files separately.