### PR TITLE
improve docdict test

### DIFF
--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -3,7 +3,6 @@
 #
 # License: BSD-3-Clause
 
-from collections import Counter
 import inspect
 from inspect import getsource
 import os.path as op

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -298,18 +298,15 @@ def test_documented():
 
 def test_docdict_order():
     """Test that docdict is alphabetical."""
+    from mne.utils.docs import docdict
+
+    # read the file as text, and get entries via regex
     docs_path = Path(__file__).parent.parent / 'utils' / 'docs.py'
     assert docs_path.is_file(), docs_path
-    with open(docs_path, 'r') as fid:
+    with open(docs_path, 'r', encoding='UTF-8') as fid:
         docs = fid.read()
-    entries = re.findall(r'docdict\[["\']([a-z_\-0-9]+)["\']\] = ', docs)
-    # We can always modify the upper or lower bounds here as entries are made.
-    # This just makes sure our regex is reasonable.
-    # As of 2022/03/02 we're at 346
-    assert 340 < len(entries) < 500
-    # no dups (verbosely describe the error)
-    for key, count in Counter(entries).items():
-        assert count == 1, key
-    # this should be redundant, but why not
-    assert len(set(entries)) == len(entries)
+    entries = re.findall(r'docdict\[["\'](.+)["\']\] = ', docs)
+    # test length & uniqueness
+    assert len(docdict) == len(entries)
+    # test order
     assert sorted(entries) == entries

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3546,6 +3546,8 @@ xscale : str
 # %%
 # Z
 
+docdict['¿test—üñɪçøɖɘ_keys*'] = '¿test—üñɪçøɖɘ_values*'
+
 docdict_indented = {}
 
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3546,6 +3546,7 @@ xscale : str
 # %%
 # Z
 
+# this is needed in test_docstring_parameters, which reads the file as text
 docdict['¿test—üñɪçøɖɘ_keys*'] = '¿test—üñɪçøɖɘ_values*'
 
 docdict_indented = {}


### PR DESCRIPTION
One for @alexrockhill to review. This was motivated by [this CI error](https://dev.azure.com/mne-tools/mne-python/_build/results?buildId=21039&view=logs&j=2bd7b19d-6351-5e7f-8417-63f327ab45bc&t=0c49e006-47ab-5675-a040-5d301cde7356&l=3268) which should be fixed by the explicit `encoding` param; while I was at it I simplified the test and added a test case.