### PR TITLE
[BUG, MRG] Fix wrong affine used in T1/CT manual registration

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -24,6 +24,7 @@ Current (1.2.dev0)
 Enhancements
 ~~~~~~~~~~~~
 - EEGLAB files (saved as MAT versions less than v7.3) can now be imported with :func:`mne.io.read_raw_eeglab` without the optional dependency ``pymatreader`` (:gh:`11006` by `Clemens Brunner`_)
+- Add ``starting_affine`` keyword argument to :func:`mne.transforms.compute_volume_registration` to seed an alignment with an affine (:gh:`11020` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -24,7 +24,8 @@ Current (1.2.dev0)
 Enhancements
 ~~~~~~~~~~~~
 - EEGLAB files (saved as MAT versions less than v7.3) can now be imported with :func:`mne.io.read_raw_eeglab` without the optional dependency ``pymatreader`` (:gh:`11006` by `Clemens Brunner`_)
-- Add ``starting_affine`` keyword argument to :func:`mne.transforms.compute_volume_registration` to seed an alignment with an affine (:gh:`11020` by `Alex Rockhill`_)
+
+- Add ``starting_affine`` keyword argument to :func:`mne.transforms.compute_volume_registration` to initialize an alignment with an affine (:gh:`11020` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -1667,7 +1667,7 @@ def compute_volume_registration(moving, static, pipeline='all', zooms=None,
         starting_affine=starting_affine)[:2]
 
 
-def _compute_volume_registration(moving, static, pipeline, zooms, niter,
+def _compute_volume_registration(moving, static, pipeline, zooms, niter, *,
                                  starting_affine=None):
     _require_version('nibabel', 'SDR morph', '2.1.0')
     _require_version('dipy', 'SDR morph', '0.10.1')

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -1644,7 +1644,7 @@ def compute_volume_registration(moving, static, pipeline='all', zooms=None,
         reslicing/accuracy for the steps.
     %(niter)s
     starting_affine : ndarray
-        The affine to seed the registration with.
+        The affine to initialize the registration with.
     %(verbose)s
 
     Returns

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -1626,7 +1626,8 @@ def _reslice_normalize(img, zooms):
 
 @verbose
 def compute_volume_registration(moving, static, pipeline='all', zooms=None,
-                                niter=None, verbose=None):
+                                niter=None, starting_affine=None,
+                                verbose=None):
     """Align two volumes using an affine and, optionally, SDR.
 
     Parameters
@@ -1642,6 +1643,8 @@ def compute_volume_registration(moving, static, pipeline='all', zooms=None,
         (each with values that are float`, tuple, or None) to provide separate
         reslicing/accuracy for the steps.
     %(niter)s
+    starting_affine : ndarray
+        The affine to seed the registration with.
     %(verbose)s
 
     Returns
@@ -1658,10 +1661,11 @@ def compute_volume_registration(moving, static, pipeline='all', zooms=None,
     .. versionadded:: 0.24
     """
     return _compute_volume_registration(
-        moving, static, pipeline, zooms, niter)[:2]
+        moving, static, pipeline, zooms, niter, starting_affine)[:2]
 
 
-def _compute_volume_registration(moving, static, pipeline, zooms, niter):
+def _compute_volume_registration(moving, static, pipeline, zooms, niter,
+                                 starting_affine=None):
     _require_version('nibabel', 'SDR morph', '2.1.0')
     _require_version('dipy', 'SDR morph', '0.10.1')
     import nibabel as nib
@@ -1682,7 +1686,7 @@ def _compute_volume_registration(moving, static, pipeline, zooms, niter):
     logger.info('Computing registration...')
 
     # affine optimizations
-    reg_affine = None
+    reg_affine = starting_affine
     sdr_morph = None
     pipeline_options = dict(translation=[center_of_mass, translation],
                             rigid=[rigid], affine=[affine])

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -1626,7 +1626,7 @@ def _reslice_normalize(img, zooms):
 
 @verbose
 def compute_volume_registration(moving, static, pipeline='all', zooms=None,
-                                niter=None, starting_affine=None,
+                                niter=None, *, starting_affine=None,
                                 verbose=None):
     """Align two volumes using an affine and, optionally, SDR.
 
@@ -1645,6 +1645,8 @@ def compute_volume_registration(moving, static, pipeline='all', zooms=None,
     %(niter)s
     starting_affine : ndarray
         The affine to initialize the registration with.
+
+        .. versionadded:: 1.2
     %(verbose)s
 
     Returns
@@ -1661,7 +1663,8 @@ def compute_volume_registration(moving, static, pipeline='all', zooms=None,
     .. versionadded:: 0.24
     """
     return _compute_volume_registration(
-        moving, static, pipeline, zooms, niter, starting_affine)[:2]
+        moving, static, pipeline, zooms, niter,
+        starting_affine=starting_affine)[:2]
 
 
 def _compute_volume_registration(moving, static, pipeline, zooms, niter,

--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -237,7 +237,7 @@ del CT_orig
 #         # convert from vox->vox to ras->ras
 #         manual_reg_affine = \
 #             CT_orig.affine @ np.linalg.inv(manual_reg_affine_vox) \
-#             @ np.linalg.inv(T1.affine)
+#             @ np.linalg.inv(CT_orig.affine)
 #         CT_aligned_fix_img = affine_registration(
 #             moving=np.array(CT_orig.dataobj), static=np.array(T1.dataobj),
 #             moving_affine=CT_orig.affine, static_affine=T1.affine,

--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -238,7 +238,7 @@ del CT_orig
 #             CT_orig.affine @ np.linalg.inv(manual_reg_affine_vox) \
 #             @ np.linalg.inv(CT_orig.affine)
 #         reg_affine, _ = mne.transforms.compute_volume_registration(
-#             CT_orig, T1, pipeline='rigids',
+#             CT_orig, T1, pipeline=['rigid'],
 #             starting_affine=manual_reg_affine)
 #         CT_aligned = mne.transforms.apply_volume_registration(
 #             CT_orig, T1, reg_affine, cval='1%')

--- a/tutorials/clinical/10_ieeg_localize.py
+++ b/tutorials/clinical/10_ieeg_localize.py
@@ -189,7 +189,7 @@ del CT_resampled
 # here::
 #
 #    reg_affine, _ = mne.transforms.compute_volume_registration(
-#         CT_orig, T1, pipeline='rigids', zooms=dict(translation=5)))
+#         CT_orig, T1, pipeline='rigids')
 #
 # Instead we just hard-code the resulting 4x4 matrix:
 
@@ -230,7 +230,6 @@ del CT_orig
 #
 #     .. code-block:: python
 #
-#         from dipy.align import affine_registration
 #         # load transform
 #         manual_reg_affine_vox = mne.read_lta(op.join(  # the path used above
 #             misc_path, 'seeg', 'sample_seeg_CT_aligned_manual.mgz.lta'))
@@ -238,13 +237,11 @@ del CT_orig
 #         manual_reg_affine = \
 #             CT_orig.affine @ np.linalg.inv(manual_reg_affine_vox) \
 #             @ np.linalg.inv(CT_orig.affine)
-#         CT_aligned_fix_img = affine_registration(
-#             moving=np.array(CT_orig.dataobj), static=np.array(T1.dataobj),
-#             moving_affine=CT_orig.affine, static_affine=T1.affine,
-#             pipeline=['rigid'], starting_affine=manual_reg_affine,
-#             level_iters=[100], sigmas=[0], factors=[1])[0]
-#         CT_aligned = nib.MGHImage(
-#             CT_aligned_fix_img.astype(np.float32), T1.affine)
+#         reg_affine, _ = mne.transforms.compute_volume_registration(
+#             CT_orig, T1, pipeline='rigids',
+#             starting_affine=manual_reg_affine)
+#         CT_aligned = mne.transforms.apply_volume_registration(
+#             CT_orig, T1, reg_affine, cval='1%')
 #
 #     The rest of the tutorial can then be completed using ``CT_aligned``
 #     from this point on.


### PR DESCRIPTION
I was using this pipeline for my own research and noticed on the manual registration, we used the T1 affine to transform back but since it's not aligned this doesn't make any sense; it needs to go back to RAS coordinates of the CT. I've tested and this works but it's tough to test in the documentation because it would require manual input in freesurfer.