### PR TITLE
MAINT: Bump SNR to help CIs

### DIFF
--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -393,7 +393,7 @@ def test_make_forward_dipole(tmp_path):
     # Now simulate evoked responses for each of the test dipoles,
     # and fit dipoles to them (sphere model, MEG and EEG)
     times, pos, amplitude, ori, gof = [], [], [], [], []
-    nave = 200  # add a tiny amount of noise to the simulated evokeds
+    nave = 400  # add a tiny amount of noise to the simulated evokeds
     for s in stc:
         evo_test = simulate_evoked(fwd, s, info, cov,
                                    nave=nave, random_state=rng)


### PR DESCRIPTION
Closes #11023

Locally I could not replicate with `conda env create -n mne -f environment.yml`. We'll see if CIs are happy with this. I'm not too worried about this as a fix since it's possible/likely that fitting is slightly worse here for one dipole because the fitting optimization is non-convex and we're probably just finding a local minimum somewhere due to numerical precision differences...