### PR TITLE
fix remaining resp: respiration!=response

### DIFF
--- a/doc/_includes/channel_types.rst
+++ b/doc/_includes/channel_types.rst
@@ -53,7 +53,7 @@ bio            Miscellaneous biological channels (e.g.,  Arbitrary units
 
 stim           stimulus (a.k.a. trigger) channels        Arbitrary units
 
-resp           response-trigger channel                  Arbitrary units
+resp           respiration monitoring channel            Volts
 
 chpi           continuous head position indicator        Teslas
                (HPI) coil channels

--- a/doc/changes/0.23.inc
+++ b/doc/changes/0.23.inc
@@ -292,7 +292,7 @@ Bugs
 
 - When creating `~mne.Epochs`, we now ensure that ``reject_tmin`` and ``reject_tmax`` cannot fall outside of the epochs' time interval anymore (:gh:`8821` by `Richard Höchenberger`_)
 
-- `~mne.io.read_raw_bti` erroneously treated response channels as respiratory channels (:gh:`8855` by `Richard Höchenberger`_)
+- `~mne.io.read_raw_bti` erroneously treated response channels as respiratory channels (:gh:`8856` by `Richard Höchenberger`_)
 
 - The RMS trace shown in the time viewer of `~mne.SourceEstimate` plots is now correctly labeled as ``RMS`` (was ``GFP`` before) (:gh:`8965` by `Richard Höchenberger`_)
 


### PR DESCRIPTION
I assume this is a leftover from:

- https://github.com/mne-tools/mne-python/pull/11022

came up in:

-  https://github.com/mne-tools/mne-bids/issues/1046

cc @hoechenberger @larsoner 


xref for why I label the units as "Volts":

- #8858