### PR TITLE
mne.viz.plot_filters was failing for ba filter, fixed

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -32,7 +32,7 @@ Bugs
 ~~~~
 - Fix bug in :func:`mne.decoding.TimeFrequency` that prevented cloning if constructor arguments were modified (:gh:`11004` by :newcontrib:`Daniel Carlström Schad`)
 - Document ``height`` and ``weight`` keys of  ``subject_info`` entry in :class:`mne.Info` (:gh:`11019` by :newcontrib:`Sena Er`)
-- Fixed bug in :func:`mne.viz.plot_filter` when plotting filters created using ``output='ba'`` mode with `compensation` turned on. (by `Marian Dovgialo`_)
+- Fixed bug in :func:`mne.viz.plot_filter` when plotting filters created using ``output='ba'`` mode with ``compensation`` turned on. (by `Marian Dovgialo`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -32,6 +32,7 @@ Bugs
 ~~~~
 - Fix bug in :func:`mne.decoding.TimeFrequency` that prevented cloning if constructor arguments were modified (:gh:`11004` by :newcontrib:`Daniel Carlström Schad`)
 - Document ``height`` and ``weight`` keys of  ``subject_info`` entry in :class:`mne.Info` (:gh:`11019` by :newcontrib:`Sena Er`)
+- Fixed bug in `mne.viz.plot_filter` when plotting filters created using ``output='ba'`` mode with `compensation` turned on. (by `Marian Dovgialo`)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -32,7 +32,7 @@ Bugs
 ~~~~
 - Fix bug in :func:`mne.decoding.TimeFrequency` that prevented cloning if constructor arguments were modified (:gh:`11004` by :newcontrib:`Daniel Carlström Schad`)
 - Document ``height`` and ``weight`` keys of  ``subject_info`` entry in :class:`mne.Info` (:gh:`11019` by :newcontrib:`Sena Er`)
-- Fixed bug in `mne.viz.plot_filter` when plotting filters created using ``output='ba'`` mode with `compensation` turned on. (by `Marian Dovgialo`)
+- Fixed bug in :func:`mne.viz.plot_filter` when plotting filters created using ``output='ba'`` mode with `compensation` turned on. (by `Marian Dovgialo`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -1006,7 +1006,7 @@ def plot_filter(h, sfreq, freq=None, gain=None, title=None, color='#1f77b4',
                 warnings.simplefilter('ignore')
                 gd = group_delay((h['b'], h['a']), omega)[1]
                 if compensate:
-                    gd += group_delay(h['b'].conj(), h['a'].conj(), omega)[1]
+                    gd += group_delay((h['b'].conj(), h['a'].conj()), omega)[1]
             n = estimate_ringing_samples((h['b'], h['a']))
             delta = np.zeros(n)
             delta[0] = 1

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -66,6 +66,12 @@ def test_plot_filter():
     iir = create_filter(data, sfreq, l_freq, h_freq, method='iir')
     plot_filter(iir, sfreq)
     plt.close('all')
+    iir = create_filter(data, sfreq, l_freq, h_freq, method='iir', iir_params={'output': 'ba'})
+    plot_filter(iir, sfreq, compensate=True)
+    plt.close('all')
+    iir = create_filter(data, sfreq, l_freq, h_freq, method='iir', iir_params={'output': 'sos'})
+    plot_filter(iir, sfreq, compensate=True)
+    plt.close('all')
     plot_filter(iir, sfreq, freq, gain)
     plt.close('all')
     iir_ba = create_filter(data, sfreq, l_freq, h_freq, method='iir',

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -66,10 +66,14 @@ def test_plot_filter():
     iir = create_filter(data, sfreq, l_freq, h_freq, method='iir')
     plot_filter(iir, sfreq)
     plt.close('all')
-    iir = create_filter(data, sfreq, l_freq, h_freq, method='iir', iir_params={'output': 'ba'})
+    iir = create_filter(data, sfreq, l_freq, h_freq,
+                        method='iir', iir_params={'output': 'ba'}
+                        )
     plot_filter(iir, sfreq, compensate=True)
     plt.close('all')
-    iir = create_filter(data, sfreq, l_freq, h_freq, method='iir', iir_params={'output': 'sos'})
+    iir = create_filter(data, sfreq, l_freq, h_freq,
+                        method='iir', iir_params={'output': 'sos'}
+                        )
     plot_filter(iir, sfreq, compensate=True)
     plt.close('all')
     plot_filter(iir, sfreq, freq, gain)


### PR DESCRIPTION
When plotting a 'ba' type filter with `compensate=True` on the function would crash, because arguments were passed wrongly

