### PR TITLE
plot_psd_topomap: suppress redundant colorbars when vlim='joint'

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -25,7 +25,7 @@ Enhancements
 ~~~~~~~~~~~~
 - EEGLAB files (saved as MAT versions less than v7.3) can now be imported with :func:`mne.io.read_raw_eeglab` without the optional dependency ``pymatreader`` (:gh:`11006` by `Clemens Brunner`_)
 - Add :func:`mne.time_frequency.csd_tfr` to compute cross-spectral density from :class:`mne.time_frequency.EpochsTFR` (:gh:`10986` by `Alex Rockhill`_)
-
+- :meth:`mne.Epochs.plot_psd_topomap` now suppresses redundant colorbars when ``vlim='joint'`` (:gh:`11051` by `Daniel McCloy`_)
 - Add ``starting_affine`` keyword argument to :func:`mne.transforms.compute_volume_registration` to initialize an alignment with an affine (:gh:`11020` by `Alex Rockhill`_)
 
 Bugs

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2125,10 +2125,11 @@ def plot_psds_topomap(
         if dB and not normalize:
             data = 10 * np.log10(data)
 
-        _plot_topomap_multi_cbar(data, pos, ax, title=title, vmin=vmin,
-                                 vmax=vmax, cmap=cmap, outlines=outlines,
-                                 colorbar=True, unit=unit, cbar_fmt=cbar_fmt,
-                                 sphere=sphere, ch_type=ch_type)
+        colorbar = vlim != 'joint' or ax == axes[-1]
+        _plot_topomap_multi_cbar(
+            data, pos, ax, title=title, vmin=vmin, vmax=vmax, cmap=cmap,
+            outlines=outlines, colorbar=colorbar, unit=unit, cbar_fmt=cbar_fmt,
+            sphere=sphere, ch_type=ch_type)
     tight_layout(fig=fig)
     fig.canvas.draw()
     plt_show(show)

--- a/tutorials/time-freq/20_sensors_time_frequency.py
+++ b/tutorials/time-freq/20_sensors_time_frequency.py
@@ -66,7 +66,7 @@ epochs.plot_psd(fmin=2., fmax=40., average=True, spatial_colors=False)
 # %%
 # Now, let's take a look at the spatial distributions of the PSD, averaged
 # across epochs and frequency bands.
-epochs.plot_psd_topomap(ch_type='grad', normalize=False)
+epochs.plot_psd_topomap(ch_type='grad', normalize=False, vlim='joint')
 
 # %%
 # Alternatively, you can also create PSDs from `~mne.Epochs` with functions


### PR DESCRIPTION
This avoids plotting a colorbar next to every topomap when we know that all of them have the same color scale.