### PR TITLE
use upstream codespell action

### DIFF
--- a/.github/workflows/codespell_and_flake.yml
+++ b/.github/workflows/codespell_and_flake.yml
@@ -34,7 +34,7 @@ jobs:
         name: 'Setup flake8 annotations'
       - run: make flake
         name: 'Run flake8'
-      - uses: GuillaumeFavelier/actions-codespell@feat/quiet_level
+      - uses: codespell-project/actions-codespell@v1
         with:
           path: ${{ env.CODESPELL_DIRS }}
           skip: ${{ env.CODESPELL_SKIPS }}

--- a/.github/workflows/codespell_and_flake.yml
+++ b/.github/workflows/codespell_and_flake.yml
@@ -34,7 +34,7 @@ jobs:
         name: 'Setup flake8 annotations'
       - run: make flake
         name: 'Run flake8'
-      - uses: codespell-project/actions-codespell@v1
+      - uses: codespell-project/actions-codespell@v1.0
         with:
           path: ${{ env.CODESPELL_DIRS }}
           skip: ${{ env.CODESPELL_SKIPS }}

--- a/ignore_words.txt
+++ b/ignore_words.txt
@@ -38,4 +38,3 @@ trough
 recuse
 ro
 nam
-bu


### PR DESCRIPTION
switches our CIs to use a pinned version of the upstream codespell action instead of Guillaume's fork of it.  I'm not 100% sure this will work, since we were previously running off [a branch of Guillaume's fork that had some changes vs upstream](https://github.com/codespell-project/actions-codespell/compare/master...GuillaumeFavelier:actions-codespell:feat/quiet_level), but then again, in the workflows YAML file we're specifying `quiet_level: 3` so I think we weren't even making use of Guillaume's customizations (?)

tagging @GuillaumeFavelier to possibly clarify this