### PR TITLE
revert vlim=joint in TF tutorial

### DIFF
--- a/tutorials/time-freq/20_sensors_time_frequency.py
+++ b/tutorials/time-freq/20_sensors_time_frequency.py
@@ -64,7 +64,7 @@ epochs.plot_psd(fmin=2., fmax=40., average=True, spatial_colors=False)
 # %%
 # Now, let's take a look at the spatial distributions of the PSD, averaged
 # across epochs and frequency bands.
-epochs.plot_psd_topomap(ch_type='grad', normalize=False, vlim='joint')
+epochs.plot_psd_topomap(ch_type='grad', normalize=False)
 
 # %%
 # Alternatively, you can also create PSDs from `~mne.Epochs` with functions


### PR DESCRIPTION
reverts a tutorial change that was mostly meant as a test of changes to module code; turns out it's already demoed elsewhere (and is more appropriate in those other contexts)

ref: https://github.com/mne-tools/mne-python/pull/11051#issuecomment-1220354886  and subsequent comments.