### PR TITLE
ENH: Use threadpoolctl for better linalg parsing

### DIFF
--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -21,6 +21,7 @@ import numpy as np
 from .check import (_validate_type, _check_qt_version, _check_option,
                     _check_fname)
 from .docs import fill_doc
+from .misc import _pl
 from ._logging import warn, logger
 
 
@@ -449,26 +450,23 @@ def _get_root_dir():
 
 
 def _get_numpy_libs():
-    from ._testing import SilenceStdout
-    with SilenceStdout(close=False) as capture:
-        np.show_config()
-    lines = capture.getvalue().split('\n')
-    capture.close()
-    libs = []
-    for li, line in enumerate(lines):
-        for key in ('lapack', 'blas'):
-            if line.startswith('%s_opt_info' % key):
-                lib = lines[li + 1]
-                if 'NOT AVAILABLE' in lib:
-                    lib = 'unknown'
-                else:
-                    try:
-                        lib = lib.split('[')[1].split("'")[1]
-                    except IndexError:
-                        pass  # keep whatever it was
-                libs += ['%s=%s' % (key, lib)]
-    libs = ', '.join(libs)
-    return libs
+    bad_lib = 'unknown linalg bindings'
+    try:
+        from threadpoolctl import threadpool_info
+    except Exception as exc:
+        return bad_lib + f' (threadpoolctl module not found: {exc})'
+    pools = threadpool_info()
+    rename = dict(
+        openblas='OpenBLAS',
+        mkl='MKL',
+    )
+    for pool in pools:
+        if pool['internal_api'] in ('openblas', 'mkl'):
+            return (
+                f'{rename[pool["internal_api"]]} '
+                f'{pool["version"]} with '
+                f'{pool["num_threads"]} thread{_pl(pool["num_threads"])}')
+    return bad_lib
 
 
 _gpu_cmd = """\

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -16,8 +16,6 @@ import sys
 import tempfile
 import re
 
-import numpy as np
-
 from .check import (_validate_type, _check_qt_version, _check_option,
                     _check_fname)
 from .docs import fill_doc

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ ipyvtklink
 mne-qt-browser
 darkdetect
 qdarkstyle
+threadpoolctl

--- a/tutorials/intro/50_configure_mne.py
+++ b/tutorials/intro/50_configure_mne.py
@@ -226,7 +226,21 @@ with mne.use_log_level('debug'):
 # Python session, it will fall back to the value of
 # ``mne.get_config('MNE_LOGGING_LEVEL')``.
 #
+# Getting information about your system
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# You can also get information about what ``mne`` imports as dependencies from
+# your system. This can be done via the command line with:
 #
+# .. code-block:: console
+#
+#    $ mne sys_info
+#
+# Or you can use :func:`mne.sys_info` directly, which prints to ``stdout`` by
+# default:
+
+mne.sys_info()
+
+# %%
 # .. LINKS
 #
 # .. _json: https://en.wikipedia.org/wiki/JSON


### PR DESCRIPTION
[threadpoolctl](https://pypi.org/project/threadpoolctl/) is the standard way to get info about bindings, let's use it instead of our own parser (which fails sometimes anyway).