### PR TITLE
DOC: updated _picks_types docstring to include array-like instead of …

### DIFF
--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2345,7 +2345,7 @@ selection : list of str
     Restrict sensor channels (MEG, EEG, etc.) to this list of channel names.
 """
 
-_picks_types = 'str | list | slice | None'
+_picks_types = 'str | array-like | slice | None'
 _picks_header = f'picks : {_picks_types}'
 _picks_desc = 'Channels to include.'
 _picks_int = ('Slices and lists of integers will be interpreted as channel '


### PR DESCRIPTION
#### Reference issue
Fixes #10389 .


#### What does this implement/fix?
updated `_picks_types` docstring to include array-like instead of list: `str | array-like | slice | None`

