### PR TITLE
Fix trans loading logic in make_field_map

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -28,6 +28,7 @@ Enhancements
 - Improve ``repr()`` for :class:`mne.minimum_norm.InverseOperator` when loose orientation is used (:gh:`11048` by `Eric Larson`_)
 - :meth:`mne.Epochs.plot_psd_topomap` now suppresses redundant colorbars when ``vlim='joint'`` (:gh:`11051` by `Daniel McCloy`_)
 - Add ``starting_affine`` keyword argument to :func:`mne.transforms.compute_volume_registration` to initialize an alignment with an affine (:gh:`11020` by `Alex Rockhill`_)
+- trans parameter in :func:`mne.make_field_map` now accepts Path and uses standardised loading logic. (:gh:`10784` by :newcontrib:`Andrew Quinn`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -28,7 +28,7 @@ Enhancements
 - Improve ``repr()`` for :class:`mne.minimum_norm.InverseOperator` when loose orientation is used (:gh:`11048` by `Eric Larson`_)
 - :meth:`mne.Epochs.plot_psd_topomap` now suppresses redundant colorbars when ``vlim='joint'`` (:gh:`11051` by `Daniel McCloy`_)
 - Add ``starting_affine`` keyword argument to :func:`mne.transforms.compute_volume_registration` to initialize an alignment with an affine (:gh:`11020` by `Alex Rockhill`_)
-- trans parameter in :func:`mne.make_field_map` now accepts Path and uses standardised loading logic. (:gh:`10784` by :newcontrib:`Andrew Quinn`_)
+- The ``trans`` parameter in :func:`mne.make_field_map` now accepts a :class:`~pathlib.Path` object, and uses standardised loading logic (:gh:`10784` by :newcontrib:`Andrew Quinn`)
 
 Bugs
 ~~~~

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -32,6 +32,8 @@
 
 .. _Andrew Dykstra: https://github.com/adykstra
 
+.. _Andrew Quinn: https://github.com/ajquinn
+
 .. _Aniket Pradhan: https://github.com/Aniket-Pradhan
 
 .. _Anna Padee: https://github.com/apadee/

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -2217,6 +2217,9 @@ def distance_to_bem(pos, bem, trans=None, verbose=None):
     bem : instance of ConductorModel
         Conductor model.
     %(trans)s If None (default), assumes bem is in head coordinates.
+
+        .. versionchanged:: 0.19
+            Support for 'fsaverage' argument.
     %(verbose)s
 
     Returns

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -251,6 +251,9 @@ class Dipole(TimeMixin):
         Parameters
         ----------
         %(trans)s
+
+            .. versionchanged:: 0.19
+                Support for 'fsaverage' argument.
         %(subject)s
         %(aseg)s
         %(subjects_dir)s

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -390,9 +390,11 @@ def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
     ----------
     evoked : Evoked | Epochs | Raw
         The measurement file. Need to have info attribute.
-    %(trans)s
-        "auto" (default) will load trans from the FreeSurfer directory
+    %(trans)s "auto" (default) will load trans from the FreeSurfer directory
         specified by ``subject`` and ``subjects_dir`` parameters.
+
+        .. versionchanged:: 0.19
+            Support for 'fsaverage' argument.
     subject : str | None
         The subject name corresponding to FreeSurfer environment
         variable SUBJECT. If None, map for EEG data will not be available.

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -391,8 +391,8 @@ def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
     evoked : Evoked | Epochs | Raw
         The measurement file. Need to have info attribute.
     %(trans)s
-        "auto" (default) will load trans from fs directory specified by
-        ``'subject'`` and ``'subjects_dir'`` parameters.
+        "auto" (default) will load trans from the FreeSurfer directory 
+        specified by ``subject`` and ``subjects_dir`` parameters.
     subject : str | None
         The subject name corresponding to FreeSurfer environment
         variable SUBJECT. If None, map for EEG data will not be available.

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -391,7 +391,7 @@ def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
     evoked : Evoked | Epochs | Raw
         The measurement file. Need to have info attribute.
     %(trans)s
-        "auto" (default) will load trans from the FreeSurfer directory 
+        "auto" (default) will load trans from the FreeSurfer directory
         specified by ``subject`` and ``subjects_dir`` parameters.
     subject : str | None
         The subject name corresponding to FreeSurfer environment

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -17,12 +17,11 @@ from ..io.pick import pick_types, pick_info
 from ..io.meas_info import _simplify_info
 from ..io.proj import _has_eeg_average_ref_proj, make_projector
 from ..surface import get_head_surf, get_meg_helmet_surf
-from ..transforms import (transform_surface_to, read_trans, _find_trans,
-                          _ensure_trans)
+from ..transforms import transform_surface_to, _find_trans, _get_trans
 from ._make_forward import _create_meg_coils, _create_eeg_els, _read_coil_defs
 from ._lead_dots import (_do_self_dots, _do_surface_dots, _get_legen_table,
                          _do_cross_dots)
-from ..utils import logger, verbose, _check_option, _reg_pinv, _pl, path_like
+from ..utils import logger, verbose, _check_option, _reg_pinv, _pl
 from ..epochs import EpochsArray, BaseEpochs
 from ..evoked import Evoked, EvokedArray
 
@@ -391,11 +390,9 @@ def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
     ----------
     evoked : Evoked | Epochs | Raw
         The measurement file. Need to have info attribute.
-    trans : str | 'auto' | None
-        The full path to the ``*-trans.fif`` file produced during
-        coregistration. If present or found using 'auto'
-        the maps will be in MRI coordinates.
-        If None, map for EEG data will not be available.
+    %(trans)s
+        "auto" (default) will load trans from fs directory specified by
+        ``'subject'`` and ``'subjects_dir'`` parameters.
     subject : str | None
         The subject name corresponding to FreeSurfer environment
         variable SUBJECT. If None, map for EEG data will not be available.
@@ -438,21 +435,17 @@ def make_field_map(evoked, trans='auto', subject=None, subjects_dir=None,
         _check_option('ch_type', ch_type, ['eeg', 'meg'])
         types = [ch_type]
 
-    if trans == 'auto':
+    if isinstance(trans, str) and trans == 'auto':
         # let's try to do this in MRI coordinates so they're easy to plot
         trans = _find_trans(subject, subjects_dir)
+    trans, trans_type = _get_trans(trans, fro='head', to='mri')
 
-    if 'eeg' in types and trans is None:
+    if 'eeg' in types and trans_type == 'identity':
         logger.info('No trans file available. EEG data ignored.')
         types.remove('eeg')
 
     if len(types) == 0:
         raise RuntimeError('No data available for mapping.')
-
-    if trans is not None:
-        if isinstance(trans, path_like):
-            trans = read_trans(trans)
-        trans = _ensure_trans(trans, 'head', 'mri')
 
     _check_option('meg_surf', meg_surf, ['helmet', 'head'])
 

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -540,6 +540,9 @@ def make_forward_solution(info, trans, src, bem, meg=True, eeg=True,
     ----------
     %(info_str)s
     %(trans)s
+
+        .. versionchanged:: 0.19
+            Support for 'fsaverage' argument.
     src : path-like | instance of SourceSpaces
         If string, should be a source space filename. Can also be an
         instance of loaded or generated SourceSpaces.

--- a/mne/forward/tests/test_field_interpolation.py
+++ b/mne/forward/tests/test_field_interpolation.py
@@ -1,4 +1,5 @@
 from os import path as op
+from pathlib import Path
 
 import numpy as np
 from numpy.polynomial import legendre
@@ -39,8 +40,8 @@ def test_field_map_ctf():
     events = make_fixed_length_events(raw, duration=0.5)
     evoked = Epochs(raw, events).average()
     evoked.pick_channels(evoked.ch_names[:50])  # crappy mapping but faster
-    # smoke test
-    make_field_map(evoked, trans=trans_fname, subject='sample',
+    # smoke test - passing trans_fname as pathlib.Path as additional check
+    make_field_map(evoked, trans=Path(trans_fname), subject='sample',
                    subjects_dir=subjects_dir)
 
 
@@ -273,3 +274,8 @@ def test_as_meg_type_evoked():
     virt_epochs = virt_epochs.as_type('mag')
     assert (all(ch.endswith('_v') for ch in virt_epochs.info['ch_names']))
     assert_allclose(virt_epochs.get_data().mean(0), virt_evoked.data)
+
+
+@testing.requires_testing_data
+def test_field_map_ctf_with_pathlike():
+    """Test that field mapping can be done with CTF data."""

--- a/mne/forward/tests/test_field_interpolation.py
+++ b/mne/forward/tests/test_field_interpolation.py
@@ -274,8 +274,3 @@ def test_as_meg_type_evoked():
     virt_epochs = virt_epochs.as_type('mag')
     assert (all(ch.endswith('_v') for ch in virt_epochs.info['ch_names']))
     assert_allclose(virt_epochs.get_data().mean(0), virt_evoked.data)
-
-
-@testing.requires_testing_data
-def test_field_map_ctf_with_pathlike():
-    """Test that field mapping can be done with CTF data."""

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -3215,6 +3215,9 @@ def stc_near_sensors(evoked, trans, subject, distance=0.01, mode='sum',
     evoked : instance of Evoked
         The evoked data. Must contain ECoG, sEEG or DBS channels.
     %(trans)s
+
+        .. versionchanged:: 0.19
+            Support for 'fsaverage' argument.
     subject : str
         The subject name.
     distance : float

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3409,9 +3409,6 @@ docdict['trans'] = f"""
 trans : path-like | dict | instance of Transform | None
     {_trans_base}
     If trans is None, an identity matrix is assumed.
-
-    .. versionchanged:: 0.19
-       Support for 'fsaverage' argument.
 """
 
 docdict['trans_not_none'] = """

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -457,9 +457,11 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
     Parameters
     ----------
     %(info)s If None (default), no sensor information will be shown.
-    %(trans)s
-        "auto" will load trans from the FreeSurfer directory
+    %(trans)s "auto" will load trans from the FreeSurfer directory
         specified by ``subject`` and ``subjects_dir`` parameters.
+
+        .. versionchanged:: 0.19
+            Support for 'fsaverage' argument.
     %(subject)s Can be omitted if ``src`` is provided.
     %(subjects_dir)s
     surfaces : str | list | dict

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -458,8 +458,8 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
     ----------
     %(info)s If None (default), no sensor information will be shown.
     %(trans)s
-        "auto" will load trans from fs directory specified by
-        ``'subject'`` and ``'subjects_dir'`` parameters.
+        "auto" will load trans from the FreeSurfer directory 
+        specified by ``subject`` and ``subjects_dir`` parameters.
     %(subject)s Can be omitted if ``src`` is provided.
     %(subjects_dir)s
     surfaces : str | list | dict

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -458,7 +458,7 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
     ----------
     %(info)s If None (default), no sensor information will be shown.
     %(trans)s
-        "auto" will load trans from the FreeSurfer directory 
+        "auto" will load trans from the FreeSurfer directory
         specified by ``subject`` and ``subjects_dir`` parameters.
     %(subject)s Can be omitted if ``src`` is provided.
     %(subjects_dir)s

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -458,6 +458,8 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
     ----------
     %(info)s If None (default), no sensor information will be shown.
     %(trans)s
+        "auto" will load trans from fs directory specified by
+        ``'subject'`` and ``'subjects_dir'`` parameters.
     %(subject)s Can be omitted if ``src`` is provided.
     %(subjects_dir)s
     surfaces : str | list | dict
@@ -603,14 +605,15 @@ def plot_alignment(info=None, trans=None, subject=None, subjects_dir=None,
             raise ValueError(f'subject ("{subject}") did not match the '
                              f'subject name in src ("{src_subject}")')
     # configure transforms
-    if trans == 'auto':
+    if isinstance(trans, str) and trans == 'auto':
         subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
         trans = _find_trans(subject, subjects_dir)
+    trans, trans_type = _get_trans(trans, fro='head', to='mri')
 
     picks = pick_types(info, meg=('sensors' in meg), ref_meg=('ref' in meg),
                        eeg=(len(eeg) > 0), ecog=ecog, seeg=seeg, dbs=dbs,
                        fnirs=(len(fnirs) > 0))
-    if trans is None:
+    if trans_type == 'identity':
         # Some stuff is natively in head coords, others in MRI coords
         msg = ('A head<->mri transformation matrix (trans) is required '
                f'to plot %s in {coord_frame} coordinates, '


### PR DESCRIPTION
Hello - this is my first PR - let me know if I've missed anything

#### Reference issue
Example: Fixes #10784.


#### What does this implement/fix?
This PR changes the loading of the trans information in `make_field_maps` and `plot_alignments`. This now uses the standard `mne.transforms._get_trans` logic and preserves the possibility to use `trans='auto'` to load from a specified fs subject directory. 

Docstrings have been updated and the `test_field_map_ctf` now loads the trans via a `pathlib.Path`.

Where these functions tested for `trans is None`, we now check if `trans == 'identity'` as this this is the default of `_get_trans`
