### PR TITLE
Add `vmin` and `vmax` specification to `mne.Evoked.animate_topomap`

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -23,7 +23,7 @@ Current (1.2.dev0)
 
 Enhancements
 ~~~~~~~~~~~~
-- Add `vmin` and `vmax` specification to `mne.Evoked.animate_topomap` (:gh:`10725` by :newcontrib:`Mats van Es`)
+- Add ``vmin`` and ``vmax`` parameters to :meth:`mne.Evoked.animate_topomap` (:gh:`10725` by :newcontrib:`Mats van Es`)
 - EEGLAB files (saved as MAT versions less than v7.3) can now be imported with :func:`mne.io.read_raw_eeglab` without the optional dependency ``pymatreader`` (:gh:`11006` by `Clemens Brunner`_)
 - Add :func:`mne.time_frequency.csd_tfr` to compute cross-spectral density from :class:`mne.time_frequency.EpochsTFR` (:gh:`10986` by `Alex Rockhill`_)
 - Improve ``repr()`` for :class:`mne.minimum_norm.InverseOperator` when loose orientation is used (:gh:`11048` by `Eric Larson`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -23,6 +23,7 @@ Current (1.2.dev0)
 
 Enhancements
 ~~~~~~~~~~~~
+- Add `vmin` and `vmax` specification to `mne.Evoked.animate_topomap` (:gh:`10725` by :newcontrib:`Mats van Es`)
 - EEGLAB files (saved as MAT versions less than v7.3) can now be imported with :func:`mne.io.read_raw_eeglab` without the optional dependency ``pymatreader`` (:gh:`11006` by `Clemens Brunner`_)
 - Add :func:`mne.time_frequency.csd_tfr` to compute cross-spectral density from :class:`mne.time_frequency.EpochsTFR` (:gh:`10986` by `Alex Rockhill`_)
 - Improve ``repr()`` for :class:`mne.minimum_norm.InverseOperator` when loose orientation is used (:gh:`11048` by `Eric Larson`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -23,7 +23,7 @@ Current (1.2.dev0)
 
 Enhancements
 ~~~~~~~~~~~~
-- Add ``vmin`` and ``vmax`` parameters to :meth:`mne.Evoked.animate_topomap` (:gh:`10725` by :newcontrib:`Mats van Es`)
+- Add ``vmin`` and ``vmax`` parameters to :meth:`mne.Evoked.animate_topomap` (:gh:`11073` by :newcontrib:`Mats van Es`)
 - EEGLAB files (saved as MAT versions less than v7.3) can now be imported with :func:`mne.io.read_raw_eeglab` without the optional dependency ``pymatreader`` (:gh:`11006` by `Clemens Brunner`_)
 - Add :func:`mne.time_frequency.csd_tfr` to compute cross-spectral density from :class:`mne.time_frequency.EpochsTFR` (:gh:`10986` by `Alex Rockhill`_)
 - Improve ``repr()`` for :class:`mne.minimum_norm.InverseOperator` when loose orientation is used (:gh:`11048` by `Eric Larson`_)

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -292,6 +292,8 @@
 
 .. _Mathurin Massias: https://mathurinm.github.io/
 
+.. _Mats van Es: https://github.com/matsvanes
+
 .. _Matt Boggess: https://github.com/mattboggess
 
 .. _Matt Courtemanche: https://github.com/mjcourte

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -455,10 +455,10 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
     @fill_doc
     def animate_topomap(self, ch_type=None, times=None, frame_rate=None,
-                        vmin=None, vmax=None, butterfly=False, blit=True,
-                        show=True, time_unit='s', sphere=None, *,
-                        image_interp=_INTERPOLATION_DEFAULT,
-                        extrapolate=_EXTRAPOLATE_DEFAULT, verbose=None):
+                        butterfly=False, blit=True, show=True, time_unit='s',
+                        sphere=None, *, image_interp=_INTERPOLATION_DEFAULT,
+                        extrapolate=_EXTRAPOLATE_DEFAULT, verbose=None,
+                        vmin=None, vmax=None):
         """Make animation of evoked data as topomap timeseries.
 
         The animation can be paused/resumed with left mouse button.
@@ -479,7 +479,6 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         frame_rate : int | None
             Frame rate for the animation in Hz. If None,
             frame rate = sfreq / 10. Defaults to None.
-        %(vmin_vmax_topomap)s
         butterfly : bool
             Whether to plot the data as butterfly plot under the topomap.
             Defaults to False.
@@ -501,6 +500,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
             .. versionadded:: 0.22
         %(verbose)s
+            .. versionadded:: 1.1.0
+        %(vmin_vmax_topomap)s
 
         Returns
         -------
@@ -515,10 +516,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """
         return _topomap_animation(
             self, ch_type=ch_type, times=times, frame_rate=frame_rate,
-            vmin=vmin, vmax=vmax, butterfly=butterfly, blit=blit,
-            show=show, time_unit=time_unit, sphere=sphere,
-            image_interp=image_interp, extrapolate=extrapolate,
-            verbose=verbose)
+            butterfly=butterfly, blit=blit, show=show, time_unit=time_unit,
+            sphere=sphere, image_interp=image_interp,
+            extrapolate=extrapolate, verbose=verbose, vmin=vmin, vmax=vmax)
 
     def as_type(self, ch_type='grad', mode='fast'):
         """Compute virtual evoked using interpolated fields.

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -504,7 +504,6 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             .. versionadded:: 1.1.0
         %(verbose)s
 
-
         Returns
         -------
         fig : instance of matplotlib.figure.Figure

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -455,8 +455,9 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
     @fill_doc
     def animate_topomap(self, ch_type=None, times=None, frame_rate=None,
-                        butterfly=False, blit=True, show=True, time_unit='s',
-                        sphere=None, *, image_interp=_INTERPOLATION_DEFAULT,
+                        vmin=None, vmax=None, butterfly=False, blit=True,
+                        show=True, time_unit='s', sphere=None, *,
+                        image_interp=_INTERPOLATION_DEFAULT,
                         extrapolate=_EXTRAPOLATE_DEFAULT, verbose=None):
         """Make animation of evoked data as topomap timeseries.
 
@@ -478,6 +479,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         frame_rate : int | None
             Frame rate for the animation in Hz. If None,
             frame rate = sfreq / 10. Defaults to None.
+        %(vmin_vmax_topomap)s
         butterfly : bool
             Whether to plot the data as butterfly plot under the topomap.
             Defaults to False.
@@ -513,9 +515,10 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         """
         return _topomap_animation(
             self, ch_type=ch_type, times=times, frame_rate=frame_rate,
-            butterfly=butterfly, blit=blit, show=show, time_unit=time_unit,
-            sphere=sphere, image_interp=image_interp,
-            extrapolate=extrapolate, verbose=verbose)
+            vmin=vmin, vmax=vmax, butterfly=butterfly, blit=blit,
+            show=show, time_unit=time_unit, sphere=sphere,
+            image_interp=image_interp, extrapolate=extrapolate,
+            verbose=verbose)
 
     def as_type(self, ch_type='grad', mode='fast'):
         """Compute virtual evoked using interpolated fields.

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -457,8 +457,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
     def animate_topomap(self, ch_type=None, times=None, frame_rate=None,
                         butterfly=False, blit=True, show=True, time_unit='s',
                         sphere=None, *, image_interp=_INTERPOLATION_DEFAULT,
-                        extrapolate=_EXTRAPOLATE_DEFAULT, verbose=None,
-                        vmin=None, vmax=None):
+                        extrapolate=_EXTRAPOLATE_DEFAULT, vmin=None, vmax=None,
+                        verbose=None):
         """Make animation of evoked data as topomap timeseries.
 
         The animation can be paused/resumed with left mouse button.
@@ -499,9 +499,11 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(extrapolate_topomap)s
 
             .. versionadded:: 0.22
-        %(verbose)s
-            .. versionadded:: 1.1.0
         %(vmin_vmax_topomap)s
+
+            .. versionadded:: 1.1.0
+        %(verbose)s
+
 
         Returns
         -------
@@ -518,7 +520,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
             self, ch_type=ch_type, times=times, frame_rate=frame_rate,
             butterfly=butterfly, blit=blit, show=show, time_unit=time_unit,
             sphere=sphere, image_interp=image_interp,
-            extrapolate=extrapolate, verbose=verbose, vmin=vmin, vmax=vmax)
+            extrapolate=extrapolate, vmin=vmin, vmax=vmax, verbose=verbose)
 
     def as_type(self, ch_type='grad', mode='fast'):
         """Compute virtual evoked using interpolated fields.

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2294,11 +2294,13 @@ def _init_anim(ax, ax_line, ax_cbar, params, merge_channels, sphere, ch_type,
     logger.info('Initializing animation...')
     data = params['data']
     items = list()
+    vmin = params['vmin'] if 'vmin' in params else None
+    vmax = params['vmax'] if 'vmax' in params else None
     if params['butterfly']:
         all_times = params['all_times']
         for idx in range(len(data)):
             ax_line.plot(all_times, data[idx], color='k', lw=1)
-        vmin, vmax = _setup_vmin_vmax(data, None, None)
+        vmin, vmax = _setup_vmin_vmax(data, vmin, vmax)
         ax_line.set(yticks=np.around(np.linspace(vmin, vmax, 5), -1),
                     xlim=all_times[[0, -1]])
         params['line'] = ax_line.axvline(all_times[0], color='r')
@@ -2309,7 +2311,7 @@ def _init_anim(ax, ax_line, ax_cbar, params, merge_channels, sphere, ch_type,
     norm = True if np.min(data) > 0 else False
     cmap = 'Reds' if norm else 'RdBu_r'
 
-    vmin, vmax = _setup_vmin_vmax(data, None, None, norm)
+    vmin, vmax = _setup_vmin_vmax(data, vmin, vmax, norm)
 
     outlines = _make_head_outlines(sphere, params['pos'], 'head',
                                    params['clip_origin'])
@@ -2427,9 +2429,9 @@ def _key_press(event, params):
         params['frame'] = min(params['frame'] + 1, len(params['frames']) - 1)
 
 
-def _topomap_animation(evoked, ch_type, times, frame_rate, butterfly, blit,
-                       show, time_unit, sphere, image_interp,
-                       extrapolate, *, verbose=None):
+def _topomap_animation(evoked, ch_type, times, frame_rate, vmin, vmax,
+                       butterfly, blit, show, time_unit, sphere,
+                       image_interp, extrapolate, *, verbose=None):
     """Make animation of evoked data as topomap timeseries.
 
     See mne.evoked.Evoked.animate_topomap.
@@ -2458,6 +2460,9 @@ def _topomap_animation(evoked, ch_type, times, frame_rate, butterfly, blit,
     data = evoked.data[picks, :]
     data *= _handle_default('scalings')[ch_type]
 
+    norm = min(data) >= 0
+    vmin, vmax = _setup_vmin_vmax(data, vmin, vmax, norm)
+
     fig = plt.figure(figsize=(6, 5))
     shape = (8, 12)
     colspan = shape[1] - 1
@@ -2474,8 +2479,8 @@ def _topomap_animation(evoked, ch_type, times, frame_rate, butterfly, blit,
     extrapolate = _check_extrapolate(extrapolate, ch_type)
 
     params = dict(data=data, pos=pos, all_times=evoked.times, frame=0,
-                  frames=frames, butterfly=butterfly, blit=blit,
-                  pause=False, times=times, time_unit=time_unit,
+                  frames=frames, vmin=vmin, vmax=vmax, butterfly=butterfly,
+                  blit=blit, pause=False, times=times, time_unit=time_unit,
                   clip_origin=clip_origin)
     init_func = partial(_init_anim, ax=ax, ax_cbar=ax_cbar, ax_line=ax_line,
                         params=params, merge_channels=merge_channels,

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2460,7 +2460,7 @@ def _topomap_animation(evoked, ch_type, times, frame_rate, vmin, vmax,
     data = evoked.data[picks, :]
     data *= _handle_default('scalings')[ch_type]
 
-    norm = min(data) >= 0
+    norm = np.min(data) >= 0
     vmin, vmax = _setup_vmin_vmax(data, vmin, vmax, norm)
 
     fig = plt.figure(figsize=(6, 5))

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2429,9 +2429,9 @@ def _key_press(event, params):
         params['frame'] = min(params['frame'] + 1, len(params['frames']) - 1)
 
 
-def _topomap_animation(evoked, ch_type, times, frame_rate, vmin, vmax,
-                       butterfly, blit, show, time_unit, sphere,
-                       image_interp, extrapolate, *, verbose=None):
+def _topomap_animation(evoked, ch_type, times, frame_rate, butterfly, blit,
+                       show, time_unit, sphere, image_interp,
+                       extrapolate, *, vmin, vmax, verbose=None):
     """Make animation of evoked data as topomap timeseries.
 
     See mne.evoked.Evoked.animate_topomap.
@@ -2479,9 +2479,9 @@ def _topomap_animation(evoked, ch_type, times, frame_rate, vmin, vmax,
     extrapolate = _check_extrapolate(extrapolate, ch_type)
 
     params = dict(data=data, pos=pos, all_times=evoked.times, frame=0,
-                  frames=frames, vmin=vmin, vmax=vmax, butterfly=butterfly,
-                  blit=blit, pause=False, times=times, time_unit=time_unit,
-                  clip_origin=clip_origin)
+                  frames=frames, butterfly=butterfly, blit=blit,
+                  pause=False, times=times, time_unit=time_unit,
+                  clip_origin=clip_origin, vmin=vmin, vmax=vmax)
     init_func = partial(_init_anim, ax=ax, ax_cbar=ax_cbar, ax_line=ax_line,
                         params=params, merge_channels=merge_channels,
                         sphere=sphere, ch_type=ch_type,


### PR DESCRIPTION
Fixes #10725 .

Add `vmin` and `vmax` specification to `mne.Evoked.animate_topomap`
