### PR TITLE
BUG: don't assume that channel info contains particular keys

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -32,6 +32,7 @@ Enhancements
 
 Bugs
 ~~~~
+- Fix bug in :func:`mne.io.read_raw_eeglab` where unlabeled fiducials causde reading errors (:gh:`11074` by :newcontrib:`Sebastiaan Mathot`)
 - Fix bug in :func:`mne.decoding.TimeFrequency` that prevented cloning if constructor arguments were modified (:gh:`11004` by :newcontrib:`Daniel Carlström Schad`)
 - Fix bug in :class:`mne.viz.Brain` constructor where the first argument was named ``subject_id`` instead of ``subject`` (:gh:`11049` by `Eric Larson`_)
 - Document ``height`` and ``weight`` keys of  ``subject_info`` entry in :class:`mne.Info` (:gh:`11019` by :newcontrib:`Sena Er`)

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -408,6 +408,8 @@
 
 .. _Scott Huberty:  https://orcid.org/0000-0003-2637-031X
 
+.. _Sebastiaan Mathot: http://www.cogsci.nl/smathot
+
 .. _Sebastian Castano: https://github.com/jscastanoc
 
 .. _Sebastian Major: https://github.com/major-s

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -148,13 +148,13 @@ def _get_montage_information(eeg, get_pos):
             len(eeg.chaninfo['nodatchans'])):
         for item in list(zip(*eeg.chaninfo['nodatchans'].values())):
             d = dict(zip(eeg.chaninfo['nodatchans'].keys(), item))
-            if d["type"] != 'FID':
+            if d.get("type", None) != 'FID':
                 continue
-            elif d['description'] == 'Nasion':
+            elif d.get('description', None) == 'Nasion':
                 nasion = np.array([d["X"], d["Y"], d["Z"]])
-            elif d['description'] == 'Right periauricular point':
+            elif d.get('description', None) == 'Right periauricular point':
                 rpa = np.array([d["X"], d["Y"], d["Z"]])
-            elif d['description'] == 'Left periauricular point':
+            elif d.get('description', None) == 'Left periauricular point':
                 lpa = np.array([d["X"], d["Y"], d["Z"]])
 
     if pos_ch_names:

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -143,9 +143,7 @@ def _get_montage_information(eeg, get_pos):
                         for key in sorted(unknown_types)]))
 
     lpa, rpa, nasion = None, None, None
-    if (hasattr(eeg, "chaninfo") and
-            "nodatchans" in eeg.chaninfo and
-            len(eeg.chaninfo['nodatchans'])):
+    if hasattr(eeg, "chaninfo") and len(eeg.chaninfo.get('nodatchans', [])):
         for item in list(zip(*eeg.chaninfo['nodatchans'].values())):
             d = dict(zip(eeg.chaninfo['nodatchans'].keys(), item))
             if d.get("type", None) != 'FID':


### PR DESCRIPTION
#### What does this implement/fix?

Load a specific `.set` file broke in the latest release of MNE. The reason is a regression introduced along with 5e60e475ef8019af73cc81e184a10bde524c681f, which assumes that certain fields exist, thus resulting in a crash when they don't. It's possible that my `.set` is non-standard, I'm not familiar enough with the format to be able to say that, but this PR seems safe enough in any case.

closes #11039