### PR TITLE
Add _on_missing functionality to UpdateChannelsMixin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           type: string
           default: "false"
       docker:
-        - image: cimg/base:stable-20.04
+        - image: cimg/base:current-22.04
       steps:
         - restore_cache:
             keys:
@@ -88,8 +88,8 @@ jobs:
             command: |
               set -e
               ./tools/setup_xvfb.sh
-              sudo apt install -qq graphviz optipng python3.8-venv python3-venv libxft2 ffmpeg
-              python3.8 -m venv ~/python_env
+              sudo apt install -qq graphviz optipng python3.10-venv python3-venv libxft2 ffmpeg
+              python3.10 -m venv ~/python_env
               echo "set -e" >> $BASH_ENV
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
               echo "export XDG_RUNTIME_DIR=/tmp/runtime-circleci" >> $BASH_ENV
@@ -127,7 +127,7 @@ jobs:
               - pip-cache
         - restore_cache:
             keys:
-              - user-install-bin-cache
+              - user-install-bin-cache-310
 
         # Hack in uninstalls of libraries as necessary if pip doesn't do the right thing in upgrading for us...
         - run:
@@ -140,9 +140,9 @@ jobs:
             paths:
               - ~/.cache/pip
         - save_cache:
-            key: user-install-bin-cache
+            key: user-install-bin-cache-310
             paths:
-              - ~/.local/lib/python3.8/site-packages
+              - ~/.local/lib/python3.10/site-packages
               - ~/.local/bin
 
         - run:

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -32,7 +32,7 @@ Enhancements
 - Add ``starting_affine`` keyword argument to :func:`mne.transforms.compute_volume_registration` to initialize an alignment with an affine (:gh:`11020` by `Alex Rockhill`_)
 - The ``trans`` parameter in :func:`mne.make_field_map` now accepts a :class:`~pathlib.Path` object, and uses standardised loading logic (:gh:`10784` by :newcontrib:`Andrew Quinn`)
 - Allow :func:`mne.beamformer.make_dics` to take ``pick_ori='vector'`` to compute vector source estimates (:gh:`19080` by `Alex Rockhill`_)
-- Add ``on_missing`` functionality to :class:`mne.channels.channels.UpdateChannelsMixin` to tune drop_channels behaviour when specified channel names are not found(:gh:`11043` by `Andrew Quinn`_)
+Add ``on_missing`` functionality to all of our classes that have a ``drop_channels`` method, to control what happens when channel names are not in the object (:gh:`11043` by `Andrew Quinn`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -32,7 +32,7 @@ Enhancements
 - Add ``starting_affine`` keyword argument to :func:`mne.transforms.compute_volume_registration` to initialize an alignment with an affine (:gh:`11020` by `Alex Rockhill`_)
 - The ``trans`` parameter in :func:`mne.make_field_map` now accepts a :class:`~pathlib.Path` object, and uses standardised loading logic (:gh:`10784` by :newcontrib:`Andrew Quinn`)
 - Allow :func:`mne.beamformer.make_dics` to take ``pick_ori='vector'`` to compute vector source estimates (:gh:`19080` by `Alex Rockhill`_)
-Add ``on_missing`` functionality to all of our classes that have a ``drop_channels`` method, to control what happens when channel names are not in the object (:gh:`11077` by `Andrew Quinn`_)
+- Add ``on_missing`` functionality to all of our classes that have a ``drop_channels`` method, to control what happens when channel names are not in the object (:gh:`11077` by `Andrew Quinn`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -31,7 +31,7 @@ Enhancements
 - :meth:`mne.Epochs.plot_psd_topomap` now suppresses redundant colorbars when ``vlim='joint'`` (:gh:`11051` by `Daniel McCloy`_)
 - Add ``starting_affine`` keyword argument to :func:`mne.transforms.compute_volume_registration` to initialize an alignment with an affine (:gh:`11020` by `Alex Rockhill`_)
 - The ``trans`` parameter in :func:`mne.make_field_map` now accepts a :class:`~pathlib.Path` object, and uses standardised loading logic (:gh:`10784` by :newcontrib:`Andrew Quinn`)
-- Add ``on_missing`` functionality to :class:`mne.channels.UpdateChannelsMixin` to tune drop_channels behaviour when specified channel names are not found(:gh:`11043` by `Andrew Quinn`_)
+- Add ``on_missing`` functionality to :class:`mne.channels.channels.UpdateChannelsMixin` to tune drop_channels behaviour when specified channel names are not found(:gh:`11043` by `Andrew Quinn`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -32,7 +32,7 @@ Enhancements
 - Add ``starting_affine`` keyword argument to :func:`mne.transforms.compute_volume_registration` to initialize an alignment with an affine (:gh:`11020` by `Alex Rockhill`_)
 - The ``trans`` parameter in :func:`mne.make_field_map` now accepts a :class:`~pathlib.Path` object, and uses standardised loading logic (:gh:`10784` by :newcontrib:`Andrew Quinn`)
 - Allow :func:`mne.beamformer.make_dics` to take ``pick_ori='vector'`` to compute vector source estimates (:gh:`19080` by `Alex Rockhill`_)
-- Add ``on_missing`` functionality to :class:`mne.channels.UpdateChannelsMixin` to tune drop_channels behaviour when specified channel names are not found(:gh:`11043` by `Andrew Quinn`_)
+- Add ``on_missing`` functionality to :class:`mne.channels.channels.UpdateChannelsMixin` to tune drop_channels behaviour when specified channel names are not found(:gh:`11043` by `Andrew Quinn`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -28,6 +28,7 @@ Enhancements
 - Improve ``repr()`` for :class:`mne.minimum_norm.InverseOperator` when loose orientation is used (:gh:`11048` by `Eric Larson`_)
 - :meth:`mne.Epochs.plot_psd_topomap` now suppresses redundant colorbars when ``vlim='joint'`` (:gh:`11051` by `Daniel McCloy`_)
 - Add ``starting_affine`` keyword argument to :func:`mne.transforms.compute_volume_registration` to initialize an alignment with an affine (:gh:`11020` by `Alex Rockhill`_)
+- Add ``on_missing`` functionality to :class:`mne.channels.UpdateChannelsMixin` to tune drop_channels behaviour when specified channel names are not found(:gh:`11043` by `Andrew Quinn`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -32,7 +32,7 @@ Enhancements
 - Add ``starting_affine`` keyword argument to :func:`mne.transforms.compute_volume_registration` to initialize an alignment with an affine (:gh:`11020` by `Alex Rockhill`_)
 - The ``trans`` parameter in :func:`mne.make_field_map` now accepts a :class:`~pathlib.Path` object, and uses standardised loading logic (:gh:`10784` by :newcontrib:`Andrew Quinn`)
 - Allow :func:`mne.beamformer.make_dics` to take ``pick_ori='vector'`` to compute vector source estimates (:gh:`19080` by `Alex Rockhill`_)
-Add ``on_missing`` functionality to all of our classes that have a ``drop_channels`` method, to control what happens when channel names are not in the object (:gh:`11043` by `Andrew Quinn`_)
+Add ``on_missing`` functionality to all of our classes that have a ``drop_channels`` method, to control what happens when channel names are not in the object (:gh:`11077` by `Andrew Quinn`_)
 
 Bugs
 ~~~~

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -24,7 +24,8 @@ import numpy as np
 from ..defaults import HEAD_SIZE_DEFAULT, _handle_default
 from ..utils import (verbose, logger, warn,
                      _check_preload, _validate_type, fill_doc, _check_option,
-                     _get_stim_channel, _check_fname, _check_dict_keys)
+                     _get_stim_channel, _check_fname, _check_dict_keys,
+                     _on_missing)
 from ..io.constants import FIFF
 from ..io.meas_info import (anonymize_info, Info, MontageMixin, create_info,
                             _rename_comps)
@@ -735,13 +736,14 @@ class UpdateChannelsMixin(object):
             idx.append(ii)
         return self._pick_drop_channels(idx)
 
-    def drop_channels(self, ch_names):
+    def drop_channels(self, ch_names, on_missing='raise'):
         """Drop channel(s).
 
         Parameters
         ----------
         ch_names : iterable or str
             Iterable (e.g. list) of channel name(s) or channel name to remove.
+        %(on_missing_ch_names)s
 
         Returns
         -------
@@ -774,7 +776,7 @@ class UpdateChannelsMixin(object):
         missing = [ch for ch in ch_names if ch not in self.ch_names]
         if len(missing) > 0:
             msg = "Channel(s) {0} not found, nothing dropped."
-            raise ValueError(msg.format(", ".join(missing)))
+            _on_missing(on_missing, msg.format(", ".join(missing)))
 
         bad_idx = [self.ch_names.index(ch) for ch in ch_names
                    if ch in self.ch_names]

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -736,6 +736,7 @@ class UpdateChannelsMixin(object):
             idx.append(ii)
         return self._pick_drop_channels(idx)
 
+    @fill_doc
     def drop_channels(self, ch_names, on_missing='raise'):
         """Drop channel(s).
 

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -454,7 +454,7 @@ def test_drop_channels():
     with pytest.raises(ValueError, match='not found, nothing dropped'):
         raw.drop_channels(m_chs)
     # ...but this can be turned to a warning
-    with pytest.raises(RuntimeWarning, match='not found, nothing dropped'):
+    with pytest.warns(RuntimeWarning, match='not found, nothing dropped'):
         raw.drop_channels(m_chs, on_missing='warn')
     # ...or ignored altogether
     raw.drop_channels(m_chs, on_missing='ignore')

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -451,9 +451,11 @@ def test_drop_channels():
 
     # by default, drop channels raises a ValueError if a channel can't be found
     m_chs = ["MEG 0111", "MEG blahblah"]
-    pytest.raises(ValueError, raw.drop_channels, m_chs)
+    with pytest.raises(ValueError, match='not found, nothing dropped'):
+        raw.drop_channels(m_chs)
     # ...but this can be turned to a warning
-    pytest.warns(RuntimeWarning, raw.drop_channels, m_chs, on_missing='warn')
+    with pytest.raises(RuntimeWarning, match='not found, nothing dropped'):
+        raw.drop_channels(m_chs, on_missing='warn')
     # ...or ignored altogether
     raw.drop_channels(m_chs, on_missing='ignore')
 

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -449,6 +449,14 @@ def test_drop_channels():
     pytest.raises(ValueError, raw.drop_channels, ["MEG 0111", 5])
     pytest.raises(ValueError, raw.drop_channels, 5)  # must be list or str
 
+    # by default, drop channels raises a ValueError if a channel can't be found
+    m_chs = ["MEG 0111", "MEG blahblah"]
+    pytest.raises(ValueError, raw.drop_channels, m_chs)
+    # ...but this can be turned to a warning
+    pytest.warns(RuntimeWarning, raw.drop_channels, m_chs, on_missing='warn')
+    # ...or ignored altogether
+    raw.drop_channels(m_chs, on_missing='ignore')
+
 
 def test_pick_channels():
     """Test if picking channels works with various arguments."""


### PR DESCRIPTION
#### Reference issue
Example: Fixes #11043.

#### What does this implement/fix?
This PR adds _on_missing functionality to UpdateChannelsMixin to customise behaviour when specified channel names are not found in object. 
