### PR TITLE
Add error message when conversion of EEG locs to head space fails

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -35,6 +35,7 @@ Bugs
 - Fix bug in :class:`mne.viz.Brain` constructor where the first argument was named ``subject_id`` instead of ``subject`` (:gh:`11049` by `Eric Larson`_)
 - Document ``height`` and ``weight`` keys of  ``subject_info`` entry in :class:`mne.Info` (:gh:`11019` by :newcontrib:`Sena Er`)
 - Fixed bug in :func:`mne.viz.plot_filter` when plotting filters created using ``output='ba'`` mode with ``compensation`` turned on. (by `Marian Dovgialo`_)
+- Applying a montage where EEG locations are not in head space (or unknown space) without fiducials will now raise an error message. (:gh:`11080` by `Marijn van Vliet`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -668,11 +668,19 @@ def transform_to_head(montage):
     # Get fiducial points and their coord_frame
     native_head_t = compute_native_head_t(montage)
     montage = montage.copy()  # to avoid inplace modification
+
     if native_head_t['from'] != FIFF.FIFFV_COORD_HEAD:
         for d in montage.dig:
             if d['coord_frame'] == native_head_t['from']:
                 d['r'] = apply_trans(native_head_t, d['r'])
                 d['coord_frame'] = FIFF.FIFFV_COORD_HEAD
+            elif d['kind'] == FIFF.FIFFV_POINT_EEG:
+                raise RuntimeError(
+                    f'Could not transform EEG channel {d["ident"]} position '
+                    f'from {_verbose_frames[d["coord_frame"]]} to head '
+                    'coordinates. Fiducial points are either missing or '
+                    'specified in a different coordinate frame than the EEG '
+                    'channel locations.')
     return montage
 
 

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1210,6 +1210,17 @@ def test_transform_to_head_and_compute_dev_head_t():
             montage_polhemus
         ))
 
+    # Test errors when transforming without fiducials explicitly where points
+    # are tagged to be not in head or unknown coord space.
+    montage_without_fids = make_dig_montage(
+        ch_pos={"ch_1": np.array([1, 2, 3]),
+                "ch_2": np.array([4, 5, 6]),
+                "ch_3": np.array([7, 8, 9])},
+        coord_frame="mri")  # MRI coordinate space
+    with pytest.raises(RuntimeError, match='Could not transform EEG channel'):
+        with pytest.warns(RuntimeWarning, match='Fiducial point .* not found'):
+            transform_to_head(montage_without_fids)
+
 
 def test_set_montage_with_mismatching_ch_names():
     """Test setting a DigMontage with mismatching ch_names."""

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -300,7 +300,7 @@ def _get_fid_coords(dig, raise_error=True):
     if len(fid_coord_frames) > 0 and raise_error:
         if set(fid_coord_frames.keys()) != set(['nasion', 'lpa', 'rpa']):
             raise ValueError("Some fiducial points are missing (got %s)." %
-                             fid_coords.keys())
+                             fid_coord_frames.keys())
 
         if len(set(fid_coord_frames.values())) > 1:
             raise ValueError(


### PR DESCRIPTION
When calling `.set_montage()`, all digitized points are transformed into head coordinate space if possible. This is not possible when there are no fiducials and the original points are not in head space already. MNE-Python is lenient when the coordinate space of the original points is marked as "unknown", assuming they are in head space. However, when the points are explicitly marked as being in some other space (e.g. MRI), then they will not get converted without fiducials.

Since MNE-Python requires all EEG channel positions to be in head space, we should raise an error when `.set_montage()` fails to do this.

Fixes #10946.