### PR TITLE
[BUG] Fix plot_topomap with sphere="eeglab"

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -41,7 +41,8 @@ Bugs
 - Fix bug in :func:`mne.decoding.TimeFrequency` that prevented cloning if constructor arguments were modified (:gh:`11004` by :newcontrib:`Daniel Carlström Schad`)
 - Fix bug in :class:`mne.viz.Brain` constructor where the first argument was named ``subject_id`` instead of ``subject`` (:gh:`11049` by `Eric Larson`_)
 - Document ``height`` and ``weight`` keys of  ``subject_info`` entry in :class:`mne.Info` (:gh:`11019` by :newcontrib:`Sena Er`)
-- Fixed bug in :func:`mne.viz.plot_filter` when plotting filters created using ``output='ba'`` mode with ``compensation`` turned on. (by `Marian Dovgialo`_)
+- Fix bug in :func:`mne.viz.plot_filter` when plotting filters created using ``output='ba'`` mode with ``compensation`` turned on. (:gh:`11040` by `Marian Dovgialo`_)
+- Fix bug in :func:`mne.viz.plot_topomap` when providing ``sphere="eeglab"`` (:gh:`11081` by `Mathieu Scheltienne`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -739,6 +739,12 @@ def test_plot_bridged_electrodes():
                                                     vmax=1, show_names=True))
     # two bridged lines plus head outlines
     assert len(fig.axes[0].lines) == 6
+    # test with sphere="eeglab"
+    fig = plot_bridged_electrodes(
+        info, bridged_idx, ed_matrix,
+        topomap_args=dict(names=info.ch_names, sphere="eeglab",
+                          vmax=1, show_names=True)
+    )
 
     with pytest.raises(RuntimeError, match='Expected'):
         plot_bridged_electrodes(info, bridged_idx, np.zeros((5, 6, 7)))

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -792,7 +792,7 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     :doc:`matplotlib docs <matplotlib:tutorials/colors/colormapnorms>`
     for more details on colormap normalization.
     """
-    sphere = _check_sphere(sphere)
+    sphere = _check_sphere(sphere, pos if isinstance(pos, Info) else None)
     from matplotlib.colors import Normalize
     _validate_type(cnorm, (Normalize, None), 'cnorm')
     if cnorm is not None:


### PR DESCRIPTION
I remember seeing that it was now possible to set `sphere="eeglab"` but it requires that an `Info` gets provided to `_check_sphere`.

Failing on main, fixed here:

```
import mne


raw_fname = mne.datasets.eegbci.load_data(subject=6, runs=(1,))[0]
raw = mne.io.read_raw(raw_fname, preload=True, verbose=False)
mne.datasets.eegbci.standardize(raw)  # set channel names
raw.set_montage("standard_1005", verbose=False)

bridged_idx, ed_matrix = mne.preprocessing.compute_bridged_electrodes(raw)

mne.viz.plot_bridged_electrodes(
    raw.info, 
    bridged_idx, 
    ed_matrix, 
    topomap_args=dict(vmax=5, sphere="eeglab")
)
```

The test I added is a bit indirect, but it was simpler 😅 