### PR TITLE
Combine gradiometer channels

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2111,8 +2111,12 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
         .. versionadded:: 0.20.0
         """
-        from .forward import _as_meg_type_inst
-        return _as_meg_type_inst(self, ch_type=ch_type, mode=mode)
+        if ch_type == 'combined_grad':
+            from .channels.layout import _combine_meg_grads
+            return _combine_meg_grads(self, method=mode)
+        else:
+            from .forward import _as_meg_type_inst
+            return _as_meg_type_inst(self, ch_type=ch_type, mode=mode)
 
 
 def _drop_log_stats(drop_log, ignore=('IGNORED',)):


### PR DESCRIPTION
This is a work-in-progress start on general functions to combine meg gradiometer channels. 

Idea is to allow users to combine gradiometer channels in the standard data instances, and eventually to replace the channel combining code used in mne/viz with this more general solution.

Would be great to get some feedback etc - any/all opinions welcome! @drammock @larsoner @agramfort 

Some points for next steps...
 - modify coil_type and kind to something indicating a combined gradiometer
 - modify channel units, depending on combination method
 - currently `_combine_meg_grads` assumes inst only contains 'grads'
 - outsource return instance creation in `_combine_meg_grads` to specific class methods
 - need to handle noise_cov? projections?
 - addtional combination methods? eg PCA/SVD
 
#### Reference issue
Relevant: #1280

#### What does this implement/fix?
I've implemented a private function in `mne.channels.layout` and linked it up to `epochs.as_type` as a first use-case
