### PR TITLE
ENH : add units parameter to read_raw_edf in case units is missing from the file

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,6 +34,7 @@ Enhancements
 - The ``trans`` parameter in :func:`mne.make_field_map` now accepts a :class:`~pathlib.Path` object, and uses standardised loading logic (:gh:`10784` by :newcontrib:`Andrew Quinn`)
 - Add HTML representation for `~mne.Evoked` in Jupyter Notebooks (:gh:`11075` by `Valerii Chirkov`_ and `Andrew Quinn`_)
 - Allow :func:`mne.beamformer.make_dics` to take ``pick_ori='vector'`` to compute vector source estimates (:gh:`19080` by `Alex Rockhill`_)
+- Add ``units`` parameter to :func:`mne.io.read_raw_edf` in case units are missing from the file (:gh:`11099` by `Alex Gramfort`_)
 - Add ``on_missing`` functionality to all of our classes that have a ``drop_channels`` method, to control what happens when channel names are not in the object (:gh:`11077` by `Andrew Quinn`_)
 
 Bugs

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -147,8 +147,8 @@ class RawEDF(BaseRaw):
         for k, (this_ch, this_unit) in enumerate(orig_units.items()):
             if this_unit != "" and this_unit in units:
                 raise ValueError(f'Unit for channel {this_ch} is present in '
-                                 'the file. Cannot overwrite it with the units '
-                                 'argument.')
+                                 'the file. Cannot overwrite it with the '
+                                 'units argument.')
             if this_unit == "" and this_ch in units:
                 orig_units[this_ch] = units[this_ch]
                 ch_type = edf_info["ch_types"][k]

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -146,8 +146,9 @@ class RawEDF(BaseRaw):
 
         for k, (this_ch, this_unit) in enumerate(orig_units.items()):
             if this_unit != "" and this_unit in units:
-                raise ValueError(f'Unit for channel {this_ch} is present in the file.'
-                                 ' . Cannot overwrite it with the units argument.')
+                raise ValueError(f'Unit for channel {this_ch} is present in '
+                                 'the file. Cannot overwrite it with the units '
+                                 'argument.')
             if this_unit == "" and this_ch in units:
                 orig_units[this_ch] = units[this_ch]
                 ch_type = edf_info["ch_types"][k]
@@ -160,8 +161,6 @@ class RawEDF(BaseRaw):
                          raw_extras=[edf_info], last_samps=last_samps,
                          orig_format='int', orig_units=orig_units,
                          verbose=verbose)
-
-        import ipdb; ipdb.set_trace()
 
         # Read annotations from file and set it
         onset, duration, desc = list(), list(), list()

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -83,7 +83,7 @@ class RawEDF(BaseRaw):
 
         .. versionadded:: 1.1
     %(preload)s
-    %(units_edf_io)s
+    %(units_edf_bdf_io)s
     %(verbose)s
 
     See Also
@@ -143,6 +143,8 @@ class RawEDF(BaseRaw):
 
         if units is not None and isinstance(units, str):
             units = {ch_name: units for ch_name in info['ch_names']}
+        elif units is None:
+            units = dict()
 
         for k, (this_ch, this_unit) in enumerate(orig_units.items()):
             if this_unit != "" and this_unit in units:
@@ -1337,7 +1339,7 @@ def read_raw_edf(input_fname, eog=None, misc=None, stim_channel='auto',
 
         .. versionadded:: 1.1
     %(preload)s
-    %(units_edf_io)s
+    %(units_edf_bdf_io)s
     %(verbose)s
 
     Returns
@@ -1406,7 +1408,7 @@ def read_raw_edf(input_fname, eog=None, misc=None, stim_channel='auto',
 @fill_doc
 def read_raw_bdf(input_fname, eog=None, misc=None, stim_channel='auto',
                  exclude=(), infer_types=False, include=None, preload=False,
-                 verbose=None):
+                 units=None, *, verbose=None):
     """Reader function for BDF files.
 
     Parameters
@@ -1446,6 +1448,7 @@ def read_raw_bdf(input_fname, eog=None, misc=None, stim_channel='auto',
 
         .. versionadded:: 1.1
     %(preload)s
+    %(units_edf_bdf_io)s
     %(verbose)s
 
     Returns
@@ -1501,7 +1504,7 @@ def read_raw_bdf(input_fname, eog=None, misc=None, stim_channel='auto',
     return RawEDF(input_fname=input_fname, eog=eog, misc=misc,
                   stim_channel=stim_channel, exclude=exclude,
                   infer_types=infer_types, preload=preload, include=include,
-                  verbose=verbose)
+                  units=units, verbose=verbose)
 
 
 @fill_doc

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3504,6 +3504,14 @@ units : str | dict | None
     channel-type-specific default unit.
 """
 
+docdict['units_edf_io'] = """
+    units : dict | str
+        The units of the channels as stored in the .edf file. This argument
+        is useful only if the units are missing from the original file.
+        If a dict, it must map a channel name to its unit, and if str
+        it is assumed that all channels have the same units.
+"""
+
 docdict['units_topomap'] = """
 units : dict | str | None
     The unit of the channel type used for colorbar label. If

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3504,9 +3504,9 @@ units : str | dict | None
     channel-type-specific default unit.
 """
 
-docdict['units_edf_io'] = """
+docdict['units_edf_bdf_io'] = """
     units : dict | str
-        The units of the channels as stored in the .edf file. This argument
+        The units of the channels as stored in the file. This argument
         is useful only if the units are missing from the original file.
         If a dict, it must map a channel name to its unit, and if str
         it is assumed that all channels have the same units.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3505,11 +3505,11 @@ units : str | dict | None
 """
 
 docdict['units_edf_bdf_io'] = """
-    units : dict | str
-        The units of the channels as stored in the file. This argument
-        is useful only if the units are missing from the original file.
-        If a dict, it must map a channel name to its unit, and if str
-        it is assumed that all channels have the same units.
+units : dict | str
+    The units of the channels as stored in the file. This argument
+    is useful only if the units are missing from the original file.
+    If a dict, it must map a channel name to its unit, and if str
+    it is assumed that all channels have the same units.
 """
 
 docdict['units_topomap'] = """


### PR DESCRIPTION
related to https://github.com/mne-tools/mne-bids/pull/1045 and https://github.com/mne-tools/mne-bids/issues/1044

now with the data from ds003775 you can just do:

`raw = mne.io.read_raw_edf(bp, units='uV')`

and in mne-bids

`raw = read_raw_bids(bp, extra_params={'units': 'uV'})`

what do you think @sappelhoff @hoechenberger ?