### PR TITLE
BUG: Improve logic for bti

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -46,8 +46,8 @@ Bugs
 - Fix bug in :class:`mne.viz.Brain` constructor where the first argument was named ``subject_id`` instead of ``subject`` (:gh:`11049` by `Eric Larson`_)
 - Fix bug in :ref:`mne coreg` where the MEG helmet position was not updated during ICP fitting (:gh:`11084` by `Eric Larson`_)
 - Document ``height`` and ``weight`` keys of  ``subject_info`` entry in :class:`mne.Info` (:gh:`11019` by :newcontrib:`Sena Er`)
-- Fixed bug in :func:`mne.viz.plot_filter` when plotting filters created using ``output='ba'`` mode with ``compensation`` turned on. (by `Marian Dovgialo`_)
 - Fix bug in :func:`mne.viz.plot_filter` when plotting filters created using ``output='ba'`` mode with ``compensation`` turned on. (:gh:`11040` by `Marian Dovgialo`_)
+- Fix bug in :func:`mne.io.read_raw_bti` where EEG, EMG, and H/VEOG channels were not detected properly, and many non-ECG channels were called ECG. The logic has been improved, and any channels of unknown type are now labeled as ``misc`` (:gh:`11102` by `Eric Larson`)
 - Fix bug in :func:`mne.viz.plot_topomap` when providing ``sphere="eeglab"`` (:gh:`11081` by `Mathieu Scheltienne`_)
 - Applying a montage where EEG locations are not in head space (or unknown space) without fiducials will now raise an error message. (:gh:`11080` by `Marijn van Vliet`_)
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -47,7 +47,7 @@ Bugs
 - Fix bug in :ref:`mne coreg` where the MEG helmet position was not updated during ICP fitting (:gh:`11084` by `Eric Larson`_)
 - Document ``height`` and ``weight`` keys of  ``subject_info`` entry in :class:`mne.Info` (:gh:`11019` by :newcontrib:`Sena Er`)
 - Fix bug in :func:`mne.viz.plot_filter` when plotting filters created using ``output='ba'`` mode with ``compensation`` turned on. (:gh:`11040` by `Marian Dovgialo`_)
-- Fix bug in :func:`mne.io.read_raw_bti` where EEG, EMG, and H/VEOG channels were not detected properly, and many non-ECG channels were called ECG. The logic has been improved, and any channels of unknown type are now labeled as ``misc`` (:gh:`11102` by `Eric Larson`)
+- Fix bug in :func:`mne.io.read_raw_bti` where EEG, EMG, and H/VEOG channels were not detected properly, and many non-ECG channels were called ECG. The logic has been improved, and any channels of unknown type are now labeled as ``misc`` (:gh:`11102` by `Eric Larson`_)
 - Fix bug in :func:`mne.viz.plot_topomap` when providing ``sphere="eeglab"`` (:gh:`11081` by `Mathieu Scheltienne`_)
 - Applying a montage where EEG locations are not in head space (or unknown space) without fiducials will now raise an error message. (:gh:`11080` by `Marijn van Vliet`_)
 

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -8,7 +8,7 @@
 #
 #          simplified BSD-3 license
 
-from functools import lru_cache
+import functools
 import os.path as op
 from io import BytesIO
 from itertools import count
@@ -998,7 +998,7 @@ class RawBTi(BaseRaw):
                 _mult_cal_one(data_view, one, idx, cals, mult)
 
 
-@lru_cache
+@functools.cache
 def _1020_names():
     from mne.channels import make_standard_montage
     return set(ch_name.lower()

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -998,7 +998,7 @@ class RawBTi(BaseRaw):
                 _mult_cal_one(data_view, one, idx, cals, mult)
 
 
-@functools.cache
+@functools.lru_cache(1)
 def _1020_names():
     from mne.channels import make_standard_montage
     return set(ch_name.lower()

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -46,7 +46,7 @@ def _instantiate_default_info_chs():
                 coord_frame=FIFF.FIFFV_COORD_UNKNOWN,
                 coil_type=FIFF.FIFFV_COIL_NONE,
                 range=1.0,
-                unit=FIFF.FIFF_UNIT_NONE,
+                unit=FIFF.FIFF_UNIT_V,
                 cal=1.0,
                 scanno=None,
                 kind=FIFF.FIFFV_MISC_CH,
@@ -1219,10 +1219,10 @@ def _get_bti_info(pdf_fname, config_fname, head_shape_fname, rotation_x,
             chan_info['kind'] = FIFF.FIFFV_EMG_CH
         elif chan_4d == ecg_ch or chan_4d.startswith('ECG'):
             chan_info['kind'] = FIFF.FIFFV_ECG_CH
-        elif chan_4d.startswith('X'):
-            chan_info['kind'] = FIFF.FIFFV_MISC_CH
-        elif chan_4d == 'UACurrent':
-            chan_info['kind'] = FIFF.FIFFV_MISC_CH
+        # Our default is now misc, but if we ever change that,
+        # we'll need this:
+        # elif chan_4d.startswith('X') or chan_4d == 'UACurrent':
+        #     chan_info['kind'] = FIFF.FIFFV_MISC_CH
 
         chs.append(chan_info)
 


### PR DESCRIPTION
We can do better with the logic:

1. Unknown channels should be MISC not ECG
2. Check for HEOG/VEOG prefixes to set as EOG
3. Check for EMG prefix to set as EMG
4. Check for `anode-cathode` pattern for EEG channel names to automatically set as EEG

Closes #10988