### PR TITLE
MAINT: Refactor forward solution code

### DIFF
--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -1337,18 +1337,11 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=None,
 
     sensors = dict()
     if 'grad' in ch_types or 'mag' in ch_types:
-        megcoils, compcoils, megnames, meg_info = \
-            _prep_meg_channels(info, exclude='bads',
-                               accuracy=accuracy, verbose=verbose)
-        sensors['meg'] = dict(
-            defs=megcoils, comp_defs=compcoils, info=meg_info,
-            ch_names=megnames)
-        del megcoils, compcoils, megnames, meg_info
+        sensors['meg'] = _prep_meg_channels(
+            info, exclude='bads', accuracy=accuracy, verbose=verbose)
     if 'eeg' in ch_types:
-        eegels, eegnames = _prep_eeg_channels(info, exclude='bads',
-                                              verbose=verbose)
-        sensors['eeg'] = dict(defs=eegels, ch_names=eegnames)
-        del eegels, eegnames
+        sensors['eeg'] = _prep_eeg_channels(
+            info, exclude='bads', verbose=verbose)
 
     # Ensure that MEG and/or EEG channels are present
     if len(sensors) == 0:

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -722,10 +722,11 @@ def _write_dipole_bdip(fname, dip):
 # #############################################################################
 # Fitting
 
-def _dipole_forwards(fwd_data, whitener, rr, n_jobs=None):
+def _dipole_forwards(*, sensors, fwd_data, whitener, rr, n_jobs=None):
     """Compute the forward solution and do other nice stuff."""
-    B = _compute_forwards_meeg(rr, fwd_data, n_jobs, silent=True)
-    B = np.concatenate(B, axis=1)
+    B = _compute_forwards_meeg(
+        rr, sensors=sensors, fwd_data=fwd_data, n_jobs=n_jobs, silent=True)
+    B = np.concatenate(list(B.values()), axis=1)
     assert np.isfinite(B).all()
     B_orig = B.copy()
 
@@ -763,11 +764,13 @@ def _make_guesses(surf, grid, exclude, mindist, n_jobs=None, verbose=None):
     return SourceSpaces([src])
 
 
-def _fit_eval(rd, B, B2, fwd_svd=None, fwd_data=None, whitener=None,
-              lwork=None):
+def _fit_eval(rd, B, B2, *, sensors, fwd_data, whitener, lwork, fwd_svd):
     """Calculate the residual sum of squares."""
     if fwd_svd is None:
-        fwd = _dipole_forwards(fwd_data, whitener, rd[np.newaxis, :])[0]
+        assert sensors is not None
+        fwd = _dipole_forwards(
+            sensors=sensors, fwd_data=fwd_data, whitener=whitener,
+            rr=rd[np.newaxis, :])[0]
         uu, sing, vv = _repeated_svd(fwd, lwork, overwrite_a=True)
     else:
         uu, sing, vv = fwd_svd
@@ -791,7 +794,7 @@ def _dipole_gof(uu, sing, vv, B, B2):
     return gof, one
 
 
-def _fit_Q(fwd_data, whitener, B, B2, B_orig, rd, ori=None):
+def _fit_Q(*, sensors, fwd_data, whitener, B, B2, B_orig, rd, ori=None):
     """Fit the dipole moment once the location is known."""
     from scipy import linalg
     if 'fwd' in fwd_data:
@@ -805,8 +808,9 @@ def _fit_Q(fwd_data, whitener, B, B2, B_orig, rd, ori=None):
         assert scales.shape == (3,)
         fwd_svd = fwd_data['fwd_svd'][0]
     else:
-        fwd, fwd_orig, scales = _dipole_forwards(fwd_data, whitener,
-                                                 rd[np.newaxis, :])
+        fwd, fwd_orig, scales = _dipole_forwards(
+            sensors=sensors, fwd_data=fwd_data, whitener=whitener,
+            rr=rd[np.newaxis, :])
         fwd_svd = None
     if ori is None:
         if fwd_svd is None:
@@ -830,15 +834,18 @@ def _fit_Q(fwd_data, whitener, B, B2, B_orig, rd, ori=None):
 
 
 def _fit_dipoles(fun, min_dist_to_inner_skull, data, times, guess_rrs,
-                 guess_data, fwd_data, whitener, ori, n_jobs, rank, rhoend):
+                 guess_data, *, sensors, fwd_data, whitener, ori, n_jobs,
+                 rank, rhoend):
     """Fit a single dipole to the given whitened, projected data."""
     from scipy.optimize import fmin_cobyla
     parallel, p_fun, n_jobs = parallel_func(fun, n_jobs)
     # parallel over time points
-    res = parallel(p_fun(min_dist_to_inner_skull, B, t, guess_rrs,
-                         guess_data, fwd_data, whitener,
-                         fmin_cobyla, ori, rank, rhoend)
-                   for B, t in zip(data.T, times))
+    res = parallel(
+        p_fun(
+            min_dist_to_inner_skull, B, t, guess_rrs, guess_data,
+            sensors=sensors, fwd_data=fwd_data, whitener=whitener,
+            fmin_cobyla=fmin_cobyla, ori=ori, rank=rank, rhoend=rhoend)
+        for B, t in zip(data.T, times))
     pos = np.array([r[0] for r in res])
     amp = np.array([r[1] for r in res])
     ori = np.array([r[2] for r in res])
@@ -948,7 +955,7 @@ def _simplex_minimize(p, ftol, stol, fun, max_eval=1000):
 '''
 
 
-def _fit_confidence(rd, Q, ori, whitener, fwd_data):
+def _fit_confidence(*, rd, Q, ori, whitener, fwd_data, sensors):
     # As describedd in the Xfit manual, confidence intervals can be calculated
     # by examining a linearization of model at the best-fitting location,
     # i.e. taking the Jacobian and using the whitener:
@@ -977,11 +984,15 @@ def _fit_confidence(rd, Q, ori, whitener, fwd_data):
         for delta in deltas:
             this_r = rd[np.newaxis] + delta * direction[ii]
             fwds.append(
-                np.dot(Q, _dipole_forwards(fwd_data, whitener, this_r)[0]))
+                np.dot(Q, _dipole_forwards(
+                    sensors=sensors, fwd_data=fwd_data,
+                    whitener=whitener, rr=this_r)[0]))
         J[:, ii] = np.diff(fwds, axis=0)[0] / np.diff(deltas)[0]
     # Get current (Q) deltas in the dipole directions
     deltas = np.array([-0.01, 0.01]) * np.linalg.norm(Q)
-    this_fwd = _dipole_forwards(fwd_data, whitener, rd[np.newaxis])[0]
+    this_fwd = _dipole_forwards(
+        sensors=sensors, fwd_data=fwd_data, whitener=whitener,
+        rr=rd[np.newaxis])[0]
     for ii in range(3):
         fwds = []
         for delta in deltas:
@@ -1031,8 +1042,8 @@ def _sphere_constraint(rd, r0, R_adj):
 
 
 def _fit_dipole(min_dist_to_inner_skull, B_orig, t, guess_rrs,
-                guess_data, fwd_data, whitener, fmin_cobyla, ori, rank,
-                rhoend):
+                guess_data, *, sensors, fwd_data, whitener, fmin_cobyla,
+                ori, rank, rhoend):
     """Fit a single bit of data."""
     B = np.dot(whitener, B_orig)
 
@@ -1053,12 +1064,14 @@ def _fit_dipole(min_dist_to_inner_skull, B_orig, t, guess_rrs,
         warn('Zero field found for time %s' % t)
         return np.zeros(3), 0, np.zeros(3), 0, B
 
-    idx = np.argmin([_fit_eval(guess_rrs[[fi], :], B, B2, fwd_svd)
-                     for fi, fwd_svd in enumerate(guess_data['fwd_svd'])])
+    idx = np.argmin([
+        _fit_eval(guess_rrs[[fi], :], B, B2, fwd_svd=fwd_svd,
+                  fwd_data=None, sensors=None, whitener=None, lwork=None)
+        for fi, fwd_svd in enumerate(guess_data['fwd_svd'])])
     x0 = guess_rrs[idx]
     lwork = _svd_lwork((3, B.shape[0]))
     fun = partial(_fit_eval, B=B, B2=B2, fwd_data=fwd_data, whitener=whitener,
-                  lwork=lwork)
+                  lwork=lwork, sensors=sensors, fwd_svd=None)
 
     # Tested minimizers:
     #    Simplex, BFGS, CG, COBYLA, L-BFGS-B, Powell, SLSQP, TNC
@@ -1074,14 +1087,17 @@ def _fit_dipole(min_dist_to_inner_skull, B_orig, t, guess_rrs,
 
     # Compute the dipole moment at the final point
     Q, gof, residual_noproj, n_comp = _fit_Q(
-        fwd_data, whitener, B, B2, B_orig, rd_final, ori=ori)
+        sensors=sensors, fwd_data=fwd_data, whitener=whitener, B=B, B2=B2,
+        B_orig=B_orig, rd=rd_final, ori=ori)
     khi2 = (1 - gof) * B2
     nfree = rank - n_comp
     amp = np.sqrt(np.dot(Q, Q))
     norm = 1. if amp == 0. else amp
     ori = Q / norm
 
-    conf = _fit_confidence(rd_final, Q, ori, whitener, fwd_data)
+    conf = _fit_confidence(
+        sensors=sensors, rd=rd_final, Q=Q, ori=ori, whitener=whitener,
+        fwd_data=fwd_data)
 
     msg = '---- Fitted : %7.1f ms' % (1000. * t)
     if surf is not None:
@@ -1095,7 +1111,7 @@ def _fit_dipole(min_dist_to_inner_skull, B_orig, t, guess_rrs,
 
 
 def _fit_dipole_fixed(min_dist_to_inner_skull, B_orig, t, guess_rrs,
-                      guess_data, fwd_data, whitener,
+                      guess_data, *, sensors, fwd_data, whitener,
                       fmin_cobyla, ori, rank, rhoend):
     """Fit a data using a fixed position."""
     B = np.dot(whitener, B_orig)
@@ -1104,8 +1120,9 @@ def _fit_dipole_fixed(min_dist_to_inner_skull, B_orig, t, guess_rrs,
         warn('Zero field found for time %s' % t)
         return np.zeros(3), 0, np.zeros(3), 0, np.zeros(6)
     # Compute the dipole moment
-    Q, gof, residual_noproj = _fit_Q(guess_data, whitener, B, B2, B_orig,
-                                     rd=None, ori=ori)[:3]
+    Q, gof, residual_noproj = _fit_Q(
+        fwd_data=guess_data, whitener=whitener, B=B, B2=B2, B_orig=B_orig,
+        sensors=sensors, rd=None, ori=ori)[:3]
     if ori is None:
         amp = np.sqrt(np.dot(Q, Q))
         norm = 1. if amp == 0. else amp
@@ -1318,18 +1335,23 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=None,
     # Forward model setup (setup_forward_model from setup.c)
     ch_types = evoked.get_channel_types()
 
-    megcoils, compcoils, megnames, meg_info = [], [], [], None
-    eegels, eegnames = [], []
+    sensors = dict()
     if 'grad' in ch_types or 'mag' in ch_types:
         megcoils, compcoils, megnames, meg_info = \
             _prep_meg_channels(info, exclude='bads',
                                accuracy=accuracy, verbose=verbose)
+        sensors['meg'] = dict(
+            defs=megcoils, comp_defs=compcoils, info=meg_info,
+            ch_names=megnames)
+        del megcoils, compcoils, megnames, meg_info
     if 'eeg' in ch_types:
         eegels, eegnames = _prep_eeg_channels(info, exclude='bads',
                                               verbose=verbose)
+        sensors['eeg'] = dict(defs=eegels, ch_names=eegnames)
+        del eegels, eegnames
 
     # Ensure that MEG and/or EEG channels are present
-    if len(megcoils + eegels) == 0:
+    if len(sensors) == 0:
         raise RuntimeError('No MEG or EEG channels found.')
 
     # Whitener for the data
@@ -1378,14 +1400,13 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=None,
                              'skull boundary' % (-1000 * check,))
 
     # C code computes guesses w/sphere model for speed, don't bother here
-    fwd_data = dict(coils_list=[megcoils, eegels], infos=[meg_info, None],
-                    ccoils_list=[compcoils, None], coil_types=['meg', 'eeg'],
-                    inner_skull=inner_skull)
-    # fwd_data['inner_skull'] in head frame, bem in mri, confusing...
-    _prep_field_computation(guess_src['rr'], bem, fwd_data, n_jobs,
-                            verbose=False)
+    fwd_data = _prep_field_computation(
+        guess_src['rr'], sensors=sensors, bem=bem, n_jobs=n_jobs,
+        verbose=False)
+    fwd_data['inner_skull'] = inner_skull
     guess_fwd, guess_fwd_orig, guess_fwd_scales = _dipole_forwards(
-        fwd_data, whitener, guess_src['rr'], n_jobs=fit_n_jobs)
+        sensors=sensors, fwd_data=fwd_data, whitener=whitener,
+        rr=guess_src['rr'], n_jobs=fit_n_jobs)
     # decompose ahead of time
     guess_fwd_svd = [linalg.svd(fwd, full_matrices=False)
                      for fwd in np.array_split(guess_fwd,
@@ -1403,7 +1424,8 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=None,
     fun = _fit_dipole_fixed if fixed_position else _fit_dipole
     out = _fit_dipoles(
         fun, min_dist_to_inner_skull, data, times, guess_src['rr'],
-        guess_data, fwd_data, whitener, ori, n_jobs, rank, tol)
+        guess_data, sensors=sensors, fwd_data=fwd_data, whitener=whitener,
+        ori=ori, n_jobs=n_jobs, rank=rank, rhoend=tol)
     assert len(out) == 8
     if fixed_position and ori is not None:
         # DipoleFixed

--- a/mne/forward/_compute_forward.py
+++ b/mne/forward/_compute_forward.py
@@ -826,13 +826,13 @@ def _compute_forwards_meeg(rr, *, sensors, fwd_data, n_jobs, silent=False):
     compensators = fwd_data['compensators']
     solutions, csolutions = fwd_data['solutions'], fwd_data['csolutions']
     del fwd_data
-    for coil_type in sensors:
-        coils = sensors[coil_type]['defs']
-        ccoils = sensors[coil_type].get('comp_defs', None)
+    for coil_type, sens in sensors.items():
+        coils = sens['defs']
+        ccoils = sens.get('comp_defs', None)
         solution = solutions.get(coil_type, None)
         compensator = compensators.get(coil_type, None)
         csolution = csolutions.get(coil_type, None)
-        info = sensors.get('info', None)
+        info = sens.get('info', None)
 
         # Do the actual forward calculation for a list MEG/EEG sensors
         if not silent:

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -374,7 +374,18 @@ def _prepare_for_forward(src, mri_head_t, info, bem, mindist, n_jobs,
                          bem_extra='', trans='', info_extra='',
                          meg=True, eeg=True, ignore_ref=False,
                          allow_bem_none=False, verbose=None):
-    """Prepare for forward computation."""
+    """Prepare for forward computation.
+
+    The sensors dict contains keys for each sensor type, e.g. 'meg', 'eeg'.
+    The vale for each of these is a dict that comes from _prep_meg_channels or
+    _prep_eeg_channels. Each dict contains:
+
+    - defs : a list of dicts (one per channel) with 'rmag', 'cosmag', etc.
+    - ch_names: a list of str channel names corresponding to the defs
+    - compensator (optional): the ndarray compensation matrix to apply
+    - post_picks (optional): the ndarray of indices to pick after applying the
+      compensator
+    """
     # Read the source locations
     logger.info('')
     # let's make a copy in case we modify something

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1845,15 +1845,13 @@ def _do_forward_solution(subject, meas, fname=None, src=None, spacing=None,
     _validate_type(subject, "str", "subject")
 
     # check for meas to exist as string, or try to make evoked
-    if isinstance(meas, str):
-        if not op.isfile(meas):
-            raise IOError('measurement file "%s" could not be found' % meas)
-    elif isinstance(meas, (BaseRaw, BaseEpochs, Evoked)):
+    _validate_type(meas, ('path-like', BaseRaw, BaseEpochs, Evoked), 'meas')
+    if isinstance(meas, (BaseRaw, BaseEpochs, Evoked)):
         meas_file = op.join(temp_dir, 'info.fif')
         write_info(meas_file, meas.info)
         meas = meas_file
     else:
-        raise ValueError('meas must be string, Raw, Epochs, or Evoked')
+        meas = _check_fname(meas, overwrite='read', must_exist=True)
 
     # deal with trans/mri
     if mri is not None and trans is not None:

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -54,7 +54,7 @@ io_path = Path(__file__).parent.parent.parent / 'io'
 bti_dir = io_path / 'bti' / 'tests' / 'data'
 kit_dir = io_path / 'kit' / 'tests' / 'data'
 trans_path = op.join(kit_dir, 'trans-sample.fif')
-fname_ctf_raw = io_path / 'tests' /  'data' / 'test_ctf_comp_raw.fif'
+fname_ctf_raw = io_path / 'tests' / 'data' / 'test_ctf_comp_raw.fif'
 
 
 def _compare_forwards(fwd, fwd_py, n_sensors, n_src,

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -255,8 +255,7 @@ def test_make_forward_solution_discrete(tmp_path, small_surf_src):
 n_src_small = 108  # this is the resulting # of verts in fwd
 
 
-@pytest.fixture(scope='module')
-@testing.requires_testing_data
+@pytest.fixture(scope='module', params=[testing._pytest_param()])
 def small_surf_src():
     """Create a small surface source space."""
     src = setup_source_space('sample', 'oct2', subjects_dir=subjects_dir,

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 import numpy as np
-from numpy.testing import assert_equal, assert_allclose, assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal
 
 from mne.channels import make_standard_montage
 from mne.datasets import testing
@@ -50,13 +50,19 @@ fname_aseg = op.join(subjects_dir, 'sample', 'mri', 'aseg.mgz')
 fname_bem_meg = op.join(subjects_dir, 'sample', 'bem',
                         'sample-1280-bem-sol.fif')
 
+io_path = Path(__file__).parent.parent.parent / 'io'
+bti_dir = io_path / 'bti' / 'tests' / 'data'
+kit_dir = io_path / 'kit' / 'tests' / 'data'
+trans_path = op.join(kit_dir, 'trans-sample.fif')
+fname_ctf_raw = io_path / 'tests' /  'data' / 'test_ctf_comp_raw.fif'
+
 
 def _compare_forwards(fwd, fwd_py, n_sensors, n_src,
                       meg_rtol=1e-4, meg_atol=1e-9,
                       eeg_rtol=1e-3, eeg_atol=1e-3):
     """Test forwards."""
     # check source spaces
-    assert_equal(len(fwd['src']), len(fwd_py['src']))
+    assert len(fwd['src']) == len(fwd_py['src'])
     _compare_source_spaces(fwd['src'], fwd_py['src'], mode='approx')
     for surf_ori, force_fixed in product([False, True], [False, True]):
         # use copy here to leave our originals unmodified
@@ -80,9 +86,9 @@ def _compare_forwards(fwd, fwd_py, n_sensors, n_src,
         assert_allclose(fwd_py['mri_head_t']['trans'],
                         fwd['mri_head_t']['trans'], rtol=1e-5, atol=1e-8)
 
-        assert_equal(fwd_py['sol']['data'].shape, (n_sensors, check_src))
-        assert_equal(len(fwd['sol']['row_names']), n_sensors)
-        assert_equal(len(fwd_py['sol']['row_names']), n_sensors)
+        assert fwd_py['sol']['data'].shape == (n_sensors, check_src)
+        assert len(fwd['sol']['row_names']) == n_sensors
+        assert len(fwd_py['sol']['row_names']) == n_sensors
 
         # check MEG
         assert_allclose(fwd['sol']['data'][:306, ori_sl],
@@ -124,36 +130,14 @@ def test_magnetic_dipole():
 
 
 @pytest.mark.slowtest  # slow-ish on Travis OSX
-@pytest.mark.timeout(60)  # can take longer than 30 sec on Travis
-@testing.requires_testing_data
 @requires_mne
-def test_make_forward_solution_kit(tmp_path):
-    """Test making fwd using KIT, BTI, and CTF (compensated) files."""
-    kit_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'kit',
-                      'tests', 'data')
+def test_make_forward_solution_kit(tmp_path, fname_src_small):
+    """Test making fwd using KIT (compensated) files."""
     sqd_path = op.join(kit_dir, 'test.sqd')
     mrk_path = op.join(kit_dir, 'test_mrk.sqd')
     elp_path = op.join(kit_dir, 'test_elp.txt')
     hsp_path = op.join(kit_dir, 'test_hsp.txt')
-    trans_path = op.join(kit_dir, 'trans-sample.fif')
     fname_kit_raw = op.join(kit_dir, 'test_bin_raw.fif')
-
-    bti_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'bti',
-                      'tests', 'data')
-    bti_pdf = op.join(bti_dir, 'test_pdf_linux')
-    bti_config = op.join(bti_dir, 'test_config_linux')
-    bti_hs = op.join(bti_dir, 'test_hs_linux')
-    fname_bti_raw = op.join(bti_dir, 'exported4D_linux_raw.fif')
-
-    fname_ctf_raw = op.join(op.dirname(__file__), '..', '..', 'io', 'tests',
-                            'data', 'test_ctf_comp_raw.fif')
-
-    # first set up a small testing source space
-    fname_src_small = tmp_path / 'sample-oct-2-src.fif'
-    src = setup_source_space('sample', 'oct2', subjects_dir=subjects_dir,
-                             add_dist=False)
-    write_source_spaces(fname_src_small, src)  # to enable working with MNE-C
-    n_src = 108  # this is the resulting # of verts in fwd
 
     # first use mne-C: convert file, make forward solution
     fwd = _do_forward_solution('sample', fname_kit_raw, src=fname_src_small,
@@ -162,9 +146,10 @@ def test_make_forward_solution_kit(tmp_path):
     assert (isinstance(fwd, Forward))
 
     # now let's use python with the same raw file
+    src = read_source_spaces(fname_src_small)
     fwd_py = make_forward_solution(fname_kit_raw, trans_path, src,
                                    fname_bem_meg, eeg=False, meg=True)
-    _compare_forwards(fwd, fwd_py, 157, n_src)
+    _compare_forwards(fwd, fwd_py, 157, n_src_small)
     assert (isinstance(fwd_py, Forward))
 
     # now let's use mne-python all the way
@@ -180,26 +165,38 @@ def test_make_forward_solution_kit(tmp_path):
     fwd_py = make_forward_solution(meg_only_info, src=src, meg=True, eeg=True,
                                    bem=fname_bem_meg, trans=trans_path,
                                    ignore_ref=True)
-    _compare_forwards(fwd, fwd_py, 157, n_src,
+    _compare_forwards(fwd, fwd_py, 157, n_src_small,
                       meg_rtol=1e-3, meg_atol=1e-7)
 
-    # BTI python end-to-end versus C
+
+@requires_mne
+def test_make_forward_solution_bti(fname_src_small):
+    """Test BTI end-to-end versus C."""
+    bti_pdf = bti_dir / 'test_pdf_linux'
+    bti_config = bti_dir / 'test_config_linux'
+    bti_hs = bti_dir / 'test_hs_linux'
+    fname_bti_raw = bti_dir / 'exported4D_linux_raw.fif'
+    raw_py = read_raw_bti(bti_pdf, bti_config, bti_hs, preload=False)
+    src = read_source_spaces(fname_src_small)
+    fwd_py = make_forward_solution(raw_py.info, src=src, eeg=False, meg=True,
+                                   bem=fname_bem_meg, trans=trans_path)
     fwd = _do_forward_solution('sample', fname_bti_raw, src=fname_src_small,
                                bem=fname_bem_meg, mri=trans_path,
                                eeg=False, meg=True, subjects_dir=subjects_dir)
-    raw_py = read_raw_bti(bti_pdf, bti_config, bti_hs, preload=False)
-    fwd_py = make_forward_solution(raw_py.info, src=src, eeg=False, meg=True,
-                                   bem=fname_bem_meg, trans=trans_path)
-    _compare_forwards(fwd, fwd_py, 248, n_src)
+    _compare_forwards(fwd, fwd_py, 248, n_src_small)
 
-    # now let's test CTF w/compensation
+
+@requires_mne
+def test_make_forward_solution_ctf(tmp_path, fname_src_small):
+    """Test CTF w/compensation against C."""
+    src = read_source_spaces(fname_src_small)
     fwd_py = make_forward_solution(fname_ctf_raw, fname_trans, src,
-                                   fname_bem_meg, eeg=False, meg=True)
+                                   fname_bem_meg, eeg=False, verbose=True)
 
     fwd = _do_forward_solution('sample', fname_ctf_raw, mri=fname_trans,
                                src=fname_src_small, bem=fname_bem_meg,
                                eeg=False, meg=True, subjects_dir=subjects_dir)
-    _compare_forwards(fwd, fwd_py, 274, n_src)
+    _compare_forwards(fwd, fwd_py, 274, n_src_small)
 
     # CTF with compensation changed in python
     ctf_raw = read_raw_fif(fname_ctf_raw)
@@ -212,12 +209,12 @@ def test_make_forward_solution_kit(tmp_path):
                                src=fname_src_small, bem=fname_bem_meg,
                                eeg=False, meg=True,
                                subjects_dir=subjects_dir)
-    _compare_forwards(fwd, fwd_py, 274, n_src)
+    _compare_forwards(fwd, fwd_py, 274, n_src_small)
 
     fname_temp = tmp_path / 'test-ctf-fwd.fif'
     write_forward_solution(fname_temp, fwd_py)
     fwd_py2 = read_forward_solution(fname_temp)
-    _compare_forwards(fwd_py, fwd_py2, 274, n_src)
+    _compare_forwards(fwd_py, fwd_py2, 274, n_src_small)
     repr(fwd_py)
 
 
@@ -242,12 +239,10 @@ def test_make_forward_solution():
                               fname_bem_meg)
 
 
-@testing.requires_testing_data
-def test_make_forward_solution_discrete(tmp_path):
+def test_make_forward_solution_discrete(tmp_path, small_surf_src):
     """Test making and converting a forward solution with discrete src."""
     # smoke test for depth weighting and discrete source spaces
-    src = setup_source_space('sample', 'oct2', subjects_dir=subjects_dir,
-                             add_dist=False)
+    src = small_surf_src
     src = src + setup_volume_source_space(
         pos=dict(rr=src[0]['rr'][src[0]['vertno'][:3]].copy(),
                  nn=src[0]['nn'][src[0]['vertno'][:3]].copy()))
@@ -257,21 +252,38 @@ def test_make_forward_solution_discrete(tmp_path):
     convert_forward_solution(fwd, surf_ori=True)
 
 
+n_src_small = 108  # this is the resulting # of verts in fwd
+
+
+@pytest.fixture(scope='module')
 @testing.requires_testing_data
-@requires_mne
-@pytest.mark.timeout(90)  # can take longer than 60 sec on Travis
-def test_make_forward_solution_sphere(tmp_path):
-    """Test making a forward solution with a sphere model."""
-    fname_src_small = tmp_path / 'sample-oct-2-src.fif'
+def small_surf_src():
+    """Create a small surface source space."""
     src = setup_source_space('sample', 'oct2', subjects_dir=subjects_dir,
                              add_dist=False)
-    write_source_spaces(fname_src_small, src)  # to enable working with MNE-C
+    assert sum(s['nuse'] for s in src) * 3 == n_src_small
+    return src
+
+
+@pytest.fixture()
+def fname_src_small(tmp_path, small_surf_src):
+    """Create a small source space."""
+    fname_src_small = tmp_path / 'sample-oct-2-src.fif'
+    write_source_spaces(fname_src_small, small_surf_src)
+    return fname_src_small
+
+
+@requires_mne
+@pytest.mark.timeout(90)  # can take longer than 60 sec on Travis
+def test_make_forward_solution_sphere(tmp_path, fname_src_small):
+    """Test making a forward solution with a sphere model."""
     out_name = tmp_path / 'tmp-fwd.fif'
     run_subprocess(['mne_forward_solution', '--meg', '--eeg',
                     '--meas', fname_raw, '--src', fname_src_small,
                     '--mri', fname_trans, '--fwd', out_name])
     fwd = read_forward_solution(out_name)
     sphere = make_sphere_model(verbose=True)
+    src = read_source_spaces(fname_src_small)
     fwd_py = make_forward_solution(fname_raw, fname_trans, src, sphere,
                                    meg=True, eeg=True, verbose=True)
     _compare_forwards(fwd, fwd_py, 366, 108,

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -785,21 +785,10 @@ def _check_destination(destination, info, head_frame):
 @verbose
 def _prep_mf_coils(info, ignore_ref=True, verbose=None):
     """Get all coil integration information loaded and sorted."""
-    coils, comp_coils = _prep_meg_channels(
-        info, head_frame=False,
-        ignore_ref=ignore_ref, do_picking=False, verbose=False)[:2]
+    meg_sensors = _prep_meg_channels(
+        info, head_frame=False, ignore_ref=ignore_ref, verbose=False)
+    coils = meg_sensors['defs']
     mag_mask = _get_mag_mask(coils)
-    if len(comp_coils) > 0:
-        meg_picks = pick_types(info, meg=True, ref_meg=False, exclude=[])
-        ref_picks = pick_types(info, meg=False, ref_meg=True, exclude=[])
-        inserts = np.searchsorted(meg_picks, ref_picks)
-        # len(inserts) == len(comp_coils)
-        for idx, comp_coil in zip(inserts[::-1], comp_coils[::-1]):
-            coils.insert(idx, comp_coil)
-        # Now we have:
-        # [c['chname'] for c in coils] ==
-        # [info['ch_names'][ii]
-        #  for ii in pick_types(info, meg=True, ref_meg=True)]
 
     # Now coils is a sorted list of coils. Time to do some vectorization.
     n_coils = len(coils)

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -346,7 +346,7 @@ def test_multipolar_bases():
     # Test our basis calculations
     info = read_info(raw_fname)
     with use_coil_def(elekta_def_fname):
-        coils = _prep_meg_channels(info, do_es=True)[0]
+        coils = _prep_meg_channels(info, do_es=True)['defs']
     # Check against a known benchmark
     sss_data = loadmat(bases_fname)
     exp = dict(int_order=int_order, ext_order=ext_order)

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -686,24 +686,27 @@ def _iter_forward_solutions(info, trans, src, bem, dev_head_ts, mindist,
     with info._unlock():
         info.update(projs=[], bads=[])  # Ensure no 'projs' or 'bads'
     mri_head_t, trans = _get_trans(trans)
-    megcoils, meg_info, compcoils, megnames, eegels, eegnames, rr, info, \
-        update_kwargs, bem = _prepare_for_forward(
-            src, mri_head_t, info, bem, mindist, n_jobs, allow_bem_none=True,
-            verbose=False)
+    sensors, rr, info, update_kwargs, bem = _prepare_for_forward(
+        src, mri_head_t, info, bem, mindist, n_jobs, allow_bem_none=True,
+        verbose=False)
     del (src, mindist)
 
-    if forward is None:
-        eegfwd = _compute_forwards(rr, bem, [eegels], [None],
-                                   [None], ['eeg'], n_jobs, verbose=False)[0]
-        eegfwd = _to_forward_dict(eegfwd, eegnames)
+    eegnames = sensors.get('eeg', dict()).get('ch_names', [])
+    if not len(eegnames):
+        eegfwd = None
+    elif forward is not None:
+        eegfwd = pick_channels_forward(forward, eegnames, verbose=False)
     else:
-        if len(eegnames) > 0:
-            eegfwd = pick_channels_forward(forward, eegnames, verbose=False)
-        else:
-            eegfwd = None
+        eegels = sensors.get('eeg', dict()).get('defs', [])
+        this_sensors = dict(eeg=dict(ch_names=eegnames, defs=eegels))
+        eegfwd = _compute_forwards(rr, bem=bem, sensors=this_sensors,
+                                   n_jobs=n_jobs, verbose=False)['eeg']
+        eegfwd = _to_forward_dict(eegfwd, eegnames)
+        del eegels
+    del eegnames
 
     # short circuit here if there are no MEG channels (don't need to iterate)
-    if len(pick_types(info, meg=True)) == 0:
+    if 'meg' not in sensors:
         eegfwd.update(**update_kwargs)
         for _ in dev_head_ts:
             yield eegfwd
@@ -718,6 +721,10 @@ def _iter_forward_solutions(info, trans, src, bem, dev_head_ts, mindist,
         # make a copy so it isn't mangled in use
         bem_surf = transform_surface_to(bem['surfs'][idx[0]], coord_frame,
                                         mri_head_t, copy=True)
+    megcoils, compcoils = sensors['meg']['defs'], sensors['meg']['comp_defs']
+    if 'eeg' in sensors:
+        del sensors['eeg']
+    megnames = sensors['meg']['ch_names']
     for ti, dev_head_t in enumerate(dev_head_ts):
         # Could be *slightly* more efficient not to do this N times,
         # but the cost here is tiny compared to actual fwd calculation
@@ -743,9 +750,9 @@ def _iter_forward_solutions(info, trans, src, bem, dev_head_ts, mindist,
                 raise RuntimeError('%s MEG sensors collided with inner skull '
                                    'surface for transform %s'
                                    % (np.sum(~outside), ti))
-            megfwd = _compute_forwards(rr, bem, [megcoils], [compcoils],
-                                       [meg_info], ['meg'], n_jobs,
-                                       verbose=False)[0]
+            megfwd = _compute_forwards(
+                rr, sensors=sensors, bem=bem, n_jobs=n_jobs,
+                verbose=False)['meg']
             megfwd = _to_forward_dict(megfwd, megnames)
         else:
             megfwd = pick_channels_forward(forward, megnames, verbose=False)

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -568,7 +568,7 @@ def add_chpi(raw, head_pos=None, interp='cos2', n_jobs=None, verbose=None):
     info = pick_info(info, meg_picks)
     with info._unlock():
         info.update(projs=[], bads=[])  # Ensure no 'projs' or 'bads'
-    megcoils, _, _, _ = _prep_meg_channels(info, ignore_ref=False)
+    megcoils = _prep_meg_channels(info, ignore_ref=True)['defs']
     used = np.zeros(len(raw.times), bool)
     dev_head_ts.append(dev_head_ts[-1])  # ZOH after time ends
     get_fwd = _HPIForwards(offsets, dev_head_ts, megcoils, hpi_rrs, hpi_nns)
@@ -721,7 +721,7 @@ def _iter_forward_solutions(info, trans, src, bem, dev_head_ts, mindist,
         # make a copy so it isn't mangled in use
         bem_surf = transform_surface_to(bem['surfs'][idx[0]], coord_frame,
                                         mri_head_t, copy=True)
-    megcoils, compcoils = sensors['meg']['defs'], sensors['meg']['comp_defs']
+    megcoils = sensors['meg']['defs']
     if 'eeg' in sensors:
         del sensors['eeg']
     megnames = sensors['meg']['ch_names']
@@ -731,7 +731,6 @@ def _iter_forward_solutions(info, trans, src, bem, dev_head_ts, mindist,
         logger.info('Computing gain matrix for transform #%s/%s'
                     % (ti + 1, len(dev_head_ts)))
         _transform_orig_meg_coils(megcoils, dev_head_t)
-        _transform_orig_meg_coils(compcoils, dev_head_t)
 
         # Make sure our sensors are all outside our BEM
         coil_rr = np.array([coil['r0'] for coil in megcoils])

--- a/mne/simulation/tests/test_evoked.py
+++ b/mne/simulation/tests/test_evoked.py
@@ -58,7 +58,8 @@ def test_simulate_evoked():
     # Generate noisy evoked data
     iir_filter = [1, -0.9]
     evoked = simulate_evoked(fwd, stc, evoked_template.info, cov,
-                             iir_filter=iir_filter, nave=nave)
+                             iir_filter=iir_filter, nave=nave,
+                             random_state=0)
     assert_array_almost_equal(evoked.times, stc.times)
     assert len(evoked.data) == len(fwd['sol']['data'])
     assert_equal(evoked.nave, nave)

--- a/mne/simulation/tests/test_evoked.py
+++ b/mne/simulation/tests/test_evoked.py
@@ -153,7 +153,7 @@ def test_rank_deficiency():
     cov = regularize(cov, evoked.info, rank=None)
     cov = pick_channels_cov(cov, evoked.ch_names)
     evoked.data[:] = 0
-    add_noise(evoked, cov)
+    add_noise(evoked, cov, random_state=0)
     cov_new = compute_covariance(
         EpochsArray(evoked.data[np.newaxis], evoked.info), verbose='error')
     assert cov['names'] == cov_new['names']


### PR DESCRIPTION
Refactor forward solution code to eventually make it easier to add channel types. This PR's goals:

- [x] Do a basic refactoring using `dict` instead of lists
- [x] Fix tests (I expect `simulation` to fail)
- [x] Make it more readable
- [x] Hopefully simplify the coils/comp-coils (ccoils) stuff so that these can be computed all at once