### PR TITLE
Revert "Add error message when conversion of EEG locs to head space f…

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -49,7 +49,6 @@ Bugs
 - Fix bug in :func:`mne.viz.plot_filter` when plotting filters created using ``output='ba'`` mode with ``compensation`` turned on. (:gh:`11040` by `Marian Dovgialo`_)
 - Fix bug in :func:`mne.io.read_raw_bti` where EEG, EMG, and H/VEOG channels were not detected properly, and many non-ECG channels were called ECG. The logic has been improved, and any channels of unknown type are now labeled as ``misc`` (:gh:`11102` by `Eric Larson`_)
 - Fix bug in :func:`mne.viz.plot_topomap` when providing ``sphere="eeglab"`` (:gh:`11081` by `Mathieu Scheltienne`_)
-- Applying a montage where EEG locations are not in head space (or unknown space) without fiducials will now raise an error message. (:gh:`11080` by `Marijn van Vliet`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -668,19 +668,11 @@ def transform_to_head(montage):
     # Get fiducial points and their coord_frame
     native_head_t = compute_native_head_t(montage)
     montage = montage.copy()  # to avoid inplace modification
-
     if native_head_t['from'] != FIFF.FIFFV_COORD_HEAD:
         for d in montage.dig:
             if d['coord_frame'] == native_head_t['from']:
                 d['r'] = apply_trans(native_head_t, d['r'])
                 d['coord_frame'] = FIFF.FIFFV_COORD_HEAD
-            elif d['kind'] == FIFF.FIFFV_POINT_EEG:
-                raise RuntimeError(
-                    f'Could not transform EEG channel {d["ident"]} position '
-                    f'from {_verbose_frames[d["coord_frame"]]} to head '
-                    'coordinates. Fiducial points are either missing or '
-                    'specified in a different coordinate frame than the EEG '
-                    'channel locations.')
     return montage
 
 

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1210,17 +1210,6 @@ def test_transform_to_head_and_compute_dev_head_t():
             montage_polhemus
         ))
 
-    # Test errors when transforming without fiducials explicitly where points
-    # are tagged to be not in head or unknown coord space.
-    montage_without_fids = make_dig_montage(
-        ch_pos={"ch_1": np.array([1, 2, 3]),
-                "ch_2": np.array([4, 5, 6]),
-                "ch_3": np.array([7, 8, 9])},
-        coord_frame="mri")  # MRI coordinate space
-    with pytest.raises(RuntimeError, match='Could not transform EEG channel'):
-        with pytest.warns(RuntimeWarning, match='Fiducial point .* not found'):
-            transform_to_head(montage_without_fids)
-
 
 def test_set_montage_with_mismatching_ch_names():
     """Test setting a DigMontage with mismatching ch_names."""

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -300,7 +300,7 @@ def _get_fid_coords(dig, raise_error=True):
     if len(fid_coord_frames) > 0 and raise_error:
         if set(fid_coord_frames.keys()) != set(['nasion', 'lpa', 'rpa']):
             raise ValueError("Some fiducial points are missing (got %s)." %
-                             fid_coords.keys())
+                             fid_coord_frames.keys())
 
         if len(set(fid_coord_frames.values())) > 1:
             raise ValueError(

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -300,7 +300,7 @@ def _get_fid_coords(dig, raise_error=True):
     if len(fid_coord_frames) > 0 and raise_error:
         if set(fid_coord_frames.keys()) != set(['nasion', 'lpa', 'rpa']):
             raise ValueError("Some fiducial points are missing (got %s)." %
-                             fid_coord_frames.keys())
+                             fid_coords.keys())
 
         if len(set(fid_coord_frames.values())) > 1:
             raise ValueError(


### PR DESCRIPTION
This reverts commit bdc435d8a7643a934365a221ab9d52ec8b33bc33.

Turns out that MNE-BIDS abuses `set_montage` a bit when reading montages. For example, in `tutorials/clinical/30_ecog.py`, `read_raw_bids` returns the channel positions as a montage applied to the `Raw`, in MRI coordinates, violating our convention. Then, the montage is fixed manually in the tutorial by calling `raw.get_montage`, transforming to head coordinates, and then calling `raw.set_montage` again.

Ideally, MNE-BIDS should have a separate `read_montage_bids` function, so it wouldn't have to rely on montages being applied to a raw object.

fixes #11100 