### PR TITLE
BUG: Spectrum deprecation cleanup

### DIFF
--- a/examples/visualization/topo_customized.py
+++ b/examples/visualization/topo_customized.py
@@ -26,7 +26,6 @@ import matplotlib.pyplot as plt
 import mne
 from mne.viz import iter_topography
 from mne import io
-from mne.time_frequency import psd_welch
 from mne.datasets import sample
 
 print(__doc__)
@@ -42,8 +41,9 @@ picks = mne.pick_types(raw.info, meg=True, exclude=[])
 tmin, tmax = 0, 120  # use the first 120s of data
 fmin, fmax = 2, 20  # look at frequencies between 2 and 20Hz
 n_fft = 2048  # the FFT size (n_fft). Ideally a power of 2
-psds, freqs = psd_welch(raw, picks=picks, tmin=tmin, tmax=tmax,
-                        fmin=fmin, fmax=fmax)
+spectrum = raw.compute_psd(
+    picks=picks, tmin=tmin, tmax=tmax, fmin=fmin, fmax=fmax)
+psds, freqs = spectrum.get_data(exclude=(), return_freqs=True)
 psds = 20 * np.log10(psds)  # scale to dB
 
 

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -254,9 +254,10 @@ def psd_welch(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None, n_fft=256,
     .. versionadded:: 0.12.0
     """
     spectrum = inst.compute_psd(
-        'welch', fmin, fmax, tmin, tmax, picks, proj, reject_by_annotation,
-        n_jobs=n_jobs, verbose=verbose, n_fft=n_fft, n_overlap=n_overlap,
-        n_per_seg=n_per_seg, average=average, window=window)
+        'welch', fmin=fmin, fmax=fmax, tmin=tmin, tmax=tmax, picks=picks,
+        proj=proj, n_jobs=n_jobs, verbose=verbose, n_fft=n_fft,
+        n_overlap=n_overlap, n_per_seg=n_per_seg, average=average,
+        window=window)
     return spectrum.get_data(return_freqs=True)
 
 
@@ -323,8 +324,8 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     .. footbibliography::
     """
     spectrum = inst.compute_psd(
-        'multitaper', fmin, fmax, tmin, tmax, picks, proj,
-        reject_by_annotation, n_jobs=n_jobs, verbose=verbose,
-        bandwidth=bandwidth, adaptive=adaptive, low_bias=low_bias,
-        normalization=normalization)
+        'multitaper', fmin=fmin, fmax=fmax, tmin=tmin, tmax=tmax, picks=picks,
+        proj=proj, reject_by_annotation=reject_by_annotation, n_jobs=n_jobs,
+        verbose=verbose, bandwidth=bandwidth, adaptive=adaptive,
+        low_bias=low_bias, normalization=normalization)
     return spectrum.get_data(return_freqs=True)

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -16,7 +16,9 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	# SciPy Windows build is missing from conda nightly builds
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps scipy vtk
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps --default-timeout=60 -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" pandas scikit-learn dipy statsmodels
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps --default-timeout=60 -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" scikit-learn dipy statsmodels
+	# as of 2022/08/29, pandas on scipy-wheels-nightly is broken for some reason (intermittent download issue?)
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps pandas
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py Pillow matplotlib
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -19,7 +19,9 @@ else
 	# pip install $STD_ARGS --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6 PyQt6-sip PyQt6-Qt6
 	pip install $STD_ARGS --only-binary ":all:" PyQt6 PyQt6-sip PyQt6-Qt6
 	echo "NumPy/SciPy/pandas etc."
-	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps  --default-timeout=60 -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy pandas scikit-learn statsmodels dipy
+	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps  --default-timeout=60 -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy scikit-learn statsmodels dipy
+	# as of 2022/08/29, pandas on scipy-wheels-nightly is broken for some reason (intermittent download issue?)
+	pip install $STD_ARGS --pre --only-binary ":all:" pandas
 	echo "H5py, pillow, matplotlib"
 	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py pillow matplotlib
 	# We don't install Numba here because it forces an old NumPy version

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -19,9 +19,9 @@ else
 	# pip install $STD_ARGS --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6 PyQt6-sip PyQt6-Qt6
 	pip install $STD_ARGS --only-binary ":all:" PyQt6 PyQt6-sip PyQt6-Qt6
 	echo "NumPy/SciPy/pandas etc."
-	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps  --default-timeout=60 -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy scikit-learn statsmodels dipy
-	# as of 2022/08/29, pandas on scipy-wheels-nightly is broken for some reason (intermittent download issue?)
-	pip install $STD_ARGS --pre --only-binary ":all:" pandas
+	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps  --default-timeout=60 -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy scikit-learn dipy
+	# as of 2022/08/29, pandas and statsmodels on scipy-wheels-nightly is broken for some reason (intermittent download issue?)
+	pip install $STD_ARGS --pre --only-binary ":all:" pandas statsmodels
 	echo "H5py, pillow, matplotlib"
 	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py pillow matplotlib
 	# We don't install Numba here because it forces an old NumPy version

--- a/tutorials/time-freq/20_sensors_time_frequency.py
+++ b/tutorials/time-freq/20_sensors_time_frequency.py
@@ -86,7 +86,7 @@ psds_std = psds.mean(0).std(0)
 
 ax.plot(freqs, psds_mean, color='k')
 ax.fill_between(freqs, psds_mean - psds_std, psds_mean + psds_std,
-                color='k', alpha=.5, linecolor='none')
+                color='k', alpha=.5, edgecolor='none')
 ax.set(title='Multitaper PSD (gradiometers)', xlabel='Frequency (Hz)',
        ylabel='Power Spectral Density (dB)')
 plt.show()

--- a/tutorials/time-freq/50_ssvep.py
+++ b/tutorials/time-freq/50_ssvep.py
@@ -141,14 +141,15 @@ fmin = 1.
 fmax = 90.
 sfreq = epochs.info['sfreq']
 
-psds, freqs = mne.time_frequency.psd_welch(
-    epochs,
+spectrum = epochs.compute_psd(
+    'welch',
     n_fft=int(sfreq * (tmax - tmin)),
     n_overlap=0, n_per_seg=None,
     tmin=tmin, tmax=tmax,
     fmin=fmin, fmax=fmax,
     window='boxcar',
     verbose=False)
+psds, freqs = spectrum.get_data(return_freqs=True)
 
 
 # %%
@@ -561,13 +562,14 @@ window_lengths = [i for i in range(2, 21, 2)]
 window_snrs = [[]] * len(window_lengths)
 for i_win, win in enumerate(window_lengths):
     # compute spectrogram
-    windowed_psd, windowed_freqs = mne.time_frequency.psd_welch(
-        epochs[str(event_id['12hz'])],
+    this_spectrum = epochs[str(event_id['12hz'])].compute_psd(
+        'welch',
         n_fft=int(sfreq * win),
         n_overlap=0, n_per_seg=None,
         tmin=0, tmax=win,
         window='boxcar',
         fmin=fmin, fmax=fmax, verbose=False)
+    windowed_psd, windowed_freqs = this_spectrum.get_data(return_freqs=True)
     # define a bandwidth of 1 Hz around stimfreq for SNR computation
     bin_width = windowed_freqs[1] - windowed_freqs[0]
     skip_neighbor_freqs = \
@@ -633,14 +635,15 @@ window_snrs = [[]] * len(window_starts)
 
 for i_win, win in enumerate(window_starts):
     # compute spectrogram
-    windowed_psd, windowed_freqs = mne.time_frequency.psd_welch(
-        epochs[str(event_id['12hz'])],
+    this_spectrum = epochs[str(event_id['12hz'])].compute_psd(
+        'welch',
         n_fft=int(sfreq * window_length) - 1,
         n_overlap=0, n_per_seg=None,
         window='boxcar',
         tmin=win, tmax=win + window_length,
         fmin=fmin, fmax=fmax,
         verbose=False)
+    windowed_psd, windowed_freqs = this_spectrum.get_data(return_freqs=True)
     # define a bandwidth of 1 Hz around stimfreq for SNR computation
     bin_width = windowed_freqs[1] - windowed_freqs[0]
     skip_neighbor_freqs = \


### PR DESCRIPTION
Should fix https://app.circleci.com/pipelines/github/mne-tools/mne-python/16083/workflows/81bf3b30-eac1-462f-a71b-ecadc0dee745/jobs/48513

@drammock I'm going to mark for merge when green to fix CircleCI, but feel free to take a look and open a follow-up PR with better changes if you have some in mind!

FYI one tutorial could be cleaned up nicely when `EpochsSpectrum` gets a `.average(method='mean' | 'median')` mode, but I'm assuming that's already in the plan somewhere!