### PR TITLE
[ENH, MRG] Add Hilbert to TFR methods comparison

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -38,6 +38,7 @@ Enhancements
 - Add ``units`` parameter to :func:`mne.io.read_raw_edf` in case units are missing from the file (:gh:`11099` by `Alex Gramfort`_)
 - Add ``on_missing`` functionality to all of our classes that have a ``drop_channels`` method, to control what happens when channel names are not in the object (:gh:`11077` by `Andrew Quinn`_)
 - Add :func:`mne.minimum_norm.apply_inverse_tfr_epochs` to apply inverse methods to time-frequency resolved epochs (:gh:`11095` by `Alex Rockhill`_)
+- Add narrow bandpass Hilbert transform to :ref:`ex-tfr-comparison` (gh:`11116` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -38,7 +38,7 @@ Enhancements
 - Add ``units`` parameter to :func:`mne.io.read_raw_edf` in case units are missing from the file (:gh:`11099` by `Alex Gramfort`_)
 - Add ``on_missing`` functionality to all of our classes that have a ``drop_channels`` method, to control what happens when channel names are not in the object (:gh:`11077` by `Andrew Quinn`_)
 - Add :func:`mne.minimum_norm.apply_inverse_tfr_epochs` to apply inverse methods to time-frequency resolved epochs (:gh:`11095` by `Alex Rockhill`_)
-- Add narrow bandpass Hilbert transform to :ref:`ex-tfr-comparison` (gh:`11116` by `Alex Rockhill`_)
+- Add narrow bandpass Hilbert transform to :ref:`ex-tfr-comparison` (:gh:`11116` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -38,7 +38,7 @@ Enhancements
 - Add ``units`` parameter to :func:`mne.io.read_raw_edf` in case units are missing from the file (:gh:`11099` by `Alex Gramfort`_)
 - Add ``on_missing`` functionality to all of our classes that have a ``drop_channels`` method, to control what happens when channel names are not in the object (:gh:`11077` by `Andrew Quinn`_)
 - Add :func:`mne.minimum_norm.apply_inverse_tfr_epochs` to apply inverse methods to time-frequency resolved epochs (:gh:`11095` by `Alex Rockhill`_)
-- Add narrow bandpass Hilbert transform to :ref:`ex-tfr-comparison` (:gh:`11116` by `Alex Rockhill`_)
+- Add example of how to obtain time-frequency decomposition using narrow bandpass Hilbert transforms to :ref:`ex-tfr-comparison` (:gh:`11116` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/examples/time_frequency/time_frequency_simulated.py
+++ b/examples/time_frequency/time_frequency_simulated.py
@@ -48,7 +48,7 @@ n_times = 1024  # Just over 1 second epochs
 n_epochs = 40
 seed = 42
 rng = np.random.RandomState(seed)
-data = rng.randn(len(ch_names), n_times * n_epochs + 100)  # buffer
+data = rng.randn(len(ch_names), n_times * n_epochs + 200)  # buffer
 
 # Add a 50 Hz sinusoidal burst to the noise and ramp it.
 t = np.arange(n_times, dtype=np.float64) / sfreq
@@ -56,7 +56,7 @@ signal = np.sin(np.pi * 2. * 50. * t)  # 50 Hz sinusoid signal
 signal[np.logical_or(t < 0.45, t > 0.55)] = 0.  # Hard windowing
 on_time = np.logical_and(t >= 0.45, t <= 0.55)
 signal[on_time] *= np.hanning(on_time.sum())  # Ramping
-data[:, 50:-50] += np.tile(signal, n_epochs)  # add signal
+data[:, 100:-100] += np.tile(signal, n_epochs)  # add signal
 
 raw = RawArray(data, info)
 events = np.zeros((n_epochs, 3), dtype=int)
@@ -91,8 +91,8 @@ vmin, vmax = -3., 3.  # Define our color limits.
 
 fig, axs = plt.subplots(1, 3, figsize=(15, 5), sharey=True)
 for n_cycles, time_bandwidth, ax, title in zip(
-        [freqs / 2, freqs, freqs / 2],
-        [2.0, 4.0, 8.0],
+        [freqs / 2, freqs, freqs / 2],  # number of cycles
+        [2.0, 4.0, 8.0],  # time bandwidth
         axs,
         ['Sim: Least smoothing, most variance',
          'Sim: Less frequency smoothing,\nmore time smoothing',
@@ -103,6 +103,7 @@ for n_cycles, time_bandwidth, ax, title in zip(
     # Plot results. Baseline correct based on first 100 ms.
     power.plot([0], baseline=(0., 0.1), mode='mean', vmin=vmin, vmax=vmax,
                axes=ax, show=False, colorbar=False)
+plt.tight_layout()
 
 ##############################################################################
 # Stockwell (S) transform
@@ -117,7 +118,7 @@ for n_cycles, time_bandwidth, ax, title in zip(
 
 fig, axs = plt.subplots(1, 3, figsize=(15, 5), sharey=True)
 fmin, fmax = freqs[[0, -1]]
-for width, ax in zip((0.2, .7, 3.0), axs):
+for width, ax in zip((0.2, 0.7, 3.0), axs):
     power = tfr_stockwell(epochs, fmin=fmin, fmax=fmax, width=width)
     power.plot([0], baseline=(0., 0.1), mode='mean', axes=ax, show=False,
                colorbar=False)
@@ -184,7 +185,7 @@ for bandwidth, ax in zip(bandwidths, axs):
     n_cycles = 'scaled by freqs' if not isinstance(n_cycles, int) else n_cycles
     ax.set_title('Sim: Using narrow bandpass filter Hilbert,\n'
                  f'bandwidth = {bandwidth}, '
-                 f'transition bandwidth={4 * bandwidth}')
+                 f'transition bandwidth = {4 * bandwidth}')
 plt.tight_layout()
 
 # %%

--- a/examples/time_frequency/time_frequency_simulated.py
+++ b/examples/time_frequency/time_frequency_simulated.py
@@ -160,13 +160,13 @@ for bandwidth, ax in zip(bandwidths, axs):
     data = np.zeros((len(ch_names), freqs.size, epochs.times.size),
                     dtype=complex)
     for idx, freq in enumerate(freqs):
-        # filter raw data and re-epoch to avoid the filter being longer than
-        # the epoch data for low frequencies and short epochs such as here
+        # Filter raw data and re-epoch to avoid the filter being longer than
+        # the epoch data for low frequencies and short epochs, such as here.
         raw_filter = raw.copy()
-        # note: the bandwidths of the filters are changed from their defaults
-        # to exaggerate differences, with the default transition bandwidths,
-        # these are all very similar because the filters are almost the same
-        # in practice, using the default is a wise choice
+        # NOTE: The bandwidths of the filters are changed from their defaults
+        # to exaggerate differences. With the default transition bandwidths,
+        # these are all very similar because the filters are almost the same.
+        # In practice, using the default is usually a wise choice.
         raw_filter.filter(
             l_freq=freq - bandwidth / 2, h_freq=freq + bandwidth / 2,
             # no negative values for large bandwidth and low freq

--- a/examples/time_frequency/time_frequency_simulated.py
+++ b/examples/time_frequency/time_frequency_simulated.py
@@ -2,19 +2,20 @@
 """
 .. _ex-tfr-comparison:
 
-======================================================================
-Time-frequency on simulated data (Multitaper vs. Morlet vs. Stockwell)
-======================================================================
+==================================================================================
+Time-frequency on simulated data (Multitaper vs. Morlet vs. Stockwell vs. Hilbert)
+==================================================================================
 
 This example demonstrates the different time-frequency estimation methods
 on simulated data. It shows the time-frequency resolution trade-off
 and the problem of estimation variance. In addition it highlights
 alternative functions for generating TFRs without averaging across
 trials, or by operating on numpy arrays.
-"""
+"""  # noqa E501
 # Authors: Hari Bharadwaj <hari@nmr.mgh.harvard.edu>
 #          Denis Engemann <denis.engemann@gmail.com>
 #          Chris Holdgraf <choldgraf@berkeley.edu>
+#          Alex Rockhill <aprockhill@mailbox.org>
 #
 # License: BSD-3-Clause
 
@@ -23,10 +24,11 @@ trials, or by operating on numpy arrays.
 import numpy as np
 from matplotlib import pyplot as plt
 
-from mne import create_info, EpochsArray
+from mne import create_info, Epochs
 from mne.baseline import rescale
+from mne.io import RawArray
 from mne.time_frequency import (tfr_multitaper, tfr_stockwell, tfr_morlet,
-                                tfr_array_morlet)
+                                tfr_array_morlet, AverageTFR)
 from mne.viz import centers_to_edges
 
 print(__doc__)
@@ -46,7 +48,7 @@ n_times = 1024  # Just over 1 second epochs
 n_epochs = 40
 seed = 42
 rng = np.random.RandomState(seed)
-noise = rng.randn(n_epochs, len(ch_names), n_times)
+data = rng.randn(len(ch_names), n_times * n_epochs + 100)  # buffer
 
 # Add a 50 Hz sinusoidal burst to the noise and ramp it.
 t = np.arange(n_times, dtype=np.float64) / sfreq
@@ -54,17 +56,13 @@ signal = np.sin(np.pi * 2. * 50. * t)  # 50 Hz sinusoid signal
 signal[np.logical_or(t < 0.45, t > 0.55)] = 0.  # Hard windowing
 on_time = np.logical_and(t >= 0.45, t <= 0.55)
 signal[on_time] *= np.hanning(on_time.sum())  # Ramping
-data = noise + signal
+data[:, 50:-50] += np.tile(signal, n_epochs)  # add signal
 
-reject = dict(grad=4000)
-events = np.empty((n_epochs, 3), dtype=int)
-first_event_sample = 100
-event_id = dict(sin50hz=1)
-for k in range(n_epochs):
-    events[k, :] = first_event_sample + k * n_times, 0, event_id['sin50hz']
-
-epochs = EpochsArray(data=data, info=info, events=events, event_id=event_id,
-                     reject=reject)
+raw = RawArray(data, info)
+events = np.zeros((n_epochs, 3), dtype=int)
+events[:, 0] = np.arange(n_epochs) * n_times
+epochs = Epochs(raw, events, dict(sin50hz=0), tmin=0, tmax=n_times / sfreq,
+                reject=dict(grad=4000), baseline=None)
 
 epochs.average().plot()
 
@@ -77,6 +75,7 @@ epochs.average().plot()
 # * :func:`mne.time_frequency.tfr_multitaper`
 # * :func:`mne.time_frequency.tfr_stockwell`
 # * :func:`mne.time_frequency.tfr_morlet`
+# * :meth:`mne.Epochs.filter` and :meth:`mne.Epochs.apply_hilbert`
 #
 # Multitaper transform
 # ====================
@@ -147,7 +146,7 @@ plt.tight_layout()
 # Morlet Wavelets
 # ===============
 #
-# Finally, show the TFR using morlet wavelets, which are a sinusoidal wave
+# Next, we'll show the TFR using morlet wavelets, which are a sinusoidal wave
 # with a gaussian envelope. We can control the balance between spectral and
 # temporal resolution with the ``n_cycles`` parameter, which defines the
 # number of cycles to include in the window.
@@ -160,7 +159,50 @@ for n_cycles, ax in zip(all_n_cycles, axs):
     power.plot([0], baseline=(0., 0.1), mode='mean', vmin=vmin, vmax=vmax,
                axes=ax, show=False, colorbar=False)
     n_cycles = 'scaled by freqs' if not isinstance(n_cycles, int) else n_cycles
-    ax.set_title('Sim: Using Morlet wavelet, n_cycles = %s' % n_cycles)
+    ax.set_title(f'Sim: Using Morlet wavelet, n_cycles = {n_cycles}')
+plt.tight_layout()
+
+# %%
+# Narrow-bandpass Filter and Hilbert Transform
+# ============================================
+#
+# Finally, we'll show a time-frequency representation using a narrow bandpass
+# filter and the Hilbert transform. Choosing the right filter parameters is
+# important so that you isolate only one oscillation of interest, generally
+# the width of this filter is recommended to be about 2 Hz.
+
+fig, axs = plt.subplots(1, 3, figsize=(15, 5), sharey=True)
+bandwidths = [1., 2., 4.]
+for bandwidth, ax in zip(bandwidths, axs):
+    data = np.zeros((len(ch_names), freqs.size, epochs.times.size),
+                    dtype=complex)
+    for idx, freq in enumerate(freqs):
+        # filter raw data and re-epoch to avoid the filter being longer than
+        # the epoch data for low frequencies and short epochs such as here
+        raw_filter = raw.copy()
+        # note: the bandwidths of the filters are changed from their defaults
+        # to exaggerate differences, with the default transition bandwidths,
+        # these are all very similar because the filters are almost the same
+        # in practice, using the default is a wise choice
+        raw_filter.filter(
+            l_freq=freq - bandwidth / 2, h_freq=freq + bandwidth / 2,
+            # no negative values for large bandwidth and low freq
+            l_trans_bandwidth=min([4 * bandwidth, freq - bandwidth]),
+            h_trans_bandwidth=4 * bandwidth)
+        raw_filter.apply_hilbert()
+        epochs_hilb = Epochs(raw_filter, events, tmin=0, tmax=n_times / sfreq,
+                             baseline=(0, 0.1))
+        tfr_data = epochs_hilb.get_data()
+        tfr_data = tfr_data * tfr_data.conj()  # compute power
+        tfr_data = np.mean(tfr_data, axis=0)  # average over epochs
+        data[:, idx] = tfr_data
+    power = AverageTFR(info, data, epochs.times, freqs, nave=n_epochs)
+    power.plot([0], baseline=(0., 0.1), mode='mean', vmin=-0.1, vmax=0.1,
+               axes=ax, show=False, colorbar=False)
+    n_cycles = 'scaled by freqs' if not isinstance(n_cycles, int) else n_cycles
+    ax.set_title('Sim: Using narrow bandpass filter Hilbert,\n'
+                 f'bandwidth = {bandwidth}, '
+                 f'transition bandwidth={4 * bandwidth}')
 plt.tight_layout()
 
 # %%

--- a/examples/time_frequency/time_frequency_simulated.py
+++ b/examples/time_frequency/time_frequency_simulated.py
@@ -89,38 +89,20 @@ epochs.average().plot()
 freqs = np.arange(5., 100., 3.)
 vmin, vmax = -3., 3.  # Define our color limits.
 
-# %%
-# **(1) Least smoothing (most variance/background fluctuations).**
-
-n_cycles = freqs / 2.
-time_bandwidth = 2.0  # Least possible frequency-smoothing (1 taper)
-power = tfr_multitaper(epochs, freqs=freqs, n_cycles=n_cycles,
-                       time_bandwidth=time_bandwidth, return_itc=False)
-# Plot results. Baseline correct based on first 100 ms.
-power.plot([0], baseline=(0., 0.1), mode='mean', vmin=vmin, vmax=vmax,
-           title='Sim: Least smoothing, most variance')
-
-# %%
-# **(2) Less frequency smoothing, more time smoothing.**
-
-n_cycles = freqs  # Increase time-window length to 1 second.
-time_bandwidth = 4.0  # Same frequency-smoothing as (1) 3 tapers.
-power = tfr_multitaper(epochs, freqs=freqs, n_cycles=n_cycles,
-                       time_bandwidth=time_bandwidth, return_itc=False)
-# Plot results. Baseline correct based on first 100 ms.
-power.plot([0], baseline=(0., 0.1), mode='mean', vmin=vmin, vmax=vmax,
-           title='Sim: Less frequency smoothing, more time smoothing')
-
-# %%
-# **(3) Less time smoothing, more frequency smoothing.**
-
-n_cycles = freqs / 2.
-time_bandwidth = 8.0  # Same time-smoothing as (1), 7 tapers.
-power = tfr_multitaper(epochs, freqs=freqs, n_cycles=n_cycles,
-                       time_bandwidth=time_bandwidth, return_itc=False)
-# Plot results. Baseline correct based on first 100 ms.
-power.plot([0], baseline=(0., 0.1), mode='mean', vmin=vmin, vmax=vmax,
-           title='Sim: Less time smoothing, more frequency smoothing')
+fig, axs = plt.subplots(1, 3, figsize=(15, 5), sharey=True)
+for n_cycles, time_bandwidth, ax, title in zip(
+        [freqs / 2, freqs, freqs / 2],
+        [2.0, 4.0, 8.0],
+        axs,
+        ['Sim: Least smoothing, most variance',
+         'Sim: Less frequency smoothing,\nmore time smoothing',
+         'Sim: Less time smoothing,\nmore frequency smoothing']):
+    power = tfr_multitaper(epochs, freqs=freqs, n_cycles=n_cycles,
+                           time_bandwidth=time_bandwidth, return_itc=False)
+    ax.set_title(title)
+    # Plot results. Baseline correct based on first 100 ms.
+    power.plot([0], baseline=(0., 0.1), mode='mean', vmin=vmin, vmax=vmax,
+               axes=ax, show=False, colorbar=False)
 
 ##############################################################################
 # Stockwell (S) transform

--- a/mne/time_frequency/_stockwell.py
+++ b/mne/time_frequency/_stockwell.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 import numpy as np
 
 from ..io.pick import _pick_data_channels, pick_info
-from ..utils import verbose, warn, fill_doc, _validate_type
+from ..utils import verbose, logger, fill_doc, _validate_type
 from ..parallel import parallel_func
 from .tfr import AverageTFR, _get_data
 
@@ -28,8 +28,8 @@ def _check_input_st(x_in, n_fft):
         raise ValueError("n_fft cannot be smaller than signal size. "
                          "Got %s < %s." % (n_fft, n_times))
     if n_times < n_fft:
-        warn('The input signal is shorter ({}) than "n_fft" ({}). '
-             'Applying zero padding.'.format(x_in.shape[-1], n_fft))
+        logger.info('The input signal is shorter ({}) than "n_fft" ({}). '
+                    'Applying zero padding.'.format(x_in.shape[-1], n_fft))
         zero_pad = n_fft - n_times
         pad_array = np.zeros(x_in.shape[:-1] + (zero_pad,), x_in.dtype)
         x_in = np.concatenate((x_in, pad_array), axis=-1)

--- a/mne/time_frequency/tests/test_stockwell.py
+++ b/mne/time_frequency/tests/test_stockwell.py
@@ -112,14 +112,12 @@ def test_stockwell_api():
     epochs = Epochs(raw, events,  # XXX pick 2 has epochs of zeros.
                     event_id, tmin, tmax, picks=[0, 1, 3])
     for fmin, fmax in [(None, 50), (5, 50), (5, None)]:
-        with pytest.warns(RuntimeWarning, match='padding'):
-            power, itc = tfr_stockwell(epochs, fmin=fmin, fmax=fmax,
-                                       return_itc=True)
+        power, itc = tfr_stockwell(epochs, fmin=fmin, fmax=fmax,
+                                   return_itc=True)
         if fmax is not None:
             assert (power.freqs.max() <= fmax)
-        with pytest.warns(RuntimeWarning, match='padding'):
-            power_evoked = tfr_stockwell(epochs.average(), fmin=fmin,
-                                         fmax=fmax, return_itc=False)
+        power_evoked = tfr_stockwell(epochs.average(), fmin=fmin,
+                                     fmax=fmax, return_itc=False)
         # for multitaper these don't necessarily match, but they seem to
         # for stockwell... if this fails, this maybe could be changed
         # just to check the shape


### PR DESCRIPTION
I think this is an important methods comparison as the Hilbert transform is a popular choice in some electrophysiology circles. I definitely have been asked about it and I think it's nice to compare in this example. Also, it's a good demonstration of how to coerce this kind of data to fit within the API since it doesn't fit naturally very well with the other time-frequency methods.