### PR TITLE
MAINT: Fix mem usage

### DIFF
--- a/examples/inverse/psf_ctf_vertices.py
+++ b/examples/inverse/psf_ctf_vertices.py
@@ -15,8 +15,6 @@ Visualise PSF and CTF at one vertex for sLORETA.
 
 # %%
 
-import numpy as np
-
 import mne
 from mne.datasets import sample
 from mne.minimum_norm import (make_inverse_resolution_matrix, get_cross_talk,
@@ -28,7 +26,6 @@ data_path = sample.data_path()
 subjects_dir = data_path / 'subjects'
 meg_path = data_path / 'MEG' / 'sample'
 fname_fwd = meg_path / 'sample_audvis-meg-eeg-oct-6-fwd.fif'
-fname_fwd_vol = meg_path / 'sample_audvis-meg-vol-7-fwd.fif'
 fname_cov = meg_path / 'sample_audvis-cov.fif'
 fname_evo = meg_path / 'sample_audvis-ave.fif'
 
@@ -37,8 +34,6 @@ forward = mne.read_forward_solution(fname_fwd)
 # forward operator with fixed source orientations
 mne.convert_forward_solution(forward, surf_ori=True,
                              force_fixed=True, copy=False)
-# read a volumetric forward solution, too
-forward_vol = mne.read_forward_solution(fname_fwd_vol)
 
 # noise covariance matrix
 noise_cov = mne.read_cov(fname_cov)
@@ -51,12 +46,11 @@ evoked = mne.read_evokeds(fname_evo, 0)
 inverse_operator = mne.minimum_norm.make_inverse_operator(
     info=evoked.info, forward=forward, noise_cov=noise_cov, loose=0.,
     depth=None)
-inverse_operator_vol = mne.minimum_norm.make_inverse_operator(
-    info=evoked.info, forward=forward_vol, noise_cov=noise_cov)
 
 # regularisation parameter
 snr = 3.0
 lambda2 = 1.0 / snr ** 2
+method = 'MNE'  # can be 'MNE' or 'sLORETA'
 
 # compute resolution matrix for sLORETA
 rm_lor = make_inverse_resolution_matrix(forward, inverse_operator,
@@ -69,17 +63,6 @@ stc_psf = get_point_spread(rm_lor, forward['src'], sources, norm=True)
 
 stc_ctf = get_cross_talk(rm_lor, forward['src'], sources, norm=True)
 del rm_lor
-
-# for the volume, pick a source that was close to the surface location and
-# compute the PSF at that source
-# compute resolution matrix for sLORETA for the volume, too
-rm_lor_vol = make_inverse_resolution_matrix(
-    forward_vol, inverse_operator_vol, method='sLORETA', lambda2=lambda2)
-
-sources_vol = [448]
-stc_psf_vol = get_point_spread(
-    rm_lor_vol, forward_vol['src'], sources_vol, norm=True)
-del rm_lor_vol
 
 ##############################################################################
 # Visualize
@@ -94,8 +77,8 @@ verttrue = [vertno_lh[sources[0]]]  # just one vertex
 vert_max_psf = vertno_lh[stc_psf.data.argmax()]
 vert_max_ctf = vertno_lh[stc_ctf.data.argmax()]
 
-brain_psf = stc_psf.plot(
-    'sample', 'inflated', 'lh', views='ven', subjects_dir=subjects_dir)
+brain_psf = stc_psf.plot('sample', 'inflated', 'lh', subjects_dir=subjects_dir)
+brain_psf.show_view('ventral')
 brain_psf.add_text(0.1, 0.9, 'sLORETA PSF', 'title', font_size=16)
 
 # True source location for PSF
@@ -109,9 +92,9 @@ brain_psf.add_foci(vert_max_psf, coords_as_verts=True, scale_factor=1.,
 # %%
 # CTF:
 
-brain_ctf = stc_ctf.plot(
-    'sample', 'inflated', 'lh', views='ven', subjects_dir=subjects_dir)
+brain_ctf = stc_ctf.plot('sample', 'inflated', 'lh', subjects_dir=subjects_dir)
 brain_ctf.add_text(0.1, 0.9, 'sLORETA CTF', 'title', font_size=16)
+brain_ctf.show_view('ventral')
 brain_ctf.add_foci(verttrue, coords_as_verts=True, scale_factor=1., hemi='lh',
                    color='green')
 
@@ -119,32 +102,7 @@ brain_ctf.add_foci(verttrue, coords_as_verts=True, scale_factor=1., hemi='lh',
 brain_ctf.add_foci(vert_max_ctf, coords_as_verts=True, scale_factor=1.,
                    hemi='lh', color='black')
 
+
 # %%
 # The green spheres indicate the true source location, and the black
 # spheres the maximum of the distribution.
-#
-# Volumetric source estimates
-# ---------------------------
-# We can do these same operations for volumetric source estimates:
-
-# Which vertex corresponds to selected source
-src_vol = forward_vol['src']
-verttrue_vol = src_vol[0]['vertno'][sources_vol]
-
-# find vertex with maximum in PSF
-max_vert_idx, _ = np.unravel_index(
-    stc_psf_vol.data.argmax(), stc_psf_vol.data.shape)
-vert_max_ctf_vol = src_vol[0]['vertno'][[max_vert_idx]]
-
-# plot them
-brain_psf_vol = stc_psf_vol.plot_3d(
-    'sample', src=forward_vol['src'], views='ven', subjects_dir=subjects_dir,
-    volume_options=dict(alpha=0.5))
-brain_psf_vol.add_text(
-    0.1, 0.9, 'Volumetric sLORETA PSF', 'title', font_size=16)
-brain_psf_vol.add_foci(
-    verttrue_vol, coords_as_verts=True,
-    scale_factor=1, hemi='vol', color='green')
-brain_psf_vol.add_foci(
-    vert_max_ctf_vol, coords_as_verts=True,
-    scale_factor=1.25, hemi='vol', color='black', alpha=0.3)

--- a/examples/inverse/psf_ctf_vertices.py
+++ b/examples/inverse/psf_ctf_vertices.py
@@ -50,7 +50,6 @@ inverse_operator = mne.minimum_norm.make_inverse_operator(
 # regularisation parameter
 snr = 3.0
 lambda2 = 1.0 / snr ** 2
-method = 'MNE'  # can be 'MNE' or 'sLORETA'
 
 # compute resolution matrix for sLORETA
 rm_lor = make_inverse_resolution_matrix(forward, inverse_operator,

--- a/examples/inverse/psf_ctf_vertices.py
+++ b/examples/inverse/psf_ctf_vertices.py
@@ -62,10 +62,6 @@ lambda2 = 1.0 / snr ** 2
 rm_lor = make_inverse_resolution_matrix(forward, inverse_operator,
                                         method='sLORETA', lambda2=lambda2)
 
-# compute resolution matrix for sLORETA for the volume, too
-rm_lor_vol = make_inverse_resolution_matrix(
-    forward_vol, inverse_operator_vol, method='sLORETA', lambda2=lambda2)
-
 # get PSF and CTF for sLORETA at one vertex
 sources = [1000]
 
@@ -76,6 +72,10 @@ del rm_lor
 
 # for the volume, pick a source that was close to the surface location and
 # compute the PSF at that source
+# compute resolution matrix for sLORETA for the volume, too
+rm_lor_vol = make_inverse_resolution_matrix(
+    forward_vol, inverse_operator_vol, method='sLORETA', lambda2=lambda2)
+
 sources_vol = [448]
 stc_psf_vol = get_point_spread(
     rm_lor_vol, forward_vol['src'], sources_vol, norm=True)

--- a/examples/inverse/psf_volume.py
+++ b/examples/inverse/psf_volume.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""
+.. _ex-psd-vol:
+
+===============================================
+Plot point-spread functions (PSFs) for a volume
+===============================================
+
+Visualise PSF at one volume vertex for sLORETA.
+"""
+# Authors: Olaf Hauk <olaf.hauk@mrc-cbu.cam.ac.uk>
+#          Alexandre Gramfort <alexandre.gramfort@inria.fr>
+#          Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD-3-Clause
+
+# %%
+
+import numpy as np
+
+import mne
+from mne.datasets import sample
+from mne.minimum_norm import make_inverse_resolution_matrix, get_point_spread
+
+print(__doc__)
+
+data_path = sample.data_path()
+subjects_dir = data_path / 'subjects'
+meg_path = data_path / 'MEG' / 'sample'
+fname_cov = meg_path / 'sample_audvis-cov.fif'
+fname_evo = meg_path / 'sample_audvis-ave.fif'
+fname_trans = meg_path / 'sample_audvis_raw-trans.fif'
+fname_bem = (
+    subjects_dir / 'sample' / 'bem' / 'sample-5120-bem-sol.fif')
+
+# %%
+# For the volume, create a coarse source space for speed (don't do this in
+# real code!), then compute the forward using this source space.
+
+# read noise cov and and evoked
+noise_cov = mne.read_cov(fname_cov)
+evoked = mne.read_evokeds(fname_evo, 0)
+
+# create a coarse source space
+src_vol = mne.setup_volume_source_space(  # this is a very course resolution!
+    'sample', pos=15., subjects_dir=subjects_dir)
+
+# compute the forward
+forward_vol = mne.make_forward_solution(  # MEG-only for speed
+    evoked.info, fname_trans, src_vol, fname_bem, eeg=False)
+del src_vol
+
+# %%
+# Now make an inverse operator and compute the PSF at a source.
+inverse_operator_vol = mne.minimum_norm.make_inverse_operator(
+    info=evoked.info, forward=forward_vol, noise_cov=noise_cov)
+
+# compute resolution matrix for sLORETA
+rm_lor_vol = make_inverse_resolution_matrix(
+    forward_vol, inverse_operator_vol, method='sLORETA', lambda2=1. / 9.)
+
+# get PSF and CTF for sLORETA at one vertex
+sources_vol = [100]
+stc_psf_vol = get_point_spread(
+    rm_lor_vol, forward_vol['src'], sources_vol, norm=True)
+del rm_lor_vol
+
+##############################################################################
+# Visualize
+# ---------
+# PSF:
+
+# Which vertex corresponds to selected source
+src_vol = forward_vol['src']
+verttrue_vol = src_vol[0]['vertno'][sources_vol]
+
+# find vertex with maximum in PSF
+max_vert_idx, _ = np.unravel_index(
+    stc_psf_vol.data.argmax(), stc_psf_vol.data.shape)
+vert_max_ctf_vol = src_vol[0]['vertno'][[max_vert_idx]]
+
+# plot them
+brain_psf_vol = stc_psf_vol.plot_3d(
+    'sample', src=forward_vol['src'], views='ven', subjects_dir=subjects_dir,
+    volume_options=dict(alpha=0.5))
+brain_psf_vol.add_text(
+    0.1, 0.9, 'Volumetric sLORETA PSF', 'title', font_size=16)
+brain_psf_vol.add_foci(
+    verttrue_vol, coords_as_verts=True,
+    scale_factor=1, hemi='vol', color='green')
+brain_psf_vol.add_foci(
+    vert_max_ctf_vol, coords_as_verts=True,
+    scale_factor=1.25, hemi='vol', color='black', alpha=0.3)

--- a/mne/minimum_norm/resolution_matrix.py
+++ b/mne/minimum_norm/resolution_matrix.py
@@ -359,6 +359,7 @@ def _prepare_info(inverse_operator):
     with info._unlock():
         info['sfreq'] = 1000.  # necessary
         info['projs'] = inverse_operator['projs']
+        info['custom_ref_applied'] = False
     return info
 
 


### PR DESCRIPTION
The example modifications I made took the example from 427.1 MB to 2289.5 MB, which [killed CircleCI](https://app.circleci.com/pipelines/github/mne-tools/mne-python/16149/workflows/768c215e-75b1-4df4-9b4d-585b373cbca3/jobs/48654). Let's see if we can get it down to at least 1-1.5GB. If not we might have to compute a lower-resolution volumetric forward/inv :(