### PR TITLE
[DOC, MRG] De-duplicate default value for bad_percent in annotate_amplitude

### DIFF
--- a/mne/preprocessing/annotate_amplitude.py
+++ b/mne/preprocessing/annotate_amplitude.py
@@ -49,7 +49,7 @@ def annotate_amplitude(raw, peak=None, flat=None, bad_percent=5,
         Above this percentage, the channel involved is return in ``bads``. Note
         the returned ``bads`` are not automatically added to
         :class:`info['bads'] <mne.Info>`.
-        Defaults to ``5`` (%%).
+        Defaults to ``5``, i.e. 5%%.
     min_duration : float
         The minimum duration (sec) required by consecutives samples to be above
         ``peak`` or below ``flat`` thresholds to be considered.

--- a/mne/preprocessing/annotate_amplitude.py
+++ b/mne/preprocessing/annotate_amplitude.py
@@ -49,7 +49,7 @@ def annotate_amplitude(raw, peak=None, flat=None, bad_percent=5,
         Above this percentage, the channel involved is return in ``bads``. Note
         the returned ``bads`` are not automatically added to
         :class:`info['bads'] <mne.Info>`.
-        Defaults to ``5`` (5%%).
+        Defaults to ``5`` (%%).
     min_duration : float
         The minimum duration (sec) required by consecutives samples to be above
         ``peak`` or below ``flat`` thresholds to be considered.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/73893616/188590458-d0e61ec3-a0e4-4f7e-8218-d21b936e6029.png)

It's looking a bit weird, so I removed the non-formatted `5` and only kept the unit in brackets.