### PR TITLE
fix fnirs channel name cropping in topomap combination

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -167,6 +167,7 @@ def _average_fnirs_overlaps(info, ch_type, sphere):
                 # first listed channel is the one to be replaced with merge
                 overlapping_set = [chs[i]['ch_name'] for i in
                                    np.where(overlapping_mask[chan_idx])[0]]
+                overlapping_set = np.array(overlapping_set).astype('>U20')
                 overlapping_set = np.insert(overlapping_set, 0,
                                             (chs[chan_idx]['ch_name']))
                 overlapping_channels.append(overlapping_set)


### PR DESCRIPTION
#### Reference issue
Resolves a bug discovered whilst reviewing #11064

@rob-luke @larsoner 

#### What does this implement/fix?
Explain your changes.

While testing out the #11064 I was having a recurrent issue that was quite subtle and tricky to pin down:

Essentially, it looks like this line

https://github.com/mne-tools/mne-python/blob/aef49669fe1bdf19221e03e85cf961671508e0bb/mne/viz/topomap.py#L170

will lead to a cropping of the added channel name, if it is longer than the channel names of the other ones in the list, and consequently than the numpy array datatype will permit. 

To properly reproduce this you would need to add a breakpoint at the above line, run the function, and monitor for when it attempts to combine channel names with differing lengths as described above. I don't have an example for that full use case, but here is the plain numpy for the scenario I have encountered, using the same variable names as the linked code:


```python
import numpy as np

# Here are two examples of the channel name being added to the combined list,
# one that will work and one that will not work.
# In the mne code these correspond to  `chs[chan_idx]['ch_name']`
new_chname_bad = 'S10_D50 hbo'
new_chname_good = 'S5_D50 hbo'
# This list is produced one line above the incrimating line
# https://github.com/mne-tools/mne-python/blob/aef49669fe1bdf19221e03e85cf961671508e0bb/mne/viz/topomap.py#L168
overlapping_set = ['S5_D50 hbo', 'S9_D50 hbo']
overlapping_set_orig_goodchan = np.insert(overlapping_set, 0, (new_chname_good))
overlapping_set_orig_badchan = np.insert(overlapping_set, 0, (new_chname_bad))
print(overlapping_set_orig_goodchan)
>> ['S5_D50 hbo', 'S5_D50 hbo', 'S9_D50 hbo']

print(overlapping_set_orig_badchan)
>> ['S10_D50 hb', 'S5_D50 hbo', 'S9_D50 hbo']
## NOTE THE CROPPED CHANNEL NAME 'S10_D50 hb' - THIS IMMEDIATELY LEADS TO ERRORS IN SUBSEQUENT FUNCTION CALLS  

# This is the proposed fix
overlapping_set = np.array(overlapping_set).astype('<U20')
overlapping_set_fixed_goodchan = np.insert(overlapping_set, 0, (new_chname_good))
overlapping_set_fixed_badchan = np.insert(overlapping_set, 0, (new_chname_bad))
print(overlapping_set_fixed_goodchan)
>> ['S5_D50 hbo', 'S5_D50 hbo', 'S9_D50 hbo']

print(overlapping_set_fixed_badchan)
>>['S10_D50 hbo', 'S5_D50 hbo', 'S9_D50 hbo']

```

#### Additional information
Any additional information you think is important.
