### PR TITLE
On ICA._reset(), reset current_fit to "unfitted"

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -216,9 +216,8 @@ class ICA(ContainsMixin):
 
     Attributes
     ----------
-    current_fit : str
-        Flag informing about which data type (raw or epochs) was used for the
-        fit.
+    current_fit : 'unfitted' | 'raw' | 'epochs'
+        Which data type was used for the fit.
     ch_names : list-like
         Channel names resulting from initial picking.
     n_components_ : int
@@ -682,6 +681,7 @@ class ICA(ContainsMixin):
                     'pca_mean_', 'n_iter_', 'drop_inds_', 'reject_'):
             if hasattr(self, key):
                 delattr(self, key)
+        self.current_fit = 'unfitted'
 
     def _fit_raw(self, raw, picks, start, stop, decim, reject, flat, tstep,
                  reject_by_annotation, verbose):

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -415,15 +415,20 @@ def test_ica_reset(method):
         'pca_mean_',
         'n_iter_'
     )
+
+    ica = ICA(n_components=3, method=method, max_iter=1)
+    assert ica.current_fit == 'unfitted'
     with pytest.warns(UserWarning, match='did not converge'):
-        ica = ICA(
-            n_components=3, method=method, max_iter=1).fit(raw, picks=picks)
+        ica.fit(raw, picks=picks)
 
     assert (all(hasattr(ica, attr) for attr in run_time_attrs))
     assert ica.labels_ is not None
+    assert ica.current_fit == 'raw'
+
     ica._reset()
     assert (not any(hasattr(ica, attr) for attr in run_time_attrs))
     assert ica.labels_ is not None
+    assert ica.current_fit == 'unfitted'
 
 
 @requires_sklearn


### PR DESCRIPTION
This is mostly a code health change fixing an internal inconsistency that I just ran into while working on another feature:

When calling the private `ICA._reset()` method, we forgot to reset `ICA.current_fit` as well.

This change causes no user-facing alterations.

MWE:
```python
# %%
import mne
mne.set_log_level('WARNING')

sample_dir = mne.datasets.sample.data_path()
sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'

raw = (
    mne.io.read_raw_fif(sample_fname)
    .crop(tmax=60)
    .pick_types(eeg=True)
    .load_data()
)

ica = mne.preprocessing.ICA(n_components=15, method='picard')
print(f'Before fit:\t{ica.current_fit}')

ica.fit(raw)
print(f'After fit:\t{ica.current_fit}')

ica._reset()
print(f'After reset:\t{ica.current_fit}')
```

On `main`:
```
Before fit:	unfitted
After fit:	raw
After reset:	raw
```
On PR branch:
```
Before fit:	unfitted
After fit:	raw
After reset:	unfitted
```