### PR TITLE
[DOC] Improve doc format and x-ref related to coordinate transformation

### DIFF
--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -1562,14 +1562,14 @@ def compute_dev_head_t(montage):
 
     Parameters
     ----------
-    montage : instance of DigMontage
-        The DigMontage must contain the fiducials in head
+    montage : DigMontage
+        The `~mne.channels.DigMontage` must contain the fiducials in head
         coordinate system and hpi points in both head and
         meg device coordinate system.
 
     Returns
     -------
-    dev_head_t : instance of Transform
+    dev_head_t : Transform
         A Device-to-Head transformation matrix.
     """
     _, coord_frame = _get_fid_coords(montage.dig)

--- a/mne/io/kit/coreg.py
+++ b/mne/io/kit/coreg.py
@@ -123,8 +123,8 @@ def _set_dig_kit(mrk, elp, hsp, eeg):
     -------
     dig_points : list
         List of digitizer points for info['dig'].
-    dev_head_t : dict
-        A dictionary describe the device-head transformation.
+    dev_head_t : Transform
+        A dictionary describing the device-head transformation.
     hpi_results : list
         The hpi results.
     """

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -419,7 +419,7 @@ class Info(dict, MontageMixin, ContainsMixin):
     comps : list of dict
         CTF software gradient compensation data.
         See Notes for more information.
-    ctf_head_t : dict | None
+    ctf_head_t : Transform | None
         The transformation from 4D/CTF head coordinates to Neuromag head
         coordinates. This is only present in 4D/CTF data.
     custom_ref_applied : int
@@ -428,10 +428,10 @@ class Info(dict, MontageMixin, ContainsMixin):
         average reference to be set.
     description : str | None
         String description of the recording.
-    dev_ctf_t : dict | None
+    dev_ctf_t : Transform | None
         The transformation from device coordinates to 4D/CTF head coordinates.
         This is only present in 4D/CTF data.
-    dev_head_t : dict | None
+    dev_head_t : Transform | None
         The device to head transformation.
     device_info : dict | None
         Information about the acquisition device. See Notes for details.

--- a/mne/preprocessing/artifact_detection.py
+++ b/mne/preprocessing/artifact_detection.py
@@ -266,7 +266,7 @@ def compute_average_dev_head_t(raw, pos):
 
     Returns
     -------
-    dev_head_t : array
+    dev_head_t : array of shape (4, 4)
         New trans matrix using the averaged good head positions.
     """
     sfreq = raw.info['sfreq']

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -88,8 +88,9 @@ class Transform(dict):
 
     Notes
     -----
-    Valid coordinate frames are 'meg','mri','mri_voxel','head','mri_tal','ras'
-    'fs_tal','ctf_head','ctf_meg','unknown'
+    Valid coordinate frames are ``'meg'``, ``'mri'``, ``'mri_voxel'``,
+    ``'head'``, ``'mri_tal'``, ``'ras'``, ``'fs_tal'``, ``'ctf_head'``,
+    ``'ctf_meg'``, ``'unknown'``.
     """
 
     def __init__(self, fro, to, trans=None):  # noqa: D102

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -82,7 +82,7 @@ class Transform(dict):
         The starting coordinate frame. See notes for valid coordinate frames.
     to : str | int
         The ending coordinate frame. See notes for valid coordinate frames.
-    trans : array-like, shape (4, 4) | None
+    trans : array of shape (4, 4) | None
         The transformation matrix. If None, an identity matrix will be
         used.
 


### PR DESCRIPTION
Minor improvements to the documentation formatting and x-ref related to `mne.transforms.Transform`.