### PR TITLE
BUG: Fix bugs with temperature and GSR plotting

### DIFF
--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -930,7 +930,8 @@ _FNIRS_CH_TYPES_SPLIT = ('hbo', 'hbr', 'fnirs_cw_amplitude',
 _DATA_CH_TYPES_ORDER_DEFAULT = (
     'mag', 'grad', 'eeg', 'csd', 'eog', 'ecg', 'resp', 'emg', 'ref_meg',
     'misc', 'stim', 'chpi', 'exci', 'ias', 'syst', 'seeg', 'bio', 'ecog',
-    'dbs') + _FNIRS_CH_TYPES_SPLIT + ('whitened',)
+    'dbs', 'temperature', 'gsr', 'gof', 'dipole',
+    ) + _FNIRS_CH_TYPES_SPLIT + ('whitened',)
 # Valid data types, ordered for consistency, used in viz/evoked.
 _VALID_CHANNEL_TYPES = (
     'eeg', 'grad', 'mag', 'seeg', 'eog', 'ecg', 'resp', 'emg', 'dipole', 'gof',

--- a/mne/io/pick.py
+++ b/mne/io/pick.py
@@ -931,7 +931,7 @@ _DATA_CH_TYPES_ORDER_DEFAULT = (
     'mag', 'grad', 'eeg', 'csd', 'eog', 'ecg', 'resp', 'emg', 'ref_meg',
     'misc', 'stim', 'chpi', 'exci', 'ias', 'syst', 'seeg', 'bio', 'ecog',
     'dbs', 'temperature', 'gsr', 'gof', 'dipole',
-    ) + _FNIRS_CH_TYPES_SPLIT + ('whitened',)
+) + _FNIRS_CH_TYPES_SPLIT + ('whitened',)
 # Valid data types, ordered for consistency, used in viz/evoked.
 _VALID_CHANNEL_TYPES = (
     'eeg', 'grad', 'mag', 'seeg', 'eog', 'ecg', 'resp', 'emg', 'dipole', 'gof',

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -254,6 +254,8 @@ class BrowserBase(ABC):
                            self.mne.ch_start + self.mne.n_channels)
             self.mne.picks = self.mne.ch_order[_slice]
             self.mne.n_channels = len(self.mne.picks)
+        assert isinstance(self.mne.picks, np.ndarray)
+        assert self.mne.picks.dtype.kind == 'i'
 
     def _make_butterfly_selections_dict(self):
         """Make an altered copy of the selections dict for butterfly mode."""

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -275,6 +275,10 @@ def plot_raw(raw, events=None, duration=10.0, start=0.0, n_channels=20,
         order = np.concatenate(list(selections.values()))
         default_selection = list(selections)[0]
         n_channels = len(selections[default_selection])
+    assert isinstance(order, np.ndarray)
+    assert order.dtype.kind == 'i'
+    if order.size == 0:
+        raise RuntimeError('No channels found to plot')
 
     # handle event colors
     event_color_dict = _make_event_color_dict(event_color, events, event_id)

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -17,6 +17,8 @@ from mne import Annotations, create_info, pick_types
 from mne.annotations import _sync_onset
 from mne.datasets import testing
 from mne.io import RawArray
+from mne.io.pick import (_DATA_CH_TYPES_ORDER_DEFAULT, _PICK_TYPES_DATA_DICT,
+                         _FNIRS_CH_TYPES_SPLIT)
 from mne.utils import _dt_to_stamp, _record_warnings, get_config, set_config
 from mne.viz import plot_raw, plot_sensors
 from mne.viz.utils import _fake_click, _fake_keypress
@@ -939,3 +941,24 @@ def test_clock_xticks(raw, dur, n_dec, browser_backend):
     assert tick_texts[0].startswith('19:01:53')
     if len(tick_texts[0].split('.')) > 1:
         assert len(tick_texts[0].split('.')[1]) == n_dec
+
+
+def test_plotting_order_consistency():
+    """Test that our internal variables have some consistency."""
+    pick_data_set = set(_PICK_TYPES_DATA_DICT)
+    pick_data_set.remove('meg')
+    pick_data_set.remove('fnirs')
+    missing = pick_data_set.difference(set(_DATA_CH_TYPES_ORDER_DEFAULT))
+    assert missing == set()
+
+
+def test_plotting_temperature_gsr(browser_backend):
+    """Test that we can plot temperature and GSR."""
+    data = np.random.RandomState(0).randn(2, 1000)
+    data[0] += 37  # deg C
+    # no idea what the scale should be for GSR
+    info = create_info(2, 1000., ['temperature', 'gsr'])
+    raw = RawArray(data, info)
+    fig = raw.plot()
+    tick_texts = fig._get_ticklabels('y')
+    assert len(tick_texts) == 2

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -17,8 +17,7 @@ from mne import Annotations, create_info, pick_types
 from mne.annotations import _sync_onset
 from mne.datasets import testing
 from mne.io import RawArray
-from mne.io.pick import (_DATA_CH_TYPES_ORDER_DEFAULT, _PICK_TYPES_DATA_DICT,
-                         _FNIRS_CH_TYPES_SPLIT)
+from mne.io.pick import _DATA_CH_TYPES_ORDER_DEFAULT, _PICK_TYPES_DATA_DICT
 from mne.utils import _dt_to_stamp, _record_warnings, get_config, set_config
 from mne.viz import plot_raw, plot_sensors
 from mne.viz.utils import _fake_click, _fake_keypress

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -386,7 +386,7 @@ def _get_channel_plotting_order(order, ch_types, picks=None):
                          f'"{order}" ({type(order)}).')
     if picks is not None:
         order = [ch for ch in order if ch in picks]
-    return np.asarray(order)
+    return np.asarray(order, int)
 
 
 def _make_event_color_dict(event_color, events=None, event_id=None):


### PR DESCRIPTION
This minimal example now produces a plot:
```
import numpy as np
import mne
data = np.random.RandomState(0).randn(2, 1000)
data[0] += 37  # deg C
# no idea what the scale should be for GSR
info = mne.create_info(2, 1000., ['temperature', 'gsr'])
raw = mne.io.RawArray(data, info)
fig = raw.plot()
```
Can't really tell if the scale is reasonable until the dataset in #11112 is confirmed as correct or fixed.

Helps with #11112 but does not close it, because we still haven't ensured that temperature and GSR data are actually displayed properly, as we don't yet have a reliable dataset to check with.