### PR TITLE
BUG: Fix bugs with digitization

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -49,6 +49,7 @@ Bugs
 - Fix bug in :func:`mne.decoding.TimeFrequency` that prevented cloning if constructor arguments were modified (:gh:`11004` by :newcontrib:`Daniel Carlström Schad`)
 - Fix bug in :class:`mne.viz.Brain` constructor where the first argument was named ``subject_id`` instead of ``subject`` (:gh:`11049` by `Eric Larson`_)
 - Fix bug in :ref:`mne coreg` where the MEG helmet position was not updated during ICP fitting (:gh:`11084` by `Eric Larson`_)
+- Fix bug in :func:`~mne.io.read_raw_curry`, and :func:`~mne.io.read_raw_cnt` where digitization points were not read properly (:gh:`11145` by `Eric Larson`_)
 - Document ``height`` and ``weight`` keys of  ``subject_info`` entry in :class:`mne.Info` (:gh:`11019` by :newcontrib:`Sena Er`)
 - Fix bug in :func:`mne.viz.plot_filter` when plotting filters created using ``output='ba'`` mode with ``compensation`` turned on. (:gh:`11040` by `Marian Dovgialo`_)
 - Fix bug in :func:`mne.io.read_raw_bti` where EEG, EMG, and H/VEOG channels were not detected properly, and many non-ECG channels were called ECG. The logic has been improved, and any channels of unknown type are now labeled as ``misc`` (:gh:`11102` by `Eric Larson`_)

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -1207,6 +1207,9 @@ def _get_bti_info(pdf_fname, config_fname, head_shape_fname, rotation_x,
             chan_info['coil_type'] = FIFF.FIFFV_COIL_EEG
             chan_info['coord_frame'] = eeg_frame
             chan_info['unit'] = FIFF.FIFF_UNIT_V
+            # TODO: We should use 'electrodes' to fill this in, and make sure
+            # we turn them into dig as well
+            chan_info['loc'][:3] = np.nan
 
         elif chan_4d == 'RESPONSE':
             chan_info['kind'] = FIFF.FIFFV_STIM_CH

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -11,6 +11,7 @@ import numpy as np
 from ...utils import warn, fill_doc, _check_option
 from ...channels.layout import _topo_to_sphere
 from ..constants import FIFF
+from .._digitization import _make_dig_points
 from ..utils import (_mult_cal_one, _find_channels, _create_chs, read_str)
 from ..meas_info import _empty_info
 from ..base import BaseRaw
@@ -301,6 +302,7 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
     coords = _topo_to_sphere(pos, eegs)
     locs = np.full((len(chs), 12), np.nan)
     locs[:, :3] = coords
+    dig = _make_dig_points(dig_ch_pos=dict(zip(ch_names, coords)))
     for ch, loc in zip(chs, locs):
         ch.update(loc=loc)
 
@@ -308,7 +310,7 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format):
                     n_bytes=n_bytes)
 
     session_label = None if str(session_label) == '' else str(session_label)
-    info.update(meas_date=meas_date,
+    info.update(meas_date=meas_date, dig=dig,
                 description=session_label, bads=bads,
                 subject_info=subject_info, chs=chs)
     info._unlocked = False

--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -11,6 +11,7 @@ import re
 import numpy as np
 from datetime import datetime, timezone
 
+from .._digitization import _make_dig_points
 from ..base import BaseRaw
 from ..meas_info import create_info
 from ..tag import _coil_trans_to_loc
@@ -21,8 +22,7 @@ from ...surface import _normal_orth
 from ...transforms import (apply_trans, Transform, get_ras_to_neuromag_trans,
                            combine_transforms, invert_transform,
                            _angle_between_quats, rot_to_quat)
-from ...utils import (check_fname, check_version, logger, verbose, warn,
-                      _check_fname)
+from ...utils import check_fname, logger, verbose, _check_fname
 from ...annotations import Annotations
 
 FILE_EXTENSIONS = {
@@ -227,6 +227,7 @@ def _read_curry_info(curry_paths):
     assert len(labels) == len(sensors) == len(normals)
 
     all_chans = list()
+    dig_ch_pos = dict()
     for key in ["meg", "eeg", "misc"]:
         chanidx_is_explicit = (len(curry_params.chanidx_in_file["CHAN_IN_FILE"
                                    + CHANTYPES[key]]) > 0)    # channel index
@@ -260,6 +261,7 @@ def _read_curry_info(curry_paths):
                 ch['loc'] = loc
                 # XXX need to check/ensure this
                 ch['coord_frame'] = FIFF.FIFFV_COORD_HEAD
+                dig_ch_pos[chan] = loc[:3]
             elif key == 'meg':
                 pos = np.array(sensors["SENSORS" + CHANTYPES[key]][ind], float)
                 pos /= 1000.  # to meters
@@ -275,6 +277,8 @@ def _read_curry_info(curry_paths):
                 ch['loc'] = _coil_trans_to_loc(trans)
                 ch['coord_frame'] = FIFF.FIFFV_COORD_DEVICE
             all_chans.append(ch)
+    dig = _make_dig_points(dig_ch_pos=dig_ch_pos)
+    del dig_ch_pos
 
     ch_count = len(all_chans)
     assert (ch_count == curry_params.n_chans)  # ensure that we have assembled
@@ -291,6 +295,7 @@ def _read_curry_info(curry_paths):
     info = create_info(ch_names, curry_params.sfreq)
     with info._unlock():
         info['meas_date'] = curry_params.dt_start  # for Git issue #8398
+        info['dig'] = dig
     _make_trans_dig(curry_paths, info, curry_dev_dev_t)
 
     for ind, ch_dict in enumerate(info["chs"]):
@@ -525,16 +530,10 @@ class RawCurry(BaseRaw):
         if self._raw_extras[fi]['is_ascii']:
             if isinstance(idx, slice):
                 idx = np.arange(idx.start, idx.stop)
-            kwargs = dict(skiprows=start, usecols=idx)
-            if check_version("numpy", "1.16.0"):
-                kwargs['max_rows'] = stop - start
-            else:
-                warn("Data reading might take longer for ASCII files. Update "
-                     "numpy to version 1.16.0 or greater for more efficient "
-                     "data reading.")
-            block = np.loadtxt(self._filenames[0], **kwargs)[:stop - start].T
-            data_view = data[:, :block.shape[1]]
-            _mult_cal_one(data_view, block, idx, cals, mult)
+            block = np.loadtxt(
+                self._filenames[0], skiprows=start, max_rows=stop - start,
+                ndmin=2).T
+            _mult_cal_one(data, block, idx, cals, mult)
 
         else:
             _read_segments_file(

--- a/mne/io/curry/tests/test_curry.py
+++ b/mne/io/curry/tests/test_curry.py
@@ -22,6 +22,7 @@ from mne.io.constants import FIFF
 from mne.io.edf import read_raw_bdf
 from mne.io.bti import read_raw_bti
 from mne.io.curry import read_raw_curry
+from mne.io.tests.test_raw import _test_raw_reader
 from mne.utils import check_version, catch_logging, _record_warnings
 from mne.annotations import read_annotations
 from mne.io.curry.curry import (_get_curry_version, _get_curry_file_structure,
@@ -96,6 +97,18 @@ def test_read_raw_curry(fname, tol, preload, bdf_curry_ref):
         bdf_curry_ref.get_data(picks=picks, start=start, stop=stop),
         rtol=tol)
     assert raw.info['dev_head_t'] is None
+
+
+@testing.requires_testing_data
+@pytest.mark.parametrize('fname', [
+    pytest.param(curry7_bdf_file, id='curry 7'),
+    pytest.param(curry8_bdf_file, id='curry 8'),
+    pytest.param(curry7_bdf_ascii_file, id='curry 7 ascii'),
+    pytest.param(curry8_bdf_ascii_file, id='curry 8 ascii'),
+])
+def test_read_raw_curry_test_raw(fname):
+    """Test read_raw_curry with _test_raw_reader."""
+    _test_raw_reader(read_raw_curry, fname=fname)
 
 
 # These values taken from a different recording but allow us to test

--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -254,7 +254,8 @@ class RawEGI(BaseRaw):
             chs[idx].update({'unit_mul': FIFF.FIFF_UNITM_NONE, 'cal': 1.,
                              'kind': FIFF.FIFFV_STIM_CH,
                              'coil_type': FIFF.FIFFV_COIL_NONE,
-                             'unit': FIFF.FIFF_UNIT_NONE})
+                             'unit': FIFF.FIFF_UNIT_NONE,
+                             'loc': np.zeros(12)})
         info['chs'] = chs
         info._unlocked = False
         info._update_redundant()

--- a/mne/io/fieldtrip/tests/helpers.py
+++ b/mne/io/fieldtrip/tests/helpers.py
@@ -9,7 +9,6 @@ import os
 import numpy as np
 
 import mne
-from mne.io.constants import FIFF
 from mne.utils import object_diff
 
 
@@ -17,7 +16,8 @@ info_ignored_fields = ('file_id', 'hpi_results', 'hpi_meas', 'meas_id',
                        'meas_date', 'highpass', 'lowpass', 'subject_info',
                        'hpi_subsystem', 'experimenter', 'description',
                        'proj_id', 'proj_name', 'line_freq', 'gantry_angle',
-                       'dev_head_t', 'bads', 'ctf_head_t', 'dev_ctf_t')
+                       'dev_head_t', 'bads', 'ctf_head_t', 'dev_ctf_t',
+                       'dig')
 
 ch_ignore_fields = ('logno', 'cal', 'range', 'scanno', 'coil_type', 'kind',
                     'loc', 'coord_frame', 'unit')
@@ -70,18 +70,6 @@ def _remove_ignored_info_fields(info):
             del info[cur_field]
 
     _remove_ignored_ch_fields(info)
-    _remove_bad_dig_fields(info)
-
-
-def _remove_bad_dig_fields(info):
-    # The reference location appears to be lost, so we cannot add it.
-    # Similarly, fiducial locations do not appear to be stored, so we
-    # cannot add those, either. Same with HPI coils.
-    if info['dig'] is not None:
-        with info._unlock():
-            info['dig'] = [d for d in info['dig']
-                           if d['kind'] == FIFF.FIFFV_POINT_EEG and
-                           d['ident'] != 0]  # ref
 
 
 def get_data_paths(system):
@@ -200,7 +188,7 @@ def check_info_fields(expected, actual, has_raw_info, ignore_long=True):
     # we annoyingly have two ways of representing this, so just always use
     # an empty list here
     for obj in (expected, actual):
-        if obj['dig'] is None:
+        if obj.get('dig', None) is None:
             with obj._unlock():
                 obj['dig'] = []
 

--- a/mne/io/fieldtrip/tests/test_fieldtrip.py
+++ b/mne/io/fieldtrip/tests/test_fieldtrip.py
@@ -14,12 +14,14 @@ import numpy as np
 
 import mne
 from mne.datasets import testing
+from mne.io import read_raw_fieldtrip
 from mne.io.fieldtrip.utils import NOINFO_WARNING, _create_events
-from mne.utils import _check_pandas_installed, _record_warnings
 from mne.io.fieldtrip.tests.helpers import (
     check_info_fields, get_data_paths, get_raw_data, get_epochs, get_evoked,
     pandas_not_found_warning_msg, get_raw_info, check_data,
     assert_warning_in_record)
+from mne.io.tests.test_raw import _test_raw_reader
+from mne.utils import _check_pandas_installed, _record_warnings
 
 # missing: KIT: biggest problem here is that the channels do not have the same
 # names.
@@ -145,7 +147,7 @@ def test_read_epochs(cur_system, version, use_info, monkeypatch):
 @pytest.mark.filterwarnings('ignore:.*parse meas date.*:RuntimeWarning')
 @pytest.mark.filterwarnings('ignore:.*number of bytes.*:RuntimeWarning')
 @pytest.mark.parametrize('cur_system, version, use_info', all_test_params_raw)
-def test_raw(cur_system, version, use_info):
+def test_read_raw_fieldtrip(cur_system, version, use_info):
     """Test comparing reading a raw fiff file and the FieldTrip version."""
     # Load the raw fiff file with mne
     test_data_folder_ft = get_data_paths(cur_system)
@@ -177,6 +179,13 @@ def test_raw(cur_system, version, use_info):
     check_data(raw_fiff_mne.get_data(),
                raw_fiff_ft.get_data(),
                cur_system)
+
+    # standard tests
+    with _record_warnings():
+        _test_raw_reader(
+            read_raw_fieldtrip, fname=cur_fname, info=info,
+            test_preloading=False,
+            test_kwargs=False)  # TODO: This should probably work
 
     # Check info field
     check_info_fields(raw_fiff_mne, raw_fiff_ft, use_info)

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -269,6 +269,8 @@ def _create_chs(ch_names, cals, ch_coil, ch_kind, eog, ecg, emg, misc):
                      'ch_name': ch_name, 'unit': FIFF.FIFF_UNIT_V,
                      'coord_frame': FIFF.FIFFV_COORD_HEAD,
                      'coil_type': coil_type, 'kind': kind, 'loc': np.zeros(12)}
+        if coil_type == FIFF.FIFFV_COIL_EEG:
+            chan_info['loc'][:3] = np.nan
         chs.append(chan_info)
     return chs
 


### PR DESCRIPTION
Fixes bugs with a few `read_raw_*` functions where `info['dig']` was not set even though EEG channel locations were read. Also moves us toward using `eeg_ch['loc'][:3] = np.nan` rather than `= 0`, which at some point I think we decided was a better way to go.