### PR TITLE
Ensure original and cleaned evokeds share the same baseline in ICA.plot_overlay()

### DIFF
--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -23,7 +23,7 @@ from ..utils import _validate_type, fill_doc
 from ..defaults import _handle_default
 from ..io.meas_info import create_info
 from ..io.pick import pick_types, _picks_to_idx
-from ..utils import _reject_data_segments, verbose
+from ..utils import _reject_data_segments, verbose, logger
 
 
 @fill_doc
@@ -923,6 +923,15 @@ def plot_ica_overlay(ica, inst, exclude=None, picks=None, start=None,
             inst.pick_channels([inst.ch_names[p] for p in picks])
         evoked_cln = ica.apply(inst.copy(), exclude=exclude,
                                n_pca_components=n_pca_components)
+
+        # Ensure input and cleaned data share the same baseline.
+        if inst.baseline is not None:
+            logger.info(
+                f'Original data was baseline-corrected. Applying baseline '
+                f'correction to cleaned data.'
+            )
+            evoked_cln.apply_baseline(inst.baseline)
+
         fig = _plot_ica_overlay_evoked(evoked=inst, evoked_cln=evoked_cln,
                                        title=title, show=show)
 


### PR DESCRIPTION
Applying ICA can lead to signal shifts, and we emit a warning:

> <ipython-input-2-633085fb6bef>:3: RuntimeWarning: The data you passed to ICA.apply() was baseline-corrected. Please note that ICA can introduce DC shifts, therefore you may wish to consider baseline-correcting the cleaned data again.


When creating the overlay plots, we should therefore automatically follow this suggestion, as the user has no way to intervene there directly:

`main`:
![image](https://user-images.githubusercontent.com/2046265/189499413-2353aaec-388e-4b71-9a70-b4ee69d45140.png)


This PR:
![image](https://user-images.githubusercontent.com/2046265/189499390-23cd477e-b027-41f4-a904-d343caee3f9d.png)


MWE:
```python
# %%
import mne

sample_dir = mne.datasets.sample.data_path()
sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'

raw = mne.io.read_raw_fif(sample_fname, preload=True)
raw.crop(tmax=60)
raw.pick_types(eeg=True, stim=True)
events = mne.find_events(raw)
epochs = mne.Epochs(raw=raw, events=events, baseline=None, preload=True)
evoked = epochs.average()

ica = mne.preprocessing.ICA(n_components=15, method='picard')
ica.fit(epochs)

# %%
evoked.apply_baseline()
ica.plot_overlay(inst=evoked, exclude=[0])
```