### PR TITLE
Add encoding parameter to read_raw_{eb}df()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -43,6 +43,7 @@ Enhancements
 - Add :func:`mne.chpi.get_active_chpi` to retrieve the number of active hpi coils for each time point (:gh:`11122` by `Eduard Ort`_)
 - Add example of how to obtain time-frequency decomposition using narrow bandpass Hilbert transforms to :ref:`ex-tfr-comparison` (:gh:`11116` by `Alex Rockhill`_)
 - Add ``==`` and ``!=`` comparison between `mne.Projection` objects (:gh:`11147` by `Mathieu Scheltienne`_)
+- Add ``encoding`` parameter to :func:`mne.io.read_raw_edf` and :func:`read_raw_bdf` to support custom (non-UTF8) annotation channel encodings (:gh:`11154` by `Clemens Brunner`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -43,7 +43,7 @@ Enhancements
 - Add :func:`mne.chpi.get_active_chpi` to retrieve the number of active hpi coils for each time point (:gh:`11122` by `Eduard Ort`_)
 - Add example of how to obtain time-frequency decomposition using narrow bandpass Hilbert transforms to :ref:`ex-tfr-comparison` (:gh:`11116` by `Alex Rockhill`_)
 - Add ``==`` and ``!=`` comparison between `mne.Projection` objects (:gh:`11147` by `Mathieu Scheltienne`_)
-- Add ``encoding`` parameter to :func:`mne.io.read_raw_edf` and :func:`read_raw_bdf` to support custom (non-UTF8) annotation channel encodings (:gh:`11154` by `Clemens Brunner`_)
+- Add ``encoding`` parameter to :func:`mne.io.read_raw_edf` and :func:`mne.io.read_raw_bdf` to support custom (non-UTF8) annotation channel encodings (:gh:`11154` by `Clemens Brunner`_)
 
 Bugs
 ~~~~

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1647,11 +1647,6 @@ def _read_annotations_edf(annotations, encoding='utf8'):
     return zip(*events) if events else (list(), list(), list())
 
 
-def _get_edf_default_event_id(descriptions):
-    mapping = {a: n for n, a in enumerate(sorted(set(descriptions)), start=1)}
-    return mapping
-
-
 def _get_annotations_gdf(edf_info, sfreq):
     onset, duration, desc = list(), list(), list()
     events = edf_info.get('events', None)

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1597,8 +1597,9 @@ def _read_annotations_edf(annotations, encoding='utf8'):
     """
     pat = '([+-]\\d+\\.?\\d*)(\x15(\\d+\\.?\\d*))?(\x14.*?)\x14\x00'
     if isinstance(annotations, str):
-        with open(annotations, encoding=encoding) as annot_file:
-            triggers = re.findall(pat, annot_file.read())
+        with open(annotations, "rb") as annot_file:
+            triggers = re.findall(pat.encode(), annot_file.read())
+            triggers = [tuple(map(lambda x: x.decode(), t)) for t in triggers]
     else:
         tals = bytearray()
         annotations = np.atleast_2d(annotations)

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -84,6 +84,7 @@ class RawEDF(BaseRaw):
         .. versionadded:: 1.1
     %(preload)s
     %(units_edf_bdf_io)s
+    %(encoding_edf)
     %(verbose)s
 
     See Also
@@ -133,7 +134,7 @@ class RawEDF(BaseRaw):
     @verbose
     def __init__(self, input_fname, eog=None, misc=None, stim_channel='auto',
                  exclude=(), infer_types=False, preload=False, include=None,
-                 units=None, *, verbose=None):
+                 units=None, encoding='utf8', *, verbose=None):
         logger.info('Extracting EDF parameters from {}...'.format(input_fname))
         input_fname = os.path.abspath(input_fname)
         info, edf_info, orig_units = _get_info(input_fname, stim_channel, eog,
@@ -176,7 +177,10 @@ class RawEDF(BaseRaw):
             tal_data = self._read_segment_file(
                 np.empty((0, self.n_times)), idx, 0, 0, int(self.n_times),
                 np.ones((len(idx), 1)), None)
-            onset, duration, desc = _read_annotations_edf(tal_data[0])
+            onset, duration, desc = _read_annotations_edf(
+                tal_data[0],
+                encoding=encoding,
+            )
 
         self.set_annotations(Annotations(onset=onset, duration=duration,
                                          description=desc, orig_time=None))
@@ -1303,7 +1307,7 @@ def _find_tal_idx(ch_names):
 @fill_doc
 def read_raw_edf(input_fname, eog=None, misc=None, stim_channel='auto',
                  exclude=(), infer_types=False, include=None, preload=False,
-                 units=None, *, verbose=None):
+                 units=None, encoding='utf8', *, verbose=None):
     """Reader function for EDF or EDF+ files.
 
     Parameters
@@ -1344,6 +1348,7 @@ def read_raw_edf(input_fname, eog=None, misc=None, stim_channel='auto',
         .. versionadded:: 1.1
     %(preload)s
     %(units_edf_bdf_io)s
+    %(encoding_edf)
     %(verbose)s
 
     Returns
@@ -1406,13 +1411,13 @@ def read_raw_edf(input_fname, eog=None, misc=None, stim_channel='auto',
     return RawEDF(input_fname=input_fname, eog=eog, misc=misc,
                   stim_channel=stim_channel, exclude=exclude,
                   infer_types=infer_types, preload=preload, include=include,
-                  units=units, verbose=verbose)
+                  units=units, encoding=encoding, verbose=verbose)
 
 
 @fill_doc
 def read_raw_bdf(input_fname, eog=None, misc=None, stim_channel='auto',
                  exclude=(), infer_types=False, include=None, preload=False,
-                 units=None, *, verbose=None):
+                 units=None, encoding='utf8', *, verbose=None):
     """Reader function for BDF files.
 
     Parameters
@@ -1453,6 +1458,7 @@ def read_raw_bdf(input_fname, eog=None, misc=None, stim_channel='auto',
         .. versionadded:: 1.1
     %(preload)s
     %(units_edf_bdf_io)s
+    %(encoding_edf)
     %(verbose)s
 
     Returns
@@ -1508,7 +1514,7 @@ def read_raw_bdf(input_fname, eog=None, misc=None, stim_channel='auto',
     return RawEDF(input_fname=input_fname, eog=eog, misc=misc,
                   stim_channel=stim_channel, exclude=exclude,
                   infer_types=infer_types, preload=preload, include=include,
-                  units=units, verbose=verbose)
+                  units=units, encoding=encoding, verbose=verbose)
 
 
 @fill_doc
@@ -1568,13 +1574,15 @@ def read_raw_gdf(input_fname, eog=None, misc=None, stim_channel='auto',
                   include=include, verbose=verbose)
 
 
-def _read_annotations_edf(annotations):
+@fill_doc
+def _read_annotations_edf(annotations, encoding='utf8'):
     """Annotation File Reader.
 
     Parameters
     ----------
     annotations : ndarray (n_chans, n_samples) | str
         Channel data in EDF+ TAL format or path to annotation file.
+    %(encoding_edf)
 
     Returns
     -------
@@ -1589,7 +1597,7 @@ def _read_annotations_edf(annotations):
     """
     pat = '([+-]\\d+\\.?\\d*)(\x15(\\d+\\.?\\d*))?(\x14.*?)\x14\x00'
     if isinstance(annotations, str):
-        with open(annotations, encoding='latin-1') as annot_file:
+        with open(annotations, encoding=encoding) as annot_file:
             triggers = re.findall(pat, annot_file.read())
     else:
         tals = bytearray()
@@ -1609,8 +1617,13 @@ def _read_annotations_edf(annotations):
                 # Exploit np vectorized processing
                 tals.extend(np.uint8([this_chan % 256, this_chan // 256])
                             .flatten('F'))
-
-        triggers = re.findall(pat, tals.decode('utf8'))
+        try:
+            triggers = re.findall(pat, tals.decode(encoding))
+        except UnicodeDecodeError as e:
+            raise Exception(
+                "Encountered invalid byte in at least one annotations channel."
+                " You might want to try setting \"encoding='latin1'\"."
+            ) from e
 
     events = []
     offset = 0.

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -84,7 +84,7 @@ class RawEDF(BaseRaw):
         .. versionadded:: 1.1
     %(preload)s
     %(units_edf_bdf_io)s
-    %(encoding_edf)
+    %(encoding_edf)s
     %(verbose)s
 
     See Also
@@ -1348,7 +1348,7 @@ def read_raw_edf(input_fname, eog=None, misc=None, stim_channel='auto',
         .. versionadded:: 1.1
     %(preload)s
     %(units_edf_bdf_io)s
-    %(encoding_edf)
+    %(encoding_edf)s
     %(verbose)s
 
     Returns
@@ -1458,7 +1458,7 @@ def read_raw_bdf(input_fname, eog=None, misc=None, stim_channel='auto',
         .. versionadded:: 1.1
     %(preload)s
     %(units_edf_bdf_io)s
-    %(encoding_edf)
+    %(encoding_edf)s
     %(verbose)s
 
     Returns
@@ -1582,7 +1582,7 @@ def _read_annotations_edf(annotations, encoding='utf8'):
     ----------
     annotations : ndarray (n_chans, n_samples) | str
         Channel data in EDF+ TAL format or path to annotation file.
-    %(encoding_edf)
+    %(encoding_edf)s
 
     Returns
     -------

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -26,7 +26,7 @@ from mne.datasets import testing
 from mne.utils import requires_pandas, _record_warnings
 from mne.io import read_raw_edf, read_raw_bdf, read_raw_fif, edf, read_raw_gdf
 from mne.io.tests.test_raw import _test_raw_reader
-from mne.io.edf.edf import (_get_edf_default_event_id, _read_annotations_edf,
+from mne.io.edf.edf import (_read_annotations_edf,
                             _read_ch, _parse_prefilter_string, _edf_str,
                             _read_edf_header, _read_header)
 from mne.io.pick import channel_indices_by_type, get_channel_type_constants
@@ -240,7 +240,12 @@ def test_find_events_backward_compatibility():
                        [1280, 0, 2]]
     # test an actual file
     raw = read_raw_edf(edf_path, preload=True)
-    event_id = _get_edf_default_event_id(raw.annotations.description)
+    event_id = {
+        a: n
+        for n, a in enumerate(
+            sorted(set(raw.annotations.description)), start=1
+        )
+    }
     event_id.pop('start')
     events_from_EFA, _ = events_from_annotations(raw, event_id=event_id,
                                                  use_rounding=False)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -951,6 +951,12 @@ emit_warning : bool
     Whether to emit warnings when cropping or omitting annotations.
 """
 
+docdict['encoding_edf'] = """
+encoding : str
+    Encoding of annotations channel(s). Default is "utf8" (the only correct
+    encoding according to the EDF+ standard).
+"""
+
 docdict['epochs_preload'] = """
     Load all epochs from disk when creating the object
     or wait before accessing each epoch (more memory


### PR DESCRIPTION
Fixes #11135. This PR adds a new parameter `encoding` to `read_raw_edf()` and `read_raw_bdf()` (as well as the underlying `RawEDF` class). Users can set a custom encoding of their annotation channel(s), which by default (and according to the EDF+ standard) is UTF8, but many files in the wild seem to ignore the standard and use Latin-1.