### PR TITLE
add on_missing keyword to mne.chpi.get_active_hpi()

### DIFF
--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -1414,7 +1414,7 @@ def get_active_chpi(raw, on_missing='raise'):
                                    ' is not implemented for other systems'
                                    ' than neuromag.'))
     # extract hpi info
-    chpi_info = get_chpi_info(raw.info, on_missing=on_missing)
+    chpi_info = get_chpi_info(raw.info, on_missing=on_missing, verbose=verbose)
 
     # extract hpi time series and infer which one was on
     chpi_ts = raw[chpi_info[1]][0].astype(int)

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -1386,8 +1386,8 @@ def _compute_good_distances(hpi_coil_dists, new_pos, dist_limit=0.005):
     return use_mask, these_dists
 
 
-@fill_doc
-def get_active_chpi(raw, on_missing='raise'):
+@verbose
+def get_active_chpi(raw, *, on_missing='raise', verbose=None):
     """Determine how many HPI coils were active for a time point.
 
     Parameters

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -1386,13 +1386,14 @@ def _compute_good_distances(hpi_coil_dists, new_pos, dist_limit=0.005):
     return use_mask, these_dists
 
 
-def get_active_chpi(raw):
+def get_active_chpi(raw, on_missing='raise'):
     """Determine how many HPI coils were active for a time point.
 
     Parameters
     ----------
     raw : instance of Raw
         Raw data with cHPI information.
+    %(on_missing_chpi)s
 
     Returns
     -------
@@ -1403,8 +1404,11 @@ def get_active_chpi(raw):
     -----
     .. versionadded:: 1.2
     """
+    _check_option(parameter='on_missing', value=on_missing,
+                  allowed_values=['ignore', 'raise', 'warn'])
+
     # get meg system
-    system, _ = _get_meg_system(raw.info)
+    system, _ = _get_meg_system(raw.info, on_missing=on_missing)
 
     # check whether we have a neuromag system
     if system not in ['122m', '306m']:

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -48,7 +48,6 @@ from .transforms import (apply_trans, invert_transform, _angle_between_quats,
 from .utils import (verbose, logger, use_log_level, _check_fname, warn,
                     _validate_type, ProgressBar, _check_option, _pl,
                     _on_missing)
-from .utils.docs import fill_doc
 
 # Eventually we should add:
 #   hpicons

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -48,6 +48,7 @@ from .transforms import (apply_trans, invert_transform, _angle_between_quats,
 from .utils import (verbose, logger, use_log_level, _check_fname, warn,
                     _validate_type, ProgressBar, _check_option, _pl,
                     _on_missing)
+from .utils.docs import fill_doc
 
 # Eventually we should add:
 #   hpicons
@@ -1386,6 +1387,7 @@ def _compute_good_distances(hpi_coil_dists, new_pos, dist_limit=0.005):
     return use_mask, these_dists
 
 
+@fill_doc
 def get_active_chpi(raw, on_missing='raise'):
     """Determine how many HPI coils were active for a time point.
 

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -1408,7 +1408,7 @@ def get_active_chpi(raw, on_missing='raise'):
                   allowed_values=['ignore', 'raise', 'warn'])
 
     # get meg system
-    system, _ = _get_meg_system(raw.info, on_missing=on_missing)
+    system, _ = _get_meg_system(raw.info)
 
     # check whether we have a neuromag system
     if system not in ['122m', '306m']:
@@ -1416,7 +1416,7 @@ def get_active_chpi(raw, on_missing='raise'):
                                    ' is not implemented for other systems'
                                    ' than neuromag.'))
     # extract hpi info
-    chpi_info = get_chpi_info(raw.info)
+    chpi_info = get_chpi_info(raw.info, on_missing=on_missing)
 
     # extract hpi time series and infer which one was on
     chpi_ts = raw[chpi_info[1]][0].astype(int)

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -1395,6 +1395,7 @@ def get_active_chpi(raw, *, on_missing='raise', verbose=None):
     raw : instance of Raw
         Raw data with cHPI information.
     %(on_missing_chpi)s
+    %(verbose)s
 
     Returns
     -------

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -1406,9 +1406,6 @@ def get_active_chpi(raw, on_missing='raise'):
     -----
     .. versionadded:: 1.2
     """
-    _check_option(parameter='on_missing', value=on_missing,
-                  allowed_values=['ignore', 'raise', 'warn'])
-
     # get meg system
     system, _ = _get_meg_system(raw.info)
 


### PR DESCRIPTION


#### What does this implement/fix?
Fixes #11162 by adding the `on_missing` argument to the get_active_hpi function


#### Additional information
Not sure why, but I have problems using the `%(on_missing_chpi)s` pattern, even though I just copy&pasted within that same file. So the documentation doesn't properly render yet. 
