### PR TITLE
ENH: Add unscale=True to head_to_mri

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -45,6 +45,7 @@ Enhancements
 - Add example of how to obtain time-frequency decomposition using narrow bandpass Hilbert transforms to :ref:`ex-tfr-comparison` (:gh:`11116` by `Alex Rockhill`_)
 - Add ``==`` and ``!=`` comparison between `mne.Projection` objects (:gh:`11147` by `Mathieu Scheltienne`_)
 - Parse automatically temperature channel with :func:`mne.io.read_raw_edf` (:gh:`11150` by `Eric Larson`_ and `Alex Gramfort`_)
+- Add ``unscale`` option to :func:`mne.head_to_mri` to facilitate working with surrogate MRI data (:gh:`11185` by `Eric Larson`_)
 - Add ``encoding`` parameter to :func:`mne.io.read_raw_edf` and :func:`mne.io.read_raw_bdf` to support custom (non-UTF8) annotation channel encodings (:gh:`11154` by `Clemens Brunner`_)
 - :class:`mne.preprocessing.ICA` gained a new method, :meth:`~mne.preprocessing.ICA.get_explained_variance_ratio`, that allows the retrieval of the proportion of variance explained by ICA components (:gh:`11141` by `Richard Höchenberger`_)
 - Add config option ``MNE_REPR_HTML`` to disable HTML repr in notebook environments (:gh:`11159` by `Clemens Brunner`_)
@@ -63,6 +64,7 @@ Bugs
 - Fix bugs in documentation of surface :class:`~mne.SourceSpaces` (:gh:`11171` by `Eric Larson`_)
 - Fix bug in :func:`mne.io.read_raw_bti` where EEG, EMG, and H/VEOG channels were not detected properly, and many non-ECG channels were called ECG. The logic has been improved, and any channels of unknown type are now labeled as ``misc`` (:gh:`11102` by `Eric Larson`_)
 - Fix bug in :func:`mne.viz.plot_topomap` when providing ``sphere="eeglab"`` (:gh:`11081` by `Mathieu Scheltienne`_)
+- Fix bug in :meth:`mne.Dipole.to_mri` where MRI RAS rather than MRI surface RAS was returned (:gh:`11185` by `Eric Larson`_)
 - The string and HTML representation of :class:`mne.preprocessing.ICA` reported incorrect values for the explained variance. This information has been removed from the representations, and should instead be retrieved via the new :meth:`~mne.preprocessing.ICA.get_explained_variance_ratio` method (:gh:`11141` by `Richard Höchenberger`_)
 - Fix bug in :meth:`mne.Evoked.plot` and related methods where a ``np.nan`` location value in any channel causes spatial colours to fail (:gh:`6870` by `Simeon Wong`_)
 
@@ -70,6 +72,7 @@ API changes
 ~~~~~~~~~~~
 - Starting with this release we now follow the Python convention of using ``FutureWarning`` instead of ``DeprecationWarning`` to signal user-facing changes to our API (:gh:`11120` by `Daniel McCloy`_)
 - The ``bands`` parameter of :meth:`mne.Epochs.plot_psd_topomap` now accepts :class:`dict` input; legacy :class:`tuple` input is supported, but discouraged for new code (:gh:`11050` by `Daniel McCloy`_)
+- The :func:`mne.head_to_mri` new function parameter ``kind`` default will change from ``'ras'`` to ``'mri'`` (:gh:`11185` by `Eric Larson`_)
 - The ``show_toolbar`` argument to :class:`mne.viz.Brain` is being removed by deprecation (:gh:`11049` by `Eric Larson`_)
 - New classes :class:`~mne.time_frequency.Spectrum` and :class:`~mne.time_frequency.EpochsSpectrum`, created via new methods :meth:`Raw.compute_psd()<mne.io.Raw.compute_psd>`, :meth:`Epochs.compute_psd()<mne.Epochs.compute_psd>`, and :meth:`Evoked.compute_psd()<mne.Evoked.compute_psd>` (:gh:`10184` by `Daniel McCloy`_)
 - The ``mne.epochs.add_channels_epochs`` function has been deprecated in favor of :meth:`epochs.add_channels <mne.Epochs.add_channels>` (:gh:`11180` by `Eric Larson`_)

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -26,6 +26,7 @@ from .io._digitization import _get_data_as_dict_from_dig
 # namespace, too)
 from ._freesurfer import (_read_mri_info, get_mni_fiducials,  # noqa: F401
                           estimate_head_mri_t)  # noqa: F401
+from ._freesurfer import _import_nibabel
 from .label import read_label, Label
 from .source_space import (add_source_space_distances, read_source_spaces,  # noqa: E501,F401
                            write_source_spaces)
@@ -1170,12 +1171,7 @@ def _scale_mri(subject_to, mri_fname, subject_from, scale, subjects_dir):
     """Scale an MRI by setting its affine."""
     subjects_dir, subject_from, scale, _ = _scale_params(
         subject_to, subject_from, scale, subjects_dir)
-
-    if not has_nibabel():
-        warn('Skipping MRI scaling for %s, please install nibabel')
-        return
-
-    import nibabel
+    nibabel = _import_nibabel('scale an MRI')
     fname_from = op.join(mri_dirname.format(
         subjects_dir=subjects_dir, subject=subject_from), mri_fname)
     fname_to = op.join(mri_dirname.format(

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -241,7 +241,8 @@ class Dipole(TimeMixin):
         """
         mri_head_t, trans = _get_trans(trans)
         return head_to_mri(self.pos, subject, mri_head_t,
-                           subjects_dir=subjects_dir, verbose=verbose)
+                           subjects_dir=subjects_dir, verbose=verbose,
+                           kind='mri')
 
     @verbose
     def to_volume_labels(self, trans, subject='fsaverage', aseg='aparc+aseg',

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -236,6 +236,23 @@ def test_scale_mri_xfm(tmp_path, few_surfaces, subjects_dir_tmp_few):
         pos_head = apply_trans(invert_transform(trans), pos_mri)
         pos_mni = mne.head_to_mni(pos_head, subject_to, trans, tempdir)
         assert_allclose(pos_mni, pos_mni_from, atol=1e-3)
+        # another way
+        pos_mri_from_2 = mne.head_to_mri(
+            pos_head_from, subject_from, trans, tempdir, kind='mri')
+        with pytest.warns(FutureWarning, match='kind defaults to'):
+            pos_mri_from_ras = mne.head_to_mri(
+                pos_head_from, subject_from, trans, tempdir)
+        mri_eq_ras = np.allclose(pos_mri_from_2, pos_mri_from_ras, atol=1e-1)
+        if subject_from == 'fsaverage':
+            assert mri_eq_ras  # fsaverage is special this way
+        else:
+            assert not mri_eq_ras  # sample is not
+        assert_allclose(pos_mri_from_2, 1e3 * pos_mri_from,
+                        atol=1e-3)
+        with pytest.raises(OSError, match=r'parameters\.cfg'):
+            mne.head_to_mri(
+                pos_head_from, subject_from, trans, tempdir, unscale=True,
+                kind='mri')
 
 
 def test_fit_matched_points():


### PR DESCRIPTION
Closes #11184

1. Introduce a `mne.head_to_mri(..., kind=None)` that via deprecation changes from `kind='ras'` (1.2) to `kind='mri'`. Everywhere else in MNE when we say MRI coordinate frame we mean FreeSurfer surface RAS, so it should mean that here, too...
2. ... fixes a bug where we were using `kind='ras'` implicitly in `Dipole.to_mri`
3. Adds the `unscale=False` proposed in #11184