### PR TITLE
ENH: Add list-of-str support to Hitachi

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -41,6 +41,7 @@ Enhancements
 - Add ``on_missing`` functionality to all of our classes that have a ``drop_channels`` method, to control what happens when channel names are not in the object (:gh:`11077` by `Andrew Quinn`_)
 - Improve interpolation of bridged electrodes with `~mne.preprocessing.interpolate_bridged_electrodes` (:gh:`11094` by `Mathieu Scheltienne`_)
 - Add :func:`mne.minimum_norm.apply_inverse_tfr_epochs` to apply inverse methods to time-frequency resolved epochs (:gh:`11095` by `Alex Rockhill`_)
+- Add support for multiple probes via multiple CSV files passed to :func:`mne.io.read_raw_hitachi` (:gh:`11186` by `Eric Larson`_)
 - Add :func:`mne.chpi.get_active_chpi` to retrieve the number of active hpi coils for each time point (:gh:`11122` by `Eduard Ort`_)
 - Add example of how to obtain time-frequency decomposition using narrow bandpass Hilbert transforms to :ref:`ex-tfr-comparison` (:gh:`11116` by `Alex Rockhill`_)
 - Add ``==`` and ``!=`` comparison between `mne.Projection` objects (:gh:`11147` by `Mathieu Scheltienne`_)

--- a/mne/io/hitachi/tests/test_hitachi.py
+++ b/mne/io/hitachi/tests/test_hitachi.py
@@ -185,18 +185,31 @@ Probe1,CH1(703.6),CH1(829.0),CH2(703.9),CH2(829.3),CH3(703.9),CH3(829.3),CH4(703
     ('1.25', 108, 10, 5., 1, (2020, 2, 2, 11, 20, 0, 0), b'\r'),
     ('1.25', 108, 10, 5., 1, (2020, 2, 2, 11, 20, 0, 0), b'\n'),
     ('1.25', 108, 10, 5., 1, (2020, 2, 2, 11, 20, 0, 0), b'\r\n'),
+    # Fake a dual-probe file
+    (['1.18', '1.18'], 92, 60, 0.1, 2, (2004, 5, 17, 5, 14, 0, 0), None),
 ])
 def test_hitachi_basic(preload, version, n_ch, n_times, lowpass, sex, date,
                        end, tmp_path):
     """Test NIRSport1 file with no saturation."""
-    fname = tmp_path / 'test.csv'
-    contents = CONTENTS[version]
-    if end is not None:
-        contents = contents.replace(b'\r', b'\n').replace(b'\n\n', b'\n')
-        contents = contents.replace(b'\n', end)
-    with open(fname, 'wb') as fid:
-        fid.write(CONTENTS[version])
-    raw = read_raw_hitachi(fname, preload=preload, verbose=True)
+    if not isinstance(version, list):
+        versions = [version]
+    else:
+        versions = version
+    del version
+    fnames = list()
+    for vi, v in enumerate(versions, 1):
+        fname = tmp_path / f'test{vi}.csv'
+        contents = CONTENTS[v].replace(
+            f'Probe{vi - 1}'.encode(),
+            f'Probe{vi}'.encode())
+        if end is not None:
+            contents = contents.replace(b'\r', b'\n').replace(b'\n\n', b'\n')
+            contents = contents.replace(b'\n', end)
+        with open(fname, 'wb') as fid:
+            fid.write(CONTENTS[v])
+        fnames.append(fname)
+        del fname
+    raw = read_raw_hitachi(fnames, preload=preload, verbose=True)
     data = raw.get_data()
     assert data.shape == (n_ch, n_times)
     assert raw.info['sfreq'] == 10
@@ -212,7 +225,7 @@ def test_hitachi_basic(preload, version, n_ch, n_times, lowpass, sex, date,
     with pytest.warns(RuntimeWarning, match='will be zero'):
         beer_lambert_law(raw_od_bad, ppf=6)
     # bad distances (too big)
-    if version == '1.18':
+    if versions[0] == '1.18' and len(fnames) == 1:
         need = sum(([f'S{ii}', f'D{ii}'] for ii in range(1, 9)), [])[:-1]
         have = 'P7 FC3 C3 CP3 P3 F5 FC5 C5 CP5 P5 F7 FT7 T7 TP7 F3'.split()
         assert len(need) == len(have)
@@ -224,22 +237,37 @@ def test_hitachi_basic(preload, version, n_ch, n_times, lowpass, sex, date,
             beer_lambert_law(raw_od_bad, ppf=6)
     # good distances
     mon = make_standard_montage('standard_1020')
-    if version == '1.18':
+    if versions[0] == '1.18':
+        assert len(fnames) in (1, 2)
         need = sum(([f'S{ii}', f'D{ii}'] for ii in range(1, 9)), [])[:-1]
         have = 'F3 FC3 C3 CP3 P3 F5 FC5 C5 CP5 P5 F7 FT7 T7 TP7 P7'.split()
+        assert len(need) == 15
+        if len(fnames) == 2:
+            need.extend(sum((
+                [f'S{ii}', f'D{jj}']
+                for ii, jj in zip(range(9, 17), range(8, 16))), [])[:-1])
+            have.extend(
+                'F4 FC4 C4 CP4 P4 F6 FC6 C6 CP6 P6 F8 FT8 T8 TP8 P8'.split())
+            assert len(need) == 30
     else:
+        assert len(fnames) == 1
         need = sum(([f'S{ii}', f'D{ii}'] for ii in range(1, 18)), [])[:-1]
         have = ('FT9 FT7 FC5 FC3 FC1 FCz FC2 FC4 FC6 FT8 FT10 '
                 'T9 T7 C5 C3 C1 Cz C2 C4 C6 T8 T10 '
                 'TP9 TP7 CP5 CP3 CP1 CPz CP2 CP4 CP6 TP8 TP10').split()
+        assert len(need) == 33
     assert len(need) == len(have)
+    for h in have:
+        assert h in mon.ch_names
     mon.rename_channels(dict(zip(have, need)))
+    for n in need:
+        assert n in mon.ch_names
     raw.set_montage(mon)
     distances = source_detector_distances(raw.info)
     want = [0.03] * (n_ch - 4)
     assert_allclose(distances, want, atol=0.01)
     test_rank = 'less' if n_times < n_ch else True
-    _test_raw_reader(read_raw_hitachi, fname=fname,
+    _test_raw_reader(read_raw_hitachi, fname=fnames,
                      boundary_decimal=1, test_rank=test_rank)  # low fs
 
     # TODO: eventually we should refactor these to be in
@@ -250,7 +278,7 @@ def test_hitachi_basic(preload, version, n_ch, n_times, lowpass, sex, date,
     assert np.isfinite(raw_od.get_data()).all()
     sci = scalp_coupling_index(raw_od, verbose='error')
     lo, mi, hi = np.percentile(sci, [5, 50, 95])
-    if version == '1.18':
+    if versions[0] == '1.18':
         assert -0.1 < lo < 0.1  # not great
         assert 0.4 < mi < 0.5
         assert 0.8 < hi < 0.9

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -397,8 +397,9 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
         # len(kwargs) == 0 for the fake arange reader
         if len(kwargs):
             assert key is not None, sorted(kwargs.keys())
-            dirname = op.dirname(fname)
-            these_kwargs[key] = op.basename(fname)
+            this_fname = fname[0] if isinstance(fname, list) else fname
+            dirname = op.dirname(this_fname)
+            these_kwargs[key] = op.basename(this_fname)
             these_kwargs['preload'] = False
             orig_dir = os.getcwd()
             try:

--- a/mne/preprocessing/nirs/_beer_lambert_law.py
+++ b/mne/preprocessing/nirs/_beer_lambert_law.py
@@ -39,12 +39,12 @@ def beer_lambert_law(raw, ppf=6.):
     freqs = np.array(
         [raw.info['chs'][pick]['loc'][9] for pick in picks], float)
     abs_coef = _load_absorption(freqs)
-    distances = source_detector_distances(raw.info)
-    if (distances == 0).any():
+    distances = source_detector_distances(raw.info, picks='all')
+    if (distances[picks] == 0).any():
         warn('Source-detector distances are zero, some resulting '
              'concentrations will be zero. Consider setting a montage '
              'with raw.set_montage.')
-    if (distances > 0.1).any():
+    if (distances[picks] > 0.1).any():
         warn('Source-detector distances are greater than 10 cm. '
              'Large distances will result in invalid data, and are '
              'likely due to optode locations being stored in a '

--- a/mne/preprocessing/nirs/nirs.py
+++ b/mne/preprocessing/nirs/nirs.py
@@ -23,7 +23,7 @@ def source_detector_distances(info, picks=None):
     Parameters
     ----------
     %(info_not_none)s
-    %(picks_all)s
+    %(picks_all_data)s
 
     Returns
     -------

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1488,6 +1488,15 @@ head_source : str | list of str
     :func:`mne.get_head_surf` for more information.
 """
 
+docdict['hitachi_fname'] = """
+fname : list | str
+    Path(s) to the Hitachi CSV file(s). This should only be a list for
+    multiple probes that were acquired simultaneously.
+
+    .. versionchanged:: 1.2
+        Added support for list-of-str.
+"""
+
 docdict['hitachi_notes'] = """
 Hitachi does not encode their channel positions, so you will need to
 create a suitable mapping using :func:`mne.channels.make_standard_montage`


### PR DESCRIPTION
If you have multiple probes simultaneously for Hitachi systems, it outputs separate CSVs that correspond to the same recording. This allows passing list-of-str to `read_raw_hitachi` to get these as a single raw instance.

An alternative would maybe be to use `raw.add_channels(other)`, but this will create problems with channel name collisions that we can avoid here.

Also fixes a minor bug with the `source_detector_distances` docstring, and `beer_lambert_law` that I don't think are worth mentioning in `latest.inc` because until now I don't think they were really possible to hit (because there were no non-fNIRS channels in between fNIRS channels in our readers until now).

Closes #11130