### PR TITLE
MAINT: Enforce verbose=True in public API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,8 +147,8 @@ jobs:
 
         - run:
             name: Check Qt
-            command: LD_DEBUG=libs python -c "from PySide6.QtWidgets import QApplication, QWidget; app = QApplication([])"
-
+            command: |
+              ./tools/check_qt_import.py PySide6
         # Load tiny cache so that ~/.mne does not need to be created below
         - restore_cache:
             keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
         - run:
             name: Check Qt
             command: |
-              ./tools/check_qt_import.py PySide6
+              ./tools/check_qt_import.sh PySide6
         # Load tiny cache so that ~/.mne does not need to be created below
         - restore_cache:
             keys:

--- a/.github/workflows/linux_pip.yml
+++ b/.github/workflows/linux_pip.yml
@@ -50,9 +50,10 @@ jobs:
       - shell: bash -el {0}
         run: ./tools/github_actions_infos.sh
         name: 'Show infos'
-      # Uncomment if "xcb not found" Qt errors/segfaults come up again
-      # - shell: bash -el {0}
-      #   run: LD_DEBUG=libs python -c "from PyQt6.QtWidgets import QApplication, QWidget; app = QApplication([]); import matplotlib; matplotlib.use('QtAgg'); import matplotlib.pyplot as plt; plt.figure()"
+      - shell: bash -el {0}
+        run: |
+          ./tools/check_qt_import.sh PyQt6
+          python -c "import matplotlib; matplotlib.use('QtAgg'); import matplotlib.pyplot as plt; plt.figure()"
       - shell: bash -el {0}
         run: ./tools/get_testing_version.sh
         name: 'Get testing version'

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -66,6 +66,7 @@ Bugs
 - Fix bug in :func:`mne.io.read_raw_bti` where EEG, EMG, and H/VEOG channels were not detected properly, and many non-ECG channels were called ECG. The logic has been improved, and any channels of unknown type are now labeled as ``misc`` (:gh:`11102` by `Eric Larson`_)
 - Fix bug in :func:`mne.viz.plot_topomap` when providing ``sphere="eeglab"`` (:gh:`11081` by `Mathieu Scheltienne`_)
 - Fix bug in :meth:`mne.Dipole.to_mri` where MRI RAS rather than MRI surface RAS was returned (:gh:`11185` by `Eric Larson`_)
+- Fix bug in :meth:`epochs.save <mne.Epochs.save>` where the ``verbose`` parameter defaulted to ``True`` instead of ``None`` (:gh:`11191` by `Eric Larson`_)
 - The string and HTML representation of :class:`mne.preprocessing.ICA` reported incorrect values for the explained variance. This information has been removed from the representations, and should instead be retrieved via the new :meth:`~mne.preprocessing.ICA.get_explained_variance_ratio` method (:gh:`11141` by `Richard Höchenberger`_)
 - Fix bug in :meth:`mne.Evoked.plot` and related methods where a ``np.nan`` location value in any channel causes spatial colours to fail (:gh:`6870` by `Simeon Wong`_)
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1689,7 +1689,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
     @verbose
     def save(self, fname, split_size='2GB', fmt='single', overwrite=False,
-             split_naming='neuromag', verbose=True):
+             split_naming='neuromag', verbose=None):
         """Save epochs in a fif file.
 
         Parameters

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -31,7 +31,7 @@ def compute_source_morph(src, subject_from=None, subject_to='fsaverage',
                          niter_affine=(100, 100, 10), niter_sdr=(5, 5, 3),
                          spacing=5, smooth=None, warn=True, xhemi=False,
                          sparse=False, src_to=None, precompute=False,
-                         verbose=False):
+                         verbose=None):
     """Create a SourceMorph from one subject to another.
 
     Method is based on spherical morphing by FreeSurfer for surface

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -193,7 +193,10 @@ def test_tabs():
     for _, modname, ispkg in walk_packages(mne.__path__, prefix='mne.'):
         # because we don't import e.g. mne.tests w/mne
         if not ispkg and modname not in tab_ignores:
-            mod = importlib.import_module(modname)
+            try:
+                mod = importlib.import_module(modname)
+            except Exception:  # e.g., mne.export not having pybv
+                continue
             source = getsource(mod)
             assert '\t' not in source, ('"%s" has tabs, please remove them '
                                         'or add it to the ignore list'

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -3,13 +3,13 @@
 #
 # License: BSD-3-Clause
 
+import importlib
 import inspect
 from inspect import getsource
 import os.path as op
 from pathlib import Path
 from pkgutil import walk_packages
 import re
-import sys
 
 import pytest
 
@@ -119,6 +119,31 @@ def check_parameters_match(func, cls=None):
                  for err in validate(name)['errors']
                  if err[0] not in error_ignores and
                  (name.split('.')[-1], err[0]) not in error_ignores_specific]
+    # Add a check that all public functions and methods that have "verbose"
+    # set the default verbose=None
+    if cls is None:
+        mod_or_class = importlib.import_module('.'.join(name.split('.')[:-1]))
+    else:
+        mod_or_class = importlib.import_module('.'.join(name.split('.')[:-2]))
+        mod_or_class = getattr(mod_or_class, cls.__name__.split('.')[-1])
+    callable_ = getattr(mod_or_class, name.split('.')[-1])
+    try:
+        sig = inspect.signature(callable_)
+    except ValueError as exc:
+        msg = str(exc)
+        # E   ValueError: no signature found for builtin type
+        #     <class 'mne.forward.forward.Forward'>
+        if inspect.isclass(callable_) and 'no signature found for buil' in msg:
+            pass
+        else:
+            raise
+    else:
+        if 'verbose' in sig.parameters:
+            verbose_default = sig.parameters['verbose'].default
+            if verbose_default is not None:
+                incorrect += [
+                    f'{name} : verbose default is not None, '
+                    f'got: {verbose_default}']
     return incorrect
 
 
@@ -168,17 +193,8 @@ def test_tabs():
     for _, modname, ispkg in walk_packages(mne.__path__, prefix='mne.'):
         # because we don't import e.g. mne.tests w/mne
         if not ispkg and modname not in tab_ignores:
-            # mod = importlib.import_module(modname)  # not py26 compatible!
-            try:
-                with _record_warnings():
-                    __import__(modname)
-            except Exception:  # can't import properly
-                continue
-            mod = sys.modules[modname]
-            try:
-                source = getsource(mod)
-            except IOError:  # user probably should have run "make clean"
-                continue
+            mod = importlib.import_module(modname)
+            source = getsource(mod)
             assert '\t' not in source, ('"%s" has tabs, please remove them '
                                         'or add it to the ignore list'
                                         % modname)

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -247,7 +247,7 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
     """Base class for Spectrum and EpochsSpectrum."""
 
     def __init__(self, inst, method, fmin, fmax, tmin, tmax, picks,
-                 proj, *, n_jobs, verbose, **method_kw):
+                 proj, *, n_jobs, verbose=None, **method_kw):
         # arg checking
         self._sfreq = inst.info['sfreq']
         if np.isfinite(fmax) and (fmax > self.sfreq / 2):
@@ -933,7 +933,8 @@ class Spectrum(BaseSpectrum):
     """
 
     def __init__(self, inst, method, fmin, fmax, tmin, tmax, picks,
-                 proj, reject_by_annotation, *, n_jobs, verbose, **method_kw):
+                 proj, reject_by_annotation, *, n_jobs, verbose=None,
+                 **method_kw):
         from ..io import BaseRaw
 
         # triage reading from file
@@ -1037,7 +1038,7 @@ class EpochsSpectrum(BaseSpectrum, GetEpochsMixin):
     """
 
     def __init__(self, inst, method, fmin, fmax, tmin, tmax, picks, proj, *,
-                 n_jobs, verbose, **method_kw):
+                 n_jobs, verbose=None, **method_kw):
         # triage reading from file
         if isinstance(inst, dict):
             self.__setstate__(inst)

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -156,7 +156,7 @@ class use_log_level:
     This message will be printed!
     """
 
-    def __init__(self, verbose, *, add_frames=None):  # noqa: D102
+    def __init__(self, verbose=None, *, add_frames=None):  # noqa: D102
         self._level = verbose
         self._add_frames = add_frames
         self._old_frames = _filter.add_frames

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -10,7 +10,9 @@ if [ "${TEST_MODE}" == "pip" ]; then
 elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off --upgrade pip setuptools wheel
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl six cycler kiwisolver pyparsing patsy
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6 PyQt6-sip PyQt6-Qt6
+	# Broken as of 2022/09/20
+	# python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6 PyQt6-sip PyQt6-Qt6
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps PyQt6 PyQt6-sip PyQt6-Qt6
 	# SciPy Windows build is missing from conda nightly builds
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy statsmodels pandas scikit-learn dipy matplotlib
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -20,6 +20,7 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
 	python -m pip install --progress-bar off --upgrade --pre imageio-ffmpeg xlrd mffpy python-picard patsy pillow
 	EXTRA_ARGS="--pre"
+	./tools/check_qt_import.sh PyQt6
 else
 	echo "Unknown run type ${TEST_MODE}"
 	exit 1

--- a/tools/check_qt_import.sh
+++ b/tools/check_qt_import.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -ef
+
+if [[ "$1" == "" ]]; then
+    echo "Qt library must be provided as first argument"
+    exit 1
+fi
+LD_DEBUG=libs python -c "from $1.QtWidgets import QApplication, QWidget; app = QApplication([])"
+echo "Python-Qt binding $1 is available"

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -15,7 +15,9 @@ else
 	# https://pip.pypa.io/en/latest/user_guide/#possible-ways-to-reduce-backtracking-occurring
 	pip install $STD_ARGS --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl six
 	echo "PyQt6"
-	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6 PyQt6-sip PyQt6-Qt6
+	# Broken as of 2022/09/20
+	# pip install $STD_ARGS --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6 PyQt6-sip PyQt6-Qt6
+	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps PyQt6 PyQt6-sip PyQt6-Qt6
 	echo "NumPy/SciPy/pandas etc."
 	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps  --default-timeout=60 -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy scikit-learn dipy matplotlib pandas statsmodels
 	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py


### PR DESCRIPTION
While working on MNE-BIDS-Pipeline I kept getting logging messages I didn't expect about split files like (anything not prefixed by a date/time is bad):
```Console
[2022-09-19 23:04:16] preprocessing/_06_ptp_reject sub-01 Using PTP rejection thresholds: {}
Overwriting existing file.
Splitting into 6 parts
Overwriting existing file.
Overwriting existing file.
Overwriting existing file.
Overwriting existing file.
Overwriting existing file.
```
This is because a `verbose=True` snuck into our API in #4827 specifically [here](https://github.com/mne-tools/mne-python/pull/4827/files#diff-a6032a51226f9175d84fb340bab2a4238ddc24bf0c0f979bd1921f9d2f54c9fbR1571) by @larsoner :)

This adds a test that `verbose=None` in all the public API endpoints we currently check in `test_docstring_parameters.py`, and fixes the `BaseEpochs` bug and a `mne.compute_source_morph` bug in the process.

@dramock this touches some `spectrum.py` code just to make explicit that `verbose=None` should be used. We could alternatively make an exception for this empty/no-default if we want (showing an error I got without the `verbose=None` insertions I did in your recently updated code):
```
mne/tests/test_docstring_parameters.py:189: in test_docstring_parameters
    raise AssertionError(msg)
E   AssertionError: 
E   mne.time_frequency.spectrum.EpochsSpectrum : verbose default is not None, got: <class 'inspect._empty'>
E   1 error
------------
```
But it seems easier/simpler just to enforce `verbose=None` practice across the codebase.