### PR TITLE
MAINT: Clean up use of verbose

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -63,6 +63,7 @@ Bugs
 - Document ``height`` and ``weight`` keys of  ``subject_info`` entry in :class:`mne.Info` (:gh:`11019` by :newcontrib:`Sena Er`)
 - Fix bug in :func:`mne.viz.plot_filter` when plotting filters created using ``output='ba'`` mode with ``compensation`` turned on. (:gh:`11040` by `Marian Dovgialo`_)
 - Fix bugs in documentation of surface :class:`~mne.SourceSpaces` (:gh:`11171` by `Eric Larson`_)
+- Fix bugs with ``verbose='error'`` not being used properly and allowing warnings through (:gh:`11193` by `Eric Larson`_)
 - Fix bug in :func:`mne.io.read_raw_bti` where EEG, EMG, and H/VEOG channels were not detected properly, and many non-ECG channels were called ECG. The logic has been improved, and any channels of unknown type are now labeled as ``misc`` (:gh:`11102` by `Eric Larson`_)
 - Fix bug in :func:`mne.viz.plot_topomap` when providing ``sphere="eeglab"`` (:gh:`11081` by `Mathieu Scheltienne`_)
 - Fix bug in :meth:`mne.Dipole.to_mri` where MRI RAS rather than MRI surface RAS was returned (:gh:`11185` by `Eric Larson`_)

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1098,6 +1098,8 @@ def _fit_sphere_to_headshape(info, dig_kinds, verbose=None):
              'percentile for adult head size' % (1e3 * radius,))
     # > 2 cm away from head center in X or Y is strange
     if np.linalg.norm(origin_head[:2]) > 0.02:
+        if logger.level < 40:
+            raise RuntimeError(logger.level)
         warn('(X, Y) fit (%0.1f, %0.1f) more than 20 mm from '
              'head frame origin' % tuple(1e3 * origin_head[:2]))
     logger.info('Origin head coordinates:'.ljust(30) +

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1098,8 +1098,6 @@ def _fit_sphere_to_headshape(info, dig_kinds, verbose=None):
              'percentile for adult head size' % (1e3 * radius,))
     # > 2 cm away from head center in X or Y is strange
     if np.linalg.norm(origin_head[:2]) > 0.02:
-        if logger.level < 40:
-            raise RuntimeError(logger.level)
         warn('(X, Y) fit (%0.1f, %0.1f) more than 20 mm from '
              'head frame origin' % tuple(1e3 * origin_head[:2]))
     logger.info('Origin head coordinates:'.ljust(30) +

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -38,7 +38,7 @@ from .utils import (verbose, logger, run_subprocess, get_subjects_dir, warn,
                     _pl, _validate_type, _TempDir, _check_freesurfer_home,
                     _check_fname, has_nibabel, _check_option, path_like,
                     _on_missing, _import_h5io_funcs, _ensure_int,
-                    _path_like)
+                    _path_like, _verbose_safe_false)
 
 
 # ############################################################################
@@ -264,7 +264,8 @@ def _fwd_bem_ip_modify_solution(solution, ip_solution, ip_mult, n_tri):
 
 
 def _check_complete_surface(surf, copy=False, incomplete='raise', extra=''):
-    surf = complete_surface_info(surf, copy=copy, verbose=False)
+    surf = complete_surface_info(
+        surf, copy=copy, verbose=_verbose_safe_false())
     fewer = np.where([len(t) < 3 for t in surf['neighbor_tri']])[0]
     if len(fewer) > 0:
         fewer = list(fewer)
@@ -1141,8 +1142,8 @@ def _check_origin(origin, info, coord_frame='head', disp=False):
             raise ValueError('origin must be a numerical array, or "auto", '
                              'not %s' % (origin,))
         if coord_frame == 'head':
-            R, origin = fit_sphere_to_headshape(info, verbose=False,
-                                                units='m')[:2]
+            R, origin = fit_sphere_to_headshape(
+                info, verbose=_verbose_safe_false(), units='m')[:2]
             logger.info('    Automatic origin fit: head of radius %0.1f mm'
                         % (R * 1000.,))
             del R
@@ -1610,7 +1611,8 @@ def read_bem_solution(fname, *, verbose=None):
 
 def _read_bem_solution_fif(fname):
     logger.info('Loading surfaces...')
-    surfs = read_bem_surfaces(fname, patch_stats=True, verbose=False)
+    surfs = read_bem_surfaces(
+        fname, patch_stats=True, verbose=_verbose_safe_false())
 
     # convert from surfaces to solution
     logger.info('\nLoading the solution matrix...\n')

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -37,7 +37,7 @@ from .utils import (check_fname, logger, verbose, check_version, _time_mask,
                     warn, copy_function_doc_to_method_doc, _pl,
                     _undo_scaling_cov, _scaled_array, _validate_type,
                     _check_option, eigh, fill_doc, _on_missing,
-                    _check_on_missing, _check_fname)
+                    _check_on_missing, _check_fname, _verbose_safe_false)
 from . import viz
 
 from .fixes import (BaseEstimator, EmpiricalCovariance, _logdet,
@@ -569,7 +569,8 @@ def compute_raw_covariance(raw, tmin=0, tmax=None, tstep=0.2, reject=None,
         pick_mask = slice(None)
         picks = _picks_to_idx(raw.info, picks)
     epochs = Epochs(raw, events, 1, 0, tstep_m1, baseline=None,
-                    picks=picks, reject=reject, flat=flat, verbose=False,
+                    picks=picks, reject=reject, flat=flat,
+                    verbose=_verbose_safe_false(),
                     preload=False, proj=False,
                     reject_by_annotation=reject_by_annotation)
     if method is None:
@@ -1019,8 +1020,9 @@ def _compute_covariance_auto(data, method, info, method_params, cv,
     """Compute covariance auto mode."""
     # rescale to improve numerical stability
     orig_rank = rank
-    rank = compute_rank(RawArray(data.T, info, copy=None, verbose=False),
-                        rank, scalings, info)
+    rank = compute_rank(
+        RawArray(data.T, info, copy=None, verbose=_verbose_safe_false()),
+        rank, scalings, info)
     with _scaled_array(data.T, picks_list, scalings):
         C = np.dot(data.T, data)
         _, eigvec, mask = _smart_eigh(C, info, rank, proj_subspace=True,
@@ -2086,5 +2088,5 @@ def _ensure_cov(cov, name='cov', *, verbose=None):
     _validate_type(cov, ('path-like', Covariance), name)
     logger.info('Noise covariance  : %s' % (cov,))
     if not isinstance(cov, Covariance):
-        cov = read_cov(cov, verbose=False)
+        cov = read_cov(cov, verbose=_verbose_safe_false())
     return cov

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -37,7 +37,8 @@ from .parallel import parallel_func
 from .utils import (logger, verbose, _time_mask, warn, _check_fname,
                     check_fname, _pl, fill_doc, _check_option,
                     _svd_lwork, _repeated_svd, _get_blas_funcs, _validate_type,
-                    copy_function_doc_to_method_doc, TimeMixin)
+                    copy_function_doc_to_method_doc, TimeMixin,
+                    _verbose_safe_false)
 from .viz import plot_dipole_locations
 
 
@@ -1251,7 +1252,8 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=None,
         logger.info('BEM               : %s' % bem_extra)
     mri_head_t, trans = _get_trans(trans)
     logger.info('MRI transform     : %s' % trans)
-    bem = _setup_bem(bem, bem_extra, neeg, mri_head_t, verbose=False)
+    safe_false = _verbose_safe_false()
+    bem = _setup_bem(bem, bem_extra, neeg, mri_head_t, verbose=safe_false)
     if not bem['is_sphere']:
         # Find the best-fitting sphere
         inner_skull = _bem_find_surface(bem, 'inner_skull')
@@ -1396,7 +1398,7 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=None,
     # C code computes guesses w/sphere model for speed, don't bother here
     fwd_data = _prep_field_computation(
         guess_src['rr'], sensors=sensors, bem=bem, n_jobs=n_jobs,
-        verbose=False)
+        verbose=safe_false)
     fwd_data['inner_skull'] = inner_skull
     guess_fwd, guess_fwd_orig, guess_fwd_scales = _dipole_forwards(
         sensors=sensors, fwd_data=fwd_data, whitener=whitener,

--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -7,7 +7,6 @@
 
 from copy import deepcopy
 from math import sqrt
-import logging
 
 import numpy as np
 
@@ -43,7 +42,8 @@ from ..transforms import _ensure_trans, transform_surface_to
 from ..source_estimate import _make_stc, _get_src_type
 from ..utils import (check_fname, logger, verbose, warn, _validate_type,
                      _check_compensation_grade, _check_option, repr_html,
-                     _check_depth, _check_src_normal, _check_fname)
+                     _check_depth, _check_src_normal, _check_fname,
+                     _verbose_safe_false)
 
 
 INVERSE_METHODS = ('MNE', 'dSPM', 'sLORETA', 'eLORETA')
@@ -1586,10 +1586,9 @@ def _prepare_forward(forward, info, noise_cov, fixed, loose, rank, pca,
     logger.info('Whitening the forward solution.')
     noise_cov = prepare_noise_cov(
         noise_cov, info, info_picked['ch_names'], rank)
-    verbose = False if logger.level <= logging.WARN else None
     whitener, _ = compute_whitener(
-        noise_cov, info, info_picked['ch_names'], pca=pca, verbose=verbose,
-        rank=rank)
+        noise_cov, info, info_picked['ch_names'], pca=pca, rank=rank,
+        verbose=_verbose_safe_false())
     gain = np.dot(whitener, forward['sol']['data'])
 
     logger.info('Creating the source covariance matrix')

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -3082,12 +3082,13 @@ class Report:
                 func=self._plot_one_evoked_topomap_timepoint,
                 n_jobs=n_jobs, max_jobs=len(times),
             )
-            fig_arrays = parallel(
-                p_fun(
-                    evoked=evoked, time=time, ch_types=ch_types,
-                    vmin=vmin, vmax=vmax, topomap_kwargs=topomap_kwargs
-                ) for time in times
-            )
+            with use_log_level(_verbose_safe_false(level='error')):
+                fig_arrays = parallel(
+                    p_fun(
+                        evoked=evoked, time=time, ch_types=ch_types,
+                        vmin=vmin, vmax=vmax, topomap_kwargs=topomap_kwargs
+                    ) for time in times
+                )
 
             captions = [f'Time point: {round(t, 3):0.3f} s' for t in times]
             self._add_slider(
@@ -3118,14 +3119,15 @@ class Report:
         if len(ch_types) == 1:
             ax = [ax]
         for idx, ch_type in enumerate(ch_types):
-            plot_compare_evokeds(
-                evokeds={
-                    label: evoked.copy().pick(ch_type, verbose=False)
-                },
-                ci=None, truncate_xaxis=False,
-                truncate_yaxis=False, legend=False,
-                axes=ax[idx], show=False
-            )
+            with use_log_level(_verbose_safe_false(level='error')):
+                plot_compare_evokeds(
+                    evokeds={
+                        label: evoked.copy().pick(ch_type, verbose=False)
+                    },
+                    ci=None, truncate_xaxis=False,
+                    truncate_yaxis=False, legend=False,
+                    axes=ax[idx], show=False
+                )
             ax[idx].set_title(ch_type)
 
             # Hide x axis label for all but the last subplot

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -41,7 +41,7 @@ from .._freesurfer import _reorient_image, _mri_orientation
 from ..utils import (logger, verbose, get_subjects_dir, warn, _ensure_int,
                      fill_doc, _check_option, _validate_type, _safe_input,
                      _path_like, use_log_level, _check_fname,
-                     _check_ch_locs, _import_h5io_funcs)
+                     _check_ch_locs, _import_h5io_funcs, _verbose_safe_false)
 from ..viz import (plot_events, plot_alignment, plot_cov, plot_projs_topomap,
                    plot_compare_evokeds, set_3d_view, get_3d_backend,
                    Figure3D, use_browser_backend)
@@ -2963,7 +2963,7 @@ class Report:
                      f'create joint plot')
                 continue
 
-            with use_log_level(False):
+            with use_log_level(_verbose_safe_false(level='error')):
                 fig = evoked.copy().pick(ch_type, verbose=False).plot_joint(
                     ts_args=dict(gfp=True),
                     title=None,
@@ -3442,7 +3442,7 @@ class Report:
         epochs.load_data()
 
         for ch_type in ch_types:
-            with use_log_level(False):
+            with use_log_level(_verbose_safe_false(level='error')):
                 figs = epochs.copy().pick(ch_type, verbose=False).plot_image(
                     show=False
                 )

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -35,7 +35,7 @@ from .fetching import _url_to_local_path
 from ._logging import (verbose, logger, set_log_level, set_log_file,
                        use_log_level, catch_logging, warn, filter_out_warnings,
                        wrapped_stdout, _get_call_line, _record_warnings,
-                       ClosingStringIO)
+                       ClosingStringIO, _verbose_safe_false)
 from .misc import (run_subprocess, _pl, _clean_names, pformat, _file_like,
                    _explain_exception, _get_argvalues, sizeof_fmt,
                    running_subprocess, _DefaultEventParser,

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -171,8 +171,9 @@ class use_log_level:
 
 
 _LOGGING_TYPES = dict(DEBUG=logging.DEBUG, INFO=logging.INFO,
-                        WARNING=logging.WARNING, ERROR=logging.ERROR,
-                        CRITICAL=logging.CRITICAL)
+                      WARNING=logging.WARNING, ERROR=logging.ERROR,
+                      CRITICAL=logging.CRITICAL)
+
 
 @fill_doc
 def set_log_level(verbose=None, return_old_level=False, add_frames=None):

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -170,6 +170,10 @@ class use_log_level:
         set_log_level(self._old_level, add_frames=add_frames)
 
 
+_LOGGING_TYPES = dict(DEBUG=logging.DEBUG, INFO=logging.INFO,
+                        WARNING=logging.WARNING, ERROR=logging.ERROR,
+                        CRITICAL=logging.CRITICAL)
+
 @fill_doc
 def set_log_level(verbose=None, return_old_level=False, add_frames=None):
     """Set the logging level.
@@ -204,11 +208,8 @@ def set_log_level(verbose=None, return_old_level=False, add_frames=None):
             verbose = 'WARNING'
     if isinstance(verbose, str):
         verbose = verbose.upper()
-        logging_types = dict(DEBUG=logging.DEBUG, INFO=logging.INFO,
-                             WARNING=logging.WARNING, ERROR=logging.ERROR,
-                             CRITICAL=logging.CRITICAL)
-        _check_option('verbose', verbose, logging_types, '(when a string)')
-        verbose = logging_types[verbose]
+        _check_option('verbose', verbose, _LOGGING_TYPES, '(when a string)')
+        verbose = _LOGGING_TYPES[verbose]
     old_verbose = logger.level
     if verbose != old_verbose:
         logger.setLevel(verbose)
@@ -487,5 +488,6 @@ def _frame_info(n):
         del frame
 
 
-def _verbose_safe_false():
-    return False if logger.level <= logging.WARNING else None
+def _verbose_safe_false(*, level='warning'):
+    lev = _LOGGING_TYPES[level.upper()]
+    return lev if logger.level <= lev else None

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -369,7 +369,7 @@ def warn(message, category=RuntimeWarning, module='mne',
     root_dirs = [importlib.import_module(ns) for ns in ignore_namespaces]
     root_dirs = [op.dirname(ns.__file__) for ns in root_dirs]
     frame = None
-    if logger.level <= logging.WARN:
+    if logger.level <= logging.WARNING:
         frame = inspect.currentframe()
         while frame:
             fname = frame.f_code.co_filename
@@ -485,3 +485,7 @@ def _frame_info(n):
         return ['unknown']
     finally:
         del frame
+
+
+def _verbose_safe_false():
+    return False if logger.level <= logging.WARNING else None

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -18,7 +18,8 @@ import numbers
 import numpy as np
 
 from ..fixes import _median_complex, _compare_version
-from ._logging import warn, logger, verbose, _record_warnings
+from ._logging import (warn, logger, verbose, _record_warnings,
+                       _verbose_safe_false)
 
 
 def _ensure_int(x, name='unknown', must_be='an int', *, extra=''):
@@ -864,7 +865,8 @@ def _check_sphere(sphere, info=None, sphere_units='m'):
         assert info is not None
 
         if sphere == 'auto':
-            R, r0, _ = fit_sphere_to_headshape(info, verbose=False, units='m')
+            R, r0, _ = fit_sphere_to_headshape(
+                info, verbose=_verbose_safe_false(), units='m')
             sphere = tuple(r0) + (R,)
             sphere_units = 'm'
         elif sphere == 'eeglab':

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -303,6 +303,7 @@ def test_strip_dev(version, want, have_unstripped, monkeypatch):
     assert looks_stable(simpler_version)
 
 
+@testing.requires_testing_data
 def test_check_sphere_verbose():
     """Test that verbose is handled properly in _check_sphere."""
     info = mne.io.read_info(fname_raw)

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -18,7 +18,8 @@ from mne.io.pick import pick_channels_cov, _picks_to_idx
 from mne.utils import (check_random_state, _check_fname, check_fname, _suggest,
                        _check_subject, _check_info_inv, _check_option, Bunch,
                        check_version, _path_like, _validate_type, _on_missing,
-                       requires_nibabel, _safe_input, _check_ch_locs)
+                       requires_nibabel, _safe_input, _check_ch_locs,
+                       _check_sphere)
 
 data_path = testing.data_path(download=False)
 base_dir = op.join(data_path, 'MEG', 'sample')
@@ -300,3 +301,14 @@ def test_strip_dev(version, want, have_unstripped, monkeypatch):
     assert 'rc' not in simpler_version
     assert not simpler_version.endswith('.')
     assert looks_stable(simpler_version)
+
+
+def test_check_sphere_verbose():
+    """Test that verbose is handled properly in _check_sphere."""
+    info = mne.io.read_info(fname_raw)
+    with info._unlock():
+        info['dig'] = info['dig'][:20]
+    with pytest.warns(RuntimeWarning, match='may be inaccurate'):
+        _check_sphere('auto', info)
+    with mne.use_log_level('error'):
+        _check_sphere('auto', info)


### PR DESCRIPTION
A lot of places in our code, if we're doing something internal we might do:
```
def _check_sphere(...):
    out = fit_sphere_to_headshape(..., verbose=False)
```
with the goal of the `verbose=False` being "don't print info messages". However, this has an unintended side effect where this code:
```
with mne.use_log_level('error'):
    _check_sphere(...)
```
can still emit warnings even though the log level is ERROR. This PR adds a `_verbose_safe_false` function that returns `False` (which will be used as WARNING) if the current logging level is low enough (debug or info), but returns None ("do not modify") otherwise.

I cleaned up a few use cases for this in our codebase but not all of them. I think we can put more in as we see `verbose='error'` failing to silence warnings in the future.

It's possible this will help with #10612, because after this in theory we can use a `verbose='error'` somewhere (conditionally, probably) and have it properly sustain through to ignore any fit warnings when `spatial_colors=True` or so.