### PR TITLE
Fix mesh display in tutorial

### DIFF
--- a/.github/workflows/macos_conda.yml
+++ b/.github/workflows/macos_conda.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       PYTHON_VERSION: '3.8'
       MNE_LOGGING_LEVEL: 'warning'
+      MNE_3D_OPTION_SMOOTH_SHADING: 'true'
       OPENBLAS_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
       CONDA_ENV: 'environment.yml'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -389,6 +389,7 @@ else:
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             import pyvista
         pyvista.OFF_SCREEN = False
+        pyvista.BUILDING_GALLERY = True
         scrapers += (
             mne.gui._GUIScraper(),
             mne.viz._brain._BrainScraper(),

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -345,13 +345,16 @@ class _PyVistaRenderer(_AbstractRenderer):
             if 'rgba' in kwargs:
                 rgba = kwargs["rgba"]
                 kwargs.pop('rgba')
+            smooth_shading = self.smooth_shading
+            if representation == 'wireframe':
+                smooth_shading = False  # never use smooth shading for wf
             actor = _add_mesh(
                 plotter=self.plotter,
-                mesh=mesh, color=color, scalars=scalars,
+                mesh=mesh, color=color, scalars=scalars, edge_color=color,
                 rgba=rgba, opacity=opacity, cmap=colormap,
                 backface_culling=backface_culling,
                 rng=[vmin, vmax], show_scalar_bar=False,
-                smooth_shading=self.smooth_shading,
+                smooth_shading=smooth_shading,
                 interpolate_before_map=interpolate_before_map,
                 style=representation, line_width=line_width, **kwargs,
             )
@@ -419,7 +422,7 @@ class _PyVistaRenderer(_AbstractRenderer):
                 rng=[vmin, vmax],
                 cmap=colormap,
                 opacity=opacity,
-                smooth_shading=self.smooth_shading
+                smooth_shading=self.smooth_shading,
             )
             return actor, contour
 
@@ -1009,7 +1012,7 @@ def _set_3d_view(figure, azimuth=None, elevation=None, focalpoint='auto',
     position = np.array(figure.plotter.camera_position[0])
     bounds = np.array(figure.plotter.renderer.ComputeVisiblePropBounds())
     if reset_camera:
-        figure.plotter.reset_camera()
+        figure.plotter.reset_camera(render=False)
 
     # focalpoint: if 'auto', we use the center of mass of the visible
     # bounds, if None, we use the existing camera focal point otherwise

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -196,7 +196,10 @@ class _PyVistaRenderer(_AbstractRenderer):
         self.antialias = _get_3d_option('antialias')
         self.depth_peeling = _get_3d_option('depth_peeling')
         # smooth_shading=True fails on MacOS CIs
-        self.smooth_shading = _get_3d_option('smooth_shading')
+        if sys.platform == 'darwin':
+            self.smooth_shading = _get_3d_option('smooth_shading')
+        else:
+            self.smooth_shading = smooth_shading
         if isinstance(fig, int):
             saved_fig = _FIGURES.get(fig)
             # Restore only active plotter

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -195,11 +195,7 @@ class _PyVistaRenderer(_AbstractRenderer):
         self.tube_n_sides = 20
         self.antialias = _get_3d_option('antialias')
         self.depth_peeling = _get_3d_option('depth_peeling')
-        # smooth_shading=True fails on MacOS CIs
-        if sys.platform == 'darwin':
-            self.smooth_shading = _get_3d_option('smooth_shading')
-        else:
-            self.smooth_shading = smooth_shading
+        self.smooth_shading = smooth_shading
         if isinstance(fig, int):
             saved_fig = _FIGURES.get(fig)
             # Restore only active plotter

--- a/mne/viz/backends/renderer.py
+++ b/mne/viz/backends/renderer.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 import importlib
 
 from ._utils import VALID_3D_BACKENDS
+from .._3d import _get_3d_option
 from ...utils import (logger, verbose, get_config, _check_option, fill_doc,
                       _validate_type)
 
@@ -277,7 +278,7 @@ def set_3d_title(figure, title, size=40):
     backend._set_3d_title(figure=figure, title=title, size=size)
 
 
-def create_3d_figure(size, bgcolor=(0, 0, 0), smooth_shading=True,
+def create_3d_figure(size, bgcolor=(0, 0, 0), smooth_shading=None,
                      handle=None, *, scene=True, show=False):
     """Return an empty figure based on the current 3d backend.
 
@@ -292,8 +293,9 @@ def create_3d_figure(size, bgcolor=(0, 0, 0), smooth_shading=True,
         The dimensions of the 3d figure (width, height).
     bgcolor : tuple
         The color of the background.
-    smooth_shading : bool
-        If True, smooth shading is enabled. Defaults to True.
+    smooth_shading : bool | None
+        Whether to enable smooth shading. If ``None``, uses the config value
+        ``MNE_3D_OPTION_SMOOTH_SHADING``. Defaults to ``None``.
     handle : int | None
         The figure identifier.
     scene : bool
@@ -310,6 +312,9 @@ def create_3d_figure(size, bgcolor=(0, 0, 0), smooth_shading=True,
     figure : instance of Figure3D or ``Renderer``
         The requested empty figure or renderer, depending on ``scene``.
     """
+    _validate_type(smooth_shading, (bool, None), 'smooth_shading')
+    if smooth_shading is None:
+        smooth_shading = _get_3d_option('smooth_shading')
     renderer = _get_renderer(
         fig=handle,
         size=size,

--- a/tutorials/forward/50_background_freesurfer_mne.py
+++ b/tutorials/forward/50_background_freesurfer_mne.py
@@ -114,8 +114,7 @@ print('Our voxel has real-world coordinates {}, {}, {} (mm)'
 ras_coords_mm = np.array([1, -17, -18])
 inv_affine = np.linalg.inv(t1.affine)
 i_, j_, k_ = np.round(apply_trans(inv_affine, ras_coords_mm)).astype(int)
-print('Our real-world coordinates correspond to voxel ({}, {}, {})'
-      .format(i_, j_, k_))
+print(f'Our real-world coordinates correspond to voxel ({i_}, {j_}, {k_})')
 
 # %%
 # Let's write a short function to visualize where our voxel lies in an

--- a/tutorials/forward/50_background_freesurfer_mne.py
+++ b/tutorials/forward/50_background_freesurfer_mne.py
@@ -307,7 +307,7 @@ renderer = mne.viz.backends.renderer.create_3d_figure(
     size=(600, 600), bgcolor='w', scene=False)
 gray = (0.5, 0.5, 0.5)
 renderer.mesh(*rr_mm.T, triangles=tris, color=gray)
-view_kwargs = dict(elevation=90, azimuth=0)
+view_kwargs = dict(elevation=90, azimuth=0)  # camera at +X with +Z up
 mne.viz.set_3d_view(
     figure=renderer.figure, distance=350, focalpoint=(0., 0., 40.),
     **view_kwargs)
@@ -341,7 +341,7 @@ fig.axes[0].tricontour(rr_vox[:, 2], rr_vox[:, 1], tris, rr_vox[:, 0],
 # sphere, a given vertex in the source (sample) mesh can be mapped easily
 # to the same location in the destination (fsaverage) mesh, and vice-versa.
 
-renderer_kwargs = dict(bgcolor='w', smooth_shading=False)
+renderer_kwargs = dict(bgcolor='w')
 renderer = mne.viz.backends.renderer.create_3d_figure(
     size=(800, 400), scene=False, **renderer_kwargs)
 curvs = [
@@ -365,30 +365,34 @@ y = (y[1:] + y[:-1]) / 2. - width / 2.
 renderer.quiver3d(zero, y, zero,
                   zero, [1] * 3, zero, 'k', width, 'arrow')
 view_kwargs['focalpoint'] = (0., 0., 0.)
-mne.viz.set_3d_view(figure=renderer.figure, distance=1000, **view_kwargs)
+mne.viz.set_3d_view(figure=renderer.figure, distance=1050, **view_kwargs)
 renderer.show()
 
 # %%
 # Let's look a bit more closely at the spherical alignment by overlaying the
-# two spherical meshes as wireframes and zooming way in (the purple points are
-# separated by about 1 mm):
+# two spherical meshes as wireframes and zooming way in (the vertices of the
+# black mesh are separated by about 1 mm):
 
 cyan = '#66CCEE'
-purple = '#AA3377'
+black = 'k'
 renderer = mne.viz.backends.renderer.create_3d_figure(
     size=(800, 800), scene=False, **renderer_kwargs)
-fnames = [subjects_dir / subj / 'surf' / 'rh.sphere'
-          for subj in ('sample', 'fsaverage')]
-colors = [cyan, purple]
-for name, color in zip(fnames, colors):
-    this_rr, this_tri = mne.read_surface(name)
+surfs = [mne.read_surface(subjects_dir / subj / 'surf' / 'rh.sphere')
+         for subj in ('fsaverage', 'sample')]
+colors = [black, cyan]
+line_widths = [2, 3]
+for surf, color, line_width in zip(surfs, colors, line_widths):
+    this_rr, this_tri = surf
+    # cull to the subset of tris with all positive X (toward camera)
+    this_tri = this_tri[(this_rr[this_tri, 0] > 0).all(axis=1)]
     renderer.mesh(*this_rr.T, triangles=this_tri, color=color,
-                  representation='wireframe')
-mne.viz.set_3d_view(figure=renderer.figure, distance=20, **view_kwargs)
+                  representation='wireframe', line_width=line_width,
+                  render_lines_as_tubes=True)
+mne.viz.set_3d_view(figure=renderer.figure, distance=150, **view_kwargs)
 renderer.show()
 
 # %%
-# You can see that the fsaverage (purple) mesh is uniformly spaced, and the
+# You can see that the fsaverage (black) mesh is uniformly spaced, and the
 # mesh for subject "sample" (in cyan) has been deformed along the spherical
 # surface by
 # FreeSurfer. This deformation is designed to optimize the sulcal-gyral
@@ -401,21 +405,24 @@ renderer.show()
 # easily be achieved by subsampling in the spherical space. To do this, we
 # use a recursively subdivided icosahedron or octahedron. For example, let's
 # load a standard oct-6 source space, and at the same zoom level as before
-# visualize how it subsampled the dense mesh:
+# visualize how it subsampled (in red) the dense mesh:
 
 src = mne.read_source_spaces(subjects_dir / 'sample' / 'bem' /
                              'sample-oct-6-src.fif')
 print(src)
 
 # sphinx_gallery_thumbnail_number = 10
-blue = '#4477AA'
+red = '#EE6677'
 renderer = mne.viz.backends.renderer.create_3d_figure(
     size=(800, 800), scene=False, **renderer_kwargs)
-rr_sph, _ = mne.read_surface(fnames[0])
-for tris, color in [(src[1]['tris'], cyan), (src[1]['use_tris'], blue)]:
+rr_sph, _ = mne.read_surface(fnames[1])
+for tris, color in [(src[1]['tris'], cyan), (src[1]['use_tris'], red)]:
+    # cull to the subset of tris with all positive X (toward camera)
+    tris = tris[(rr_sph[tris, 0] > 0).all(axis=1)]
     renderer.mesh(*rr_sph.T, triangles=tris, color=color,
-                  representation='wireframe')
-mne.viz.set_3d_view(figure=renderer.figure, distance=20, **view_kwargs)
+                  representation='wireframe', line_width=3,
+                  render_lines_as_tubes=True)
+mne.viz.set_3d_view(figure=renderer.figure, distance=150, **view_kwargs)
 renderer.show()
 
 # %%
@@ -431,7 +438,7 @@ for y_shift, tris in zip(y_shifts, tris):
     renderer.mesh(*this_rr.T, triangles=tris, color=None, scalars=curvs[0],
                   colormap='copper_r', vmin=-0.2, vmax=1.2)
 renderer.quiver3d([0], [-width / 2.], [0], [0], [1], [0], 'k', width, 'arrow')
-mne.viz.set_3d_view(figure=renderer.figure, distance=400, **view_kwargs)
+mne.viz.set_3d_view(figure=renderer.figure, distance=450, **view_kwargs)
 renderer.show()
 
 


### PR DESCRIPTION
This should fix the mesh display color bug that has been in `tutorials/forward/50_background_freesurfer_mne.py` since the 1.0 release (last known good was 0.24).  Unfortunately we probably won't be able to tell because that tutorial is bricking Circle in other ways right now:

```
generating gallery for auto_tutorials/forward... [ 75%] 50_background_freesurfer_mne.py
Clean 1636.6 s : 1.73 GB
qt.qpa.xcb: QXcbConnection: XCB error: 128 (Unknown), sequence: 15178, resource id: 2098234, major code: 130 (Unknown), minor code: 2
```

...and I haven't been able to pinpoint the cause of that yet.