### PR TITLE
MRG: Fix displayed Raw duration in Jupyter notebook

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -73,6 +73,7 @@ Bugs
 - The string and HTML representation of :class:`mne.preprocessing.ICA` reported incorrect values for the explained variance. This information has been removed from the representations, and should instead be retrieved via the new :meth:`~mne.preprocessing.ICA.get_explained_variance_ratio` method (:gh:`11141` by `Richard Höchenberger`_)
 - Fix bug in :meth:`mne.Evoked.plot` and related methods where a ``np.nan`` location value in any channel causes spatial colours to fail (:gh:`6870` by `Simeon Wong`_)
 - Fix bug in :meth:`mne.preprocessing.ICA.find_bads_muscle` where epochs caused an error when passed as the ``inst`` (:gh:`11197` by `Alex Rockhill`_)
+- The duration of raw data sometimes wasn't displayed correctly in Jupyter notebooks by omitting fractions of a second. We now always round up to the next full second so a duration of less than 1 second will not be displayed as a duration of zero anymore (:gh:`11203` by `Richard Höchenberger`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1747,7 +1747,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         ]
 
         # https://stackoverflow.com/a/10981895
-        duration = timedelta(seconds=raw.times[-1])
+        duration = timedelta(seconds=self.times[-1])
         hours, remainder = divmod(duration.seconds, 3600)
         minutes, seconds = divmod(remainder, 60)
         seconds += duration.microseconds / 1e6

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1745,9 +1745,15 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         basenames = [
             os.path.basename(f) for f in self._filenames if f is not None
         ]
-        m, s = divmod(self._last_time - self.first_time, 60)
-        h, m = divmod(m, 60)
-        duration = f'{int(h):02d}:{int(m):02d}:{int(s):02d}'
+
+        # https://stackoverflow.com/a/10981895
+        duration = timedelta(seconds=self._last_time - self.first_time)
+        hours, remainder = divmod(duration.seconds, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        seconds += duration.microseconds / 1e6
+        seconds = np.ceil(seconds)  # always take full seconds
+
+        duration = f'{int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}'
         raw_template = repr_templates_env.get_template('raw.html.jinja')
         return raw_template.render(
             info_repr=self.info._repr_html_(caption=caption),

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1747,7 +1747,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         ]
 
         # https://stackoverflow.com/a/10981895
-        duration = timedelta(seconds=self._last_time - self.first_time)
+        duration = timedelta(seconds=raw.times[-1])
         hours, remainder = divmod(duration.seconds, 3600)
         minutes, seconds = divmod(remainder, 60)
         seconds += duration.microseconds / 1e6


### PR DESCRIPTION
Fixes #11202

```python
# %%
import numpy as np
import mne

n_seconds = 1
sfreq = 100
ch_names = ['1']
data = np.ones((len(ch_names), sfreq*n_seconds))
info = mne.create_info(ch_names=ch_names, sfreq=sfreq)
raw = mne.io.RawArray(data, info)
raw
```

`main`:
<img width="321" alt="Screen Shot 2022-09-25 at 13 43 28" src="https://user-images.githubusercontent.com/2046265/192141624-301d2a74-2c98-443f-ba3a-f11a827ca6fd.png">


PR:
<img width="321" alt="Screen Shot 2022-09-25 at 13 43 06" src="https://user-images.githubusercontent.com/2046265/192141612-f5785856-f3d0-44c3-97f0-6298011709f6.png">

I'm don't feel like adding a regression test for this…