### PR TITLE
Fix `include_tmax` not considered in `mne.io.Raw.crop` to check `tmax` in bounds

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -53,7 +53,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Fix bug in :func:`mne.io.Raw.crop` where argument ``include_tmax`` was not considered in checking ``tmax`` in bounds (:gh:`10718` by `Lukas Gemein`)
+- Fix bug in :func:`mne.io.Raw.crop` where argument ``include_tmax`` was not considered in checking ``tmax`` in bounds (:gh:`11196` by `Lukas Gemein`)
 - Fix bug in :func:`mne.io.read_raw_eeglab` where unlabeled fiducials causde reading errors (:gh:`11074` by :newcontrib:`Sebastiaan Mathot`)
 - Fix bug in :func:`mne.time_frequency.read_csd` that returned ``projs`` as a list of dict instead of :class:`mne.Projection` (:gh:`11072` by :newcontrib:`Chetan Gohil`)
 - Fix bug in :func:`mne.decoding.TimeFrequency` that prevented cloning if constructor arguments were modified (:gh:`11004` by :newcontrib:`Daniel Carlström Schad`)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -53,7 +53,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Fix bug in :func:`mne.io.Raw.crop` where argument ``include_tmax`` was not considered in checking ``tmax`` in bounds (:gh:`11196` by `Lukas Gemein`)
+- Fix bug in :meth:`mne.io.Raw.crop` where argument ``include_tmax`` was not considered in checking ``tmax`` in bounds (:gh:`11196` by `Lukas Gemein`_)
 - Fix bug in :func:`mne.io.read_raw_eeglab` where unlabeled fiducials causde reading errors (:gh:`11074` by :newcontrib:`Sebastiaan Mathot`)
 - Fix bug in :func:`mne.time_frequency.read_csd` that returned ``projs`` as a list of dict instead of :class:`mne.Projection` (:gh:`11072` by :newcontrib:`Chetan Gohil`)
 - Fix bug in :func:`mne.decoding.TimeFrequency` that prevented cloning if constructor arguments were modified (:gh:`11004` by :newcontrib:`Daniel Carlström Schad`)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -53,6 +53,7 @@ Enhancements
 
 Bugs
 ~~~~
+- Fix bug in :func:`mne.io.Raw.crop` where argument ``include_tmax`` was not considered in checking ``tmax`` in bounds (:gh:`10718` by `Lukas Gemein`)
 - Fix bug in :func:`mne.io.read_raw_eeglab` where unlabeled fiducials causde reading errors (:gh:`11074` by :newcontrib:`Sebastiaan Mathot`)
 - Fix bug in :func:`mne.time_frequency.read_csd` that returned ``projs`` as a list of dict instead of :class:`mne.Projection` (:gh:`11072` by :newcontrib:`Chetan Gohil`)
 - Fix bug in :func:`mne.decoding.TimeFrequency` that prevented cloning if constructor arguments were modified (:gh:`11004` by :newcontrib:`Daniel Carlström Schad`)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1263,7 +1263,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                              % (tmin, tmax))
         if tmin < 0.0:
             raise ValueError('tmin (%s) must be >= 0' % (tmin,))
-        elif tmax - int(not include_tmax)/self.info['sfreq'] > max_time:
+        elif tmax - int(not include_tmax) / self.info['sfreq'] > max_time:
             raise ValueError('tmax (%s) must be less than or equal to the max '
                              'time (%0.4f sec)' % (tmax, max_time))
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1263,7 +1263,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
                              % (tmin, tmax))
         if tmin < 0.0:
             raise ValueError('tmin (%s) must be >= 0' % (tmin,))
-        elif tmax > max_time:
+        elif tmax - int(not include_tmax)/self.info['sfreq'] > max_time:
             raise ValueError('tmax (%s) must be less than or equal to the max '
                              'time (%0.4f sec)' % (tmax, max_time))
 

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1049,7 +1049,7 @@ def test_crop():
     tmaxs /= sfreq
     tmins /= sfreq
 
-    # going in revere order so the last fname is the first file (need it later)
+    # going in reverse order so the last fname is the first file (need it later)
     raws = [None] * len(tmins)
     for ri, (tmin, tmax) in enumerate(zip(tmins, tmaxs)):
         raws[ri] = raw.copy().crop(tmin, tmax)
@@ -1073,6 +1073,19 @@ def test_crop():
     # degenerate
     with pytest.raises(ValueError, match='No samples.*when include_tmax=Fals'):
         raw.crop(0, 0, include_tmax=False)
+
+    # edge cases cropping to exact duration +/- 1 sample
+    data = np.zeros((1, 100))
+    info = create_info(1, 100)
+    raw = RawArray(data, info)
+    with pytest.raises(ValueError, 'tmax (1s) must be less than or equal'):
+        raw.copy().crop(tmax=1, include_tmax=True)
+    raw1 = raw.copy().crop(tmax=1 - 1/raw.info['sfreq'], include_tmax=True)
+    assert raw.n_times == raw1.n_times
+    raw2 = raw.copy().crop(tmax=1, include_tmax=False)
+    assert raw.n_times == raw2.n_times
+    raw3 = raw.copy().crop(tmax=1 - 1/raw.info['sfreq'], include_tmax=False)
+    assert raw.n_times - 1 == raw3.n_times
 
 
 @testing.requires_testing_data

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1049,7 +1049,8 @@ def test_crop():
     tmaxs /= sfreq
     tmins /= sfreq
 
-    # going in reverse order so the last fname is the first file (need it later)
+    # going in reverse order so the last fname is the first file (need it
+    # later)
     raws = [None] * len(tmins)
     for ri, (tmin, tmax) in enumerate(zip(tmins, tmaxs)):
         raws[ri] = raw.copy().crop(tmin, tmax)
@@ -1078,13 +1079,13 @@ def test_crop():
     data = np.zeros((1, 100))
     info = create_info(1, 100)
     raw = RawArray(data, info)
-    with pytest.raises(ValueError, match='tmax \\(1\\) must be less than or equal'):
+    with pytest.raises(ValueError, match='tmax \\(1\\) must be less than or '):
         raw.copy().crop(tmax=1, include_tmax=True)
-    raw1 = raw.copy().crop(tmax=1 - 1/raw.info['sfreq'], include_tmax=True)
+    raw1 = raw.copy().crop(tmax=1 - 1 / raw.info['sfreq'], include_tmax=True)
     assert raw.n_times == raw1.n_times
     raw2 = raw.copy().crop(tmax=1, include_tmax=False)
     assert raw.n_times == raw2.n_times
-    raw3 = raw.copy().crop(tmax=1 - 1/raw.info['sfreq'], include_tmax=False)
+    raw3 = raw.copy().crop(tmax=1 - 1 / raw.info['sfreq'], include_tmax=False)
     assert raw.n_times - 1 == raw3.n_times
 
 

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -1078,7 +1078,7 @@ def test_crop():
     data = np.zeros((1, 100))
     info = create_info(1, 100)
     raw = RawArray(data, info)
-    with pytest.raises(ValueError, 'tmax (1s) must be less than or equal'):
+    with pytest.raises(ValueError, match='tmax \\(1\\) must be less than or equal'):
         raw.copy().crop(tmax=1, include_tmax=True)
     raw1 = raw.copy().crop(tmax=1 - 1/raw.info['sfreq'], include_tmax=True)
     assert raw.n_times == raw1.n_times


### PR DESCRIPTION
Closes https://github.com/mne-tools/mne-python/issues/11196