### PR TITLE
[DOC, MRG] Minor documentation improvements and remove glossary entry for array-like

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -181,7 +181,7 @@ numpydoc_xref_aliases = {
     'file-like': ':term:`file-like <python:file object>`',
     'iterator': ':term:`iterator <python:iterator>`',
     'path-like': ':term:`path-like`',
-    'array-like': ':term:`array-like`',
+    'array-like': ':term:`array_like <numpy:array_like>`',
     'Path': ':class:`python:pathlib.Path`',
     'bool': ':class:`python:bool`',
     # Matplotlib

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -22,13 +22,6 @@ general neuroimaging concepts. If you think a term is missing, please consider
         :ref:`tut-events-vs-annotations` for a short tutorial.
         See also :term:`events`.
 
-    array-like
-        Something that acts like – or can be converted to – a
-        :class:`NumPy array <numpy.ndarray>`.
-        This includes (but is not limited to)
-        :class:`arrays <numpy.ndarray>`, `lists <list>`, and
-        `tuples <tuple>`.
-
     beamformer
         A beamformer is a popular source estimation approach that uses a set of
         spatial filters (beamformer weights) to compute time courses of sources

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -369,6 +369,9 @@ def psd_array_multitaper(x, sfreq, fmin=0.0, fmax=np.inf, bandwidth=None,
                          output='power', n_jobs=None, verbose=None):
     """Compute power spectral density (PSD) using a multi-taper method.
 
+    The power spectral density is computed with DPSS
+    tapers\ :footcite:p:`Slepian1978`.
+
     Parameters
     ----------
     x : array, shape=(..., n_times)
@@ -417,6 +420,10 @@ def psd_array_multitaper(x, sfreq, fmin=0.0, fmax=np.inf, bandwidth=None,
     Notes
     -----
     .. versionadded:: 0.14.0
+
+    References
+    ----------
+    .. footbibliography::
     """
     from scipy.fft import rfftfreq
     _check_option('normalization', normalization, ['length', 'full'])

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -367,7 +367,7 @@ def _compute_mt_params(n_times, sfreq, bandwidth, low_bias, adaptive,
 def psd_array_multitaper(x, sfreq, fmin=0.0, fmax=np.inf, bandwidth=None,
                          adaptive=False, low_bias=True, normalization='length',
                          output='power', n_jobs=None, verbose=None):
-    """Compute power spectral density (PSD) using a multi-taper method.
+    r"""Compute power spectral density (PSD) using a multi-taper method.
 
     The power spectral density is computed with DPSS
     tapers\ :footcite:p:`Slepian1978`.

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -99,6 +99,8 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
                     window='hamming', *, verbose=None):
     """Compute power spectral density (PSD) using Welch's method.
 
+    Welch's method is described in :footcite:t:`Welch1967`.
+
     Parameters
     ----------
     x : array, shape=(..., n_times)
@@ -142,6 +144,10 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     Notes
     -----
     .. versionadded:: 0.14.0
+
+    References
+    ----------
+    .. footbibliography::
     """
     _check_option('average', average, (None, False, 'mean', 'median'))
     if average is False:

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -930,6 +930,10 @@ class Spectrum(BaseSpectrum):
     mne.io.Raw.compute_psd
     mne.Epochs.compute_psd
     mne.Evoked.compute_psd
+
+    References
+    ----------
+    .. footbibliography::
     """
 
     def __init__(self, inst, method, fmin, fmax, tmin, tmax, picks,
@@ -1035,6 +1039,10 @@ class EpochsSpectrum(BaseSpectrum, GetEpochsMixin):
     mne.io.Raw.compute_psd
     mne.Epochs.compute_psd
     mne.Evoked.compute_psd
+
+    References
+    ----------
+    .. footbibliography::
     """
 
     def __init__(self, inst, method, fmin, fmax, tmin, tmax, picks, proj, *,

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -922,7 +922,8 @@ class Spectrum(BaseSpectrum):
         have been computed.
     %(info_not_none)s
     method : str
-        The method used to compute the spectrum ('welch' or 'multitaper').
+        The method used to compute the spectrum (``'welch'`` or
+        ``'multitaper'``).
 
     See Also
     --------

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1964,9 +1964,9 @@ docdict['method_kw_psd'] = """\
 
 _method_psd = """\
 method : ``'welch'`` | ``'multitaper'``{}
-    Spectral estimation method. ``'welch'`` uses Welch's method
-    :footcite:`Welch1967`, ``'multitaper'`` uses DPSS tapers
-    :footcite:`Slepian1978`.{}
+    Spectral estimation method. ``'welch'`` uses Welch's method\
+    :footcite:p:`Welch1967`, ``'multitaper'`` uses DPSS tapers\
+    :footcite:p:`Slepian1978`.{}
 """
 docdict['method_plot_psd_auto'] = _method_psd.format(
     " | ``'auto'``",

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1964,9 +1964,9 @@ docdict['method_kw_psd'] = """\
 
 _method_psd = """\
 method : ``'welch'`` | ``'multitaper'``{}
-    Spectral estimation method. ``'welch'`` uses Welch's method\
-    :footcite:p:`Welch1967`, ``'multitaper'`` uses DPSS tapers\
-    :footcite:p:`Slepian1978`.{}
+    Spectral estimation method. ``'welch'`` uses Welch's
+    method\ :footcite:p:`Welch1967`, ``'multitaper'`` uses DPSS
+    tapers\ :footcite:p:`Slepian1978`.{}
 """
 docdict['method_plot_psd_auto'] = _method_psd.format(
     " | ``'auto'``",

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1962,7 +1962,7 @@ docdict['method_kw_psd'] = """\
     :func:`~mne.time_frequency.psd_array_multitaper` for details.
 """
 
-_method_psd = """\
+_method_psd = r"""
 method : ``'welch'`` | ``'multitaper'``{}
     Spectral estimation method. ``'welch'`` uses Welch's
     method\ :footcite:p:`Welch1967`, ``'multitaper'`` uses DPSS

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1215,7 +1215,7 @@ t_power : float
 """
 
 docdict['fiducials'] = """
-fiducials : list | dict | str
+fiducials : list | dict | str
     The fiducials given in the MRI (surface RAS) coordinate
     system. If a dictionary is provided, it must contain the **keys**
     ``'lpa'``, ``'rpa'``, and ``'nasion'``, with **values** being the
@@ -1963,18 +1963,18 @@ docdict['method_kw_psd'] = """\
 """
 
 _method_psd = """\
-method : 'welch' | 'multitaper'{}
+method : ``'welch'`` | ``'multitaper'``{}
     Spectral estimation method. ``'welch'`` uses Welch's method
     :footcite:`Welch1967`, ``'multitaper'`` uses DPSS tapers
     :footcite:`Slepian1978`.{}
 """
 docdict['method_plot_psd_auto'] = _method_psd.format(
-    " | 'auto'",
+    " | ``'auto'``",
     (" ``'auto'`` (default) uses Welch's method for continuous data and "
      "multitaper for :class:`~mne.Epochs` or :class:`~mne.Evoked` data.")
 )
 docdict['method_psd'] = _method_psd.format('', '')
-docdict['method_psd_auto'] = _method_psd.format(" | 'auto'", '')
+docdict['method_psd_auto'] = _method_psd.format(" | ``'auto'``", '')
 
 docdict['mode_eltc'] = """
 mode : str


### PR DESCRIPTION
A couple of minor formatting fixes, and I removed the entry for `array-like` in favor of the one defined in the `numpy` glossary.

Also looking if I can figure out which CSS variable to override to format `terms` in the same way as `py:obj`. 

![Screenshot 2022-09-26 at 13 59 10](https://user-images.githubusercontent.com/73893616/192270790-06296325-030d-481d-bb82-400abc2b6030.png)
