### PR TITLE
MAINT: Ensure no datasets are downloaded in tests

### DIFF
--- a/mne/datasets/tests/test_datasets.py
+++ b/mne/datasets/tests/test_datasets.py
@@ -74,7 +74,7 @@ def test_downloads(tmp_path, monkeypatch, capsys):
     # that we're hitting (https://github.com/pytest-dev/pytest/issues/5997)
     # now that we use pooch
     with capsys.disabled():
-        with pytest.raises(RuntimeError, match='Cannot download .* in tests'):
+        with pytest.raises(RuntimeError, match='Do not download .* in tests'):
             path = datasets._fake.data_path(update_path=False, **kwargs)
         monkeypatch.setattr(
             datasets.utils,

--- a/mne/datasets/tests/test_datasets.py
+++ b/mne/datasets/tests/test_datasets.py
@@ -74,6 +74,11 @@ def test_downloads(tmp_path, monkeypatch, capsys):
     # that we're hitting (https://github.com/pytest-dev/pytest/issues/5997)
     # now that we use pooch
     with capsys.disabled():
+        with pytest.raises(RuntimeError, match='Cannot download .* in tests'):
+            path = datasets._fake.data_path(update_path=False, **kwargs)
+        monkeypatch.setattr(
+            datasets.utils,
+            '_MODULES_TO_ENSURE_DOWNLOAD_IS_FALSE_IN_TESTS', ())
         path = datasets._fake.data_path(update_path=False, **kwargs)
     assert op.isdir(path)
     assert op.isfile(op.join(path, 'bar'))

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -188,8 +188,6 @@ def _check_in_testing_and_raise(name, download):
             f'{func}(download=False) to prevent accidental downloads')
 
 
-
-
 def _download_mne_dataset(name, processor, path, force_update,
                           update_path, download, accept=False):
     """Aux function for downloading internal MNE datasets."""

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -154,7 +154,7 @@ def _check_in_testing_and_raise(name, download):
     root_dirs = [
         importlib.import_module(ns)
         for ns in _MODULES_TO_ENSURE_DOWNLOAD_IS_FALSE_IN_TESTS]
-    root_dirs = [Path(ns.__file__).parent for ns in root_dirs]
+    root_dirs = [str(Path(ns.__file__).parent) for ns in root_dirs]
     check = False
     func = None
     frame = inspect.currentframe()
@@ -172,7 +172,8 @@ def _check_in_testing_and_raise(name, download):
             if fname is not None:
                 fname = Path(fname)
                 # in mne namespace, and
-                if any(fname.is_relative_to(rd) for rd in root_dirs) and (
+                # (can't use is_relative_to here until 3.9)
+                if any(str(fname).startswith(rd) for rd in root_dirs) and (
                         # in tests/*.py
                         fname.parent.stem == 'tests' or
                         # or in a conftest.py

--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -185,7 +185,7 @@ def _check_in_testing_and_raise(name, download):
         del frame
     if check and download is not False:
         raise RuntimeError(
-            f'Cannot download dataset {repr(name)} in tests, pass '
+            f'Do not download dataset {repr(name)} in tests, pass '
             f'{func}(download=False) to prevent accidental downloads')
 
 

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -454,7 +454,10 @@ def _get_numpy_libs():
         from threadpoolctl import threadpool_info
     except Exception as exc:
         return bad_lib + f' (threadpoolctl module not found: {exc})'
-    pools = threadpool_info()
+    try:
+        pools = threadpool_info()
+    except Exception as exc:
+        return bad_lib + f' (threadpoolctl failed to get info: {exc})'
     rename = dict(
         openblas='OpenBLAS',
         mkl='MKL',

--- a/mne/viz/backends/tests/test_abstract.py
+++ b/mne/viz/backends/tests/test_abstract.py
@@ -13,7 +13,12 @@ def _do_widget_tests(backend):
     widget_checks = set()
 
     def callback(x=None):
-        widget_checks.add('click' if x is None else x)
+        add = x
+        if add is None:
+            add = 'click'
+        elif isinstance(add, str):
+            add = add.lstrip('&')  # new notebooks can add this
+        widget_checks.add(add)
 
     window = backend._AppWindow()
     central_layout = backend._VBoxLayout(scroll=(500, 500))


### PR DESCRIPTION
There have been a few times `mne.datasets.testing.data_path()` have snuck into our tests without the `download=False` that avoids a download, leading to interpreters that seem hung while a lengthy large download occurs. This PR adds a check via `inspect` that we don't do this, along with a private attribute that other packages like mne-bids can use to enable a similar check.

I'm hoping that these checks will reveal a problem here or in MNE-BIDS, otherwise more investigation is necessary why this download happens.