### PR TITLE
Fix tfr db

### DIFF
--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -571,9 +571,10 @@ def test_dB_computation():
     fig1 = tfr.plot(**plot_kwargs)[0]
     fig2 = complex_tfr.plot(**plot_kwargs)[0]
     # since we're fixing vmin/vmax, equal colors should mean ~equal input data
-    quadmesh1 = fig1.axes[0].collections[0]._mapped_colors
-    quadmesh2 = fig2.axes[0].collections[0]._mapped_colors
-    assert_array_equal(quadmesh1, quadmesh2)
+    quadmesh1 = fig1.axes[0].collections[0]
+    quadmesh2 = fig2.axes[0].collections[0]
+    if hasattr(quadmesh1, '_mapped_colors'):  # fails on compat/old
+        assert_array_equal(quadmesh1._mapped_colors, quadmesh2._mapped_colors)
 
 
 def test_plot():

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -554,6 +554,27 @@ def test_init_EpochsTFR():
         del tfr
 
 
+def test_dB_computation():
+    """Test dB computation in plot methods (gh 11091)."""
+    data = np.full((3, 2, 3), 4.)              # dB will be 10 log10(4)
+    complex_data = np.full((3, 2, 3), 2 + 0j)  # dB will be 20 log10(2)
+    times = np.array([.1, .2, .3])
+    freqs = np.array([.10, .20])
+    info = mne.create_info(['MEG 001', 'MEG 002', 'MEG 003'], 1000.,
+                           ['mag', 'mag', 'mag'])
+    kwargs = dict(times=times, freqs=freqs, nave=20, comment='test',
+                  method='crazy-tfr')
+    tfr = AverageTFR(info, data=data, **kwargs)
+    complex_tfr = AverageTFR(info, data=complex_data, **kwargs)
+    plot_kwargs = dict(dB=True, combine='mean', vmin=0, vmax=7)
+    fig1 = tfr.plot(**plot_kwargs)[0]
+    fig2 = complex_tfr.plot(**plot_kwargs)[0]
+    # since we're fixing vmin/vmax, equal colors should mean ~equal input data
+    quadmesh1 = fig1.axes[0].collections[0]._mapped_colors
+    quadmesh2 = fig2.axes[0].collections[0]._mapped_colors
+    assert_array_equal(quadmesh1, quadmesh2)
+
+
 def test_plot():
     """Test TFR plotting."""
     data = np.zeros((3, 2, 3))

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -556,8 +556,9 @@ def test_init_EpochsTFR():
 
 def test_dB_computation():
     """Test dB computation in plot methods (gh 11091)."""
-    data = np.full((3, 2, 3), 4.)              # dB will be 10 log10(4)
-    complex_data = np.full((3, 2, 3), 2 + 0j)  # dB will be 20 log10(2)
+    ampl = 2.
+    data = np.full((3, 2, 3), ampl ** 2)  # already power
+    complex_data = np.full((3, 2, 3), ampl + 0j)  # ampl → power when plotting
     times = np.array([.1, .2, .3])
     freqs = np.array([.10, .20])
     info = mne.create_info(['MEG 001', 'MEG 002', 'MEG 003'], 1000.,

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -112,17 +112,19 @@ def test_time_frequency():
     # the other is average of the squared magnitudes (epochs PSD)
     # so values shouldn't match, but shapes should
     assert_array_equal(power.data.shape, power_evoked.data.shape)
-    pytest.raises(AssertionError, assert_allclose,
-                  power.data, power_evoked.data)
+    with pytest.raises(AssertionError, match='Not equal to tolerance'):
+        assert_allclose(power.data, power_evoked.data)
 
     # complex output
-    pytest.raises(ValueError, tfr_morlet, epochs, freqs, n_cycles,
-                  return_itc=False, average=True, output="complex")
-    pytest.raises(ValueError, tfr_morlet, epochs, freqs, n_cycles,
-                  output="complex", average=False, return_itc=True)
-    epochs_power_complex = tfr_morlet(epochs, freqs, n_cycles,
-                                      output="complex", average=False,
-                                      return_itc=False)
+    with pytest.raises(ValueError, match='must be "power" if average=True'):
+        tfr_morlet(epochs, freqs, n_cycles, return_itc=False, average=True,
+                   output='complex')
+    with pytest.raises(ValueError, match='Inter-trial coher.*average=False'):
+        tfr_morlet(epochs, freqs, n_cycles, return_itc=True, average=False,
+                   output='complex')
+    epochs_power_complex = tfr_morlet(
+        epochs, freqs, n_cycles, return_itc=False, average=False,
+        output='complex')
     epochs_amplitude_2 = abs(epochs_power_complex)
     epochs_amplitude_3 = epochs_amplitude_2.copy()
     epochs_amplitude_3.data[:] = np.inf  # test that it's actually copied

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -2409,11 +2409,11 @@ def _preproc_tfr(data, times, freqs, tmin, tmax, fmin, fmax, mode,
     if copy is None:
         copy = baseline is not None
     data = rescale(data, times, baseline, mode, copy=copy)
-    coef = 10
 
     if np.iscomplexobj(data):
-        data = np.sqrt((data * data.conj()).real)
-        coef = 20  # because of sqrt, data is amplitude(-like) not power
+        # complex amplitude → real power (for plotting); if data are
+        # real-valued they should already be power
+        data = (data * data.conj()).real
 
     # crop time
     itmin, itmax = None, None
@@ -2439,7 +2439,7 @@ def _preproc_tfr(data, times, freqs, tmin, tmax, fmin, fmax, mode,
     data = data[:, ifmin:ifmax, itmin:itmax]
 
     if dB:
-        data = coef * np.log10(data)
+        data = 10 * np.log10(data)
 
     vmin, vmax = _setup_vmin_vmax(data, vmin, vmax)
     return data, times, freqs, vmin, vmax

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -2409,9 +2409,11 @@ def _preproc_tfr(data, times, freqs, tmin, tmax, fmin, fmax, mode,
     if copy is None:
         copy = baseline is not None
     data = rescale(data, times, baseline, mode, copy=copy)
+    coef = 10
 
     if np.iscomplexobj(data):
         data = np.sqrt((data * data.conj()).real)
+        coef = 20  # because of sqrt, data is amplitude(-like) not power
 
     # crop time
     itmin, itmax = None, None
@@ -2437,7 +2439,7 @@ def _preproc_tfr(data, times, freqs, tmin, tmax, fmin, fmax, mode,
     data = data[:, ifmin:ifmax, itmin:itmax]
 
     if dB:
-        data = 20 * np.log10(data)
+        data = coef * np.log10(data)
 
     vmin, vmax = _setup_vmin_vmax(data, vmin, vmax)
     return data, times, freqs, vmin, vmax


### PR DESCRIPTION
closes #11091

after reading through the TFR code, to me it seems that #10978 introduced a mistake.  Specifically, the changed coef here:

https://github.com/mne-tools/mne-python/blob/71271588e7d7fd3e165ad158571f40085eaa05e0/mne/time_frequency/tfr.py#L2439-L2440

is only appropriate for complex data (which have been converted to real-valued amplitude a few  lines above).  Data that is already real-valued will be power, not amplitude, and so should have coef `10` not `20` in the dB conversion.

My only hesitation is the case of `avg_power_itc` where the data will be complex, but the complex part is ITC, so it seems like the test of `if np.iscomplexobj` is too coarse here:

https://github.com/mne-tools/mne-python/blob/71271588e7d7fd3e165ad158571f40085eaa05e0/mne/time_frequency/tfr.py#L2413-L2414

...and data in the form `avg_power_itc` needs to be special-cased to simply discard the imaginary part and get treated like the (non-complex) power cases.  @alexrockhill @agramfort @larsoner since you three authored/reviewed #10978 can you confirm that I'm interpreting the code correctly here and that what I've said makes sense? 

