### PR TITLE
MAINT: Fix link and update instantiation note

### DIFF
--- a/examples/connectivity/README.txt
+++ b/examples/connectivity/README.txt
@@ -7,4 +7,4 @@ Examples demonstrating connectivity analysis in sensor and source space.
 .. note::
     Connectivity functionality has moved into the
     :mod:`mne-connectivity:mne_connectivity` package. Examples can be found at
-    :ref:`mne-connectivity:sphx_glr_auto_examples`.
+    :doc:`mne-connectivity:auto_examples/index`.

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -69,9 +69,10 @@ def _get_tslice(epochs, tmin, tmax):
 class Covariance(dict):
     """Noise covariance matrix.
 
-    .. warning:: This class should not be instantiated directly, but
-                 instead should be created using a covariance reading or
-                 computation function.
+    .. note::
+        This class should not be instantiated directly via
+        ``mne.Covariance(...)``. Instead, use one of the functions
+        listed in the See Also section below.
 
     Parameters
     ----------

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -46,8 +46,10 @@ from .viz import plot_dipole_locations
 class Dipole(TimeMixin):
     u"""Dipole class for sequential dipole fits.
 
-    .. note:: This class should usually not be instantiated directly,
-              instead :func:`mne.read_dipole` should be used.
+    .. note::
+        This class should usually not be instantiated directly via
+        ``mne.Dipole(...)``. Instead, use one of the functions
+        listed in the See Also section below.
 
     Used to store positions, orientations, amplitudes, times, goodness of fit
     of dipoles, typically obtained with Neuromag/xfit, mne_dipole_fit
@@ -366,8 +368,10 @@ def _read_dipole_fixed(fname):
 class DipoleFixed(TimeMixin):
     """Dipole class for fixed-position dipole fits.
 
-    .. note:: This class should usually not be instantiated directly,
-              instead :func:`mne.read_dipole` should be used.
+    .. note::
+        This class should usually not be instantiated directly
+        via ``mne.DipoleFixed(...)``. Instead, use one of the functions
+        listed in the See Also section below.
 
     Parameters
     ----------

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -345,8 +345,10 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
                  SpectrumMixin):
     """Abstract base class for `~mne.Epochs`-type classes.
 
-    .. warning:: This class provides basic functionality and should never be
-                 instantiated directly.
+    .. note::
+        This class should not be instantiated directly via
+        ``mne.BaseEpochs(...)``. Instead, use one of the functions listed in
+        the See Also section below.
 
     Parameters
     ----------
@@ -387,6 +389,12 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         ``info['sfreq']``.
     annotations : instance of mne.Annotations | None
         Annotations to set.
+
+    See Also
+    --------
+    Epochs
+    EpochsArray
+    make_fixed_length_epochs
 
     Notes
     -----

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -377,19 +377,21 @@ class Info(dict, MontageMixin, ContainsMixin):
     `FIF format specification <https://github.com/mne-tools/fiff-constants>`__,
     so new entries should not be manually added.
 
-    .. warning:: The only entries that should be manually changed by the user
-                 are ``info['bads']``, ``info['description']``,
-                 ``info['device_info']``, ``info['dev_head_t']``,
-                 ``info['experimenter']``, info['helium_info'],
-                 ``info['line_freq']``, ``info['temp']`` and
-                 ``info['subject_info']``. All other entries should be
-                 considered read-only, though they can be modified by various
-                 MNE-Python functions or methods (which have safeguards to
-                 ensure all fields remain in sync).
+    .. note::
+        This class should not be instantiated directly via
+        ``mne.Info(...)``. Instead, use :func:`mne.create_info` to create
+        measurement information from scratch.
 
-    .. warning:: This class should not be instantiated directly. To create a
-                 measurement information structure, use
-                 :func:`mne.create_info`.
+    .. warning::
+        The only entries that should be manually changed by the user are:
+        ``info['bads']``, ``info['description']``, ``info['device_info']``
+        ``info['dev_head_t']``, ``info['experimenter']``,
+        ``info['helium_info']``, ``info['line_freq']``, ``info['temp']``,
+        and ``info['subject_info']``.
+
+        All other entries should be considered read-only, though they can be
+        modified by various MNE-Python functions or methods (which have
+        safeguards to ensure all fields remain in sync).
 
     Parameters
     ----------

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -300,8 +300,10 @@ _SOURCE_MORPH_ATTRIBUTES = [  # used in writing
 class SourceMorph:
     """Morph source space data from one subject to another.
 
-    .. note:: This class should not be instantiated directly.
-              Use :func:`mne.compute_source_morph` instead.
+    .. note::
+        This class should not be instantiated directly via
+        ``mne.SourceMorph(...)``. Instead, use one of the functions
+        listed in the See Also section below.
 
     Parameters
     ----------
@@ -351,6 +353,11 @@ class SourceMorph:
         The volumetric morph matrix, if :meth:`compute_vol_morph_mat`
         was used.
     %(verbose)s
+
+    See Also
+    --------
+    compute_source_morph
+    read_source_morph
 
     Notes
     -----

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -17,8 +17,13 @@ class Figure3D(ABC):
     """Class that refers to a 3D figure.
 
     .. note::
-        This class is not meant to be instantiated directly, use
-        :func:`mne.viz.create_3d_figure` instead.
+        This class should not be instantiated directly via
+        ``mne.viz.Figure3D(...)``. Instead, use
+        :func:`mne.viz.create_3d_figure`.
+
+    See Also
+    --------
+    mne.viz.create_3d_figure
     """
 
     # Here we use _init rather than __init__ so that users are less tempted to

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -70,8 +70,13 @@ _FIGURES = dict()
 class PyVistaFigure(Figure3D):
     """PyVista-based 3D Figure.
 
-    This class is not meant to be instantiated directly, use
-    :func:`mne.viz.create_3d_figure` instead.
+    .. note:: This class should not be instantiated directly via
+              ``mne.viz.PyVistaFigure(...)``. Instead, use
+              :func:`mne.viz.create_3d_figure`.
+
+    See Also
+    --------
+    mne.viz.create_3d_figure
     """
 
     def __init__(self):


### PR DESCRIPTION
Closes #11226

Fixed by a quick
```
python -m sphinx.ext.intersphinx https://mne.tools/mne-connectivity/stable/objects.inv > mne-connectivity.txt
```
then inspection, plus doc check with `make html_dev-noplot`. So should come back green for the Circle run, but I'll merge manually since the `skip`s won't allow auto-merge to work.

I then tweaked and unified our "don't instantiate directly" lines. @drammock feel free to review and approve if you're happy with the wording and `.. note::` I chose to unify around. If not I'm happy to change them:

![Screenshot from 2022-10-06 11-51-59](https://user-images.githubusercontent.com/2365790/194360180-a01cca0e-5bcd-4587-9825-907e10507484.png)
