### PR TITLE
BUG: Fix regression with run_subprocess

### DIFF
--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -138,14 +138,14 @@ def run_subprocess(command, return_code=False, verbose=None, *args, **kwargs):
                 except Empty:
                     break
                 else:
+                    out = out.decode('utf-8')
                     # Strip newline at end of the string, otherwise we'll end
                     # up with two subsequent newlines (as the logger adds one)
                     #
                     # XXX Once we drop support for Python <3.9, uncomment the
                     # following line and remove the if/else block below.
                     #
-                    # out = out.decode('utf-8').removesuffix('\n')
-                    out = out.decode('utf-8')
+                    # log_out = out.removesuffix('\n')
                     if sys.version_info[:2] >= (3, 9):
                         log_out = out.removesuffix('\n')
                     elif out.endswith('\n'):
@@ -162,14 +162,14 @@ def run_subprocess(command, return_code=False, verbose=None, *args, **kwargs):
                 except Empty:
                     break
                 else:
+                    err = err.decode('utf-8')
                     # Strip newline at end of the string, otherwise we'll end
                     # up with two subsequent newlines (as the logger adds one)
                     #
                     # XXX Once we drop support for Python <3.9, uncomment the
                     # following line and remove the if/else block below.
                     #
-                    # err = err.decode('utf-8').removesuffix('\n')
-                    err = err.decode('utf-8')
+                    # err_out = err.removesuffix('\n')
                     if sys.version_info[:2] >= (3, 9):
                         err_out = err.removesuffix('\n')
                     elif err.endswith('\n'):

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -147,12 +147,13 @@ def run_subprocess(command, return_code=False, verbose=None, *args, **kwargs):
                     # out = out.decode('utf-8').removesuffix('\n')
                     out = out.decode('utf-8')
                     if sys.version_info[:2] >= (3, 9):
-                        out = out.removesuffix('\n')
+                        log_out = out.removesuffix('\n')
+                    elif out.endswith('\n'):
+                        log_out = out[:-1]
                     else:
-                        if out.endswith('\n'):
-                            out = out[:-1]
+                        log_out = out
 
-                    logger.info(out)
+                    logger.info(log_out)
                     all_out += out
 
             while True:  # process stderr
@@ -170,10 +171,11 @@ def run_subprocess(command, return_code=False, verbose=None, *args, **kwargs):
                     # err = err.decode('utf-8').removesuffix('\n')
                     err = err.decode('utf-8')
                     if sys.version_info[:2] >= (3, 9):
-                        err = err.removesuffix('\n')
+                        err_out = err.removesuffix('\n')
+                    elif err.endswith('\n'):
+                        err_out = err[:-1]
                     else:
-                        if err.endswith('\n'):
-                            err = err[:-1]
+                        err_out = err
 
                     # Leave this as logger.warning rather than warn(...) to
                     # mirror the logger.info above for stdout. This function
@@ -181,7 +183,7 @@ def run_subprocess(command, return_code=False, verbose=None, *args, **kwargs):
                     # shouldn't emit Python warnings due to stderr outputs
                     # (the calling function can check for stderr output and
                     # emit a warning if it wants).
-                    logger.warning(err)
+                    logger.warning(err_out)
                     all_err += err
 
             if do_break:

--- a/mne/utils/tests/test_misc.py
+++ b/mne/utils/tests/test_misc.py
@@ -49,6 +49,9 @@ print('bar', file=sys.{kind})
             [sys.executable, str(fname)], verbose=True)
     log = log.getvalue()
     log = '\n'.join(log.split('\n')[1:])  # get rid of header
+    log = log.replace('\r\n', '\n')  # Windows
+    stdout = stdout.replace('\r\n', '\n')
+    stderr = stderr.replace('\r\n', '\n')
     want = 'foo\nbar\n'
     assert log == want
     if kind == 'stdout':


### PR DESCRIPTION
@hoechenberger fixes a regression due to #11219. We shouldn't remove the `\n` from the `stdout` *returns*, only remove it when actually `logger.info` and `logger.warning`'ing them.

This should fix https://app.circleci.com/pipelines/github/mne-tools/mne-bids/4710/workflows/a2f8cafe-dd31-49cc-952d-3e46e06b5c14/jobs/6848, marking for merge-when-green