### PR TITLE
Fix welch windows

### DIFF
--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -1186,4 +1186,5 @@ def _compute_n_welch_segments(n_times, method_kw):
     # sanity check values / replace `None`s with real numbers
     n_fft, n_per_seg, n_overlap = _check_nfft(n_times, **_defaults)
     # compute expected number of segments
-    return n_times // (n_per_seg - n_overlap)
+    step = n_per_seg - n_overlap
+    return (n_times - n_overlap) // step

--- a/mne/time_frequency/tests/test_spectrum.py
+++ b/mne/time_frequency/tests/test_spectrum.py
@@ -44,6 +44,14 @@ def test_spectrum_params(method, fmin, fmax, tmin, tmax, picks, proj, n_fft,
     raw.compute_psd(**kwargs)
 
 
+def test_n_welch_windows(raw):
+    """Test computation of welch windows https://mne.discourse.group/t/5734."""
+    with raw.info._unlock():
+        raw.info['sfreq'] = 999.412109375
+    raw.compute_psd(
+        method='welch', n_fft=999, n_per_seg=999, n_overlap=250, average=None)
+
+
 def _get_inst(inst, request, evoked):
     # ↓ XXX workaround:
     # ↓ parametrized fixtures are not accessible via request.getfixturevalue


### PR DESCRIPTION
reported here https://mne.discourse.group/t/is-this-a-bug-in-the-new-compute-psd-method/5734

The corrected computation was based on what they do in scipy.signal._fft_helper

The new test fails on main and passes here.