### PR TITLE
Update 20_rejecting_bad_data.py

### DIFF
--- a/tutorials/preprocessing/20_rejecting_bad_data.py
+++ b/tutorials/preprocessing/20_rejecting_bad_data.py
@@ -257,7 +257,7 @@ epochs = mne.Epochs(raw, events, tmin=-0.2, tmax=0.5, reject_tmax=0,
 epochs.plot_drop_log()
 
 # %%
-# More importantly, note that *many* more epochs are rejected (~20% instead of
+# More importantly, note that *many* more epochs are rejected (~12.2% instead of
 # ~2.5%) when rejecting based on the blink labels, underscoring why it is
 # usually desirable to repair artifacts rather than exclude them.
 #

--- a/tutorials/preprocessing/20_rejecting_bad_data.py
+++ b/tutorials/preprocessing/20_rejecting_bad_data.py
@@ -257,8 +257,8 @@ epochs = mne.Epochs(raw, events, tmin=-0.2, tmax=0.5, reject_tmax=0,
 epochs.plot_drop_log()
 
 # %%
-# More importantly, note that *many* more epochs are rejected (~12.2% instead of
-# ~2.5%) when rejecting based on the blink labels, underscoring why it is
+# More importantly, note that *many* more epochs are rejected (~12.2% instead
+# of ~2.5%) when rejecting based on the blink labels, underscoring why it is
 # usually desirable to repair artifacts rather than exclude them.
 #
 # The :meth:`~mne.Epochs.plot_drop_log` method is a visualization of an


### PR DESCRIPTION
#### What does this implement/fix?
A  typo in the [preprocessing - rejecting bad data spans and breaks](https://mne.tools/stable/auto_tutorials/preprocessing/20_rejecting_bad_data.html#rejecting-epochs-based-on-channel-amplitude) tutorial.

Currently the written description of the number of epochs that are dropped when `reject_by_annotation=True` is 20%.
This does not match the actual number, which is 12.2%, according to the function output (both log and plot title).
