### PR TITLE
BUG: add missing `verbose` argument in combine_channels function

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1876,8 +1876,9 @@ def make_1020_channel_selections(info, midline="z"):
     return selections
 
 
+@verbose
 def combine_channels(inst, groups, method='mean', keep_stim=False,
-                     drop_bad=False):
+                     drop_bad=False, verbose=None):
     """Combine channels based on specified channel grouping.
 
     Parameters
@@ -1915,6 +1916,7 @@ def combine_channels(inst, groups, method='mean', keep_stim=False,
     drop_bad : bool
         If ``True``, drop channels marked as bad before combining. Defaults to
         ``False``.
+    %(verbose)s
 
     Returns
     -------


### PR DESCRIPTION
#### Reference issue
Closes #11252


#### What does this implement/fix?
Adds the missing `verbose` command to the `combine_channels` function. 


#### Additional information
Changed three lines of code: 

1. Added @verbose before the function call
2. Added verbose=None to the function arguments
3. Added %(verbose)s to the docstring
