### PR TITLE
BUG: Fix X coordinates of ear_left and ear_right in head outlines dict

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -29,6 +29,7 @@ Bugs
 ~~~~
 - Fix bug in documentation of :func:`mne.channels.make_dig_montage` (:gh:`11235` by :newcontrib:`Daniel Hasegan`)
 - Add support for bad channel handling in :func:`mne.set_bipolar_reference` (:gh:`11245` by `Moritz Gerster`_, :newcontrib:`Dinara Issagaliyeva`, :newcontrib:`Jennifer Behnke`, :newcontrib:`Hakimeh Aslsardroud`, and :newcontrib:`Pavel Navratil`)
+- Fix X coordinates of ear_left and ear_right in head outlines dict (:gh:`11255` by :newcontrib:`Tom Ma`)
 - Fix bug where ``ica.reject_`` was not saved to disk, and the ``ica.reject_`` property was not inherited from ``Epochs`` when doing ``ICA.fit(epochs)`` (:gh:`11244` by `Eric Larson`_)
 
 API changes

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -515,3 +515,5 @@
 .. _Hakimeh Pourakbari: https://github.com/Hpakbari
 
 .. _Pavel Navratil: https://github.com/navrpa13
+
+.. _Tom Ma: https://github.com/myd7349

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -472,8 +472,8 @@ def _make_head_outlines(sphere, pos, outlines, clip_origin):
         if outlines is not None:
             # Define the outline of the head, ears and nose
             outlines_dict = dict(head=(head_x, head_y), nose=(nose_x, nose_y),
-                                 ear_left=(ear_x + x, ear_y),
-                                 ear_right=(-ear_x + x, ear_y))
+                                 ear_left=(-ear_x + x, ear_y),
+                                 ear_right=(ear_x + x, ear_y))
         else:
             outlines_dict = dict()
 


### PR DESCRIPTION
Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

#### Reference issue
N/A.


#### What does this implement/fix?
When debuging a code snippet(will paste it later) with Spyder today, I found that the X coordinate of `ear_left` and `ear_right` may have been exchanged accidentally at [```mne.viz.topomap._make_head_outlines```](https://github.com/mne-tools/mne-python/blob/3d13746dc3d08b1eff073dab5c119812de4d42ee/mne/viz/topomap.py#L475-L476).

#### Additional information

My test code:

```python
#!/usr/bin/env python3
# coding: utf-8

import mne.channels
import mne.viz


def main():
    standard_1005_montage = mne.channels.make_standard_montage('standard_1005')
    mne.viz.plot_montage(standard_1005_montage)
    mne.viz.plot_montage(standard_1005_montage, sphere='eeglab')


if __name__ == '__main__':
    main()
```

I  was debugging this script with Spyder step by step today, trying to figure out how `plot_montage` works.

When I stepped into this function [```mne.viz.utils.plot_sensors```](https://github.com/mne-tools/mne-python/blob/3d13746dc3d08b1eff073dab5c119812de4d42ee/mne/viz/utils.py#L913), I noticed that:

![Fix](https://user-images.githubusercontent.com/5435649/196199748-916db7b0-d90c-41c1-9134-0e298e583add.png)

In this snapshot,  we can see that the X coordinates of `ear_left` is close to the X coordinate of A2 and the X coordinates of `ear_right` is close to A1.

