### PR TITLE
[DOC] Improve argument documentation for TFR multitaper

### DIFF
--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -597,7 +597,7 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
     ``n_cycles=freqs/2`` yields ``T=array([0.5, 0.5, 0.5])``.
 
     .. versionadded:: 0.14.0
-    """
+    """  # noqa: E501
     from .tfr import _compute_tfr
     return _compute_tfr(epoch_data, freqs, sfreq=sfreq,
                         method='multitaper', n_cycles=n_cycles,

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -382,7 +382,7 @@ def psd_array_multitaper(x, sfreq, fmin=0.0, fmax=np.inf, bandwidth=None,
     %(fmin_fmax_psd)s
     bandwidth : float
         Half-bandwith of the multi-taper window function in Hz. For a given
-        frequency, frequencies at ``± half-bandwith`` are smoothed together.
+        frequency, frequencies at ± half-bandwith are smoothed together.
         The default value is a half-bandwidth of 4.
     adaptive : bool
         Use adaptive weights to combine the tapered spectra into PSD
@@ -510,7 +510,7 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
     %(n_cycles_tfr)s
     zero_mean : bool
         If True, make sure the wavelets have a mean of zero. Defaults to True.
-    %(time_bandwitdh_tfr)s
+    %(time_bandwidth_tfr)s
     use_fft : bool
         Use the FFT for convolutions or not. Defaults to True.
     %(decim_tfr)s
@@ -551,9 +551,9 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
 
     Notes
     -----
-    %(time-window_tfr_notes)s
+    %(temporal-window_tfr_notes)s
 
-    %(time_bandwitdh_tfr_note)s
+    %(time_bandwidth_tfr_notes)s
 
     .. versionadded:: 0.14.0
     """

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -574,12 +574,13 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
     Either the time-window has a fixed length independent of frequency, or the
     time-window decreases in length with increased frequency.
 
-    .. image:: _static/diagrams/tfr.png
+    .. image:: https://www.fieldtriptoolbox.org/assets/img/tutorial/timefrequencyanalysis/figure1.png
 
     *Figure: Time and frequency smoothing. (a) For a fixed length time window
     the time and frequency smoothing remains fixed. (b) For time windows that
     decrease with frequency, the temporal smoothing decreases and the frequency
-    smoothing increases. Source: `FieldTrip tutorial <FT_tut_>`_.*
+    smoothing increases.
+    Source: `FieldTrip tutorial <https://www.fieldtriptoolbox.org/tutorial/timefrequencyanalysis>`_.*
 
     In MNE, the time-window length is defined by the arguments ``freqs`` and
     ``n_cycles`` respectively defining the frequencies of interest and the
@@ -597,7 +598,6 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
 
     .. versionadded:: 0.14.0
 
-    .. _FT_tut: https://www.fieldtriptoolbox.org/tutorial/timefrequencyanalysis
     """
     from .tfr import _compute_tfr
     return _compute_tfr(epoch_data, freqs, sfreq=sfreq,

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -379,12 +379,11 @@ def psd_array_multitaper(x, sfreq, fmin=0.0, fmax=np.inf, bandwidth=None,
         The data to compute PSD from.
     sfreq : float
         The sampling frequency.
-    fmin : float
-        The lower frequency of interest.
-    fmax : float
-        The upper frequency of interest.
+    %(fmin_fmax_psd)s
     bandwidth : float
-        The bandwidth of the multi taper windowing function in Hz.
+        Half-bandwith of the multi-taper window function in Hz. For a given
+        frequency, frequencies at ``± half-bandwith`` are smoothed together.
+        The default value is a half-bandwidth of 4.
     adaptive : bool
         Use adaptive weights to combine the tapered spectra into PSD
         (slow, use n_jobs >> 1 to speed up computation).
@@ -393,10 +392,12 @@ def psd_array_multitaper(x, sfreq, fmin=0.0, fmax=np.inf, bandwidth=None,
         bandwidth.
     %(normalization)s
     output : str
-        The format of the returned ``psds`` array. Can be either ``'complex'``
-        or ``'power'``. If ``'power'``, the power spectral density is returned.
-        If ``output='complex'``, the complex fourier coefficients are returned
-        per taper.
+        The format of the returned ``psds`` array, ``'complex'`` or
+        ``'power'``:
+
+        * ``'power'`` : the power spectral density is returned.
+        * ``'complex'`` : the complex fourier coefficients are returned per
+          taper.
     %(n_jobs)s
     %(max_iter_multitaper)s
     %(verbose)s

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -584,16 +584,14 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
 
     In MNE, the time-window length is defined by the arguments ``freqs`` and
     ``n_cycles`` respectively defining the frequencies of interest and the
-    number of cycles:
-
-    :math:`T = n_cycles / freqs`
+    number of cycles: :math:`T = n_{cycles} / freqs`
 
     A fixed number of cycles for all frequencies will yield a time-window which
-    decreases with frequency. For example, ``freqs=np.arange(1., 6., 2.)`` and
+    decreases with frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
     ``n_cycles=2`` yields ``T=array([2. , 0.7, 0.4])``.
 
     To use a fixed length time-window, the number of cycles has to be defined
-    based on the frequency. For example, ``freqs=np.arange(1., 6., 2.)`` and
+    based on the frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
     ``n_cycles=freqs/2`` yields ``T=array([0.5, 0.5, 0.5])``.
 
     .. versionadded:: 0.14.0

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -528,9 +528,9 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
     Returns
     -------
     out : array
-        Time frequency transform of epoch_data.
+        Time frequency transform of ``epoch_data``.
 
-        - if ``output`` is ``'complex'`` or ``'phase'``, array of shape
+        - if ``output in ('complex',' 'phase')``, array of shape
           ``(n_epochs, n_chans, n_tapers, n_freqs, n_times)``
         - if ``output`` is ``'power'``, array of shape ``(n_epochs, n_chans,
           n_freqs, n_times)``

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -577,7 +577,7 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
     *Figure: Time and frequency smoothing. (a) For a fixed length time window
     the time and frequency smoothing remains fixed. (b) For time windows that
     decrease with frequency, the temporal smoothing decreases and the frequency
-    smoothing increases.
+    smoothing increases.*
     Source: `FieldTrip tutorial <https://www.fieldtriptoolbox.org/tutorial/timefrequencyanalysis>`_.
 
     In MNE, the time-window length is defined by the arguments ``freqs`` and

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -578,7 +578,8 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
     the time and frequency smoothing remains fixed. (b) For time windows that
     decrease with frequency, the temporal smoothing decreases and the frequency
     smoothing increases.*
-    Source: `FieldTrip tutorial <https://www.fieldtriptoolbox.org/tutorial/timefrequencyanalysis>`_.
+    Source: `FieldTrip tutorial: Time-frequency analysis using Hanning window,
+    multitapers and wavelets <https://www.fieldtriptoolbox.org/tutorial/timefrequencyanalysis>`_.
 
     In MNE, the time-window length is defined by the arguments ``freqs`` and
     ``n_cycles`` respectively defining the frequencies of interest and the
@@ -590,7 +591,7 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
 
     To use a fixed length time-window, the number of cycles has to be defined
     based on the frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
-    ``n_cycles=freqs/2`` yields ``T=array([0.5, 0.5, 0.5])``.
+    ``n_cycles=freqs / 2`` yields ``T=array([0.5, 0.5, 0.5])``.
 
     .. versionadded:: 0.14.0
     """  # noqa: E501

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -552,7 +552,6 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
     Notes
     -----
     %(temporal-window_tfr_notes)s
-
     %(time_bandwidth_tfr_notes)s
 
     .. versionadded:: 0.14.0

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -550,7 +550,9 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
 
     Notes
     -----
-    %(tfr_time-window_notes)s
+    %(time-window_tfr_notes)s
+
+    %(time_bandwitdh_tfr_note)s
 
     .. versionadded:: 0.14.0
     """

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -505,7 +505,7 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
         The epochs.
     sfreq : float
         Sampling frequency of the data in Hz.
-    freqs : array-like of float, shape (n_freqs,)
+    freqs : array of float, shape (n_freqs,)
         The frequencies of interest in Hz.
     n_cycles : int | array of int
         Number of cycles in the wavelet, either a fixed number or one per

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -580,7 +580,7 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
     the time and frequency smoothing remains fixed. (b) For time windows that
     decrease with frequency, the temporal smoothing decreases and the frequency
     smoothing increases.
-    Source: `FieldTrip tutorial <https://www.fieldtriptoolbox.org/tutorial/timefrequencyanalysis>`_.*
+    Source: `FieldTrip tutorial <https://www.fieldtriptoolbox.org/tutorial/timefrequencyanalysis>`_.
 
     In MNE, the time-window length is defined by the arguments ``freqs`` and
     ``n_cycles`` respectively defining the frequencies of interest and the

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -505,36 +505,14 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
         The epochs.
     sfreq : float
         Sampling frequency of the data in Hz.
-    freqs : array of float, shape (n_freqs,)
-        The frequencies of interest in Hz.
-    n_cycles : int | array of int
-        Number of cycles in the wavelet, either a fixed number or one per
-        frequency. The number of cycles ``n_cycles`` and the frequencies of
-        interest ``freqs`` define the time-window length. See notes for
-        additional information about the relationship between those arguments
-        and about time and frequency smoothing.
+    %(freqs_tfr)s
+    %(n_cycles_tfr)s
     zero_mean : bool
         If True, make sure the wavelets have a mean of zero. Defaults to True.
-    time_bandwidth : float
-        Time x (Full) Bandwidth product. Should be ``≥ 2.0``.
-        Choose this along with ``n_cycles`` to set the desired frequency
-        resolution. The number of good tapers (least leakage from far away
-        frequencies) is chosen automatically based on this to
-        floor ``time_bandwidth - 1``.
-        For example, with ``freq = 20 Hz`` and ``n_cycles = 10``, we get
-        ``time = 0.5 s``. If ``time_bandwidth = 4.``, then frequency smoothing
-        is ``(4 / time) = 8 Hz``.
+    %(time_bandwitdh_tfr)s
     use_fft : bool
         Use the FFT for convolutions or not. Defaults to True.
-    decim : int | slice
-        To reduce memory usage, decimation factor after time-frequency
-        decomposition. Defaults to 1.
-        If `int`, returns ``tfr[..., ::decim]``.
-        If `slice`, returns ``tfr[..., decim]``.
-
-        .. note::
-            Decimation may create aliasing artifacts, yet decimation
-            is done after the convolutions.
+    %(decim_tfr)s
     output : str, default 'complex'
 
         * ``'complex'`` : single trial per taper complex values.
@@ -572,33 +550,10 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
 
     Notes
     -----
-    Time-frequency representations are computed using a sliding time-window.
-    Either the time-window has a fixed length independent of frequency, or the
-    time-window decreases in length with increased frequency.
-
-    .. image:: https://www.fieldtriptoolbox.org/assets/img/tutorial/timefrequencyanalysis/figure1.png
-
-    *Figure: Time and frequency smoothing. (a) For a fixed length time window
-    the time and frequency smoothing remains fixed. (b) For time windows that
-    decrease with frequency, the temporal smoothing decreases and the frequency
-    smoothing increases.*
-    Source: `FieldTrip tutorial: Time-frequency analysis using Hanning window,
-    multitapers and wavelets <https://www.fieldtriptoolbox.org/tutorial/timefrequencyanalysis>`_.
-
-    In MNE, the time-window length is defined by the arguments ``freqs`` and
-    ``n_cycles`` respectively defining the frequencies of interest and the
-    number of cycles: :math:`T = n_{cycles} / freqs`
-
-    A fixed number of cycles for all frequencies will yield a time-window which
-    decreases with frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
-    ``n_cycles=2`` yields ``T=array([2. , 0.7, 0.4])``.
-
-    To use a fixed length time-window, the number of cycles has to be defined
-    based on the frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
-    ``n_cycles=freqs / 2`` yields ``T=array([0.5, 0.5, 0.5])``.
+    %(tfr_time-window_notes)s
 
     .. versionadded:: 0.14.0
-    """  # noqa: E501
+    """
     from .tfr import _compute_tfr
     return _compute_tfr(epoch_data, freqs, sfreq=sfreq,
                         method='multitaper', n_cycles=n_cycles,

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -597,7 +597,6 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
     ``n_cycles=freqs/2`` yields ``T=array([0.5, 0.5, 0.5])``.
 
     .. versionadded:: 0.14.0
-
     """
     from .tfr import _compute_tfr
     return _compute_tfr(epoch_data, freqs, sfreq=sfreq,

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -529,8 +529,8 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
     decim : int | slice
         To reduce memory usage, decimation factor after time-frequency
         decomposition. Defaults to 1.
-        If `int`, returns tfr[..., ::decim].
-        If `slice`, returns tfr[..., decim].
+        If `int`, returns ``tfr[..., ::decim]``.
+        If `slice`, returns ``tfr[..., decim]``.
 
         .. note::
             Decimation may create aliasing artifacts, yet decimation
@@ -550,13 +550,17 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
     Returns
     -------
     out : array
-        Time frequency transform of epoch_data. If ``output in ['complex',
-        'phase']``, then the shape of ``out`` is ``(n_epochs, n_chans,
-        n_tapers, n_freqs, n_times)``; if output is 'power', the shape of
-        ``out`` is ``(n_epochs, n_chans, n_freqs, n_times)``, else it is
-        ``(n_chans, n_freqs, n_times)``. If output is 'avg_power_itc', the real
-        values in ``out`` contain the average power and the imaginary values
-        contain the ITC: ``out = avg_power + i * itc``.
+        Time frequency transform of epoch_data.
+
+        - if ``output`` is ``'complex'`` or ``'phase'``, array of shape
+          ``(n_epochs, n_chans, n_tapers, n_freqs, n_times)``
+        - if ``output`` is ``'power'``, array of shape ``(n_epochs, n_chans,
+          n_freqs, n_times)``
+        - else, array of shape ``(n_chans, n_freqs, n_times)``
+
+        If ``output`` is ``'avg_power_itc'``, the real values in ``out``
+        contain the average power and the imaginary values contain the ITC:
+        :math:`out = power_{avg} + i * itc`.
 
     See Also
     --------

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -381,8 +381,8 @@ def psd_array_multitaper(x, sfreq, fmin=0.0, fmax=np.inf, bandwidth=None,
         The sampling frequency.
     %(fmin_fmax_psd)s
     bandwidth : float
-        Half-bandwith of the multi-taper window function in Hz. For a given
-        frequency, frequencies at ± half-bandwith are smoothed together.
+        Half-bandwidth of the multi-taper window function in Hz. For a given
+        frequency, frequencies at ± half-bandwidth are smoothed together.
         The default value is a half-bandwidth of 4.
     adaptive : bool
         Use adaptive weights to combine the tapered spectra into PSD
@@ -538,8 +538,8 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
         - else, array of shape ``(n_chans, n_freqs, n_times)``
 
         If ``output`` is ``'avg_power_itc'``, the real values in ``out``
-        contain the average power and the imaginary values contain the ITC:
-        :math:`out = power_{avg} + i * itc`.
+        contain the average power and the imaginary values contain the
+        inter-trial coherence: :math:`out = power_{avg} + i * ITC`.
 
     See Also
     --------

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -545,8 +545,6 @@ def tfr_array_multitaper(epoch_data, sfreq, freqs, n_cycles=7.0,
         * ``'avg_power_itc'`` : average of single trial power and inter-trial
           coherence across trials.
     %(n_jobs)s
-        The number of epochs to process at the same time. The parallelization
-        is implemented across channels. Defaults to 1.
     %(verbose)s
 
     Returns

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -287,8 +287,9 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     %(fmin_fmax_psd)s
     %(tmin_tmax_psd)s
     bandwidth : float
-        The bandwidth of the multi taper windowing function in Hz. The default
-        value is a window half-bandwidth of 4.
+        Half-bandwith of the multitaper window function in Hz. For a given
+        frequency, frequencies at ``± half-bandwith`` are smoothed together.
+        The default value is a half-bandwidth of 4.
     adaptive : bool
         Use adaptive weights to combine the tapered spectra into PSD
         (slow, use n_jobs >> 1 to speed up computation).

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -288,7 +288,7 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     %(tmin_tmax_psd)s
     bandwidth : float
         Half-bandwith of the multi-taper window function in Hz. For a given
-        frequency, frequencies at ``± half-bandwith`` are smoothed together.
+        frequency, frequencies at ± half-bandwith are smoothed together.
         The default value is a half-bandwidth of 4.
     adaptive : bool
         Use adaptive weights to combine the tapered spectra into PSD

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -287,7 +287,7 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     %(fmin_fmax_psd)s
     %(tmin_tmax_psd)s
     bandwidth : float
-        Half-bandwith of the multitaper window function in Hz. For a given
+        Half-bandwith of the multi-taper window function in Hz. For a given
         frequency, frequencies at ``± half-bandwith`` are smoothed together.
         The default value is a half-bandwidth of 4.
     adaptive : bool

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -287,8 +287,8 @@ def psd_multitaper(inst, fmin=0, fmax=np.inf, tmin=None, tmax=None,
     %(fmin_fmax_psd)s
     %(tmin_tmax_psd)s
     bandwidth : float
-        Half-bandwith of the multi-taper window function in Hz. For a given
-        frequency, frequencies at ± half-bandwith are smoothed together.
+        Half-bandwidth of the multi-taper window function in Hz. For a given
+        frequency, frequencies at ± half-bandwidth are smoothed together.
         The default value is a half-bandwidth of 4.
     adaptive : bool
         Use adaptive weights to combine the tapered spectra into PSD

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -836,11 +836,11 @@ def tfr_array_morlet(epoch_data, sfreq, freqs, n_cycles=7.0,
 @verbose
 def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
                    use_fft=True, return_itc=True, decim=1,
-                   n_jobs=None, picks=None, average=True, verbose=None):
+                   n_jobs=None, picks=None, average=True, *, verbose=None):
     """Compute Time-Frequency Representation (TFR) using DPSS tapers.
 
     Same computation as `~mne.time_frequency.tfr_array_multitaper`, but
-    operates on `~mne.Epochs` objects instead of
+    operates on `~mne.Epochs` or `~mne.Evoked` objects instead of
     :class:`NumPy arrays <numpy.ndarray>`.
 
     Parameters
@@ -848,7 +848,7 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
     inst : Epochs | Evoked
         The epochs or evoked object.
     freqs : ndarray, shape (n_freqs,)
-        The frequencies in Hz.
+        The frequencies of interest in Hz.
     n_cycles : float | ndarray, shape (n_freqs,)
         The number of cycles globally or for each frequency.
         The time-window length is thus T = n_cycles / freq.

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -786,11 +786,15 @@ def tfr_array_morlet(epoch_data, sfreq, freqs, n_cycles=7.0,
     Returns
     -------
     out : array
-        Time frequency transform of epoch_data. If output is in ['complex',
-        'phase', 'power'], then shape of out is (n_epochs, n_chans, n_freqs,
-        n_times), else it is (n_chans, n_freqs, n_times). If output is
-        'avg_power_itc', the real values code for 'avg_power' and the
-        imaginary values code for the 'itc': out = avg_power + i * itc.
+        Time frequency transform of epoch_data.
+
+        - if ``output in ('complex', 'phase', 'power')``, array of shape
+          ``(n_epochs, n_chans, n_freqs, n_times)``
+        - else, array of shape ``(n_chans, n_freqs, n_times)``
+
+        If ``output`` is ``'avg_power_itc'``, the real values in ``out``
+        contain the average power and the imaginary values contain the ITC:
+        :math:`out = power_{avg} + i * itc`.
 
     See Also
     --------

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -833,7 +833,7 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
         The epochs or evoked object.
     %(freqs_tfr)s
     %(n_cycles_tfr)s
-    %(time_bandwitdh_tfr)s
+    %(time_bandwidth_tfr)s
     use_fft : bool, default True
         The fft based convolution or not.
     return_itc : bool, default True
@@ -865,7 +865,7 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
     -----
     %(time-window_tfr_notes)s
 
-    %(time_bandwitdh_tfr_note)s
+    %(time_bandwidth_tfr_note)s
 
     .. versionadded:: 0.9.0
     """

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -769,14 +769,14 @@ def tfr_array_morlet(epoch_data, sfreq, freqs, n_cycles=7.0,
     use_fft : bool
         Use the FFT for convolutions or not. default True.
     %(decim_tfr)s
-    output : str, default 'complex'
+    output : str, default ``'complex'``
 
-        * 'complex' : single trial complex.
-        * 'power' : single trial power.
-        * 'phase' : single trial phase.
-        * 'avg_power' : average of single trial power.
-        * 'itc' : inter-trial coherence.
-        * 'avg_power_itc' : average of single trial power and inter-trial
+        * ``'complex'`` : single trial complex.
+        * ``'power'`` : single trial power.
+        * ``'phase'`` : single trial phase.
+        * ``'avg_power'`` : average of single trial power.
+        * ``'itc'`` : inter-trial coherence.
+        * ``'avg_power_itc'`` : average of single trial power and inter-trial
           coherence across trials.
     %(n_jobs)s
         The number of epochs to process at the same time. The parallelization

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -864,7 +864,6 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
     Notes
     -----
     %(temporal-window_tfr_notes)s
-
     %(time_bandwidth_tfr_notes)s
 
     .. versionadded:: 0.9.0

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -739,7 +739,7 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False, return_itc=True, decim=1,
 
     Notes
     -----
-    %(tfr_time-window_notes)s
+    %(time-window_tfr_notes)s
     """
     tfr_params = dict(n_cycles=n_cycles, n_jobs=n_jobs, use_fft=use_fft,
                       zero_mean=zero_mean, output=output)
@@ -806,7 +806,7 @@ def tfr_array_morlet(epoch_data, sfreq, freqs, n_cycles=7.0,
 
     Notes
     -----
-    %(tfr_time-window_notes)s
+    %(time-window_tfr_notes)s
 
     .. versionadded:: 0.14.0
     """
@@ -863,7 +863,9 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
 
     Notes
     -----
-    %(tfr_time-window_notes)s
+    %(time-window_tfr_notes)s
+
+    %(time_bandwitdh_tfr_note)s
 
     .. versionadded:: 0.9.0
     """

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -579,8 +579,9 @@ def _time_frequency_loop(X, Ws, output, use_fft, mode, decim,
     return tfrs
 
 
+@fill_doc
 def cwt(X, Ws, use_fft=True, mode='same', decim=1):
-    """Compute time freq decomposition with continuous wavelet transform.
+    """Compute time-frequency decomposition with continuous wavelet transform.
 
     Parameters
     ----------
@@ -593,15 +594,7 @@ def cwt(X, Ws, use_fft=True, mode='same', decim=1):
     mode : 'same' | 'valid' | 'full'
         Convention for convolution. 'full' is currently not implemented with
         ``use_fft=False``. Defaults to ``'same'``.
-    decim : int | slice
-        To reduce memory usage, decimation factor after time-frequency
-        decomposition.
-        If `int`, returns tfr[..., ::decim].
-        If `slice`, returns tfr[..., decim].
-
-        .. note:: Decimation may create aliasing artifacts.
-
-        Defaults to 1.
+    %(decim_tfr)s
 
     Returns
     -------
@@ -704,22 +697,14 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False, return_itc=True, decim=1,
     ----------
     inst : Epochs | Evoked
         The epochs or evoked object.
-    freqs : ndarray, shape (n_freqs,)
-        The frequencies in Hz.
-    n_cycles : float | ndarray, shape (n_freqs,)
-        The number of cycles globally or for each frequency.
+    %(freqs_tfr)s
+    %(n_cycles_tfr)s
     use_fft : bool, default False
         The fft based convolution or not.
     return_itc : bool, default True
         Return inter-trial coherence (ITC) as well as averaged power.
         Must be ``False`` for evoked data.
-    decim : int | slice, default 1
-        To reduce memory usage, decimation factor after time-frequency
-        decomposition.
-        If `int`, returns tfr[..., ::decim].
-        If `slice`, returns tfr[..., decim].
-
-        .. note:: Decimation may create aliasing artifacts.
+    %(decim_tfr)s
     %(n_jobs)s
     picks : array-like of int | None, default None
         The indices of the channels to decompose. If None, all available
@@ -730,8 +715,8 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False, return_itc=True, decim=1,
         .. versionadded:: 0.13.0
     %(average_tfr)s
     output : str
-        Can be "power" (default) or "complex". If "complex", then
-        average must be False.
+        Can be ``"power"`` (default) or ``"complex"``. If ``"complex"``, then
+        ``average`` must be ``False``.
 
         .. versionadded:: 0.15.0
     %(verbose)s
@@ -751,6 +736,10 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False, return_itc=True, decim=1,
     mne.time_frequency.tfr_array_multitaper
     mne.time_frequency.tfr_stockwell
     mne.time_frequency.tfr_array_stockwell
+
+    Notes
+    -----
+    %(tfr_time-window_notes)s
     """
     tfr_params = dict(n_cycles=n_cycles, n_jobs=n_jobs, use_fft=use_fft,
                       zero_mean=zero_mean, output=output)
@@ -773,24 +762,13 @@ def tfr_array_morlet(epoch_data, sfreq, freqs, n_cycles=7.0,
         The epochs.
     sfreq : float | int
         Sampling frequency of the data.
-    freqs : array-like of float, shape (n_freqs,)
-        The frequencies.
-    n_cycles : float | array of float, default 7.0
-        Number of cycles in the Morlet wavelet. Fixed number or one per
-        frequency.
+    %(freqs_tfr)s
+    %(n_cycles_tfr)s
     zero_mean : bool | False
         If True, make sure the wavelets have a mean of zero. default False.
     use_fft : bool
         Use the FFT for convolutions or not. default True.
-    decim : int | slice
-        To reduce memory usage, decimation factor after time-frequency
-        decomposition. default 1
-        If `int`, returns tfr[..., ::decim].
-        If `slice`, returns tfr[..., decim].
-
-        .. note::
-            Decimation may create aliasing artifacts, yet decimation
-            is done after the convolutions.
+    %(decim_tfr)s
     output : str, default 'complex'
 
         * 'complex' : single trial complex.
@@ -824,6 +802,8 @@ def tfr_array_morlet(epoch_data, sfreq, freqs, n_cycles=7.0,
 
     Notes
     -----
+    %(tfr_time-window_notes)s
+
     .. versionadded:: 0.14.0
     """
     return _compute_tfr(epoch_data=epoch_data, freqs=freqs,
@@ -847,30 +827,15 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
     ----------
     inst : Epochs | Evoked
         The epochs or evoked object.
-    freqs : ndarray, shape (n_freqs,)
-        The frequencies of interest in Hz.
-    n_cycles : float | ndarray, shape (n_freqs,)
-        The number of cycles globally or for each frequency.
-        The time-window length is thus T = n_cycles / freq.
-    time_bandwidth : float, (optional), default 4.0 (n_tapers=3)
-        Time x (Full) Bandwidth product. Should be >= 2.0.
-        Choose this along with n_cycles to get desired frequency resolution.
-        The number of good tapers (least leakage from far away frequencies)
-        is chosen automatically based on this to floor(time_bandwidth - 1).
-        E.g., With freq = 20 Hz and n_cycles = 10, we get time = 0.5 s.
-        If time_bandwidth = 4., then frequency smoothing is (4 / time) = 8 Hz.
+    %(freqs_tfr)s
+    %(n_cycles_tfr)s
+    %(time_bandwitdh_tfr)s
     use_fft : bool, default True
         The fft based convolution or not.
     return_itc : bool, default True
         Return inter-trial coherence (ITC) as well as averaged (or
         single-trial) power.
-    decim : int | slice, default 1
-        To reduce memory usage, decimation factor after time-frequency
-        decomposition.
-        If `int`, returns tfr[..., ::decim].
-        If `slice`, returns tfr[..., decim].
-
-        .. note:: Decimation may create aliasing artifacts.
+    %(decim_tfr)s
     %(n_jobs)s
     %(picks_good_data)s
     %(average_tfr)s
@@ -894,6 +859,8 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
 
     Notes
     -----
+    %(tfr_time-window_notes)s
+
     .. versionadded:: 0.9.0
     """
     tfr_params = dict(n_cycles=n_cycles, n_jobs=n_jobs, use_fft=use_fft,

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -739,7 +739,7 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False, return_itc=True, decim=1,
 
     Notes
     -----
-    %(time-window_tfr_notes)s
+    %(temporal-window_tfr_notes)s
     """
     tfr_params = dict(n_cycles=n_cycles, n_jobs=n_jobs, use_fft=use_fft,
                       zero_mean=zero_mean, output=output)
@@ -806,7 +806,7 @@ def tfr_array_morlet(epoch_data, sfreq, freqs, n_cycles=7.0,
 
     Notes
     -----
-    %(time-window_tfr_notes)s
+    %(temporal-window_tfr_notes)s
 
     .. versionadded:: 0.14.0
     """
@@ -863,9 +863,9 @@ def tfr_multitaper(inst, freqs, n_cycles, time_bandwidth=4.0,
 
     Notes
     -----
-    %(time-window_tfr_notes)s
+    %(temporal-window_tfr_notes)s
 
-    %(time_bandwidth_tfr_note)s
+    %(time_bandwidth_tfr_notes)s
 
     .. versionadded:: 0.9.0
     """

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -340,7 +340,8 @@ def _compute_tfr(epoch_data, freqs, sfreq=1.0, method='morlet',
         ``'phase'`` results in shape of ``out`` being ``(n_epochs, n_chans,
         n_tapers, n_freqs, n_times)``. If output is ``'avg_power_itc'``, the
         real values in the ``output`` contain average power' and the imaginary
-        values contain the ITC: ``out = avg_power + i * itc``.
+        values contain the inter-trial coherence:
+        ``out = avg_power + i * ITC``.
     """
     # Check data
     epoch_data = np.asarray(epoch_data)

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -690,7 +690,7 @@ def tfr_morlet(inst, freqs, n_cycles, use_fft=False, return_itc=True, decim=1,
     """Compute Time-Frequency Representation (TFR) using Morlet wavelets.
 
     Same computation as `~mne.time_frequency.tfr_array_morlet`, but
-    operates on `~mne.Epochs` objects instead of
+    operates on `~mne.Epochs` or `~mne.Evoked` objects instead of
     :class:`NumPy arrays <numpy.ndarray>`.
 
     Parameters

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -807,6 +807,17 @@ Decimation can be done multiple times. For example,
 ``inst.decimate(4)``.
 """
 
+docdict['decim_tfr'] = """
+decim : int | slice, default 1
+    To reduce memory usage, decimation factor after time-frequency
+    decomposition.
+    - if `int`, returns ``tfr[..., ::decim]``.
+    - if `slice`, returns ``tfr[..., decim]``.
+
+    .. note::
+        Decimation is done after convolutions and may create aliasing
+        artifacts."""
+
 docdict['depth'] = """
 depth : None | float | dict
     How to weight (or normalize) the forward using a depth prior.
@@ -1368,6 +1379,10 @@ forward : instance of Forward | None
 
     .. versionadded:: 0.21
 """
+
+docdict['freqs_tfr'] = """
+freqs : array of float, shape (n_freqs,)
+    The frequencies of interest in Hz."""
 
 docdict['fullscreen'] = """
 fullscreen : bool
@@ -2034,6 +2049,15 @@ docdict['n_comp_pctf_n'] = """
 n_comp : int
     Number of PSF/CTF components to return for mode='max' or mode='svd'.
     Default n_comp=1.
+"""
+
+docdict["n_cycles_tfr"] = """
+n_cycles : int | array of int (n_freqs,)
+    Number of cycles in the wavelet, either a fixed number or one per
+    frequency. The number of cycles ``n_cycles`` and the frequencies of
+    interest ``freqs`` define the time-window length. See notes for
+    additional information about the relationship between those arguments
+    and about time and frequency smoothing.
 """
 
 docdict['n_jobs'] = """\
@@ -3426,6 +3450,32 @@ tail : int
     the distribution.
 """
 
+docdict['tfr_time-window_notes'] = """
+Time-frequency representations are computed using a sliding time-window.
+Either the time-window has a fixed length independent of frequency, or the
+time-window decreases in length with increased frequency.
+
+.. image:: https://www.fieldtriptoolbox.org/assets/img/tutorial/timefrequencyanalysis/figure1.png
+
+*Figure: Time and frequency smoothing. (a) For a fixed length time window
+the time and frequency smoothing remains fixed. (b) For time windows that
+decrease with frequency, the temporal smoothing decreases and the frequency
+smoothing increases.*
+Source: `FieldTrip tutorial: Time-frequency analysis using Hanning window,
+multitapers and wavelets <https://www.fieldtriptoolbox.org/tutorial/timefrequencyanalysis>`_.
+
+In MNE, the time-window length is defined by the arguments ``freqs`` and
+``n_cycles`` respectively defining the frequencies of interest and the
+number of cycles: :math:`T = n_{cycles} / freqs`
+
+A fixed number of cycles for all frequencies will yield a time-window which
+decreases with frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
+``n_cycles=2`` yields ``T=array([2. , 0.7, 0.4])``.
+
+To use a fixed length time-window, the number of cycles has to be defined
+based on the frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
+``n_cycles=freqs / 2`` yields ``T=array([0.5, 0.5, 0.5])``."""  # noqa: E501
+
 _theme = """\
 theme : str | path-like
     Can be "auto", "light", or "dark" or a path-like to a
@@ -3494,6 +3544,17 @@ from :meth:`scipy.stats.rv_continuous.ppf`::
 For a one-tailed test (``tail=1``), don't divide the p-value by 2.
 For testing the lower tail (``tail=-1``), don't subtract ``pval`` from 1.
 """
+
+docdict['time_bandwitdh_tfr'] = """
+time_bandwidth : float
+    Time x (Full) Bandwidth product. Should be ``≥ 2.0``.
+    Choose this along with ``n_cycles`` to set the desired frequency
+    resolution. The number of good tapers (least leakage from far away
+    frequencies) is chosen automatically based on this to
+    floor ``time_bandwidth - 1``.
+    For example, with ``freq = 20 Hz`` and ``n_cycles = 10``, we get
+    ``time = 0.5 s``. If ``time_bandwidth = 4.``, then frequency smoothing
+    is ``(4 / time) = 8 Hz``."""
 
 docdict['time_format'] = """
 time_format : 'float' | 'clock'

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3522,7 +3522,7 @@ For a one-tailed test (``tail=1``), don't divide the p-value by 2.
 For testing the lower tail (``tail=-1``), don't subtract ``pval`` from 1.
 """
 
-docdict['time_bandwitdh_tfr'] = """
+docdict['time_bandwidth_tfr'] = """
 time_bandwidth : float
     Time x (Full) Bandwidth product. Should be ``≥ 2.0``. The frequency
     resolution achieved depends on ``n_cycles`` and ``time_bandwdith``. For a
@@ -3551,7 +3551,7 @@ For example, with a fixed length time-window of ``0.5`` seconds defined by
 
 .. note::
 
-    Frequency resolution, or bandwidth, is also refered to as frequency
+    Frequency resolution, or bandwidth, is also referred to as frequency
     smoothing. The bandwidth is centered around the frequencies of interest
     ``freqs`` and will smooth together the frequencies in its range.
     For example, a bandwidth of 4 Hz at a frequency of interest of 10 Hz will

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3551,7 +3551,7 @@ For testing the lower tail (``tail=-1``), don't subtract ``pval`` from 1.
 docdict['time_bandwidth_tfr'] = """
 time_bandwidth : float ``≥ 2.0``
     Product between the temporal window length (in seconds) and the *full*
-    frequency bandwidth (Hz). This product can be seen as the surface of the
+    frequency bandwidth (in Hz). This product can be seen as the surface of the
     window on the time/frequency plane and controls the frequency bandwidth
     (thus the frequency resolution) and the number of good tapers. See notes
     for additional information."""

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3569,7 +3569,7 @@ frequencies of interest: :math:`T = \frac{\mathtt{n\_cycles}}{\mathtt{freqs}}`.
 The ``time_bandwidth`` parameter defines the "time-bandwidth product", which is
 the product of the temporal window length (in seconds) and the frequency
 bandwidth (in Hz). Thus once ``n_cycles`` has been set, frequency bandwidth is
-determined by :math:`\frac{\mathrm{time bandwidth}}{\mathrm{time window}}`, and
+determined by :math:`\frac{\mathrm{time~bandwidth}}{\mathrm{time~window}}`, and
 thus passing a larger ``time_bandwidth`` value will increase the frequency
 bandwidth (thereby decreasing the frequency *resolution*).
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3562,7 +3562,7 @@ time_bandwidth : float ``≥ 2.0``
     for additional information."""
 
 docdict['time_bandwidth_tfr_notes'] = r"""
-In MNE-Python's multitaper functions, the time-frequency trade-off is
+In MNE-Python's multitaper functions, the frequency bandwidth is
 additionally affected by the parameter ``time_bandwidth``.
 The ``n_cycles`` parameter determines the temporal window length based on the
 frequencies of interest: :math:`T = \frac{\mathtt{n\_cycles}}{\mathtt{freqs}}`.
@@ -3573,16 +3573,16 @@ determined by :math:`\frac{\mathrm{time~bandwidth}}{\mathrm{time~window}}`, and
 thus passing a larger ``time_bandwidth`` value will increase the frequency
 bandwidth (thereby decreasing the frequency *resolution*).
 
-Note that ``time_bandwidth`` also determines the number of tapers used.
-MNE-Python uses only "good" tapers (tapers with minimal leakage from far-away
-frequencies); the number of good tapers is ``floor(time_bandwidth - 1)``. This
-means there is another trade-off at play, between frequency resolution and the
-variance reduction that multitaper analysis provides. Striving for finer
-frequency resolution (by setting ``time_bandwidth`` low) means fewer tapers
-will be used, which undermines what is unique about multitaper methods — namely
-their ability to improve accuracy / reduce noise in the power estimates by
-using several (orthogonal) tapers. This variance reduction comes at the cost of
-having wider frequency bandwidths.
+The increased frequency bandwidth is reached by averaging spectral estimates
+obtained from multiple tapers. Thus, ``time_bandwidth`` also determines the
+number of tapers used. MNE-Python uses only "good" tapers (tapers with minimal
+leakage from far-away frequencies); the number of good tapers is
+``floor(time_bandwidth - 1)``. This means there is another trade-off at play,
+between frequency resolution and the variance reduction that multitaper
+analysis provides. Striving for finer frequency resolution (by setting
+``time_bandwidth`` low) means fewer tapers will be used, which undermines what
+is unique about multitaper methods — namely their ability to improve accuracy /
+reduce noise in the power estimates by using several (orthogonal) tapers.
 
 .. warning::
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3530,39 +3530,45 @@ time_bandwidth : float
     decreasing ``time_bandwidth`` at the cost of the number of good tapers. See
     notes for additional information."""
 
-docdict['time_bandwidth_tfr_note'] = """
-The frequency resolution achieved depends on 2 arguments:
+docdict['time_bandwidth_tfr_notes'] = """
+In multitaper spectrotemporal analysis (as with traditional fourier methods),
+the temporal and spectral resolution are interrelated: longer temporal windows
+allow more precise frequency estimates; shorter temporal windows "smear"
+frequency estimates while providing more precise timing information. In
+MNE-Python's multitaper functions, this time-frequency trade-off is controlled
+by two parameters: ``n_cycles`` and ``time_bandwidth``.
 
-- ``n_cycles``, the number of cycles which defines the time-window length.
-- ``time_bandwitdh``, the product of the time-window length (in seconds) and of
-  the frequency resolution (in Hz), the bandwidth. This product can be seen as
-  the surface of the window on the time/frequency plane.
+The ``n_cycles`` parameter determines the temporal window length based on the
+frequencies of interest: :math:`T = n_{cycles} / freqs`. The ``time_bandwidth``
+parameter provides the "time-bandwidth product", which is the product of the
+temporal window length (in seconds) and of the frequency bandwidth (in Hz).
+Thus once ``n_cycles`` has been set, frequency bandwidth is determined by
+:math:`\frac{time bandwidth}{time window}`, and thus passing a larger
+``time_bandwidth`` value will increase the frequency bandwidth (thereby
+decreasing the frequency *resolution*).
 
-The frequency resolution is
-:math:`fq_{resolution} = {time-bandwitdh} / {time-window}`. Once ``n_cycles``
-is set, the time-window length is fixed. Increasing ``time_bandwidth`` will
-increase the bandwidth, and vice-versa.
+*NB:* ``time_bandwidth`` also determines the number of "good" tapers (tapers
+with minimal leakage from far-away frequencies). In MNE-Python, this is chosen
+as ``floor(time_bandwidth - 1)``. This means there is another trade-off at
+play, between frequency resolution and variance reduction. Striving for finer
+frequency resolution (by setting ``time_bandwidth`` low) means fewer tapers
+will be used, which undermines what is unique about multitaper methods — namely
+their ability to improve accuracy / reduce noise in the power estimates by
+using several (orthogonal) tapers; this comes at the cost of having wider
+frequency bandwidths, AKA spectral smoothing.
 
-For example, with a fixed length time-window of ``0.5`` seconds defined by
-``freqs=np.arange(1, 6, 2)`` and ``n_cycles=freqs / 2``:
+.. warning::
 
-- if ``time_bandwith = 4``, the frequency resolution is :math:`4 / 0.5 = 8 Hz`
-- if ``time_bandwith = 2``, the frequency resolution is :math:`2 / 0.5 = 4 Hz`
+    In `~mne.time_frequency.tfr_array_multitaper` and
+    `~mne.time_frequency.tfr_multitaper`, ``time_bandwidth`` defines the
+    product of the temporal window length with the *full* frequency bandwidth
+    For example, a full bandwidth of 4 Hz at a frequency of interest of 10 Hz
+    will "smear" the frequency estimate between 8 Hz and 12 Hz.
 
-.. note::
-
-    Frequency resolution, or bandwidth, is also referred to as frequency
-    smoothing. The bandwidth is centered around the frequencies of interest
-    ``freqs`` and will smooth together the frequencies in its range.
-    For example, a bandwidth of 4 Hz at a frequency of interest of 10 Hz will
-    smooth together the frequencies ± 2 Hz around 10 Hz, i.e. between 8 Hz and
-    12 Hz.
-
-However, the gained frequency resolution reduces the number of good tapers,
-(least leakage from far away frequencies) chosen as
-:math:`floor(time_bandwith - 1)`. Thus, ``time_bandwith`` should be ``≥ 2.0``
-to yield at least one taper. Increasing the number of tapers will reduce the
-variance (noise) in the power spectral estimates."""
+    This is not the case for `~mne.time_frequency.psd_array_multitaper` and
+    `~mne.time_frequency.psd_multitaper` where the argument ``bandwidth``
+    defines the *half* frequency bandwidth. In the example above, the
+    half-frequency bandwidth is 2 Hz."""
 
 docdict['time_format'] = """
 time_format : 'float' | 'clock'
@@ -3609,30 +3615,30 @@ time_viewer : bool
     ``time_viewer=True`` and ``separate_canvas=False``.
 """
 
-docdict['time-window_tfr_notes'] = """
-Time-frequency representations are computed using a sliding time-window.
-Either the time-window has a fixed length independent of frequency, or the
-time-window decreases in length with increased frequency.
+docdict['temporal-window_tfr_notes'] = """
+Time-frequency representations are computed using a sliding temporal window.
+Either the temporal window has a fixed length independent of frequency, or the
+temporal window decreases in length with increased frequency.
 
 .. image:: https://www.fieldtriptoolbox.org/assets/img/tutorial/timefrequencyanalysis/figure1.png
 
-*Figure: Time and frequency smoothing. (a) For a fixed length time window
-the time and frequency smoothing remains fixed. (b) For time windows that
+*Figure: Time and frequency smoothing. (a) For a fixed length temporal window
+the time and frequency smoothing remains fixed. (b) For temporal windows that
 decrease with frequency, the temporal smoothing decreases and the frequency
 smoothing increases.*
 Source: `FieldTrip tutorial: Time-frequency analysis using Hanning window,
 multitapers and wavelets <https://www.fieldtriptoolbox.org/tutorial/timefrequencyanalysis>`_.
 
-In MNE, the time-window length is defined by the arguments ``freqs`` and
-``n_cycles`` respectively defining the frequencies of interest and the
+In MNE-Python, the temporal window length is defined by the arguments ``freqs``
+and ``n_cycles``, respectively defining the frequencies of interest and the
 number of cycles: :math:`T = n_{cycles} / freqs`
 
-A fixed number of cycles for all frequencies will yield a time-window which
+A fixed number of cycles for all frequencies will yield a temporal window which
 decreases with frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
 ``n_cycles=2`` yields ``T=array([2., 0.7, 0.4])``.
 
-To use a fixed length time-window, the number of cycles has to be defined
-based on the frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
+To use a temporal window with fixed length, the number of cycles has to be
+defined based on the frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
 ``n_cycles=freqs / 2`` yields ``T=array([0.5, 0.5, 0.5])``."""  # noqa: E501
 
 docdict['title_none'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3556,7 +3556,7 @@ time_bandwidth : float
     decreasing ``time_bandwidth`` at the cost of the number of good tapers. See
     notes for additional information."""
 
-docdict['time_bandwidth_tfr_notes'] = """
+docdict['time_bandwidth_tfr_notes'] = r"""
 In multitaper spectrotemporal analysis (as with traditional fourier methods),
 the temporal and spectral resolution are interrelated: longer temporal windows
 allow more precise frequency estimates; shorter temporal windows "smear"

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2058,7 +2058,7 @@ docdict['n_cycles_tfr'] = """
 n_cycles : int | array of int (n_freqs,)
     Number of cycles in the wavelet, either a fixed number or one per
     frequency. The number of cycles ``n_cycles`` and the frequencies of
-    interest ``freqs`` define the time-window length. See notes for
+    interest ``freqs`` define the temporal window length. See notes for
     additional information about the relationship between those arguments
     and about time and frequency smoothing.
 """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3451,32 +3451,6 @@ tail : int
     the distribution.
 """
 
-docdict['tfr_time-window_notes'] = """
-Time-frequency representations are computed using a sliding time-window.
-Either the time-window has a fixed length independent of frequency, or the
-time-window decreases in length with increased frequency.
-
-.. image:: https://www.fieldtriptoolbox.org/assets/img/tutorial/timefrequencyanalysis/figure1.png
-
-*Figure: Time and frequency smoothing. (a) For a fixed length time window
-the time and frequency smoothing remains fixed. (b) For time windows that
-decrease with frequency, the temporal smoothing decreases and the frequency
-smoothing increases.*
-Source: `FieldTrip tutorial: Time-frequency analysis using Hanning window,
-multitapers and wavelets <https://www.fieldtriptoolbox.org/tutorial/timefrequencyanalysis>`_.
-
-In MNE, the time-window length is defined by the arguments ``freqs`` and
-``n_cycles`` respectively defining the frequencies of interest and the
-number of cycles: :math:`T = n_{cycles} / freqs`
-
-A fixed number of cycles for all frequencies will yield a time-window which
-decreases with frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
-``n_cycles=2`` yields ``T=array([2. , 0.7, 0.4])``.
-
-To use a fixed length time-window, the number of cycles has to be defined
-based on the frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
-``n_cycles=freqs / 2`` yields ``T=array([0.5, 0.5, 0.5])``."""  # noqa: E501
-
 _theme = """\
 theme : str | path-like
     Can be "auto", "light", or "dark" or a path-like to a
@@ -3548,14 +3522,45 @@ For testing the lower tail (``tail=-1``), don't subtract ``pval`` from 1.
 
 docdict['time_bandwitdh_tfr'] = """
 time_bandwidth : float
-    Time x (Full) Bandwidth product. Should be ``≥ 2.0``.
-    Choose this along with ``n_cycles`` to set the desired frequency
-    resolution. The number of good tapers (least leakage from far away
-    frequencies) is chosen automatically based on this to
-    floor ``time_bandwidth - 1``.
-    For example, with ``freq = 20 Hz`` and ``n_cycles = 10``, we get
-    ``time = 0.5 s``. If ``time_bandwidth = 4.``, then frequency smoothing
-    is ``(4 / time) = 8 Hz``."""
+    Time x (Full) Bandwidth product. Should be ``≥ 2.0``. The frequency
+    resolution achieved depends on ``n_cycles`` and ``time_bandwdith``. For a
+    given time-window length, a finer frequency resolution is achieved by
+    decreasing ``time_bandwidth`` at the cost of the number of good tapers. See
+    notes for additional information."""
+
+docdict['time_bandwitdh_tfr_note'] = """
+The frequency resolution achieved depends on 2 arguments:
+
+- ``n_cycles``, the number of cycles which defines the time-window length.
+- ``time_bandwitdh``, the product of the time-window length (in seconds) and of
+  the frequency resolution (in Hz), the bandwidth. This product can be seen as
+  the surface of the window on the time/frequency plane.
+
+The frequency resolution is
+:math:`fq_{resolution} = {time-bandwitdh} / {time-window}`. Once ``n_cycles``
+is set, the time-window length is fixed. Increasing ``time_bandwidth`` will
+increase the bandwidth, and vice-versa.
+
+For example, with a fixed length time-window of ``0.5`` seconds defined by
+``freqs=np.arange(1, 6, 2)`` and ``n_cycles=freqs / 2``:
+
+- if ``time_bandwith = 4``, the frequency resolution is :math:`4 / 0.5 = 8 Hz`
+- if ``time_bandwith = 2``, the frequency resolution is :math:`2 / 0.5 = 4 Hz`
+
+.. note::
+
+    Frequency resolution, or bandwitdh, is also refered to as frequency
+    smoothing. The bandwitdth is centered around the frequencies of interest
+    ``freqs`` and will smooth together the frequencies in its range.
+    For example, a bandwidth of 4 Hz at a frequency of interest of 10 Hz will
+    smooth together the frequencies ± 2 Hz around 10 Hz, i.e. between 8 Hz and
+    12 Hz.
+
+However, the gained frequency resolution reduces the number of good tapers,
+(least leakage from far away frequencies) chosen as
+:math:`floor(time_bandwith - 1)`. Thus, ``time_bandwith`` should be ``≥ 2.0``
+to yield at least one taper. Increasing the number of tapers will reduce the
+variance (noise) in the power spectral estimates."""
 
 docdict['time_format'] = """
 time_format : 'float' | 'clock'
@@ -3601,6 +3606,32 @@ time_viewer : bool
     If True, include time viewer traces. Only used if
     ``time_viewer=True`` and ``separate_canvas=False``.
 """
+
+docdict['time-window_tfr_notes'] = """
+Time-frequency representations are computed using a sliding time-window.
+Either the time-window has a fixed length independent of frequency, or the
+time-window decreases in length with increased frequency.
+
+.. image:: https://www.fieldtriptoolbox.org/assets/img/tutorial/timefrequencyanalysis/figure1.png
+
+*Figure: Time and frequency smoothing. (a) For a fixed length time window
+the time and frequency smoothing remains fixed. (b) For time windows that
+decrease with frequency, the temporal smoothing decreases and the frequency
+smoothing increases.*
+Source: `FieldTrip tutorial: Time-frequency analysis using Hanning window,
+multitapers and wavelets <https://www.fieldtriptoolbox.org/tutorial/timefrequencyanalysis>`_.
+
+In MNE, the time-window length is defined by the arguments ``freqs`` and
+``n_cycles`` respectively defining the frequencies of interest and the
+number of cycles: :math:`T = n_{cycles} / freqs`
+
+A fixed number of cycles for all frequencies will yield a time-window which
+decreases with frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
+``n_cycles=2`` yields ``T=array([2. , 0.7, 0.4])``.
+
+To use a fixed length time-window, the number of cycles has to be defined
+based on the frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
+``n_cycles=freqs / 2`` yields ``T=array([0.5, 0.5, 0.5])``."""  # noqa: E501
 
 docdict['title_none'] = """
 title : str | None

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3453,7 +3453,12 @@ tail : int
     the distribution.
 """
 
-docdict['temporal-window_tfr_notes'] = """
+docdict['temporal-window_tfr_notes'] = r"""
+In spectrotemporal analysis (as with traditional fourier methods),
+the temporal and spectral resolution are interrelated: longer temporal windows
+allow more precise frequency estimates; shorter temporal windows "smear"
+frequency estimates while providing more precise timing information.
+
 Time-frequency representations are computed using a sliding temporal window.
 Either the temporal window has a fixed length independent of frequency, or the
 temporal window decreases in length with increased frequency.
@@ -3463,13 +3468,13 @@ temporal window decreases in length with increased frequency.
 *Figure: Time and frequency smoothing. (a) For a fixed length temporal window
 the time and frequency smoothing remains fixed. (b) For temporal windows that
 decrease with frequency, the temporal smoothing decreases and the frequency
-smoothing increases.*
+smoothing increases with frequency.*
 Source: `FieldTrip tutorial: Time-frequency analysis using Hanning window,
 multitapers and wavelets <https://www.fieldtriptoolbox.org/tutorial/timefrequencyanalysis>`_.
 
 In MNE-Python, the temporal window length is defined by the arguments ``freqs``
 and ``n_cycles``, respectively defining the frequencies of interest and the
-number of cycles: :math:`T = n_{cycles} / freqs`
+number of cycles: :math:`T = \frac{n_{cycles}}{freqs}`
 
 A fixed number of cycles for all frequencies will yield a temporal window which
 decreases with frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
@@ -3557,20 +3562,16 @@ time_bandwidth : float ``≥ 2.0``
     for additional information."""
 
 docdict['time_bandwidth_tfr_notes'] = r"""
-In multitaper spectrotemporal analysis (as with traditional fourier methods),
-the temporal and spectral resolution are interrelated: longer temporal windows
-allow more precise frequency estimates; shorter temporal windows "smear"
-frequency estimates while providing more precise timing information. In
-MNE-Python's multitaper functions, this time-frequency trade-off is controlled
-by two parameters: ``n_cycles`` and ``time_bandwidth``.
+In MNE-Python's multitaper functions, the time-frequency trade-off is
+additionally controlled by the parameter ``time_bandwidth``.
 
 The ``n_cycles`` parameter determines the temporal window length based on the
-frequencies of interest: :math:`T = n_{cycles} / freqs`. The ``time_bandwidth``
-parameter provides the "time-bandwidth product", which is the product of the
-temporal window length (in seconds) and of the frequency bandwidth (in Hz).
-Thus once ``n_cycles`` has been set, frequency bandwidth is determined by
-:math:`\frac{time bandwidth}{time window}`, and thus passing a larger
-``time_bandwidth`` value will increase the frequency bandwidth (thereby
+frequencies of interest: :math:`T = \frac{n_{cycles}}{freqs}`. The
+``time_bandwidth`` parameter defines the "time-bandwidth product", which is the
+product of the temporal window length (in seconds) and of the frequency
+bandwidth (in Hz). Thus once ``n_cycles`` has been set, frequency bandwidth is
+determined by :math:`\frac{time bandwidth}{time window}`, and thus passing a
+larger ``time_bandwidth`` value will increase the frequency bandwidth (thereby
 decreasing the frequency *resolution*).
 
 *NB:* ``time_bandwidth`` also determines the number of "good" tapers (tapers

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3474,7 +3474,7 @@ multitapers and wavelets <https://www.fieldtriptoolbox.org/tutorial/timefrequenc
 
 In MNE-Python, the temporal window length is defined by the arguments ``freqs``
 and ``n_cycles``, respectively defining the frequencies of interest and the
-number of cycles: :math:`T = \frac{\mathtt{n\_cycles}}}{\mathtt{freqs}}`
+number of cycles: :math:`T = \frac{\mathtt{n\_cycles}}{\mathtt{freqs}}`
 
 A fixed number of cycles for all frequencies will yield a temporal window which
 decreases with frequency. For example, ``freqs=np.arange(1, 6, 2)`` and

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -811,6 +811,7 @@ docdict['decim_tfr'] = """
 decim : int | slice, default 1
     To reduce memory usage, decimation factor after time-frequency
     decomposition.
+
     - if `int`, returns ``tfr[..., ::decim]``.
     - if `slice`, returns ``tfr[..., decim]``.
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -817,7 +817,8 @@ decim : int | slice, default 1
 
     .. note::
         Decimation is done after convolutions and may create aliasing
-        artifacts."""
+        artifacts.
+"""
 
 docdict['depth'] = """
 depth : None | float | dict
@@ -1383,7 +1384,8 @@ forward : instance of Forward | None
 
 docdict['freqs_tfr'] = """
 freqs : array of float, shape (n_freqs,)
-    The frequencies of interest in Hz."""
+    The frequencies of interest in Hz.
+"""
 
 docdict['fullscreen'] = """
 fullscreen : bool
@@ -3528,7 +3530,7 @@ time_bandwidth : float
     decreasing ``time_bandwidth`` at the cost of the number of good tapers. See
     notes for additional information."""
 
-docdict['time_bandwitdh_tfr_note'] = """
+docdict['time_bandwidth_tfr_note'] = """
 The frequency resolution achieved depends on 2 arguments:
 
 - ``n_cycles``, the number of cycles which defines the time-window length.
@@ -3549,8 +3551,8 @@ For example, with a fixed length time-window of ``0.5`` seconds defined by
 
 .. note::
 
-    Frequency resolution, or bandwitdh, is also refered to as frequency
-    smoothing. The bandwitdth is centered around the frequencies of interest
+    Frequency resolution, or bandwidth, is also refered to as frequency
+    smoothing. The bandwidth is centered around the frequencies of interest
     ``freqs`` and will smooth together the frequencies in its range.
     For example, a bandwidth of 4 Hz at a frequency of interest of 10 Hz will
     smooth together the frequencies ± 2 Hz around 10 Hz, i.e. between 8 Hz and
@@ -3627,7 +3629,7 @@ number of cycles: :math:`T = n_{cycles} / freqs`
 
 A fixed number of cycles for all frequencies will yield a time-window which
 decreases with frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
-``n_cycles=2`` yields ``T=array([2. , 0.7, 0.4])``.
+``n_cycles=2`` yields ``T=array([2., 0.7, 0.4])``.
 
 To use a fixed length time-window, the number of cycles has to be defined
 based on the frequency. For example, ``freqs=np.arange(1, 6, 2)`` and

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1911,7 +1911,7 @@ match_case : bool
     .. versionadded:: 0.20
 """
 
-docdict["max_iter_multitaper"] = """
+docdict['max_iter_multitaper'] = """
 max_iter : int
     Maximum number of iterations to reach convergence when combining the
     tapered spectra with adaptive weights (see argument ``adaptive``). This
@@ -2051,7 +2051,7 @@ n_comp : int
     Default n_comp=1.
 """
 
-docdict["n_cycles_tfr"] = """
+docdict['n_cycles_tfr'] = """
 n_cycles : int | array of int (n_freqs,)
     Number of cycles in the wavelet, either a fixed number or one per
     frequency. The number of cycles ``n_cycles`` and the frequencies of
@@ -2632,7 +2632,7 @@ pipeline : str | tuple
         the SDR step.
 """
 
-docdict["plot_psd_doc"] = """\
+docdict['plot_psd_doc'] = """\
 Plot power or amplitude spectra.
 
 Separate plots are drawn for each channel type. When the data have been

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3453,6 +3453,32 @@ tail : int
     the distribution.
 """
 
+docdict['temporal-window_tfr_notes'] = """
+Time-frequency representations are computed using a sliding temporal window.
+Either the temporal window has a fixed length independent of frequency, or the
+temporal window decreases in length with increased frequency.
+
+.. image:: https://www.fieldtriptoolbox.org/assets/img/tutorial/timefrequencyanalysis/figure1.png
+
+*Figure: Time and frequency smoothing. (a) For a fixed length temporal window
+the time and frequency smoothing remains fixed. (b) For temporal windows that
+decrease with frequency, the temporal smoothing decreases and the frequency
+smoothing increases.*
+Source: `FieldTrip tutorial: Time-frequency analysis using Hanning window,
+multitapers and wavelets <https://www.fieldtriptoolbox.org/tutorial/timefrequencyanalysis>`_.
+
+In MNE-Python, the temporal window length is defined by the arguments ``freqs``
+and ``n_cycles``, respectively defining the frequencies of interest and the
+number of cycles: :math:`T = n_{cycles} / freqs`
+
+A fixed number of cycles for all frequencies will yield a temporal window which
+decreases with frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
+``n_cycles=2`` yields ``T=array([2., 0.7, 0.4])``.
+
+To use a temporal window with fixed length, the number of cycles has to be
+defined based on the frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
+``n_cycles=freqs / 2`` yields ``T=array([0.5, 0.5, 0.5])``."""  # noqa: E501
+
 _theme = """\
 theme : str | path-like
     Can be "auto", "light", or "dark" or a path-like to a
@@ -3614,32 +3640,6 @@ time_viewer : bool
     If True, include time viewer traces. Only used if
     ``time_viewer=True`` and ``separate_canvas=False``.
 """
-
-docdict['temporal-window_tfr_notes'] = """
-Time-frequency representations are computed using a sliding temporal window.
-Either the temporal window has a fixed length independent of frequency, or the
-temporal window decreases in length with increased frequency.
-
-.. image:: https://www.fieldtriptoolbox.org/assets/img/tutorial/timefrequencyanalysis/figure1.png
-
-*Figure: Time and frequency smoothing. (a) For a fixed length temporal window
-the time and frequency smoothing remains fixed. (b) For temporal windows that
-decrease with frequency, the temporal smoothing decreases and the frequency
-smoothing increases.*
-Source: `FieldTrip tutorial: Time-frequency analysis using Hanning window,
-multitapers and wavelets <https://www.fieldtriptoolbox.org/tutorial/timefrequencyanalysis>`_.
-
-In MNE-Python, the temporal window length is defined by the arguments ``freqs``
-and ``n_cycles``, respectively defining the frequencies of interest and the
-number of cycles: :math:`T = n_{cycles} / freqs`
-
-A fixed number of cycles for all frequencies will yield a temporal window which
-decreases with frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
-``n_cycles=2`` yields ``T=array([2., 0.7, 0.4])``.
-
-To use a temporal window with fixed length, the number of cycles has to be
-defined based on the frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
-``n_cycles=freqs / 2`` yields ``T=array([0.5, 0.5, 0.5])``."""  # noqa: E501
 
 docdict['title_none'] = """
 title : str | None

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3549,12 +3549,12 @@ For testing the lower tail (``tail=-1``), don't subtract ``pval`` from 1.
 """
 
 docdict['time_bandwidth_tfr'] = """
-time_bandwidth : float
-    Time x (Full) Bandwidth product. Should be ``≥ 2.0``. The frequency
-    resolution achieved depends on ``n_cycles`` and ``time_bandwdith``. For a
-    given time-window length, a finer frequency resolution is achieved by
-    decreasing ``time_bandwidth`` at the cost of the number of good tapers. See
-    notes for additional information."""
+time_bandwidth : float ``≥ 2.0``
+    Product between the temporal window length (in seconds) and the *full*
+    frequency bandwidth (Hz). This product can be seen as the surface of the
+    window on the time/frequency plane and controls the frequency bandwidth
+    (thus the frequency resolution) and the number of good tapers. See notes
+    for additional information."""
 
 docdict['time_bandwidth_tfr_notes'] = r"""
 In multitaper spectrotemporal analysis (as with traditional fourier methods),

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2055,7 +2055,7 @@ n_comp : int
 """
 
 docdict['n_cycles_tfr'] = """
-n_cycles : int | array of int (n_freqs,)
+n_cycles : int | array of int, shape (n_freqs,)
     Number of cycles in the wavelet, either a fixed number or one per
     frequency. The number of cycles ``n_cycles`` and the frequencies of
     interest ``freqs`` define the temporal window length. See notes for
@@ -3474,7 +3474,7 @@ multitapers and wavelets <https://www.fieldtriptoolbox.org/tutorial/timefrequenc
 
 In MNE-Python, the temporal window length is defined by the arguments ``freqs``
 and ``n_cycles``, respectively defining the frequencies of interest and the
-number of cycles: :math:`T = \frac{n_{cycles}}{freqs}`
+number of cycles: :math:`T = \frac{\mathtt{n\_cycles}}}{\mathtt{freqs}}`
 
 A fixed number of cycles for all frequencies will yield a temporal window which
 decreases with frequency. For example, ``freqs=np.arange(1, 6, 2)`` and
@@ -3563,26 +3563,26 @@ time_bandwidth : float ``≥ 2.0``
 
 docdict['time_bandwidth_tfr_notes'] = r"""
 In MNE-Python's multitaper functions, the time-frequency trade-off is
-additionally controlled by the parameter ``time_bandwidth``.
-
+additionally affected by the parameter ``time_bandwidth``.
 The ``n_cycles`` parameter determines the temporal window length based on the
-frequencies of interest: :math:`T = \frac{n_{cycles}}{freqs}`. The
-``time_bandwidth`` parameter defines the "time-bandwidth product", which is the
-product of the temporal window length (in seconds) and of the frequency
+frequencies of interest: :math:`T = \frac{\mathtt{n\_cycles}}{\mathtt{freqs}}`.
+The ``time_bandwidth`` parameter defines the "time-bandwidth product", which is
+the product of the temporal window length (in seconds) and the frequency
 bandwidth (in Hz). Thus once ``n_cycles`` has been set, frequency bandwidth is
-determined by :math:`\frac{time bandwidth}{time window}`, and thus passing a
-larger ``time_bandwidth`` value will increase the frequency bandwidth (thereby
-decreasing the frequency *resolution*).
+determined by :math:`\frac{\mathrm{time bandwidth}}{\mathrm{time window}}`, and
+thus passing a larger ``time_bandwidth`` value will increase the frequency
+bandwidth (thereby decreasing the frequency *resolution*).
 
-*NB:* ``time_bandwidth`` also determines the number of "good" tapers (tapers
-with minimal leakage from far-away frequencies). In MNE-Python, this is chosen
-as ``floor(time_bandwidth - 1)``. This means there is another trade-off at
-play, between frequency resolution and variance reduction. Striving for finer
+Note that ``time_bandwidth`` also determines the number of tapers used.
+MNE-Python uses only "good" tapers (tapers with minimal leakage from far-away
+frequencies); the number of good tapers is ``floor(time_bandwidth - 1)``. This
+means there is another trade-off at play, between frequency resolution and the
+variance reduction that multitaper analysis provides. Striving for finer
 frequency resolution (by setting ``time_bandwidth`` low) means fewer tapers
 will be used, which undermines what is unique about multitaper methods — namely
 their ability to improve accuracy / reduce noise in the power estimates by
-using several (orthogonal) tapers; this comes at the cost of having wider
-frequency bandwidths, AKA spectral smoothing.
+using several (orthogonal) tapers. This variance reduction comes at the cost of
+having wider frequency bandwidths.
 
 .. warning::
 


### PR DESCRIPTION
I've been giving a shot at TFR representation for the first time today, and it took me a while to grasp how it works. And it's still a bit of a headache for now 🤯 

With that in mind, I'd like to improve the documentation. I've been starting with multitapers, the goal of this PR is to describe better the relation between `freqs`, `n_cycles`, `time-window size`, and `time_bandwith`.
- [x] Update `tfr_array_multitaper`
- [x] Update `tfr_multitaper`
- [ ] ~~Update the tutorial `Time-frequency on simulated data (Multitaper vs. Morlet vs. Stockwell vs. Hilbert)`~~

That said I could really use an advanced course on signal processing one of those days, so please let me know if anything I wrote is wrong! 

---------

**PR Status:** for starters, I'll only update `tfr_array_multitaper`, and once the documentation is consolidated there, I will update `tfr_multitaper`, deduplicate docstrings and update the tutorial. 

Covered:
- [x] freqs
- [x] n_cycles
- [x] time-window size
- [x] time-bandwith
