### PR TITLE
BUG: Fix bugs with passing stdout/stderr to run_subprocess

### DIFF
--- a/mne/utils/tests/test_misc.py
+++ b/mne/utils/tests/test_misc.py
@@ -67,6 +67,7 @@ print('bar', file=sys.{kind})
     log = log.getvalue()
     log = '\n'.join(log.split('\n')[1:])  # get rid of header
     log = log.replace('\r\n', '\n')  # Windows
+    orig_log = log
     stdout = stdout.replace('\r\n', '\n')
     stderr = stderr.replace('\r\n', '\n')
     if do_raise:  # remove traceback
@@ -85,7 +86,7 @@ print('bar', file=sys.{kind})
         if stderr:
             stderr += '\n'
     want = 'foo\nbar\n'
-    assert log == want
+    assert log == want, orig_log
     if kind == 'stdout':
         std = stdout
         other = stderr

--- a/mne/utils/tests/test_misc.py
+++ b/mne/utils/tests/test_misc.py
@@ -74,20 +74,19 @@ time.sleep(0.02)
     stdout = stdout.replace('\r\n', '\n')
     stderr = stderr.replace('\r\n', '\n')
     if do_raise:  # remove traceback
-        tb_line = np.where(
-            [line.startswith('Traceback') for line in log.split('\n')])[0]
-        assert len(tb_line) == 1
-        tb_line = tb_line[0]
-        log = '\n'.join(log.split('\n')[:tb_line])
-        if log:
-            log += '\n'
-        tb_line = np.where(
-            [line.startswith('Traceback') for line in stderr.split('\n')])[0]
-        assert len(tb_line) == 1
-        tb_line = tb_line[0]
-        stderr = '\n'.join(stderr.split('\n')[:tb_line])
-        if stderr:
-            stderr += '\n'
+
+        def truncate_before_traceback(log):
+            tb_line = np.where(
+                [line.startswith('Traceback') for line in log.split('\n')])[0]
+            assert len(tb_line) == 1
+            tb_line = tb_line[0]
+            log = '\n'.join(log.split('\n')[:tb_line])
+            if log:
+                log += '\n'
+            return log
+
+        log = truncate_before_traceback(log)
+        stderr = truncate_before_traceback(stderr)
     want = 'foo\nbar\n'
     assert log == want, orig_log
     if kind == 'stdout':

--- a/mne/utils/tests/test_misc.py
+++ b/mne/utils/tests/test_misc.py
@@ -1,4 +1,6 @@
+from contextlib import nullcontext
 import os
+import subprocess
 import sys
 
 import pytest
@@ -35,25 +37,88 @@ def test_html_repr():
 
 
 @pytest.mark.parametrize('kind', ('stdout', 'stderr'))
-def test_run_subprocess(tmp_path, kind):
+@pytest.mark.parametrize('do_raise', (True, False))
+def test_run_subprocess(tmp_path, capsys, kind, do_raise):
     """Test run_subprocess."""
     fname = tmp_path / 'subp.py'
+    extra = ''
+    if do_raise:
+        extra = """
+raise RuntimeError('This is a test')
+"""
+        raise_context = pytest.raises(subprocess.CalledProcessError)
+    else:
+        extra = ''
+        raise_context = nullcontext()
     with open(fname, 'w') as fid:
         fid.write(f"""\
 import sys
 print('foo', file=sys.{kind})
 print('bar', file=sys.{kind})
-""")
-    with catch_logging() as log:
+""" + extra)
+    with catch_logging() as log, raise_context:
         stdout, stderr = run_subprocess(
             [sys.executable, str(fname)], verbose=True)
+    if do_raise:
+        exc = raise_context.excinfo.value
+        stdout = exc.stdout
+        stderr = exc.stderr
     log = log.getvalue()
     log = '\n'.join(log.split('\n')[1:])  # get rid of header
     log = log.replace('\r\n', '\n')  # Windows
     stdout = stdout.replace('\r\n', '\n')
     stderr = stderr.replace('\r\n', '\n')
+    if do_raise:  # remove traceback
+        log = '\n'.join(log.split('\n')[:2]) + '\n'
+        stderr = '\n'.join(stderr.split('\n')[:-5])
+        if stderr:
+            stderr += '\n'
     want = 'foo\nbar\n'
     assert log == want
+    if kind == 'stdout':
+        std = stdout
+        other = stderr
+    else:
+        std = stderr
+        other = stdout
+    assert std == want
+    assert other == ''
+    stdout, stderr = capsys.readouterr()
+    assert stdout == ''
+    assert stderr == ''
+
+    # Now make sure we can pass other stuff as stdout/stderr
+    capsys.readouterr()  # clear
+    stdout_fname = tmp_path / 'stdout.txt'
+    stderr_fname = tmp_path / 'stderr.txt'
+    stdout_file = open(stdout_fname, 'w')
+    stderr_file = open(stderr_fname, 'w')
+    if do_raise:
+        raise_context = pytest.raises(subprocess.CalledProcessError)
+    else:
+        raise_context = nullcontext()
+    with catch_logging() as log, stdout_file, stderr_file, raise_context:
+        stdout, stderr = run_subprocess(
+            [sys.executable, str(fname)], verbose=False,
+            stdout=stdout_file, stderr=stderr_file)
+    if do_raise:
+        exc = raise_context.excinfo.value
+        assert exc.stdout is None
+        assert exc.stderr is None
+    else:
+        assert stdout == ''
+        assert stderr == ''
+    log = log.getvalue()
+    assert log == ''
+    stdout, stderr = capsys.readouterr()
+    assert stdout == ''
+    assert stderr == ''
+    stdout = stdout_fname.read_text()
+    stderr = stderr_fname.read_text()
+    if do_raise:
+        stderr = '\n'.join(stderr.split('\n')[:-5])
+        if stderr:
+            stderr += '\n'
     if kind == 'stdout':
         std = stdout
         other = stderr

--- a/mne/utils/tests/test_misc.py
+++ b/mne/utils/tests/test_misc.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 
+import numpy as np
 import pytest
 
 import mne
@@ -69,8 +70,18 @@ print('bar', file=sys.{kind})
     stdout = stdout.replace('\r\n', '\n')
     stderr = stderr.replace('\r\n', '\n')
     if do_raise:  # remove traceback
-        log = '\n'.join(log.split('\n')[:2]) + '\n'
-        stderr = '\n'.join(stderr.split('\n')[:-5])
+        tb_line = np.where(
+            [line.startswith('Traceback') for line in log.split('\n')])[0]
+        assert len(tb_line) == 1
+        tb_line = tb_line[0]
+        log = '\n'.join(log.split('\n')[:tb_line])
+        if log:
+            log += '\n'
+        tb_line = np.where(
+            [line.startswith('Traceback') for line in stderr.split('\n')])[0]
+        assert len(tb_line) == 1
+        tb_line = tb_line[0]
+        stderr = '\n'.join(stderr.split('\n')[:tb_line])
         if stderr:
             stderr += '\n'
     want = 'foo\nbar\n'

--- a/mne/utils/tests/test_misc.py
+++ b/mne/utils/tests/test_misc.py
@@ -54,8 +54,11 @@ raise RuntimeError('This is a test')
     with open(fname, 'w') as fid:
         fid.write(f"""\
 import sys
+import time
 print('foo', file=sys.{kind})
 print('bar', file=sys.{kind})
+sys.{kind}.flush()
+time.sleep(0.02)
 """ + extra)
     with catch_logging() as log, raise_context:
         stdout, stderr = run_subprocess(


### PR DESCRIPTION
Over in `mne-bids-pipeline` I want to call `run_subprocess(..., stdout=sys.stdout, stderr=sys.stderr)` because I don't want to capture the output when entering debug mode on failure. This should be fine, but on `main` we get:

1. An error message at the beginning of the `run_subprocess` call
2. An error message at the end of the `run_subprocess` call
3. A `print` of the `(stdout, stderr)` tuple, which we didn't ask for and is also two empty strings anyway

See:

<details>

```
📝 Running the following tests in debug mode: ERP_CORE_ERN
Exception in thread Thread-1 (_enqueue_output):
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
Exception in thread Thread-2 (_enqueue_output):
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
    self._target(*self._args, **self._kwargs)
  File "/home/larsoner/python/mne-python/mne/utils/misc.py", line 85, in _enqueue_output
  File "/home/larsoner/python/mne-python/mne/utils/misc.py", line 85, in _enqueue_output
    for line in iter(out.readline, b''):
    for line in iter(out.readline, b''):
AttributeError: 'NoneType' object has no attribute 'readline'
AttributeError: 'NoneType' object has no attribute 'readline'
[2022-10-20 12:15:46] ╶╴👋 Welcome aboard the MNE BIDS Pipeline!
...
[2022-10-20 12:16:06] │ ⏳️ report/_01_make_reports sub-015 ses-ERN A critical error occurred. The error message was: /home/larsoner/mne_data/derivatives/mne-bids-pipeline/ERP_CORE/sub-015/ses-ERN/eeg/sub-015_ses-ERN_task-ERN_proc-responseincorrect+responsecorrect+CSP+rocauc_decoding.mat

Starting post-mortem debugger.
Traceback (most recent call last):
  File "/home/larsoner/python/mne-bids-pipeline/mne_bids_pipeline/config.py", line 2932, in wrapper
    out = memory.cache(func)(*args, **kwargs)
  File "/home/larsoner/python/mne-bids-pipeline/mne_bids_pipeline/config.py", line 3024, in wrapper
    func(*args, **kwargs)
  File "/home/larsoner/python/mne-bids-pipeline/mne_bids_pipeline/scripts/report/_01_make_reports.py", line 1319, in run_report
    report = run_report_sensor(**kwargs)
  File "/home/larsoner/python/mne-bids-pipeline/mne_bids_pipeline/scripts/report/_01_make_reports.py", line 1020, in run_report_sensor
    assert fname_decoding.fpath.is_file(), fname_decoding.fpath
AssertionError: /home/larsoner/mne_data/derivatives/mne-bids-pipeline/ERP_CORE/sub-015/ses-ERN/eeg/sub-015_ses-ERN_task-ERN_proc-responseincorrect+responsecorrect+CSP+rocauc_decoding.mat
> /home/larsoner/python/mne-bids-pipeline/mne_bids_pipeline/scripts/report/_01_make_reports.py(1020)run_report_sensor()
-> assert fname_decoding.fpath.is_file(), fname_decoding.fpath
(Pdb) q
('', '')
Traceback (most recent call last):
  File "/home/larsoner/python/mne-bids-pipeline/mne_bids_pipeline/tests/run_tests.py", line 255, in <module>
    run_tests(test_suite, download=download, debug=debug, cache=cache)
  File "/home/larsoner/python/mne-bids-pipeline/mne_bids_pipeline/tests/run_tests.py", line 198, in run_tests
    run_subprocess(command=command, stdout=sys.stdout, stderr=sys.stderr)
  File "<decorator-gen-1>", line 12, in run_subprocess
  File "/home/larsoner/python/mne-python/mne/utils/misc.py", line 199, in run_subprocess
    raise subprocess.CalledProcessError(p.returncode, command, output)
subprocess.CalledProcessError: Command '['mne_bids_pipeline', '--config=/home/larsoner/python/mne-bids-pipeline/mne_bids_pipeline/tests/configs/config_ERP_CORE.py', '--steps=preprocessing,sensor,report', '--task=ERN', '--n_jobs=1', '--debug=1', '--interactive=0']' returned non-zero exit status 1.

```

</details>

This PR fixes this problem by:

1. Keeping track of whether *we* are in control of `stdout` and `stderr`
2. Only context-managing them (now with `ExitStack`) if we are in control
3. Only doing `readline` on them if we are in control
4. Removing the errant/crufty `print` statement

For (4), if callers really want this information printed, they should catch the exception and get it from the `CalledProcessError` like we do in the updated tests.