### PR TITLE
BUG: Correctly detect MESA

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -33,6 +33,7 @@ Bugs
 - Fix X coordinates of ear_left and ear_right in head outlines dict (:gh:`11255` by :newcontrib:`Tom Ma`)
 - Add type checking for ``tmin`` and ``tmax`` arguments for ``crop`` (:gh:`11263` by :newcontrib:`Carlos de la Torre-Ortiz`).
 - Fix bug where ``ica.reject_`` was not saved to disk, and the ``ica.reject_`` property was not inherited from ``Epochs`` when doing ``ICA.fit(epochs)`` (:gh:`11244` by `Eric Larson`_)
+- Fix bug in automatic MESA detection for disabling advanced 3D options (:gh:`11271` by `Eric Larson`_)
 - Fix bug in the ``.compute_psd()`` methods where the number of unaggregated Welch segments was wrongly computed for some inputs, leading to an assertion error when computing the PSD (:gh:`11248` by `Daniel McCloy`_)
 
 API changes

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -1214,8 +1214,9 @@ def _is_mesa(plotter):
         if version:
             version = version[0]
             if _compare_version(version, '<', '18.3.6'):
-                warn('Mesa version %s is too old for translucent 3D surface '
-                     'rendering, consider upgrading to 18.3.6 or later')
+                warn(f'Mesa version {version} is too old for translucent 3D '
+                     'surface rendering, consider upgrading to 18.3.6 or '
+                     'later.')
         else:
             raise RuntimeError
     return is_mesa

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -33,7 +33,8 @@ from qtpy.QtWidgets import (QComboBox, QGroupBox, QHBoxLayout, QLabel,
 
 from ._pyvista import _PyVistaRenderer
 from ._pyvista import (_close_3d_figure, _check_3d_figure, _close_all,  # noqa: F401,E501 analysis:ignore
-                       _set_3d_view, _set_3d_title, _take_3d_screenshot)  # noqa: F401,E501 analysis:ignore
+                       _set_3d_view, _set_3d_title, _take_3d_screenshot,  # noqa: F401,E501 analysis:ignore
+                       _is_mesa)  # noqa: F401,E501 analysis:ignore
 from ._abstract import (_AbstractAppWindow, _AbstractHBoxLayout,
                         _AbstractVBoxLayout, _AbstractGridLayout,
                         _AbstractWidget, _AbstractCanvas,

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -214,7 +214,7 @@ def test_3d_warning(renderer_pyvistaqt, monkeypatch):
     monkeypatch.setattr(plotter.ren_win, 'ReportCapabilities', lambda: good)
     assert _is_mesa(plotter)
     monkeypatch.setattr(plotter.ren_win, 'ReportCapabilities', lambda: bad)
-    with pytest.warns(RuntimeWarning, match='too old'):
+    with pytest.warns(RuntimeWarning, match=r'18\.3\.4 is too old'):
         assert _is_mesa(plotter)
     non = 'OpenGL 4.1 Metal - 76.3 via Apple M1 Pro\n'
     monkeypatch.setattr(plotter.ren_win, 'ReportCapabilities', lambda: non)

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -339,7 +339,9 @@ def test_plot_topomap_basic():
 
     p = plt_topomap(times, ch_type='grad', image_interp='cubic',
                     show_names=lambda x: x.replace('MEG', ''))
-    subplot = [x for x in p.get_children() if 'Subplot' in str(type(x))]
+    subplot = [
+        x for x in p.get_children()
+        if any(t in str(type(x)) for t in ('Axes', 'Subplot'))]
     assert len(subplot) >= 1, [type(x) for x in p.get_children()]
     subplot = subplot[0]
 


### PR DESCRIPTION
Closes #10991

Fixes a bug with Mesa detection, and now emits a warning if someone is using a version of MESA that is too old to work.