### PR TITLE
DOC: Avoid documenting base class methods

### DIFF
--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -1,4 +1,4 @@
-{{ fullname | escape | underline}}
+{{ fullname | escape | underline }}
 
 .. currentmodule:: {{ module }}
 

--- a/doc/_templates/autosummary/class_no_inherited_members.rst
+++ b/doc/_templates/autosummary/class_no_inherited_members.rst
@@ -1,4 +1,4 @@
-{{ fullname | escape | underline}}
+{{ fullname | escape | underline }}
 
 .. currentmodule:: {{ module }}
 

--- a/doc/_templates/autosummary/class_no_members.rst
+++ b/doc/_templates/autosummary/class_no_members.rst
@@ -1,4 +1,4 @@
-{{ fullname | escape | underline}}
+{{ fullname | escape | underline }}
 
 .. currentmodule:: {{ module }}
 

--- a/doc/_templates/autosummary/class_no_members.rst
+++ b/doc/_templates/autosummary/class_no_members.rst
@@ -1,0 +1,8 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :no-special-members:
+   :no-members:
+   :no-inherited-members:

--- a/doc/_templates/autosummary/function.rst
+++ b/doc/_templates/autosummary/function.rst
@@ -1,4 +1,4 @@
-{{ fullname | escape | underline}}
+{{ fullname | escape | underline }}
 
 .. currentmodule:: {{ module }}
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -586,6 +586,11 @@ nitpick_ignore = [
     ("py:class", "_FuncT"),  # type hint used in @verbose decorator
     ("py:class", "mne.utils._logging._FuncT"),
 ]
+nitpick_ignore_regex = [
+    ('py:.*', r"mne\.io\.BaseRaw.*"),
+    ('py:.*', r"mne\.BaseEpochs.*"),
+    ('py:obj', "(filename|metadata|proj|times|tmax|tmin|annotations|ch_names|compensation_grade|filenames|first_samp|first_time|last_samp|n_times|proj|times|tmax|tmin)"),  # noqa: E501
+]
 suppress_warnings = ['image.nonlocal_uri']  # we intentionally link outside
 
 

--- a/doc/file_io.rst
+++ b/doc/file_io.rst
@@ -59,5 +59,6 @@ Base class:
 
 .. autosummary::
    :toctree: generated
+   :template: autosummary/class_no_members.rst
 
    BaseEpochs

--- a/doc/reading_raw_data.rst
+++ b/doc/reading_raw_data.rst
@@ -42,6 +42,7 @@ Base class:
 
 .. autosummary::
    :toctree: generated
+   :template: autosummary/class_no_members.rst
 
    BaseRaw
 


### PR DESCRIPTION
For #11173, avoid documenting BaseRaw and BaseEpochs methods. This makes it so that searching `plot_psd` for example no longer shows BaseRaw or BaseEpochs. It's not perfect because the pages still list the names, but I think this is okay -- end-users will ignore these and can easily look at `Raw` or `Epochs` for them.