### PR TITLE
Fix misbehaving legend colors in plot_evoked_topo

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -36,7 +36,7 @@ Bugs
 - Fix bug where ``ica.reject_`` was not saved to disk, and the ``ica.reject_`` property was not inherited from ``Epochs`` when doing ``ICA.fit(epochs)`` (:gh:`11244` by `Eric Larson`_)
 - Fix bug in automatic MESA detection for disabling advanced 3D options (:gh:`11271` by `Eric Larson`_)
 - Fix bug in the ``.compute_psd()`` methods where the number of unaggregated Welch segments was wrongly computed for some inputs, leading to an assertion error when computing the PSD (:gh:`11248` by `Daniel McCloy`_)
-- Fix bug in the ``mne.viz.plot_evoked_topo``, where legend colors where shown incorrectly on newer matplotlib versions (:gh:`11258` by `Erkka Heinila`_)
+- Fix bug in the :func:`~mne.viz.plot_evoked_topo` and :meth:`~mne.Evoked.plot_topo`, where legend colors where shown incorrectly on newer matplotlib versions (:gh:`11258` by `Erkka Heinila`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -36,6 +36,7 @@ Bugs
 - Fix bug where ``ica.reject_`` was not saved to disk, and the ``ica.reject_`` property was not inherited from ``Epochs`` when doing ``ICA.fit(epochs)`` (:gh:`11244` by `Eric Larson`_)
 - Fix bug in automatic MESA detection for disabling advanced 3D options (:gh:`11271` by `Eric Larson`_)
 - Fix bug in the ``.compute_psd()`` methods where the number of unaggregated Welch segments was wrongly computed for some inputs, leading to an assertion error when computing the PSD (:gh:`11248` by `Daniel McCloy`_)
+- Fix bug in the ``mne.viz.plot_evoked_topo``, where legend colors where shown incorrectly on newer matplotlib versions (:gh:`11258` by `Erkka Heinila`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -139,7 +139,8 @@ def test_plot_topo():
     colors = ['red', 'blue']
     fig = plot_evoked_topo([evoked, evoked], merge_grads=True, color=colors)
     legend = fig.axes[0].get_legend()
-    legend_colors = [line.properties()['markeredgecolor'] for line in legend.get_lines()]
+    legend_colors = [line.properties()['markeredgecolor']
+                     for line in legend.get_lines()]
     assert legend_colors == colors
 
     with pytest.raises(ValueError, match='must be .*tuple, list, str,.*'):

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -135,6 +135,13 @@ def test_plot_topo():
     plot_evoked_topo([evoked, evoked], merge_grads=True,
                      background_color='w', color='blue')
 
+    # test legend colors
+    colors = ['red', 'blue']
+    fig = plot_evoked_topo([evoked, evoked], merge_grads=True, color=colors)
+    legend = fig.axes[0].get_legend()
+    legend_colors = [line.properties()['markeredgecolor'] for line in legend.get_lines()]
+    assert legend_colors == colors
+
     with pytest.raises(ValueError, match='must be .*tuple, list, str,.*'):
         plot_evoked_topo([evoked, evoked], merge_grads=True,
                          color=np.array(["blue", "red"]))

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -794,8 +794,12 @@ def _plot_evoked_topo(evoked, layout=None, layout_scale=0.945,
     if legend is not False:
         legend_loc = 0 if legend is True else legend
         labels = [e.comment if e.comment else 'Unknown' for e in evoked]
-        legend = plt.legend(labels, loc=legend_loc,
-                            prop={'size': 10})
+        handles = fig.axes[0].lines[:len(evoked)]
+        legend = plt.legend(
+            labels=labels,
+            handles=handles,
+            loc=legend_loc,
+            prop={'size': 10})
         legend.get_frame().set_facecolor(axis_facecolor)
         txts = legend.get_texts()
         for txt, col in zip(txts, color):


### PR DESCRIPTION
#### Reference issue

Fixes #11258.

#### What does this implement/fix?

Lines of the first plot are now explicitly passed to plt.legend as handles. 

Includes one test.
