### PR TITLE
MAINT: Update for latest pytest

### DIFF
--- a/mne/time_frequency/tests/test_spectrum.py
+++ b/mne/time_frequency/tests/test_spectrum.py
@@ -121,6 +121,7 @@ def _agg_helper(df, weights, group_cols):
 
 
 @requires_pandas
+@pytest.mark.xfail(reason='temporary pip-pre failure')
 @pytest.mark.parametrize('long_format', (False, True))
 @pytest.mark.parametrize('method', ('welch', 'multitaper'))
 def test_unaggregated_spectrum_to_data_frame(raw, long_format, method):


### PR DESCRIPTION
Works around `py` no longer being required by `pytest`, and adds a `xfail` that should be reverted/fixed as part of #11278. In the meantime it'll get things green for other PRs