### PR TITLE
BUG: Work around ppc64le bugs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,7 +116,7 @@ stages:
     - bash: |
         set -e
         python -m pip install --progress-bar off --upgrade pip setuptools wheel codecov
-        python -m pip install --progress-bar off mne-qt-browser[opengl] pyvista scikit-learn pytest-error-for-skips python-picard "PySide6!=6.3.0,!=6.4" qtpy
+        python -m pip install --progress-bar off mne-qt-browser[opengl] pyvista scikit-learn pytest-error-for-skips python-picard "PySide6!=6.3.0,!=6.4.0,!=6.4.0.1" qtpy
         python -m pip uninstall -yq mne
         python -m pip install --progress-bar off --upgrade -e .[test]
       displayName: 'Install dependencies with pip'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,7 +116,7 @@ stages:
     - bash: |
         set -e
         python -m pip install --progress-bar off --upgrade pip setuptools wheel codecov
-        python -m pip install --progress-bar off mne-qt-browser[opengl] pyvista scikit-learn pytest-error-for-skips python-picard "PySide6!=6.3.0,!=6.4.0" qtpy
+        python -m pip install --progress-bar off mne-qt-browser[opengl] pyvista scikit-learn pytest-error-for-skips python-picard "PySide6!=6.3.0,!=6.4" qtpy
         python -m pip uninstall -yq mne
         python -m pip install --progress-bar off --upgrade -e .[test]
       displayName: 'Install dependencies with pip'

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -225,14 +225,10 @@ def _mixed_norm_solver_bcd(M, G, alpha, lipschitz_constant, maxit=200,
                 # equivalent to:
                 # z = np.linalg.solve(C, np.ones(K))
                 u, s, _ = np.linalg.svd(C, hermitian=True)
-                if s[-1] <= 1e-6 * s[0]:
+                if s[-1] <= 1e-6 * s[0] or not np.isfinite(s).all():
                     logger.debug("Iteration %d: LinAlg Error" % (i + 1))
                     continue
                 z = ((u * 1 / s) @ u.T).sum(0)
-                if z.sum() == 0:
-                    # This can happen on aarch64
-                    logger.debug("Iteration %d: Z-sum Error" % (i + 1))
-                    continue
                 c = z / z.sum()
                 X_acc = np.sum(
                     last_K_X[:-1] * c[:, None, None], axis=0

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -229,6 +229,10 @@ def _mixed_norm_solver_bcd(M, G, alpha, lipschitz_constant, maxit=200,
                     logger.debug("Iteration %d: LinAlg Error" % (i + 1))
                     continue
                 z = ((u * 1 / s) @ u.T).sum(0)
+                if z.sum() == 0:
+                    # This can happen on aarch64
+                    logger.debug("Iteration %d: Z-sum Error" % (i + 1))
+                    continue
                 c = z / z.sum()
                 X_acc = np.sum(
                     last_K_X[:-1] * c[:, None, None], axis=0

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -99,6 +99,8 @@ def test_time_frequency():
         tfr_morlet(epochs_nopicks,
                    freqs=freqs, n_cycles=n_cycles, use_fft=True,
                    return_itc=False, picks=picks, average=False)
+    assert_allclose(
+        epochs_power_picks.data[0, 0, 0, 0], 9.130315e-23, rtol=1e-4)
     power_picks_avg = epochs_power_picks.average()
     # the actual data arrays here are equivalent, too...
     assert_allclose(power.data, power_picks.data)

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -248,7 +248,12 @@ def _cwt_gen(X, Ws, *, fsize=0, mode="same", decim=1, use_fft=True):
             if use_fft:
                 ret = ifft(fft_x * fft_Ws[ii])[:n_times + W.size - 1]
             else:
-                ret = np.convolve(x, W, mode=mode)
+                # Work around multarray.correlate->OpenBLAS bug on ppc64le
+                # ret = np.correlate(x, W, mode=mode)
+                ret = (
+                    np.convolve(x, W.real, mode=mode) +
+                    1j * np.convolve(x, W.imag, mode=mode)
+                )
 
             # Center and decimate decomposition
             if mode == 'valid':

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ h5io
 packaging
 pymatreader
 qtpy
-PySide6!=6.3.0,!=6.4  # incompat with Matplotlib 3.6.1 and qtpy
+PySide6!=6.3.0,!=6.4.0,!=6.4.0.1  # incompat with Matplotlib 3.6.1 and qtpy
 pyobjc-framework-Cocoa>=5.2.0; platform_system=="Darwin"
 sip
 scikit-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ h5io
 packaging
 pymatreader
 qtpy
-PySide6!=6.3.0,!=6.4.0  # incompat with Matplotlib 3.6.1
+PySide6!=6.3.0,!=6.4  # incompat with Matplotlib 3.6.1 and qtpy
 pyobjc-framework-Cocoa>=5.2.0; platform_system=="Darwin"
 sip
 scikit-learn


### PR DESCRIPTION
Closes #10985
Closes #10984

Ubuntu 22.10 fixed the QEMU bug that was stopping me from tracking this down. There must be a bug in OpenBLAS 3.19 with `np.convolve`->`multiarray.correlate` for complex arrays, but I haven't followed the chain to see what this wraps to under the hood. In the meantime, this workaround should be fine and have a negligible performance hit.