### PR TITLE
make compute_psd work on a BaseEpochs instance

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -37,6 +37,7 @@ Bugs
 - Fix bug in automatic MESA detection for disabling advanced 3D options (:gh:`11271` by `Eric Larson`_)
 - Fix bug in the ``.compute_psd()`` methods where the number of unaggregated Welch segments was wrongly computed for some inputs, leading to an assertion error when computing the PSD (:gh:`11248` by `Daniel McCloy`_)
 - Fix bug in the :func:`~mne.viz.plot_evoked_topo` and :meth:`~mne.Evoked.plot_topo`, where legend colors where shown incorrectly on newer matplotlib versions (:gh:`11258` by `Erkka Heinila`_)
+- Fix bug in the ``.compute_psd()`` method when applied on a ``BaseEpochs`` instance (:gh:`11287` by `Alex Gramfort`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -412,7 +412,7 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
         from .. import BaseEpochs, Evoked, EvokedArray
         from ..io import BaseRaw
 
-        parent_classes = self._inst_type.__bases__
+        parent_classes = list(self._inst_type.__bases__) + [self._inst_type]
         if BaseRaw in parent_classes:
             inst_type_str = 'Raw'
         elif BaseEpochs in parent_classes:

--- a/mne/time_frequency/tests/test_spectrum.py
+++ b/mne/time_frequency/tests/test_spectrum.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_array_equal
 from mne.time_frequency import read_spectrum
 from mne.time_frequency.multitaper import _psd_from_mt
 from mne.utils import requires_h5py, requires_pandas
+from mne.epochs import BaseEpochs
 
 
 def test_spectrum_errors(raw):
@@ -92,6 +93,17 @@ def test_spectrum_getitem_raw(raw):
 
 def test_spectrum_getitem_epochs(epochs):
     """Test Spectrum.__getitem__ for Epochs-derived spectra."""
+    spect = epochs.compute_psd()
+    # testing data has just one epoch, its event_id label is "1"
+    want = spect.get_data()
+    got = spect['1'].get_data()
+    assert_array_equal(want, got)
+
+
+def test_spectrum_base_epochs(epochs):
+    """Test Spectrum.__getitem__ for Epochs-derived spectra."""
+    epochs = BaseEpochs(epochs.info, epochs.get_data(), epochs.events,
+                        epochs.event_id, epochs.tmin, epochs.tmax)
     spect = epochs.compute_psd()
     # testing data has just one epoch, its event_id label is "1"
     want = spect.get_data()


### PR DESCRIPTION
BaseEpochs can appear from the code base eg when concatenating Epochs.