### PR TITLE
[MRG] Remove remaining use of op.join on Path objects in tutorials and examples

### DIFF
--- a/examples/visualization/publication_figure.py
+++ b/examples/visualization/publication_figure.py
@@ -21,8 +21,6 @@ customize them for a more publication-ready look.
 # -------
 # We are importing everything we need for this example:
 
-import os.path as op
-
 import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import (make_axes_locatable, ImageGrid,
@@ -39,9 +37,9 @@ import mne
 # start by loading some :ref:`example data <sample-dataset>`.
 
 data_path = mne.datasets.sample.data_path()
-subjects_dir = op.join(data_path, 'subjects')
-fname_stc = op.join(data_path, 'MEG', 'sample', 'sample_audvis-meg-eeg-lh.stc')
-fname_evoked = op.join(data_path, 'MEG', 'sample', 'sample_audvis-ave.fif')
+subjects_dir = data_path / 'subjects'
+fname_stc = data_path / 'MEG' / 'sample' / 'sample_audvis-meg-eeg-lh.stc'
+fname_evoked = data_path / 'MEG' / 'sample' / 'sample_audvis-ave.fif'
 
 evoked = mne.read_evokeds(fname_evoked, 'Left Auditory')
 evoked.pick_types(meg='grad').apply_baseline((None, 0.))
@@ -195,7 +193,7 @@ for ax, label in zip(axes, 'AB'):
 # Let's start by loading some :ref:`example data <sample-dataset>`.
 
 data_path = mne.datasets.sample.data_path()
-fname_raw = op.join(data_path, "MEG", "sample", "sample_audvis_raw.fif")
+fname_raw = data_path / "MEG" / "sample" / "sample_audvis_raw.fif"
 raw = mne.io.read_raw_fif(fname_raw)
 
 # For the sake of the example, we focus on EEG data

--- a/examples/visualization/sensor_noise_level.py
+++ b/examples/visualization/sensor_noise_level.py
@@ -15,13 +15,13 @@ of systems. See :footcite:`KhanCohen2013` for an example.
 
 # %%
 
-import os.path as op
 import mne
 
 data_path = mne.datasets.sample.data_path()
 
-raw_erm = mne.io.read_raw_fif(op.join(data_path, 'MEG', 'sample',
-                                      'ernoise_raw.fif'), preload=True)
+raw_erm = mne.io.read_raw_fif(
+    data_path / 'MEG' / 'sample' / 'ernoise_raw.fif', preload=True
+)
 
 # %%
 # We can plot the absolute noise levels:

--- a/tutorials/inverse/20_dipole_fit.py
+++ b/tutorials/inverse/20_dipole_fit.py
@@ -14,7 +14,6 @@ For a comparison of fits between MNE-C and MNE-Python, see
 
 # %%
 
-import os.path as op
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -76,7 +75,7 @@ label = dip.to_volume_labels(fname_trans, subject=subject,
                              aseg='aparc.a2009s+aseg')[best_dip_idx]
 
 # Draw dipole position on MRI scan and add anatomical label from parcellation
-t1_fname = op.join(subjects_dir, subject, 'mri', 'T1.mgz')
+t1_fname = subjects_dir / subject / 'mri' / 'T1.mgz'
 fig_T1 = plot_anat(t1_fname, cut_coords=mri_pos[0],
                    title=f'Dipole location: {label}')
 

--- a/tutorials/inverse/60_visualize_stc.py
+++ b/tutorials/inverse/60_visualize_stc.py
@@ -15,8 +15,6 @@ First, we get the paths for the evoked data and the source time courses (stcs).
 
 # %%
 
-import os.path as op
-
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -140,7 +138,7 @@ stc.plot(src, subject='sample', subjects_dir=subjects_dir, mode='glass_brain')
 # You can also extract label time courses using volumetric atlases. Here we'll
 # use the built-in ``aparc+aseg.mgz``:
 
-fname_aseg = op.join(subjects_dir, 'sample', 'mri', 'aparc+aseg.mgz')
+fname_aseg = subjects_dir / 'sample' / 'mri' / 'aparc+aseg.mgz'
 label_names = mne.get_volume_labels_from_aseg(fname_aseg)
 label_tc = stc.extract_label_time_course(fname_aseg, src=src)
 
@@ -178,8 +176,9 @@ stc_back.plot(src, subjects_dir=subjects_dir, mode='glass_brain')
 # -----------------------
 # If we choose to use ``pick_ori='vector'`` in
 # :func:`apply_inverse <mne.minimum_norm.apply_inverse>`
-fname_inv = op.join(data_path, 'MEG', 'sample',
-                    'sample_audvis-meg-oct-6-meg-inv.fif')
+fname_inv = (
+    data_path / 'MEG' / 'sample' / 'sample_audvis-meg-oct-6-meg-inv.fif'
+)
 inv = read_inverse_operator(fname_inv)
 stc = apply_inverse(evoked, inv, lambda2, 'dSPM', pick_ori='vector')
 brain = stc.plot(subject='sample', subjects_dir=subjects_dir,

--- a/tutorials/io/60_ctf_bst_auditory.py
+++ b/tutorials/io/60_ctf_bst_auditory.py
@@ -31,7 +31,6 @@ The specifications of this dataset were discussed initially on the
 
 # %%
 
-import os.path as op
 import pandas as pd
 import numpy as np
 
@@ -57,11 +56,11 @@ use_precomputed = True
 data_path = bst_auditory.data_path()
 
 subject = 'bst_auditory'
-subjects_dir = op.join(data_path, 'subjects')
+subjects_dir = data_path / 'subjects'
 
-raw_fname1 = op.join(data_path, 'MEG', subject, 'S01_AEF_20131218_01.ds')
-raw_fname2 = op.join(data_path, 'MEG', subject, 'S01_AEF_20131218_02.ds')
-erm_fname = op.join(data_path, 'MEG', subject, 'S01_Noise_20131218_01.ds')
+raw_fname1 = data_path / 'MEG' / subject / 'S01_AEF_20131218_01.ds'
+raw_fname2 = data_path / 'MEG' / subject / 'S01_AEF_20131218_02.ds'
+erm_fname = data_path / 'MEG' / subject / 'S01_Noise_20131218_01.ds'
 
 # %%
 # In the memory saving mode we use ``preload=False`` and use the memory
@@ -108,8 +107,7 @@ if not use_precomputed:
 annotations_df = pd.DataFrame()
 offset = n_times_run1
 for idx in [1, 2]:
-    csv_fname = op.join(data_path, 'MEG', 'bst_auditory',
-                        'events_bad_0%s.csv' % idx)
+    csv_fname = data_path / 'MEG' / 'bst_auditory' / f'events_bad_0{idx}.csv'
     df = pd.read_csv(csv_fname, header=None,
                      names=['onset', 'duration', 'id', 'label'])
     print('Events from run {0}:'.format(idx))
@@ -139,8 +137,9 @@ saccade_epochs = mne.Epochs(raw, saccades_events, 1, 0., 0.5, preload=True,
 projs_saccade = mne.compute_proj_epochs(saccade_epochs, n_mag=1, n_eeg=0,
                                         desc_prefix='saccade')
 if use_precomputed:
-    proj_fname = op.join(data_path, 'MEG', 'bst_auditory',
-                         'bst_auditory-eog-proj.fif')
+    proj_fname = (
+        data_path / 'MEG' / 'bst_auditory' / 'bst_auditory-eog-proj.fif'
+    )
     projs_eog = mne.read_proj(proj_fname)[0]
 else:
     projs_eog, _ = mne.preprocessing.compute_proj_eog(raw.load_data(),
@@ -298,8 +297,7 @@ del raw_erm
 
 # %%
 # The transformation is read from a file:
-trans_fname = op.join(data_path, 'MEG', 'bst_auditory',
-                      'bst_auditory-trans.fif')
+trans_fname = data_path /'MEG' / 'bst_auditory' / 'bst_auditory-trans.fif'
 trans = mne.read_trans(trans_fname)
 
 # %%
@@ -311,8 +309,9 @@ trans = mne.read_trans(trans_fname)
 # information: :ref:`CHDBBCEJ`, :func:`mne.setup_source_space`,
 # :ref:`bem-model`, :func:`mne.bem.make_watershed_bem`.
 if use_precomputed:
-    fwd_fname = op.join(data_path, 'MEG', 'bst_auditory',
-                        'bst_auditory-meg-oct-6-fwd.fif')
+    fwd_fname = (
+        data_path / 'MEG' / 'bst_auditory' / 'bst_auditory-meg-oct-6-fwd.fif'
+    )
     fwd = mne.read_forward_solution(fwd_fname)
 else:
     src = mne.setup_source_space(subject, spacing='ico4',

--- a/tutorials/preprocessing/70_fnirs_processing.py
+++ b/tutorials/preprocessing/70_fnirs_processing.py
@@ -16,7 +16,6 @@ Here we will work with the :ref:`fNIRS motor data <fnirs-motor-dataset>`.
 
 # %%
 
-import os.path as op
 import numpy as np
 import matplotlib.pyplot as plt
 from itertools import compress
@@ -25,7 +24,7 @@ import mne
 
 
 fnirs_data_folder = mne.datasets.fnirs_motor.data_path()
-fnirs_cw_amplitude_dir = op.join(fnirs_data_folder, 'Participant-1')
+fnirs_cw_amplitude_dir = fnirs_data_folder / 'Participant-1'
 raw_intensity = mne.io.read_raw_nirx(fnirs_cw_amplitude_dir, verbose=True)
 raw_intensity.load_data()
 
@@ -58,7 +57,7 @@ raw_intensity.annotations.delete(unwanted)
 # optionally shown as orange dots. Source are optionally shown as red dots and
 # detectors as black.
 
-subjects_dir = op.join(mne.datasets.sample.data_path(), 'subjects')
+subjects_dir = mne.datasets.sample.data_path() / 'subjects'
 
 brain = mne.viz.Brain(
     'fsaverage', subjects_dir=subjects_dir, background='w', cortex='0.5')

--- a/tutorials/simulation/70_point_spread.py
+++ b/tutorials/simulation/70_point_spread.py
@@ -13,8 +13,6 @@ signal with point-spread by applying a forward and inverse solution.
 
 # %%
 
-import os.path as op
-
 import numpy as np
 
 import mne
@@ -42,14 +40,13 @@ dt = times[1] - times[0]
 
 # Paths to MEG data
 data_path = sample.data_path()
-subjects_dir = op.join(data_path, 'subjects')
-fname_fwd = op.join(data_path, 'MEG', 'sample',
-                    'sample_audvis-meg-oct-6-fwd.fif')
-fname_inv = op.join(data_path, 'MEG', 'sample',
-                    'sample_audvis-meg-oct-6-meg-fixed-inv.fif')
+subjects_dir = data_path / 'subjects'
+fname_fwd = data_path / 'MEG' / 'sample' / 'sample_audvis-meg-oct-6-fwd.fif'
+fname_inv = (
+    data_path / 'MEG' / 'sample' / 'sample_audvis-meg-oct-6-meg-fixed-inv.fif'
+)
 
-fname_evoked = op.join(data_path, 'MEG', 'sample',
-                       'sample_audvis-ave.fif')
+fname_evoked = data_path / 'MEG' / 'sample' / 'sample_audvis-ave.fif'
 
 # %%
 # Load the MEG data
@@ -61,8 +58,10 @@ fwd = mne.convert_forward_solution(fwd, force_fixed=True, surf_ori=True,
 fwd['info']['bads'] = []
 inv_op = read_inverse_operator(fname_inv)
 
-raw = mne.io.read_raw_fif(op.join(data_path, 'MEG', 'sample',
-                                  'sample_audvis_raw.fif'))
+raw = mne.io.read_raw_fif(
+    data_path / 'MEG' / 'sample' / 'sample_audvis_raw.fif'
+)
+
 raw.info['bads'] = []
 raw.set_eeg_reference(projection=True)
 events = mne.find_events(raw)

--- a/tutorials/simulation/80_dics.py
+++ b/tutorials/simulation/80_dics.py
@@ -23,7 +23,6 @@ simulated sources.
 # -----
 # We first import the required packages to run this tutorial and define a list
 # of filenames for various things we'll be using.
-import os.path as op
 import numpy as np
 from scipy.signal import welch, coherence, unit_impulse
 from matplotlib import pyplot as plt
@@ -37,13 +36,13 @@ from mne.beamformer import make_dics, apply_dics_csd
 
 # We use the MEG and MRI setup from the MNE-sample dataset
 data_path = sample.data_path(download=False)
-subjects_dir = op.join(data_path, 'subjects')
+subjects_dir = data_path / 'subjects'
 
 # Filenames for various files we'll be using
-meg_path = op.join(data_path, 'MEG', 'sample')
-raw_fname = op.join(meg_path, 'sample_audvis_raw.fif')
-fwd_fname = op.join(meg_path, 'sample_audvis-meg-eeg-oct-6-fwd.fif')
-cov_fname = op.join(meg_path, 'sample_audvis-cov.fif')
+meg_path = data_path / 'MEG' / 'sample'
+raw_fname = meg_path / 'sample_audvis_raw.fif'
+fwd_fname = meg_path / 'sample_audvis-meg-eeg-oct-6-fwd.fif'
+cov_fname = meg_path / 'sample_audvis-cov.fif'
 fwd = mne.read_forward_solution(fwd_fname)
 
 # Seed for the random number generator

--- a/tutorials/stats-source-space/60_cluster_rmANOVA_spatiotemporal.py
+++ b/tutorials/stats-source-space/60_cluster_rmANOVA_spatiotemporal.py
@@ -24,7 +24,6 @@ across space and time.
 
 # %%
 
-import os.path as op
 import numpy as np
 from numpy.random import randn
 import matplotlib.pyplot as plt
@@ -243,7 +242,7 @@ stc_all_cluster_vis = summarize_clusters_stc(clu, tstep=tstep,
 #    Let's actually plot the first "time point" in the SourceEstimate, which
 #    shows all the clusters, weighted by duration
 
-subjects_dir = op.join(data_path, 'subjects')
+subjects_dir = data_path / 'subjects'
 # The brighter the color, the stronger the interaction between
 # stimulus modality and stimulus location
 


### PR DESCRIPTION
Some `op.join` remained across tutorials and examples despite the new developer code sprint.
I quickly searched through the files for `'os.path as op'` and replaced the syntax with a modern `pathlib` syntax.