### PR TITLE
rely more on SciPy for DPSS tapers

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -45,4 +45,4 @@ Bugs
 
 API changes
 ~~~~~~~~~~~
-- None yet
+- In :func:`mne.time_frequency.dpss_windows`, interpolating is deprecated (nowadays SciPy's computations are fast enough for large ``N`` without interpolation). This affects parameters ``interp_from`` and ``interp_kind``. (:gh:`11293` by `Daniel McCloy`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -45,4 +45,4 @@ Bugs
 
 API changes
 ~~~~~~~~~~~
-- In :func:`mne.time_frequency.dpss_windows`, interpolating is deprecated (nowadays SciPy's computations are fast enough for large ``N`` without interpolation). This affects parameters ``interp_from`` and ``interp_kind``. (:gh:`11293` by `Daniel McCloy`_)
+- In :func:`mne.time_frequency.dpss_windows`, interpolating is deprecated (nowadays SciPy's computations are fast enough for large ``N`` without interpolation). This affects parameters ``interp_from`` and ``interp_kind``. Two new parameters of the underlying SciPy :func:`~scipy.signal.windows.dpss` function are also exposed: ``sym`` (for choosing symmetric vs. periodic windows) and ``norm`` (window normalization method). (:gh:`11293` by `Daniel McCloy`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -43,6 +43,8 @@ Bugs
 - Fix bug where EEGLAB channel positions were read as meters, while they are commonly in millimeters, leading to head outlies of the size of one channel when plotting topomaps. Now ``montage_units`` argument has been added to :func:`~mne.io.read_raw_eeglab` and :func:`~mne.read_epochs_eeglab` to control in what units EEGLAB channel positions are read. The default is millimeters, ``'mm'`` (:gh:`11283` by `Mikołaj Magnuski`_)
 - Fix channel selection edge-cases in `~mne.preprocessing.ICA.find_bads_muscle` (:gh:`11300` by `Mathieu Scheltienne`_)
 
+- Multitaper spectral estimation now uses periodic (rather than symmetric) taper windows (:gh:`11293` by `Daniel McCloy`_)
+
 API changes
 ~~~~~~~~~~~
 - In :func:`mne.time_frequency.dpss_windows`, interpolating is deprecated (nowadays SciPy's computations are fast enough for large ``N`` without interpolation). This affects parameters ``interp_from`` and ``interp_kind``. Two new parameters of the underlying SciPy :func:`~scipy.signal.windows.dpss` function are also exposed: ``sym`` (for choosing symmetric vs. periodic windows) and ``norm`` (window normalization method). (:gh:`11293` by `Daniel McCloy`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -42,8 +42,7 @@ Bugs
 - Fix bug in the :func:`~mne.viz.plot_evoked_topo` and :meth:`~mne.Evoked.plot_topo`, where legend colors where shown incorrectly on newer matplotlib versions (:gh:`11258` by `Erkka Heinila`_)
 - Fix bug where EEGLAB channel positions were read as meters, while they are commonly in millimeters, leading to head outlies of the size of one channel when plotting topomaps. Now ``montage_units`` argument has been added to :func:`~mne.io.read_raw_eeglab` and :func:`~mne.read_epochs_eeglab` to control in what units EEGLAB channel positions are read. The default is millimeters, ``'mm'`` (:gh:`11283` by `Mikołaj Magnuski`_)
 - Fix channel selection edge-cases in `~mne.preprocessing.ICA.find_bads_muscle` (:gh:`11300` by `Mathieu Scheltienne`_)
-
-- Multitaper spectral estimation now uses periodic (rather than symmetric) taper windows (:gh:`11293` by `Daniel McCloy`_)
+- Multitaper spectral estimation now uses periodic (rather than symmetric) taper windows. This also necessitated changing the default ``max_iter`` of our cross-spectral density functions from 150 to 250. (:gh:`11293` by `Daniel McCloy`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -1195,20 +1195,12 @@ def notch_filter(x, Fs, freqs, filter_length='auto', notch_widths=None,
 
 
 def _get_window_thresh(n_times, sfreq, mt_bandwidth, p_value):
-    # max taper size chosen because it has an max error < 1e-3:
-    # >>> np.max(np.diff(dpss_windows(953, 4, 100)[0]))
-    # 0.00099972447657578449
-    # so we use 1000 because it's the first "nice" number bigger than 953.
-    # but if we have a new enough scipy,
-    # it's only ~0.175 sec for 8 tapers even with 100000 samples
     from scipy import stats
     from .time_frequency.multitaper import _compute_mt_params
-    dpss_n_times_max = 100000
 
     # figure out what tapers to use
     window_fun, _, _ = _compute_mt_params(
-        n_times, sfreq, mt_bandwidth, False, False,
-        interp_from=min(n_times, dpss_n_times_max), verbose=False)
+        n_times, sfreq, mt_bandwidth, False, False, verbose=False)
 
     # F-stat of 1-p point
     threshold = stats.f.ppf(1 - p_value / n_times, 2, 2 * len(window_fun) - 2)

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -809,7 +809,7 @@ def csd_multitaper(epochs, fmin=0, fmax=np.inf, tmin=None, tmax=None,
 def csd_array_multitaper(X, sfreq, t0=0, fmin=0, fmax=np.inf, tmin=None,
                          tmax=None, ch_names=None, n_fft=None, bandwidth=None,
                          adaptive=False, low_bias=True, projs=None,
-                         n_jobs=None, max_iter=150, *, verbose=None):
+                         n_jobs=None, max_iter=250, *, verbose=None):
     """Estimate cross-spectral density from an array using a multitaper method.
 
     Parameters
@@ -1233,7 +1233,7 @@ def _csd_fourier(X, sfreq, n_times, freq_mask, n_fft):
 
 
 def _csd_multitaper(X, sfreq, n_times, window_fun, eigvals, freq_mask, n_fft,
-                    adaptive, max_iter=150):
+                    adaptive, max_iter=250):
     """Compute cross spectral density (CSD) using multitaper module."""
     x_mt, _ = _mt_spectra(X, window_fun, sfreq, n_fft)
 

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -31,6 +31,8 @@ def dpss_windows(N, half_nbw, Kmax, *, sym=True, norm=None, low_bias=True,
         Whether to generate a symmetric window (``True``, for filter design) or
         a periodic window (``False``, for spectral analysis). Default is
         ``True``.
+
+        .. versionadded:: 1.3
     norm : 2 | ``'approximate'`` | ``'subsample'`` | None
         Window normalization method. If ``'approximate'`` or ``'subsample'``,
         windows are normalized by the maximum, and a correction scale-factor
@@ -38,6 +40,8 @@ def dpss_windows(N, half_nbw, Kmax, *, sym=True, norm=None, low_bias=True,
         ``N**2/(N**2+half_nbw)`` ("approximate") or a FFT-based subsample shift
         ("subsample"). ``2`` uses the L2 norm. ``None`` (the default) uses
         ``"approximate"`` when ``Kmax=None`` and ``2`` otherwise.
+
+        .. versionadded:: 1.3
     low_bias : bool
         Keep only tapers with eigenvalues > 0.9.
     interp_from : int | None

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -98,7 +98,7 @@ def dpss_windows(N, half_nbw, Kmax, *, sym=True, norm=None, low_bias=True,
     return dpss, eigvals
 
 
-def _psd_from_mt_adaptive(x_mt, eigvals, freq_mask, max_iter=150,
+def _psd_from_mt_adaptive(x_mt, eigvals, freq_mask, max_iter=250,
                           return_weights=False):
     r"""Use iterative procedure to compute the PSD from tapered spectra.
 

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -3,17 +3,14 @@
 
 # Parts of this code were copied from NiTime http://nipy.sourceforge.net/nitime
 
-import operator
-
 import numpy as np
 
-from ..filter import next_fast_len
 from ..parallel import parallel_func
-from ..utils import sum_squared, warn, verbose, logger, _check_option
+from ..utils import warn, verbose, logger, _check_option
 
 
-def dpss_windows(N, half_nbw, Kmax, low_bias=True, interp_from=None,
-                 interp_kind='linear'):
+def dpss_windows(N, half_nbw, Kmax, *, low_bias=True,
+                 interp_from=None, interp_kind=None):
     """Compute Discrete Prolate Spheroidal Sequences.
 
     Will give of orders [0,Kmax-1] for a given frequency-spacing multiple
@@ -32,19 +29,27 @@ def dpss_windows(N, half_nbw, Kmax, low_bias=True, interp_from=None,
         Number of DPSS windows to return is Kmax (orders 0 through Kmax-1).
     low_bias : bool
         Keep only tapers with eigenvalues > 0.9.
-    interp_from : int (optional)
+    interp_from : int | None
         The dpss can be calculated using interpolation from a set of dpss
         with the same NW and Kmax, but shorter N. This is the length of this
         shorter set of dpss windows.
 
-        .. note:: If SciPy 1.1 or greater is available, interpolating
-                  is likely not necessary as DPSS computations should be
-                  sufficiently fast.
-    interp_kind : str (optional)
+        .. deprecated:: 1.3
+           The ``interp_from`` option is deprecated and will be
+           removed in version 1.4. Modern implementations can handle large
+           values of ``N`` so interpolation is no longer necessary; any value
+           passed here will be ignored.
+    interp_kind : str | None
         This input variable is passed to scipy.interpolate.interp1d and
         specifies the kind of interpolation as a string ('linear', 'nearest',
         'zero', 'slinear', 'quadratic, 'cubic') or as an integer specifying the
         order of the spline interpolator to use.
+
+        .. deprecated:: 1.3
+           The ``interp_kind`` option is deprecated and will be
+           removed in version 1.4. Modern implementations can handle large
+           values of ``N`` so interpolation is no longer necessary; any value
+           passed here will be ignored.
 
     Returns
     -------
@@ -60,57 +65,16 @@ def dpss_windows(N, half_nbw, Kmax, low_bias=True, interp_from=None,
     ----------
     .. footbibliography::
     """
-    from scipy import interpolate
-    from scipy.fft import rfft, irfft
     from scipy.signal.windows import dpss as sp_dpss
 
-    # This np.int32 business works around a weird Windows bug, see
-    # gh-5039 and https://github.com/scipy/scipy/pull/8608
-    Kmax = np.int32(operator.index(Kmax))
-    N = np.int32(operator.index(N))
-    W = float(half_nbw) / N
-    nidx = np.arange(N, dtype='d')
-
-    # In this case, we create the dpss windows of the smaller size
-    # (interp_from) and then interpolate to the larger size (N)
     if interp_from is not None:
-        if interp_from > N:
-            e_s = 'In dpss_windows, interp_from is: %s ' % interp_from
-            e_s += 'and N is: %s. ' % N
-            e_s += 'Please enter interp_from smaller than N.'
-            raise ValueError(e_s)
-        dpss = []
-        d, e = dpss_windows(interp_from, half_nbw, Kmax, low_bias=False)
-        for this_d in d:
-            x = np.arange(this_d.shape[-1])
-            tmp = interpolate.interp1d(x, this_d, kind=interp_kind)
-            d_temp = tmp(np.linspace(0, this_d.shape[-1] - 1, N,
-                                     endpoint=False))
+        warn('The ``interp_from`` option is deprecated and will be removed in '
+             'version 1.4.', FutureWarning)
+    if interp_kind is not None:
+        warn('The ``interp_kind`` option is deprecated and will be removed in '
+             'version 1.4.', FutureWarning)
 
-            # Rescale:
-            d_temp = d_temp / np.sqrt(sum_squared(d_temp))
-
-            dpss.append(d_temp)
-
-        dpss = np.array(dpss)
-
-    else:
-        dpss = sp_dpss(N, half_nbw, Kmax)
-
-    # Now find the eigenvalues of the original spectral concentration problem
-    # Use the autocorr sequence technique from Percival and Walden, 1993 pg 390
-
-    # compute autocorr using FFT (same as nitime.utils.autocorr(dpss) * N)
-    rxx_size = 2 * N - 1
-    n_fft = next_fast_len(rxx_size)
-    dpss_fft = rfft(dpss, n_fft)
-    dpss_rxx = irfft(dpss_fft * dpss_fft.conj(), n_fft)
-    dpss_rxx = dpss_rxx[:, :N]
-
-    r = 4 * W * np.sinc(2 * W * nidx)
-    r[0] = 2 * W
-    eigvals = np.dot(dpss_rxx, r)
-
+    dpss, eigvals = sp_dpss(N, half_nbw, Kmax, return_ratios=True)
     if low_bias:
         idx = (eigvals > 0.9)
         if not idx.any():
@@ -327,7 +291,7 @@ def _mt_spectra(x, dpss, sfreq, n_fft=None):
 
 @verbose
 def _compute_mt_params(n_times, sfreq, bandwidth, low_bias, adaptive,
-                       interp_from=None, verbose=None):
+                       verbose=None):
     """Triage windowing and multitaper parameters."""
     # Compute standardized half-bandwidth
     from scipy.signal import get_window
@@ -350,8 +314,7 @@ def _compute_mt_params(n_times, sfreq, bandwidth, low_bias, adaptive,
     # Compute DPSS windows
     n_tapers_max = int(2 * half_nbw)
     window_fun, eigvals = dpss_windows(n_times, half_nbw, n_tapers_max,
-                                       low_bias=low_bias,
-                                       interp_from=interp_from)
+                                       sym=False, low_bias=low_bias)
     logger.info('    Using multitaper spectrum estimation with %d DPSS '
                 'windows' % len(eigvals))
 

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -9,7 +9,7 @@ from ..parallel import parallel_func
 from ..utils import warn, verbose, logger, _check_option
 
 
-def dpss_windows(N, half_nbw, Kmax, *, low_bias=True,
+def dpss_windows(N, half_nbw, Kmax, *, sym=True, norm=None, low_bias=True,
                  interp_from=None, interp_kind=None):
     """Compute Discrete Prolate Spheroidal Sequences.
 
@@ -27,6 +27,17 @@ def dpss_windows(N, half_nbw, Kmax, *, low_bias=True,
         = BW*N/dt but with dt taken as 1.
     Kmax : int
         Number of DPSS windows to return is Kmax (orders 0 through Kmax-1).
+    sym : bool
+        Whether to generate a symmetric window (``True``, for filter design) or
+        a periodic window (``False``, for spectral analysis). Default is
+        ``True``.
+    norm : 2 | ``'approximate'`` | ``'subsample'`` | None
+        Window normalization method. If ``'approximate'`` or ``'subsample'``,
+        windows are normalized by the maximum, and a correction scale-factor
+        for even-length windows is applied either using
+        ``N**2/(N**2+half_nbw)`` ("approximate") or a FFT-based subsample shift
+        ("subsample"). ``2`` uses the L2 norm. ``None`` (the default) uses
+        ``"approximate"`` when ``Kmax=None`` and ``2`` otherwise.
     low_bias : bool
         Keep only tapers with eigenvalues > 0.9.
     interp_from : int | None
@@ -74,7 +85,8 @@ def dpss_windows(N, half_nbw, Kmax, *, low_bias=True,
         warn('The ``interp_kind`` option is deprecated and will be removed in '
              'version 1.4.', FutureWarning)
 
-    dpss, eigvals = sp_dpss(N, half_nbw, Kmax, return_ratios=True)
+    dpss, eigvals = sp_dpss(N, half_nbw, Kmax, sym=sym, norm=norm,
+                            return_ratios=True)
     if low_bias:
         idx = (eigvals > 0.9)
         if not idx.any():

--- a/mne/time_frequency/tests/test_multitaper.py
+++ b/mne/time_frequency/tests/test_multitaper.py
@@ -23,14 +23,17 @@ def test_dpss_windows():
     assert_array_almost_equal(dpss, dpss_ni)
     assert_array_almost_equal(eigs, eigs_ni)
 
-    dpss, eigs = dpss_windows(N, half_nbw, Kmax, interp_from=200,
-                              low_bias=False)
+    dpss, eigs = dpss_windows(N, half_nbw, Kmax, low_bias=False)
     with _record_warnings():  # conversions
-        dpss_ni, eigs_ni = ni.algorithms.dpss_windows(N, half_nbw, Kmax,
-                                                      interp_from=200)
+        dpss_ni, eigs_ni = ni.algorithms.dpss_windows(N, half_nbw, Kmax)
 
     assert_array_almost_equal(dpss, dpss_ni)
     assert_array_almost_equal(eigs, eigs_ni)
+
+    with pytest.warns(FutureWarning, match='``interp_from`` option is deprec'):
+        dpss_windows(N, half_nbw, Kmax, interp_from=200)
+    with pytest.warns(FutureWarning, match='``interp_kind`` option is deprec'):
+        dpss_windows(N, half_nbw, Kmax, interp_kind='linear')
 
 
 @requires_nitime

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -158,7 +158,7 @@ def _make_dpss(sfreq, freqs, n_cycles=7., time_bandwidth=4.0, zero_mean=False):
 
             # Get dpss tapers
             tapers, conc = dpss_windows(t.shape[0], time_bandwidth / 2.,
-                                        n_taps)
+                                        n_taps, sym=False)
 
             Wk = oscillation * tapers[m]
             if zero_mean:  # to make it zero mean


### PR DESCRIPTION
closes #11292

@larsoner @mmagnuski this goes a bit beyond what you two discussed in #11292, but the changes are well-segregated by commit so it will be easy to revert part of it if needed:

- [x] deprecate DPSS interpolation in the API; remove associated code and just compute directly for large ``N``
- [x] expose SciPy's `sym` and `norm` parameters
- [x] use `sym=False` when we are doing spectral estimation
- [x] ~~use `scipy.signal.morlet2` and `scipy.signal.cwt` where possible~~ *will do in a separate PR*

Feel free to review now (just the DPSS changes) and I'll add the morlet / CWT changes in the next couple days (or can bump that to a separate PR if you prefer)