### PR TITLE
MAINT: Return EpochsArray instead of BaseEpochs for concatenate_epochs

### DIFF
--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2779,6 +2779,8 @@ def test_concatenate_epochs():
     epochs2 = epochs.copy()
     epochs_list = [epochs, epochs2]
     epochs_conc = concatenate_epochs(epochs_list)
+    assert epochs_conc.preload
+    assert isinstance(epochs_conc, EpochsArray)
     assert_array_equal(
         epochs_conc.events[:, 0], np.unique(epochs_conc.events[:, 0]))
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -887,6 +887,12 @@ distance : float | None
     in plot units (either m or mm).
 """
 
+docdict['drop_log'] = """
+drop_log : tuple | None
+    Tuple of tuple of strings indicating which epochs have been marked to
+    be ignored.
+"""
+
 docdict['dtype_applyfun'] = """
 dtype : numpy.dtype
     Data type to use after applying the function. If None
@@ -2808,6 +2814,12 @@ raw : Raw object
     An instance of `~mne.io.Raw`.
 """
 
+docdict['raw_sfreq'] = """
+raw_sfreq : float
+    The original Raw object sampling rate. If None, then it is set to
+    ``info['sfreq']``.
+"""
+
 docdict['reduce_rank'] = """
 reduce_rank : bool
     If True, the rank of the denominator of the beamformer formula (i.e.,
@@ -3049,6 +3061,12 @@ sensors : bool | str
     valid matplotlib format string (e.g., ``'r+'`` for red plusses, see the
     Notes section of :meth:`~matplotlib.axes.Axes.plot`). If ``True`` (the
     default), black circles will be used.
+"""
+
+docdict['selection'] = """
+selection : iterable | None
+    Iterable of indices of selected epochs. If ``None``, will be
+    automatically generated, corresponding to all non-zero events.
 """
 
 docdict['set_eeg_reference_see_also_notes'] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3055,18 +3055,18 @@ seeg : bool
     If True (default), show sEEG electrodes.
 """
 
+docdict['selection'] = """
+selection : iterable | None
+    Iterable of indices of selected epochs. If ``None``, will be
+    automatically generated, corresponding to all non-zero events.
+"""
+
 docdict['sensors_topomap'] = """
 sensors : bool | str
     Whether to add markers for sensor locations. If :class:`str`, should be a
     valid matplotlib format string (e.g., ``'r+'`` for red plusses, see the
     Notes section of :meth:`~matplotlib.axes.Axes.plot`). If ``True`` (the
     default), black circles will be used.
-"""
-
-docdict['selection'] = """
-selection : iterable | None
-    Iterable of indices of selected epochs. If ``None``, will be
-    automatically generated, corresponding to all non-zero events.
 """
 
 docdict['set_eeg_reference_see_also_notes'] = """


### PR DESCRIPTION
Seems potentially useful/cleaner even if we also add https://github.com/mne-tools/mne-python/pull/11287