### PR TITLE
BUG: Fix bug with parallel progress bars

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -43,6 +43,7 @@ Bugs
 - Fix bug in the :func:`~mne.viz.plot_evoked_topo` and :meth:`~mne.Evoked.plot_topo`, where legend colors where shown incorrectly on newer matplotlib versions (:gh:`11258` by `Erkka Heinila`_)
 - Fix bug where EEGLAB channel positions were read as meters, while they are commonly in millimeters, leading to head outlies of the size of one channel when plotting topomaps. Now ``montage_units`` argument has been added to :func:`~mne.io.read_raw_eeglab` and :func:`~mne.read_epochs_eeglab` to control in what units EEGLAB channel positions are read. The default is millimeters, ``'mm'`` (:gh:`11283` by `Mikołaj Magnuski`_)
 - Fix bug where computing PSD with welch's method with more jobs than channels would fail (:gh:`11298` by `Mathieu Scheltienne`_)
+- Fix bug with :func:`mne.decoding.cross_val_multiscore` where progress bars were not displayed correctly (:gh:`11311` by `Eric Larson`_)
 - Fix channel selection edge-cases in `~mne.preprocessing.ICA.find_bads_muscle` (:gh:`11300` by `Mathieu Scheltienne`_)
 - Multitaper spectral estimation now uses periodic (rather than symmetric) taper windows. This also necessitated changing the default ``max_iter`` of our cross-spectral density functions from 150 to 250. (:gh:`11293` by `Daniel McCloy`_)
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2663,6 +2663,11 @@ pos : array, shape (n_channels, 2){}
 docdict['pos_topomap'] = _pos_topomap.format(' | instance of Info')
 docdict['pos_topomap_psd'] = _pos_topomap.format('')
 
+docdict['position'] = """
+position : int
+    The position for the progress bar.
+"""
+
 docdict['precompute'] = """
 precompute : bool | str
     Whether to load all data (not just the visible portion) into RAM and


### PR DESCRIPTION
Related to #7478, but not quite the same (though I remember this being an issue there, too).

Now with this code:

<details>
<summary>Code</summary>

```
import mne
from sklearn.pipeline import make_pipeline
from sklearn.preprocessing import StandardScaler
from sklearn.linear_model import LogisticRegression
import mne
from mne.datasets import sample
from mne.decoding import GeneralizingEstimator, cross_val_multiscore

data_path = sample.data_path()
raw_fname = data_path / 'MEG/sample/sample_audvis_filt-0-40_raw.fif'
events_fname = data_path / 'MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
raw = mne.io.read_raw_fif(raw_fname, preload=True)
picks = mne.pick_types(raw.info, meg=True, exclude='bads')  # Pick MEG channels
events = mne.read_events(events_fname)
event_id = {'Auditory/Left': 1, 'Auditory/Right': 2,
            'Visual/Left': 3, 'Visual/Right': 4}
epochs = mne.Epochs(raw, events, event_id, picks=picks, preload=True)
clf = make_pipeline(StandardScaler(), LogisticRegression(solver='lbfgs'))
time_gen = GeneralizingEstimator(clf, scoring='roc_auc', n_jobs=2,
                                 verbose=True)
X = epochs['Right'].get_data()
y = epochs['Right'].events[:, 2] > 2
cross_val_multiscore(time_gen, X, y, cv=5, n_jobs=2, verbose=True)
```

</details>

Instead of having two progress bars on top of each other conflicting (actually it doesn't display at all, but if I fix this by putting a `verbose=verbose` in the right place in our code):

https://user-images.githubusercontent.com/2365790/200844186-b82315d0-4a64-4e34-9c7b-2fd7b0377dd5.mp4

Now we get the right number of progress bars, and they don't fight each other:

https://user-images.githubusercontent.com/2365790/200844251-0b3c68fc-f296-4d94-8c51-1a7d41dedad1.mp4


