### PR TITLE
[MAINT, MRG] fix is_mesa

### DIFF
--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -1210,7 +1210,9 @@ def _is_mesa(plotter):
     is_mesa = 'mesa' in gpu_info.split()
     if is_mesa:
         # Try to warn if it's ancient
-        version = re.findall("mesa ([0-9.]+) .*", gpu_info)
+        version = re.findall("mesa ([0-9.]+) .*", gpu_info) or \
+            re.findall("OpenGL version string: .* Mesa ([0-9.]+)\n",
+                       plotter.ren_win.ReportCapabilities())
         if version:
             version = version[0]
             if _compare_version(version, '<', '18.3.6'):

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -1204,15 +1204,15 @@ def _is_mesa(plotter):
     # MESA (could use GPUInfo / _get_gpu_info here, but it takes
     # > 700 ms to make a new window + report capabilities!)
     # CircleCI's is: "Mesa 20.0.8 via llvmpipe (LLVM 10.0.0, 256 bits)"
-    gpu_info = plotter.ren_win.ReportCapabilities()
-    gpu_info = re.findall("OpenGL renderer string:(.+)\n", gpu_info)
+    gpu_info_full = plotter.ren_win.ReportCapabilities()
+    gpu_info = re.findall("OpenGL renderer string:(.+)\n", gpu_info_full)
     gpu_info = ' '.join(gpu_info).lower()
     is_mesa = 'mesa' in gpu_info.split()
     if is_mesa:
         # Try to warn if it's ancient
         version = re.findall("mesa ([0-9.]+) .*", gpu_info) or \
             re.findall("OpenGL version string: .* Mesa ([0-9.]+)\n",
-                       plotter.ren_win.ReportCapabilities())
+                       gpu_info_full)
         if version:
             version = version[0]
             if _compare_version(version, '<', '18.3.6'):


### PR DESCRIPTION
I get a RuntimeError with no description for my mesa setup. The key part of the gpu info string is

```
OpenGL vendor string:  Intel
OpenGL renderer string:  Mesa Intel(R) Xe Graphics (TGL GT2)
OpenGL version string:  4.6 (Core Profile) Mesa 22.2.0
```

This appears to be a difference from previous where in the comments it says the CIs say

```
OpenGL renderer string: Mesa 20.0.8 via llvmpipe (LLVM 10.0.0, 256 bits)
```

So this just fixes so that it gets the version from the version string if it's not in the render string.