### PR TITLE
BUG: Fix bug with report replacement

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -44,6 +44,7 @@ Bugs
 - Fix bug where EEGLAB channel positions were read as meters, while they are commonly in millimeters, leading to head outlies of the size of one channel when plotting topomaps. Now ``montage_units`` argument has been added to :func:`~mne.io.read_raw_eeglab` and :func:`~mne.read_epochs_eeglab` to control in what units EEGLAB channel positions are read. The default is millimeters, ``'mm'`` (:gh:`11283` by `Mikołaj Magnuski`_)
 - Fix bug where computing PSD with welch's method with more jobs than channels would fail (:gh:`11298` by `Mathieu Scheltienne`_)
 - Fix channel selection edge-cases in `~mne.preprocessing.ICA.find_bads_muscle` (:gh:`11300` by `Mathieu Scheltienne`_)
+- Fix bug with :class:`mne.Report` with ``replace=True`` where the wrong content was replaced (:gh:`11318` by `Eric Larson`_)
 - Multitaper spectral estimation now uses periodic (rather than symmetric) taper windows. This also necessitated changing the default ``max_iter`` of our cross-spectral density functions from 150 to 250. (:gh:`11293` by `Daniel McCloy`_)
 
 API changes

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -1811,8 +1811,8 @@ class Report:
         existing_names = [element.name for element in self._content]
         if name in existing_names and replace:
             # Find and replace last existing element with the same name
-            idx = [ii for ii, element in enumerate(self._content)
-                   if element.name == name][-1]
+            idx = [ii for ii, element_name in enumerate(existing_names)
+                   if element_name == name][-1]
             self._content[idx] = new_content
         else:
             self._content.append(new_content)

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -765,7 +765,7 @@ class Report:
             'baseline', 'cov_fname', 'include', '_content', 'image_format',
             'info_fname', '_dom_id', 'raw_psd', 'projs',
             'subjects_dir', 'subject', 'title', 'data_path', 'lang',
-            'fname'
+            'fname',
         )
 
     def _get_dom_id(self, increment=True):
@@ -1810,14 +1810,11 @@ class Report:
 
         existing_names = [element.name for element in self._content]
         if name in existing_names and replace:
-            # Find and replace existing content, starting from the last element
-            for idx, content_element in enumerate(self._content[::-1]):
-                if content_element.name == name:
-                    self._content[idx] = new_content
-                    return
-            raise RuntimeError('This should never happen')
+            # Find and replace last existing element with the same name
+            idx = [ii for ii, element in enumerate(self._content)
+                   if element.name == name][-1]
+            self._content[idx] = new_content
         else:
-            # Simply append new content (no replace)
             self._content.append(new_content)
 
     def _add_code(self, *, code, title, language, section, tags, replace):

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -71,8 +71,8 @@ topomap_kwargs = dict(res=8, contours=0, sensors=False)
 
 def _get_example_figures():
     """Create two example figures."""
-    fig1 = plt.plot([1, 2], [1, 2])[0].figure
-    fig2 = plt.plot([3, 4], [3, 4])[0].figure
+    fig1 = np.zeros((2, 2, 3))
+    fig2 = np.ones((2, 2, 3))
     return [fig1, fig2]
 
 
@@ -609,28 +609,33 @@ def test_remove():
     assert r2.html[2] == r.html[3]
 
 
-def test_add_or_replace():
+@pytest.mark.parametrize('tags', (True, False))  # shouldn't matter
+def test_add_or_replace(tags):
     """Test replacing existing figures in a report."""
+    # Note that tags don't matter, only titles do!
     r = Report()
     fig1, fig2 = _get_example_figures()
-    r.add_figure(fig=fig1, title='duplicate', tags=('foo',))
-    r.add_figure(fig=fig1, title='duplicate', tags=('foo',))
-    r.add_figure(fig=fig1, title='duplicate', tags=('bar',))
-    r.add_figure(fig=fig2, title='nonduplicate', tags=('foo',))
+    r.add_figure(fig=fig1, title='duplicate', tags=('foo',) if tags else ())
+    r.add_figure(fig=fig2, title='duplicate', tags=('foo',) if tags else ())
+    r.add_figure(fig=fig1, title='duplicate', tags=('bar',) if tags else ())
+    r.add_figure(fig=fig2, title='nonduplicate', tags=('foo',) if tags else ())
     # By default, replace=False, so all figures should be there
     assert len(r.html) == 4
+    assert len(r._content) == 4
 
     old_r = copy.deepcopy(r)
 
     # Replace last occurrence of `fig1` tagges as `foo`
     r.add_figure(
-        fig=fig2, title='duplicate', tags=('foo',), replace=True
+        fig=fig2, title='duplicate', tags=('bar',) if tags else (),
+        replace=True,
     )
     assert len(r._content) == len(r.html) == 4
-    assert r.html[1] != old_r.html[1]  # This figure should have changed
+    # This figure should have changed
+    assert r.html[2] != old_r.html[2]
     # All other figures should be the same
     assert r.html[0] == old_r.html[0]
-    assert r.html[2] == old_r.html[2]
+    assert r.html[1] == old_r.html[1]
     assert r.html[3] == old_r.html[3]
 
 


### PR DESCRIPTION
Iteration was done over `content[::-1]` but the `idx` used came from `enumerate`ing this, which meant it was in the wrong order. What needed to be used was `len(content) - idx - 1`. This code just simplifies things by iterating over all elements (which should be fast enough even for hundreds of them) and taking the last matching index directly.