### PR TITLE
[DOC, MRG] fix/improve documentation of n_jobs for apply_function

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1524,7 +1524,8 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         %(fun_applyfun)s
         %(picks_all_data_noref)s
         %(dtype_applyfun)s
-        %(n_jobs)s
+        %(n_jobs)s Ignored if ``channel_wise=False`` as the workload is
+            is splitted across channels.
         %(channel_wise_applyfun_epo)s
         %(verbose)s
         %(kwargs_fun)s

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1524,7 +1524,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         %(fun_applyfun)s
         %(picks_all_data_noref)s
         %(dtype_applyfun)s
-        %(n_jobs)s Ignored if ``channel_wise=False`` as the workload is
+        %(n_jobs)s Ignored if ``channel_wise=False`` as the workload
             is splitted across channels.
         %(channel_wise_applyfun_epo)s
         %(verbose)s

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1525,7 +1525,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         %(picks_all_data_noref)s
         %(dtype_applyfun)s
         %(n_jobs)s Ignored if ``channel_wise=False`` as the workload
-            is splitted across channels.
+            is split across channels.
         %(channel_wise_applyfun_epo)s
         %(verbose)s
         %(kwargs_fun)s

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -210,7 +210,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(fun_applyfun_evoked)s
         %(picks_all_data_noref)s
         %(dtype_applyfun)s
-        %(n_jobs)s Ignored if ``channel_wise=False`` as the workload is
+        %(n_jobs)s Ignored if ``channel_wise=False`` as the workload
             is splitted across channels.
         %(verbose)s
         %(kwargs_fun)s

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -210,7 +210,8 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(fun_applyfun_evoked)s
         %(picks_all_data_noref)s
         %(dtype_applyfun)s
-        %(n_jobs)s
+        %(n_jobs)s Ignored if ``channel_wise=False`` as the workload is
+            is splitted across channels.
         %(verbose)s
         %(kwargs_fun)s
 

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -211,7 +211,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(picks_all_data_noref)s
         %(dtype_applyfun)s
         %(n_jobs)s Ignored if ``channel_wise=False`` as the workload
-            is splitted across channels.
+            is split across channels.
         %(verbose)s
         %(kwargs_fun)s
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -925,7 +925,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(fun_applyfun)s
         %(picks_all_data_noref)s
         %(dtype_applyfun)s
-        %(n_jobs)s Ignored if ``channel_wise=False`` as the workload is
+        %(n_jobs)s Ignored if ``channel_wise=False`` as the workload
             is splitted across channels.
         %(channel_wise_applyfun)s
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -925,7 +925,8 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(fun_applyfun)s
         %(picks_all_data_noref)s
         %(dtype_applyfun)s
-        %(n_jobs)s
+        %(n_jobs)s Ignored if ``channel_wise=False`` as the workload is
+            is splitted across channels.
         %(channel_wise_applyfun)s
 
             .. versionadded:: 0.18

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -926,7 +926,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         %(picks_all_data_noref)s
         %(dtype_applyfun)s
         %(n_jobs)s Ignored if ``channel_wise=False`` as the workload
-            is splitted across channels.
+            is split across channels.
         %(channel_wise_applyfun)s
 
             .. versionadded:: 0.18

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -184,7 +184,7 @@ using the ``dtype`` parameter, which causes the data type of **all** the data
 to change (even if the function is only applied to channels in ``picks``).{}
 
 .. note:: If ``n_jobs`` > 1, more memory is required as
-          ``len(picks) * n_times`` additional time points need to
+          ``n_jobs * n_times`` additional time points need to
           be temporarily stored in memory.
 .. note:: If the data type changes (``dtype != None``), more memory is
           required since the original and the converted data needs

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -184,7 +184,7 @@ using the ``dtype`` parameter, which causes the data type of **all** the data
 to change (even if the function is only applied to channels in ``picks``).{}
 
 .. note:: If ``n_jobs`` > 1, more memory is required as
-          ``n_jobs * n_times`` additional time points need to
+          ``len(picks) * n_times`` additional time points need to
           be temporarily stored in memory.
 .. note:: If the data type changes (``dtype != None``), more memory is
           required since the original and the converted data needs


### PR DESCRIPTION
Minor documentation fix for the `apply_function` methods, e.g. https://mne.tools/dev/generated/mne.io.Raw.html#mne.io.Raw.apply_function

```
If n_jobs > 1, more memory is required as len(picks) * n_times additional time points need to be temporarily stored in memory.
```

-> n_jobs * n_times and not len(picks).