### PR TITLE
MRG: Add support for a callable in the combine argument of TFR plots

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -27,7 +27,7 @@ Enhancements
 - Mixed, cortical + discrete source spaces with fixed orientations are now allowed. (:gh:`11241` by `Jevri Hanna`_)
 - Add :func:`mne.beamformer.apply_dics_tfr_epochs` to apply a DICS beamformer to time-frequency resolved epochs (:gh:`11096` by `Alex Rockhill`_)
 - Check whether head radius (estimated from channel positions) is correct when reading EEGLAB data with :func:`~mne.io.read_raw_eeglab` and :func:`~mne.read_epochs_eeglab`. If head radius is not within likely values, warn informing about possible units mismatch and the new ``montage_units`` argument (:gh:`11283` by `Mikołaj Magnuski`_).
-- Add support for a callable passed in ``combine`` for `mne.time_frequency.AverageTFR.plot` and `mne.time_frequency.AverageTFR.plot:joint` (:gh:`11329` by `Mathieu Scheltienne`_)
+- Add support for a callable passed in ``combine`` for `mne.time_frequency.AverageTFR.plot` and `mne.time_frequency.AverageTFR.plot_joint` (:gh:`11329` by `Mathieu Scheltienne`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -27,6 +27,7 @@ Enhancements
 - Mixed, cortical + discrete source spaces with fixed orientations are now allowed. (:gh:`11241` by `Jevri Hanna`_)
 - Add :func:`mne.beamformer.apply_dics_tfr_epochs` to apply a DICS beamformer to time-frequency resolved epochs (:gh:`11096` by `Alex Rockhill`_)
 - Check whether head radius (estimated from channel positions) is correct when reading EEGLAB data with :func:`~mne.io.read_raw_eeglab` and :func:`~mne.read_epochs_eeglab`. If head radius is not within likely values, warn informing about possible units mismatch and the new ``montage_units`` argument (:gh:`11283` by `Mikołaj Magnuski`_).
+- Add support for a callable passed in ``combine`` for `mne.time_frequency.AverageTFR.plot` and `mne.time_frequency.AverageTFR.plot:joint` (:gh:`11329` by `Mathieu Scheltienne`_)
 
 Bugs
 ~~~~

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -127,6 +127,8 @@ def pytest_configure(config):
     ignore:Passing a schema to Validator\.iter_errors is deprecated.*:
     ignore:Unclosed context <zmq.asyncio.Context.*:ResourceWarning
     ignore:Jupyter is migrating its paths.*:DeprecationWarning
+    # hopefully temporary https://github.com/matplotlib/matplotlib/pull/24455#issuecomment-1319318629
+    ignore:The circles attribute was deprecated in Matplotlib.*:
     """.format(first_kind)  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -1,6 +1,7 @@
 from itertools import product
 import datetime
 import os.path as op
+import re
 
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_equal, assert_allclose)
@@ -610,7 +611,7 @@ def test_plot():
         picks,
         title='auto',
         colorbar=False,
-        combine=lambda x: x.median(axis=0),
+        combine=lambda x: x.mean(axis=0),
         mask=np.ones(tfr.data.shape[1:], bool),
     )
     assert len(figs) == 1
@@ -620,9 +621,15 @@ def test_plot():
                  mask=np.ones(tfr.data.shape[1:], bool))
     with pytest.raises(RuntimeError, match="must operate on a single"):
         tfr.plot(picks, combine=lambda x, y: x.mean(axis=0))
-    with pytest.raises(RuntimeError, match="of shape (n_freqs, n_times)."):
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape("of shape (n_freqs, n_times).")
+    ):
         tfr.plot(picks, combine=lambda x: x.mean(axis=0, keepdims=True))
-    with pytest.raises(RuntimeError, match="of shape (n_freqs, n_times)."):
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape("return a numpy array of shape (n_freqs, n_times).")
+    ):
         tfr.plot(picks, combine=lambda x: 101)
 
     plt.close('all')
@@ -692,7 +699,7 @@ def test_plot_joint():
 
     topomap_args = {'res': 8, 'contours': 0, 'sensors': False}
 
-    for combine in ('mean', 'rms', lambda x: x.median(axis=0)):
+    for combine in ('mean', 'rms', lambda x: x.mean(axis=0)):
         with catch_logging() as log:
             tfr.plot_joint(title='auto', colorbar=True,
                            combine=combine, topomap_args=topomap_args,

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1360,7 +1360,7 @@ class AverageTFR(_BaseTFR):
                     "(n_freqs, n_times)."
                 )
             # keep initial dimensions
-            data = data.reshape(1, *data.shape)
+            data = data[np.newaxis]
 
         # figure overhead
         # set plot dimension
@@ -1482,6 +1482,9 @@ class AverageTFR(_BaseTFR):
             function, it must operate on an array of shape
             ``(n_channels, n_freqs, n_times)`` and return an array of shape
             ``(n_freqs, n_times)``.
+
+            .. versionchanged:: 1.3
+               Added support for ``callable``.
         exclude : list of str | 'bads'
             Channels names to exclude from being shown. If 'bads', the
             bad channels are excluded. Defaults to an empty list, i.e., ``[]``.

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1664,7 +1664,7 @@ class AverageTFR(_BaseTFR):
                 picks = _pair_grad_sensors(tfr.info, topomap_coords=False)
                 pos = _find_topomap_coords(
                     tfr.info, picks=picks[::2], sphere=sphere)
-                method = combine or 'rms'
+                method = combine if isinstance(combine, str) else "rms"
                 data, _ = _merge_ch_data(data[picks], ch_type, [],
                                          method=method)
                 del picks, method

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1284,6 +1284,9 @@ class AverageTFR(_BaseTFR):
             None, plot one figure per selected channel. If a function, it must
             operate on an array of shape ``(n_channels, n_freqs, n_times)`` and
             return an array of shape ``(n_freqs, n_times)``.
+            
+            .. versionchanged:: 1.3
+               Added support for ``callable``.
         exclude : list of str | 'bads'
             Channels names to exclude from being shown. If 'bads', the
             bad channels are excluded. Defaults to an empty list.

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1344,7 +1344,13 @@ class AverageTFR(_BaseTFR):
             # It must operate on (n_channels, n_freqs, n_times) and return
             # (n_freqs, n_times). Operates on a copy in-case 'combine' does
             # some in-place operations.
-            data = combine(data.copy())
+            try:
+                data = combine(data.copy())
+            except TypeError:
+                raise RuntimeError(
+                    "A callable 'combine' must operate on a single argument, "
+                    "a numpy array of shape (n_channels, n_freqs, n_times)."
+                )
             if (
                 not isinstance(data, np.ndarray)
                 or data.shape != tfr.data.shape[1:]

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1284,7 +1284,7 @@ class AverageTFR(_BaseTFR):
             None, plot one figure per selected channel. If a function, it must
             operate on an array of shape ``(n_channels, n_freqs, n_times)`` and
             return an array of shape ``(n_freqs, n_times)``.
-            
+
             .. versionchanged:: 1.3
                Added support for ``callable``.
         exclude : list of str | 'bads'
@@ -1410,7 +1410,7 @@ class AverageTFR(_BaseTFR):
                     subtitle = tfr.info['ch_names'][idx]
                 else:
                     subtitle = _set_title_multiple_electrodes(
-                        None, combine, tfr.info["ch_names"], all=True,
+                        None, combine, tfr.info["ch_names"], all_=True,
                         ch_type=ch_type)
             else:
                 subtitle = title

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1279,9 +1279,11 @@ class AverageTFR(_BaseTFR):
             Defaults to 0.1.
 
             .. versionadded:: 0.16.0
-        combine : 'mean' | 'rms' | None
+        combine : 'mean' | 'rms' | callable | None
             Type of aggregation to perform across selected channels. If
-            None, plot one figure per selected channel.
+            None, plot one figure per selected channel. If a function, it must
+            operate on an array of shape ``(n_channels, n_freqs, n_times)`` and
+            return an array of shape ``(n_freqs, n_times)``.
         exclude : list of str | 'bads'
             Channels names to exclude from being shown. If 'bads', the
             bad channels are excluded. Defaults to an empty list.
@@ -1469,8 +1471,11 @@ class AverageTFR(_BaseTFR):
             The scale of y (frequency) axis. 'linear' gives linear y axis,
             'log' leads to log-spaced y axis and 'auto' detects if frequencies
             are log-spaced and only then sets the y axis to 'log'.
-        combine : 'mean' | 'rms'
-            Type of aggregation to perform across selected channels.
+        combine : 'mean' | 'rms' | callable
+            Type of aggregation to perform across selected channels. If a
+            function, it must operate on an array of shape
+            ``(n_channels, n_freqs, n_times)`` and return an array of shape
+            ``(n_freqs, n_times)``.
         exclude : list of str | 'bads'
             Channels names to exclude from being shown. If 'bads', the
             bad channels are excluded. Defaults to an empty list, i.e., ``[]``.

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1950,7 +1950,7 @@ def _check_cov(noise_cov, info):
 
 
 def _set_title_multiple_electrodes(title, combine, ch_names, max_chans=6,
-                                   all=False, ch_type=None):
+                                   all_=False, ch_type=None):
     """Prepare a title string for multiple electrodes."""
     if title is None:
         title = ", ".join(ch_names[:max_chans])
@@ -1959,15 +1959,15 @@ def _set_title_multiple_electrodes(title, combine, ch_names, max_chans=6,
             ch_type = "sensor"
         if len(ch_names) > 1:
             ch_type += "s"
-        if all is True and isinstance(combine, str):
-            combine = combine.capitalize()
-            title = "{} of {} {}".format(
-                combine, len(ch_names), ch_type)
+        combine = combine.capitalize() \
+            if isinstance(combine, str) else "Combination"
+        if all_:
+            title = f"{combine} of {len(ch_names)} {ch_type}"
         elif len(ch_names) > max_chans and combine != "gfp":
-            logger.info("More than {} channels, truncating title ...".format(
-                max_chans))
-            title += ", ...\n({} of {} {})".format(
-                combine, len(ch_names), ch_type,)
+            logger.info(
+                "More than %i channels, truncating title ...", max_chans
+            )
+            title += f", ...\n({combine} of {len(ch_names)} {ch_type})"
     return title
 
 

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -14,7 +14,8 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	# python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6 PyQt6-sip PyQt6-Qt6
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps PyQt6 PyQt6-sip PyQt6-Qt6
 	# SciPy Windows build is missing from conda nightly builds
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy statsmodels pandas scikit-learn dipy "matplotlib<3.7"
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" "matplotlib<3.7"  # gh-11332
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy statsmodels pandas scikit-learn dipy
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://test.pypi.org/simple" openmeeg
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps vtk

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -14,7 +14,7 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	# python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6 PyQt6-sip PyQt6-Qt6
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps PyQt6 PyQt6-sip PyQt6-Qt6
 	# SciPy Windows build is missing from conda nightly builds
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy statsmodels pandas scikit-learn dipy matplotlib
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy statsmodels pandas scikit-learn dipy "matplotlib<3.7"
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://test.pypi.org/simple" openmeeg
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps vtk

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -19,7 +19,7 @@ else
 	# pip install $STD_ARGS --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6 PyQt6-sip PyQt6-Qt6
 	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps PyQt6 PyQt6-sip PyQt6-Qt6
 	echo "NumPy/SciPy/pandas etc."
-	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps  --default-timeout=60 -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy scikit-learn dipy matplotlib pandas statsmodels
+	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps  --default-timeout=60 -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy scikit-learn dipy "matplotlib<3.7" pandas statsmodels
 	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
 	pip install $STD_ARGS --pre --only-binary ":all:" pillow
 	# We don't install Numba here because it forces an old NumPy version

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -19,7 +19,8 @@ else
 	# pip install $STD_ARGS --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6 PyQt6-sip PyQt6-Qt6
 	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps PyQt6 PyQt6-sip PyQt6-Qt6
 	echo "NumPy/SciPy/pandas etc."
-	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps  --default-timeout=60 -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy scikit-learn dipy "matplotlib<3.7" pandas statsmodels
+	pip install $STD_ARGS --pre --only-binary ":all:" "matplotlib<3.7"  # gh-11332
+	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps  --default-timeout=60 -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy scikit-learn dipy pandas statsmodels
 	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
 	pip install $STD_ARGS --pre --only-binary ":all:" pillow
 	# We don't install Numba here because it forces an old NumPy version


### PR DESCRIPTION
I added support for passing a `callable` to control how the channels are combined when plotting a TFR.
For now, it only supported `'mean'` and `'rms'`. I could use this feature as I'd like to do a weighted average instead.