### PR TITLE
Ensure n_fft, n_overlap and n_per_seg are integers

### DIFF
--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -7,7 +7,7 @@ from functools import partial
 import numpy as np
 
 from ..parallel import parallel_func
-from ..utils import logger, verbose, _check_option
+from ..utils import logger, verbose, _check_option, _validate_type
 
 
 # adapted from SciPy
@@ -145,6 +145,10 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     .. footbibliography::
     """
     _check_option('average', average, (None, False, 'mean', 'median'))
+    _validate_type(n_fft, "int", "n_fft")
+    _validate_type(n_overlap, "int", "n_overlap")
+    if n_per_seg is not None:
+        _validate_type(n_per_seg, "int", "n_per_seg")
     if average is False:
         average = None
 

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -146,9 +146,9 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     """
     _check_option('average', average, (None, False, 'mean', 'median'))
     n_fft = _ensure_int(n_fft, "n_fft")
-    n_overlap= _ensure_int(n_overlap, "n_overlap")
+    n_overlap = _ensure_int(n_overlap, "n_overlap")
     if n_per_seg is not None:
-        n_per_seg= _ensure_int(n_per_seg, "n_per_seg")
+        n_per_seg = _ensure_int(n_per_seg, "n_per_seg")
     if average is False:
         average = None
 

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -147,7 +147,8 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     _check_option('average', average, (None, False, 'mean', 'median'))
     _validate_type(n_fft, "int", "n_fft")
     _validate_type(n_overlap, "int", "n_overlap")
-    _validate_type(n_per_seg, ("int", None), "n_per_seg")
+    if n_per_seg is not None:
+        _validate_type(n_per_seg, "int", "n_per_seg")
     if average is False:
         average = None
 

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -7,7 +7,7 @@ from functools import partial
 import numpy as np
 
 from ..parallel import parallel_func
-from ..utils import logger, verbose, _check_option, _validate_type
+from ..utils import logger, verbose, _check_option, _ensure_int
 
 
 # adapted from SciPy
@@ -145,10 +145,10 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     .. footbibliography::
     """
     _check_option('average', average, (None, False, 'mean', 'median'))
-    _validate_type(n_fft, "int", "n_fft")
-    _validate_type(n_overlap, "int", "n_overlap")
+    n_fft = _ensure_int(n_fft, "n_fft")
+    n_overlap= _ensure_int(n_overlap, "n_overlap")
     if n_per_seg is not None:
-        _validate_type(n_per_seg, "int", "n_per_seg")
+        n_per_seg= _ensure_int(n_per_seg, "n_per_seg")
     if average is False:
         average = None
 

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -147,8 +147,7 @@ def psd_array_welch(x, sfreq, fmin=0, fmax=np.inf, n_fft=256, n_overlap=0,
     _check_option('average', average, (None, False, 'mean', 'median'))
     _validate_type(n_fft, "int", "n_fft")
     _validate_type(n_overlap, "int", "n_overlap")
-    if n_per_seg is not None:
-        _validate_type(n_per_seg, "int", "n_per_seg")
+    _validate_type(n_per_seg, ("int", None), "n_per_seg")
     if average is False:
         average = None
 

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -741,7 +741,7 @@ def test_plot_raw_psd(raw, raw_orig):
     raw.plot_psd(tmax=None, picks=picks, area_mode='range', average=False,
                  spatial_colors=True)
     raw.plot_psd(tmax=20., color='yellow', dB=False, line_alpha=0.4,
-                 n_overlap=0.1, average=False)
+                 average=False)
     plt.close('all')
     # one axes supplied
     ax = plt.axes()


### PR DESCRIPTION
Improvement to make sure the arguments `n_fft`, `n_overlap` and `n_per_seg` are integers in Welch's method, to avoid this crpytic traceback when a float is provided (which is common if you do `duration * raw.info["sfreq"]` and forget to convert to int):

```
Effective window size : 4.000 (s)
Traceback (most recent call last):
  File "/Users/rellis/Library/Application Support/JetBrains/IntelliJIdea2021.2/plugins/python/helpers/pydev/pydevd.py", line 1483, in _exec
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "/Users/rellis/Library/Application Support/JetBrains/IntelliJIdea2021.2/plugins/python/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/Users/rellis/dev/git/[project]/analysis/power-spectrum-measures.py", line 152, in <module>
    epochPs = epochs.compute_psd(method='welch', picks=picks, fmin=FMIN, fmax=FMAX, n_fft=4*epochs.info["sfreq"])
  File "<decorator-gen-277>", line 12, in compute_psd
  File "/Users/rellis/opt/anaconda3/envs/rob-nme/lib/python3.9/site-packages/mne/epochs.py", line 2031, in compute_psd
    return EpochsSpectrum(
  File "/Users/rellis/opt/anaconda3/envs/rob-nme/lib/python3.9/site-packages/mne/time_frequency/spectrum.py", line 1042, in __init__
    self._compute_spectra(data, fmin, fmax, n_jobs, method_kw, verbose)
  File "/Users/rellis/opt/anaconda3/envs/rob-nme/lib/python3.9/site-packages/mne/time_frequency/spectrum.py", line 380, in _compute_spectra
    result = self._psd_func(
  File "<decorator-gen-199>", line 12, in psd_array_welch
  File "/Users/rellis/opt/anaconda3/envs/rob-nme/lib/python3.9/site-packages/mne/time_frequency/psd.py", line 184, in psd_array_welch
    f_spect = parallel(my_spect_func(d, func=func, freq_sl=freq_sl,
  File "/Users/rellis/opt/anaconda3/envs/rob-nme/lib/python3.9/site-packages/mne/time_frequency/psd.py", line 184, in <genexpr>
    f_spect = parallel(my_spect_func(d, func=func, freq_sl=freq_sl,
  File "/Users/rellis/opt/anaconda3/envs/rob-nme/lib/python3.9/site-packages/mne/time_frequency/psd.py", line 73, in _spect_func
    spect = np.apply_along_axis(
  File "<__array_function__ internals>", line 5, in apply_along_axis
  File "/Users/rellis/opt/anaconda3/envs/rob-nme/lib/python3.9/site-packages/numpy/lib/shape_base.py", line 379, in apply_along_axis
    res = asanyarray(func1d(inarr_view[ind0], *args, **kwargs))
  File "/Users/rellis/opt/anaconda3/envs/rob-nme/lib/python3.9/site-packages/mne/time_frequency/psd.py", line 52, in _decomp_aggregate_mask
    _, _, spect = func(epoch)
  File "/Users/rellis/opt/anaconda3/envs/rob-nme/lib/python3.9/site-packages/scipy/signal/spectral.py", line 737, in spectrogram
    window, nperseg = _triage_segments(window, nperseg,
  File "/Users/rellis/opt/anaconda3/envs/rob-nme/lib/python3.9/site-packages/scipy/signal/spectral.py", line 1965, in _triage_segments
    win = get_window(window, nperseg)
  File "/Users/rellis/opt/anaconda3/envs/rob-nme/lib/python3.9/site-packages/scipy/signal/windows/windows.py", line 2153, in get_window
    return winfunc(*params)
  File "/Users/rellis/opt/anaconda3/envs/rob-nme/lib/python3.9/site-packages/scipy/signal/windows/windows.py", line 1095, in hamming
    return general_hamming(M, 0.54, sym)
  File "/Users/rellis/opt/anaconda3/envs/rob-nme/lib/python3.9/site-packages/scipy/signal/windows/windows.py", line 1017, in general_hamming
    return general_cosine(M, [alpha, 1. - alpha], sym)
  File "/Users/rellis/opt/anaconda3/envs/rob-nme/lib/python3.9/site-packages/scipy/signal/windows/windows.py", line 113, in general_cosine
    fac = np.linspace(-np.pi, np.pi, M)
  File "<__array_function__ internals>", line 5, in linspace
  File "/Users/rellis/opt/anaconda3/envs/rob-nme/lib/python3.9/site-packages/numpy/core/function_base.py", line 120, in linspace
    num = operator.index(num)
TypeError: 'float' object cannot be interpreted as an integer
python-BaseException

Process finished with exit code 1
```

From the forum post https://mne.discourse.group/t/set-window-size-for-welch-via-compute-psd/5958/6