### PR TITLE
BUG: Fix bug with dots in directory names

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -47,6 +47,7 @@ Bugs
 - Fix bug where computing PSD with welch's method with more jobs than channels would fail (:gh:`11298` by `Mathieu Scheltienne`_)
 - Fix bug with :func:`mne.decoding.cross_val_multiscore` where progress bars were not displayed correctly (:gh:`11311` by `Eric Larson`_)
 - Fix channel selection edge-cases in `~mne.preprocessing.ICA.find_bads_muscle` (:gh:`11300` by `Mathieu Scheltienne`_)
+- Fix bug with :func:`mne.io.read_raw_curry` where a dot in the parent folders prevented files from being read (:gh:`11340` by `Eric Larson`_)
 - Fix bug with :class:`mne.Report` with ``replace=True`` where the wrong content was replaced (:gh:`11318` by `Eric Larson`_)
 - Multitaper spectral estimation now uses periodic (rather than symmetric) taper windows. This also necessitated changing the default ``max_iter`` of our cross-spectral density functions from 150 to 250. (:gh:`11293` by `Daniel McCloy`_)
 - Fix :meth:`mne.Epochs.plot_image` and :func:`mne.viz.plot_epochs_image` when using EMG signals (:gh:`11322` by `Alex Gramfort`_)

--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -5,11 +5,13 @@
 #
 # License: BSD-3-Clause
 
-import os.path as op
 from collections import namedtuple
-import re
-import numpy as np
 from datetime import datetime, timezone
+import os.path as op
+from pathlib import Path
+import re
+
+import numpy as np
 
 from .._digitization import _make_dig_points
 from ..base import BaseRaw
@@ -65,10 +67,16 @@ def _get_curry_file_structure(fname, required=()):
     """Store paths to a dict and check for required files."""
     _msg = "The following required files cannot be found: {0}.\nPlease make " \
            "sure all required files are located in the same directory as {1}."
-    fname = _check_fname(fname, 'read', True, 'fname')
+    fname = Path(_check_fname(fname, 'read', True, 'fname'))
 
     # we don't use os.path.splitext to also handle extensions like .cdt.dpa
-    fname_base, ext = fname.split(".", maxsplit=1)
+    # this won't handle a dot in the filename, but it should handle it in
+    # the parent directories
+    fname_base = fname.name.split('.', maxsplit=1)[0]
+    ext = fname.name[len(fname_base):]
+    fname_base = str(fname)
+    fname_base = fname_base[:len(fname_base) - len(ext)]
+    del fname
     version = _get_curry_version(ext)
     my_curry = dict()
     for key in ('info', 'data', 'labels', 'events_cef', 'events_ceo', 'hpi'):
@@ -470,7 +478,7 @@ def read_raw_curry(fname, preload=False, verbose=None):
     Parameters
     ----------
     fname : str
-        Path to a curry file with extensions .dat, .dap, .rs3, .cdt, cdt.dpa,
+        Path to a curry file with extensions .dat, .dap, .rs3, .cdt, .cdt.dpa,
         .cdt.cef or .cef.
     %(preload)s
     %(verbose)s
@@ -489,7 +497,7 @@ class RawCurry(BaseRaw):
     Parameters
     ----------
     fname : str
-        Path to a curry file with extensions .dat, .dap, .rs3, .cdt, cdt.dpa,
+        Path to a curry file with extensions .dat, .dap, .rs3, .cdt, .cdt.dpa,
         .cdt.cef or .cef.
     %(preload)s
     %(verbose)s

--- a/mne/io/curry/tests/test_curry.py
+++ b/mne/io/curry/tests/test_curry.py
@@ -7,6 +7,7 @@
 
 from datetime import datetime, timezone
 import os.path as op
+from pathlib import Path
 from shutil import copyfile
 
 import pytest
@@ -491,3 +492,22 @@ def test_meas_date(fname, expected_meas_date):
     # If the information is not valid, raw.info['meas_date'] should be None
     raw = read_raw_curry(fname, preload=False)
     assert raw.info['meas_date'] == expected_meas_date
+
+
+@testing.requires_testing_data
+@pytest.mark.parametrize('fname, others', [
+    pytest.param(curry7_rfDC_file, ('.dap', '.rs3'), id='curry7'),
+    pytest.param(curry8_rfDC_file, ('.cdt.dpa',), id='curry8'),
+])
+def test_dot_names(fname, others, tmp_path):
+    """Test that dots are parsed properly (e.g., in paths)."""
+    my_path = tmp_path / 'dot.dot.dot'
+    my_path.mkdir()
+    my_path = my_path / Path(fname).parts[-1]
+    fname = Path(fname)
+    copyfile(fname, my_path)
+    for ext in others:
+        this_fname = fname.with_suffix(ext)
+        to_fname = my_path.with_suffix(ext)
+        copyfile(this_fname, to_fname)
+    read_raw_curry(my_path)


### PR DESCRIPTION
`read_raw_curry` didn't work if there was a `.` in a parent folder name, this fixes it