### PR TITLE
fix default n_fft for spectrum plots

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -46,6 +46,7 @@ Bugs
 - Fix bug in the :func:`~mne.viz.plot_evoked_topo` and :meth:`~mne.Evoked.plot_topo`, where legend colors where shown incorrectly on newer matplotlib versions (:gh:`11258` by `Erkka Heinila`_)
 - Fix bug where EEGLAB channel positions were read as meters, while they are commonly in millimeters, leading to head outlies of the size of one channel when plotting topomaps. Now ``montage_units`` argument has been added to :func:`~mne.io.read_raw_eeglab` and :func:`~mne.read_epochs_eeglab` to control in what units EEGLAB channel positions are read. The default is millimeters, ``'mm'`` (:gh:`11283` by `Mikołaj Magnuski`_)
 - Fix bug where computing PSD with welch's method with more jobs than channels would fail (:gh:`11298` by `Mathieu Scheltienne`_)
+- Fix bug where the default FFT length changed for spectrum plots (:gh:`11345` by `Daniel McCloy`_)
 - Fix bug with :func:`mne.decoding.cross_val_multiscore` where progress bars were not displayed correctly (:gh:`11311` by `Eric Larson`_)
 - Fix channel selection edge-cases in `~mne.preprocessing.ICA.find_bads_muscle` (:gh:`11300` by `Mathieu Scheltienne`_)
 - Fix bug with :func:`mne.io.read_raw_curry` where a dot in the parent folders prevented files from being read (:gh:`11340` by `Eric Larson`_)

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -94,6 +94,7 @@ class SpectrumMixin():
         """
         from ..io import BaseRaw
 
+        method = _validate_method(method, type(self).__name__)
         self._set_legacy_nfft_default(tmin, tmax, method, method_kw)
         # triage reject_by_annotation
         rba = dict()
@@ -149,6 +150,7 @@ class SpectrumMixin():
         fig : instance of matplotlib.figure.Figure
             Figure distributing one image per channel across sensor topography.
         """
+        method = _validate_method(method, type(self).__name__)
         self._set_legacy_nfft_default(tmin, tmax, method, method_kw)
 
         spectrum = self.compute_psd(
@@ -253,10 +255,7 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
                 f'frequency of the data ({0.5 * inst.info["sfreq"]} Hz).')
         # method
         self._inst_type = type(inst)
-        if method == 'auto':
-            method = ('welch' if self._get_instance_type_string() == 'Raw'
-                      else 'multitaper')
-        _check_option('method', method, ('welch', 'multitaper'))
+        method = _validate_method(method, self._get_instance_type_string())
 
         # triage method and kwargs. partial() doesn't check validity of kwargs,
         # so we do it manually to save compute time if any are invalid.
@@ -1188,3 +1187,11 @@ def _compute_n_welch_segments(n_times, method_kw):
     # compute expected number of segments
     step = n_per_seg - n_overlap
     return (n_times - n_overlap) // step
+
+
+def _validate_method(method, instance_type):
+    """Convert 'auto' to a real method name, and validate."""
+    if method == 'auto':
+        method = 'welch' if instance_type == 'Raw' else 'multitaper'
+    _check_option('method', method, ('welch', 'multitaper'))
+    return method

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -1192,6 +1192,6 @@ def _compute_n_welch_segments(n_times, method_kw):
 def _validate_method(method, instance_type):
     """Convert 'auto' to a real method name, and validate."""
     if method == 'auto':
-        method = 'welch' if instance_type == 'Raw' else 'multitaper'
+        method = 'welch' if instance_type.startswith('Raw') else 'multitaper'
     _check_option('method', method, ('welch', 'multitaper'))
     return method


### PR DESCRIPTION
closes #11343 

there was already code in there to use the old default `n_fft` in hopes of avoiding this bug, but that code wasn't getting triggered in some cases because it looked for `method=='welch'` and was receiving `method=='auto'`.  Now we convert "auto" to a proper method name right away.