### PR TITLE
BUG: Fix where report replacement did not respect section

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -49,7 +49,7 @@ Bugs
 - Fix bug with :func:`mne.decoding.cross_val_multiscore` where progress bars were not displayed correctly (:gh:`11311` by `Eric Larson`_)
 - Fix channel selection edge-cases in `~mne.preprocessing.ICA.find_bads_muscle` (:gh:`11300` by `Mathieu Scheltienne`_)
 - Fix bug with :func:`mne.io.read_raw_curry` where a dot in the parent folders prevented files from being read (:gh:`11340` by `Eric Larson`_)
-- Fix bug with :class:`mne.Report` with ``replace=True`` where the wrong content was replaced (:gh:`11318` by `Eric Larson`_)
+- Fix bug with :class:`mne.Report` with ``replace=True`` where the wrong content was replaced and ``section`` was not respected (:gh:`11318`, :gh:`11346` by `Eric Larson`_)
 - Multitaper spectral estimation now uses periodic (rather than symmetric) taper windows. This also necessitated changing the default ``max_iter`` of our cross-spectral density functions from 150 to 250. (:gh:`11293` by `Daniel McCloy`_)
 - Fix :meth:`mne.Epochs.plot_image` and :func:`mne.viz.plot_epochs_image` when using EMG signals (:gh:`11322` by `Alex Gramfort`_)
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -1778,16 +1778,14 @@ class Report:
 
     @fill_doc
     def _add_or_replace(
-        self, *, name, section, dom_id, tags, html, replace=False
+        self, *, title, section, dom_id, tags, html, replace=False
     ):
         """Append HTML content report, or replace it if it already exists.
 
         Parameters
         ----------
-        name : str
-            The entry under which the content shall be listed in the table of
-            contents. If it already exists, the content will be replaced if
-            ``replace`` is ``True``
+        title : str
+            The title entry.
         %(section_report)s
         dom_id : str
             A unique element ``id`` in the DOM.
@@ -1796,25 +1794,29 @@ class Report:
         html : str
             The HTML.
         replace : bool
-            Whether to replace existing content.
+            Whether to replace existing content if the title and section match.
         """
         assert isinstance(html, str)  # otherwise later will break
 
         new_content = _ContentElement(
-            name=name,
+            name=title,
             section=section,
             dom_id=dom_id,
             tags=tags,
             html=html
         )
 
-        existing_names = [element.name for element in self._content]
-        if name in existing_names and replace:
-            # Find and replace last existing element with the same name
-            idx = [ii for ii, element_name in enumerate(existing_names)
-                   if element_name == name][-1]
-            self._content[idx] = new_content
-        else:
+        append = True
+        if replace:
+            matches = [
+                ii
+                for ii, element in enumerate(self._content)
+                if (element.name, element.section) == (title, section)
+            ]
+            if matches:
+                self._content[matches[-1]] = new_content
+                append = False
+        if append:
             self._content.append(new_content)
 
     def _add_code(self, *, code, title, language, section, tags, replace):
@@ -1831,7 +1833,7 @@ class Report:
         )
         self._add_or_replace(
             dom_id=dom_id,
-            name=title,
+            title=title,
             section=section,
             tags=tags,
             html=html,
@@ -1912,7 +1914,7 @@ class Report:
         )
         self._add_or_replace(
             dom_id=dom_id,
-            name=title,
+            title=title,
             section=section,
             tags=tags,
             html=html,
@@ -2047,7 +2049,8 @@ class Report:
 
     @fill_doc
     def add_html(
-        self, html, title, *, tags=('custom-html',), replace=False
+        self, html, title, *, tags=('custom-html',), section=None,
+        replace=False
     ):
         """Add HTML content to the report.
 
@@ -2058,6 +2061,9 @@ class Report:
         title : str
             The title corresponding to ``html``.
         %(tags_report)s
+        %(section_report)s
+
+            .. versionadded:: 1.3
         %(replace_report)s
 
         Notes
@@ -2072,7 +2078,7 @@ class Report:
         )
         self._add_or_replace(
             dom_id=dom_id,
-            name=title,
+            title=title,
             section=None,
             tags=tags,
             html=html_element,
@@ -2114,7 +2120,7 @@ class Report:
         self._add_bem(
             subject=subject, subjects_dir=subjects_dir,
             decim=decim, n_jobs=n_jobs, width=width,
-            image_format=self.image_format, section=title, tags=tags,
+            image_format=self.image_format, title=title, tags=tags,
             replace=replace
         )
 
@@ -2163,7 +2169,7 @@ class Report:
             klass=klass, own_figure=own_figure
         )
         self._add_or_replace(
-            name=title,
+            title=title,
             section=section,
             dom_id=dom_id,
             tags=tags,
@@ -2882,7 +2888,7 @@ class Report:
             tags=tags
         )
         self._add_or_replace(
-            name=title,
+            title=title,
             section=section,
             dom_id=dom_id,
             tags=tags,
@@ -2941,7 +2947,7 @@ class Report:
             tags=tags,
         )
         self._add_or_replace(
-            name=title,
+            title=title,
             section=section,
             dom_id=dom_id,
             tags=tags,
@@ -3325,7 +3331,7 @@ class Report:
             html=html
         )
         self._add_or_replace(
-            name=title,
+            title=title,
             section=section,
             dom_id=dom_id,
             tags=tags,
@@ -3714,7 +3720,7 @@ class Report:
 
     def _add_bem(
         self, *, subject, subjects_dir, decim, n_jobs, width=512,
-        image_format, section, tags, replace
+        image_format, title, tags, replace
     ):
         """Render mri+bem (only PNG)."""
         if subjects_dir is None:
@@ -3756,11 +3762,11 @@ class Report:
             html_slider_sagittal=html_slider_sagittal,
             html_slider_coronal=html_slider_coronal,
             tags=tags,
-            title=section,
+            title=title,
         )
         self._add_or_replace(
-            name=section,
-            section=None,  # avoid nesting
+            title=title,
+            section=None,  # no nesting
             dom_id=dom_id,
             tags=tags,
             html=html,

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -639,6 +639,42 @@ def test_add_or_replace(tags):
     assert r.html[3] == old_r.html[3]
 
 
+def test_add_or_replace_section():
+    """Test that sections are respected when adding or replacing."""
+    r = Report()
+    fig1, fig2 = _get_example_figures()
+    r.add_figure(fig=fig1, title='a', section='A')
+    r.add_figure(fig=fig1, title='a', section='B')
+    r.add_figure(fig=fig1, title='a', section='C')
+    # By default, replace=False, so all figures should be there
+    assert len(r.html) == 3
+    assert len(r._content) == 3
+
+    old_r = copy.deepcopy(r)
+    assert r.html[0] == old_r.html[0]
+    assert r.html[1] == old_r.html[1]
+    assert r.html[2] == old_r.html[2]
+
+    # Replace last occurrence of `fig1` tagges as `foo`
+    r.add_figure(fig=fig2, title='a', section='B', replace=True)
+    r._dom_id = 3  # help out the .html property
+    assert len(r._content) == 3
+    assert len(r.html) == 3
+    assert r.html[0] == old_r.html[0]
+    assert r.html[1] != old_r.html[1]
+    assert r.html[2] == old_r.html[2]
+    r.add_figure(fig=fig1, title='a', section='B', replace=True)
+    r._dom_id = 3
+    assert r.html[0] == old_r.html[0]
+    assert r.html[1].replace('global-4', 'global-2') == old_r.html[1]
+    assert r.html[2] == old_r.html[2]
+    r.add_figure(fig=fig1, title='a', section='C', replace=True)
+    r._dom_id = 3
+    assert r.html[0] == old_r.html[0]
+    assert r.html[1].replace('global-4', 'global-2') == old_r.html[1]
+    assert r.html[2] != old_r.html[2]
+
+
 def test_scraper(tmp_path):
     """Test report scraping."""
     r = Report()

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2938,9 +2938,10 @@ reject : dict | None
 
 docdict['replace_report'] = """
 replace : bool
-    If ``True``, content already present that has the same ``title`` will be
-    replaced. Defaults to ``False``, which will cause duplicate entries in the
-    table of contents if an entry for ``title`` already exists.
+    If ``True``, content already present that has the same ``title`` and
+    ``section`` will be replaced. Defaults to ``False``, which will cause
+    duplicate entries in the table of contents if an entry for ``title``
+    already exists.
 """
 
 docdict['res_topomap'] = """


### PR DESCRIPTION
Helps with https://github.com/mne-tools/mne-bids-pipeline/issues/669, otherwise `you can only have one evoked plot at a time because they are nested by condition as section, and the `title`s are all the same when using `.add_section` (e.g., `Time course (EEG)` is the title but the section is `Condition: Auditory` would replace a plot from `Condition: Visual` if it exists already)!