### PR TITLE
[DOC] Fix video link for coregistration

### DIFF
--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -124,7 +124,7 @@ def coregistration(tabbed=False, split=True, width=None, inst=None,
 
     Step by step instructions for the coregistrations are shown below:
 
-    .. youtube:: uK4n5g6DBcg
+    .. youtube:: ALV5qqMHLlQ
     """
     unsupported_params = {
         'tabbed': (tabbed, False),


### PR DESCRIPTION
While preparing teaching, I found that the video link in the coregistration docstring seems to be broken (on stable and dev). I replaced the link with a matching video I found on the MNE-Python Youtube channel.

Seems to fit the link that was mentioned before merging here: https://github.com/mne-tools/mne-python/pull/10802#issuecomment-1164772429

Someone please double check it is the intended one? @drammock @larsoner @alexrockhill 