### PR TITLE
ENH: Add webp support to Report

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -28,6 +28,7 @@ Enhancements
 - Add a warning to the docstring of :func:`mne.channels.find_ch_adjacency` to encourage users to validate their outputs (:gh:`11236` by `Felix Klotzsche`_ and `Eric Larson`_)
 - Mixed, cortical + discrete source spaces with fixed orientations are now allowed. (:gh:`11241` by `Jevri Hanna`_)
 - Add size information to the ``repr`` of :class:`mne.Report` (:gh:`11357` by `Eric Larson`_)
+- Add support for ``image_format='webp'`` to :class:`mne.Report` when using Matplotlib 3.6+, which can reduce file sizes by up to 50% compared to ``'png'`` (:gh:`11359` by `Eric Larson`_)
 - Add :func:`mne.beamformer.apply_dics_tfr_epochs` to apply a DICS beamformer to time-frequency resolved epochs (:gh:`11096` by `Alex Rockhill`_)
 - Check whether head radius (estimated from channel positions) is correct when reading EEGLAB data with :func:`~mne.io.read_raw_eeglab` and :func:`~mne.read_epochs_eeglab`. If head radius is not within likely values, warn informing about possible units mismatch and the new ``montage_units`` argument (:gh:`11283` by `Mikołaj Magnuski`_).
 - Add support for a callable passed in ``combine`` for `mne.time_frequency.AverageTFR.plot` and `mne.time_frequency.AverageTFR.plot_joint` (:gh:`11329` by `Mathieu Scheltienne`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -28,7 +28,7 @@ Enhancements
 - Add a warning to the docstring of :func:`mne.channels.find_ch_adjacency` to encourage users to validate their outputs (:gh:`11236` by `Felix Klotzsche`_ and `Eric Larson`_)
 - Mixed, cortical + discrete source spaces with fixed orientations are now allowed. (:gh:`11241` by `Jevri Hanna`_)
 - Add size information to the ``repr`` of :class:`mne.Report` (:gh:`11357` by `Eric Larson`_)
-- Add support for ``image_format='webp'`` to :class:`mne.Report` when using Matplotlib 3.6+, which can reduce file sizes by up to 50% compared to ``'png'`` (:gh:`11359` by `Eric Larson`_)
+- Add support for ``image_format='webp'`` to :class:`mne.Report` when using Matplotlib 3.6+, which can reduce file sizes by up to 50% compared to ``'png'``. The new default ``image_format='auto'`` will automatically use this format if it's available on the system (:gh:`11359` by `Eric Larson`_)
 - Add :func:`mne.beamformer.apply_dics_tfr_epochs` to apply a DICS beamformer to time-frequency resolved epochs (:gh:`11096` by `Alex Rockhill`_)
 - Check whether head radius (estimated from channel positions) is correct when reading EEGLAB data with :func:`~mne.io.read_raw_eeglab` and :func:`~mne.read_epochs_eeglab`. If head radius is not within likely values, warn informing about possible units mismatch and the new ``montage_units`` argument (:gh:`11283` by `Mikołaj Magnuski`_).
 - Add support for a callable passed in ``combine`` for `mne.time_frequency.AverageTFR.plot` and `mne.time_frequency.AverageTFR.plot_joint` (:gh:`11329` by `Mathieu Scheltienne`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -56,6 +56,7 @@ Bugs
 - Fix bug with :class:`mne.Report` with ``replace=True`` where the wrong content was replaced and ``section`` was not respected (:gh:`11318`, :gh:`11346` by `Eric Larson`_)
 - Fix bug with unit conversion when setting reference MEG as the channel type in :meth:`mne.io.Raw.set_channel_types` and related methods (:gh:`11344` by `Eric Larson`_)
 - Fix bug where reference MEG channels could not be plotted using :func:`mne.viz.plot_epochs_image` (:gh:`11344` by `Eric Larson`_)
+- Fix bug where ``image_format='gif'`` was errantly documented as being supported by :class:`mne.Report`, it is now only supported in :meth:`mne.Report.add_image` (:gh:`11347` by `Eric Larson`_)
 - Multitaper spectral estimation now uses periodic (rather than symmetric) taper windows. This also necessitated changing the default ``max_iter`` of our cross-spectral density functions from 150 to 250. (:gh:`11293` by `Daniel McCloy`_)
 - Fix :meth:`mne.Epochs.plot_image` and :func:`mne.viz.plot_epochs_image` when using EMG signals (:gh:`11322` by `Alex Gramfort`_)
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -353,7 +353,7 @@ def _fig_to_img(fig, *, image_format='png', own_figure=True):
     )
 
     # https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
-    kwargs = dict()
+    mpl_kwargs = dict()
     pil_kwargs = dict()
     if image_format == 'webp':
         pil_kwargs.update(lossless=True, method=6)
@@ -361,14 +361,14 @@ def _fig_to_img(fig, *, image_format='png', own_figure=True):
         pil_kwargs.update(optimize=True, compress_level=9)
     if pil_kwargs:
         # matplotlib modifies the passed dict, which is a bug
-        kwargs['pil_kwargs'] = pil_kwargs.copy()
+        mpl_kwargs['pil_kwargs'] = pil_kwargs.copy()
     with warnings.catch_warnings():
         warnings.filterwarnings(
             action='ignore',
             message='.*Axes that are not compatible with tight_layout.*',
             category=UserWarning
         )
-        fig.savefig(output, format=image_format, dpi=dpi, **kwargs)
+        fig.savefig(output, format=image_format, dpi=dpi, **mpl_kwargs)
 
     if own_figure:
         plt.close(fig)

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -354,7 +354,8 @@ def _fig_to_img(fig, *, image_format='png', own_figure=True):
     # https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
     mpl_kwargs = dict()
     pil_kwargs = dict()
-    if check_version('PIL'):
+    has_pillow = check_version('PIL')
+    if has_pillow:
         if image_format == 'webp':
             pil_kwargs.update(lossless=True, method=6)
         elif image_format == 'png':
@@ -374,7 +375,7 @@ def _fig_to_img(fig, *, image_format='png', own_figure=True):
         plt.close(fig)
 
     # Remove alpha
-    if image_format != 'svg':
+    if image_format != 'svg' and has_pillow:
         from PIL import Image
         output.seek(0)
         orig = Image.open(output)

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -26,7 +26,6 @@ import webbrowser
 import numpy as np
 
 from .. import __version__ as MNE_VERSION
-from ..fixes import _compare_version
 from .. import (read_evokeds, read_events, read_cov,
                 read_source_estimate, read_trans, sys_info,
                 Evoked, SourceEstimate, Covariance, Info, Transform)

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -39,7 +39,7 @@ from ..proj import read_proj
 from .._freesurfer import _reorient_image, _mri_orientation
 from ..utils import (logger, verbose, get_subjects_dir, warn, _ensure_int,
                      fill_doc, _check_option, _validate_type, _safe_input,
-                     _path_like, use_log_level, _check_fname, _pl, _pl,
+                     _path_like, use_log_level, _check_fname, _pl,
                      _check_ch_locs, _import_h5io_funcs, _verbose_safe_false,
                      check_version)
 from ..viz import (plot_events, plot_alignment, plot_cov, plot_projs_topomap,
@@ -354,10 +354,14 @@ def _fig_to_img(fig, *, image_format='png', own_figure=True):
 
     # https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
     kwargs = dict()
+    pil_kwargs = dict()
     if image_format == 'webp':
-        kwargs['pil_kwargs'] = dict(lossless=True, method=6)
+        pil_kwargs.update(lossless=True, method=6)
     elif image_format == 'png':
-        kwargs['pil_kwargs'] = dict(optimize=True, compress_level=9)
+        pil_kwargs.update(optimize=True, compress_level=9)
+    if pil_kwargs:
+        # matplotlib modifies the passed dict, which is a bug
+        kwargs['pil_kwargs'] = pil_kwargs.copy()
     with warnings.catch_warnings():
         warnings.filterwarnings(
             action='ignore',
@@ -378,7 +382,7 @@ def _fig_to_img(fig, *, image_format='png', own_figure=True):
             background = Image.new('RGBA', orig.size, (255, 255, 255))
             new = Image.alpha_composite(background, orig).convert('RGB')
             output = BytesIO()
-            new.save(output, format=image_format, dpi=(dpi, dpi), **kwargs)
+            new.save(output, format=image_format, dpi=(dpi, dpi), **pil_kwargs)
 
     output = output.getvalue()
     return (output.decode('utf-8') if image_format == 'svg' else

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -429,9 +429,8 @@ def _get_bem_contour_figs_as_arrays(
         A list of NumPy arrays that represent the generated Matplotlib figures.
     """
     # Matplotlib <3.2 doesn't work nicely with process-based parallelization
-    from matplotlib import __version__ as MPL_VERSION
     kwargs = dict()
-    if _compare_version(MPL_VERSION, '<', '3.2'):
+    if not check_version('matplotilb', '3.2'):
         kwargs['prefer'] = 'threads'
 
     parallel, p_fun, n_jobs = parallel_func(
@@ -638,7 +637,7 @@ def _check_image_format(rep, image_format):
         extra = ''
         if not check_version('matplotlib', '3.6'):
             allowed.pop(allowed.index('webp'))
-            extra = '("webp" supported on Matplotlib 3.6+)'
+            extra = '("webp" supported on matplotlib 3.6+)'
         _check_option(
             'image_format', image_format, allowed_values=allowed, extra=extra)
     else:

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -625,7 +625,11 @@ _ALLOWED_IMAGE_FORMATS = ('png', 'svg', 'webp')
 
 
 def _webp_supported():
-    return check_version('matplotlib', '3.6') and check_version('PIL')
+    good = check_version('matplotlib', '3.6') and check_version('PIL')
+    if good:
+        from PIL import features
+        good = features.check('webp')
+    return good
 
 
 def _check_scale(scale):

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -101,8 +101,8 @@ report.save('report_raw.html', overwrite=True)
 # ^^^^^^^^^^^^^
 #
 # Events can be added via :meth:`mne.Report.add_events`. You also need to
-# supply the sampling frequency used during the recording; this information
-# is used to generate a meaningful time axis.
+# supply the sampling frequency used during the recording; this information is
+# used to generate a meaningful time axis.
 
 events_path = sample_dir / 'sample_audvis_filt-0-40_raw-eve.fif'
 events = mne.find_events(raw=raw)


### PR DESCRIPTION
Saves ~50% in mne-bids-pipeline
```
$ python -c "import mne; print(mne.report.open_report('~/mne_data/derivatives/mne-bids-pipeline/ds000248_base/sub-01/meg/sub-01_task-audiovisual_report.h5'))"
<Report | 28 titles | 78 items | sub-01, task-audiovisual  | 31.2 MB
 Raw (original run 01), run 01                             |  1.0 MB
 Data quality                                              |  0.2 MB
 Raw (maxwell filtered), run 01                            |  0.9 MB
 Raw (filtered), run 01                                    |  0.8 MB
 Events                                                    |  0.0 MB
 Epochs: before cleaning                                   |  0.5 MB
 Epochs: after cleaning                                    |  0.5 MB
 Condition: Auditory                                       |  1.4 MB
 Condition: Visual                                         |  1.6 MB
 Condition: Auditory/Left                                  |  1.4 MB
 Condition: Auditory/Right                                 |  1.5 MB
 Contrast: Visual+Auditory                                 |  1.6 MB
 Contrast: Auditory/Right+Auditory/Left                    |  1.6 MB
 Decoding: full-epochs                                     |  0.0 MB
 Decoding: time-by-time                                    |  0.1 MB
 TFR Power: Auditory                                       |  0.0 MB
 TFR ITC: Auditory                                         |  0.1 MB
 TFR Power: Visual                                         |  0.0 MB
 TFR ITC: Visual                                           |  0.1 MB
 Noise covariance                                          |  0.6 MB
 BEM                                                       |  2.4 MB
 Sensor alignment                                          |  0.5 MB
 Forward solution                                          |  0.0 MB
 Source: Auditory                                          |  3.6 MB
 Source: Visual                                            |  3.7 MB
 Source: Auditory/Left                                     |  3.6 MB
 Source: Auditory/Right                                    |  3.6 MB
 Configuration file                                        |  0.0 MB
>
```

Closes #11358
Closes https://github.com/mne-tools/mne-bids-pipeline/issues/682