### PR TITLE
[ENH] Add support for importing UCL/FIL OPM data

### DIFF
--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -87,7 +87,7 @@ I agree to the following:
 # respective repos, and make a new release of the dataset on GitHub. Then
 # update the checksum in the MNE_DATASETS dict below, and change version
 # here:                  ↓↓↓↓↓         ↓↓↓
-RELEASES = dict(testing='0.140', misc='0.23')
+RELEASES = dict(testing='0.141', misc='0.23')
 TESTING_VERSIONED = f'mne-testing-data-{RELEASES["testing"]}'
 MISC_VERSIONED = f'mne-misc-data-{RELEASES["misc"]}'
 
@@ -111,7 +111,7 @@ MNE_DATASETS = dict()
 # Testing and misc are at the top as they're updated most often
 MNE_DATASETS['testing'] = dict(
     archive_name=f'{TESTING_VERSIONED}.tar.gz',
-    hash='md5:f4377b017867f58a7c490b568764f44a',
+    hash='md5:08b1e81e944de9616a408eb70d73775b',
     url=('https://codeload.github.com/mne-tools/mne-testing-data/'
          f'tar.gz/{RELEASES["testing"]}'),
     # In case we ever have to resort to osf.io again...

--- a/mne/io/__init__.py
+++ b/mne/io/__init__.py
@@ -27,6 +27,7 @@ from . import fiff
 from . import kit
 from . import nicolet
 from . import nirx
+from . import ucl
 from . import boxy
 from . import persyst
 from . import eeglab
@@ -57,7 +58,9 @@ from .persyst import read_raw_persyst
 from .fieldtrip import (read_raw_fieldtrip, read_epochs_fieldtrip,
                         read_evoked_fieldtrip)
 from .nihon import read_raw_nihon
+from .ucl import read_raw_ucl
 from ._read_raw import read_raw
+
 
 # for backward compatibility
 from .fiff import Raw

--- a/mne/io/ucl/__init__.py
+++ b/mne/io/ucl/__init__.py
@@ -1,0 +1,5 @@
+# Authors: George O'Neill <g.o'neill@ucl.ac.uk>
+#
+# License: BSD-3-Clause
+
+from .ucl import read_raw_ucl 

--- a/mne/io/ucl/sensors.py
+++ b/mne/io/ucl/sensors.py
@@ -1,0 +1,146 @@
+# Authors: George O'Neill <g.o'neill@ucl.ac.uk>
+#
+# License: BSD-3-Clause
+
+from copy import deepcopy
+import numpy as np
+
+
+def _refine_sensor_orientation(chanin):
+    """the ex and ey elements from _convert_channel_info were oriented not
+    based on the physical orientation of the sensor.
+    It doesn't have to be this way, we can use (if available) the orientation
+    information from mulit-axis recordings to refine these elements.
+    """
+    print("refining sensor orientations")
+    chanout = deepcopy(chanin)
+    tmpname = list()
+    for ii in range(len(chanin)):
+        tmpname.append(chanin[ii]["ch_name"])
+
+    for ii in range(len(chanin)):
+        tmploc = deepcopy(chanin[ii]["loc"])
+        tmploc = tmploc.reshape(3, 4, order="F")
+        if np.isnan(tmploc.sum()) is False:
+            target, flipFlag = _guess_other_chan_axis(tmpname, ii)
+            if np.isnan(target) is False:
+                targetloc = deepcopy(chanin[target]["loc"])
+                if np.isnan(targetloc.sum()) is False:
+                    targetloc = targetloc.reshape(3, 4, order="F")
+                    tmploc[:, 2] = targetloc[:, 3]
+                    tmploc[:, 1] = flipFlag * np.cross(tmploc[:, 2],
+                                                       tmploc[:, 3])
+                    chanout[ii]["loc"] = tmploc.reshape(12, order="F")
+
+    return chanout
+
+
+def _guess_other_chan_axis(tmpname, seedID):
+    """Try to guess the name of another axis of a multiaxis sensor"""
+    targetID = np.NAN
+
+    # see if its using the old RAD/TAN convention first, otherwise use XYZ
+    if tmpname[seedID][-3:] == "RAD":
+        prefix1 = "RAD"
+        prefix2 = "TAN"
+        flipflag = 1.0
+    elif tmpname[seedID][-3:] == "TAN":
+        prefix1 = "TAN"
+        prefix2 = "RAD"
+        flipflag = -1.0
+    elif tmpname[seedID][-1:] == "Z" or tmpname[seedID][-3:] == "[Z]":
+        prefix1 = "Z"
+        prefix2 = "Y"
+        flipflag = -1.0
+    elif tmpname[seedID][-1:] == "Y" or tmpname[seedID][-3:] == "[Y]":
+        prefix1 = "Y"
+        prefix2 = "Z"
+        flipflag = 1.0
+    elif tmpname[seedID][-1:] == "X" or tmpname[seedID][-3:] == "[X]":
+        prefix1 = "X"
+        prefix2 = "Y"
+        flipflag = 1.0
+    else:
+        prefix1 = "?"
+        prefix2 = "?"
+        flipflag = 1.0
+
+    targetName = tmpname[seedID][: -len(prefix1)] + prefix2
+
+    # iterate through loop to find target, stop when found
+    hit = False
+    ii = 0
+    while (ii < len(tmpname)) and (hit is False):
+        if targetName == tmpname[ii]:
+            targetID = ii
+            hit = True
+        ii += 1
+
+    return targetID, flipflag
+
+
+def _get_pos_units(pos):
+    """Determines the units a point cloud of sensor positions, provides the
+    scale factor required to ensure the units can be converted to meters.
+    """
+    # get rid of None elements
+    nppos = np.empty((0, 3))
+    for ii in range(0, len(pos)):
+        if pos[ii] is not None and sum(np.isnan(pos[ii])) == 0:
+            nppos = np.vstack((nppos, pos[ii]))
+
+    idrange = np.empty(shape=(0, 3))
+    for ii in range(0, 3):
+        q90, q10 = np.percentile(nppos[:, ii], [90, 10])
+        idrange = np.append(idrange, q90 - q10)
+
+    size = np.linalg.norm(idrange)
+
+    unit, sf = _size2units(size)
+
+    return unit, sf
+
+
+def _size2units(size):
+    """Convert the size returned from _get_pos_units into a physical unit"""
+    if size >= 0.050 and size < 0.500:
+        unit = "m"
+        sf = 1
+    elif size >= 0.50 and size < 5:
+        unit = "dm"
+        sf = 10
+    elif size >= 5 and size < 50:
+        unit = "cm"
+        sf = 100
+    elif size >= 50 and size < 500:
+        unit = "mm"
+        sf = 1000
+    else:
+        unit = "unknown"
+        sf = 1
+
+    return unit, sf
+
+
+def _get_plane_vectors(ez):
+    """Get two orthogonal vectors orthogonal to ez (ez will be modified).
+    Note: the ex and ey positions will not be realistic, this can be fixed
+    using _refine_sensor_orientation.
+    """
+    assert ez.shape == (3,)
+    ez_len = np.sqrt(np.sum(ez * ez))
+    if ez_len == 0:
+        raise RuntimeError("Zero length normal. Cannot proceed.")
+    if np.abs(ez_len - np.abs(ez[2])) < 1e-5:  # ez already in z-direction
+        ex = np.array([1.0, 0.0, 0.0])
+    else:
+        ex = np.zeros(3)
+        if ez[1] < ez[2]:
+            ex[0 if ez[0] < ez[1] else 1] = 1.0
+        else:
+            ex[0 if ez[0] < ez[2] else 2] = 1.0
+    ez /= ez_len
+    ex -= np.dot(ez, ex) * ez
+    ex /= np.sqrt(np.sum(ex * ex))
+    ey = np.cross(ez, ex)
+    return ex, ey

--- a/mne/io/ucl/ucl.py
+++ b/mne/io/ucl/ucl.py
@@ -1,0 +1,304 @@
+# Authors: George O'Neill <g.o'neill@ucl.ac.uk>
+#
+# License: BSD-3-Clause
+
+import json
+import numpy as np
+import os.path as op
+from collections import OrderedDict
+
+from ..constants import FIFF
+from ..meas_info import _empty_info
+from ..write import get_new_file_id
+from ..base import BaseRaw
+from ..utils import _read_segments_file
+from .._digitization import _make_dig_points
+from ...transforms import get_ras_to_neuromag_trans, apply_trans, Transform
+from ...utils import warn
+
+from .sensors import (_refine_sensor_orientation, _get_pos_units,
+                      _size2units, _get_plane_vectors)
+
+
+def read_raw_ucl(binfile, precision='single', preload=False):
+    """Raw object from FIL/UCL formatted files.
+
+    Parameters
+    ----------
+    binfile : str
+        Path to the MEG data (ending in ``'_meg.bin'``).
+    precision : str, optional
+        How is the data represented? ``'single'`` if 32-bit or ``'double'`` if
+        64-bit (default is single)
+    %(preload)s
+
+    Returns
+    -------
+    raw : instance of RawUCL
+        The raw data.
+
+    """
+    return RawUCL(binfile, precision=precision, preload=preload)
+
+
+class RawUCL(BaseRaw):
+    def __init__(self, binfile, precision='single', preload=False):
+        """Raw object from FIL/UCL formatted files.
+
+        Parameters
+        ----------
+        binfile : str
+            Path to the MEG data (ending in ``'_meg.bin'``).
+        precision : str, optional
+            How is the data represented? ``'single'`` if 32-bit or
+            ``'double'`` if 64-bit (default is single)
+        %(preload)s
+
+        Returns
+        -------
+        raw : instance of RawUCL
+            The raw data.
+
+        """
+
+        if precision == 'single':
+            dt = np.dtype('>f')
+            bps = 4
+        else:
+            dt = np.dtype('>d')
+            bps = 8
+
+        sample_info = dict()
+        sample_info['dt'] = dt
+        sample_info['bps'] = bps
+
+        files = _get_file_names(binfile)
+
+        chans = _from_tsv(files['chans'])
+        chanpos = _from_tsv(files['positions'])
+        nchans = len(chans['name'])
+        nlocs = len(chanpos['name'])
+        nsamples = _determine_nsamples(files['bin'], nchans, precision) - 1
+        sample_info['nsamples'] = nsamples
+
+        raw_extras = list()
+        raw_extras.append(sample_info)
+
+        chans['pos'] = [None] * nchans
+        chans['ori'] = [None] * nchans
+
+        for ii in range(0, nlocs):
+            idx = chans['name'].index(chanpos['name'][ii])
+            tmp = np.array([chanpos['Px'][ii],
+                            chanpos['Py'][ii],
+                            chanpos['Pz'][ii]])
+            chans['pos'][idx] = tmp.astype(np.float64)
+            tmp = np.array([chanpos['Ox'][ii],
+                            chanpos['Oy'][ii],
+                            chanpos['Oz'][ii]])
+            chans['ori'][idx] = tmp.astype(np.float64)
+
+        fid = open(files['meg'], 'r')
+        meg = json.load(fid)
+        fid.close()
+        info = _compose_meas_info(meg, chans)
+
+        super(RawUCL, self).__init__(
+            info, preload, filenames=[files['bin']], raw_extras=raw_extras,
+            last_samps=[nsamples], orig_format=precision)
+
+        if op.exists(files['coordsystem']):
+            fid = open(files['coordsystem'], 'r')
+            csys = json.load(fid)
+            fid.close()
+            hc = csys['HeadCoilCoordinates']
+
+            for key in hc:
+                if key == 'lpa' or key == 'LPA':
+                    lpa = np.asarray(hc[key])
+                elif key == 'rpa' or key == 'RPA':
+                    rpa = np.asarray(hc[key])
+                elif key == 'nas' or key == 'NAS' or key == 'nasion':
+                    nas = np.asarray(hc[key])
+                else:
+                    warn(key + ' is not a valid fiducial name!')
+
+            size = np.linalg.norm(nas - rpa)
+            unit, sf = _size2units(size)
+            lpa /= sf
+            rpa /= sf
+            nas /= sf
+
+            t = get_ras_to_neuromag_trans(nas, lpa, rpa)
+
+            # transform fiducial points
+            nas = apply_trans(t, nas)
+            lpa = apply_trans(t, lpa)
+            rpa = apply_trans(t, rpa)
+
+            with self.info._unlock():
+                self.info['dig'] = _make_dig_points(nasion=nas,
+                                                    lpa=lpa,
+                                                    rpa=rpa,
+                                                    coord_frame='meg')
+        else:
+            print('No fiducials found in files,',
+                  'defaulting sensor array to FIFFV_COORD_DEVICE,.',
+                  ' May cause problems later!')
+            t = np.eye(4)
+
+        with self.info._unlock():
+            self.info['dev_head_t'] = \
+                Transform(FIFF.FIFFV_COORD_DEVICE,
+                          FIFF.FIFFV_COORD_HEAD, t)
+
+    def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
+        """Read a chunk of raw data."""
+        si = self._raw_extras[fi]
+        _read_segments_file(
+            self, data, idx, fi, start, stop, cals, mult, dtype=si['dt'])
+
+
+def _convert_channel_info(chans):
+    """convert the imported _channels.tsv into the chs element of raw.info"""
+    nmeg = nstim = nmisc = nref = 0
+
+    units, sf = _get_pos_units(chans['pos'])
+
+    chs = list()
+    for ii in range(0, len(chans['name'])):
+        ch = dict(scanno=ii + 1, range=1., cal=1., loc=np.full(12, np.nan),
+                  unit_mul=FIFF.FIFF_UNITM_NONE, ch_name=chans['name'][ii],
+                  coil_type=FIFF.FIFFV_COIL_NONE)
+        chs.append(ch)
+
+        # create the channel information
+        if chans['pos'][ii] is not None:
+            r0 = chans['pos'][ii].copy() / sf   # mm to m
+            ez = chans['ori'][ii].copy()
+            ez = ez / np.linalg.norm(ez)
+            ex, ey = _get_plane_vectors(ez)
+            ch['loc'] = np.concatenate([r0, ex, ey, ez])
+
+        if chans['type'][ii] == 'MEGMAG':
+            nmeg += 1
+            ch.update(logno=nmeg, coord_frame=FIFF.FIFFV_COORD_DEVICE,
+                      kind=FIFF.FIFFV_MEG_CH, unit=FIFF.FIFF_UNIT_T,
+                      coil_type=FIFF.FIFFV_COIL_QUSPIN_ZFOPM_MAG2)
+        elif chans['type'][ii] == 'MEGREFMAG':
+            nref += 1
+            ch.update(logno=nref, coord_frame=FIFF.FIFFV_COORD_UNKNOWN,
+                      kind=FIFF.FIFFV_REF_MEG_CH, unit=FIFF.FIFF_UNIT_T,
+                      coil_type=FIFF.FIFFV_COIL_QUSPIN_ZFOPM_MAG2)
+        elif chans['type'][ii] == 'TRIG':
+            nstim += 1
+            ch.update(logno=nstim, coord_frame=FIFF.FIFFV_COORD_UNKNOWN,
+                      kind=FIFF.FIFFV_STIM_CH, unit=FIFF.FIFF_UNIT_V)
+        else:
+            nmisc += 1
+            ch.update(logno=nmisc, coord_frame=FIFF.FIFFV_COORD_UNKNOWN,
+                      kind=FIFF.FIFFV_MISC_CH, unit=FIFF.FIFF_UNIT_NONE)
+
+        # set the calibration based on the units - MNE expects T units for meg
+        # and V for eeg
+        if chans['units'][ii] == 'fT':
+            ch.update(cal=1e-15)
+        elif chans['units'][ii] == 'pT':
+            ch.update(cal=1e-12)
+        elif chans['units'][ii] == 'nT':
+            ch.update(cal=1e-9)
+        elif chans['units'][ii] == 'mV':
+            ch.update(cal=1e3)
+        elif chans['units'][ii] == 'uV':
+            ch.update(cal=1e6)
+
+    return chs
+
+
+def _compose_meas_info(meg, chans):
+    """Create info structure"""
+    info = _empty_info(meg['SamplingFrequency'])
+
+    # Collect all the necessary data from the structures read
+    info['meas_id'] = get_new_file_id()
+    tmp = _convert_channel_info(chans)
+    info['chs'] = _refine_sensor_orientation(tmp)
+    # info['chs'] = _convert_channel_info(chans)
+    info['line_freq'] = meg['PowerLineFrequency']
+    info['bads'] = _read_bad_channels(chans)
+    info._unlocked = False
+    info._update_redundant()
+    return info
+
+
+def _determine_nsamples(bin_fname, nchans, precision):
+    """Identify how many temporal samples in a dataset based on
+    size of file, number of channels and bitdepth"""
+    bsize = op.getsize(bin_fname)
+    if precision == 'single':
+        bps = 4
+    else:
+        bps = 8
+    nsamples = int(bsize / (nchans * bps))
+    return nsamples
+
+
+def _read_bad_channels(chans):
+    """Check _channels.tsv file to look for premarked bad channels"""
+    bads = list()
+    for ii in range(0, len(chans['status'])):
+        if chans['status'][ii] == 'bad':
+            bads.append(chans['name'][ii])
+    return bads
+
+
+def _from_tsv(fname, dtypes=None):
+    """Read a tsv file into an OrderedDict.
+    Parameters
+    ----------
+    fname : str
+        Path to the file being loaded.
+    dtypes : list, optional
+        List of types to cast the values loaded as. This is specified column by
+        column.
+        Defaults to None. In this case all the data is loaded as strings.
+    Returns
+    -------
+    data_dict : collections.OrderedDict
+        Keys are the column names, and values are the column data.
+    """
+    data = np.loadtxt(fname, dtype=str, delimiter='\t', ndmin=2,
+                      comments=None, encoding='utf-8-sig')
+    column_names = data[0, :]
+    info = data[1:, :]
+    data_dict = OrderedDict()
+    if dtypes is None:
+        dtypes = [str] * info.shape[1]
+    if not isinstance(dtypes, (list, tuple)):
+        dtypes = [dtypes] * info.shape[1]
+    if not len(dtypes) == info.shape[1]:
+        raise ValueError('dtypes length mismatch. Provided: {0}, '
+                         'Expected: {1}'.format(len(dtypes), info.shape[1]))
+    for i, name in enumerate(column_names):
+        data_dict[name] = info[:, i].astype(dtypes[i]).tolist()
+    return data_dict
+
+
+def _get_file_names(binfile):
+    """guess the filenames based on predicted suffixes"""
+    files = dict()
+    files['dir'] = op.dirname(binfile)
+
+    tmp = op.basename(binfile)
+    tmp = str.split(tmp, '_meg.bin')
+
+    files['root'] = tmp[0]
+    files['bin'] = op.join(files['dir'], files['root'] + '_meg.bin')
+    files['meg'] = op.join(files['dir'], files['root'] + '_meg.json')
+    files['chans'] = op.join(files['dir'], files['root'] + '_channels.tsv')
+    files['positions'] = op.join(files['dir'],
+                                 files['root'] + '_positions.tsv')
+    files['coordsystem'] = op.join(files['dir'],
+                                   files['root'] + '_coordsystem.json')
+
+    return files


### PR DESCRIPTION
#### Reference issue
Example: Provides a solution to #11257.

#### What does this implement/fix?
- Adds means to import data as a rawUCL object.
- Adds a test to check data when imported matches established MATLAB-style importers
- Updates testing dataset version to include the FIL data.

#### Open question
This PR has used UCL instead of FIL, to avoid confusion with FIF. However the corresponding mne-test-data uses FIL. Should we use FIL for consistency here?
