### PR TITLE
[DRAFT][DOC] Adapt LCMV tutorial

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1952,13 +1952,13 @@ year = {2019}
 }
 
 @article{WestnerEtAl2022,
-	author = {Westner, Britta U. and Dalal, Sarang S. and Gramfort, Alexandre and Litvak, Vladimir and Mosher, John C. and Oostenveld, Robert and Schoffelen, Jan-Mathijs},
-	doi = {10.1016/j.neuroimage.2021.118789},
-	journal = {NeuroImage},
-	pages = {118789},
+  author = {Westner, Britta U. and Dalal, Sarang S. and Gramfort, Alexandre and Litvak, Vladimir and Mosher, John C. and Oostenveld, Robert and Schoffelen, Jan-Mathijs},
+  doi = {10.1016/j.neuroimage.2021.118789},
+  journal = {NeuroImage},
+  pages = {118789},
   title = {A unified view on beamformers for {M}/{EEG} source reconstruction},
-	volume = {246},
-	year = {2022},
+  volume = {246},
+  year = {2022},
 }
 
 @article{WheatEtAl2010,

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1951,6 +1951,16 @@ year = {2019}
   year = {2008}
 }
 
+@article{WestnerEtAl2022,
+	author = {Westner, Britta U. and Dalal, Sarang S. and Gramfort, Alexandre and Litvak, Vladimir and Mosher, John C. and Oostenveld, Robert and Schoffelen, Jan-Mathijs},
+	doi = {10.1016/j.neuroimage.2021.118789},
+	journal = {NeuroImage},
+	pages = {118789},
+  title = {A unified view on beamformers for {M}/{EEG} source reconstruction},
+	volume = {246},
+	year = {2022},
+}
+
 @article{WheatEtAl2010,
   author = {Wheat, Katherine L. and Cornelissen, Piers L. and Frost, Stephen J. and Hansen, Peter C.},
   doi = {10.1523/JNEUROSCI.4448-09.2010},

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -331,7 +331,7 @@ def _compute_beamformer(G, Cm, reg, n_orient, weight_norm, pick_ori,
     if weight_norm is not None:
         # Three different ways to calculate the normalization factors here.
         # Only matters when in vector mode, as otherwise n_orient == 1 and
-        # they are all equivalent. Sekihara 2008 says to use
+        # they are all equivalent.
         #
         # In MNE < 0.21, we just used the Frobenius matrix norm:
         #

--- a/tutorials/inverse/50_beamformer_lcmv.py
+++ b/tutorials/inverse/50_beamformer_lcmv.py
@@ -92,8 +92,8 @@ del raw  # save memory
 # includes the brain signal of interest,
 # and incorporate enough samples for a stable estimate. A rule of thumb is to
 # use more samples than there are channels in the data set; see
-# :footcite:`BrookesEtAl2008` for more detailed advice on covariance estimation
-# for beamformers. Here, we use a time
+# :footcite:`BrookesEtAl2008,WestnerEtAl2022` for more detailed advice on
+# covariance estimation for beamformers. Here, we use a time
 # window incorporating the expected auditory response at around 100 ms post
 # stimulus and extend the period to account for a low number of trials (72) and
 # low sampling rate of 150 Hz.
@@ -108,11 +108,13 @@ del epochs
 # %%
 # When looking at the covariance matrix plots, we can see that our data is
 # slightly rank-deficient as the rank is not equal to the number of channels.
-# Thus, we will have to regularize the covariance matrix before inverting it
+# Thus, we choose to regularize the covariance matrix before inverting it
 # in the beamformer calculation. This can be achieved by setting the parameter
 # ``reg=0.05`` when calculating the spatial filter with
 # :func:`~mne.beamformer.make_lcmv`. This corresponds to loading the diagonal
-# of the covariance matrix with 5% of the sensor power.
+# of the covariance matrix with 5% of the sensor power. Other ways to deal with
+# rank-deficient covariance matrices are discussed in
+# :footcite:`WestnerEtAl2022`.
 
 # %%
 # The forward model
@@ -173,12 +175,15 @@ filters = make_lcmv(evoked.info, forward, data_cov, reg=0.05,
 # estimates per voxel, corresponding to the three direction components of the
 # source. This can be achieved by setting
 # ``pick_ori='vector'`` and will yield a :class:`volume vector source estimate
-# <mne.VolVectorSourceEstimate>`. So we will compute another set of filters
-# using the vector beamformer approach:
+# <mne.VolVectorSourceEstimate>`. Note that we switch the ``weight_norm``
+# parameter to ``'unit-noise-gain-invariant'``, which is only necessary for the
+# vector unit-noise-gain beamformer. For more in-depth detail, see
+# :footcite:`WestnerEtAl2022`.
+# We will compute another set of filters using the vector beamformer approach:
 
 filters_vec = make_lcmv(evoked.info, forward, data_cov, reg=0.05,
                         noise_cov=noise_cov, pick_ori='vector',
-                        weight_norm='unit-noise-gain', rank=None)
+                        weight_norm='unit-noise-gain-invariant', rank=None)
 # save a bit of memory
 src = forward['src']
 del forward


### PR DESCRIPTION
Adapting the LCMV tutorial for the new-ish default of `weight_norm='unit-noise-gain-invariant'`. Happy to discuss the change in the reconstructed activity for the vector beamformer - it seems to now be more in line with what we get from the scalar beamformer, and the third orientation seems to be floating around 0.
We could probably do with a different color limit, but wanted to keep it as is for comparison first.

Also added a few references to the beamformer overview paper I published earlier this year - I think it could be a helpful resource if I may say so myself.

Otherwise, some minor fixes in the tutorial and docstring text.