### PR TITLE
Replaced package mention ESINet by invertmeeg

### DIFF
--- a/doc/install/mne_tools_suite.rst
+++ b/doc/install/mne_tools_suite.rst
@@ -63,7 +63,7 @@ MNE-Python, including packages for:
 - automatic multi-dipole localization and uncertainty quantification with
   the Bayesian algorithm SESAME (`sesameeg`_)
 - GLM and group level analysis of near-infrared spectroscopy data (`mne-nirs`_)
-- M/EEG inverse solutions using artificial neural networks (`ESINet`_)
+- High-level EEG Python library for all kinds of EEG inverse solutions (`invertmeeg`_)
 - All-Resolutions Inference (ARI) for statistically valid circular inference
   and effect localization (`MNE-ARI`_)
 
@@ -110,5 +110,5 @@ Help with installation is available through the `MNE Forum`_. See the
 .. _pyprep: https://github.com/sappelhoff/pyprep
 .. _sesameeg: https://pybees.github.io/sesameeg
 .. _mne-nirs: https://github.com/mne-tools/mne-nirs
-.. _ESINet: https://github.com/LukeTheHecker/ESINet
+.. _invertmeeg: https://github.com/LukeTheHecker/invert
 .. _MNE-ARI: https://github.com/john-veillette/mne_ari


### PR DESCRIPTION
In your list of MNE-friendly packages I replaced my former package ESINet with my updated package "invertmeeg" which implements various EEG inverse solutions. ESINet is replaced since all features are now available in the new package as well.

The package utilizes many mne-python objects like Evoked, Raw, Epochs, Forward, SourceEstimate etc., wherefore I think my package may be of interest to the community.

Keep up the good work!
-Lukas

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

#### Reference issue
Example: Fixes #1234.


#### What does this implement/fix?
Explain your changes.


#### Additional information
Any additional information you think is important.
