### PR TITLE
[ENH, MRG] Add info save method

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -24,7 +24,7 @@ Current (1.4.dev0)
 Enhancements
 ~~~~~~~~~~~~
 - Added ability to read stimulus durations from SNIRF files when using :func:`mne.io.read_raw_snirf` (:gh:`11397` by `Robert Luke`_)
-- Add :meth:`mne.Info.save` to save an :class:`mne.Info` object to a fif file (:gh:`11398` by `Alex Rockhill`_)
+- Add :meth:`mne.Info.save` to save an :class:`mne.Info` object to a fif file (:gh:`11401` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -24,6 +24,7 @@ Current (1.4.dev0)
 Enhancements
 ~~~~~~~~~~~~
 - Added ability to read stimulus durations from SNIRF files when using :func:`mne.io.read_raw_snirf` (:gh:`11397` by `Robert Luke`_)
+- Add :meth:`mne.Info.save` to save an :class:`mne.Info` object to a fif file (:gh:`11398` by `Alex Rockhill`_)
 
 Bugs
 ~~~~

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1233,7 +1233,7 @@ class Info(dict, MontageMixin, ContainsMixin):
         Parameters
         ----------
         fname : str
-            The name of the file. Should end by -info.fif.
+            The name of the file. Should end by `'-info.fif'`.
         """
         write_info(fname, self)
 

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1227,21 +1227,15 @@ class Info(dict, MontageMixin, ContainsMixin):
             experimenter=self.get('experimenter'),
         )
 
-    def save(self, fname, data_type=None, reset_range=True):
+    def save(self, fname):
         """Write measurement info in fif file.
 
         Parameters
         ----------
         fname : str
             The name of the file. Should end by -info.fif.
-        data_type : int
-            The data_type in case it is necessary. Should be 4 (FIFFT_FLOAT),
-            5 (FIFFT_DOUBLE), or 16 (FIFFT_DAU_PACK16) for
-            raw data.
-        reset_range : bool
-            If True, info['chs'][k]['range'] will be set to unity.
         """
-        write_info(fname, self, data_type=data_type, reset_range=reset_range)
+        write_info(fname, self)
 
 
 def _simplify_info(info):

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1227,6 +1227,22 @@ class Info(dict, MontageMixin, ContainsMixin):
             experimenter=self.get('experimenter'),
         )
 
+    def save(self, fname, data_type=None, reset_range=True):
+        """Write measurement info in fif file.
+
+        Parameters
+        ----------
+        fname : str
+            The name of the file. Should end by -info.fif.
+        data_type : int
+            The data_type in case it is necessary. Should be 4 (FIFFT_FLOAT),
+            5 (FIFFT_DOUBLE), or 16 (FIFFT_DAU_PACK16) for
+            raw data.
+        reset_range : bool
+            If True, info['chs'][k]['range'] will be set to unity.
+        """
+        write_info(fname, self, data_type=data_type, reset_range=reset_range)
+
 
 def _simplify_info(info):
     """Return a simplified info structure to speed up picking."""

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -1233,7 +1233,7 @@ class Info(dict, MontageMixin, ContainsMixin):
         Parameters
         ----------
         fname : str
-            The name of the file. Should end by `'-info.fif'`.
+            The name of the file. Should end by ``'-info.fif'``.
         """
         write_info(fname, self)
 


### PR DESCRIPTION
Adds a save method to the info class in addition to `mne.io.write_info` for convenience.