### PR TITLE
[BUG, MRG] Fix mne.read_lta for different source and destination volumes

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -29,6 +29,7 @@ Enhancements
 Bugs
 ~~~~
 - Fix bug where channel names were not properly sanitized in :func:`mne.write_evokeds` and related functions (:gh:`11399` by `Eric Larson`_)
+- Fix bug where loading different combinations of volumes were in ``freeview`` when rotating and translating a volume to make a linear transformation array (LTA), different ``dst`` (destination) volumes were used in the LTA file, resulting in different affines for :func:`mne.read_lta` when the rotation and translations were the same (:gh:`11402` by `Alex Rockhill`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -29,7 +29,7 @@ Enhancements
 Bugs
 ~~~~
 - Fix bug where channel names were not properly sanitized in :func:`mne.write_evokeds` and related functions (:gh:`11399` by `Eric Larson`_)
-- Fix bug where loading different combinations of volumes were in ``freeview`` when rotating and translating a volume to make a linear transformation array (LTA), different ``dst`` (destination) volumes were used in the LTA file, resulting in different affines for :func:`mne.read_lta` when the rotation and translations were the same (:gh:`11402` by `Alex Rockhill`_)
+- Fix bug where having a different combination of volumes loaded into ``freeview`` caused different affines to be returned by :func:`mne.read_lta` for the same Linear Transform Array (LTA) (:gh:`11402` by `Alex Rockhill`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/_freesurfer.py
+++ b/mne/_freesurfer.py
@@ -504,8 +504,15 @@ def read_lta(fname, verbose=None):
     _validate_type(fname, ('path-like', None), 'fname')
     _check_fname(fname, 'read', must_exist=True)
     with open(fname, 'r') as fid:
-        affine = np.loadtxt(fid.readlines()[5:9])
-    return affine
+        lines = fid.readlines()
+    affine = np.loadtxt(lines[5:9])
+    fro_affine = np.eye(4)
+    fro_affine[:3, :3] = np.loadtxt(
+        [line.split('=')[1] for line in lines[14:17]])
+    to_affine = np.eye(4)
+    to_affine[:3, :3] = np.loadtxt(
+        [line.split('=')[1] for line in lines[23:26]])
+    return fro_affine @ affine @ np.linalg.inv(to_affine)
 
 
 @verbose

--- a/mne/tests/test_freesurfer.py
+++ b/mne/tests/test_freesurfer.py
@@ -2,7 +2,7 @@ import os.path as op
 import numpy as np
 
 import pytest
-from numpy.testing import assert_allclose, assert_array_equal, assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 
 import mne
 from mne import (vertex_to_mni, head_to_mni,

--- a/mne/tests/test_freesurfer.py
+++ b/mne/tests/test_freesurfer.py
@@ -2,7 +2,7 @@ import os.path as op
 import numpy as np
 
 import pytest
-from numpy.testing import assert_allclose, assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal, assert_allclose
 
 import mne
 from mne import (vertex_to_mni, head_to_mni,
@@ -127,13 +127,49 @@ def test_read_lta(tmp_path):
                      xras   = -1 0 0
                      yras   = 0 0 -1
                      zras   = 0 1 0
-                     cras   = -1.19374 -3.31686 3.25835)""")
+                     cras   = -1.19374 -3.31686 3.25835""")
     assert_array_equal(
         read_lta(op.join(tmp_path, 'test.lta')),
         np.array([[0.99221027, -0.05494503, 0.11180324, -3.84350586],
                   [0.05233596, 0.99828744, 0.02614108, -9.77523804],
                   [-0.11304809, -0.02008611, 0.99338663, 15.25457001],
                   [0., 0., 0., 1.]]))
+
+    # test when dst volume != src_volume
+    with open(op.join(tmp_path, 'test2.lta'), 'w') as fid:
+        fid.write("""type      = 0 # LINEAR_VOX_TO_VOX
+                     nxforms   = 1
+                     mean      = 0.0000 0.0000 0.0000
+                     sigma     = 1.0000
+                     1 4 4
+                     0.41397345  -0.02919456  -0.00069703  26.37020874
+                     -0.02894894 -0.40985453  -0.06119149 212.38204956
+                     0.00361269   0.0611503   -0.41046342 203.33338928
+                     0 0 0 1
+                     src volume info
+                     valid = 1  # volume info valid
+                     filename = tmp2.mgz
+                     volume = 512 385 512
+                     voxelsize = 0.41499999 0.41541821 0.41499999
+                     xras   = -1 0 0
+                     yras   = 0 0 1
+                     zras   = 0 -1 0
+                     cras   = -106.23999786 105.82500458 -79.55259705
+                     dst volume info
+                     valid = 1  # volume info valid
+                     filename = tmp.mgz
+                     volume = 256 256 256
+                     voxelsize = 1 1 1
+                     xras   = -1 0 0
+                     yras   = 0 0 -1
+                     zras   = 0 1 0
+                     cras   = -3.68961334 -0.12011719 3.4160614""")
+    assert_allclose(
+        read_lta(op.join(tmp_path, 'test2.lta')),
+        np.array([[0.99752641, -0.07034834, -0.00167959, -236.00043542],
+                  [0.06968626, 0.98660704, 0.14730093, 189.09766694],
+                  [-0.00870528, -0.14735012, 0.98906851, 329.7632126],
+                  [0., 0., 0., 1.]]), atol=1e-8)
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
Here is one example lta file, notice that the source and destination files are both a CT that is 512 385 512:

```
type      = 0 # LINEAR_VOX_TO_VOX
nxforms   = 1
mean      = 0.0000 0.0000 0.0000
sigma     = 1.0000
1 4 4
9.966146945953369e-01 -7.456155866384506e-02 3.480117395520210e-02 -2.464399566650391e+02 
6.968625634908676e-02 9.901284575462341e-01 1.214500889182091e-01 1.951967315673828e+02 
-4.351313412189484e-02 -1.188529580831528e-01 9.919724464416504e-01 3.338456115722656e+02 
0.000000000000000e+00 0.000000000000000e+00 0.000000000000000e+00 1.000000000000000e+00 
src volume info
valid = 1  # volume info valid
filename = CT_High_Def_20221108082419_104.nii.gz
volume = 512 385 512
voxelsize = 4.149999916553497e-01 4.154182076454163e-01 4.149999916553497e-01
xras   = -1.000000000000000e+00 0.000000000000000e+00 0.000000000000000e+00
yras   = -0.000000000000000e+00 0.000000000000000e+00 1.000000000000000e+00
zras   = 0.000000000000000e+00 -1.000000000000000e+00 0.000000000000000e+00
cras   = -1.062399978637695e+02 1.058250045776367e+02 -7.955259704589844e+01
dst volume info
valid = 1  # volume info valid
filename = CT_High_Def_20221108082419_104.nii.gz
volume = 512 385 512
voxelsize = 4.149999916553497e-01 4.154182076454163e-01 4.149999916553497e-01
xras   = -1.000000000000000e+00 0.000000000000000e+00 0.000000000000000e+00
yras   = -0.000000000000000e+00 0.000000000000000e+00 1.000000000000000e+00
zras   = 0.000000000000000e+00 -1.000000000000000e+00 0.000000000000000e+00
cras   = -1.062399978637695e+02 1.058250045776367e+02 -7.955259704589844e+01
```

This is good because the affine in the first several lines can be used by `dipy` to do an affine registration.

Here is another lta file where the only difference (besides a slight difference in the alignment because it was done manually) is that another freesurfer file, in this case the brainmask was loaded:

```
type      = 0 # LINEAR_VOX_TO_VOX
nxforms   = 1
mean      = 0.0000 0.0000 0.0000
sigma     = 1.0000
1 4 4
4.139734506607056e-01 -2.919455803930759e-02 -6.970292306505144e-04 2.637020874023438e+01 
-2.894894406199455e-02 -4.098545312881470e-01 -6.119149178266525e-02 2.123820495605469e+02 
3.612691536545753e-03 6.115030124783516e-02 -4.104634225368500e-01 2.033333892822266e+02 
0.000000000000000e+00 0.000000000000000e+00 0.000000000000000e+00 1.000000000000000e+00 
src volume info
valid = 1  # volume info valid
filename = CT_High_Def_20221108082419_104.nii.gz
volume = 512 385 512
voxelsize = 4.149999916553497e-01 4.154182076454163e-01 4.149999916553497e-01
xras   = -1.000000000000000e+00 0.000000000000000e+00 0.000000000000000e+00
yras   = -0.000000000000000e+00 0.000000000000000e+00 1.000000000000000e+00
zras   = 0.000000000000000e+00 -1.000000000000000e+00 0.000000000000000e+00
cras   = -1.062399978637695e+02 1.058250045776367e+02 -7.955259704589844e+01
dst volume info
valid = 1  # volume info valid
filename = T1.mgz
volume = 256 256 256
voxelsize = 1.000000000000000e+00 1.000000000000000e+00 1.000000000000000e+00
xras   = -9.999999403953552e-01 0.000000000000000e+00 0.000000000000000e+00
yras   = 0.000000000000000e+00 0.000000000000000e+00 -9.999999403953552e-01
zras   = 0.000000000000000e+00 9.999999403953552e-01 0.000000000000000e+00
cras   = -3.689613342285156e+00 -1.201171875000000e-01 3.416061401367188e+00
```

This lta will not work properly as input to a `dipy` affine registration which is the problem.

When you do `mri_vol2vol` to use Freesurfer to apply the lta, the output is the following in the first case:

```
$ mri_vol2vol --mov CT_High_Def_20221108082419_104.nii.gz --o test.mgz --lta CT.mgz.lta --targ T1.mgz

Matrix from LTA:
 0.99661   0.04351   0.06976  -102.89421;
-0.03480   0.99197  -0.12157  -131.16629;
-0.07449   0.11873   0.99013   92.77279;
 0.00000   0.00000   0.00000   1.00000;

CT_High_Def_20221108082419_104.nii.gz T1.mgz
INFO: dst volume info differs from the one stored in lta.  gets modified now.
volume geometry:
extent  : (256, 256, 256)
voxel   : ( 1.0000,  1.0000,  1.0000)
x_(ras) : (-1.0000,  0.0000,  0.0000)
y_(ras) : ( 0.0000,  0.0000, -1.0000)
z_(ras) : ( 0.0000,  1.0000,  0.0000)
c_(ras) : (-3.6896, -0.1201,  3.4161)
file    : T1.mgz
volume geometry:
extent  : (512, 385, 512)
voxel   : ( 0.4150,  0.4154,  0.4150)
x_(ras) : (-1.0000,  0.0000,  0.0000)
y_(ras) : (-0.0000,  0.0000,  1.0000)
z_(ras) : ( 0.0000, -1.0000,  0.0000)
c_(ras) : (-106.2400, 105.8250, -79.5526)
file    : CT_High_Def_20221108082419_104.nii.gz
movvol CT_High_Def_20221108082419_104.nii.gz
targvol T1.mgz
outvol test.mgz
regfile CT.mgz.lta
invert 0
tal    0
talres 2
regheader 0
noresample 0
interp  trilinear (1)
precision  float (3)
Gdiag_no  -1
Synth      0
SynthSeed  1672985419

Final tkRAS-to-tkRAS Matrix is:
 0.99661  -0.04351  -0.06976  -1.86864;
-0.03480  -0.99197   0.12157  -19.55386;
-0.07449  -0.11873  -0.99013   15.56377;
 0.00000   0.00000   0.00000   1.00000;


Vox2Vox Matrix is:
 2.40148  -0.16809   0.10485  -38.79236;
-0.17930  -2.38345   0.28582   446.48267;
 0.08386  -0.29295  -2.39029   541.60309;
 0.00000   0.00000   0.00000   1.00000;

Resampling
Output registration matrix is identity

mri_vol2vol done
```

and the following in the second case:

```
$ mri_vol2vol --mov CT_High_Def_20221108082419_104.nii.gz --o test2.mgz --lta CT2.mgz.lta --targ T1.mgz

Matrix from LTA:
 0.99753  -0.00871  -0.06976  -0.36873;
 0.00168  -0.98907   0.14745  -19.45879;
-0.07028  -0.14720  -0.98661   14.94764;
 0.00000   0.00000   0.00000   1.00000;

CT_High_Def_20221108082419_104.nii.gz T1.mgz
movvol CT_High_Def_20221108082419_104.nii.gz
targvol T1.mgz
outvol test2.mgz
regfile CT2.mgz.lta
invert 0
tal    0
talres 2
regheader 0
noresample 0
interp  trilinear (1)
precision  float (3)
Gdiag_no  -1
Synth      0
SynthSeed  1673183014

Final tkRAS-to-tkRAS Matrix is:
 0.99753  -0.00871  -0.06976  -0.36873;
 0.00168  -0.98907   0.14745  -19.45884;
-0.07028  -0.14720  -0.98661   14.94762;
 0.00000   0.00000   0.00000   1.00000;


Vox2Vox Matrix is:
 2.40368  -0.16809   0.02098  -31.95184;
-0.16917  -2.37497   0.35435   436.81210;
-0.00405  -0.35530  -2.38330   560.16949;
 0.00000   0.00000   0.00000   1.00000;

Resampling
Output registration matrix is identity

mri_vol2vol done
```

If you used `mne.read_lta` you would get very different results in the two cases despite the transforms being very similar because it does not currently take into account the source and destination volumes. In my opinion, what should be returned is the `Final tkRAS-to-tkRAS Matrix` which will be compatible with `dipy`. I'm still working on how exactly that gets computed from here though https://github.com/freesurfer/freesurfer/blob/57bc564a8b2a92dae21a8ac9a2ce802790f586b6/mri_vol2vol/mri_vol2vol.cpp...