### PR TITLE
removed info = _simplify_info(info) from make_lcmv

### DIFF
--- a/mne/beamformer/_lcmv.py
+++ b/mne/beamformer/_lcmv.py
@@ -142,7 +142,6 @@ def make_lcmv(info, forward, data_cov, reg=0.05, noise_cov=None, label=None,
     .. footbibliography::
     """
     # check number of sensor types present in the data and ensure a noise cov
-    info = _simplify_info(info)
     noise_cov, _, allow_mismatch = _check_one_ch_type(
         'lcmv', info, forward, data_cov, noise_cov)
     # XXX we need this extra picking step (can't just rely on minimum norm's


### PR DESCRIPTION
it removes the the maxfilter processing_history from info which leads to incorrect rank detection with MaxFiltered FIFF MEG data.

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

#### Reference issue
Example: Fixes #1234.


#### What does this implement/fix?
Explain your changes.


#### Additional information
Any additional information you think is important.
