### PR TITLE
BUG: updates for MPL 3.7 compatibility

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -52,6 +52,7 @@ Bugs
 - Make :class:`~mne.decoding.SlidingEstimator` and :class:`~mne.decoding.GeneralizingEstimator` respect the ``verbose`` argument. Now with ``verbose=False``, the progress bar is not shown during fitting, scoring, etc. (:gh:`11450` by `Mikołaj Magnuski`_)
 - Fix bug with :func:`mne.gui.locate_ieeg` where Freesurfer ``?h.pial.T1`` was not recognized and suppress excess logging (:gh:`11489` by `Alex Rockhill`_)
 - All functions accepting paths can now correctly handle :class:`~pathlib.Path` as input. Historically, we expected strings (instead of "proper" path objects), and only added :class:`~pathlib.Path` support in a few select places, leading to inconsistent behavior. (:gh:`11473` and :gh:`11499` by `Mathieu Scheltienne`_)
+- Fix visualization dialog compatibility with matplotlib 3.7 (:gh:`11409` by `Daniel McCloy`_ and `Eric Larson`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1011,7 +1011,8 @@ def reset_warnings(gallery_conf, fname):
         # pkg_resources
         'Implementing implicit namespace packages',
         'Deprecated call to `pkg_resources',
-        r'The .* was deprecated in Matplotlib 3\.7',
+        # nilearn
+        r'The register_cmap function was deprecated in Matplotlib 3\.7',
     ):
         warnings.filterwarnings(  # deal with other modules having bad imports
             'ignore', message=".*%s.*" % key, category=DeprecationWarning)

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -122,9 +122,6 @@ def pytest_configure(config):
     ignore:`np.MachAr` is deprecated.*:DeprecationWarning
     # matplotlib 3.6 and pyvista/nilearn
     ignore:.*cmap function will be deprecated.*:
-    # TODO: matplotlib 3.7 that needs to be fixed
-    ignore:The rectangles attribute was deprecated in Matplotlib.*:
-    ignore:The lines attribute was deprecated in Matplotlib.*:
     # joblib hasn't updated to avoid distutils
     ignore:.*distutils package is deprecated.*:DeprecationWarning
     ignore:.*distutils Version classes are deprecated.*:DeprecationWarning
@@ -134,8 +131,6 @@ def pytest_configure(config):
     ignore:Jupyter is migrating its paths.*:DeprecationWarning
     ignore:Widget\..* is deprecated\.:DeprecationWarning
     ignore:.*is deprecated in pyzmq.*:DeprecationWarning
-    # hopefully temporary https://github.com/matplotlib/matplotlib/pull/24455#issuecomment-1319318629
-    ignore:The circles attribute was deprecated in Matplotlib.*:
     # PySide6
     ignore:Enum value .* is marked as deprecated:DeprecationWarning
     ignore:Function.*is marked as deprecated, please check the documentation.*:DeprecationWarning

--- a/mne/viz/_mpl_figure.py
+++ b/mne/viz/_mpl_figure.py
@@ -284,6 +284,7 @@ class MNESelectionFigure(MNEFigure):
 
     def _radiopress(self, event):
         """Handle RadioButton clicks for channel selection groups."""
+        logger.debug(f'Got radio press: {repr(event)}')
         selections_dict = self.mne.parent_fig.mne.ch_selections
         buttons = self.mne.radio_ax.buttons
         labels = [label.get_text() for label in buttons.labels]
@@ -295,6 +296,7 @@ class MNESelectionFigure(MNEFigure):
             return
         # clicking a selection cancels butterfly mode
         if parent.mne.butterfly:
+            logger.debug('Disabling butterfly mode')
             parent._toggle_butterfly()
             with _events_off(buttons):
                 buttons.set_active(labels.index(this_label))

--- a/mne/viz/_mpl_figure.py
+++ b/mne/viz/_mpl_figure.py
@@ -217,11 +217,7 @@ class MNEAnnotationFigure(MNEFigure):
         idx = labels.index(buttons.value_selected)
         self._set_active_button(idx)
         # update click-drag rectangle color
-        if _OLD_BUTTONS:
-            color = buttons.circles[idx].get_edgecolor()
-        else:
-            # TODO: Figure out a way to use a non-private attribute for this :(
-            color = buttons._buttons.get_edgecolor()[idx]
+        color = self.mne.parent_fig.mne.annotation_segment_colors[labels[idx]]
         selector = self.mne.parent_fig.mne.ax_main.selector
         # https://github.com/matplotlib/matplotlib/issues/20618
         # https://github.com/matplotlib/matplotlib/pull/20693
@@ -1018,14 +1014,12 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
             for artist in lines + (rect, text):
                 artist.set_transform(drag_ax.transData)
         # setup interactivity in plot window
-        buttons = fig.mne.radio_ax.buttons
-        if buttons is None:
+        if fig.mne.radio_ax.buttons is None:
             col = '#ff0000'
-        elif _OLD_BUTTONS:
-            col = buttons.circles[0].get_edgecolor()
         else:
-            # TODO: Figure out a way to use a non-private attribute for this :(
-            col = buttons._buttons.get_edgecolor()[0]
+            col = self.mne.annotation_segment_colors[
+                self._get_annotation_labels()[0]
+            ]
 
         # TODO: we would like useblit=True here, but it behaves oddly when the
         # first span is dragged (subsequent spans seem to work OK)

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -14,11 +14,7 @@ import pytest
 from mne import Epochs, create_info, EpochsArray
 from mne.datasets import testing
 from mne.event import make_fixed_length_events
-from mne.utils import check_version
 from mne.viz import plot_drop_log
-
-
-_mpl_37 = check_version('matplotlib', '3.7')
 
 
 def test_plot_epochs_not_preloaded(epochs_unloaded, browser_backend):
@@ -135,8 +131,6 @@ def test_plot_epochs_clicks(epochs, epochs_full, capsys,
     fig = epochs_full.plot(n_epochs=3)
     first_ch = fig._get_ticklabels('y')[0]
     assert first_ch not in fig.mne.info['bads']
-    if _mpl_37 and browser_backend.name == 'matplotlib':
-        pytest.xfail(reason='KeyError on matplotlib 3.7')
     fig._click_ch_name(ch_index=0, button=1)  # click ch name to mark bad
     assert first_ch in fig.mne.info['bads']
     # test clicking scrollbars

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -6,7 +6,6 @@ import itertools
 import os
 from copy import deepcopy
 
-import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib import backend_bases
 import numpy as np
@@ -19,13 +18,21 @@ from mne.datasets import testing
 from mne.io import RawArray
 from mne.io.pick import _DATA_CH_TYPES_ORDER_DEFAULT, _PICK_TYPES_DATA_DICT
 from mne.utils import (_dt_to_stamp, _record_warnings, get_config, set_config,
-                       _assert_no_instances, check_version)
+                       _assert_no_instances)
 from mne.viz import plot_raw, plot_sensors
 from mne.viz.utils import _fake_click, _fake_keypress
 
 
-# TODO: fix these matplotlib 3.7 compat bugs
-_mpl_37 = check_version('matplotlib', '3.7')
+def _get_button_xy(buttons, idx):
+    from mne.viz._mpl_figure import _OLD_BUTTONS
+    if _OLD_BUTTONS:
+        return buttons.circles[idx].center
+    else:
+        # Each transform is to display coords, and our offsets are in Axes
+        # coords. We want data coords, so we go Axes -> display -> data.
+        return buttons.ax.transData.inverted().transform(
+            buttons.ax.transAxes.transform(
+                buttons.ax.collections[0].get_offsets()[idx]))
 
 
 def _annotation_helper(raw, browse_backend, events=False):
@@ -63,7 +70,7 @@ def _annotation_helper(raw, browse_backend, events=False):
             fig._fake_keypress(key, fig=ann_fig)
         # change annotation label
         for ix in (-1, 0):
-            xy = ann_fig.mne.radio_ax.buttons.circles[ix].center
+            xy = _get_button_xy(ann_fig.mne.radio_ax.buttons, ix)
             fig._fake_click(xy, fig=ann_fig, ax=ann_fig.mne.radio_ax,
                             xform='data')
     else:
@@ -159,10 +166,8 @@ def _annotation_helper(raw, browse_backend, events=False):
 
 
 def _proj_status(ssp_fig, browse_backend):
-    if browse_backend.name == 'matplotlib':
-        ax = ssp_fig.mne.proj_checkboxes.ax
-        return [line.get_visible() for line
-                in ax.findobj(matplotlib.lines.Line2D)][::2]
+    if browse_backend == 'matplotlib' or browse_backend.name == 'matplotlib':
+        return ssp_fig.mne.proj_checkboxes.get_status()
     else:
         return [chkbx.isChecked() for chkbx in ssp_fig.checkboxes]
 
@@ -177,11 +182,10 @@ def _proj_label(ssp_fig, browse_backend):
 def _proj_click(idx, fig, browse_backend):
     ssp_fig = fig.mne.fig_proj
     if browse_backend.name == 'matplotlib':
-        pos = np.array(ssp_fig.mne.proj_checkboxes.
-                       labels[idx].get_position()) + 0.01
-
+        text_lab = ssp_fig.mne.proj_checkboxes.labels[idx]
+        pos = np.mean(text_lab.get_tightbbox(), axis=0)
         fig._fake_click(pos, fig=ssp_fig, ax=ssp_fig.mne.proj_checkboxes.ax,
-                        xform='data')
+                        xform='pix')
     else:
         # _fake_click on QCheckBox is inconsistent across platforms
         # (also see comment in test_plot_raw_selection).
@@ -282,8 +286,9 @@ def test_plot_raw_selection(raw, browser_backend):
     sel_fig = fig.mne.fig_selection
     assert sel_fig is not None
     # test changing selection with arrow keys
+    left_temp = 'Left-temporal'
     sel_dict = fig.mne.ch_selections
-    assert len(fig.mne.traces) == len(sel_dict['Left-temporal'])  # 6
+    assert len(fig.mne.traces) == len(sel_dict[left_temp])  # 6
     fig._fake_keypress('down', fig=sel_fig)
     assert len(fig.mne.traces) == len(sel_dict['Left-frontal'])  # 3
     fig._fake_keypress('down', fig=sel_fig)
@@ -306,7 +311,13 @@ def test_plot_raw_selection(raw, browser_backend):
     assert fig.mne.butterfly
     # test clicking on radio buttons → should cancel butterfly mode
     if ismpl:
-        xy = sel_fig.mne.radio_ax.buttons.circles[0].center
+        print(f'Clicking button: {repr(left_temp)}')
+        assert sel_fig.mne.radio_ax.buttons.labels[0].get_text() == left_temp
+        xy = _get_button_xy(sel_fig.mne.radio_ax.buttons, 0)
+        lim = sel_fig.mne.radio_ax.get_xlim()
+        assert lim[0] < xy[0] < lim[1]
+        lim = sel_fig.mne.radio_ax.get_ylim()
+        assert lim[0] < xy[1] < lim[1]
         fig._fake_click(xy, fig=sel_fig, ax=sel_fig.mne.radio_ax, xform='data')
     else:
         # For an unknown reason test-clicking on checkboxes is inconsistent
@@ -314,15 +325,12 @@ def test_plot_raw_selection(raw, browser_backend):
         # (QTest.mouseClick works isolated on all platforms but somehow
         # not in this context. _fake_click isn't working on linux)
         sel_fig._chkbx_changed(list(sel_fig.chkbxs.keys())[0])
-    # TODO: Results are wrong on matplotlib 3.7!
-    if browser_backend.name == 'matplotlib' and _mpl_37:
-        pytest.xfail('Fails on matplotlib 3.7')
-    assert len(fig.mne.traces) == len(sel_dict['Left-temporal'])  # 6
     assert not fig.mne.butterfly
+    assert len(fig.mne.traces) == len(sel_dict[left_temp])  # 6
     # test clicking on "custom" when not defined: should be no-op
     if ismpl:
         before_state = sel_fig.mne.radio_ax.buttons.value_selected
-        xy = sel_fig.mne.radio_ax.buttons.circles[-1].center
+        xy = _get_button_xy(sel_fig.mne.radio_ax.buttons, -1)
         fig._fake_click(xy, fig=sel_fig, ax=sel_fig.mne.radio_ax, xform='data')
         lasso = sel_fig.lasso
         sensor_ax = sel_fig.mne.sensor_ax
@@ -334,7 +342,7 @@ def test_plot_raw_selection(raw, browser_backend):
         lasso = sel_fig.channel_fig.lasso
         sensor_ax = sel_fig.channel_widget
         assert before_state == sel_fig.mne.old_selection          # unchanged
-    assert len(fig.mne.traces) == len(sel_dict['Left-temporal'])  # unchanged
+    assert len(fig.mne.traces) == len(sel_dict[left_temp])  # unchanged
     # test marking bad channel in selection mode → should make sensor red
     assert lasso.ec[:, 0].sum() == 0   # R of RGBA zero for all chans
     fig._click_ch_name(ch_index=1, button=1)  # mark bad
@@ -385,9 +393,6 @@ def test_plot_raw_ssp_interaction(raw, browser_backend):
     assert _proj_status(ssp_fig, browser_backend) == [True, True, True]
     # this should work (proj 1 not applied)
     _proj_click(1, fig, browser_backend)
-    # TODO: Broken on matplotlib 3.7
-    if browser_backend.name == 'matplotlib' and _mpl_37:
-        pytest.xfail('Fails on matplotlib 3.7')
     assert _proj_status(ssp_fig, browser_backend) == [True, False, True]
     # turn it back on
     _proj_click(1, fig, browser_backend)
@@ -407,8 +412,6 @@ def test_plot_raw_ssp_interaction(raw, browser_backend):
 
 def test_plot_raw_child_figures(raw, browser_backend):
     """Test spawning and closing of child figures."""
-    if browser_backend.name == 'matplotlib' and _mpl_37:
-        pytest.xfail(reason='IndexError on matplotlib 3.7')
     ismpl = browser_backend.name == 'matplotlib'
     with raw.info._unlock():
         raw.info['lowpass'] = 10.  # allow heavy decim during plotting
@@ -446,8 +449,6 @@ def test_orphaned_annot_fig(raw, browser_backend):
     """Test that annotation window is not orphaned (GH #10454)."""
     if browser_backend.name != 'matplotlib':
         return
-    if _mpl_37:
-        pytest.xfail(reason='IndexError on matplotlib 3.7')
     assert browser_backend._get_n_figs() == 0
     fig = raw.plot()
     _spawn_child_fig(fig, 'fig_annotation', browser_backend, 'a')
@@ -661,8 +662,6 @@ def test_plot_misc_auto(browser_backend):
 @pytest.mark.slowtest
 def test_plot_annotations(raw, browser_backend):
     """Test annotation mode of the plotter."""
-    if browser_backend.name == 'matplotlib' and _mpl_37:
-        pytest.xfail(reason='IndexError on matplotlib 3.7')
     ismpl = browser_backend.name == 'matplotlib'
     with raw.info._unlock():
         raw.info['lowpass'] = 10.

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -183,7 +183,9 @@ def _proj_click(idx, fig, browse_backend):
     ssp_fig = fig.mne.fig_proj
     if browse_backend.name == 'matplotlib':
         text_lab = ssp_fig.mne.proj_checkboxes.labels[idx]
-        pos = np.mean(text_lab.get_tightbbox(), axis=0)
+        pos = np.mean(
+            text_lab.get_tightbbox(renderer=fig.canvas.get_renderer()),
+            axis=0)
         fig._fake_click(pos, fig=ssp_fig, ax=ssp_fig.mne.proj_checkboxes.ax,
                         xform='pix')
     else:

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -38,6 +38,8 @@ from mne.viz.utils import (_find_peaks, _fake_click, _fake_keypress,
                            _fake_scroll)
 from mne.utils import requires_sklearn, check_version
 
+from mne.viz.tests.test_raw import _proj_status
+
 data_dir = testing.data_path(download=False)
 subjects_dir = data_dir / "subjects"
 ecg_fname = data_dir / "MEG" / "sample" / "sample_audvis_ecg-proj.fif"
@@ -52,11 +54,6 @@ layout = read_layout("Vectorview-all")
 cov_fname = base_dir / "test-cov.fif"
 
 
-# TODO: This is a problem on Windows at least
-@pytest.mark.xfail(
-    condition=check_version('matplotlib', '3.7'),
-    reason='Lines not visible',
-)
 @pytest.mark.parametrize('constrained_layout', (False, True))
 def test_plot_topomap_interactive(constrained_layout):
     """Test interactive topomap projection plotting."""
@@ -86,7 +83,7 @@ def test_plot_topomap_interactive(constrained_layout):
     assert len(plt.get_fignums()) == 1
 
     ax.clear()
-    evoked.copy().plot_topomap(proj='interactive', **kwargs)
+    fig = evoked.copy().plot_topomap(proj='interactive', **kwargs)
     canvas.draw()
     image_interactive = np.frombuffer(canvas.tostring_rgb(), dtype='uint8')
     assert_array_equal(image_noproj, image_interactive)
@@ -94,14 +91,10 @@ def test_plot_topomap_interactive(constrained_layout):
     assert len(plt.get_fignums()) == 2
 
     proj_fig = plt.figure(plt.get_fignums()[-1])
-    assert len(proj_fig.axes[0].lines) == 2
-    for line in proj_fig.axes[0].lines:
-        assert not line.get_visible()
-    _fake_click(proj_fig, proj_fig.axes[0], [0.5, 0.5], xform='data')
-    assert len(proj_fig.axes[0].lines) == 2
+    assert _proj_status(fig, 'matplotlib') == [False]
+    _fake_click(proj_fig, proj_fig.axes[0], [0.5, 0.5], xform='ax')
     proj_fig.canvas.draw_idle()
-    for li, line in enumerate(proj_fig.axes[0].lines):
-        assert line.get_visible(), f'line {li} not visible'
+    assert _proj_status(fig, 'matplotlib') == [True]
     canvas.draw()
     image_interactive_click = np.frombuffer(
         canvas.tostring_rgb(), dtype='uint8')
@@ -112,7 +105,7 @@ def test_plot_topomap_interactive(constrained_layout):
         image_noproj.ravel(), image_interactive_click.ravel())[0, 1]
     assert 0.85 < corr < 0.9
 
-    _fake_click(proj_fig, proj_fig.axes[0], [0.5, 0.5], xform='data')
+    _fake_click(proj_fig, proj_fig.axes[0], [0.5, 0.5], xform='ax')
     canvas.draw()
     image_interactive_click = np.frombuffer(
         canvas.tostring_rgb(), dtype='uint8')

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1824,6 +1824,10 @@ def plot_evoked_topomap(
             merge_channels=merge_channels, scale=scaling, axes=axes,
             contours=contours, interp=interp, extrapolate=extrapolate)
         _draw_proj_checkbox(None, params)
+        # This is mostly for testing purposes, but it's also consistent with
+        # raw.plot, so maybe not a bad thing in principle either
+        from mne.viz._figure import BrowserParams
+        fig.mne = BrowserParams(proj_checkboxes=params['proj_checks'])
 
     plt_show(show, block=False)
     if axes_given:

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -487,7 +487,7 @@ def _draw_proj_checkbox(event, params, draw_current_state=True):
     check_kwargs = dict()
     if not _OLD_BUTTONS:
         checkcolor = ['#ff0000' if p['active'] else 'k' for p in projs]
-        check_kwargs['check_props'].update(facecolor=checkcolor)
+        check_kwargs['check_props'] = dict(facecolor=checkcolor)
         check_kwargs['frame_props'] = dict(edgecolor='0.5', linewidth=1)
     proj_checks = widgets.CheckButtons(
         ax_temp, labels=labels, actives=actives, **check_kwargs)

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -481,21 +481,27 @@ def _draw_proj_checkbox(event, params, draw_current_state=True):
     ax_temp = fig_proj.add_axes((0, offset, 1, 0.8 - offset), frameon=False)
     ax_temp.set_title('Projectors marked with "X" are active')
 
-    proj_checks = widgets.CheckButtons(ax_temp, labels=labels, actives=actives)
-    # make edges around checkbox areas
-    # TODO: .rectangles deprecated in matplotlib 3.7
-    for rect in proj_checks.rectangles:
-        rect.set_edgecolor('0.5')
-        rect.set_linewidth(1.)
+    # make edges around checkbox areas and change already-applied projectors
+    # to red
+    from ._mpl_figure import _OLD_BUTTONS
+    check_kwargs = dict()
+    if not _OLD_BUTTONS:
+        checkcolor = ['#ff0000' if p['active'] else 'k' for p in projs]
+        check_kwargs['check_props'].update(facecolor=checkcolor)
+        check_kwargs['frame_props'] = dict(edgecolor='0.5', linewidth=1)
+    proj_checks = widgets.CheckButtons(
+        ax_temp, labels=labels, actives=actives, **check_kwargs)
+    if _OLD_BUTTONS:
+        for rect in proj_checks.rectangles:
+            rect.set_edgecolor('0.5')
+            rect.set_linewidth(1.)
+        for ii, p in enumerate(projs):
+            if p['active']:
+                for x in proj_checks.lines[ii]:
+                    x.set_color('#ff0000')
 
-    # change already-applied projectors to red
-    for ii, p in enumerate(projs):
-        if p['active']:
-            for x in proj_checks.lines[ii]:
-                x.set_color('#ff0000')
     # make minimal size
     # pass key presses from option dialog over
-
     proj_checks.on_clicked(partial(_toggle_proj, params=params))
     params['proj_checks'] = proj_checks
     fig_proj.canvas.mpl_connect('key_press_event', _key_press)

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -778,6 +778,8 @@ def _fake_click(fig, ax, point, xform='ax', button=1, kind='press', key=None):
             assert kind == 'motion'
             kind = 'motion_notify_event'
             button = None
+        logger.debug(
+            f'Faking {kind} @ ({x}, {y}) with button={button} and key={key}')
         fig.canvas.callbacks.process(
             kind,
             backend_bases.MouseEvent(

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ xlrd
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1
 traitlets
-pyvista>=0.32,!=0.35.2,!=0.38.0,!=0.38.1,!=0.38.2
+pyvista>=0.32,!=0.35.2,!=0.38.0,!=0.38.1,!=0.38.2,!=0.38.3
 pyvistaqt>=0.4
 mffpy>=0.5.7
 ipywidgets

--- a/tutorials/clinical/30_ecog.py
+++ b/tutorials/clinical/30_ecog.py
@@ -36,7 +36,7 @@ Please note that this tutorial requires 3D plotting dependencies (see
 
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib import cm
+from matplotlib import colormaps
 from mne_bids import BIDSPath, read_raw_bids
 
 import mne
@@ -147,7 +147,7 @@ gamma_power_at_15s = gamma_power_t.to_data_frame(index='time').loc[15]
 # scale values to be between 0 and 1, then map to colors
 gamma_power_at_15s -= gamma_power_at_15s.min()
 gamma_power_at_15s /= gamma_power_at_15s.max()
-rgba = cm.get_cmap("viridis")
+rgba = colormaps.get_cmap("viridis")
 sensor_colors = gamma_power_at_15s.map(rgba).tolist()
 
 fig = plot_alignment(raw.info, trans='fsaverage',

--- a/tutorials/evoked/20_visualize_evoked.py
+++ b/tutorials/evoked/20_visualize_evoked.py
@@ -11,6 +11,7 @@ This tutorial shows the different visualization methods for
 
 As usual we'll start by importing the modules we need:
 """
+
 # %%
 
 import numpy as np

--- a/tutorials/inverse/20_dipole_fit.py
+++ b/tutorials/inverse/20_dipole_fit.py
@@ -6,7 +6,7 @@
 Source localization with equivalent current dipole (ECD) fit
 ============================================================
 
-This shows how to fit a dipole :footcite:`Sarvas1987` using mne-python.
+This shows how to fit a dipole :footcite:`Sarvas1987` using MNE-Python.
 
 For a comparison of fits between MNE-C and MNE-Python, see
 `this gist <https://gist.github.com/larsoner/ca55f791200fe1dc3dd2>`__.

--- a/tutorials/preprocessing/50_artifact_correction_ssp.py
+++ b/tutorials/preprocessing/50_artifact_correction_ssp.py
@@ -34,7 +34,6 @@ from mne.preprocessing import (create_eog_epochs, create_ecg_epochs,
 #     See :ref:`tut-artifact-overview` for guidance on detecting and
 #     visualizing various types of artifact.
 #
-#
 # What is SSP?
 # ^^^^^^^^^^^^
 #


### PR DESCRIPTION
closes #11332 

So far this is just proof of concept that the new MPL RadioButtons API can do what we need it to do.  Tested against [this commit](https://github.com/matplotlib/matplotlib/pull/24838/commits/2c895fb01600cdef5afb35bb8f62256ac2621234) in [this open MPL PR](https://github.com/matplotlib/matplotlib/pull/24838). The radio buttons look OK:

![Screenshot_2023-01-06_15-18-01](https://user-images.githubusercontent.com/1810515/211106164-5afe30a8-14d2-45e4-9e4e-7b2ca95f8fc9.png)

...but our current min version of MPL is 3.1 and MPL 3.7 isn't even out yet (probably end of January according to @tacaswell). So we should talk about how we want to handle this; presumably some combination/sequence of 

- pin MPL<3.7 once it's released (in user-facing files, not just in the CI pre jobs)
- finish implementing this PR (and related changes to CheckButtons)
- remove the warning filter and CI version pin from:
    - https://github.com/mne-tools/mne-python/pull/11329
    - https://github.com/mne-tools/mne-python/pull/11497
- bump min version
- remove MPL pin from user-facing files

but I'm not sure on the timing of each step.