### PR TITLE
WIP / RFC: Rework sys_info output

### DIFF
--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -28,7 +28,6 @@ _temp_home_dir = None
 _UNICODE_TERMINAL = sys.stdout.encoding.lower().startswith('utf')
 
 
-
 def set_cache_dir(cache_dir):
     """Set the directory to be used for temporary file storage.
 
@@ -608,14 +607,15 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
         try:
             mod = __import__(mod_name)
         except Exception:
-            out('   Not found\n')
+            out('  Not found\n')
         else:
             if mod_name == 'vtk':
                 if _UNICODE_TERMINAL:
-                    icon = '✔︎ '
+                    icon = '✔︎'
                 else:
                     icon = ''
-                out(f'{icon} {mod.__version__}')
+                prefix = f'{icon} ' if icon else ''
+                out(f'{prefix}{mod.__version__}')
 
                 vtk_version = mod.vtkVersion()
                 # 9.0 dev has VersionFull but 9.0 doesn't
@@ -629,10 +629,11 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
                     out(f'{icon} unknown')
             else:
                 if _UNICODE_TERMINAL:
-                    icon = '✔︎ '
+                    icon = '✔︎'
                 else:
                     icon = ''
-                out(f'{icon} {mod.__version__}')
+                prefix = f'{icon} ' if icon else ''
+                out(f'{prefix}{mod.__version__}')
             if mod_name == 'numpy':
                 out(f' {{{libs}}}')
             elif mod_name == 'qtpy':

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -557,29 +557,10 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
 
     out = partial(print, end='', file=fid)
 
-    if _UNICODE_TERMINAL:
-        icon = '\N{personal computer}'
-    else:
-        icon = ''
-    out(f'{icon} Platform:'.ljust(ljust) + platform_str + '\n')
-
-    if _UNICODE_TERMINAL:
-        icon = '\N{snake}'
-    else:
-        icon = ''
-    out(f'{icon} Python:'.ljust(ljust) + str(sys.version).replace('\n', ' ') + '\n')
-
-    if _UNICODE_TERMINAL:
-        icon = '\N{runner}'
-    else:
-        icon = ''
-    out(f'{icon} Executable:'.ljust(ljust) + sys.executable + '\n')
-
-    if _UNICODE_TERMINAL:
-        icon = '\N{automobile}'
-    else:
-        icon = ''
-    out(f'{icon} CPU:'.ljust(ljust) + f'{platform.processor()}: ')
+    out('Platform:'.ljust(ljust) + platform_str + '\n')
+    out('Python:'.ljust(ljust) + str(sys.version).replace('\n', ' ') + '\n')
+    out('Executable:'.ljust(ljust) + sys.executable + '\n')
+    out('CPU:'.ljust(ljust) + f'{platform.processor()}: ')
     try:
         import multiprocessing
     except ImportError:
@@ -588,11 +569,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
     else:
         out(f'{multiprocessing.cpu_count()} cores\n')
 
-    if _UNICODE_TERMINAL:
-        icon = '\N{thought balloon}'
-    else:
-        icon = ''
-    out(f'{icon} Memory:'.ljust(ljust))
+    out('Memory:'.ljust(ljust))
     try:
         import psutil
     except ImportError:
@@ -619,16 +596,11 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
         try:
             mod = __import__(mod_name)
         except Exception:
-            if _UNICODE_TERMINAL:
-                icon = '\N{cross mark}'
-            else:
-                icon = '×'
-
-            out(f'{icon} Not found\n')
+            out('   Not found\n')
         else:
             if mod_name == 'vtk':
                 if _UNICODE_TERMINAL:
-                    icon = '\N{check mark}'
+                    icon = '✔︎ '
                 else:
                     icon = ''
                 out(f'{icon} {mod.__version__}')
@@ -645,7 +617,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
                     out(f'{icon} unknown')
             else:
                 if _UNICODE_TERMINAL:
-                    icon = '\N{check mark}'
+                    icon = '✔︎ '
                 else:
                     icon = ''
                 out(f'{icon} {mod.__version__}')
@@ -664,8 +636,8 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
                     out(f' {{OpenGL {version} via {renderer}}}')
             if show_paths or mod_name == 'mne':  # always show path to mne
                 if _UNICODE_TERMINAL:
-                    folder_icon = '\N{open file folder}'
+                    icon = '📂'
                 else:
-                    folder_icon = '»'
-                out(f'\n{" " * ljust}{folder_icon} {op.dirname(mod.__file__)}')
+                    icon = '»'
+                out(f'\n{" " * ljust}{icon} {op.dirname(mod.__file__)}')
             out('\n')


### PR DESCRIPTION
- Include `mne` package location in output by default to make it easier to discover issues like the one reported here: https://mne.discourse.group/t/wrong-version-installed-with-conda/6158
- Use emojis if we're on a unicode terminal

This is just a quick and dirty test. The emoji handling bit probably should go into the `out()` function, which should accept a parameter for adding an emoji.

No new dependencies are introduced.

WDYT?

<img width="825" alt="Screenshot 2023-01-08 at 17 45 12" src="https://user-images.githubusercontent.com/2046265/211208723-4dbcf901-98ff-45d1-9d4c-d22546f828a1.png">
