### PR TITLE
[Doc] Minor doc fixes for interpolate_bads

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1009,11 +1009,11 @@ class InterpolationMixin(object):
             Method to use for each channel type.
             Currently only the key ``"eeg"`` has multiple options:
 
-            * ``"spline"`` (default)
-              Use spherical spline interpolation.
-            * ``"MNE"``
-              Use minimum-norm projection to a sphere and back.
-              This is the method used for MEG channels.
+            - ``"spline"`` (default)
+                Use spherical spline interpolation.
+            - ``"MNE"``
+                Use minimum-norm projection to a sphere and back.
+                This is the method used for MEG channels.
 
             The value for ``"meg"`` is ``"MNE"``, and the value for
             ``"fnirs"`` is ``"nearest"``. The default (None) is thus an alias

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1007,16 +1007,17 @@ class InterpolationMixin(object):
             .. versionadded:: 0.17
         method : dict
             Method to use for each channel type.
-            Currently only the key "eeg" has multiple options:
+            Currently only the key ``"eeg"`` has multiple options:
 
-            - ``"spline"`` (default)
-                Use spherical spline interpolation.
-            - ``"MNE"``
-                Use minimum-norm projection to a sphere and back.
-                This is the method used for MEG channels.
+            * ``"spline"`` (default)
+              Use spherical spline interpolation.
+            * ``"MNE"``
+              Use minimum-norm projection to a sphere and back.
+              This is the method used for MEG channels.
 
-            The value for "meg" is "MNE", and the value for
-            "fnirs" is "nearest". The default (None) is thus an alias for::
+            The value for ``"meg"`` is ``"MNE"``, and the value for
+            ``"fnirs"`` is ``"nearest"``. The default (None) is thus an alias
+            for::
 
                 method=dict(meg="MNE", eeg="spline", fnirs="nearest")
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1005,7 +1005,7 @@ class InterpolationMixin(object):
             origin fit.
 
             .. versionadded:: 0.17
-        method : dict
+        method : dict | None
             Method to use for each channel type.
             Currently only the key ``"eeg"`` has multiple options:
 

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -64,9 +64,9 @@ def _make_interpolation_matrix(pos_from, pos_to, alpha=1e-5):
     Parameters
     ----------
     pos_from : np.ndarray of float, shape(n_good_sensors, 3)
-        The positions to interpoloate from.
+        The positions to interpolate from.
     pos_to : np.ndarray of float, shape(n_bad_sensors, 3)
-        The positions to interpoloate.
+        The positions to interpolate.
     alpha : float
         Regularization parameter. Defaults to 1e-5.
 


### PR DESCRIPTION
A couple of minor style fixes while I was looking at the interpolation code.

Before:

<img width="671" alt="Screenshot 2023-01-09 at 18 19 30" src="https://user-images.githubusercontent.com/73893616/211368536-b4b81f17-6758-4937-908a-723cca827768.png">

After:

<img width="671" alt="Screenshot 2023-01-09 at 18 19 07" src="https://user-images.githubusercontent.com/73893616/211368555-93fcd3ac-c538-4ac0-a11b-2383e13ff8a8.png">

If you don't think this is an improvement, feel free to close the PR 😉 