### PR TITLE
MRG: In epochs plot window title, don't use "evoked-style" fractional-sum notation

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -28,6 +28,7 @@ Enhancements
 - Add :meth:`mne.Info.save` to save an :class:`mne.Info` object to a fif file (:gh:`11401` by `Alex Rockhill`_)
 - Improved error message when downloads are corrupted for :func:`mne.datasets.sample.data_path` and related functions (:gh:`11407` by `Eric Larson`_)
 - Add support for ``skip_by_annotation`` in :func:`mne.io.Raw.notch_filter` (:gh:`11388` by `Mainak Jas`_)
+- Slightly adjusted the window title for :func:`mne.Epochs.plot` (:gh:`11419` by `Richard Höchenberger`_ and `Daniel McCloy`_)
 
 Bugs
 ~~~~

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1066,15 +1066,33 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     @property
     def _name(self):
         """Give a nice string representation based on event ids."""
+        return self._get_name()
+
+    def _get_name(self, include_frac=True, sep='+'):
+        """Generate human-readable name for epochs and evokeds from event_id.
+
+        Parameters
+        ----------
+        include_frac : bool, optional
+            Whether to include the fraction of epochs that each event type
+            contributes to the total number of epochs. Ignored if only one
+            event type is present.
+        sep : str, optional
+            How to separate the different events names. Ignored if only one
+            event type is present.
+        """
         if len(self.event_id) == 1:
             comment = next(iter(self.event_id.keys()))
         else:
             count = Counter(self.events[:, 2])
             comments = list()
-            for key, value in self.event_id.items():
-                comments.append('%.2f × %s' % (
-                    float(count[value]) / len(self.events), key))
-            comment = ' + '.join(comments)
+            for event_name, event_code in self.event_id.items():
+                frac = float(count[event_code]) / len(self.events)
+                if include_frac:
+                    comments.append(f'{frac:.2f} × {event_name}')
+                else:
+                    comments.append(event_name)
+            comment = f' {sep} '.join(comments)
         return comment
 
     def _evoked_from_epoch_data(self, data, info, picks, n_events, kind,

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1089,7 +1089,7 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         if len(self.event_id) == 1:
             comment = next(iter(self.event_id.keys()))
         else:
-            count = Counter(self.events[:, 2])
+            counter = Counter(self.events[:, 2])
             comments = list()
 
             # Take care of padding
@@ -1100,10 +1100,10 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
 
             for event_name, event_code in self.event_id.items():
                 if count == 'frac':
-                    frac = float(count[event_code]) / len(self.events)
+                    frac = float(counter[event_code]) / len(self.events)
                     comment = f'{frac:.2f}{ms}{event_name}'
                 else:  # 'total'
-                    comment = f'{count[event_code]}{ms}{event_name}'
+                    comment = f'{counter[event_code]}{ms}{event_name}'
                 comments.append(comment)
 
             comment = f' {sep} '.join(comments)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1068,30 +1068,44 @@ class BaseEpochs(ProjMixin, ContainsMixin, UpdateChannelsMixin,
         """Give a nice string representation based on event ids."""
         return self._get_name()
 
-    def _get_name(self, include_frac=True, sep='+'):
+    def _get_name(self, count='frac', ms='×', sep='+'):
         """Generate human-readable name for epochs and evokeds from event_id.
 
         Parameters
         ----------
-        include_frac : bool, optional
-            Whether to include the fraction of epochs that each event type
-            contributes to the total number of epochs. Ignored if only one
-            event type is present.
-        sep : str, optional
+        count : 'frac' | 'total'
+            Whether to include the fraction or total number of epochs that each
+            event type contributes to the number of all epochs.
+            Ignored if only one event type is present.
+        ms : str | None
+            The multiplication sign to use. Pass ``None`` to omit the sign.
+            Ignored if only one event type is present.
+        sep : str
             How to separate the different events names. Ignored if only one
             event type is present.
         """
+        _check_option('count', value=count, allowed_values=['frac', 'total'])
+
         if len(self.event_id) == 1:
             comment = next(iter(self.event_id.keys()))
         else:
             count = Counter(self.events[:, 2])
             comments = list()
+
+            # Take care of padding
+            if ms is None:
+                ms = ' '
+            else:
+                ms = f' {ms} '
+
             for event_name, event_code in self.event_id.items():
-                frac = float(count[event_code]) / len(self.events)
-                if include_frac:
-                    comments.append(f'{frac:.2f} × {event_name}')
-                else:
-                    comments.append(event_name)
+                if count == 'frac':
+                    frac = float(count[event_code]) / len(self.events)
+                    comment = f'{frac:.2f}{ms}{event_name}'
+                else:  # 'total'
+                    comment = f'{count[event_code]}{ms}{event_name}'
+                comments.append(comment)
+
             comment = f' {sep} '.join(comments)
         return comment
 

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -854,7 +854,7 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
 
     # generate window title
     if title is None:
-        title = epochs._get_name(include_frac=False, sep='•')
+        title = epochs._get_name(count='total', sep='•', ms=None)
         if title is None or len(title) == 0:
             title = 'Epochs'
     elif not isinstance(title, str):

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -670,8 +670,8 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
     n_channels : int
         The number of channels per view. Defaults to 20.
     title : str | None
-        The title of the window. If None, epochs name will be displayed.
-        Defaults to None.
+        The title of the window. If None, the event names (from
+        ``epochs.event_id``) will be displayed. Defaults to None.
     events : None | array, shape (n_events, 3)
         Events to show with vertical bars. You can use `~mne.viz.plot_events`
         as a legend for the colors. By default, the coloring scheme is the
@@ -854,7 +854,7 @@ def plot_epochs(epochs, picks=None, scalings=None, n_epochs=20, n_channels=20,
 
     # generate window title
     if title is None:
-        title = epochs._name
+        title = epochs._get_name(include_frac=False, sep='•')
         if title is None or len(title) == 0:
             title = 'Epochs'
     elif not isinstance(title, str):


### PR DESCRIPTION
When plotting epochs, we currently get a window titlte that is exactly the same as the comment we'd put into the evoked produced by averaging the displayed epochs.
<img width="688" alt="Screenshot 2023-01-15 at 20 10 47" src="https://user-images.githubusercontent.com/2046265/212562331-e2ce34e2-a34a-425e-b8fa-0dbddded0cdd.png">

This is actually misleading – nothing has been averaged yet, so, strictly speaking, the formula doesn't make sense; and it's quite noisy when many different event types are involved.

I have two different proposals, both of which involve removal of the plus signs:

a) we could remove the fractional numbers like this:

<img width="688" alt="Screenshot 2023-01-15 at 20 09 24" src="https://user-images.githubusercontent.com/2046265/212562320-0daf0708-9919-4011-aa85-b19659903492.png">

I like how clean that is.

b) instead of having fractions, we could display the absolute numbers of epochs for each event type. However, this again is very verbose for many conditions – but it makes it very nice and easy to sanity-check whether you're looking at the correct subset of epochs while viewing them.
<img width="688" alt="Screenshot 2023-01-15 at 20 15 01" src="https://user-images.githubusercontent.com/2046265/212562337-23d654db-f682-46fc-beec-e2555d16fd51.png">

In this draft, only a) has been implemented (as a and b are mutually exclusive with our existing public API)

Thoughts?