### PR TITLE
Fix typo in Maxwell filter documentation

### DIFF
--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -1296,7 +1296,7 @@ def filter_chpi(raw, include_line=True, t_step=0.01, t_window='auto',
     -----
     cHPI signals are in general not stationary, because head movements act
     like amplitude modulators on cHPI signals. Thus it is recommended to
-    to use this procedure, which uses an iterative fitting method, to
+    use this procedure, which uses an iterative fitting method, to
     remove cHPI signals, as opposed to notch filtering.
 
     .. versionadded:: 0.12

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -216,7 +216,7 @@ def maxwell_filter(raw, origin='auto', int_order=8, ext_order=3,
         buffer window will be lumped into the previous buffer.
     st_correlation : float
         Correlation limit between inner and outer subspaces used to reject
-        ovwrlapping intersecting inner/outer signals during spatiotemporal SSS.
+        overlapping intersecting inner/outer signals during spatiotemporal SSS.
     %(coord_frame_maxwell)s
     %(destination_maxwell_dest)s
     %(regularize_maxwell_reg)s

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -308,8 +308,8 @@ azimuth : float
 
 docdict['bad_condition_maxwell_cond'] = """
 bad_condition : str
-    How to deal with ill-conditioned SSS matrices. Can be "error"
-    (default), "warning", "info", or "ignore".
+    How to deal with ill-conditioned SSS matrices. Can be ``"error"``
+    (default), ``"warning"``, ``"info"``, or ``"ignore"``.
 """
 
 docdict['bands_psd_topo'] = """
@@ -2913,8 +2913,8 @@ reg_affine : ndarray of float, shape (4, 4)
 
 docdict['regularize_maxwell_reg'] = """
 regularize : str | None
-    Basis regularization type, must be "in" or None.
-    "in" is the same algorithm as the "-regularize in" option in
+    Basis regularization type, must be ``"in"`` or None.
+    ``"in"`` is the same algorithm as the ``"-regularize in"`` option in
     MaxFilter™.
 """
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2914,7 +2914,7 @@ reg_affine : ndarray of float, shape (4, 4)
 docdict['regularize_maxwell_reg'] = """
 regularize : str | None
     Basis regularization type, must be ``"in"`` or None.
-    ``"in"`` is the same algorithm as the ``"-regularize in"`` option in
+    ``"in"`` is the same algorithm as the ``-regularize in`` option in
     MaxFilter™.
 """
 


### PR DESCRIPTION
A couple of typos/formatting while I was looking at MNE's version of Maxwell filters.