### PR TITLE
FIX reading of EDF data with different sampling rates of a mix of data channels when using infer_types=True

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -36,6 +36,7 @@ Bugs
 - Fix bug where splash screen would not always disappear (:gh:`11398` by `Eric Larson`_)
 - Fix bug where having a different combination of volumes loaded into ``freeview`` caused different affines to be returned by :func:`mne.read_lta` for the same Linear Transform Array (LTA) (:gh:`11402` by `Alex Rockhill`_)
 - Fix how :class:`mne.channels.DigMontage` is set when using :func:`mne.gui.locate_ieeg` so that :func:`mne.Info.get_montage` works and does not return ``None`` (:gh:`11421` by `Alex Rockhill`_)
+- Fix :func:`mne.io.read_raw_edf` when reading EDF data with different sampling rates and a mix of data channels when using ``infer_types=True`` (:gh:`11427` by `Alex Gramfort`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -488,7 +488,7 @@ def _get_info(fname, stim_channel, eog, misc, exclude, infer_types, preload,
             chan_info['kind'] = CH_TYPE_MAPPING.get(ch_type)
             if ch_type not in ['EEG', 'ECOG', 'SEEG', 'DBS']:
                 chan_info['coil_type'] = FIFF.FIFFV_COIL_NONE
-                pick_mask[idx] = False
+            pick_mask[idx] = False
         # if user passes in explicit mapping for eog, misc and stim
         # channels set them here
         if ch_name in eog or idx in eog or idx - nchan in eog:


### PR DESCRIPTION
addresses https://mne.discourse.group/t/mass-dataset-mne-function-read-half-file-when-infer-types-true/6193

it was a nasty one...