### PR TITLE
fixed annotations error on export

### DIFF
--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -87,7 +87,7 @@ I agree to the following:
 # respective repos, and make a new release of the dataset on GitHub. Then
 # update the checksum in the MNE_DATASETS dict below, and change version
 # here:                  ↓↓↓↓↓         ↓↓↓
-RELEASES = dict(testing='0.141', misc='0.24')
+RELEASES = dict(testing='0.142', misc='0.24')
 TESTING_VERSIONED = f'mne-testing-data-{RELEASES["testing"]}'
 MISC_VERSIONED = f'mne-misc-data-{RELEASES["misc"]}'
 
@@ -111,7 +111,7 @@ MNE_DATASETS = dict()
 # Testing and misc are at the top as they're updated most often
 MNE_DATASETS['testing'] = dict(
     archive_name=f'{TESTING_VERSIONED}.tar.gz',
-    hash='md5:08b1e81e944de9616a408eb70d73775b',
+    hash='md5:44b857ddb34aefd752e4f5b19d625dee',
     url=('https://codeload.github.com/mne-tools/mne-testing-data/'
          f'tar.gz/{RELEASES["testing"]}'),
     # In case we ever have to resort to osf.io again...

--- a/mne/export/_eeglab.py
+++ b/mne/export/_eeglab.py
@@ -42,7 +42,7 @@ def _export_epochs(fname, epochs):
     ch_names = [ch for ch in epochs.ch_names if ch not in drop_chs]
     cart_coords = _get_als_coords_from_chs(epochs.info['chs'], drop_chs)
 
-    if (epochs.annotations is not None) and (len(epochs.annotations) > 0):
+    if epochs.annotations:
         annot = [epochs.annotations.description, epochs.annotations.onset,
                  epochs.annotations.duration]
     else:

--- a/mne/export/_eeglab.py
+++ b/mne/export/_eeglab.py
@@ -42,10 +42,9 @@ def _export_epochs(fname, epochs):
     ch_names = [ch for ch in epochs.ch_names if ch not in drop_chs]
     cart_coords = _get_als_coords_from_chs(epochs.info['chs'], drop_chs)
 
-    if (type(epochs.annotations)!=None.__class__):
-        if (len(epochs.annotations) > 0):
-            annot = [epochs.annotations.description, epochs.annotations.onset,
-                     epochs.annotations.duration]
+    if (epochs.annotations is not None) and (len(epochs.annotations) > 0):
+        annot = [epochs.annotations.description, epochs.annotations.onset,
+                 epochs.annotations.duration]
     else:
         annot = None
 

--- a/mne/export/_eeglab.py
+++ b/mne/export/_eeglab.py
@@ -42,9 +42,10 @@ def _export_epochs(fname, epochs):
     ch_names = [ch for ch in epochs.ch_names if ch not in drop_chs]
     cart_coords = _get_als_coords_from_chs(epochs.info['chs'], drop_chs)
 
-    if len(epochs.annotations) > 0:
-        annot = [epochs.annotations.description, epochs.annotations.onset,
-                 epochs.annotations.duration]
+    if (type(epochs.annotations)!=None.__class__):
+        if (len(epochs.annotations) > 0):
+            annot = [epochs.annotations.description, epochs.annotations.onset,
+                     epochs.annotations.duration]
     else:
         annot = None
 


### PR DESCRIPTION

#### Reference issue
Fixes #11434.


#### What does this implement/fix?
The code verifies is annotations exists (not type None) before attempting to fetch the length of the annotations' object.


#### Additional information
Missing annotations is probably caused by mne.concatenate_epochs(). Fixing the function will avoid having None type annotations. However I am not sure that's the only case, as such this fix may help in more than a situation.