### PR TITLE
[MAINT/BUG, MRG] Use make_dig_montage for ECoG projection

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -39,6 +39,7 @@ Bugs
 - Fix bug where having a different combination of volumes loaded into ``freeview`` caused different affines to be returned by :func:`mne.read_lta` for the same Linear Transform Array (LTA) (:gh:`11402` by `Alex Rockhill`_)
 - Fix how :class:`mne.channels.DigMontage` is set when using :func:`mne.gui.locate_ieeg` so that :func:`mne.Info.get_montage` works and does not return ``None`` (:gh:`11421` by `Alex Rockhill`_)
 - Fix :func:`mne.io.read_raw_edf` when reading EDF data with different sampling rates and a mix of data channels when using ``infer_types=True`` (:gh:`11427` by `Alex Gramfort`_)
+- Fix how :class:`mne.channels.DigMontage` is set when using :func:`mne.preprocessing.ieeg.project_sensors_onto_brain` so that :func:`mne.Info.get_montage` works and does not return ``None`` (:gh:`11436` by `Alex Rockhill`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -111,7 +111,7 @@ MNE_DATASETS = dict()
 # Testing and misc are at the top as they're updated most often
 MNE_DATASETS['testing'] = dict(
     archive_name=f'{TESTING_VERSIONED}.tar.gz',
-    hash='md5:08b1e81e944de9616a408eb70d73775b',
+    hash='md5:f7e70e7cd9ee0ae3e7364a52e52262e6',
     url=('https://codeload.github.com/mne-tools/mne-testing-data/'
          f'tar.gz/{RELEASES["testing"]}'),
     # In case we ever have to resort to osf.io again...

--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -123,7 +123,7 @@ MNE_DATASETS['testing'] = dict(
 )
 MNE_DATASETS['misc'] = dict(
     archive_name=f'{MISC_VERSIONED}.tar.gz',  # 'mne-misc-data',
-    hash='md5:eb017a919939511932bd683f26f97490',
+    hash='md5:b3b45379e5be40d64383ef5a08c1f21f',
     url=('https://codeload.github.com/mne-tools/mne-misc-data/tar.gz/'
          f'{RELEASES["misc"]}'),
     folder_name='MNE-misc-data',

--- a/mne/preprocessing/ieeg/_projection.py
+++ b/mne/preprocessing/ieeg/_projection.py
@@ -7,6 +7,7 @@ from os import path as op
 from itertools import combinations
 import numpy as np
 
+from ...channels import make_dig_montage
 from ...io.pick import _picks_to_idx
 from ...surface import _read_mri_surface, fast_cross_3d
 from ...transforms import (apply_trans, invert_transform, _cart_to_sph,
@@ -97,6 +98,11 @@ def project_sensors_onto_brain(info, trans, subject, subjects_dir=None,
         proj_locs[i] = use_rr[np.argmin(surf_dists)]
     # back to the "head" coordinate frame for storing in ``raw``
     proj_locs = apply_trans(invert_transform(trans), proj_locs)
+    montage = info.get_montage()
+    montage_kwargs = montage.get_positions() if montage else \
+        dict(ch_pos=dict(), coord_frame='head')
     for idx, loc in zip(picks_idx, proj_locs):
-        info['chs'][idx]['loc'][:3] = loc
+        # surface RAS-> head and mm->m
+        montage_kwargs['ch_pos'][info.ch_names[idx]] = loc
+    info.set_montage(make_dig_montage(**montage_kwargs))
     return info

--- a/mne/preprocessing/ieeg/tests/test_projection.py
+++ b/mne/preprocessing/ieeg/tests/test_projection.py
@@ -64,5 +64,9 @@ def test_project_sensors_onto_brain(tmp_path):
     test_locs = [[0.00149, -0.001588, 0.133029],
                  [0.004302, 0.001959, 0.133922],
                  [0.008602, 0.00116, 0.133723]]
-    for ch, test_loc in zip(raw.info['chs'][:3], test_locs):
-        assert_allclose(ch['loc'][:3], test_loc, rtol=0.01)
+
+    montage = raw.get_montage()
+    assert montage is not None
+    ch_pos = montage.get_positions()['ch_pos']
+    for ch, test_loc in zip(raw.ch_names[:3], test_locs):
+        assert_allclose(ch_pos[ch], test_loc, atol=0.01)


### PR DESCRIPTION
Followup on previous issue setting the `info.chs` locations directly in the `ieeg_locate` GUI but for sensor projections in ECoG.