### PR TITLE
BUG: add infer_types=True for read_raw_edf in Sleep stage classificat…

### DIFF
--- a/tutorials/clinical/60_sleep.py
+++ b/tutorials/clinical/60_sleep.py
@@ -78,7 +78,7 @@ ALICE, BOB = 0, 1
 [alice_files, bob_files] = fetch_data(subjects=[ALICE, BOB], recording=[1])
 
 raw_train = mne.io.read_raw_edf(alice_files[0], stim_channel='Event marker',
-                                misc=['Temp rectal'])
+                                misc=['Temp rectal'], infer_types=True)
 annot_train = mne.read_annotations(alice_files[1])
 
 raw_train.set_annotations(annot_train, emit_warning=False)
@@ -158,7 +158,7 @@ print(epochs_train)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 raw_test = mne.io.read_raw_edf(bob_files[0], stim_channel='Event marker',
-                               misc=['Temp rectal'])
+                               misc=['Temp rectal'], infer_types=True)
 annot_test = mne.read_annotations(bob_files[1])
 annot_test.crop(annot_test[1]['onset'] - 30 * 60,
                 annot_test[-2]['onset'] + 30 * 60)

--- a/tutorials/clinical/60_sleep.py
+++ b/tutorials/clinical/60_sleep.py
@@ -78,7 +78,7 @@ ALICE, BOB = 0, 1
 [alice_files, bob_files] = fetch_data(subjects=[ALICE, BOB], recording=[1])
 
 raw_train = mne.io.read_raw_edf(alice_files[0], stim_channel='Event marker',
-                                misc=['Temp rectal'], infer_types=True)
+                                infer_types=True)
 annot_train = mne.read_annotations(alice_files[1])
 
 raw_train.set_annotations(annot_train, emit_warning=False)
@@ -158,7 +158,7 @@ print(epochs_train)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 raw_test = mne.io.read_raw_edf(bob_files[0], stim_channel='Event marker',
-                               misc=['Temp rectal'], infer_types=True)
+                               infer_types=True)
 annot_test = mne.read_annotations(bob_files[1])
 annot_test.crop(annot_test[1]['onset'] - 30 * 60,
                 annot_test[-2]['onset'] + 30 * 60)


### PR DESCRIPTION
#### What does this implement/fix?
In the tutorial 
[Sleep stage classification from polysomnography (PSG) data](https://mne.tools/stable/auto_tutorials/clinical/60_sleep.html),
it creates `eeg_power_band` by picking `eeg` type channels.

But in this tutorial, all channels except 'Event marker' and 'Temp rectal' are type `eeg`.

To fix this, add `infer_type=True` for `read_raw_edf`.

The tutorial data has channel type names in the channel names and then it correctly picks only "EEG Fpz-Cz" and "EEG Pz-Oz" as eeg channels.