### PR TITLE
Fix: Use `importlib.resources` or `importlib_resources` instead of `pkg_resources`

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,6 +34,7 @@ Enhancements
 
 Bugs
 ~~~~
+- Fix bug where installation of a package depending on `mne` will error when done in an environment where `setuptools` is not present (:gh:`11454` by :newcontrib: `Arne Pelzer`_)
 - Fix bug where :func:`mne.preprocessing.regress_artifact` and :class:`mne.preprocessing.EOGRegression` incorrectly tracked ``picks`` (:gh:`11366` by `Eric Larson`_)
 - Fix bug where channel names were not properly sanitized in :func:`mne.write_evokeds` and related functions (:gh:`11399` by `Eric Larson`_)
 - Fix bug where splash screen would not always disappear (:gh:`11398` by `Eric Larson`_)

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -50,6 +50,8 @@
 
 .. _Archit Singhal: https://github.com/architsinghal-mriirs
 
+.. _Arne Pelzer: https://github.com/aplzr
+
 .. _Ashley Drew: https://github.com/ashdrew
 
 .. _Asish Panda: https://github.com/kaichogami

--- a/mne/datasets/eegbci/eegbci.py
+++ b/mne/datasets/eegbci/eegbci.py
@@ -4,13 +4,17 @@
 # License: BSD Style.
 
 import os
-from os import path as op
-import pkg_resources
 import re
+from os import path as op
 from pathlib import Path
 
-from ..utils import _get_path, _do_path_update
 from ...utils import _url_to_local_path, verbose
+from ..utils import _do_path_update, _get_path
+
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 
 EEGMI_URL = 'https://physionet.org/files/eegmmidb/1.0.0/'
@@ -185,8 +189,7 @@ def load_data(subject, runs, path=None, force_update=False, update_path=None,
     )
 
     # load the checksum registry
-    registry = pkg_resources.resource_stream(
-        'mne', op.join('data', 'eegbci_checksums.txt'))
+    registry = files('mne').joinpath('data', 'eegbci_checksums.txt')
     fetcher.load_registry(registry)
 
     # fetch the file(s)

--- a/mne/datasets/eegbci/eegbci.py
+++ b/mne/datasets/eegbci/eegbci.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from ...utils import _url_to_local_path, verbose
 from ..utils import _do_path_update, _get_path
 
+# TODO: remove try/except when our min version is py 3.9
 try:
     from importlib.resources import files
 except ImportError:

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -440,7 +440,7 @@ def _resource_path(submodule, filename):
     -------
     path : str
         The full system path to the requested file.
-    """     
+    """
     return files(submodule).joinpath(filename)
 
 

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -22,6 +22,7 @@ import numpy as np
 from ..utils import _check_option, _validate_type
 from ._logging import logger, verbose, warn
 
+# TODO: remove try/except when our min version is py 3.9
 try:
     from importlib.resources import files
 except ImportError:

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -22,6 +22,11 @@ import numpy as np
 from ..utils import _check_option, _validate_type
 from ._logging import logger, verbose, warn
 
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
+
 
 def _pl(x, non_pl='', pl='s'):
     """Determine if plural should be used."""
@@ -435,13 +440,8 @@ def _resource_path(submodule, filename):
     -------
     path : str
         The full system path to the requested file.
-    """
-    try:
-        from importlib.resources import files
-        return files(submodule).joinpath(filename)
-    except ImportError:
-        from pkg_resources import resource_filename
-        return resource_filename(submodule, filename)
+    """     
+    return files(submodule).joinpath(filename)
 
 
 def repr_html(f):

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -7,3 +7,4 @@ pooch>=1.5
 decorator
 packaging
 jinja2
+importlib_resources>=5.10.2


### PR DESCRIPTION
#### Reference issue
Fixes #11448.

#### What does this implement/fix?
`mne` currently relies on `pkg_resources`, which is a part of `setuptools`, without declaring it as a dependency. This can cause issues in environments where `setuptools` is not present by default (see #11448 for an example). 

This PR updates `mne` to use `importlib.resources` for Python >= 3.9 or its backport `importlib_resources` for Python < 3.9 as recommended [here](https://setuptools.pypa.io/en/latest/pkg_resources.html). `importlib` is part of the standard library.

#### Additional information
The only `importlib` function this PR uses is `importlib.resources.files()`, which was added in Python 3.9. I added a dependency to `importlib_resources` in `requirements_base.txt` for Python versions < 3.9. Please advise if this is ok. If not I will update the PR accordingly, but it would mean that `mne` would still rely on `pkg_resources` for Python < 3.9 (meaning that `setuptools` should be declared as a dependency then).

`pkg_resources` was used in two functions, `mne/datasets/eegbci/eegbci.py:load_data()` and `mne/utils/misc.py:_resource_path()`. There are currently no unit tests that test `load_data()`, but manually calling the updated version works for Python 3.7 and 3.11 on my end. All unit tests calling the updated `_resource_path()` are passing when I run them locally in Python 3.7 and 3.11.