### PR TITLE
MAINT: Work around PyVista bug

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1757,7 +1757,7 @@ class Brain(object):
             Original clim arguments.
         %(src_volume_options)s
         colorbar_kwargs : dict | None
-            Options to pass to :meth:`pyvista.Plotter.add_scalar_bar`
+            Options to pass to ``pyvista.Plotter.add_scalar_bar``
             (e.g., ``dict(title_font_size=10)``).
         %(verbose)s
 
@@ -2417,7 +2417,7 @@ class Brain(object):
             Add a legend displaying the names of the ``labels``. Default (None)
             is ``True`` if the number of ``labels`` is 10 or fewer.
             Can also be a dict of ``kwargs`` to pass to
-            :meth:`pyvista.Plotter.add_legend`.
+            ``pyvista.Plotter.add_legend``.
 
         Notes
         -----

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ xlrd
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1
 traitlets
-pyvista>=0.32,!=0.35.2
+pyvista>=0.32,!=0.35.2,!=0.38.0,!=0.38.1
 pyvistaqt>=0.4
 mffpy>=0.5.7
 ipywidgets

--- a/tutorials/evoked/20_visualize_evoked.py
+++ b/tutorials/evoked/20_visualize_evoked.py
@@ -30,8 +30,8 @@ import mne
 # that when loading:
 
 root = mne.datasets.sample.data_path() / 'MEG' / 'sample'
-evk_file = root / 'sample_audvis-ave.fif'
-evokeds_list = mne.read_evokeds(evk_file, baseline=(None, 0), proj=True,
+evoked_file = root / 'sample_audvis-ave.fif'
+evokeds_list = mne.read_evokeds(evoked_file, baseline=(None, 0), proj=True,
                                 verbose=False)
 
 # Show condition names and baseline intervals


### PR DESCRIPTION
Hopefully works around:
```
/home/circleci/project/mne/viz/_brain/_brain.py:docstring of mne.viz._brain._brain.Brain:134: WARNING: py:meth reference target not found: pyvista.Plotter.add_scalar_bar
```
and a AttributeError related to `plotter.image` from PyVista 0.38 release.

I'm opening PRs/bug reports to PyVista. Once those are fixed, we can link back to `add_scalar_bar` properly