### PR TITLE
[ENH] Adjusted SSD algorithm to support non-full rank data

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -23,6 +23,7 @@ Current (1.4.dev0)
 
 Enhancements
 ~~~~~~~~~~~~
+- Adjusted the algorithm used in :class:`mne.decoding.SSD` to support non-full rank data (:gh:`11458` by :newcontrib:`Thomas Binns`_)
 - Add support for UCL/FIL OPM data using :func:`mne.io.read_raw_fil` (:gh:`11366` by :newcontrib:`George O'Neill` and `Robert Seymour`_)
 - Added ability to read stimulus durations from SNIRF files when using :func:`mne.io.read_raw_snirf` (:gh:`11397` by `Robert Luke`_)
 - Add :meth:`mne.Info.save` to save an :class:`mne.Info` object to a fif file (:gh:`11401` by `Alex Rockhill`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -23,7 +23,7 @@ Current (1.4.dev0)
 
 Enhancements
 ~~~~~~~~~~~~
-- Adjusted the algorithm used in :class:`mne.decoding.SSD` to support non-full rank data (:gh:`11458` by :newcontrib:`Thomas Binns`_)
+- Adjusted the algorithm used in :class:`mne.decoding.SSD` to support non-full rank data (:gh:`11458` by :newcontrib:`Thomas Binns`)
 - Add support for UCL/FIL OPM data using :func:`mne.io.read_raw_fil` (:gh:`11366` by :newcontrib:`George O'Neill` and `Robert Seymour`_)
 - Added ability to read stimulus durations from SNIRF files when using :func:`mne.io.read_raw_snirf` (:gh:`11397` by `Robert Luke`_)
 - Add :meth:`mne.Info.save` to save an :class:`mne.Info` object to a fif file (:gh:`11401` by `Alex Rockhill`_)

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -531,3 +531,5 @@
 .. _Pavel Navratil: https://github.com/navrpa13
 
 .. _Tom Ma: https://github.com/myd7349
+
+.. _Thomas Binns: https://github.com/tsbinns

--- a/mne/decoding/ssd.py
+++ b/mne/decoding/ssd.py
@@ -191,6 +191,7 @@ class SSD(BaseEstimator, TransformerMixin):
         self.eigvals_ = eigvals_[ix]
         # restores dimensionality
         self.filters_ = np.matmul(dim_red, eigvects_[:, ix])
+        self.patterns_ = np.linalg.pinv(self.filters_)
 
         # We assume that ordering by spectral ratio is more important
         # than the initial ordering. This ordering should be also learned when

--- a/mne/decoding/ssd.py
+++ b/mne/decoding/ssd.py
@@ -4,7 +4,6 @@
 # License: BSD-3-Clause
 
 import numpy as np
-from scipy import linalg
 
 from . import TransformerMixin, BaseEstimator
 from ..cov import _regularized_covariance, Covariance
@@ -163,6 +162,7 @@ class SSD(BaseEstimator, TransformerMixin):
         self : instance of SSD
             Returns the modified instance.
         """
+        from scipy import linalg
         self._check_X(X)
         X_aux = X[..., self.picks_, :]
 
@@ -308,6 +308,7 @@ class SSD(BaseEstimator, TransformerMixin):
 
 def _dimensionality_reduction(cov_signal, cov_noise, info, rank):
     """Perform dimensionality reduction on the covariance matrices."""
+    from scipy import linalg
     n_channels = cov_signal.shape[0]
     rank_signal = list(compute_rank(
         Covariance(cov_signal, info.ch_names, list(), list(), 0,

--- a/mne/decoding/ssd.py
+++ b/mne/decoding/ssd.py
@@ -1,15 +1,21 @@
 # Author: Denis A. Engemann <denis.engemann@gmail.com>
 #         Victoria Peterson <victoriapeterson09@gmail.com>
+#         Thomas S. Binns <t.s.binns@outlook.com>
 # License: BSD-3-Clause
 
 import numpy as np
+from scipy.linalg import eigh
 
-from ..filter import filter_data
-from ..cov import _regularized_covariance
 from . import TransformerMixin, BaseEstimator
-from ..time_frequency import psd_array_welch
-from ..utils import _time_mask, fill_doc, _validate_type, _check_option
+from ..cov import _regularized_covariance, Covariance
+from ..defaults import _handle_default
+from ..filter import filter_data
 from ..io.pick import _get_channel_types, _picks_to_idx
+from ..rank import compute_rank
+from ..time_frequency import psd_array_welch
+from ..utils import (
+    fill_doc, logger, _check_option, _time_mask, _validate_type,
+    _verbose_safe_false)
 
 
 @fill_doc
@@ -157,7 +163,6 @@ class SSD(BaseEstimator, TransformerMixin):
         self : instance of SSD
             Returns the modified instance.
         """
-        from scipy.linalg import eigh
         self._check_X(X)
         X_aux = X[..., self.picks_, :]
 
@@ -172,17 +177,26 @@ class SSD(BaseEstimator, TransformerMixin):
 
         cov_signal = _regularized_covariance(
             X_signal, reg=self.reg, method_params=self.cov_method_params,
-            rank=self.rank, info=self.info)
+            rank="full", info=self.info)
         cov_noise = _regularized_covariance(
             X_noise, reg=self.reg, method_params=self.cov_method_params,
-            rank=self.rank, info=self.info)
+            rank="full", info=self.info)
 
-        eigvals_, eigvects_ = eigh(cov_signal, cov_noise)
+        cov_signal_red, cov_noise_red, dim_red = (_dimensionality_reduction(
+            cov_signal, cov_noise, self.info, self.rank))
+
+        eigvals_, eigvects_ = eigh(
+            cov_signal_red, cov_noise_red)
         # sort in descending order
         ix = np.argsort(eigvals_)[::-1]
-        self.eigvals_ = eigvals_[ix]
-        self.filters_ = eigvects_[:, ix]
-        self.patterns_ = np.linalg.pinv(self.filters_)
+        self.eigvals_ = np.real(eigvals_[ix])
+        filters_ = eigvects_[:, ix]
+        # restores dimensionality
+        self.filters_ = np.matmul(dim_red, filters_)
+        self.patterns_ = np.linalg.solve(
+            np.matmul(self.filters_.T, np.matmul(cov_signal, self.filters_)).T,
+            np.matmul(cov_signal, self.filters_).T)
+
         # We assume that ordering by spectral ratio is more important
         # than the initial ordering. This ordering should be also learned when
         # fitting.
@@ -191,6 +205,7 @@ class SSD(BaseEstimator, TransformerMixin):
         if self.sort_by_spectral_ratio:
             _, sorter_spec = self.get_spectral_ratio(ssd_sources=X_ssd)
         self.sorter_spec = sorter_spec
+        logger.info("Done.")
         return self
 
     def transform(self, X):
@@ -290,3 +305,36 @@ class SSD(BaseEstimator, TransformerMixin):
         pick_patterns = self.patterns_[self.sorter_spec][:self.n_components].T
         X = pick_patterns @ X_ssd
         return X
+
+
+def _dimensionality_reduction(cov_signal, cov_noise, info, rank):
+    """Performs dimensionality reduction on the covariance matrices."""
+    n_channels = cov_signal.shape[0]
+    rank_signal = list(compute_rank(
+        Covariance(cov_signal, info.ch_names, list(), list(), 0,
+                   verbose=_verbose_safe_false()),
+        rank, _handle_default('scalings_cov_rank', None), info).values())[0]
+    rank_noise = list(compute_rank(
+        Covariance(cov_signal, info.ch_names, list(), list(), 0,
+                   verbose=_verbose_safe_false()),
+        rank, _handle_default('scalings_cov_rank', None), info).values())[0]
+    rank = np.min([rank_signal, rank_noise]) # should be identical
+
+    if rank < n_channels:
+        eigvals, eigvects = eigh(cov_signal)
+        # sort in descending order
+        ix = np.argsort(eigvals)[::-1]
+        eigvals = eigvals[ix]
+        eigvects = eigvects[:, ix]
+        # compute dimensionality reduction transformation matrix
+        dim_red = np.matmul(
+            eigvects[:, :rank], np.eye(rank) * (eigvals[:rank]**-0.5))
+        logger.info(
+            "Reducing covariance rank from %i -> %i" % (n_channels, rank,))
+    else:
+        dim_red = np.eye(n_channels)
+        logger.info("Preserving covariance rank (%i)" % (rank,))
+    
+    cov_signal_red = np.matmul(dim_red.T, np.matmul(cov_signal, dim_red))
+    cov_noise_red = np.matmul(dim_red.T, np.matmul(cov_noise, dim_red))
+    return cov_signal_red, cov_noise_red, dim_red

--- a/mne/decoding/ssd.py
+++ b/mne/decoding/ssd.py
@@ -4,7 +4,7 @@
 # License: BSD-3-Clause
 
 import numpy as np
-from scipy.linalg import eigh
+import scipy as sp
 
 from . import TransformerMixin, BaseEstimator
 from ..cov import _regularized_covariance, Covariance
@@ -185,7 +185,7 @@ class SSD(BaseEstimator, TransformerMixin):
         cov_signal_red, cov_noise_red, dim_red = (_dimensionality_reduction(
             cov_signal, cov_noise, self.info, self.rank))
 
-        eigvals_, eigvects_ = eigh(
+        eigvals_, eigvects_ = sp.linalg.eigh(
             cov_signal_red, cov_noise_red)
         # sort in descending order
         ix = np.argsort(eigvals_)[::-1]
@@ -308,7 +308,7 @@ class SSD(BaseEstimator, TransformerMixin):
 
 
 def _dimensionality_reduction(cov_signal, cov_noise, info, rank):
-    """Performs dimensionality reduction on the covariance matrices."""
+    """Perform dimensionality reduction on the covariance matrices."""
     n_channels = cov_signal.shape[0]
     rank_signal = list(compute_rank(
         Covariance(cov_signal, info.ch_names, list(), list(), 0,
@@ -318,10 +318,10 @@ def _dimensionality_reduction(cov_signal, cov_noise, info, rank):
         Covariance(cov_signal, info.ch_names, list(), list(), 0,
                    verbose=_verbose_safe_false()),
         rank, _handle_default('scalings_cov_rank', None), info).values())[0]
-    rank = np.min([rank_signal, rank_noise]) # should be identical
+    rank = np.min([rank_signal, rank_noise])  # should be identical
 
     if rank < n_channels:
-        eigvals, eigvects = eigh(cov_signal)
+        eigvals, eigvects = sp.linalg.eigh(cov_signal)
         # sort in descending order
         ix = np.argsort(eigvals)[::-1]
         eigvals = eigvals[ix]
@@ -334,7 +334,7 @@ def _dimensionality_reduction(cov_signal, cov_noise, info, rank):
     else:
         dim_red = np.eye(n_channels)
         logger.info("Preserving covariance rank (%i)" % (rank,))
-    
+
     cov_signal_red = np.matmul(dim_red.T, np.matmul(cov_signal, dim_red))
     cov_noise_red = np.matmul(dim_red.T, np.matmul(cov_noise, dim_red))
     return cov_signal_red, cov_noise_red, dim_red

--- a/mne/decoding/ssd.py
+++ b/mne/decoding/ssd.py
@@ -4,7 +4,7 @@
 # License: BSD-3-Clause
 
 import numpy as np
-import scipy as sp
+from scipy import linalg
 
 from . import TransformerMixin, BaseEstimator
 from ..cov import _regularized_covariance, Covariance
@@ -185,8 +185,7 @@ class SSD(BaseEstimator, TransformerMixin):
         cov_signal_red, cov_noise_red, dim_red = (_dimensionality_reduction(
             cov_signal, cov_noise, self.info, self.rank))
 
-        eigvals_, eigvects_ = sp.linalg.eigh(
-            cov_signal_red, cov_noise_red)
+        eigvals_, eigvects_ = linalg.eigh(cov_signal_red, cov_noise_red)
         # sort in descending order
         ix = np.argsort(eigvals_)[::-1]
         self.eigvals_ = np.real(eigvals_[ix])
@@ -321,7 +320,7 @@ def _dimensionality_reduction(cov_signal, cov_noise, info, rank):
     rank = np.min([rank_signal, rank_noise])  # should be identical
 
     if rank < n_channels:
-        eigvals, eigvects = sp.linalg.eigh(cov_signal)
+        eigvals, eigvects = linalg.eigh(cov_signal)
         # sort in descending order
         ix = np.argsort(eigvals)[::-1]
         eigvals = eigvals[ix]

--- a/mne/decoding/ssd.py
+++ b/mne/decoding/ssd.py
@@ -188,13 +188,9 @@ class SSD(BaseEstimator, TransformerMixin):
         eigvals_, eigvects_ = linalg.eigh(cov_signal_red, cov_noise_red)
         # sort in descending order
         ix = np.argsort(eigvals_)[::-1]
-        self.eigvals_ = np.real(eigvals_[ix])
-        filters_ = eigvects_[:, ix]
+        self.eigvals_ = eigvals_[ix]
         # restores dimensionality
-        self.filters_ = np.matmul(dim_red, filters_)
-        self.patterns_ = np.linalg.solve(
-            np.matmul(self.filters_.T, np.matmul(cov_signal, self.filters_)).T,
-            np.matmul(cov_signal, self.filters_).T)
+        self.filters_ = np.matmul(dim_red, eigvects_[:, ix])
 
         # We assume that ordering by spectral ratio is more important
         # than the initial ordering. This ordering should be also learned when

--- a/mne/decoding/tests/test_ssd.py
+++ b/mne/decoding/tests/test_ssd.py
@@ -336,9 +336,9 @@ def test_non_full_rank_data():
     filt_params_noise = dict(l_freq=freqs_noise[0], h_freq=freqs_noise[1],
                              l_trans_bandwidth=1, h_trans_bandwidth=1)
 
-    # Make data non full rank
+    # Make data non-full rank
     rank = 5
-    X[rank:] = X[:rank] #  (an extreme example, but a valid one)
+    X[rank:] = X[:rank]  # an extreme example, but a valid one
     assert np.linalg.matrix_rank(X) == rank
 
     ssd = SSD(info, filt_params_signal, filt_params_noise)


### PR DESCRIPTION
#### Reference issue
**Spatio-spectral decomposition (SSD) implemented in `mne.decoding.SSD` can fail to fit data that is not full rank**, even when specifying an appropriate number of components to reduce the dimensionality of the data to using the `rank` argument. This is due to the dimensionality reduction performed when computing covariance producing matrices which are not positive definite, causing the subsequent eigenvalue decomposition to fail with a `LinAlgError`:
![image](https://user-images.githubusercontent.com/56922019/217353337-9a35d2e0-b104-45db-9cfb-c27dceb2c9d9.png)
<br />

#### What does this implement/fix?
**This change adds a new private function for performing the dimensionality reduction** after the covariance matrices have been computed (`mne.decoding.ssd._dimensionality_reduction()`; called by the `fit()` method of `mne.decoding.SSD`), **which allows `SSD` to fit both full and non-full rank data**. The `rank` argument of `SSD` maintains the same behaviour as before, however it is now used in `_dimensionality_reduction()` rather than passed when computing covariance.

The updated algorithm is based on that implemented and used by the original authors of the method (see e.g. https://github.com/svendaehne/matlab_SSD/blob/master/ssd.m), and compared to the current algorithm, the updated approach is more similar to that employed in the literature for related dimensionality reduction and reconstruction problems (see e.g. [Ewald _et al._, 2012, NeuroImage](https://doi.org/10.1016/j.neuroimage.2011.11.084)).

Alongside the updated algorithm, a new test (`test_non_full_rank_data()`) has been added to the test suite (`mne.decoding.tests.test_ssd`) which checks that the new approach does in fact work for non-full rank data (the existing tests already show the approach continues to work for full rank data).
<br />

#### Additional information
**No changes to the API or documentation have been made**, and the ultimate function of `SSD` to enhance the contrast between a set of 'signal' and 'noise' frequencies has been preserved; the only change is that the updated algorithm is generalisable to wider forms of data. In line with the lack of change to the API, **when using `SSD` with full rank data or `rank="full"`, the results will be identical as the current algorithm's**.

The argument could be made that this is an unecessary change, as the end user could instead first perform their own dimensionality reduction on non-full rank data and then fit SSD to this data, however: **1) this adds an additional burden to the end user**; and **2) this would require end users interested in the spatial topographies of the SSD components (`SSD.patterns_`) to transform the patterns themselves from the dimensionality-reduced space, to their original channel space**. Ultimately, those users less familiar with such methods may be disuaded from using this SSD implementation, and may feel forced to rely on e.g. [the MATLAB implementation](https://github.com/svendaehne/matlab_SSD/blob/master/ssd.m).

This issue is not unique to non-full rank data (e.g. the same problem can arise when full rank data is used but a rank less than the true rank of the data is specified, such as EEG data with rank 30 and `rank={'eeg':25}`, raising the same `LinAlgError`), however this is less of an issue, as SSD can be computed on the full rank data and then the desired number of components taken. On the other hand, for non-full rank data, there is no possibility of using `SSD` without prior manipulations of the data.
<br />

I am of course happy to discuss the suggested changes further!
Thomas