### PR TITLE
[MRG] Forward argument axes from plot_sensors to DigMontage.plot

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -24,6 +24,7 @@ Current (1.4.dev0)
 Enhancements
 ~~~~~~~~~~~~
 - Add support for UCL/FIL OPM data using :func:`mne.io.read_raw_fil` (:gh:`11366` by :newcontrib:`George O'Neill` and `Robert Seymour`_)
+- Forward argument ``axes`` from `mne.viz.plot_sensors` to `mne.channels.DigMontage.plot` (:gh:`11470` by :newcontrib:`Jan Ebert` and `Mathieu Scheltienne`_)
 - Added ability to read stimulus durations from SNIRF files when using :func:`mne.io.read_raw_snirf` (:gh:`11397` by `Robert Luke`_)
 - Add :meth:`mne.Info.save` to save an :class:`mne.Info` object to a fif file (:gh:`11401` by `Alex Rockhill`_)
 - Improved error message when downloads are corrupted for :func:`mne.datasets.sample.data_path` and related functions (:gh:`11407` by `Eric Larson`_)
@@ -32,7 +33,6 @@ Enhancements
 - Add :func:`mne.count_events` to count unique event types in a given event array (:gh:`11430` by `Clemens Brunner`_)
 - Add a video to :ref:`tut-freesurfer-mne` of a brain inflating from the pial surface to aid in understanding the inflated brain (:gh:`11440` by `Alex Rockhill`_)
 - Add automatic projection of sEEG contact onto the inflated surface for :meth:`mne.viz.Brain.add_sensors` (:gh:`11436` by `Alex Rockhill`_)
-- Forward argument ``axes`` from `mne.viz.plot_sensors` to `mne.channels.DigMontage.plot` (:gh:`11470` by `Mathieu Scheltienne`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -32,6 +32,7 @@ Enhancements
 - Add :func:`mne.count_events` to count unique event types in a given event array (:gh:`11430` by `Clemens Brunner`_)
 - Add a video to :ref:`tut-freesurfer-mne` of a brain inflating from the pial surface to aid in understanding the inflated brain (:gh:`11440` by `Alex Rockhill`_)
 - Add automatic projection of sEEG contact onto the inflated surface for :meth:`mne.viz.Brain.add_sensors` (:gh:`11436` by `Alex Rockhill`_)
+- Forward argument ``axes`` from `mne.viz.plot_sensors` to `mne.channels.DigMontage.plot` (:gh:`11470` by `Mathieu Scheltienne`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -35,7 +35,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Fix bug where installation of a package depending on `mne` will error when done in an environment where `setuptools` is not present (:gh:`11454` by :newcontrib: `Arne Pelzer`_)
+- Fix bug where installation of a package depending on ``mne`` will error when done in an environment where ``setuptools`` is not present (:gh:`11454` by :newcontrib: `Arne Pelzer`_)
 - Fix bug where :func:`mne.preprocessing.regress_artifact` and :class:`mne.preprocessing.EOGRegression` incorrectly tracked ``picks`` (:gh:`11366` by `Eric Larson`_)
 - Fix bug where channel names were not properly sanitized in :func:`mne.write_evokeds` and related functions (:gh:`11399` by `Eric Larson`_)
 - Fix bug where splash screen would not always disappear (:gh:`11398` by `Eric Larson`_)

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -116,6 +116,8 @@
 
 .. _Denis Engemann: http://denis-engemann.de
 
+.. _Dinara Issagaliyeva: https://github.com/dissagaliyeva
+
 .. _Dirk Gütlin: https://github.com/DiGyt
 
 .. _Dmitrii Altukhov: https://github.com/dmalt
@@ -178,6 +180,8 @@
 
 .. _Hamid Maymandi: https://github.com/HamidMandi
 
+.. _Hakimeh Pourakbari: https://github.com/Hpakbari
+
 .. _Hari Bharadwaj: http://www.haribharadwaj.com
 
 .. _Henrich Kolkhorst: https://github.com/hekolk
@@ -198,6 +202,8 @@
 
 .. _Jair Montoya Martinez: https://github.com/jmontoyam
 
+.. _Jan Ebert: https://www.jan-ebert.com/
+
 .. _Jan Sedivy: https://github.com/honzaseda
 
 .. _Jan Sosulski: https://jan-sosulski.de
@@ -211,6 +217,8 @@
 .. _Jean-Remi King: https://github.com/kingjr
 
 .. _Jeff Stout: https://megcore.nih.gov/index.php/Staff
+
+.. _Jennifer Behnke: https://github.com/JKBehnke
 
 .. _Jeroen Van Der Donckt: https://github.com/jvdd
 
@@ -376,6 +384,8 @@
 
 .. _Paul Roujansky: https://github.com/paulroujansky
 
+.. _Pavel Navratil: https://github.com/navrpa13
+
 .. _Peter Molfese: https://github.com/pmolfese
 
 .. _Phillip Alday: https://palday.bitbucket.io
@@ -498,6 +508,8 @@
 
 .. _Tod Flak: https://github.com/todflak
 
+.. _Tom Ma: https://github.com/myd7349
+
 .. _Tommy Clausner: https://github.com/TommyClausner
 
 .. _Toomas Erik Anijärv: http://www.toomaserikanijarv.com/
@@ -521,13 +533,3 @@
 .. _Yu-Han Luo: https://github.com/yh-luo
 
 .. _Zhi Zhang: https://github.com/tczhangzhi/
-
-.. _Dinara Issagaliyeva: https://github.com/dissagaliyeva
-
-.. _Jennifer Behnke: https://github.com/JKBehnke
-
-.. _Hakimeh Pourakbari: https://github.com/Hpakbari
-
-.. _Pavel Navratil: https://github.com/navrpa13
-
-.. _Tom Ma: https://github.com/myd7349

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -328,10 +328,10 @@ class DigMontage(object):
 
     @copy_function_doc_to_method_doc(plot_montage)
     def plot(self, scale_factor=20, show_names=True, kind='topomap', show=True,
-             sphere=None, verbose=None):
+             sphere=None, axes=None, *, verbose=None):
         return plot_montage(self, scale_factor=scale_factor,
                             show_names=show_names, kind=kind, show=show,
-                            sphere=sphere)
+                            sphere=sphere, axes=axes)
 
     @fill_doc
     def rename_channels(self, mapping, allow_duplicates=False):

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1648,6 +1648,13 @@ def test_plot_montage():
     montage.plot(axes=ax)
     plt.close("all")
 
+    with pytest.raises(TypeError, match="must be an instance of Axes"):
+        montage.plot(axes=101)
+    with pytest.raises(TypeError, match="when 'kind' is '3d'"):
+        montage.plot(axes=ax, kind="3d")
+    with pytest.raises(TypeError, match="when 'kind' is '3d'"):
+        montage.plot(axes=101, kind="3d")
+
 
 def test_montage_equality():
     """Test montage equality."""

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -1644,6 +1644,10 @@ def test_plot_montage():
     montage.plot()
     plt.close('all')
 
+    f, ax = plt.subplots(1, 1)
+    montage.plot(axes=ax)
+    plt.close("all")
+
 
 def test_montage_equality():
     """Test montage equality."""

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -280,6 +280,10 @@ docdict['axes_cov_plot_topomap'] = _axes_list.format('axes', 'be length 1')
 docdict['axes_evoked_plot_topomap'] = _axes_list.format(
     'axes',
     'match the number of ``times`` provided (unless ``times`` is ``None``)')
+docdict['axes_montage'] = """
+axes : instance of Axes | instance of Axes3D | None
+    Axes to draw the sensors to. If ``kind='3d'``, axes must be an instance
+    of Axes3D. If None (default), a new axes will be created."""
 docdict['axes_plot_projs_topomap'] = _axes_list.format(
     'axes', 'match the number of projectors')
 docdict['axes_plot_topomap'] = _axes_base.format('axes', '', '', '')

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -29,11 +29,6 @@ def plot_montage(montage, scale_factor=20, show_names=True, kind='topomap',
 
         .. versionadded:: 1.4
     %(verbose)s
-    axes : instance of Axes | instance of Axes3D | None
-        Axes to draw the sensors to. If ``kind='3d'``, axes must be an instance
-        of Axes3D. If None (default), a new axes will be created.
-
-        .. versionadded:: 1.4.0
 
     Returns
     -------

--- a/mne/viz/montage.py
+++ b/mne/viz/montage.py
@@ -8,7 +8,7 @@ from ..io._digitization import _get_fid_coords
 
 @verbose
 def plot_montage(montage, scale_factor=20, show_names=True, kind='topomap',
-                 show=True, sphere=None, verbose=None):
+                 show=True, sphere=None, axes=None, *, verbose=None):
     """Plot a montage.
 
     Parameters
@@ -25,6 +25,9 @@ def plot_montage(montage, scale_factor=20, show_names=True, kind='topomap',
     show : bool
         Show figure if True.
     %(sphere_topomap_auto)s
+    %(axes_montage)s
+
+        .. versionadded:: 1.4
     %(verbose)s
 
     Returns
@@ -69,7 +72,7 @@ def plot_montage(montage, scale_factor=20, show_names=True, kind='topomap',
     info = create_info(ch_names, sfreq=256, ch_types="eeg")
     info.set_montage(montage, on_missing='ignore')
     fig = plot_sensors(info, kind=kind, show_names=show_names, show=show,
-                       title=title, sphere=sphere)
+                       title=title, sphere=sphere, axes=axes)
     collection = fig.axes[0].collections[0]
     collection.set_sizes([scale_factor])
     return fig

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -981,22 +981,21 @@ def plot_sensors(info, kind='topomap', ch_type=None, title=None,
         from matplotlib.axes import Axes
         from mpl_toolkits.mplot3d.axes3d import Axes3D
 
-        if kind == "3d" and not isinstance(axes, Axes3D):
-            raise TypeError(
-                "Argument 'axes' must be an Axes3D if 'kind' is '3d'."
+        if kind == "3d":
+            _validate_type(axes, Axes3D, "axes", extra="when 'kind' is '3d'")
+        elif kind in ("topomap", "select"):
+            _validate_type(
+                axes,
+                Axes,
+                "axes",
+                extra="when 'kind' is 'topomap' or 'select'"
             )
-        elif kind in ("topomap", "select") and not isinstance(axes, Axes):
-            raise TypeError(
-                "Argument 'axes' must be an Axes if 'kind' is 'topomap'."
-            )
-        elif kind in ("topomap", "select") and isinstance(axes, Axes3D):
-            raise TypeError(
-                "Argument 'axes' must be an Axes if 'kind' is 'topomap'. An "
-                "Axes3D must be provided if 'kind' is '3d'."
-            )
-
-    if not isinstance(info, Info):
-        raise TypeError(f'info must be an instance of Info not {type(info)}')
+            if isinstance(axes, Axes3D):
+                raise TypeError(
+                    "axes must be an instance of Axes when 'kind' is "
+                    f"'topomap' or 'select', got {type(axes)} instead."
+                )
+    _validate_type(info, Info, "info")
     ch_indices = channel_indices_by_type(info)
     allowed_types = _DATA_CH_TYPES_SPLIT
     if ch_type is None:

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -908,16 +908,17 @@ def plot_sensors(info, kind='topomap', ch_type=None, title=None,
     %(info_not_none)s
     kind : str
         Whether to plot the sensors as 3d, topomap or as an interactive
-        sensor selection dialog. Available options 'topomap', '3d', 'select'.
-        If 'select', a set of channels can be selected interactively by using
-        lasso selector or clicking while holding control key. The selected
-        channels are returned along with the figure instance. Defaults to
-        'topomap'.
+        sensor selection dialog. Available options ``'topomap'``, ``'3d'``,
+        ``'select'``. If ``'select'``, a set of channels can be selected
+        interactively by using lasso selector or clicking while holding control
+        key. The selected channels are returned along with the figure instance.
+        Defaults to ``'topomap'``.
     ch_type : None | str
-        The channel type to plot. Available options 'mag', 'grad', 'eeg',
-        'seeg', 'dbs', 'ecog', 'all'. If ``'all'``, all the available mag,
-        grad, eeg, seeg, dbs and ecog channels are plotted. If None (default),
-        then channels are chosen in the order given above.
+        The channel type to plot. Available options ``'mag'``, ``'grad'``,
+        ``'eeg'``, ``'seeg'``, ``'dbs'``, ``'ecog'``, ``'all'``. If ``'all'``,
+        all the available mag, grad, eeg, seeg, dbs and ecog channels are
+        plotted. If None (default), then channels are chosen in the order given
+        above.
     title : str | None
         Title for the figure. If None (default), equals to
         ``'Sensor positions (%%s)' %% ch_type``.
@@ -934,7 +935,7 @@ def plot_sensors(info, kind='topomap', ch_type=None, title=None,
     to_sphere : bool
         Whether to project the 3d locations to a sphere. When False, the
         sensor array appears similar as to looking downwards straight above the
-        subject's head. Has no effect when kind='3d'. Defaults to True.
+        subject's head. Has no effect when ``kind='3d'``. Defaults to True.
 
         .. versionadded:: 0.14.0
     %(axes_montage)s
@@ -949,10 +950,10 @@ def plot_sensors(info, kind='topomap', ch_type=None, title=None,
         Show figure if True. Defaults to True.
     %(sphere_topomap_auto)s
     pointsize : float | None
-        The size of the points. If None (default), will bet set to 75 if
-        ``kind='3d'``, or 25 otherwise.
+        The size of the points. If None (default), will bet set to ``75`` if
+        ``kind='3d'``, or ``25`` otherwise.
     linewidth : float
-        The width of the outline. If 0, the outline will not be drawn.
+        The width of the outline. If ``0``, the outline will not be drawn.
     %(verbose)s
 
     Returns

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -977,6 +977,24 @@ def plot_sensors(info, kind='topomap', ch_type=None, title=None,
     """
     from .evoked import _rgb
     _check_option('kind', kind, ['topomap', '3d', 'select'])
+    if axes is not None:
+        from matplotlib.axes import Axes
+        from mpl_toolkits.mplot3d.axes3d import Axes3D
+
+        if kind == "3d" and not isinstance(axes, Axes3D):
+            raise TypeError(
+                "Argument 'axes' must be an Axes3D if 'kind' is '3d'."
+            )
+        elif kind in ("topomap", "select") and not isinstance(axes, Axes):
+            raise TypeError(
+                "Argument 'axes' must be an Axes if 'kind' is 'topomap'."
+            )
+        elif kind in ("topomap", "select") and isinstance(axes, Axes3D):
+            raise TypeError(
+                "Argument 'axes' must be an Axes if 'kind' is 'topomap'. An "
+                "Axes3D must be provided if 'kind' is '3d'."
+            )
+
     if not isinstance(info, Info):
         raise TypeError(f'info must be an instance of Info not {type(info)}')
     ch_indices = channel_indices_by_type(info)

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -937,9 +937,7 @@ def plot_sensors(info, kind='topomap', ch_type=None, title=None,
         subject's head. Has no effect when kind='3d'. Defaults to True.
 
         .. versionadded:: 0.14.0
-    axes : instance of Axes | instance of Axes3D | None
-        Axes to draw the sensors to. If ``kind='3d'``, axes must be an instance
-        of Axes3D. If None (default), a new axes will be created.
+    %(axes_montage)s
 
         .. versionadded:: 0.13.0
     block : bool


### PR DESCRIPTION
This PR enables:

```
montage = ...  # DigMontage
f, ax = plt.subplots(1, 1)
montage.plot(axes=ax)
```

I noticed it was missing when I tried to plot 3 montages on the same figure. One more step towards a unified plotting API :smiley: 

Closes #11404