### PR TITLE
MAINT: Use mamba in CIs

### DIFF
--- a/.github/workflows/compat_minimal.yml
+++ b/.github/workflows/compat_minimal.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           channels: conda-forge
+          channel-priority: strict
           mamba-version: "*"
           use-mamba: true
       - shell: bash -el {0}

--- a/.github/workflows/compat_minimal.yml
+++ b/.github/workflows/compat_minimal.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          channels: conda-forge
           mamba-version: "*"
           use-mamba: true
         name: 'Setup conda'

--- a/.github/workflows/compat_minimal.yml
+++ b/.github/workflows/compat_minimal.yml
@@ -38,9 +38,8 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          channels: conda-forge
-          channel-priority: true
-          mamba-version: "*"
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
           use-mamba: true
       - shell: bash -el {0}
         run: |

--- a/.github/workflows/compat_minimal.yml
+++ b/.github/workflows/compat_minimal.yml
@@ -38,6 +38,8 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          mamba-version: "*"
+          use-mamba: true
         name: 'Setup conda'
       - shell: bash -el {0}
         run: |

--- a/.github/workflows/compat_minimal.yml
+++ b/.github/workflows/compat_minimal.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           channels: conda-forge
-          channel-priority: strict
+          channel-priority: true
           mamba-version: "*"
           use-mamba: true
       - shell: bash -el {0}

--- a/.github/workflows/compat_minimal.yml
+++ b/.github/workflows/compat_minimal.yml
@@ -41,7 +41,6 @@ jobs:
           channels: conda-forge
           mamba-version: "*"
           use-mamba: true
-        name: 'Setup conda'
       - shell: bash -el {0}
         run: |
           ./tools/github_actions_dependencies.sh

--- a/.github/workflows/compat_old.yml
+++ b/.github/workflows/compat_old.yml
@@ -35,7 +35,6 @@ jobs:
           channels: conda-forge
           mamba-version: "*"
           use-mamba: true
-        name: 'Setup conda'
       - shell: bash -el {0}
         run: |
           ./tools/github_actions_dependencies.sh

--- a/.github/workflows/compat_old.yml
+++ b/.github/workflows/compat_old.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           channels: conda-forge
+          channel-priority: strict
           mamba-version: "*"
           use-mamba: true
       - shell: bash -el {0}

--- a/.github/workflows/compat_old.yml
+++ b/.github/workflows/compat_old.yml
@@ -32,9 +32,8 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          channels: conda-forge
-          channel-priority: true
-          mamba-version: "*"
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
           use-mamba: true
       - shell: bash -el {0}
         run: |

--- a/.github/workflows/compat_old.yml
+++ b/.github/workflows/compat_old.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          mamba-version: "*"
+          use-mamba: true
         name: 'Setup conda'
       - shell: bash -el {0}
         run: |

--- a/.github/workflows/compat_old.yml
+++ b/.github/workflows/compat_old.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           channels: conda-forge
-          channel-priority: strict
+          channel-priority: true
           mamba-version: "*"
           use-mamba: true
       - shell: bash -el {0}

--- a/.github/workflows/compat_old.yml
+++ b/.github/workflows/compat_old.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          channels: conda-forge
           mamba-version: "*"
           use-mamba: true
         name: 'Setup conda'

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -81,7 +81,7 @@ jobs:
         shell: bash
     env:
       CONDA_ENV: 'environment.yml'
-      PYTHON_VERSION: '3.10'
+      PYTHON_VERSION: '3.11'
     steps:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -37,7 +37,6 @@ jobs:
           # channels: conda-forge
           # mamba-version: "*"
           # use-mamba: true
-        name: 'Setup conda'
       - shell: bash -el {0}
         run: |
           ./tools/github_actions_dependencies.sh
@@ -96,7 +95,6 @@ jobs:
           channels: conda-forge
           mamba-version: "*"
           use-mamba: true
-        name: 'Setup conda'
       - shell: bash -el {0}
         run: |
           conda install -c conda-forge "vtk>=9.2=*osmesa*"

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -34,6 +34,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           environment-file: ${{ env.CONDA_ENV }}
           # No mamba for this one job (use conda)
+          # channels: conda-forge
           # mamba-version: "*"
           # use-mamba: true
         name: 'Setup conda'
@@ -92,6 +93,7 @@ jobs:
           activate-environment: 'mne'
           python-version: ${{ env.PYTHON_VERSION }}
           environment-file: ${{ env.CONDA_ENV }}
+          channels: conda-forge
           mamba-version: "*"
           use-mamba: true
         name: 'Setup conda'

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -33,10 +33,7 @@ jobs:
           activate-environment: 'mne'
           python-version: ${{ env.PYTHON_VERSION }}
           environment-file: ${{ env.CONDA_ENV }}
-          # No mamba for this one job (use conda)
-          # channels: conda-forge
-          # mamba-version: "*"
-          # use-mamba: true
+          # No mamba for this one job (use conda itself!)
       - shell: bash -el {0}
         run: |
           ./tools/github_actions_dependencies.sh
@@ -93,6 +90,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           environment-file: ${{ env.CONDA_ENV }}
           channels: conda-forge
+          channel-priority: strict
           mamba-version: "*"
           use-mamba: true
       - shell: bash -el {0}

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -90,7 +90,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           environment-file: ${{ env.CONDA_ENV }}
           channels: conda-forge
-          channel-priority: strict
+          channel-priority: true
           mamba-version: "*"
           use-mamba: true
       - shell: bash -el {0}

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -81,7 +81,7 @@ jobs:
         shell: bash
     env:
       CONDA_ENV: 'environment.yml'
-      PYTHON_VERSION: '3.11'
+      PYTHON_VERSION: '3.10'
     steps:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
@@ -89,9 +89,8 @@ jobs:
           activate-environment: 'mne'
           python-version: ${{ env.PYTHON_VERSION }}
           environment-file: ${{ env.CONDA_ENV }}
-          channels: conda-forge
-          channel-priority: true
-          mamba-version: "*"
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
           use-mamba: true
       - shell: bash -el {0}
         run: |

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -33,6 +33,9 @@ jobs:
           activate-environment: 'mne'
           python-version: ${{ env.PYTHON_VERSION }}
           environment-file: ${{ env.CONDA_ENV }}
+          # No mamba for this one job (use conda)
+          # mamba-version: "*"
+          # use-mamba: true
         name: 'Setup conda'
       - shell: bash -el {0}
         run: |
@@ -89,6 +92,8 @@ jobs:
           activate-environment: 'mne'
           python-version: ${{ env.PYTHON_VERSION }}
           environment-file: ${{ env.CONDA_ENV }}
+          mamba-version: "*"
+          use-mamba: true
         name: 'Setup conda'
       - shell: bash -el {0}
         run: |

--- a/.github/workflows/macos_conda.yml
+++ b/.github/workflows/macos_conda.yml
@@ -35,7 +35,6 @@ jobs:
           channels: conda-forge
           mamba-version: "*"
           use-mamba: true
-        name: 'Setup conda'
       - shell: bash -el {0}
         run: |
           ./tools/github_actions_dependencies.sh

--- a/.github/workflows/macos_conda.yml
+++ b/.github/workflows/macos_conda.yml
@@ -32,9 +32,8 @@ jobs:
           activate-environment: 'mne'
           python-version: ${{ env.PYTHON_VERSION }}
           environment-file: ${{ env.CONDA_ENV }}
-          channels: conda-forge
-          channel-priority: true
-          mamba-version: "*"
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
           use-mamba: true
       - shell: bash -el {0}
         run: |

--- a/.github/workflows/macos_conda.yml
+++ b/.github/workflows/macos_conda.yml
@@ -32,6 +32,7 @@ jobs:
           activate-environment: 'mne'
           python-version: ${{ env.PYTHON_VERSION }}
           environment-file: ${{ env.CONDA_ENV }}
+          channels: conda-forge
           mamba-version: "*"
           use-mamba: true
         name: 'Setup conda'

--- a/.github/workflows/macos_conda.yml
+++ b/.github/workflows/macos_conda.yml
@@ -33,6 +33,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           environment-file: ${{ env.CONDA_ENV }}
           channels: conda-forge
+          channel-priority: strict
           mamba-version: "*"
           use-mamba: true
       - shell: bash -el {0}

--- a/.github/workflows/macos_conda.yml
+++ b/.github/workflows/macos_conda.yml
@@ -32,6 +32,8 @@ jobs:
           activate-environment: 'mne'
           python-version: ${{ env.PYTHON_VERSION }}
           environment-file: ${{ env.CONDA_ENV }}
+          mamba-version: "*"
+          use-mamba: true
         name: 'Setup conda'
       - shell: bash -el {0}
         run: |

--- a/.github/workflows/macos_conda.yml
+++ b/.github/workflows/macos_conda.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           environment-file: ${{ env.CONDA_ENV }}
           channels: conda-forge
-          channel-priority: strict
+          channel-priority: true
           mamba-version: "*"
           use-mamba: true
       - shell: bash -el {0}

--- a/environment.yml
+++ b/environment.yml
@@ -55,4 +55,3 @@ dependencies:
 - eeglabio
 - edflib-python
 - pybv
-- mamba

--- a/environment.yml
+++ b/environment.yml
@@ -55,3 +55,4 @@ dependencies:
 - eeglabio
 - edflib-python
 - pybv
+- mamba

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -5,7 +5,7 @@ EXTRA_ARGS=""
 if [ ! -z "$CONDA_ENV" ]; then
 	pip uninstall -yq mne
 elif [ ! -z "$CONDA_DEPENDENCIES" ]; then
-	conda install -y $CONDA_DEPENDENCIES
+	mamba install -y $CONDA_DEPENDENCIES
 else
 	# Changes here should also go in the interactive_test CircleCI job
 	python -m pip install $STD_ARGS pip setuptools wheel


### PR DESCRIPTION
~~One way to move toward being able to recommend mamba is by including it in `environment.yml`, so I added it here.~~ I made our solvers use `mamba` by including it in the `setup-miniconda` action [according to the instructions here](https://github.com/marketplace/actions/setup-miniconda#example-6-mamba). Note that they even say it's experimental, and I'm assuming that's because `mamba` is moreso than the action itself:

> Example 6: Mamba
> Experimental! Use mamba to handle conda installs in a faster way. mamba-version accepts a version string x.y (including "*"). It requires you specify conda-forge as part of the channels, ideally with the highest priority.

FWIW @drammock Azure was already using `mamba env update` on Windows, IIRC to speed up the solve time.