### PR TITLE
[MRG] Improve error message raised on channels missing from DigMontage

### DIFF
--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -1191,9 +1191,9 @@ def _set_montage(info, montage, match_case=True, match_alias=False,
             f"DigMontage. The channel{pl} missing from the montage {are_is}:"
             f"\n\n{missing_names}.\n\nConsider using inst.rename_channels to "
             "match the montage nomenclature, or inst.set_channel_types if "
-            f"{'these' if pl else 'this'} {are_is} not {'' if pl else 'an '}EEG channel{pl}, or use "
-            f"the on_missing parameter if the channel position{pl} {are_is} "
-            "allowed to be unknown in your analyses."
+            f"{'these' if pl else 'this'} {are_is} not {'' if pl else 'an '}"
+            f"EEG channel{pl}, or use the on_missing parameter if the channel "
+            f"position{pl} {are_is} allowed to be unknown in your analyses."
         )
         _on_missing(on_missing, missing_coord_msg)
 

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -1191,7 +1191,7 @@ def _set_montage(info, montage, match_case=True, match_alias=False,
             f"DigMontage. The channel{pl} missing from the montage {are_is}:"
             f"\n\n{missing_names}.\n\nConsider using inst.rename_channels to "
             "match the montage nomenclature, or inst.set_channel_types if "
-            f"these {are_is} not {'' if pl else 'an '}EEG channel{pl}, or use "
+            f"{'these' if pl else 'this'} {are_is} not {'' if pl else 'an '}EEG channel{pl}, or use "
             f"the on_missing parameter if the channel position{pl} {are_is} "
             "allowed to be unknown in your analyses."
         )

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -1183,14 +1183,17 @@ def _set_montage(info, montage, match_case=True, match_alias=False,
     missing = np.where([use not in ch_pos for use in info_names_use])[0]
     if len(missing):  # DigMontage is subset of info
         missing_names = [info_names[ii] for ii in missing]
+        pl = _pl(missing)
+        are_is = "are" if pl else "is"
         missing_coord_msg = (
-            'DigMontage is only a subset of info. There are '
-            f'{len(missing)} channel position{_pl(missing)} '
-            'not present in the DigMontage. The required channels are:\n\n'
-            f'{missing_names}.\n\nConsider using inst.set_channel_types '
-            'if these are not EEG channels, or use the on_missing '
-            'parameter if the channel positions are allowed to be unknown '
-            'in your analyses.'
+            f"DigMontage is only a subset of info. There {are_is} "
+            f"{len(missing)} channel position{pl} not present in the "
+            f"DigMontage. The channel{pl} missing from the montage {are_is}:"
+            f"\n\n{missing_names}.\n\nConsider using inst.rename_channels to "
+            "match the montage nomenclature, or inst.set_channel_types if "
+            f"these {are_is} not {'' if pl else 'an '}EEG channel{pl}, or use "
+            f"the on_missing parameter if the channel position{pl} {are_is} "
+            "allowed to be unknown in your analyses."
         )
         _on_missing(on_missing, missing_coord_msg)
 


### PR DESCRIPTION
Closes #8830

Improves the unclear error message raised by:

```
from mne import create_info


info = create_info(["Fpz", "EEG2", "EEG1"], 1000, "eeg")
info.set_montage("standard_1020")
```

The main change is `channel missing from the montage [...] Consider using inst.rename_channels to match the montage nomenclature`.
