### PR TITLE
Updating documentation to clarify full vs half-bandwidth and defaults in time_frequency.multitaper.py

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -39,6 +39,7 @@ Enhancements
 
 Bugs
 ~~~~
+- Fix :func:`mne.time_frequency.psd_multitaper` docstring where argument ``bandwidth`` incorrectly reported argument as half-bandwidth and gave wrong explanation of default value (:gh:`11479` by :newcontrib: `Tom Stone`_)
 - Fix bug where installation of a package depending on ``mne`` will error when done in an environment where ``setuptools`` is not present (:gh:`11454` by :newcontrib: `Arne Pelzer`_)
 - Fix bug where :func:`mne.preprocessing.regress_artifact` and :class:`mne.preprocessing.EOGRegression` incorrectly tracked ``picks`` (:gh:`11366` by `Eric Larson`_)
 - Fix bug where channel names were not properly sanitized in :func:`mne.write_evokeds` and related functions (:gh:`11399` by `Eric Larson`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -39,7 +39,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Fix :func:`mne.time_frequency.psd_multitaper` docstring where argument ``bandwidth`` incorrectly reported argument as half-bandwidth and gave wrong explanation of default value (:gh:`11479` by :newcontrib: `Tom Stone`_)
+- Fix :func:`mne.time_frequency.psd_array_multitaper` docstring where argument ``bandwidth`` incorrectly reported argument as half-bandwidth and gave wrong explanation of default value (:gh:`11479` by :newcontrib: `Tom Stone`_)
 - Fix bug where installation of a package depending on ``mne`` will error when done in an environment where ``setuptools`` is not present (:gh:`11454` by :newcontrib: `Arne Pelzer`_)
 - Fix bug where :func:`mne.preprocessing.regress_artifact` and :class:`mne.preprocessing.EOGRegression` incorrectly tracked ``picks`` (:gh:`11366` by `Eric Larson`_)
 - Fix bug where channel names were not properly sanitized in :func:`mne.write_evokeds` and related functions (:gh:`11399` by `Eric Larson`_)

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -516,6 +516,8 @@
 
 .. _Tom Ma: https://github.com/myd7349
 
+.. _Tom Stone: https://github.com/tomdstone
+
 .. _Tommy Clausner: https://github.com/TommyClausner
 
 .. _Toomas Erik Anijärv: http://www.toomaserikanijarv.com/

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -332,8 +332,8 @@ def psd_array_multitaper(x, sfreq, fmin=0.0, fmax=np.inf, bandwidth=None,
     %(fmin_fmax_psd)s
     bandwidth : float
         Frequency bandwidth of the multi-taper window function in Hz. For a
-        given frequency, frequencies at ± bandwidth/2 are smoothed together.
-        The default value is a bandwidth of 8 * (sfreq / n_times).
+        given frequency, frequencies at ``± bandwidth / 2`` are smoothed together.
+        The default value is a bandwidth of ``8 * (sfreq / n_times)``.
     adaptive : bool
         Use adaptive weights to combine the tapered spectra into PSD
         (slow, use n_jobs >> 1 to speed up computation).

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -331,9 +331,9 @@ def psd_array_multitaper(x, sfreq, fmin=0.0, fmax=np.inf, bandwidth=None,
         The sampling frequency.
     %(fmin_fmax_psd)s
     bandwidth : float
-        Half-bandwidth of the multi-taper window function in Hz. For a given
-        frequency, frequencies at ± half-bandwidth are smoothed together.
-        The default value is a half-bandwidth of 4.
+        Frequency bandwidth of the multi-taper window function in Hz. For a
+        given frequency, frequencies at ± bandwidth/2 are smoothed together.
+        The default value is a bandwidth of 8 * (sfreq / n_times).
     adaptive : bool
         Use adaptive weights to combine the tapered spectra into PSD
         (slow, use n_jobs >> 1 to speed up computation).

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -294,7 +294,7 @@ def _compute_mt_params(n_times, sfreq, bandwidth, low_bias, adaptive,
         half_nbw = 4.
     if half_nbw < 0.5:
         raise ValueError(
-            'bandwidth value %s yields a normalized bandwidth of %s < 0.5, '
+            'bandwidth value %s yields a normalized half-bandwidth of %s < 0.5, '
             'use a value of at least %s'
             % (bandwidth, half_nbw, sfreq / n_times))
 

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -294,8 +294,8 @@ def _compute_mt_params(n_times, sfreq, bandwidth, low_bias, adaptive,
         half_nbw = 4.
     if half_nbw < 0.5:
         raise ValueError(
-            'bandwidth value %s yields a normalized half-bandwidth of %s < 0.5, '
-            'use a value of at least %s'
+            'bandwidth value %s yields a normalized half-bandwidth of '
+            '%s < 0.5, use a value of at least %s'
             % (bandwidth, half_nbw, sfreq / n_times))
 
     # Compute DPSS windows
@@ -332,8 +332,9 @@ def psd_array_multitaper(x, sfreq, fmin=0.0, fmax=np.inf, bandwidth=None,
     %(fmin_fmax_psd)s
     bandwidth : float
         Frequency bandwidth of the multi-taper window function in Hz. For a
-        given frequency, frequencies at ``± bandwidth / 2`` are smoothed together.
-        The default value is a bandwidth of ``8 * (sfreq / n_times)``.
+        given frequency, frequencies at ``± bandwidth / 2`` are smoothed
+        together. The default value is a bandwidth of
+        ``8 * (sfreq / n_times)``.
     adaptive : bool
         Use adaptive weights to combine the tapered spectra into PSD
         (slow, use n_jobs >> 1 to speed up computation).


### PR DESCRIPTION
#### Reference issue
Fixes #11324

#### What does this implement/fix?
Several folks noticed that the default bandwidth in `time_frequency.psd_multitaper()` was not documented correctly, and that the bandwidth was incorrectly documented as a half-bandwidth. The documentation has been updated to specify that it is the full frequency bandwidth, and the documentation of how the default bandwidth is 'computed'. The old version saying that the default bandwidth was 4 Hz was incorrect, as the 4 was the normalized time-half-bandwidth product.

Also updated the `ValueError` in `_compute_mt_params` when computing `half_nbw` to specify which is full bandwidth and which is half-bandwidth.