### PR TITLE
Fix docstrings by replacing str with path-like and fix double backticks for formatting

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -51,7 +51,7 @@ Bugs
 - Fix configuration folder discovery on Windows, which would fail in certain edge cases; and produce a helpful error message if discovery still fails (:gh:`11441` by `Richard Höchenberger`_)
 - Make :class:`~mne.decoding.SlidingEstimator` and :class:`~mne.decoding.GeneralizingEstimator` respect the ``verbose`` argument. Now with ``verbose=False``, the progress bar is not shown during fitting, scoring, etc. (:gh:`11450` by `Mikołaj Magnuski`_)
 - Fix bug with :func:`mne.gui.locate_ieeg` where Freesurfer ``?h.pial.T1`` was not recognized and suppress excess logging (:gh:`11489` by `Alex Rockhill`_)
-- All functions accepting paths can now correctly handle `~pathlib.Path` as input. Historically, we expected strings (instead of "proper" path objects), and only added `~pathlib.Path` support in a few select places, leading to inconsistent behavior. (:gh:`11473` and :gh:`11499` by `Mathieu Scheltienne`_)
+- All functions accepting paths can now correctly handle :class:`~pathlib.Path` as input. Historically, we expected strings (instead of "proper" path objects), and only added :class:`~pathlib.Path` support in a few select places, leading to inconsistent behavior. (:gh:`11473` and :gh:`11499` by `Mathieu Scheltienne`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -51,6 +51,7 @@ Bugs
 - Fix configuration folder discovery on Windows, which would fail in certain edge cases; and produce a helpful error message if discovery still fails (:gh:`11441` by `Richard Höchenberger`_)
 - Make :class:`~mne.decoding.SlidingEstimator` and :class:`~mne.decoding.GeneralizingEstimator` respect the ``verbose`` argument. Now with ``verbose=False``, the progress bar is not shown during fitting, scoring, etc. (:gh:`11450` by `Mikołaj Magnuski`_)
 - Fix bug with :func:`mne.gui.locate_ieeg` where Freesurfer ``?h.pial.T1`` was not recognized and suppress excess logging (:gh:`11489` by `Alex Rockhill`_)
+- Fix support for `~pathlib.Path` in the MNE codebase (:gh:`11473` and :gh:`11499` by `Mathieu Scheltienne`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -51,7 +51,7 @@ Bugs
 - Fix configuration folder discovery on Windows, which would fail in certain edge cases; and produce a helpful error message if discovery still fails (:gh:`11441` by `Richard Höchenberger`_)
 - Make :class:`~mne.decoding.SlidingEstimator` and :class:`~mne.decoding.GeneralizingEstimator` respect the ``verbose`` argument. Now with ``verbose=False``, the progress bar is not shown during fitting, scoring, etc. (:gh:`11450` by `Mikołaj Magnuski`_)
 - Fix bug with :func:`mne.gui.locate_ieeg` where Freesurfer ``?h.pial.T1`` was not recognized and suppress excess logging (:gh:`11489` by `Alex Rockhill`_)
-- Fix support for `~pathlib.Path` in the MNE codebase (:gh:`11473` and :gh:`11499` by `Mathieu Scheltienne`_)
+- All functions accepting paths can now correctly handle `~pathlib.Path` as input. Historically, we expected strings (instead of "proper" path objects), and only added `~pathlib.Path` support in a few select places, leading to inconsistent behavior. (:gh:`11473` and :gh:`11499` by `Mathieu Scheltienne`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1146,7 +1146,7 @@ def _read_annotations_csv(fname):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         The filename.
 
     Returns
@@ -1181,7 +1181,7 @@ def _read_brainstorm_annotations(fname, orig_time=None):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         The filename
     orig_time : float | int | instance of datetime | array of int | None
         A POSIX Timestamp, datetime or an array containing the timestamp as the
@@ -1408,7 +1408,7 @@ def events_from_annotations(raw, event_id="auto",
     ----------
     raw : instance of Raw
         The raw data for which Annotations are defined.
-    event_id : dict | callable | None | 'auto'
+    event_id : dict | callable | None | ``'auto'``
         Can be:
 
         - **dict**: map descriptions (keys) to integer event codes (values).

--- a/mne/beamformer/_compute_beamformer.py
+++ b/mne/beamformer/_compute_beamformer.py
@@ -455,7 +455,7 @@ class Beamformer(dict):
 
         Parameters
         ----------
-        fname : str
+        fname : path-like
             The filename to use to write the HDF5 data.
             Should end in ``'-lcmv.h5'`` or ``'-dics.h5'``.
         %(overwrite)s
@@ -481,7 +481,7 @@ def read_beamformer(fname):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         The filename of the HDF5 file.
 
     Returns

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -447,7 +447,7 @@ def make_bem_solution(surfs, *, solver='mne', verbose=None):
     surfs : list of dict
         The BEM surfaces to use (from :func:`mne.make_bem_model`).
     solver : str
-        Can be 'mne' (default) to use MNE-Python, or 'openmeeg' to use
+        Can be ``'mne'`` (default) to use MNE-Python, or ``'openmeeg'`` to use
         the :doc:`OpenMEEG <openmeeg:index>` package.
 
         .. versionadded:: 1.2
@@ -975,7 +975,7 @@ def fit_sphere_to_headshape(info, dig_kinds='auto', units='m', verbose=None):
     %(info_not_none)s
     %(dig_kinds)s
     units : str
-        Can be "m" (default) or "mm".
+        Can be ``"m"`` (default) or ``"mm"``.
 
         .. versionadded:: 0.12
     %(verbose)s
@@ -1742,11 +1742,11 @@ def write_bem_surfaces(fname, surfs, overwrite=False, *, verbose=None):
 @verbose
 def write_head_bem(fname, rr, tris, on_defects='raise', overwrite=False,
                    *, verbose=None):
-    """Write a head surface to a fiff file.
+    """Write a head surface to a FIF file.
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         Filename to write.
     rr : array, shape (n_vertices, 3)
         Coordinate points in the MRI coordinate system.

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -1068,7 +1068,7 @@ def generate_2d_layout(xy, w=.07, h=.05, pad=.02, ch_names=None,
         one index per channel.
     name : str
         The name of this layout type.
-    bg_image : str | ndarray
+    bg_image : path-like | ndarray
         The image over which sensor axes will be plotted. Either a path to an
         image file, or an array that can be plotted with plt.imshow. If
         provided, xy points will be normalized by the width/height of this

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -1278,7 +1278,7 @@ def _read_isotrak_elp_points(fname):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         The filepath of .elp Polhemus Isotrak file.
 
     Returns
@@ -1308,7 +1308,7 @@ def _read_isotrak_hsp_points(fname):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         The filepath of .hsp Polhemus Isotrak file.
 
     Returns

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -1130,7 +1130,7 @@ def compute_chpi_locs(info, chpi_amplitudes, t_step_max=1., too_close='raise',
         Maximum time step to use.
     too_close : str
         How to handle HPI positions too close to the sensors,
-        can be 'raise' (default), 'warning', or 'info'.
+        can be ``'raise'`` (default), ``'warning'``, or ``'info'``.
     %(adjust_dig_chpi)s
     %(verbose)s
 

--- a/mne/commands/mne_anonymize.py
+++ b/mne/commands/mne_anonymize.py
@@ -27,9 +27,9 @@ def mne_anonymize(fif_fname, out_fname, keep_his, daysback, overwrite):
 
     Parameters
     ----------
-    fif_fname : str
+    fif_fname : path-like
         Raw fif File
-    out_fname : str | None
+    out_fname : path-like | None
         Output file name
         relative paths are saved relative to parent dir of fif_fname
         None will save to parent dir of fif_fname with default prefix

--- a/mne/commands/mne_clean_eog_ecg.py
+++ b/mne/commands/mne_clean_eog_ecg.py
@@ -26,7 +26,7 @@ def clean_ecg_eog(in_fif_fname, out_fif_fname=None, eog=True, ecg=True,
 
     Parameters
     ----------
-    in_fif_fname : str
+    in_fif_fname : path-like
         Raw fif File
     eog_event_fname : str
         name of EOG event file required.

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -110,7 +110,7 @@ def coregister_fiducials(info, fiducials, tol=0.01):
     Parameters
     ----------
     %(info_not_none)s
-    fiducials : str | list of dict
+    fiducials : path-like | list of dict
         Fiducials in MRI coordinate space (either path to a ``*-fiducials.fif``
         file or list of fiducials as returned by :func:`read_fiducials`.
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -371,7 +371,7 @@ def read_cov(fname, verbose=None):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         The path-like of file containing the covariance matrix. It should end
         with ``-cov.fif`` or ``-cov.fif.gz``.
     %(verbose)s
@@ -1379,8 +1379,9 @@ def write_cov(fname, cov, *, overwrite=False, verbose=None):
 
     Parameters
     ----------
-    fname : str
-        The name of the file. It should end with -cov.fif or -cov.fif.gz.
+    fname : path-like
+        The name of the file. It should end with ``-cov.fif`` or
+        ``-cov.fif.gz``.
     cov : Covariance
         The noise covariance matrix.
     %(overwrite)s

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -17,7 +17,7 @@ def get_cuda_memory(kind='available'):
     Parameters
     ----------
     kind : str
-        Can be "available" or "total".
+        Can be ``"available"`` or ``"total"``.
 
     Returns
     -------
@@ -119,7 +119,7 @@ def _setup_cuda_fft_multiply_repeated(n_jobs, h, n_fft,
     Parameters
     ----------
     n_jobs : int | str
-        If n_jobs == 'cuda', the function will attempt to set up for CUDA
+        If ``n_jobs='cuda'``, the function will attempt to set up for CUDA
         FFT multiplication.
     h : array
         The filtering function that will be used repeatedly.

--- a/mne/decoding/time_delaying_ridge.py
+++ b/mne/decoding/time_delaying_ridge.py
@@ -238,7 +238,7 @@ class TimeDelayingRidge(BaseEstimator):
     alpha : float
         The ridge (or laplacian) regularization factor.
     reg_type : str | list
-        Can be "ridge" (default) or "laplacian".
+        Can be ``"ridge"`` (default) or ``"laplacian"``.
         Can also be a 2-element list specifying how to regularize in time
         and across adjacent features.
     fit_intercept : bool

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -447,7 +447,7 @@ class DipoleFixed(TimeMixin):
 
         Parameters
         ----------
-        fname : str
+        fname : path-like
             The name of the .fif file. Must end with ``'.fif'`` or
             ``'.fif.gz'`` to make it explicit that the file contains
             dipole information in FIF format.
@@ -1155,9 +1155,9 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=None,
         The dataset to fit.
     cov : str | instance of Covariance
         The noise covariance.
-    bem : str | instance of ConductorModel
+    bem : path-like | instance of ConductorModel
         The BEM filename (str) or conductor model.
-    trans : str | None
+    trans : path-like | None
         The head<->MRI transform filename. Must be provided unless BEM
         is a sphere model.
     min_dist : float
@@ -1187,8 +1187,9 @@ def fit_dipole(evoked, cov, bem, trans=None, min_dist=5., n_jobs=None,
 
         .. versionadded:: 0.20
     accuracy : str
-        Can be "normal" (default) or "accurate", which gives the most accurate
-        coil definition but is typically not necessary for real-world data.
+        Can be ``"normal"`` (default) or ``"accurate"``, which gives the most
+        accurate coil definition but is typically not necessary for real-world
+        data.
 
         .. versionadded:: 0.24
     tol : float

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -292,7 +292,7 @@ class Evoked(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
         Parameters
         ----------
-        fname : str
+        fname : path-like
             The name of the file, which should end with ``-ave.fif(.gz)`` or
             ``_ave.fif(.gz)``.
         %(overwrite)s
@@ -1409,8 +1409,8 @@ def write_evokeds(fname, evoked, *, on_mismatch='raise', overwrite=False,
 
     Parameters
     ----------
-    fname : str
-        The file name, which should end with -ave.fif or -ave.fif.gz.
+    fname : path-like
+        The file name, which should end with ``-ave.fif`` or ``-ave.fif.gz``.
     evoked : Evoked instance, or list of Evoked instances
         The evoked dataset, or list of evoked datasets, to save in one file.
         Note that the measurement info from the first evoked instance is used,

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -131,19 +131,19 @@ def _overlap_add_filter(x, h, n_fft=None, phase='zero', picks=None,
         Signals to filter.
     h : 1d array
         Filter impulse response (FIR filter coefficients). Must be odd length
-        if phase == 'linear'.
+        if ``phase='linear'``.
     n_fft : int
         Length of the FFT. If None, the best size is determined automatically.
     phase : str
-        If 'zero', the delay for the filter is compensated (and it must be
-        an odd-length symmetric filter). If 'linear', the response is
-        uncompensated. If 'zero-double', the filter is applied in the
+        If ``'zero'``, the delay for the filter is compensated (and it must be
+        an odd-length symmetric filter). If ``'linear'``, the response is
+        uncompensated. If ``'zero-double'``, the filter is applied in the
         forward and reverse directions. If 'minimum', a minimum-phase
         filter will be used.
     picks : list | None
         See calling functions.
     n_jobs : int | str
-        Number of jobs to run in parallel. Can be 'cuda' if ``cupy``
+        Number of jobs to run in parallel. Can be ``'cuda'`` if ``cupy``
         is installed properly.
     copy : bool
         If True, a copy of x, filtered, is returned. Otherwise, it operates

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -763,7 +763,7 @@ def use_coil_def(fname):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         The filename of the coil definition file.
 
     Returns

--- a/mne/gui/__init__.py
+++ b/mne/gui/__init__.py
@@ -59,7 +59,7 @@ def coregistration(tabbed=False, split=True, width=None, inst=None,
         Use a high resolution head surface.
         Default is None, which uses ``MNE_COREG_HEAD_HIGH_RES`` config value
         (which defaults to True).
-    trans : str | None
+    trans : path-like | None
         The transform file to use.
     scrollable : bool
         Make the coregistration panel vertically scrollable (default True).

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -87,7 +87,7 @@ class CoregistrationUI(HasTraits):
         with a different color. Defaults to True.
     sensor_opacity : float
         The opacity of the sensors between 0 and 1. Defaults to 1.0.
-    trans : str
+    trans : path-like
         The path to the Head<->MRI transform FIF file ("-trans.fif").
     size : tuple
         The dimensions (width, height) of the rendering view. The default is

--- a/mne/io/_digitization.py
+++ b/mne/io/_digitization.py
@@ -348,7 +348,7 @@ def _write_dig_points(fname, dig_points):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         Path to the file to write. The kind of file to write is determined
         based on the extension: '.txt' for tab separated text file.
     dig_points : numpy.ndarray, shape (n_points, 3)

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -24,13 +24,13 @@ def read_raw_artemis123(input_fname, preload=False, verbose=None,
 
     Parameters
     ----------
-    input_fname : str
+    input_fname : path-like
         Path to the data file (extension ``.bin``). The header file with the
         same file name stem and an extension ``.txt`` is expected to be found
         in the same directory.
     %(preload)s
     %(verbose)s
-    pos_fname : str or None (default None)
+    pos_fname : path-like | None
         If not None, load digitized head points from this file.
     add_head_trans : bool (default True)
         If True attempt to perform initial head localization. Compute initial

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1786,7 +1786,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
         stim_channel : str | None
             Name of the stim channel to add to. If None, the config variable
             'MNE_STIM_CHANNEL' is used. If this is not found, it will default
-            to 'STI 014'.
+            to ``'STI 014'``.
         replace : bool
             If True the old events on the stim channel are removed before
             adding the new ones.

--- a/mne/io/besa/besa.py
+++ b/mne/io/besa/besa.py
@@ -10,15 +10,15 @@ from ...evoked import EvokedArray
 @fill_doc
 @verbose
 def read_evoked_besa(fname, verbose=None):
-    """Reader function for BESA .avr or .mul files.
+    """Reader function for BESA ``.avr`` or ``.mul`` files.
 
-    When a .elp sidecar file is present, it will be used to determine electrode
-    information.
+    When a ``.elp`` sidecar file is present, it will be used to determine
+    electrode information.
 
     Parameters
     ----------
-    fname : str | Path
-        Path to the .avr or .mul file.
+    fname : path-like
+        Path to the ``.avr`` or ``.mul`` file.
     %(verbose)s
 
     Returns

--- a/mne/io/boxy/boxy.py
+++ b/mne/io/boxy/boxy.py
@@ -22,7 +22,7 @@ def read_raw_boxy(fname, preload=False, verbose=None):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         Path to the BOXY data file.
     %(preload)s
     %(verbose)s

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -35,16 +35,16 @@ class RawBrainVision(BaseRaw):
 
     Parameters
     ----------
-    vhdr_fname : str
+    vhdr_fname : path-like
         Path to the EEG header file.
     eog : list or tuple
         Names of channels or list of indices that should be designated
         EOG channels. Values should correspond to the header file.
         Default is ``('HEOGL', 'HEOGR', 'VEOGb')``.
-    misc : list or tuple of str | 'auto'
+    misc : list or tuple of str | ``'auto'``
         Names of channels or list of indices that should be designated
         MISC channels. Values should correspond to the electrodes
-        in the header file. If 'auto', units in header file are used for
+        in the header file. If ``'auto'``, units in header file are used for
         inferring misc channels. Default is ``'auto'``.
     scale : float
         The scaling factor for EEG data. Unless specified otherwise by
@@ -859,16 +859,16 @@ def read_raw_brainvision(vhdr_fname,
 
     Parameters
     ----------
-    vhdr_fname : str
+    vhdr_fname : path-like
         Path to the EEG header file.
     eog : list or tuple of str
         Names of channels or list of indices that should be designated
         EOG channels. Values should correspond to the header file
         Default is ``('HEOGL', 'HEOGR', 'VEOGb')``.
-    misc : list or tuple of str | 'auto'
+    misc : list or tuple of str | ``'auto'``
         Names of channels or list of indices that should be designated
         MISC channels. Values should correspond to the electrodes in the
-        header file. If 'auto', units in header file are used for inferring
+        header file. If ``'auto'``, units in header file are used for inferring
         misc channels. Default is ``'auto'``.
     scale : float
         The scaling factor for EEG data. Unless specified otherwise by

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -909,11 +909,11 @@ class RawBTi(BaseRaw):
 
     Parameters
     ----------
-    pdf_fname : str
+    pdf_fname : path-like
         Path to the processed data file (PDF).
-    config_fname : str
+    config_fname : path-like
         Path to system config file.
-    head_shape_fname : str | None
+    head_shape_fname : path-like | None
         Path to the head shape file.
     rotation_x : float
         Degrees to tilt x-axis for sensor frame misalignment. Ignored
@@ -1269,11 +1269,11 @@ def read_raw_bti(pdf_fname, config_fname='config',
 
     Parameters
     ----------
-    pdf_fname : str
+    pdf_fname : path-like
         Path to the processed data file (PDF).
-    config_fname : str
+    config_fname : path-like
         Path to system config file.
-    head_shape_fname : str | None
+    head_shape_fname : path-like | None
         Path to the head shape file.
     rotation_x : float
         Degrees to tilt x-axis for sensor frame misalignment. Ignored

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -32,8 +32,8 @@ def _read_annotations_cnt(fname, data_format='int16'):
 
     Parameters
     ----------
-    fname: str
-        path to cnt file containing the annotations.
+    fname: path-like
+        Path to CNT file containing the annotations.
     data_format : 'int16' | 'int32'
         Defines the data format the data is read in.
 
@@ -121,30 +121,30 @@ def read_raw_cnt(input_fname, eog=(), misc=(), ecg=(),
 
     Parameters
     ----------
-    input_fname : str
+    input_fname : path-like
         Path to the data file.
-    eog : list | tuple | 'auto' | 'header'
+    eog : list | tuple | ``'auto'`` | ``'header'``
         Names of channels or list of indices that should be designated
         EOG channels. If 'header', VEOG and HEOG channels assigned in the file
-        header are used. If 'auto', channel names containing 'EOG' are used.
-        Defaults to empty tuple.
+        header are used. If ``'auto'``, channel names containing ``'EOG'`` are
+        used. Defaults to empty tuple.
     misc : list | tuple
         Names of channels or list of indices that should be designated
         MISC channels. Defaults to empty tuple.
-    ecg : list | tuple | 'auto'
+    ecg : list | tuple | ``'auto'``
         Names of channels or list of indices that should be designated
-        ECG channels. If 'auto', the channel names containing 'ECG' are used.
-        Defaults to empty tuple.
+        ECG channels. If ``'auto'``, the channel names containing ``'ECG'`` are
+        used. Defaults to empty tuple.
     emg : list | tuple
         Names of channels or list of indices that should be designated
         EMG channels. If 'auto', the channel names containing 'EMG' are used.
         Defaults to empty tuple.
-    data_format : 'auto' | 'int16' | 'int32'
-        Defines the data format the data is read in. If 'auto', it is
+    data_format : ``'auto'`` | ``'int16'`` | ``'int32'``
+        Defines the data format the data is read in. If ``'auto'``, it is
         determined from the file header using ``numsamples`` field.
-        Defaults to 'auto'.
-    date_format : 'mm/dd/yy' | 'dd/mm/yy'
-        Format of date in the header. Defaults to 'mm/dd/yy'.
+        Defaults to ``'auto'``.
+    date_format : ``'mm/dd/yy'`` | ``'dd/mm/yy'``
+        Format of date in the header. Defaults to ``'mm/dd/yy'``.
     %(preload)s
     %(verbose)s
 
@@ -338,29 +338,29 @@ class RawCNT(BaseRaw):
 
     Parameters
     ----------
-    input_fname : str
+    input_fname : path-like
         Path to the CNT file.
     eog : list | tuple
         Names of channels or list of indices that should be designated
-        EOG channels. If 'auto', the channel names beginning with
+        EOG channels. If ``'auto'``, the channel names beginning with
         ``EOG`` are used. Defaults to empty tuple.
     misc : list | tuple
         Names of channels or list of indices that should be designated
         MISC channels. Defaults to empty tuple.
     ecg : list | tuple
         Names of channels or list of indices that should be designated
-        ECG channels. If 'auto', the channel names beginning with
+        ECG channels. If ``'auto'``, the channel names beginning with
         ``ECG`` are used. Defaults to empty tuple.
     emg : list | tuple
         Names of channels or list of indices that should be designated
-        EMG channels. If 'auto', the channel names beginning with
+        EMG channels. If ``'auto'``, the channel names beginning with
         ``EMG`` are used. Defaults to empty tuple.
-    data_format : 'auto' | 'int16' | 'int32'
-        Defines the data format the data is read in. If 'auto', it is
+    data_format : ``'auto'`` | ``'int16'`` | ``'int32'``
+        Defines the data format the data is read in. If ``'auto'``, it is
         determined from the file header using ``numsamples`` field.
-        Defaults to 'auto'.
-    date_format : 'mm/dd/yy' | 'dd/mm/yy'
-        Format of date in the header. Defaults to 'mm/dd/yy'.
+        Defaults to ``'auto'``.
+    date_format : ``'mm/dd/yy'`` | ``'dd/mm/yy'``
+        Format of date in the header. Defaults to ``'mm/dd/yy'``.
     %(preload)s
     stim_channel : bool | None
         Add a stim channel from the events. Defaults to None to trigger a

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -32,7 +32,7 @@ def read_raw_ctf(directory, system_clock='truncate', preload=False,
 
     Parameters
     ----------
-    directory : str
+    directory : path-like
         Path to the CTF data (ending in ``'.ds'``).
     system_clock : str
         How to treat the system clock. Use "truncate" (default) to truncate

--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -97,7 +97,7 @@ def _read_curry_lines(fname, regex_list):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         Path to a curry file.
     regex_list : list of str
         A list of strings or regular expressions to search within the file.
@@ -420,7 +420,7 @@ def _read_events_curry(fname):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         Path to a curry event file with extensions .cef, .ceo,
         .cdt.cef, or .cdt.ceo
 
@@ -477,9 +477,9 @@ def read_raw_curry(fname, preload=False, verbose=None):
 
     Parameters
     ----------
-    fname : str
-        Path to a curry file with extensions .dat, .dap, .rs3, .cdt, .cdt.dpa,
-        .cdt.cef or .cef.
+    fname : path-like
+        Path to a curry file with extensions ``.dat``, ``.dap``, ``.rs3``,
+        ``.cdt``, ``.cdt.dpa``, ``.cdt.cef`` or ``.cef``.
     %(preload)s
     %(verbose)s
 
@@ -496,9 +496,9 @@ class RawCurry(BaseRaw):
 
     Parameters
     ----------
-    fname : str
-        Path to a curry file with extensions .dat, .dap, .rs3, .cdt, .cdt.dpa,
-        .cdt.cef or .cef.
+    fname : path-like
+        Path to a curry file with extensions ``.dat``, ``.dap``, ``.rs3``,
+        ``.cdt``, ``.cdt.dpa``, ``.cdt.cef`` or ``.cef``.
     %(preload)s
     %(verbose)s
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -50,7 +50,7 @@ class RawEDF(BaseRaw):
 
     Parameters
     ----------
-    input_fname : str
+    input_fname : path-like
         Path to the EDF, EDF+ or BDF file.
     eog : list or tuple
         Names of channels or list of indices that should be designated EOG
@@ -60,11 +60,12 @@ class RawEDF(BaseRaw):
         Names of channels or list of indices that should be designated MISC
         channels. Values should correspond to the electrodes in the file.
         Default is None.
-    stim_channel : 'auto' | str | list of str | int | list of int
-        Defaults to 'auto', which means that channels named 'status' or
-        'trigger' (case insensitive) are set to STIM. If str (or list of str),
-        all channels matching the name(s) are set to STIM. If int (or list of
-        ints), the channels corresponding to the indices are set to STIM.
+    stim_channel : ``'auto'`` | str | list of str | int | list of int
+        Defaults to ``'auto'``, which means that channels named ``'status'`` or
+        ``'trigger'`` (case insensitive) are set to STIM. If str (or list of
+        str), all channels matching the name(s) are set to STIM. If int (or
+        list of ints), the channels corresponding to the indices are set to
+        STIM.
     exclude : list of str
         Channel names to exclude. This can help when reading data with
         different sampling rates to avoid unnecessary resampling.
@@ -199,7 +200,7 @@ class RawGDF(BaseRaw):
 
     Parameters
     ----------
-    input_fname : str
+    input_fname : path-like
         Path to the GDF file.
     eog : list or tuple
         Names of channels or list of indices that should be designated EOG
@@ -209,7 +210,7 @@ class RawGDF(BaseRaw):
         Names of channels or list of indices that should be designated MISC
         channels. Values should correspond to the electrodes in the file.
         Default is None.
-    stim_channel : 'auto' | str | list of str | int | list of int
+    stim_channel : ``'auto'`` | str | list of str | int | list of int
         Defaults to 'auto', which means that channels named 'status' or
         'trigger' (case insensitive) are set to STIM. If str (or list of str),
         all channels matching the name(s) are set to STIM. If int (or list of
@@ -1313,7 +1314,7 @@ def read_raw_edf(input_fname, eog=None, misc=None, stim_channel='auto',
 
     Parameters
     ----------
-    input_fname : str
+    input_fname : path-like
         Path to the EDF or EDF+ file.
     eog : list or tuple
         Names of channels or list of indices that should be designated EOG
@@ -1323,11 +1324,11 @@ def read_raw_edf(input_fname, eog=None, misc=None, stim_channel='auto',
         Names of channels or list of indices that should be designated MISC
         channels. Values should correspond to the electrodes in the file.
         Default is None.
-    stim_channel : 'auto' | str | list of str | int | list of int
-        Defaults to 'auto', which means that channels named 'status' or
-        'trigger' (case insensitive) are set to STIM. If str (or list of str),
-        all channels matching the name(s) are set to STIM. If int (or list of
-        ints), channels corresponding to the indices are set to STIM.
+    stim_channel : ``'auto'`` | str | list of str | int | list of int
+        Defaults to ``'auto'``, which means that channels named ``'status'`` or
+        ``'trigger'`` (case insensitive) are set to STIM. If str (or list of
+        str), all channels matching the name(s) are set to STIM. If int (or
+        list of ints), channels corresponding to the indices are set to STIM.
     exclude : list of str | str
         Channel names to exclude. This can help when reading data with
         different sampling rates to avoid unnecessary resampling. A str is
@@ -1423,7 +1424,7 @@ def read_raw_bdf(input_fname, eog=None, misc=None, stim_channel='auto',
 
     Parameters
     ----------
-    input_fname : str
+    input_fname : path-like
         Path to the BDF file.
     eog : list or tuple
         Names of channels or list of indices that should be designated EOG
@@ -1433,11 +1434,11 @@ def read_raw_bdf(input_fname, eog=None, misc=None, stim_channel='auto',
         Names of channels or list of indices that should be designated MISC
         channels. Values should correspond to the electrodes in the file.
         Default is None.
-    stim_channel : 'auto' | str | list of str | int | list of int
-        Defaults to 'auto', which means that channels named 'status' or
-        'trigger' (case insensitive) are set to STIM. If str (or list of str),
-        all channels matching the name(s) are set to STIM. If int (or list of
-        ints), channels corresponding to the indices are set to STIM.
+    stim_channel : ``'auto'`` | str | list of str | int | list of int
+        Defaults to ``'auto'``, which means that channels named ``'status'`` or
+        ``'trigger'`` (case insensitive) are set to STIM. If str (or list of
+        str), all channels matching the name(s) are set to STIM. If int (or
+        list of ints), channels corresponding to the indices are set to STIM.
     exclude : list of str | str
         Channel names to exclude. This can help when reading data with
         different sampling rates to avoid unnecessary resampling. A str is
@@ -1525,7 +1526,7 @@ def read_raw_gdf(input_fname, eog=None, misc=None, stim_channel='auto',
 
     Parameters
     ----------
-    input_fname : str
+    input_fname : path-like
         Path to the GDF file.
     eog : list or tuple
         Names of channels or list of indices that should be designated EOG
@@ -1535,11 +1536,11 @@ def read_raw_gdf(input_fname, eog=None, misc=None, stim_channel='auto',
         Names of channels or list of indices that should be designated MISC
         channels. Values should correspond to the electrodes in the file.
         Default is None.
-    stim_channel : 'auto' | str | list of str | int | list of int
-        Defaults to 'auto', which means that channels named 'status' or
-        'trigger' (case insensitive) are set to STIM. If str (or list of str),
-        all channels matching the name(s) are set to STIM. If int (or list of
-        ints), channels corresponding to the indices are set to STIM.
+    stim_channel : ``'auto'`` | str | list of str | int | list of int
+        Defaults to ``'auto'``, which means that channels named ``'status'`` or
+        ``'trigger'`` (case insensitive) are set to STIM. If str (or list of
+        str), all channels matching the name(s) are set to STIM. If int (or
+        list of ints), channels corresponding to the indices are set to STIM.
     exclude : list of str | str
         Channel names to exclude. This can help when reading data with
         different sampling rates to avoid unnecessary resampling. A str is

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -255,16 +255,16 @@ def read_raw_eeglab(input_fname, eog=(), preload=False,
 
     Parameters
     ----------
-    input_fname : str
-        Path to the .set file. If the data is stored in a separate .fdt file,
-        it is expected to be in the same folder as the .set file.
-    eog : list | tuple | 'auto'
+    input_fname : path-like
+        Path to the ``.set`` file. If the data is stored in a separate ``.fdt``
+        file, it is expected to be in the same folder as the ``.set`` file.
+    eog : list | tuple | ``'auto'``
         Names or indices of channels that should be designated EOG channels.
         If 'auto', the channel names containing ``EOG`` or ``EYE`` are used.
         Defaults to empty tuple.
     %(preload)s
-        Note that preload=False will be effective only if the data is stored
-        in a separate binary file.
+        Note that ``preload=False`` will be effective only if the data is
+        stored in a separate binary file.
     %(uint16_codec)s
     %(montage_units)s
     %(verbose)s

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -338,7 +338,7 @@ def _read_raw_egi_mff(input_fname, eog=None, misc=None,
 
     Parameters
     ----------
-    input_fname : str
+    input_fname : path-like
         Path to the raw file.
     eog : list or tuple
         Names of channels or list of indices that should be designated
@@ -775,8 +775,8 @@ def read_evokeds_mff(fname, condition=None, channel_naming='E%d',
 
     Parameters
     ----------
-    fname : str
-        File path to averaged MFF file. Should end in .mff.
+    fname : path-like
+        File path to averaged MFF file. Should end in ``.mff``.
     condition : int or str | list of int or str | None
         The index (indices) or category (categories) from which to read in
         data. Averaged MFF files can contain separate averages for different

--- a/mne/io/egi/events.py
+++ b/mne/io/egi/events.py
@@ -17,7 +17,7 @@ def _read_events(input_fname, info):
 
     Parameters
     ----------
-    input_fname : str
+    input_fname : path-like
         The file path.
     info : dict
         Header info array.
@@ -38,7 +38,7 @@ def _read_mff_events(filename, sfreq):
 
     Parameters
     ----------
-    filename : str
+    filename : path-like
         File path.
     sfreq : float
         The sampling frequency

--- a/mne/io/eximia/eximia.py
+++ b/mne/io/eximia/eximia.py
@@ -17,8 +17,8 @@ def read_raw_eximia(fname, preload=False, verbose=None):
 
     Parameters
     ----------
-    fname : str
-        Path to the eXimia data file (.nxe).
+    fname : path-like
+        Path to the eXimia ``.nxe`` data file.
     %(preload)s
     %(verbose)s
 

--- a/mne/io/fieldtrip/fieldtrip.py
+++ b/mne/io/fieldtrip/fieldtrip.py
@@ -92,8 +92,8 @@ def read_epochs_fieldtrip(fname, info, data_name='data',
 
     Parameters
     ----------
-    fname : str
-        Path and filename of the .mat file containing the data.
+    fname : path-like
+        Path and filename of the ``.mat`` file containing the data.
     info : dict or None
         The info dict of the raw data file corresponding to the data to import.
         If this is set to None, limited information is extracted from the
@@ -149,8 +149,8 @@ def read_evoked_fieldtrip(fname, info, comment=None,
 
     Parameters
     ----------
-    fname : str
-        Path and filename of the .mat file containing the data.
+    fname : path-like
+        Path and filename of the ``.mat`` file containing the data.
     info : dict or None
         The info dict of the raw data file corresponding to the data to import.
         If this is set to None, limited information is extracted from the

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -34,7 +34,7 @@ class Raw(BaseRaw):
 
     Parameters
     ----------
-    fname : str | file-like
+    fname : path-like | file-like
         The raw filename to load. For files that have automatically been split,
         the split part will be automatically loaded. Filenames not ending with
         ``raw.fif``, ``raw_sss.fif``, ``raw_tsss.fif``, ``_meg.fif``,
@@ -446,7 +446,7 @@ def read_raw_fif(fname, allow_maxshield=False, preload=False,
 
     Parameters
     ----------
-    fname : str | file-like
+    fname : path-like | file-like
         The raw filename to load. For files that have automatically been split,
         the split part will be automatically loaded. Filenames should end
         with raw.fif, raw.fif.gz, raw_sss.fif, raw_sss.fif.gz, raw_tsss.fif,

--- a/mne/io/fil/fil.py
+++ b/mne/io/fil/fil.py
@@ -26,7 +26,7 @@ def read_raw_fil(binfile, precision='single', preload=False, *, verbose=None):
 
     Parameters
     ----------
-    binfile : str
+    binfile : path-like
         Path to the MEG data binary (ending in ``'_meg.bin'``).
     precision : str, optional
         How is the data represented? ``'single'`` if 32-bit or ``'double'`` if
@@ -52,7 +52,7 @@ class RawFIL(BaseRaw):
 
     Parameters
     ----------
-    binfile : str
+    binfile : path-like
         Path to the MEG data binary (ending in ``'_meg.bin'``).
     precision : str, optional
         How is the data represented? ``'single'`` if 32-bit or

--- a/mne/io/kit/coreg.py
+++ b/mne/io/kit/coreg.py
@@ -84,7 +84,7 @@ def read_sns(fname):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         Absolute path to sensor definition file.
 
     Returns

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -74,8 +74,8 @@ class RawKIT(BaseRaw):
 
     Parameters
     ----------
-    input_fname : str
-        Path to the sqd file.
+    input_fname : path-like
+        Path to the SQD file.
     %(kit_mrk)s
     %(kit_elp)s
     %(kit_hsp)s
@@ -425,7 +425,7 @@ def get_kit_info(rawfile, allow_unknown_format, standardize_names=None,
 
     Parameters
     ----------
-    rawfile : str
+    rawfile : path-like
         KIT file to be read.
     allow_unknown_format : bool
         Force reading old data that is not officially supported. Alternatively,
@@ -807,8 +807,8 @@ def read_raw_kit(input_fname, mrk=None, elp=None, hsp=None, stim='>',
 
     Parameters
     ----------
-    input_fname : str
-        Path to the sqd file.
+    input_fname : path-like
+        Path to the SQD file.
     %(kit_mrk)s
     %(kit_elp)s
     %(kit_hsp)s
@@ -857,8 +857,8 @@ def read_epochs_kit(input_fname, events, event_id=None, mrk=None, elp=None,
 
     Parameters
     ----------
-    input_fname : str
-        Path to the sqd file.
+    input_fname : path-like
+        Path to the SQD file.
     events : array of int, shape (n_events, 3) | path-like
         The array of :term:`events`. The first column contains the event time
         in samples, with :term:`first_samp` included. The third column contains

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -249,7 +249,8 @@ class ContainsMixin(object):
         Parameters
         ----------
         ch_type : str
-            Channel type to check for. Can be e.g. ``'meg'``, ``'eeg'``, ``'stim', etc.
+            Channel type to check for. Can be e.g. ``'meg'``, ``'eeg'``,
+            ``'stim'``, etc.
 
         Returns
         -------

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -249,7 +249,7 @@ class ContainsMixin(object):
         Parameters
         ----------
         ch_type : str
-            Channel type to check for. Can be e.g. 'meg', 'eeg', 'stim', etc.
+            Channel type to check for. Can be e.g. ``'meg'``, ``'eeg'``, ``'stim', etc.
 
         Returns
         -------
@@ -1233,7 +1233,7 @@ class Info(dict, MontageMixin, ContainsMixin):
 
         Parameters
         ----------
-        fname : str
+        fname : path-like
             The name of the file. Should end by ``'-info.fif'``.
         """
         write_info(fname, self)
@@ -1331,7 +1331,7 @@ def read_info(fname, verbose=None):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         File name.
     %(verbose)s
 
@@ -2206,8 +2206,8 @@ def write_info(fname, info, data_type=None, reset_range=True):
 
     Parameters
     ----------
-    fname : str
-        The name of the file. Should end by -info.fif.
+    fname : path-like
+        The name of the file. Should end by ``-info.fif``.
     %(info_not_none)s
     data_type : int
         The data_type in case it is necessary. Should be 4 (FIFFT_FLOAT),

--- a/mne/io/nedf/nedf.py
+++ b/mne/io/nedf/nedf.py
@@ -202,8 +202,8 @@ def read_raw_nedf(filename, preload=False, verbose=None):
 
     Parameters
     ----------
-    filename : str
-        Path to the .nedf file.
+    filename : path-like
+        Path to the ``.nedf`` file.
     %(preload)s
     %(verbose)s
 

--- a/mne/io/nicolet/nicolet.py
+++ b/mne/io/nicolet/nicolet.py
@@ -26,22 +26,22 @@ def read_raw_nicolet(input_fname, ch_type, eog=(),
 
     Parameters
     ----------
-    input_fname : str
+    input_fname : path-like
         Path to the data file (ending with ``.data`` not ``.head``).
     ch_type : str
         Channel type to designate to the data channels. Supported data types
-        include 'eeg', 'dbs'.
-    eog : list | tuple | 'auto'
+        include ``'eeg'``, ``'dbs'``.
+    eog : list | tuple | ``'auto'``
         Names of channels or list of indices that should be designated
-        EOG channels. If 'auto', the channel names beginning with
+        EOG channels. If ``'auto'``, the channel names beginning with
         ``EOG`` are used. Defaults to empty tuple.
-    ecg : list or tuple | 'auto'
+    ecg : list or tuple | ``'auto'``
         Names of channels or list of indices that should be designated
-        ECG channels. If 'auto', the channel names beginning with
+        ECG channels. If ``'auto'``, the channel names beginning with
         ``ECG`` are used. Defaults to empty tuple.
-    emg : list or tuple | 'auto'
+    emg : list or tuple | ``'auto'``
         Names of channels or list of indices that should be designated
-        EMG channels. If 'auto', the channel names beginning with
+        EMG channels. If ``'auto'``, the channel names beginning with
         ``EMG`` are used. Defaults to empty tuple.
     misc : list or tuple
         Names of channels or list of indices that should be designated
@@ -130,22 +130,22 @@ class RawNicolet(BaseRaw):
 
     Parameters
     ----------
-    input_fname : str
+    input_fname : path-like
         Path to the Nicolet file.
     ch_type : str
         Channel type to designate to the data channels. Supported data types
-        include 'eeg', 'seeg'.
-    eog : list | tuple | 'auto'
+        include ``'eeg'``, ``'seeg'``.
+    eog : list | tuple | ``'auto'``
         Names of channels or list of indices that should be designated
-        EOG channels. If 'auto', the channel names beginning with
+        EOG channels. If ``'auto'``, the channel names beginning with
         ``EOG`` are used. Defaults to empty tuple.
-    ecg : list or tuple | 'auto'
+    ecg : list or tuple | ``'auto'``
         Names of channels or list of indices that should be designated
-        ECG channels. If 'auto', the channel names beginning with
+        ECG channels. If ``'auto'``, the channel names beginning with
         ``ECG`` are used. Defaults to empty tuple.
-    emg : list or tuple | 'auto'
+    emg : list or tuple | ``'auto'``
         Names of channels or list of indices that should be designated
-        EMG channels. If 'auto', the channel names beginning with
+        EMG channels. If ``'auto'``, the channel names beginning with
         ``EMG`` are used. Defaults to empty tuple.
     misc : list or tuple
         Names of channels or list of indices that should be designated

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -29,7 +29,7 @@ def read_raw_nirx(fname, saturated='annotate', preload=False, verbose=None):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         Path to the NIRX data folder or header file.
     %(saturated)s
     %(preload)s

--- a/mne/io/open.py
+++ b/mne/io/open.py
@@ -103,7 +103,7 @@ def fiff_open(fname, preload=False, verbose=None):
 
     Parameters
     ----------
-    fname : str | fid
+    fname : path-like | fid
         Name of the fif file, or an opened file (will seek back to 0).
     preload : bool
         If True, all data from the file is read into a memory buffer. This
@@ -199,7 +199,7 @@ def show_fiff(fname, indent='    ', read_limit=np.inf, max_str=30,
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         Filename to evaluate.
     indent : str
         How to indent the lines.

--- a/mne/io/persyst/persyst.py
+++ b/mne/io/persyst/persyst.py
@@ -22,8 +22,8 @@ def read_raw_persyst(fname, preload=False, verbose=None):
 
     Parameters
     ----------
-    fname : str
-        Path to the Persyst header (.lay) file.
+    fname : path-like
+        Path to the Persyst header ``.lay`` file.
     %(preload)s
     %(verbose)s
 

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -873,7 +873,7 @@ def make_eeg_average_ref_proj(info, activate=True, *, ch_type='eeg',
         If True projections are activated.
     ch_type : str
         The channel type to use for reference projection.
-        Valid types are 'eeg', 'ecog', 'seeg' and 'dbs'.
+        Valid types are ``'eeg'``, ``'ecog'``, ``'seeg'`` and ``'dbs'``.
 
         .. versionadded:: 1.2
     %(verbose)s

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -32,7 +32,7 @@ def read_raw_snirf(fname, optode_frame="unknown", preload=False, verbose=None):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         Path to the SNIRF data file.
     optode_frame : str
         Coordinate frame used for the optode positions. The default is unknown,

--- a/mne/io/what.py
+++ b/mne/io/what.py
@@ -14,8 +14,8 @@ def what(fname):
 
     Parameters
     ----------
-    fname : str
-        The filename. Should end in .fif or .fif.gz.
+    fname : path-like
+        The filename. Should end in ``.fif`` or ``.fif.gz``.
 
     Returns
     -------

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -327,7 +327,7 @@ def start_file(fname, id_=None):
 
     Parameters
     ----------
-    fname : string | fid
+    fname : path-like | fid
         The name of the file to open. It is recommended
         that the name ends with .fif or .fif.gz. Can also be an
         already opened file.

--- a/mne/label.py
+++ b/mne/label.py
@@ -376,7 +376,7 @@ class Label:
 
         Parameters
         ----------
-        filename : str
+        filename : path-like
             Path to label file to produce.
 
         Notes

--- a/mne/misc.py
+++ b/mne/misc.py
@@ -9,7 +9,7 @@ def parse_config(fname):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         Config file name.
 
     Returns
@@ -60,7 +60,7 @@ def read_reject_parameters(fname):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         Filename to read.
 
     Returns

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -315,7 +315,7 @@ class SourceMorph:
         subject_to can be the path to a MRI volume. Can also be a list of
         two arrays if morphing to hemisphere surfaces.
     kind : str | None
-        Kind of source estimate. E.g. 'volume' or 'surface'.
+        Kind of source estimate. E.g. ``'volume'`` or ``'surface'``.
     zooms : float | tuple
         See :func:`mne.compute_source_morph`.
     niter_affine : tuple of int
@@ -430,13 +430,14 @@ class SourceMorph:
         stc_from : VolSourceEstimate | VolVectorSourceEstimate | SourceEstimate | VectorSourceEstimate
             The source estimate to morph.
         output : str
-            Can be 'stc' (default) or possibly 'nifti1', or 'nifti2'
-            when working with a volume source space defined on a regular
-            grid.
+            Can be ``'stc'`` (default) or possibly ``'nifti1'``, or
+            ``'nifti2'`` when working with a volume source space defined on a
+            regular grid.
         mri_resolution : bool | tuple | int | float
             If True the image is saved in MRI resolution. Default False.
-            WARNING: if you have many time points the file produced can be
-            huge. The default is mri_resolution=False.
+
+            .. warning: If you have many time points the file produced can be
+                        huge. The default is ``mri_resolution=False``.
         mri_space : bool | None
             Whether the image to world registration should be in mri space. The
             default (None) is mri_space=mri_resolution.
@@ -744,8 +745,8 @@ def read_source_morph(fname):
 
     Parameters
     ----------
-    fname : str
-        Full filename including path.
+    fname : path-like
+        Path to the file containing the morph source estimates.
 
     Returns
     -------

--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -25,13 +25,13 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='n_jobs',
     func : callable
         A function.
     %(n_jobs)s
-    max_nbytes : int, str, or None
+    max_nbytes : int | str | None
         Threshold on the minimum size of arrays passed to the workers that
         triggers automated memory mapping. Can be an int in Bytes,
         or a human-readable string, e.g., '1M' for 1 megabyte.
         Use None to disable memmaping of large arrays. Use 'auto' to
         use the value set using mne.set_memmap_min_size.
-    pre_dispatch : int, or str, optional
+    pre_dispatch : int | str
         See :class:`joblib.Parallel`.
     total : int | None
         If int, use a progress bar to display the progress of dispatched
@@ -39,7 +39,8 @@ def parallel_func(func, n_jobs, max_nbytes='auto', pre_dispatch='n_jobs',
         using ``split_list`` or :func:`np.array_split`.
         If None (default), do not add a progress bar.
     prefer : str | None
-        If str, can be "processes" or "threads". See :class:`joblib.Parallel`.
+        If str, can be ``"processes"`` or ``"threads"``.
+        See :class:`joblib.Parallel`.
 
         .. versionadded:: 0.18
     max_jobs : int | None

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2583,7 +2583,7 @@ def read_ica(fname, verbose=None):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         Absolute path to fif file containing ICA matrices.
         The file name should end with -ica.fif or -ica.fif.gz.
     %(verbose)s
@@ -2970,8 +2970,8 @@ def read_ica_eeglab(fname, *, verbose=None):
 
     Parameters
     ----------
-    fname : str
-        Complete path to a .set EEGLAB file that contains an ICA object.
+    fname : path-like
+        Complete path to a ``.set`` EEGLAB file that contains an ICA object.
     %(verbose)s
 
     Returns

--- a/mne/preprocessing/maxfilter.py
+++ b/mne/preprocessing/maxfilter.py
@@ -31,13 +31,13 @@ def apply_maxfilter(in_fname, out_fname, origin=None, frame='device',
 
     Parameters
     ----------
-    in_fname : str
+    in_fname : path-like
         Input file name.
-    out_fname : str
+    out_fname : path-like
         Output file name.
     origin : array-like or str
         Head origin in mm. If None it will be estimated from headshape points.
-    frame : str ('device' or 'head')
+    frame : ``'device'`` | ``'head'``
         Coordinate frame for head center.
     bad : str, list (or None)
         List of static bad channels. Can be a list with channel names, or a

--- a/mne/preprocessing/ssp.py
+++ b/mne/preprocessing/ssp.py
@@ -218,9 +218,9 @@ def compute_proj_ecg(raw, raw_event=None, tmin=-0.2, tmax=0.4,
 
         .. versionadded:: 0.15
     meg : str
-        Can be 'separate' (default) or 'combined' to compute projectors
+        Can be ``'separate'`` (default) or ``'combined'`` to compute projectors
         for magnetometers and gradiometers separately or jointly.
-        If 'combined', ``n_mag == n_grad`` is required and the number of
+        If ``'combined'``, ``n_mag == n_grad`` is required and the number of
         projectors computed for MEG will be ``n_mag``.
 
         .. versionadded:: 0.18

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -26,9 +26,9 @@ def read_proj(fname, verbose=None):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         The name of file containing the projections vectors. It should end with
-        -proj.fif or -proj.fif.gz.
+        ``-proj.fif`` or ``-proj.fif.gz``.
     %(verbose)s
 
     Returns
@@ -166,9 +166,9 @@ def compute_proj_epochs(epochs, n_grad=2, n_mag=2, n_eeg=2, n_jobs=None,
         The description prefix to use. If None, one will be created based on
         the event_id, tmin, and tmax.
     meg : str
-        Can be 'separate' (default) or 'combined' to compute projectors
+        Can be ``'separate'`` (default) or ``'combined'`` to compute projectors
         for magnetometers and gradiometers separately or jointly.
-        If 'combined', ``n_mag == n_grad`` is required and the number of
+        If ``'combined'``, ``n_mag == n_grad`` is required and the number of
         projectors computed for MEG will be ``n_mag``.
 
         .. versionadded:: 0.18
@@ -355,16 +355,16 @@ def sensitivity_map(fwd, projs=None, ch_type='grad', mode='fixed', exclude=[],
         The forward operator.
     projs : list
         List of projection vectors.
-    ch_type : 'grad' | 'mag' | 'eeg'
+    ch_type : ``'grad'`` | ``'mag'`` | ``'eeg'``
         The type of sensors to use.
     mode : str
-        The type of sensitivity map computed. See manual. Should be 'free',
-        'fixed', 'ratio', 'radiality', 'angle', 'remaining', or 'dampening'
-        corresponding to the argument --map 1, 2, 3, 4, 5, 6 and 7 of the
-        command mne_sensitivity_map.
+        The type of sensitivity map computed. See manual. Should be ``'free'``,
+        ``'fixed'``, ``'ratio'``, ``'radiality'``, ``'angle'``,
+        ``'remaining'``, or ``'dampening'`` corresponding to the argument
+        ``--map 1, 2, 3, 4, 5, 6, 7`` of the command ``mne_sensitivity_map``.
     exclude : list of str | str
         List of channels to exclude. If empty do not exclude any (default).
-        If 'bads', exclude channels in fwd['info']['bads'].
+        If ``'bads'``, exclude channels in ``fwd['info']['bads']``.
     %(verbose)s
 
     Returns

--- a/mne/rank.py
+++ b/mne/rank.py
@@ -67,13 +67,13 @@ def _estimate_rank_from_s(s, tol='auto', tol_kind='absolute'):
     ----------
     s : ndarray, shape (..., ndim)
         The singular values of the matrix.
-    tol : float | 'auto'
+    tol : float | ``'auto'``
         Tolerance for singular values to consider non-zero in calculating the
         rank. Can be 'auto' to use the same thresholding as
         ``scipy.linalg.orth`` (assuming np.float64 datatype) adjusted
         by a factor of 2.
     tol_kind : str
-        Can be "absolute" or "relative".
+        Can be ``"absolute"`` or ``"relative"``.
 
     Returns
     -------
@@ -128,13 +128,13 @@ def _estimate_rank_meeg_signals(data, info, scalings, tol='auto',
     data : np.ndarray of float, shape(n_channels, n_samples)
         The M/EEG signals.
     %(info_not_none)s
-    scalings : dict | 'norm' | np.ndarray | None
+    scalings : dict | ``'norm'`` | np.ndarray | None
         The rescaling method to be applied. If dict, it will override the
         following default dict:
 
             dict(mag=1e15, grad=1e13, eeg=1e6)
 
-        If 'norm' data will be scaled by channel-wise norms. If array,
+        If ``'norm'`` data will be scaled by channel-wise norms. If array,
         pre-specified norms will be used. If None, no scaling will be applied.
     tol : float | str
         Tolerance. See ``estimate_rank``.

--- a/mne/simulation/metrics/metrics.py
+++ b/mne/simulation/metrics/metrics.py
@@ -29,7 +29,7 @@ def source_estimate_quantification(stc1, stc2, metric='rms'):
     stc2 : SourceEstimate
         Second source estimate for comparison.
     metric : str
-        Metric to calculate, 'rms' or 'cosine'.
+        Metric to calculate, ``'rms'`` or ``'cosine'``.
 
     Returns
     -------

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -158,11 +158,11 @@ def simulate_raw(info, stc=None, trans=None, src=None, bem=None, head_pos=None,
         be in FIF format, any other ending will be assumed to be a text
         file with a 4x4 transformation matrix (like the ``--trans`` MNE-C
         option). If trans is None, an identity transform will be used.
-    src : str | instance of SourceSpaces | None
+    src : path-like | instance of SourceSpaces | None
         Source space corresponding to the stc. If string, should be a source
         space filename. Can also be an instance of loaded or generated
         SourceSpaces. Can be None if ``forward`` is provided.
-    bem : str | dict | None
+    bem : path-like | dict | None
         BEM solution  corresponding to the stc. If string, should be a BEM
         solution filename (e.g., "sample-5120-5120-5120-bem-sol.fif").
         Can be None if ``forward`` is provided.

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -112,9 +112,9 @@ def simulate_sparse_stc(src, n_dipoles, times,
         The labels. The default is None, otherwise its size must be n_dipoles.
     %(random_state)s
     location : str
-        The label location to choose. Can be 'random' (default) or 'center'
-        to use :func:`mne.Label.center_of_mass`. Note that for 'center'
-        mode the label values are used as weights.
+        The label location to choose. Can be ``'random'`` (default) or
+        ``'center'`` to use :func:`mne.Label.center_of_mass`. Note that for
+        ``'center'`` mode the label values are used as weights.
 
         .. versionadded:: 0.13
     subject : str | None

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -91,7 +91,7 @@ def _write_stc(filename, tmin, tstep, vertices, data):
 
     Parameters
     ----------
-    filename : string
+    filename : path-like
         The name of the STC file.
     tmin : float
         The first time point of the data in seconds.
@@ -102,7 +102,6 @@ def _write_stc(filename, tmin, tstep, vertices, data):
     data : 2D array
         The data matrix (nvert * ntime).
     """
-    filename
     with open(filename, 'wb') as fid:
         # write start time in ms
         fid.write(np.array(1000 * tmin, dtype='>f4').tobytes())
@@ -135,7 +134,7 @@ def _read_w(filename):
 
     Parameters
     ----------
-    filename : string
+    filename : path-like
         The name of the w file.
 
     Returns
@@ -184,7 +183,7 @@ def _write_w(filename, vertices, data):
 
     Parameters
     ----------
-    filename: string
+    filename: path-like
         The name of the w file.
     vertices: array of int
         Vertex indices (0 based).
@@ -2063,8 +2062,8 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
         mri_resolution : bool
             It True the image is saved in MRI resolution.
 
-            .. warning:: If you have many time points, the file produced can be
-                         huge.
+            .. warning: If you have many time points the file produced can be
+                        huge. The default is ``mri_resolution=False``.
         format : str
             Either ``'nifti1'`` (default) or ``'nifti2'``.
 
@@ -2101,15 +2100,15 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
         src : instance of SourceSpaces
             The source spaces (should all be of type volume, or part of a
             mixed source space).
-        dest : 'mri' | 'surf'
-            If 'mri' the volume is defined in the coordinate system of
+        dest : ``'mri'`` | ``'surf'``
+            If ``'mri'`` the volume is defined in the coordinate system of
             the original T1 image. If 'surf' the coordinate system
             of the FreeSurfer surface is used (Surface RAS).
         mri_resolution : bool
             It True the image is saved in MRI resolution.
 
-            .. warning:: If you have many time points, the file produced can be
-                         huge.
+            .. warning: If you have many time points the file produced can be
+                        huge. The default is ``mri_resolution=False``.
         format : str
             Either 'nifti1' (default) or 'nifti2'.
 
@@ -3223,11 +3222,10 @@ def stc_near_sensors(evoked, trans, subject, distance=0.01, mode='sum',
     distance : float
         Distance (m) defining the activation "ball" of the sensor.
     mode : str
-        Can be "sum" to do a linear sum of weights, "weighted" to make this
-        a weighted sum, "nearest" to
-        use only the weight of the nearest sensor, or "single" to
-        do a distance-weight of the nearest sensor. Default is "sum".
-        See Notes.
+        Can be ``"sum"`` to do a linear sum of weights, ``"weighted"`` to make
+        this a weighted sum, ``"nearest"`` to use only the weight of the
+        nearest sensor, or ``"single"`` to do a distance-weight of the nearest
+        sensor. Default is ``"sum"``. See Notes.
 
         .. versionchanged:: 0.24
            Added "weighted" option.

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -284,20 +284,21 @@ class SourceSpaces(list):
             If True, show head surface.
         brain : bool | str
             If True, show the brain surfaces. Can also be a str for
-            surface type (e.g., 'pial', same as True). Default is None,
-            which means 'white' for surface source spaces and False otherwise.
+            surface type (e.g., ``'pial'``, same as True). Default is None,
+            which means ``'white'`` for surface source spaces and ``False``
+            otherwise.
         skull : bool | str | list of str | list of dict | None
             Whether to plot skull surface. If string, common choices would be
-            'inner_skull', or 'outer_skull'. Can also be a list to plot
+            ``'inner_skull'``, or ``'outer_skull'``. Can also be a list to plot
             multiple skull surfaces. If a list of dicts, each dict must
             contain the complete surface info (such as you get from
             :func:`mne.make_bem_model`). True is an alias of 'outer_skull'.
             The subjects bem and bem/flash folders are searched for the 'surf'
             files. Defaults to None, which is False for surface source spaces,
             and True otherwise.
-        subjects_dir : str | None
-            Path to SUBJECTS_DIR if it is not set in the environment.
-        trans : str | 'auto' | dict | None
+        subjects_dir : path-like | None
+            Path to ``SUBJECTS_DIR`` if it is not set in the environment.
+        trans : path-like | ``'auto'`` | dict | None
             The full path to the head<->MRI transform ``*-trans.fif`` file
             produced during coregistration. If trans is None, an identity
             matrix is assumed. This is only needed when the source space is in
@@ -440,7 +441,7 @@ class SourceSpaces(list):
 
         Parameters
         ----------
-        fname : str
+        fname : path-like
             File to write.
         %(overwrite)s
         %(verbose)s
@@ -456,13 +457,13 @@ class SourceSpaces(list):
 
         Parameters
         ----------
-        fname : str
+        fname : path-like
             Name of nifti or mgz file to write.
         include_surfaces : bool
             If True, include surface source spaces.
         include_discrete : bool
             If True, include discrete source spaces.
-        dest : 'mri' | 'surf'
+        dest : ``'mri'`` | ``'surf'``
             If 'mri' the volume is defined in the coordinate system of the
             original T1 image. If 'surf' the coordinate system of the
             FreeSurfer surface is used (Surface RAS).
@@ -1171,9 +1172,9 @@ def write_source_spaces(fname, src, *, overwrite=False, verbose=None):
 
     Parameters
     ----------
-    fname : str
-        The name of the file, which should end with -src.fif or
-        -src.fif.gz.
+    fname : path-like
+        The name of the file, which should end with ``-src.fif`` or
+        ``-src.fif.gz``.
     src : instance of SourceSpaces
         The source spaces (as returned by read_source_spaces).
     %(overwrite)s
@@ -2702,8 +2703,8 @@ def morph_source_spaces(src_from, subject_to, surf='white', subject_from=None,
     subject_from : str | None
         The "from" subject. For most source spaces this shouldn't need
         to be provided, since it is stored in the source space itself.
-    subjects_dir : str | None
-        Path to SUBJECTS_DIR if it is not set in the environment.
+    subjects_dir : path-like | None
+        Path to ``SUBJECTS_DIR`` if it is not set in the environment.
     %(verbose)s
 
     Returns

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -730,14 +730,14 @@ def read_curvature(filepath, binary=True):
 
     Parameters
     ----------
-    filepath : str
-        Input path to the .curv file.
+    filepath : path-like
+        Input path to the ``.curv`` file.
     binary : bool
         Specify if the output array is to hold binary values. Defaults to True.
 
     Returns
     -------
-    curv : array, shape=(n_vertices,)
+    curv : array of shape (n_vertices,)
         The curvature values loaded from the user given file.
     """
     with open(filepath, "rb") as fobj:
@@ -1608,8 +1608,8 @@ def read_tri(fname_in, swap=False, verbose=None):
 
     Parameters
     ----------
-    fname_in : str
-        Path to surface ASCII file (ending with '.tri').
+    fname_in : path-like
+        Path to surface ASCII file (ending with ``'.tri'``).
     swap : bool
         Assume the ASCII file vertex ordering is clockwise instead of
         counterclockwise.

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -70,12 +70,12 @@ def _stc_to_label(stc, src, smooth, subjects_dir=None):
         The source estimates.
     src : SourceSpaces | str | None
         The source space over which the source estimates are defined.
-        If it's a string it should the subject name (e.g. fsaverage).
-        Can be None if stc.subject is not None.
+        If it's a string it should be the subject name (e.g. ``'fsaverage'``').
+        Can be None if ``stc.subject`` is not None.
     smooth : int
         Number of smoothing iterations.
-    subjects_dir : str | None
-        Path to SUBJECTS_DIR if it is not set in the environment.
+    subjects_dir : path-like | None
+        Path to ``SUBJECTS_DIR`` if it is not set in the environment.
 
     Returns
     -------

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -589,9 +589,9 @@ def read_csd(fname):
 
     Parameters
     ----------
-    fname : str
-        The name of the file to read the CSD from. The extension '.h5' will be
-        appended if the given filename doesn't have it already.
+    fname : path-like
+        The name of the file to read the CSD from. The extension ``'.h5'`` will
+        be appended if the given filename doesn't have it already.
 
     Returns
     -------

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -387,7 +387,7 @@ def _compute_tfr(epoch_data, freqs, sfreq=1.0, method='morlet',
     Parameters
     ----------
     epoch_data : array of shape (n_epochs, n_channels, n_times)
-        The epochs.
+        The epochs.default ``'complex'``
     freqs : array-like of floats, shape (n_freqs)
         The frequencies.
     sfreq : float | int, default 1.0
@@ -419,9 +419,9 @@ def _compute_tfr(epoch_data, freqs, sfreq=1.0, method='morlet',
             Decimation may create aliasing artifacts, yet decimation
             is done after the convolutions.
 
-    output : str, default 'complex'
+    output : str
 
-        * 'complex' : single trial complex.
+        * 'complex' (default) : single trial complex.
         * 'power' : single trial power.
         * 'phase' : single trial phase.
         * 'avg_power' : average of single trial power.
@@ -1112,7 +1112,7 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin, TimeMixin):
 
         Parameters
         ----------
-        fname : str
+        fname : path-like
             The file name, which should end with ``-tfr.h5``.
         %(overwrite)s
         %(verbose)s
@@ -2568,7 +2568,7 @@ def write_tfrs(fname, tfr, overwrite=False, *, verbose=None):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         The file name, which should end with ``-tfr.h5``.
     tfr : AverageTFR | list of AverageTFR | EpochsTFR
         The TFR dataset, or list of TFR datasets, to save in one file.
@@ -2617,7 +2617,7 @@ def read_tfrs(fname, condition=None, *, verbose=None):
 
     Parameters
     ----------
-    fname : str
+    fname : path-like
         The file name, which should end with -tfr.h5 .
     condition : int or str | list of int or str | None
         The condition to load. If None, all conditions will be returned.

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -169,8 +169,8 @@ class Transform(dict):
 
         Parameters
         ----------
-        fname : str
-            The name of the file, which should end in '-trans.fif'.
+        fname : path-like
+            The name of the file, which should end in ``-trans.fif``.
         """
         write_trans(fname, self)
 
@@ -1778,7 +1778,7 @@ def apply_volume_registration(moving, static, reg_affine, sdr_morph=None,
     %(sdr_morph)s
     interpolation : str
         Interpolation to be used during the interpolation.
-        Can be "linear" (default) or "nearest".
+        Can be ``"linear"`` (default) or ``"nearest"``.
     cval : float | str
         The constant value to assume exists outside the bounds of the
         ``moving`` image domain. Can be a string percentage like ``'1%%'``

--- a/mne/utils/_logging.py
+++ b/mne/utils/_logging.py
@@ -237,7 +237,7 @@ def set_log_file(fname=None, output_format='%(message)s', overwrite=None):
 
     Parameters
     ----------
-    fname : str, or None
+    fname : path-like | None
         Filename of the log to print to. If None, stdout is used.
         To suppress log outputs, use set_log_level('WARNING').
     output_format : str

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -3004,10 +3004,10 @@ class Brain(object):
 
         Parameters
         ----------
-        filename : str
+        filename : path-like
             Path to new image file.
         mode : str
-            Either 'rgb' or 'rgba' for values to return.
+            Either ``'rgb'`` or ``'rgba'`` for values to return.
         """
         if filename is None:
             filename = _generate_default_filename(".png")
@@ -3021,7 +3021,7 @@ class Brain(object):
         Parameters
         ----------
         mode : str
-            Either 'rgb' or 'rgba' for values to return.
+            Either ``'rgb'`` or ``'rgba'`` for values to return.
         %(time_viewer_brain_screenshot)s
 
         Returns

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -538,11 +538,11 @@ def compare_fiff(fname_1, fname_2, fname_out=None, show=True, indent='    ',
 
     Parameters
     ----------
-    fname_1 : str
+    fname_1 : path-like
         First file to compare.
-    fname_2 : str
+    fname_2 : path-like
         Second file to compare.
-    fname_out : str | None
+    fname_out : path-like | None
         Filename to store the resulting diff. If None, a temporary
         file will be created.
     show : bool


### PR DESCRIPTION
Improves docstrings following #11473
I started chasing the `fname : str` to convert them to `path-like` and ended up also adding double backticks where they were missing.