### PR TITLE
Deprecate 'kind' and 'path' in favor of 'fname' in the layout reader

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -54,4 +54,4 @@ Bugs
 
 API changes
 ~~~~~~~~~~~
-- None yet
+- Deprecate arguments ``kind`` and ``path`` from `mne.channels.read_layout` in favor of a common argument ``fname`` (:gh:`11500` by `Mathieu Scheltienne`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -56,4 +56,4 @@ Bugs
 
 API changes
 ~~~~~~~~~~~
-- Deprecate arguments ``kind`` and ``path`` from `mne.channels.read_layout` in favor of a common argument ``fname`` (:gh:`11500` by `Mathieu Scheltienne`_)
+- Deprecate arguments ``kind`` and ``path`` from :func:`mne.channels.read_layout` in favor of a common argument ``fname`` (:gh:`11500` by `Mathieu Scheltienne`_)

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -260,12 +260,18 @@ def read_layout(kind=None, path=None, fname=None, *, scale=True):
         )
         if path is None:
             path = Path(__file__).parent / "data" / "layouts"
-        # kind should be the name as a string, but let's consider the case where
-        # the path to the file is provided instead.
+        # kind should be the name as a string, but let's consider the case
+        # where the path to the file is provided instead.
         kind = Path(kind)
-        if len(kind.suffix) == 0 and (path / kind.with_suffix(".lout")).exists():
+        if (
+            len(kind.suffix) == 0
+            and (path / kind.with_suffix(".lout")).exists()
+        ):
             kind = kind.with_suffix(".lout")
-        elif len(kind.suffix) == 0 and (path / kind.with_suffix(".lay")).exists():
+        elif (
+            len(kind.suffix) == 0
+            and (path / kind.with_suffix(".lay")).exists()
+        ):
             kind = kind.with_suffix(".lay")
 
         fname = kind if kind.exists() else path / kind.name
@@ -289,11 +295,8 @@ def read_layout(kind=None, path=None, fname=None, *, scale=True):
             elif (directory / fname).with_suffix(".lay").exists():
                 fname = (directory / fname).with_suffix(".lay")
         # if not, it must be a valid path provided as str or Path
-        fname = _check_fname(
-            fname, "read", must_exist=True, name="layout"
-        )
+        fname = _check_fname(fname, "read", must_exist=True, name="layout")
         kind = fname.stem
-
     box, pos, names, ids = readers[fname.suffix](fname)
 
     if scale:

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -163,18 +163,15 @@ def _read_lay(fname):
     return box, pos, names, ids
 
 
-def read_layout(kind=None, path=None, fname=None, *, scale=True):
+def read_layout(fname=None, path="", scale=True, *, kind=None):
     """Read layout from a file.
 
     Parameters
     ----------
-    kind : str | None
-        The name of the ``.lout`` file (e.g. ``kind='Vectorview-all'`` for
-        ``'Vectorview-all.lout'``).
-
-        .. deprecated:: v1.4
-           The ``kind`` and ``path`` parameters will be removed in version
-           1.5. Please use the ``fname`` parameter instead.
+    fname : path-like | str
+        Either the path to a ``.lout`` or ``.lay`` file or the name of a
+        built-in layout. c.f. Notes for a list of the available built-in
+        layouts.
     path : path-like | None
         The path of the folder containing the Layout file. Defaults to the
         ``mne/channels/data/layouts`` folder inside your mne-python
@@ -183,13 +180,16 @@ def read_layout(kind=None, path=None, fname=None, *, scale=True):
         .. deprecated:: v1.4
            The ``kind`` and ``path`` parameters will be removed in version
            1.5. Please use the ``fname`` parameter instead.
-    fname : path-like | str
-        Either the path to a ``.lout`` or ``.lay`` file or the name of a
-        built-in layout. c.f. Notes for a list of the available built-in
-        layouts.
     scale : bool
         Apply useful scaling for out the box plotting using ``layout.pos``.
         Defaults to True.
+    kind : str | None
+        The name of the ``.lout`` file (e.g. ``kind='Vectorview-all'`` for
+        ``'Vectorview-all.lout'``).
+
+        .. deprecated:: v1.4
+           The ``kind`` and ``path`` parameters will be removed in version
+           1.5. Please use the ``fname`` parameter instead.
 
     Returns
     -------
@@ -202,7 +202,7 @@ def read_layout(kind=None, path=None, fname=None, *, scale=True):
 
     Notes
     -----
-    Valid ``fname`` (or ``kind``) arguments are:
+    Valid ``fname`` arguments are:
 
     .. table::
        :widths: auto
@@ -258,7 +258,7 @@ def read_layout(kind=None, path=None, fname=None, *, scale=True):
             "Argument 'kind' and 'path' are deprecated in favor of 'fname'.",
             DeprecationWarning,
         )
-        if path is None:
+        if path == "" or path is None:
             path = Path(__file__).parent / "data" / "layouts"
         # kind should be the name as a string, but let's consider the case
         # where the path to the file is provided instead.
@@ -281,9 +281,11 @@ def read_layout(kind=None, path=None, fname=None, *, scale=True):
             )
         kind = fname.stem
     else:
-        if kind is not None:  # to be removed along the deprecated argument
-            raise ValueError(
-                "Argument 'kind' and 'path' should be None if 'fname' is used."
+        if kind is not None or path != "":  # to be removed along the deprecated argument
+            warn(
+                "Argument 'kind' and 'path' are deprecated in favor of "
+                "'fname' and should not be provided alongside 'fname'.",
+                DeprecationWarning,
             )
         if isinstance(fname, str):
             # is it a built-in layout?

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -298,6 +298,8 @@ def read_layout(fname=None, path="", scale=True, *, kind=None):
                 fname = (directory / fname).with_suffix(".lay")
         # if not, it must be a valid path provided as str or Path
         fname = _check_fname(fname, "read", must_exist=True, name="layout")
+        # and it must have a valid extension
+        _check_option("fname extension", fname.suffix, readers)
         kind = fname.stem
     box, pos, names, ids = readers[fname.suffix](fname)
 

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -281,7 +281,8 @@ def read_layout(fname=None, path="", scale=True, *, kind=None):
             )
         kind = fname.stem
     else:
-        if kind is not None or path != "":  # to be removed along the deprecated argument
+        # to be removed along the deprecated argument
+        if kind is not None or path != "":
             warn(
                 "Argument 'kind' and 'path' are deprecated in favor of "
                 "'fname' and should not be provided alongside 'fname'.",

--- a/mne/channels/tests/test_layout.py
+++ b/mne/channels/tests/test_layout.py
@@ -54,22 +54,44 @@ def _get_test_info():
 
 def test_io_layout_lout(tmp_path):
     """Test IO with .lout files."""
-    layout = read_layout('Vectorview-all', scale=False)
+    with pytest.warns(
+        DeprecationWarning, match="'kind' and 'path' are deprecated"
+    ):
+        layout = read_layout('Vectorview-all', scale=False)
     layout.save(tmp_path / "foobar.lout")
+    with pytest.warns(
+        DeprecationWarning, match="'kind' and 'path' are deprecated"
+    ):
+        layout_read = read_layout(
+            tmp_path / "foobar.lout", path="./", scale=False
+        )
+    assert_array_almost_equal(layout.pos, layout_read.pos, decimal=2)
+    assert layout.names == layout_read.names
+    assert "<Layout |" in layout.__repr__()
+
+    # with fname
+    layout = read_layout(fname="Vectorview-all", scale=False)
+    layout.save(tmp_path / "foobar.lout", overwrite=True)
     layout_read = read_layout(
-        tmp_path / "foobar.lout", path="./", scale=False
+        fname=tmp_path / "foobar.lout", scale=False,
     )
     assert_array_almost_equal(layout.pos, layout_read.pos, decimal=2)
     assert layout.names == layout_read.names
     assert "<Layout |" in layout.__repr__()
 
+    # deprecation
+    with pytest.raises(ValueError, match="'kind' and 'path' should be None"):
+        layout_read = read_layout(
+            kind="Vectorview-all", fname=tmp_path / "foobar.lout", scale=False,
+        )
+
 
 def test_io_layout_lay(tmp_path):
     """Test IO with .lay files."""
-    layout = read_layout('CTF151', scale=False)
+    layout = read_layout(fname="CTF151", scale=False)
     layout.save(str(tmp_path / "foobar.lay"))
     layout_read = read_layout(
-        str(tmp_path / "foobar.lay"), path="./", scale=False
+        fname = tmp_path / "foobar.lay", scale=False
     )
     assert_array_almost_equal(layout.pos, layout_read.pos, decimal=2)
     assert layout.names == layout_read.names
@@ -143,14 +165,20 @@ def test_make_eeg_layout(tmp_path):
     """Test creation of EEG layout."""
     tmp_name = 'foo'
     lout_name = 'test_raw'
-    lout_orig = read_layout(kind=lout_name, path=lout_path)
+    with pytest.warns(
+        DeprecationWarning, match="'kind' and 'path' are deprecated"
+    ):
+        lout_orig = read_layout(kind=lout_name, path=lout_path)
     info = read_info(fif_fname)
     info['bads'].append(info['ch_names'][360])
     layout = make_eeg_layout(info, exclude=[])
     assert_array_equal(len(layout.names), len([ch for ch in info['ch_names']
                                                if ch.startswith('EE')]))
     layout.save(str(tmp_path / (tmp_name + ".lout")))
-    lout_new = read_layout(kind=tmp_name, path=tmp_path, scale=False)
+    with pytest.warns(
+        DeprecationWarning, match="'kind' and 'path' are deprecated"
+    ):
+        lout_new = read_layout(kind=tmp_name, path=tmp_path, scale=False)
     assert_array_equal(lout_new.kind, tmp_name)
     assert_allclose(layout.pos, lout_new.pos, atol=0.1)
     assert_array_equal(lout_orig.names, lout_new.names)
@@ -168,10 +196,16 @@ def test_make_grid_layout(tmp_path):
     """Test creation of grid layout."""
     tmp_name = 'bar'
     lout_name = 'test_ica'
-    lout_orig = read_layout(kind=lout_name, path=lout_path)
+    with pytest.warns(
+        DeprecationWarning, match="'kind' and 'path' are deprecated"
+    ):
+        lout_orig = read_layout(kind=lout_name, path=lout_path)
     layout = make_grid_layout(_get_test_info())
     layout.save(str(tmp_path / (tmp_name + ".lout")))
-    lout_new = read_layout(kind=tmp_name, path=tmp_path)
+    with pytest.warns(
+        DeprecationWarning, match="'kind' and 'path' are deprecated"
+    ):
+        lout_new = read_layout(kind=tmp_name, path=tmp_path)
     assert_array_equal(lout_new.kind, tmp_name)
     assert_array_equal(lout_orig.pos, lout_new.pos)
     assert_array_equal(lout_orig.names, lout_new.names)

--- a/mne/channels/tests/test_layout.py
+++ b/mne/channels/tests/test_layout.py
@@ -155,23 +155,17 @@ def test_find_topomap_coords():
 
 def test_make_eeg_layout(tmp_path):
     """Test creation of EEG layout."""
-    tmp_name = 'foo'
-    lout_name = 'test_raw'
-    with pytest.warns(
-        DeprecationWarning, match="'kind' and 'path' are deprecated"
-    ):
-        lout_orig = read_layout(kind=lout_name, path=lout_path)
+    lout_orig = read_layout(fname=lout_path / "test_raw.lout")
     info = read_info(fif_fname)
-    info['bads'].append(info['ch_names'][360])
+    info["bads"].append(info["ch_names"][360])
     layout = make_eeg_layout(info, exclude=[])
-    assert_array_equal(len(layout.names), len([ch for ch in info['ch_names']
-                                               if ch.startswith('EE')]))
-    layout.save(str(tmp_path / (tmp_name + ".lout")))
-    with pytest.warns(
-        DeprecationWarning, match="'kind' and 'path' are deprecated"
-    ):
-        lout_new = read_layout(kind=tmp_name, path=tmp_path, scale=False)
-    assert_array_equal(lout_new.kind, tmp_name)
+    assert_array_equal(
+        len(layout.names),
+        len([ch for ch in info["ch_names"] if ch.startswith("EE")]),
+    )
+    layout.save(str(tmp_path / "foo.lout"))
+    lout_new = read_layout(fname=tmp_path / "foo.lout", scale=False)
+    assert_array_equal(lout_new.kind, "foo")
     assert_allclose(layout.pos, lout_new.pos, atol=0.1)
     assert_array_equal(lout_orig.names, lout_new.names)
 
@@ -186,19 +180,11 @@ def test_make_eeg_layout(tmp_path):
 
 def test_make_grid_layout(tmp_path):
     """Test creation of grid layout."""
-    tmp_name = 'bar'
-    lout_name = 'test_ica'
-    with pytest.warns(
-        DeprecationWarning, match="'kind' and 'path' are deprecated"
-    ):
-        lout_orig = read_layout(kind=lout_name, path=lout_path)
+    lout_orig = read_layout(fname=lout_path / "test_ica.lout")
     layout = make_grid_layout(_get_test_info())
-    layout.save(str(tmp_path / (tmp_name + ".lout")))
-    with pytest.warns(
-        DeprecationWarning, match="'kind' and 'path' are deprecated"
-    ):
-        lout_new = read_layout(kind=tmp_name, path=tmp_path)
-    assert_array_equal(lout_new.kind, tmp_name)
+    layout.save(str(tmp_path / "bar.lout"))
+    lout_new = read_layout(fname=tmp_path / "bar.lout")
+    assert_array_equal(lout_new.kind, "bar")
     assert_array_equal(lout_orig.pos, lout_new.pos)
     assert_array_equal(lout_orig.names, lout_new.names)
 

--- a/mne/channels/tests/test_layout.py
+++ b/mne/channels/tests/test_layout.py
@@ -54,22 +54,6 @@ def _get_test_info():
 
 def test_io_layout_lout(tmp_path):
     """Test IO with .lout files."""
-    with pytest.warns(
-        DeprecationWarning, match="'kind' and 'path' are deprecated"
-    ):
-        layout = read_layout('Vectorview-all', scale=False)
-    layout.save(tmp_path / "foobar.lout")
-    with pytest.warns(
-        DeprecationWarning, match="'kind' and 'path' are deprecated"
-    ):
-        layout_read = read_layout(
-            tmp_path / "foobar.lout", path="./", scale=False
-        )
-    assert_array_almost_equal(layout.pos, layout_read.pos, decimal=2)
-    assert layout.names == layout_read.names
-    assert "<Layout |" in layout.__repr__()
-
-    # with fname
     layout = read_layout(fname="Vectorview-all", scale=False)
     layout.save(tmp_path / "foobar.lout", overwrite=True)
     layout_read = read_layout(
@@ -80,10 +64,18 @@ def test_io_layout_lout(tmp_path):
     assert "<Layout |" in layout.__repr__()
 
     # deprecation
-    with pytest.raises(ValueError, match="'kind' and 'path' should be None"):
+    with pytest.warns(DeprecationWarning, match="should not be provided"):
         layout_read = read_layout(
-            kind="Vectorview-all", fname=tmp_path / "foobar.lout", scale=False,
+            fname=tmp_path / "foobar.lout", kind="Vectorview-all", scale=False,
         )
+    with pytest.warns(DeprecationWarning, match="should not be provided"):
+        layout_read = read_layout(
+            fname=tmp_path / "foobar.lout", path=None, scale=False,
+        )
+    with pytest.warns(
+        DeprecationWarning, match="'kind' and 'path' are deprecated"
+    ):
+        layout_read = read_layout(kind="Vectorview-all", scale=False)
 
 
 def test_io_layout_lay(tmp_path):

--- a/mne/channels/tests/test_layout.py
+++ b/mne/channels/tests/test_layout.py
@@ -91,7 +91,7 @@ def test_io_layout_lay(tmp_path):
     layout = read_layout(fname="CTF151", scale=False)
     layout.save(str(tmp_path / "foobar.lay"))
     layout_read = read_layout(
-        fname = tmp_path / "foobar.lay", scale=False
+        fname=tmp_path / "foobar.lay", scale=False
     )
     assert_array_almost_equal(layout.pos, layout_read.pos, decimal=2)
     assert layout.names == layout_read.names


### PR DESCRIPTION
Closes #11483

As discussed in #11483, those 2 arguments don't play well and could be replaced by a common explicit `fname` argument.