### PR TITLE
BUG: Fix deprecated API usage in example

### DIFF
--- a/examples/visualization/3d_to_2d.py
+++ b/examples/visualization/3d_to_2d.py
@@ -122,7 +122,7 @@ ax.set_axis_off()
 # lt.save(layout_path / layout_name)  # save if we want
 
 # # We've already got the layout, load it
-lt = mne.channels.read_layout(layout_name, path=layout_path, scale=False)
+lt = mne.channels.read_layout(layout_path / layout_name, scale=False)
 x = lt.pos[:, 0] * float(im.shape[1])
 y = (1 - lt.pos[:, 1]) * float(im.shape[0])  # Flip the y-position
 fig, ax = plt.subplots()


### PR DESCRIPTION
Just a tiny commit following https://github.com/mne-tools/mne-python/pull/11500 to avoid using the deprecated arguments. Should fix the [CircleCI main failure](https://app.circleci.com/pipelines/github/mne-tools/mne-python/18112/workflows/37b4fa1d-378d-458e-9153-401211685e91/jobs/52763).