### PR TITLE
MAINT: Avoid bad version for nb tests

### DIFF
--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -94,8 +94,8 @@ jobs:
           use-mamba: true
       - shell: bash -el {0}
         run: |
-          # TODO: As of 2023/02/28, ipython 8.11 breaks our notebook tests
-          mamba install -c conda-forge "vtk>=9.2=*osmesa*" "ipython!=8.11"
+          # TODO: As of 2023/02/28, notebook tests need a pin
+          mamba install -c conda-forge "vtk>=9.2=*osmesa*" "jupyter_console!=6.6.2"
         name: 'Install OSMesa VTK variant'
       - shell: bash -el {0}
         run: |
@@ -117,7 +117,7 @@ jobs:
         run: ./tools/github_actions_download.sh
         name: 'Download testing data'
       - shell: bash -el {0}
-        run: pytest --tb=short -m "not pgtest" --cov=mne --cov-report=xml --cov-report=html -vv mne/viz
+        run: pytest --tb=short -m "not pgtest" --cov=mne --cov-report=xml --cov-report=html -vv mne/viz/_brain/tests/test_notebook.py
         name: 'Run viz tests'
       - uses: codecov/codecov-action@v3
         if: success()

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -95,7 +95,7 @@ jobs:
       - shell: bash -el {0}
         run: |
           # TODO: As of 2023/02/28, notebook tests need a pin
-          mamba install -c conda-forge "vtk>=9.2=*osmesa*" "jupyter_console!=6.6.2"
+          mamba install -c conda-forge "vtk>=9.2=*osmesa*" "imageio=2.25.1" "ipython=8.10.0" "jupyter_console==6.6.1" "libnghttp2=1.51.0" "pooch=1.6.0" "prompt-toolkit=3.0.36" "prompt_toolkit=3.0.36" "tifffile=2023.2.3" "wrapt=1.14.1" "xorg-libx11=1.7.2"
         name: 'Install OSMesa VTK variant'
       - shell: bash -el {0}
         run: |

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -94,7 +94,8 @@ jobs:
           use-mamba: true
       - shell: bash -el {0}
         run: |
-          conda install -c conda-forge "vtk>=9.2=*osmesa*"
+          # TODO: As of 2023/02/28, ipython 8.11 breaks our notebook tests
+          conda install -c conda-forge "vtk>=9.2=*osmesa*" "ipython!=8.11"
         name: 'Install OSMesa VTK variant'
       - shell: bash -el {0}
         run: |

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -75,7 +75,7 @@ jobs:
 
   notebook:
     timeout-minutes: 90
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash
@@ -118,7 +118,6 @@ jobs:
         run: ./tools/github_actions_download.sh
         name: 'Download testing data'
       - shell: bash -el {0}
-        # TODO: Revert making this list short
         run: pytest --tb=short -m "not pgtest" --cov=mne --cov-report=xml --cov-report=html -vv mne/viz
         name: 'Run viz tests'
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -94,8 +94,8 @@ jobs:
           use-mamba: true
       - shell: bash -el {0}
         run: |
-          # TODO: As of 2023/02/28, notebook tests need a pin
-          mamba install -c conda-forge "vtk>=9.2=*osmesa*" "imageio=2.25.1" "ipython=8.10.0" "jupyter_console==6.6.1" "libnghttp2=1.51.0" "mesalib=21.2.5" "pooch=1.6.0" "prompt-toolkit=3.0.36" "prompt_toolkit=3.0.36" "tifffile=2023.2.3" "wrapt=1.14.1" "xorg-libx11=1.7.2"
+          # TODO: As of 2023/02/28, notebook tests need a pinned mesalib
+          mamba install -c conda-forge "vtk>=9.2=*osmesa*" "mesalib=21.2.5"
           mamba list
         name: 'Install OSMesa VTK variant'
       - shell: bash -el {0}
@@ -119,7 +119,7 @@ jobs:
         name: 'Download testing data'
       - shell: bash -el {0}
         # TODO: Revert making this list short
-        run: pytest --tb=short -m "not pgtest" --cov=mne --cov-report=xml --cov-report=html -vv -x mne/viz/_brain/tests/test_notebook.py
+        run: pytest --tb=short -m "not pgtest" --cov=mne --cov-report=xml --cov-report=html -vv mne/viz
         name: 'Run viz tests'
       - uses: codecov/codecov-action@v3
         if: success()

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -75,7 +75,7 @@ jobs:
 
   notebook:
     timeout-minutes: 90
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash
@@ -96,6 +96,7 @@ jobs:
         run: |
           # TODO: As of 2023/02/28, notebook tests need a pin
           mamba install -c conda-forge "vtk>=9.2=*osmesa*" "imageio=2.25.1" "ipython=8.10.0" "jupyter_console==6.6.1" "libnghttp2=1.51.0" "pooch=1.6.0" "prompt-toolkit=3.0.36" "prompt_toolkit=3.0.36" "tifffile=2023.2.3" "wrapt=1.14.1" "xorg-libx11=1.7.2"
+          mamba list
         name: 'Install OSMesa VTK variant'
       - shell: bash -el {0}
         run: |
@@ -117,7 +118,8 @@ jobs:
         run: ./tools/github_actions_download.sh
         name: 'Download testing data'
       - shell: bash -el {0}
-        run: pytest --tb=short -m "not pgtest" --cov=mne --cov-report=xml --cov-report=html -vv mne/viz/_brain/tests/test_notebook.py
+        # TODO: Revert making this list short
+        run: pytest --tb=short -m "not pgtest" --cov=mne --cov-report=xml --cov-report=html -vv -x mne/viz/_brain/tests/test_notebook.py
         name: 'Run viz tests'
       - uses: codecov/codecov-action@v3
         if: success()

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -95,7 +95,7 @@ jobs:
       - shell: bash -el {0}
         run: |
           # TODO: As of 2023/02/28, ipython 8.11 breaks our notebook tests
-          conda install -c conda-forge "vtk>=9.2=*osmesa*" "ipython!=8.11"
+          mamba install -c conda-forge "vtk>=9.2=*osmesa*" "ipython!=8.11"
         name: 'Install OSMesa VTK variant'
       - shell: bash -el {0}
         run: |

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -95,7 +95,7 @@ jobs:
       - shell: bash -el {0}
         run: |
           # TODO: As of 2023/02/28, notebook tests need a pin
-          mamba install -c conda-forge "vtk>=9.2=*osmesa*" "imageio=2.25.1" "ipython=8.10.0" "jupyter_console==6.6.1" "libnghttp2=1.51.0" "pooch=1.6.0" "prompt-toolkit=3.0.36" "prompt_toolkit=3.0.36" "tifffile=2023.2.3" "wrapt=1.14.1" "xorg-libx11=1.7.2"
+          mamba install -c conda-forge "vtk>=9.2=*osmesa*" "imageio=2.25.1" "ipython=8.10.0" "jupyter_console==6.6.1" "libnghttp2=1.51.0" "mesalib=21.2.5" "pooch=1.6.0" "prompt-toolkit=3.0.36" "prompt_toolkit=3.0.36" "tifffile=2023.2.3" "wrapt=1.14.1" "xorg-libx11=1.7.2"
           mamba list
         name: 'Install OSMesa VTK variant'
       - shell: bash -el {0}

--- a/doc/install/advanced.rst
+++ b/doc/install/advanced.rst
@@ -93,7 +93,7 @@ MESA to render properly):
 
 .. code-block:: console
 
-    $ conda install -c conda-forge "vtk>=9.2=*osmesa*"
+    $ conda install -c conda-forge "vtk>=9.2=*osmesa*" "mesalib=21.2.5"
 
 Using the development version
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
 - imageio-ffmpeg>=0.4.1
 - vtk>=9.2
 - traitlets
-- pyvista>=0.32,!=0.35.2
+- pyvista>=0.32,!=0.35.2,!=0.38.0,!=0.38.1,!=0.38.2,!=0.38.3
 - pyvistaqt>=0.4
 - qdarkstyle
 - darkdetect


### PR DESCRIPTION
Based on a diff of what `conda` installs between when [it worked](https://github.com/mne-tools/mne-python/actions/runs/4270263385/jobs/7433949955) and [didn't](https://github.com/mne-tools/mne-python/actions/runs/4306180548/jobs/7509648948), it's most likely either ipython 8.11 or jupyter_console 6.6.2 that broke our `notebook` run. This avoids `8.11` for now, let's see if it comes back green. If it does, I'll merge to get `main` green again, then try to figure out how to fix it properly.