### PR TITLE
Ignore pkg_resources deprecations

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1012,7 +1012,6 @@ def reset_warnings(gallery_conf, fname):
         'Implementing implicit namespace packages',
         'Deprecated call to `pkg_resources',
         # nilearn
-        r'The register_cmap function was deprecated in Matplotlib 3\.7',
         'pkg_resources is deprecated as an API',
         r'The .* was deprecated in Matplotlib 3\.7',
     ):

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1013,6 +1013,8 @@ def reset_warnings(gallery_conf, fname):
         'Deprecated call to `pkg_resources',
         # nilearn
         r'The register_cmap function was deprecated in Matplotlib 3\.7',
+        'pkg_resources is deprecated as an API',
+        r'The .* was deprecated in Matplotlib 3\.7',
     ):
         warnings.filterwarnings(  # deal with other modules having bad imports
             'ignore', message=".*%s.*" % key, category=DeprecationWarning)

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -137,6 +137,7 @@ def pytest_configure(config):
     # pkg_resources usage bug
     ignore:Implementing implicit namespace packages.*:DeprecationWarning
     ignore:Deprecated call to `pkg_resources.*:DeprecationWarning
+    ignore:pkg_resources is deprecated as an API.*:DeprecationWarning
     """.format(first_kind)  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()


### PR DESCRIPTION
This should fix CIs that hit a deprecation warning related to `pkg_resources` (follow-up to #11478).