### PR TITLE
Refactor `mne.sys_info()`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include requirements_hdf5.txt
 include requirements_testing.txt
 include requirements_testing_extra.txt
 include requirements_doc.txt
+include requirements_browser.txt
 include mne/__init__.py
 
 recursive-include examples *.py

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,7 +123,6 @@ stages:
     - bash: |
         set -e
         mne sys_info -pd
-        mne sys_info -pd | grep "qtpy: .*{PySide6=.*}$"
       displayName: Print config
     # Uncomment if "xcb not found" Qt errors/segfaults come up again
     # - bash: |
@@ -198,7 +197,6 @@ stages:
     - bash: |
         set -e
         mne sys_info -pd
-        mne sys_info -pd | grep "qtpy: .*{PySide6=.*}$"
         pytest -m "not slowtest" ${TEST_OPTIONS}
         python -m pip uninstall -yq PySide6
       displayName: 'PySide6'
@@ -206,7 +204,6 @@ stages:
         set -e
         python -m pip install PyQt6
         mne sys_info -pd
-        mne sys_info -pd | grep "^qtpy: .*{PyQt6=.*}$"
         pytest -m "not slowtest" ${TEST_OPTIONS}
         python -m pip uninstall -yq PyQt6 PyQt6-sip PyQt6-Qt6
       displayName: 'PyQt6'
@@ -214,7 +211,6 @@ stages:
         set -e
         python -m pip install PySide2
         mne sys_info -pd
-        mne sys_info -pd | grep "^qtpy: .*{PySide2=.*}$"
         pytest -m "not slowtest" ${TEST_OPTIONS}
         python -m pip uninstall -yq PySide2
       displayName: 'PySide2'
@@ -223,7 +219,6 @@ stages:
         set -e
         python -m pip install PyQt5
         mne sys_info -pd
-        mne sys_info -pd | grep "^qtpy: .*{PyQt5=.*}$"
         pytest -m "not slowtest" ${TEST_OPTIONS}
         python -m pip uninstall -yq PyQt5 PyQt5-sip PyQt5-Qt5
       displayName: 'PyQt5'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,7 +198,7 @@ stages:
         set -e
         mne sys_info -pd
         pytest -m "not slowtest" ${TEST_OPTIONS}
-        python -m pip uninstall -yq PySide6
+        python -m pip uninstall -yq PySide6 PySide6-Essentials PySide6-Addons shiboken6
       displayName: 'PySide6'
     - bash: |
         set -e

--- a/mne/commands/mne_sys_info.py
+++ b/mne/commands/mne_sys_info.py
@@ -18,18 +18,27 @@ import mne
 def run():
     """Run command."""
     parser = mne.commands.utils.get_optparser(__file__, usage='mne sys_info')
+    parser.set_defaults(unicode=False)
     parser.add_option('-p', '--show-paths', dest='show_paths',
                       help='Show module paths', action='store_true')
     parser.add_option('-d', '--developer', dest='developer',
                       help='Show additional developer module information',
                       action='store_true')
+    parser.add_option('-u', '--unicode', dest='unicode',
+                      help='Use Unicode symbols', action='store_true')
+    parser.add_option('-a', '--ascii', dest='unicode',
+                      help='Use ASCII symbols', action='store_false')
     options, args = parser.parse_args()
     dependencies = 'developer' if options.developer else 'user'
     if len(args) != 0:
         parser.print_help()
         sys.exit(1)
 
-    mne.sys_info(show_paths=options.show_paths, dependencies=dependencies)
+    mne.sys_info(
+        show_paths=options.show_paths,
+        dependencies=dependencies,
+        unicode=options.unicode
+    )
 
 
 mne.utils.run_command_if_main()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -138,6 +138,8 @@ def pytest_configure(config):
     ignore:Implementing implicit namespace packages.*:DeprecationWarning
     ignore:Deprecated call to `pkg_resources.*:DeprecationWarning
     ignore:pkg_resources is deprecated as an API.*:DeprecationWarning
+    # some packages during sys_info
+    ignore:Implicit None on return values is deprecated.*:DeprecationWarning
     """.format(first_kind)  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -603,4 +603,3 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
                 out("\n")
         if unavailable:
             out(f"Not installed: {', '.join(unavailable)}\n")
-

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -17,8 +17,7 @@ import sys
 import tempfile
 from collections import defaultdict
 from functools import partial
-from importlib import import_module
-from importlib.metadata import requires
+from importlib import import_module, metadata
 from pathlib import Path
 
 from .check import (_validate_type, _check_qt_version, _check_option,
@@ -553,7 +552,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
         out(f'{int(psutil.virtual_memory().total / 2**30)} GB\n')
 
     libs = _get_numpy_libs()
-    requirements = requires("mne")
+    requirements = metadata.requires("mne")
     packages = defaultdict(list, {"core": []})
 
     for requirement in requirements:
@@ -588,7 +587,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
                 else:
                     out(f"{name}".ljust(ljust))
                 try:
-                    out(module.__version__.lstrip("v"))
+                    out(metadata.version(name))
                 except AttributeError:
                     out("?")
                 if name == "numpy":

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -17,6 +17,7 @@ import sys
 import tempfile
 from collections import defaultdict
 from functools import partial
+from importlib import import_module
 from importlib.metadata import requires
 from pathlib import Path
 
@@ -578,7 +579,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
         unavailable = []
         for name in packages[group]:
             try:
-                module = __import__(name)
+                module = import_module(name)
             except ModuleNotFoundError:
                 unavailable.append(name)
             else:

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -510,7 +510,8 @@ def _get_import_name(package_name):
     mapping = {
         "scikit-learn": "sklearn",
         "edflib-python": "EDFlib",
-        "codespell": "codespell_lib"
+        "codespell": "codespell_lib",
+        "pyside6": "PySide6"
     }
     if package_name.lower() in mapping:
         return mapping[package_name.lower()]
@@ -609,7 +610,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='core', unicode=True):
                     out(f"{name}".ljust(ljust))
                 try:
                     out(metadata.version(name))
-                except AttributeError:
+                except (AttributeError, metadata.PackageNotFoundError):
                     out("?")
                 if name == "numpy":
                     out(f" ({libs})")

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -518,7 +518,7 @@ def _get_import_name(package_name):
         return package_name.replace("-", "_")
 
 
-def sys_info(fid=None, show_paths=False, *, dependencies='user'):
+def sys_info(fid=None, show_paths=False, *, dependencies='core'):
     """Print system information.
 
     This function prints system information useful when triaging bugs.
@@ -530,13 +530,17 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
         use :data:`sys.stdout`.
     show_paths : bool
         If True, print paths for each module.
-    dependencies : 'user' | 'developer'
-        Show dependencies relevant for users (default) or for developers.
+    dependencies : 'core' | 'all'
+        Show only core or include extra dependencies.
 
         .. versionadded:: 0.24
     """
     _validate_type(dependencies, str)
-    _check_option('dependencies', dependencies, ('user', 'developer'))
+    _check_option(
+        'dependencies',
+        dependencies,
+        ('core', 'all', 'user', 'developer')
+    )
     ljust = 23
     platform_str = platform.platform()
     if platform.system() == 'Darwin' and sys.version_info[:2] < (3, 8):
@@ -574,8 +578,9 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
             requirement, extra = requirement.split(";")
         requirement = requirement.split(">=")[0]  # strip version
         if extra is not None:
-            group = extra.split(" == ")[-1].replace('"', "")
-            packages[group].append(requirement)
+            if dependencies in ("all", "developer"):
+                group = extra.split(" == ")[-1].replace('"', "")
+                packages[group].append(requirement)
         else:
             packages["core"].append(requirement)
 

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -29,7 +29,7 @@ from ._logging import warn, logger
 
 _temp_home_dir = None
 
-_UNICODE = sys.stdout.encoding.lower().startswith('utf')
+_UNICODE_SUPPORT = sys.stdout.encoding.lower().startswith('utf')
 
 
 def set_cache_dir(cache_dir):
@@ -518,7 +518,7 @@ def _get_import_name(package_name):
         return package_name.replace("-", "_")
 
 
-def sys_info(fid=None, show_paths=False, *, dependencies='core'):
+def sys_info(fid=None, show_paths=False, *, dependencies='core', unicode=True):
     """Print system information.
 
     This function prints system information useful when triaging bugs.
@@ -532,6 +532,8 @@ def sys_info(fid=None, show_paths=False, *, dependencies='core'):
         If True, print paths for each module.
     dependencies : 'core' | 'all'
         Show only core or include extra dependencies.
+    unicode : bool
+        Include unicode characters for nicer output.
 
         .. versionadded:: 0.24
     """
@@ -600,7 +602,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='core'):
             except ModuleNotFoundError:
                 unavailable.append(name)
             else:
-                if _UNICODE:
+                if unicode and _UNICODE_SUPPORT:
                     out(f"✔︎ {name}".ljust(ljust + 1))
                 else:
                     out(f"{name}".ljust(ljust))
@@ -625,7 +627,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='core'):
                     out(f" ({op.dirname(module.__file__)})")
                 out("\n")
         if unavailable:
-            if _UNICODE:
+            if unicode and _UNICODE_SUPPORT:
                 out(f"✘ Not installed: {', '.join(unavailable)}\n")
             else:
                 out(f"Not installed: {', '.join(unavailable)}\n")

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -29,6 +29,8 @@ from ._logging import warn, logger
 
 _temp_home_dir = None
 
+_UNICODE = sys.stdout.encoding.lower().startswith('utf')
+
 
 def set_cache_dir(cache_dir):
     """Set the directory to be used for temporary file storage.
@@ -522,7 +524,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
     """
     _validate_type(dependencies, str)
     _check_option('dependencies', dependencies, ('user', 'developer'))
-    ljust = 21
+    ljust = 22
     platform_str = platform.platform()
     if platform.system() == 'Darwin' and sys.version_info[:2] < (3, 8):
         # platform.platform() in Python < 3.8 doesn't call
@@ -580,7 +582,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
             except ModuleNotFoundError:
                 unavailable.append(name)
             else:
-                out(f"{name}".ljust(ljust))
+                out(f"{'✔︎ ' if _UNICODE else ''}{name}".ljust(ljust))
                 try:
                     out(module.__version__.lstrip("v"))
                 except AttributeError:

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -607,4 +607,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
                     out(f" ({op.dirname(module.__file__)})")
                 out("\n")
         if unavailable:
-            out(f"Not installed: {', '.join(unavailable)}\n")
+            if _UNICODE:
+                out(f"✘ Not installed: {', '.join(unavailable)}\n")
+            else:
+                out(f"Not installed: {', '.join(unavailable)}\n")

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -575,6 +575,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='core', unicode=True):
     packages = defaultdict(list, {"core": []})
 
     for requirement in requirements:
+        requirement = requirement.lower()
         extra = None
         if "extra" in requirement:  # extra (optional)
             requirement, extra = requirement.split(";")

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -18,6 +18,7 @@ import tempfile
 from collections import defaultdict
 from functools import partial
 from importlib import import_module, metadata
+from importlib.util import find_spec
 from pathlib import Path
 
 from .check import (_validate_type, _check_qt_version, _check_option,
@@ -626,7 +627,8 @@ def sys_info(fid=None, show_paths=False, *, dependencies='core', unicode=True):
                     else:
                         out(f" (OpenGL {version} via {renderer})")
                 if show_paths:
-                    out(f" ({op.dirname(module.__file__)})")
+                    path = op.dirname(find_spec(_get_import_name(name)).origin)
+                    out(f" ({path})")
                 out("\n")
         if unavailable:
             if unicode and _UNICODE_SUPPORT:

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -582,7 +582,10 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
             except ModuleNotFoundError:
                 unavailable.append(name)
             else:
-                out(f"{'✔︎ ' if _UNICODE else ''}{name}".ljust(ljust))
+                if _UNICODE:
+                    out(f"✔︎ {name}".ljust(ljust + 1))
+                else:
+                    out(f"{name}".ljust(ljust))
                 try:
                     out(module.__version__.lstrip("v"))
                 except AttributeError:

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -505,6 +505,19 @@ def _get_gpu_info():
     return out
 
 
+def _get_import_name(package_name):
+    """Get import name from a given package name."""
+    mapping = {
+        "scikit-learn": "sklearn",
+        "edflib-python": "EDFlib",
+        "codespell": "codespell_lib"
+    }
+    if package_name.lower() in mapping:
+        return mapping[package_name.lower()]
+    else:
+        return package_name.replace("-", "_")
+
+
 def sys_info(fid=None, show_paths=False, *, dependencies='user'):
     """Print system information.
 
@@ -524,7 +537,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
     """
     _validate_type(dependencies, str)
     _check_option('dependencies', dependencies, ('user', 'developer'))
-    ljust = 22
+    ljust = 23
     platform_str = platform.platform()
     if platform.system() == 'Darwin' and sys.version_info[:2] < (3, 8):
         # platform.platform() in Python < 3.8 doesn't call
@@ -578,7 +591,7 @@ def sys_info(fid=None, show_paths=False, *, dependencies='user'):
         unavailable = []
         for name in packages[group]:
             try:
-                module = import_module(name)
+                module = import_module(_get_import_name(name))
             except ModuleNotFoundError:
                 unavailable.append(name)
             else:

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -574,12 +574,12 @@ def sys_info(fid=None, show_paths=False, *, dependencies='core'):
 
     for requirement in requirements:
         extra = None
-        if ";" in requirement:  # extra (optional)
+        if "extra" in requirement:  # extra (optional)
             requirement, extra = requirement.split(";")
         requirement = requirement.split(">=")[0]  # strip version
         if extra is not None:
             if dependencies in ("all", "developer"):
-                group = extra.split(" == ")[-1].replace('"', "")
+                group = extra.split("extra == ")[-1].replace('"', "")
                 packages[group].append(requirement)
         else:
             packages["core"].append(requirement)

--- a/mne/utils/tests/test_config.py
+++ b/mne/utils/tests/test_config.py
@@ -86,9 +86,9 @@ def test_sys_info():
     assert ('numpy' in out)
 
     if platform.system() == 'Darwin':
-        assert 'Platform              macOS-' in out
+        assert 'Platform               macOS-' in out
     elif platform.system() == 'Linux':
-        assert 'Platform              Linux' in out
+        assert 'Platform               Linux' in out
 
 
 def test_get_subjects_dir(tmp_path, monkeypatch):

--- a/mne/utils/tests/test_config.py
+++ b/mne/utils/tests/test_config.py
@@ -83,12 +83,12 @@ def test_sys_info():
     out = ClosingStringIO()
     sys_info(fid=out)
     out = out.getvalue()
-    assert ('numpy:' in out)
+    assert ('numpy' in out)
 
     if platform.system() == 'Darwin':
-        assert 'Platform:         macOS-' in out
+        assert 'Platform              macOS-' in out
     elif platform.system() == 'Linux':
-        assert 'Platform:         Linux' in out
+        assert 'Platform              Linux' in out
 
 
 def test_get_subjects_dir(tmp_path, monkeypatch):

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -8,4 +8,3 @@ decorator
 packaging
 jinja2
 importlib_resources>=5.10.2
-importlib_metadata; python_version < '3.9'

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -7,4 +7,3 @@ pooch>=1.5
 decorator
 packaging
 jinja2
-importlib_resources>=5.10.2

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -7,3 +7,4 @@ pooch>=1.5
 decorator
 packaging
 jinja2
+importlib_resources>=5.10.2

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -7,4 +7,4 @@ pooch>=1.5
 decorator
 packaging
 jinja2
-importlib_resources>=5.10.2
+importlib_resources>=5.10.2; python_version < '3.9'

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -8,3 +8,4 @@ decorator
 packaging
 jinja2
 importlib_resources>=5.10.2
+importlib_metadata; python_version < '3.9'

--- a/requirements_browser.txt
+++ b/requirements_browser.txt
@@ -1,3 +1,2 @@
 mne-qt-browser
-QtPy
 PySide6

--- a/requirements_browser.txt
+++ b/requirements_browser.txt
@@ -1,0 +1,3 @@
+mne-qt-browser
+QtPy
+PySide6

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ if __name__ == "__main__":
     hdf5_requires = parse_requirements_file('requirements_hdf5.txt')
     test_requires = (parse_requirements_file('requirements_testing.txt') +
                      parse_requirements_file('requirements_testing_extra.txt'))
+    browser_requires = parse_requirements_file('requirements_browser.txt')
     setup(name=DISTNAME,
           maintainer=MAINTAINER,
           include_package_data=True,
@@ -96,6 +97,7 @@ if __name__ == "__main__":
               'data': data_requires,
               'hdf5': hdf5_requires,
               'test': test_requires,
+              'browser': browser_requires
           },
           packages=package_tree('mne'),
           package_data={'mne': [


### PR DESCRIPTION
This shortens the output of `mne.sys_info()` such that modules that are not installed are not printed in the output. I've also fixed some minor things like importing `multiprocessing` at the top (because it is available in the standard library) and removing the example (because this was outdated and it's probably not worth to change it everytime the function changes, plus I think it doesn't add any value).

Fixes #11543.

### To do
- [x] Update `dependencies` parameter.
- [x] ~~Add new `use_unicode=True` parameter?~~
- [x] ~~Add an option to wrap lines?~~