### PR TITLE
Resample channels after loading whole file

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -293,9 +293,8 @@ def _read_ch(fid, subtype, samp, dtype_byte, dtype=None):
 
 def _read_segment_file(data, idx, fi, start, stop, raw_extras, filenames,
                        cals, mult):
-    """Read a chunk of raw data."""
+    """Read EDF data or annotations in chunks."""
     from scipy.interpolate import interp1d
-
     n_samps = raw_extras['n_samps']
     buf_len = int(raw_extras['max_samp'])
     dtype = raw_extras['dtype_np']
@@ -328,6 +327,14 @@ def _read_segment_file(data, idx, fi, start, stop, raw_extras, filenames,
         # Extract data
         start_offset = (data_offset +
                         block_start_idx * ch_offsets[-1] * dtype_byte)
+
+        # first read everything as list, put into array later
+        # ignore TAL/annotations channel
+        ones = np.zeros((len(orig_sel), data.shape[-1]), dtype=data.dtype)
+        # save how many samples have already been stored for channel
+        n_read_chs = [0 for _ in range(len(orig_sel))]
+
+        # read data in chunks
         for ai in range(0, len(r_lims), n_per):
             block_offset = ai * ch_offsets[-1] * dtype_byte
             n_read = min(len(r_lims) - ai, n_per)
@@ -339,12 +346,14 @@ def _read_segment_file(data, idx, fi, start, stop, raw_extras, filenames,
             r_eidx = (buf_len * (n_read - 1) + r_lims[ai + n_read - 1][1])
             d_sidx = d_lims[ai][0]
             d_eidx = d_lims[ai + n_read - 1][1]
-            one = np.zeros((len(orig_sel), d_eidx - d_sidx), dtype=data.dtype)
+
+            # loop over selected channels, ci=channel selection
             for ii, ci in enumerate(read_sel):
-                # This now has size (n_chunks_read, n_samp[ci])
+                # This now has size (n_chunks_read, n_samps[ci])
                 ch_data = many_chunk[:,
                                      ch_offsets[ci]:ch_offsets[ci + 1]].copy()
 
+                # annotation channel has to be treated separately
                 if ci in tal_idx:
                     tal_data.append(ch_data)
                     continue
@@ -365,18 +374,34 @@ def _read_segment_file(data, idx, fi, start, stop, raw_extras, filenames,
                             ch_data, np.zeros((len(ch_data), 1)), -1)
                         ch_data = interp1d(old, ch_data,
                                            kind='zero', axis=-1)(new)
-                    else:
-                        # XXX resampling each chunk isn't great,
-                        # it forces edge artifacts to appear at
-                        # each buffer boundary :(
-                        # it can also be very slow...
-                        ch_data = resample(
-                            ch_data.astype(np.float64), buf_len, n_samps[ci],
-                            npad=0, axis=-1)
                 elif orig_idx in stim_channel_idxs:
                     ch_data = np.bitwise_and(ch_data.astype(int), 2**17 - 1)
-                one[orig_idx] = ch_data.ravel()[r_sidx:r_eidx]
-            _mult_cal_one(data[:, d_sidx:d_eidx], one, idx, cals, mult)
+                    
+                one_i = ch_data.ravel()[r_sidx:r_eidx]
+                
+                # note how many samples have been read
+                smp_read = n_read_chs[orig_idx]
+                ones[orig_idx, smp_read:smp_read+len(one_i)] = one_i
+                n_read_chs[orig_idx] += len(one_i)
+
+        # skip if no data was requested, ie. only annotations were read
+        if len(data)>0:
+            # expected number of samples, equals maximum sfreq
+            smp_exp = data.shape[-1]
+
+            # resample data after loading all chunks to prevent edge artifacts
+            for i, smp_read in enumerate(n_read_chs):
+                # nothing read, nothing to resample
+                if smp_read==0:
+                    continue
+                # resample if n_samples is lower than from highest sfreq
+                if smp_read!=smp_exp:
+                    assert (ones[i, smp_read:]==0).all()  # sanity check
+                    ones[i,:] = resample(
+                                    ones[i,:smp_read].astype(np.float64),
+                                    data.shape[-1], smp_read,
+                                    npad=0, axis=-1)
+            _mult_cal_one(data[:,:], ones, idx, cals, mult)
 
     if len(tal_data) > 1:
         tal_data = np.concatenate([tal.ravel() for tal in tal_data])


### PR DESCRIPTION
#### Reference issue
Example: Fixes #10635

TODO before merge:
- write some tests, just opening this PR for the issue that came up below
- include warning when resampling is applied

#### What does this implement/fix?
Previously, when loading EDF files with different sample frequencies, data was loaded in chunks and each chunk was resampled independently. This created edge artifacts for each chunk, see also: https://github.com/mne-tools/mne-python/blob/bf2502166eb15626c1205accc2d2d467535b8d93/mne/io/edf/edf.py#L368-L372

I changed the loading such that minimal changes in the code appear. All channel data is loaded completely, and then resampled. 

However, some tests now fail, as in `test_raw.py`, it is tested whether data from certain time selections loaded "on the fly" is equivalent to when data is preloaded. I suspect this fails now, as the "on the fly" loaded resampled data contains different edge artifacts, however, I don't fully understand yet why in some cases the edge artifacts look so different.

#### Details

One tests fails when `preload=False` and specific timeframes are accessed. I presume this is due to edge artifacts, as it only happens for channels which were resampled:

this test:
https://github.com/mne-tools/mne-python/blob/bf2502166eb15626c1205accc2d2d467535b8d93/mne/io/edf/tests/test_edf.py#L177-L182

which calls this test in `io/tests/test_raw.py`, when using `preload=False`, the other tests works (`preload=buffer`)
https://github.com/mne-tools/mne-python/blob/bf2502166eb15626c1205accc2d2d467535b8d93/mne/io/tests/test_raw.py#L120-L125

Plotting differences between the loaded signals reveals A9 having clear edge artefacts, as it is indeed the only resampled channel
![test_reduced edf-1](https://user-images.githubusercontent.com/14980558/224567932-d2469bc8-dea5-41bb-b2ba-40c7956c7283.png)

However, some other time indices look weird and not like clear edge artifacts (plottet are diffs between data1 and data2):

![test_reduced edf-5](https://user-images.githubusercontent.com/14980558/224567998-21c04bf7-3f0c-4085-b737-c6bb422e404e.png)
![test_reduced edf-7](https://user-images.githubusercontent.com/14980558/224567999-34fd0c30-b461-428e-bf8a-dca2769c15e9.png)

Any idea what to do with this? Simply remove the test? 
