### PR TITLE
Bump minimum Python to 3.8

### DIFF
--- a/.github/workflows/compat_minimal.yml
+++ b/.github/workflows/compat_minimal.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   # Minimal (runs with and without testing data)
   job:
-    name: 'minimal 3.7'
+    name: 'minimal 3.8'
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -28,7 +28,7 @@ jobs:
       MNE_SKIP_NETWORK_TEST: 1
       OPENBLAS_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
-      PYTHON_VERSION: '3.7'
+      PYTHON_VERSION: '3.8'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/compat_old.yml
+++ b/.github/workflows/compat_old.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   job:
-    name: 'old 3.7'
+    name: 'old 3.8'
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -23,7 +23,7 @@ jobs:
       MNE_LOGGING_LEVEL: 'warning'
       OPENBLAS_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
-      PYTHON_VERSION: '3.7'
+      PYTHON_VERSION: '3.8'
       MNE_IGNORE_WARNINGS_IN_TESTS: 'true'
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/compat_old.yml
+++ b/.github/workflows/compat_old.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         shell: bash
     env:
-      CONDA_DEPENDENCIES: 'numpy=1.18 scipy=1.4 matplotlib=3.1 pandas=1.0 scikit-learn=0.22'
+      CONDA_DEPENDENCIES: 'numpy=1.18 scipy=1.6.3 matplotlib=3.1 pandas=1.0 scikit-learn=0.22'
       DISPLAY: ':99.0'
       MNE_LOGGING_LEVEL: 'warning'
       OPENBLAS_NUM_THREADS: '1'

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ The minimum required dependencies to run MNE-Python are:
 
 - Python >= 3.8
 - NumPy >= 1.18.1
-- SciPy >= 1.4.1
+- SciPy >= 1.6.3
 - Matplotlib >= 3.1.0
 - pooch >= 1.5
 - tqdm

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,7 @@ To install the latest stable version of MNE-Python, you can use pip_ in a termin
 - MNE-Python 0.18 requires Python 3.5 or higher
 - MNE-Python 0.21 requires Python 3.6 or higher
 - MNE-Python 0.24 requires Python 3.7 or higher
+- MNE-Python 1.4 requires Python 3.8 or higher
 
 For more complete instructions and more advanced installation methods (e.g. for
 the latest development version), see the `installation guide`_.
@@ -92,7 +93,7 @@ Dependencies
 
 The minimum required dependencies to run MNE-Python are:
 
-- Python >= 3.7
+- Python >= 3.8
 - NumPy >= 1.18.1
 - SciPy >= 1.4.1
 - Matplotlib >= 3.1.0

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -246,7 +246,7 @@ Creating the virtual environment
 These instructions will set up a Python environment that is separated from your
 system-level Python and any other managed Python environments on your computer.
 This lets you switch between different versions of Python (MNE-Python requires
-version 3.7 or higher) and also switch between the stable and development
+version 3.8 or higher) and also switch between the stable and development
 versions of MNE-Python (so you can, for example, use the same computer to
 analyze your data with the stable release, and also work with the latest
 development version to fix bugs or add new features). Even if you've already

--- a/doc/install/manual_install_python.rst
+++ b/doc/install/manual_install_python.rst
@@ -30,7 +30,7 @@ conda to ``/home/user/anaconda3``):
 
             $ conda --version && python --version
             conda 4.9.2
-            Python 3.7.7 :: Anaconda, Inc.
+            Python 3.8.13 :: Anaconda, Inc.
             $ which python
             /home/user/anaconda3/bin/python
             $ which pip
@@ -44,7 +44,7 @@ conda to ``/home/user/anaconda3``):
 
             $ conda --version && python --version
             conda 4.9.2
-            Python 3.7.7
+            Python 3.8.13
             $ which python
             /Users/user/opt/anaconda3/bin/python
             $ which pip

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -13,7 +13,7 @@ from copy import deepcopy
 from numbers import Integral
 from time import time
 from dataclasses import dataclass
-from typing import Optional, List
+from typing import Optional, List, Literal
 import warnings
 
 import math
@@ -448,12 +448,13 @@ class ICA(ContainsMixin):
     def _get_infos_for_repr(self):
         @dataclass
         class _InfosForRepr:
-            # XXX replace with Optional[Literal['raw data', 'epochs'] once we
-            # drop support for Py 3.7
-            fit_on: Optional[str]
-            # XXX replace with fit_method: Literal['fastica', 'infomax',
-            # 'extended-infomax', 'picard'] once we drop support for Py 3.7
-            fit_method: str
+            fit_on: Optional[Literal['raw data', 'epochs']]
+            fit_method: Literal[
+                'fastica',
+                'infomax',
+                'extended-infomax',
+                'picard'
+            ]
             fit_n_iter: Optional[int]
             fit_n_samples: Optional[int]
             fit_n_components: Optional[int]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # requirements for full MNE-Python functionality (other than raw/epochs export)
 numpy>=1.15.4
-scipy>=1.1.0
+scipy>=1.6.3
 matplotlib
 tqdm
 pooch>=1.5

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -1,6 +1,6 @@
 # requirements for basic MNE-Python functionality
 numpy>=1.15.4
-scipy>=1.1.0
+scipy>=1.6.3
 matplotlib
 tqdm
 pooch>=1.5

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -8,4 +8,3 @@ decorator
 packaging
 jinja2
 importlib_resources>=5.10.2
-importlib_metadata; python_version < '3.8'

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
               'Tracker': 'https://github.com/mne-tools/mne-python/issues/',
           },
           platforms='any',
-          python_requires='>=3.7',
+          python_requires='>=3.8',
           install_requires=install_requires,
           setup_requires=["setuptools>=45", "setuptools_scm>=6.2"],
           use_scm_version={


### PR DESCRIPTION
Most related packages (e.g. SciPy, Scikit-Learn) require Python 3.8, and given that 3.7 is EOL very soon, we should also bump to 3.8.

To Do:
- [ ] Remove/change required workflows ("minimal 3.7" and "old 3.7")
- [ ] Not sure what to do with [mne/conftest.py:901](https://github.com/cbrnr/mne-python/blob/58c6e02b9ac2f450062e7c5ae488ed95c6bef3d9/mne/conftest.py#L901) – does this need to be updated?