### PR TITLE
MAINT: Bump minimums

### DIFF
--- a/.github/workflows/compat_old.yml
+++ b/.github/workflows/compat_old.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         shell: bash
     env:
-      CONDA_DEPENDENCIES: 'numpy=1.18 scipy=1.6.3 matplotlib=3.1 pandas=1.0 scikit-learn=0.22'
+      CONDA_DEPENDENCIES: 'numpy=1.20.2 scipy=1.6.3 matplotlib=3.4.0 pandas=1.2.4 scikit-learn=0.24.2'
       DISPLAY: ':99.0'
       MNE_LOGGING_LEVEL: 'warning'
       OPENBLAS_NUM_THREADS: '1'

--- a/.github/workflows/compat_old.yml
+++ b/.github/workflows/compat_old.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         shell: bash
     env:
-      CONDA_DEPENDENCIES: 'numpy=1.20.2 scipy=1.6.3 matplotlib=3.4.0 pandas=1.2.4 scikit-learn=0.24.2'
+      CONDA_DEPENDENCIES: 'numpy=1.20.2 scipy=1.6.3 matplotlib=3.4 pandas=1.2.4 scikit-learn=0.24.2'
       DISPLAY: ':99.0'
       MNE_LOGGING_LEVEL: 'warning'
       OPENBLAS_NUM_THREADS: '1'

--- a/README.rst
+++ b/README.rst
@@ -109,10 +109,10 @@ For full functionality, some functions require:
 - mne-qt-browser >= 0.1 (for fast raw data visualization)
 - Qt5 >= 5.12 via one of the following bindings (for fast raw data visualization and interactive 3D visualization):
 
-  - PyQt5 >= 5.12
   - PyQt6 >= 6.0
-  - PySide2 >= 5.12
   - PySide6 >= 6.0
+  - PyQt5 >= 5.12
+  - PySide2 >= 5.12
 
 - Numba >= 0.53.1
 - NiBabel >= 3.2.1

--- a/README.rst
+++ b/README.rst
@@ -94,9 +94,9 @@ Dependencies
 The minimum required dependencies to run MNE-Python are:
 
 - Python >= 3.8
-- NumPy >= 1.18.1
+- NumPy >= 1.20.2
 - SciPy >= 1.6.3
-- Matplotlib >= 3.1.0
+- Matplotlib >= 3.4.0
 - pooch >= 1.5
 - tqdm
 - Jinja2
@@ -104,18 +104,26 @@ The minimum required dependencies to run MNE-Python are:
 
 For full functionality, some functions require:
 
-- Scikit-learn >= 0.22.0
+- Scikit-learn >= 0.24.2
 - joblib >= 0.15 (for parallelization control)
-- Numba >= 0.48.0
-- NiBabel >= 2.5.0
+- mne-qt-browser >= 0.1 (for fast raw data visualization)
+- Qt5 >= 5.12 via one of the following bindings (for fast raw data visualization and interactive 3D visualization):
+
+  - PyQt5 >= 5.12
+  - PyQt6 >= 6.0
+  - PySide2 >= 5.12
+  - PySide6 >= 6.0
+
+- Numba >= 0.53.1
+- NiBabel >= 3.2.1
 - OpenMEEG >= 2.5.5
-- Pandas >= 1.0.0
+- Pandas >= 1.2.4
 - Picard >= 0.3
-- CuPy >= 7.1.1 (for NVIDIA CUDA acceleration)
-- DIPY >= 1.1.0
-- Imageio >= 2.6.1
-- PyVista >= 0.32
-- pyvistaqt >= 0.4
+- CuPy >= 9.0.0 (for NVIDIA CUDA acceleration)
+- DIPY >= 1.4.0
+- Imageio >= 2.8.0
+- PyVista >= 0.32 (for 3D visualization)
+- pyvistaqt >= 0.4 (for 3D visualization)
 - mffpy >= 0.5.7
 - h5py
 - h5io

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -631,7 +631,8 @@ html_theme_options = {
     'navigation_with_keys': False,
     'show_toc_level': 1,
     'navbar_end': ['theme-switcher', 'version-switcher', 'navbar-icon-links'],
-    'footer_items': ['copyright'],
+    'footer_start': ['copyright'],
+    'footer_end': [],
     'secondary_sidebar_items': ['page-toc'],
     'analytics': dict(google_analytics_id='G-5TBCPCRB6X'),
     'switcher': {

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -10,7 +10,7 @@ import pytest
 
 from mne import create_info, EpochsArray
 from mne.fixes import is_regressor, is_classifier
-from mne.utils import requires_sklearn, requires_version
+from mne.utils import requires_sklearn
 from mne.decoding.base import (_get_inverse_funcs, LinearModel, get_coef,
                                cross_val_multiscore, BaseEstimator)
 from mne.decoding.search_light import SlidingEstimator
@@ -268,7 +268,7 @@ def test_get_coef_multiclass(n_features, n_targets):
     lm.fit(X, Y, sample_weight=np.ones(len(Y)))
 
 
-@requires_version('sklearn', '0.22')  # roc_auc_ovr_weighted
+@requires_sklearn
 @pytest.mark.parametrize('n_classes, n_channels, n_times', [
     (4, 10, 2),
     (4, 3, 2),

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -95,84 +95,6 @@ def _csc_matrix_cast(x):
 
 
 ###############################################################################
-# Backporting nibabel's read_geometry
-
-def _get_read_geometry():
-    """Get the geometry reading function."""
-    try:
-        import nibabel as nib
-        has_nibabel = True
-    except ImportError:
-        has_nibabel = False
-    if has_nibabel:
-        from nibabel.freesurfer import read_geometry
-    else:
-        read_geometry = _read_geometry
-    return read_geometry
-
-
-def _read_geometry(filepath, read_metadata=False, read_stamp=False):
-    """Backport from nibabel."""
-    from .surface import _fread3, _fread3_many
-    volume_info = dict()
-
-    TRIANGLE_MAGIC = 16777214
-    QUAD_MAGIC = 16777215
-    NEW_QUAD_MAGIC = 16777213
-    with open(filepath, "rb") as fobj:
-        magic = _fread3(fobj)
-        if magic in (QUAD_MAGIC, NEW_QUAD_MAGIC):  # Quad file
-            nvert = _fread3(fobj)
-            nquad = _fread3(fobj)
-            (fmt, div) = (">i2", 100.) if magic == QUAD_MAGIC else (">f4", 1.)
-            coords = np.fromfile(fobj, fmt, nvert * 3).astype(np.float64) / div
-            coords = coords.reshape(-1, 3)
-            quads = _fread3_many(fobj, nquad * 4)
-            quads = quads.reshape(nquad, 4)
-            #
-            #   Face splitting follows
-            #
-            faces = np.zeros((2 * nquad, 3), dtype=np.int64)
-            nface = 0
-            for quad in quads:
-                if (quad[0] % 2) == 0:
-                    faces[nface] = quad[0], quad[1], quad[3]
-                    nface += 1
-                    faces[nface] = quad[2], quad[3], quad[1]
-                    nface += 1
-                else:
-                    faces[nface] = quad[0], quad[1], quad[2]
-                    nface += 1
-                    faces[nface] = quad[0], quad[2], quad[3]
-                    nface += 1
-
-        elif magic == TRIANGLE_MAGIC:  # Triangle file
-            create_stamp = fobj.readline().rstrip(b'\n').decode('utf-8')
-            fobj.readline()
-            vnum = np.fromfile(fobj, ">i4", 1)[0]
-            fnum = np.fromfile(fobj, ">i4", 1)[0]
-            coords = np.fromfile(fobj, ">f4", vnum * 3).reshape(vnum, 3)
-            faces = np.fromfile(fobj, ">i4", fnum * 3).reshape(fnum, 3)
-
-            if read_metadata:
-                volume_info = _read_volume_info(fobj)
-        else:
-            raise ValueError("File does not appear to be a Freesurfer surface")
-
-    coords = coords.astype(np.float64)
-
-    ret = (coords, faces)
-    if read_metadata:
-        if len(volume_info) == 0:
-            warnings.warn('No volume information contained in the file')
-        ret += (volume_info,)
-    if read_stamp:
-        ret += (create_stamp,)
-
-    return ret
-
-
-###############################################################################
 # NumPy Generator (NumPy 1.17)
 
 
@@ -232,36 +154,6 @@ def _read_volume_info(fobj):
             volume_info[key] = np.array(pair[1].split()).astype(float)
     # Ignore the rest
     return volume_info
-
-
-def _serialize_volume_info(volume_info):
-    """An implementation of nibabel.freesurfer.io._serialize_volume_info, since
-    old versions of nibabel (<=2.1.0) don't have it."""
-    keys = ['head', 'valid', 'filename', 'volume', 'voxelsize', 'xras', 'yras',
-            'zras', 'cras']
-    diff = set(volume_info.keys()).difference(keys)
-    if len(diff) > 0:
-        raise ValueError('Invalid volume info: %s.' % diff.pop())
-
-    strings = list()
-    for key in keys:
-        if key == 'head':
-            if not (np.array_equal(volume_info[key], [20]) or np.array_equal(
-                    volume_info[key], [2, 0, 20])):
-                warnings.warn("Unknown extension code.")
-            strings.append(np.array(volume_info[key], dtype='>i4').tobytes())
-        elif key in ('valid', 'filename'):
-            val = volume_info[key]
-            strings.append('{} = {}\n'.format(key, val).encode('utf-8'))
-        elif key == 'volume':
-            val = volume_info[key]
-            strings.append('{} = {} {} {}\n'.format(
-                key, val[0], val[1], val[2]).encode('utf-8'))
-        else:
-            val = volume_info[key]
-            strings.append('{} = {:0.10g} {:0.10g} {:0.10g}\n'.format(
-                key.ljust(6), val[0], val[1], val[2]).encode('utf-8'))
-    return b''.join(strings)
 
 
 ##############################################################################
@@ -877,27 +769,8 @@ def stable_cumsum(arr, axis=None, rtol=1e-05, atol=1e-08):
     return out
 
 
-# This shim can be removed once NumPy 1.19.0+ is required (1.18.4 has sign bug)
-def svd(a, hermitian=False):
-    if hermitian:  # faster
-        s, u = np.linalg.eigh(a)
-        sgn = np.sign(s)
-        s = np.abs(s)
-        sidx = np.argsort(s)[..., ::-1]
-        sgn = np.take_along_axis(sgn, sidx, axis=-1)
-        s = np.take_along_axis(s, sidx, axis=-1)
-        u = np.take_along_axis(u, sidx[..., None, :], axis=-1)
-        # singular values are unsigned, move the sign into v
-        vt = (u * sgn[..., np.newaxis, :]).swapaxes(-2, -1).conj()
-        np.abs(s, out=s)
-        return u, s, vt
-    else:
-        return np.linalg.svd(a)
-
-
 ###############################################################################
 # From nilearn
-
 
 def _crop_colorbar(cbar, cbar_vmin, cbar_vmax):
     """
@@ -915,31 +788,18 @@ def _crop_colorbar(cbar, cbar_vmin, cbar_vmax):
     new_tick_locs = np.linspace(cbar_vmin, cbar_vmax,
                                 len(cbar_tick_locs))
 
-    # matplotlib >= 3.2.0 no longer normalizes axes between 0 and 1
-    # See https://matplotlib.org/3.2.1/api/prev_api_changes/api_changes_3.2.0.html
-    # _outline was removed in
-    # https://github.com/matplotlib/matplotlib/commit/03a542e875eba091a027046d5ec652daa8be6863
-    # so we use the code from there
-    if _compare_version(matplotlib.__version__, '>=', '3.2.0'):
-        cbar.ax.set_ylim(cbar_vmin, cbar_vmax)
-        X = cbar._mesh()[0]
-        X = np.array([X[0], X[-1]])
-        Y = np.array([[cbar_vmin, cbar_vmin], [cbar_vmax, cbar_vmax]])
-        N = X.shape[0]
-        ii = [0, 1, N - 2, N - 1, 2 * N - 1, 2 * N - 2, N + 1, N, 0]
-        x = X.T.reshape(-1)[ii]
-        y = Y.T.reshape(-1)[ii]
-        xy = (np.column_stack([y, x])
-              if cbar.orientation == 'horizontal' else
-              np.column_stack([x, y]))
-        cbar.outline.set_xy(xy)
-    else:
-        cbar.ax.set_ylim(cbar.norm(cbar_vmin), cbar.norm(cbar_vmax))
-        outline = cbar.outline.get_xy()
-        outline[:2, 1] += cbar.norm(cbar_vmin)
-        outline[2:6, 1] -= (1. - cbar.norm(cbar_vmax))
-        outline[6:, 1] += cbar.norm(cbar_vmin)
-        cbar.outline.set_xy(outline)
+    cbar.ax.set_ylim(cbar_vmin, cbar_vmax)
+    X = cbar._mesh()[0]
+    X = np.array([X[0], X[-1]])
+    Y = np.array([[cbar_vmin, cbar_vmin], [cbar_vmax, cbar_vmax]])
+    N = X.shape[0]
+    ii = [0, 1, N - 2, N - 1, 2 * N - 1, 2 * N - 2, N + 1, N, 0]
+    x = X.T.reshape(-1)[ii]
+    y = Y.T.reshape(-1)[ii]
+    xy = (np.column_stack([y, x])
+            if cbar.orientation == 'horizontal' else
+            np.column_stack([x, y]))
+    cbar.outline.set_xy(xy)
 
     cbar.set_ticks(new_tick_locs)
     cbar.update_ticks()
@@ -951,7 +811,7 @@ def _crop_colorbar(cbar, cbar_vmin, cbar_vmax):
 # Here we choose different defaults to speed things up by default
 try:
     import numba
-    if _compare_version(numba.__version__, '<', '0.48'):
+    if _compare_version(numba.__version__, '<', '0.53.1'):
         raise ImportError
     prange = numba.prange
     def jit(nopython=True, nogil=True, fastmath=True, cache=True,

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1062,7 +1062,6 @@ def test_annotations_simple_iteration():
             assert elem == expected_value
 
 
-@requires_version('numpy', '1.12')
 def test_annotations_slices():
     """Test indexing Annotations."""
     NUM_ANNOT = 5

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -118,6 +118,7 @@ def test_compute_nearest():
 @testing.requires_testing_data
 def test_io_surface(tmp_path):
     """Test reading and writing of Freesurfer surface mesh files."""
+    pytest.importorskip('nibabel')
     fname_quad = data_path / "subjects" / "bert" / "surf" / "lh.inflated.nofix"
     fname_tri = data_path / "subjects" / "sample" / "bem" / "inner_skull.surf"
     for fname in (fname_quad, fname_tri):
@@ -155,6 +156,7 @@ def test_io_surface(tmp_path):
 @testing.requires_testing_data
 def test_read_curv():
     """Test reading curvature data."""
+    pytest.importorskip('nibabel')
     fname_curv = data_path / "subjects" / "fsaverage" / "surf" / "lh.curv"
     fname_surf = data_path / "subjects" / "fsaverage" / "surf" / "lh.inflated"
     bin_curv = read_curvature(fname_curv)

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -11,7 +11,6 @@ import operator
 import os
 from pathlib import Path
 import re
-import sys
 import numbers
 
 import numpy as np
@@ -840,11 +839,6 @@ def _check_qt_version(*, return_api=False):
             version = QtCore.__version__
         except AttributeError:
             version = QtCore.QT_VERSION_STR
-        if sys.platform == 'darwin' and api in ('PyQt5', 'PySide2'):
-            if not _compare_version(version, '>=', '5.10'):
-                warn(f'macOS users should use {api} >= 5.10 for GUIs, '
-                     f'got {version}. Please upgrade e.g. with:\n\n'
-                     f'    pip install "{api}>=5.10"\n')
         # Having Qt installed is not enough -- sometimes the app is unusable
         # for example because there is no usable display (e.g., on a server),
         # so we have to try instantiating one to actually know.

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -144,8 +144,7 @@ def _reg_pinv(x, reg=0, rank='full', rcond=1e-15):
     n = x.shape[-1]
 
     # Decompose the matrix, not necessarily positive semidefinite
-    from mne.fixes import svd
-    U, s, Vh = svd(x, hermitian=True)
+    U, s, Vh = np.linalg.svd(x, hermitian=True)
 
     # Estimate the rank before regularization
     tol = 'auto' if rcond == 'auto' else rcond * s[..., :1]
@@ -154,7 +153,7 @@ def _reg_pinv(x, reg=0, rank='full', rcond=1e-15):
     # Decompose the matrix again after regularization
     loading_factor = reg * np.mean(s, axis=-1)
     if reg:
-        U, s, Vh = svd(
+        U, s, Vh = np.linalg.svd(
             x + loading_factor[..., np.newaxis, np.newaxis] * np.eye(n),
             hermitian=True)
 

--- a/mne/utils/tests/test_linalg.py
+++ b/mne/utils/tests/test_linalg.py
@@ -8,12 +8,9 @@ from numpy.testing import assert_allclose, assert_array_equal
 from scipy import linalg
 import pytest
 
-from mne.utils import (_sym_mat_pow, _reg_pinv, requires_version,
-                       _record_warnings)
-from mne.fixes import _compare_version
+from mne.utils import _sym_mat_pow, _reg_pinv, _record_warnings
 
 
-@requires_version('numpy', '1.17')  # pinv bugs
 @pytest.mark.parametrize('dtype', (np.float64, np.complex128))  # real, complex
 @pytest.mark.parametrize('ndim', (2, 3, 4))
 @pytest.mark.parametrize('n', (3, 4))
@@ -29,10 +26,7 @@ from mne.fixes import _compare_version
 ])
 def test_pos_semidef_inv(ndim, dtype, n, deficient, reduce_rank, psdef, func):
     """Test positive semidefinite matrix inverses."""
-    if _compare_version(np.__version__, '>=', '1.19'):
-        svd = np.linalg.svd
-    else:
-        from mne.fixes import svd
+    svd = np.linalg.svd
     # make n-dimensional matrix
     n_extra = 2  # how many we add along the other dims
     rng = np.random.RandomState(73)

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -21,8 +21,7 @@ from mne.utils import (_get_inst_data, hashfunc,
                        _undo_scaling_array, _PCA, requires_sklearn,
                        _array_equal_nan, _julian_to_cal, _cal_to_julian,
                        _dt_to_julian, _julian_to_dt, grand_average,
-                       _ReuseCycle, requires_version, numerics,
-                       _custom_lru_cache)
+                       _ReuseCycle, numerics, _custom_lru_cache)
 from mne.utils.numerics import _LRU_CACHES, _LRU_CACHE_MAXSIZES
 
 
@@ -237,7 +236,6 @@ def test_cov_scaling():
     assert_allclose(data, evoked.data, atol=1e-20)
 
 
-@requires_version('numpy', '1.17')  # hermitian kwarg
 @pytest.mark.parametrize('ndim', (2, 3))
 def test_reg_pinv(ndim):
     """Test regularization and inversion of covariance matrix."""

--- a/mne/viz/_brain/_scraper.py
+++ b/mne/viz/_brain/_scraper.py
@@ -18,7 +18,6 @@ class _BrainScraper(object):
             # PyVista and matplotlib scrapers can just do the work
             if (not isinstance(brain, Brain)) or brain._closed:
                 continue
-            import matplotlib
             from matplotlib import animation, pyplot as plt
             from sphinx_gallery.scrapers import matplotlib_scraper
             img = brain.screenshot(time_viewer=True)

--- a/mne/viz/_brain/_scraper.py
+++ b/mne/viz/_brain/_scraper.py
@@ -1,7 +1,6 @@
 import os
 import os.path as op
 
-from ...fixes import _compare_version
 from ._brain import Brain
 
 
@@ -70,10 +69,7 @@ class _BrainScraper(object):
                 # Out to sphinx-gallery:
                 #
                 # 1. A static image but hide it (useful for carousel)
-                if (
-                    _compare_version(matplotlib.__version__, '>=', '3.3.1') and
-                    animation.FFMpegWriter.isAvailable()
-                ):
+                if animation.FFMpegWriter.isAvailable():
                     writer = 'ffmpeg'
                 elif animation.ImageMagickWriter.isAvailable():
                     writer = 'imagemagick'

--- a/mne/viz/_mpl_figure.py
+++ b/mne/viz/_mpl_figure.py
@@ -1313,7 +1313,6 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
     def _create_selection_fig(self):
         """Create channel selection dialog window."""
         from matplotlib.colors import to_rgb
-        from matplotlib.gridspec import GridSpec
         from matplotlib.widgets import RadioButtons
 
         # make figure
@@ -1321,9 +1320,7 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
                                      FigureClass=MNESelectionFigure,
                                      fig_name='fig_selection',
                                      window_title='Channel selection')
-        # XXX when matplotlib 3.3 is min version, replace this with
-        # XXX gs = fig.add_gridspec(15, 1)
-        gs = GridSpec(nrows=15, ncols=1)
+        gs = fig.add_gridspec(15, 1)
         # add sensor plot at top
         fig.mne.sensor_ax = fig.add_subplot(gs[:5])
         plot_sensors(self.mne.info, kind='select', ch_type='all', title='',

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -236,18 +236,10 @@ def test_plot_evoked_topomap_units(evoked, units, scalings, expected_unit):
     evoked.pick(['EEG 001', 'EEG 002', 'EEG 003'])
     fig = evoked.plot_topomap(times=0.1, res=8, contours=0, sensors=False,
                               units=units, scalings=scalings)
-    # ideally we'd do this:
-    #     cbar = [ax for ax in fig.axes if hasattr(ax, '_colorbar')]
-    #     assert len(cbar) == 1
-    #     cbar = cbar[0]
-    #     assert cbar.get_title() == expected_unit
-    # ...but not all matplotlib versions support it, and we can't use
-    # @requires_version because it's hard figure out exactly which MPL version
-    # is the cutoff since it relies on a private attribute. So for now we just
-    # do this:
-    for ax in fig.axes:
-        if hasattr(ax, '_colorbar'):
-            assert ax.get_title() == expected_unit
+    cbar = [ax for ax in fig.axes if hasattr(ax, '_colorbar')]
+    assert len(cbar) == 1
+    cbar = cbar[0]
+    assert cbar.get_title() == expected_unit
 
 
 @pytest.mark.parametrize('extrapolate', ('box', 'local', 'head'))

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -236,10 +236,19 @@ def test_plot_evoked_topomap_units(evoked, units, scalings, expected_unit):
     evoked.pick(['EEG 001', 'EEG 002', 'EEG 003'])
     fig = evoked.plot_topomap(times=0.1, res=8, contours=0, sensors=False,
                               units=units, scalings=scalings)
-    cbar = [ax for ax in fig.axes if hasattr(ax, '_colorbar')]
-    assert len(cbar) == 1
-    cbar = cbar[0]
-    assert cbar.get_title() == expected_unit
+    # ideally we'd do this:
+    #     cbar = [ax for ax in fig.axes if hasattr(ax, '_colorbar')]
+    #     assert len(cbar) == 1
+    #     cbar = cbar[0]
+    #     assert cbar.get_title() == expected_unit
+    # ...but not all matplotlib versions support it, and we can't use
+    # @requires_version because it's hard figure out exactly which MPL version
+    # is the cutoff since it relies on a private attribute. Based on some
+    # basic testing it's at least matplotlib version >= 3.5.
+    # So for now we just do this:
+    for ax in fig.axes:
+        if hasattr(ax, '_colorbar'):
+            assert ax.get_title() == expected_unit
 
 
 @pytest.mark.parametrize('extrapolate', ('box', 'local', 'head'))

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,7 +1,7 @@
 # requirements for building docs
 sphinx!=4.1.0,<6
 https://github.com/numpy/numpydoc/archive/main.zip
-https://github.com/pydata/pydata-sphinx-theme/archive/f367a58af33be362351686f1e207ea099f8e529e.zip
+pydata_sphinx_theme==0.13.1
 https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip
 sphinxcontrib-bibtex>=2.5
 memory_profiler


### PR DESCRIPTION
Bumps min reqs in README.rst to those ~2 years old this April, and adjusts/removes code shims for deps lower than those. Also `nibabel` is now required for `read_surface` which I think is reasonable (it is pure Python and has been stable and pip/conda-installable for years now).

Closes #10977