### PR TITLE
MAINT: Add nibabel as a required dependency

### DIFF
--- a/.github/workflows/compat_minimal.yml
+++ b/.github/workflows/compat_minimal.yml
@@ -19,8 +19,7 @@ jobs:
       run:
         shell: bash
     env:
-      # TODO: Revert nibabel here pending https://github.com/mne-tools/mne-python/issues/11564
-      CONDA_DEPENDENCIES: 'numpy scipy matplotlib nibabel'
+      CONDA_DEPENDENCIES: 'numpy scipy matplotlib'
       DEPS: 'minimal'
       DISPLAY: ':99.0'
       MNE_DONTWRITE_HOME: true

--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,7 @@ The minimum required dependencies to run MNE-Python are:
 - NumPy >= 1.20.2
 - SciPy >= 1.6.3
 - Matplotlib >= 3.4.0
+- NiBabel >= 3.2.1
 - pooch >= 1.5
 - tqdm
 - Jinja2
@@ -104,7 +105,6 @@ For full functionality, some functions require:
   - PySide2 >= 5.12
 
 - Numba >= 0.53.1
-- NiBabel >= 3.2.1
 - OpenMEEG >= 2.5.5
 - Pandas >= 1.2.4
 - Picard >= 0.3

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1018,6 +1018,11 @@ def reset_warnings(gallery_conf, fname):
     ):
         warnings.filterwarnings(  # deal with other modules having bad imports
             'ignore', message=".*%s.*" % key, category=DeprecationWarning)
+    warnings.filterwarnings(
+        'ignore', message=(
+            'Matplotlib is currently using agg, which is a non-GUI backend.*'
+        )
+    )
     # matplotlib 3.6 in nilearn and pyvista
     warnings.filterwarnings(
         'ignore', message='.*cmap function will be deprecated.*')

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1018,11 +1018,6 @@ def reset_warnings(gallery_conf, fname):
     ):
         warnings.filterwarnings(  # deal with other modules having bad imports
             'ignore', message=".*%s.*" % key, category=DeprecationWarning)
-    warnings.filterwarnings(
-        'ignore', message=(
-            'Matplotlib is currently using agg, which is a non-GUI backend.*'
-        )
-    )
     # matplotlib 3.6 in nilearn and pyvista
     warnings.filterwarnings(
         'ignore', message='.*cmap function will be deprecated.*')

--- a/mne/_freesurfer.py
+++ b/mne/_freesurfer.py
@@ -555,7 +555,7 @@ def _check_mri(mri, subject, subjects_dir):
     return mri
 
 
-def _read_mri_info(path, units='m', return_img=False, use_nibabel=False):
+def _read_mri_info(path, units='m', return_img=False):
     import nibabel as nib
     hdr = nib.load(path).header
     n_orig = hdr.get_vox2ras()

--- a/mne/_freesurfer.py
+++ b/mne/_freesurfer.py
@@ -7,7 +7,6 @@
 
 import os.path as op
 import numpy as np
-from gzip import GzipFile
 from pathlib import Path
 
 from .bem import _bem_find_surface, read_bem_surfaces
@@ -17,7 +16,7 @@ from .transforms import (apply_trans, invert_transform, combine_transforms,
                          _ensure_trans, read_ras_mni_t, Transform)
 from .surface import read_surface, _read_mri_surface
 from .utils import (verbose, _validate_type, _check_fname, _check_option,
-                    get_subjects_dir, _require_version, logger)
+                    get_subjects_dir, logger)
 
 
 def _check_subject_dir(subject, subjects_dir):

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -36,7 +36,7 @@ from .surface import (read_surface, write_surface, complete_surface_info,
 from .transforms import _ensure_trans, apply_trans, Transform
 from .utils import (verbose, logger, run_subprocess, get_subjects_dir, warn,
                     _pl, _validate_type, _TempDir, _check_freesurfer_home,
-                    _check_fname, has_nibabel, _check_option, path_like,
+                    _check_fname, _check_option, path_like,
                     _on_missing, _import_h5io_funcs, _ensure_int,
                     _path_like, _verbose_safe_false, _check_head_radius)
 
@@ -1283,7 +1283,7 @@ def make_watershed_bem(subject, subjects_dir=None, overwrite=False,
     run_subprocess_env(cmd)
     del tempdir  # clean up directory
     if op.isfile(T1_mgz):
-        new_info = _extract_volume_info(T1_mgz) if has_nibabel() else dict()
+        new_info = _extract_volume_info(T1_mgz)
         if not new_info:
             warn('nibabel is not available or the volume info is invalid.'
                  'Volume info not updated in the written surface.')

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -24,8 +24,7 @@ from mne.commands import (mne_browse_raw, mne_bti2fiff, mne_clean_eog_ecg,
                           mne_prepare_bem_model, mne_sys_info)
 from mne.datasets import testing
 from mne.io import read_raw_fif, read_info
-from mne.utils import (requires_mne, requires_freesurfer,
-                       requires_nibabel, ArgvSetter,
+from mne.utils import (requires_mne, requires_freesurfer, ArgvSetter,
                        _stamp_to_dt, _record_warnings)
 
 base_dir = op.join(op.dirname(__file__), '..', '..', 'io', 'tests', 'data')
@@ -138,7 +137,6 @@ def test_kit2fiff():
 @testing.requires_testing_data
 def test_make_scalp_surfaces(tmp_path, monkeypatch):
     """Test mne make_scalp_surfaces."""
-    pytest.importorskip('nibabel')
     pytest.importorskip('pyvista')
     check_usage(mne_make_scalp_surfaces)
     has = 'SUBJECTS_DIR' in os.environ
@@ -199,7 +197,6 @@ def test_maxfilter():
 @testing.requires_testing_data
 def test_report(tmp_path):
     """Test mne report."""
-    pytest.importorskip('nibabel')
     check_usage(mne_report)
     tempdir = str(tmp_path)
     use_fname = op.join(tempdir, op.basename(raw_fname))
@@ -220,7 +217,6 @@ def test_surf2bem():
 @pytest.mark.timeout(900)  # took ~400 s on a local test
 @pytest.mark.slowtest
 @pytest.mark.ultraslowtest
-@requires_nibabel()
 @requires_freesurfer('mri_watershed')
 @testing.requires_testing_data
 def test_watershed_bem(tmp_path):

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -613,7 +613,6 @@ def _fwd_surf(_evoked_cov_sphere):
 @pytest.fixture(scope='session')
 def _fwd_subvolume(_evoked_cov_sphere):
     """Compute a forward for a surface source space."""
-    pytest.importorskip('nibabel')
     evoked, cov, sphere = _evoked_cov_sphere
     volume_labels = ['Left-Cerebellum-Cortex', 'right-Cerebellum-Cortex']
     with pytest.raises(ValueError,
@@ -701,7 +700,6 @@ def mixed_fwd_cov_evoked(_evoked_cov_sphere, _all_src_types_fwd):
 @pytest.mark.parametrize(params=[testing._pytest_param()])
 def src_volume_labels():
     """Create a 7mm source space with labels."""
-    pytest.importorskip('nibabel')
     volume_labels = mne.get_volume_labels_from_aseg(fname_aseg)
     with pytest.warns(RuntimeWarning, match='Found no usable.*Left-vessel.*'):
         src = mne.setup_volume_source_space(

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -19,9 +19,8 @@ from mne import (read_forward_solution, write_forward_solution,
                  get_volume_labels_from_aseg)
 from mne.surface import _get_ico_surface
 from mne.transforms import Transform
-from mne.utils import (requires_mne, requires_nibabel, run_subprocess,
-                       catch_logging, requires_mne_mark,
-                       requires_openmeeg_mark)
+from mne.utils import (requires_mne, run_subprocess, catch_logging,
+                       requires_mne_mark, requires_openmeeg_mark)
 from mne.forward._make_forward import _create_meg_coils, make_forward_dipole
 from mne.forward._compute_forward import _magnetic_dipole_field_vec
 from mne.forward import Forward, _do_forward_solution, use_coil_def
@@ -433,7 +432,6 @@ def test_make_forward_solution_sphere(tmp_path, fname_src_small):
 
 @pytest.mark.slowtest
 @testing.requires_testing_data
-@requires_nibabel()
 def test_forward_mixed_source_space(tmp_path):
     """Test making the forward solution for a mixed source space."""
     # get the surface source space

--- a/mne/gui/_core.py
+++ b/mne/gui/_core.py
@@ -21,7 +21,6 @@ from matplotlib.backends.backend_qt5agg import FigureCanvas
 from matplotlib.figure import Figure
 from matplotlib.patches import Rectangle
 
-from .._freesurfer import _import_nibabel
 from ..viz.backends.renderer import _get_renderer
 from ..viz.utils import safe_event
 from ..surface import _read_mri_surface, _marching_cubes
@@ -35,7 +34,7 @@ _ZOOM_STEP_SIZE = 5
 @verbose
 def _load_image(img, verbose=None):
     """Load data from a 3D image file (e.g. CT, MR)."""
-    nib = _import_nibabel('use GUI')
+    import nibabel as nib
     if not isinstance(img, nib.spatialimages.SpatialImage):
         logger.debug(f'Loading {img}')
         _check_fname(img, overwrite='read', must_exist=True)

--- a/mne/gui/tests/test_core.py
+++ b/mne/gui/tests/test_core.py
@@ -6,10 +6,11 @@
 import numpy as np
 from numpy.testing import assert_allclose
 
+import nibabel as nib
 import pytest
 
 from mne.datasets import testing
-from mne.utils import requires_nibabel, catch_logging, use_log_level
+from mne.utils import catch_logging, use_log_level
 from mne.viz.utils import _fake_click
 
 data_path = testing.data_path(download=False)
@@ -17,11 +18,9 @@ subject = "sample"
 subjects_dir = data_path / "subjects"
 
 
-@requires_nibabel()
 @testing.requires_testing_data
 def test_slice_browser_io(renderer_interactive_pyvistaqt):
     """Test the input/output of the slice browser GUI."""
-    import nibabel as nib
     from mne.gui._core import SliceBrowser
     with pytest.raises(ValueError, match='Base image is not aligned to MRI'):
         SliceBrowser(nib.MGHImage(

--- a/mne/gui/tests/test_ieeg_locate.py
+++ b/mne/gui/tests/test_ieeg_locate.py
@@ -6,12 +6,13 @@
 import numpy as np
 from numpy.testing import assert_allclose
 
+import nibabel as nib
 import pytest
 
 import mne
 from mne.datasets import testing
 from mne.transforms import apply_trans
-from mne.utils import requires_nibabel, requires_version, use_log_level
+from mne.utils import requires_version, use_log_level
 from mne.viz.utils import _fake_click
 
 data_path = testing.data_path(download=False)
@@ -22,11 +23,9 @@ raw_path = sample_dir / "sample_audvis_trunc_raw.fif"
 fname_trans = sample_dir / "sample_audvis_trunc-trans.fif"
 
 
-@requires_nibabel()
 @pytest.fixture
 def _fake_CT_coords(skull_size=5, contact_size=2):
     """Make somewhat realistic CT data with contacts."""
-    import nibabel as nib
     brain = nib.load(subjects_dir / subject / "mri" / "brain.mgz")
     verts = mne.read_surface(
         subjects_dir / subject / "bem" / "outer_skull.surf"
@@ -59,10 +58,8 @@ def _fake_CT_coords(skull_size=5, contact_size=2):
     return ct, coords
 
 
-@requires_nibabel()
 def test_ieeg_elec_locate_io(renderer_interactive_pyvistaqt):
     """Test the input/output of the intracranial location GUI."""
-    import nibabel as nib
     import mne.gui
     info = mne.create_info([], 1000)
 

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -27,8 +27,7 @@ from mne.report.report import (
 from mne.io import read_raw_fif, read_info, RawArray
 from mne.datasets import testing
 from mne.report import Report, open_report, _ReportScraper, report
-from mne.utils import (requires_nibabel, Bunch, requires_version,
-                       requires_sklearn)
+from mne.utils import Bunch, requires_version, requires_sklearn
 from mne.viz import plot_alignment
 from mne.io.write import DATE_NONE
 from mne.preprocessing import ICA
@@ -441,7 +440,6 @@ def test_render_add_sections(renderer, tmp_path):
 
 @pytest.mark.slowtest
 @testing.requires_testing_data
-@requires_nibabel()
 def test_render_mri(renderer, tmp_path):
     """Test rendering MRI for mne report."""
     trans_fname_new = tmp_path / "temp-trans.fif"
@@ -464,7 +462,6 @@ def test_render_mri(renderer, tmp_path):
 
 
 @testing.requires_testing_data
-@requires_nibabel()
 @pytest.mark.parametrize('n_jobs', [
     1,
     pytest.param(2, marks=pytest.mark.slowtest),  # 1.5 s locally
@@ -499,7 +496,6 @@ def test_add_bem_n_jobs(n_jobs, monkeypatch):
 
 
 @testing.requires_testing_data
-@requires_nibabel()
 def test_render_mri_without_bem(tmp_path):
     """Test rendering MRI without BEM for mne report."""
     os.mkdir(tmp_path / "sample")
@@ -516,7 +512,6 @@ def test_render_mri_without_bem(tmp_path):
 
 
 @testing.requires_testing_data
-@requires_nibabel()
 def test_add_html():
     """Test adding html str to mne report."""
     report = Report(info_fname=raw_fname,

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -17,7 +17,7 @@ from .cov import Covariance
 from .evoked import _get_peak
 from .filter import resample
 from .fixes import _safe_svd
-from ._freesurfer import (_import_nibabel, _get_mri_info_data,
+from ._freesurfer import (_get_mri_info_data,
                           _get_atlas_values, read_freesurfer_lut)
 from .io.constants import FIFF
 from .io.pick import pick_types
@@ -2970,7 +2970,6 @@ def _volume_labels(src, labels, mri_resolution):
     assert src.kind == 'volume'
     subject = src._subject
     extra = ' when using a volume source space'
-    _import_nibabel('use volume atlas labels')
     _validate_type(labels, ('path-like', list, tuple), 'labels' + extra)
     if _path_like(labels):
         mri = labels

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -808,7 +808,6 @@ def read_surface(fname, read_metadata=False, return_dict=False,
     write_surface
     read_tri
     """
-    from ._freesurfer import _import_nibabel
     fname = _check_fname(fname, 'read', True)
     _check_option('file_format', file_format, ['auto', 'freesurfer', 'obj'])
 
@@ -819,7 +818,6 @@ def read_surface(fname, read_metadata=False, return_dict=False,
             file_format = 'freesurfer'
 
     if file_format == 'freesurfer':
-        _import_nibabel('read surface geometry')
         from nibabel.freesurfer import read_geometry
         ret = read_geometry(fname, read_metadata=read_metadata)
     elif file_format == 'obj':
@@ -1186,7 +1184,6 @@ def write_surface(fname, coords, faces, create_stamp='', volume_info=None,
     read_surface
     read_tri
     """
-    from ._freesurfer import _import_nibabel
     fname = _check_fname(fname, overwrite=overwrite)
     _check_option('file_format', file_format, ['auto', 'freesurfer', 'obj'])
 
@@ -1197,7 +1194,6 @@ def write_surface(fname, coords, faces, create_stamp='', volume_info=None,
             file_format = 'freesurfer'
 
     if file_format == 'freesurfer':
-        _import_nibabel('write surface geometry')
         from nibabel.freesurfer import write_geometry
         write_geometry(
             fname, coords, faces, create_stamp=create_stamp,
@@ -1932,7 +1928,6 @@ def warp_montage_volume(montage, base_image, reg_affine, sdr_morph,
         The warped image with voxel values corresponding to the index
         of the channel. The background is 0s and this index starts at 1.
     """
-    _require_version('nibabel', 'SDR morph', '2.1.0')
     _require_version('dipy', 'SDR morph', '0.10.1')
     from .channels import DigMontage, make_dig_montage
     from ._freesurfer import _check_subject_dir

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -18,8 +18,7 @@ from mne.coreg import (fit_matched_points, create_default_subject, scale_mri,
                        coregister_fiducials, get_mni_fiducials, Coregistration)
 from mne.io import read_fiducials, read_info
 from mne.io.constants import FIFF
-from mne.utils import (requires_nibabel, check_version, catch_logging,
-                       _record_warnings)
+from mne.utils import check_version, catch_logging
 from mne.source_space import write_source_spaces
 from mne.channels import DigMontage
 
@@ -62,7 +61,6 @@ def test_coregister_fiducials():
     assert_array_almost_equal(trans_est['trans'], trans['trans'])
 
 
-@requires_nibabel()
 @pytest.mark.slowtest  # can take forever on OSX Travis
 @testing.requires_testing_data
 @pytest.mark.parametrize('scale', (.9, [1, .2, .8]))
@@ -111,15 +109,14 @@ def test_scale_mri(tmp_path, few_surfaces, scale):
 
     # scale fsaverage
     write_source_spaces(bem_path / (bem_fname % "ico-0"), src, overwrite=True)
-    with _record_warnings():  # sometimes missing nibabel
-        scale_mri(
-            "fsaverage",
-            "flachkopf",
-            scale,
-            True,
-            subjects_dir=tmp_path,
-            verbose="debug",
-        )
+    scale_mri(
+        "fsaverage",
+        "flachkopf",
+        scale,
+        True,
+        subjects_dir=tmp_path,
+        verbose="debug",
+    )
     assert _is_mri_subject("flachkopf", tmp_path), "Scaling failed"
     spath = tmp_path / "flachkopf" / "bem"
     spath_fname = "flachkopf-%s-src.fif"
@@ -176,7 +173,6 @@ def test_scale_mri(tmp_path, few_surfaces, scale):
 
 @pytest.mark.slowtest  # can take forever on OSX Travis
 @testing.requires_testing_data
-@requires_nibabel()
 def test_scale_mri_xfm(tmp_path, few_surfaces, subjects_dir_tmp_few):
     """Test scale_mri transforms and MRI scaling."""
     # scale fsaverage
@@ -350,7 +346,6 @@ def test_fit_matched_points():
 
 
 @testing.requires_testing_data
-@requires_nibabel()
 def test_get_mni_fiducials():
     """Test get_mni_fiducials."""
     fids, coord_frame = read_fiducials(fid_fname)

--- a/mne/tests/test_dipole.py
+++ b/mne/tests/test_dipole.py
@@ -20,8 +20,7 @@ from mne import (read_dipole, read_forward_solution,
 from mne.dipole import get_phantom_dipoles, _BDIP_ERROR_KEYS
 from mne.simulation import simulate_evoked
 from mne.datasets import testing
-from mne.utils import (requires_mne, run_subprocess, requires_nibabel,
-                       _record_warnings)
+from mne.utils import requires_mne, run_subprocess, _record_warnings
 from mne.proj import make_eeg_average_ref_proj
 
 from mne.io import read_raw_fif, read_raw_ctf
@@ -107,7 +106,6 @@ def test_dipole_fitting_ctf():
 
 @pytest.mark.slowtest
 @testing.requires_testing_data
-@requires_nibabel()
 @requires_mne
 def test_dipole_fitting(tmp_path):
     """Test dipole fitting."""

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -4,10 +4,13 @@
 # License: BSD-3-Clause
 from inspect import signature
 
-import pytest
+import nibabel as nib
+from nibabel.processing import resample_from_to
+from nibabel.spatialimages import SpatialImage
 import numpy as np
 from numpy.testing import (assert_array_less, assert_allclose,
                            assert_array_equal)
+import pytest
 from scipy.spatial.distance import cdist
 from scipy.sparse import csr_matrix, eye as speye
 
@@ -26,7 +29,7 @@ from mne.minimum_norm import (apply_inverse, read_inverse_operator,
                               make_inverse_operator)
 from mne.source_space import _add_interpolator, _grid_interp
 from mne.transforms import quat_to_rot
-from mne.utils import (requires_nibabel, check_version, requires_version,
+from mne.utils import (check_version, requires_version,
                        requires_dipy, catch_logging, _record_warnings)
 
 # Setup paths
@@ -290,13 +293,11 @@ def test_surface_vector_source_morph(tmp_path):
 
 
 @requires_version('h5io')
-@requires_nibabel()
 @requires_dipy()
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_volume_source_morph_basic(tmp_path):
     """Test volume source estimate morph, special cases and exceptions."""
-    import nibabel as nib
     inverse_operator_vol = read_inverse_operator(fname_inv_vol)
     stc_vol = read_source_estimate(fname_vol_w, 'sample')
 
@@ -475,7 +476,6 @@ def test_volume_source_morph_basic(tmp_path):
 
 
 @requires_version('h5io')
-@requires_nibabel()
 @requires_dipy()
 @pytest.mark.slowtest
 @testing.requires_testing_data
@@ -491,8 +491,6 @@ def test_volume_source_morph_round_trip(
         tmp_path, subject_from, subject_to, lower, upper, dtype, morph_mat,
         monkeypatch):
     """Test volume source estimate morph round-trips well."""
-    import nibabel as nib
-    from nibabel.processing import resample_from_to
     src = dict()
     if morph_mat:
         # ~1.5 minutes with pos=7. (4157 morphs!) for sample, so only test
@@ -752,7 +750,6 @@ def test_morph_stc_sparse():
             spacing=None, sparse=True, xhemi=True, subjects_dir=subjects_dir)
 
 
-@requires_nibabel()
 @testing.requires_testing_data
 @pytest.mark.parametrize('sl, n_real, n_mri, n_orig', [
     # First and last should add up, middle can have overlap should be <= sum
@@ -762,7 +759,6 @@ def test_morph_stc_sparse():
 ])
 def test_volume_labels_morph(tmp_path, sl, n_real, n_mri, n_orig):
     """Test generating a source space from volume label."""
-    import nibabel as nib
     n_use = (sl.stop - sl.start) // (sl.step or 1)
     # see gh-5224
     evoked = mne.read_evokeds(fname_evoked)[0].crop(0, 0)
@@ -846,13 +842,11 @@ def _mixed_morph_srcs():
     return morph, src, src_fs
 
 
-@requires_nibabel()
 @requires_dipy()
 @pytest.mark.slowtest
 @pytest.mark.parametrize('vector', (False, True))
 def test_mixed_source_morph(_mixed_morph_srcs, vector):
     """Test mixed source space morphing."""
-    import nibabel as nib
     morph, src, src_fs = _mixed_morph_srcs
     # Test some basic properties in the subject's own space
     lut, _ = read_freesurfer_lut()
@@ -926,7 +920,6 @@ _affines = (
 )
 
 
-@requires_nibabel()
 @requires_version('dipy', '1.3')
 @pytest.mark.parametrize('from_shape', _shapes)
 @pytest.mark.parametrize('from_affine', _affines)
@@ -956,8 +949,6 @@ def test_resample_equiv(from_shape, from_affine, to_shape, to_affine,
     # 1. nibabel.processing.resample_from_to
     #
     # for a 1mm iso / 256 -> 5mm / 51 one sample takes ~486 ms
-    from nibabel.processing import resample_from_to
-    from nibabel.spatialimages import SpatialImage
     start = np.linalg.norm(from_data)
     got_nibabel = resample_from_to(
         SpatialImage(from_data, from_affine),

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -9,6 +9,8 @@ from copy import deepcopy
 from pathlib import Path
 from shutil import copyfile
 
+import nibabel as nib
+
 import numpy as np
 from numpy.fft import fft
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
@@ -44,7 +46,7 @@ from mne.minimum_norm import (read_inverse_operator, apply_inverse,
                               apply_inverse_epochs, make_inverse_operator)
 from mne.label import read_labels_from_annot, label_sign_flip
 from mne.utils import (requires_pandas, requires_sklearn, catch_logging,
-                       requires_nibabel, requires_version, _record_warnings)
+                       requires_version, _record_warnings)
 from mne.io import read_raw_fif
 
 data_path = testing.data_path(download=False)
@@ -228,11 +230,9 @@ def test_volume_stc(tmp_path):
             assert_array_almost_equal(stc.data, stc_new.data)
 
 
-@requires_nibabel()
 @testing.requires_testing_data
 def test_stc_as_volume():
     """Test previous volume source estimate morph."""
-    import nibabel as nib
     inverse_operator_vol = read_inverse_operator(fname_inv_vol)
 
     # Apply inverse operator
@@ -255,10 +255,8 @@ def test_stc_as_volume():
 
 
 @testing.requires_testing_data
-@requires_nibabel()
 def test_save_vol_stc_as_nifti(tmp_path):
     """Save the stc as a nifti file and export."""
-    import nibabel as nib
     src = read_source_spaces(fname_vsrc)
     vol_fname = tmp_path / 'stc.nii.gz'
 
@@ -617,7 +615,6 @@ def test_extract_label_time_course(kind, vector):
 
     src = read_inverse_operator(fname_inv)['src']
     if kind == 'mixed':
-        pytest.importorskip('nibabel')
         label_names = ('Left-Cerebellum-Cortex',
                        'Right-Cerebellum-Cortex')
         src += setup_volume_source_space(
@@ -1531,7 +1528,6 @@ def test_spatial_src_adjacency():
 
 
 @requires_sklearn
-@requires_nibabel()
 @testing.requires_testing_data
 def test_vol_mask():
     """Test extraction of volume mask."""
@@ -1681,7 +1677,6 @@ def _make_morph_map_hemi_same(subject_from, subject_to, subjects_dir,
                                 reg_from, reg_from)
 
 
-@requires_nibabel()
 @testing.requires_testing_data
 @pytest.mark.parametrize('kind', (
     pytest.param('volume', marks=[requires_version('dipy'),
@@ -1855,8 +1850,7 @@ def test_scale_morph_labels(kind, scale, monkeypatch, tmp_path):
 @testing.requires_testing_data
 @pytest.mark.parametrize('kind', [
     'surface',
-    pytest.param('volume', marks=[pytest.mark.slowtest,
-                                  requires_version('nibabel')]),
+    pytest.param('volume', marks=[pytest.mark.slowtest]),
 ])
 def test_label_extraction_subject(kind):
     """Test that label extraction subject is treated properly."""

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from shutil import copyfile
 
 import nibabel as nib
-
 import numpy as np
 from numpy.fft import fft
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -7,11 +7,13 @@
 from pathlib import Path
 from shutil import copytree
 
-import pytest
-import scipy
+import nibabel as nib
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_allclose, assert_equal,
                            assert_array_less)
+import pytest
+import scipy
+
 from mne.datasets import testing
 import mne
 from mne import (read_source_spaces, write_source_spaces,
@@ -22,8 +24,8 @@ from mne import (read_source_spaces, write_source_spaces,
                  read_bem_solution, read_freesurfer_lut,
                  read_trans)
 from mne.fixes import _get_img_fdata
-from mne.utils import (requires_nibabel, run_subprocess, _record_warnings,
-                       requires_mne, check_version)
+from mne.utils import (run_subprocess, _record_warnings, requires_mne,
+                       check_version)
 from mne.surface import _accumulate_normals, _triangle_neighbors
 from mne.source_estimate import _get_src_type
 from mne.source_space import (get_volume_labels_from_src,
@@ -319,7 +321,6 @@ def test_discrete_source_space(tmp_path):
             pos=dict(rr=[[0, 0, float('inf')]], nn=[[0, 1, 0]]))
 
 
-@requires_nibabel()
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_volume_source_space(tmp_path):
@@ -592,7 +593,6 @@ def test_write_source_space(tmp_path):
 
 
 @testing.requires_testing_data
-@requires_nibabel()
 @pytest.mark.parametrize('pass_ids', (True, False))
 def test_source_space_from_label(tmp_path, pass_ids):
     """Test generating a source space from volume label."""
@@ -641,7 +641,6 @@ def test_source_space_from_label(tmp_path, pass_ids):
 
 
 @testing.requires_testing_data
-@requires_nibabel()
 def test_source_space_exclusive_complete(src_volume_labels):
     """Test that we produce exclusive and complete labels."""
     # these two are neighbors and are quite large, so let's use them to
@@ -672,7 +671,6 @@ def test_source_space_exclusive_complete(src_volume_labels):
 @pytest.mark.timeout(60)  # ~24 s on Travis
 @pytest.mark.slowtest
 @testing.requires_testing_data
-@requires_nibabel()
 def test_read_volume_from_src():
     """Test reading volumes from a mixed source space."""
     labels_vol = ['Left-Amygdala',
@@ -710,10 +708,8 @@ def test_read_volume_from_src():
 
 
 @testing.requires_testing_data
-@requires_nibabel()
 def test_combine_source_spaces(tmp_path):
     """Test combining source spaces."""
-    import nibabel as nib
     rng = np.random.RandomState(2)
     volume_labels = ['Brain-Stem', 'Right-Hippocampus']  # two fairly large
 

--- a/mne/tests/test_surface.py
+++ b/mne/tests/test_surface.py
@@ -4,9 +4,10 @@
 
 from pathlib import Path
 
-import pytest
+import nibabel as nib
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose, assert_equal
+import pytest
 
 from mne import (read_surface, write_surface, decimate_surface, pick_types,
                  dig_mri_distances, get_montage_volume_labels)
@@ -22,9 +23,8 @@ from mne.surface import (_compute_nearest, _tessellate_sphere, fast_cross_3d,
                          _project_onto_surface, _get_ico_surface)
 from mne.transforms import (_get_trans, compute_volume_registration,
                             apply_trans)
-from mne.utils import (catch_logging, object_diff,
-                       requires_freesurfer, requires_nibabel, requires_dipy,
-                       _record_warnings)
+from mne.utils import (catch_logging, object_diff, requires_freesurfer,
+                       requires_dipy, _record_warnings)
 
 data_path = testing.data_path(download=False)
 subjects_dir = data_path / "subjects"
@@ -118,7 +118,6 @@ def test_compute_nearest():
 @testing.requires_testing_data
 def test_io_surface(tmp_path):
     """Test reading and writing of Freesurfer surface mesh files."""
-    pytest.importorskip('nibabel')
     fname_quad = data_path / "subjects" / "bert" / "surf" / "lh.inflated.nofix"
     fname_tri = data_path / "subjects" / "sample" / "bem" / "inner_skull.surf"
     for fname in (fname_quad, fname_tri):
@@ -156,7 +155,6 @@ def test_io_surface(tmp_path):
 @testing.requires_testing_data
 def test_read_curv():
     """Test reading curvature data."""
-    pytest.importorskip('nibabel')
     fname_curv = data_path / "subjects" / "fsaverage" / "surf" / "lh.curv"
     fname_surf = data_path / "subjects" / "fsaverage" / "surf" / "lh.inflated"
     bin_curv = read_curvature(fname_curv)
@@ -259,7 +257,6 @@ def test_marching_cubes(dtype, value, smooth):
         _marching_cubes(data[0], [1])
 
 
-@requires_nibabel()
 @testing.requires_testing_data
 def test_get_montage_volume_labels():
     """Test finding ROI labels near montage channel locations."""
@@ -306,13 +303,11 @@ def test_voxel_neighbors():
     assert true_volume.difference(volume) == set()
 
 
-@requires_nibabel()
 @requires_dipy()
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_warp_montage_volume():
     """Test warping an montage based on intracranial electrode positions."""
-    import nibabel as nib
     subject_brain = nib.load(subjects_dir / "sample" / "mri" / "brain.mgz")
     template_brain = nib.load(subjects_dir / "fsaverage" / "mri" / "brain.mgz")
     zooms = dict(translation=10, rigid=10, sdr=10)

--- a/mne/tests/test_transforms.py
+++ b/mne/tests/test_transforms.py
@@ -7,10 +7,11 @@ import itertools
 import os
 from pathlib import Path
 
-import pytest
+import nibabel as nib
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_equal, assert_allclose,
                            assert_array_less, assert_almost_equal)
+import pytest
 
 import mne
 from mne.datasets import testing
@@ -29,7 +30,7 @@ from mne.transforms import (invert_transform, _get_trans,
                             _write_fs_xfm, _quat_real, _fit_matched_points,
                             _quat_to_euler, _euler_to_quat,
                             _quat_to_affine, _compute_r2, _validate_pipeline)
-from mne.utils import requires_nibabel, requires_dipy
+from mne.utils import requires_dipy
 
 data_path = testing.data_path(download=False)
 fname = data_path / "MEG" / "sample" / "sample_audvis_trunc-trans.fif"
@@ -522,13 +523,11 @@ def test_euler(quats):
     assert_allclose(quat_rot, euler_rot, atol=1e-14)
 
 
-@requires_nibabel()
 @requires_dipy()
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_volume_registration():
     """Test volume registration."""
-    import nibabel as nib
     from dipy.align import resample
     T1 = nib.load(fname_t1)
     affine = np.eye(4)

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -1680,7 +1680,6 @@ def compute_volume_registration(moving, static, pipeline='all', zooms=None,
 
 def _compute_volume_registration(moving, static, pipeline, zooms, niter, *,
                                  starting_affine=None):
-    _require_version('nibabel', 'SDR morph', '2.1.0')
     _require_version('dipy', 'SDR morph', '0.10.1')
     import nibabel as nib
     with np.testing.suppress_warnings():
@@ -1794,7 +1793,6 @@ def apply_volume_registration(moving, static, reg_affine, sdr_morph=None,
     -----
     .. versionadded:: 0.24
     """
-    _require_version('nibabel', 'SDR morph', '2.1.0')
     _require_version('dipy', 'SDR morph', '0.10.1')
     from nibabel.spatialimages import SpatialImage
     from dipy.align.imwarp import DiffeomorphicMap

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -42,10 +42,10 @@ from .misc import (run_subprocess, _pl, _clean_names, pformat, _file_like,
                    _assert_no_instances, _resource_path, repr_html)
 from .progressbar import ProgressBar
 from ._testing import (run_command_if_main, requires_sklearn,
-                       requires_version, requires_nibabel, requires_mne,
+                       requires_version, requires_mne,
                        requires_good_network, requires_pandas, requires_h5py,
                        ArgvSetter, SilenceStdout, has_freesurfer, has_mne_c,
-                       _TempDir, has_nibabel, buggy_mkl_svd,
+                       _TempDir, buggy_mkl_svd,
                        requires_numpydoc, requires_freesurfer,
                        requires_nitime, requires_dipy, requires_mne_mark,
                        requires_neuromag2ft, requires_pylsl,

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -56,11 +56,6 @@ class _TempDir(str):
         rmtree(self._path, ignore_errors=True)
 
 
-def requires_nibabel():
-    """Wrap to requires_module with a function call (fewer lines to change)."""
-    return partial(requires_module, name='nibabel')
-
-
 def requires_dipy():
     """Check for dipy."""
     import pytest

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -222,22 +222,6 @@ class SilenceStdout(object):
         sys.stdout = self.stdout
 
 
-def has_nibabel():
-    """Determine if nibabel is installed.
-
-    Returns
-    -------
-    has : bool
-        True if the user has nibabel.
-    """
-    try:
-        import nibabel  # noqa
-    except ImportError:
-        return False
-    else:
-        return True
-
-
 def has_mne_c():
     """Check for MNE-C."""
     return 'MNE_ROOT' in os.environ

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -18,7 +18,7 @@ from mne.io.pick import pick_channels_cov, _picks_to_idx
 from mne.utils import (check_random_state, _check_fname, check_fname, _suggest,
                        _check_subject, _check_info_inv, _check_option, Bunch,
                        check_version, _path_like, _validate_type, _on_missing,
-                       requires_nibabel, _safe_input, _check_ch_locs,
+                       _safe_input, _check_ch_locs,
                        _check_sphere)
 
 data_path = testing.data_path(download=False)
@@ -186,7 +186,6 @@ def test_validate_type():
         _validate_type(False, 'int-like')
 
 
-@requires_nibabel()
 @testing.requires_testing_data
 def test_suggest():
     """Test suggestions."""

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -44,7 +44,7 @@ from ..transforms import (apply_trans, rot_to_quat, combine_transforms,
                           transform_surface_to, _frame_to_str,
                           _get_transforms_to_coord_frame)
 from ..utils import (get_subjects_dir, logger, _check_subject, verbose, warn,
-                     has_nibabel, check_version, fill_doc, _pl, get_config,
+                     check_version, fill_doc, _pl, get_config,
                      _ensure_int, _validate_type, _check_option, _to_rgb)
 from ._3d_overlay import _LayeredMesh
 from .utils import (mne_analyze_colormap, _get_color_list, _get_cmap,
@@ -3146,8 +3146,6 @@ def _plot_dipole_mri_orthoview(dipole, trans, subject, subjects_dir=None,
     """Plot dipoles on top of MRI slices in 3-D."""
     import matplotlib.pyplot as plt
     from mpl_toolkits.mplot3d import Axes3D
-    if not has_nibabel():
-        raise ImportError('This function requires nibabel.')
 
     _check_option('coord_frame', coord_frame, ['head', 'mri'])
 

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -34,7 +34,7 @@ from mne.viz import (plot_sparse_source_estimates, plot_source_estimates,
                      plot_brain_colorbar, link_brains, mne_analyze_colormap)
 from mne.viz._3d import _process_clim, _linearize_map, _get_map_ticks
 from mne.viz.utils import _fake_click, _fake_keypress, _fake_scroll, _get_cmap
-from mne.utils import requires_nibabel, catch_logging, _record_warnings
+from mne.utils import catch_logging, _record_warnings
 from mne.datasets import testing
 from mne.source_space import read_source_spaces
 from mne.transforms import Transform
@@ -580,7 +580,6 @@ def test_process_clim_round_trip():
 
 
 @testing.requires_testing_data
-@requires_nibabel()
 def test_stc_mpl():
     """Test plotting source estimates with matplotlib."""
     sample_src = read_source_spaces(src_fname)
@@ -612,7 +611,6 @@ def test_stc_mpl():
 @pytest.mark.slowtest
 @pytest.mark.timeout(60)  # can sometimes take > 60 s
 @testing.requires_testing_data
-@requires_nibabel()
 @pytest.mark.parametrize('coord_frame, idx, show_all, title',
                          [('head', 'gof', True, 'Test'),
                           ('mri', 'amplitude', False, None)])

--- a/mne/viz/tests/test_3d_mpl.py
+++ b/mne/viz/tests/test_3d_mpl.py
@@ -15,7 +15,7 @@ import pytest
 from mne import (read_forward_solution, VolSourceEstimate, SourceEstimate,
                  VolVectorSourceEstimate, compute_source_morph)
 from mne.datasets import testing
-from mne.utils import (requires_dipy, requires_nibabel, requires_version,
+from mne.utils import (requires_dipy, requires_version,
                        catch_logging, _record_warnings)
 from mne.viz import plot_volume_source_estimates
 from mne.viz.utils import _fake_click, _fake_keypress
@@ -30,7 +30,6 @@ fwd_fname = (
 @pytest.mark.slowtest  # can be slow on OSX
 @testing.requires_testing_data
 @requires_dipy()
-@requires_nibabel()
 @requires_version('nilearn', '0.4')
 @pytest.mark.parametrize(
     'mode, stype, init_t, want_t, init_p, want_p, bg_img', [
@@ -90,7 +89,6 @@ def test_plot_volume_source_estimates(mode, stype, init_t, want_t,
 @pytest.mark.slowtest  # can be slow on OSX
 @testing.requires_testing_data
 @requires_dipy()
-@requires_nibabel()
 @requires_version('nilearn', '0.4')
 def test_plot_volume_source_estimates_morph():
     """Test interactive plotting of volume source estimates with morph."""

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -25,7 +25,6 @@ from mne.viz import (plot_bem, plot_events, plot_source_spectrogram,
                      plot_snr_estimate, plot_filter, plot_csd, plot_chpi_snr)
 from mne.viz.misc import _handle_event_colors
 from mne.viz.utils import _get_color_list
-from mne.utils import requires_nibabel
 from mne.time_frequency import CrossSpectralDensity
 
 data_path = testing.data_path(download=False)
@@ -134,7 +133,6 @@ def test_plot_cov():
 
 
 @testing.requires_testing_data
-@requires_nibabel()
 def test_plot_bem():
     """Test plotting of BEM contours."""
     with pytest.raises(IOError, match='MRI file .* not found'):

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -8,3 +8,4 @@ decorator
 packaging
 jinja2
 importlib_resources>=5.10.2
+nibabel>=3.2.1

--- a/tutorials/preprocessing/25_background_filtering.py
+++ b/tutorials/preprocessing/25_background_filtering.py
@@ -22,7 +22,6 @@ Widmann *et al.* (2015) :footcite:`WidmannEtAl2015`.
    tutorial and read :ref:`tut-filter-resample` instead (but someday, you
    should come back and read this one too 🙂).
 
-
 Problem statement
 =================
 

--- a/tutorials/preprocessing/25_background_filtering.py
+++ b/tutorials/preprocessing/25_background_filtering.py
@@ -22,6 +22,7 @@ Widmann *et al.* (2015) :footcite:`WidmannEtAl2015`.
    tutorial and read :ref:`tut-filter-resample` instead (but someday, you
    should come back and read this one too 🙂).
 
+
 Problem statement
 =================
 


### PR DESCRIPTION
Just the start of a proof-of-concept for #11564, in addition to the lines I removed already in #11557. Would still need:

- [x] ~50 instances of `@requires_nibabel` to be removed
- [x] Revert `nibabel` part of #11566