### PR TITLE
Fix export to EDF format with a set physical range smaller than the data range

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -56,6 +56,7 @@ Bugs
 - Expand tilde (user directory) in config keys (:gh:`11537` by `Clemens Brunner`_)
 - Fix bug in :func:`mne.preprocessing.compute_maxwell_basis` where using ``int_order=0`` would raise an error (:gh:`11562` by `Eric Larson`_)
 - Fix :func:`mne.io.read_raw` for file names containing multiple dots (:gh:`11521` by `Clemens Brunner`_)
+- Fix bug in :func:`mne.export.export_raw` when exporting to EDF with a physical range set smaller than the data range (:gh:`11569` by `Mathieu Scheltienne`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -142,11 +142,15 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
 
         # check that physical min and max is not exceeded
         if data.max() > pmax:
-            raise RuntimeError(f'The maximum μV of the data {data.max()} is '
-                               f'more than the physical max passed in {pmax}.')
+            warn(
+                f"The maximum μV of the data {data.max()} is "
+                f"more than the physical max passed in {pmax}.",
+            )
         if data.min() < pmin:
-            raise RuntimeError(f'The minimum μV of the data {data.min()} is '
-                               f'less than the physical min passed in {pmin}.')
+            warn(
+                f"The minimum μV of the data {data.min()} is "
+                f"less than the physical min passed in {pmin}.",
+            )
 
     # create instance of EDF Writer
     with _auto_close(EDFwriter(fname, file_type, n_channels)) as hdl:


### PR DESCRIPTION
Today, I had a researcher from our sleep lab that came-in  with a ~8 hours long night recording that could not be converted to EDF either through the BrainVision software or through MNE. The converted signals were all "flat" (or mostly flat), and this was due to 10' in the recording (around hour 7 ) where the signal went completely off-scale, for whatever reason.

The physical range is estimated here https://github.com/mne-tools/mne-python/blob/6384a8901182272c48f3e72a10142ea75184f47f/mne/export/_edf.py#L122-L131

On a good file, I get: `pmin = ~ -130k` and `pmax= ~ 80k`. The range is in the `~ 250k` scale. On the bad file, the range was in the `~ 10M` or `100M` range, several order of magnitude larger. Thus, the conversion failed.

By setting the `physical_range` to `(-150000, 80000)` in the BrainVision software or in MNE, the data could be exported to EDF and the 10' segment off-scale is saturating as expected. However, in MNE, I did have to comment out this sanity-check https://github.com/mne-tools/mne-python/blob/6384a8901182272c48f3e72a10142ea75184f47f/mne/export/_edf.py#L143-L149

I am not familiar at all with the EDF format, and might be missing something; but IMO it should be a warning instead of a raise.



