### PR TITLE
pin pyvista to fix circle

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
 - imageio-ffmpeg>=0.4.1
 - vtk>=9.2
 - traitlets
-- pyvista>=0.32,!=0.35.2,!=0.38.0,!=0.38.1,!=0.38.2,!=0.38.3
+- pyvista>=0.32,!=0.35.2,<0.38.0
 - pyvistaqt>=0.4
 - qdarkstyle
 - darkdetect

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ xlrd
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1
 traitlets
-pyvista>=0.32,!=0.35.2,!=0.38.0,!=0.38.1,!=0.38.2,!=0.38.3,!=0.38.4,!=0.38.5
+pyvista>=0.32,!=0.35.2,<0.38.0
 pyvistaqt>=0.4
 mffpy>=0.5.7
 ipywidgets


### PR DESCRIPTION
Every release in the pyvista 0.38 series is failing, so let's just pin to <0.38 until it's sorted out.