### PR TITLE
DOC: attribute → attributes

### DIFF
--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -45,7 +45,7 @@ def read_raw_artemis123(input_fname, preload=False, verbose=None,
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
     return RawArtemis123(input_fname, preload=preload, verbose=verbose,
                          pos_fname=pos_fname, add_head_trans=add_head_trans)
@@ -299,7 +299,7 @@ class RawArtemis123(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
 
     @verbose

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -103,7 +103,7 @@ class BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin, SetChannelsMixin,
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
 
     Notes
     -----

--- a/mne/io/boxy/boxy.py
+++ b/mne/io/boxy/boxy.py
@@ -34,7 +34,7 @@ def read_raw_boxy(fname, preload=False, verbose=None):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
     return RawBOXY(fname, preload, verbose)
 
@@ -52,7 +52,7 @@ class RawBOXY(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
 
     @verbose

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -59,7 +59,7 @@ class RawBrainVision(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
 
     @verbose
@@ -883,7 +883,7 @@ def read_raw_brainvision(vhdr_fname,
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
     return RawBrainVision(vhdr_fname=vhdr_fname, eog=eog,
                           misc=misc, scale=scale, preload=preload,

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -1306,7 +1306,7 @@ def read_raw_bti(pdf_fname, config_fname='config',
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
     return RawBTi(pdf_fname, config_fname=config_fname,
                   head_shape_fname=head_shape_fname,

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -155,7 +155,7 @@ def read_raw_cnt(input_fname, eog=(), misc=(), ecg=(),
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
 
     Notes
     -----
@@ -376,7 +376,7 @@ class RawCNT(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
 
     def __init__(self, input_fname, eog=(), misc=(),

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -52,7 +52,7 @@ def read_raw_ctf(directory, system_clock='truncate', preload=False,
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
 
     Notes
     -----
@@ -88,7 +88,7 @@ class RawCTF(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
 
     @verbose

--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -504,7 +504,7 @@ class RawCurry(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
 
     """
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -276,7 +276,7 @@ def read_raw_eeglab(input_fname, eog=(), preload=False,
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
 
     Notes
     -----
@@ -330,7 +330,7 @@ def read_epochs_eeglab(input_fname, events=None, event_id=None,
 
     See Also
     --------
-    mne.Epochs : Documentation of attribute and methods.
+    mne.Epochs : Documentation of attributes and methods.
 
     Notes
     -----
@@ -364,7 +364,7 @@ class RawEEGLAB(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
 
     Notes
     -----
@@ -494,7 +494,7 @@ class EpochsEEGLAB(BaseEpochs):
 
     See Also
     --------
-    mne.Epochs : Documentation of attribute and methods.
+    mne.Epochs : Documentation of attributes and methods.
 
     Notes
     -----

--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -133,7 +133,7 @@ def read_raw_egi(input_fname, eog=None, misc=None,
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
 
     Notes
     -----

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -384,7 +384,7 @@ def _read_raw_egi_mff(input_fname, eog=None, misc=None,
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
 
     .. versionadded:: 0.15.0
     """

--- a/mne/io/eximia/eximia.py
+++ b/mne/io/eximia/eximia.py
@@ -29,7 +29,7 @@ def read_raw_eximia(fname, preload=False, verbose=None):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
     return RawEximia(fname, preload, verbose)
 
@@ -47,7 +47,7 @@ class RawEximia(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
 
     @verbose

--- a/mne/io/fil/fil.py
+++ b/mne/io/fil/fil.py
@@ -41,7 +41,7 @@ def read_raw_fil(binfile, precision='single', preload=False, *, verbose=None):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
     return RawFIL(binfile, precision=precision, preload=preload)
 
@@ -66,7 +66,7 @@ class RawFIL(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
 
     def __init__(self, binfile, precision='single', preload=False):

--- a/mne/io/hitachi/hitachi.py
+++ b/mne/io/hitachi/hitachi.py
@@ -33,7 +33,7 @@ def read_raw_hitachi(fname, preload=False, verbose=None):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
 
     Notes
     -----
@@ -59,7 +59,7 @@ class RawHitachi(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
 
     Notes
     -----

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -102,7 +102,7 @@ class RawKIT(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
 
     @verbose
@@ -318,7 +318,7 @@ class EpochsKIT(BaseEpochs):
 
     See Also
     --------
-    mne.Epochs : Documentation of attribute and methods.
+    mne.Epochs : Documentation of attributes and methods.
     """
 
     @verbose
@@ -830,7 +830,7 @@ def read_raw_kit(input_fname, mrk=None, elp=None, hsp=None, stim='>',
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
 
     Notes
     -----

--- a/mne/io/nedf/nedf.py
+++ b/mne/io/nedf/nedf.py
@@ -214,6 +214,6 @@ def read_raw_nedf(filename, preload=False, verbose=None):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
     return RawNedf(filename, preload, verbose)

--- a/mne/io/nicolet/nicolet.py
+++ b/mne/io/nicolet/nicolet.py
@@ -56,7 +56,7 @@ def read_raw_nicolet(input_fname, ch_type, eog=(),
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
     return RawNicolet(input_fname, ch_type, eog=eog, ecg=ecg,
                       emg=emg, misc=misc, preload=preload, verbose=verbose)
@@ -155,7 +155,7 @@ class RawNicolet(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
 
     def __init__(self, input_fname, ch_type, eog=(),

--- a/mne/io/nihon/nihon.py
+++ b/mne/io/nihon/nihon.py
@@ -41,7 +41,7 @@ def read_raw_nihon(fname, preload=False, verbose=None):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
     return RawNihon(fname, preload, verbose)
 
@@ -341,7 +341,7 @@ class RawNihon(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
 
     @verbose

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -42,7 +42,7 @@ def read_raw_nirx(fname, saturated='annotate', preload=False, verbose=None):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
 
     Notes
     -----
@@ -69,7 +69,7 @@ class RawNIRX(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
 
     Notes
     -----

--- a/mne/io/persyst/persyst.py
+++ b/mne/io/persyst/persyst.py
@@ -34,7 +34,7 @@ def read_raw_persyst(fname, preload=False, verbose=None):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
 
     Notes
     -----
@@ -60,7 +60,7 @@ class RawPersyst(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
 
     @verbose

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -49,7 +49,7 @@ def read_raw_snirf(fname, optode_frame="unknown", preload=False, verbose=None):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
     return RawSNIRF(fname, optode_frame, preload, verbose)
 
@@ -76,7 +76,7 @@ class RawSNIRF(BaseRaw):
 
     See Also
     --------
-    mne.io.Raw : Documentation of attribute and methods.
+    mne.io.Raw : Documentation of attributes and methods.
     """
 
     @verbose


### PR DESCRIPTION
#### Reference issue

Vaguely related to #11588.

#### What does this implement/fix?

Change
> Documentation of attribute and methods.

into
> Documentation of attribute**s** and methods.

#### Additional information

Matches an existing `attributes` here:
https://github.com/mne-tools/mne-python/blob/7d389814213b1f2c9e67c5af4049ee1b07654744/mne/io/edf/edf.py#L94