### PR TITLE
DOC: Link to Raw in doc of classes derived from BaseRaw

### DIFF
--- a/mne/io/boxy/boxy.py
+++ b/mne/io/boxy/boxy.py
@@ -31,10 +31,11 @@ def read_raw_boxy(fname, preload=False, verbose=None):
     -------
     raw : instance of RawBOXY
         A Raw object containing BOXY data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawBOXY.
     """
     return RawBOXY(fname, preload, verbose)
 

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -880,10 +880,11 @@ def read_raw_brainvision(vhdr_fname,
     -------
     raw : instance of RawBrainVision
         A Raw object containing BrainVision data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawBrainVision.
     """
     return RawBrainVision(vhdr_fname=vhdr_fname, eog=eog,
                           misc=misc, scale=scale, preload=preload,

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -1303,10 +1303,11 @@ def read_raw_bti(pdf_fname, config_fname='config',
     -------
     raw : instance of RawBTi
         A Raw object containing BTI data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawBTi.
     """
     return RawBTi(pdf_fname, config_fname=config_fname,
                   head_shape_fname=head_shape_fname,

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -152,10 +152,11 @@ def read_raw_cnt(input_fname, eog=(), misc=(), ecg=(),
     -------
     raw : instance of RawCNT.
         The raw data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawCNT.
 
     Notes
     -----

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -49,10 +49,11 @@ def read_raw_ctf(directory, system_clock='truncate', preload=False,
     -------
     raw : instance of RawCTF
         The raw data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawCTF.
 
     Notes
     -----

--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -487,6 +487,11 @@ def read_raw_curry(fname, preload=False, verbose=None):
     -------
     raw : instance of RawCurry
         A Raw object containing Curry data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
+
+    See Also
+    --------
+    mne.io.Raw : Documentation of attributes and methods of RawCurry.
     """
     return RawCurry(fname, preload, verbose)
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1310,7 +1310,7 @@ def _find_tal_idx(ch_names):
 def read_raw_edf(input_fname, eog=None, misc=None, stim_channel='auto',
                  exclude=(), infer_types=False, include=None, preload=False,
                  units=None, encoding='utf8', *, verbose=None):
-    """Reader function for EDF or EDF+ files.
+    """Reader function for EDF and EDF+ files.
 
     Parameters
     ----------
@@ -1357,12 +1357,14 @@ def read_raw_edf(input_fname, eog=None, misc=None, stim_channel='auto',
     -------
     raw : instance of RawEDF
         The raw instance.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
     mne.io.read_raw_bdf : Reader function for BDF files.
     mne.io.read_raw_gdf : Reader function for GDF files.
     mne.export.export_raw : Export function for EDF files.
+    mne.io.Raw : Documentation of attributes and methods of RawEDF.
 
     Notes
     -----
@@ -1467,11 +1469,13 @@ def read_raw_bdf(input_fname, eog=None, misc=None, stim_channel='auto',
     -------
     raw : instance of RawEDF
         The raw instance.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
     mne.io.read_raw_edf : Reader function for EDF and EDF+ files.
     mne.io.read_raw_gdf : Reader function for GDF files.
+    mne.io.Raw : Documentation of attributes and methods of RawEDF.
 
     Notes
     -----
@@ -1555,11 +1559,13 @@ def read_raw_gdf(input_fname, eog=None, misc=None, stim_channel='auto',
     -------
     raw : instance of RawGDF
         The raw instance.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
     mne.io.read_raw_edf : Reader function for EDF and EDF+ files.
     mne.io.read_raw_bdf : Reader function for BDF files.
+    mne.io.Raw : Documentation of attributes and methods of RawGDF.
 
     Notes
     -----

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -273,10 +273,11 @@ def read_raw_eeglab(input_fname, eog=(), preload=False,
     -------
     raw : instance of RawEEGLAB
         A Raw object containing EEGLAB .set data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawEEGLAB.
 
     Notes
     -----

--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -130,10 +130,11 @@ def read_raw_egi(input_fname, eog=None, misc=None,
     -------
     raw : instance of RawEGI
         A Raw object containing EGI data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawEGI.
 
     Notes
     -----

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -366,6 +366,7 @@ def _read_raw_egi_mff(input_fname, eog=None, misc=None,
     -------
     raw : instance of RawMff
         A Raw object containing EGI mff data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     Notes
     -----
@@ -384,7 +385,7 @@ def _read_raw_egi_mff(input_fname, eog=None, misc=None,
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawMff.
 
     .. versionadded:: 0.15.0
     """

--- a/mne/io/eximia/eximia.py
+++ b/mne/io/eximia/eximia.py
@@ -26,10 +26,11 @@ def read_raw_eximia(fname, preload=False, verbose=None):
     -------
     raw : instance of RawEximia
         A Raw object containing eXimia data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawEximia.
     """
     return RawEximia(fname, preload, verbose)
 

--- a/mne/io/fieldtrip/fieldtrip.py
+++ b/mne/io/fieldtrip/fieldtrip.py
@@ -43,6 +43,11 @@ def read_raw_fieldtrip(fname, info, data_name='data'):
     -------
     raw : instance of RawArray
         A Raw Object containing the loaded data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
+
+    See Also
+    --------
+    mne.io.Raw : Documentation of attributes and methods of RawArray.
     """
     read_mat = _import_pymatreader_funcs('FieldTrip I/O')
     fname = _check_fname(fname, overwrite='read', must_exist=True)

--- a/mne/io/fil/fil.py
+++ b/mne/io/fil/fil.py
@@ -38,10 +38,11 @@ def read_raw_fil(binfile, precision='single', preload=False, *, verbose=None):
     -------
     raw : instance of RawFIL
         The raw data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawFIL.
     """
     return RawFIL(binfile, precision=precision, preload=preload)
 
@@ -63,10 +64,11 @@ class RawFIL(BaseRaw):
     -------
     raw : instance of RawFIL
         The raw data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawFIL.
     """
 
     def __init__(self, binfile, precision='single', preload=False):

--- a/mne/io/hitachi/hitachi.py
+++ b/mne/io/hitachi/hitachi.py
@@ -30,10 +30,11 @@ def read_raw_hitachi(fname, preload=False, verbose=None):
     -------
     raw : instance of RawHitachi
         A Raw object containing Hitachi data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawHitachi.
 
     Notes
     -----

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -827,10 +827,11 @@ def read_raw_kit(input_fname, mrk=None, elp=None, hsp=None, stim='>',
     -------
     raw : instance of RawKIT
         A Raw object containing KIT data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawKIT.
 
     Notes
     -----

--- a/mne/io/nedf/nedf.py
+++ b/mne/io/nedf/nedf.py
@@ -211,9 +211,10 @@ def read_raw_nedf(filename, preload=False, verbose=None):
     -------
     raw : instance of RawNedf
         A Raw object containing NEDF data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawNedf.
     """
     return RawNedf(filename, preload, verbose)

--- a/mne/io/nihon/nihon.py
+++ b/mne/io/nihon/nihon.py
@@ -38,10 +38,11 @@ def read_raw_nihon(fname, preload=False, verbose=None):
     -------
     raw : instance of RawNihon
         A Raw object containing Nihon Kohden data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawNihon.
     """
     return RawNihon(fname, preload, verbose)
 

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -39,10 +39,11 @@ def read_raw_nirx(fname, saturated='annotate', preload=False, verbose=None):
     -------
     raw : instance of RawNIRX
         A Raw object containing NIRX data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawNIRX.
 
     Notes
     -----

--- a/mne/io/persyst/persyst.py
+++ b/mne/io/persyst/persyst.py
@@ -31,10 +31,11 @@ def read_raw_persyst(fname, preload=False, verbose=None):
     -------
     raw : instance of RawPersyst
         A Raw object containing Persyst data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawPersyst.
 
     Notes
     -----

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -46,10 +46,11 @@ def read_raw_snirf(fname, optode_frame="unknown", preload=False, verbose=None):
     -------
     raw : instance of RawSNIRF
         A Raw object containing fNIRS data.
+        See :class:`mne.io.Raw` for documentation of attributes and methods.
 
     See Also
     --------
-    mne.io.Raw : Documentation of attributes and methods.
+    mne.io.Raw : Documentation of attributes and methods of RawSNIRF.
     """
     return RawSNIRF(fname, optode_frame, preload, verbose)
 


### PR DESCRIPTION
#### Reference issue

Fixes #11588.

#### What does this implement/fix?

Because the returned classes **`RawEDF`** and **`RawGDF`** are not documented, add links to [`Raw`](https://mne.tools/stable/generated/mne.io.Raw.html) (instead of base class [`BaseRaw`](https://mne.tools/stable/generated/mne.io.BaseRaw.html) which is not well documented but shares the same API).