### PR TITLE
MAINT: Avoid specific PyVista versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
 - imageio-ffmpeg>=0.4.1
 - vtk>=9.2
 - traitlets
-- pyvista>=0.32,!=0.35.2,<0.38.0
+- pyvista>=0.32,!=0.35.2,!=0.38.0,!=0.38.1,!=0.38.2,!=0.38.3,!=0.38.4,!=0.38.5
 - pyvistaqt>=0.4
 - qdarkstyle
 - darkdetect

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ xlrd
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1
 traitlets
-pyvista>=0.32,!=0.35.2,<0.38.0
+pyvista>=0.32,!=0.35.2,!=0.38.0,!=0.38.1,!=0.38.2,!=0.38.3,!=0.38.4,!=0.38.5
 pyvistaqt>=0.4
 mffpy>=0.5.7
 ipywidgets


### PR DESCRIPTION
Now that the scraping bug is fixed in PyVista, we know the set of versions to avoid (0.38.0->0.38.5). If their next release is 0.39.0 we can change this to just `!=0.38` but for now this should work