### PR TITLE
MAINT: IOError is an alias of OSError

### DIFF
--- a/mne/_freesurfer.py
+++ b/mne/_freesurfer.py
@@ -134,7 +134,7 @@ def _get_mgz_header(fname):
     fname = _check_fname(fname, overwrite='read', must_exist=True,
                          name='MRI image')
     if fname.suffix != ".mgz":
-        raise IOError('Filename must end with .mgz')
+        raise OSError('Filename must end with .mgz')
     header_dtd = [('version', '>i4'), ('dims', '>i4', (4,)),
                   ('type', '>i4'), ('dof', '>i4'), ('goodRASFlag', '>i2'),
                   ('delta', '>f4', (3,)), ('Mdc', '>f4', (3, 3)),
@@ -569,7 +569,7 @@ def read_talxfm(subject, subjects_dir=None, verbose=None):
     if not path.is_file():
         path = subjects_dir / subject / "mri" / "T1.mgz"
     if not path.is_file():
-        raise IOError('mri not found: %s' % path)
+        raise OSError('mri not found: %s' % path)
     _, _, mri_ras_t, _, _ = _read_mri_info(path)
     mri_mni_t = combine_transforms(mri_ras_t, ras_mni_t, 'mri', 'mni_tal')
     return mri_mni_t
@@ -591,7 +591,7 @@ def _check_mri(mri, subject, subjects_dir):
     if op.basename(mri) == mri:
         err = (f'Ambiguous filename - found {mri!r} in current folder.\n'
                'If this is correct prefix name with relative or absolute path')
-        raise IOError(err)
+        raise OSError(err)
     return mri
 
 
@@ -746,7 +746,7 @@ def _get_head_surface(surf, subject, subjects_dir, bem=None, verbose=None):
                 return read_bem_surfaces(fname, on_defects='warn')[0]
             else:
                 return _read_mri_surface(fname)
-    raise IOError('No head surface found for subject '
+    raise OSError('No head surface found for subject '
                   f'{subject} after trying:\n' + '\n'.join(try_fnames))
 
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1134,10 +1134,10 @@ def read_annotations(fname, sfreq='auto', uint16_codec=None):
     elif name.startswith('events_') and fname.endswith('mat'):
         annotations = _read_brainstorm_annotations(fname)
     else:
-        raise IOError('Unknown annotation file format "%s"' % fname)
+        raise OSError('Unknown annotation file format "%s"' % fname)
 
     if annotations is None:
-        raise IOError('No annotation data found in file "%s"' % fname)
+        raise OSError('No annotation data found in file "%s"' % fname)
     return annotations
 
 

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -2247,7 +2247,7 @@ def _ensure_bem_surfaces(bem, extra_allow=(), name='bem'):
 def _check_file(fname, overwrite):
     """Prevent overwrites."""
     if op.isfile(fname) and not overwrite:
-        raise IOError(f'File {fname} exists, use --overwrite to overwrite it')
+        raise OSError(f'File {fname} exists, use --overwrite to overwrite it')
 
 
 _tri_levels = dict(

--- a/mne/commands/tests/test_commands.py
+++ b/mne/commands/tests/test_commands.py
@@ -165,7 +165,7 @@ def test_make_scalp_surfaces(tmp_path, monkeypatch):
         mne_make_scalp_surfaces.run()
         assert op.isfile(dense_fname)
         assert op.isfile(medium_fname)
-        with pytest.raises(IOError, match='overwrite'):
+        with pytest.raises(OSError, match='overwrite'):
             mne_make_scalp_surfaces.run()
     # actually check the outputs
     head_py = read_bem_surfaces(dense_fname)

--- a/mne/coreg.py
+++ b/mne/coreg.py
@@ -182,24 +182,24 @@ def create_default_subject(fs_home=None, update=False, subjects_dir=None,
     # make sure freesurfer files exist
     fs_src = os.path.join(fs_home, 'subjects', 'fsaverage')
     if not os.path.exists(fs_src):
-        raise IOError('fsaverage not found at %r. Is fs_home specified '
+        raise OSError('fsaverage not found at %r. Is fs_home specified '
                       'correctly?' % fs_src)
     for name in ('label', 'mri', 'surf'):
         dirname = os.path.join(fs_src, name)
         if not os.path.isdir(dirname):
-            raise IOError("Freesurfer fsaverage seems to be incomplete: No "
+            raise OSError("Freesurfer fsaverage seems to be incomplete: No "
                           "directory named %s found in %s" % (name, fs_src))
 
     # make sure destination does not already exist
     dest = os.path.join(subjects_dir, 'fsaverage')
     if dest == fs_src:
-        raise IOError(
+        raise OSError(
             "Your subjects_dir points to the freesurfer subjects_dir (%r). "
             "The default subject can not be created in the freesurfer "
             "installation directory; please specify a different "
             "subjects_dir." % subjects_dir)
     elif (not update) and os.path.exists(dest):
-        raise IOError(
+        raise OSError(
             "Can not create fsaverage because %r already exists in "
             "subjects_dir %r. Delete or rename the existing fsaverage "
             "subject folder." % ('fsaverage', subjects_dir))
@@ -527,7 +527,7 @@ def _find_mri_paths(subject, skip_fiducials, subjects_dir):
     subject : str
         Name of the mri subject.
     skip_fiducials : bool
-        Do not scale the MRI fiducials. If False, an IOError will be raised
+        Do not scale the MRI fiducials. If False, an OSError will be raised
         if no fiducials file can be found.
     subjects_dir : None | path-like
         Override the SUBJECTS_DIR environment variable
@@ -591,7 +591,7 @@ def _find_mri_paths(subject, skip_fiducials, subjects_dir):
         paths['fid'] = _find_fiducials_files(subject, subjects_dir)
         # check that we found at least one
         if len(paths['fid']) == 0:
-            raise IOError("No fiducials file found for %s. The fiducials "
+            raise OSError("No fiducials file found for %s. The fiducials "
                           "file should be named "
                           "{subject}/bem/{subject}-fiducials.fif. In "
                           "order to scale an MRI without fiducials set "
@@ -740,7 +740,7 @@ def read_mri_cfg(subject, subjects_dir=None):
     fname = subjects_dir / subject / "MRI scaling parameters.cfg"
 
     if not fname.exists():
-        raise IOError("%r does not seem to be a scaled mri subject: %r does "
+        raise OSError("%r does not seem to be a scaled mri subject: %r does "
                       "not exist." % (subject, fname))
 
     logger.info("Reading MRI cfg file %s" % fname)
@@ -864,7 +864,7 @@ def scale_bem(subject_to, bem_name, subject_from=None, scale=None,
                            name=bem_name)
 
     if os.path.exists(dst):
-        raise IOError("File already exists: %s" % dst)
+        raise OSError("File already exists: %s" % dst)
 
     surfs = read_bem_surfaces(src, on_defects=on_defects)
     for surf in surfs:
@@ -949,7 +949,7 @@ def scale_mri(subject_from, subject_to, scale, overwrite=False,
     subjects_dir : None | path-like
         Override the ``SUBJECTS_DIR`` environment variable.
     skip_fiducials : bool
-        Do not scale the MRI fiducials. If False (default), an IOError will be
+        Do not scale the MRI fiducials. If False (default), an OSError will be
         raised if no fiducials file can be found.
     labels : bool
         Also scale all labels (default True).
@@ -987,7 +987,7 @@ def scale_mri(subject_from, subject_to, scale, overwrite=False,
                                   subjects_dir=subjects_dir)
     if os.path.exists(dest):
         if not overwrite:
-            raise IOError("Subject directory for %s already exists: %r"
+            raise OSError("Subject directory for %s already exists: %r"
                           % (subject_to, dest))
         shutil.rmtree(dest)
 

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -542,7 +542,7 @@ def _read_dipole_text(fname):
         del line
     data = np.atleast_2d(np.array(data, float))
     if def_line is None:
-        raise IOError('Dipole text file is missing field definition '
+        raise OSError('Dipole text file is missing field definition '
                       'comment, cannot parse %s' % (fname,))
     # actually parse the fields
     def_line = def_line.lstrip('%').lstrip('#').strip()
@@ -575,7 +575,7 @@ def _read_dipole_text(fname):
     if len(ignored_fields) > 0:
         warn('Ignoring extra fields in dipole file: %s' % (ignored_fields,))
     if len(fields) != data.shape[1]:
-        raise IOError('More data fields (%s) found than data columns (%s): %s'
+        raise OSError('More data fields (%s) found than data columns (%s): %s'
                       % (len(fields), data.shape[1], fields))
 
     logger.info("%d dipole(s) found" % len(data))

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -145,7 +145,7 @@ def _read_volume_info(fobj):
                 'zras', 'cras']:
         pair = fobj.readline().decode('utf-8').split('=')
         if pair[0].strip() != key or len(pair) != 2:
-            raise IOError('Error parsing volume info.')
+            raise OSError('Error parsing volume info.')
         if key in ('valid', 'filename'):
             volume_info[key] = pair[1].strip()
         elif key == 'volume':

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1880,7 +1880,7 @@ def _do_forward_solution(subject, meas, fname=None, src=None, spacing=None,
             try:
                 write_trans(trans, trans_data)
             except Exception:
-                raise IOError('trans was a dict, but could not be '
+                raise OSError('trans was a dict, but could not be '
                               'written to disk as a transform file')
         elif isinstance(trans, (str, Path, PathLike)):
             _check_fname(trans, "read", must_exist=True, name="trans")
@@ -1894,7 +1894,7 @@ def _do_forward_solution(subject, meas, fname=None, src=None, spacing=None,
             try:
                 write_trans(mri, mri_data)
             except Exception:
-                raise IOError('mri was a dict, but could not be '
+                raise OSError('mri was a dict, but could not be '
                               'written to disk as a transform file')
         elif isinstance(mri, (str, Path, PathLike)):
             _check_fname(mri, "read", must_exist=True, name="mri")

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -406,7 +406,7 @@ class CoregistrationUI(HasTraits):
                 info_file = _check_fname(
                     fname, overwrite='read', must_exist=True, need_dir=False)
             valid = True
-        except IOError:
+        except OSError:
             valid = False
         if valid:
             style = dict(border="initial")
@@ -1151,7 +1151,7 @@ class CoregistrationUI(HasTraits):
                 self._renderer, surface, self._subject,
                 self._subjects_dir, bem, self._coord_frame, self._to_cf_t,
                 alpha=self._head_opacity)
-        except IOError:
+        except OSError:
             head_actor, head_surf, _ = _plot_head_surface(
                 self._renderer, "head", self._subject, self._subjects_dir,
                 bem, self._coord_frame, self._to_cf_t,

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -107,7 +107,7 @@ def _get_artemis123_info(fname, pos_fname=None):
                 elif sectionFlag == 2:
                     values = line.strip().split('\t')
                     if len(values) != 7:
-                        raise IOError('Error parsing line \n\t:%s\n' % line +
+                        raise OSError('Error parsing line \n\t:%s\n' % line +
                                       'from file %s' % header)
                     tmp = dict()
                     for k, v in zip(chan_keys, values):

--- a/mne/io/artemis123/utils.py
+++ b/mne/io/artemis123/utils.py
@@ -13,7 +13,7 @@ def _load_mne_locs(fname=None):
         fname = op.join(resource_dir, 'Artemis123_mneLoc.csv')
 
     if not op.exists(fname):
-        raise IOError('MNE locs file "%s" does not exist' % (fname))
+        raise OSError('MNE locs file "%s" does not exist' % (fname))
 
     logger.info('Loading mne loc file {}'.format(fname))
     locs = dict()

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -469,7 +469,7 @@ def _get_hdr_info(hdr_fname, eog, misc, scale):
     ext = op.splitext(hdr_fname)[-1]
     ahdr_format = (ext == '.ahdr')
     if ext not in ('.vhdr', '.ahdr'):
-        raise IOError("The header file must be given to read the data, "
+        raise OSError("The header file must be given to read the data, "
                       "not a file with extension '%s'." % ext)
 
     settings, cfg, cinfostr, info = _aux_hdr_info(hdr_fname)

--- a/mne/io/brainvision/tests/test_brainvision.py
+++ b/mne/io/brainvision/tests/test_brainvision.py
@@ -498,7 +498,7 @@ def test_brainvision_data_software_filters_latin1_global_units():
 
 def test_brainvision_data():
     """Test reading raw Brain Vision files."""
-    pytest.raises(IOError, read_raw_brainvision, vmrk_path)
+    pytest.raises(OSError, read_raw_brainvision, vmrk_path)
     pytest.raises(ValueError, read_raw_brainvision, vhdr_path,
                   preload=True, scale="foo")
 

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -147,7 +147,7 @@ class RawCTF(BaseRaw):
             raw_extras.append(sample_info)
             first_samps = [0] * len(last_samps)
         if len(fnames) == 0:
-            raise IOError(
+            raise OSError(
                 f'Could not find any data, could not find the following '
                 f'file(s): {missing_names}, and the following file(s) had no '
                 f'valid samples: {no_samps}')

--- a/mne/io/ctf/res4.py
+++ b/mne/io/ctf/res4.py
@@ -19,7 +19,7 @@ def _make_ctf_name(directory, extra, raise_error=True):
     found = True
     if not op.isfile(fname):
         if raise_error:
-            raise IOError('Standard file %s not found' % fname)
+            raise OSError('Standard file %s not found' % fname)
         found = False
     return fname, found
 

--- a/mne/io/ctf/tests/test_ctf.py
+++ b/mne/io/ctf/tests/test_ctf.py
@@ -416,7 +416,7 @@ def test_missing_res4(tmp_path):
                     tmp_path / ctf_fname_continuous)
     read_raw_ctf(use_ds)
     os.remove(use_ds / (ctf_fname_continuous[:-2] + 'meg4'))
-    with pytest.raises(IOError, match='could not find the following'):
+    with pytest.raises(OSError, match='could not find the following'):
         read_raw_ctf(use_ds)
 
 

--- a/mne/io/curry/tests/test_curry.py
+++ b/mne/io/curry/tests/test_curry.py
@@ -296,7 +296,7 @@ def test_check_missing_files():
     """Test checking for missing curry files (smoke test)."""
     invalid_fname = "/invalid/path/name.xy"
 
-    with pytest.raises(IOError, match="file type .*? must end with"):
+    with pytest.raises(OSError, match="file type .*? must end with"):
         _read_events_curry(invalid_fname)
 
     with pytest.raises(FileNotFoundError, match='does not exist'):

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -42,7 +42,7 @@ def _check_eeglab_fname(fname, dataname):
             'Old data format .dat detected. Please update your EEGLAB '
             'version and resave the data in .fdt format')
     elif fmt != '.fdt':
-        raise IOError('Expected .fdt file format. Found %s format' % fmt)
+        raise OSError('Expected .fdt file format. Found %s format' % fmt)
 
     basedir = op.dirname(fname)
     data_fname = op.join(basedir, dataname)

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -436,7 +436,7 @@ def _get_fname_rep(fname):
 def _check_entry(first, nent):
     """Sanity check entries."""
     if first >= nent:
-        raise IOError('Could not read data, perhaps this is a corrupt file')
+        raise OSError('Could not read data, perhaps this is a corrupt file')
 
 
 @fill_doc

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -220,7 +220,7 @@ def test_output_formats(tmp_path):
     for ii, (fmt, tol) in enumerate(zip(formats, tols)):
         # Let's test the overwriting error throwing while we're at it
         if ii > 0:
-            pytest.raises(IOError, raw.save, temp_file, fmt=fmt)
+            pytest.raises(OSError, raw.save, temp_file, fmt=fmt)
         raw.save(temp_file, fmt=fmt, overwrite=True)
         raw2 = read_raw_fif(temp_file)
         raw2_data = raw2[:, :][0]
@@ -1468,7 +1468,7 @@ def test_save(tmp_path):
         raw.save(temp_fname)
     raw.load_data()
     # can't overwrite file without overwrite=True
-    with pytest.raises(IOError, match='file exists'):
+    with pytest.raises(OSError, match='file exists'):
         raw.save(fif_fname)
 
     # test abspath support and annotations

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -573,7 +573,7 @@ def get_kit_info(rawfile, allow_unknown_format, standardize_names=None,
             elif channel_type == KIT.CHANNEL_NULL:
                 channels.append({'type': channel_type})
             else:
-                raise IOError("Unknown KIT channel type: %i" % channel_type)
+                raise OSError("Unknown KIT channel type: %i" % channel_type)
         exg_gains = np.array(exg_gains)
 
         #
@@ -639,7 +639,7 @@ def get_kit_info(rawfile, allow_unknown_format, standardize_names=None,
             else:
                 sqd['n_samples'] = sqd['frame_length'] * sqd['n_epochs']
         else:
-            raise IOError("Invalid acquisition type: %i. Your file is neither "
+            raise OSError("Invalid acquisition type: %i. Your file is neither "
                           "continuous nor epoched data." % (acq_type,))
 
         #
@@ -707,7 +707,7 @@ def get_kit_info(rawfile, allow_unknown_format, standardize_names=None,
     # precompute conversion factor for reading data
     if unsupported_format:
         if sysid not in LEGACY_AMP_PARAMS:
-            raise IOError("Legacy parameters for system ID %i unavailable" %
+            raise OSError("Legacy parameters for system ID %i unavailable" %
                           (sysid,))
         adc_range, adc_stored = LEGACY_AMP_PARAMS[sysid]
     is_meg = np.array([ch['type'] in KIT.CHANNELS_MEG for ch in channels])

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -291,7 +291,7 @@ def _test_raw_reader(reader, test_preloading=True, test_kwargs=True,
 
     # Test saving with not correct extension
     out_fname_h5 = op.join(tempdir, 'test_raw.h5')
-    with pytest.raises(IOError, match='raw must end with .fif or .fif.gz'):
+    with pytest.raises(OSError, match='raw must end with .fif or .fif.gz'):
         raw.save(out_fname_h5)
 
     raw3 = read_raw_fif(out_fname)

--- a/mne/io/write.py
+++ b/mne/io/write.py
@@ -368,7 +368,7 @@ def check_fiff_length(fid, close=True):
     if fid.tell() > 2147483648:  # 2 ** 31, FIFF uses signed 32-bit locations
         if close:
             fid.close()
-        raise IOError('FIFF file exceeded 2GB limit, please split file, reduce'
+        raise OSError('FIFF file exceeded 2GB limit, please split file, reduce'
                       ' split_size (if possible), or save to a different '
                       'format')
 

--- a/mne/label.py
+++ b/mne/label.py
@@ -1954,7 +1954,7 @@ def _read_annot_cands(dir_name, raise_error=True):
     if not op.isdir(dir_name):
         if not raise_error:
             return list()
-        raise IOError('Directory for annotation does not exist: %s',
+        raise OSError('Directory for annotation does not exist: %s',
                       dir_name)
     cands = os.listdir(dir_name)
     cands = sorted(set(c.replace('lh.', '').replace('rh.', '').replace(
@@ -1990,10 +1990,10 @@ def _read_annot(fname):
         dir_name = op.split(fname)[0]
         cands = _read_annot_cands(dir_name)
         if len(cands) == 0:
-            raise IOError('No such file %s, no candidate parcellations '
+            raise OSError('No such file %s, no candidate parcellations '
                           'found in directory' % fname)
         else:
-            raise IOError('No such file %s, candidate parcellations in '
+            raise OSError('No such file %s, candidate parcellations in '
                           'that directory:\n%s' % (fname, '\n'.join(cands)))
     with open(fname, "rb") as fid:
         n_verts = np.fromfile(fid, '>i4', 1)[0]

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -198,7 +198,7 @@ def compute_source_morph(src, subject_from=None, subject_to='fsaverage',
         # let's KISS and use `brain.mgz`, too
         mri_path_to = op.join(subjects_dir, subject_to, mri_subpath)
         if not op.isfile(mri_path_to):
-            raise IOError('cannot read file: %s' % mri_path_to)
+            raise OSError('cannot read file: %s' % mri_path_to)
         logger.info('    Loading %s as "to" volume' % mri_path_to)
         with warnings.catch_warnings():
             mri_to = nib.load(mri_path_to)

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -460,7 +460,7 @@ def _iterate_trans_views(function, alpha, **kwargs):
             return _itv(
                 function, fig, surfaces={'head-dense': alpha}, **kwargs
             )
-        except IOError:
+        except OSError:
             return _itv(function, fig, surfaces={'head': alpha}, **kwargs)
     finally:
         backend._close_3d_figure(fig)

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -261,7 +261,7 @@ def read_source_estimate(fname, subject=None):
                 err = ("Invalid .stc filename: %r; needs to end with "
                        "hemisphere tag ('...-lh.stc' or '...-rh.stc')"
                        % fname)
-                raise IOError(err)
+                raise OSError(err)
         elif fname.endswith('.w'):
             ftype = 'w'
             if fname.endswith(('-lh.w', '-rh.w')):
@@ -270,7 +270,7 @@ def read_source_estimate(fname, subject=None):
                 err = ("Invalid .w filename: %r; needs to end with "
                        "hemisphere tag ('...-lh.w' or '...-rh.w')"
                        % fname)
-                raise IOError(err)
+                raise OSError(err)
         elif fname.endswith('.h5'):
             ftype = 'h5'
             fname = fname[:-3]
@@ -292,9 +292,9 @@ def read_source_estimate(fname, subject=None):
             ftype = 'h5'
             fname += '-stc'
         elif any(stc_exist) or any(w_exist):
-            raise IOError("Hemisphere missing for %r" % fname_arg)
+            raise OSError("Hemisphere missing for %r" % fname_arg)
         else:
-            raise IOError("SourceEstimate File(s) not found for: %r"
+            raise OSError("SourceEstimate File(s) not found for: %r"
                           % fname_arg)
 
     # read the files
@@ -307,7 +307,7 @@ def read_source_estimate(fname, subject=None):
             kwargs['tmin'] = 0.0
             kwargs['tstep'] = 0.0
         else:
-            raise IOError('Volume source estimate must end with .stc or .w')
+            raise OSError('Volume source estimate must end with .stc or .w')
         kwargs['vertices'] = [kwargs['vertices']]
     elif ftype == 'surface':  # stc file with surface source spaces
         lh = _read_stc(fname + '-lh.stc')

--- a/mne/source_space.py
+++ b/mne/source_space.py
@@ -1410,7 +1410,7 @@ def setup_source_space(subject, spacing='oct6', surface='white',
     ]
     for surf, hemi in zip(surfs, ['LH', 'RH']):
         if surf is not None and not op.isfile(surf):
-            raise IOError('Could not find the %s surface %s'
+            raise OSError('Could not find the %s surface %s'
                           % (hemi, surf))
 
     logger.info('Setting up the source space with the following parameters:\n')
@@ -1675,7 +1675,7 @@ def setup_volume_source_space(subject=None, pos=5.0, mri=None,
             surf_extra = 'dict()'
         else:
             if not op.isfile(surface):
-                raise IOError('surface file "%s" not found' % surface)
+                raise OSError('surface file "%s" not found' % surface)
             surf_extra = surface
         logger.info('Boundary surface file : %s', surf_extra)
     else:
@@ -2381,7 +2381,7 @@ def _ensure_src(src, kind=None, extra='', verbose=None):
     if _path_like(src):
         src = str(src)
         if not op.isfile(src):
-            raise IOError('Source space file "%s" not found' % src)
+            raise OSError('Source space file "%s" not found' % src)
         logger.info('Reading %s...' % src)
         src = read_source_spaces(src, verbose=False)
     if not isinstance(src, SourceSpaces):

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -95,7 +95,7 @@ def _get_head_surface(subject, source, subjects_dir, on_defects,
             # let's do a more sophisticated search
             path = op.join(subjects_dir, subject, 'bem')
             if not op.isdir(path):
-                raise IOError('Subject bem directory "%s" does not exist.'
+                raise OSError('Subject bem directory "%s" does not exist.'
                               % path)
             files = sorted(glob(op.join(path, '%s*%s.fif'
                                         % (subject, this_source))))
@@ -114,7 +114,7 @@ def _get_head_surface(subject, source, subjects_dir, on_defects,
 
     if surf is None:
         if raise_error:
-            raise IOError('No file matching "%s*%s" and containing a head '
+            raise OSError('No file matching "%s*%s" and containing a head '
                           'surface found.' % (subject, this_source))
         else:
             return surf
@@ -1621,7 +1621,7 @@ def read_tri(fname_in, swap=False, verbose=None):
     elif n_items in [4, 7]:
         inds = range(1, 4)
     else:
-        raise IOError('Unrecognized format of data.')
+        raise OSError('Unrecognized format of data.')
     rr = np.array([np.array([float(v) for v in line.split()])[inds]
                    for line in lines[1:n_nodes + 1]])
     tris = np.array([np.array([int(v) for v in line.split()])[inds]

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -66,7 +66,7 @@ def test_basics():
     raw = read_raw_fif(fif_fname)
     assert raw.annotations is not None
     assert len(raw.annotations.onset) == 0
-    pytest.raises(IOError, read_annotations, fif_fname)
+    pytest.raises(OSError, read_annotations, fif_fname)
     onset = np.array(range(10))
     duration = np.ones(10)
     description = np.repeat('test', 10)
@@ -234,7 +234,7 @@ def test_crop(tmp_path):
     assert_array_equal(annot_read.description, raw.annotations.description)
     annot = Annotations((), (), ())
     annot.save(fname, overwrite=True)
-    pytest.raises(IOError, read_annotations, fif_fname)  # none in old raw
+    pytest.raises(OSError, read_annotations, fif_fname)  # none in old raw
     annot = read_annotations(fname)
     assert isinstance(annot, Annotations)
     assert len(annot) == 0

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -88,7 +88,7 @@ def test_io_bem(tmp_path, ext):
     surf = read_bem_surfaces(fname_bem_3, patch_stats=True)
     surf = read_bem_surfaces(fname_bem_3, patch_stats=False)
     write_bem_surfaces(temp_bem, surf[0])
-    with pytest.raises(IOError, match='exists'):
+    with pytest.raises(OSError, match='exists'):
         write_bem_surfaces(temp_bem, surf[0])
     write_bem_surfaces(temp_bem, surf[0], overwrite=True)
     if ext == 'h5':

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -120,7 +120,7 @@ def test_read_write_head_pos(tmp_path):
     pytest.raises(ValueError, write_head_pos, temp_name, 'foo')  # not array
     pytest.raises(ValueError, write_head_pos, temp_name, head_pos_read[:, :9])
     pytest.raises(TypeError, read_head_pos, 0)
-    pytest.raises(IOError, read_head_pos, "101")
+    pytest.raises(OSError, read_head_pos, "101")
 
 
 @testing.requires_testing_data

--- a/mne/tests/test_coreg.py
+++ b/mne/tests/test_coreg.py
@@ -211,7 +211,7 @@ def test_scale_mri_xfm(tmp_path, few_surfaces, subjects_dir_tmp_few):
         if subject_from == 'fsaverage':
             overwrite = skip_fiducials = False
         else:
-            with pytest.raises(IOError, match='No fiducials file'):
+            with pytest.raises(OSError, match='No fiducials file'):
                 scale_mri(
                     subject_from,
                     subject_to,
@@ -219,7 +219,7 @@ def test_scale_mri_xfm(tmp_path, few_surfaces, subjects_dir_tmp_few):
                     subjects_dir=subjects_dir_tmp_few,
                 )
             skip_fiducials = True
-            with pytest.raises(IOError, match='already exists'):
+            with pytest.raises(OSError, match='already exists'):
                 scale_mri(
                     subject_from,
                     subject_to, scale,

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -3250,7 +3250,7 @@ def test_save_overwrite(tmp_path):
 
     # scenario 2: overwrite=False and there is a file to overwrite
     # fname1 exists because of scenario 1 above
-    with pytest.raises(IOError, match='Destination file exists.'):
+    with pytest.raises(OSError, match='Destination file exists.'):
         epochs.save(fname1, overwrite=False)
 
     # scenario 3: overwrite=True and there isn't a file to overwrite
@@ -3260,7 +3260,7 @@ def test_save_overwrite(tmp_path):
     epochs.save(fname2, overwrite=True)
     # check that the file got written
     assert fname2.is_file()
-    with pytest.raises(IOError, match='exists'):
+    with pytest.raises(OSError, match='exists'):
         epochs.save(fname2)
 
     # scenario 4: overwrite=True and there is a file to overwrite

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -359,7 +359,7 @@ def test_annot_io(tmp_path):
     shutil.copy(surf_src / "rh.white", surf_dir)
 
     # read original labels
-    with pytest.raises(IOError, match='\nPALS_B12_Lobes$'):
+    with pytest.raises(OSError, match='\nPALS_B12_Lobes$'):
         read_labels_from_annot(subject, 'PALS_B12_Lobesey',
                                subjects_dir=tmp_path)
     labels = read_labels_from_annot(subject, 'PALS_B12_Lobes',
@@ -455,9 +455,9 @@ def test_read_labels_from_annot(tmp_path):
                   subjects_dir=subjects_dir)
     pytest.raises(ValueError, read_labels_from_annot, 'sample',
                   annot_fname='bla.annot', subjects_dir=subjects_dir)
-    with pytest.raises(IOError, match='does not exist'):
+    with pytest.raises(OSError, match='does not exist'):
         _read_annot_cands('foo')
-    with pytest.raises(IOError, match='no candidate'):
+    with pytest.raises(OSError, match='no candidate'):
         _read_annot(str(tmp_path))
 
     # read labels using hemi specification
@@ -977,7 +977,7 @@ def test_label_center_of_mass():
                   restrict_vertices='foo')
     pytest.raises(TypeError, label.center_of_mass, subjects_dir=subjects_dir,
                   surf=1)
-    pytest.raises(IOError, label.center_of_mass, subjects_dir=subjects_dir,
+    pytest.raises(OSError, label.center_of_mass, subjects_dir=subjects_dir,
                   surf='foo')
 
 

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -353,7 +353,7 @@ def test_volume_source_morph_basic(tmp_path):
         **kwargs)
 
     # check wrong subject_to
-    with pytest.raises(IOError, match='cannot read file'):
+    with pytest.raises(OSError, match='cannot read file'):
         compute_source_morph(fwd['src'], 'sample', '42',
                              subjects_dir=subjects_dir)
 
@@ -364,7 +364,7 @@ def test_volume_source_morph_basic(tmp_path):
     source_morph_vol_r = read_source_morph(tmp_path / 'vol-morph.h5')
 
     # check for invalid file name handling ()
-    with pytest.raises(IOError, match='not found'):
+    with pytest.raises(OSError, match='not found'):
         read_source_morph(tmp_path / '42')
 
     # check morph

--- a/mne/tests/test_source_space.py
+++ b/mne/tests/test_source_space.py
@@ -333,7 +333,7 @@ def test_volume_source_space(tmp_path):
         del src_new
         src_new = read_source_spaces(temp_name)
         _compare_source_spaces(src, src_new, mode='approx')
-    with pytest.raises(IOError, match='surface file.*not exist'):
+    with pytest.raises(OSError, match='surface file.*not exist'):
         setup_volume_source_space(
             'sample', surface='foo', mri=fname_mri, subjects_dir=subjects_dir)
     bem['surfs'][-1]['coord_frame'] = FIFF.FIFFV_COORD_HEAD

--- a/mne/tests/test_transforms.py
+++ b/mne/tests/test_transforms.py
@@ -87,7 +87,7 @@ def test_io_trans(tmp_path):
     assert trans0 == trans1
 
     # check reading non -trans.fif files
-    pytest.raises(IOError, read_trans, fname_eve)
+    pytest.raises(OSError, read_trans, fname_eve)
 
     # check warning on bad filenames
     fname2 = tmp_path / 'trans-test-bad-name.fif'

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -493,7 +493,7 @@ def test_io(tmp_path):
     assert_equal(tfr.comment, tfr2.comment)
     assert_equal(tfr.nave, tfr2.nave)
 
-    pytest.raises(IOError, tfr.save, fname)
+    pytest.raises(OSError, tfr.save, fname)
 
     tfr.comment = None
     # test old meas_date

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -462,7 +462,7 @@ def _get_trans(trans, fro='mri', to='head', allow_none=True):
             )
         trans = Path(trans)
         if not trans.is_file():
-            raise IOError(f'trans file "{trans}" not found')
+            raise OSError(f'trans file "{trans}" not found')
         if trans.suffix in ['.fif', '.gz']:
             fro_to_t = read_trans(trans)
         else:
@@ -561,7 +561,7 @@ def read_trans(fname, return_all=False, verbose=None):
                 if not return_all:
                     break
     if len(trans) == 0:
-        raise IOError('This does not seem to be a -trans.fif file.')
+        raise OSError('This does not seem to be a -trans.fif file.')
     return trans if return_all else trans[0]
 
 

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -56,7 +56,7 @@ def check_fname(fname, filetype, endings, endings_err=()):
     if len(endings_err) > 0 and not fname.endswith(endings_err):
         print_endings = ' or '.join([', '.join(endings_err[:-1]),
                                      endings_err[-1]])
-        raise IOError('The filename (%s) for file type %s must end with %s'
+        raise OSError('The filename (%s) for file type %s must end with %s'
                       % (fname, filetype, print_endings))
     print_endings = ' or '.join([', '.join(endings[:-1]), endings[-1]])
     if not fname.endswith(endings):
@@ -234,13 +234,13 @@ def _check_fname(
         if must_exist:
             if need_dir:
                 if not fname.is_dir():
-                    raise IOError(
+                    raise OSError(
                         f"Need a directory for {name} but found a file "
                         f"at {fname}"
                     )
             else:
                 if not fname.is_file():
-                    raise IOError(
+                    raise OSError(
                         f"Need a file for {name} but found a directory "
                         f"at {fname}"
                     )

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -43,7 +43,7 @@ def set_cache_dir(cache_dir):
         temporary file storage.
     """
     if cache_dir is not None and not op.exists(cache_dir):
-        raise IOError('Directory %s does not exist' % cache_dir)
+        raise OSError('Directory %s does not exist' % cache_dir)
 
     set_config('MNE_CACHE_DIR', cache_dir, set_env=False)
 

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -48,7 +48,7 @@ def test_check(tmp_path):
     os.chmod(fname, orig_perms)
     os.remove(fname)
     assert not fname.is_file()
-    pytest.raises(IOError, check_fname, 'foo', 'tets-dip.x', (), ('.fif',))
+    pytest.raises(OSError, check_fname, 'foo', 'tets-dip.x', (), ('.fif',))
     pytest.raises(ValueError, _check_subject, None, None)
     pytest.raises(TypeError, _check_subject, None, 1)
     pytest.raises(TypeError, _check_subject, 1, None)

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -329,7 +329,7 @@ QToolBar::handle:vertical {
     else:
         try:
             file = open(theme, 'r')
-        except IOError:
+        except OSError:
             warn('Requested theme file not found, will use light instead: '
                  f'{repr(theme)}')
         else:

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -570,7 +570,7 @@ def plot_bem(subject, subjects_dir=None, orientation='coronal',
     bem_path = subjects_dir / subject / "bem"
 
     if not bem_path.is_dir():
-        raise IOError(f'Subject bem directory "{bem_path}" does not exist')
+        raise OSError(f'Subject bem directory "{bem_path}" does not exist')
 
     surfaces = _get_bem_plotting_surfaces(bem_path)
     if brain_surfaces is not None:
@@ -584,7 +584,7 @@ def plot_bem(subject, subjects_dir=None, orientation='coronal',
                 if surf_fname.exists():
                     surfaces.append((surf_fname, '#00DD00'))
                 else:
-                    raise IOError("Surface %s does not exist." % surf_fname)
+                    raise OSError("Surface %s does not exist." % surf_fname)
 
     if isinstance(src, (str, Path, os.PathLike)):
         src = Path(src)
@@ -592,7 +592,7 @@ def plot_bem(subject, subjects_dir=None, orientation='coronal',
             # convert to Path until get_subjects_dir returns a Path object
             src_ = Path(subjects_dir) / subject / "bem" / src
             if not src_.exists():
-                raise IOError(f"{src} does not exist")
+                raise OSError(f"{src} does not exist")
             src = src_
         src = read_source_spaces(src)
     elif src is not None and not isinstance(src, SourceSpaces):
@@ -602,7 +602,7 @@ def plot_bem(subject, subjects_dir=None, orientation='coronal',
         )
 
     if len(surfaces) == 0:
-        raise IOError('No surface files found. Surface files must end with '
+        raise OSError('No surface files found. Surface files must end with '
                       'inner_skull.surf, outer_skull.surf or outer_skin.surf')
 
     # Plot the contours

--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -136,7 +136,7 @@ def test_plot_cov():
 def test_plot_bem():
     """Test plotting of BEM contours."""
     pytest.importorskip('nibabel')
-    with pytest.raises(IOError, match='MRI file .* not found'):
+    with pytest.raises(OSError, match='MRI file .* not found'):
         plot_bem(subject='bad-subject', subjects_dir=subjects_dir)
     with pytest.raises(ValueError, match="Invalid value for the 'orientation"):
         plot_bem(subject='sample', subjects_dir=subjects_dir,


### PR DESCRIPTION
#### Reference issue

None.

#### What does this implement/fix?

Starting from Python 3.3, IOError is an alias of OSError, and is kept for compatibility with previous versions.	

#### Additional information

See [Built-in Exceptions](https://docs.python.org/3/library/exceptions.html):
> _Changed in version 3.3:_ [`EnvironmentError`](https://docs.python.org/3/library/exceptions.html#EnvironmentError), [`IOError`](https://docs.python.org/3/library/exceptions.html#IOError), [`WindowsError`](https://docs.python.org/3/library/exceptions.html#WindowsError), [`socket.error`](https://docs.python.org/3/library/socket.html#socket.error), [`select.error`](https://docs.python.org/3/library/select.html#select.error) and `mmap.error` have been merged into [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError), and the constructor may return a subclass.