### PR TITLE
MAINT: In Python 3, do not prefix literals with `u`

### DIFF
--- a/mne/datasets/brainstorm/bst_phantom_elekta.py
+++ b/mne/datasets/brainstorm/bst_phantom_elekta.py
@@ -5,7 +5,7 @@ from ...utils import verbose
 from ..utils import (_get_version, _version_doc,
                      _data_path_doc_accept, _download_mne_dataset)
 
-_description = u"""
+_description = """
 URL: http://neuroimage.usc.edu/brainstorm/Tutorials/PhantomElekta
 """
 

--- a/mne/datasets/hf_sef/hf_sef.py
+++ b/mne/datasets/hf_sef/hf_sef.py
@@ -14,7 +14,7 @@ from ..config import MNE_DATASETS
 @verbose
 def data_path(dataset='evoked', path=None, force_update=False,
               update_path=True, *, verbose=None):
-    u"""Get path to local copy of the high frequency SEF dataset.
+    """Get path to local copy of the high frequency SEF dataset.
 
     Gets a local copy of the high frequency SEF MEG dataset
     :footcite:`NurminenEtAl2017`.

--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -67,7 +67,7 @@ def _sklearn_reshape_apply(func, return_result, X, *args, **kwargs):
 
 @fill_doc
 class Scaler(TransformerMixin, BaseEstimator):
-    u"""Standardize channel data.
+    """Standardize channel data.
 
     This class scales data for each channel. It differs from scikit-learn
     classes (e.g., :class:`sklearn.preprocessing.StandardScaler`) in that

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -44,7 +44,7 @@ from .viz import plot_dipole_locations
 
 @fill_doc
 class Dipole(TimeMixin):
-    u"""Dipole class for sequential dipole fits.
+    """Dipole class for sequential dipole fits.
 
     .. note::
         This class should usually not be instantiated directly via

--- a/mne/io/meas_info.py
+++ b/mne/io/meas_info.py
@@ -72,7 +72,7 @@ def _get_valid_units():
                           'micro', 'milli', 'centi', 'deci', 'deca', 'hecto',
                           'kilo', 'mega', 'giga', 'tera', 'peta', 'exa',
                           'zetta', 'yotta']
-    valid_prefix_symbols = ['y', 'z', 'a', 'f', 'p', 'n', u'µ', 'm', 'c', 'd',
+    valid_prefix_symbols = ['y', 'z', 'a', 'f', 'p', 'n', 'µ', 'm', 'c', 'd',
                             'da', 'h', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
     valid_unit_names = ['metre', 'kilogram', 'second', 'ampere', 'kelvin',
                         'mole', 'candela', 'radian', 'steradian', 'hertz',
@@ -81,8 +81,8 @@ def _get_valid_units():
                         'degree Celsius', 'lumen', 'lux', 'becquerel', 'gray',
                         'sievert', 'katal']
     valid_unit_symbols = ['m', 'kg', 's', 'A', 'K', 'mol', 'cd', 'rad', 'sr',
-                          'Hz', 'N', 'Pa', 'J', 'W', 'C', 'V', 'F', u'Ω', 'S',
-                          'Wb', 'T', 'H', u'°C', 'lm', 'lx', 'Bq', 'Gy', 'Sv',
+                          'Hz', 'N', 'Pa', 'J', 'W', 'C', 'V', 'F', 'Ω', 'S',
+                          'Wb', 'T', 'H', '°C', 'lm', 'lx', 'Bq', 'Gy', 'Sv',
                           'kat']
 
     # Valid units are all possible combinations of either prefix name or prefix

--- a/mne/io/open.py
+++ b/mne/io/open.py
@@ -310,7 +310,7 @@ def _show_tree(fid, tree, indent, level, read_limit, max_str, tag_id):
                         '/'.join(this_type) +
                         ' (' + str(size) + 'b %s)' % type_ +
                         postpend]
-                out[-1] = out[-1].replace('\n', u'¶')
+                out[-1] = out[-1].replace('\n', '¶')
                 counter = 0
                 good = True
         if tag_id in kinds:

--- a/mne/io/proc_history.py
+++ b/mne/io/proc_history.py
@@ -228,7 +228,7 @@ def _read_maxfilter_record(fid, tree):
                     tag = read_tag(fid, pos)
                     chs = _safe_name_list(tag.data, 'read', 'proj_items_chs')
                     # This list can null chars in the last entry, e.g.:
-                    # [..., u'MEG2642', u'MEG2643', u'MEG2641\x00 ... \x00']
+                    # [..., 'MEG2642', 'MEG2643', 'MEG2641\x00 ... \x00']
                     chs[-1] = chs[-1].split('\x00')[0]
                     sss_ctc['proj_items_chs'] = chs
 

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -248,7 +248,7 @@ def test_read_write_info(tmp_path):
     assert (len(info['chs']) == len(info2['chs']))
     assert_array_equal(t1, t2)
     # proc_history (e.g., GH#1875)
-    creator = u'é'
+    creator = 'é'
     info = read_info(chpi_fname)
     info['proc_history'][0]['creator'] = creator
     info['hpi_meas'][0]['creator'] = creator

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -632,8 +632,8 @@ class SourceMorph:
         return img_to
 
     def __repr__(self):  # noqa: D105
-        s = u"%s" % self.kind
-        s += u", %s -> %s" % (self.subject_from, self.subject_to)
+        s = "%s" % self.kind
+        s += ", %s -> %s" % (self.subject_from, self.subject_to)
         if self.kind == 'volume':
             s += ", zooms : {}".format(self.zooms)
             s += ", niter_affine : {}".format(self.niter_affine)

--- a/mne/preprocessing/artifact_detection.py
+++ b/mne/preprocessing/artifact_detection.py
@@ -181,8 +181,8 @@ def annotate_movement(raw, pos, rotation_velocity_limit=None,
         onsets, offsets = _mask_to_onsets_offsets(bad_mask)
         onsets, offsets = hp_ts[onsets], hp_ts[offsets]
         bad_pct = 100 * (offsets - onsets).sum() / t_tot
-        logger.info(u'Omitting %5.1f%% (%3d segments): '
-                    u'ω >= %5.1f°/s (max: %0.1f°/s)'
+        logger.info('Omitting %5.1f%% (%3d segments): '
+                    'ω >= %5.1f°/s (max: %0.1f°/s)'
                     % (bad_pct, len(onsets), rotation_velocity_limit,
                        np.rad2deg(r.max())))
         annot += _annotations_from_mask(
@@ -197,8 +197,8 @@ def annotate_movement(raw, pos, rotation_velocity_limit=None,
         onsets, offsets = _mask_to_onsets_offsets(bad_mask)
         onsets, offsets = hp_ts[onsets], hp_ts[offsets]
         bad_pct = 100 * (offsets - onsets).sum() / t_tot
-        logger.info(u'Omitting %5.1f%% (%3d segments): '
-                    u'v >= %5.4fm/s (max: %5.4fm/s)'
+        logger.info('Omitting %5.1f%% (%3d segments): '
+                    'v >= %5.4fm/s (max: %5.4fm/s)'
                     % (bad_pct, len(onsets), translation_velocity_limit,
                        v.max()))
         annot += _annotations_from_mask(
@@ -242,8 +242,8 @@ def annotate_movement(raw, pos, rotation_velocity_limit=None,
         onsets, offsets = _mask_to_onsets_offsets(bad_mask)
         onsets, offsets = hp_ts[onsets], hp_ts[offsets]
         bad_pct = 100 * (offsets - onsets).sum() / t_tot
-        logger.info(u'Omitting %5.1f%% (%3d segments): '
-                    u'disp >= %5.4fm (max: %5.4fm)'
+        logger.info('Omitting %5.1f%% (%3d segments): '
+                    'disp >= %5.4fm (max: %5.4fm)'
                     % (bad_pct, len(onsets), mean_distance_limit, disp.max()))
         annot += _annotations_from_mask(
             hp_ts, bad_mask, 'BAD_mov_dist', orig_time=orig_time)

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -149,7 +149,7 @@ _KNOWN_ICA_METHODS = ('fastica', 'infomax', 'picard')
 
 @fill_doc
 class ICA(ContainsMixin):
-    u"""Data decomposition using Independent Component Analysis (ICA).
+    """Data decomposition using Independent Component Analysis (ICA).
 
     This object estimates independent components from :class:`mne.io.Raw`,
     :class:`mne.Epochs`, or :class:`mne.Evoked` objects. Components can

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -2000,7 +2000,7 @@ def _regularize_in(int_order, ext_order, S_decomp, mag_or_fine,
 
 
 def _compute_sphere_activation_in(degrees):
-    u"""Compute the "in" power from random currents in a sphere.
+    """Compute the "in" power from random currents in a sphere.
 
     Parameters
     ----------

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -129,7 +129,7 @@ def _check_head_pos(head_pos, info, first_samp, times=None):
 def simulate_raw(info, stc=None, trans=None, src=None, bem=None, head_pos=None,
                  mindist=1.0, interp='cos2', n_jobs=None, use_cps=True,
                  forward=None, first_samp=0, max_iter=10000, verbose=None):
-    u"""Simulate raw data.
+    """Simulate raw data.
 
     Head movements can optionally be simulated using the ``head_pos``
     parameter.

--- a/mne/tests/test_chpi.py
+++ b/mne/tests/test_chpi.py
@@ -438,7 +438,7 @@ def test_simulate_calculate_head_pos_chpi():
     # Read info dict from raw FIF file
     info = read_info(raw_fname)
     # Tune the info structure
-    chpi_channel = u'STI201'
+    chpi_channel = 'STI201'
     ncoil = len(info['hpi_results'][0]['order'])
     coil_freq = 10 + np.arange(ncoil) * 5
     hpi_subsystem = {'event_channel': chpi_channel,

--- a/mne/viz/_brain/colormap.py
+++ b/mne/viz/_brain/colormap.py
@@ -64,7 +64,7 @@ def get_fill_colors(cols, n_fill):
 
 def calculate_lut(lut_table, alpha, fmin, fmid, fmax, center=None,
                   transparent=True):
-    u"""Transparent color map calculation.
+    """Transparent color map calculation.
 
     A colormap may be sequential or divergent. When the colormap is
     divergent indicate this by providing a value for 'center'. The

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -184,7 +184,7 @@ def plot_cov(cov, info, exclude=(), colorbar=True, proj=False, show_svd=True,
             axes[0, k].text(this_rank - 1, axes[0, k].get_ylim()[1],
                             'rank ≈ %d' % (this_rank,), ha='right', va='top',
                             color='r', alpha=0.5, zorder=4)
-            axes[0, k].set(ylabel=u'Noise σ (%s)' % unit, yscale='log',
+            axes[0, k].set(ylabel='Noise σ (%s)' % unit, yscale='log',
                            xlabel='Eigenvalue index', title=name,
                            xlim=[0, len(s) - 1])
         tight_layout(fig=fig_svd)
@@ -1357,9 +1357,9 @@ def plot_csd(csd, info=None, mode='csd', colorbar=True, cmap=None,
         if colorbar:
             cb = plt.colorbar(im, ax=[a for ax_ in axes for a in ax_])
             if mode == 'csd':
-                label = u'CSD'
+                label = 'CSD'
                 if ch_type in units:
-                    label += u' (%s)' % units[ch_type]
+                    label += ' (%s)' % units[ch_type]
                 cb.set_label(label)
             elif mode == 'coh':
                 cb.set_label('Coherence')

--- a/tutorials/stats-sensor-space/10_background_stats.py
+++ b/tutorials/stats-sensor-space/10_background_stats.py
@@ -263,7 +263,7 @@ p_type_I = 1 - (1 - alpha) ** N
 fig, ax = plt.subplots(figsize=(4, 3))
 ax.scatter(N, p_type_I, 3)
 ax.set(xlim=N[[0, -1]], ylim=[0, 1], xlabel=r'$N_{\mathrm{test}}$',
-       ylabel=u'Probability of at least\none type I error')
+       ylabel='Probability of at least\none type I error')
 ax.grid(True)
 fig.tight_layout()
 fig.show()


### PR DESCRIPTION
#### Reference issue

None.

#### What does this implement/fix?

In Python 3, string literals are `str` and support Unicode by default. No need to prefix with `u` to change them into `unicode` as in Python 2.
