### PR TITLE
ENH: Speed up code a bit

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -40,6 +40,7 @@ Enhancements
 - Add automatic projection of sEEG contact onto the inflated surface for :meth:`mne.viz.Brain.add_sensors` (:gh:`11436` by `Alex Rockhill`_)
 - Allow an image with intracranial electrode contacts (e.g. computed tomography) to be used without the freesurfer recon-all surfaces to locate contacts so that it doesn't have to be downsampled to freesurfer dimensions (for microelectrodes) and show an example :ref:`ex-ieeg-micro` with :func:`mne.transforms.apply_volume_registration_points` added to aid this transform (:gh:`11567` by `Alex Rockhill`_)
 - Use new :meth:`dipy.workflows.align.DiffeomorphicMap.transform_points` to transform a montage of intracranial contacts more efficiently (:gh:`11572` by `Alex Rockhill`_)
+- Improve performance of raw data browsing with many annotations (:gh:`11614` by `Eric Larson`_)
 - Add support for eyetracking data using :func:`mne.io.read_raw_eyelink` (:gh:`11152` by `Dominik Welke`_ and `Scott Huberty`_)
 
 Bugs

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -172,7 +172,7 @@
 
 .. _George O'Neill: https://georgeoneill.github.io
 
-.. _Guillaume Dumas: http://www.extrospection.eu
+.. _Guillaume Dumas: https://mila.quebec/en/person/guillaume-dumas
 
 .. _Guillaume Favelier: https://github.com/GuillaumeFavelier
 

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -312,16 +312,20 @@ class Annotations:
 
     def __iter__(self):
         """Iterate over the annotations."""
+        # Figure this out once ahead of time for consistency and speed (for
+        # thousands of annotations)
+        with_ch_names = self._any_ch_names()
         for idx in range(len(self.onset)):
-            yield self.__getitem__(idx)
+            yield self.__getitem__(idx, with_ch_names=with_ch_names)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key, *, with_ch_names=None):
         """Propagate indexing and slicing to the underlying numpy structure."""
         if isinstance(key, int_like):
             out_keys = ('onset', 'duration', 'description', 'orig_time')
             out_vals = (self.onset[key], self.duration[key],
                         self.description[key], self.orig_time)
-            if self._any_ch_names():
+            if with_ch_names or (with_ch_names is None and
+                                 self._any_ch_names()):
                 out_keys += ('ch_names',)
                 out_vals += (self.ch_names[key],)
             return OrderedDict(zip(out_keys, out_vals))

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -739,8 +739,8 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
         index : str | list of str | None
             Kind of index to use for the DataFrame. If ``None``, a sequential
             integer index (:class:`pandas.RangeIndex`) will be used. If a
-            :class:`str`, a :class:`pandas.Index`will be used (see Notes). If a
-            list of two or more string values, a :class:`pandas.MultiIndex`
+            :class:`str`, a :class:`pandas.Index` will be used (see Notes). If
+            a list of two or more string values, a :class:`pandas.MultiIndex`
             will be used. Defaults to ``None``.
         %(copy_df)s
         %(long_format_df_spe)s

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -739,10 +739,9 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
         index : str | list of str | None
             Kind of index to use for the DataFrame. If ``None``, a sequential
             integer index (:class:`pandas.RangeIndex`) will be used. If a
-            :class:`str`, a :class:`pandas.Index`, ``pandas.Int64Index``,
-            or ``pandas.Float64Index`` will be used (see Notes). If a list
-            of two or more string values, a :class:`pandas.MultiIndex` will be
-            used. Defaults to ``None``.
+            :class:`str`, a :class:`pandas.Index`will be used (see Notes). If a
+            list of two or more string values, a :class:`pandas.MultiIndex`
+            will be used. Defaults to ``None``.
         %(copy_df)s
         %(long_format_df_spe)s
         %(verbose)s

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -739,8 +739,8 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
         index : str | list of str | None
             Kind of index to use for the DataFrame. If ``None``, a sequential
             integer index (:class:`pandas.RangeIndex`) will be used. If a
-            :class:`str`, a :class:`pandas.Index`, :class:`pandas.Int64Index`,
-            or :class:`pandas.Float64Index` will be used (see Notes). If a list
+            :class:`str`, a :class:`pandas.Index`, ``pandas.Int64Index``,
+            or ``pandas.Float64Index`` will be used (see Notes). If a list
             of two or more string values, a :class:`pandas.MultiIndex` will be
             used. Defaults to ``None``.
         %(copy_df)s

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1658,12 +1658,11 @@ _index_df_base = """
 index : {} | None
     Kind of index to use for the DataFrame. If ``None``, a sequential
     integer index (:class:`pandas.RangeIndex`) will be used. If ``'time'``, a
-    ``pandas.Float64Index``, ``pandas.Int64Index``, {}or
-    :class:`pandas.TimedeltaIndex` will be used
+    ``pandas.Index``{} or :class:`pandas.TimedeltaIndex` will be used
     (depending on the value of ``time_format``). {}
 """
 
-datetime = ':class:`pandas.DatetimeIndex`, '
+datetime = ', :class:`pandas.DatetimeIndex`,'
 multiindex = ('If a list of two or more string values, a '
               ':class:`pandas.MultiIndex` will be created. ')
 raw = ("'time'", datetime, '')

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1658,7 +1658,7 @@ _index_df_base = """
 index : {} | None
     Kind of index to use for the DataFrame. If ``None``, a sequential
     integer index (:class:`pandas.RangeIndex`) will be used. If ``'time'``, a
-    :class:`pandas.Float64Index`, :class:`pandas.Int64Index`, {}or
+    ``pandas.Float64Index``, ``pandas.Int64Index``, {}or
     :class:`pandas.TimedeltaIndex` will be used
     (depending on the value of ``time_format``). {}
 """

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -886,7 +886,12 @@ something
 #                  interpolation='linear', time_viewer=True)
 #
 """, 1)
-    gallery_conf = dict(src_dir=str(tmp_path), compress_images=[])
+    gallery_conf = dict(
+        src_dir=str(tmp_path),
+        compress_images=[],
+        image_srcset=[],
+        matplotlib_animations=False,
+    )
     scraper = _BrainScraper()
     rst = scraper(block, block_vars, gallery_conf)
     assert brain.plotter is None  # closed
@@ -918,7 +923,12 @@ def test_brain_scraper(renderer_interactive_pyvistaqt, brain_gc, tmp_path):
     block_vars = dict(image_path_iterator=iter(fnames),
                       example_globals=dict(brain=brain))
     block = ('code', '', 1)
-    gallery_conf = dict(src_dir=str(tmp_path), compress_images=[])
+    gallery_conf = dict(
+        src_dir=str(tmp_path),
+        compress_images=[],
+        image_srcset=[],
+        matplotlib_animations=False,
+    )
     scraper = _BrainScraper()
     rst = scraper(block, block_vars, gallery_conf)
     assert brain.plotter is None  # closed

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -95,6 +95,9 @@ def _qt_disable_paint(widget):
         widget.paintEvent = paintEvent
 
 
+_QT_ICON_KEYS = dict(app=None)
+
+
 def _init_mne_qtapp(enable_icon=True, pg_app=False, splash=False):
     """Get QApplication-instance for MNE-Python.
 
@@ -159,10 +162,12 @@ def _init_mne_qtapp(enable_icon=True, pg_app=False, splash=False):
     if enable_icon or splash:
         icons_path = _qt_init_icons()
 
-    if enable_icon:
+    if enable_icon and app.windowIcon().cacheKey() != _QT_ICON_KEYS['app']:
         # Set icon
         kind = 'bigsur_' if platform.mac_ver()[0] >= '10.16' else 'default_'
-        app.setWindowIcon(QIcon(f"{icons_path}/mne_{kind}icon.png"))
+        icon = QIcon(f"{icons_path}/mne_{kind}icon.png")
+        app.setWindowIcon(icon)
+        _QT_ICON_KEYS['app'] = app.windowIcon().cacheKey()
 
     out = app
     if splash:


### PR DESCRIPTION
From `py-spy` profiling based on https://github.com/mne-tools/mne-qt-browser/issues/161#issuecomment-1490649689 , i.e., Raw with thousands of annotations, I've found a couple of things so far:

1. `Annotations.__iter__` can be slow due to `_any_ch_names()`. The fix is to check this once and pass it to `__getitem__`.
2. Actually `setApplicationIcon` was taking tens of seconds for `pytest mne/viz` (!), so check to see if we actually need to set it based on the `cacheKey()` property.

Draft for now just so I can see if I've broken anything so far. I plan to add other stuff as I find it.