### PR TITLE
Replace .absolute() with .resolve()

### DIFF
--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1908,7 +1908,7 @@ def _do_forward_solution(subject, meas, fname=None, src=None, spacing=None,
 
     if not fname.suffix == ".fif":
         raise ValueError('Forward name does not end with .fif')
-    path = fname.parent.absolute()
+    path = fname.parent.resolve()
     fname = fname.name
 
     # deal with mindist
@@ -1950,9 +1950,9 @@ def _do_forward_solution(subject, meas, fname=None, src=None, spacing=None,
     if bem is not None:
         cmd += ['--bem', bem]
     if mri is not None:
-        cmd += ['--mri', '%s' % str(mri.absolute())]
+        cmd += ['--mri', '%s' % str(mri.resolve())]
     if trans is not None:
-        cmd += ['--trans', '%s' % str(trans.absolute())]
+        cmd += ['--trans', '%s' % str(trans.resolve())]
     if not meg:
         cmd.append('--eegonly')
     if not eeg:

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -265,7 +265,7 @@ write_info
 
 def test_documented():
     """Test that public functions and classes are documented."""
-    doc_dir = (Path(__file__).parent.parent.parent / "doc").absolute()
+    doc_dir = (Path(__file__).parent.parent.parent / "doc").resolve()
     doc_file = doc_dir / "python_reference.rst"
     if not doc_file.is_file():
         pytest.skip('Documentation file not found: %s' % doc_file)

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -220,7 +220,7 @@ def _check_fname(
 ):
     """Check for file existence, and return string of its absolute path."""
     _validate_type(fname, "path-like", name)
-    fname = Path(fname).expanduser().absolute()
+    fname = Path(fname).expanduser().resolve()
 
     if fname.exists():
         if not overwrite:

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -454,7 +454,7 @@ def _get_stim_channel(stim_channel, info, raise_error=True):
 
 def _get_root_dir():
     """Get as close to the repo root as possible."""
-    root_dir = Path(__file__).parent.parent.expanduser().absolute()
+    root_dir = Path(__file__).parent.parent.expanduser().resolve()
     up_dir = root_dir.parent
     if (up_dir / "setup.py").is_file() and all(
         (up_dir / x).is_dir() for x in ("mne", "examples", "doc")


### PR DESCRIPTION
To get the absolute version of a Path, the go-to method should be `.resolve()` instead of `.absolute()`, which also resolves symlinks and `..`  syntax. Also, `.absolute()` was added later to the public API, and still has a couple of untested/fixme comments in its [source code](https://github.com/python/cpython/blob/d76a5c6f7b1caf55c2162fd66bcdb9d8dd890005/Lib/pathlib.py#L1050-L1062).