### PR TITLE
MAINT: Use git rather than zipball

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,7 +116,7 @@ stages:
     - bash: |
         set -e
         python -m pip install --progress-bar off --upgrade pip setuptools wheel codecov
-        python -m pip install --progress-bar off mne-qt-browser[opengl] pyvista scikit-learn pytest-error-for-skips python-picard "PySide6!=6.3.0,!=6.4.0,!=6.4.0.1" qtpy
+        python -m pip install --progress-bar off mne-qt-browser[opengl] pyvista scikit-learn pytest-error-for-skips python-picard "PySide6!=6.3.0,!=6.4.0,!=6.4.0.1,!=6.5" qtpy
         python -m pip uninstall -yq mne
         python -m pip install --progress-bar off --upgrade -e .[test]
       displayName: 'Install dependencies with pip'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,7 +116,7 @@ stages:
     - bash: |
         set -e
         python -m pip install --progress-bar off --upgrade pip setuptools wheel codecov
-        python -m pip install --progress-bar off mne-qt-browser[opengl] pyvista scikit-learn pytest-error-for-skips python-picard "PySide6!=6.3.0,!=6.4.0,!=6.4.0.1,!=6.5" qtpy
+        python -m pip install --progress-bar off mne-qt-browser[opengl] pyvista scikit-learn pytest-error-for-skips python-picard "PySide6!=6.3.0,!=6.4.0,!=6.4.0.1,!=6.5.0" qtpy
         python -m pip uninstall -yq mne
         python -m pip install --progress-bar off --upgrade -e .[test]
       displayName: 'Install dependencies with pip'

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -149,9 +149,14 @@ def _init_mne_qtapp(enable_icon=True, pg_app=False, splash=False):
 
     if pg_app:
         from pyqtgraph import mkQApp
-        app = mkQApp(app_name)
+        old_argv = sys.argv
+        try:
+            sys.argv = []
+            app = mkQApp(app_name)
+        finally:
+            sys.argv = old_argv
     else:
-        app = QApplication.instance() or QApplication(sys.argv or [app_name])
+        app = QApplication.instance() or QApplication([app_name])
         app.setApplicationName(app_name)
     app.setOrganizationName(organization_name)
     try:

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -144,7 +144,8 @@ def _init_mne_qtapp(enable_icon=True, pg_app=False, splash=False):
 
     # First we need to check to make sure the display is valid, otherwise
     # Qt might segfault on us
-    if not _display_is_valid():
+    app = QApplication.instance()
+    if not (app or _display_is_valid()):
         raise RuntimeError('Cannot connect to a valid display')
 
     if pg_app:
@@ -155,9 +156,9 @@ def _init_mne_qtapp(enable_icon=True, pg_app=False, splash=False):
             app = mkQApp(app_name)
         finally:
             sys.argv = old_argv
-    else:
-        app = QApplication.instance() or QApplication([app_name])
-        app.setApplicationName(app_name)
+    elif not app:
+        app = QApplication([app_name])
+    app.setApplicationName(app_name)
     app.setOrganizationName(organization_name)
     try:
         app.setAttribute(Qt.AA_UseHighDpiPixmaps)  # works on PyQt5 and PySide2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ h5io
 packaging
 pymatreader
 qtpy
-PySide6!=6.3.0,!=6.4.0,!=6.4.0.1  # incompat with Matplotlib 3.6.1 and qtpy
+PySide6!=6.3.0,!=6.4.0,!=6.4.0.1,!=6.5.0  # incompat with Matplotlib 3.6.1 and qtpy
 pyobjc-framework-Cocoa>=5.2.0; platform_system=="Darwin"
 sip
 scikit-learn

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -3,7 +3,6 @@ pytest
 pytest-cov
 pytest-timeout
 pytest-harvest
-pytest-qt
 flake8
 flake8-array-spacing
 numpydoc

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -3,6 +3,7 @@ pytest
 pytest-cov
 pytest-timeout
 pytest-harvest
+pytest-qt
 flake8
 flake8-array-spacing
 numpydoc

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -6,7 +6,7 @@ if [ "${TEST_MODE}" == "pip" ]; then
 	python -m pip install --upgrade --only-binary ":all:" numpy scipy vtk
 	python -m pip install --upgrade --only-binary="numba,llvmlite" -r requirements.txt
 	# This can be removed once PyVistaQt 0.6 is out (including https://github.com/pyvista/pyvistaqt/pull/127)
-	python -m pip install --upgrade https://github.com/pyvista/pyvistaqt/zipball/main
+	python -m pip install --upgrade git+https://github.com/pyvista/pyvistaqt
 elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off --upgrade pip setuptools wheel
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl six cycler kiwisolver pyparsing patsy
@@ -19,8 +19,8 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps -i "https://test.pypi.org/simple" openmeeg
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --no-deps vtk
-	python -m pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
-	python -m pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
+	python -m pip install --progress-bar off git+https://github.com/pyvista/pyvista
+	python -m pip install --progress-bar off git+https://github.com/pyvista/pyvistaqt
 	python -m pip install --progress-bar off --upgrade --pre imageio-ffmpeg xlrd mffpy python-picard patsy pillow
 	EXTRA_ARGS="--pre"
 	./tools/check_qt_import.sh PyQt6

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -11,7 +11,7 @@ else  # standard doc build
 	echo "Installing doc build dependencies"
 	python -m pip install --upgrade --progress-bar off PyQt6
 	python -m pip install --upgrade --progress-bar off --only-binary "numpy,scipy,matplotlib,pandas,statsmodels" -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
-	python -m pip install --upgrade --progress-bar off https://github.com/mne-tools/mne-qt-browser/zipball/main https://github.com/sphinx-gallery/sphinx-gallery/zipball/master
+	python -m pip install --upgrade --progress-bar off git+https://github.com/mne-tools/mne-qt-browser git+https://github.com/sphinx-gallery/sphinx-gallery
 	# deal with comparisons and escapes (https://app.circleci.com/pipelines/github/mne-tools/mne-python/9686/workflows/3fd32b47-3254-4812-8b9a-8bab0d646d18/jobs/32934)
 	python -m pip install --upgrade --progress-bar off quantities
 fi

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -26,15 +26,15 @@ else
 	pip install $STD_ARGS --pre --only-binary ":all:" pillow
 	# We don't install Numba here because it forces an old NumPy version
 	echo "nilearn and openmeeg"
-	pip install $STD_ARGS --pre https://github.com/nilearn/nilearn/zipball/main
+	pip install $STD_ARGS --pre git+https://github.com/nilearn/nilearn
 	pip install $STD_ARGS --pre --only-binary ":all:" -i "https://test.pypi.org/simple" openmeeg
 	echo "VTK"
 	pip install $STD_ARGS --pre --only-binary ":all:" vtk
 	python -c "import vtk"
 	echo "PyVista"
-	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
+	pip install --progress-bar off git+https://github.com/pyvista/pyvista
 	echo "pyvistaqt"
-	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
+	pip install --progress-bar off git+https://github.com/pyvista/pyvistaqt
 	echo "imageio-ffmpeg, xlrd, mffpy, python-picard"
 	pip install --progress-bar off --pre imageio-ffmpeg xlrd mffpy python-picard patsy
 	if [ "$OSTYPE" == "darwin"* ]; then
@@ -42,7 +42,7 @@ else
 	  pip install --progress-bar off pyobjc-framework-Cocoa>=5.2.0
 	fi
 	echo "mne-qt-browser"
-	pip install --progress-bar off https://github.com/mne-tools/mne-qt-browser/zipball/main
+	pip install --progress-bar off git+https://github.com/mne-tools/mne-qt-browser
 	EXTRA_ARGS="--pre"
 fi
 # for compat_minimal and compat_old, we don't want to --upgrade

--- a/tools/setup_xvfb.sh
+++ b/tools/setup_xvfb.sh
@@ -11,5 +11,5 @@ done
 
 # This also includes the libraries necessary for PyQt5/PyQt6
 sudo apt update
-sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils libxcb-shape0
+sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils libxcb-shape0 libxcb-cursor0
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset


### PR DESCRIPTION
I'm moving mne-qt-browser to setuptools_scm-based versioning so we need to use `git+` to install it now. Might as well future-proof the other repos we currently `zipball` while we're at it