### PR TITLE
API: One cycle of backward compat

### DIFF
--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -23,7 +23,8 @@ from .check import (check_fname, check_version, check_random_state,
                     _check_edflib_installed, _to_rgb, _soft_import,
                     _check_dict_keys, _check_pymatreader_installed,
                     _import_h5py, _import_h5io_funcs, _import_nibabel,
-                    _import_pymatreader_funcs, _check_head_radius)
+                    _import_pymatreader_funcs, _check_head_radius,
+                    has_nibabel)
 from .config import (set_config, get_config, get_config_path, set_cache_dir,
                      set_memmap_min_size, get_subjects_dir, _get_stim_channel,
                      sys_info, _get_extra_data_path, _get_root_dir,


### PR DESCRIPTION
From https://github.com/mne-tools/mne-installers/actions/runs/4658808262/jobs/8245584263?pr=184 we can see that the backward compat shim was missing the import in `mne/utils/__init__.py`