### PR TITLE
MAINT: Add token [ci skip]

### DIFF
--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -9,6 +9,7 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLECI_TOKEN }}
           artifact-path: 0/dev/index.html
           circleci-jobs: build_docs,build_docs_main
           job-title: Check the rendered docs here!


### PR DESCRIPTION
CircleCI is getting pickier about API endpoints. Procedure:

1. Add new token with admin permission to https://app.circleci.com/settings/project/github/mne-tools/mne-python/api
2. Add the string as a CIRCLECI_TOKEN repo secret in https://github.com/mne-tools/mne-python/settings/secrets/actions
3. Open this PR
4. Merge and hope a rerun of a circle job (like in #11619) shows status again