### PR TITLE
FIX: missing channels/fiducials can be np.nan

### DIFF
--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -1656,7 +1656,8 @@ def compute_native_head_t(montage, *, on_missing='warn', verbose=None):
     else:
         fid_keys = ('nasion', 'lpa', 'rpa')
         for key in fid_keys:
-            if fid_coords[key] is None:
+            this_coord = fid_coords[key]
+            if this_coord is None or np.any(np.isnan(this_coord)):
                 msg = (
                     f'Fiducial point {key} not found, assuming identity '
                     f'{_verbose_frames[coord_frame]} to head transformation')


### PR DESCRIPTION
This essentially fixes the problem I encountered in #11610 in the context of localizing iEEG channels and microelectrodes on a high-resolution CT scan (for you, GitHub: fixes #11610).
The problem was that all my channel positions localized in the ieeg GUI were NaN'ed when using `apply_volume_registration_points` to transfer point positions from high resolution CT space to MRI coords. One of the last steps in `apply_volume_registration_points` was using `compute_native_head_t`, and this function assumes that fiducials are not present only when at least one of the fiducial positons is `None`, while in my case they were al `np.nan`. 

I assume here that using `np.nan` for no channel position information is now the default in mne (info objects created via `mne.create_info` have `info['chs'][idx]['loc']` as all np.nans by default), and that `compute_native_head_t` should treat nans as no positios as well, but maybe that assumption is not correct (for example maybe `mne.io._digitization._get_fid_coords` should return `None` when for channels/points with `np.nan` positions).

So this fixes the problem I was experiencing, but mabe some other fix would be preffered.
 