### PR TITLE
MAINT: Simplify doc/conf.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
         - run:
             name: make test-doc
             command: |
-              if [[ $(cat gitlog.txt) == *"[circle front]"* ]] || [[ $(cat build.txt) == "html_dev-memory" ]] || [[ $(cat build.txt) == "html_stable-memory" ]]; then
+              if [[ $(cat gitlog.txt) == *"[circle front]"* ]] || [[ $(cat build.txt) == "html-memory" ]] ; then
                 make test-doc;
                 mkdir -p doc/_build/test-results/test-doc;
                 cp junit-results.xml doc/_build/test-results/test-doc/junit.xml;
@@ -276,7 +276,7 @@ jobs:
         - run:
             name: Reduce artifact upload time
             command: |
-              if grep -q html_dev-pattern-memory build.txt || grep -q html_dev-noplot build.txt; then
+              if grep -q html-pattern-memory build.txt || grep -q html-noplot build.txt; then
                 zip -rm doc/_build/html/_downloads.zip doc/_build/html/_downloads
               fi
               for NAME in generated auto_tutorials auto_examples; do
@@ -299,15 +299,11 @@ jobs:
         # Save the HTML
         - store_artifacts:
             path: doc/_build/html/
-            destination: dev
-        - store_artifacts:
-            path: doc/_build/html_stable/
-            destination: stable
+            destination: html
         - persist_to_workspace:
             root: doc/_build
             paths:
               - html
-              - html_stable
 
         # Keep these separate, maybe better in terms of size limitations (?)
         - save_cache:
@@ -465,7 +461,7 @@ jobs:
         - run:
             name: Check docs
             command: |
-              if [ ! -f /tmp/build/html/index.html ] && [ ! -f /tmp/build/html_stable/index.html ]; then
+              if [ ! -f /tmp/build/html/index.html ] ; then
                 echo "No files found to upload (build: ${CIRCLE_BRANCH}).";
                 circleci-agent step halt;
               fi;
@@ -498,7 +494,7 @@ jobs:
               else
                 echo "Deploying stable docs for ${CIRCLE_BRANCH}.";
                 rm -Rf stable;
-                cp -a /tmp/build/html_stable stable;
+                cp -a /tmp/build/html stable;
                 git add -A;
                 git commit -m "CircleCI update of stable docs (${CIRCLE_BUILD_NUM}).";
               fi;

--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -10,6 +10,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           api-token: ${{ secrets.CIRCLECI_TOKEN }}
-          artifact-path: 0/dev/index.html
+          artifact-path: 0/html/index.html
           circleci-jobs: build_docs,build_docs_main
           job-title: Check the rendered docs here!

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -335,37 +335,3 @@ stages:
         codeCoverageTool: Cobertura
         summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
         reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
-
-  - job: SphinxWindows
-    pool:
-      vmImage: 'windows-latest'
-    variables:
-      AZURE_CI_WINDOWS: 'true'
-    steps:
-    - bash: |
-        set -e
-        git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
-        powershell gl-ci-helpers/appveyor/install_opengl.ps1
-      displayName: Install OpenGL
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.10'
-    - bash: |
-        set -eo pipefail
-        PYTHONUTF8=1 pip install --progress-bar off -r requirements.txt -r requirements_doc.txt
-      displayName: Install documentation dependencies
-    - script: pip install -e .
-      displayName: Install dev MNE
-    - script: mne sys_info -pd
-      displayName: Print config and test access to commands
-    - script: python -c "import numpy; numpy.show_config()"
-      displayName: Print NumPy config
-    - bash: |
-        set -eo pipefail
-        sed -i 's/.. graphviz::/.. graphviz/g' doc/install/contributing.rst
-        sed -i 's/.. graphviz::/.. graphviz/g' tutorials/preprocessing/40_artifact_correction_ica.py
-        sed -i '/sphinx\.ext\.graphviz/d' doc/conf.py
-      displayName: Skip graph that we cannot render
-    # TODO: Reenable this once we can get it to work!
-    # - bash: make -C doc html_dev-noplot
-    #   displayName: 'Build doc'

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,125 +4,59 @@
 # You can set these variables from the command line.
 SPHINXOPTS    = -nWT --keep-going
 SPHINXBUILD   = sphinx-build
-PAPER         =
 MPROF         = SG_STAMP_STARTS=true mprof run -E --python sphinx
 
 # Internal variables.
-PAPEROPT_a4     = -D latex_paper_size=a4
-PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d _build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -d _build/doctrees $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest
+.PHONY: help clean html html-noplot html-pattern linkcheck linkcheck-grep doctest
 
 # make with no arguments will build the first target by default, i.e., build standalone HTML files
-first_target: html_dev-noplot
+first_target: html-noplot
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  html_stable      to make standalone HTML files (stable version)"
-	@echo "  html_dev         to make standalone HTML files (dev version)"
-	@echo "  html_dev-pattern to make standalone HTML files for one example dir (dev version)"
-	@echo "  *-noplot     	  to make standalone HTML files without plotting"
-	@echo "  dirhtml          to make HTML files named index.html in directories"
-	@echo "  pickle           to make pickle files"
-	@echo "  json             to make JSON files"
-	@echo "  htmlhelp         to make HTML files and a HTML help project"
-	@echo "  qthelp           to make HTML files and a qthelp project"
-	@echo "  latex            to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
-	@echo "  changes          to make an overview of all changed/added/deprecated items"
+	@echo "  html             to make standalone HTML files"
+	@echo "  html-memory      to make standalone HTML files while monitoring memory usage"
+	@echo "  html-pattern     to make standalone HTML files for a specific filename pattern"
+	@echo "  html-front       to make standalone HTML files with only the frontpage examples"
+	@echo "  html-noplot      to make standalone HTML files without plotting"
+	@echo "  clean            to clean HTML files"
 	@echo "  linkcheck        to check all external links for integrity"
+	@echo "  linkcheck-grep   to grep the linkcheck resut"
 	@echo "  doctest          to run all doctests embedded in the documentation (if enabled)"
+	@echo "  view             to view the built HTML"
 
 clean:
 	-rm -rf _build auto_examples auto_tutorials generated *.stc *.fif *.nii.gz
 
-html_stable:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) _build/html_stable
-	@echo
-	@echo "Build finished. The HTML pages are in _build/html_stable."
-
-html_stable-memory:
-	$(MPROF) -b html $(ALLSPHINXOPTS) _build/html_stable
-	@echo
-	@echo "Build finished. The HTML pages are in _build/html_stable."
-
-html_dev:
-	BUILD_DEV_HTML=1 $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) _build/html
-	@echo
-	@echo "Build finished. The HTML pages are in _build/html"
-
-html_dev-memory:
-	BUILD_DEV_HTML=1 $(MPROF) -b html $(ALLSPHINXOPTS) _build/html
-	@echo
-	@echo "Build finished. The HTML pages are in _build/html"
-
-html_dev-pattern:
-	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -D sphinx_gallery_conf.run_stale_examples=True -b html $(ALLSPHINXOPTS) _build/html
-	@echo
-	@echo "Build finished. The HTML pages are in _build/html"
-
-html_dev-pattern-memory:
-	BUILD_DEV_HTML=1 $(MPROF) -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -D sphinx_gallery_conf.run_stale_examples=True -b html $(ALLSPHINXOPTS) _build/html
-	@echo
-	@echo "Build finished. The HTML pages are in _build/html"
-
-html_dev-noplot:
-	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) _build/html
+html:
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) _build/html
 	@echo
 	@echo "Build finished. The HTML pages are in _build/html."
 
-html_dev-debug:
-	BUILD_DEV_HTML=1 $(SPHINXBUILD) -PD plot_gallery=0 -b html $(ALLSPHINXOPTS) _build/html
+html-memory:
+	$(MPROF) -b html $(ALLSPHINXOPTS) _build/html
+	@echo
+	@echo "Build finished. The HTML pages are in _build/html."
+
+html-pattern:
+	$(SPHINXBUILD) -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -D sphinx_gallery_conf.run_stale_examples=True -b html $(ALLSPHINXOPTS) _build/html
+	@echo
+	@echo "Build finished. The HTML pages are in _build/html"
 
 html-noplot:
-	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) _build/html_stable
+	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) _build/html
 	@echo
-	@echo "Build finished. The HTML pages are in _build/html_stable."
+	@echo "Build finished. The HTML pages are in _build/html."
 
-html_dev-front:
-	@PATTERN="\(30_mne_dspm_loreta.py\|50_decoding.py\|30_strf.py\|20_cluster_1samp_spatiotemporal.py\|20_visualize_evoked.py\)" make html_dev-pattern;
+html-front:
+	@PATTERN="\(30_mne_dspm_loreta.py\|50_decoding.py\|30_strf.py\|20_cluster_1samp_spatiotemporal.py\|20_visualize_evoked.py\)" make html-pattern
 
-dirhtml:
-	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) _build/dirhtml
-	@echo
-	@echo "Build finished. The HTML pages are in _build/dirhtml."
-
-pickle:
-	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) _build/pickle
-	@echo
-	@echo "Build finished; now you can process the pickle files."
-
-json:
-	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) _build/json
-	@echo
-	@echo "Build finished; now you can process the JSON files."
-
-htmlhelp:
-	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) _build/htmlhelp
-	@echo
-	@echo "Build finished; now you can run HTML Help Workshop with the" \
-	      ".hhp project file in _build/htmlhelp."
-
-qthelp:
-	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) _build/qthelp
-	@echo
-	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
-	      ".qhcp project file in _build/qthelp, like this:"
-	@echo "# qcollectiongenerator _build/qthelp/MNE.qhcp"
-	@echo "To view the help file:"
-	@echo "# assistant -collectionFile _build/qthelp/MNE.qhc"
-
-latex:
-	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) _build/latex
-	@echo
-	@echo "Build finished; the LaTeX files are in _build/latex."
-	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \
-	      "run these through (pdf)latex."
-
-changes:
-	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) _build/changes
-	@echo
-	@echo "The overview file is in _build/changes."
+# Aliases for old methods
+html_dev-pattern-memory: html-pattern
+html_dev-noplot: html-noplot
+html_dev-front: html-front
 
 linkcheck:
 	@$(SPHINXBUILD) -b linkcheck -D nitpicky=0 -D plot_gallery=0 -D exclude_patterns="cited.rst,whats_new.rst,configure_git.rst" -d _build/doctrees . _build/linkcheck

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1064,15 +1064,15 @@ for icon in brand_icons + fixed_width_icons + other_icons:
     icon_class[icon] = ('fa-brands',) if icon in brand_icons else ('fa-solid',)
     icon_class[icon] += ('fa-fw',) if icon in fixed_width_icons else ()
 
-prolog = ''
+rst_prolog = ''
 for icon, classes in icon_class.items():
-    prolog += f'''
+    rst_prolog += f'''
 .. |{icon}| raw:: html
 
     <i class="{' '.join(classes + (f'fa-{icon}',))}"></i>
 '''
 
-prolog += '''
+rst_prolog += '''
 .. |ensp| unicode:: U+2002 .. EN SPACE
 '''
 
@@ -1088,7 +1088,7 @@ except ModuleNotFoundError:
         if line.strip().startswith('Requires-Python'):
             min_py = line.split(':')[1]
 min_py = min_py.lstrip(' =<>')
-prolog += f'\n.. |min_python_version| replace:: {min_py}\n'
+rst_prolog += f'\n.. |min_python_version| replace:: {min_py}\n'
 
 # -- website redirects --------------------------------------------------------
 
@@ -1330,7 +1330,6 @@ def make_version(app, exception):
 def setup(app):
     """Set up the Sphinx app."""
     app.connect('autodoc-process-docstring', append_attr_meth_examples)
-    app.config.rst_prolog = prolog
     report_scraper.app = app
     app.connect('builder-inited', report_scraper.copyfiles)
     app.connect('build-finished', make_redirects)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -338,7 +338,7 @@ class Resetter(object):
         gc.collect()
         when = f'mne/conf.py:Resetter.__call__:{when}:{fname}'
         # Support stuff like
-        # MNE_SKIP_INSTANCE_ASSERTIONS="Brain,Plotter,BackgroundPlotter,vtkPolyData,_Renderer" make html_dev-memory  # noqa: E501
+        # MNE_SKIP_INSTANCE_ASSERTIONS="Brain,Plotter,BackgroundPlotter,vtkPolyData,_Renderer" make html-memory  # noqa: E501
         # to just test MNEQtBrowser
         skips = os.getenv('MNE_SKIP_INSTANCE_ASSERTIONS', '').lower()
         prefix = ''
@@ -690,7 +690,6 @@ xl = '5'
 xxl = '6'
 # variables to pass to HTML templating engine
 html_context = {
-    'build_dev_html': bool(int(os.environ.get('BUILD_DEV_HTML', False))),
     'default_mode': 'auto',
     'pygment_light_style': 'tango',
     'pygment_dark_style': 'native',

--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -909,27 +909,15 @@ You can build the documentation locally using `GNU Make`_ with
 :file:`doc/Makefile`. From within the :file:`doc` directory, you can test
 formatting and linking by running::
 
-    $ make html_dev-noplot
+    $ make html-noplot
 
 This will build the documentation *except* it will format (but not execute) the
 tutorial and example files. If you have created or modified an example or
 tutorial, you should instead run
-:samp:`PATTERN={<REGEX_TO_SELECT_MY_TUTORIAL>} make html_dev-pattern` to render
+:samp:`make html-pattern PATTERN={<REGEX_TO_SELECT_MY_TUTORIAL>}` to render
 all the documentation and additionally execute just your example or tutorial
 (so you can make sure it runs successfully and generates the output / figures
 you expect).
-
-.. note::
-   If you are using a *Windows command shell*, to use the pattern approach,
-   use the following two lines:
-
-   .. code-block:: doscon
-
-      > set PATTERN=<REGEX_TO_SELECT_MY_TUTORIAL>
-      > make html_dev-pattern
-
-   If you are on Windows but using the `git BASH`_ shell, use the same two
-   commands but replace ``set`` with ``export``.
 
 After either of these commands completes, ``make show`` will open the
 locally-rendered documentation site in your browser. If you see many warnings

--- a/doc/sphinxext/gen_commands.py
+++ b/doc/sphinxext/gen_commands.py
@@ -1,7 +1,7 @@
 import glob
 from importlib import import_module
 import os
-from os import path as op
+from pathlib import Path
 
 from mne.utils import _replace_md5, ArgvSetter
 
@@ -47,17 +47,20 @@ command_rst = """
 
 
 def generate_commands_rst(app=None):
-    from sphinx.util import status_iterator
-    out_dir = op.abspath(op.join(op.dirname(__file__), '..', 'generated'))
-    if not op.isdir(out_dir):
-        os.mkdir(out_dir)
-    out_fname = op.join(out_dir, 'commands.rst.new')
+    try:
+        from sphinx.util.display import status_iterator
+    except Exception:
+        from sphinx.util import status_iterator
+    root = Path(__file__).parent.parent.parent.absolute()
+    out_dir = (root / 'doc' / 'generated').absolute()
+    out_dir.mkdir(exist_ok=True)
+    out_fname =out_dir / 'commands.rst.new'
 
-    command_path = op.abspath(
-        op.join(os.path.dirname(__file__), '..', '..', 'mne', 'commands'))
-    fnames = sorted([
-        op.basename(fname)
-        for fname in glob.glob(op.join(command_path, 'mne_*.py'))])
+    command_path = root / 'mne' / 'commands'
+    fnames = sorted(
+        Path(fname).name
+        for fname in glob.glob(str(command_path / 'mne_*.py')))
+    assert len(fnames)
     iterator = status_iterator(
         fnames, 'generating MNE command help ... ', length=len(fnames))
     with open(out_fname, 'w', encoding='utf8') as f:
@@ -97,7 +100,7 @@ def generate_commands_rst(app=None):
             cmd_name_space = cmd_name.replace('mne_', 'mne ')
             f.write(command_rst.format(
                 cmd_name_space, '=' * len(cmd_name_space), output))
-    _replace_md5(out_fname)
+    _replace_md5(str(out_fname))
 
 
 # This is useful for testing/iterating to see what the result looks like

--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,7 @@ dependencies:
 - numexpr
 - imageio
 - spyder-kernels>=1.10.0
+- imageio>=2.6.1
 - imageio-ffmpeg>=0.4.1
 - vtk>=9.2
 - traitlets

--- a/requirements_testing_extra.txt
+++ b/requirements_testing_extra.txt
@@ -5,4 +5,5 @@ sphinx-gallery
 eeglabio
 EDFlib-Python
 pybv
-imageio-ffmpeg
+imageio>=2.6.1
+imageio-ffmpeg>=0.4.1

--- a/tools/circleci_download.sh
+++ b/tools/circleci_download.sh
@@ -3,13 +3,9 @@
 set -o pipefail
 export MNE_TQDM=off
 
-if [ "$CIRCLE_BRANCH" == "main" ] || [[ $(cat gitlog.txt) == *"[circle full]"* ]]; then
-    echo "Doing a full dev build";
-    echo html_dev-memory > build.txt;
-    python -c "import mne; mne.datasets._download_all_example_data()";
-elif [ "$CIRCLE_BRANCH" == "maint/1.3" ]; then
-    echo "Doing a full stable build";
-    echo html_stable-memory > build.txt;
+if [ "$CIRCLE_BRANCH" == "main" ] || [[ $(cat gitlog.txt) == *"[circle full]"* ]] || [[ "$CIRCLE_BRANCH" == "maint/"* ]]; then
+    echo "Doing a full build";
+    echo html-memory > build.txt;
     python -c "import mne; mne.datasets._download_all_example_data()";
 else
     echo "Doing a partial build";
@@ -119,9 +115,9 @@ else
     echo PATTERN="$PATTERN";
     if [[ $PATTERN ]]; then
         PATTERN="\(${PATTERN::-2}\)";
-        echo html_dev-pattern-memory > build.txt;
+        echo html-pattern-memory > build.txt;
     else
-        echo html_dev-noplot > build.txt;
+        echo html-noplot > build.txt;
     fi;
 fi;
 echo "$PATTERN" > pattern.txt;

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -22,7 +22,10 @@ else
 	# pip install $STD_ARGS --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6
 	pip install $STD_ARGS --pre --only-binary ":all:" PyQt6
 	echo "NumPy/SciPy/pandas etc."
-	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy scikit-learn dipy pandas matplotlib pillow statsmodels
+	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy
+	# SciPy<->sklearn problematic, see https://github.com/scipy/scipy/issues/18377
+	pip install $STD_ARGS --pre --only-binary ":all:" scipy
+	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" scikit-learn dipy pandas matplotlib pillow statsmodels
 	pip install $STD_ARGS --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
 	# No Numba because it forces an old NumPy version
 	echo "nilearn and openmeeg"


### PR DESCRIPTION
I realized `build_dev_html` was a relic of when we used to inject/modify our build based on being dev or stable. Removing this we can simplify our `Makefile` to avoid `make html_dev-noplot` --  we can just do `make html-noplot` as the result is the same. So I've simplified a bunch of stuff and tried to keep aliases for the old commands. I also updated to a newer sphinx iterator to avoid a Sphinx 6 warning.

Note that the CircleCI artifacts redirector won't point to a valid file on this PR but it should once the PR is merged, as the redirector action only runs the `main` version of the action.

Helps a little bit with #11507