### PR TITLE
API: Deprecate ordered=False and legacy some functions

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -81,3 +81,6 @@ API changes
 - Deprecate arguments ``kind`` and ``path`` from :func:`mne.channels.read_layout` in favor of a common argument ``fname`` (:gh:`11500` by `Mathieu Scheltienne`_)
 - Change ``aligned_ct`` positional argument in ``mne.gui.locate_ieeg`` to ``base_image`` to reflect that this can now be used with unaligned images (:gh:`11567` by `Alex Rockhill`_)
 - ``mne.warp_montage_volume`` was deprecated in favor of :func:`mne.preprocessing.ieeg.warp_montage` (acts directly on points instead of using an intermediate volume) and :func:`mne.preprocessing.ieeg.make_montage_volume` (which makes a volume of ieeg contact locations which can still be useful) (:gh:`11572` by `Alex Rockhill`_)
+- Deprecate ``mne.pick_channels_evoked`` in favor of ``evoked.copy().pick(...)`` (:gh:`11665` by `Eric Larson`_)
+- Set instance methods ``inst.pick_types`` and ``inst.pick_channels`` as legacy in favor of ``inst.pick(...)`` (:gh:`11665` by `Eric Larson`_)
+- The default of ``inst.pick_channels(..., ordered=False)`` will change to ``ordered=True`` in 1.5 to avoid silent bugs (:gh:`11665` by `Eric Larson`_)

--- a/examples/inverse/time_frequency_mixed_norm_inverse.py
+++ b/examples/inverse/time_frequency_mixed_norm_inverse.py
@@ -50,7 +50,6 @@ cov = mne.read_cov(cov_fname)
 # Handling average file
 condition = 'Left visual'
 evoked = mne.read_evokeds(ave_fname, condition=condition, baseline=(None, 0))
-evoked = mne.pick_channels_evoked(evoked)
 # We make the window slightly larger than what you'll eventually be interested
 # in ([-0.05, 0.3]) to avoid edge effects.
 evoked.crop(tmin=-0.1, tmax=0.4)

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -8,7 +8,7 @@
 import numpy as np
 
 from ..forward import is_fixed_orient, convert_forward_solution
-from ..io.pick import pick_channels_evoked, pick_info, pick_channels_forward
+from ..io.pick import pick_info, pick_channels_forward
 from ..inverse_sparse.mxne_inverse import _make_dipoles_sparse
 from ..minimum_norm.inverse import _log_exp_var
 from ..utils import logger, verbose, _check_info_inv, fill_doc
@@ -274,11 +274,7 @@ def rap_music(evoked, forward, noise_cov, n_dipoles=5, return_residual=False,
                                                picks)
 
     if return_residual:
-        residual = evoked.copy()
-        selection = [info['ch_names'][p] for p in picks]
-
-        residual = pick_channels_evoked(residual,
-                                        include=selection)
+        residual = evoked.copy().pick([info['ch_names'][p] for p in picks])
         residual.data -= explained_data
         active_projs = [p for p in residual.info['projs'] if p['active']]
         for p in active_projs:

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -25,7 +25,7 @@ from ..defaults import HEAD_SIZE_DEFAULT, _handle_default
 from ..utils import (verbose, logger, warn,
                      _check_preload, _validate_type, fill_doc, _check_option,
                      _get_stim_channel, _check_fname, _check_dict_keys,
-                     _on_missing)
+                     _on_missing, legacy)
 from ..io.constants import FIFF
 from ..io.meas_info import (anonymize_info, Info, MontageMixin, create_info,
                             _rename_comps)
@@ -596,6 +596,7 @@ class UpdateChannelsMixin:
     """Mixin class for Raw, Evoked, Epochs, Spectrum, AverageTFR."""
 
     @verbose
+    @legacy(alt='inst.pick(...)')
     def pick_types(self, meg=False, eeg=False, stim=False, eog=False,
                    ecg=False, emg=False, ref_meg='auto', *, misc=False,
                    resp=False, chpi=False, exci=False, ias=False, syst=False,
@@ -649,18 +650,15 @@ class UpdateChannelsMixin:
         return self
 
     @verbose
-    def pick_channels(self, ch_names, ordered=False, *, verbose=None):
+    @legacy(alt='inst.pick(...)')
+    def pick_channels(self, ch_names, ordered=None, *, verbose=None):
         """Pick some channels.
 
         Parameters
         ----------
         ch_names : list
             The list of channels to select.
-        ordered : bool
-            If True (default False), ensure that the order of the channels in
-            the modified instance matches the order of ``ch_names``.
-
-            .. versionadded:: 0.20.0
+        %(ordered)s
         %(verbose)s
 
             .. versionadded:: 1.1

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -162,7 +162,8 @@ def test_set_channel_types():
     assert info['chs'][375]['kind'] == FIFF.FIFFV_SEEG_CH
     assert info['chs'][375]['unit'] == FIFF.FIFF_UNIT_V
     assert info['chs'][375]['coil_type'] == FIFF.FIFFV_COIL_EEG
-    for idx in pick_channels(raw.ch_names, ['MEG 2441', 'MEG 2443']):
+    for idx in pick_channels(raw.ch_names, ['MEG 2441', 'MEG 2443'],
+                             ordered=False):
         assert info['chs'][idx]['kind'] == FIFF.FIFFV_EEG_CH
         assert info['chs'][idx]['unit'] == FIFF.FIFF_UNIT_V
         assert info['chs'][idx]['coil_type'] == FIFF.FIFFV_COIL_EEG
@@ -470,9 +471,8 @@ def test_pick_channels():
     assert len(raw.ch_names) == 3
 
     # selected correctly 3 channels and ignored 'meg', and emit warning
-    with pytest.warns(RuntimeWarning, match='not present in the info'):
+    with pytest.raises(ValueError, match='not present in the info'):
         raw.pick(['MEG 0113', "meg", 'MEG 0112', 'MEG 0111'])
-        assert len(raw.ch_names) == 3
 
     names_len = len(raw.ch_names)
     raw.pick(['all'])  # selected correctly all channels

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -336,16 +336,16 @@ class Covariance(dict):
             extrapolate=extrapolate, sphere=sphere, border=border,
             time_format='')
 
-    def pick_channels(self, ch_names, ordered=False):
+    @verbose
+    def pick_channels(self, ch_names, ordered=None, *, verbose=None):
         """Pick channels from this covariance matrix.
 
         Parameters
         ----------
         ch_names : list of str
             List of channels to keep. All other channels are dropped.
-        ordered : bool
-            If True (default False), ensure that the order of the channels
-            matches the order of ``ch_names``.
+        %(ordered)s
+        %(verbose)s
 
         Returns
         -------
@@ -1665,7 +1665,8 @@ def regularize(cov, info, mag=0.1, grad=0.1, eeg=0.1, exclude='bads',
 
     # This actually removes bad channels from the cov, which is not backward
     # compatible, so let's leave all channels in
-    cov_good = pick_channels_cov(cov, include=info_ch_names, exclude=exclude)
+    cov_good = pick_channels_cov(
+        cov, include=info_ch_names, exclude=exclude, ordered=False)
     ch_names = cov_good.ch_names
 
     # Now get the indices for each channel type in the cov

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -475,7 +475,8 @@ def _merge_fwds(fwds, *, verbose=None):
 
 
 @verbose
-def read_forward_solution(fname, include=(), exclude=(), verbose=None):
+def read_forward_solution(fname, include=(), exclude=(), *, ordered=None,
+                          verbose=None):
     """Read a forward solution a.k.a. lead field.
 
     Parameters
@@ -487,6 +488,7 @@ def read_forward_solution(fname, include=(), exclude=(), verbose=None):
         are included.
     exclude : list, optional
         List of names of channels to exclude. If empty include all channels.
+    %(ordered)s
     %(verbose)s
 
     Returns
@@ -665,7 +667,7 @@ def read_forward_solution(fname, include=(), exclude=(), verbose=None):
 
 @verbose
 def convert_forward_solution(fwd, surf_ori=False, force_fixed=False,
-                             copy=True, use_cps=True, verbose=None):
+                             copy=True, use_cps=True, *, verbose=None):
     """Convert forward solution between different source orientations.
 
     Parameters

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -9,7 +9,6 @@ from ..source_estimate import SourceEstimate, _BaseSourceEstimate, _make_stc
 from ..minimum_norm.inverse import (combine_xyz, _prepare_forward,
                                     _check_reference, _log_exp_var)
 from ..forward import is_fixed_orient
-from ..io.pick import pick_channels_evoked
 from ..io.proj import deactivate_proj
 from ..utils import (logger, verbose, _check_depth, _check_option, sum_squared,
                      _validate_type, check_random_state, warn)
@@ -82,8 +81,7 @@ def _reapply_source_weighting(X, source_weighting, active_set):
 def _compute_residual(forward, evoked, X, active_set, info):
     # OK, picking based on row_names is safe
     sel = [forward['sol']['row_names'].index(c) for c in info['ch_names']]
-    residual = evoked.copy()
-    residual = pick_channels_evoked(residual, include=info['ch_names'])
+    residual = evoked.copy().pick(info['ch_names'])
     r_tmp = residual.copy()
 
     r_tmp.data = np.dot(forward['sol']['data'][sel, :][:, active_set], X)

--- a/mne/io/tests/test_meas_info.py
+++ b/mne/io/tests/test_meas_info.py
@@ -903,7 +903,7 @@ def test_channel_name_limit(tmp_path, monkeypatch, fname):
         data=proj, active=False, desc='test', kind=0, explained_var=0.)
     raw.add_proj(proj, remove_existing=True)
     raw.info.normalize_proj()
-    raw.pick_channels(data_names + ref_names).crop(0, 2)
+    raw.pick_channels(data_names + ref_names, ordered=False).crop(0, 2)
     long_names = ['123456789abcdefg' + name for name in raw.ch_names]
     fname = tmp_path / 'test-raw.fif'
     with catch_logging() as log:

--- a/mne/rank.py
+++ b/mne/rank.py
@@ -325,7 +325,8 @@ def compute_rank(inst, rank=None, scalings=None, info=None, tol='auto',
         info = info.copy()
         info['bads'] = []
         inst = pick_channels_cov(
-            inst, set(inst['names']) & set(info['ch_names']), exclude=[])
+            inst, set(inst['names']) & set(info['ch_names']), exclude=[],
+            ordered=False)
         if info['ch_names'] != inst['names']:
             info = pick_info(info, [info['ch_names'].index(name)
                                     for name in inst['names']])

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -245,7 +245,6 @@ mesh_dist
 mesh_edges
 next_fast_len
 parallel_func
-pick_channels_evoked
 plot_epochs_psd
 plot_epochs_psd_topomap
 plot_raw_psd_topo

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -20,7 +20,9 @@ from ..time_frequency.multitaper import (_compute_mt_params, _mt_spectra,
 from ..parallel import parallel_func
 
 
-def pick_channels_csd(csd, include=[], exclude=[], ordered=False, copy=True):
+@verbose
+def pick_channels_csd(csd, include=[], exclude=[], ordered=None, copy=True, *,
+                      verbose=None):
     """Pick channels from cross-spectral density matrix.
 
     Parameters
@@ -31,11 +33,7 @@ def pick_channels_csd(csd, include=[], exclude=[], ordered=False, copy=True):
         List of channels to include (if empty, include all available).
     exclude : list of str
         Channels to exclude (if empty, do not exclude any).
-    ordered : bool
-        If True (default False), ensure that the order of the channels in the
-        modified instance matches the order of ``include``.
-
-        .. versionadded:: 0.20.0
+    %(ordered)s
     copy : bool
         If True (the default), return a copy of the CSD matrix with the
         modified channels. If False, channels are modified in-place.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2510,6 +2510,16 @@ outlines : 'head' | dict | None
     Defaults to 'head'.
 """
 
+docdict['ordered'] = """
+ordered : bool
+    If True (default False), ensure that the order of the channels in
+    the modified instance matches the order of ``ch_names``.
+
+    .. versionadded:: 0.20.0
+    .. versionchanged:: 1.5
+        The default changed from False in 1.4 to True in 1.5.
+"""
+
 docdict['overview_mode'] = """
 overview_mode : str | None
     Can be "channels", "empty", or "hidden" to set the overview bar mode

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -16,7 +16,7 @@ import matplotlib.pyplot as plt
 from matplotlib.colors import Colormap
 from matplotlib.figure import Figure
 
-from mne import (make_field_map, pick_channels_evoked, read_evokeds,
+from mne import (make_field_map, read_evokeds,
                  read_trans, read_dipole, SourceEstimate,
                  make_sphere_model, use_coil_def, pick_types,
                  setup_volume_source_space, read_forward_solution,
@@ -151,7 +151,7 @@ def test_plot_evoked_field(renderer):
     """Test plotting evoked field."""
     evoked = read_evokeds(evoked_fname, condition='Left Auditory',
                           baseline=(-0.2, 0.0))
-    evoked = pick_channels_evoked(evoked, evoked.ch_names[::10])  # speed
+    evoked.pick(evoked.ch_names[::10])  # speed
     for t, n_contours in zip(['meg', None], [21, 0]):
         with pytest.warns(RuntimeWarning, match='projection'):
             maps = make_field_map(evoked, trans_fname, subject='sample',

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -14,8 +14,7 @@ import pytest
 import matplotlib
 import matplotlib.pyplot as plt
 
-from mne import (read_events, Epochs, pick_channels_evoked, read_cov,
-                 compute_proj_evoked)
+from mne import read_events, Epochs, read_cov, compute_proj_evoked
 from mne.channels import read_layout
 from mne.io import read_raw_fif
 from mne.time_frequency.tfr import AverageTFR
@@ -161,8 +160,7 @@ def test_plot_topo():
 
     evoked_delayed_ssp = _get_epochs_delayed_ssp().average()
     ch_names = evoked_delayed_ssp.ch_names[:3]  # make it faster
-    picked_evoked_delayed_ssp = pick_channels_evoked(evoked_delayed_ssp,
-                                                     ch_names)
+    picked_evoked_delayed_ssp = evoked_delayed_ssp.pick(ch_names)
     fig = plot_evoked_topo(picked_evoked_delayed_ssp, layout,
                            proj='interactive')
     func = _get_presser(fig)


### PR DESCRIPTION
Closes #11546
Closes #11531

I think this is probably good enough to close #11531. @drammock you had slight differences / a bit more stuff in https://github.com/mne-tools/mne-python/issues/11531#issuecomment-1464442314 . For example, I left out the new forward instance method as I think picking channels for forward is very rare for users so the cost of having to use `pick_channels_forward` is low (same with cov), and hence not worth the code churn to replace it. I did add an `ordered=None` to those functions, though, in order to minimize the risk of problems for people, which I think is the most critical thing end-user-safety-wise.

I also did not `@legacy` the `mne.pick_types` function for now because 1) there is no straightforward replacement that allows you to get the indices of given channel types, and 2) we would have to alias all of our internal uses to a private `_pick_types` to avoid the `legacy` print (and there are a lot of them). I did `@legacy` the instance method `inst.pick_types`, though, which seems reasonable. Same goes for `mne.pick_channels` and `inst.pick_channels`.

If/when this is reviewed and approved and I've fixed all the tests (I'm sure some will have broken!) I'll push a `[circle full]` before merge so we can find out now about any broken examples/tutorials rather than this evening.