### PR TITLE
MRG: Allow silencing of "The unit for channel(s) ... has changed" warnings

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -45,6 +45,7 @@ Enhancements
 - Add support for :func:`mne.preprocessing.maxwell_filter` with gradient-compensated CTF data, e.g., for tSSS-only mode (:gh:`10554` by `Eric Larson`_)
 - Add support for eyetracking data using :func:`mne.io.read_raw_eyelink` (:gh:`11152` by `Dominik Welke`_ and `Scott Huberty`_)
 - :func:`mne.channels.make_1020_channel_selections` gained a new parameter, ``return_ch_names``, to allow for easy retrieval of EEG channel names corresponding to the left, right, and midline portions of the montage (:gh:`11632` by `Richard Höchenberger`_)
+- Methods for setting the sensor types of channels (e.g., for raw data :meth:`mne.io.Raw.set_channel_types`) gained a new parameter, ``on_unit_change``, to control whether to warn in case the measurement unit is adjusted automatically (:gh:`11668` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -45,7 +45,7 @@ Enhancements
 - Add support for :func:`mne.preprocessing.maxwell_filter` with gradient-compensated CTF data, e.g., for tSSS-only mode (:gh:`10554` by `Eric Larson`_)
 - Add support for eyetracking data using :func:`mne.io.read_raw_eyelink` (:gh:`11152` by `Dominik Welke`_ and `Scott Huberty`_)
 - :func:`mne.channels.make_1020_channel_selections` gained a new parameter, ``return_ch_names``, to allow for easy retrieval of EEG channel names corresponding to the left, right, and midline portions of the montage (:gh:`11632` by `Richard Höchenberger`_)
-- Methods for setting the sensor types of channels (e.g., for raw data :meth:`mne.io.Raw.set_channel_types`) gained a new parameter, ``on_unit_change``, to control whether to warn in case the measurement unit is adjusted automatically (:gh:`11668` by `Richard Höchenberger`_)
+- Methods for setting the sensor types of channels (e.g., for raw data, :meth:`mne.io.Raw.set_channel_types`) gained a new parameter, ``on_unit_change``, to control behavior (raise an exception, emit a warning, or do nothing) in case the measurement unit is adjusted automatically (:gh:`11668` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -316,10 +316,9 @@ class SetChannelsMixin(MontageMixin):
         mapping : dict
             A dictionary mapping channel names to sensor types, e.g.,
             ``{'EEG061': 'eog'}``.
-        on_unit_change : 'warn' | 'ignore'
-            Whether to emit a warning (default) if the measurement unit of a
-            channel is changed automatically to match the new sensor
-            type.
+        on_unit_change : 'raise' | 'warn' | 'ignore'
+            What to do if the measurement unit of a channel is changed
+            automatically to match the new sensor type.
 
             .. versionadded:: 1.4
         %(verbose)s
@@ -343,10 +342,6 @@ class SetChannelsMixin(MontageMixin):
 
         .. versionadded:: 0.9.0
         """
-        _check_option(
-            'on_unit_change', value=on_unit_change,
-            allowed_values=('warn', 'ignore')
-        )
         ch_names = self.info['ch_names']
 
         # first check and assemble clean mappings of index and name
@@ -399,10 +394,13 @@ class SetChannelsMixin(MontageMixin):
                 coil_type = FIFF.FIFFV_COIL_NONE
             self.info['chs'][c_ind]['coil_type'] = coil_type
 
-        if on_unit_change == 'warn':
-            msg = "The unit for channel(s) {0} has changed from {1} to {2}."
-            for this_change, names in unit_changes.items():
-                warn(msg.format(", ".join(sorted(names)), *this_change))
+        msg = "The unit for channel(s) {0} has changed from {1} to {2}."
+        for this_change, names in unit_changes.items():
+            _on_missing(
+                on_missing=on_unit_change,
+                msg=msg.format(", ".join(sorted(names)), *this_change),
+                name='on_unit_change',
+            )
 
         return self
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -309,16 +309,16 @@ class SetChannelsMixin(MontageMixin):
 
     @verbose
     def set_channel_types(self, mapping, *, on_unit_change='warn', verbose=None):
-        """Define the sensor type of channels.
+        """Specify the sensor types of channels.
 
         Parameters
         ----------
         mapping : dict
-            A dictionary mapping a channel to a sensor type (str), e.g.,
+            A dictionary mapping channel names to sensor types, e.g.,
             ``{'EEG061': 'eog'}``.
         on_unit_change : 'warn' | 'ignore'
-            Whether to emit a warning (default) or not if the unit of one or
-            more channels are changed automatically to match the new sensor
+            Whether to emit a warning (default) if the measurement unit of a
+            channels is changed automatically to match the new sensor
             type.
 
             .. versionadded:: 1.4

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -318,7 +318,7 @@ class SetChannelsMixin(MontageMixin):
             ``{'EEG061': 'eog'}``.
         on_unit_change : 'warn' | 'ignore'
             Whether to emit a warning (default) if the measurement unit of a
-            channels is changed automatically to match the new sensor
+            channel is changed automatically to match the new sensor
             type.
 
             .. versionadded:: 1.4

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -144,12 +144,12 @@ def test_set_channel_types():
     with pytest.raises(ValueError, match='unit for channel.* has changed'):
         raw2.copy().set_channel_types(mapping, on_unit_change='raise')
 
-    # Shouldn't warn
-    raw2.copy().set_channel_types(mapping, on_unit_change='ignore')
-
     # Should warn
     with pytest.warns(RuntimeWarning, match='unit for channel.* has changed'):
-        raw2 = raw2.set_channel_types(mapping)
+        raw2.copy().set_channel_types(mapping)
+
+    # Shouldn't warn
+    raw2.set_channel_types(mapping, on_unit_change='ignore')
 
     info = raw2.info
     assert info['chs'][371]['ch_name'] == 'EEG 057'

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -140,6 +140,10 @@ def test_set_channel_types():
         raw2.set_channel_types(mapping)  # has prj
     raw2.add_proj([], remove_existing=True)
 
+    # Should raise
+    with pytest.raises(ValueError, match='unit for channel.* has changed'):
+        raw2.copy().set_channel_types(mapping, on_unit_change='raise')
+
     # Shouldn't warn
     raw2.copy().set_channel_types(mapping, on_unit_change='ignore')
 

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -139,8 +139,14 @@ def test_set_channel_types():
     with pytest.raises(RuntimeError, match='type .* in projector "PCA-v1"'):
         raw2.set_channel_types(mapping)  # has prj
     raw2.add_proj([], remove_existing=True)
+
+    # Shouldn't warn
+    raw2.copy().set_channel_types(mapping, on_unit_change='ignore')
+
+    # Should warn
     with pytest.warns(RuntimeWarning, match='unit for channel.* has changed'):
         raw2 = raw2.set_channel_types(mapping)
+
     info = raw2.info
     assert info['chs'][371]['ch_name'] == 'EEG 057'
     assert info['chs'][371]['kind'] == FIFF.FIFFV_DBS_CH

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -182,8 +182,7 @@ def test_interpolation_meg():
     # before MEG channels
     raw.crop(0, 0.1).load_data().pick_channels(epochs_meg.ch_names)
     raw.info.normalize_proj()
-    with pytest.warns(RuntimeWarning, match='unit .* changed from .* to .*'):
-        raw.set_channel_types({raw.ch_names[0]: 'stim'})
+    raw.set_channel_types({raw.ch_names[0]: 'stim'}, on_unit_change='ignore')
     raw.info['bads'] = [raw.ch_names[1]]
     raw.load_data()
     raw.interpolate_bads(mode='fast')

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -260,8 +260,7 @@ def test_rawarray_edf(tmp_path):
 
     # test that warning is raised if there are non-voltage based channels
     raw = RawArray(data, info)
-    with pytest.warns(RuntimeWarning, match='The unit'):
-        raw.set_channel_types({'9': 'hbr'})
+    raw.set_channel_types({'9': 'hbr'}, on_unit_change='ignore')
     with pytest.warns(RuntimeWarning, match='Non-voltage channels'):
         raw.export(temp_fname, overwrite=True)
 

--- a/mne/preprocessing/tests/test_ecg.py
+++ b/mne/preprocessing/tests/test_ecg.py
@@ -76,8 +76,7 @@ def test_find_ecg():
     # test with user provided ecg channel
     raw.del_proj()
     assert 'MEG 2641' in raw.ch_names
-    with pytest.warns(RuntimeWarning, match='unit for channel'):
-        raw.set_channel_types({'MEG 2641': 'ecg'})
+    raw.set_channel_types({'MEG 2641': 'ecg'}, on_unit_change='ignore')
     create_ecg_epochs(raw)
 
     raw.pick_types(meg=True)  # remove ECG

--- a/mne/preprocessing/tests/test_ecg.py
+++ b/mne/preprocessing/tests/test_ecg.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import pytest
 import numpy as np
 
 from mne.io import read_raw_fif

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1505,8 +1505,9 @@ def test_evoked_io_from_epochs(tmp_path):
     picks = pick_types(raw.info, meg=True, eeg=True)
     epochs = Epochs(raw, events[:4], event_id, -0.2, tmax,
                     picks=picks, baseline=(0.1, 0.2), decim=5)
-    with pytest.warns(RuntimeWarning, match='unit for.*changed from'):
-        epochs.set_channel_types({epochs.ch_names[0]: 'syst'})
+    epochs.set_channel_types(
+        {epochs.ch_names[0]: 'syst'}, on_unit_change='ignore'
+    )
     evokeds = list()
     for picks in (None, 'all'):
         evoked = epochs.average(picks)

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -111,8 +111,7 @@ def test_plot_joint():
     # test sEEG (gh:8733)
     evoked.del_proj().pick_types('mag')  # avoid overlapping positions error
     mapping = {ch_name: 'seeg' for ch_name in evoked.ch_names}
-    with pytest.warns(RuntimeWarning, match='The unit .* has changed from .*'):
-        evoked.set_channel_types(mapping)
+    evoked.set_channel_types(mapping, on_unit_change='ignore')
     evoked.plot_joint()
 
     # test DBS (gh:8739)

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -118,8 +118,7 @@ def test_plot_joint():
     # test DBS (gh:8739)
     evoked = _get_epochs().average().pick_types('mag')
     mapping = {ch_name: 'dbs' for ch_name in evoked.ch_names}
-    with pytest.warns(RuntimeWarning, match='The unit for'):
-        evoked.set_channel_types(mapping)
+    evoked.set_channel_types(mapping, on_unit_change='ignore')
     evoked.plot_joint()
     plt.close('all')
 


### PR DESCRIPTION
In MNE-BIDS we commonly change the units during an ordinary reading operation. This is expected behavior and should not yield a warning.

However, trying to **catch and filter** the warning that MNE emits is quite cumbersome, esp. inside the MNE-BIDS test suite.

I, therefore, believe the best approach is to allow the silencing of the warnings in MNE-Python directly.

This PR adds a new parameter, `on_unit_change`, to the `.set_channel_types()` methods. The default is to warn, but users can now also choose to `'ignore'` this.

x-ref https://github.com/mne-tools/mne-bids/issues/1100

cc @sappelhoff 