### PR TITLE
Trap music

### DIFF
--- a/doc/changes/0.19.inc
+++ b/doc/changes/0.19.inc
@@ -37,7 +37,7 @@ Changelog
 
 - Allow :meth:`mne.Annotations.crop` to support negative ``tmin`` and ``tmax`` by `Joan Massich`_
 
-- Unknown events code in GDF are now visible in the ``event_id`` by `Theodore Papadopoulo`_
+- Unknown events code in GDF are now visible in the ``event_id`` by `Théodore Papadopoulo`_
 
 - Now :func:`mne.io.read_raw_ctf` populates ``raw.annotations`` with the markers in ``MarkerFile.mrk`` if any by `Joan Massich`_
 

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -48,7 +48,7 @@ Enhancements
 - Add support for eyetracking data using :func:`mne.io.read_raw_eyelink` (:gh:`11152` by `Dominik Welke`_ and `Scott Huberty`_)
 - :func:`mne.channels.make_1020_channel_selections` gained a new parameter, ``return_ch_names``, to allow for easy retrieval of EEG channel names corresponding to the left, right, and midline portions of the montage (:gh:`11632` by `Richard Höchenberger`_)
 - Methods for setting the sensor types of channels (e.g., for raw data, :meth:`mne.io.Raw.set_channel_types`) gained a new parameter, ``on_unit_change``, to control behavior (raise an exception, emit a warning, or do nothing) in case the measurement unit is adjusted automatically (:gh:`11668` by `Richard Höchenberger`_)
-- :func:`mne.beamformer.trap_music` implements the TRAP-MUSIC localisation algorithm with the same signature as :func:`mne.bemformer.rap_music` (:gh:`11679` by `Théodore Papadopoulo`_)
+- :func:`mne.beamformer.trap_music` implements the TRAP-MUSIC localisation algorithm with the same signature as :func:`mne.beamformer.rap_music` (:gh:`11679` by `Théodore Papadopoulo`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -48,6 +48,8 @@ Enhancements
 - Add support for eyetracking data using :func:`mne.io.read_raw_eyelink` (:gh:`11152` by `Dominik Welke`_ and `Scott Huberty`_)
 - :func:`mne.channels.make_1020_channel_selections` gained a new parameter, ``return_ch_names``, to allow for easy retrieval of EEG channel names corresponding to the left, right, and midline portions of the montage (:gh:`11632` by `Richard Höchenberger`_)
 - Methods for setting the sensor types of channels (e.g., for raw data, :meth:`mne.io.Raw.set_channel_types`) gained a new parameter, ``on_unit_change``, to control behavior (raise an exception, emit a warning, or do nothing) in case the measurement unit is adjusted automatically (:gh:`11668` by `Richard Höchenberger`_)
+- :func:`mne.beamformer.trap_music` implements the TRAP-MUSIC localisation algorithm. It has exactly the same signature as
+ :func:`mne.bemformer.rap_music` (:gh:`11679` by `Théodore Papadopoulo`_)
 
 Bugs
 ~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -48,8 +48,7 @@ Enhancements
 - Add support for eyetracking data using :func:`mne.io.read_raw_eyelink` (:gh:`11152` by `Dominik Welke`_ and `Scott Huberty`_)
 - :func:`mne.channels.make_1020_channel_selections` gained a new parameter, ``return_ch_names``, to allow for easy retrieval of EEG channel names corresponding to the left, right, and midline portions of the montage (:gh:`11632` by `Richard Höchenberger`_)
 - Methods for setting the sensor types of channels (e.g., for raw data, :meth:`mne.io.Raw.set_channel_types`) gained a new parameter, ``on_unit_change``, to control behavior (raise an exception, emit a warning, or do nothing) in case the measurement unit is adjusted automatically (:gh:`11668` by `Richard Höchenberger`_)
-- :func:`mne.beamformer.trap_music` implements the TRAP-MUSIC localisation algorithm. It has exactly the same signature as
- :func:`mne.bemformer.rap_music` (:gh:`11679` by `Théodore Papadopoulo`_)
+- :func:`mne.beamformer.trap_music` implements the TRAP-MUSIC localisation algorithm with the same signature as :func:`mne.bemformer.rap_music` (:gh:`11679` by `Théodore Papadopoulo`_)
 
 Bugs
 ~~~~

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -508,7 +508,7 @@
 
 .. _Teon Brooks: https://teonbrooks.com
 
-.. _Theodore Papadopoulo: https://github.com/papadop
+.. _Théodore Papadopoulo: https://github.com/papadop
 
 .. _Thomas Binns: https://github.com/tsbinns
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1481,6 +1481,7 @@ needed_plot_redirects = {
     "psf_ctf_vertices_lcmv.py",
     "publication_figure.py",
     "rap_music.py",
+    "trap_music.py",
     "read_inverse.py",
     "read_neo_format.py",
     "read_noise_covariance_matrix.py",

--- a/doc/inverse.rst
+++ b/doc/inverse.rst
@@ -74,6 +74,7 @@ Inverse Solutions
    apply_dics_epochs
    apply_dics_tfr_epochs
    rap_music
+   trap_music
    make_lcmv_resolution_matrix
 
 .. currentmodule:: mne

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1270,7 +1270,6 @@
   year = {1999}
 }
 
-
 @inproceedings{MosherLeahy1996,
 	title = {{EEG} and {MEG} source localization using recursively applied ({RAP}) {MUSIC}},
 	doi = {10.1109/ACSSC.1996.599135},

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1270,6 +1270,18 @@
   year = {1999}
 }
 
+
+@inproceedings{MosherLeahy1996,
+	title = {{EEG} and {MEG} source localization using recursively applied ({RAP}) {MUSIC}},
+	doi = {10.1109/ACSSC.1996.599135},
+	booktitle = {Conference {Record} of {The} {Thirtieth} {Asilomar} {Conference} on {Signals}, {Systems} and {Computers}},
+	author = {Mosher, J.C. and Leahy, R.M.},
+	month = nov,
+	year = {1996},
+	note = {ISSN: 1058-6393},
+	pages = {1201--1207 vol.2}
+}
+
 @inproceedings{MoukademEtAl2014,
   address = {{Lisbon}},
   author = {Moukadem, Ali and Bouguila, Zied and Abdeslam, Djaffar Ould and Dieterlen, Alain},

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1190,6 +1190,17 @@
   year = {1993}
 }
 
+@article{Makela2018,
+  author = {Mäkelä, Niko and Stenroos, Matti and Sarvas, Jukka and Ilmoniemi, Risto J.},
+  doi = {10.1016/j.neuroimage.2017.11.013},
+  journal = {Neuroimage},
+  number = {},
+  pages = {73-83},
+  title = {Truncated RAP-MUSIC (TRAP-MUSIC) for MEG and EEG source localization},
+  volume = {167},
+  year = {2018}
+}
+
 @article{MarisOostenveld2007,
   author = {Maris, Eric and Oostenveld, Robert},
   doi = {10.1016/j.jneumeth.2007.03.024},

--- a/examples/inverse/trap_music.py
+++ b/examples/inverse/trap_music.py
@@ -9,7 +9,7 @@ Compute a Truncated Recursively Applied and Projected MUltiple Signal Classifica
 (TRAP-MUSIC) :footcite:`Makela2018` on evoked data.
 """
 
-# Author: Theo Papadopoulo <papadoppoulo@gmail.com>
+# Author: Théodore Papadopoulo <Theodore.Papadopoulo@inria.fr>
 #
 # License: BSD-3-Clause
 

--- a/examples/inverse/trap_music.py
+++ b/examples/inverse/trap_music.py
@@ -1,0 +1,61 @@
+"""
+.. _ex-trap-music:
+
+================================
+Compute Trap-Music on evoked data
+================================
+
+Compute a Truncated Recursively Applied and Projected MUltiple Signal Classification
+(TRAP-MUSIC) :footcite:`Makela2018` on evoked data.
+"""
+
+# Author: Theo Papadopoulo <papadoppoulo@gmail.com>
+#
+# License: BSD-3-Clause
+
+# %%
+
+import mne
+
+from mne.datasets import sample
+from mne.beamformer import trap_music
+from mne.viz import plot_dipole_locations, plot_dipole_amplitudes
+
+print(__doc__)
+
+data_path = sample.data_path()
+subjects_dir = data_path / "subjects"
+meg_path = data_path / "MEG" / "sample"
+fwd_fname = meg_path / "sample_audvis-meg-eeg-oct-6-fwd.fif"
+evoked_fname = meg_path / "sample_audvis-ave.fif"
+cov_fname = meg_path / "sample_audvis-cov.fif"
+
+# Read the evoked response and crop it
+condition = "Right Auditory"
+evoked = mne.read_evokeds(evoked_fname, condition=condition, baseline=(None, 0))
+# select N100
+evoked.crop(tmin=0.05, tmax=0.15)
+
+evoked.pick_types(meg=True, eeg=False)
+
+# Read the forward solution
+forward = mne.read_forward_solution(fwd_fname)
+
+# Read noise covariance matrix
+noise_cov = mne.read_cov(cov_fname)
+
+dipoles, residual = trap_music(
+    evoked, forward, noise_cov, n_dipoles=2, return_residual=True, verbose=True
+)
+trans = forward["mri_head_t"]
+plot_dipole_locations(dipoles, trans, "sample", subjects_dir=subjects_dir)
+plot_dipole_amplitudes(dipoles)
+
+# Plot the evoked data and the residual.
+evoked.plot(ylim=dict(grad=[-300, 300], mag=[-800, 800], eeg=[-6, 8]), time_unit="s")
+residual.plot(ylim=dict(grad=[-300, 300], mag=[-800, 800], eeg=[-6, 8]), time_unit="s")
+
+# %%
+# References
+# ----------
+# .. footbibliography::

--- a/examples/inverse/trap_music.py
+++ b/examples/inverse/trap_music.py
@@ -1,9 +1,9 @@
 """
 .. _ex-trap-music:
 
-================================
+=================================
 Compute Trap-Music on evoked data
-================================
+=================================
 
 Compute a Truncated Recursively Applied and Projected MUltiple Signal Classification
 (TRAP-MUSIC) :footcite:`Makela2018` on evoked data.

--- a/mne/beamformer/__init__.py
+++ b/mne/beamformer/__init__.py
@@ -15,5 +15,6 @@ from ._dics import (
     apply_dics_csd,
 )
 from ._rap_music import rap_music
+from ._rap_music import trap_music
 from ._compute_beamformer import Beamformer, read_beamformer
 from .resolution_matrix import make_lcmv_resolution_matrix

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -251,7 +251,7 @@ def rap_music(
     See Also
     --------
     mne.fit_dipole
-    mne.trap_music
+    mne.beamformer.trap_music
 
     Notes
     -----
@@ -315,7 +315,7 @@ def trap_music(
     See Also
     --------
     mne.fit_dipole
-    mne.rap_music
+    mne.beamformer.rap_music
 
     Notes
     -----
@@ -325,6 +325,6 @@ def trap_music(
         (TRAP-MUSIC) for MEG and EEG source localization, Neuroimage, 2018.
         doi: 10.1016/j.neuroimage.2017.11.013
 
-    .. versionadded:: 1.3.2
+    .. versionadded:: 1.4
     """
     return _rap_music(evoked, forward, noise_cov, n_dipoles, return_residual, True)

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -269,7 +269,7 @@ def rap_music(
 
     .. versionadded:: 0.9.0
     """
-    return _rap_music(evoked, forward, noise_cov, n_dipoles, return_residual, verbose)
+    return _rap_music(evoked, forward, noise_cov, n_dipoles, return_residual)
 
 
 @verbose
@@ -328,5 +328,5 @@ def trap_music(
     .. versionadded:: 1.3.2
     """
     return _rap_music(
-        evoked, forward, noise_cov, n_dipoles, return_residual, verbose, use_trap=True
+        evoked, forward, noise_cov, n_dipoles, return_residual, use_trap=True
     )

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -163,6 +163,8 @@ def _compute_subcorr(G, phi_sig):
     # eg. when using MEG and a sphere model for which the
     # radial component will be truly 0.
     rank = np.sum(Sg > (Sg[0] * 1e-6))
+    if rank == 0:
+        return 0, np.zeros(len(G))
     rank = max(rank, 2)  # rank cannot be 1
     Ug, Sg, Vg = Ug[:, :rank], Sg[:rank], Vg[:rank]
     tmp = np.dot(Ug.T.conjugate(), phi_sig)

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -221,7 +221,7 @@ def rap_music(
     """RAP-MUSIC source localization method.
 
     Compute Recursively Applied and Projected MUltiple SIgnal Classification
-    (RAP-MUSIC) on evoked data.
+    (RAP-MUSIC) :footcite:`MosherLeahy1999,MosherLeahy1996` on evoked data.
 
     .. note:: The goodness of fit (GOF) of all the returned dipoles is the
               same and corresponds to the GOF of the full set of dipoles.
@@ -255,19 +255,11 @@ def rap_music(
 
     Notes
     -----
-    The references are:
-
-        J.C. Mosher and R.M. Leahy. 1999. Source localization using recursively
-        applied and projected (RAP) MUSIC. Signal Processing, IEEE Trans. 47, 2
-        (February 1999), 332-340.
-        DOI=10.1109/78.740118 https://doi.org/10.1109/78.740118
-
-        Mosher, J.C.; Leahy, R.M., EEG and MEG source localization using
-        recursively applied (RAP) MUSIC, Signals, Systems and Computers, 1996.
-        pp.1201,1207 vol.2, 3-6 Nov. 1996
-        doi: 10.1109/ACSSC.1996.599135
-
     .. versionadded:: 0.9.0
+
+    References
+    ----------
+    .. footbibliography::
     """
     return _rap_music(evoked, forward, noise_cov, n_dipoles, return_residual, False)
 
@@ -285,7 +277,7 @@ def trap_music(
     """TRAP-MUSIC source localization method.
 
     Compute Truncated Recursively Applied and Projected MUltiple SIgnal Classification
-    (TRAP-MUSIC) on evoked data.
+    (TRAP-MUSIC) :footcite:`Makela2018` on evoked data.
 
     .. note:: The goodness of fit (GOF) of all the returned dipoles is the
               same and corresponds to the GOF of the full set of dipoles.
@@ -319,12 +311,10 @@ def trap_music(
 
     Notes
     -----
-    The reference is:
-
-        N. Mäkelä, M. Stenroos, J. Sarvas, R. J. Ilmoniemi, Truncated RAP-MUSIC
-        (TRAP-MUSIC) for MEG and EEG source localization, Neuroimage, 2018.
-        doi: 10.1016/j.neuroimage.2017.11.013
-
     .. versionadded:: 1.4
+
+    References
+    ----------
+    .. footbibliography::
     """
     return _rap_music(evoked, forward, noise_cov, n_dipoles, return_residual, True)

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -163,8 +163,6 @@ def _compute_subcorr(G, phi_sig):
     # eg. when using MEG and a sphere model for which the
     # radial component will be truly 0.
     rank = np.sum(Sg > (Sg[0] * 1e-6))
-    if rank == 0:
-        return 0, np.zeros(len(G))
     rank = max(rank, 2)  # rank cannot be 1
     Ug, Sg, Vg = Ug[:, :rank], Sg[:rank], Vg[:rank]
     tmp = np.dot(Ug.T.conjugate(), phi_sig)
@@ -284,7 +282,7 @@ def trap_music(
 ):
     """TRAP-MUSIC source localization method.
 
-    Compute Trucated Recursively Applied and Projected MUltiple SIgnal Classification
+    Compute Truncated Recursively Applied and Projected MUltiple SIgnal Classification
     (TRAP-MUSIC) on evoked data.
 
     .. note:: The goodness of fit (GOF) of all the returned dipoles is the

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -269,7 +269,7 @@ def rap_music(
 
     .. versionadded:: 0.9.0
     """
-    return _rap_music(evoked, forward, noise_cov, n_dipoles, return_residual)
+    return _rap_music(evoked, forward, noise_cov, n_dipoles, return_residual, False)
 
 
 @verbose
@@ -327,6 +327,4 @@ def trap_music(
 
     .. versionadded:: 1.3.2
     """
-    return _rap_music(
-        evoked, forward, noise_cov, n_dipoles, return_residual, use_trap=True
-    )
+    return _rap_music(evoked, forward, noise_cov, n_dipoles, return_residual, True)

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -43,7 +43,6 @@ def _apply_rap_music(data, info, times, forward, noise_cov, n_dipoles=2, picks=N
     explained_data : array | None
         Data explained by the dipoles using a least square fitting with the
         selected active dipoles and their estimated orientation.
-        Computed only if return_explained_data is True.
     """
     from scipy import linalg
 

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -182,7 +182,7 @@ def _compute_proj(A):
 
 @verbose
 def rap_music(
-    evoked, forward, noise_cov, n_dipoles=5, return_residual=False, verbose=None, use_trap=False
+    evoked, forward, noise_cov, n_dipoles=5, return_residual=False, use_trap=False
 ):
     """RAP-MUSIC source localization method.
 
@@ -204,7 +204,6 @@ def rap_music(
         The number of dipoles to look for. The default value is 5.
     return_residual : bool
         If True, the residual is returned as an Evoked instance.
-    %(verbose)s
     use_trap : boolean
         Use the TRAP-MUSIC variant if True. The default value is False.
 

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -38,7 +38,7 @@ def _apply_rap_music(
     picks : list of int
         Caller ensures this is a list of int.
     use_trap : boolean
-        Use the TRAP-MUSIC variant if True. The default value is False.
+        Use the TRAP-MUSIC variant if True (default False).
 
     Returns
     -------
@@ -189,8 +189,9 @@ def rap_music(
     noise_cov,
     n_dipoles=5,
     return_residual=False,
-    verbose=None,
+    *,
     use_trap=False,
+    verbose=None,
 ):
     """RAP-MUSIC source localization method.
 
@@ -212,9 +213,9 @@ def rap_music(
         The number of dipoles to look for. The default value is 5.
     return_residual : bool
         If True, the residual is returned as an Evoked instance.
-    %(verbose)s
     use_trap : boolean
-        Use the TRAP-MUSIC variant if True. The default value is False.
+        Use the TRAP-MUSIC variant if True (default False).
+    %(verbose)s
 
     Returns
     -------

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -182,7 +182,7 @@ def _compute_proj(A):
 
 @verbose
 def rap_music(
-    evoked, forward, noise_cov, n_dipoles=5, return_residual=False, use_trap=False
+    evoked, forward, noise_cov, n_dipoles=5, return_residual=False, verbose=None, use_trap=False
 ):
     """RAP-MUSIC source localization method.
 
@@ -204,6 +204,7 @@ def rap_music(
         The number of dipoles to look for. The default value is 5.
     return_residual : bool
         If True, the residual is returned as an Evoked instance.
+    %(verbose)s
     use_trap : boolean
         Use the TRAP-MUSIC variant if True. The default value is False.
 

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -149,39 +149,6 @@ def _apply_rap_music(data, info, times, forward, noise_cov, n_dipoles=2, picks=N
     return dipoles, explained_data
 
 
-def _make_dipoles(times, poss, oris, sol, gof):
-    """Instantiate a list of Dipoles.
-
-    Parameters
-    ----------
-    times : array, shape (n_times,)
-        The time instants.
-    poss : array, shape (n_dipoles, 3)
-        The dipoles' positions.
-    oris : array, shape (n_dipoles, 3)
-        The dipoles' orientations.
-    sol : array, shape (n_times,)
-        The dipoles' amplitudes over time.
-    gof : array, shape (n_times,)
-        The goodness of fit of the dipoles.
-        Shared between all dipoles.
-
-    Returns
-    -------
-    dipoles : list
-        The list of Dipole instances.
-    """
-    oris = np.array(oris)
-
-    dipoles = []
-    for i_dip in range(poss.shape[0]):
-        i_pos = poss[i_dip][np.newaxis, :].repeat(len(times), axis=0)
-        i_ori = oris[i_dip][np.newaxis, :].repeat(len(times), axis=0)
-        dipoles.append(Dipole(times, i_pos, sol[i_dip], i_ori, gof))
-
-    return dipoles
-
-
 def _compute_subcorr(G, phi_sig):
     """Compute the subspace correlation."""
     from scipy import linalg

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -12,7 +12,6 @@ from ..io.pick import pick_info, pick_channels_forward
 from ..inverse_sparse.mxne_inverse import _make_dipoles_sparse
 from ..minimum_norm.inverse import _log_exp_var
 from ..utils import logger, verbose, _check_info_inv, fill_doc
-from ..dipole import Dipole
 from ._compute_beamformer import _prepare_beamformer_input
 
 

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -17,7 +17,9 @@ from ._compute_beamformer import _prepare_beamformer_input
 
 
 @fill_doc
-def _apply_rap_music(data, info, times, forward, noise_cov, n_dipoles=2, picks=None, use_trap=False):
+def _apply_rap_music(
+    data, info, times, forward, noise_cov, n_dipoles=2, picks=None, use_trap=False
+):
     """RAP-MUSIC for evoked data.
 
     Parameters
@@ -116,7 +118,7 @@ def _apply_rap_music(data, info, times, forward, noise_cov, n_dipoles=2, picks=N
         G_proj = np.einsum("ab,bso->aso", projection, G)
         phi_sig_proj = np.dot(projection, phi_sig)
         if use_trap:
-            phi_sig_proj = phi_sig_proj[:, -(n_dipoles - k):]
+            phi_sig_proj = phi_sig_proj[:, -(n_dipoles - k) :]
     del G, G_proj
 
     sol = linalg.lstsq(A, M)[0]
@@ -182,7 +184,13 @@ def _compute_proj(A):
 
 @verbose
 def rap_music(
-    evoked, forward, noise_cov, n_dipoles=5, return_residual=False, verbose=None, use_trap=False
+    evoked,
+    forward,
+    noise_cov,
+    n_dipoles=5,
+    return_residual=False,
+    verbose=None,
+    use_trap=False,
 ):
     """RAP-MUSIC source localization method.
 

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -19,7 +19,7 @@ from ._compute_beamformer import _prepare_beamformer_input
 def _apply_rap_music(
     data, info, times, forward, noise_cov, n_dipoles=2, picks=None, use_trap=False
 ):
-    """RAP-MUSIC for evoked data.
+    """RAP-MUSIC or TRAP-MUSIC for evoked data.
 
     Parameters
     ----------
@@ -181,73 +181,8 @@ def _compute_proj(A):
     return np.identity(A.shape[0]) - np.dot(U, U.T.conjugate())
 
 
-@verbose
-def rap_music(
-    evoked,
-    forward,
-    noise_cov,
-    n_dipoles=5,
-    return_residual=False,
-    *,
-    use_trap=False,
-    verbose=None,
-):
-    """RAP-MUSIC source localization method.
-
-    Compute Recursively Applied and Projected MUltiple SIgnal Classification
-    (RAP-MUSIC) on evoked data.
-
-    .. note:: The goodness of fit (GOF) of all the returned dipoles is the
-              same and corresponds to the GOF of the full set of dipoles.
-
-    Parameters
-    ----------
-    evoked : instance of Evoked
-        Evoked data to localize.
-    forward : instance of Forward
-        Forward operator.
-    noise_cov : instance of Covariance
-        The noise covariance.
-    n_dipoles : int
-        The number of dipoles to look for. The default value is 5.
-    return_residual : bool
-        If True, the residual is returned as an Evoked instance.
-    use_trap : boolean
-        Use the TRAP-MUSIC variant if True (default False).
-    %(verbose)s
-
-    Returns
-    -------
-    dipoles : list of instance of Dipole
-        The dipole fits.
-    residual : instance of Evoked
-        The residual a.k.a. data not explained by the dipoles.
-        Only returned if return_residual is True.
-
-    See Also
-    --------
-    mne.fit_dipole
-
-    Notes
-    -----
-    The references are:
-
-        J.C. Mosher and R.M. Leahy. 1999. Source localization using recursively
-        applied and projected (RAP) MUSIC. Signal Processing, IEEE Trans. 47, 2
-        (February 1999), 332-340.
-        DOI=10.1109/78.740118 https://doi.org/10.1109/78.740118
-
-        Mosher, J.C.; Leahy, R.M., EEG and MEG source localization using
-        recursively applied (RAP) MUSIC, Signals, Systems and Computers, 1996.
-        pp.1201,1207 vol.2, 3-6 Nov. 1996
-        doi: 10.1109/ACSSC.1996.599135
-
-        N. Mäkelä, M. Stenroos, J. Sarvas, R. J. Ilmoniemi, Truncated RAP-MUSIC
-        (TRAP-MUSIC) for MEG and EEG source localization, Neuroimage, 2018.
-        doi: 10.1016/j.neuroimage.2017.11.013
-
-    .. versionadded:: 0.9.0
-    """
+def _rap_music(evoked, forward, noise_cov, n_dipoles, return_residual, use_trap):
+    """RAP-/TRAP-MUSIC implementation."""
     info = evoked.info
     data = evoked.data
     times = evoked.times
@@ -271,3 +206,127 @@ def rap_music(
         return dipoles, residual
     else:
         return dipoles
+
+
+@verbose
+def rap_music(
+    evoked,
+    forward,
+    noise_cov,
+    n_dipoles=5,
+    return_residual=False,
+    *,
+    verbose=None,
+):
+    """RAP-MUSIC source localization method.
+
+    Compute Recursively Applied and Projected MUltiple SIgnal Classification
+    (RAP-MUSIC) on evoked data.
+
+    .. note:: The goodness of fit (GOF) of all the returned dipoles is the
+              same and corresponds to the GOF of the full set of dipoles.
+
+    Parameters
+    ----------
+    evoked : instance of Evoked
+        Evoked data to localize.
+    forward : instance of Forward
+        Forward operator.
+    noise_cov : instance of Covariance
+        The noise covariance.
+    n_dipoles : int
+        The number of dipoles to look for. The default value is 5.
+    return_residual : bool
+        If True, the residual is returned as an Evoked instance.
+    %(verbose)s
+
+    Returns
+    -------
+    dipoles : list of instance of Dipole
+        The dipole fits.
+    residual : instance of Evoked
+        The residual a.k.a. data not explained by the dipoles.
+        Only returned if return_residual is True.
+
+    See Also
+    --------
+    mne.fit_dipole
+    mne.trap_music
+
+    Notes
+    -----
+    The references are:
+
+        J.C. Mosher and R.M. Leahy. 1999. Source localization using recursively
+        applied and projected (RAP) MUSIC. Signal Processing, IEEE Trans. 47, 2
+        (February 1999), 332-340.
+        DOI=10.1109/78.740118 https://doi.org/10.1109/78.740118
+
+        Mosher, J.C.; Leahy, R.M., EEG and MEG source localization using
+        recursively applied (RAP) MUSIC, Signals, Systems and Computers, 1996.
+        pp.1201,1207 vol.2, 3-6 Nov. 1996
+        doi: 10.1109/ACSSC.1996.599135
+
+    .. versionadded:: 0.9.0
+    """
+    return _rap_music(evoked, forward, noise_cov, n_dipoles, return_residual, verbose)
+
+
+@verbose
+def trap_music(
+    evoked,
+    forward,
+    noise_cov,
+    n_dipoles=5,
+    return_residual=False,
+    *,
+    verbose=None,
+):
+    """TRAP-MUSIC source localization method.
+
+    Compute Trucated Recursively Applied and Projected MUltiple SIgnal Classification
+    (TRAP-MUSIC) on evoked data.
+
+    .. note:: The goodness of fit (GOF) of all the returned dipoles is the
+              same and corresponds to the GOF of the full set of dipoles.
+
+    Parameters
+    ----------
+    evoked : instance of Evoked
+        Evoked data to localize.
+    forward : instance of Forward
+        Forward operator.
+    noise_cov : instance of Covariance
+        The noise covariance.
+    n_dipoles : int
+        The number of dipoles to look for. The default value is 5.
+    return_residual : bool
+        If True, the residual is returned as an Evoked instance.
+    %(verbose)s
+
+    Returns
+    -------
+    dipoles : list of instance of Dipole
+        The dipole fits.
+    residual : instance of Evoked
+        The residual a.k.a. data not explained by the dipoles.
+        Only returned if return_residual is True.
+
+    See Also
+    --------
+    mne.fit_dipole
+    mne.rap_music
+
+    Notes
+    -----
+    The reference is:
+
+        N. Mäkelä, M. Stenroos, J. Sarvas, R. J. Ilmoniemi, Truncated RAP-MUSIC
+        (TRAP-MUSIC) for MEG and EEG source localization, Neuroimage, 2018.
+        doi: 10.1016/j.neuroimage.2017.11.013
+
+    .. versionadded:: 1.3.2
+    """
+    return _rap_music(
+        evoked, forward, noise_cov, n_dipoles, return_residual, verbose, use_trap=True
+    )

--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -36,7 +36,7 @@ def _apply_rap_music(
         The number of dipoles to estimate. The default value is 2.
     picks : list of int
         Caller ensures this is a list of int.
-    use_trap : boolean
+    use_trap : bool
         Use the TRAP-MUSIC variant if True (default False).
 
     Returns

--- a/mne/beamformer/tests/test_rap_music.py
+++ b/mne/beamformer/tests/test_rap_music.py
@@ -9,7 +9,7 @@ from scipy import linalg
 from numpy.testing import assert_allclose
 
 import mne
-from mne.beamformer import rap_music
+from mne.beamformer import rap_music, trap_music
 from mne.cov import regularize
 from mne.datasets import testing
 from mne.minimum_norm.tests.test_inverse import assert_var_exp_log

--- a/mne/beamformer/tests/test_rap_music.py
+++ b/mne/beamformer/tests/test_rap_music.py
@@ -212,3 +212,15 @@ def test_rap_music_picks():
     noise_cov = mne.read_cov(fname_cov)
     dipoles = rap_music(evoked, forward, noise_cov, n_dipoles=2)
     assert len(dipoles) == 2
+
+
+@testing.requires_testing_data
+def test_rap_music_trap():
+    """Test TRAP-MUSIC."""
+    evoked = mne.read_evokeds(fname_ave, condition="Right Auditory", baseline=(None, 0))
+    evoked.crop(tmin=0.05, tmax=0.15)  # select N100
+    evoked.pick_types(meg=True, eeg=False)
+    forward = mne.read_forward_solution(fname_fwd)
+    noise_cov = mne.read_cov(fname_cov)
+    dipoles = rap_music(evoked, forward, noise_cov, n_dipoles=2, use_trap=True)
+    assert len(dipoles) == 2

--- a/mne/beamformer/tests/test_rap_music.py
+++ b/mne/beamformer/tests/test_rap_music.py
@@ -215,12 +215,12 @@ def test_rap_music_picks():
 
 
 @testing.requires_testing_data
-def test_rap_music_trap():
+def test_trap_music():
     """Test TRAP-MUSIC."""
     evoked = mne.read_evokeds(fname_ave, condition="Right Auditory", baseline=(None, 0))
     evoked.crop(tmin=0.05, tmax=0.15)  # select N100
     evoked.pick_types(meg=True, eeg=False)
     forward = mne.read_forward_solution(fname_fwd)
     noise_cov = mne.read_cov(fname_cov)
-    dipoles = rap_music(evoked, forward, noise_cov, n_dipoles=2, use_trap=True)
+    dipoles = trap_music(evoked, forward, noise_cov, n_dipoles=2)
     assert len(dipoles) == 2


### PR DESCRIPTION
#### Reference issue
Example: Fixes #7679 .

#### What does this implement/fix?
It implements TRAP-MUSIC, which is a very simple variant of RAP-MUSIC.
Basically at each step the signal space is reduced by one dimension instead of being kept of constant diemnsion.
I also noticed some unused parameters and functions which I removed.

#### Additional information
On a simple example I tested the approach, it did not make a lot of difference. But technically, this is more sound than the original RAP. Yet, I kept the default to RAP instead of TRAP to avoid changing a behaviour.

The changes were tested outside of mne (but calling mne routines for everything outside the _rap_music_implementation.py file. I also did not test the new test in test_rap_music.py, but the change is very trivial. I leave it to any checker to catch eventual copy-paste errors, I may have made when I transferred the outside-of-mne implementation to mne. 
