### PR TITLE
Fix call to plot_tfr_topomap from interactive AverageTFR.plot_topo function

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -79,6 +79,7 @@ Bugs
 - Fix bug where Maxwell-filtered data rank was not handled properly in :func:`mne.beamformer.make_lcmv` (:gh:`11664` by `Eric Larson`_)
 - In :class:`~mne.Report`, custom figures now show up correctly when ``image_format='svg'`` is requested (:gh:`11623` by `Richard Höchenberger`_)
 - Fix bug where providing ``axes`` in `mne.preprocessing.ICA.plot_components` would fail (:gh:`11654` by `Mathieu Scheltienne`_)
+- Fix deprecation of ``title``, ``vmin`` and ``vmax`` in `~mne.viz.plot_tfr_topomap` called from interactive `mne.time_frequency.AverageTFR.plot_topo` (:gh:`11683` by `Mathieu Scheltienne`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -2279,11 +2279,11 @@ class AverageTFR(_BaseTFR):
                     baseline=baseline,
                     mode=mode,
                     cmap=None,
-                    title=ch_type,
-                    vmin=None,
-                    vmax=None,
+                    vlim=(None, None),
                     axes=ax,
                 )
+                ax.set_title(ch_type)
+            fig.tight_layout()
 
     @verbose
     def plot_topo(


### PR DESCRIPTION
As reported on the forum [here](https://mne.discourse.group/t/i-think-that-is-a-bug/6853).

To reproduce:

```
import numpy as np

import mne
from mne.datasets import sample
from mne.time_frequency import tfr_morlet

data_path = sample.data_path()
raw_fname = sample.data_path() / "MEG" / "sample" / "sample_audvis_raw.fif"

# Setup for reading the raw data
raw = mne.io.read_raw_fif(raw_fname, preload=False)
# crop and resample just to reduce computation time
raw.crop(120, 200).load_data().resample(200)
events = mne.find_events(raw, stim_channel="STI 014")

# picks MEG gradiometers
picks = mne.pick_types(raw.info, meg="grad", eeg=True, eog=True, stim=False)

# Construct Epochs
event_id, tmin, tmax = 1, -1.0, 3.0
epochs = mne.Epochs(
    raw,
    events,
    event_id,
    tmin,
    tmax,
    picks=picks,
    baseline=(None, 0),
    reject=dict(grad=4000e-13, eog=350e-6),
    preload=True,
)

freqs = np.logspace(*np.log10([6, 35]), num=8)
n_cycles = freqs / 2.0  # different number of cycle per frequency
power, itc = tfr_morlet(
    epochs,
    freqs=freqs,
    n_cycles=n_cycles,
    use_fft=True,
    return_itc=True,
    decim=3,
    n_jobs=None,
)

power.plot_topo(baseline=(-0.5, 0), mode="logratio", title="Average power")
```

And then click and select as on the initial post on the forum.

It's due to the deprecation in #11371.