### PR TITLE
Fix canvas.draw() in callback

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1647,7 +1647,7 @@ def plot_ica_components(
         fig.canvas.draw()
 
         # add title selection interactivity
-        def onclick_title(event, ica=ica, titles=subplot_titles):
+        def onclick_title(event, ica=ica, titles=subplot_titles, fig=fig):
             # check if any title was pressed
             title_pressed = None
             for title in titles:
@@ -1705,7 +1705,8 @@ def plot_ica_components(
             fig.canvas.mpl_connect("button_press_event", onclick_topo)
         figs.append(fig)
 
-    plt_show(show)
+    for fig in figs:
+        plt_show(show, fig)
     return figs[0] if len(figs) == 1 else figs
 
 

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1705,8 +1705,7 @@ def plot_ica_components(
             fig.canvas.mpl_connect("button_press_event", onclick_topo)
         figs.append(fig)
 
-    for fig in figs:
-        plt_show(show, fig)
+    plt_show(show)
     return figs[0] if len(figs) == 1 else figs
 
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -141,11 +141,12 @@ def plt_show(show=True, fig=None, **kwargs):
         Extra arguments for :func:`matplotlib.pyplot.show`.
     """
     import matplotlib.pyplot as plt
-    from matplotlib import get_backend
 
     if hasattr(fig, "mne") and hasattr(fig.mne, "backend"):
         backend = fig.mne.backend
     else:
+        from matplotlib import get_backend
+
         backend = get_backend()
     if show and backend != "agg":
         (fig or plt).show(**kwargs)

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -141,12 +141,11 @@ def plt_show(show=True, fig=None, **kwargs):
         Extra arguments for :func:`matplotlib.pyplot.show`.
     """
     import matplotlib.pyplot as plt
+    from matplotlib import get_backend
 
     if hasattr(fig, "mne") and hasattr(fig.mne, "backend"):
         backend = fig.mne.backend
     else:
-        from matplotlib import get_backend
-
         backend = get_backend()
     if show and backend != "agg":
         (fig or plt).show(**kwargs)


### PR DESCRIPTION
So.. I broke the update of the canvas in #11696, my bad :sweat_smile: The title are not changing color anymore when you select/deselect a component, except for the last figure. When I changed the structure of `plot_ica_components` to remove the recursion and call only once `plt.show()` after gathering the figures, it overwrote the variable `fig` used in the callback.

Should also be backported as #11696 was?