### PR TITLE
CLN raise TypeError for include in  pick_events

### DIFF
--- a/mne/event.py
+++ b/mne/event.py
@@ -24,6 +24,7 @@ from .utils import (
     _check_fname,
     _on_missing,
     _check_on_missing,
+    _check_integer_or_list,
 )
 from .io.constants import FIFF
 from .io.tree import dir_tree_find
@@ -59,8 +60,7 @@ def pick_events(events, include=None, exclude=None, step=False):
         The list of events.
     """
     if include is not None:
-        if not isinstance(include, list):
-            include = [include]
+        include = _check_integer_or_list(include, 'include')
         mask = np.zeros(len(events), dtype=bool)
         for e in include:
             mask = np.logical_or(mask, events[:, 2] == e)
@@ -68,8 +68,7 @@ def pick_events(events, include=None, exclude=None, step=False):
                 mask = np.logical_or(mask, events[:, 1] == e)
         events = events[mask]
     elif exclude is not None:
-        if not isinstance(exclude, list):
-            exclude = [exclude]
+        exclude = _check_integer_or_list(exclude, 'exclude')
         mask = np.ones(len(events), dtype=bool)
         for e in exclude:
             mask = np.logical_and(mask, events[:, 2] != e)

--- a/mne/tests/test_event.py
+++ b/mne/tests/test_event.py
@@ -424,6 +424,9 @@ def test_pick_events():
         [[1, 0, 1], [2, 1, 0], [4, 4, 2], [5, 2, 0]],
     )
 
+    pytest.raises(TypeError, pick_events, events, include=1.2)
+    pytest.raises(TypeError, pick_events, events, include={'a': 1})
+
 
 def test_make_fixed_length_events():
     """Test making events of a fixed length."""

--- a/mne/utils/__init__.py
+++ b/mne/utils/__init__.py
@@ -28,6 +28,7 @@ from .check import (
     _check_if_nan,
     _is_numeric,
     _ensure_int,
+    _check_integer_or_list,
     _check_preload,
     _validate_type,
     _check_range,

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -35,6 +35,16 @@ def _ensure_int(x, name="unknown", must_be="an int", *, extra=""):
     return x
 
 
+def _check_integer_or_list(arg, name):
+    """Validate arguments that should be an integer or a list.
+
+    Always returns a list.
+    """
+    if not isinstance(arg, list):
+        arg = [_ensure_int(arg, name=name, must_be="an integer or a list")]
+    return arg
+
+
 def check_fname(fname, filetype, endings, endings_err=()):
     """Enforce MNE filename conventions.
 


### PR DESCRIPTION
Raises an error when not passing a list or an integer. This prevents the user from passing a dict of event_id or a `event_id.values()` that will return `RuntimeError: no event found`.

Fixes #11700 