### PR TITLE
Fix installer links

### DIFF
--- a/doc/install/installers.rst
+++ b/doc/install/installers.rst
@@ -17,7 +17,7 @@ Got any questions? Let us know on the `MNE Forum`_!
         :class-content: text-center
         :name: linux-installers
 
-        .. button-link:: https://github.com/mne-tools/mne-installers/releases/download/v1.4.0/MNE-Python-1.4.0_1-Linux.sh
+        .. button-link:: https://github.com/mne-tools/mne-installers/releases/download/v1.4.0-post1/MNE-Python-1.4.0_1-Linux.sh
             :ref-type: ref
             :color: primary
             :shadow:
@@ -38,7 +38,7 @@ Got any questions? Let us know on the `MNE Forum`_!
         :class-content: text-center
         :name: macos-intel-installers
 
-        .. button-link:: https://github.com/mne-tools/mne-installers/releases/download/v1.4.0/MNE-Python-1.4.0_1-macOS_Intel.pkg
+        .. button-link:: https://github.com/mne-tools/mne-installers/releases/download/v1.4.0-post1/MNE-Python-1.4.0_1-macOS_Intel.pkg
             :ref-type: ref
             :color: primary
             :shadow:
@@ -54,7 +54,7 @@ Got any questions? Let us know on the `MNE Forum`_!
         :class-content: text-center
         :name: macos-apple-installers
 
-        .. button-link:: https://github.com/mne-tools/mne-installers/releases/download/v1.4.0/MNE-Python-1.4.0_1-macOS_M1.pkg
+        .. button-link:: https://github.com/mne-tools/mne-installers/releases/download/v1.4.0-post1/MNE-Python-1.4.0_1-macOS_M1.pkg
             :ref-type: ref
             :color: primary
             :shadow:
@@ -70,7 +70,7 @@ Got any questions? Let us know on the `MNE Forum`_!
         :class-content: text-center
         :name: windows-installers
 
-        .. button-link:: https://github.com/mne-tools/mne-installers/releases/download/v1.4.0/MNE-Python-1.4.0_1-Windows.exe
+        .. button-link:: https://github.com/mne-tools/mne-installers/releases/download/v1.4.0-post1/MNE-Python-1.4.0_1-Windows.exe
             :ref-type: ref
             :color: primary
             :shadow:


### PR DESCRIPTION
Reported on the forum here: https://mne.discourse.group/t/unable-to-download-the-linux-version-of-mne/6978
I updated the links to [v1.4.0-post1](https://github.com/mne-tools/mne-installers/releases/tag/v1.4.0-post1), do you prefer [v1.4.0](https://github.com/mne-tools/mne-installers/releases/tag/v1.4.0)?

I'm away for the weekend, feel free to push to this PR and merge it.