### PR TITLE
Add "array-like" to `_validate_type()`

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,4 +34,4 @@ Bugs
 
 API changes
 ~~~~~~~~~~~
-- :func:`mne.utils._validate_type` can now check if a given object is `"array-like"` (:gh:`11713` by `Clemens Brunner`_)
+- The ``baseline`` argument can now be array-like (e.g. ``list``, ``tuple``, ``np.ndarray``, ...) instead of only a ``tuple`` (:gh:`11713` by `Clemens Brunner`_)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,4 +34,4 @@ Bugs
 
 API changes
 ~~~~~~~~~~~
-- None yet
+- :func:`mne.utils._validate_type` can now check if a given object is `"array-like"` (:gh:`11713` by `Clemens Brunner`_)

--- a/mne/baseline.py
+++ b/mne/baseline.py
@@ -6,7 +6,7 @@
 
 import numpy as np
 
-from .utils import logger, verbose, _check_option
+from .utils import logger, verbose, _check_option, _validate_type
 
 
 def _log_rescale(baseline, mode="mean"):
@@ -143,14 +143,14 @@ def rescale(data, times, baseline, mode="mean", copy=True, picks=None, verbose=N
 
 
 def _check_baseline(baseline, times, sfreq, on_baseline_outside_data="raise"):
-    """Check if the baseline is valid, and adjust it if requested.
+    """Check if the baseline is valid and adjust it if requested.
 
-    ``None`` values inside the baseline parameter will be replaced with
-    ``times[0]`` and ``times[-1]``.
+    ``None`` values inside ``baseline`` will be replaced with ``times[0]`` and
+    ``times[-1]``.
 
     Parameters
     ----------
-    baseline : tuple | None
+    baseline : array-like | None
         Beginning and end of the baseline period, in seconds. If ``None``,
         assume no baseline and return immediately.
     times : array
@@ -158,27 +158,27 @@ def _check_baseline(baseline, times, sfreq, on_baseline_outside_data="raise"):
     sfreq : float
         The sampling rate.
     on_baseline_outside_data : 'raise' | 'info' | 'adjust'
-        What do do if the baseline period exceeds the data.
+        What to do if the baseline period exceeds the data.
         If ``'raise'``, raise an exception (default).
         If ``'info'``, log an info message.
-        If ``'adjust'``, adjust the baseline such that it's within the data
-        range again.
+        If ``'adjust'``, adjust the baseline such that it is within the data range.
 
     Returns
     -------
     (baseline_tmin, baseline_tmax) | None
-        The baseline with ``None`` values replaced with times, and with
-        adjusted times if ``on_baseline_outside_data='adjust'``; or ``None``
-        if the ``baseline`` parameter is ``None``.
-
+        The baseline with ``None`` values replaced with times, and with adjusted times
+        if ``on_baseline_outside_data='adjust'``; or ``None``, if ``baseline`` is
+        ``None``.
     """
     if baseline is None:
         return None
 
-    if not isinstance(baseline, tuple) or len(baseline) != 2:
+    _validate_type(baseline, "array-like")
+    baseline = tuple(baseline)
+    
+    if len(baseline) != 2:
         raise ValueError(
-            f"`baseline={baseline}` is an invalid argument, must "
-            f"be a tuple of length 2 or None"
+            f"baseline must have exactly two elements (got {len(baseline)})."
         )
 
     tmin, tmax = times[0], times[-1]

--- a/mne/baseline.py
+++ b/mne/baseline.py
@@ -175,7 +175,7 @@ def _check_baseline(baseline, times, sfreq, on_baseline_outside_data="raise"):
 
     _validate_type(baseline, "array-like")
     baseline = tuple(baseline)
-    
+
     if len(baseline) != 2:
         raise ValueError(
             f"baseline must have exactly two elements (got {len(baseline)})."

--- a/mne/baseline.py
+++ b/mne/baseline.py
@@ -150,7 +150,7 @@ def _check_baseline(baseline, times, sfreq, on_baseline_outside_data="raise"):
 
     Parameters
     ----------
-    baseline : array-like | None
+    baseline : array-like, shape (2,) | None
         Beginning and end of the baseline period, in seconds. If ``None``,
         assume no baseline and return immediately.
     times : array

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1349,7 +1349,7 @@ def test_epochs_io_preload(tmp_path, preload):
     epochs_no_bl.save(temp_fname_no_bl, overwrite=True)
     epochs_read = read_epochs(temp_fname)
     epochs_no_bl_read = read_epochs(temp_fname_no_bl)
-    with pytest.raises(ValueError, match="invalid"):
+    with pytest.raises(ValueError, match="exactly two elements"):
         epochs.apply_baseline(baseline=[1, 2, 3])
     epochs_with_bl = epochs_no_bl_read.copy().apply_baseline(baseline)
     assert isinstance(epochs_with_bl, BaseEpochs)

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -4,6 +4,7 @@
 # License: BSD-3-Clause
 
 from builtins import input  # no-op here but facilitates testing
+from collections.abc import Sequence
 from difflib import get_close_matches
 from importlib import import_module
 import operator
@@ -525,6 +526,7 @@ _multi = {
     "path-like": path_like,
     "int-like": (int_like,),
     "callable": (_Callable(),),
+    "array-like": (Sequence, np.ndarray),
 }
 
 
@@ -538,9 +540,8 @@ def _validate_type(item, types=None, item_name=None, type_name=None, *, extra=""
     types : type | str | tuple of types | tuple of str
          The types to be checked against.
          If str, must be one of {'int', 'int-like', 'str', 'numeric', 'info',
-         'path-like', 'callable'}.
-         If a tuple of str is passed, use 'int-like' and not 'int' for
-         integers.
+         'path-like', 'callable', 'array-like'}.
+         If a tuple of str is passed, use 'int-like' and not 'int' for integers.
     item_name : str | None
         Name of the item to show inside the error message.
     type_name : str | None


### PR DESCRIPTION
Since we typically require arguments to be "array-like", I think it is convenient to add such a type union to `_validate_type()`. I've used this new addition to now accept `baseline` to be array-like (instead of just `tuple`).

Let me know if this already exists and I just missed it.