### PR TITLE
MRG: If _check_fname() cannot find a file, display the path in quotation marks to help spot accidental trailing spaces

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -23,7 +23,7 @@ Current (1.5.dev0)
 
 Enhancements
 ~~~~~~~~~~~~
-- None yet
+- When failing to locate a file, we now print the full path in quotation marks to help spot accidentally added trailing spaces (:gh:`11718` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/mne/preprocessing/stim.py
+++ b/mne/preprocessing/stim.py
@@ -14,7 +14,7 @@ from ..utils import _check_preload, _check_option, fill_doc
 
 def _get_window(start, end):
     """Return window which has length as much as parameter start - end."""
-    from scipy.signal import hann
+    from scipy.signal.windows import hann
 
     window = 1 - np.r_[hann(4)[:2], np.ones(np.abs(end - start) - 4), hann(4)[-2:]].T
     return window

--- a/mne/stats/tests/test_regression.py
+++ b/mne/stats/tests/test_regression.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose, assert_equal
 import pytest
 
-from scipy.signal import hann
+from scipy.signal.windows import hann
 
 import mne
 from mne import read_source_estimate

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -258,7 +258,7 @@ def _check_fname(
             if not os.access(fname, os.R_OK):
                 raise PermissionError(f"{name} does not have read permissions: {fname}")
     elif must_exist:
-        raise FileNotFoundError(f"{name} does not exist: {fname}")
+        raise FileNotFoundError(f'{name} does not exist: "{fname}"')
 
     return fname
 


### PR DESCRIPTION
We had a user on the forum who got an error message about a missing file that didn't actually **seem** to be missing. Turns out a trailing space was present in the search path, which was hard to spot.

https://mne.discourse.group/t/the-source-estimate-is-not-displayed-i-think-it-may-be-a-bug/6993/4

Here, I'm changing the `FileNotFoundError` message to put the path in quotation marks to help identify such issues quicker in the future.
