### PR TITLE
Allow int-like as ID of make_fixed_length_events

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -38,6 +38,7 @@ Bugs
 - Fix hanging interpreter with matplotlib figures using ``mne/viz/_mpl_figure.py`` in spyder console and jupyter notebooks (:gh:`11696` by `Mathieu Scheltienne`_)
 - Fix bug with overlapping text for :meth:`mne.Evoked.plot` (:gh:`11698` by `Alex Rockhill`_)
 - For :func:`mne.io.read_raw_eyelink`, the default value of the ``gap_description`` parameter is now ``'BAD_ACQ_SKIP'``, following MNE convention (:gh:`11719` by `Scott Huberty`_)
+- Allow int-like for the argument ``id`` of `~mne.make_fixed_length_events` (:gh:`11748` by `Mathieu Scheltienne`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/event.py
+++ b/mne/event.py
@@ -957,7 +957,7 @@ def make_fixed_length_events(
     from .io.base import BaseRaw
 
     _validate_type(raw, BaseRaw, "raw")
-    _validate_type(id, int, "id")
+    _validate_type(id, "int", "id")
     _validate_type(duration, "numeric", "duration")
     _validate_type(overlap, "numeric", "overlap")
     duration, overlap = float(duration), float(overlap)


### PR DESCRIPTION
This function was raising when an ID `np.int64` retrieved from the event array returned by `mne.find_events` was used.