### PR TITLE
Reset the channel unit multiplication factor on unit change

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -36,7 +36,7 @@ from ..utils import (
     _on_missing,
     legacy,
 )
-from ..io.constants import FIFF
+from ..io.constants import FIFF, _ch_unit_mul_named
 from ..io.meas_info import (
     anonymize_info,
     Info,
@@ -442,6 +442,8 @@ class SetChannelsMixin(MontageMixin):
                 if this_change not in unit_changes:
                     unit_changes[this_change] = list()
                 unit_changes[this_change].append(ch_name)
+                # reset unit multiplication factor since the unit has now changed
+                self.info["chs"][c_ind]["unit_mul"] = _ch_unit_mul_named[0]
             self.info["chs"][c_ind]["unit"] = _human2unit[ch_type]
             if ch_type in ["eeg", "seeg", "ecog", "dbs"]:
                 coil_type = FIFF.FIFFV_COIL_EEG

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -38,7 +38,7 @@ from mne.io import (
     read_raw_kit,
     RawArray,
 )
-from mne.io.constants import FIFF
+from mne.io.constants import FIFF, _ch_unit_mul_named
 from mne import (
     pick_types,
     pick_channels,
@@ -222,6 +222,13 @@ def test_set_channel_types():
     raw.info["chs"][0]["unit"] = 0.0
     ch_types = {raw.ch_names[0]: "misc"}
     pytest.raises(ValueError, raw.set_channel_types, ch_types)
+
+    # test reset of channel units on unit change
+    idx = raw.ch_names.index("EEG 003")
+    raw.info["chs"][idx]["unit_mul"] = _ch_unit_mul_named[-6]
+    assert raw.info["chs"][idx]["unit_mul"] == -6
+    raw.set_channel_types({"EEG 003": "misc"}, on_unit_change="ignore")
+    assert raw.info["chs"][idx]["unit_mul"] == 0
 
 
 def test_get_builtin_ch_adjacencies():


### PR DESCRIPTION
MNE does not use the channel `unit_mul` key a lot, most of the time it is hard-coded to `FIFF.FIFF_UNITM_NONE`, a.k.a. 0.
I am however using it to store the unit of the channels from data streams (most of the time EEG streams in microvolts). When changing the type of a channel, MNE will warn if the unit is changed. But since the field `unit_mul` is not that used in the MNE-ecosystem, it's simply left as is. Instead, I would like to reset the field to `FIFF.FIFF_UNITM_NONE` when the unit of a channel is changed.

```
import numpy as np
from mne import create_info
from mne.io import RawArray
from mne.io.constants import _ch_unit_mul_named


info = create_info(["MISC1", "EEG1"], 2, ch_types="eeg")
raw = RawArray(np.zeros((2, 5)), info)
# set both to uV
raw.info["chs"][0]["unit_mul"] = _ch_unit_mul_named[-6]
raw.info["chs"][1]["unit_mul"] = _ch_unit_mul_named[-6]
# change type to MISC
raw.set_channel_types({"MISC1": "misc"})
```

If one day this field starts being used, IMO, the reset on unit change will make a lot of sense.