### PR TITLE
Change color from annotation to red if name changes to "bad_" or "edge_"

### DIFF
--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -163,10 +163,10 @@ class BrowserBase(ABC):
             if color != red and key in labels:
                 next(color_cycle)
         for idx, key in enumerate(labels):
-            if key in segment_colors:
-                continue
-            elif key.lower().startswith("bad") or key.lower().startswith("edge"):
+            if key.lower().startswith("bad") or key.lower().startswith("edge"):
                 segment_colors[key] = red
+            elif key in segment_colors:
+                continue
             else:
                 segment_colors[key] = next(color_cycle)
         self.mne.annotation_segment_colors = segment_colors


### PR DESCRIPTION
Part of https://github.com/mne-tools/mne-qt-browser/pull/172
The Qt Browser has a dialog menu to edit existing annotation. At the moment, editing an annotation from "whatever" to "bad" would not change the color to red. It would use the same color as what "whatever" had.

With this PR, all annotations starting with "bad" or "edge" will have their color overwritten to red *before* checking if the annotation name already had an attributed color.