### PR TITLE
BUG: Fix bug with cHPI off

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -41,6 +41,7 @@ Bugs
 - Fix bug with overlapping text for :meth:`mne.Evoked.plot` (:gh:`11698` by `Alex Rockhill`_)
 - For :func:`mne.io.read_raw_eyelink`, the default value of the ``gap_description`` parameter is now ``'BAD_ACQ_SKIP'``, following MNE convention (:gh:`11719` by `Scott Huberty`_)
 - Fix bug with :func:`mne.io.read_raw_fil` where datasets without sensor positions would not import (:gh:`11733` by `George O'Neill`_)
+- Fix bug with :func:`mne.chpi.compute_chpi_snr` where cHPI being off for part of the recording led to an error (:gh:`11754` by `Eric Larson`_)
 - Allow int-like for the argument ``id`` of `~mne.make_fixed_length_events` (:gh:`11748` by `Mathieu Scheltienne`_)
 - blink :class:`mne.Annotations` read in by :func:`mne.io.read_raw_eyelink` now begin with ``'BAD_'``, i.e. ``'BAD_blink'``, because ocular data are missing during blinks. (:gh:`11746` by `Scott Huberty`_)
 

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -1245,6 +1245,8 @@ def _compute_chpi_amp_or_snr(
         #
         amps_or_snrs = _fit_chpi_amplitudes(raw, time_sl, hpi, snr)
         if snr:
+            if amps_or_snrs is None:
+                amps_or_snrs = np.full((n_freqs, grad_offset + 3), np.nan)
             # unpack the SNR estimates. mag & grad are returned in one array
             # (because of Numba) so take care with which column is which.
             # note that mean residual is a scalar (same for all HPI freqs) but


### PR DESCRIPTION
If cHPI was off for part of the recording the estimation would fail. Now it puts in `np.nan` for the values, which should work correctly with plotting etc.