### PR TITLE
Update manual install docs

### DIFF
--- a/doc/install/manual_install.rst
+++ b/doc/install/manual_install.rst
@@ -77,7 +77,7 @@ or via :code:`conda`
 This will create a new ``conda`` environment called ``mne`` (you can adjust
 this by passing a different name via ``--name``).
 
-If you already have MNE-Python with core dependencies (e.g. via `pip install mne`),
+If you already have MNE-Python with core dependencies (e.g. via ``pip install mne``),
 you can install these two packages to unlock HDF5 support:
 
 .. code-block:: console

--- a/doc/install/manual_install.rst
+++ b/doc/install/manual_install.rst
@@ -11,14 +11,14 @@ Install via :code:`pip` or :code:`conda`
    instead.
 
 MNE-Python requires Python version |min_python_version| or higher. If you
-need to install Python, please see our :ref:`install-python` guide.
+need help installing Python, please refer to our :ref:`install-python` guide.
 
 Installing MNE-Python with all dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-We suggest to install MNE-Python into its own ``conda`` environment.
+If you use Anaconda, we suggest installing MNE-Python into its own ``conda`` environment.
 
 The dependency stack is large and may take a long time (several tens of
-minutes) to resolve on some systems via the default ``conda`` solver. We
+minutes) to resolve on some systems via the default ``conda`` command. We
 therefore highly recommend using `mamba <https://mamba.readthedocs.io/>`__
 instead, a ``conda`` replacement that is **much** faster.
 
@@ -60,7 +60,8 @@ functionality later on, you can install individual packages as needed.
 
 Installing MNE-Python with HDF5 support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-If you plan to use MNE-Python's functions that require **HDF5** I/O (this
+If you plan to use MNE-Python's functions that require
+`HDF5 <https://www.hdfgroup.org/solutions/hdf5/>`__ I/O (this
 includes :func:`mne.io.read_raw_eeglab`, :meth:`mne.SourceMorph.save`, and
 others), you should run via :code:`pip`:
 
@@ -68,7 +69,7 @@ others), you should run via :code:`pip`:
 
    $ pip install mne[hdf5]
 
-or via :code:`conda`
+or via :code:`conda`:
 
 .. code-block:: console
 
@@ -77,7 +78,7 @@ or via :code:`conda`
 This will create a new ``conda`` environment called ``mne`` (you can adjust
 this by passing a different name via ``--name``).
 
-If you already have MNE-Python with core dependencies (e.g. via ``pip install mne``),
+If you have already installed MNE-Python with core dependencies (e.g. via ``pip install mne``),
 you can install these two packages to unlock HDF5 support:
 
 .. code-block:: console
@@ -102,7 +103,7 @@ Python development are:
 - `Visual Studio Code`_ (often shortened to "VS Code" or "vscode") is a
   development-focused text editor that supports many programming languages in
   addition to Python, includes an integrated terminal console, and has a rich
-  ecosystem of packages to extend its capabilities. Installing
+  extension ecosystem. Installing
   `Microsoft's Python Extension
   <https://marketplace.visualstudio.com/items?itemName=ms-python.python>`__ is
   enough to get most Python users up and running. VS Code is free and
@@ -145,5 +146,5 @@ Python development are:
   environment.
 
 - `PyCharm`_ is an IDE specifically for Python development that provides an
-  all-in-one installation (no extension packages needed). PyCharm comes in a
-  free and open-source Community edition and a paid "professional" edition.
+  all-in-one solution (no extension packages needed). PyCharm comes in a
+  free and open-source Community edition as well as a paid Professional edition.

--- a/doc/install/manual_install.rst
+++ b/doc/install/manual_install.rst
@@ -11,7 +11,7 @@ Install via :code:`pip` or :code:`conda`
    instead.
 
 MNE-Python requires Python version |min_python_version| or higher. If you
-need to install Python, please see :ref:`install-python`.
+need to install Python, please see our :ref:`install-python` guide.
 
 Installing MNE-Python with all dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -35,12 +35,12 @@ dependencies into it.
 
 If you need to convert structural MRI scans into models
 of the scalp, inner/outer skull, and cortical surfaces, you will also need
-:doc:`FreeSurfer <freesurfer>`.
+to install :doc:`FreeSurfer <freesurfer>`.
 
-Installing a minimal MNE-Python with core functionality only
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-If you only need MNE-Python's core functionality including 2D plotting (but
-**without 3D visualization**), install via :code:`pip`:
+Installing MNE-Python with core dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If you only need MNE-Python's core functionality, which includes 2D plotting
+(but does not support 3D visualization), install via :code:`pip`:
 
 .. code-block:: console
 
@@ -55,9 +55,12 @@ or via :code:`conda`:
 This will create a new ``conda`` environment called ``mne`` (you can adjust
 this by passing a different name via ``--name``).
 
-Installing a minimal MNE-Python with EEGLAB I/O support
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-If you plan to use MNE-Python's functions that require **HDF5 I/O** (this
+This minimal installation requires only a few dependencies. If you need additional
+functionality later on, you can install individual packages as needed.
+
+Installing MNE-Python with HDF5 support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If you plan to use MNE-Python's functions that require **HDF5** I/O (this
 includes :func:`mne.io.read_raw_eeglab`, :meth:`mne.SourceMorph.save`, and
 others), you should run via :code:`pip`:
 
@@ -73,6 +76,13 @@ or via :code:`conda`
 
 This will create a new ``conda`` environment called ``mne`` (you can adjust
 this by passing a different name via ``--name``).
+
+If you already have MNE-Python with core dependencies (e.g. via `pip install mne`),
+you can install these two packages to unlock HDF5 support:
+
+.. code-block:: console
+
+   $ pip install h5io pymatreader
 
 Installing MNE-Python for other scenarios
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -103,11 +113,11 @@ Python development are:
   ``spyder`` (or on Windows or macOS, launched from the Anaconda Navigator GUI).
   It can also be installed with `dedicated installers <https://www.spyder-ide.org/#section-download>`_.
   To avoid dependency conflicts with Spyder, you should install ``mne`` in a
-  separate environment, like explained in the earlier sections. Then, set
+  separate environment, as explained in previous sections. Then, instruct
   Spyder to use the ``mne`` environment as its default interpreter by opening
   Spyder and navigating to
   :samp:`Tools > Preferences > Python Interpreter > Use the following interpreter`.
-  There, paste the output of the following terminal commands
+  There, paste the output of the following terminal commands:
 
   .. code-block:: console
 
@@ -136,5 +146,4 @@ Python development are:
 
 - `PyCharm`_ is an IDE specifically for Python development that provides an
   all-in-one installation (no extension packages needed). PyCharm comes in a
-  free "community" edition and a paid "professional" edition, and is
-  closed-source.
+  free and open-source Community edition and a paid "professional" edition.

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,7 +1,7 @@
 # requirements for building docs
 sphinx!=4.1.0,<6
 git+https://github.com/numpy/numpydoc.git@main
-pydata_sphinx_theme==0.13.3
+git+https://github.com/pydata/pydata-sphinx-theme@main
 git+https://github.com/sphinx-gallery/sphinx-gallery@master
 sphinxcontrib-bibtex>=2.5
 memory_profiler

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,7 +1,7 @@
 # requirements for building docs
 sphinx!=4.1.0,<6
 git+https://github.com/numpy/numpydoc.git@main
-git+https://github.com/pydata/pydata-sphinx-theme@main
+pydata_sphinx_theme==0.13.3
 git+https://github.com/sphinx-gallery/sphinx-gallery@master
 sphinxcontrib-bibtex>=2.5
 memory_profiler


### PR DESCRIPTION
I've tweaked the manual install docs a little (e.g. shortened headings). I've also corrected an error – PyCharm Community is open-source (https://github.com/JetBrains/intellij-community/tree/master/python).