### PR TITLE
[MRG] By-pass set_annotations when plotting ICA sources 

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -44,7 +44,7 @@ Bugs
 - Fix bug with :func:`mne.chpi.compute_chpi_snr` where cHPI being off for part of the recording or bad channels being defined led to an error or incorrect behavior (:gh:`11754`, :gh:`11755` by `Eric Larson`_)
 - Allow int-like for the argument ``id`` of `~mne.make_fixed_length_events` (:gh:`11748` by `Mathieu Scheltienne`_)
 - blink :class:`mne.Annotations` read in by :func:`mne.io.read_raw_eyelink` now begin with ``'BAD_'``, i.e. ``'BAD_blink'``, because ocular data are missing during blinks. (:gh:`11746` by `Scott Huberty`_)
-- Fix display of :class:`~mne.Annotations` in `mne.preprocessing.ICA.plot_sources` when the ``raw`` has ``raw.first_samp != 0`` and doesn't have a measurement date (:gh:`11763` by `Mathieu Scheltienne`_)
+- Fix display of :class:`~mne.Annotations` in `mne.preprocessing.ICA.plot_sources` when the ``raw`` has ``raw.first_samp != 0`` and doesn't have a measurement date (:gh:`11766` by `Mathieu Scheltienne`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -44,6 +44,7 @@ Bugs
 - Fix bug with :func:`mne.chpi.compute_chpi_snr` where cHPI being off for part of the recording or bad channels being defined led to an error or incorrect behavior (:gh:`11754`, :gh:`11755` by `Eric Larson`_)
 - Allow int-like for the argument ``id`` of `~mne.make_fixed_length_events` (:gh:`11748` by `Mathieu Scheltienne`_)
 - blink :class:`mne.Annotations` read in by :func:`mne.io.read_raw_eyelink` now begin with ``'BAD_'``, i.e. ``'BAD_blink'``, because ocular data are missing during blinks. (:gh:`11746` by `Scott Huberty`_)
+- Fix display of :class:`~mne.Annotations` in `mne.preprocessing.ICA.plot_sources` when the ``raw`` has ``raw.first_samp != 0`` and doesn't have a measurement date (:gh:`11763` by `Mathieu Scheltienne`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -1302,7 +1302,7 @@ def _plot_sources(
     info["bads"] = [ch_names[x] for x in exclude if x in picks]
     if is_raw:
         inst_array = RawArray(data, info, inst.first_samp)
-        inst_array.set_annotations(inst.annotations)
+        inst_array._annotations = inst.annotations
     else:
         data = data.reshape(-1, len(inst), len(inst.times)).swapaxes(0, 1)
         inst_array = EpochsArray(data, info)

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -319,7 +319,7 @@ def test_plot_ica_sources(raw_orig, browser_backend, monkeypatch):
     assert browser_backend._get_n_figs() == 0
     del long_raw
 
-    # test with annotations
+    # test with annotations and a measurement date
     orig_annot = raw.annotations
     raw.set_annotations(Annotations([0.2], [0.1], "Test"))
     fig = ica.plot_sources(raw)
@@ -328,6 +328,22 @@ def test_plot_ica_sources(raw_orig, browser_backend, monkeypatch):
         assert len(fig.mne.ax_hscroll.collections) == 1
     else:
         assert len(fig.mne.regions) == 1
+        assert np.allclose(fig.mne.regions[0].getRegion(), (0.2, 0.3))
+
+    # test with annotations and no measurement date
+    orig_meas_date = raw.info["meas_date"]
+    raw.set_meas_date(None)
+    assert raw.first_samp != 0
+    raw.set_annotations(Annotations([0.2], [0.1], "Test"))
+    fig = ica.plot_sources(raw)
+    if browser_backend.name == "matplotlib":
+        assert len(fig.mne.ax_main.collections) == 1
+        assert len(fig.mne.ax_hscroll.collections) == 1
+    else:
+        assert len(fig.mne.regions) == 1
+        assert np.allclose(fig.mne.regions[0].getRegion(), (0.2, 0.3))
+
+    raw.set_meas_date(orig_meas_date)
     raw.set_annotations(orig_annot)
 
     # test error handling

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-from numpy.testing import assert_equal, assert_array_equal
+from numpy.testing import assert_equal, assert_array_equal, assert_allclose
 
 from mne import (
     read_events,
@@ -328,7 +328,7 @@ def test_plot_ica_sources(raw_orig, browser_backend, monkeypatch):
         assert len(fig.mne.ax_hscroll.collections) == 1
     else:
         assert len(fig.mne.regions) == 1
-        assert np.allclose(fig.mne.regions[0].getRegion(), (0.2, 0.3))
+        assert assert_allclose(fig.mne.regions[0].getRegion(), (0.2, 0.3))
 
     # test with annotations and no measurement date
     orig_meas_date = raw.info["meas_date"]
@@ -341,7 +341,7 @@ def test_plot_ica_sources(raw_orig, browser_backend, monkeypatch):
         assert len(fig.mne.ax_hscroll.collections) == 1
     else:
         assert len(fig.mne.regions) == 1
-        assert np.allclose(fig.mne.regions[0].getRegion(), (0.2, 0.3))
+        assert assert_allclose(fig.mne.regions[0].getRegion(), (0.2, 0.3))
 
     raw.set_meas_date(orig_meas_date)
     raw.set_annotations(orig_annot)

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -328,7 +328,7 @@ def test_plot_ica_sources(raw_orig, browser_backend, monkeypatch):
         assert len(fig.mne.ax_hscroll.collections) == 1
     else:
         assert len(fig.mne.regions) == 1
-        assert assert_allclose(fig.mne.regions[0].getRegion(), (0.2, 0.3))
+        assert_allclose(fig.mne.regions[0].getRegion(), (0.2, 0.3))
 
     # test with annotations and no measurement date
     orig_meas_date = raw.info["meas_date"]
@@ -341,7 +341,7 @@ def test_plot_ica_sources(raw_orig, browser_backend, monkeypatch):
         assert len(fig.mne.ax_hscroll.collections) == 1
     else:
         assert len(fig.mne.regions) == 1
-        assert assert_allclose(fig.mne.regions[0].getRegion(), (0.2, 0.3))
+        assert_allclose(fig.mne.regions[0].getRegion(), (0.2, 0.3))
 
     raw.set_meas_date(orig_meas_date)
     raw.set_annotations(orig_annot)


### PR DESCRIPTION
No idea why my other branch is broken; but even on the website I can visualize it only once out of 5 tries.
Same as #11763 but working.

Fixes #11762