### PR TITLE
Fix eeglab.py, an error for read annotations in `RawEEGLab`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -690,6 +690,9 @@ linkcheck_ignore = [  # will be compiled to regex
     "https://doi.org/10.1167/",  # jov.arvojournals.org
     "https://doi.org/10.1177/",  # journals.sagepub.com
     "https://doi.org/10.1063/",  # pubs.aip.org/aip/jap
+    "https://doi.org/10.1080/",  # www.tandfonline.com
+    "https://doi.org/10.1088/",  # www.tandfonline.com
+    "https://doi.org/10.3109/",  # www.tandfonline.com
     "https://www.researchgate.net/profile/",
     # 503 Server error
     "https://hal.archives-ouvertes.fr/hal-01848442",

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -478,7 +478,7 @@ class RawEEGLAB(BaseRaw):
             )
 
         # create event_ch from annotations
-        annot = read_annotations(input_fname, uint16_codec=uint16_codec) # fix: none -> uint16_codec
+        annot = read_annotations(input_fname, uint16_codec=uint16_codec)
         self.set_annotations(annot)
         _check_boundary(annot, None)
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -478,7 +478,7 @@ class RawEEGLAB(BaseRaw):
             )
 
         # create event_ch from annotations
-        annot = read_annotations(input_fname, uint16_codec=uint16_codec)
+        annot = read_annotations(input_fname, uint16_codec=uint16_codec) # fix: none -> uint16_codec
         self.set_annotations(annot)
         _check_boundary(annot, None)
 

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -478,7 +478,7 @@ class RawEEGLAB(BaseRaw):
             )
 
         # create event_ch from annotations
-        annot = read_annotations(input_fname)
+        annot = read_annotations(input_fname, uint16_codec=uint16_codec)
         self.set_annotations(annot)
         _check_boundary(annot, None)
 


### PR DESCRIPTION
In `io.eeglab.RawEEGLab`, read annotations should also pass argument `uint16_codec`.

#### Reference issue

This problem has been reported in the group, click link for details:

https://mne.discourse.group/t/bug-report-an-error-in-io-eeglab-and-solution-to-it/7173


#### What does this implement/fix?

Merely by passing the correct codec argument to function call.


#### Additional information

No
