### PR TITLE
Fix kwarg handling in legacy .plot_psd() method

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -45,6 +45,7 @@ Bugs
 - Fix bug with :func:`mne.io.read_raw_fil` where datasets without sensor positions would not import (:gh:`11733` by `George O'Neill`_)
 - Fix bug with :func:`mne.chpi.compute_chpi_snr` where cHPI being off for part of the recording or bad channels being defined led to an error or incorrect behavior (:gh:`11754`, :gh:`11755` by `Eric Larson`_)
 - Allow int-like for the argument ``id`` of `~mne.make_fixed_length_events` (:gh:`11748` by `Mathieu Scheltienne`_)
+- Fix bug with legacy :meth:`~mne.io.Raw.plot_psd` method where passed axes were not used (:gh:`11778` by `Daniel McCloy`_)
 - blink :class:`mne.Annotations` read in by :func:`mne.io.read_raw_eyelink` now begin with ``'BAD_'``, i.e. ``'BAD_blink'``, because ocular data are missing during blinks. (:gh:`11746` by `Scott Huberty`_)
 
 API changes

--- a/mne/time_frequency/tests/test_spectrum.py
+++ b/mne/time_frequency/tests/test_spectrum.py
@@ -373,3 +373,16 @@ def test_spectrum_complex(method, average):
         coef = coef.mean(-1)  # over segments
     coef = coef.item()
     assert_allclose(np.angle(coef), phase, rtol=1e-4)
+
+
+def test_spectrum_kwarg_triaging(raw):
+    """Test kwarg triaging in legacy plot_psd() method."""
+    import matplotlib.pyplot as plt
+
+    regex = r"legacy plot_psd\(\) method.*unexpected keyword.*'axes'.*Try rewriting"
+    fig, axes = plt.subplots(1, 2)
+    # `axes` is the new param name: technically only valid for Spectrum.plot()
+    with pytest.warns(RuntimeWarning, match=regex):
+        raw.plot_psd(axes=axes)
+    # `ax` is the correct legacy param name
+    raw.plot_psd(ax=axes)

--- a/mne/utils/spectrum.py
+++ b/mne/utils/spectrum.py
@@ -15,13 +15,15 @@ def _update_old_psd_kwargs(kwargs):
     """
     from ..viz import plot_raw_psd as fallback_fun
 
-    kwargs["axes"] = _pop_with_fallback(kwargs, "ax", fallback_fun)
-    kwargs["alpha"] = _pop_with_fallback(kwargs, "line_alpha", fallback_fun)
-    kwargs["ci_alpha"] = _pop_with_fallback(kwargs, "area_alpha", fallback_fun)
+    kwargs.setdefault("axes", _pop_with_fallback(kwargs, "ax", fallback_fun))
+    kwargs.setdefault("alpha", _pop_with_fallback(kwargs, "line_alpha", fallback_fun))
+    kwargs.setdefault(
+        "ci_alpha", _pop_with_fallback(kwargs, "area_alpha", fallback_fun)
+    )
     est = _pop_with_fallback(kwargs, "estimate", fallback_fun)
-    kwargs["amplitude"] = "auto" if est == "auto" else (est == "amplitude")
+    kwargs.setdefault("amplitude", "auto" if est == "auto" else (est == "amplitude"))
     area_mode = _pop_with_fallback(kwargs, "area_mode", fallback_fun)
-    kwargs["ci"] = "sd" if area_mode == "std" else area_mode
+    kwargs.setdefault("ci", "sd" if area_mode == "std" else area_mode)
 
 
 def _split_psd_kwargs(*, plot_fun=None, kwargs=None):

--- a/mne/utils/spectrum.py
+++ b/mne/utils/spectrum.py
@@ -1,4 +1,5 @@
 from inspect import currentframe, getargvalues, signature
+from ..utils import warn
 
 
 def _pop_with_fallback(mapping, key, fallback_fun):
@@ -15,6 +16,14 @@ def _update_old_psd_kwargs(kwargs):
     """
     from ..viz import plot_raw_psd as fallback_fun
 
+    may_change = ("axes", "alpha", "ci_alpha", "amplitude", "ci")
+    for kwarg in may_change:
+        if kwarg in kwargs:
+            warn(
+                "The legacy plot_psd() method got an unexpected keyword argument "
+                f"'{kwarg}', which is a parameter of Spectrum.plot(). Try rewriting as "
+                f"object.compute_psd(...).plot(..., {kwarg}=<whatever>)."
+            )
     kwargs.setdefault("axes", _pop_with_fallback(kwargs, "ax", fallback_fun))
     kwargs.setdefault("alpha", _pop_with_fallback(kwargs, "line_alpha", fallback_fun))
     kwargs.setdefault(


### PR DESCRIPTION
closes #11772 

new behavior is

- any kwargs passed to legacy `raw.plot_psd()` that are not recognized params of that method but happen to be params of Spectrum.plot() now raise a warning. 
- those kwargs will be respected though, instead of overwritten with the fallback values drawn from the defaults of `plot_raw_psd()`.

@larsoner @mscheltienne LMK if you think this is a good approach... normally unrecognized kwargs will raise a TypeError (and we could do that here) but my feeling was that since this is a legacy method whose kwargs are getting split up and translated to be passed into a chain of two new methods, it might be nice/smart/OK to be more forgiving.

Once we agree on an implementation I can add test/changelog