### PR TITLE
DOC: Fix incorrect docs for annotate_movement [ci skip]

### DIFF
--- a/mne/preprocessing/artifact_detection.py
+++ b/mne/preprocessing/artifact_detection.py
@@ -166,9 +166,9 @@ def annotate_movement(
         The position and quaternion parameters from cHPI fitting. Obtained
         with `mne.chpi` functions.
     rotation_velocity_limit : float
-        Head rotation velocity limit in radians per second.
+        Head rotation velocity limit in degrees per second.
     translation_velocity_limit : float
-        Head translation velocity limit in radians per second.
+        Head translation velocity limit in meters per second.
     mean_distance_limit : float
         Head position limit from mean recording in meters.
     use_dev_head_trans : 'average' (default) | 'info'


### PR DESCRIPTION
Units were incorrectly documented for both of these. Could change the code to reflect the SI unit for rad/sec for rotation velocity limit, but given that degrees/s was the existing *behavior* this seems like a less invasive change (and also the units are wrong in docs for translation and must be changed anyway).

Pushed with `[ci skip]` because we don't need CIs for this I think :)