### PR TITLE
Keeping event names when combining channel on epochs objects

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -2300,6 +2300,7 @@ def combine_channels(
             new_data,
             info,
             events=inst.events,
+            event_id=inst.event_id,
             tmin=inst.times[0],
             baseline=inst.baseline,
         )


### PR DESCRIPTION
#### Reference issue
Fixes #11784


#### What does this implement/fix?
When combining channels on `mne.Epochs` object, the resulting instance will keep the event names of the input instance.

