### PR TITLE
MAINT: Test NumPy versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,24 +45,24 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
-          python: '3.10'
-          kind: conda
-        - os: ubuntu-latest
-          python: '3.10'
-          kind: notebook
+        #- os: ubuntu-latest
+        #  python: '3.10'
+        #  kind: conda
+        #- os: ubuntu-latest
+        #  python: '3.10'
+        #  kind: notebook
         - os: ubuntu-latest
           python: '3.11'
           kind: pip-pre
-        - os: macos-latest
-          python: '3.8'
-          kind: mamba
-        - os: ubuntu-latest
-          python: '3.8'
-          kind: minimal
-        - os: ubuntu-20.04
-          python: '3.8'
-          kind: old
+        #- os: macos-latest
+        #  python: '3.8'
+        #  kind: mamba
+        #- os: ubuntu-latest
+        #  python: '3.8'
+        #  kind: minimal
+        #- os: ubuntu-20.04
+        #  python: '3.8'
+        #  kind: old
     steps:
       - uses: actions/checkout@v3
         with:

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -17,7 +17,7 @@ else
 	echo "PyQt6"
 	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6
 	echo "NumPy/SciPy/pandas etc."
-	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" numpy scipy scikit-learn pandas matplotlib pillow statsmodels
+	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy<1.99" scipy scikit-learn pandas matplotlib pillow statsmodels
 	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" dipy
 	pip install $STD_ARGS --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
 	pip install $STD_ARGS --pre --only-binary ":all:" --extra-index-url "https://test.pypi.org/simple" openmeeg

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -17,7 +17,7 @@ else
 	echo "PyQt6"
 	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6
 	echo "NumPy/SciPy/pandas etc."
-	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy<1.99" scipy scikit-learn pandas matplotlib pillow statsmodels
+	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy==1.25.0rc1+218.g0e5a362fd" scipy scikit-learn pandas matplotlib pillow statsmodels
 	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" dipy
 	pip install $STD_ARGS --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
 	pip install $STD_ARGS --pre --only-binary ":all:" --extra-index-url "https://test.pypi.org/simple" openmeeg
@@ -41,7 +41,7 @@ fi
 if [ ! -z "$CONDA_DEPENDENCIES" ]; then
 	pip install -r requirements_base.txt -r requirements_testing.txt
 else
-	pip install $STD_ARGS $EXTRA_ARGS -r requirements_base.txt -r requirements_testing.txt -r requirements_hdf5.txt
+	pip install $STD_ARGS $EXTRA_ARGS -r requirements_base.txt -r requirements_testing.txt -r requirements_hdf5.txt "numpy==1.25.0rc1+218.g0e5a362fd"
 fi
 
 if [ "${DEPS}" != "minimal" ]; then

--- a/tools/github_actions_test.sh
+++ b/tools/github_actions_test.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 if [[ "${CI_OS_NAME}" != "macos"* ]]; then
   if [[ "${MNE_CI_KIND}" == "pip-pre" ]]; then
-    CONDITION="not (slowtest or pgtest)"
+    CONDITION="not (ultraslowtest or pgtest)"
   else
     CONDITION="not (ultraslowtest or pgtest)"
   fi


### PR DESCRIPTION
Plan:

1. Show the problem with a timeout by reverting to `not ultraslowtest` rather than `not slowtest`:

   - **Timed out @ 75%** complete in [1h 5m 43s](https://github.com/mne-tools/mne-python/actions/runs/5524442692/jobs/10076785760?pr=11793) on https://github.com/mne-tools/mne-python/pull/11793/commits/43256dd4e29041dff771b59f292e58c665a1e6f9 / `2.0.0.dev0+466.gc143f7b93 (OpenBLAS 0.3.23 with 1 thread)`
   - `np.show_config` (in the [`_infos.sh` step](https://github.com/mne-tools/mne-python/actions/runs/5524442692/jobs/10076785760?pr=11793#step:11:102)) has no `Supported SIMD extensions` section.
2. Try the `1.25.1` wheel from PyPI:

   - **Completed** in [1h 1m 30s](https://github.com/mne-tools/mne-python/actions/runs/5525045408/jobs/10078189893?pr=11793) on https://github.com/mne-tools/mne-python/pull/11793/commits/ac997269134bee8a00edb59e50bbf6541a42d3a0 / `1.25.1 (OpenBLAS 0.3.23 with 1 thread)`
   - 77% complete in ~43m (manual inspection)
   - `np.show_config` in the [`_infos.sh` step](https://github.com/mne-tools/mne-python/actions/runs/5525045408/jobs/10078189893?pr=11793#step:11:115) says:

     ```
     Supported SIMD extensions in this NumPy install:
         baseline = SSE,SSE2,SSE3
         found = SSSE3,SSE41,POPCNT,SSE42,AVX,F16C,FMA3,AVX2
         not found = AVX512F,AVX512CD,AVX512_KNL,AVX512_KNM,AVX512_SKX,AVX512_CLX,AVX512_CNL,AVX512_ICL
     ```
3. Try the `1.25.0rc1` wheel from scientific-python-nightly-wheels

   - **Completed** in [52m 40s](https://github.com/mne-tools/mne-python/actions/runs/5525644381/jobs/10079507123?pr=11793) on https://github.com/mne-tools/mne-python/pull/11793/commits/3e2a5fc7b6a7eb61e3a11d1b5750f07264884eba / `1.25.0rc1+218.g0e5a362fd (OpenBLAS 0.3.23 with 1 thread)`
   - 76% complete in ~36m (manual inspection)
   - `np.show_config` (in the [`_infos.sh` step](https://github.com/mne-tools/mne-python/actions/runs/5525644381/jobs/10079507123?pr=11793#step:11:114)) says:

     ```
     Supported SIMD extensions in this NumPy install:
         baseline = SSE,SSE2,SSE3
         found = SSSE3,SSE41,POPCNT,SSE42,AVX,F16C,FMA3,AVX2
         not found = AVX512F,AVX512CD,AVX512_KNL,AVX512_KNM,AVX512_SKX,AVX512_CLX,AVX512_CNL,AVX512_ICL
     ```


(2) and (3) being faster than (1) will help isolate the time frame of changes and ensure it's not an issue with all SPNW wheels. Looks like the `1.25` RC wheel [up here](https://anaconda.org/scientific-python-nightly-wheels/numpy/files) was ~23 days ago, so not an awesome `bisect` but at least a start.