### PR TITLE
Add `mne.count_annotations()`

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -31,6 +31,7 @@ Enhancements
 - Ocular :class:`mne.Annotations` read in by :func:`mne.io.read_raw_eyelink` are now channel aware. This means if the left eye blinked, the associated annotation will store this in the ``'ch_names'`` key. (:gh:`11746` by `Scott Huberty`_)
 - Added :func:`mne.preprocessing.eyetracking.interpolate_blinks` to linear interpolate eyetrack signals during blink periods. (:gh:`11740` by `Scott Huberty`_)
 - Added a section for combining eye-tracking and EEG data to the preprocessing tutorial "working with eye tracker data in MNE-Python" (:gh:`11770` by `Scott Huberty`_)
+- Add :meth:`mne.Annotations.count` and :func:`mne.count_annotations` to count unique annotations (:gh:`11796` by `Clemens Brunner`_)
 
 Bugs
 ~~~~

--- a/doc/events.rst
+++ b/doc/events.rst
@@ -24,6 +24,7 @@ Events
    concatenate_epochs
    events_from_annotations
    annotations_from_events
+   count_annotations
 
 :py:mod:`mne.event`:
 

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -167,6 +167,7 @@ from .annotations import (
     read_annotations,
     annotations_from_events,
     events_from_annotations,
+    count_annotations,
 )
 from .epochs import (
     BaseEpochs,

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -465,6 +465,17 @@ class Annotations:
         df = pd.DataFrame(df)
         return df
 
+    def count(self):
+        """Count annotations.
+
+        Returns
+        -------
+        counts : dict
+            A dictionary containing unique annotation descriptions as keys with their
+            counts as values.
+    """
+        return count_annotations(self)
+
     def _any_ch_names(self):
         return any(len(ch) for ch in self.ch_names)
 
@@ -1694,3 +1705,27 @@ def _adjust_onset_meas_date(annot, raw):
     # account the first_samp / first_time.
     if raw.info["meas_date"] is not None:
         annot.onset += raw.first_time
+
+
+def count_annotations(annotations):
+    """Count annotations.
+
+    Parameters
+    ----------
+    annotations : mne.Annotations
+        The annotations instance.
+
+    Returns
+    -------
+    counts : dict
+        A dictionary containing unique annotation descriptions as keys with their
+        counts as values.
+
+    Examples
+    --------
+        >>> annotations = mne.Annotations([0, 1, 2], [1, 2, 1], ["T0", "T1", "T0"])
+        >>> count_annotations(annotations)
+        {'T0': 2, 'T1': 1}
+    """
+    types, counts = np.unique(annotations.description, return_counts=True)
+    return {t: count for t, count in zip(types, counts)}

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -473,7 +473,7 @@ class Annotations:
         counts : dict
             A dictionary containing unique annotation descriptions as keys with their
             counts as values.
-    """
+        """
         return count_annotations(self)
 
     def _any_ch_names(self):

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -26,7 +26,7 @@ from mne import (
     read_annotations,
     annotations_from_events,
     events_from_annotations,
-    count_annotations
+    count_annotations,
 )
 from mne import Epochs, Annotations
 from mne.utils import (
@@ -1753,4 +1753,3 @@ def test_count_annotations():
     annotations = Annotations([0, 1, 2], [1, 2, 1], ["T0", "T1", "T0"])
     assert annotations.count() == {"T0": 2, "T1": 1}
     assert count_annotations(annotations) == {"T0": 2, "T1": 1}
-    

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -26,6 +26,7 @@ from mne import (
     read_annotations,
     annotations_from_events,
     events_from_annotations,
+    count_annotations
 )
 from mne import Epochs, Annotations
 from mne.utils import (
@@ -1746,3 +1747,10 @@ def test_annot_meas_date_first_samp_crop(meas_date, first_samp):
         assert len(this_raw.annotations) == 1
         assert_allclose(this_raw.annotations.onset, want_onset)
         assert_allclose(this_raw.annotations.duration, annot.duration[2:])
+
+
+def test_count_annotations():
+    annotations = Annotations([0, 1, 2], [1, 2, 1], ["T0", "T1", "T0"])
+    assert annotations.count() == {"T0": 2, "T1": 1}
+    assert count_annotations(annotations) == {"T0": 2, "T1": 1}
+    

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1750,6 +1750,7 @@ def test_annot_meas_date_first_samp_crop(meas_date, first_samp):
 
 
 def test_count_annotations():
+    """Test counting unique annotations."""
     annotations = Annotations([0, 1, 2], [1, 2, 1], ["T0", "T1", "T0"])
     assert annotations.count() == {"T0": 2, "T1": 1}
     assert count_annotations(annotations) == {"T0": 2, "T1": 1}


### PR DESCRIPTION
Similar to `mne.count_events()`, I think a function to count unique annotations would be quite useful. This PR adds a function `mne.count_annotations()` as well as a method `mne.Annotations.count()`.