### PR TITLE
Fix small bug that raised error under some conditions

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -41,6 +41,7 @@ Bugs
 - Fix bug where user-provided codec was not used to read annotations when loading EEGLAB ``.set`` files (:gh:`11773` by :newcontrib:`Yiping Zuo`)
 - Fix bug that required curv.*h files to create Brain object (:gh:`11704` by :newcontrib:`Aaron Earle-Richardson`)
 - Extended test to highlight bug in :func:`mne.stats.permutation_t_test` (:gh:`11575` by :newcontrib:`Joshua Calder-Travis`)
+- Fix bug that used wrong indices for line/label styles (sometimes causing an ``IndexError``) in :meth:`mne.preprocessing.ICA.plot_sources` under certain conditions (:gh:`11808` by :newcontrib:`Joshua Calder-Travis`)
 - Fix bug where :meth:`mne.viz.Brain.add_volume_labels` used an incorrect orientation (:gh:`11730` by `Alex Rockhill`_)
 - Fix bug with :func:`mne.forward.restrict_forward_to_label` where cortical patch information was not adjusted (:gh:`11694` by `Eric Larson`_)
 - Fix bug with PySide6 compatibility (:gh:`11721` by `Eric Larson`_)
@@ -55,7 +56,6 @@ Bugs
 - Fix bug where :ref:`mne show_fiff` could fail with an ambiguous error if the file is corrupt (:gh:`11800` by `Eric Larson`_)
 - Fix bug where annotation FIF files lacked an end block tag (:gh:`11800` by `Eric Larson`_)
 - Fix display of :class:`~mne.Annotations` in `mne.preprocessing.ICA.plot_sources` when the ``raw`` has ``raw.first_samp != 0`` and doesn't have a measurement date (:gh:`11766` by `Mathieu Scheltienne`_)
-- Fix bug that used wrong indices for line/label styles (sometimes causing an ``IndexError``) in :meth:`mne.preprocessing.ICA.plot_sources` under certain conditions (:gh:`11808` by `Joshua Calder-Travis`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -54,6 +54,7 @@ Bugs
 - Fix bug where :ref:`mne show_fiff` could fail with an ambiguous error if the file is corrupt (:gh:`11800` by `Eric Larson`_)
 - Fix bug where annotation FIF files lacked an end block tag (:gh:`11800` by `Eric Larson`_)
 - Fix display of :class:`~mne.Annotations` in `mne.preprocessing.ICA.plot_sources` when the ``raw`` has ``raw.first_samp != 0`` and doesn't have a measurement date (:gh:`11766` by `Mathieu Scheltienne`_)
+- Fix bug that raised error when using `mne.preprocessing.ICA.plot_sources` under certain conditions (:gh:`11808` by `Joshua Calder-Travis`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -54,7 +54,7 @@ Bugs
 - Fix bug where :ref:`mne show_fiff` could fail with an ambiguous error if the file is corrupt (:gh:`11800` by `Eric Larson`_)
 - Fix bug where annotation FIF files lacked an end block tag (:gh:`11800` by `Eric Larson`_)
 - Fix display of :class:`~mne.Annotations` in `mne.preprocessing.ICA.plot_sources` when the ``raw`` has ``raw.first_samp != 0`` and doesn't have a measurement date (:gh:`11766` by `Mathieu Scheltienne`_)
-- Fix bug that raised error when using `mne.preprocessing.ICA.plot_sources` under certain conditions (:gh:`11808` by `Joshua Calder-Travis`_)
+- Fix bug that used wrong indices for line/label styles (sometimes causing an ``IndexError``) in :meth:`mne.preprocessing.ICA.plot_sources` under certain conditions (:gh:`11808` by `Joshua Calder-Travis`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -824,14 +824,14 @@ def _plot_ica_sources_evoked(evoked, picks, exclude, title, show, ica, labels=No
                 style = cat_styles[label_name]
                 label_props[label_idx] = (color, style)
 
-    for exc_label, ii in zip(exclude_labels, picks):
-        color, style = label_props[ii]
+    for pick_idx, (exc_label, i_pick) in enumerate(zip(exclude_labels, picks)):
+        color, style = label_props[pick_idx]
         # ensure traces of excluded components are plotted on top
         zorder = 2 if exc_label is None else 10
         lines.extend(
             ax.plot(
                 times,
-                evoked.data[ii].T,
+                evoked.data[i_pick].T,
                 picker=True,
                 zorder=zorder,
                 color=color,

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -824,14 +824,14 @@ def _plot_ica_sources_evoked(evoked, picks, exclude, title, show, ica, labels=No
                 style = cat_styles[label_name]
                 label_props[label_idx] = (color, style)
 
-    for pick_idx, (exc_label, i_pick) in enumerate(zip(exclude_labels, picks)):
+    for pick_idx, (exc_label, pick) in enumerate(zip(exclude_labels, picks)):
         color, style = label_props[pick_idx]
         # ensure traces of excluded components are plotted on top
         zorder = 2 if exc_label is None else 10
         lines.extend(
             ax.plot(
                 times,
-                evoked.data[i_pick].T,
+                evoked.data[pick].T,
                 picker=True,
                 zorder=zorder,
                 color=color,

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -408,6 +408,13 @@ def test_plot_ica_overlay():
     pytest.raises(TypeError, ica.plot_overlay, raw[:2, :3][0])
     pytest.raises(TypeError, ica.plot_overlay, raw, exclude=2)
     ica.plot_overlay(raw)
+
+    # Check that the issue addressed by the following pull request is fixed:
+    # https://github.com/mne-tools/mne-python/pull/11808
+    # Issue meant that an error would be raised by plot_sources, unless picks
+    # were consecutive, starting at 0.
+    ica.plot_sources(eog_epochs.average(), picks=1)
+
     plt.close("all")
 
     # smoke test for CTF

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -373,6 +373,10 @@ def test_plot_ica_sources(raw_orig, browser_backend, monkeypatch):
     ica.exclude = [0]
     ica.plot_sources(evoked)
 
+    # regression test for `IndexError` when passing non-consecutive picks or consecutive
+    # picks not including `0` (https://github.com/mne-tools/mne-python/pull/11808)
+    ica.plot_sources(evoked, picks=1)
+
     # pretend find_bads_eog() yielded some results
     ica.labels_ = {"eog": [0], "eog/0/crazy-channel": [0]}
     ica.plot_sources(evoked)  # now with labels
@@ -408,11 +412,6 @@ def test_plot_ica_overlay():
     pytest.raises(TypeError, ica.plot_overlay, raw[:2, :3][0])
     pytest.raises(TypeError, ica.plot_overlay, raw, exclude=2)
     ica.plot_overlay(raw)
-
-    # regression test for `IndexError` when passing non-consecutive picks or consecutive
-    # picks not including `0` (https://github.com/mne-tools/mne-python/pull/11808)
-    ica.plot_sources(eog_epochs.average(), picks=1)
-
     plt.close("all")
 
     # smoke test for CTF

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -409,10 +409,8 @@ def test_plot_ica_overlay():
     pytest.raises(TypeError, ica.plot_overlay, raw, exclude=2)
     ica.plot_overlay(raw)
 
-    # Check that the issue addressed by the following pull request is fixed:
-    # https://github.com/mne-tools/mne-python/pull/11808
-    # Issue meant that an error would be raised by plot_sources, unless picks
-    # were consecutive, starting at 0.
+    # regression test for `IndexError` when passing non-consecutive picks or consecutive
+    # picks not including `0` (https://github.com/mne-tools/mne-python/pull/11808)
     ica.plot_sources(eog_epochs.average(), picks=1)
 
     plt.close("all")


### PR DESCRIPTION
Fixes #11800.

#### What does this implement/fix?
ICA.plot_sources raised an indexing error under specific conditions described in #11800. This error is no longer raised.

The problem was that ICA component numbers, as stored in the variable ``picks``, were being used to index into a variable ``label_props`` that describes the style in which lines should be plotted. ``label_props`` is as long as ``picks``, not as long as the total number of ica components. Hence, the index of the component in ``picks``, not the ICA component number itself, should be used.