### PR TITLE
fix tutorial whitespace

### DIFF
--- a/tutorials/preprocessing/45_projectors_background.py
+++ b/tutorials/preprocessing/45_projectors_background.py
@@ -85,7 +85,7 @@ ax.quiver3D(
 #     ``plot(*point)`` expands to ``plot(3, 2, 5)``.
 #
 # Notice that we used matrix multiplication to compute the projection of our
-# point :math:`(3, 2, 5)`onto the :math:`x, y` plane:
+# point :math:`(3, 2, 5)` onto the :math:`x, y` plane:
 #
 # .. math::
 #


### PR DESCRIPTION
tiny change (missing space) that caused bad rendering in the projectors background tutorial:

![Screenshot 2023-07-19 at 10-21-37 Background on projectors and projections — MNE 1 5 0 dev63 g1704513f4 documentation](https://github.com/mne-tools/mne-python/assets/1810515/0295eb19-6553-4949-818f-998bf9c101e6)
