### PR TITLE
shrink versionadded notes in docstrings

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -104,22 +104,20 @@ html[data-theme="dark"] img {
 }
 
 /* make versionadded smaller and inline with param name */
-div.deprecated > p, div.versionadded > p, div.versionchanged > p {
+/* don't do for deprecated / versionchanged; they have extra info (too long to fit) */
+div.versionadded > p {
     margin-top: 0;
     margin-bottom: 0;
 }
-div.versionadded,
-div.versionchanged,
-div.deprecated {
-    position: absolute;
-    right: 0%;
-    bottom: 100%;
-    margin-bottom: 0;
+div.versionadded {
+    margin: 0;
+    margin-left: 0.5rem;
+    display: inline-block;
 }
-dd {
-    position: relative;
+/* when FF supports :has(), change to →  dd > p:has(+div.versionadded) */
+dd>p {
+    display: inline;
 }
-
 
 /* **************************************************** sphinx-gallery fixes */
 

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -103,6 +103,24 @@ html[data-theme="dark"] img {
     color: var(--pst-color-link);
 }
 
+/* make versionadded smaller and inline with param name */
+div.deprecated > p, div.versionadded > p, div.versionchanged > p {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+div.versionadded,
+div.versionchanged,
+div.deprecated {
+    position: absolute;
+    right: 0%;
+    bottom: 100%;
+    margin-bottom: 0;
+}
+dd {
+    position: relative;
+}
+
+
 /* **************************************************** sphinx-gallery fixes */
 
 /* backreference links: restore hover decoration that SG removes */

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,7 +21,6 @@ from sphinx_gallery.sorting import FileNameSortKey, ExplicitOrder
 from numpydoc import docscrape
 
 import mne
-from mne.fixes import _compare_version
 from mne.tests.test_docstring_parameters import error_ignores
 from mne.utils import (
     linkcode_resolve,  # noqa, analysis:ignore

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,7 @@ import warnings
 import numpy as np
 import matplotlib
 import sphinx
+from sphinx.domains.changeset import versionlabels
 from sphinx_gallery.sorting import FileNameSortKey, ExplicitOrder
 from numpydoc import docscrape
 
@@ -751,6 +752,10 @@ nitpick_ignore_regex = [
 ]
 suppress_warnings = ["image.nonlocal_uri"]  # we intentionally link outside
 
+
+# -- Sphinx hacks / overrides ------------------------------------------------
+
+versionlabels["versionadded"] = sphinx.locale._("New in v%s")
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -382,6 +382,12 @@ class Covariance(dict):
         %(sphere_topomap_auto)s
         %(image_interp_topomap)s
         %(extrapolate_topomap)s
+
+            .. versionchanged:: 0.21
+
+               - The default was changed to ``'local'`` for MEG sensors.
+               - ``'local'`` was changed to use a convex hull mask
+               - ``'head'`` was changed to extrapolate out to the clipping circle.
         %(border_topomap)s
 
             .. versionadded:: 0.20

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -383,6 +383,8 @@ class Covariance(dict):
         %(image_interp_topomap)s
         %(extrapolate_topomap)s
         %(border_topomap)s
+
+            .. versionadded:: 0.20
         %(res_topomap)s
         %(size_topomap)s
         %(cmap_topomap)s

--- a/mne/io/eyelink/eyelink.py
+++ b/mne/io/eyelink/eyelink.py
@@ -97,11 +97,15 @@ def read_raw_eyelink(
         times of the left and right eyes are separated by less than 50 ms, then the
         blink will be merged into a single :class:`mne.Annotations`.
     gap_description : str (default 'BAD_ACQ_SKIP')
-        This parameter is deprecated and will be removed in 1.6.
-        Use :meth:`mne.Annotations.rename` instead.
-        the annotation that will span across the gap period between the
+        Label for annotations that span across the gap period between the
         blocks. Uses ``'BAD_ACQ_SKIP'`` by default so that these time periods will
         be considered bad by MNE and excluded from operations like epoching.
+
+        .. deprecated:: 1.5
+
+           This parameter is deprecated and will be removed in version 1.6. Use
+           :meth:`mne.Annotations.rename` if you want something other than
+           ``BAD_ACQ_SKIP`` as the annotation label.
 
     Returns
     -------

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -429,6 +429,12 @@ class ProjMixin:
         %(extrapolate_topomap)s
 
             .. versionadded:: 0.20
+
+            .. versionchanged:: 0.21
+
+               - The default was changed to ``'local'`` for MEG sensors.
+               - ``'local'`` was changed to use a convex hull mask
+               - ``'head'`` was changed to extrapolate out to the clipping circle.
         %(border_topomap)s
 
             .. versionadded:: 0.20

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -143,6 +143,8 @@ class Projection(dict):
 
             .. versionadded:: 1.2
         %(border_topomap)s
+
+            .. versionadded:: 0.20
         %(res_topomap)s
         %(size_topomap)s
         %(cmap_topomap)s
@@ -428,6 +430,8 @@ class ProjMixin:
 
             .. versionadded:: 0.20
         %(border_topomap)s
+
+            .. versionadded:: 0.20
         %(res_topomap)s
         %(size_topomap)s
             Only applies when plotting multiple topomaps at a time.

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -2530,13 +2530,23 @@ class AverageTFR(_BaseTFR):
               ('zlogratio')
         %(sensors_topomap)s
         %(show_names_topomap)s
+
+            .. versionadded:: 1.2
         %(mask_evoked_topomap)s
+
+            .. versionadded:: 1.2
         %(mask_params_topomap)s
+
+            .. versionadded:: 1.2
         %(contours_topomap)s
         %(outlines_topomap)s
         %(sphere_topomap_auto)s
         %(image_interp_topomap)s
+
+            .. versionadded:: 1.2
         %(extrapolate_topomap)s
+
+            .. versionadded:: 1.2
         %(border_topomap)s
 
             .. versionadded:: 0.20

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -2538,6 +2538,8 @@ class AverageTFR(_BaseTFR):
         %(image_interp_topomap)s
         %(extrapolate_topomap)s
         %(border_topomap)s
+
+            .. versionadded:: 0.20
         %(res_topomap)s
         %(size_topomap)s
         %(cmap_topomap)s

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -492,8 +492,6 @@ docdict[
 border : float | 'mean'
     Value to extrapolate to on the topomap borders. If ``'mean'`` (default),
     then each extrapolated point has the average value of its neighbours.
-
-    .. versionadded:: 0.20
 """
 
 docdict[

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1471,12 +1471,6 @@ extrapolate : str
         the head circle when the sensors are contained within the head circle,
         but it can extend beyond the head when sensors are plotted outside
         the head circle.
-
-    .. versionchanged:: 0.21
-
-       - The default was changed to ``'local'`` for MEG sensors.
-       - ``'local'`` was changed to use a convex hull mask
-       - ``'head'`` was changed to extrapolate out to the clipping circle.
 """
 
 # %%

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -767,7 +767,7 @@ def plot_epochs(
     n_epochs=20,
     n_channels=20,
     title=None,
-    events=None,
+    events=False,
     event_color=None,
     order=None,
     show=True,
@@ -816,6 +816,11 @@ def plot_epochs(
             align with the data.
 
         .. versionadded:: 0.14.0
+
+        .. versionchanged:: 1.5
+            Passing ``events=None`` is deprecated and will be removed in version 1.6.
+            The new equivalent is ``events=False``.
+
     %(event_color)s
         Defaults to ``None``.
     order : array of str | None

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -820,7 +820,6 @@ def plot_epochs(
         .. versionchanged:: 1.5
             Passing ``events=None`` is deprecated and will be removed in version 1.6.
             The new equivalent is ``events=False``.
-
     %(event_color)s
         Defaults to ``None``.
     order : array of str | None

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -376,6 +376,12 @@ def plot_projs_topomap(
     %(extrapolate_topomap)s
 
         .. versionadded:: 0.20
+
+        .. versionchanged:: 0.21
+
+           - The default was changed to ``'local'`` for MEG sensors.
+           - ``'local'`` was changed to use a convex hull mask
+           - ``'head'`` was changed to extrapolate out to the clipping circle.
     %(border_topomap)s
 
         .. versionadded:: 0.20
@@ -938,6 +944,12 @@ def plot_topomap(
     %(extrapolate_topomap)s
 
         .. versionadded:: 0.18
+
+        .. versionchanged:: 0.21
+
+           - The default was changed to ``'local'`` for MEG sensors.
+           - ``'local'`` was changed to use a convex hull mask
+           - ``'head'`` was changed to extrapolate out to the clipping circle.
     %(border_topomap)s
 
         .. versionadded:: 0.20
@@ -1796,6 +1808,12 @@ def plot_tfr_topomap(
     %(sphere_topomap_auto)s
     %(image_interp_topomap)s
     %(extrapolate_topomap)s
+
+        .. versionchanged:: 0.21
+
+           - The default was changed to ``'local'`` for MEG sensors.
+           - ``'local'`` was changed to use a convex hull mask
+           - ``'head'`` was changed to extrapolate out to the clipping circle.
     %(border_topomap)s
 
         .. versionadded:: 0.20
@@ -1990,6 +2008,12 @@ def plot_evoked_topomap(
     %(extrapolate_topomap)s
 
         .. versionadded:: 0.18
+
+        .. versionchanged:: 0.21
+
+           - The default was changed to ``'local'`` for MEG sensors.
+           - ``'local'`` was changed to use a convex hull mask
+           - ``'head'`` was changed to extrapolate out to the clipping circle.
     %(border_topomap)s
 
         .. versionadded:: 0.20
@@ -2525,6 +2549,12 @@ def plot_epochs_psd_topomap(
     %(sphere_topomap_auto)s
     %(image_interp_topomap)s
     %(extrapolate_topomap)s
+
+        .. versionchanged:: 0.21
+
+           - The default was changed to ``'local'`` for MEG sensors.
+           - ``'local'`` was changed to use a convex hull mask
+           - ``'head'`` was changed to extrapolate out to the clipping circle.
     %(border_topomap)s
 
         .. versionadded:: 0.20
@@ -2620,6 +2650,12 @@ def plot_psds_topomap(
     %(sphere_topomap_auto)s
     %(image_interp_topomap)s
     %(extrapolate_topomap)s
+
+        .. versionchanged:: 0.21
+
+           - The default was changed to ``'local'`` for MEG sensors.
+           - ``'local'`` was changed to use a convex hull mask
+           - ``'head'`` was changed to extrapolate out to the clipping circle.
     %(border_topomap)s
 
         .. versionadded:: 0.20
@@ -3433,6 +3469,12 @@ def plot_arrowmap(
     %(extrapolate_topomap)s
 
         .. versionadded:: 0.18
+
+        .. versionchanged:: 0.21
+
+           - The default was changed to ``'local'`` for MEG sensors.
+           - ``'local'`` was changed to use a convex hull mask
+           - ``'head'`` was changed to extrapolate out to the clipping circle.
     %(sphere_topomap_auto)s
 
     Returns
@@ -3876,6 +3918,12 @@ def plot_regression_weights(
     %(sphere_topomap_auto)s
     %(image_interp_topomap)s
     %(extrapolate_topomap)s
+
+        .. versionchanged:: 0.21
+
+           - The default was changed to ``'local'`` for MEG sensors.
+           - ``'local'`` was changed to use a convex hull mask
+           - ``'head'`` was changed to extrapolate out to the clipping circle.
     %(border_topomap)s
 
         .. versionadded:: 0.20

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -377,6 +377,8 @@ def plot_projs_topomap(
 
         .. versionadded:: 0.20
     %(border_topomap)s
+
+        .. versionadded:: 0.20
     %(res_topomap)s
     %(size_topomap)s
     %(cmap_topomap)s
@@ -937,6 +939,8 @@ def plot_topomap(
 
         .. versionadded:: 0.18
     %(border_topomap)s
+
+        .. versionadded:: 0.20
     %(res_topomap)s
     %(size_topomap)s
     %(cmap_topomap_simple)s
@@ -1793,6 +1797,8 @@ def plot_tfr_topomap(
     %(image_interp_topomap)s
     %(extrapolate_topomap)s
     %(border_topomap)s
+
+        .. versionadded:: 0.20
     %(res_topomap)s
     %(size_topomap)s
     %(cmap_topomap)s
@@ -1985,6 +1991,8 @@ def plot_evoked_topomap(
 
         .. versionadded:: 0.18
     %(border_topomap)s
+
+        .. versionadded:: 0.20
     %(res_topomap)s
     %(size_topomap)s
     %(cmap_topomap)s
@@ -2518,6 +2526,8 @@ def plot_epochs_psd_topomap(
     %(image_interp_topomap)s
     %(extrapolate_topomap)s
     %(border_topomap)s
+
+        .. versionadded:: 0.20
     %(res_topomap)s
     %(size_topomap)s
     %(cmap_topomap)s
@@ -2611,6 +2621,8 @@ def plot_psds_topomap(
     %(image_interp_topomap)s
     %(extrapolate_topomap)s
     %(border_topomap)s
+
+        .. versionadded:: 0.20
     %(res_topomap)s
     %(size_topomap)s
     %(cmap_topomap)s
@@ -3865,6 +3877,8 @@ def plot_regression_weights(
     %(image_interp_topomap)s
     %(extrapolate_topomap)s
     %(border_topomap)s
+
+        .. versionadded:: 0.20
     %(res_topomap)s
     %(size_topomap)s
     %(cmap_topomap)s


### PR DESCRIPTION
closes #11816 

First attempt worked pretty well, I thought:

![Screenshot 2023-07-21 at 10-20-24 mne Epochs — MNE 1 4 0 dev127 g9145025c4 d20230423 documentation](https://github.com/mne-tools/mne-python/assets/1810515/8b8f39d7-a48c-4869-973c-c3a0cdf76139)

Until I did a quick scan of `git grep versionadded` results, and checked some other API pages, and found this in `CSP.plot_filters`:

![Screenshot 2023-07-21 at 11-31-10 mne decoding CSP — MNE 1 4 0 dev127 g9145025c4 d20230423 documentation](https://github.com/mne-tools/mne-python/assets/1810515/fd580d90-61ab-4785-84a4-c83b653cf4cb)
