### PR TITLE
BUG: Fix bug with MFF reference setting

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -52,6 +52,7 @@ Bugs
 - Fix bug with :func:`mne.io.read_raw_fil` where datasets without sensor positions would not import (:gh:`11733` by `George O'Neill`_)
 - Fix bug with :func:`mne.chpi.compute_chpi_snr` where cHPI being off for part of the recording or bad channels being defined led to an error or incorrect behavior (:gh:`11754`, :gh:`11755` by `Eric Larson`_)
 - Allow int-like for the argument ``id`` of `~mne.make_fixed_length_events` (:gh:`11748` by `Mathieu Scheltienne`_)
+- Fix bug where :func:`mne.io.read_raw_egi` did not properly set the EEG reference location for the reference channel itself (:gh:`11822` by `Eric Larson`_)
 - Fix bug with legacy :meth:`~mne.io.Raw.plot_psd` method where passed axes were not used (:gh:`11778` by `Daniel McCloy`_)
 - blink :class:`mne.Annotations` read in by :func:`mne.io.read_raw_eyelink` now begin with ``'BAD_'``, i.e. ``'BAD_blink'``, because ocular data are missing during blinks. (:gh:`11746` by `Scott Huberty`_)
 - Fix bug where :ref:`mne show_fiff` could fail with an ambiguous error if the file is corrupt (:gh:`11800` by `Eric Larson`_)

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -1171,25 +1171,22 @@ def _set_montage(info, montage, match_case=True, match_alias=False, on_missing="
     chs = [info["chs"][ii] for ii in picks]
     non_names = [info["chs"][ii]["ch_name"] for ii in non_picks]
     del picks
-    ref_pos = [ch["loc"][3:6] for ch in chs]
+    ref_pos = np.array([ch["loc"][3:6] for ch in chs])
 
     # keep reference location from EEG-like channels if they
     # already exist and are all the same.
-    custom_eeg_ref_dig = False
     # Note: ref position is an empty list for fieldtrip data
-    if ref_pos:
-        if (
-            all([np.equal(ref_pos[0], pos).all() for pos in ref_pos])
-            and not np.equal(ref_pos[0], [0, 0, 0]).all()
-        ):
-            eeg_ref_pos = ref_pos[0]
-            # since we have an EEG reference position, we have
-            # to add it into the info['dig'] as EEG000
-            custom_eeg_ref_dig = True
-    if not custom_eeg_ref_dig:
+    if len(ref_pos) and ref_pos[0].any() and (ref_pos[0] == ref_pos).all():
+        eeg_ref_pos = ref_pos[0]
+        # since we have an EEG reference position, we have
+        # to add it into the info['dig'] as EEG000
+        custom_eeg_ref_dig = True
+    else:
         refs = set(ch_pos) & {"EEG000", "REF"}
         assert len(refs) <= 1
         eeg_ref_pos = np.zeros(3) if not refs else ch_pos.pop(refs.pop())
+        custom_eeg_ref_dig = False
+    del ref_pos
 
     # This raises based on info being subset/superset of montage
     info_names = [ch["ch_name"] for ch in chs]

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -575,14 +575,9 @@ class RawMff(BaseRaw):
             ref_idx = ref_idx.item()
             ref_coords = info["chs"][int(ref_idx)]["loc"][:3]
             for chan in info["chs"]:
-                is_eeg = chan["kind"] == FIFF.FIFFV_EEG_CH
-                is_not_ref = chan["ch_name"] not in REFERENCE_NAMES
-                if is_eeg and is_not_ref:
+                if chan["kind"] == FIFF.FIFFV_EEG_CH:
                     chan["loc"][3:6] = ref_coords
 
-            # Cz ref was applied during acquisition, so mark as already set.
-            with info._unlock():
-                info["custom_ref_applied"] = FIFF.FIFFV_MNE_CUSTOM_REF_ON
         file_bin = op.join(input_fname, egi_info["eeg_fname"])
         egi_info["egi_events"] = egi_events
 
@@ -1013,9 +1008,6 @@ def _read_evoked_mff(fname, condition, channel_naming="E%d", verbose=None):
     info["bads"] = bads
 
     # Add EEG reference to info
-    # Initialize 'custom_ref_applied' to False
-    with info._unlock():
-        info["custom_ref_applied"] = False
     try:
         fp = mff.directory.filepointer("history")
     except (ValueError, FileNotFoundError):  # old (<=0.6.3) vs new mffpy
@@ -1027,10 +1019,7 @@ def _read_evoked_mff(fname, condition, channel_naming="E%d", verbose=None):
             if entry["method"] == "Montage Operations Tool":
                 if "Average Reference" in entry["settings"]:
                     # Average reference has been applied
-                    projector, info = setup_proj(info)
-                else:
-                    # Custom reference has been applied that is not an average
-                    info["custom_ref_applied"] = True
+                    _, info = setup_proj(info)
 
     # Get nave from categories.xml
     try:


### PR DESCRIPTION
A channel can be its own reference (and thus be all zero) -- its `info['chs'][ii]['loc'][3:6]` should still be set properly and it wasn't before. Moreover I don't think this counts as a `FIFFV_MNE_CUSTOM_REF_ON` because really *something* has to be the ref, and I don't think it being in the dataset is necessarily problematic / custom. I think that's more meant for use cases like some channels having bipolar ref etc.

While investigating this I simplified some logic (with equivalent operations) in `montage`.

@scott-huberty according to `git blame` I think you worked on this most recently, please have a look when you get a chance!