### PR TITLE
MRG: Allow reading Curry and NEDF raw data via io.read_raw()

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -34,6 +34,7 @@ Enhancements
 - Added a section for combining eye-tracking and EEG data to the preprocessing tutorial "working with eye tracker data in MNE-Python" (:gh:`11770` by `Scott Huberty`_)
 - Added a ``show_bytes`` option to :ref:`mne show_fiff` to show byte offsets (:gh:`11800` by `Eric Larson`_)
 - Add :meth:`mne.Annotations.count` and :func:`mne.count_annotations` to count unique annotations (:gh:`11796` by `Clemens Brunner`_)
+- Curry and NEDF raw files can now also be read with the generic :func:`mne.io.read_raw` function (:gh:`11841` by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/mne/io/_read_raw.py
+++ b/mne/io/_read_raw.py
@@ -28,6 +28,8 @@ from . import (
     read_raw_snirf,
     read_raw_fil,
     read_raw_nihon,
+    read_raw_curry,
+    read_raw_nedf,
 )
 from ..utils import fill_doc
 
@@ -68,6 +70,16 @@ supported = {
     ".con": dict(KIT=read_raw_kit),
     ".ds": dict(CTF=read_raw_ctf),
     ".txt": dict(BOXY=read_raw_boxy),
+    # Curry
+    ".dat": dict(CURRY=read_raw_curry),
+    ".dap": dict(CURRY=read_raw_curry),
+    ".rs3": dict(CURRY=read_raw_curry),
+    ".cdt": dict(CURRY=read_raw_curry),
+    ".cdt.dpa": dict(CURRY=read_raw_curry),
+    ".cdt.cef": dict(CURRY=read_raw_curry),
+    ".cef": dict(CURRY=read_raw_curry),
+    # NEDF
+    ".nedf": dict(NEDF=read_raw_nedf),
 }
 
 # known but unsupported file formats
@@ -108,7 +120,8 @@ def read_raw(fname, *, preload=False, verbose=None, **kwargs):
     `~mne.io.read_raw_eximia`, `~mne.io.read_raw_fieldtrip`,
     `~mne.io.read_raw_fif`,  `~mne.io.read_raw_gdf`, `~mne.io.read_raw_kit`,
     `~mne.io.read_raw_fil`,
-    `~mne.io.read_raw_nicolet`, and `~mne.io.read_raw_nirx`.
+    `~mne.io.read_raw_nicolet`, `~mne.io.read_raw_nirx`,
+    `~mne.io.read_raw_curry`, and `~mne.io.read_raw_nedf`.
 
     Parameters
     ----------


### PR DESCRIPTION
Closes #11813
