### PR TITLE
convert_flash_mrism: crush when flash30 and no flash5_reg.mgz file

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -37,6 +37,7 @@ Enhancements
 
 Bugs
 ~~~~
+- Fix bug in convert_flash_mris, when flash30 and no flash5_reg.mgz file regenrated, add missing_ok=True as it is done in line 2074. (:gh:`11842` by :newcontrib: `Hamza Abdelhedi`_)
 - Fix bug where epochs ``event_id`` was not kept by :func:`mne.channels.combine_channels` (:gh:`11786` by :newcontrib:`Samuel Louviot`)
 - Fix bug where user-provided codec was not used to read annotations when loading EEGLAB ``.set`` files (:gh:`11773` by :newcontrib:`Yiping Zuo`)
 - Fix bug that required curv.*h files to create Brain object (:gh:`11704` by :newcontrib:`Aaron Earle-Richardson`)
@@ -60,7 +61,6 @@ Bugs
 - Fix bug where annotation FIF files lacked an end block tag (:gh:`11800` by `Eric Larson`_)
 - Fix display of :class:`~mne.Annotations` in `mne.preprocessing.ICA.plot_sources` when the ``raw`` has ``raw.first_samp != 0`` and doesn't have a measurement date (:gh:`11766` by `Mathieu Scheltienne`_)
 - Fix bug in read_raw_eyelink, where STATUS information of samples was always assumed to be in the file. Performance and memory improvements were also made. (:gh:`11823` by `Scott Huberty`_)
-- Fix bug in convert_flash_mris, when flash30 and no flash5_reg.mgz file regenrated, add missing_ok=True as it is done in line 2074. (:gh:`11842` by `Hamza Abdelhedi`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -37,7 +37,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Fix bug in convert_flash_mris, when flash30 and no flash5_reg.mgz file regenrated, add missing_ok=True as it is done in line 2074. (:gh:`11842` by :newcontrib: `Hamza Abdelhedi`)
+- Fix bug in convert_flash_mris, when flash30 and no flash5_reg.mgz file regenerated, add missing_ok=True as it is done in line 2074. (:gh:`11842` by :newcontrib: `Hamza Abdelhedi`)
 - Fix bug where epochs ``event_id`` was not kept by :func:`mne.channels.combine_channels` (:gh:`11786` by :newcontrib:`Samuel Louviot`)
 - Fix bug where user-provided codec was not used to read annotations when loading EEGLAB ``.set`` files (:gh:`11773` by :newcontrib:`Yiping Zuo`)
 - Fix bug that required curv.*h files to create Brain object (:gh:`11704` by :newcontrib:`Aaron Earle-Richardson`)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -37,7 +37,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Fix bug in convert_flash_mris, when flash30 and no flash5_reg.mgz file regenerated, add missing_ok=True as it is done in line 2074. (:gh:`11842` by :newcontrib: `Hamza Abdelhedi`)
+- Fix bug in :func:`mne.bem.convert_flash_mris` to handle missing "flash5_reg.mgz" when processing "flash30" data. (:gh:`11842` by :newcontrib: `Hamza Abdelhedi`)
 - Fix bug where epochs ``event_id`` was not kept by :func:`mne.channels.combine_channels` (:gh:`11786` by :newcontrib:`Samuel Louviot`)
 - Fix bug where user-provided codec was not used to read annotations when loading EEGLAB ``.set`` files (:gh:`11773` by :newcontrib:`Yiping Zuo`)
 - Fix bug that required curv.*h files to create Brain object (:gh:`11704` by :newcontrib:`Aaron Earle-Richardson`)

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -60,6 +60,7 @@ Bugs
 - Fix bug where annotation FIF files lacked an end block tag (:gh:`11800` by `Eric Larson`_)
 - Fix display of :class:`~mne.Annotations` in `mne.preprocessing.ICA.plot_sources` when the ``raw`` has ``raw.first_samp != 0`` and doesn't have a measurement date (:gh:`11766` by `Mathieu Scheltienne`_)
 - Fix bug in read_raw_eyelink, where STATUS information of samples was always assumed to be in the file. Performance and memory improvements were also made. (:gh:`11823` by `Scott Huberty`_)
+- Fix bug in convert_flash_mris, when flash30 and no flash5_reg.mgz file regenrated, add missing_ok=True as it is done in line 2074. (:gh:`11842` by `Hamza Abdelhedi`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -37,7 +37,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Fix bug in convert_flash_mris, when flash30 and no flash5_reg.mgz file regenrated, add missing_ok=True as it is done in line 2074. (:gh:`11842` by :newcontrib: `Hamza Abdelhedi`_)
+- Fix bug in convert_flash_mris, when flash30 and no flash5_reg.mgz file regenrated, add missing_ok=True as it is done in line 2074. (:gh:`11842` by :newcontrib: `Hamza Abdelhedi`)
 - Fix bug where epochs ``event_id`` was not kept by :func:`mne.channels.combine_channels` (:gh:`11786` by :newcontrib:`Samuel Louviot`)
 - Fix bug where user-provided codec was not used to read annotations when loading EEGLAB ``.set`` files (:gh:`11773` by :newcontrib:`Yiping Zuo`)
 - Fix bug that required curv.*h files to create Brain object (:gh:`11704` by :newcontrib:`Aaron Earle-Richardson`)

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -190,6 +190,8 @@
 
 .. _Hamid Maymandi: https://github.com/HamidMandi
 
+.. _Hamza Abdelhedi: https://github.com/BabaSanfour
+
 .. _Hakimeh Pourakbari: https://github.com/Hpakbari
 
 .. _Hari Bharadwaj: https://github.com/haribharadwaj

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -2060,7 +2060,7 @@ def convert_flash_mris(
                 (pm_dir / "flash5.mgz"),
             ]
             run_subprocess_env(cmd)
-            (pm_dir / "flash5_reg.mgz").unlink()
+            (pm_dir / "flash5_reg.mgz").unlink(missing_ok=True)
         else:
             logger.info("Synthesized flash 5 volume is already there")
     else:


### PR DESCRIPTION
Fixes #11842.
convert_flash_mris function in bem.py file
crush when flash30==True and no flash5_reg.mgz file generated
add dd missing_ok=True as it is done in line 2074
