### PR TITLE
MAINT: Use pytest-qt

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ stages:
     - bash: |
         set -eo pipefail
         python -m pip install --progress-bar off --upgrade pip setuptools wheel
-        python -m pip install --progress-bar off -r requirements_base.txt -r requirements_hdf5.txt -r requirements_testing.txt
+        python -m pip install --progress-bar off -r requirements_base.txt -r requirements_hdf5.txt -r requirements_testing.txt PyQt6
         pre-commit install --install-hooks
       displayName: Install dependencies
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ stages:
         set -eo pipefail
         python -m pip install --progress-bar off --upgrade pip setuptools wheel
         python -m pip install --progress-bar off -r requirements_base.txt -r requirements_hdf5.txt -r requirements_testing.txt
-        python -m pip uninstall pytest-qt  # don't want to set up display, etc. for this
+        python -m pip uninstall -yq pytest-qt  # don't want to set up display, etc. for this
         pre-commit install --install-hooks
       displayName: Install dependencies
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,8 @@ stages:
     - bash: |
         set -eo pipefail
         python -m pip install --progress-bar off --upgrade pip setuptools wheel
-        python -m pip install --progress-bar off -r requirements_base.txt -r requirements_hdf5.txt -r requirements_testing.txt PyQt6
+        python -m pip install --progress-bar off -r requirements_base.txt -r requirements_hdf5.txt -r requirements_testing.txt
+        python -m pip uninstall pytest-qt  # don't want to set up display, etc. for this
         pre-commit install --install-hooks
       displayName: Install dependencies
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -191,7 +191,7 @@ stages:
         set -e
         mne sys_info -pd
         mne sys_info -pd | grep "qtpy .* (PySide6=.*)$"
-        pytest -m "not slowtest" ${TEST_OPTIONS}
+        PYTEST_QT_API=PySide6 pytest -m "not slowtest" ${TEST_OPTIONS}
         python -m pip uninstall -yq PySide6
       displayName: 'PySide6'
     - bash: |
@@ -201,7 +201,7 @@ stages:
         # LD_DEBUG=libs python -c "from PyQt6.QtWidgets import QApplication, QWidget; app = QApplication([]); import matplotlib; matplotlib.use('QtAgg'); import matplotlib.pyplot as plt; plt.figure()"
         mne sys_info -pd
         mne sys_info -pd | grep "qtpy .* (PyQt6=.*)$"
-        pytest -m "not slowtest" ${TEST_OPTIONS}
+        PYTEST_QT_API=PyQt6 pytest -m "not slowtest" ${TEST_OPTIONS}
         python -m pip uninstall -yq PyQt6 PyQt6-sip PyQt6-Qt6
       displayName: 'PyQt6'
     - bash: |
@@ -209,7 +209,7 @@ stages:
         python -m pip install PySide2
         mne sys_info -pd
         mne sys_info -pd | grep "qtpy .* (PySide2=.*)$"
-        pytest -m "not slowtest" ${TEST_OPTIONS}
+        PYTEST_QT_API=PySide2 pytest -m "not slowtest" ${TEST_OPTIONS}
         python -m pip uninstall -yq PySide2
       displayName: 'PySide2'
     # PyQt5 leaves cruft behind, so run it last
@@ -218,7 +218,7 @@ stages:
         python -m pip install PyQt5
         mne sys_info -pd
         mne sys_info -pd | grep "qtpy .* (PyQt5=.*)$"
-        pytest -m "not slowtest" ${TEST_OPTIONS}
+        PYTEST_QT_API=PyQt5 pytest -m "not slowtest" ${TEST_OPTIONS}
         python -m pip uninstall -yq PyQt5 PyQt5-sip PyQt5-Qt5
       displayName: 'PyQt5'
     # Coverage

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -209,6 +209,7 @@ def verbose_debug():
 def qt_config():
     """Configure the Qt backend for viz tests."""
     os.environ["_MNE_BROWSER_NO_BLOCK"] = "true"
+    os.environ["_MNE_BROWSER_BACK"] = "true"
 
 
 @pytest.fixture(scope="session")

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -209,7 +209,8 @@ def verbose_debug():
 def qt_config():
     """Configure the Qt backend for viz tests."""
     os.environ["_MNE_BROWSER_NO_BLOCK"] = "true"
-    os.environ["_MNE_BROWSER_BACK"] = "true"
+    if "_MNE_BROWSER_BACK" not in os.environ:
+        os.environ["_MNE_BROWSER_BACK"] = "true"
 
 
 @pytest.fixture(scope="session")

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -1911,7 +1911,7 @@ def test_scale_morph_labels(kind, scale, monkeypatch, tmp_path):
             if isinstance(scale, tuple):
                 # some other fixed constant
                 # min_, max_ = 0.84, 0.855  # zooms='auto' values
-                min_, max_ = 0.57, 0.67
+                min_, max_ = 0.55, 0.67
             elif scale == 1:
                 # min_, max_ = 0.85, 0.875  # zooms='auto' values
                 min_, max_ = 0.72, 0.76

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -720,6 +720,10 @@ class _MNEMainWindow(MainWindow):
             MainWindow.__init__(self, parent=parent, title=title, size=size)
         self.setAttribute(Qt.WA_ShowWithoutActivating, True)
         self.setAttribute(Qt.WA_DeleteOnClose, True)
+        from . import renderer
+
+        if renderer.MNE_3D_BACKEND_TESTING:
+            self.setWindowFlags(self.windowFlags() | Qt.WindowStaysOnBottomHint)
 
 
 class _AppWindow(_AbstractAppWindow, _MNEMainWindow, _Widget, metaclass=_BaseWidget):

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -175,9 +175,12 @@ def _show_browser(show=True, block=True, fig=None, **kwargs):
     if backend == "matplotlib":
         plt_show(show, block=block, **kwargs)
     else:
+        from qtpy.QtCore import Qt
         from qtpy.QtWidgets import QApplication
         from .backends._utils import _qt_app_exec
 
+        if fig is not None and os.getenv("_MNE_BROWSER_BACK", "").lower() == "true":
+            fig.setWindowFlags(fig.windowFlags() | Qt.WindowStaysOnBottomHint)
         if show:
             fig.show()
         # If block=False, a Qt-Event-Loop has to be started
@@ -1293,6 +1296,7 @@ def _plot_sensors(
     from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 analysis:ignore
     from .topomap import _get_pos_outlines, _draw_outlines
 
+    ch_names = [str(ch_name) for ch_name in ch_names]
     sphere = _check_sphere(sphere, info)
 
     edgecolors = np.repeat(rcParams["axes.edgecolor"], len(colors))

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -3,6 +3,7 @@ pytest
 pytest-cov
 pytest-timeout
 pytest-harvest
+pytest-qt
 ruff
 numpydoc
 codespell


### PR DESCRIPTION
1. Add `pytest-qt`
2. Fix bugs that now show up thanks to re-throwing errors in callbacks
3. Add Qt option during testing to prefer windows stay at the back (helps with interactive testing not to have a ton of windows pop up)

Closes #11655