### PR TITLE
MAINT: Remove custom decorators

### DIFF
--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -32,7 +32,7 @@ from mne.surface import _compute_nearest
 from mne.time_frequency import CrossSpectralDensity, csd_morlet, EpochsTFR, csd_tfr
 from mne.time_frequency.csd import _sym_mat_to_vector
 from mne.transforms import invert_transform, apply_trans
-from mne.utils import object_diff, requires_version, catch_logging
+from mne.utils import object_diff, catch_logging
 
 data_path = testing.data_path(download=False)
 fname_raw = data_path / "MEG" / "sample" / "sample_audvis_trunc_raw.fif"
@@ -156,7 +156,6 @@ def _make_rand_csd(info, csd):
 
 @pytest.mark.slowtest
 @testing.requires_testing_data
-@requires_version("h5io")
 @idx_param
 @pytest.mark.parametrize(
     "whiten",
@@ -167,6 +166,7 @@ def _make_rand_csd(info, csd):
 )
 def test_make_dics(tmp_path, _load_forward, idx, whiten):
     """Test making DICS beamformer filters."""
+    pytest.importorskip("h5io")
     # We only test proper handling of parameters here. Testing the results is
     # done in test_apply_dics_timeseries and test_apply_dics_csd.
 

--- a/mne/beamformer/tests/test_external.py
+++ b/mne/beamformer/tests/test_external.py
@@ -11,7 +11,6 @@ import mne
 from mne.beamformer import make_lcmv, apply_lcmv, apply_lcmv_cov
 from mne.beamformer.tests.test_lcmv import _get_data
 from mne.datasets import testing
-from mne.utils import requires_version
 
 data_path = testing.data_path(download=False)
 ft_data_path = data_path / "fieldtrip" / "beamformer"
@@ -64,7 +63,6 @@ def _get_bf_data(save_fieldtrip=False):
 
 # beamformer types to be tested: unit-gain (vector and scalar) and
 # unit-noise-gain (time series and power output [apply_lcmv_cov])
-@requires_version("pymatreader")
 @pytest.mark.parametrize(
     "bf_type, weight_norm, pick_ori, pwr",
     [
@@ -77,7 +75,7 @@ def _get_bf_data(save_fieldtrip=False):
 )
 def test_lcmv_fieldtrip(_get_bf_data, bf_type, weight_norm, pick_ori, pwr):
     """Test LCMV vs fieldtrip output."""
-    from pymatreader import read_mat
+    pymatreader = pytest.importorskip("pymatreader")
 
     evoked, data_cov, fwd = _get_bf_data
 
@@ -98,7 +96,7 @@ def test_lcmv_fieldtrip(_get_bf_data, bf_type, weight_norm, pick_ori, pwr):
 
     # load the FieldTrip output
     ft_fname = ft_data_path / ("ft_source_" + bf_type + "-vol.mat")
-    stc_ft_data = read_mat(ft_fname)["stc"]
+    stc_ft_data = pymatreader.read_mat(ft_fname)["stc"]
     if stc_ft_data.ndim == 1:
         stc_ft_data.shape = (stc_ft_data.size, 1)
 

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -42,7 +42,7 @@ from mne.io.constants import FIFF
 from mne.minimum_norm import make_inverse_operator, apply_inverse
 from mne.minimum_norm.tests.test_inverse import _assert_free_ori_match
 from mne.simulation import simulate_evoked
-from mne.utils import object_diff, requires_version, catch_logging, _record_warnings
+from mne.utils import object_diff, catch_logging, _record_warnings
 
 
 data_path = testing.data_path(download=False)
@@ -257,7 +257,6 @@ def test_lcmv_vector():
 
 
 @pytest.mark.slowtest
-@requires_version("h5io")
 @testing.requires_testing_data
 @pytest.mark.parametrize(
     "reg, proj, kind",
@@ -270,6 +269,7 @@ def test_lcmv_vector():
 )
 def test_make_lcmv_bem(tmp_path, reg, proj, kind):
     """Test LCMV with evoked data and single trials."""
+    pytest.importorskip("h5io")
     (
         raw,
         epochs,

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -50,7 +50,6 @@ from mne import (
     Epochs,
 )
 from mne.datasets import testing
-from mne.utils import requires_pandas, requires_version
 from mne.parallel import parallel_func
 
 io_dir = Path(__file__).parent.parent.parent / "io"
@@ -410,10 +409,10 @@ def test_get_set_sensor_positions():
     assert_array_equal(raw1.info["chs"][13]["loc"], raw2.info["chs"][13]["loc"])
 
 
-@requires_version("pymatreader")
 @testing.requires_testing_data
 def test_1020_selection():
     """Test making a 10/20 selection dict."""
+    pytest.importorskip("pymatreader")
     raw_fname = testing_path / "EEGLAB" / "test_raw.set"
     loc_fname = testing_path / "EEGLAB" / "test_chans.locs"
     raw = read_raw_eeglab(raw_fname, preload=True)
@@ -676,11 +675,9 @@ def test_combine_channels():
     assert len(record) == 3
 
 
-@requires_pandas
 def test_combine_channels_metadata():
     """Test if metadata is correctly retained in combined object."""
-    import pandas as pd
-
+    pd = pytest.importorskip("pandas")
     raw = read_raw_fif(raw_fname, preload=True)
     epochs = Epochs(raw, read_events(eve_fname), preload=True)
 

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -15,7 +15,7 @@ from mne.preprocessing.nirs import (
 )
 from mne.io import read_raw_nirx
 from mne.io.proj import _has_eeg_average_ref_proj
-from mne.utils import _record_warnings, requires_version
+from mne.utils import _record_warnings
 
 base_dir = Path(__file__).parent.parent.parent / "io" / "tests" / "data"
 raw_fname = base_dir / "test_raw.fif"
@@ -302,10 +302,10 @@ def test_interpolation_ctf_comp():
     assert raw.info["bads"] == []
 
 
-@requires_version("pymatreader")
 @testing.requires_testing_data
 def test_interpolation_nirs():
     """Test interpolating bad nirs channels."""
+    pytest.importorskip("pymatreader")
     fname = testing_path / "NIRx" / "nirscout" / "nirx_15_2_recording_w_overlap"
     raw_intensity = read_raw_nirx(fname, preload=False)
     raw_od = optical_density(raw_intensity)

--- a/mne/datasets/sleep_physionet/tests/test_physionet.py
+++ b/mne/datasets/sleep_physionet/tests/test_physionet.py
@@ -8,7 +8,6 @@ import pytest
 
 
 from mne.utils import requires_good_network
-from mne.utils import requires_pandas, requires_version
 from mne.datasets.sleep_physionet import age, temazepam
 from mne.datasets.sleep_physionet._utils import _update_sleep_temazepam_records
 from mne.datasets.sleep_physionet._utils import _update_sleep_age_records
@@ -56,11 +55,10 @@ def _check_mocked_function_calls(mocked_func, call_fname_hash_pairs, base_path):
 @pytest.mark.timeout(60)
 @pytest.mark.xfail(strict=False)
 @requires_good_network
-@requires_pandas
-@requires_version("xlrd", "0.9")
 def test_run_update_age_records(tmp_path):
     """Test Sleep Physionet URL handling."""
-    import pandas as pd
+    pd = pytest.importorskip("pandas")
+    pytest.importorskip("xlrd", "0.9")
 
     fname = tmp_path / "records.csv"
     _update_sleep_age_records(fname)
@@ -179,12 +177,10 @@ def test_sleep_physionet_age(physionet_tmpdir, fake_retrieve):
 
 @pytest.mark.xfail(strict=False)
 @requires_good_network
-@requires_pandas
-@requires_version("xlrd", "0.9")
 def test_run_update_temazepam_records(tmp_path):
     """Test Sleep Physionet URL handling."""
-    import pandas as pd
-
+    pd = pytest.importorskip("pandas")
+    pytest.importorskip("xlrd", "0.9")
     fname = tmp_path / "records.csv"
     _update_sleep_temazepam_records(fname)
     data = pd.read_csv(fname)

--- a/mne/decoding/tests/test_base.py
+++ b/mne/decoding/tests/test_base.py
@@ -14,8 +14,7 @@ from numpy.testing import (
 import pytest
 
 from mne import create_info, EpochsArray
-from mne.fixes import is_regressor, is_classifier
-from mne.utils import requires_sklearn
+from mne.fixes import is_classifier, is_regressor
 from mne.decoding.base import (
     _get_inverse_funcs,
     LinearModel,
@@ -25,6 +24,9 @@ from mne.decoding.base import (
 )
 from mne.decoding.search_light import SlidingEstimator
 from mne.decoding import Scaler, TransformerMixin, Vectorizer, GeneralizingEstimator
+
+
+pytest.importorskip("sklearn")
 
 
 def _make_data(n_samples=1000, n_features=5, n_targets=3):
@@ -66,7 +68,6 @@ def _make_data(n_samples=1000, n_features=5, n_targets=3):
     return X, Y, A
 
 
-@requires_sklearn
 def test_get_coef():
     """Test getting linear coefficients (filters/patterns) from estimators."""
     from sklearn.base import TransformerMixin, BaseEstimator
@@ -200,7 +201,6 @@ class _Noop(BaseEstimator, TransformerMixin):
     inverse_transform = transform
 
 
-@requires_sklearn
 @pytest.mark.parametrize("inverse", (True, False))
 @pytest.mark.parametrize(
     "Scale, kwargs",
@@ -237,7 +237,6 @@ def test_get_coef_inverse_transform(inverse, Scale, kwargs):
             assert_array_equal(filters_t, filters[:, t])
 
 
-@requires_sklearn
 @pytest.mark.parametrize("n_features", [1, 5])
 @pytest.mark.parametrize("n_targets", [1, 3])
 def test_get_coef_multiclass(n_features, n_targets):
@@ -284,7 +283,6 @@ def test_get_coef_multiclass(n_features, n_targets):
     lm.fit(X, Y, sample_weight=np.ones(len(Y)))
 
 
-@requires_sklearn
 @pytest.mark.parametrize(
     "n_classes, n_channels, n_times",
     [
@@ -332,7 +330,6 @@ def test_get_coef_multiclass_full(n_classes, n_channels, n_times):
     assert_allclose(patterns[:, 1:], 0.0, atol=1e-7)  # no other channels useful
 
 
-@requires_sklearn
 def test_linearmodel():
     """Test LinearModel class for computing filters and patterns."""
     # check categorical target fit in standard linear model
@@ -390,7 +387,6 @@ def test_linearmodel():
         clf.fit(X, wrong_y)
 
 
-@requires_sklearn
 def test_cross_val_multiscore():
     """Test cross_val_multiscore for computing scores on decoding over time."""
     from sklearn.model_selection import KFold, StratifiedKFold, cross_val_score

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -13,7 +13,6 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_
 
 from mne import io, Epochs, read_events, pick_types
 from mne.decoding.csp import CSP, _ajd_pham, SPoC
-from mne.utils import requires_sklearn
 
 data_dir = Path(__file__).parent.parent.parent / "io" / "tests" / "data"
 raw_fname = data_dir / "test_raw.fif"
@@ -245,9 +244,9 @@ def test_csp():
         assert np.abs(corr) > 0.95
 
 
-@requires_sklearn
 def test_regularized_csp():
     """Test Common Spatial Patterns algorithm using regularized covariance."""
+    pytest.importorskip("sklearn")
     raw = io.read_raw_fif(raw_fname)
     events = read_events(event_name)
     picks = pick_types(
@@ -281,9 +280,9 @@ def test_regularized_csp():
         assert sources.shape[1] == n_components
 
 
-@requires_sklearn
 def test_csp_pipeline():
     """Test if CSP works in a pipeline."""
+    pytest.importorskip("sklearn")
     from sklearn.svm import SVC
     from sklearn.pipeline import Pipeline
 

--- a/mne/decoding/tests/test_ems.py
+++ b/mne/decoding/tests/test_ems.py
@@ -9,7 +9,6 @@ from numpy.testing import assert_array_almost_equal, assert_equal
 import pytest
 
 from mne import io, Epochs, read_events, pick_types
-from mne.utils import requires_sklearn
 from mne.decoding import compute_ems, EMS
 
 data_dir = Path(__file__).parent.parent.parent / "io" / "tests" / "data"
@@ -18,8 +17,9 @@ event_name = data_dir / "test-eve.fif"
 tmin, tmax = -0.2, 0.5
 event_id = dict(aud_l=1, vis_l=3)
 
+pytest.importorskip("sklearn")
 
-@requires_sklearn
+
 def test_ems():
     """Test event-matched spatial filters."""
     from sklearn.model_selection import StratifiedKFold

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -10,7 +10,6 @@ from numpy import einsum
 from numpy.fft import rfft, irfft
 from numpy.testing import assert_array_equal, assert_allclose, assert_equal
 
-from mne.utils import requires_sklearn
 from mne.decoding import ReceptiveField, TimeDelayingRidge
 from mne.decoding.receptive_field import (
     _delay_time_series,
@@ -78,10 +77,10 @@ def test_compute_reg_neighbors():
                 )
 
 
-@requires_sklearn
 def test_rank_deficiency():
     """Test signals that are rank deficient."""
     # See GH#4253
+    pytest.importorskip("sklearn")
     from sklearn.linear_model import Ridge
 
     N = 256
@@ -174,9 +173,9 @@ def test_time_delay():
 
 @pytest.mark.slowtest  # slow on Azure
 @pytest.mark.parametrize("n_jobs", n_jobs_test)
-@requires_sklearn
 def test_receptive_field_basic(n_jobs):
     """Test model prep and fitting."""
+    pytest.importorskip("sklearn")
     from sklearn.linear_model import Ridge
 
     # Make sure estimator pulling works
@@ -372,9 +371,9 @@ def test_time_delaying_fast_calc(n_jobs):
 
 
 @pytest.mark.parametrize("n_jobs", n_jobs_test)
-@requires_sklearn
 def test_receptive_field_1d(n_jobs):
     """Test that the fast solving works like Ridge."""
+    pytest.importorskip("sklearn")
     from sklearn.linear_model import Ridge
 
     rng = np.random.RandomState(0)
@@ -433,9 +432,9 @@ def test_receptive_field_1d(n_jobs):
 
 
 @pytest.mark.parametrize("n_jobs", n_jobs_test)
-@requires_sklearn
 def test_receptive_field_nd(n_jobs):
     """Test multidimensional support."""
+    pytest.importorskip("sklearn")
     from sklearn.linear_model import Ridge
 
     # multidimensional
@@ -552,9 +551,9 @@ def _make_data(n_feats, n_targets, n_samples, tmin, tmax):
     return X, y
 
 
-@requires_sklearn
 def test_inverse_coef():
     """Test inverse coefficients computation."""
+    pytest.importorskip("sklearn")
     from sklearn.linear_model import Ridge
 
     tmin, tmax = 0.0, 10.0
@@ -583,9 +582,9 @@ def test_inverse_coef():
         assert_allclose(np.dot(c0, c1.T), np.eye(c0.shape[0]), atol=0.2)
 
 
-@requires_sklearn
 def test_linalg_warning():
     """Test that warnings are issued when no regularization is applied."""
+    pytest.importorskip("sklearn")
     from sklearn.linear_model import Ridge
 
     n_feats, n_targets, n_samples = 5, 60, 50

--- a/mne/decoding/tests/test_search_light.py
+++ b/mne/decoding/tests/test_search_light.py
@@ -8,9 +8,11 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_equal
 import pytest
 
-from mne.utils import requires_sklearn, _record_warnings, use_log_level
+from mne.utils import _record_warnings, use_log_level
 from mne.decoding.search_light import SlidingEstimator, GeneralizingEstimator
 from mne.decoding.transformer import Vectorizer
+
+pytest.importorskip("sklearn")
 
 
 def make_data():
@@ -25,7 +27,6 @@ def make_data():
     return X, y
 
 
-@requires_sklearn
 def test_search_light():
     """Test SlidingEstimator."""
     from sklearn.linear_model import Ridge, LogisticRegression
@@ -167,7 +168,6 @@ def test_search_light():
         assert isinstance(pipe.estimators_[0], BaggingClassifier)
 
 
-@requires_sklearn
 def test_generalization_light():
     """Test GeneralizingEstimator."""
     from sklearn.pipeline import make_pipeline
@@ -254,7 +254,6 @@ def test_generalization_light():
     assert_array_equal(y_preds[0], y_preds[1])
 
 
-@requires_sklearn
 @pytest.mark.parametrize(
     "n_jobs, verbose", [(1, False), (2, False), (1, True), (2, "info")]
 )
@@ -280,7 +279,6 @@ def test_verbose_arg(capsys, n_jobs, verbose):
                 assert any(len(channel) > 0 for channel in (stdout, stderr))
 
 
-@requires_sklearn
 def test_cross_val_predict():
     """Test cross_val_predict with predict_proba."""
     from sklearn.linear_model import LinearRegression

--- a/mne/decoding/tests/test_ssd.py
+++ b/mne/decoding/tests/test_ssd.py
@@ -9,7 +9,6 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from mne import io
 from mne.time_frequency import psd_array_welch
 from mne.decoding.ssd import SSD
-from mne.utils import requires_sklearn
 from mne.filter import filter_data
 from mne import create_info
 from mne.decoding import CSP
@@ -296,9 +295,9 @@ def test_ssd_epoched_data():
     )
 
 
-@requires_sklearn
 def test_ssd_pipeline():
     """Test if SSD works in a pipeline."""
+    pytest.importorskip("sklearn")
     from sklearn.pipeline import Pipeline
 
     sf = 250

--- a/mne/decoding/tests/test_time_frequency.py
+++ b/mne/decoding/tests/test_time_frequency.py
@@ -7,13 +7,12 @@ import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
 
-from mne.utils import requires_sklearn
 from mne.decoding.time_frequency import TimeFrequency
 
 
-@requires_sklearn
 def test_timefrequency():
     """Test TimeFrequency."""
+    pytest.importorskip("sklearn")
     from sklearn.base import clone
 
     # Init

--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -25,7 +25,7 @@ from mne.decoding import (
     TemporalFilter,
 )
 from mne.defaults import DEFAULTS
-from mne.utils import requires_sklearn, check_version, use_log_level
+from mne.utils import check_version, use_log_level
 
 tmin, tmax = -0.2, 0.5
 event_id = dict(aud_l=1, vis_l=3)
@@ -217,9 +217,9 @@ def test_vectorizer():
     pytest.raises(ValueError, vect.inverse_transform, np.random.rand(102, 12, 12))
 
 
-@requires_sklearn
 def test_unsupervised_spatial_filter():
     """Test unsupervised spatial filter."""
+    pytest.importorskip("sklearn")
     from sklearn.decomposition import PCA
     from sklearn.kernel_ridge import KernelRidge
 

--- a/mne/gui/tests/test_coreg.py
+++ b/mne/gui/tests/test_coreg.py
@@ -15,7 +15,7 @@ from mne.datasets import testing
 from mne.io import read_info
 from mne.io.kit.tests import data_dir as kit_data_dir
 from mne.io.constants import FIFF
-from mne.utils import get_config, catch_logging, requires_version
+from mne.utils import get_config, catch_logging
 from mne.channels import DigMontage
 from mne.coreg import Coregistration
 from mne.viz import _3d
@@ -308,10 +308,10 @@ def test_fullscreen(renderer_interactive_pyvistaqt):
 
 
 @pytest.mark.slowtest
-@requires_version("sphinx_gallery")
 @testing.requires_testing_data
 def test_coreg_gui_scraper(tmp_path, renderer_interactive_pyvistaqt):
     """Test the scrapper for the coregistration GUI."""
+    pytest.importorskip("sphinx_gallery")
     from mne.gui import coregistration
 
     coreg = coregistration(

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -25,7 +25,6 @@ import pytest
 from mne import pick_types, Annotations
 from mne.annotations import events_from_annotations, read_annotations
 from mne.datasets import testing
-from mne.utils import requires_pandas
 from mne.io import read_raw_edf, read_raw_bdf, read_raw_fif, edf, read_raw_gdf
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.edf.edf import (
@@ -333,10 +332,10 @@ def test_no_data_channels():
         read_raw_edf(edf_annot_only)
 
 
-@requires_pandas
 @pytest.mark.parametrize("fname", [edf_path, bdf_path])
 def test_to_data_frame(fname):
     """Test EDF/BDF Raw Pandas exporter."""
+    pytest.importorskip("pandas")
     ext = fname.suffix
     if ext == ".edf":
         raw = read_raw_edf(fname, preload=True, verbose="error")

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -18,7 +18,7 @@ from mne.io import read_raw_egi, read_evokeds_mff, read_raw_fif
 from mne.io.constants import FIFF
 from mne.io.egi.egi import _combine_triggers
 from mne.io.tests.test_raw import _test_raw_reader
-from mne.utils import requires_version, object_diff
+from mne.utils import object_diff
 from mne.datasets.testing import data_path, requires_testing_data
 
 base_dir = Path(__file__).parent / "data"
@@ -364,7 +364,6 @@ def test_io_egi_crop_no_preload():
 
 
 @pytest.mark.filterwarnings("ignore::FutureWarning")
-@requires_version("mffpy", "0.5.7")
 @requires_testing_data
 @pytest.mark.parametrize(
     "idx, cond, tmax, signals, bads",
@@ -381,6 +380,7 @@ def test_io_egi_crop_no_preload():
 )
 def test_io_egi_evokeds_mff(idx, cond, tmax, signals, bads):
     """Test reading evoked MFF file."""
+    pytest.importorskip("mffpy", "0.5.7")
     # expected n channels
     n_eeg = 256
     n_ref = 1
@@ -444,10 +444,10 @@ def test_io_egi_evokeds_mff(idx, cond, tmax, signals, bads):
 
 
 @pytest.mark.filterwarnings("ignore::FutureWarning")
-@requires_version("mffpy", "0.5.7")
 @requires_testing_data
 def test_read_evokeds_mff_bad_input():
     """Test errors are thrown when reading invalid input file."""
+    pytest.importorskip("mffpy", "0.5.7")
     # Test file that is not an MFF
     with pytest.raises(ValueError) as exc_info:
         read_evokeds_mff(egi_fname)

--- a/mne/io/eyelink/tests/test_eyelink.py
+++ b/mne/io/eyelink/tests/test_eyelink.py
@@ -8,9 +8,10 @@ from mne.datasets.testing import data_path, requires_testing_data
 from mne.io import read_raw_eyelink
 from mne.io.tests.test_raw import _test_raw_reader
 from mne.io.constants import FIFF
+from mne.io.eyelink.eyelink import _adjust_times, _find_overlaps
 from mne.io.pick import _DATA_CH_TYPES_SPLIT
-from mne.utils import _check_pandas_installed, requires_pandas
 
+pd = pytest.importorskip("pandas")
 
 MAPPING = {
     "left": ["xpos_left", "ypos_left", "pupil_left"],
@@ -41,7 +42,6 @@ def test_eyetrack_not_data_ch():
 
 
 @requires_testing_data
-@requires_pandas
 @pytest.mark.parametrize(
     "fname, create_annotations, find_overlaps, apply_offsets",
     [
@@ -122,7 +122,6 @@ def test_eyelink(fname, create_annotations, find_overlaps, apply_offsets):
 
 
 @requires_testing_data
-@requires_pandas
 @pytest.mark.parametrize("fname_href", [(fname_href)])
 def test_radian(fname_href):
     """Test converting HREF position data to radians."""
@@ -142,7 +141,6 @@ def test_radian(fname_href):
 
 
 @requires_testing_data
-@requires_pandas
 @pytest.mark.parametrize("fname", [(fname)])
 def test_fill_times(fname):
     """Test use of pd.merge_asof in _fill_times.
@@ -153,8 +151,6 @@ def test_fill_times(fname):
     with np.arange don't result in the time columns not merging
     correctly - i.e. 1560687.0 and 1560687.000001 should merge.
     """
-    from ..eyelink import _adjust_times
-
     raw = read_raw_eyelink(fname, create_annotations=False)
     sfreq = raw.info["sfreq"]
     # just take first 1000 points for testing
@@ -169,7 +165,6 @@ def test_fill_times(fname):
     assert df_merged["pupil_left"].isna().sum() == nan_count  # i.e. 0
 
 
-@requires_pandas
 def test_find_overlaps():
     """Test finding overlapping occular events between the left and right eyes.
 
@@ -180,9 +175,6 @@ def test_find_overlaps():
     (4.20 - 4.14 = .06). The 5th and 6th rows will not be considered an
     overlap because they are both left eye events.
     """
-    from ..eyelink import _find_overlaps
-
-    pd = _check_pandas_installed()
     blink_df = pd.DataFrame(
         {
             "eye": ["L", "R", "L", "R", "L", "L"],
@@ -253,7 +245,6 @@ def _simulate_eye_tracking_data(in_file, out_file):
 
 
 @requires_testing_data
-@requires_pandas
 @pytest.mark.parametrize("fname", [fname_href])
 def test_multi_block_misc_channels(fname, tmp_path):
     """Test an eyelink file with multiple blocks and additional misc channels."""

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -36,7 +36,6 @@ from mne.utils import (
     _stamp_to_dt,
     object_diff,
     check_version,
-    requires_pandas,
     _import_h5io_funcs,
 )
 from mne.io.meas_info import _get_valid_units
@@ -844,10 +843,10 @@ def test_describe_print():
     )
 
 
-@requires_pandas
 @pytest.mark.slowtest
 def test_describe_df():
     """Test returned data frame of describe method."""
+    pytest.importorskip("pandas")
     fname = Path(__file__).parent / "data" / "test_raw.fif"
     raw = read_raw_fif(fname)
 

--- a/mne/io/tests/test_what.py
+++ b/mne/io/tests/test_what.py
@@ -11,16 +11,16 @@ from mne import what, create_info
 from mne.datasets import testing
 from mne.io import RawArray
 from mne.preprocessing import ICA
-from mne.utils import requires_sklearn, _record_warnings
+from mne.utils import _record_warnings
 
 data_path = testing.data_path(download=False)
 
 
 @pytest.mark.slowtest
-@requires_sklearn
 @testing.requires_testing_data
 def test_what(tmp_path, verbose_debug):
     """Test mne.what."""
+    pytest.importorskip("sklearn")
     # ICA
     ica = ICA(max_iter=1)
     raw = RawArray(np.random.RandomState(0).randn(3, 10), create_info(3, 1000.0, "eeg"))

--- a/mne/preprocessing/eyetracking/tests/test_pupillometry.py
+++ b/mne/preprocessing/eyetracking/tests/test_pupillometry.py
@@ -8,14 +8,12 @@ from mne import create_info
 from mne.datasets.testing import data_path, requires_testing_data
 from mne.io import read_raw_eyelink, RawArray
 from mne.preprocessing.eyetracking import interpolate_blinks
-from mne.utils import requires_pandas
-
 
 fname = data_path(download=False) / "eyetrack" / "test_eyelink.asc"
+pytest.importorskip("pandas")
 
 
 @requires_testing_data
-@requires_pandas
 @pytest.mark.parametrize(
     "buffer, match, cause_error, interpolate_gaze",
     [

--- a/mne/preprocessing/nirs/tests/test_beer_lambert_law.py
+++ b/mne/preprocessing/nirs/tests/test_beer_lambert_law.py
@@ -10,7 +10,7 @@ import numpy as np
 from mne.datasets.testing import data_path
 from mne.io import read_raw_nirx, BaseRaw, read_raw_fif
 from mne.preprocessing.nirs import optical_density, beer_lambert_law
-from mne.utils import _validate_type, requires_version
+from mne.utils import _validate_type
 from mne.datasets import testing
 
 testing_path = data_path(download=False)
@@ -71,12 +71,10 @@ def test_beer_lambert_unordered_errors():
         beer_lambert_law(raw_od)
 
 
-@requires_version("pymatreader")
 @testing.requires_testing_data
 def test_beer_lambert_v_matlab():
     """Compare MNE results to MATLAB toolbox."""
-    from pymatreader import read_mat
-
+    pymatreader = pytest.importorskip("pymatreader")
     raw = read_raw_nirx(fname_nirx_15_0)
     raw = optical_density(raw)
     raw = beer_lambert_law(raw, ppf=0.121)
@@ -85,7 +83,7 @@ def test_beer_lambert_v_matlab():
     matlab_fname = (
         testing_path / "NIRx" / "nirscout" / "validation" / "nirx_15_0_recording_bl.mat"
     )
-    matlab_data = read_mat(matlab_fname)
+    matlab_data = pymatreader.read_mat(matlab_fname)
 
     for idx in range(raw.get_data().shape[0]):
         mean_error = np.mean(matlab_data["data"][:, idx] - raw._data[idx])

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -49,7 +49,7 @@ from mne.io import read_raw_fif, Info, RawArray, read_raw_ctf, read_raw_eeglab
 from mne.io.pick import _DATA_CH_TYPES_SPLIT, get_channel_type_constants
 from mne.io.eeglab.eeglab import _check_load_mat
 from mne.rank import _compute_rank_int
-from mne.utils import catch_logging, requires_sklearn, _record_warnings, check_version
+from mne.utils import catch_logging, _record_warnings, check_version
 from mne.datasets import testing
 from mne.event import make_fixed_length_events
 
@@ -72,6 +72,7 @@ score_funcs_unsuited = ["pointbiserialr", "ansari"]
 pymatreader_mark = pytest.mark.skipif(
     not check_version("pymatreader"), reason="Requires pymatreader"
 )
+pytest.importorskip("sklearn")
 
 
 def ICA(*args, **kwargs):
@@ -83,13 +84,9 @@ def ICA(*args, **kwargs):
 
 def _skip_check_picard(method):
     if method == "picard":
-        try:
-            import picard  # noqa, analysis:ignore
-        except Exception as exp:
-            pytest.skip("Picard is not installed (%s)." % (exp,))
+        pytest.importorskip("picard")
 
 
-@requires_sklearn
 @pytest.mark.parametrize("method", ["fastica", "picard"])
 def test_ica_full_data_recovery(method):
     """Test recovery of full data when no source is rejected."""
@@ -160,11 +157,6 @@ def test_ica_full_data_recovery(method):
 @pytest.mark.parametrize("method", ["fastica", "picard"])
 def test_ica_simple(method):
     """Test that ICA recovers the unmixing matrix in a simple case."""
-    if method == "fastica":
-        try:
-            import sklearn  # noqa: F401
-        except ImportError:
-            pytest.skip("scikit-learn not installed")
     _skip_check_picard(method)
     n_components = 3
     n_samples = 1000
@@ -215,7 +207,6 @@ def test_warnings():
         ica.apply(epochs)
 
 
-@requires_sklearn
 @pytest.mark.parametrize("n_components", (None, 0.9999, 8, 9, 10))
 @pytest.mark.parametrize("n_pca_components", [8, 9, 0.9999, 10])
 @pytest.mark.filterwarnings("ignore:FastICA did not converge.*:UserWarning")
@@ -273,7 +264,6 @@ def test_ica_noop(n_components, n_pca_components, tmp_path):
     assert ica.reject_ == ica_new.reject_
 
 
-@requires_sklearn
 @pytest.mark.parametrize(
     "method, max_iter_default", [("fastica", 1000), ("infomax", 500), ("picard", 500)]
 )
@@ -292,7 +282,6 @@ def test_ica_max_iter_(method, max_iter_default):
         ICA(max_iter=1.0)
 
 
-@requires_sklearn
 @pytest.mark.parametrize("method", ["infomax", "fastica", "picard"])
 def test_ica_n_iter_(method, tmp_path):
     """Test that ICA.n_iter_ is set after fitting."""
@@ -325,7 +314,6 @@ def test_ica_n_iter_(method, tmp_path):
     assert_equal(ica.n_iter_, max_iter)
 
 
-@requires_sklearn
 @pytest.mark.parametrize("method", ["fastica", "picard"])
 def test_ica_rank_reduction(method):
     """Test recovery ICA rank reduction."""
@@ -418,7 +406,6 @@ def test_ica_projs(n_pca_components, proj, cov, meg, eeg):
         assert_allclose(apply_data, raw_data, **kwargs)
 
 
-@requires_sklearn
 @pytest.mark.parametrize("method", ["fastica", "picard"])
 def test_ica_reset(method):
     """Test ICA resetting."""
@@ -455,7 +442,6 @@ def test_ica_reset(method):
     assert ica.current_fit == "unfitted"
 
 
-@requires_sklearn
 @pytest.mark.parametrize("method", ["fastica", "picard"])
 @pytest.mark.parametrize("n_components", (2, 0.6))
 @pytest.mark.parametrize("noise_cov", (False, True))
@@ -640,7 +626,6 @@ def short_raw_epochs():
     return raw, epochs, epochs_eog
 
 
-@requires_sklearn
 @pytest.mark.slowtest
 @pytest.mark.parametrize("method", ["picard", "fastica"])
 def test_ica_additional(method, tmp_path, short_raw_epochs):
@@ -1021,9 +1006,9 @@ def test_ica_additional(method, tmp_path, short_raw_epochs):
     ica.fit(raw_, picks=picks, reject_by_annotation=True)
 
 
-@requires_sklearn
 def test_get_explained_variance_ratio(tmp_path, short_raw_epochs):
     """Test ICA.get_explained_variance_ratio()."""
+    pytest.importorskip("sklearn")
     raw, epochs, _ = short_raw_epochs
     ica = ICA(max_iter=1)
 
@@ -1093,7 +1078,6 @@ def test_get_explained_variance_ratio(tmp_path, short_raw_epochs):
         ica.get_explained_variance_ratio(raw, ch_type="foobar")
 
 
-@requires_sklearn
 @pytest.mark.slowtest
 @pytest.mark.parametrize(
     "method, cov",
@@ -1144,7 +1128,6 @@ def test_ica_cov(method, cov, tmp_path, short_raw_epochs):
         assert ica.exclude == [ica_raw.ch_names.index(e) for e in ica_raw.info["bads"]]
 
 
-@requires_sklearn
 @pytest.mark.parametrize("method", ["fastica", "picard"])
 def test_ica_reject_buffer(method):
     """Test ICA data raw buffer rejection."""
@@ -1171,7 +1154,6 @@ def test_ica_reject_buffer(method):
     _assert_ica_attributes(ica)
 
 
-@requires_sklearn
 @pytest.mark.parametrize("method", ["fastica", "picard"])
 def test_ica_twice(method):
     """Test running ICA twice."""
@@ -1196,7 +1178,6 @@ def test_ica_twice(method):
     assert_equal(ica1.n_components_, ica2.n_components_)
 
 
-@requires_sklearn
 @pytest.mark.parametrize("method", ["fastica", "picard", "infomax"])
 def test_fit_methods(method, tmp_path):
     """Test fit_params for ICA."""
@@ -1269,7 +1250,6 @@ def test_fit_params_epochs_vs_raw(param_name, param_val, tmp_path):
     _assert_ica_attributes(ica)
 
 
-@requires_sklearn
 @pytest.mark.parametrize("method", ["fastica", "picard"])
 @pytest.mark.parametrize("allow_ref_meg", [True, False])
 def test_bad_channels(method, allow_ref_meg):
@@ -1318,7 +1298,6 @@ def test_bad_channels(method, allow_ref_meg):
             ica.fit(inst, picks=[])
 
 
-@requires_sklearn
 @pytest.mark.parametrize("method", ["fastica", "picard"])
 def test_eog_channel(method):
     """Test that EOG channel is included when performing ICA."""
@@ -1363,7 +1342,6 @@ def test_eog_channel(method):
         assert not any("EOG" in ch for ch in ica.ch_names)
 
 
-@requires_sklearn
 @pytest.mark.parametrize("method", ["fastica", "picard"])
 def test_n_components_none(method, tmp_path):
     """Test n_components=None."""
@@ -1393,7 +1371,6 @@ def test_n_components_none(method, tmp_path):
 
 
 @pytest.mark.slowtest
-@requires_sklearn
 @testing.requires_testing_data
 def test_ica_ctf():
     """Test run ICA computation on ctf data with/without compensation."""
@@ -1441,7 +1418,6 @@ def test_ica_ctf():
             ica.get_sources(inst)
 
 
-@requires_sklearn
 @testing.requires_testing_data
 def test_ica_labels():
     """Test ICA labels."""
@@ -1523,7 +1499,6 @@ def test_ica_labels():
     assert "muscle" in ica.labels_
 
 
-@requires_sklearn
 @testing.requires_testing_data
 @pytest.mark.parametrize(
     "fname, grade",

--- a/mne/preprocessing/tests/test_infomax.py
+++ b/mne/preprocessing/tests/test_infomax.py
@@ -13,7 +13,8 @@ from scipy import stats
 from scipy import linalg
 
 from mne.preprocessing.infomax_ import infomax
-from mne.utils import requires_sklearn
+
+pytest.importorskip("sklearn")
 
 
 def center_and_norm(x, axis=-1):
@@ -32,7 +33,6 @@ def center_and_norm(x, axis=-1):
     x /= x.std(axis=0)
 
 
-@requires_sklearn
 def test_infomax_blowup():
     """Test the infomax algorithm blowup condition."""
     # scipy.stats uses the global RNG:
@@ -72,7 +72,6 @@ def test_infomax_blowup():
     assert_almost_equal(np.dot(s2_, s2) / n_samples, 1, decimal=2)
 
 
-@requires_sklearn
 def test_infomax_simple():
     """Test the infomax algorithm on very simple data."""
     rng = np.random.RandomState(0)
@@ -133,7 +132,6 @@ def test_infomax_weights_ini():
     assert_almost_equal(w2, weights)
 
 
-@requires_sklearn
 def test_non_square_infomax():
     """Test non-square infomax."""
     rng = np.random.RandomState(0)

--- a/mne/preprocessing/tests/test_regress.py
+++ b/mne/preprocessing/tests/test_regress.py
@@ -15,7 +15,6 @@ from mne.preprocessing import (
     EOGRegression,
     read_eog_regression,
 )
-from mne.utils import requires_version
 
 data_path = testing.data_path(download=False)
 raw_fname = data_path / "MEG" / "sample" / "sample_audvis_trunc_raw.fif"
@@ -122,10 +121,10 @@ def test_eog_regression():
     assert fig.axes[5].title.get_text() == "eeg/EOG 061"
 
 
-@requires_version("h5io")
 @testing.requires_testing_data
 def test_read_eog_regression(tmp_path):
     """Test saving and loading an EOGRegression object."""
+    pytest.importorskip("h5io")
     raw = read_raw_fif(raw_fname).pick(["eeg", "eog"])
     raw.load_data()
     model = EOGRegression().fit(raw)

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -21,7 +21,6 @@ from mne import (
 )
 from mne.decoding import Vectorizer
 from mne.io import read_raw_fif
-from mne.utils import requires_sklearn
 from mne.preprocessing.xdawn import Xdawn, _XdawnTransformer
 
 base_dir = Path(__file__).parent.parent.parent / "io" / "tests" / "data"
@@ -174,9 +173,9 @@ def test_xdawn_apply_transform():
     assert_array_almost_equal(denoise["cond2"]._data, denoise_shfl["cond2"]._data)
 
 
-@requires_sklearn
 def test_xdawn_regularization():
     """Test Xdawn with regularization."""
+    pytest.importorskip("sklearn")
     # Get data, this time MEG so we can test proper reg/ch type support
     raw = read_raw_fif(raw_fname, verbose=False, preload=True)
     events = read_events(event_name)
@@ -235,9 +234,9 @@ def test_xdawn_regularization():
     #     xd.fit(epochs)
 
 
-@requires_sklearn
 def test_XdawnTransformer():
     """Test _XdawnTransformer."""
+    pytest.importorskip("sklearn")
     # Get data
     raw, events, picks = _get_data()
     raw.del_proj()
@@ -346,9 +345,9 @@ def _simulate_erplike_mixed_data(n_epochs=100, n_channels=10):
     return epochs, mixing_mat
 
 
-@requires_sklearn
 def test_xdawn_decoding_performance():
     """Test decoding performance and extracted pattern on synthetic data."""
+    pytest.importorskip("sklearn")
     from sklearn.model_selection import KFold
     from sklearn.pipeline import make_pipeline
     from sklearn.linear_model import LogisticRegression

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -34,7 +34,7 @@ from mne.report.report import (
 from mne.io import read_raw_fif, read_info, RawArray
 from mne.datasets import testing
 from mne.report import Report, open_report, _ReportScraper, report
-from mne.utils import Bunch, requires_version, requires_sklearn
+from mne.utils import Bunch
 from mne.viz import plot_alignment
 from mne.io.write import DATE_NONE
 from mne.preprocessing import ICA
@@ -596,9 +596,9 @@ def test_validate_input():
     items_new, captions_new, comments_new = values
 
 
-@requires_version("h5io")
 def test_open_report(tmp_path):
     """Test the open_report function."""
+    pytest.importorskip("h5io")
     hdf5 = str(tmp_path / "report.h5")
 
     # Test creating a new report through the open_report function
@@ -810,10 +810,10 @@ def test_survive_pickle(tmp_path):
 
 
 @pytest.mark.slowtest  # ~30 s on Azure Windows
-@requires_sklearn
 @testing.requires_testing_data
 def test_manual_report_2d(tmp_path, invisible_fig):
     """Simulate user manually creating report by adding one file at a time."""
+    pytest.importorskip("sklearn")
     from sklearn.exceptions import ConvergenceWarning
 
     r = Report(title="My Report")

--- a/mne/simulation/metrics/tests/test_metrics.py
+++ b/mne/simulation/metrics/tests/test_metrics.py
@@ -12,7 +12,6 @@ from scipy.linalg import norm
 from mne import SourceEstimate
 from mne import read_source_spaces
 from mne.datasets import testing
-from mne.utils import requires_sklearn
 from mne.simulation import metrics
 from mne.simulation.metrics import (
     cosine_score,
@@ -77,9 +76,9 @@ def test_cosine_score():
 
 
 @testing.requires_testing_data
-@requires_sklearn
 def test_region_localization_error():
     """Test simulation metrics."""
+    pytest.importorskip("sklearn")
     src = read_source_spaces(src_fname)
     vert1 = [src[0]["vertno"][0:1], []]
     vert2 = [src[0]["vertno"][1:2], []]
@@ -99,9 +98,9 @@ def test_region_localization_error():
 
 
 @testing.requires_testing_data
-@requires_sklearn
 def test_precision_score():
     """Test simulation metrics."""
+    pytest.importorskip("sklearn")
     from sklearn.exceptions import UndefinedMetricWarning
 
     src = read_source_spaces(src_fname)
@@ -131,9 +130,9 @@ def test_precision_score():
 
 
 @testing.requires_testing_data
-@requires_sklearn
 def test_recall_score():
     """Test simulation metrics."""
+    pytest.importorskip("sklearn")
     src = read_source_spaces(src_fname)
     vert1 = [src[0]["vertno"][0:2], []]
     vert2 = [src[0]["vertno"][1:3], []]
@@ -160,9 +159,9 @@ def test_recall_score():
 
 
 @testing.requires_testing_data
-@requires_sklearn
 def test_f1_score():
     """Test simulation metrics."""
+    pytest.importorskip("sklearn")
     src = read_source_spaces(src_fname)
     vert1 = [src[0]["vertno"][0:2], []]
     vert2 = [src[0]["vertno"][1:3], []]
@@ -185,9 +184,9 @@ def test_f1_score():
 
 
 @testing.requires_testing_data
-@requires_sklearn
 def test_roc_auc_score():
     """Test simulation metrics."""
+    pytest.importorskip("sklearn")
     src = read_source_spaces(src_fname)
     vert1 = [src[0]["vertno"][0:4], []]
     vert2 = [src[0]["vertno"][0:4], []]

--- a/mne/stats/tests/test_adjacency.py
+++ b/mne/stats/tests/test_adjacency.py
@@ -7,10 +7,10 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from mne.stats import combine_adjacency
-from mne.utils import requires_sklearn
+
+pytest.importorskip("sklearn")
 
 
-@requires_sklearn
 @pytest.mark.parametrize(
     "shape",
     [

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -27,7 +27,7 @@ from mne.stats.cluster_level import (
     ttest_1samp_no_p,
     summarize_clusters_stc,
 )
-from mne.utils import catch_logging, requires_sklearn, _record_warnings
+from mne.utils import catch_logging, _record_warnings
 
 
 n_space = 50
@@ -330,9 +330,9 @@ def test_cluster_permutation_t_test(numba_conditional, stat_fun):
             )
 
 
-@requires_sklearn
 def test_cluster_permutation_with_adjacency(numba_conditional, monkeypatch):
     """Test cluster level permutations with adjacency matrix."""
+    pytest.importorskip("sklearn")
     from sklearn.feature_extraction.image import grid_to_graph
 
     condition1_1d, condition2_1d, condition1_2d, condition2_2d = _get_conditions()
@@ -566,9 +566,9 @@ def test_permutation_cluster_signs(threshold, kind):
     assert_array_equal(clu_signs, want_signs)
 
 
-@requires_sklearn
 def test_permutation_adjacency_equiv(numba_conditional):
     """Test cluster level permutations with and without adjacency."""
+    pytest.importorskip("sklearn")
     from sklearn.feature_extraction.image import grid_to_graph
 
     rng = np.random.RandomState(0)
@@ -645,9 +645,9 @@ def test_permutation_adjacency_equiv(numba_conditional):
         assert_array_equal(stat_map, this_stat_map)
 
 
-@requires_sklearn
 def test_spatio_temporal_cluster_adjacency(numba_conditional):
     """Test spatio-temporal cluster permutations."""
+    pytest.importorskip("sklearn")
     from sklearn.feature_extraction.image import grid_to_graph
 
     condition1_1d, condition2_1d, condition1_2d, condition2_2d = _get_conditions()

--- a/mne/stats/tests/test_regression.py
+++ b/mne/stats/tests/test_regression.py
@@ -15,7 +15,6 @@ from mne import read_source_estimate
 from mne.datasets import testing
 from mne.stats.regression import linear_regression, linear_regression_raw
 from mne.io import RawArray
-from mne.utils import requires_sklearn
 
 data_path = testing.data_path(download=False)
 stc_fname = data_path / "MEG" / "sample" / "sample_audvis_trunc-meg-lh.stc"
@@ -115,10 +114,10 @@ def test_continuous_regression_no_overlap():
     )
 
 
-@requires_sklearn
 @testing.requires_testing_data
 def test_continuous_regression_with_overlap():
     """Test regression with overlap correction."""
+    pytest.importorskip("sklearn")
     signal = np.zeros(100000)
     times = [1000, 2500, 3000, 5000, 5250, 7000, 7250, 8000]
     events = np.zeros((len(times), 3), int)

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -30,9 +30,7 @@ from mne import (
 )
 from mne import Epochs, Annotations
 from mne.utils import (
-    requires_version,
     catch_logging,
-    requires_pandas,
     assert_and_remove_boundary_annot,
     _raw_annot,
     _dt_to_stamp,
@@ -984,11 +982,10 @@ def test_io_annotation(dummy_annotation_file, tmp_path, fmt, ch_names):
     _assert_annotations_equal(annot, annot2)
 
 
-@requires_version("pandas")
 def test_broken_csv(tmp_path):
     """Test broken .csv that does not use timestamps."""
+    pytest.importorskip("pandas")
     content = "onset,duration,description\n" "1.,1.0,AA\n" "3.,2.425,BB"
-
     fname = tmp_path / "annotations_broken.csv"
     with open(fname, "w") as f:
         f.write(content)
@@ -1414,9 +1411,9 @@ def test_repr():
     assert r == "<Annotations | 0 segments>"
 
 
-@requires_pandas
 def test_annotation_to_data_frame():
     """Test annotation class to data frame conversion."""
+    pytest.importorskip("pandas")
     onset = np.arange(1, 10)
     durations = np.full_like(onset, [4, 5, 6, 4, 5, 6, 4, 5, 6])
     description = ["yy"] * onset.shape[0]

--- a/mne/tests/test_cov.py
+++ b/mne/tests/test_cov.py
@@ -50,7 +50,7 @@ from mne.io import read_raw_fif, RawArray, read_raw_ctf, read_info
 from mne.io.pick import _DATA_CH_TYPES_SPLIT, pick_info
 from mne.preprocessing import maxwell_filter
 from mne.rank import _compute_rank_int
-from mne.utils import requires_sklearn, catch_logging, assert_snr, _record_warnings
+from mne.utils import catch_logging, assert_snr, _record_warnings
 
 base_dir = Path(__file__).parent.parent / "io" / "tests" / "data"
 cov_fname = base_dir / "test-cov.fif"
@@ -373,9 +373,9 @@ def test_cov_estimation_on_raw(method, tmp_path):
 
 
 @pytest.mark.slowtest
-@requires_sklearn
 def test_cov_estimation_on_raw_reg():
     """Test estimation from raw with regularization."""
+    pytest.importorskip("sklearn")
     raw = read_raw_fif(raw_fname, preload=True)
     with raw.info._unlock():
         raw.info["sfreq"] /= 10.0
@@ -587,9 +587,9 @@ def test_regularized_covariance():
     assert_allclose(data, evoked.data, atol=1e-20)
 
 
-@requires_sklearn
 def test_auto_low_rank():
     """Test probabilistic low rank estimators."""
+    pytest.importorskip("sklearn")
     n_samples, n_features, rank = 400, 10, 5
     sigma = 0.1
 
@@ -629,9 +629,9 @@ def test_auto_low_rank():
 
 @pytest.mark.slowtest
 @pytest.mark.parametrize("rank", ("full", None, "info"))
-@requires_sklearn
 def test_compute_covariance_auto_reg(rank):
     """Test automated regularization."""
+    pytest.importorskip("sklearn")
     raw = read_raw_fif(raw_fname, preload=True)
     raw.resample(100, npad="auto")  # much faster estimation
     events = find_events(raw, stim_channel="STI 014")
@@ -766,10 +766,10 @@ def raw_epochs_events():
     return (raw, epochs, events)
 
 
-@requires_sklearn
 @pytest.mark.parametrize("rank", (None, "full", "info"))
 def test_low_rank_methods(rank, raw_epochs_events):
     """Test low-rank covariance matrix estimation."""
+    pytest.importorskip("sklearn")
     epochs = raw_epochs_events[1]
     sss_proj_rank = 139  # 80 MEG + 60 EEG - 1 proj
     n_ch = 366
@@ -800,9 +800,9 @@ def test_low_rank_methods(rank, raw_epochs_events):
         assert these_bounds[0] < cov["loglik"] < these_bounds[1], (rank, method)
 
 
-@requires_sklearn
 def test_low_rank_cov(raw_epochs_events):
     """Test additional properties of low rank computations."""
+    pytest.importorskip("sklearn")
     raw, epochs, events = raw_epochs_events
     sss_proj_rank = 139  # 80 MEG + 60 EEG - 1 proj
     n_ch = 366
@@ -876,9 +876,9 @@ def test_low_rank_cov(raw_epochs_events):
 
 
 @testing.requires_testing_data
-@requires_sklearn
 def test_cov_ctf():
     """Test basic cov computation on ctf data with/without compensation."""
+    pytest.importorskip("sklearn")
     raw = read_raw_ctf(ctf_fname).crop(0.0, 2.0).load_data()
     events = make_fixed_length_events(raw, 99999)
     assert len(events) == 2

--- a/mne/tests/test_docstring_parameters.py
+++ b/mne/tests/test_docstring_parameters.py
@@ -11,7 +11,7 @@ import re
 import pytest
 
 import mne
-from mne.utils import requires_numpydoc, _pl, _record_warnings
+from mne.utils import _pl, _record_warnings
 
 public_modules = [
     # the list of modules users need to access for all functionality
@@ -164,11 +164,9 @@ def check_parameters_match(func, cls=None):
 
 
 @pytest.mark.slowtest
-@requires_numpydoc
 def test_docstring_parameters():
     """Test module docstring formatting."""
-    from numpydoc import docscrape
-
+    npd = pytest.importorskip("numpydoc")
     incorrect = []
     for name in public_modules:
         # Assert that by default we import all public names with `import mne`
@@ -184,7 +182,7 @@ def test_docstring_parameters():
             if cname.startswith("_"):
                 continue
             incorrect += check_parameters_match(cls)
-            cdoc = docscrape.ClassDoc(cls)
+            cdoc = npd.docscrape.ClassDoc(cls)
             for method_name in cdoc.methods:
                 method = getattr(cls, method_name)
                 incorrect += check_parameters_match(method, cls=cls)

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -33,7 +33,7 @@ from mne import (
 from mne.evoked import _get_peak, Evoked, EvokedArray
 from mne.io import read_raw_fif
 from mne.io.constants import FIFF
-from mne.utils import requires_pandas, grand_average
+from mne.utils import grand_average
 
 base_dir = Path(__file__).parent.parent / "io" / "tests" / "data"
 fname = base_dir / "test-ave.fif"
@@ -439,9 +439,9 @@ def test_evoked_detrend():
     assert_allclose(ave.data[picks], ave_normal.data[picks], rtol=1e-8, atol=1e-16)
 
 
-@requires_pandas
 def test_to_data_frame():
     """Test evoked Pandas exporter."""
+    pytest.importorskip("pandas")
     ave = read_evokeds(fname, 0)
     # test index checking
     with pytest.raises(ValueError, match="options. Valid index options are"):
@@ -470,16 +470,14 @@ def test_to_data_frame():
     assert_array_equal(df.values[:, 2], ave.data[2] * 1e15)
 
 
-@requires_pandas
 @pytest.mark.parametrize("time_format", (None, "ms", "timedelta"))
 def test_to_data_frame_time_format(time_format):
     """Test time conversion in evoked Pandas exporter."""
-    from pandas import Timedelta
-
+    pd = pytest.importorskip("pandas")
     ave = read_evokeds(fname, 0)
     # test time_format
     df = ave.to_data_frame(time_format=time_format)
-    dtypes = {None: np.float64, "ms": np.int64, "timedelta": Timedelta}
+    dtypes = {None: np.float64, "ms": np.int64, "timedelta": pd.Timedelta}
     assert isinstance(df["time"].iloc[0], dtypes[time_format])
 
 

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -50,7 +50,7 @@ from mne.label import (
 from mne.source_space import SourceSpaces
 from mne.source_estimate import mesh_edges
 from mne.surface import _mesh_borders
-from mne.utils import requires_sklearn, get_subjects_dir, _record_warnings
+from mne.utils import get_subjects_dir, _record_warnings
 
 
 data_path = testing.data_path(download=False)
@@ -739,11 +739,11 @@ def test_write_labels_to_annot(tmp_path):
     pytest.raises(ValueError, write_labels_to_annot, labels4, annot_fname=fnames[0])
 
 
-@requires_sklearn
 @testing.requires_testing_data
 def test_split_label():
     """Test splitting labels."""
     pytest.importorskip("nibabel")
+    pytest.importorskip("sklearn")
     aparc = read_labels_from_annot(
         "fsaverage", "aparc", "lh", regexp="lingual", subjects_dir=subjects_dir
     )
@@ -839,10 +839,10 @@ def test_split_label():
 
 @pytest.mark.slowtest
 @testing.requires_testing_data
-@requires_sklearn
 def test_stc_to_label():
     """Test stc_to_label."""
     pytest.importorskip("nibabel")
+    pytest.importorskip("sklearn")
     src = read_source_spaces(fwd_fname)
     src_bad = read_source_spaces(src_bad_fname)
     stc = read_source_estimate(stc_fname, "sample")

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -35,7 +35,7 @@ from mne._freesurfer import _get_mri_info_data, _get_atlas_values
 from mne.minimum_norm import apply_inverse, read_inverse_operator, make_inverse_operator
 from mne.source_space import _add_interpolator, _grid_interp
 from mne.transforms import quat_to_rot
-from mne.utils import check_version, requires_version, catch_logging, _record_warnings
+from mne.utils import check_version, catch_logging, _record_warnings
 
 # Setup paths
 
@@ -297,10 +297,10 @@ def assert_power_preserved(orig, new, limits=(1.0, 1.05)):
         assert min_ < power_ratio < max_, f"Power ratio {kind} = {power_ratio}"
 
 
-@requires_version("h5io")
 @testing.requires_testing_data
 def test_surface_vector_source_morph(tmp_path):
     """Test surface and vector source estimate morph."""
+    pytest.importorskip("h5io")
     inverse_operator_surf = read_inverse_operator(fname_inv_surf)
 
     stc_surf = read_source_estimate(fname_smorph, subject="sample")
@@ -354,12 +354,12 @@ def test_surface_vector_source_morph(tmp_path):
         source_morph_surf.apply(stc_vol)
 
 
-@requires_version("h5io")
 @pytest.mark.slowtest
 @testing.requires_testing_data
 def test_volume_source_morph_basic(tmp_path):
     """Test volume source estimate morph, special cases and exceptions."""
     nib = pytest.importorskip("nibabel")
+    pytest.importorskip("h5io")
     pytest.importorskip("dipy")
     inverse_operator_vol = read_inverse_operator(fname_inv_vol)
     stc_vol = read_source_estimate(fname_vol_w, "sample")
@@ -551,7 +551,6 @@ def test_volume_source_morph_basic(tmp_path):
     assert_allclose(img_vol, img_vol_2)
 
 
-@requires_version("h5io")
 @pytest.mark.slowtest
 @testing.requires_testing_data
 @pytest.mark.parametrize(
@@ -569,6 +568,7 @@ def test_volume_source_morph_round_trip(
 ):
     """Test volume source estimate morph round-trips well."""
     nib = pytest.importorskip("nibabel")
+    pytest.importorskip("h5io")
     pytest.importorskip("dipy")
     from nibabel.processing import resample_from_to
 

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -75,10 +75,7 @@ from mne.minimum_norm import (
 )
 from mne.label import read_labels_from_annot, label_sign_flip
 from mne.utils import (
-    requires_pandas,
-    requires_sklearn,
     catch_logging,
-    requires_version,
     _record_warnings,
 )
 from mne.io import read_raw_fif
@@ -183,10 +180,9 @@ def test_spatial_inter_hemi_adjacency():
 
 @pytest.mark.slowtest
 @testing.requires_testing_data
-@requires_version("h5io")
 def test_volume_stc(tmp_path):
     """Test volume STCs."""
-    from h5io import write_hdf5
+    h5io = pytest.importorskip("h5io")
 
     N = 100
     data = np.arange(N)[:, np.newaxis]
@@ -213,7 +209,7 @@ def test_volume_stc(tmp_path):
             else:
                 # Pass stc.vertices[0], an ndarray, to ensure support for
                 # the way we used to write volume STCs
-                write_hdf5(
+                h5io.write_hdf5(
                     str(fname_temp),
                     dict(
                         vertices=stc.vertices[0],
@@ -470,11 +466,11 @@ def test_io_stc(tmp_path):
         stc2.save(tmp_path / "complex.stc")
 
 
-@requires_version("h5io")
 @pytest.mark.parametrize("is_complex", (True, False))
 @pytest.mark.parametrize("vector", (True, False))
 def test_io_stc_h5(tmp_path, is_complex, vector):
     """Test IO for STC files using HDF5."""
+    pytest.importorskip("h5io")
     if vector:
         stc = _fake_vec_stc(is_complex=is_complex)
     else:
@@ -1087,9 +1083,9 @@ def test_transform():
     assert_array_equal(stc.data, data_t)
 
 
-@requires_sklearn
 def test_spatio_temporal_tris_adjacency():
     """Test spatio-temporal adjacency from triangles."""
+    pytest.importorskip("sklearn")
     tris = np.array([[0, 1, 2], [3, 4, 5]])
     adjacency = spatio_temporal_tris_adjacency(tris, 2)
     x = [1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
@@ -1139,9 +1135,9 @@ def test_spatio_temporal_src_adjacency():
     assert_equal(grade_to_tris(5).shape, [40960, 3])
 
 
-@requires_pandas
 def test_to_data_frame():
     """Test stc Pandas exporter."""
+    pytest.importorskip("pandas")
     n_vert, n_times = 10, 5
     vertices = [np.arange(n_vert, dtype=np.int64), np.empty(0, dtype=np.int64)]
     data = rng.randn(n_vert, n_times)
@@ -1162,10 +1158,10 @@ def test_to_data_frame():
         assert set(expected) == set(df_long.columns)
 
 
-@requires_pandas
 @pytest.mark.parametrize("index", ("time", ["time", "subject"], None))
 def test_to_data_frame_index(index):
     """Test index creation in stc Pandas exporter."""
+    pytest.importorskip("pandas")
     n_vert, n_times = 10, 5
     vertices = [np.arange(n_vert, dtype=np.int64), np.empty(0, dtype=np.int64)]
     data = rng.randn(n_vert, n_times)
@@ -1235,10 +1231,10 @@ def test_get_peak(kind, vector, n_times):
             stc.get_peak(hemi="rh")
 
 
-@requires_version("h5io")
 @testing.requires_testing_data
 def test_mixed_stc(tmp_path):
     """Test source estimate from mixed source space."""
+    pytest.importorskip("h5io")
     N = 90  # number of sources
     T = 2  # number of time points
     S = 3  # number of source spaces
@@ -1262,7 +1258,6 @@ def test_mixed_stc(tmp_path):
     assert isinstance(stc_out, MixedSourceEstimate)
 
 
-@requires_version("h5io")
 @pytest.mark.parametrize(
     "klass, kind",
     [
@@ -1275,6 +1270,7 @@ def test_mixed_stc(tmp_path):
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
 def test_vec_stc_basic(tmp_path, klass, kind, dtype):
     """Test (vol)vector source estimate."""
+    pytest.importorskip("h5io")
     nn = np.array(
         [
             [1, 0, 0],
@@ -1532,10 +1528,10 @@ def test_epochs_vector_inverse():
     assert_allclose(stc_epo.data, stc_evo.data, rtol=1e-9, atol=0)
 
 
-@requires_sklearn
 @testing.requires_testing_data
 def test_vol_adjacency():
     """Test volume adjacency."""
+    pytest.importorskip("sklearn")
     vol = read_source_spaces(fname_vsrc)
 
     pytest.raises(ValueError, spatial_src_adjacency, vol, dist=1.0)
@@ -1578,11 +1574,11 @@ def test_spatial_src_adjacency():
     assert_array_equal(con_lh.indices, con_lh_tris.indices)
 
 
-@requires_sklearn
 @testing.requires_testing_data
 def test_vol_mask():
     """Test extraction of volume mask."""
     pytest.importorskip("nibabel")
+    pytest.importorskip("sklearn")
     src = read_source_spaces(fname_vsrc)
     mask = _get_vol_mask(src)
     # Let's use an alternative way that should be equivalent
@@ -1712,10 +1708,10 @@ def test_stc_near_sensors(tmp_path):
     assert "4157 volume vertices" in log
 
 
-@requires_version("pymatreader")
 @testing.requires_testing_data
 def test_stc_near_sensors_picks():
     """Test using picks with stc_near_sensors."""
+    pytest.importorskip("pymatreader")
     info = mne.io.read_raw_nirx(fname_nirx).info
     evoked = mne.EvokedArray(np.ones((len(info["ch_names"]), 1)), info)
     src = mne.read_source_spaces(fname_src_fs)
@@ -1757,7 +1753,7 @@ def _make_morph_map_hemi_same(subject_from, subject_to, subjects_dir, reg_from, 
 @pytest.mark.parametrize(
     "kind",
     (
-        pytest.param("volume", marks=[requires_version("dipy"), pytest.mark.slowtest]),
+        pytest.param("volume", marks=[pytest.mark.slowtest]),
         "surface",
     ),
 )
@@ -1765,6 +1761,8 @@ def _make_morph_map_hemi_same(subject_from, subject_to, subjects_dir, reg_from, 
 def test_scale_morph_labels(kind, scale, monkeypatch, tmp_path):
     """Test label extraction, morphing, and MRI scaling relationships."""
     pytest.importorskip("nibabel")
+    if kind == "volume":
+        pytest.importorskip("dipy")
     subject_from = "sample"
     subject_to = "small"
     testing_dir = subjects_dir / subject_from

--- a/mne/time_frequency/tests/test_ar.py
+++ b/mne/time_frequency/tests/test_ar.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
+import pytest
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_allclose
 from scipy.signal import lfilter
 
 from mne import io
 from mne.time_frequency.ar import _yule_walker, fit_iir_model_raw
-from mne.utils import requires_version
 
 
 raw_fname = (
@@ -14,11 +14,10 @@ raw_fname = (
 )
 
 
-# 0.7 attempts to import nonexistent TimeSeries from Pandas 0.20
-@requires_version("patsy", "0.4")
-@requires_version("statsmodels", "0.8")
 def test_yule_walker():
     """Test Yule-Walker against statsmodels."""
+    pytest.importorskip("patsy", "0.4")
+    pytest.importorskip("statsmodels", "0.8")
     from statsmodels.regression.linear_model import yule_walker as sm_yw
 
     d = np.random.randn(100)

--- a/mne/time_frequency/tests/test_csd.py
+++ b/mne/time_frequency/tests/test_csd.py
@@ -8,7 +8,7 @@ from itertools import product
 
 import mne
 from mne.channels import equalize_channels
-from mne.utils import sum_squared, requires_version
+from mne.utils import sum_squared
 from mne.time_frequency import (
     csd_fourier,
     csd_multitaper,
@@ -240,9 +240,9 @@ def test_csd_get_data():
     raises(IndexError, csd.mean().get_data, index=15)
 
 
-@requires_version("h5io")
 def test_csd_save(tmp_path):
     """Test saving and loading a CrossSpectralDensity."""
+    pytest.importorskip("h5io")
     csd = _make_csd(add_proj=True)
     fname = op.join(str(tmp_path), "csd.h5")
     csd.save(fname)

--- a/mne/time_frequency/tests/test_multitaper.py
+++ b/mne/time_frequency/tests/test_multitaper.py
@@ -4,13 +4,12 @@ from numpy.testing import assert_array_almost_equal
 
 from mne.time_frequency import psd_array_multitaper
 from mne.time_frequency.multitaper import dpss_windows
-from mne.utils import requires_nitime, _record_warnings
+from mne.utils import _record_warnings
 
 
-@requires_nitime
 def test_dpss_windows():
     """Test computation of DPSS windows."""
-    import nitime as ni
+    ni = pytest.importorskip("nitime")
 
     N = 1000
     half_nbw = 4
@@ -31,12 +30,11 @@ def test_dpss_windows():
     assert_array_almost_equal(eigs, eigs_ni)
 
 
-@requires_nitime
 @pytest.mark.parametrize("n_times", (100, 101))
 @pytest.mark.parametrize("adaptive, n_jobs", [(False, 1), (True, 1), (True, 2)])
 def test_multitaper_psd(n_times, adaptive, n_jobs):
     """Test multi-taper PSD computation."""
-    import nitime as ni
+    ni = pytest.importorskip("nitime")
 
     n_channels = 5
     data = np.random.default_rng(0).random((n_channels, n_times))

--- a/mne/utils/_testing.py
+++ b/mne/utils/_testing.py
@@ -54,18 +54,7 @@ class _TempDir(str):
         rmtree(self._path, ignore_errors=True)
 
 
-def requires_version(library, min_version="0.0"):
-    """Check for a library version."""
-    import pytest
-
-    reason = f"Requires {library}"
-    if min_version != "0.0":
-        reason += f" version >= {min_version}"
-    return pytest.mark.skipif(not check_version(library, min_version), reason=reason)
-
-
-def requires_module(function, name, call=None):
-    """Skip a test if package is not available (decorator)."""
+def _requires_module(function, name, *, call):
     import pytest
 
     call = ("import %s" % name) if call is None else call
@@ -91,16 +80,7 @@ if not has_freesurfer():
     raise ImportError
 """
 
-_n2ft_call = """
-if 'NEUROMAG2FT_ROOT' not in os.environ:
-    raise ImportError
-"""
-
-requires_pandas = partial(requires_module, name="pandas")
-requires_pylsl = partial(requires_module, name="pylsl")
-requires_sklearn = partial(requires_module, name="sklearn")
-requires_mne = partial(requires_module, name="MNE-C", call=_mne_call)
-requires_mne_qt_browser = partial(requires_module, name="mne_qt_browser")
+requires_mne = partial(_requires_module, name="MNE-C", call=_mne_call)
 
 
 def requires_mne_mark():
@@ -130,29 +110,64 @@ run_subprocess([%r, '--version'])
 """ % (
             arg,
         )
-        return partial(requires_module, name="Freesurfer (%s)" % (arg,), call=call)
+        return partial(_requires_module, name="Freesurfer (%s)" % (arg,), call=call)
     else:
         # Calling directly as @requires_freesurfer: return decorated function
         # and just check env var existence
-        return requires_module(arg, name="Freesurfer", call=_fs_call)
+        return _requires_module(arg, name="Freesurfer", call=_fs_call)
 
-
-requires_neuromag2ft = partial(requires_module, name="neuromag2ft", call=_n2ft_call)
 
 requires_good_network = partial(
-    requires_module,
+    _requires_module,
     name="good network connection",
     call='if int(os.environ.get("MNE_SKIP_NETWORK_TESTS", 0)):\n'
     "    raise ImportError",
 )
+
+
+# %%
+# Deprecated
+def requires_version(library, min_version="0.0"):
+    """Check for a library version."""
+    warn(
+        f"requires_version({repr(library)}, min_version={repr(min_version)}) "
+        "is deprecated and will be removed in 1.6, use pytest.importorskip("
+        f"{repr(library)}, minversion={repr(min_version)}) instead",
+        FutureWarning,
+    )
+    import pytest
+
+    reason = f"Requires {library}"
+    if min_version != "0.0":
+        reason += f" version >= {min_version}"
+    return pytest.mark.skipif(not check_version(library, min_version), reason=reason)
+
+
+def requires_module(function, name, call=None):
+    """Skip a test if package is not available (decorator)."""
+    msg = f"@requires_module({repr(name)}) is deprecated and will be removed " f"in 1.6"
+    if call is None:
+        msg += f" use pytest.importorskip({repr(name)}) instead"
+    else:
+        msg += f" use pytest.mark.skipif instead with the condition:\n\n{call}\n"
+    warn(msg, FutureWarning)
+    return _requires_module(function, name, call=call)
+
+
+_n2ft_call = """
+if 'NEUROMAG2FT_ROOT' not in os.environ:
+    raise ImportError
+"""
+requires_pandas = partial(requires_module, name="pandas")
+requires_pylsl = partial(requires_module, name="pylsl")
+requires_sklearn = partial(requires_module, name="sklearn")
+requires_mne_qt_browser = partial(requires_module, name="mne_qt_browser")
+requires_neuromag2ft = partial(requires_module, name="neuromag2ft", call=_n2ft_call)
 requires_nitime = partial(requires_module, name="nitime")
-# just keep this in case downstream packages need it (no coverage hit here)
 requires_h5py = partial(requires_module, name="h5py")
+requires_numpydoc = partial(requires_version, "numpydoc", "1.0")
 
-
-def requires_numpydoc(func):
-    """Decorate tests that need numpydoc."""
-    return requires_version("numpydoc", "1.0")(func)  # validate needs 1.0
+# %% End deprecated
 
 
 def run_command_if_main():

--- a/mne/utils/tests/test_config.py
+++ b/mne/utils/tests/test_config.py
@@ -12,7 +12,6 @@ from mne.utils import (
     sys_info,
     ClosingStringIO,
     get_subjects_dir,
-    requires_mne_qt_browser,
 )
 
 
@@ -105,9 +104,9 @@ def test_sys_info():
         assert "Platform             Linux" in out
 
 
-@requires_mne_qt_browser
 def test_sys_info_qt_browser():
     """Test if mne_qt_browser is correctly detected."""
+    pytest.importorskip("mne_qt_browser")
     out = ClosingStringIO()
     sys_info(fid=out)
     out = out.getvalue()

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -31,7 +31,6 @@ from mne.utils import (
     _apply_scaling_array,
     _undo_scaling_array,
     _PCA,
-    requires_sklearn,
     _array_equal_nan,
     _julian_to_cal,
     _cal_to_julian,
@@ -433,11 +432,11 @@ def test_hash():
     assert object_hash(np.bool_(True)) != 0
 
 
-@requires_sklearn
 @pytest.mark.parametrize("n_components", (None, 0.9999, 8, "mle"))
 @pytest.mark.parametrize("whiten", (True, False))
 def test_pca(n_components, whiten):
     """Test PCA equivalence."""
+    pytest.importorskip("sklearn")
     from sklearn.decomposition import PCA
 
     n_samples, n_dim = 1000, 10

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -35,7 +35,7 @@ from mne.minimum_norm import apply_inverse, make_inverse_operator
 from mne.source_space import read_source_spaces, setup_volume_source_space
 from mne.datasets import testing
 from mne.io import read_info
-from mne.utils import check_version, requires_version
+from mne.utils import check_version
 from mne.label import read_label
 from mne.viz._brain import Brain, _LinkViewer, _BrainScraper, _LayeredMesh
 from mne.viz._brain.colormap import calculate_lut
@@ -1028,10 +1028,10 @@ something
 # https://github.com/mne-tools/mne-python/pull/10935
 # for some reason there is a dependency issue with ipympl even using pyvista
 @pytest.mark.skipif(sys.platform == "win32", reason="ipympl issue on Windows")
-@requires_version("sphinx_gallery")
 @testing.requires_testing_data
 def test_brain_scraper(renderer_interactive_pyvistaqt, brain_gc, tmp_path):
     """Test a simple scraping example."""
+    pytest.importorskip("sphinx_gallery")
     stc = read_source_estimate(fname_stc, subject="sample")
     size = (600, 300)
     brain = stc.plot(

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -21,7 +21,7 @@ from mne import (
 )
 from mne.io import read_raw_fif
 from mne.preprocessing import ICA, create_ecg_epochs, create_eog_epochs
-from mne.utils import requires_sklearn, catch_logging, _record_warnings
+from mne.utils import catch_logging, _record_warnings
 from mne.viz.ica import _create_properties_layout, plot_ica_properties
 from mne.viz.utils import _fake_click, _fake_keypress
 
@@ -32,6 +32,8 @@ cov_fname = base_dir / "test-cov.fif"
 event_name = base_dir / "test-eve.fif"
 event_id, tmin, tmax = 1, -0.1, 0.2
 raw_ctf_fname = base_dir / "test_ctf_raw.fif"
+
+pytest.importorskip("sklearn")
 
 
 def _get_raw(preload=False):
@@ -59,7 +61,6 @@ def _get_epochs():
     return epochs
 
 
-@requires_sklearn
 def test_plot_ica_components():
     """Test plotting of ICA solutions."""
     res = 8
@@ -138,7 +139,6 @@ def test_plot_ica_components():
 
 
 @pytest.mark.slowtest
-@requires_sklearn
 def test_plot_ica_properties():
     """Test plotting of ICA properties."""
     raw = _get_raw(preload=True).crop(0, 5)
@@ -262,7 +262,6 @@ def test_plot_ica_properties():
     ica.plot_properties(raw_annot, reject_by_annotation=False, **topoargs)
 
 
-@requires_sklearn
 def test_plot_ica_sources(raw_orig, browser_backend, monkeypatch):
     """Test plotting of ICA panel."""
     raw = raw_orig.copy().crop(0, 1)
@@ -387,7 +386,6 @@ def test_plot_ica_sources(raw_orig, browser_backend, monkeypatch):
 
 
 @pytest.mark.slowtest
-@requires_sklearn
 def test_plot_ica_overlay():
     """Test plotting of ICA cleaning."""
     raw = _get_raw(preload=True)
@@ -436,7 +434,6 @@ def _get_geometry(fig):
         return fig.axes[0].get_geometry()  # pragma: no cover
 
 
-@requires_sklearn
 def test_plot_ica_scores():
     """Test plotting of ICA scores."""
     raw = _get_raw()
@@ -475,7 +472,6 @@ def test_plot_ica_scores():
         ica.plot_scores([0.2])
 
 
-@requires_sklearn
 def test_plot_instance_components(browser_backend):
     """Test plotting of components as instances of raw and epochs."""
     raw = _get_raw()

--- a/mne/viz/tests/test_scraper.py
+++ b/mne/viz/tests/test_scraper.py
@@ -5,13 +5,12 @@
 import os.path as op
 import pytest
 import mne
-from mne.utils import requires_version
 
 
 @pytest.mark.pgtest
-@requires_version("sphinx_gallery")
 def test_qt_scraper(raw, pg_backend, tmp_path):
     """Test sphinx-gallery scraping of the browser."""
+    pytest.importorskip("sphinx_gallery")
     # make sure there is only one to scrape from old tests
     fig = raw.plot(group_by="selection")
     (tmp_path / "_images").mkdir()

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -54,7 +54,6 @@ from mne.viz.topomap import (
     plot_ch_adjacency,
 )
 from mne.viz.utils import _find_peaks, _fake_click, _fake_keypress, _fake_scroll
-from mne.utils import requires_sklearn
 
 from mne.viz.tests.test_raw import _proj_status
 
@@ -257,7 +256,7 @@ def test_plot_evoked_topomap_units(evoked, units, scalings, expected_unit):
     #     cbar = cbar[0]
     #     assert cbar.get_title() == expected_unit
     # ...but not all matplotlib versions support it, and we can't use
-    # @requires_version because it's hard figure out exactly which MPL version
+    # check_version because it's hard figure out exactly which MPL version
     # is the cutoff since it relies on a private attribute. Based on some
     # basic testing it's at least matplotlib version >= 3.5.
     # So for now we just do this:
@@ -735,9 +734,9 @@ def test_plot_topomap_nirs_overlap(fnirs_epochs):
     plt.close("all")
 
 
-@requires_sklearn
 def test_plot_topomap_nirs_ica(fnirs_epochs):
     """Test plotting nirs ica topomap."""
+    pytest.importorskip("sklearn")
     from mne.preprocessing import ICA
 
     fnirs_epochs = fnirs_epochs.load_data().pick(picks="hbo")


### PR DESCRIPTION
For a while I've been bothered by our use of custom skipping decorators in tests when `pytest.importorskip` exists. Not only is it a more general/standard mechanism, but it has some nice benefits like being able to be used a test-module level. This deprecates all `requires_*` decorators that could be readily replaced by `pytest.importorskip` calls, plus a couple that should just live in `mne-realtime` anyway.