### PR TITLE
Fix closing topographic map created from PSD/Evoked plot

### DIFF
--- a/doc/changes/latest.inc
+++ b/doc/changes/latest.inc
@@ -71,6 +71,7 @@ Bugs
 - Fix bug where annotation FIF files lacked an end block tag (:gh:`11800` by `Eric Larson`_)
 - Fix display of :class:`~mne.Annotations` in `mne.preprocessing.ICA.plot_sources` when the ``raw`` has ``raw.first_samp != 0`` and doesn't have a measurement date (:gh:`11766` by `Mathieu Scheltienne`_)
 - Fix bug in read_raw_eyelink, where STATUS information of samples was always assumed to be in the file. Performance and memory improvements were also made. (:gh:`11823` by `Scott Huberty`_)
+- Fix closing of a topographic map created from an interactive drag on an Evoked or PSD plot (:gh:`11862` by `Mathieu Scheltienne`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -226,8 +226,8 @@ def _line_plot_onselect(
 def _topo_closed(events, ax, lines, fill):
     """Remove lines from evoked plot as topomap is closed."""
     for line in lines:
-        ax.lines.remove(line)
-    ax.patches.remove(fill)
+        line.remove()
+    fill.remove()
     ax.get_figure().canvas.draw()
 
 


### PR DESCRIPTION
On `main`, creating a topographic map by drag (SpanSelector) on a PSD plot, and then closing the topographic map yields:

```
Traceback (most recent call last):
  File "/home/scheltie/pyvenv/mscheltienne/mne-python/lib/python3.10/site-packages/matplotlib/cbook/__init__.py", line 309, in process
    func(*args, **kwargs)
  File "/home/scheltie/git/mscheltienne/mne-python/mne/viz/evoked.py", line 229, in _topo_closed
    ax.lines.remove(line)
AttributeError: 'ArtistList' object has no attribute 'remove'
```

And the lines/fill are not removed from the PSD plot.