### PR TITLE
Replace xref to plot_psd with compute_psd

### DIFF
--- a/examples/visualization/sensor_noise_level.py
+++ b/examples/visualization/sensor_noise_level.py
@@ -5,7 +5,7 @@
 Show noise levels from empty room data
 ======================================
 
-This shows how to use :meth:`mne.io.Raw.plot_psd` to examine noise levels
+This shows how to use :meth:`mne.io.Raw.compute_psd` to examine noise levels
 of systems. See :footcite:`KhanCohen2013` for an example.
 """
 # Author: Eric Larson <larson.eric.d@gmail.com>

--- a/tutorials/intro/10_overview.py
+++ b/tutorials/intro/10_overview.py
@@ -70,7 +70,7 @@ print(raw.info)
 # %%
 # `~mne.io.Raw` objects also have several built-in plotting methods; here we
 # show the power spectral density (PSD) for each sensor type with
-# `~mne.io.Raw.plot_psd`, as well as a plot of the raw sensor traces with
+# `~mne.io.Raw.compute_psd`, as well as a plot of the raw sensor traces with
 # `~mne.io.Raw.plot`. In the PSD plot, we'll only plot frequencies below 50 Hz
 # (since our data are low-pass filtered at 40 Hz). In interactive Python
 # sessions, `~mne.io.Raw.plot` is interactive and allows scrolling, scaling,

--- a/tutorials/preprocessing/10_preprocessing_overview.py
+++ b/tutorials/preprocessing/10_preprocessing_overview.py
@@ -134,7 +134,7 @@ raw.plot(duration=60, order=mag_channels, n_channels=len(mag_channels), remove_d
 # ~~~~~~~~~~~~~~~~
 #
 # Power line artifacts are easiest to see on plots of the spectrum, so we'll
-# use :meth:`~mne.io.Raw.plot_psd` to illustrate.
+# use :meth:`~mne.io.Raw.compute_psd` to illustrate.
 
 fig = raw.compute_psd(tmax=np.inf, fmax=250).plot(
     average=True, picks="data", exclude="bads"


### PR DESCRIPTION
Even if the method used is `.compute_psd(...).plot(...)`, I think a x-ref to `compute_psd` is better than a x-ref to the legacy `plot_psd` method.