### PR TITLE
Exclude bots from homepage and project metadata

### DIFF
--- a/doc/_static/js/contrib-avatars.js
+++ b/doc/_static/js/contrib-avatars.js
@@ -6,6 +6,7 @@ async function getContribs(url) {
 
 function addCards(data, container) {
     data.forEach((entry) => {
+      if (!entry.login.endsWith("[bot]")) {
         let card = document.createElement("div");
         let anchor = document.createElement("a");
         let image = document.createElement("img");
@@ -18,14 +19,15 @@ function addCards(data, container) {
         anchor.append(image);
         card.append(anchor);
         container.append(card);
+      }
     });
 }
 
 async function putAvatarsInPage() {
     // container
-    const outer = document.createElement("div");
-    const title = document.createElement("p");
-    const inner = document.createElement("div");
+    let outer = document.createElement("div");
+    let title = document.createElement("p");
+    let inner = document.createElement("div");
     outer.setAttribute("id", "contributor-avatars");
     outer.setAttribute("class", "container my-4");
     title.setAttribute("class", "h4 text-center font-weight-light");

--- a/tools/generate_codemeta.py
+++ b/tools/generate_codemeta.py
@@ -92,7 +92,7 @@ assert len(split_version) == 3, msg
 args = ["git", "shortlog", "-nse"]
 result = subprocess.run(args, capture_output=True, text=True)
 lines = result.stdout.strip().split("\n")
-all_names = [parse_name(line) for line in lines]
+all_names = [parse_name(line) for line in lines if "[bot]" not in line]
 
 
 # CONSTRUCT JSON AUTHORS LIST


### PR DESCRIPTION
excludes bots from our homepage contributor avatars grid, and from our `codemeta.json` and `CITATION.cff` files.