### PR TITLE
FIX: A couple of minor changes to eyetracking Calibrations

### DIFF
--- a/mne/io/eyelink/_utils.py
+++ b/mne/io/eyelink/_utils.py
@@ -281,7 +281,7 @@ def _parse_calibration(
             gaze = np.array([point[3:] for point in points])
             # create the Calibration instance
             calibration = Calibration(
-                onset=max(0.0, onset),  # 0 if calibrated before recording
+                onset=onset,
                 model=model,
                 eye=this_eye,
                 avg_error=avg_error,

--- a/mne/preprocessing/eyetracking/calibration.py
+++ b/mne/preprocessing/eyetracking/calibration.py
@@ -114,13 +114,11 @@ class Calibration(dict):
         """
         return deepcopy(self)
 
-    def plot(self, title=None, show_offsets=True, axes=None, show=True):
+    def plot(self, show_offsets=True, axes=None, show=True):
         """Visualize calibration.
 
         Parameters
         ----------
-        title : str
-            The title to be displayed. Defaults to ``None``, which uses a generic title.
         show_offsets : bool
             Whether to display the offset (in visual degrees) of each calibration
             point or not. Defaults to ``True``.
@@ -152,10 +150,7 @@ class Calibration(dict):
         px, py = self["positions"].T
         gaze_x, gaze_y = self["gaze"].T
 
-        if title is None:
-            ax.set_title(f"Calibration ({self['eye']} eye)")
-        else:
-            ax.set_title(title)
+        ax.set_title(f"Calibration ({self['eye']} eye)")
         ax.set_xlabel("x (pixels)")
         ax.set_ylabel("y (pixels)")
 

--- a/mne/preprocessing/eyetracking/tests/test_calibration.py
+++ b/mne/preprocessing/eyetracking/tests/test_calibration.py
@@ -199,7 +199,7 @@ def test_read_calibration(fname):
 
     assert len(calibrations) == 2  # calibration[0] is left, calibration[1] is right
     assert np.isclose(calibrations[0]["onset"], -6.85)
-    assert np.isclose(calibrations[0]["onset"], -6.85)
+    assert np.isclose(calibrations[1]["onset"], -6.85)
     assert calibrations[0]["model"] == "HV13"
     assert calibrations[1]["model"] == "HV13"
     assert calibrations[0]["eye"] == "left"

--- a/mne/preprocessing/eyetracking/tests/test_calibration.py
+++ b/mne/preprocessing/eyetracking/tests/test_calibration.py
@@ -198,8 +198,8 @@ def test_read_calibration(fname):
     ]
 
     assert len(calibrations) == 2  # calibration[0] is left, calibration[1] is right
-    assert calibrations[0]["onset"] == 0
-    assert calibrations[1]["onset"] == 0
+    assert np.isclose(calibrations[0]["onset"], -6.85)
+    assert np.isclose(calibrations[0]["onset"], -6.85)
     assert calibrations[0]["model"] == "HV13"
     assert calibrations[1]["model"] == "HV13"
     assert calibrations[0]["eye"] == "left"

--- a/mne/preprocessing/eyetracking/tests/test_calibration.py
+++ b/mne/preprocessing/eyetracking/tests/test_calibration.py
@@ -198,8 +198,8 @@ def test_read_calibration(fname):
     ]
 
     assert len(calibrations) == 2  # calibration[0] is left, calibration[1] is right
-    assert np.isclose(calibrations[0]["onset"], -6.85)
-    assert np.isclose(calibrations[1]["onset"], -6.85)
+    np.testing.assert_allclose(calibrations[0]["onset"], -6.85)
+    np.testing.assert_allclose(calibrations[1]["onset"], -6.85)
     assert calibrations[0]["model"] == "HV13"
     assert calibrations[1]["model"] == "HV13"
     assert calibrations[0]["eye"] == "left"
@@ -208,11 +208,11 @@ def test_read_calibration(fname):
     assert calibrations[0]["max_error"] == 0.90
     assert calibrations[1]["avg_error"] == 0.31
     assert calibrations[1]["max_error"] == 0.52
-    assert np.array_equal(POSITIONS_L, calibrations[0]["positions"])
-    assert np.array_equal(POSITIONS_R, calibrations[1]["positions"])
-    assert np.array_equal(GAZE_L, calibrations[0]["gaze"])
-    assert np.array_equal(GAZE_R, calibrations[1]["gaze"])
-    assert np.array_equal(OFFSETS_R, calibrations[1]["offsets"])
+    np.testing.assert_array_equal(POSITIONS_L, calibrations[0]["positions"])
+    np.testing.assert_array_equal(POSITIONS_R, calibrations[1]["positions"])
+    np.testing.assert_array_equal(GAZE_L, calibrations[0]["gaze"])
+    np.testing.assert_array_equal(GAZE_R, calibrations[1]["gaze"])
+    np.testing.assert_array_equal(OFFSETS_R, calibrations[1]["offsets"])
 
 
 @requires_testing_data
@@ -242,6 +242,8 @@ def test_plot_calibration(fname, axes):
     assert ax.title.get_text() == f"Calibration ({cal_left['eye']} eye)"
     assert len(ax.collections) == 2  # Two scatter plots
 
-    assert np.allclose(scatter1.get_offsets(), np.column_stack((px, py)))
-    assert np.allclose(scatter2.get_offsets(), np.column_stack((gaze_x, gaze_y)))
+    np.testing.assert_allclose(scatter1.get_offsets(), np.column_stack((px, py)))
+    np.testing.assert_allclose(
+        scatter2.get_offsets(), np.column_stack((gaze_x, gaze_y))
+    )
     plt.close(fig)


### PR DESCRIPTION
Was hoping to squeeze this in before 1.5 release, i.e. when the `Calibrations` class will be part of a stable version of MNE:

Here are 2 changes:

1. Allow a `Calibration` to have a negative onset time. While initially creating the (EDIT: `Calibrations`) PR, [we agreed](https://github.com/mne-tools/mne-python/pull/11719#discussion_r1235552854) that it should be okay for a calibration to have a negative onset time (i.e. for calibrations that were conducted before the task/recording started). However, on the main branch, these calibration onsets were forced to be `0` (_mea culpa_).
2. for the `plot` method of the `Calibrations` class, there is a `title` parameter. However, since we added an `axes` parameter so that users can pass in a custom axes and make whatever customizations they want, I don't think this method needs to have a specific `title` parameter anymore, and I've removed it.

