### PR TITLE
MAINT: Prefer _safe_svd for SVDs

### DIFF
--- a/mne/beamformer/_rap_music.py
+++ b/mne/beamformer/_rap_music.py
@@ -7,6 +7,7 @@
 
 import numpy as np
 
+from ..fixes import _safe_svd
 from ..forward import is_fixed_orient, convert_forward_solution
 from ..io.pick import pick_info, pick_channels_forward
 from ..inverse_sparse.mxne_inverse import _make_dipoles_sparse
@@ -155,9 +156,7 @@ def _apply_rap_music(
 
 def _compute_subcorr(G, phi_sig):
     """Compute the subspace correlation."""
-    from scipy import linalg
-
-    Ug, Sg, Vg = linalg.svd(G, full_matrices=False)
+    Ug, Sg, Vg = _safe_svd(G, full_matrices=False)
     # Now we look at the actual rank of the forward fields
     # in G and handle the fact that it might be rank defficient
     # eg. when using MEG and a sphere model for which the
@@ -168,16 +167,14 @@ def _compute_subcorr(G, phi_sig):
     rank = max(rank, 2)  # rank cannot be 1
     Ug, Sg, Vg = Ug[:, :rank], Sg[:rank], Vg[:rank]
     tmp = np.dot(Ug.T.conjugate(), phi_sig)
-    Uc, Sc, _ = linalg.svd(tmp, full_matrices=False)
+    Uc, Sc, _ = _safe_svd(tmp, full_matrices=False)
     X = np.dot(Vg.T / Sg[None, :], Uc[:, 0])  # subcorr
     return Sc[0], X / np.linalg.norm(X)
 
 
 def _compute_proj(A):
     """Compute the orthogonal projection operation for a manifold vector A."""
-    from scipy import linalg
-
-    U, _, _ = linalg.svd(A, full_matrices=False)
+    U, _, _ = _safe_svd(A, full_matrices=False)
     return np.identity(A.shape[0]) - np.dot(U, U.T.conjugate())
 
 

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -20,7 +20,7 @@ import shutil
 
 import numpy as np
 
-from .fixes import _compare_version
+from .fixes import _compare_version, _safe_svd
 from .io.constants import FIFF, FWD
 from .io._digitization import _dig_kind_dict, _dig_kind_rev, _dig_kind_ints
 from .io.write import (
@@ -752,15 +752,13 @@ def _fwd_eeg_get_multi_sphere_model_coeffs(m, n_terms):
 
 def _compose_linear_fitting_data(mu, u):
     """Get the linear fitting data."""
-    from scipy import linalg
-
     k1 = np.arange(1, u["nterms"])
     mu1ns = mu[0] ** k1
     # data to be fitted
     y = u["w"][:-1] * (u["fn"][1:] - mu1ns * u["fn"][0])
     # model matrix
     M = u["w"][:-1, np.newaxis] * (mu[1:] ** k1[:, np.newaxis] - mu1ns[:, np.newaxis])
-    uu, sing, vv = linalg.svd(M, full_matrices=False)
+    uu, sing, vv = _safe_svd(M, full_matrices=False)
     ncomp = u["nfit"] - 1
     uu, sing, vv = uu[:, :ncomp], sing[:ncomp], vv[:ncomp]
     return y, uu, sing, vv

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -16,6 +16,7 @@ from .defaults import (
     _BORDER_DEFAULT,
     DEFAULTS,
 )
+from .fixes import _safe_svd
 from .io.write import start_and_end_file
 from .io.proj import (
     make_projector,
@@ -1963,8 +1964,6 @@ def regularize(
     --------
     mne.compute_covariance
     """  # noqa: E501
-    from scipy import linalg
-
     cov = cov.copy()
     info._check_consistency()
     scalings = _handle_default("scalings_cov_rank", scalings)
@@ -2060,7 +2059,7 @@ def regularize(
                 P, ncomp, _ = make_projector(projs, this_ch_names)
                 if ncomp > 0:
                     # This adjustment ends up being redundant if rank is None:
-                    U = linalg.svd(P)[0][:, :-ncomp]
+                    U = _safe_svd(P)[0][:, :-ncomp]
                     logger.info(
                         "    Created an SSP operator for %s "
                         "(dimension = %d)" % (desc, ncomp)

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from ..bem import _check_origin
 from ..cov import make_ad_hoc_cov
+from ..fixes import _safe_svd
 from ..io.constants import FIFF
 from ..io.pick import pick_types, pick_info
 from ..io.meas_info import _simplify_info
@@ -88,9 +89,7 @@ def _compute_mapping_matrix(fmd, info):
 
 def _pinv_trunc(x, miss):
     """Compute pseudoinverse, truncating at most "miss" fraction of varexp."""
-    from scipy import linalg
-
-    u, s, v = linalg.svd(x, full_matrices=False)
+    u, s, v = _safe_svd(x, full_matrices=False)
 
     # Eigenvalue truncation
     varexp = np.cumsum(s)

--- a/mne/inverse_sparse/_gamma_map.py
+++ b/mne/inverse_sparse/_gamma_map.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 
+from ..fixes import _safe_svd
 from ..forward import is_fixed_orient
 from ..minimum_norm.inverse import _check_reference, _log_exp_var
 from ..utils import logger, verbose, warn
@@ -59,8 +60,6 @@ def _gamma_map_opt(
     active_set : array, shape=(n_active,)
         Indices of active sources.
     """
-    from scipy import linalg
-
     G = G.copy()
     M = M.copy()
 
@@ -112,7 +111,7 @@ def _gamma_map_opt(
         CM = np.dot(G * gammas[np.newaxis, :], G.T)
         CM.flat[:: n_sensors + 1] += alpha
         # Invert CM keeping symmetry
-        U, S, _ = linalg.svd(CM, full_matrices=False)
+        U, S, _ = _safe_svd(CM, full_matrices=False)
         S = S[np.newaxis, :]
         del CM
         CMinv = np.dot(U / (S + eps), U.T)

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -204,7 +204,7 @@ def _split_gof(M, X, gain):
     res = M - M_est
     assert gain.shape[0] == M.shape[0], (gain.shape, M.shape)
     # find an orthonormal basis for our matrices that spans the actual data
-    U, s, _ = _safe_svd(gain, full_matrices=False)
+    U, s, _ = np.linalg.svd(gain, full_matrices=False)
     if U.shape[1] > 0:
         U = U[:, s >= s[0] * 1e-6]
     # the part that gets explained

--- a/mne/inverse_sparse/mxne_inverse.py
+++ b/mne/inverse_sparse/mxne_inverse.py
@@ -12,6 +12,7 @@ from ..minimum_norm.inverse import (
     _check_reference,
     _log_exp_var,
 )
+from ..fixes import _safe_svd
 from ..forward import is_fixed_orient
 from ..io.proj import deactivate_proj
 from ..utils import (
@@ -203,7 +204,7 @@ def _split_gof(M, X, gain):
     res = M - M_est
     assert gain.shape[0] == M.shape[0], (gain.shape, M.shape)
     # find an orthonormal basis for our matrices that spans the actual data
-    U, s, _ = np.linalg.svd(gain, full_matrices=False)
+    U, s, _ = _safe_svd(gain, full_matrices=False)
     if U.shape[1] > 0:
         U = U[:, s >= s[0] * 1e-6]
     # the part that gets explained
@@ -456,8 +457,6 @@ def mixed_norm(
     ----------
     .. footbibliography::
     """
-    from scipy import linalg
-
     _validate_type(alpha, ("numeric", str), "alpha")
     if isinstance(alpha, str):
         _check_option("alpha", alpha, ("sure",))
@@ -520,7 +519,7 @@ def mixed_norm(
     M = np.dot(whitener, M)
 
     if time_pca:
-        U, s, Vh = linalg.svd(M, full_matrices=False)
+        U, s, Vh = _safe_svd(M, full_matrices=False)
         if not isinstance(time_pca, bool) and isinstance(time_pca, int):
             U = U[:, :time_pca]
             s = s[:time_pca]

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -12,7 +12,6 @@ import re
 import numpy as np
 
 from .constants import FIFF
-from .fixes import _safe_svd
 from .pick import pick_types, pick_info, _electrode_types, _ELECTRODE_CH_TYPES
 from .tag import find_tag, _rename_list
 from .tree import dir_tree_find
@@ -27,6 +26,7 @@ from .write import (
     _safe_name_list,
 )
 from ..defaults import _INTERPOLATION_DEFAULT, _BORDER_DEFAULT, _EXTRAPOLATE_DEFAULT
+from ..fixes import _safe_svd
 from ..utils import (
     logger,
     verbose,

--- a/mne/io/proj.py
+++ b/mne/io/proj.py
@@ -12,6 +12,7 @@ import re
 import numpy as np
 
 from .constants import FIFF
+from .fixes import _safe_svd
 from .pick import pick_types, pick_info, _electrode_types, _ELECTRODE_CH_TYPES
 from .tag import find_tag, _rename_list
 from .tree import dir_tree_find
@@ -772,8 +773,6 @@ def _make_projector(projs, ch_names, bads=(), include_active=True, inplace=False
     warning will be raised next time projectors are constructed with
     the given inputs. If inplace=True, no meaningful data are returned.
     """
-    from scipy import linalg
-
     nchan = len(ch_names)
     if nchan == 0:
         raise ValueError("No channel names specified")
@@ -871,7 +870,7 @@ def _make_projector(projs, ch_names, bads=(), include_active=True, inplace=False
         return default_return
 
     # Reorthogonalize the vectors
-    U, S, _ = linalg.svd(vecs[:, :nvec], full_matrices=False)
+    U, S, _ = _safe_svd(vecs[:, :nvec], full_matrices=False)
 
     # Throw away the linearly dependent guys
     nproj = np.sum((S / S[0]) > 1e-2)

--- a/mne/label.py
+++ b/mne/label.py
@@ -13,6 +13,7 @@ import re
 
 import numpy as np
 
+from .fixes import _safe_svd
 from .morph_map import read_morph_map
 from .parallel import parallel_func
 from .source_estimate import (
@@ -1462,8 +1463,6 @@ def label_sign_flip(label, src):
     flip : array
         Sign flip vector (contains 1 or -1).
     """
-    from scipy import linalg
-
     if len(src) != 2:
         raise ValueError("Only source spaces with 2 hemisphers are accepted")
 
@@ -1486,7 +1485,7 @@ def label_sign_flip(label, src):
     if len(ori) == 0:
         return np.array([], int)
 
-    _, _, Vh = linalg.svd(ori, full_matrices=False)
+    _, _, Vh = _safe_svd(ori, full_matrices=False)
 
     # The sign of Vh is ambiguous, so we should align to the max-positive
     # (outward) direction

--- a/mne/minimum_norm/time_frequency.py
+++ b/mne/minimum_norm/time_frequency.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from ..epochs import Epochs, make_fixed_length_events
 from ..evoked import EvokedArray
+from ..fixes import _safe_svd
 from ..io.constants import FIFF
 from ..io.pick import pick_info
 from ..source_estimate import _make_stc
@@ -47,8 +48,6 @@ def _prepare_source_params(
     verbose=None,
 ):
     """Prepare inverse operator and params for spectral / TFR analysis."""
-    from scipy import linalg
-
     inv = _check_or_prepare(
         inverse_operator, nave, lambda2, method, method_params, prepared
     )
@@ -71,7 +70,7 @@ def _prepare_source_params(
     )
 
     if pca:
-        U, s, Vh = linalg.svd(K, full_matrices=False)
+        U, s, Vh = _safe_svd(K, full_matrices=False)
         rank = np.sum(s > 1e-8 * s[0])
         K = s[:rank] * U[:, :rank]
         Vh = Vh[:rank]
@@ -103,6 +102,7 @@ def source_band_induced_power(
     prepared=False,
     method_params=None,
     use_cps=True,
+    *,
     verbose=None,
 ):
     """Compute source space induced power in given frequency bands.
@@ -578,7 +578,7 @@ def compute_source_psd(
     return_sensor=False,
     dB=False,
     *,
-    verbose=None
+    verbose=None,
 ):
     """Compute source power spectral density (PSD).
 

--- a/mne/preprocessing/otp.py
+++ b/mne/preprocessing/otp.py
@@ -129,7 +129,7 @@ def _otp(data, picks_good, picks_bad):
     for mi, pick in enumerate(picks_good):
         # operate on original data
         idx = list(range(mi)) + list(range(mi + 1, len(data_good)))
-        # Equivalent: linalg.svd(data[idx], full_matrices=False)[2]
+        # Equivalent: svd(data[idx], full_matrices=False)[2]
         t_basis = _svd_cov(cov[np.ix_(idx, idx)], data_good[idx])[2]
         x = np.dot(np.dot(data_good[mi], t_basis.T), t_basis)
         x *= norms[mi]

--- a/mne/preprocessing/tests/test_xdawn.py
+++ b/mne/preprocessing/tests/test_xdawn.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal, assert_allclose
 import pytest
-from scipy import linalg, stats
+from scipy import stats
 
 from mne import (
     Epochs,
@@ -20,6 +20,7 @@ from mne import (
     EpochsArray,
 )
 from mne.decoding import Vectorizer
+from mne.fixes import _safe_svd
 from mne.io import read_raw_fif
 from mne.preprocessing.xdawn import Xdawn, _XdawnTransformer
 
@@ -326,7 +327,7 @@ def _simulate_erplike_mixed_data(n_epochs=100, n_channels=10):
     epoch_data[y == 0, informative_ch_idx, :] += nontarget_template
     epoch_data[y == 1, informative_ch_idx, :] += target_template
 
-    mixing_mat = linalg.svd(rng.randn(n_channels, n_channels))[0]
+    mixing_mat = _safe_svd(rng.randn(n_channels, n_channels))[0]
     mixed_epoch_data = np.dot(mixing_mat.T, epoch_data).transpose((1, 0, 2))
 
     events = np.zeros((n_epochs, 3), dtype=int)

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -5,6 +5,7 @@
 import numpy as np
 
 from .epochs import Epochs
+from .fixes import _safe_svd
 from .utils import check_fname, logger, verbose, _check_option, _check_fname
 from .io.constants import FIFF
 from .io.open import fiff_open
@@ -89,8 +90,6 @@ def write_proj(fname, projs, *, overwrite=False, verbose=None):
 def _compute_proj(
     data, info, n_grad, n_mag, n_eeg, desc_prefix, meg="separate", verbose=None
 ):
-    from scipy import linalg
-
     grad_ind = pick_types(info, meg="grad", ref_meg=False, exclude="bads")
     mag_ind = pick_types(info, meg="mag", ref_meg=False, exclude="bads")
     eeg_ind = pick_types(info, meg=False, eeg=True, ref_meg=False, exclude="bads")
@@ -138,7 +137,7 @@ def _compute_proj(
             continue
         data_ind = data[ind][:, ind]
         # data is the covariance matrix: U * S**2 * Ut
-        U, Sexp2, _ = linalg.svd(data_ind, full_matrices=False)
+        U, Sexp2, _ = _safe_svd(data_ind, full_matrices=False)
         U = U[:, :n]
         exp_var = Sexp2 / Sexp2.sum()
         exp_var = exp_var[:n]
@@ -426,8 +425,6 @@ def sensitivity_map(
     When mode is ``'fixed'`` or ``'free'``, the sensitivity map is normalized
     by its maximum value.
     """
-    from scipy import linalg
-
     # check strings
     _check_option("ch_type", ch_type, ["eeg", "grad", "mag"])
     _check_option(
@@ -487,11 +484,11 @@ def sensitivity_map(
     for k in range(n_locations):
         gg = gain[:, 3 * k : 3 * (k + 1)]
         if mode != "fixed":
-            s = linalg.svd(gg, full_matrices=False, compute_uv=False)
+            s = _safe_svd(gg, full_matrices=False, compute_uv=False)
         if mode == "free":
             sensitivity_map[k] = s[0]
         else:
-            gz = linalg.norm(gg[:, 2])  # the normal component
+            gz = np.linalg.norm(gg[:, 2])  # the normal component
             if mode == "fixed":
                 sensitivity_map[k] = gz
             elif mode == "ratio":
@@ -500,10 +497,10 @@ def sensitivity_map(
                 sensitivity_map[k] = 1.0 - (gz / s[0])
             else:
                 if mode == "angle":
-                    co = linalg.norm(np.dot(gg[:, 2], U))
+                    co = np.linalg.norm(np.dot(gg[:, 2], U))
                     sensitivity_map[k] = co / gz
                 else:
-                    p = linalg.norm(np.dot(proj, gg[:, 2]))
+                    p = np.linalg.norm(np.dot(proj, gg[:, 2]))
                     if mode == "remaining":
                         sensitivity_map[k] = p / gz
                     elif mode == "dampening":

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -1540,7 +1540,7 @@ def _average_quats(quats, weights=None):
     A = np.einsum("ij,ik->jk", quats, quats)  # sum of outer product of each q
     avg_quat = linalg.eigh(A)[1][:, -1]  # largest eigenvector is the avg
     # Same as the largest eigenvector from the concatenation of all as
-    # linalg.svd(quats, full_matrices=False)[-1][0], but faster.
+    # svd(quats, full_matrices=False)[-1][0], but faster.
     #
     # By local convention we take the real term (which we remove from our
     # representation) as positive. Since it can be zero, let's just ensure

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import numpy as np
 
 from ..defaults import DEFAULTS
+from ..fixes import _safe_svd
 from .._freesurfer import _reorient_image, _read_mri_info, _check_mri, _mri_orientation
 from ..rank import compute_rank
 from ..surface import read_surface
@@ -140,7 +141,6 @@ def plot_cov(
     """
     import matplotlib.pyplot as plt
     from matplotlib.colors import Normalize
-    from scipy import linalg
     from ..cov import Covariance
 
     info, C, ch_names, idx_names = _index_info_cov(info, cov, exclude)
@@ -197,7 +197,7 @@ def plot_cov(
         )
         for k, (idx, name, unit, scaling, key) in enumerate(idx_names):
             this_C = C[idx][:, idx]
-            s = linalg.svd(this_C, compute_uv=False)
+            s = _safe_svd(this_C, compute_uv=False)
             this_C = Covariance(this_C, [info["ch_names"][ii] for ii in idx], [], [], 0)
             this_info = pick_info(info, idx)
             with this_info._unlock():

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -7,6 +7,8 @@
 #
 # License: Simplified BSD
 
+import platform
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -22,6 +24,8 @@ ev = dict(events=False)
 
 def test_plot_epochs_not_preloaded(epochs_unloaded, browser_backend):
     """Test plotting non-preloaded epochs."""
+    if platform.machine() == "arm64":
+        pytest.xfail("Flakey verbose behavior on macOS arm64")
     assert epochs_unloaded._data is None
     epochs_unloaded.plot(**ev)
     assert epochs_unloaded._data is None


### PR DESCRIPTION
A coworker ran into the annoying SVD error:
```
  File "/somewhere/mne-python/mne/minimum_norm/time_frequency.py", line 51, in _prepare_source_params
    U, s, Vh = linalg.svd(K, full_matrices=False)
  File "/elsewhere/lib/python3.10/site-packages/scipy/linalg/_decomp_svd.py", line 131, in svd
    raise LinAlgError("SVD did not converge")
numpy.linalg.LinAlgError: SVD did not converge
```
This transitions us to using `_safe_svd` in place of `scipy.linalg.svd` to work around the issue.