### PR TITLE
FIX: Missing Saccade information in Eyelink File

### DIFF
--- a/mne/io/eyelink/eyelink.py
+++ b/mne/io/eyelink/eyelink.py
@@ -590,20 +590,20 @@ class RawEyelink(BaseRaw):
         for key, df in self.dataframes.items():
             if key in ["samples", "DINS"]:
                 # convert missing position values to NaN
-                self._set_missing_values(df)
+                self._set_missing_values(df, df.columns[1:])
                 _set_pandas_dtype(df, df.columns, float, verbose="warning")
             elif key in ["blinks", "fixations", "saccades"]:
+                self._set_missing_values(df, df.columns[1:])
                 _set_pandas_dtype(df, df.columns[1:], float, verbose="warning")
             elif key == "messages":
                 _set_pandas_dtype(df, ["time"], float, verbose="warning")  # timestamp
 
-    def _set_missing_values(self, df):
+    def _set_missing_values(self, df, columns):
         """Set missing values to NaN. operates in-place."""
         missing_vals = (".", "MISSING_DATA")
-        for col in df.columns:
-            if col.startswith(("xpos", "ypos")):
-                # we explicitly use numpy instead of pd.replace because it is faster
-                df[col] = np.where(df[col].isin(missing_vals), np.nan, df[col])
+        for col in columns:
+            # we explicitly use numpy instead of pd.replace because it is faster
+            df[col] = np.where(df[col].isin(missing_vals), np.nan, df[col])
 
     def _create_info(self, ch_names, sfreq):
         """Create info object for RawEyelink."""

--- a/mne/io/eyelink/tests/test_eyelink.py
+++ b/mne/io/eyelink/tests/test_eyelink.py
@@ -209,6 +209,8 @@ def _simulate_eye_tracking_data(in_file, out_file):
                     tokens[4:4] = ["100", "20", "45", "45", "127.0"]  # vel, res, DIN
                     tokens.extend(["1497.0", "5189.0", "512.5", "............."])
                 elif event_type in ("EFIX", "ESACC"):
+                    if event_type == "ESACC":
+                        tokens[5:7] = [".", "."]  # pretend start pos is unknown
                     tokens.extend(["45", "45"])  # resolution
                 elif event_type == "SAMPLES":
                     tokens[1] = "PUPIL"  # simulate raw coordinate data


### PR DESCRIPTION
This is an issue as PR. 

I hit an edge case in one of my Eyelink files, where the participant was in the middle of a saccade upon recording start. This edge case results in missing values (i.e. ".") in the "ESACC" event of the ASCII file, that need to be properly converted to nans during reading. 

it was a quick fix, and I added a line to the test suite to simulate this edge case, but Let me know if you want me to share a file and code to reproduce the error, or if you need more info.
