### PR TITLE
Refactor test_epochs.py::test_split_saving (1 out of 2)

### DIFF
--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1479,6 +1479,7 @@ def test_epochs_io_preload(tmp_path, preload):
 @pytest.fixture(scope="session")
 def epochs_factory():
     """Function to create fake Epochs object."""
+
     def factory(n_epochs, metadata=False, concat=False):
         if metadata:
             pytest.importorskip("pandas")
@@ -1507,19 +1508,22 @@ def epochs_factory():
             epochs = concatenate_epochs([epochs[ii] for ii in range(len(epochs))])
         assert len(epochs) == n_epochs
         return epochs
+
     return factory
 
 
-@pytest.fixture(params=[
-    ("1.5MB", 9, True, True, 6),
-    ("1.5MB", 9, True, False, 6),
-    ("1.5MB", 9, False, True, 6),
-    ("1.5MB", 9, False, False, 6),
-    ("3MB", 18, True, True, 3),
-    ("3MB", 18, True, False, 3),
-    ("3MB", 18, False, True, 3),
-    ("3MB", 18, False, False, 3),
-])
+@pytest.fixture(
+    params=[
+        ("1.5MB", 9, True, True, 6),
+        ("1.5MB", 9, True, False, 6),
+        ("1.5MB", 9, False, True, 6),
+        ("1.5MB", 9, False, False, 6),
+        ("3MB", 18, True, True, 3),
+        ("3MB", 18, True, False, 3),
+        ("3MB", 18, False, True, 3),
+        ("3MB", 18, False, False, 3),
+    ]
+)
 def epochs_to_split(request, epochs_factory):
     """Epochs tailored to produce specific number of splits when saving.
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1553,17 +1553,24 @@ def test_split_saving(tmp_path, epochs_to_split, preload):
     assert_array_equal(epochs.events, epochs2.events)
 
 
-@pytest.mark.parametrize("split_naming, split_fname, split_fname_part1", [
-    ("neuromag", "test_epo.fif", lambda n: f"test_epo-{n + 1}.fif"),
-    ("bids", "test_epo.fif", lambda n: f"test_split-{n + 1:02d}_epo.fif"),
-])
-def test_split_naming(tmp_path, epochs_to_split, split_naming, split_fname, split_fname_part1):
+@pytest.mark.parametrize(
+    "split_naming, split_fname, split_fname_part1",
+    [
+        ("neuromag", "test_epo.fif", lambda n: f"test_epo-{n + 1}.fif"),
+        ("bids", "test_epo.fif", lambda n: f"test_split-{n + 1:02d}_epo.fif"),
+    ],
+)
+def test_split_naming(
+    tmp_path, epochs_to_split, split_naming, split_fname, split_fname_part1
+):
     """Test naming of the split files."""
     epochs, _, n_files = epochs_to_split
     split_fpath = tmp_path / split_fname
     # we don't test for reserved files as it's not implemented here
 
-    epochs.save(split_fpath, split_size="1.4MB", split_naming=split_naming, verbose=True)
+    epochs.save(
+        split_fpath, split_size="1.4MB", split_naming=split_naming, verbose=True
+    )
 
     # check that the filenames match the intended pattern
     assert split_fpath.is_file()
@@ -1586,7 +1593,7 @@ def test_saved_fname_no_splitting(tmp_path, epochs_to_split):
 
 @pytest.mark.parametrize("split_naming", ["neuromag", "bids"])
 def test_saving_fails_with_not_permitted_overwrite(
-        tmp_path, epochs_factory, split_naming
+    tmp_path, epochs_factory, split_naming
 ):
     """Check exception is raised when overwriting without explicit flag."""
     dst_fpath = tmp_path / "test-epo.fif"

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1478,7 +1478,7 @@ def test_epochs_io_preload(tmp_path, preload):
 
 @pytest.fixture(scope="session")
 def epochs_factory():
-    """Function to create fake Epochs object."""
+    """Function to create fake Epochs object."""  # noqa: D401
 
     def factory(n_epochs, metadata=False, concat=False):
         if metadata:

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1536,7 +1536,8 @@ def epochs_to_split(request, epochs_factory):
     return epochs, split_size, n_files
 
 
-def test_split_saving(tmp_path, epochs_to_split):
+@pytest.mark.parametrize("preload", [True, False], ids=["preload", "no_preload"])
+def test_split_saving(tmp_path, epochs_to_split, preload):
     """Test saving split epochs."""
     epochs, split_size, n_files = epochs_to_split
     epochs_data = epochs.get_data()
@@ -1545,10 +1546,9 @@ def test_split_saving(tmp_path, epochs_to_split):
     got_size = _get_split_size(split_size)
     _assert_splits(fname, n_files, got_size)
     assert not fname.with_name(f"{fname.stem}-{n_files + 1}{fname.suffix}").is_file()
-    for preload in (True, False):
-        epochs2 = mne.read_epochs(fname, preload=preload)
-        assert_allclose(epochs2.get_data(), epochs_data)
-        assert_array_equal(epochs.events, epochs2.events)
+    epochs2 = mne.read_epochs(fname, preload=preload)
+    assert_allclose(epochs2.get_data(), epochs_data)
+    assert_array_equal(epochs.events, epochs2.events)
 
 
 def test_split_naming(tmp_path, epochs_to_split):

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1550,6 +1550,9 @@ def test_split_saving(tmp_path, epochs_to_split):
         assert_allclose(epochs2.get_data(), epochs_data)
         assert_array_equal(epochs.events, epochs2.events)
 
+
+def test_split_naming(tmp_path, epochs_to_split):
+    epochs, _, n_files = epochs_to_split
     # Check that if BIDS is used and no split is needed it defaults to
     # simple writing without _split- entity.
     split_fname = tmp_path / "test_epo.fif"

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -4,7 +4,6 @@
 #
 # License: BSD-3-Clause
 
-import os
 import pickle
 from copy import deepcopy
 from datetime import timedelta

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1542,16 +1542,19 @@ def test_split_saving(tmp_path, epochs_to_split, preload):
     epochs, split_size, n_files = epochs_to_split
     epochs_data = epochs.get_data()
     fname = tmp_path / "test-epo.fif"
-    epochs.save(fname, split_size=split_size, overwrite=True)
     got_size = _get_split_size(split_size)
+
+    epochs.save(fname, split_size=split_size, overwrite=True)
+    epochs2 = mne.read_epochs(fname, preload=preload)
+
     _assert_splits(fname, n_files, got_size)
     assert not fname.with_name(f"{fname.stem}-{n_files + 1}{fname.suffix}").is_file()
-    epochs2 = mne.read_epochs(fname, preload=preload)
     assert_allclose(epochs2.get_data(), epochs_data)
     assert_array_equal(epochs.events, epochs2.events)
 
 
 def test_split_naming(tmp_path, epochs_to_split):
+    """Test naming of the split files."""
     epochs, _, n_files = epochs_to_split
     # Check that if BIDS is used and no split is needed it defaults to
     # simple writing without _split- entity.

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1497,8 +1497,6 @@ def test_split_saving(tmp_path, split_size, n_epochs, n_files, size, metadata, c
     )
     events = mne.make_fixed_length_events(raw, 1)
     epochs = mne.Epochs(raw, events)
-    if split_size == "2MB" and (metadata or concat):
-        n_files += 1
     if metadata:
         from pandas import DataFrame
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1477,15 +1477,15 @@ def test_epochs_io_preload(tmp_path, preload):
 
 
 @pytest.mark.parametrize(
-    "split_size, n_epochs, n_files, size",
+    "split_size, n_epochs, n_files",
     [
-        ("1.5MB", 9, 6, 1572864),
-        ("3MB", 18, 3, 3 * 1024 * 1024),
+        ("1.5MB", 9, 6),
+        ("3MB", 18, 3),
     ],
 )
 @pytest.mark.parametrize("metadata", [False, True])
 @pytest.mark.parametrize("concat", (False, True))
-def test_split_saving(tmp_path, split_size, n_epochs, n_files, size, metadata, concat):
+def test_split_saving(tmp_path, split_size, n_epochs, n_files, metadata, concat):
     """Test saving split epochs."""
     if metadata:
         pytest.importorskip("pandas")
@@ -1517,8 +1517,7 @@ def test_split_saving(tmp_path, split_size, n_epochs, n_files, size, metadata, c
     fname = tmp_path / "test-epo.fif"
     epochs.save(fname, split_size=split_size, overwrite=True)
     got_size = _get_split_size(split_size)
-    assert got_size == size
-    _assert_splits(fname, n_files, size)
+    _assert_splits(fname, n_files, got_size)
     assert not fname.with_name(f"{fname.stem}-{n_files + 1}{fname.suffix}").is_file()
     for preload in (True, False):
         epochs2 = mne.read_epochs(fname, preload=preload)

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1556,16 +1556,9 @@ def test_split_saving(tmp_path, epochs_to_split, preload):
 def test_split_naming(tmp_path, epochs_to_split):
     """Test naming of the split files."""
     epochs, _, n_files = epochs_to_split
-    # Check that if BIDS is used and no split is needed it defaults to
-    # simple writing without _split- entity.
     split_fname = tmp_path / "test_epo.fif"
     split_fname_neuromag_part1 = tmp_path / f"test_epo-{n_files + 1}.fif"
     split_fname_bids_part1 = tmp_path / f"test_split-{n_files + 1:02d}_epo.fif"
-
-    epochs.save(split_fname, split_naming="bids", verbose=True)
-    assert split_fname.is_file()
-    assert not split_fname_bids_part1.is_file()
-    os.remove(split_fname)
     # we don't test for reserved files as it's not implemented here
 
     epochs.save(split_fname, split_size="1.4MB", verbose=True)
@@ -1581,6 +1574,20 @@ def test_split_naming(tmp_path, epochs_to_split):
         verbose=True,
     )
     assert split_fname_bids_part1.is_file()
+
+
+def test_saved_fname_no_splitting(tmp_path, epochs_to_split):
+    """Test saved fname doesn't get split suffix when splitting not needed."""
+    # Check that if BIDS is used and no split is needed it defaults to
+    # simple writing without _split- entity.
+    epochs, _, n_files = epochs_to_split
+    split_fname = tmp_path / "test_epo.fif"
+    split_fname_bids_part1 = tmp_path / f"test_split-{n_files + 1:02d}_epo.fif"
+
+    epochs.save(split_fname, split_naming="bids", verbose=True)
+
+    assert split_fname.is_file()
+    assert not split_fname_bids_part1.is_file()
 
 
 @pytest.mark.parametrize("split_naming", ["neuromag", "bids"])

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1478,7 +1478,7 @@ def test_epochs_io_preload(tmp_path, preload):
 
 @pytest.fixture(scope="session")
 def epochs_factory():
-    """Function to create fake Epochs object."""  # noqa: D401
+    """Function to create fake Epochs object."""  # noqa: D401 (imperative mood)
 
     def factory(n_epochs, metadata=False, concat=False):
         if metadata:
@@ -1565,9 +1565,6 @@ def test_split_naming(tmp_path, epochs_to_split):
     epochs.save(split_fname, split_naming="bids", verbose=True)
     assert split_fname.is_file()
     assert not split_fname_bids_part1.is_file()
-    for split_naming in ("neuromag", "bids"):
-        with pytest.raises(FileExistsError, match="Destination file"):
-            epochs.save(split_fname, split_naming=split_naming, verbose=True)
     os.remove(split_fname)
     # we don't test for reserved files as it's not implemented here
 
@@ -1584,6 +1581,20 @@ def test_split_naming(tmp_path, epochs_to_split):
         verbose=True,
     )
     assert split_fname_bids_part1.is_file()
+
+
+@pytest.mark.parametrize("split_naming", ["neuromag", "bids"])
+def test_saving_fails_with_not_permitted_overwrite(
+        tmp_path, epochs_factory, split_naming
+):
+    """Check exception is raised when overwriting without explicit flag."""
+    dst_fpath = tmp_path / "test-epo.fif"
+    epochs = epochs_factory(n_epochs=5)
+
+    epochs.save(dst_fpath, split_naming=split_naming, verbose=True)
+
+    with pytest.raises(FileExistsError, match="Destination file"):
+        epochs.save(dst_fpath, split_naming=split_naming, verbose=True)
 
 
 @pytest.mark.slowtest


### PR DESCRIPTION
Second attempt on PR #11876.

Start with refactoring  tests related to saving epochs splits, while keeping the library code intact.

Related issues:
#11870
#7897
#5102
