### PR TITLE
Small splits fix

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1700,6 +1700,7 @@ class BaseRaw(
         # write the raw file
         _validate_type(split_naming, str, "split_naming")
         _check_option("split_naming", split_naming, ("neuromag", "bids"))
+
         _write_raw(
             fname,
             self,
@@ -2594,7 +2595,7 @@ def _write_raw(
             use_fname = "%s-%d%s" % (base, part_idx, ext)
         else:
             assert split_naming == "bids"
-            use_fname = _construct_bids_filename(base, ext, part_idx + 1)
+            use_fname = _construct_bids_filename(base, ext, part_idx)
             # check for file existence
             _check_fname(use_fname, overwrite)
     else:
@@ -2602,7 +2603,7 @@ def _write_raw(
     # reserve our BIDS split fname in case we need to split
     if split_naming == "bids" and part_idx == 0:
         # reserve our possible split name
-        reserved_fname = _construct_bids_filename(base, ext, part_idx + 1)
+        reserved_fname = _construct_bids_filename(base, ext, part_idx)
         logger.info(f"Reserving possible split file {op.basename(reserved_fname)}")
         _check_fname(reserved_fname, overwrite)
         ctx = _ReservedFilename(reserved_fname)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2596,10 +2596,10 @@ def _write_raw(
         else:
             assert split_naming == "bids"
             use_fname = _construct_bids_filename(base, ext, part_idx)
-            # check for file existence
-            _check_fname(use_fname, overwrite)
     else:
         use_fname = fname
+    # check for file existence
+    _check_fname(use_fname, overwrite)
     # reserve our BIDS split fname in case we need to split
     if split_naming == "bids" and part_idx == 0:
         # reserve our possible split name

--- a/mne/io/utils.py
+++ b/mne/io/utils.py
@@ -338,7 +338,7 @@ def _construct_bids_filename(base, ext, part_idx, validate=True):
         )
     suffix = deconstructed_base[-1]
     base = "_".join(deconstructed_base[:-1])
-    use_fname = "{}_split-{:02}_{}{}".format(base, part_idx, suffix, ext)
+    use_fname = "{}_split-{:02}_{}{}".format(base, part_idx + 1, suffix, ext)
     if dirname:
         use_fname = op.join(dirname, use_fname)
     return use_fname
@@ -355,5 +355,5 @@ def _make_split_fnames(fname, n_splits, split_naming):
             res.append(f"{base}-{i:d}{ext}" if i else fname)
         else:
             assert split_naming == "bids"
-            res.append(_construct_bids_filename(base, ext, i + 1))
+            res.append(_construct_bids_filename(base, ext, i))
     return res

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -231,7 +231,7 @@ def _check_fname(
     *,
     verbose=None,
 ):
-    """Check for file existence, and return string of its absolute path."""
+    """Check for file existence, and return its absolute path."""
     _validate_type(fname, "path-like", name)
     fname = Path(fname).expanduser().absolute()
 


### PR DESCRIPTION
- a small follow-up indexing simplification when creating bids split fnames.
- a small fix to a docstring.
- check writing over a split when saving raw also for neuromag schema (we did the same fix for epochs earlier)
