### PR TITLE
adds niseq package to "Related software"

### DIFF
--- a/doc/install/mne_tools_suite.rst
+++ b/doc/install/mne_tools_suite.rst
@@ -67,6 +67,7 @@ MNE-Python, including packages for:
 - All-Resolutions Inference (ARI) for statistically valid circular inference
   and effect localization (`MNE-ARI`_)
 - real-time analysis (`MNE-Realtime`_)
+- non-parametric sequential analyses and adaptive sample size determination (`niseq`_)
 
 What should I install?
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -111,3 +112,4 @@ Help with installation is available through the `MNE Forum`_. See the
 .. _sesameeg: https://pybees.github.io/sesameeg
 .. _invertmeeg: https://github.com/LukeTheHecker/invert
 .. _MNE-ARI: https://github.com/john-veillette/mne_ari
+.. _niseq: https://github.com/john-veillette/niseq


### PR DESCRIPTION
#### Reference issue
n/a


#### What does this implement/fix?
Adds the new [niseq](https://github.com/john-veillette/niseq) package to the list of related packages on "Overview of the MNE tools suite" page.


#### Additional information
n/a
