### PR TITLE
Fix snirf loader

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -32,6 +32,7 @@ Bugs
 - Fix bugs with saving splits for :class:`~mne.Epochs` (:gh:`11876` by `Dmitrii Altukhov`_) 
 - Fix bug with multi-plot 3D rendering where only one plot was updated (:gh:`11896` by `Eric Larson`_)
 - Fix bug where subject birthdays were not correctly read by :func:`mne.io.read_raw_snirf` (:gh:`11912` by `Eric Larson`_)
+- Fix bug where non-compliant stimulus data streams were not ignored by :func:`mne.io.read_raw_snirf` (:gh:`11915` by `Johann Benerradi`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -471,7 +471,7 @@ class RawSNIRF(BaseRaw):
             for key in dat["nirs"]:
                 if "stim" in key:
                     data = np.atleast_2d(np.array(dat.get("/nirs/" + key + "/data")))
-                    if data.size > 0:
+                    if data.shape[1] >= 3:
                         desc = _correct_shape(
                             np.array(dat.get("/nirs/" + key + "/name"))
                         )[0]


### PR DESCRIPTION
#### Reference issue
Fixes #11710


#### What does this implement/fix?
Instead of checking that the `stim.data` size is strictly greater than 0, we check that it has at least 3 columns. This would follow the [*snirf* specifications](https://github.com/fNIRS/snirf/blob/master/snirf_specification.md#nirsistimjdata) about `stim.data`:
> This is a numeric 2-D array with at least 3 columns, specifying the stimulus time course for the jth condition. Each row corresponds to a specific stimulus trial. The first three columns indicate `[starttime duration value]`.

@rob-luke @larsoner 