### PR TITLE
MAINT: Cleanup use of _fiff

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -26,6 +26,7 @@ Enhancements
 - Improve tests for saving splits with `Epochs` (:gh:`11884` by `Dmitrii Altukhov`_) 
 - Added functionality for linking interactive figures together, such that changing one figure will affect another, see :ref:`tut-ui-events` and :mod:`mne.viz.ui_events` (:gh:`11685` by `Marijn van Vliet`_)
 - HTML anchors for :class:`mne.Report` now reflect the ``section-title`` of the report items rather than using a global incrementor ``global-N`` (:gh:`11890` by `Eric Larson`_)
+- Added public :func:`mne.io.write_info` to complement :func:`mne.io.read_info` (:gh:`11918` by `Eric Larson`_)
 - Added option ``remove_dc`` to to :meth:`Raw.compute_psd() <mne.io.Raw.compute_psd>`, :meth:`Epochs.compute_psd() <mne.Epochs.compute_psd>`, and :meth:`Evoked.compute_psd() <mne.Evoked.compute_psd>`, to allow skipping DC removal when computing Welch or multitaper spectra (:gh:`11769` by `Nikolai Chapochnikov`_)
 
 Bugs

--- a/doc/file_io.rst
+++ b/doc/file_io.rst
@@ -53,6 +53,7 @@ File I/O
    write_trans
    what
    io.read_info
+   io.write_info
    io.show_fiff
    io.get_channel_type_constants
 

--- a/mne/_fiff/meas_info.py
+++ b/mne/_fiff/meas_info.py
@@ -19,11 +19,11 @@ import numpy as np
 
 from .pick import (
     channel_type,
-    _get_channel_types,
     get_channel_type_constants,
     pick_types,
     _picks_to_idx,
     _contains_ch_type,
+    _DATA_CH_TYPES_SPLIT,
 )
 from .constants import FIFF, _coord_frame_named, _ch_unit_mul_named
 from .open import fiff_open
@@ -906,9 +906,17 @@ class ContainsMixin:
             The channel types.
         """
         info = self if isinstance(self, Info) else self.info
-        return _get_channel_types(
-            info, picks=picks, unique=unique, only_data_chs=only_data_chs
-        )
+        none = "data" if only_data_chs else "all"
+        picks = _picks_to_idx(info, picks, none, (), allow_empty=False)
+        ch_types = [channel_type(info, pick) for pick in picks]
+        if only_data_chs:
+            ch_types = [
+                ch_type for ch_type in ch_types if ch_type in _DATA_CH_TYPES_SPLIT
+            ]
+        if unique:
+            # set does not preserve order but dict does, so let's just use it
+            ch_types = list({k: k for k in ch_types}.keys())
+        return ch_types
 
 
 def _format_trans(obj, key):

--- a/mne/_fiff/pick.py
+++ b/mne/_fiff/pick.py
@@ -1428,33 +1428,3 @@ def _picks_str_to_idx(
     if return_kind:
         return picks, picked_ch_type_or_generic
     return picks
-
-
-# TODO: Remove this, shouldn't be needed
-def _pick_inst(inst, picks, exclude, copy=True):
-    """Return an instance with picked and excluded channels."""
-    if copy is True:
-        inst = inst.copy()
-    picks = _picks_to_idx(inst.info, picks, exclude=[])
-    pick_names = [inst.info["ch_names"][pick] for pick in picks]
-    inst.pick_channels(pick_names)
-
-    if exclude == "bads":
-        exclude = [ch for ch in inst.info["bads"] if ch in inst.info["ch_names"]]
-    if exclude is not None:
-        inst.drop_channels(exclude)
-    return inst
-
-
-# TODO: Remove this and make it a method of info
-def _get_channel_types(info, picks=None, unique=False, only_data_chs=False):
-    """Get the data channel types in an info instance."""
-    none = "data" if only_data_chs else "all"
-    picks = _picks_to_idx(info, picks, none, (), allow_empty=False)
-    ch_types = [channel_type(info, pick) for pick in picks]
-    if only_data_chs:
-        ch_types = [ch_type for ch_type in ch_types if ch_type in _DATA_CH_TYPES_SPLIT]
-    if unique:
-        # set does not preserve order but dict does, so let's just use it
-        ch_types = list({k: k for k in ch_types}.keys())
-    return ch_types

--- a/mne/_fiff/tests/test_pick.py
+++ b/mne/_fiff/tests/test_pick.py
@@ -33,7 +33,6 @@ from mne._fiff.pick import (
     _picks_by_type,
     _picks_to_idx,
     _contains_ch_type,
-    _get_channel_types,
     _DATA_CH_TYPES_SPLIT,
     get_channel_type_constants,
 )
@@ -353,7 +352,7 @@ def test_pick_chpi():
     # Make sure we don't mis-classify cHPI channels
     info = read_info(io_dir / "tests" / "data" / "test_chpi_raw_sss.fif")
     _assert_channel_types(info)
-    channel_types = _get_channel_types(info)
+    channel_types = info.get_channel_types()
     assert "chpi" in channel_types
     assert "seeg" not in channel_types
     assert "ecog" not in channel_types

--- a/mne/decoding/ssd.py
+++ b/mne/decoding/ssd.py
@@ -11,7 +11,7 @@ from ..fixes import BaseEstimator
 from ..cov import _regularized_covariance, Covariance
 from ..defaults import _handle_default
 from ..filter import filter_data
-from .._fiff.pick import _get_channel_types, _picks_to_idx
+from .._fiff.pick import _picks_to_idx
 from ..rank import compute_rank
 from ..time_frequency import psd_array_welch
 from ..utils import (
@@ -129,7 +129,7 @@ class SSD(BaseEstimator, TransformerMixin):
             )
         self.picks_ = _picks_to_idx(info, picks, none="data", exclude="bads")
         del picks
-        ch_types = _get_channel_types(info, picks=self.picks_, unique=True)
+        ch_types = info.get_channel_types(picks=self.picks_, unique=True)
         if len(ch_types) > 1:
             raise ValueError(
                 "At this point SSD only supports fitting "

--- a/mne/io/__init__.py
+++ b/mne/io/__init__.py
@@ -52,6 +52,7 @@ __getattr_lz__, __dir__, __all__ = lazy.attach(
         "eyelink": ["read_raw_eyelink"],
         "_fiff_wrap": [
             "read_info",
+            "write_info",
             "anonymize_info",
             "read_fiducials",
             "write_fiducials",

--- a/mne/io/_fiff_wrap.py
+++ b/mne/io/_fiff_wrap.py
@@ -4,6 +4,7 @@
 # (and _empty_info is convenient to keep here for tests and is private)
 from .._fiff.meas_info import (
     read_info,
+    write_info,
     anonymize_info,
     read_fiducials,
     write_fiducials,

--- a/mne/preprocessing/_annotate_amplitude.py
+++ b/mne/preprocessing/_annotate_amplitude.py
@@ -11,7 +11,7 @@ from ..annotations import (
     _adjust_onset_meas_date,
     _annotations_starts_stops,
 )
-from .._fiff.pick import _picks_to_idx, _picks_by_type, _get_channel_types
+from .._fiff.pick import _picks_to_idx, _picks_by_type
 from ..utils import _validate_type, verbose, logger, _mask_to_onsets_offsets
 
 
@@ -204,7 +204,7 @@ def _check_ptp(ptp, name, info, picks):
                 f"Argument '{name}' should define a positive threshold. "
                 f"Provided: '{ptp}'."
             )
-        ch_types = set(_get_channel_types(info, picks))
+        ch_types = set(info.get_channel_types(picks))
         ptp = {ch_type: ptp for ch_type in ch_types}
     elif isinstance(ptp, dict):
         for key, value in ptp.items():

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -36,7 +36,6 @@ from .._fiff.pick import (
     pick_channels,
     pick_info,
     _picks_to_idx,
-    _get_channel_types,
     _DATA_CH_TYPES_SPLIT,
 )
 from .._fiff.proj import make_projector
@@ -189,7 +188,7 @@ def _check_for_unsupported_ica_channels(picks, info, allow_ref_meg=False):
     """
     types = _DATA_CH_TYPES_SPLIT + ("eog",)
     types += ("ref_meg",) if allow_ref_meg else ()
-    chs = _get_channel_types(info, picks, unique=True, only_data_chs=False)
+    chs = info.get_channel_types(picks, unique=True, only_data_chs=False)
     check = all([ch in types for ch in chs])
     if not check:
         raise ValueError(

--- a/mne/tests/test_rank.py
+++ b/mne/tests/test_rank.py
@@ -10,7 +10,7 @@ from mne import read_evokeds, read_cov, compute_raw_covariance, pick_types, pick
 from mne.cov import prepare_noise_cov
 from mne.datasets import testing
 from mne.io import read_raw_fif
-from mne._fiff.pick import _picks_by_type, _get_channel_types
+from mne._fiff.pick import _picks_by_type
 from mne._fiff.proj import _has_eeg_average_ref_proj
 from mne.proj import compute_proj_raw
 from mne.rank import (
@@ -169,7 +169,7 @@ def test_cov_rank_estimation(rank_method, proj, meg):
             )
 
             # count channel types
-            ch_types = _get_channel_types(this_info)
+            ch_types = this_info.get_channel_types()
             n_eeg, n_mag, n_grad = [ch_types.count(k) for k in ["eeg", "mag", "grad"]]
             n_meg = n_mag + n_grad
             has_sss = n_meg > 0 and len(this_info["proc_history"]) > 0

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -55,8 +55,6 @@ from .._fiff.pick import (
     pick_info,
     _picks_to_idx,
     channel_type,
-    _pick_inst,
-    _get_channel_types,
 )
 from .._fiff.meas_info import Info, ContainsMixin
 from ..viz.utils import (
@@ -1929,9 +1927,12 @@ class AverageTFR(_BaseTFR):
         # channel type.
         # Nonetheless, it should be refactored for code reuse.
         copy = any(var is not None for var in (exclude, picks, baseline))
-        tfr = _pick_inst(self, picks, exclude, copy=copy)
+        tfr = self
+        if copy:
+            tfr = tfr.copy()
+        tfr.pick(picks, exclude=exclude)
         del picks
-        ch_types = _get_channel_types(tfr.info, unique=True)
+        ch_types = tfr.info.get_channel_types(unique=True)
 
         # if multiple sensor types: one plot per channel type, recursive call
         if len(ch_types) > 1:
@@ -1945,8 +1946,8 @@ class AverageTFR(_BaseTFR):
                     for idx in range(tfr.info["nchan"])
                     if channel_type(tfr.info, idx) == this_type
                 ]
-                tf_ = _pick_inst(tfr, type_picks, None, copy=True)
-                if len(_get_channel_types(tf_.info, unique=True)) > 1:
+                tf_ = tfr.copy().pick(type_picks)
+                if len(tf_.info.get_channel_types(unique=True)) > 1:
                     raise RuntimeError(
                         "Possibly infinite loop due to channel selection "
                         "problem. This should never happen! Please check "

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1930,7 +1930,8 @@ class AverageTFR(_BaseTFR):
         tfr = self
         if copy:
             tfr = tfr.copy()
-        tfr.pick(picks, exclude=exclude)
+        picks = "data" if picks is None else picks
+        tfr.pick(picks, exclude=() if exclude is None else exclude)
         del picks
         ch_types = tfr.info.get_channel_types(unique=True)
 

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -26,7 +26,6 @@ from ..utils.spectrum import _split_psd_kwargs
 from .._fiff.meas_info import create_info
 
 from .._fiff.pick import (
-    _get_channel_types,
     _picks_to_idx,
     _DATA_CH_TYPES_SPLIT,
     _VALID_CHANNEL_TYPES,
@@ -237,7 +236,7 @@ def plot_epochs_image(
 
     # is picks a channel type (or None)?
     picks, picked_types = _picks_to_idx(epochs.info, picks, return_kind=True)
-    ch_types = _get_channel_types(epochs.info, picks)
+    ch_types = epochs.info.get_channel_types(picks)
 
     # `combine` defaults to 'gfp' unless picks are specific channels and
     # there was no group_by passed

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -23,8 +23,6 @@ from .._fiff.pick import (
     _VALID_CHANNEL_TYPES,
     channel_indices_by_type,
     _DATA_CH_TYPES_SPLIT,
-    _pick_inst,
-    _get_channel_types,
     _PICK_TYPES_DATA_DICT,
     _picks_to_idx,
     pick_info,
@@ -452,7 +450,7 @@ def _plot_evoked(
 
         picks = np.array([pick for pick in picks if pick not in exclude])
 
-    types = np.array(_get_channel_types(info, picks), str)
+    types = np.array(info.get_channel_types(picks), str)
     ch_types_used = list()
     for this_type in _VALID_CHANNEL_TYPES:
         if this_type in types:
@@ -1912,9 +1910,9 @@ def plot_evoked_joint(
         if proj == "reconstruct":
             evoked._reconstruct_proj()
     topomap_args["proj"] = ts_args["proj"] = False  # don't reapply
-    evoked = _pick_inst(evoked, picks, exclude, copy=False)
+    evoked.pick(picks, exclude=exclude)
     info = evoked.info
-    ch_types = _get_channel_types(info, unique=True, only_data_chs=True)
+    ch_types = info.get_channel_types(unique=True, only_data_chs=True)
 
     # if multiple sensor types: one plot per channel type, recursive call
     if len(ch_types) > 1:
@@ -1932,7 +1930,7 @@ def plot_evoked_joint(
                     if channel_type(info, idx) == this_type
                 ]
             )
-            if len(_get_channel_types(ev_.info, unique=True)) > 1:
+            if len(ev_.info.get_channel_types(unique=True)) > 1:
                 raise RuntimeError(
                     "Possibly infinite loop due to channel "
                     "selection problem. This should never "
@@ -2903,7 +2901,7 @@ def plot_compare_evokeds(
         "ref_meg",
     )
     ch_types = [
-        t for t in _get_channel_types(info, picks=picks, unique=True) if t in all_types
+        t for t in info.get_channel_types(picks=picks, unique=True) if t in all_types
     ]
     picks_by_type = channel_indices_by_type(info, picks)
     # discard picks from non-data channels (e.g., ref_meg)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -36,7 +36,6 @@ from .._fiff.pick import (
     pick_channels,
     _pick_data_channels,
     _picks_to_idx,
-    _get_channel_types,
     _MEG_CH_TYPES_SPLIT,
 )
 from ..utils import (
@@ -481,7 +480,7 @@ def _plot_projs_topomap(
         ch_names = _clean_names(proj["data"]["col_names"], remove_whitespace=True)
         if vlim == "joint":
             ch_idxs = np.where(np.in1d(info["ch_names"], proj["data"]["col_names"]))[0]
-            these_ch_types = _get_channel_types(info, ch_idxs, unique=True)
+            these_ch_types = info.get_channel_types(ch_idxs, unique=True)
             # each projector should have only one channel type
             assert len(these_ch_types) == 1
             types.append(list(these_ch_types)[0])
@@ -1181,7 +1180,7 @@ def _plot_topomap(
         pos = pick_info(pos, picks)
 
         # check if there is only 1 channel type, and n_chans matches the data
-        ch_type = _get_channel_types(pos, unique=True)
+        ch_type = pos.get_channel_types(pos, unique=True)
         info_help = (
             "Pick Info with e.g. mne.pick_info and " "mne.channel_indices_by_type."
         )
@@ -4003,7 +4002,7 @@ def plot_regression_weights(
 
     sphere = _check_sphere(sphere)
     if ch_type is None:
-        ch_types = _get_channel_types(model.info_, unique=True, only_data_chs=True)
+        ch_types = model.info_.get_channel_types(unique=True, only_data_chs=True)
     else:
         ch_types = [ch_type]
     del ch_type

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1180,7 +1180,7 @@ def _plot_topomap(
         pos = pick_info(pos, picks)
 
         # check if there is only 1 channel type, and n_chans matches the data
-        ch_type = pos.get_channel_types(pos, unique=True)
+        ch_type = pos.get_channel_types(picks=None, unique=True)
         info_help = (
             "Pick Info with e.g. mne.pick_info and " "mne.channel_indices_by_type."
         )


### PR DESCRIPTION
Some TODOs I noticed:

1. Shouldn't need `_pick_inst`, just use `inst.pick` directly
2. From @alexrockhill we should have `write_info` to match `read_info`
3. `_get_channel_types` always operates on `info` and we have a public `info.get_channel_types` so we should just use it directly