### PR TITLE
fix Spectrum init in tutorial

### DIFF
--- a/tutorials/simulation/10_array_objs.py
+++ b/tutorials/simulation/10_array_objs.py
@@ -251,6 +251,7 @@ def spectrum_from_array(
         tmax=None,
         picks=None,
         proj=None,
+        remove_dc=None,
         reject_by_annotation=None,
         n_jobs=None,
         verbose=None,


### PR DESCRIPTION
#11769 introduced a new `remove_dc` param to `Spectrum.__init__` but we forgot to add it to the relevant tutorial. 