### PR TITLE
DOC: update name of changelog in contributing guide

### DIFF
--- a/doc/install/contributing.rst
+++ b/doc/install/contributing.rst
@@ -587,7 +587,7 @@ Describe your changes in the changelog
 --------------------------------------
 
 Include in your changeset a brief description of the change in the
-:ref:`changelog <whats_new>` (:file:`doc/changes/latest.inc`; this can be
+:ref:`changelog <whats_new>` (:file:`doc/changes/devel.rst`; this can be
 skipped for very minor changes like correcting typos in the documentation).
 
 There are different sections of the changelog for each release, and separate


### PR DESCRIPTION
I got a bit confused when I couldn't find `latest.inc` in my doc folder anymore! - Thinking I may have forgot something I checked the contributing guide and it still points users to `latest.inc`.  I updated the doc to point users to `devel.rst`, which seems to be the new changelog file name!

Since this is a very minor change, I included `[skip actions] [skip azp]` in my commit message, but let me know if you want to trigger a full run of the CI.