### PR TITLE
MAINT: Simplify logic for radius

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -30,7 +30,7 @@ Enhancements
 - Added option ``remove_dc`` to to :meth:`Raw.compute_psd() <mne.io.Raw.compute_psd>`, :meth:`Epochs.compute_psd() <mne.Epochs.compute_psd>`, and :meth:`Evoked.compute_psd() <mne.Evoked.compute_psd>`, to allow skipping DC removal when computing Welch or multitaper spectra (:gh:`11769` by `Nikolai Chapochnikov`_)
 - Add the possibility to provide a float between 0 and 1 as ``n_grad``, ``n_mag`` and ``n_eeg`` in `~mne.compute_proj_raw`, `~mne.compute_proj_epochs` and `~mne.compute_proj_evoked` to select the number of vectors based on the cumulative explained variance (:gh:`11919` by `Mathieu Scheltienne`_)
 - Add helpful error messages when using methods on empty :class:`mne.Epochs`-objects (:gh:`11306` by `Martin Schulz`_)
-- Add inferring EEGLAB files' montage unit automatically based on estimated head radius using :func:`read_raw_eeglab(..., montage_units="auto") <mne.io.read_raw_eeglab>` (:gh:`11925` by `Jack Zhang`_)
+- Add inferring EEGLAB files' montage unit automatically based on estimated head radius using :func:`read_raw_eeglab(..., montage_units="auto") <mne.io.read_raw_eeglab>` (:gh:`11925` by `Jack Zhang`_, :gh:`11951` by `Eric Larson`_)
 - Add :class:`~mne.time_frequency.EpochsSpectrumArray` and :class:`~mne.time_frequency.SpectrumArray` to support creating power spectra from :class:`NumPy array <numpy.ndarray>` data (:gh:`11803` by `Alex Rockhill`_)
 
 Bugs

--- a/examples/visualization/roi_erpimage_by_rt.py
+++ b/examples/visualization/roi_erpimage_by_rt.py
@@ -9,8 +9,7 @@ This will produce what is sometimes called an event related
 potential / field (ERP/ERF) image.
 
 The EEGLAB example file, which contains an experiment with button press
-responses to simple visual stimuli, is read in and response times are
-calculated.
+responses to simple visual stimuli, is read in and response times are calculated.
 Regions of Interest are determined by the channel types (in 10/20 channel
 notation, even channels are right, odd are left, and 'z' are central). The
 median and the Global Field Power within each channel group is calculated,

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -268,10 +268,10 @@ def _handle_montage_units(montage_units, mean_radius):
             montage_units = "m"
         elif mean_radius < 2.5:
             montage_units = "dm"
-        elif mean_radius > 25:
-            montage_units = "mm"
-        else:  # 2.5 <= mean_radius <= 25
+        elif mean_radius < 25:
             montage_units = "cm"
+        else:  # mean_radius >= 25
+            montage_units = "mm"
     prefix = montage_units[:-1]
     scale_units = 1 / DEFAULTS["prefixes"][prefix]
     return scale_units

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -665,7 +665,11 @@ def test_get_montage_info_with_ch_type():
     mat["EEG"]["chanlocs"]["type"] = ["eeg"] * (n - 2) + ["eog"] + ["stim"]
     mat["EEG"]["chanlocs"] = _dol_to_lod(mat["EEG"]["chanlocs"])
     mat["EEG"] = Bunch(**mat["EEG"])
-    ch_names, ch_types, montage = _get_montage_information(mat["EEG"], False)
+    ch_names, ch_types, montage = _get_montage_information(
+        mat["EEG"],
+        get_pos=False,
+        montage_units="mm",
+    )
     assert len(ch_names) == len(ch_types) == n
     assert ch_types == ["eeg"] * (n - 2) + ["eog"] + ["stim"]
     assert montage is None
@@ -677,7 +681,11 @@ def test_get_montage_info_with_ch_type():
     mat["EEG"]["chanlocs"] = _dol_to_lod(mat["EEG"]["chanlocs"])
     mat["EEG"] = Bunch(**mat["EEG"])
     with pytest.warns(RuntimeWarning, match="Unknown types found"):
-        ch_names, ch_types, montage = _get_montage_information(mat["EEG"], False)
+        ch_names, ch_types, montage = _get_montage_information(
+            mat["EEG"],
+            get_pos=False,
+            montage_units="mm",
+        )
 
 
 @testing.requires_testing_data
@@ -686,9 +694,9 @@ def test_fidsposition_information(monkeypatch, has_type):
     """Test reading file with 3 fiducial locations."""
     if not has_type:
 
-        def get_bad_information(eeg, get_pos, scale_units=1.0):
+        def get_bad_information(eeg, get_pos, *, montage_units):
             del eeg.chaninfo["nodatchans"]["type"]
-            return _get_montage_information(eeg, get_pos, scale_units=scale_units)
+            return _get_montage_information(eeg, get_pos, montage_units=montage_units)
 
         monkeypatch.setattr(
             mne.io.eeglab.eeglab, "_get_montage_information", get_bad_information

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -3446,13 +3446,16 @@ def corrmap(
 
 
 @verbose
-def read_ica_eeglab(fname, *, verbose=None):
+def read_ica_eeglab(fname, *, montage_units="auto", verbose=None):
     """Load ICA information saved in an EEGLAB .set file.
 
     Parameters
     ----------
     fname : path-like
         Complete path to a ``.set`` EEGLAB file that contains an ICA object.
+    %(montage_units)s
+
+        .. versionadded:: 1.6
     %(verbose)s
 
     Returns
@@ -3461,7 +3464,7 @@ def read_ica_eeglab(fname, *, verbose=None):
         An ICA object based on the information contained in the input file.
     """
     eeg = _check_load_mat(fname, None)
-    info, eeg_montage, _ = _get_info(eeg)
+    info, eeg_montage, _ = _get_info(eeg, eog=(), montage_units=montage_units)
     info.set_montage(eeg_montage)
     pick_info(info, np.round(eeg["icachansind"]).astype(int) - 1, copy=False)
 

--- a/tutorials/intro/20_events_from_raw.py
+++ b/tutorials/intro/20_events_from_raw.py
@@ -61,7 +61,6 @@ raw.crop(tmax=60).load_data()
 #    :class:`NumPy array <numpy.ndarray>`, whereas `~mne.Annotations` is
 #    a :class:`list`-like class defined in MNE-Python.
 #
-#
 # .. _stim-channel-defined:
 #
 # What is a STIM channel?


### PR DESCRIPTION
Follow-up to #11925 by @jackz314 to simplify the logic a bit and fix [CircleCI](https://app.circleci.com/pipelines/github/mne-tools/mne-python/20496/workflows/c463dfaf-1a7a-4eff-9916-0d1707a1f730/jobs/58294). Basically by waiting to process `montage_units` until later we can avoid having to check if there are positions available, and we only try to figure out the radius if they are. This refactoring -- which involved moving the logic deeper in `_get_info` -- made it clear that it should also be added to `mne.preprocessing.read_ica_eeglab`, too, which is nice.