### PR TITLE
Fix bug with subject_info when loading from and exporting to EDF file

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -43,6 +43,7 @@ Bugs
 - Fix bug with ``pca=False`` in :func:`mne.minimum_norm.compute_source_psd` (:gh:`11927` by `Alex Gramfort`_)
 - Removed preload parameter from :func:`mne.io.read_raw_eyelink`, because data are always preloaded no matter what preload is set to (:gh:`11910` by `Scott Huberty`_)
 - Fix bug with :meth:`~mne.viz.Brain.add_annotation` when reading an annotation from a file with both hemispheres shown (:gh:`11946` by `Marijn van Vliet`_)
+- Fix bug with ``subject_info`` when loading data from and exporting to EDF file (:gh:`11952` by `Paul Roujansky`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -193,12 +193,7 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
             first_name = subj_info.get("first_name", "")
             middle_name = subj_info.get("middle_name", "")
             last_name = subj_info.get("last_name", "")
-            name = ""
-            for value in [first_name, middle_name, last_name]:
-                if value:
-                    if name:
-                        name += " "
-                    name += value
+            name = " ".join(filter(None, [first_name, middle_name, last_name]))
 
             birthday = subj_info.get("birthday")
             hand = subj_info.get("hand")
@@ -206,18 +201,14 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
             height = subj_info.get("height")
             sex = subj_info.get("sex")
 
-            additional_patient_info = ""
-            for key, value in [
-                ("height", height),
-                ("weight", weight),
-                ("hand", hand),
-            ]:
+            additional_patient_info = []
+            for key, value in [("height", height), ("weight", weight), ("hand", hand)]:
                 if value:
-                    if additional_patient_info:
-                        additional_patient_info += " "
-                    additional_patient_info += f"{key}={value}"
-            if not additional_patient_info:
+                    additional_patient_info.append(f"{key}={value}")
+            if len(additional_patient_info) == 0:
                 additional_patient_info = None
+            else:
+                additional_patient_info = " ".join(additional_patient_info)
 
             if birthday is not None:
                 if hdl.setPatientBirthDate(birthday[0], birthday[1], birthday[2]) != 0:

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -140,11 +140,19 @@ def test_double_export_edf(tmp_path):
         "bio",
     ]
     info = create_info(len(ch_types), sfreq=1000, ch_types=ch_types)
+    info = info.set_meas_date("2023-09-04 14:53:09.000")
     data = rng.random(size=(len(ch_types), 1000)) * 1e-5
 
     # include subject info and measurement date
     info["subject_info"] = dict(
-        first_name="mne", last_name="python", birthday=(1992, 1, 20), sex=1, hand=3
+        his_id="12345",
+        first_name="mne",
+        last_name="python",
+        birthday=(1992, 1, 20),
+        sex=1,
+        weight=78.3,
+        height=1.75,
+        hand=3,
     )
     raw = RawArray(data, info)
 
@@ -168,6 +176,10 @@ def test_double_export_edf(tmp_path):
         raw.get_data(), raw_read.get_data()[:, :orig_raw_len], decimal=4
     )
     assert_allclose(raw.times, raw_read.times[:orig_raw_len], rtol=0, atol=1e-5)
+
+    # check info
+    for key in set(raw.info) - {"chs"}:
+        assert raw.info[key] == raw_read.info[key]
 
     # check channel types except for 'bio', which loses its type
     orig_ch_types = raw.get_channel_types()

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -642,6 +642,49 @@ def _get_info(
     info["chs"] = chs
     info["ch_names"] = ch_names
 
+    # Subject information
+    info["subject_info"] = {}
+
+    # String subject identifier
+    if edf_info["subject_info"]["id"] is not None:
+        info["subject_info"]["his_id"] = edf_info["subject_info"]["id"]
+    # Subject sex (0=unknown, 1=male, 2=female)
+    if edf_info["subject_info"].get("sex") is not None:
+        if edf_info["subject_info"]["sex"] == "M":
+            info["subject_info"]["sex"] = 1
+        elif edf_info["subject_info"]["sex"] == "F":
+            info["subject_info"]["sex"] = 2
+        else:
+            info["subject_info"]["sex"] = 0
+    # Subject names (first, middle, last).
+    if edf_info["subject_info"].get("name") is not None:
+        sub_names = edf_info["subject_info"]["name"].split("_")
+        if len(sub_names) < 2 or len(sub_names) > 3:
+            info["subject_info"]["last_name"] = edf_info["subject_info"]["name"]
+        elif len(sub_names) == 2:
+            info["subject_info"]["first_name"] = sub_names[0]
+            info["subject_info"]["last_name"] = sub_names[1]
+        else:
+            info["subject_info"]["first_name"] = sub_names[0]
+            info["subject_info"]["middle_name"] = sub_names[1]
+            info["subject_info"]["last_name"] = sub_names[2]
+    # Birthday in (year, month, day) format.
+    if isinstance(edf_info["subject_info"].get("birthday"), datetime):
+        info["subject_info"]["birthday"] = (
+            edf_info["subject_info"]["birthday"].year,
+            edf_info["subject_info"]["birthday"].month,
+            edf_info["subject_info"]["birthday"].day,
+        )
+    # Handedness (1=right, 2=left, 3=ambidextrous).
+    if edf_info["subject_info"].get("hand") is not None:
+        info["subject_info"]["hand"] = int(edf_info["subject_info"]["hand"])
+    # Height in meters.
+    if edf_info["subject_info"].get("height") is not None:
+        info["subject_info"]["height"] = float(edf_info["subject_info"]["height"])
+    # Weight in kilograms.
+    if edf_info["subject_info"].get("weight") is not None:
+        info["subject_info"]["weight"] = float(edf_info["subject_info"]["weight"])
+
     # Filter settings
     highpass = edf_info["highpass"]
     lowpass = edf_info["lowpass"]
@@ -764,7 +807,7 @@ def _read_edf_header(fname, exclude, infer_types, include=None):
         id_info = id_info.split(" ")
         if len(id_info):
             patient["id"] = id_info[0]
-            if len(id_info) == 4:
+            if len(id_info) >= 4:
                 try:
                     birthdate = datetime.strptime(id_info[2], "%d-%b-%Y")
                 except ValueError:
@@ -772,6 +815,16 @@ def _read_edf_header(fname, exclude, infer_types, include=None):
                 patient["sex"] = id_info[1]
                 patient["birthday"] = birthdate
                 patient["name"] = id_info[3]
+                if len(id_info) > 4:
+                    for info in id_info[4:]:
+                        if "=" in info:
+                            key, value = info.split("=")
+                            if key in ["weight", "height"]:
+                                patient[key] = float(value)
+                            elif key in ["hand"]:
+                                patient[key] = int(value)
+                            else:
+                                warn(f"Invalid patient information {key}")
 
         # Recording ID
         meas_id = {}

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -646,7 +646,7 @@ def _get_info(
     info["subject_info"] = {}
 
     # String subject identifier
-    if edf_info["subject_info"]["id"] is not None:
+    if edf_info["subject_info"].get("id") is not None:
         info["subject_info"]["his_id"] = edf_info["subject_info"]["id"]
     # Subject sex (0=unknown, 1=male, 2=female)
     if edf_info["subject_info"].get("sex") is not None:

--- a/mne/io/edf/tests/test_gdf.py
+++ b/mne/io/edf/tests/test_gdf.py
@@ -100,8 +100,14 @@ def test_gdf2_birthday(tmp_path):
         assert np.fromfile(fid, np.uint64, 1)[0] == d
     raw = read_raw_gdf(new_fname, eog=None, misc=None, preload=True)
     assert raw._raw_extras[0]["subject_info"]["age"] == 44
-    # XXX this is a bug, it should be populated...
-    assert raw.info["subject_info"] is None
+    assert raw.info["subject_info"] is not None
+
+    birthdate = datetime(1, 1, 1, tzinfo=timezone.utc) + offset_44_yr
+    assert raw.info["subject_info"]["birthday"] == (
+        birthdate.year,
+        birthdate.month,
+        birthdate.day,
+    )
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
Fixes https://github.com/mne-tools/mne-python/issues/11947

"subject_info" were never actually set in the `RawEDF.info` object when loading an EDF file. Plus, additional subject's information were not correctly set in `RawEDF._raw_extras`. This PR aims at fixing this and therefore prevent any subject information from being lost when either reading or exporting data.

As per @larsoner's suggestion (see https://github.com/mne-tools/mne-python/issues/11947#issuecomment-1703037741), `info` are updated from `edf_info` in func `_get_info()` from [mne/io/edf/edf.py#L521](https://github.com/mne-tools/mne-python/blob/maint/1.5/mne/io/edf/edf.py#L521) following `subject_info` description in the Notes section from https://mne.tools/stable/generated/mne.Info.html description.

Tests have been modified to both reflect the bug and check the fix.

