### PR TITLE
Refactor writing raw file

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1697,7 +1697,7 @@ class BaseRaw(
         _validate_type(split_naming, str, "split_naming")
         _check_option("split_naming", split_naming, ("neuromag", "bids"))
 
-        cfg = _WriteRawFidCfg(buffer_size, split_size, drop_small_buffer, fmt)
+        cfg = _RawFidWriterCfg(buffer_size, split_size, drop_small_buffer, fmt)
         raw_fid_writer = _RawFidWriter(self, info, picks, projector, start, stop, cfg)
         _write_raw(raw_fid_writer, fname, split_naming, overwrite)
 
@@ -2603,7 +2603,7 @@ class _ReservedFilename:
 
 
 @dataclass(frozen=True)
-class _WriteRawFidCfg:
+class _RawFidWriterCfg:
     buffer_size: int
     split_size: int
     drop_small_buffer: bool
@@ -2698,7 +2698,11 @@ class _RawFidWriter:
             if self.projector is not None:
                 data = np.dot(self.projector, data)
 
-            if self.cfg.drop_small_buffer and (first > self.start) and (len(times) < self.cfg.buffer_size):
+            if (
+                self.cfg.drop_small_buffer
+                and (first > self.start)
+                and (len(times) < self.cfg.buffer_size)
+            ):
                 logger.info("Skipping data chunk due to small buffer ... " "[done]")
                 break
             logger.debug(f"Writing FIF {first:6d} ... {last:6d} ...")
@@ -2750,7 +2754,6 @@ class _RawFidWriter:
         end_block(fid, FIFF.FIFFB_MEAS)
         return is_next_split
 
-
     @fill_doc
     def _start_writing_raw(self, fid):
         """Start write raw data in file.
@@ -2801,7 +2804,9 @@ class _RawFidWriter:
                 info["chs"][k]["range"] = 1.0
             cals.append(info["chs"][k]["cal"] * info["chs"][k]["range"])
 
-        write_meas_info(fid, info, data_type=self.cfg.data_type, reset_range=self.cfg.reset_range)
+        write_meas_info(
+            fid, info, data_type=self.cfg.data_type, reset_range=self.cfg.reset_range
+        )
 
         #
         # Annotations

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2603,7 +2603,7 @@ def _write_raw(
         _check_fname(reserved_fname, overwrite)
         ctx = _ReservedFilename(reserved_fname)
 
-    is_next_split, part_idx, next_idx = True, 0, 1
+    is_next_split, part_idx = True, 0
     use_fname = fname
     prev_fname = None
     new_start = start
@@ -2612,7 +2612,7 @@ def _write_raw(
             prev_fname = use_fname
             use_fname = dir_path / split_fnames[part_idx]
             _check_fname(use_fname, overwrite)
-        next_fname = dir_path / split_fnames[next_idx]
+        next_fname = dir_path / split_fnames[part_idx + 1]
         logger.info(f"Writing {use_fname}")
 
         picks = _picks_to_idx(info, picks, "all", ())
@@ -2637,7 +2637,6 @@ def _write_raw(
                     drop_small_buffer=drop_small_buffer,
                     fmt=fmt,
                     next_fname=next_fname,
-                    next_idx=next_idx,
                 )
                 if part_idx == 1 and split_naming == "bids":
                     logger.info(f"Renaming BIDS split file {split_fnames[0]}")
@@ -2645,7 +2644,6 @@ def _write_raw(
                     shutil.move(fname, dir_path / split_fnames[0])
             logger.info("Closing %s" % use_fname)
         part_idx += 1
-        next_idx += 1
 
     logger.info("[done]")
 
@@ -2682,7 +2680,6 @@ def _write_raw_fid(
     drop_small_buffer,
     fmt,
     next_fname,
-    next_idx,
 ):
     first_samp = raw.first_samp + start
     if first_samp != 0:
@@ -2785,7 +2782,7 @@ def _write_raw_fid(
             write_string(fid, FIFF.FIFF_REF_FILE_NAME, op.basename(next_fname))
             if info["meas_id"] is not None:
                 write_id(fid, FIFF.FIFF_REF_FILE_ID, info["meas_id"])
-            write_int(fid, FIFF.FIFF_REF_FILE_NUM, next_idx)
+            write_int(fid, FIFF.FIFF_REF_FILE_NUM, part_idx + 1)
             end_block(fid, FIFF.FIFFB_REF)
             is_next_split = True
             new_start = first + buffer_size

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -9,7 +9,6 @@
 #
 # License: BSD-3-Clause
 
-from contextlib import nullcontext
 from copy import deepcopy
 from datetime import timedelta
 import os
@@ -1702,7 +1701,8 @@ class BaseRaw(
         if split_naming == "neuromag":
             _write_raw_neuromag(raw_fid_writer, fname, overwrite)
         else:
-            _write_raw(raw_fid_writer, fname, split_naming, overwrite)
+            assert split_naming == "bids"
+            _write_raw_bids(raw_fid_writer, fname, overwrite)
 
     @verbose
     def export(
@@ -2539,44 +2539,45 @@ class _RawShell:
 
 ###############################################################################
 # Writing
-def _write_raw(raw_fid_writer, fname, split_naming, overwrite):
-    """Write raw file with splitting."""
-    # Expand `~` if present
-    fname = _check_fname(fname=fname, overwrite=overwrite)
-
+def _write_raw_bids(raw_fid_writer, fname, overwrite):
+    """Write raw file with bids split naming."""
+    MAX_N_SPLITS = 100
     dir_path = fname.parent
     # Assume we never hit more than 100 splits, like for epochs
     split_fnames = _make_split_fnames(
-        fname.name, n_splits=100, split_naming=split_naming
+        fname.name, n_splits=MAX_N_SPLITS, split_naming="bids"
     )
     # reserve our BIDS split fname in case we need to split
-    reserved_fname, ctx = fname, nullcontext()
-    if split_naming == "bids":
-        # reserve our possible split name
-        reserved_fname = dir_path / split_fnames[0]
-        logger.info(f"Reserving possible split file {reserved_fname.name}")
-        _check_fname(reserved_fname, overwrite)
-        ctx = _ReservedFilename(reserved_fname)
+    reserved_fname = dir_path / split_fnames[0]
+    logger.info(f"Reserving possible split file {reserved_fname.name}")
+    _check_fname(reserved_fname, overwrite)
+    reserved_ctx = _ReservedFilename(reserved_fname)
 
-    is_next_split, part_idx = True, 0
-    use_fname = fname
-    prev_fname = None
+    part_idx, prev_fname, next_fname = 0, None, split_fnames[1]
+    logger.info(f"Writing {fname}")
+    with start_and_end_file(fname) as fid, reserved_ctx:
+        is_next_split = raw_fid_writer.write(fid, part_idx, prev_fname, next_fname)
+        if is_next_split:
+            logger.info(f"Renaming BIDS split file {fname.name}")
+            reserved_ctx.remove = False
+            shutil.move(fname, dir_path / split_fnames[0])
+        logger.info("Closing %s" % fname)
+
+    part_idx = 1
     while is_next_split:
-        if part_idx > 0:
-            prev_fname = use_fname
-            use_fname = dir_path / split_fnames[part_idx]
-            _check_fname(use_fname, overwrite)
-        next_fname = dir_path / split_fnames[part_idx + 1]
-        logger.info(f"Writing {use_fname}")
+        prev_fname = split_fnames[part_idx - 1]
+        next_fname = split_fnames[part_idx + 1]
+        use_fname = dir_path / split_fnames[part_idx]
+        _check_fname(use_fname, overwrite)
 
-        with start_and_end_file(use_fname) as fid, ctx:
+        logger.info(f"Writing {use_fname}")
+        with start_and_end_file(use_fname) as fid:
             is_next_split = raw_fid_writer.write(fid, part_idx, prev_fname, next_fname)
-            if part_idx == 1 and split_naming == "bids":
-                logger.info(f"Renaming BIDS split file {split_fnames[0]}")
-                ctx.remove = False
-                shutil.move(fname, dir_path / split_fnames[0])
             logger.info("Closing %s" % use_fname)
         part_idx += 1
+        assert (
+            part_idx <= MAX_N_SPLITS
+        ), f"Exceeded maximum amount of splits: {MAX_N_SPLITS}."
 
     logger.info("[done]")
 
@@ -2602,7 +2603,9 @@ def _write_raw_neuromag(raw_fid_writer, fname, overwrite):
             logger.info(f"Closing {use_fname}")
 
         part_idx += 1
-        assert part_idx <= MAX_N_SPLITS, f"Exceeded maximum amount of splits: {MAX_N_SPLITS}."
+        assert (
+            part_idx <= MAX_N_SPLITS
+        ), f"Exceeded maximum amount of splits: {MAX_N_SPLITS}."
 
     logger.info("[done]")
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2566,16 +2566,15 @@ def _write_raw(raw_fid_writer, fname, split_naming, overwrite):
         next_fname = dir_path / split_fnames[part_idx + 1]
         logger.info(f"Writing {use_fname}")
 
-        with start_and_end_file(use_fname) as fid:
+        with start_and_end_file(use_fname) as fid, ctx:
             cals = raw_fid_writer._start_writing_raw(fid)
-            with ctx:
-                is_next_split = raw_fid_writer._write_raw_fid(
-                    fid, cals, part_idx, prev_fname, next_fname
-                )
-                if part_idx == 1 and split_naming == "bids":
-                    logger.info(f"Renaming BIDS split file {split_fnames[0]}")
-                    ctx.remove = False
-                    shutil.move(fname, dir_path / split_fnames[0])
+            is_next_split = raw_fid_writer._write_raw_fid(
+                fid, cals, part_idx, prev_fname, next_fname
+            )
+            if part_idx == 1 and split_naming == "bids":
+                logger.info(f"Renaming BIDS split file {split_fnames[0]}")
+                ctx.remove = False
+                shutil.move(fname, dir_path / split_fnames[0])
             logger.info("Closing %s" % use_fname)
         part_idx += 1
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2813,9 +2813,6 @@ def _write_raw_metadata(fid, info, data_type, reset_range, annotations):
     fid : file
         The created file.
     %(info_not_none)s
-    sel : array of int | None
-        Indices of channels to include. If None, all channels
-        are included.
     data_type : int
         The data_type in case it is necessary. Should be 4 (FIFFT_FLOAT),
         5 (FIFFT_DOUBLE), 16 (FIFFT_DAU_PACK16), or 3 (FIFFT_INT) for raw data.
@@ -2826,8 +2823,6 @@ def _write_raw_metadata(fid, info, data_type, reset_range, annotations):
 
     Returns
     -------
-    fid : file
-        The file descriptor.
     cals : list
         calibration factors.
     """

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2731,10 +2731,7 @@ class _RawFidWriter:
             # Split files if necessary, leave some space for next file info
             # make sure we check to make sure we actually *need* another buffer
             # with the "and" check
-            if (
-                pos >= self.cfg.split_size - this_buff_size_bytes - _NEXT_FILE_BUFFER
-                and first + self.cfg.buffer_size < self.stop
-            ):
+            if self._should_split(first, pos, pos_prev):
                 self._write_neighbour_fname(fid, op.basename(next_fname), part_idx + 1, "next")
                 is_next_split = True
                 self.start = first + self.cfg.buffer_size
@@ -2743,6 +2740,13 @@ class _RawFidWriter:
 
         self._end_raw_block(fid)
         return is_next_split
+
+    def _should_split(self, first, pos, pos_prev):
+        is_last_buffer = first + self.cfg.buffer_size >= self.stop
+        if is_last_buffer:
+            return False
+        this_buff_size_bytes = pos - pos_prev
+        return pos >= self.cfg.split_size - this_buff_size_bytes - _NEXT_FILE_BUFFER
 
     @fill_doc
     def _start_writing_raw(self, fid):

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2633,7 +2633,6 @@ def _write_raw(
                     buffer_size=buffer_size,
                     prev_fname=prev_fname,
                     split_size=split_size,
-                    use_fname=use_fname,
                     projector=projector,
                     drop_small_buffer=drop_small_buffer,
                     fmt=fmt,
@@ -2644,6 +2643,7 @@ def _write_raw(
                     logger.info(f"Renaming BIDS split file {split_fnames[0]}")
                     ctx.remove = False
                     shutil.move(fname, dir_path / split_fnames[0])
+            logger.info("Closing %s" % use_fname)
         part_idx += 1
         next_idx += 1
 
@@ -2678,7 +2678,6 @@ def _write_raw_fid(
     buffer_size,
     prev_fname,
     split_size,
-    use_fname,
     projector,
     drop_small_buffer,
     fmt,
@@ -2793,7 +2792,6 @@ def _write_raw_fid(
             break
         pos_prev = pos
 
-    logger.info("Closing %s" % use_fname)
     if info.get("maxshield", False):
         end_block(fid, FIFF.FIFFB_IAS_RAW_DATA)
     else:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2575,7 +2575,7 @@ def _write_raw(raw_fid_writer, fpath, split_naming, overwrite):
             logger.info(f"Closing {use_fpath}")
         part_idx += 1
         assert (
-            part_idx <= MAX_N_SPLITS
+            part_idx < MAX_N_SPLITS
         ), f"Exceeded maximum amount of splits: {MAX_N_SPLITS}."
 
     logger.info("[done]")

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2559,7 +2559,7 @@ def _write_raw(raw_fid_writer, fname, split_naming, overwrite):
                 logger.info(f"Renaming BIDS split file {fname.name}")
                 reserved_ctx.remove = False
                 shutil.move(fname, dir_path / split_fnames[0])
-            logger.info("Closing %s" % fname)
+            logger.info(f"Closing {fname}")
 
         part_idx += 1
 
@@ -2572,7 +2572,7 @@ def _write_raw(raw_fid_writer, fname, split_naming, overwrite):
         logger.info(f"Writing {use_fname}")
         with start_and_end_file(use_fname) as fid:
             is_next_split = raw_fid_writer.write(fid, part_idx, prev_fname, next_fname)
-            logger.info("Closing %s" % use_fname)
+            logger.info(f"Closing {fname}")
         part_idx += 1
         assert (
             part_idx <= MAX_N_SPLITS
@@ -2659,11 +2659,11 @@ class _RawFidWriter:
     def _check_start_stop_within_bounds(self):
         # we've done something wrong if we hit this
         n_times_max = len(self.raw.times)
+        error_msg = (
+            "Can't write raw file with no data: {0} -> {1} (max: {2}) requested"
+        ).format(self.start, self.stop, n_times_max)
         if self.start >= self.stop or self.stop > n_times_max:
-            raise RuntimeError(
-                "Cannot write raw file with no data: %s -> %s "
-                "(max: %s) requested" % (self.start, self.stop, n_times_max)
-            )
+            raise RuntimeError(error_msg)
 
 
 def _write_raw_fid(

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2582,10 +2582,9 @@ def _write_raw(
         logger.info(f"Writing {use_fname}")
 
         with start_and_end_file(use_fname) as fid:
-            cals = _start_writing_raw(raw_fid_writer, fid, write_raw_fid_cfg)
+            cals = raw_fid_writer._start_writing_raw(fid, write_raw_fid_cfg)
             with ctx:
-                is_next_split, new_start = _write_raw_fid(
-                    raw_fid_writer,
+                is_next_split, new_start = raw_fid_writer._write_raw_fid(
                     fid=fid,
                     cals=cals,
                     part_idx=part_idx,
@@ -2650,193 +2649,192 @@ class _RawFidWriter:
         self.picks = _picks_to_idx(info, picks, "all", ())
         self.projector = projector
 
+    def _write_raw_fid(
+        self, fid, cals, part_idx, start, stop, prev_fname, next_fname, cfg
+    ):
+        first_samp = self.raw.first_samp + start
+        if first_samp != 0:
+            write_int(fid, FIFF.FIFF_FIRST_SAMPLE, first_samp)
 
-def _write_raw_fid(
-    self, fid, cals, part_idx, start, stop, prev_fname, next_fname, cfg
-):
-    first_samp = self.raw.first_samp + start
-    if first_samp != 0:
-        write_int(fid, FIFF.FIFF_FIRST_SAMPLE, first_samp)
-
-    # previous file name and id
-    if part_idx > 0 and prev_fname is not None:
-        start_block(fid, FIFF.FIFFB_REF)
-        write_int(fid, FIFF.FIFF_REF_ROLE, FIFF.FIFFV_ROLE_PREV_FILE)
-        write_string(fid, FIFF.FIFF_REF_FILE_NAME, prev_fname)
-        if self.info["meas_id"] is not None:
-            write_id(fid, FIFF.FIFF_REF_FILE_ID, self.info["meas_id"])
-        write_int(fid, FIFF.FIFF_REF_FILE_NUM, part_idx - 1)
-        end_block(fid, FIFF.FIFFB_REF)
-
-    pos_prev = fid.tell()
-    if pos_prev > cfg.split_size:
-        raise ValueError(
-            'file is larger than "split_size" after writing '
-            "measurement information, you must use a larger "
-            "value for split size: %s plus enough bytes for "
-            "the chosen buffer_size" % pos_prev
-        )
-
-    # Check to see if this has acquisition skips and, if so, if we can
-    # write out empty buffers instead of zeroes
-    firsts = list(range(start, stop, cfg.buffer_size))
-    lasts = np.array(firsts) + cfg.buffer_size
-    if lasts[-1] > stop:
-        lasts[-1] = stop
-    sk_onsets, sk_ends = _annotations_starts_stops(self.raw, "bad_acq_skip")
-    do_skips = False
-    if len(sk_onsets) > 0:
-        if np.in1d(sk_onsets, firsts).all() and np.in1d(sk_ends, lasts).all():
-            do_skips = True
-        else:
-            if part_idx == 0:
-                warn(
-                    "Acquisition skips detected but did not fit evenly into "
-                    "output buffer_size, will be written as zeroes."
-                )
-
-    n_current_skip = 0
-    is_next_split, new_start = False, None
-    for first, last in zip(firsts, lasts):
-        if do_skips:
-            if ((first >= sk_onsets) & (last <= sk_ends)).any():
-                # Track how many we have
-                n_current_skip += 1
-                continue
-            elif n_current_skip > 0:
-                # Write out an empty buffer instead of data
-                write_int(fid, FIFF.FIFF_DATA_SKIP, n_current_skip)
-                # These two NOPs appear to be optional (MaxFilter does not do
-                # it, but some acquisition machines do) so let's not bother.
-                # write_nop(fid)
-                # write_nop(fid)
-                n_current_skip = 0
-        data, times = self.raw[self.picks, first:last]
-        assert len(times) == last - first
-
-        if self.projector is not None:
-            data = np.dot(self.projector, data)
-
-        if cfg.drop_small_buffer and (first > start) and (len(times) < cfg.buffer_size):
-            logger.info("Skipping data chunk due to small buffer ... " "[done]")
-            break
-        logger.debug(f"Writing FIF {first:6d} ... {last:6d} ...")
-        _write_raw_buffer(fid, data, cals, cfg.fmt)
-
-        pos = fid.tell()
-        this_buff_size_bytes = pos - pos_prev
-        overage = pos - cfg.split_size + _NEXT_FILE_BUFFER
-        if overage > 0:
-            # This should occur on the first buffer write of the file, so
-            # we should mention the space required for the meas info
-            raise ValueError(
-                "buffer size (%s) is too large for the given split size (%s) "
-                "by %s bytes after writing info (%s) and leaving enough space "
-                'for end tags (%s): decrease "buffer_size_sec" or increase '
-                '"split_size".'
-                % (
-                    this_buff_size_bytes,
-                    cfg.split_size,
-                    overage,
-                    pos_prev,
-                    _NEXT_FILE_BUFFER,
-                )
-            )
-
-        # Split files if necessary, leave some space for next file info
-        # make sure we check to make sure we actually *need* another buffer
-        # with the "and" check
-        if (
-            pos >= cfg.split_size - this_buff_size_bytes - _NEXT_FILE_BUFFER
-            and first + cfg.buffer_size < stop
-        ):
+        # previous file name and id
+        if part_idx > 0 and prev_fname is not None:
             start_block(fid, FIFF.FIFFB_REF)
-            write_int(fid, FIFF.FIFF_REF_ROLE, FIFF.FIFFV_ROLE_NEXT_FILE)
-            write_string(fid, FIFF.FIFF_REF_FILE_NAME, op.basename(next_fname))
+            write_int(fid, FIFF.FIFF_REF_ROLE, FIFF.FIFFV_ROLE_PREV_FILE)
+            write_string(fid, FIFF.FIFF_REF_FILE_NAME, prev_fname)
             if self.info["meas_id"] is not None:
                 write_id(fid, FIFF.FIFF_REF_FILE_ID, self.info["meas_id"])
-            write_int(fid, FIFF.FIFF_REF_FILE_NUM, part_idx + 1)
+            write_int(fid, FIFF.FIFF_REF_FILE_NUM, part_idx - 1)
             end_block(fid, FIFF.FIFFB_REF)
-            is_next_split = True
-            new_start = first + cfg.buffer_size
-            break
-        pos_prev = pos
 
-    if self.info.get("maxshield", False):
-        end_block(fid, FIFF.FIFFB_IAS_RAW_DATA)
-    else:
-        end_block(fid, FIFF.FIFFB_RAW_DATA)
-    end_block(fid, FIFF.FIFFB_MEAS)
-    return is_next_split, new_start
+        pos_prev = fid.tell()
+        if pos_prev > cfg.split_size:
+            raise ValueError(
+                'file is larger than "split_size" after writing '
+                "measurement information, you must use a larger "
+                "value for split size: %s plus enough bytes for "
+                "the chosen buffer_size" % pos_prev
+            )
+
+        # Check to see if this has acquisition skips and, if so, if we can
+        # write out empty buffers instead of zeroes
+        firsts = list(range(start, stop, cfg.buffer_size))
+        lasts = np.array(firsts) + cfg.buffer_size
+        if lasts[-1] > stop:
+            lasts[-1] = stop
+        sk_onsets, sk_ends = _annotations_starts_stops(self.raw, "bad_acq_skip")
+        do_skips = False
+        if len(sk_onsets) > 0:
+            if np.in1d(sk_onsets, firsts).all() and np.in1d(sk_ends, lasts).all():
+                do_skips = True
+            else:
+                if part_idx == 0:
+                    warn(
+                        "Acquisition skips detected but did not fit evenly into "
+                        "output buffer_size, will be written as zeroes."
+                    )
+
+        n_current_skip = 0
+        is_next_split, new_start = False, None
+        for first, last in zip(firsts, lasts):
+            if do_skips:
+                if ((first >= sk_onsets) & (last <= sk_ends)).any():
+                    # Track how many we have
+                    n_current_skip += 1
+                    continue
+                elif n_current_skip > 0:
+                    # Write out an empty buffer instead of data
+                    write_int(fid, FIFF.FIFF_DATA_SKIP, n_current_skip)
+                    # These two NOPs appear to be optional (MaxFilter does not do
+                    # it, but some acquisition machines do) so let's not bother.
+                    # write_nop(fid)
+                    # write_nop(fid)
+                    n_current_skip = 0
+            data, times = self.raw[self.picks, first:last]
+            assert len(times) == last - first
+
+            if self.projector is not None:
+                data = np.dot(self.projector, data)
+
+            if cfg.drop_small_buffer and (first > start) and (len(times) < cfg.buffer_size):
+                logger.info("Skipping data chunk due to small buffer ... " "[done]")
+                break
+            logger.debug(f"Writing FIF {first:6d} ... {last:6d} ...")
+            _write_raw_buffer(fid, data, cals, cfg.fmt)
+
+            pos = fid.tell()
+            this_buff_size_bytes = pos - pos_prev
+            overage = pos - cfg.split_size + _NEXT_FILE_BUFFER
+            if overage > 0:
+                # This should occur on the first buffer write of the file, so
+                # we should mention the space required for the meas info
+                raise ValueError(
+                    "buffer size (%s) is too large for the given split size (%s) "
+                    "by %s bytes after writing info (%s) and leaving enough space "
+                    'for end tags (%s): decrease "buffer_size_sec" or increase '
+                    '"split_size".'
+                    % (
+                        this_buff_size_bytes,
+                        cfg.split_size,
+                        overage,
+                        pos_prev,
+                        _NEXT_FILE_BUFFER,
+                    )
+                )
+
+            # Split files if necessary, leave some space for next file info
+            # make sure we check to make sure we actually *need* another buffer
+            # with the "and" check
+            if (
+                pos >= cfg.split_size - this_buff_size_bytes - _NEXT_FILE_BUFFER
+                and first + cfg.buffer_size < stop
+            ):
+                start_block(fid, FIFF.FIFFB_REF)
+                write_int(fid, FIFF.FIFF_REF_ROLE, FIFF.FIFFV_ROLE_NEXT_FILE)
+                write_string(fid, FIFF.FIFF_REF_FILE_NAME, op.basename(next_fname))
+                if self.info["meas_id"] is not None:
+                    write_id(fid, FIFF.FIFF_REF_FILE_ID, self.info["meas_id"])
+                write_int(fid, FIFF.FIFF_REF_FILE_NUM, part_idx + 1)
+                end_block(fid, FIFF.FIFFB_REF)
+                is_next_split = True
+                new_start = first + cfg.buffer_size
+                break
+            pos_prev = pos
+
+        if self.info.get("maxshield", False):
+            end_block(fid, FIFF.FIFFB_IAS_RAW_DATA)
+        else:
+            end_block(fid, FIFF.FIFFB_RAW_DATA)
+        end_block(fid, FIFF.FIFFB_MEAS)
+        return is_next_split, new_start
 
 
-@fill_doc
-def _start_writing_raw(self, fid, cfg):
-    """Start write raw data in file.
+    @fill_doc
+    def _start_writing_raw(self, fid, cfg):
+        """Start write raw data in file.
 
-    Parameters
-    ----------
-    fid : file
-        The created file.
-    %(info_not_none)s
-    sel : array of int | None
-        Indices of channels to include. If None, all channels
-        are included.
-    data_type : int
-        The data_type in case it is necessary. Should be 4 (FIFFT_FLOAT),
-        5 (FIFFT_DOUBLE), 16 (FIFFT_DAU_PACK16), or 3 (FIFFT_INT) for raw data.
-    reset_range : bool
-        If True, the info['chs'][k]['range'] parameter will be set to unity.
-    annotations : instance of Annotations
-        The annotations to write.
+        Parameters
+        ----------
+        fid : file
+            The created file.
+        %(info_not_none)s
+        sel : array of int | None
+            Indices of channels to include. If None, all channels
+            are included.
+        data_type : int
+            The data_type in case it is necessary. Should be 4 (FIFFT_FLOAT),
+            5 (FIFFT_DOUBLE), 16 (FIFFT_DAU_PACK16), or 3 (FIFFT_INT) for raw data.
+        reset_range : bool
+            If True, the info['chs'][k]['range'] parameter will be set to unity.
+        annotations : instance of Annotations
+            The annotations to write.
 
-    Returns
-    -------
-    fid : file
-        The file descriptor.
-    cals : list
-        calibration factors.
-    """
-    #
-    # Measurement info
-    #
-    info = pick_info(self.info, self.picks)
-
-    #
-    # Create the file and save the essentials
-    #
-    start_block(fid, FIFF.FIFFB_MEAS)
-    write_id(fid, FIFF.FIFF_BLOCK_ID)
-    if info["meas_id"] is not None:
-        write_id(fid, FIFF.FIFF_PARENT_BLOCK_ID, info["meas_id"])
-
-    cals = []
-    for k in range(info["nchan"]):
+        Returns
+        -------
+        fid : file
+            The file descriptor.
+        cals : list
+            calibration factors.
+        """
         #
-        #   Scan numbers may have been messed up
+        # Measurement info
         #
-        info["chs"][k]["scanno"] = k + 1  # scanno starts at 1 in FIF format
-        if cfg.reset_range is True:
-            info["chs"][k]["range"] = 1.0
-        cals.append(info["chs"][k]["cal"] * info["chs"][k]["range"])
+        info = pick_info(self.info, self.picks)
 
-    write_meas_info(fid, info, data_type=cfg.data_type, reset_range=cfg.reset_range)
+        #
+        # Create the file and save the essentials
+        #
+        start_block(fid, FIFF.FIFFB_MEAS)
+        write_id(fid, FIFF.FIFF_BLOCK_ID)
+        if info["meas_id"] is not None:
+            write_id(fid, FIFF.FIFF_PARENT_BLOCK_ID, info["meas_id"])
 
-    #
-    # Annotations
-    #
-    if len(self.raw.annotations) > 0:  # don't save empty annot
-        _write_annotations(fid, self.raw.annotations)
+        cals = []
+        for k in range(info["nchan"]):
+            #
+            #   Scan numbers may have been messed up
+            #
+            info["chs"][k]["scanno"] = k + 1  # scanno starts at 1 in FIF format
+            if cfg.reset_range is True:
+                info["chs"][k]["range"] = 1.0
+            cals.append(info["chs"][k]["cal"] * info["chs"][k]["range"])
 
-    #
-    # Start the raw data
-    #
-    if info.get("maxshield", False):
-        start_block(fid, FIFF.FIFFB_IAS_RAW_DATA)
-    else:
-        start_block(fid, FIFF.FIFFB_RAW_DATA)
+        write_meas_info(fid, info, data_type=cfg.data_type, reset_range=cfg.reset_range)
 
-    return cals
+        #
+        # Annotations
+        #
+        if len(self.raw.annotations) > 0:  # don't save empty annot
+            _write_annotations(fid, self.raw.annotations)
+
+        #
+        # Start the raw data
+        #
+        if info.get("maxshield", False):
+            start_block(fid, FIFF.FIFFB_IAS_RAW_DATA)
+        else:
+            start_block(fid, FIFF.FIFFB_RAW_DATA)
+
+        return cals
 
 
 def _write_raw_buffer(fid, buf, cals, fmt):

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2563,8 +2563,6 @@ def _write_raw(raw_fid_writer, fpath, split_naming, overwrite):
         else:
             reserved_ctx = nullcontext()
             use_fpath = dir_path / split_fnames[part_idx]
-            if split_naming == "neuromag" and part_idx == 0:
-                assert use_fpath == fpath  # neuromag naming
         next_fname = split_fnames[part_idx + 1]
         _check_fname(use_fpath, overwrite)
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2535,44 +2535,44 @@ class _RawShell:
 
 ###############################################################################
 # Writing
-def _write_raw(raw_fid_writer, fname, split_naming, overwrite):
+def _write_raw(raw_fid_writer, fpath, split_naming, overwrite):
     """Write raw file with splitting."""
     # Assume we never hit more than 100 splits, like for epochs
     MAX_N_SPLITS = 100
-    dir_path = fname.parent
+    dir_path = fpath.parent
     split_fnames = _make_split_fnames(
-        fname.name, n_splits=MAX_N_SPLITS, split_naming=split_naming
+        fpath.name, n_splits=MAX_N_SPLITS, split_naming=split_naming
     )
     part_idx, is_next_split = 0, True
     if split_naming == "bids":
-        # reserve our BIDS split fname in case we need to split
+        # reserve our BIDS split fpath in case we need to split
         reserved_fname = dir_path / split_fnames[0]
         logger.info(f"Reserving possible split file {reserved_fname.name}")
         _check_fname(reserved_fname, overwrite)
         reserved_ctx = _ReservedFilename(reserved_fname)
 
         prev_fname, next_fname = None, split_fnames[1]
-        logger.info(f"Writing {fname}")
-        with start_and_end_file(fname) as fid, reserved_ctx:
+        logger.info(f"Writing {fpath}")
+        with start_and_end_file(fpath) as fid, reserved_ctx:
             is_next_split = raw_fid_writer.write(fid, part_idx, prev_fname, next_fname)
             if is_next_split:
-                logger.info(f"Renaming BIDS split file {fname.name}")
+                logger.info(f"Renaming BIDS split file {fpath.name}")
                 reserved_ctx.remove = False
-                shutil.move(fname, dir_path / split_fnames[0])
-            logger.info(f"Closing {fname}")
+                shutil.move(fpath, dir_path / split_fnames[0])
+            logger.info(f"Closing {fpath}")
 
         part_idx += 1
 
     while is_next_split:
         prev_fname = split_fnames[part_idx - 1] if part_idx else None
         next_fname = split_fnames[part_idx + 1]
-        use_fname = dir_path / split_fnames[part_idx]
-        _check_fname(use_fname, overwrite)
+        use_fpath = dir_path / split_fnames[part_idx]
+        _check_fname(use_fpath, overwrite)
 
-        logger.info(f"Writing {use_fname}")
-        with start_and_end_file(use_fname) as fid:
+        logger.info(f"Writing {use_fpath}")
+        with start_and_end_file(use_fpath) as fid:
             is_next_split = raw_fid_writer.write(fid, part_idx, prev_fname, next_fname)
-            logger.info(f"Closing {fname}")
+            logger.info(f"Closing {use_fpath}")
         part_idx += 1
         assert (
             part_idx <= MAX_N_SPLITS

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2621,8 +2621,8 @@ class _RawFidWriterCfg:
 class _RawFidWriter:
     def __init__(self, raw, info, picks, projector, start, stop, cfg):
         self.raw = raw
-        self.info = info
         self.picks = _picks_to_idx(info, picks, "all", ())
+        self.info = pick_info(info, self.picks)
         self.projector = projector
         self.start, self.stop = start, stop
         self.cfg = cfg
@@ -2783,29 +2783,24 @@ class _RawFidWriter:
             calibration factors.
         """
         #
-        # Measurement info
-        #
-        info = pick_info(self.info, self.picks)
-
-        #
         # Create the file and save the essentials
         #
         write_id(fid, FIFF.FIFF_BLOCK_ID)
-        if info["meas_id"] is not None:
-            write_id(fid, FIFF.FIFF_PARENT_BLOCK_ID, info["meas_id"])
+        if self.info["meas_id"] is not None:
+            write_id(fid, FIFF.FIFF_PARENT_BLOCK_ID, self.info["meas_id"])
 
         cals = []
-        for k in range(info["nchan"]):
+        for k in range(self.info["nchan"]):
             #
             #   Scan numbers may have been messed up
             #
-            info["chs"][k]["scanno"] = k + 1  # scanno starts at 1 in FIF format
+            self.info["chs"][k]["scanno"] = k + 1  # scanno starts at 1 in FIF format
             if self.cfg.reset_range is True:
-                info["chs"][k]["range"] = 1.0
-            cals.append(info["chs"][k]["cal"] * info["chs"][k]["range"])
+                self.info["chs"][k]["range"] = 1.0
+            cals.append(self.info["chs"][k]["cal"] * self.info["chs"][k]["range"])
 
         write_meas_info(
-            fid, info, data_type=self.cfg.data_type, reset_range=self.cfg.reset_range
+            fid, self.info, data_type=self.cfg.data_type, reset_range=self.cfg.reset_range
         )
 
         #

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2628,10 +2628,12 @@ class _RawFidWriter:
         self.cfg = cfg
 
     def write(self, fid, part_idx, prev_fname, next_fname):
+        start_block(fid, FIFF.FIFFB_MEAS)
         cals = self._start_writing_raw(fid)
         is_next_split = self._write_raw_fid(
             fid, cals, part_idx, prev_fname, next_fname
         )
+        end_block(fid, FIFF.FIFFB_MEAS)
         return is_next_split
 
     def _write_raw_fid(self, fid, cals, part_idx, prev_fname, next_fname):
@@ -2751,7 +2753,6 @@ class _RawFidWriter:
             pos_prev = pos
 
         self._end_raw_block(fid)
-        end_block(fid, FIFF.FIFFB_MEAS)
         return is_next_split
 
     @fill_doc
@@ -2789,7 +2790,6 @@ class _RawFidWriter:
         #
         # Create the file and save the essentials
         #
-        start_block(fid, FIFF.FIFFB_MEAS)
         write_id(fid, FIFF.FIFF_BLOCK_ID)
         if info["meas_id"] is not None:
             write_id(fid, FIFF.FIFF_PARENT_BLOCK_ID, info["meas_id"])

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2555,11 +2555,10 @@ def _write_raw(raw_fid_writer, fpath, split_naming, overwrite):
         logger.info(f"Writing {fpath}")
         with start_and_end_file(fpath) as fid, reserved_ctx:
             is_next_split = raw_fid_writer.write(fid, part_idx, prev_fname, next_fname)
-            if is_next_split:
-                logger.info(f"Renaming BIDS split file {fpath.name}")
-                reserved_ctx.remove = False
-                shutil.move(fpath, dir_path / split_fnames[0])
             logger.info(f"Closing {fpath}")
+        if is_next_split:
+            logger.info(f"Renaming BIDS split file {fpath.name}")
+            shutil.move(fpath, dir_path / split_fnames[0])
 
         part_idx += 1
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2570,11 +2570,7 @@ def _write_raw(raw_fid_writer, fname, split_naming, overwrite):
             cals = raw_fid_writer._start_writing_raw(fid)
             with ctx:
                 is_next_split = raw_fid_writer._write_raw_fid(
-                    fid=fid,
-                    cals=cals,
-                    part_idx=part_idx,
-                    prev_fname=prev_fname,
-                    next_fname=next_fname,
+                    fid, cals, part_idx, prev_fname, next_fname
                 )
                 if part_idx == 1 and split_naming == "bids":
                     logger.info(f"Renaming BIDS split file {split_fnames[0]}")

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2567,9 +2567,8 @@ def _write_raw(raw_fid_writer, fname, split_naming, overwrite):
         logger.info(f"Writing {use_fname}")
 
         with start_and_end_file(use_fname) as fid, ctx:
-            cals = raw_fid_writer._start_writing_raw(fid)
-            is_next_split = raw_fid_writer._write_raw_fid(
-                fid, cals, part_idx, prev_fname, next_fname
+            is_next_split = raw_fid_writer.write(
+                fid, part_idx, prev_fname, next_fname
             )
             if part_idx == 1 and split_naming == "bids":
                 logger.info(f"Renaming BIDS split file {split_fnames[0]}")
@@ -2627,6 +2626,13 @@ class _RawFidWriter:
         self.projector = projector
         self.start, self.stop = start, stop
         self.cfg = cfg
+
+    def write(self, fid, part_idx, prev_fname, next_fname):
+        cals = self._start_writing_raw(fid)
+        is_next_split = self._write_raw_fid(
+            fid, cals, part_idx, prev_fname, next_fname
+        )
+        return is_next_split
 
     def _write_raw_fid(self, fid, cals, part_idx, prev_fname, next_fname):
         self._check_start_stop_within_bounds()

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2745,8 +2745,9 @@ class _RawFidWriter:
         is_last_buffer = first + self.cfg.buffer_size >= self.stop
         if is_last_buffer:
             return False
-        this_buff_size_bytes = pos - pos_prev
-        return pos >= self.cfg.split_size - this_buff_size_bytes - _NEXT_FILE_BUFFER
+        buff_size_bytes = pos - pos_prev
+        available_bytes = self.cfg.split_size - pos
+        return buff_size_bytes + _NEXT_FILE_BUFFER >= available_bytes
 
     @fill_doc
     def _start_writing_raw(self, fid):

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2635,6 +2635,8 @@ class _RawFidWriter:
         return is_next_split
 
     def _write_raw_fid(self, fid, cals, part_idx, prev_fname, next_fname):
+        self._start_raw_block(fid)
+
         self._check_start_stop_within_bounds()
         first_samp = self.raw.first_samp + self.start
         if first_samp != 0:
@@ -2748,10 +2750,7 @@ class _RawFidWriter:
                 break
             pos_prev = pos
 
-        if self.info.get("maxshield", False):
-            end_block(fid, FIFF.FIFFB_IAS_RAW_DATA)
-        else:
-            end_block(fid, FIFF.FIFFB_RAW_DATA)
+        self._end_raw_block(fid)
         end_block(fid, FIFF.FIFFB_MEAS)
         return is_next_split
 
@@ -2815,15 +2814,19 @@ class _RawFidWriter:
         if len(self.raw.annotations) > 0:  # don't save empty annot
             _write_annotations(fid, self.raw.annotations)
 
-        #
-        # Start the raw data
-        #
-        if info.get("maxshield", False):
+        return cals
+
+    def _start_raw_block(self, fid):
+        if self.info.get("maxshield", False):
             start_block(fid, FIFF.FIFFB_IAS_RAW_DATA)
         else:
             start_block(fid, FIFF.FIFFB_RAW_DATA)
 
-        return cals
+    def _end_raw_block(self, fid):
+        if self.info.get("maxshield", False):
+            end_block(fid, FIFF.FIFFB_IAS_RAW_DATA)
+        else:
+            end_block(fid, FIFF.FIFFB_RAW_DATA)
 
     def _check_start_stop_within_bounds(self):
         # we've done something wrong if we hit this

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -650,7 +650,7 @@ def test_split_files(tmp_path, mod, monkeypatch):
     assert not (tmp_path / "test_split-01_{mod}.fif").is_file()
 
     # MAX_N_SPLITS exceeeded
-    raw = RawArray(np.zeros((100, 10000000)), create_info(100, 1000.0, "eeg"))
+    raw = RawArray(np.zeros((1, 2000000)), create_info(1, 1000.0, "eeg"))
     fname.unlink()
     kwargs = dict(split_size="2MB", overwrite=True, verbose=True)
     with monkeypatch.context() as m:

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -642,7 +642,7 @@ def test_split_files(tmp_path, mod, monkeypatch):
 
     # reserved file is deleted
     fname = tmp_path / "test_raw.fif"
-    monkeypatch.setattr(base, "_write_raw_fid", _err)
+    monkeypatch.setattr(base._RawFidWriter, "_write_raw_fid", _err)
     with pytest.raises(RuntimeError, match="Killed mid-write"):
         raw_1.save(fname, split_size="10MB", split_naming="bids")
     assert fname.is_file()

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -642,7 +642,7 @@ def test_split_files(tmp_path, mod, monkeypatch):
 
     # reserved file is deleted
     fname = tmp_path / "test_raw.fif"
-    monkeypatch.setattr(base, "_write_raw_fid", _err)
+    monkeypatch.setattr(base, "_write_raw_data", _err)
     with pytest.raises(RuntimeError, match="Killed mid-write"):
         raw_1.save(fname, split_size="10MB", split_naming="bids")
     assert fname.is_file()

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -642,7 +642,7 @@ def test_split_files(tmp_path, mod, monkeypatch):
 
     # reserved file is deleted
     fname = tmp_path / "test_raw.fif"
-    monkeypatch.setattr(base._RawFidWriter, "_write_raw_fid", _err)
+    monkeypatch.setattr(base, "_write_raw_fid", _err)
     with pytest.raises(RuntimeError, match="Killed mid-write"):
         raw_1.save(fname, split_size="10MB", split_naming="bids")
     assert fname.is_file()

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -551,7 +551,7 @@ def test_split_files(tmp_path, mod, monkeypatch):
 
     annot = Annotations(np.arange(20), np.ones((20,)), "test")
     raw_1.set_annotations(annot)
-    split_fname = tmp_path / "split_raw.fif"
+    split_fname = tmp_path / f"split_{mod}.fif"
     raw_1.save(split_fname, buffer_size_sec=1.0, split_size="10MB")
     raw_2 = read_raw_fif(split_fname)
     assert_allclose(raw_2.buffer_size_sec, 1.0, atol=1e-2)  # samp rate
@@ -641,32 +641,35 @@ def test_split_files(tmp_path, mod, monkeypatch):
         raw_crop.save(tmp_path / "test.fif", split_naming="bids", verbose="error")
 
     # reserved file is deleted
-    fname = tmp_path / "test_raw.fif"
+    fname = tmp_path / f"test_{mod}.fif"
     with monkeypatch.context() as m:
         m.setattr(base, "_write_raw_data", _err)
         with pytest.raises(RuntimeError, match="Killed mid-write"):
             raw_1.save(fname, split_size="10MB", split_naming="bids")
     assert fname.is_file()
-    assert not (tmp_path / "test_split-01_raw.fif").is_file()
+    assert not (tmp_path / "test_split-01_{mod}.fif").is_file()
 
     # MAX_N_SPLITS exceeeded
     raw = RawArray(np.zeros((100, 10000000)), create_info(100, 1000.0, "eeg"))
     fname.unlink()
+    kwargs = dict(split_size="2MB", overwrite=True, verbose=True)
     with monkeypatch.context() as m:
         m.setattr(base, "MAX_N_SPLITS", 2)
         with pytest.raises(RuntimeError, match="Exceeded maximum number of splits"):
-            raw.save(
-                fname,
-                split_size="2MB",
-                split_naming="bids",
-                overwrite=True,
-                verbose=True,
-            )
+            raw.save(fname, split_naming="bids", **kwargs)
     fname_1, fname_2, fname_3 = [
-        (tmp_path / f"test_split-{ii:02d}_raw.fif") for ii in range(1, 4)
+        (tmp_path / f"test_split-{ii:02d}_{mod}.fif") for ii in range(1, 4)
     ]
     assert not fname.is_file()
     assert fname_1.is_file()
+    assert fname_2.is_file()
+    assert not fname_3.is_file()
+    with monkeypatch.context() as m:
+        m.setattr(base, "MAX_N_SPLITS", 2)
+        with pytest.raises(RuntimeError, match="Exceeded maximum number of splits"):
+            raw.save(fname, split_naming="neuromag", **kwargs)
+    fname_2, fname_3 = [(tmp_path / f"test_{mod}-{ii}.fif") for ii in range(1, 3)]
+    assert fname.is_file()
     assert fname_2.is_file()
     assert not fname_3.is_file()
 

--- a/mne/io/nsx/tests/test_nsx.py
+++ b/mne/io/nsx/tests/test_nsx.py
@@ -82,7 +82,7 @@ def test_nsx_ver_31():
     assert raw.annotations[0]["onset"] * raw.info["sfreq"] == 101
     assert raw.annotations[0]["duration"] * raw.info["sfreq"] == 49
 
-    # Ignore following RuntimeWarning in mne/io/base.py in _write_raw_fid
+    # Ignore following RuntimeWarning in mne/io/base.py in _write_raw_data
     # "Acquisition skips detected but did not fit evenly into output"
     # "buffer_size, will be written as zeroes."
     with pytest.warns(RuntimeWarning, match="skips detected"):


### PR DESCRIPTION
#### Reference issue
Necessary for PR #11924


#### What does this implement/fix?
- Purge recursion from `_write_raw()` and `_write_raw_fid()` interaction
- Improve general code readability

#### Additional information
In #11924 I'm adding support for reading and writing from zip archives via using `Path` interface in the reading and writing functions. At the moment such change is not possible because `zipfile.Path`s don't support writing to several `fid`s at once. It's a problem because currently MNE-Python writes splits recursively, such that it keeps the `fid` for the first file open until we're done writing all the remaining splits.  

This PR attempts at fixing this recursion problem by using a simple `while` loop. As a bonus, no-recursion implementation is easier to understand and maintain (hopefully).
