### PR TITLE
Handle channel information in annotations when loading data from and exporting to EDF file 

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -32,6 +32,7 @@ Enhancements
 - Add helpful error messages when using methods on empty :class:`mne.Epochs`-objects (:gh:`11306` by `Martin Schulz`_)
 - Add inferring EEGLAB files' montage unit automatically based on estimated head radius using :func:`read_raw_eeglab(..., montage_units="auto") <mne.io.read_raw_eeglab>` (:gh:`11925` by `Jack Zhang`_, :gh:`11951` by `Eric Larson`_)
 - Add :class:`~mne.time_frequency.EpochsSpectrumArray` and :class:`~mne.time_frequency.SpectrumArray` to support creating power spectra from :class:`NumPy array <numpy.ndarray>` data (:gh:`11803` by `Alex Rockhill`_)
+- Handle channel information in annotations when loading data from and exporting to EDF file (:gh:`11960` by `Paul Roujansky`_)
 
 Bugs
 ~~~~

--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -32,7 +32,6 @@ Enhancements
 - Add helpful error messages when using methods on empty :class:`mne.Epochs`-objects (:gh:`11306` by `Martin Schulz`_)
 - Add inferring EEGLAB files' montage unit automatically based on estimated head radius using :func:`read_raw_eeglab(..., montage_units="auto") <mne.io.read_raw_eeglab>` (:gh:`11925` by `Jack Zhang`_, :gh:`11951` by `Eric Larson`_)
 - Add :class:`~mne.time_frequency.EpochsSpectrumArray` and :class:`~mne.time_frequency.SpectrumArray` to support creating power spectra from :class:`NumPy array <numpy.ndarray>` data (:gh:`11803` by `Alex Rockhill`_)
-- Handle channel information in annotations when loading data from and exporting to EDF file (:gh:`11960` by `Paul Roujansky`_)
 
 Bugs
 ~~~~
@@ -45,6 +44,7 @@ Bugs
 - Removed preload parameter from :func:`mne.io.read_raw_eyelink`, because data are always preloaded no matter what preload is set to (:gh:`11910` by `Scott Huberty`_)
 - Fix bug with :meth:`~mne.viz.Brain.add_annotation` when reading an annotation from a file with both hemispheres shown (:gh:`11946` by `Marijn van Vliet`_)
 - Fix bug with ``subject_info`` when loading data from and exporting to EDF file (:gh:`11952` by `Paul Roujansky`_)
+- Fix handling of channel information in annotations when loading data from and exporting to EDF file (:gh:`11960` by `Paul Roujansky`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1232,11 +1232,15 @@ def read_annotations(fname, sfreq="auto", uint16_codec=None):
         annotations = _read_annotations_eeglab(fname, uint16_codec=uint16_codec)
 
     elif name.endswith(("edf", "bdf", "gdf")):
-        onset, duration, description = _read_annotations_edf(fname)
+        onset, duration, description, ch_names = _read_annotations_edf(fname)
         onset = np.array(onset, dtype=float)
         duration = np.array(duration, dtype=float)
         annotations = Annotations(
-            onset=onset, duration=duration, description=description, orig_time=None
+            onset=onset,
+            duration=duration,
+            description=description,
+            orig_time=None,
+            ch_names=ch_names,
         )
 
     elif name.startswith("events_") and fname.endswith("mat"):

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -323,7 +323,6 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
                                 f"trying to write {desc}@@{ch_name} at {onset} "
                                 f"for {duration} seconds."
                             )
-                        # print("Write annotation", onset, duration, desc, ch_name)
                 else:
                     if hdl.writeAnnotation(onset, duration, desc) != 0:
                         raise RuntimeError(
@@ -331,4 +330,3 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
                             f"trying to write {desc} at {onset} "
                             f"for {duration} seconds."
                         )
-                    # print("Write annotation", onset, duration, desc)

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -221,6 +221,7 @@ def test_export_edf_annotations(tmp_path):
         onset=[0.01, 0.05, 0.90, 1.05],
         duration=[0, 1, 0, 0],
         description=["test1", "test2", "test3", "test4"],
+        ch_names=[["0"], ["0", "1"], [], ["1"]],
     )
     raw.set_annotations(annotations)
 
@@ -233,6 +234,7 @@ def test_export_edf_annotations(tmp_path):
     assert_array_equal(raw.annotations.onset, raw_read.annotations.onset)
     assert_array_equal(raw.annotations.duration, raw_read.annotations.duration)
     assert_array_equal(raw.annotations.description, raw_read.annotations.description)
+    assert_array_equal(raw.annotations.ch_names, raw_read.annotations.ch_names)
 
 
 @pytest.mark.skipif(

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1959,7 +1959,6 @@ def _read_annotations_edf(annotations, encoding="utf8"):
         duration = float(ev[2]) if ev[2] else 0
         for description in ev[3].split("\x14")[1:]:
             if description:
-                # print("description", description)
                 if "@@" in description:
                     description, ch_name = description.split("@@")
                     key = f"{onset}_{duration}_{description}"

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -192,7 +192,7 @@ class RawEDF(BaseRaw):
         )
 
         # Read annotations from file and set it
-        onset, duration, desc = list(), list(), list()
+        onset, duration, desc, ch_names = list(), list(), list(), list()
         if len(edf_info["tal_idx"]) > 0:
             # Read TAL data exploiting the header info (no regexp)
             idx = np.empty(0, int)
@@ -205,14 +205,18 @@ class RawEDF(BaseRaw):
                 np.ones((len(idx), 1)),
                 None,
             )
-            onset, duration, desc = _read_annotations_edf(
+            onset, duration, desc, ch_names = _read_annotations_edf(
                 tal_data[0],
                 encoding=encoding,
             )
 
         self.set_annotations(
             Annotations(
-                onset=onset, duration=duration, description=desc, orig_time=None
+                onset=onset,
+                duration=duration,
+                description=desc,
+                orig_time=None,
+                ch_names=ch_names,
             )
         )
 
@@ -1948,14 +1952,32 @@ def _read_annotations_edf(annotations, encoding="utf8"):
                 " You might want to try setting \"encoding='latin1'\"."
             ) from e
 
-    events = []
+    events = {}
     offset = 0.0
     for k, ev in enumerate(triggers):
         onset = float(ev[0]) + offset
         duration = float(ev[2]) if ev[2] else 0
         for description in ev[3].split("\x14")[1:]:
             if description:
-                events.append([onset, duration, description])
+                # print("description", description)
+                if "@@" in description:
+                    description, ch_name = description.split("@@")
+                    key = f"{onset}_{duration}_{description}"
+                else:
+                    ch_name = None
+                    key = f"{onset}_{duration}_{description}"
+                    if key in events:
+                        key += f"_{k}"  # make key unique
+                if key in events and ch_name:
+                    events[key][3] += (ch_name,)
+                else:
+                    events[key] = [
+                        onset,
+                        duration,
+                        description,
+                        (ch_name,) if ch_name else (),
+                    ]
+
             elif k == 0:
                 # The startdate/time of a file is specified in the EDF+ header
                 # fields 'startdate of recording' and 'starttime of recording'.
@@ -1967,7 +1989,7 @@ def _read_annotations_edf(annotations, encoding="utf8"):
                 # header. If X=0, then the .X may be omitted.
                 offset = -onset
 
-    return zip(*events) if events else (list(), list(), list())
+    return zip(*events.values()) if events else (list(), list(), list(), list())
 
 
 def _get_annotations_gdf(edf_info, sfreq):

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -365,7 +365,7 @@ def test_parse_annotation(tmp_path):
         ]
     )
     for tal_channel in [tal_channel_A, tal_channel_B]:
-        onset, duration, description = _read_annotations_edf([tal_channel])
+        onset, duration, description, ch_names = _read_annotations_edf([tal_channel])
         assert_allclose(onset, want_onset)
         assert_allclose(duration, want_duration)
         assert description == want_description
@@ -478,18 +478,26 @@ def test_read_annot(tmp_path):
     with open(annot_file, "wb") as f:
         f.write(annot)
 
-    onset, duration, desc = _read_annotations_edf(annotations=str(annot_file))
+    onset, duration, desc, ch_names = _read_annotations_edf(annotations=str(annot_file))
     annotation = Annotations(
-        onset=onset, duration=duration, description=desc, orig_time=None
+        onset=onset,
+        duration=duration,
+        description=desc,
+        orig_time=None,
+        ch_names=ch_names,
     )
     _assert_annotations_equal(annotation, EXPECTED_ANNOTATIONS)
 
     # Now test when reading from buffer of data
     with open(annot_file, "rb") as fid:
         ch_data = np.fromfile(fid, dtype="<i2", count=len(annot))
-    onset, duration, desc = _read_annotations_edf([ch_data])
+    onset, duration, desc, ch_names = _read_annotations_edf([ch_data])
     annotation = Annotations(
-        onset=onset, duration=duration, description=desc, orig_time=None
+        onset=onset,
+        duration=duration,
+        description=desc,
+        orig_time=None,
+        ch_names=ch_names,
     )
     _assert_annotations_equal(annotation, EXPECTED_ANNOTATIONS)
 
@@ -538,7 +546,7 @@ def test_read_latin1_annotations(tmp_path):
             samp=-1,
             dtype_byte=None,
         )
-    onset, duration, description = _read_annotations_edf(
+    onset, duration, description, ch_names = _read_annotations_edf(
         tal_channel,
         encoding="latin1",
     )


### PR DESCRIPTION
Fixes https://github.com/mne-tools/mne-python/issues/11959.

This PR aims at enabling to save channels when defined in channel-specific annotations. It basically writes each annotation with an extra `"@@{ch_name}"` appended to its description. Equally the channel info is parsed when reading the annotation file. 