### PR TITLE
Use newer ipympl package for drawing matplotlib figures into a notebook

### DIFF
--- a/mne/viz/backends/_notebook.py
+++ b/mne/viz/backends/_notebook.py
@@ -86,7 +86,7 @@ from ._pyvista import (
     _take_3d_screenshot,  # noqa: F401
 )
 from ._utils import _notebook_vtk_works
-from ...utils import check_version
+from ...utils import check_version, _soft_import
 
 
 # dict values are icon names from: https://fontawesome.com/icons
@@ -1346,10 +1346,9 @@ class _IpyPlayback(_AbstractPlayback):
 
 class _IpyMplInterface(_AbstractMplInterface):
     def _mpl_initialize(self):
-        from matplotlib.backends.backend_nbagg import FigureCanvasNbAgg, FigureManager
-
-        self.canvas = FigureCanvasNbAgg(self.fig)
-        self.manager = FigureManager(self.canvas, 0)
+        ipympl = _soft_import("ipympl", "Drawing figures into a notebook.", strict=True)
+        self.canvas = ipympl.backend_nbagg.Canvas(self.fig)
+        self.manager = ipympl.backend_nbagg.FigureManager(self.canvas, 0)
 
 
 class _IpyMplCanvas(_AbstractMplCanvas, _IpyMplInterface):


### PR DESCRIPTION
`%matplotlib notebook` doesn't work in Jupyter-Lab and since now also the plain notebook runs on the jupyterlab engine, it would be nice to support it. This means not using the internal `matplotlib.backends.backend_nbagg` but rather the `ipympl` package.