### PR TITLE
Make `_read_annotations_edf()` and `_read_annotations_txt()` return an `mne.Annotations` instance

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -32,7 +32,7 @@ Enhancements
 - Add helpful error messages when using methods on empty :class:`mne.Epochs`-objects (:gh:`11306` by `Martin Schulz`_)
 - Add inferring EEGLAB files' montage unit automatically based on estimated head radius using :func:`read_raw_eeglab(..., montage_units="auto") <mne.io.read_raw_eeglab>` (:gh:`11925` by `Jack Zhang`_, :gh:`11951` by `Eric Larson`_)
 - Add :class:`~mne.time_frequency.EpochsSpectrumArray` and :class:`~mne.time_frequency.SpectrumArray` to support creating power spectra from :class:`NumPy array <numpy.ndarray>` data (:gh:`11803` by `Alex Rockhill`_)
-- Refactoring ``mne.io.edf.edf._read_annotations_edf`` in order for it to return an :class:`mne.Annotations` instance (:gh:`11964` by `Paul Roujansky`_)
+- Refactored internals of :func:`mne.read_annotations` (:gh:`11964` by `Paul Roujansky`_)
 
 Bugs
 ~~~~

--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -32,6 +32,7 @@ Enhancements
 - Add helpful error messages when using methods on empty :class:`mne.Epochs`-objects (:gh:`11306` by `Martin Schulz`_)
 - Add inferring EEGLAB files' montage unit automatically based on estimated head radius using :func:`read_raw_eeglab(..., montage_units="auto") <mne.io.read_raw_eeglab>` (:gh:`11925` by `Jack Zhang`_, :gh:`11951` by `Eric Larson`_)
 - Add :class:`~mne.time_frequency.EpochsSpectrumArray` and :class:`~mne.time_frequency.SpectrumArray` to support creating power spectra from :class:`NumPy array <numpy.ndarray>` data (:gh:`11803` by `Alex Rockhill`_)
+- Refactoring ``mne.io.edf.edf._read_annotations_edf`` in order for it to return an :class:`mne.Annotations` instance (:gh:`11964` by `Paul Roujansky`_)
 
 Bugs
 ~~~~
@@ -52,4 +53,3 @@ API changes
 ~~~~~~~~~~~
 - ``mne.preprocessing.apply_maxfilter`` and ``mne maxfilter`` have been deprecated and will be removed in 1.7. Use :func:`mne.preprocessing.maxwell_filter` (see :ref:`this tutorial <tut-artifact-sss>`) in Python or the command-line utility from MEGIN ``maxfilter`` and :func:`mne.bem.fit_sphere_to_headshape` instead (:gh:`11938` by `Eric Larson`_)
 - :func:`mne.io.kit.read_mrk` reading pickled files is deprecated using something like ``np.savetxt(fid, pts, delimiter="\t", newline="\n")`` to save your points instead (:gh:`11937` by `Eric Larson`_)
-- ``mne.io.edf.edf._read_annotations_edf`` returns an :class:`mne.Annotations` instance (:gh:`11964` by `Paul Roujansky`_)

--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -52,3 +52,4 @@ API changes
 ~~~~~~~~~~~
 - ``mne.preprocessing.apply_maxfilter`` and ``mne maxfilter`` have been deprecated and will be removed in 1.7. Use :func:`mne.preprocessing.maxwell_filter` (see :ref:`this tutorial <tut-artifact-sss>`) in Python or the command-line utility from MEGIN ``maxfilter`` and :func:`mne.bem.fit_sphere_to_headshape` instead (:gh:`11938` by `Eric Larson`_)
 - :func:`mne.io.kit.read_mrk` reading pickled files is deprecated using something like ``np.savetxt(fid, pts, delimiter="\t", newline="\n")`` to save your points instead (:gh:`11937` by `Eric Larson`_)
+- ``mne.io.edf.edf._read_annotations_edf`` returns an :class:`mne.Annotations` instance (:gh:`11964` by `Paul Roujansky`_)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1140,7 +1140,7 @@ def _write_annotations_txt(fname, annot):
         np.savetxt(fid, data, delimiter=",", fmt="%s")
 
 
-def read_annotations(fname, sfreq="auto", uint16_codec=None):
+def read_annotations(fname, sfreq="auto", uint16_codec=None, encoding_edf="utf8"):
     r"""Read annotations from a file.
 
     This function reads a ``.fif``, ``.fif.gz``, ``.vmrk``, ``.amrk``,
@@ -1168,6 +1168,7 @@ def read_annotations(fname, sfreq="auto", uint16_codec=None):
         too small". ``uint16_codec`` allows to specify what codec (for example:
         ``'latin1'`` or ``'utf-8'``) should be used when reading character
         arrays and can therefore help you solve this problem.
+    %(encoding_edf)s
 
     Returns
     -------
@@ -1232,7 +1233,7 @@ def read_annotations(fname, sfreq="auto", uint16_codec=None):
         annotations = _read_annotations_eeglab(fname, uint16_codec=uint16_codec)
 
     elif name.endswith(("edf", "bdf", "gdf")):
-        annotations = _read_annotations_edf(fname)
+        annotations = _read_annotations_edf(fname, encoding=encoding_edf)
 
     elif name.startswith("events_") and fname.endswith("mat"):
         annotations = _read_brainstorm_annotations(fname)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1234,7 +1234,7 @@ def read_annotations(fname, sfreq="auto", uint16_codec=None, encoding="utf8"):
         annotations = _read_annotations_eeglab(fname, uint16_codec=uint16_codec)
 
     elif name.endswith(("edf", "bdf", "gdf")):
-        annotations = _read_annotations_edf(fname, encoding=encoding_edf)
+        annotations = _read_annotations_edf(fname, encoding=encoding)
 
     elif name.startswith("events_") and fname.endswith("mat"):
         annotations = _read_brainstorm_annotations(fname)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1232,16 +1232,7 @@ def read_annotations(fname, sfreq="auto", uint16_codec=None):
         annotations = _read_annotations_eeglab(fname, uint16_codec=uint16_codec)
 
     elif name.endswith(("edf", "bdf", "gdf")):
-        onset, duration, description, ch_names = _read_annotations_edf(fname)
-        onset = np.array(onset, dtype=float)
-        duration = np.array(duration, dtype=float)
-        annotations = Annotations(
-            onset=onset,
-            duration=duration,
-            description=description,
-            orig_time=None,
-            ch_names=ch_names,
-        )
+        annotations = _read_annotations_edf(fname)
 
     elif name.startswith("events_") and fname.endswith("mat"):
         annotations = _read_brainstorm_annotations(fname)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1140,7 +1140,7 @@ def _write_annotations_txt(fname, annot):
         np.savetxt(fid, data, delimiter=",", fmt="%s")
 
 
-def read_annotations(fname, sfreq="auto", uint16_codec=None, encoding_edf="utf8"):
+def read_annotations(fname, sfreq="auto", uint16_codec=None, encoding="utf8"):
     r"""Read annotations from a file.
 
     This function reads a ``.fif``, ``.fif.gz``, ``.vmrk``, ``.amrk``,
@@ -1169,6 +1169,7 @@ def read_annotations(fname, sfreq="auto", uint16_codec=None, encoding_edf="utf8"
         ``'latin1'`` or ``'utf-8'``) should be used when reading character
         arrays and can therefore help you solve this problem.
     %(encoding_edf)s
+        Only used when reading EDF annotations.
 
     Returns
     -------

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1206,15 +1206,7 @@ def read_annotations(fname, sfreq="auto", uint16_codec=None, encoding="utf8"):
         with ff as fid:
             annotations = _read_annotations_fif(fid, tree)
     elif name.endswith("txt"):
-        orig_time = _read_annotations_txt_parse_header(fname)
-        onset, duration, description, ch_names = _read_annotations_txt(fname)
-        annotations = Annotations(
-            onset=onset,
-            duration=duration,
-            description=description,
-            orig_time=orig_time,
-            ch_names=ch_names,
-        )
+        annotations = _read_annotations_txt(fname)
 
     elif name.endswith(("vmrk", "amrk")):
         annotations = _read_annotations_brainvision(fname, sfreq=sfreq)
@@ -1367,7 +1359,18 @@ def _read_annotations_txt(fname):
             _safe_name_list(ch.decode().strip(), "read", f"ch_names[{ci}]")
             for ci, ch in enumerate(ch_names)
         ]
-    return onset, duration, desc, ch_names
+
+    orig_time = _read_annotations_txt_parse_header(fname)
+
+    annotations = Annotations(
+        onset=onset,
+        duration=duration,
+        description=desc,
+        orig_time=orig_time,
+        ch_names=ch_names,
+    )
+
+    return annotations
 
 
 def _read_annotations_fif(fid, tree):

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1140,6 +1140,7 @@ def _write_annotations_txt(fname, annot):
         np.savetxt(fid, data, delimiter=",", fmt="%s")
 
 
+@fill_doc
 def read_annotations(fname, sfreq="auto", uint16_codec=None, encoding="utf8"):
     r"""Read annotations from a file.
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -421,7 +421,7 @@ def _read_segment_file(data, idx, fi, start, stop, raw_extras, filenames, cals, 
                         ch_data = np.append(ch_data, np.zeros((len(ch_data), 1)), -1)
                         ch_data = interp1d(old, ch_data, kind="zero", axis=-1)(new)
                 elif orig_idx in stim_channel_idxs:
-                    ch_data = np.bitwise_and(ch_data.astype(int), 2 ** 17 - 1)
+                    ch_data = np.bitwise_and(ch_data.astype(int), 2**17 - 1)
 
                 one_i = ch_data.ravel()[r_sidx:r_eidx]
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1948,7 +1948,6 @@ def _read_annotations_edf(annotations, encoding="utf8"):
         onset = float(ev[0]) + offset
         duration = float(ev[2]) if ev[2] else 0
         for description in ev[3].split("\x14")[1:]:
-            print(onset, duration, description)
             if description:
                 if "@@" in description:
                     description, ch_name = description.split("@@")

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -526,7 +526,7 @@ def test_read_latin1_annotations(tmp_path):
         f.write(annot)
 
     # Test reading directly from file
-    annotations = read_annotations(fname=annot_file, encoding_edf="latin1")
+    annotations = read_annotations(fname=annot_file, encoding="latin1")
     assert_allclose(annotations.onset, [1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9])
     assert not any(annotations.duration)  # all durations are 0
     assert_array_equal(

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -521,18 +521,17 @@ def test_read_latin1_annotations(tmp_path):
         b"+1.8\x14\xf4\x14\x00\x00"  # +1.8 ô
         b"+1.9\x14\xfb\x14\x00\x00"  # +1.9 û
     )
-    annot_file = tmp_path / "annotations.txt"
+    annot_file = tmp_path / "annotations.edf"
     with open(annot_file, "wb") as f:
         f.write(annot)
 
     # Test reading directly from file
-    onset, duration, description, ch_names = _read_annotations_edf(
-        annotations=str(annot_file),  # _read_annotations_edf expects fpath as string
-        encoding="latin1",
+    annotations = read_annotations(fname=annot_file, encoding_edf="latin1")
+    assert_allclose(annotations.onset, [1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9])
+    assert not any(annotations.duration)  # all durations are 0
+    assert_array_equal(
+        annotations.description, ["é", "à", "è", "ù", "â", "ê", "î", "ô", "û"]
     )
-    assert onset == (1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9)
-    assert not any(duration)  # all durations are 0
-    assert description == ("é", "à", "è", "ù", "â", "ê", "î", "ô", "û")
 
     # Test reading annotations from channel data
     with open(annot_file, "rb") as f:
@@ -544,7 +543,7 @@ def test_read_latin1_annotations(tmp_path):
             dtype_byte=None,
         )
     annotations = _read_annotations_edf(tal_channel, encoding="latin1")
-    assert_allclose(annotations.onset, (1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9))
+    assert_allclose(annotations.onset, [1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9])
     assert not any(annotations.duration)  # all durations are 0
     assert_array_equal(
         annotations.description, ["é", "à", "è", "ù", "â", "ê", "î", "ô", "û"]

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -356,19 +356,19 @@ def test_parse_annotation(tmp_path):
 
     want_onset, want_duration, want_description = zip(
         *[
-            [180.0, 0.0, "Lights off"],
-            [180.0, 0.0, "Close door"],
-            [180.0, 0.0, "Lights off"],
-            [180.0, 0.0, "Close door"],
             [3.14, 4.2, "nothing"],
+            [180.0, 0.0, "Lights off"],
+            [180.0, 0.0, "Close door"],
+            [180.0, 0.0, "Lights off"],
+            [180.0, 0.0, "Close door"],
             [1800.2, 25.5, "Apnea"],
         ]
     )
     for tal_channel in [tal_channel_A, tal_channel_B]:
-        onset, duration, description, ch_names = _read_annotations_edf([tal_channel])
-        assert_allclose(onset, want_onset)
-        assert_allclose(duration, want_duration)
-        assert description == want_description
+        annotations = _read_annotations_edf([tal_channel])
+        assert_allclose(annotations.onset, want_onset)
+        assert_allclose(annotations.duration, want_duration)
+        assert_array_equal(annotations.description, want_description)
 
 
 def test_find_events_backward_compatibility():
@@ -478,28 +478,14 @@ def test_read_annot(tmp_path):
     with open(annot_file, "wb") as f:
         f.write(annot)
 
-    onset, duration, desc, ch_names = _read_annotations_edf(annotations=str(annot_file))
-    annotation = Annotations(
-        onset=onset,
-        duration=duration,
-        description=desc,
-        orig_time=None,
-        ch_names=ch_names,
-    )
-    _assert_annotations_equal(annotation, EXPECTED_ANNOTATIONS)
+    annotations = _read_annotations_edf(annotations=str(annot_file))
+    _assert_annotations_equal(annotations, EXPECTED_ANNOTATIONS)
 
     # Now test when reading from buffer of data
     with open(annot_file, "rb") as fid:
         ch_data = np.fromfile(fid, dtype="<i2", count=len(annot))
-    onset, duration, desc, ch_names = _read_annotations_edf([ch_data])
-    annotation = Annotations(
-        onset=onset,
-        duration=duration,
-        description=desc,
-        orig_time=None,
-        ch_names=ch_names,
-    )
-    _assert_annotations_equal(annotation, EXPECTED_ANNOTATIONS)
+    annotations = _read_annotations_edf([ch_data])
+    _assert_annotations_equal(annotations, EXPECTED_ANNOTATIONS)
 
 
 @testing.requires_testing_data
@@ -557,13 +543,12 @@ def test_read_latin1_annotations(tmp_path):
             samp=-1,
             dtype_byte=None,
         )
-    onset, duration, description, ch_names = _read_annotations_edf(
-        tal_channel,
-        encoding="latin1",
+    annotations = _read_annotations_edf(tal_channel, encoding="latin1")
+    assert_allclose(annotations.onset, (1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9))
+    assert not any(annotations.duration)  # all durations are 0
+    assert_array_equal(
+        annotations.description, ["é", "à", "è", "ù", "â", "ê", "î", "ô", "û"]
     )
-    assert onset == (1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9)
-    assert not any(duration)  # all durations are 0
-    assert description == ("é", "à", "è", "ù", "â", "ê", "î", "ô", "û")
 
     with pytest.raises(Exception, match="Encountered invalid byte in"):
         _read_annotations_edf(tal_channel)  # default encoding="utf8" fails


### PR DESCRIPTION
The goal is to harmonize `_read_annotations_edf()` with other annotation reading functions and make it return an `mne.Annotations` object instead of a tuple containing its content. This simplifies `mne.annotations.read_annotations()` and reduces a bit the codebase.

**Note:** the same could apply to `_read_annotations_txt()`.