### PR TITLE
MAINT: Refactor codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,6 +43,7 @@
 /*.* @larsoner @drammock  # files in the root directory
 /.circleci @larsoner
 /.github @larsoner
+/tools @larsoner @drammock
 
 # Examples and Tutorials
 /examples @drammock
@@ -50,7 +51,4 @@
 
 # Non-tutorial documentation text and infrastructure
 /doc @larsoner @drammock
-
-# misc
 /logo @drammock
-/tools @drammock

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 
 # Each line is a file pattern followed by one or more owners.
 # Syntax follows .gitignore, see https://git-scm.com/docs/gitignore#_pattern_format
-# Headings ideally should correspend to domains of knowledge/expertise.
+# Headings ideally should correspond to domains of knowledge/expertise.
 
 # Beamforming
 /mne/beamformer @britta-wstnr
@@ -26,14 +26,31 @@
 /mne/export @sappelhoff
 
 # Viz
+/mne/viz @drammock
 /mne/viz/_brain @larsoner
 /tutorials/visualization @larsoner
 /examples/visualization @larsoner
 
+# Core sensor-space classes
+/mne/epochs.py @drammock
+/mne/evoked.py @drammock
+/mne/io/*.* @drammock
+
+# TFR
+/mne/time_frequency @drammock
+
 # Project infrastructure and CIs
-/*.* @larsoner  # files in the root directory
+/*.* @larsoner @drammock  # files in the root directory
 /.circleci @larsoner
 /.github @larsoner
 
-# Documentation text and infrastructure
-/doc @larsoner
+# Examples and Tutorials
+/examples @drammock
+/tutorials @drammock
+
+# Non-tutorial documentation text and infrastructure
+/doc @larsoner @drammock
+
+# misc
+/logo @drammock
+/tools @drammock

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,10 +13,27 @@
 # This file was adapted from SciPy.
 
 # Each line is a file pattern followed by one or more owners.
+# Syntax follows .gitignore, see https://git-scm.com/docs/gitignore#_pattern_format
+# Headings ideally should correspend to domains of knowledge/expertise.
+
+# Beamforming
+/mne/beamformer @britta-wstnr
+*dics*.py @britta-wstnr  # related tutorials and examples
+*lcmv*.py @britta-wstnr
 
 # IO
 /mne/io/brainvision @sappelhoff
 /mne/export @sappelhoff
 
-# Beamforming
-/mne/beamformer/ @britta-wstnr
+# Viz
+/mne/viz/_brain @larsoner
+/tutorials/visualization @larsoner
+/examples/visualization @larsoner
+
+# Project infrastructure and CIs
+/*.* @larsoner  # files in the root directory
+/.circleci @larsoner
+/.github @larsoner
+
+# Documentation text and infrastructure
+/doc @larsoner


### PR DESCRIPTION
@britta-wstnr @drammock in anticipation of asking other people to add themselves, I added more examples and myself in a few places (I should probably add myself more places but I'll do that later I think!). I tried to go by "category of knowledge" rather than file hierarchy, so @britta-wstnr you can see I added a couple of wildcards to the beamforming sections that I think should help catch relevant `tutorials/` and `examples/` without too many false alarms hopefully.