### PR TITLE
MAINT: Add maintenance tool to check status

### DIFF
--- a/tools/check_steering_committee.py
+++ b/tools/check_steering_committee.py
@@ -1,0 +1,58 @@
+# Install pygithub and add GITHUB_TOKEN as env var using a personal access token
+# with read:org, read:user, and read:project
+# https://docs.github.com/en/enterprise-server@3.6/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+# https://pygithub.readthedocs.io/
+
+from collections import Counter
+import os
+import pprint
+from datetime import timezone, datetime, timedelta
+from github import Auth, Github
+from github.Commit import Commit
+from tqdm import tqdm
+
+daysback = 365
+
+# Authenticate
+auth = Auth.Token(os.environ["GITHUB_TOKEN"])
+g = Github(auth=auth, per_page=100)
+print(f"Authenticated as {g.get_user().login}")
+org = g.get_organization("mne-tools")
+teams = org.get_teams()
+team_names = [team.name for team in teams]
+team = teams[team_names.index("MNE-Python Steering Committee")]
+members = list(team.get_members())
+when = (datetime.now().astimezone(timezone.utc) - timedelta(days=daysback)).replace(
+    tzinfo=None
+)
+events = {
+    user.login: Counter(Total=0, Commit=0, IssueComment=0, PullRequestComment=0)
+    for user in members
+}
+kinds = ("commits", "pulls_comments", "issues_comments")
+ljust = max(len(k) for k in kinds)
+for repo in org.get_repos():
+    print(f"{repo.name}:")
+    for kind in kinds:
+        kind_events = getattr(repo, f"get_{kind}")(since=when)
+        desc = f" {kind}".ljust(ljust + 2)
+        total = kind_events.totalCount
+        if total == 0:
+            continue
+        for event in tqdm(kind_events, total=total, desc=desc):
+            if isinstance(event, Commit):
+                if event.author is None:  # happens on mne-testing-data
+                    continue
+                key = event.author.login
+            else:
+                key = event.user.login
+            try:
+                count = events[key]
+            except KeyError:
+                continue
+            count["Total"] += 1
+            count[type(event).__name__] += 1
+events = {k: dict(v) for k, v in events.items()}
+ljust = max(len(k) for k in events)
+pp = pprint.PrettyPrinter(width=120, compact=True)
+pp.pprint({k.ljust(ljust): v for k, v in events.items()})


### PR DESCRIPTION
To follow steering committee policies we need to know member activity levels. This PR adds a tool to use PyGitHub to figure out the steering committee member activity levels across all of `mne-tools` for commits, issue comments, and PR comments:
```
{'GuillaumeFavelier': {'Commit': 0, 'IssueComment': 8, 'PullRequestComment': 0, 'Total': 8},
 'adam2392         ': {'Commit': 18, 'IssueComment': 95, 'PullRequestComment': 125, 'Total': 238},
 'agramfort        ': {'Commit': 24, 'IssueComment': 351, 'PullRequestComment': 141, 'Total': 516},
 'alexrockhill     ': {'Commit': 35, 'IssueComment': 262, 'PullRequestComment': 103, 'Total': 400},
 'bloyl            ': {'Commit': 0, 'IssueComment': 0, 'PullRequestComment': 0, 'Total': 0},
 'britta-wstnr     ': {'Commit': 5, 'IssueComment': 76, 'PullRequestComment': 63, 'Total': 144},
 'cbrnr            ': {'Commit': 23, 'IssueComment': 439, 'PullRequestComment': 63, 'Total': 525},
 'dengemann        ': {'Commit': 2, 'IssueComment': 29, 'PullRequestComment': 6, 'Total': 37},
 'drammock         ': {'Commit': 73, 'IssueComment': 564, 'PullRequestComment': 418, 'Total': 1055},
 'hoechenberger    ': {'Commit': 45, 'IssueComment': 688, 'PullRequestComment': 194, 'Total': 927},
 'jasmainak        ': {'Commit': 3, 'IssueComment': 47, 'PullRequestComment': 15, 'Total': 65},
 'larsoner         ': {'Commit': 348, 'IssueComment': 1737, 'PullRequestComment': 692, 'Total': 2777},
 'mmagnuski        ': {'Commit': 3, 'IssueComment': 104, 'PullRequestComment': 24, 'Total': 131},
 'mscheltienne     ': {'Commit': 63, 'IssueComment': 229, 'PullRequestComment': 113, 'Total': 405},
 'rob-luke         ': {'Commit': 24, 'IssueComment': 53, 'PullRequestComment': 12, 'Total': 89},
 'sappelhoff       ': {'Commit': 49, 'IssueComment': 148, 'PullRequestComment': 31, 'Total': 228},
 'wmvanvliet       ': {'Commit': 5, 'IssueComment': 60, 'PullRequestComment': 20, 'Total': 85}}
```
I can add other categories if it would be helpful, but I think these are already maybe good enough. We could even probably get away without having "Commit" in there (people who commit almost always comment on PRs), but it's quick enough to include.

FWIW these tools could someday perhaps be used to help with #11605. PyGitHub is pretty awesome as it gives access to a lot of attributes and such. So instead of just doing counts you could do "word counts" or something better instead. 🤔 