### PR TITLE
Deprecate complex spectrum obj

### DIFF
--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -317,10 +317,17 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
         # method
         self._inst_type = type(inst)
         method = _validate_method(method, self._get_instance_type_string())
-
+        # don't allow complex output
+        psd_funcs = dict(welch=psd_array_welch, multitaper=psd_array_multitaper)
+        if method_kw.get("output", "") == "complex":
+            warn(
+                f"Complex output support in {type(self).__name__} objects is "
+                "deprecated and will be removed in version 1.7. If you need complex "
+                f"output please use mne.time_frequency.{psd_funcs[method].__name__}() "
+                "instead."
+            )
         # triage method and kwargs. partial() doesn't check validity of kwargs,
         # so we do it manually to save compute time if any are invalid.
-        psd_funcs = dict(welch=psd_array_welch, multitaper=psd_array_multitaper)
         invalid_ix = np.in1d(
             list(method_kw), list(signature(psd_funcs[method]).parameters), invert=True
         )

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -324,7 +324,8 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
                 f"Complex output support in {type(self).__name__} objects is "
                 "deprecated and will be removed in version 1.7. If you need complex "
                 f"output please use mne.time_frequency.{psd_funcs[method].__name__}() "
-                "instead."
+                "instead.",
+                FutureWarning,
             )
         # triage method and kwargs. partial() doesn't check validity of kwargs,
         # so we do it manually to save compute time if any are invalid.

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -317,10 +317,15 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
         # method
         self._inst_type = type(inst)
         method = _validate_method(method, self._get_instance_type_string())
-
+        # don't allow complex output
+        psd_funcs = dict(welch=psd_array_welch, multitaper=psd_array_multitaper)
+        if method_kw.get("output", "") == "complex":
+            raise ValueError(
+                f"Complex output is not supported in {type(self).__name__} objects. "
+                f"Please use mne.time_frequency.{psd_funcs[method].__name__}() instead."
+            )
         # triage method and kwargs. partial() doesn't check validity of kwargs,
         # so we do it manually to save compute time if any are invalid.
-        psd_funcs = dict(welch=psd_array_welch, multitaper=psd_array_multitaper)
         invalid_ix = np.in1d(
             list(method_kw), list(signature(psd_funcs[method]).parameters), invert=True
         )
@@ -356,8 +361,6 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
         )
         if method_kw.get("average", "") in (None, False):
             self._dims += ("segment",)
-        if self._returns_complex_tapers(**method_kw):
-            self._dims = self._dims[:-1] + ("taper",) + self._dims[-1:]
         # record data type (for repr and html_repr)
         self._data_type = (
             "Fourier Coefficients" if "taper" in self._dims else "Power Spectrum"
@@ -399,8 +402,6 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
         # instance type
         inst_types = dict(Raw=Raw, Epochs=Epochs, Evoked=Evoked, Array=np.ndarray)
         self._inst_type = inst_types[state["inst_type_str"]]
-        if "weights" in state and state["weights"] is not None:
-            self._mt_weights = state["weights"]
 
     def __repr__(self):
         """Build string representation of the Spectrum object."""
@@ -442,23 +443,14 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
             s = _pl(bad_value.sum())
             warn(f'Zero value in spectrum for channel{s} {", ".join(chs)}', UserWarning)
 
-    def _returns_complex_tapers(self, **method_kw):
-        return method_kw.get("output", "") == "complex" and self.method == "multitaper"
-
     def _compute_spectra(self, data, fmin, fmax, n_jobs, method_kw, verbose):
         # make the spectra
         result = self._psd_func(
             data, self.sfreq, fmin=fmin, fmax=fmax, n_jobs=n_jobs, verbose=verbose
         )
-        # assign ._data (handling unaggregated multitaper output)
-        if self._returns_complex_tapers(**method_kw):
-            fourier_coefs, freqs, weights = result
-            self._data = fourier_coefs
-            self._mt_weights = weights
-        else:
-            psds, freqs = result
-            self._data = psds
-        # assign properties (._data already assigned above)
+        # assign ._data ._freqs, ._shape
+        psds, freqs = result
+        self._data = psds
         self._freqs = freqs
         # this is *expected* shape, it gets asserted later in _check_values()
         # (and then deleted afterwards)
@@ -467,9 +459,6 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
         if method_kw.get("average", "") in (None, False):
             n_welch_segments = _compute_n_welch_segments(data.shape[-1], method_kw)
             self._shape += (n_welch_segments,)
-        # insert n_tapers
-        if self._returns_complex_tapers(**method_kw):
-            self._shape = self._shape[:-1] + (self._mt_weights.size,) + self._shape[-1:]
         # we don't need these anymore, and they make save/load harder
         del self._picks
         del self._psd_func
@@ -647,7 +636,6 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
         """
         # Must nest this _mpl_figure import because of the BACKEND global
         # stuff
-        from .multitaper import _psd_from_mt
         from ..viz._mpl_figure import _line_figure, _split_picks_by_type
 
         # arg checking
@@ -669,12 +657,8 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
         (picks_list, units_list, scalings_list, titles_list) = _split_picks_by_type(
             self, picks, units, scalings, titles
         )
-        # handle unaggregated multitaper
-        if hasattr(self, "_mt_weights"):
-            logger.info("Aggregating multitaper estimates before plotting...")
-            _f = partial(_psd_from_mt, weights=self._mt_weights)
         # handle unaggregated Welch
-        elif "segment" in self._dims:
+        if "segment" in self._dims:
             logger.info("Aggregating Welch estimates (median) before plotting...")
             seg_axis = self._dims.index("segment")
             _f = partial(np.nanmedian, axis=seg_axis)
@@ -1046,9 +1030,8 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
             for that channel type.
         """
         units = _handle_default("si_units", None)
-        power = not hasattr(self, "_mt_weights")
         return {
-            ch_type: _format_units_psd(units[ch_type], power=power, latex=latex)
+            ch_type: _format_units_psd(units[ch_type], power=True, latex=latex)
             for ch_type in sorted(self.get_channel_types(unique=True))
         }
 
@@ -1428,12 +1411,7 @@ class EpochsSpectrum(BaseSpectrum, GetEpochsMixin):
                 f"got a {type(method).__name__} ({method})."
             )
         # averaging unaggregated spectral estimates are not supported
-        if hasattr(self, "_mt_weights"):
-            raise NotImplementedError(
-                "Averaging complex spectra is not supported. Consider "
-                "averaging the signals before computing the complex spectrum."
-            )
-        elif "segment" in self._dims:
+        if "segment" in self._dims:
             raise NotImplementedError(
                 "Averaging individual Welch segments across epochs is not "
                 "supported. Consider averaging the signals before computing "

--- a/mne/time_frequency/tests/test_spectrum.py
+++ b/mne/time_frequency/tests/test_spectrum.py
@@ -1,10 +1,13 @@
+from contextlib import nullcontext
 from functools import partial
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_allclose
 import matplotlib.pyplot as plt
 
+from mne import create_info, make_fixed_length_epochs
+from mne.io import RawArray
 from mne import Annotations
 from mne.time_frequency import read_spectrum
 from mne.time_frequency.multitaper import _psd_from_mt
@@ -19,7 +22,7 @@ def test_compute_psd_errors(raw):
         raw.compute_psd(foo=None)
     with pytest.raises(TypeError, match="keyword arguments foo, bar for"):
         raw.compute_psd(foo=None, bar=None)
-    with pytest.warns(RuntimeWarning, match="Complex output support in.*deprecated"):
+    with pytest.warns(FutureWarning, match="Complex output support in.*deprecated"):
         raw.compute_psd(output="complex")
 
 
@@ -204,9 +207,17 @@ def _agg_helper(df, weights, group_cols):
     return Series(_df)
 
 
+@pytest.mark.filterwarnings("ignore:Complex output support.*:FutureWarning")
 @pytest.mark.parametrize("long_format", (False, True))
-@pytest.mark.parametrize("method", ("welch", "multitaper"))
-def test_unaggregated_spectrum_to_data_frame(raw, long_format, method):
+@pytest.mark.parametrize(
+    "method, output",
+    [
+        ("welch", "complex"),
+        ("welch", "power"),
+        ("multitaper", "complex"),
+    ],
+)
+def test_unaggregated_spectrum_to_data_frame(raw, long_format, method, output):
     """Test converting complex multitaper spectra to data frame."""
     pytest.importorskip("pandas")
     from pandas.testing import assert_frame_equal
@@ -220,10 +231,10 @@ def test_unaggregated_spectrum_to_data_frame(raw, long_format, method):
     kwargs = dict()
     if method == "welch":
         kwargs.update(average=False, verbose="error")
-    spectrum = raw.compute_psd(method=method, **kwargs)
+    spectrum = raw.compute_psd(method=method, output=output, **kwargs)
     df = spectrum.to_data_frame(long_format=long_format)
     grouping_cols = ["freq"]
-    drop_cols = ["segment"] if method == "welch" else []
+    drop_cols = ["segment"] if method == "welch" else ["taper"]
     if long_format:
         grouping_cols.append("channel")
         drop_cols.append("ch_type")
@@ -238,7 +249,18 @@ def test_unaggregated_spectrum_to_data_frame(raw, long_format, method):
     # aggregate
     df = df.drop(columns=drop_cols)
     gb = df.groupby(grouping_cols, as_index=False, observed=False)
-    agg_df = gb.mean()  # excludes NA values automatically
+    if method == "welch":
+        if output == "complex":
+
+            def _fun(x):
+                return np.nanmean(np.abs(x))
+
+            agg_df = gb.agg(_fun)
+        else:
+            agg_df = gb.mean()  # excludes missing values itself
+    else:
+        gb = gb[df.columns]  # https://github.com/pandas-dev/pandas/pull/52477
+        agg_df = gb.apply(_agg_helper, spectrum._mt_weights, grouping_cols)
     # even with check_categorical=False, we know that the *data* matches;
     # what may differ is the order of the "levels" in the *metadata* for the
     # channel name column
@@ -305,6 +327,59 @@ def test_spectrum_proj(inst, request):
     with has_proj.info._unlock():
         has_proj.info["projs"] = no_proj.info["projs"]
     assert has_proj == no_proj
+
+
+@pytest.mark.filterwarnings("ignore:Complex output support.*:FutureWarning")
+@pytest.mark.parametrize(
+    "method, average",
+    [
+        ("welch", False),
+        ("welch", "mean"),
+        ("multitaper", False),
+    ],
+)
+def test_spectrum_complex(method, average):
+    """Test output='complex' support."""
+    sfreq = 100
+    n = 10 * sfreq
+    freq = 3.0
+    phase = np.pi / 4  # should be recoverable
+    data = np.cos(2 * np.pi * freq * np.arange(n) / sfreq + phase)[np.newaxis]
+    raw = RawArray(data, create_info(1, sfreq, "eeg"))
+    epochs = make_fixed_length_epochs(raw, duration=2.0, preload=True)
+    assert len(epochs) == 5
+    assert len(epochs.times) == 2 * sfreq
+    kwargs = dict(output="complex", method=method)
+    ctx = pytest.warns(UserWarning, match="Zero value")
+    if method == "welch":
+        kwargs["n_fft"] = sfreq
+        want_dims = ("epoch", "channel", "freq")
+        want_shape = (5, 1, sfreq // 2 + 1)
+        if not average:
+            want_dims = want_dims + ("segment",)
+            want_shape = want_shape + (2,)
+            kwargs["average"] = average
+    else:
+        assert method == "multitaper"
+        assert not average
+        ctx = nullcontext()
+        want_dims = ("epoch", "channel", "taper", "freq")
+        want_shape = (5, 1, 7, sfreq + 1)
+    with ctx:
+        spectrum = epochs.compute_psd(**kwargs)
+    idx = np.argmin(np.abs(spectrum.freqs - freq))
+    assert spectrum.freqs[idx] == freq
+    assert spectrum._dims == want_dims
+    assert spectrum.shape == want_shape
+    data = spectrum.get_data()
+    assert data.dtype == np.complex128
+    coef = spectrum.get_data(fmin=freq, fmax=freq).mean(0)
+    if method == "multitaper":
+        coef = coef[..., 0, :]  # first taper
+    elif not average:
+        coef = coef.mean(-1)  # over segments
+    coef = coef.item()
+    assert_allclose(np.angle(coef), phase, rtol=1e-4)
 
 
 def test_spectrum_kwarg_triaging(raw):

--- a/mne/time_frequency/tests/test_spectrum.py
+++ b/mne/time_frequency/tests/test_spectrum.py
@@ -1,20 +1,17 @@
-from contextlib import nullcontext
 from functools import partial
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal, assert_allclose
+from numpy.testing import assert_array_equal
 import matplotlib.pyplot as plt
 
-from mne import create_info, make_fixed_length_epochs
-from mne.io import RawArray
 from mne import Annotations
 from mne.time_frequency import read_spectrum
 from mne.time_frequency.multitaper import _psd_from_mt
 from mne.time_frequency.spectrum import SpectrumArray, EpochsSpectrumArray
 
 
-def test_spectrum_errors(raw):
+def test_compute_psd_errors(raw):
     """Test for expected errors in the .compute_psd() method."""
     with pytest.raises(ValueError, match="must not exceed ½ the sampling"):
         raw.compute_psd(fmax=raw.info["sfreq"] * 0.51)
@@ -22,6 +19,8 @@ def test_spectrum_errors(raw):
         raw.compute_psd(foo=None)
     with pytest.raises(TypeError, match="keyword arguments foo, bar for"):
         raw.compute_psd(foo=None, bar=None)
+    with pytest.raises(ValueError, match="Complex output is not supported in "):
+        raw.compute_psd(output="complex")
 
 
 @pytest.mark.parametrize("method", ("welch", "multitaper"))
@@ -206,15 +205,8 @@ def _agg_helper(df, weights, group_cols):
 
 
 @pytest.mark.parametrize("long_format", (False, True))
-@pytest.mark.parametrize(
-    "method, output",
-    [
-        ("welch", "complex"),
-        ("welch", "power"),
-        ("multitaper", "complex"),
-    ],
-)
-def test_unaggregated_spectrum_to_data_frame(raw, long_format, method, output):
+@pytest.mark.parametrize("method", ("welch", "multitaper"))
+def test_unaggregated_spectrum_to_data_frame(raw, long_format, method):
     """Test converting complex multitaper spectra to data frame."""
     pytest.importorskip("pandas")
     from pandas.testing import assert_frame_equal
@@ -228,10 +220,10 @@ def test_unaggregated_spectrum_to_data_frame(raw, long_format, method, output):
     kwargs = dict()
     if method == "welch":
         kwargs.update(average=False, verbose="error")
-    spectrum = raw.compute_psd(method=method, output=output, **kwargs)
+    spectrum = raw.compute_psd(method=method, **kwargs)
     df = spectrum.to_data_frame(long_format=long_format)
     grouping_cols = ["freq"]
-    drop_cols = ["segment"] if method == "welch" else ["taper"]
+    drop_cols = ["segment"] if method == "welch" else []
     if long_format:
         grouping_cols.append("channel")
         drop_cols.append("ch_type")
@@ -246,18 +238,7 @@ def test_unaggregated_spectrum_to_data_frame(raw, long_format, method, output):
     # aggregate
     df = df.drop(columns=drop_cols)
     gb = df.groupby(grouping_cols, as_index=False, observed=False)
-    if method == "welch":
-        if output == "complex":
-
-            def _fun(x):
-                return np.nanmean(np.abs(x))
-
-            agg_df = gb.agg(_fun)
-        else:
-            agg_df = gb.mean()  # excludes missing values itself
-    else:
-        gb = gb[df.columns]  # https://github.com/pandas-dev/pandas/pull/52477
-        agg_df = gb.apply(_agg_helper, spectrum._mt_weights, grouping_cols)
+    agg_df = gb.mean()  # excludes NA automatically
     # even with check_categorical=False, we know that the *data* matches;
     # what may differ is the order of the "levels" in the *metadata* for the
     # channel name column
@@ -324,58 +305,6 @@ def test_spectrum_proj(inst, request):
     with has_proj.info._unlock():
         has_proj.info["projs"] = no_proj.info["projs"]
     assert has_proj == no_proj
-
-
-@pytest.mark.parametrize(
-    "method, average",
-    [
-        ("welch", False),
-        ("welch", "mean"),
-        ("multitaper", False),
-    ],
-)
-def test_spectrum_complex(method, average):
-    """Test output='complex' support."""
-    sfreq = 100
-    n = 10 * sfreq
-    freq = 3.0
-    phase = np.pi / 4  # should be recoverable
-    data = np.cos(2 * np.pi * freq * np.arange(n) / sfreq + phase)[np.newaxis]
-    raw = RawArray(data, create_info(1, sfreq, "eeg"))
-    epochs = make_fixed_length_epochs(raw, duration=2.0, preload=True)
-    assert len(epochs) == 5
-    assert len(epochs.times) == 2 * sfreq
-    kwargs = dict(output="complex", method=method)
-    ctx = pytest.warns(UserWarning, match="Zero value")
-    if method == "welch":
-        kwargs["n_fft"] = sfreq
-        want_dims = ("epoch", "channel", "freq")
-        want_shape = (5, 1, sfreq // 2 + 1)
-        if not average:
-            want_dims = want_dims + ("segment",)
-            want_shape = want_shape + (2,)
-            kwargs["average"] = average
-    else:
-        assert method == "multitaper"
-        assert not average
-        ctx = nullcontext()
-        want_dims = ("epoch", "channel", "taper", "freq")
-        want_shape = (5, 1, 7, sfreq + 1)
-    with ctx:
-        spectrum = epochs.compute_psd(**kwargs)
-    idx = np.argmin(np.abs(spectrum.freqs - freq))
-    assert spectrum.freqs[idx] == freq
-    assert spectrum._dims == want_dims
-    assert spectrum.shape == want_shape
-    data = spectrum.get_data()
-    assert data.dtype == np.complex128
-    coef = spectrum.get_data(fmin=freq, fmax=freq).mean(0)
-    if method == "multitaper":
-        coef = coef[..., 0, :]  # first taper
-    elif not average:
-        coef = coef.mean(-1)  # over segments
-    coef = coef.item()
-    assert_allclose(np.angle(coef), phase, rtol=1e-4)
 
 
 def test_spectrum_kwarg_triaging(raw):

--- a/mne/time_frequency/tests/test_spectrum.py
+++ b/mne/time_frequency/tests/test_spectrum.py
@@ -1,17 +1,20 @@
+from contextlib import nullcontext
 from functools import partial
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_allclose
 import matplotlib.pyplot as plt
 
+from mne import create_info, make_fixed_length_epochs
+from mne.io import RawArray
 from mne import Annotations
 from mne.time_frequency import read_spectrum
 from mne.time_frequency.multitaper import _psd_from_mt
 from mne.time_frequency.spectrum import SpectrumArray, EpochsSpectrumArray
 
 
-def test_compute_psd_errors(raw):
+def test_spectrum_errors(raw):
     """Test for expected errors in the .compute_psd() method."""
     with pytest.raises(ValueError, match="must not exceed ½ the sampling"):
         raw.compute_psd(fmax=raw.info["sfreq"] * 0.51)
@@ -19,8 +22,6 @@ def test_compute_psd_errors(raw):
         raw.compute_psd(foo=None)
     with pytest.raises(TypeError, match="keyword arguments foo, bar for"):
         raw.compute_psd(foo=None, bar=None)
-    with pytest.raises(ValueError, match="Complex output is not supported in "):
-        raw.compute_psd(output="complex")
 
 
 @pytest.mark.parametrize("method", ("welch", "multitaper"))
@@ -205,8 +206,15 @@ def _agg_helper(df, weights, group_cols):
 
 
 @pytest.mark.parametrize("long_format", (False, True))
-@pytest.mark.parametrize("method", ("welch", "multitaper"))
-def test_unaggregated_spectrum_to_data_frame(raw, long_format, method):
+@pytest.mark.parametrize(
+    "method, output",
+    [
+        ("welch", "complex"),
+        ("welch", "power"),
+        ("multitaper", "complex"),
+    ],
+)
+def test_unaggregated_spectrum_to_data_frame(raw, long_format, method, output):
     """Test converting complex multitaper spectra to data frame."""
     pytest.importorskip("pandas")
     from pandas.testing import assert_frame_equal
@@ -220,10 +228,10 @@ def test_unaggregated_spectrum_to_data_frame(raw, long_format, method):
     kwargs = dict()
     if method == "welch":
         kwargs.update(average=False, verbose="error")
-    spectrum = raw.compute_psd(method=method, **kwargs)
+    spectrum = raw.compute_psd(method=method, output=output, **kwargs)
     df = spectrum.to_data_frame(long_format=long_format)
     grouping_cols = ["freq"]
-    drop_cols = ["segment"] if method == "welch" else []
+    drop_cols = ["segment"] if method == "welch" else ["taper"]
     if long_format:
         grouping_cols.append("channel")
         drop_cols.append("ch_type")
@@ -238,7 +246,18 @@ def test_unaggregated_spectrum_to_data_frame(raw, long_format, method):
     # aggregate
     df = df.drop(columns=drop_cols)
     gb = df.groupby(grouping_cols, as_index=False, observed=False)
-    agg_df = gb.mean()  # excludes NA automatically
+    if method == "welch":
+        if output == "complex":
+
+            def _fun(x):
+                return np.nanmean(np.abs(x))
+
+            agg_df = gb.agg(_fun)
+        else:
+            agg_df = gb.mean()  # excludes missing values itself
+    else:
+        gb = gb[df.columns]  # https://github.com/pandas-dev/pandas/pull/52477
+        agg_df = gb.apply(_agg_helper, spectrum._mt_weights, grouping_cols)
     # even with check_categorical=False, we know that the *data* matches;
     # what may differ is the order of the "levels" in the *metadata* for the
     # channel name column
@@ -305,6 +324,58 @@ def test_spectrum_proj(inst, request):
     with has_proj.info._unlock():
         has_proj.info["projs"] = no_proj.info["projs"]
     assert has_proj == no_proj
+
+
+@pytest.mark.parametrize(
+    "method, average",
+    [
+        ("welch", False),
+        ("welch", "mean"),
+        ("multitaper", False),
+    ],
+)
+def test_spectrum_complex(method, average):
+    """Test output='complex' support."""
+    sfreq = 100
+    n = 10 * sfreq
+    freq = 3.0
+    phase = np.pi / 4  # should be recoverable
+    data = np.cos(2 * np.pi * freq * np.arange(n) / sfreq + phase)[np.newaxis]
+    raw = RawArray(data, create_info(1, sfreq, "eeg"))
+    epochs = make_fixed_length_epochs(raw, duration=2.0, preload=True)
+    assert len(epochs) == 5
+    assert len(epochs.times) == 2 * sfreq
+    kwargs = dict(output="complex", method=method)
+    ctx = pytest.warns(UserWarning, match="Zero value")
+    if method == "welch":
+        kwargs["n_fft"] = sfreq
+        want_dims = ("epoch", "channel", "freq")
+        want_shape = (5, 1, sfreq // 2 + 1)
+        if not average:
+            want_dims = want_dims + ("segment",)
+            want_shape = want_shape + (2,)
+            kwargs["average"] = average
+    else:
+        assert method == "multitaper"
+        assert not average
+        ctx = nullcontext()
+        want_dims = ("epoch", "channel", "taper", "freq")
+        want_shape = (5, 1, 7, sfreq + 1)
+    with ctx:
+        spectrum = epochs.compute_psd(**kwargs)
+    idx = np.argmin(np.abs(spectrum.freqs - freq))
+    assert spectrum.freqs[idx] == freq
+    assert spectrum._dims == want_dims
+    assert spectrum.shape == want_shape
+    data = spectrum.get_data()
+    assert data.dtype == np.complex128
+    coef = spectrum.get_data(fmin=freq, fmax=freq).mean(0)
+    if method == "multitaper":
+        coef = coef[..., 0, :]  # first taper
+    elif not average:
+        coef = coef.mean(-1)  # over segments
+    coef = coef.item()
+    assert_allclose(np.angle(coef), phase, rtol=1e-4)
 
 
 def test_spectrum_kwarg_triaging(raw):


### PR DESCRIPTION
following discussion in #11803 (summarized in [this comment](https://github.com/mne-tools/mne-python/pull/11803#issuecomment-1697994547)) this deprecates support for complex output in Spectrum and EpochsSpectrum objects.