### PR TITLE
MAINT: Switch to scheduled runs for macOS [skip azp] [skip actions]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -539,8 +539,6 @@ jobs:
 workflows:
   default:
     jobs:
-      - pytest-macos-arm64:
-          name: pytest-macos-arm64
       - build_docs:
           name: build_docs
       - linkcheck:
@@ -575,12 +573,26 @@ workflows:
 
   weekly:
     jobs:
-      - linkcheck:
-          name: linkcheck_weekly
+      - pytest-macos-arm64:
+          name: pytest_macos_arm64_weekly
           scheduled: "true"
     triggers:
       - schedule:
-          # "At 6:00 AM GMT on the first day of each month" is often enough
+          # "At 6:00 AM GMT every Monday"
+          cron: "0 6 * * 1"
+          filters:
+            branches:
+              only:
+                - main
+
+  monthly:
+    jobs:
+      - linkcheck:
+          name: linkcheck_monthly
+          scheduled: "true"
+    triggers:
+      - schedule:
+          # "At 6:00 AM GMT on the first day of each month"
           cron: "0 6 1 * *"
           filters:
             branches:


### PR DESCRIPTION
I logged in to CircleCI to an unpleasant surprise. The 250k credits we buy per month plus all our roll-over credits had been spent. This is why :scream: :

![Screenshot from 2023-09-12 11-15-04](https://github.com/mne-tools/mne-python/assets/2365790/06be762e-2c20-4c68-b35b-38527930bc56)

Switching to a scheduled run once a week is probably good enough given the upstream abstractions/testing in place. And this also fixes an existing misnomer with a "weekly" run that was actually being done monthly.