### PR TITLE
MAINT: Replace in1d with isin

### DIFF
--- a/examples/visualization/evoked_topomap.py
+++ b/examples/visualization/evoked_topomap.py
@@ -148,7 +148,7 @@ significant_channels = [
     ("MEG 2411", "MEG 2421"),
     ("MEG 1621"),
 ]
-_channels = [np.in1d(evoked.ch_names, ch) for ch in significant_channels]
+_channels = [np.isin(evoked.ch_names, ch) for ch in significant_channels]
 
 mask = np.zeros(evoked.data.shape, dtype="bool")
 for _chs, _time in zip(_channels, _times):

--- a/mne/_freesurfer.py
+++ b/mne/_freesurfer.py
@@ -249,7 +249,7 @@ def get_volume_labels_from_aseg(mgz_fname, return_colors=False, atlas_ids=None):
     elif return_colors:
         raise ValueError("return_colors must be False if atlas_ids are " "provided")
     # restrict to the ones in the MRI, sorted by label name
-    keep = np.in1d(list(atlas_ids.values()), want)
+    keep = np.isin(list(atlas_ids.values()), want)
     keys = sorted(
         (key for ki, key in enumerate(atlas_ids.keys()) if keep[ki]),
         key=lambda x: atlas_ids[x],

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -108,7 +108,7 @@ def _simulate_data(fwd, idx):  # Somewhere on the frontal lobe by default
     csd = csd_morlet(epochs, frequencies=[10, 20], n_cycles=[5, 10], decim=5)
 
     labels = mne.read_labels_from_annot("sample", hemi="lh", subjects_dir=subjects_dir)
-    label = [label for label in labels if np.isin(source_vertno, label.vertices)[0]]
+    label = [label for label in labels if np.isin(source_vertno, label.vertices)]
     assert len(label) == 1
     label = label[0]
     vertices = np.intersect1d(label.vertices, fwd["src"][0]["vertno"])

--- a/mne/beamformer/tests/test_dics.py
+++ b/mne/beamformer/tests/test_dics.py
@@ -108,7 +108,7 @@ def _simulate_data(fwd, idx):  # Somewhere on the frontal lobe by default
     csd = csd_morlet(epochs, frequencies=[10, 20], n_cycles=[5, 10], decim=5)
 
     labels = mne.read_labels_from_annot("sample", hemi="lh", subjects_dir=subjects_dir)
-    label = [label for label in labels if np.in1d(source_vertno, label.vertices)[0]]
+    label = [label for label in labels if np.isin(source_vertno, label.vertices)[0]]
     assert len(label) == 1
     label = label[0]
     vertices = np.intersect1d(label.vertices, fwd["src"][0]["vertno"])

--- a/mne/beamformer/tests/test_lcmv.py
+++ b/mne/beamformer/tests/test_lcmv.py
@@ -193,7 +193,7 @@ def test_lcmv_vector():
 
     # Figure out our indices
     mask = np.concatenate(
-        [np.in1d(s["vertno"], v) for s, v in zip(forward["src"], vertices)]
+        [np.isin(s["vertno"], v) for s, v in zip(forward["src"], vertices)]
     )
     mapping = np.where(mask)[0]
     assert_array_equal(source_rr, forward["source_rr"][mapping])

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -212,7 +212,7 @@ def _interpolate_bads_meeg(
         picks_bad = pick_channels(inst.info["ch_names"], bads_type, exclude=[])
         if ch_type == "eeg":
             picks_to = picks_type
-            bad_sel = np.in1d(picks_type, picks_bad)
+            bad_sel = np.isin(picks_type, picks_bad)
         else:
             picks_to = picks_bad
             bad_sel = slice(None)

--- a/mne/chpi.py
+++ b/mne/chpi.py
@@ -727,7 +727,7 @@ def _setup_ext_proj(info, ext_order):
         dict(origin=(0.0, 0.0, 0.0), int_order=0, ext_order=ext_order), mf_coils
     ).T
     out_removes = _regularize_out(0, 1, mag_or_fine, [])
-    ext = ext[~np.in1d(np.arange(len(ext)), out_removes)]
+    ext = ext[~np.isin(np.arange(len(ext)), out_removes)]
     ext = orth(ext.T).T
     assert ext.shape[1] == len(meg_picks)
     proj = Projection(

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -167,6 +167,8 @@ def pytest_configure(config):
     ignore:mne\.io\.pick.channel_indices_by_type is deprecated.*:
     # Windows CIs using MESA get this
     ignore:Mesa version 10\.2\.4 is too old for translucent.*:RuntimeWarning
+    # Matplotlib <-> NumPy 2.0
+    ignore:`row_stack` alias is deprecated.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()

--- a/mne/cov.py
+++ b/mne/cov.py
@@ -709,7 +709,7 @@ def compute_raw_covariance(
     if picks is None:
         # Need to include all channels e.g. if eog rejection is to be used
         picks = np.arange(raw.info["nchan"])
-        pick_mask = np.in1d(picks, _pick_data_channels(raw.info, with_ref_meg=False))
+        pick_mask = np.isin(picks, _pick_data_channels(raw.info, with_ref_meg=False))
     else:
         pick_mask = slice(None)
         picks = _picks_to_idx(raw.info, picks)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -503,7 +503,7 @@ class BaseEpochs(
             del events
 
             values = list(self.event_id.values())
-            selected = np.where(np.in1d(self.events[:, 2], values))[0]
+            selected = np.where(np.isin(self.events[:, 2], values))[0]
             if selection is None:
                 selection = selected
             else:
@@ -538,7 +538,7 @@ class BaseEpochs(
             )
 
             # then subselect
-            sub = np.where(np.in1d(selection, self.selection))[0]
+            sub = np.where(np.isin(selection, self.selection))[0]
             if isinstance(metadata, list):
                 metadata = [metadata[s] for s in sub]
             elif metadata is not None:
@@ -2849,7 +2849,7 @@ def make_metadata(
     id_to_name_map = {v: k for k, v in event_id.items()}
 
     # Only keep events that are of interest
-    events = events[np.in1d(events[:, 2], list(event_id.values()))]
+    events = events[np.isin(events[:, 2], list(event_id.values()))]
     events_df = events_df.loc[events_df["id"].isin(event_id.values()), :]
 
     # Prepare & condition the metadata DataFrame
@@ -2954,7 +2954,7 @@ def make_metadata(
         event_id_timelocked = {
             name: val for name, val in event_id.items() if name in row_events
         }
-        events = events[np.in1d(events[:, 2], list(event_id_timelocked.values()))]
+        events = events[np.isin(events[:, 2], list(event_id_timelocked.values()))]
         metadata = metadata.loc[metadata["event_name"].isin(event_id_timelocked)]
         assert len(events) == len(metadata)
         event_id = event_id_timelocked
@@ -3302,7 +3302,7 @@ class EpochsArray(BaseEpochs):
             self._do_baseline = True
         if (
             len(events)
-            != np.in1d(self.events[:, 2], list(self.event_id.values())).sum()
+            != np.isin(self.events[:, 2], list(self.event_id.values())).sum()
         ):
             raise ValueError(
                 "The events must only contain event numbers from " "event_id"

--- a/mne/event.py
+++ b/mne/event.py
@@ -914,7 +914,7 @@ def shift_time_events(events, ids, tshift, sfreq):
     if ids is None:
         mask = slice(None)
     else:
-        mask = np.in1d(events[:, 2], ids)
+        mask = np.isin(events[:, 2], ids)
     events[mask, 0] += int(tshift * sfreq)
 
     return events

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -1643,7 +1643,7 @@ def _read_evoked(fname, condition=None, kind="average", allow_maxshield=False):
                 raise ValueError('kind must be "average" or ' '"standard_error"')
 
             comments, aspect_kinds, t = _get_entries(fid, evoked_node, allow_maxshield)
-            goods = np.in1d(comments, [condition]) & np.in1d(
+            goods = np.isin(comments, [condition]) & np.isin(
                 aspect_kinds, [_aspect_dict[kind]]
             )
             found_cond = np.where(goods)[0]

--- a/mne/filter.py
+++ b/mne/filter.py
@@ -2947,7 +2947,7 @@ def _filt_check_picks(info, picks, h_freq, l_freq):
                 "lowpass values in the measurement info will not "
                 "be updated."
             )
-        elif np.in1d(data_picks, picks).all():
+        elif np.isin(data_picks, picks).all():
             update_info = True
         else:
             logger.info(

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -848,7 +848,7 @@ def make_forward_dipole(dipole, bem, info, trans=None, n_jobs=None, *, verbose=N
     data = np.zeros((len(amplitude), len(timepoints)))  # (n_d, n_t)
     row = 0
     for tpind, tp in enumerate(timepoints):
-        amp = amplitude[np.in1d(times, tp)]
+        amp = amplitude[np.isin(times, tp)]
         data[row : row + len(amp), tpind] = amp
         row += len(amp)
 

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -1846,7 +1846,7 @@ def restrict_forward_to_label(fwd, labels):
     # Remove duplicates and sort
     vertices = [np.unique(vert_hemi) for vert_hemi in vertices]
     vertices = [
-        vert_hemi[np.in1d(vert_hemi, s["vertno"])]
+        vert_hemi[np.isin(vert_hemi, s["vertno"])]
         for vert_hemi, s in zip(vertices, fwd["src"])
     ]
     src_sel, _, _ = _stc_src_sel(fwd["src"], vertices, on_missing="raise")

--- a/mne/forward/tests/test_forward.py
+++ b/mne/forward/tests/test_forward.py
@@ -495,7 +495,7 @@ def test_priors():
         compute_orient_prior(fwd, 0.5)
     fwd_surf_ori = convert_forward_solution(fwd, surf_ori=True)
     orient_prior = compute_orient_prior(fwd_surf_ori, 0.5)
-    assert all(np.in1d(orient_prior, (0.5, 1.0)))
+    assert all(np.isin(orient_prior, (0.5, 1.0)))
     with pytest.raises(ValueError, match="between 0 and 1"):
         compute_orient_prior(fwd_surf_ori, -0.5)
     with pytest.raises(ValueError, match="with fixed orientation"):

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2727,7 +2727,7 @@ def _write_raw_data(
     sk_onsets, sk_ends = _annotations_starts_stops(raw, "bad_acq_skip")
     do_skips = False
     if len(sk_onsets) > 0:
-        if np.in1d(sk_onsets, firsts).all() and np.in1d(sk_ends, lasts).all():
+        if np.isin(sk_onsets, firsts).all() and np.isin(sk_ends, lasts).all():
             do_skips = True
         else:
             if part_idx == 0:

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -765,11 +765,11 @@ def _get_hdr_info(hdr_fname, eog, misc, scale):
                 # We convert channels with disabled filters to having
                 # highpass relaxed / no filters
                 highpass = [
-                    float(filt) if filt not in ("NaN", "Off", "DC") else np.Inf
+                    float(filt) if filt not in ("NaN", "Off", "DC") else np.inf
                     for filt in highpass
                 ]
                 info["highpass"] = np.max(np.array(highpass, dtype=np.float64))
-                # Coveniently enough 1 / np.Inf = 0.0, so this works for
+                # Coveniently enough 1 / np.inf = 0.0, so this works for
                 # DC / no highpass filter
                 # filter time constant t [secs] to Hz conversion: 1/2*pi*t
                 info["highpass"] = 1.0 / (2 * np.pi * info["highpass"])
@@ -839,7 +839,7 @@ def _get_hdr_info(hdr_fname, eog, misc, scale):
                 # We convert channels with disabled filters to having
                 # infinitely relaxed / no filters
                 lowpass = [
-                    float(filt) if filt not in ("NaN", "Off", "0") else np.Inf
+                    float(filt) if filt not in ("NaN", "Off", "0") else np.inf
                     for filt in lowpass
                 ]
                 info["lowpass"] = np.max(np.array(lowpass, dtype=np.float64))

--- a/mne/io/ctf/info.py
+++ b/mne/io/ctf/info.py
@@ -353,7 +353,7 @@ def _conv_comp(comp, first, last, chs):
     n_col = comp[first]["ncoeff"]
     col_names = comp[first]["sensors"][:n_col]
     row_names = [comp[p]["sensor_name"] for p in range(first, last + 1)]
-    mask = np.in1d(col_names, ch_names)  # missing channels excluded
+    mask = np.isin(col_names, ch_names)  # missing channels excluded
     col_names = np.array(col_names)[mask].tolist()
     n_col = len(col_names)
     n_row = len(row_names)

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1548,7 +1548,7 @@ def _find_exclude_idx(ch_names, exclude, include=None):
 def _find_tal_idx(ch_names):
     # Annotations / TAL Channels
     accepted_tal_ch_names = ["EDF Annotations", "BDF Annotations"]
-    tal_channel_idx = np.where(np.in1d(ch_names, accepted_tal_ch_names))[0]
+    tal_channel_idx = np.where(np.isin(ch_names, accepted_tal_ch_names))[0]
     return tal_channel_idx
 
 

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -571,7 +571,7 @@ class RawMff(BaseRaw):
         if mon is not None:
             info.set_montage(mon, on_missing="ignore")
 
-        ref_idx = np.flatnonzero(np.in1d(mon.ch_names, REFERENCE_NAMES))
+        ref_idx = np.flatnonzero(np.isin(mon.ch_names, REFERENCE_NAMES))
         if len(ref_idx):
             ref_idx = ref_idx.item()
             ref_coords = info["chs"][int(ref_idx)]["loc"][:3]

--- a/mne/io/hitachi/hitachi.py
+++ b/mne/io/hitachi/hitachi.py
@@ -240,7 +240,7 @@ def _get_hitachi_info(fname, S_offset, D_offset, ignore_names):
     assert len(fnirs_wavelengths) == 2
     ch_names = lines[li + 1].rstrip(",\r\n").split(",")
     # cull to correct ones
-    raw_extra["keep_mask"] = ~np.in1d(ch_names, list(ignore_names))
+    raw_extra["keep_mask"] = ~np.isin(ch_names, list(ignore_names))
     for ci, ch_name in enumerate(ch_names):
         if re.match("Probe[0-9]+", ch_name):
             raw_extra["keep_mask"][ci] = False

--- a/mne/label.py
+++ b/mne/label.py
@@ -414,7 +414,7 @@ class Label:
                 )
 
         if self.hemi == other.hemi:
-            keep = np.in1d(self.vertices, other.vertices, True, invert=True)
+            keep = np.isin(self.vertices, other.vertices, True, invert=True)
         else:
             keep = np.arange(len(self.vertices))
 
@@ -487,7 +487,7 @@ class Label:
             return self.copy()
         hemi_src = _get_label_src(self, src)
 
-        if not np.all(np.in1d(self.vertices, hemi_src["vertno"])):
+        if not np.all(np.isin(self.vertices, hemi_src["vertno"])):
             msg = "Source space does not contain all of the label's vertices"
             raise ValueError(msg)
 
@@ -503,7 +503,7 @@ class Label:
         nearest = hemi_src["nearest"]
 
         # find new vertices
-        include = np.in1d(nearest, self.vertices, False)
+        include = np.isin(nearest, self.vertices, False)
         vertices = np.nonzero(include)[0]
 
         # values
@@ -552,7 +552,7 @@ class Label:
         if len(self.vertices) == 0:
             return self.copy()
         hemi_src = _get_label_src(self, src)
-        mask = np.in1d(self.vertices, hemi_src["vertno"])
+        mask = np.isin(self.vertices, hemi_src["vertno"])
         name = self.name if name is None else name
         label = Label(
             self.vertices[mask],
@@ -784,7 +784,7 @@ class Label:
         if vertices is None:
             vertices = np.arange(10242)
 
-        label_verts = vertices[np.in1d(vertices, self.vertices)]
+        label_verts = vertices[np.isin(vertices, self.vertices)]
         return label_verts
 
     def get_tris(self, tris, vertices=None):
@@ -805,7 +805,7 @@ class Label:
             The subset of tris used by the label.
         """
         vertices_ = self.get_vertices_used(vertices)
-        selection = np.all(np.in1d(tris, vertices_).reshape(tris.shape), axis=1)
+        selection = np.all(np.isin(tris, vertices_).reshape(tris.shape), axis=1)
         label_tris = tris[selection]
         if len(np.unique(label_tris)) < len(vertices_):
             logger.info("Surprising label structure. Trying to repair " "triangles.")
@@ -960,7 +960,7 @@ class Label:
         complete_surface_info(
             surf, do_neighbor_vert=False, do_neighbor_tri=False, copy=False
         )
-        in_ = np.in1d(surf["tris"], self.vertices).reshape(surf["tris"].shape)
+        in_ = np.isin(surf["tris"], self.vertices).reshape(surf["tris"].shape)
         tidx = np.where(in_.all(-1))[0]
         if len(tidx) == 0:
             warn("No complete triangles found, perhaps label is not filled?")
@@ -1310,7 +1310,7 @@ def _split_label_contig(label_to_split, subject=None, subjects_dir=None):
     for div, name, color in zip(label_divs, names, colors):
         # Get indices of dipoles within this division of the label
         verts = np.array(sorted(list(div)), int)
-        vert_indices = np.in1d(verts_arr, verts, assume_unique=True)
+        vert_indices = np.isin(verts_arr, verts, assume_unique=True)
 
         # Set label attributes
         pos = label_to_split.pos[vert_indices]
@@ -2456,7 +2456,7 @@ def morph_labels(
     values = filename = None
     for label in labels:
         li = dict(lh=0, rh=1)[label.hemi]
-        vertices = np.where(np.in1d(idxs[li], label.vertices))[0]
+        vertices = np.where(np.isin(idxs[li], label.vertices))[0]
         pos = vert_poss[li][vertices]
         out_labels.append(
             Label(

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -1440,7 +1440,7 @@ def _get_zooms_orig(morph):
 def _check_vertices_match(v1, v2, name):
     if not np.array_equal(v1, v2):
         ext = ""
-        if np.in1d(v2, v1).all():
+        if np.isin(v2, v1).all():
             ext = " Vertices were likely excluded during forward computation."
         raise ValueError(
             "vertices do not match between morph (%s) and stc (%s) for %s:\n%s"

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1376,7 +1376,7 @@ def _get_mf_picks_fix_mags(info, int_order, ext_order, ignore_ref=False, verbose
         FIFF.FIFFV_COIL_CTF_REF_GRAD,
         FIFF.FIFFV_COIL_CTF_OFFDIAG_REF_GRAD,
     ]
-    mag_or_fine[np.in1d(coil_types, ctf_grads)] = False
+    mag_or_fine[np.isin(coil_types, ctf_grads)] = False
     msg = "    Processing %s gradiometers and %s magnetometers" % (
         len(grad_picks),
         len(mag_picks),

--- a/mne/simulation/evoked.py
+++ b/mne/simulation/evoked.py
@@ -151,7 +151,7 @@ def _add_noise(inst, cov, iir_filter, random_state, allow_subselection=True):
     picks = gen_picks = slice(None)
     if allow_subselection:
         use_chs = list(set(info["ch_names"]) & set(cov["names"]))
-        picks = np.where(np.in1d(info["ch_names"], use_chs))[0]
+        picks = np.where(np.isin(info["ch_names"], use_chs))[0]
         logger.info(
             "Adding noise to %d/%d channels (%d channels in cov)"
             % (len(picks), len(info["chs"]), len(cov["names"]))

--- a/mne/simulation/source.py
+++ b/mne/simulation/source.py
@@ -557,13 +557,13 @@ class SourceSimulator:
             wf_stop = self._last_samples[ind[i]]
 
             # Recover the indices of the event that should be in the chunk
-            waveform_ind = np.in1d(
+            waveform_ind = np.isin(
                 np.arange(wf_start, wf_stop + 1),
                 np.arange(start_sample, stop_sample + 1),
             )
 
             # Recover the indices that correspond to the overlap
-            stc_ind = np.in1d(
+            stc_ind = np.isin(
                 np.arange(start_sample, stop_sample + 1),
                 np.arange(wf_start, wf_stop + 1),
             )

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1496,7 +1496,7 @@ class _BaseSurfaceSourceEstimate(_BaseSourceEstimate):
             stc_vertices = self.vertices[1]
 
         # find index of the Label's vertices
-        idx = np.nonzero(np.in1d(stc_vertices, label.vertices))[0]
+        idx = np.nonzero(np.isin(stc_vertices, label.vertices))[0]
 
         # find output vertices
         vertices = stc_vertices[idx]
@@ -2368,7 +2368,7 @@ class _BaseVolSourceEstimate(_BaseSourceEstimate):
         assert len(label) == 1
         label = label[0]
         vertices = label.vertices
-        keep = np.in1d(self.vertices[0], label.vertices)
+        keep = np.isin(self.vertices[0], label.vertices)
         values, vertices = self.data[keep], [self.vertices[0][keep]]
         label_stc = self.__class__(
             values,
@@ -2922,7 +2922,7 @@ def _spatio_temporal_src_adjacency_surf(src, n_times):
     adjacency = spatio_temporal_tris_adjacency(tris, n_times)
 
     # deal with source space only using a subset of vertices
-    masks = [np.in1d(u, s["vertno"]) for s, u in zip(src, used_verts)]
+    masks = [np.isin(u, s["vertno"]) for s, u in zip(src, used_verts)]
     if sum(u.size for u in used_verts) != adjacency.shape[0] / n_times:
         raise ValueError("Used vertices do not match adjacency shape")
     if [np.sum(m) for m in masks] != [len(s["vertno"]) for s in src]:
@@ -3265,7 +3265,7 @@ def _check_stc_src(stc, src):
             second_kind="stc.subject",
         )
         for s, v, hemi in zip(src, stc.vertices, ("left", "right")):
-            n_missing = (~np.in1d(v, s["vertno"])).sum()
+            n_missing = (~np.isin(v, s["vertno"])).sum()
             if n_missing:
                 raise ValueError(
                     "%d/%d %s hemisphere stc vertices "

--- a/mne/source_space/_source_space.py
+++ b/mne/source_space/_source_space.py
@@ -2295,7 +2295,7 @@ def _make_volume_source_space(
         old_shape = neigh.shape
         neigh = neigh.ravel()
         checks = np.where(neigh >= 0)[0]
-        removes = np.logical_not(np.in1d(checks, sp["vertno"]))
+        removes = np.logical_not(np.isin(checks, sp["vertno"]))
         neigh[checks[removes]] = -1
         neigh.shape = old_shape
         neigh = neigh.T
@@ -3053,12 +3053,12 @@ def _get_morph_src_reordering(
         # some are omitted during fwd calc), so we must do some indexing magic:
 
         # From all vertices, a subset could be chosen by fwd calc:
-        used_vertices = np.in1d(full_mapping, vertices[ii])
+        used_vertices = np.isin(full_mapping, vertices[ii])
         from_vertices.append(src_from[ii]["vertno"][used_vertices])
         remaining_mapping = full_mapping[used_vertices]
         if (
             not np.array_equal(np.sort(remaining_mapping), vertices[ii])
-            or not np.in1d(vertices[ii], full_mapping).all()
+            or not np.isin(vertices[ii], full_mapping).all()
         ):
             raise RuntimeError(
                 "Could not map vertices, perhaps the wrong "

--- a/mne/source_space/tests/test_source_space.py
+++ b/mne/source_space/tests/test_source_space.py
@@ -409,7 +409,7 @@ def test_other_volume_source_spaces(tmp_path):
     assert len(src_new[0]["vertno"]) == 7497
     assert len(src) == 1
     assert len(src_new) == 1
-    good_mask = np.in1d(src[0]["vertno"], src_new[0]["vertno"])
+    good_mask = np.isin(src[0]["vertno"], src_new[0]["vertno"])
     src[0]["inuse"][src[0]["vertno"][~good_mask]] = 0
     assert src[0]["inuse"].sum() == 7497
     src[0]["vertno"] = src[0]["vertno"][good_mask]

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -38,7 +38,7 @@ def _get_buddies_fallback(r, s, neighbors, indices=None):
         buddies = np.where(r)[0]
     else:
         buddies = indices[r[indices]]
-    buddies = buddies[np.in1d(s[buddies], neighbors, assume_unique=True)]
+    buddies = buddies[np.isin(s[buddies], neighbors, assume_unique=True)]
     r[buddies] = False
     return buddies.tolist()
 

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -380,7 +380,7 @@ def _prepare_rerp_preds(
             ids = (
                 [event_id[cond]] if isinstance(event_id[cond], int) else event_id[cond]
             )
-            onsets = -(events[np.in1d(events[:, 2], ids), 0] + tmin_)
+            onsets = -(events[np.isin(events[:, 2], ids), 0] + tmin_)
             values = np.ones((len(onsets), n_lags))
 
         else:  # for predictors from covariates, e.g. continuous ones

--- a/mne/stats/tests/test_adjacency.py
+++ b/mne/stats/tests/test_adjacency.py
@@ -41,6 +41,6 @@ def test_adjacency_equiv(shape):
     # eventually we might want to keep these as 1's but it's easy enough
     # with a .astype(bool) (also matches sklearn output) so let's leave it
     # for now
-    assert np.in1d(conn, [0, 1, 2, 3]).all()
+    assert np.isin(conn, [0, 1, 2, 3]).all()
     assert conn.shape == conn_sk.shape
     assert_array_equal(conn, conn_sk)

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -613,8 +613,8 @@ def test_annotation_epoching():
     raw = concatenate_raws([RawArray(data, info) for ii in range(3)])
     assert raw.annotations is not None
     assert len(raw.annotations) == 4
-    assert np.in1d(raw.annotations.description, ["BAD boundary"]).sum() == 2
-    assert np.in1d(raw.annotations.description, ["EDGE boundary"]).sum() == 2
+    assert np.isin(raw.annotations.description, ["BAD boundary"]).sum() == 2
+    assert np.isin(raw.annotations.description, ["EDGE boundary"]).sum() == 2
     assert_array_equal(raw.annotations.duration, 0.0)
     events = np.array([[a, 0, 1] for a in [0, 500, 1000, 1500, 2000]])
     epochs = Epochs(

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -2863,8 +2863,8 @@ def test_to_data_frame():
         epochs.to_data_frame(index=np.arange(400))
     # test wide format
     df_wide = epochs.to_data_frame()
-    assert all(np.in1d(epochs.ch_names, df_wide.columns))
-    assert all(np.in1d(["time", "epoch", "condition"], df_wide.columns))
+    assert all(np.isin(epochs.ch_names, df_wide.columns))
+    assert all(np.isin(["time", "epoch", "condition"], df_wide.columns))
     # test long format
     df_long = epochs.to_data_frame(long_format=True)
     expected = ("condition", "epoch", "time", "channel", "ch_type", "value")
@@ -2904,7 +2904,7 @@ def test_to_data_frame_index(index):
     # test that non-indexed data were present as columns
     non_index = list(set(["condition", "time", "epoch"]) - set(index))
     if len(non_index):
-        assert all(np.in1d(non_index, df.columns))
+        assert all(np.isin(non_index, df.columns))
 
 
 @pytest.mark.parametrize("time_format", (None, "ms", "timedelta"))
@@ -4116,7 +4116,7 @@ def test_channel_types_mixin():
     epochs = Epochs(raw, events[:1], preload=True)
     ch_types = epochs.get_channel_types()
     assert len(ch_types) == len(epochs.ch_names)
-    assert all(np.in1d(ch_types, ["mag", "grad", "eeg", "eog", "stim"]))
+    assert all(np.isin(ch_types, ["mag", "grad", "eeg", "eog", "stim"]))
 
 
 def test_average_methods():

--- a/mne/tests/test_evoked.py
+++ b/mne/tests/test_evoked.py
@@ -456,7 +456,7 @@ def test_to_data_frame():
     assert "time" in df.index.names
     # test wide and long formats
     df_wide = ave.to_data_frame()
-    assert all(np.in1d(ave.ch_names, df_wide.columns))
+    assert all(np.isin(ave.ch_names, df_wide.columns))
     df_long = ave.to_data_frame(long_format=True)
     expected = ("time", "channel", "ch_type", "value")
     assert set(expected) == set(df_long.columns)

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -300,11 +300,11 @@ def test_label_fill_restrict(fname):
     assert src[0]["nearest"] is not None
 
     # check label vertices
-    vertices_status = np.in1d(src[0]["nearest"], label.vertices)
+    vertices_status = np.isin(src[0]["nearest"], label.vertices)
     vertices_in = np.nonzero(vertices_status)[0]
     vertices_out = np.nonzero(np.logical_not(vertices_status))[0]
     assert_array_equal(label_src.vertices, vertices_in)
-    assert_array_equal(np.in1d(vertices_out, label_src.vertices), False)
+    assert_array_equal(np.isin(vertices_out, label_src.vertices), False)
 
     # check values
     value_idx = np.digitize(src[0]["nearest"][vertices_in], vert_in_src, True)
@@ -431,8 +431,8 @@ def test_morph_labels():
     for lf, ls, lfs in zip(parc_fsaverage, parc_sample, parc_fssamp):
         assert lf.hemi == ls.hemi == lfs.hemi
         assert lf.name == ls.name == lfs.name
-        perc_1 = np.in1d(lfs.vertices, ls.vertices).mean() * 100
-        perc_2 = np.in1d(ls.vertices, lfs.vertices).mean() * 100
+        perc_1 = np.isin(lfs.vertices, ls.vertices).mean() * 100
+        perc_2 = np.isin(ls.vertices, lfs.vertices).mean() * 100
         # Ideally this would be 100%, but we do not use the same algorithm
         # as FreeSurfer ...
         assert perc_1 > 92
@@ -731,7 +731,7 @@ def test_write_labels_to_annot(tmp_path):
     label0 = labels_lh[0]
     label1 = labels_reloaded[-1]
     assert_equal(label1.name, "unknown-lh")
-    assert np.all(np.in1d(label0.vertices, label1.vertices))
+    assert np.all(np.isin(label0.vertices, label1.vertices))
 
     # unnamed labels
     labels4 = labels[:]
@@ -937,7 +937,7 @@ def test_morph():
         label.values.fill(1)
         label = label.morph(None, "fsaverage", 5, grade, subjects_dir, 1)
         label = label.morph("fsaverage", "sample", 5, None, subjects_dir, 2)
-        assert np.in1d(label_orig.vertices, label.vertices).all()
+        assert np.isin(label_orig.vertices, label.vertices).all()
         assert len(label.vertices) < 3 * len(label_orig.vertices)
         vals.append(label.vertices)
     assert_array_equal(vals[0], vals[1])
@@ -973,7 +973,7 @@ def test_grow_labels():
         labels, seeds, tgt_hemis, should_be_in, tgt_names
     ):
         assert np.any(label.vertices == seed)
-        assert np.all(np.in1d(sh, label.vertices))
+        assert np.all(np.isin(sh, label.vertices))
         assert_equal(label.hemi, hemi)
         assert_equal(label.name, name)
 
@@ -1243,14 +1243,14 @@ def test_label_geometry(fname, area):
     rr, tris = read_surface(subjects_dir / "sample" / "surf" / "lh.white")
     mask = np.zeros(len(rr), bool)
     mask[label.vertices] = 1
-    border_mask = np.in1d(label.vertices, _mesh_borders(tris, mask))
+    border_mask = np.isin(label.vertices, _mesh_borders(tris, mask))
     # The distances of the border vertices is smaller than that of non-border
     lo, mi, hi = np.percentile(dist[border_mask], (0, 50, 100))
     assert 0.1e-3 < lo < 0.5e-3 < mi < 1.0e-3 < hi < 2.0e-3
     lo, mi, hi = np.percentile(dist[~border_mask], (0, 50, 100))
     assert 0.5e-3 < lo < 1.0e-3 < mi < 9.0e-3 < hi < 25e-3
     # check that the distances are close but uniformly <= than euclidean
-    assert not np.in1d(outside, label.vertices).any()
+    assert not np.isin(outside, label.vertices).any()
     border_dist = dist[border_mask]
     border_euc = 1e-3 * np.linalg.norm(
         rr[label.vertices[border_mask]] - rr[outside[border_mask]], axis=1

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -192,7 +192,7 @@ def test_xhemi_morph():
     assert vertices_use[0].shape == (n_grade_verts,)
     assert vertices_use[1].shape == (n_src_verts,)
     # ensure it's sufficiently diffirent to manifest round-trip errors
-    assert np.in1d(vertices_use[1], stc.vertices[1]).mean() < 0.3
+    assert np.isin(vertices_use[1], stc.vertices[1]).mean() < 0.3
     morph = compute_source_morph(
         stc,
         "fsaverage_sym",
@@ -931,7 +931,7 @@ def test_volume_labels_morph(tmp_path, sl, n_real, n_mri, n_orig):
     assert img.shape == (86, 86, 86, 1)
     n_on = np.array(img.dataobj).astype(bool).sum()
     aseg_img = _get_img_fdata(nib.load(fname_aseg))
-    n_got_real = np.in1d(
+    n_got_real = np.isin(
         aseg_img.ravel(), [lut[name] for name in use_label_names]
     ).sum()
     assert n_got_real == n_real
@@ -1034,11 +1034,11 @@ def test_mixed_source_morph(_mixed_morph_srcs, vector):
     stc = klass(data, vertices, 0, 1, "sample")
     vol_info = _get_mri_info_data(fname_aseg, data=True)
     rrs = np.concatenate([src[2]["rr"][sp["vertno"]] for sp in src[2:]])
-    n_want = np.in1d(_get_atlas_values(vol_info, rrs), ids).sum()
+    n_want = np.isin(_get_atlas_values(vol_info, rrs), ids).sum()
     img = _get_img_fdata(stc.volume().as_volume(src, mri_resolution=False))
     assert img.astype(bool).sum() == n_want
     img_res = nib.load(fname_aseg)
-    n_want = np.in1d(_get_img_fdata(img_res), ids).sum()
+    n_want = np.isin(_get_img_fdata(img_res), ids).sum()
     img = _get_img_fdata(stc.volume().as_volume(src, mri_resolution=True))
     assert img.astype(bool).sum() > n_want  # way more get interpolated into
 
@@ -1049,7 +1049,7 @@ def test_mixed_source_morph(_mixed_morph_srcs, vector):
     stc_fs = morph.apply(stc)
     vol_info = _get_mri_info_data(fname_aseg_fs, data=True)
     rrs = np.concatenate([src_fs[2]["rr"][sp["vertno"]] for sp in src_fs[2:]])
-    n_want = np.in1d(_get_atlas_values(vol_info, rrs), ids).sum()
+    n_want = np.isin(_get_atlas_values(vol_info, rrs), ids).sum()
     with pytest.raises(ValueError, match=r"stc\.subject does not match src s"):
         stc_fs.volume().as_volume(src, mri_resolution=False)
     img = _get_img_fdata(stc_fs.volume().as_volume(src_fs, mri_resolution=False))

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -173,7 +173,7 @@ def test_spatial_inter_hemi_adjacency():
         use_labels = [
             label.name[:-3]
             for label in labels
-            if np.in1d(label.vertices, has_neighbors).any()
+            if np.isin(label.vertices, has_neighbors).any()
         ]
         assert set(use_labels) - set(good_labels) == set()
 
@@ -837,7 +837,7 @@ def test_extract_label_time_course_volume(
     assert sum(s["nuse"] for s in src_labels) == 4157
     assert_array_equal(src_labels[-1]["vertno"], [8011, 8032, 8557])
     assert_array_equal(
-        np.where(np.in1d(src[0]["vertno"], [8011, 8032, 8557]))[0], [2672, 2688, 2995]
+        np.where(np.isin(src[0]["vertno"], [8011, 8032, 8557]))[0], [2672, 2688, 2995]
     )
     # triage "labels" argument
     if mri_res:
@@ -908,7 +908,7 @@ def test_extract_label_time_course_volume(
             rtol = 0.0
         for si, s in enumerate(src_labels):
             func = dict(mean=np.mean, max=np.max)[mode]
-            these = vertex_values[np.in1d(src[0]["vertno"], s["vertno"])]
+            these = vertex_values[np.isin(src[0]["vertno"], s["vertno"])]
             assert len(these) == s["nuse"]
             if si == 0 and s["seg_name"] == "Unknown":
                 continue  # unknown is crappy
@@ -1174,7 +1174,7 @@ def test_to_data_frame_index(index):
     # test that non-indexed data were present as columns
     non_index = list(set(["time", "subject"]) - set(index))
     if len(non_index):
-        assert all(np.in1d(non_index, df.columns))
+        assert all(np.isin(non_index, df.columns))
 
 
 @pytest.mark.parametrize("kind", ("surface", "mixed", "volume"))

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 from scipy.fft import rfft, rfftfreq
+from scipy.integrate import trapezoid
 from scipy.signal import get_window
 from scipy.signal.windows import dpss as sp_dpss
 
@@ -116,7 +117,7 @@ def _psd_from_mt_adaptive(x_mt, eigvals, freq_mask, max_iter=250, return_weights
 
     # estimate the variance from an estimate with fixed weights
     psd_est = _psd_from_mt(x_mt, rt_eig[np.newaxis, :, np.newaxis])
-    x_var = np.trapz(psd_est, dx=np.pi / n_freqs) / (2 * np.pi)
+    x_var = trapezoid(psd_est, dx=np.pi / n_freqs) / (2 * np.pi)
     del psd_est
 
     # allocate space for output

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -329,7 +329,7 @@ class BaseSpectrum(ContainsMixin, UpdateChannelsMixin):
             )
         # triage method and kwargs. partial() doesn't check validity of kwargs,
         # so we do it manually to save compute time if any are invalid.
-        invalid_ix = np.in1d(
+        invalid_ix = np.isin(
             list(method_kw), list(signature(psd_funcs[method]).parameters), invert=True
         )
         if invalid_ix.any():

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -1372,8 +1372,8 @@ def test_to_data_frame():
         tfr.to_data_frame(index=np.arange(400))
     # test wide format
     df_wide = tfr.to_data_frame()
-    assert all(np.in1d(tfr.ch_names, df_wide.columns))
-    assert all(np.in1d(["time", "condition", "freq", "epoch"], df_wide.columns))
+    assert all(np.isin(tfr.ch_names, df_wide.columns))
+    assert all(np.isin(["time", "condition", "freq", "epoch"], df_wide.columns))
     # test long format
     df_long = tfr.to_data_frame(long_format=True)
     expected = ("condition", "epoch", "freq", "time", "channel", "ch_type", "value")
@@ -1403,8 +1403,8 @@ def test_to_data_frame():
         tfr.to_data_frame(index=np.arange(400))
     # test wide format
     df_wide = tfr.to_data_frame()
-    assert all(np.in1d(tfr.ch_names, df_wide.columns))
-    assert all(np.in1d(["time", "freq"], df_wide.columns))
+    assert all(np.isin(tfr.ch_names, df_wide.columns))
+    assert all(np.isin(["time", "freq"], df_wide.columns))
     # test long format
     df_long = tfr.to_data_frame(long_format=True)
     expected = ("freq", "time", "channel", "ch_type", "value")
@@ -1455,7 +1455,7 @@ def test_to_data_frame_index(index):
     # test that non-indexed data were present as columns
     non_index = list(set(["condition", "time", "freq", "epoch"]) - set(index))
     if len(non_index):
-        assert all(np.in1d(non_index, df.columns))
+        assert all(np.isin(non_index, df.columns))
 
 
 @pytest.mark.parametrize("time_format", (None, "ms", "timedelta"))

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -421,7 +421,9 @@ def _check_edflib_installed(strict=True):
     except Exception:
         pass
     else:
-        out &= not check_version("numpy", "2.0") or _compare_version(ver, ">", "1.0.7")
+        out &= not check_version("numpy", "1.9.9") or _compare_version(
+            ver, ">", "1.0.7"
+        )
     return out
 
 

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -411,7 +411,18 @@ def _check_eeglabio_installed(strict=True):
 
 def _check_edflib_installed(strict=True):
     """Aux function."""
-    return _soft_import("EDFlib", "exporting to EDF", strict=strict)
+    out = _soft_import("EDFlib", "exporting to EDF", strict=strict) is not None
+    # EDFlib-Python 1.0.7 not NumPy 2.0 compatible
+    # https://gitlab.com/Teuniz/EDFlib-Python/-/issues/10
+    try:
+        from importlib.metadata import version
+
+        ver = version("EDFlib-Python")
+    except Exception:
+        pass
+    else:
+        out &= not check_version("numpy", "2.0") or _compare_version(ver, ">", "1.0.7")
+    return out
 
 
 def _check_pybv_installed(strict=True):

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2427,7 +2427,7 @@ class Brain:
             show = np.zeros(scalars.size, dtype=np.int64)
             if isinstance(borders, int):
                 for _ in range(borders):
-                    keep_idx = np.in1d(self.geo[hemi].faces.ravel(), keep_idx)
+                    keep_idx = np.isin(self.geo[hemi].faces.ravel(), keep_idx)
                     keep_idx.shape = self.geo[hemi].faces.shape
                     keep_idx = self.geo[hemi].faces[np.any(keep_idx, axis=1)]
                     keep_idx = np.unique(keep_idx)
@@ -4164,12 +4164,12 @@ class Brain:
             keep_idx = np.unique(edges.row[border_edges])
             if isinstance(borders, int):
                 for _ in range(borders):
-                    keep_idx = np.in1d(self.geo[hemi].orig_faces.ravel(), keep_idx)
+                    keep_idx = np.isin(self.geo[hemi].orig_faces.ravel(), keep_idx)
                     keep_idx.shape = self.geo[hemi].orig_faces.shape
                     keep_idx = self.geo[hemi].orig_faces[np.any(keep_idx, axis=1)]
                     keep_idx = np.unique(keep_idx)
                 if restrict_idx is not None:
-                    keep_idx = keep_idx[np.in1d(keep_idx, restrict_idx)]
+                    keep_idx = keep_idx[np.isin(keep_idx, restrict_idx)]
             show[keep_idx] = 1
             label *= show
 

--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -282,7 +282,7 @@ class BrowserBase(ABC):
             stim_pick = self.mne.ch_names.tolist().index(stim_ch[0])
             for _sel, _picks in selections_dict.items():
                 if _sel != "Misc":
-                    stim_mask = np.in1d(_picks, [stim_pick], invert=True)
+                    stim_mask = np.isin(_picks, [stim_pick], invert=True)
                     selections_dict[_sel] = np.array(_picks)[stim_mask]
         return selections_dict
 
@@ -332,7 +332,7 @@ class BrowserBase(ABC):
         starts = np.maximum(starts[mask], start) - start
         stops = np.minimum(stops[mask], stop) - start
         for _start, _stop in zip(starts, stops):
-            _picks = np.where(np.in1d(picks, self.mne.picks_data))[0]
+            _picks = np.where(np.isin(picks, self.mne.picks_data))[0]
             if len(_picks) == 0:
                 break
             this_data = data[_picks, _start:_stop]
@@ -373,8 +373,8 @@ class BrowserBase(ABC):
         this_types = self.mne.ch_types[picks]
         stims = this_types == "stim"
         white = np.logical_and(
-            np.in1d(this_names, self.mne.whitened_ch_names),
-            np.in1d(this_names, self.mne.info["bads"], invert=True),
+            np.isin(this_names, self.mne.whitened_ch_names),
+            np.isin(this_names, self.mne.info["bads"], invert=True),
         )
         norms = np.vectorize(self.mne.scalings.__getitem__)(this_types)
         norms[stims] = data[stims].max(axis=-1)
@@ -415,7 +415,7 @@ class BrowserBase(ABC):
         logger.debug(f"Closing {self.mne.instance_type} browser...")
         # write out bad epochs (after converting epoch numbers to indices)
         if self.mne.instance_type == "epochs":
-            bad_ixs = np.in1d(self.mne.inst.selection, self.mne.bad_epochs).nonzero()[0]
+            bad_ixs = np.isin(self.mne.inst.selection, self.mne.bad_epochs).nonzero()[0]
             self.mne.inst.drop(bad_ixs)
             logger.info(
                 "The following epochs were marked as bad "
@@ -486,7 +486,7 @@ class BrowserBase(ABC):
             show=False,
         )
         # highlight desired channel & disable interactivity
-        inds = np.in1d(fig.lasso.ch_names, [ch_name])
+        inds = np.isin(fig.lasso.ch_names, [ch_name])
         fig.lasso.disconnect()
         fig.lasso.alpha_other = 0.3
         fig.lasso.linewidth_selected = 3

--- a/mne/viz/_mpl_figure.py
+++ b/mne/viz/_mpl_figure.py
@@ -333,7 +333,7 @@ class MNESelectionFigure(MNEFigure):
         if not len(chs):
             return
         labels = [label.get_text() for label in buttons.labels]
-        inds = np.in1d(parent.mne.ch_names, chs)
+        inds = np.isin(parent.mne.ch_names, chs)
         parent.mne.ch_selections["Custom"] = inds.nonzero()[0]
         buttons.set_active(labels.index("Custom"))
 
@@ -1545,7 +1545,7 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
 
     def _update_highlighted_sensors(self):
         """Update the sensor plot to show what is selected."""
-        inds = np.in1d(
+        inds = np.isin(
             self.mne.fig_selection.lasso.ch_names, self.mne.ch_names[self.mne.picks]
         ).nonzero()[0]
         self.mne.fig_selection.lasso.select_many(inds)
@@ -1558,7 +1558,7 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
         for this_type in _DATA_CH_TYPES_SPLIT:
             if this_type in self.mne.ch_types:
                 sensor_picks.extend(ch_indices[this_type])
-        sensor_idx = np.in1d(sensor_picks, pick).nonzero()[0]
+        sensor_idx = np.isin(sensor_picks, pick).nonzero()[0]
         # change the sensor color
         fig = self.mne.fig_selection
         fig.lasso.ec[sensor_idx, 0] = float(mark_bad)  # change R of RGBA array
@@ -1870,7 +1870,7 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
         if self.mne.butterfly and self.mne.fig_selection is not None:
             exclude = ("Vertex", "Custom")
             ticklabels = list(self.mne.ch_selections)
-            keep_mask = np.in1d(ticklabels, exclude, invert=True)
+            keep_mask = np.isin(ticklabels, exclude, invert=True)
             ticklabels = [
                 t.replace("Left-", "L-").replace("Right-", "R-") for t in ticklabels
             ]  # avoid having to rotate labels
@@ -2003,7 +2003,7 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
             else slice(None)
         )
         offsets = self.mne.trace_offsets[offset_ixs]
-        bad_bool = np.in1d(ch_names, self.mne.info["bads"])
+        bad_bool = np.isin(ch_names, self.mne.info["bads"])
         # colors
         good_ch_colors = [self.mne.ch_color_dict[_type] for _type in ch_types]
         ch_colors = to_rgba_array(
@@ -2022,7 +2022,7 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
                 label.set_color(color)
         # decim
         decim = np.ones_like(picks)
-        data_picks_mask = np.in1d(picks, self.mne.picks_data)
+        data_picks_mask = np.isin(picks, self.mne.picks_data)
         decim[data_picks_mask] = self.mne.decim
         # decim can vary by channel type, so compute different `times` vectors
         decim_times = {
@@ -2049,7 +2049,7 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
             epoch_ix = np.searchsorted(self.mne.boundary_times, time_range)
             epoch_ix = np.arange(epoch_ix[0], epoch_ix[1])
             epoch_nums = self.mne.inst.selection[epoch_ix[0] : epoch_ix[-1] + 1]
-            (visible_bad_epoch_ix,) = np.in1d(epoch_nums, self.mne.bad_epochs).nonzero()
+            (visible_bad_epoch_ix,) = np.isin(epoch_nums, self.mne.bad_epochs).nonzero()
             while len(self.mne.epoch_traces):
                 self.mne.epoch_traces.pop(-1).remove()
             # handle custom epoch colors (for autoreject integration)

--- a/mne/viz/_proj.py
+++ b/mne/viz/_proj.py
@@ -127,7 +127,7 @@ def plot_projs_joint(
         these_idxs, these_projs = zip(*these_projs)
         ch_names = ch_names_by_type[ch_type]
         idx = np.where(
-            [np.in1d(ch_names, proj["data"]["col_names"]).all() for proj in these_projs]
+            [np.isin(ch_names, proj["data"]["col_names"]).all() for proj in these_projs]
         )[0]
         used[idx] += 1
         count = len(these_projs)

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -284,7 +284,7 @@ def plot_epochs_image(
         group_by = deepcopy(group_by)
     # check for heterogeneous sensor type combinations / "combining" 1 channel
     for this_group, these_picks in group_by.items():
-        this_ch_type = np.array(ch_types)[np.in1d(picks, these_picks)]
+        this_ch_type = np.array(ch_types)[np.isin(picks, these_picks)]
         if len(set(this_ch_type)) > 1:
             types = ", ".join(set(this_ch_type))
             raise ValueError(
@@ -422,7 +422,7 @@ def plot_epochs_image(
     plt_show(show)
     # impose deterministic order of returned objects
     return_order = np.array(sorted(group_by))
-    are_ch_types = np.in1d(return_order, _VALID_CHANNEL_TYPES)
+    are_ch_types = np.isin(return_order, _VALID_CHANNEL_TYPES)
     if any(are_ch_types):
         return_order = np.concatenate(
             (return_order[are_ch_types], return_order[~are_ch_types])

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -855,7 +855,7 @@ def plot_events(
     min_event = np.min(unique_events_id)
     max_event = np.max(unique_events_id)
     max_x = (
-        events[np.in1d(events[:, 2], unique_events_id), 0].max() - first_samp
+        events[np.isin(events[:, 2], unique_events_id), 0].max() - first_samp
     ) / sfreq
 
     handles, labels = list(), list()

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -623,6 +623,6 @@ def _setup_channel_selections(raw, kind, order):
         gsr=True,
         exclude=(),
     )
-    if len(misc) and np.in1d(misc, order).any():
+    if len(misc) and np.isin(misc, order).any():
         selections_dict["Misc"] = misc
     return selections_dict

--- a/mne/viz/tests/test_epochs.py
+++ b/mne/viz/tests/test_epochs.py
@@ -244,7 +244,7 @@ def test_plot_overlapping_epochs_with_events(browser_backend, event_id, expected
         assert set(texts) == expected_texts
     # plot one epoch with its defining event plus events at its first & last sample
     # (regression test for https://mne.discourse.group/t/6334)
-    events = np.row_stack(([[0, 0, 4]], events[[0]], [[99, 0, 4]]))
+    events = np.vstack(([[0, 0, 4]], events[[0]], [[99, 0, 4]]))
     fig = epochs[0].plot(events=events, picks="misc", event_id=event_id)
     expected_texts.add("4")
     for text in ("2", "3", "b", "c"):

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -481,7 +481,7 @@ def _plot_projs_topomap(
         proj = _eliminate_zeros(proj)  # gh 5641
         ch_names = _clean_names(proj["data"]["col_names"], remove_whitespace=True)
         if vlim == "joint":
-            ch_idxs = np.where(np.in1d(info["ch_names"], proj["data"]["col_names"]))[0]
+            ch_idxs = np.where(np.isin(info["ch_names"], proj["data"]["col_names"]))[0]
             these_ch_types = info.get_channel_types(ch_idxs, unique=True)
             # each projector should have only one channel type
             assert len(these_ch_types) == 1
@@ -532,7 +532,7 @@ def _plot_projs_topomap(
     vlims = [None for _ in range(len(datas))]
     if vlim == "joint":
         for _ch_type in set(types):
-            idx = np.where(np.in1d(types, _ch_type))[0]
+            idx = np.where(np.isin(types, _ch_type))[0]
             these_data = np.concatenate(np.array(datas, dtype=object)[idx])
             norm = all(these_data >= 0)
             _vl = _setup_vmin_vmax(these_data, vmin=None, vmax=None, norm=norm)

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1786,7 +1786,7 @@ class SelectFromCollection:
             self.selection.pop(sel_ind)
         else:
             self.selection.append(ch_name)
-        inds = np.in1d(self.ch_names, self.selection).nonzero()[0]
+        inds = np.isin(self.ch_names, self.selection).nonzero()[0]
         self.style_sensors(inds)
         self.notify()
 

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -7,8 +7,7 @@ if [ "${TEST_MODE}" == "pip" ]; then
 elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off --upgrade pip setuptools wheel packaging setuptools_scm
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://www.riverbankcomputing.com/pypi/simple" PyQt6 PyQt6-sip PyQt6-Qt6
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" numpy
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" scipy statsmodels pandas scikit-learn matplotlib
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" numpy scipy statsmodels pandas scikit-learn matplotlib
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" dipy
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://wheels.vtk.org" vtk

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -22,6 +22,8 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off git+https://github.com/pyvista/pyvistaqt
 	echo "misc"
 	python -m pip install --progress-bar off --upgrade --pre imageio-ffmpeg xlrd mffpy python-picard pillow
+	echo "nibabel with workaround"
+	python -m pip install --progress-bar off --upgrade --pre git+https://github.com/mscheltienne/nibabel.git@np.sctypes
 	EXTRA_ARGS="--pre"
 	./tools/check_qt_import.sh PyQt6
 else

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -7,13 +7,20 @@ if [ "${TEST_MODE}" == "pip" ]; then
 elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off --upgrade pip setuptools wheel packaging setuptools_scm
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://www.riverbankcomputing.com/pypi/simple" PyQt6 PyQt6-sip PyQt6-Qt6
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" numpy scipy statsmodels pandas scikit-learn matplotlib
+	echo "Numpy etc."
+	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0" scipy statsmodels pandas scikit-learn matplotlib
+	echo "dipy"
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" dipy
+	echo "h5py"
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
+	echo "vtk"
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://wheels.vtk.org" vtk
+	echo "openmeeg"
 	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://test.pypi.org/simple" openmeeg
+	echo "pyvista/pyvistaqt"
 	python -m pip install --progress-bar off git+https://github.com/pyvista/pyvista
 	python -m pip install --progress-bar off git+https://github.com/pyvista/pyvistaqt
+	echo "misc"
 	python -m pip install --progress-bar off --upgrade --pre imageio-ffmpeg xlrd mffpy python-picard pillow
 	EXTRA_ARGS="--pre"
 	./tools/check_qt_import.sh PyQt6

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -23,7 +23,7 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	echo "misc"
 	python -m pip install --progress-bar off --upgrade --pre imageio-ffmpeg xlrd mffpy python-picard pillow
 	echo "nibabel with workaround"
-	python -m pip install --progress-bar off --upgrade --pre git+https://github.com/larsoner/nibabel.git@np.sctypes
+	python -m pip install --progress-bar off --upgrade --pre git+https://github.com/mscheltienne/nibabel.git@np.sctypes
 	EXTRA_ARGS="--pre"
 	./tools/check_qt_import.sh PyQt6
 else

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -23,7 +23,7 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	echo "misc"
 	python -m pip install --progress-bar off --upgrade --pre imageio-ffmpeg xlrd mffpy python-picard pillow
 	echo "nibabel with workaround"
-	python -m pip install --progress-bar off --upgrade --pre git+https://github.com/mscheltienne/nibabel.git@np.sctypes
+	python -m pip install --progress-bar off --upgrade --pre git+https://github.com/larsoner/nibabel.git@np.sctypes
 	EXTRA_ARGS="--pre"
 	./tools/check_qt_import.sh PyQt6
 else

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -18,8 +18,7 @@ else
 	echo "PyQt6"
 	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6
 	echo "NumPy/SciPy/pandas etc."
-	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 numpy
-	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" scipy scikit-learn pandas matplotlib pillow statsmodels
+	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" numpy scipy scikit-learn pandas matplotlib pillow statsmodels
 	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" dipy
 	pip install $STD_ARGS --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
 	pip install $STD_ARGS --pre --only-binary ":all:" --extra-index-url "https://test.pypi.org/simple" openmeeg

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -40,7 +40,7 @@ else
 	echo "mne-qt-browser"
 	pip install --progress-bar off git+https://github.com/mne-tools/mne-qt-browser
 	echo "nibabel with workaround"
-	pip install --progress-bar off --pre git+https://github.com/mscheltienne/nibabel.git@np.sctypes
+	pip install --progress-bar off --pre git+https://github.com/larsoner/nibabel.git@np.sctypes
 	EXTRA_ARGS="--pre"
 fi
 echo ""

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -40,7 +40,7 @@ else
 	echo "mne-qt-browser"
 	pip install --progress-bar off git+https://github.com/mne-tools/mne-qt-browser
 	echo "nibabel with workaround"
-	pip install --progress-bar off --pre git+https://github.com/larsoner/nibabel.git@np.sctypes
+	pip install --progress-bar off --pre git+https://github.com/mscheltienne/nibabel.git@np.sctypes
 	EXTRA_ARGS="--pre"
 fi
 echo ""

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -18,9 +18,12 @@ else
 	echo "PyQt6"
 	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6
 	echo "NumPy/SciPy/pandas etc."
-	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" numpy scipy scikit-learn pandas matplotlib pillow statsmodels
+	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0" scipy scikit-learn pandas matplotlib pillow statsmodels
+	echo "dipy"
 	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" dipy
+	echo "H5py"
 	pip install $STD_ARGS --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
+	echo "OpenMEEG"
 	pip install $STD_ARGS --pre --only-binary ":all:" --extra-index-url "https://test.pypi.org/simple" openmeeg
 	# No Numba because it forces an old NumPy version
 	echo "nilearn and openmeeg"

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -39,6 +39,8 @@ else
 	pip install --progress-bar off --pre imageio-ffmpeg xlrd mffpy python-picard patsy
 	echo "mne-qt-browser"
 	pip install --progress-bar off git+https://github.com/mne-tools/mne-qt-browser
+	echo "nibabel with workaround"
+	pip install --progress-bar off --pre git+https://github.com/mscheltienne/nibabel.git@np.sctypes
 	EXTRA_ARGS="--pre"
 fi
 echo ""


### PR DESCRIPTION
No idea why we haven't hit this error that mne-qt-browser is hitting:

https://github.com/mne-tools/mne-qt-browser/actions/runs/6155800978/job/16721232893?pr=194

```
../mne-python/mne/viz/_figure.py:376: in _process_data
1276
    np.in1d(this_names, self.mne.whitened_ch_names),
1277
/opt/hostedtoolcache/Python/3.11.5/x64/lib/python3.11/site-packages/numpy/lib/_arraysetops_impl.py:611: in in1d
1278
    warnings.warn(
1279
E   DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
```

But this is a naive replace-in-files, let's see if it works.