### PR TITLE
Fix _check_edflib_installed

### DIFF
--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -414,19 +414,18 @@ def _check_eeglabio_installed(strict=True):
 def _check_edflib_installed(strict=True):
     """Aux function."""
     out = _soft_import("EDFlib", "exporting to EDF", strict=strict)
-    if not out:  # strict=False and library missing
-        return False
-    # EDFlib-Python 1.0.7 is not compatible with NumPy 2.0
-    # https://gitlab.com/Teuniz/EDFlib-Python/-/issues/10
-    ver = version("EDFlib-Python")
-    if ver > parse("1.0.7") or parse(np.__version__).major < 2:
-        return out
-    if strict:  # pragma: no cover
-        raise RuntimeError(
-            f"EDFlib version={ver} is not compatible with NumPy 2.0, consider "
-            "upgrading EDFlib-Python"
-        )
-    return False
+    if out:
+        # EDFlib-Python 1.0.7 is not compatible with NumPy 2.0
+        # https://gitlab.com/Teuniz/EDFlib-Python/-/issues/10
+        ver = version("EDFlib-Python")
+        if ver <= parse("1.0.7") or parse(np.__version__).major >= 2:
+            if strict:  # pragma: no cover
+                raise RuntimeError(
+                    f"EDFlib version={ver} is not compatible with NumPy 2.0, consider "
+                    "upgrading EDFlib-Python"
+                )
+            out = False
+    return out
 
 
 def _check_pybv_installed(strict=True):

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -418,7 +418,7 @@ def _check_edflib_installed(strict=True):
         # EDFlib-Python 1.0.7 is not compatible with NumPy 2.0
         # https://gitlab.com/Teuniz/EDFlib-Python/-/issues/10
         ver = version("EDFlib-Python")
-        if ver <= parse("1.0.7") or parse(np.__version__).major >= 2:
+        if ver <= parse("1.0.7") and parse(np.__version__).major >= 2:
             if strict:  # pragma: no cover
                 raise RuntimeError(
                     f"EDFlib version={ver} is not compatible with NumPy 2.0, consider "

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -411,20 +411,22 @@ def _check_eeglabio_installed(strict=True):
 
 def _check_edflib_installed(strict=True):
     """Aux function."""
-    out = _soft_import("EDFlib", "exporting to EDF", strict=strict) is not None
-    # EDFlib-Python 1.0.7 not NumPy 2.0 compatible
+    out = _soft_import("EDFlib", "exporting to EDF", strict=strict)
+    if not out:  # strict=False and library missing
+        return False
+    # EDFlib-Python 1.0.7 is not compatible with NumPy 2.0
     # https://gitlab.com/Teuniz/EDFlib-Python/-/issues/10
     try:
         from importlib.metadata import version
 
         ver = version("EDFlib-Python")
+        ver_np = version("numpy")
     except Exception:
-        pass
+        return False
     else:
-        out &= not check_version("numpy", "1.9.9") or _compare_version(
-            ver, ">", "1.0.7"
+        return _compare_version(ver, ">", "1.0.7") or _compare_version(
+            ver_np, "<", "2.0"
         )
-    return out
 
 
 def _check_pybv_installed(strict=True):

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -418,10 +418,8 @@ def _check_edflib_installed(strict=True):
         return False
     # EDFlib-Python 1.0.7 is not compatible with NumPy 2.0
     # https://gitlab.com/Teuniz/EDFlib-Python/-/issues/10
-    ver = "unknown"
     ver = version("EDFlib-Python")
-    ver_np_major = parse(version("numpy")).major
-    if _compare_version(ver, ">", "1.0.7") or ver_np_major < 2:
+    if ver > parse("1.0.7") or parse(np.__version__).major < 2:
         return out
     if strict:  # pragma: no cover
         raise RuntimeError(

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -418,15 +418,17 @@ def _check_edflib_installed(strict=True):
     # https://gitlab.com/Teuniz/EDFlib-Python/-/issues/10
     try:
         from importlib.metadata import version
+        from packaging.version import parse
 
         ver = version("EDFlib-Python")
-        ver_np = version("numpy")
+        ver_np_major = parse(version("numpy")).major
     except Exception:
         return False
     else:
-        return _compare_version(ver, ">", "1.0.7") or _compare_version(
-            ver_np, "<", "2.0"
-        )
+        if _compare_version(ver, ">", "1.0.7") or ver_np_major < 2:
+            return out
+        else:
+            return False
 
 
 def _check_pybv_installed(strict=True):

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -418,7 +418,7 @@ def _check_edflib_installed(strict=True):
         # EDFlib-Python 1.0.7 is not compatible with NumPy 2.0
         # https://gitlab.com/Teuniz/EDFlib-Python/-/issues/10
         ver = version("EDFlib-Python")
-        if ver <= parse("1.0.7") and parse(np.__version__).major >= 2:
+        if parse(ver) <= parse("1.0.7") and parse(np.__version__).major >= 2:
             if strict:  # pragma: no cover
                 raise RuntimeError(
                     f"EDFlib version={ver} is not compatible with NumPy 2.0, consider "

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -428,6 +428,11 @@ def _check_edflib_installed(strict=True):
         if _compare_version(ver, ">", "1.0.7") or ver_np_major < 2:
             return out
         else:
+            if strict:  # pragma: no cover
+                raise RuntimeError(
+                    f"EDFlib {ver} is not compatible with NumPy 2.0, consider "
+                    "upgrading EDFlib-Python"
+                )
             return False
 
 

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -7,8 +7,10 @@ from builtins import input  # no-op here but facilitates testing
 from collections.abc import Sequence
 from difflib import get_close_matches
 from importlib import import_module
+from importlib.metadata import version
 import operator
 import os
+from packaging.version import parse
 from pathlib import Path
 import re
 import numbers
@@ -416,24 +418,17 @@ def _check_edflib_installed(strict=True):
         return False
     # EDFlib-Python 1.0.7 is not compatible with NumPy 2.0
     # https://gitlab.com/Teuniz/EDFlib-Python/-/issues/10
-    try:
-        from importlib.metadata import version
-        from packaging.version import parse
-
-        ver = version("EDFlib-Python")
-        ver_np_major = parse(version("numpy")).major
-    except Exception:
-        return False
-    else:
-        if _compare_version(ver, ">", "1.0.7") or ver_np_major < 2:
-            return out
-        else:
-            if strict:  # pragma: no cover
-                raise RuntimeError(
-                    f"EDFlib {ver} is not compatible with NumPy 2.0, consider "
-                    "upgrading EDFlib-Python"
-                )
-            return False
+    ver = "unknown"
+    ver = version("EDFlib-Python")
+    ver_np_major = parse(version("numpy")).major
+    if _compare_version(ver, ">", "1.0.7") or ver_np_major < 2:
+        return out
+    if strict:  # pragma: no cover
+        raise RuntimeError(
+            f"EDFlib version={ver} is not compatible with NumPy 2.0, consider "
+            "upgrading EDFlib-Python"
+        )
+    return False
 
 
 def _check_pybv_installed(strict=True):

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -1,30 +1,34 @@
 #!/bin/bash -ef
 
-EXTRA_ARGS=""
+STD_ARGS="--progress-bar off --upgrade"
 if [ "${TEST_MODE}" == "pip" ]; then
 	python -m pip install --upgrade pip setuptools wheel
 	python -m pip install --upgrade --only-binary="numba,llvmlite,numpy,scipy,vtk" -r requirements.txt
 elif [ "${TEST_MODE}" == "pip-pre" ]; then
-	python -m pip install --progress-bar off --upgrade pip setuptools wheel packaging setuptools_scm
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://www.riverbankcomputing.com/pypi/simple" PyQt6 PyQt6-sip PyQt6-Qt6
+	STD_ARGS="$STD_ARGS --pre"
+	python -m pip install $STD_ARGS pip setuptools wheel packaging setuptools_scm
+	python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://www.riverbankcomputing.com/pypi/simple" PyQt6 PyQt6-sip PyQt6-Qt6
 	echo "Numpy etc."
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0" scipy statsmodels pandas scikit-learn matplotlib
+	python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0" scipy statsmodels pandas scikit-learn matplotlib
 	echo "dipy"
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" dipy
+	python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" dipy
 	echo "h5py"
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
+	python -m pip install $STD_ARGS --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
 	echo "vtk"
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://wheels.vtk.org" vtk
+	python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://wheels.vtk.org" vtk
 	echo "openmeeg"
-	python -m pip install --progress-bar off --upgrade --pre --only-binary ":all:" --extra-index-url "https://test.pypi.org/simple" openmeeg
+	python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://test.pypi.org/simple" openmeeg
 	echo "pyvista/pyvistaqt"
 	python -m pip install --progress-bar off git+https://github.com/pyvista/pyvista
 	python -m pip install --progress-bar off git+https://github.com/pyvista/pyvistaqt
 	echo "misc"
-	python -m pip install --progress-bar off --upgrade --pre imageio-ffmpeg xlrd mffpy python-picard pillow
+	python -m pip install $STD_ARGS imageio-ffmpeg xlrd mffpy python-picard pillow
 	echo "nibabel with workaround"
-	python -m pip install --progress-bar off --upgrade --pre git+https://github.com/mscheltienne/nibabel.git@np.sctypes
-	EXTRA_ARGS="--pre"
+	python -m pip install --progress-bar off git+https://github.com/mscheltienne/nibabel.git@np.sctypes
+	echo "joblib"
+	python -m pip install --progress-bar off git+https://github.com/joblib/joblib@master
+	echo "EDFlib-Python"
+	python -m pip install $STD_ARGS git+https://gitlab.com/Teuniz/EDFlib-Python@master
 	./tools/check_qt_import.sh PyQt6
 else
 	echo "Unknown run type ${TEST_MODE}"

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -ef
 
 STD_ARGS="--progress-bar off --upgrade"
-EXTRA_ARGS=""
 if [ ! -z "$CONDA_ENV" ]; then
 	echo "Uninstalling MNE for CONDA_ENV=${CONDA_ENV}"
 	conda remove -c conda-forge --force -yq mne
@@ -12,36 +11,40 @@ elif [ ! -z "$CONDA_DEPENDENCIES" ]; then
 else
 	echo "Install pip-pre dependencies"
 	test "${MNE_CI_KIND}" == "pip-pre"
+	STD_ARGS="$STD_ARGS --pre"
 	python -m pip install $STD_ARGS pip setuptools wheel packaging
 	echo "Numpy"
 	pip uninstall -yq numpy
 	echo "PyQt6"
-	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6
+	pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6
 	echo "NumPy/SciPy/pandas etc."
-	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0" scipy scikit-learn pandas matplotlib pillow statsmodels
+	pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0" scipy scikit-learn pandas matplotlib pillow statsmodels
 	echo "dipy"
-	pip install $STD_ARGS --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" dipy
+	pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" dipy
 	echo "H5py"
-	pip install $STD_ARGS --pre --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
+	pip install $STD_ARGS --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
 	echo "OpenMEEG"
-	pip install $STD_ARGS --pre --only-binary ":all:" --extra-index-url "https://test.pypi.org/simple" openmeeg
+	pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://test.pypi.org/simple" openmeeg
 	# No Numba because it forces an old NumPy version
 	echo "nilearn and openmeeg"
-	pip install $STD_ARGS --pre git+https://github.com/nilearn/nilearn
+	pip install $STD_ARGS git+https://github.com/nilearn/nilearn
 	echo "VTK"
-	pip install $STD_ARGS --pre --only-binary ":all:" --extra-index-url "https://wheels.vtk.org" vtk
+	pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://wheels.vtk.org" vtk
 	python -c "import vtk"
 	echo "PyVista"
-	pip install --progress-bar off git+https://github.com/pyvista/pyvista
+	pip install $STD_ARGS git+https://github.com/pyvista/pyvista
 	echo "pyvistaqt"
-	pip install --progress-bar off git+https://github.com/pyvista/pyvistaqt
+	pip install $STD_ARGS git+https://github.com/pyvista/pyvistaqt
 	echo "imageio-ffmpeg, xlrd, mffpy, python-picard"
-	pip install --progress-bar off --pre imageio-ffmpeg xlrd mffpy python-picard patsy
+	pip install $STD_ARGS imageio-ffmpeg xlrd mffpy python-picard patsy
 	echo "mne-qt-browser"
-	pip install --progress-bar off git+https://github.com/mne-tools/mne-qt-browser
+	pip install $STD_ARGS git+https://github.com/mne-tools/mne-qt-browser
 	echo "nibabel with workaround"
-	pip install --progress-bar off --pre git+https://github.com/mscheltienne/nibabel.git@np.sctypes
-	EXTRA_ARGS="--pre"
+	pip install $STD_ARGS git+https://github.com/mscheltienne/nibabel.git@np.sctypes
+	echo "joblib"
+	pip install $STD_ARGS git+https://github.com/joblib/joblib@master
+	echo "EDFlib-Python"
+	pip install $STD_ARGS git+https://gitlab.com/Teuniz/EDFlib-Python@master
 fi
 echo ""
 
@@ -51,11 +54,11 @@ if [ ! -z "$CONDA_DEPENDENCIES" ]; then
 	python -m pip install -r requirements_base.txt -r requirements_testing.txt
 else
 	echo "Installing dependencies using pip"
-	python -m pip install $STD_ARGS $EXTRA_ARGS -r requirements_base.txt -r requirements_testing.txt -r requirements_hdf5.txt
+	python -m pip install $STD_ARGS -r requirements_base.txt -r requirements_testing.txt -r requirements_hdf5.txt
 fi
 echo ""
 
 if [ "${DEPS}" != "minimal" ]; then
 	echo "Installing non-minimal dependencies"
-	python -m pip install $STD_ARGS $EXTRA_ARGS -r requirements_testing_extra.txt
+	python -m pip install $STD_ARGS -r requirements_testing_extra.txt
 fi


### PR DESCRIPTION
Following #11994
The change introduce by @larsoner seems wrong, `out` can never be None and numpy versions `1.9.x` are 7/8 years old.

```
def _check_edflib_installed(strict=True):
    """Aux function."""
    out = _soft_import("EDFlib", "exporting to EDF", strict=strict) is not None
    # EDFlib-Python 1.0.7 not NumPy 2.0 compatible
    # https://gitlab.com/Teuniz/EDFlib-Python/-/issues/10
    try:
        from importlib.metadata import version

        ver = version("EDFlib-Python")
    except Exception:
        pass
    else:
        out &= not check_version("numpy", "1.9.9") or _compare_version(
            ver, ">", "1.0.7"
        )
    return out
```