### PR TITLE
BUG: Fix bug with clip box setting

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -47,6 +47,7 @@ Bugs
 - Fix bug with notebooks when using PyVista 0.42 by implementing ``trame`` backend support (:gh:`11956` by `Eric Larson`_)
 - Removed preload parameter from :func:`mne.io.read_raw_eyelink`, because data are always preloaded no matter what preload is set to (:gh:`11910` by `Scott Huberty`_)
 - Fix bug with :meth:`~mne.viz.Brain.add_annotation` when reading an annotation from a file with both hemispheres shown (:gh:`11946` by `Marijn van Vliet`_)
+- Fix bug with axis clip box boundaries in :func:`mne.viz.plot_evoked_topo` and related functions (:gh:`11999` by `Eric Larson`_)
 - Fix bug with ``subject_info`` when loading data from and exporting to EDF file (:gh:`11952` by `Paul Roujansky`_)
 - Fix handling of channel information in annotations when loading data from and exporting to EDF file (:gh:`11960` by `Paul Roujansky`_)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -200,7 +200,7 @@ numpydoc_xref_aliases = {
     "Path": ":class:`python:pathlib.Path`",
     "bool": ":class:`python:bool`",
     # Matplotlib
-    "colormap": ":doc:`colormap <matplotlib:tutorials/colors/colormaps>`",
+    "colormap": ":ref:`colormap <matplotlib:colormaps>`",
     "color": ":doc:`color <matplotlib:api/colors_api>`",
     "Axes": "matplotlib.axes.Axes",
     "Figure": "matplotlib.figure.Figure",

--- a/examples/io/elekta_epochs.py
+++ b/examples/io/elekta_epochs.py
@@ -5,9 +5,8 @@
 Getting averaging info from .fif files
 ======================================
 
-Parse averaging information defined in Elekta Vectorview/TRIUX DACQ (data
-acquisition). Extract and average epochs accordingly. Modify some
-averaging parameters and get epochs.
+Parse averaging information defined in Elekta Vectorview/TRIUX DACQ (data acquisition).
+Extract and average epochs accordingly. Modify some averaging parameters and get epochs.
 """
 # Author: Jussi Nurminen (jnu@iki.fi)
 #

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -777,7 +777,7 @@ docdict[
 cnorm : matplotlib.colors.Normalize | None
     How to normalize the colormap. If ``None``, standard linear normalization
     is performed. If not ``None``, ``vmin`` and ``vmax`` will be ignored.
-    See :doc:`Matplotlib docs <matplotlib:tutorials/colors/colormapnorms>`
+    See :ref:`Matplotlib docs <matplotlib:colormapnorms>`
     for more details on colormap normalization, and
     :ref:`the ERDs example<cnorm-example>` for an example of its use.
 """

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -2654,8 +2654,8 @@ def plot_compare_evokeds(
         :class:`dict` of :class:`ints <int>` or :class:`floats <float>`
         indicating steps or percentiles (respectively) along the colormap. If
         ``cmap`` is ``None``, list elements or dict values of ``colors`` must
-        be :class:`ints <int>` or valid :doc:`matplotlib colors
-        <matplotlib:tutorials/colors/colors>`; lists are cycled through
+        be :class:`ints <int>` or valid :ref:`matplotlib colors
+        <matplotlib:colors_def>`; lists are cycled through
         sequentially,
         while dicts must have keys matching the keys or conditions of an
         ``evokeds`` dict (see Notes for details). If ``None``, the current

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -783,7 +783,7 @@ def plot_events(
         Dictionary of event_id integers as keys and colors as values. If None,
         colors are automatically drawn from a default list (cycled through if
         number of events longer than list of default colors). Color can be any
-        valid :doc:`matplotlib color <matplotlib:tutorials/colors/colors>`.
+        valid :ref:`matplotlib color <matplotlib:colors_def>`.
     event_id : dict | None
         Dictionary of event labels (e.g. 'aud_l') as keys and their associated
         event_id values. Labels are used to plot a legend. If None, no legend

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -496,8 +496,6 @@ def _imshow_tfr_unified(
     data_lines.append(
         ax.imshow(
             tfr[ch_idx],
-            clip_on=True,
-            clip_box=tuple(bn.pos),
             extent=extent,
             aspect="auto",
             origin="lower",
@@ -506,6 +504,7 @@ def _imshow_tfr_unified(
             cmap=cmap,
         )
     )
+    data_lines[-1].set_clip_box(_pos_to_bbox(bn.pos, ax))
 
 
 def _plot_timeseries(
@@ -664,7 +663,6 @@ def _plot_timeseries_unified(
     pos = bn.pos
     data_lines = bn.data_lines
     ax = bn.ax
-    # XXX These calls could probably be made faster by using collections
     for data_, color_, times_ in zip(data, color, times):
         data_lines.append(
             ax.plot(
@@ -672,10 +670,10 @@ def _plot_timeseries_unified(
                 bn.y_t + bn.y_s * data_[ch_idx],
                 linewidth=0.5,
                 color=color_,
-                clip_on=True,
-                clip_box=tuple(pos),
             )[0]
         )
+        # Needs to be done afterward for some reason (probable matlotlib bug)
+        data_lines[-1].set_clip_box(_pos_to_bbox(pos, ax))
     if vline:
         vline = np.array(vline) * bn.x_s + bn.x_t
         ax.vlines(
@@ -1300,3 +1298,13 @@ def plot_topo_image_epochs(
     add_background_image(fig, fig_background)
     plt_show(show)
     return fig
+
+
+def _pos_to_bbox(pos, ax):
+    """Convert layout position to bbox."""
+    import matplotlib.transforms as mtransforms
+
+    return mtransforms.TransformedBbox(
+        mtransforms.Bbox.from_bounds(*pos),
+        ax.transAxes,
+    )

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2066,8 +2066,8 @@ def plot_evoked_topomap(
     the same call as the colorbar. Note also that the colorbar will not be
     resized automatically when ``axes`` are provided; use Matplotlib's
     :meth:`axes.set_position() <matplotlib.axes.Axes.set_position>` method or
-    :doc:`gridspec <matplotlib:tutorials/intermediate/arranging_axes>`
-    interface to adjust the colorbar size yourself.
+    :ref:`gridspec <matplotlib:arranging_axes>` interface to adjust the colorbar
+    size yourself.
 
     When ``time=="interactive"``, the figure will publish and subscribe to the
     following UI events:

--- a/tutorials/preprocessing/70_fnirs_processing.py
+++ b/tutorials/preprocessing/70_fnirs_processing.py
@@ -12,7 +12,6 @@ topographic representation of the response.
 
 Here we will work with the :ref:`fNIRS motor data <fnirs-motor-dataset>`.
 """
-
 # %%
 
 import numpy as np

--- a/tutorials/time-freq/20_sensors_time_frequency.py
+++ b/tutorials/time-freq/20_sensors_time_frequency.py
@@ -10,7 +10,7 @@ of your data (frequency and time-frequency). Here we'll work on Epochs.
 
 We will use this dataset: :ref:`somato-dataset`. It contains so-called event
 related synchronizations (ERS) / desynchronizations (ERD) in the beta band.
-"""  # noqa: E501
+"""
 # Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #          Richard Höchenberger <richard.hoechenberger@gmail.com>


### PR DESCRIPTION
I don't think `clip_box` ever really worked. Worked in local testing when doing for example `ylim=dict(mag=[-10, 10], grad=[-10, 10])` in the `examples`. Probably wasn't noticed much because by default we compute the limits to include the `max(abs(evoked.data))`.Should fix https://app.circleci.com/pipelines/github/mne-tools/mne-python/20804/workflows/fb9767de-6f57-4a69-9585-d964ec4e5bd9/jobs/59196