### PR TITLE
Add the missing overwrite and verbose parameters to Transform.save

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -52,7 +52,7 @@ Bugs
 - Fix bug with axis clip box boundaries in :func:`mne.viz.plot_evoked_topo` and related functions (:gh:`11999` by `Eric Larson`_)
 - Fix bug with ``subject_info`` when loading data from and exporting to EDF file (:gh:`11952` by `Paul Roujansky`_)
 - Fix handling of channel information in annotations when loading data from and exporting to EDF file (:gh:`11960` by `Paul Roujansky`_)
-- Add missing ``overwrite`` and ``verbose`` parameters to :meth:`~mne.transforms.Transforms.save` (:gh:`12004` by `Marijn van Vliet`_)
+- Add missing ``overwrite`` and ``verbose`` parameters to :meth:`Transform.save() <mne.transforms.Transform.save>` (:gh:`12004` by `Marijn van Vliet`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -52,6 +52,7 @@ Bugs
 - Fix bug with axis clip box boundaries in :func:`mne.viz.plot_evoked_topo` and related functions (:gh:`11999` by `Eric Larson`_)
 - Fix bug with ``subject_info`` when loading data from and exporting to EDF file (:gh:`11952` by `Paul Roujansky`_)
 - Fix handling of channel information in annotations when loading data from and exporting to EDF file (:gh:`11960` by `Paul Roujansky`_)
+- Add missing ``overwrite`` and ``verbose`` parameters to :meth:`~mne.transforms.Transforms.save` (:gh:`12004` by `Marijn van Vliet`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -184,15 +184,19 @@ class Transform(dict):
         """The "to" frame as a string."""
         return _coord_frame_name(self["to"])
 
-    def save(self, fname):
+    @fill_doc
+    @verbose
+    def save(self, fname, *, overwrite=False, verbose=None):
         """Save the transform as -trans.fif file.
 
         Parameters
         ----------
         fname : path-like
             The name of the file, which should end in ``-trans.fif``.
+        %(overwrite)s
+        %(verbose)s
         """
-        write_trans(fname, self)
+        write_trans(fname, self, overwrite=overwrite, verbose=verbose)
 
     def copy(self):
         """Make a copy of the transform."""


### PR DESCRIPTION
There were some parameters that `write_transform` has but `Transform.save` does not. This adds them.