### PR TITLE
MAINT: Link to sg_execution_times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
           name: List packages
           command: python -m pip list
 
-      # Figure out if we should run a full, pattern, or noplot version
+      # Figure out if we should run a full build or specify a pattern
       - restore_cache:
           keys:
             - data-cache-tiny-1
@@ -311,7 +311,7 @@ jobs:
       - run:
           name: Reduce artifact upload time
           command: |
-            if grep -q html-pattern-memory build.txt || grep -q html-noplot build.txt; then
+            if grep -q html-pattern-memory build.txt; then
               zip -rm doc/_build/html/_downloads.zip doc/_build/html/_downloads
             fi
             for NAME in generated auto_tutorials auto_examples; do

--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -10,6 +10,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           api-token: ${{ secrets.CIRCLECI_TOKEN }}
-          artifact-path: 0/html/index.html
+          artifact-path: 0/html/sg_execution_times.html
           circleci-jobs: build_docs,build_docs_main
           job-title: Check the rendered docs here!

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ doc/samples
 doc/*.dat
 doc/fil-result
 doc/optipng.exe
+sg_execution_times.rst
 cover
 *.html
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -28,7 +28,7 @@ help:
 	@echo "  view             to view the built HTML"
 
 clean:
-	-rm -rf _build auto_examples auto_tutorials generated *.stc *.fif *.nii.gz
+	-rm -rf _build sg_execution_times.rst auto_examples auto_tutorials generated *.stc *.fif *.nii.gz
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) _build/html

--- a/tools/circleci_download.sh
+++ b/tools/circleci_download.sh
@@ -113,11 +113,11 @@ else
         fi;
     done;
     echo PATTERN="$PATTERN";
+    echo html-pattern-memory > build.txt;
     if [[ $PATTERN ]]; then
         PATTERN="\(${PATTERN::-2}\)";
-        echo html-pattern-memory > build.txt;
     else
-        echo html-noplot > build.txt;
+        PATTERN="run_no_examples_or_tutorials"
     fi;
 fi;
 echo "$PATTERN" > pattern.txt;


### PR DESCRIPTION
Once https://github.com/sphinx-gallery/sphinx-gallery/pull/1198 is merged we should merge this. Then "check built docs" will link to the root-level `sg_execution_times.html` which will have at the top any changed or modified examples, which is something I've wanted easy access to for a while now!

Draft until https://github.com/sphinx-gallery/sphinx-gallery/pull/1198 lands. I also simplified the circleci logic a tiny bit by always running a PATTERN variant (and when there are no examples that have changed, use a pattern that will have no matches).