### PR TITLE
Correctly prune channel-specific annotations when creating Epochs

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -55,6 +55,7 @@ Bugs
 - Fix bug with ``subject_info`` when loading data from and exporting to EDF file (:gh:`11952` by `Paul Roujansky`_)
 - Fix handling of channel information in annotations when loading data from and exporting to EDF file (:gh:`11960` by `Paul Roujansky`_)
 - Add missing ``overwrite`` and ``verbose`` parameters to :meth:`Transform.save() <mne.transforms.Transform.save>` (:gh:`12004` by `Marijn van Vliet`_)
+- Correctly prune channel-specific :class:`~mne.Annotations` when creating :class:`~mne.Epochs` without the channel(s) included in the channel specific annotations (:gh:`12010` by `Mathieu Scheltienne`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -817,7 +817,7 @@ class EpochAnnotationsMixin:
                     "disk) before 1.0 will yield incorrect results if "
                     "decimation or resampling was performed on the instance, "
                     "we recommend regenerating the Epochs and re-saving them "
-                    "to disk"
+                    "to disk."
                 )
             new_annotations = annotations.copy()
             new_annotations._prune_ch_names(self.info, on_missing)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -691,7 +691,7 @@ class BaseEpochs(
             raw_sfreq = self.info["sfreq"]
         self._raw_sfreq = raw_sfreq
         self._check_consistency()
-        self.set_annotations(annotations, on_missing="ingore")
+        self.set_annotations(annotations, on_missing="ignore")
 
     def _check_consistency(self):
         """Check invariants of epochs object."""

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -691,7 +691,7 @@ class BaseEpochs(
             raw_sfreq = self.info["sfreq"]
         self._raw_sfreq = raw_sfreq
         self._check_consistency()
-        self.set_annotations(annotations)
+        self.set_annotations(annotations, on_missing="ingore")
 
     def _check_consistency(self):
         """Check invariants of epochs object."""


### PR DESCRIPTION
On `main`, creating Epochs including only MEG channels from an MEG + EyeLink re-aligned recording raises.

```
epochs = Epochs(
    raw, events, event_id, tmin=-0.3, tmax=1, baseline=(None, 0), picks="meg"
)
```

Traceback:

```  
Cell In[1], line 19
    epochs = Epochs(

  File <decorator-gen-201>:12 in __init__

  File ~/git/mscheltienne/mne-python/mne/epochs.py:3111 in __init__
    super(Epochs, self).__init__(

  File <decorator-gen-187>:12 in __init__

  File ~/git/mscheltienne/mne-python/mne/epochs.py:694 in __init__
    self.set_annotations(annotations)

  File <decorator-gen-184>:12 in set_annotations

  File ~/git/mscheltienne/mne-python/mne/annotations.py:823 in set_annotations
    new_annotations._prune_ch_names(self.info, on_missing)

  File ~/git/mscheltienne/mne-python/mne/annotations.py:496 in _prune_ch_names
    _on_missing(

  File ~/git/mscheltienne/mne-python/mne/utils/check.py:1165 in _on_missing
    raise error_klass(msg)

ValueError: At least one channel name in annotations missing from info: xpos_left
```

FYI @scott-huberty since it was discovered on eye-tracker data.