### PR TITLE
FIX: allow user to pick "eyegaze" or "pupil" (fix in triage_eyetrack_picks)

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -56,6 +56,7 @@ Bugs
 - Fix handling of channel information in annotations when loading data from and exporting to EDF file (:gh:`11960` :gh:`12017` by `Paul Roujansky`_)
 - Add missing ``overwrite`` and ``verbose`` parameters to :meth:`Transform.save() <mne.transforms.Transform.save>` (:gh:`12004` by `Marijn van Vliet`_)
 - Correctly prune channel-specific :class:`~mne.Annotations` when creating :class:`~mne.Epochs` without the channel(s) included in the channel specific annotations (:gh:`12010` by `Mathieu Scheltienne`_)
+- Correctly handle passing ``"eyegaze"`` or ``"pupil"`` to :meth:`mne.io.Raw.pick` (:gh:`12019` by `Scott Huberty`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/_fiff/pick.py
+++ b/mne/_fiff/pick.py
@@ -1388,16 +1388,12 @@ def _picks_str_to_idx(
                 extra_picks |= set(
                     pick_types(info, meg=use_meg, ref_meg=False, exclude=exclude)
                 )
-        if len(fnirs) > 0 and not kwargs.get("fnirs", False):
-            if len(fnirs) == 1:
-                kwargs["fnirs"] = list(fnirs)[0]
-            else:
-                kwargs["fnirs"] = list(fnirs)
-        if len(eyetrack) > 0 and not kwargs.get("eyetrack", False):
-            if len(eyetrack) == 1:
-                kwargs["eyetrack"] = list(eyetrack)[0]
-            else:
-                kwargs["eyetrack"] = list(eyetrack)
+        if len(fnirs) and not kwargs.get("fnirs", False):
+            idx = 0 if len(fnirs) == 1 else slice(None)
+            kwargs["fnirs"] = list(fnirs)[idx]
+        if len(eyetrack) and not kwargs.get("eyetrack", False):
+            idx = 0 if len(eyetrack) == 1 else slice(None)
+            kwargs["eyetrack"] = list(eyetrack)[idx]  # slice(None) is equivalent to all
         picks_type = pick_types(info, exclude=exclude, **kwargs)
         if len(extra_picks) > 0:
             picks_type = sorted(set(picks_type) | set(extra_picks))

--- a/mne/_fiff/pick.py
+++ b/mne/_fiff/pick.py
@@ -1362,7 +1362,7 @@ def _picks_str_to_idx(
     bad_type = None
     picks_type = list()
     kwargs = dict(meg=False)
-    meg, fnirs = set(), set()
+    meg, fnirs, eyetrack = set(), set(), set()
     for pick in picks:
         if pick in _PICK_TYPES_KEYS:
             kwargs[pick] = True
@@ -1370,13 +1370,15 @@ def _picks_str_to_idx(
             meg |= {pick}
         elif pick in _FNIRS_CH_TYPES_SPLIT:
             fnirs |= {pick}
+        elif pick in _EYETRACK_CH_TYPES_SPLIT:
+            eyetrack |= {pick}
         else:
             bad_type = pick
             break
     else:
         # bad_type is None but this could still be empty
         bad_type = list(picks)
-        # triage MEG and FNIRS, which are complicated due to non-bool entries
+        # triage MEG, FNIRS, and eyetrack, which are complicated due to non-bool entries
         extra_picks = set()
         if "ref_meg" not in picks and not with_ref_meg:
             kwargs["ref_meg"] = False
@@ -1391,6 +1393,11 @@ def _picks_str_to_idx(
                 kwargs["fnirs"] = list(fnirs)[0]
             else:
                 kwargs["fnirs"] = list(fnirs)
+        if len(eyetrack) > 0 and not kwargs.get("eyetrack", False):
+            if len(eyetrack) == 1:
+                kwargs["eyetrack"] = list(eyetrack)[0]
+            else:
+                kwargs["eyetrack"] = list(eyetrack)
         picks_type = pick_types(info, exclude=exclude, **kwargs)
         if len(extra_picks) > 0:
             picks_type = sorted(set(picks_type) | set(extra_picks))

--- a/mne/_fiff/tests/test_pick.py
+++ b/mne/_fiff/tests/test_pick.py
@@ -658,6 +658,11 @@ def test_picks_to_idx():
         picks_ref, _picks_to_idx(info_ref, "ref_meg", with_ref_meg=False)
     )
     assert_array_equal(picks_meg_ref, _picks_to_idx(info_ref, "meg", with_ref_meg=True))
+    # Eyetrack
+    info = create_info(["a", "b"], 1000.0, ["eyegaze", "pupil"])
+    assert_array_equal(np.arange(2), _picks_to_idx(info, "eyetrack"))
+    assert_array_equal([0], _picks_to_idx(info, "eyegaze"))
+    assert_array_equal([1], _picks_to_idx(info, "pupil"))
 
 
 def test_pick_channels_cov():


### PR DESCRIPTION
Fixes #12018

Now, `inst.pick("eyegaze")` or `inst.pick("pupil")` will work. 

EDIT: Note to self, verify that tests pass, then update changelog.