### PR TITLE
MAINT: Fix typos found by codespell

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2398,7 +2398,7 @@ def _get_ch_factors(inst, units, picks_idxs):
     Returns
     -------
     ch_factors : ndarray of floats, shape(len(picks),)
-        The sacling factors for each channel, ordered according
+        The scaling factors for each channel, ordered according
         to picks.
 
     """

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -769,7 +769,7 @@ def _get_hdr_info(hdr_fname, eog, misc, scale):
                     for filt in highpass
                 ]
                 info["highpass"] = np.max(np.array(highpass, dtype=np.float64))
-                # Coveniently enough 1 / np.inf = 0.0, so this works for
+                # Conveniently enough 1 / np.inf = 0.0, so this works for
                 # DC / no highpass filter
                 # filter time constant t [secs] to Hz conversion: 1/2*pi*t
                 info["highpass"] = 1.0 / (2 * np.pi * info["highpass"])


### PR DESCRIPTION
#### Reference issue
\-


#### What does this implement/fix?
Fix misspellings.


#### Additional information
