### PR TITLE
[ENH] update version and checksum in config.py for testing datasets

### DIFF
--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -87,7 +87,7 @@ I agree to the following:
 # respective repos, and make a new release of the dataset on GitHub. Then
 # update the checksum in the MNE_DATASETS dict below, and change version
 # here:                  ↓↓↓↓↓         ↓↓↓
-RELEASES = dict(testing="0.147", misc="0.26")
+RELEASES = dict(testing="0.149", misc="0.26")
 TESTING_VERSIONED = f'mne-testing-data-{RELEASES["testing"]}'
 MISC_VERSIONED = f'mne-misc-data-{RELEASES["misc"]}'
 
@@ -111,7 +111,7 @@ MNE_DATASETS = dict()
 # Testing and misc are at the top as they're updated most often
 MNE_DATASETS["testing"] = dict(
     archive_name=f"{TESTING_VERSIONED}.tar.gz",
-    hash="md5:63fa41e3067f330a6d029dcc1673a919",
+    hash="md5:86c47eb83426f48ff17338cb0e379754",
     url=(
         "https://codeload.github.com/mne-tools/mne-testing-data/"
         f'tar.gz/{RELEASES["testing"]}'


### PR DESCRIPTION
#### Reference issue
Relates to #11874 and WIP PR #11969. 

#### What does this implement/fix?
Update version number and checksum in `mne/datasets/config.py` to reflect the [release 0.149](https://github.com/mne-tools/mne-testing-data/releases/tag/0.149) of mne-testing-data which had Neuralynx testing dataset added.

#### Additional information
Note: the version in `config.py` was updated from `0.147` to `0.149` (it seems there hasn't been an update for 0.148)