### PR TITLE
adding crossref from forward to create trans

### DIFF
--- a/tutorials/forward/20_source_alignment.py
+++ b/tutorials/forward/20_source_alignment.py
@@ -329,6 +329,8 @@ mne.viz.set_3d_view(
 renderer.show()
 
 # %%
+# .. _creating-trans:
+#
 # Defining the head↔MRI ``trans`` using the GUI
 # ---------------------------------------------
 # You can try creating the head↔MRI transform yourself using

--- a/tutorials/forward/30_forward.py
+++ b/tutorials/forward/30_forward.py
@@ -82,7 +82,8 @@ mne.viz.plot_bem(**plot_bem_kwargs)
 # system.
 #
 # Here we assume the coregistration is done, so we just visually check the
-# alignment with the following code.
+# alignment with the following code. See :ref:`creating-trans` for instructions
+# on creating the ``-trans.fif`` file interactively.
 
 # The transformation file obtained by coregistration
 trans = sample_dir / "sample_audvis_raw-trans.fif"


### PR DESCRIPTION
Closes #9181 

Per discussion with @drammock and @britta-wstnr,  the relevant information is already there in `tutorials/forward/20_source_alignment.py` so just adding a crossref to there from `30_forward.py`. 