### PR TITLE
MAINT: Use PyPI upload action for published releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+# Upload a Python Package using Twine when a release is created
+
+name: Build
+on:  # yamllint disable-line rule:truthy
+  release:
+    types: [published]
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mne
+    permissions:
+      id-token: write  # for trusted publishing
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      - run: python -m build --sdist --wheel
+      - run: twine check --strict dist/*
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        if: github.event_name == 'release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,12 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   package:
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/mne
-    permissions:
-      id-token: write  # for trusted publishing
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -30,5 +28,24 @@ jobs:
           pip install build twine
       - run: python -m build --sdist --wheel
       - run: twine check --strict dist/*
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist
+
+  pypi-upload:
+    needs: package
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    permissions:
+      id-token: write  # for trusted publishing
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mne
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'release'


### PR DESCRIPTION
Closes #11509 

- [x] Add GitHub action
- [x] Get it green
- [x] Add trusted publisher by following https://docs.pypi.org/trusted-publishers/adding-a-publisher/
- [x] Merge

... then we wait to tag a GitHub release to see if it actually works!

Eventually we should also add `package` and `bandit` to PR merge requirements