### PR TITLE
Mark tests as network tests

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -57,6 +57,7 @@ Bugs
 - Add missing ``overwrite`` and ``verbose`` parameters to :meth:`Transform.save() <mne.transforms.Transform.save>` (:gh:`12004` by `Marijn van Vliet`_)
 - Correctly prune channel-specific :class:`~mne.Annotations` when creating :class:`~mne.Epochs` without the channel(s) included in the channel specific annotations (:gh:`12010` by `Mathieu Scheltienne`_)
 - Correctly handle passing ``"eyegaze"`` or ``"pupil"`` to :meth:`mne.io.Raw.pick` (:gh:`12019` by `Scott Huberty`_)
+- Mark tests ``test_adjacency_matches_ft`` and ``test_fetch_uncompressed_file`` as network tests (:gh:`12041` by :newcontrib:`Maksym Balatsko`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -40,6 +40,7 @@ Bugs
 ~~~~
 - Fix bugs with :func:`mne.preprocessing.realign_raw` where the start of ``other`` was incorrectly cropped; and onsets and durations in ``other.annotations`` were left unsynced with the resampled data (:gh:`11950` by :newcontrib:`Qian Chu`)
 - Fix bug where ``encoding`` argument was ignored when reading annotations from an EDF file (:gh:`11958` by :newcontrib:`Andrew Gilbert`)
+- Mark tests ``test_adjacency_matches_ft`` and ``test_fetch_uncompressed_file`` as network tests (:gh:`12041` by :newcontrib:`Maksym Balatsko`)
 - Fix bugs with saving splits for :class:`~mne.Epochs` (:gh:`11876` by `Dmitrii Altukhov`_)
 - Fix bug with multi-plot 3D rendering where only one plot was updated (:gh:`11896` by `Eric Larson`_)
 - Fix bug where subject birthdays were not correctly read by :func:`mne.io.read_raw_snirf` (:gh:`11912` by `Eric Larson`_)
@@ -57,7 +58,6 @@ Bugs
 - Add missing ``overwrite`` and ``verbose`` parameters to :meth:`Transform.save() <mne.transforms.Transform.save>` (:gh:`12004` by `Marijn van Vliet`_)
 - Correctly prune channel-specific :class:`~mne.Annotations` when creating :class:`~mne.Epochs` without the channel(s) included in the channel specific annotations (:gh:`12010` by `Mathieu Scheltienne`_)
 - Correctly handle passing ``"eyegaze"`` or ``"pupil"`` to :meth:`mne.io.Raw.pick` (:gh:`12019` by `Scott Huberty`_)
-- Mark tests ``test_adjacency_matches_ft`` and ``test_fetch_uncompressed_file`` as network tests (:gh:`12041` by :newcontrib:`Maksym Balatsko`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -320,6 +320,8 @@
 
 .. _Mainak Jas: https://jasmainak.github.io
 
+.. _Maksym Balatsko: https://github.com/mbalatsko
+
 .. _Marcin Koculak: https://github.com/mkoculak
 
 .. _Marian Dovgialo: https://github.com/mdovgialo

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -51,6 +51,7 @@ from mne import (
 )
 from mne.datasets import testing
 from mne.parallel import parallel_func
+from mne.utils import requires_good_network
 
 io_dir = Path(__file__).parent.parent.parent / "io"
 base_dir = io_dir / "tests" / "data"
@@ -362,6 +363,7 @@ def _download_ft_neighbors(target_dir):
 
 
 @pytest.mark.slowtest
+@requires_good_network
 def test_adjacency_matches_ft(tmp_path):
     """Test correspondence of built-in adjacency matrices with FT repo."""
     builtin_neighbors_dir = Path(__file__).parents[1] / "data" / "neighbors"

--- a/mne/datasets/tests/test_datasets.py
+++ b/mne/datasets/tests/test_datasets.py
@@ -306,6 +306,7 @@ def test_phantom(tmp_path, monkeypatch):
     assert op.isfile(tmp_path / "phantom_otaniemi" / "mri" / "T1.mgz")
 
 
+@requires_good_network
 def test_fetch_uncompressed_file(tmp_path):
     """Test downloading an uncompressed file with our fetch function."""
     dataset_dict = dict(


### PR DESCRIPTION
This PR mark tests `test_adjacency_matches_ft` and `test_fetch_uncompressed_file` as network tests as they touch the internet.
