### PR TITLE
Do not set annotation channel when missing from input data when reading EDF

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -56,7 +56,7 @@ Bugs
 - Fix bug with axis clip box boundaries in :func:`mne.viz.plot_evoked_topo` and related functions (:gh:`11999` by `Eric Larson`_)
 - Fix bug with ``subject_info`` when loading data from and exporting to EDF file (:gh:`11952` by `Paul Roujansky`_)
 - Fix bug with delayed checking of :class:`info["bads"] <mne.Info>` (:gh:`12038` by `Eric Larson`_)
-- Fix handling of channel information in annotations when loading data from and exporting to EDF file (:gh:`11960` :gh:`12017` by `Paul Roujansky`_)
+- Fix handling of channel information in annotations when loading data from and exporting to EDF file (:gh:`11960` :gh:`12017` :gh:`12044` by `Paul Roujansky`_)
 - Add missing ``overwrite`` and ``verbose`` parameters to :meth:`Transform.save() <mne.transforms.Transform.save>` (:gh:`12004` by `Marijn van Vliet`_)
 - Fix parsing of eye-link :class:`~mne.Annotations` when ``apply_offsets=False`` is provided to :func:`~mne.io.read_raw_eyelink` (:gh:`12003` by `Mathieu Scheltienne`_)
 - Correctly prune channel-specific :class:`~mne.Annotations` when creating :class:`~mne.Epochs` without the channel(s) included in the channel specific annotations (:gh:`12010` by `Mathieu Scheltienne`_)

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -206,6 +206,7 @@ class RawEDF(BaseRaw):
             )
             annotations = _read_annotations_edf(
                 tal_data[0],
+                ch_names=info["ch_names"],
                 encoding=encoding,
             )
             self.set_annotations(annotations, on_missing="warn")
@@ -1892,25 +1893,21 @@ def read_raw_gdf(
 
 
 @fill_doc
-def _read_annotations_edf(annotations, encoding="utf8"):
+def _read_annotations_edf(annotations, ch_names=None, encoding="utf8"):
     """Annotation File Reader.
 
     Parameters
     ----------
     annotations : ndarray (n_chans, n_samples) | str
         Channel data in EDF+ TAL format or path to annotation file.
+    ch_names : list of string
+        List of channels' names.
     %(encoding_edf)s
 
     Returns
     -------
-    onset : array of float, shape (n_annotations,)
-        The starting time of annotations in seconds after ``orig_time``.
-    duration : array of float, shape (n_annotations,)
-        Durations of the annotations in seconds.
-    description : array of str, shape (n_annotations,)
-        Array of strings containing description for each annotation. If a
-        string, all the annotations are given the same description. To reject
-        epochs, use description starting with keyword 'bad'. See example above.
+    annot : instance of Annotations
+        The annotations.
     """
     pat = "([+-]\\d+\\.?\\d*)(\x15(\\d+\\.?\\d*))?(\x14.*?)\x14\x00"
     if isinstance(annotations, str):
@@ -1949,7 +1946,11 @@ def _read_annotations_edf(annotations, encoding="utf8"):
         duration = float(ev[2]) if ev[2] else 0
         for description in ev[3].split("\x14")[1:]:
             if description:
-                if "@@" in description:
+                if (
+                    "@@" in description
+                    and ch_names is not None
+                    and description.split("@@")[1] in ch_names
+                ):
                     description, ch_name = description.split("@@")
                     key = f"{onset}_{duration}_{description}"
                 else:
@@ -1979,21 +1980,19 @@ def _read_annotations_edf(annotations, encoding="utf8"):
                 offset = -onset
 
     if events:
-        onset, duration, description, ch_names = zip(*events.values())
+        onset, duration, description, annot_ch_names = zip(*events.values())
     else:
-        onset, duration, description, ch_names = list(), list(), list(), list()
+        onset, duration, description, annot_ch_names = list(), list(), list(), list()
 
-    assert len(onset) == len(duration) == len(description) == len(ch_names)
+    assert len(onset) == len(duration) == len(description) == len(annot_ch_names)
 
-    annotations = Annotations(
+    return Annotations(
         onset=onset,
         duration=duration,
         description=description,
         orig_time=None,
-        ch_names=ch_names,
+        ch_names=annot_ch_names,
     )
-
-    return annotations
 
 
 def _get_annotations_gdf(edf_info, sfreq):

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -563,8 +563,8 @@ def test_read_annotations_edf(tmp_path):
         _ndarray_ch_names([("CH1",), (), ("CH1", "CH2"), ("CH3",), ()]),
     )
 
-    # Read annotations with incomplete input channel names: CH3 is missing from input
-    # channels, turning into a global annotations
+    # Read annotations with incomplete input channel names: "CH3" is missing from input
+    # channels, turning the related annotation into a global one
     annotations = _read_annotations_edf(
         tal_channel, ch_names=["CH1", "CH2"], encoding="latin1"
     )

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -528,7 +528,7 @@ def test_read_annotations_edf(tmp_path):
             dtype_byte=None,
         )
 
-    # Read annotations without input channel names: annotation as left untouched and
+    # Read annotations without input channel names: annotations are left untouched and
     # assigned as global
     annotations = _read_annotations_edf(tal_channel, ch_names=None, encoding="latin1")
     assert_allclose(annotations.onset, [1.1, 1.2, 1.3, 1.3, 1.4, 1.5])


### PR DESCRIPTION
In the light of https://github.com/mne-tools/mne-python/pull/12017 (and issue https://github.com/mne-tools/mne-python/issues/12007), the following PR aims at preventing an annotation channel to be set when parsing an EDF+ annotation' description that contains the channel information (through [EDF+ "@@" convention](https://www.edfplus.info/specs/edftexts.html)) but that the parsed channel does not exist in the input data (see https://github.com/mne-tools/mne-python/pull/12017#discussion_r1337576499 for an example).
In such cases, the description is left as is and no channel is associated to the annotation, therefore making it global.