### PR TITLE
MAINT: Use github_changelog_generator for release notes

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,0 +1,25 @@
+name: Labels
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+      - synchronize
+
+env:
+  LABELS: ${{ join( github.event.pull_request.labels.*.name, ' ' ) }}
+
+jobs:
+  check-type-label:
+    name: ensure labeled
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Labels: $LABELS"
+          if [[ "$LABELS" != *"BUG"* ]] && [[ "$LABELS" != *"ENH"* ]] && [[ "$LABELS" != *"API"* ]] && [[ "$LABELS" != *"MAINT"* ]]; then
+            echo "Please add a valid type label to this PR"
+            exit 1
+          fi

--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,0 +1,7 @@
+project=mne-python
+user=mne-tools
+add-sections={"enh":{"prefix":"**Enhancements**","labels":["ENH"]},"bug":{"prefix":"**Bugfixes**","labels":["BUG"]},"api":{"prefix":"**API changes**","labels":["API"]},"doc":{"prefix":"**Documentation**","labels":["DOC"]},"maintenance":{"prefix":"**Code health**","labels":["MAINT"]}}
+max-issues=2
+issues=no
+compare-link=no
+cache-file=.github_changelog_cache

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ venv/
 .hypothesis/
 .ruff_cache/
 .ipynb_checkpoints/
+.github_changelog_cache/

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,5 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    labels:
+      - "MAINT"

--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -1,71 +1,94 @@
-.. NOTE: we use cross-references to highlight new functions and classes.
-   Please follow the examples below like :func:`mne.stats.f_mway_rm`, so the
-   whats_new page will have a link to the function/class documentation.
+`1.6.0.dev235+gc154d8aa7 <https://github.com/mne-tools/mne-python/main>`__ (2023-10-02)
+---------------------------------------------------------------------------------------
 
-.. NOTE: there are 3 separate sections for changes, based on type:
-   - "Enhancements" for new features
-   - "Bugs" for bug fixes
-   - "API changes" for backward-incompatible changes
+**Enhancements**
 
-.. NOTE: changes from first-time contributors should be added to the TOP of
-   the relevant section (Enhancements / Bugs / API changes), and should look
-   like this (where xxxx is the pull request number):
+-  MAINT: Warn when fitting cHPI amplitudes on Maxwell filtered data `#12038 <https://github.com/mne-tools/mne-python/pull/12038>`__ (`larsoner <https://github.com/larsoner>`__)
+-  ENH: Add Forward.save and hdf5 support `#12036 <https://github.com/mne-tools/mne-python/pull/12036>`__ (`larsoner <https://github.com/larsoner>`__)
+-  [ENH] update version and checksum in config.py for testing datasets `#12032 <https://github.com/mne-tools/mne-python/pull/12032>`__ (`KristijanArmeni <https://github.com/KristijanArmeni>`__)
+-  Adding nan method to interpolate channels `#12027 <https://github.com/mne-tools/mne-python/pull/12027>`__ (`anaradanovic <https://github.com/anaradanovic>`__)
+-  [MRG] Improve docstring format and support floats for conductivity in make_bem_model `#12020 <https://github.com/mne-tools/mne-python/pull/12020>`__ (`mscheltienne <https://github.com/mscheltienne>`__)
+-  Add mne.preprocessing.unify_bad_channels `#12014 <https://github.com/mne-tools/mne-python/pull/12014>`__ (`anaradanovic <https://github.com/anaradanovic>`__)
+-  ENH: Build API entry usage graphs `#12013 <https://github.com/mne-tools/mne-python/pull/12013>`__ (`larsoner <https://github.com/larsoner>`__)
 
-       - description of enhancement/bugfix/API change (:gh:`xxxx` by
-         :newcontrib:`Firstname Lastname`)
+**Bugfixes**
 
-   Also add a corresponding entry for yourself in doc/changes/names.inc
+-  Do not set annotation channel when missing from input data when reading EDF `#12044 <https://github.com/mne-tools/mne-python/pull/12044>`__ (`paulroujansky <https://github.com/paulroujansky>`__)
+-  Mark tests as network tests `#12041 <https://github.com/mne-tools/mne-python/pull/12041>`__ (`mbalatsko <https://github.com/mbalatsko>`__)
+-  BUG: Fix bug with validation of info[“bads”] `#12039 <https://github.com/mne-tools/mne-python/pull/12039>`__ (`larsoner <https://github.com/larsoner>`__)
+-  Stack vertices in plot_volume_source_estimates `#12025 <https://github.com/mne-tools/mne-python/pull/12025>`__ (`mscheltienne <https://github.com/mscheltienne>`__)
+-  FIX: allow user to pick “eyegaze” or “pupil” (fix in triage_eyetrack_picks) `#12019 <https://github.com/mne-tools/mne-python/pull/12019>`__ (`scott-huberty <https://github.com/scott-huberty>`__)
+-  Raise warning instead of error when loading channel-specific annotations for missing channels `#12017 <https://github.com/mne-tools/mne-python/pull/12017>`__ (`paulroujansky <https://github.com/paulroujansky>`__)
+-  Correctly prune channel-specific annotations when creating Epochs `#12010 <https://github.com/mne-tools/mne-python/pull/12010>`__ (`mscheltienne <https://github.com/mscheltienne>`__)
 
-.. _current:
+**Documentation**
 
-Version 1.6.dev0 (development)
-------------------------------
+-  DOC: Remove make test `#12042 <https://github.com/mne-tools/mne-python/pull/12042>`__ (`larsoner <https://github.com/larsoner>`__)
+-  MAINT: Fix example `#12035 <https://github.com/mne-tools/mne-python/pull/12035>`__ (`larsoner <https://github.com/larsoner>`__)
+-  adding crossref from forward to create trans `#12033 <https://github.com/mne-tools/mne-python/pull/12033>`__ (`anaradanovic <https://github.com/anaradanovic>`__)
+-  Fix minor typo found by codespell `#12029 <https://github.com/mne-tools/mne-python/pull/12029>`__ (`DimitriPapadopoulos <https://github.com/DimitriPapadopoulos>`__)
+-  MAINT: Fix typos found by codespell `#12021 <https://github.com/mne-tools/mne-python/pull/12021>`__ (`DimitriPapadopoulos <https://github.com/DimitriPapadopoulos>`__)
+-  MRG: Suggest to use conda-libmamba-solver instead of mamba in install docs `#11944 <https://github.com/mne-tools/mne-python/pull/11944>`__ (`hoechenberger <https://github.com/hoechenberger>`__)
 
-Enhancements
-~~~~~~~~~~~~
-- Improve tests for saving splits with `Epochs` (:gh:`11884` by `Dmitrii Altukhov`_)
-- Added functionality for linking interactive figures together, such that changing one figure will affect another, see :ref:`tut-ui-events` and :mod:`mne.viz.ui_events`. Current figures implementing UI events are :func:`mne.viz.plot_topomap` and :func:`mne.viz.plot_source_estimates` (:gh:`11685` :gh:`11891` by `Marijn van Vliet`_)
-- HTML anchors for :class:`mne.Report` now reflect the ``section-title`` of the report items rather than using a global incrementor ``global-N`` (:gh:`11890` by `Eric Larson`_)
-- Added public :func:`mne.io.write_info` to complement :func:`mne.io.read_info` (:gh:`11918` by `Eric Larson`_)
-- Added option ``remove_dc`` to to :meth:`Raw.compute_psd() <mne.io.Raw.compute_psd>`, :meth:`Epochs.compute_psd() <mne.Epochs.compute_psd>`, and :meth:`Evoked.compute_psd() <mne.Evoked.compute_psd>`, to allow skipping DC removal when computing Welch or multitaper spectra (:gh:`11769` by `Nikolai Chapochnikov`_)
-- Add the possibility to provide a float between 0 and 1 as ``n_grad``, ``n_mag`` and ``n_eeg`` in `~mne.compute_proj_raw`, `~mne.compute_proj_epochs` and `~mne.compute_proj_evoked` to select the number of vectors based on the cumulative explained variance (:gh:`11919` by `Mathieu Scheltienne`_)
-- Added support for Artinis fNIRS data files to :func:`mne.io.read_raw_snirf` (:gh:`11926` by `Robert Luke`_)
-- Add helpful error messages when using methods on empty :class:`mne.Epochs`-objects (:gh:`11306` by `Martin Schulz`_)
-- Add inferring EEGLAB files' montage unit automatically based on estimated head radius using :func:`read_raw_eeglab(..., montage_units="auto") <mne.io.read_raw_eeglab>` (:gh:`11925` by `Jack Zhang`_, :gh:`11951` by `Eric Larson`_)
-- Add :class:`~mne.time_frequency.EpochsSpectrumArray` and :class:`~mne.time_frequency.SpectrumArray` to support creating power spectra from :class:`NumPy array <numpy.ndarray>` data (:gh:`11803` by `Alex Rockhill`_)
-- Add support for writing forward solutions to HDF5 and convenience function :meth:`mne.Forward.save` (:gh:`12036` by `Eric Larson`_)
-- Refactored internals of :func:`mne.read_annotations` (:gh:`11964` by `Paul Roujansky`_)
-- Enhance :func:`~mne.viz.plot_evoked_field` with a GUI that has controls for time, colormap, and contour lines (:gh:`11942` by `Marijn van Vliet`_)
+**Code health**
 
-Bugs
-~~~~
-- Fix bugs with :func:`mne.preprocessing.realign_raw` where the start of ``other`` was incorrectly cropped; and onsets and durations in ``other.annotations`` were left unsynced with the resampled data (:gh:`11950` by :newcontrib:`Qian Chu`)
-- Fix bug where ``encoding`` argument was ignored when reading annotations from an EDF file (:gh:`11958` by :newcontrib:`Andrew Gilbert`)
-- Mark tests ``test_adjacency_matches_ft`` and ``test_fetch_uncompressed_file`` as network tests (:gh:`12041` by :newcontrib:`Maksym Balatsko`)
-- Fix bugs with saving splits for :class:`~mne.Epochs` (:gh:`11876` by `Dmitrii Altukhov`_)
-- Fix bug with multi-plot 3D rendering where only one plot was updated (:gh:`11896` by `Eric Larson`_)
-- Fix bug where subject birthdays were not correctly read by :func:`mne.io.read_raw_snirf` (:gh:`11912` by `Eric Larson`_)
-- Fix bug with :func:`mne.chpi.compute_head_pos` for CTF data where digitization points were modified in-place, producing an incorrect result during a save-load round-trip (:gh:`11934` by `Eric Larson`_)
-- Fix bug where non-compliant stimulus data streams were not ignored by :func:`mne.io.read_raw_snirf` (:gh:`11915` by `Johann Benerradi`_)
-- Fix bug with ``pca=False`` in :func:`mne.minimum_norm.compute_source_psd` (:gh:`11927` by `Alex Gramfort`_)
-- Fix bug with notebooks when using PyVista 0.42 by implementing ``trame`` backend support (:gh:`11956` by `Eric Larson`_)
-- Removed preload parameter from :func:`mne.io.read_raw_eyelink`, because data are always preloaded no matter what preload is set to (:gh:`11910` by `Scott Huberty`_)
-- Fix bug with :meth:`mne.viz.Brain.get_view` where calling :meth:`~mne.viz.Brain.show_view` with returned parameters would change the view (:gh:`12000` by `Eric Larson`_)
-- Fix bug with :meth:`mne.viz.Brain.show_view` where ``distance=None`` would change the view distance (:gh:`12000` by `Eric Larson`_)
-- Fix bug with :meth:`~mne.viz.Brain.add_annotation` when reading an annotation from a file with both hemispheres shown (:gh:`11946` by `Marijn van Vliet`_)
-- Fix bug with axis clip box boundaries in :func:`mne.viz.plot_evoked_topo` and related functions (:gh:`11999` by `Eric Larson`_)
-- Fix bug with ``subject_info`` when loading data from and exporting to EDF file (:gh:`11952` by `Paul Roujansky`_)
-- Fix bug with delayed checking of :class:`info["bads"] <mne.Info>` (:gh:`12038` by `Eric Larson`_)
-- Fix handling of channel information in annotations when loading data from and exporting to EDF file (:gh:`11960` :gh:`12017` :gh:`12044` by `Paul Roujansky`_)
-- Add missing ``overwrite`` and ``verbose`` parameters to :meth:`Transform.save() <mne.transforms.Transform.save>` (:gh:`12004` by `Marijn van Vliet`_)
-- Fix parsing of eye-link :class:`~mne.Annotations` when ``apply_offsets=False`` is provided to :func:`~mne.io.read_raw_eyelink` (:gh:`12003` by `Mathieu Scheltienne`_)
-- Correctly prune channel-specific :class:`~mne.Annotations` when creating :class:`~mne.Epochs` without the channel(s) included in the channel specific annotations (:gh:`12010` by `Mathieu Scheltienne`_)
-- Fix :func:`~mne.viz.plot_volume_source_estimates` with :class:`~mne.VolSourceEstimate` which include a list of vertices (:gh:`12025` by `Mathieu Scheltienne`_)
-- Correctly handle passing ``"eyegaze"`` or ``"pupil"`` to :meth:`mne.io.Raw.pick` (:gh:`12019` by `Scott Huberty`_)
+-  MAINT: Speed up doc build `#12040 <https://github.com/mne-tools/mne-python/pull/12040>`__ (`larsoner <https://github.com/larsoner>`__)
+-  MAINT: Use PyPI upload action for published releases `#12037 <https://github.com/mne-tools/mne-python/pull/12037>`__ (`larsoner <https://github.com/larsoner>`__)
+-  [pre-commit.ci] pre-commit autoupdate `#12016 <https://github.com/mne-tools/mne-python/pull/12016>`__ (`pre-commit-ci[bot] <https://github.com/apps/pre-commit-ci>`__)
 
-API changes
-~~~~~~~~~~~
-- ``mne.preprocessing.apply_maxfilter`` and ``mne maxfilter`` have been deprecated and will be removed in 1.7. Use :func:`mne.preprocessing.maxwell_filter` (see :ref:`this tutorial <tut-artifact-sss>`) in Python or the command-line utility from MEGIN ``maxfilter`` and :func:`mne.bem.fit_sphere_to_headshape` instead (:gh:`11938` by `Eric Larson`_)
-- :func:`mne.io.kit.read_mrk` reading pickled files is deprecated using something like ``np.savetxt(fid, pts, delimiter="\t", newline="\n")`` to save your points instead (:gh:`11937` by `Eric Larson`_)
-- Replace legacy ``inst.pick_channels`` and ``inst.pick_types`` with ``inst.pick`` (where ``inst`` is an instance of :class:`~mne.io.Raw`, :class:`~mne.Epochs`, or :class:`~mne.Evoked`) wherever possible (:gh:`11907` by `Clemens Brunner`_)
-- The ``reset_camera`` parameter has been removed in favor of ``distance="auto"`` in :func:`mne.viz.set_3d_view`, :meth:`mne.viz.Brain.show_view`, and related functions (:gh:`12000` by `Eric Larson`_)
+**Merged pull requests:**
+
+-  Bump actions/checkout from 3 to 4 `#12046 <https://github.com/mne-tools/mne-python/pull/12046>`__ (`dependabot[bot] <https://github.com/apps/dependabot>`__)
+-  MAINT, DOC: add eyetracking & Dipole convention for loc array to Info class API `#12023 <https://github.com/mne-tools/mne-python/pull/12023>`__ (`scott-huberty <https://github.com/scott-huberty>`__)
+-  BUG: Fix doc building bugs `#12009 <https://github.com/mne-tools/mne-python/pull/12009>`__ (`larsoner <https://github.com/larsoner>`__)
+-  MAINT: Link to sg_execution_times `#12008 <https://github.com/mne-tools/mne-python/pull/12008>`__ (`larsoner <https://github.com/larsoner>`__)
+-  Add EvokedField.plotter `#12005 <https://github.com/mne-tools/mne-python/pull/12005>`__ (`wmvanvliet <https://github.com/wmvanvliet>`__)
+-  Add the missing overwrite and verbose parameters to Transform.save `#12004 <https://github.com/mne-tools/mne-python/pull/12004>`__ (`wmvanvliet <https://github.com/wmvanvliet>`__)
+-  [MRG] Don’t look for an offset in an eyelink message if the message contains only 2 elements `#12003 <https://github.com/mne-tools/mne-python/pull/12003>`__ (`mscheltienne <https://github.com/mscheltienne>`__)
+-  [pre-commit.ci] pre-commit autoupdate `#12002 <https://github.com/mne-tools/mne-python/pull/12002>`__ (`pre-commit-ci[bot] <https://github.com/apps/pre-commit-ci>`__)
+-  BUG: Fix bug with get_view `#12000 <https://github.com/mne-tools/mne-python/pull/12000>`__ (`larsoner <https://github.com/larsoner>`__)
+-  BUG: Fix bug with clip box setting `#11999 <https://github.com/mne-tools/mne-python/pull/11999>`__ (`larsoner <https://github.com/larsoner>`__)
+-  more dev reports infrastructure `#11997 <https://github.com/mne-tools/mne-python/pull/11997>`__ (`drammock <https://github.com/drammock>`__)
+-  Fix \_check_edflib_installed `#11996 <https://github.com/mne-tools/mne-python/pull/11996>`__ (`mscheltienne <https://github.com/mscheltienne>`__)
+-  MAINT: Replace in1d with isin `#11994 <https://github.com/mne-tools/mne-python/pull/11994>`__ (`larsoner <https://github.com/larsoner>`__)
+-  MAINT: Switch to scheduled runs for macOS [skip azp] [skip actions] `#11993 <https://github.com/mne-tools/mne-python/pull/11993>`__ (`larsoner <https://github.com/larsoner>`__)
+-  Add mscheltienne to codeowners `#11989 <https://github.com/mne-tools/mne-python/pull/11989>`__ (`mscheltienne <https://github.com/mscheltienne>`__)
+-  [pre-commit.ci] pre-commit autoupdate `#11988 <https://github.com/mne-tools/mne-python/pull/11988>`__ (`pre-commit-ci[bot] <https://github.com/apps/pre-commit-ci>`__)
+-  update codeowners agramfort `#11987 <https://github.com/mne-tools/mne-python/pull/11987>`__ (`agramfort <https://github.com/agramfort>`__)
+-  Add ADAM2392 to codeowners `#11983 <https://github.com/mne-tools/mne-python/pull/11983>`__ (`adam2392 <https://github.com/adam2392>`__)
+-  MAINT: Fix notebook `#11982 <https://github.com/mne-tools/mne-python/pull/11982>`__ (`larsoner <https://github.com/larsoner>`__)
+-  Add Richard to CODEOWNERS `#11981 <https://github.com/mne-tools/mne-python/pull/11981>`__ (`hoechenberger <https://github.com/hoechenberger>`__)
+-  Bump actions/checkout from 3 to 4 `#11980 <https://github.com/mne-tools/mne-python/pull/11980>`__ (`dependabot[bot] <https://github.com/apps/dependabot>`__)
+-  Add cbrnr to codeowners `#11979 <https://github.com/mne-tools/mne-python/pull/11979>`__ (`cbrnr <https://github.com/cbrnr>`__)
+-  Deprecate complex spectrum obj `#11978 <https://github.com/mne-tools/mne-python/pull/11978>`__ (`drammock <https://github.com/drammock>`__)
+-  [MAINT] Add Marijn to codeowners `#11976 <https://github.com/mne-tools/mne-python/pull/11976>`__ (`wmvanvliet <https://github.com/wmvanvliet>`__)
+-  MAINT: Add maintenance tool to check status `#11975 <https://github.com/mne-tools/mne-python/pull/11975>`__ (`larsoner <https://github.com/larsoner>`__)
+-  [MAINT] Add to codeowners `#11974 <https://github.com/mne-tools/mne-python/pull/11974>`__ (`alexrockhill <https://github.com/alexrockhill>`__)
+-  MAINT: Add rob-luke to CODEOWNERS `#11972 <https://github.com/mne-tools/mne-python/pull/11972>`__ (`larsoner <https://github.com/larsoner>`__)
+-  mailmap updates `#11971 <https://github.com/mne-tools/mne-python/pull/11971>`__ (`drammock <https://github.com/drammock>`__)
+-  MAINT: Refactor codeowners `#11970 <https://github.com/mne-tools/mne-python/pull/11970>`__ (`larsoner <https://github.com/larsoner>`__)
+-  MAINT: Test notebook on Windows `#11965 <https://github.com/mne-tools/mne-python/pull/11965>`__ (`larsoner <https://github.com/larsoner>`__)
+-  Make ``_read_annotations_edf()`` and ``_read_annotations_txt()`` return an ``mne.Annotations`` instance `#11964 <https://github.com/mne-tools/mne-python/pull/11964>`__ (`paulroujansky <https://github.com/paulroujansky>`__)
+-  Use newer ipympl package for drawing matplotlib figures into a notebook `#11962 <https://github.com/mne-tools/mne-python/pull/11962>`__ (`wmvanvliet <https://github.com/wmvanvliet>`__)
+-  Handle channel information in annotations when loading data from and exporting to EDF file `#11960 <https://github.com/mne-tools/mne-python/pull/11960>`__ (`paulroujansky <https://github.com/paulroujansky>`__)
+-  Fix encoding in read_annotations_edf `#11958 <https://github.com/mne-tools/mne-python/pull/11958>`__ (`adgilbert <https://github.com/adgilbert>`__)
+-  update MNE-C install docs `#11957 <https://github.com/mne-tools/mne-python/pull/11957>`__ (`drammock <https://github.com/drammock>`__)
+-  MAINT: Update to use trame backend `#11956 <https://github.com/mne-tools/mne-python/pull/11956>`__ (`larsoner <https://github.com/larsoner>`__)
+-  remove compat code for versions we no longer support `#11955 <https://github.com/mne-tools/mne-python/pull/11955>`__ (`drammock <https://github.com/drammock>`__)
+-  [pre-commit.ci] pre-commit autoupdate `#11954 <https://github.com/mne-tools/mne-python/pull/11954>`__ (`pre-commit-ci[bot] <https://github.com/apps/pre-commit-ci>`__)
+-  Refactor writing raw file `#11953 <https://github.com/mne-tools/mne-python/pull/11953>`__ (`dmalt <https://github.com/dmalt>`__)
+-  Fix bug with subject_info when loading from and exporting to EDF file `#11952 <https://github.com/mne-tools/mne-python/pull/11952>`__ (`paulroujansky <https://github.com/paulroujansky>`__)
+-  MAINT: Simplify logic for radius `#11951 <https://github.com/mne-tools/mne-python/pull/11951>`__ (`larsoner <https://github.com/larsoner>`__)
+-  Fix realign_raw and test_realign `#11950 <https://github.com/mne-tools/mne-python/pull/11950>`__ (`qian-chu <https://github.com/qian-chu>`__)
+-  MAINT: Work around seaborn<->pandas warning `#11948 <https://github.com/mne-tools/mne-python/pull/11948>`__ (`larsoner <https://github.com/larsoner>`__)
+-  Fix bug with Brain.add_annotation when reading from file `#11946 <https://github.com/mne-tools/mne-python/pull/11946>`__ (`wmvanvliet <https://github.com/wmvanvliet>`__)
+-  Interactive version of plot_evoked_fieldmap `#11942 <https://github.com/mne-tools/mne-python/pull/11942>`__ (`wmvanvliet <https://github.com/wmvanvliet>`__)
+-  MAINT: Fix examples for newer pandas `#11940 <https://github.com/mne-tools/mne-python/pull/11940>`__ (`larsoner <https://github.com/larsoner>`__)
+-  API: Deprecate mne maxfilter `#11939 <https://github.com/mne-tools/mne-python/pull/11939>`__ (`larsoner <https://github.com/larsoner>`__)
+-  Fix some security issues and add Bandit to our CIs `#11937 <https://github.com/mne-tools/mne-python/pull/11937>`__ (`drammock <https://github.com/drammock>`__)
+-  DOC: update name of changelog in contributing guide `#11935 <https://github.com/mne-tools/mne-python/pull/11935>`__ (`scott-huberty <https://github.com/scott-huberty>`__)
+-  BUG: Fix bug with CTF data `#11934 <https://github.com/mne-tools/mne-python/pull/11934>`__ (`larsoner <https://github.com/larsoner>`__)
+-  MAINT: Use automatic weakref decorator `#11932 <https://github.com/mne-tools/mne-python/pull/11932>`__ (`larsoner <https://github.com/larsoner>`__)
+
+`v1.5.1 <https://github.com/mne-tools/mne-python/main>`__ (2023-09-06)
+----------------------------------------------------------------------


### PR DESCRIPTION
Closes #11508

- [x] Get basics in
- [ ] Tweak aesthetics
- [ ] Add post-processing for mne.* resolution
- [ ] Fix "Co-Authored-By" omission
- [ ] Fix removal of last couple of lines
- [ ] Turn into GitHub action that runs every night before the doc build (maybe)
- [ ] Merge after 1.6 is released

| main | PR |
| -- | -- |
| <img width="698" alt="Screenshot 2023-10-02 at 10 18 40 PM" src="https://github.com/mne-tools/mne-python/assets/2365790/fadada52-54e7-49f2-9578-04d0d417ea6a"> | <img width="789" alt="Screenshot 2023-10-03 at 12 01 23 AM" src="https://github.com/mne-tools/mne-python/assets/2365790/a5b4c9e5-6d0d-4ab2-bffb-d949ea885d69"> |

We could in theory also change these to actual names, but I don't mind leaving that for `doc/authors.html` instead.