### PR TITLE
MAINT: Auto-update installer link for old doc versions

### DIFF
--- a/doc/_static/update_installer_version.js
+++ b/doc/_static/update_installer_version.js
@@ -1,0 +1,55 @@
+async function getRelease() {
+    result = await fetch("https://api.github.com/repos/mne-tools/mne-installers/releases/latest");
+    data = await result.json();
+    return data;
+}
+async function warnVersion() {
+    data = await getRelease();
+    // Take v1.5.1 for example and change to 1.5
+    ids = ["linux-installers", "macos-intel-installers", "macos-apple-installers", "windows-installers"];
+    warn = false;
+    ids.forEach((id) => {
+        label_id = document.getElementById(id);
+        // tab is immediately after label
+        children = [].slice.call(label_id.parentNode.children);
+        div = children[children.indexOf(label_id) + 1];
+        a = div.children[0].children[0];  // div->p->a
+        ending = a.href.split("-").slice(-1)[0];  // Should be one of: ["macOS_Intel.pkg", "macOS_M1.pkg", "Linux.sh", "Windows.exe"]
+        data["assets"].every((asset) => {
+            // find the matching asset
+            if (!asset["browser_download_url"].endsWith(ending)) {
+                return true;  // continue
+            }
+            old_stem = a.href.split("/").slice(-1)[0];
+            new_stem = asset["browser_download_url"].split("/").slice(-1)[0];
+            a.href = asset["browser_download_url"];
+            // also replace the command on Linux
+            if (ending === "Linux.sh") {
+                code = document.getElementById("codecell0");
+            }
+            if (!warn) {
+                // MNE-Python-1.5.1_0-Linux.sh to 1.5 for example
+                old_ver = old_stem.split("-").slice(2)[0].split("_")[0].split(".").slice(0, 2).join(".");
+                new_ver = new_stem.split("-").slice(2)[0].split("_")[0].split(".").slice(0, 2).join(".");
+                if (old_ver !== new_ver) {
+                    warn = `The installers below are for version ${new_ver} as ${old_ver} is no longer supported`;
+                }
+            }
+            return false;  // do not continue
+        });
+    });
+    if (warn) {
+        let outer = document.createElement("div");
+        let title = document.createElement("p");
+        let inner = document.createElement("p");
+        outer.setAttribute("class", "admonition warning");
+        title.setAttribute("class", "admonition-title");
+        title.innerText = "Warning";
+        inner.innerText = warn;
+        outer.append(title, inner);
+        document.querySelectorAll('.platform-selector-tabset')[0].before(outer);
+    }
+}
+document.addEventListener('DOMContentLoaded', function () {
+    warnVersion();
+});

--- a/doc/install/installers.rst
+++ b/doc/install/installers.rst
@@ -78,6 +78,9 @@ Got any questions? Let us know on the `MNE Forum`_!
 
         **Supported platforms:** Windows 10 and newer
 
+.. raw:: html
+
+  <script async="async" src="../_static/update_installer_version.js"></script>
 
 First steps
 ^^^^^^^^^^^
@@ -137,7 +140,7 @@ interpreter.
         // just default to showing the first of the 2 macOS tabs
         platform = "macos-intel";
       }
-     $(document).ready(function(){
+      document.addEventListener('DOMContentLoaded', function() {
          let all_tab_nodes = document.querySelectorAll(
              '.platform-selector-tabset')[0].children;
          let input_nodes = [...all_tab_nodes].filter(


### PR DESCRIPTION
Closes #10451

Not sure it will save us too much maintenance burden in its current form but it will at least update links for 1.5 once we release 1.6.

If I change the `!==` conditional to `===` then we get a nice warning:

<img width="916" alt="Screenshot 2023-10-03 at 2 43 36 PM" src="https://github.com/mne-tools/mne-python/assets/2365790/10219bc2-783c-440e-9888-1381bdb16a64">

Also fixes a bug where the jQuery tab selection JS with `$(` no longer works because pydata-sphinx-theme dropped jQuery.