### PR TITLE
clean  up some deprecations

### DIFF
--- a/mne/io/__init__.py
+++ b/mne/io/__init__.py
@@ -7,15 +7,11 @@
 
 import lazy_loader as lazy
 
-__getattr_lz__, __dir__, __all__ = lazy.attach(
+__getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submodules=[
         "constants",
         "pick",
-        # Remove these three in 1.6 along with their .py files
-        "proj",
-        "meas_info",
-        "reference",
     ],
     submod_attrs={
         "base": ["BaseRaw", "concatenate_raws", "match_channel_orders"],
@@ -61,42 +57,3 @@ __getattr_lz__, __dir__, __all__ = lazy.attach(
         ],
     },
 )
-
-
-# Remove in 1.6 and change __getattr_lz__ to __getattr__
-from ..utils import warn as _warn
-from .._fiff.reference import (
-    set_eeg_reference as _set_eeg_reference,
-    set_bipolar_reference as _set_bipolar_reference,
-    add_reference_channels as _add_referenc_channels,
-)
-from .._fiff.meas_info import Info as _Info
-
-
-def __getattr__(name):
-    """Try getting attribute from fiff submodule."""
-    if name in (
-        "set_eeg_reference",
-        "set_bipolar_reference",
-        "add_reference_channels",
-    ):
-        _warn(
-            f"mne.io.{name} is deprecated and will be removed in 1.6, "
-            "use mne.{name} instead",
-            FutureWarning,
-        )
-        return globals()[f"_{name}"]
-    elif name == "RawFIF":
-        _warn(
-            "RawFIF is deprecated and will be removed in 1.6, use Raw instead",
-            FutureWarning,
-        )
-        name = "Raw"
-    elif name == "Info":
-        _warn(
-            "mne.io.Info is deprecated and will be removed in 1.6, "
-            "use mne.Info instead",
-            FutureWarning,
-        )
-        return _Info
-    return __getattr_lz__(name)

--- a/mne/io/tests/test_deprecation.py
+++ b/mne/io/tests/test_deprecation.py
@@ -4,7 +4,6 @@
 #
 # License: BSD-3-Clause
 
-from mne.io import Raw
 import pytest
 
 
@@ -28,12 +27,3 @@ def test_deprecation():
 
     with pytest.warns(FutureWarning, match=r"mne\.io\.meas_info\.read_info is dep"):
         meas_info.read_info
-    with pytest.warns(FutureWarning, match="RawFIF is deprecated"):
-        mne.io.RawFIF
-    with pytest.warns(FutureWarning, match="RawFIF is deprecated"):
-        from mne.io import RawFIF
-    assert RawFIF is Raw
-    with pytest.warns(FutureWarning, match="set_eeg_reference is deprecated"):
-        mne.io.set_eeg_reference
-    with pytest.warns(FutureWarning, match=r"use mne\.Info instead"):
-        mne.io.Info

--- a/mne/source_space/__init__.py
+++ b/mne/source_space/__init__.py
@@ -2,7 +2,7 @@
 
 import lazy_loader as lazy
 
-__getattr_lz__, __dir__, __all__ = lazy.attach(
+__getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submodules=["_source_space"],
     submod_attrs={
@@ -20,35 +20,3 @@ __getattr_lz__, __dir__, __all__ = lazy.attach(
         ],
     },
 )
-
-
-from . import _source_space
-from ..utils import warn as _warn
-
-
-def __getattr__(name):
-    msg = out = None
-    try:
-        return __getattr_lz__(name)
-    except AttributeError:
-        try:
-            out = getattr(_source_space, name)
-        except AttributeError:
-            pass  # will raise original error below
-        else:
-            # These should be removed (they're in the MNE namespace)
-            msg = f"mne.source_space.{name} is deprecated and will be removed in 1.6, "
-            if name in (
-                "read_freesurfer_lut",
-                "get_mni_fiducials",
-                "get_volume_labels_from_aseg",
-                "get_volume_labels_from_src",
-            ):
-                msg += f"use mne.{name} instead"
-            else:
-                msg += "use public API instead"
-        if out is None:
-            raise
-    if msg is not None:
-        _warn(msg, FutureWarning)
-    return out

--- a/mne/source_space/tests/test_source_space.py
+++ b/mne/source_space/tests/test_source_space.py
@@ -1020,12 +1020,6 @@ def test_get_decimated_surfaces(src, n, nv):
         assert_array_equal(np.unique(s["tris"]), np.arange(nv))
 
 
-def test_deprecation():
-    """Test deprecation of mne.source_space functions."""
-    with pytest.warns(FutureWarning, match="use mne.get_volume_labels_from_src"):
-        mne.source_space.get_volume_labels_from_src
-
-
 # The following code was used to generate small-src.fif.gz.
 # Unfortunately the C code bombs when trying to add source space distances,
 # possibly due to incomplete "faking" of a smaller surface on our part here.


### PR DESCRIPTION
these are some things that need to happen before converting our lazy imports to type stubs. NB @hoechenberger: I have a script working locally that automatically generates *ALL* `.pyi` files and also automatically changes all `__init__.py` files to use `attach_stub()`, but it needs this PR first.