### PR TITLE
added missing docstring for a public class method.

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2640,6 +2640,24 @@ class _RawFidWriter:
         self.cfg = cfg
 
     def write(self, fid, part_idx, prev_fname, next_fname):
+        """Write raw data to a file.
+
+        Parameters
+        ----------
+        fid : file object
+            The file object to which the raw data will be written.
+        part_idx : int
+            The index of the current part being written.
+        prev_fname : str
+            The filename of the previous part.
+        next_fname : str
+            The filename of the next part.
+
+        Returns
+        -------
+        bool
+            True if there are more parts to write, False otherwise.
+        """
         self._check_start_stop_within_bounds()
         start_block(fid, FIFF.FIFFB_MEAS)
         _write_raw_metadata(


### PR DESCRIPTION

#### Reference issue
Example: added missing docstring for a public class method.


#### What does this implement/fix?

Per the feedback on my last PR (thanks, btw!) I wanted to attempt a docstring update based on the desired repository requirements -- specifically public function defs that aren't using @copy_doc or @copy_function_doc_to_method_doc that don't currently have a docstring.  I've only made one change to make sure i'm getting this correct before looking for more.  Any feedback is welcome!

Note: The method is public, but the class does start with a _ -- This wasn't discussed in the comments of my last PR, so I figured i'd submit anyway, but if you don't want any documentation whatsoever for classes that start with _ (regardless of whether the documented method is public) just let me know and I'm happy to close the PR. thanks!

#### Additional information
Added docstring to the "write" method in the _RawFidWriter
