### PR TITLE
MNT: add "doc/api/generated" to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ mne/viz/_brain/tests/.ipynb_checkpoints
 
 dist/
 doc/_build/
+doc/api/generated/
 doc/generated/
 doc/auto_examples/
 doc/auto_tutorials/


### PR DESCRIPTION
- I _think_ that after PR #12043 , we need to update `.gitignore` to include `doc/api/generated` ? At least on my local computer, `doc/api/generated/*` showed up in my untracked files after building the docs locally.

edit: Sorry for using CI resources on this without checking first.