### PR TITLE
MAINT: isort

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,3 @@
 e81ec528a42ac687f3d961ed5cf8e25f236925b0  # black
-20737c0bd7c0dafee0a00caa1dba8ce573fd0f53  # move SetChannelsMixin between files
 12395f9d9cf6ea3c72b225b62e052dd0d17d9889  # YAML indentation
+d6d2f8c6a2ed4a0b27357da9ddf8e0cd14931b59  # isort


### PR DESCRIPTION
Self-merging without CIs because this one is trivial. Removed `SetChannelsMixin` one because it doesn't show up in `git log` (must have been squash-merged?)