### PR TITLE
restore original location of API stubs

### DIFF
--- a/doc/api/covariance.rst
+++ b/doc/api/covariance.rst
@@ -5,7 +5,7 @@ Covariance computation
 .. currentmodule:: mne
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    Covariance
    compute_covariance

--- a/doc/api/creating_from_arrays.rst
+++ b/doc/api/creating_from_arrays.rst
@@ -5,7 +5,7 @@ Creating data objects from arrays
 .. currentmodule:: mne
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    EvokedArray
    EpochsArray

--- a/doc/api/datasets.rst
+++ b/doc/api/datasets.rst
@@ -11,7 +11,7 @@ Datasets
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    fetch_dataset
    has_dataset

--- a/doc/api/decoding.rst
+++ b/doc/api/decoding.rst
@@ -11,7 +11,7 @@ Decoding
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    CSP
    EMS
@@ -33,7 +33,7 @@ Decoding
 Functions that assist with decoding and model fitting:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    compute_ems
    cross_val_multiscore

--- a/doc/api/events.rst
+++ b/doc/api/events.rst
@@ -5,7 +5,7 @@ Events
 .. currentmodule:: mne
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    Annotations
    AcqParserFIF
@@ -35,7 +35,7 @@ Events
 .. currentmodule:: mne.event
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    define_target_events
    match_event_names
@@ -50,7 +50,7 @@ Events
 .. currentmodule:: mne.epochs
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    average_movements
    combine_event_ids

--- a/doc/api/export.rst
+++ b/doc/api/export.rst
@@ -11,7 +11,7 @@ Exporting
 .. currentmodule:: mne.export
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    export_epochs
    export_evokeds

--- a/doc/api/file_io.rst
+++ b/doc/api/file_io.rst
@@ -4,7 +4,7 @@ File I/O
 .. currentmodule:: mne
 
 .. autosummary::
-   :toctree: generated
+   :toctree: ../generated/
 
    channel_type
    channel_indices_by_type
@@ -60,7 +60,7 @@ File I/O
 Base class:
 
 .. autosummary::
-   :toctree: generated
+   :toctree: ../generated/
    :template: autosummary/class_no_members.rst
 
    BaseEpochs

--- a/doc/api/forward.rst
+++ b/doc/api/forward.rst
@@ -5,14 +5,14 @@ Forward Modeling
 .. currentmodule:: mne
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
    :template: autosummary/class_no_inherited_members.rst
 
    Forward
    SourceSpaces
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    add_source_space_distances
    apply_forward
@@ -55,7 +55,7 @@ Forward Modeling
 .. currentmodule:: mne.bem
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    ConductorModel
    fit_sphere_to_headshape

--- a/doc/api/inverse.rst
+++ b/doc/api/inverse.rst
@@ -11,7 +11,7 @@ Inverse Solutions
 .. currentmodule:: mne.minimum_norm
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    InverseOperator
    apply_inverse
@@ -43,7 +43,7 @@ Inverse Solutions
 .. currentmodule:: mne.inverse_sparse
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    mixed_norm
    tf_mixed_norm
@@ -59,7 +59,7 @@ Inverse Solutions
 .. currentmodule:: mne.beamformer
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    Beamformer
    read_beamformer
@@ -80,7 +80,7 @@ Inverse Solutions
 .. currentmodule:: mne
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    Dipole
    DipoleFixed
@@ -95,6 +95,6 @@ Inverse Solutions
 .. currentmodule:: mne.dipole
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    get_phantom_dipoles

--- a/doc/api/logging.rst
+++ b/doc/api/logging.rst
@@ -5,7 +5,7 @@ Logging and Configuration
 .. currentmodule:: mne
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    get_config_path
    get_config
@@ -28,7 +28,7 @@ Logging and Configuration
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    deprecated
    warn
@@ -42,7 +42,7 @@ Logging and Configuration
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    get_cuda_memory
    init_cuda

--- a/doc/api/most_used_classes.rst
+++ b/doc/api/most_used_classes.rst
@@ -4,7 +4,7 @@ Most-used classes
 .. currentmodule:: mne
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    io.Raw
    Epochs

--- a/doc/api/mri.rst
+++ b/doc/api/mri.rst
@@ -16,7 +16,7 @@ See also:
 - :func:`mne-gui-addons:mne_gui_addons.locate_ieeg`.
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    coreg.get_mni_fiducials
    coreg.estimate_head_mri_t

--- a/doc/api/preprocessing.rst
+++ b/doc/api/preprocessing.rst
@@ -7,13 +7,13 @@ Projections:
 .. currentmodule:: mne
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
    :template: autosummary/class_no_inherited_members.rst
 
    Projection
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    compute_proj_epochs
    compute_proj_evoked
@@ -30,7 +30,7 @@ Projections:
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    Layout
    DigMontage
@@ -72,7 +72,7 @@ Projections:
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    ICA
    Xdawn
@@ -124,7 +124,7 @@ Projections:
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    optical_density
    beer_lambert_law
@@ -142,7 +142,7 @@ Projections:
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    project_sensors_onto_brain
    make_montage_volume
@@ -157,7 +157,7 @@ Projections:
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    Calibration
    read_eyelink_calibration
@@ -169,7 +169,7 @@ EEG referencing:
 .. currentmodule:: mne
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    add_reference_channels
    set_bipolar_reference
@@ -184,7 +184,7 @@ EEG referencing:
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    construct_iir_filter
    create_filter
@@ -202,7 +202,7 @@ EEG referencing:
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    compute_chpi_amplitudes
    compute_chpi_snr
@@ -226,7 +226,7 @@ EEG referencing:
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    Transform
    quat_to_rot

--- a/doc/api/reading_raw_data.rst
+++ b/doc/api/reading_raw_data.rst
@@ -10,7 +10,7 @@ Reading raw data
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    anonymize_info
    read_raw
@@ -44,7 +44,7 @@ Reading raw data
 Base class:
 
 .. autosummary::
-   :toctree: generated
+   :toctree: ../generated/
    :template: autosummary/class_no_members.rst
 
    BaseRaw
@@ -58,6 +58,6 @@ Base class:
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    read_mrk

--- a/doc/api/report.rst
+++ b/doc/api/report.rst
@@ -7,7 +7,7 @@ MNE-Report
 .. currentmodule:: mne
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    Report
    open_report

--- a/doc/api/sensor_space.rst
+++ b/doc/api/sensor_space.rst
@@ -5,7 +5,7 @@ Sensor Space Data
 .. currentmodule:: mne
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    combine_evoked
    concatenate_raws
@@ -33,6 +33,6 @@ Sensor Space Data
 .. currentmodule:: mne.baseline
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    rescale

--- a/doc/api/simulation.rst
+++ b/doc/api/simulation.rst
@@ -11,7 +11,7 @@ Simulation
 .. currentmodule:: mne.simulation
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    add_chpi
    add_ecg
@@ -33,7 +33,7 @@ Simulation
 .. currentmodule:: mne.simulation.metrics
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    cosine_score
    region_localization_error

--- a/doc/api/source_space.rst
+++ b/doc/api/source_space.rst
@@ -5,7 +5,7 @@ Source Space Data
 .. currentmodule:: mne
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    BiHemiLabel
    Label

--- a/doc/api/statistics.rst
+++ b/doc/api/statistics.rst
@@ -16,7 +16,7 @@ Parametric statistics (see :mod:`scipy.stats` and :mod:`statsmodels` for more
 options):
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    ttest_1samp_no_p
    ttest_ind_no_p
@@ -29,7 +29,7 @@ options):
 Mass-univariate multiple comparison correction:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    bonferroni_correction
    fdr_correction
@@ -37,7 +37,7 @@ Mass-univariate multiple comparison correction:
 Non-parametric (clustering) resampling methods:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    combine_adjacency
    permutation_cluster_test
@@ -53,7 +53,7 @@ Compute ``adjacency`` matrices for cluster-level statistics:
 .. currentmodule:: mne
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    channels.find_ch_adjacency
    channels.read_ch_adjacency

--- a/doc/api/time_frequency.rst
+++ b/doc/api/time_frequency.rst
@@ -11,7 +11,7 @@ Time-Frequency
 .. currentmodule:: mne.time_frequency
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    AverageTFR
    EpochsTFR
@@ -24,7 +24,7 @@ Time-Frequency
 Functions that operate on mne-python objects:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    csd_tfr
    csd_fourier
@@ -43,7 +43,7 @@ Functions that operate on mne-python objects:
 Functions that operate on ``np.ndarray`` objects:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    csd_array_fourier
    csd_array_multitaper
@@ -70,7 +70,7 @@ Functions that operate on ``np.ndarray`` objects:
 .. currentmodule:: mne.time_frequency.tfr
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    cwt
    morlet

--- a/doc/api/visualization.rst
+++ b/doc/api/visualization.rst
@@ -11,7 +11,7 @@ Visualization
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    Brain
    ClickableImage
@@ -99,7 +99,7 @@ Eyetracking
    :no-members:
    :no-inherited-members:
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    plot_gaze
 
@@ -115,7 +115,7 @@ UI Events
    :no-inherited-members:
 
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    subscribe
    unsubscribe


### PR DESCRIPTION
after #12403 the URL of API pages moved from `generated/` to `api/generated/`. This will break lots of links from the forum (as pointed out by @mscheltienne) and will also break the version switcher's ability to find corresponding pages in different docs versions.

This PR puts the autodoc stub files back where they used to be, to avoid all that badness.

supersedes / closes #12100 