### PR TITLE
Better error message when a bad method type is provided

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -72,6 +72,7 @@ Bugs
 - Add support for non-ASCII characters in Annotations, Evoked comments, etc when saving to FIFF format (:gh:`12080` by `Daniel McCloy`_)
 - Correctly handle passing ``"eyegaze"`` or ``"pupil"`` to :meth:`mne.io.Raw.pick` (:gh:`12019` by `Scott Huberty`_)
 - Fix bug with :func:`~mne.viz.plot_raw` where changing ``MNE_BROWSER_BACKEND`` via :func:`~mne.set_config` would have no effect within a Python session (:gh:`12078` by `Santeri Ruuskanen`_)
+- Improve handling of ``method`` argument in the channel interpolation function to support :class:`str` and raise helpful error messages (:gh:`12113` by `Mathieu Scheltienne`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -893,7 +893,8 @@ class InterpolationMixin:
         for key in method:
             _check_option("method[key]", key, ("meg", "eeg", "fnirs"))
             _check_option(f"method['{key}']", method[key], valids[key])
-        if _picks_to_idx(self.info, list(method), exclude=()).size == 0:
+        idx = _picks_to_idx(self.info, list(method), exclude=())
+        if idx.size == 0 or len(pick_info(self.info, idx)["bads"]) == 0:
             warn("No bad channels to interpolate. Doing nothing...")
             return self
         logger.info("Interpolating bad channels.")

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -886,7 +886,6 @@ class InterpolationMixin:
         keys2delete = set(method) - set(ch_types)
         for key in keys2delete:
             del method[key]
-        logger.info("Setting channel interpolation method to %s.", method)
         valids = {
             "eeg": ("spline", "MNE", "nan"),
             "meg": ("MNE", "nan"),
@@ -895,6 +894,7 @@ class InterpolationMixin:
         for key in method:
             _check_option("method[key]", key, ("meg", "eeg", "fnirs"))
             _check_option(f"method['{key}']", method[key], valids[key])
+        logger.info("Setting channel interpolation method to %s.", method)
         idx = _picks_to_idx(self.info, list(method), exclude=(), allow_empty=True)
         if idx.size == 0 or len(pick_info(self.info, idx)["bads"]) == 0:
             warn("No bad channels to interpolate. Doing nothing...")

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -833,7 +833,7 @@ class InterpolationMixin:
             Method to use for each channel type.
 
             - ``"meg"`` channels support ``"MNE"`` (default) and ``"nan"``
-            - ``"eeg"`` channels support ``"spline" (default), ``"MNE"`` and ``"nan"``
+            - ``"eeg"`` channels support ``"spline"`` (default), ``"MNE"`` and ``"nan"``
             - ``"fnirs"`` channels support ``"nearest"`` (default) and ``"nan"``
 
             None is an alias for::

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -861,9 +861,9 @@ class InterpolationMixin:
 
         Notes
         -----
-        .. versionadded:: 0.9.0
-
         The ``"MNE"`` method uses minimum-norm projection to a sphere and back.
+
+        .. versionadded:: 0.9.0
         """
         from .interpolation import (
             _interpolate_bads_eeg,

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -840,7 +840,7 @@ class InterpolationMixin:
 
                 method=dict(meg="MNE", eeg="spline", fnirs="nearest")
 
-            If a :class:`str` is provided, the method will be applied to all channels
+            If a :class:`str` is provided, the method will be applied to all channel
             types supported and available in the instance. The method ``"nan"`` will
             replace the channel data with ``np.nan``.
 
@@ -880,7 +880,7 @@ class InterpolationMixin:
         for ch_type in ("meg", "fnirs"):
             for sub_ch_type in _second_rules[ch_type][1].values():
                 if sub_ch_type in ch_types:
-                    del ch_types[ch_types.index(sub_ch_type)]
+                    ch_types.remove(sub_ch_type)
                     if ch_type not in ch_types:
                         ch_types.append(ch_type)
         keys2delete = set(method) - set(ch_types)
@@ -901,7 +901,7 @@ class InterpolationMixin:
             return self
         logger.info("Interpolating bad channels.")
         origin = _check_origin(origin, self.info)
-        if "eeg" in method and method["eeg"] == "spline":
+        if method.get("eeg", "") == "spline":
             _interpolate_bads_eeg(self, origin=origin, exclude=exclude)
             eeg_mne = False
         elif "eeg" not in method:

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -1014,7 +1014,7 @@ class _BuiltinChannelAdjacency:
 
 
 _ft_neighbor_url_t = string.Template(
-    "https://github.com/fieldtrip/fieldtrip/raw/master/" "template/neighbours/$fname"
+    "https://github.com/fieldtrip/fieldtrip/raw/master/template/neighbours/$fname"
 )
 
 _BUILTIN_CHANNEL_ADJACENCIES = [

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -872,6 +872,7 @@ class InterpolationMixin:
         )
 
         _check_preload(self, "interpolation")
+        _validate_type(method, (dict, None), "method")
         method = _handle_default("interpolation_method", method)
         for key in method:
             _check_option("method[key]", key, ("meg", "eeg", "fnirs"))

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -828,23 +828,23 @@ class InterpolationMixin:
             origin fit.
 
             .. versionadded:: 0.17
-        method : dict | None
+        method : dict | str | None
             Method to use for each channel type.
-            All channel types support "nan".
-            The key ``"eeg"`` has two additional options:
 
-            - ``"spline"`` (default)
-                Use spherical spline interpolation.
-            - ``"MNE"``
-                Use minimum-norm projection to a sphere and back.
-                This is the method used for MEG channels.
+            - ``"meg"`` channels support ``"MNE"`` (default) and ``"nan"``
+            - ``"eeg"`` channels support ``"spline" (default), ``"MNE"`` and ``"nan"``
+            - ``"fnirs"`` channels support ``"nearest"`` (default) and ``"nan"``
 
-            The default value for ``"meg"`` is ``"MNE"``, and the default value
-            for ``"fnirs"`` is ``"nearest"``.
-
-            The default (None) is thus an alias for::
+            None is an alias for::
 
                 method=dict(meg="MNE", eeg="spline", fnirs="nearest")
+
+            If a :class:`str` is provided, a single channel type is expected in the
+            instance.
+
+            .. warning::
+                Be careful when using ``method="nan"``; the default value
+                ``reset_bads=True`` may not be what you want.
 
             .. versionadded:: 0.21
         exclude : list | tuple
@@ -861,9 +861,7 @@ class InterpolationMixin:
         -----
         .. versionadded:: 0.9.0
 
-        .. warning::
-            Be careful when using ``method="nan"``; the default value
-            ``reset_bads=True`` may not be what you want.
+        The ``"MNE"`` method uses minimum-norm projection to a sphere and back.
         """
         from .interpolation import (
             _interpolate_bads_eeg,
@@ -872,7 +870,7 @@ class InterpolationMixin:
         )
 
         _check_preload(self, "interpolation")
-        _validate_type(method, (dict, None), "method")
+        _validate_type(method, (dict, str, None), "method")
         method = _handle_default("interpolation_method", method)
         for key in method:
             _check_option("method[key]", key, ("meg", "eeg", "fnirs"))

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -351,6 +351,7 @@ def test_nan_interpolation(raw):
     assert np.isfinite(good_chs).all()
 
 
+@testing.requires_testing_data
 def test_method_str():
     """Test method argument types."""
     raw = read_raw_fif(


### PR DESCRIPTION
Better error message raised when someone accidentally provided the `method` argument as a `str`, e.g.

```
from mne.datasets import sample
from mne.io import read_raw_fif


directory = sample.data_path() / "MEG" / "sample"
raw = read_raw_fif(directory / "sample_audvis_raw.fif", preload=False)
raw.pick("eeg", exclude=[]).load_data()
raw.interpolate_bads(method="spline")
```

On main:

```
ValueError: Invalid value for the 'method['meg']' parameter. Allowed values are 'MNE' and 'nan', but got 'spline' instead.
```

On this PR:

```
TypeError: method must be an instance of dict or None, got <class 'str'> instead.
```