### PR TITLE
Add “py” to the explicit test dependencies (for pytest 7.2.0+)

### DIFF
--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -3,6 +3,7 @@ pytest!=4.6.0
 pytest-cov
 pytest-timeout
 pytest-harvest
+py
 flake8
 flake8-array-spacing
 numpydoc


### PR DESCRIPTION
We import from `py.io` in `mne/conftest.py`. This has worked because `py` was an implicit/indirect dependency via `pytest`, but this is no longer true beginning with `pytest` 7.2.0.

#### Reference issue
No issue filed.


#### What does this implement/fix?
```
python3.11 -m venv _e
. _e/bin/activate
pip install -e .[data,hdf5,test]
make test
```

```
[…]
Dataset testing version 0.0 out of date, latest version is 0.138
Dataset out of date but force_update=False and download=False, returning empty data_path
[…]
mne/viz/tests/test_utils.py ...FF.F...................................                                         [100%]

Traceback (most recent call last):
  File "/home/ben/src/forks/mne-python/_e/bin/py.test", line 8, in <module>
    sys.exit(console_main())
             ^^^^^^^^^^^^^^
  File "/home/ben/src/forks/mne-python/_e/lib64/python3.11/site-packages/_pytest/config/__init__.py", line 192, in console_main
    code = main()
           ^^^^^^
  File "/home/ben/src/forks/mne-python/_e/lib64/python3.11/site-packages/_pytest/config/__init__.py", line 169, in main   
    ret: Union[ExitCode, int] = config.hook.pytest_cmdline_main(
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ben/src/forks/mne-python/_e/lib64/python3.11/site-packages/pluggy/_hooks.py", line 493, in __call__
    return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ben/src/forks/mne-python/_e/lib64/python3.11/site-packages/pluggy/_manager.py", line 115, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ben/src/forks/mne-python/_e/lib64/python3.11/site-packages/pluggy/_callers.py", line 113, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/home/ben/src/forks/mne-python/_e/lib64/python3.11/site-packages/pluggy/_callers.py", line 77, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ben/src/forks/mne-python/_e/lib64/python3.11/site-packages/_pytest/main.py", line 318, in pytest_cmdline_main
    return wrap_session(config, _main)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ben/src/forks/mne-python/_e/lib64/python3.11/site-packages/_pytest/main.py", line 306, in wrap_session
    config.hook.pytest_sessionfinish(
  File "/home/ben/src/forks/mne-python/_e/lib64/python3.11/site-packages/pluggy/_hooks.py", line 493, in __call__
    return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ben/src/forks/mne-python/_e/lib64/python3.11/site-packages/pluggy/_manager.py", line 115, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ben/src/forks/mne-python/_e/lib64/python3.11/site-packages/pluggy/_callers.py", line 130, in _multicall
    teardown[0].send(outcome)
  File "/home/ben/src/forks/mne-python/_e/lib64/python3.11/site-packages/_pytest/terminal.py", line 857, in pytest_sessionfinish
    outcome.get_result()
  File "/home/ben/src/forks/mne-python/_e/lib64/python3.11/site-packages/pluggy/_result.py", line 114, in get_result
    raise exc.with_traceback(exc.__traceback__)
  File "/home/ben/src/forks/mne-python/_e/lib64/python3.11/site-packages/pluggy/_callers.py", line 77, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ben/src/forks/mne-python/mne/conftest.py", line 773, in pytest_sessionfinish
    from py.io import TerminalWriter
ModuleNotFoundError: No module named 'py.io'; 'py' is not a package
make: *** [Makefile:48: test] Error 1
```

#### Additional information

After this PR:

```
[…]
=========== 574 failed, 999 passed, 1974 skipped, 3 deselected, 1 xfailed, 80 errors in 107.88s (0:01:47) ============
```

Well, every little fix counts!