### PR TITLE
BUG: Fix bug with weakref

### DIFF
--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -414,7 +414,7 @@ def _fig_to_img(fig, *, image_format="png", own_figure=True):
     dpi = fig.get_dpi()
     logger.debug(
         f"Saving figure with dimension {fig.get_size_inches()} inches with "
-        f"{{dpi}} dpi"
+        f"{dpi} dpi"
     )
 
     # https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2494,7 +2494,7 @@ def _on_time_change(
 
 def _on_colormap_range(event, kwargs):
     """Handle updating colormap range."""
-    logger.debug(f"Updating colormap range to {event.vmin}, {event.vmax}")
+    logger.debug(f"Updating colormap range to {event.fmin}, {event.fmax}")
     kwargs.update(vlim=(event.fmin, event.fmax), cmap=event.cmap)
 
 

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2494,6 +2494,7 @@ def _on_time_change(
 
 def _on_colormap_range(event, kwargs):
     """Handle updating colormap range."""
+    logger.debug(f"Updating colormap range to {event.vmin}, {event.vmax}")
     kwargs.update(vlim=(event.fmin, event.fmax), cmap=event.cmap)
 
 

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -48,6 +48,7 @@ from ..defaults import _handle_default
 from ..rank import compute_rank
 from ..transforms import apply_trans
 from ..utils import (
+    _auto_weakref,
     _check_ch_locs,
     _check_decim,
     _check_option,
@@ -1493,7 +1494,12 @@ class DraggableColorbar:
         self.index = self.cycle.index(mappable.get_cmap().name)
         self.lims = (self.cbar.norm.vmin, self.cbar.norm.vmax)
         self.connect()
-        subscribe(self.fig, "colormap_range", self._on_colormap_range)
+
+        @_auto_weakref
+        def _on_colormap_range(event):
+            return self._on_colormap_range(event)
+
+        subscribe(self.fig, "colormap_range", _on_colormap_range)
 
     def connect(self):
         """Connect to all the events we need."""


### PR DESCRIPTION
Should fix the mysterious timeout observed in https://github.com/mne-tools/mne-bids-pipeline/pull/793. This one was tough to track down. Somehow having `n_jobs > 1` and having these `subscribe`s caused what I assume is a circular reference problem. Could be related to `Agg` backend not emitting the `close` event, not sure. Locally this `_auto_weakref` fixes the error at least when testing with:
```
rm -Rf ~/mne_data/derivatives/mne-bids-pipeline/ds000248_base/ && pytest mne_bids_pipeline -k ds000248_base
```
cc @wmvanvliet we'll need to be mindful of creating these circular references going forward I think :shrug: 

No idea how to make a nicely self-contained test for this so I'll open a PR to mne-bids-pipeline to make sure the doc build works when built against this branch, then I'll restart the `ds000248_base` run a few times.

Within-release bugfix so I don't think we need a changelog entry