### PR TITLE
Fix combination of DIN events channels with EGI reader

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -73,6 +73,7 @@ Bugs
 - Correctly handle passing ``"eyegaze"`` or ``"pupil"`` to :meth:`mne.io.Raw.pick` (:gh:`12019` by `Scott Huberty`_)
 - Fix bug with :func:`~mne.viz.plot_raw` where changing ``MNE_BROWSER_BACKEND`` via :func:`~mne.set_config` would have no effect within a Python session (:gh:`12078` by `Santeri Ruuskanen`_)
 - Improve handling of ``method`` argument in the channel interpolation function to support :class:`str` and raise helpful error messages (:gh:`12113` by `Mathieu Scheltienne`_)
+- Fix combination of ``DIN`` event channels into a single synthetic trigger channel ``STI 014`` by the MFF reader of :func:`mne.io.read_raw_egi` (:gh:`12122` by `Mathieu Scheltienne`_)
 
 API changes
 ~~~~~~~~~~~

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -176,7 +176,7 @@ def pytest_configure(config):
     ignore:numpy\.core\._multiarray_umath.*:DeprecationWarning
     ignore:numpy\.core\.numeric is deprecated.*:DeprecationWarning
     ignore:numpy\.core\.multiarray is deprecated.*:DeprecationWarning
-    ignore:numpy\.fft\.helper has been made private.*:DeprecationWarning
+    ignore:The numpy\.fft\.helper has been made private.*:DeprecationWarning
     # TODO: Should actually fix these two
     ignore:scipy.signal.morlet2 is deprecated in SciPy.*:DeprecationWarning
     ignore:The `needs_threshold` and `needs_proba`.*:FutureWarning

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -176,6 +176,7 @@ def pytest_configure(config):
     ignore:numpy\.core\._multiarray_umath.*:DeprecationWarning
     ignore:numpy\.core\.numeric is deprecated.*:DeprecationWarning
     ignore:numpy\.core\.multiarray is deprecated.*:DeprecationWarning
+    ignore:numpy\.fft\.helper has been made private.*:DeprecationWarning
     # TODO: Should actually fix these two
     ignore:scipy.signal.morlet2 is deprecated in SciPy.*:DeprecationWarning
     ignore:The `needs_threshold` and `needs_proba`.*:FutureWarning

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -507,7 +507,17 @@ class RawMff(BaseRaw):
                 "    Excluding events {%s} ..."
                 % ", ".join([k for i, k in enumerate(event_codes) if i not in include_])
             )
-            events_ids = np.arange(len(include_)) + 1
+            if all(ch.startswith("D") for ch in include_names):
+                # support the DIN format DIN1, DIN2, ..., DIN9, DI10, DI11, ... DI99,
+                # D100, D101, ..., D255 that we get when sending 0-255 triggers on a
+                # parallel port.
+                events_ids = list()
+                for ch in include_names:
+                    while not ch[0].isnumeric():
+                        ch = ch[1:]
+                    events_ids.append(int(ch))
+            else:
+                events_ids = np.arange(len(include_)) + 1
             egi_info["new_trigger"] = _combine_triggers(
                 egi_events[include_], remapping=events_ids
             )

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -190,9 +190,9 @@ def test_io_egi_mff():
         read_raw_egi(egi_mff_fname, include=["Foo"])
     with pytest.raises(ValueError, match="Could not find event"):
         read_raw_egi(egi_mff_fname, exclude=["Bar"])
-    for ii, k in enumerate(include, 1):
-        assert k in raw.event_id
-        assert raw.event_id[k] == ii
+    for ch in include:
+        assert ch in raw.event_id
+        assert raw.event_id[ch] == int(ch[-1])
 
 
 def test_io_egi():


### PR DESCRIPTION
I'm going to guess that some version of the EGI software, including the one at my site, store events on channels `DIN`. Those events are delivered from a parallel port (0 to 255) and the `DIN` names span:

```
DIN1, DIN2, ..., DIN9, DI10, DI11, ... DI99, D100, D101, ..., D255
```

The MFF format does not store them in order, but in the order of occurrence. If a `DIN2` occurs before a `DIN1`, the `DIN2` event is stored "first". Thus, when combining the binary event channels into a synthetic trigger channel, simply remapping to `events_ids = np.arange(len(include_)) + 1` yields incorrect values and swap between events.