### PR TITLE
Fix array-like check

### DIFF
--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -542,7 +542,7 @@ _multi = {
     "path-like": path_like,
     "int-like": (int_like,),
     "callable": (_Callable(),),
-    "array-like": (Sequence, np.ndarray),
+    "array-like": (list, tuple, set, np.ndarray),
 }
 
 

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -8,7 +8,6 @@ import operator
 import os
 import re
 from builtins import input  # no-op here but facilitates testing
-from collections.abc import Sequence
 from difflib import get_close_matches
 from importlib import import_module
 from importlib.metadata import version

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -212,6 +212,11 @@ def test_validate_type():
     _validate_type(1, "int-like")
     with pytest.raises(TypeError, match="int-like"):
         _validate_type(False, "int-like")
+    _validate_type([1, 2, 3], "array-like")
+    _validate_type((1, 2, 3), "array-like")
+    _validate_type({1, 2, 3}, "array-like")
+    with pytest.raises(TypeError, match="array-like"):
+        _validate_type("123", "array-like")
 
 
 def test_check_range():

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -216,7 +216,7 @@ def test_validate_type():
     _validate_type((1, 2, 3), "array-like")
     _validate_type({1, 2, 3}, "array-like")
     with pytest.raises(TypeError, match="array-like"):
-        _validate_type("123", "array-like")
+        _validate_type("123", "array-like")  # a string is not array-like
 
 
 def test_check_range():


### PR DESCRIPTION
Fixes #12127. Previously, a string was considered to be array-like, but now only the following types are accepted: list, tuple, set, and np.array. For all other list-like types: YAGNI for now.