### PR TITLE
DOC: Document governance updates

### DIFF
--- a/doc/development/governance.rst
+++ b/doc/development/governance.rst
@@ -69,7 +69,7 @@ BDFL
 ----
 
 The Project will have a BDFL (Benevolent Dictator for Life), who is currently
-Alexandre Gramfort. As Dictator, the BDFL has the authority to make all final
+Daniel McCloy. As Dictator, the BDFL has the authority to make all final
 decisions for The Project. As Benevolent, the BDFL, in practice, chooses to
 defer that authority to the consensus of the community discussion channels and
 the Steering Council (see below). It is expected, and in the past has been the

--- a/doc/overview/people.rst
+++ b/doc/overview/people.rst
@@ -22,8 +22,6 @@ Steering Council
 * `Daniel McCloy`_
 * `Denis Engemann`_
 * `Eric Larson`_
-* `Guillaume Favelier`_
-* `Luke Bloy`_
 * `Mainak Jas`_
 * `Marijn van Vliet`_
 * `Mathieu Scheltienne`_


### PR DESCRIPTION
Document update of governance structure following discussion in the last month or so in `mne-python-steering-council` in accordance with our governing guidelines:

1. BDFL @agramfort -> @drammock
2. Removal of @bloyl and @GuillaumeFavelier from steering council (inactivity)