### PR TITLE
Remove LGTM.com configuration file

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,8 +1,0 @@
-extraction:
-  javascript:
-    index:
-      filters:
-        - exclude: "**/*.js"
-queries:
-  - exclude: py/missing-equals
-  - exclude: py/import-and-import-from


### PR DESCRIPTION
#### What does this implement/fix?

LGTM.com has been deprecated and replaced by GitHub code analysis:
https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/

#### Additional information

File initially added by #5914.