### PR TITLE
[ADD] support for motion data

### DIFF
--- a/mne/_fiff/constants.py
+++ b/mne/_fiff/constants.py
@@ -217,7 +217,7 @@ FIFF.FIFFV_FNIRS_CH = 1100  # Functional near-infrared spectroscopy
 FIFF.FIFFV_TEMPERATURE_CH = 1200  # Functional near-infrared spectroscopy
 FIFF.FIFFV_GALVANIC_CH = 1300  # Galvanic skin response
 FIFF.FIFFV_EYETRACK_CH = 1400  # Eye-tracking
-
+FIFF.FIFFV_MOTION_CH = 1500  # Motion
 _ch_kind_named = {
     key: key
     for key in (
@@ -244,6 +244,7 @@ _ch_kind_named = {
         FIFF.FIFFV_GALVANIC_CH,
         FIFF.FIFFV_TEMPERATURE_CH,
         FIFF.FIFFV_EYETRACK_CH,
+        FIFF.FIFFV_MOTION_CH,
     )
 }
 
@@ -1037,6 +1038,16 @@ FIFF.FIFFV_COIL_FNIRS_TD_MOMENTS_AMPLITUDE = 307  # fNIRS time-domain moments am
 
 FIFF.FIFFV_COIL_EYETRACK_POS = 400  # Eye-tracking gaze position
 FIFF.FIFFV_COIL_EYETRACK_PUPIL = 401  # Eye-tracking pupil size
+
+# Define constants for channel types for Motion data (from Motion-BIDS)
+FIFF.FIFFV_COIL_MOTION_ACCEL = 500  # Motion acceleration
+FIFF.FIFFV_COIL_MOTION_ANGACCEL = 501  # Motion angular acceleration
+FIFF.FIFFV_COIL_MOTION_GYRO = 504  # Motion gyroscope
+FIFF.FIFFV_COIL_MOTION_JNTANG = 505  # Motion joint angle
+FIFF.FIFFV_COIL_MOTION_MAGN = 507  # Motion magnetic field strength
+FIFF.FIFFV_COIL_MOTION_ORNT = 509  # Motion orientation
+FIFF.FIFFV_COIL_MOTION_POS = 510  # Motion position
+FIFF.FIFFV_COIL_MOTION_VEL = 511  # Motion velocity
 
 FIFF.FIFFV_COIL_MCG_42 = 1000  # For testing the MCG software
 

--- a/mne/_fiff/pick.py
+++ b/mne/_fiff/pick.py
@@ -131,6 +131,7 @@ def get_channel_type_constants(include_defaults=False):
         pupil=dict(
             kind=FIFF.FIFFV_EYETRACK_CH, coil_type=FIFF.FIFFV_COIL_EYETRACK_PUPIL
         ),
+        motion=dict(kind=FIFF.FIFFV_MOTION_CH),
     )
     if include_defaults:
         coil_none = dict(coil_type=FIFF.FIFFV_COIL_NONE)
@@ -187,6 +188,7 @@ _first_rule = {
     FIFF.FIFFV_TEMPERATURE_CH: "temperature",
     FIFF.FIFFV_GALVANIC_CH: "gsr",
     FIFF.FIFFV_EYETRACK_CH: "eyetrack",
+    FIFF.FIFFV_MOTION_CH: "motion",
 }
 # How to reduce our categories in channel_type (originally)
 _second_rules = {
@@ -218,6 +220,19 @@ _second_rules = {
             FIFF.FIFFV_COIL_EYETRACK_PUPIL: "pupil",
         },
     ),
+#    "motion": (
+#        "coil_type",
+#        {
+#            FIFF.FIFFV_COIL_MOTION_ACCEL: "acceleration",
+#            FIFF.FIFFV_COIL_MOTION_ANGACCEL: "angular_acceleration",
+#            FIFF.FIFFV_COIL_MOTION_GYRO: "gyroscope",
+#            FIFF.FIFFV_COIL_MOTION_JNTANG: "joint_angle",
+#            FIFF.FIFFV_COIL_MOTION_MAGN: "magnetic_field_strenght",
+#            FIFF.FIFFV_COIL_MOTION_ORNT: "orientation",
+#            FIFF.FIFFV_COIL_MOTION_POS: "position",
+#            FIFF.FIFFV_COIL_MOTION_VEL: "velocity",
+#        },
+#    ),
 }
 
 
@@ -239,7 +254,7 @@ def channel_type(info, idx):
             {'grad', 'mag', 'eeg', 'csd', 'stim', 'eog', 'emg', 'ecg',
              'ref_meg', 'resp', 'exci', 'ias', 'syst', 'misc', 'seeg', 'dbs',
               'bio', 'chpi', 'dipole', 'gof', 'ecog', 'hbo', 'hbr',
-              'temperature', 'gsr', 'eyetrack'}
+              'temperature', 'gsr', 'eyetrack', 'motion'}
     """
     # This is faster than the original _channel_type_old now in test_pick.py
     # because it uses (at most!) two dict lookups plus one conditional


### PR DESCRIPTION
This PR is intended to add motion channels to be allowed in MNE. The motivation comes from extending [BIDS to motion data](https://bids-specification.readthedocs.io/en/latest/modality-specific-files/motion.html). A MNE Raw object should serve as a starting point to use MNE-BIDS for motion data.

There already has been a brief discussion on the points that have to be [implemented](https://github.com/mne-tools/mne-bids/issues/1145#) in MNE.

For the next step, I would like to differentiate between multiple channel types of motion data. 
