### PR TITLE
Add mne-icalabel wildcard

### DIFF
--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -205,6 +205,7 @@ _known_config_wildcards = (
     "MNE_DATASETS_FNIRS",  # mne-nirs
     "MNE_NIRS",  # mne-nirs
     "MNE_KIT2FIFF",  # mne-kit-gui
+    "MNE_DATASETS_ICALABEL",  # mne-icalabel
 )
 
 

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -205,7 +205,7 @@ _known_config_wildcards = (
     "MNE_DATASETS_FNIRS",  # mne-nirs
     "MNE_NIRS",  # mne-nirs
     "MNE_KIT2FIFF",  # mne-kit-gui
-    "MNE_DATASETS_ICALABEL",  # mne-icalabel
+    "MNE_ICALABEL",  # mne-icalabel
 )
 
 


### PR DESCRIPTION
@adam2392 configured the `mne-icalabel` repository to use the datasets downloads infrastructure from MNE-Python.
For now, it issues:

```
RuntimeWarning: Setting non-standard config type: "MNE_DATASETS_ICALABEL_TESTING_PATH"
```