### PR TITLE
BUG: Fix bug with interior points not showing

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -63,6 +63,7 @@ Bugs
 - Fix bug with ``subject_info`` when loading data from and exporting to EDF file (:gh:`11952` by `Paul Roujansky`_)
 - Fix rendering glitches when plotting Neuromag/TRIUX sensors in :func:`mne.viz.plot_alignment` and related functions (:gh:`12098` by `Eric Larson`_)
 - Fix bug with delayed checking of :class:`info["bads"] <mne.Info>` (:gh:`12038` by `Eric Larson`_)
+- Fix bug with :ref:`mne coreg` where points inside the head surface were not shown (:gh:`12147` by `Eric Larson`_)
 - Fix bug with :func:`mne.viz.plot_alignment` where ``sensor_colors`` were not handled properly on a per-channel-type basis (:gh:`12067` by `Eric Larson`_)
 - Fix handling of channel information in annotations when loading data from and exporting to EDF file (:gh:`11960` :gh:`12017` :gh:`12044` by `Paul Roujansky`_)
 - Add missing ``overwrite`` and ``verbose`` parameters to :meth:`Transform.save() <mne.transforms.Transform.save>` (:gh:`12004` by `Marijn van Vliet`_)
@@ -81,3 +82,4 @@ API changes
 - :func:`mne.io.kit.read_mrk` reading pickled files is deprecated using something like ``np.savetxt(fid, pts, delimiter="\t", newline="\n")`` to save your points instead (:gh:`11937` by `Eric Larson`_)
 - Replace legacy ``inst.pick_channels`` and ``inst.pick_types`` with ``inst.pick`` (where ``inst`` is an instance of :class:`~mne.io.Raw`, :class:`~mne.Epochs`, or :class:`~mne.Evoked`) wherever possible (:gh:`11907` by `Clemens Brunner`_)
 - The ``reset_camera`` parameter has been removed in favor of ``distance="auto"`` in :func:`mne.viz.set_3d_view`, :meth:`mne.viz.Brain.show_view`, and related functions (:gh:`12000` by `Eric Larson`_)
+- Several unused parameters from :func:`mne.gui.coregistration` are now deprecated: tabbed, split, scrollable, head_inside, guess_mri_subject, scale, and ``advanced_rendering``. All arguments are also now keyword-only. (:gh:`12147` by `Eric Larson`_)

--- a/mne/commands/mne_coreg.py
+++ b/mne/commands/mne_coreg.py
@@ -44,7 +44,7 @@ def run():
         "--tabbed",
         dest="tabbed",
         action="store_true",
-        default=False,
+        default=None,
         help="Option for small screens: Combine "
         "the data source panel and the coregistration panel "
         "into a single panel with tabs.",
@@ -103,6 +103,7 @@ def run():
         "--simple-rendering",
         action="store_false",
         dest="advanced_rendering",
+        default=None,
         help="Use simplified OpenGL rendering",
     )
     _add_verbose_flag(parser)
@@ -131,7 +132,7 @@ def run():
 
     faulthandler.enable()
     mne.gui.coregistration(
-        options.tabbed,
+        tabbed=options.tabbed,
         inst=options.inst,
         subject=options.subject,
         subjects_dir=subjects_dir,
@@ -139,7 +140,7 @@ def run():
         head_opacity=options.head_opacity,
         head_high_res=head_high_res,
         trans=trans,
-        scrollable=True,
+        scrollable=None,
         interaction=options.interaction,
         scale=options.scale,
         advanced_rendering=options.advanced_rendering,

--- a/mne/gui/_gui.py
+++ b/mne/gui/_gui.py
@@ -7,8 +7,9 @@ from ..utils import get_config, verbose, warn
 
 @verbose
 def coregistration(
-    tabbed=False,
-    split=True,
+    *,
+    tabbed=None,
+    split=None,
     width=None,
     inst=None,
     subject=None,
@@ -18,15 +19,14 @@ def coregistration(
     head_opacity=None,
     head_high_res=None,
     trans=None,
-    scrollable=True,
-    *,
-    orient_to_surface=True,
-    scale_by_distance=True,
-    mark_inside=True,
+    scrollable=None,
+    orient_to_surface=None,
+    scale_by_distance=None,
+    mark_inside=None,
     interaction=None,
     scale=None,
     advanced_rendering=None,
-    head_inside=True,
+    head_inside=None,
     fullscreen=None,
     show=True,
     block=False,
@@ -143,10 +143,10 @@ def coregistration(
     .. youtube:: ALV5qqMHLlQ
     """
     unsupported_params = {
-        "tabbed": (tabbed, False),
-        "split": (split, True),
-        "scrollable": (scrollable, True),
-        "head_inside": (head_inside, True),
+        "tabbed": tabbed,
+        "split": split,
+        "scrollable": scrollable,
+        "head_inside": head_inside,
         "guess_mri_subject": guess_mri_subject,
         "scale": scale,
         "advanced_rendering": advanced_rendering,
@@ -158,22 +158,17 @@ def coregistration(
             to_raise = val is not None
         if to_raise:
             warn(
-                f"The parameter {key} is not supported with"
-                " the pyvistaqt 3d backend. It will be ignored."
+                f"The parameter {key} is deprecated and will be removed in 1.7, do "
+                "not pass a value for it",
+                FutureWarning,
             )
+    del tabbed, split, scrollable, head_inside, guess_mri_subject, scale
+    del advanced_rendering
     config = get_config()
-    if guess_mri_subject is None:
-        guess_mri_subject = config.get("MNE_COREG_GUESS_MRI_SUBJECT", "true") == "true"
     if head_high_res is None:
         head_high_res = config.get("MNE_COREG_HEAD_HIGH_RES", "true") == "true"
-    if advanced_rendering is None:
-        advanced_rendering = (
-            config.get("MNE_COREG_ADVANCED_RENDERING", "true") == "true"
-        )
     if head_opacity is None:
         head_opacity = config.get("MNE_COREG_HEAD_OPACITY", 0.8)
-    if head_inside is None:
-        head_inside = config.get("MNE_COREG_HEAD_INSIDE", "true").lower() == "true"
     if width is None:
         width = config.get("MNE_COREG_WINDOW_WIDTH", 800)
     if height is None:
@@ -183,23 +178,23 @@ def coregistration(
             subjects_dir = config["SUBJECTS_DIR"]
         elif "MNE_COREG_SUBJECTS_DIR" in config:
             subjects_dir = config["MNE_COREG_SUBJECTS_DIR"]
+    false_like = ("false", "0")
     if orient_to_surface is None:
-        orient_to_surface = config.get("MNE_COREG_ORIENT_TO_SURFACE", "") == "true"
+        orient_to_surface = config.get("MNE_COREG_ORIENT_TO_SURFACE", "true").lower()
+        orient_to_surface = orient_to_surface not in false_like
     if scale_by_distance is None:
-        scale_by_distance = config.get("MNE_COREG_SCALE_BY_DISTANCE", "") == "true"
+        scale_by_distance = config.get("MNE_COREG_SCALE_BY_DISTANCE", "true").lower()
+        scale_by_distance = scale_by_distance not in false_like
     if interaction is None:
         interaction = config.get("MNE_COREG_INTERACTION", "terrain")
     if mark_inside is None:
-        mark_inside = config.get("MNE_COREG_MARK_INSIDE", "") == "true"
-    if scale is None:
-        scale = config.get("MNE_COREG_SCENE_SCALE", 0.16)
+        mark_inside = config.get("MNE_COREG_MARK_INSIDE", "true").lower()
+        mark_inside = mark_inside not in false_like
     if fullscreen is None:
         fullscreen = config.get("MNE_COREG_FULLSCREEN", "") == "true"
     head_opacity = float(head_opacity)
-    head_inside = bool(head_inside)
     width = int(width)
     height = int(height)
-    scale = float(scale)
 
     from ..viz.backends.renderer import MNE_3D_BACKEND_TESTING
     from ._coreg import CoregistrationUI

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1252,10 +1252,9 @@ def _orient_glyphs(
     proj_pts, proj_nn = _get_nearest(nearest, check_inside, project_to_trans, proj_rr)
     vec = pts - proj_pts  # point to the surface
     nn = proj_nn
+    scalars = np.ones(len(pts))
     if mark_inside and not project_to_surface:
-        scalars = (~check_inside(proj_rr)).astype(int)
-    else:
-        scalars = np.ones(len(pts))
+        scalars[:] = ~check_inside(proj_rr)
     dist = np.linalg.norm(vec, axis=-1, keepdims=True)
     vectors = (250 * dist + 1) * nn
     return scalars, vectors, proj_pts
@@ -1277,28 +1276,16 @@ def _plot_glyphs(
     check_inside=None,
     nearest=None,
 ):
+    from matplotlib.colors import ListedColormap, to_rgba
+
+    _validate_type(mark_inside, bool, "mark_inside")
     if surf is not None and len(loc) > 0:
         defaults = DEFAULTS["coreg"]
         scalars, vectors, proj_pts = _orient_glyphs(
             loc, surf, project_points, mark_inside, check_inside, nearest
         )
         if mark_inside:
-            from matplotlib.colors import ListedColormap
-
-            color = np.append(color, 1)
-            colormap = ListedColormap(
-                np.array(
-                    [
-                        (
-                            0,
-                            0,
-                            0,
-                            1,
-                        ),
-                        color,
-                    ]
-                )
-            )
+            colormap = ListedColormap([to_rgba("darkslategray"), to_rgba(color)])
             color = None
             clim = [0, 1]
         else:


### PR DESCRIPTION
Closes #12123

@nordme feel free to try it. Now I get after running this and clicking "Lock Fiducials":
```
mne coreg --subjects-dir=~/mne_data/MNE-sample-data/subjects -s sample -f ~/mne_data/MNE-sample-data/MEG/sample/sample_audvis_raw.fif --trans ~/mne_data/MNE-sample-data/MEG/sample/sample_audvis_raw-trans.fif
```

![Screenshot from 2023-10-26 14-06-46](https://github.com/mne-tools/mne-python/assets/2365790/5c3c3336-660d-49d6-91c5-936039573b78)

And after clicking "Fit Fiducials" just to get more points outside the scalp:

![Screenshot from 2023-10-26 14-06-52](https://github.com/mne-tools/mne-python/assets/2365790/1cd2d4b9-6a85-4c94-8573-facc28ca5eee)

Also fixes a bug where env var setting had no effect, and deprecates some parameters that we haven't had support for for years so probably will never add. We were already emitting a warning for these so officially deprecating them is easy enough.
