### PR TITLE
BUG: Fix bug with Report.add_ica component number

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -61,6 +61,7 @@ Bugs
 - Fix bug with :meth:`mne.viz.Brain.get_view` where calling :meth:`~mne.viz.Brain.show_view` with returned parameters would change the view (:gh:`12000` by `Eric Larson`_)
 - Fix bug with :meth:`mne.viz.Brain.show_view` where ``distance=None`` would change the view distance (:gh:`12000` by `Eric Larson`_)
 - Fix bug with :meth:`~mne.viz.Brain.add_annotation` when reading an annotation from a file with both hemispheres shown (:gh:`11946` by `Marijn van Vliet`_)
+- Fix bug with reported component number in :meth:`mne.Report.add_ica` (:gh:`12155` by `Eric Larson`_)
 - Fix bug with axis clip box boundaries in :func:`mne.viz.plot_evoked_topo` and related functions (:gh:`11999` by `Eric Larson`_)
 - Fix bug with ``subject_info`` when loading data from and exporting to EDF file (:gh:`11952` by `Paul Roujansky`_)
 - Fix bug where :class:`mne.Info` HTML representations listed all channel counts instead of good channel counts under the heading "Good channels" (:gh:`12145` by `Eric Larson`_) 

--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -61,7 +61,7 @@ Bugs
 - Fix bug with :meth:`mne.viz.Brain.get_view` where calling :meth:`~mne.viz.Brain.show_view` with returned parameters would change the view (:gh:`12000` by `Eric Larson`_)
 - Fix bug with :meth:`mne.viz.Brain.show_view` where ``distance=None`` would change the view distance (:gh:`12000` by `Eric Larson`_)
 - Fix bug with :meth:`~mne.viz.Brain.add_annotation` when reading an annotation from a file with both hemispheres shown (:gh:`11946` by `Marijn van Vliet`_)
-- Fix bug with reported component number in :meth:`mne.Report.add_ica` (:gh:`12155` by `Eric Larson`_)
+- Fix bug with reported component number and errant reporting of PCA explained variance as ICA explained variance in :meth:`mne.Report.add_ica` (:gh:`12155` by `Eric Larson`_)
 - Fix bug with axis clip box boundaries in :func:`mne.viz.plot_evoked_topo` and related functions (:gh:`11999` by `Eric Larson`_)
 - Fix bug with ``subject_info`` when loading data from and exporting to EDF file (:gh:`11952` by `Paul Roujansky`_)
 - Fix bug where :class:`mne.Info` HTML representations listed all channel counts instead of good channel counts under the heading "Good channels" (:gh:`12145` by `Eric Larson`_) 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -1669,20 +1669,20 @@ class Report:
         figs = _plot_ica_properties_as_arrays(
             ica=ica, inst=inst, picks=picks, n_jobs=n_jobs
         )
+        # TODO: Maybe use get_explained_variance_ratio for the inst rather than
+        # what was explained during the fit, see gh-11141
         rel_explained_var = (
-            ica.pca_explained_variance_ / ica.pca_explained_variance_.sum()
+            100 * ica.pca_explained_variance_ / ica.pca_explained_variance_.sum()
         )
-        cum_explained_var = np.cumsum(rel_explained_var)
         captions = []
-        for idx, rel_var, cum_var in zip(
-            range(len(figs)),
-            rel_explained_var[: len(figs)],
-            cum_explained_var[: len(figs)],
-        ):
+        cum_var = dict()
+        for idx in range(len(figs)):
+            rel_var = rel_explained_var[picks[idx]]
+            cum_var += rel_var
             caption = (
                 f"ICA component {picks[idx]}. "
-                f"Variance explained: {100 * rel_var:0.1f}%"
-                f" ({100 * cum_var:0.1f}% cumulative)."
+                f"Variance explained: {rel_var:0.1f}%"
+                f" ({cum_var:0.1f}% cumulative across picks)."
             )
             captions.append(caption)
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -1680,13 +1680,10 @@ class Report:
             cum_explained_var[: len(figs)],
         ):
             caption = (
-                f"ICA component {idx}. " f"Variance explained: {round(100 * rel_var)}%"
+                f"ICA component {picks[idx]}. "
+                f"Variance explained: {100 * rel_var:0.1f}%"
+                f" ({100 * cum_var:0.1f}% cumulative)."
             )
-            if idx == 0:
-                caption += "."
-            else:
-                caption += f" ({round(100 * cum_var)}% cumulative)."
-
             captions.append(caption)
 
         title = "ICA component properties"

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -1669,21 +1669,9 @@ class Report:
         figs = _plot_ica_properties_as_arrays(
             ica=ica, inst=inst, picks=picks, n_jobs=n_jobs
         )
-        # TODO: Maybe use get_explained_variance_ratio for the inst rather than
-        # what was explained during the fit, see gh-11141
-        rel_explained_var = (
-            100 * ica.pca_explained_variance_ / ica.pca_explained_variance_.sum()
-        )
         captions = []
-        cum_var = dict()
         for idx in range(len(figs)):
-            rel_var = rel_explained_var[picks[idx]]
-            cum_var += rel_var
-            caption = (
-                f"ICA component {picks[idx]}. "
-                f"Variance explained: {rel_var:0.1f}%"
-                f" ({cum_var:0.1f}% cumulative across picks)."
-            )
+            caption = f"ICA component {picks[idx]}."
             captions.append(caption)
 
         title = "ICA component properties"

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -913,10 +913,10 @@ def test_manual_report_2d(tmp_path, invisible_fig):
     evoked = evokeds[0].pick("eeg")
 
     with pytest.warns(ConvergenceWarning, match="did not converge"):
-        ica = ICA(n_components=2, max_iter=1, random_state=42).fit(
+        ica = ICA(n_components=3, max_iter=1, random_state=42).fit(
             inst=raw.copy().crop(tmax=1)
         )
-    ica_ecg_scores = ica_eog_scores = np.array([3, 0])
+    ica_ecg_scores = ica_eog_scores = np.array([3, 0, 0])
     ica_ecg_evoked = ica_eog_evoked = epochs_without_metadata.average()
 
     r.add_raw(raw=raw, title="my raw data", tags=("raw",), psd=True, projs=False)
@@ -969,12 +969,13 @@ def test_manual_report_2d(tmp_path, invisible_fig):
         ica=ica,
         title="my ica with raw inst",
         inst=raw.copy().load_data(),
-        picks=[0],
+        picks=[2],
         ecg_evoked=ica_ecg_evoked,
         eog_evoked=ica_eog_evoked,
         ecg_scores=ica_ecg_scores,
         eog_scores=ica_eog_scores,
     )
+    assert "ICA component 2" in r._content[-1].html
     epochs_baseline = epochs_without_metadata.copy().load_data()
     epochs_baseline.apply_baseline((None, 0))
     r.add_ica(

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -266,7 +266,7 @@ report = mne.Report(title="ICA example")
 report.add_ica(
     ica=ica,
     title="ICA cleaning",
-    picks=[0, 1],  # only plot the first two components
+    picks=ica.exclude,  # plot the excluded EOG components
     inst=raw,
     eog_evoked=eog_epochs.average(),
     eog_scores=eog_scores,


### PR DESCRIPTION
Closes https://github.com/mne-tools/mne-bids-pipeline/issues/573

cc @hoechenberger

See for example https://mne.tools/mne-bids-pipeline/1.4/examples/ds000248_ica/sub-01_task-audiovisual_report.html#ICA 

1. Fix component numbers which used to just be `range(len(picks))` as noted in https://github.com/mne-tools/mne-bids-pipeline/issues/573
2. Always write the cumulative variance explained. Even though it's not informative for the first component, it makes the slider behavior between the first and second components more uniform and thus easier to use.
3. Fix bug where `{round(x)}` was used, but `round` always returns a `float` so these were displayed with `.0` at the end, which is misleading (looks like there is one decimal point of precision when there are none). This now formats better with `{x:0.1f}` which is more accurate in the same number of characters.