### PR TITLE
[DOC] Add documentation for setting montage order

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -45,7 +45,7 @@ Enhancements
 - Add :class:`mne.viz.ui_events.UIEvent` linking for interactive colorbars, allowing users to link figures and change the colormap and limits interactively. This supports :func:`~mne.viz.plot_evoked_topomap`, :func:`~mne.viz.plot_ica_components`, :func:`~mne.viz.plot_tfr_topomap`, :func:`~mne.viz.plot_projs_topomap`, :meth:`~mne.Evoked.plot_image`, and :meth:`~mne.Epochs.plot_image` (:gh:`12057` by `Santeri Ruuskanen`_)
 - :func:`~mne.epochs.make_metadata` now accepts ``tmin=None`` and ``tmax=None``, which will bound the time window used for metadata generation by event names (instead of a fixed time). That way, you can now for example generate metadata spanning from one cue or fixation cross to the next, even if trial durations vary throughout the recording (:gh:`12118` by `Richard Höchenberger`_)
 - Add support for passing multiple labels to :func:`mne.minimum_norm.source_induced_power` (:gh:`12026` by `Erica Peterson`_, `Eric Larson`_, and `Daniel McCloy`_ )
-- Added documentation to :func:`mne.io.Raw.set_montage`and :func:`mne.add_reference_channels` to specify that montages should be set after adding reference channels (:gh:`12160` by `Jacob Woessner`_)
+- Added documentation to :meth:`mne.io.Raw.set_montage`and :func:`mne.add_reference_channels` to specify that montages should be set after adding reference channels (:gh:`12160` by `Jacob Woessner`_)
 
 Bugs
 ~~~~

--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -45,7 +45,7 @@ Enhancements
 - Add :class:`mne.viz.ui_events.UIEvent` linking for interactive colorbars, allowing users to link figures and change the colormap and limits interactively. This supports :func:`~mne.viz.plot_evoked_topomap`, :func:`~mne.viz.plot_ica_components`, :func:`~mne.viz.plot_tfr_topomap`, :func:`~mne.viz.plot_projs_topomap`, :meth:`~mne.Evoked.plot_image`, and :meth:`~mne.Epochs.plot_image` (:gh:`12057` by `Santeri Ruuskanen`_)
 - :func:`~mne.epochs.make_metadata` now accepts ``tmin=None`` and ``tmax=None``, which will bound the time window used for metadata generation by event names (instead of a fixed time). That way, you can now for example generate metadata spanning from one cue or fixation cross to the next, even if trial durations vary throughout the recording (:gh:`12118` by `Richard Höchenberger`_)
 - Add support for passing multiple labels to :func:`mne.minimum_norm.source_induced_power` (:gh:`12026` by `Erica Peterson`_, `Eric Larson`_, and `Daniel McCloy`_ )
-- Added documentation to :meth:`mne.io.Raw.set_montage`and :func:`mne.add_reference_channels` to specify that montages should be set after adding reference channels (:gh:`12160` by `Jacob Woessner`_)
+- Added documentation to :meth:`mne.io.Raw.set_montage` and :func:`mne.add_reference_channels` to specify that montages should be set after adding reference channels (:gh:`12160` by `Jacob Woessner`_)
 
 Bugs
 ~~~~

--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -44,6 +44,7 @@ Enhancements
 - Enhance :func:`~mne.viz.plot_evoked_field` with a GUI that has controls for time, colormap, and contour lines (:gh:`11942` by `Marijn van Vliet`_)
 - Add :class:`mne.viz.ui_events.UIEvent` linking for interactive colorbars, allowing users to link figures and change the colormap and limits interactively. This supports :func:`~mne.viz.plot_evoked_topomap`, :func:`~mne.viz.plot_ica_components`, :func:`~mne.viz.plot_tfr_topomap`, :func:`~mne.viz.plot_projs_topomap`, :meth:`~mne.Evoked.plot_image`, and :meth:`~mne.Epochs.plot_image` (:gh:`12057` by `Santeri Ruuskanen`_)
 - :func:`~mne.epochs.make_metadata` now accepts ``tmin=None`` and ``tmax=None``, which will bound the time window used for metadata generation by event names (instead of a fixed time). That way, you can now for example generate metadata spanning from one cue or fixation cross to the next, even if trial durations vary throughout the recording (:gh:`12118` by `Richard Höchenberger`_)
+- Added documentation to :func:`mne.io.Raw.set_montage`and :func:`mne.add_reference_channels` to specify that montages should be set after adding reference channels (:gh:`12160` by `Jacob Woessner`_)
 
 Bugs
 ~~~~

--- a/mne/_fiff/meas_info.py
+++ b/mne/_fiff/meas_info.py
@@ -412,8 +412,8 @@ class MontageMixin:
             functions.
         .. warning::
             Applying a montage will only set locations of channels that exist
-            at the time it is applied. This means when :doc:`re-referencing
-            </auto_tutorials/preprocessing/55_setting_eeg_reference>`
+            at the time it is applied. This means when
+            :ref:`re-referencing <tut-set-eeg-ref>`
             make sure to apply the montage only after calling
             :func:`mne.add_reference_channels`
         """

--- a/mne/_fiff/meas_info.py
+++ b/mne/_fiff/meas_info.py
@@ -410,6 +410,13 @@ class MontageMixin:
             a montage. Other channel types (e.g., MEG channels) should have
             their positions defined properly using their data reading
             functions.
+        .. warning::
+            Applying a montage will only set locations of channels that exist
+            at the time it is applied. This means when
+            :doc:`re-referencing
+            </auto_tutorials/preprocessing/55_setting_eeg_reference>`
+            make sure to apply the montage after calling
+            :func:`mne.add_reference_channels`
         """
         # How to set up a montage to old named fif file (walk through example)
         # https://gist.github.com/massich/f6a9f4799f1fbeb8f5e8f8bc7b07d3df

--- a/mne/_fiff/meas_info.py
+++ b/mne/_fiff/meas_info.py
@@ -412,10 +412,9 @@ class MontageMixin:
             functions.
         .. warning::
             Applying a montage will only set locations of channels that exist
-            at the time it is applied. This means when
-            :doc:`re-referencing
+            at the time it is applied. This means when :doc:`re-referencing
             </auto_tutorials/preprocessing/55_setting_eeg_reference>`
-            make sure to apply the montage after calling
+            make sure to apply the montage only after calling
             :func:`mne.add_reference_channels`
         """
         # How to set up a montage to old named fif file (walk through example)

--- a/mne/_fiff/reference.py
+++ b/mne/_fiff/reference.py
@@ -179,9 +179,8 @@ def add_reference_channels(inst, ref_channels, copy=True):
     Notes
     -----
     .. warning::
-        When :doc:`re-referencing
-        </auto_tutorials/preprocessing/55_setting_eeg_reference>`
-        , make sure to apply the montage using :func:`mne.io.Raw.set_montage`
+        When :ref:`re-referencing <tut-set-eeg-ref>`,
+        make sure to apply the montage using :func:`mne.io.Raw.set_montage`
         only after calling this function. Applying a montage will only set
         locations of channels that exist at the time it is applied.
     """

--- a/mne/_fiff/reference.py
+++ b/mne/_fiff/reference.py
@@ -180,7 +180,7 @@ def add_reference_channels(inst, ref_channels, copy=True):
     -----
     .. warning::
         When :ref:`re-referencing <tut-set-eeg-ref>`,
-        make sure to apply the montage using :func:`mne.io.Raw.set_montage`
+        make sure to apply the montage using :meth:`mne.io.Raw.set_montage`
         only after calling this function. Applying a montage will only set
         locations of channels that exist at the time it is applied.
     """

--- a/mne/_fiff/reference.py
+++ b/mne/_fiff/reference.py
@@ -175,6 +175,15 @@ def add_reference_channels(inst, ref_channels, copy=True):
     -------
     inst : instance of Raw | Epochs | Evoked
         Data with added EEG reference channels.
+
+    Notes
+    -----
+    .. warning::
+        When :doc:`re-referencing
+        </auto_tutorials/preprocessing/55_setting_eeg_reference>`
+        , make sure to apply the montage using :func:`mne.io.Raw.set_montage`
+        only after calling this function. Applying a montage will only set
+        locations of channels that exist at the time it is applied.
     """
     from ..epochs import BaseEpochs
     from ..evoked import Evoked
@@ -239,7 +248,9 @@ def add_reference_channels(inst, ref_channels, copy=True):
         ref_dig_array = np.full(12, np.nan)
         logger.info(
             "Location for this channel is unknown; consider calling "
-            "set_montage() again if needed."
+            "set_montage() after adding new reference channels if needed. "
+            "Applying a montage will only set locations of channels that "
+            "exist at the time it is applied."
         )
 
     for ch in ref_channels:


### PR DESCRIPTION

#### Reference issue
Example: Fixes #5619


#### What does this implement/fix?
Adds documentation that explains that the montage must be set after adding a reference.


#### Additional information
Should I also add a warning that runs inside the code itself after running `set_montage`?
