### PR TITLE
Changed casting rule in np.clip to allow reading of raw GDF files

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -49,6 +49,7 @@ Enhancements
 
 Bugs
 ~~~~
+- Fix bug where :func:`mne.io.read_raw_gdf` would fail due to improper usage of ``np.clip`` (:gh:`12168` by :newcontrib:`Rasmus Aagaard`) 
 - Fix bugs with :func:`mne.preprocessing.realign_raw` where the start of ``other`` was incorrectly cropped; and onsets and durations in ``other.annotations`` were left unsynced with the resampled data (:gh:`11950` by :newcontrib:`Qian Chu`)
 - Fix bug where ``encoding`` argument was ignored when reading annotations from an EDF file (:gh:`11958` by :newcontrib:`Andrew Gilbert`)
 - Mark tests ``test_adjacency_matches_ft`` and ``test_fetch_uncompressed_file`` as network tests (:gh:`12041` by :newcontrib:`Maksym Balatsko`)

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -442,6 +442,8 @@
 
 .. _ramonapariciog: https://github.com/ramonapariciog
 
+.. _Rasmus Aagaard: https://github.com/rasgaard
+
 .. _Rasmus Zetter: https://people.aalto.fi/rasmus.zetter
 
 .. _Reza Nasri: https://github.com/rznas

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1443,7 +1443,7 @@ def _read_gdf_header(fname, exclude, include=None):
                 else:
                     chn = np.zeros(n_events, dtype=np.uint32)
                     dur = np.ones(n_events, dtype=np.uint32)
-                np.clip(dur, 1, np.inf, out=dur, casting="unsafe")
+                np.maximum(dur, 1, out=dur)
                 events = [n_events, pos, typ, chn, dur]
                 edf_info["event_sfreq"] = event_sr
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1443,7 +1443,7 @@ def _read_gdf_header(fname, exclude, include=None):
                 else:
                     chn = np.zeros(n_events, dtype=np.uint32)
                     dur = np.ones(n_events, dtype=np.uint32)
-                np.clip(dur, 1, np.inf, out=dur)
+                np.clip(dur, 1, np.inf, out=dur, casting="unsafe")
                 events = [n_events, pos, typ, chn, dur]
                 edf_info["event_sfreq"] = event_sr
 
@@ -1878,7 +1878,7 @@ def read_raw_gdf(
     input_fname = os.path.abspath(input_fname)
     ext = os.path.splitext(input_fname)[1][1:].lower()
     if ext != "gdf":
-        raise NotImplementedError(f"Only BDF files are supported, got {ext}.")
+        raise NotImplementedError(f"Only GDF files are supported, got {ext}.")
     return RawGDF(
         input_fname=input_fname,
         eog=eog,


### PR DESCRIPTION
When reading in raw GDF files I got the following error
>UFuncTypeError: Cannot cast ufunc 'clip' output from dtype('float64') to dtype('uint32') with casting rule 'same_kind'

Referring to the usage of `np.clip` here: https://github.com/mne-tools/mne-python/blob/87d6be9047bbd5b234e22eafd79ab7695814fb41/mne/io/edf/edf.py#L1446

This error can reproduced noting that `np.inf` has dtype of `float64`. 
```python
import numpy as np
dur = np.ones(10, dtype=np.uint32)
np.clip(dur, 1, np.inf, out=dur)
>>> UFuncTypeError: Cannot cast ufunc 'clip' output from dtype('float64') to dtype('uint32') with casting rule 'same_kind'
```
Changing aforementioned line 1446 to `np.clip(dur, 1, np.inf, out=dur, casting="unsafe")` seemingly fixes this issue.

Additionally, there is a typo when using the `read_raw_gdf`-function on files that does not have the `gdf`-file extenion https://github.com/mne-tools/mne-python/blob/87d6be9047bbd5b234e22eafd79ab7695814fb41/mne/io/edf/edf.py#L1881 