### PR TITLE
FIX: skip empty lines in read_raw_eyelink

### DIFF
--- a/mne/io/eyelink/_utils.py
+++ b/mne/io/eyelink/_utils.py
@@ -122,6 +122,8 @@ def _parse_recording_blocks(fname):
                 is_recording_block = True
             if is_recording_block:
                 tokens = line.split()
+                if not tokens:
+                    continue  # skip empty lines
                 if tokens[0][0].isnumeric():  # Samples
                     data_dict["sample_lines"].append(tokens)
                 elif tokens[0] in data_dict["event_lines"].keys():


### PR DESCRIPTION
This PR Fixes a problem with reading an Eyelink file that was raised on the Discussion forum: https://mne.discourse.group/t/issue-with-read-raw-eyelink/7787


The problematic file provided by the researcher had a line that only contained a newline character, which broke the parser.
This branch checks for and skips empty lines, fixing the problem.

I did a quick performance check to see how much longer file reading takes with the additional checks:

```
import mne
fname = mne.datasets.eyelink.data_path() / "eeg-et" / "sub-01_task-plr_eyetrack.asc"
%timeit mne.io.read_raw_eyelink(fname)
```

on main:
```
860 ms ± 30.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

on this branch:

```
997 ms ± 139 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```