### PR TITLE
BUG: Fix bug with default alpha and axes

### DIFF
--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -984,7 +984,7 @@ def _handle_sensor_types(meg, eeg, fnirs):
         fnirs=dict(channels="fnirs", pairs="fnirs_pairs"),
     )
     sensor_alpha = {
-        key: 0.25 if key == "meg_helmet" else 0.8
+        key: dict(meg_helmet=0.25, meg=0.25).get(key, 0.8)
         for ch_dict in alpha_map.values()
         for key in ch_dict.values()
     }

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -733,7 +733,7 @@ class _PyVistaRenderer(_AbstractRenderer):
                 mesh=mesh,
                 color=color,
                 opacity=opacity,
-                scalars=mesh_scalars,
+                scalars=mesh_scalars if colormap is not None else None,
                 colormap=colormap,
                 show_scalar_bar=False,
                 backface_culling=backface_culling,

--- a/tutorials/forward/20_source_alignment.py
+++ b/tutorials/forward/20_source_alignment.py
@@ -66,8 +66,7 @@ t1_mgh = nib.MGHImage(t1w.dataobj, t1w.affine)
 # to their equivalent locations in another. The three main coordinate frames
 # are:
 #
-# * :blue:`"meg"`: the coordinate frame for the physical locations of MEG
-#   sensors
+# * :blue:`"meg"`: the coordinate frame for the physical locations of MEG sensors
 # * :gray:`"mri"`: the coordinate frame for MRI images, and scalp/skull/brain
 #   surfaces derived from the MRI images
 # * :pink:`"head"`: the coordinate frame for digitized sensor locations and


### PR DESCRIPTION
I noticed two 3D rendering bug I introduced recently, fixed on this PR:

| [stable](https://mne.tools/stable/auto_tutorials/forward/20_source_alignment.html) | [dev](https://mne.tools/dev/auto_tutorials/forward/20_source_alignment.html) | PR |
| -- | -- | -- |
| ![image](https://github.com/mne-tools/mne-python/assets/2365790/6760c7b0-8336-4649-93dc-44024c6f4234) | ![image](https://github.com/mne-tools/mne-python/assets/2365790/40505023-daba-4a66-9c4d-4cf72f117b7f) | ![image](https://github.com/mne-tools/mne-python/assets/2365790/7727d7e2-966e-4a12-935b-6992675ec6a2) |

1. The axes are errantly multicolored
2. The MEG sensor opacity is too high

This PR fixes those two issues
