### PR TITLE
MAINT: Fix CIs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,7 @@ jobs:
       - name: 'Install OSMesa VTK variant'
         run: |
           # TODO: As of 2023/02/28, notebook tests need a pinned mesalib
-          mamba install -c conda-forge "vtk>=9.2=*osmesa*" "vtk-base>=9.2=*osmesa*" "mesalib=23.1.4"
+          mamba install -c conda-forge "vtk>=9.2=*osmesa*" "vtk-base>=9.2=*osmesa*" "mesalib=23.1.4" "numpy=1.24.4" "numba=0.57.1"
           mamba list
         if: matrix.kind == 'notebook'
       - run: ./tools/github_actions_dependencies.sh


### PR DESCRIPTION
I am tempted to get rid of this `osmesa` job since I think we already test notebooks on systems with VMs, and we should be able to trust PyVista / trame to deal with the client + headless-server stuff. But let's see if this commit fixes things for a while.

If not I'll probably just get rid of the `notebook` job...

For now I'm trying pinning `numpy` and `numba` since these are what appear to have changed between the two builds based on the `mamba list` calls on one that failed and one that succeeded.