### PR TITLE
MRG: Add ICA's `fit_params` to HTML representation

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -48,6 +48,7 @@ Enhancements
 - Add support for passing multiple labels to :func:`mne.minimum_norm.source_induced_power` (:gh:`12026` by `Erica Peterson`_, `Eric Larson`_, and `Daniel McCloy`_ )
 - Added documentation to :meth:`mne.io.Raw.set_montage` and :func:`mne.add_reference_channels` to specify that montages should be set after adding reference channels (:gh:`12160` by `Jacob Woessner`_)
 - Add argument ``splash`` to the function using the ``qt`` browser backend to allow enabling/disabling the splash screen (:gh:`12185` by `Mathieu Scheltienne`_)
+- :class:`~mne.preprocessing.ICA`'s HTML representation (displayed in Jupyter notebooks and :class:`mne.Report`) now includes all optional fit parameters (e.g., max. number of iterations) (:gh:`xxx`, by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -48,7 +48,7 @@ Enhancements
 - Add support for passing multiple labels to :func:`mne.minimum_norm.source_induced_power` (:gh:`12026` by `Erica Peterson`_, `Eric Larson`_, and `Daniel McCloy`_ )
 - Added documentation to :meth:`mne.io.Raw.set_montage` and :func:`mne.add_reference_channels` to specify that montages should be set after adding reference channels (:gh:`12160` by `Jacob Woessner`_)
 - Add argument ``splash`` to the function using the ``qt`` browser backend to allow enabling/disabling the splash screen (:gh:`12185` by `Mathieu Scheltienne`_)
-- :class:`~mne.preprocessing.ICA`'s HTML representation (displayed in Jupyter notebooks and :class:`mne.Report`) now includes all optional fit parameters (e.g., max. number of iterations) (:gh:`xxx`, by `Richard Höchenberger`_)
+- :class:`~mne.preprocessing.ICA`'s HTML representation (displayed in Jupyter notebooks and :class:`mne.Report`) now includes all optional fit parameters (e.g., max. number of iterations) (:gh:`12194`, by `Richard Höchenberger`_)
 
 Bugs
 ~~~~

--- a/mne/html_templates/repr/ica.html.jinja
+++ b/mne/html_templates/repr/ica.html.jinja
@@ -4,6 +4,10 @@
         <td>{{ method }}</td>
     </tr>
     <tr>
+        <th>Fit parameters</th>
+        <td>{% if fit_params %}{% for key, value in fit_params.items() %}{{ key }}={{ value }}<br />{% endfor %}{% else %}&mdash;{% endif %}</td>
+    </tr>
+    <tr>
         <th>Fit</th>
         <td>{% if fit_on %}{{ n_iter }} iterations on {{ fit_on }} ({{ n_samples }} samples){% else %}no{% endif %}</td>
     </tr>

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, is_dataclass
 from inspect import Parameter, isfunction, signature
 from numbers import Integral
 from time import time
-from typing import List, Literal, Optional
+from typing import Dict, List, Literal, Optional, Union
 
 import numpy as np
 from scipy import linalg, stats
@@ -507,6 +507,7 @@ class ICA(ContainsMixin):
         class _InfosForRepr:
             fit_on: Optional[Literal["raw data", "epochs"]]
             fit_method: Literal["fastica", "infomax", "extended-infomax", "picard"]
+            fit_params: Dict[str, Union[str, float]]
             fit_n_iter: Optional[int]
             fit_n_samples: Optional[int]
             fit_n_components: Optional[int]
@@ -522,6 +523,7 @@ class ICA(ContainsMixin):
             fit_on = "epochs"
 
         fit_method = self.method
+        fit_params = self.fit_params
         fit_n_iter = getattr(self, "n_iter_", None)
         fit_n_samples = getattr(self, "n_samples_", None)
         fit_n_components = getattr(self, "n_components_", None)
@@ -542,6 +544,7 @@ class ICA(ContainsMixin):
         infos_for_repr = _InfosForRepr(
             fit_on=fit_on,
             fit_method=fit_method,
+            fit_params=fit_params,
             fit_n_iter=fit_n_iter,
             fit_n_samples=fit_n_samples,
             fit_n_components=fit_n_components,
@@ -576,6 +579,7 @@ class ICA(ContainsMixin):
         html = t.render(
             fit_on=infos.fit_on,
             method=infos.fit_method,
+            fit_params=infos.fit_params,
             n_iter=infos.fit_n_iter,
             n_samples=infos.fit_n_samples,
             n_components=infos.fit_n_components,

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -490,6 +490,7 @@ def test_ica_core(method, n_components, noise_cov, n_pca_components, browser_bac
     repr_html_ = ica._repr_html_()
     assert repr_ == f"<ICA | no decomposition, method: {method}>"
     assert method in repr_html_
+    assert "max_iter=1" in repr_html_
 
     # test fit checker
     with pytest.raises(RuntimeError, match="No fit available"):


### PR DESCRIPTION
I was experimenting with different optional `fit_params` when working with ICA, generating Reports that included the HTML representation of ICA instances. However, I then realized that we don't display those fit parameters yet, even though we apply some defaults if the user doesn't explicitly pass any values. This PR adds this feature:
 
<img width="533" alt="Screenshot 2023-11-11 at 11 21 08" src="https://github.com/mne-tools/mne-python/assets/2046265/3e4a46e4-172a-424e-a325-e27ac820112e">
