### PR TITLE
ENH: increment testing ds version + hash

### DIFF
--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -87,7 +87,7 @@ I agree to the following:
 # respective repos, and make a new release of the dataset on GitHub. Then
 # update the checksum in the MNE_DATASETS dict below, and change version
 # here:                  ↓↓↓↓↓         ↓↓↓
-RELEASES = dict(testing="0.149", misc="0.26")
+RELEASES = dict(testing="0.150", misc="0.26")
 TESTING_VERSIONED = f'mne-testing-data-{RELEASES["testing"]}'
 MISC_VERSIONED = f'mne-misc-data-{RELEASES["misc"]}'
 
@@ -111,7 +111,7 @@ MNE_DATASETS = dict()
 # Testing and misc are at the top as they're updated most often
 MNE_DATASETS["testing"] = dict(
     archive_name=f"{TESTING_VERSIONED}.tar.gz",
-    hash="md5:86c47eb83426f48ff17338cb0e379754",
+    hash="md5:0b7452daef4d19132505b5639d695628",
     url=(
         "https://codeload.github.com/mne-tools/mne-testing-data/"
         f'tar.gz/{RELEASES["testing"]}'


### PR DESCRIPTION
#### Reference issue
ENH: Follow up to the [PR in mne-testing-repo](https://github.com/mne-tools/mne-testing-data/pull/111) and the new testing dataset release.


#### What does this implement/fix?
Incrementing testing dataset version to 0.150 and setting the new hash.