### PR TITLE
Fix issue 11712  "Function _plot_connectivity_circle connects nodes with score zero"

### DIFF
--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -290,6 +290,8 @@ def _plot_connectivity_circle(
 
     # Finally, we draw the connections
     for pos, (i, j) in enumerate(zip(indices[0], indices[1])):
+        if con_val_scaled[pos] == 0:
+            continue
         # Start point
         t0, r0 = node_angles[i], 10
 


### PR DESCRIPTION
#### Reference issue
Example: Fixes #11712 .


#### What does this implement/fix?
Now function `_plot_connectivity_circle` only shows links between nodes when the score between nodes is larger than zero.
