### PR TITLE
Add tomli to rstcheck dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,4 +47,6 @@ repos:
     rev: v6.2.0
     hooks:
       - id: rstcheck
+        additional_dependencies:
+          - tomli
         files: ^doc/.*\.(rst|inc)$


### PR DESCRIPTION
This was needed on my end to have the rstcheck pre-commit hook work correctly.