### PR TITLE
Remove Python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,16 +63,16 @@ jobs:
             python: '3.11'
             kind: pip-pre
           - os: macos-latest
-            python: '3.8'
+            python: '3.9'
             kind: mamba
           - os: windows-latest
             python: '3.10'
             kind: mamba
           - os: ubuntu-latest
-            python: '3.8'
+            python: '3.9'
             kind: minimal
           - os: ubuntu-20.04
-            python: '3.8'
+            python: '3.9'
             kind: old
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,6 @@ repos:
         additional_dependencies:
           - tomli
         files: ^doc/.*\.(rst|inc)$
+
+ci:
+  autofix_prs: false

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ only, use pip_ in a terminal:
 
     $ pip install --upgrade mne
 
-The current MNE-Python release requires Python 3.8 or higher. MNE-Python 0.17
+The current MNE-Python release requires Python 3.9 or higher. MNE-Python 0.17
 was the last release to support Python 2.7.
 
 For more complete instructions, including our standalone installers and more
@@ -73,7 +73,7 @@ Dependencies
 
 The minimum required dependencies to run MNE-Python are:
 
-- `Python <https://www.python.org>`__ ≥ 3.8
+- `Python <https://www.python.org>`__ ≥ 3.9
 - `NumPy <https://numpy.org>`__ ≥ 1.21.2
 - `SciPy <https://scipy.org>`__ ≥ 1.7.1
 - `Matplotlib <https://matplotlib.org>`__ ≥ 3.5.0

--- a/doc/development/contributing.rst
+++ b/doc/development/contributing.rst
@@ -243,7 +243,7 @@ Creating the virtual environment
 These instructions will set up a Python environment that is separated from your
 system-level Python and any other managed Python environments on your computer.
 This lets you switch between different versions of Python (MNE-Python requires
-version 3.8 or higher) and also switch between the stable and development
+version 3.9 or higher) and also switch between the stable and development
 versions of MNE-Python (so you can, for example, use the same computer to
 analyze your data with the stable release, and also work with the latest
 development version to fix bugs or add new features). Even if you've already

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: mne
 channels:
   - conda-forge
 dependencies:
-  - python>=3.8
+  - python>=3.9
   - pip
   - numpy
   - scipy

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -10,7 +10,6 @@ import multiprocessing
 import os
 import os.path as op
 import platform
-import re
 import shutil
 import subprocess
 import sys

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -626,16 +626,6 @@ def sys_info(
     _validate_type(check_version, (bool, "numeric"), "check_version")
     ljust = 24 if dependencies == "developer" else 21
     platform_str = platform.platform()
-    if platform.system() == "Darwin" and sys.version_info[:2] < (3, 8):
-        # platform.platform() in Python < 3.8 doesn't call
-        # platform.mac_ver() if we're on Darwin, so we don't get a nice macOS
-        # version number. Therefore, let's do this manually here.
-        macos_ver = platform.mac_ver()[0]
-        macos_architecture = re.findall("Darwin-.*?-(.*)", platform_str)
-        if macos_architecture:
-            macos_architecture = macos_architecture[0]
-            platform_str = f"macOS-{macos_ver}-{macos_architecture}"
-        del macos_ver, macos_architecture
 
     out = partial(print, end="", file=fid)
     out("Platform".ljust(ljust) + platform_str + "\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 maintainers = [{ name = "Dan McCloy", email = "dan@mccloy.info" }]
 license = { text = "BSD-3-Clause" }
 readme = { file = "README.rst", content-type = "text/x-rst" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = [
     "neuroscience",
     "neuroimaging",


### PR DESCRIPTION
Now that v1.6 is out, it's time to remove support for Python 3.8. We should also add support for Python 3.12, but since I don't know if there are any major blockers (likely!), we'd better tackle this in another PR.

This PR is required for #12218.