### PR TITLE
Add some omitted dependencies to "full" and "doc" variants

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,11 @@ full = [
     "darkdetect",
     "qdarkstyle",
     "threadpoolctl",
+    # duplicated in test_extra:
+    "eeglabio",
+    "edfio>=0.2.1",
+    "pybv",
+    "snirf",
 ]
 
 # Dependencies for running the test infrastructure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,9 +157,8 @@ doc = [
     "pyzmq!=24.0.0",
     "ipython!=8.7.0",
     "selenium",
-    "rcssmin",
 ]
-dev = ["mne[test,doc]"]
+dev = ["mne[test,doc]", "rcssmin"]
 
 [project.urls]
 Homepage = "https://mne.tools/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ doc = [
     "pyzmq!=24.0.0",
     "ipython!=8.7.0",
     "selenium",
+    "rcssmin",
 ]
 dev = ["mne[test,doc]"]
 


### PR DESCRIPTION
A few dependencies were only included in `test_extra`, but they should also be included in `full` (e.g., `pybv`). This now adds duplication – should we add a "private" variant to avoid this?

Another `doc` dep was needed for running `mne/report/js_and_css/bootstrap-icons/gen_css_for_mne.py`
