### PR TITLE
Fix incorrect type hint in Neuralynx I/O module

### DIFF
--- a/doc/api/reading_raw_data.rst
+++ b/doc/api/reading_raw_data.rst
@@ -40,6 +40,7 @@ Reading raw data
    read_raw_nihon
    read_raw_fil
    read_raw_nsx
+   read_raw_neuralynx
 
 Base class:
 

--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -29,7 +29,7 @@ Enhancements
 Bugs
 ~~~~
 - Allow :func:`mne.viz.plot_compare_evokeds` to plot eyetracking channels, and improve error handling (:gh:`12190` by `Scott Huberty`_)
-- Fix bug with type hints in :func:`mne.io.read_raw_neuralynx` (:gh:`12236` by `Richard Hoechenberger`_)
+- Fix bug with type hints in :func:`mne.io.read_raw_neuralynx` (:gh:`12236` by `Richard Höchenberger`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -29,6 +29,7 @@ Enhancements
 Bugs
 ~~~~
 - Allow :func:`mne.viz.plot_compare_evokeds` to plot eyetracking channels, and improve error handling (:gh:`12190` by `Scott Huberty`_)
+- Fix bug with type hints in :func:`mne.io.read_raw_neuralynx` (:gh:`12236` by `Richard Hoechenberger`_)
 
 API changes
 ~~~~~~~~~~~

--- a/doc/changes/v1.6.rst
+++ b/doc/changes/v1.6.rst
@@ -5,7 +5,7 @@ Version 1.6.0 (2023-11-20)
 
 Enhancements
 ~~~~~~~~~~~~
-- Add support for Neuralynx data files with ``mne.io.read_raw_neuralynx`` (:gh:`11969` by :newcontrib:`Kristijan Armeni` and :newcontrib:`Ivan Skelin`)
+- Add support for Neuralynx data files with :func:`mne.io.read_raw_neuralynx` (:gh:`11969` by :newcontrib:`Kristijan Armeni` and :newcontrib:`Ivan Skelin`)
 - Improve tests for saving splits with :class:`mne.Epochs` (:gh:`11884` by `Dmitrii Altukhov`_)
 - Added functionality for linking interactive figures together, such that changing one figure will affect another, see :ref:`tut-ui-events` and :mod:`mne.viz.ui_events`. Current figures implementing UI events are :func:`mne.viz.plot_topomap` and :func:`mne.viz.plot_source_estimates` (:gh:`11685` :gh:`11891` by `Marijn van Vliet`_)
 - HTML anchors for :class:`mne.Report` now reflect the ``section-title`` of the report items rather than using a global incrementor ``global-N`` (:gh:`11890` by `Eric Larson`_)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -382,6 +382,7 @@ numpydoc_xref_ignore = {
     "RawBrainVision",
     "RawCurry",
     "RawNIRX",
+    "RawNeuralynx",
     "RawGDF",
     "RawSNIRF",
     "RawBOXY",

--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -46,9 +46,7 @@ class RawNeuralynx(BaseRaw):
     """RawNeuralynx class."""
 
     @verbose
-    def __init__(
-        self, fname, preload=False, verbose=None, exclude_fname_patterns: list = None
-    ):
+    def __init__(self, fname, preload=False, verbose=None, exclude_fname_patterns=None):
         _soft_import("neo", "Reading NeuralynxIO files", strict=True)
         from neo.io import NeuralynxIO
 

--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -38,7 +38,12 @@ def read_raw_neuralynx(
     --------
     mne.io.Raw : Documentation of attributes and methods of RawNeuralynx.
     """
-    return RawNeuralynx(fname, preload, verbose, exclude_fname_patterns)
+    return RawNeuralynx(
+        fname,
+        preload=preload,
+        exclude_fname_patterns=exclude_fname_patterns,
+        verbose=verbose,
+    )
 
 
 @fill_doc
@@ -46,7 +51,14 @@ class RawNeuralynx(BaseRaw):
     """RawNeuralynx class."""
 
     @verbose
-    def __init__(self, fname, preload=False, verbose=None, exclude_fname_patterns=None):
+    def __init__(
+        self,
+        fname,
+        *,
+        preload=False,
+        exclude_fname_patterns=None,
+        verbose=None,
+    ):
         _soft_import("neo", "Reading NeuralynxIO files", strict=True)
         from neo.io import NeuralynxIO
 


### PR DESCRIPTION
An incorrect type hint sneaked in via #11969, causing confusion to static type checkers.

Since we don't use type hints in MNE yet (except for some very rare exceptions), I simply removed the faulty one instead of fixing it.

cc @KristijanArmeni 

FYI the correct hint for our supported versions of Python would be `Optional[List[str]]` or `Union[None, List[str]]`