### PR TITLE
DOC: fix the description of extract_label_time_course modes

### DIFF
--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1193,7 +1193,7 @@ docdict[
 Valid values for ``mode`` are:
 
 - ``'max'``
-    Maximum value across vertices at each time point within each label.
+    Maximum absolute value across vertices at each time point within each label.
 - ``'mean'``
     Average across vertices at each time point within each label. Ignores
     orientation of sources for standard source estimates, which varies
@@ -1203,7 +1203,7 @@ Valid values for ``mode`` are:
 - ``'mean_flip'``
     Finds the dominant direction of source space normal vector orientations
     within each label, applies a sign-flip to time series at vertices whose
-    orientation is more than 180° different from the dominant direction, and
+    orientation is more than 90° different from the dominant direction, and
     then averages across vertices at each time point within each label.
 - ``'pca_flip'``
     Applies singular value decomposition to the time courses within each label,


### PR DESCRIPTION
#### Reference issue
#11922 


#### What does this implement/fix?
This PR fixes two small details in the description of `max` and `mean_flip` modes for `mne.extract_label_time_course`.
