### PR TITLE
Fix pyproject.toml setuptools configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,9 +176,8 @@ namespaces = false
 write_to = "mne/_version.py"
 version_scheme = "release-branch-semver"
 
-[options]
-zip_safe = false            # the package can run out of an .egg file
-include_package_data = true
+[tool.setuptools]
+include-package-data = true
 
 [tool.setuptools.package-data]
 "mne" = [


### PR DESCRIPTION
My linter showed the entire pyproject.toml file in red, so I went on the investigate.

Turns out both section and key names were incorrect. I fixed that. I also removed the zip-safe flag because it's been deprecated for many years and isn't used anymore.

BTW the linter I'm using is https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml
It's pyproject.toml-aware.