### PR TITLE
MAINT: Restore NumPy 2.0 testing

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - traitlets
   - pyvista>=0.32,!=0.35.2,!=0.38.0,!=0.38.1,!=0.38.2,!=0.38.3,!=0.38.4,!=0.38.5,!=0.38.6,!=0.42.0
   - pyvistaqt>=0.4
-  - qdarkstyle
+  - qdarkstyle!=3.2.2
   - darkdetect
   - dipy
   - nibabel

--- a/mne/gui/tests/test_coreg.py
+++ b/mne/gui/tests/test_coreg.py
@@ -93,7 +93,7 @@ def test_coreg_gui_pyvista_file_support(
     """Test reading supported files."""
     from mne.gui import coregistration
 
-    if inst_path.suffix == ".snirf":
+    if Path(inst_path).suffix == ".snirf":
         pytest.importorskip("snirf")
 
     if inst_path == "gen_montage":

--- a/mne/gui/tests/test_coreg.py
+++ b/mne/gui/tests/test_coreg.py
@@ -93,6 +93,9 @@ def test_coreg_gui_pyvista_file_support(
     """Test reading supported files."""
     from mne.gui import coregistration
 
+    if inst_path.suffix == ".snirf":
+        pytest.importorskip("snirf")
+
     if inst_path == "gen_montage":
         # generate a montage fig to use as inst.
         tmp_info = read_info(raw_path)

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -103,6 +103,8 @@ def invisible_fig(monkeypatch):
 @testing.requires_testing_data
 def test_render_report(renderer_pyvistaqt, tmp_path, invisible_fig):
     """Test rendering *.fif files for mne report."""
+    pytest.importorskip("pymatreader")
+
     raw_fname_new = tmp_path / "temp_raw.fif"
     raw_fname_new_bids = tmp_path / "temp_meg.fif"
     ms_fname_new = tmp_path / "temp_ms_raw.fif"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ full = [
     "trame-vuetify",
     "mne-qt-browser",
     "darkdetect",
-    "qdarkstyle",
+    "qdarkstyle!=3.2.2",
     "threadpoolctl",
     # duplicated in test_extra:
     "eeglabio",

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -25,7 +25,7 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	python -m pip install --progress-bar off git+https://github.com/pyvista/pyvista
 	python -m pip install --progress-bar off git+https://github.com/pyvista/pyvistaqt
 	echo "misc"
-	python -m pip install $STD_ARGS imageio-ffmpeg xlrd mffpy python-picard pillow traitlets pybv eeglabio
+	python -m pip install $STD_ARGS imageio-ffmpeg xlrd mffpy pillow traitlets pybv eeglabio
 	echo "nibabel with workaround"
 	python -m pip install --progress-bar off git+https://github.com/nipy/nibabel.git
 	echo "joblib"

--- a/tools/azure_dependencies.sh
+++ b/tools/azure_dependencies.sh
@@ -10,16 +10,17 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	echo "Numpy etc."
 	# See github_actions_dependencies.sh for comments
 	python -m pip install $STD_ARGS --only-binary "numpy" numpy
-	python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "scipy>=1.12.0.dev0" scikit-learn matplotlib pandas statsmodels
-	echo "dipy"
-	python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" dipy
-	echo "h5py"
-	python -m pip install $STD_ARGS --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
+	python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0" "scipy>=1.12.0.dev0" scikit-learn matplotlib pandas statsmodels
+	# echo "dipy"
+	# python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" dipy
+	# echo "h5py"
+	# python -m pip install $STD_ARGS --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
+	# echo "OpenMEEG"
+	# pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://test.pypi.org/simple" openmeeg
 	echo "vtk"
 	python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://wheels.vtk.org" vtk
-	echo "nilearn and openmeeg"
+	echo "nilearn"
 	python -m pip install $STD_ARGS git+https://github.com/nilearn/nilearn
-	python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://test.pypi.org/simple" openmeeg
 	echo "pyvista/pyvistaqt"
 	python -m pip install --progress-bar off git+https://github.com/pyvista/pyvista
 	python -m pip install --progress-bar off git+https://github.com/pyvista/pyvistaqt
@@ -30,9 +31,9 @@ elif [ "${TEST_MODE}" == "pip-pre" ]; then
 	echo "joblib"
 	python -m pip install --progress-bar off git+https://github.com/joblib/joblib@master
 	echo "EDFlib-Python"
-	python -m pip install $STD_ARGS git+https://gitlab.com/Teuniz/EDFlib-Python@master
+	python -m pip install $STD_ARGS git+https://github.com/the-siesta-group/edfio
 	./tools/check_qt_import.sh PyQt6
-	python -m pip install $STD_ARGS -e .[hdf5,test]
+	python -m pip install $STD_ARGS -e .[test]
 else
 	echo "Unknown run type ${TEST_MODE}"
 	exit 1

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -24,20 +24,18 @@ else
 	echo "PyQt6"
 	pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6
 	echo "NumPy/SciPy/pandas etc."
-	# As of 2023/11/20 no NumPy 2.0 because it requires everything using its ABI to
-	# compile against 2.0, and h5py isn't (and probably not VTK either)
-	pip install $STD_ARGS --only-binary "numpy" --default-timeout=60 numpy
-	pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" scipy scikit-learn matplotlib pillow pandas statsmodels
-	echo "dipy"
-	pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" dipy
-	echo "H5py"
-	pip install $STD_ARGS --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
-	echo "OpenMEEG"
-	pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://test.pypi.org/simple" openmeeg
+	pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0" "scipy>=1.12.0.dev0" scikit-learn matplotlib pillow pandas statsmodels
+	# No dipy, h5py, openmeeg until they update to NumPy 2.0 compat
+	INSTALL_KIND="test_extra"
+	# echo "dipy"
+	# pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" dipy
+	# echo "H5py"
+	# pip install $STD_ARGS --only-binary ":all:" -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" h5py
+	# echo "OpenMEEG"
+	# pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://test.pypi.org/simple" openmeeg
 	# No Numba because it forces an old NumPy version
-	echo "nilearn and openmeeg"
+	echo "nilearn"
 	pip install $STD_ARGS git+https://github.com/nilearn/nilearn
-	pip install $STD_ARGS openmeeg
 	echo "VTK"
 	pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://wheels.vtk.org" vtk
 	python -c "import vtk"
@@ -53,10 +51,10 @@ else
 	pip install $STD_ARGS git+https://github.com/nipy/nibabel.git
 	echo "joblib"
 	pip install $STD_ARGS git+https://github.com/joblib/joblib@master
-	echo "EDFlib-Python"
-	pip install $STD_ARGS git+https://gitlab.com/Teuniz/EDFlib-Python@master
-	# Until Pandas is fixed, make sure we didn't install it
-	! python -c "import pandas"
+	echo "edfio"
+	pip install $STD_ARGS git+https://github.com/the-siesta-group/edfio
+	# Make sure we're on a NumPy 2.0 variant
+	python -c "import numpy as np; assert np.__version__[0] == '2', np.__version__"
 fi
 echo ""
 

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -25,7 +25,7 @@ else
 	pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6
 	echo "NumPy/SciPy/pandas etc."
 	pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0" "scipy>=1.12.0.dev0" scikit-learn matplotlib pillow pandas statsmodels
-	# No dipy, h5py, openmeeg until they update to NumPy 2.0 compat
+	# No dipy, h5py, openmeeg, python-picard (needs numexpr) until they update to NumPy 2.0 compat
 	INSTALL_KIND="test_extra"
 	# echo "dipy"
 	# pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scipy-wheels-nightly/simple" dipy
@@ -43,8 +43,8 @@ else
 	pip install $STD_ARGS git+https://github.com/pyvista/pyvista
 	echo "pyvistaqt"
 	pip install $STD_ARGS git+https://github.com/pyvista/pyvistaqt
-	echo "imageio-ffmpeg, xlrd, mffpy, python-picard"
-	pip install $STD_ARGS imageio-ffmpeg xlrd mffpy python-picard patsy traitlets pybv eeglabio
+	echo "imageio-ffmpeg, xlrd, mffpy"
+	pip install $STD_ARGS imageio-ffmpeg xlrd mffpy patsy traitlets pybv eeglabio
 	echo "mne-qt-browser"
 	pip install $STD_ARGS git+https://github.com/mne-tools/mne-qt-browser
 	echo "nibabel with workaround"


### PR DESCRIPTION
Put NumPy 2.0 back and remove HDF5 and dipy, which we'll have to omit until they release builds built against NumPy 2.0. Also fix a transition from EDFlib-Python to edfio in the install step that we missed.