### PR TITLE
MRG: Remove `_version.py` file; and small doc cleanups

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ codespell:  # running manually
 	@codespell --builtin clear,rare,informal,names,usage -w -i 3 -q 3 -S $(CODESPELL_SKIPS) --ignore-words=ignore_words.txt --uri-ignore-words-list=bu $(CODESPELL_DIRS)
 
 check-manifest:
-	check-manifest -q --ignore .circleci/config.yml,doc,logo,mne/io/*/tests/data*,mne/io/tests/data,mne/preprocessing/tests/data,.DS_Store,mne/_version.py
+	check-manifest -q --ignore .circleci/config.yml,doc,logo,mne/io/*/tests/data*,mne/io/tests/data,mne/preprocessing/tests/data,.DS_Store,.git_archival.txt
 
 check-readme: clean wheel
 	twine check dist/*

--- a/doc/development/contributing.rst
+++ b/doc/development/contributing.rst
@@ -304,11 +304,11 @@ be reflected the next time you open a Python interpreter and ``import mne``
 Finally, we'll add a few dependencies that are not needed for running
 MNE-Python, but are needed for locally running our test suite::
 
-    $ pip install -e .[test]
+    $ pip install -e ".[test]"
 
 And for building our documentation::
 
-    $ pip install -e .[doc]
+    $ pip install -e ".[doc]"
     $ conda install graphviz
 
 .. note::

--- a/doc/install/manual_install.rst
+++ b/doc/install/manual_install.rst
@@ -67,7 +67,7 @@ others), you should run via :code:`pip`:
 
 .. code-block:: console
 
-   $ pip install mne[hdf5]
+   $ pip install "mne[hdf5]"
 
 or via :code:`conda`:
 

--- a/doc/install/updating.rst
+++ b/doc/install/updating.rst
@@ -78,7 +78,7 @@ Sometimes, new features or bugfixes become available that are important to your
 research and you just can't wait for the next official release of MNE-Python to
 start taking advantage of them. In such cases, you can use ``pip`` to install
 the *development version* of MNE-Python. Ensure to activate the MNE conda
-environment first by running ``conda activate name_of_environment``.
+environment first by running ``conda activate mne``.
 
 .. code-block:: console
 

--- a/doc/install/updating.rst
+++ b/doc/install/updating.rst
@@ -82,4 +82,4 @@ environment first by running ``conda activate name_of_environment``.
 
 .. code-block:: console
 
-    $ pip install -U --no-deps git+https://github.com/mne-tools/mne-python@main
+    $ pip install -U --no-deps https://github.com/mne-tools/mne-python/archive/refs/heads/main.zip

--- a/mne/__init__.py
+++ b/mne/__init__.py
@@ -23,11 +23,10 @@ try:
 
     __version__ = version("mne")
 except Exception:
-    try:
-        from ._version import __version__
-    except ImportError:
-        __version__ = "0.0.0"
+    __version__ = "0.0.0"
+
 (__getattr__, __dir__, __all__) = lazy.attach_stub(__name__, __file__)
+
 # initialize logging
 from .utils import set_log_level, set_log_file
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,6 @@ include = ["mne*"]
 namespaces = false
 
 [tool.setuptools_scm]
-write_to = "mne/_version.py"
 version_scheme = "release-branch-semver"
 
 [tool.setuptools]


### PR DESCRIPTION
I added `.git_archival.txt`, which allows us to entirely remove the `mne/_version.py` file:
    
- When downloading an archive from GH, this file will then contain the  correct version number
- When building an sdist, the version number is added to `PKG-INFO`

I have also included some tiny corrections / touchups in the install & contributions guides.