### PR TITLE
BUG: Fix bug with last item access

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -29,6 +29,7 @@ Enhancements
 Bugs
 ~~~~
 - Allow :func:`mne.viz.plot_compare_evokeds` to plot eyetracking channels, and improve error handling (:gh:`12190` by `Scott Huberty`_)
+- Fix bug with accessing the last data sample using ``raw[:, -1]`` where an empty array was returned (:gh:`12248` by `Eric Larson`_)
 - Fix bug with type hints in :func:`mne.io.read_raw_neuralynx` (:gh:`12236` by `Richard Höchenberger`_)
 
 API changes

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -797,6 +797,9 @@ class BaseRaw(
                 item1 = int(item1)
             if isinstance(item1, (int, np.integer)):
                 start, stop, step = item1, item1 + 1, 1
+                # Need to special case -1, because -1:0 will be empty
+                if start == -1:
+                    stop = None
             else:
                 raise ValueError("Must pass int or slice to __getitem__")
 

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -1022,3 +1022,10 @@ def test_concatenate_raw_dev_head_t():
     raw.info["dev_head_t"]["trans"][0, 0] = np.nan
     raw2 = raw.copy()
     concatenate_raws([raw, raw2])
+
+
+def test_last_samp():
+    """Test that getting the last sample works."""
+    raw = read_raw_fif(raw_fname).crop(0, 0.1).load_data()
+    last_data = raw._data[:, [-1]]
+    assert_array_equal(raw[:, -1][0], last_data)


### PR DESCRIPTION
Perhaps I'm the first person to try `raw[:, -1]` because it returns an empty array on `main` which is wrong:
```
>>> raw[:, -1][0].shape
(63, 0)
```