### PR TITLE
Demo & RFC: Add return type hints to `read_evokeds()`

### DIFF
--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -1539,8 +1539,8 @@ def combine_evoked(all_evoked, weights):
 @overload
 def read_evokeds(
     fname,
-    condition: Literal[
-        None
+    condition: Union[
+        Literal[None], List[int], List[str]
     ] = None,  # repeating the default value here to help type the checker
     baseline=None,
     kind="average",
@@ -1554,7 +1554,7 @@ def read_evokeds(
 @overload
 def read_evokeds(
     fname,
-    condition: int,
+    condition: int | str,
     baseline=None,
     kind="average",
     proj=True,
@@ -1567,7 +1567,7 @@ def read_evokeds(
 @verbose
 def read_evokeds(
     fname,
-    condition: Optional[int] = None,
+    condition: Optional[Union[int, str, List[int], List[str]]] = None,
     baseline=None,
     kind="average",
     proj=True,

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -1554,7 +1554,7 @@ def read_evokeds(
 @overload
 def read_evokeds(
     fname,
-    condition: int | str,
+    condition: Union[int, str],
     baseline=None,
     kind="average",
     proj=True,

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -10,6 +10,13 @@
 
 from copy import deepcopy
 
+# Once we drop support for Py3.9:
+#
+#     Union -> |
+#     Optional[x] -> None | x
+#     List -> list
+from typing import List, Optional, Union, overload
+
 import numpy as np
 
 from ._fiff.constants import FIFF
@@ -1529,16 +1536,42 @@ def combine_evoked(all_evoked, weights):
     return evoked
 
 
-@verbose
+@overload
 def read_evokeds(
     fname,
-    condition=None,
+    condition: None = None,  # repeating the default value here to help type the checker
     baseline=None,
     kind="average",
     proj=True,
     allow_maxshield=False,
     verbose=None,
-):
+) -> List[Evoked]:
+    ...
+
+
+@overload
+def read_evokeds(
+    fname,
+    condition: int,
+    baseline=None,
+    kind="average",
+    proj=True,
+    allow_maxshield=False,
+    verbose=None,
+) -> Evoked:
+    ...
+
+
+@verbose
+def read_evokeds(
+    fname,
+    condition: Optional[int] = None,
+    baseline=None,
+    kind="average",
+    proj=True,
+    allow_maxshield=False,
+    verbose=None,
+) -> Union[Evoked, List[Evoked]]:
     """Read evoked dataset(s).
 
     Parameters

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -15,7 +15,7 @@ from copy import deepcopy
 #     Union -> |
 #     Optional[x] -> None | x
 #     List -> list
-from typing import List, Optional, Union, overload
+from typing import List, Literal, Optional, Union, overload
 
 import numpy as np
 
@@ -1539,7 +1539,9 @@ def combine_evoked(all_evoked, weights):
 @overload
 def read_evokeds(
     fname,
-    condition: None = None,  # repeating the default value here to help type the checker
+    condition: Literal[
+        None
+    ] = None,  # repeating the default value here to help type the checker
     baseline=None,
     kind="average",
     proj=True,


### PR DESCRIPTION
x-ref #12243

Here I'm demonstrating a slightly tricky case for type hints: the value of a parameter determines the function's return value. I just wanted to show to you what this looks like, so we can evaluate whether this is acceptable.

MWE:
```python
import mne

evokeds_path = (
    mne.datasets.sample.data_path() / "MEG" / "sample" / "sample_audvis-ave.fif"
)

evokeds = mne.read_evokeds(evokeds_path)
evoked = mne.read_evokeds(evokeds_path, condition=0)
```

`main`:
<img width="802" alt="Screenshot 2023-11-29 at 22 17 30" src="https://github.com/mne-tools/mne-python/assets/2046265/64fdf140-e14c-498f-bbb0-7037c209dff9">
<img width="802" alt="Screenshot 2023-11-29 at 22 17 37" src="https://github.com/mne-tools/mne-python/assets/2046265/91e9fd29-5b7d-43f5-bdd0-cfd03a0d824c">

This PR:
<img width="802" alt="Screenshot 2023-11-29 at 22 33 34" src="https://github.com/mne-tools/mne-python/assets/2046265/c2aefa36-11dd-4f56-bc00-0badd3c153de">
<img width="802" alt="Screenshot 2023-11-29 at 22 33 39" src="https://github.com/mne-tools/mne-python/assets/2046265/d5468ed2-db22-47d7-a391-cd0afaa93f8f">


cc @cbrnr @agramfort @larsoner @drammock 