### PR TITLE
[BUG, MRG] Account for clipping when finding voxel neighbors

### DIFF
--- a/mne/surface.py
+++ b/mne/surface.py
@@ -2175,7 +2175,7 @@ def _get_neighbors(loc, image, voxels, thresh, dist_params):
                 next_loc = tuple(next_loc)
                 if (
                     image[next_loc] > thresh
-                    and image[next_loc] < image[loc]
+                    and image[next_loc] <= image[loc]
                     and next_loc not in voxels
                 ):
                     neighbors.add(next_loc)


### PR DESCRIPTION
I used strictly less than before but since some of the images (e.g. CTs) have clipping, that caused equally high intensity neighbors not to be counted so this fixes that.