### PR TITLE
MAINT: Make selenium optional and use on CircleCI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ doc/*.dat
 doc/fil-result
 doc/optipng.exe
 sg_execution_times.rst
+sg_api_usage.rst
 cover
 *.html
 

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ doc/fil-result
 doc/optipng.exe
 sg_execution_times.rst
 sg_api_usage.rst
+sg_api_unused.dot
 cover
 *.html
 

--- a/doc/sphinxext/contrib_avatars.py
+++ b/doc/sphinxext/contrib_avatars.py
@@ -25,7 +25,7 @@ MNE_ADD_CONTRIBUTOR_IMAGE=true in your environment to generate it.</p>"""
             driver = webdriver.Chrome(options=options)
         except WebDriverException:
             options = webdriver.FirefoxOptions()
-            options.add_argument("--headless=new")
+            options.add_argument("-headless")
             driver = webdriver.Firefox(options=options)
         driver.get(f"file://{infile}")
         wait = WebDriverWait(driver, 20)

--- a/doc/sphinxext/contrib_avatars.py
+++ b/doc/sphinxext/contrib_avatars.py
@@ -1,11 +1,7 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
+import os
 from pathlib import Path
-
-from selenium import webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.common.exceptions import WebDriverException
 
 
 def generate_contrib_avatars(app, config):
@@ -13,21 +9,33 @@ def generate_contrib_avatars(app, config):
     root = Path(app.srcdir)
     infile = root / "sphinxext" / "_avatar_template.html"
     outfile = root / "_templates" / "avatars.html"
-    try:
-        options = webdriver.ChromeOptions()
-        options.add_argument("--headless=new")
-        driver = webdriver.Chrome(options=options)
-    except WebDriverException:
-        options = webdriver.FirefoxOptions()
-        options.add_argument("--headless=new")
-        driver = webdriver.Firefox(options=options)
-    driver.get(f"file://{infile}")
-    wait = WebDriverWait(driver, 20)
-    wait.until(lambda d: d.find_element(by=By.ID, value="contributor-avatars"))
-    body = driver.find_element(by=By.TAG_NAME, value="body").get_attribute("innerHTML")
+    if os.getenv("MNE_ADD_CONTRIBUTOR_IMAGE", "false").lower() != "true":
+        body = """\
+<p>Contributor avators will appear here in full doc builds. Set \
+MNE_ADD_CONTRIBUTOR_IMAGE=true in your environment to generate it.</p>"""
+    else:
+        from selenium import webdriver
+        from selenium.webdriver.common.by import By
+        from selenium.webdriver.support.ui import WebDriverWait
+        from selenium.common.exceptions import WebDriverException
+
+        try:
+            options = webdriver.ChromeOptions()
+            options.add_argument("--headless=new")
+            driver = webdriver.Chrome(options=options)
+        except WebDriverException:
+            options = webdriver.FirefoxOptions()
+            options.add_argument("--headless=new")
+            driver = webdriver.Firefox(options=options)
+        driver.get(f"file://{infile}")
+        wait = WebDriverWait(driver, 20)
+        wait.until(lambda d: d.find_element(by=By.ID, value="contributor-avatars"))
+        body = driver.find_element(by=By.TAG_NAME, value="body").get_attribute(
+            "innerHTML"
+        )
+        driver.quit()
     with open(outfile, "w") as fid:
         fid.write(body)
-    driver.quit()
 
 
 def setup(app):

--- a/tools/circleci_bash_env.sh
+++ b/tools/circleci_bash_env.sh
@@ -17,6 +17,7 @@ source tools/get_minimal_commands.sh
 echo "export MNE_3D_BACKEND=pyvistaqt" >> $BASH_ENV
 echo "export MNE_BROWSER_BACKEND=qt" >> $BASH_ENV
 echo "export MNE_BROWSER_PRECOMPUTE=false" >> $BASH_ENV
+echo "export MNE_ADD_CONTRIBUTOR_IMAGE=true" >> $BASH_ENV
 echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
 echo "export DISPLAY=:99" >> $BASH_ENV
 echo "source ~/python_env/bin/activate" >> $BASH_ENV


### PR DESCRIPTION
See title, should make it easier to build our docs. @britta-wstnr can you try building docs on this branch and see if it works? I made the avatar image gen opt-in (and opted CircleCI in) rather than opt-out so you should just be able to check out my branch, and run `make clean` then `make html` and see if it succeeds. I think we should iterate until things work for you to improve our odds of other contributors being able to build docs.