### PR TITLE
BUG: Fix bug with parent dir check

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -45,6 +45,7 @@ Bugs
 - Allow :func:`mne.viz.plot_compare_evokeds` to plot eyetracking channels, and improve error handling (:gh:`12190` by `Scott Huberty`_)
 - Fix bug with accessing the last data sample using ``raw[:, -1]`` where an empty array was returned (:gh:`12248` by `Eric Larson`_)
 - Remove incorrect type hints in :func:`mne.io.read_raw_neuralynx` (:gh:`12236` by `Richard Höchenberger`_)
+- Fix bug where parent directory existence was not checked properly in :meth:`mne.io.Raw.save` (:gh:`12282` by `Eric Larson`_)
 - ``defusedxml`` is now an optional (rather than required) dependency and needed when reading EGI-MFF data, NEDF data, and BrainVision montages (:gh:`12264` by `Eric Larson`_)
 
 API changes

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2563,6 +2563,13 @@ MAX_N_SPLITS = 100
 def _write_raw(raw_fid_writer, fpath, split_naming, overwrite):
     """Write raw file with splitting."""
     dir_path = fpath.parent
+    _check_fname(
+        dir_path,
+        overwrite="read",
+        must_exist=True,
+        name="parent directory",
+        need_dir=True,
+    )
     # We have to create one extra filename here to make the for loop below happy,
     # but it will raise an error if it actually gets used
     split_fnames = _make_split_fnames(

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -771,6 +771,10 @@ def test_io_raw(tmp_path):
     sl = slice(inds[0], inds[1])
     assert_allclose(data[:, sl], raw[:, sl][0], rtol=1e-6, atol=1e-20)
 
+    # missing dir raises informative error
+    with pytest.raises(FileNotFoundError, match="parent directory does not exist"):
+        raw.save(tmp_path / "foo" / "test_raw.fif", split_size="1MB")
+
 
 @pytest.mark.parametrize(
     "fname_in, fname_out",


### PR DESCRIPTION
Turns this cryptic error (from MNE-BIDS-Pipeline but the idea is clear I think):
```
│13:37:40│ 🐛 sub-01 run-noise A critical error occurred. The error message was: /mnt/ssds2/larsoner/mcq/natural-conversations-bids/derivatives/mne-bids-pipeline/sub-emptyroom/ses-20230412/meg/sub-emptyroom_ses-20230412_task-noise_proc-filt_split-01_raw.fif

Starting post-mortem debugger.
<traceback object at 0x7f11e2640d80>
> /home/larsoner/python/mne-python/mne/io/base.py(2606)__init__()
-> assert op.isdir(op.dirname(fname)), fname
```
into a useful one:
```
13:46:43│ 🐛 sub-01 run-noise A critical error occurred. The error message was: parent directory does not exist: "/mnt/ssds2/larsoner/mcq/natural-conversations-bids/derivatives/mne-bids-pipeline/sub-emptyroom/ses-20230412/meg"
```