### PR TITLE
Remove license text in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,40 +134,7 @@ About
 License
 ^^^^^^^
 
-MNE-Python is **BSD-licensed** (BSD-3-Clause):
-
-    This software is OSI Certified Open Source Software.
-    OSI Certified is a certification mark of the Open Source Initiative.
-
-    Copyright (c) 2011-2022, authors of MNE-Python.
-    All rights reserved.
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the names of MNE-Python authors nor the names of any
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    **This software is provided by the copyright holders and contributors
-    "as is" and any express or implied warranties, including, but not
-    limited to, the implied warranties of merchantability and fitness for
-    a particular purpose are disclaimed. In no event shall the copyright
-    owner or contributors be liable for any direct, indirect, incidental,
-    special, exemplary, or consequential damages (including, but not
-    limited to, procurement of substitute goods or services; loss of use,
-    data, or profits; or business interruption) however caused and on any
-    theory of liability, whether in contract, strict liability, or tort
-    (including negligence or otherwise) arising in any way out of the use
-    of this software, even if advised of the possibility of such
-    damage.**
+MNE-Python is licensed under the BSD-3-Clause license.
 
 
 .. _Documentation: https://mne.tools/dev/


### PR DESCRIPTION
I've removed the license text at the bottom of README.rst (now it just says that the license is BSD-3-Clause). I think this is sufficient, and the license text is linked in at least two places on GitHub (right sidebar and tab right next to README, Code of conduct, and Security).

We could even remove the entire section here, WDYT?