### PR TITLE
support different time formats in Annotations.to_data_frame()

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -39,6 +39,7 @@ Enhancements
 - We added type hints for the return values of :func:`mne.read_evokeds` and :func:`mne.io.read_raw`. Development environments like VS Code or PyCharm will now provide more help when using these functions in your code. (:gh:`12250` by `Richard Höchenberger`_ and `Eric Larson`_)
 - Add ``method="polyphase"`` to :meth:`mne.io.Raw.resample` and related functions to allow resampling using :func:`scipy.signal.upfirdn` (:gh:`12268` by `Eric Larson`_)
 - The package build backend was switched from ``setuptools`` to ``hatchling``. This will only affect users who build and install MNE-Python from source. (:gh:`12269`, :gh:`12281` by `Richard Höchenberger`_)
+- :meth:`mne.Annotations.to_data_frame` can now output different formats for the ``onset`` column: seconds, milliseconds, datetime objects, and timedelta objects. (:gh:`12289` by `Daniel McCloy`_)
 
 Bugs
 ~~~~

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -452,7 +452,7 @@ class Annotations:
         ----------
         %(time_format_df_raw)s
 
-            ..versionadded:: 1.7
+            .. versionadded:: 1.7
 
         Returns
         -------

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -444,7 +444,7 @@ class Annotations:
         self.description = np.delete(self.description, idx)
         self.ch_names = np.delete(self.ch_names, idx)
 
-    def to_data_frame(self, time_format=None):
+    def to_data_frame(self, time_format="datetime"):
         """Export annotations in tabular structure as a pandas DataFrame.
 
         Parameters
@@ -467,10 +467,7 @@ class Annotations:
             dt = _handle_meas_date(0)
         time_format = _check_time_format(time_format, valid_time_formats, dt)
         dt = dt.replace(tzinfo=None)
-        # hack Annotations object to temporarily have an .info attribute
-        self.info = dict(meas_date=dt)
-        times = _convert_times(self, self.onset, time_format)
-        del self.info
+        times = _convert_times(self.onset, time_format, dt)
         df = dict(onset=times, duration=self.duration, description=self.description)
         if self._any_ch_names():
             df.update(ch_names=self.ch_names)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -444,6 +444,7 @@ class Annotations:
         self.description = np.delete(self.description, idx)
         self.ch_names = np.delete(self.ch_names, idx)
 
+    @fill_doc
     def to_data_frame(self, time_format="datetime"):
         """Export annotations in tabular structure as a pandas DataFrame.
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2661,7 +2661,7 @@ class BaseEpochs(
         # prepare extra columns / multiindex
         mindex = list()
         times = np.tile(times, n_epochs)
-        times = _convert_times(self, times, time_format)
+        times = _convert_times(times, time_format, self.info["meas_date"])
         mindex.append(("time", times))
         rev_event_id = {v: k for k, v in self.event_id.items()}
         conditions = [rev_event_id[k] for k in self.events[:, 2]]

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -1256,7 +1256,7 @@ class Evoked(
         data = _scale_dataframe_data(self, data, picks, scalings)
         # prepare extra columns / multiindex
         mindex = list()
-        times = _convert_times(self, times, time_format)
+        times = _convert_times(times, time_format, self.info["meas_date"])
         mindex.append(("time", times))
         # build DataFrame
         df = _build_data_frame(

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2271,7 +2271,9 @@ class BaseRaw(
         data = _scale_dataframe_data(self, data, picks, scalings)
         # prepare extra columns / multiindex
         mindex = list()
-        times = _convert_times(self, times, time_format)
+        times = _convert_times(
+            times, time_format, self.info["meas_date"], self.first_time
+        )
         mindex.append(("time", times))
         # build DataFrame
         df = _build_data_frame(

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -1398,7 +1398,7 @@ class _BaseSourceEstimate(TimeMixin):
         if self.subject is not None:
             default_index = ["subject", "time"]
             mindex.append(("subject", np.repeat(self.subject, data.shape[0])))
-        times = _convert_times(self, times, time_format)
+        times = _convert_times(times, time_format)
         mindex.append(("time", times))
         # triage surface vs volume source estimates
         col_names = list()

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1416,7 +1416,8 @@ def test_repr():
     assert r == "<Annotations | 0 segments>"
 
 
-def test_annotation_to_data_frame():
+@pytest.mark.parametrize("time_format", (None, "ms", "datetime", "timedelta"))
+def test_annotation_to_data_frame(time_format):
     """Test annotation class to data frame conversion."""
     pytest.importorskip("pandas")
     onset = np.arange(1, 10)
@@ -1427,11 +1428,15 @@ def test_annotation_to_data_frame():
         onset=onset, duration=durations, description=description, orig_time=0
     )
 
-    df = a.to_data_frame()
+    df = a.to_data_frame(time_format=time_format)
     for col in ["onset", "duration", "description"]:
         assert col in df.columns
     assert df.description[0] == "yy"
-    assert (df.onset[1] - df.onset[0]).seconds == 1
+    want = 1000 if time_format == "ms" else 1
+    got = df.onset[1] - df.onset[0]
+    if time_format in ("datetime", "timedelta"):
+        got = got.seconds
+    assert want == got
     assert df.groupby("description").count().onset["yy"] == 9
 
 

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1333,7 +1333,7 @@ class _BaseTFR(ContainsMixin, UpdateChannelsMixin, SizeMixin, ExtendedTimeMixin)
         # prepare extra columns / multiindex
         mindex = list()
         times = np.tile(times, n_epochs * n_freqs)
-        times = _convert_times(self, times, time_format)
+        times = _convert_times(times, time_format, self.info["meas_date"])
         mindex.append(("time", times))
         freqs = self.freqs
         freqs = np.tile(np.repeat(freqs, n_times), n_epochs)

--- a/mne/utils/dataframe.py
+++ b/mne/utils/dataframe.py
@@ -35,7 +35,7 @@ def _scale_dataframe_data(inst, data, picks, scalings):
     return data
 
 
-def _convert_times(inst, times, time_format):
+def _convert_times(times, time_format, meas_date=None, first_time=0):
     """Convert vector of time in seconds to ms, datetime, or timedelta."""
     # private function; pandas already checked in calling function
     from pandas import to_timedelta
@@ -45,8 +45,7 @@ def _convert_times(inst, times, time_format):
     elif time_format == "timedelta":
         times = to_timedelta(times, unit="s")
     elif time_format == "datetime":
-        first_time = getattr(inst, "first_time", 0)  # Annotations don't have it
-        times = to_timedelta(times + first_time, unit="s") + inst.info["meas_date"]
+        times = to_timedelta(times + first_time, unit="s") + meas_date
     return times
 
 

--- a/mne/utils/dataframe.py
+++ b/mne/utils/dataframe.py
@@ -45,7 +45,8 @@ def _convert_times(inst, times, time_format):
     elif time_format == "timedelta":
         times = to_timedelta(times, unit="s")
     elif time_format == "datetime":
-        times = to_timedelta(times + inst.first_time, unit="s") + inst.info["meas_date"]
+        first_time = getattr(inst, "first_time", 0)  # Annotations don't have it
+        times = to_timedelta(times + first_time, unit="s") + inst.info["meas_date"]
     return times
 
 


### PR DESCRIPTION
~~it's working, but a bit hackish, so marking as draft while I clean it up.~~
closes #12274 

```pycon
In [1]: import mne
In [2]: foo = mne.Annotations(onset=[1,5,11], duration=[2, 2, 3], description=list('abc'))
In [3]: foo.to_data_frame(None)
Out[3]: 
   onset  duration description
0    1.0       2.0           a
1    5.0       2.0           b
2   11.0       3.0           c
In [4]: foo.to_data_frame("datetime")
Out[4]: 
                onset  duration description
0 1970-01-01 00:00:01       2.0           a
1 1970-01-01 00:00:05       2.0           b
2 1970-01-01 00:00:11       3.0           c
In [5]: foo.to_data_frame("ms")
Out[5]: 
   onset  duration description
0   1000       2.0           a
1   5000       2.0           b
2  11000       3.0           c
In [6]: foo.to_data_frame("timedelta")
Out[6]: 
            onset  duration description
0 0 days 00:00:01       2.0           a
1 0 days 00:00:05       2.0           b
2 0 days 00:00:11       3.0           c
```