### PR TITLE
Unignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ tutorials/misc/report.h5
 tutorials/io/fnirs.csv
 pip-log.txt
 .coverage*
+!.coveragerc
 coverage.xml
 tags
 doc/coverages
@@ -93,6 +94,7 @@ cover
 .venv/
 venv/
 *.json
+!codemeta.json
 .hypothesis/
 .ruff_cache/
 .ipynb_checkpoints/


### PR DESCRIPTION
I noticed that `.coveragerc` and `codemeta.json` are in `.gitignore`, but this is probably a mistake.

I'm not sure if there are more ignored files that are already under version control, so here's a list:

```
❯ git ls-files -i -c --exclude-from=.gitignore
doc/_static/CoordinateSystems.png
doc/_static/HeadCS.png
doc/_static/funding/cds.png
doc/_static/funding/nsf.png
doc/_static/institution_logos/CEA.png
doc/_static/institution_logos/Donders.png
doc/_static/institution_logos/Harvard.png
doc/_static/institution_logos/Martinos.png
doc/_static/institution_logos/inria.png
doc/_static/mne_helmet.png
doc/_static/mne_installer_console.png
doc/_static/mne_installer_macOS.png
doc/_static/versions.json
doc/_templates/copyright.html
doc/_templates/homepage.html
doc/_templates/layout.html
doc/_templates/sidebar-quicklinks.html
doc/contributing.html
doc/documentation.html
doc/getting_started.html
doc/install_mne_python.html
doc/sphinxext/_avatar_template.html
mne/data/coil_def.dat
mne/data/coil_def_Elekta.dat
mne/data/fsaverage/fsaverage-fiducials.fif
mne/data/fsaverage/fsaverage-head.fif
mne/data/fsaverage/fsaverage-inner_skull-bem.fif
mne/data/fsaverage/fsaverage-trans.fif
mne/data/helmets/122m.fif.gz
mne/data/helmets/306m.fif.gz
mne/data/helmets/306m_rt.fif.gz
mne/data/helmets/BabySQUID.fif.gz
mne/data/helmets/CTF_275.fif.gz
mne/data/helmets/KIT.fif.gz
mne/data/helmets/Kernel_Flux.fif.gz
mne/data/helmets/Magnes_2500wh.fif.gz
mne/data/helmets/Magnes_3600wh.fif.gz
mne/data/icos.fif.gz
mne/icons/mne_bigsur_icon.png
mne/icons/mne_default_icon.png
mne/icons/mne_icon-cropped.png
mne/icons/mne_icon.png
mne/icons/mne_splash.png
mne/icons/toolbar_move_horizontal@2x.png
mne/icons/toolbar_move_vertical@2x.png
mne/icons/toolbar_separator_horizontal.png
mne/icons/toolbar_separator_horizontal@2x.png
mne/icons/toolbar_separator_vertical@2x.png
mne/io/brainvision/tests/data/test_bin_raw.fif
mne/io/bti/tests/data/exported4D_linux_raw.fif
mne/io/bti/tests/data/exported4D_solaris_raw.fif
mne/io/kit/tests/data/test_bin_raw.fif
mne/io/kit/tests/data/trans-sample.fif
mne/io/tests/data/process_raw.sh
mne/io/tests/data/small-src.fif.gz
mne/io/tests/data/test-1-eve.fif
mne/io/tests/data/test-ave-2.log
mne/io/tests/data/test-ave.fif
mne/io/tests/data/test-ave.fif.gz
mne/io/tests/data/test-ave.log
mne/io/tests/data/test-cov.fif
mne/io/tests/data/test-cov.fif.gz
mne/io/tests/data/test-eve.fif
mne/io/tests/data/test-eve.fif.gz
mne/io/tests/data/test-km-cov.fif
mne/io/tests/data/test-nf-ave.fif
mne/io/tests/data/test-proj.fif
mne/io/tests/data/test-proj.fif.gz
mne/io/tests/data/test_chpi_raw_sss.fif
mne/io/tests/data/test_ctf_comp_raw.fif
mne/io/tests/data/test_ctf_raw.fif
mne/io/tests/data/test_erm-cov.fif
mne/io/tests/data/test_raw-annot.fif
mne/io/tests/data/test_raw-eve.fif
mne/io/tests/data/test_raw.fif
mne/io/tests/data/test_raw.fif.gz
mne/io/tests/data/test_withbads_raw.fif
tools/azure_dependencies.sh
tools/check_qt_import.sh
tools/circleci_bash_env.sh
tools/circleci_dependencies.sh
tools/circleci_download.sh
tools/get_minimal_commands.sh
tools/get_testing_version.sh
tools/github_actions_dependencies.sh
tools/github_actions_download.sh
tools/github_actions_env_vars.sh
tools/github_actions_infos.sh
tools/github_actions_test.sh
tools/setup_xvfb.sh
```

Should any of these files/patterns be removed from `.gitignore`?