### PR TITLE
MRG: Add return type hints to all `read_epochs_*()` functions

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -25,7 +25,8 @@ In this version, we started adding type hints (also known as "type annotations")
 This meta information will be used by development environments (IDEs) like VS Code and PyCharm automatically to provide
 better assistance such as tab completion or error detection even before running your code.
 
-So far, we've only added return type hints to :func:`mne.read_evokeds` and :func:`mne.io.read_raw`. Now your editors will know:
+So far, we've only added return type hints to :func:`mne.io.read_raw`, :func:`mne.read_epochs`, :func:`mne.read_evokeds` and
+all format-specific ``read_raw_*()`` and ``read_epochs_*()`` functions. Now your editors will know:
 these functions return evoked and raw data, respectively. We are planning add type hints to more functions after careful
 evaluation in the future.
 
@@ -36,7 +37,7 @@ Enhancements
 ~~~~~~~~~~~~
 - Speed up export to .edf in :func:`mne.export.export_raw` by using ``edfio`` instead of ``EDFlib-Python`` (:gh:`12218` by :newcontrib:`Florian Hofer`)
 - Inform the user about channel discrepancy between provided info, forward operator, and/or covariance matrices in :func:`mne.beamformer.make_lcmv` (:gh:`12238` by :newcontrib:`Nikolai Kapralov`)
-- We added type hints for the return values of :func:`mne.read_evokeds` and :func:`mne.io.read_raw`. Development environments like VS Code or PyCharm will now provide more help when using these functions in your code. (:gh:`12250` by `Richard Höchenberger`_ and `Eric Larson`_)
+- We added type hints for the return values of raw, epochs, and evoked reading functions. Development environments like VS Code or PyCharm will now provide more help when using these functions in your code. (:gh:`12250` by `Richard Höchenberger`_ and `Eric Larson`_)
 - Add ``method="polyphase"`` to :meth:`mne.io.Raw.resample` and related functions to allow resampling using :func:`scipy.signal.upfirdn` (:gh:`12268` by `Eric Larson`_)
 - The package build backend was switched from ``setuptools`` to ``hatchling``. This will only affect users who build and install MNE-Python from source. (:gh:`12269`, :gh:`12281` by `Richard Höchenberger`_)
 - :meth:`mne.Annotations.to_data_frame` can now output different formats for the ``onset`` column: seconds, milliseconds, datetime objects, and timedelta objects. (:gh:`12289` by `Daniel McCloy`_)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -270,6 +270,8 @@ numpydoc_xref_aliases = {
     "Spectrum": "mne.time_frequency.Spectrum",
     "EpochsSpectrum": "mne.time_frequency.EpochsSpectrum",
     "EpochsFIF": "mne.Epochs",
+    "EpochsEEGLAB": "mne.Epochs",
+    "EpochsKIT": "mne.Epochs",
     "RawBOXY": "mne.io.Raw",
     "RawBrainVision": "mne.io.Raw",
     "RawBTi": "mne.io.Raw",
@@ -685,11 +687,7 @@ def append_attr_meth_examples(app, what, name, obj, options, lines):
 
 .. minigallery:: {1}
 
-""".format(
-                name.split(".")[-1], name
-            ).split(
-                "\n"
-            )
+""".format(name.split(".")[-1], name).split("\n")
 
 
 # -- Other extension configuration -------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -781,7 +781,7 @@ nitpick_ignore_regex = [
     ("py:.*", r"mne\.BaseEpochs.*"),  # use mne.Epochs
     # Type hints for undocumented types
     ("py:.*", r"mne\.io\..*\.Raw.*"),  # RawEDF etc.
-    ("py:.*", r"mne\.epochs\.EpochsFIF.*"),
+    ("py:.*", r"mne\.epochs\.Epochs.*"),  # EpochsKIT
     (
         "py:obj",
         "(filename|metadata|proj|times|tmax|tmin|annotations|ch_names|compensation_grade|filenames|first_samp|first_time|last_samp|n_times|proj|times|tmax|tmin)",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -781,7 +781,8 @@ nitpick_ignore_regex = [
     ("py:.*", r"mne\.BaseEpochs.*"),  # use mne.Epochs
     # Type hints for undocumented types
     ("py:.*", r"mne\.io\..*\.Raw.*"),  # RawEDF etc.
-    ("py:.*", r"mne\.epochs\.Epochs.*"),  # EpochsKIT
+    ("py:.*", r"mne\.epochs\.EpochsFIF.*"),
+    ("py:.*", r"mne\.io\..*\.Epochs.*"),  # EpochsKIT etc.
     (
         "py:obj",
         "(filename|metadata|proj|times|tmax|tmin|annotations|ch_names|compensation_grade|filenames|first_samp|first_time|last_samp|n_times|proj|times|tmax|tmin)",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -6,32 +6,32 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
-from datetime import datetime, timezone
 import faulthandler
 import gc
-from importlib.metadata import metadata
 import os
-from pathlib import Path
 import subprocess
 import sys
 import time
 import warnings
+from datetime import datetime, timezone
+from importlib.metadata import metadata
+from pathlib import Path
 
-import numpy as np
 import matplotlib
+import numpy as np
 import sphinx
-from sphinx.domains.changeset import versionlabels
-from sphinx_gallery.sorting import FileNameSortKey, ExplicitOrder
 from numpydoc import docscrape
+from sphinx.domains.changeset import versionlabels
+from sphinx_gallery.sorting import ExplicitOrder, FileNameSortKey
 
 import mne
 import mne.html_templates._templates
 from mne.tests.test_docstring_parameters import error_ignores
 from mne.utils import (
-    linkcode_resolve,  # noqa, analysis:ignore
     _assert_no_instances,
-    sizeof_fmt,
+    linkcode_resolve,  # noqa, analysis:ignore
     run_subprocess,
+    sizeof_fmt,
 )
 from mne.viz import Brain  # noqa
 

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -921,7 +921,7 @@ def read_raw_brainvision(
     scale=1.0,
     preload=False,
     verbose=None,
-):
+) -> RawBrainVision:
     """Reader for Brain Vision EEG file.
 
     Parameters

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -1435,7 +1435,7 @@ def read_raw_bti(
     eog_ch=("E63", "E64"),
     preload=False,
     verbose=None,
-) -> "RawBTi":
+) -> RawBTi:
     """Raw object from 4D Neuroimaging MagnesWH3600 data.
 
     .. note::

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -349,7 +349,7 @@ def read_epochs_eeglab(
     uint16_codec=None,
     montage_units="auto",
     verbose=None,
-):
+) -> "EpochsEEGLAB":
     r"""Reader function for EEGLAB epochs files.
 
     Parameters

--- a/mne/io/fieldtrip/fieldtrip.py
+++ b/mne/io/fieldtrip/fieldtrip.py
@@ -83,7 +83,9 @@ def read_raw_fieldtrip(fname, info, data_name="data") -> RawArray:
     return raw
 
 
-def read_epochs_fieldtrip(fname, info, data_name="data", trialinfo_column=0):
+def read_epochs_fieldtrip(
+    fname, info, data_name="data", trialinfo_column=0
+) -> EpochsArray:
     """Load epoched data from a FieldTrip preprocessing structure.
 
     This function expects to find epoched data in the structure data_name is

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -981,7 +981,7 @@ def read_epochs_kit(
     allow_unknown_format=False,
     standardize_names=False,
     verbose=None,
-):
+) -> EpochsKIT:
     """Reader function for Ricoh/KIT epochs files.
 
     Parameters

--- a/mne/io/nedf/nedf.py
+++ b/mne/io/nedf/nedf.py
@@ -202,7 +202,7 @@ def _convert_eeg(chunks, n_eeg, n_tot):
 
 
 @verbose
-def read_raw_nedf(filename, preload=False, verbose=None) -> "RawNedf":
+def read_raw_nedf(filename, preload=False, verbose=None) -> RawNedf:
     """Read NeuroElectrics .nedf files.
 
     NEDF file versions starting from 1.3 are supported.


### PR DESCRIPTION
Also clean up a little after #12296, where I accidentally put a few return types in quoation marks that were, in fact, no forward references; and forgot to annotate the BV reader.

Also updated the changelog.
