### PR TITLE
MAINT: Use HTML5 embedding for examples

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -380,3 +380,9 @@ img.hidden {
 td.justify {
     text-align-last: justify;
 }
+
+/* Matplotlib HTML5 video embedding */
+div.sphx-glr-animation video {
+    max-width: 100%;
+    height: auto;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -174,10 +174,7 @@ intersphinx_mapping = {
     "imageio": ("https://imageio.readthedocs.io/en/latest", None),
     "picard": ("https://pierreablin.github.io/picard/", None),
     "eeglabio": ("https://eeglabio.readthedocs.io/en/latest", None),
-    "dipy": (
-        "https://dipy.org/documentation/1.7.0/",
-        "https://dipy.org/documentation/1.7.0/objects.inv/",
-    ),
+    "dipy": ("https://docs.dipy.org/stable", None),
     "pybv": ("https://pybv.readthedocs.io/en/latest/", None),
     "pyqtgraph": ("https://pyqtgraph.readthedocs.io/en/latest/", None),
 }
@@ -479,6 +476,8 @@ class Resetter(object):
         plt.ioff()
         plt.rcParams["animation.embed_limit"] = 40.0
         plt.rcParams["figure.raise_window"] = False
+        # https://github.com/sphinx-gallery/sphinx-gallery/pull/1243#issue-2043332860
+        plt.rcParams["animation.html"] = "html5"
         # neo holds on to an exception, which in turn holds a stack frame,
         # which will keep alive the global vars during SG execution
         try:


### PR DESCRIPTION
Should make our video embedding a bit nicer (and much smaller) by using standard browser controls:

| main | PR |
| -- | -- |
| <img width="940" alt="Screenshot 2023-12-15 at 1 19 24 PM" src="https://github.com/mne-tools/mne-python/assets/2365790/14dd6bcd-6b96-4ba3-b784-81ed22243a65"> | <img width="847" alt="Screenshot 2023-12-15 at 1 18 19 PM" src="https://github.com/mne-tools/mne-python/assets/2365790/e64e865e-a3ff-4624-8149-0603fcbfce3b"> |