### PR TITLE
Switch from `epoch_data` to `data` for TFR array functions

### DIFF
--- a/doc/changes/devel.rst
+++ b/doc/changes/devel.rst
@@ -52,4 +52,4 @@ Bugs
 
 API changes
 ~~~~~~~~~~~
-- None yet
+- The parameter for providing data to :func:`mne.time_frequency.tfr_array_morlet` and :func:`mne.time_frequency.tfr_array_multitaper` has been switched from ``epoch_data`` to ``data``. Only use the ``data`` parameter to avoid a warning (:gh:`12308` by `Thomas Binns`_)

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -510,6 +510,10 @@ def tfr_array_multitaper(
           coherence across trials.
     %(n_jobs)s
     %(verbose)s
+    epoch_data : None
+        Deprecated parameter for providing epoched data as of 1.7, will be replaced with
+        the ``data`` parameter in 1.8. New code should use the ``data`` parameter. If
+        ``epoch_data`` is not ``None``, a warning will be raised.
 
     Returns
     -------

--- a/mne/time_frequency/multitaper.py
+++ b/mne/time_frequency/multitaper.py
@@ -465,7 +465,7 @@ def psd_array_multitaper(
 
 @verbose
 def tfr_array_multitaper(
-    epoch_data,
+    data,
     sfreq,
     freqs,
     n_cycles=7.0,
@@ -477,6 +477,7 @@ def tfr_array_multitaper(
     n_jobs=None,
     *,
     verbose=None,
+    epoch_data=None,
 ):
     """Compute Time-Frequency Representation (TFR) using DPSS tapers.
 
@@ -486,7 +487,7 @@ def tfr_array_multitaper(
 
     Parameters
     ----------
-    epoch_data : array of shape (n_epochs, n_channels, n_times)
+    data : array of shape (n_epochs, n_channels, n_times)
         The epochs.
     sfreq : float
         Sampling frequency of the data in Hz.
@@ -513,7 +514,7 @@ def tfr_array_multitaper(
     Returns
     -------
     out : array
-        Time frequency transform of ``epoch_data``.
+        Time frequency transform of ``data``.
 
         - if ``output in ('complex',' 'phase')``, array of shape
           ``(n_epochs, n_chans, n_tapers, n_freqs, n_times)``
@@ -543,8 +544,15 @@ def tfr_array_multitaper(
     """
     from .tfr import _compute_tfr
 
+    if epoch_data is not None:
+        warn(
+            "The parameter for providing data will be switched from `epoch_data` to "
+            "`data` in 1.8. Use the `data` parameter to avoid this warning.",
+            FutureWarning,
+        )
+
     return _compute_tfr(
-        epoch_data,
+        data,
         freqs,
         sfreq=sfreq,
         method="multitaper",

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -973,7 +973,7 @@ def tfr_morlet(
 
 @verbose
 def tfr_array_morlet(
-    epoch_data,
+    data,
     sfreq,
     freqs,
     n_cycles=7.0,
@@ -983,6 +983,7 @@ def tfr_array_morlet(
     output="complex",
     n_jobs=None,
     verbose=None,
+    epoch_data=None,
 ):
     """Compute Time-Frequency Representation (TFR) using Morlet wavelets.
 
@@ -991,7 +992,7 @@ def tfr_array_morlet(
 
     Parameters
     ----------
-    epoch_data : array of shape (n_epochs, n_channels, n_times)
+    data : array of shape (n_epochs, n_channels, n_times)
         The epochs.
     sfreq : float | int
         Sampling frequency of the data.
@@ -1019,7 +1020,7 @@ def tfr_array_morlet(
     Returns
     -------
     out : array
-        Time frequency transform of epoch_data.
+        Time frequency transform of ``data``.
 
         - if ``output in ('complex', 'phase', 'power')``, array of shape
           ``(n_epochs, n_chans, n_freqs, n_times)``
@@ -1049,8 +1050,15 @@ def tfr_array_morlet(
     ----------
     .. footbibliography::
     """
+    if epoch_data is not None:
+        warn(
+            "The parameter for providing data will be switched from `epoch_data` to "
+            "`data` in 1.8. Use the `data` parameter to avoid this warning.",
+            FutureWarning,
+        )
+
     return _compute_tfr(
-        epoch_data=epoch_data,
+        epoch_data=data,
         freqs=freqs,
         sfreq=sfreq,
         method="morlet",

--- a/mne/time_frequency/tfr.py
+++ b/mne/time_frequency/tfr.py
@@ -1016,6 +1016,10 @@ def tfr_array_morlet(
         The number of epochs to process at the same time. The parallelization
         is implemented across channels. Default 1.
     %(verbose)s
+    epoch_data : None
+        Deprecated parameter for providing epoched data as of 1.7, will be replaced with
+        the ``data`` parameter in 1.8. New code should use the ``data`` parameter. If
+        ``epoch_data`` is not ``None``, a warning will be raised.
 
     Returns
     -------


### PR DESCRIPTION
Follow-up of #12305.

As discussed, I have just switched the `epoch_data` parameter for the `tfr_array_morlet` and `tfr_array_multitaper` functions to `data`, and have added a `FutureWarning` if `epoch_data is not None`.

The `_compute_tfr` function which is called internally has the `epoch_data` parameter, but I haven't touched that here.

https://github.com/mne-tools/mne-python/blob/b1dd84c36264d716beebd5f6c6ae470a36c762e8/mne/time_frequency/tfr.py#L417-L431
