### PR TITLE
fix section parameter to allow proper hierarchy

### DIFF
--- a/doc/changes/devel/12319.bugfix.rst
+++ b/doc/changes/devel/12319.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where section parameter in :meth:`mne.Report.add_html` was not being utilized resulting in improper formatting, by :newcontrib:`Martin Oberg`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -348,6 +348,8 @@
 
 .. _Martin Luessi: https://github.com/mluessi
 
+.. _Martin Oberg: https://github.com/obergmartin
+
 .. _Martin Schulz: https://github.com/marsipu
 
 .. _Mathieu Scheltienne: https://github.com/mscheltienne

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -2383,7 +2383,7 @@ class Report:
         )
         self._add_or_replace(
             title=title,
-            section=None,
+            section=section,
             tags=tags,
             html_partial=html_partial,
             replace=replace,


### PR DESCRIPTION
#### Reference issue
Discussion [on Discourse](https://mne.discourse.group/t/report-add-html-does-not-obey-section/8016/2) about Report.add_html().
HTML chunks were added to the main level, not within the supplied `section`. 

The section value passed to `self._add_or_replace` was hard coded as `None` and didn't use the supplied section argument.

