### PR TITLE
MAINT: Fix CIs

### DIFF
--- a/mne/decoding/tests/test_transformer.py
+++ b/mne/decoding/tests/test_transformer.py
@@ -62,7 +62,7 @@ def test_scaler(info, method):
     epochs_data_t = epochs_data.transpose([1, 0, 2])
     if method in ("mean", "median"):
         if not check_version("sklearn"):
-            with pytest.raises(ImportError, match="No module"):
+            with pytest.raises((ImportError, RuntimeError), match=" module "):
                 Scaler(info, method)
             return
 

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -28,7 +28,7 @@ else
 	echo "PyQt6"
 	pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 --extra-index-url https://www.riverbankcomputing.com/pypi/simple "PyQt6!=6.6.1" "PyQt6-Qt6!=6.6.1"
 	echo "NumPy/SciPy/pandas etc."
-	pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0" "scipy>=1.12.0.dev0" scikit-learn matplotlib pillow statsmodels
+	pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0" "scipy>=1.12.0.dev0" "scikit-learn==1.4.dev0" matplotlib pillow statsmodels
 	# No pandas, dipy, h5py, openmeeg, python-picard (needs numexpr) until they update to NumPy 2.0 compat
 	INSTALL_KIND="test_extra"
 	# echo "dipy"


### PR DESCRIPTION
We were picking up the `rc` which is not NumPy 2.0 compatible so for now pin to 1.4.dev0 (which we'll need to un-pin whenever they cut 1.4.0). But in case this happens again, also make the test more lenient about what type of error is caught.