### PR TITLE
[FIX] Fix the function to parse prefilter for EDF files to add np.nan when the prefilter information does not exist for the channel

### DIFF
--- a/doc/changes/devel/12329.bugfix.rst
+++ b/doc/changes/devel/12329.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``mne.io.edf.edf._parse_prefilter_string`` to add prefilter information as ``np.nan`` when the prefilter information does not exist, by `Michiru Kaneda`_

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -758,26 +758,18 @@ def _get_info(
     return info, edf_info, orig_units
 
 
+def _extract_filter_value(s, prefix, suffix):
+    if prefix in s:
+        start = s.find(prefix) + len(prefix)
+        end = s.find(suffix, start)
+        return s[start:end].strip()
+    return np.nan
+
+
 def _parse_prefilter_string(prefiltering):
     """Parse prefilter string from EDF+ and BDF headers."""
-    highpass = np.array(
-        [
-            v
-            for hp in [
-                re.findall(r"HP:\s*([0-9]+[.]*[0-9]*)", filt) for filt in prefiltering
-            ]
-            for v in hp
-        ]
-    )
-    lowpass = np.array(
-        [
-            v
-            for hp in [
-                re.findall(r"LP:\s*([0-9]+[.]*[0-9]*)", filt) for filt in prefiltering
-            ]
-            for v in hp
-        ]
-    )
+    highpass = [_extract_filter_value(s, "HP:", "Hz") for s in prefiltering]
+    lowpass = [_extract_filter_value(s, "LP:", "Hz") for s in prefiltering]
     return highpass, lowpass
 
 

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -768,8 +768,8 @@ def _extract_filter_value(s, prefix, suffix):
 
 def _parse_prefilter_string(prefiltering):
     """Parse prefilter string from EDF+ and BDF headers."""
-    highpass = [_extract_filter_value(s, "HP:", "Hz") for s in prefiltering]
-    lowpass = [_extract_filter_value(s, "LP:", "Hz") for s in prefiltering]
+    highpass = np.array([_extract_filter_value(s, "HP:", "Hz") for s in prefiltering])
+    lowpass = np.array([_extract_filter_value(s, "LP:", "Hz") for s in prefiltering])
     return highpass, lowpass
 
 

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -644,13 +644,18 @@ def test_edf_prefilter_parse():
 
     prefilter_unfiltered_ch = prefilter_normal_multi_ch + [""]
     highpass, lowpass = _parse_prefilter_string(prefilter_unfiltered_ch)
-    assert_array_equal(highpass, ["1"] * 10)
-    assert_array_equal(lowpass, ["30"] * 10)
+    assert_array_equal(highpass, ["1"] * 10 + [np.nan])
+    assert_array_equal(lowpass, ["30"] * 10 + [np.nan])
 
     prefilter_edf_specs_doc = ["HP:0.1Hz LP:75Hz N:50Hz"]
     highpass, lowpass = _parse_prefilter_string(prefilter_edf_specs_doc)
     assert_array_equal(highpass, ["0.1"])
     assert_array_equal(lowpass, ["75"])
+
+    prefilter_edf_specs_doc = ["", "HP:0.1Hz LP:75Hz N:50Hz", ""]
+    highpass, lowpass = _parse_prefilter_string(prefilter_edf_specs_doc)
+    assert_array_equal(highpass, [np.nan, "0.1", np.nan])
+    assert_array_equal(lowpass, [np.nan, "75", np.nan])
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
For EDF, BDF and GDF, prefilter information is parsed by [_parse_prefilter_string](https://github.com/mne-tools/mne-python/blob/6790426221b83ee16375ec19e974808d7b9aad4c/mne/io/edf/edf.py#L761) function.

This function makes arrays for highpass and lowpass values
but values are added only when the filter exist.

As a result, it is not possible to extract the filter for the corresponding channel from `raw.info['highpass']` and `raw.info['lowpass']` by using `raw.info['sel']`.

To make it as same as other variables like `raw.info['n_samps']`, add `np.nan` if the filter does not exist.

In addition, the function was refactored by adding new helper function, `_extract_filter_value`.