### PR TITLE
BUG: Fix bug with epochs image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,14 +89,12 @@ jobs:
           python-version: ${{ matrix.python }}
         if: startswith(matrix.kind, 'pip')
       # Python (if conda)
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: mamba-org/setup-micromamba@v1
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           environment-file: ${{ env.CONDA_ENV }}
-          activate-environment: mne
-          miniforge-version: latest
-          miniforge-variant: Mambaforge
-          use-mamba: ${{ matrix.kind != 'conda' }}
+          environment-name: mne
+          create-args: >-
+            python=${{ env.PYTHON_VERSION }}
         if: ${{ !startswith(matrix.kind, 'pip') }}
       - run: ./tools/github_actions_dependencies.sh
       # Minimal commands on Linux (macOS stalls)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,6 @@ jobs:
       - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ${{ env.CONDA_ENV }}
-          environment-name: mne
           create-args: >-
             python=${{ env.PYTHON_VERSION }}
         if: ${{ !startswith(matrix.kind, 'pip') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,7 @@ jobs:
           environment-name: mne
           create-args: >-
             python=${{ env.PYTHON_VERSION }}
-            mamba
+            mamba!=1.5.6
         if: ${{ !startswith(matrix.kind, 'pip') }}
       - run: ./tools/github_actions_dependencies.sh
       # Minimal commands on Linux (macOS stalls)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,8 +92,10 @@ jobs:
       - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ${{ env.CONDA_ENV }}
+          environment-name: mne
           create-args: >-
             python=${{ env.PYTHON_VERSION }}
+            mamba
         if: ${{ !startswith(matrix.kind, 'pip') }}
       - run: ./tools/github_actions_dependencies.sh
       # Minimal commands on Linux (macOS stalls)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,7 @@ jobs:
           environment-name: mne
           create-args: >-
             python=${{ env.PYTHON_VERSION }}
-            mamba!=1.5.6
+            mamba
         if: ${{ !startswith(matrix.kind, 'pip') }}
       - run: ./tools/github_actions_dependencies.sh
       # Minimal commands on Linux (macOS stalls)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,6 +96,7 @@ jobs:
           create-args: >-
             python=${{ env.PYTHON_VERSION }}
             mamba
+            fmt!=10.2.0
         if: ${{ !startswith(matrix.kind, 'pip') }}
       - run: ./tools/github_actions_dependencies.sh
       # Minimal commands on Linux (macOS stalls)

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -788,7 +788,7 @@ def src_volume_labels():
     """Create a 7mm source space with labels."""
     pytest.importorskip("nibabel")
     volume_labels = mne.get_volume_labels_from_aseg(fname_aseg)
-    with pytest.warns(RuntimeWarning, match="Found no usable.*Left-vessel.*"):
+    with pytest.warns(RuntimeWarning, match="Found no usable.*t-vessel.*"):
         src = mne.setup_volume_source_space(
             "sample",
             7.0,

--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -654,10 +654,9 @@ def _plot_epochs_image(
 
     # draw the colorbar
     if colorbar:
-        from matplotlib.pyplot import colorbar as cbar
-
         if "colorbar" in ax:  # axes supplied by user
-            this_colorbar = cbar(im, cax=ax["colorbar"])
+            cax = ax["colorbar"]
+            this_colorbar = cax.figure.colorbar(im, cax=cax)
             this_colorbar.ax.set_ylabel(unit, rotation=270, labelpad=12)
         else:  # we created them
             this_colorbar = fig.colorbar(im, ax=ax_im)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ full = [
 
 # Dependencies for running the test infrastructure
 test = [
-    "pytest",
+    "pytest!=8.0.0rc1",
     "pytest-cov",
     "pytest-timeout",
     "pytest-harvest",


### PR DESCRIPTION
Calling `plt.colorbar` isn't as clean because it uses `gcf().colorbar(...)`. Instead let's use `ax.figure.colorbar` to avoid warnings like https://github.com/mne-tools/mne-qt-browser/actions/runs/7324019308/job/19960149079?pr=222#step:11:195 :
```
UserWarning: Adding colorbar to a different Figure <Figure size 600x400 with 4 Axes> than <Figure size 640x480 with 0 Axes> which fig.colorbar is called on.
```