### PR TITLE
Fix typo in contributing guide

### DIFF
--- a/doc/development/contributing.rst
+++ b/doc/development/contributing.rst
@@ -621,7 +621,7 @@ contain:
 1. A brief description of the change, typically in a single line of one or two
    sentences.
 2. reST links to **public** API endpoints like functions (``:func:``),
-   classes (``:class``), and methods (``:meth:``). If changes are only internal
+   classes (``:class:``), and methods (``:meth:``). If changes are only internal
    to private functions/attributes, mention internal refactoring rather than name
    the private attributes changed.
 3. Author credit. If you are a new contributor (we're very happy to have you here! 🤗),


### PR DESCRIPTION
I added a missing colon. The contributing guide mentions that changelog entries can be skipped for such minor changes, but it doesn't say how (the check is failing). I think it would be good to be explicit here (i.e. it is supposed to fail). Let me know how it's done and I can add a sentence in this PR.