### PR TITLE
[MRG] Fix clicking on an axis of mne.viz.plot_evoked_topo when multiple vertical lines are added

### DIFF
--- a/doc/changes/devel/12345.bugfix.rst
+++ b/doc/changes/devel/12345.bugfix.rst
@@ -1,0 +1,1 @@
+Fix clicking on an axis of :func:`mne.viz.plot_evoked_topo` when multiple vertical lines ``vlines`` are used, by `Mathieu Scheltienne`_.

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1218,7 +1218,7 @@ def plot_evoked_topo(
         If true SSP projections are applied before display. If 'interactive',
         a check box for reversible selection of SSP projection vectors will
         be shown.
-    vline : list of float | None
+    vline : list of float | float| None
         The values at which to show a vertical line.
     fig_background : None | ndarray
         A background image for the figure. This must work with a call to

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -8,6 +8,7 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
+import numbers
 from copy import deepcopy
 from functools import partial
 
@@ -632,11 +633,11 @@ def _plot_timeseries(
             ax.set_ylabel(y_label)
 
     if vline:
-        vline = [vline] if isinstance(vline, float) else vline
+        vline = [vline] if isinstance(vline, numbers.Real) else vline
         for vline_ in vline:
             plt.axvline(vline_, color=hvline_color, linewidth=1.0, linestyle="--")
     if hline:
-        hline = [hline] if isinstance(hline, float) else hline
+        hline = [hline] if isinstance(hline, numbers.Real) else hline
         for hline_ in hline:
             plt.axhline(hline_, color=hvline_color, linewidth=1.0, zorder=10)
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -632,9 +632,13 @@ def _plot_timeseries(
             ax.set_ylabel(y_label)
 
     if vline:
-        plt.axvline(vline, color=hvline_color, linewidth=1.0, linestyle="--")
+        vline = [vline] if isinstance(vline, float) else vline
+        for vline_ in vline:
+            plt.axvline(vline_, color=hvline_color, linewidth=1.0, linestyle="--")
     if hline:
-        plt.axhline(hline, color=hvline_color, linewidth=1.0, zorder=10)
+        hline = [hline] if isinstance(hline, float) else hline
+        for hline_ in hline:
+            plt.axhline(hline_, color=hvline_color, linewidth=1.0, zorder=10)
 
     if colorbar:
         plt.colorbar()

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -8,9 +8,9 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
-import numbers
 from copy import deepcopy
 from functools import partial
+from numbers import Real
 
 import numpy as np
 from scipy import ndimage
@@ -633,11 +633,11 @@ def _plot_timeseries(
             ax.set_ylabel(y_label)
 
     if vline:
-        vline = [vline] if isinstance(vline, numbers.Real) else vline
+        vline = [vline] if isinstance(vline, Real) else vline
         for vline_ in vline:
             plt.axvline(vline_, color=hvline_color, linewidth=1.0, linestyle="--")
     if hline:
-        hline = [hline] if isinstance(hline, numbers.Real) else hline
+        hline = [hline] if isinstance(hline, Real) else hline
         for hline_ in hline:
             plt.axhline(hline_, color=hvline_color, linewidth=1.0, zorder=10)
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -16,13 +16,12 @@ from scipy import ndimage
 
 from .._fiff.pick import channel_type, pick_types
 from ..defaults import _handle_default
-from ..utils import Bunch, _check_option, _clean_names, _to_rgb, fill_doc
+from ..utils import Bunch, _check_option, _clean_names, _is_numeric, _to_rgb, fill_doc
 from .utils import (
     DraggableColorbar,
     _check_cov,
     _check_delayed_ssp,
     _draw_proj_checkbox,
-    _is_numeric,
     _plot_masked_image,
     _setup_ax_spines,
     _setup_vmin_vmax,

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -10,7 +10,6 @@
 
 from copy import deepcopy
 from functools import partial
-from numbers import Real
 
 import numpy as np
 from scipy import ndimage
@@ -23,6 +22,7 @@ from .utils import (
     _check_cov,
     _check_delayed_ssp,
     _draw_proj_checkbox,
+    _is_numeric,
     _plot_masked_image,
     _setup_ax_spines,
     _setup_vmin_vmax,
@@ -632,12 +632,12 @@ def _plot_timeseries(
         else:
             ax.set_ylabel(y_label)
 
-    if vline:
-        vline = [vline] if isinstance(vline, Real) else vline
+    if vline is not None:
+        vline = [vline] if _is_numeric(vline) else vline
         for vline_ in vline:
             plt.axvline(vline_, color=hvline_color, linewidth=1.0, linestyle="--")
-    if hline:
-        hline = [hline] if isinstance(hline, Real) else hline
+    if hline is not None:
+        hline = [hline] if _is_numeric(hline) else hline
         for hline_ in hline:
             plt.axhline(hline_, color=hvline_color, linewidth=1.0, zorder=10)
 


### PR DESCRIPTION
Code snippet to reproduce:

```python
from mne import Epochs, find_events
from mne.datasets import sample
from mne.io import read_raw_fif
from mne.viz import plot_evoked_topo


directory = sample.data_path()
fname = directory / "MEG" / "sample" / "sample_audvis_filt-0-40_raw.fif"
raw = read_raw_fif(fname, preload=False)
raw.pick(("eeg", "stim")).load_data()
events = find_events(raw)
epochs = Epochs(raw, events, dict(cond1=1, cond2=2), tmin=-0.2, tmax=0.5, preload=True)
evokeds = {"cond1": epochs["cond1"].average(), "cond2": epochs["cond2"].average()}
fig = plot_evoked_topo(
    [evokeds["cond1"], evokeds["cond2"]],
    color=["#3498DB", "gray"],
    vline=[0, 0.080],
)
```

On `main`, clicking on axis yields:

```python
Traceback (most recent call last):
  File "c:\Users\scheltie\pyvenv\mscheltienne\mne-python\lib\site-packages\matplotlib\cbook.py", line 298, in process
    func(*args, **kwargs)
  File "C:\Users\scheltie\git\mscheltienne\mne-python\mne\viz\topo.py", line 380, in _plot_topo_onpick
    show_func(ax, ch_idx)
  File "C:\Users\scheltie\git\mscheltienne\mne-python\mne\viz\topo.py", line 635, in _plot_timeseries
    plt.axvline(vline, color=hvline_color, linewidth=1.0, linestyle="--")
  File "c:\Users\scheltie\pyvenv\mscheltienne\mne-python\lib\site-packages\matplotlib\pyplot.py", line 2716, in axvline
    return gca().axvline(x=x, ymin=ymin, ymax=ymax, **kwargs)
  File "c:\Users\scheltie\pyvenv\mscheltienne\mne-python\lib\site-packages\matplotlib\axes\_axes.py", line 849, in axvline
    scalex = (xx < xmin) or (xx > xmax)
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```