### PR TITLE
Fix vmax slider for EvokedField figures

### DIFF
--- a/mne/viz/evoked_field.py
+++ b/mne/viz/evoked_field.py
@@ -380,6 +380,10 @@ class EvokedField:
         if self._show_density:
             r._dock_add_label(value="max value", align=True, layout=layout)
 
+            @_auto_weakref
+            def _callback(vmax, kind, scaling):
+                self.set_vmax(vmax / scaling, kind=kind)
+
             for surf_map in self._surf_maps:
                 if surf_map["map_kind"] == "meg":
                     scaling = DEFAULTS["scalings"]["grad"]
@@ -388,10 +392,6 @@ class EvokedField:
                 rng = [0, np.max(np.abs(surf_map["data"])) * scaling]
                 hlayout = r._dock_add_layout(vertical=False)
 
-                @_auto_weakref
-                def _callback(vmax, type, scaling):
-                    self.set_vmax(vmax / scaling, type=type)
-
                 self._widgets[
                     f"vmax_slider_{surf_map['map_kind']}"
                 ] = r._dock_add_slider(
@@ -399,7 +399,7 @@ class EvokedField:
                     value=surf_map["map_vmax"] * scaling,
                     rng=rng,
                     callback=partial(
-                        _callback, type=surf_map["map_kind"], scaling=scaling
+                        _callback, kind=surf_map["map_kind"], scaling=scaling
                     ),
                     double=True,
                     layout=hlayout,
@@ -411,7 +411,7 @@ class EvokedField:
                     value=surf_map["map_vmax"] * scaling,
                     rng=rng,
                     callback=partial(
-                        _callback, type=surf_map["map_kind"], scaling=scaling
+                        _callback, kind=surf_map["map_kind"], scaling=scaling
                     ),
                     layout=hlayout,
                 )
@@ -473,17 +473,15 @@ class EvokedField:
         if self._show_density:
             surf_map["mesh"].update_overlay(name="field", rng=[vmin, vmax])
             # Update the GUI widgets
-            # TODO: type is undefined here and only avoids a flake warning because it's
-            # a builtin!
-            if type == "meg":  # noqa: E721
+            if kind == "meg":
                 scaling = DEFAULTS["scalings"]["grad"]
             else:
                 scaling = DEFAULTS["scalings"]["eeg"]
             with disable_ui_events(self):
-                widget = self._widgets.get(f"vmax_slider_{type}", None)
+                widget = self._widgets.get(f"vmax_slider_{kind}", None)
                 if widget is not None:
                     widget.set_value(vmax * scaling)
-                widget = self._widgets.get(f"vmax_spin_{type}", None)
+                widget = self._widgets.get(f"vmax_spin_{kind}", None)
                 if widget is not None:
                     widget.set_value(vmax * scaling)
 
@@ -543,7 +541,7 @@ class EvokedField:
                 ),
             )
 
-    def set_vmax(self, vmax, type="meg"):
+    def set_vmax(self, vmax, kind="meg"):
         """Change the color range of the density maps.
 
         Parameters
@@ -553,18 +551,18 @@ class EvokedField:
         type : 'meg' | 'eeg'
             Which field map to apply the new color range to.
         """
-        _check_option("type", type, ["eeg", "meg"])
+        _check_option("type", kind, ["eeg", "meg"])
         for surf_map in self._surf_maps:
-            if surf_map["map_kind"] == type:
+            if surf_map["map_kind"] == kind:
                 publish(
                     self,
                     ColormapRange(
-                        kind=f"field_strength_{type}",
+                        kind=f"field_strength_{kind}",
                         fmin=-vmax,
                         fmax=vmax,
                     ),
                 )
-            break
+                break
         else:
             raise ValueError(f"No {type.upper()} field map currently shown.")
 
@@ -573,4 +571,4 @@ class EvokedField:
         for surf_map in self._surf_maps:
             current_data = surf_map["data_interp"](self._current_time)
             vmax = float(np.max(current_data))
-            self.set_vmax(vmax, type=surf_map["map_kind"])
+            self.set_vmax(vmax, kind=surf_map["map_kind"])

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -36,6 +36,7 @@ from mne._fiff._digitization import write_dig
 from mne._fiff.constants import FIFF
 from mne.bem import read_bem_solution, read_bem_surfaces
 from mne.datasets import testing
+from mne.defaults import DEFAULTS
 from mne.io import read_info, read_raw_bti, read_raw_ctf, read_raw_kit, read_raw_nirx
 from mne.minimum_norm import apply_inverse
 from mne.source_estimate import _BaseVolSourceEstimate
@@ -196,8 +197,16 @@ def test_plot_evoked_field(renderer):
     assert isinstance(fig, EvokedField)
     fig._rescale()
     fig.set_time(0.05)
+    assert fig._current_time == 0.05
     fig.set_contours(10)
-    fig.set_vmax(2)
+    assert fig._n_contours == 10
+    assert fig._widgets["contours"].get_value() == 10
+    fig.set_vmax(2e-12, kind="meg")
+    assert fig._surf_maps[1]["contours"][-1] == 2e-12
+    assert (
+        fig._widgets["vmax_slider_meg"].get_value()
+        == DEFAULTS["scalings"]["grad"] * 2e-12
+    )
 
     fig = evoked.plot_field(maps, time_viewer=False)
     assert isinstance(fig, Figure3D)


### PR DESCRIPTION
This fixes bugs introduced by shadowing the build-in `type` object. When adding unit tests, more bugs surfaced and were fixed.

fixes #12352 