### PR TITLE
[FIX] remove indexing along channel axis in `AnalogSignalGap.load()`

### DIFF
--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -22,7 +22,7 @@ class AnalogSignalGap(object):
     Parameters
     ----------
     signal : array-like
-        Array of shape (n_channels, n_samples) containing the data.
+        Array of shape (n_samples, n_chans) containing the data.
     units : str
         Units of the data. (e.g., 'uV')
     sampling_rate : quantity
@@ -39,13 +39,20 @@ class AnalogSignalGap(object):
         self.units = units
         self.sampling_rate = sampling_rate
 
-    def load(self, channel_indexes):
+    def load(self, **kwargs):
         """Return AnalogSignal object."""
         _soft_import("neo", "Reading NeuralynxIO files", strict=True)
         from neo import AnalogSignal
 
+        # `kwargs` is a dummy argument to mirror the
+        # AnalogSignalProxy.load() call signature which
+        # accepts `channel_indexes`` argument; but here we don't need
+        # any extra data selection arguments since
+        # self.signal array is already in the correct shape
+        # (channel dimension is based on `idx` variable)
+
         sig = AnalogSignal(
-            signal=self.signal[:, channel_indexes],
+            signal=self.signal,
             units=self.units,
             sampling_rate=self.sampling_rate,
         )

--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -148,8 +148,7 @@ class RawNeuralynx(BaseRaw):
             sfreq=nlx_reader.get_signal_sampling_rate(),
         )
 
-        # find total number of samples per .ncs file (`channel`) by summing
-        # the sample sizes of all segments
+        # Neo reads only valid contiguous .ncs samples grouped as segments
         n_segments = nlx_reader.header["nb_segment"][0]
         block_id = 0  # assumes there's only one block of recording
 
@@ -167,7 +166,7 @@ class RawNeuralynx(BaseRaw):
         seg_diffs = next_start_times - previous_stop_times
 
         # mark as discontinuous any two segments that have
-        # start/stop delta larger than sampling period (1/sampling_rate)
+        # start/stop delta larger than sampling period (1.5/sampling_rate)
         logger.info("Checking for temporal discontinuities in Neo data segments.")
         delta = 1.5 / info["sfreq"]
         gaps = seg_diffs > delta


### PR DESCRIPTION
#### Reference issue
Fixes #12356.

#### What does this implement/fix?
Removing indexing along channel dimension with `idx` in `AnalogSignalGap.load()` on zero-arrays representing the gap data in `self.signal` (commit: [1aa66](https://github.com/mne-tools/mne-python/commit/1aa66df3806da014231874634d98bab0331b5899)). These arrays are constructed on the fly using the `idx` variable and hence have the appropriate channel dimension to begin with. In case of a single channel, slicing a 1-dimensional array with `slice(1:2)` slice yields a 0-dimensional array which breaks the concatenation downstream in l. 359.
