### PR TITLE
fix misleading docstring return description for covariance SVD plot

### DIFF
--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -130,7 +130,7 @@ def plot_cov(
     fig_cov : instance of matplotlib.figure.Figure
         The covariance plot.
     fig_svd : instance of matplotlib.figure.Figure | None
-        The SVD spectra plot of the covariance.
+        The SVD plot of the covariance.
 
     See Also
     --------

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -130,7 +130,7 @@ def plot_cov(
     fig_cov : instance of matplotlib.figure.Figure
         The covariance plot.
     fig_svd : instance of matplotlib.figure.Figure | None
-        The SVD plot of the covariance.
+        The SVD plot of the covariance (i.e., the eigenvalues or "matrix spectrum").
 
     See Also
     --------


### PR DESCRIPTION
seems misleading to refer to SVD plots as "spectra" given that eigenvalue indices are discrete; a spectrum 

> is a condition that is not limited to a specific set of values but can vary, without gaps, across a continuum. (Wikipedia)

xref: https://mne.discourse.group/t/spectra-plot-of-the-covariance-explanation/8141