### PR TITLE
Add Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,6 +93,7 @@ jobs:
         run: |  # TODO: Remove when numba 0.59 and dipy 1.8 land on conda-forge
           sed -i '/numba/d' environment.yml
           sed -i '/dipy/d' environment.yml
+          sed -i 's/- mne$/- mne-base/' environment.yml
         if: matrix.os == 'ubuntu-latest' && startswith(matrix.kind, 'conda') && matrix.python == '3.12'
       - uses: mamba-org/setup-micromamba@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
             python: '3.10'
             kind: conda
           - os: ubuntu-latest
-            python: '3.11'
+            python: '3.12'
             kind: pip-pre
           - os: macos-latest
             python: '3.9'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,16 +56,16 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.10'
+            python: '3.12'
             kind: conda
           - os: ubuntu-latest
-            python: '3.12'
+            python: '3.11'
             kind: pip-pre
           - os: macos-latest
-            python: '3.9'
+            python: '3.12'
             kind: mamba
           - os: windows-latest
-            python: '3.10'
+            python: '3.12'
             kind: mamba
           - os: ubuntu-latest
             python: '3.9'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,16 +56,16 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.12'
-            kind: conda
-          - os: ubuntu-latest
             python: '3.11'
             kind: pip-pre
-          - os: macos-latest
+          - os: ubuntu-latest
             python: '3.12'
+            kind: conda
+          - os: macos-latest
+            python: '3.11'
             kind: mamba
           - os: windows-latest
-            python: '3.12'
+            python: '3.10'
             kind: mamba
           - os: ubuntu-latest
             python: '3.9'
@@ -89,6 +89,8 @@ jobs:
           python-version: ${{ matrix.python }}
         if: startswith(matrix.kind, 'pip')
       # Python (if conda)
+      - run: sed -i '/numba/d' environment.yml  # TODO: Remove when numba 0.59 lands on conda-forge
+        if: matrix.os == 'ubuntu-latest' && startswith(matrix.kind, 'conda') && matrix.python == '3.12'
       - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ${{ env.CONDA_ENV }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,10 @@ jobs:
           python-version: ${{ matrix.python }}
         if: startswith(matrix.kind, 'pip')
       # Python (if conda)
-      - run: sed -i '/numba/d' environment.yml  # TODO: Remove when numba 0.59 lands on conda-forge
+      - name: Remove numba and dipy
+        run: |  # TODO: Remove when numba 0.59 and dipy 1.8 land on conda-forge
+          sed -i '/numba/d' environment.yml
+          sed -i '/dipy/d' environment.yml
         if: matrix.os == 'ubuntu-latest' && startswith(matrix.kind, 'conda') && matrix.python == '3.12'
       - uses: mamba-org/setup-micromamba@v1
         with:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1335,6 +1335,8 @@ def reset_warnings(gallery_conf, fname):
         r"The .* was deprecated in Matplotlib 3\.7",
         # scipy
         r"scipy.signal.morlet2 is deprecated in SciPy 1\.12",
+        # Matplotlib->tz
+        r"datetime\.datetime\.utcfromtimestamp",
     ):
         warnings.filterwarnings(  # deal with other modules having bad imports
             "ignore", message=".*%s.*" % key, category=DeprecationWarning

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1337,6 +1337,8 @@ def reset_warnings(gallery_conf, fname):
         r"scipy.signal.morlet2 is deprecated in SciPy 1\.12",
         # Matplotlib->tz
         r"datetime\.datetime\.utcfromtimestamp",
+        # joblib
+        r"ast\.Num is deprecated",
     ):
         warnings.filterwarnings(  # deal with other modules having bad imports
             "ignore", message=".*%s.*" % key, category=DeprecationWarning

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1340,6 +1340,10 @@ def reset_warnings(gallery_conf, fname):
         # joblib
         r"ast\.Num is deprecated",
         r"Attribute n is deprecated and will be removed in Python 3\.14",
+        # numpydoc
+        r"ast\.NameConstant is deprecated and will be removed in Python 3\.14",
+        # pooch
+        r"Python 3\.14 will, by default, filter extracted tar archives.*",
     ):
         warnings.filterwarnings(  # deal with other modules having bad imports
             "ignore", message=".*%s.*" % key, category=DeprecationWarning

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1339,6 +1339,7 @@ def reset_warnings(gallery_conf, fname):
         r"datetime\.datetime\.utcfromtimestamp",
         # joblib
         r"ast\.Num is deprecated",
+        r"Attribute n is deprecated and will be removed in Python 3\.14",
     ):
         warnings.filterwarnings(  # deal with other modules having bad imports
             "ignore", message=".*%s.*" % key, category=DeprecationWarning

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -191,6 +191,7 @@ def pytest_configure(config):
     ignore:datetime.datetime.utcfromtimestamp.*:DeprecationWarning
     # joblib
     ignore:ast\.Num is deprecated.*:DeprecationWarning
+    ignore:Attribute n is deprecated and will be removed in Python 3\.14.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -192,6 +192,10 @@ def pytest_configure(config):
     # joblib
     ignore:ast\.Num is deprecated.*:DeprecationWarning
     ignore:Attribute n is deprecated and will be removed in Python 3\.14.*:DeprecationWarning
+    # numpydoc
+    ignore:ast\.NameConstant is deprecated and will be removed in Python 3\.14.*:DeprecationWarning
+    # pooch
+    ignore:Python 3\.14 will, by default, filter extracted tar archives.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -189,6 +189,8 @@ def pytest_configure(config):
     ignore:`row_stack` alias is deprecated.*:DeprecationWarning
     # Matplotlib->tz
     ignore:datetime.datetime.utcfromtimestamp.*:DeprecationWarning
+    # joblib
+    ignore:ast\.Num is deprecated.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -187,6 +187,8 @@ def pytest_configure(config):
     ignore:Mesa version 10\.2\.4 is too old for translucent.*:RuntimeWarning
     # Matplotlib <-> NumPy 2.0
     ignore:`row_stack` alias is deprecated.*:DeprecationWarning
+    # Matplotlib->tz
+    ignore:datetime.datetime.utcfromtimestamp.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -72,7 +72,7 @@ def export_evokeds_mff(fname, evoked, history=None, *, overwrite=False, verbose=
     if op.exists(fname):
         os.remove(fname) if op.isfile(fname) else shutil.rmtree(fname)
     writer = mffpy.Writer(fname)
-    current_time = datetime.datetime.now(datetime.UTC)
+    current_time = datetime.datetime.now(datetime.timezone.utc)
     writer.addxml("fileInfo", recordTime=current_time)
     try:
         device = info["device_info"]["type"]

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -50,7 +50,6 @@ def export_evokeds_mff(fname, evoked, history=None, *, overwrite=False, verbose=
     using MFF read functions.
     """
     mffpy = _import_mffpy("Export evokeds to MFF.")
-    import pytz
 
     info = evoked[0].info
     if np.round(info["sfreq"]) != info["sfreq"]:
@@ -73,7 +72,7 @@ def export_evokeds_mff(fname, evoked, history=None, *, overwrite=False, verbose=
     if op.exists(fname):
         os.remove(fname) if op.isfile(fname) else shutil.rmtree(fname)
     writer = mffpy.Writer(fname)
-    current_time = pytz.utc.localize(datetime.datetime.now(datetime.UTC))
+    current_time = datetime.datetime.now(datetime.UTC)
     writer.addxml("fileInfo", recordTime=current_time)
     try:
         device = info["device_info"]["type"]

--- a/mne/export/_egimff.py
+++ b/mne/export/_egimff.py
@@ -73,7 +73,7 @@ def export_evokeds_mff(fname, evoked, history=None, *, overwrite=False, verbose=
     if op.exists(fname):
         os.remove(fname) if op.isfile(fname) else shutil.rmtree(fname)
     writer = mffpy.Writer(fname)
-    current_time = pytz.utc.localize(datetime.datetime.utcnow())
+    current_time = pytz.utc.localize(datetime.datetime.now(datetime.UTC))
     writer.addxml("fileInfo", recordTime=current_time)
     try:
         device = info["device_info"]["type"]

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -7,7 +7,7 @@ INSTALL_ARGS="-e"
 INSTALL_KIND="test_extra,hdf5"
 if [ ! -z "$CONDA_ENV" ]; then
 	echo "Uninstalling MNE for CONDA_ENV=${CONDA_ENV}"
-	conda remove -c conda-forge --force -yq mne
+	conda remove -c conda-forge --force -yq mne-base
 	python -m pip uninstall -y mne
 	if [[ "${RUNNER_OS}" != "Windows" ]]; then
 		INSTALL_ARGS=""


### PR DESCRIPTION
I've replaced Python 3.11 with Python 3.12 in our `pip-pre` test on `ubuntu-latest`.

Which versions do we want to test explicitly? Currently (with this change), we're testing 3.9 (ubuntu-latest/minimal, macos-latest/mamba, ubuntu-20.04/old), 3.10 (ubuntu-latest/conda, windows-latest/mamba), and 3.12.