### PR TITLE
[ENH] Speed up `read_raw_neuralynx()` on large datasets with many gaps

### DIFF
--- a/doc/changes/devel/12371.newfeature.rst
+++ b/doc/changes/devel/12371.newfeature.rst
@@ -1,0 +1,1 @@
+Speed up :func:`mne.io.read_raw_neuralynx` on large datasets with many gaps, by `Kristijan Armeni`_.

--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -226,14 +226,6 @@ class RawNeuralynx(BaseRaw):
         # get the start sample index for each gap segment ()
         gap_start_ids = np.cumsum(np.hstack([[0], sizes_sorted[:-1]]))[gap_indicator]
 
-        # construct Annotations()
-        #gap_seg_ids = np.unique(sample2segment)[gap_indicator]
-        #gap_start_ids = np.array(
-        #    [np.where(sample2segment == seg_id)[0][0] for seg_id in gap_seg_ids]
-        #)
-
-        #assert (gap_start_ids2 == gap_start_ids).all()
-
         # recreate time axis for gap annotations
         mne_times = np.arange(0, len(sample2segment)) / info["sfreq"]
 

--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -223,11 +223,16 @@ class RawNeuralynx(BaseRaw):
             [np.full(shape=(n,), fill_value=i) for i, n in enumerate(sizes_sorted)]
         )
 
+        # get the start sample index for each gap segment ()
+        gap_start_ids = np.cumsum(np.hstack([[0], sizes_sorted[:-1]]))[gap_indicator]
+
         # construct Annotations()
-        gap_seg_ids = np.unique(sample2segment)[gap_indicator]
-        gap_start_ids = np.array(
-            [np.where(sample2segment == seg_id)[0][0] for seg_id in gap_seg_ids]
-        )
+        #gap_seg_ids = np.unique(sample2segment)[gap_indicator]
+        #gap_start_ids = np.array(
+        #    [np.where(sample2segment == seg_id)[0][0] for seg_id in gap_seg_ids]
+        #)
+
+        #assert (gap_start_ids2 == gap_start_ids).all()
 
         # recreate time axis for gap annotations
         mne_times = np.arange(0, len(sample2segment)) / info["sfreq"]


### PR DESCRIPTION
#### Reference issue
Fixes #12370.

#### What does this implement/fix?
**Drop `np.where` and compute onsets via `np.cumsum`** Instead of using `np.where` to iterative over gap indices and search over the recording samples, in this PR I compute all segment start samples by cumulatively summing segment sample sizes (see this change: [5b40d2](https://github.com/KristijanArmeni/mne-python/commit/5b40d21f33e92e1d101aa6de8866a15aea0b997d)).

This gives starting indices for all segments, then I select only those corresponding to gaps. Doing it this way, yields substantial improvements over using `np.where` as confirmed on a a few local datasets with increasing numbers of gaps (see Figure in #12370) 

#### Additional information
Any additional information you think is important.
