### PR TITLE
MAINT: Deal with pytest 8.0

### DIFF
--- a/mne/viz/tests/test_misc.py
+++ b/mne/viz/tests/test_misc.py
@@ -30,6 +30,7 @@ from mne.filter import create_filter
 from mne.io import read_raw_fif
 from mne.minimum_norm import read_inverse_operator
 from mne.time_frequency import CrossSpectralDensity
+from mne.utils import _record_warnings
 from mne.viz import (
     plot_bem,
     plot_chpi_snr,
@@ -214,7 +215,9 @@ def test_plot_events():
     assert fig.axes[0].get_legend() is not None
     with pytest.warns(RuntimeWarning, match="Color was not assigned"):
         plot_events(events, raw.info["sfreq"], raw.first_samp, color=color)
-    with pytest.warns(RuntimeWarning, match=r"vent \d+ missing from event_id"):
+    with _record_warnings(), pytest.warns(
+        RuntimeWarning, match=r"vent \d+ missing from event_id"
+    ):
         plot_events(
             events,
             raw.info["sfreq"],
@@ -223,7 +226,7 @@ def test_plot_events():
             color=color,
         )
     multimatch = r"event \d+ missing from event_id|in the color dict but is"
-    with pytest.warns(RuntimeWarning, match=multimatch):
+    with _record_warnings(), pytest.warns(RuntimeWarning, match=multimatch):
         plot_events(
             events,
             raw.info["sfreq"],
@@ -243,7 +246,9 @@ def test_plot_events():
             on_missing="ignore",
         )
     extra_id = {"aud_l": 1, "missing": 111}
-    with pytest.warns(RuntimeWarning, match="from event_id is not present in"):
+    with _record_warnings(), pytest.warns(
+        RuntimeWarning, match="from event_id is not present in"
+    ):
         plot_events(
             events,
             raw.info["sfreq"],
@@ -251,7 +256,7 @@ def test_plot_events():
             event_id=extra_id,
             on_missing="warn",
         )
-    with pytest.warns(RuntimeWarning, match="event 2 missing"):
+    with _record_warnings(), pytest.warns(RuntimeWarning, match="event 2 missing"):
         plot_events(
             events,
             raw.info["sfreq"],


### PR DESCRIPTION
See https://github.com/pytest-dev/pytest/pull/10937#issuecomment-1619222493, TL;DR is that `pytest.warns` in 8.0 will re-emit any unmatched warnings. So in effect our options are, for every call where this happens (about 100 according to [this run](https://github.com/mne-tools/mne-python/actions/runs/7562092509/job/20668202667?pr=12237#step:16:8662)), do one or a combination of:

1. Chain multiple context managers to catch all warnings
2. Add an outer context manager just to swallow other warnings
3. Roll our own `warns(...)` variant with a `reemit=False` default

I don't like (3) because the more we specialize our code the more hard it becomes to work with and come from other packages. (2) is the easiest and probably most appropriate for some cases actually where we get multiple warnings -- like in this first `test_misc.py` we get multiple "event missing" warnings we don't care about and rather than catch a bunch of them, just make sure the *one* we care about *does* get emitted. (In the volume source estimate cases this could be dozens of warnings, so impractical there as well.) And (1) could be ideal in some cases.

So I think my plan is to do a combination of (1) and (2) based on judgment of the ~85 currently failing tests. It'll take some time but hopefully end up readable. Okay @drammock ?