### PR TITLE
MAINT: Test arm64 on GHA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,59 +21,6 @@ _check_skip: &check_skip
       circleci-agent step halt;
     fi
 
-jobs:
-  pytest-macos-arm64:
-    parameters:
-      scheduled:
-        type: string
-        default: "false"
-    macos:
-      xcode: "14.2.0"
-    resource_class: macos.m1.medium.gen1
-    environment:
-      HOMEBREW_NO_AUTO_UPDATE: 1
-    steps:
-      - checkout
-      - run:
-          <<: *check_skip
-      - run:
-          name: Install Python and dependencies
-          command: |
-            set -eo pipefail
-            brew install python@3.11
-            which python
-            which pip
-            pip install --upgrade pip
-            pip install --upgrade --only-binary "numpy,scipy,dipy,statsmodels" -ve .[full,test_extra]
-            # 3D too slow on Apple's software renderer, and numba causes us problems
-            pip uninstall -y vtk pyvista pyvistaqt numba
-            mkdir -p test-results
-            echo "set -eo pipefail" >> $BASH_ENV
-      - run:
-          command: mne sys_info
-      - run:
-          command: ./tools/get_testing_version.sh && cat testing_version.txt
-      - restore_cache:
-          keys:
-            - data-cache-testing-{{ checksum "testing_version.txt" }}
-      - run:
-          command: python -c "import mne; mne.datasets.testing.data_path(verbose=True)"
-      - save_cache:
-          key: data-cache-testing-{{ checksum "testing_version.txt" }}
-          paths:
-            - ~/mne_data/MNE-testing-data  # (2.5 G)
-      - run:
-          command: pytest -m "not slowtest" --tb=short --cov=mne --cov-report xml -vv mne
-      - run:
-          name: Prepare test data upload
-          command: cp -av junit-results.xml test-results/junit.xml
-      - store_test_results:
-          path: ./test-results
-      # Codecov orb has bugs on macOS (gpg issues)
-      # - codecov/upload
-      - run:
-          command: bash <(curl -s https://codecov.io/bash)
-
   build_docs:
     parameters:
       scheduled:
@@ -586,20 +533,6 @@ workflows:
       - schedule:
           # "At 6:00 AM GMT every day"
           cron: "0 6 * * *"
-          filters:
-            branches:
-              only:
-                - main
-
-  weekly:
-    jobs:
-      - pytest-macos-arm64:
-          name: pytest_macos_arm64_weekly
-          scheduled: "true"
-    triggers:
-      - schedule:
-          # "At 6:00 AM GMT every Monday"
-          cron: "0 6 * * 1"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ _check_skip: &check_skip
       circleci-agent step halt;
     fi
 
+jobs:
   build_docs:
     parameters:
       scheduled:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,28 +55,28 @@ jobs:
     strategy:
       matrix:
         include:
-          # - os: ubuntu-latest
-          #  python: '3.11'
-          #  kind: pip-pre
-          # - os: ubuntu-latest
-          #  python: '3.12'
-          #  kind: conda
-          # - os: macos-latest
-          #  python: '3.11'
-          #  kind: mamba
-          # - os: windows-latest
-          #  python: '3.10'
-          #  kind: mamba
-          # - os: ubuntu-latest
-          #  python: '3.9'
-          #  kind: minimal
-          # - os: ubuntu-20.04
-          #  python: '3.9'
-          #  kind: old
+          - os: ubuntu-latest
+            python: '3.11'
+            kind: pip-pre
+          - os: ubuntu-latest
+            python: '3.12'
+            kind: conda
           # 3.12 needs https://github.com/conda-forge/dipy-feedstock/pull/50
-          - os: macos-14
+          - os: macos-14  # arm64
             python: '3.11'
             kind: mamba
+          - os: macos-latest  # intel
+            python: '3.11'
+            kind: mamba
+          - os: windows-latest
+            python: '3.10'
+            kind: mamba
+          - os: ubuntu-latest
+            python: '3.9'
+            kind: minimal
+          - os: ubuntu-20.04
+            python: '3.9'
+            kind: old
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,8 +73,9 @@ jobs:
           # - os: ubuntu-20.04
           #  python: '3.9'
           #  kind: old
+          # 3.12 needs https://github.com/conda-forge/dipy-feedstock/pull/50
           - os: macos-14
-            python: '3.12'
+            python: '3.11'
             kind: mamba
     steps:
       - uses: actions/checkout@v4
@@ -108,7 +109,7 @@ jobs:
             fmt!=10.2.0
         if: ${{ !startswith(matrix.kind, 'pip') }}
       # Make sure we have the right Python
-      - run: python -c "import platform; platform.machine() == "arm64", platform.machine()"
+      - run: python -c "import platform; platform.machine() == 'arm64', platform.machine()"
         if: matrix.os == 'macos-14'
       - run: ./tools/github_actions_dependencies.sh
       # Minimal commands on Linux (macOS stalls)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,24 +55,27 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
-            python: '3.11'
-            kind: pip-pre
-          - os: ubuntu-latest
+          # - os: ubuntu-latest
+          #  python: '3.11'
+          #  kind: pip-pre
+          # - os: ubuntu-latest
+          #  python: '3.12'
+          #  kind: conda
+          # - os: macos-latest
+          #  python: '3.11'
+          #  kind: mamba
+          # - os: windows-latest
+          #  python: '3.10'
+          #  kind: mamba
+          # - os: ubuntu-latest
+          #  python: '3.9'
+          #  kind: minimal
+          # - os: ubuntu-20.04
+          #  python: '3.9'
+          #  kind: old
+          - os: macos-14
             python: '3.12'
-            kind: conda
-          - os: macos-latest
-            python: '3.11'
             kind: mamba
-          - os: windows-latest
-            python: '3.10'
-            kind: mamba
-          - os: ubuntu-latest
-            python: '3.9'
-            kind: minimal
-          - os: ubuntu-20.04
-            python: '3.9'
-            kind: old
     steps:
       - uses: actions/checkout@v4
         with:
@@ -104,6 +107,9 @@ jobs:
             mamba
             fmt!=10.2.0
         if: ${{ !startswith(matrix.kind, 'pip') }}
+      # Make sure we have the right Python
+      - run: python -c "import platform; platform.machine() == "arm64", platform.machine()"
+        if: matrix.os == 'macos-14'
       - run: ./tools/github_actions_dependencies.sh
       # Minimal commands on Linux (macOS stalls)
       - run: ./tools/get_minimal_commands.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,7 @@ jobs:
             fmt!=10.2.0
         if: ${{ !startswith(matrix.kind, 'pip') }}
       # Make sure we have the right Python
-      - run: python -c "import platform; platform.machine() == 'arm64', platform.machine()"
+      - run: python -c "import platform; assert platform.machine() == 'arm64', platform.machine()"
         if: matrix.os == 'macos-14'
       - run: ./tools/github_actions_dependencies.sh
       # Minimal commands on Linux (macOS stalls)


### PR DESCRIPTION
In theory this should work:

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

But who knows if `setup-micromamba` actually handles it properly, etc. Let's see!

Shouldn't merge until the one run of interest is green and I uncomment the other ones.