### PR TITLE
Allow notch filtering of epochs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,5 +5,5 @@ MNE-Python is maintained by a community of scientists and research labs. The pro
 
 Users and contributors to MNE-Python are expected to follow our [code of conduct](https://github.com/mne-tools/.github/blob/main/CODE_OF_CONDUCT.md).
 
-The [contributing guide](https://mne.tools/dev/development/contributing.html) has details on the preferred contribution workflow
+The [contributing guide](https://mne.tools/stable/development/contributing.html) has details on the preferred contribution workflow
 and the recommended system configuration for a smooth contribution/development experience.


### PR DESCRIPTION
#### Reference issue
Resolves #12398 


#### What does this implement/fix?
Moved notch_filter from mne/io/base.py to class FilterMixin in mne/filter.py to allow filtering of Epoch objects, not only Raw. Fixed broken link to the contributing guidelines. 

