### PR TITLE
disable (mostly broken) "edit on GitHub" link in sidebar

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -839,7 +839,7 @@ html_theme_options = {
         ),
     ],
     "icon_links_label": "External Links",  # for screen reader
-    "use_edit_page_button": True,
+    "use_edit_page_button": False,
     "navigation_with_keys": False,
     "show_toc_level": 1,
     "article_header_start": [],  # disable breadcrumbs

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1408,7 +1408,7 @@ class BaseEpochs(
         Dropping bad epochs can be done multiple times with different
         ``reject`` and ``flat`` parameters. However, once an epoch is
         dropped, it is dropped forever, so if more lenient thresholds may
-        subsequently be applied, `epochs.copy <mne.Epochs.copy>` should be
+        subsequently be applied, :meth:`epochs.copy <mne.Epochs.copy>` should be
         used.
         """
         if reject == "existing":

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3366,6 +3366,7 @@ reject : dict | str | None
 
     .. note:: If ``reject`` is a callable, than **any** criteria can be
             used to reject epochs (including maxima and minima).
+
     If ``reject`` is ``None``, no rejection is performed. If ``'existing'``
     (default), then the rejection parameters set at instantiation are used.
 """  # noqa: E501


### PR DESCRIPTION
The "Edit on GitHub" link is broken for all *generated* pages on our site (which means all tutorials, and all API pages below the top-level "python reference" page). This is a known problem at the theme level; until fixed let's just disable it.

Thanks @britta-wstnr for pointing it out.