### PR TITLE
[FIX] remove AnalogSignalGap

### DIFF
--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -4,7 +4,6 @@ import glob
 import os
 
 import numpy as np
-from neo.core import AnalogSignal
 
 from ..._fiff.meas_info import create_info
 from ..._fiff.utils import _mult_cal_one
@@ -212,8 +211,9 @@ class RawNeuralynx(BaseRaw):
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a chunk of raw data."""
-        from neo import Segment
+        from neo import AnalogSignal, Segment
         from neo.io import NeuralynxIO
+        from neo.io.proxyobjects import AnalogSignalProxy
 
         # quantities is a dependency of neo so we are guaranteed it exists
         from quantities import Hz
@@ -313,7 +313,7 @@ class RawNeuralynx(BaseRaw):
                 signal.load(channel_indexes=idx).magnitude[
                     samples[0] : samples[-1] + 1, :
                 ]
-                if type(signal) is not AnalogSignal  # then it's AnalogSignalProxy
+                if isinstance(signal, AnalogSignalProxy)
                 else signal.magnitude[samples[0] : samples[-1] + 1, :]
                 for seg, samples in zip(
                     segments_arr[first_seg : last_seg + 1], sel_samples_local

--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -4,59 +4,13 @@ import glob
 import os
 
 import numpy as np
+from neo.core import AnalogSignal
 
 from ..._fiff.meas_info import create_info
 from ..._fiff.utils import _mult_cal_one
 from ...annotations import Annotations
 from ...utils import _check_fname, _soft_import, fill_doc, logger, verbose
 from ..base import BaseRaw
-
-
-class AnalogSignalGap:
-    """Dummy object to represent gaps in Neuralynx data.
-
-    Creates a AnalogSignalProxy-like object.
-    Propagate `signal`, `units`, and `sampling_rate` attributes
-    to the `AnalogSignal` init returned by `load()`.
-
-    Parameters
-    ----------
-    signal : array-like
-        Array of shape (n_samples, n_chans) containing the data.
-    units : str
-        Units of the data. (e.g., 'uV')
-    sampling_rate : quantity
-        Sampling rate of the data. (e.g., 4000 * pq.Hz)
-
-    Returns
-    -------
-    sig : instance of AnalogSignal
-        A AnalogSignal object representing a gap in Neuralynx data.
-    """
-
-    def __init__(self, signal, units, sampling_rate):
-        self.signal = signal
-        self.units = units
-        self.sampling_rate = sampling_rate
-
-    def load(self, **kwargs):
-        """Return AnalogSignal object."""
-        _soft_import("neo", "Reading NeuralynxIO files", strict=True)
-        from neo import AnalogSignal
-
-        # `kwargs` is a dummy argument to mirror the
-        # AnalogSignalProxy.load() call signature which
-        # accepts `channel_indexes`` argument; but here we don't need
-        # any extra data selection arguments since
-        # self.signal array is already in the correct shape
-        # (channel dimension is based on `idx` variable)
-
-        sig = AnalogSignal(
-            signal=self.signal,
-            units=self.units,
-            sampling_rate=self.sampling_rate,
-        )
-        return sig
 
 
 @fill_doc
@@ -338,7 +292,7 @@ class RawNeuralynx(BaseRaw):
         )
 
         for seg, n in zip(gap_segments, gap_samples):
-            asig = AnalogSignalGap(
+            asig = AnalogSignal(
                 signal=np.zeros((n, n_chans)), units="uV", sampling_rate=sfreq * Hz
             )
             seg.analogsignals.append(asig)
@@ -351,13 +305,16 @@ class RawNeuralynx(BaseRaw):
         segments_arr[~isgap] = neo_block[0].segments
         segments_arr[isgap] = gap_segments
 
-        # now load data from selected segments/channels via
-        # neo.Segment.AnalogSignal.load() or AnalogSignalGap.load()
+        # now load data for selected segments/channels via
+        # neo.Segment.AnalogSignalProxy.load() or
+        # pad directly as AnalogSignal.magnitude for any gap data
         all_data = np.concatenate(
             [
                 signal.load(channel_indexes=idx).magnitude[
                     samples[0] : samples[-1] + 1, :
                 ]
+                if type(signal) is not AnalogSignal  # then it's AnalogSignalProxy
+                else signal.magnitude[samples[0] : samples[-1] + 1, :]
                 for seg, samples in zip(
                     segments_arr[first_seg : last_seg + 1], sel_samples_local
                 )


### PR DESCRIPTION
#### Reference issue
Fixes #12413.

#### What does this implement/fix
So far, to insert gap data (0's representing missing samples), the `AnalogSignalGap` class with a dummy `load()` method was defined and used to mirror the `neo.AnalogSignalProxy` object which loads recorded samples from disk.

As of v13, `neo` allows only`AnalogSignal`/`AnalogSignalProxy` types to be appended to `Segment.analogsignals` attribute. To fix this, we drop the over-engineered `AnalogSignalGap` class. Instead, we create zero-arrays directly with `AnalogSignal` and use a simple control statement to distinguish loading real data (via `AnalogSignalProxy.load().magnitude`) and padding 0's (via `AnalogSignal.magnitude`) when looping over segments and creating the output data array.