### PR TITLE
Remove incorrect assertions in snirf parsing

### DIFF
--- a/doc/changes/devel/12430.bugfix.rst
+++ b/doc/changes/devel/12430.bugfix.rst
@@ -1,0 +1,1 @@
+Reformats channel and detector lookup in :class:`mne.io.RawSNIRF` from array based to dictionary based. Removes incorrect assertions that every detector and source must have data associated with every registered optode position, by :newcontrib:`Alex Kiefer`.

--- a/doc/changes/devel/12430.bugfix.rst
+++ b/doc/changes/devel/12430.bugfix.rst
@@ -1,1 +1,1 @@
-Reformats channel and detector lookup in :class:`mne.io.RawSNIRF` from array based to dictionary based. Removes incorrect assertions that every detector and source must have data associated with every registered optode position, by :newcontrib:`Alex Kiefer`.
+Reformats channel and detector lookup in :func:`mne.io.read_raw_snirf` from array based to dictionary based. Removes incorrect assertions that every detector and source must have data associated with every registered optode position, by :newcontrib:`Alex Kiefer`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -20,6 +20,8 @@
 
 .. _Alex Gramfort: https://alexandre.gramfort.net
 
+.. _Alex Kiefer: https://home.alex101.dev
+
 .. _Alex Rockhill: https://github.com/alexrockhill/
 
 .. _Alexander Rudiuk: https://github.com/ARudiuk

--- a/mne/_fiff/meas_info.py
+++ b/mne/_fiff/meas_info.py
@@ -1104,9 +1104,9 @@ class Info(dict, SetChannelsMixin, MontageMixin, ContainsMixin):
         The transformation from 4D/CTF head coordinates to Neuromag head
         coordinates. This is only present in 4D/CTF data.
     custom_ref_applied : int
-        Whether a custom (=other than average) reference has been applied to
-        the EEG data. This flag is checked by some algorithms that require an
-        average reference to be set.
+        Whether a custom (=other than an average projector) reference has been
+        applied to the EEG data. This flag is checked by some algorithms that
+        require an average reference to be set.
     description : str | None
         String description of the recording.
     dev_ctf_t : Transform | None

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -168,7 +168,7 @@ class RawSNIRF(BaseRaw):
                         for c in channels
                     ]
                 )
-                sources = [f"S{int(s)}" for s in sources]
+                sources = {int(s): f"S{int(s)}" for s in sources}
 
             if "detectorLabels_disabled" in dat["nirs/probe"]:
                 # This is disabled as
@@ -185,7 +185,7 @@ class RawSNIRF(BaseRaw):
                         for c in channels
                     ]
                 )
-                detectors = [f"D{int(d)}" for d in detectors]
+                detectors = {int(d): f"D{int(d)}" for d in detectors}
 
             # Extract source and detector locations
             # 3D positions are optional in SNIRF,
@@ -224,8 +224,6 @@ class RawSNIRF(BaseRaw):
                     "location information"
                 )
 
-            assert len(sources) == srcPos3D.shape[0]
-            assert len(detectors) == detPos3D.shape[0]
 
             chnames = []
             ch_types = []
@@ -248,9 +246,9 @@ class RawSNIRF(BaseRaw):
                         )[0]
                     )
                     ch_name = (
-                        sources[src_idx - 1]
+                        sources[src_idx]
                         + "_"
-                        + detectors[det_idx - 1]
+                        + detectors[det_idx]
                         + " "
                         + str(fnirs_wavelengths[wve_idx - 1])
                     )
@@ -265,7 +263,7 @@ class RawSNIRF(BaseRaw):
                     # Convert between SNIRF processed names and MNE type names
                     dt_id = dt_id.lower().replace("dod", "fnirs_od")
 
-                    ch_name = sources[src_idx - 1] + "_" + detectors[det_idx - 1]
+                    ch_name = sources[src_idx] + "_" + detectors[det_idx]
 
                     if dt_id == "fnirs_od":
                         wve_idx = int(


### PR DESCRIPTION
Reformats channel and detector lookup from array based to dictionary based. Removes incorrect assertions that every detector and source must have data associated with every registered optode position.

#### Reference issue
Example: Fixes #12429.


#### What does this implement/fix?
Reformats channel and detector lookup from array based to dictionary based. Removes incorrect assertions that every detector and source must have data associated with every registered optode position.
