### PR TITLE
Specify CODECOV_TOKEN in codecov/codecov-action@v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,4 +130,6 @@ jobs:
       - run: ./tools/github_actions_download.sh
       - run: ./tools/github_actions_test.sh
       - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
         if: success()


### PR DESCRIPTION
Since #12419 the coverage tanked to 29%.
Likely because token-less uploads are not supported anymore, thus the secrets `CODECOV_TOKEN` should be added to this repository if it is missing.

c.f. https://github.com/codecov/codecov-action?tab=readme-ov-file#usage