### PR TITLE
Fix stc_near_sensors error

### DIFF
--- a/doc/changes/devel/12436.bugfix.rst
+++ b/doc/changes/devel/12436.bugfix.rst
@@ -1,0 +1,1 @@
+Fix :ref:`tut-working-with-seeg` use of :func:`mne.stc_near_sensors` to use the :class:`mne.VolSourceEstimate` positions and not the pial surface, by `Alex Rockhill`_

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -3879,8 +3879,11 @@ def stc_near_sensors(
     if surface == "auto":
         if src is not None:
             pial_fname = op.join(subjects_dir, subject, "surf", "lh.pial")
-            src_surf_is_pial = op.isfile(pial_fname) and np.allclose(
-                src[0]["rr"], read_surface(pial_fname)[0]
+            pial_rr = read_surface(pial_fname)[0]
+            src_surf_is_pial = (
+                op.isfile(pial_fname)
+                and src[0]["rr"].shape == pial_rr.shape
+                and np.allclose(src[0]["rr"], pial_rr)
             )
             if not src_surf_is_pial:
                 warn(

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -3893,7 +3893,7 @@ def stc_near_sensors(
                     "or ``surface=None`` to suppress this warning",
                     DeprecationWarning,
                 )
-        surface = "pial"
+        surface = "pial" if src is None or src.kind == "surface" else None
 
     # create a copy of Evoked using ecog, seeg and dbs
     if picks is None:

--- a/tutorials/clinical/20_seeg.py
+++ b/tutorials/clinical/20_seeg.py
@@ -219,7 +219,7 @@ stc = mne.stc_near_sensors(
     src=vol_src,
     surface=None,
     verbose="error",
-)  # ignore missing electrode warnings
+)
 stc = abs(stc)  # just look at magnitude
 clim = dict(kind="value", lims=np.percentile(abs(evoked.data), [10, 50, 75]))
 

--- a/tutorials/clinical/20_seeg.py
+++ b/tutorials/clinical/20_seeg.py
@@ -212,7 +212,13 @@ vol_src = mne.read_source_spaces(fname_src)
 
 evoked = epochs.average()
 stc = mne.stc_near_sensors(
-    evoked, trans, "fsaverage", subjects_dir=subjects_dir, src=vol_src, verbose="error"
+    evoked,
+    trans,
+    "fsaverage",
+    subjects_dir=subjects_dir,
+    src=vol_src,
+    surface=None,
+    verbose="error",
 )  # ignore missing electrode warnings
 stc = abs(stc)  # just look at magnitude
 clim = dict(kind="value", lims=np.percentile(abs(evoked.data), [10, 50, 75]))


### PR DESCRIPTION
Fixes broken CI from https://github.com/mne-tools/mne-python/pull/12382#issuecomment-1937367062

Ok so, I forgot to test that the shape was the same so volume source estimates with a different rr shape caused an error so I fixed that. But also, in doing so I noticed that the default, `surface='pial'` was being used (right). I'm not sure if this was on purpose but I think the `surface=None` version looks a lot better (left) which uses the src vertices. I think it actually was super confusing having an STC projected to pial surfaces and I would think maybe is a bug.

![image](https://github.com/mne-tools/mne-python/assets/13473576/7c947be1-d585-41d7-a5f7-660916f8ad8c)