### PR TITLE
don't put pytest marks on test fixtures

### DIFF
--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -797,8 +797,6 @@ def mixed_fwd_cov_evoked(_evoked_cov_sphere, _all_src_types_fwd):
 
 
 @pytest.fixture(scope="session")
-@pytest.mark.slowtest
-@pytest.mark.parametrize(params=[testing._pytest_param()])
 def src_volume_labels():
     """Create a 7mm source space with labels."""
     pytest.importorskip("nibabel")

--- a/mne/source_space/tests/test_source_space.py
+++ b/mne/source_space/tests/test_source_space.py
@@ -679,6 +679,7 @@ def test_source_space_from_label(tmp_path, pass_ids):
     _compare_source_spaces(src, src_from_file, mode="approx")
 
 
+@pytest.mark.slowtest
 @testing.requires_testing_data
 def test_source_space_exclusive_complete(src_volume_labels):
     """Test that we produce exclusive and complete labels."""


### PR DESCRIPTION
should prevent pytest warnings like this one:

```
======================================== warnings summary ========================================
mne/conftest.py:836
  /opt/mne/python/mne/conftest.py:836: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
    @pytest.fixture(scope="session")

../../mambaforge/envs/mnedev/lib/python3.11/site-packages/_pytest/mark/structures.py:357
  /opt/mambaforge/envs/mnedev/lib/python3.11/site-packages/_pytest/mark/structures.py:357: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
    store_mark(func, self.mark)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```