### PR TITLE
FIX: na_rep for reports

### DIFF
--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -3842,9 +3842,10 @@ class Report:
             index=False,
             show_dimensions=True,
             justify="unset",
-            float_format=lambda x: f"{round(x, 3):.3f}",
+            float_format=lambda x: f"{x:.3f}",
             classes="table table-hover table-striped "
             "table-sm table-responsive small",
+            na_rep="",
         )
         del metadata
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -3835,9 +3835,9 @@ class Report:
             metadata.index.name = "Epoch #"
 
         assert metadata.index.is_unique
-        index_name = metadata.index.name  # store for later use
+        data_id = metadata.index.name  # store for later use
         metadata = metadata.reset_index()  # We want "proper" columns only
-        html = _df_bootstrap_table(df=metadata, index_name=index_name)
+        html = _df_bootstrap_table(df=metadata, data_id=data_id)
         self._add_html_element(
             div_klass="epochs",
             tags=tags,
@@ -4336,7 +4336,7 @@ class _ReportScraper:
             copyfile(key, value)
 
 
-def _df_bootstrap_table(*, df, index_name):
+def _df_bootstrap_table(*, df, data_id):
     html = df.to_html(
         border=0,
         index=False,
@@ -4356,7 +4356,7 @@ def _df_bootstrap_table(*, df, index_name):
                 "<table "
                 'id="mytable" '
                 'data-toggle="table" '
-                f'data-unique-id="{index_name}" '
+                f'data-unique-id="{data_id}" '
                 'data-search="true" '  # search / filter
                 'data-search-highlight="true" '
                 'data-show-columns="true" '  # show/hide columns


### PR DESCRIPTION
Very minor change -- just omit nan rather than putting `NaN` in epoch event count report sections, makes things more readable. For example:

| main | PR |
| -- | -- |
| ![Screenshot from 2024-02-16 15-24-51](https://github.com/mne-tools/mne-python/assets/2365790/6fce19e9-c3b0-4f6c-a032-43c7276d8c1d) | ![Screenshot from 2024-02-16 15-25-00](https://github.com/mne-tools/mne-python/assets/2365790/09d51901-e274-4d94-9ab1-54727a9e5b76) |



Don't think this warrants a changelog entry since it's so minor.