### PR TITLE
Disable interpolation in BrainVision config parser

### DIFF
--- a/doc/changes/devel/12456.bugfix.rst
+++ b/doc/changes/devel/12456.bugfix.rst
@@ -1,0 +1,1 @@
+Disable config parser interpolation when reading BrainVision files, which allows using the percent sign as a regular character in channel units, by `Clemens Brunner`_.

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -447,7 +447,7 @@ def _aux_hdr_info(hdr_fname):
         params, settings = settings.split("[Comment]")
     else:
         params, settings = settings, ""
-    cfg = configparser.ConfigParser()
+    cfg = configparser.ConfigParser(interpolation=None)
     with StringIO(params) as fid:
         cfg.read_file(fid)
 


### PR DESCRIPTION
I recently came across a BrainVision file, which contains a channel `SpO2` (peripheral oxygen saturation) with a unit `%`. However, reading this file raises a `configparser.InterpolationError`, because by default `configparser.ConfigParser` uses `interpolation=configparser.BasicInterpolation` (see [here](https://docs.python.org/3/library/configparser.html#interpolation-of-values)). This means that it uses percent-based interpolation, e.g. it replaces `%(some_dir)` with the value of the variable `some_dir` (defined elsewhere in the config file).

I am pretty sure that BrainVision header files do not contain such format strings, and therefore, I suggest that we disable interpolation when parsing this file. That way, channels can be specified to have a unit `%`.