### PR TITLE
Fix dead links to contribution guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,4 +10,4 @@ This project and everyone participating in it is governed by the [MNE-Python's C
 
 ## How to contribute
 
-Before contributing make sure you are familiar with [our contributing guide](https://mne.tools/dev/install/contributing.html).
+Before contributing make sure you are familiar with [our contributing guide](https://mne.tools/dev/development/contributing.html).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 Thanks for contributing a pull request! Please make sure you have read the
-[contribution guidelines](https://mne.tools/dev/install/contributing.html)
+[contribution guidelines](https://mne.tools/dev/development/contributing.html)
 before submitting.
 
 Please be aware that we are a loose team of volunteers so patience is

--- a/doc/changes/devel/12461.other.rst
+++ b/doc/changes/devel/12461.other.rst
@@ -1,0 +1,1 @@
+Fix dead links in ``README.rst`` documentation by :newcontrib:`Will Turner`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -594,6 +594,8 @@
 
 .. _Xiaokai Xia: https://github.com/dddd1007
 
+.. _Will Turner: https://bootstrapbill.github.io
+
 .. _Yaroslav Halchenko: http://haxbylab.dartmouth.edu/ppl/yarik.html
 
 .. _Yiping Zuo: https://github.com/frostime


### PR DESCRIPTION
Fixes #12460 (also related to #12316). 

Such a simple fix I thought I should probably just implement it. Hope that's appropriate! 