### PR TITLE
MRG: Allow `tmin` and `tmax` in `mne.epochs.make_metadata()` to accept strings

### DIFF
--- a/doc/changes/devel/12462.newfeature.rst
+++ b/doc/changes/devel/12462.newfeature.rst
@@ -1,0 +1,1 @@
+:func:`mne.epochs.make_metadata` now accepts strings as ``tmin`` and ``tmax`` parameter values, simplifying metadata creation based on time-varying events such as responses to a stimulus, by `Richard Höchenberger`_.

--- a/examples/preprocessing/epochs_metadata.py
+++ b/examples/preprocessing/epochs_metadata.py
@@ -100,7 +100,7 @@ metadata
 # Fixed time window with ``keep_first``
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# One workaround is using the ``keep_first`` paramter, which will create a new column
+# One workaround is using the ``keep_first`` parameter, which will create a new column
 # containing the first event of the specified type.
 
 metadata_tmin = 0.0

--- a/examples/preprocessing/epochs_metadata.py
+++ b/examples/preprocessing/epochs_metadata.py
@@ -1,0 +1,171 @@
+"""
+.. _epochs-metadata:
+
+===============================================================
+Automated epochs metadata generation with variable time windows
+===============================================================
+
+When working with :class:`~mne.Epochs`, :ref:`metadata <tut-epochs-metadata>` can be
+invaluable. There is an extensive tutorial on
+:ref:`how it can be generated automatically <tut-autogenerate-metadata>`.
+In the brief examples below, we will demonstrate different ways to bound the time
+windows used to generate the metadata.
+
+"""
+# Authors: Richard Höchenberger <richard.hoechenberger@gmail.com>
+#
+# License: BSD-3-Clause
+# Copyright the MNE-Python contributors.
+
+# %%
+# We will use data from an EEG recording during an Eriksen flanker task task. For the
+# purpose of demonstration, we'll only load the first 60 seconds of data.
+
+import mne
+
+data_dir = mne.datasets.erp_core.data_path()
+infile = data_dir / "ERP-CORE_Subject-001_Task-Flankers_eeg.fif"
+
+raw = mne.io.read_raw(infile, preload=True)
+raw.crop(tmax=60).filter(l_freq=0.1, h_freq=40)
+
+# %%
+# Visualizing the events
+# ^^^^^^^^^^^^^^^^^^^^^^
+#
+# All experimental events are stored in the :class:`mne.io.Raw` instance as
+# :class:`mne.Annotations`. We first need to convert these to events and the
+# corresponding mapping from event codes to event names (``event_id``). We then
+# visualize the events.
+all_events, all_event_id = mne.events_from_annotations(raw)
+mne.viz.plot_events(events=all_events, event_id=all_event_id, sfreq=raw.info["sfreq"])
+
+
+# %%
+# As you can see, there are four types of ``stimulus`` and two types of ``response``
+# events.
+#
+# Declaring "row events"
+# ^^^^^^^^^^^^^^^^^^^^^^
+#
+# For the sake of this example, we will assume that during analysis our epochs will be
+# time-locked to the stimulus onset events. Hence, we would like to create metadata with
+# one row per stimulus. We can achieve this by specifying all stimulus event names as
+# ``row_events``.
+
+row_events = [
+    "stimulus/compatible/target_left",
+    "stimulus/compatible/target_right",
+    "stimulus/incompatible/target_left",
+    "stimulus/incompatible/target_right",
+]
+
+# %%
+# Specifying metadata time windows
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# Now, we will explore different ways of specifying the time windows around the
+# ``row_events`` when generating metadata. Any events falling within the same time
+# window will be added to the same row in the metadata table.
+#
+# Fixed time window
+# ~~~~~~~~~~~~~~~~~
+#
+# A simple way to specify the time window extent is by specifying the time in seconds
+# relative to the row event. In the following example, the time window spans from the
+# row event (time point zero) up until three seconds later.
+
+metadata_tmin = 0.0
+metadata_tmax = 3.0
+
+metadata, events, event_id = mne.epochs.make_metadata(
+    events=all_events,
+    event_id=all_event_id,
+    tmin=metadata_tmin,
+    tmax=metadata_tmax,
+    sfreq=raw.info["sfreq"],
+    row_events=row_events,
+)
+
+metadata
+
+# %%
+# This looks good at the first glance. However, for example in the 2nd and 3rd row, we
+# have two responses listed (left and right). This is because the 3-second time window
+# is obviously a bit too wide and captures more than one trial. While we could make it
+# narrower, this could lead to a loss of events – if the window becomes **too** narrow.
+# Ultimately, this problem arises because the response time varies from trial to trial,
+# so it's difficult for us to set a fixed upper bound for the time window.
+#
+# Fixed time window with ``keep_first``
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# One workaround is using the ``keep_first`` paramter, which will create a new column
+# containing the first event of the specified type.
+
+metadata_tmin = 0.0
+metadata_tmax = 3.0
+keep_first = "response"  # <-- new
+
+metadata, events, event_id = mne.epochs.make_metadata(
+    events=all_events,
+    event_id=all_event_id,
+    tmin=metadata_tmin,
+    tmax=metadata_tmax,
+    sfreq=raw.info["sfreq"],
+    row_events=row_events,
+    keep_first=keep_first,  # <-- new
+)
+
+metadata
+
+# %%
+# As you can see, a new column ``response`` was created with the time of the first
+# response event falling inside the time window. The ``first_response`` column specifies
+# **which** response occurred first (left or right).
+#
+# Variable time window
+# ~~~~~~~~~~~~~~~~~~~~
+#
+# Another way to address the challenge of variable time windows **without** the need to
+# create new columns is by specifying ``tmin`` and ``tmax`` as event names. In this
+# example, we use ``tmin=row_events``, because we want the time window to start
+# with the time-locked event. ``tmax``, on the other hand, are the response events:
+# The first response event following ``tmin`` will be used to determine the duration of
+# the time window.
+
+metadata_tmin = row_events
+metadata_tmax = ["response/left", "response/right"]
+
+metadata, events, event_id = mne.epochs.make_metadata(
+    events=all_events,
+    event_id=all_event_id,
+    tmin=metadata_tmin,
+    tmax=metadata_tmax,
+    sfreq=raw.info["sfreq"],
+    row_events=row_events,
+)
+
+metadata
+
+# %%
+# Variable time window (simplified)
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# We can slightly simplify the above code: Since ``tmin`` shall be set to the
+# ``row_events``, we can paass ``tmin=None``, which is a more convenient way to express
+# ``tmin=row_events``. The resulting metadata looks the same as in the previous example.
+
+metadata_tmin = None  # <-- new
+metadata_tmax = ["response/left", "response/right"]
+
+metadata, events, event_id = mne.epochs.make_metadata(
+    events=all_events,
+    event_id=all_event_id,
+    tmin=metadata_tmin,
+    tmax=metadata_tmax,
+    sfreq=raw.info["sfreq"],
+    row_events=row_events,
+)
+
+metadata

--- a/examples/preprocessing/epochs_metadata.py
+++ b/examples/preprocessing/epochs_metadata.py
@@ -98,7 +98,7 @@ metadata
 # so it's difficult for us to set a fixed upper bound for the time window.
 #
 # Fixed time window with ``keep_first``
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # One workaround is using the ``keep_first`` parameter, which will create a new column
 # containing the first event of the specified type.
@@ -150,7 +150,7 @@ metadata
 
 # %%
 # Variable time window (simplified)
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # We can slightly simplify the above code: Since ``tmin`` shall be set to the
 # ``row_events``, we can paass ``tmin=None``, which is a more convenient way to express

--- a/examples/preprocessing/epochs_metadata.py
+++ b/examples/preprocessing/epochs_metadata.py
@@ -18,7 +18,7 @@ windows used to generate the metadata.
 # Copyright the MNE-Python contributors.
 
 # %%
-# We will use data from an EEG recording during an Eriksen flanker task task. For the
+# We will use data from an EEG recording during an Eriksen flanker task. For the
 # purpose of demonstration, we'll only load the first 60 seconds of data.
 
 import mne
@@ -33,8 +33,8 @@ raw.crop(tmax=60).filter(l_freq=0.1, h_freq=40)
 # Visualizing the events
 # ^^^^^^^^^^^^^^^^^^^^^^
 #
-# All experimental events are stored in the :class:`mne.io.Raw` instance as
-# :class:`mne.Annotations`. We first need to convert these to events and the
+# All experimental events are stored in the :class:`~mne.io.Raw` instance as
+# :class:`~mne.Annotations`. We first need to convert these to events and the
 # corresponding mapping from event codes to event names (``event_id``). We then
 # visualize the events.
 all_events, all_event_id = mne.events_from_annotations(raw)
@@ -50,8 +50,8 @@ mne.viz.plot_events(events=all_events, event_id=all_event_id, sfreq=raw.info["sf
 #
 # For the sake of this example, we will assume that during analysis our epochs will be
 # time-locked to the stimulus onset events. Hence, we would like to create metadata with
-# one row per stimulus. We can achieve this by specifying all stimulus event names as
-# ``row_events``.
+# one row per ``stimulus``. We can achieve this by specifying all stimulus event names
+# as ``row_events``.
 
 row_events = [
     "stimulus/compatible/target_left",
@@ -93,9 +93,9 @@ metadata
 # This looks good at the first glance. However, for example in the 2nd and 3rd row, we
 # have two responses listed (left and right). This is because the 3-second time window
 # is obviously a bit too wide and captures more than one trial. While we could make it
-# narrower, this could lead to a loss of events – if the window becomes **too** narrow.
-# Ultimately, this problem arises because the response time varies from trial to trial,
-# so it's difficult for us to set a fixed upper bound for the time window.
+# narrower, this could lead to a loss of events – if the window might become **too**
+# narrow. Ultimately, this problem arises because the response time varies from trial
+# to trial, so it's difficult for us to set a fixed upper bound for the time window.
 #
 # Fixed time window with ``keep_first``
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2852,7 +2852,9 @@ def make_metadata(
 
         If a string or a list of strings, the events bounding the metadata around each
         "row event". For ``tmin``, the events are assumed to occur **before** the row
-        event, and for ``tmax``, the events are assumed to occur **after**.
+        event, and for ``tmax``, the events are assumed to occur **after** – unless
+        ``tmin`` or ``tmax`` are equal to a row event, in which case the row event
+        serves as the bound.
 
         .. versionchanged:: 1.6.0
            Added support for ``None``.

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2829,14 +2829,15 @@ def make_metadata(
         A mapping from event names (keys) to event IDs (values). The event
         names will be incorporated as columns of the returned metadata
         :class:`~pandas.DataFrame`.
-    tmin, tmax : float | None
-        Start and end of the time interval for metadata generation in seconds, relative
-        to the time-locked event of the respective time window (the "row events").
+    tmin, tmax : float | str | list of str | None
+        If float, start and end of the time interval for metadata generation in seconds,
+        relative to the time-locked event of the respective time window (the "row
+        events").
 
         .. note::
            If you are planning to attach the generated metadata to
            `~mne.Epochs` and intend to include only events that fall inside
-           your epochs time interval, pass the same ``tmin`` and ``tmax``
+           your epoch's time interval, pass the same ``tmin`` and ``tmax``
            values here as you use for your epochs.
 
         If ``None``, the time window used for metadata generation is bounded by the
@@ -2849,8 +2850,15 @@ def make_metadata(
            the first row event. If ``tmax=None``, the last time window for metadata
            generation ends with the last event in ``events``.
 
+        If a string or a list of strings, the events bounding the metadata around each
+        "row event". For ``tmin``, the events are assumed to occur **before** the row
+        event, and for ``tmax``, the events are assumed to occur **after**.
+
         .. versionchanged:: 1.6.0
            Added support for ``None``.
+
+        .. versionadded:: 1.7.0
+           Added support for strings.
     sfreq : float
         The sampling frequency of the data from which the events array was
         extracted.
@@ -2936,8 +2944,8 @@ def make_metadata(
     be attached; it may well be much shorter or longer, or not overlap at all,
     if desired. This can be useful, for example, to include events that
     occurred before or after an epoch, e.g. during the inter-trial interval.
-    If either ``tmin``, ``tmax``, or both are ``None``, the time window will
-    typically vary, too.
+    If either ``tmin``, ``tmax``, or both are ``None``, or a string referring e.g. to a
+    response event, the time window will typically vary, too.
 
     .. versionadded:: 0.23
 
@@ -2950,11 +2958,11 @@ def make_metadata(
     _validate_type(events, types=("array-like",), item_name="events")
     _validate_type(event_id, types=(dict,), item_name="event_id")
     _validate_type(sfreq, types=("numeric",), item_name="sfreq")
-    _validate_type(tmin, types=("numeric", None), item_name="tmin")
-    _validate_type(tmax, types=("numeric", None), item_name="tmax")
-    _validate_type(row_events, types=(None, str, list, tuple), item_name="row_events")
-    _validate_type(keep_first, types=(None, str, list, tuple), item_name="keep_first")
-    _validate_type(keep_last, types=(None, str, list, tuple), item_name="keep_last")
+    _validate_type(tmin, types=("numeric", str, "array-like", None), item_name="tmin")
+    _validate_type(tmax, types=("numeric", str, "array-like", None), item_name="tmax")
+    _validate_type(row_events, types=(None, str, "array-like"), item_name="row_events")
+    _validate_type(keep_first, types=(None, str, "array-like"), item_name="keep_first")
+    _validate_type(keep_last, types=(None, str, "array-like"), item_name="keep_last")
 
     if not event_id:
         raise ValueError("event_id dictionary must contain at least one entry")
@@ -2970,6 +2978,19 @@ def make_metadata(
     row_events = _ensure_list(row_events)
     keep_first = _ensure_list(keep_first)
     keep_last = _ensure_list(keep_last)
+
+    # Turn tmin, tmax into a list if they're strings or arrays of strings
+    try:
+        _validate_type(tmin, types=(str, "array-like"), item_name="tmin")
+        tmin = _ensure_list(tmin)
+    except TypeError:
+        pass
+
+    try:
+        _validate_type(tmax, types=(str, "array-like"), item_name="tmax")
+        tmax = _ensure_list(tmax)
+    except TypeError:
+        pass
 
     keep_first_and_last = set(keep_first) & set(keep_last)
     if keep_first_and_last:
@@ -2990,18 +3011,40 @@ def make_metadata(
                     f"{param_name}, cannot be found in event_id dictionary"
                 )
 
-    event_name_diff = sorted(set(row_events) - set(event_id.keys()))
-    if event_name_diff:
-        raise ValueError(
-            f"Present in row_events, but missing from event_id: "
-            f'{", ".join(event_name_diff)}'
+    # If tmin, tmax are strings, ensure these event names are present in event_id
+    def _diff_input_strings_vs_event_id(input_strings, input_name, event_id):
+        event_name_diff = sorted(set(input_strings) - set(event_id.keys()))
+        if event_name_diff:
+            raise ValueError(
+                f"Present in {input_name}, but missing from event_id: "
+                f'{", ".join(event_name_diff)}'
+            )
+
+    _diff_input_strings_vs_event_id(
+        input_strings=row_events, input_name="row_events", event_id=event_id
+    )
+    if isinstance(tmin, list):
+        _diff_input_strings_vs_event_id(
+            input_strings=tmin, input_name="tmin", event_id=event_id
         )
-    del event_name_diff
+    if isinstance(tmax, list):
+        _diff_input_strings_vs_event_id(
+            input_strings=tmax, input_name="tmax", event_id=event_id
+        )
 
     # First and last sample of each epoch, relative to the time-locked event
     # This follows the approach taken in mne.Epochs
-    start_sample = None if tmin is None else int(round(tmin * sfreq))
-    stop_sample = None if tmax is None else int(round(tmax * sfreq)) + 1
+    # For strings and None, we don't know the start and stop samples in advance as the
+    # time window can vary.
+    if isinstance(tmin, (type(None), list)):
+        start_sample = None
+    else:
+        start_sample = int(round(tmin * sfreq))
+
+    if isinstance(tmax, (type(None), list)):
+        stop_sample = None
+    else:
+        stop_sample = int(round(tmax * sfreq)) + 1
 
     # Make indexing easier
     # We create the DataFrame before subsetting the events so we end up with
@@ -3055,14 +3098,47 @@ def make_metadata(
         metadata.loc[row_idx, "event_name"] = id_to_name_map[row_event.id]
 
         # Determine which events fall into the current time window
-        if start_sample is None:
+        if start_sample is None and isinstance(tmin, list):
+            # Lower bound is the the current or the closest previpus event with a name
+            # in "tmin"; if there is no such event (e.g., beginning of the recording is
+            # being approached), the upper lower becomes the last event in the
+            # recording.
+            prev_matching_events = events_df.loc[
+                (events_df["sample"] <= row_event.sample)
+                & (events_df["id"].isin([event_id[name] for name in tmin])),
+                :,
+            ]
+            if prev_matching_events.size == 0:
+                # No earlier matching event. Use the current one as the beginning of the
+                # time window. This may occur at the beginning of a recording.
+                window_start_sample = row_event.sample
+            else:
+                # At least one earlier matching event. Use the closest one.
+                window_start_sample = prev_matching_events.iloc[-1]["sample"]
+        elif start_sample is None:
             # Lower bound is the current event.
             window_start_sample = row_event.sample
         else:
             # Lower bound is determined by tmin.
             window_start_sample = row_event.sample + start_sample
 
-        if stop_sample is None:
+        if stop_sample is None and isinstance(tmax, list):
+            # Upper bound is the the current or the closest following event with a name
+            # in "tmax"; if there is no such event (e.g., end of the recording is being
+            # approached), the upper bound becomes the last event in the recording.
+            next_matching_events = events_df.loc[
+                (events_df["sample"] >= row_event.sample)
+                & (events_df["id"].isin([event_id[name] for name in tmax])),
+                :,
+            ]
+            if next_matching_events.size == 0:
+                # No matching event after the current one; use the end of the recording
+                # as upper bound. This may occur at the end of a recording.
+                window_stop_sample = events_df["sample"].iloc[-1]
+            else:
+                # At least one matching later event. Use the closest one..
+                window_stop_sample = next_matching_events.iloc[0]["sample"]
+        elif stop_sample is None:
             # Upper bound: next event of the same type, or the last event (of
             # any type) if no later event of the same type can be found.
             next_events = events_df.loc[

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -4297,7 +4297,7 @@ def test_make_metadata(all_event_id, row_events, tmin, tmax, keep_first, keep_la
         (["rec_start", "cue"], ["resp", "rec_end"]),
     ],
 )
-def test_make_metadata_bounded_by_row_events(tmin, tmax):
+def test_make_metadata_bounded_by_row_or_tmin_tmax_event_names(tmin, tmax):
     """Test make_metadata() with tmin, tmax set to None or strings."""
     pytest.importorskip("pandas")
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -4286,8 +4286,19 @@ def test_make_metadata(all_event_id, row_events, tmin, tmax, keep_first, keep_la
     Epochs(raw, events=events, event_id=event_id, metadata=metadata, verbose="warning")
 
 
-def test_make_metadata_bounded_by_row_events():
-    """Test make_metadata() with tmin, tmax set to None."""
+@pytest.mark.parametrize(
+    ("tmin", "tmax"),
+    [
+        (None, None),
+        ("cue", "resp"),
+        (["cue"], ["resp"]),
+        (None, "resp"),
+        ("cue", None),
+        (["rec_start", "cue"], ["resp", "rec_end"]),
+    ],
+)
+def test_make_metadata_bounded_by_row_events(tmin, tmax):
+    """Test make_metadata() with tmin, tmax set to None or strings."""
     pytest.importorskip("pandas")
 
     sfreq = 100
@@ -4332,8 +4343,8 @@ def test_make_metadata_bounded_by_row_events():
     metadata, events_new, event_id_new = mne.epochs.make_metadata(
         events=events,
         event_id=event_id,
-        tmin=None,
-        tmax=None,
+        tmin=tmin,
+        tmax=tmax,
         sfreq=raw.info["sfreq"],
         row_events="cue",
     )
@@ -4356,8 +4367,15 @@ def test_make_metadata_bounded_by_row_events():
     # 2nd trial
     assert np.isnan(metadata.iloc[1]["rec_end"])
 
-    # 3rd trial until end of the recording
-    assert metadata.iloc[2]["resp"] < metadata.iloc[2]["rec_end"]
+    # 3rd trial
+    if tmax is None:
+        # until end of the recording
+        assert metadata.iloc[2]["resp"] < metadata.iloc[2]["rec_end"]
+    else:
+        # until tmax
+        assert np.isnan(metadata.iloc[2]["rec_end"])
+        last_event_name = tmax[0] if isinstance(tmax, list) else tmax
+        assert metadata.iloc[2][last_event_name] > 0
 
 
 def test_events_list():

--- a/tutorials/epochs/40_autogenerate_metadata.py
+++ b/tutorials/epochs/40_autogenerate_metadata.py
@@ -46,13 +46,11 @@ by calling `mne.events_from_annotations`.
 # Copyright the MNE-Python contributors.
 # %%
 
-from pathlib import Path
-
 import matplotlib.pyplot as plt
 
 import mne
 
-data_dir = Path(mne.datasets.erp_core.data_path())
+data_dir = mne.datasets.erp_core.data_path()
 infile = data_dir / "ERP-CORE_Subject-001_Task-Flankers_eeg.fif"
 
 raw = mne.io.read_raw(infile, preload=True)

--- a/tutorials/epochs/40_autogenerate_metadata.py
+++ b/tutorials/epochs/40_autogenerate_metadata.py
@@ -88,7 +88,7 @@ all_events, all_event_id = mne.events_from_annotations(raw)
 # i.e. starting with stimulus onset and expanding beyond the end of the epoch
 metadata_tmin, metadata_tmax = 0.0, 1.5
 
-# auto-create metadata
+# auto-create metadata:
 # this also returns a new events array and an event_id dictionary. we'll see
 # later why this is important
 metadata, events, event_id = mne.epochs.make_metadata(


### PR DESCRIPTION
This makes it possible to auto-generate metadata in time windows of varying duration, e.g., from a stimulus cue to a participant's response. Here, the response might occur at different times in every epoch. Now, one can specify `tmax="response"` in this case, and capture all events from `tmin` until the response for metadata generation. I imagine this to be particularly useful for MNE-BIDS-Pipeline (in fact, I'm already using this feature in my personal pipeline branch)