### PR TITLE
store online filter freqs and meas_date to from .ncs headers in `RawNeuralynx.info`

### DIFF
--- a/doc/changes/devel/12463.newfeature.rst
+++ b/doc/changes/devel/12463.newfeature.rst
@@ -1,0 +1,1 @@
+Include date of acquisition and filter parameters in `raw.info` for :func:`mne.io.read_raw_neuralynx` by `Kristijan Armeni`_.

--- a/doc/changes/devel/12463.newfeature.rst
+++ b/doc/changes/devel/12463.newfeature.rst
@@ -1,1 +1,1 @@
-Include date of acquisition and filter parameters in `raw.info` for :func:`mne.io.read_raw_neuralynx` by `Kristijan Armeni`_.
+Include date of acquisition and filter parameters in ``raw.info`` for :func:`mne.io.read_raw_neuralynx` by `Kristijan Armeni`_.

--- a/mne/decoding/base.py
+++ b/mne/decoding/base.py
@@ -11,6 +11,7 @@ import datetime as dt
 import numbers
 
 import numpy as np
+from scipy.sparse import issparse
 
 from ..fixes import BaseEstimator, _check_fit_params, _get_check_scoring
 from ..parallel import parallel_func
@@ -106,6 +107,12 @@ class LinearModel(BaseEstimator):
         self : instance of LinearModel
             Returns the modified instance.
         """
+        # Once we require sklearn 1.1+ we should do:
+        # from sklearn.utils import check_array
+        # X = check_array(X, input_name="X")
+        # y = check_array(y, dtype=None, ensure_2d=False, input_name="y")
+        if issparse(X):
+            raise TypeError("X should be a dense array, got sparse instead.")
         X, y = np.asarray(X), np.asarray(y)
         if X.ndim != 2:
             raise ValueError(

--- a/mne/decoding/search_light.py
+++ b/mne/decoding/search_light.py
@@ -5,6 +5,7 @@
 import logging
 
 import numpy as np
+from scipy.sparse import issparse
 
 from ..fixes import _get_check_scoring
 from ..parallel import parallel_func
@@ -254,6 +255,12 @@ class SlidingEstimator(BaseEstimator, TransformerMixin):
 
     def _check_Xy(self, X, y=None):
         """Aux. function to check input data."""
+        # Once we require sklearn 1.1+ we should do something like:
+        # from sklearn.utils import check_array
+        # X = check_array(X, ensure_2d=False, input_name="X")
+        # y = check_array(y, dtype=None, ensure_2d=False, input_name="y")
+        if issparse(X):
+            raise TypeError("X should be a dense array, got sparse instead.")
         X = np.asarray(X)
         if y is not None:
             y = np.asarray(y)

--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -1,8 +1,9 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
+import datetime
 import glob
 import os
-import datetime
+
 import numpy as np
 
 from ..._fiff.meas_info import create_info

--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -42,7 +42,8 @@ def read_raw_neuralynx(
 
     Notes
     -----
-    Neuralynx files are read from disk using the Neo package (http://neuralensemble.org/neo/).
+    Neuralynx files are read from disk using the `Neo package
+    <http://neuralensemble.org/neo/>`__.
     Currently, only reading of the ``.ncs files`` is supported.
 
     ``raw.info["meas_date"]`` is read from the ``recording_opened`` property

--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -43,18 +43,21 @@ def read_raw_neuralynx(
     Notes
     -----
     Neuralynx files are read from disk using the Neo package (http://neuralensemble.org/neo/).
-    Currently, only reading of the .ncs files is supported. ``raw.info["meas_date"]``
-    is determined based on the ``recording_opened`` property of the first .ncs file
-    in the dataset.
+    Currently, only reading of the ``.ncs files`` is supported.
 
-    Channel-specific high and lowpass frequencies are determined based on the
-    ``DspLowCutFrequency`` and ``DspHighCutFrequency`` header fields, respectively.
-    If no filters were used for a channel, the default lowpass is set to the Nyquist
-    frequency and the default highpass is set to 0. ``raw.info["highpass"]`` and
-    ``raw.info["lowpass"]`` are then set to the maximum and minimum values across
-    all .ncs sfiles, respectively.
+    ``raw.info["meas_date"]`` is read from the ``recording_opened`` property
+    of the first ``.ncs`` file (i.e. channel) in the dataset (a warning is issued
+    if files have different dates of acquisition).
 
-    Other header variables can be inspected using neo directly. For example:
+    Channel-specific high and lowpass frequencies of online filters are determined
+    based on the ``DspLowCutFrequency`` and ``DspHighCutFrequency`` header fields,
+    respectively. If no filters were used for a channel, the default lowpass is set
+    to the Nyquist frequency and the default highpass is set to 0.
+    If channels have different high/low cutoffs, ``raw.info["highpass"]`` and
+    ``raw.info["lowpass"]`` are then set to the maximum highpass and minimumlowpass
+    values across channels, respectively.
+
+    Other header variables can be inspected using Neo directly. For example:
 
     .. code-block:: python
     from neo.io import NeuralynxIO
@@ -62,6 +65,7 @@ def read_raw_neuralynx(
     nlx_reader = NeuralynxIO(dirname=fname)
     print(nlx_reader.header)
     print(nlx_reader.file_headers.items())
+
     """
     return RawNeuralynx(
         fname,

--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -62,7 +62,6 @@ def read_raw_neuralynx(
     nlx_reader = NeuralynxIO(dirname=fname)
     print(nlx_reader.header)
     print(nlx_reader.file_headers.items())
-
     """
     return RawNeuralynx(
         fname,

--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -57,16 +57,13 @@ def read_raw_neuralynx(
     ``raw.info["lowpass"]`` are then set to the maximum highpass and minimumlowpass
     values across channels, respectively.
 
-    Other header variables can be inspected using Neo directly. For example:
-
-    .. code-block:: python
+    Other header variables can be inspected using Neo directly. For example::
 
         from neo.io import NeuralynxIO
         fname = 'path/to/your/data'
         nlx_reader = NeuralynxIO(dirname=fname)
         print(nlx_reader.header)
         print(nlx_reader.file_headers.items())
-
     """
     return RawNeuralynx(
         fname,

--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -43,16 +43,16 @@ def read_raw_neuralynx(
     Notes
     -----
     Neuralynx files are read from disk using the Neo package (http://neuralensemble.org/neo/).
-    Currently, only reading of the .ncs files is supported. `raw.info["meas_date"]` is
-    determined based on the `recording_opened` property of the first .ncs file
+    Currently, only reading of the .ncs files is supported. ``raw.info["meas_date"]``
+    is determined based on the ``recording_opened`` property of the first .ncs file
     in the dataset.
 
-    High/lowpass filter frequencies are determined based on the
-    `DspLowCutFrequency` and `DspHighCutFrequency` fields, respectively, in the
-    .ncs file header. If no filters were used for a channel, the default lowpass is set
-    to the Nyquist frequency and the default highpass is set to 0. `raw["highpass"]` and
-    `raw["lowpass"]` are set to the maximum and minimum of these values across all .ncs
-    files, respectively.
+    Channel-specific high and lowpass frequencies are determined based on the
+    ``DspLowCutFrequency`` and ``DspHighCutFrequency`` header fields, respectively.
+    If no filters were used for a channel, the default lowpass is set to the Nyquist
+    frequency and the default highpass is set to 0. ``raw.info["highpass"]`` and
+    ``raw.info["lowpass"]`` are then set to the maximum and minimum values across
+    all .ncs sfiles, respectively.
 
     Other header variables can be inspected using neo directly. For example:
 

--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -59,11 +59,11 @@ def read_raw_neuralynx(
 
     Other header variables can be inspected using Neo directly. For example::
 
-        from neo.io import NeuralynxIO
-        fname = 'path/to/your/data'
-        nlx_reader = NeuralynxIO(dirname=fname)
-        print(nlx_reader.header)
-        print(nlx_reader.file_headers.items())
+        from neo.io import NeuralynxIO  # doctest: +SKIP
+        fname = 'path/to/your/data'  # doctest: +SKIP
+        nlx_reader = NeuralynxIO(dirname=fname)  # doctest: +SKIP
+        print(nlx_reader.header)  # doctest: +SKIP
+        print(nlx_reader.file_headers.items())  # doctest: +SKIP
     """
     return RawNeuralynx(
         fname,

--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -60,11 +60,12 @@ def read_raw_neuralynx(
     Other header variables can be inspected using Neo directly. For example:
 
     .. code-block:: python
-    from neo.io import NeuralynxIO
-    fname = 'path/to/your/data'
-    nlx_reader = NeuralynxIO(dirname=fname)
-    print(nlx_reader.header)
-    print(nlx_reader.file_headers.items())
+
+        from neo.io import NeuralynxIO
+        fname = 'path/to/your/data'
+        nlx_reader = NeuralynxIO(dirname=fname)
+        print(nlx_reader.header)
+        print(nlx_reader.file_headers.items())
 
     """
     return RawNeuralynx(

--- a/mne/io/neuralynx/tests/test_neuralynx.py
+++ b/mne/io/neuralynx/tests/test_neuralynx.py
@@ -103,7 +103,11 @@ def _read_nlx_mat_chan_keep_gaps(matfile: str) -> np.ndarray:
     return x
 
 
+# set known values for the Neuralynx data for testing
 expected_chan_names = ["LAHC1", "LAHC2", "LAHC3", "xAIR1", "xEKG1"]
+expected_hp_freq = 0.1
+expected_lp_freq = 500.0
+expected_sfreq = 2000.0
 
 
 @requires_testing_data
@@ -124,6 +128,11 @@ def test_neuralynx():
         preload=True,
         exclude_fname_patterns=fname_patterns,
     )
+
+    # test that we picked the right info from headers
+    assert raw.info["highpass"] == expected_hp_freq, "highpass freq not set correctly"
+    assert raw.info["lowpass"] == expected_lp_freq, "lowpass freq not set correctly"
+    assert raw.info["sfreq"] == expected_sfreq, "sampling freq not set correctly"
 
     # test that channel selection worked
     assert (

--- a/mne/io/neuralynx/tests/test_neuralynx.py
+++ b/mne/io/neuralynx/tests/test_neuralynx.py
@@ -2,6 +2,7 @@
 # Copyright the MNE-Python contributors.
 import os
 from ast import literal_eval
+from datetime import datetime, timezone
 
 import numpy as np
 import pytest
@@ -108,7 +109,7 @@ expected_chan_names = ["LAHC1", "LAHC2", "LAHC3", "xAIR1", "xEKG1"]
 expected_hp_freq = 0.1
 expected_lp_freq = 500.0
 expected_sfreq = 2000.0
-
+expected_meas_date = datetime.strptime("2023/11/02 13:39:27", "%Y/%m/%d  %H:%M:%S")
 
 @requires_testing_data
 def test_neuralynx():
@@ -133,6 +134,9 @@ def test_neuralynx():
     assert raw.info["highpass"] == expected_hp_freq, "highpass freq not set correctly"
     assert raw.info["lowpass"] == expected_lp_freq, "lowpass freq not set correctly"
     assert raw.info["sfreq"] == expected_sfreq, "sampling freq not set correctly"
+
+    meas_date_utc = expected_meas_date.astimezone(timezone.utc)
+    assert raw.info["meas_date"] == meas_date_utc, "meas_date not set correctly"
 
     # test that channel selection worked
     assert (

--- a/mne/io/neuralynx/tests/test_neuralynx.py
+++ b/mne/io/neuralynx/tests/test_neuralynx.py
@@ -111,6 +111,7 @@ expected_lp_freq = 500.0
 expected_sfreq = 2000.0
 expected_meas_date = datetime.strptime("2023/11/02 13:39:27", "%Y/%m/%d  %H:%M:%S")
 
+
 @requires_testing_data
 def test_neuralynx():
     """Test basic reading."""


### PR DESCRIPTION
#### Reference issue
Fixes #12404.

#### What does this implement/fix?
So far, `read_raw_neuralynx()` did not propagate online filter information (highpass/lowpass) or acquisition date from the .ncs file headers to relevant `RawNeuralynx().info` fields. The challenge is that filter params can be different across .ncs files/channels in the dataset.

For each .ncs file, it reads in the lowpass/highpass freqs and then stores, conservatively, the highest highpass freq and the lowest lowpass frequency as the dataset frequencies. If settings are non-uniform across channels and there's a channel with no online filters, then it assumes nyquist as the highpass value and 0 as the lowpass value.

A small test asserts are added in `test_neuralynx()` to test that `info` fields are correctly populated on the testing dataset (has online filter applied).