### PR TITLE
Fix default color of mne.viz.Brain.add_text

### DIFF
--- a/doc/changes/devel/12470.bugfix.rst
+++ b/doc/changes/devel/12470.bugfix.rst
@@ -1,0 +1,1 @@
+- Fix the default color of :meth:`mne.viz.Brain.add_text` to properly contrast with the figure background color, by `Marijn van Vliet`_.

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2917,6 +2917,8 @@ class Brain:
         name = text if name is None else name
         if "text" in self._actors and name in self._actors["text"]:
             raise ValueError(f"Text with the name {name} already exists")
+        if color is None:
+            color = self._fg_color
         for ri, ci, _ in self._iter_views("vol"):
             if (row is None or row == ri) and (col is None or col == ci):
                 actor = self._renderer.text2d(


### PR DESCRIPTION
I guess this got lost at some point. `mne.viz.Brain.add_text` should by default use `_fg_color` for the color of the text, but didn't and defaulted to always be black, even when the background color of the figure is black.