### PR TITLE
fix merge_asof usage in read_raw_eyelink()

### DIFF
--- a/doc/changes/devel/12481.bugfix.rst
+++ b/doc/changes/devel/12481.bugfix.rst
@@ -1,0 +1,1 @@
+- Fix reading segmented recordings with :func:`mne.io.read_raw_eyelink` by `Dominik Welke`_.

--- a/mne/io/eyelink/_utils.py
+++ b/mne/io/eyelink/_utils.py
@@ -507,7 +507,7 @@ def _adjust_times(
         np.arange(first, last + step / 2, step), columns=[time_col]
     )
     return pd.merge_asof(
-        new_times, df, on=time_col, direction="nearest", tolerance=step / 10
+        new_times, df, on=time_col, direction="nearest", tolerance=step / 2
     )
 
 


### PR DESCRIPTION
closes #12480


the new parameter set is also not perfect:
`direction=nearest` can lead to duplicating samples (as a sample on an uneven ms is equally distanced to the previous and subsequent millisecond). you can see this behavior running the simplified example code in the issue.

but i think this is better than `forward/backward` which does not duplicate samples, but works worse with sfreqs < 500 Hz, as it can shift samples in the wrong direction