### PR TITLE
MAINT: Play nicer with themes

### DIFF
--- a/doc/changes/devel/12483.bugfix.rst
+++ b/doc/changes/devel/12483.bugfix.rst
@@ -1,0 +1,1 @@
+Improve compatibility with other Qt-based GUIs by handling theme icons better, by `Eric Larson`_.

--- a/mne/viz/backends/_qt.py
+++ b/mne/viz/backends/_qt.py
@@ -112,6 +112,7 @@ from ._pyvista import (
     _take_3d_screenshot,  # noqa: F401
 )
 from ._utils import (
+    _ICONS_PATH,
     _init_mne_qtapp,
     _qt_app_exec,
     _qt_detect_theme,
@@ -276,13 +277,13 @@ class _Button(QPushButton, _AbstractButton, _Widget, metaclass=_BaseWidget):
         self.setText(value)
         self.released.connect(callback)
         if icon:
-            self.setIcon(QIcon.fromTheme(icon))
+            self.setIcon(_qicon(icon))
 
     def _click(self):
         self.click()
 
     def _set_icon(self, icon):
-        self.setIcon(QIcon.fromTheme(icon))
+        self.setIcon(_qicon(icon))
 
 
 class _Slider(QSlider, _AbstractSlider, _Widget, metaclass=_BaseWidget):
@@ -474,16 +475,16 @@ class _PlayMenu(QVBoxLayout, _AbstractPlayMenu, _Widget, metaclass=_BaseWidget):
         self._slider.valueChanged.connect(callback)
         self._nav_hbox = QHBoxLayout()
         self._play_button = QPushButton()
-        self._play_button.setIcon(QIcon.fromTheme("play"))
+        self._play_button.setIcon(_qicon("play"))
         self._nav_hbox.addWidget(self._play_button)
         self._pause_button = QPushButton()
-        self._pause_button.setIcon(QIcon.fromTheme("pause"))
+        self._pause_button.setIcon(_qicon("pause"))
         self._nav_hbox.addWidget(self._pause_button)
         self._reset_button = QPushButton()
-        self._reset_button.setIcon(QIcon.fromTheme("reset"))
+        self._reset_button.setIcon(_qicon("reset"))
         self._nav_hbox.addWidget(self._reset_button)
         self._loop_button = QPushButton()
-        self._loop_button.setIcon(QIcon.fromTheme("restore"))
+        self._loop_button.setIcon(_qicon("restore"))
         self._loop_button.setStyleSheet("background-color : lightgray;")
         self._loop_button._checked = True
 
@@ -1494,18 +1495,18 @@ class _QtWindow(_AbstractWindow):
         self._window.closeEvent = closeEvent
 
     def _window_load_icons(self):
-        self._icons["help"] = QIcon.fromTheme("help")
-        self._icons["play"] = QIcon.fromTheme("play")
-        self._icons["pause"] = QIcon.fromTheme("pause")
-        self._icons["reset"] = QIcon.fromTheme("reset")
-        self._icons["scale"] = QIcon.fromTheme("scale")
-        self._icons["clear"] = QIcon.fromTheme("clear")
-        self._icons["movie"] = QIcon.fromTheme("movie")
-        self._icons["restore"] = QIcon.fromTheme("restore")
-        self._icons["screenshot"] = QIcon.fromTheme("screenshot")
-        self._icons["visibility_on"] = QIcon.fromTheme("visibility_on")
-        self._icons["visibility_off"] = QIcon.fromTheme("visibility_off")
-        self._icons["folder"] = QIcon.fromTheme("folder")
+        self._icons["help"] = _qicon("help")
+        self._icons["play"] = _qicon("play")
+        self._icons["pause"] = _qicon("pause")
+        self._icons["reset"] = _qicon("reset")
+        self._icons["scale"] = _qicon("scale")
+        self._icons["clear"] = _qicon("clear")
+        self._icons["movie"] = _qicon("movie")
+        self._icons["restore"] = _qicon("restore")
+        self._icons["screenshot"] = _qicon("screenshot")
+        self._icons["visibility_on"] = _qicon("visibility_on")
+        self._icons["visibility_off"] = _qicon("visibility_off")
+        self._icons["folder"] = _qicon("folder")
 
     def _window_clean(self):
         self.figure._plotter = None
@@ -1844,3 +1845,10 @@ def _testing_context(interactive):
     finally:
         pyvista.OFF_SCREEN = orig_offscreen
         renderer.MNE_3D_BACKEND_TESTING = orig_testing
+
+
+def _qicon(name):
+    # Get icon from theme with a file fallback
+    return QIcon.fromTheme(
+        name, QIcon(str(_ICONS_PATH / "light" / "actions" / f"{name}.svg"))
+    )

--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -33,6 +33,7 @@ VALID_3D_BACKENDS = (
     "notebook",
 )
 ALLOWED_QUIVER_MODES = ("2darrow", "arrow", "cone", "cylinder", "sphere", "oct")
+_ICONS_PATH = Path(__file__).parents[2] / "icons"
 
 
 def _get_colormap_from_array(
@@ -89,9 +90,9 @@ def _alpha_blend_background(ctable, background_color):
 def _qt_init_icons():
     from qtpy.QtGui import QIcon
 
-    icons_path = str(Path(__file__).parents[2] / "icons")
-    QIcon.setThemeSearchPaths([icons_path])
-    return icons_path
+    QIcon.setThemeSearchPaths([str(_ICONS_PATH)] + QIcon.themeSearchPaths())
+    QIcon.setFallbackThemeName("light")
+    return str(_ICONS_PATH)
 
 
 @contextmanager


### PR DESCRIPTION
See https://github.com/mne-tools/mne-qt-browser/pull/233#issuecomment-1978881862, but in short:

1. Setting the global `QIcon.setThemeSearchPaths` to *only* our path is not compatible with other bits of software like mne-qt-browser and MNELAB
2. Instead, prepend our path
3. When calling `QIcon.fromTheme`, ask for the correct icon name but also provide a fallback in case the user has switched to a theme name that does not provide the correct icons. In MNE-Qt-browser and MNE we provide support for "light" and "dark" and I checked to make sure these work concurrently (they seem to at least!)

   ![image](https://github.com/mne-tools/mne-python/assets/2365790/569f795d-3514-47b2-bea8-0f40ead944ba)

@cbrnr feel free to see if this helps with MNELAB