### PR TITLE
Fix cleaning of channel names which can create duplicate for non vectorview or CTF systems

### DIFF
--- a/doc/changes/devel/12489.bugfix.rst
+++ b/doc/changes/devel/12489.bugfix.rst
@@ -1,0 +1,1 @@
+Fix cleaning of channel names for non vectorview or CTF dataset including whitespaces or dash in their channel names, by `Mathieu Scheltienne`_.

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -294,7 +294,7 @@ def _clean_names(names, remove_whitespace=False, before_dash=True):
         cleaned.append(name)
     if len(set(cleaned)) != len(names):
         # this was probably not a VectorView or CTF dataset, and we now broke the
-        # dataset by creating duplicates.
+        # dataset by creating duplicates, so let's use the original channel names.
         return names
     return cleaned
 

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -269,9 +269,8 @@ def running_subprocess(command, after="wait", verbose=None, *args, **kwargs):
 def _clean_names(names, remove_whitespace=False, before_dash=True):
     """Remove white-space on topo matching.
 
-    This function handles different naming
-    conventions for old VS new VectorView systems (`remove_whitespace`).
-    Also it allows to remove system specific parts in CTF channel names
+    This function handles different naming conventions for old VS new VectorView systems
+    (`remove_whitespace`) and removes system specific parts in CTF channel names
     (`before_dash`).
 
     Usage
@@ -281,7 +280,6 @@ def _clean_names(names, remove_whitespace=False, before_dash=True):
 
     # for CTF
     ch_names = _clean_names(epochs.ch_names, before_dash=True)
-
     """
     cleaned = []
     for name in names:

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -292,7 +292,10 @@ def _clean_names(names, remove_whitespace=False, before_dash=True):
         if name.endswith("_v"):
             name = name[:-2]
         cleaned.append(name)
-
+    if len(set(cleaned)) != len(names):
+        # this was probably not a VectorView or CTF dataset, and we now broke the
+        # dataset by creating duplicates.
+        return names
     return cleaned
 
 

--- a/mne/utils/tests/test_misc.py
+++ b/mne/utils/tests/test_misc.py
@@ -8,7 +8,7 @@ from contextlib import nullcontext
 import pytest
 
 import mne
-from mne.utils import catch_logging, run_subprocess, sizeof_fmt
+from mne.utils import _clean_names, catch_logging, run_subprocess, sizeof_fmt
 
 
 def test_sizeof_fmt():
@@ -144,3 +144,16 @@ print('bar', file=sys.{kind})
         other = stdout
     assert std == want
     assert other == ""
+
+
+def test_clean_names():
+    """Test cleaning names on OPM dataset.
+
+    This channel name list is a subset from a user OPM dataset reported on the forum
+    https://mne.discourse.group/t/error-when-trying-to-plot-projectors-ssp/8456
+    where the function _clean_names ended up creating a duplicate channel name L108_bz.
+    """
+    ch_names = ["R305_bz-s2", "L108_bz-s77", "R112_bz-s109", "L108_bz-s110"]
+    ch_names_clean = _clean_names(ch_names, before_dash=True)
+    assert ch_names == ch_names_clean
+    assert len(set(ch_names_clean)) == len(ch_names_clean)


### PR DESCRIPTION
Reported on the forum here: https://mne.discourse.group/t/error-when-trying-to-plot-projectors-ssp/8456

MWE: 

```
from pathlib import Path

from mne import read_proj
from mne.io import read_info
from mne.viz import plot_projs_topomap


directory = Path.home() / "Downloads"
info = read_info(directory / "test-info.fif")
projs = read_proj(directory / "test-proj.fif")
plot_projs_topomap(projs, colorbar=True, vlim="joint", info=info)
```

Dataset: [test-projs.zip](https://github.com/mne-tools/mne-python/files/14557013/test-projs.zip)

------------

I'm not sure if this is the best fix as I'm not familiar with the channel name format of old vectorview system and of CTF system; thus I'm not certain about the intended purpose of `_clean_names`.

