### PR TITLE
Do not set browse raw icon when app icon already exists

### DIFF
--- a/mne/viz/backends/_utils.py
+++ b/mne/viz/backends/_utils.py
@@ -181,7 +181,11 @@ def _init_mne_qtapp(enable_icon=True, pg_app=False, splash=False):
     if enable_icon or splash:
         icons_path = _qt_init_icons()
 
-    if enable_icon and app.windowIcon().cacheKey() != _QT_ICON_KEYS["app"]:
+    if (
+        enable_icon
+        and app.windowIcon().cacheKey() != _QT_ICON_KEYS["app"]
+        and app.windowIcon().isNull()  # don't overwrite existing icon (e.g. MNELAB)
+    ):
         # Set icon
         kind = "bigsur_" if platform.mac_ver()[0] >= "10.16" else "default_"
         icon = QIcon(f"{icons_path}/mne_{kind}icon.png")


### PR DESCRIPTION
Fixes https://github.com/mne-tools/mne-qt-browser/issues/234. This sets the app icon of the MNE Qt Browser only if it has not already been set (by e.g. MNELAB).