### PR TITLE
Feature: Pupil Deconvolution (port from prepares)

### DIFF
--- a/doc/api/preprocessing.rst
+++ b/doc/api/preprocessing.rst
@@ -166,6 +166,9 @@ Projections:
    convert_units
    get_screen_visual_angle
    interpolate_blinks
+   deconvolve
+   pupil_zscores
+   pupil_kernel
 
 EEG referencing:
 

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -823,6 +823,17 @@
   year = {2012}
 }
 
+@article{Hoeks1993,
+  author = {Hoeks, Bert and Levelt, Willem J M},
+  doi = {10.3758/BF03204445},
+  journal = {Behavior Research Methods, Instruments, & Computers},
+  number = {1},
+  pages = {16--26},
+  title = {Pupillary dilation as a measure of attention: a quantitative system analysis},
+  volume = {25},
+  year = {1993}
+}
+
 @article{HoldgrafEtAl2016,
   author = {Holdgraf, Christopher R. and {de Heer}, Wendy and Pasley, Brian and Rieger, Jochem and Crone, Nathan and Lin, Jack J. and Knight, Robert T. and Theunissen, Frédéric E.},
   doi = {10.1038/ncomms13654},
@@ -2151,6 +2162,18 @@ year = {2019}
   author = {Strohmeier, Daniel and Gramfort, Alexandre and Haueisen, Jens},
   year = {2015},
   pages = {21--24}
+}
+
+@article{Wierda2012,
+  title     = "Pupil dilation deconvolution reveals the dynamics of attention
+               at high temporal resolution",
+  author    = "Wierda, Stefan M and van Rijn, Hedderik and Taatgen, Niels A and
+               Martens, Sander",
+  journal   = "Proceedings of the National Academy of Sciences",
+  volume    =  109,
+  number    =  22,
+  pages     = "8456--8460",
+  year      =  2012,
 }
 
 @misc{WikipediaSI,

--- a/ignore_words.txt
+++ b/ignore_words.txt
@@ -38,4 +38,4 @@ pres
 aas
 vor
 connec
-Hoeks
+hoeks

--- a/ignore_words.txt
+++ b/ignore_words.txt
@@ -38,3 +38,4 @@ pres
 aas
 vor
 connec
+Hoeks

--- a/mne/preprocessing/eyetracking/__init__.py
+++ b/mne/preprocessing/eyetracking/__init__.py
@@ -7,5 +7,5 @@
 
 from .eyetracking import set_channel_types_eyetrack, convert_units
 from .calibration import Calibration, read_eyelink_calibration
-from ._pupillometry import interpolate_blinks
+from ._pupillometry import interpolate_blinks, deconvolve, pupil_kernel, pupil_zscores
 from .utils import get_screen_visual_angle

--- a/mne/preprocessing/eyetracking/tests/test_pupillometry.py
+++ b/mne/preprocessing/eyetracking/tests/test_pupillometry.py
@@ -5,13 +5,13 @@
 import numpy as np
 import pytest
 
-from mne import create_info
+import mne
 from mne.datasets.testing import data_path, requires_testing_data
 from mne.io import RawArray, read_raw_eyelink
-from mne.preprocessing.eyetracking import interpolate_blinks
+from mne.preprocessing.eyetracking import deconvolve, interpolate_blinks
 
 fname = data_path(download=False) / "eyetrack" / "test_eyelink.asc"
-pytest.importorskip("pandas")
+# pytest.importorskip("pandas")
 
 
 @requires_testing_data
@@ -29,7 +29,7 @@ def test_interpolate_blinks(buffer, match, cause_error, interpolate_gaze):
     raw = read_raw_eyelink(fname, create_annotations=["blinks"], find_overlaps=True)
     # Create a dummy stim channel
     # this will hit a certain line in the interpolate_blinks function
-    info = create_info(["STI"], raw.info["sfreq"], ["stim"])
+    info = mne.create_info(["STI"], raw.info["sfreq"], ["stim"])
     stim_data = np.zeros((1, len(raw.times)))
     stim_raw = RawArray(stim_data, info)
     raw.add_channels([stim_raw], force_update_info=True)
@@ -64,3 +64,54 @@ def test_interpolate_blinks(buffer, match, cause_error, interpolate_gaze):
     if interpolate_gaze:
         assert not np.isnan(data[0, blink_ind]).any()  # left eye
         assert not np.isnan(data[1, blink_ind]).any()  # right eye
+
+
+@pytest.mark.parametrize("method", ["minimize", "inverse"])
+def test_deconvolve(eyetrack_raw, method):
+    """Test deconvolving pupil data."""
+    # simulate the convolved pupil data
+    signal = (np.zeros(30), np.ones(10), np.zeros(20), 2 * np.ones(10), np.zeros(30))
+    signal = np.concatenate(signal, axis=0)
+    kernel = np.exp(-(np.linspace(-2, 2, 20) ** 2))
+    kernel = kernel / sum(kernel)
+    ps = np.convolve(signal, kernel, mode="same")
+
+    # replace the pupil data with the simulated data
+    raw = eyetrack_raw.copy()
+    raw.rename_channels({"pupil": "pupil_left"})
+    raw._data[-1] = ps
+    epochs = mne.make_fixed_length_epochs(raw, preload=True)
+
+    data = epochs.get_data(picks=["pupil_left"])
+    fit, times = deconvolve(epochs, method=method)
+    # Check that we didn't change the epochs data in place
+    np.testing.assert_array_equal(data, epochs.get_data(picks=["pupil_left"]))
+    # Check that the fit has the expected shape
+    n_chs = data.shape[1]
+    np.testing.assert_equal(fit.shape, (len(epochs), n_chs, len(times)))
+    # Check the above with custom spacing and bounds
+    fit, times = deconvolve(epochs, spacing=[0, 0.3, 0.9], bounds=(0, np.inf))
+    np.testing.assert_equal(fit.shape, (len(epochs), n_chs, len(times)))
+    np.testing.assert_equal(len(times), 3)
+
+
+def test_pupil_zscore(eyetrack_raw):
+    """Test z-scoring pupil data."""
+    signal = (np.zeros(30), np.ones(10), np.zeros(20), 2 * np.ones(10), np.zeros(30))
+    signal = np.concatenate(signal, axis=0)
+    raw = eyetrack_raw.copy()
+    raw.rename_channels({"pupil": "pupil_left"})
+    raw._data[-1] = signal
+    epochs = mne.make_fixed_length_epochs(raw, preload=True)
+    ps = mne.preprocessing.eyetracking.pupil_zscores(epochs, (None, None))
+    np.testing.assert_almost_equal(ps.mean(), 0)
+    np.testing.assert_almost_equal(ps.std(), 1)
+
+
+def test_pupil_kernel():
+    """Test the pupil kernel function."""
+    kernel = mne.preprocessing.eyetracking.pupil_kernel(2, 2, 2, 2)
+    np.testing.assert_equal(kernel.shape, (4,))
+    kernel = mne.preprocessing.eyetracking.pupil_kernel(100, 1)
+    t_kernel = np.linspace(0, 1, 100)
+    np.testing.assert_almost_equal(t_kernel[np.argmax(kernel)], 0.93, decimal=2)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -3172,6 +3172,16 @@ projs : bool | None
     the data. If ``None``, use ``projs`` from `~mne.Report` creation.
 """
 
+docdict["pupil_baseline"] = """
+baseline : tuple of length 2
+    2-element tuple of time points to use for baseline calculation.
+    If a tuple ``(a, b)``, the interval is between ``a`` and ``b`` (in seconds),
+    is used, end-inclusive. ``None`` can be used for either ``a`` or ``b``
+    to specify the beginning or end of the data. If ``(None, None)``, use all time
+    points for baseline calculation. The default is ``(None, 0)``, which uses all
+    negative time points (before stimulus onset) for baseline calculation.
+"""
+
 # %%
 # R
 


### PR DESCRIPTION
#### Reference issue
This PR implements the last feature proposed for my GSoC in #11879 that I didn't get to over the summer. 


#### What does this implement/fix?
This basically ports the pupil deconvolution code from (the unmaintained?)  https://github.com/pyeparse/pyeparse , and which was used for @larsoner and @drammock 's pupil deconvolution [paper](https://pubmed.ncbi.nlm.nih.gov/27036288/) in 2016.

#### Additional information
 I made some minor changes to the code and docstring to work with MNE's API and follow MNE conventions (and make the code more modern i.e. use format specifiers instead of percent specifiers).

 To check that the ported code in this branch behaves similarly to the code in pyeparse, I re-ran the [scripts](https://github.com/LABSN-pubs/2016-JASA-pupil-deconv-methods/tree/master) to deconvolve the data and generate `figure 3` in Dan and Eric's paper (The original scripts used the deconvolution method from `pyeparse`, and I updated the scripts to use the MNE API in this branch:


| Library |  Figure 3         |
| ------------- | ------------- |
| Pyeparse        | ![Pyeparse](https://github.com/mne-tools/mne-python/files/14643207/fig-3.pdf) |
| MNE               | ![MNE](https://github.com/mne-tools/mne-python/files/14643210/fig-3_mne.pdf) |

# Possible Alternatives

I have not opened an issue for deconvolution specifically, so if there are concerns about merging this into MNE or other ideas, don't hesitate to share. 





