### PR TITLE
Improve consistency of sensor types in code and documentation

### DIFF
--- a/doc/documentation/glossary.rst
+++ b/doc/documentation/glossary.rst
@@ -47,9 +47,9 @@ general neuroimaging concepts. If you think a term is missing, please consider
         Many functions in MNE-Python operate on "data channels" by default. These
         are channels that contain electrophysiological data from the brain,
         as opposed to other channel types such as EOG, ECG, stimulus/trigger,
-        or acquisition system status data. The set of channels considered
-        "data channels" in MNE contains the following types (together with scale
-        factors for plotting):
+        or acquisition system status data (see :term:`non-data channels`).
+        The set of channels considered "data channels" in MNE contains the
+        following types (together with scale factors for plotting):
 
         .. mne:: data channels list
 
@@ -287,6 +287,27 @@ general neuroimaging concepts. If you think a term is missing, please consider
         data into a common space for statistical analysis.
         See :ref:`ch_morph` for more details.
 
+    non-data types
+        All types of channels other than :term:`data channels`.
+        The set of channels considered "non-data channels" in MNE contains the
+        following types (together with scale factors for plotting):
+
+        .. mne:: non-data channels list
+        - 'ecg': ECG (scaled by 1e+15 to plot in fT)
+        - 'emg': EMG (scaled by 1e+13 to plot in fT/cm)
+        - 'bio': EEG (scaled by 1e+06 to plot in µV)
+        - 'stim': Current source density (scaled by 1000 to plot in mV/m²)
+        - 'resp': sEEG (scaled by 1000 to plot in mV)
+        - 'chpi': ECoG (scaled by 1e+06 to plot in µV)
+        - 'exci': DBS (scaled by 1e+06 to plot in µV)
+        - 'ias': Oxyhemoglobin (scaled by 1e+06 to plot in µM)
+        - 'syst': Deoxyhemoglobin (scaled by 1e+06 to plot in µM)
+        - 'temperature': fNIRS (CW amplitude) (scaled by 1 to plot in V)
+        - 'gsr': fNIRS (FD AC amplitude) (scaled by 1 to plot in V)
+        - 'misc': misc (FD AC amplitude) (scaled by 1 to plot in V)
+        - 'dipole': Dipole (FD AC amplitude) (scaled by 1 to plot in V)
+        - 'ref_meg': Reference Magnetometers (FD AC amplitude) (scaled by 1 to plot in V)
+
     OPM
     optically pumped magnetometer
         An optically pumped magnetometer (OPM) is a type of magnetometer
@@ -349,6 +370,10 @@ general neuroimaging concepts. If you think a term is missing, please consider
     selection
         A selection is a set of picked channels (for example, all sensors
         falling within a :term:`region of interest`).
+
+    sensor types
+        All the sensors handled by MNE-Python can be divided into two categories:
+        :term:`data channels` and :term:`non-data channels`.
 
     STC
     source estimate

--- a/doc/sphinxext/mne_substitutions.py
+++ b/doc/sphinxext/mne_substitutions.py
@@ -38,6 +38,25 @@ class MNESubstitution(Directive):  # noqa: D101
                 )
                 for key in keys
             )
+        elif self.arguments[0] == "non-data channels list":
+            keys = list()
+            for key in _DATA_CH_TYPES_ORDER_DEFAULT:
+                if key in _DATA_CH_TYPES_SPLIT:
+                    keys.append(key)
+                elif key not in ("meg", "fnirs") and _PICK_TYPES_DATA_DICT.get(
+                        key, False
+                ):
+                    keys.append(key)
+            rst = "- " + "\n- ".join(
+                "``%r``: **%s** (scaled by %g to plot in *%s*)"
+                % (
+                    key,
+                    DEFAULTS["titles"][key],
+                    DEFAULTS["scalings"][key],
+                    DEFAULTS["units"][key],
+                )
+                for key in keys
+            )
         else:
             raise self.error(
                 "MNE directive unknown in %s: %r"


### PR DESCRIPTION
Aim to resolve this issue #12490 about improving the glossary for sensor types and add some referencement in some part of the documentation (docstrings, tutorial) but during the processing of this issue we found inconsistencies with @larsoner in the dictionaries containing the sensor type constants.
The aim is to adress these inconsistencies bit by bit, while keeping an eye on what breaks.

- [ ] Add the non-data channels and sensor types entries in the glossary using MNESubstitution class to keep it updated.
- [ ] Add some reference to the sensor types entry in set_channel_types and channel_type docstring and the tutorial https://mne.tools/stable/auto_tutorials/raw/10_raw_overview.html#changing-channel-name-and-type
- [ ] Add the missing sensor types in https://github.com/mne-tools/mne-python/blob/main/mne/defaults.py#L192 dicts and doc/documentation/channel_types.rst one by one to see if anything breaks.
- [ ] Resolve inconsistencies in the types listed in docstrings of some functions.
