### PR TITLE
Add `physical_range="channelwise"` for EDF export

### DIFF
--- a/doc/changes/devel/12510.newfeature.rst
+++ b/doc/changes/devel/12510.newfeature.rst
@@ -1,0 +1,1 @@
+Add ``physical_range="per-channel"`` to :meth:`mne.io.Raw.export` for exporting to EDF, which can improve amplitude resolution if individual channels vary greatly in their offsets, by `Clemens Brunner`_.

--- a/doc/changes/devel/12510.newfeature.rst
+++ b/doc/changes/devel/12510.newfeature.rst
@@ -1,1 +1,1 @@
-Add ``physical_range="per-channel"`` to :meth:`mne.io.Raw.export` for exporting to EDF, which can improve amplitude resolution if individual channels vary greatly in their offsets, by `Clemens Brunner`_.
+Add ``physical_range="channelwise"`` to :meth:`mne.io.Raw.export` for exporting to EDF, which can improve amplitude resolution if individual channels vary greatly in their offsets, by `Clemens Brunner`_.

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -79,6 +79,8 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
             _data = raw.get_data(units=units, picks=_picks)
             ch_types_phys_max[_type] = _data.max()
             ch_types_phys_min[_type] = _data.min()
+    elif physical_range == "channelwise":
+        physical_range = None
     else:
         # get the physical min and max of the data in uV
         # Physical ranges of the data in uV are usually set by the manufacturer and
@@ -112,10 +114,10 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
                 "before exporting to EDF."
             )
 
-        if physical_range == "auto":
-            # take the channel type minimum and maximum
+        if physical_range == "auto":  # per channel type
             pmin = ch_types_phys_min[ch_type]
             pmax = ch_types_phys_max[ch_type]
+            physical_range = pmin, pmax
 
         signals.append(
             EdfSignal(
@@ -124,7 +126,7 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
                 label=signal_label,
                 transducer_type="",
                 physical_dimension="" if ch_type == "stim" else "uV",
-                physical_range=(pmin, pmax),
+                physical_range=physical_range,
                 digital_range=(digital_min, digital_max),
                 prefiltering=filter_str_info,
             )

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -79,7 +79,7 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
             _data = raw.get_data(units=units, picks=_picks)
             ch_types_phys_max[_type] = _data.max()
             ch_types_phys_min[_type] = _data.min()
-    elif physical_range == "per-channel":
+    elif physical_range == "channelwise":
         prange = None
     else:
         # get the physical min and max of the data in uV

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -79,7 +79,7 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
             _data = raw.get_data(units=units, picks=_picks)
             ch_types_phys_max[_type] = _data.max()
             ch_types_phys_min[_type] = _data.min()
-    elif physical_range == "channelwise":
+    elif physical_range == "per-channel":
         physical_range = None
     else:
         # get the physical min and max of the data in uV
@@ -118,7 +118,7 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
             pmin = ch_types_phys_min[ch_type]
             pmax = ch_types_phys_max[ch_type]
 
-        prange = (pmin, pmax) if physical_range != "channelwise" else None
+        prange = (pmin, pmax) if physical_range != "per-channel" else None
         signals.append(
             EdfSignal(
                 data[idx],

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -117,8 +117,8 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
         if physical_range == "auto":  # per channel type
             pmin = ch_types_phys_min[ch_type]
             pmax = ch_types_phys_max[ch_type]
-            physical_range = pmin, pmax
 
+        prange = (pmin, pmax) if physical_range != "channelwise" else None
         signals.append(
             EdfSignal(
                 data[idx],
@@ -126,7 +126,7 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
                 label=signal_label,
                 transducer_type="",
                 physical_dimension="" if ch_type == "stim" else "uV",
-                physical_range=physical_range,
+                physical_range=prange,
                 digital_range=(digital_min, digital_max),
                 prefiltering=filter_str_info,
             )

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -80,7 +80,7 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
             ch_types_phys_max[_type] = _data.max()
             ch_types_phys_min[_type] = _data.min()
     elif physical_range == "per-channel":
-        physical_range = None
+        prange = None
     else:
         # get the physical min and max of the data in uV
         # Physical ranges of the data in uV are usually set by the manufacturer and
@@ -103,6 +103,7 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
                 f" passed in {pmin}."
             )
         data = np.clip(data, pmin, pmax)
+        prange = pmin, pmax
     signals = []
     for idx, ch in enumerate(raw.ch_names):
         ch_type = ch_types[idx]
@@ -117,8 +118,8 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
         if physical_range == "auto":  # per channel type
             pmin = ch_types_phys_min[ch_type]
             pmax = ch_types_phys_max[ch_type]
+            prange = pmin, pmax
 
-        prange = (pmin, pmax) if physical_range != "per-channel" else None
         signals.append(
             EdfSignal(
                 data[idx],

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -190,6 +190,33 @@ def test_double_export_edf(tmp_path):
 
 
 @edfio_mark()
+def test_edf_physical_range(tmp_path):
+    """Test exporting an EDF file with different physical range settings."""
+    ch_types = ["eeg"] * 4
+    ch_names = np.arange(len(ch_types)).astype(str).tolist()
+    fs = 1000
+    info = create_info(len(ch_types), sfreq=fs, ch_types=ch_types)
+    data = np.tile(
+        np.sin(2 * np.pi * 10 * np.arange(0, 2, 1 / fs)) * 1e-5, (len(ch_names), 1)
+    )
+    data = (data.T + [0.1, 0, 0, -0.1]).T  # add offsets
+    raw = RawArray(data, info)
+
+    # export with physical range per channel type (default)
+    temp_fname = tmp_path / "test_auto.edf"
+    raw.export(temp_fname)
+    raw_read = read_raw_edf(temp_fname, preload=True)
+    with pytest.raises(AssertionError, match="Arrays are not almost equal"):
+        assert_array_almost_equal(raw.get_data(), raw_read.get_data(), decimal=10)
+
+    # export with physical range per channel
+    temp_fname = tmp_path / "test_per_channel.edf"
+    raw.export(temp_fname, physical_range="per-channel")
+    raw_read = read_raw_edf(temp_fname, preload=True)
+    assert_array_almost_equal(raw.get_data(), raw_read.get_data(), decimal=10)
+
+
+@edfio_mark()
 def test_export_edf_annotations(tmp_path):
     """Test that exporting EDF preserves annotations."""
     raw = _create_raw_for_edf_tests()

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -211,7 +211,7 @@ def test_edf_physical_range(tmp_path):
 
     # export with physical range per channel
     temp_fname = tmp_path / "test_per_channel.edf"
-    raw.export(temp_fname, physical_range="per-channel")
+    raw.export(temp_fname, physical_range="channelwise")
     raw_read = read_raw_edf(temp_fname, preload=True)
     assert_array_almost_equal(raw.get_data(), raw_read.get_data(), decimal=10)
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1401,15 +1401,12 @@ Although this function supports storing channel types in the signal label (e.g.
 ``EEG Fz`` or ``MISC E``), other software may not support this (optional) feature of the
 EDF standard.
 
-If ``add_ch_type`` is True, then channel types are written based on what
-they are currently set in MNE-Python. One should double check that all
-their channels are set correctly. You can call
-:attr:`raw.set_channel_types <mne.io.Raw.set_channel_types>` to set
-channel types.
+If ``add_ch_type`` is True, then channel types are written based on what they are
+currently set in MNE-Python. One should double check that all their channels are set
+correctly. You can call :meth:`mne.io.Raw.set_channel_types` to set channel types.
 
-In addition, EDF does not support storing a montage. You will need
-to store the montage separately and call :attr:`raw.set_montage()
-<mne.io.Raw.set_montage>`.
+In addition, EDF does not support storing a montage. You will need to store the montage
+separately and call :meth:`mne.io.Raw.set_montage`.
 
 The physical range of the signals is determined by signal type by default
 (``physical_range="auto"``). However, if individual channel ranges vary significantly

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1410,6 +1410,13 @@ channel types.
 In addition, EDF does not support storing a montage. You will need
 to store the montage separately and call :attr:`raw.set_montage()
 <mne.io.Raw.set_montage>`.
+
+The physical range of the signals is determined by signal type by default
+(``physical_range='auto'``). However, if individual channel ranges vary significantly
+due to the presence of e.g. drifts/offsets/biases, setting
+``physical_range='channelwise'`` might be more appropriate. This will ensure a maximum
+resulution for each individual channel, but some tools might not be able to handle this
+appropriately (even though channelwise ranges are covered by the EDF standard).
 """
 
 docdict["export_eeglab_note"] = """
@@ -3201,11 +3208,10 @@ phase : str
 
 docdict["physical_range_export_params"] = """
 physical_range : str | tuple
-    The physical range of the data. If 'auto' (default), then
-    it will infer the physical min and max from the data itself,
-    taking the minimum and maximum values per channel type.
-    If it is a 2-tuple of minimum and maximum limit, then those
-    physical ranges will be used. Only used for exporting EDF files.
+    The physical range of the data. If 'auto' (default), the physical range is inferred
+    from the data, taking the minimum and maximum values per channel type. If
+    'channelwise', the range will be defined per channel. If a tuple of minimum and
+    maximum, this manual physical range will be used. Only used for exporting EDF files.
 """
 
 _pick_ori_novec = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1411,7 +1411,7 @@ separately and call :meth:`mne.io.Raw.set_montage`.
 The physical range of the signals is determined by signal type by default
 (``physical_range="auto"``). However, if individual channel ranges vary significantly
 due to the presence of e.g. drifts/offsets/biases, setting
-``physical_range="per-channel"`` might be more appropriate. This will ensure a maximum
+``physical_range="channelwise"`` might be more appropriate. This will ensure a maximum
 resolution for each individual channel, but some tools might not be able to handle this
 appropriately (even though channel-wise ranges are covered by the EDF standard).
 """
@@ -3207,7 +3207,7 @@ docdict["physical_range_export_params"] = """
 physical_range : str | tuple
     The physical range of the data. If 'auto' (default), the physical range is inferred
     from the data, taking the minimum and maximum values per channel type. If
-    'per-channel', the range will be defined per channel. If a tuple of minimum and
+    'channelwise', the range will be defined per channel. If a tuple of minimum and
     maximum, this manual physical range will be used. Only used for exporting EDF files.
 """
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1412,11 +1412,11 @@ to store the montage separately and call :attr:`raw.set_montage()
 <mne.io.Raw.set_montage>`.
 
 The physical range of the signals is determined by signal type by default
-(``physical_range='auto'``). However, if individual channel ranges vary significantly
+(``physical_range="auto"``). However, if individual channel ranges vary significantly
 due to the presence of e.g. drifts/offsets/biases, setting
-``physical_range='channelwise'`` might be more appropriate. This will ensure a maximum
-resulution for each individual channel, but some tools might not be able to handle this
-appropriately (even though channelwise ranges are covered by the EDF standard).
+``physical_range="per-channel"`` might be more appropriate. This will ensure a maximum
+resolution for each individual channel, but some tools might not be able to handle this
+appropriately (even though channel-wise ranges are covered by the EDF standard).
 """
 
 docdict["export_eeglab_note"] = """
@@ -3210,7 +3210,7 @@ docdict["physical_range_export_params"] = """
 physical_range : str | tuple
     The physical range of the data. If 'auto' (default), the physical range is inferred
     from the data, taking the minimum and maximum values per channel type. If
-    'channelwise', the range will be defined per channel. If a tuple of minimum and
+    'per-channel', the range will be defined per channel. If a tuple of minimum and
     maximum, this manual physical range will be used. Only used for exporting EDF files.
 """
 


### PR DESCRIPTION
Fixes #12493 by adding `physical_range="channelwise"`. The default behavior remains `physical_range="auto"`, which sets the physical range per channel *type*. However, in some cases where channels vary wildly in their ranges (mainly due to different offsets), which is often the case if the amplifier used no DC HP filter (e.g. Biosemi), setting individual physical ranges per channel ensures that each channel uses the maximum resolution afforded by the EDF format (only 16 bits). This seems to be perfectly compatible with the EDF standard (please correct me if I'm wrong), but I've added a note that some tools might be incompatible with such EDF files.