### PR TITLE
Add exclude_after_unique option to mne.io.read_raw_edf/read_raw_edf to search for exclude channels after making channel names unique

### DIFF
--- a/doc/changes/devel/12518.newfeature.rst
+++ b/doc/changes/devel/12518.newfeature.rst
@@ -1,1 +1,1 @@
-Add ``exclude_after_unique`` option to :meth:`mne.io.read_raw_edf` and :meth:`mne.io.read_raw_edf` to able to apply :meth:`mne._fiff.meas_info._unique_channel_names` after checking include/exclude channels, and add ``orig_ch_names`` to ``mne.io.edf.edf.RawEDF._raw_extras`` by `Michiru Kaneda`_
+Add ``exclude_after_unique`` option to :meth:`mne.io.read_raw_edf` and :meth:`mne.io.read_raw_edf` to able to apply :meth:`mne._fiff.meas_info._unique_channel_names` after checking include/exclude channels, by `Michiru Kaneda`_

--- a/doc/changes/devel/12518.newfeature.rst
+++ b/doc/changes/devel/12518.newfeature.rst
@@ -1,1 +1,1 @@
-Add ``orig_ch_names`` to ``mne.io.edf.edf.RawEDF._raw_extras``, and apply ``mne._fiff.meas_info._unique_channel_names`` before checking include/exclude channels , by `Michiru Kaneda`_
+Add ``exclude_after_unique`` option to :meth:`mne.io.read_raw_edf` and :meth:`mne.io.read_raw_edf` to able to apply :meth:`mne._fiff.meas_info._unique_channel_names` after checking include/exclude channels, and add ``orig_ch_names`` to ``mne.io.edf.edf.RawEDF._raw_extras`` by `Michiru Kaneda`_

--- a/doc/changes/devel/12518.newfeature.rst
+++ b/doc/changes/devel/12518.newfeature.rst
@@ -1,0 +1,1 @@
+Add ``orig_ch_names`` to ``mne.io.edf.edf.RawEDF._raw_extras``, and apply ``mne._fiff.meas_info._unique_channel_names`` before checking include/exclude channels , by `Michiru Kaneda`_

--- a/doc/changes/devel/12518.newfeature.rst
+++ b/doc/changes/devel/12518.newfeature.rst
@@ -1,1 +1,1 @@
-Add ``exclude_after_unique`` option to :meth:`mne.io.read_raw_edf` and :meth:`mne.io.read_raw_edf` to search for exclude channels after applying :meth:`mne._fiff.meas_info._unique_channel_names`, by `Michiru Kaneda`_
+Add ``exclude_after_unique`` option to :meth:`mne.io.read_raw_edf` and :meth:`mne.io.read_raw_edf` to search for exclude channels after making channels names unique, by `Michiru Kaneda`_

--- a/doc/changes/devel/12518.newfeature.rst
+++ b/doc/changes/devel/12518.newfeature.rst
@@ -1,1 +1,1 @@
-Add ``exclude_after_unique`` option to :meth:`mne.io.read_raw_edf` and :meth:`mne.io.read_raw_edf` to able to apply :meth:`mne._fiff.meas_info._unique_channel_names` after checking include/exclude channels, by `Michiru Kaneda`_
+Add ``exclude_after_unique`` option to :meth:`mne.io.read_raw_edf` and :meth:`mne.io.read_raw_edf` to search for exclude channels after applying :meth:`mne._fiff.meas_info._unique_channel_names`, by `Michiru Kaneda`_

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -87,10 +87,7 @@ class RawEDF(BaseRaw):
     %(preload)s
     %(units_edf_bdf_io)s
     %(encoding_edf)s
-    exclude_after_unique : bool
-        If True, exclude channels are searched for after they have been made
-        unique. This is useful to choose channels that have been made unique
-        by adding a suffix.
+    %(exclude_after_unique)s
     %(verbose)s
 
     See Also
@@ -486,6 +483,7 @@ def _read_segment_file(data, idx, fi, start, stop, raw_extras, filenames, cals, 
     return tal_data
 
 
+@fill_doc
 def _read_header(fname, exclude, infer_types, include=None, exclude_after_unique=False):
     """Unify EDF, BDF and GDF _read_header call.
 
@@ -508,10 +506,7 @@ def _read_header(fname, exclude, infer_types, include=None, exclude_after_unique
     include : list of str | str
         Channel names to be included. A str is interpreted as a regular
         expression. 'exclude' must be empty if include is assigned.
-    exclude_after_unique : bool
-        If True, exclude channels are searched for after they have been made
-        unique. This is useful to choose channels that have been made unique
-        by adding a suffix.
+    %(exclude_after_unique)s
 
     Returns
     -------
@@ -1651,10 +1646,7 @@ def read_raw_edf(
     %(preload)s
     %(units_edf_bdf_io)s
     %(encoding_edf)s
-    exclude_after_unique : bool
-        If True, exclude channels are searched for after they have been made
-        unique. This is useful to choose channels that have been made unique
-        by adding a suffix.
+    %(exclude_after_unique)s
     %(verbose)s
 
     Returns
@@ -1791,10 +1783,7 @@ def read_raw_bdf(
     %(preload)s
     %(units_edf_bdf_io)s
     %(encoding_edf)s
-    exclude_after_unique : bool
-        If True, exclude channels are searched for after they have been made
-        unique. This is useful to choose channels that have been made unique
-        by adding a suffix.
+    %(exclude_after_unique)s
     %(verbose)s
 
     Returns

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -944,8 +944,6 @@ def _read_edf_header(
         else:
             ch_types, ch_names = ["EEG"] * nchan, ch_labels
 
-        orig_ch_names = ch_names.copy()
-
         tal_idx = _find_tal_idx(ch_names)
         if exclude_after_unique:
             # make sure channel names are unique
@@ -999,7 +997,6 @@ def _read_edf_header(
         # Populate edf_info
         edf_info.update(
             ch_names=ch_names,
-            orig_ch_names=orig_ch_names,
             ch_types=ch_types,
             data_offset=header_nbytes,
             digital_max=digital_max,
@@ -1150,7 +1147,6 @@ def _read_gdf_header(fname, exclude, include=None):
             nchan = int(np.fromfile(fid, UINT32, 1)[0])
             channels = list(range(nchan))
             ch_names = [_edf_str(fid.read(16)).strip() for ch in channels]
-            orig_ch_names = ch_names.copy()
             exclude = _find_exclude_idx(ch_names, exclude, include)
             sel = np.setdiff1d(np.arange(len(ch_names)), exclude)
             fid.seek(80 * len(channels), 1)  # transducer
@@ -1189,7 +1185,6 @@ def _read_gdf_header(fname, exclude, include=None):
             edf_info.update(
                 bytes_tot=bytes_tot,
                 ch_names=ch_names,
-                orig_ch_names=orig_ch_names,
                 data_offset=header_nbytes,
                 digital_min=digital_min,
                 digital_max=digital_max,
@@ -1348,7 +1343,6 @@ def _read_gdf_header(fname, exclude, include=None):
             # Channels (variable header)
             channels = list(range(nchan))
             ch_names = [_edf_str(fid.read(16)).strip() for ch in channels]
-            orig_ch_names = ch_names.copy()
             exclude = _find_exclude_idx(ch_names, exclude, include)
             sel = np.setdiff1d(np.arange(len(ch_names)), exclude)
 
@@ -1433,7 +1427,6 @@ def _read_gdf_header(fname, exclude, include=None):
             edf_info.update(
                 bytes_tot=bytes_tot,
                 ch_names=ch_names,
-                orig_ch_names=orig_ch_names,
                 data_offset=header_nbytes,
                 dtype_byte=dtype_byte,
                 dtype_np=dtype_np,

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -318,17 +318,10 @@ def test_edf_data_broken(tmp_path):
 def test_duplicate_channel_labels_edf():
     """Test reading edf file with duplicate channel names."""
     EXPECTED_CHANNEL_NAMES = ["EEG F1-Ref-0", "EEG F2-Ref", "EEG F1-Ref-1"]
-    EXPECTED_ORIGINAL_CHANNEL_NAMES = [
-        "EEG F1-Ref",
-        "EEG F2-Ref",
-        "EEG F1-Ref",
-        "EDF Annotations",
-    ]
     with pytest.warns(RuntimeWarning, match="Channel names are not unique"):
         raw = read_raw_edf(duplicate_channel_labels_path, preload=False)
 
     assert raw.ch_names == EXPECTED_CHANNEL_NAMES
-    assert raw._raw_extras[0]["orig_ch_names"] == EXPECTED_ORIGINAL_CHANNEL_NAMES
 
 
 def test_parse_annotation(tmp_path):

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1261,15 +1261,6 @@ encoding : str
     encoding according to the EDF+ standard).
 """
 
-docdict["exclude_after_unique"] = """
-exclude_after_unique : bool
-    If True, exclude channels are searched for after they have been made
-    unique. This is useful to choose channels that have been made unique
-    by adding a suffix.  If False, the original names are checked.
-
-    .. versionchanged:: 1.7
-"""
-
 docdict["epochs_preload"] = """
     Load all epochs from disk when creating the object
     or wait before accessing each epoch (more memory
@@ -1377,6 +1368,15 @@ evoked : instance of Evoked | list of Evoked
     separate :class:`~mne.Evoked` object for each event type. The list has the
     same order as the event types as specified in the ``event_id``
     dictionary.
+"""
+
+docdict["exclude_after_unique"] = """
+exclude_after_unique : bool
+    If True, exclude channels are searched for after they have been made
+    unique. This is useful to choose channels that have been made unique
+    by adding a suffix.  If False, the original names are checked.
+
+    .. versionchanged:: 1.7
 """
 
 docdict["exclude_clust"] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1261,6 +1261,15 @@ encoding : str
     encoding according to the EDF+ standard).
 """
 
+docdict["exclude_after_unique"] = """
+exclude_after_unique : bool
+    If True, exclude channels are searched for after they have been made
+    unique. This is useful to choose channels that have been made unique
+    by adding a suffix.  If False, the original names are checked.
+
+    .. versionchanged:: 1.7
+"""
+
 docdict["epochs_preload"] = """
     Load all epochs from disk when creating the object
     or wait before accessing each epoch (more memory


### PR DESCRIPTION
#### What does this implement/fix?

This pull request addresses an issue with handling EDF/BDF/GDF files that contain channels with duplicate names. Previously, channels with duplicate names were assigned a suffix (-N) after the process of including/excluding channels, which made it impossible to selectively include or exclude specific instances of these channels.

The proposed solution is to apply the `_unique_channel_names` function before the inclusion/exclusion process. Additionally, the original channel names (`orig_ch_names`) are now stored in `Raw._raw_extras`. This inclusion is particularly useful as it allows users to determine whether channel names have been modified and facilitates a more detailed examination of the raw data alongside other contents of `_raw_extras`.

#### Additional information

This modification could impact existing workflows. For instance, consider an EDF file with channels named ["A", "A", "B", "C"]. If a user attempts to exclude channels "A" and "C" using the following code:

```
raw = mne.io.read_raw_edf("my.edf", exclude=["A", "C"])
```

The behavior will differ pre and post-PR:

* Before PR: ch_names = ["B"]
* After PR: ch_names = ["A-0", "A-1", "B"]

If a channel is excluded using a string (interpreted as a regex), the outcome remains unchanged:

```
raw = mne.io.read_raw_edf("my.edf", exclude="A")
```

* Both before and after PR: ch_names = ["B", "C"]
