### PR TITLE
Fix file format check in _check_eeglab_fname function

### DIFF
--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -611,3 +611,5 @@
 .. _Zhi Zhang: https://github.com/tczhangzhi/
 
 .. _Zvi Baratz: https://github.com/ZviBaratz
+
+.. _Seyed Yahya Shirazi: https://neuromechanist.github.io

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -52,8 +52,6 @@ def _check_eeglab_fname(fname, dataname):
             "Old data format .dat detected. Please update your EEGLAB "
             "version and resave the data in .fdt format"
         )
-    elif fmt != ".fdt":
-        raise OSError("Expected .fdt file format. Found %s format" % fmt)
 
     basedir = op.dirname(fname)
     data_fname = op.join(basedir, dataname)


### PR DESCRIPTION
Fixes #12500

Following the conversation in the issue, it seems that the explicit check for the `.fdt` and raising error is not necessary.

By removing the Error condition, the method will look for a `.fdt` file in the directory if it does not find it in the `EEG.data` field while issuing a warning. This is also the expected and observed behavior in EEGLAB.

I have tested the behavior with the [GDrive file](https://drive.google.com/drive/folders/18y0TALqwT4Z2yg4T6QafDAqIrY04jI5k?usp=sharing) shared in the issue, which has stemmed from OpenNeuro dataset ds003645.

Thanks.