### PR TITLE
MAINT: Reenable picard in pre testing

### DIFF
--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -12,7 +12,7 @@ STD_ARGS="--progress-bar off --upgrade --pre"
 # we can use strict --index-url (instead of --extra-index-url) below
 python -m pip install $STD_ARGS pip setuptools packaging \
 	threadpoolctl cycler fonttools kiwisolver pyparsing pillow python-dateutil \
-	patsy pytz tzdata nibabel tqdm trx-python joblib
+	patsy pytz tzdata nibabel tqdm trx-python joblib numexpr
 echo "PyQt6"
 # Now broken in latest release and in the pre release:
 # pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 --extra-index-url https://www.riverbankcomputing.com/pypi/simple "PyQt6!=6.6.1,!=6.6.2" "PyQt6-Qt6!=6.6.1,!=6.6.2"
@@ -31,7 +31,6 @@ python -m pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 \
 	matplotlib statsmodels pandas \
 	$OTHERS
 
-# No python-picard (needs numexpr) until they update to NumPy 2.0 compat
 # No Numba because it forces an old NumPy version
 
 echo "OpenMEEG"
@@ -46,6 +45,9 @@ python -c "import vtk"
 
 echo "PyVista"
 python -m pip install $STD_ARGS git+https://github.com/pyvista/pyvista
+
+echo "picard"
+python -m pip install $STD_ARGS git+https://github.com/pierreablin/picard
 
 echo "pyvistaqt"
 pip install $STD_ARGS git+https://github.com/pyvista/pyvistaqt


### PR DESCRIPTION
numexpr just cut a 2.0-compatible release so we should be able to reenable `python-picard` installation