### PR TITLE
MAINT: Reinstall statsmodels and improve logging

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -193,7 +193,7 @@ stages:
             displayName: 'PyQt6'
           - bash: |
               set -e
-              python -m pip install PySide6
+              python -m pip install "PySide6!=6.7.0"
               mne sys_info -pd
               mne sys_info -pd | grep "qtpy .* (PySide6=.*)$"
               PYTEST_QT_API=PySide6 pytest -m "not slowtest" ${TEST_OPTIONS}

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -866,7 +866,7 @@ def pinvh(a, rtol=None):
 
 def pinv(a, rtol=None):
     """Compute a pseudo-inverse of a matrix."""
-    u, s, vh = np.linalg.svd(a, full_matrices=False)
+    u, s, vh = _safe_svd(a, full_matrices=False)
     del a
     maxS = np.max(s)
     if rtol is None:

--- a/mne/proj.py
+++ b/mne/proj.py
@@ -152,7 +152,7 @@ def _compute_proj(
                 ncol=u.size,
             )
             desc = f"{kind}-{desc_prefix}-PCA-{k + 1:02d}"
-            logger.info("Adding projection: %s", desc)
+            logger.info(f"Adding projection: {desc} (exp var={100 * float(var):0.1f}%)")
             proj = Projection(
                 active=False,
                 data=proj_data,
@@ -221,13 +221,16 @@ def compute_proj_epochs(
     return _compute_proj(data, epochs.info, n_grad, n_mag, n_eeg, desc_prefix, meg=meg)
 
 
-def _compute_cov_epochs(epochs, n_jobs):
+def _compute_cov_epochs(epochs, n_jobs, *, log_drops=False):
     """Compute epochs covariance."""
     parallel, p_fun, n_jobs = parallel_func(np.dot, n_jobs)
+    n_start = len(epochs.events)
     data = parallel(p_fun(e, e.T) for e in epochs)
     n_epochs = len(data)
     if n_epochs == 0:
         raise RuntimeError("No good epochs found")
+    if log_drops:
+        logger.info(f"Dropped {n_start - n_epochs}/{n_start} epochs")
 
     n_chan, n_samples = epochs.info["nchan"], len(epochs.times)
     _check_n_samples(n_samples * n_epochs, n_chan)
@@ -351,7 +354,7 @@ def compute_proj_raw(
             baseline=None,
             proj=False,
         )
-        data = _compute_cov_epochs(epochs, n_jobs)
+        data = _compute_cov_epochs(epochs, n_jobs, log_drops=True)
         info = epochs.info
         if not stop:
             stop = raw.n_times / raw.info["sfreq"]

--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -28,10 +28,9 @@ fi
 python -m pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 \
 	--index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" \
 	"numpy>=2.1.0.dev0" "scipy>=1.14.0.dev0" "scikit-learn>=1.5.dev0" \
-	matplotlib pandas \
+	matplotlib pandas statsmodels \
 	$OTHERS
 
-# No statsmodels: https://github.com/statsmodels/statsmodels/issues/9198
 # No Numba because it forces an old NumPy version
 
 echo "OpenMEEG"


### PR DESCRIPTION
1. Slight tweaks to `proj` logging to make it clear how many epochs are dropped in `compute_proj_raw` and how much variance was explained by each projector created
2. Put `statsmodels` back in pip-pre because their wheels should be back up now