### PR TITLE
explicitly disallow multitaper in presence of bad annotations

### DIFF
--- a/doc/changes/devel/12535.bugfix.rst
+++ b/doc/changes/devel/12535.bugfix.rst
@@ -1,0 +1,1 @@
+Calling :meth:`~mne.io.Raw.compute_psd` with ``method="multitaper"`` is now expressly disallowed when ``reject_by_annotation=True`` and ``bad_*`` annotations are present (previously this was nominally allowed but resulted in ``nan`` values in the PSD). By `Daniel McCloy`_.

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2197,7 +2197,9 @@ class BaseRaw(
         Parameters
         ----------
         %(method_psd)s
-            Default is ``'welch'``.
+            Note that ``"multitaper"`` cannot be used if ``reject_by_annotation=True``
+            and there are ``"bad_*"`` annotations in the :class:`~mne.io.Raw` data;
+            in such cases use ``"welch"``. Default is ``'welch'``.
         %(fmin_fmax_psd)s
         %(tmin_tmax_psd)s
         %(picks_good_data_noref)s

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -1132,6 +1132,12 @@ class Spectrum(BaseSpectrum):
             data = self.inst.get_data(
                 self._picks, start, stop + 1, reject_by_annotation=rba
             )
+            if np.any(np.isnan(data)) and method == "multitaper":
+                raise NotImplementedError(
+                    'Cannot use method="multitaper" when reject_by_annotation=True. '
+                    'Please use method="welch" instead.'
+                )
+
         else:  # Evoked
             data = self.inst.data[self._picks][:, self._time_mask]
         # set nave

--- a/mne/time_frequency/tests/test_spectrum.py
+++ b/mne/time_frequency/tests/test_spectrum.py
@@ -24,6 +24,9 @@ def test_compute_psd_errors(raw):
         raw.compute_psd(foo=None, bar=None)
     with pytest.raises(ValueError, match="Complex output is not supported in "):
         raw.compute_psd(output="complex")
+    raw.set_annotations(Annotations(onset=0.01, duration=0.01, description="bad_foo"))
+    with pytest.raises(NotImplementedError, match='Cannot use method="multitaper"'):
+        raw.compute_psd(method="multitaper", reject_by_annotation=True)
 
 
 @pytest.mark.parametrize("method", ("welch", "multitaper"))


### PR DESCRIPTION
closes #12519 

For now, with the 1.7 release pending, @larsoner and I agreed that disallowing multitaper on Raws when there are `bad_*` annotations present (and `reject_by_annotation=True`) is the best way to go.

In the long term, we could make that combination actually work by adding a new param (`chunk_size` or so, analogous to `n_per_seg` in Welch) and basically doing a welch-MT combination (using multitaper for each chunk, then combining the estimates from each chunk at the end).  It's a bit complicated because (we think) you would need to aggregate across-chunks-within-taper first, and then agg across tapers afterward. (cc @mmagnuski who I think has done that for his research before / maybe even implemented in borsar?)