### PR TITLE
fix PSD weights handling when bad annotations present

### DIFF
--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -216,16 +216,28 @@ def psd_array_welch(
     )
 
     parallel, my_spect_func, n_jobs = parallel_func(_spect_func, n_jobs=n_jobs)
-    func = partial(
-        spectrogram,
-        detrend=detrend,
-        noverlap=n_overlap,
-        nperseg=n_per_seg,
-        nfft=n_fft,
-        fs=sfreq,
-        window=window,
-        mode=mode,
-    )
+
+    def func(*args, **kwargs):
+        # swallow SciPy warnings
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                action="ignore",
+                module="scipy",
+                category=UserWarning,
+                message=r"nperseg = \d+ is greater than input length",
+            )
+            return spectrogram(
+                *args,
+                **kwargs,
+                detrend=detrend,
+                noverlap=n_overlap,
+                nperseg=n_per_seg,
+                nfft=n_fft,
+                fs=sfreq,
+                window=window,
+                mode=mode,
+            )
+
     if np.any(np.isnan(x)):
         good_mask = ~np.isnan(x)
         # NaNs originate from annot, so must match for all channels. Note that we CANNOT
@@ -256,18 +268,10 @@ def psd_array_welch(
     else:
         x_splits = [arr for arr in np.array_split(x, n_jobs) if arr.size != 0]
         agg_func = np.concatenate
-    # swallow SciPy warnings
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            action="ignore",
-            module="scipy",
-            category=UserWarning,
-            message=r"nperseg = \d+ is greater than input length",
-        )
-        f_spect = parallel(
-            my_spect_func(d, func=func, freq_sl=freq_sl, average=average, output=output)
-            for d in x_splits
-        )
+    f_spect = parallel(
+        my_spect_func(d, func=func, freq_sl=freq_sl, average=average, output=output)
+        for d in x_splits
+    )
     psds = agg_func(f_spect, axis=0)
     shape = dshape + (len(freqs),)
     if average is None:

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -232,11 +232,9 @@ def psd_array_welch(
         assert np.allclose(good_mask, good_mask[[0]], equal_nan=True)
         t_onsets, t_offsets = _mask_to_onsets_offsets(good_mask[0])
         x_splits = [x[..., t_ons:t_off] for t_ons, t_off in zip(t_onsets, t_offsets)]
-        # weights reflect the number of welch windows in each span
-        stepsize = n_per_seg - n_overlap
-        weights = [(span.shape[-1] - n_overlap) // stepsize for span in x_splits]
-        # spans < n_per_seg aren't skipped: done with reduced n_per_seg (and a warning)
-        weights = [max(w, 1) for w in weights]
+        weights = [
+            split.shape[-1] for split in x_splits if split.shape[-1] >= n_per_seg
+        ]
         agg_func = partial(np.average, weights=weights)
         if n_jobs > 1:
             logger.info(

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -216,28 +216,16 @@ def psd_array_welch(
     )
 
     parallel, my_spect_func, n_jobs = parallel_func(_spect_func, n_jobs=n_jobs)
-
-    def func(*args, **kwargs):
-        # swallow SciPy warnings
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                action="ignore",
-                module="scipy",
-                category=UserWarning,
-                message=r"nperseg = \d+ is greater than input length",
-            )
-            return spectrogram(
-                *args,
-                **kwargs,
-                detrend=detrend,
-                noverlap=n_overlap,
-                nperseg=n_per_seg,
-                nfft=n_fft,
-                fs=sfreq,
-                window=window,
-                mode=mode,
-            )
-
+    func = partial(
+        spectrogram,
+        detrend=detrend,
+        noverlap=n_overlap,
+        nperseg=n_per_seg,
+        nfft=n_fft,
+        fs=sfreq,
+        window=window,
+        mode=mode,
+    )
     if np.any(np.isnan(x)):
         good_mask = ~np.isnan(x)
         # NaNs originate from annot, so must match for all channels. Note that we CANNOT
@@ -268,10 +256,18 @@ def psd_array_welch(
     else:
         x_splits = [arr for arr in np.array_split(x, n_jobs) if arr.size != 0]
         agg_func = np.concatenate
-    f_spect = parallel(
-        my_spect_func(d, func=func, freq_sl=freq_sl, average=average, output=output)
-        for d in x_splits
-    )
+    # swallow SciPy warnings
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            action="ignore",
+            module="scipy",
+            category=UserWarning,
+            message=r"nperseg = \d+ is greater than input length",
+        )
+        f_spect = parallel(
+            my_spect_func(d, func=func, freq_sl=freq_sl, average=average, output=output)
+            for d in x_splits
+        )
     psds = agg_func(f_spect, axis=0)
     shape = dshape + (len(freqs),)
     if average is None:

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -232,9 +232,11 @@ def psd_array_welch(
         assert np.allclose(good_mask, good_mask[[0]], equal_nan=True)
         t_onsets, t_offsets = _mask_to_onsets_offsets(good_mask[0])
         x_splits = [x[..., t_ons:t_off] for t_ons, t_off in zip(t_onsets, t_offsets)]
-        weights = [
-            split.shape[-1] for split in x_splits if split.shape[-1] >= n_per_seg
-        ]
+        # weights reflect the number of welch windows in each span
+        stepsize = n_per_seg - n_overlap
+        weights = [(span.shape[-1] - n_overlap) // stepsize for span in x_splits]
+        # spans < n_per_seg aren't skipped: done with reduced n_per_seg (and a warning)
+        weights = [max(w, 1) for w in weights]
         agg_func = partial(np.average, weights=weights)
         if n_jobs > 1:
             logger.info(

--- a/mne/time_frequency/psd.py
+++ b/mne/time_frequency/psd.py
@@ -248,6 +248,11 @@ def psd_array_welch(
                 f"Data split into {len(x_splits)} (probably unequal) chunks due to "
                 '"bad_*" annotations. Parallelization may be sub-optimal.'
             )
+        if (np.array(span_lengths) < n_per_seg).any():
+            logger.info(
+                "At least one good data span is shorter than n_per_seg, and will be "
+                "analyzed with a shorter window than the rest of the file."
+            )
     else:
         x_splits = [arr for arr in np.array_split(x, n_jobs) if arr.size != 0]
         agg_func = np.concatenate


### PR DESCRIPTION
follow-up to #12536

- corrects bug where weights were discarded for spans shorter than `n_per_seg` (the wrapped function actually just shrinks `n_per_seg` in those cases)
- reduces weights for long spans to the number of *used* samples (where we expect trailing samples to be discarded)