### PR TITLE
MAINT: Pin Sphinx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ test_extra = [
 
 # Dependencies for building the documentation
 doc = [
-    "sphinx>=6",
+    "sphinx>=6,<7.3",
     "numpydoc",
     "pydata_sphinx_theme==0.15.2",
     "sphinx-gallery",


### PR DESCRIPTION
Sphinx 7.3 causes all sorts of problems, see for example https://github.com/sphinx-gallery/sphinx-gallery/pull/1289 and related issues. For now let's pin to `<7.3`. Then hopefully we can release