### PR TITLE
ENH: Add white matter fiber tracking to sEEG tutorial

### DIFF
--- a/doc/changes/devel/XXX.newfeature.rst
+++ b/doc/changes/devel/XXX.newfeature.rst
@@ -1,0 +1,1 @@
+Add diffusion imaging to :ref:`tut-working-with-seeg` including adding :meth:`mne.viz.Brain.add_streamlines` and :meth:`mne.viz.Brain.remove_streamlines` to visualize the fiber tracts, by `Alex Rockhill`_.

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -226,6 +226,8 @@ class Brain:
        +-------------------------------------+--------------+---------------+
        | :meth:`add_skull`                   |              | ✓             |
        +-------------------------------------+--------------+---------------+
+       | :meth:`add_streamlines`             |              | ✓             |
+       +-------------------------------------+--------------+---------------+
        | :meth:`add_text`                    | ✓            | ✓             |
        +-------------------------------------+--------------+---------------+
        | :meth:`add_volume_labels`           |              | ✓             |
@@ -253,6 +255,8 @@ class Brain:
        | :meth:`remove_sensors`              |              | ✓             |
        +-------------------------------------+--------------+---------------+
        | :meth:`remove_skull`                |              | ✓             |
+       +-------------------------------------+--------------+---------------+
+       | :meth:`remove_streamlines`          |              | ✓             |
        +-------------------------------------+--------------+---------------+
        | :meth:`remove_text`                 |              | ✓             |
        +-------------------------------------+--------------+---------------+
@@ -2529,6 +2533,46 @@ class Brain:
     def remove_skull(self):
         """Remove skull objects from the rendered scene."""
         self._remove("skull", render=True)
+
+    @fill_doc
+    def add_streamlines(self, streamlines, line_width=1, color="red", alpha=1):
+        """Add a streamlines to render fiber tracts.
+
+        Parameters
+        ----------
+        streamlines : list
+            A list of array-like points that form lines in units of m.
+        line_width : int
+            The width of the lines.
+        %(color_matplotlib)s
+        %(alpha)s
+
+        Notes
+        -----
+        .. versionadded:: 0.24
+        """
+        streamlines = [
+            streamline * (1e3 if self._units == "mm" else 1)
+            for streamline in streamlines
+        ]
+        color = _to_rgb(color)
+
+        for _ in self._iter_views("vol"):
+            actor, _ = self._renderer.lines(
+                streamlines,
+                color=color,
+                opacity=alpha,
+                line_width=line_width,
+                reset_camera=False,
+                render=False,
+            )
+            self._add_actor("streamlines", actor)
+
+        self._renderer._update()
+
+    def remove_streamlines(self):
+        """Remove streamline objects from the rendered scene."""
+        self._remove("streamlines", render=True)
 
     @fill_doc
     def add_volume_labels(

--- a/mne/viz/backends/_abstract.py
+++ b/mne/viz/backends/_abstract.py
@@ -195,6 +195,66 @@ class _AbstractRenderer(ABC):
         pass
 
     @abstractclassmethod
+    def lines(
+        self,
+        lines,
+        colors,
+        opacity=1.0,
+        backface_culling=False,
+        scalars=None,
+        colormap=None,
+        vmin=None,
+        vmax=None,
+        interpolate_before_map=True,
+        line_width=1.0,
+        polygon_offset=None,
+        **kwargs,
+    ):
+        """Add a mesh in the scene.
+
+        Parameters
+        ----------
+        lines : list
+            A list of array-like points defining the lines.
+        colors : list of tuple | str
+            The colors of the lines as tuples (red, green, blue) of float
+            values between 0 and 1 or a valid color name (i.e. 'white'
+            or 'w').
+        opacity : float
+            The opacity of the mesh.
+        shading : bool
+            If True, enable the mesh shading.
+        backface_culling : bool
+            If True, enable backface culling on the mesh.
+        scalars : ndarray, shape (n_vertices,)
+            The scalar valued associated to the vertices.
+        vmin : float | None
+            vmin is used to scale the colormap.
+            If None, the min of the data will be used.
+        vmax : float | None
+            vmax is used to scale the colormap.
+            If None, the max of the data will be used.
+        colormap : str | np.ndarray | matplotlib.colors.Colormap | None
+            The colormap to use.
+        interpolate_before_map :
+            Enabling makes for a smoother scalars display. Default is True.
+            When False, OpenGL will interpolate the mapped colors which can
+            result is showing colors that are not present in the color map.
+        line_width : int
+            The width of the lines when representation='wireframe'.
+        polygon_offset : float
+            If not None, the factor used to resolve coincident topology.
+        kwargs : args
+            The arguments to pass to triangular_mesh
+
+        Returns
+        -------
+        lines :
+            Handle of the lines in the scene.
+        """
+        pass
+
+    @abstractclassmethod
     def contour(
         self,
         surface,

--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -466,6 +466,47 @@ class _PyVistaRenderer(_AbstractRenderer):
             **kwargs,
         )
 
+    def lines(
+        self,
+        lines,
+        colors,
+        opacity=1.0,
+        backface_culling=False,
+        scalars=None,
+        colormap=None,
+        vmin=None,
+        vmax=None,
+        interpolate_before_map=True,
+        line_width=1.0,
+        polygon_offset=None,
+        **kwargs,
+    ):
+        actors = list()
+        meshes = list()
+        colors = colors if np.iterable(colors) else [colors] * len(lines)
+        if scalars is None:
+            scalars_lines = [None] * len(lines)
+        else:
+            scalars_lines = scalars if np.iterable(scalars) else [scalars] * len(lines)
+        for line, color, scalars in zip(lines, colors, scalars_lines):
+            actor, mesh = self.polydata(
+                mesh=pyvista.MultipleLines(line),
+                color=color,
+                opacity=opacity,
+                backface_culling=backface_culling,
+                scalars=scalars,
+                colormap=colormap,
+                vmin=vmin,
+                vmax=vmax,
+                interpolate_before_map=interpolate_before_map,
+                line_width=line_width,
+                polygon_offset=polygon_offset,
+                **kwargs,
+            )
+            actors.append(actor)
+            meshes.append(mesh)
+        return actors, meshes
+
     def contour(
         self,
         surface,

--- a/mne/viz/backends/tests/test_renderer.py
+++ b/mne/viz/backends/tests/test_renderer.py
@@ -101,6 +101,9 @@ def test_3d_backend(renderer):
     txt_text = "renderer"
     txt_size = 14
 
+    lines_data = [[0, 0, 0], [1, 1, 1]]
+    lines_color = "red"
+
     cam_distance = 5 * tet_size
 
     # init scene
@@ -122,6 +125,14 @@ def test_3d_backend(renderer):
         color=tet_color,
     )
     rend.remove_mesh(mesh_data)
+
+    # use lines
+    lines_actor = rend.lines(
+        lines_data,
+        colors=lines_color,
+        line_width=5,
+    )
+    rend.remove_mesh(lines_actor)
 
     # use contour
     rend.contour(


### PR DESCRIPTION
This adds white matter tracking to the sEEG tutorial so that electrode contacts in white matter can be better interpreted.