### PR TITLE
Allow activating slider keyboard control in `Report` by clicking on linked carousel of images; and add a fix for Safari to allow for focussing of the slider

### DIFF
--- a/doc/changes/devel/12556.newfeature.rst
+++ b/doc/changes/devel/12556.newfeature.rst
@@ -1,0 +1,1 @@
+In :class:`~mne.Report` you can now easily navigate through images and figures connected to a slider with the left and right arrow keys. Clicking on the slider or respective image will focus the slider, enabling keyboard navigation, by `Richard Höchenberger`_

--- a/mne/html_templates/report/slider.html.jinja
+++ b/mne/html_templates/report/slider.html.jinja
@@ -1,4 +1,5 @@
-<div class="accordion-item slider {{ klass }}" id="{{ id }}" data-mne-tags="{% for tag in tags %} {{ tag }} {% endfor %}">
+<div class="accordion-item slider {{ klass }}" id="{{ id }}"
+  data-mne-tags="{% for tag in tags %} {{ tag }} {% endfor %}">
   <div class="accordion-header" id="accordion-header-{{ id }}">
     <button class="accordion-button pt-1 pb-1" type="button" data-bs-toggle="collapse"
       data-bs-target="#accordion-collapse-{{ id }}" aria-expanded="true" aria-controls="accordion-collapse-{{ id }}">
@@ -24,14 +25,8 @@
           id="slider-{{id}}">
       </div>
 
-      <div id="corousel-{{ id }}" class="carousel carousel-dark" data-bs-interval="false" data-bs-wrap="false">
-        {# <!-- <div class="carousel-indicators">
-          {{for idx, caption in zip(range(len(images)), captions) }}
-          <button type="button" data-bs-target="#corousel-{{id}}" data-bs-slide-to="{{idx}}" class="active"
-            aria-current="true" aria-label="{{caption}}"></button>
-          {{endfor}}
-        </div> --> #}
-
+      <div id="corousel-{{ id }}" class="carousel carousel-dark" data-bs-interval="false" data-bs-wrap="false"
+        data-bs-keyboard="true">
         <div class="carousel-inner">
           {% for idx, img, caption in range(images|length)|zip(images, captions) %}
           <div class="carousel-item {% if idx == start_idx %}active{% endif %}">
@@ -46,14 +41,14 @@
           {% endfor %}
         </div>
 
-        {# <!-- <button class="carousel-control-prev" type="button" data-bs-target="#corousel-{{id}}" data-bs-slide="prev">
+        {# <button class="carousel-control-prev" type="button" data-bs-target="#corousel-{{id}}" data-bs-slide="prev">
           <span class="carousel-control-prev-icon" aria-hidden="true"></span>
           <span class="visually-hidden">Previous</span>
         </button>
         <button class="carousel-control-next" type="button" data-bs-target="#corousel-{{id}}" data-bs-slide="next">
           <span class="carousel-control-next-icon" aria-hidden="true"></span>
           <span class="visually-hidden">Next</span>
-        </button> --> #}
+        </button> #}
       </div>
     </div>
   </div>

--- a/mne/report/js_and_css/report.js
+++ b/mne/report/js_and_css/report.js
@@ -196,14 +196,14 @@ const addSliderEventHandlers = () => {
 
     // Allow focussing the slider with a click on the slider or carousel, so keyboard
     // controls (left / right arrow) can be enabled.
-    // This also appears to be the only way to focus the slider in Safari.
-    slider.addEventListener('click', (e) => {
-      slider.focus()
+    // This also appears to be the only way to focus the slider in Safari:
+    // https://itnext.io/fixing-focus-for-safari-b5916fef1064?gi=c1b8b043fa9b
+    slider.addEventListener('click', () => {
+      slider.focus({preventScroll: true})
     })
-    carousel.addEventListener('click', (e) => {
-      slider.focus()
+    carousel.addEventListener('click', () => {
+      slider.focus({preventScroll: true})
     })
-
   })
 }
 

--- a/mne/report/js_and_css/report.js
+++ b/mne/report/js_and_css/report.js
@@ -247,19 +247,19 @@ const disableGlobalKeysInSearchBox = () => {
 }
 
 $(document).ready(() => {
-//   gatherTags();
-//   updateTagCountBadges();
-//   addFilterByTagsCheckboxEventHandlers();
+  gatherTags();
+  updateTagCountBadges();
+  addFilterByTagsCheckboxEventHandlers();
   addSliderEventHandlers();
-//   fixTopMargin();
-//   fixScrollingForTocLinks();
-//   hljs.highlightAll();   // enable highlight.js
-//   disableGlobalKeysInSearchBox();
-//   enableGlobalKeyHandler();
-//   propagateScrollSpyURL();
+  fixTopMargin();
+  fixScrollingForTocLinks();
+  hljs.highlightAll();   // enable highlight.js
+  disableGlobalKeysInSearchBox();
+  enableGlobalKeyHandler();
+  propagateScrollSpyURL();
 });
 
-// window.onresize = () => {
-//   fixTopMargin();
-//   refreshScrollSpy();
-// };
+window.onresize = () => {
+  fixTopMargin();
+  refreshScrollSpy();
+};

--- a/mne/report/js_and_css/report.js
+++ b/mne/report/js_and_css/report.js
@@ -195,7 +195,8 @@ const addSliderEventHandlers = () => {
     })
 
     // Allow focussing the slider with a click on the slider or carousel, so keyboard
-    // controls (left / right arrow) can be enabled. Required for Safari.
+    // controls (left / right arrow) can be enabled.
+    // This also appears to be the only way to focus the slider in Safari.
     slider.addEventListener('click', (e) => {
       slider.focus()
     })

--- a/mne/report/js_and_css/report.js
+++ b/mne/report/js_and_css/report.js
@@ -193,6 +193,16 @@ const addSliderEventHandlers = () => {
       const sliderValue = parseInt(e.target.value);
       $(carousel).carousel(sliderValue);
     })
+
+    // Allow focussing the slider with a click on the slider or carousel, so keyboard
+    // controls (left / right arrow) can be enabled. Required for Safari.
+    slider.addEventListener('click', (e) => {
+      slider.focus()
+    })
+    carousel.addEventListener('click', (e) => {
+      slider.focus()
+    })
+
   })
 }
 
@@ -236,19 +246,19 @@ const disableGlobalKeysInSearchBox = () => {
 }
 
 $(document).ready(() => {
-  gatherTags();
-  updateTagCountBadges();
-  addFilterByTagsCheckboxEventHandlers();
+//   gatherTags();
+//   updateTagCountBadges();
+//   addFilterByTagsCheckboxEventHandlers();
   addSliderEventHandlers();
-  fixTopMargin();
-  fixScrollingForTocLinks();
-  hljs.highlightAll();   // enable highlight.js
-  disableGlobalKeysInSearchBox();
-  enableGlobalKeyHandler();
-  propagateScrollSpyURL();
+//   fixTopMargin();
+//   fixScrollingForTocLinks();
+//   hljs.highlightAll();   // enable highlight.js
+//   disableGlobalKeysInSearchBox();
+//   enableGlobalKeyHandler();
+//   propagateScrollSpyURL();
 });
 
-window.onresize = () => {
-  fixTopMargin();
-  refreshScrollSpy();
-};
+// window.onresize = () => {
+//   fixTopMargin();
+//   refreshScrollSpy();
+// };


### PR DESCRIPTION
This works in Safari and Chrome now (once the slider is focused, I can use the left and right arrow keys to move through the figures):

https://github.com/mne-tools/mne-python/assets/2046265/3c398196-3e78-4e79-94e3-6a5bcb7eefb5


```python
# %%
from pathlib import Path

import matplotlib.pyplot as plt
import mne
import numpy as np
import scipy.ndimage

mne_logo_path = Path(mne.__file__).parent / "icons" / "mne_icon-cropped.png"
fig_array = plt.imread(mne_logo_path)
rotation_angles = np.linspace(start=0, stop=360, num=8, endpoint=False)

figs = []
captions = []
for angle in rotation_angles:
    # Rotate and remove some rounding errors to avoid Matplotlib warnings
    fig_array_rotated = scipy.ndimage.rotate(input=fig_array, angle=angle)
    fig_array_rotated = fig_array_rotated.clip(min=0, max=1)

    # Create the figure
    fig, ax = plt.subplots(figsize=(3, 3), layout="constrained")
    ax.imshow(fig_array_rotated)
    ax.set_axis_off()

    # Store figure and caption
    figs.append(fig)
    captions.append(f"Rotation angle: {round(angle, 1)}°")

report = mne.Report(title="Multiple figures example")
report.add_figure(fig=figs, title="Fun with figures! 🥳", caption=captions)
report.save("/tmp/report_custom_figures.html", overwrite=True)
```

Previously, keyboard controls didn't work in Safari as the slider would not receive focus after a click.

This PR fixes this and additionally adds a new functionality: clicking on the figure now also focuses the slider (in all browsers), activating keyboard controls.