### PR TITLE
In `Report`, fix scrolling when clicking on the same TOC entry multiple times

### DIFF
--- a/doc/changes/devel/12561.bugfix.rst
+++ b/doc/changes/devel/12561.bugfix.rst
@@ -1,0 +1,1 @@
+Fix scrolling behavior in :class:`~mne.Report` when clicking on a TOC entry multiple times, by `Richard Höchenberger`_.

--- a/mne/report/js_and_css/report.js
+++ b/mne/report/js_and_css/report.js
@@ -165,10 +165,12 @@ const _handleTocLinkClick = (e) => {
     const targetDomId = tocLinkElement.getAttribute('href');
     const targetElement = document.querySelector(targetDomId);
     const top = $(targetElement).offset().top;
-    /* Update URL to reflect the current scroll position */
-    var url = document.URL.replace(/#.*$/, "");
-    url = url + targetDomId;
-    window.location.href = url;
+
+    // Update URL to reflect the current scroll position.
+    // We use history.pushState to change the URL without causing the browser to scroll.
+    history.pushState(null, "", targetDomId);
+
+    // Now scroll to the correct position.
     window.scrollTo(0, top - margin);
 }
 


### PR DESCRIPTION
In `main`, clicking multiple times on the same TOC entry would cause the content to jump up and down.

`main`:

https://github.com/mne-tools/mne-python/assets/2046265/9a657572-ba18-41d1-b09b-3aab31c8f97e

This PR:

https://github.com/mne-tools/mne-python/assets/2046265/e9961786-df8f-4d24-93e7-53899d697261


Importantly, this fix still ensures that the URL in the location bar gets updated.