### PR TITLE
Try fixed-width social icons on website

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -839,11 +839,6 @@ html_theme_options = {
             attributes=dict(rel="me"),
         ),
         dict(
-            name="Twitter",
-            url="https://twitter.com/mne_python",
-            icon="fa-brands fa-square-twitter fa-fw",
-        ),
-        dict(
             name="Forum",
             url="https://mne.discourse.group/",
             icon="fa-brands fa-discourse fa-fw",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -828,9 +828,9 @@ switcher_version_match = "dev" if ".dev" in version else version
 html_theme_options = {
     "icon_links": [
         dict(
-            name="GitHub",
-            url="https://github.com/mne-tools/mne-python",
-            icon="fa-brands fa-square-github fa-fw",
+            name="Discord",
+            url="https://discord.gg/rKfvxTuATa",
+            icon="fa-brands fa-discord fa-fw",
         ),
         dict(
             name="Mastodon",
@@ -844,9 +844,9 @@ html_theme_options = {
             icon="fa-brands fa-discourse fa-fw",
         ),
         dict(
-            name="Discord",
-            url="https://discord.gg/rKfvxTuATa",
-            icon="fa-brands fa-discord fa-fw",
+            name="GitHub",
+            url="https://github.com/mne-tools/mne-python",
+            icon="fa-brands fa-square-github fa-fw",
         ),
     ],
     "icon_links_label": "External Links",  # for screen reader

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -830,28 +830,28 @@ html_theme_options = {
         dict(
             name="GitHub",
             url="https://github.com/mne-tools/mne-python",
-            icon="fa-brands fa-square-github",
+            icon="fa-brands fa-square-github fa-fw",
         ),
         dict(
             name="Mastodon",
             url="https://fosstodon.org/@mne",
-            icon="fa-brands fa-mastodon",
+            icon="fa-brands fa-mastodon fa-fw",
             attributes=dict(rel="me"),
         ),
         dict(
             name="Twitter",
             url="https://twitter.com/mne_python",
-            icon="fa-brands fa-square-twitter",
+            icon="fa-brands fa-square-twitter fa-fw",
         ),
         dict(
             name="Forum",
             url="https://mne.discourse.group/",
-            icon="fa-brands fa-discourse",
+            icon="fa-brands fa-discourse fa-fw",
         ),
         dict(
             name="Discord",
             url="https://discord.gg/rKfvxTuATa",
-            icon="fa-brands fa-discord",
+            icon="fa-brands fa-discord fa-fw",
         ),
     ],
     "icon_links_label": "External Links",  # for screen reader

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -855,11 +855,11 @@ html_theme_options = {
     "show_toc_level": 1,
     "article_header_start": [],  # disable breadcrumbs
     "navbar_end": [
-        "search-button.html",
         "theme-switcher",
         "version-switcher",
         "navbar-icon-links",
     ],
+    "navbar_persistent": ["search-button"],
     "footer_start": ["copyright"],
     "secondary_sidebar_items": ["page-toc", "edit-this-page"],
     "analytics": dict(google_analytics_id="G-5TBCPCRB6X"),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -858,7 +858,7 @@ html_theme_options = {
         "search-button.html",
         "theme-switcher",
         "version-switcher",
-        "navbar-icon-links"
+        "navbar-icon-links",
     ],
     "footer_start": ["copyright"],
     "secondary_sidebar_items": ["page-toc", "edit-this-page"],

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -854,7 +854,12 @@ html_theme_options = {
     "navigation_with_keys": False,
     "show_toc_level": 1,
     "article_header_start": [],  # disable breadcrumbs
-    "navbar_end": ["theme-switcher", "version-switcher", "navbar-icon-links"],
+    "navbar_end": [
+        "search-button.html",
+        "theme-switcher",
+        "version-switcher",
+        "navbar-icon-links"
+    ],
     "footer_start": ["copyright"],
     "secondary_sidebar_items": ["page-toc", "edit-this-page"],
     "analytics": dict(google_analytics_id="G-5TBCPCRB6X"),


### PR DESCRIPTION
This fixes the width of all social icons to 25px (previously, only the Discord icon was 25px wide, whereas the other icons were 18px wide). I'm also removing the Twitter (X) social icon to increase horizontal space in the navbar. Finally, I've moved the GitHub logo all the way to the right to make it stand out more.