### PR TITLE
DOC: Clearer error message and warning

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1362,6 +1362,8 @@ def reset_warnings(gallery_conf, fname):
         r"DataFrameGroupBy\.apply operated on the grouping columns.*",
         # pandas
         r"\nPyarrow will become a required dependency of pandas.*",
+        # latexcodec
+        "open_text is deprecated. Use files.*",
     ):
         warnings.filterwarnings(  # deal with other modules having bad imports
             "ignore", message=".*%s.*" % key, category=DeprecationWarning

--- a/mne/commands/mne_freeview_bem_surfaces.py
+++ b/mne/commands/mne_freeview_bem_surfaces.py
@@ -20,7 +20,7 @@ import mne
 from mne.utils import get_subjects_dir, run_subprocess
 
 
-def freeview_bem_surfaces(subject, subjects_dir, method):
+def freeview_bem_surfaces(subject, subjects_dir, method=None):
     """View 3-Layers BEM model with Freeview.
 
     Parameters
@@ -29,8 +29,9 @@ def freeview_bem_surfaces(subject, subjects_dir, method):
         Subject name
     subjects_dir : path-like
         Directory containing subjects data (Freesurfer SUBJECTS_DIR)
-    method : str
-        Can be ``'flash'`` or ``'watershed'``.
+    method : str | None
+        Can be ``'flash'`` or ``'watershed'``, or None to use the ``bem/`` directory
+        files.
     """
     subjects_dir = str(get_subjects_dir(subjects_dir, raise_error=True))
 
@@ -85,10 +86,6 @@ def run():
     parser = get_optparser(__file__)
 
     subject = os.environ.get("SUBJECT")
-    subjects_dir = get_subjects_dir()
-    if subjects_dir is not None:
-        subjects_dir = str(subjects_dir)
-
     parser.add_option(
         "-s", "--subject", dest="subject", help="Subject name", default=subject
     )
@@ -97,13 +94,12 @@ def run():
         "--subjects-dir",
         dest="subjects_dir",
         help="Subjects directory",
-        default=subjects_dir,
     )
     parser.add_option(
         "-m",
         "--method",
         dest="method",
-        help=("Method used to generate the BEM model. " "Can be flash or watershed."),
+        help="Method used to generate the BEM model. Can be flash or watershed.",
     )
 
     options, args = parser.parse_args()

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -468,16 +468,34 @@ def get_subjects_dir(subjects_dir=None, raise_error=False):
     value : Path | None
         The SUBJECTS_DIR value.
     """
+    from_config = False
     if subjects_dir is None:
         subjects_dir = get_config("SUBJECTS_DIR", raise_error=raise_error)
+        from_config = True
     if subjects_dir is not None:
-        subjects_dir = _check_fname(
-            fname=subjects_dir,
-            overwrite="read",
-            must_exist=True,
-            need_dir=True,
-            name="subjects_dir",
-        )
+        # Emit a nice error or warning if their config is bad
+        try:
+            subjects_dir = _check_fname(
+                fname=subjects_dir,
+                overwrite="read",
+                must_exist=True,
+                need_dir=True,
+                name="subjects_dir",
+            )
+        except FileNotFoundError:
+            if from_config:
+                msg = (
+                    "SUBJECTS_DIR in your MNE-Python configuration or environment "
+                    "does not exist, considering using mne.set_config to fix it: "
+                    f"{subjects_dir}"
+                )
+                if raise_error:
+                    raise FileNotFoundError(msg) from None
+                else:
+                    warn(msg)
+            elif raise_error:
+                raise
+
     return subjects_dir
 
 

--- a/mne/utils/tests/test_config.py
+++ b/mne/utils/tests/test_config.py
@@ -161,6 +161,12 @@ def test_get_subjects_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("USERPROFILE", str(tmp_path))  # Windows
     assert str(get_subjects_dir("~/foo")) == str(subjects_dir)
 
+    monkeypatch.setenv("SUBJECTS_DIR", str(tmp_path / "doesntexist"))
+    with pytest.warns(RuntimeWarning, match="MNE-Python config"):
+        get_subjects_dir()
+    with pytest.raises(FileNotFoundError, match="MNE-Python config"):
+        get_subjects_dir(raise_error=True)
+
 
 @pytest.mark.slowtest
 @requires_good_network


### PR DESCRIPTION
1. Simplify the `mne_freeview_bem_surfaces` to be DRY -- no need to use `get_subjects_dir` twice.
2. Improve the error message when `SUBJECTS_DIR` is set in env or config to an invalid value
3. New ignore for latest `latexcodec` release