### PR TITLE
Tweak website structure

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -897,11 +897,6 @@ html_extra_path = [
     "install_mne_python.html",
 ]
 
-# Custom sidebar templates, maps document names to template names.
-html_sidebars = {
-    "index": ["sidebar-quicklinks.html"],
-}
-
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 html_copy_source = False

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,6 +36,11 @@ MNE-Python Homepage
 
    Install <install/index>
    Documentation <documentation/index>
-   API Reference <api/python_reference>
-   Get help <help/index>
+   API <api/python_reference>
+   Help <help/index>
    Development <development/index>
+   Tutorials <auto_tutorials/index>
+   Examples <auto_examples/index>
+   Changelog <development/whats_new>
+   Cite <documentation/cite>
+   Contribute <development/contributing>


### PR DESCRIPTION
As initially discussed in #12558, this PR aims to tweak the structure and content of our website. Here are my suggestions:

1. Remove sidebar from main page, and move the sidebar items to the main menu (navbar). This is already implemented here.
2. The sidebar is useful on many subpages, such as the API, but there are some pages where it is empty and therefore should be removed, e.g. Cite and Contribute. Any hints on how to selectively remove the sidebar welcome.
3. Move the Contributors gallery to a separate page, since it really clutters our landing page. I suggest to move them to Development.
4. The Funders could also be moved to a separate page, and maybe only current funders could be shown on the main page.
5. The six feature boxes should be simplified. One issue is that they don't respect the "minimal motion" browser setting. Another issue is that when hovering over a box, no text/description is shown. I suggest to completely remove all motion effects on hover.
6. The version menu is still broken, this is probably due to a missing jQuery.
7. I think we should move all versions < 1.0 to the archive. This was discussed in #11885, and the suggestion was to keep the last 2 years in the menu. This would be 1.0.0 now.