### PR TITLE
Fix NumPy 2 related reshape in Persyst

### DIFF
--- a/mne/io/persyst/persyst.py
+++ b/mne/io/persyst/persyst.py
@@ -282,7 +282,7 @@ class RawPersyst(BaseRaw):
 
         # chs * rows
         # cast as float32; more than enough precision
-        record = np.reshape(record, (n_chs, -1), "F").astype(np.float32)
+        record = np.reshape(record, (n_chs, -1), order="F").astype(np.float32)
 
         # calibrate to convert to V and handle mult
         _mult_cal_one(data, record, idx, cals, mult)


### PR DESCRIPTION
The `order` argument is kw-only in NumPy >= 2 (https://numpy.org/devdocs/reference/generated/numpy.reshape.html), so this should hopefully fix the pip-pre tests.