### PR TITLE
MAINT: Fix faulty links

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -18,4 +18,4 @@ jobs:
           python-version: '3.12'
       - run: pip install --upgrade towncrier pygithub
       - run: python ./.github/actions/rename_towncrier/rename_towncrier.py
-      - uses: autofix-ci/action@ea32e3a12414e6d3183163c3424a7d7a8631ad84
+      - uses: autofix-ci/action@d3e591514b99d0fca6779455ff8338516663f7cc

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -655,6 +655,7 @@ linkcheck_ignore = [  # will be compiled to regex
     "https://www.dtu.dk/english/service/phonebook/person",
     # SSL problems sometimes
     "http://ilabs.washington.edu",
+    "https://psychophysiology.cpmc.columbia.edu",
 ]
 linkcheck_anchors = False  # saves a bit of time
 linkcheck_timeout = 15  # some can be quite slow

--- a/examples/preprocessing/eeg_bridging.py
+++ b/examples/preprocessing/eeg_bridging.py
@@ -22,8 +22,7 @@ the extent of the bridging so as not to introduce bias into the data from this
 effect and exclude subjects with bridging that might effect the outcome of a
 study. Preventing electrode bridging is ideal but awareness of the problem at
 least will mitigate its potential as a confound to a study. This tutorial
-follows
-https://psychophysiology.cpmc.columbia.edu/software/eBridge/tutorial.html.
+follows the eBridge tutorial from https://psychophysiology.cpmc.columbia.edu.
 
 .. _electrodes.tsv: https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/03-electroencephalography.html#electrodes-description-_electrodestsv
 """  # noqa: E501

--- a/mne/preprocessing/_csd.py
+++ b/mne/preprocessing/_csd.py
@@ -219,7 +219,7 @@ def compute_bridged_electrodes(
 
     Based on :footcite:`TenkeKayser2001,GreischarEtAl2004,DelormeMakeig2004`
     and the `EEGLAB implementation
-    <https://psychophysiology.cpmc.columbia.edu/software/eBridge/index.html>`_.
+    <https://psychophysiology.cpmc.columbia.edu/>`__.
 
     Parameters
     ----------


### PR DESCRIPTION
Should fix https://app.circleci.com/pipelines/github/mne-tools/mne-python/23902/workflows/ea14ec98-52fd-48f7-b359-61761835a068/jobs/65760 by just making the link more generic.