### PR TITLE
FIX: `mne.io.read_raw_fil` handling of bad channels 

### DIFF
--- a/doc/changes/devel/12597.bugfix.rst
+++ b/doc/changes/devel/12597.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where :func:`mne.io.read_raw_fil` could not assign bad channels on import, by `George O'Neill`_.

--- a/mne/io/fil/fil.py
+++ b/mne/io/fil/fil.py
@@ -266,16 +266,14 @@ def _convert_channel_info(chans):
 def _compose_meas_info(meg, chans):
     """Create info structure."""
     info = _empty_info(meg["SamplingFrequency"])
-
     # Collect all the necessary data from the structures read
     info["meas_id"] = get_new_file_id()
     tmp = _convert_channel_info(chans)
     info["chs"] = _refine_sensor_orientation(tmp)
-    # info['chs'] = _convert_channel_info(chans)
     info["line_freq"] = meg["PowerLineFrequency"]
+    info._update_redundant()
     info["bads"] = _read_bad_channels(chans)
     info._unlocked = False
-    info._update_redundant()
     return info
 
 

--- a/mne/io/fil/tests/test_fil.py
+++ b/mne/io/fil/tests/test_fil.py
@@ -10,6 +10,7 @@ import pytest
 import scipy.io
 from numpy import array, empty, isnan
 from numpy.testing import assert_array_almost_equal, assert_array_equal
+from pandas import read_csv
 
 from mne import pick_types
 from mne.datasets import testing
@@ -159,3 +160,23 @@ def test_fil_no_positions(tmp_path):
     chs = raw.info["chs"]
     locs = array([ch["loc"][:] for ch in chs])
     assert isnan(locs).all()
+
+
+@testing.requires_testing_data
+def test_fil_bad_channel_spec(tmp_path):
+    """Test FIL reader when a bad channel is specified in channels.tsv."""
+    test_path = tmp_path / "FIL"
+    shutil.copytree(fil_path, test_path)
+
+    channame = test_path / "sub-noise_ses-001_task-noise220622_run-001_channels.tsv"
+    binname = test_path / "sub-noise_ses-001_task-noise220622_run-001_meg.bin"
+    bad_chan = "G2-OG-Y"
+
+    df = read_csv(channame, delimiter="\t")
+    index = df[df["name"] == bad_chan].index
+    df.loc[index, "status"] = "bad"
+    df.to_csv(channame, sep="\t", index=False)
+
+    raw = read_raw_fil(binname)
+    bads = raw.info["bads"]
+    assert bad_chan in bads

--- a/mne/io/fil/tests/test_fil.py
+++ b/mne/io/fil/tests/test_fil.py
@@ -28,12 +28,12 @@ pytestmark = pytest.mark.filterwarnings(
 def _set_bads_tsv(chanfile, badchan):
     """Update channels.tsv by setting target channel to bad."""
     data = []
-    with open(chanfile) as f:
+    with open(chanfile, encoding="utf-8") as f:
         for line in f:
             columns = line.strip().split("\t")
             data.append(columns)
 
-    with open(chanfile, "w") as f:
+    with open(chanfile, "w", encoding="utf-8") as f:
         for row in data:
             if badchan in row:
                 row[-1] = "bad"

--- a/mne/io/fil/tests/test_fil.py
+++ b/mne/io/fil/tests/test_fil.py
@@ -28,12 +28,12 @@ pytestmark = pytest.mark.filterwarnings(
 def _set_bads_tsv(chanfile, badchan):
     """Update channels.tsv by setting target channel to bad."""
     data = []
-    with open(chanfile) as f:
+    with open(chanfile, "rt") as f:
         for line in f:
             columns = line.strip().split("\t")
             data.append(columns)
 
-    with open(chanfile, "w") as f:
+    with open(chanfile, "wt") as f:
         for row in data:
             if badchan in row:
                 row[-1] = "bad"

--- a/mne/io/fil/tests/test_fil.py
+++ b/mne/io/fil/tests/test_fil.py
@@ -28,12 +28,12 @@ pytestmark = pytest.mark.filterwarnings(
 def _set_bads_tsv(chanfile, badchan):
     """Update channels.tsv by setting target channel to bad."""
     data = []
-    with open(chanfile, "rt") as f:
+    with open(chanfile) as f:
         for line in f:
             columns = line.strip().split("\t")
             data.append(columns)
 
-    with open(chanfile, "wt") as f:
+    with open(chanfile, "w") as f:
         for row in data:
             if badchan in row:
                 row[-1] = "bad"


### PR DESCRIPTION
#### Reference issue
Fixes #12594.


#### What does this implement/fix?
Changes the ordering that the `info` struct is populated in `read_raw_fil` so that bad channels can be read straight from the `channels.tsv` file without raising an error.
