### PR TITLE
Updated dead links in bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,8 +29,8 @@ body:
         Paste here a code snippet or minimal working example
         ([MWE](https://en.wikipedia.org/wiki/Minimal_Working_Example))
         to replicate your problem, using one of the
-        [datasets shipped with MNE-Python](https://mne.tools/dev/overview/datasets_index.html),
-        preferably the one called [sample](https://mne.tools/dev/overview/datasets_index.html#sample).
+        [datasets shipped with MNE-Python](https://mne.tools/stable/documentation/datasets.html#datasets),
+        preferably the one called [sample](https://mne.tools/stable/documentation/datasets.html#sample).
       render: Python
     validations:
       required: true

--- a/doc/changes/devel/12600.other.rst
+++ b/doc/changes/devel/12600.other.rst
@@ -1,0 +1,1 @@
+Fixed issue template links by :newcontrib:`Michal Žák`

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -382,6 +382,8 @@
 
 .. _Mauricio Cespedes Tenorio: https://github.com/mcespedes99
 
+.. _Michal Žák: https://github.com/michalrzak
+
 .. _Michiru Kaneda: https://github.com/rcmdnk
 
 .. _Mikołaj Magnuski: https://github.com/mmagnuski


### PR DESCRIPTION
#### What does this implement/fix?
Currently, there are 2 dead links in the issue template. This PR updates the links to their up-to-date locations.

