### PR TITLE
Permutation cluster test with TFCE: improvement of speed and memory usage in 2D

### DIFF
--- a/doc/changes/devel/12609.bugfix.rst
+++ b/doc/changes/devel/12609.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where :func:`mne.stats._permutation_cluster_test` (and related functions) uses excessive amount of memory for large 2D data when TFCE method is selected, by `Nicolas Fourcaud-Trocmé`_.

--- a/doc/changes/devel/12609.bugfix.rst
+++ b/doc/changes/devel/12609.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug where :func:`mne.stats._permutation_cluster_test` (and related functions) uses excessive amount of memory for large 2D data when TFCE method is selected, by `Nicolas Fourcaud-Trocmé`_.
+Fix bug where :func:`mne.stats.permutation_cluster_test` (and related functions) uses excessive amount of memory for large 2D data when TFCE method is selected, by :newcontrib:`Nicolas Fourcaud-Trocmé`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -412,6 +412,8 @@
 
 .. _Nicolas Barascud: https://github.com/nbara
 
+.. _Nicolas Fourcaud-Trocmé: https://www.crnl.fr/fr/user/316
+
 .. _Niels Focke: https://neurologie.umg.eu/forschung/arbeitsgruppen/epilepsie-und-bildgebungsforschung
 
 .. _Niklas Wilming: https://github.com/nwilming

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -824,7 +824,8 @@ def test_tfce_thresholds(numba_conditional):
 @pytest.mark.parametrize("shape", ((11,), (11, 3), (11, 1, 2)))
 @pytest.mark.parametrize("out_type", ("mask", "indices"))
 @pytest.mark.parametrize("adjacency", (None, "sparse"))
-def test_output_equiv(shape, out_type, adjacency):
+@pytest.mark.parametrize("threshold", (None, dict(start=0, step=0.1)))
+def test_output_equiv(shape, out_type, adjacency, threshold):
     """Test equivalence of output types."""
     rng = np.random.RandomState(0)
     n_subjects = 10
@@ -832,14 +833,22 @@ def test_output_equiv(shape, out_type, adjacency):
     data -= data.mean(axis=0, keepdims=True)
     data[:, 2:4] += 2
     data[:, 6:9] += 2
+    tfce = isinstance(threshold, dict)
     want_mask = np.zeros(shape, int)
-    want_mask[2:4] = 1
-    want_mask[6:9] = 2
+    if not tfce:
+        want_mask[2:4] = 1
+        want_mask[6:9] = 2
+    else:
+        want_mask = np.arange(want_mask.size).reshape(shape) + 1
     if adjacency is not None:
         assert adjacency == "sparse"
         adjacency = combine_adjacency(*shape)
     clusters = permutation_cluster_1samp_test(
-        X=data, n_permutations=1, adjacency=adjacency, out_type=out_type
+        X=data,
+        n_permutations=1,
+        adjacency=adjacency,
+        out_type=out_type,
+        threshold=threshold,
     )[1]
     got_mask = np.zeros_like(want_mask)
     for n, clu in enumerate(clusters, 1):

--- a/tools/dev/ensure_headers.py
+++ b/tools/dev/ensure_headers.py
@@ -32,8 +32,7 @@ COPYRIGHT_LINE = "# Copyright the MNE-Python contributors."
 def get_paths_from_tree(root, level=0):
     for entry in root:
         if entry.type == "tree":
-            for x in get_paths_from_tree(entry, level + 1):
-                yield x
+            yield from get_paths_from_tree(entry, level + 1)
         else:
             yield Path(entry.path)  # entry.type
 


### PR DESCRIPTION
#### Reference issue
No ref, only a post in the forum


#### What does this implement/fix?
In mne.stats.cluster_level.py :
The use of TFCE with large 2D data implied a huge amount of memory because of the creation of as many boolean arrays of the same size of the data as the number of data points (with TFCE, each point is considered as a cluster - consisting of a single point - and need an array to describe it). For this case, I replace the large boolean array by a single index, and removed the clusters output when it was not necessary.


#### Additional information
It is my first ever PR, all comments are welcomed
