### PR TITLE
Fix Brain slider ranges

### DIFF
--- a/doc/changes/devel/12612.bugfix.rst
+++ b/doc/changes/devel/12612.bugfix.rst
@@ -1,0 +1,1 @@
+Fix overflow when plotting source estimates where data is all zero (or close to zero), and fix the range of allowed values for the colorbar sliders, by `Marijn van Vliet`_.

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -869,8 +869,8 @@ class Brain:
         )
 
     def _configure_dock_colormap_widget(self, name):
-        fmin, fmax, fscale, fscale_power = _get_range(self)
-        rng = [fmin * fscale, fmax * fscale]
+        fmax, fscale, fscale_power = _get_range(self)
+        rng = [0, fmax * fscale]
         self._data["fscale"] = fscale
 
         layout = self._renderer._dock_add_group_box(name)
@@ -4157,16 +4157,15 @@ def _get_range(brain):
     multiplied by the scaling factor and when getting a value, this value
     should be divided by the scaling factor.
     """
-    val = np.abs(np.concatenate(list(brain._current_act_data.values())))
-    fmin, fmax = np.min(val), np.max(val)
+    fmax = brain._data["fmax"]
     if 1e-02 <= fmax <= 1e02:
         fscale_power = 0
     else:
-        fscale_power = int(np.log10(fmax))
+        fscale_power = int(np.log10(max(fmax, np.finfo("float32").min)))
         if fscale_power < 0:
             fscale_power -= 1
     fscale = 10**-fscale_power
-    return fmin, fmax, fscale, fscale_power
+    return fmax, fscale, fscale_power
 
 
 class _FakeIren:


### PR DESCRIPTION
This updates the logic that determines the ranges for the three sliders (fmin, fmid, fmax) on the left of a `Brain` figure. There was an overflow when the data is all zeros (`np.log10(fmax)`) which this PR fixes by using `np.log10(max(fmax, 1e-30))` instead. While I was there, I noticed that the minimum and maximum values for the sliders were set based on the `fmin` and `fmax` of the current timepoint instead of the entire data. Finally, on second thought, the minimum value for the sliders should always be `0`, that makes a lot more sense to me than capping it to `fmin`.

To check out the new behavior:

```python
import mne
path = mne.datasets.sample.data_path()
stc = mne.read_source_estimate(path / "MEG/sample/fsaverage_audvis-meg")
brain = stc.plot("fsaverage", hemi="both", subjects_dir=path / "subjects")
```
![image](https://github.com/mne-tools/mne-python/assets/428273/b0c43a96-b907-4315-9c3f-6a31226598bf)
![image](https://github.com/mne-tools/mne-python/assets/428273/2c375434-b018-4479-b24b-f952cbd1eeb4)

fixes #12606