### PR TITLE
MAINT: Workaround hook bug

### DIFF
--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -67,7 +67,9 @@ echo "joblib"
 pip install $STD_ARGS git+https://github.com/joblib/joblib
 
 echo "edfio"
-pip install $STD_ARGS git+https://github.com/the-siesta-group/edfio
+# Disable protection for Azure, see
+# https://github.com/mne-tools/mne-python/pull/12609#issuecomment-2115639369
+GIT_CLONE_PROTECTION_ACTIVE=false pip install $STD_ARGS git+https://github.com/the-siesta-group/edfio
 
 if [[ "${PLATFORM}" == "Linux" ]]; then
 	echo "h5io"


### PR DESCRIPTION
Should work aroun the weird checkout hook bug, which I assume is due to some misconfiguration of `git` or something in an updated CI image. Should be safe enough since we trust the authors (and if something weird does happen, it just happens in a CI run).