### PR TITLE
Fix `EpochsTFR.add_channels()`

### DIFF
--- a/doc/changes/devel/12616.bugfix.rst
+++ b/doc/changes/devel/12616.bugfix.rst
@@ -1,0 +1,1 @@
+Fix adding channels to :class:`mne.time_frequency.EpochsTFR` objects, by `Clemens Brunner`_.

--- a/doc/changes/devel/12616.bugfix.rst
+++ b/doc/changes/devel/12616.bugfix.rst
@@ -1,1 +1,1 @@
-Fix adding channels to :class:`mne.time_frequency.EpochsTFR` objects, by `Clemens Brunner`_.
+Fix adding channels to :class:`~mne.time_frequency.EpochsTFR` objects, by `Clemens Brunner`_.

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -696,6 +696,7 @@ class UpdateChannelsMixin:
         # avoid circular imports
         from ..epochs import BaseEpochs
         from ..io import BaseRaw
+        from ..time_frequency import EpochsTFR
 
         _validate_type(add_list, (list, tuple), "Input")
 
@@ -708,6 +709,9 @@ class UpdateChannelsMixin:
         elif isinstance(self, BaseEpochs):
             con_axis = 1
             comp_class = BaseEpochs
+        elif isinstance(self, EpochsTFR):
+            con_axis = 1
+            comp_class = EpochsTFR
         else:
             con_axis = 0
             comp_class = type(self)

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -945,20 +945,20 @@ def test_add_channels():
 
     # Test for EpochsTFR(Array)
     tfr1 = EpochsTFRArray(
-        info=mne.create_info(["EEG 001", "EEG 002"], 1000, "eeg"),
-        data=np.zeros((5, 2, 2, 3)),  # epochs, channels, freqs, times
+        info=mne.create_info(["EEG 001"], 1000, "eeg"),
+        data=np.zeros((5, 1, 2, 3)),  # epochs, channels, freqs, times
         times=[0.1, 0.2, 0.3],
         freqs=[0.1, 0.2],
     )
     tfr2 = EpochsTFRArray(
-        info=mne.create_info(["EEG 003", "EEG 004"], 1000, "eeg"),
+        info=mne.create_info(["EEG 002", "EEG 003"], 1000, "eeg"),
         data=np.zeros((5, 2, 2, 3)),  # epochs, channels, freqs, times
         times=[0.1, 0.2, 0.3],
         freqs=[0.1, 0.2],
     )
     tfr1.add_channels([tfr2])
-    assert tfr1.ch_names == ["EEG 001", "EEG 002", "EEG 003", "EEG 004"]
-    assert tfr1.data.shape == (5, 4, 2, 3)
+    assert tfr1.ch_names == ["EEG 001", "EEG 002", "EEG 003"]
+    assert tfr1.data.shape == (5, 3, 2, 3)
 
 
 def test_compute_tfr():

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -943,6 +943,23 @@ def test_add_channels():
     pytest.raises(ValueError, tfr_meg.add_channels, [tfr_meg])
     pytest.raises(TypeError, tfr_meg.add_channels, tfr_badsf)
 
+    # Test for EpochsTFR(Array)
+    tfr1 = EpochsTFRArray(
+        info=mne.create_info(["EEG 001", "EEG 002"], 1000, "eeg"),
+        data=np.zeros((5, 2, 2, 3)),  # epochs, channels, freqs, times
+        times=[0.1, 0.2, 0.3],
+        freqs=[0.1, 0.2],
+    )
+    tfr2 = EpochsTFRArray(
+        info=mne.create_info(["EEG 003", "EEG 004"], 1000, "eeg"),
+        data=np.zeros((5, 2, 2, 3)),  # epochs, channels, freqs, times
+        times=[0.1, 0.2, 0.3],
+        freqs=[0.1, 0.2],
+    )
+    tfr1.add_channels([tfr2])
+    assert tfr1.ch_names == ["EEG 001", "EEG 002", "EEG 003", "EEG 004"]
+    assert tfr1.data.shape == (5, 4, 2, 3)
+
 
 def test_compute_tfr():
     """Test _compute_tfr function."""


### PR DESCRIPTION
`EpochsTFR.add_channels()` is currently broken, since it adds the objects in the wrong dimension (0, but should be 1). I think this should be backported if possible.