### PR TITLE
In HTML repr, display channel names on hover

### DIFF
--- a/mne/html_templates/repr/_channels.html.jinja
+++ b/mne/html_templates/repr/_channels.html.jinja
@@ -26,13 +26,13 @@
     <td class="repr-section-toggle-col"></td>
     <td>{{ channel_type }}</td>
     <td>
-        <button class="channel-names-btn" onclick="alert('Good {{ channel_type}}:\n\n{{ channel_names_good | safe }}')" title="Show good channel names">
+        <button class="channel-names-btn" onclick="alert('Good {{ channel_type}}:\n\n{{ channel_names_good | safe }}')" title="(Click to open in popup)&#13;&#13;{{ channel_names_good | safe }}">
             {{ channels["good"] | length}}
         </button>
 
         {% if channels["bad"] %}
         {% set channel_names_bad = channels["bad"] | map(attribute='name_html') | join(', ') %}
-        and <button class="channel-names-btn" onclick="alert('Bad {{ channel_type}}:\n\n{{ channel_names_bad | safe }}')" title="Show bad channel names">
+        and <button class="channel-names-btn" onclick="alert('Bad {{ channel_type}}:\n\n{{ channel_names_bad | safe }}')" title="(Click to open in popup)&#13;&#13;{{ channel_names_bad | safe }}">
             {{ channels["bad"] | length}} bad
         </button>
         {% endif %}


### PR DESCRIPTION
This aims to address a concern @mscheltienne voiced at
https://github.com/mne-tools/mne-python/pull/12583#issuecomment-2126706812

Now, the channel names can already be viewed by simply hovering
over the number of good or bad channels. The appearing overlay still lets the user know that by clicking, they can open the channel names in a popup window.

@drammock @larsoner These changes belong together with #12583 in the changelog; how can I achieve this grouping?
