### PR TITLE
Fix intersphinx_registry API break

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -165,7 +165,7 @@ intersphinx_mapping = {
 }
 intersphinx_mapping.update(
     get_intersphinx_mapping(
-        only=set(
+        packages=set(
             """
 imageio matplotlib numpy pandas python scipy statsmodels sklearn numba joblib nibabel
 seaborn patsy pyvista dipy nilearn pyqtgraph

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ doc = [
     "pyzmq!=24.0.0",
     "ipython!=8.7.0",
     "selenium",
-    "intersphinx_registry",
+    "intersphinx_registry>=0.2405.27",
 ]
 dev = ["mne[test,doc]", "rcssmin"]
 


### PR DESCRIPTION
c.f. https://github.com/Carreau/intersphinx_registry/commit/9aa7ec5f934d5215dad5e9673d48d2bbcebf312d
Reported upstream on commit comments to avoid API breaks on keyword-only arguments. I'm not pinning the version here as I'm not confident the version schema in `intersphinx_registry` will not change again.