### PR TITLE
MAINT: More lenient timeout for downloader

### DIFF
--- a/mne/datasets/utils.py
+++ b/mne/datasets/utils.py
@@ -813,7 +813,7 @@ def _log_time_size(t0, sz):
 
 
 def _downloader_params(*, auth=None, token=None):
-    params = dict()
+    params = dict(timeout=15)
     params["progressbar"] = (
         logger.level <= logging.INFO and get_config("MNE_TQDM", "tqdm.auto") != "off"
     )


### PR DESCRIPTION
Should help with situations where `osf.io` is slow to respond like in https://app.circleci.com/pipelines/github/mne-tools/mne-bids-pipeline/4566/workflows/9b8fd064-fe8c-4d1d-a30b-fa01000777f2/jobs/66642 for example. There it works after repeated retries of the job, but setting this to 15 instead of the default (which appears to be 5 based on the traceback).