### PR TITLE
[BUG] Cross-spectral density missing frequencies

### DIFF
--- a/doc/changes/devel/12633.bugfix.rst
+++ b/doc/changes/devel/12633.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where :func:`mne.time_frequency.csd_multitaper`, :func:`mne.time_frequency.csd_fourier`, :func:`mne.time_frequency.csd_array_multitaper`, and :func:`mne.time_frequency.csd_array_fourier` would return cross-spectral densities with the ``fmin`` and ``fmax`` frequencies missing, by `Thomas Binns`_

--- a/mne/time_frequency/csd.py
+++ b/mne/time_frequency/csd.py
@@ -810,9 +810,10 @@ def csd_array_fourier(
     n_fft = n_times if n_fft is None else n_fft
 
     # Preparing frequencies of interest
-    # orig_frequencies = fftfreq(n_fft, 1. / sfreq)
     orig_frequencies = rfftfreq(n_fft, 1.0 / sfreq)
-    freq_mask = (orig_frequencies > fmin) & (orig_frequencies < fmax)
+    freq_mask = (
+        (orig_frequencies > 0) & (orig_frequencies >= fmin) & (orig_frequencies <= fmax)
+    )
     frequencies = orig_frequencies[freq_mask]
 
     if len(frequencies) == 0:
@@ -1013,7 +1014,9 @@ def csd_array_multitaper(
 
     # Preparing frequencies of interest
     orig_frequencies = rfftfreq(n_fft, 1.0 / sfreq)
-    freq_mask = (orig_frequencies > fmin) & (orig_frequencies < fmax)
+    freq_mask = (
+        (orig_frequencies > 0) & (orig_frequencies >= fmin) & (orig_frequencies <= fmax)
+    )
     frequencies = orig_frequencies[freq_mask]
 
     if len(frequencies) == 0:

--- a/mne/time_frequency/tests/test_csd.py
+++ b/mne/time_frequency/tests/test_csd.py
@@ -394,15 +394,15 @@ def _test_fourier_multitaper_parameters(epochs, csd_epochs, csd_array):
         fmin=20,
         fmax=10,
     )
-    raises(ValueError, csd_epochs, epochs, fmin=20, fmax=20.1)
+    raises(ValueError, csd_epochs, epochs, fmin=20.11, fmax=20.19)
     raises(
         ValueError,
         csd_array,
         epochs._data,
         epochs.info["sfreq"],
         epochs.tmin,
-        fmin=20,
-        fmax=20.1,
+        fmin=20.11,
+        fmax=20.19,
     )
     raises(ValueError, csd_epochs, epochs, tmin=0.15, tmax=0.1)
     raises(


### PR DESCRIPTION
#### Reference issue
Discussed in call with @larsoner & @wmvanvliet.


#### What does this implement/fix?
Currently, computing the CSD with the `csd_multitaper`, `csd_fourier`, `csd_array_multitaper`, or `csd_array_fourier` functions of the `time_frequency` module will return a `CrossSpectralDensity` object whose frequencies do not match the `fmin` and `fmax` parameters supplied to the functions.

E.g. calling the functions with `fmin=5, fmax=10` could be expected to return a CSD object with frequencies `[5, 6, 7, 8, 9, 10]` (assuming a 1 Hz resolution). Instead, the following frequencies are returned `[6, 7, 8, 9]`.

This occurs because of the logic used to generate the internal frequency mask:
```
orig_frequencies = rfftfreq(n_fft, 1.0 / sfreq)
freq_mask = (orig_frequencies > fmin) & (orig_frequencies < fmax)
```

As such, the `fmin` and `fmax` entries of 5 and 10 Hz may be included in the list of possible frequencies, but they are ignored when generating the frequency mask (e.g. as 5 is not greater than itself, and 10 is not less than itself).

A simple solution if to allow entries of `orig_frequencies` to also match `fmin` and `fmax`, e.g.:
https://github.com/mne-tools/mne-python/blob/74e7348be7536b42bca2fa3ce48ecd4f0536a89b/mne/time_frequency/csd.py#L814-L816
This change ensures that `fmin=5, fmax=10` will return a CSD object with frequencies `[5, 6, 7, 8, 9, 10]`. Note that `(orig_frequencies > 0)` is important to prevent the CSD being returned for the zero frequency, which would not match the behaviour of other spectral methods (e.g. PSD computation).

@larsoner This does not include logic for cases that can be considered as floating point errors, but if I recall you said this was optional.

This requires a small change to the unit tests for catching failing cases where no frequency bins are captured due to `fmin` and `fmax` being too close, e.g.:
https://github.com/tsbinns/mne-python/blob/74e7348be7536b42bca2fa3ce48ecd4f0536a89b/mne/time_frequency/tests/test_csd.py#L397