### PR TITLE
MAINT: Switch to sparse arrays

### DIFF
--- a/doc/changes/devel/12646.bugfix.rst
+++ b/doc/changes/devel/12646.bugfix.rst
@@ -1,0 +1,3 @@
+Output types of sparse arrays were changed from ``matrix`` to ``array``
+to comply with the pending deprecation of ``np.matrix`` types in scipy,
+by `Eric Larson`_.

--- a/doc/changes/devel/12646.bugfix.rst
+++ b/doc/changes/devel/12646.bugfix.rst
@@ -1,3 +1,10 @@
-Output types of sparse arrays were changed from ``matrix`` to ``array``
-to comply with the pending deprecation of ``np.matrix`` types in scipy,
-by `Eric Larson`_.
+Output types of sparse arrays were changed from ``matrix`` to ``array`` in
+:func:`~mne.channels.read_ch_adjacency`, :func:`~mne.channels.find_ch_adjacency`,
+:func:`~mne.stats.combine_adjacency`, :func:`~mne.spatio_temporal_src_adjacency`,
+and related functions to comply with the pending deprecation of ``np.matrix``.
+The returned objects now behave like standard :class:`~numpy.ndarray` objects, and
+in particular ``*`` now operates element-wise instead of performing matrix
+multiplication. You can use ``@`` as a backward compatible matrix multiplication
+for both ``np.matrix`` and ``np.ndarray`` objects, and if a matrix is desired
+the outputs can be cast directly, for example as ``scipy.sparse.csr_matrix(out)``.
+Changed by `Eric Larson`_.

--- a/mne/_fiff/proc_history.py
+++ b/mne/_fiff/proc_history.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 
-from ..fixes import _csc_matrix_cast
+from ..fixes import _csc_array_cast
 from ..utils import _check_fname, warn
 from .constants import FIFF
 from .open import fiff_open, read_tag
@@ -198,7 +198,7 @@ _sss_ctc_ids = (
     FIFF.FIFF_DECOUPLER_MATRIX,
 )
 _sss_ctc_writers = (write_id, write_int, write_string, write_float_sparse)
-_sss_ctc_casters = (dict, np.array, str, _csc_matrix_cast)
+_sss_ctc_casters = (dict, np.array, str, _csc_array_cast)
 
 _sss_cal_keys = ("cal_chans", "cal_corrs")
 _sss_cal_ids = (FIFF.FIFF_SSS_CAL_CHANS, FIFF.FIFF_SSS_CAL_CORRS)

--- a/mne/_fiff/tag.py
+++ b/mne/_fiff/tag.py
@@ -12,7 +12,7 @@ from functools import partial
 from typing import Any
 
 import numpy as np
-from scipy.sparse import csc_matrix, csr_matrix
+from scipy.sparse import csc_array, csr_array
 
 from ..utils import _check_option, warn
 from ..utils.numerics import _julian_to_cal
@@ -214,7 +214,7 @@ def _read_matrix(fid, tag, shape, rlims):
                     )
                 )
                 indptr = np.frombuffer(tmp_ptr, dtype="<i4")
-            data = csc_matrix((data, indices, indptr), shape=shape)
+            data = csc_array((data, indices, indptr), shape=shape)
         else:
             assert matrix_coding == "sparse RCS", matrix_coding
             tmp_indices = fid.read(4 * nnz)
@@ -231,7 +231,7 @@ def _read_matrix(fid, tag, shape, rlims):
                     )
                 )
                 indptr = np.frombuffer(tmp_ptr, dtype="<i4")
-            data = csr_matrix((data, indices, indptr), shape=shape)
+            data = csr_array((data, indices, indptr), shape=shape)
     return data
 
 

--- a/mne/_fiff/tests/test_meas_info.py
+++ b/mne/_fiff/tests/test_meas_info.py
@@ -803,23 +803,23 @@ def test_csr_csc(tmp_path):
     sss_ctc = info["proc_history"][0]["max_info"]["sss_ctc"]
     ct = sss_ctc["decoupler"].copy()
     # CSC
-    assert isinstance(ct, sparse.csc_matrix)
+    assert isinstance(ct, sparse.csc_array)
     fname = tmp_path / "test.fif"
     write_info(fname, info)
     info_read = read_info(fname)
     ct_read = info_read["proc_history"][0]["max_info"]["sss_ctc"]["decoupler"]
-    assert isinstance(ct_read, sparse.csc_matrix)
+    assert isinstance(ct_read, sparse.csc_array)
     assert_array_equal(ct_read.toarray(), ct.toarray())
     # Now CSR
     csr = ct.tocsr()
-    assert isinstance(csr, sparse.csr_matrix)
+    assert isinstance(csr, sparse.csr_array)
     assert_array_equal(csr.toarray(), ct.toarray())
     info["proc_history"][0]["max_info"]["sss_ctc"]["decoupler"] = csr
     fname = tmp_path / "test1.fif"
     write_info(fname, info)
     info_read = read_info(fname)
     ct_read = info_read["proc_history"][0]["max_info"]["sss_ctc"]["decoupler"]
-    assert isinstance(ct_read, sparse.csc_matrix)  # this gets cast to CSC
+    assert isinstance(ct_read, sparse.csc_array)  # this gets cast to CSC
     assert_array_equal(ct_read.toarray(), ct.toarray())
 
 

--- a/mne/_fiff/write.py
+++ b/mne/_fiff/write.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from gzip import GzipFile
 
 import numpy as np
-from scipy.sparse import csc_matrix, csr_matrix
+from scipy.sparse import csc_array, csr_array
 
 from ..utils import _file_like, _validate_type, logger
 from ..utils.numerics import _cal_to_julian
@@ -417,8 +417,8 @@ def write_float_sparse_rcs(fid, kind, mat):
 def write_float_sparse(fid, kind, mat, fmt="auto"):
     """Write a single-precision floating-point sparse matrix tag."""
     if fmt == "auto":
-        fmt = "csr" if isinstance(mat, csr_matrix) else "csc"
-    need = csr_matrix if fmt == "csr" else csc_matrix
+        fmt = "csr" if isinstance(mat, csr_array) else "csc"
+    need = csr_array if fmt == "csr" else csc_array
     matrix_type = getattr(FIFF, f"FIFFT_SPARSE_{fmt[-1].upper()}CS_MATRIX")
     _validate_type(mat, need, "sparse")
     matrix_type = matrix_type | FIFF.FIFFT_MATRIX | FIFF.FIFFT_FLOAT

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -24,7 +24,7 @@ from typing import Union
 
 import numpy as np
 from scipy.io import loadmat
-from scipy.sparse import csr_matrix, lil_matrix
+from scipy.sparse import csr_array, lil_array
 from scipy.spatial import Delaunay
 from scipy.stats import zscore
 
@@ -1336,7 +1336,7 @@ def read_ch_adjacency(fname, picks=None):
 
     Returns
     -------
-    ch_adjacency : scipy.sparse.csr_matrix, shape (n_channels, n_channels)
+    ch_adjacency : scipy.sparse.csr_array, shape (n_channels, n_channels)
         The adjacency matrix.
     ch_names : list
         The list of channel names present in adjacency matrix.
@@ -1437,7 +1437,7 @@ def _ch_neighbor_adjacency(ch_names, neighbors):
     ch_adjacency = np.eye(len(ch_names), dtype=bool)
     for ii, neigbs in enumerate(neighbors):
         ch_adjacency[ii, [ch_names.index(i) for i in neigbs]] = True
-    ch_adjacency = csr_matrix(ch_adjacency)
+    ch_adjacency = csr_array(ch_adjacency)
     return ch_adjacency
 
 
@@ -1459,7 +1459,7 @@ def find_ch_adjacency(info, ch_type):
 
     Returns
     -------
-    ch_adjacency : scipy.sparse.csr_matrix, shape (n_channels, n_channels)
+    ch_adjacency : scipy.sparse.csr_array, shape (n_channels, n_channels)
         The adjacency matrix.
     ch_names : list
         The list of channel names present in adjacency matrix.
@@ -1572,7 +1572,7 @@ def _compute_ch_adjacency(info, ch_type):
 
     Returns
     -------
-    ch_adjacency : scipy.sparse.csr_matrix, shape (n_channels, n_channels)
+    ch_adjacency : scipy.sparse.csr_array, shape (n_channels, n_channels)
         The adjacency matrix.
     ch_names : list
         The list of channel names present in adjacency matrix.
@@ -1611,9 +1611,9 @@ def _compute_ch_adjacency(info, ch_type):
                 for jj in range(2):
                     ch_adjacency[idx * 2 + ii, neigbs * 2 + jj] = True
                     ch_adjacency[idx * 2 + ii, idx * 2 + jj] = True  # pair
-        ch_adjacency = csr_matrix(ch_adjacency)
+        ch_adjacency = csr_array(ch_adjacency)
     else:
-        ch_adjacency = lil_matrix(neighbors)
+        ch_adjacency = lil_array(neighbors)
         ch_adjacency.setdiag(np.repeat(1, ch_adjacency.shape[0]))
         ch_adjacency = ch_adjacency.tocsr()
 

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -472,7 +472,7 @@ def test_find_ch_adjacency():
     for ch_type in ["mag", "grad", "eeg"]:
         conn, ch_names = find_ch_adjacency(raw.info, ch_type)
         # Silly test for checking the number of neighbors.
-        assert_equal(conn.getnnz(), sizes[ch_type])
+        assert_equal(conn.astype(bool).sum(), sizes[ch_type])
         assert_equal(len(ch_names), nchans[ch_type])
         kwargs = dict(exclude=())
         if ch_type in ("mag", "grad"):
@@ -485,7 +485,7 @@ def test_find_ch_adjacency():
 
     # Test computing the conn matrix with gradiometers.
     conn, ch_names = _compute_ch_adjacency(raw.info, "grad")
-    assert_equal(conn.getnnz(), 2680)
+    assert_equal(conn.astype(bool).sum(), 2680)
 
     # Test ch_type=None.
     raw.pick(picks="mag")
@@ -516,7 +516,7 @@ def test_neuromag122_adjacency():
     nm122_fname = testing_path / "misc" / "neuromag122_test_file-raw.fif"
     raw = read_raw_fif(nm122_fname)
     conn, ch_names = find_ch_adjacency(raw.info, "grad")
-    assert conn.getnnz() == 1564
+    assert conn.astype(bool).sum() == 1564
     assert len(ch_names) == 122
     assert conn.shape == (122, 122)
 

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -111,10 +111,7 @@ def _csc_array_cast(x):
 def _eye_array(n, *, format="csr"):  # noqa: A002
     from scipy import sparse
 
-    indptr = np.arange(n + 1)
-    indices = np.arange(n)
-    data = np.ones(n)
-    return sparse.csr_array((data, indices, indptr), (n, n)).asformat(format)
+    return sparse.dia_array((np.ones(n), 0), shape=(n, n)).asformat(format)
 
 
 ###############################################################################

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -101,10 +101,10 @@ def _safe_svd(A, **kwargs):
         return linalg.svd(A, lapack_driver="gesvd", **kwargs)
 
 
-def _csc_matrix_cast(x):
-    from scipy.sparse import csc_matrix
+def _csc_array_cast(x):
+    from scipy.sparse import csc_array
 
-    return csc_matrix(x)
+    return csc_array(x)
 
 
 ###############################################################################

--- a/mne/fixes.py
+++ b/mne/fixes.py
@@ -107,6 +107,16 @@ def _csc_array_cast(x):
     return csc_array(x)
 
 
+# Can be replaced with sparse.eye_array once we depend on SciPy >= 1.12
+def _eye_array(n, *, format="csr"):  # noqa: A002
+    from scipy import sparse
+
+    indptr = np.arange(n + 1)
+    indices = np.arange(n)
+    data = np.ones(n)
+    return sparse.csr_array((data, indices, indptr), (n, n)).asformat(format)
+
+
 ###############################################################################
 # NumPy Generator (NumPy 1.17)
 

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -832,7 +832,7 @@ def convert_forward_solution(
             fwd["sol"]["ncol"] = fwd["nsource"]
             if fwd["sol_grad"] is not None:
                 x = sparse.block_diag([fix_rot] * 3)
-                fwd["sol_grad"]["data"] = fwd["_orig_sol_grad"] * x  # dot prod
+                fwd["sol_grad"]["data"] = fwd["_orig_sol_grad"] @ x
                 fwd["sol_grad"]["ncol"] = 3 * fwd["nsource"]
             fwd["source_ori"] = FIFF.FIFFV_MNE_FIXED_ORI
             fwd["surf_ori"] = True
@@ -842,7 +842,7 @@ def convert_forward_solution(
             fwd["sol"]["ncol"] = 3 * fwd["nsource"]
             if fwd["sol_grad"] is not None:
                 x = sparse.block_diag([surf_rot] * 3)
-                fwd["sol_grad"]["data"] = fwd["_orig_sol_grad"] @ x  # dot prod
+                fwd["sol_grad"]["data"] = fwd["_orig_sol_grad"] @ x
                 fwd["sol_grad"]["ncol"] = 9 * fwd["nsource"]
             fwd["source_ori"] = FIFF.FIFFV_MNE_FREE_ORI
             fwd["surf_ori"] = True

--- a/mne/forward/forward.py
+++ b/mne/forward/forward.py
@@ -292,7 +292,7 @@ def _block_diag(A, n):
 
     Returns
     -------
-    bd : scipy.sparse.spmatrix
+    bd : scipy.sparse.csc_array
         The block diagonal matrix
     """
     if sparse.issparse(A):  # then make block sparse
@@ -311,7 +311,7 @@ def _block_diag(A, n):
     jj = jj * np.ones(ma, dtype=np.int64)[:, None]
     jj = jj.T.ravel()  # column indices foreach sparse bd
 
-    bd = sparse.coo_matrix((A.T.ravel(), np.c_[ii, jj].T)).tocsc()
+    bd = sparse.coo_array((A.T.ravel(), np.c_[ii, jj].T)).tocsc()
 
     return bd
 
@@ -797,11 +797,11 @@ def convert_forward_solution(
             fix_rot = _block_diag(fwd["source_nn"].T, 1)
             # newer versions of numpy require explicit casting here, so *= no
             # longer works
-            fwd["sol"]["data"] = (fwd["_orig_sol"] * fix_rot).astype("float32")
+            fwd["sol"]["data"] = (fwd["_orig_sol"] @ fix_rot).astype("float32")
             fwd["sol"]["ncol"] = fwd["nsource"]
             if fwd["sol_grad"] is not None:
                 x = sparse.block_diag([fix_rot] * 3)
-                fwd["sol_grad"]["data"] = fwd["_orig_sol_grad"] * x  # dot prod
+                fwd["sol_grad"]["data"] = fwd["_orig_sol_grad"] @ x
                 fwd["sol_grad"]["ncol"] = 3 * fwd["nsource"]
         fwd["source_ori"] = FIFF.FIFFV_MNE_FIXED_ORI
         fwd["surf_ori"] = True
@@ -828,7 +828,7 @@ def convert_forward_solution(
             fix_rot = _block_diag(fwd["source_nn"].T, 1)
             # newer versions of numpy require explicit casting here, so *= no
             # longer works
-            fwd["sol"]["data"] = (fwd["_orig_sol"] * fix_rot).astype("float32")
+            fwd["sol"]["data"] = (fwd["_orig_sol"] @ fix_rot).astype("float32")
             fwd["sol"]["ncol"] = fwd["nsource"]
             if fwd["sol_grad"] is not None:
                 x = sparse.block_diag([fix_rot] * 3)
@@ -838,11 +838,11 @@ def convert_forward_solution(
             fwd["surf_ori"] = True
         else:
             surf_rot = _block_diag(fwd["source_nn"].T, 3)
-            fwd["sol"]["data"] = fwd["_orig_sol"] * surf_rot
+            fwd["sol"]["data"] = fwd["_orig_sol"] @ surf_rot
             fwd["sol"]["ncol"] = 3 * fwd["nsource"]
             if fwd["sol_grad"] is not None:
                 x = sparse.block_diag([surf_rot] * 3)
-                fwd["sol_grad"]["data"] = fwd["_orig_sol_grad"] * x  # dot prod
+                fwd["sol_grad"]["data"] = fwd["_orig_sol_grad"] @ x  # dot prod
                 fwd["sol_grad"]["ncol"] = 9 * fwd["nsource"]
             fwd["source_ori"] = FIFF.FIFFV_MNE_FREE_ORI
             fwd["surf_ori"] = True

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -747,5 +747,5 @@ def test_eeglab_drop_nan_annotations(tmp_path):
         ch_types=np.repeat("EEG", len(ch_names)),
     )
 
-    with pytest.raises(RuntimeWarning, match="1 .* have an onset that is NaN.*"):
+    with pytest.warns(RuntimeWarning, match="1 .* have an onset that is NaN.*"):
         raw = read_raw_eeglab(file_path, preload=True)

--- a/mne/io/eyelink/tests/test_eyelink.py
+++ b/mne/io/eyelink/tests/test_eyelink.py
@@ -291,6 +291,7 @@ def test_basics(this_fname):
     _test_raw_reader(read_raw_eyelink, fname=this_fname, test_preloading=False)
 
 
+@requires_testing_data
 def test_annotations_without_offset(tmp_path):
     """Test read of annotations without offset."""
     out_file = tmp_path / "tmp_eyelink.asc"

--- a/mne/label.py
+++ b/mne/label.py
@@ -2573,7 +2573,7 @@ def _labels_to_stc_surf(labels, values, tmin, tstep, subject):
         cols = np.arange(len(vertices[hemi]))
         vertices[hemi], rows = np.unique(vertices[hemi], return_inverse=True)
         mat = sparse.coo_array((np.ones(len(rows)), (rows, cols))).tocsr()
-        mat = mat @ sparse.diags_array(1.0 / np.asarray(mat.sum(axis=-1)))
+        mat *= 1.0 / mat.sum(axis=-1)
         data[hemi] = mat @ data[hemi]
     vertices = [vertices[hemi] for hemi in hemis]
     data = np.concatenate([data[hemi] for hemi in hemis], axis=0)

--- a/mne/label.py
+++ b/mne/label.py
@@ -1673,7 +1673,7 @@ def _verts_within_dist(graph, sources, max_dist):
         verts_added = []
         for i in verts_added_last:
             v_dist = dist_map[i]
-            row = graph[i, :]
+            row = graph[[i], :]
             neighbor_vert = row.indices
             neighbor_dist = row.data
             for j, d in zip(neighbor_vert, neighbor_dist):
@@ -1914,7 +1914,7 @@ def _grow_nonoverlapping_labels(
             label, old_dist = sources[vert_from]
 
             # add neighbors within allowable distance
-            row = graph[vert_from, :]
+            row = graph[[vert_from], :]
             for vert_to, dist in zip(row.indices, row.data):
                 # Prevent adding a point that has already been used
                 # (prevents infinite loop)
@@ -2573,7 +2573,7 @@ def _labels_to_stc_surf(labels, values, tmin, tstep, subject):
         cols = np.arange(len(vertices[hemi]))
         vertices[hemi], rows = np.unique(vertices[hemi], return_inverse=True)
         mat = sparse.coo_array((np.ones(len(rows)), (rows, cols))).tocsr()
-        mat = mat @ sparse.diags_array(1.0 / np.asarray(mat.sum(axis=-1))[:, 0])
+        mat = mat @ sparse.diags_array(1.0 / np.asarray(mat.sum(axis=-1)))
         data[hemi] = mat @ data[hemi]
     vertices = [vertices[hemi] for hemi in hemis]
     data = np.concatenate([data[hemi] for hemi in hemis], axis=0)

--- a/mne/label.py
+++ b/mne/label.py
@@ -1648,7 +1648,7 @@ def _verts_within_dist(graph, sources, max_dist):
 
     Parameters
     ----------
-    graph : scipy.sparse.csr_matrix
+    graph : scipy.sparse.csr_array
         Sparse matrix with distances between adjacent vertices.
     sources : list of int
         Source vertices.
@@ -2572,9 +2572,9 @@ def _labels_to_stc_surf(labels, values, tmin, tstep, subject):
         data[hemi] = np.concatenate(data[hemi], axis=0).astype(float)
         cols = np.arange(len(vertices[hemi]))
         vertices[hemi], rows = np.unique(vertices[hemi], return_inverse=True)
-        mat = sparse.coo_matrix((np.ones(len(rows)), (rows, cols))).tocsr()
-        mat = mat * sparse.diags(1.0 / np.asarray(mat.sum(axis=-1))[:, 0])
-        data[hemi] = mat.dot(data[hemi])
+        mat = sparse.coo_array((np.ones(len(rows)), (rows, cols))).tocsr()
+        mat = mat @ sparse.diags_array(1.0 / np.asarray(mat.sum(axis=-1))[:, 0])
+        data[hemi] = mat @ data[hemi]
     vertices = [vertices[hemi] for hemi in hemis]
     data = np.concatenate([data[hemi] for hemi in hemis], axis=0)
     return data, vertices, subject

--- a/mne/minimum_norm/tests/test_inverse.py
+++ b/mne/minimum_norm/tests/test_inverse.py
@@ -145,7 +145,7 @@ def _compare(a, b):
             assert len(a) == len(b)
             for i, j in zip(a, b):
                 _compare(i, j)
-        elif isinstance(a, sparse.csr_matrix):
+        elif isinstance(a, sparse.csr_array):
             assert_array_almost_equal(a.data, b.data)
             assert_equal(a.indices, b.indices)
             assert_equal(a.indptr, b.indptr)

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -1394,7 +1394,7 @@ def _surf_upsampling_mat(idx_from, e, smooth):
         # compute row sums + output indices
         if recompute_idx_sum:
             if len(idx) == n_tot:
-                row_sum = np.asarray(e.sum(-1))[:, 0]
+                row_sum = np.asarray(e.sum(-1))
                 idx = np.arange(n_tot)
                 recompute_idx_sum = False
             else:

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -1338,6 +1338,15 @@ def _surf_nearest(vertices, adj_mat):
     # Vertices can be out of order, so sort them to start ...
     order = np.argsort(vertices)
     vertices = vertices[order]
+    # work around https://github.com/scipy/scipy/issues/20904
+    adj_mat = sparse.csr_array(
+        (
+            adj_mat.data,
+            adj_mat.indices.astype(np.int32),
+            adj_mat.indptr.astype(np.int32),
+        ),
+        shape=adj_mat.shape,
+    )
     _, _, sources = sparse.csgraph.dijkstra(
         adj_mat, False, indices=vertices, min_only=True, return_predecessors=True
     )

--- a/mne/morph.py
+++ b/mne/morph.py
@@ -658,7 +658,7 @@ class SourceMorph:
             for attr in attrs:
                 # transform from source space to mri_from resolution/space
                 if vols is None:
-                    img_real = interp[:, ii]
+                    img_real = interp[:, [ii]]
                 else:
                     img_real = interp @ getattr(vols[:, ii], attr)
                 _debug_img(img_real, from_affine, "From", src_shape)

--- a/mne/morph_map.py
+++ b/mne/morph_map.py
@@ -12,7 +12,7 @@
 import os
 
 import numpy as np
-from scipy.sparse import csr_matrix, eye
+from scipy.sparse import csr_array, eye_array
 
 from ._fiff.constants import FIFF
 from ._fiff.open import fiff_open
@@ -63,7 +63,7 @@ def read_morph_map(
 
     Returns
     -------
-    left_map, right_map : ~scipy.sparse.csr_matrix
+    left_map, right_map : ~scipy.sparse.csr_array
         The morph maps for the 2 hemispheres.
     """
     subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
@@ -213,7 +213,7 @@ def _make_morph_map_hemi(subject_from, subject_to, subjects_dir, reg_from, reg_t
     if subject_from == subject_to and reg_from == reg_to:
         fname = subjects_dir / subject_from / "surf" / reg_from
         n_pts = len(read_surface(fname, verbose=False)[0])
-        return eye(n_pts, n_pts, format="csr")
+        return eye_array(n_pts, n_pts, format="csr")
 
     # load surfaces and normalize points to be on unit sphere
     fname = subjects_dir / subject_from / "surf" / reg_from
@@ -244,7 +244,7 @@ def _make_morph_map_hemi(subject_from, subject_to, subjects_dir, reg_from, reg_t
     weights = np.array(weights)
 
     row_ind = np.repeat(np.arange(len(to_rr)), 3)
-    this_map = csr_matrix(
+    this_map = csr_array(
         (weights.ravel(), (row_ind, nn_idx.ravel())), shape=(len(to_rr), len(from_rr))
     )
     return this_map

--- a/mne/morph_map.py
+++ b/mne/morph_map.py
@@ -12,7 +12,7 @@
 import os
 
 import numpy as np
-from scipy.sparse import csr_array, eye_array
+from scipy.sparse import csr_array
 
 from ._fiff.constants import FIFF
 from ._fiff.open import fiff_open
@@ -26,6 +26,7 @@ from ._fiff.write import (
     write_int,
     write_string,
 )
+from .fixes import _eye_array
 from .surface import (
     _compute_nearest,
     _find_nearest_tri_pts,
@@ -213,7 +214,7 @@ def _make_morph_map_hemi(subject_from, subject_to, subjects_dir, reg_from, reg_t
     if subject_from == subject_to and reg_from == reg_to:
         fname = subjects_dir / subject_from / "surf" / reg_from
         n_pts = len(read_surface(fname, verbose=False)[0])
-        return eye_array(n_pts, n_pts, format="csr")
+        return _eye_array(n_pts, format="csr")
 
     # load surfaces and normalize points to be on unit sphere
     fname = subjects_dir / subject_from / "surf" / reg_from

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -881,15 +881,15 @@ def test_cross_talk(tmp_path):
         maxwell_filter(raw, cross_talk=raw_fname)
     mf_ctc = sss_ctc.info["proc_history"][0]["max_info"]["sss_ctc"]
     del mf_ctc["block_id"]  # we don't write this
-    assert isinstance(py_ctc["decoupler"], sparse.csc_matrix)
-    assert isinstance(mf_ctc["decoupler"], sparse.csc_matrix)
+    assert isinstance(py_ctc["decoupler"], sparse.csc_array)
+    assert isinstance(mf_ctc["decoupler"], sparse.csc_array)
     assert_array_equal(py_ctc["decoupler"].toarray(), mf_ctc["decoupler"].toarray())
     # I/O roundtrip
     fname = tmp_path / "test_sss_raw.fif"
     sss_ctc.save(fname)
     sss_ctc_read = read_raw_fif(fname)
     mf_ctc_read = sss_ctc_read.info["proc_history"][0]["max_info"]["sss_ctc"]
-    assert isinstance(mf_ctc_read["decoupler"], sparse.csc_matrix)
+    assert isinstance(mf_ctc_read["decoupler"], sparse.csc_array)
     assert_array_equal(
         mf_ctc_read["decoupler"].toarray(), mf_ctc["decoupler"].toarray()
     )

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -23,7 +23,7 @@ from .baseline import rescale
 from .cov import Covariance
 from .evoked import _get_peak
 from .filter import FilterMixin, _check_fun, resample
-from .fixes import _safe_svd
+from .fixes import _eye_array, _safe_svd
 from .parallel import parallel_func
 from .source_space._source_space import (
     SourceSpaces,
@@ -3186,7 +3186,7 @@ def spatio_temporal_tris_adjacency(tris, n_times, remap_vertices=False, verbose=
         tris = np.searchsorted(np.unique(tris), tris)
 
     edges = mesh_edges(tris)
-    edges = (edges + sparse.eye_array(edges.shape[0], format="csr")).tocoo()
+    edges = (edges + _eye_array(edges.shape[0])).tocoo()
     return _get_adjacency_from_edges(edges, n_times)
 
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -3470,7 +3470,7 @@ def _prepare_label_extraction(stc, labels, src, mode, allow_empty, use_sparse):
             # Efficiency shortcut: use linearity early to avoid redundant
             # calculations
             elif mode == "mean":
-                vertidx = sparse.csr_array(vertidx.mean(axis=0))
+                vertidx = sparse.csr_array(vertidx.mean(axis=0)[np.newaxis])
             label_vertidx.append(vertidx)
             label_flip.append(None)
             continue

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -3112,7 +3112,7 @@ def spatio_temporal_src_adjacency(src, n_times, dist=None, verbose=None):
 
     Returns
     -------
-    adjacency : ~scipy.sparse.coo_matrix
+    adjacency : ~scipy.sparse.coo_array
         The adjacency matrix describing the spatio-temporal
         graph structure. If N is the number of vertices in the
         source space, the N first nodes in the graph are the
@@ -3174,7 +3174,7 @@ def spatio_temporal_tris_adjacency(tris, n_times, remap_vertices=False, verbose=
 
     Returns
     -------
-    adjacency : ~scipy.sparse.coo_matrix
+    adjacency : ~scipy.sparse.coo_array
         The adjacency matrix describing the spatio-temporal
         graph structure. If N is the number of vertices in the
         source space, the N first nodes in the graph are the
@@ -3186,7 +3186,7 @@ def spatio_temporal_tris_adjacency(tris, n_times, remap_vertices=False, verbose=
         tris = np.searchsorted(np.unique(tris), tris)
 
     edges = mesh_edges(tris)
-    edges = (edges + sparse.eye(edges.shape[0], format="csr")).tocoo()
+    edges = (edges + sparse.eye_array(edges.shape[0], format="csr")).tocoo()
     return _get_adjacency_from_edges(edges, n_times)
 
 
@@ -3210,7 +3210,7 @@ def spatio_temporal_dist_adjacency(src, n_times, dist, verbose=None):
 
     Returns
     -------
-    adjacency : ~scipy.sparse.coo_matrix
+    adjacency : ~scipy.sparse.coo_array
         The adjacency matrix describing the spatio-temporal
         graph structure. If N is the number of vertices in the
         source space, the N first nodes in the graph are the
@@ -3255,7 +3255,7 @@ def spatial_src_adjacency(src, dist=None, verbose=None):
 
     Returns
     -------
-    adjacency : ~scipy.sparse.coo_matrix
+    adjacency : ~scipy.sparse.coo_array
         The adjacency matrix describing the spatial graph structure.
     """
     return spatio_temporal_src_adjacency(src, 1, dist)
@@ -3276,7 +3276,7 @@ def spatial_tris_adjacency(tris, remap_vertices=False, verbose=None):
 
     Returns
     -------
-    adjacency : ~scipy.sparse.coo_matrix
+    adjacency : ~scipy.sparse.coo_array
         The adjacency matrix describing the spatial graph structure.
     """
     return spatio_temporal_tris_adjacency(tris, 1, remap_vertices)
@@ -3300,7 +3300,7 @@ def spatial_dist_adjacency(src, dist, verbose=None):
 
     Returns
     -------
-    adjacency : ~scipy.sparse.coo_matrix
+    adjacency : ~scipy.sparse.coo_array
         The adjacency matrix describing the spatial graph structure.
     """
     return spatio_temporal_dist_adjacency(src, 1, dist)
@@ -3321,7 +3321,7 @@ def spatial_inter_hemi_adjacency(src, dist, verbose=None):
 
     Returns
     -------
-    adjacency : ~scipy.sparse.coo_matrix
+    adjacency : ~scipy.sparse.coo_array
         The adjacency matrix describing the spatial graph structure.
         Typically this should be combined (addititively) with another
         existing intra-hemispheric adjacency matrix, e.g. computed
@@ -3329,8 +3329,8 @@ def spatial_inter_hemi_adjacency(src, dist, verbose=None):
     """
     src = _ensure_src(src, kind="surface")
     adj = cdist(src[0]["rr"][src[0]["vertno"]], src[1]["rr"][src[1]["vertno"]])
-    adj = sparse.csr_matrix(adj <= dist, dtype=int)
-    empties = [sparse.csr_matrix((nv, nv), dtype=int) for nv in adj.shape]
+    adj = sparse.csr_array(adj <= dist, dtype=int)
+    empties = [sparse.csr_array((nv, nv), dtype=int) for nv in adj.shape]
     adj = sparse.vstack(
         [sparse.hstack([empties[0], adj]), sparse.hstack([adj.T, empties[1]])]
     )
@@ -3359,7 +3359,7 @@ def _get_adjacency_from_edges(edges, n_times, verbose=None):
     data = np.ones(
         edges.data.size * n_times + 2 * n_vertices * (n_times - 1), dtype=np.int64
     )
-    adjacency = sparse.coo_matrix((data, (row, col)), shape=(n_times * n_vertices,) * 2)
+    adjacency = sparse.coo_array((data, (row, col)), shape=(n_times * n_vertices,) * 2)
     return adjacency
 
 
@@ -3470,7 +3470,7 @@ def _prepare_label_extraction(stc, labels, src, mode, allow_empty, use_sparse):
             # Efficiency shortcut: use linearity early to avoid redundant
             # calculations
             elif mode == "mean":
-                vertidx = sparse.csr_matrix(vertidx.mean(axis=0))
+                vertidx = sparse.csr_array(vertidx.mean(axis=0))
             label_vertidx.append(vertidx)
             label_flip.append(None)
             continue
@@ -3725,7 +3725,7 @@ def _gen_extract_label_time_course(
             label_tc = np.zeros((n_labels,) + stc.data.shape[1:], dtype=stc.data.dtype)
         for i, (vertidx, flip) in enumerate(zip(label_vertidx, src_flip)):
             if vertidx is not None:
-                if isinstance(vertidx, sparse.csr_matrix):
+                if isinstance(vertidx, sparse.csr_array):
                     assert mri_resolution
                     assert vertidx.shape[1] == stc.data.shape[0]
                     this_data = np.reshape(stc.data, (stc.data.shape[0], -1))

--- a/mne/source_space/_source_space.py
+++ b/mne/source_space/_source_space.py
@@ -1403,7 +1403,9 @@ def _write_one_source_space(fid, this, verbose=None):
     if this["dist"] is not None:
         # Save only upper triangular portion of the matrix
         dists = this["dist"].copy()
-        dists = triu(dists, format=dists.format)
+        # Shouldn't need this cast but on SciPy 1.9.3 at least this returns a csr_matrix
+        # instead of csr_array
+        dists = csr_array(triu(dists, format=dists.format))
         write_float_sparse_rcs(fid, FIFF.FIFF_MNE_SOURCE_SPACE_DIST, dists)
         write_float_matrix(
             fid,

--- a/mne/source_space/_source_space.py
+++ b/mne/source_space/_source_space.py
@@ -13,7 +13,7 @@ from copy import deepcopy
 from functools import partial
 
 import numpy as np
-from scipy.sparse import csr_matrix, triu
+from scipy.sparse import csr_array, triu
 from scipy.sparse.csgraph import dijkstra
 from scipy.spatial.distance import cdist
 
@@ -191,7 +191,7 @@ class SourceSpaces(list):
             The number of triangles in the subsampled surface.
         use_tris : ndarray, shape (nuse_tri, 3)
             The subsampled surface triangulation.
-        dist : scipy.sparse.csr_matrix, shape (n_src, n_src) | None
+        dist : scipy.sparse.csr_array, shape (n_src, n_src) | None
             The distances (euclidean for volume, along the cortical surface for
             surfaces) between source points.
         dist_limit : float
@@ -262,7 +262,7 @@ class SourceSpaces(list):
             The MRI dimensions (in voxels).
         neighbor_vert : ndarray
             The 26-neighborhood information for each vertex.
-        interpolator : scipy.sparse.csr_matrix | None
+        interpolator : scipy.sparse.csr_array | None
             The linear interpolator to go from the subsampled volume vertices
             to the high-resolution volume.
         shape : tuple of int
@@ -1378,7 +1378,7 @@ def _write_one_source_space(fid, this, verbose=None):
         mri_width, mri_height, mri_depth, nvox = _src_vol_dims(this)
         interpolator = this.get("interpolator")
         if interpolator is None:
-            interpolator = csr_matrix((nvox, this["np"]))
+            interpolator = csr_array((nvox, this["np"]))
         write_float_sparse_rcs(
             fid, FIFF.FIFF_MNE_SOURCE_SPACE_INTERPOLATOR, interpolator
         )
@@ -2356,7 +2356,7 @@ def _add_interpolator(sp):
         order=1,
         inuse=inuse,
     )
-    assert isinstance(interp, csr_matrix)
+    assert isinstance(interp, csr_array)
 
     # Compose the sparse matrices
     for si, s in enumerate(sp):
@@ -2381,7 +2381,7 @@ def _add_interpolator(sp):
             indices = interp.indices[mask]
             data = interp.data[mask]
             assert data.shape == indices.shape == (indptr[-1],)
-            this_interp = csr_matrix((data, indices, indptr), shape=interp.shape)
+            this_interp = csr_array((data, indices, indptr), shape=interp.shape)
         s["interpolator"] = this_interp
         logger.info(
             "    %d/%d nonzero values for %s"
@@ -2406,7 +2406,7 @@ def _grid_interp(from_shape, to_shape, trans, order=1, inuse=None):
     data = np.concatenate(data)
     indices = np.concatenate(indices)
     indptr = np.cumsum(indptr)
-    interp = csr_matrix((data, indices, indptr), shape=shape)
+    interp = csr_array((data, indices, indptr), shape=shape)
     return interp
 
 
@@ -2748,7 +2748,7 @@ def add_source_space_distances(src, dist_limit=np.inf, n_jobs=None, *, verbose=N
             i, j = np.meshgrid(s["vertno"], s["vertno"])
             i = i.ravel()[idx]
             j = j.ravel()[idx]
-            s["dist"] = csr_matrix(
+            s["dist"] = csr_array(
                 (d, (i, j)), shape=(s["np"], s["np"]), dtype=np.float32
             )
             s["dist_limit"] = np.array([dist_limit], np.float32)

--- a/mne/stats/_adjacency.py
+++ b/mne/stats/_adjacency.py
@@ -19,7 +19,7 @@ def combine_adjacency(*structure):
     *structure : list
         The adjacency along each dimension. Each entry can be:
 
-        - ndarray or scipy.sparse.spmatrix
+        - ndarray or scipy.sparse.sparray
             A square binary adjacency matrix for the given dimension.
             For example created by :func:`mne.channels.find_ch_adjacency`.
         - int
@@ -56,7 +56,7 @@ def combine_adjacency(*structure):
     ...     np.zeros((n_freqs, n_freqs)),  # no adjacency between freq. bins
     ...     chan_adj,  # custom matrix, or use mne.channels.find_ch_adjacency
     ...     )  # doctest: +SKIP
-    <5600x5600 sparse matrix of type '<class 'numpy.float64'>'
+    <5600x5600 sparse array of type '<class 'numpy.float64'>'
             with 27076 stored elements in COOrdinate format>
     """
     structure = list(structure)
@@ -65,7 +65,7 @@ def combine_adjacency(*structure):
         _validate_type(dim, ("int-like", np.ndarray, sparse.spmatrix), name)
         if isinstance(dim, int_like):
             # Don't add the diagonal, because we explicitly remove it later
-            dim = sparse.diags(
+            dim = sparse.diags_array(
                 [1, 1], offsets=(-1, 1), shape=(int(dim), int(dim)), dtype=float
             ).tocoo()
         else:

--- a/mne/stats/_adjacency.py
+++ b/mne/stats/_adjacency.py
@@ -65,8 +65,9 @@ def combine_adjacency(*structure):
         _validate_type(dim, ("int-like", np.ndarray, sparse.spmatrix), name)
         if isinstance(dim, int_like):
             # Don't add the diagonal, because we explicitly remove it later
-            dim = sparse.diags_array(
-                [1, 1], offsets=(-1, 1), shape=(int(dim), int(dim)), dtype=float
+            dim = sparse.dia_array(
+                (np.ones((2, dim)), [-1, 1]),
+                shape=(dim, dim),
             ).tocoo()
         else:
             _check_option(f"{name}.ndim", dim.ndim, [2])

--- a/mne/stats/_adjacency.py
+++ b/mne/stats/_adjacency.py
@@ -30,7 +30,7 @@ def combine_adjacency(*structure):
 
     Returns
     -------
-    adjacency : scipy.sparse.coo_matrix, shape (n_features, n_features)
+    adjacency : scipy.sparse.coo_array, shape (n_features, n_features)
         The square adjacency matrix, where the shape ``n_features``
         corresponds to the product of the length of all dimensions.
         For example ``len(times) * len(freqs) * len(chans)``.
@@ -72,8 +72,8 @@ def combine_adjacency(*structure):
             _check_option(f"{name}.ndim", dim.ndim, [2])
             if dim.shape[0] != dim.shape[1]:
                 raise ValueError(f"{name} must be square, got shape {dim.shape}")
-            if not isinstance(dim, sparse.coo_matrix):
-                dim = sparse.coo_matrix(dim)
+            if not isinstance(dim, sparse.coo_array):
+                dim = sparse.coo_array(dim)
             else:
                 dim = dim.copy()
         dim.data[dim.row == dim.col] = 0.0  # remove diagonal, will add later
@@ -82,7 +82,7 @@ def combine_adjacency(*structure):
             raise ValueError("All adjacency values must be 0 or 1")
         structure[di] = dim
     # list of coo
-    assert all(isinstance(dim, sparse.coo_matrix) for dim in structure)
+    assert all(isinstance(dim, sparse.coo_array) for dim in structure)
     shape = np.array([d.shape[0] for d in structure], int)
     n_others = np.array(
         [
@@ -115,5 +115,5 @@ def combine_adjacency(*structure):
     # Handle the diagonal separately at the end to avoid duplicate entries
     edges[:, n_off:] = vertices.ravel()
     weights[n_off:] = 1.0
-    graph = sparse.coo_matrix((weights, edges), (vertices.size, vertices.size))
+    graph = sparse.coo_array((weights, edges), (vertices.size, vertices.size))
     return graph

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -549,7 +549,7 @@ def _find_clusters_1dir(x, x_in, adjacency, max_step, t_power, ndimage):
             )
         if isinstance(adjacency, sparse.spmatrix):
             adjacency = sparse.coo_array(adjacency)
-        if isinstance(adjacency, sparse.sparray) or adjacency is False:
+        if sparse.issparse(adjacency) or adjacency is False:
             clusters = _get_components(x_in, adjacency)
         elif isinstance(adjacency, list):  # use temporal adjacency
             clusters = _get_clusters_st(x_in, adjacency, max_step)

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -547,12 +547,16 @@ def _find_clusters_1dir(x, x_in, adjacency, max_step, t_power, ndimage):
             raise Exception(
                 "Data should be 1D when using a adjacency to define clusters."
             )
-        if isinstance(adjacency, sparse.spmatrix) or adjacency is False:
+        if isinstance(adjacency, sparse.spmatrix):
+            adjacency = sparse.coo_array(adjacency)
+        if isinstance(adjacency, sparse.sparray) or adjacency is False:
             clusters = _get_components(x_in, adjacency)
         elif isinstance(adjacency, list):  # use temporal adjacency
             clusters = _get_clusters_st(x_in, adjacency, max_step)
         else:
-            raise ValueError("adjacency must be a sparse matrix or list")
+            raise TypeError(
+                f"adjacency must be a sparse array or list, got {type(adjacency)}"
+            )
         if t_power == 1:
             sums = [_masked_sum(x, c) for c in clusters]
         else:

--- a/mne/stats/cluster_level.py
+++ b/mne/stats/cluster_level.py
@@ -306,7 +306,7 @@ def _get_components(x_in, adjacency, return_list=True):
         row = np.concatenate((row, idx))
         col = np.concatenate((col, idx))
         data = np.concatenate((data, np.ones(len(idx), dtype=data.dtype)))
-        adjacency = sparse.coo_matrix((data, (row, col)), shape=shape)
+        adjacency = sparse.coo_array((data, (row, col)), shape=shape)
         _, components = connected_components(adjacency)
     if return_list:
         start = np.min(components)
@@ -348,7 +348,7 @@ def _find_clusters(
         threshold-free cluster enhancement.
     tail : -1 | 0 | 1
         Type of comparison
-    adjacency : scipy.sparse.coo_matrix, None, or list
+    adjacency : scipy.sparse.coo_array, None, or list
         Defines adjacency between features. The matrix is assumed to
         be symmetric and only the upper triangular half is used.
         If adjacency is a list, it is assumed that each entry stores the
@@ -1606,7 +1606,7 @@ def _get_partitions_from_adjacency(adjacency, n_times, verbose=None):
         test_adj = np.zeros((len(adjacency), len(adjacency)), dtype="bool")
         for vi in range(len(adjacency)):
             test_adj[adjacency[vi], vi] = True
-        test_adj = sparse.coo_matrix(test_adj, dtype="float")
+        test_adj = sparse.coo_array(test_adj, dtype="float")
     else:
         test = np.ones(adjacency.shape[0])
         test_adj = adjacency

--- a/mne/stats/tests/test_cluster_level.py
+++ b/mne/stats/tests/test_cluster_level.py
@@ -376,7 +376,7 @@ def test_cluster_permutation_with_adjacency(numba_conditional, monkeypatch):
             assert np.all(a[b])
 
         # test spatio-temporal w/o time adjacency (repeat spatial pattern)
-        adjacency_2 = sparse.coo_matrix(
+        adjacency_2 = sparse.coo_array(
             linalg.block_diag(
                 adjacency.asfptype().todense(), adjacency.asfptype().todense()
             )

--- a/mne/stats/tests/test_permutations.py
+++ b/mne/stats/tests/test_permutations.py
@@ -6,8 +6,9 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
-from scipy import sparse, stats
+from scipy import stats
 
+from mne.fixes import _eye_array
 from mne.stats import permutation_cluster_1samp_test
 from mne.stats.permutations import (
     _ci,
@@ -48,7 +49,7 @@ def test_permutation_t_test():
     assert_array_equal(is_significant, [True, True, False, False, False])
 
     # check equivalence with spatio_temporal_cluster_test
-    for adjacency in (sparse.eye_array(n_tests), False):
+    for adjacency in (_eye_array(n_tests), False):
         t_obs_clust, _, p_values_clust, _ = permutation_cluster_1samp_test(
             X, n_permutations=999, seed=0, adjacency=adjacency, out_type="mask"
         )

--- a/mne/stats/tests/test_permutations.py
+++ b/mne/stats/tests/test_permutations.py
@@ -48,7 +48,7 @@ def test_permutation_t_test():
     assert_array_equal(is_significant, [True, True, False, False, False])
 
     # check equivalence with spatio_temporal_cluster_test
-    for adjacency in (sparse.eye(n_tests), False):
+    for adjacency in (sparse.eye_array(n_tests), False):
         t_obs_clust, _, p_values_clust, _ = permutation_cluster_1samp_test(
             X, n_permutations=999, seed=0, adjacency=adjacency, out_type="mask"
         )

--- a/mne/surface.py
+++ b/mne/surface.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import numpy as np
 from scipy.ndimage import binary_dilation
-from scipy.sparse import coo_matrix, csr_matrix
+from scipy.sparse import coo_array, csr_array
 from scipy.spatial import ConvexHull, Delaunay
 from scipy.spatial.distance import cdist
 
@@ -398,7 +398,7 @@ def _triangle_neighbors(tris, npts):
     rows = tris.ravel()
     cols = np.repeat(np.arange(len(tris)), 3)
     data = np.ones(len(cols))
-    csr = coo_matrix((data, (rows, cols)), shape=(npts, len(tris))).tocsr()
+    csr = coo_array((data, (rows, cols)), shape=(npts, len(tris))).tocsr()
     neighbor_tri = [
         csr.indices[start:stop] for start, stop in zip(csr.indptr[:-1], csr.indptr[1:])
     ]
@@ -1725,7 +1725,7 @@ def _mesh_edges(tris=None):
     a, b, c = tris.T
     x = np.concatenate((a, b, c))
     y = np.concatenate((b, c, a))
-    edges = coo_matrix((ones_ntris, (x, y)), shape=(npoints, npoints))
+    edges = coo_array((ones_ntris, (x, y)), shape=(npoints, npoints))
     edges = edges.tocsr()
     edges = edges + edges.T
     return edges
@@ -1746,14 +1746,14 @@ def mesh_dist(tris, vert):
 
     Returns
     -------
-    dist_matrix : scipy.sparse.csr_matrix
+    dist_matrix : scipy.sparse.csr_array
         Sparse matrix with distances between adjacent vertices.
     """
     edges = mesh_edges(tris).tocoo()
 
     # Euclidean distances between neighboring vertices
     dist = np.linalg.norm(vert[edges.row, :] - vert[edges.col, :], axis=1)
-    dist_matrix = csr_matrix((dist, (edges.row, edges.col)), shape=edges.shape)
+    dist_matrix = csr_array((dist, (edges.row, edges.col)), shape=edges.shape)
     return dist_matrix
 
 

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -19,7 +19,6 @@ from numpy.testing import (
     assert_array_less,
     assert_equal,
 )
-from scipy import sparse
 
 from mne import (
     grow_labels,
@@ -37,6 +36,7 @@ from mne import (
     write_labels_to_annot,
 )
 from mne.datasets import testing
+from mne.fixes import _eye_array
 from mne.label import (
     Label,
     _blend_colors,
@@ -131,7 +131,7 @@ def _stc_to_label(stc, src, smooth, subjects_dir=None):
         e = mesh_edges(this_tris)
         e.data[e.data == 2] = 1
         n_vertices = e.shape[0]
-        e = e + sparse.eye_array(n_vertices, n_vertices)
+        e = e + _eye_array(n_vertices)
 
         clusters = [this_vertno[np.any(this_data, axis=1)]]
 
@@ -148,7 +148,7 @@ def _stc_to_label(stc, src, smooth, subjects_dir=None):
                 idx_use = c
                 for k in range(smooth):
                     e_use = e[:, idx_use]
-                    data1 = e_use * np.ones(len(idx_use))
+                    data1 = e_use @ np.ones(len(idx_use))
                     idx_use = np.where(data1)[0]
 
                 label = Label(

--- a/mne/tests/test_label.py
+++ b/mne/tests/test_label.py
@@ -131,7 +131,7 @@ def _stc_to_label(stc, src, smooth, subjects_dir=None):
         e = mesh_edges(this_tris)
         e.data[e.data == 2] = 1
         n_vertices = e.shape[0]
-        e = e + sparse.eye(n_vertices, n_vertices)
+        e = e + sparse.eye_array(n_vertices, n_vertices)
 
         clusters = [this_vertno[np.any(this_data, axis=1)]]
 

--- a/mne/tests/test_morph.py
+++ b/mne/tests/test_morph.py
@@ -7,7 +7,7 @@ from inspect import signature
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal, assert_array_less
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from scipy.sparse import eye as speye
 from scipy.spatial.distance import cdist
 
@@ -671,7 +671,7 @@ def test_volume_source_morph_round_trip(
         morph_to_from.compute_vol_morph_mat(verbose=True)
         morph_to_from.save(fname, overwrite=True)
         morph_to_from = read_source_morph(fname)
-        assert isinstance(morph_to_from.vol_morph_mat, csr_matrix), "csr"
+        assert isinstance(morph_to_from.vol_morph_mat, csr_array), "csr"
         # equivalence (plus automatic calling)
         assert morph_from_to.vol_morph_mat is None
         monkeypatch.setattr(mne.morph, "_VOL_MAT_CHECK_RATIO", 0.0)
@@ -680,7 +680,7 @@ def test_volume_source_morph_round_trip(
                 stc_from_rt_lin = morph_to_from.apply(
                     morph_from_to.apply(stc_from, verbose="debug")
                 )
-        assert isinstance(morph_from_to.vol_morph_mat, csr_matrix), "csr"
+        assert isinstance(morph_from_to.vol_morph_mat, csr_array), "csr"
         log = log.getvalue()
         assert "sparse volume morph matrix" in log
         assert_allclose(stc_from_rt.data, stc_from_rt_lin.data)

--- a/mne/tests/test_morph_map.py
+++ b/mne/tests/test_morph_map.py
@@ -59,4 +59,4 @@ def test_make_morph_maps(tmp_path):
     with _record_warnings():
         mmap = read_morph_map("sample", "sample", subjects_dir=tmp_path)
     for mm in mmap:
-        assert (mm - sparse.eye(mm.shape[0], mm.shape[0])).sum() == 0
+        assert (mm - sparse.eye_array(mm.shape[0], mm.shape[0])).sum() == 0

--- a/mne/tests/test_morph_map.py
+++ b/mne/tests/test_morph_map.py
@@ -9,10 +9,10 @@ from shutil import copyfile
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-from scipy import sparse
 
 from mne import read_morph_map
 from mne.datasets import testing
+from mne.fixes import _eye_array
 from mne.utils import _record_warnings, catch_logging
 
 data_path = testing.data_path(download=False)
@@ -59,4 +59,4 @@ def test_make_morph_maps(tmp_path):
     with _record_warnings():
         mmap = read_morph_map("sample", "sample", subjects_dir=tmp_path)
     for mm in mmap:
-        assert (mm - sparse.eye_array(mm.shape[0], mm.shape[0])).sum() == 0
+        assert (mm - _eye_array(mm.shape[0])).sum() == 0

--- a/mne/tests/test_source_estimate.py
+++ b/mne/tests/test_source_estimate.py
@@ -1607,7 +1607,7 @@ def test_vol_adjacency():
     n_vertices = vol[0]["inuse"].sum()
     assert_equal(adjacency.shape, (n_vertices, n_vertices))
     assert np.all(adjacency.data == 1)
-    assert isinstance(adjacency, sparse.coo_matrix)
+    assert isinstance(adjacency, sparse.coo_array)
 
     adjacency2 = spatio_temporal_src_adjacency(vol, n_times=2)
     assert_equal(adjacency2.shape, (2 * n_vertices, 2 * n_vertices))

--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -647,7 +647,7 @@ def object_hash(x, h=None):
         object_hash(_dt_to_stamp(x))
     elif sparse.issparse(x):
         h.update(str(type(x)).encode("utf-8"))
-        if not isinstance(x, (sparse.csr_matrix, sparse.csc_matrix)):
+        if not isinstance(x, (sparse.csr_array, sparse.csc_array)):
             raise RuntimeError(f"Unsupported sparse type {type(x)}")
         h.update(x.data.tobytes())
         h.update(x.indices.tobytes())

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -8,11 +8,11 @@ from pathlib import Path
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
-from scipy import sparse
 
 from mne import pick_types, read_cov, read_evokeds
 from mne._fiff.pick import _picks_by_type
 from mne.epochs import make_fixed_length_epochs
+from mne.fixes import _eye_array
 from mne.io import read_raw_fif
 from mne.time_frequency import tfr_morlet
 from mne.utils import (
@@ -314,8 +314,8 @@ def test_object_size():
         (150, 500, np.ones(20)),
         (30, 400, dict()),
         (400, 1000, dict(a=np.ones(50))),
-        (200, 900, sparse.eye_array(20, format="csc")),
-        (200, 900, sparse.eye_array(20, format="csr")),
+        (200, 900, _eye_array(20, format="csc")),
+        (200, 900, _eye_array(20, format="csr")),
     ):
         size = object_size(obj)
         assert lower < size < upper, f"{lower} < {size} < {upper}:\n{obj}"
@@ -416,14 +416,14 @@ def test_hash():
     pytest.raises(RuntimeError, object_diff, d1, d2)
     pytest.raises(RuntimeError, object_hash, d1)
 
-    x = sparse.eye_array(2, 2, format="csc")
-    y = sparse.eye_array(2, 2, format="csr")
+    x = _eye_array(2, format="csc")
+    y = _eye_array(2, format="csr")
     assert "type mismatch" in object_diff(x, y)
-    y = sparse.eye_array(2, 2, format="csc")
+    y = _eye_array(2, format="csc")
     assert len(object_diff(x, y)) == 0
     y[1, 1] = 2
     assert "elements" in object_diff(x, y)
-    y = sparse.eye_array(3, 3, format="csc")
+    y = _eye_array(3, format="csc")
     assert "shape" in object_diff(x, y)
     y = 0
     assert "type mismatch" in object_diff(x, y)
@@ -604,10 +604,10 @@ def test_custom_lru_cache():
     assert my_fun(1, np.array([2]), 3) == "int, ndarray, int"
     assert n_calls == [2, 1]
     assert len(_LRU_CACHES[fun_hash]) == 2
-    assert my_fun_2(1, sparse.eye_array(1, format="csc")) == "int, csc_array"
+    assert my_fun_2(1, _eye_array(1, format="csc")) == "int, csc_array"
     assert n_calls == [2, 2]
     assert len(_LRU_CACHES[fun_2_hash]) == 1  # other got popped
     # we could add support for this eventually, but don't bother for now
     with pytest.raises(RuntimeError, match="Unsupported sparse type"):
-        my_fun_2(1, sparse.eye_array(1, format="coo"))
+        my_fun_2(1, _eye_array(1, format="coo"))
     assert n_calls == [2, 2]  # never did any computation

--- a/mne/utils/tests/test_numerics.py
+++ b/mne/utils/tests/test_numerics.py
@@ -314,8 +314,8 @@ def test_object_size():
         (150, 500, np.ones(20)),
         (30, 400, dict()),
         (400, 1000, dict(a=np.ones(50))),
-        (200, 900, sparse.eye(20, format="csc")),
-        (200, 900, sparse.eye(20, format="csr")),
+        (200, 900, sparse.eye_array(20, format="csc")),
+        (200, 900, sparse.eye_array(20, format="csr")),
     ):
         size = object_size(obj)
         assert lower < size < upper, f"{lower} < {size} < {upper}:\n{obj}"
@@ -416,14 +416,14 @@ def test_hash():
     pytest.raises(RuntimeError, object_diff, d1, d2)
     pytest.raises(RuntimeError, object_hash, d1)
 
-    x = sparse.eye(2, 2, format="csc")
-    y = sparse.eye(2, 2, format="csr")
+    x = sparse.eye_array(2, 2, format="csc")
+    y = sparse.eye_array(2, 2, format="csr")
     assert "type mismatch" in object_diff(x, y)
-    y = sparse.eye(2, 2, format="csc")
+    y = sparse.eye_array(2, 2, format="csc")
     assert len(object_diff(x, y)) == 0
     y[1, 1] = 2
     assert "elements" in object_diff(x, y)
-    y = sparse.eye(3, 3, format="csc")
+    y = sparse.eye_array(3, 3, format="csc")
     assert "shape" in object_diff(x, y)
     y = 0
     assert "type mismatch" in object_diff(x, y)
@@ -604,10 +604,10 @@ def test_custom_lru_cache():
     assert my_fun(1, np.array([2]), 3) == "int, ndarray, int"
     assert n_calls == [2, 1]
     assert len(_LRU_CACHES[fun_hash]) == 2
-    assert my_fun_2(1, sparse.eye(1, format="csc")) == "int, csc_matrix"
+    assert my_fun_2(1, sparse.eye_array(1, format="csc")) == "int, csc_array"
     assert n_calls == [2, 2]
     assert len(_LRU_CACHES[fun_2_hash]) == 1  # other got popped
     # we could add support for this eventually, but don't bother for now
     with pytest.raises(RuntimeError, match="Unsupported sparse type"):
-        my_fun_2(1, sparse.eye(1, format="coo"))
+        my_fun_2(1, sparse.eye_array(1, format="coo"))
     assert n_calls == [2, 2]  # never did any computation

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -19,7 +19,7 @@ from io import BytesIO
 
 import numpy as np
 from scipy.interpolate import interp1d
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from scipy.spatial.distance import cdist
 
 from ..._fiff.meas_info import Info
@@ -1100,7 +1100,7 @@ class Brain:
                 vertices = hemi_data["vertices"]
                 if hemi == "vol":
                     assert smooth_mat is None
-                    smooth_mat = csr_matrix(
+                    smooth_mat = csr_array(
                         (np.ones(len(vertices)), (vertices, np.arange(len(vertices))))
                     )
                 self.act_data_smooth[hemi] = (act_data, smooth_mat)

--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1534,7 +1534,7 @@ class Brain:
                 xfm["trans"][:3, 3] *= 1000.0
             ijk = np.unravel_index(vertex_id, self._data[hemi]["grid_shape"], order="F")
             src_mri_t = self._data[hemi]["grid_src_mri_t"]
-            mni = apply_trans(np.dot(xfm["trans"], src_mri_t), ijk)
+            mni = apply_trans(xfm["trans"] @ src_mri_t, ijk)
         else:
             hemi_str = "L" if hemi == "lh" else "R"
             try:
@@ -1553,7 +1553,7 @@ class Brain:
         label = f"{hemi_str}:{str(vertex_id).ljust(6)}{mni}"
         act_data, smooth = self.act_data_smooth[hemi]
         if smooth is not None:
-            act_data = smooth[vertex_id].dot(act_data)[0]
+            act_data = (smooth[[vertex_id]] @ act_data)[0]
         else:
             act_data = act_data[vertex_id].copy()
         line = self.mpl_canvas.plot(

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -3809,7 +3809,7 @@ def plot_ch_adjacency(info, adjacency, ch_names, kind="2d", edit=False):
         path_collection[0].set_zorder(10)
 
         # scale node size with number of connections
-        n_connections = [np.sum(adjacency[i]) - 1 for i in range(adjacency.shape[0])]
+        n_connections = [np.sum(adjacency[[i]]) - 1 for i in range(adjacency.shape[0])]
         node_size = [max(x, 3) ** 2.5 for x in n_connections]
         path_collection[0].set_sizes(node_size)
     else:
@@ -3825,7 +3825,7 @@ def plot_ch_adjacency(info, adjacency, ch_names, kind="2d", edit=False):
     n_channels = adjacency.shape[0]
     for ch_idx in range(n_channels):
         # make sure we don't repeat channels
-        row = adjacency[ch_idx, ch_idx + 1 :]
+        row = adjacency[[ch_idx], ch_idx + 1 :]
         if has_sparse:
             ch_neighbours = row.nonzero()[1]
         else:
@@ -3921,7 +3921,7 @@ def _onpick_ch_adjacency(
 
             # update node sizes
             n_connections = [
-                np.sum(adjacency[idx]) - 1 + n_conn_change for idx in both_nodes
+                np.sum(adjacency[[idx]]) - 1 + n_conn_change for idx in both_nodes
             ]
             for idx, n_conn in zip(both_nodes, n_connections):
                 node_size[idx] = max(n_conn, 3) ** 2.5

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -23,7 +23,7 @@ from scipy.interpolate import (
     LinearNDInterpolator,
     NearestNDInterpolator,
 )
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from scipy.spatial import Delaunay, Voronoi
 from scipy.spatial.distance import pdist, squareform
 
@@ -3769,8 +3769,8 @@ def plot_ch_adjacency(info, adjacency, ch_names, kind="2d", edit=False):
     import matplotlib.pyplot as plt
 
     _validate_type(info, Info, "info")
-    _validate_type(adjacency, (np.ndarray, csr_matrix), "adjacency")
-    has_sparse = isinstance(adjacency, csr_matrix)
+    _validate_type(adjacency, (np.ndarray, csr_array), "adjacency")
+    has_sparse = isinstance(adjacency, csr_array)
 
     if edit and kind == "3d":
         raise ValueError("Editing a 3d adjacency plot is not supported.")

--- a/tools/environment_minimal.yml
+++ b/tools/environment_minimal.yml
@@ -1,0 +1,15 @@
+name: mne
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.9
+  - pip
+  - numpy
+  - scipy
+  - matplotlib
+  - tqdm
+  - pooch
+  - decorator
+  - packaging
+  - jinja2
+  - lazy_loader

--- a/tools/environment_old.yml
+++ b/tools/environment_old.yml
@@ -1,0 +1,17 @@
+name: mne
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9
+  - numpy=1.23
+  - scipy=1.9
+  - matplotlib=3.6
+  - pandas=1.3.2
+  - scikit-learn=1.1
+  - nibabel  # whichever one works
+  - tqdm
+  - pooch
+  - decorator
+  - packaging
+  - jinja2
+  - lazy_loader

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -8,17 +8,18 @@ INSTALL_ARGS="-e"
 INSTALL_KIND="test_extra,hdf5"
 if [ ! -z "$CONDA_ENV" ]; then
 	echo "Uninstalling MNE for CONDA_ENV=${CONDA_ENV}"
-	conda remove -c conda-forge --force -yq mne-base
-	python -m pip uninstall -y mne
-	if [[ "${RUNNER_OS}" != "Windows" ]]; then
+	# This will fail if mne-base is not in the env (like in our minimial/old envs, so ||true them):
+	conda remove -c conda-forge --force -yq mne-base || true
+	python -m pip uninstall -y mne || true
+	# If using bare environment.yml and not on windows, do a non-editable install
+	if [[ "${RUNNER_OS}" != "Windows" ]] && [[ "${CONDA_ENV}" != "environment_"* ]]; then
 		INSTALL_ARGS=""
 	fi
-elif [ ! -z "$CONDA_DEPENDENCIES" ]; then
-	echo "Using Mamba to install CONDA_DEPENDENCIES=${CONDA_DEPENDENCIES}"
-	mamba install -y $CONDA_DEPENDENCIES
-	# for compat_minimal and compat_old, we don't want to --upgrade
-	STD_ARGS="--progress-bar off"
-	INSTALL_KIND="test"
+	# If on minimal or old, just install testing deps
+	if [[ "${CONDA_ENV}" == "environment_"* ]]; then
+		INSTALL_KIND="test"
+		STD_ARGS="--progress-bar off"
+	fi
 else
 	test "${MNE_CI_KIND}" == "pip-pre"
 	STD_ARGS="$STD_ARGS --pre"

--- a/tools/github_actions_env_vars.sh
+++ b/tools/github_actions_env_vars.sh
@@ -18,6 +18,7 @@ else  # conda-like
     else  # conda, mamba (use warning level for completeness)
         echo "CONDA_ENV=environment.yml" >> $GITHUB_ENV
         echo "MNE_LOGGING_LEVEL=warning" >> $GITHUB_ENV
+    fi
     echo "MNE_QT_BACKEND=PyQt5" >> $GITHUB_ENV
 fi
 set +x

--- a/tools/github_actions_env_vars.sh
+++ b/tools/github_actions_env_vars.sh
@@ -2,25 +2,22 @@
 set -eo pipefail -x
 
 # old and minimal use conda
-if [[ "$MNE_CI_KIND" == "old" ]]; then
-    echo "Setting conda env vars for old"
-    echo "CONDA_DEPENDENCIES=numpy=1.23 scipy=1.9 matplotlib=3.6 pandas=1.3.2 scikit-learn=1.1" >> $GITHUB_ENV
-    echo "MNE_IGNORE_WARNINGS_IN_TESTS=true" >> $GITHUB_ENV
-    echo "MNE_SKIP_NETWORK_TESTS=1" >> $GITHUB_ENV
-    echo "MNE_QT_BACKEND=PyQt5" >> $GITHUB_ENV
-elif [[ "$MNE_CI_KIND" == "minimal" ]]; then
-    echo "Setting conda env vars for minimal"
-    echo "CONDA_DEPENDENCIES=numpy scipy matplotlib" >> $GITHUB_ENV
-    echo "MNE_QT_BACKEND=PyQt5" >> $GITHUB_ENV
-elif [[ "$MNE_CI_KIND" != "pip"* ]]; then  # conda, mamba (use warning level for completeness)
-    echo "Setting conda env vars for $MNE_CI_KIND"
-    echo "CONDA_ENV=environment.yml" >> $GITHUB_ENV
-    echo "MNE_QT_BACKEND=PyQt5" >> $GITHUB_ENV
-    echo "MNE_LOGGING_LEVEL=warning" >> $GITHUB_ENV
-else  # pip-like
+if [[ "$MNE_CI_KIND" == "pip"* ]]; then
     echo "Setting pip env vars for $MNE_CI_KIND"
     echo "MNE_QT_BACKEND=PyQt6" >> $GITHUB_ENV
     # We should test an eager import somewhere, might as well be here
     echo "EAGER_IMPORT=true" >> $GITHUB_ENV
+else  # conda-like
+    echo "Setting conda env vars for $MNE_CI_KIND"
+    if [[ "$MNE_CI_KIND" == "old" ]]; then
+        echo "CONDA_ENV=tools/environment_old.yml" >> $GITHUB_ENV
+        echo "MNE_IGNORE_WARNINGS_IN_TESTS=true" >> $GITHUB_ENV
+        echo "MNE_SKIP_NETWORK_TESTS=1" >> $GITHUB_ENV
+    elif [[ "$MNE_CI_KIND" == "minimal" ]]; then
+        echo "CONDA_ENV=tools/environment_minimal.yml" >> $GITHUB_ENV
+    else  # conda, mamba (use warning level for completeness)
+        echo "CONDA_ENV=environment.yml" >> $GITHUB_ENV
+        echo "MNE_LOGGING_LEVEL=warning" >> $GITHUB_ENV
+    echo "MNE_QT_BACKEND=PyQt5" >> $GITHUB_ENV
 fi
 set +x

--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -46,7 +46,7 @@ python -m pip install $STD_ARGS vtk
 python -c "import vtk"
 
 echo "PyVista"
-python -m pip install $STD_ARGS git+https://github.com/pyvista/pyvista
+python -m pip install $STD_ARGS "git+https://github.com/adeak/pyvista.git@fix_numpy_2"  # pyvista/pyvista
 
 echo "picard"
 python -m pip install $STD_ARGS git+https://github.com/pierreablin/picard


### PR DESCRIPTION
Closes #12642

Eventually `*_matrix` will be deprecated, let's try to use `*_array` instead. TBD how much we have to deprecate vs just change directly.