### PR TITLE
Add equalization of epochs randomly

### DIFF
--- a/doc/changes/devel/12649.newfeature.rst
+++ b/doc/changes/devel/12649.newfeature.rst
@@ -1,1 +1,1 @@
-Adding argument ``'random'`` to :func:`~mne.epochs.equalize_epoch_counts` to randomly select epochs. By `Mathieu Scheltienne`_.
+Adding argument ``'random'`` to :func:`~mne.epochs.equalize_epoch_counts` and to :meth:`~mne.Epochs.equalize_event_counts` to randomly select epochs or events. By `Mathieu Scheltienne`_.

--- a/doc/changes/devel/12649.newfeature.rst
+++ b/doc/changes/devel/12649.newfeature.rst
@@ -1,0 +1,1 @@
+Adding argument ``'random'`` to :func:`~mne.epochs.equalize_epoch_counts` to randomly select epochs. By `Mathieu Scheltienne`_.

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3837,16 +3837,17 @@ def equalize_epoch_counts(epochs_list, method="mintime"):
     ----------
     epochs_list : list of Epochs instances
         The Epochs instances to equalize trial counts for.
-    method : str
-        If 'truncate', events will be truncated from the end of each event
-        list. If 'mintime', timing differences between each event list will be
-        minimized.
+    method : ``'truncate'`` | ``'mintime'`` | ``'random'``
+        If ``'truncate'``, events will be truncated from the end of each event
+        list. If ``'mintime'``, timing differences between each event list will be
+        minimized. If ``'random'``, events will be randomly selected from each event
+        list.
 
     Notes
     -----
-    This tries to make the remaining epochs occurring as close as possible in
-    time. This method works based on the idea that if there happened to be some
-    time-varying (like on the scale of minutes) noise characteristics during
+    The method ``'mintime'`` tries to make the remaining epochs occurring as close as
+    possible in time. This method works based on the idea that if there happened to be
+    some time-varying (like on the scale of minutes) noise characteristics during
     a recording, they could be compensated for (to some extent) in the
     equalization process. This method thus seeks to reduce any of those effects
     by minimizing the differences in the times of the events in the two sets of
@@ -3875,14 +3876,16 @@ def _get_drop_indices(sample_nums, method):
     """Get indices to drop from multiple event timing lists."""
     small_idx = np.argmin([e.shape[0] for e in sample_nums])
     small_epoch_indices = sample_nums[small_idx]
-    _check_option("method", method, ["mintime", "truncate"])
+    _check_option("method", method, ["mintime", "truncate", "random"])
     indices = list()
     for event in sample_nums:
         if method == "mintime":
             mask = _minimize_time_diff(small_epoch_indices, event)
-        else:
+        elif method == "truncate":
             mask = np.ones(event.shape[0], dtype=bool)
             mask[small_epoch_indices.shape[0] :] = False
+        elif method == "random":
+            raise NotImplementedError
         indices.append(np.where(np.logical_not(mask))[0])
     return indices
 

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3865,7 +3865,7 @@ def equalize_epoch_counts(epochs_list, method="mintime", *, random_state=None):
         if not epoch._bad_dropped:
             epoch.drop_bad()
     sample_nums = [epoch.events[:, 0] for epoch in epochs_list]
-    indices = _get_drop_indices(sample_nums, method)
+    indices = _get_drop_indices(sample_nums, method, random_state)
     for epoch, inds in zip(epochs_list, indices):
         epoch.drop(inds, reason="EQUALIZED_COUNT")
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -3001,6 +3001,21 @@ def test_epoch_eq():
         epochs.equalize_event_counts(1.5)
 
 
+def test_equalize_epoch_counts_random():
+    """Test random equalization of epochs."""
+    raw, events, picks = _get_data()
+    # create epochs with unequal counts
+    events_1 = events[events[:, 2] == event_id]
+    epochs_1 = Epochs(raw, events_1, event_id, tmin, tmax, picks=picks)
+    events_2 = events[events[:, 2] == event_id_2]
+    epochs_2 = Epochs(raw, events_2, event_id_2, tmin, tmax, picks=picks)
+    epochs_1.drop_bad()
+    epochs_2.drop_bad()
+    assert len(epochs_1) != len(epochs_2)
+    equalize_epoch_counts([epochs_1, epochs_2], method="random")
+    assert len(epochs_1) == len(epochs_2)
+
+
 def test_access_by_name(tmp_path):
     """Test accessing epochs by event name and on_missing for rare events."""
     raw, events, picks = _get_data()

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1295,6 +1295,8 @@ method : ``'truncate'`` | ``'mintime'`` | ``'random'``
     list. If ``'mintime'``, timing differences between each event list will be
     minimized. If ``'random'``, events will be randomly selected from each event
     list.
+
+    .. versionadded:: 1.8
 """
 
 docdict["estimate_plot_psd"] = """\

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1265,6 +1265,14 @@ encoding : str
     encoding according to the EDF+ standard).
 """
 
+docdict["equalize_events_method"] = """
+method : ``'truncate'`` | ``'mintime'`` | ``'random'``
+    If ``'truncate'``, events will be truncated from the end of each event
+    list. If ``'mintime'``, timing differences between each event list will be
+    minimized. If ``'random'``, events will be randomly selected from each event
+    list.
+"""
+
 docdict["epochs_preload"] = """
     Load all epochs from disk when creating the object
     or wait before accessing each epoch (more memory

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1265,14 +1265,6 @@ encoding : str
     encoding according to the EDF+ standard).
 """
 
-docdict["equalize_events_method"] = """
-method : ``'truncate'`` | ``'mintime'`` | ``'random'``
-    If ``'truncate'``, events will be truncated from the end of each event
-    list. If ``'mintime'``, timing differences between each event list will be
-    minimized. If ``'random'``, events will be randomly selected from each event
-    list.
-"""
-
 docdict["epochs_preload"] = """
     Load all epochs from disk when creating the object
     or wait before accessing each epoch (more memory
@@ -1295,6 +1287,14 @@ tmin, tmax : float
     Start and end time of the epochs in seconds, relative to the time-locked
     event. The closest or matching samples corresponding to the start and end
     time are included. Defaults to ``-0.2`` and ``0.5``, respectively.
+"""
+
+docdict["equalize_events_method"] = """
+method : ``'truncate'`` | ``'mintime'`` | ``'random'``
+    If ``'truncate'``, events will be truncated from the end of each event
+    list. If ``'mintime'``, timing differences between each event list will be
+    minimized. If ``'random'``, events will be randomly selected from each event
+    list.
 """
 
 docdict["estimate_plot_psd"] = """\


### PR DESCRIPTION
Requested by a colleague in Geneva for sleep study epochs.
Adds the argument `'random'` to `mne.epochs.equalize_epoch_counts` to randomly select epochs.