### PR TITLE
Enhance documentation on decimation filtering to prevent aliasing

### DIFF
--- a/doc/changes/devel/12650.other.rst
+++ b/doc/changes/devel/12650.other.rst
@@ -1,0 +1,1 @@
+Enhance documentation on decimation filtering to prevent aliasing

--- a/doc/changes/devel/12650.other.rst
+++ b/doc/changes/devel/12650.other.rst
@@ -1,1 +1,1 @@
-Enhance documentation on decimation filtering to prevent aliasing
+Enhance documentation on decimation filtering to prevent aliasing, by :newcontrib:`Xabier de Zuazo`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -602,6 +602,8 @@
 
 .. _Victoria Peterson: https://github.com/vpeterson
 
+.. _Xabier de Zuazo: https://github.com/zuazo
+
 .. _Xiaokai Xia: https://github.com/dddd1007
 
 .. _Will Turner: https://bootstrapbill.github.io

--- a/doc/help/faq.rst
+++ b/doc/help/faq.rst
@@ -236,9 +236,9 @@ of data. We'll discuss some major ones here, with some of their implications:
   ``decim`` parameter in the :class:`mne.Epochs` constructor, sub-selects every
   :math:`N^{th}` sample before and after each event. To avoid aliasing
   artifacts, the raw data should be sufficiently low-passed before decimation.
-  It is recommended to use :func:`mne.io.Raw.filter` with ``l_freq`` set to
-  half the new sampling rate (fs/2N), as per the Nyquist criterion, to ensure
-  effective attenuation of frequency content above this threshold.
+  It is recommended to use :func:`mne.io.Raw.filter` with ``h_freq`` set to
+  half the new sampling rate (fs/2N) or lower, as per the Nyquist criterion, to
+  ensure effective attenuation of frequency content above this threshold.
 
 - :func:`mne.Epochs.resample`, :func:`mne.Evoked.resample`, and
   :func:`mne.SourceEstimate.resample` all resample data.

--- a/doc/help/faq.rst
+++ b/doc/help/faq.rst
@@ -234,9 +234,11 @@ of data. We'll discuss some major ones here, with some of their implications:
 
 - :func:`mne.Epochs.decimate`, which does the same thing as the
   ``decim`` parameter in the :class:`mne.Epochs` constructor, sub-selects every
-  :math:`N^{th}` sample before and after each event. This should only be
-  used when the raw data have been sufficiently low-passed e.g. by
-  :func:`mne.io.Raw.filter` to avoid aliasing artifacts.
+  :math:`N^{th}` sample before and after each event. To avoid aliasing
+  artifacts, the raw data should be sufficiently low-passed before decimation.
+  It is recommended to use :func:`mne.io.Raw.filter` with `l_freq` set to half
+  the new sampling rate (fs/2N), as per the Nyquist criterion, to ensure
+  effective attenuation of frequency content above this threshold.
 
 - :func:`mne.Epochs.resample`, :func:`mne.Evoked.resample`, and
   :func:`mne.SourceEstimate.resample` all resample data.

--- a/doc/help/faq.rst
+++ b/doc/help/faq.rst
@@ -236,8 +236,8 @@ of data. We'll discuss some major ones here, with some of their implications:
   ``decim`` parameter in the :class:`mne.Epochs` constructor, sub-selects every
   :math:`N^{th}` sample before and after each event. To avoid aliasing
   artifacts, the raw data should be sufficiently low-passed before decimation.
-  It is recommended to use :func:`mne.io.Raw.filter` with `l_freq` set to half
-  the new sampling rate (fs/2N), as per the Nyquist criterion, to ensure
+  It is recommended to use :func:`mne.io.Raw.filter` with ``l_freq`` set to
+  half the new sampling rate (fs/2N), as per the Nyquist criterion, to ensure
   effective attenuation of frequency content above this threshold.
 
 - :func:`mne.Epochs.resample`, :func:`mne.Evoked.resample`, and

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1058,7 +1058,7 @@ decim : int
                  ``decim``), i.e., it compresses the signal (see Notes).
                  To avoid aliasing artifacts, the raw data should be
                  sufficiently low-passed before decimation. It is recommended
-                 to use :func:`mne.io.Raw.filter` with `l_freq` set to
+                 to use :func:`mne.io.Raw.filter` with ``l_freq`` set to
                  half the new sampling rate (fs/2N), as per the Nyquist
                  criterion, to ensure effective attenuation of frequency
                  content above this threshold.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1056,8 +1056,12 @@ decim : int
     .. warning:: Low-pass filtering is not performed, this simply selects
                  every Nth sample (where N is the value passed to
                  ``decim``), i.e., it compresses the signal (see Notes).
-                 If the data are not properly filtered, aliasing artifacts
-                 may occur.
+                 To avoid aliasing artifacts, the raw data should be
+                 sufficiently low-passed before decimation. It is recommended
+                 to use :func:`mne.io.Raw.filter` with `l_freq` set to
+                 half the new sampling rate (fs/2N), as per the Nyquist
+                 criterion, to ensure effective attenuation of frequency
+                 content above this threshold.
 """
 
 docdict["decim_notes"] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1058,10 +1058,10 @@ decim : int
                  ``decim``), i.e., it compresses the signal (see Notes).
                  To avoid aliasing artifacts, the raw data should be
                  sufficiently low-passed before decimation. It is recommended
-                 to use :func:`mne.io.Raw.filter` with ``l_freq`` set to
-                 half the new sampling rate (fs/2N), as per the Nyquist
-                 criterion, to ensure effective attenuation of frequency
-                 content above this threshold.
+                 to use :func:`mne.io.Raw.filter` with ``h_freq`` set to
+                 half the new sampling rate (fs/2N) or lower, as per the
+                 Nyquist criterion, to ensure effective attenuation of
+                 frequency content above this threshold.
 """
 
 docdict["decim_notes"] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1056,12 +1056,9 @@ decim : int
     .. warning:: Low-pass filtering is not performed, this simply selects
                  every Nth sample (where N is the value passed to
                  ``decim``), i.e., it compresses the signal (see Notes).
-                 To avoid aliasing artifacts, the raw data should be
-                 sufficiently low-passed before decimation. It is recommended
-                 to use :func:`mne.io.Raw.filter` with ``h_freq`` set to
-                 half the new sampling rate (fs/2N) or lower, as per the
-                 Nyquist criterion, to ensure effective attenuation of
-                 frequency content above this threshold.
+                 If the data are not properly filtered, aliasing artifacts
+                 may occur.
+                 See :ref:`resampling-and-decimating` for more information.
 """
 
 docdict["decim_notes"] = """


### PR DESCRIPTION
#### What does this implement/fix?

This update revises the **documentation** sections related to the `decim` parameter in `mne.Epochs` and the `mne.Epochs.decimate` function. It adds specific recommendations for applying a low-pass filter based on the Nyquist criterion to prevent aliasing artifacts when decimating data.
