### PR TITLE
Fix EDF/BDF filter warning bug

### DIFF
--- a/doc/changes/devel/12661.bugfix.rst
+++ b/doc/changes/devel/12661.bugfix.rst
@@ -1,0 +1,1 @@
+Fix incorrect RuntimeWarning (different channel filter settings) in EDF/BDF import, by `Clemens Brunner`_.

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -706,7 +706,7 @@ def _get_info(
         info["subject_info"]["weight"] = float(edf_info["subject_info"]["weight"])
 
     # Filter settings
-    if filt_ch_idxs := [x for x in sel if x not in stim_channel_idxs]:
+    if filt_ch_idxs := [x for x in range(len(sel)) if x not in stim_channel_idxs]:
         _set_prefilter(info, edf_info, filt_ch_idxs, "highpass")
         _set_prefilter(info, edf_info, filt_ch_idxs, "lowpass")
 
@@ -951,6 +951,7 @@ def _read_edf_header(
         edf_info["units"] = np.array(edf_info["units"], float)
 
         ch_names = [ch_names[idx] for idx in sel]
+        ch_types = [ch_types[idx] for idx in sel]
         units = [units[idx] for idx in sel]
 
         if not exclude_after_unique:

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -173,26 +173,24 @@ def test_bdf_data():
     # XXX BDF data for these is around 0.01 when it should be in the uV range,
     # probably some bug
     test_scaling = False
-    with pytest.warns(RuntimeWarning, match="Channels contain different"):
-        raw_py = _test_raw_reader(
-            read_raw_bdf,
-            input_fname=bdf_path,
-            eog=eog,
-            misc=misc,
-            exclude=["M2", "IEOG"],
-            test_scaling=test_scaling,
-        )
+    raw_py = _test_raw_reader(
+        read_raw_bdf,
+        input_fname=bdf_path,
+        eog=eog,
+        misc=misc,
+        exclude=["M2", "IEOG"],
+        test_scaling=test_scaling,
+    )
     assert len(raw_py.ch_names) == 71
-    with pytest.warns(RuntimeWarning, match="Channels contain different"):
-        raw_py = _test_raw_reader(
-            read_raw_bdf,
-            input_fname=bdf_path,
-            montage="biosemi64",
-            eog=eog,
-            misc=misc,
-            exclude=["M2", "IEOG"],
-            test_scaling=test_scaling,
-        )
+    raw_py = _test_raw_reader(
+        read_raw_bdf,
+        input_fname=bdf_path,
+        montage="biosemi64",
+        eog=eog,
+        misc=misc,
+        exclude=["M2", "IEOG"],
+        test_scaling=test_scaling,
+    )
     assert len(raw_py.ch_names) == 71
     assert "RawEDF" in repr(raw_py)
     picks = pick_types(raw_py.info, meg=False, eeg=True, exclude="bads")


### PR DESCRIPTION
Addresses the most urgent issue in #12643. The warning was incorrectly emitted because there was a bug with iterating over selected channel indices.

Note that I still don't know if the behavior is actually correct or not, so this needs to be fixed in a follow-up PR. However, fixing the warning is more important, and I'd appreciate if we pushed a hotfix release with a backport soon.