### PR TITLE
[DOC] Make SSD fit docstring clearer

### DIFF
--- a/doc/changes/devel/12664.other.rst
+++ b/doc/changes/devel/12664.other.rst
@@ -1,0 +1,1 @@
+Improved clarity of parameter documentation for `mne.decoding.SSD.fit`, by `Thomas Binns`_.

--- a/mne/decoding/ssd.py
+++ b/mne/decoding/ssd.py
@@ -177,8 +177,8 @@ class SSD(BaseEstimator, TransformerMixin):
             The input data from which to estimate the SSD. Either 2D array
             obtained from continuous data or 3D array obtained from epoched
             data.
-        y : None | array, shape (n_samples,)
-            Used for scikit-learn compatibility.
+        y : None
+            Ignored; exists for compatibility with scikit-learn pipelines.
 
         Returns
         -------


### PR DESCRIPTION
Discussed with @drammock: https://github.com/mne-tools/mne-connectivity/pull/193#discussion_r1638760912

The [`fit()`](https://mne.tools/dev/generated/mne.decoding.SSD.html#mne.decoding.SSD.fit) method of the SSD class has argument `y` which is unused, but retained for compatibility with scikit-learn. Suggestion is to rewrite this entry of the docstring to make it clearer that `y` is not used.