### PR TITLE
MAINT: Tweak which branches actions run on

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -3,6 +3,7 @@ name: Changelog
 on:  # yamllint disable-line rule:truthy
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
+    branches: ["main"]
 
 jobs:
   changelog_checker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,9 @@ on:  # yamllint disable-line rule:truthy
   release:
     types: [published]
   push:
-    branches:
-      - main
+    branches: ["main", "maint/*"]
   pull_request:
-    branches:
-      - main
+    branches: ["main", "maint/*"]
 
 permissions:
   contents: read


### PR DESCRIPTION
Now that backports are done by PR it'll be nice to have checks run against them in case we want to pay attention to them. Conversely I think we don't need the changelog checker.