### PR TITLE
NumPy 2.0 compat problems in doc build

### DIFF
--- a/doc/sphinxext/mne_doc_utils.py
+++ b/doc/sphinxext/mne_doc_utils.py
@@ -84,6 +84,8 @@ def reset_warnings(gallery_conf, fname):
         r"\nPyarrow will become a required dependency of pandas.*",
         # latexcodec
         r"open_text is deprecated\. Use files.*",
+        # python-quantities, via neo
+        r"numpy\.core is deprecated and has been renamed to numpy\._core",
     ):
         warnings.filterwarnings(  # deal with other modules having bad imports
             "ignore", message=f".*{key}.*", category=DeprecationWarning

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -ef
 
 python -m pip install --upgrade "pip!=20.3.0" build
-python -m pip install --upgrade --progress-bar off --only-binary "numpy,scipy,matplotlib,pandas,statsmodels" git+https://github.com/sphinx-gallery/sphinx-gallery.git -ve .[full,test,doc]
+python -m pip install --upgrade --progress-bar off --only-binary "numpy<2,scipy,matplotlib,pandas,statsmodels" git+https://github.com/sphinx-gallery/sphinx-gallery.git -ve .[full,test,doc]


### PR DESCRIPTION
There are (only!) two NumPy 2.0 compatibility problems showing up in our CircleCI builds:

```
../examples/io/read_neo_format.py failed leaving traceback:

Traceback (most recent call last):
  File "/home/circleci/project/examples/io/read_neo_format.py", line 18, in <module>
    import neo
  File "/home/circleci/python_env/lib/python3.10/site-packages/neo/__init__.py", line 15, in <module>
    from neo.core import *
  File "/home/circleci/python_env/lib/python3.10/site-packages/neo/core/__init__.py", line 35, in <module>
    from neo.core.block import Block
  File "/home/circleci/python_env/lib/python3.10/site-packages/neo/core/block.py", line 12, in <module>
    from neo.core.container import Container, unique_objs
  File "/home/circleci/python_env/lib/python3.10/site-packages/neo/core/container.py", line 13, in <module>
    from neo.core.spiketrain import SpikeTrain
  File "/home/circleci/python_env/lib/python3.10/site-packages/neo/core/spiketrain.py", line 27, in <module>
    import quantities as pq
  File "/home/circleci/python_env/lib/python3.10/site-packages/quantities/__init__.py", line 273, in <module>
    from . import quantity
  File "/home/circleci/python_env/lib/python3.10/site-packages/quantities/quantity.py", line 10, in <module>
    from .dimensionality import Dimensionality, p_dict
  File "/home/circleci/python_env/lib/python3.10/site-packages/quantities/dimensionality.py", line 333, in <module>
    p_dict[np.core.umath.clip] = _d_clip
  File "/home/circleci/python_env/lib/python3.10/site-packages/numpy/core/__init__.py", line 31, in __getattr__
    _raise_warning(attr_name)
  File "/home/circleci/python_env/lib/python3.10/site-packages/numpy/core/_utils.py", line 10, in _raise_warning
    warnings.warn(
DeprecationWarning: numpy.core is deprecated and has been renamed to numpy._core. The numpy._core namespace contains private NumPy internals and its use is discouraged, as NumPy internals can change without warning in any release. In practice, most real-world usage of numpy.core is to access functionality in the public NumPy API. If that is the case, use the public NumPy API. If not, you are using NumPy internals. If you would still like to access an internal attribute, use numpy._core.umath.

../tutorials/inverse/50_beamformer_lcmv.py failed leaving traceback:

Traceback (most recent call last):
  File "/home/circleci/project/tutorials/inverse/50_beamformer_lcmv.py", line 316, in <module>
    morph = mne.compute_source_morph(
  File "<decorator-gen-489>", line 10, in compute_source_morph
  File "/home/circleci/project/mne/morph.py", line 262, in compute_source_morph
    shape, zooms, affine, pre_affine, sdr_morph = _compute_morph_sdr(
  File "/home/circleci/project/mne/morph.py", line 1147, in _compute_morph_sdr
    from dipy.align.imaffine import AffineMap
  File "/home/circleci/python_env/lib/python3.10/site-packages/dipy/align/__init__.py", line 26, in <module>
    from dipy.align._public import (syn_registration, register_dwi_to_template, # noqa
  File "/home/circleci/python_env/lib/python3.10/site-packages/dipy/align/_public.py", line 15, in <module>
    from dipy.align.metrics import CCMetric, EMMetric, SSDMetric
  File "/home/circleci/python_env/lib/python3.10/site-packages/dipy/align/metrics.py", line 7, in <module>
    from dipy.align import vector_fields as vfu
  File "vector_fields.pyx", line 1, in init dipy.align.vector_fields
ImportError: numpy.core.multiarray failed to import (auto-generated because you didn't call 'numpy.import_array()' after cimporting numpy; use '<void>numpy._import_array' to disable if you are certain you don't need it).
```

(the second one also occurs for `examples/inverse/morph_volume_stc.py`)

This PR handles the deprecation coming from neo -> quantities (also [reported upstream](https://github.com/python-quantities/python-quantities/pull/232#issuecomment-2176416118)).

The DIPY problem has also been [reported upstream](https://github.com/dipy/dipy/issues/3265) but I don't think can be ~~fixed~~ *worked around in our code* other than pinning to lower NumPy :(