### PR TITLE
Change EDF zero-padding to edge-padding with annotation and test

### DIFF
--- a/doc/changes/devel/12676.bugfix.rst
+++ b/doc/changes/devel/12676.bugfix.rst
@@ -1,0 +1,2 @@
+In :func:`mne.export.export_raw` (``fmt='edf'``), when padding data to create equal-length data blocks,
+edge-padding is favored over zero-padding in order to avoid accidentally enlarging physical range, by `Qian Chu`_.

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -62,10 +62,10 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
         if (pad_width := int(np.ceil(n_times / sfreq) * sfreq - n_times)) > 0:
             warn(
                 "EDF format requires equal-length data blocks, so "
-                f"{pad_width / sfreq:.3g} seconds of zeros were appended to all "
+                f"{pad_width / sfreq:.3g} seconds of edge values were appended to all "
                 "channels when writing the final block."
             )
-            data = np.pad(data, (0, int(pad_width)))
+            data = np.pad(data, (0, int(pad_width)), "edge")
     else:
         data_record_duration = _round_float_to_8_characters(
             np.floor(sfreq) / sfreq, round

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -41,6 +41,7 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
     )
 
     digital_min, digital_max = -32767, 32767
+    annotations = []
 
     # load data first
     raw.load_data()
@@ -66,6 +67,11 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
                 "channels when writing the final block."
             )
             data = np.pad(data, (0, int(pad_width)), "edge")
+            annotations.append(
+                EdfAnnotation(
+                    raw.times[-1] + 1 / sfreq, pad_width / sfreq, "BAD_ACQ_SKIP"
+                )
+            )
     else:
         data_record_duration = _round_float_to_8_characters(
             np.floor(sfreq) / sfreq, round
@@ -197,7 +203,6 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
     else:
         recording = Recording(startdate=startdate)
 
-    annotations = []
     for desc, onset, duration, ch_names in zip(
         raw.annotations.description,
         raw.annotations.onset,

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -246,6 +246,9 @@ def test_edf_padding(tmp_path, pad_width):
     edge_data = raw_read.get_data()[:, -pad_width - 1]
     pad_data = raw_read.get_data()[:, -pad_width:]
     assert_array_almost_equal(
+        raw.get_data(), raw_read.get_data()[:, :-pad_width], decimal=10
+    )
+    assert_array_almost_equal(
         pad_data, np.tile(edge_data, (pad_width, 1)).T, decimal=10
     )
 

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -219,7 +219,7 @@ def test_edf_physical_range(tmp_path):
 @edfio_mark()
 @pytest.mark.parametrize("pad_width", (1, 10, 100, 500, 999))
 def test_edf_padding(tmp_path, pad_width):
-    """Test exporting an EDF file with not-equal-length data blocks"""
+    """Test exporting an EDF file with not-equal-length data blocks."""
     ch_types = ["eeg"] * 4
     ch_names = np.arange(len(ch_types)).astype(str).tolist()
     fs = 1000


### PR DESCRIPTION
Fixes #12654.

#### What does this implement/fix?
Changes how `mne.export.export_raw(..., fmt='edf')` handles data that cannot be segmented into equal-length data blocks. The original zero-padding is not optimal for uncentered data and may unexpectedly enlarge the physical range. Here, zero-padding is replaced with `np.pad(array, pad_width, mode='edge'`. The last available value in each channel will be used to pad the data. It also adds a "BAD_ACQ_SKIP" annotation to denote the padded data.

Corresponding tests also added.