### PR TITLE
MAINT: Fix doc build

### DIFF
--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -2,4 +2,8 @@
 
 python -m pip install --upgrade "pip!=20.3.0" build
 # https://github.com/dipy/dipy/issues/3265 for numpy, dipy
-python -m pip install --upgrade --progress-bar off --only-binary "numpy,dipy,scipy,matplotlib,pandas,statsmodels" git+https://github.com/sphinx-gallery/sphinx-gallery.git -ve .[full,test,doc] "numpy<2" "dipy!=1.9.0"
+python -m pip install --upgrade --progress-bar off \
+    --only-binary "numpy,dipy,scipy,matplotlib,pandas,statsmodels" \
+    -ve .[full,test,doc] "numpy<2" "dipy!=1.9.0" \
+    "git+https://github.com/larsoner/pyvista.git@refcycle" \
+    git+https://github.com/sphinx-gallery/sphinx-gallery.git

--- a/tutorials/preprocessing/70_fnirs_processing.py
+++ b/tutorials/preprocessing/70_fnirs_processing.py
@@ -5,10 +5,10 @@
 Preprocessing functional near-infrared spectroscopy (fNIRS) data
 ================================================================
 
-This tutorial covers how to convert functional near-infrared spectroscopy
-(fNIRS) data from raw measurements to relative oxyhaemoglobin (HbO) and
-deoxyhaemoglobin (HbR) concentration, view the average waveform, and
-topographic representation of the response.
+This tutorial covers how to convert functional near-infrared spectroscopy (fNIRS) data
+from raw measurements to relative oxyhaemoglobin (HbO) and deoxyhaemoglobin (HbR)
+concentration, view the average waveform, and topographic representation of the
+response.
 
 Here we will work with the :ref:`fNIRS motor data <fnirs-motor-dataset>`.
 """


### PR DESCRIPTION
Let's see if this fixes:

https://app.circleci.com/pipelines/github/mne-tools/mne-python/24519/workflows/d7b1e478-c51f-46e3-96c4-259b5be3b627/jobs/67052

It should, in which case we can wait for https://github.com/pyvista/pyvista/pull/6356 to be merged, then change this to use the `main` branch of PyVista, which would have caught this months ago *before* they cut 0.44.