### PR TITLE
Add license header to mne.stats.erp

### DIFF
--- a/mne/stats/erp.py
+++ b/mne/stats/erp.py
@@ -1,3 +1,8 @@
+"""ERP-related statistics."""
+
+# License: BSD-3-Clause
+# Copyright the MNE-Python contributors.
+
 import numpy as np
 
 from mne.utils import _validate_type


### PR DESCRIPTION
In #12707, I forgot to include a license header in the source.