### PR TITLE
DOC: Update install docs for Spyder

### DIFF
--- a/doc/install/installers.rst
+++ b/doc/install/installers.rst
@@ -93,7 +93,7 @@ bundles to the ``Applications`` folder on macOS.
 .. rst-class:: mt-4
 .. rst-class:: mb-5
 
-- |code| |ensp| Set up an :ref:`IDE <ide_setup>` to start writing your own analysis scripts right away, or to run one of our examples from this website.
+- |code| |ensp| Set up **Visual Studio Code** or another IDE (:ref:`instructions here <ide_setup>`) to start writing your own analysis scripts right away, or to run one of our examples from this website.
 
   .. rst-class:: mt-3
 - |desktop| |ensp| With **System Info**, list the versions of all installed MNE-Python-related packages.

--- a/doc/install/installers.rst
+++ b/doc/install/installers.rst
@@ -5,8 +5,7 @@ MNE-Python installers
 
 MNE-Python installers are the easiest way to install MNE-Python and
 all dependencies. They also provide many additional
-Python packages and tools, including the `Spyder`_ development environment.
-Got any questions? Let us know on the `MNE Forum`_!
+Python packages and tools. Got any questions? Let us know on the `MNE Forum`_!
 
 .. tab-set::
     :class: platform-selector-tabset
@@ -94,7 +93,7 @@ bundles to the ``Applications`` folder on macOS.
 .. rst-class:: mt-4
 .. rst-class:: mb-5
 
-- |code| |ensp| Use **Spyder** to start writing your own analysis scripts right away, or to run one of our examples from this website.
+- |code| |ensp| Set up an :ref:`IDE <ide_setup>` to start writing your own analysis scripts right away, or to run one of our examples from this website.
 
   .. rst-class:: mt-3
 - |desktop| |ensp| With **System Info**, list the versions of all installed MNE-Python-related packages.
@@ -108,22 +107,3 @@ bundles to the ``Applications`` folder on macOS.
    applications to start, especially on the very first run – which may take
    particularly long on Apple Silicon-based computers. Subsequent runs should
    usually be much faster.
-
-
-VS Code Setup
-^^^^^^^^^^^^^
-
-If you want to use MNE-Python with `Visual Studio Code`_, you need to tell the
-VS Code Python extension where to find the respective Python executable. To do
-so, simply start the **Prompt**. It will display several lines of
-information, including a line that will read something like:
-
-.. code-block::
-
-   Using Python: /some/directory/mne-python_1.7.1_0/bin/python
-
-This path is what you need to enter in VS Code when selecting the Python
-interpreter.
-
-.. note::
-   This information is currently not displayed on the Windows platform.

--- a/doc/install/manual_install.rst
+++ b/doc/install/manual_install.rst
@@ -94,8 +94,10 @@ the development version, etc). The :ref:`contributing` has additional
 installation instructions for (future) contributors to MNE-Python (e.g, extra
 dependencies for running our tests and building our documentation).
 
-Python IDEs
-===========
+.. _ide_setup:
+
+Python IDE integration
+======================
 
 Most users find it convenient to write and run their code in an `Integrated
 Development Environment`_ (IDE). Some popular choices for scientific
@@ -109,43 +111,33 @@ Python development are:
   <https://marketplace.visualstudio.com/items?itemName=ms-python.python>`__ is
   enough to get most Python users up and running. VS Code is free and
   open-source.
+
 - `Spyder`_ is a free and open-source IDE developed by and for scientists who
-  use Python. It is included by default in the ``base`` environment when you
-  install Anaconda, and can be started from a terminal with the command
-  ``spyder`` (or on Windows or macOS, launched from the Anaconda Navigator GUI).
-  It can also be installed with `dedicated installers <https://www.spyder-ide.org/#section-download>`_.
+  use Python. It can be installed via a
+  `standalone Spyder installer <https://docs.spyder-ide.org/current/installation.html#downloading-and-installing>`__.
   To avoid dependency conflicts with Spyder, you should install ``mne`` in a
-  separate environment, as explained in previous sections. Then, instruct
-  Spyder to use the ``mne`` environment as its default interpreter by opening
-  Spyder and navigating to
+  separate environment, as explained in previous sections or using our dedicated
+  installer. Then, instruct
+  Spyder to use the MNE-Python interpreter by opening
+  Spyder and `navigating to <https://docs.spyder-ide.org/current/faq.html#using-existing-environment>`__
   :samp:`Tools > Preferences > Python Interpreter > Use the following interpreter`.
-  There, paste the output of the following terminal commands:
-
-  .. code-block:: console
-
-      $ conda activate mne
-      $ python -c "import sys; print(sys.executable)"
-
-  It should be something like ``C:\Users\user\anaconda3\envs\mne\python.exe``
-  (Windows) or ``/Users/user/opt/anaconda3/envs/mne/bin/python`` (macOS).
-
-  If the Spyder console can not start because ``spyder-kernels`` is missing,
-  install the required version in the ``mne`` environment with the following
-  commands in the terminal, where you replace ``...`` with the exact version of
-  ``spyder-kernels`` that Spyder tells you it requires.
-
-  .. code-block:: console
-
-      $ conda activate mne
-      $ conda install --override-channels --channel=conda-forge spyder-kernels=...
-
-  Refer to the `Spyder documentation <https://docs.spyder-ide.org/current/troubleshooting/common-illnesses.html#spyder-kernels-not-installed-incompatible>`_
-  for more information about ``spyder-kernels`` and the version matching.
-
-  If the Spyder graphic backend is not set to ``inline`` but to e.g. ``Qt5``,
-  ``PyQt5`` (``pip``) or ``pyqt`` (``conda``) must be installed in the ``mne``
-  environment.
 
 - `PyCharm`_ is an IDE specifically for Python development that provides an
   all-in-one solution (no extension packages needed). PyCharm comes in a
   free and open-source Community edition as well as a paid Professional edition.
+
+For these IDEs, you'll need to provide the path to the Python interpreter you want it
+to use. To find that path, open the Python interpreter you want to use (e.g., the one
+from the MNE-Python installer, or a ``conda`` environment that you have activated)
+and run::
+
+   >>> import sys
+   >>> print(sys.executable)
+
+This should print something like
+``C:\Program Files\MNE-Python\1.7.0_0\bin\python.exe`` (Windows) or
+``/Users/user/Applications/MNE-Python/1.7.0_0/.mne-python/bin/python`` (macOS).
+
+For Spyder, if the console cannot start because ``spyder-kernels`` is missing,
+install the required version in the conda environment. For example, with the
+environment you want to use activated, run ``conda install spyder-kernels``.

--- a/doc/install/manual_install.rst
+++ b/doc/install/manual_install.rst
@@ -127,9 +127,17 @@ Python development are:
   free and open-source Community edition as well as a paid Professional edition.
 
 For these IDEs, you'll need to provide the path to the Python interpreter you want it
-to use. To find that path, open the Python interpreter you want to use (e.g., the one
-from the MNE-Python installer, or a ``conda`` environment that you have activated)
-and run::
+to use. If you're using the MNE-Python installers, on Linux and macOS opening the
+**Prompt** will display several lines of information, including a line that will read
+something like:
+
+.. code-block:: output
+
+   Using Python: /some/directory/mne-python_1.7.1_0/bin/python
+
+Altertatively (or on Windows), you can find that path by opening the Python interpreter
+you want to use (e.g., the one from the MNE-Python installer, or a ``conda`` environment
+that you have activated) and running::
 
    >>> import sys
    >>> print(sys.executable)

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -489,7 +489,9 @@ def create_ecg_epochs(
 def _make_ecg(inst, start, stop, reject_by_annotation=False, verbose=None):
     """Create ECG signal from cross channel average."""
     if not any(c in inst for c in ["mag", "grad"]):
-        raise ValueError("Unable to generate artificial ECG channel")
+        raise ValueError(
+            "Generating an artificial ECG channel can only be done for MEG data"
+        )
     for ch in ["mag", "grad"]:
         if ch in inst:
             break

--- a/mne/preprocessing/tests/test_ecg.py
+++ b/mne/preprocessing/tests/test_ecg.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from mne import pick_types
 from mne.io import read_raw_fif
@@ -114,3 +115,7 @@ def test_find_ecg():
     assert ecg_events.size == 0
     assert average_pulse == 0
     assert np.allclose(ecg, np.zeros_like(ecg))
+
+    # Needs MEG
+    with pytest.raises(ValueError, match="Generating an artificial"):
+        find_ecg_events(read_raw_fif(raw_fname, preload=False).pick("eeg"))

--- a/mne/rank.py
+++ b/mne/rank.py
@@ -340,7 +340,7 @@ def compute_rank(
 
     This function will normalize the rows of the data (typically
     channels or vertices) such that non-zero singular values
-    should be close to one.
+    should be close to one. It operates on :term:`data channels` only.
 
     Parameters
     ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 scripts = { mne = "mne.commands.utils:main" }
 dependencies = [
-    "numpy>=1.23",
+    "numpy>=1.23,<3",
     "scipy>=1.9",
     "matplotlib>=3.6",
     "tqdm",


### PR DESCRIPTION
The bulk of this has to do with us no longer packaging Spyder in our installers and adjusting the install docs (mostly) minimally to comply with this change. #10707 and #11615 for example ask for something more comprehensive and aren't meant to be addressed here. This does help a tiny bit (maybe!) with #10707 in the sense that it deduplicates some stuff. I also snuck in a couple of tiny single-digit-line changes to close three other issues:

1. Pinning `numpy<3`
2. Adding a note that `compute_rank` operates on data channels
3. Improving an error message

@hoechenberger for the Spyder stuff, think this is good enough?

Closes #12672
Closes #12705
Closes #11540
Closes #11482