### PR TITLE
DOC: do not use sphinx gallery comment as section header

### DIFF
--- a/examples/visualization/evoked_topomap.py
+++ b/examples/visualization/evoked_topomap.py
@@ -19,6 +19,7 @@ additional options.
 # Copyright the MNE-Python contributors.
 
 # %%
+
 # sphinx_gallery_thumbnail_number = 5
 
 import matplotlib.pyplot as plt

--- a/tutorials/machine-learning/50_decoding.py
+++ b/tutorials/machine-learning/50_decoding.py
@@ -25,6 +25,7 @@ Let's start by loading data for a simple two-class problem:
 """
 
 # %%
+
 # sphinx_gallery_thumbnail_number = 6
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
fixes the erroneous `sphinx_gallery_thumbnail_number = 5` header in the examples, see here: https://mne.tools/stable/auto_examples/visualization/evoked_topomap.html#plotting-topographic-maps-of-evoked-data


