### PR TITLE
Simplify keeping track of ylim dictionary in _plot_topo

### DIFF
--- a/doc/changes/devel/12724.bugfix.rst
+++ b/doc/changes/devel/12724.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where the ``ylim`` parameter would sometimes apply to the wrong channel types in :func:`mne.viz.plot_evoked_topo`, by `Marijn van Vliet`_.

--- a/examples/io/elekta_epochs.py
+++ b/examples/io/elekta_epochs.py
@@ -51,9 +51,6 @@ for cat in raw.acqparser.categories:
     evoked = epochs.average()
     evoked.comment = cat["comment"]
     evokeds.append(evoked)
-# save all averages to an evoked fiff file
-# fname_out = 'multimodal-ave.fif'
-# mne.write_evokeds(fname_out, evokeds)
 
 # %%
 # Make a new averaging category

--- a/examples/visualization/topo_compare_conditions.py
+++ b/examples/visualization/topo_compare_conditions.py
@@ -30,21 +30,21 @@ print(__doc__)
 data_path = sample.data_path()
 
 # %%
-# Set parameters
+# Set parameters.
 meg_path = data_path / "MEG" / "sample"
 raw_fname = meg_path / "sample_audvis_filt-0-40_raw.fif"
 event_fname = meg_path / "sample_audvis_filt-0-40_raw-eve.fif"
 tmin = -0.2
 tmax = 0.5
 
-#   Setup for reading the raw data
+# Setup for reading the raw data.
 raw = mne.io.read_raw_fif(raw_fname)
 events = mne.read_events(event_fname)
 
-#   Set up amplitude-peak rejection values for MEG channels
+# Set up amplitude-peak rejection values for MEG channels.
 reject = dict(grad=4000e-13, mag=4e-12)
 
-# Create epochs including different events
+# Create epochs including different events.
 event_id = {"audio/left": 1, "audio/right": 2, "visual/left": 3, "visual/right": 4}
 epochs = mne.Epochs(
     raw, events, event_id, tmin, tmax, picks="meg", baseline=(None, 0), reject=reject
@@ -54,7 +54,7 @@ epochs = mne.Epochs(
 evokeds = [epochs[name].average() for name in ("left", "right")]
 
 # %%
-# Show topography for two different conditions
+# Show topography for two different conditions.
 
 colors = "blue", "red"
 title = "MNE sample data\nleft vs right (A/V combined)"

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -397,11 +397,6 @@ def _compute_ax_scalings(bn, xlim, ylim):
     bn.y_t = pos[1] - bn.y_s * ylim[0]
 
 
-def _check_vlim(vlim):
-    """Check the vlim."""
-    return not np.isscalar(vlim) and vlim is not None
-
-
 def _imshow_tfr(
     ax,
     ch_idx,
@@ -1008,13 +1003,11 @@ def _plot_evoked_topo(
             > 0
         )
         if is_meg:
-            types_used = list(types_used)[::-1]  # -> restore kwarg order
             picks = [
                 pick_types(info, meg=kk, ref_meg=False, exclude=exclude)
                 for kk in types_used
             ]
         elif is_nirs:
-            types_used = list(types_used)[::-1]  # -> restore kwarg order
             picks = [
                 pick_types(info, fnirs=kk, ref_meg=False, exclude=exclude)
                 for kk in types_used

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -330,7 +330,7 @@ def _plot_topo(
 
     for ax, ch_idx in my_topo_plot:
         if layout.kind == "Vectorview-all" and ylim is not None:
-            ylim_ = ylim.get(channel_type(info, ch_idx), None)
+            ylim_ = ylim.get(channel_type(info, ch_idx))
         else:
             ylim_ = ylim
 

--- a/mne/viz/topo.py
+++ b/mne/viz/topo.py
@@ -330,8 +330,7 @@ def _plot_topo(
 
     for ax, ch_idx in my_topo_plot:
         if layout.kind == "Vectorview-all" and ylim is not None:
-            this_type = {"mag": 0, "grad": 1}[channel_type(info, ch_idx)]
-            ylim_ = [v[this_type] if _check_vlim(v) else v for v in ylim]
+            ylim_ = ylim.get(channel_type(info, ch_idx), None)
         else:
             ylim_ = ylim
 
@@ -388,8 +387,9 @@ def _plot_topo_onpick(event, show_func):
 
 def _compute_ax_scalings(bn, xlim, ylim):
     """Compute scale factors for a unified plot."""
-    if isinstance(ylim[0], (tuple, list, np.ndarray)):
-        ylim = (ylim[0][0], ylim[1][0])
+    if isinstance(ylim, dict):
+        # Take the first (ymin, ymax) entry.
+        ylim = next(iter(ylim.values()))
     pos = bn.pos
     bn.x_s = pos[2] / (xlim[1] - xlim[0])
     bn.x_t = pos[0] - bn.x_s * xlim[0]
@@ -1045,21 +1045,15 @@ def _plot_evoked_topo(
 
     if ylim is None:
         # find minima and maxima over all evoked data for each channel pick
-        ymaxes = np.array([max((e.data[t]).max() for e in evoked) for t in picks])
-        ymins = np.array([min((e.data[t]).min() for e in evoked) for t in picks])
-
-        ylim_ = (ymins, ymaxes)
+        ylim_ = dict()
+        for ch_type, p in zip(types_used, picks):
+            ylim_[ch_type] = [
+                min([e.data[p].min() for e in evoked]),
+                max([e.data[p].max() for e in evoked]),
+            ]
     elif isinstance(ylim, dict):
         ylim_ = _handle_default("ylim", ylim)
-        ylim_ = [ylim_[kk] for kk in types_used]
-        # extra unpack to avoid bug #1700
-        if len(ylim_) == 1:
-            ylim_ = ylim_[0]
-        else:
-            ylim_ = [np.array(yl) for yl in ylim_]
-            # Transposing to avoid Zipping confusion
-            if is_meg or is_nirs:
-                ylim_ = list(map(list, zip(*ylim_)))
+        ylim_ = {kk: ylim_[kk] for kk in types_used}
     else:
         raise TypeError(f"ylim must be None or a dict. Got {type(ylim)}.")
 


### PR DESCRIPTION
fixes #12723

The handling of the `ylim` parameter in `mne.viz.plot_evoked_topo` is currently weirdly converted into a list of lists, but then transposed... This PR changes it to just remain a dictionary and do away with conversions.