### PR TITLE
pin h5io to >= 0.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
 data = []
 
 # Dependencies for MNE-Python functions that use HDF5 I/O
-hdf5 = ["h5io", "pymatreader"]
+hdf5 = ["h5io>=0.2.4", "pymatreader"]
 
 # Dependencies for full MNE-Python functionality (other than raw/epochs export)
 # We first define a variant without any Qt bindings. The "complete" variant, mne[full],


### PR DESCRIPTION
needed for datetime.date support; otherwise writing to hdf5 will fail sometimes (e.g., the nirx tests; noticed when looking into https://github.com/mne-tools/mne-nirs/issues/543, not sure why that didn't surface in #12720)

cc @larsoner 