### PR TITLE
add encoding parameter to read_raw_nirx

### DIFF
--- a/doc/changes/devel/12730.bugfix.rst
+++ b/doc/changes/devel/12730.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug when reading NIRX files saved in a non-western encoding, by `Daniel McCloy`_.

--- a/mne/io/nirx/_localized_abbr.py
+++ b/mne/io/nirx/_localized_abbr.py
@@ -41,6 +41,7 @@ for loc in ('en_US.utf8', 'de_DE', 'fr_FR', 'it_IT'):
 print('}\n')
 """
 
+# TODO: this should really be outsourced to a dedicated module like arrow or babel
 _localized_abbr = {
     "en_US.utf8": {
         "month": {

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -246,6 +246,7 @@ class RawNIRX(BaseRaw):
                 '"%a %d %b %Y""%H:%M:%S.%f"',
                 '"%a, %d %b %Y""%H:%M:%S.%f"',
                 "%Y-%m-%d %H:%M:%S.%f",
+                '"%Y年%m月%d日""%H:%M:%S.%f"',
             ]:
                 try:
                     meas_date = dt.datetime.strptime(loc_datetime_str, dt_code)

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -35,7 +35,7 @@ from ._localized_abbr import _localized_abbr
 
 @fill_doc
 def read_raw_nirx(
-    fname, saturated="annotate", *, preload=False, encoding=None, verbose=None
+    fname, saturated="annotate", *, preload=False, encoding="latin-1", verbose=None
 ) -> "RawNIRX":
     """Reader for a NIRX fNIRS recording.
 

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -106,10 +106,7 @@ class RawNIRX(BaseRaw):
         fname = str(_check_fname(fname, "read", True, "fname", need_dir=True))
 
         json_config = glob.glob(f"{fname}/*{'config.json'}")
-        if len(json_config):
-            is_aurora = True
-        else:
-            is_aurora = False
+        is_aurora = len(json_config)
 
         if is_aurora:
             # NIRSport2 devices using Aurora software

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -35,7 +35,7 @@ from ._localized_abbr import _localized_abbr
 
 @fill_doc
 def read_raw_nirx(
-    fname, saturated="annotate", preload=False, verbose=None
+    fname, saturated="annotate", *, preload=False, encoding=None, verbose=None
 ) -> "RawNIRX":
     """Reader for a NIRX fNIRS recording.
 
@@ -45,6 +45,7 @@ def read_raw_nirx(
         Path to the NIRX data folder or header file.
     %(saturated)s
     %(preload)s
+    %(encoding_nirx)s
     %(verbose)s
 
     Returns
@@ -61,7 +62,9 @@ def read_raw_nirx(
     -----
     %(nirx_notes)s
     """
-    return RawNIRX(fname, saturated, preload, verbose)
+    return RawNIRX(
+        fname, saturated, preload=preload, encoding=encoding, verbose=verbose
+    )
 
 
 def _open(fname):
@@ -78,6 +81,7 @@ class RawNIRX(BaseRaw):
         Path to the NIRX data folder or header file.
     %(saturated)s
     %(preload)s
+    %(encoding_nirx)s
     %(verbose)s
 
     See Also
@@ -90,7 +94,7 @@ class RawNIRX(BaseRaw):
     """
 
     @verbose
-    def __init__(self, fname, saturated, preload=False, verbose=None):
+    def __init__(self, fname, saturated, *, preload=False, encoding=None, verbose=None):
         logger.info(f"Loading {fname}")
         _validate_type(fname, "path-like", "fname")
         _validate_type(saturated, str, "saturated")
@@ -178,7 +182,7 @@ class RawNIRX(BaseRaw):
         # Read header file
         # The header file isn't compliant with the configparser. So all the
         # text between comments must be removed before passing to parser
-        with _open(files["hdr"]) as f:
+        with open(files["hdr"], encoding=encoding) as f:
             hdr_str_all = f.read()
         hdr_str = re.sub("#.*?#", "", hdr_str_all, flags=re.DOTALL)
         if is_aurora:

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1269,15 +1269,15 @@ emit_warning : bool
     Whether to emit warnings when cropping or omitting annotations.
 """
 
-docdict["encoding_nirx"] = """
-encoding : str
-    Text encoding of the NIRX header file. See :std:label:`standard-encodings`.
-"""
-
 docdict["encoding_edf"] = """
 encoding : str
     Encoding of annotations channel(s). Default is "utf8" (the only correct
     encoding according to the EDF+ standard).
+"""
+
+docdict["encoding_nirx"] = """
+encoding : str
+    Text encoding of the NIRX header file. See :std:label:`standard-encodings`.
 """
 
 docdict["epochs_preload"] = """

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1269,6 +1269,11 @@ emit_warning : bool
     Whether to emit warnings when cropping or omitting annotations.
 """
 
+docdict["encoding_nirx"] = """
+encoding : str
+    Text encoding of the NIRX header file. See :std:label:`standard-encodings`.
+"""
+
 docdict["encoding_edf"] = """
 encoding : str
     Encoding of annotations channel(s). Default is "utf8" (the only correct

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1277,7 +1277,7 @@ encoding : str
 
 docdict["encoding_nirx"] = """
 encoding : str
-    Text encoding of the NIRX header file. See :std:label:`standard-encodings`.
+    Text encoding of the NIRX header file. See :ref:`standard-encodings`.
 """
 
 docdict["epochs_preload"] = """


### PR DESCRIPTION
Add new param `encoding` to `read_raw_nirx`. Default ~~`None`~~ `"latin-1"` should be backward compatible. Also adds another strptime pattern (zh-locale appropriate) to check the meas_date against when reading the file.

Fixes https://github.com/mne-tools/mne-nirs/issues/543

Draft PR because I haven't added a test yet, and because IDK how many of our readers might need such functionality. Input welcome on that question.