### PR TITLE
Add a type guard to the metadata tutorial

### DIFF
--- a/tutorials/epochs/30_epochs_metadata.py
+++ b/tutorials/epochs/30_epochs_metadata.py
@@ -47,9 +47,13 @@ epochs = mne.read_epochs(kiloword_data_file)
 #    reloading the `~mne.Epochs` object to/from disk.
 #
 # The metadata attached to `~mne.Epochs` objects is stored as a
-# :class:`pandas.DataFrame` containing one row for each epoch. The columns of
-# this :class:`~pandas.DataFrame` can contain just about any information you
-# want to store about each epoch; in this case, the metadata encodes
+# :class:`pandas.DataFrame`.
+
+assert isinstance(epochs.metadata, pd.DataFrame)
+
+# %%
+# Each row corresponds to one epoch. The columns can contain just about any information
+# you want to store about each epoch; in this case, the metadata encodes
 # information about the stimulus seen on each trial, including properties of
 # the visual word form itself (e.g., ``NumberOfLetters``, ``VisualComplexity``)
 # as well as properties of what the word means (e.g., its ``Concreteness``) and

--- a/tutorials/epochs/30_epochs_metadata.py
+++ b/tutorials/epochs/30_epochs_metadata.py
@@ -47,7 +47,7 @@ epochs = mne.read_epochs(kiloword_data_file)
 #    reloading the `~mne.Epochs` object to/from disk.
 #
 # The metadata attached to `~mne.Epochs` objects is stored as a
-# :class:`pandas.DataFrame`.
+# :class:`pandas.DataFrame`:
 
 assert isinstance(epochs.metadata, pd.DataFrame)
 


### PR DESCRIPTION
The tutorial looked like this before:

<img width="600" alt="Screenshot 2024-07-18 at 18 54 13" src="https://github.com/user-attachments/assets/b274ec6b-0a68-48e0-85cb-9ce57c5b3a2b">

Now it looks like this:

<img width="600" alt="Screenshot 2024-07-18 at 18 53 27" src="https://github.com/user-attachments/assets/34b1b6d3-a892-4e45-82bc-9956167566cb">

The reason is that `Epochs.metadata` may be `None`, in which case all the Pandas methods won't work; hence, the type checker complains.