### PR TITLE
Remove need for `Union` and `Optional` type annotations in Python 3.9

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -12,7 +12,7 @@
 # Copyright the MNE-Python contributors.
 
 
-from __future__ import annotations  # Only needed for Python 3.9
+from __future__ import annotations  # only needed for Python ≤ 3.9
 
 import os.path as op
 import string

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -12,6 +12,8 @@
 # Copyright the MNE-Python contributors.
 
 
+from __future__ import annotations  # Only needed for Python 3.9
+
 import os.path as op
 import string
 import sys
@@ -20,7 +22,6 @@ from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from typing import Union
 
 import numpy as np
 from scipy.io import loadmat
@@ -1032,7 +1033,7 @@ class _BuiltinChannelAdjacency:
     name: str
     description: str
     fname: str
-    source_url: Union[str, None]
+    source_url: str | None
 
 
 _ft_neighbor_url_t = string.Template(

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -8,10 +8,11 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
+from __future__ import annotations  # Only needed for Python 3.9
+
 from copy import deepcopy
 from inspect import getfullargspec
 from pathlib import Path
-from typing import Union
 
 import numpy as np
 
@@ -1661,7 +1662,7 @@ def read_evokeds(
     proj=True,
     allow_maxshield=False,
     verbose=None,
-) -> Union[list[Evoked], Evoked]:
+) -> list[Evoked] | Evoked:
     """Read evoked dataset(s).
 
     Parameters

--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -8,7 +8,7 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
-from __future__ import annotations  # Only needed for Python 3.9
+from __future__ import annotations  # only needed for Python ≤ 3.9
 
 from copy import deepcopy
 from inspect import getfullargspec

--- a/mne/html_templates/_templates.py
+++ b/mne/html_templates/_templates.py
@@ -1,7 +1,7 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
-from __future__ import annotations  # Only needed for Python 3.9
+from __future__ import annotations  # only needed for Python ≤ 3.9
 
 import datetime
 import functools

--- a/mne/html_templates/_templates.py
+++ b/mne/html_templates/_templates.py
@@ -1,10 +1,13 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
+
+from __future__ import annotations  # Only needed for Python 3.9
+
 import datetime
 import functools
 import uuid
 from dataclasses import dataclass
-from typing import Any, Literal, Union
+from typing import Any, Literal
 
 from .._fiff.pick import channel_type
 from ..defaults import _handle_default
@@ -12,7 +15,7 @@ from ..defaults import _handle_default
 _COLLAPSED = False  # will override in doc build
 
 
-def _format_number(value: Union[int, float]) -> str:
+def _format_number(value: int | float) -> str:
     """Insert thousand separators."""
     return f"{value:,}"
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -6,7 +6,7 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
-from __future__ import annotations  # Only needed for Python 3.9
+from __future__ import annotations  # only needed for Python ≤ 3.9
 
 import json
 import math

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -6,6 +6,8 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
+from __future__ import annotations  # Only needed for Python 3.9
+
 import json
 import math
 import warnings
@@ -16,7 +18,7 @@ from dataclasses import dataclass, is_dataclass
 from inspect import Parameter, isfunction, signature
 from numbers import Integral
 from time import time
-from typing import Literal, Optional, Union
+from typing import Literal
 
 import numpy as np
 from scipy import stats
@@ -507,13 +509,13 @@ class ICA(ContainsMixin):
     def _get_infos_for_repr(self):
         @dataclass
         class _InfosForRepr:
-            fit_on: Optional[Literal["raw data", "epochs"]]
+            fit_on: Literal["raw data", "epochs"] | None
             fit_method: Literal["fastica", "infomax", "extended-infomax", "picard"]
-            fit_params: dict[str, Union[str, float]]
-            fit_n_iter: Optional[int]
-            fit_n_samples: Optional[int]
-            fit_n_components: Optional[int]
-            fit_n_pca_components: Optional[int]
+            fit_params: dict[str, str | float]
+            fit_n_iter: int | None
+            fit_n_samples: int | None
+            fit_n_components: int | None
+            fit_n_pca_components: int | None
             ch_types: list[str]
             excludes: list[str]
 

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -7,6 +7,8 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
+from __future__ import annotations  # Only needed for Python 3.9
+
 import base64
 import copy
 import dataclasses
@@ -24,7 +26,6 @@ from functools import partial
 from io import BytesIO, StringIO
 from pathlib import Path
 from shutil import copyfile
-from typing import Optional
 
 import numpy as np
 
@@ -299,7 +300,7 @@ def _html_element(*, id_, div_klass, html, title, tags):
 @dataclass
 class _ContentElement:
     name: str
-    section: Optional[str]
+    section: str | None
     dom_id: str
     tags: tuple[str]
     html: str

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -7,7 +7,7 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
-from __future__ import annotations  # Only needed for Python 3.9
+from __future__ import annotations  # only needed for Python ≤ 3.9
 
 import base64
 import copy

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -10,6 +10,8 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
+from __future__ import annotations  # Only needed for Python 3.9
+
 import os
 import os.path as op
 import warnings
@@ -19,7 +21,6 @@ from dataclasses import dataclass
 from functools import partial
 from itertools import cycle
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 from scipy.spatial import ConvexHull, Delaunay
@@ -2880,7 +2881,7 @@ def plot_volume_source_estimates(
         Can also be a string to use the ``bg_img`` file in the subject's
         MRI directory (default is ``'T1.mgz'``).
         Not used in "glass brain" plotting.
-    colorbar : bool, optional
+    colorbar : bool
         If True, display a colorbar on the right of the plots.
     %(colormap)s
     %(clim)s
@@ -4108,10 +4109,10 @@ def plot_brain_colorbar(
 
 @dataclass()
 class _3d_Options:
-    antialias: Optional[bool]
-    depth_peeling: Optional[bool]
-    smooth_shading: Optional[bool]
-    multi_samples: Optional[int]
+    antialias: bool | None
+    depth_peeling: bool | None
+    smooth_shading: bool | None
+    multi_samples: int | None
 
 
 _3d_options = _3d_Options(

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -10,7 +10,7 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
-from __future__ import annotations  # Only needed for Python 3.9
+from __future__ import annotations  # only needed for Python ≤ 3.9
 
 import os
 import os.path as op

--- a/mne/viz/ui_events.py
+++ b/mne/viz/ui_events.py
@@ -12,7 +12,7 @@ Authors: Marijn van Vliet <w.m.vanvliet@gmail.com>
 
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
-from __future__ import annotations  # Only needed for Python 3.9
+from __future__ import annotations  # only needed for Python ≤ 3.9
 
 import contextlib
 import re

--- a/mne/viz/ui_events.py
+++ b/mne/viz/ui_events.py
@@ -12,11 +12,12 @@ Authors: Marijn van Vliet <w.m.vanvliet@gmail.com>
 
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
+from __future__ import annotations  # Only needed for Python 3.9
+
 import contextlib
 import re
 import weakref
 from dataclasses import dataclass
-from typing import Optional, Union
 
 from matplotlib.colors import Colormap
 
@@ -145,12 +146,12 @@ class ColormapRange(UIEvent):
     """
 
     kind: str
-    ch_type: Optional[str] = None
-    fmin: Optional[float] = None
-    fmid: Optional[float] = None
-    fmax: Optional[float] = None
-    alpha: Optional[bool] = None
-    cmap: Optional[Union[Colormap, str]] = None
+    ch_type: str | None = None
+    fmin: float | None = None
+    fmid: float | None = None
+    fmax: float | None = None
+    alpha: bool | None = None
+    cmap: Colormap | str | None = None
 
 
 @dataclass


### PR DESCRIPTION
Makes the existing annotations much cleaner and more readable.
