### PR TITLE
channel_types: add important note on eye-tracking

### DIFF
--- a/mne/_fiff/meas_info.py
+++ b/mne/_fiff/meas_info.py
@@ -551,6 +551,9 @@ class SetChannelsMixin(MontageMixin):
             fnirs_od, gof, gsr, hbo, hbr, ias, misc, pupil, ref_meg, resp,
             seeg, stim, syst, temperature.
 
+        When working with eye-tracking data, see
+        :func:`mne.preprocessing.eyetracking.set_channel_types_eyetrack`.
+
         .. versionadded:: 0.9.0
         """
         info = self if isinstance(self, Info) else self.info


### PR DESCRIPTION
I am important eye tracking data from a tobii device (XDF format), and kept running into this issue when trying to `set_channel_types`:

> KeyError: 0 (FIFFV_COIL_NONE)

After some digging, I found that there is a different function that I should call. With this PR I want to make this more obvious in the documentation. However, the above issue also points out that there is probably a bug when setting channel types for eye-tracking.