### PR TITLE
BUG: Fix bug with CircleCI Path [skip azp] [skip actions]

### DIFF
--- a/tools/get_minimal_commands.sh
+++ b/tools/get_minimal_commands.sh
@@ -20,7 +20,7 @@ elif [ "${AZURE_CI}" == "true" ]; then
 elif [ "${CIRCLECI}" == "true" ]; then
 	echo "Setting MNE_ROOT for CircleCI"
 	echo "export MNE_ROOT=${MNE_ROOT}" >> "$BASH_ENV";
-	echo "export PATH=${MNE_ROOT}/bin:$PATH" >> "$BASH_ENV";
+	echo "export PATH=${MNE_ROOT}/bin:\$PATH" >> "$BASH_ENV";
 fi;
 if [[ "${CI_OS_NAME}" != "macos"* ]]; then
 	echo "Getting files for Linux..."


### PR DESCRIPTION
As evidenced by this [mne-bids-pipeline PR](https://app.circleci.com/pipelines/github/mne-tools/mne-bids-pipeline/4622/workflows/66058499-726d-4685-bba7-728c84593225/jobs/67932) working, we need this `\$` to avoid variable expansion. Basically having the bare `$` causes the `PATH` variable to be expanded *at the time of script running* when really we want it to run *whenever the BASH_ENV gets run* in subsequent steps. It prevents errors like [this](https://app.circleci.com/pipelines/github/mne-tools/mne-bids-pipeline/4621/workflows/f56cca01-af93-4260-8595-ce867ccc04e0/jobs/67931).