### PR TITLE
Expose color param in report add_events

### DIFF
--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -1565,6 +1565,7 @@ class Report:
         event_id=None,
         sfreq,
         first_samp=0,
+        color=None,
         tags=("events",),
         replace=False,
     ):
@@ -1583,6 +1584,9 @@ class Report:
         first_samp : int
             The first sample point in the recording. This corresponds to
             ``raw.first_samp`` on files created with Elekta/Neuromag systems.
+        color : dict | None
+            Dictionary of event_id integers as keys and colors as values. This
+            parameter is directly passed to :func:`mne.viz.plot_events`.
         %(tags_report)s
         %(replace_report)s
 
@@ -1596,6 +1600,7 @@ class Report:
             event_id=event_id,
             sfreq=sfreq,
             first_samp=first_samp,
+            color=color,
             title=title,
             section=None,
             image_format=self.image_format,
@@ -3740,6 +3745,7 @@ class Report:
         *,
         events,
         event_id,
+        color,
         sfreq,
         first_samp,
         title,
@@ -3757,6 +3763,7 @@ class Report:
             event_id=event_id,
             sfreq=sfreq,
             first_samp=first_samp,
+            color=color,
             show=False,
         )
         _constrain_fig_resolution(fig, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES)


### PR DESCRIPTION
While generating an mne.Report, I was running into this warning:

>RuntimeWarning: More events than default colors available. You should pass a list of unique colors.

And without the `color` parameter exposed, I cannot remedy the situation. Hence this PR :-)