### PR TITLE
Safeguard loading of meas_date in EDF files

### DIFF
--- a/doc/changes/devel/12754.bugfix.rst
+++ b/doc/changes/devel/12754.bugfix.rst
@@ -1,0 +1,1 @@
+Safeguard loading of ``meas_date`` in :func:`mne.io.read_raw_edf`, by `Mathieu Scheltienne`_.

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -839,7 +839,7 @@ def _read_edf_header(
 
         # Recording ID
         rec_info = fid.read(80).decode("latin-1").rstrip().split(" ")
-        # if the measurement date is avaialble in the recording info, it's used instead
+        # if the measurement date is available in the recording info, it's used instead
         # of the file's meas_date since it contains all 4 digits of the year.
         meas_date = None
         if len(rec_info) == 5:

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -838,48 +838,39 @@ def _read_edf_header(
                                 warn(f"Invalid patient information {key}")
 
         # Recording ID
-        meas_id = {}
         rec_info = fid.read(80).decode("latin-1").rstrip().split(" ")
-        valid_startdate = False
+        # if the measurement date is avaialble in the recording info, it's used instead
+        # of the file's meas_date since it contains all 4 digits of the year.
+        meas_date = None
         if len(rec_info) == 5:
             try:
-                startdate = datetime.strptime(rec_info[1], "%d-%b-%Y")
+                meas_date = datetime.strptime(rec_info[1], "%d-%b-%Y").replace(
+                    tzinfo=timezone.utc
+                )
+                fid.read(16)  # skip the file's meas_date
+            except Exception:
+                meas_date = None
+        if meas_date is None:
+            try:
+                meas_date = fid.read(8).decode("latin-1")
+                day, month, year = (int(x) for x in meas_date.split("."))
+                year = year + 2000 if year < 85 else year + 1900
+            except Exception:
+                meas_date = None
+            try:
+                meas_time = fid.read(8).decode("latin-1")
+                hour, minute, sec = (int(x) for x in meas_time.split("."))
+            except Exception:
+                hour, minute, sec = 0, 0, 0
+            try:
+                meas_date = datetime(
+                    year, month, day, hour, minute, sec, tzinfo=timezone.utc
+                )
             except ValueError:
-                startdate = "X"
-            else:
-                valid_startdate = True
-            meas_id["startdate"] = startdate
-            meas_id["study_id"] = rec_info[2]
-            meas_id["technician"] = rec_info[3]
-            meas_id["equipment"] = rec_info[4]
-
-        # If startdate available in recording info, use it instead of the
-        # file's meas_date since it contains all 4 digits of the year
-        if valid_startdate:
-            day = meas_id["startdate"].day
-            month = meas_id["startdate"].month
-            year = meas_id["startdate"].year
-            fid.read(8)  # skip file's meas_date
-        else:
-            meas_date = fid.read(8).decode("latin-1")
-            day, month, year = (int(x) for x in meas_date.split("."))
-            year = year + 2000 if year < 85 else year + 1900
-
-        meas_time = fid.read(8).decode("latin-1")
-        hour, minute, sec = (int(x) for x in meas_time.split("."))
-        try:
-            meas_date = datetime(
-                year, month, day, hour, minute, sec, tzinfo=timezone.utc
-            )
-        except ValueError:
-            warn(
-                f"Invalid date encountered ({year:04d}-{month:02d}-"
-                f"{day:02d} {hour:02d}:{minute:02d}:{sec:02d})."
-            )
-            meas_date = None
+                warn("Invalid measurement date encountered in the header.")
+                meas_date = None
 
         header_nbytes = int(_edf_str(fid.read(8)))
-
         # The following 44 bytes sometimes identify the file type, but this is
         # not guaranteed. Therefore, we skip this field and use the file
         # extension to determine the subtype (EDF or BDF, which differ in the

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -847,16 +847,18 @@ def _read_edf_header(
                 meas_date = datetime.strptime(rec_info[1], "%d-%b-%Y").replace(
                     tzinfo=timezone.utc
                 )
-                fid.read(16)  # skip the file's meas_date
             except Exception:
                 meas_date = None
+            else:
+                fid.read(16)  # skip the file's meas_date
         if meas_date is None:
             try:
                 meas_date = fid.read(8).decode("latin-1")
                 day, month, year = (int(x) for x in meas_date.split("."))
-                year = year + 2000 if year < 85 else year + 1900
             except Exception:
                 meas_date = None
+            else:
+                year = year + 2000 if year < 85 else year + 1900
             try:
                 meas_time = fid.read(8).decode("latin-1")
                 hour, minute, sec = (int(x) for x in meas_time.split("."))

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -874,7 +874,7 @@ def test_invalid_date(tmp_path):
     edf[172] = ord("2")
     with open(fname, "wb") as f:
         f.write(edf)
-    with pytest.warns(RuntimeWarning, match="Invalid date"):
+    with pytest.warns(RuntimeWarning, match="Invalid measurement date"):
         read_raw_edf(fname)
 
     # another invalid date 29.00.14 (0 is not a month)
@@ -882,7 +882,7 @@ def test_invalid_date(tmp_path):
     edf[172] = ord("0")
     with open(fname, "wb") as f:
         f.write(edf)
-    with pytest.warns(RuntimeWarning, match="Invalid date"):
+    with pytest.warns(RuntimeWarning, match="Invalid measurement date"):
         read_raw_edf(fname)
 
 


### PR DESCRIPTION
As reported here: https://mne.discourse.group/t/wrong-in-mne-io-read-raw-edf/9123/14
Refactors the loading of the measurement date with a bunch of `try/except` and removes the collection of un-used fields: `meas_id["study_id"]`, `meas_id["technician"]`, and `meas_id["equipment"]`.