### PR TITLE
fix first_samp matching in maxwell_filter_prepare_emptyroom 

### DIFF
--- a/doc/changes/devel/bugfix.rst
+++ b/doc/changes/devel/bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug in :func:`~mne.preprocessing.maxwell_filter_prepare_emptyroom` where a difference in sampling frequencies between data and emptyroom files was ignored, by `Daniel McCloy`_.

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -181,7 +181,8 @@ def maxwell_filter_prepare_emptyroom(
 
     # handle first_samp
     raw_er_prepared.annotations.onset += raw.first_time - raw_er_prepared.first_time
-    raw_er_prepared._cropped_samp = raw._cropped_samp
+    # don't copy _cropped_samp directly, as sfreqs may differ
+    raw_er_prepared._cropped_samp = raw_er_prepared.time_as_index(raw.first_time).item()
 
     # handle annotations
     if annotations != "keep":

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1864,13 +1864,13 @@ def test_prepare_emptyroom_annot_first_samp(
         want_date = raw.info["meas_date"]
     if not equal_sfreq:
         with raw_er.info._unlock():
-            raw_er.info["sfreq"] += 100
+            raw_er.info["sfreq"] -= 100
     raw_er_prepared = maxwell_filter_prepare_emptyroom(
         raw_er=raw_er, raw=raw, meas_date=meas_date, emit_warning=True
     )
     assert raw_er.first_samp == raw_er_first_samp_orig
     assert raw_er_prepared.info["meas_date"] == want_date
-    assert raw_er_prepared.first_samp == raw.first_samp
+    assert raw_er_prepared.first_time == raw.first_time
 
     # Ensure (movement) annotations carry over regardless of whether they're
     # set before or after preparation
@@ -1882,7 +1882,8 @@ def test_prepare_emptyroom_annot_first_samp(
     prop_bad = np.isnan(raw.get_data([0], reject_by_annotation="nan")).mean()
     assert 0.3 < prop_bad < 0.4
     assert len(raw_er_prepared.annotations) == want_annot
-    prop_bad_er = np.isnan(
-        raw_er_prepared.get_data([0], reject_by_annotation="nan")
-    ).mean()
-    assert_allclose(prop_bad, prop_bad_er)
+    if equal_sfreq:
+        prop_bad_er = np.isnan(
+            raw_er_prepared.get_data([0], reject_by_annotation="nan")
+        ).mean()
+        assert_allclose(prop_bad, prop_bad_er)

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1820,8 +1820,9 @@ def test_prepare_emptyroom_bads(bads):
 @pytest.mark.parametrize("set_annot_when", ("before", "after"))
 @pytest.mark.parametrize("raw_meas_date", ("orig", None))
 @pytest.mark.parametrize("raw_er_meas_date", ("orig", None))
+@pytest.mark.parametrize("equal_sfreq", (False, True))
 def test_prepare_emptyroom_annot_first_samp(
-    set_annot_when, raw_meas_date, raw_er_meas_date
+    set_annot_when, raw_meas_date, raw_er_meas_date, equal_sfreq
 ):
     """Test prepare_emptyroom."""
     raw = read_raw_fif(raw_fname, allow_maxshield="yes", verbose=False)
@@ -1861,6 +1862,9 @@ def test_prepare_emptyroom_annot_first_samp(
         assert set_annot_when == "after"
         meas_date = "from_raw"
         want_date = raw.info["meas_date"]
+    if not equal_sfreq:
+        with raw_er.info._unlock():
+            raw_er.info["sfreq"] += 100
     raw_er_prepared = maxwell_filter_prepare_emptyroom(
         raw_er=raw_er, raw=raw, meas_date=meas_date, emit_warning=True
     )


### PR DESCRIPTION
closes https://github.com/mne-tools/mne-bids-pipeline/issues/967

`maxwell_filter_prepare_emptyroom` matches the ER raw file's `first_samp` (really `_cropped_samp`) attribute to that of the raw file from which the headpos data comes.  This breaks things if the two files have different sampling frequencies. See https://github.com/mne-tools/mne-bids-pipeline/issues/967#issuecomment-2253524228 for more info.

Draft because I'm having trouble getting tests to run on the remote machine where I found/fixed(?) this, so IDK yet if the test is actually going to pass.