### PR TITLE
ENH: check for dropping all channels

### DIFF
--- a/doc/changes/devel/12763.bugfix.rst
+++ b/doc/changes/devel/12763.bugfix.rst
@@ -1,0 +1,1 @@
+Fix check for dropping all channels in :meth:`mne.io.Raw.drop_channels` and related methods, by :newcontrib:`Farzin Negahbani`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -168,6 +168,8 @@
 
 .. _Fahimeh Mamashli: https://github.com/fmamashli
 
+.. _Farzin Negahbani: https://github.com/Farzin-Negahbani
+
 .. _Federico Raimondo: https://github.com/fraimondo
 
 .. _Federico Zamberlan: https://github.com/fzamberlan
@@ -508,6 +510,8 @@
 
 .. _Rotem Falach: https://github.com/Falach
 
+.. _Sammi Chekroud: https://github.com/schekroud
+
 .. _Samu Taulu: https://phys.washington.edu/people/samu-taulu
 
 .. _Samuel Deslauriers-Gauthier: https://github.com/sdeslauriers
@@ -535,6 +539,8 @@
 .. _Sena Er: https://github.com/sena-neuro
 
 .. _Senwen Deng: https://snwn.de
+
+.. _Seyed Yahya Shirazi: https://neuromechanist.github.io
 
 .. _Sheraz Khan: https://github.com/SherazKhan
 
@@ -625,9 +631,3 @@
 .. _Zhi Zhang: https://github.com/tczhangzhi/
 
 .. _Zvi Baratz: https://github.com/ZviBaratz
-
-.. _Seyed Yahya Shirazi: https://neuromechanist.github.io
-
-.. _Sammi Chekroud: https://github.com/schekroud
-
-.. _Farzin Negahbani: https://github.com/Farzin-Negahbani

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -629,3 +629,5 @@
 .. _Seyed Yahya Shirazi: https://neuromechanist.github.io
 
 .. _Sammi Chekroud: https://github.com/schekroud
+
+.. _Farzin Negahbani: https://github.com/Farzin-Negahbani

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -600,11 +600,10 @@ class UpdateChannelsMixin:
             msg = "Channel(s) {0} not found, nothing dropped."
             _on_missing(on_missing, msg.format(", ".join(missing)))
 
-        if set(ch_names) == set(self.ch_names):
-            raise ValueError("All channel(s) would be dropped.")
-
         bad_idx = [self.ch_names.index(ch) for ch in ch_names if ch in self.ch_names]
         idx = np.setdiff1d(np.arange(len(self.ch_names)), bad_idx)
+        if len(idx) == 0:
+            raise ValueError("All channel(s) would be dropped.")
         return self._pick_drop_channels(idx)
 
     @verbose

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -602,7 +602,7 @@ class UpdateChannelsMixin:
 
         if set(ch_names) == set(self.ch_names):
             raise ValueError("All channel(s) would be dropped.")
-            
+
         bad_idx = [self.ch_names.index(ch) for ch in ch_names if ch in self.ch_names]
         idx = np.setdiff1d(np.arange(len(self.ch_names)), bad_idx)
         return self._pick_drop_channels(idx)

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -603,7 +603,7 @@ class UpdateChannelsMixin:
         bad_idx = [self.ch_names.index(ch) for ch in ch_names if ch in self.ch_names]
         idx = np.setdiff1d(np.arange(len(self.ch_names)), bad_idx)
         if len(idx) == 0:
-            raise ValueError("All channel(s) would be dropped.")
+            raise ValueError("All channels would be dropped.")
         return self._pick_drop_channels(idx)
 
     @verbose

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -600,6 +600,9 @@ class UpdateChannelsMixin:
             msg = "Channel(s) {0} not found, nothing dropped."
             _on_missing(on_missing, msg.format(", ".join(missing)))
 
+        if set(ch_names) == set(self.ch_names):
+            raise ValueError("All channel(s) would be dropped.")
+            
         bad_idx = [self.ch_names.index(ch) for ch in ch_names if ch in self.ch_names]
         idx = np.setdiff1d(np.arange(len(self.ch_names)), bad_idx)
         return self._pick_drop_channels(idx)

--- a/mne/channels/tests/test_channels.py
+++ b/mne/channels/tests/test_channels.py
@@ -539,6 +539,8 @@ def test_drop_channels():
         raw.drop_channels(m_chs, on_missing="warn")
     # ...or ignored altogether
     raw.drop_channels(m_chs, on_missing="ignore")
+    with pytest.raises(ValueError, match="All channels"):
+        raw.drop_channels(raw.ch_names)
 
 
 def test_pick_channels():


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue
Fixes  #12762.


#### What does this implement/fix?
Avoids dropping all channels in an object by raising a ValueError with the message: `All channel(s) would be dropped.` 
