### PR TITLE
Website fixes

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -204,16 +204,16 @@ aside.footnote:last-child {
 }
 
 /* ******************************************************* navbar icon links */
-.navbar-icon-links i.fa-square-github::before {
+.navbar-icon-links svg.fa-square-github {
     color: var(--mne-color-github);
 }
-.navbar-icon-links i.fa-discourse::before {
+.navbar-icon-links svg.fa-discourse {
     color: var(--mne-color-discourse);
 }
-.navbar-icon-links i.fa-discord::before {
+.navbar-icon-links svg.fa-discord {
     color: var(--mne-color-discord);
 }
-.navbar-icon-links i.fa-mastodon::before {
+.navbar-icon-links svg.fa-mastodon {
     color: var(--mne-color-mastodon);
 }
 

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -126,8 +126,11 @@ p.sphx-glr-signature {
     border-radius: 0.5rem;
     /* ↓↓↓↓↓↓↓ these two rules copied from sphinx-design */
     box-shadow: 0 .125rem .25rem var(--sd-color-shadow) !important;
-    color: var(--sg-download-a-color);
+    text-decoration: none;
     transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+}
+.sphx-glr-download a.download code {
+    color: var(--sg-download-a-color);
 }
 .sphx-glr-download a.download::before {
     color: var(--sg-download-a-color);

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -106,11 +106,11 @@ a.sphx-glr-backref-instance:hover {
 }
 /* backreference links: make non-MNE func/meth calls resemble regular code */
 a[class^="sphx-glr-backref-module"] {
-    color: rgb(var(--pst-color-text-base));
+    color: var(--pst-color-text-base);
 }
 /* backreference links: make MNE calls bold and colorful */
 a[class^="sphx-glr-backref-module-mne"] {
-    color: rgb(var(--pst-color-link));
+    color: var(--pst-color-link);
     font-weight: var(--mne-font-weight-semibold);
 }
 /* suppress redundant note at top of every tutorial and signature at the end */
@@ -267,7 +267,7 @@ div.frontpage-gallery {
 }
 div.frontpage-gallery a {
     text-decoration: none;
-    color: rgb(var(--pst-color-text-base));
+    color: var(--pst-color-text-base);
 }
 div.frontpage-gallery img.card-img {
     transform: scale(1.8);
@@ -292,7 +292,7 @@ div.frontpage-gallery:hover .fadeout {
    needed for dark mode. */
 div.card {
     border: 1px solid var(--pst-color-border);
-    background-color: rgb(var(--pst-color-background));
+    background-color: var(--pst-color-background);
 }
 .card-header {
     border-bottom-color: var(--pst-color-border);

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -244,6 +244,9 @@ ul.quicklinks a {
     color: var(--pst-color-text-base);
     text-decoration: none;
 }
+ul.quicklinks a svg {
+    color: var(--pst-color-text-muted);
+}
 ul.quicklinks a:hover {
     text-decoration: none;
 }

--- a/doc/_templates/copyright.html
+++ b/doc/_templates/copyright.html
@@ -1,1 +1,1 @@
-<p class="text-center text-muted small">&copy; Copyright {{ copyright }}</p>
+<p class="text-center small">&copy; Copyright {{ copyright }}</p>

--- a/doc/_templates/sidebar-quicklinks.html
+++ b/doc/_templates/sidebar-quicklinks.html
@@ -2,11 +2,11 @@
     <h5 class="card-header font-weight-bold">Version {{ release }}</h5>
     <div class="card-body">
         <ul class="list-group list-group-flush list-unstyled quicklinks">
-            <li><a href="{{ pathto('auto_tutorials/index.html', 1) }}"><i class="text-muted fas fa-book fa-fw"></i> Tutorials</a></li>
-            <li><a href="{{ pathto('development/whats_new.html', 1) }}"><i class="text-muted fas fa-newspaper fa-fw"></i> Changelog</a></li>
-            <li><a href="{{ pathto('help/index.html', 1) }}"><i class="text-muted fas fa-circle-question fa-fw"></i> Get help</a></li>
-            <li><a href="{{ pathto('documentation/cite.html', 1) }}"><i class="text-muted fas fa-quote-left fa-fw"></i> Cite</a></li>
-            <li><a href="{{ pathto('development/contributing.html', 1) }}"><i class="text-muted fas fa-code-branch fa-fw"></i> Contribute</a></li>
+            <li><a href="{{ pathto('auto_tutorials/index.html', 1) }}"><i class="fas fa-book fa-fw"></i> Tutorials</a></li>
+            <li><a href="{{ pathto('development/whats_new.html', 1) }}"><i class="fas fa-newspaper fa-fw"></i> Changelog</a></li>
+            <li><a href="{{ pathto('help/index.html', 1) }}"><i class="fas fa-circle-question fa-fw"></i> Get help</a></li>
+            <li><a href="{{ pathto('documentation/cite.html', 1) }}"><i class="fas fa-quote-left fa-fw"></i> Cite</a></li>
+            <li><a href="{{ pathto('development/contributing.html', 1) }}"><i class="fas fa-code-branch fa-fw"></i> Contribute</a></li>
         </ul>
     </div>
 </div>


### PR DESCRIPTION
This PR:

- re-does the fixes to navbar icon colors from #12301 (CSS rule broke because fontawesome icons are now `<svg>` instead of `<i>` tags)
- fixes color contrast problems on sphinx-gallery page elements (closes #12750)
- fixes sidebar quicklink icon colors on dark theme
- fixes frontpage gallery text colors on dark theme

Does *not* address https://github.com/mne-tools/mne-python/issues/12750#issuecomment-2269424078 for which #12775 has been opened.