### PR TITLE
BUG: Fix bug with example

### DIFF
--- a/tutorials/stats-sensor-space/70_cluster_rmANOVA_time_freq.py
+++ b/tutorials/stats-sensor-space/70_cluster_rmANOVA_time_freq.py
@@ -239,14 +239,16 @@ F_obs, clusters, cluster_p_values, h0 = mne.stats.permutation_cluster_test(
     n_permutations=n_permutations,
     buffer_size=None,
     out_type="mask",
+    seed=0,
 )
 
 # %%
 # Create new stats image with only significant clusters:
 
 good_clusters = np.where(cluster_p_values < 0.05)[0]
-F_obs_plot = F_obs.copy()
-F_obs_plot[~clusters[np.squeeze(good_clusters)]] = np.nan
+F_obs_plot = np.full_like(F_obs, np.nan)
+for ii in good_clusters:
+    F_obs_plot[clusters[ii]] = F_obs[clusters[ii]]
 
 fig, ax = plt.subplots(figsize=(6, 4), layout="constrained")
 for f_image, cmap in zip([F_obs, F_obs_plot], ["gray", "autumn"]):


### PR DESCRIPTION
Should fix https://app.circleci.com/pipelines/github/mne-tools/mne-python/24939/workflows/56cc382c-a845-4109-8d43-f2e54f79c483/jobs/67947. Basically the example assumes that there is exactly one good cluster, which is not best practice and seems to have been affected in this case by the random state somehow.