### PR TITLE
Add support for a Transform in the trans argument of the coregistration GUI

### DIFF
--- a/doc/changes/devel/12801.newfeature.rst
+++ b/doc/changes/devel/12801.newfeature.rst
@@ -1,0 +1,1 @@
+- Add support for a :class:`mne.transforms.Transform` in the argument ``trans`` of the coregistration GUI called with :func:`mne.gui.coregistration`, by `Mathieu Scheltienne`_.

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -37,6 +37,7 @@ from ..defaults import DEFAULTS
 from ..io._read_raw import _get_supported, read_raw
 from ..surface import _CheckInside, _DistanceQuery
 from ..transforms import (
+    Transform,
     _ensure_trans,
     _get_trans,
     _get_transforms_to_coord_frame,
@@ -120,8 +121,8 @@ class CoregistrationUI(HasTraits):
         with a different color. Defaults to True.
     sensor_opacity : float
         The opacity of the sensors between 0 and 1. Defaults to 1.0.
-    trans : path-like
-        The path to the Head<->MRI transform FIF file ("-trans.fif").
+    trans : path-like | Transform
+        The Head<->MRI transform or the path to its FIF file ("-trans.fif").
     size : tuple
         The dimensions (width, height) of the rendering view. The default is
         (800, 600).
@@ -1543,10 +1544,10 @@ class CoregistrationUI(HasTraits):
         self._display_message(f"{fname} transform file is saved.")
         self._trans_modified = False
 
-    def _load_trans(self, fname):
-        mri_head_t = _ensure_trans(read_trans(fname, return_all=True), "mri", "head")[
-            "trans"
-        ]
+    def _load_trans(self, trans):
+        if not isinstance(trans, Transform):
+            trans = read_trans(trans, return_all=True)
+        mri_head_t = _ensure_trans(trans, "mri", "head")["trans"]
         rot_x, rot_y, rot_z = rotation_angles(mri_head_t)
         x, y, z = mri_head_t[:3, 3]
         self.coreg._update_params(
@@ -1556,7 +1557,7 @@ class CoregistrationUI(HasTraits):
         self._update_parameters()
         self._update_distance_estimation()
         self._update_plot()
-        self._display_message(f"{fname} transform file is loaded.")
+        self._display_message(f"{trans} transform file is loaded.")
 
     def _update_fiducials_label(self):
         if self._fiducials_file is None:

--- a/mne/gui/_gui.py
+++ b/mne/gui/_gui.py
@@ -59,8 +59,8 @@ def coregistration(
         Use a high resolution head surface.
         Default is None, which uses ``MNE_COREG_HEAD_HIGH_RES`` config value
         (which defaults to True).
-    trans : path-like | None
-        The transform file to use.
+    trans : path-like | Transform | None
+        The Head<->MRI transform or the path to its FIF file ("-trans.fif").
     orient_to_surface : bool | None
         If True (default), orient EEG electrode and head shape points
         to the head surface.


### PR DESCRIPTION
This will now work:

```
        coreg = Coregistration(
            raw.info,
            subject,
            subjects_dir,
        )
        coreg.fit_fiducials()
        coreg.fit_icp(n_iterations=40)
        coregistration(
            subject=subject,
            subjects_dir=subjects_dir,
            inst=file,
            trans=coreg.trans,  # previously, required the path to a file
            block=True,
        )
```