### PR TITLE
Cast paths to string before saving to h5

### DIFF
--- a/doc/changes/devel/12803.bugfix.rst
+++ b/doc/changes/devel/12803.bugfix.rst
@@ -1,1 +1,1 @@
-Cast :class:`pathlib.Path` to :class:`str` with the method :meth:`pathlib.Path.as_posix` before saving paths in an ``.h5`` file with ``h5io``, by `Mathieu Scheltienne`_.
+Fix handling of MRI file-path in :class:`mne.SourceSpaces` and safeguard saving of :class:`pathlib.Path` with ``h5io`` by casting to :class:`str`, by `Mathieu Scheltienne`_.

--- a/doc/changes/devel/12803.bugfix.rst
+++ b/doc/changes/devel/12803.bugfix.rst
@@ -1,0 +1,1 @@
+Cast :class:`pathlib.Path` to :class:`str` with the method :meth:`pathlib.Path.as_posix` before saving paths in an ``.h5`` file with ``h5io``, by `Mathieu Scheltienne`_.

--- a/mne/_freesurfer.py
+++ b/mne/_freesurfer.py
@@ -601,7 +601,8 @@ def read_talxfm(subject, subjects_dir=None, verbose=None):
 
 def _check_mri(mri, subject, subjects_dir) -> str:
     """Check whether an mri exists in the Freesurfer subject directory."""
-    mri = _check_fname(mri, overwrite="read", must_exist=False)
+    _validate_type(mri, "path-like", mri)
+    mri = Path(mri)
     if mri.is_file() and mri.name != mri:
         return str(mri)
     elif not mri.is_file():

--- a/mne/_freesurfer.py
+++ b/mne/_freesurfer.py
@@ -602,6 +602,7 @@ def read_talxfm(subject, subjects_dir=None, verbose=None):
 def _check_mri(mri, subject, subjects_dir):
     """Check whether an mri exists in the Freesurfer subject directory."""
     _validate_type(mri, "path-like", "mri")
+    mri = str(mri)  # cast to string as I/O requires str
     if op.isfile(mri) and op.basename(mri) != mri:
         return mri
     if not op.isfile(mri):

--- a/mne/_freesurfer.py
+++ b/mne/_freesurfer.py
@@ -599,28 +599,29 @@ def read_talxfm(subject, subjects_dir=None, verbose=None):
     return mri_mni_t
 
 
-def _check_mri(mri, subject, subjects_dir):
+def _check_mri(mri, subject, subjects_dir) -> str:
     """Check whether an mri exists in the Freesurfer subject directory."""
-    _validate_type(mri, "path-like", "mri")
-    mri = str(mri)  # cast to string as I/O requires str
-    if op.isfile(mri) and op.basename(mri) != mri:
-        return mri
-    if not op.isfile(mri):
+    mri = _check_fname(mri, overwrite="read", must_exist=False)
+    if mri.is_file() and mri.name != mri:
+        return str(mri)
+    elif not mri.is_file():
         if subject is None:
             raise FileNotFoundError(
-                f"MRI file {mri!r} not found and no subject provided"
+                f"MRI file {mri!r} not found and no subject provided."
             )
-        subjects_dir = str(get_subjects_dir(subjects_dir, raise_error=True))
-        mri = op.join(subjects_dir, subject, "mri", mri)
-        if not op.isfile(mri):
-            raise FileNotFoundError(f"MRI file {mri!r} not found")
-    if op.basename(mri) == mri:
-        err = (
-            f"Ambiguous filename - found {mri!r} in current folder.\n"
-            "If this is correct prefix name with relative or absolute path"
+        subjects_dir = get_subjects_dir(subjects_dir, raise_error=True)
+        mri = subjects_dir / subject / "mri" / mri
+        if not mri.is_file():
+            raise FileNotFoundError(
+                f"MRI file {mri!r} not found in the subjects directory "
+                f"{subjects_dir!r} for subject {subject}."
+            )
+    if mri.name == mri:
+        raise OSError(
+            f"Ambiguous filename - found {mri!r} in current folder. "
+            "If this is correct prefix name with relative or absolute path."
         )
-        raise OSError(err)
-    return mri
+    return str(mri)
 
 
 def _read_mri_info(path, units="m", return_img=False, use_nibabel=False):

--- a/mne/source_space/_source_space.py
+++ b/mne/source_space/_source_space.py
@@ -1791,9 +1791,8 @@ def setup_volume_source_space(
         mri = _check_mri(mri, subject, subjects_dir)
         if isinstance(pos, dict):
             raise ValueError(
-                "Cannot create interpolation matrix for "
-                "discrete source space, mri must be None if "
-                "pos is a dict"
+                "Cannot create interpolation matrix for discrete source space, mri "
+                "must be None if pos is a dict"
             )
 
     if volume_label is not None:

--- a/mne/source_space/_source_space.py
+++ b/mne/source_space/_source_space.py
@@ -1665,7 +1665,7 @@ def setup_volume_source_space(
 
         .. note:: For a discrete source space (``pos`` is a dict),
                   ``mri`` must be None.
-    mri : str | None
+    mri : path-like | None
         The filename of an MRI volume (mgh or mgz) to create the
         interpolation matrix over. Source estimates obtained in the
         volume source space can then be morphed onto the MRI volume

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -168,6 +168,9 @@ def _import_h5py():
 def _import_h5io_funcs():
     h5io = _soft_import("h5io", "HDF5-based I/O")
 
+    # Saving to HDF5 does not support pathlib.Path objects, which are more and more used
+    # in MNE-Python.
+    # Related issue in h5io: https://github.com/h5io/h5io/issues/113
     def cast_path_to_str(data: dict) -> dict:
         """Cast all paths value to string in data."""
         keys2cast = []

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -187,7 +187,12 @@ def _import_h5io_funcs():
 
     def write_hdf5(fname, data, *args, **kwargs):
         """Write h5 and cast all paths to string in data."""
-        data = cast_path_to_str(data)
+        if isinstance(data, dict):
+            data = cast_path_to_str(data)
+        elif isinstance(data, list):
+            for k, elt in enumerate(data):
+                if isinstance(elt, dict):
+                    data[k] = cast_path_to_str(elt)
         h5io.write_hdf5(fname, data, *args, **kwargs)
 
     return h5io.read_hdf5, write_hdf5


### PR DESCRIPTION
Related to: https://github.com/h5io/h5io/issues/113
I had several failures saving a forward model where the `mri` field was provided as a path object.

```
Traceback (most recent call last):
  File "/mnt/Isilon/9003_CBT_HNP_MEEG/temp-mathieu/meg-eeg-fMRI/subject-03.py", line 237, in <module>
    fwd.save(directory / "Sources" / "forward" / f"sub_{subject}-pos_{pos}-fwd.h5")
  File "<decorator-gen-341>", line 12, in save
  File "/pyvenv/mne/lib/python3.10/site-packages/mne/forward/forward.py", line 176, in save
    write_forward_solution(fname, self, overwrite=overwrite)
  File "<decorator-gen-345>", line 12, in write_forward_solution
  File "/pyvenv/mne/lib/python3.10/site-packages/mne/forward/forward.py", line 903, in write_forward_solution
    _write_forward_hdf5(fname, fwd)
  File "/pyvenv/mne/lib/python3.10/site-packages/mne/forward/forward.py", line 911, in _write_forward_hdf5
    write_hdf5(fname, dict(fwd=fwd), overwrite=True)
  File "/pyvenv/mne/lib/python3.10/site-packages/h5io/_h5io.py", line 111, in write_hdf5
    _triage_write(title, data, fid, comp_kw, str(type(data)),
  File "/pyvenv/mne/lib/python3.10/site-packages/h5io/_h5io.py", line 148, in _triage_write
    _triage_write(
  File "/pyvenv/mne/lib/python3.10/site-packages/h5io/_h5io.py", line 148, in _triage_write
    _triage_write(
  File "/pyvenv/mne/lib/python3.10/site-packages/h5io/_h5io.py", line 155, in _triage_write
    _triage_write(
  File "/pyvenv/mne/lib/python3.10/site-packages/h5io/_h5io.py", line 148, in _triage_write
    _triage_write(
  File "/pyvenv/mne/lib/python3.10/site-packages/h5io/_h5io.py", line 235, in _triage_write
    raise TypeError(err_str)
TypeError: unsupported type <class 'pathlib.PosixPath'> (in <class 'dict'>["fwd"]["src"][0]["mri_file"])
```