### PR TITLE
[MRG] Improves functionality of ANT Neuro reader

### DIFF
--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -87,7 +87,7 @@ I agree to the following:
 # update the checksum in the MNE_DATASETS dict below, and change version
 # here: ↓↓↓↓↓↓↓↓
 RELEASES = dict(
-    testing="0.154",
+    testing="0.155",
     misc="0.27",
     phantom_kit="0.2",
     ucl_opm_auditory="0.2",
@@ -115,7 +115,7 @@ MNE_DATASETS = dict()
 # Testing and misc are at the top as they're updated most often
 MNE_DATASETS["testing"] = dict(
     archive_name=f"{TESTING_VERSIONED}.tar.gz",
-    hash="md5:c079431e69ea1c30462a7c5fb4b5d8e0",
+    hash="md5:a3ddc1fbfd48830207112db13c3fdd6a",
     url=(
         "https://codeload.github.com/mne-tools/mne-testing-data/"
         f'tar.gz/{RELEASES["testing"]}'

--- a/mne/io/ant/ant.py
+++ b/mne/io/ant/ant.py
@@ -142,31 +142,23 @@ class RawANT(BaseRaw):
         )
         info.set_meas_date(read_meas_date(cnt))
         make, model, serial, site = read_device_info(cnt)
-        info['device_info'] = dict(
-            type = make,
-            model = model,
-            serial = serial,
-            site = site
-        )
+        info["device_info"] = dict(type=make, model=model, serial=serial, site=site)
         his_id, name, sex, birthday = read_subject_info(cnt)
-        info['subject_info'] = dict(
-            his_id = his_id,
-            first_name = name,
-            sex = sex,
-            birthday = birthday
-    )
+        info["subject_info"] = dict(
+            his_id=his_id, first_name=name, sex=sex, birthday=birthday
+        )
         if bipolars is not None:
             with info._unlock():
                 for idx in bipolars_idx:
                     info["chs"][idx]["coil_type"] = FIFF.FIFFV_COIL_EEG_BIPOLAR
         first_samps = np.array((0,))
-        last_samps = (cnt.get_sample_count() - 1, )
+        last_samps = (cnt.get_sample_count() - 1,)
         raw_extras = {
-            'orig_nchan': cnt.get_channel_count(),
-            'orig_ch_units': ch_units,
-            'first_samples': np.array(first_samps),
-            'last_samples': np.array(last_samps),
-            }
+            "orig_nchan": cnt.get_channel_count(),
+            "orig_ch_units": ch_units,
+            "first_samples": np.array(first_samps),
+            "last_samples": np.array(last_samps),
+        }
         super().__init__(
             info,
             preload=preload,
@@ -174,8 +166,8 @@ class RawANT(BaseRaw):
             last_samps=last_samps,
             filenames=[fname],
             verbose=verbose,
-            raw_extras=[raw_extras]
-            )
+            raw_extras=[raw_extras],
+        )
         # look for annotations (called trigger by ant)
         onsets, durations, descriptions, impedances, disconnect = read_triggers(cnt)
         onsets, durations, descriptions = _prepare_annotations(
@@ -199,9 +191,9 @@ class RawANT(BaseRaw):
         from antio import read_cnt
         from antio.parser import read_data
 
-        ch_units = self._raw_extras[0]['orig_ch_units']
-        first_samples = self._raw_extras[0]['first_samples']
-        n_times = self._raw_extras[0]['last_samples'] + 1
+        ch_units = self._raw_extras[0]["orig_ch_units"]
+        first_samples = self._raw_extras[0]["first_samples"]
+        n_times = self._raw_extras[0]["last_samples"] + 1
         for first_samp, this_n_times in zip(first_samples, n_times):
             i_start = max(start, first_samp)
             i_stop = min(stop, this_n_times + first_samp)
@@ -215,6 +207,7 @@ class RawANT(BaseRaw):
             else:
                 # faster than doing one = one[idx]
                 np.take(one, idx, axis=0, out=data_view)
+
 
 def _handle_bipolar_channels(
     ch_names: list[str], ch_refs: list[str], bipolars: list[str] | tuple[str, ...]

--- a/mne/io/ant/ant.py
+++ b/mne/io/ant/ant.py
@@ -80,6 +80,7 @@ class RawANT(BaseRaw):
             Note that the impedance annotation will likely have a duration of ``0``.
             If the measurement marks a discontinuity, the duration should be modified to
             cover the discontinuity in its entirety.
+    %(preload)s
     %(verbose)s
     """
 
@@ -93,6 +94,7 @@ class RawANT(BaseRaw):
         misc: str | None,
         bipolars: list[str] | tuple[str, ...] | None,
         impedance_annotation: str,
+        preload: bool | NDArray,
         *,
         verbose=None,
     ) -> None:
@@ -157,10 +159,23 @@ class RawANT(BaseRaw):
             with info._unlock():
                 for idx in bipolars_idx:
                     info["chs"][idx]["coil_type"] = FIFF.FIFFV_COIL_EEG_BIPOLAR
-        # read and scale data array
-        data = read_data(cnt)
-        _scale_data(data, ch_units)
-        super().__init__(info, preload=data, filenames=[fname], verbose=verbose)
+        first_samps = np.array((0,))
+        last_samps = (cnt.get_sample_count() - 1, )
+        raw_extras = {
+            'orig_nchan': cnt.get_channel_count(),
+            'orig_ch_units': ch_units,
+            'first_samples': np.array(first_samps),
+            'last_samples': np.array(last_samps),
+            }
+        super().__init__(
+            info,
+            preload=preload,
+            first_samps=first_samps,
+            last_samps=last_samps,
+            filenames=[fname],
+            verbose=verbose,
+            raw_extras=[raw_extras]
+            )
         # look for annotations (called trigger by ant)
         onsets, durations, descriptions, impedances, disconnect = read_triggers(cnt)
         onsets, durations, descriptions = _prepare_annotations(
@@ -180,6 +195,26 @@ class RawANT(BaseRaw):
         """List of impedance measurements."""
         return self._impedances
 
+    def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
+        from antio import read_cnt
+        from antio.parser import read_data
+
+        ch_units = self._raw_extras[0]['orig_ch_units']
+        first_samples = self._raw_extras[0]['first_samples']
+        n_times = self._raw_extras[0]['last_samples'] + 1
+        for first_samp, this_n_times in zip(first_samples, n_times):
+            i_start = max(start, first_samp)
+            i_stop = min(stop, this_n_times + first_samp)
+            # read and scale data array
+            cnt = read_cnt(str(self._filenames[fi]))
+            one = read_data(cnt, i_start, i_stop)
+            _scale_data(one, ch_units)
+            data_view = data[:, i_start - start : i_stop - start]
+            if isinstance(idx, slice):
+                data_view[:] = one[idx]
+            else:
+                # faster than doing one = one[idx]
+                np.take(one, idx, axis=0, out=data_view)
 
 def _handle_bipolar_channels(
     ch_names: list[str], ch_refs: list[str], bipolars: list[str] | tuple[str, ...]
@@ -293,6 +328,7 @@ def read_raw_ant(
     misc=r"BIP\d+",
     bipolars=None,
     impedance_annotation="impedance",
+    preload=False,
     *,
     verbose=None,
 ) -> RawANT:
@@ -310,5 +346,6 @@ def read_raw_ant(
         misc=misc,
         bipolars=bipolars,
         impedance_annotation=impedance_annotation,
+        preload=preload,
         verbose=verbose,
     )

--- a/mne/io/ant/ant.py
+++ b/mne/io/ant/ant.py
@@ -94,8 +94,8 @@ class RawANT(BaseRaw):
         misc: str | None,
         bipolars: list[str] | tuple[str, ...] | None,
         impedance_annotation: str,
-        preload: bool | NDArray,
         *,
+        preload: bool | NDArray,
         verbose=None,
     ) -> None:
         logger.info("Reading ANT file %s", fname)
@@ -321,8 +321,8 @@ def read_raw_ant(
     misc=r"BIP\d+",
     bipolars=None,
     impedance_annotation="impedance",
-    preload=False,
     *,
+    preload=False,
     verbose=None,
 ) -> RawANT:
     """

--- a/mne/io/ant/ant.py
+++ b/mne/io/ant/ant.py
@@ -102,10 +102,16 @@ class RawANT(BaseRaw):
                 "Missing optional dependency 'antio'. Use pip or conda to install "
                 "'antio'."
             )
-        check_version("antio", "0.2.0")
+        check_version("antio", "0.3.0")
 
         from antio import read_cnt
-        from antio.parser import read_data, read_info, read_triggers
+        from antio.parser import (
+            read_device_info,
+            read_info,
+            read_meas_date,
+            read_subject_info,
+            read_triggers,
+        )
 
         fname = _check_fname(fname, overwrite="read", must_exist=True, name="fname")
         _validate_type(eog, (str, None), "eog")
@@ -132,6 +138,21 @@ class RawANT(BaseRaw):
         info = create_info(
             ch_names, sfreq=cnt.get_sample_frequency(), ch_types=ch_types
         )
+        info.set_meas_date(read_meas_date(cnt))
+        make, model, serial, site = read_device_info(cnt)
+        info['device_info'] = dict(
+            type = make,
+            model = model,
+            serial = serial,
+            site = site
+        )
+        his_id, name, sex, birthday = read_subject_info(cnt)
+        info['subject_info'] = dict(
+            his_id = his_id,
+            first_name = name,
+            sex = sex,
+            birthday = birthday
+    )
         if bipolars is not None:
             with info._unlock():
                 for idx in bipolars_idx:

--- a/mne/io/ant/tests/test_ant.py
+++ b/mne/io/ant/tests/test_ant.py
@@ -108,8 +108,19 @@ def test_io_data(dataset, request):
     cnt = raw_cnt.get_data()
     bv = raw_bv.get_data()
     assert cnt.shape == bv.shape
-    assert_allclose(raw_cnt.get_data(), raw_bv.get_data(), atol=1e-8)
-
+    assert_allclose(cnt, bv, atol=1e-8)
+    _raw_cnt = read_raw_ant(dataset["cnt"]["short"], preload=False)
+    assert_allclose(
+        raw_cnt.crop(0.05, 1.05).get_data(),
+        _raw_cnt.crop(0.05, 1.05).load_data().get_data()
+        )
+    raw_cnt = read_raw_ant(dataset["cnt"]["short"], preload=False)
+    _raw_cnt = read_raw_ant(dataset["cnt"]["short"], preload=True)
+    bads = [raw_cnt.ch_names[idx] for idx in (1, 5, 10)]
+    assert_allclose(
+        raw_cnt.drop_channels(bads).get_data(),
+        _raw_cnt.drop_channels(bads).get_data()
+        )
 
 @pytest.mark.parametrize("dataset", ["ca_208", "andy_101"])
 def test_io_info(dataset: dict[str, dict[str, Path]], request) -> None:

--- a/mne/io/ant/tests/test_ant.py
+++ b/mne/io/ant/tests/test_ant.py
@@ -18,7 +18,7 @@ from mne.io import BaseRaw, read_raw_ant, read_raw_brainvision
 if TYPE_CHECKING:
     from pathlib import Path
 
-
+pytest.importorskip("antio", minversion="0.3.0")
 data_path = testing.data_path(download=False) / "antio"
 
 
@@ -45,8 +45,6 @@ def read_raw_bv(fname: Path) -> BaseRaw:
 @pytest.fixture(scope="module")
 def ca_208() -> dict[str, dict[str, Path] | str | int | dict[str, str | int]]:
     """Return the paths to the CA_208 dataset containing 64 channel gel recordings."""
-    pytest.importorskip("antio", minversion="0.3.0.dev")
-
     cnt = {
         "short": data_path / "CA_208" / "test_CA_208.cnt",
         "amp-dc": data_path / "CA_208" / "test_CA_208_amp_disconnection.cnt",
@@ -54,7 +52,6 @@ def ca_208() -> dict[str, dict[str, Path] | str | int | dict[str, str | int]]:
     }
     bv = {key: value.with_suffix(".vhdr") for key, value in cnt.items()}
     return {
-        "name": "ca_208",
         "cnt": cnt,
         "bv": bv,
         "eeg": 64,
@@ -74,14 +71,11 @@ def ca_208() -> dict[str, dict[str, Path] | str | int | dict[str, str | int]]:
 @pytest.fixture(scope="module")
 def andy_101() -> dict[str, dict[str, Path] | str | int | dict[str, str | int]]:
     """Return the path and info to the andy_101 dataset."""
-    pytest.importorskip("antio", minversion="0.3.0.dev")
-
     cnt = {
         "short": data_path / "andy_101" / "Andy_101-raw.cnt",
     }
     bv = {key: value.with_suffix(".vhdr") for key, value in cnt.items()}
     return {
-        "name": "andy_101",
         "cnt": cnt,
         "bv": bv,
         "eeg": 128,
@@ -93,7 +87,6 @@ def andy_101() -> dict[str, dict[str, Path] | str | int | dict[str, str | int]]:
             "birthday": "2024-08-19",
             "sex": 2,
         },
-        # TODO: Investigate why the serial number is missing.
         "machine_info": ("eego", "EE_226", ""),
         "hospital": "",
     }

--- a/mne/io/ant/tests/test_ant.py
+++ b/mne/io/ant/tests/test_ant.py
@@ -189,7 +189,7 @@ def test_subject_info(dataset, request):
     assert subject_info["first_name"] == dataset["patient_info"]["name"]
     assert subject_info["sex"] == dataset["patient_info"]["sex"]
     assert (
-        subject_info["birthday"].strftime("%Y-%m-%d%z")
+        subject_info["birthday"].strftime("%Y-%m-%d")
         == dataset["patient_info"]["birthday"]
     )
 

--- a/mne/io/ant/tests/test_ant.py
+++ b/mne/io/ant/tests/test_ant.py
@@ -68,7 +68,7 @@ def ca_208() -> dict[str, dict[str, Path] | str | int | dict[str, str | int]]:
         },
         "machine_info": ("eego", "EE_225", ""),
         "hospital": "",
-        }
+    }
 
 
 @pytest.fixture(scope="session")
@@ -96,7 +96,7 @@ def andy_101() -> dict[str, dict[str, Path] | str | int | dict[str, str | int]]:
         # TODO: Investigate why the serial number is missing.
         "machine_info": ("eego", "EE_226", ""),
         "hospital": "",
-        }
+    }
 
 
 @pytest.mark.parametrize("dataset", ["andy_101", "ca_208"])
@@ -112,15 +112,15 @@ def test_io_data(dataset, request):
     _raw_cnt = read_raw_ant(dataset["cnt"]["short"], preload=False)
     assert_allclose(
         raw_cnt.crop(0.05, 1.05).get_data(),
-        _raw_cnt.crop(0.05, 1.05).load_data().get_data()
-        )
+        _raw_cnt.crop(0.05, 1.05).load_data().get_data(),
+    )
     raw_cnt = read_raw_ant(dataset["cnt"]["short"], preload=False)
     _raw_cnt = read_raw_ant(dataset["cnt"]["short"], preload=True)
     bads = [raw_cnt.ch_names[idx] for idx in (1, 5, 10)]
     assert_allclose(
-        raw_cnt.drop_channels(bads).get_data(),
-        _raw_cnt.drop_channels(bads).get_data()
-        )
+        raw_cnt.drop_channels(bads).get_data(), _raw_cnt.drop_channels(bads).get_data()
+    )
+
 
 @pytest.mark.parametrize("dataset", ["ca_208", "andy_101"])
 def test_io_info(dataset: dict[str, dict[str, Path]], request) -> None:
@@ -130,13 +130,14 @@ def test_io_info(dataset: dict[str, dict[str, Path]], request) -> None:
     raw_bv = read_raw_bv(dataset["bv"]["short"])
     assert raw_cnt.ch_names == raw_bv.ch_names
     assert raw_cnt.info["sfreq"] == raw_bv.info["sfreq"]
-    assert raw_cnt.get_channel_types() == (["eeg"] * dataset["eeg"]
-                                           + ["misc"] * dataset["misc"])
+    assert raw_cnt.get_channel_types() == (
+        ["eeg"] * dataset["eeg"] + ["misc"] * dataset["misc"]
+    )
     assert_allclose(
-        (
-            raw_bv.info["meas_date"] - raw_cnt.info["meas_date"]
-            ).total_seconds(), 0, atol=1e-3
-        )
+        (raw_bv.info["meas_date"] - raw_cnt.info["meas_date"]).total_seconds(),
+        0,
+        atol=1e-3,
+    )
     if dataset["name"] == "ca_208":
         with pytest.warns(
             RuntimeWarning,
@@ -160,8 +161,10 @@ def test_subject_info(dataset, request):
     assert subject_info["his_id"] == dataset["patient_info"]["his_id"]
     assert subject_info["first_name"] == dataset["patient_info"]["name"]
     assert subject_info["sex"] == dataset["patient_info"]["sex"]
-    assert subject_info["birthday"].strftime("%Y-%m-%d%z") == \
-        dataset["patient_info"]["birthday"]
+    assert (
+        subject_info["birthday"].strftime("%Y-%m-%d%z")
+        == dataset["patient_info"]["birthday"]
+    )
 
 
 def test_io_amp_disconnection(ca_208: dict[str, dict[str, Path]]) -> None:

--- a/mne/io/ant/tests/test_ant.py
+++ b/mne/io/ant/tests/test_ant.py
@@ -71,7 +71,7 @@ def ca_208() -> dict[str, dict[str, Path] | str | int | dict[str, str | int]]:
     }
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def andy_101() -> dict[str, dict[str, Path] | str | int | dict[str, str | int]]:
     """Return the path and info to the andy_101 dataset."""
     pytest.importorskip("antio", minversion="0.3.0.dev")

--- a/tools/vulture_allowlist.py
+++ b/tools/vulture_allowlist.py
@@ -73,6 +73,9 @@ _cleanup_agg
 _notebook_vtk_works
 _.drop_inds_
 
+# mne/io/ant/tests/test_ant.py
+andy_101
+
 # mne/io/snirf/tests/test_snirf.py
 _.dataTimeSeries
 _.sourceIndex


### PR DESCRIPTION
Improves functionality added in [#12792](https://github.com/mne-tools/mne-python/pull/12792)  


#### What does this implement/fix?

- Adds following meta information in `RawANT.info`:
   - `'subject_info'` (`'his_id'`, `'first_name'`, `'sex'`, `'birthday'`)
   - `'device_info'` (`'type'`, `'model'`, `'serial'`, `'site'`)
   - `'meas_date'`
- Enables lazy data reading (i.e.`preload=False` argument) in `read_raw_ant()` 


#### Additional information
This requires bumping up the `antio` version to `0.3.0.dev0`. 
