### PR TITLE
Return filenames on save

### DIFF
--- a/doc/changes/devel/12811.newfeature.rst
+++ b/doc/changes/devel/12811.newfeature.rst
@@ -1,0 +1,1 @@
+:meth:`~mne.io.Raw` and :meth:`~mne.Epochs.save` now return the path to the saved file(s), by `Victor Ferat`_.

--- a/doc/changes/v1.8.rst
+++ b/doc/changes/v1.8.rst
@@ -129,7 +129,7 @@ New features
 - Add support for storing Fourier coefficients in :class:`mne.time_frequency.Spectrum`,
   :class:`mne.time_frequency.EpochsSpectrum`, :class:`mne.time_frequency.SpectrumArray`,
   and :class:`mne.time_frequency.EpochsSpectrumArray` objects, by `Thomas Binns`_. (`#12747 <https://github.com/mne-tools/mne-python/pulls/12747>`__)
-- :meth:`~mne.io.Raw` and :meth:`~mne.Epochs.save` now return the path to the saved file(s), by `Victor Ferat`_. (`#12811 <https://github.com/mne-tools/mne-python/pull/12811>`__)
+
 
 Other changes
 -------------

--- a/doc/changes/v1.8.rst
+++ b/doc/changes/v1.8.rst
@@ -129,7 +129,7 @@ New features
 - Add support for storing Fourier coefficients in :class:`mne.time_frequency.Spectrum`,
   :class:`mne.time_frequency.EpochsSpectrum`, :class:`mne.time_frequency.SpectrumArray`,
   and :class:`mne.time_frequency.EpochsSpectrumArray` objects, by `Thomas Binns`_. (`#12747 <https://github.com/mne-tools/mne-python/pulls/12747>`__)
-
+- :meth:`~mne.io.Raw` and :meth:`~mne.Epochs.save` now return the path to the saved file(s), by `Victor Ferat`_. (`#12811 <https://github.com/mne-tools/mne-python/pull/12811>`__)
 
 Other changes
 -------------

--- a/mne/_fiff/utils.py
+++ b/mne/_fiff/utils.py
@@ -4,6 +4,7 @@
 
 import os
 import os.path as op
+from pathlib import Path
 
 import numpy as np
 
@@ -320,8 +321,10 @@ def _make_split_fnames(fname, n_splits, split_naming):
     base, ext = op.splitext(fname)
     for i in range(n_splits):
         if split_naming == "neuromag":
-            res.append(f"{base}-{i:d}{ext}" if i else fname)
+            path = Path(f"{base}-{i:d}{ext}" if i else fname)
+            res.append(path)
         else:
             assert split_naming == "bids"
-            res.append(_construct_bids_filename(base, ext, i))
+            path = Path(_construct_bids_filename(base, ext, i))
+            res.append(path)
     return res

--- a/mne/_fiff/utils.py
+++ b/mne/_fiff/utils.py
@@ -316,6 +316,7 @@ def _construct_bids_filename(base, ext, part_idx, validate=True):
 def _make_split_fnames(fname, n_splits, split_naming):
     """Make a list of split filenames."""
     if n_splits == 1:
+        fname = Path(fname)
         return [fname]
     res = []
     base, ext = op.splitext(fname)

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2195,6 +2195,12 @@ class BaseEpochs(
             .. versionadded:: 0.24
         %(verbose)s
 
+        Returns
+        -------
+        fnames : List of path-like
+            List of path-like objects containing the path to each file split.
+            .. versionadded:: 0.18.1
+
         Notes
         -----
         Bad epochs will be dropped before saving the epochs to disk.
@@ -2306,6 +2312,7 @@ class BaseEpochs(
             this_epochs.event_id = self.event_id
 
             _save_split(this_epochs, split_fnames, part_idx, n_parts, fmt, overwrite)
+        return split_fnames
 
     @verbose
     def export(self, fname, fmt="auto", *, overwrite=False, verbose=None):

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2199,7 +2199,7 @@ class BaseEpochs(
         -------
         fnames : List of path-like
             List of path-like objects containing the path to each file split.
-            .. versionadded:: 0.19
+            .. versionadded:: 1.9
 
         Notes
         -----

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -2199,7 +2199,7 @@ class BaseEpochs(
         -------
         fnames : List of path-like
             List of path-like objects containing the path to each file split.
-            .. versionadded:: 0.18.1
+            .. versionadded:: 0.19
 
         Notes
         -----

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1667,7 +1667,7 @@ class BaseRaw(
         -------
         fnames : List of path-like
             List of path-like objects containing the path to each file split.
-            .. versionadded:: 0.18.1
+            .. versionadded:: 0.19
 
         Notes
         -----

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1663,6 +1663,12 @@ class BaseRaw(
             .. versionadded:: 0.17
         %(verbose)s
 
+        Returns
+        -------
+        filenames : List of path-like
+            List of path-like objects containing the path to each file split.
+            .. versionadded:: 0.18.1
+
         Notes
         -----
         If Raw is a concatenation of several raw files, **be warned** that
@@ -1741,7 +1747,8 @@ class BaseRaw(
 
         cfg = _RawFidWriterCfg(buffer_size, split_size, drop_small_buffer, fmt)
         raw_fid_writer = _RawFidWriter(self, info, picks, projector, start, stop, cfg)
-        _write_raw(raw_fid_writer, fname, split_naming, overwrite)
+        filenames = _write_raw(raw_fid_writer, fname, split_naming, overwrite)
+        return(filenames)
 
     @verbose
     def export(
@@ -2677,6 +2684,7 @@ def _write_raw(raw_fid_writer, fpath, split_naming, overwrite):
         raise RuntimeError(f"Exceeded maximum number of splits ({MAX_N_SPLITS}).")
 
     logger.info("[done]")
+    return split_fnames
 
 
 class _ReservedFilename:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1748,7 +1748,7 @@ class BaseRaw(
         cfg = _RawFidWriterCfg(buffer_size, split_size, drop_small_buffer, fmt)
         raw_fid_writer = _RawFidWriter(self, info, picks, projector, start, stop, cfg)
         filenames = _write_raw(raw_fid_writer, fname, split_naming, overwrite)
-        return(filenames)
+        return filenames
 
     @verbose
     def export(

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1667,7 +1667,7 @@ class BaseRaw(
         -------
         fnames : List of path-like
             List of path-like objects containing the path to each file split.
-            .. versionadded:: 0.19
+            .. versionadded:: 1.9
 
         Notes
         -----

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1665,7 +1665,7 @@ class BaseRaw(
 
         Returns
         -------
-        filenames : List of path-like
+        fnames : List of path-like
             List of path-like objects containing the path to each file split.
             .. versionadded:: 0.18.1
 
@@ -2655,6 +2655,7 @@ def _write_raw(raw_fid_writer, fpath, split_naming, overwrite):
         fpath.name, n_splits=MAX_N_SPLITS + 1, split_naming=split_naming
     )
     is_next_split, prev_fname = True, None
+    output_fnames = []
     for part_idx in range(0, MAX_N_SPLITS):
         if not is_next_split:
             break
@@ -2679,12 +2680,15 @@ def _write_raw(raw_fid_writer, fpath, split_naming, overwrite):
             logger.info(f"Renaming BIDS split file {fpath.name}")
             prev_fname = dir_path / split_fnames[0]
             shutil.move(use_fpath, prev_fname)
+            output_fnames.append(prev_fname)
+        else:
+            output_fnames.append(use_fpath)
         prev_fname = use_fpath
     else:
         raise RuntimeError(f"Exceeded maximum number of splits ({MAX_N_SPLITS}).")
 
     logger.info("[done]")
-    return split_fnames
+    return output_fnames
 
 
 class _ReservedFilename:

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -523,9 +523,11 @@ def test_split_files(tmp_path, mod, monkeypatch):
 
     # Check that if BIDS is used and no split is needed it defaults to
     # simple writing without _split- entity.
-    raw_1.save(split_fname, split_naming="bids", verbose=True)
+    split_fnames = raw_1.save(split_fname, split_naming="bids", verbose=True)
     assert split_fname.is_file()
     assert not split_fname_bids_part1.is_file()
+    assert split_fnames == [split_fname]
+
     for split_naming in ("neuromag", "bids"):
         with pytest.raises(FileExistsError, match="Destination file"):
             raw_1.save(split_fname, split_naming=split_naming, verbose=True)
@@ -535,26 +537,27 @@ def test_split_files(tmp_path, mod, monkeypatch):
     with pytest.raises(FileExistsError, match="Destination file"):
         raw_1.save(split_fname, split_naming="bids", verbose=True)
     assert not split_fname.is_file()
-    raw_1.save(split_fname, split_naming="neuromag", verbose=True)  # okay
+    split_fnames = raw_1.save(split_fname, split_naming="neuromag", verbose=True)  # okay
     os.remove(split_fname)
     os.remove(split_fname_bids_part1)
-
-    raw_1.save(split_fname, buffer_size_sec=1.0, split_size="10MB", verbose=True)
-
+    # Multiple splits
+    split_filenames = raw_1.save(split_fname, buffer_size_sec=1.0, split_size="10MB", verbose=True)
     # check that the filenames match the intended pattern
     assert split_fname.is_file()
     assert split_fname_elekta_part2.is_file()
+    assert split_filenames == [split_fname, split_fname_elekta_part2]
     # check that filenames are being formatted correctly for BIDS
-    raw_1.save(
-        split_fname,
-        buffer_size_sec=1.0,
-        split_size="10MB",
-        split_naming="bids",
-        overwrite=True,
-        verbose=True,
-    )
+    split_filenames = raw_1.save(
+                                split_fname,
+                                buffer_size_sec=1.0,
+                                split_size="10MB",
+                                split_naming="bids",
+                                overwrite=True,
+                                verbose=True,
+                            )
     assert split_fname_bids_part1.is_file()
     assert split_fname_bids_part2.is_file()
+    assert split_filenames == [split_fname_bids_part1, split_fname_bids_part2]
 
     annot = Annotations(np.arange(20), np.ones((20,)), "test")
     raw_1.set_annotations(annot)

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -537,24 +537,28 @@ def test_split_files(tmp_path, mod, monkeypatch):
     with pytest.raises(FileExistsError, match="Destination file"):
         raw_1.save(split_fname, split_naming="bids", verbose=True)
     assert not split_fname.is_file()
-    split_fnames = raw_1.save(split_fname, split_naming="neuromag", verbose=True)  # okay
+    split_fnames = raw_1.save(
+        split_fname, split_naming="neuromag", verbose=True
+    )  # okay
     os.remove(split_fname)
     os.remove(split_fname_bids_part1)
     # Multiple splits
-    split_filenames = raw_1.save(split_fname, buffer_size_sec=1.0, split_size="10MB", verbose=True)
+    split_filenames = raw_1.save(
+        split_fname, buffer_size_sec=1.0, split_size="10MB", verbose=True
+    )
     # check that the filenames match the intended pattern
     assert split_fname.is_file()
     assert split_fname_elekta_part2.is_file()
     assert split_filenames == [split_fname, split_fname_elekta_part2]
     # check that filenames are being formatted correctly for BIDS
     split_filenames = raw_1.save(
-                                split_fname,
-                                buffer_size_sec=1.0,
-                                split_size="10MB",
-                                split_naming="bids",
-                                overwrite=True,
-                                verbose=True,
-                            )
+        split_fname,
+        buffer_size_sec=1.0,
+        split_size="10MB",
+        split_naming="bids",
+        overwrite=True,
+        verbose=True,
+    )
     assert split_fname_bids_part1.is_file()
     assert split_fname_bids_part2.is_file()
     assert split_filenames == [split_fname_bids_part1, split_fname_bids_part2]

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -348,7 +348,7 @@ def _test_raw_reader(
         out_fname, tmax=raw.times[-1], overwrite=True, buffer_size_sec=1
     )
     for filename in filenames:
-        assert op.isfile(filename)
+        assert filename.is_file()
     # Test saving with not correct extension
     out_fname_h5 = op.join(tempdir, "test_raw.h5")
     with pytest.raises(OSError, match="raw must end with .fif or .fif.gz"):

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -344,8 +344,9 @@ def _test_raw_reader(
     # Test saving and reading
     out_fname = op.join(tempdir, "test_raw.fif")
     raw = concatenate_raws([raw])
-    raw.save(out_fname, tmax=raw.times[-1], overwrite=True, buffer_size_sec=1)
-
+    filenames = raw.save(out_fname, tmax=raw.times[-1], overwrite=True, buffer_size_sec=1)
+    for filename in filenames:
+        assert op.isfile(filename)
     # Test saving with not correct extension
     out_fname_h5 = op.join(tempdir, "test_raw.h5")
     with pytest.raises(OSError, match="raw must end with .fif or .fif.gz"):

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -371,11 +371,14 @@ def _test_raw_reader(
 
     # Check splitting raw files( 2 splits)
     filenames = raw.save(
-        out_fname, tmax=raw.times[-1], overwrite=True, buffer_size_sec=0.5, split_size=1066094
+        out_fname,
+        tmax=raw.times[-1],
+        overwrite=True,
+        buffer_size_sec=0.5,
+        split_size=1066094,
     )
     for filename in filenames:
         assert op.isfile(filename)
-    
 
     # Make sure concatenation works
     first_samp = raw.first_samp

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -369,6 +369,14 @@ def _test_raw_reader(
 
     assert raw3.info["kit_system_id"] == raw.info["kit_system_id"]
 
+    # Check splitting raw files( 2 splits)
+    filenames = raw.save(
+        out_fname, tmax=raw.times[-1], overwrite=True, buffer_size_sec=0.5, split_size=1066094
+    )
+    for filename in filenames:
+        assert op.isfile(filename)
+    
+
     # Make sure concatenation works
     first_samp = raw.first_samp
     last_samp = raw.last_samp

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -369,17 +369,6 @@ def _test_raw_reader(
 
     assert raw3.info["kit_system_id"] == raw.info["kit_system_id"]
 
-    # Check splitting raw files( 2 splits)
-    filenames = raw.save(
-        out_fname,
-        tmax=raw.times[-1],
-        overwrite=True,
-        buffer_size_sec=0.5,
-        split_size=1066094,
-    )
-    for filename in filenames:
-        assert op.isfile(filename)
-
     # Make sure concatenation works
     first_samp = raw.first_samp
     last_samp = raw.last_samp

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -344,7 +344,9 @@ def _test_raw_reader(
     # Test saving and reading
     out_fname = op.join(tempdir, "test_raw.fif")
     raw = concatenate_raws([raw])
-    filenames = raw.save(out_fname, tmax=raw.times[-1], overwrite=True, buffer_size_sec=1)
+    filenames = raw.save(
+        out_fname, tmax=raw.times[-1], overwrite=True, buffer_size_sec=1
+    )
     for filename in filenames:
         assert op.isfile(filename)
     # Test saving with not correct extension

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1751,7 +1751,9 @@ def test_saved_fname_no_splitting(
     dst_fpath = tmp_path / dst_fname
     split_1_fpath = tmp_path / split_1_fname
 
-    epochs.save(dst_fpath, split_naming=split_naming, verbose=True)
+    filenames = epochs.save(dst_fpath, split_naming=split_naming, verbose=True)
+    assert len(filenames) == 1
+    assert filenames[0] == Path(dst_fpath)
 
     assert dst_fpath.is_file()
     assert not split_1_fpath.is_file()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1696,7 +1696,7 @@ def test_split_naming(
     assert len(list(dst_fpath.parent.iterdir())) == n_files
     assert not (tmp_path / split_fname_fn(n_files)).is_file()
     want_paths = [tmp_path / split_fname_fn(i) for i in range(n_files)]
-    assert np.all(split_fnames == want_paths)
+    assert split_fnames == want_paths
     for want_path in want_paths:
         assert want_path.is_file()
 

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1752,8 +1752,7 @@ def test_saved_fname_no_splitting(
     split_1_fpath = tmp_path / split_1_fname
 
     filenames = epochs.save(dst_fpath, split_naming=split_naming, verbose=True)
-    assert len(filenames) == 1
-    assert filenames[0] == Path(dst_fpath)
+    assert filenames == [dst_fpath]
 
     assert dst_fpath.is_file()
     assert not split_1_fpath.is_file()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1690,12 +1690,13 @@ def test_split_naming(
     if dst_fpath.parent != tmp_path:
         dst_fpath.parent.mkdir(parents=True)
 
-    epochs.save(dst_fpath, verbose=True, **save_kwargs)
+    split_fnames = epochs.save(dst_fpath, verbose=True, **save_kwargs)
 
     # check that the filenames match the intended pattern
     assert len(list(dst_fpath.parent.iterdir())) == n_files
     assert not (tmp_path / split_fname_fn(n_files)).is_file()
     want_paths = [tmp_path / split_fname_fn(i) for i in range(n_files)]
+    assert np.all(split_fnames == want_paths)
     for want_path in want_paths:
         assert want_path.is_file()
 
@@ -1725,9 +1726,9 @@ def test_split_naming(
     assert str(bad_path).count("_split-01") == 2
     assert not bad_path.is_file(), bad_path
     bids_path.split = None
-    epochs.save(bids_path, verbose=True, **save_kwargs)
-    for want_path in want_paths:
-        assert want_path.is_file()
+    split_fnames = epochs.save(bids_path, verbose=True, **save_kwargs)
+    for split_fname in split_fnames:
+        assert split_fname.is_file()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference issue
Implements #12809.

#### What does this implement/fix?
Return filenames when saving files which might be splitted. Users can have access to the path of each split without additional code.


