### PR TITLE
DOC: read_annotations also reads BDF and GDF

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1146,8 +1146,8 @@ def read_annotations(
     r"""Read annotations from a file.
 
     This function reads a ``.fif``, ``.fif.gz``, ``.vmrk``, ``.amrk``,
-    ``.edf``, ``.txt``, ``.csv``, ``.cnt``, ``.cef``, or ``.set`` file and
-    makes an :class:`mne.Annotations` object.
+    ``.edf``, ``.bdf``, ``.gdf``, ``.txt``, ``.csv``, ``.cnt``, ``.cef``, or
+    ``.set`` file and makes an :class:`mne.Annotations` object.
 
     Parameters
     ----------


### PR DESCRIPTION
minor fix of the docstr, as BDF and GDF are also supported, but not mentioned, see: 

https://github.com/mne-tools/mne-python/blob/0aae72dda030242d992866ce6d551206749474b2/mne/annotations.py#L1235-L1236