### PR TITLE
[MRG] Fix missing safety around device_info field

### DIFF
--- a/examples/io/read_neo_format.py
+++ b/examples/io/read_neo_format.py
@@ -6,7 +6,7 @@ How to use data in neural ensemble (NEO) format
 ===============================================
 
 This example shows how to create an MNE-Python `~mne.io.Raw` object from data
-in the `neural ensemble <https://neo.readthedocs.io>`__ format. For general
+in the `neural ensemble <https://neo.readthedocs.io>`_ format. For general
 information on creating MNE-Python's data objects from NumPy arrays, see
 :ref:`tut-creating-data-structures`.
 """
@@ -14,8 +14,6 @@ information on creating MNE-Python's data objects from NumPy arrays, see
 # Authors: The MNE-Python contributors.
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
-
-# %%
 
 import neo
 

--- a/mne/_fiff/meas_info.py
+++ b/mne/_fiff/meas_info.py
@@ -2799,7 +2799,8 @@ def write_meas_info(fid, info, data_type=None, reset_range=True):
     if info.get("device_info") is not None:
         start_block(fid, FIFF.FIFFB_DEVICE)
         di = info["device_info"]
-        write_string(fid, FIFF.FIFF_DEVICE_TYPE, di["type"])
+        if di.get("type") is not None:
+            write_string(fid, FIFF.FIFF_DEVICE_TYPE, di["type"])
         for key in ("model", "serial", "site"):
             if di.get(key) is not None:
                 write_string(fid, getattr(FIFF, "FIFF_DEVICE_" + key.upper()), di[key])

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -175,6 +175,8 @@ def pytest_configure(config):
     ignore:__array_wrap__ must accept context and return_scalar arguments.*:DeprecationWarning
     # nibabel <-> NumPy 2.0
     ignore:__array__ implementation doesn't accept a copy.*:DeprecationWarning
+    # neo
+    ignore:The 'copy' argument in Quantity is deprecated.*:quantities.QuantitiesDeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()


### PR DESCRIPTION
Almost all fields are safeguard behind an `if dict.get(...) is not None`, and yet I manage to hit one of the only one that was not during saving of a `RawArray` in a unit test  ;)