### PR TITLE
[API] Deprecate average parameter from CSP and SPoC plotting methods

### DIFF
--- a/doc/changes/devel/12829.apichange.rst
+++ b/doc/changes/devel/12829.apichange.rst
@@ -1,0 +1,1 @@
+Deprecate ``average`` parameter in ``plot_filters`` and ``plot_patterns`` methods of the :class:`mne.decoding.CSP` and :class:`mne.decoding.SPoC` classes, by `Thomas Binns`_.

--- a/mne/decoding/csp.py
+++ b/mne/decoding/csp.py
@@ -18,6 +18,7 @@ from ..utils import (
     copy_doc,
     fill_doc,
     pinv,
+    warn,
 )
 from .base import BaseEstimator
 from .mixin import TransformerMixin
@@ -369,6 +370,9 @@ class CSP(TransformerMixin, BaseEstimator):
         if components is None:
             components = np.arange(self.n_components)
 
+        if average is not None:
+            warn("`average` is deprecated and will be removed in 1.10.", FutureWarning)
+
         # set sampling frequency to have 1 component per time point
         info = cp.deepcopy(info)
         with info._unlock():
@@ -499,6 +503,9 @@ class CSP(TransformerMixin, BaseEstimator):
             units = "AU"
         if components is None:
             components = np.arange(self.n_components)
+
+        if average is not None:
+            warn("`average` is deprecated and will be removed in 1.10.", FutureWarning)
 
         # set sampling frequency to have 1 component per time point
         info = cp.deepcopy(info)


### PR DESCRIPTION
#### Reference issue
Closes #12665.


#### What does this implement/fix?
In the `plot_filters` and `plot_patterns` methods used by the `CSP` and `SPoC` classes, adds a `FutureWarning` for the `average` parameter that it will be removed in v1.10.


#### Additional information
Currently in the tests, `average` isn't called anywhere. Should I add a new test for the `FutureWarning`?
