### PR TITLE
Add update to `.elc` montage reader

### DIFF
--- a/doc/changes/devel/12812.rst
+++ b/doc/changes/devel/12812.rst
@@ -1,0 +1,1 @@
+:func:`mne.channels.read_custom_montage` may now read a newer version of the ``.elc`` ASA Electrode file format, by `Stefan Appelhoff`_.

--- a/mne/channels/_standard_montage_utils.py
+++ b/mne/channels/_standard_montage_utils.py
@@ -230,6 +230,11 @@ def _check_dupes_odict(ch_names, pos):
 def _read_elc(fname, head_size):
     """Read .elc files.
 
+    The `.elc` files are so-called "asa electrode files". ASA here stands for
+    Advances Source Analysis, and is a software package developed and sold by
+    the ANT Neuro company. They provide a device for sensor digitization, called
+    'xensor', which produces the `.elc` files.
+
     Parameters
     ----------
     fname : str
@@ -241,12 +246,12 @@ def _read_elc(fname, head_size):
     Returns
     -------
     montage : instance of DigMontage
-        The montage in [m].
+        The montage units are [m].
     """
     fid_names = ("Nz", "LPA", "RPA")
 
-    ch_names_, pos = [], []
     with open(fname) as fid:
+        # Read units
         # _read_elc does require to detect the units. (see _mgh_or_standard)
         for line in fid:
             if "UnitPosition" in line:
@@ -258,15 +263,25 @@ def _read_elc(fname, head_size):
         for line in fid:
             if "Positions\n" in line:
                 break
+
+        # Read positions
         pos = []
         for line in fid:
             if "Labels\n" in line:
                 break
-            pos.append(list(map(float, line.split())))
+            if ':' in line:
+                # Of the 'new' format: `E01	:	5.288	-3.658	119.693`
+                pos.append(list(map(float, line.split(':')[1].split())))
+            else:
+                # Of the 'old' format: `5.288	-3.658	119.693`
+                pos.append(list(map(float, line.split())))
+
+        # Read labels
+        ch_names_ = []
         for line in fid:
             if not line or not set(line) - {" "}:
                 break
-            ch_names_.append(line.strip(" ").strip("\n"))
+            ch_names_.extend(line.strip(" ").strip("\n").split())
 
     pos = np.array(pos) * scale
     if head_size is not None:

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -300,7 +300,30 @@ def test_documented():
             ),
             "elc",
             None,
-            id="ASA electrode",
+            id="old ASA electrode (elc)",
+        ),
+        pytest.param(
+            partial(read_custom_montage, head_size=None),
+            (
+                "NumberPositions= 96\n"
+                "UnitPosition mm\n"
+                "Positions\n"
+                "E01	:	5.288	-3.658	119.693\n"
+                "E02	:	59.518	-4.031	101.404\n"
+                "E03	:	29.949	-50.988	98.145\n"
+                "Labels\n"
+                "E01	E02	E03\n"
+            ),
+            make_dig_montage(
+                ch_pos={
+                    "E01": [0.005288, -0.003658, 0.119693],
+                    "E02": [0.059518, -0.004031, 0.101404],
+                    "E03": [0.029949, -0.050988, 0.098145],
+                },
+            ),
+            "elc",
+            None,
+            id="new ASA electrode (elc)",
         ),
         pytest.param(
             partial(read_custom_montage, head_size=1),


### PR DESCRIPTION
Here I add some code so that `read_custom_montage` may also read newer style `.elc` files. This is consistent with tests files I have locally, as well as code in fieldtrip and discussions on the EEGLAB mailing list:

xrefs:
- https://sccn.ucsd.edu/pipermail/eeglablist/2011/003086.html
- https://github.com/fieldtrip/fieldtrip/blob/8448851bf169dc2df818a989742ad3b74474610d/fileio/private/read_asa_elc.m#L26-L28
- https://www.ant-neuro.com/products/xensor
