### PR TITLE
hotfix elc reader

### DIFF
--- a/mne/channels/_standard_montage_utils.py
+++ b/mne/channels/_standard_montage_utils.py
@@ -265,6 +265,7 @@ def _read_elc(fname, head_size):
                 break
 
         # Read positions
+        new_style = False
         pos = []
         for line in fid:
             if "Labels\n" in line:
@@ -272,6 +273,7 @@ def _read_elc(fname, head_size):
             if ":" in line:
                 # Of the 'new' format: `E01 : 5.288 -3.658 119.693`
                 pos.append(list(map(float, line.split(":")[1].split())))
+                new_style = True
             else:
                 # Of the 'old' format: `5.288 -3.658 119.693`
                 pos.append(list(map(float, line.split())))
@@ -281,7 +283,13 @@ def _read_elc(fname, head_size):
         for line in fid:
             if not line or not set(line) - {" "}:
                 break
-            ch_names_.extend(line.strip(" ").strip("\n").split())
+            if new_style:
+                # Not sure how this format would deal with spaces in channel labels,
+                # but none of my test files had this, so let's wait until it comes up.
+                parsed = line.strip(" ").strip("\n").split()
+            else:
+                parsed = [line.strip(" ").strip("\n")]
+            ch_names_.extend(parsed)
 
     pos = np.array(pos) * scale
     if head_size is not None:

--- a/mne/channels/montage.py
+++ b/mne/channels/montage.py
@@ -1537,7 +1537,10 @@ def _read_eeglab_locations(fname):
     return ch_names, pos
 
 
-def read_custom_montage(fname, head_size=HEAD_SIZE_DEFAULT, coord_frame=None):
+@verbose
+def read_custom_montage(
+    fname, head_size=HEAD_SIZE_DEFAULT, coord_frame=None, *, verbose=None
+):
     """Read a montage from a file.
 
     Parameters
@@ -1558,6 +1561,7 @@ def read_custom_montage(fname, head_size=HEAD_SIZE_DEFAULT, coord_frame=None):
         for most readers but ``"head"`` for EEGLAB.
 
         .. versionadded:: 0.20
+    %(verbose)s
 
     Returns
     -------

--- a/tutorials/inverse/70_eeg_mri_coords.py
+++ b/tutorials/inverse/70_eeg_mri_coords.py
@@ -5,8 +5,8 @@
 EEG source localization given electrode locations on an MRI
 ===========================================================
 
-This tutorial explains how to compute the forward operator from EEG data when
-the electrodes are in MRI voxel coordinates.
+This tutorial explains how to compute the forward operator from EEG data when the
+electrodes are in MRI voxel coordinates.
 """
 
 # Authors: Eric Larson <larson.eric.d@gmail.com>
@@ -104,7 +104,12 @@ plot_glass_brain(
 #     You can also verify that these are correct (or manually convert voxels
 #     to MRI coords) by looking at the points in Freeview or tkmedit.
 
-dig_montage = read_custom_montage(fname_mon, head_size=None, coord_frame="mri")
+dig_montage = read_custom_montage(
+    fname_mon,
+    head_size=None,
+    coord_frame="mri",
+    verbose="error",  # because it contains a duplicate point
+)
 dig_montage.plot()
 
 ##############################################################################

--- a/tutorials/inverse/70_eeg_mri_coords.py
+++ b/tutorials/inverse/70_eeg_mri_coords.py
@@ -104,12 +104,7 @@ plot_glass_brain(
 #     You can also verify that these are correct (or manually convert voxels
 #     to MRI coords) by looking at the points in Freeview or tkmedit.
 
-dig_montage = read_custom_montage(
-    fname_mon,
-    head_size=None,
-    coord_frame="mri",
-    verbose="error",  # because it contains a duplicate point
-)
+dig_montage = read_custom_montage(fname_mon, head_size=None, coord_frame="mri")
 dig_montage.plot()
 
 ##############################################################################


### PR DESCRIPTION
- follow up to #12830 
- see also #12837 

@larsoner a proper test to include would be to add to each pytest.parametrize item the expected channel names that the montage should contain. Do you think that's overkill, or should we do it?