### PR TITLE
Before checking with .endswith, convert raw.filenames[0] to str in case it is a path

### DIFF
--- a/mne/export/_eeglab.py
+++ b/mne/export/_eeglab.py
@@ -18,7 +18,7 @@ def _export_raw(fname, raw):
     # remove extra epoc and STI channels
     drop_chs = ["epoc"]
     # filenames attribute of RawArray is filled with None
-    if raw.filenames[0] and not (raw.filenames[0].endswith(".fif")):
+    if raw.filenames[0] and not (str(raw.filenames[0]).endswith(".fif")):
         drop_chs.append("STI 014")
 
     ch_names = [ch for ch in raw.ch_names if ch not in drop_chs]

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -276,7 +276,9 @@ class BaseRaw(
             # STI 014 channel is native only to fif ... for all other formats
             # this was artificially added by the IO procedure, so remove it
             ch_names = list(info["ch_names"])
-            if ("STI 014" in ch_names) and not (self.filenames[0].endswith(".fif")):
+            if ("STI 014" in ch_names) and not (
+                str(self.filenames[0]).endswith(".fif")
+            ):
                 ch_names.remove("STI 014")
 
             # Each channel in the data must have a corresponding channel in


### PR DESCRIPTION
I ran into an issue when I tried to export a Raw object to EEGLAB and it expected `raw.filenames[0]` to be a str, but it was a pathlib.Path.

With the little fix here, such surprises will be minimized, at no real cost for mne, IMHO.

Furthermore, we do not specify in the API, what `raw.filenames` SHOULD be in terms of a datatype: 

https://mne.tools/stable/generated/mne.io.Raw.html#mne.io.Raw.filenames

Can somebody tell me the difference between `.filenames` and `._filenames`? For example @cbrnr you are using the private attribute here: https://github.com/cbrnr/mnelab/blob/f5f641ba4376e53f1d8687692b592aecb9beea8d/src/mnelab/io/xdf.py#L154

What is your reasoning for that over using the public one?