### PR TITLE
scale figsize in plot_events depending on n unique events

### DIFF
--- a/doc/changes/devel/12844.other.rst
+++ b/doc/changes/devel/12844.other.rst
@@ -1,1 +1,1 @@
-Improve automatic figure scaling of :func:`mne.viz.plot_events` when a high amount of unique events is supplied, by `Stefan Appelhoff`_.
+Improve automatic figure scaling of :func:`mne.viz.plot_events`, and event_id and count overview legend when a high amount of unique events is supplied, by `Stefan Appelhoff`_.

--- a/doc/changes/devel/12844.other.rst
+++ b/doc/changes/devel/12844.other.rst
@@ -1,0 +1,1 @@
+Improve automatic figure scaling of :func:`mne.viz.plot_events` when a high amount of unique events is supplied, by `Stefan Appelhoff`_.

--- a/examples/datasets/limo_data.py
+++ b/examples/datasets/limo_data.py
@@ -107,7 +107,7 @@ fig.suptitle("Distribution of events in LIMO epochs")
 print(limo_epochs.metadata.head())
 
 # %%
-# Now let's take a closer look at the information in the epochs
+# Now let us take a closer look at the information in the epochs
 # metadata.
 
 # We want include all columns in the summary table

--- a/examples/preprocessing/epochs_metadata.py
+++ b/examples/preprocessing/epochs_metadata.py
@@ -35,8 +35,8 @@ raw.crop(tmax=60).filter(l_freq=0.1, h_freq=40)
 #
 # All experimental events are stored in the :class:`~mne.io.Raw` instance as
 # :class:`~mne.Annotations`. We first need to convert these to events and the
-# corresponding mapping from event codes to event names (``event_id``). We then
-# visualize the events.
+# corresponding mapping from event codes to event names (``event_id``).
+# We then visualize the events.
 all_events, all_event_id = mne.events_from_annotations(raw)
 mne.viz.plot_events(events=all_events, event_id=all_event_id, sfreq=raw.info["sfreq"])
 

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -847,7 +847,7 @@ def plot_events(
     figsize = plt.rcParams["figure.figsize"]
     # assuming the user did not change matplotlib default params, the figsize of
     # (6.4, 4.8) becomes too big if scaled beyond twice its size, so maximum 2
-    _scaling = min(max(1, len(unique_events_id) / 20), 2)
+    _scaling = min(max(1, len(unique_events_id) / 10), 2)
     figsize_scaled = np.array(figsize) * _scaling
     if axes is None:
         fig = plt.figure(layout="constrained", figsize=tuple(figsize_scaled))
@@ -867,9 +867,9 @@ def plot_events(
             continue
         y = np.full(count, idx + 1 if equal_spacing else events[ev_mask, 2][0])
         if event_id is not None:
-            event_label = f"{event_id_rev[ev]} (id={ev}; N={count})"
+            event_label = f"{event_id_rev[ev]}\n(id:{ev}; N:{count})"
         else:
-            event_label = f"id={ev}; N={count:d}"
+            event_label = f"id:{ev}; N:{count:d}"
         labels.append(event_label)
         kwargs = {}
         if ev in color:
@@ -902,15 +902,16 @@ def plot_events(
     box = ax.get_position()
     factor = 0.8 if event_id is not None else 0.9
     ax.set_position([box.x0, box.y0, box.width * factor, box.height])
-    # spread legend entries over more columns, 40 still fit in one column
+    # spread legend entries over more columns, 30 still fit in one column
     # (assuming non-user supplied fig)
-    ncols = int(np.ceil(len(unique_events_id) / 40))
+    ncols = int(np.ceil(len(unique_events_id) / 30))
     ax.legend(
         handles,
         labels,
         loc="center left",
         bbox_to_anchor=(1, 0.5),
-        fontsize="small",
+        fontsize="x-small",
+        labelspacing=0.25,
         ncols=ncols,
     )
     fig.canvas.draw()

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -841,12 +841,18 @@ def plot_events(
     color = _handle_event_colors(color, unique_events, event_id)
     import matplotlib.pyplot as plt
 
+    unique_events_id = np.array(unique_events_id)
+
     fig = None
+    figsize = plt.rcParams["figure.figsize"]
+    # XXX: low-hanging fruit scaling, this could be much improved
+    # beyond scaling factor 2, the figure gets too big
+    _scaling = min(max(1, len(unique_events_id) / 20), 2)
+    figsize_scaled = np.array(figsize) * _scaling
     if axes is None:
-        fig = plt.figure(layout="constrained")
+        fig = plt.figure(layout="constrained", figsize=tuple(figsize_scaled))
     ax = axes if axes else plt.gca()
 
-    unique_events_id = np.array(unique_events_id)
     min_event = np.min(unique_events_id)
     max_event = np.max(unique_events_id)
     max_x = (

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -867,9 +867,9 @@ def plot_events(
             continue
         y = np.full(count, idx + 1 if equal_spacing else events[ev_mask, 2][0])
         if event_id is not None:
-            event_label = f"{event_id_rev[ev]} ({count})"
+            event_label = f"{event_id_rev[ev]} (id={ev}; N={count})"
         else:
-            event_label = f"N={count:d}"
+            event_label = f"id={ev}; N={count:d}"
         labels.append(event_label)
         kwargs = {}
         if ev in color:

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -845,8 +845,8 @@ def plot_events(
 
     fig = None
     figsize = plt.rcParams["figure.figsize"]
-    # XXX: low-hanging fruit scaling, this could be much improved
-    # beyond scaling factor 2, the figure gets too big
+    # assuming the user did not change matplotlib default params, the figsize of
+    # (6.4, 4.8) becomes too big if scaled beyond twice its size, so maximum 2
     _scaling = min(max(1, len(unique_events_id) / 20), 2)
     figsize_scaled = np.array(figsize) * _scaling
     if axes is None:
@@ -902,8 +902,16 @@ def plot_events(
     box = ax.get_position()
     factor = 0.8 if event_id is not None else 0.9
     ax.set_position([box.x0, box.y0, box.width * factor, box.height])
+    # spread legend entries over more columns, 40 still fit in one column
+    # (assuming non-user supplied fig)
+    ncols = int(np.ceil(len(unique_events_id) / 40))
     ax.legend(
-        handles, labels, loc="center left", bbox_to_anchor=(1, 0.5), fontsize="small"
+        handles,
+        labels,
+        loc="center left",
+        bbox_to_anchor=(1, 0.5),
+        fontsize="small",
+        ncols=ncols,
     )
     fig.canvas.draw()
     plt_show(show)

--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -899,19 +899,31 @@ def plot_events(
     # reverse order so that the highest numbers are at the top
     # (match plot order)
     handles, labels = handles[::-1], labels[::-1]
+
+    # spread legend entries over more columns, 25 still ~fit in one column
+    # (assuming non-user supplied fig)
+    ncols = int(np.ceil(len(unique_events_id) / 25))
+
+    # Make space for legend
     box = ax.get_position()
     factor = 0.8 if event_id is not None else 0.9
+    factor -= 0.1 * (ncols - 1)
     ax.set_position([box.x0, box.y0, box.width * factor, box.height])
-    # spread legend entries over more columns, 30 still fit in one column
-    # (assuming non-user supplied fig)
-    ncols = int(np.ceil(len(unique_events_id) / 30))
+
+    # Try some adjustments to squeeze as much information into the legend
+    # without cutting off the ends
     ax.legend(
         handles,
         labels,
         loc="center left",
         bbox_to_anchor=(1, 0.5),
-        fontsize="x-small",
-        labelspacing=0.25,
+        fontsize="small",
+        borderpad=0,  # default 0.4
+        labelspacing=0.25,  # default 0.5
+        columnspacing=1.0,  # default 2
+        handletextpad=0,  # default 0.8
+        markerscale=2,  # default 1
+        borderaxespad=0.2,  # default 0.5
         ncols=ncols,
     )
     fig.canvas.draw()

--- a/tutorials/clinical/60_sleep.py
+++ b/tutorials/clinical/60_sleep.py
@@ -48,22 +48,22 @@ from mne.datasets.sleep_physionet.age import fetch_data
 # Load the data
 # -------------
 #
-# Here we download the data from two subjects and the end goal is to obtain
-# :term:`epochs` and its associated ground truth.
+# Here we download the data of two subjects. The end goal is to obtain
+# :term:`epochs` and the associated ground truth.
 #
 # MNE-Python provides us with
 # :func:`mne.datasets.sleep_physionet.age.fetch_data` to conveniently download
 # data from the Sleep Physionet dataset
 # :footcite:`KempEtAl2000,GoldbergerEtAl2000`.
 # Given a list of subjects and records, the fetcher downloads the data and
-# provides us for each subject, a pair of files:
+# provides us with a pair of files for each subject:
 #
 # * ``-PSG.edf`` containing the polysomnography. The :term:`raw` data from the
 #   EEG helmet,
 # * ``-Hypnogram.edf`` containing the :term:`annotations` recorded by an
 #   expert.
 #
-# Combining these two in a :class:`mne.io.Raw` object then we can extract
+# Combining these two in a :class:`mne.io.Raw` object will allow us to extract
 # :term:`events` based on the descriptions of the annotations to obtain the
 # :term:`epochs`.
 #

--- a/tutorials/intro/10_overview.py
+++ b/tutorials/intro/10_overview.py
@@ -208,7 +208,7 @@ event_dict = {
 # example of this is shown in the next section. There is also a convenient
 # `~mne.viz.plot_events` function for visualizing the distribution of events
 # across the duration of the recording (to make sure event detection worked as
-# expected). Here we'll also make use of the `~mne.Info` attribute to get the
+# expected). Here we will also make use of the `~mne.Info` attribute to get the
 # sampling frequency of the recording (so our x-axis will be in seconds instead
 # of in samples).
 

--- a/tutorials/preprocessing/70_fnirs_processing.py
+++ b/tutorials/preprocessing/70_fnirs_processing.py
@@ -172,7 +172,7 @@ for when, _raw in dict(Before=raw_haemo_unfiltered, After=raw_haemo).items():
 # and the unwanted heart rate component has been removed, we can extract epochs
 # related to each of the experimental conditions.
 #
-# First we extract the events of interest and visualise them to ensure they are
+# First we extract the events of interest and visualize them to ensure they are
 # correct.
 
 events, event_dict = mne.events_from_annotations(raw_haemo)
@@ -181,7 +181,7 @@ fig = mne.viz.plot_events(events, event_id=event_dict, sfreq=raw_haemo.info["sfr
 
 # %%
 # Next we define the range of our epochs, the rejection criteria,
-# baseline correction, and extract the epochs. We visualise the log of which
+# baseline correction, and extract the epochs. We visualize the log of which
 # epochs were dropped.
 
 reject_criteria = dict(hbo=80e-6)
@@ -209,7 +209,7 @@ epochs.plot_drop_log()
 # -------------------------------------------
 #
 # Now we can view the haemodynamic response for our tapping condition.
-# We visualise the response for both the oxy- and deoxyhaemoglobin, and
+# We visualize the response for both the oxy- and deoxyhaemoglobin, and
 # observe the expected peak in HbO at around 6 seconds consistently across
 # trials, and the consistent dip in HbR that is slightly delayed relative to
 # the HbO peak.
@@ -296,7 +296,7 @@ epochs["Tapping"].average(picks="hbo").plot_joint(
 # ---------------------------------------
 #
 # Finally we generate topo maps for the left and right conditions to view
-# the location of activity. First we visualise the HbO activity.
+# the location of activity. First we visualize the HbO activity.
 
 times = np.arange(4.0, 11.0, 1.0)
 epochs["Tapping/Left"].average(picks="hbo").plot_topomap(times=times, **topomap_args)

--- a/tutorials/raw/20_event_arrays.py
+++ b/tutorials/raw/20_event_arrays.py
@@ -158,8 +158,8 @@ event_dict = {
 # :func:`mne.viz.plot_events` will plot each event versus its sample number
 # (or, if you provide the sampling frequency, it will plot them versus time in
 # seconds). It can also account for the offset between sample number and sample
-# index in Neuromag systems, with the ``first_samp`` parameter. If an event
-# dictionary is provided, it will be used to generate a legend:
+# index in Neuromag systems, with the ``first_samp`` parameter.
+# If an event dictionary is provided, it will be used to generate a legend:
 
 fig = mne.viz.plot_events(
     events, sfreq=raw.info["sfreq"], first_samp=raw.first_samp, event_id=event_dict


### PR DESCRIPTION
- xref #12835 

@larsoner what do you think of this "low hanging fruit" improvement?

Using this MWE (if you checkout and install my branch here), this scales well to a number of 40 unique events. It looks a bit small in this PR preview, but on my screen it looks fine. Beyond scaling factor 2, it all gets wonky.

```python
# %%
import numpy as np
import mne

events = np.arange(300).reshape(-1, 3)

if 1:
    for i in range(10, 100, 10):
        fig = mne.viz.plot_events(events[:i, :], show=True)
        figsize = fig.get_size_inches()
        print(f"previous was: n events: {i}, Figure size: {figsize}")

# Looks good up to 40 unique events
report = mne.Report("try")
report.add_events(events[:40, :], title="events", sfreq=100)
report.save("try.html", overwrite=True)
```

# 20 unique events (no changes compared to `main` ... and any fewer events will also produce same size fig)

![image](https://github.com/user-attachments/assets/52670cd0-f64f-485e-b9db-bb67da0eec83)


# 30 unique events (slightly bigger figure, no events cut off)
![image](https://github.com/user-attachments/assets/7c1164b7-dd70-40b6-8e12-5c9b492f792e)



# 40 unique events (max scaling, no events cut off)
![image](https://github.com/user-attachments/assets/f5f8e9d2-f9a8-42cc-99de-18cab4f5f258)



# 60 unique events (same scaling as for 40, now some events cut off)
![image](https://github.com/user-attachments/assets/3f4679cb-a0c2-4239-8164-443821ef8986)

