### PR TITLE
FIX: use meters for pupil SI, not moles

### DIFF
--- a/doc/changes/devel/12850.bugfix.rst
+++ b/doc/changes/devel/12850.bugfix.rst
@@ -1,1 +1,0 @@
-Fix bug introduced in :gh:`12846` where the pupil channel SI unit was incorrectly set to Moles instead of Meters. (by `Scott Huberty`_)

--- a/doc/changes/devel/12850.bugfix.rst
+++ b/doc/changes/devel/12850.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug introduced in :gh:`12850` where the pupil channel SI unit was incorrectly set to Moles instead of Meters. (by `Scott Huberty`_)
+Fix bug introduced in :gh:`12846` where the pupil channel SI unit was incorrectly set to Moles instead of Meters. (by `Scott Huberty`_)

--- a/doc/changes/devel/12850.bugfix.rst
+++ b/doc/changes/devel/12850.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug introduced in :gh:`12850` where the pupil channel SI unit was incorrectly set to Moles instead of Meters. (by `Scott Huberty`_)

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -65,7 +65,7 @@ DEFAULTS = dict(
         gsr="S",
         temperature="C",
         eyegaze="rad",
-        pupil="M",
+        pupil="m",
     ),
     units=dict(
         mag="fT",
@@ -93,7 +93,7 @@ DEFAULTS = dict(
         gsr="S",
         temperature="C",
         eyegaze="rad",
-        pupil="µM",
+        pupil="µm",
     ),
     # scalings for the units
     scalings=dict(

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -157,7 +157,7 @@ DEFAULTS = dict(
         gsr=1.0,
         temperature=0.1,
         eyegaze=2e-1,
-        pupil=10e-6,
+        pupil=1e-2,
     ),
     scalings_cov_rank=dict(
         mag=1e12,
@@ -184,7 +184,7 @@ DEFAULTS = dict(
         hbr=(0, 20),
         csd=(-50.0, 50.0),
         eyegaze=(-1, 1),
-        pupil=(0.0, 20),
+        pupil=(-1.0, 1.0),
     ),
     titles=dict(
         mag="Magnetometers",


### PR DESCRIPTION
fixes #12849 


I actually need to simulate some pupil data in meters and  test this plotting function to see if the scalings make sense (we probably need to adjust them). 