### PR TITLE
[BUG] Fix ignored `colorbar` flag in `plot_psds_topomap()`

### DIFF
--- a/doc/changes/devel/12853.bugfix.rst
+++ b/doc/changes/devel/12853.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent the ``colorbar`` parameter being ignored in topomap plots such as :meth:`mne.time_frequency.Spectrum.plot_topomap`, by `Thomas Binns`_.

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -568,6 +568,24 @@ def test_plot_topomap_basic():
     assert_array_equal(evoked_grad.info["bads"], orig_bads)
 
 
+def test_plot_psds_topomap_colorbar():
+    """Test plot_psds_topomap colorbar option."""
+    raw = read_raw_fif(raw_fname)
+    picks = pick_types(raw.info, meg="grad")
+    info = pick_info(raw.info, picks)
+    freqs = np.arange(3.0, 9.5)
+    rng = np.random.default_rng(42)
+    psd = np.abs(rng.standard_normal((len(picks), len(freqs))))
+    bands = {"theta": [4, 8]}
+
+    plt.close("all")
+    fig_cbar = plot_psds_topomap(psd, freqs, info, colorbar=True, bands=bands)
+    assert len(fig_cbar.axes) == 2
+
+    fig_nocbar = plot_psds_topomap(psd, freqs, info, colorbar=False, bands=bands)
+    assert len(fig_nocbar.axes) == 1
+
+
 def test_plot_tfr_topomap():
     """Test plotting of TFR data."""
     raw = read_raw_fif(raw_fname)

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -2835,7 +2835,7 @@ def plot_psds_topomap(
     for ax, _mask, _data, (title, (fmin, fmax)) in zip(
         axes, freq_masks, band_data, bands.items()
     ):
-        colorbar = (not joint_vlim) or ax == axes[-1]
+        plot_colorbar = False if not colorbar else (not joint_vlim) or ax == axes[-1]
         _plot_topomap_multi_cbar(
             _data,
             pos,
@@ -2844,7 +2844,7 @@ def plot_psds_topomap(
             vlim=vlim,
             cmap=cmap,
             outlines=outlines,
-            colorbar=colorbar,
+            colorbar=plot_colorbar,
             unit=unit,
             cbar_fmt=cbar_fmt,
             sphere=sphere,


### PR DESCRIPTION
#### Reference issue

Fixes #12852


#### What does this implement/fix?

Stops `colorbar=False` from being overwritten in `plot_psds_topomap()` (and also in e.g., `*Spectrum.plot_topomap()` which calls it).


#### Additional information

Also includes a small unit test to check the `colorbar` flag isn't ignored.
