### PR TITLE
[fix] edf.py: potential overflow with n_events=256

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1440,9 +1440,7 @@ def _read_gdf_header(fname, exclude, include=None):
                     n_events = np.fromfile(fid, UINT32, 1)[0]
                 else:
                     ne = np.fromfile(fid, UINT8, 3)
-                    n_events = ne[0]
-                    for i in range(1, len(ne)):
-                        n_events = n_events + ne[i] * 2 ** (i * 8)
+                    n_events = ne[0] + (ne[1] << 8) + (ne[2] << 16)
                     event_sr = np.fromfile(fid, FLOAT32, 1)[0]
 
                 pos = np.fromfile(fid, UINT32, n_events) - 1  # 1-based inds


### PR DESCRIPTION
since the n_events assigned with the UINT8 type of number "ne". So, the default type of n_events will also be UINT8. During the summation of all three byte of "ne" will potentially cause overflow. In my case, python raised overflow error when it reach 256 which exceed the upper limit of 255. Direct Bit-Wise operation can avoid this.

<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

<!-- Example:

Fixes #1234.

-->


#### What does this implement/fix?

<!-- Explain your changes. -->


#### Additional information

<!-- Any additional information you think is important. -->
