### PR TITLE
Let users run `find_bads_muscle` also when no sensor positions are available

### DIFF
--- a/doc/changes/devel/12862.other.rst
+++ b/doc/changes/devel/12862.other.rst
@@ -1,0 +1,1 @@
+:meth:`mne.preprocessing.ICA.find_bads_muscle` can now be run when passing an ``inst`` without sensor positions. However, it will just use the first of three criteria (slope) to find muscle-related ICA components, by `Stefan Appelhoff`_.

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2014,11 +2014,14 @@ class ICA(ContainsMixin):
 
         # Need sensor positions for the criteria below, so return with only one score
         # if no positions available
-        picks = _picks_to_idx(inst.info, self.ch_names, "all", exclude=(), allow_empty=False)
+        picks = _picks_to_idx(
+            inst.info, self.ch_names, "all", exclude=(), allow_empty=False
+        )
         if not _check_ch_locs(inst.info, picks=picks):
             logger.warning(
                 "No sensor positions found. Scores for bad muscle components are only "
-                "based on the 'slope' criterion.")
+                "based on the 'slope' criterion."
+            )
             scores = slope_score
             self.labels_["muscle"] = [
                 idx for idx, score in enumerate(scores) if score > threshold

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1995,7 +1995,7 @@ class ICA(ContainsMixin):
         """
         _validate_type(threshold, "numeric", "threshold")
 
-        slope_score, focus_score, smoothness_score= None, None, None
+        slope_score, focus_score, smoothness_score = None, None, None
 
         sources = self.get_sources(inst, start=start, stop=stop)
         components = self.get_components()
@@ -2049,7 +2049,11 @@ class ICA(ContainsMixin):
             pass  # Send some warning that only one criterion will be used
 
         # multiply all criteria that are present
-        scores = [score for score in [slope_score, focus_score, smoothness_score] if score is not None]
+        scores = [
+            score
+            for score in [slope_score, focus_score, smoothness_score]
+            if score is not None
+        ]
         n_criteria = len(scores)
         scores = np.prod(np.array(scores), axis=0)
 

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -2018,7 +2018,7 @@ class ICA(ContainsMixin):
             inst.info, self.ch_names, "all", exclude=(), allow_empty=False
         )
         if not _check_ch_locs(inst.info, picks=picks):
-            logger.warning(
+            warn(
                 "No sensor positions found. Scores for bad muscle components are only "
                 "based on the 'slope' criterion."
             )

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1955,7 +1955,7 @@ class ICA(ContainsMixin):
         has been modified to 45 Hz as a default based on the criteria being
         more accurate in practice.
 
-        If `inst` is supplied without sensor positions, only the first criterion
+        If ``inst`` is supplied without sensor positions, only the first criterion
         (slope) is applied.
 
         Parameters

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -1520,6 +1520,15 @@ def test_ica_labels():
     ica.find_bads_muscle(raw)
     assert "muscle" in ica.labels_
 
+    # Try without sensor locations
+    raw.set_montage(None)
+    with catch_logging() as log:
+        labels, scores = ica.find_bads_muscle(raw, threshold=0.35)
+    log = log.getvalue()
+    assert "based on the 'slope' criterion" in log
+    assert "muscle" in ica.labels_
+    assert labels == [3]
+
 
 @testing.requires_testing_data
 @pytest.mark.parametrize(

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -1522,10 +1522,8 @@ def test_ica_labels():
 
     # Try without sensor locations
     raw.set_montage(None)
-    with catch_logging() as log:
+    with pytest.warns(RuntimeWarning, match="based on the 'slope' criterion"):
         labels, scores = ica.find_bads_muscle(raw, threshold=0.35)
-    log = log.getvalue()
-    assert "based on the 'slope' criterion" in log
     assert "muscle" in ica.labels_
     assert labels == [3]
 


### PR DESCRIPTION
This is an "issue as PR", that also contains some commits from #12860 that can be ignored.

The main point that I would like to discuss is, that [`find_bads_muscle`](https://mne.tools/stable/generated/mne.preprocessing.ICA.html#mne.preprocessing.ICA.find_bads_muscle) is using three criteria to flag components as bad by muscle activity. However, two of these criteria require sensor positions to work.

I have a dataset without sensor positions available (and no option to add standard positions), and I would still like to run this function, using only the first criterion to flag channels.

In the diff below, I show that this is easily accomplished in principle. In practice I would much rather have **some** guidance in what components **may** be muscle related, than none at all.

What are your thoughts on this?