### PR TITLE
FIX: limit ncols to a reasonable max in plot_events

### DIFF
--- a/mne/viz/misc.py
+++ b/mne/viz/misc.py
@@ -901,8 +901,8 @@ def plot_events(
     handles, labels = handles[::-1], labels[::-1]
 
     # spread legend entries over more columns, 25 still ~fit in one column
-    # (assuming non-user supplied fig)
-    ncols = int(np.ceil(len(unique_events_id) / 25))
+    # (assuming non-user supplied fig), max at 3 columns
+    ncols = min(int(np.ceil(len(unique_events_id) / 25)), 3)
 
     # Make space for legend
     box = ax.get_position()


### PR DESCRIPTION
Follow up to:

- #12844 

Beyond 3 columns (75! unique event IDs), adding more columns just ends up being chaotic.