### PR TITLE
Require good and bad channels when creating a SpectrumArray object

### DIFF
--- a/doc/changes/devel/12877.bugfix.rst
+++ b/doc/changes/devel/12877.bugfix.rst
@@ -1,0 +1,3 @@
+Fix bug where creating a :class:`~mne.time_frequency.SpectrumArray` from a
+:class:`numpy.ndarray` would require online the 'good' data channels to be present in
+the :class:`~mne.Info`, by `Mathieu Scheltienne`_.

--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -1238,12 +1238,12 @@ def _check_data_shape(data, info, freqs, dim_names, weights, is_epoched):
             f"'channel' must be the {'second' if is_epoched else 'first'} dimension of "
             "the data."
         )
-    want_n_chan = _pick_data_channels(info).size
+    want_n_chan = _pick_data_channels(info, exclude=()).size
     got_n_chan = data.shape[list(dim_names).index("channel")]
     if got_n_chan != want_n_chan:
         raise ValueError(
             f"The number of channels in `data` ({got_n_chan}) must match the number of "
-            f"good data channels in `info` ({want_n_chan})."
+            f"good + bads data channels in `info` ({want_n_chan})."
         )
 
     # given we limit max array size and ensure channel & freq dims present, only one of


### PR DESCRIPTION
Failure reported today:

```
import numpy as np
from mne.datasets import sample
from mne.io import read_raw
from mne.time_frequency import SpectrumArray
from numpy.testing import assert_allclose

fname = sample.data_path() / "MEG" / "sample" / "sample_audvis_raw.fif"
raw = read_raw(fname, preload=False).pick("eeg").load_data()

spectrum1 = raw.copy().crop(0, 10).compute_psd()
spectrum2 = raw.copy().crop(10, 20).compute_psd()

# make sure you have the same freqs!
assert_allclose(spectrum1.freqs, spectrum2.freqs)

# array of shape (n_channels, n_freqs)
data1 = spectrum1.get_data()
data2 = spectrum2.get_data()
data = np.array([data1, data2])  # array of shape (n_spectrum, n_channels, n_freqs)
data = np.average(data, axis=0)

# recompute the Spectrum object
spectrum = SpectrumArray(data, spectrum1.info, spectrum1.freqs)
spectrum.plot()
```

Raises `IndexError: index 59 is out of bounds for axis 0 with size 59` in `spectrum.plot`, i.e. the plotting functions expects the good and bad channels. And indeed, `spectrum1` or `spectrum2` include the `bads`, i.e. the underlying array as shape `(60, ...)`.

Now, if you do:

```
data1 = spectrum1.get_data(exclude=())
data2 = spectrum2.get_data(exclude=())
```

It will also raise but this time in the creation of the `SpectrumArray`: `ValueError: The number of channels in `data` (60) must match the number of good data channels in `info` (59).`

There is a clear inconsistency in what `SpectrumArray` expects and `BaseSpectrum.plot` expects. I think the cleaner fix is to have `SpectrumArray` require the `good` and `bad` channels; matching the behavior obtained by `Spectrum` when running `inst.compute_psd(...)`.