### PR TITLE
make HTML repr for Forward match others

### DIFF
--- a/mne/html_templates/repr/_channels.html.jinja
+++ b/mne/html_templates/repr/_channels.html.jinja
@@ -11,23 +11,7 @@
 {%include 'static/_section_header_row.html.jinja' %}
 
 {% for channel_type, channels in (info | format_channels).items() %}
-{% set channel_names_good = channels["good"] | map(attribute='name_html') | join(', ') %}
-<tr class="repr-element {{ section_class_name }} {{ collapsed_row_class }}">
-    <td class="mne-repr-section-toggle"></td>
-    <td>{{ channel_type }}</td>
-    <td>
-        <button class="mne-ch-names-btn sd-sphinx-override sd-btn sd-btn-info sd-text-wrap sd-shadow-sm" onclick="alert('Good {{ channel_type}}:\n\n{{ channel_names_good | safe }}')" title="(Click to open in popup)&#13;&#13;{{ channel_names_good | safe }}">
-            {{ channels["good"] | length}}
-        </button>
-
-        {% if channels["bad"] %}
-        {% set channel_names_bad = channels["bad"] | map(attribute='name_html') | join(', ') %}
-        and <button class="mne-ch-names-btn sd-sphinx-override sd-btn sd-btn-info sd-text-wrap sd-shadow-sm" onclick="alert('Bad {{ channel_type}}:\n\n{{ channel_names_bad | safe }}')" title="(Click to open in popup)&#13;&#13;{{ channel_names_bad | safe }}">
-            {{ channels["bad"] | length}} bad
-        </button>
-        {% endif %}
-    </td>
-</tr>
+    {% include 'static/_channels.html.jinja' %}
 {% endfor %}
 
 <tr class="repr-element {{ section_class_name }} {{ collapsed_row_class }}">

--- a/mne/html_templates/repr/forward.html.jinja
+++ b/mne/html_templates/repr/forward.html.jinja
@@ -1,17 +1,29 @@
 {%include '_js_and_css.html.jinja' %}
 
+{% set section = "Forward" %}
+{% set section_class_name = section | lower | append_uuid %}
+
+{# Collapse content during documentation build. #}
+{% if collapsed %}
+{% set collapsed_row_class = "mne-repr-collapsed" %}
+{% else %}
+{% set collapsed_row_class = "" %}
+{% endif %}
+
 <table class="table mne-repr-table">
     {%include 'static/_section_header_row.html.jinja' %}
     {% for channel_type, channels in (info | format_channels).items() %}
         {% include 'static/_channels.html.jinja' %}
     {% endfor %}
 
-    <tr>
-        <th>Source space</th>
+    <tr class="repr-element {{ section_class_name }} {{ collapsed_row_class }}">
+        <td class="mne-repr-section-toggle"></td>
+        <td>Source space</td>
         <td>{{ source_space_descr }}</td>
     </tr>
-    <tr>
-        <th>Source orientation</th>
+    <tr class="repr-element {{ section_class_name }} {{ collapsed_row_class }}">
+        <td class="mne-repr-section-toggle"></td>
+        <td>Source orientation</td>
         <td>{{ source_orientation }}</td>
     </tr>
 </table>

--- a/mne/html_templates/repr/forward.html.jinja
+++ b/mne/html_templates/repr/forward.html.jinja
@@ -1,27 +1,9 @@
 {%include '_js_and_css.html.jinja' %}
 
 <table class="table mne-repr-table">
+    {%include 'static/_section_header_row.html.jinja' %}
     {% for channel_type, channels in (info | format_channels).items() %}
-    {% set channel_names_good = channels["good"] | map(attribute='name_html') | join(', ') %}
-    <tr class="repr-element {{ section_class_name }} {{ collapsed_row_class }}">
-        <th>{{ channel_type }}</th>
-        <td>
-            <button class="mne-ch-names-btn sd-sphinx-override sd-button sd-btn-info sd-text-wrap sd-shadow-sm"
-                onclick="alert('Good {{ channel_type}}:\n\n{{ channel_names_good | safe }}')"
-                title="Show good channel names">
-                {{ channels["good"] | length}}
-            </button>
-
-            {% if channels["bad"] %}
-            {% set channel_names_bad = channels["bad"] | map(attribute='name_html') | join(', ') %}
-            and <button class="mne-ch-names-btn sd-sphinx-override sd-button sd-btn-info sd-text-wrap sd-shadow-sm"
-                onclick="alert('Bad {{ channel_type}}:\n\n{{ channel_names_bad | safe }}')"
-                title="Show bad channel names">
-                {{ channels["bad"] | length}} bad
-            </button>
-            {% endif %}
-        </td>
-    </tr>
+        {% include 'static/_channels.html.jinja' %}
     {% endfor %}
 
     <tr>

--- a/mne/html_templates/repr/static/_channels.html.jinja
+++ b/mne/html_templates/repr/static/_channels.html.jinja
@@ -1,0 +1,17 @@
+{% set channel_names_good = channels["good"] | map(attribute='name_html') | join(', ') %}
+<tr class="repr-element {{ section_class_name }} {{ collapsed_row_class }}">
+    <td class="mne-repr-section-toggle"></td>
+    <td>{{ channel_type }}</td>
+    <td>
+        <button class="mne-ch-names-btn sd-sphinx-override sd-btn sd-btn-info sd-text-wrap sd-shadow-sm" onclick="alert('Good {{ channel_type}}:\n\n{{ channel_names_good | safe }}')" title="(Click to open in popup)&#13;&#13;{{ channel_names_good | safe }}">
+            {{ channels["good"] | length}}
+        </button>
+
+        {% if channels["bad"] %}
+        {% set channel_names_bad = channels["bad"] | map(attribute='name_html') | join(', ') %}
+        and <button class="mne-ch-names-btn sd-sphinx-override sd-btn sd-btn-info sd-text-wrap sd-shadow-sm" onclick="alert('Bad {{ channel_type}}:\n\n{{ channel_names_bad | safe }}')" title="(Click to open in popup)&#13;&#13;{{ channel_names_bad | safe }}">
+            {{ channels["bad"] | length}} bad
+        </button>
+        {% endif %}
+    </td>
+</tr>

--- a/tutorials/forward/35_eeg_no_mri.py
+++ b/tutorials/forward/35_eeg_no_mri.py
@@ -82,7 +82,7 @@ mne.viz.plot_alignment(
 fwd = mne.make_forward_solution(
     raw.info, trans=trans, src=src, bem=bem, eeg=True, mindist=5.0, n_jobs=None
 )
-print(fwd)
+fwd
 
 ##############################################################################
 # From here on, standard inverse imaging methods can be used!


### PR DESCRIPTION
Just noticed the mismatch, thought this would improve consistency. There is a slight change in behavior, in that in the HTML repr for Forward, the hover tooltip for channels used to be "show good channel names" and now is "click to open in popup" followed by the actual channel names (consistent with the Channels section in other HTML reprs).