### PR TITLE
Website

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -20,6 +20,9 @@ html[data-theme="light"] {
     /* ↓↓↓ use default "primary" colors for "info" */
     --pst-color-info: var(--pst-teal-500);
     --pst-color-info-bg: var(--pst-teal-200);
+    /* ↓↓↓ use "warning" colors for "secondary" */
+    --pst-color-secondary: var(--pst-color-warning);
+    --pst-color-secondary-bg: var(--pst-color-warning-bg);
     /* ↓↓↓ make sure new primary (link) color propogates to links on code */
     --pst-color-inline-code-links: var(--pst-color-link);
     /* topbar logo links */
@@ -47,6 +50,9 @@ html[data-theme="dark"] {
     /* ↓↓↓ use default "primary" colors for "info" */
     --pst-color-info: var(--pst-teal-400);
     --pst-color-info-bg: var(--pst-teal-800);
+    /* ↓↓↓ use "warning" colors for "secondary" */
+    --pst-color-secondary: var(--pst-color-warning);
+    --pst-color-secondary-bg: var(--pst-color-warning-bg);
     /* ↓↓↓ make sure new primary (link) color propogates to links on code */
     --pst-color-inline-code-links: var(--pst-color-link);
     /* topbar logo links */

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -21,8 +21,6 @@ html[data-theme="light"] {
     --copybtn-opacity: 0.75;
     /* card header bg color */
     --mne-color-card-header: rgba(0, 0, 0, 0.05);
-    /* section headings */
-    --mne-color-heading: #003e80;
     /* sphinx-gallery overrides */
     --sg-download-a-background-color: var(--pst-color-primary);
     --sg-download-a-background-image: unset;
@@ -41,8 +39,6 @@ html[data-theme="dark"] {
     --copybtn-opacity: 0.25;
     /* card header bg color */
     --mne-color-card-header: rgba(255, 255, 255, 0.2);
-    /* section headings */
-    --mne-color-heading: #b8cbe0;
     /* sphinx-gallery overrides */
     --sg-download-a-background-color: var(--pst-color-primary);
     --sg-download-a-background-image: unset;
@@ -51,9 +47,6 @@ html[data-theme="dark"] {
     --sg-download-a-hover-background-color: var(--pst-color-primary-highlight);
     --sg-download-a-hover-box-shadow-1: none;
     --sg-download-a-hover-box-shadow-2: none;
-}
-h1, h2, h3, h4, h5, h6 {
-    color: var(--mne-color-heading);
 }
 
 /* ************************************************************ Sphinx fixes */

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -13,6 +13,15 @@
 
 
 html[data-theme="light"] {
+    /* pydata-sphinx-theme overrides */
+    /* ↓↓↓ use default "info" colors for "primary" */
+    --pst-color-primary: #276be9;
+    --pst-color-primary-bg: #dce7fc;
+    /* ↓↓↓ use default "primary" colors for "info" */
+    --pst-color-info: var(--pst-teal-500);
+    --pst-color-info-bg: var(--pst-teal-200);
+    /* ↓↓↓ make sure new primary (link) color propogates to links on code */
+    --pst-color-inline-code-links: var(--pst-color-link);
     /* topbar logo links */
     --mne-color-github: #000;
     --mne-color-discourse: #d0232b;
@@ -31,6 +40,15 @@ html[data-theme="light"] {
     --sg-download-a-hover-box-shadow-2: none;
 }
 html[data-theme="dark"] {
+    /* pydata-sphinx-theme overrides */
+    /* ↓↓↓ use default "info" colors for "primary" */
+    --pst-color-primary: #79a3f2;
+    --pst-color-primary-bg: #06245d;
+    /* ↓↓↓ use default "primary" colors for "info" */
+    --pst-color-info: var(--pst-teal-400);
+    --pst-color-info-bg: var(--pst-teal-800);
+    /* ↓↓↓ make sure new primary (link) color propogates to links on code */
+    --pst-color-inline-code-links: var(--pst-color-link);
     /* topbar logo links */
     --mne-color-github: rgb(240, 246, 252);  /* from their logo SVG */
     --mne-color-discourse: #FFF9AE;  /* from their logo SVG */


### PR DESCRIPTION
This PR implements 2 changes to the website's default color palette, following suggestions in https://github.com/mne-tools/mne-python/issues/12568#issuecomment-2072904141:

1. swaps the "primary" (teal) and "info" (blue) colors
2. changes the "secondary" (purple) color to be the "warning" color (orange). Thus if this PR is merged, purple is no longer used in the MNE site (as @cbrnr suggested/requested).

Marking as draft because I'm not actually convinced that this is an improvement:

- I think the info boxes look great when they're teal
- The primary color is mostly used for links, and I think the new blue color looks good in light mode but a bit off in dark mode.
- The secondary colormostly shows up in link hover effects, and I think the new orange color is a bit too prominent / high contrast for something that flickers on and off as you mouse / scroll through the page.

None of these are show-stoppers for me, so if others strongly prefer how it looks in this PR, we can go for it.

closes #12568 
