### PR TITLE
Cast tuple of filenames to list to improve error handling

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -685,6 +685,8 @@ class BaseRaw(
     def filenames(self, value):
         """The filenames used, cast to list of paths."""  # noqa: D401
         _validate_type(value, (list, tuple), "filenames")
+        if isinstance(value, tuple):
+            value = list(value)
         for k, elt in enumerate(value):
             if elt is not None:
                 value[k] = _check_fname(elt, overwrite="read", must_exist=False)


### PR DESCRIPTION
@sappelhoff Is this better? c.f. https://github.com/mne-tools/mne-python/pull/12843#issuecomment-2402147170

Now:

```py
# %%
from pathlib import Path
import numpy as np
import mne

# create a dummy raw
sampling_freq = 1000
times = np.linspace(0, 1, sampling_freq, endpoint=False)
sine = np.sin(20 * np.pi * times)
cosine = np.cos(10 * np.pi * times)
data = np.array([sine, cosine])
info = mne.create_info(
    ch_names=["10 Hz sine", "5 Hz cosine"], ch_types=["misc"] * 2, sfreq=sampling_freq
)
raw = mne.io.RawArray(data, info)

# I want to set raw.filenames
a = Path.cwd() / "IDoNotExist.jpg"

# previous error: TypeError: 'tuple' object does not support item assignment
# new error: FileNotFoundError: File <...>/IDoNotExist.jpg not found.
raw.filenames = (a,)

# this gives the right error: FileNotFoundError: File <...>/IDoNotExist.jpg not found.
raw.filenames = [a]

# this works correctly
#path_to_file_that_exists = ...
#raw.filenames = [path_to_file_that_exists]

# this works, no errors raised (which is ok, because I am using a private attribute to circumvent checks)
raw._filenames = (a,)
```