### PR TITLE
remove trailing slash from pybv base URL [ci skip]

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -166,7 +166,7 @@ intersphinx_mapping = {
     "mne-gui-addons": ("https://mne.tools/mne-gui-addons", None),
     "picard": ("https://pierreablin.github.io/picard/", None),
     "eeglabio": ("https://eeglabio.readthedocs.io/en/latest", None),
-    "pybv": ("https://pybv.readthedocs.io/en/latest/", None),
+    "pybv": ("https://pybv.readthedocs.io/en/latest", None),
 }
 intersphinx_mapping.update(
     get_intersphinx_mapping(


### PR DESCRIPTION
trailing slashes for intersphinx base URLs on readthedocs.io are triggering redirection warnings. Most are fixable upstream in https://github.com/Quansight-Labs/intersphinx_registry/pull/34, except this one.