### PR TITLE
Allow exporting edf where a channel contains only constant values

### DIFF
--- a/doc/changes/devel/12911.bugfix.rst
+++ b/doc/changes/devel/12911.bugfix.rst
@@ -1,0 +1,1 @@
+Allow exporting edf where a channel contains only constant values, by `Florian Hofer`_.

--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -138,6 +138,8 @@ def _export_raw(fname, raw, physical_range, add_ch_type):
         if physical_range == "auto":  # per channel type
             pmin = ch_types_phys_min[ch_type]
             pmax = ch_types_phys_max[ch_type]
+            if pmax == pmin:
+                pmax = pmin + 1
             prange = pmin, pmax
 
         signals.append(

--- a/mne/export/tests/test_export.py
+++ b/mne/export/tests/test_export.py
@@ -380,6 +380,16 @@ def test_export_edf_signal_clipping(tmp_path, physical_range, exceeded_bound):
 
 
 @edfio_mark()
+def test_export_edf_with_constant_channel(tmp_path):
+    """Test if exporting to edf works if a channel contains only constant values."""
+    temp_fname = tmp_path / "test.edf"
+    raw = RawArray(np.zeros((1, 10)), info=create_info(1, 1))
+    raw.export(temp_fname)
+    raw_read = read_raw_edf(temp_fname, preload=True)
+    assert_array_equal(raw_read.get_data(), np.zeros((1, 10)))
+
+
+@edfio_mark()
 @pytest.mark.parametrize(
     ("input_path", "warning_msg"),
     [


### PR DESCRIPTION
Currently, exporting to edf fails if one channel contains only constant values and `physical_range="auto"`, because `edfio` requires that (explicitly passed) physical minimum and maximum differ from each other ([link](https://github.com/the-siesta-group/edfio/blob/v0.4.4/edfio/edf_signal.py#L420-L423)). This requirement is suggested in Q8 in the [EDF FAQ](https://www.edfplus.info/specs/edffaq.html), because min == max leads to a division by zero when calculating the signal offset, which might cause an error when loading the file. This PR ensures that physical minimum and maximum are always different when using `physical_range="auto"`. For `physical_range="channelwise"`, `edfio` takes care of that , as `mne` passes no physical range to `edfio.EdfSignal`.