### PR TITLE
Fix: When using Nuitka to package a project, an error occurred when reading the file: "KeyError: 'self'" #12923

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Ruff mne
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.7.1
     hooks:
       - id: ruff
         name: ruff lint mne

--- a/mne/io/ant/ant.py
+++ b/mne/io/ant/ant.py
@@ -157,6 +157,9 @@ class RawANT(BaseRaw):
             "first_samples": np.array(first_samps),
             "last_samples": np.array(last_samps),
         }
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload=preload,

--- a/mne/io/array/array.py
+++ b/mne/io/array/array.py
@@ -83,6 +83,9 @@ class RawArray(BaseRaw):
             f"Creating RawArray with {dtype.__name__} data, "
             f"n_channels={data.shape[0]}, n_times={data.shape[1]}"
         )
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info, data, first_samps=(int(first_samp),), dtype=dtype, verbose=verbose
         )

--- a/mne/io/artemis123/artemis123.py
+++ b/mne/io/artemis123/artemis123.py
@@ -358,6 +358,8 @@ class RawArtemis123(BaseRaw):
 
         last_samps = [header_info.get("num_samples", 1) - 1]
 
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload,

--- a/mne/io/boxy/boxy.py
+++ b/mne/io/boxy/boxy.py
@@ -168,6 +168,9 @@ class RawBOXY(BaseRaw):
         assert len(raw_extras["offsets"]) == delta + 1
         if filetype == "non-parsed":
             delta //= raw_extras["source_num"]
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload,

--- a/mne/io/brainvision/brainvision.py
+++ b/mne/io/brainvision/brainvision.py
@@ -126,6 +126,9 @@ class RawBrainVision(BaseRaw):
 
         orig_format = "single" if isinstance(fmt, dict) else fmt
         raw_extras = dict(offsets=offsets, fmt=fmt, order=order, n_samples=n_samples)
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             last_samps=[n_samples - 1],

--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -1007,6 +1007,7 @@ class RawBTi(BaseRaw):
         filename = bti_info["pdf"]
         if isinstance(filename, BytesIO):
             filename = None
+        __import__("inspect").currentframe().f_locals.update(locals())
         super().__init__(
             info,
             preload,

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -536,6 +536,7 @@ class RawCNT(BaseRaw):
                 "please use mne.io.read_raw_ant instead."
             )
         last_samps = [cnt_info["n_samples"] - 1]
+        __import__("inspect").currentframe().f_locals.update(locals())
         super().__init__(
             info,
             preload,

--- a/mne/io/ctf/ctf.py
+++ b/mne/io/ctf/ctf.py
@@ -162,6 +162,9 @@ class RawCTF(BaseRaw):
                 f"file(s): {missing_names}, and the following file(s) had no "
                 f"valid samples: {no_samps}"
             )
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload,

--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -593,6 +593,8 @@ class RawCurry(BaseRaw):
         last_samps = [n_samples - 1]
         raw_extras = dict(is_ascii=is_ascii)
 
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload,

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -185,6 +185,9 @@ class RawEDF(BaseRaw):
 
         # Raw attributes
         last_samps = [edf_info["nsamples"] - 1]
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload,

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -463,6 +463,8 @@ class RawEEGLAB(BaseRaw):
             data_fname = _check_eeglab_fname(input_fname, eeg.data)
             logger.info(f"Reading {data_fname}")
 
+            __import__("inspect").currentframe().f_locals.update(locals())
+
             super().__init__(
                 info,
                 preload,
@@ -487,6 +489,7 @@ class RawEEGLAB(BaseRaw):
             data = np.empty((n_chan, n_times), dtype=float)
             data[:n_chan] = eeg.data
             data *= CAL
+            __import__("inspect").currentframe().f_locals.update(locals())
             super().__init__(
                 info,
                 data,

--- a/mne/io/egi/egi.py
+++ b/mne/io/egi/egi.py
@@ -288,6 +288,9 @@ class RawEGI(BaseRaw):
         orig_format = (
             egi_info["orig_format"] if egi_info["orig_format"] != "float" else "single"
         )
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload,

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -545,6 +545,8 @@ class RawMff(BaseRaw):
                     % (pns_samples, eeg_samples)
                 )
 
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload=preload,

--- a/mne/io/eximia/eximia.py
+++ b/mne/io/eximia/eximia.py
@@ -90,6 +90,9 @@ class RawEximia(BaseRaw):
             )
         for ch, cal in zip(info["chs"], cals):
             ch["cal"] = cal
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload=preload,

--- a/mne/io/eyelink/eyelink.py
+++ b/mne/io/eyelink/eyelink.py
@@ -105,6 +105,9 @@ class RawEyelink(BaseRaw):
             fname, find_overlaps, overlap_threshold, apply_offsets
         )
         # ======================== Create Raw Object =========================
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload=eye_ch_data,

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -130,6 +130,9 @@ class Raw(BaseRaw):
         fname = _path_from_fname(fname)
 
         _check_raw_compatibility(raws)
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             copy.deepcopy(raws[0].info),
             preload=False,

--- a/mne/io/fil/fil.py
+++ b/mne/io/fil/fil.py
@@ -120,6 +120,8 @@ class RawFIL(BaseRaw):
             meg = json.load(fid)
         info = _compose_meas_info(meg, chans)
 
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload,

--- a/mne/io/hitachi/hitachi.py
+++ b/mne/io/hitachi/hitachi.py
@@ -101,6 +101,9 @@ class RawHitachi(BaseRaw):
         raw_extras = [dict(probes=probes)]
         # One representative filename is good enough here
         # (additional filenames indicate temporal concat, not ch concat)
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload,

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -155,6 +155,9 @@ class RawKIT(BaseRaw):
         last_samps = [kit_info["n_samples"] - 1]
         self._raw_extras = [kit_info]
         _set_stimchannels(self, info, stim, stim_code)
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload,

--- a/mne/io/nedf/nedf.py
+++ b/mne/io/nedf/nedf.py
@@ -151,6 +151,9 @@ class RawNedf(BaseRaw):
         with info._unlock():
             info["meas_date"] = header["meas_date"]
         raw_extra = dict(dt=dt, dt_last=dt_last, n_full=n_full)
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload=preload,

--- a/mne/io/neuralynx/neuralynx.py
+++ b/mne/io/neuralynx/neuralynx.py
@@ -287,6 +287,8 @@ class RawNeuralynx(BaseRaw):
             description=["BAD_ACQ_SKIP"] * len(gap_start_ids),
         )
 
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info=info,
             last_samps=[sizes_sorted.sum() - 1],

--- a/mne/io/nicolet/nicolet.py
+++ b/mne/io/nicolet/nicolet.py
@@ -186,6 +186,9 @@ class RawNicolet(BaseRaw):
         input_fname = path.abspath(input_fname)
         info, header_info = _get_nicolet_info(input_fname, ch_type, eog, ecg, emg, misc)
         last_samps = [header_info["num_samples"] - 1]
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload,

--- a/mne/io/nihon/nihon.py
+++ b/mne/io/nihon/nihon.py
@@ -414,6 +414,8 @@ class RawNihon(BaseRaw):
             info["chs"][i_ch]["range"] = t_range
             info["chs"][i_ch]["cal"] = 1 / t_range
 
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload=preload,

--- a/mne/io/nirx/nirx.py
+++ b/mne/io/nirx/nirx.py
@@ -477,6 +477,8 @@ class RawNIRX(BaseRaw):
                 annot_mask |= mask
                 nan_mask[key] = None  # shouldn't need again
 
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload,

--- a/mne/io/nsx/nsx.py
+++ b/mne/io/nsx/nsx.py
@@ -194,6 +194,9 @@ class RawNSX(BaseRaw):
         ) = _get_hdr_info(input_fname, stim_channel=stim_channel, eog=eog, misc=misc)
         raw_extras["orig_format"] = orig_format
         first_samps = (raw_extras["timestamp"][0],)
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             first_samps=first_samps,

--- a/mne/io/persyst/persyst.py
+++ b/mne/io/persyst/persyst.py
@@ -226,6 +226,9 @@ class RawPersyst(BaseRaw):
 
         raw_extras = {"dtype": dtype, "n_chs": n_chs, "n_samples": n_samples}
         # create Raw object
+
+        __import__("inspect").currentframe().f_locals.update(locals())
+
         super().__init__(
             info,
             preload,

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -463,6 +463,8 @@ class RawSNIRF(BaseRaw):
                     with info._unlock():
                         info["subject_info"]["birthday"] = birthday
 
+            __import__("inspect").currentframe().f_locals.update(locals())
+
             super().__init__(
                 info,
                 preload,


### PR DESCRIPTION
Fixes #12923 

The reason the current code cannot correctly retrieve the calling parameters is that the `inspect` module does not store complete frame information for each normal call by default; it only populates the call stack information when an exception occurs. In other words, the frame information that this code relies on may not be complete, which could lead to the inability to retrieve the parameters.