### PR TITLE
MAINT: Fix tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,6 @@ jobs:
     name: '${{ matrix.os }} / ${{ matrix.kind }} / ${{ matrix.python }}'
     needs: style
     timeout-minutes: 70
-    continue-on-error: true
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -54,6 +53,7 @@ jobs:
       MNE_CI_KIND: '${{ matrix.kind }}'
       CI_OS_NAME: '${{ matrix.os }}'
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -132,4 +132,4 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-        if: always()
+        if: success() || failure()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
   pytest:
     name: '${{ matrix.os }} / ${{ matrix.kind }} / ${{ matrix.python }}'
     needs: style
-    timeout-minutes: 70
+    timeout-minutes: 80
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/doc/sphinxext/mne_doc_utils.py
+++ b/doc/sphinxext/mne_doc_utils.py
@@ -95,6 +95,8 @@ def reset_warnings(gallery_conf, fname):
         r"numpy\.core is deprecated and has been renamed to numpy\._core",
         # matplotlib
         "__array_wrap__ must accept context and return_scalar.*",
+        # selenium
+        "setting remote_server_addr",
     ):
         warnings.filterwarnings(  # deal with other modules having bad imports
             "ignore", message=f".*{key}.*", category=DeprecationWarning

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -139,6 +139,7 @@ def pytest_configure(config):
     ignore:Passing a schema to Validator\.iter_errors is deprecated.*:
     ignore:Unclosed context <zmq.asyncio.Context.*:ResourceWarning
     ignore:Jupyter is migrating its paths.*:DeprecationWarning
+    ignore:datetime\.datetime\.utcnow\(\) is deprecated.*:DeprecationWarning
     ignore:Widget\..* is deprecated\.:DeprecationWarning
     ignore:.*is deprecated in pyzmq.*:DeprecationWarning
     ignore:The `ipykernel.comm.Comm` class has been deprecated.*:DeprecationWarning

--- a/mne/decoding/receptive_field.py
+++ b/mne/decoding/receptive_field.py
@@ -392,7 +392,7 @@ class ReceptiveField(BaseEstimator):
                     f"X and y do not have the same n_epochs\n{X.shape[1]} != "
                     f"{y.shape[1]}"
                 )
-            if predict and y.shape[-1] != len(self.estimator_.coef_):
+            if predict and y.shape[-1] not in (len(self.estimator_.coef_), 1):
                 raise ValueError(
                     "Number of outputs does not match estimator coefficients dimensions"
                 )

--- a/mne/decoding/tests/test_receptive_field.py
+++ b/mne/decoding/tests/test_receptive_field.py
@@ -198,6 +198,7 @@ def test_receptive_field_basic(n_jobs):
     feature_names = [f"feature_{ii}" for ii in [0, 1, 2]]
     rf = ReceptiveField(tmin, tmax, 1, feature_names, estimator=mod, patterns=True)
     rf.fit(X, y)
+    assert rf.coef_.shape == (3, 11)
     assert_array_equal(rf.delays_, np.arange(tmin, tmax + 1))
 
     y_pred = rf.predict(X)

--- a/mne/stats/regression.py
+++ b/mne/stats/regression.py
@@ -297,9 +297,10 @@ def linear_regression_raw(
     coefs = solver(X, data.T)
     if coefs.shape[0] != data.shape[0]:
         raise ValueError(
-            "solver output has unexcepted shape. Supply a "
+            f"solver output has unexcepted shape {coefs.shape}. Supply a "
             "function that returns coefficients in the form "
-            "(n_targets, n_features), where targets == channels."
+            "(n_targets, n_features), where "
+            f"n_targets == n_channels == {data.shape[0]}."
         )
 
     # construct Evoked objects to be returned from output

--- a/mne/stats/tests/test_regression.py
+++ b/mne/stats/tests/test_regression.py
@@ -139,7 +139,9 @@ def test_continuous_regression_with_overlap():
     from sklearn.linear_model import ridge_regression
 
     def solver(X, y):
-        return ridge_regression(X, y, alpha=0.0, solver="cholesky")
+        # Newer scikit-learn returns 1D array for ridge_regression, so ensure
+        # 2D output
+        return np.atleast_2d(ridge_regression(X, y, alpha=0.0, solver="cholesky"))
 
     assert_allclose(
         effect,


### PR DESCRIPTION
Couldn't figure out why only the Azure pip-pre was failing, it was because `continue-on-error: true` was set which means the failed test in pip-pre was ignored because the `codecov` step after it succeeded :grimacing: 

![image](https://github.com/user-attachments/assets/a6b5b3bd-778c-4d79-a91a-75a130cdd2ab)


Also the doc build is failing because of a new deprecation warning in selenium.

I expect this to fail with a sklearn error in the Linux pip-pre job. Once it does, I'll push a fix for that, then self-merge if it's trivial.