### PR TITLE
Fix unit handling for µV and parsing of birthday in ANT format

### DIFF
--- a/mne/io/ant/ant.py
+++ b/mne/io/ant/ant.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
     from numpy.typing import NDArray
 
-units = {"uv": 1e-6}
+_UNITS: dict[str, float] = {"uv": 1e-6, "µV": 1e-6}
 
 
 @fill_doc
@@ -298,8 +298,8 @@ def _scale_data(data: NDArray[np.float64], ch_units: list[str]) -> None:
     for idx, unit in enumerate(ch_units):
         units_index[unit].append(idx)
     for unit, value in units_index.items():
-        if unit in units:
-            data[np.array(value, dtype=np.int16), :] *= units[unit]
+        if unit in _UNITS:
+            data[np.array(value, dtype=np.int16), :] *= _UNITS[unit]
         else:
             warn(
                 f"Unit {unit} not recognized, not scaling. Please report the unit on "

--- a/mne/io/ant/ant.py
+++ b/mne/io/ant/ant.py
@@ -143,8 +143,12 @@ class RawANT(BaseRaw):
         info["device_info"] = dict(type=make, model=model, serial=serial, site=site)
         his_id, name, sex, birthday = read_subject_info(cnt)
         info["subject_info"] = dict(
-            his_id=his_id, first_name=name, sex=sex, birthday=birthday
+            his_id=his_id,
+            first_name=name,
+            sex=sex,
         )
+        if birthday is not None:
+            info["subject_info"]["birthday"] = birthday
         if bipolars is not None:
             with info._unlock():
                 for idx in bipolars_idx:

--- a/mne/io/ant/ant.py
+++ b/mne/io/ant/ant.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
     from numpy.typing import NDArray
 
-_UNITS: dict[str, float] = {"uv": 1e-6, "µV": 1e-6}
+_UNITS: dict[str, float] = {"uv": 1e-6, "µv": 1e-6}
 
 
 @fill_doc


### PR DESCRIPTION
A couple of fixes thanks to a problematic file shared by ANT's support which go with https://github.com/mscheltienne/antio/commit/21406289b4784b0d8e35a1fb7f148eb7eb4a72d4 and https://github.com/mscheltienne/antio/commit/05e5ebb8a39a2567785fff2f10c146d3cbf28649

I didn't add any tests in `antio` for now as this file was strange with birthday partially set, sex set to `[`, and with this encoding issue that needs more attention/information for now.