### PR TITLE
fix ref=canonical in HTML page headers

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,7 +1,7 @@
 {%- extends 'pydata_sphinx_theme/layout.html' %}
 
 {% block extrahead %}
-    <link rel="canonical" href="https://mne.tools/stable/index.html" />
+    <link rel="canonical" href="https://mne.tools/stable/{{ pagename }}.html" />
     {{ super() }}
 {% endblock %}
 


### PR DESCRIPTION
a google search console report made me realize we've been doing canonical hints wrong. We had been telling crawlers that the stable docs homepage was the canonical version for *every page* in our docs. This fixes it so that the *corresponding* stable docs page is marked as canonical, e.g., https://mne.tools/**dev**/auto_tutorials/preprocessing/10_preprocessing_overview.html will now have https://mne.tools/**stable**/auto_tutorials/preprocessing/10_preprocessing_overview.html as its canonical version.
