### PR TITLE
fix doc build on windows

### DIFF
--- a/examples/inverse/evoked_ers_source_power.py
+++ b/examples/inverse/evoked_ers_source_power.py
@@ -190,4 +190,4 @@ brain_dspm = stc_dspm.plot(
 
 # %%
 # For more advanced usage, see
-# :ref:`mne-gui-addons:sphx_glr_auto_examples_evoked_ers_source_power.py`.
+# :external+mne-gui-addons:ref:`sphx_glr_auto_examples_evoked_ers_source_power.py`.


### PR DESCRIPTION
A couple of contributors have reported doc build failures on Windows:

```
Traceback (most recent call last):
  File "C:\Users\user\anaconda3\envs\mnedev\Lib\shutil.py", line 847, in move
    os.rename(src, real_dst)
OSError: [WinError 87] The parameter is incorrect: 'C:\Users\user\Documents\GitHub\mne-python\doc\generated\mne-gui-addons:sphx_glr_auto_examples_evoked_ers_source_power.py.examples.new' -> 'C:\Users\user\Documents\GitHub\mne-python\doc\generated\mne-gui-addons:sphx_glr_auto_examples_evoked_ers_source_power.py.examples'
```

The direct problem (IIUC) seems to be that the file name `mne-gui-addons:sphx_glr_auto_examples_evoked_ers_source_power.py.examples.new` contains a colon, which is not allowed by the Windows filesystem.

This PR should hopefully make it possible again to build our docs on windows. Since I don't have a windows machine I'm hoping either @contsili or @CarinaFo can test this branch (or anyone else with access to a MNE dev environment on a windows machine).

The fix (🤞🏻) is to explicitly mark the intersphinx cross-reference as an [external crossref](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#role-external) so that Sphinx (or Sphinx-Gallery? not sure) won't generate that file with the colon in its filename in the first place. TBH I haven't dug into why this works, I just tried it on a hunch and it seems to have the desired effect: it does prevent that file-that-contains-a-colon from getting generated, no alternatively-named file exists in its place, and yet in the locally-built docs the crossref is correctly resolved to https://mne.tools/mne-gui-addons/auto_examples/evoked_ers_source_power.html#sphx-glr-auto-examples-evoked-ers-source-power-py

cc @lucyleeow, do you know whether it's Sphinx or Sphinx-gallery that generates that file, and if it's Sphinx Gallery, do you think it's worth adding a note to the sphinx-gallery docs about avoiding using crossref syntax that contains a colon?