### PR TITLE
Add BaseRaw.duration property and fix duration calculation for BaseRaw "repr/html" display

### DIFF
--- a/doc/changes/devel/12955.bugfix.rst
+++ b/doc/changes/devel/12955.bugfix.rst
@@ -1,0 +1,1 @@
+Fix duration calculation for the textual (``__repr__``) and html (``_repr_html_``, used by e.g. Jupyter) display of :class:`mne.io.BaseRaw` instances. For ex. a duration of 1h is now displayed as ``00:01:00`` rather than ``00:59:60``.  By :newcontrib:`Leonardo Rochael Almeida`.

--- a/doc/changes/devel/12955.bugfix.rst
+++ b/doc/changes/devel/12955.bugfix.rst
@@ -1,1 +1,1 @@
-Fix duration calculation for the textual (``__repr__``) and html (``_repr_html_``, used by e.g. Jupyter) display of :class:`mne.io.BaseRaw` instances. For ex. a duration of 1h is now displayed as ``00:01:00`` rather than ``00:59:60``.  By :newcontrib:`Leonardo Rochael Almeida`.
+Fix duration calculation for the textual (``__repr__``) and html (``_repr_html_``, used by e.g. Jupyter) display of :class:`mne.io.Raw` instances. For example a duration of 1h is now displayed as ``00:01:00`` rather than ``00:59:60``.  By :newcontrib:`Leonardo Rochael Almeida`.

--- a/doc/changes/devel/12955.newfeature.rst
+++ b/doc/changes/devel/12955.newfeature.rst
@@ -1,0 +1,1 @@
+Add convenience :attr:`mne.io.BaseRaw.duration` property to centralize duration calculation for the textual (``__repr__``) and html (``_repr_html_``, used by e.g. Jupyter) display of :class:`mne.io.BaseRaw` instances, by :newcontrib:`Leonardo Rochael Almeida`.

--- a/doc/changes/devel/12955.newfeature.rst
+++ b/doc/changes/devel/12955.newfeature.rst
@@ -1,1 +1,1 @@
-Add convenience :attr:`mne.io.Raw.duration` property to centralize duration calculation for the textual (``__repr__``) and html (``_repr_html_``, used by e.g. Jupyter) display of :class:`mne.io.BaseRaw` instances, by :newcontrib:`Leonardo Rochael Almeida`.
+Add convenience :attr:`mne.io.Raw.duration` property to centralize duration calculation for the textual (``__repr__``) and html (``_repr_html_``, used by e.g. Jupyter) display of :class:`mne.io.Raw` instances, by :newcontrib:`Leonardo Rochael Almeida`.

--- a/doc/changes/devel/12955.newfeature.rst
+++ b/doc/changes/devel/12955.newfeature.rst
@@ -1,1 +1,1 @@
-Add convenience :attr:`mne.io.BaseRaw.duration` property to centralize duration calculation for the textual (``__repr__``) and html (``_repr_html_``, used by e.g. Jupyter) display of :class:`mne.io.BaseRaw` instances, by :newcontrib:`Leonardo Rochael Almeida`.
+Add convenience :attr:`mne.io.Raw.duration` property to centralize duration calculation for the textual (``__repr__``) and html (``_repr_html_``, used by e.g. Jupyter) display of :class:`mne.io.BaseRaw` instances, by :newcontrib:`Leonardo Rochael Almeida`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -161,6 +161,7 @@
 .. _Lau Møller Andersen: https://github.com/ualsbombe
 .. _Laura Gwilliams: https://lauragwilliams.github.io
 .. _Leonardo Barbosa: https://github.com/noreun
+.. _Leonardo Rochael Almeida: https://github.com/leorochael
 .. _Liberty Hamilton: https://github.com/libertyh
 .. _Lorenzo Desantis: https://github.com/lorenzo-desantis/
 .. _Lukas Breuer: https://www.researchgate.net/profile/Lukas-Breuer-2

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -734,9 +734,9 @@ nitpick_ignore_regex = [
     ("py:.*", r"mne\.io\..*\.Epochs.*"),  # EpochsKIT etc.
     (  # BaseRaw attributes are documented in Raw
         "py:obj",
-        "(filename|metadata|proj|times|tmax|tmin|annotations|ch_names|"
-        "|compensation_grade|duration|filenames|first_samp|first_time|"
-        "last_samp|n_times|proj|times|tmax|tmin)",
+        "(filename|metadata|proj|times|tmax|tmin|annotations|ch_names"
+        "|compensation_grade|duration|filenames|first_samp|first_time"
+        "|last_samp|n_times|proj|times|tmax|tmin)",
     ),
 ]
 suppress_warnings = [

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -732,10 +732,12 @@ nitpick_ignore_regex = [
     ("py:.*", r"mne\.io\..*\.Raw.*"),  # RawEDF etc.
     ("py:.*", r"mne\.epochs\.EpochsFIF.*"),
     ("py:.*", r"mne\.io\..*\.Epochs.*"),  # EpochsKIT etc.
-    (
+    (  # BaseRaw attributes are documented in Raw
         "py:obj",
-        "(filename|metadata|proj|times|tmax|tmin|annotations|ch_names|compensation_grade|filenames|first_samp|first_time|last_samp|n_times|proj|times|tmax|tmin)",
-    ),  # noqa: E501
+        "(filename|metadata|proj|times|tmax|tmin|annotations|ch_names|"
+        "|compensation_grade|duration|filenames|first_samp|first_time|"
+        "last_samp|n_times|proj|times|tmax|tmin)",
+    ),
 ]
 suppress_warnings = [
     "image.nonlocal_uri",  # we intentionally link outside

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -179,7 +179,7 @@ class BaseRaw(
     # NOTE: If you add a new attribute to this class and get a Sphinx warning like:
     #     docstring of mne.io.base.BaseRaw:71:
     #     WARNING: py:obj reference target not found: duration [ref.obj]
-    # You need to add the attribute to doc/conf.py nitpick_ignore. You should also
+    # You need to add the attribute to doc/conf.py nitpick_ignore_regex. You should also
     # consider adding it to the Attributes list for Raw in mne/io/fiff/raw.py.
 
     _extra_attributes = ()

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1927,7 +1927,7 @@ class BaseRaw(
     @property
     def duration(self):
         """Duration of the data in seconds."""
-        return self.times[-1]
+        return self.n_times / self.info["sfreq"]
 
     def __len__(self):
         """Return the number of time points.
@@ -2139,14 +2139,11 @@ class BaseRaw(
         )
 
     def _get_duration_string(self):
-        duration = timedelta(seconds=self.duration)
         # https://stackoverflow.com/a/10981895
-        hours, remainder = divmod(duration.seconds, 3600)
+        duration = np.ceil(self.duration)  # always take full seconds
+        hours, remainder = divmod(duration, 3600)
         minutes, seconds = divmod(remainder, 60)
-        seconds += duration.microseconds / 1e6
-        seconds = np.ceil(seconds)  # always take full seconds
-
-        return f"{int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}"
+        return f"{hours:02.0f}:{minutes:02.0f}:{seconds:02.0f}"
 
     def add_events(self, events, stim_channel=None, replace=False):
         """Add events to stim channel.

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -176,6 +176,12 @@ class BaseRaw(
           (only needed for types that support on-demand disk reads)
     """
 
+    # NOTE: If you add a new attribute to this class and get a Sphinx warning like:
+    #     docstring of mne.io.base.BaseRaw:71:
+    #     WARNING: py:obj reference target not found: duration [ref.obj]
+    # You need to add the attribute to doc/conf.py nitpick_ignore. You should also
+    # consider adding it to the Attributes list for Raw in mne/io/fiff/raw.py.
+
     _extra_attributes = ()
 
     @verbose
@@ -1926,7 +1932,10 @@ class BaseRaw(
 
     @property
     def duration(self):
-        """Duration of the data in seconds."""
+        """Duration of the data in seconds.
+
+        .. versionadded:: 1.9
+        """
         return self.n_times / self.info["sfreq"]
 
     def __len__(self):

--- a/mne/io/fiff/raw.py
+++ b/mne/io/fiff/raw.py
@@ -73,9 +73,12 @@ class Raw(BaseRaw):
         Time vector in seconds. Starts from 0, independently of `first_samp`
         value. Time interval between consecutive time samples is equal to the
         inverse of the sampling frequency.
+    duration : float
+        The duration of the raw file in seconds.
+
+        .. versionadded:: 1.9
     preload : bool
         Indicates whether raw data are in memory.
-    %(verbose)s
     """
 
     _extra_attributes = (

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -40,6 +40,7 @@ from mne.utils import (
     catch_logging,
     check_version,
     object_diff,
+    sizeof_fmt,
 )
 
 raw_fname = op.join(
@@ -783,9 +784,8 @@ def test_repr():
     info = create_info(3, sfreq)
     raw = RawArray(np.zeros((3, 10 * sfreq)), info)
     r = repr(raw)
-    assert (
-        re.search("<RawArray | 3 x 2560 (10.0 s), ~.* kB, data loaded>", r) is not None
-    ), r
+    size_str = sizeof_fmt(raw._size)
+    assert r == f"<RawArray | 3 x 2560 (10.0 s), ~{size_str}, data loaded>"
     assert raw._repr_html_()
 
 

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -778,14 +778,44 @@ def test_5839():
     assert raw_A.annotations.orig_time == _stamp_to_dt((0, 0))
 
 
-def test_repr():
+def test_duration_property():
+    """Test BaseRAW.duration property."""
+    sfreq = 1000
+    info = create_info(ch_names=["EEG 001"], sfreq=sfreq)
+    raw = BaseRaw(info, last_samps=[sfreq * 60 - 1])
+    assert raw.duration == 60
+
+
+@pytest.mark.parametrize("sfreq", [1, 10, 100, 1000])
+@pytest.mark.parametrize(
+    "duration, expected",
+    [
+        (0.1, "00:00:01"),
+        (1, "00:00:01"),
+        (59, "00:00:59"),
+        (59.1, "00:01:00"),
+        (60, "00:01:00"),
+        (60.1, "00:01:01"),
+        (61, "00:01:01"),
+        (61.1, "00:01:02"),
+    ],
+)
+def test_get_duration_string(sfreq, duration, expected):
+    """Test BaseRAW_get_duration_string() method."""
+    info = create_info(ch_names=["EEG 001"], sfreq=sfreq)
+    raw = BaseRaw(info, last_samps=[sfreq * duration - 1])
+    assert raw._get_duration_string() == expected
+
+
+@pytest.mark.parametrize("sfreq", [1, 10, 100, 256, 1000])
+def test_repr(sfreq):
     """Test repr of Raw."""
-    sfreq = 256
     info = create_info(3, sfreq)
-    raw = RawArray(np.zeros((3, 10 * sfreq)), info)
+    sample_count = 10 * sfreq
+    raw = RawArray(np.zeros((3, sample_count)), info)
     r = repr(raw)
     size_str = sizeof_fmt(raw._size)
-    assert r == f"<RawArray | 3 x 2560 (10.0 s), ~{size_str}, data loaded>"
+    assert r == f"<RawArray | 3 x {sample_count} (10.0 s), ~{size_str}, data loaded>"
     assert raw._repr_html_()
 
 


### PR DESCRIPTION
#### Reference issue (if any)

Fixes: #12954


#### What does this implement/fix?

Now the duration calculation takes into account the length of the last sample, by calculating the duration in seconds based on the number of samples divided by the sampling frequency.

#### Additional information

Instead of using `len(self.times) / self.info['sfreq']` as suggested in the bugfix, I used `self.n_times / self.info['sfreq']` instead, as `self.times` is calculated from the same info `self.n_times` is calculated from, but `self.n_times` seems to be "cheaper".

I humbly suggest reviewing commit by commit.