### PR TITLE
FIX: gracefully handle bad patient info in edf reader

### DIFF
--- a/doc/changes/devel/12968.bugfix.rst
+++ b/doc/changes/devel/12968.bugfix.rst
@@ -1,0 +1,1 @@
+Gracefully handle invalid patient info when reading EDF files by `Scott Huberty`_.

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -824,10 +824,19 @@ def _read_edf_header(
                     for info in id_info[4:]:
                         if "=" in info:
                             key, value = info.split("=")
+                            err = f"patient {key} info cannot be {value}, skipping."
                             if key in ["weight", "height"]:
-                                patient[key] = float(value)
+                                try:
+                                    patient[key] = float(value)
+                                except ValueError:
+                                    logger.debug(err)
+                                    continue
                             elif key in ["hand"]:
-                                patient[key] = int(value)
+                                try:
+                                    patient[key] = int(value)
+                                except ValueError:
+                                    logger.debug(err)
+                                    continue
                             else:
                                 warn(f"Invalid patient information {key}")
 


### PR DESCRIPTION
I have EEG data that I  saved to EDF with MNE a long time ago (maybe 2 years ago). Reading that file back used to work, but I believe a regression/bug was introduced in #11952 . Specifically this block:

https://github.com/mne-tools/mne-python/blob/d810cc5977f95f76c3eb82db6b7003af68bd6176/mne/io/edf/edf.py#L826-L830
This code logic  assumed that patient hand info would be something like `"hand=1"` or `"hand=2"` but in my case it was `"hand=None"` which caused a `ValueError` because you cannot do `int('None')`.

#### What does this implement/fix?

This PR just wraps things in a try-except block to gracefully handle weird cases like mine.

#### Additional information

I really don't know much about the EDF format, so cc'ing @paulroujansky as the author of https://github.com/mne-tools/mne-python/pull/11952. LMK if you think this looks reasonable to you!.



~~Also - Perhaps no change log necessary?~~