### PR TITLE
Use `uint16_codec` argument

### DIFF
--- a/doc/changes/devel/12971.newfeature.rst
+++ b/doc/changes/devel/12971.newfeature.rst
@@ -1,0 +1,1 @@
+Add support for ``uint16_codec`` argument in :func:`mne.io.read_raw_eeglab` when ``pymatreader`` (which already supported this argument previously) is not installed, by `Clemens Brunner`_.

--- a/mne/io/eeglab/_eeglab.py
+++ b/mne/io/eeglab/_eeglab.py
@@ -75,7 +75,9 @@ def _readmat(fname, uint16_codec=None):
     try:
         read_mat = _import_pymatreader_funcs("EEGLAB I/O")
     except RuntimeError:  # pymatreader not installed
-        eeg = loadmat(fname, squeeze_me=True, mat_dtype=False)
+        eeg = loadmat(
+            fname, squeeze_me=True, mat_dtype=False, uint16_codec=uint16_codec
+        )
         return _check_for_scipy_mat_struct(eeg)
     else:
         return read_mat(fname, uint16_codec=uint16_codec)


### PR DESCRIPTION
The `uint16_codec` argument for `mne.io.read_raw_eeglab()` is only used if the optional dependency `pymatreader` is installed. This PR adds support for this argument for the case when `pymatreader` is not installed and hence the base implementation via `scipy.io.loadmat()` is used.

Note that `uint16_codec` is an undocumented parameter of `scipy.io.loadmat()` (which is also used by `pymatreader`). However, since it seems to work in practice, I guess adding it should be fine.

This issue was originally reported in our forum [here](https://mne.discourse.group/t/why-is-the-uint16-codec-parameter-of-mne-io-read-raw-eeglab-not-passed-to-loadmat/10547/1).