### PR TITLE
Changed epochs_clean_sub = model_plain.apply(epochs) to epochs_clean_sub = model_sub.apply(epochs), making use of the regression coefficients from model_sub. #12977

### DIFF
--- a/doc/changes/devel/12978.other.rst
+++ b/doc/changes/devel/12978.other.rst
@@ -1,1 +1,1 @@
-Fix a mistake in :ref:`_tut-artifact-regression` where the wrong regression coefficients were applied, by :newcontrib:`Jacob Phelan`.
+Fix a mistake in :ref:`tut-artifact-regression` where the wrong regression coefficients were applied, by :newcontrib:`Jacob Phelan`.

--- a/doc/changes/devel/12978.other.rst
+++ b/doc/changes/devel/12978.other.rst
@@ -1,1 +1,1 @@
-Fix a mistake in :ref:`_tut-artifact-regression` where the wrong regression coefficients were applied, by `Jacob Phelan`_.
+Fix a mistake in :ref:`_tut-artifact-regression` where the wrong regression coefficients were applied, by :newcontrib:`Jacob Phelan`.

--- a/doc/changes/devel/12978.other.rst
+++ b/doc/changes/devel/12978.other.rst
@@ -1,0 +1,1 @@
+Fix a mistake in :ref:`_tut-artifact-regression` where the wrong regression coefficients were applied, by `Jacob Phelan`_.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -119,6 +119,7 @@
 .. _Ivo de Jong: https://github.com/ivopascal
 .. _Jaakko Leppakangas: https://github.com/jaeilepp
 .. _Jack Zhang: https://github.com/jackz314
+.. _Jacob Phelan: https://github.com/JacPhe
 .. _Jacob Woessner: https://github.com/withmywoessner
 .. _Jair Montoya Martinez: https://github.com/jmontoyam
 .. _Jan Ebert: https://www.jan-ebert.com/

--- a/tutorials/preprocessing/35_artifact_correction_regression.py
+++ b/tutorials/preprocessing/35_artifact_correction_regression.py
@@ -149,7 +149,7 @@ fig = model_sub.plot(vlim=(None, 0.4))
 fig.set_size_inches(3, 2)
 
 # apply the regression coefficients to the original epochs
-epochs_clean_sub = model_plain.apply(epochs).apply_baseline()
+epochs_clean_sub = model_sub.apply(epochs).apply_baseline()
 fig = epochs_clean_sub.average("all").plot(**plot_kwargs)
 fig.set_size_inches(6, 6)
 


### PR DESCRIPTION
Fixes #12977  

Originally, the documentation has epochs_clean_sub = model_plain.apply(epochs), which uses model_plain. This contains regression coefficients for EOG, with some bleed in from adjacent EEG sensors. I believe that it should be using epochs_clean_sub = model_sub.apply(epochs), as this makes use of model_sub, which has the regression coefficients for EOG, with a subtraction of epochs.evoked. I think this makes sense because otherwise, model_sub is completely redundant. 






