### PR TITLE
DOC: fix numpy docstr example Vectorizer()

### DIFF
--- a/mne/decoding/transformer.py
+++ b/mne/decoding/transformer.py
@@ -251,8 +251,10 @@ class Vectorizer(TransformerMixin):
 
     Examples
     --------
-    clf = make_pipeline(SpatialFilter(), _XdawnTransformer(), Vectorizer(),
-                        LogisticRegression())
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> from sklearn.pipeline import make_pipeline
+    >>> from sklearn.preprocessing import StandardScaler
+    >>> clf = make_pipeline(Vectorizer(), StandardScaler(), LogisticRegression())
     """
 
     def fit(self, X, y=None):


### PR DESCRIPTION
I added these changes because the previous example was confusing in some ways, for example:

- what is SpatialFilter?
- what is _XDawnTransformer, and why do we use a private class here?
- the example [did not render](https://mne.tools/stable/generated/mne.decoding.Vectorizer.html) due to lack of `>>>`

How it was before this PR:

![image](https://github.com/user-attachments/assets/594eeac4-f4a7-4463-97c3-69cd77af9bae)

How it is [now](https://output.circle-artifacts.com/output/job/18c00058-093c-45c0-a4d6-374cee496619/artifacts/0/html/generated/mne.decoding.Vectorizer.html):

![image](https://github.com/user-attachments/assets/73041730-522b-4ad6-bf80-3f6e1b1d5025)

