### PR TITLE
remove some ._filenames uses in favor of .filenames

### DIFF
--- a/mne/io/ant/ant.py
+++ b/mne/io/ant/ant.py
@@ -191,7 +191,7 @@ class RawANT(BaseRaw):
             i_start = max(start, first_samp)
             i_stop = min(stop, this_n_times + first_samp)
             # read and scale data array
-            cnt = read_cnt(self._filenames[fi])
+            cnt = read_cnt(self.filenames[fi])
             one = read_data(cnt, i_start, i_stop)
             _scale_data(one, ch_units)
             data_view = data[:, i_start - start : i_stop - start]

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2629,7 +2629,7 @@ class _ReadSegmentFileProtector:
     def __init__(self, raw):
         self.__raw = raw
         assert hasattr(raw, "_projector")
-        self.filenames = raw.filenames
+        self._filenames = raw._filenames
         self._raw_extras = raw._raw_extras
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -2629,7 +2629,7 @@ class _ReadSegmentFileProtector:
     def __init__(self, raw):
         self.__raw = raw
         assert hasattr(raw, "_projector")
-        self._filenames = raw._filenames
+        self.filenames = raw.filenames
         self._raw_extras = raw._raw_extras
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):

--- a/mne/io/kit/kit.py
+++ b/mne/io/kit/kit.py
@@ -404,7 +404,7 @@ class EpochsKIT(BaseEpochs):
         )
         kit_info.update(input_fname=input_fname)
         self._raw_extras = [kit_info]
-        self._filenames = []
+        self.filenames = []
         if len(events) != self._raw_extras[0]["n_epochs"]:
             raise ValueError("Event list does not match number of epochs.")
 

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -492,7 +492,7 @@ class RawSNIRF(BaseRaw):
         """Read a segment of data from a file."""
         import h5py
 
-        with h5py.File(self._filenames[0], "r") as dat:
+        with h5py.File(self.filenames[0], "r") as dat:
             one = dat["/nirs/data1/dataTimeSeries"][start:stop].T
 
         _mult_cal_one(data, one, idx, cals, mult)

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -543,12 +543,12 @@ def _test_raw_crop(reader, t_prop, kwargs):
     raw_2, raw_3 = raw_1.copy(), raw_1.copy()
     t_tot = raw_1.times[-1] * 3 + 2.0 / raw_1.info["sfreq"]
     raw_concat = concatenate_raws([raw_1, raw_2, raw_3])
-    assert len(raw_concat._filenames) == 3
+    assert len(raw_concat.filenames) == 3
     assert_allclose(raw_concat.times[-1], t_tot)
     assert_allclose(raw_concat.first_time, first_time)
     # keep all instances, but crop to t_start at the beginning
     raw_concat.crop(t_start, None)
-    assert len(raw_concat._filenames) == 3
+    assert len(raw_concat.filenames) == 3
     assert_allclose(raw_concat.times[-1], t_tot - t_start, atol=atol)
     assert_allclose(
         raw_concat.first_time,
@@ -558,7 +558,7 @@ def _test_raw_crop(reader, t_prop, kwargs):
     )
     # drop the first instance
     raw_concat.crop(crop_t, None)
-    assert len(raw_concat._filenames) == 2
+    assert len(raw_concat.filenames) == 2
     assert_allclose(raw_concat.times[-1], t_tot - t_start - crop_t, atol=atol)
     assert_allclose(
         raw_concat.first_time,
@@ -568,7 +568,7 @@ def _test_raw_crop(reader, t_prop, kwargs):
     )
     # drop the second instance, leaving just one
     raw_concat.crop(crop_t, None)
-    assert len(raw_concat._filenames) == 1
+    assert len(raw_concat.filenames) == 1
     assert_allclose(raw_concat.times[-1], t_tot - t_start - 2 * crop_t, atol=atol)
     assert_allclose(
         raw_concat.first_time,

--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1297,7 +1297,7 @@ class ICA(ContainsMixin):
         out._data = data_
         out._first_samps = [out.first_samp]
         out._last_samps = [out.last_samp]
-        out._filenames = [None]
+        out.filenames = [None]
         out.preload = True
         out._projector = None
         self._export_info(out.info, raw, add_channels)

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -525,7 +525,7 @@ def test_ica_core(method, n_components, noise_cov, n_pca_components, browser_bac
 
     raw_sources = ica.get_sources(raw)
     # test for #3804
-    assert_equal(raw_sources._filenames, [None])
+    assert_equal(raw_sources.filenames, (None,))
     print(raw_sources)
 
     # test for gh-6271 (scaling of ICA traces)
@@ -973,7 +973,7 @@ def test_ica_additional(method, tmp_path, short_raw_epochs):
     assert ica_raw.n_times == 100
     assert ica_raw.last_samp - ica_raw.first_samp + 1 == 100
     assert ica_raw._data.shape[1] == 100
-    assert_equal(len(ica_raw._filenames), 1)  # API consistency
+    assert_equal(len(ica_raw.filenames), 1)  # API consistency
     ica_chans = [ch for ch in ica_raw.ch_names if "ICA" in ch]
     assert ica.n_components_ == len(ica_chans)
     test_ica_fname = Path.cwd() / "test-ica_raw.fif"

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -336,7 +336,7 @@ def plot_raw(
     # generate window title; allow instances without a filename (e.g., ICA)
     if title is None:
         title = "<unknown>"
-        fnames = raw._filenames.copy()  # use the private attribute to get a list
+        fnames = list(tuple(raw.filenames))  # get a list of a copy of the filenames
         if len(fnames):
             title = fnames.pop(0)
             extra = f" ... (+ {len(fnames)} more)" if len(fnames) else ""


### PR DESCRIPTION
following https://github.com/mne-tools/mne-python/pull/12843

I think it'd be good to reduce the use of private attributes in our own code base as well, if we might as well use the public attribute.