### PR TITLE
pin selenium and stop filtering its warning

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -264,7 +264,7 @@ stages:
           - bash: |
               set -eo pipefail
               git clone --depth 1 https://github.com/pyvista/setup-headless-display-action.git
-              bash setup-headless-display-action/windows/install_opengl.sh
+              MESA3D_VERSION=24.3.0 bash setup-headless-display-action/windows/install_opengl.sh
             displayName: Install OpenGL
           - bash: ./tools/azure_dependencies.sh
             displayName: Install dependencies with pip

--- a/doc/sphinxext/mne_doc_utils.py
+++ b/doc/sphinxext/mne_doc_utils.py
@@ -95,8 +95,6 @@ def reset_warnings(gallery_conf, fname):
         r"numpy\.core is deprecated and has been renamed to numpy\._core",
         # matplotlib
         "__array_wrap__ must accept context and return_scalar.*",
-        # selenium
-        "setting remote_server_addr",
     ):
         warnings.filterwarnings(  # deal with other modules having bad imports
             "ignore", message=f".*{key}.*", category=DeprecationWarning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ doc = [
   "pyxdf",
   "pyzmq != 24.0.0",
   "seaborn != 0.11.2",
-  "selenium",
+  "selenium >= 4.27.1",
   "sphinx >= 6",
   "sphinx-design",
   "sphinx-gallery >= 0.16",


### PR DESCRIPTION
The selenium workaround from #12928 is no longer needed, as an upstream fix has been released, and our CI is already pulling in the latest version:
https://app.circleci.com/pipelines/github/mne-tools/mne-python/25889/workflows/48bc89d6-279f-4b79-a579-b061f59c38af/jobs/69943?invite=true#step-118-9020_36
