### PR TITLE
Cuda zero copy

### DIFF
--- a/doc/changes/devel/13002.other.rst
+++ b/doc/changes/devel/13002.other.rst
@@ -1,0 +1,1 @@
+Short description of the changes, by :newcontrib:`Scott Robertson`.

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -33,19 +33,14 @@ def _share_cuda_mem(x):
 
     Parameters
     ----------
-    portable: bool
-        a boolean flag to allow the allocated device memory to be
-              usable in multiple devices.
-    wc: bool
-        a boolean flag to enable writecombined allocation which is faster
-        to write by the host and to read by the device, but slower to
-        write by the host and slower to write by the device.
+    x : 1-d array
 
     Returns
     -------
     a mapped array: np.ndarray
         An array to be passed into cupy.asarray, which does not copy if
-        shared memory is already allocated.
+        shared memory is already allocated. If cuda and numba are not 
+        available, return the original array.
     """
     from mne.fixes import has_numba
 

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -19,9 +19,8 @@ from .utils import (
 
 _cuda_capable = False
 
-def _share_cuda_mem(
-    x, n_jobs
-):
+
+def _share_cuda_mem(x, n_jobs):
     """Get shared memory space to avoid copying from cpu to gpu when possible.
 
     Allocate a mapped ndarray with a buffer that is pinned and mapped on
@@ -49,10 +48,12 @@ def _share_cuda_mem(
         shared memory is already allocated.
     """
     from numba import cuda
+
     from mne.fixes import has_numba
 
     if n_jobs == "cuda" and _cuda_capable and has_numba:
         from numba import cuda
+
         out = cuda.mapped_array(x.shape, ...)
         out[:] = x
     else:
@@ -344,6 +345,7 @@ def _setup_cuda_fft_resample(n_jobs, W, new_len):
 def _cuda_upload_rfft(x, n, axis=-1):
     """Upload and compute rfft."""
     import cupy
+
     x = _share_cuda_mem(x, "cuda")
 
     return cupy.fft.rfft(cupy.asarray(x), n=n, axis=axis)
@@ -352,6 +354,7 @@ def _cuda_upload_rfft(x, n, axis=-1):
 def _cuda_irfft_get(x, n, axis=-1):
     """Compute irfft and get."""
     import cupy
+
     x = _share_cuda_mem(x, "cuda")
 
     return cupy.fft.irfft(x, n=n, axis=axis).get()

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -9,7 +9,6 @@ from scipy.fft import irfft, rfft
 from .utils import (
     _check_option,
     _explain_exception,
-    _soft_import,
     fill_doc,
     get_config,
     logger,

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -216,8 +216,7 @@ def _setup_cuda_fft_multiply_repeated(n_jobs, h, n_fft, kind="FFT FIR filtering"
 
             try:
                 # do the IFFT normalization now so we don't have to later
-                h_fft = _share_cuda_mem(cuda_dict["h_fft"], n_jobs)
-                h_fft = cupy.asarray(h_fft)
+                h_fft = cupy.asarray(_share_cuda_mem(cuda_dict["h_fft"], n_jobs))
                 logger.info(f"Using CUDA for {kind}")
             except Exception as exp:
                 logger.info(
@@ -316,7 +315,7 @@ def _setup_cuda_fft_resample(n_jobs, W, new_len):
             try:
                 import cupy
 
-                W = _share_cuda_mem(W, n_jobs)
+                W = _share_cuda_mem(W, "cuda")
 
                 # do the IFFT normalization now so we don't have to later
                 W = cupy.asarray(W)

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -47,7 +47,7 @@ def _share_cuda_mem(x):
     if _cuda_capable and has_numba:
         from numba import cuda
 
-        out = cuda.mapped_array(x.shape) 
+        out = cuda.mapped_array(x.shape)
         out[:] = x.get()
     else:
         out = x
@@ -316,7 +316,7 @@ def _setup_cuda_fft_resample(n_jobs, W, new_len):
                 # do the IFFT normalization now so we don't have to later
                 W = cupy.asarray(W)
                 logger.info("Using CUDA for FFT resampling")
-            except Exception as e:
+            except Exception:
                 logger.info(
                     "CUDA not used, could not instantiate memory "
                     "(arrays may be too large), falling back to "

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -39,7 +39,7 @@ def _share_cuda_mem(x):
     -------
     a mapped array: np.ndarray
         An array to be passed into cupy.asarray, which does not copy if
-        shared memory is already allocated. If cuda and numba are not 
+        shared memory is already allocated. If cuda and numba are not
         available, return the original array.
     """
     from mne.fixes import has_numba

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -20,7 +20,7 @@ from .utils import (
 _cuda_capable = False
 
 
-def _share_cuda_mem(x, n_jobs):
+def _share_cuda_mem(x):
     """Get shared memory space to avoid copying from cpu to gpu when possible.
 
     Allocate a mapped ndarray with a buffer that is pinned and mapped on
@@ -216,7 +216,7 @@ def _setup_cuda_fft_multiply_repeated(n_jobs, h, n_fft, kind="FFT FIR filtering"
 
             try:
                 # do the IFFT normalization now so we don't have to later
-                h_fft = cupy.asarray(_share_cuda_mem(cuda_dict["h_fft"], "cuda"))
+                h_fft = cupy.asarray(_share_cuda_mem(cuda_dict["h_fft"]))
                 logger.info(f"Using CUDA for {kind}")
             except Exception as exp:
                 logger.info(
@@ -315,7 +315,7 @@ def _setup_cuda_fft_resample(n_jobs, W, new_len):
             try:
                 import cupy
 
-                W = _share_cuda_mem(W, "cuda")
+                W = _share_cuda_mem(W)
 
                 # do the IFFT normalization now so we don't have to later
                 W = cupy.asarray(W)
@@ -343,7 +343,7 @@ def _cuda_upload_rfft(x, n, axis=-1):
     """Upload and compute rfft."""
     import cupy
 
-    x = _share_cuda_mem(x, "cuda")
+    x = _share_cuda_mem(x)
 
     return cupy.fft.rfft(cupy.asarray(x), n=n, axis=axis)
 
@@ -352,7 +352,7 @@ def _cuda_irfft_get(x, n, axis=-1):
     """Compute irfft and get."""
     import cupy
 
-    x = _share_cuda_mem(x, "cuda")
+    x = _share_cuda_mem(x)
 
     return cupy.fft.irfft(x, n=n, axis=axis).get()
 

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -48,9 +48,6 @@ def _share_cuda_mem(x, n_jobs):
         An array to be passed into cupy.asarray, which does not copy if
         shared memory is already allocated.
     """
-    _soft_import("numba", "using shared memory")
-    from numba import cuda
-
     from mne.fixes import has_numba
 
     if n_jobs == "cuda" and _cuda_capable and has_numba:

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -216,7 +216,7 @@ def _setup_cuda_fft_multiply_repeated(n_jobs, h, n_fft, kind="FFT FIR filtering"
 
             try:
                 # do the IFFT normalization now so we don't have to later
-                h_fft = cupy.asarray(_share_cuda_mem(cuda_dict["h_fft"], n_jobs))
+                h_fft = cupy.asarray(_share_cuda_mem(cuda_dict["h_fft"], "cuda"))
                 logger.info(f"Using CUDA for {kind}")
             except Exception as exp:
                 logger.info(

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -54,6 +54,7 @@ def get_shared_mem(
         An array to be passed into cupy.asarray, which does not copy if
         shared memory is already allocated.
     """
+    _soft_import("numba", "using shared memory")
     from numba import cuda
 
     return cuda.mapped_array(

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -5,7 +5,6 @@
 import numpy as np
 from scipy.fft import irfft, rfft
 
-
 from .utils import (
     _check_option,
     _explain_exception,
@@ -18,6 +17,7 @@ from .utils import (
 )
 
 _cuda_capable = False
+
 
 def get_shared_mem(
     shape,
@@ -45,10 +45,11 @@ def get_shared_mem(
 
     Returns
     -------
-    a mapped array: np.ndarray 
+    a mapped array: np.ndarray
         An array to be passed into cupy.asarray, which does not copy if shared memory is already allocated.
     """
     from numba import cuda
+
     return cuda.mapped_array(
         shape,
         dtype=dtype,
@@ -58,6 +59,7 @@ def get_shared_mem(
         portable=portable,
         wc=wc,
     )
+
 
 def get_cuda_memory(kind="available"):
     """Get the amount of free memory for CUDA operations.

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -49,7 +49,7 @@ def _share_cuda_mem(x):
     """
     from mne.fixes import has_numba
 
-    if n_jobs == "cuda" and _cuda_capable and has_numba:
+    if _cuda_capable and has_numba:
         from numba import cuda
 
         out = cuda.mapped_array(x.shape, ...)

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -9,6 +9,7 @@ from scipy.fft import irfft, rfft
 from .utils import (
     _check_option,
     _explain_exception,
+    _soft_import,
     fill_doc,
     get_config,
     logger,
@@ -47,6 +48,7 @@ def _share_cuda_mem(x, n_jobs):
         An array to be passed into cupy.asarray, which does not copy if
         shared memory is already allocated.
     """
+    _soft_import("numba", "using shared memory")
     from numba import cuda
 
     from mne.fixes import has_numba

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -45,8 +45,8 @@ def get_shared_mem(
 
     Returns
     -------
-    a mapped array: np.ndarray
-        An array to be passed into cupy.asarray, which does not copy if
+    a mapped array: np.ndarray 
+        An array to be passed into cupy.asarray, which does not copy if 
         shared memory is already allocated.
     """
     from numba import cuda

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -2,8 +2,8 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
+
 import numpy as np
-import os
 from scipy.fft import irfft, rfft
 
 from .utils import (
@@ -19,6 +19,7 @@ from .utils import (
 
 _cuda_capable = False
 
+
 def get_shared_mem(
     shape,
     dtype=np.float64,
@@ -33,9 +34,9 @@ def get_shared_mem(
     Allocate a mapped ndarray with a buffer that is pinned and mapped on
     to the device. Similar to np.empty()
 
-    It is recommended to gate this function with 
+    It is recommended to gate this function with
         os.getenv("MNE_USE_NUMBA").lower() == "true"
-    to avoid import errors. 
+    to avoid import errors.
 
     Parameters
     ----------

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -46,7 +46,8 @@ def get_shared_mem(
     Returns
     -------
     a mapped array: np.ndarray
-        An array to be passed into cupy.asarray, which does not copy if shared memory is already allocated.
+        An array to be passed into cupy.asarray, which does not copy if
+        shared memory is already allocated.
     """
     from numba import cuda
 

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -48,7 +48,7 @@ def _share_cuda_mem(x):
         from numba import cuda
 
         out = cuda.mapped_array(x.shape)
-        out[:] = x.get()
+        out[:] = x
     else:
         out = x
     return out

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -3,6 +3,7 @@
 # Copyright the MNE-Python contributors.
 
 import numpy as np
+import os
 from scipy.fft import irfft, rfft
 
 from .utils import (
@@ -18,7 +19,6 @@ from .utils import (
 
 _cuda_capable = False
 
-
 def get_shared_mem(
     shape,
     dtype=np.float64,
@@ -32,6 +32,10 @@ def get_shared_mem(
 
     Allocate a mapped ndarray with a buffer that is pinned and mapped on
     to the device. Similar to np.empty()
+
+    It is recommended to gate this function with 
+        os.getenv("MNE_USE_NUMBA").lower() == "true"
+    to avoid import errors. 
 
     Parameters
     ----------

--- a/mne/cuda.py
+++ b/mne/cuda.py
@@ -45,8 +45,8 @@ def get_shared_mem(
 
     Returns
     -------
-    a mapped array: np.ndarray 
-        An array to be passed into cupy.asarray, which does not copy if 
+    a mapped array: np.ndarray
+        An array to be passed into cupy.asarray, which does not copy if
         shared memory is already allocated.
     """
     from numba import cuda

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -402,8 +402,8 @@ def test_resample(method):
 
 def test_resample_scipy():
     """Test resampling against SciPy."""
-    from mne.cuda import _cuda_capable  # allow above funs to set it
-
+    from mne.cuda import _cuda_capable# allow cuda.init_cuda() to set it
+    from mne.fixes import has_numba
     n_jobs_test = (1, "cuda")
     for window in ("boxcar", "hann"):
         for N in (100, 101, 102, 103):
@@ -411,7 +411,7 @@ def test_resample_scipy():
             err_msg = f"{N}: {window}"
             x_2_sp = sp_resample(x, 2 * N, window=window)
             for n_jobs in n_jobs_test:
-                if n_jobs == "cuda" and _cuda_capable:
+                if n_jobs == "cuda" and _cuda_capable and has_numba:
                     tmp = x
                     x = get_shared_mem(x.shape)
                     x[:] = tmp
@@ -427,11 +427,11 @@ def test_resample_scipy():
 @pytest.mark.parametrize("n_jobs", (2, "cuda"))
 def test_n_jobs(n_jobs):
     """Test resampling against SciPy."""
-    from mne.cuda import _cuda_capable  # allow above funs to set it
-
+    from mne.cuda import _cuda_capable# allow cuda.init_cuda() to set it
+    from mne.fixes import has_numba
     x = np.random.RandomState(0).randn(4, 100)
 
-    if n_jobs == "cuda" and _cuda_capable:
+    if n_jobs == "cuda" and _cuda_capable and has_numba:
         tmp = x
         x = get_shared_mem(x.shape)
         x[:] = tmp
@@ -855,15 +855,15 @@ def test_cuda_fir():
 
 def test_cuda_resampling():
     """Test CUDA resampling."""
-    from mne.cuda import _cuda_capable  # allow above funs to set it
-
+    from mne.cuda import _cuda_capable# allow cuda.init_cuda() to set it
+    from mne.fixes import has_numba
     rng = np.random.RandomState(0)
     for window in ("boxcar", "triang"):
         for N in (997, 1000):  # one prime, one even
             a = rng.randn(2, N)
             for fro, to in ((1, 2), (2, 1), (1, 3), (3, 1)):
                 a1 = resample(a, fro, to, n_jobs=None, npad="auto", window=window)
-                if _cuda_capable:
+                if _cuda_capable and has_numba:
                     x = get_shared_mem(a.shape)
                     x[:] = a
                     a2 = resample(x, fro, to, n_jobs="cuda", npad="auto", window=window)

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -421,7 +421,6 @@ def test_resample_scipy():
 def test_n_jobs(n_jobs):
     """Test resampling against SciPy."""
     x = np.random.RandomState(0).randn(4, 100)
-
     y1 = resample(x, 2, 1, n_jobs=None)
     y2 = resample(x, 2, 1, n_jobs=n_jobs)
     assert_allclose(y1, y2)

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -402,8 +402,9 @@ def test_resample(method):
 
 def test_resample_scipy():
     """Test resampling against SciPy."""
-    from mne.cuda import _cuda_capable# allow cuda.init_cuda() to set it
+    from mne.cuda import _cuda_capable  # allow cuda.init_cuda() to set it
     from mne.fixes import has_numba
+
     n_jobs_test = (1, "cuda")
     for window in ("boxcar", "hann"):
         for N in (100, 101, 102, 103):
@@ -427,8 +428,9 @@ def test_resample_scipy():
 @pytest.mark.parametrize("n_jobs", (2, "cuda"))
 def test_n_jobs(n_jobs):
     """Test resampling against SciPy."""
-    from mne.cuda import _cuda_capable# allow cuda.init_cuda() to set it
+    from mne.cuda import _cuda_capable  # allow cuda.init_cuda() to set it
     from mne.fixes import has_numba
+
     x = np.random.RandomState(0).randn(4, 100)
 
     if n_jobs == "cuda" and _cuda_capable and has_numba:
@@ -855,8 +857,9 @@ def test_cuda_fir():
 
 def test_cuda_resampling():
     """Test CUDA resampling."""
-    from mne.cuda import _cuda_capable# allow cuda.init_cuda() to set it
+    from mne.cuda import _cuda_capable  # allow cuda.init_cuda() to set it
     from mne.fixes import has_numba
+
     rng = np.random.RandomState(0)
     for window in ("boxcar", "triang"):
         for N in (997, 1000):  # one prime, one even

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -16,8 +16,8 @@ from scipy.signal import butter, freqz, sosfreqz
 from scipy.signal import resample as sp_resample
 
 from mne import Epochs, create_info
-from mne.cuda import get_shared_mem
 from mne._fiff.pick import _DATA_CH_TYPES_SPLIT
+from mne.cuda import get_shared_mem
 from mne.filter import (
     _length_factors,
     _overlap_add_filter,
@@ -858,7 +858,7 @@ def test_cuda_resampling():
             for fro, to in ((1, 2), (2, 1), (1, 3), (3, 1)):
                 a1 = resample(a, fro, to, n_jobs=None, npad="auto", window=window)
                 x = get_shared_mem(a.shape)
-                x[:] = a 
+                x[:] = a
                 a2 = resample(a, fro, to, n_jobs="cuda", npad="auto", window=window)
                 assert_allclose(a1, a2, rtol=1e-7, atol=1e-14)
     assert_array_almost_equal(a1, a2, 14)

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -16,6 +16,7 @@ from scipy.signal import butter, freqz, sosfreqz
 from scipy.signal import resample as sp_resample
 
 from mne import Epochs, create_info
+from mne.cuda import get_shared_mem
 from mne._fiff.pick import _DATA_CH_TYPES_SPLIT
 from mne.filter import (
     _length_factors,
@@ -408,6 +409,10 @@ def test_resample_scipy():
             err_msg = f"{N}: {window}"
             x_2_sp = sp_resample(x, 2 * N, window=window)
             for n_jobs in n_jobs_test:
+                if n_jobs == "cuda":
+                    tmp = x
+                    x = get_shared_mem(x.shape)
+                    x[:] = tmp
                 x_2 = resample(x, 2, 1, npad=0, window=window, n_jobs=n_jobs)
                 assert_allclose(x_2, x_2_sp, atol=1e-12, err_msg=err_msg)
             new_len = int(round(len(x) * (1.0 / 2.0)))
@@ -421,6 +426,12 @@ def test_resample_scipy():
 def test_n_jobs(n_jobs):
     """Test resampling against SciPy."""
     x = np.random.RandomState(0).randn(4, 100)
+
+    if n_jobs == "cuda":
+        tmp = x
+        x = get_shared_mem(x.shape)
+        x[:] = tmp
+
     y1 = resample(x, 2, 1, n_jobs=None)
     y2 = resample(x, 2, 1, n_jobs=n_jobs)
     assert_allclose(y1, y2)
@@ -846,6 +857,8 @@ def test_cuda_resampling():
             a = rng.randn(2, N)
             for fro, to in ((1, 2), (2, 1), (1, 3), (3, 1)):
                 a1 = resample(a, fro, to, n_jobs=None, npad="auto", window=window)
+                x = get_shared_mem(a.shape)
+                x[:] = a 
                 a2 = resample(a, fro, to, n_jobs="cuda", npad="auto", window=window)
                 assert_allclose(a1, a2, rtol=1e-7, atol=1e-14)
     assert_array_almost_equal(a1, a2, 14)

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -403,6 +403,7 @@ def test_resample(method):
 def test_resample_scipy():
     """Test resampling against SciPy."""
     from mne.cuda import _cuda_capable  # allow above funs to set it
+
     n_jobs_test = (1, "cuda")
     for window in ("boxcar", "hann"):
         for N in (100, 101, 102, 103):
@@ -427,6 +428,7 @@ def test_resample_scipy():
 def test_n_jobs(n_jobs):
     """Test resampling against SciPy."""
     from mne.cuda import _cuda_capable  # allow above funs to set it
+
     x = np.random.RandomState(0).randn(4, 100)
 
     if n_jobs == "cuda" and _cuda_capable:
@@ -854,6 +856,7 @@ def test_cuda_fir():
 def test_cuda_resampling():
     """Test CUDA resampling."""
     from mne.cuda import _cuda_capable  # allow above funs to set it
+
     rng = np.random.RandomState(0)
     for window in ("boxcar", "triang"):
         for N in (997, 1000):  # one prime, one even

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -17,7 +17,6 @@ from scipy.signal import resample as sp_resample
 
 from mne import Epochs, create_info
 from mne._fiff.pick import _DATA_CH_TYPES_SPLIT
-from mne.cuda import get_shared_mem
 from mne.filter import (
     _length_factors,
     _overlap_add_filter,
@@ -402,9 +401,6 @@ def test_resample(method):
 
 def test_resample_scipy():
     """Test resampling against SciPy."""
-    from mne.cuda import _cuda_capable  # allow cuda.init_cuda() to set it
-    from mne.fixes import has_numba
-
     n_jobs_test = (1, "cuda")
     for window in ("boxcar", "hann"):
         for N in (100, 101, 102, 103):
@@ -412,10 +408,6 @@ def test_resample_scipy():
             err_msg = f"{N}: {window}"
             x_2_sp = sp_resample(x, 2 * N, window=window)
             for n_jobs in n_jobs_test:
-                if n_jobs == "cuda" and _cuda_capable and has_numba:
-                    tmp = x
-                    x = get_shared_mem(x.shape)
-                    x[:] = tmp
                 x_2 = resample(x, 2, 1, npad=0, window=window, n_jobs=n_jobs)
                 assert_allclose(x_2, x_2_sp, atol=1e-12, err_msg=err_msg)
             new_len = int(round(len(x) * (1.0 / 2.0)))
@@ -428,15 +420,7 @@ def test_resample_scipy():
 @pytest.mark.parametrize("n_jobs", (2, "cuda"))
 def test_n_jobs(n_jobs):
     """Test resampling against SciPy."""
-    from mne.cuda import _cuda_capable  # allow cuda.init_cuda() to set it
-    from mne.fixes import has_numba
-
     x = np.random.RandomState(0).randn(4, 100)
-
-    if n_jobs == "cuda" and _cuda_capable and has_numba:
-        tmp = x
-        x = get_shared_mem(x.shape)
-        x[:] = tmp
 
     y1 = resample(x, 2, 1, n_jobs=None)
     y2 = resample(x, 2, 1, n_jobs=n_jobs)
@@ -857,21 +841,13 @@ def test_cuda_fir():
 
 def test_cuda_resampling():
     """Test CUDA resampling."""
-    from mne.cuda import _cuda_capable  # allow cuda.init_cuda() to set it
-    from mne.fixes import has_numba
-
     rng = np.random.RandomState(0)
     for window in ("boxcar", "triang"):
         for N in (997, 1000):  # one prime, one even
             a = rng.randn(2, N)
             for fro, to in ((1, 2), (2, 1), (1, 3), (3, 1)):
                 a1 = resample(a, fro, to, n_jobs=None, npad="auto", window=window)
-                if _cuda_capable and has_numba:
-                    x = get_shared_mem(a.shape)
-                    x[:] = a
-                    a2 = resample(x, fro, to, n_jobs="cuda", npad="auto", window=window)
-                else:
-                    a2 = resample(a, fro, to, n_jobs="cuda", npad="auto", window=window)
+                a2 = resample(a, fro, to, n_jobs="cuda", npad="auto", window=window)
                 assert_allclose(a1, a2, rtol=1e-7, atol=1e-14)
     assert_array_almost_equal(a1, a2, 14)
     assert_array_equal(resample(np.zeros(2), 2, 1, n_jobs="cuda"), np.zeros(4))


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

<!-- Example:

Fixes #1234.

-->


#### What does this implement/fix?

<!-- Explain your changes. -->
Looking through the `cuda` options for running signal transformations, I noticed the possibility of leveraging zero-copy methods for further speedup.  These were adopted from [cuSignal](https://developer.nvidia.com/blog/accelerated-signal-processing-with-cusignal/).  The [cuSignal README Quickstart](https://github.com/rapidsai/cusignal/blob/branch-23.10/README.md#quick-start) illlustrates an example of how to allocate shared memory.  This method `get_shared_memory` did not migrate into `cupy` like the other methods and so I added it here for `mne`.

Per some example benchmarks shared in [the most relevante cuda issue from mne](https://github.com/mne-tools/mne-python/issues/5439), this simple adjustment potentially cuts resampling time in half.  


#### Additional information

1. Benchmarks are hard.  I'm not 100% confident this is a guaranteed performance gain.  When running cold, the difference might not be noticeable, but once the gpu is warm, subsequent runs appear to be significantly different (on my machine).  [My initial tests](https://gitlab.com/scottrbrtsn/streaming-sandbox/-/tree/main/streaming-apps/signal-generator/tests?ref_type=heads) with `mne_shared_test.py` to be the final version for `mne` implemented here. 
2. I `grep`'ed for all occurrances of `cupy.array` and am surprised there are only 3.  I'm wondering if other areas of `mne` would benefit which are still just using `np.asarray`.
3. This implementation is the simple way, to offer `cupy.asarray` which will copy if shared memory is not provided, but will use shared memory if the array is already allocated on the device.  This puts the burden onto the caller to provide shared memory space (as demonstrated in the tests).

<!-- Any additional information you think is important. -->
