### PR TITLE
Warn about out-of-bounds event sample numbers when creating Epochs.

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -895,6 +895,8 @@ class BaseEpochs(
         """Determine if epoch is good."""
         if isinstance(data, str):
             return False, (data,)
+        if data == 'OUT_OF_BOUNDS':
+            return False, ('OUT_OF_BOUNDS',)
         if data is None:
             return False, ("NO_DATA",)
         n_times = len(self.times)
@@ -3644,6 +3646,10 @@ class Epochs(BaseEpochs):
         reject_stop = stop - diff
 
         logger.debug(f"    Getting epoch for {start}-{stop}")
+        n_times_raw = self._raw.n_times
+        if start < 0 or stop > n_times_raw:
+            warn(f'Epoch {idx}: sample numbers [{start}, {stop}] are out of bounds for raw data with {n_times_raw} samples. This epoch will be dropped.')
+            return 'OUT_OF_BOUNDS'
         data = self._raw._check_bad_segment(
             start,
             stop,


### PR DESCRIPTION
Previously, when creating Epochs with event sample numbers that were out of bounds for the raw data, the corresponding epochs were silently dropped. This could lead to confusion, as users might not be aware that some epochs were being excluded.

This commit modifies the Epochs class to issue a warning when out-of-bounds event sample numbers are detected. The warning message includes the epoch index and the out-of-bounds sample numbers, making it easier for users to identify and correct the issue.

A new test case has been added to verify that the warning is issued correctly.

<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

<!-- Example:

Fixes #1234.

-->


#### What does this implement/fix?

<!-- Explain your changes. -->


#### Additional information

<!-- Any additional information you think is important. -->
