### PR TITLE
Fix cnt response

### DIFF
--- a/doc/changes/devel/13007.bugfix.rst
+++ b/doc/changes/devel/13007.bugfix.rst
@@ -1,0 +1,1 @@
+Correct :func:`mne.io.read_raw_cnt` to read responses and fix exceptions by `Jacob Woessner`_. 

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -14,13 +14,7 @@ from ..._fiff.meas_info import _empty_info
 from ..._fiff.utils import _create_chs, _find_channels, _mult_cal_one, read_str
 from ...annotations import Annotations
 from ...channels.layout import _topo_to_sphere
-from ...utils import (
-    _check_option,
-    _validate_type,
-    fill_doc,
-    warn,
-    _explain_exception
-)
+from ...utils import _check_option, _explain_exception, _validate_type, fill_doc, warn
 from ..base import BaseRaw
 from ._utils import (
     CNTEventType3,

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -161,7 +161,7 @@ def _read_annotations_cnt(fname, data_format="int16"):
             if str(keypad) != "0":
                 description.append("KeyPad Response" + " " + str(keypad))
             elif event.KeyBoard != 0:
-                description.append("Keyboard Response" + " " + str(event.KeyBoard))
+                description.append(f"Keyboard Response {event.KeyBoard}")
             else:
                 description.append(str(event.StimType))
 

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -155,7 +155,7 @@ def _read_annotations_cnt(fname, data_format="int16"):
         for event in my_events:
             # Extract the 4-bit fields
             # Upper nibble (4 bits) currently not used
-            accept = (event.KeyPad_Accept[0] & 0xF0) >> 4
+            # accept = (event.KeyPad_Accept[0] & 0xF0) >> 4
             # Lower nibble (4 bits) keypad button press
             keypad = event.KeyPad_Accept[0] & 0x0F
             if str(keypad) != "0":

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -150,7 +150,23 @@ def _read_annotations_cnt(fname, data_format="int16"):
             np.array([e.KeyPad_Accept for e in my_events])
         )
 
-        description = np.array([str(e.StimType) for e in my_events])
+        # Check to see if there are any button presses
+        description = []
+        for event in my_events:
+            # Extract the 4-bit fields
+            # Upper nibble (4 bits) currently not used
+            accept = (event.KeyPad_Accept[0] & 0xF0) >> 4
+            # Lower nibble (4 bits) keypad button press
+            keypad = event.KeyPad_Accept[0] & 0x0F
+            if str(keypad) != '0':
+                description.append("KeyPad Response" + " " + str(keypad))
+            elif event.KeyBoard != 0:
+                description.append("Keyboard Response" +
+                                   " " + str(event.KeyBoard))
+            else:
+                description.append(str(event.StimType))
+
+        description = np.array(description)
 
         onset, duration, description = _update_bad_span_onset(
             accept_reject, onset / sfreq, duration, description

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -159,7 +159,7 @@ def _read_annotations_cnt(fname, data_format="int16"):
             # Lower nibble (4 bits) keypad button press
             keypad = event.KeyPad_Accept[0] & 0x0F
             if str(keypad) != "0":
-                description.append("KeyPad Response" + " " + str(keypad))
+                description.append(f"KeyPad Response {keypad}")
             elif event.KeyBoard != 0:
                 description.append(f"Keyboard Response {event.KeyBoard}")
             else:

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -14,7 +14,13 @@ from ..._fiff.meas_info import _empty_info
 from ..._fiff.utils import _create_chs, _find_channels, _mult_cal_one, read_str
 from ...annotations import Annotations
 from ...channels.layout import _topo_to_sphere
-from ...utils import _check_option, _validate_type, fill_doc, warn
+from ...utils import (
+    _check_option,
+    _validate_type,
+    fill_doc,
+    warn,
+    _explain_exception
+)
 from ..base import BaseRaw
 from ._utils import (
     CNTEventType3,
@@ -547,7 +553,8 @@ class RawCNT(BaseRaw):
             )
         except Exception:
             raise RuntimeError(
-                "Could not read header from *.cnt file. mne.io.read_raw_cnt "
+                f"{_explain_exception()}\n"
+                "WARNING: mne.io.read_raw_cnt "
                 "supports Neuroscan CNT files only. If this file is an ANT Neuro CNT, "
                 "please use mne.io.read_raw_ant instead."
             )

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -158,11 +158,10 @@ def _read_annotations_cnt(fname, data_format="int16"):
             accept = (event.KeyPad_Accept[0] & 0xF0) >> 4
             # Lower nibble (4 bits) keypad button press
             keypad = event.KeyPad_Accept[0] & 0x0F
-            if str(keypad) != '0':
+            if str(keypad) != "0":
                 description.append("KeyPad Response" + " " + str(keypad))
             elif event.KeyBoard != 0:
-                description.append("Keyboard Response" +
-                                   " " + str(event.KeyBoard))
+                description.append("Keyboard Response" + " " + str(event.KeyBoard))
             else:
                 description.append(str(event.StimType))
 

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -58,7 +58,7 @@ def test_auto_data():
     with first, second, third:
         raw = read_raw_cnt(input_fname=fname_bad_spans)
     # Test that responses are read properly
-    assert 'KeyPad Response 1' in raw.annotations.description
+    assert "KeyPad Response 1" in raw.annotations.description
     assert raw.info["bads"] == ["F8"]
 
     with _no_parse, pytest.warns(RuntimeWarning, match="number of bytes"):

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -58,6 +58,7 @@ def test_auto_data():
     with first, second, third:
         raw = read_raw_cnt(input_fname=fname_bad_spans)
 
+    assert 'KeyPad Response 1' in raw.annotations.description
     assert raw.info["bads"] == ["F8"]
 
     with _no_parse, pytest.warns(RuntimeWarning, match="number of bytes"):
@@ -67,6 +68,7 @@ def test_auto_data():
 
     # make sure we use annotations event if we synthesized stim
     assert len(raw.annotations) == 6
+    # Test that responses are read properly
 
     eog_chs = pick_types(raw.info, eog=True, exclude=[])
     assert len(eog_chs) == 2  # test eog='auto'

--- a/mne/io/cnt/tests/test_cnt.py
+++ b/mne/io/cnt/tests/test_cnt.py
@@ -57,7 +57,7 @@ def test_auto_data():
     third = pytest.warns(RuntimeWarning, match="Omitted 6 annot")
     with first, second, third:
         raw = read_raw_cnt(input_fname=fname_bad_spans)
-
+    # Test that responses are read properly
     assert 'KeyPad Response 1' in raw.annotations.description
     assert raw.info["bads"] == ["F8"]
 
@@ -68,7 +68,6 @@ def test_auto_data():
 
     # make sure we use annotations event if we synthesized stim
     assert len(raw.annotations) == 6
-    # Test that responses are read properly
 
     eog_chs = pick_types(raw.info, eog=True, exclude=[])
     assert len(eog_chs) == 2  # test eog='auto'


### PR DESCRIPTION
#### Reference issue

Fixes #13006
Closes #13005 



#### What does this implement/fix?

<!-- Explain your changes. -->
Currently all annotation descriptions are imported from event.StimType. This means all responses are recorded as 0, even when they should be read as a number representing the button the participant pressed. I correctly imported the response and appended `KeyPad Response` and `Keyboard Response` to the annotation because MNE does not differentiate explicitly between stimuluses and responses like Neuroscan does. 

