### PR TITLE
[ENH] Add fig.mne container for colorbar

### DIFF
--- a/doc/changes/devel/13019.newfeature.rst
+++ b/doc/changes/devel/13019.newfeature.rst
@@ -1,1 +1,1 @@
-Add ``fig.mne`` container for :class:`Colorbar <matplotlib.colorbar.Colorbar>` in :func:`mne.viz.circle._plot_connectivity_circle` to allow users to access it directly, by `Santeri Ruuskanen`_.
+Add ``fig.mne`` container for :class:`Colorbar <matplotlib.colorbar.Colorbar>` in :func:`plot_connectivity_circle <mne_connectivity.viz.plot_connectivity_circle>` to allow users to access it directly, by `Santeri Ruuskanen`_.

--- a/doc/changes/devel/13019.newfeature.rst
+++ b/doc/changes/devel/13019.newfeature.rst
@@ -1,0 +1,1 @@
+Add ``fig.mne`` container for :class:`Colorbar <matplotlib.colorbar.Colorbar>` in :func:`mne.viz.circle._plot_connectivity_circle` to allow users to access it directly, by `Santeri Ruuskanen`_.

--- a/mne/viz/circle.py
+++ b/mne/viz/circle.py
@@ -6,6 +6,7 @@
 
 from functools import partial
 from itertools import cycle
+from types import SimpleNamespace
 
 import numpy as np
 
@@ -371,6 +372,7 @@ def _plot_connectivity_circle(
         cb_yticks = plt.getp(cb.ax.axes, "yticklabels")
         cb.ax.tick_params(labelsize=fontsize_colorbar)
         plt.setp(cb_yticks, color=textcolor)
+        fig.mne = SimpleNamespace(colorbar=cb)
 
     # Add callback for interaction
     if interactive:

--- a/mne/viz/tests/test_circle.py
+++ b/mne/viz/tests/test_circle.py
@@ -16,8 +16,10 @@ def test_plot_channel_labels_circle():
     """Test plotting channel labels in a circle."""
     fig, axes = plot_channel_labels_circle(
         dict(brain=["big", "great", "smart"]),
-        colors=dict(big="r", great="y", smart="b"),
+        colors=dict(big="r", great="y", smart="b"), colorbar=True
     )
+    # check that colorbar handle is returned
+    assert isinstance(fig.mne.colorbar, matplotlib.colorbar.Colorbar)
     texts = [
         child.get_text()
         for child in axes.get_children()

--- a/mne/viz/tests/test_circle.py
+++ b/mne/viz/tests/test_circle.py
@@ -16,7 +16,8 @@ def test_plot_channel_labels_circle():
     """Test plotting channel labels in a circle."""
     fig, axes = plot_channel_labels_circle(
         dict(brain=["big", "great", "smart"]),
-        colors=dict(big="r", great="y", smart="b"), colorbar=True
+        colors=dict(big="r", great="y", smart="b"),
+        colorbar=True
     )
     # check that colorbar handle is returned
     assert isinstance(fig.mne.colorbar, matplotlib.colorbar.Colorbar)


### PR DESCRIPTION
This fixes [Issue 262](https://github.com/mne-tools/mne-connectivity/issues/262) in `mne_connectivity`.

I added a `fig.mne` `SimpleNamespace`, which holds the `Colorbar` for a circular plot. This allows users to directly access the `Colorbar` after creating a figure using `mne_connectivity.viz.plot_connectivity_circle`, which calls `mne.viz.circle._plot_connectivity_circle`. 

I will add something in the docstring of `plot_connectivity_circle` to describe this functionality and modify one of the examples to use it. 