### PR TITLE
[BUG] Fix simple documentation bug

### DIFF
--- a/doc/development/contributing.rst
+++ b/doc/development/contributing.rst
@@ -860,7 +860,7 @@ data with a meaningful middle (zero-point) and ``Reds`` otherwise. This applies
 to both visualization functions and tutorials/examples.
 
 
-.. _run_tests:
+.. _run-tests:
 
 Running the test suite
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The section "Running the test suite" was labeled as `_run_tests` although the references are to `_run-tests`. For some reason, the _run_tests reference points to a similar section in the documentation of statsmodels. This glorious one-character PR fixes the bug and the link now works correctly.

I skipped the changelog entry for this tiny thing.
