### PR TITLE
Fixes make_scalp_surfaces

### DIFF
--- a/mne/bem.py
+++ b/mne/bem.py
@@ -2394,19 +2394,20 @@ def make_scalp_surfaces(
         mri = mri if (subj_path / "mri" / mri).exists() else "T1"
 
     logger.info("1. Creating a dense scalp tessellation with mkheadsurf...")
+    threshold = _ensure_int(threshold, "threshold")
 
-    def check_seghead(surf_path=subj_path / "surf"):
+    def check_seghead(surf_path=subj_path / "surf", overwrite=overwrite):
         surf = None
         for k in ["lh.seghead", "lh.smseghead"]:
             this_surf = surf_path / k
             if this_surf.exists():
                 surf = this_surf
+                _check_file(surf, overwrite)
                 break
         return surf
 
-    my_seghead = check_seghead()
-    threshold = _ensure_int(threshold, "threshold")
-    if my_seghead is None:
+    my_seghead = check_seghead(overwrite=overwrite)
+    if (my_seghead is None) or overwrite:
         this_env = deepcopy(os.environ)
         this_env["SUBJECTS_DIR"] = str(subjects_dir)
         this_env["SUBJECT"] = subject
@@ -2432,7 +2433,7 @@ def make_scalp_surfaces(
             env=this_env,
         )
 
-    surf = check_seghead()
+    surf = check_seghead(overwrite=False)
     if surf is None:
         raise RuntimeError("mkheadsurf did not produce the standard output file.")
 

--- a/mne/tests/test_bem.py
+++ b/mne/tests/test_bem.py
@@ -43,7 +43,7 @@ from mne.datasets import testing
 from mne.io import read_info
 from mne.surface import _get_ico_surface, read_surface
 from mne.transforms import translation
-from mne.utils import _record_warnings, catch_logging, check_version
+from mne.utils import _record_warnings, catch_logging, check_version, requires_freesurfer
 
 fname_raw = Path(__file__).parents[1] / "io" / "tests" / "data" / "test_raw.fif"
 subjects_dir = testing.data_path(download=False) / "subjects"
@@ -519,11 +519,26 @@ def test_io_head_bem(tmp_path):
     assert np.allclose(head["tris"], head_defect["tris"])
 
 
-@pytest.mark.slowtest  # ~4 s locally
+@pytest.mark.slowtest
+@requires_freesurfer("mkheadsurf")
+@testing.requires_testing_data
 def test_make_scalp_surfaces_topology(tmp_path, monkeypatch):
-    """Test topology checks for make_scalp_surfaces."""
+    """Test make_scalp_surfaces and topology checks."""
     pytest.importorskip("pyvista")
     pytest.importorskip("nibabel")
+
+    # tests on 'sample'
+    subject = 'sample'
+    with pytest.raises(OSError, match="use --overwrite to overwrite it"):
+        make_scalp_surfaces(
+            subject, subjects_dir, force=False, verbose=True, overwrite=False
+        )
+    
+    make_scalp_surfaces(
+        subject, subjects_dir, force=False, verbose=True, overwrite=True
+    )
+
+    # tests on custom surface
     subjects_dir = tmp_path
     subject = "test"
     surf_dir = subjects_dir / subject / "surf"
@@ -551,6 +566,7 @@ def test_make_scalp_surfaces_topology(tmp_path, monkeypatch):
         make_scalp_surfaces(
             subject, subjects_dir, force=False, verbose=True, overwrite=True
         )
+
     bem_dir = subjects_dir / subject / "bem"
     sparse_path = bem_dir / f"{subject}-head-sparse.fif"
     assert not sparse_path.is_file()
@@ -569,6 +585,8 @@ def test_make_scalp_surfaces_topology(tmp_path, monkeypatch):
         make_scalp_surfaces(subject, subjects_dir, force=True, overwrite=True)
     (surf,) = read_bem_surfaces(sparse_path, on_defects="ignore")
     assert len(surf["tris"]) == 319
+
+    
 
 
 @pytest.mark.parametrize("bem_type", ["bem", "sphere"])


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

Fixes #13014.



#### What does this implement/fix?

Updates `make_scalp_surfaces` to force regenerating `seghead.mgz` ,`lh.seghead` and `{subject}-head-{{}}.fif` if `overwrite` is set to `True`. Will raise an OSError if  either `seghead.mgz` ,`lh.seghead` and `{subject}-head-{{}}.fif` exists and `overwrite` is set to `False`

#### Additional information
There are some edgy cases when mixing `overwrite` and `no_decimate` which can lead to `{subject}-head-medium.fif` / `{subject}-head-sparse.fif` to be untouched while `seghead.mgz` ,`lh.seghead` and `{subject}-head-dense.fif` are regenerated.

I tried to handle theses cases by always deleting `{subject}-head-medium.fif` / `{subject}-head-sparse.fif`  if `overwrite=True` (even if `no_decimate=True`) and by raising and specific error if  `overwrite=False` , `no_decimate=True` but `{subject}-head-medium.fif` / `{subject}-head-sparse.fif`  exist.
