### PR TITLE
Fix a bug for ica.get_sources() and add a corresponding test

### DIFF
--- a/mne/preprocessing/ica.py
+++ b/mne/preprocessing/ica.py
@@ -1295,8 +1295,12 @@ class ICA(ContainsMixin):
             picks = pick_channels(raw.ch_names, add_channels)
             data_ = np.concatenate([data_, raw.get_data(picks, start=start, stop=stop)])
         out._data = data_
-        out._first_samps = [out.first_samp]
-        out._last_samps = [out.last_samp]
+        # out._first_samps = [out.first_samp]
+        # out._last_samps = [out.last_samp]
+        out_first_samp = out.first_samp
+        out_last_samp = out.last_samp
+        out._first_samps = [out_first_samp]
+        out._last_samps = [out_last_samp]
         out.filenames = [None]
         out.preload = True
         out._projector = None

--- a/mne/tests/test_ica.py
+++ b/mne/tests/test_ica.py
@@ -1,0 +1,19 @@
+import mne
+from mne.datasets import testing
+
+data_path = testing.data_path(download=False)
+
+@testing.requires_testing_data
+def test_ica_get_sources_concatenated():
+    """Test ICA get_sources method with concatenated raws."""
+    # load data
+    data_raw_file = data_path / "MEG" / "sample" / "sample_audvis_trunc_raw.fif"
+    raw = mne.io.read_raw_fif(data_raw_file).crop(0, 15).load_data()  # raw has 15 seconds of data
+    # concatenate
+    raw_concat = mne.concatenate_raws([raw.copy(), raw.copy()])  # raw_concat has 30 seconds of data
+    # do ICA
+    ica = mne.preprocessing.ICA(n_components=20)
+    ica.fit(raw_concat)
+    # get sources
+    raw_sources = ica.get_sources(raw_concat)  # but this only has 15 seconds of data
+    assert raw_concat.n_times == raw_sources.n_times  # this will fail


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

<!-- Example:

Fixes #1234.

-->

Fixes #13057.

#### What does this implement/fix?

<!-- Explain your changes. -->

It fixes the bug in ica.get_sources() for concatenated raw object.

There is a bug in the ica._source_as_raw function, [here](https://github.com/mne-tools/mne-python/blob/maint/1.9/mne/preprocessing/ica.py#L1299) it assigns [self.last_samp] to self._last_samps, however self.last_samp is a property function and it seems that if its wrapped in a list, it won't actually call this function until used later. So I change it to first calculate the values and then put them in the list.

