### PR TITLE
[FIX] Reading an EDF with preload=False and mixed frequency

### DIFF
--- a/doc/changes/devel/13069.bugfix.rst
+++ b/doc/changes/devel/13069.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug cause by unneccessary assertion when loading mixed frequency EDFs without preloading :func:`mne.io.read_raw_edf` by `Simon Kern`_.

--- a/doc/changes/devel/13069.bugfix.rst
+++ b/doc/changes/devel/13069.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug cause by unneccessary assertion when loading mixed frequency EDFs without preloading :func:`mne.io.read_raw_edf` by `Simon Kern`_.
+Fix bug cause by unnecessary assertion when loading mixed frequency EDFs without preloading :func:`mne.io.read_raw_edf` by `Simon Kern`_.

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -186,6 +186,7 @@ def pytest_configure(config: pytest.Config):
     ignore:.*builtin type swigvarlink has no.*:DeprecationWarning
     # eeglabio
     ignore:numpy\.core\.records is deprecated.*:DeprecationWarning
+    ignore:Starting field name with a underscore.*:
     # joblib
     ignore:process .* is multi-threaded, use of fork/exec.*:DeprecationWarning
     """  # noqa: E501

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -436,21 +436,24 @@ def _read_segment_file(data, idx, fi, start, stop, raw_extras, filenames, cals, 
                 ones[orig_idx, smp_read : smp_read + len(one_i)] = one_i
                 n_smp_read[orig_idx] += len(one_i)
 
+        # resample channels with lower sample requency
         # skip if no data was requested, ie. only annotations were read
-        if sum(n_smp_read) > 0:
+        if any(n_smp_read) > 0:
             # expected number of samples, equals maximum sfreq
             smp_exp = data.shape[-1]
-            assert max(n_smp_read) == smp_exp
 
             # resample data after loading all chunks to prevent edge artifacts
             resampled = False
+
             for i, smp_read in enumerate(n_smp_read):
                 # nothing read, nothing to resample
                 if smp_read == 0:
                     continue
                 # upsample if n_samples is lower than from highest sfreq
                 if smp_read != smp_exp:
-                    assert (ones[i, smp_read:] == 0).all()  # sanity check
+                    # sanity check that we read exactly how much we expected
+                    assert (ones[i, smp_read:] == 0).all()
+
                     ones[i, :] = resample(
                         ones[i, :smp_read].astype(np.float64),
                         smp_exp,

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -436,7 +436,7 @@ def _read_segment_file(data, idx, fi, start, stop, raw_extras, filenames, cals, 
                 ones[orig_idx, smp_read : smp_read + len(one_i)] = one_i
                 n_smp_read[orig_idx] += len(one_i)
 
-        # resample channels with lower sample requency
+        # resample channels with lower sample frequency
         # skip if no data was requested, ie. only annotations were read
         if any(n_smp_read) > 0:
             # expected number of samples, equals maximum sfreq

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -258,26 +258,23 @@ def test_edf_different_sfreqs(stim_channel):
     assert_allclose(data1, data2, err_msg="Data mismatch with preload")
     assert_allclose(times1, times2)
 
+
 @testing.requires_testing_data
 @pytest.mark.parametrize("stim_channel", (None, False, "auto"))
 def test_edf_different_sfreqs_nopreload(stim_channel):
     """Test loading smaller sfreq channels without preloading"""
-
     # load without preloading, then load a channel that has smaller sfreq
     # as other channels, produced an error, see mne-python/issues/12897
 
     for i in range(1, 13):
-        raw = read_raw_edf(
-            input_fname=edf_reduced,
-            verbose='error',
-            preload=False)
+        raw = read_raw_edf(input_fname=edf_reduced, verbose="error", preload=False)
 
         # this should work for channels of all sfreq, even if larger sfreqs
         # are present in the file
-        x1 = raw.get_data(picks=[f'A{i}'], return_times=False)
+        x1 = raw.get_data(picks=[f"A{i}"], return_times=False)
         # load next ch, this is sometimes with a higher sometimes a lower sfreq
-        x2 = raw.get_data([f'A{i+1}'], return_times=False)
-        assert x1.shape==x2.shape
+        x2 = raw.get_data([f"A{i + 1}"], return_times=False)
+        assert x1.shape == x2.shape
 
 
 def test_edf_data_broken(tmp_path):

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -262,7 +262,7 @@ def test_edf_different_sfreqs(stim_channel):
 @testing.requires_testing_data
 @pytest.mark.parametrize("stim_channel", (None, False, "auto"))
 def test_edf_different_sfreqs_nopreload(stim_channel):
-    """Test loading smaller sfreq channels without preloading"""
+    """Test loading smaller sfreq channels without preloading."""
     # load without preloading, then load a channel that has smaller sfreq
     # as other channels, produced an error, see mne-python/issues/12897
 

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -258,6 +258,27 @@ def test_edf_different_sfreqs(stim_channel):
     assert_allclose(data1, data2, err_msg="Data mismatch with preload")
     assert_allclose(times1, times2)
 
+@testing.requires_testing_data
+@pytest.mark.parametrize("stim_channel", (None, False, "auto"))
+def test_edf_different_sfreqs_nopreload(stim_channel):
+    """Test loading smaller sfreq channels without preloading"""
+
+    # load without preloading, then load a channel that has smaller sfreq
+    # as other channels, produced an error, see mne-python/issues/12897
+
+    for i in range(1, 13):
+        raw = read_raw_edf(
+            input_fname=edf_reduced,
+            verbose='error',
+            preload=False)
+
+        # this should work for channels of all sfreq, even if larger sfreqs
+        # are present in the file
+        x1 = raw.get_data(picks=[f'A{i}'], return_times=False)
+        # load next ch, this is sometimes with a higher sometimes a lower sfreq
+        x2 = raw.get_data([f'A{i+1}'], return_times=False)
+        assert x1.shape==x2.shape
+
 
 def test_edf_data_broken(tmp_path):
     """Test edf files."""


### PR DESCRIPTION
Fixes #12897.

When loading an EDF with mixed sample frequencies and using `preload=False` and then requesting a channel that has lower sample frequency than the maximum resulted in an `AssertionError`.

#### What does this implement/fix?

 This Assertion was in place to make sure that enough samples were read, but only made sense when one of the channels of maximum sample frequency was loaded.

It can simply be removed as I don't think that the case can actually occur. Additionally, there is another check for zeros a few lines later that serves a similar purpose.


