### PR TITLE
Backport PR #13067 on branch maint/1.9 ([BUG] Fix taper weighting in computation of TFR multitaper power)

### DIFF
--- a/doc/changes/devel/13067.bugfix.rst
+++ b/doc/changes/devel/13067.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where taper weights were not correctly applied when computing multitaper power with :meth:`mne.Epochs.compute_tfr` and :func:`mne.time_frequency.tfr_array_multitaper`, by `Thomas Binns`_.

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -25,6 +25,14 @@ def export_raw(
 
     %(export_warning)s
 
+    .. warning::
+        When exporting ``Raw`` with annotations, ``raw.info["meas_date"]`` must be the
+        same as ``raw.annotations.orig_time``. This guarantees that the annotations are
+        in the same reference frame as the samples. When
+        :attr:`Raw.first_time <mne.io.Raw.first_time>` is not zero (e.g., after
+        cropping), the onsets are automatically corrected so that onsets are always
+        relative to the first sample.
+
     Parameters
     ----------
     %(fname_export_params)s
@@ -216,7 +224,6 @@ def _infer_check_export_fmt(fmt, fname, supported_formats):
 
         supported_str = ", ".join(supported)
         raise ValueError(
-            f"Format '{fmt}' is not supported. "
-            f"Supported formats are {supported_str}."
+            f"Format '{fmt}' is not supported. Supported formats are {supported_str}."
         )
     return fmt

--- a/mne/time_frequency/tests/test_tfr.py
+++ b/mne/time_frequency/tests/test_tfr.py
@@ -255,22 +255,6 @@ def test_tfr_morlet():
     # computed within the method.
     assert_allclose(epochs_amplitude_2.data**2, epochs_power_picks.data)
 
-    # test that averaging power across tapers when multitaper with
-    # output='complex' gives the same as output='power'
-    epoch_data = epochs.get_data()
-    multitaper_power = tfr_array_multitaper(
-        epoch_data, epochs.info["sfreq"], freqs, n_cycles, output="power"
-    )
-    multitaper_complex = tfr_array_multitaper(
-        epoch_data, epochs.info["sfreq"], freqs, n_cycles, output="complex"
-    )
-
-    taper_dim = 2
-    power_from_complex = (multitaper_complex * multitaper_complex.conj()).real.mean(
-        axis=taper_dim
-    )
-    assert_allclose(power_from_complex, multitaper_power)
-
     print(itc)  # test repr
     print(itc.ch_names)  # test property
     itc += power  # test add

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1494,19 +1494,22 @@ fmt : 'auto' | 'brainvision' | 'edf' | 'eeglab'
 
 docdict["export_fmt_support_epochs"] = """\
 Supported formats:
-    - EEGLAB (``.set``, uses :mod:`eeglabio`)
+
+- EEGLAB (``.set``, uses :mod:`eeglabio`)
 """
 
 docdict["export_fmt_support_evoked"] = """\
 Supported formats:
-    - MFF (``.mff``, uses :func:`mne.export.export_evokeds_mff`)
+
+- MFF (``.mff``, uses :func:`mne.export.export_evokeds_mff`)
 """
 
 docdict["export_fmt_support_raw"] = """\
 Supported formats:
-    - BrainVision (``.vhdr``, ``.vmrk``, ``.eeg``, uses `pybv <https://github.com/bids-standard/pybv>`_)
-    - EEGLAB (``.set``, uses :mod:`eeglabio`)
-    - EDF (``.edf``, uses `edfio <https://github.com/the-siesta-group/edfio>`_)
+
+- BrainVision (``.vhdr``, ``.vmrk``, ``.eeg``, uses `pybv <https://github.com/bids-standard/pybv>`_)
+- EEGLAB (``.set``, uses :mod:`eeglabio`)
+- EDF (``.edf``, uses `edfio <https://github.com/the-siesta-group/edfio>`_)
 """  # noqa: E501
 
 docdict["export_warning"] = """\


### PR DESCRIPTION
@larsoner My attempt at a manual backport of #13067 due to some merge conflicts.
Also had to add some code from #12910 which ensured the correct weights were returned from `_make_dpss`, and removed part of a unit test that would no longer function (to do so would require API changes introduced in #12910).
