### PR TITLE
ENH: Support BDF export

### DIFF
--- a/mne/export/_edf.py
+++ b/mne/export/_edf.py
@@ -11,7 +11,6 @@ from ..annotations import _sync_onset
 from ..utils import _check_edfio_installed, warn
 
 _check_edfio_installed()
-from edfio import Edf, EdfAnnotation, EdfSignal, Patient, Recording  # noqa: E402
 
 
 # copied from edfio (Apache license)
@@ -29,12 +28,17 @@ def _round_float_to_8_characters(
     return round_func(value * factor) / factor
 
 
-def _export_raw(fname, raw, physical_range, add_ch_type):
+def _export_raw(fname, raw, physical_range, add_ch_type, *, fmt="edf"):
     """Export Raw objects to EDF files.
 
     TODO: if in future the Info object supports transducer or technician information,
     allow writing those here.
     """
+    assert fmt in ("edf", "bdf"), fmt
+    _check_edfio_installed(min_version="0.4.6" if fmt == "bdf" else None)
+
+    from edfio import Edf, EdfAnnotation, EdfSignal, Patient, Recording  # noqa: E402
+
     # get voltage-based data in uV
     units = dict(
         eeg="uV", ecog="uV", seeg="uV", eog="uV", ecg="uV", emg="uV", bio="uV", dbs="uV"

--- a/mne/export/_export.py
+++ b/mne/export/_export.py
@@ -58,6 +58,7 @@ def export_raw(
     supported_export_formats = {  # format : (extensions,)
         "eeglab": ("set",),
         "edf": ("edf",),
+        "bdf": ("bdf",),
         "brainvision": (
             "eeg",
             "vmrk",
@@ -77,10 +78,10 @@ def export_raw(
         from ._eeglab import _export_raw
 
         _export_raw(fname, raw)
-    elif fmt == "edf":
+    elif fmt in ("edf", "bdf"):
         from ._edf import _export_raw
 
-        _export_raw(fname, raw, physical_range, add_ch_type)
+        _export_raw(fname, raw, physical_range, add_ch_type, fmt=fmt)
     elif fmt == "brainvision":
         from ._brainvision import _export_raw
 

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -446,9 +446,11 @@ def _check_eeglabio_installed(strict=True):
     return _soft_import("eeglabio", "exporting to EEGLab", strict=strict)
 
 
-def _check_edfio_installed(strict=True):
+def _check_edfio_installed(strict=True, *, min_version=None):
     """Aux function."""
-    return _soft_import("edfio", "exporting to EDF", strict=strict)
+    return _soft_import(
+        "edfio", "exporting to EDF", min_version=min_version, strict=strict
+    )
 
 
 def _check_pybv_installed(strict=True):

--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -75,7 +75,7 @@ pip install $STD_ARGS git+https://github.com/joblib/joblib
 echo "edfio"
 # Disable protection for Azure, see
 # https://github.com/mne-tools/mne-python/pull/12609#issuecomment-2115639369
-GIT_CLONE_PROTECTION_ACTIVE=false pip install $STD_ARGS git+https://github.com/the-siesta-group/edfio
+GIT_CLONE_PROTECTION_ACTIVE=false pip install $STD_ARGS "git+https://github.com/larsoner/edfio@bdf"
 
 echo "h5io"
 pip install $STD_ARGS git+https://github.com/h5io/h5io


### PR DESCRIPTION
Closes #13090

Draft because I haven't done any of the actual work in `edfio`. I modified all `edf` export tests to now test both EDF and BDF. They should pass on all runs other than `pip-pre` (as these should skip the BDF tests due to insufficient edfio version), and on `pip-pre` they should fail (because new enough `edfio` will be installed from source :crossed_fingers: .

- [ ] Actually enhance `edfio`
- [ ] Restart CIs to see them green
- [ ] Get `edfio` PR merged
- [ ] Remove shim to install my branch rather than upstream

Then we should be able to merge.