### PR TITLE
Support preload=False for the new EEGLAB single .set format

### DIFF
--- a/mne/io/eeglab/_eeglab.py
+++ b/mne/io/eeglab/_eeglab.py
@@ -9,7 +9,7 @@ try:
 except ImportError:  # scipy < 1.8
     from scipy.io.matlab.mio5 import MatlabFunction
     from scipy.io.matlab.mio5_params import MatlabOpaque
-from scipy.io import loadmat
+from scipy.io import loadmat, whosmat
 
 from ...utils import _import_pymatreader_funcs
 
@@ -71,13 +71,29 @@ def _check_for_scipy_mat_struct(data):  # taken from pymatreader.utils
     return data
 
 
-def _readmat(fname, uint16_codec=None):
+def _readmat(fname, uint16_codec=None, preload=False):
     try:
         read_mat = _import_pymatreader_funcs("EEGLAB I/O")
     except RuntimeError:  # pymatreader not installed
-        eeg = loadmat(
-            fname, squeeze_me=True, mat_dtype=False, uint16_codec=uint16_codec
-        )
+        if preload:
+            eeg = loadmat(
+                fname, squeeze_me=True, mat_dtype=False, uint16_codec=uint16_codec
+            )
+        else:
+            info_fields = ['setname', 'filename', 'filepath', 'subject', 'group', 'condition', 'session', 'comments', 'nbchan', 'trials', 'pnts', 'srate', 'xmin', 'xmax', 'times', 'icaact', 'icawinv', 'icasphere', 'icaweights', 'icachansind', 'chanlocs', 'urchanlocs', 'chaninfo', 'ref', 'event', 'urevent', 'eventdescription', 'epoch', 'epochdescription', 'reject', 'stats', 'specdata', 'specicaact', 'splinefile', 'icasplinefile', 'dipfit', 'history', 'saved', 'etc']
+            eeg = loadmat(
+                fname, variable_names=info_fields, squeeze_me=True, mat_dtype=False, uint16_codec=uint16_codec
+            )
+            variables = whosmat(str(fname))
+            for var in variables:
+                if var[0] == 'data':
+                    numeric_types = ['int8', 'int16', 'int32', 'int64', 'uint8', 'uint16', 'uint32', 'uint64', 'single', 'double']
+                    if var[2] in numeric_types:
+                        # in preload=False mode and data is in .set file
+                        eeg['data'] = str(fname)
+                    else:
+                        eeg['data'] = loadmat(fname, variable_names=['data'], squeeze_me=True, mat_dtype=False, uint16_codec=uint16_codec)
+                    break
         return _check_for_scipy_mat_struct(eeg)
     else:
         return read_mat(fname, uint16_codec=uint16_codec)


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

<!-- Example:

Fixes #1234.

-->


#### What does this implement/fix?

EEGLAB introduced a new mechanism that allows reading only metadata from a single .set file that has both data and metadata. Thus raw data no longer needed to be stored in a separate .fdt file. Adding this feature to MNE. This implementation uses scipy's loadmat and whosmat functions.


#### Additional information

<!-- Any additional information you think is important. -->
