### PR TITLE
Fix EEGLAB import (nodatchans)

### DIFF
--- a/doc/changes/devel/13097.bugfix.rst
+++ b/doc/changes/devel/13097.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug when loading certain EEGLAB files that do not contain a `nodatchans` field, by `Clemens Brunner`_.
+Fix bug when loading certain EEGLAB files that do not contain a ``nodatchans`` field, by `Clemens Brunner`_.

--- a/doc/changes/devel/13097.bugfix.rst
+++ b/doc/changes/devel/13097.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug when loading certain EEGLAB files that do not contain a `nodatchans` field, by `Clemens Brunner`_.

--- a/mne/io/eeglab/eeglab.py
+++ b/mne/io/eeglab/eeglab.py
@@ -162,7 +162,7 @@ def _get_montage_information(eeg, get_pos, *, montage_units):
         )
 
     lpa, rpa, nasion = None, None, None
-    if hasattr(eeg, "chaninfo") and isinstance(eeg.chaninfo["nodatchans"], dict):
+    if hasattr(eeg, "chaninfo") and isinstance(eeg.chaninfo.get("nodatchans"), dict):
         nodatchans = eeg.chaninfo["nodatchans"]
         types = nodatchans.get("type", [])
         descriptions = nodatchans.get("description", [])


### PR DESCRIPTION
Use a safe way to try and access `eeg.chaninfo["nodatchans"]`. Fixes #13094.