### PR TITLE
Take units (m or mm) into account when showing fieldmaps on top of brains

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,10 +102,7 @@ jobs:
       # Python (if conda)
       - name: Fixes for conda
         run: |
-          # For some reason on Linux we get crashes
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
-            sed -i "/numba/d" environment.yml
-          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
             sed -i "" "s/  - PySide6 .*/  - PySide6 <6.8/g" environment.yml
           fi
         if: matrix.kind == 'conda' || matrix.kind == 'mamba'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,7 +102,10 @@ jobs:
       # Python (if conda)
       - name: Fixes for conda
         run: |
-          if [[ "$RUNNER_OS" == "macOS" ]]; then
+          # For some reason on Linux we get crashes
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sed -i "/numba/d" environment.yml
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
             sed -i "" "s/  - PySide6 .*/  - PySide6 <6.8/g" environment.yml
           fi
         if: matrix.kind == 'conda' || matrix.kind == 'mamba'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,6 +89,7 @@ stages:
           DISPLAY: ':99'
           OPENBLAS_NUM_THREADS: '1'
           MNE_TEST_ALLOW_SKIP: '^.*(PySide6 causes segfaults).*$'
+          MNE_BROWSER_PRECOMPUTE: 'false'
         steps:
           - bash: |
               set -e

--- a/doc/changes/devel/13101.bugfix.rst
+++ b/doc/changes/devel/13101.bugfix.rst
@@ -1,0 +1,1 @@
+Take units (m or mm) into account when drawing :func:`~mne.viz.plot_evoked_field` on top of :class:`~mne.viz.Brain`, by `Marijn van Vliet`_.

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -190,6 +190,8 @@ def pytest_configure(config: pytest.Config):
     ignore:Starting field name with a underscore.*:
     # joblib
     ignore:process .* is multi-threaded, use of fork/exec.*:DeprecationWarning
+    # sklearn
+    ignore:Python binding for RankQuantileOptions.*:RuntimeWarning
     """  # noqa: E501
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -6,6 +6,7 @@ import gc
 import inspect
 import os
 import os.path as op
+import platform
 import re
 import shutil
 import sys
@@ -287,9 +288,10 @@ def matplotlib_config():
 @pytest.fixture(scope="session")
 def azure_windows():
     """Determine if running on Azure Windows."""
-    return os.getenv(
-        "AZURE_CI_WINDOWS", "false"
-    ).lower() == "true" and sys.platform.startswith("win")
+    return (
+        os.getenv("AZURE_CI_WINDOWS", "false").lower() == "true"
+        and platform.system() == "Windows"
+    )
 
 
 @pytest.fixture(scope="function")
@@ -612,6 +614,11 @@ def renderer_pyvistaqt(request, options_3d, garbage_collect):
 @pytest.fixture(params=[pytest.param("notebook", marks=pytest.mark.pvtest)])
 def renderer_notebook(request, options_3d):
     """Yield the 3D notebook renderer."""
+    if (
+        os.getenv("MNE_CI_KIND", "") in ("conda", "mamba")
+        and platform.system() == "Linux"
+    ):
+        pytest.skip("Skipping notebook tests on conda Linux CI")
     with _use_backend(request.param, interactive=False) as renderer:
         yield renderer
 

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -614,11 +614,6 @@ def renderer_pyvistaqt(request, options_3d, garbage_collect):
 @pytest.fixture(params=[pytest.param("notebook", marks=pytest.mark.pvtest)])
 def renderer_notebook(request, options_3d):
     """Yield the 3D notebook renderer."""
-    if (
-        os.getenv("MNE_CI_KIND", "") in ("conda", "mamba")
-        and platform.system() == "Linux"
-    ):
-        pytest.skip("Skipping notebook tests on conda Linux CI")
     with _use_backend(request.param, interactive=False) as renderer:
         yield renderer
 

--- a/mne/viz/evoked_field.py
+++ b/mne/viz/evoked_field.py
@@ -7,6 +7,7 @@ author: Marijn van Vliet <w.m.vanvliet@gmail.com>
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
+from copy import deepcopy
 from functools import partial
 
 import numpy as np
@@ -185,6 +186,7 @@ class EvokedField:
         if isinstance(fig, Brain):
             self._renderer = fig._renderer
             self._in_brain_figure = True
+            self._units = fig._units
             if _get_3d_backend() == "notebook":
                 raise NotImplementedError(
                     "Plotting on top of an existing Brain figure "
@@ -195,6 +197,7 @@ class EvokedField:
                 fig, bgcolor=(0.0, 0.0, 0.0), size=(600, 600)
             )
             self._in_brain_figure = False
+            self._units = "m"
 
         self.plotter = self._renderer.plotter
         self.interaction = interaction
@@ -276,8 +279,8 @@ class EvokedField:
         current_data = data_interp(self._current_time)
 
         # Make a solid surface
-        surf = surf_map["surf"]
-        if self._in_brain_figure:
+        surf = deepcopy(surf_map["surf"])
+        if self._units == "mm":
             surf["rr"] *= 1000
         map_vmax = self._vmax.get(surf_map["kind"])
         if map_vmax is None:

--- a/mne/viz/evoked_field.py
+++ b/mne/viz/evoked_field.py
@@ -279,8 +279,8 @@ class EvokedField:
         current_data = data_interp(self._current_time)
 
         # Make a solid surface
-        surf = deepcopy(surf_map["surf"])
         if self._units == "mm":
+            surf = deepcopy(surf_map["surf"])
             surf["rr"] *= 1000
         map_vmax = self._vmax.get(surf_map["kind"])
         if map_vmax is None:

--- a/mne/viz/evoked_field.py
+++ b/mne/viz/evoked_field.py
@@ -279,8 +279,9 @@ class EvokedField:
         current_data = data_interp(self._current_time)
 
         # Make a solid surface
+        surf = surf_map["surf"]
         if self._units == "mm":
-            surf = deepcopy(surf_map["surf"])
+            surf = deepcopy(surf)
             surf["rr"] *= 1000
         map_vmax = self._vmax.get(surf_map["kind"])
         if map_vmax is None:

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -191,6 +191,7 @@ def test_plot_evoked_field(renderer):
                 ch_type=t,
             )
         evoked.plot_field(maps, time=0.1, n_contours=n_contours)
+    renderer.backend._close_all()
 
     # Test plotting inside an existing Brain figure. Check that units are taken into
     # account.
@@ -204,6 +205,7 @@ def test_plot_evoked_field(renderer):
         assert (
             fig._surf_maps[0]["surf"]["rr"][0, 0] == scale * maps[0]["surf"]["rr"][0, 0]
         )
+        renderer.backend._close_all()
 
     # Test some methods
     fig = evoked.plot_field(maps, time_viewer=True)
@@ -223,6 +225,7 @@ def test_plot_evoked_field(renderer):
 
     fig = evoked.plot_field(maps, time_viewer=False)
     assert isinstance(fig, Figure3D)
+    renderer.backend._close_all()
 
 
 @testing.requires_testing_data

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -204,6 +204,7 @@ def test_plot_evoked_field(renderer):
         assert (
             fig._surf_maps[0]["surf"]["rr"][0, 0] == scale * maps[0]["surf"]["rr"][0, 0]
         )
+        brain.close()
 
     # Test some methods
     fig = evoked.plot_field(maps, time_viewer=True)

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -2,6 +2,8 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
+import os
+import platform
 from contextlib import nullcontext
 from pathlib import Path
 
@@ -204,7 +206,6 @@ def test_plot_evoked_field(renderer):
         assert (
             fig._surf_maps[0]["surf"]["rr"][0, 0] == scale * maps[0]["surf"]["rr"][0, 0]
         )
-        brain.close()
 
     # Test some methods
     fig = evoked.plot_field(maps, time_viewer=True)
@@ -226,8 +227,14 @@ def test_plot_evoked_field(renderer):
     assert isinstance(fig, Figure3D)
 
 
+bad_ci = (
+    os.getenv("MNE_CI_KIND", "") in ("conda", "mamba") and platform.system() == "Linux"
+)
+
+
 @testing.requires_testing_data
 @pytest.mark.slowtest
+@pytest.mark.skipif(bad_ci, reason="Segfaults on Linux conda CI")
 def test_plot_evoked_field_notebook(renderer_notebook, nbexec):
     """Test plotting the evoked field inside a notebook."""
     import pytest

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -192,9 +192,18 @@ def test_plot_evoked_field(renderer):
             )
         evoked.plot_field(maps, time=0.1, n_contours=n_contours)
 
-    # Test plotting inside an existing Brain figure.
-    brain = Brain("fsaverage", "lh", "inflated", subjects_dir=subjects_dir)
-    fig = evoked.plot_field(maps, time=0.1, fig=brain)
+    # Test plotting inside an existing Brain figure. Check that units are taken into
+    # account.
+    for units in ["mm", "m"]:
+        brain = Brain(
+            "fsaverage", "lh", "inflated", units=units, subjects_dir=subjects_dir
+        )
+        fig = evoked.plot_field(maps, time=0.1, fig=brain)
+        assert brain._units == fig._units
+        scale = 1000 if units == "mm" else 1
+        assert (
+            fig._surf_maps[0]["surf"]["rr"][0, 0] == scale * maps[0]["surf"]["rr"][0, 0]
+        )
 
     # Test some methods
     fig = evoked.plot_field(maps, time_viewer=True)

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -2,8 +2,6 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
-import os
-import platform
 from contextlib import nullcontext
 from pathlib import Path
 
@@ -227,14 +225,8 @@ def test_plot_evoked_field(renderer):
     assert isinstance(fig, Figure3D)
 
 
-bad_ci = (
-    os.getenv("MNE_CI_KIND", "") in ("conda", "mamba") and platform.system() == "Linux"
-)
-
-
 @testing.requires_testing_data
 @pytest.mark.slowtest
-@pytest.mark.skipif(bad_ci, reason="Segfaults on Linux conda CI")
 def test_plot_evoked_field_notebook(renderer_notebook, nbexec):
     """Test plotting the evoked field inside a notebook."""
     import pytest


### PR DESCRIPTION
Plotting evoked fieldlines on top of distributed source estimates is very cool:

![image](https://github.com/user-attachments/assets/9e83b4e0-31be-402e-b85d-66e24d62a98b)

But, `mne.viz.Brain` can use either `units="m"` or `units="mm"`. The `plot_evoked_field` function always assumed it would be kept at the default `units="mm"`. This PR makes it actually pay attention to the unit. Another bug fixed is that when plotting in millimeters, the helmet surface would be modified in place: `surf["rr"] *= 1000`. This causes trouble as now the surface will forever be upscaled and should you plot it again, it will be upscaled again. In this PR a `deepcopy()` is made first.