### PR TITLE
Fix `Annotations` time formats

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1264,7 +1264,13 @@ def _read_annotations_csv(fname):
             "onsets in seconds."
         )
     except ValueError:
-        pass
+        # remove nanoseconds for ISO8601 (microsecond) compliance
+        timestamp = pd.Timestamp(orig_time)
+        timespec = "microseconds"
+        if timestamp == pd.Timestamp(_handle_meas_date(0)).astimezone(None):
+            timespec = "auto"  # use default timespec for `orig_time=None`
+        orig_time = timestamp.isoformat(sep=" ", timespec=timespec)
+
     onset_dt = pd.to_datetime(df["onset"])
     onset = (onset_dt - onset_dt[0]).dt.total_seconds()
     duration = df["duration"].values.astype(float)

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1041,6 +1041,24 @@ def test_broken_csv(tmp_path):
         read_annotations(fname)
 
 
+def test_nanosecond_csv(tmp_path):
+    """Test .csv with nanosecond timestamps for onsets read correctly."""
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    onset = (
+        pd.Timestamp(_ORIG_TIME)
+        .astimezone(None)
+        .isoformat(sep=" ", timespec="nanoseconds")
+    )
+    content = f"onset,duration,description\n{onset},1.0,AA"
+    fname = tmp_path / "annotations_broken.csv"
+    with open(fname, "w") as f:
+        f.write(content)
+    annot = read_annotations(fname)
+    assert annot.orig_time == _ORIG_TIME
+
+
 # Test for IO with .txt files
 
 
@@ -1462,6 +1480,8 @@ def test_repr():
 def test_annotation_to_data_frame(time_format):
     """Test annotation class to data frame conversion."""
     pytest.importorskip("pandas")
+    import pandas as pd
+
     onset = np.arange(1, 10)
     durations = np.full_like(onset, [4, 5, 6, 4, 5, 6, 4, 5, 6])
     description = ["yy"] * onset.shape[0]
@@ -1480,6 +1500,12 @@ def test_annotation_to_data_frame(time_format):
         got = got.seconds
     assert want == got
     assert df.groupby("description").count().onset["yy"] == 9
+
+    # Check nanoseconds omitted from onset times
+    if time_format == "datetime":
+        a.onset += 1e-7  # >6 decimals to trigger nanosecond component
+        df = a.to_data_frame(time_format=time_format)
+        assert pd.Timestamp(df.onset[0]).nanosecond == 0
 
 
 def test_annotation_ch_names():

--- a/mne/utils/dataframe.py
+++ b/mne/utils/dataframe.py
@@ -46,7 +46,9 @@ def _convert_times(times, time_format, meas_date=None, first_time=0):
     elif time_format == "timedelta":
         times = to_timedelta(times, unit="s")
     elif time_format == "datetime":
-        times = to_timedelta(times + first_time, unit="s") + meas_date
+        times = (to_timedelta(times + first_time, unit="s") + meas_date).astype(
+            "datetime64[us]"
+        )  # make ISO8601 (microsecond) compatible
     return times
 
 


### PR DESCRIPTION
#### Reference issue (if any)

Fixes #13108 


#### What does this implement/fix?

When reading annotations from a csv file, truncates nanoseconds from `orig_time` by converting to the microsecond format. The exception is for the default time of `1970-01-01 00:00:00` used in the files when `Annotations.orig_time=None`, as converting this to microseconds would cause it to be read as a proper time rather than being converted to `None` which is intended.

Also truncates nanoseconds from the times in `utils.dataframes._convert_times()` when `time_format="datetime"` by converting to `dtype=datetime64[us]`.
Should this also be done when `time_format="timedelta"`?

Finally, updates unit tests that check csv files with nanosecond times get assigned proper `orig_time` when read in and checks that `Annotations.to_data_frame()` returns times with nanoseconds truncated (which in turn means truncated times are saved).
