### PR TITLE
BUG: Fix EDF Out of Bound Error

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1453,9 +1453,7 @@ def _read_gdf_header(fname, exclude, include=None):
                     n_events = np.fromfile(fid, UINT32, 1)[0]
                 else:
                     ne = np.fromfile(fid, UINT8, 3)
-                    n_events = ne[0]
-                    for i in range(1, len(ne)):
-                        n_events = n_events + int(ne[i]) * 2 ** (i * 8)
+                    n_events = sum(int(ne[i]) << (i * 8) for i in range(len(ne)))
                     event_sr = np.fromfile(fid, FLOAT32, 1)[0]
 
                 pos = np.fromfile(fid, UINT32, n_events) - 1  # 1-based inds


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

Fixes #13111.


#### What does this implement/fix?

This fixes a "Python integer 512 out of bounds" issue that occurred when accumulating values using a for-loop with exponentiation (2 ** (i * 8)). The issue arose because intermediate values exceeded the uint8 (0-255) limit.


