### PR TITLE
DOC: add link to governance people so that it is findable.

### DIFF
--- a/doc/development/governance.rst
+++ b/doc/development/governance.rst
@@ -46,7 +46,9 @@ Governance Model
 Leadership Roles
 ^^^^^^^^^^^^^^^^
 
-The MNE-Python leadership structure shall consist of:
+The MNE-Python leadership structure shall consist of the following groups.
+A list of the current members of the respective groups is maintained at the
+page :ref:`governance-people`.
 
 Maintainer Team
 ---------------


### PR DESCRIPTION
https://mne.tools/dev/overview/people.html

As far as I see, this page (☝️) would be an "orphan" otherwise (if that is the right term), in that there is no page linking to it, and it does not occur in any index. I think it is important to make this findable, both for credit and accountability reasons.

This link existed in our previous governance and was likely accidentally removed (or not adjusted) in #12896

