### PR TITLE
ENH: Improve robustness in extracting sfreq

### DIFF
--- a/doc/changes/devel/13184.bugfix.rst
+++ b/doc/changes/devel/13184.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug with sampling frequency estimation in snirf files, by `Daniel McCloy`_.
+Fix bug with sampling frequency estimation in snirf files, by `Daniel McCloy`_ and :newcontrib:`Yixiao Shen`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -322,6 +322,7 @@
 .. _Xiaokai Xia: https://github.com/dddd1007
 .. _Yaroslav Halchenko: http://haxbylab.dartmouth.edu/ppl/yarik.html
 .. _Yiping Zuo: https://github.com/frostime
+.. _Yixiao Shen: https://github.com/SYXiao2002
 .. _Yousra Bekhti: https://www.linkedin.com/pub/yousra-bekhti/56/886/421
 .. _Yu-Han Luo: https://github.com/yh-luo
 .. _Zhi Zhang: https://github.com/tczhangzhi/

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -546,14 +546,11 @@ def _extract_sampling_rate(dat):
     else:
         # specified as time points
         periods = np.diff(time_data)
-        uniq_periods = np.unique(periods.round(decimals=4))
-        if uniq_periods.size == 1:
-            # Uniformly sampled data
-            sampling_rate = 1.0 / uniq_periods.item()
-        else:
+        mean_period = np.mean(periods)
+        sampling_rate = 1.0 / mean_period
+        if not np.allclose(periods, mean_period, rtol=1e-6):
             # Hopefully uniformly sampled data with some precision issues.
             # This is a workaround to provide support for Artinis data.
-            mean_period = np.mean(periods)
             sampling_rate = 1.0 / mean_period
             ideal_times = np.linspace(time_data[0], time_data[-1], time_data.size)
             max_jitter = np.max(np.abs(time_data - ideal_times))

--- a/mne/io/snirf/_snirf.py
+++ b/mne/io/snirf/_snirf.py
@@ -551,7 +551,6 @@ def _extract_sampling_rate(dat):
         if not np.allclose(periods, mean_period, rtol=1e-6):
             # Hopefully uniformly sampled data with some precision issues.
             # This is a workaround to provide support for Artinis data.
-            sampling_rate = 1.0 / mean_period
             ideal_times = np.linspace(time_data[0], time_data[-1], time_data.size)
             max_jitter = np.max(np.abs(time_data - ideal_times))
             percent_jitter = 100.0 * max_jitter / mean_period


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

<!-- Example:

Fixes #1234.

-->

Fixes #13117.

#### What does this implement/fix?

<!-- Explain your changes. -->

Enhanced the calculation of the sampling rate to avoid potential indexing errors. 

#### Additional information

<!-- Any additional information you think is important. -->

It is recommended to include `rtol` as a function parameter for [_extract_sampling_rate(dat)](https://github.com/mne-tools/mne-python/blob/4c98f8ae5524fea24968fb1aa2bf2028886d5934/mne/io/snirf/_snirf.py#L534) in the future.



