### PR TITLE
BUG: Fix bug with coord frame reading

### DIFF
--- a/mne/_fiff/_digitization.py
+++ b/mne/_fiff/_digitization.py
@@ -186,7 +186,8 @@ def _read_dig_fif(fid, meas_info, *, return_ch_names=False):
                 dig.extend(tag.data)
             elif kind == FIFF.FIFF_MNE_COORD_FRAME:
                 tag = read_tag(fid, pos)
-                coord_frame = _coord_frame_named.get(int(tag.data.item()))
+                coord_frame = int(tag.data.item())
+                coord_frame = _coord_frame_named.get(coord_frame, coord_frame)
             elif kind == FIFF.FIFF_MNE_CH_NAME_LIST:
                 tag = read_tag(fid, pos)
                 ch_names = _safe_name_list(tag.data, "read", "ch_names")

--- a/mne/_fiff/constants.py
+++ b/mne/_fiff/constants.py
@@ -281,10 +281,11 @@ _coord_frame_named = {
         FIFF.FIFFV_COORD_HPI,
         FIFF.FIFFV_COORD_HEAD,
         FIFF.FIFFV_COORD_MRI,
-        FIFF.FIFFV_COORD_MRI_SLICE,
-        FIFF.FIFFV_COORD_MRI_DISPLAY,
-        FIFF.FIFFV_COORD_DICOM_DEVICE,
-        FIFF.FIFFV_COORD_IMAGING_DEVICE,
+        # We never use these but could add at some point
+        # FIFF.FIFFV_COORD_MRI_SLICE,
+        # FIFF.FIFFV_COORD_MRI_DISPLAY,
+        # FIFF.FIFFV_COORD_DICOM_DEVICE,
+        # FIFF.FIFFV_COORD_IMAGING_DEVICE,
     )
 }
 #
@@ -817,6 +818,17 @@ FIFF.FIFFV_MNE_COORD_FS_TAL = 2006  # FreeSurfer Talairach coordinates
 #
 FIFF.FIFFV_MNE_COORD_4D_HEAD = FIFF.FIFFV_MNE_COORD_CTF_HEAD
 FIFF.FIFFV_MNE_COORD_KIT_HEAD = FIFF.FIFFV_MNE_COORD_CTF_HEAD
+_coord_frame_named.update({
+    key: key
+    for key in (
+        FIFF.FIFFV_MNE_COORD_CTF_DEVICE,
+        FIFF.FIFFV_MNE_COORD_MRI_VOXEL,
+        FIFF.FIFFV_MNE_COORD_RAS,
+        FIFF.FIFFV_MNE_COORD_MNI_TAL,
+        FIFF.FIFFV_MNE_COORD_FS_TAL,
+        FIFF.FIFFV_MNE_COORD_KIT_HEAD,
+    )
+})
 
 #
 #   FWD Types

--- a/mne/channels/tests/test_montage.py
+++ b/mne/channels/tests/test_montage.py
@@ -169,11 +169,16 @@ def test_fiducials(tmp_path, fname):
     assert_allclose(points[1, 0], 0.0, atol=1e-6)
     assert points[1, 1] > 0
     fname_out = tmp_path / "test-dig.fif"
-    mne.channels.make_dig_montage(
-        lpa=points[0], nasion=points[1], rpa=points[2], coord_frame="mri_voxel"
+    make_dig_montage(
+        lpa=fids[0]["r"], nasion=fids[1]["r"], rpa=fids[2]["r"], coord_frame="mri_voxel"
     ).save(fname_out, overwrite=True)
     fids_2, coord_frame_2 = read_fiducials(fname_out)
-    assert coord_frame != coord_frame_2
+    assert coord_frame_2 == FIFF.FIFFV_MNE_COORD_MRI_VOXEL
+    assert_allclose(
+        [fid["r"] for fid in fids[:3]],
+        [fid["r"] for fid in fids_2],
+        rtol=1e-6,
+    )
     assert coord_frame_2 is not None
 
 

--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -41,10 +41,12 @@ als_ras_trans = np.array([[0, -1, 0, 0], [1, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1
 
 
 _str_to_frame = dict(
+    isotrak=FIFF.FIFFV_COORD_ISOTRAK,
     meg=FIFF.FIFFV_COORD_DEVICE,
     mri=FIFF.FIFFV_COORD_MRI,
     mri_voxel=FIFF.FIFFV_MNE_COORD_MRI_VOXEL,
     head=FIFF.FIFFV_COORD_HEAD,
+    hpi=FIFF.FIFFV_COORD_HPI,
     mni_tal=FIFF.FIFFV_MNE_COORD_MNI_TAL,
     ras=FIFF.FIFFV_MNE_COORD_RAS,
     fs_tal=FIFF.FIFFV_MNE_COORD_FS_TAL,
@@ -62,15 +64,16 @@ _verbose_frames = {
     FIFF.FIFFV_COORD_HEAD: "head",
     FIFF.FIFFV_COORD_MRI: "MRI (surface RAS)",
     FIFF.FIFFV_MNE_COORD_MRI_VOXEL: "MRI voxel",
-    FIFF.FIFFV_COORD_MRI_SLICE: "MRI slice",
-    FIFF.FIFFV_COORD_MRI_DISPLAY: "MRI display",
     FIFF.FIFFV_MNE_COORD_CTF_DEVICE: "CTF MEG device",
     FIFF.FIFFV_MNE_COORD_CTF_HEAD: "CTF/4D/KIT head",
     FIFF.FIFFV_MNE_COORD_RAS: "RAS (non-zero origin)",
     FIFF.FIFFV_MNE_COORD_MNI_TAL: "MNI Talairach",
-    FIFF.FIFFV_MNE_COORD_FS_TAL_GTZ: "Talairach (MNI z > 0)",
-    FIFF.FIFFV_MNE_COORD_FS_TAL_LTZ: "Talairach (MNI z < 0)",
-    -1: "unknown",
+    FIFF.FIFFV_MNE_COORD_FS_TAL: "FS Talairach",
+    # We don't use these, but keep them in case we ever want to add them.
+    # FIFF.FIFFV_COORD_MRI_SLICE: "MRI slice",
+    # FIFF.FIFFV_COORD_MRI_DISPLAY: "MRI display",
+    # FIFF.FIFFV_MNE_COORD_FS_TAL_GTZ: "Talairach (MNI z > 0)",
+    # FIFF.FIFFV_MNE_COORD_FS_TAL_LTZ: "Talairach (MNI z < 0)",
 }
 
 


### PR DESCRIPTION
Fixes bugs in mne-bids `main` introduced by #13083, see for example [here](https://github.com/mne-tools/mne-bids/actions/runs/13504084782/job/37729445482?pr=1376). Short fix would have been to just change a `.get(coord_frame)` to `.get(coord_frame, coord_frame)`, but then I realized we didn't fully test consistency of coord frame constant use. So this PR also cleans that up.

Notably there are some coordinate frames that AFAIK we never use, so those have been singled out a couple of places here. But critically I added some tests to make sure three private constants that we use in many places are now internally consistent. We could in principle include these, but it will bloat all `_check_option` errors that people see so I don't see much value. And these tests/comments will make it easy to add them later if we ever want them.