### PR TITLE
MAINT: Update towncrier dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,10 +77,8 @@ doc = [
   "sphinx-gallery >= 0.16",
   "sphinx_copybutton",
   "sphinxcontrib-bibtex >= 2.5",
-  "sphinxcontrib-towncrier",
+  "sphinxcontrib-towncrier >=0.5.0a0",
   "sphinxcontrib-youtube",
-  # https://github.com/sphinx-contrib/sphinxcontrib-towncrier/issues/92
-  "towncrier < 24.7",
 ]
 full = ["mne[full-no-qt]", "PyQt6 != 6.6.0", "PyQt6-Qt6 != 6.6.0, != 6.7.0"]
 # Dependencies for full MNE-Python functionality (other than raw/epochs export)


### PR DESCRIPTION
sphinxcontrib-towncrier was updated and released so now we can remove the pin. (Note all releases of theirs on PyPI have an alpha tag so it should be the best we can do to pin to `>=` the currently released "alpha" version.) Will mark for merge-when-green once I make sure the dev whats new looks okay.