### PR TITLE
Fix apply_function docstring for Epochs #13118

### DIFF
--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1861,7 +1861,7 @@ fun : callable
         additional argument(s) to your function definition.
 """
 docdict["fun_applyfun"] = applyfun_fun_base.format(
-    " if ``channel_wise=True`` and ``(len(picks), n_times)`` otherwise"
+    " if ``channel_wise=True`` then a 3D array of shape ``(n_epochs, len(picks), n_times)`` is passed, otherwise a 3D array of shape ``(n_epochs, n_channels, n_times)`` is passed"
 )
 docdict["fun_applyfun_evoked"] = applyfun_fun_base.format(
     " because it will apply channel-wise"


### PR DESCRIPTION
The current documentation for apply_function in mne.Epochs is misleading, as it does not accurately describe the shape of the epochs data (3D arrays). This can cause confusion about how the function processes the data across different dimensions.

This PR updates the relevant docstrings in mne/utils/docs.py to clearly state how apply_function operates on the epochs data, ensuring users understand the function's behavior when applied to multi-dimensional data structures. The updated documentation improves clarity and consistency with other MNE functions.