### PR TITLE
Fix intersphinx

### DIFF
--- a/doc/_includes/forward.rst
+++ b/doc/_includes/forward.rst
@@ -444,8 +444,8 @@ data:
           automatically created by the MNE-C utility ``mne_list_coil_def``.
 
 .. tabularcolumns:: |p{0.1\linewidth}|p{0.3\linewidth}|p{0.1\linewidth}|p{0.25\linewidth}|p{0.2\linewidth}|
-.. _normal_coil_descriptions:
 .. table:: Normal coil descriptions.
+    :name: normal_coil_descriptions
 
     +------+-------------------------+----+----------------------------------+----------------------+
     | Id   | Description             | n  | r/mm                             | w                    |
@@ -506,8 +506,8 @@ data:
           combinations have to be included.
 
 .. tabularcolumns:: |p{0.1\linewidth}|p{0.3\linewidth}|p{0.05\linewidth}|p{0.25\linewidth}|p{0.15\linewidth}|
-.. _accurate_coil_descriptions:
 .. table:: Accurate coil descriptions
+    :name: accurate_coil_descriptions
 
     +------+-------------------------+----+----------------------------------+----------------------+
     | Id   | Description             | n  | r/mm                             | w                    |
@@ -602,8 +602,8 @@ description line containing the following fields:
 
 
 .. tabularcolumns:: |p{0.1\linewidth}|p{0.5\linewidth}|
-.. _coil_accuracies:
 .. table:: Coil representation accuracies.
+    :name: coil_accuracies
 
     =======  ====================================================================================
     Value    Meaning

--- a/doc/_includes/forward.rst
+++ b/doc/_includes/forward.rst
@@ -186,7 +186,7 @@ and
    The symbols :math:`T_x` are defined in :ref:`coordinate_system_figure`.
 
 .. tabularcolumns:: |p{0.2\linewidth}|p{0.3\linewidth}|p{0.5\linewidth}|
-.. table:: Coordinate transformations in FreeSurfer and MNE software packages.
+.. table:: Coordinate transformations in FreeSurfer and MNE software packages
 
     +------------------------------+-------------------------------+-------------------------------------------------+
     | Transformation               | FreeSurfer                    | MNE                                             |
@@ -444,7 +444,7 @@ data:
           automatically created by the MNE-C utility ``mne_list_coil_def``.
 
 .. tabularcolumns:: |p{0.1\linewidth}|p{0.3\linewidth}|p{0.1\linewidth}|p{0.25\linewidth}|p{0.2\linewidth}|
-.. table:: Normal coil descriptions.
+.. table:: Normal coil descriptions
     :name: normal_coil_descriptions
 
     +------+-------------------------+----+----------------------------------+----------------------+
@@ -602,7 +602,7 @@ description line containing the following fields:
 
 
 .. tabularcolumns:: |p{0.1\linewidth}|p{0.5\linewidth}|
-.. table:: Coil representation accuracies.
+.. table:: Coil representation accuracies
     :name: coil_accuracies
 
     =======  ====================================================================================

--- a/doc/documentation/cookbook.rst
+++ b/doc/documentation/cookbook.rst
@@ -185,10 +185,7 @@ has been completed as described in :ref:`CHDBBCEJ`.
 
 .. _BABGCDHA:
 
-.. table:: Recommended subdivisions of an icosahedron and an octahedron for
-           the creation of source spaces. The approximate source spacing and
-           corresponding surface area have been calculated assuming a
-           1000-cm2 surface area per hemisphere.
+.. table:: Recommended subdivisions of an icosahedron and an octahedron for the creation of source spaces. The approximate source spacing and corresponding surface area have been calculated assuming a 1000-cm2 surface area per hemisphere.
 
     ===========  ======================  ===================  =============================
     ``spacing``  Sources per hemisphere  Source spacing / mm  Surface area per source / mm2


### PR DESCRIPTION
This PR:

- puts an rST table caption all on one line, which fixes an irregularity in how mkdocs parses the `objects.inv` file. This will enable intersphinx-like xrefs from the MNE-BIDS-Pipeline docs into MNE-Python docs. needed for https://github.com/mne-tools/mne-bids-pipeline/pull/1066

unrelated tweaks, since I was mucking in that file already:

- removes trailing periods from a couple table captions
- utilizes the preferred docutils `:name:` syntax for defining tables as xref targets