### PR TITLE
Colocated topomaps for OPM

### DIFF
--- a/doc/changes/devel/13144.newfeature.rst
+++ b/doc/changes/devel/13144.newfeature.rst
@@ -1,1 +1,1 @@
-Allow for :func:`mne.viz.topomap` plotting of optically pumped MEG (OPM) sensors with overlapping channel locations. When channel locations overlap, plot the most radially oriented channel. By `Harrison Ritz`_.
+Allow for `topomap` plotting of optically pumped MEG (OPM) sensors with overlapping channel locations. When channel locations overlap, plot the most radially oriented channel. By :newcontrib:`Harrison Ritz`.

--- a/doc/changes/devel/13144.newfeature.rst
+++ b/doc/changes/devel/13144.newfeature.rst
@@ -1,1 +1,1 @@
-Allow for `topomap` plotting of optically pumped MEG (OPM) sensors with overlapping channel locations. When channel locations overlap, plot the most radially oriented channel. By :newcontrib:`Harrison Ritz`.
+Allow for ``topomap`` plotting of optically pumped MEG (OPM) sensors with overlapping channel locations. When channel locations overlap, plot the most radially oriented channel. By :newcontrib:`Harrison Ritz`.

--- a/doc/changes/devel/13144.newfeature.rst
+++ b/doc/changes/devel/13144.newfeature.rst
@@ -1,0 +1,1 @@
+Allow for :func:`mne.viz.topomap` plotting of optically pumped MEG (OPM) sensors with overlapping channel locations. When channel locations overlap, plot the most radially oriented channel. By `Harrison Ritz`_.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -107,6 +107,7 @@
 .. _Hamid Maymandi: https://github.com/HamidMandi
 .. _Hamza Abdelhedi: https://github.com/BabaSanfour
 .. _Hari Bharadwaj: https://github.com/haribharadwaj
+.. _Harrison Ritz: https://github.com/harrisonritz
 .. _Hasrat Ali Arzoo: https://github.com/hasrat17
 .. _Henrich Kolkhorst: https://github.com/hekolk
 .. _Hongjiang Ye: https://github.com/hongjiang-ye

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -1208,7 +1208,7 @@ def _merge_opm_data(data, merged_names):
     """
     to_remove = np.empty(0, dtype=np.int32)
     for idx, ch in enumerate(merged_names):
-        if ch.endswith("MERGE_REMOVE"):
+        if ch.endswith("MERGE-REMOVE"):
             to_remove = np.append(to_remove, idx)
     to_remove = np.unique(to_remove)
     for rem in sorted(to_remove, reverse=True):

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -902,7 +902,7 @@ def _auto_topomap_coords(info, picks, ignore_overlap, to_sphere, sphere):
     # Use channel locations if available
     locs3d = np.array([ch["loc"][:3] for ch in chs])
 
-    # If electrode locations are not available, use digization points
+    # If electrode locations are not available, use digitization points
     if not _check_ch_locs(info=info, picks=picks):
         logging.warning(
             "Did not find any electrode locations (in the info "

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -1218,7 +1218,7 @@ def _merge_opm_data(data, merged_names):
     to_remove = np.unique(to_remove)
     for rem in sorted(to_remove, reverse=True):
         del merged_names[rem]
-        data = np.delete(data, rem, 0)
+    data = np.delete(data, to_remove, axis=0)
     return data, merged_names
 
 

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -1189,7 +1189,7 @@ def _merge_nirs_data(data, merged_names):
 def _merge_opm_data(data, merged_names):
     """Merge data from multiple opm channel by just using the radial component.
 
-    Channel names that end in "MERGE_REMOVE" (ie non-radial channels) will be 
+    Channel names that end in "MERGE_REMOVE" (ie non-radial channels) will be
     removed. Only the the radial channel is kept.
 
     Parameters

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -1089,7 +1089,7 @@ def _pair_grad_sensors(
         return picks
 
 
-def _merge_ch_data(data, ch_type, names, method="rms", modality='opm'):
+def _merge_ch_data(data, ch_type, names, method="rms", modality="opm"):
     """Merge data from channel pairs.
 
     Parameters
@@ -1116,11 +1116,11 @@ def _merge_ch_data(data, ch_type, names, method="rms", modality='opm'):
         data = _merge_grad_data(data, method)
     elif ch_type in _FNIRS_CH_TYPES_SPLIT:
         data, names = _merge_nirs_data(data, names)
-    elif modality == 'opm' and ch_type == 'mag':
+    elif modality == "opm" and ch_type == "mag":
         data, names = _merge_opm_data(data, names)
     else:
         raise ValueError(f"Unknown modality {modality} for channel type {ch_type}")
-        
+
     return data, names
 
 

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -1089,7 +1089,7 @@ def _pair_grad_sensors(
         return picks
 
 
-def _merge_ch_data(data, ch_type, names, method="rms"):
+def _merge_ch_data(data, ch_type, names, method="rms", modality='opm'):
     """Merge data from channel pairs.
 
     Parameters
@@ -1102,6 +1102,8 @@ def _merge_ch_data(data, ch_type, names, method="rms"):
         List of channel names.
     method : str
         Can be 'rms' or 'mean'.
+    modality : str
+        The modality of the data, either 'fnirs', 'opm', or 'other'
 
     Returns
     -------
@@ -1112,9 +1114,13 @@ def _merge_ch_data(data, ch_type, names, method="rms"):
     """
     if ch_type == "grad":
         data = _merge_grad_data(data, method)
-    else:
-        assert ch_type in _FNIRS_CH_TYPES_SPLIT
+    elif ch_type in _FNIRS_CH_TYPES_SPLIT:
         data, names = _merge_nirs_data(data, names)
+    elif modality == 'opm' and ch_type == 'mag':
+        data, names = _merge_opm_data(data, names)
+    else:
+        raise ValueError(f"Unknown modality {modality} for channel type {ch_type}")
+        
     return data, names
 
 
@@ -1172,6 +1178,42 @@ def _merge_nirs_data(data, merged_names):
             for sub_ch in channels[1:]:
                 indices = np.append(indices, merged_names.index(sub_ch))
             data[idx] = np.mean(data[np.append(idx, indices)], axis=0)
+            to_remove = np.append(to_remove, indices)
+    to_remove = np.unique(to_remove)
+    for rem in sorted(to_remove, reverse=True):
+        del merged_names[rem]
+        data = np.delete(data, rem, 0)
+    return data, merged_names
+
+
+def _merge_opm_data(data, merged_names):
+    """Merge data from multiple opm channel using the mean.
+
+    Channel names that have an x in them will be merged. The first channel in
+    the name is replaced with the mean of all listed channels. The other
+    channels are removed.
+
+    Parameters
+    ----------
+    data : array, shape = (n_channels, ..., n_times)
+        Data for channels.
+    merged_names : list
+        List of strings containing the channel names. Channels that are to be
+        merged contain an x between them.
+
+    Returns
+    -------
+    data : array
+        Data for channels with requested channels merged. Channels used in the
+        merge are removed from the array.
+    """
+    to_remove = np.empty(0, dtype=np.int32)
+    for idx, ch in enumerate(merged_names):
+        if "." in ch:
+            indices = np.empty(0, dtype=np.int32)
+            channels = ch.split(".")
+            for sub_ch in channels[1:]:
+                indices = np.append(indices, merged_names.index(sub_ch))
             to_remove = np.append(to_remove, indices)
     to_remove = np.unique(to_remove)
     for rem in sorted(to_remove, reverse=True):

--- a/mne/channels/layout.py
+++ b/mne/channels/layout.py
@@ -1089,7 +1089,7 @@ def _pair_grad_sensors(
         return picks
 
 
-def _merge_ch_data(data, ch_type, names, method="rms", modality="opm"):
+def _merge_ch_data(data, ch_type, names, method="rms", *, modality="opm"):
     """Merge data from channel pairs.
 
     Parameters

--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -87,7 +87,7 @@ I agree to the following:
 # update the checksum in the MNE_DATASETS dict below, and change version
 # here: ↓↓↓↓↓↓↓↓
 RELEASES = dict(
-    testing="0.156",
+    testing="0.160",
     misc="0.27",
     phantom_kit="0.2",
     ucl_opm_auditory="0.2",

--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -115,7 +115,7 @@ MNE_DATASETS = dict()
 # Testing and misc are at the top as they're updated most often
 MNE_DATASETS["testing"] = dict(
     archive_name=f"{TESTING_VERSIONED}.tar.gz",
-    hash="md5:d94fe9f3abe949a507eaeb865fb84a3f",
+    hash="md5:9f1d5c9848b1d7531bada6f2d86115b5",
     url=(
         "https://codeload.github.com/mne-tools/mne-testing-data/"
         f"tar.gz/{RELEASES['testing']}"

--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -87,7 +87,7 @@ I agree to the following:
 # update the checksum in the MNE_DATASETS dict below, and change version
 # here: ↓↓↓↓↓↓↓↓
 RELEASES = dict(
-    testing="0.160",
+    testing="0.161",
     misc="0.27",
     phantom_kit="0.2",
     ucl_opm_auditory="0.2",
@@ -115,7 +115,7 @@ MNE_DATASETS = dict()
 # Testing and misc are at the top as they're updated most often
 MNE_DATASETS["testing"] = dict(
     archive_name=f"{TESTING_VERSIONED}.tar.gz",
-    hash="md5:9f1d5c9848b1d7531bada6f2d86115b5",
+    hash="md5:a32cfb9e098dec39a5f3ed6c0833580d",
     url=(
         "https://codeload.github.com/mne-tools/mne-testing-data/"
         f"tar.gz/{RELEASES['testing']}"

--- a/mne/preprocessing/tests/test_ica.py
+++ b/mne/preprocessing/tests/test_ica.py
@@ -1027,7 +1027,6 @@ def test_ica_additional(method, tmp_path, short_raw_epochs):
 
 def test_get_explained_variance_ratio(tmp_path, short_raw_epochs):
     """Test ICA.get_explained_variance_ratio()."""
-    pytest.importorskip("sklearn")
     raw, epochs, _ = short_raw_epochs
     ica = ICA(max_iter=1)
 

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -17,8 +17,10 @@ from mne import (
     pick_types,
     read_cov,
     read_events,
+    read_evokeds,
 )
-from mne.io import read_raw_fif
+from mne.datasets import testing
+from mne.io import RawArray, read_raw_fif
 from mne.preprocessing import ICA, create_ecg_epochs, create_eog_epochs
 from mne.utils import _record_warnings, catch_logging
 from mne.viz.ica import _create_properties_layout, plot_ica_properties
@@ -31,6 +33,9 @@ cov_fname = base_dir / "test-cov.fif"
 event_name = base_dir / "test-eve.fif"
 event_id, tmin, tmax = 1, -0.1, 0.2
 raw_ctf_fname = base_dir / "test_ctf_raw.fif"
+
+testing_path = testing.data_path(download=False)
+opm_fname = testing_path / "OPM" / "opm-evoked-ave.fif"
 
 pytest.importorskip("sklearn")
 
@@ -526,3 +531,15 @@ def test_plot_instance_components(browser_backend):
     fig._fake_click((x, y), xform="data")
     fig._click_ch_name(ch_index=0, button=1)
     fig._fake_keypress("escape")
+
+
+@pytest.mark.slowtest
+@pytest.mark.filterwarnings("ignore:.*did not converge.*:")
+@testing.requires_testing_data
+def test_plot_components_opm():
+    """Test for gh-12934."""
+    evoked = read_evokeds(opm_fname, kind="average")[0]
+    ica = ICA(max_iter=1, random_state=0, n_components=10)
+    ica.fit(RawArray(evoked.data, evoked.info), picks="mag", verbose="error")
+    fig = ica.plot_components()
+    assert len(fig.axes) == 10

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -20,6 +20,7 @@ from mne import (
     compute_proj_evoked,
     compute_proj_raw,
     create_info,
+    find_events,
     find_layout,
     make_fixed_length_events,
     pick_types,
@@ -38,7 +39,7 @@ from mne.channels import (
     read_layout,
 )
 from mne.datasets import testing
-from mne.io import RawArray, read_info, read_raw_fif
+from mne.io import RawArray, read_info, read_raw_fif, read_raw_fil
 from mne.preprocessing import (
     ICA,
     compute_bridged_electrodes,
@@ -63,6 +64,7 @@ subjects_dir = data_dir / "subjects"
 ecg_fname = data_dir / "MEG" / "sample" / "sample_audvis_ecg-proj.fif"
 triux_fname = data_dir / "SSS" / "TRIUX" / "triux_bmlhus_erm_raw.fif"
 
+
 base_dir = Path(__file__).parents[2] / "io" / "tests" / "data"
 evoked_fname = base_dir / "test-ave.fif"
 raw_fname = base_dir / "test_raw.fif"
@@ -70,6 +72,7 @@ event_name = base_dir / "test-eve.fif"
 ctf_fname = base_dir / "test_ctf_comp_raw.fif"
 layout = read_layout("Vectorview-all")
 cov_fname = base_dir / "test-cov.fif"
+opm_fname = base_dir / "sub-002_ses-001_task-aef_run-001_meg.bin"
 
 fast_test = dict(res=8, contours=0, sensors=False)
 
@@ -774,6 +777,31 @@ def test_plot_topomap_bads_grad():
     info = pick_info(info, picks)
     assert len(info["chs"]) == 203
     plot_topomap(data, info, res=8)
+
+
+def test_plot_topomap_opm():
+    """Test plotting topomap with OPM data."""
+    # load data
+
+    raw = read_raw_fil(opm_fname, verbose="error")
+    raw.crop(120, 210).load_data()  # crop for speed
+    picks = pick_types(raw.info, meg=True)
+
+    # events and epochs
+    events = find_events(raw, min_duration=0.1)
+    epochs = Epochs(raw, events, tmin=-0.1, tmax=0.4, verbose="error")
+    evoked = epochs.average()
+    t_peak = evoked.times[np.argmax(np.std(evoked.copy().pick("meg").data, axis=0))]
+
+    # plot evoked topomap
+    fig_evoked = evoked.plot_topomap(times=t_peak, ch_type="mag", show=False)
+    assert len(fig_evoked.axes) == 2
+
+    # plot ICA
+    ica = ICA(n_components=2, max_iter=10)
+    ica.fit(epochs, picks=picks, decim=100)
+    fig_ica = ica.plot_components(show=False)
+    assert len(fig_ica.axes) == 2
 
 
 def test_plot_topomap_nirs_overlap(fnirs_epochs):

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -777,6 +777,7 @@ def test_plot_topomap_bads_grad():
     assert len(info["chs"]) == 203
     plot_topomap(data, info, res=8)
 
+
 @testing.requires_testing_data
 def test_plot_topomap_opm():
     """Test plotting topomap with OPM data."""
@@ -784,7 +785,9 @@ def test_plot_topomap_opm():
     evoked = read_evokeds(opm_fname, kind="average")[0]
 
     # plot evoked topomap
-    fig_evoked = evoked.plot_topomap(times=[-.1, 0, .1, .2], ch_type="mag", show=False)
+    fig_evoked = evoked.plot_topomap(
+        times=[-0.1, 0, 0.1, 0.2], ch_type="mag", show=False
+    )
     assert len(fig_evoked.axes) == 5
 
 

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -20,7 +20,6 @@ from mne import (
     compute_proj_evoked,
     compute_proj_raw,
     create_info,
-    find_events,
     find_layout,
     make_fixed_length_events,
     pick_types,
@@ -39,7 +38,7 @@ from mne.channels import (
     read_layout,
 )
 from mne.datasets import testing
-from mne.io import RawArray, read_info, read_raw_fif, read_raw_fil
+from mne.io import RawArray, read_info, read_raw_fif
 from mne.preprocessing import (
     ICA,
     compute_bridged_electrodes,
@@ -781,7 +780,6 @@ def test_plot_topomap_bads_grad():
 
 def test_plot_topomap_opm():
     """Test plotting topomap with OPM data."""
-    
     # load data
     evoked = read_evokeds(opm_fname, kind="average")
 

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -777,15 +777,15 @@ def test_plot_topomap_bads_grad():
     assert len(info["chs"]) == 203
     plot_topomap(data, info, res=8)
 
-
+@testing.requires_testing_data
 def test_plot_topomap_opm():
     """Test plotting topomap with OPM data."""
     # load data
-    evoked = read_evokeds(opm_fname, kind="average")
+    evoked = read_evokeds(opm_fname, kind="average")[0]
 
     # plot evoked topomap
-    fig_evoked = evoked.plot_topomap(ch_type="mag", show=False)
-    assert len(fig_evoked.axes) == 2
+    fig_evoked = evoked.plot_topomap(times=[-.1, 0, .1, .2], ch_type="mag", show=False)
+    assert len(fig_evoked.axes) == 5
 
 
 def test_plot_topomap_nirs_overlap(fnirs_epochs):

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -63,6 +63,7 @@ data_dir = testing.data_path(download=False)
 subjects_dir = data_dir / "subjects"
 ecg_fname = data_dir / "MEG" / "sample" / "sample_audvis_ecg-proj.fif"
 triux_fname = data_dir / "SSS" / "TRIUX" / "triux_bmlhus_erm_raw.fif"
+opm_fname = data_dir / "OPM" / "opm-evoked.fif"
 
 
 base_dir = Path(__file__).parents[2] / "io" / "tests" / "data"
@@ -72,7 +73,6 @@ event_name = base_dir / "test-eve.fif"
 ctf_fname = base_dir / "test_ctf_comp_raw.fif"
 layout = read_layout("Vectorview-all")
 cov_fname = base_dir / "test-cov.fif"
-opm_fname = base_dir / "sub-002_ses-001_task-aef_run-001_meg.bin"
 
 fast_test = dict(res=8, contours=0, sensors=False)
 
@@ -781,27 +781,13 @@ def test_plot_topomap_bads_grad():
 
 def test_plot_topomap_opm():
     """Test plotting topomap with OPM data."""
+    
     # load data
-
-    raw = read_raw_fil(opm_fname, verbose="error")
-    raw.crop(120, 210).load_data()  # crop for speed
-    picks = pick_types(raw.info, meg=True)
-
-    # events and epochs
-    events = find_events(raw, min_duration=0.1)
-    epochs = Epochs(raw, events, tmin=-0.1, tmax=0.4, verbose="error")
-    evoked = epochs.average()
-    t_peak = evoked.times[np.argmax(np.std(evoked.copy().pick("meg").data, axis=0))]
+    evoked = read_evokeds(opm_fname, kind="average")
 
     # plot evoked topomap
-    fig_evoked = evoked.plot_topomap(times=t_peak, ch_type="mag", show=False)
+    fig_evoked = evoked.plot_topomap(ch_type="mag", show=False)
     assert len(fig_evoked.axes) == 2
-
-    # plot ICA
-    ica = ICA(n_components=2, max_iter=10)
-    ica.fit(epochs, picks=picks, decim=100)
-    fig_ica = ica.plot_components(show=False)
-    assert len(fig_ica.axes) == 2
 
 
 def test_plot_topomap_nirs_overlap(fnirs_epochs):

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -62,7 +62,7 @@ data_dir = testing.data_path(download=False)
 subjects_dir = data_dir / "subjects"
 ecg_fname = data_dir / "MEG" / "sample" / "sample_audvis_ecg-proj.fif"
 triux_fname = data_dir / "SSS" / "TRIUX" / "triux_bmlhus_erm_raw.fif"
-opm_fname = data_dir / "OPM" / "opm-evoked.fif"
+opm_fname = data_dir / "OPM" / "opm-evoked-ave.fif"
 
 
 base_dir = Path(__file__).parents[2] / "io" / "tests" / "data"

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -789,11 +789,18 @@ def test_plot_topomap_opm():
         times=[-0.1, 0, 0.1, 0.2], ch_type="mag", show=False
     )
     assert len(fig_evoked.axes) == 5
-    # smoke test for gh-12934
-    ica = ICA(max_iter=1, random_state=0)
-    with pytest.warns(Warning, match="did not converge"):
-        ica.fit(RawArray(evoked.data, evoked.info), picks="mag", verbose="error")
-    ica.plot_components()
+
+
+@pytest.mark.slowtest
+@pytest.mark.filterwarnings("ignore:.*did not converge.*:")
+def test_plot_components_opm():
+    """Test for gh-12934."""
+    pytest.importorskip("sklearn")
+    evoked = read_evokeds(opm_fname, kind="average")[0]
+    ica = ICA(max_iter=1, random_state=0, n_components=10)
+    ica.fit(RawArray(evoked.data, evoked.info), picks="mag", verbose="error")
+    fig = ica.plot_components()
+    assert len(fig.axes) == 10
 
 
 def test_plot_topomap_nirs_overlap(fnirs_epochs):

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -789,6 +789,11 @@ def test_plot_topomap_opm():
         times=[-0.1, 0, 0.1, 0.2], ch_type="mag", show=False
     )
     assert len(fig_evoked.axes) == 5
+    # smoke test for gh-12934
+    ica = ICA(max_iter=1, random_state=0)
+    with pytest.warns(Warning, match="did not converge"):
+        ica.fit(RawArray(evoked.data, evoked.info), picks="mag", verbose="error")
+    ica.plot_components()
 
 
 def test_plot_topomap_nirs_overlap(fnirs_epochs):

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -791,18 +791,6 @@ def test_plot_topomap_opm():
     assert len(fig_evoked.axes) == 5
 
 
-@pytest.mark.slowtest
-@pytest.mark.filterwarnings("ignore:.*did not converge.*:")
-def test_plot_components_opm():
-    """Test for gh-12934."""
-    pytest.importorskip("sklearn")
-    evoked = read_evokeds(opm_fname, kind="average")[0]
-    ica = ICA(max_iter=1, random_state=0, n_components=10)
-    ica.fit(RawArray(evoked.data, evoked.info), picks="mag", verbose="error")
-    fig = ica.plot_components()
-    assert len(fig.axes) == 10
-
-
 def test_plot_topomap_nirs_overlap(fnirs_epochs):
     """Test plotting nirs topomap with overlapping channels (gh-7414)."""
     fig = fnirs_epochs["A"].average(picks="hbo").plot_topomap()

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -124,7 +124,7 @@ def _prepare_topomap_plot(inst, ch_type, sphere=None):
     info["bads"] = _clean_names(info["bads"])
     info._check_consistency()
 
-    if any(ch["coil_type"] in _opm_coils for ch in inst.info["chs"]):
+    if any(ch["coil_type"] in _opm_coils for ch in info["chs"]):
         modality = "opm"
     elif ch_type in _fnirs_types:
         modality = "fnirs"

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -292,12 +292,12 @@ def _find_radial_channel(info, overlapping_set):
     radial_score = np.zeros(len(overlapping_set))
     for s, sens in enumerate(overlapping_set):
         ch_idx = pick_channels(info["ch_names"], [sens])[0]
-        radial_direction = copy.copy(info["chs"][ch_idx]["loc"][0:3])
+        radial_direction = info["chs"][ch_idx]["loc"][0:3].copy()
         radial_direction /= np.linalg.norm(radial_direction)
 
         orientation_vector = info["chs"][ch_idx]["loc"][9:12]
         if info["dev_head_t"] is not None:
-            orientation_vector = apply_trans(info["dev_head_t"], orientation_vector)
+            orientation_vector = apply_trans(info["dev_head_t"], orientation_vector, move=False)
         radial_score[s] = np.abs(np.dot(radial_direction, orientation_vector))
 
     radial_sensor = overlapping_set[np.argmax(radial_score)]

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -297,7 +297,9 @@ def _find_radial_channel(info, overlapping_set):
 
         orientation_vector = info["chs"][ch_idx]["loc"][9:12]
         if info["dev_head_t"] is not None:
-            orientation_vector = apply_trans(info["dev_head_t"], orientation_vector, move=False)
+            orientation_vector = apply_trans(
+                info["dev_head_t"], orientation_vector, move=False
+            )
         radial_score[s] = np.abs(np.dot(radial_direction, orientation_vector))
 
     radial_sensor = overlapping_set[np.argmax(radial_score)]

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -294,13 +294,7 @@ def _find_radial_channel(info, overlapping_set):
         radial_direction = copy.copy(info["chs"][ch_idx]["loc"][0:3])
         radial_direction /= np.linalg.norm(radial_direction)
 
-        # use different orientation vector for dual-axis and triaxial sensors
-        # risky, will have to accommodate new OPM sensors in the future
-        if any(key in sens for key in ["RAD", "TAN"]):
-            orientation_vector = info["chs"][ch_idx]["loc"][3:6]
-        else:
-            orientation_vector = info["chs"][ch_idx]["loc"][9:12]
-
+        orientation_vector = info["chs"][ch_idx]["loc"][9:12]
         if info["dev_head_t"] is not None:
             orientation_vector = apply_trans(info["dev_head_t"], orientation_vector)
         radial_score[s] = np.abs(np.dot(radial_direction, orientation_vector))

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -20,6 +20,7 @@ from scipy.sparse import csr_array
 from scipy.spatial import Delaunay, Voronoi
 from scipy.spatial.distance import pdist, squareform
 
+from .._fiff.constants import FIFF
 from .._fiff.meas_info import Info, _simplify_info
 from .._fiff.pick import (
     _MEG_CH_TYPES_SPLIT,
@@ -76,7 +77,7 @@ from .utils import (
 )
 
 _fnirs_types = ("hbo", "hbr", "fnirs_cw_amplitude", "fnirs_od")
-_opm_coils = (8002,)
+_opm_coils = (FIFF.FIFFV_COIL_QUSPIN_ZFOPM_MAG, FIFF.FIFFV_COIL_QUSPIN_ZFOPM_MAG2)
 
 
 # 3.8+ uses a single Collection artist rather than .collections
@@ -187,12 +188,12 @@ def _prepare_topomap_plot(inst, ch_type, sphere=None):
                 new_name = "x".join(s[:-4] for s in set_)
                 ch_names[idx] = new_name
         elif modality == "opm":
-            # Modify the channel names to indicate they are to be merged
-            # New names will have the form  S1xS2
+            # indicate that non-radial changes are to be removed
             for set_ in overlapping_channels:
-                idx = ch_names.index(set_[0])
-                new_name = ".".join(s for s in set_)
-                ch_names[idx] = new_name
+                for set_ch in set_[1:]:
+                    idx = ch_names.index(set_ch)
+                    new_name = set_ch.append("_MERGE-REMOVE")
+                    ch_names[idx] = new_name
 
     pos = np.array(pos)[:, :2]  # 2D plot, otherwise interpolation bugs
     return picks, pos, merge_channels, ch_names, ch_type, sphere, clip_origin

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -192,7 +192,7 @@ def _prepare_topomap_plot(inst, ch_type, sphere=None):
             for set_ in overlapping_channels:
                 for set_ch in set_[1:]:
                     idx = ch_names.index(set_ch)
-                    new_name = set_ch.append("_MERGE-REMOVE")
+                    new_name = set_ch + "_MERGE-REMOVE"
                     ch_names[idx] = new_name
 
     pos = np.array(pos)[:, :2]  # 2D plot, otherwise interpolation bugs

--- a/tutorials/preprocessing/80_opm_processing.py
+++ b/tutorials/preprocessing/80_opm_processing.py
@@ -243,8 +243,7 @@ epochs = mne.Epochs(
 )
 evoked = epochs.average()
 t_peak = evoked.times[np.argmax(np.std(evoked.copy().pick("meg").data, axis=0))]
-fig = evoked.plot()
-fig.axes[0].axvline(t_peak, color="red", ls="--", lw=1)
+fig = evoked.plot_joint(picks="mag")
 
 # %%
 # Visualizing coregistration


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)
Adds features from https://github.com/mne-tools/mne-python/issues/11579

<!-- Example:

Fixes #1234.

-->


#### What does this implement/fix?
This PR extends topomaps to accommodate OPM data with colocated sensors.

It modifies the code used for colocated fNIRS, which now handles both fnirs and OPM. 
In contrast to fNIRS which averages the colocated sensors, for OPM sensors we just take the most radial sensor.


#### Additional information

<!-- Any additional information you think is important. -->

- I've written an opm test, but would like guidance about how to access `mne.datasets.ucl_opm_auditory`. Test won't work as is (eg can't update UCL dataset, and wanted to confirm proper method), but the test is structured on the fnirs overlap test so probably won't need much more
- I rely on some hard-coded look-ups:
   - lookup OPM sensor coil types (quspin currently included)
   - I need to use different `loc` triplets for dual-axis vs triaxial sensors, based on comparing `ucl_opm_auditory` vs Princeton's triaxial opms. At UCL, they use `*-RAD` and `*-TAN` to indicate the two axes, and at Princeton we use `* X` or `* [X]`.
- for the UCL dataset, most of the `*-RAD` channels are the most radial, but in some cases both `RAD` and `TAN` have low radial scores, and TAN is the most radial sensors


Attaching my internal testing code to validate against picking `RAD` channels. 
Happy to share Princeton dataset if that's helpful.


```python
# %%
import numpy as np
import mne


opm_file = (
mne.datasets.ucl_opm_auditory.data_path() / "sub-002" / "ses-001" / "meg" / "sub-002_ses-001_task-aef_run-001_meg.bin"
)
raw = mne.io.read_raw_fil(opm_file, verbose="error")
raw.crop(100, 300).load_data()  # crop for speed
rad_string = "^.*-RAD$"
picks = mne.pick_types(raw.info, meg=True)


# %% preprocess --------

raw.notch_filter(50, picks=picks)
raw.filter(1, 40, picks=picks)

projs = mne.preprocessing.compute_proj_hfc(raw.info, order=2)
raw.add_proj(projs).apply_proj(verbose="error")


# %%  epoch data --------

events = mne.find_events(raw, min_duration=0.1)
epochs = mne.Epochs(
    raw, events, tmin=-0.1, tmax=0.4, baseline=(-0.1, 0.0), verbose="error",event_repeated='merge',
)
evoked = epochs.average()
t_peak = evoked.times[np.argmax(np.std(evoked.copy().pick("meg").data, axis=0))]


# %% plot evoked topomap --------

fig = evoked.plot_topomap(times=t_peak, ch_type="mag", time_unit="s")
print('len axes: ', len(fig.axes))

rad_picks = mne.pick_channels_regexp(evoked.info.ch_names, rad_string)
fig = evoked.copy().pick(rad_picks).plot_topomap(times=t_peak, ch_type="mag", time_unit="s")
print('len axes: ', len(fig.axes))


# %% test ICA --------

ica = mne.preprocessing.ICA(n_components=10)
ica.fit(epochs, picks=picks, decim=10)

fig = ica.plot_components()
print('len axes: ', len(fig.axes))


# %% test spectrum --------

spec = raw.compute_psd()
spec.plot_topomap()

rad_picks = mne.pick_channels_regexp(raw.info.ch_names, rad_string)
spec2 = raw.copy().pick(rad_picks).compute_psd()
spec2.plot_topomap()
```

Closes #11579