### PR TITLE
FIX: Gracefully handle bad XML files in EGI reader

### DIFF
--- a/doc/changes/devel/13145.bugfix.rst
+++ b/doc/changes/devel/13145.bugfix.rst
@@ -1,0 +1,1 @@
+Improved the handling of problematic MFF files in `mne.io.read_raw_egi` by `Scott Huberty`_.

--- a/mne/io/egi/events.py
+++ b/mne/io/egi/events.py
@@ -48,7 +48,9 @@ def _read_mff_events(filename, sfreq):
     orig = {}
     for xml_file in glob(join(filename, "*.xml")):
         xml_type = splitext(basename(xml_file))[0]
-        orig[xml_type] = _parse_xml(xml_file)
+        et = _parse_xml(xml_file)
+        if et is not None:
+            orig[xml_type] = _parse_xml(xml_file)
     xml_files = orig.keys()
     xml_events = [x for x in xml_files if x[:7] == "Events_"]
     for item in orig["info"]:
@@ -80,10 +82,14 @@ def _read_mff_events(filename, sfreq):
     return events_tims, code
 
 
-def _parse_xml(xml_file):
+def _parse_xml(xml_file: str) -> list[dict[str, str]] | None:
     """Parse XML file."""
     defusedxml = _soft_import("defusedxml", "reading EGI MFF data")
-    xml = defusedxml.ElementTree.parse(xml_file)
+    try:
+        xml = defusedxml.ElementTree.parse(xml_file)
+    except defusedxml.ElementTree.ParseError:
+        warn(f"Could not parse the XML file {xml_file}.")
+        return
     root = xml.getroot()
     return _xml2list(root)
 

--- a/mne/io/egi/events.py
+++ b/mne/io/egi/events.py
@@ -87,8 +87,8 @@ def _parse_xml(xml_file: str) -> list[dict[str, str]] | None:
     defusedxml = _soft_import("defusedxml", "reading EGI MFF data")
     try:
         xml = defusedxml.ElementTree.parse(xml_file)
-    except defusedxml.ElementTree.ParseError:
-        warn(f"Could not parse the XML file {xml_file}.")
+    except defusedxml.ElementTree.ParseError as e:
+        warn(f"Could not parse the XML file {xml_file}: {e}")
         return
     root = xml.getroot()
     return _xml2list(root)

--- a/mne/io/egi/events.py
+++ b/mne/io/egi/events.py
@@ -50,7 +50,7 @@ def _read_mff_events(filename, sfreq):
         xml_type = splitext(basename(xml_file))[0]
         et = _parse_xml(xml_file)
         if et is not None:
-            orig[xml_type] = _parse_xml(xml_file)
+            orig[xml_type] = et
     xml_files = orig.keys()
     xml_events = [x for x in xml_files if x[:7] == "Events_"]
     for item in orig["info"]:

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -5,6 +5,7 @@
 
 import os
 import shutil
+import tempfile
 from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
@@ -586,3 +587,16 @@ def test_set_standard_montage_mff(fname, standard_montage):
     # Check that the reference remained
     for pick in picks:
         assert_allclose(raw.info["chs"][pick]["loc"][3:6], ref_loc)
+
+
+def test_egi_mff_bad_xml():
+    """Test that corrupt XML files are gracefully handled."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_dir = Path(temp_dir)
+        mff_fname = shutil.copytree(egi_mff_fname, temp_dir / "test_egi_bad_xml.mff")
+        bad_xml = mff_fname / "bad.xml"
+        bad_xml.write_text("<bad>")
+        with pytest.warns(RuntimeWarning, match="Could not parse the XML"):
+            raw = read_raw_egi(mff_fname)
+        # little check that the bad XML doesn't affect the parsing of other xml files
+        assert "DIN1" in raw.annotations.description

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -589,9 +589,8 @@ def test_set_standard_montage_mff(fname, standard_montage):
         assert_allclose(raw.info["chs"][pick]["loc"][3:6], ref_loc)
 
 
-def test_egi_mff_bad_xml():
+def test_egi_mff_bad_xml(tmp_path):
     """Test that corrupt XML files are gracefully handled."""
-    with tempfile.TemporaryDirectory() as temp_dir:
         temp_dir = Path(temp_dir)
         mff_fname = shutil.copytree(egi_mff_fname, temp_dir / "test_egi_bad_xml.mff")
         bad_xml = mff_fname / "bad.xml"

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -594,8 +594,7 @@ def test_egi_mff_bad_xml(tmp_path):
     pytest.importorskip("defusedxml")
     mff_fname = shutil.copytree(egi_mff_fname, tmp_path / "test_egi_bad_xml.mff")
     bad_xml = mff_fname / "bad.xml"
-    with bad_xml.open("w") as fid:
-        fid.write("<foo>")
+    bad_xml.write_text("<foo>", encoding="utf-8")
     with pytest.warns(RuntimeWarning, match="Could not parse the XML"):
         raw = read_raw_egi(mff_fname)
     # little check that the bad XML doesn't affect the parsing of other xml files


### PR DESCRIPTION
I have a few MFF files which contain a corrupt XML file (a tag didn't close properly).

This PR uses defensive programming to gracefully handle the scenario, while also providing more information to the user about the XML file that couldn't be parsed.



```python
from pathlib import Path
import mne
import shutil
egi_fname = mne.datasets.testing.data_path() / "EGI" / "test_egi.mff"

test_fname = shutil.copytree(egi_fname, Path("./bad_xml_egi.mff").resolve())
bad_xml = test_fname / "bad.xml"
bad_xml.write_text("<bad>")
raw = mne.io.read_raw_egi(test_fname)
test_fname.unlink()
```

#### on main (crashes and doesn't give a hint)

```
Reading EGI MFF Header from /Users/scotterik/devel/repos/mne-python/bad_xml_egi.mff...
    Reading events ...
Traceback (most recent call last):

  File ~/.local/share/uv/python/cpython-3.10.16-macos-x86_64-none/lib/python3.10/xml/etree/ElementTree.py:1725 in close
    self.parser.Parse(b"", True) # end of data

ExpatError: no element found: line 1, column 5


During handling of the above exception, another exception occurred:

Traceback (most recent call last):

  File ~/devel/projects/IBIS-EEG/.venv/lib/python3.10/site-packages/IPython/core/interactiveshell.py:3577 in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)

  Cell In[4], line 9
    raw = mne.io.read_raw_egi(test_fname)

  File <decorator-gen-359>:12 in read_raw_egi

  File ~/devel/repos/mne-python/mne/io/egi/egi.py:175 in read_raw_egi
    return _read_raw_egi_mff(

  File <decorator-gen-356>:12 in _read_raw_egi_mff

  File ~/devel/repos/mne-python/mne/io/egi/egimff.py:361 in _read_raw_egi_mff
    return RawMff(

  File <decorator-gen-357>:12 in __init__

  File ~/devel/repos/mne-python/mne/io/egi/egimff.py:411 in __init__
    egi_events, egi_info, mff_events = _read_events(input_fname, egi_info)

  File ~/devel/repos/mne-python/mne/io/egi/events.py:26 in _read_events
    mff_events, event_codes = _read_mff_events(input_fname, info["sfreq"])

  File ~/devel/repos/mne-python/mne/io/egi/events.py:51 in _read_mff_events
    orig[xml_type] = _parse_xml(xml_file)

  File ~/devel/repos/mne-python/mne/io/egi/events.py:86 in _parse_xml
    xml = defusedxml.ElementTree.parse(xml_file)

  File ~/devel/projects/IBIS-EEG/.venv/lib/python3.10/site-packages/defusedxml/common.py:100 in parse
    return _parse(source, parser)

  File ~/.local/share/uv/python/cpython-3.10.16-macos-x86_64-none/lib/python3.10/xml/etree/ElementTree.py:1222 in parse
    tree.parse(source, parser)

  File ~/.local/share/uv/python/cpython-3.10.16-macos-x86_64-none/lib/python3.10/xml/etree/ElementTree.py:587 in parse
    self._root = parser.close()

  File ~/.local/share/uv/python/cpython-3.10.16-macos-x86_64-none/lib/python3.10/xml/etree/ElementTree.py:1727 in close
    self._raiseerror(v)

  File ~/.local/share/uv/python/cpython-3.10.16-macos-x86_64-none/lib/python3.10/xml/etree/ElementTree.py:1627 in _raiseerror
    raise err

  File <string>
ParseError: no element found: line 1, column 5
```

#### this branch:

```
Reading EGI MFF Header from /Users/scotterik/devel/repos/mne-python/bad_xml_egi.mff...
    Reading events ...
<ipython-input-17-ca7d688fd187>:1: RuntimeWarning: Could not parse the XML file /Users/scotterik/devel/repos/mne-python/bad_xml_egi.mff/bad.xml.
  raw = mne.io.read_raw_egi(test_fname)
    Assembling measurement info ...
    Excluding events {} ...
```