### PR TITLE
BUG: Fix bug with not short-circuiting n_jobs=1

### DIFF
--- a/mne/parallel.py
+++ b/mne/parallel.py
@@ -128,6 +128,21 @@ def parallel_func(
 
         my_func = delayed(run_verbose)
 
+        # if we got that n_jobs=1, we shouldn't bother with any parallelization
+        if n_jobs == 1:
+            # TODO: Hack until https://github.com/joblib/joblib/issues/1687 lands
+            try:
+                backend_repr = str(parallel._backend)
+            except Exception:
+                backend_repr = ""
+            is_local = any(
+                f"{x}Backend" in backend_repr
+                for x in ("Loky", "Threading", "Multiprocessing")
+            )
+            if is_local:
+                my_func = func
+                parallel = list
+
     if total is not None:
 
         def parallel_progress(op_iter):

--- a/mne/tests/test_filter.py
+++ b/mne/tests/test_filter.py
@@ -417,7 +417,7 @@ def test_resample_scipy():
                 assert_allclose(x_p5, x_p5_sp, atol=1e-12, err_msg=err_msg)
 
 
-@pytest.mark.parametrize("n_jobs", (1, 2, "cuda"))
+@pytest.mark.parametrize("n_jobs", (2, "cuda"))
 def test_n_jobs(n_jobs, capsys):
     """Test resampling against SciPy."""
     joblib = pytest.importorskip("joblib")


### PR DESCRIPTION
I noticed lately that even with `n_jobs=None` (which should really be equivalent to `n_jobs=1`) I would see parallel stuff in logging:
```
FIR filter parameters
---------------------
Designing a one-pass, zero-phase, non-causal lowpass filter:
- Windowed time-domain design (firwin) method
- Hamming window with 0.0194 passband ripple and 53 dB stopband attenuation
- Upper passband edge: 40.00 Hz
- Upper transition bandwidth: 10.00 Hz (-6 dB cutoff frequency: 45.00 Hz)
- Filter length: 331 samples (0.331 s)

[Parallel(n_jobs=1)]: Done  17 tasks      | elapsed:    0.1s
[Parallel(n_jobs=1)]: Done  71 tasks      | elapsed:    0.6s
[Parallel(n_jobs=1)]: Done 161 tasks      | elapsed:    1.4s
[Parallel(n_jobs=1)]: Done 287 tasks      | elapsed:    2.4s
[Parallel(n_jobs=1)]: Done 431 out of 431 | elapsed:    3.6s finished
```
This PR fixes the logic such that when `n_jobs=None` ends up being equivalent to `n_jobs=1` and using `list` directly instead of any `Parallel` stuff for the actual execution.

*EDIT: Think we don't need a changelog entry since it's just a minor logging change at the end of the day.*