### PR TITLE
FIX: Missing coordinates.xml in MFF file

### DIFF
--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -280,7 +280,7 @@ def _read_locs(filepath, egi_info, channel_naming):
 
     fname = op.join(filepath, "coordinates.xml")
     if not op.exists(fname):
-        logger.warn("File coordinates.xml not found, not setting channel locations")
+        warn("File coordinates.xml not found, not setting channel locations")
         ch_names = [channel_naming % (i + 1) for i in range(egi_info["n_channels"])]
         return ch_names, None
     dig_ident_map = {
@@ -488,7 +488,6 @@ class RawMff(BaseRaw):
 
         if mon is not None:
             info.set_montage(mon, on_missing="ignore")
-
             ref_idx = np.flatnonzero(np.isin(mon.ch_names, REFERENCE_NAMES))
             if len(ref_idx):
                 ref_idx = ref_idx.item()

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -122,6 +122,7 @@ def _read_mff_header(filepath):
     # Add the sensor info.
     sensor_layout_file = op.join(filepath, "sensorLayout.xml")
     sensor_layout_obj = parse(sensor_layout_file)
+
     summaryinfo["device"] = sensor_layout_obj.getElementsByTagName("name")[
         0
     ].firstChild.data
@@ -488,13 +489,13 @@ class RawMff(BaseRaw):
         if mon is not None:
             info.set_montage(mon, on_missing="ignore")
 
-        ref_idx = np.flatnonzero(np.isin(mon.ch_names, REFERENCE_NAMES))
-        if len(ref_idx):
-            ref_idx = ref_idx.item()
-            ref_coords = info["chs"][int(ref_idx)]["loc"][:3]
-            for chan in info["chs"]:
-                if chan["kind"] == FIFF.FIFFV_EEG_CH:
-                    chan["loc"][3:6] = ref_coords
+            ref_idx = np.flatnonzero(np.isin(mon.ch_names, REFERENCE_NAMES))
+            if len(ref_idx):
+                ref_idx = ref_idx.item()
+                ref_coords = info["chs"][int(ref_idx)]["loc"][:3]
+                for chan in info["chs"]:
+                    if chan["kind"] == FIFF.FIFFV_EEG_CH:
+                        chan["loc"][3:6] = ref_coords
 
         file_bin = op.join(input_fname, egi_info["eeg_fname"])
         egi_info["egi_events"] = egi_events

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -595,7 +595,10 @@ def test_egi_mff_bad_xml(tmp_path):
     mff_fname = shutil.copytree(egi_mff_fname, tmp_path / "test_egi_bad_xml.mff")
     bad_xml = mff_fname / "bad.xml"
     bad_xml.write_text("<foo>", encoding="utf-8")
+    # Missing coordinate file
+    (mff_fname / "coordinates.xml").unlink()
     with pytest.warns(RuntimeWarning, match="Could not parse the XML"):
-        raw = read_raw_egi(mff_fname)
+        with pytest.warns(RuntimeWarning, match="File coordinates.xml not found"):
+            raw = read_raw_egi(mff_fname)
     # little check that the bad XML doesn't affect the parsing of other xml files
     assert "DIN1" in raw.annotations.description


### PR DESCRIPTION

The EGI MFF reader already tries to account for the case where a sensor coordinate file (`coordinates.xml`) is missing:

https://github.com/mne-tools/mne-python/blob/a5073bf977b73e9981a2222cc546c93081914a7d/mne/io/egi/egimff.py#L275-L284

So if this variable `mon` can be `None`, then _all_ the code dealing with it should be nested inside the if-block below: 

https://github.com/mne-tools/mne-python/blob/a5073bf977b73e9981a2222cc546c93081914a7d/mne/io/egi/egimff.py#L449

https://github.com/mne-tools/mne-python/blob/a5073bf977b73e9981a2222cc546c93081914a7d/mne/io/egi/egimff.py#L488-L491



I also updated a test to simulate this case.