### PR TITLE
doc: point to read_dipole

### DIFF
--- a/mne/_fiff/meas_info.py
+++ b/mne/_fiff/meas_info.py
@@ -1324,6 +1324,7 @@ class Info(ValidatedDict, SetChannelsMixin, MontageMixin, ContainsMixin):
     See Also
     --------
     mne.create_info
+    mne.pick_info
 
     Notes
     -----

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -166,6 +166,10 @@ class Dipole(TimeMixin):
         -----
         .. versionchanged:: 0.20
            Support for writing bdip (Xfit binary) files.
+
+        See Also
+        --------
+        read_dipole
         """
         # obligatory fields
         fname = _check_fname(fname, overwrite=overwrite)
@@ -518,15 +522,19 @@ class DipoleFixed(ExtendedTimeMixin):
 
     @verbose
     def save(self, fname, verbose=None):
-        """Save dipole in a .fif file.
+        """Save dipole in FIF format.
 
         Parameters
         ----------
         fname : path-like
-            The name of the .fif file. Must end with ``'.fif'`` or
-            ``'.fif.gz'`` to make it explicit that the file contains
+            The name of the FIF file. Must end with ``'-dip.fif'`` or
+            ``'-dip.fif.gz'`` to make it explicit that the file contains
             dipole information in FIF format.
         %(verbose)s
+
+        See Also
+        --------
+        read_dipole
         """
         check_fname(
             fname,
@@ -585,12 +593,12 @@ class DipoleFixed(ExtendedTimeMixin):
 # IO
 @verbose
 def read_dipole(fname, verbose=None):
-    """Read ``.dip`` file from Neuromag/xfit or MNE.
+    """Read a dipole object from a file.
 
     Parameters
     ----------
     fname : path-like
-        The name of the ``.dip`` or ``.fif`` file.
+        The name of the ``.[b]dip`` (Neuromag/xfit) or ``.fif[.gz]`` (MNE) file.
     %(verbose)s
 
     Returns

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -162,14 +162,14 @@ class Dipole(TimeMixin):
             .. versionadded:: 0.20
         %(verbose)s
 
+        See Also
+        --------
+        read_dipole
+
         Notes
         -----
         .. versionchanged:: 0.20
            Support for writing bdip (Xfit binary) files.
-
-        See Also
-        --------
-        read_dipole
         """
         # obligatory fields
         fname = _check_fname(fname, overwrite=overwrite)

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -598,7 +598,7 @@ def read_dipole(fname, verbose=None):
     Parameters
     ----------
     fname : path-like
-        The name of the ``.[b]dip`` (Neuromag/xfit) or ``.fif[.gz]`` (MNE) file.
+        The name of the ``.[b]dip`` or ``.fif[.gz]`` file.
     %(verbose)s
 
     Returns


### PR DESCRIPTION
This PR also comes with a question: Why do we support saving Dipoles in dip and bdip, but FixedDipoles in FIF? would it not be possible to support all formats for all objects?

https://mne.tools/stable/generated/mne.DipoleFixed.html#mne.DipoleFixed.save

https://mne.tools/stable/generated/mne.Dipole.html#mne.Dipole.save