### PR TITLE
remove misformatted (and unused) crossref anchor

### DIFF
--- a/tutorials/preprocessing/50_artifact_correction_ssp.py
+++ b/tutorials/preprocessing/50_artifact_correction_ssp.py
@@ -106,8 +106,6 @@ empty_room_raw.del_proj()
 
 # %%
 #
-# _ex-noise-level:
-#
 # Visualizing the empty-room noise
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #


### PR DESCRIPTION
noticed a stray crossref anchor that was visible in the rendered tutorial (just above this heading: https://mne.tools/dev/auto_tutorials/preprocessing/50_artifact_correction_ssp.html#visualizing-the-empty-room-noise). Turns out it's not referenced anywhere, so removing instead of fixing.