### PR TITLE
Feature: Support for file-like objects for EDF/BDF/GDF files

### DIFF
--- a/mne/_fiff/open.py
+++ b/mne/_fiff/open.py
@@ -53,8 +53,8 @@ def _fiff_get_fid(fname):
             fid = open(fname, "rb")  # Open in binary mode
     return fid
 
-def _edf_get_fid(fname):
-    """Open a EDF file with no additional parsing."""
+def __gdf_edf_get_fid(fname):
+    """Open a EDF/BDF/GDF file with no additional parsing."""
     if _file_like(fname):
         logger.debug("Using file-like I/O")
         fid = _NoCloseRead(fname)
@@ -401,14 +401,12 @@ def _edf_open(fid, preload):
         # but that's okay here since we are using mode "rb" anyway
         with fid as fid_old:
             fid = BytesIO(fid_old.read())
-        
-        #TO-DO: Find a way to validate edf headers
 
     fid.seek(0)
     return fid
 
 def edf_open(fname, preload=False, verbose=None):
-    """Open an EDF file.
+    """Open an EDF/BDF file.
 
     Parameters
     ----------
@@ -425,9 +423,42 @@ def edf_open(fname, preload=False, verbose=None):
     fid : file
         The file descriptor of the open file.
     """
-    fid = _edf_get_fid(fname)
+    fid = __gdf_edf_get_fid(fname)
     try:
         return _edf_open(fid, preload)
+    except Exception:
+        fid.close()
+        raise
+
+def _gdf_open(fid, preload):
+    if preload:
+        # Ignore preloading, since we need to parse the file sequentially in _read_gdf_header
+        warn("Ignoring preload for GFS file.")
+
+    fid.seek(0)
+    return fid
+
+def gdf_open(fname, preload=False, verbose=None):
+    """Open an GDF file.
+
+    Parameters
+    ----------
+    fname : path-like | fid
+        Name of the fif file, or an opened file (will seek back to 0).
+    preload : bool
+        If True, all data from the file is read into a memory buffer. This
+        requires more memory, but can be faster for I/O operations that require
+        frequent seeks.
+    %(verbose)s
+
+    Returns
+    -------
+    fid : file
+        The file descriptor of the open file.
+    """
+    fid = __gdf_edf_get_fid(fname)
+    try:
+        return _gdf_open(fid, preload)
     except Exception:
         fid.close()
         raise

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -51,8 +51,9 @@ class RawEDF(BaseRaw):
 
     Parameters
     ----------
-    input_fname : path-like
-        Path to the EDF, EDF+ or BDF file.
+    input_fname : path-like | file-like
+        Path to the EDF, EDF+ or BDF file. If a file-like object is provided, 
+        preloading must be used.
     eog : list or tuple
         Names of channels or list of indices that should be designated EOG
         channels. Values should correspond to the electrodes in the file.
@@ -260,8 +261,9 @@ class RawGDF(BaseRaw):
 
     Parameters
     ----------
-    input_fname : path-like
-        Path to the GDF file.
+    input_fname : path-like | file-like
+        Path to the GDF file. If a file-like object is provided, 
+        preloading must be used.
     eog : list or tuple
         Names of channels or list of indices that should be designated EOG
         channels. Values should correspond to the electrodes in the file.

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -958,10 +958,12 @@ def test_degenerate():
         read_raw_edf,
         read_raw_bdf,
         read_raw_gdf,
-        partial(_read_header, exclude=(), infer_types=False),
     ):
         with pytest.raises(NotImplementedError, match="Only.*txt.*"):
             func(edf_txt_stim_channel_path)
+
+        with pytest.raises(NotImplementedError, match="Only GDF, EDF, and BDF files are supported."):
+            partial(_read_header, exclude=(), infer_types=False, preload=False, file_type=4)(edf_txt_stim_channel_path)
 
 
 def test_exclude():
@@ -1208,3 +1210,103 @@ def test_anonymization():
     assert bday == datetime.date(1967, 10, 9)
     raw.anonymize()
     assert raw.info["subject_info"]["birthday"] != bday
+
+def test_bdf_read_from_file_like():
+    """ Test that RawEDF is able to read from file-like objects for BDF files"""
+    with open(bdf_path, 'rb') as blob:
+        raw = read_raw_edf(blob, preload=True)
+        channels = [
+            'Fp1', 'AF7', 'AF3', 
+            'F1', 'F3', 'F5', 
+            'F7', 'FT7', 'FC5', 
+            'FC3', 'FC1', 'C1', 
+            'C3', 'C5', 'T7', 
+            'TP7', 'CP5', 'CP3', 
+            'CP1', 'P1', 'P3', 
+            'P5', 'P7', 'P9', 
+            'PO7', 'PO3', 'O1', 
+            'Iz', 'Oz', 'POz', 
+            'Pz', 'CPz', 'Fpz', 
+            'Fp2', 'AF8', 'AF4', 
+            'AFz', 'Fz', 'F2', 
+            'F4', 'F6', 'F8', 
+            'FT8', 'FC6', 'FC4', 
+            'FC2', 'FCz', 'Cz', 
+            'C2', 'C4', 'C6', 
+            'T8', 'TP8', 'CP6', 
+            'CP4', 'CP2', 'P2', 
+            'P4', 'P6', 'P8', 
+            'P10', 'PO8', 'PO4', 
+            'O2', 'EXG1', 'REOG', 
+            'LEOG', 'IEOG', 'EXG5', 
+            'M2', 'M1', 'EXG8', 
+            'Status']
+
+        assert raw.ch_names == channels
+
+@pytest.mark.filterwarnings("ignore:Invalid measurement date encountered in the header.") 
+def test_edf_read_from_bad_file_like():
+    with pytest.raises(Exception, match="Bad EDF file provided."):
+        with open(edf_txt_stim_channel_path, 'rb') as blob:
+            read_raw_edf(blob, preload=True)
+    
+def test_edf_read_from_file_like():
+    """ Test that RawEDF is able to read from file-like objects for EDF files"""
+    with open(edf_path, 'rb') as blob:
+        raw = read_raw_edf(blob, preload=True)
+        channels = [
+            'A1', 'A2', 'A3', 
+            'A4', 'A5', 'A6', 
+            'A7', 'A8', 'A9', 
+            'A10', 'A11', 'A12', 
+            'A13', 'A14', 'A15', 
+            'A16', 'B1', 'B2', 
+            'B3', 'B4', 'B5', 
+            'B6', 'B7', 'B8', 
+            'B9', 'B10', 'B11', 
+            'B12', 'B13', 'B14', 
+            'B15', 'B16', 'C1', 
+            'C2', 'C3', 'C4', 
+            'C5', 'C6', 'C7', 
+            'C8', 'C9', 'C10', 
+            'C11', 'C12', 'C13', 
+            'C14', 'C15', 'C16', 
+            'D1', 'D2', 'D3', 
+            'D4', 'D5', 'D6', 
+            'D7', 'D8', 'D9', 
+            'D10', 'D11', 'D12', 
+            'D13', 'D14', 'D15', 
+            'D16', 'E1', 'E2', 
+            'E3', 'E4', 'E5', 
+            'E6', 'E7', 'E8', 
+            'E9', 'E10', 'E11', 
+            'E12', 'E13', 'E14', 
+            'E15', 'E16', 'F1', 
+            'F2', 'F3', 'F4', 
+            'F5', 'F6', 'F7', 
+            'F8', 'F9', 'F10', 
+            'F11', 'F12', 'F13', 
+            'F14', 'F15', 'F16', 
+            'G1', 'G2', 'G3', 
+            'G4', 'G5', 'G6', 
+            'G7', 'G8', 'G9', 
+            'G10', 'G11', 'G12', 
+            'G13', 'G14', 'G15', 
+            'G16', 'H1', 'H2', 
+            'H3', 'H4', 'H5', 
+            'H6', 'H7', 'H8', 
+            'H9', 'H10', 'H11', 
+            'H12', 'H13', 'H14', 
+            'H15', 'H16', 'I1', 
+            'I2', 'I3', 'I4', 
+            'I5', 'I6', 'I7', 
+            'I8', 'Ergo-Left', 'Ergo-Right', 
+            'Status']
+
+        assert raw.ch_names == channels
+
+@pytest.mark.filterwarnings("ignore:Invalid measurement date encountered in the header.") 
+def test_bdf_read_from_bad_file_like():
+    with pytest.raises(Exception, match="Bad BDF file provided."):
+        with open(edf_txt_stim_channel_path, 'rb') as blob:
+            read_raw_bdf(blob, preload=True)

--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -1246,6 +1246,7 @@ def test_bdf_read_from_file_like():
 
 @pytest.mark.filterwarnings("ignore:Invalid measurement date encountered in the header.") 
 def test_edf_read_from_bad_file_like():
+    """ Test that RawEDF is NOT able to read from file-like objects for non EDF files"""
     with pytest.raises(Exception, match="Bad EDF file provided."):
         with open(edf_txt_stim_channel_path, 'rb') as blob:
             read_raw_edf(blob, preload=True)
@@ -1307,6 +1308,7 @@ def test_edf_read_from_file_like():
 
 @pytest.mark.filterwarnings("ignore:Invalid measurement date encountered in the header.") 
 def test_bdf_read_from_bad_file_like():
+    """ Test that RawEDF is NOT able to read from file-like objects for non BDF files"""
     with pytest.raises(Exception, match="Bad BDF file provided."):
         with open(edf_txt_stim_channel_path, 'rb') as blob:
             read_raw_bdf(blob, preload=True)

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -338,7 +338,10 @@ def _test_raw_reader(
 
     # test resetting raw
     if test_kwargs:
-        del raw._init_kwargs["file_type"]
+        try:
+            del raw._init_kwargs["file_type"]
+        except KeyError:
+            pass
         raw2 = reader(**raw._init_kwargs)
         assert set(raw.info.keys()) == set(raw2.info.keys())
         assert_array_equal(raw.times, raw2.times)

--- a/mne/io/tests/test_raw.py
+++ b/mne/io/tests/test_raw.py
@@ -338,6 +338,7 @@ def _test_raw_reader(
 
     # test resetting raw
     if test_kwargs:
+        del raw._init_kwargs["file_type"]
         raw2 = reader(**raw._init_kwargs)
         assert set(raw.info.keys()) == set(raw2.info.keys())
         assert_array_equal(raw.times, raw2.times)


### PR DESCRIPTION
#### Reference issue (if any)

Feature #8976.

#### What does this implement/fix?

Added support for file-like objects for EDF/BDF/GDF files.

#### Additional information

Until today, mne was checking for the file extension to validate file types, we may not have a file name from a binary object, so, if a binary object (file-like) is provided we trust the user (depending on what API function he is using: read_raw_edf, read_raw_gdf, read_raw_bdf). A new enumeration has been [declared](https://github.com/szz-dvl/mne-python/blob/main/mne/io/edf/edf.py#L25) to propagate the file type to underlying methods. In the function [_read_edf_header](https://github.com/szz-dvl/mne-python/blob/main/mne/io/edf/edf.py#L909) a new exception is raised if the header can be properly parsed, informing the user that the file provided is not valid. In the function [_read_gdf_header](https://github.com/szz-dvl/mne-python/blob/main/mne/io/edf/edf.py#L1114), a new exception is raised when the version of the document can't be properly parsed, informing the user that the file provided is not valid.

To accommodate this changes the class RawEDF have a new parameter [file_type](https://github.com/szz-dvl/mne-python/blob/main/mne/io/edf/edf.py#L155) to differentiate between BDF and EDF files when the extension is not known. It does not imply a change in the API, but the class parameters have changed, because of that the file mne-python/mne/io/tests/test_raw.py have been [modified](https://github.com/szz-dvl/mne-python/blob/main/mne/io/tests/test_raw.py#L341) to remove file_type parameter from the kwargs, I think this is not actually desired but I don't know how to proceed otherwise.

Additionally 4 new tests have been added to the file mne-python/mne/io/edf/tests/test_edf.py and 2 new tests have been added to the file mne-python/mne/io/edf/tests/test_gdf.py, those tests will open a valid file and check for the channels, and open an invalid file and expect an error. For GDF I needed a new file in MNE-testing-data/GDF, the file is simply an empty file that must be named "test_empty_gdf.gdf". If I need to open a PR at https://github.com/mne-tools/mne-testing-data please let me know. 
