### PR TITLE
FIX, DOC: Bug in plot_evoked_joint API

### DIFF
--- a/doc/changes/devel/13159.bugfix.rst
+++ b/doc/changes/devel/13159.bugfix.rst
@@ -1,0 +1,1 @@
+Changed `exclude=None` to `exclude="bads"` in :func:`~mne.viz.evoked.plot_evoked_joint`, because `None` was not a valid argument for this parameter. By `Scott Huberty`_.

--- a/doc/changes/devel/13159.bugfix.rst
+++ b/doc/changes/devel/13159.bugfix.rst
@@ -1,1 +1,1 @@
-Changed `exclude=None` to `exclude="bads"` in :func:`~mne.viz.evoked.plot_evoked_joint`, because `None` was not a valid argument for this parameter. By `Scott Huberty`_.
+Changed ``exclude=None`` to ``exclude="bads"`` in :func:`~mne.viz.plot_evoked_joint`, because ``None`` was not a valid argument for this parameter. By `Scott Huberty`_.

--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -1797,7 +1797,7 @@ def plot_evoked_joint(
     times="peaks",
     title="",
     picks=None,
-    exclude=None,
+    exclude="bads",
     show=True,
     ts_args=None,
     topomap_args=None,
@@ -1824,9 +1824,10 @@ def plot_evoked_joint(
         axes are passed make sure to set ``title=None``, otherwise some of your
         axes may be removed during placement of the title axis.
     %(picks_all)s
-    exclude : None | list of str | 'bads'
+    exclude : list of str | 'bads'
         Channels names to exclude from being shown. If ``'bads'``, the
-        bad channels are excluded. Defaults to ``None``.
+        bad channels are excluded. If an empty list, no channels are
+        excluded. Defaults to ``"bads"``.
     show : bool
         Show figure if ``True``. Defaults to ``True``.
     ts_args : None | dict


### PR DESCRIPTION
Fixes #13157 

 FYI It's a little more complicated that I thought...

The _function_ [plot_evoked_joint](https://mne.tools/stable/generated/mne.viz.plot_evoked_joint.html#mne.viz.plot_evoked_joint) does have the default `exclude=None`, **which actually does not work!**  🚨  But the docstring was technically inline with the ~API~ function signature:

https://github.com/mne-tools/mne-python/blob/df4a3f1601418bf1dfd1a3621c34bfa3b1188f8b/mne/viz/evoked.py#L1794-L1857

The _method_ [evoked.plot_joint](https://mne.tools/stable/generated/mne.Evoked.html#mne.Evoked.plot_joint) has a default `exclude="bads"`. The docstring is copied from the _function_ `plot_evoked_joint` to the _method_ `evoked.plot_joint` which is where the docstring-to-code discrepancy arises:


https://github.com/mne-tools/mne-python/blob/8f83332cac8b0cdbc28ca038ef4a66c6f876dc9c/mne/evoked.py#L772-L792


**TL;DR**


We can update the docstring but we have to change

https://github.com/mne-tools/mne-python/blob/df4a3f1601418bf1dfd1a3621c34bfa3b1188f8b/mne/viz/evoked.py#L1800

to `exclude="bads"`