### PR TITLE
replace import nesting tests with tach

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,12 @@ repos:
       - id: toml-sort-fix
         files: pyproject.toml
 
+  # module interdependencies
+  - repo: https://github.com/gauge-sh/tach-pre-commit
+    rev: v0.28.0
+    hooks:
+      - id: tach
+
   # dependencies
   - repo: local
     hooks:

--- a/mne/preprocessing/_regress.py
+++ b/mne/preprocessing/_regress.py
@@ -5,11 +5,11 @@
 import numpy as np
 
 from .._fiff.pick import _picks_to_idx, pick_info
+from .._fiff.proj import _needs_eeg_average_ref_proj
 from ..defaults import _BORDER_DEFAULT, _EXTRAPOLATE_DEFAULT, _INTERPOLATION_DEFAULT
 from ..epochs import BaseEpochs
 from ..evoked import Evoked
 from ..io import BaseRaw
-from ..minimum_norm.inverse import _needs_eeg_average_ref_proj
 from ..utils import (
     _check_fname,
     _check_option,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ test = [
   "pytest-qt",
   "pytest-timeout",
   "ruff",
+  "tach",
   "toml-sort",
   "tomli; python_version<'3.11'",
   "twine",

--- a/tach.toml
+++ b/tach.toml
@@ -12,7 +12,7 @@ source_roots = [ "mne",
 
 [[modules ]]
 path = "preprocessing"
-depends_on = ["epochs", "forward", "surface", "decoding", "io", "channels", "utils", "cov", "bem", "filter", "viz", "transforms", "event", "minimum_norm"]
+depends_on = ["epochs", "forward", "surface", "decoding", "io", "channels", "utils", "cov", "bem", "filter", "viz", "transforms", "event"]
 
 [[modules ]]
 path = "datasets"

--- a/tach.toml
+++ b/tach.toml
@@ -1,0 +1,131 @@
+interfaces = []
+exclude = [
+    "**/*__pycache__",
+    "**/*egg-info",
+    "**/tests",
+    "**/venv",
+    "mne/conftest.py"
+]
+
+source_roots = [ "mne",
+]
+
+[[modules ]]
+path = "preprocessing"
+depends_on = ["epochs", "forward", "surface", "decoding", "io", "channels", "utils", "cov", "bem", "filter", "viz", "transforms", "event", "minimum_norm"]
+
+[[modules ]]
+path = "datasets"
+depends_on = ["channels", "epochs", "utils", "label"]
+
+[[modules ]]
+path = "minimum_norm"
+depends_on = ["baseline", "time_frequency", "transforms", "io", "cov", "source_space", "surface", "epochs", "label", "event", "forward", "utils"]
+
+[[modules ]]
+path = "io"
+depends_on = ["utils", "time_frequency", "viz", "filter", "epochs", "transforms", "chpi", "preprocessing", "surface", "channels", "export", "event", "coreg"]
+
+[[modules ]]
+path = "source_space"
+depends_on = ["label", "transforms", "surface", "utils", "bem", "viz"]
+
+[[modules ]]
+path = "simulation"
+depends_on = ["source_space", "io", "label", "epochs", "utils", "chpi", "bem", "forward", "cov", "event", "surface", "transforms"]
+
+[[modules ]]
+path = "bem"
+depends_on = ["utils", "surface", "transforms", "viz"]
+
+[[modules ]]
+path = "epochs"
+depends_on = ["export", "channels", "utils", "chpi", "baseline", "io", "viz", "time_frequency", "preprocessing", "filter", "bem", "event", "forward"]
+
+[[modules ]]
+path = "coreg"
+depends_on = ["bem", "surface", "source_space", "label", "utils", "viz", "channels", "transforms"]
+
+[[modules ]]
+path = "gui"
+depends_on = ["channels", "io", "surface", "viz", "coreg", "bem", "transforms", "utils"]
+
+[[modules ]]
+path = "label"
+depends_on = ["surface", "stats", "viz", "utils", "source_space"]
+
+[[modules ]]
+path = "decoding"
+depends_on = ["epochs", "cuda", "cov", "filter", "time_frequency", "utils"]
+
+[[modules ]]
+path = "chpi"
+depends_on = ["preprocessing", "utils", "cov", "dipole", "io", "event", "channels", "transforms", "forward"]
+
+[[modules ]]
+path = "cuda"
+depends_on = ["utils"]
+
+[[modules ]]
+path = "time_frequency"
+depends_on = ["viz", "baseline", "channels", "io", "epochs", "cov", "utils", "filter"]
+
+[[modules ]]
+path = "transforms"
+depends_on = ["utils", "bem", "channels", "source_space"]
+
+[[modules ]]
+path = "baseline"
+depends_on = ["utils"]
+
+[[modules ]]
+path = "export"
+depends_on = ["io", "utils"]
+
+[[modules ]]
+path = "stats"
+depends_on = ["epochs", "source_space", "utils"]
+
+[[modules ]]
+path = "event"
+depends_on = ["io", "utils"]
+
+[[modules ]]
+path = "utils"
+depends_on = ["event", "source_space", "cov", "dipole", "channels", "io", "time_frequency", "viz", "bem", "epochs"]
+
+[[modules ]]
+path = "forward"
+depends_on = ["dipole", "label", "epochs", "source_space", "cov", "utils", "surface", "bem", "io", "transforms"]
+
+[[modules ]]
+path = "dipole"
+depends_on = ["forward", "transforms", "utils", "source_space", "cov", "bem", "surface", "viz"]
+
+[[modules ]]
+path = "inverse_sparse"
+depends_on = ["dipole", "minimum_norm", "time_frequency", "forward", "utils"]
+
+[[modules ]]
+path = "surface"
+depends_on = ["bem", "utils", "transforms", "channels"]
+
+[[modules ]]
+path = "viz"
+depends_on = ["preprocessing", "utils", "io", "baseline", "time_frequency", "stats", "source_space", "bem", "coreg", "forward", "transforms", "surface", "dipole", "channels", "label", "minimum_norm", "chpi", "cov", "epochs", "filter"]
+
+[[modules ]]
+path = "channels"
+depends_on = ["preprocessing", "utils", "bem", "viz", "forward", "io", "transforms", "surface", "cov", "time_frequency", "epochs"]
+
+[[modules ]]
+path = "filter"
+depends_on = ["utils", "epochs", "io", "cuda", "time_frequency"]
+
+[[modules ]]
+path = "beamformer"
+depends_on = ["channels", "minimum_norm", "time_frequency", "utils", "cov", "source_space", "inverse_sparse", "forward"]
+
+[[modules ]]
+path = "cov"
+depends_on = ["viz", "utils", "epochs", "io", "event"]


### PR DESCRIPTION
This PR uses [tach](https://github.com/gauge-sh/tach) as a pre-commit hook to test submodule interdependence. TODO:

- [x] make sure it runs in `pre-commmit.ci` (https://github.com/mne-tools/mne-python/actions/runs/13843290676/job/38735774113?pr=13160#step:4:153)
- [x] change the `tach.toml` config to stop allowing an existing internal dependency, and make sure the CI fails. (https://github.com/mne-tools/mne-python/actions/runs/13843379560/job/38736078349?pr=13160#step:4:116)
- [x] change the codebase to actually remove that internal dependency, and make sure CI passes. https://github.com/mne-tools/mne-python/actions/runs/13843411801/job/38736168047?pr=13160#step:4:116
- [ ] go through `tests/test_import_nesting.py` and make sure `tach.toml` reflects all the expectations we've set there. When it does, we can remove those tests.
- [ ] add a visualization of the dependency graph to our docs somewhere? (it can output `.dot` files)
