### PR TITLE
expose 'mode' for plotting dipole on brain

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -2338,7 +2338,9 @@ class Brain:
         self._remove("forward", render=True)
 
     @fill_doc
-    def add_dipole(self, dipole, trans, colors="red", alpha=1, scales=None):
+    def add_dipole(
+        self, dipole, trans, colors="red", alpha=1, scales=None, *, mode="arrow"
+    ):
         """Add a quiver to render positions of dipoles.
 
         Parameters
@@ -2354,6 +2356,10 @@ class Brain:
         scales : list | float | None
             The size of the arrow representing the dipole in
             :class:`mne.viz.Brain` units. Default 5mm.
+        mode : str
+            The drawing mode for the dipole to render. May be one of
+            ``("2darrow", "arrow", "cone", "cylinder", "sphere", "oct")``.
+            Defaults to ``"arrow"``.
 
         Notes
         -----
@@ -2392,7 +2398,7 @@ class Brain:
                     *this_ori,
                     color=color,
                     opacity=alpha,
-                    mode="arrow",
+                    mode=mode,
                     scale=scale,
                 )
                 self._add_actor("dipole", actor)

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -483,7 +483,9 @@ def test_brain_init(renderer_pyvistaqt, tmp_path, pixel_ratio, brain_gc):
         ori=[[0, 1, 0]],
         gof=50,
     )
-    brain.add_dipole(dip, fname_trans, colors="blue", scales=5, alpha=0.5)
+    brain.add_dipole(
+        dip, fname_trans, colors="blue", scales=5, alpha=0.5, mode="sphere"
+    )
     brain.remove_dipole()
 
     with pytest.raises(ValueError, match="The number of colors"):


### PR DESCRIPTION
This PR will allow users to plot dipoles using spheres, instead of only arrow on a Brain object. This is helpful for cases where the dipole orientation is either meaningless or unimportant.

options are taken from ALLOWED_QUIVER_MODES and are alreday checked in `self._renderer.quiver3d`.

**before, we only could do this:**

![image](https://github.com/user-attachments/assets/77507011-577e-4b67-8a5d-230741d32530)

**now we can also do this:**

![image](https://github.com/user-attachments/assets/27ea7b30-2368-4cb5-8860-71e0dd1598d7)
