### PR TITLE
[draft] new reader for curry files, using curry-pyhon-reader code

### DIFF
--- a/mne/io/curry/curry.py
+++ b/mne/io/curry/curry.py
@@ -3,539 +3,19 @@
 # License: BSD-3-Clause
 # Copyright the MNE-Python contributors.
 
-import os.path as op
 import re
-from collections import namedtuple
-from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
 
-from ..._fiff._digitization import _make_dig_points
-from ..._fiff.constants import FIFF
 from ..._fiff.meas_info import create_info
-from ..._fiff.tag import _coil_trans_to_loc
-from ..._fiff.utils import _mult_cal_one, _read_segments_file
-from ...annotations import Annotations
-from ...surface import _normal_orth
-from ...transforms import (
-    Transform,
-    _angle_between_quats,
-    apply_trans,
-    combine_transforms,
-    get_ras_to_neuromag_trans,
-    invert_transform,
-    rot_to_quat,
-)
-from ...utils import _check_fname, check_fname, logger, verbose
+from ...annotations import annotations_from_events
+from ...channels import make_dig_montage
+from ...utils import verbose
 from ..base import BaseRaw
-from ..ctf.trans import _quaternion_align
+from .curryreader import read
 
-FILE_EXTENSIONS = {
-    "Curry 7": {
-        "info": ".dap",
-        "data": ".dat",
-        "labels": ".rs3",
-        "events_cef": ".cef",
-        "events_ceo": ".ceo",
-        "hpi": ".hpi",
-    },
-    "Curry 8": {
-        "info": ".cdt.dpa",
-        "data": ".cdt",
-        "labels": ".cdt.dpa",
-        "events_cef": ".cdt.cef",
-        "events_ceo": ".cdt.ceo",
-        "hpi": ".cdt.hpi",
-    },
-}
-CHANTYPES = {"meg": "_MAG1", "eeg": "", "misc": "_OTHERS"}
-FIFFV_CHANTYPES = {
-    "meg": FIFF.FIFFV_MEG_CH,
-    "eeg": FIFF.FIFFV_EEG_CH,
-    "misc": FIFF.FIFFV_MISC_CH,
-}
-FIFFV_COILTYPES = {
-    "meg": FIFF.FIFFV_COIL_CTF_GRAD,
-    "eeg": FIFF.FIFFV_COIL_EEG,
-    "misc": FIFF.FIFFV_COIL_NONE,
-}
-SI_UNITS = dict(V=FIFF.FIFF_UNIT_V, T=FIFF.FIFF_UNIT_T)
-SI_UNIT_SCALE = dict(c=1e-2, m=1e-3, u=1e-6, µ=1e-6, n=1e-9, p=1e-12, f=1e-15)
-
-CurryParameters = namedtuple(
-    "CurryParameters",
-    "n_samples, sfreq, is_ascii, unit_dict, n_chans, dt_start, chanidx_in_file",
-)
-
-
-def _get_curry_version(file_extension):
-    """Check out the curry file version."""
-    return "Curry 8" if "cdt" in file_extension else "Curry 7"
-
-
-def _get_curry_file_structure(fname, required=()):
-    """Store paths to a dict and check for required files."""
-    _msg = (
-        "The following required files cannot be found: {0}.\nPlease make "
-        "sure all required files are located in the same directory as {1}."
-    )
-    fname = Path(_check_fname(fname, "read", True, "fname"))
-
-    # we don't use os.path.splitext to also handle extensions like .cdt.dpa
-    # this won't handle a dot in the filename, but it should handle it in
-    # the parent directories
-    fname_base = fname.name.split(".", maxsplit=1)[0]
-    ext = fname.name[len(fname_base) :]
-    fname_base = str(fname)
-    fname_base = fname_base[: len(fname_base) - len(ext)]
-    del fname
-    version = _get_curry_version(ext)
-    my_curry = dict()
-    for key in ("info", "data", "labels", "events_cef", "events_ceo", "hpi"):
-        fname = fname_base + FILE_EXTENSIONS[version][key]
-        if op.isfile(fname):
-            _key = "events" if key.startswith("events") else key
-            my_curry[_key] = fname
-
-    missing = [field for field in required if field not in my_curry]
-    if missing:
-        raise FileNotFoundError(_msg.format(np.unique(missing), fname))
-
-    return my_curry
-
-
-def _read_curry_lines(fname, regex_list):
-    """Read through the lines of a curry parameter files and save data.
-
-    Parameters
-    ----------
-    fname : path-like
-        Path to a curry file.
-    regex_list : list of str
-        A list of strings or regular expressions to search within the file.
-        Each element `regex` in `regex_list` must be formulated so that
-        `regex + " START_LIST"` initiates the start and `regex + " END_LIST"`
-        initiates the end of the elements that should be saved.
-
-    Returns
-    -------
-    data_dict : dict
-        A dictionary containing the extracted data. For each element `regex`
-        in `regex_list` a dictionary key `data_dict[regex]` is created, which
-        contains a list of the according data.
-
-    """
-    save_lines = {}
-    data_dict = {}
-
-    for regex in regex_list:
-        save_lines[regex] = False
-        data_dict[regex] = []
-
-    with open(fname) as fid:
-        for line in fid:
-            for regex in regex_list:
-                if re.match(regex + " END_LIST", line):
-                    save_lines[regex] = False
-
-                if save_lines[regex] and line != "\n":
-                    result = line.replace("\n", "")
-                    if "\t" in result:
-                        result = result.split("\t")
-                    data_dict[regex].append(result)
-
-                if re.match(regex + " START_LIST", line):
-                    save_lines[regex] = True
-
-    return data_dict
-
-
-def _read_curry_parameters(fname):
-    """Extract Curry params from a Curry info file."""
-    _msg_match = (
-        "The sampling frequency and the time steps extracted from "
-        "the parameter file do not match."
-    )
-    _msg_invalid = "sfreq must be greater than 0. Got sfreq = {0}"
-
-    var_names = [
-        "NumSamples",
-        "SampleFreqHz",
-        "DataFormat",
-        "SampleTimeUsec",
-        "NumChannels",
-        "StartYear",
-        "StartMonth",
-        "StartDay",
-        "StartHour",
-        "StartMin",
-        "StartSec",
-        "StartMillisec",
-        "NUM_SAMPLES",
-        "SAMPLE_FREQ_HZ",
-        "DATA_FORMAT",
-        "SAMPLE_TIME_USEC",
-        "NUM_CHANNELS",
-        "START_YEAR",
-        "START_MONTH",
-        "START_DAY",
-        "START_HOUR",
-        "START_MIN",
-        "START_SEC",
-        "START_MILLISEC",
-    ]
-
-    param_dict = dict()
-    unit_dict = dict()
-
-    with open(fname) as fid:
-        for line in iter(fid):
-            if any(var_name in line for var_name in var_names):
-                key, val = line.replace(" ", "").replace("\n", "").split("=")
-                param_dict[key.lower().replace("_", "")] = val
-            for key, type_ in CHANTYPES.items():
-                if f"DEVICE_PARAMETERS{type_} START" in line:
-                    data_unit = next(fid)
-                    unit_dict[key] = (
-                        data_unit.replace(" ", "").replace("\n", "").split("=")[-1]
-                    )
-
-    # look for CHAN_IN_FILE sections, which may or may not exist; issue #8391
-    types = ["meg", "eeg", "misc"]
-    chanidx_in_file = _read_curry_lines(
-        fname, ["CHAN_IN_FILE" + CHANTYPES[key] for key in types]
-    )
-
-    n_samples = int(param_dict["numsamples"])
-    sfreq = float(param_dict["samplefreqhz"])
-    time_step = float(param_dict["sampletimeusec"]) * 1e-6
-    is_ascii = param_dict["dataformat"] == "ASCII"
-    n_channels = int(param_dict["numchannels"])
-    try:
-        dt_start = datetime(
-            int(param_dict["startyear"]),
-            int(param_dict["startmonth"]),
-            int(param_dict["startday"]),
-            int(param_dict["starthour"]),
-            int(param_dict["startmin"]),
-            int(param_dict["startsec"]),
-            int(param_dict["startmillisec"]) * 1000,
-            timezone.utc,
-        )
-        # Note that the time zone information is not stored in the Curry info
-        # file, and it seems the start time info is in the local timezone
-        # of the acquisition system (which is unknown); therefore, just set
-        # the timezone to be UTC.  If the user knows otherwise, they can
-        # change it later.  (Some Curry files might include StartOffsetUTCMin,
-        # but its presence is unpredictable, so we won't rely on it.)
-    except (ValueError, KeyError):
-        dt_start = None  # if missing keywords or illegal values, don't set
-
-    if time_step == 0:
-        true_sfreq = sfreq
-    elif sfreq == 0:
-        true_sfreq = 1 / time_step
-    elif not np.isclose(sfreq, 1 / time_step):
-        raise ValueError(_msg_match)
-    else:  # they're equal and != 0
-        true_sfreq = sfreq
-    if true_sfreq <= 0:
-        raise ValueError(_msg_invalid.format(true_sfreq))
-
-    return CurryParameters(
-        n_samples,
-        true_sfreq,
-        is_ascii,
-        unit_dict,
-        n_channels,
-        dt_start,
-        chanidx_in_file,
-    )
-
-
-def _read_curry_info(curry_paths):
-    """Extract info from curry parameter files."""
-    curry_params = _read_curry_parameters(curry_paths["info"])
-    R = np.eye(4)
-    R[[0, 1], [0, 1]] = -1  # rotate 180 deg
-    # shift down and back
-    # (chosen by eyeballing to make the CTF helmet look roughly correct)
-    R[:3, 3] = [0.0, -0.015, -0.12]
-    curry_dev_dev_t = Transform("ctf_meg", "meg", R)
-
-    # read labels from label files
-    label_fname = curry_paths["labels"]
-    types = ["meg", "eeg", "misc"]
-    labels = _read_curry_lines(
-        label_fname, ["LABELS" + CHANTYPES[key] for key in types]
-    )
-    sensors = _read_curry_lines(
-        label_fname, ["SENSORS" + CHANTYPES[key] for key in types]
-    )
-    normals = _read_curry_lines(
-        label_fname, ["NORMALS" + CHANTYPES[key] for key in types]
-    )
-    assert len(labels) == len(sensors) == len(normals)
-
-    all_chans = list()
-    dig_ch_pos = dict()
-    for key in ["meg", "eeg", "misc"]:
-        chanidx_is_explicit = (
-            len(curry_params.chanidx_in_file["CHAN_IN_FILE" + CHANTYPES[key]]) > 0
-        )  # channel index
-        # position in the datafile may or may not be explicitly declared,
-        # based on the CHAN_IN_FILE section in info file
-        for ind, chan in enumerate(labels["LABELS" + CHANTYPES[key]]):
-            chanidx = len(all_chans) + 1  # by default, just assume the
-            # channel index in the datafile is in order of the channel
-            # names as we found them in the labels file
-            if chanidx_is_explicit:  # but, if explicitly declared, use
-                # that index number
-                chanidx = int(
-                    curry_params.chanidx_in_file["CHAN_IN_FILE" + CHANTYPES[key]][ind]
-                )
-            if chanidx <= 0:  # if chanidx was explicitly declared to be ' 0',
-                # it means the channel is not actually saved in the data file
-                # (e.g. the "Ref" channel), so don't add it to our list.
-                # Git issue #8391
-                continue
-            ch = {
-                "ch_name": chan,
-                "unit": curry_params.unit_dict[key],
-                "kind": FIFFV_CHANTYPES[key],
-                "coil_type": FIFFV_COILTYPES[key],
-                "ch_idx": chanidx,
-            }
-            if key == "eeg":
-                loc = np.array(sensors["SENSORS" + CHANTYPES[key]][ind], float)
-                # XXX just the sensor, where is ref (next 3)?
-                assert loc.shape == (3,)
-                loc /= 1000.0  # to meters
-                loc = np.concatenate([loc, np.zeros(9)])
-                ch["loc"] = loc
-                # XXX need to check/ensure this
-                ch["coord_frame"] = FIFF.FIFFV_COORD_HEAD
-                dig_ch_pos[chan] = loc[:3]
-            elif key == "meg":
-                pos = np.array(sensors["SENSORS" + CHANTYPES[key]][ind], float)
-                pos /= 1000.0  # to meters
-                pos = pos[:3]  # just the inner coil
-                pos = apply_trans(curry_dev_dev_t, pos)
-                nn = np.array(normals["NORMALS" + CHANTYPES[key]][ind], float)
-                assert np.isclose(np.linalg.norm(nn), 1.0, atol=1e-4)
-                nn /= np.linalg.norm(nn)
-                nn = apply_trans(curry_dev_dev_t, nn, move=False)
-                trans = np.eye(4)
-                trans[:3, 3] = pos
-                trans[:3, :3] = _normal_orth(nn).T
-                ch["loc"] = _coil_trans_to_loc(trans)
-                ch["coord_frame"] = FIFF.FIFFV_COORD_DEVICE
-            all_chans.append(ch)
-    dig = _make_dig_points(
-        dig_ch_pos=dig_ch_pos, coord_frame="head", add_missing_fiducials=True
-    )
-    del dig_ch_pos
-
-    ch_count = len(all_chans)
-    assert ch_count == curry_params.n_chans  # ensure that we have assembled
-    # the same number of channels as declared in the info (.DAP) file in the
-    # DATA_PARAMETERS section. Git issue #8391
-
-    # sort the channels to assure they are in the order that matches how
-    # recorded in the datafile.  In general they most likely are already in
-    # the correct order, but if the channel index in the data file was
-    # explicitly declared we might as well use it.
-    all_chans = sorted(all_chans, key=lambda ch: ch["ch_idx"])
-
-    ch_names = [chan["ch_name"] for chan in all_chans]
-    info = create_info(ch_names, curry_params.sfreq)
-    with info._unlock():
-        info["meas_date"] = curry_params.dt_start  # for Git issue #8398
-        info["dig"] = dig
-    _make_trans_dig(curry_paths, info, curry_dev_dev_t)
-
-    for ind, ch_dict in enumerate(info["chs"]):
-        all_chans[ind].pop("ch_idx")
-        ch_dict.update(all_chans[ind])
-        assert ch_dict["loc"].shape == (12,)
-        ch_dict["unit"] = SI_UNITS[all_chans[ind]["unit"][1]]
-        ch_dict["cal"] = SI_UNIT_SCALE[all_chans[ind]["unit"][0]]
-
-    return info, curry_params.n_samples, curry_params.is_ascii
-
-
-_card_dict = {
-    "Left ear": FIFF.FIFFV_POINT_LPA,
-    "Nasion": FIFF.FIFFV_POINT_NASION,
-    "Right ear": FIFF.FIFFV_POINT_RPA,
-}
-
-
-def _make_trans_dig(curry_paths, info, curry_dev_dev_t):
-    # Coordinate frame transformations and definitions
-    no_msg = "Leaving device<->head transform as None"
-    info["dev_head_t"] = None
-    label_fname = curry_paths["labels"]
-    key = "LANDMARKS" + CHANTYPES["meg"]
-    lm = _read_curry_lines(label_fname, [key])[key]
-    lm = np.array(lm, float)
-    lm.shape = (-1, 3)
-    if len(lm) == 0:
-        # no dig
-        logger.info(no_msg + " (no landmarks found)")
-        return
-    lm /= 1000.0
-    key = "LM_REMARKS" + CHANTYPES["meg"]
-    remarks = _read_curry_lines(label_fname, [key])[key]
-    assert len(remarks) == len(lm)
-    with info._unlock():
-        info["dig"] = list()
-    cards = dict()
-    for remark, r in zip(remarks, lm):
-        kind = ident = None
-        if remark in _card_dict:
-            kind = FIFF.FIFFV_POINT_CARDINAL
-            ident = _card_dict[remark]
-            cards[ident] = r
-        elif remark.startswith("HPI"):
-            kind = FIFF.FIFFV_POINT_HPI
-            ident = int(remark[3:]) - 1
-        if kind is not None:
-            info["dig"].append(
-                dict(kind=kind, ident=ident, r=r, coord_frame=FIFF.FIFFV_COORD_UNKNOWN)
-            )
-    with info._unlock():
-        info["dig"].sort(key=lambda x: (x["kind"], x["ident"]))
-    has_cards = len(cards) == 3
-    has_hpi = "hpi" in curry_paths
-    if has_cards and has_hpi:  # have all three
-        logger.info("Composing device<->head transformation from dig points")
-        hpi_u = np.array(
-            [d["r"] for d in info["dig"] if d["kind"] == FIFF.FIFFV_POINT_HPI], float
-        )
-        hpi_c = np.ascontiguousarray(_first_hpi(curry_paths["hpi"])[: len(hpi_u), 1:4])
-        unknown_curry_t = _quaternion_align("unknown", "ctf_meg", hpi_u, hpi_c, 1e-2)
-        angle = np.rad2deg(
-            _angle_between_quats(
-                np.zeros(3), rot_to_quat(unknown_curry_t["trans"][:3, :3])
-            )
-        )
-        dist = 1000 * np.linalg.norm(unknown_curry_t["trans"][:3, 3])
-        logger.info(f"   Fit a {angle:0.1f}° rotation, {dist:0.1f} mm translation")
-        unknown_dev_t = combine_transforms(
-            unknown_curry_t, curry_dev_dev_t, "unknown", "meg"
-        )
-        unknown_head_t = Transform(
-            "unknown",
-            "head",
-            get_ras_to_neuromag_trans(
-                *(
-                    cards[key]
-                    for key in (
-                        FIFF.FIFFV_POINT_NASION,
-                        FIFF.FIFFV_POINT_LPA,
-                        FIFF.FIFFV_POINT_RPA,
-                    )
-                )
-            ),
-        )
-        with info._unlock():
-            info["dev_head_t"] = combine_transforms(
-                invert_transform(unknown_dev_t), unknown_head_t, "meg", "head"
-            )
-            for d in info["dig"]:
-                d.update(
-                    coord_frame=FIFF.FIFFV_COORD_HEAD,
-                    r=apply_trans(unknown_head_t, d["r"]),
-                )
-    else:
-        if has_cards:
-            no_msg += " (no .hpi file found)"
-        elif has_hpi:
-            no_msg += " (not all cardinal points found)"
-        else:
-            no_msg += " (neither cardinal points nor .hpi file found)"
-        logger.info(no_msg)
-
-
-def _first_hpi(fname):
-    # Get the first HPI result
-    with open(fname) as fid:
-        for line in fid:
-            line = line.strip()
-            if any(x in line for x in ("FileVersion", "NumCoils")) or not line:
-                continue
-            hpi = np.array(line.split(), float)
-            break
-        else:
-            raise RuntimeError(f"Could not find valid HPI in {fname}")
-    # t is the first entry
-    assert hpi.ndim == 1
-    hpi = hpi[1:]
-    hpi.shape = (-1, 5)
-    hpi /= 1000.0
-    return hpi
-
-
-def _read_events_curry(fname):
-    """Read events from Curry event files.
-
-    Parameters
-    ----------
-    fname : path-like
-        Path to a curry event file with extensions .cef, .ceo,
-        .cdt.cef, or .cdt.ceo
-
-    Returns
-    -------
-    events : ndarray, shape (n_events, 3)
-        The array of events.
-    """
-    check_fname(
-        fname,
-        "curry event",
-        (".cef", ".ceo", ".cdt.cef", ".cdt.ceo"),
-        endings_err=(".cef", ".ceo", ".cdt.cef", ".cdt.ceo"),
-    )
-
-    events_dict = _read_curry_lines(fname, ["NUMBER_LIST"])
-    # The first 3 column seem to contain the event information
-    curry_events = np.array(events_dict["NUMBER_LIST"], dtype=int)[:, 0:3]
-
-    return curry_events
-
-
-def _read_annotations_curry(fname, sfreq="auto"):
-    r"""Read events from Curry event files.
-
-    Parameters
-    ----------
-    fname : str
-        The filename.
-    sfreq : float | 'auto'
-        The sampling frequency in the file. If set to 'auto' then the
-        ``sfreq`` is taken from the respective info file of the same name with
-        according file extension (\*.dap for Curry 7; \*.cdt.dpa for Curry8).
-        So data.cef looks in data.dap and data.cdt.cef looks in data.cdt.dpa.
-
-    Returns
-    -------
-    annot : instance of Annotations | None
-        The annotations.
-    """
-    required = ["events", "info"] if sfreq == "auto" else ["events"]
-    curry_paths = _get_curry_file_structure(fname, required)
-    events = _read_events_curry(curry_paths["events"])
-
-    if sfreq == "auto":
-        sfreq = _read_curry_parameters(curry_paths["info"]).sfreq
-
-    onset = events[:, 0] / sfreq
-    duration = np.zeros(events.shape[0])
-    description = events[:, 2]
-
-    return Annotations(onset, duration, description)
+_RE_COMBINE_WHITESPACE = re.compile(r"\s+")
 
 
 @verbose
@@ -582,50 +62,144 @@ class RawCurry(BaseRaw):
 
     @verbose
     def __init__(self, fname, preload=False, verbose=None):
-        curry_paths = _get_curry_file_structure(
-            fname, required=["info", "data", "labels"]
+        fname = Path(fname)
+
+        # use curry-python-reader
+        try:
+            currydata = read(str(fname), plotdata=0, verbosity=1)
+        except Exception as e:
+            raise ValueError(f"file could not be read - {e}")
+
+        # extract info
+        sfreq = currydata["info"]["samplingfreq"]
+        n_samples = currydata["info"]["samples"]
+        n_ch = currydata["info"]["channels"]
+        ch_names = currydata["labels"]
+        ch_pos = currydata["sensorpos"]
+        landmarks = currydata["landmarks"]
+        landmarkslabels = currydata["landmarkslabels"]
+
+        # extract data
+        orig_format = (
+            "single"
+            if isinstance(currydata["data"].dtype, type(np.dtype("float32")))
+            else None
         )
+        preload = currydata["data"].T.astype(
+            "float64"
+        )  # curryreader returns float32, but mne seems to need float64
+        events = currydata["events"]
+        # annotations = currydata[
+        #    "annotations"
+        # ]  # dont always seem to correspond to events?!
+        # epochinfo = currydata["epochinfo"]  # TODO
+        # epochlabels = currydata["epochlabels"]  # TODO
+        # impedances = currydata["impedances"]  # TODO
+        # hpimatrix = currydata["hpimatrix"]  # TODO
 
-        data_fname = op.abspath(curry_paths["data"])
+        # extract some more essential info not provided by reader
+        fname_hdr = None
+        for hdr_suff in [".cdt.dpa", ".cdt.dpo", ".dap"]:
+            if fname.with_suffix(hdr_suff).exists():
+                fname_hdr = fname.with_suffix(hdr_suff)
 
-        info, n_samples, is_ascii = _read_curry_info(curry_paths)
+        ch_types, units = [], []
+        if fname_hdr:
+            changroups = fname_hdr.read_text().split("DEVICE_PARAMETERS")[1::2]
+            for changroup_info in changroups:
+                changroup_info = _RE_COMBINE_WHITESPACE.sub(" ", changroup_info).strip()
+                groupid = changroup_info.split()[0]
+                unit = changroup_info.split("DataUnit = ")[1].split()[0]
+                n_ch_group = int(
+                    changroup_info.split("NumChanThisGroup = ")[1].split()[0]
+                )
+                ch_type = (
+                    "mag"
+                    if ("MAG" in groupid)
+                    else "misc"
+                    if ("OTHER") in groupid
+                    else "eeg"
+                )
+                # combine info
+                ch_types += [ch_type] * n_ch_group
+                units += [unit] * n_ch_group
 
+            assert len(ch_types) == len(units) == len(ch_names) == n_ch
+
+        else:
+            # not implemented
+            raise NotImplementedError
+
+        # finetune channel types (e.g. stim, eog etc might be identified by name)
+        # TODO
+
+        # scale data to SI units
+        orig_units = dict(zip(ch_names, units))
+        for i_ch, unit in enumerate(units):
+            if unit == "fT":  # femtoTesla
+                preload[i_ch, :] /= 1e15
+            elif unit == "uV":  # microVolt
+                preload[i_ch, :] /= 1e6
+            else:  # leave as is
+                pass
+
+        # construct info
+        info = create_info(ch_names=ch_names, sfreq=sfreq, ch_types=ch_types)
         last_samps = [n_samples - 1]
-        raw_extras = dict(is_ascii=is_ascii)
 
+        # create raw object
         super().__init__(
             info,
             preload,
-            filenames=[data_fname],
+            filenames=[fname],
             last_samps=last_samps,
-            orig_format="int",
-            raw_extras=[raw_extras],
+            orig_format=orig_format,
+            orig_units=orig_units,
             verbose=verbose,
         )
 
-        if "events" in curry_paths:
-            logger.info(
-                "Event file found. Extracting Annotations from "
-                f"{curry_paths['events']}..."
-            )
-            annots = _read_annotations_curry(
-                curry_paths["events"], sfreq=self.info["sfreq"]
-            )
-            self.set_annotations(annots)
-        else:
-            logger.info("Event file not found. No Annotations set.")
+        # set events / annotations
+        # format from curryreader: sample, etype, startsample, endsample
+        if isinstance(events, np.ndarray):  # if there are events
+            events = events.astype("int")
+            events = np.insert(events, 1, np.diff(events[:, 2:]).flatten(), axis=1)[
+                :, :3
+            ]
+            annot = annotations_from_events(events, sfreq)
+            self.set_annotations(annot)
 
-    def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
-        """Read a chunk of raw data."""
-        if self._raw_extras[fi]["is_ascii"]:
-            if isinstance(idx, slice):
-                idx = np.arange(idx.start, idx.stop)
-            block = np.loadtxt(
-                self.filenames[0], skiprows=start, max_rows=stop - start, ndmin=2
-            ).T
-            _mult_cal_one(data, block, idx, cals, mult)
+        # make montage
+        mont = _make_curry_montage(ch_names, ch_pos, landmarks, landmarkslabels)
+        self.set_montage(mont, on_missing="ignore")
 
-        else:
-            _read_segments_file(
-                self, data, idx, fi, start, stop, cals, mult, dtype="<f4"
-            )
+
+def _make_curry_montage(ch_names, ch_pos, landmarks, landmarkslabels):
+    ch_pos_dict = dict(zip(ch_names, ch_pos))
+    landmark_dict = dict(zip(landmarkslabels, landmarks))
+    for k in ["Nas", "RPA", "LPA"]:
+        if k not in landmark_dict.keys():
+            landmark_dict[k] = None
+    if len(landmarkslabels) > 0:
+        hpi_pos = landmarks[[i for i, n in enumerate(landmarkslabels) if "HPI" in n], :]
+    else:
+        hpi_pos = None
+    # TODO headshape (H1,2,3..)
+
+    mont = None
+    if ch_pos.shape[1] == 3:  # eeg xyz space
+        mont = make_dig_montage(
+            ch_pos=ch_pos_dict,
+            nasion=landmark_dict["Nas"],
+            lpa=landmark_dict["LPA"],
+            rpa=landmark_dict["RPA"],
+            hsp=None,
+            hpi=hpi_pos,
+            coord_frame="unknown",
+        )
+    elif ch_pos.shape[1] == 6:  # meg?
+        # TODO
+        pass
+    else:  # not recorded?
+        pass
+
+    return mont

--- a/mne/io/curry/curryreader.py
+++ b/mne/io/curry/curryreader.py
@@ -1,0 +1,629 @@
+import logging as log
+import os
+import tkinter as tk
+from tkinter import filedialog
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def read(inputfilename="", plotdata=1, verbosity=2):
+    """Curry Reader Help.
+
+    Usage:
+    currydata = read(inputfilename = '', plotdata = 1, verbosity = 2)
+
+    Inputs:
+    inputfilename:      if left empty, reader will prompt user with file selection box,
+                        otherwise specify filename with path;
+                        supported files are: raw float (cdt), ascii (cdt), legacy raw
+                        float (dat) and legacy ascii (dat)
+    plotdata:           plotdata = 0, don't show plot
+                        plotdata = 1, show plot (default)
+                        plotdata = x, with x > 1, shows and automatically closes plot
+                        after x seconds
+    verbosity:          1 is low, 2 is medium (default) and 3 is high
+
+    Output as dictionary with keys:
+    'data'              functional data matrix (e.g. EEG, MEG) with dimensions (samples,
+                        channels)
+    'info'              data information with keys:
+                        {'samples', 'channels', 'trials', 'samplingfreq'}
+    'labels'            channel labels list
+    'sensorpos'         channel locations matrix [x,y,z]
+    'events'            events matrix where every row corresponds to:
+                        [event latency, event type, event start, event stop]
+    'annotations'       events annotation list
+    'epochinfo'         epochs matrix where every row corresponds to:
+                        [number of averages, total epochs, type, accept, correct,
+                        response, response time]
+    'epochlabels'       epoch labels list
+    'impedancematrix'   impedance matrix with max size (channels, 10), corresponding to
+                        last ten impedance measurements
+    'landmarks'         functional, HPI or headshape landmarks locations
+    'landmarkslabels'   labels for functional (e.g. LPA, Nasion,...), HPI (e.g. HPI 1,
+                        HPI 2,...) or headshape (e.g. H1, H2,...) landmarks
+    'hpimatrix'         HPI-coil measurements matrix (Orion-MEG only) where every row is
+                        [measurementsample, dipolefitflag, x, y, z, deviation]
+
+    2021 - Compumedics Neuroscan
+    """
+    # configure verbosity logging
+    verbositylevel = (
+        log.WARNING
+        if verbosity == 1
+        else log.INFO
+        if verbosity == 2
+        else log.DEBUG
+        if verbosity == 3
+        else log.INFO
+    )
+
+    log.basicConfig(format="%(levelname)s: %(message)s", level=verbositylevel)
+
+    if inputfilename == "":
+        try:
+            # create root window for filedialog
+            root = tk.Tk()
+            root.withdraw()
+
+            # check if last used directory was kept
+            lastdirfilename = "lastdir.txt"
+            if os.path.isfile(lastdirfilename):
+                lastdirfile = open(lastdirfilename)
+                initdir = lastdirfile.read().strip()
+                lastdirfile.close()
+            else:
+                initdir = "/"
+
+            filepath = filedialog.askopenfilename(
+                initialdir=initdir,
+                title="Open Curry Data File",
+                filetypes=(
+                    ("All Curry files", "*.cdt *.dat"),
+                    ("cdt files", "*.cdt"),
+                    ("dat files", "*.dat"),
+                    ("all files", "*.*"),
+                ),
+            )
+            root.destroy()
+
+            lastdirfile = open(lastdirfilename, "w")
+            lastdirfile.write(os.path.dirname(filepath))
+            lastdirfile.close()
+
+            # handle cancel
+            if not filepath:
+                raise Exception
+        except Exception as _:
+            raise Exception("Unable to open file")
+    else:
+        filepath = inputfilename
+
+    # pathname = os.path.dirname(filepath)
+    filename = os.path.basename(filepath)
+
+    try:
+        basename, extension = filepath.split(".", maxsplit=1)
+    except Exception as _:
+        raise Exception("Unsupported file, choose a cdt or dat file")
+
+    parameterfile = ""
+    parameterfile2 = ""
+    labelfile = ""
+    # labelfile2 = ""
+    eventfile = ""
+    eventfile2 = ""
+    hpifile = ""
+
+    if extension == "dat":
+        parameterfile = basename + ".dap"
+        labelfile = basename + ".rs3"
+        eventfile = basename + ".cef"
+        eventfile2 = basename + ".ceo"
+    elif extension == "cdt":
+        parameterfile = filepath + ".dpa"
+        parameterfile2 = filepath + ".dpo"
+        eventfile = filepath + ".cef"
+        eventfile2 = filepath + ".ceo"
+        hpifile = filepath + ".hpi"
+    else:
+        raise Exception("Unsupported extension, choose a cdt or dat file")
+
+    log.info("Reading file %s ...", filename)
+
+    # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    # open parameter file
+
+    contents = []
+
+    try:
+        fid = open(parameterfile)
+        contents = fid.read()
+    except Exception as _:
+        log.debug("Could not open parameter file, trying alternative extension...")
+
+    # open alternative parameter file
+    if not contents:
+        try:
+            fid = open(parameterfile2)
+            contents = fid.read()
+        except FileNotFoundError:
+            raise FileNotFoundError("Parameter file not found")
+        except Exception as _:
+            raise Exception("Could not open alternative parameter file")
+
+    fid.close()
+
+    if not contents:
+        raise Exception("Parameter file is empty")
+
+    # check for compressed file format
+    ctok = "DataGuid"
+    ix = contents.find(ctok)
+    ixstart = contents.find("=", ix) + 1
+    ixstop = contents.find("\n", ix)
+
+    if ix != -1:
+        text = contents[ixstart:ixstop].strip()
+        if text == "{2912E8D8-F5C8-4E25-A8E7-A1385967DA09}":
+            raise Exception(
+                "Unsupported compressed data format, use Curry to convert file to raw "
+                "float format"
+            )
+
+    # read parameters from parameter file
+    # tokens (second line is for Curry 6 notation)
+    tok = [
+        "NumSamples",
+        "NumChannels",
+        "NumTrials",
+        "SampleFreqHz",
+        "TriggerOffsetUsec",
+        "DataFormat",
+        "DataSampOrder",
+        "SampleTimeUsec",
+        "NUM_SAMPLES",
+        "NUM_CHANNELS",
+        "NUM_TRIALS",
+        "SAMPLE_FREQ_HZ",
+        "TRIGGER_OFFSET_USEC",
+        "DATA_FORMAT",
+        "DATA_SAMP_ORDER",
+        "SAMPLE_TIME_USEC",
+    ]
+
+    # scan keywords - all keywords must exist!
+    nt = len(tok)
+    a = [0] * nt  # initialize
+    for i in range(nt):
+        ctok = tok[i]
+        ix = contents.find(ctok)
+        ixstart = contents.find("=", ix) + 1  # skip =
+        ixstop = contents.find("\n", ix)
+        if ix != -1:
+            text = contents[ixstart:ixstop].strip()
+            if text == "ASCII" or text == "CHAN":  # test for alphanumeric values
+                a[i] = 1
+            elif text.isnumeric():
+                a[i] = float(text)  # assign if it was a number
+
+    # derived variables.  numbers (1) (2) etc are the token numbers
+    nSamples = int(a[0] + a[int(0 + nt / 2)])
+    nChannels = int(a[1] + a[int(1 + nt / 2)])
+    nTrials = int(a[2] + a[int(2 + nt / 2)])
+    fFrequency = a[3] + a[int(3 + nt / 2)]
+    fOffsetUsec = a[4] + a[int(4 + nt / 2)]
+    nASCII = int(a[5] + a[int(5 + nt / 2)])
+    nMultiplex = int(a[6] + a[int(6 + nt / 2)])
+    fSampleTime = a[7] + a[int(7 + nt / 2)]
+
+    datainfo = {
+        "samples": nSamples,
+        "channels": nChannels,
+        "trials": nTrials,
+        "samplingfreq": fFrequency,
+    }
+    log.info(
+        "Number of samples = %s, number of channels = %s, number of trials/epochs = %s,"
+        " sampling frequency = %s Hz",
+        str(nSamples),
+        str(nChannels),
+        str(nTrials),
+        str(fFrequency),
+    )
+
+    if fFrequency == 0 or fSampleTime != 0:
+        fFrequency = 1000000 / fSampleTime
+
+    # try to guess number of samples based on datafile size
+    if nSamples < 0:
+        if nASCII == 1:
+            raise Exception(
+                "Number of samples cannot be guessed from ASCII data file. "
+                "Use Curry to convert this file to Raw Float format"
+            )
+        else:
+            log.warning(
+                "Number of samples not present in parameter file. It will be estimated "
+                "from size of data file"
+            )
+            fileSize = os.path.getsize(filepath)
+            nSamples = fileSize / (4 * nChannels * nTrials)
+
+    # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    # search for Impedance Values
+    tixstart = contents.find("IMPEDANCE_VALUES START_LIST")
+    tixstart = contents.find("\n", tixstart)
+    tixstop = contents.find("IMPEDANCE_VALUES END_LIST")
+
+    impedancelist = []
+
+    if tixstart != -1 and tixstop != 1:
+        text = contents[tixstart : tixstop - 1].split()
+        for imp in text:
+            if int(imp) != -1:  # skip?
+                impedancelist.append(float(imp))
+
+        # Curry records last 10 impedances
+        try:
+            impedancematrix = np.asarray(impedancelist, dtype=float).reshape(
+                int(len(impedancelist) / nChannels), nChannels
+            )
+        except ValueError:
+            impedancematrix = np.empty((int(len(impedancelist) / nChannels), nChannels))
+
+    if impedancematrix.any():
+        log.info("Found impedance matrix")
+
+    # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    # open label file
+    if extension == "dat":
+        try:
+            fid = open(labelfile)
+            contents = fid.read()
+            fid.close()
+        except Exception as _:
+            log.warning("Found no label file")
+
+    # read labels from label file
+    # initialize labels
+    labels = [""] * nChannels
+
+    for i in range(nChannels):
+        labels[i] = "EEG" + str(i + 1)
+
+    # scan for LABELS (occurs four times per channel group)
+    ix = findtokens("\nLABELS", contents)
+    nc = 0
+
+    if ix:
+        for i in range(3, len(ix), 4):  # loop over channel groups
+            text = contents[ix[i - 1] : ix[i]]
+            text = text[text.find("\n", 1) :].split()
+            last = nChannels - nc
+            numLabels = min(last, len(text))
+            for j in range(numLabels):  # loop over labels
+                labels[nc] = text[j]
+                nc += 1
+        log.info("Found channel labels")
+    else:
+        log.warning("Using dummy labels (EEG1, EEG2, ...)")
+
+    # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    # search for landmarks
+    landmarks = []
+    landmarkslabels = []
+
+    # scan for LANDMARKS (occurs four times per channel group)
+    ix = findtokens("\nLANDMARKS", contents)
+    nc = 0
+    totallandmarks = 0
+    numlandmarksgroup = []  # number of landmarks per group
+
+    if ix:
+        for i in range(
+            3, len(ix), 4
+        ):  # first pass over groups to find total of landmarks
+            text = contents[ix[i - 1] : ix[i]]
+            text = text[text.find("\n", 1) :].splitlines()[1:]
+            totallandmarks += len(text)
+            numlandmarksgroup.append(len(text))
+
+        lmpositions = np.zeros([totallandmarks, 3])
+        for i in range(3, len(ix), 4):  # loop over channel groups
+            text = contents[ix[i - 1] : ix[i]]
+            text = text[text.find("\n", 1) :].split()
+            last = totallandmarks - nc
+            numlandmarks = min(last, int(len(text) / 3))
+            for j in range(0, numlandmarks * 3, 3):
+                lmpositions[nc][:] = np.array(text[j : j + 3])
+                nc += 1
+
+        landmarks = lmpositions
+        log.info("Found landmarks")
+
+    # landmark labels
+    ix = findtokens("\nLM_REMARKS", contents)
+    landmarkslabels = [""] * totallandmarks
+    startindex = 0
+    count = 0
+
+    if ix and totallandmarks:
+        for i in range(3, len(ix), 4):  # loop over channel groups
+            text = contents[ix[i - 1] : ix[i]]
+            text = text[text.find("\n", 1) :].splitlines()[1:]
+            landmarkslabels[startindex : startindex + len(text)] = text
+            startindex += numlandmarksgroup[count]
+            count += 1
+
+    ##########################################################################
+    # read sensor locations from label file
+    sensorpos = []
+
+    # scan for SENSORS (occurs four times per channel group)
+    ix = findtokens("\nSENSORS", contents)
+    nc = 0
+
+    if ix:
+        grouppospersensor = []
+        maxpersensor = 0
+        numchanswithpos = 0
+        for i in range(
+            3, len(ix), 4
+        ):  # first pass over groups to determine sensorpos and maxpersensor sizes
+            text = contents[ix[i - 1] : ix[i]]
+            text = text[text.find("\n", 1) :].splitlines()[1:]
+            numchanswithpos += len(text)
+            pospersensor = len(text[0].split())
+            maxpersensor = max(pospersensor, maxpersensor)
+            grouppospersensor.append(pospersensor)
+
+        if (
+            (maxpersensor == 3 or maxpersensor == 6)
+            # 3 is (x,y,z) per sensor (EEG,MEG)
+            # 6 is (x,y,z,x1,y1,z1) per sensor (MEG)
+            and numchanswithpos > 0
+            and numchanswithpos <= nChannels
+        ):
+            positions = np.zeros((numchanswithpos, maxpersensor))
+
+            for group, i in enumerate(range(3, len(ix), 4)):  # loop over channel groups
+                text = contents[ix[i - 1] : ix[i]]
+                text = text[text.find("\n", 1) :].split()
+                last = nChannels - nc
+                pospersensor = grouppospersensor[group]
+                numchannels = min(last, int(len(text) / pospersensor))
+                for j in range(0, numchannels * pospersensor, pospersensor):
+                    positions[nc][:pospersensor] = np.array(text[j : j + pospersensor])
+                    nc += 1
+
+            sensorpos = positions
+            log.info("Found sensor positions")
+        else:
+            log.warning("Reading sensor positions failed (dimensions inconsistency)")
+    else:
+        log.warning("No sensor positions were found")
+
+    # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    # search for epoch labels
+    epochlabelslist = []
+
+    if extension == "dat":
+        try:
+            fid = open(parameterfile)
+            contents = fid.read()
+            fid.close()
+        except Exception as _:
+            log.warning("Found no parameter file")
+
+    ctok = "\nEPOCH_LABELS"
+    if ctok in contents:
+        tixstart = contents.find("EPOCH_LABELS START_LIST")
+        tixstart = contents.find("\n", tixstart)
+        tixstop = contents.find("EPOCH_LABELS END_LIST")
+
+        if tixstart != -1 and tixstop != 1:
+            epochlabelslist = contents[tixstart : tixstop - 1].split()
+
+    if epochlabelslist:
+        log.info("Found epoch labels")
+
+    # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    # search for epoch information
+    tixstart = contents.find("EPOCH_INFORMATION START_LIST")
+    tixstart = contents.find("\n", tixstart)
+    tixstop = contents.find("EPOCH_INFORMATION END_LIST")
+    infoelements = 7
+    epochinformation = []
+
+    if tixstart != -1 and tixstop != 1:
+        epochinformation = np.zeros((len(epochlabelslist), infoelements))
+        text = contents[tixstart : tixstop - 1].split()
+        for i in range(0, len(text), infoelements):
+            for j in range(infoelements):
+                epochinformation[int(i / infoelements)][j] = int(text[i + j])
+
+    if epochinformation.any():
+        log.info("Found epoch information")
+
+    # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    # read events from event file
+    # initialize events
+    events = []
+    annotations = []
+    contents = []
+
+    try:
+        fid = open(eventfile)
+        contents = fid.read()
+    except Exception as _:
+        log.debug("Trying event file alternative extension...")
+
+    # open alternative event file
+    if fid.closed:
+        try:
+            fid = open(eventfile2)
+            contents = fid.read()
+        except Exception as _:
+            log.debug("Found no event file")
+
+    fid.close()
+
+    if contents:
+        # scan for NUMBER_LIST (occurs five times)
+        tixstart = contents.find("NUMBER_LIST START_LIST")
+        tixstart = contents.find("\n", tixstart)
+        tixstop = contents.find("NUMBER_LIST END_LIST")
+        numberelements = 11
+        numbereventprops = 4
+
+        text = contents[tixstart : tixstop - 1].split()
+        events = np.zeros((0, numbereventprops))
+
+        for i in range(0, len(text), numberelements):
+            sample = int(text[i])
+            etype = int(text[i + 2])
+            startsample = int(text[i + 4])
+            endsample = int(text[i + 5])
+            newevent = np.array([sample, etype, startsample, endsample])
+            events = np.vstack([events, newevent])  # concat new event in events matrix
+
+        # scan for REMARK_LIST (occurs five times)
+        tixstart = contents.find("REMARK_LIST START_LIST")
+        tixstart = contents.find("\n", tixstart)
+        tixstop = contents.find("REMARK_LIST END_LIST")
+
+        if tixstart != -1 and tixstop != 1:
+            annotations = contents[tixstart : tixstop - 1].splitlines()
+
+        log.info("Found events")
+
+    # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    # read HPI coils (only Orion-MEG) if present
+
+    hpimatrix = []
+    contents = []
+
+    try:
+        fid = open(hpifile)
+        contents = fid.read()
+    except Exception as _:
+        log.debug("Found no HPI file")
+
+    fid.close()
+
+    if contents:
+        # get file version and number of coils
+        tixstart = contents.find("FileVersion")
+        tixstop = contents.find("\n", tixstart)
+        text = contents[tixstart:tixstop].split()
+        # hpifileversion = text[1]
+
+        tixstart = contents.find("NumCoils")
+        tixstop = contents.find("\n", tixstart)
+        text = contents[tixstart:tixstop].split()
+        # numberofcoils = text[1]
+
+        hpimatrix = np.loadtxt(hpifile, dtype=np.float32, skiprows=3)
+        log.info("Found HPI matrix")
+
+    # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    # % read data file
+
+    data = []
+
+    try:
+        itemstoread = nSamples * nTrials * nChannels
+        if nASCII == 1:
+            data = np.fromfile(
+                filepath, dtype=np.float32, count=itemstoread, sep=" "
+            ).reshape(nSamples * nTrials, nChannels)
+        else:
+            data = np.fromfile(
+                filepath,
+                dtype=np.float32,
+                count=itemstoread,
+            ).reshape(nSamples * nTrials, nChannels)
+    except FileNotFoundError:
+        raise FileNotFoundError("Data file not found")
+    except Exception as _:
+        raise Exception("Could not open data file")
+
+    if nSamples * nTrials != data.shape[0]:
+        log.warning(
+            "Inconsistent number of samples. File may be displayed incompletely"
+        )
+        nSamples = data.shape[0] / nTrials
+
+    # transpose?
+    if nMultiplex == 1:
+        data = data.transpose()
+
+    if plotdata > 0 and data.any():
+        time = np.linspace(
+            fOffsetUsec / 1000,
+            fOffsetUsec / 1000 + (nSamples * nTrials - 1) * 1000 / fFrequency,
+            nSamples * nTrials,
+            dtype=np.float32,
+        )
+        # avoid logging output from matplotlib
+        log.getLogger("matplotlib.font_manager").disabled = True
+        # stacked plot
+        amprange = max(abs(data.min()), abs(data.max()))
+        shift = np.linspace(
+            (nChannels - 1) * amprange * 0.3, 0, nChannels, dtype=np.float32
+        )
+        data += np.tile(shift, (nSamples * nTrials, 1))
+        fig, ax = plt.subplots()
+        ax.plot(time, data)
+        ax.set_yticks(shift)
+        ax.set_yticklabels(labels)
+        ax.set_xlabel("Time [ms]")
+        ax.set_title(filename)
+        log.info("Found data file")
+        if plotdata == 1:
+            plt.show()
+        elif plotdata > 1:
+            plt.show(block=False)
+            plt.pause(plotdata)
+            plt.close()
+        else:
+            log.warning("Invalid plotdata input: please see description in help")
+
+    # assemble output dict
+    output = {
+        "data": data,
+        "info": datainfo,
+        "labels": labels,
+        "sensorpos": sensorpos,
+        "events": events,
+        "annotations": annotations,
+        "epochinfo": epochinformation,
+        "epochlabels": epochlabelslist,
+        "impedances": impedancematrix,
+        "landmarks": landmarks,
+        "landmarkslabels": landmarkslabels,
+        "hpimatrix": hpimatrix,
+    }
+
+    return output
+
+
+def findtokens(token, contents):
+    """Findtoken.
+
+    Returns indices of token occurrences in input string contents.
+    """
+    if not token or not contents:
+        raise Exception("Invalid input for finding token")
+
+    tokenindices = []
+    index = 0
+    while index < len(contents):
+        index = contents.find(token, index)
+        if index == -1:
+            break
+        tokenindices.append(index)
+        index += len(token)
+    return tokenindices


### PR DESCRIPTION
hi all
as discussed in #13033 here a draft PR to use the official curry reader code.

in a first step i just use the reader as a module (only fixed formatting to force it past pre-commit).
it has some drawbacks (e.g. data is always loaded) and i did not implement all possible data yet (eg hpi, or epoched recordings) but in general it already works pretty well. tested it with all their example data, and one of my own recordings that didnt work in mne before.

it would be great to get some feedback how you want me to proceed with this @drammock @larsoner:
- do we want to stick with the "module" approach, leave their code untouched and work with the output (would allow easier updating when they push changes)
- or should i merge the code more thoroughly. making it easier to maintain and in terms of clarity

BACKGROUND:
the curry data reader currently cant handle all/newer curry files
plan is port code from the official curry reader into mne-python

for permission see #12855 

fixes #12795 #13033 