### PR TITLE
ENH: Add upsampling for MEG helmet surface

### DIFF
--- a/doc/changes/devel/newfeature.rst
+++ b/doc/changes/devel/newfeature.rst
@@ -1,0 +1,1 @@
+Add ``upsampling`` option to :func:`mne.make_field_maps` to allow upsampling MEG helmet surfaces for plotting, by `Eric Larson`_.

--- a/examples/visualization/mne_helmet.py
+++ b/examples/visualization/mne_helmet.py
@@ -35,9 +35,10 @@ maps = mne.make_field_map(
     ch_type="meg",
     subject="sample",
     subjects_dir=subjects_dir,
+    upsampling=2,
 )
 time = 0.083
-fig = mne.viz.create_3d_figure((256, 256))
+fig = mne.viz.create_3d_figure((512, 512), bgcolor="w", title="MNE helmet")
 mne.viz.plot_alignment(
     evoked.info,
     subject="sample",
@@ -50,13 +51,18 @@ mne.viz.plot_alignment(
     coord_frame="mri",
 )
 evoked.plot_field(
-    maps, time=time, fig=fig, time_label=None, vmax=5e-13, time_viewer=False
+    maps,
+    time=time,
+    fig=fig,
+    time_label=None,
+    vmax=5e-13,
+    time_viewer=False,
 )
 mne.viz.set_3d_view(
     fig,
     azimuth=40,
     elevation=87,
     focalpoint=(0.0, -0.01, 0.04),
-    roll=-25,
+    roll=-105,
     distance=0.55,
 )

--- a/mne/forward/_field_interpolation.py
+++ b/mne/forward/_field_interpolation.py
@@ -446,6 +446,7 @@ def make_field_map(
     origin=(0.0, 0.0, 0.04),
     n_jobs=None,
     *,
+    upsampling=1,
     head_source=("bem", "head"),
     verbose=None,
 ):
@@ -483,6 +484,9 @@ def make_field_map(
 
         .. versionadded:: 0.11
     %(n_jobs)s
+    %(helmet_upsampling)s
+
+        .. versionadded:: 1.10
     %(head_source)s
 
         .. versionadded:: 1.1
@@ -527,7 +531,7 @@ def make_field_map(
     surfs = []
     for this_type in types:
         if this_type == "meg" and meg_surf == "helmet":
-            surf = get_meg_helmet_surf(info, trans)
+            surf = get_meg_helmet_surf(info, trans, upsampling=upsampling)
         else:
             surf = get_head_surf(subject, source=head_source, subjects_dir=subjects_dir)
         surfs.append(surf)

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -2009,6 +2009,13 @@ head_source : str | list of str
     :func:`mne.get_head_surf` for more information.
 """
 
+docdict["helmet_upsampling"] = """
+upsampling : int
+    The upsampling factor to use for the helmet mesh. The default (1) does no
+    upsampling. Larger integers lead to more densely sampled helmet surfaces, and
+    the number of vertices increases as a factor of ``4**(upsampling-1)``.
+"""
+
 docdict["hitachi_fname"] = """
 fname : list | str
     Path(s) to the Hitachi CSV file(s). This should only be a list for


### PR DESCRIPTION
I didn't like that the MEG helmet surfaces were very discretized, this offers the option to upsample the helmet mesh so that the contours can be smoother. 

| No upsampling | Upsampled |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/0e7f2e43-816e-4807-96a3-2fe718977a73) | ![image](https://github.com/user-attachments/assets/95ef2b62-5f2b-4c70-b89f-d3680b9adc02) |

Still need to add some tests