### PR TITLE
ENH: Update related software list

### DIFF
--- a/doc/install/mne_tools_suite.rst
+++ b/doc/install/mne_tools_suite.rst
@@ -67,24 +67,4 @@ Getting help
 Help with installation is available through the `MNE Forum`_. See the
 :ref:`help` page for more information.
 
-
-.. LINKS:
-
-.. _MNELAB: https://github.com/cbrnr/mnelab
-.. _autoreject: https://autoreject.github.io/
-.. _alphaCSC: https://alphacsc.github.io/
-.. _pactools: https://pactools.github.io/
-.. _rsa: https://github.com/wmvanvliet/mne-rsa
-.. _microstate: https://github.com/wmvanvliet/mne_microstates
-.. _conpy: https://aaltoimaginglanguage.github.io/conpy/
-.. _eelbrain: https://eelbrain.readthedocs.io/en/stable/index.html
-.. _posthoc: https://users.aalto.fi/~vanvlm1/posthoc/python/
-.. _pyprep: https://github.com/sappelhoff/pyprep
-.. _sesameeg: https://pybees.github.io/sesameeg
-.. _invertmeeg: https://github.com/LukeTheHecker/invert
-.. _MNE-ARI: https://github.com/john-veillette/mne_ari
-.. _niseq: https://github.com/john-veillette/niseq
-.. _Meggie: https://github.com/cibr-jyu/meggie
-.. _MEM: https://github.com/multifunkim/best-python
-
 .. include:: ../links.inc

--- a/doc/sphinxext/related_software.py
+++ b/doc/sphinxext/related_software.py
@@ -29,10 +29,10 @@ from sphinx.util.display import status_iterator
 
 # If it's available on PyPI, add it to this set:
 PYPI_PACKAGES = {
-    "alphaCSC",
     "meggie",
     "niseq",
     "sesameeg",
+    "invertmeeg",
 }
 
 # If it's not available on PyPI, add it to this dict:
@@ -72,13 +72,6 @@ MANUAL_PACKAGES = {
     "dcm2niix": {
         "Home-page": "https://github.com/rordenlab/dcm2niix",
         "Summary": "DICOM to NIfTI converter",
-    },
-    # TODO: mnelab forces PySide6, it can be added to `tools/circleci_dependencies.sh`
-    # when we use PySide6 for doc building. Also its package does not set the Home-page
-    # property.
-    "mnelab": {
-        "Home-page": "https://github.com/cbrnr/mnelab",
-        "Summary": "A graphical user interface for MNE",
     },
     # TODO: these do not set a valid homepage or documentation page on PyPI
     "eeg_positions": {

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -12,6 +12,6 @@ python -m pip install --upgrade --progress-bar off \
     alphaCSC autoreject bycycle conpy emd fooof meggie \
     mne-ari mne-bids-pipeline mne-faster mne-features \
     mne-icalabel mne-lsl mne-microstates mne-nirs mne-rsa \
-    neurodsp neurokit2 niseq nitime pactools \
+    neurodsp neurokit2 niseq nitime pactools mnelab \
     plotly pycrostates pyprep pyriemann python-picard sesameeg \
     sleepecg tensorpac yasa meegkit eeg_positions wfdb invertmeeg

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -14,4 +14,4 @@ python -m pip install --upgrade --progress-bar off \
     mne-icalabel mne-lsl mne-microstates mne-nirs mne-rsa \
     neurodsp neurokit2 niseq nitime pactools \
     plotly pycrostates pyprep pyriemann python-picard sesameeg \
-    sleepecg tensorpac yasa meegkit eeg_positions wfdb
+    sleepecg tensorpac yasa meegkit eeg_positions wfdb invertmeeg


### PR DESCRIPTION
I noticed we had a few `links` in `mne_tools_suite.rst` that weren't used, probably cruft from when our old related software stuff. This PR just adds `invertmeeg` and I want to make sure that comes back green for CircleCI, then we should wait for https://github.com/mne-tools/mne-installers/pull/342 to land then restart CircleCI to make sure `alphacsc` can be parsed correctly.