### PR TITLE
Improve tests of maxwell_filter_prepare_emptyroom

### DIFF
--- a/doc/changes/devel/13208.bugfix.rst.rst
+++ b/doc/changes/devel/13208.bugfix.rst.rst
@@ -1,0 +1,1 @@
+Remove channels with potential electrode location from :func:`~mne.preprocessing.maxwell_filter_prepare_emptyroom`, by `Mathieu Scheltienne`_.

--- a/doc/changes/devel/13208.bugfix.rst.rst
+++ b/doc/changes/devel/13208.bugfix.rst.rst
@@ -1,1 +1,1 @@
-Remove channels with potential electrode location from :func:`~mne.preprocessing.maxwell_filter_prepare_emptyroom`, by `Mathieu Scheltienne`_.
+Handle channels with potential electrode location in :func:`~mne.preprocessing.maxwell_filter_prepare_emptyroom`, by `Mathieu Scheltienne`_.

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -180,7 +180,7 @@ def maxwell_filter_prepare_emptyroom(
 
     # handle montage
     montage = raw.get_montage()
-    raw_er_prepared.set_montage(montage, on_missing="ignore")
+    raw_er_prepared.set_montage(montage)
 
     # handle first_samp
     raw_er_prepared.annotations.onset += raw.first_time - raw_er_prepared.first_time

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -139,8 +139,8 @@ def maxwell_filter_prepare_emptyroom(
 
     .. note::
 
-        Note that EEG channels should not be included. If provided, a warning will be
-        emitted and they will be ignored.
+        Note that in case of dual MEG/EEG acquisition, EEG channels should not be
+        included in the emoty room recording. If provided, they will be ignored.
 
     .. versionadded:: 1.1
     """  # noqa: E501
@@ -162,6 +162,17 @@ def maxwell_filter_prepare_emptyroom(
     )
 
     raw_er_prepared = raw_er.copy()
+    # just in case of combine MEG/other modality, let's explicitly drop those and
+    # emit a warning.
+    raw_er_prepared.pick("all", exclude=("eeg", "ecog", "seeg", "dbs"))
+    if len(raw_er.ch_names) != len(raw_er_prepared.ch_names):
+        warn(
+            "The empty-room recording contained EEG-like channels. These channels "
+            "were dropped from the empty-room recording, as they are not "
+            "compatible with Maxwell filtering. If you need to, add those channels "
+            "back after the execution of 'maxwell_filter_prepare_emptyroom' from your "
+            "original empty-room recording using 'raw.add_channels'."
+        )
     del raw_er  # just to be sure
 
     # handle bads; only keep MEG channels

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -140,7 +140,7 @@ def maxwell_filter_prepare_emptyroom(
     .. note::
 
         Note that in case of dual MEG/EEG acquisition, EEG channels should not be
-        included in the emoty room recording. If provided, they will be ignored.
+        included in the empty room recording. If provided, they will be ignored.
 
     .. versionadded:: 1.1
     """  # noqa: E501

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -16,7 +16,7 @@ from .. import __version__
 from .._fiff.compensator import make_compensator
 from .._fiff.constants import FIFF, FWD
 from .._fiff.meas_info import Info, _simplify_info
-from .._fiff.pick import _picks_to_idx, pick_info, pick_types
+from .._fiff.pick import pick_info, pick_types
 from .._fiff.proc_history import _read_ctc
 from .._fiff.proj import Projection
 from .._fiff.tag import _coil_trans_to_loc, _loc_to_coil_trans
@@ -162,29 +162,6 @@ def maxwell_filter_prepare_emptyroom(
     )
 
     raw_er_prepared = raw_er.copy()
-    # just in case of combine MEG/other modality, let's explicitly drop other channels
-    # that might have a digitization and emit a warning.
-    picks = [elt for elt in ("eeg", "ecog", "seeg", "dbs") if elt in raw_er_prepared]
-    if len(picks) != 0:
-        picks = _picks_to_idx(raw_er_prepared.info, picks=picks, exclude=())
-        idx = np.setdiff1d(np.arange(raw_er_prepared.info["nchan"]), picks)
-        raw_er_prepared.pick(idx, exclude=())
-    if len(raw_er.ch_names) != len(raw_er_prepared.ch_names):
-        warn(
-            "The empty-room recording contained EEG-like channels. These channels "
-            "were dropped from the empty-room recording, as they are not "
-            "compatible with Maxwell filtering. If you need to, add those channels "
-            "back after the execution of 'maxwell_filter_prepare_emptyroom' from your "
-            "original empty-room recording using 'raw.add_channels'."
-        )
-    # apply the same channel selection to raw
-    picks = [elt for elt in ("eeg", "ecog", "seeg", "dbs") if elt in raw]
-    if len(picks) != 0:
-        picks = _picks_to_idx(
-            raw.info, picks=("eeg", "ecog", "seeg", "dbs"), exclude=()
-        )
-        idx = np.setdiff1d(np.arange(raw_er_prepared.info["nchan"]), picks)
-        raw = raw.copy().pick(idx, exclude=())
     del raw_er  # just to be sure
 
     # handle bads; only keep MEG channels
@@ -203,7 +180,7 @@ def maxwell_filter_prepare_emptyroom(
 
     # handle montage
     montage = raw.get_montage()
-    raw_er_prepared.set_montage(montage)
+    raw_er_prepared.set_montage(montage, on_missing="ignore")
 
     # handle first_samp
     raw_er_prepared.annotations.onset += raw.first_time - raw_er_prepared.first_time

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -131,11 +131,16 @@ def maxwell_filter_prepare_emptyroom(
     * Set the following properties of the empty-room recording to match the
       experimental recording:
 
-      * Montage
+      * Montage (required for the fiducials defining the head coordinate frame)
       * ``raw.first_time`` and ``raw.first_samp``
 
     * Adjust annotations according to the ``annotations`` parameter.
     * Adjust the measurement date according to the ``meas_date`` parameter.
+
+    .. note::
+
+        Note that EEG channels should not be included. If provided, a warning will be
+        emitted and they will be ignored.
 
     .. versionadded:: 1.1
     """  # noqa: E501

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1918,6 +1918,14 @@ def test_prepare_empty_room_with_eeg() -> None:
     montage_expected = raw.get_montage()
     assert raw_er_prepared.get_montage() == montage_expected
 
+    raw_er = raw_er.pick("meg")
+    assert "eeg" in raw
+    assert "eeg" not in raw_er
+    raw_er_prepared = maxwell_filter_prepare_emptyroom(raw_er=raw_er, raw=raw)
+    assert raw_er_prepared.info["dev_head_t"] == raw.info["dev_head_t"]
+    montage_expected = raw.pick("meg").get_montage()
+    assert raw_er_prepared.get_montage() == montage_expected
+
 
 @testing.requires_testing_data
 @pytest.mark.slowtest  # lots of params

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1911,10 +1911,9 @@ def test_prepare_empty_room_with_eeg() -> None:
     """Test preparation of MEG empty-room which was acquired with EEG enabled."""
     raw = read_raw_fif(raw_fname, allow_maxshield="yes", verbose=False)
     raw_er = read_raw_fif(erm_fname, allow_maxshield="yes", verbose=False)
-    with pytest.warns(RuntimeWarning, match="empty-room recording contained EEG-like"):
-        raw_er_prepared = maxwell_filter_prepare_emptyroom(raw_er=raw_er, raw=raw)
+    raw_er_prepared = maxwell_filter_prepare_emptyroom(raw_er=raw_er, raw=raw)
     assert raw_er_prepared.info["dev_head_t"] == raw.info["dev_head_t"]
-    montage_expected = raw.pick(picks="meg").get_montage()
+    montage_expected = raw.get_montage()
     assert raw_er_prepared.get_montage() == montage_expected
 
 

--- a/mne/preprocessing/tests/test_maxwell.py
+++ b/mne/preprocessing/tests/test_maxwell.py
@@ -1911,6 +1911,8 @@ def test_prepare_empty_room_with_eeg() -> None:
     """Test preparation of MEG empty-room which was acquired with EEG enabled."""
     raw = read_raw_fif(raw_fname, allow_maxshield="yes", verbose=False)
     raw_er = read_raw_fif(erm_fname, allow_maxshield="yes", verbose=False)
+    assert "eeg" in raw
+    assert "eeg" in raw_er
     raw_er_prepared = maxwell_filter_prepare_emptyroom(raw_er=raw_er, raw=raw)
     assert raw_er_prepared.info["dev_head_t"] == raw.info["dev_head_t"]
     montage_expected = raw.get_montage()

--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -46,9 +46,10 @@ python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https:/
 echo "nilearn"
 python -m pip install $STD_ARGS "git+https://github.com/nilearn/nilearn"
 
-echo "VTK"
-python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://wheels.vtk.org" vtk
-python -c "import vtk"
+# Not VTK 9.5+ compat yet
+# echo "VTK"
+# python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://wheels.vtk.org" vtk
+# python -c "import vtk"
 
 echo "PyVista"
 python -m pip install $STD_ARGS "git+https://github.com/pyvista/pyvista" trame trame-vtk trame-vuetify jupyter ipyevents ipympl


### PR DESCRIPTION
Following https://mne.discourse.group/t/montage-error-in-preparing-empty-room-for-maxfilter-for-simultaneous-meg-eeg/11089

In Geneva, an acquisition with combined MEG / EEG was done while preserving the EEG channels enabled. If you blindly apply `maxwell_filter_prepare_emptyroom` you get a failure during the `get_montage(...)` / `set_montage(...)` step. Beside the fiducial digitization, I can't think of an information from the `DigMontage` required by MaxWell filter to be set on the ER. Pointing in that direction, the existing `test` are removing EEG channels from the test files prior to running `maxwell_filter_prepare_emptyroom`.

This PR adds a tiny piece of documentation about it; and drops EEG (and ECOG, sEEG, DBS channels which might also not played nicely since they would contain some un-needed electrode location information) in `maxwell_filter_prepare_emptyroom`. It also adds a warning informing that this channel drop happens; maybe you will need to add them back at a later stage to the ER, e.g. to run ICA if you fitted it on combined MEG / EEG?

I'm not fully convinced this is the best fix, if anyone has a better proposal, please advise.