### PR TITLE
Fix Nonetype has no attribute SetVisibility in _coreg.py

### DIFF
--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -1197,7 +1197,7 @@ class CoregistrationUI(HasTraits):
                     if actor is None:
                         continue
                     actor.SetVisibility(state)
-                    
+
         self._renderer._update()
 
     def _update_actor(self, actor_name, actor):

--- a/mne/gui/_coreg.py
+++ b/mne/gui/_coreg.py
@@ -1194,7 +1194,10 @@ class CoregistrationUI(HasTraits):
                 actors = self._actors[sensor]
                 actors = actors if isinstance(actors, list) else [actors]
                 for actor in actors:
+                    if actor is None:
+                        continue
                     actor.SetVisibility(state)
+                    
         self._renderer._update()
 
     def _update_actor(self, actor_name, actor):


### PR DESCRIPTION
#### What does this implement/fix?

For some CTF data, when passing `inst='/path/to/fif'` to `mne.gui.coregistration(inst=inst)`, it will prompt "`Nonetype` has no attribute `SetVisibility`". This is because actors list contain `None`. A solution is to judge if actor in actors is `None`. (or using `try`-`except`).

I met this problem in mne-1.9.0 Windows 11 Python 3.12.10. I'm willing to provide related fif info file to reproduce the problem :)