### PR TITLE
fix typo (missing space) that messed up rst rendering

### DIFF
--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -1093,7 +1093,7 @@ class Spectrum(BaseSpectrum):
         Frequencies at which the amplitude, power, or fourier coefficients
         have been computed.
     %(info_not_none)s
-    method : ``'welch'``| ``'multitaper'``
+    method : ``'welch'`` | ``'multitaper'``
         The method used to compute the spectrum.
     nave : int | None
         The number of trials averaged together when generating the spectrum. ``None``


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d17aa8c1-cea9-4dee-ab7e-1ac8f854778e)

https://mne.tools/stable/generated/mne.time_frequency.EpochsSpectrum.html#mne.time_frequency.EpochsSpectrum