### PR TITLE
Improve error message for overwrite

### DIFF
--- a/doc/changes/devel/13233.newfeature.rst
+++ b/doc/changes/devel/13233.newfeature.rst
@@ -1,0 +1,1 @@
+Improved error message in :meth:`mne.io.Raw.save` when attempting to overwrite a file, by `Sebastian Jentschke`_

--- a/doc/changes/devel/13233.newfeature.rst
+++ b/doc/changes/devel/13233.newfeature.rst
@@ -1,1 +1,1 @@
-Improved error message in :meth:`mne.io.Raw.save` when attempting to overwrite a file, by `Sebastian Jentschke`_
+Improved error message in :meth:`mne.io.Raw.save` when attempting to overwrite a file, by :newcontrib:`Sebastian Jentschke`

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -272,6 +272,7 @@
 .. _Scott Huberty:  https://orcid.org/0000-0003-2637-031X
 .. _Sebastiaan Mathot: https://www.cogsci.nl/smathot
 .. _Sebastian Castano: https://github.com/jscastanoc
+.. _Sebastian Jentschke: https://github.com/sjentsch
 .. _Sebastian Major: https://github.com/major-s
 .. _Sena Er: https://github.com/sena-neuro
 .. _Senwen Deng: https://snwn.de

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1792,9 +1792,10 @@ class BaseRaw(
 
         split_size = _get_split_size(split_size)
         if not self.preload and fname in self.filenames:
+            extra = " and overwrite must be True" if not overwrite else ""
             raise ValueError(
-                "You cannot save data to the same file. Please use a different "
-                "filename."
+                "In order to save data to the same file, data need to be preloaded "
+                + extra
             )
 
         if self.preload:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1794,7 +1794,7 @@ class BaseRaw(
         if not self.preload and fname in self.filenames:
             extra = " and overwrite must be True" if not overwrite else ""
             raise ValueError(
-                "In order to save data to the same file, data need to be preloaded "
+                "In order to save data to the same file, data need to be preloaded"
                 + extra
             )
 


### PR DESCRIPTION
#### Reference issue (if any)

Fixes #13230.



#### What does this implement/fix?

Provides an error message that makes more clear that data need to be preloaded if one wishes to overwrite files (`save()` with the parameter `overwrite=True`).