### PR TITLE
ENH: Add plot_kwargs to report.add_trans

### DIFF
--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -265,6 +265,7 @@ DEFAULTS = dict(
         nasion_color=(0.0, 1.0, 0.0),
         rpa_color=(0.0, 0.0, 1.0),
     ),
+    report_coreg=dict(dig=True, meg=("helmet", "sensors"), show_axes=True),
     noise_std=dict(grad=5e-13, mag=20e-15, eeg=0.2e-6),
     eloreta_options=dict(eps=1e-6, max_iter=20, force_equal=False),
     depth_mne=dict(

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -518,9 +518,11 @@ def _iterate_trans_views(function, alpha, **kwargs):
 
     try:
         try:
-            return _itv(function, fig, surfaces={"head-dense": alpha}, **kwargs)
+            return _itv(function, fig, **kwargs)
         except OSError:
-            return _itv(function, fig, surfaces={"head": alpha}, **kwargs)
+            # XXX: warn here? ... why do we need this fallback?
+            kwargs["surfaces"] = {"head": alpha}
+            return _itv(function, fig, **kwargs)
     finally:
         backend._close_3d_figure(fig)
 
@@ -1597,6 +1599,7 @@ class Report:
         subject=None,
         subjects_dir=None,
         alpha=None,
+        plot_kwargs=None,
         tags=("coregistration",),
         section=None,
         coord_frame="mri",
@@ -1623,6 +1626,8 @@ class Report:
             The level of opacity to apply to the head surface. If a float, must
             be between 0 and 1 (inclusive), where 1 means fully opaque. If
             ``None``, will use the MNE-Python default value.
+        plot_kwargs : dict | None
+
         %(tags_report)s
         %(section_report)s
 
@@ -1642,6 +1647,7 @@ class Report:
             subject=subject,
             subjects_dir=subjects_dir,
             alpha=alpha,
+            plot_kwargs=plot_kwargs,
             title=title,
             section=section,
             tags=tags,
@@ -4217,6 +4223,7 @@ class Report:
         subject,
         subjects_dir,
         alpha,
+        plot_kwargs,
         title,
         section,
         tags,
@@ -4229,22 +4236,39 @@ class Report:
         if not isinstance(info, Info):
             info = read_info(info)
 
-        kwargs = dict(
+        plot_kwargs = _handle_default("report_coreg", plot_kwargs)
+
+        plot_kwargs.update(dict(
             info=info,
             trans=trans,
             subject=subject,
             subjects_dir=subjects_dir,
-            dig=True,
-            meg=["helmet", "sensors"],
-            show_axes=True,
-            coord_frame=coord_frame,
-        )
+        ))
+
+        if "coord_frame" not in plot_kwargs:
+            plot_kwargs["coord_frame"] = coord_frame
+        elif plot_kwargs["coord_frame"] != coord_frame:
+            raise ValueError("specification mismatch.")  # XXX
+
+        if alpha is not None:
+            surfaces = plot_kwargs.get("surfaces", "auto")
+            if isinstance(surfaces, dict):
+                raise ValueError("do not specify surfaces and alpha at the same time")  # XXX
+            elif isinstance(surfaces, list):
+                surfaces = {surf: alpha for surf in surfaces}
+            elif isinstance(surfaces, str) and surfaces != "auto":
+                surfaces = {surfaces: alpha}
+            else:
+                assert surfaces == "auto"  # only remaining option?
+        else:
+            pass  # if alpha is None, then we do not need any adjustments
+
         img, caption = _iterate_trans_views(
             function=plot_alignment,
             alpha=alpha,
             max_width=self.img_max_width,
             max_res=self.img_max_res,
-            **kwargs,
+            **plot_kwargs,
         )
         self._add_image(
             img=img,


### PR DESCRIPTION
- closes #13231 

> I think we could add a add_trans(..., plot_kwargs=None | dict) that we have as defaults["report_coreg"] = dict(dig=True, meg=("helmet", "sensors"), show_axes=True) and handle with _handle_default. @sappelhoff do you have time to give it a shot?

@larsoner this is a draft, is this approximately what you had in mind? 

It is a bit inconvenient, that a few plotting kwargs were already exposed (alpha, coord_frame), so they now need to be handled on top. I was also slightly confused by why we need to special handle an OSError when a dense head surface cannot be plotted. ... I left a few XXX comments in the code where I wasn't sure.

Some comments would be appreciated!