### PR TITLE
FIX: Tolerate bad coverage.xml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,7 +296,7 @@ jobs:
             CODECOV_TOKEN: fb4c4a94-72d7-4743-bb08-af25b623a29a
           command: |
             if [[ -f doc/_build/test-results/test-doc/coverage.xml ]]; then
-              bash <(curl -s https://codecov.io/bash) -f doc/_build/test-results/test-doc/coverage.xml
+              bash <(curl -s https://codecov.io/bash) -f doc/_build/test-results/test-doc/coverage.xml || true
             fi
       # Save the SG RST
       - store_artifacts:


### PR DESCRIPTION
Sometimes the CircleCI `coverage.yml` is junk (see [this failure](https://app.circleci.com/pipelines/github/mne-tools/mne-python/27424/workflows/2dfc70f1-faa7-4d56-bd9b-66a47bede8d6/jobs/73144)). Not 100% sure why but it shouldn't kill the build. We can investigate the failure separately, but it's a pretty small issue since the coverage report is not super useful yet anyway (the doctest for `doc/` is very limited!).