### PR TITLE
ENH: Add time to date stamp of mne.Report footer

### DIFF
--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -3181,7 +3181,7 @@ class Report:
                 with warnings.catch_warnings(record=True):
                     warnings.simplefilter("ignore")
                     footer_html = _html_footer_element(
-                        mne_version=MNE_VERSION, date=time.strftime("%B %d, %Y")
+                        mne_version=MNE_VERSION, date=time.strftime("%Y-%m-%d %H:%M:%S")
                     )
 
                 html = [header_html, toc_html, *self.html, footer_html]


### PR DESCRIPTION
- fixes #13243 

The footer will now read approx like this:

> Created on 2025-05-13 09:21:51 via MNE-Python ...

