### PR TITLE
DOC: link to background info on fsaverage

### DIFF
--- a/doc/documentation/datasets.rst
+++ b/doc/documentation/datasets.rst
@@ -398,7 +398,8 @@ fsaverage
 :func:`mne.datasets.fetch_fsaverage`
 
 For convenience, we provide a function to separately download and extract the
-(or update an existing) fsaverage subject.
+(or update an existing) fsaverage subject. See also the
+:ref:`background information on fsaverage <fsaverage_background>`.
 
 .. topic:: Examples
 

--- a/mne/datasets/_fsaverage/base.py
+++ b/mne/datasets/_fsaverage/base.py
@@ -12,7 +12,7 @@ FSAVERAGE_MANIFEST_PATH = Path(__file__).parent
 
 @verbose
 def fetch_fsaverage(subjects_dir=None, *, verbose=None):
-    """Fetch and update fsaverage.
+    """Fetch and update :ref:`fsaverage <fsaverage_background>`.
 
     Parameters
     ----------

--- a/tutorials/forward/10_background_freesurfer.py
+++ b/tutorials/forward/10_background_freesurfer.py
@@ -118,6 +118,8 @@ brain.add_annotation("aparc.a2009s", borders=False)
 # MNE-Python and FreeSurfer are integrated.
 #
 #
+# .. _fsaverage_background:
+#
 # 'fsaverage'
 # ===========
 #

--- a/tutorials/forward/35_eeg_no_mri.py
+++ b/tutorials/forward/35_eeg_no_mri.py
@@ -6,7 +6,7 @@ EEG forward operator with a template MRI
 ========================================
 
 This tutorial explains how to compute the forward operator from EEG data
-using the standard template MRI subject ``fsaverage``.
+using the standard template MRI subject :ref:`fsaverage <fsaverage_background>`.
 
 .. caution:: Source reconstruction without an individual T1 MRI from the
              subject will be less accurate. Do not over interpret activity


### PR DESCRIPTION
these links can be helpful for people who do not know what the "magic" "fsaverage" is, that is used so often throughout the codebase, examples, and tutorials.

It links to: https://mne.tools/stable/auto_tutorials/forward/10_background_freesurfer.html#fsaverage

![image](https://github.com/user-attachments/assets/49adf2c2-0379-41e1-a80b-93baaa64be83)
