### PR TITLE
Allow concatenating `BaseRaw` objects

### DIFF
--- a/doc/changes/dev/13263.newfeature.rst
+++ b/doc/changes/dev/13263.newfeature.rst
@@ -1,1 +1,1 @@
-It is now possible to concatenate raw objects with :func:`mne.concatenate_raws` as long as they inherit from `BaseRaw`, even if their specific types differ (e.g., :class:`~ mne.io.Raw` and :class:`~mne.io.RawArray`), by `Clemens Brunner`_.
+It is now possible to concatenate raw objects with :func:`mne.concatenate_raws` as long as they inherit from :class:`~mne.io.BaseRaw`, even if their specific types differ (e.g., :class:`~mne.io.Raw` and :class:`~mne.io.RawArray`), by `Clemens Brunner`_.

--- a/doc/changes/dev/13263.newfeature.rst
+++ b/doc/changes/dev/13263.newfeature.rst
@@ -1,0 +1,1 @@
+It is now possible to concatenate raw objects with :func:`mne.concatenate_raws` as long as they inherit from `BaseRaw`, even if their specific types differ (e.g., :class:`~ mne.io.Raw` and :class:`~mne.io.RawArray`), by `Clemens Brunner`_.

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -3239,15 +3239,6 @@ def concatenate_raws(
             on_mismatch=on_mismatch,
         )
 
-    # check if all raws have the same type
-    mixed_types = not all(type(r) is type(raws[0]) for r in raws[1:])
-    if mixed_types:
-        # preload all data before concatenating different Raw types
-        for r in raws:
-            if not r.preload:
-                r.load_data()
-        preload = True
-
     if events_list is not None:
         if len(events_list) != len(raws):
             raise ValueError(
@@ -3255,15 +3246,19 @@ def concatenate_raws(
             )
         first, last = zip(*[(r.first_samp, r.last_samp) for r in raws])
         events = concatenate_events(events_list, first, last)
-    raws[0].append(raws[1:], preload)
 
-    if mixed_types:
+    if not all(type(r) is type(raws[0]) for r in raws[1:]):
         from .array import RawArray
 
-        out = RawArray(raws[0]._data, raws[0].info, first_samp=raws[0].first_samp)
-        out.set_annotations(raws[0].annotations)
-    else:
-        out = raws[0]
+        raws = list(raws)  # local copy of list
+        if not raws[0].preload:
+            raws[0].load_data()
+        annotations = raws[0].annotations
+        raws[0] = RawArray(raws[0]._data, raws[0].info, first_samp=raws[0].first_samp)
+        raws[0].set_annotations(annotations)
+        preload = True
+    raws[0].append(raws[1:], preload)
+    out = raws[0]
 
     if events_list is None:
         return out

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -3167,7 +3167,11 @@ def _write_raw_buffer(fid, buf, cals, fmt):
 def _check_raw_compatibility(raw):
     """Ensure all instances of Raw have compatible parameters."""
     for ri in range(1, len(raw)):
-        _validate_type(raw[ri], BaseRaw, f"raw[{ri}]")
+        if not isinstance(raw[ri], (BaseRaw, _RawShell)):
+            raise ValueError(
+                f"raw[{ri}] type must match raw[0]: expected BaseRaw, got "
+                f"{type(raw[ri]).__name__}"
+            )
         for key in ("nchan", "sfreq"):
             a, b = raw[ri].info[key], raw[0].info[key]
             if a != b:
@@ -3180,7 +3184,7 @@ def _check_raw_compatibility(raw):
             mismatch = set1.symmetric_difference(set2)
             if mismatch:
                 raise ValueError(
-                    f"raw[{ri}]['info'][{kind}] do not match: {sorted(mismatch)}"
+                    f"raw[{ri}].info[{kind}] must match: {sorted(mismatch)}"
                 )
         if any(raw[ri]._cals != raw[0]._cals):
             raise ValueError(f"raw[{ri}]._cals must match")

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -3207,11 +3207,12 @@ def concatenate_raws(
 ):
     """Concatenate `~mne.io.Raw` instances as if they were continuous.
 
-    .. note:: ``raws[0]`` is modified in-place to achieve the concatenation.
-              Boundaries of the raw files are annotated bad. If you wish to use
-              the data as continuous recording, you can remove the boundary
-              annotations after concatenation (see
-              :meth:`mne.Annotations.delete`).
+    .. note:: If all ``raws`` have the same type, ``raws[0]`` is modified in-place to
+              achieve the concatenation. If the types differ, a new
+              :class:`~mne.io.RawArray` is returned and all data are preloaded
+              automatically. Boundaries of the raw files are annotated bad. If you wish
+              to use the data as continuous recording, you can remove the boundary
+              annotations after concatenation (see :meth:`mne.Annotations.delete`).
 
     Parameters
     ----------
@@ -3226,7 +3227,9 @@ def concatenate_raws(
     Returns
     -------
     raw : instance of Raw
-        The result of the concatenation (first Raw instance passed in).
+        The result of the concatenation. If all ``raws`` have the same type, the first
+        Raw instance passed in is returned (modified in-place). If the types differ, a
+        new :class:`~mne.io.RawArray` is returned.
     events : ndarray of int, shape (n_events, 3)
         The events. Only returned if ``event_list`` is not None.
     """
@@ -3238,6 +3241,15 @@ def concatenate_raws(
             on_mismatch=on_mismatch,
         )
 
+    # check if all raws have the same type
+    mixed_types = not all(type(r) is type(raws[0]) for r in raws[1:])
+    if mixed_types:
+        # preload all data before concatenating different Raw types
+        for r in raws:
+            if not r.preload:
+                r.load_data()
+        preload = True
+
     if events_list is not None:
         if len(events_list) != len(raws):
             raise ValueError(
@@ -3247,10 +3259,18 @@ def concatenate_raws(
         events = concatenate_events(events_list, first, last)
     raws[0].append(raws[1:], preload)
 
-    if events_list is None:
-        return raws[0]
+    if mixed_types:
+        from .array import RawArray
+
+        out = RawArray(raws[0]._data, raws[0].info, first_samp=raws[0].first_samp)
+        out.set_annotations(raws[0].annotations)
     else:
-        return raws[0], events
+        out = raws[0]
+
+    if events_list is None:
+        return out
+    else:
+        return out, events
 
 
 @fill_doc

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -3167,7 +3167,7 @@ def _write_raw_buffer(fid, buf, cals, fmt):
 def _check_raw_compatibility(raw):
     """Ensure all instances of Raw have compatible parameters."""
     for ri in range(1, len(raw)):
-        if not isinstance(raw[ri], type(raw[0])):
+        if not isinstance(raw[ri], BaseRaw):
             raise ValueError(f"raw[{ri}] type must match")
         for key in ("nchan", "sfreq"):
             a, b = raw[ri].info[key], raw[0].info[key]

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -3168,7 +3168,8 @@ def _check_raw_compatibility(raw):
     """Ensure all instances of Raw have compatible parameters."""
     for ri in range(1, len(raw)):
         if not isinstance(raw[ri], BaseRaw):
-            raise ValueError(f"raw[{ri}] type must match")
+            if type(raw[ri]) is not type(raw[0]):
+                raise ValueError(f"raw[{ri}] type must match")
         for key in ("nchan", "sfreq"):
             a, b = raw[ri].info[key], raw[0].info[key]
             if a != b:

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -3167,9 +3167,7 @@ def _write_raw_buffer(fid, buf, cals, fmt):
 def _check_raw_compatibility(raw):
     """Ensure all instances of Raw have compatible parameters."""
     for ri in range(1, len(raw)):
-        if not isinstance(raw[ri], BaseRaw):
-            if type(raw[ri]) is not type(raw[0]):
-                raise ValueError(f"raw[{ri}] type must match")
+        _validate_type(raw[ri], BaseRaw, f"raw[{ri}]")
         for key in ("nchan", "sfreq"):
             a, b = raw[ri].info[key], raw[0].info[key]
             if a != b:

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -488,6 +488,22 @@ def test_concatenate_raws_order():
     assert np.all(ch0 == 0)
 
 
+def test_concatenate_raws_different_subtypes(tmp_path):
+    """Test concatenating raws with different subtypes."""
+    sfreq = 100.0
+    ch_names = ["EEG 001", "EEG 002"]
+    ch_types = ["eeg"] * 2
+    info = create_info(ch_names=ch_names, sfreq=sfreq, ch_types=ch_types)
+    data = np.random.randn(len(ch_names), 1000)
+
+    raw_array = RawArray(data, info)
+    raw_array.save(tmp_path / "temp_raw.fif", overwrite=True)
+    raw_fiff = read_raw_fif(tmp_path / "temp_raw.fif", preload=True)
+
+    with pytest.warns(RuntimeWarning, match="raw files do not all have the same"):
+        concatenate_raws([raw_fiff, raw_array])
+
+
 @testing.requires_testing_data
 @pytest.mark.parametrize(
     "mod",

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -501,7 +501,10 @@ def test_concatenate_raws_different_subtypes(tmp_path):
     raw_fiff = read_raw_fif(tmp_path / "temp_raw.fif", preload=True)
 
     with pytest.warns(RuntimeWarning, match="raw files do not all have the same"):
-        concatenate_raws([raw_fiff, raw_array])
+        result = concatenate_raws([raw_fiff, raw_array])
+    assert isinstance(result, RawArray)
+    assert result.preload
+    assert result.n_times == 2 * data.shape[1]
 
 
 @testing.requires_testing_data

--- a/mne/io/fiff/tests/test_raw_fiff.py
+++ b/mne/io/fiff/tests/test_raw_fiff.py
@@ -500,8 +500,7 @@ def test_concatenate_raws_different_subtypes(tmp_path):
     raw_array.save(tmp_path / "temp_raw.fif", overwrite=True)
     raw_fiff = read_raw_fif(tmp_path / "temp_raw.fif", preload=True)
 
-    with pytest.warns(RuntimeWarning, match="raw files do not all have the same"):
-        result = concatenate_raws([raw_fiff, raw_array])
+    result = concatenate_raws([raw_fiff, raw_array])
     assert isinstance(result, RawArray)
     assert result.preload
     assert result.n_times == 2 * data.shape[1]


### PR DESCRIPTION
As reported in [this forum post](https://mne.discourse.group/t/is-there-a-hacky-way-to-concatenate-class-mne-io-edf-edf-rawedf-with-class-mne-io-array-array-rawarray/11182), `mne.concatenate_raws()` only works if all objects share the _exact_ same type. In particular, this means that it is not possible to concatenate `Raw` (an alias for `RawFIF`) and `RawArray` objects, and other types like `RawEDF`, `RawEEGLAB`, etc. do not work either. However, since all concrete types inherit from `BaseRaw`, I think we could relax the compatibility check accordingly.

The following example fails on `main`, but works on this branch:

```python
import numpy as np

import mne

sfreq = 100.0
ch_names = ["EEG 001", "EEG 002"]
ch_types = ["eeg"] * 2
info = mne.create_info(ch_names=ch_names, sfreq=sfreq, ch_types=ch_types)
data = np.random.randn(len(ch_names), 1000)

raw_array = mne.io.RawArray(data, info)
raw_array.save("temp_raw.fif", overwrite=True)
raw_fiff = mne.io.read_raw_fif("temp_raw.fif", preload=True)

mne.concatenate_raws([raw_fiff, raw_array])
```