### PR TITLE
Add a dev dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,12 @@ test_extra = [
   "statsmodels",
 ]
 
+[dependency-groups]
+dev = [
+  "mne[dev]",
+  "PySide6 != 6.7.0, != 6.8.0, != 6.8.0.1",
+]
+
 [project.urls]
 "Bug Tracker" = "https://github.com/mne-tools/mne-python/issues/"
 Documentation = "https://mne.tools/"


### PR DESCRIPTION
Add a `dev` dependency group so that `uv sync` automatically installs these dependencies.