### PR TITLE
Drop bad channel in 10_publication_figure.py

### DIFF
--- a/tutorials/visualization/10_publication_figure.py
+++ b/tutorials/visualization/10_publication_figure.py
@@ -41,7 +41,7 @@ fname_stc = data_path / "MEG" / "sample" / "sample_audvis-meg-eeg-lh.stc"
 fname_evoked = data_path / "MEG" / "sample" / "sample_audvis-ave.fif"
 
 evoked = mne.read_evokeds(fname_evoked, "Left Auditory")
-evoked.pick(picks="grad").apply_baseline((None, 0.0))
+evoked.pick(picks="grad").drop_channels(evoked.info['bads']).apply_baseline((None, 0.0))
 max_t = evoked.get_peak()[1]
 
 stc = mne.read_source_estimate(fname_stc)


### PR DESCRIPTION
If you look at [tutorial 10](https://mne.tools/dev/auto_tutorials/visualization/10_publication_figure.html), getting figures publication ready, the source space plots are empty. The clue to what's going on is in the vertical line to indicate the time of peak activation: it's in some seemingly random pre-baseline time window.

![sphx_glr_10_publication_figure_003](https://github.com/user-attachments/assets/b9af471b-0d2e-470e-ab43-eb6a2cb85d12)

The reason is that evoked.get_peak is invoked without excluding the bad channel, which has extreme amplitude. I couldn't find the version where this problem was introduced. But dropping the bad channel gives a sensible peak instead (0.8 s instead of -0.03).

I can't actually fully build this example; something is broken for me where the vertical line is never updated. However, the source spaces now show actual activation.

<img width="355" alt="Screenshot 2025-06-01 at 00 31 09" src="https://github.com/user-attachments/assets/e1c7c14f-4dc0-48df-b399-f7378ada0a04" />

Looking at this, it seems like it should be documented that `evoked.drop_channels` works in place ...

Also, 👋 