### PR TITLE
Implement data skip in samples

### DIFF
--- a/mne/_fiff/tag.py
+++ b/mne/_fiff/tag.py
@@ -361,9 +361,9 @@ def _read_old_pack(fid, tag, shape, rlims):
 
 def _read_dir_entry_struct(fid, tag, shape, rlims):
     """Read dir entry struct tag."""
-    pos = tag.pos + 16
+    pos = tag.pos
     entries = list()
-    for offset in range(1, tag.size // 16):
+    for offset in range(tag.size // 16):
         ent = _read_tag_header(fid, pos + offset * 16)
         # The position of the real tag on disk is stored in the "next" entry within the
         # directory, so we need to overwrite ent.pos. For safety let's also overwrite


### PR DESCRIPTION
#### Reference issue (if any)

None

#### What does this implement/fix?

This implements the handling of the tag FIFF_DATA_SKIP_SAMP.

#### Additional information

Fiff documentation states:
```
Data skip is a time segment where no data has been
measured. There are two ways of encoding a data skip. Currently only
only data_skip tag is supported, but any data reading routines should be
designed to handle also data_skip_samples tag. The difference is that
data_skip gives the length of the skip in number of data buffers whereas
data_skip_samples gives the length in samples.
```
This patch does it.
This is not a feature used that often, but since it is documented that way....