### PR TITLE
fix Maxwell bads filtering

### DIFF
--- a/doc/changes/devel/13280.bugfix.rst
+++ b/doc/changes/devel/13280.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug where `mne.preprocessing.maxwell.maxwell_filter_prepare_emptyroom` would not properly identify bad OPM channels by their `meg` type, by `Harrison Ritz`_.
+Fixed bug where :func:`mne.preprocessing.maxwell_filter_prepare_emptyroom` would not reliably identify bad channels by their `meg` type, by `Harrison Ritz`_.

--- a/doc/changes/devel/13280.bugfix.rst
+++ b/doc/changes/devel/13280.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where :func:`mne.preprocessing.maxwell.maxwell_filter_prepare_emptyroom` would not properly identify bad OPM channels by their `meg` type, by `Harrison Ritz`_.

--- a/doc/changes/devel/13280.bugfix.rst
+++ b/doc/changes/devel/13280.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug where :func:`mne.preprocessing.maxwell.maxwell_filter_prepare_emptyroom` would not properly identify bad OPM channels by their `meg` type, by `Harrison Ritz`_.
+Fix bug where `mne.preprocessing.maxwell.maxwell_filter_prepare_emptyroom` would not properly identify bad OPM channels by their `meg` type, by `Harrison Ritz`_.

--- a/doc/changes/devel/13280.bugfix.rst
+++ b/doc/changes/devel/13280.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed bug where :func:`mne.preprocessing.maxwell_filter_prepare_emptyroom` would not reliably identify bad channels by their `meg` type, by `Harrison Ritz`_.
+Fixed bug where :func:`mne.preprocessing.maxwell_filter_prepare_emptyroom` would not reliably identify meg channel types for matching bads across emptyroom and task, by `Harrison Ritz`_.

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -168,7 +168,10 @@ def maxwell_filter_prepare_emptyroom(
         bads = raw_er_prepared.info["bads"]
 
     # Filter to only include MEG channels
-    meg_ch_names = [raw_er_prepared.ch_names[pick] for pick in pick_types(raw_er_prepared.info, meg=True, exclude=[])]
+    meg_ch_names = [
+        raw_er_prepared.ch_names[pick]
+        for pick in pick_types(raw_er_prepared.info, meg=True, exclude=[])
+    ]
     bads = [ch_name for ch_name in bads if ch_name in meg_ch_names]
     raw_er_prepared.info["bads"] = bads
 

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -168,7 +168,7 @@ def maxwell_filter_prepare_emptyroom(
         bads = raw_er_prepared.info["bads"]
 
     # bads = [ch_name for ch_name in bads if ch_name.startswith("MEG")]
-    print('----- MNE: include bads: ', bads)
+    # print('----- MNE: include bads: ', bads)
     raw_er_prepared.info["bads"] = bads
 
     # handle dev_head_t

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -167,8 +167,9 @@ def maxwell_filter_prepare_emptyroom(
     elif bads == "keep":
         bads = raw_er_prepared.info["bads"]
 
-    # bads = [ch_name for ch_name in bads if ch_name.startswith("MEG")]
-    # print('----- MNE: include bads: ', bads)
+    # Filter to only include MEG channels
+    meg_ch_names = [raw_er_prepared.ch_names[pick] for pick in pick_types(raw_er_prepared.info, meg=True, exclude=[])]
+    bads = [ch_name for ch_name in bads if ch_name in meg_ch_names]
     raw_er_prepared.info["bads"] = bads
 
     # handle dev_head_t

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -167,7 +167,8 @@ def maxwell_filter_prepare_emptyroom(
     elif bads == "keep":
         bads = raw_er_prepared.info["bads"]
 
-    bads = [ch_name for ch_name in bads if ch_name.startswith("MEG")]
+    # bads = [ch_name for ch_name in bads if ch_name.startswith("MEG")]
+    print('----- MNE: include bads: ', bads)
     raw_er_prepared.info["bads"] = bads
 
     # handle dev_head_t


### PR DESCRIPTION
#### What does this implement/fix?

`prepare_empty_room` only includes bad channels if they are MEG channels (make sense), but it does this by looking for "MEG" in at the start of the channel name. This breaks for OPM sensors (or any sensors without this formatting).

Fixed to use `pick_types` instead.