### PR TITLE
Birthday input cast to datetime.date

### DIFF
--- a/mne/_fiff/meas_info.py
+++ b/mne/_fiff/meas_info.py
@@ -1010,6 +1010,12 @@ def _check_types(x, *, info, name, types, cast=None):
         x = cast(x)
     return x
 
+def _check_bday(birthday_input, *, info):
+    date = _check_types(birthday_input, info=info, name='subject_info["birthday"]', types=(datetime.date, None))
+    # test if we have a pd.Timestamp
+    if hasattr(date, "date"):
+        date = date.date()
+    return date
 
 class SubjectInfo(ValidatedDict):
     _attributes = {
@@ -1022,9 +1028,7 @@ class SubjectInfo(ValidatedDict):
         "middle_name": partial(
             _check_types, name='subject_info["middle_name"]', types=str
         ),
-        "birthday": partial(
-            _check_types, name='subject_info["birthday"]', types=(datetime.date, None)
-        ),
+        "birthday": partial(_check_bday),
         "sex": partial(_check_types, name='subject_info["sex"]', types=int),
         "hand": partial(_check_types, name='subject_info["hand"]', types=int),
         "weight": partial(

--- a/mne/_fiff/tests/test_meas_info.py
+++ b/mne/_fiff/tests/test_meas_info.py
@@ -779,19 +779,16 @@ def test_birthday_input():
     # Test valid date
     info = create_info(ch_names=["EEG 001"], sfreq=1000.0, ch_types="eeg")
     info["subject_info"] = {}
-    with info._unlock():
-        info["subject_info"]["birthday"] = date(2000, 1, 1)
+    info["subject_info"]["birthday"] = date(2000, 1, 1)
     assert info["subject_info"]["birthday"] == date(2000, 1, 1)
 
-    with info._unlock():
-        info["subject_info"]["birthday"] = Timestamp("2000-01-01")
+    # input a pandas Timestamp converts to datetime date
+    info["subject_info"]["birthday"] = Timestamp("2000-01-01")
     assert info["subject_info"]["birthday"] == date(2000, 1, 1)
-
 
     # Test invalid date raises error
     with pytest.raises(TypeError, match="must be a date"):
-        with info._unlock():
-            info["subject_info"]["birthday"] = "not a date"
+        info["subject_info"]["birthday"] = "not a date"
 
 
 def _complete_info(info):

--- a/mne/_fiff/tests/test_meas_info.py
+++ b/mne/_fiff/tests/test_meas_info.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 from scipy import sparse
+from pandas import Timestamp
 
 from mne import (
     Annotations,
@@ -771,6 +772,26 @@ def test_meas_date_convert(stamp, dt):
     with info._unlock():
         info["meas_date"] = meas_datetime
     assert str(dt[0]) in repr(info)
+
+
+def test_birthday_input():
+    """Test that birthday input is handled correctly."""
+    # Test valid date
+    info = create_info(ch_names=["EEG 001"], sfreq=1000.0, ch_types="eeg")
+    info["subject_info"] = {}
+    with info._unlock():
+        info["subject_info"]["birthday"] = date(2000, 1, 1)
+    assert info["subject_info"]["birthday"] == date(2000, 1, 1)
+
+    with info._unlock():
+        info["subject_info"]["birthday"] = Timestamp("2000-01-01")
+    assert info["subject_info"]["birthday"] == date(2000, 1, 1)
+
+
+    # Test invalid date raises error
+    with pytest.raises(TypeError, match="must be a date"):
+        with info._unlock():
+            info["subject_info"]["birthday"] = "not a date"
 
 
 def _complete_info(info):


### PR DESCRIPTION
#### Reference issue 
Fixes #13279.


#### What does this implement/fix?
Converts pd.Timestamp subject birthday input to datetime.date

`pandas.Timestamp` were allowed into `info['subject_info']['birthday']` because they _can_ be cast into a `datetime.date`. This was causing an issue when exporting to a FIFF file because the entry had not been converted to the right type.


#### Additional information
This seems to be specific to the birthday input, `meas_date` has the right checks to prevent pd.Timestamp inputs.