### PR TITLE
Fix: nearly invisible traces with spatial_colors=True

### DIFF
--- a/mne/viz/evoked.py
+++ b/mne/viz/evoked.py
@@ -226,6 +226,8 @@ def _rgb(x, y, z):
     rgb = np.array([x, y, z]).T
     rgb -= np.nanmin(rgb, 0)
     rgb /= np.maximum(np.nanmax(rgb, 0), 1e-16)  # avoid div by zero
+    # Reduce RGB intensity for overly light colors
+    rgb[rgb.sum(axis=1) > 2.5] = rgb[rgb.sum(axis=1) > 2.5] - 0.3    
     return rgb
 
 


### PR DESCRIPTION
#### Reference issue (if any)

Fixes #6686 #13285.

#### What does this implement/fix?

This patch modifies the `_rgb` function in `mne/viz/evoked.py` to reduce the intensity of overly light RGB colors that can occur when `spatial_colors=True` is used in PSD plots. Specifically, it checks whether the sum of RGB components is above a threshold (2.5) and reduces the brightness to improve trace visibility.

This issue was previously discussed in [Discourse thread #6572](https://mne.discourse.group/t/channels-colors-in-psd-plot/6572/5), and this fix follows the workaround suggested by @bboyth, which has been confirmed to work in MNE 1.9.0 by multiple users.

#### Additional information
None
