### PR TITLE
DOC: fix missing space, use f-strings, structure->object

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1272,13 +1272,16 @@ def _plot_topomap(
 
         # check if there is only 1 channel type, and n_chans matches the data
         ch_type = pos.get_channel_types(picks=None, unique=True)
-        info_help = "Pick Info with e.g. mne.pick_info and mne.channel_indices_by_type."
+        info_help = (
+            "Pick the Info object "
+            "(e.g., using mne.pick_info and mne.channel_indices_by_type)."
+        )
         if len(ch_type) > 1:
-            raise ValueError("Multiple channel types in Info structure. " + info_help)
+            raise ValueError(f"Multiple channel types in Info object. {info_help}")
         elif len(pos["chs"]) != data.shape[0]:
             raise ValueError(
                 f"Number of channels in the Info object ({len(pos['chs'])}) and the "
-                f"data array ({data.shape[0]}) do not match." + info_help
+                f"data array ({data.shape[0]}) do not match. {info_help}"
             )
         else:
             ch_type = ch_type.pop()


### PR DESCRIPTION
Before:

> ValueError: Number of channels in the Info object (60) and the data array (59) do not match.Pick Info with e.g. mne.pick_info and mne.channel_indices_by_type.

After:

> ValueError: Number of channels in the Info object (60) and the data array (59) do not match. Pick the Info object (e.g., using mne.pick_info and mne.channel_indices_by_type). 