### PR TITLE
doc: fix rendering typo rst docstr

### DIFF
--- a/mne/time_frequency/spectrum.py
+++ b/mne/time_frequency/spectrum.py
@@ -1380,7 +1380,7 @@ class EpochsSpectrum(BaseSpectrum, GetEpochsMixin):
         Frequencies at which the amplitude, power, or fourier coefficients
         have been computed.
     %(info_not_none)s
-    method : ``'welch'``| ``'multitaper'``
+    method : ``'welch'`` | ``'multitaper'``
         The method used to compute the spectrum.
     weights : array | None
         The weights for each taper. Only present if spectra computed with


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ddc7414e-5824-46f9-9a35-73d20e9766cd)

https://mne.tools/stable/generated/mne.time_frequency.EpochsSpectrum.html#mne.time_frequency.EpochsSpectrum