### PR TITLE
Update docstring to reflect default setting in annotations

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -164,7 +164,7 @@ intersphinx_mapping = {
     "mne_bids": ("https://mne.tools/mne-bids/stable", None),
     "mne-connectivity": ("https://mne.tools/mne-connectivity/stable", None),
     "mne-gui-addons": ("https://mne.tools/mne-gui-addons", None),
-    "picard": ("https://pierreablin.github.io/picard/", None),
+    "picard": ("https://mind-inria.github.io/picard/", None),
     "eeglabio": ("https://eeglabio.readthedocs.io/en/latest", None),
     "pybv": ("https://pybv.readthedocs.io/en/latest", None),
 }

--- a/doc/links.inc
+++ b/doc/links.inc
@@ -26,7 +26,7 @@
 .. _`MNE-ICAlabel`: https://github.com/mne-tools/mne-icalabel
 .. _`MNE-Connectivity`: https://github.com/mne-tools/mne-connectivity
 .. _`MNE-NIRS`: https://github.com/mne-tools/mne-nirs
-.. _PICARD: https://pierreablin.github.io/picard/
+.. _PICARD: https://mind-inria.github.io/picard/
 .. _OpenMEEG: https://openmeeg.github.io
 .. _openneuro-py: https://pypi.org/project/openneuro-py
 .. _EOSS2: https://chanzuckerberg.com/eoss/proposals/improving-usability-of-core-neuroscience-analysis-tools-with-mne-python

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -598,6 +598,7 @@ class Annotations:
         ----------
         %(time_format_df_raw)s
 
+        Default is ``datetime``.
             .. versionadded:: 1.7
 
         Returns

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -597,8 +597,8 @@ class Annotations:
         Parameters
         ----------
         %(time_format_df_raw)s
+            Default is ``datetime``.
 
-        Default is ``datetime``.
             .. versionadded:: 1.7
 
         Returns

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -4629,7 +4629,7 @@ time_format : str | None
     remain as float values in seconds. If ``'ms'``, time values will be rounded
     to the nearest millisecond and converted to integers. If ``'timedelta'``,
     time values will be converted to :class:`pandas.Timedelta` values. {}
-    Default is ``None``.
+    Default is ``None`` unless specified otherwise. 
 """
 
 docdict["time_format_df"] = _time_format_df_base.format("")

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -4629,7 +4629,7 @@ time_format : str | None
     remain as float values in seconds. If ``'ms'``, time values will be rounded
     to the nearest millisecond and converted to integers. If ``'timedelta'``,
     time values will be converted to :class:`pandas.Timedelta` values. {}
-    Default is ``None`` unless specified otherwise. 
+    Default is ``None`` unless specified otherwise.
 """
 
 docdict["time_format_df"] = _time_format_df_base.format("")


### PR DESCRIPTION
Fixes #13295.

#### What does this implement/fix?

I modified the base docstring to signal the potential difference in default. It seems like all the other methods do default to `None` except the one for annotations. Instead of removing the default base docstring for all the other methods, I modified it to read unless otherwise specified and then added the specification to the annotation method.


#### Additional information

<!-- Any additional information you think is important. -->
