### PR TITLE
ENH: Add on_inside kwarg to make_forward_solution

### DIFF
--- a/doc/changes/devel/newfeature.rst
+++ b/doc/changes/devel/newfeature.rst
@@ -1,0 +1,1 @@
+Added ``on_inside="raise"`` parameter to :func:`mne.forward.make_forward_solution` and :func:`mne.forward.make_forward_dipole` to control behavior when MEG sensors are inside the outer skin surface. This is useful for forward solutions that are computed with sensors just inside the outer skin surface (e.g., with some OPM coregistrations), by `Eric Larson`_.

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -839,8 +839,11 @@ def test_sensors_inside_bem():
     trans["trans"][2, 3] = 0.03
     sphere_noshell = make_sphere_model((0.0, 0.0, 0.0), None)
     sphere = make_sphere_model((0.0, 0.0, 0.0), 1.01)
-    with pytest.raises(RuntimeError, match=".* 15 MEG.*inside the scalp.*"):
-        make_forward_solution(info, trans, fname_src, fname_bem)
+    with pytest.warns(RuntimeWarning, match=".* 15 MEG.*inside the scalp.*"):
+        fwd = make_forward_solution(info, trans, fname_src, fname_bem, on_inside="warn")
+    assert fwd["nsource"] == 516
+    assert fwd["nchan"] == 42
+    assert np.isfinite(fwd["sol"]["data"]).all()
     make_forward_solution(info, trans, fname_src, fname_bem_meg)  # okay
     make_forward_solution(info, trans, fname_src, sphere_noshell)  # okay
     with pytest.raises(RuntimeError, match=".* 42 MEG.*outermost sphere sh.*"):

--- a/mne/simulation/raw.py
+++ b/mne/simulation/raw.py
@@ -46,6 +46,7 @@ from ..utils import (
     _check_preload,
     _pl,
     _validate_type,
+    _verbose_safe_false,
     check_random_state,
     logger,
     verbose,
@@ -792,7 +793,14 @@ def _iter_forward_solutions(
         info.update(projs=[], bads=[])  # Ensure no 'projs' or 'bads'
     mri_head_t, trans = _get_trans(trans)
     sensors, rr, info, update_kwargs, bem = _prepare_for_forward(
-        src, mri_head_t, info, bem, mindist, n_jobs, allow_bem_none=True, verbose=False
+        src,
+        mri_head_t,
+        info,
+        bem,
+        mindist,
+        n_jobs,
+        allow_bem_none=True,
+        verbose=_verbose_safe_false(),
     )
     del (src, mindist)
 


### PR DESCRIPTION
Closes #13272

@wadelab can you try this? The comparison in results of the deformed and non-deformed surface would be especially useful. Really just the forward solution for any sensors that are inside the surface would be most useful.

In particular I'm worried that if a sensor is very close to a vertex on the scalp surface (like 0.01 mm or something) then the volume current contribution from that vertex will be far too high in the forward solution. Maybe you can try a few scenarios:

1. With the surfaces as they are from the MRI with `on_inside="warn"` (a sensor or two end up inside the surface but okay)
2. With the surfaces deformed / shrunk near that sensor such that the surface is > 5 mm away from the sensor (no need for any `on_inside`)
3. With the surfaces deformed / shrunk near that sensor *less* such that one of the surface vertices is 0.001 mm away from the sensor (and probably `on_inside="warn"` again). This could be done for example by starting from the original best alignment, finding the MRI surface vertex closest to the sensor, and moving it to 0.001mm from the sensor location (keeping in mind coord frames etc).

I suspect (1) and (2) might be similar but that (3) will be a problem. In which case having the sensors inside might be okay but having them close to a surface vertex will not be and we should add an additional check that ensures that the sensors are also sufficiently far from any BEM mesh vertex and at least warns if they are not ...