### PR TITLE
Added high-level diagrams

### DIFF
--- a/.codeboarding/Advanced_Analysis_Decoding.md
+++ b/.codeboarding/Advanced_Analysis_Decoding.md
@@ -1,0 +1,141 @@
+```mermaid
+
+graph LR
+
+    Time_Frequency_Analysis_Core["Time-Frequency Analysis Core"]
+
+    Statistical_Analysis_Framework["Statistical Analysis Framework"]
+
+    Decoding_Machine_Learning_Utilities["Decoding & Machine Learning Utilities"]
+
+    Decoding_Algorithms["Decoding Algorithms"]
+
+    Time_Frequency_Analysis_Core -- "uses" --> Core_Data_Model
+
+    Time_Frequency_Analysis_Core -- "produces" --> Time_Frequency_Data_Models
+
+    Statistical_Analysis_Framework -- "analyzes" --> Time_Frequency_Data_Models
+
+    Statistical_Analysis_Framework -- "analyzes" --> Core_Data_Model
+
+    Decoding_Machine_Learning_Utilities -- "transforms" --> Core_Data_Model
+
+    Decoding_Machine_Learning_Utilities -- "prepares data for" --> Decoding_Algorithms
+
+    Decoding_Algorithms -- "uses" --> Decoding_Machine_Learning_Utilities
+
+    Decoding_Algorithms -- "outputs" --> Decoding_Results
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Advanced Analysis & Decoding` component in MNE-Python is a crucial part of the `Neuroscience Data Analysis Library`, providing sophisticated tools for in-depth neurophysiological data analysis. It aligns with the `Modular Design` and `Data-Centric Architecture` patterns by offering specialized modules that operate on core MNE data structures.
+
+
+
+### Time-Frequency Analysis Core
+
+This component provides the foundational data structures and algorithms for time-frequency analysis. It includes classes for representing time-frequency data (e.g., `AverageTFR`, `EpochsTFR`) and functions for decomposing signals into their time-frequency representations using various methods like Morlet wavelets, multitapers, and Stockwell transforms. This component is fundamental for understanding the spectral dynamics of neural activity.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/time_frequency/tfr.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.time_frequency.tfr` (1:1)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/time_frequency/spectrum.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.time_frequency.spectrum` (1:1)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/time_frequency/multitaper.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.time_frequency.multitaper` (1:1)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/time_frequency/_stockwell.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.time_frequency._stockwell` (1:1)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/time_frequency/csd.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.time_frequency.csd` (1:1)</a>
+
+
+
+
+
+### Statistical Analysis Framework
+
+This component offers a comprehensive suite of statistical tools, including parametric tests (t-tests, F-tests), non-parametric permutation tests, and methods for multiple comparison correction (FDR, Bonferroni). A key feature is cluster-level statistical analysis, which is essential for addressing the multiple comparisons problem in neuroimaging data by identifying significant spatio-temporal clusters. This component is fundamental for drawing statistically sound conclusions from neurophysiological data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/stats/parametric.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.stats.parametric` (1:1)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/stats/multi_comp.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.stats.multi_comp` (1:1)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/stats/permutations.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.stats.permutations` (1:1)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/stats/cluster_level.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.stats.cluster_level` (1:1)</a>
+
+
+
+
+
+### Decoding & Machine Learning Utilities
+
+This component provides a set of utility classes and functions for preparing neurophysiological data for machine learning and decoding analyses. It includes transformers for data scaling, vectorization, Power Spectral Density (PSD) estimation, and filtering. These utilities are crucial preprocessing steps that ensure data is in an optimal format for subsequent decoding algorithms. This component is fundamental for applying machine learning techniques to extract information from neural signals.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/decoding/transformer.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.decoding.transformer` (1:1)</a>
+
+
+
+
+
+### Decoding Algorithms
+
+This component implements various machine learning algorithms specifically tailored for decoding neurophysiological data. This includes spatial filtering techniques like Common Spatial Patterns (CSP) and Spatially Patterned Covariance (SPoC), as well as estimators for time-resolved and generalization decoding (e.g., `SlidingEstimator`, `GeneralizingEstimator`). It also encompasses models for continuous data, such as receptive field and time-delaying ridge regression. This component is fundamental for building predictive models of brain activity and understanding neural representations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/decoding/csp.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.decoding.csp` (1:1)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/decoding/search_light.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.decoding.search_light` (1:1)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/decoding/receptive_field.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.decoding.receptive_field` (1:1)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/decoding/time_delaying_ridge.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.decoding.time_delaying_ridge` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data_Management_Core_Models.md
+++ b/.codeboarding/Data_Management_Core_Models.md
@@ -1,0 +1,215 @@
+```mermaid
+
+graph LR
+
+    mne_io["mne.io"]
+
+    mne_io_base_BaseRaw["mne.io.base.BaseRaw"]
+
+    mne__fiff_meas_info_Info["mne._fiff.meas_info.Info"]
+
+    mne_annotations_Annotations["mne.annotations.Annotations"]
+
+    mne_epochs_Epochs["mne.epochs.Epochs"]
+
+    mne_evoked_Evoked["mne.evoked.Evoked"]
+
+    mne_cov_Covariance["mne.cov.Covariance"]
+
+    mne_datasets["mne.datasets"]
+
+    mne_datasets -- "provides data for" --> mne_io
+
+    mne_io -- "produces" --> mne_io_base_BaseRaw
+
+    mne_io_base_BaseRaw -- "contains" --> mne__fiff_meas_info_Info
+
+    mne_io_base_BaseRaw -- "contains" --> mne_annotations_Annotations
+
+    mne_epochs_Epochs -- "consumes" --> mne_io_base_BaseRaw
+
+    mne_epochs_Epochs -- "consumes" --> mne_annotations_Annotations
+
+    mne_epochs_Epochs -- "contains" --> mne__fiff_meas_info_Info
+
+    mne_evoked_Evoked -- "consumes" --> mne_epochs_Epochs
+
+    mne_evoked_Evoked -- "contains" --> mne__fiff_meas_info_Info
+
+    mne_cov_Covariance -- "consumes" --> mne_io_base_BaseRaw
+
+    mne_cov_Covariance -- "consumes" --> mne_epochs_Epochs
+
+    mne_cov_Covariance -- "contains" --> mne__fiff_meas_info_Info
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Data Management & Core Models` component in MNE-Python is fundamental to the library's operation, serving as the backbone for all neuroimaging data handling. It adheres to the "Data-Centric Architecture" pattern, where core data objects are central, and other components interact with these objects. The "Modular Design" pattern is also evident, as different data formats are handled by specific sub-modules within `mne.io`, and each core data structure is encapsulated in its own module.
+
+
+
+### mne.io
+
+This component is responsible for reading and writing various neuroimaging data formats (e.g., FIF, EDF, BrainVision, KIT). It acts as a facade for different raw data readers, providing a unified interface for loading diverse datasets.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `mne.io` (1:1)
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/io/fiff/raw.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.io.fiff.raw` (1:1)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/io/edf/edf.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.io.edf.edf` (1:1)</a>
+
+
+
+
+
+### mne.io.base.BaseRaw
+
+This is the foundational abstract class for representing continuous raw neurophysiological data. It provides common methods and attributes for all raw data types, ensuring consistency across different acquisition systems.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/io/base.py#L107-L2564" target="_blank" rel="noopener noreferrer">`mne.io.base.BaseRaw` (107:2564)</a>
+
+
+
+
+
+### mne._fiff.meas_info.Info
+
+This class stores comprehensive metadata about a neuroimaging recording, including channel names, types, sampling frequency, sensor locations, and acquisition parameters. It's crucial for correctly interpreting and processing the data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/_fiff/meas_info.py#L1170-L1966" target="_blank" rel="noopener noreferrer">`mne._fiff.meas_info.Info` (1170:1966)</a>
+
+
+
+
+
+### mne.annotations.Annotations
+
+This component manages annotations and events within the data, such as bad segments, experimental events, or physiological markers. These annotations are critical for data cleaning, epoching, and event-related analysis.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/annotations.py#L216-L915" target="_blank" rel="noopener noreferrer">`mne.annotations.Annotations` (216:915)</a>
+
+
+
+
+
+### mne.epochs.Epochs
+
+This class represents data segmented into trials or epochs, typically extracted around specific events. It's a key data structure for event-related potential (ERP) and event-related field (ERF) analysis.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/epochs.py#L3418-L3667" target="_blank" rel="noopener noreferrer">`mne.epochs.Epochs` (3418:3667)</a>
+
+
+
+
+
+### mne.evoked.Evoked
+
+This class represents averaged data across multiple epochs, typically used to visualize and analyze event-related potentials/fields. Averaging improves the signal-to-noise ratio.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/evoked.py#L96-L1400" target="_blank" rel="noopener noreferrer">`mne.evoked.Evoked` (96:1400)</a>
+
+
+
+
+
+### mne.cov.Covariance
+
+This component handles the noise covariance matrix, which is essential for source localization and inverse modeling. It characterizes the noise present in the data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/cov.py#L99-L471" target="_blank" rel="noopener noreferrer">`mne.cov.Covariance` (99:471)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/cov.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.cov.cov` (1:1)</a>
+
+
+
+
+
+### mne.datasets
+
+This component provides access to various publicly available neuroimaging datasets. These datasets are invaluable for examples, tutorials, testing, and demonstrating MNE-Python's capabilities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `mne.datasets` (1:1)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Output_Visualization.md
+++ b/.codeboarding/Output_Visualization.md
@@ -1,0 +1,245 @@
+```mermaid
+
+graph LR
+
+    Report_Generator["Report Generator"]
+
+    Interactive_Data_Browser["Interactive Data Browser"]
+
+    3D_Brain_Visualization["3D Brain Visualization"]
+
+    Abstract_Renderer["Abstract Renderer"]
+
+    Abstract_UI_Widget["Abstract UI Widget"]
+
+    Matplotlib_Figure_Wrapper["Matplotlib Figure Wrapper"]
+
+    PyVista_Renderer["PyVista Renderer"]
+
+    HTML_Templating_Utilities["HTML Templating Utilities"]
+
+    UI_Event_System["UI Event System"]
+
+    Time_Interaction_Manager["Time Interaction Manager"]
+
+    Report_Generator -- "uses" --> HTML_Templating_Utilities
+
+    Report_Generator -- "uses" --> 3D_Brain_Visualization
+
+    Interactive_Data_Browser -- "inherits from" --> Matplotlib_Figure_Wrapper
+
+    Interactive_Data_Browser -- "uses" --> UI_Event_System
+
+    3D_Brain_Visualization -- "uses" --> Abstract_Renderer
+
+    3D_Brain_Visualization -- "uses" --> Time_Interaction_Manager
+
+    Abstract_Renderer -- "is implemented by" --> PyVista_Renderer
+
+    Abstract_UI_Widget -- "is implemented by" --> concrete_UI_widget_classes
+
+    Abstract_UI_Widget -- "uses" --> UI_Event_System
+
+    Time_Interaction_Manager -- "uses" --> UI_Event_System
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+One paragraph explaining the functionality which is represented by this graph. What the main flow is and what is its purpose.
+
+
+
+### Report Generator
+
+This is the primary component for creating rich, interactive HTML reports that summarize MNE-Python analysis results. It acts as a high-level interface to aggregate various data objects, figures, and textual information into a single, shareable document.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/report/report.py#L701-L4502" target="_blank" rel="noopener noreferrer">`mne.report.Report` (701:4502)</a>
+
+
+
+
+
+### Interactive Data Browser
+
+This component offers a dynamic and interactive graphical user interface for exploring raw, epoch, and evoked neuroscience data. Users can scroll through time series, mark bad channels or epochs, and view associated plots, making it crucial for data inspection and quality control.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/viz/_mpl_figure.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.viz._mpl_figure.MNEBrowseFigure` (1:1)</a>
+
+
+
+
+
+### 3D Brain Visualization
+
+This component is dedicated to rendering and interacting with 3D brain models. It allows for the visualization of source estimates, anatomical labels, and other volumetric or surface-based data, providing a crucial tool for spatial analysis in neuroimaging.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/viz/_brain/_brain.py#L90-L4037" target="_blank" rel="noopener noreferrer">`mne.viz._brain._brain.Brain` (90:4037)</a>
+
+
+
+
+
+### Abstract Renderer
+
+This abstract component defines a standardized interface for all rendering operations, regardless of whether they are 2D (e.g., Matplotlib) or 3D (e.g., PyVista). It ensures that higher-level visualization components can interact with different graphics backends consistently, promoting modularity and extensibility.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/viz/backends/_abstract.py#L56-L612" target="_blank" rel="noopener noreferrer">`mne.viz.backends._abstract._AbstractRenderer` (56:612)</a>
+
+
+
+
+
+### Abstract UI Widget
+
+This abstract base class provides a unified API for creating and managing interactive user interface elements such as buttons, sliders, checkboxes, and text inputs. Concrete implementations exist for different UI toolkits (e.g., Jupyter's ipywidgets, PyQt6), ensuring consistent interaction across environments.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/viz/backends/_abstract.py#L620-L679" target="_blank" rel="noopener noreferrer">`mne.viz.backends._abstract._AbstractWidget` (620:679)</a>
+
+
+
+
+
+### Matplotlib Figure Wrapper
+
+This is a foundational component that encapsulates Matplotlib figures, providing common functionalities and integrating them seamlessly into the MNE-Python visualization framework. Other Matplotlib-based figures, like MNEBrowseFigure, inherit from this class.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/viz/_mpl_figure.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.viz._mpl_figure.MNEFigure` (1:1)</a>
+
+
+
+
+
+### PyVista Renderer
+
+A concrete implementation of the Abstract Renderer that utilizes the PyVista library for high-performance 3D visualization, particularly for brain surfaces and volumetric data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/viz/backends/_pyvista.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.viz.backends._pyvista._PyVistaRenderer` (1:1)</a>
+
+
+
+
+
+### HTML Templating Utilities
+
+This component provides the underlying HTML structure and rendering logic for generating rich, interactive reports. It defines templates and helper functions to embed various data representations and plots into HTML documents.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `mne.html_templates` (1:1)
+
+
+
+
+
+### UI Event System
+
+This module implements an event-driven mechanism for managing and dispatching custom UI events. It enables decoupled communication between different interactive components within the visualization subsystem, promoting flexibility and extensibility.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/viz/ui_events.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.viz.ui_events.UIEvent` (1:1)</a>
+
+
+
+
+
+### Time Interaction Manager
+
+This component is responsible for controlling and synchronizing time-based aspects across various visualizations. It manages functionalities like playback, time-point selection, and animation, which are critical for exploring dynamic neuroscience data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/viz/backends/renderer.py#L411-L586" target="_blank" rel="noopener noreferrer">`mne.viz.backends.renderer._TimeInteraction` (411:586)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Signal_Preprocessing.md
+++ b/.codeboarding/Signal_Preprocessing.md
@@ -1,0 +1,95 @@
+```mermaid
+
+graph LR
+
+    Signal_Filtering["Signal Filtering"]
+
+    Artifact_Noise_Removal["Artifact & Noise Removal"]
+
+    Signal_Filtering -- "uses" --> Data_Management_Core_Models
+
+    Artifact_Noise_Removal -- "uses" --> Data_Management_Core_Models
+
+    Signal_Filtering -- "uses" --> Processing_and_Algorithm_Modules
+
+    Artifact_Noise_Removal -- "uses" --> Processing_and_Algorithm_Modules
+
+    Signal_Filtering -- "uses" --> Utility_Modules
+
+    Artifact_Noise_Removal -- "uses" --> Utility_Modules
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+This document provides an overview of the `Signal Preprocessing` component, detailing its sub-components, their responsibilities, and their relationships within a Neuroscience Data Analysis Library.
+
+
+
+### Signal Filtering
+
+This component provides core functionalities for applying various digital filters (e.g., band-pass, low-pass, high-pass, notch) to neurophysiological data. It leverages a `FilterMixin` to integrate filtering directly into core data structures like `Raw`, `Epochs`, and `Evoked` objects, allowing for efficient in-place data manipulation. This ensures that filtering is a seamlessly integrated and fundamental operation on the primary data models.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/filter.py#L2369-L2778" target="_blank" rel="noopener noreferrer">`mne.filter.FilterMixin` (2369:2778)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/filter.py#L928-L1033" target="_blank" rel="noopener noreferrer">`mne.filter.filter_data` (928:1033)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/filter.py#L1420-L1585" target="_blank" rel="noopener noreferrer">`mne.filter.notch_filter` (1420:1585)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/filter.py#L1799-L1891" target="_blank" rel="noopener noreferrer">`mne.filter.resample` (1799:1891)</a>
+
+
+
+
+
+### Artifact & Noise Removal
+
+This component encompasses a comprehensive suite of advanced techniques for detecting, characterizing, and removing various biological and environmental artifacts and noise components from neurophysiological data. This includes methods for ocular (EOG) and cardiac (ECG) artifact removal, muscle artifact suppression, Independent Component Analysis (ICA) for source separation, Maxwell filtering (SSS) for MEG noise reduction, and bad channel interpolation. It aims to clean the data to improve the signal-to-noise ratio for subsequent analyses.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/preprocessing/ica.py#L201-L2682" target="_blank" rel="noopener noreferrer">`mne.preprocessing.ica.ICA` (201:2682)</a>
+
+- `mne.preprocessing.create_ecg_epochs` (1:1)
+
+- `mne.preprocessing.create_eog_epochs` (1:1)
+
+- `mne.preprocessing.maxwell_filter` (1:1)
+
+- `mne.preprocessing.interpolate_bad_channels` (1:1)
+
+- `mne.preprocessing.compute_proj_ecg` (1:1)
+
+- `mne.preprocessing.compute_proj_eog` (1:1)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Source_Analysis.md
+++ b/.codeboarding/Source_Analysis.md
@@ -1,0 +1,267 @@
+```mermaid
+
+graph LR
+
+    mne_bem["mne.bem"]
+
+    mne_surface["mne.surface"]
+
+    mne_transforms["mne.transforms"]
+
+    mne_coreg["mne.coreg"]
+
+    mne_source_space["mne.source_space"]
+
+    mne_forward["mne.forward"]
+
+    mne_minimum_norm["mne.minimum_norm"]
+
+    mne_inverse_sparse["mne.inverse_sparse"]
+
+    mne_beamformer["mne.beamformer"]
+
+    mne_source_estimate["mne.source_estimate"]
+
+    mne_bem -- "depends on" --> mne_surface
+
+    mne_bem -- "depends on" --> mne_transforms
+
+    mne_surface -- "depends on" --> mne_transforms
+
+    mne_coreg -- "depends on" --> mne_bem
+
+    mne_coreg -- "depends on" --> mne_source_space
+
+    mne_coreg -- "depends on" --> mne_surface
+
+    mne_coreg -- "depends on" --> mne_transforms
+
+    mne_source_space -- "depends on" --> mne_surface
+
+    mne_source_space -- "depends on" --> mne_transforms
+
+    mne_forward -- "depends on" --> mne_bem
+
+    mne_forward -- "depends on" --> mne_source_space
+
+    mne_forward -- "depends on" --> mne_transforms
+
+    mne_minimum_norm -- "depends on" --> mne_forward
+
+    mne_minimum_norm -- "depends on" --> mne_source_space
+
+    mne_inverse_sparse -- "depends on" --> mne_forward
+
+    mne_beamformer -- "depends on" --> mne_forward
+
+    mne_minimum_norm -- "produces" --> mne_source_estimate
+
+    mne_inverse_sparse -- "produces" --> mne_source_estimate
+
+    mne_beamformer -- "produces" --> mne_source_estimate
+
+    mne_source_estimate -- "depends on" --> mne_source_space
+
+    mne_source_estimate -- "depends on" --> mne_transforms
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Source Analysis` component in MNE-Python is a critical part of the neuroscience data analysis pipeline, focusing on localizing neural activity within the brain. It integrates several sub-components to achieve this, moving from anatomical data processing to the final estimation of brain activity. This analysis details the core components, their responsibilities, and interactions within the Source Analysis pipeline, highlighting their fundamental roles and interdependencies. The pipeline follows a clear flow from anatomical data processing to final source estimation, aligning with 'Layered Architecture', 'Modular Design', and 'Data-Centric Architecture' patterns where `SourceEstimate` serves as a central data model for the output.
+
+
+
+### mne.bem
+
+This component is responsible for creating and managing Boundary Element Models (BEMs). BEMs are crucial for forward modeling as they represent the different tissue layers of the head (e.g., inner skull, outer skull, scalp). These models define the conductivity properties of the head, which are essential for accurately calculating how neural currents propagate to the sensors.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/bem.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.bem` (1:1)</a>
+
+
+
+
+
+### mne.surface
+
+This component handles operations related to brain surfaces, typically derived from FreeSurfer reconstructions (e.g., cortical surfaces). It provides functionalities for reading, writing, and manipulating surface geometries, which are often used to define the potential locations of neural activity (source space).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/surface.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.surface` (1:1)</a>
+
+
+
+
+
+### mne.transforms
+
+This component provides a robust framework for handling and applying coordinate transformations between various anatomical and sensor coordinate systems (e.g., MRI, head, MEG/EEG device). It is vital for integrating data from different modalities and ensuring that all data are aligned in a common reference frame.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/transforms.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.transforms` (1:1)</a>
+
+
+
+
+
+### mne.coreg
+
+This component focuses on aligning the coordinate frames of the MEG/EEG sensor data with the MRI anatomical data. This coregistration step is critical to accurately map sensor measurements to their corresponding brain locations. It often involves interactive graphical user interfaces to refine the alignment.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/coreg.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.coreg` (1:1)</a>
+
+
+
+
+
+### mne.source_space
+
+This component defines the set of discrete locations (vertices on a surface or voxels in a volume) within the brain where neural activity is assumed to originate. It handles the creation and manipulation of these source spaces, which can be defined on the cortical surface, in the brain volume, or as a combination.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `mne.source_space` (1:1)
+
+
+
+
+
+### mne.forward
+
+This component computes the forward solution, also known as the leadfield matrix. The leadfield matrix mathematically describes how a current dipole at each source location would be measured by each sensor. It is the crucial link between the unobservable brain activity and the observable sensor data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `mne.forward` (1:1)
+
+
+
+
+
+### mne.minimum_norm
+
+This component implements various minimum norm inverse methods (e.g., MNE, dSPM, sLORETA) to estimate the distributed neural activity in the brain from sensor data. These methods aim to find the simplest source distribution that explains the observed sensor data, often favoring solutions with minimum overall energy.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `mne.minimum_norm` (1:1)
+
+
+
+
+
+### mne.inverse_sparse
+
+This component provides algorithms for sparse inverse solutions (e.g., L1-based methods like MxNE, Gamma-MAP). These methods promote focal source estimates, which can be beneficial for identifying discrete active brain regions by encouraging sparsity in the estimated source activity.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `mne.inverse_sparse` (1:1)
+
+
+
+
+
+### mne.beamformer
+
+This component implements beamforming techniques (e.g., LCMV, DICS, RAP-MUSIC) for source localization. Beamformers act as spatial filters, optimally suppressing noise and interference to estimate activity at specific brain locations. They are particularly effective at localizing deep sources and handling correlated noise.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `mne.beamformer` (1:1)
+
+
+
+
+
+### mne.source_estimate
+
+This component defines the `SourceEstimate` class and related utilities for representing the estimated neural activity in source space. This is the primary data structure for the output of source localization. It encapsulates the estimated amplitudes/currents over time and across source locations, providing a standardized way to store and manipulate source-level results.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/source_estimate.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.source_estimate` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/System_Utilities_CLI.md
+++ b/.codeboarding/System_Utilities_CLI.md
@@ -1,0 +1,97 @@
+```mermaid
+
+graph LR
+
+    Utility_Modules["Utility Modules"]
+
+    Command_Line_Interface_CLI_Tools["Command-Line Interface (CLI) Tools"]
+
+    Command_Line_Interface_CLI_Tools -- "uses" --> Utility_Modules
+
+    Utility_Modules -- "supports" --> Data_I_O_Modules
+
+    Utility_Modules -- "supports" --> Core_Data_Model
+
+    Utility_Modules -- "supports" --> Processing_and_Algorithm_Modules
+
+    Utility_Modules -- "supports" --> Visualization_Modules
+
+    Utility_Modules -- "supports" --> Dataset_Management
+
+    Utility_Modules -- "supports" --> Testing_Framework
+
+    Utility_Modules -- "supports" --> Examples_and_Tutorials
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+This overarching component provides essential support services and user interaction mechanisms for the entire MNE-Python library. It is divided into two fundamental sub-components: Utility Modules and Command-Line Interface (CLI) Tools.
+
+
+
+### Utility Modules
+
+This component serves as the foundational backbone of the MNE-Python library, offering a comprehensive collection of general-purpose helper functions, classes, and mixins. Its functionalities span critical areas such as input validation, configuration management, robust logging, testing utilities, numerical operations, and compatibility fixes. The `mne.parallel` sub-module, a key part of this component, provides tools for parallelizing computations, which is vital for performance in a neuroscience data analysis library dealing with large datasets.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/utils/_bunch.py#L12-L17" target="_blank" rel="noopener noreferrer">`mne.utils._bunch.Bunch` (12:17)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/utils/_logging.py#L299-L307" target="_blank" rel="noopener noreferrer">`mne.utils._logging.ClosingStringIO` (299:307)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/utils/progressbar.py#L21-L191" target="_blank" rel="noopener noreferrer">`mne.utils.progressbar.ProgressBar` (21:191)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/utils/mixin.py#L492-L574" target="_blank" rel="noopener noreferrer">`mne.utils.mixin.TimeMixin` (492:574)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/parallel.py#L23-L153" target="_blank" rel="noopener noreferrer">`mne.parallel.parallel_func` (23:153)</a>
+
+
+
+
+
+### Command-Line Interface (CLI) Tools
+
+This component provides a user-friendly command-line interface to various MNE-Python functionalities. It enables users to perform common neuroimaging operations directly from the terminal, facilitating scripting, automation, and seamless integration into larger data processing workflows. Acting as a facade, it simplifies complex library operations into straightforward commands, abstracting away the underlying complexities of the core MNE-Python library.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/commands/mne_anonymize.py#L25-L56" target="_blank" rel="noopener noreferrer">`mne.commands.mne_anonymize` (25:56)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/commands/mne_browse_raw.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.commands.mne_browse_raw` (1:1)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/commands/mne_compute_proj_ecg.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.commands.mne_compute_proj_ecg` (1:1)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/commands/mne_setup_forward_model.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.commands.mne_setup_forward_model` (1:1)</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/commands/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`mne.commands.utils.run` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,285 @@
+```mermaid
+
+graph LR
+
+    Data_Management_Core_Models["Data Management & Core Models"]
+
+    Signal_Preprocessing["Signal Preprocessing"]
+
+    Source_Analysis["Source Analysis"]
+
+    Advanced_Analysis_Decoding["Advanced Analysis & Decoding"]
+
+    Data_Simulation["Data Simulation"]
+
+    Output_Visualization["Output & Visualization"]
+
+    System_Utilities_CLI["System Utilities & CLI"]
+
+    Data_Management_Core_Models -- "provides raw/processed data to" --> Signal_Preprocessing
+
+    Data_Management_Core_Models -- "provides raw/processed data to" --> Source_Analysis
+
+    Data_Management_Core_Models -- "provides raw/processed data to" --> Advanced_Analysis_Decoding
+
+    Data_Management_Core_Models -- "provides raw/processed data to" --> Output_Visualization
+
+    Signal_Preprocessing -- "outputs processed data to" --> Data_Management_Core_Models
+
+    Source_Analysis -- "outputs source estimates to" --> Data_Management_Core_Models
+
+    Data_Simulation -- "outputs simulated data to" --> Data_Management_Core_Models
+
+    Data_Management_Core_Models -- "interacts with" --> System_Utilities_CLI
+
+    Data_Management_Core_Models -- "receives raw data from" --> Data_Management_Core_Models
+
+    Signal_Preprocessing -- "provides processed data to" --> Source_Analysis
+
+    Signal_Preprocessing -- "provides processed data to" --> Advanced_Analysis_Decoding
+
+    Signal_Preprocessing -- "provides processed data to" --> Output_Visualization
+
+    Signal_Preprocessing -- "interacts with" --> System_Utilities_CLI
+
+    Data_Management_Core_Models -- "receives data from" --> Data_Management_Core_Models
+
+    Signal_Preprocessing -- "receives processed data from" --> Data_Management_Core_Models
+
+    Source_Analysis -- "provides source estimates/models to" --> Advanced_Analysis_Decoding
+
+    Source_Analysis -- "provides source estimates/models to" --> Data_Simulation
+
+    Source_Analysis -- "provides anatomical/source info to" --> Output_Visualization
+
+    Source_Analysis -- "interacts with" --> System_Utilities_CLI
+
+    Advanced_Analysis_Decoding -- "outputs analysis results to" --> Output_Visualization
+
+    Advanced_Analysis_Decoding -- "interacts with" --> System_Utilities_CLI
+
+    Data_Management_Core_Models -- "receives data from" --> Data_Management_Core_Models
+
+    Signal_Preprocessing -- "receives processed data from" --> Data_Management_Core_Models
+
+    Source_Analysis -- "receives source estimates from" --> Data_Management_Core_Models
+
+    Data_Simulation -- "outputs simulated data to" --> Data_Management_Core_Models
+
+    Data_Simulation -- "interacts with" --> System_Utilities_CLI
+
+    Output_Visualization -- "interacts with" --> System_Utilities_CLI
+
+    System_Utilities_CLI -- "provides support services to" --> Data_Management_Core_Models
+
+    System_Utilities_CLI -- "provides support services to" --> Signal_Preprocessing
+
+    System_Utilities_CLI -- "provides support services to" --> Source_Analysis
+
+    System_Utilities_CLI -- "provides support services to" --> Advanced_Analysis_Decoding
+
+    System_Utilities_CLI -- "provides support services to" --> Data_Simulation
+
+    System_Utilities_CLI -- "provides support services to" --> Output_Visualization
+
+    click Data_Management_Core_Models href "https://github.com/mne-tools/mne-python/blob/main/.codeboarding//Data_Management_Core_Models.md" "Details"
+
+    click Signal_Preprocessing href "https://github.com/mne-tools/mne-python/blob/main/.codeboarding//Signal_Preprocessing.md" "Details"
+
+    click Source_Analysis href "https://github.com/mne-tools/mne-python/blob/main/.codeboarding//Source_Analysis.md" "Details"
+
+    click Advanced_Analysis_Decoding href "https://github.com/mne-tools/mne-python/blob/main/.codeboarding//Advanced_Analysis_Decoding.md" "Details"
+
+    click Output_Visualization href "https://github.com/mne-tools/mne-python/blob/main/.codeboarding//Output_Visualization.md" "Details"
+
+    click System_Utilities_CLI href "https://github.com/mne-tools/mne-python/blob/main/.codeboarding//System_Utilities_CLI.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `mne-python` architecture is designed as a comprehensive neuroscience data analysis library, emphasizing modularity, clear data flow, and specialized processing stages. The core of the system revolves around central data models that are progressively transformed and analyzed by distinct functional components.
+
+
+
+### Data Management & Core Models [[Expand]](./Data_Management_Core_Models.md)
+
+This foundational component is responsible for all aspects of data input/output (reading/writing various neuroimaging formats like FIF, EDF, BrainVision) and the definition of core in-memory data structures. It provides access to example datasets and defines the fundamental data objects (`Info`, `Annotations`, `Epochs`, `Evoked`, `Covariance`, `Raw`) that serve as the central data model for all subsequent processing and analysis stages.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `mne.io`
+
+- `mne.datasets`
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/_fiff/meas_info.py" target="_blank" rel="noopener noreferrer">`mne._fiff.meas_info`</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/annotations.py" target="_blank" rel="noopener noreferrer">`mne.annotations`</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/epochs.py" target="_blank" rel="noopener noreferrer">`mne.epochs`</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/evoked.py" target="_blank" rel="noopener noreferrer">`mne.evoked`</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/cov.py" target="_blank" rel="noopener noreferrer">`mne.cov`</a>
+
+
+
+
+
+### Signal Preprocessing [[Expand]](./Signal_Preprocessing.md)
+
+This component focuses on cleaning and preparing neurophysiological data for analysis. It includes functionalities for filtering (e.g., band-pass, notch), artifact detection and removal (e.g., ECG, EOG, muscle artifacts), Independent Component Analysis (ICA), Maxwell filtering (SSS), and bad channel interpolation. It takes raw or epoched data and outputs processed data, often updating the core data structures within the `Data Management & Core Models`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/filter.py" target="_blank" rel="noopener noreferrer">`mne.filter`</a>
+
+- `mne.preprocessing`
+
+
+
+
+
+### Source Analysis [[Expand]](./Source_Analysis.md)
+
+This comprehensive component handles the entire pipeline for localizing neural activity within the brain. It integrates functionalities for Head Modeling & Coregistration (managing anatomical data, BEM, coregistration), Source Space Definition (defining potential neural activity locations), Forward Modeling (computing the leadfield matrix), Inverse Modeling & Source Localization (estimating neural activity from sensor data), and Source Estimate Representation (defining data structures like `SourceEstimate`). It relies on anatomical information and sensor data to produce brain activity estimates.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/bem.py" target="_blank" rel="noopener noreferrer">`mne.bem`</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/coreg.py" target="_blank" rel="noopener noreferrer">`mne.coreg`</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/surface.py" target="_blank" rel="noopener noreferrer">`mne.surface`</a>
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/transforms.py" target="_blank" rel="noopener noreferrer">`mne.transforms`</a>
+
+- `mne.source_space`
+
+- `mne.forward`
+
+- `mne.minimum_norm`
+
+- `mne.inverse_sparse`
+
+- `mne.beamformer`
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/source_estimate.py" target="_blank" rel="noopener noreferrer">`mne.source_estimate`</a>
+
+
+
+
+
+### Advanced Analysis & Decoding [[Expand]](./Advanced_Analysis_Decoding.md)
+
+This component provides specialized tools for in-depth analysis of neurophysiological data beyond basic preprocessing. It includes Time-Frequency Analysis (decomposing signals into time-frequency representations), Statistical Analysis (performing statistical tests like permutation testing and cluster-level statistics), and Machine Learning & Decoding (applying machine learning techniques for decoding and encoding models). It operates on processed sensor data or source estimates to derive higher-level insights.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `mne.time_frequency`
+
+- `mne.stats`
+
+- `mne.decoding`
+
+
+
+
+
+### Data Simulation
+
+This component allows users to generate synthetic M/EEG data. It can simulate raw data, evoked responses, or source activity based on specified forward models, noise characteristics, and source dynamics. This is valuable for testing algorithms, validating methods, and exploring theoretical scenarios. It often uses models from `Source Analysis` and outputs data into the `Data Management & Core Models`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `mne.simulation`
+
+
+
+
+
+### Output & Visualization [[Expand]](./Output_Visualization.md)
+
+This component is responsible for presenting processed data and analysis results in various visual and report formats. It offers extensive plotting capabilities for 2D (e.g., topomaps, time courses) and 3D (e.g., brain surfaces, source activations) visualization of M/EEG data, anatomical structures, and source estimates. Additionally, it facilitates the generation of comprehensive HTML reports that summarize data processing and analysis workflows, including embedded plots and metadata.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `mne.viz`
+
+- `mne.report`
+
+
+
+
+
+### System Utilities & CLI [[Expand]](./System_Utilities_CLI.md)
+
+This overarching component provides essential support services and user interaction mechanisms for the entire library. It includes a collection of general-purpose helper functions, configuration management, logging, testing utilities, and compatibility fixes. The Command-Line Interface (CLI) sub-component offers a set of command-line tools for common MNE-Python operations, enabling scripting, automation, and integration into larger workflows. It supports and interacts with all other components.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `mne.utils`
+
+- <a href="https://github.com/mne-tools/mne-python/blob/main/mne/parallel.py" target="_blank" rel="noopener noreferrer">`mne.parallel`</a>
+
+- `mne.commands`
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
#### Reference issue (if any)

#### What does this implement/fix?

This PR introduces **diagram-first documentation** for the MNE-Python codebase. The aim is to provide clear, high-level visualizations of the main components and their interactions to help users, contributors, and researchers quickly understand the architecture and navigate the project efficiently. You can see how it renders here: 
https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main/mne-python

The diagrams are automatically generated and designed to reflect the key abstractions within MNE-Python, enabling faster onboarding and focused development on specific modules of interest. This approach is particularly useful given the scientific audience that often engages with the project, who may prioritize understanding methods and pipelines over code details.

A GitHub Action is included to keep the diagrams up to date with ongoing code changes, ensuring the documentation remains relevant.

#### Additional information

This is an early step towards improving project transparency and easing contributor engagement. Feedback and suggestions are welcome. Full disclosure: this tooling is part of a broader effort to explore new documentation approaches and potential startup opportunities.