### PR TITLE
ENH: Cleaner forward solution plotting options

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,7 +156,7 @@ stages:
         variables:
           DISPLAY: ':99'
           OPENBLAS_NUM_THREADS: '1'
-          TEST_OPTIONS: "--tb=short --cov=mne --cov-report=xml --cov-append -vv mne/viz/_brain mne/viz/backends mne/viz/tests/test_evoked.py mne/gui mne/report"
+          TEST_OPTIONS: "--tb=short --cov=mne --cov-report=xml --cov-append -m \"not ultraslowtest\" -vv mne/viz/_brain mne/viz/backends mne/viz/tests/test_evoked.py mne/gui mne/report"
           MNE_TEST_ALLOW_SKIP: '^.*(PySide6 causes segfaults).*$'
         steps:
           - bash: ./tools/setup_xvfb.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,7 +156,7 @@ stages:
         variables:
           DISPLAY: ':99'
           OPENBLAS_NUM_THREADS: '1'
-          TEST_OPTIONS: "--tb=short --cov=mne --cov-report=xml --cov-append -m \"not ultraslowtest\" -vv mne/viz/_brain mne/viz/backends mne/viz/tests/test_evoked.py mne/gui mne/report"
+          TEST_OPTIONS: "--tb=short --cov=mne --cov-report=xml --cov-append -m 'not ultraslowtest' -vv mne/viz/_brain mne/viz/backends mne/viz/tests/test_evoked.py mne/gui mne/report"
           MNE_TEST_ALLOW_SKIP: '^.*(PySide6 causes segfaults).*$'
         steps:
           - bash: ./tools/setup_xvfb.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,7 +156,7 @@ stages:
         variables:
           DISPLAY: ':99'
           OPENBLAS_NUM_THREADS: '1'
-          TEST_OPTIONS: "--tb=short --cov=mne --cov-report=xml --cov-append -m 'not ultraslowtest' -vv mne/viz/_brain mne/viz/backends mne/viz/tests/test_evoked.py mne/gui mne/report"
+          TEST_OPTIONS: "--tb=short --cov=mne --cov-report=xml --cov-append -vv mne/viz/_brain mne/viz/backends mne/viz/tests/test_evoked.py mne/gui mne/report"
           MNE_TEST_ALLOW_SKIP: '^.*(PySide6 causes segfaults).*$'
         steps:
           - bash: ./tools/setup_xvfb.sh
@@ -198,7 +198,7 @@ stages:
               set -eo pipefail
               mne sys_info -pd
               mne sys_info -pd | grep "qtpy .* (PyQt6=.*)$"
-              PYTEST_QT_API=PyQt6 pytest ${TEST_OPTIONS}
+              PYTEST_QT_API=PyQt6 pytest -m "not ultraslowtest" ${TEST_OPTIONS}
               python -m pip uninstall -yq PyQt6 PyQt6-sip PyQt6-Qt6
             displayName: 'PyQt6'
           - bash: |
@@ -206,7 +206,7 @@ stages:
               python -m pip install "PySide6!=6.8.0,!=6.8.0.1,!=6.9.1"
               mne sys_info -pd
               mne sys_info -pd | grep "qtpy .* (PySide6=.*)$"
-              PYTEST_QT_API=PySide6 pytest ${TEST_OPTIONS}
+              PYTEST_QT_API=PySide6 pytest -m "not ultraslowtest" ${TEST_OPTIONS}
               python -m pip uninstall -yq PySide6
             displayName: 'PySide6'
           # PyQt5 leaves cruft behind, so run it last
@@ -215,7 +215,7 @@ stages:
               python -m pip install PyQt5
               mne sys_info -pd
               mne sys_info -pd | grep "qtpy .* (PyQt5=.*)$"
-              PYTEST_QT_API=PyQt5 pytest ${TEST_OPTIONS}
+              PYTEST_QT_API=PyQt5 pytest -m "not ultraslowtest" ${TEST_OPTIONS}
               python -m pip uninstall -yq PyQt5 PyQt5-sip PyQt5-Qt5
             displayName: 'PyQt5'
           # Coverage

--- a/mne/_fiff/tests/test_constants.py
+++ b/mne/_fiff/tests/test_constants.py
@@ -10,6 +10,7 @@ import zipfile
 import numpy as np
 import pooch
 import pytest
+from flaky import flaky
 
 from mne._fiff.constants import (
     FIFF,
@@ -117,7 +118,9 @@ _aliases = dict(
 )
 
 
+@flaky
 @requires_good_network
+@pytest.mark.ultraslowtest  # not that slow, just doesn't need to run very often
 def test_constants(tmp_path):
     """Test compensation."""
     fname = "fiff.zip"

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1019,7 +1019,7 @@ def get_fitting_dig(info, dig_kinds="auto", exclude_frontal=True, verbose=None):
     .. versionadded:: 0.14
     """
     _validate_type(info, "info")
-    if info["dig"] is None:
+    if info.get("dig", None) is None:  # "dig" can be missing for fwd/inv
         raise RuntimeError(
             'Cannot fit headshape without digitization, info["dig"] is None'
         )

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -84,12 +84,13 @@ collect_ignore = ["export/_brainvision.py", "export/_eeglab.py", "export/_edf.py
 def pytest_configure(config: pytest.Config):
     """Configure pytest options."""
     # Markers
+    # can be queried with `pytest --markers` for example
     for marker in (
-        "slowtest",
-        "ultraslowtest",
-        "pgtest",
-        "pvtest",
-        "allow_unclosed",
+        "slowtest: mark a test as slow",
+        "ultraslowtest: mark a test as ultraslow or to be run rarely",
+        "pgtest: mark a test as relevant for mne-qt-browser",
+        "pvtest: mark a test as relevant for pyvistaqt",
+        "allow_unclosed: allow unclosed pyvistaqt instances",
     ):
         config.addinivalue_line("markers", marker)
 
@@ -201,6 +202,13 @@ def pytest_configure(config: pytest.Config):
         warning_line = warning_line.strip()
         if warning_line and not warning_line.startswith("#"):
             config.addinivalue_line("filterwarnings", warning_line)
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]):
+    """Add slowtest marker automatically to anything marked ultraslow."""
+    for item in items:
+        if len(list(item.iter_markers("ultraslowtest"))):
+            item.add_marker(pytest.mark.slowtest)
 
 
 # Have to be careful with autouse=True, but this is just an int comparison
@@ -1197,7 +1205,8 @@ def pytest_runtest_makereport(item, call):
     outcome = yield
     rep: pytest.TestReport = outcome.get_result()
     item.stash.setdefault(_phase_report_key, {})[rep.when] = rep
-    _modify_report_skips(rep)
+    if rep.outcome == "passed":  # only check for skips etc. if otherwise green
+        _modify_report_skips(rep)
     return rep
 
 

--- a/mne/datasets/tests/test_datasets.py
+++ b/mne/datasets/tests/test_datasets.py
@@ -175,7 +175,7 @@ def test_downloads(tmp_path, monkeypatch, capsys):
 
 
 @flaky(max_runs=3)
-@pytest.mark.slowtest
+@pytest.mark.ultraslowtest  # not really ultraslow, but flakes out a lot
 @testing.requires_testing_data
 @requires_good_network
 def test_fetch_parcellations(tmp_path):

--- a/mne/html_templates/report/forward.html.jinja
+++ b/mne/html_templates/report/forward.html.jinja
@@ -2,4 +2,5 @@
 {% block html_content %}
 {{repr | safe}}
 {{sensitivity_maps | safe}}
+{{source_space | safe}}
 {% endblock html_content %}

--- a/mne/html_templates/report/image.html.jinja
+++ b/mne/html_templates/report/image.html.jinja
@@ -1,4 +1,6 @@
+{% if not embedded %}
 {% extends "section.html.jinja" %}
+{% endif %}
 {% block html_content %}
       <figure class="figure mx-auto d-block">
         {% if image_format == 'svg' %}

--- a/mne/preprocessing/tests/test_fine_cal.py
+++ b/mne/preprocessing/tests/test_fine_cal.py
@@ -89,7 +89,7 @@ def test_compute_fine_cal(kind):
         cl["grad"] = (0.0, 0.1)
         gwoma = [48, 52]
         ggoma = [13, 82]
-        ggwma = [13, 120]
+        ggwma = [13, 135]
         sfs = [34, 35, 27, 28, 50, 53, 75, 79]  # ours is better!
         cl3 = [-0.3, -0.1]
     raw = read_raw_fif(erm)

--- a/mne/preprocessing/tests/test_fine_cal.py
+++ b/mne/preprocessing/tests/test_fine_cal.py
@@ -88,7 +88,7 @@ def test_compute_fine_cal(kind):
         angle_limit = 10
         cl["grad"] = (0.0, 0.1)
         gwoma = [48, 52]
-        ggoma = [13, 67]
+        ggoma = [13, 82]
         ggwma = [13, 120]
         sfs = [34, 35, 27, 28, 50, 53, 75, 79]  # ours is better!
         cl3 = [-0.3, -0.1]

--- a/mne/report/report.py
+++ b/mne/report/report.py
@@ -42,8 +42,9 @@ from ..parallel import parallel_func
 from ..preprocessing.ica import read_ica
 from ..proj import read_proj
 from ..source_estimate import SourceEstimate, read_source_estimate
+from ..source_space._source_space import _ensure_src
 from ..surface import dig_mri_distances
-from ..transforms import Transform, _find_trans, read_trans
+from ..transforms import _find_trans
 from ..utils import (
     _check_ch_locs,
     _check_fname,
@@ -188,11 +189,14 @@ def _html_toc_element(*, titles, dom_ids, tags):
     return _renderer("toc.html.jinja")(titles=titles, dom_ids=dom_ids, tags=tags)
 
 
-def _html_forward_sol_element(*, id_, repr_, sensitivity_maps, title, tags):
+def _html_forward_sol_element(
+    *, id_, repr_, sensitivity_maps, source_space, title, tags
+):
     return _renderer("forward.html.jinja")(
         id=id_,
         repr=repr_,
         sensitivity_maps=sensitivity_maps,
+        source_space=source_space,
         tags=tags,
         title=title,
     )
@@ -200,7 +204,11 @@ def _html_forward_sol_element(*, id_, repr_, sensitivity_maps, title, tags):
 
 def _html_inverse_operator_element(*, id_, repr_, source_space, title, tags):
     return _renderer("inverse.html.jinja")(
-        id=id_, repr=repr_, source_space=source_space, tags=tags, title=title
+        id=id_,
+        repr=repr_,
+        source_space=source_space,
+        tags=tags,
+        title=title,
     )
 
 
@@ -228,7 +236,17 @@ def _html_slider_element(
 
 
 def _html_image_element(
-    *, id_, img, image_format, caption, show, div_klass, img_klass, title, tags
+    *,
+    id_,
+    img,
+    image_format,
+    caption,
+    show,
+    div_klass,
+    img_klass,
+    title,
+    tags,
+    embedded=False,
 ):
     return _renderer("image.html.jinja")(
         id=id_,
@@ -239,6 +257,7 @@ def _html_image_element(
         image_format=image_format,
         div_klass=div_klass,
         img_klass=img_klass,
+        embedded=embedded,
         show="show" if show else "",
     )
 
@@ -584,21 +603,24 @@ def _itv(function, fig, *, max_width=MAX_IMG_WIDTH, max_res=MAX_IMG_RES, **kwarg
         [np.concatenate(images[:5], axis=1), np.concatenate(images[5:], axis=1)], axis=0
     )
 
-    try:
-        dists = dig_mri_distances(
-            info=kwargs["info"],
-            trans=kwargs["trans"],
-            subject=kwargs["subject"],
-            subjects_dir=kwargs["subjects_dir"],
-            on_defects="ignore",
-        )
-        caption = (
-            f"Average distance from {len(dists)} digitized points to "
-            f"head: {1e3 * np.mean(dists):.2f} mm"
-        )
-    except BaseException as e:
-        caption = "Distances could not be calculated from digitized points"
-        warn(f"{caption}: {e}")
+    if "info" in kwargs:  # fwd/inv do not have dig points
+        try:
+            dists = dig_mri_distances(
+                info=kwargs["info"],
+                trans=kwargs["trans"],
+                subject=kwargs["subject"],
+                subjects_dir=kwargs["subjects_dir"],
+                on_defects="ignore",
+            )
+            caption = (
+                f"Average distance from {len(dists)} digitized points to "
+                f"head: {1e3 * np.mean(dists):.2f} mm"
+            )
+        except BaseException as e:
+            caption = "Distances could not be calculated from digitized points"
+            warn(f"{caption}: {e}")
+    else:
+        caption = None
     img = _fig_to_img(images, image_format="png", max_width=max_width, max_res=max_res)
 
     return img, caption
@@ -1523,6 +1545,7 @@ class Report:
         *,
         subject=None,
         subjects_dir=None,
+        plot=False,
         tags=("forward-solution",),
         section=None,
         replace=False,
@@ -1536,12 +1559,14 @@ class Report:
         title : str
             The title corresponding to forward solution.
         subject : str | None
-            The name of the FreeSurfer subject ``forward`` belongs to. If
-            provided, the sensitivity maps of the forward solution will
-            be visualized. If ``None``, will use the value of ``subject``
-            passed on report creation. If supplied, also pass ``subjects_dir``.
+            The name of the FreeSurfer subject ``forward`` belongs to.
+            If ``None``, will use the value of ``subject`` passed on report creation.
         subjects_dir : path-like | None
             The FreeSurfer ``SUBJECTS_DIR``.
+        plot : bool
+            If True, plot the source space of the forward solution.
+
+            .. versionadded:: 1.10
         %(tags_report)s
         %(section_report)s
 
@@ -1563,6 +1588,7 @@ class Report:
             section=section,
             tags=tags,
             replace=replace,
+            plot=plot,
         )
 
     @fill_doc
@@ -1574,6 +1600,7 @@ class Report:
         subject=None,
         subjects_dir=None,
         trans=None,
+        plot=False,
         tags=("inverse-operator",),
         section=None,
         replace=False,
@@ -1587,15 +1614,18 @@ class Report:
         title : str
             The title corresponding to the inverse operator object.
         subject : str | None
-            The name of the FreeSurfer subject ``inverse_op`` belongs to. If
-            provided, the source space the inverse solution is based on will
-            be visualized. If ``None``, will use the value of ``subject``
-            passed on report creation. If supplied, also pass ``subjects_dir``
-            and ``trans``.
+            The name of the FreeSurfer subject ``inverse_op`` belongs to
+            If ``None``, will use the value of ``subject``
+            passed on report creation.
         subjects_dir : path-like | None
             The FreeSurfer ``SUBJECTS_DIR``.
         trans : path-like | instance of Transform | None
-            The ``head -> MRI`` transformation for ``subject``.
+            Deprecated and will be removed in 1.11.
+            The trans stored in the inverse operator will be used instead.
+        plot : bool
+            If True, plot the source space of the inverse operator.
+
+            .. versionadded:: 1.10
         %(tags_report)s
         %(section_report)s
 
@@ -1607,19 +1637,19 @@ class Report:
         .. versionadded:: 0.24.0
         """
         tags = _check_tags(tags)
-
-        if (subject is not None and trans is None) or (
-            trans is not None and subject is None
-        ):
-            raise ValueError("Please pass subject AND trans, or neither.")
-
+        if trans is not None:
+            warn(
+                "trans is deprecated and will be removed in 1.11, do not pass it "
+                "to add_inverse_operator",
+                category=FutureWarning,
+            )
         self._add_inverse_operator(
             inverse_operator=inverse_operator,
             subject=subject,
             subjects_dir=subjects_dir,
-            trans=trans,
             title=title,
             image_format=self.image_format,
+            plot=plot,
             section=section,
             tags=tags,
             replace=replace,
@@ -2833,6 +2863,7 @@ class Report:
         on_error,
         stc_plot_kwargs,
         topomap_kwargs,
+        plot_src,
     ):
         """Parallel process in batch mode."""
         assert self.data_path is not None
@@ -2856,10 +2887,15 @@ class Report:
                         title=title,
                         subject=self.subject,
                         subjects_dir=self.subjects_dir,
+                        plot=plot_src,
                     )
                 elif _endswith(fname, "inv"):
                     # XXX if we pass trans, we can plot the source space, too…
-                    self.add_inverse_operator(inverse_operator=fname, title=title)
+                    self.add_inverse_operator(
+                        inverse_operator=fname,
+                        title=title,
+                        plot=plot_src,
+                    )
                 elif _endswith(fname, "ave"):
                     evokeds = read_evokeds(fname)
                     titles = [f"{Path(fname).name}: {e.comment}" for e in evokeds]
@@ -2936,6 +2972,7 @@ class Report:
         on_error="warn",
         image_format=None,
         render_bem=True,
+        plot_src=False,
         n_time_points_evokeds=None,
         n_time_points_stcs=None,
         raw_butterfly=True,
@@ -2977,6 +3014,11 @@ class Report:
             If True (default), try to render the BEM.
 
             .. versionadded:: 0.16
+        plot_src : bool
+            If True (default False), plot the source space when adding a forward
+            or inverse.
+
+            .. versionadded:: 1.10
         n_time_points_evokeds, n_time_points_stcs : int | None
             The number of equidistant time points to render for :class:`~mne.Evoked`
             and :class:`~mne.SourceEstimate` data, respectively. If ``None``,
@@ -3096,6 +3138,7 @@ class Report:
                 on_error=on_error,
                 stc_plot_kwargs=stc_plot_kwargs,
                 topomap_kwargs=topomap_kwargs,
+                plot_src=plot_src,
             )
             for fname in np.array_split(fnames, n_jobs)
         )
@@ -3583,6 +3626,7 @@ class Report:
         subjects_dir,
         title,
         image_format,
+        plot,
         section,
         tags,
         replace,
@@ -3592,19 +3636,26 @@ class Report:
             forward = read_forward_solution(forward)
 
         subject = self.subject if subject is None else subject
-        subjects_dir = self.subjects_dir if subjects_dir is None else subjects_dir
+        subject = forward["src"][0]["subject_his_id"] if subject is None else subject
 
         # XXX Todo
         # Render sensitivity maps
-        if subject is not None:
-            sensitivity_maps_html = ""
-        else:
-            sensitivity_maps_html = ""
+        sensitivity_maps_html = ""
+        source_space_html = ""
+        if plot:
+            source_space_html = self._src_html(
+                subject=subject,
+                subjects_dir=subjects_dir,
+                src=forward["src"],
+                trans=forward["mri_head_t"],
+                image_format=image_format,
+            )
 
         html_partial = partial(
             _html_forward_sol_element,
             repr_=forward._repr_html_(),
             sensitivity_maps=sensitivity_maps_html,
+            source_space=source_space_html,
             title=title,
             tags=tags,
         )
@@ -3616,88 +3667,52 @@ class Report:
             replace=replace,
         )
 
-        if subject:
-            src = forward["src"]
-            trans = forward["mri_head_t"]
-            # Alignment
-            kwargs = dict(
-                info=forward["info"],
-                trans=trans,
-                src=src,
-                subject=subject,
-                subjects_dir=subjects_dir,
-                meg=["helmet", "sensors"],
-                show_axes=True,
-                eeg=dict(original=0.2, projected=0.8),
-                coord_frame="mri",
-            )
-            img, _ = _iterate_trans_views(
-                function=plot_alignment,
-                alpha=0.5,
-                max_width=self.img_max_width,
-                max_res=self.img_max_res,
-                **kwargs,
-            )
-            self._add_image(
-                img=img,
-                title="Alignment",
-                section=section,
-                caption=None,
-                image_format="png",
-                tags=tags,
-                replace=replace,
-            )
-            # Source space
-            kwargs = dict(
-                trans=trans,
-                subjects_dir=subjects_dir,
-            )
-
-            self._add_bem(
-                subject=subject,
-                subjects_dir=subjects_dir,
-                src=src,
-                trans=trans,
-                decim=1,
-                n_jobs=1,
-                width=512,
-                image_format=image_format,
-                title="Source space(s) (BEM view)",
-                section=section,
-                tags=tags,
-                replace=replace,
-            )
-
-            if src.kind == "surface" or src.kind == "mixed":
-                surfaces = dict(head=0.1, white=0.5)
-            else:
-                surfaces = dict(head=0.1)
-
-            kwargs = dict(
-                trans=trans,
-                src=src,
-                subject=subject,
-                subjects_dir=subjects_dir,
-                show_axes=False,
-                coord_frame="mri",
-                surfaces=surfaces,
-            )
-            img, _ = _iterate_alignment_views(
-                function=plot_alignment,
-                alpha=0.5,
-                max_width=self.img_max_width,
-                max_res=self.img_max_res,
-                **kwargs,
-            )
-            self._add_image(
-                img=img,
-                title="Source space(s) (3D view)",
-                section=section,
-                caption=None,
-                image_format="png",
-                tags=tags,
-                replace=replace,
-            )
+    def _src_html(
+        self,
+        *,
+        subject,
+        subjects_dir,
+        src,
+        trans,
+        image_format,
+    ):
+        src = _ensure_src(src)
+        subject = self.subject if subject is None else subject
+        subject = src[0]["subject_his_id"] if subject is None else subject
+        subjects_dir = self.subjects_dir if subjects_dir is None else subjects_dir
+        trans, _ = _find_trans(trans=trans, subject=subject, subjects_dir=subjects_dir)
+        if src.kind == "surface" or src.kind == "mixed":
+            surfaces = dict(head=0.1, white=0.5)
+        else:
+            surfaces = dict(head=0.1)
+        kwargs = dict(
+            trans=trans,
+            src=src,
+            subject=subject,
+            subjects_dir=subjects_dir,
+            show_axes=False,
+            coord_frame="mri",
+            surfaces=surfaces,
+        )
+        img, _ = _iterate_alignment_views(
+            function=plot_alignment,
+            alpha=0.5,
+            max_width=self.img_max_width,
+            max_res=self.img_max_res,
+            **kwargs,
+        )
+        return _html_image_element(
+            embedded=True,  # because it's embedded in an existing section...
+            id_=None,  # a bunch of options are not used (they are part of "section")
+            tags=None,
+            div_klass=None,
+            img_klass=None,
+            show=None,
+            img=img,
+            title="Source space",  # just the alt text
+            caption="Source space",
+            image_format=image_format,
+        )
 
     def _add_inverse_operator(
         self,
@@ -3705,9 +3720,9 @@ class Report:
         inverse_operator,
         subject,
         subjects_dir,
-        trans,
         title,
         image_format,
+        plot,
         section,
         tags,
         replace,
@@ -3716,42 +3731,19 @@ class Report:
         if not isinstance(inverse_operator, InverseOperator):
             inverse_operator = read_inverse_operator(inverse_operator)
 
-        if trans is not None and not isinstance(trans, Transform):
-            trans = read_trans(trans)
-
-        subject = self.subject if subject is None else subject
-        subjects_dir = self.subjects_dir if subjects_dir is None else subjects_dir
-
-        # XXX Todo Render source space?
-        # if subject is not None and trans is not None:
-        #     src = inverse_operator['src']
-
-        #     fig = plot_alignment(
-        #         subject=subject,
-        #         subjects_dir=subjects_dir,
-        #         trans=trans,
-        #         surfaces='white',
-        #         src=src
-        #     )
-        #     set_3d_view(fig, focalpoint=(0., 0., 0.06))
-        #     img = self._fig_to_img(fig=fig, image_format=image_format)
-
-        #     src_img_html = partial(
-        #         _html_image_element,
-        #         img=img,
-        #         div_klass='inverse-operator source-space',
-        #         img_klass='inverse-operator source-space',
-        #         title='Source space', caption=None, show=True,
-        #         image_format=image_format,
-        #         tags=tags
-        #     )
-        # else:
-        src_img_html = ""
-
+        source_space_html = ""
+        if plot:
+            source_space_html = self._src_html(
+                subject=subject,
+                subjects_dir=subjects_dir,
+                src=inverse_operator["src"],
+                trans=inverse_operator["mri_head_t"],
+                image_format=image_format,
+            )
         html_partial = partial(
             _html_inverse_operator_element,
             repr_=inverse_operator._repr_html_(),
-            source_space=src_img_html,
+            source_space=source_space_html,
             title=title,
             tags=tags,
         )

--- a/mne/report/tests/test_report.py
+++ b/mne/report/tests/test_report.py
@@ -522,19 +522,22 @@ def test_add_forward(renderer_interactive_pyvistaqt):
     report = Report(subjects_dir=subjects_dir, image_format="png")
     report.add_forward(
         forward=fwd_fname,
-        subject="sample",
         subjects_dir=subjects_dir,
         title="Forward solution",
+        plot=True,
     )
-    assert len(report.html) == 4
+    assert len(report.html) == 1
+    assert report.html[0].count("<img") == 1
 
     report = Report(subjects_dir=subjects_dir, image_format="png")
     report.add_forward(
         forward=fwd_fname,
         subjects_dir=subjects_dir,
         title="Forward solution",
+        plot=False,
     )
     assert len(report.html) == 1
+    assert report.html[0].count("<img") == 0
 
 
 @testing.requires_testing_data
@@ -906,7 +909,7 @@ def test_survive_pickle(tmp_path):
 @pytest.mark.slowtest  # ~30 s on Azure Windows
 @testing.requires_testing_data
 @pytest.mark.filterwarnings("ignore:Distances could not be calculated.*:RuntimeWarning")
-def test_manual_report_2d(tmp_path, invisible_fig, renderer_pyvistaqt):
+def test_manual_report_2d(tmp_path, invisible_fig):
     """Simulate user manually creating report by adding one file at a time."""
     pytest.importorskip("sklearn")
     pytest.importorskip("pandas")
@@ -1209,7 +1212,7 @@ def test_manual_report_3d(tmp_path, renderer):
         title="my inverse",
         subject="sample",
         subjects_dir=subjects_dir,
-        trans=trans_fname,
+        plot=True,
     )
     r.add_stc(
         stc=stc_fname,

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -324,7 +324,9 @@ report.save("report_coregistration.html", overwrite=True)
 fwd_path = sample_dir / "sample_audvis-meg-oct-6-fwd.fif"
 
 report = mne.Report(title="Forward solution example")
-report.add_forward(forward=fwd_path, title="Forward solution", plot=True)
+report.add_forward(
+    forward=fwd_path, title="Forward solution", plot=True, subjects_dir=subjects_dir
+)
 report.save("report_forward_sol.html", overwrite=True)
 
 # %%
@@ -339,7 +341,10 @@ inverse_op_path = sample_dir / "sample_audvis-meg-oct-6-meg-inv.fif"
 
 report = mne.Report(title="Inverse operator example")
 report.add_inverse_operator(
-    inverse_operator=inverse_op_path, title="Inverse operator", plot=True
+    inverse_operator=inverse_op_path,
+    title="Inverse operator",
+    plot=True,
+    subjects_dir=subjects_dir,
 )
 report.save("report_inverse_op.html", overwrite=True)
 

--- a/tutorials/intro/70_report.py
+++ b/tutorials/intro/70_report.py
@@ -324,7 +324,7 @@ report.save("report_coregistration.html", overwrite=True)
 fwd_path = sample_dir / "sample_audvis-meg-oct-6-fwd.fif"
 
 report = mne.Report(title="Forward solution example")
-report.add_forward(forward=fwd_path, title="Forward solution")
+report.add_forward(forward=fwd_path, title="Forward solution", plot=True)
 report.save("report_forward_sol.html", overwrite=True)
 
 # %%
@@ -338,7 +338,9 @@ report.save("report_forward_sol.html", overwrite=True)
 inverse_op_path = sample_dir / "sample_audvis-meg-oct-6-meg-inv.fif"
 
 report = mne.Report(title="Inverse operator example")
-report.add_inverse_operator(inverse_operator=inverse_op_path, title="Inverse operator")
+report.add_inverse_operator(
+    inverse_operator=inverse_op_path, title="Inverse operator", plot=True
+)
 report.save("report_inverse_op.html", overwrite=True)
 
 # %%


### PR DESCRIPTION
Tightening up the API a bit from https://github.com/mne-tools/mne-python/pull/12848 before merge:

1. Make `add_forward(..., plot=False)` new kwarg, so keep old behavior (don't try to plot unless asked)
2. Make `report.parse_folder(..., plot_src=False)` a new kwarg
3. Add `add_inverse_operator(..., plot=False)` new kwarg to allow showing the source space for the inverse operator in the same way
4. Don't try to calculate distances using `info` from fwd/inv (dig points are not stored)
5. Only add the source space plot, not the alignment or the BEM

(1) and (2) are backward compat fixes I missed, (3) improves consistency, (4) is a bugfix, and (5) is done because we already have `report.add_trans` and `report.add_bem` which have this functionality (with more options!), so better not to duplicate it.

This results in the same number of titled sections as in 1.9, which I think makes sense (rather than putting the image and `repr` in their own sections):

![image](https://github.com/user-attachments/assets/36582502-a86d-4e8c-8869-adc63ae3c98d)

Maybe someday we want a ` report.add_source_space` or similar... but I think we could probably add that separately if people want it. (Yet another option I considered was a,dding a `src` option to `plot_trans`, but that plot would be too busy I think.)