### PR TITLE
Adjust Pupil channel units (again)

### DIFF
--- a/doc/changes/devel/13314.bugfix.rst
+++ b/doc/changes/devel/13314.bugfix.rst
@@ -1,0 +1,1 @@
+Change default pupil unit scalings from micrometrs to millimeters by `Scott Huberty`_

--- a/mne/defaults.py
+++ b/mne/defaults.py
@@ -93,7 +93,7 @@ DEFAULTS = dict(
         gsr="S",
         temperature="C",
         eyegaze="rad",
-        pupil="µm",
+        pupil="mm",
     ),
     # scalings for the units
     scalings=dict(
@@ -122,7 +122,7 @@ DEFAULTS = dict(
         gsr=1.0,
         temperature=1.0,
         eyegaze=1.0,
-        pupil=1e6,
+        pupil=1e3,
     ),
     # rough guess for a good plot
     scalings_plot_raw=dict(


### PR DESCRIPTION
closes #13244 

There have been several iterations on the issue of eyetracking units, so let me summarize for brevity:

Stemming from Issue https://github.com/mne-tools/mne-python/issues/12756#issuecomment-2260832644 (and PR https://github.com/mne-tools/mne-python/pull/12846#issuecomment-2349960065 + https://github.com/mne-tools/mne-python/pull/12850), we changed MNE internals to assume all incoming Eyetracking data were already represented in Meters (SI unit of distance, as _some_ eyetrackers report pupil size in mm). In those PR's I adjusted the scaling for Pupil channels so that data in meters would look nice when plotting by default. I chose a scaling factor of 1e6 (meters -> micro meters). 

This caused `inst.to_data_frame()` to convert from meters -> micrometers which is probably not very intuitive for researchers (hence #13244).

It is probably more intuitive to adjust the scalings to go from meters to mm. The plotting still looks good, and pupil channels will be converted to mm by default by `to_data_frame()`:



```
import mne
import numpy as np


sfreq = 100
ch_names = ["my_pupil"]
ch_types = "pupil"
info = mne.create_info(ch_names, sfreq, ch_types)
data = np.full((1, 900), np.repeat(np.linspace(0, .008, 9), sfreq))  # data between 0-8mm
raw = mne.io.RawArray(data, info, verbose=False)
raw.plot(remove_dc=False)

df = raw.to_data_frame()
df.head()
```
<img width="930" height="609" alt="Screenshot 2025-07-10 at 6 13 58 PM" src="https://github.com/user-attachments/assets/47657339-b27c-4b65-b5b4-e22fddaecb77" />

```
Out[4]: 
     time  my_pupil
0    0.00       0.0
1    0.01       0.0
2    0.02       0.0
3    0.03       0.0
4    0.04       0.0
..    ...       ...
895  8.95       8.0
896  8.96       8.0
897  8.97       8.0
898  8.98       8.0
899  8.99       8.0

[900 rows x 2 columns]
```


Does this sound reasonable to you @larsoner and @drammock ?
