### PR TITLE
MAINT: Stabilize MxNE tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,14 @@ on:  # yamllint disable-line rule:truthy
     branches: ["main", "maint/*"]
   pull_request:
     branches: ["main", "maint/*"]
+  # adapted from spyder-ide/spyder
+  workflow_dispatch:
+    inputs:
+      ssh:
+        description: 'Enable ssh debugging'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -87,6 +95,21 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Get commit message
+        run: echo "COMMIT_MESSAGE=$(git show -s --format=%s ${{ github.event.pull_request.head.sha || github.sha }})" | tee -a ${GITHUB_ENV}
+      - name: Triage SSH
+        run: |
+          if [[ "${{ inputs.ssh }}" == "true" ]] || [[ "$COMMIT_MESSAGE" == *"[actions ssh]"* ]]; then
+            echo "ENABLE_SSH=true" | tee -a $GITHUB_ENV
+          else
+            echo "ENABLE_SSH=false" | tee -a $GITHUB_ENV
+          fi
+      - name: Setup Remote SSH Connection
+        if: env.ENABLE_SSH == 'true'
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 80
+        with:
+          detached: true
       - run: ./tools/github_actions_env_vars.sh
       # Xvfb/OpenGL
       - uses: pyvista/setup-headless-display-action@v4

--- a/mne/inverse_sparse/tests/test_mxne_inverse.py
+++ b/mne/inverse_sparse/tests/test_mxne_inverse.py
@@ -364,7 +364,13 @@ def test_mxne_vol_sphere():
         tstep=stc.tstep,
     )
     evoked_dip = mne.simulation.simulate_evoked(
-        fwd, stc, info, cov, nave=1e9, use_cps=True
+        fwd,
+        stc,
+        info,
+        cov,
+        nave=1e9,
+        use_cps=True,
+        random_state=0,
     )
 
     dip_mxne = mixed_norm(
@@ -587,7 +593,14 @@ def test_mxne_inverse_sure_meg():
     assert_array_equal(stc.vertices[1], [70279])
     nave = 30
     evoked = simulate_evoked(
-        forward, stc, info, noise_cov, nave=nave, use_cps=False, iir_filter=None
+        forward,
+        stc,
+        info,
+        noise_cov,
+        nave=nave,
+        use_cps=False,
+        iir_filter=None,
+        random_state=0,
     )
     evoked = evoked.crop(tmin=0, tmax=10e-3)
     stc_ = mixed_norm(

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -21,10 +21,7 @@ if [ ! -z "$CONDA_ENV" ]; then
 		STD_ARGS="--progress-bar off"
 	fi
 elif [[ "${MNE_CI_KIND}" == "pip" ]]; then
-	# Only used for 3.13 at the moment, just get test deps plus a few extras
-	# that we know are available
-	INSTALL_ARGS="nibabel scikit-learn numpydoc PySide6!=6.9.1 mne-qt-browser pandas h5io mffpy defusedxml numba pyvistaqt"
-	INSTALL_KIND="test"
+	INSTALL_KIND="full-pyside6,$INSTALL_KIND"
 else
 	test "${MNE_CI_KIND}" == "pip-pre"
 	STD_ARGS="$STD_ARGS --pre"


### PR DESCRIPTION
@Genuster from some testing on SSH I realized it was a Heisenbug -- only showed up on some calls to `pytest mne/inverse_sparse -xk sure_meg` for example. I am hoping adding these `random_state=0`s to the `simulate_evoked` calls fixes the bug. I expect them to. Will merge this either way then merge `main` into your branch, and we can continue testing there if needed. But hopefully it just comes back green!