### PR TITLE
Use __setattr__ to set `PolyData._hemi` dynamically

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -442,7 +442,8 @@ class Brain:
                     )
                     self._layered_meshes[h] = mesh
                     # add metadata to the mesh for picking
-                    mesh._polydata._hemi = h
+                    # using __setattr__ is needed to set dynamic properties for PolyData
+                    object.__setattr__(mesh._polydata, '_hemi', h)
                 else:
                     actor = self._layered_meshes[h]._actor
                     self._renderer.plotter.add_actor(actor, render=False)


### PR DESCRIPTION
Upstream as part of https://github.com/pyvista/pyvista/pull/7716, setting dynamic attributes on meshes will no longer be allowed. MNE currently adds a `_hemi` attribute dynamically, which is causing integration test failures:
https://github.com/pyvista/pyvista/actions/runs/16335129476/job/46145621314?pr=7716#step:15:2380

I'm pretty sure they'll all be resolved by this PR with this change.

There will be a global flag as part of the API to allow setting dynamic attributes, but pending review/approval of https://github.com/pyvista/pyvista/pull/7716, I'm pretty this will be off by default. Until a release is made with the "official" flag/mechanism for enabling this, a workaround for this restriction is to use `object.__setattr__`.