### PR TITLE
MAINT: Dont set attribute on PolyData

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -441,8 +441,6 @@ class Brain:
                         name="curv",
                     )
                     self._layered_meshes[h] = mesh
-                    # add metadata to the mesh for picking
-                    mesh._polydata._hemi = h
                 else:
                     actor = self._layered_meshes[h]._actor
                     self._renderer.plotter.add_actor(actor, render=False)
@@ -1248,12 +1246,12 @@ class Brain:
             return
 
         # 3) Otherwise, pick the objects in the scene
-        try:
-            hemi = mesh._hemi
-        except AttributeError:  # volume
-            hemi = "vol"
+        for hemi, this_mesh in self._layered_meshes.items():
+            assert hemi in ("lh", "rh"), f"Unexpected {hemi=}"
+            if this_mesh._polydata is mesh:
+                break
         else:
-            assert hemi in ("lh", "rh")
+            hemi = "vol"
         if self.act_data_smooth[hemi][0] is None:  # no data to add for hemi
             return
         pos = np.array(vtk_picker.GetPickPosition())

--- a/mne/viz/_brain/tests/test_brain.py
+++ b/mne/viz/_brain/tests/test_brain.py
@@ -774,6 +774,7 @@ def test_single_hemi(hemi, renderer_interactive_pyvistaqt, brain_gc):
 @pytest.mark.parametrize("interactive_state", (False, True))
 def test_brain_save_movie(tmp_path, renderer, brain_gc, interactive_state):
     """Test saving a movie of a Brain instance."""
+    pytest.importorskip("imageio")
     imageio_ffmpeg = pytest.importorskip("imageio_ffmpeg")
 
     brain = _create_testing_brain(


### PR DESCRIPTION
@wmvanvliet @user27182 I think this is a cleaner way -- avoid monkey-patching altogether. We might need similar things elsewhere at some point, not sure. If we hit those we should keep a similar "registry" of objects that we can use to query I think.

Closes #13329