### PR TITLE
Add icon links to our donation pages

### DIFF
--- a/doc/_static/js/custom-icons.js
+++ b/doc/_static/js/custom-icons.js
@@ -1,0 +1,19 @@
+FontAwesome.library.add(
+  /**
+   * Custom icon definitions
+   *
+   * see https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/header-links.html#svg-image-icons
+   */
+  {
+    prefix: "fa-custom",
+    iconName: "opencollective",
+    icon: [
+      24,
+      24,
+      [],
+      "e001",
+      // https://simpleicons.org/icons/opencollective.svg
+      "M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12c2.54 0 4.894-.79 6.834-2.135l-3.107-3.109a7.715 7.715 0 1 1 0-13.512l3.107-3.109A11.943 11.943 0 0 0 12 0zm9.865 5.166l-3.109 3.107A7.67 7.67 0 0 1 19.715 12a7.682 7.682 0 0 1-.959 3.727l3.109 3.107A11.943 11.943 0 0 0 24 12c0-2.54-.79-4.894-2.135-6.834z",
+    ],
+  },
+);

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -257,7 +257,7 @@ aside.footnote:last-child {
 }
 
 /* ******************************************************* navbar icon links */
-.navbar-icon-links svg.fa-square-github {
+.navbar-icon-links svg.fa-github {
     color: var(--mne-color-github);
 }
 .navbar-icon-links svg.fa-discourse {

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -32,6 +32,7 @@ html[data-theme="light"] {
     --mne-color-discourse: #d0232b;
     --mne-color-mastodon: #2F0C7A;
     --mne-color-sponsor: #BF3989;  /* from GH sponsor heart, via browser devtools */
+    --mne-color-opencollective: #1F87FF;  /* scraped from logo SVG */
     /* code block copy button */
     --copybtn-opacity: 0.75;
     /* card header bg color */
@@ -65,6 +66,7 @@ html[data-theme="dark"] {
     --mne-color-discourse: #FFF9AE;  /* from their logo SVG */
     --mne-color-mastodon: #858AFA;  /* www.joinmastodon.org/en/branding */
     --mne-color-sponsor: #DB61A2;  /* from GH sponsor heart, via browser devtools */
+    --mne-color-opencollective: #99CFFF;  /* scraped from logo SVG */
     /* code block copy button */
     --copybtn-opacity: 0.25;
     /* card header bg color */
@@ -269,6 +271,9 @@ aside.footnote:last-child {
 }
 .navbar-icon-links svg.fa-heart {
     color: var(--mne-color-sponsor);
+}
+.navbar-icon-links svg.fa-opencollective {
+    color: var(--mne-color-opencollective);
 }
 
 /* ************************************************************ nav elements */

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -31,6 +31,7 @@ html[data-theme="light"] {
     --mne-color-github: #000;
     --mne-color-discourse: #d0232b;
     --mne-color-mastodon: #2F0C7A;
+    --mne-color-sponsor: #BF3989;  /* from GH sponsor heart, via browser devtools */
     /* code block copy button */
     --copybtn-opacity: 0.75;
     /* card header bg color */
@@ -63,6 +64,7 @@ html[data-theme="dark"] {
     --mne-color-github: rgb(240, 246, 252);  /* from their logo SVG */
     --mne-color-discourse: #FFF9AE;  /* from their logo SVG */
     --mne-color-mastodon: #858AFA;  /* www.joinmastodon.org/en/branding */
+    --mne-color-sponsor: #DB61A2;  /* from GH sponsor heart, via browser devtools */
     /* code block copy button */
     --copybtn-opacity: 0.25;
     /* card header bg color */
@@ -264,6 +266,9 @@ aside.footnote:last-child {
 }
 .navbar-icon-links svg.fa-mastodon {
     color: var(--mne-color-mastodon);
+}
+.navbar-icon-links svg.fa-heart {
+    color: var(--mne-color-sponsor);
 }
 
 /* ************************************************************ nav elements */

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -798,7 +798,7 @@ html_theme_options = {
         dict(
             name="GitHub",
             url="https://github.com/mne-tools/mne-python",
-            icon="fa-brands fa-square-github fa-fw",
+            icon="fa-brands fa-github fa-fw",
         ),
         dict(
             name="Sponsor on GitHub",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -780,7 +780,7 @@ switcher_version_match = "dev" if ".dev" in version else version
 html_theme_options = {
     "icon_links": [
         dict(
-            name="Discord",
+            name="Discord (office hours)",
             url="https://discord.gg/rKfvxTuATa",
             icon="fa-brands fa-discord fa-fw",
         ),
@@ -791,17 +791,17 @@ html_theme_options = {
             attributes=dict(rel="me"),
         ),
         dict(
-            name="Forum",
+            name="Q&A Forum",
             url="https://mne.discourse.group/",
             icon="fa-brands fa-discourse fa-fw",
         ),
         dict(
-            name="GitHub",
+            name="Code Repository",
             url="https://github.com/mne-tools/mne-python",
             icon="fa-brands fa-github fa-fw",
         ),
         dict(
-            name="Sponsor on GitHub",
+            name="Sponsor us on GitHub",
             url="https://github.com/sponsors/mne-tools",
             icon="fa-regular fa-heart fa-fw",
         ),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -800,6 +800,11 @@ html_theme_options = {
             url="https://github.com/mne-tools/mne-python",
             icon="fa-brands fa-square-github fa-fw",
         ),
+        dict(
+            name="Sponsor on GitHub",
+            url="https://github.com/sponsors/mne-tools",
+            icon="fa-regular fa-heart fa-fw",
+        ),
     ],
     "icon_links_label": "External Links",  # for screen reader
     "use_edit_page_button": False,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -805,6 +805,11 @@ html_theme_options = {
             url="https://github.com/sponsors/mne-tools",
             icon="fa-regular fa-heart fa-fw",
         ),
+        dict(
+            name="Donate via OpenCollective",
+            url="https://opencollective.com/mne-python",
+            icon="fa-custom fa-opencollective fa-fw",
+        ),
     ],
     "icon_links_label": "External Links",  # for screen reader
     "use_edit_page_button": False,
@@ -844,6 +849,9 @@ html_favicon = "_static/favicon.ico"
 html_static_path = ["_static"]
 html_css_files = [
     "style.css",
+]
+html_js_files = [
+    ("js/custom-icons.js", {"defer": "defer"}),
 ]
 
 # Add any extra paths that contain custom files (such as robots.txt or


### PR DESCRIPTION
- adds links to https://github.com/sponsors/mne-tools and https://opencollective.com/mne-python with appropriate icons and colors
- switches from squarish GitHub icon to round one
- tweaks the hover text of some of the icons:
    - "Forum" -> "Q&A Forum"
    - "Discord" -> "Discord (office hours)"
    - "GitHub" -> "Code Repository"
    - "Mastodon" is unchanged

here's screenshots of a local build, hovering over each of the two new icons:

<img width="930" height="170" alt="Screenshot_2025-07-17_15-05-18" src="https://github.com/user-attachments/assets/0041a295-8b6d-4972-b934-fa5e00922b10" />

<img width="1005" height="169" alt="Screenshot_2025-07-17_15-05-08" src="https://github.com/user-attachments/assets/8a52e87f-5197-4cd7-b653-399f4e819b8e" />
