### PR TITLE
BUG: Fix bug with tolerances

### DIFF
--- a/mne/decoding/_ged.py
+++ b/mne/decoding/_ged.py
@@ -55,26 +55,34 @@ def _smart_ged(S, R, restr_mat=None, R_func=None):
 
 
 def _is_cov_symm_pos_semidef(
-    cov, rtol=1e-10, atol=1e-11, eval_tol=1e-15, check_pos_semidef=True
+    cov, rtol=1e-7, atol=None, eval_tol=None, check_pos_semidef=True
 ):
+    if atol is None:
+        atol = 1e-7 * np.max(np.abs(cov))
     is_symm = scipy.linalg.issymmetric(cov, rtol=rtol, atol=atol)
     if not is_symm:
         return False
 
     if check_pos_semidef:
         # numerically slightly negative evals are considered 0
-        is_pos_semidef = np.all(scipy.linalg.eigvalsh(cov) >= -eval_tol)
+        evals = scipy.linalg.eigvalsh(cov)
+        if eval_tol is None:
+            eval_tol = 1e-7 * np.max(np.abs(evals))
+        is_pos_semidef = np.all(evals >= -eval_tol)
         return is_pos_semidef
 
     return True
 
 
-def _is_cov_pos_def(cov, eval_tol=1e-15):
+def _is_cov_pos_def(cov, eval_tol=None):
     is_symm = _is_cov_symm_pos_semidef(cov, check_pos_semidef=False)
     if not is_symm:
         return False
     # numerically slightly positive evals are considered 0
-    is_pos_def = np.all(scipy.linalg.eigvalsh(cov) > eval_tol)
+    evals = scipy.linalg.eigvalsh(cov)
+    if eval_tol is None:
+        eval_tol = 1e-7 * np.max(np.abs(evals))
+    is_pos_def = np.all(evals > eval_tol)
     return is_pos_def
 
 


### PR DESCRIPTION
@Genuster see this failure:
```
https://app.circleci.com/pipelines/github/mne-tools/mne-bids-pipeline/5106/workflows/2b623eb6-112a-4f57-a71c-6962e53b76c3/jobs/82110
```
locally I can reproduce running `pytest mne_bids_pipeline/ -k ERN` (you might want to add a `--download` if you want to try).

This shouldn't fail the check, but it does. The values are generally around 1e11, so the `atol` here becomes meaningless. A `rtol=1e-7` or `1e-6` is generally safer because our data are often stored in `float32` so we end up operating near `float32` tolerances (especially after a save-load round trip of a covariance for example).

Not 100% sure what to do about `atol`. A safer value for `atol` is zero, since in general we don't know the scale of the data. Really it should probably auto-scale based on the abs max of the data -- the current value of `1e-11` will pass for data that are tiny, e.g., if the values are all 1e-13 scale then *any* matrix will pass the test, which is bad. Here I've made `atol=None` to mean "use 1e-7 times the largest absolute value in the data". The same argument holds for `eval_tol`, which I've changed correspondingly.

WDYT? If you agree with these changes, can you take over? You can cherry-pick my commit or start over and open another PR with any additional changes. Or you can review and I can make changes etc.