### PR TITLE
MAINT: Restore statsmodels to pip-pre

### DIFF
--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -31,9 +31,8 @@ python -m pip install $STD_ARGS --only-binary ":all:" --default-timeout=60 \
 	"dipy>=1.10.0.dev0" \
 	"pyarrow>=20.0.0.dev0" \
 	"tables>=3.10.3.dev0" \
+	"statsmodels>=0.15.0.dev697" \
 	"h5py>=3.13.0"
-# TODO: should have above: "statsmodels>=0.15.0.dev0"
-# https://github.com/statsmodels/statsmodels/issues/9572
 echo "::endgroup::"
 
 # No Numba because it forces an old NumPy version


### PR DESCRIPTION
Should be doable [now](https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/statsmodels/):

<img width="913" height="45" alt="image" src="https://github.com/user-attachments/assets/8547badf-5777-4a30-b3da-c3e1f1725a9f" />
