### PR TITLE
MAINT: Fix CircleCI

### DIFF
--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -378,7 +378,6 @@ def _fullname(obj, *, referent=None):
                 if value is referent:
                     name += f"[{key!r}]"
                     break
-
     return name
 
 
@@ -409,8 +408,10 @@ def _assert_no_instances(cls, when=""):
                     if isinstance(r, list | dict | tuple):
                         rep = f"len={len(r)}"
                         r_ = gc.get_referrers(r)
-                        types = (_fullname(x, referent=r) for x in r_)
-                        types = " / ".join(sorted(x for x in types if x is not None))
+                        types = list()
+                        for x in r_:
+                            types.append(_fullname(x, referent=r))
+                        types = " / ".join(sorted(types))
                         rep += f" | {len(r_)} referrers: {types}"
                         del r_
                     else:

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -358,12 +358,28 @@ def _file_like(obj):
     return all(callable(getattr(obj, name, None)) for name in ("read", "seek"))
 
 
-def _fullname(obj):
+def _fullname(obj, *, referent=None):
     klass = obj.__class__
     module = klass.__module__
-    if module == "builtins":
-        return klass.__qualname__
-    return module + "." + klass.__qualname__
+    name = klass.__qualname__
+    if module != "builtins":
+        name = f"{module}.{name}"
+    if referent is not None:
+        if isinstance(obj, list | tuple):
+            for ii, item in enumerate(obj):
+                if item is referent:
+                    name += f"[{ii}]"
+                    break
+        elif isinstance(obj, dict):
+            for key, value in obj.items():
+                if key is referent:
+                    name += "-key"
+                    break
+                if value is referent:
+                    name += f"[{key!r}]"
+                    break
+
+    return name
 
 
 def _assert_no_instances(cls, when=""):
@@ -372,7 +388,7 @@ def _assert_no_instances(cls, when=""):
     ref = list()
     gc.collect()
     objs = gc.get_objects()
-    for obj in objs:
+    for obj in objs:  # e.g., vtkPolyData, Brain, Plotter, etc.
         try:
             check = isinstance(obj, cls)
         except Exception:  # such as a weakref
@@ -382,30 +398,31 @@ def _assert_no_instances(cls, when=""):
                 ref.append(f"Brain._cleaned = {getattr(obj, '_cleaned', None)}")
             rr = gc.get_referrers(obj)
             count = 0
-            for r in rr:
+            for r in rr:  # e.g., list, dict, etc. that holds the reference to obj
                 if (
                     r is not objs
                     and r is not globals()
                     and r is not locals()
                     and not inspect.isframe(r)
                 ):
+                    name = _fullname(r, referent=obj)
                     if isinstance(r, list | dict | tuple):
                         rep = f"len={len(r)}"
                         r_ = gc.get_referrers(r)
-                        types = (_fullname(x) for x in r_)
-                        types = "/".join(sorted(set(x for x in types if x is not None)))
-                        rep += f", {len(r_)} referrers: {types}"
+                        types = (_fullname(x, referent=r) for x in r_)
+                        types = " / ".join(sorted(x for x in types if x is not None))
+                        rep += f" | {len(r_)} referrers: {types}"
                         del r_
                     else:
-                        rep = repr(r)[:100].replace("\n", " ")
+                        rep = "repr="
+                        rep += repr(r)[:100].replace("\n", " ")
                         # If it's a __closure__, get more information
                         if rep.startswith("<cell at "):
                             try:
                                 rep += f" ({repr(r.cell_contents)[:100]})"
                             except Exception:
                                 pass
-                    name = _fullname(r)
-                    ref.append(f"{name}: {rep}")
+                    ref.append(f"{name} with {rep}")
                     count += 1
                 del r
             del rr

--- a/tutorials/preprocessing/70_fnirs_processing.py
+++ b/tutorials/preprocessing/70_fnirs_processing.py
@@ -30,7 +30,6 @@ fnirs_cw_amplitude_dir = fnirs_data_folder / "Participant-1"
 raw_intensity = mne.io.read_raw_nirx(fnirs_cw_amplitude_dir, verbose=True)
 raw_intensity.load_data()
 
-
 # %%
 # Providing more meaningful annotation information
 # ------------------------------------------------
@@ -47,7 +46,6 @@ raw_intensity.annotations.rename(
 )
 unwanted = np.nonzero(raw_intensity.annotations.description == "15.0")
 raw_intensity.annotations.delete(unwanted)
-
 
 # %%
 # Viewing location of sensors over brain surface
@@ -89,7 +87,6 @@ raw_intensity.plot(
     n_channels=len(raw_intensity.ch_names), duration=500, show_scrollbars=False
 )
 
-
 # %%
 # Converting from raw intensity to optical density
 # ------------------------------------------------
@@ -98,7 +95,6 @@ raw_intensity.plot(
 
 raw_od = mne.preprocessing.nirs.optical_density(raw_intensity)
 raw_od.plot(n_channels=len(raw_od.ch_names), duration=500, show_scrollbars=False)
-
 
 # %%
 # Evaluating the quality of the data
@@ -118,13 +114,11 @@ fig, ax = plt.subplots(layout="constrained")
 ax.hist(sci)
 ax.set(xlabel="Scalp Coupling Index", ylabel="Count", xlim=[0, 1])
 
-
 # %%
 # In this example we will mark all channels with a SCI less than 0.5 as bad
 # (this dataset is quite clean, so no channels are marked as bad).
 
 raw_od.info["bads"] = list(compress(raw_od.ch_names, sci < 0.5))
-
 
 # %%
 # At this stage it is appropriate to inspect your data
@@ -133,7 +127,6 @@ raw_od.info["bads"] = list(compress(raw_od.ch_names, sci < 0.5))
 # to ensure that channels with poor scalp coupling have been removed.
 # If your data contains lots of artifacts you may decide to apply
 # artifact reduction techniques as described in :ref:`ex-fnirs-artifacts`.
-
 
 # %%
 # Converting from optical density to haemoglobin
@@ -144,7 +137,6 @@ raw_od.info["bads"] = list(compress(raw_od.ch_names, sci < 0.5))
 
 raw_haemo = mne.preprocessing.nirs.beer_lambert_law(raw_od, ppf=0.1)
 raw_haemo.plot(n_channels=len(raw_haemo.ch_names), duration=500, show_scrollbars=False)
-
 
 # %%
 # Removing heart rate from signal
@@ -178,7 +170,6 @@ for when, _raw in dict(Before=raw_haemo_unfiltered, After=raw_haemo).items():
 events, event_dict = mne.events_from_annotations(raw_haemo)
 fig = mne.viz.plot_events(events, event_id=event_dict, sfreq=raw_haemo.info["sfreq"])
 
-
 # %%
 # Next we define the range of our epochs, the rejection criteria,
 # baseline correction, and extract the epochs. We visualize the log of which
@@ -203,7 +194,6 @@ epochs = mne.Epochs(
 )
 epochs.plot_drop_log()
 
-
 # %%
 # View consistency of responses across trials
 # -------------------------------------------
@@ -221,7 +211,6 @@ epochs["Tapping"].plot_image(
     ts_args=dict(ylim=dict(hbo=[-15, 15], hbr=[-15, 15])),
 )
 
-
 # %%
 # We can also view the epoched data for the control condition and observe
 # that it does not show the expected morphology.
@@ -232,7 +221,6 @@ epochs["Control"].plot_image(
     vmax=30,
     ts_args=dict(ylim=dict(hbo=[-15, 15], hbr=[-15, 15])),
 )
-
 
 # %%
 # View consistency of responses across channels
@@ -249,7 +237,6 @@ epochs["Tapping"].average().plot_image(axes=axes[:, 1], clim=clims)
 for column, condition in enumerate(["Control", "Tapping"]):
     for ax in axes[:, column]:
         ax.set_title(f"{condition}: {ax.get_title()}")
-
 
 # %%
 # Plot standard fNIRS response image
@@ -277,7 +264,6 @@ mne.viz.plot_compare_evokeds(
     evoked_dict, combine="mean", ci=0.95, colors=color_dict, styles=styles_dict
 )
 
-
 # %%
 # View topographic representation of activity
 # -------------------------------------------
@@ -289,7 +275,6 @@ topomap_args = dict(extrapolate="local")
 epochs["Tapping"].average(picks="hbo").plot_joint(
     times=times, topomap_args=topomap_args
 )
-
 
 # %%
 # Compare tapping of left and right hands


### PR DESCRIPTION
Will fail until https://github.com/pyvista/pyvista/pull/7746 lands. In the meantime, we should be able to see the improved traceback in the CircleCI output of the touched example (which is [failing on `main`](https://app.circleci.com/pipelines/github/mne-tools/mne-python/28164/workflows/d33ebd65-7d1d-4d7b-963a-144c2be17bec/jobs/74694)) that takes
```
    3 vtkPolyData @ mne/conf.py:Resetter.__call__:after:70_fnirs_processing.py:
    list: len=1, 4 referrers: dict/list
    list: len=1, 4 referrers: dict/list
    list: len=1, 4 referrers: dict/list
```
and makes it a bit more informative:
```
    3 vtkPolyData @ mne/conf.py:Resetter.__call__:after:70_fnirs_processing.py:
    list[0] with len=1 | 3 referrers: dict['_glyph_geom'] / list[1] / list[743437]
    list[0] with len=1 | 3 referrers: dict['_glyph_geom'] / list[1] / list[743441]
    list[0] with len=1 | 3 referrers: dict['_glyph_geom'] / list[1] / list[743444]
```
which made it *way* faster to diagnose than before (I could `git grep _glyph_geom` and see it had to be a PyVista regression rather than an MNE one).