### PR TITLE
Use `clipping=3` as default in `raw.plot()`

### DIFF
--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -23,7 +23,7 @@ from .utils import (
     _shorten_path_from_middle,
 )
 
-_RAW_CLIP_DEF = 1.5
+_RAW_CLIP_DEF = 3
 
 
 @verbose

--- a/tutorials/intro/15_inplace.py
+++ b/tutorials/intro/15_inplace.py
@@ -5,16 +5,15 @@
 Modifying data in-place
 =======================
 
-Many of MNE-Python's data objects (`~mne.io.Raw`, `~mne.Epochs`, `~mne.Evoked`,
-etc) have methods that modify the data in-place (either optionally or
-obligatorily). This can be advantageous when working with large datasets
-because it reduces the amount of computer memory needed to perform the
-computations. However, it can lead to unexpected results if you're not aware
-that it's happening. This tutorial provides a few examples of in-place
-processing, and how and when to avoid it.
+Many of MNE-Python's data objects (`~mne.io.Raw`, `~mne.Epochs`, `~mne.Evoked`, etc)
+have methods that modify the data in-place (either optionally or obligatorily). This can
+be advantageous when working with large datasets because it reduces the amount of
+computer memory needed to perform the computations. However, it can lead to unexpected
+results if you're not aware that it's happening. This tutorial provides a few examples
+of in-place processing, and how and when to avoid it.
 
-As usual we'll start by importing the modules we need and loading some
-:ref:`example data <sample-dataset>`:
+As usual we'll start by importing the modules we need and loading some :ref:`example
+data <sample-dataset>`:
 """
 
 # Authors: The MNE-Python contributors.


### PR DESCRIPTION
The default was accidentally set to 1.5. This PR reverts that change and therefore makes large artifacts easier to spot in the browser. Fixes #13352.