### PR TITLE
Update license fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ keywords = [
   "neuroimaging",
   "neuroscience",
 ]
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 maintainers = [{email = "dan@mccloy.info", name = "Dan McCloy"}]
 name = "mne"
 readme = {content-type = "text/x-rst", file = "README.rst"}


### PR DESCRIPTION
As per PEP 639, licenses should be declared with two fields (see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files).