### PR TITLE
add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+# github:  # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+# patreon:  # Replace with a single Patreon username
+open_collective: mne-python
+# ko_fi:  # Replace with a single Ko-fi username
+# tidelift:  # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+# community_bridge:  # Replace with a single Community Bridge project-name e.g., cloud-foundry
+# liberapay:  # Replace with a single Liberapay username
+# issuehunt:  # Replace with a single IssueHunt username
+# lfx_crowdfunding:  # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+# polar:  # Replace with a single Polar username
+# buy_me_a_coffee:  # Replace with a single Buy Me a Coffee username
+# thanks_dev:  # Replace with a single thanks.dev username
+# custom:  # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
This should enable the sponsor button on the mne-python repo page (currently it's only enabled on the mne-tools org page)