### PR TITLE
BUG: Fix check_inside with spherical BEM

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
   pytest:
     name: '${{ matrix.os }} / ${{ matrix.kind }} / ${{ matrix.python }}'
     needs: style
-    timeout-minutes: 85
+    timeout-minutes: 90
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/doc/changes/dev/13371.bugfix.rst
+++ b/doc/changes/dev/13371.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the check in :func:`mne.make_forward_model` that all MEG sensors are outside a spherical BEM model, by `Marijn van Vliet`_

--- a/doc/changes/dev/13371.bugfix.rst
+++ b/doc/changes/dev/13371.bugfix.rst
@@ -1,1 +1,1 @@
-Fix the check in :func:`mne.make_forward_model` that all MEG sensors are outside a spherical BEM model, by `Marijn van Vliet`_
+Fix the check in :func:`mne.make_forward_solution` that all MEG sensors are outside a spherical BEM model, by `Marijn van Vliet`_

--- a/mne/forward/_make_forward.py
+++ b/mne/forward/_make_forward.py
@@ -553,9 +553,8 @@ def _prepare_for_forward(
             else:
 
                 def check_inside(x):
-                    return (
-                        np.linalg.norm(x - bem["r0"], axis=1) < bem["layers"][-1]["rad"]
-                    )
+                    r0 = apply_trans(invert_transform(mri_head_t), bem["r0"])
+                    return np.linalg.norm(x - r0, axis=1) < bem["layers"][-1]["rad"]
 
         if "meg" in sensors:
             meg_loc = apply_trans(

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -597,6 +597,7 @@ def test_make_forward_solution_sphere(tmp_path, fname_src_small):
     # not matter for the check that MEG sensors are outside the sphere.
     custom_trans = Transform("head", "mri")
     custom_trans["trans"][0, 3] = 0.05  # move MEG sensors close to mesh
+    sphere = make_sphere_model()
     fwd = make_forward_solution(fname_raw, custom_trans, src, sphere)
     assert fwd["mri_head_t"]["trans"][0, 3] == -0.05
 

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -595,10 +595,10 @@ def test_make_forward_solution_sphere(tmp_path, fname_src_small):
 
     # Since the spherical model is defined in head space, the head->MRI transform should
     # not matter for the check that MEG sensors are outside the sphere.
-    extreme_trans = Transform("head", "mri")
-    extreme_trans["trans"][0, 3] = 100  # translation of 100 meters
-    fwd = make_forward_solution(fname_raw, extreme_trans, src, sphere)
-    assert fwd["mri_head_t"]["trans"][0, 3] == -100
+    custom_trans = Transform("head", "mri")
+    custom_trans["trans"][0, 3] = 0.05  # move MEG sensors close to mesh
+    fwd = make_forward_solution(fname_raw, custom_trans, src, sphere)
+    assert fwd["mri_head_t"]["trans"][0, 3] == -0.05
 
 
 @pytest.mark.slowtest

--- a/mne/forward/tests/test_make_forward.py
+++ b/mne/forward/tests/test_make_forward.py
@@ -574,6 +574,7 @@ def test_make_forward_solution_sphere(tmp_path, fname_src_small):
             1.0,
             rtol=1e-3,
         )
+
     # Number of layers in the sphere model doesn't matter for MEG
     # (as long as no sources are omitted due to distance)
     assert len(sphere["layers"]) == 4
@@ -591,6 +592,13 @@ def test_make_forward_solution_sphere(tmp_path, fname_src_small):
     sphere = make_sphere_model(head_radius=None)
     with pytest.raises(RuntimeError, match="zero shells.*EEG"):
         make_forward_solution(fname_raw, fname_trans, src, sphere)
+
+    # Since the spherical model is defined in head space, the head->MRI transform should
+    # not matter for the check that MEG sensors are outside the sphere.
+    extreme_trans = Transform("head", "mri")
+    extreme_trans["trans"][0, 3] = 100  # translation of 100 meters
+    fwd = make_forward_solution(fname_raw, extreme_trans, src, sphere)
+    assert fwd["mri_head_t"]["trans"][0, 3] == -100
 
 
 @pytest.mark.slowtest

--- a/tools/github_actions_test.sh
+++ b/tools/github_actions_test.sh
@@ -21,6 +21,7 @@ if [[ ! -z "$CONDA_ENV" ]] && [[ "${RUNNER_OS}" != "Windows" ]] && [[ "${MNE_CI_
   INSTALL_PATH=$(python -c "import mne, pathlib; print(str(pathlib.Path(mne.__file__).parents[1]))")
   echo "Copying tests from ${PROJ_PATH}/mne-python/mne/ to ${INSTALL_PATH}/mne/"
   echo "::group::rsync mne"
+  set -x
   rsync -a --partial --progress --prune-empty-dirs --exclude="*.pyc" --include="**/" --include="**/tests/*" --include="**/tests/data/**" --exclude="**" ${PROJ_PATH}/mne/ ${INSTALL_PATH}/mne/
   echo "::endgroup::"
   echo "::group::rsync doc"
@@ -29,6 +30,7 @@ if [[ ! -z "$CONDA_ENV" ]] && [[ "${RUNNER_OS}" != "Windows" ]] && [[ "${MNE_CI_
   test -f ${INSTALL_PATH}/doc/api/reading_raw_data.rst
   cd $INSTALL_PATH
   cp -av $PROJ_PATH/pyproject.toml .
+  set +x
   echo "::endgroup::"
 fi
 

--- a/tools/github_actions_test.sh
+++ b/tools/github_actions_test.sh
@@ -22,7 +22,7 @@ if [[ ! -z "$CONDA_ENV" ]] && [[ "${RUNNER_OS}" != "Windows" ]] && [[ "${MNE_CI_
   echo "Copying tests from ${PROJ_PATH}/mne-python/mne/ to ${INSTALL_PATH}/mne/"
   echo "::group::rsync mne"
   set -x
-  rsync -a --partial --progress --prune-empty-dirs --exclude="*.pyc" --include="**/" --include="**/tests/*" --include="**/tests/data/**" --exclude="**" ${PROJ_PATH}/mne/ ${INSTALL_PATH}/mne/
+  rsync -a --partial --progress --prune-empty-dirs --exclude="*.pyc" --include="*/" --include="tests/**" --include="**/tests/*" --include="**/tests/data/**" --exclude="**" ${PROJ_PATH}/mne/ ${INSTALL_PATH}/mne/
   echo "::endgroup::"
   echo "::group::rsync doc"
   mkdir -p ${INSTALL_PATH}/doc/

--- a/tools/github_actions_test.sh
+++ b/tools/github_actions_test.sh
@@ -35,5 +35,5 @@ if [[ ! -z "$CONDA_ENV" ]] && [[ "${RUNNER_OS}" != "Windows" ]] && [[ "${MNE_CI_
 fi
 
 set -x
-pytest -m "${CONDITION}" --cov=mne --cov-report xml --color=yes --continue-on-collection-errors --junit-xml=$JUNIT_PATH -vv ${USE_DIRS} -x
+pytest -m "${CONDITION}" --cov=mne --cov-report xml --color=yes --continue-on-collection-errors --junit-xml=$JUNIT_PATH -vv ${USE_DIRS}
 echo "Exited with code $?"

--- a/tools/github_actions_test.sh
+++ b/tools/github_actions_test.sh
@@ -25,8 +25,11 @@ if [[ ! -z "$CONDA_ENV" ]] && [[ "${RUNNER_OS}" != "Windows" ]] && [[ "${MNE_CI_
   rsync -a --partial --progress --prune-empty-dirs --exclude="*.pyc" --include="**/" --include="**/tests/*" --include="**/tests/data/**" --exclude="**" ${PROJ_PATH}/mne/ ${INSTALL_PATH}/mne/
   echo "::endgroup::"
   echo "::group::rsync doc"
+  echo "mkdir"
   mkdir -p ${INSTALL_PATH}/doc/
+  echo "rsync"
   rsync -a --partial --progress --prune-empty-dirs --include="**/" --include="**/api/*" --exclude="**" ${PROJ_PATH}/doc/ ${INSTALL_PATH}/doc/
+  echo "test"
   test -f ${INSTALL_PATH}/doc/api/reading_raw_data.rst
   cd $INSTALL_PATH
   cp -av $PROJ_PATH/pyproject.toml .

--- a/tools/github_actions_test.sh
+++ b/tools/github_actions_test.sh
@@ -35,5 +35,5 @@ if [[ ! -z "$CONDA_ENV" ]] && [[ "${RUNNER_OS}" != "Windows" ]] && [[ "${MNE_CI_
 fi
 
 set -x
-pytest -m "${CONDITION}" --cov=mne --cov-report xml --color=yes --continue-on-collection-errors --junit-xml=$JUNIT_PATH -vv ${USE_DIRS}
+pytest -m "${CONDITION}" --cov=mne --cov-report xml --color=yes --continue-on-collection-errors --junit-xml=$JUNIT_PATH -vv ${USE_DIRS} -x
 echo "Exited with code $?"

--- a/tools/github_actions_test.sh
+++ b/tools/github_actions_test.sh
@@ -25,11 +25,8 @@ if [[ ! -z "$CONDA_ENV" ]] && [[ "${RUNNER_OS}" != "Windows" ]] && [[ "${MNE_CI_
   rsync -a --partial --progress --prune-empty-dirs --exclude="*.pyc" --include="**/" --include="**/tests/*" --include="**/tests/data/**" --exclude="**" ${PROJ_PATH}/mne/ ${INSTALL_PATH}/mne/
   echo "::endgroup::"
   echo "::group::rsync doc"
-  echo "mkdir"
   mkdir -p ${INSTALL_PATH}/doc/
-  echo "rsync"
-  rsync -a --partial --progress --prune-empty-dirs --include="**/" --include="**/api/*" --exclude="**" ${PROJ_PATH}/doc/ ${INSTALL_PATH}/doc/
-  echo "test"
+  rsync -a --partial --progress --prune-empty-dirs --include="api/" --include="api/*.rst" --exclude="*" ${PROJ_PATH}/doc/ ${INSTALL_PATH}/doc/
   test -f ${INSTALL_PATH}/doc/api/reading_raw_data.rst
   cd $INSTALL_PATH
   cp -av $PROJ_PATH/pyproject.toml .

--- a/tools/github_actions_test.sh
+++ b/tools/github_actions_test.sh
@@ -22,7 +22,7 @@ if [[ ! -z "$CONDA_ENV" ]] && [[ "${RUNNER_OS}" != "Windows" ]] && [[ "${MNE_CI_
   echo "Copying tests from ${PROJ_PATH}/mne-python/mne/ to ${INSTALL_PATH}/mne/"
   echo "::group::rsync mne"
   set -x
-  rsync -a --partial --progress --prune-empty-dirs --exclude="*.pyc" --include="*/" --include="tests/**" --include="**/tests/*" --include="**/tests/data/**" --exclude="**" ${PROJ_PATH}/mne/ ${INSTALL_PATH}/mne/
+  rsync -a --partial --progress --prune-empty-dirs --exclude="*.pyc" --include="*/" --include="tests/**" --include="**/tests/**" --exclude="**" ${PROJ_PATH}/mne/ ${INSTALL_PATH}/mne/
   echo "::endgroup::"
   echo "::group::rsync doc"
   mkdir -p ${INSTALL_PATH}/doc/


### PR DESCRIPTION
fixes #13370

This fixes the check for whether all MEG sensors are outside the final layer of a spherical BEM model. Since the MEG sensor locations have been transformed to MRI space, so should `r0` of the BEM model.