### PR TITLE
BUG: Fix typo in _brain causing picking to fail

### DIFF
--- a/mne/viz/_brain/_brain.py
+++ b/mne/viz/_brain/_brain.py
@@ -1203,7 +1203,7 @@ class Brain:
             # programmatically detect the picked renderer
             self._picked_renderer = self.plotter.iren.interactor.FindPokedRenderer(x, y)
             # trigger the pick
-            self._renderer._picker.Pick(x, y, 0, self.picked_renderer)
+            self._renderer._picker.Pick(x, y, 0, self._picked_renderer)
         self._mouse_no_mvt = 0
 
     def _on_pick(self, vtk_picker, event):


### PR DESCRIPTION
#13334 introduced a typo that makes picking points on a brain fail when doing it manually with a mouse. Possibly the unit test could be improved to catch this in the future, but here is a quick fix.