### PR TITLE
specify `testpaths` in pytest config

### DIFF
--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -25,6 +25,7 @@ from .utils import (
     _ensure_int,
     _import_nibabel,
     _path_like,
+    _record_warnings,
     _require_version,
     _validate_type,
     check_fname,
@@ -1786,7 +1787,7 @@ def _compute_volume_registration(
 ):
     nib = _import_nibabel("SDR morph")
     _require_version("dipy", "SDR morph", "0.10.1")
-    with np.testing.suppress_warnings():
+    with _record_warnings():
         from dipy.align import (
             affine,
             affine_registration,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -271,6 +271,10 @@ addopts = """--durations=20 --doctest-modules -rfEXs --cov-report= --tb=short \
     --ignore=mne/gui/_*.py --ignore=mne/icons --ignore=tools \
     --ignore=mne/report/js_and_css \
     --color=yes --capture=sys"""
+markers = [
+  "pgtest: test needs PyQtGraph (AKA mne-qt-browser).",
+  "pvtest: test needs PyVistaQt.",
+]
 
 [tool.rstcheck]
 ignore_directives = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,12 +265,26 @@ module = ['mne.annotations', 'mne.epochs', 'mne.evoked', 'mne.io']
 # -r f (failed), E (error), s (skipped), x (xfail), X (xpassed), w (warnings)
 # don't put in xfail for pytest 8.0+ because then it prints the tracebacks,
 # which look like real errors
-addopts = """--durations=20 --doctest-modules -rfEXs --cov-report= --tb=short \
-    --cov-branch --doctest-ignore-import-errors --junit-xml=junit-results.xml \
-    --ignore=doc --ignore=logo --ignore=examples --ignore=tutorials \
-    --ignore=mne/gui/_*.py --ignore=mne/icons --ignore=tools \
-    --ignore=mne/report/js_and_css \
-    --color=yes --capture=sys"""
+addopts = [
+  "--capture=sys",
+  "--color=yes",
+  "--cov-branch",
+  "--cov-report=",
+  "--doctest-ignore-import-errors",
+  "--doctest-modules",
+  "--durations=20",
+  "--ignore=doc",
+  "--ignore=examples",
+  "--ignore=logo",
+  "--ignore=mne/gui/_*.py",
+  "--ignore=mne/icons",
+  "--ignore=mne/report/js_and_css",
+  "--ignore=tools",
+  "--ignore=tutorials",
+  "--junit-xml=junit-results.xml",
+  "--tb=short",
+  "-rfEXs",
+]
 markers = [
   "pgtest: test needs PyQtGraph (AKA mne-qt-browser).",
   "pvtest: test needs PyVistaQt.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,10 +280,6 @@ addopts = [
   "--tb=short",
   "-rfEXs",
 ]
-markers = [
-  "pgtest: test needs PyQtGraph (AKA mne-qt-browser).",
-  "pvtest: test needs PyVistaQt.",
-]
 testpaths = [
   "mne",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,14 +273,9 @@ addopts = [
   "--doctest-ignore-import-errors",
   "--doctest-modules",
   "--durations=20",
-  "--ignore=doc",
-  "--ignore=examples",
-  "--ignore=logo",
   "--ignore=mne/gui/_*.py",
   "--ignore=mne/icons",
   "--ignore=mne/report/js_and_css",
-  "--ignore=tools",
-  "--ignore=tutorials",
   "--junit-xml=junit-results.xml",
   "--tb=short",
   "-rfEXs",
@@ -288,6 +283,9 @@ addopts = [
 markers = [
   "pgtest: test needs PyQtGraph (AKA mne-qt-browser).",
   "pvtest: test needs PyVistaQt.",
+]
+testpaths = [
+  "mne",
 ]
 
 [tool.rstcheck]


### PR DESCRIPTION
I'm seeing "undefined marker" errors during pytest collection, but only for some markers.  This registers the `pgtest` and `pvtest` marks in the pyproject.toml file (as is recommended in [the docs](https://docs.pytest.org/en/stable/example/markers.html#registering-markers)).  I don't understand why it isn't working when they're here:

https://github.com/mne-tools/mne-python/blob/f7cab3af285eb3e1e7afd3879d76b5539942a01e/mne/conftest.py#L88-L95

or why I don't see "undefined marker" for those other markers.  Possible clue: `pytest --markers` on main currently doesn't show any of those defined in conftest, but on this branch, `pytest --markers` *does* show them all, and *also* shows `pvtest` and `pgtest` twice (once from pyproject.toml and once from conftest.py).  PR is draft until I get the mystery sorted out.

Meanwhile, while I was editing the pytest table in TOML, I cleaned up our `addopts` entry a bit.