### PR TITLE
Bump Github VM MacOS-13 -> MacOS-14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,10 +82,10 @@ jobs:
             python: '3.13'
             kind: mamba
           - os: windows-latest
-            python: '3.10'
+            python: '3.12'
             kind: mamba
           - os: ubuntu-latest
-            python: '3.10'
+            python: '3.11'
             kind: minimal
           - os: ubuntu-22.04
             python: '3.10'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,10 +82,10 @@ jobs:
             python: '3.13'
             kind: mamba
           - os: windows-latest
-            python: '3.13'
+            python: '3.11'
             kind: mamba
           - os: ubuntu-latest
-            python: '3.11'
+            python: '3.12'
             kind: minimal
           - os: ubuntu-22.04
             python: '3.10'
@@ -128,7 +128,8 @@ jobs:
           # For some reason on Linux we get crashes
           if [[ "$RUNNER_OS" == "Linux" ]]; then
             sed -i "/numba/d" environment.yml
-          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+          # And on Windows and macOS PySide6.9.0 segfaults
+          elif [[ "$RUNNER_OS" == "macOS" ]] || [[ "$RUNNER_OS" == "Windows" ]]; then
             sed -i "" "s/  - PySide6 .*/  - PySide6 <6.8/g" environment.yml
           fi
         if: matrix.kind == 'conda' || matrix.kind == 'mamba'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,10 +75,10 @@ jobs:
           - os: ubuntu-latest
             python: '3.13'
             kind: conda
-          - os: macos-latest  # arm64 (Apple Silicon)
+          - os: macos-latest  # arm64 (Apple Silicon): Sequoia
             python: '3.13'
             kind: mamba
-          - os: macos-13  # latest Intel release
+          - os: macos-14  # arm64 (Apple Silicon): Sonoma
             python: '3.13'
             kind: mamba
           - os: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
             python: '3.13'
             kind: mamba
           - os: windows-latest
-            python: '3.12'
+            python: '3.13'
             kind: mamba
           - os: ubuntu-latest
             python: '3.11'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,6 +139,7 @@ jobs:
           create-args: >-
             python=${{ env.PYTHON_VERSION }}
         if: ${{ !startswith(matrix.kind, 'pip') }}
+        timeout-minutes: 20
       - run: bash ./tools/github_actions_dependencies.sh
       # Minimal commands on Linux (macOS stalls)
       - run: bash ./tools/get_minimal_commands.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,8 +129,10 @@ jobs:
           if [[ "$RUNNER_OS" == "Linux" ]]; then
             sed -i "/numba/d" environment.yml
           # And on Windows and macOS PySide6.9.0 segfaults
-          elif [[ "$RUNNER_OS" == "macOS" ]] || [[ "$RUNNER_OS" == "Windows" ]]; then
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
             sed -i "" "s/  - PySide6 .*/  - PySide6 <6.8/g" environment.yml
+          elif [[ "$RUNNER_OS" == "Windows" ]]; then
+            sed -i "s/  - PySide6 .*/  - PySide6 <6.8/g" environment.yml
           fi
         if: matrix.kind == 'conda' || matrix.kind == 'mamba'
       - uses: mamba-org/setup-micromamba@v2


### PR DESCRIPTION


<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

closes #13388


<!-- Example:

Fixes #1234.

-->


#### What does this implement/fix?

Now our tests will run against MacOS Sonoma and MacOS Sequoia, both on apple silicone architectures. I selected MacOS-14 based on the listed available runners [here](https://github.com/actions/runner-images)



#### Additional information

[Github](https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down), [Python](https://github.com/python/cpython/issues/137638) (I think), and [Apple](https://9to5mac.com/2025/06/09/apple-will-end-support-for-intel-macs/) itself are deprecating support for Intel Macs.

