### PR TITLE
Add more options to `sphere` argument in topomap plots.

### DIFF
--- a/doc/changes/dev/13400.newfeature.rst
+++ b/doc/changes/dev/13400.newfeature.rst
@@ -1,0 +1,1 @@
+Add more options for the ``sphere`` parameter of :func:`mne.viz.plot_sensors`, by `Marijn van Vliet`_

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1090,10 +1090,17 @@ def _fit_sphere_to_headshape(info, dig_kinds, *, verbose=None):
     o_mm = origin_head * 1e3
     o_d = origin_device * 1e3
     if np.linalg.norm(origin_head[:2]) > 0.02:
-        warn(
+        msg = (
             f"(X, Y) fit ({o_mm[0]:0.1f}, {o_mm[1]:0.1f}) "
             "more than 20 mm from head frame origin"
         )
+        if dig_kinds == "auto":
+            logger.info(msg)
+            logger.info('Trying again with both "extra" and "eeg" digitization points.')
+            return _fit_sphere_to_headshape(
+                info, dig_kinds=("extra", "eeg"), verbose=verbose
+            )
+        warn(msg)
     logger.info(
         "Origin head coordinates:".ljust(30)
         + f"{o_mm[0]:0.1f} {o_mm[1]:0.1f} {o_mm[2]:0.1f} mm"

--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1096,9 +1096,9 @@ def _fit_sphere_to_headshape(info, dig_kinds, *, verbose=None):
         )
         if dig_kinds == "auto":
             logger.info(msg)
-            logger.info('Trying again with both "extra" and "eeg" digitization points.')
+            logger.info("Trying again with all digitization points.")
             return _fit_sphere_to_headshape(
-                info, dig_kinds=("extra", "eeg"), verbose=verbose
+                info, dig_kinds=("extra", "eeg", "hpi", "cardinal"), verbose=verbose
             )
         warn(msg)
     logger.info(

--- a/mne/source_space/tests/test_source_space.py
+++ b/mne/source_space/tests/test_source_space.py
@@ -371,7 +371,7 @@ def test_volume_source_space(tmp_path):
     src = setup_volume_source_space(pos=10, sphere=(0.0, 0.0, 0.0, 0.09))
     src_new = setup_volume_source_space(pos=10, sphere=sphere)
     _compare_source_spaces(src, src_new, mode="exact")
-    with pytest.raises(ValueError, match="sphere, if str"):
+    with pytest.raises(ValueError, match="Invalid value for the 'sphere' parameter"):
         setup_volume_source_space(sphere="foo")
     # Need a radius
     sphere = make_sphere_model(head_radius=None)

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -1040,90 +1040,90 @@ def _check_sphere(sphere, info=None, sphere_units="m"):
                 sphere = "auto"
 
     if isinstance(sphere, str):
-        if sphere not in ("auto", "eeglab"):
-            raise ValueError(
-                f'sphere, if str, must be "auto" or "eeglab", got {sphere}'
-            )
+        _check_option(
+            "sphere", sphere, ("auto", "eeglab", "extra", "eeg", "cardinal", "hpi")
+        )
+
+    if isinstance(sphere, str) and sphere == "eeglab":
         assert info is not None
 
-        if sphere == "auto":
-            R, r0, _ = fit_sphere_to_headshape(
-                info, verbose=_verbose_safe_false(), units="m"
+        # We need coordinates for the 2D plane formed by
+        # Fpz<->Oz and T7<->T8, as this plane will be the horizon (i.e. it
+        # will determine the location of the head circle).
+        #
+        # We implement some special-handling in case Fpz is missing, as this seems to be
+        # a quite common situation in numerous EEG labs.
+        montage = info.get_montage()
+        if montage is None:
+            raise ValueError(
+                'No montage was set on your data, but sphere="eeglab" can only work if '
+                "digitization points for the EEG channels are available. Consider "
+                "calling set_montage() to apply a montage."
             )
-            sphere = tuple(r0) + (R,)
-            sphere_units = "m"
-        elif sphere == "eeglab":
-            # We need coordinates for the 2D plane formed by
-            # Fpz<->Oz and T7<->T8, as this plane will be the horizon (i.e. it
-            # will determine the location of the head circle).
-            #
-            # We implement some special-handling in case Fpz is missing, as
-            # this seems to be a quite common situation in numerous EEG labs.
-            montage = info.get_montage()
-            if montage is None:
-                raise ValueError(
-                    'No montage was set on your data, but sphere="eeglab" '
-                    "can only work if digitization points for the EEG "
-                    "channels are available. Consider calling set_montage() "
-                    "to apply a montage."
+        ch_pos = montage.get_positions()["ch_pos"]
+        horizon_ch_names = ("Fpz", "Oz", "T7", "T8")
+
+        if "FPz" in ch_pos:  # "fix" naming
+            ch_pos["Fpz"] = ch_pos["FPz"]
+            del ch_pos["FPz"]
+        elif "Fpz" not in ch_pos and "Oz" in ch_pos:
+            logger.info(
+                "Approximating Fpz location by mirroring Oz along the X and Y axes."
+            )
+            # This assumes Fpz and Oz have the same Z coordinate
+            ch_pos["Fpz"] = ch_pos["Oz"] * [-1, -1, 1]
+
+        for ch_name in horizon_ch_names:
+            if ch_name not in ch_pos:
+                msg = (
+                    f'sphere="eeglab" requires digitization points of the following '
+                    f"electrode locations in the data: {', '.join(horizon_ch_names)}, "
+                    f"but could not find: {ch_name}"
                 )
-            ch_pos = montage.get_positions()["ch_pos"]
-            horizon_ch_names = ("Fpz", "Oz", "T7", "T8")
+                if ch_name == "Fpz":
+                    msg += ", and was unable to approximate its location from Oz"
+                raise ValueError(msg)
 
-            if "FPz" in ch_pos:  # "fix" naming
-                ch_pos["Fpz"] = ch_pos["FPz"]
-                del ch_pos["FPz"]
-            elif "Fpz" not in ch_pos and "Oz" in ch_pos:
-                logger.info(
-                    "Approximating Fpz location by mirroring Oz along the X and Y axes."
-                )
-                # This assumes Fpz and Oz have the same Z coordinate
-                ch_pos["Fpz"] = ch_pos["Oz"] * [-1, -1, 1]
+        # Calculate the radius from: T7<->T8, Fpz<->Oz
+        radius = np.abs(
+            [
+                ch_pos["T7"][0],  # X axis
+                ch_pos["T8"][0],  # X axis
+                ch_pos["Fpz"][1],  # Y axis
+                ch_pos["Oz"][1],  # Y axis
+            ]
+        ).mean()
 
-            for ch_name in horizon_ch_names:
-                if ch_name not in ch_pos:
-                    msg = (
-                        f'sphere="eeglab" requires digitization points of '
-                        f"the following electrode locations in the data: "
-                        f"{', '.join(horizon_ch_names)}, but could not find: "
-                        f"{ch_name}"
-                    )
-                    if ch_name == "Fpz":
-                        msg += ", and was unable to approximate its location from Oz"
-                    raise ValueError(msg)
-
-            # Calculate the radius from: T7<->T8, Fpz<->Oz
-            radius = np.abs(
+        # Calculate the center of the head sphere.
+        # Use 4 digpoints for each of the 3 axes to hopefully get a better approximation
+        # than when using just 2 digpoints.
+        sphere_locs = dict()
+        for idx, axis in enumerate(("X", "Y", "Z")):
+            sphere_locs[axis] = np.mean(
                 [
-                    ch_pos["T7"][0],  # X axis
-                    ch_pos["T8"][0],  # X axis
-                    ch_pos["Fpz"][1],  # Y axis
-                    ch_pos["Oz"][1],  # Y axis
+                    ch_pos["T7"][idx],
+                    ch_pos["T8"][idx],
+                    ch_pos["Fpz"][idx],
+                    ch_pos["Oz"][idx],
                 ]
-            ).mean()
-
-            # Calculate the center of the head sphere
-            # Use 4 digpoints for each of the 3 axes to hopefully get a better
-            # approximation than when using just 2 digpoints.
-            sphere_locs = dict()
-            for idx, axis in enumerate(("X", "Y", "Z")):
-                sphere_locs[axis] = np.mean(
-                    [
-                        ch_pos["T7"][idx],
-                        ch_pos["T8"][idx],
-                        ch_pos["Fpz"][idx],
-                        ch_pos["Oz"][idx],
-                    ]
-                )
-            sphere = (sphere_locs["X"], sphere_locs["Y"], sphere_locs["Z"], radius)
-            sphere_units = "m"
-            del sphere_locs, radius, montage, ch_pos
+            )
+        sphere = (sphere_locs["X"], sphere_locs["Y"], sphere_locs["Z"], radius)
+        sphere_units = "m"
+        del sphere_locs, radius, montage, ch_pos
+    elif isinstance(sphere, str) or (
+        isinstance(sphere, list) and all(isinstance(s, str) for s in sphere)
+    ):
+        # Fit a sphere to the head points.
+        R, r0, _ = fit_sphere_to_headshape(
+            info, dig_kinds=sphere, verbose=_verbose_safe_false(), units="m"
+        )
+        sphere = tuple(r0) + (R,)
+        sphere_units = "m"
     elif isinstance(sphere, ConductorModel):
         if not sphere["is_sphere"] or len(sphere["layers"]) == 0:
             raise ValueError(
-                "sphere, if a ConductorModel, must be spherical "
-                "with multiple layers, not a BEM or single-layer "
-                f"sphere (got {sphere})"
+                "sphere, if a ConductorModel, must be spherical with multiple layers, "
+                f"not a BEM or single-layer sphere (got {sphere})"
             )
         sphere = tuple(sphere["r0"]) + (sphere["layers"][0]["rad"],)
         sphere_units = "m"
@@ -1132,8 +1132,8 @@ def _check_sphere(sphere, info=None, sphere_units="m"):
         sphere = np.concatenate([[0.0] * 3, [sphere]])
     if sphere.shape != (4,):
         raise ValueError(
-            "sphere must be float or 1D array of shape (4,), got "
-            f"array-like of shape {sphere.shape}"
+            "sphere must be float or 1D array of shape (4,), "
+            f"got array-like of shape {sphere.shape}"
         )
     _check_option("sphere_units", sphere_units, ("m", "mm"))
     if sphere_units == "mm":

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -4217,21 +4217,40 @@ spatial_colors : bool
 """
 
 docdict["sphere_topomap_auto"] = f"""\
-sphere : float | array-like | instance of ConductorModel | None  | 'auto' | 'eeglab'
-    The sphere parameters to use for the head outline. Can be array-like of
-    shape (4,) to give the X/Y/Z origin and radius in meters, or a single float
-    to give just the radius (origin assumed 0, 0, 0). Can also be an instance
-    of a spherical :class:`~mne.bem.ConductorModel` to use the origin and
-    radius from that object. If ``'auto'`` the sphere is fit to digitization
-    points. If ``'eeglab'`` the head circle is defined by EEG electrodes
-    ``'Fpz'``, ``'Oz'``, ``'T7'``, and ``'T8'`` (if ``'Fpz'`` is not present,
-    it will be approximated from the coordinates of ``'Oz'``). ``None`` (the
-    default) is equivalent to ``'auto'`` when enough extra digitization points
-    are available, and (0, 0, 0, {HEAD_SIZE_DEFAULT}) otherwise.
+sphere : float | array-like of float | instance of ConductorModel | str | list of str | None
+    The sphere parameters to use for the head outline.
+    Can be array-like of shape (4,) to give the X/Y/Z origin and radius in meters, or a
+    single float to give just the radius (origin assumed 0, 0, 0).
+    Can also be an instance of a spherical :class:`~mne.bem.ConductorModel` to use the
+    origin and radius from that object.
+    Can also be a ``str``, in which case:
+
+    - ``'auto'``: the sphere is fit to external digitization points first, and to
+      external + EEG digitization points if the former fails.
+
+    - ``'eeglab'``: the head circle is defined by EEG electrodes ``'Fpz'``, ``'Oz'``,
+      ``'T7'``, and ``'T8'`` (if ``'Fpz'`` is not present, it will be approximated from
+      the coordinates of ``'Oz'``).
+
+      - ``'extra'``: the sphere is fit to external digitization points.
+
+      - ``'eeg'``: the sphere is fit to EEG digitization points.
+
+      - ``'cardinal'``: the sphere is fit to cardinal digitization points.
+
+      - ``'hpi'``: the sphere is fit to HPI coil digitization points.
+
+    Can also be a list of ``str``, in which case the sphere is fit to the specified
+    digitization points, which can be any combination of ``'extra'``, ``'eeg'``,
+    ``'cardinal'``, and ``'hpi'``, as specified above.
+    ``None`` (the default) is equivalent to ``'auto'`` when enough extra digitization
+    points are available, and (0, 0, 0, {HEAD_SIZE_DEFAULT}) otherwise.
 
     .. versionadded:: 0.20
     .. versionchanged:: 1.1 Added ``'eeglab'`` option.
-"""
+    .. versionchanged:: 1.11 Added ``'extra'``, ``'eeg'``, ``'cardinal'``, ``'hpi'`` and
+       list of ``str`` options.
+"""  # noqa E501
 
 docdict["splash"] = """
 splash : bool

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -10,9 +10,10 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 
 import mne
-from mne import pick_channels_cov, read_vectorview_selection
+from mne import create_info, pick_channels_cov, read_vectorview_selection
 from mne._fiff.pick import _picks_to_idx
 from mne.datasets import testing
 from mne.utils import (
@@ -364,15 +365,48 @@ def test_strip_dev(version, want, have_unstripped, monkeypatch):
 
 
 @testing.requires_testing_data
-def test_check_sphere_verbose():
-    """Test that verbose is handled properly in _check_sphere."""
+def test_check_sphere():
+    """Test the _check_sphere function."""
     info = mne.io.read_info(fname_raw)
-    with info._unlock():
-        info["dig"] = info["dig"][:20]
+
+    # Test passing None.
+    assert_equal(_check_sphere(None), [0, 0, 0, 0.095])  # default head pos
+    assert not np.any(_check_sphere(None, info) == 0)  # fit to dig points
+
+    # Test passing a 4-element array-like as sphere parameter.
+    assert_equal(_check_sphere([1, 2, 3, 4], info), [1, 2, 3, 4])
+    assert_equal(_check_sphere([1, 2, 3, 4], info=None), [1, 2, 3, 4])
+    with pytest.raises(ValueError, match=r"1D array of shape \(4,\)"):
+        _check_sphere([1, 2, 3], info)
+
+    # Test passing various strings.
+    assert_allclose(
+        _check_sphere("auto", info), [-0.00415196, 0.01635826, 0.05183149, 0.09117732]
+    )
+    assert_allclose(_check_sphere("extra", info), _check_sphere("auto", info))
+    assert_allclose(
+        _check_sphere("eeg", info),
+        [-0.00291458, 0.01068758, 0.05653534, 0.09027862],
+        atol=1e-8,
+    )
+    info_eeglab = create_info(
+        ch_names=["Fpz", "Oz", "T7", "T8"], sfreq=100, ch_types="eeg"
+    )
+    info_eeglab.set_montage("biosemi64")
+    assert_allclose(
+        _check_sphere("eeglab", info_eeglab), [0, 0, 0.036, 0.095], atol=1e-3
+    )
+    with pytest.raises(TypeError, match="Item must be an instance of Info"):
+        _check_sphere("auto", info=None)
+
+    # Test that verbose is handled properly in _check_sphere.
+    info_trunc = info.copy()
+    with info_trunc._unlock():
+        info_trunc["dig"] = info_trunc["dig"][:20]
     with _record_warnings(), pytest.warns(RuntimeWarning, match="may be inaccurate"):
-        _check_sphere("auto", info)
+        _check_sphere("auto", info_trunc)
     with mne.use_log_level("error"):
-        _check_sphere("auto", info)
+        _check_sphere("auto", info_trunc)
 
 
 def test_soft_import():

--- a/mne/utils/tests/test_check.py
+++ b/mne/utils/tests/test_check.py
@@ -390,11 +390,13 @@ def test_check_sphere():
     sphere_eeg = _check_sphere("eeg", info)
     with _record_warnings(), pytest.warns(RuntimeWarning, match="may be inaccurate"):
         sphere_hpi = _check_sphere("hpi", info)
+    sphere_all = _check_sphere(["extra", "eeg", "cardinal", "hpi"], info)
 
     assert_allclose(sphere_auto, sphere_extra)
     assert not np.allclose(sphere_auto, sphere_eeglab, rtol=1e-4, atol=1e-4)
     assert not np.allclose(sphere_auto, sphere_eeg, rtol=1e-4, atol=1e-4)
     assert not np.allclose(sphere_auto, sphere_hpi, rtol=1e-4, atol=1e-4)
+    assert not np.allclose(sphere_auto, sphere_all, rtol=1e-4, atol=1e-4)
 
     with pytest.raises(TypeError, match="Item must be an instance of Info"):
         _check_sphere("auto", info=None)

--- a/tutorials/intro/40_sensor_locations.py
+++ b/tutorials/intro/40_sensor_locations.py
@@ -5,9 +5,9 @@
 Working with sensor locations
 =============================
 
-This tutorial describes how to read and plot sensor locations, and how
-MNE-Python handles physical locations of sensors.
-As usual we'll start by importing the modules we need:
+This tutorial describes how to read and plot sensor locations, and how MNE-Python
+handles physical locations of sensors. As usual we'll start by importing the modules we
+need:
 """
 # Authors: The MNE-Python contributors.
 # License: BSD-3-Clause
@@ -26,77 +26,70 @@ import mne
 # About montages and layouts
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# `Montages <mne.channels.DigMontage>` contain sensor positions in 3D (x, y, z
-# in meters), which can be assigned to existing EEG/MEG data. By specifying the
-# locations of sensors relative to the brain,
-# `Montages <mne.channels.DigMontage>` play an important role in computing the
-# forward solution and inverse estimates.
+# `Montages <mne.channels.DigMontage>` contain sensor positions in 3D (x, y, z in
+# meters), which can be assigned to existing EEG/MEG data. By specifying the locations
+# of sensors relative to the brain, `Montages <mne.channels.DigMontage>` play an
+# important role in computing the forward solution and inverse estimates.
 #
-# In contrast, `Layouts <mne.channels.Layout>` are *idealized* 2D
-# representations of sensor positions. They are primarily used for arranging
-# individual sensor subplots in a topoplot or for showing the *approximate*
-# relative arrangement of sensors as seen from above.
+# In contrast, `Layouts <mne.channels.Layout>` are *idealized* 2D representations of
+# sensor positions. They are primarily used for arranging individual sensor subplots in
+# a topoplot or for showing the *approximate* relative arrangement of sensors as seen
+# from above.
 #
 # .. note::
 #
-#    If you're working with EEG data exclusively, you'll want to use
-#    `Montages <mne.channels.DigMontage>`, not layouts. Idealized montages
-#    (e.g., those provided by the manufacturer, or the ones shipping with
-#    MNE-Python mentioned below) are typically referred to as
-#    :term:`template montages <template montage>`.
+#    If you're working with EEG data exclusively, you'll want to use `Montages
+#    <mne.channels.DigMontage>`, not layouts. Idealized montages (e.g., those provided
+#    by the manufacturer, or the ones shipping with MNE-Python mentioned below) are
+#    typically referred to as :term:`template montages <template montage>`.
 #
 # Working with built-in montages
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # .. admonition:: Computing sensor locations
 #     :class: sidebar note
 #
-#     If you are interested in how standard (idealized) EEG sensor positions
-#     are computed on a spherical head model, make sure to check out the
-#     `eeg_positions`_ repository.
+#     If you are interested in how standard (idealized) EEG sensor positions are
+#     computed on a spherical head model, make sure to check out the `eeg_positions`_
+#     repository.
 #
-# The 3D coordinates of MEG sensors are included in the raw recordings from MEG
-# systems. They are automatically stored in the ``info`` attribute of the
-# `~mne.io.Raw` object upon loading. EEG electrode locations are much more
-# variable because of differences in head shape. Idealized montages
-# (":term:`template montages <template montage>`") for many EEG systems are
-# included in MNE-Python, and you can get an overview of them by using
-# :func:`mne.channels.get_builtin_montages`:
+# The 3D coordinates of MEG sensors are included in the raw recordings from MEG systems.
+# They are automatically stored in the ``info`` attribute of the `~mne.io.Raw` object
+# upon loading. EEG electrode locations are much more variable because of differences in
+# head shape. Idealized montages (":term:`template montages <template montage>`") for
+# many EEG systems are included in MNE-Python, and you can get an overview of them by
+# using :func:`mne.channels.get_builtin_montages`:
 
 builtin_montages = mne.channels.get_builtin_montages(descriptions=True)
 for montage_name, montage_description in builtin_montages:
     print(f"{montage_name}: {montage_description}")
 
 # %%
-# These built-in EEG montages can be loaded with
-# `mne.channels.make_standard_montage`:
+# These built-in EEG montages can be loaded with `mne.channels.make_standard_montage`:
 
 easycap_montage = mne.channels.make_standard_montage("easycap-M1")
 print(easycap_montage)
 
 # %%
-# `Montage <mne.channels.DigMontage>` objects have a
-# `~mne.channels.DigMontage.plot` method for visualizing the sensor locations
-# in 2D or 3D:
+# `Montage <mne.channels.DigMontage>` objects have a `~mne.channels.DigMontage.plot`
+# method for visualizing the sensor locations in 2D or 3D:
 
 easycap_montage.plot()  # 2D
 fig = easycap_montage.plot(kind="3d", show=False)  # 3D
 fig = fig.gca().view_init(azim=70, elev=15)  # set view angle for tutorial
 
 # %%
-# Once loaded, a montage can be applied to data with the
-# `~mne.io.Raw.set_montage` method, for example
-# `raw.set_montage() <mne.io.Raw.set_montage>`,
-# `epochs.set_montage() <mne.Epochs.set_montage>`, or
-# `evoked.set_montage() <mne.Evoked.set_montage>`. This will only work with
-# data whose EEG channel names correspond to those in the montage.
-# (Therefore, we're loading some EEG data below, and not the usual MNE "sample"
-# dataset.)
+# Once loaded, a montage can be applied to data with the `~mne.io.Raw.set_montage`
+# method, for example `raw.set_montage() <mne.io.Raw.set_montage>`,
+# `epochs.set_montage() <mne.Epochs.set_montage>`, or `evoked.set_montage()
+# <mne.Evoked.set_montage>`. This will only work with data whose EEG channel names
+# correspond to those in the montage. (Therefore, we're loading some EEG data below, and
+# not the usual MNE "sample" dataset.)
 #
-# You can then visualize the sensor locations via the
-# :meth:`~mne.io.Raw.plot_sensors` method.
+# You can then visualize the sensor locations via the :meth:`~mne.io.Raw.plot_sensors`
+# method.
 #
-# It is also possible to skip the manual montage loading step by passing the
-# montage name directly to the :meth:`~mne.io.Raw.set_montage` method.
+# It is also possible to skip the manual montage loading step by passing the montage
+# name directly to the :meth:`~mne.io.Raw.set_montage` method.
 
 ssvep_folder = mne.datasets.ssvep.data_path()
 ssvep_data_raw_path = (
@@ -115,13 +108,12 @@ fig = ssvep_raw.plot_sensors(show_names=True)
 # %%
 # .. note::
 #
-#    You may have noticed that the figures created via
-#    :meth:`~mne.io.Raw.plot_sensors` contain fewer sensors than the result of
-#    `easycap_montage.plot() <mne.channels.DigMontage.plot>`. This is because
-#    the montage contains *all channels defined for that EEG system*; but not
-#    all recordings will necessarily use all possible channels. Thus when
-#    applying a montage to an actual EEG dataset, information about sensors
-#    that are not actually present in the data is removed.
+#    You may have noticed that the figures created via :meth:`~mne.io.Raw.plot_sensors`
+#    contain fewer sensors than the result of `easycap_montage.plot()
+#    <mne.channels.DigMontage.plot>`. This is because the montage contains *all channels
+#    defined for that EEG system*; but not all recordings will necessarily use all
+#    possible channels. Thus when applying a montage to an actual EEG dataset,
+#    information about sensors that are not actually present in the data is removed.
 #
 # Plotting 2D sensor locations like EEGLAB
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -129,37 +121,36 @@ fig = ssvep_raw.plot_sensors(show_names=True)
 # .. admonition:: The ``sphere`` keyword is available in many places!
 #     :class: sidebar hint
 #
-#     All MNE plotting functions for EEG topographies and sensor locations
-#     support the ``sphere`` keyword argument, and therefore allow for
-#     adjustment of the way the sensors are projected onto the head circle.
+#     All MNE plotting functions for EEG topographies and sensor locations support the
+#     ``sphere`` keyword argument, and therefore allow for adjustment of the way the
+#     sensors are projected onto the head circle.
 #
-# In MNE-Python, by default the head center is calculated using
-# :term:`fiducial points <fiducial>`. This means that
-# the head circle represents the head circumference **at the nasion and ear
-# level,** and not where it is commonly measured in the 10–20 EEG system
-# (i.e., above the nasion at T4/T8, T3/T7, Oz, and Fpz).
+# In MNE-Python, by default the head center is calculated using :term:`fiducial points
+# <fiducial>`. This means that the head circle represents the head circumference **at
+# the nasion and ear level,** and not where it is commonly measured in the 10–20 EEG
+# system (i.e., above the nasion at T4/T8, T3/T7, Oz, and Fpz).
 #
-# If you prefer to draw the head circle using 10–20 conventions (which are also
-# used by EEGLAB), you can pass ``sphere='eeglab'``:
+# If you prefer to draw the head circle using 10–20 conventions (which are also used by
+# EEGLAB), you can pass ``sphere='eeglab'``:
 
 fig = ssvep_raw.plot_sensors(show_names=True, sphere="eeglab")
 
 # %%
-# Because the data we're using here doesn't contain an Fpz channel, its
-# putative location was approximated automatically.
+# Because the data we're using here doesn't contain an Fpz channel, its putative
+# location was approximated automatically.
 #
 # .. _control-chan-projection:
 #
 # Manually controlling 2D channel projection
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# Channel positions in 2D space are obtained by projecting their actual 3D
-# positions onto a sphere, then projecting the sphere onto a plane.
-# By default, a sphere with origin at ``(0, 0, 0)`` (x, y, z coordinates) and
-# radius of ``0.095`` meters (9.5 cm) is used. You can use a different sphere
-# radius by passing a single value as the  ``sphere`` argument in any function
-# that plots channels in 2D (like `~mne.channels.DigMontage.plot` that we use
-# here, but also for example `mne.viz.plot_topomap`):
+# Channel positions in 2D space are obtained by projecting their actual 3D positions
+# onto a sphere, then projecting the sphere onto a plane. By default, a sphere with
+# origin at ``(0, 0, 0)`` (x, y, z coordinates) and radius of ``0.095`` meters (9.5 cm)
+# is used. You can use a different sphere radius by passing a single value as the
+# ``sphere`` argument in any function that plots channels in 2D (like
+# `~mne.channels.DigMontage.plot` that we use here, but also for example
+# `mne.viz.plot_topomap`):
 
 fig1 = easycap_montage.plot()  # default radius of 0.095
 fig2 = easycap_montage.plot(sphere=0.07)
@@ -176,17 +167,16 @@ fig = easycap_montage.plot(sphere=(0.03, 0.02, 0.01, 0.075))
 # Reading sensor digitization files
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# In the sample data, the sensor positions are already available in the
-# ``info`` attribute of the `~mne.io.Raw` object (see the documentation of the
-# reading functions and :meth:`~mne.io.Raw.set_montage` for details on how that
-# works). Therefore, we can plot sensor locations directly from the
-# `~mne.io.Raw` object using :meth:`~mne.io.Raw.plot_sensors`, which provides
-# similar functionality to `montage.plot() <mne.channels.DigMontage.plot>`. In
-# addition, :meth:`~mne.io.Raw.plot_sensors` supports channel selection by
-# type, color-coding channels in various ways (by default, channels listed in
-# ``raw.info['bads']`` will be plotted in red), and drawing in an existing
-# Matplotlib ``Axes`` object (so the channel positions can easily be added as a
-# subplot in a multi-panel figure):
+# In the sample data, the sensor positions are already available in the ``info``
+# attribute of the `~mne.io.Raw` object (see the documentation of the reading functions
+# and :meth:`~mne.io.Raw.set_montage` for details on how that works). Therefore, we can
+# plot sensor locations directly from the `~mne.io.Raw` object using
+# :meth:`~mne.io.Raw.plot_sensors`, which provides similar functionality to
+# `montage.plot() <mne.channels.DigMontage.plot>`. In addition,
+# :meth:`~mne.io.Raw.plot_sensors` supports channel selection by type, color-coding
+# channels in various ways (by default, channels listed in ``raw.info['bads']`` will be
+# plotted in red), and drawing in an existing Matplotlib ``Axes`` object (so the channel
+# positions can easily be added as a subplot in a multi-panel figure):
 
 sample_data_folder = mne.datasets.sample.data_path()
 sample_data_raw_path = sample_data_folder / "MEG" / "sample" / "sample_audvis_raw.fif"
@@ -201,35 +191,32 @@ sample_raw.plot_sensors(ch_type="eeg", axes=ax3d, kind="3d")
 ax3d.view_init(azim=70, elev=15)
 
 # %%
-# The previous 2D topomap reveals irregularities in the EEG sensor positions in
-# the :ref:`sample dataset <sample-dataset>` — this is because the sensor
-# positions in that dataset are digitizations of actual sensor positions on the
-# head rather than idealized sensor positions based on a spherical head model.
-# Depending on the digitization device (e.g., a Polhemus Fastrak digitizer),
-# you need to use different montage reading functions (see :ref:`dig-formats`).
-# The resulting `montage <mne.channels.DigMontage>` can then be added to
-# `~mne.io.Raw` objects by passing it as an argument to the
-# :meth:`~mne.io.Raw.set_montage` method (just as we did before with the name
-# of the predefined ``'standard_1020'`` montage). Once loaded, locations can be
-# plotted with the :meth:`~mne.channels.DigMontage.plot` method and saved with
-# the :meth:`~mne.channels.DigMontage.save` method of the
+# The previous 2D topomap reveals irregularities in the EEG sensor positions in the
+# :ref:`sample dataset <sample-dataset>` — this is because the sensor positions in that
+# dataset are digitizations of actual sensor positions on the head rather than idealized
+# sensor positions based on a spherical head model. Depending on the digitization device
+# (e.g., a Polhemus Fastrak digitizer), you need to use different montage reading
+# functions (see :ref:`dig-formats`). The resulting `montage <mne.channels.DigMontage>`
+# can then be added to `~mne.io.Raw` objects by passing it as an argument to the
+# :meth:`~mne.io.Raw.set_montage` method (just as we did before with the name of the
+# predefined ``'standard_1020'`` montage). Once loaded, locations can be plotted with
+# the :meth:`~mne.channels.DigMontage.plot` method and saved with the
+# :meth:`~mne.channels.DigMontage.save` method of the
 # `montage <mne.channels.DigMontage>` object.
 #
 # .. note::
 #
-#     When setting a montage with :meth:`~mne.io.Raw.set_montage`, the
-#     measurement info is updated in two places (both ``chs`` and ``dig``
-#     entries are updated) – see :ref:`tut-info-class` for more details. Note
-#     that ``dig`` may contain HPI, fiducial, or head shape points in addition
-#     to electrode locations.
+#     When setting a montage with :meth:`~mne.io.Raw.set_montage`, the measurement info
+#     is updated in two places (both ``chs`` and ``dig`` entries are updated) – see
+#     :ref:`tut-info-class` for more details. Note that ``dig`` may contain HPI,
+#     fiducial, or head shape points in addition to electrode locations.
 #
 #
 # Visualizing sensors in 3D surface renderings
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# It is also possible to render an image of an MEG sensor helmet using 3D
-# surface rendering instead of matplotlib. This works by calling
-# :func:`mne.viz.plot_alignment`:
+# It is also possible to render an image of an MEG sensor helmet using 3D surface
+# rendering instead of matplotlib. This works by calling :func:`mne.viz.plot_alignment`:
 
 fig = mne.viz.plot_alignment(
     sample_raw.info,
@@ -242,20 +229,20 @@ fig = mne.viz.plot_alignment(
 mne.viz.set_3d_view(fig, azimuth=50, elevation=90, distance=0.5)
 
 # %%
-# Note that :func:`~mne.viz.plot_alignment` requires an `~mne.Info` object, and
-# can also render MRI surfaces of the scalp, skull, and brain (by passing a
-# dict with keys like ``'head'``, ``'outer_skull'`` or ``'brain'`` to the
-# ``surfaces`` parameter). This makes the function useful for
-# :ref:`assessing coordinate frame transformations <tut-source-alignment>`.
-# For examples of various uses of :func:`~mne.viz.plot_alignment`, see
-# :ref:`plot_montage`, :ref:`ex-eeg-on-scalp`, and :ref:`ex-plot-meg-sensors`.
+# Note that :func:`~mne.viz.plot_alignment` requires an `~mne.Info` object, and can also
+# render MRI surfaces of the scalp, skull, and brain (by passing a dict with keys like
+# ``'head'``, ``'outer_skull'`` or ``'brain'`` to the ``surfaces`` parameter). This
+# makes the function useful for :ref:`assessing coordinate frame transformations
+# <tut-source-alignment>`. For examples of various uses of
+# :func:`~mne.viz.plot_alignment`, see :ref:`plot_montage`, :ref:`ex-eeg-on-scalp`, and
+# :ref:`ex-plot-meg-sensors`.
 #
 #
 # Working with layout files
 # ^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# Similar to montages, many layout files are included with MNE-Python. They are
-# stored in the :file:`mne/channels/data/layouts` folder:
+# Similar to montages, many layout files are included with MNE-Python. They are stored
+# in the :file:`mne/channels/data/layouts` folder:
 
 layout_dir = Path(mne.__file__).parent / "channels" / "data" / "layouts"
 layouts = sorted(path.name for path in layout_dir.iterdir())
@@ -263,29 +250,27 @@ print("\nBUILT-IN LAYOUTS\n================")
 print("\n".join(layouts))
 
 # %%
-# To load a layout file, use the `mne.channels.read_layout` function.
-# You can then visualize the layout using its
-# `~mne.channels.Layout.plot` method:
+# To load a layout file, use the `mne.channels.read_layout` function. You can then
+# visualize the layout using its `~mne.channels.Layout.plot` method:
 
 biosemi_layout = mne.channels.read_layout("biosemi")
 
 # %%
-# Similar to the ``picks`` argument for selecting channels from `~mne.io.Raw`
-# objects, the :meth:`~mne.channels.Layout.plot` method of
-# `~mne.channels.Layout` objects also has a ``picks`` argument. However,
-# because layouts only contain information about sensor name and location (not
-# sensor type), the :meth:`~mne.channels.Layout.plot` method only supports
-# picking channels by index (not by name or by type). In the following example,
-# we find the desired indices using :func:`numpy.where`; selection by name or
-# type is possible with :func:`mne.pick_channels` or :func:`mne.pick_types`.
+# Similar to the ``picks`` argument for selecting channels from `~mne.io.Raw` objects,
+# the :meth:`~mne.channels.Layout.plot` method of `~mne.channels.Layout` objects also
+# has a ``picks`` argument. However, because layouts only contain information about
+# sensor name and location (not sensor type), the :meth:`~mne.channels.Layout.plot`
+# method only supports picking channels by index (not by name or by type). In the
+# following example, we find the desired indices using :func:`numpy.where`; selection by
+# name or type is possible with :func:`mne.pick_channels` or :func:`mne.pick_types`.
 
 midline = np.where([name.endswith("z") for name in biosemi_layout.names])[0]
 biosemi_layout.plot(picks=midline)
 
 # %%
-# If you have a `~mne.io.Raw` object that contains sensor positions, you can
-# create a `~mne.channels.Layout` object with either
-# :func:`mne.channels.make_eeg_layout` or :func:`mne.channels.find_layout`.
+# If you have a `~mne.io.Raw` object that contains sensor positions, you can create a
+# `~mne.channels.Layout` object with either :func:`mne.channels.make_eeg_layout` or
+# :func:`mne.channels.find_layout`.
 
 layout_from_raw = mne.channels.make_eeg_layout(sample_raw.info)
 # same result as mne.channels.find_layout(raw.info, ch_type='eeg')
@@ -294,20 +279,18 @@ layout_from_raw.plot()
 # %%
 # .. note::
 #
-#     There is no corresponding ``make_meg_layout()`` function because sensor
-#     locations are fixed in an MEG system (unlike in EEG, where sensor caps
-#     deform to fit snugly on a specific head). Therefore, MEG layouts are
-#     consistent (constant) for a given system and you can simply load them
-#     with :func:`mne.channels.read_layout` or use
-#     :func:`mne.channels.find_layout` with
-#     the ``ch_type`` parameter (as previously demonstrated for EEG).
+#     There is no corresponding ``make_meg_layout()`` function because sensor locations
+#     are fixed in an MEG system (unlike in EEG, where sensor caps deform to fit snugly
+#     on a specific head). Therefore, MEG layouts are consistent (constant) for a given
+#     system and you can simply load them with :func:`mne.channels.read_layout` or use
+#     :func:`mne.channels.find_layout` with the ``ch_type`` parameter (as previously
+#     demonstrated for EEG).
 #
-# All `~mne.channels.Layout` objects have a `~mne.channels.Layout.save` method
-# that writes layouts to disk as either :file:`.lout` or :file:`.lay` formats
-# (inferred from the file extension contained in the ``fname`` argument). The
-# choice between :file:`.lout` and :file:`.lay` format only matters if you need
-# to load the layout file in some other application (MNE-Python can read both
-# formats).
+# All `~mne.channels.Layout` objects have a `~mne.channels.Layout.save` method that
+# writes layouts to disk as either :file:`.lout` or :file:`.lay` formats (inferred from
+# the file extension contained in the ``fname`` argument). The choice between
+# :file:`.lout` and :file:`.lay` format only matters if you need to load the layout file
+# in some other application (MNE-Python can read both formats).
 #
 #
 # .. LINKS


### PR DESCRIPTION
Fixes #13399

This PR adds some more options to the `sphere` argument of `plot_sensors`. With this you can control what digitized points the sphere is fitted to. Specifically, it now passes the `sphere` string on to `mne.bem.fit_sphere_to_headshape` as `dig_kinds`, so supports all the options for that function. For example, to fix #13399, one could do: `raw.plot_sensors(ch_type="eeg", sphere="eeg")` to fit the sphere to just the EEG digitization points.

In addition, the `"auto"` setting has been made a bit more clever. By default, it tries to fit the sphere with just the `"extra"` digitization points just like before. The new thing is that if it produces a weird fit that generates a warning about an unlikely head position, it will now try again with all digitization points. This also fixes #13399.
