### PR TITLE
reroute internal dependency

### DIFF
--- a/mne/preprocessing/_regress.py
+++ b/mne/preprocessing/_regress.py
@@ -5,11 +5,11 @@
 import numpy as np
 
 from .._fiff.pick import _picks_to_idx, pick_info
+from .._fiff.proj import _needs_eeg_average_ref_proj
 from ..defaults import _BORDER_DEFAULT, _EXTRAPOLATE_DEFAULT, _INTERPOLATION_DEFAULT
 from ..epochs import BaseEpochs
 from ..evoked import Evoked
 from ..io import BaseRaw
-from ..minimum_norm.inverse import _needs_eeg_average_ref_proj
 from ..utils import (
     _check_fname,
     _check_option,


### PR DESCRIPTION
closes #13160

[Tach](https://github.com/gauge-sh/tach) is now unmaintained, so let's abandon the idea of using it in our CIs. This PR fixes the one odd internal dependency that tach found that was *easy* to fix. Any further steps toward modularization will be a considerable undertaking, and are left for another day.