### PR TITLE
remove all empty __init__ files in test folders

### DIFF
--- a/mne/beamformer/tests/__init__.py
+++ b/mne/beamformer/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/channels/tests/__init__.py
+++ b/mne/channels/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/commands/tests/__init__.py
+++ b/mne/commands/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/datasets/tests/__init__.py
+++ b/mne/datasets/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/decoding/tests/__init__.py
+++ b/mne/decoding/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/forward/tests/__init__.py
+++ b/mne/forward/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/gui/tests/__init__.py
+++ b/mne/gui/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/inverse_sparse/tests/__init__.py
+++ b/mne/inverse_sparse/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/ant/tests/__init__.py
+++ b/mne/io/ant/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/array/tests/__init__.py
+++ b/mne/io/array/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/artemis123/tests/__init__.py
+++ b/mne/io/artemis123/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/boxy/tests/__init__.py
+++ b/mne/io/boxy/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/brainvision/tests/__init__.py
+++ b/mne/io/brainvision/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/bti/tests/__init__.py
+++ b/mne/io/bti/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/cnt/tests/__init__.py
+++ b/mne/io/cnt/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/ctf/tests/__init__.py
+++ b/mne/io/ctf/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/curry/tests/__init__.py
+++ b/mne/io/curry/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/edf/tests/__init__.py
+++ b/mne/io/edf/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/eeglab/tests/__init__.py
+++ b/mne/io/eeglab/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/egi/tests/__init__.py
+++ b/mne/io/egi/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/eximia/tests/__init__.py
+++ b/mne/io/eximia/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/eyelink/tests/__init__.py
+++ b/mne/io/eyelink/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/fieldtrip/tests/__init__.py
+++ b/mne/io/fieldtrip/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/fiff/tests/__init__.py
+++ b/mne/io/fiff/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/nedf/tests/__init__.py
+++ b/mne/io/nedf/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/neuralynx/tests/__init__.py
+++ b/mne/io/neuralynx/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/nicolet/tests/__init__.py
+++ b/mne/io/nicolet/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/nirx/tests/__init__.py
+++ b/mne/io/nirx/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/persyst/tests/__init__.py
+++ b/mne/io/persyst/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/io/snirf/tests/__init__.py
+++ b/mne/io/snirf/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/minimum_norm/tests/__init__.py
+++ b/mne/minimum_norm/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/preprocessing/eyetracking/tests/__init__.py
+++ b/mne/preprocessing/eyetracking/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/preprocessing/tests/__init__.py
+++ b/mne/preprocessing/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/simulation/metrics/tests/__init__.py
+++ b/mne/simulation/metrics/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/simulation/tests/__init__.py
+++ b/mne/simulation/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/source_space/tests/__init__.py
+++ b/mne/source_space/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/stats/tests/__init__.py
+++ b/mne/stats/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/tests/__init__.py
+++ b/mne/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/time_frequency/tests/__init__.py
+++ b/mne/time_frequency/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/viz/eyetracking/tests/__init__.py
+++ b/mne/viz/eyetracking/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.

--- a/mne/viz/tests/__init__.py
+++ b/mne/viz/tests/__init__.py
@@ -1,3 +1,0 @@
-# Authors: The MNE-Python contributors.
-# License: BSD-3-Clause
-# Copyright the MNE-Python contributors.


### PR DESCRIPTION
I'm wondering why we have all these empty `__init__.py` files in our test directories, and I couldn't figure it out by 

1. consulting `git blame`
2. consulting @larsoner 

so this is option 3: remove them and see what breaks.


FWIW: there are 3 non-empty `__init__.py` files in test directories (not touched in this PR):
- `mne/_fiff/tests/__init__.py`
- `mne/io/kit/tests/__init__.py`
- `mne/io/tests/__init__.py`