### PR TITLE
MAINT: Ensure full checkout is used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,8 @@ jobs:
       - restore_cache:
           keys:
             - source-cache
-      - checkout
+      - checkout:
+          method: full
       - run:
           name: Complete checkout
           command: |


### PR DESCRIPTION
To deal with https://circleci.com/changelog/default-method-used-to-checkout-code-from-your-repository-is-changing-on-nov/

Pretty sure we need full since we do some merging, need tags, etc., similar to how we use `fetch-depth: 0` in our GHA tests.