### PR TITLE
DOC: Link to membership from governance page

### DIFF
--- a/doc/development/governance.rst
+++ b/doc/development/governance.rst
@@ -53,8 +53,8 @@ page :ref:`governance-people`.
 Maintainer Team
 ---------------
 
-The Maintainer Team is responsible for implementing changes to the software and
-supporting the user community. Duties:
+The Maintainer Team (:ref:`members <maintainer-team-people>`) is responsible for
+implementing changes to the software and supporting the user community. Duties:
 
 - Infrastructure/large-scale software decisions, in partnership with the Steering
   Council
@@ -73,8 +73,8 @@ automatically.
 Steering Council
 ----------------
 
-The Steering Council is responsible for guiding and shepherding the project on a
-day-to-day basis. Duties:
+The Steering Council (:ref:`members <steering-council-people>`) is responsible for
+guiding and shepherding the project on a day-to-day basis. Duties:
 
 - Obtaining funding (either by writing grants specifically for MNE development, or
   convincing others to include funds for MNE development in their research grants)
@@ -102,8 +102,8 @@ afforded to maintainers (passwords, merge rights, etc).
 Chair of the Steering Council
 -----------------------------
 
-The Chair of the Steering Council is responsible for liaising between the Steering
-Council and the community. Duties:
+The Chair (:ref:`member <steering-council-people>`) of the Steering Council is
+responsible for liaising between the Steering Council and the community. Duties:
 
 - Convening the Steering Council meetings
 - Calling for votes when consensus fails
@@ -113,8 +113,8 @@ Council and the community. Duties:
 External Advisory Board
 -----------------------
 
-The External Advisory Board is responsible for high-level roadmap and funding
-guidance. Duties:
+The External Advisory Board (:ref:`members <advisory-board-people>`) is responsible for
+high-level roadmap and funding guidance. Duties:
 
 - Attendance at Advisory Board meetings (approx. every 1-2 years)
 - Periodically communicating with Steering Council to impart guidance

--- a/doc/overview/people.rst
+++ b/doc/overview/people.rst
@@ -5,6 +5,8 @@
 Current Project Leadership and Institutional Partners
 =====================================================
 
+.. _maintainer-team-people:
+
 Maintainer Team
 ---------------
 
@@ -24,12 +26,16 @@ Maintainer Team
 * `Robert Luke`_
 * `Stefan Appelhoff`_
 
+.. _steering-council-people:
+
 Steering Council
 ----------------
 
 * `Britta Westner`_
 * `Daniel McCloy`_ (chair)
 * `Eric Larson`_
+
+.. _advisory-board-people:
 
 Advisory Board
 --------------


### PR DESCRIPTION
I recently looked at our governance doc to see where members were listed and I missed the link to current membership. I would have seen it if each category had its own link to current membership.

I went with adding a parenthetical `(members)` link after each category. I thought about maybe just linking the names themselves like `The Chair` part  of `The Chair of the Steering Council is responsible..." but that seemed less explicit.