### PR TITLE
Remove reference to invalid "ssd" `restr_type`

### DIFF
--- a/mne/decoding/ssd.py
+++ b/mne/decoding/ssd.py
@@ -67,15 +67,14 @@ class SSD(_GEDTransformer):
     cov_method_params : dict | None (default None)
         As in :class:`mne.decoding.SPoC`
         The default is None.
-    restr_type : "restricting" | "whitening" | "ssd" | None
+    restr_type : "restricting" | "whitening" | None
         Restricting transformation for covariance matrices before performing
         generalized eigendecomposition.
         If "restricting" only restriction to the principal subspace of signal_cov
         will be performed.
         If "whitening", covariance matrices will be additionally rescaled according
         to the whitening for the signal_cov.
-        If "ssd", simplified version of "whitening" is performed.
-        If None, no restriction will be applied. Defaults to "ssd".
+        If None, no restriction will be applied. Defaults to "whitening".
 
         .. versionadded:: 1.11
     rank : None | dict | ‘info’ | ‘full’


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

Fixes #13512.


#### What does this implement/fix?

Removes reference to "ssd" `restr_type` in docstring and changes stated default to actual value of "whitening".
