### PR TITLE
Clarify `mne.find_events` usage for Biosemi event extraction

### DIFF
--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -1802,8 +1802,11 @@ def read_raw_bdf(
         >>> events[:, 2] &= (2**16 - 1)  # doctest:+SKIP
 
     The above operation can be carried out directly in :func:`mne.find_events`
-    using the ``mask`` and ``mask_type`` parameters (see
-    :func:`mne.find_events` for more details).
+    using the ``mask`` parameter as follows:
+
+        >>> events = mne.find_events(..., mask=2**16 - 1)  # doctest:+SKIP
+
+    See :func:`mne.find_events` for more details.
 
     It is also possible to retrieve system codes, but no particular effort has
     been made to decode these in MNE. In case it is necessary, for instance to


### PR DESCRIPTION
The `mne.io.read_raw_bdf` docstring already explains how to manually extract event values (bits 1–16) from Biosemi BDF files. It also notes that `mne.find_events` can perform this automatically, but it does not explain how. This PR adds the missing explanation.