### PR TITLE
FIX Respect event duration (#13552)

### DIFF
--- a/doc/changes/dev/13552.rst
+++ b/doc/changes/dev/13552.rst
@@ -1,0 +1,1 @@
+Allow :func:`mne.annotations_from_events` to use event durations, by `Martin Oberg`_.

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1994,7 +1994,8 @@ def annotations_from_events(
 
     Notes
     -----
-    Annotations returned by this function will all have zero (null) duration.
+    Annotations returned by this function will have duration as specified by
+    the second column (index=1) of the passed events array.
 
     Creating events from annotations via the function
     `mne.events_from_annotations` takes in event mappings with
@@ -2009,7 +2010,7 @@ def annotations_from_events(
     events_sel = events[event_sel]
     onsets = (events_sel[:, 0] - first_samp) / sfreq
     descriptions = [event_desc_[e[2]] for e in events_sel]
-    durations = np.zeros(len(events_sel))  # dummy durations
+    durations = events_sel[:, 1]
 
     # Create annotations
     annots = Annotations(


### PR DESCRIPTION
Fixes #13552

#### What does this implement/fix?

This allows the durations in the events parameter to be used

I know that this has the possibility to break default behaviour, but the utility is nice. Would there need to be an optional parameter: `use_event_duration=False` in the function header?

