### PR TITLE
ENH: Add support for legacy sparse matrices in object_hash

### DIFF
--- a/mne/utils/numerics.py
+++ b/mne/utils/numerics.py
@@ -663,7 +663,10 @@ def object_hash(x, h=None):
         object_hash(_dt_to_stamp(x))
     elif sparse.issparse(x):
         h.update(str(type(x)).encode("utf-8"))
-        if not isinstance(x, sparse.csr_array | sparse.csc_array):
+        if not isinstance(
+            x,
+            sparse.csr_array | sparse.csc_array | sparse.csr_matrix | sparse.csc_matrix,
+        ):
             raise RuntimeError(f"Unsupported sparse type {type(x)}")
         h.update(x.data.tobytes())
         h.update(x.indices.tobytes())


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)
None
<!-- Example:

Fixes #1234.

-->


#### What does this implement/fix?
This enhances mne.utils.numerics.object_hash to support standard SciPy sparse matrices (csr_matrix and csc_matrix).

Previously, passing these legacy matrix types caused a RuntimeError because the function strictly checked for the newer csr_array and csc_array classes.
<!-- Explain your changes. -->


#### Additional information

<!-- Any additional information you think is important. -->
