### PR TITLE
MAINT: Remove legacy Python checks in utils.misc._empty_hash

### DIFF
--- a/doc/changes/dev/13566.other.rst
+++ b/doc/changes/dev/13566.other.rst
@@ -1,0 +1,1 @@
+Remove legacy Python-version compatibility checks in ``mne.utils.misc._empty_hash`` now that ``usedforsecurity=False`` is always supported, by :newcontrib:`Varun Kasyap Pentamaraju` (:gh:`13566`).

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -336,6 +336,7 @@
 .. _Tziona NessAiver: https://github.com/TzionaN
 .. _user27182: https://github.com/user27182
 .. _Valerii Chirkov: https://github.com/vagechirkov
+.. _Varun Kasyap Pentamaraju: https://github.com/varunkasyap
 .. _Velu Prabhakar Kumaravel: https://github.com/vpKumaravel
 .. _Victor Ferat: https://github.com/vferat
 .. _Victoria Peterson: https://github.com/vpeterson

--- a/mne/utils/misc.py
+++ b/mne/utils/misc.py
@@ -32,13 +32,8 @@ def _identity_function(x):
     return x
 
 
-# TODO: no longer needed when py3.9 is minimum supported version
 def _empty_hash(kind="md5"):
-    func = getattr(hashlib, kind)
-    if "usedforsecurity" in inspect.signature(func).parameters:
-        return func(usedforsecurity=False)
-    else:
-        return func()
+    return getattr(hashlib, kind)(usedforsecurity=False)
 
 
 def _pl(x, non_pl="", pl="s"):


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)
Fixes #13565.
<!-- Example:

Fixes #13565.

-->


#### What does this implement/fix?
This change implements a maintenance cleanup in the mne/utils/misc.py
<!-- Explain your changes. -->


#### Additional information

<!-- Any additional information you think is important. -->
