### PR TITLE
MAINT: Fix Circle

### DIFF
--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -1,14 +1,13 @@
 #!/bin/bash -ef
 
+ONLY_BINARY="--only-binary \"numpy,dipy,scipy,matplotlib,pandas,statsmodels,netCDF4,h5py\""
+
 set -x
 python -m pip install --upgrade "pip>=25.1" build
-ONLY_BINARY="--only-binary \"numpy,dipy,scipy,matplotlib,pandas,statsmodels,netCDF5,h5py\""
-# netCDF5 is here to work around an annoying bug
 python -m pip install --upgrade --progress-bar off $ONLY_BINARY \
     -ve .[full] \
     --group=test \
     --group=doc \
-    netCDF5 \
     -r doc/sphinxext/related_software.txt \
     "git+https://github.com/mne-tools/mne-bids.git" \
     "git+https://github.com/mne-tools/mne-qt-browser.git" \


### PR DESCRIPTION
Should fix https://app.circleci.com/pipelines/github/mne-tools/mne-python/29709/workflows/c933fcd6-93e0-442c-ae13-e2b1604bae1b/jobs/77959 , I think netCDF4 had a bad release without wheels, which caused it to try to be built from source. They've since fixed it but a) let's make sure and b) let's protect against building from source anyway