### PR TITLE
Make mne.sys_info() work with powershell 7+

### DIFF
--- a/doc/changes/dev/13593.other.rst
+++ b/doc/changes/dev/13593.other.rst
@@ -1,0 +1,1 @@
+make :func:`mne.sys_info` work on Windows systems with Powershell version 7+, by `Marijn van Vliet`_

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -681,11 +681,9 @@ def _get_gpu_info():
 def _get_total_memory():
     """Return the total memory of the system in bytes."""
     if platform.system() == "Windows":
+        ps = shutil.which("pwsh") or shutil.which("powershell")
         o = subprocess.check_output(
-            [
-                "powershell.exe",
-                "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory",
-            ]
+            [ps, "-c", "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory"]
         ).decode()
         # Can get for example a "running scripts is disabled on this system"
         # error where "o" will be a long string rather than an int
@@ -708,8 +706,9 @@ def _get_total_memory():
 def _get_cpu_brand():
     """Return the CPU brand string."""
     if platform.system() == "Windows":
+        ps = shutil.which("pwsh") or shutil.which("powershell")
         o = subprocess.check_output(
-            ["powershell.exe", "(Get-CimInstance Win32_Processor).Name"]
+            [ps, "-c", "(Get-CimInstance Win32_Processor).Name"]
         ).decode()
         cpu_brand = o.strip().splitlines()[-1]
     elif platform.system() == "Linux":


### PR DESCRIPTION
`mne.sys_info` uses powershell in Windows to query memory and CPU.
The newer (version 7+) powershell executable is called `pwsh` instead of `powershell`. My Windows11 system no longer seems to have the old one. This PR adds compatibility so it works for all versions.