### PR TITLE
np.fix -> np.trunc (deprecation)

### DIFF
--- a/mne/io/egi/events.py
+++ b/mne/io/egi/events.py
@@ -68,7 +68,7 @@ def _read_mff_events(filename, sfreq):
             marker = {
                 "name": event["code"],
                 "start": start,
-                "start_sample": int(np.fix(start * sfreq)),
+                "start_sample": int(np.trunc(start * sfreq)),
                 "end": start + float(event["duration"]) / 1e9,
                 "chan": None,
             }

--- a/mne/preprocessing/infomax_.py
+++ b/mne/preprocessing/infomax_.py
@@ -247,7 +247,7 @@ def infomax(
                     oldsigns = signs
 
                     if signcount >= signcount_threshold:
-                        ext_blocks = np.fix(ext_blocks * signcount_step)
+                        ext_blocks = np.trunc(ext_blocks * signcount_step)
                         signcount = 0
 
         # here we continue after the for loop over the ICA training blocks

--- a/mne/viz/utils.py
+++ b/mne/viz/utils.py
@@ -1926,7 +1926,7 @@ def _setup_ax_spines(
 
         def log_fix(tval):
             exp = np.log10(np.abs(tval))
-            return np.sign(tval) * 10 ** (np.fix(exp) - (exp < 0))
+            return np.sign(tval) * 10 ** (np.trunc(exp) - (exp < 0))
 
         xlims = np.array([xmin, xmax])
         temp_ticks = log_fix(xlims)


### PR DESCRIPTION
Fixes CI failures seen in #13593 (deprecations in numpy 2.5: np.fix replaced by np.trunc)


