### PR TITLE
fix: Styled the sensor labels for topomap mask

### DIFF
--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1423,15 +1423,39 @@ def _plot_topomap(
         _draw_outlines(axes, outlines)
 
     if names is not None and sensors:
-        for _pos, _name in zip(pos, names):
-            axes.text(
-                _pos[0],
-                _pos[1],
-                _name,
-                horizontalalignment="center",
-                verticalalignment="center",
-                size="x-small",
-            )
+        if mask is None:
+            for _pos, _name in zip(pos, names):
+                axes.text(
+                    _pos[0],
+                    _pos[1],
+                    _name,
+                    horizontalalignment="center",
+                    verticalalignment="center",
+                    size="x-small",
+                )
+        else:
+            for i, (_pos, _name) in enumerate(zip(pos, names)):
+                if mask[i]:
+                    axes.text(
+                        _pos[0],
+                        _pos[1],
+                        _name,
+                        horizontalalignment="center",
+                        verticalalignment="center",
+                        size="small",
+                        weight="bold",
+                        color="black",
+                        bbox=dict(facecolor="white", alpha=0.6, edgecolor="none"),
+                    )
+                else:
+                    axes.text(
+                        _pos[0],
+                        _pos[1],
+                        _name,
+                        horizontalalignment="center",
+                        verticalalignment="center",
+                        size="x-small",
+                    )
 
     if onselect is not None:
         lim = axes.dataLim


### PR DESCRIPTION
Fixes #13474 



#### What does this implement/fix?

This PR introduces an initial styling change for masked sensor labels in topomap plots.
Masked labels now use a distinct visual style (bold) so they can be easily
distinguished from unmasked labels.

This follows the discussion suggesting that masked sensors should not look identical
to normal ones. A simple default style is implemented first, and additional styling
options (e.g. font properties dict) can be added in later PRs based on further
design discussion.


#### Additional information

At this stage, only minimal changes were made: the relevant text drawing
call applies a bold font weight when a sensor is masked.

This keeps the PR focused and beginner friendly. Future PRs may explore
exposing a `mask_label_style` parameter or creating mockups for alternative
styles as mentioned in the issue discussion.