### PR TITLE
Convert event offset to int, avoiding overflow with i32

### DIFF
--- a/mne/io/cnt/_utils.py
+++ b/mne/io/cnt/_utils.py
@@ -147,4 +147,4 @@ def _compute_robust_event_table_position(fid, data_format="int32"):
         )
 
     fid.seek(fid_origin)  # restore the state
-    return event_table_pos
+    return int(event_table_pos)


### PR DESCRIPTION
#### What does this implement/fix?

The function `_compute_robust_event_table_position` read the offset of the event tables. Since numpy 2.x.y, the following line returns `np.int32` rather than pythonic `int`:
```python
(event_table_pos,) = np.frombuffer(fid.read(4), dtype="<i4")
```

This causes an overflow in other places, such as 
```python
data_size // (n_samples * n_channels)
```


#### Additional information

<!-- Any additional information you think is important. -->
