### PR TITLE
DOC: Move mne-kit-gui

### DIFF
--- a/doc/sphinxext/related_software.py
+++ b/doc/sphinxext/related_software.py
@@ -33,6 +33,7 @@ PYPI_PACKAGES = {
     "meggie",
     "niseq",
     "sesameeg",
+    "mne-kit-gui",  # moved to its own env in the installers
 }
 
 # If it's not available on PyPI, add it to this dict:


### PR DESCRIPTION
`mayavi` is barely maintained and it's forcing the installers to be a bit out of date. In https://github.com/mne-tools/mne-installers/pull/411 I've moved `mne-kit-gui` to its own env until https://github.com/mne-tools/mne-kit-gui/issues/36 is resolved (which could be a while!), so in the meantime we need to add `mne-kit-gui` to the manual set of packages here to keep it in the related software list.