### PR TITLE
BUG: Fix bug with somato dataset paths

### DIFF
--- a/doc/changes/dev/13630.bugfix.rst
+++ b/doc/changes/dev/13630.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug with :func:`mne.datasets.somato.data_path` where the archive couldn't be extracted due to an absolute path issue, by `Eric Larson`_.

--- a/examples/inverse/dics_epochs.py
+++ b/examples/inverse/dics_epochs.py
@@ -5,11 +5,10 @@
 Compute source level time-frequency timecourses using a DICS beamformer
 =======================================================================
 
-In this example, a Dynamic Imaging of Coherent Sources (DICS)
-:footcite:`GrossEtAl2001` beamformer is used to transform sensor-level
-time-frequency objects to the source level. We will look at the event-related
-synchronization (ERS) of beta band activity in the :ref:`somato dataset
-<somato-dataset>`.
+In this example, a Dynamic Imaging of Coherent Sources (DICS) :footcite:`GrossEtAl2001`
+beamformer is used to transform sensor-level time-frequency objects to the source level.
+We will look at the event-related synchronization (ERS) of beta band activity in the
+:ref:`somato dataset <somato-dataset>`.
 """
 # Authors: Marijn van Vliet <w.m.vanvliet@gmail.com>
 #          Alex Rockhill <aprockhill@mailbox.org>

--- a/mne/datasets/_fetch.py
+++ b/mne/datasets/_fetch.py
@@ -26,6 +26,7 @@ from .utils import (
     _downloader_params,
     _get_path,
     _log_time_size,
+    _pl,
 )
 
 _FAKE_VERSION = None  # used for monkeypatching while testing versioning
@@ -253,6 +254,9 @@ def fetch_dataset(
     # use our logger level for pooch's logger too
     pooch.get_logger().setLevel(logger.getEffectiveLevel())
     sz = 0
+    logger.info(
+        "Fetching %s file%s for the %s dataset ...", len(names), _pl(names), name
+    )
 
     for idx in range(len(names)):
         # fetch and unpack the data

--- a/mne/datasets/config.py
+++ b/mne/datasets/config.py
@@ -211,8 +211,8 @@ MNE_DATASETS["sample"] = dict(
 
 MNE_DATASETS["somato"] = dict(
     archive_name="MNE-somato-data.tar.gz",
-    hash="md5:32fd2f6c8c7eb0784a1de6435273c48b",
-    url="https://osf.io/download/tp4sg?version=7",
+    hash="md5:9a191907b326b9402341ee7a0d1240d8",
+    url="https://osf.io/download/tp4sg?version=8",
     folder_name="MNE-somato-data",
     config_key="MNE_DATASETS_SOMATO_PATH",
 )


### PR DESCRIPTION
A link to the absolute path `/usr/local/...` snuck in as `MNE-somato-data/derivatives/freesurfer/subjects/fsaverage` causing failures like [this](https://app.circleci.com/jobs/github/mne-tools/mne-bids/10215):
```
        ../examples/update_bids_datasets.py failed leaving traceback:
    
        Traceback (most recent call last):
          File "/home/circleci/project/examples/update_bids_datasets.py", line 43, in <module>
            bids_root = somato.data_path()
          ...
          File "/opt/circleci/.pyenv/versions/3.13.0/lib/python3.13/tarfile.py", line 808, in _get_filtered_attrs
            raise AbsoluteLinkError(member)
        tarfile.AbsoluteLinkError: 'MNE-somato-data/derivatives/freesurfer/subjects/fsaverage' is a link to an absolute path
```
Will fail until I get the dataset to actually upload! Opening so I can restart CI once it's done