### PR TITLE
Update evoked.py

### DIFF
--- a/mne/evoked.py
+++ b/mne/evoked.py
@@ -254,7 +254,7 @@ class Evoked(
         # Avoid circular import
         from .io.base import _get_ch_factors
 
-        picks = _picks_to_idx(self.info, picks, "all", exclude=())
+        picks = _picks_to_idx(self.info, picks, "all", exclude=("bads"))
 
         start, stop = self._handle_tmin_tmax(tmin, tmax)
 


### PR DESCRIPTION
successfully corrected issue"Inconsistent behavior between Epochs and Evoked in get_data() method when picking EEG channels and bads are present.#12577" by excluding bad channels getting in data for evoked

<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

<!-- Example:

Fixes #1234.

-->
inconsistent behaviour between Epochs and Evoked in get_data() method when picking EEG channels and bads are present

#### What does this implement/fix?

exclude bad channel getting in data

#### Additional information

<!-- Any additional information you think is important. -->
