### PR TITLE
Implement reading .CMT comment files in our Nihon Kohden reader

### DIFF
--- a/doc/changes/dev/13642.newfeature.rst
+++ b/doc/changes/dev/13642.newfeature.rst
@@ -1,0 +1,1 @@
+Add ability to read comments to :func:`~mne.io.read_raw_nihon`, by `Marijn van Vliet`_ and `Dariush Karamati`_

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -62,6 +62,7 @@
 .. _Daniel Strohmeier: https://github.com/joewalter
 .. _Daniel Tse: https://github.com/Xiezhibin
 .. _Darin Erat Sleiter: https://github.com/dsleiter
+.. _Dariush Karamati: https://github.com/eulerleibniz
 .. _David Haslacher: https://github.com/davidhaslacher
 .. _David Julien: https://github.com/Swy7ch
 .. _David Sabbagh: https://github.com/DavidSabbagh

--- a/mne/io/nihon/nihon.py
+++ b/mne/io/nihon/nihon.py
@@ -392,7 +392,7 @@ def _read_nihon_comments(fname, encoding="utf-8"):
         n_commentblocks = (filesize - 0x429) // 0x230
         all_comments = []
         for t_block in range(n_commentblocks):
-            fid.seek(0x42D + t_block * 0x230 + 0x30)
+            fid.seek(0x429 + t_block * 0x230 + 0x30)
             # As the number of comments needs to match number of placeholders, we cannot
             # fail softly if the decoding fails, as we do in other places.
             all_comments.append(np.fromfile(fid, "|S384", 1)[0].decode(encoding))


### PR DESCRIPTION
This implements basic support for reading the `.CMT` sidecar file in Nihon Kohden EEG recordings. These comment are an extension to the  annotations functionality, where the annotation description is `P_COMMENT` and should be replaced with the corresponding comment in the `.CMT` file. Comments can include images and have markup such as background and foreground colors. We ignore all that and just replace the `P_COMMENT` string in the annotation with the text of the comment.

Fixes #13633.

Todo:

- [ ] Add example file with comments to the testing dataset
- [ ] Add unit tests.
