### PR TITLE
DOC: Add placeholder comment for future JupyterLite documentation interactivity

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -116,13 +116,11 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_gallery.gen_gallery",
-    
     # Documentation interactivity (roadmap item)
     # Placeholder for potential JupyterLite integration to enable interactive
     # examples directly in the browser via sphinx-gallery.
     # See roadmap: https://mne.tools/stable/development/roadmap.html
     # "jupyterlite_sphinx",
-    
     "sphinxcontrib.bibtex",
     "sphinxcontrib.youtube",
     "sphinxcontrib.towncrier.ext",


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

Refs #13660 

#### What does this implement/fix?

Adds a placeholder comment in `doc/conf.py` indicating where JupyterLite support
could be integrated in the future to enable interactive sphinx-gallery examples.

This serves as a small preparatory step aligned with the documentation interactivity
roadmap and helps clarify where relevant extensions such as `jupyterlite_sphinx`
would be configured.


#### Additional information

This is a documentation-only change and introduces no functional changes.