### PR TITLE
DOC: clarify average EEG reference behavior and update tutorial note

### DIFF
--- a/doc/changes/dev/13664.doc.rst
+++ b/doc/changes/dev/13664.doc.rst
@@ -1,0 +1,4 @@
+Clarify in the documentation that :func:`mne.add_reference_channels`
+should be used before :func:`mne.set_eeg_reference` with
+``ref_channels="average"`` when the original reference electrode
+is missing.

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1028,16 +1028,6 @@ issn = {1053-8119},
   year = {2008}
 }
 
-@article{KimEtAl2023,
-  author = {Kim, Hyeonseok and Luo, Justin and Chu, Shannon and Cannard, Cedric and Hoffmann, Sven and Miyakoshi, Makoto},
-  doi = {10.3389/frsip.2023.1064138},
-  journal = {Frontiers in Signal Processing},
-  pages = {1064138},
-  title = {{ICA's bug: How ghost ICs emerge from effective rank deficiency caused by EEG electrode interpolation and incorrect re-referencing}},
-  volume = {3},
-  year = {2023}
-}
-
 @article{LaaksoCottrell2000,
   author = {Laakso, Aarre and Cottrell, Garrison},
   doi = {10.1080/09515080050002726},

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1028,6 +1028,16 @@ issn = {1053-8119},
   year = {2008}
 }
 
+@article{KimEtAl2023,
+  author = {Kim, Hyeonseok and Luo, Justin and Chu, Shannon and Cannard, Cedric and Hoffmann, Sven and Miyakoshi, Makoto},
+  doi = {10.3389/frsip.2023.1064138},
+  journal = {Frontiers in Signal Processing},
+  pages = {1064138},
+  title = {{ICA's bug: How ghost ICs emerge from effective rank deficiency caused by EEG electrode interpolation and incorrect re-referencing}},
+  volume = {3},
+  year = {2023}
+}
+
 @article{LaaksoCottrell2000,
   author = {Laakso, Aarre and Cottrell, Garrison},
   doi = {10.1080/09515080050002726},

--- a/mne/_fiff/reference.py
+++ b/mne/_fiff/reference.py
@@ -405,17 +405,6 @@ def set_eeg_reference(
         ``None`` if ``projection=True``, or if ``ref_channels`` is ``"REST"`` or a
         :class:`dict`.
 
-    Notes
-    -----
-    When using ``ref_channels="average"`` with ``projection=False`` (the
-    default), the average reference is computed over the EEG channels present
-    in the data. If the original reference electrode was not recorded as a
-    channel (or was removed during acquisition or preprocessing), it is not
-    implicitly accounted for in the average.
-    For sensor-space analyses where this distinction matters, consider adding
-    a zero-filled reference channel using :func:`add_reference_channel` before
-    applying the average reference.
-
     %(set_eeg_reference_see_also_notes)s
     """
     from ..forward import Forward

--- a/mne/_fiff/reference.py
+++ b/mne/_fiff/reference.py
@@ -404,6 +404,18 @@ def set_eeg_reference(
         Array of reference data subtracted from EEG channels. This will be
         ``None`` if ``projection=True``, or if ``ref_channels`` is ``"REST"`` or a
         :class:`dict`.
+
+    Notes
+    -----
+    When using ``ref_channels="average"`` with ``projection=False`` (the
+    default), the average reference is computed over the EEG channels present
+    in the data. If the original reference electrode was not recorded as a
+    channel (or was removed during acquisition or preprocessing), it is not
+    implicitly accounted for in the average.
+    For sensor-space analyses where this distinction matters, consider adding
+    a zero-filled reference channel using :func:`add_reference_channel` before
+    applying the average reference.
+
     %(set_eeg_reference_see_also_notes)s
     """
     from ..forward import Forward

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -4103,6 +4103,15 @@ Some common referencing schemes and the corresponding value for the
     EEG signal by setting ``ref_channels='average'``. Bad EEG channels are
     automatically excluded if they are properly set in ``info['bads']``.
 
+    For sensor-space analyses, if the original reference electrode is not
+    present as a channel, the resulting average reference is biased because
+    the subtracted signal is divided by n channels instead of n + 1
+    (including the reference). For a correct average reference, add a
+    zero-filled reference channel with :func:`~mne.add_reference_channels`
+    before calling :func:`~mne.set_eeg_reference`. For further discussion,
+    see Kim et al. (2023) `Frontiers in Signal Processing
+    <https://doi.org/10.3389/frsip.2023.1064138>`__.
+
 - A single electrode:
     Set ``ref_channels`` to a list containing the name of the channel that
     will act as the new reference, for example ``ref_channels=['Cz']``.

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -4109,8 +4109,7 @@ Some common referencing schemes and the corresponding value for the
     (including the reference). For a correct average reference, add a
     zero-filled reference channel with :func:`~mne.add_reference_channels`
     before calling :func:`~mne.set_eeg_reference`. For further discussion,
-    see Kim et al. (2023) `Frontiers in Signal Processing
-    <https://doi.org/10.3389/frsip.2023.1064138>`__.
+    see :footcite:t:`KimEtAl2023`.
 
 - A single electrode:
     Set ``ref_channels`` to a list containing the name of the channel that

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -4109,7 +4109,7 @@ Some common referencing schemes and the corresponding value for the
     (including the reference). For a correct average reference, add a
     zero-filled reference channel with :func:`~mne.add_reference_channels`
     before calling :func:`~mne.set_eeg_reference`. For further discussion,
-    see :footcite:t:`KimEtAl2023`.
+    see Kim et al. (2023, doi:10.3389/frsip.2023.1064138).
 
 - A single electrode:
     Set ``ref_channels`` to a list containing the name of the channel that

--- a/tutorials/preprocessing/55_setting_eeg_reference.py
+++ b/tutorials/preprocessing/55_setting_eeg_reference.py
@@ -141,12 +141,13 @@ raw_new_ref.plot()
 raw_avg_ref = raw.copy().set_eeg_reference(ref_channels="average")
 raw_avg_ref.plot()
 
-# Note:
-# When computing an average reference, if the dataset does not include the original
-# reference electrode, the average will be biased because the missing channel is ignored.
-# To avoid this, first add a zero-valued reference channel using
-# mne.add_reference_channels(). This ensures that all intended channels,
-# including the original reference, contribute correctly to the average.
+# .. note::
+#     When computing an average reference, if the dataset does not include
+#     the original reference electrode, the average will be biased because the
+#     missing channel is ignored. To avoid this, first add a zero-valued
+#     reference channel using :func:`mne.add_reference_channels`. This ensures
+#     that all intended channels, including the original reference, contribute
+#     correctly to the average.
 
 # %%
 # .. _section-avg-ref-proj:

--- a/tutorials/preprocessing/55_setting_eeg_reference.py
+++ b/tutorials/preprocessing/55_setting_eeg_reference.py
@@ -141,6 +141,13 @@ raw_new_ref.plot()
 raw_avg_ref = raw.copy().set_eeg_reference(ref_channels="average")
 raw_avg_ref.plot()
 
+# Note:
+# When computing an average reference, if the dataset does not include the original
+# reference electrode, the average will be biased because the missing channel is ignored.
+# To avoid this, first add a zero-valued reference channel using
+# mne.add_reference_channels(). This ensures that all intended channels,
+# including the original reference, contribute correctly to the average.
+
 # %%
 # .. _section-avg-ref-proj:
 #


### PR DESCRIPTION
This PR clarifies the behavior of average EEG referencing when the original
reference electrode is not present in the data.

- Adds an explicit note to the `set_eeg_reference` docstring explaining that
  the average is computed only over existing EEG channels.
- Updates the preprocessing tutorial to explicitly mention using
  `add_reference_channel` when applying an average reference and the original
  reference is missing.

Closes #13618


