### PR TITLE
ENH: Add optional JupyterLite support prototype for documentation interactivity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,8 +243,10 @@ jobs:
               cp coverage.xml doc/_build/test-results/test-doc/coverage.xml;
             fi;
       # Build docs
-      - run:
+       - run:
           name: make html
+          environment:
+            MNE_ENABLE_JUPYTERLITE: "true"
           command: |  # we have -o pipefail in #BASH_ENV so we should be okay
             set -x
             PATTERN=$(cat pattern.txt) make -C doc $(cat build.txt) 2>&1 | tee sphinx_log.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ jobs:
               cp coverage.xml doc/_build/test-results/test-doc/coverage.xml;
             fi;
       # Build docs
-       - run:
+      - run:
           name: make html
           environment:
             MNE_ENABLE_JUPYTERLITE: "true"

--- a/doc/changes/dev/13666.newfeature.rst
+++ b/doc/changes/dev/13666.newfeature.rst
@@ -1,0 +1,2 @@
+Add optional prototype support for enabling JupyterLite in documentation builds
+via the ``jupyterlite_sphinx`` extension, controlled by an environment variable.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -130,6 +130,16 @@ extensions = [
     "related_software",
     "directive_formatting",
 ]
+# Optional JupyterLite support prototype (roadmap item: documentation interactivity)
+if os.getenv("MNE_ENABLE_JUPYTERLITE", "false").lower() == "true":
+    try:
+        import jupyterlite_sphinx  # noqa: F401
+    except ImportError:
+        sphinx_logger.warning(
+            "MNE_ENABLE_JUPYTERLITE is true but jupyterlite_sphinx is not installed."
+        )
+    else:
+        extensions.append("jupyterlite_sphinx")
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -1740,8 +1750,15 @@ def make_version(app, exception):
     sphinx_logger.info(f'Added "{stdout.rstrip()}" > _version.txt')
 
 
-# -- Connect our handlers to the main Sphinx app ---------------------------
+# -- JupyterLite configuration ---------------------------------------------
 
+jupyterlite_config = {
+    "LiteBuildConfig": {
+        "apps": ["lab"],
+    },
+}
+
+# -- Connect our handlers to the main Sphinx app ---------------------------
 
 def setup(app):
     """Set up the Sphinx app."""

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1760,6 +1760,7 @@ jupyterlite_config = {
 
 # -- Connect our handlers to the main Sphinx app ---------------------------
 
+
 def setup(app):
     """Set up the Sphinx app."""
     app.connect("autodoc-process-docstring", append_attr_meth_examples)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1752,11 +1752,7 @@ def make_version(app, exception):
 
 # -- JupyterLite configuration ---------------------------------------------
 
-jupyterlite_config = {
-    "LiteBuildConfig": {
-        "apps": ["lab"],
-    },
-}
+jupyterlite_config = "jupyter_lite_config.json"
 
 # -- Connect our handlers to the main Sphinx app ---------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1753,6 +1753,7 @@ def make_version(app, exception):
 # -- JupyterLite configuration ---------------------------------------------
 
 jupyterlite_config = "jupyter_lite_config.json"
+jupyterlite_dir = "lite"
 
 # -- Connect our handlers to the main Sphinx app ---------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1752,7 +1752,6 @@ def make_version(app, exception):
 
 # -- JupyterLite configuration ---------------------------------------------
 
-jupyterlite_config = "jupyter_lite_config.json"
 jupyterlite_dir = "lite"
 
 # -- Connect our handlers to the main Sphinx app ---------------------------

--- a/doc/jupyter_lite_config.json
+++ b/doc/jupyter_lite_config.json
@@ -1,0 +1,5 @@
+{
+  "LiteBuildConfig": {
+    "apps": ["lab"]
+  }
+}

--- a/doc/jupyter_lite_config.json
+++ b/doc/jupyter_lite_config.json
@@ -1,5 +1,0 @@
-{
-  "LiteBuildConfig": {
-    "apps": ["lab"]
-  }
-}

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -12,6 +12,7 @@ python -m pip install --upgrade --progress-bar off $ONLY_BINARY \
     "git+https://github.com/mne-tools/mne-bids.git" \
     "git+https://github.com/mne-tools/mne-qt-browser.git" \
     "git+https://github.com/pyvista/pyvista.git" \
-    "git+https://github.com/sphinx-gallery/sphinx-gallery.git"
+    "git+https://github.com/sphinx-gallery/sphinx-gallery.git" \
+    "jupyterlite-sphinx"
 python -m pip install --upgrade --progress-bar off --no-deps $ONLY_BINARY \
     -r doc/sphinxext/related_software_nodeps.txt

--- a/tutorials/simulation/10_array_objs.py
+++ b/tutorials/simulation/10_array_objs.py
@@ -235,3 +235,34 @@ spectrum = mne.time_frequency.SpectrumArray(
 )
 
 spectrum.plot(spatial_colors=False, amplitude=False)
+
+Now I have everything I need. Your conf.py is well set up — the jupyterlite_sphinx extension is conditionally loaded and there's already a jupyterlite_config dict at the bottom. The directive to use is replite (lightweight, no full notebook UI needed for a prototype).
+Here's exactly what to append to the bottom of tutorials/simulation/10_array_objs.py:
+python# %%
+# Try it interactively
+# ^^^^^^^^^^^^^^^^^^^^
+#
+# The code below lets you experiment with this tutorial directly in your
+# browser — no installation required. Note that ``mne`` availability depends
+# on the JupyterLite environment; the example below uses only ``numpy`` to
+# ensure it runs reliably as a prototype.
+#
+# .. replite::
+#    :kernel: python3
+#    :height: 600px
+#    :prompt: Click to launch an interactive session
+#
+#    import numpy as np
+#
+#    # Reproduce the core Raw simulation from the tutorial
+#    sampling_freq = 200
+#    times = np.linspace(0, 1, sampling_freq, endpoint=False)
+#    sine = np.sin(20 * np.pi * times)
+#    cosine = np.cos(10 * np.pi * times)
+#    data = np.array([sine, cosine])
+#
+#    print("sine shape:", data.shape)
+#    print("First 5 sine values:", sine[:5].round(4))
+#    print("First 5 cosine values:", cosine[:5].round(4))
+#
+#    # Try modifying the frequency and re-running!

--- a/tutorials/simulation/10_array_objs.py
+++ b/tutorials/simulation/10_array_objs.py
@@ -236,9 +236,7 @@ spectrum = mne.time_frequency.SpectrumArray(
 
 spectrum.plot(spatial_colors=False, amplitude=False)
 
-Now I have everything I need. Your conf.py is well set up — the jupyterlite_sphinx extension is conditionally loaded and there's already a jupyterlite_config dict at the bottom. The directive to use is replite (lightweight, no full notebook UI needed for a prototype).
-Here's exactly what to append to the bottom of tutorials/simulation/10_array_objs.py:
-python# %%
+# %%
 # Try it interactively
 # ^^^^^^^^^^^^^^^^^^^^
 #
@@ -254,7 +252,6 @@ python# %%
 #
 #    import numpy as np
 #
-#    # Reproduce the core Raw simulation from the tutorial
 #    sampling_freq = 200
 #    times = np.linspace(0, 1, sampling_freq, endpoint=False)
 #    sine = np.sin(20 * np.pi * times)


### PR DESCRIPTION
#### Reference issue (if any)
Refs #13660.


#### What does this implement/fix?
This PR adds optional support for the `jupyterlite_sphinx` extension in the
documentation configuration (`doc/conf.py`) as an initial step toward enabling
interactive examples using JupyterLite.

The extension is only enabled when the environment variable
`MNE_ENABLE_JUPYTERLITE=true` is set and the dependency is installed. This keeps
the default documentation build and CI unchanged while allowing JupyterLite to
be tested locally or in future integrations.

The goal is to establish a safe starting point for experimenting with interactive
sphinx-gallery examples, in line with the documentation interactivity roadmap.


#### Additional information
This change does not alter any existing examples or documentation behavior by
default. It simply adds a configuration hook so that JupyterLite support can be
incrementally explored and expanded in follow-up PRs.

Happy to adjust the approach if there is a preferred way to integrate this.