### PR TITLE
DOC: Diátaxis application to Source Tutorial part 3: Manual Coreg with / without MRI tutorial

### DIFF
--- a/tutorials/forward/15_manual_coreg.py
+++ b/tutorials/forward/15_manual_coreg.py
@@ -13,6 +13,10 @@ coregistration for subjects using a template source space instead of an MRI.
 Let's start out by loading some data.
 """
 
+# Authors: The MNE-Python contributors.
+# License: BSD-3-Clause
+# Copyright the MNE-Python contributors.
+
 import mne
 
 data_path = mne.datasets.sample.data_path()


### PR DESCRIPTION
#### What does this implement/fix?

This PR applies Diátaxis framework principles to the "Source Alignment and Coordinate Frame" tutorial. Currently, the Source Alignment tutorial covers a large number of topics that are not closely related to the stated goal, which is visual alignment assessment. This PR moves exercises for the user to practice manual coregistration of digitized points with head surfaces to a separate tutorial.  This PR is the third of a three part series refactoring the original tutorial. 

