### PR TITLE
DOC: Add missing links to supported data format tables in events tutorialSusani/explore docs

### DIFF
--- a/tutorials/intro/20_events_from_raw.py
+++ b/tutorials/intro/20_events_from_raw.py
@@ -104,7 +104,7 @@ raw.copy().pick(picks="stim").plot(start=3, duration=6)
 #
 # For a list of which EEG/MEG systems use STIM channels versus marker files
 # or embedded arrays, see the "Supported data formats" tables in
-# :ref:`tut-import-meg` and :ref:`tut-import-eeg`.
+# :doc:`/auto_tutorials/io/10_reading_meg_data` and :doc:`/auto_tutorials/io/20_reading_eeg_data`.
 #
 #
 # Converting a STIM channel signal to an Events array

--- a/tutorials/intro/20_events_from_raw.py
+++ b/tutorials/intro/20_events_from_raw.py
@@ -102,9 +102,9 @@ raw.copy().pick(picks="stim").plot(start=3, duration=6)
 # magnitudes. You can also see that every time there is a pulse on one of the
 # other STIM channels, there is a corresponding pulse on ``STI 014``.
 #
-# .. TODO: somewhere in prev. section, link out to a table of which systems
-#    have STIM channels vs. which have marker files or embedded event arrays
-#    (once such a table has been created).
+# For a list of which EEG/MEG systems use STIM channels versus marker files
+# or embedded arrays, see the "Supported data formats" tables in
+# :ref:`tut-import-meg` and :ref:`tut-import-eeg`.
 #
 #
 # Converting a STIM channel signal to an Events array


### PR DESCRIPTION
#### Reference issue (if any)
No specific issue, but this PR addresses a `TODO` comment found in `tutorials/intro/20_events_from_raw.py` regarding missing links to supported data format tables.
#### What does this implement/fix?
This PR replaces the `TODO` text with functional cross-references to the MEG and EEG "Supported data formats" tables. 

I used the `:doc:` role to link directly to:
- `tutorials/io/10_reading_meg_data.py`
- `tutorials/io/20_reading_eeg_data.py`
- I chose `:doc:` because these source files do not currently have internal labels defined (which would be required for `:ref:`).

#### Additional information
I am a **GSoC 2026 applicant** for the **Project 4: Interactive Documentation (JupyterLite)** project. 

Building these docs locally and troubleshooting the Sphinx cross-referencing logic gave me great insight into the current documentation workflow and why the JupyterLite initiative is so important for reducing contributor friction
I am really excited for  JupyterLite to make this process even smoother for future contributors. 