### PR TITLE
Feature: implement find blinks using pupil size data (velocity, ...)

### DIFF
--- a/mne/preprocessing/eyetracking/_pupillometry.py
+++ b/mne/preprocessing/eyetracking/_pupillometry.py
@@ -3,9 +3,11 @@
 # Copyright the MNE-Python contributors.
 
 import numpy as np
+from scipy.ndimage import gaussian_filter1d
+from scipy.stats import mstats
 
 from ..._fiff.constants import FIFF
-from ...annotations import _annotations_starts_stops
+from ...annotations import Annotations, _annotations_starts_stops
 from ...io import BaseRaw
 from ...utils import _check_preload, _validate_type, logger, warn
 
@@ -119,3 +121,151 @@ def _interpolate_blinks(raw, buffer, blink_annots, interpolate_gaze):
         )
     else:
         warn("No channels were interpolated.")
+
+
+def annotate_velocity_blinks(
+    raw,
+    channel_names=("pupil_left", "pupil_right"),
+    margin_before=0.01,
+    margin_after=0.01,
+    max_duration=0.5,
+    description="BAD_velo_blink",
+    sigma=5,
+    vt_start_multiplyer=40,
+    vt_end_multiplyer=40,
+    low_v_thresh_multiplyer=1,
+):
+    """
+    Annotate blinks based on pupil velocity profile.
+
+    fast constriction -> fast dilation -> low velocity.
+
+    Parameters
+    ----------
+    raw : mne.io.Raw
+        Raw object with pupil data.
+    channel_names : tuple of str
+        Names of pupil channels (e.g., ('pupil_left', 'pupil_right')).
+    margin_before : float
+        Time (in seconds) to extend before blink onset.
+    margin_after : float
+        Time (in seconds) to extend after blink offset.
+    max_duration : float
+        Maximum allowable blink duration (in seconds).
+    description : str
+        Annotation label.
+    sigma : float
+        Sigma for Gaussian smoothing.
+    vt_start_multiplyer : float
+        Multiplier for median absolute deviation (MAD) to set blink onset threshold.
+    vt_end_multiplyer : float
+        Multiplier for median absolute deviation (MAD) to set blink dilation threshold.
+    low_v_thresh_multiplyer : float
+        Multiplier for median velocity (MED) to define stabilization (low velocity)
+        threshold.
+
+    Returns
+    -------
+    raw : mne.io.Raw
+        Modified Raw object with blink annotations.
+
+    """
+    annotations = raw.annotations
+
+    sfreq = raw.info["sfreq"]
+    max_search_duration = max_duration
+
+    onsets, durations, descriptions, ch_names_list = [], [], [], []
+
+    for ch_name in channel_names:
+        if ch_name not in raw.ch_names:
+            raise ValueError(f"Channel '{ch_name}' not found in raw.")
+
+        data = raw.get_data(picks=ch_name)[0]
+
+        if sigma > 0:
+            smoothed = gaussian_filter1d(data, sigma=sigma)
+            velocity = np.gradient(smoothed) * sfreq
+        else:
+            velocity = np.gradient(data) * sfreq
+
+        # clipping the top 1 percent of data to not have outliers
+        # influence the threshold (winsorizing)
+        velocity_clipped = mstats.winsorize(
+            velocity, limits=[0.01, 0.01]
+        )  # clip top and bottom 1%
+        abs_velocity = np.abs(velocity_clipped.data)
+
+        # median velocity
+        med = np.nanmedian(abs_velocity)
+        # median absolute deviation
+        mad = np.nanmedian(np.abs(abs_velocity - med))
+
+        vt_start = med + (vt_start_multiplyer * mad)
+        vt_end = med + (vt_end_multiplyer * mad)
+        low_v_thresh = med * low_v_thresh_multiplyer
+
+        # Optionally print thresholds per participant and channel
+        # print(
+        #     f"{ch_name}: med={med:.2f}, "
+        #     "mad={mad:.2f}, "
+        #     "vt_start={vt_start:.2f}, "
+        #     "vt_end={vt_end:.2f}, "
+        #     "low_v_thresh={low_v_thresh:.2f}"
+        # )
+
+        i = 0
+        while i < len(velocity) - 1:
+            imid = None
+
+            # Blink onset: rapid constriction
+            if velocity[i] < -vt_start:
+                istart = i
+
+                # Limit search range
+                max_search = int(sfreq * max_search_duration)
+
+                # Dilation: search after constriction
+                dilation_zone = velocity[istart : istart + max_search]
+                dilation_indices = np.where(dilation_zone > vt_end)[0]
+                if dilation_indices.size > 0:
+                    imid = dilation_indices[0] + istart
+
+                    # Look for stabilization
+                    post_dilate_zone = velocity[imid : imid + max_search]
+                    low_v_indices = np.where(np.abs(post_dilate_zone) < low_v_thresh)[0]
+                    if low_v_indices.size > 0:
+                        iend = low_v_indices[0] + imid
+
+                        # Validate and annotate
+                        duration_sec = (iend - istart) / sfreq
+                        if duration_sec <= max_duration:
+                            onset = (istart / sfreq) - margin_before
+                            onset = max(0, onset)
+                            total_duration = duration_sec + margin_before + margin_after
+
+                            onsets.append(onset)
+                            durations.append(total_duration)
+                            descriptions.append(description)
+                            ch_names_list.append([ch_name])
+                            i = iend - 1
+                            continue  # go to next blink candidate
+                # Adaptive skip logic
+            if imid is not None:
+                i = imid + 1
+            else:
+                i += int(sfreq * 0.01)  # skip 10 ms
+
+    if onsets:
+        new_annotations = Annotations(
+            onset=onsets,
+            duration=durations,
+            description=descriptions,
+            orig_time=raw.annotations.orig_time,
+            ch_names=ch_names_list,
+        )
+        raw.set_annotations(annotations + new_annotations)
+    else:
+        print("No blinks detected.")
+
+    return raw


### PR DESCRIPTION
> Work from @aabielefeldt, extracted from her comment: https://github.com/mne-tools/mne-python/pull/12946#issuecomment-3570064526

## MNE Blink Detection Function

### Background

#### What are blinks?

Currently there is little consensus as to how to deal with blinks in pupillometric data (Grootjen et al., 2023). In eyetracking data, blinks are the most frequent artefacts, with an average healthy person blinking around 17 times per min at rest. Large variations in this rate occur in response to behavioural tasks though (Bentivoglio et al., 1997). Blinks are the rapid closing and re-opening of the eyelid which makes eyetrackers detect a strong pupil constriction, a consecutive strong dilation and a consecutive return to a baseline pupil size. It is important to dissect this type of missing data, from other artefacts due to recording problems, other reasons for closed eyed (sleeping) or movement.

#### Inconsistency in preprocessing

Some eyetrackers have online parsers that detect blinks themselves (like the commonly used Eyelink eyetrackers), while other devices might not detect blinks. Even with online parsers, many researchers opt to use custom algorithms to detect blinks in their data, leading to lack of standardised preprocessing pipelines (MathÃ´t and Vilotijevic, 2023). MNE can import blink annotations from eyetracking devices, but does not currently have an internal function to detect blinks. Such a function would enable detecting blinks if no online parser was available, or if specific algorithms should be chosen for blink detection making preprocessing comparable between different studies. In my case, working with data collected on an Eyelink eyetracker, blinks are already annotated but are simply any period of data where the pupil size is zero. This includes periods where the recording of the pupil failed or where the participant had fallen asleep. Interpolating these periods without dissecting those separate reasons for missing data leads to distortion of the data.

#### My function

I therefore created a function (based on MathÃ´t, 2013), that would detect typical blink trajectories in the data and annotate them in the MNE format. The function identifies areas where the velocity of the signal first crosses a negative threshold, indicating a strong constriction of the pupil, then crosses a positive threshold, indicating the pupils dilation, and then returns to a velocity that neared median velocity values. After clipping the bottom and top 1% of absolute velocity to reduce the influence of outliers, velocity thresholds were adaptively set based on the median and the median absolute deviation of the participants data. In addition the identified blinks were time capped to 0.5s to include only eye movements with a typical blink trajectory.

#### Differences to other approaches or functions

In comparison to other algorithms, my function uses the individual participants velocity to build thresholds adaptively. Since individual participants have differing baseline pupil sizes, the velocity profile of blinks are recorded as if they were more or less extreme and therefore require individual thresholds. To not have to adjust thresholds manually when preprocessing large datasets, using the median velocity of each participant seemed to work well. Visualisation of my data showed that blinks do not always reach a pupil size of zero, while still presenting a clear blink trajectory (MathÃ´t et al., 2018). With the present function, blinks are still recognised (see Fig.1). Most other functions seem to use missing data as the main initial defining feature of blinks (Hershman et al., 2018; Schwartz et al., 2025). The algorithm presented in MathÃ´t (2013) seemed to be a rare exception.

<img width="858" height="582" alt="image" src="https://github.com/user-attachments/assets/775f0de8-6c0d-4826-ae9c-4db2d4da5435" />

Blinks detected in raw data by my algorithm. Blinks that are not reaching a pupil size of zero are still detected well.

Furthermore, the algorithm only annotates blinks rather than reconstructing them straight away (as in MathÃ´t, 2013). I also did not merge blinks within the annotation function, which some proposed functions do. While I did create a separate function merging and renaming all blinks that were 0.1s or less apart to avoid artefacts due to too few datapoints to use for interpolation surrounding those blinks, I wanted to keep the annotations of each individual blink to allow later statistics on the number of blinks. Blink rate is suggested to correlate with both task demands and individual differences (Unsworth et al., 2019) and statistics on blinks might also help finding outliers in the data.

#### What is needed for a complete preprocessing pipeline

After the blinks are correctly annotated, I do think it is advisable to remove all periods of data that have a pupil size of zero but are not considered a blink by the function. I wrote a function for that too, turning remaining zero data into NaNs. Then the blinks can be interpolated using the MNE interpolate function. I wanted to use monotonic cubic spline interpolation though, so I also rewrote the interpolation function slightly, including more methods and also making it nan-aware (also there is a bug in the interpolate function that I mentioned here: https://mne.discourse.group/t/dealing-with-nans-and-missing-data-in- pupil-and-eyetracking-data/11470). As a last step I added a buffer to all remaining missing data periods and annotated these with mne.preprocessing.annotate_nan. (In a later step I also add a baseline to my data and z-score it.) While creating this I also created function to visualise the velocity and the set thresholds for more intuitive use. I also created a function to create a dataframe of all the blink data to inspect after preprocessing.

#### Open questions

This function was created using data from an experiment where participants were fixating on a central fixation cross. The data was collected on an Eyelink eyetracker. To make sure this function is robust, it would need to be tested in other datasets. Currently I am especially unsure if it would work well if the missing data is identified as NaNs by the used eyetracker.