### PR TITLE
BUG: Fix bug with default

### DIFF
--- a/mne/datasets/_phantom/base.py
+++ b/mne/datasets/_phantom/base.py
@@ -11,13 +11,17 @@ PHANTOM_MANIFEST_PATH = Path(__file__).parent
 
 
 @verbose
-def fetch_phantom(kind, subjects_dir=None, *, verbose=None):
+def fetch_phantom(kind="otaniemi", subjects_dir=None, *, verbose=None):
     """Fetch and update a phantom subject.
 
     Parameters
     ----------
     kind : str
         The kind of phantom to fetch. Can only be ``'otaniemi'`` (default).
+
+        .. versionchanged:: 1.12
+           The default is now properly set in the signature so it doesn't need to be
+           provided.
     %(subjects_dir)s
     %(verbose)s
 

--- a/mne/utils/check.py
+++ b/mne/utils/check.py
@@ -281,7 +281,7 @@ def _check_fname(
         if not overwrite:
             raise FileExistsError(
                 "Destination file exists. Please use option "
-                '"overwrite=True" to force overwriting.'
+                f'"overwrite=True" to force overwriting of: {name}'
             )
         elif overwrite != "read":
             logger.info("Overwriting existing file.")


### PR DESCRIPTION
A couple of minor fixes not worthy of `changelog`:

1. `mne.datasets.fetch_phantom` said its default was `kind="otaniemi"`, but there was no default (even though it's the only option!). We might as well do what the docs say to simplify usage, now you can just do `fetch_phantom()` if you want and it should work.
2. If a file needs `overwrite=True`, say what the path is (similar to how, when we try to read, we report the path if a file is missing like `FileNotFoundError: File does not exist: "/..."`). I was using `import pdb; pdb.pm()` to find the filename and this would have saved me some time (the writing code was buried in another library so I couldn't just pull it from my script).