### PR TITLE
Improve handling of dropped epochs in ica.plot_properties

### DIFF
--- a/doc/changes/dev/13746.bugfix.rst
+++ b/doc/changes/dev/13746.bugfix.rst
@@ -1,0 +1,1 @@
+Improved handling of dropped epochs in :func:`mne.viz.plot_ica_properties` and :method:`mne.preprocessing.ICA.plot_properties`, allowing plots to be generated even with many bad annotations, by `Clemens Brunner`_.

--- a/doc/changes/dev/13746.bugfix.rst
+++ b/doc/changes/dev/13746.bugfix.rst
@@ -1,1 +1,1 @@
-Improved handling of dropped epochs in :func:`mne.viz.plot_ica_properties` and :method:`mne.preprocessing.ICA.plot_properties`, allowing plots to be generated even with many bad annotations, by `Clemens Brunner`_.
+Improved handling of dropped epochs in :func:`mne.viz.plot_ica_properties` and :meth:`mne.preprocessing.ICA.plot_properties`, allowing plots to be generated even with many bad annotations, by `Clemens Brunner`_.

--- a/mne/viz/ica.py
+++ b/mne/viz/ica.py
@@ -731,34 +731,47 @@ def _prepare_data_ica_properties(inst, ica, reject_by_annotation=True, reject="a
 
         if reject == "auto":
             reject = ica.reject_
+        drop_inds = None
+        dropped_indices = []
         if reject is None:
-            drop_inds = None
-            dropped_indices = []
-            # break up continuous signal into segments
-            epochs_src = make_fixed_length_epochs(
-                ica.get_sources(inst),
-                duration=2,
-                preload=True,
-                reject_by_annotation=reject_by_annotation,
-                proj=False,
-                verbose=False,
-            )
+            inst_current = inst
         else:
             data = inst.get_data()
             data, drop_inds = _reject_data_segments(
                 data, reject, flat=None, decim=None, info=inst.info, tstep=2.0
             )
-            inst_rejected = RawArray(data, inst.info)
-            # break up continuous signal into segments
+            inst_current = RawArray(data, inst.info)
+        # break up continuous signal into segments; suppress "All epochs were
+        # dropped!" because we handle that case gracefully below
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", "All epochs were dropped!", RuntimeWarning
+            )
             epochs_src = make_fixed_length_epochs(
-                ica.get_sources(inst_rejected),
+                ica.get_sources(inst_current),
                 duration=2,
                 preload=True,
                 reject_by_annotation=reject_by_annotation,
                 proj=False,
                 verbose=False,
             )
-            # getting dropped epochs indexes
+        # if all epochs were dropped by annotations, stitch the good segments
+        # together so that the plot can still be generated
+        if reject_by_annotation and len(epochs_src) == 0:
+            good_data = inst_current.get_data(reject_by_annotation="omit")
+            min_samples = int(2 * inst.info["sfreq"])
+            if good_data.shape[1] >= min_samples:
+                inst_good = RawArray(good_data, inst_current.info.copy(), verbose=False)
+                epochs_src = make_fixed_length_epochs(
+                    ica.get_sources(inst_good),
+                    duration=2,
+                    preload=True,
+                    reject_by_annotation=False,
+                    proj=False,
+                    verbose=False,
+                )
+        # getting dropped epochs indexes
+        if drop_inds is not None:
             dropped_indices = [(d[0] // len(epochs_src.times)) + 1 for d in drop_inds]
         kind = "Segment"
     else:

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -265,9 +265,9 @@ def test_plot_ica_properties():
     # don't drop
     ica.plot_properties(raw_annot, reject_by_annotation=False, **topoargs)
 
-    # Test fallback when ALL 2-second epoch windows are contaminated by
-    # annotations: one bad segment per window so every epoch is dropped, but
-    # the inter-annotation gaps stitch together to >= 2 s of clean data.
+    # test fallback when ALL 2-second epoch windows are contaminated by annotations: one
+    # bad segment per window so every epoch is dropped, but the inter-annotation gaps
+    # stitch together to >= 2 s of clean data.
     annot_all_bad = Annotations(
         onset=[0.5, 2.5, 4.5, 6.5],
         duration=[1.0, 1.0, 1.0, 1.0],

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -265,6 +265,21 @@ def test_plot_ica_properties():
     # don't drop
     ica.plot_properties(raw_annot, reject_by_annotation=False, **topoargs)
 
+    # Test fallback when ALL 2-second epoch windows are contaminated by
+    # annotations: one bad segment per window so every epoch is dropped, but
+    # the inter-annotation gaps stitch together to >= 2 s of clean data.
+    annot_all_bad = Annotations(
+        onset=[0.5, 2.5, 4.5, 6.5],
+        duration=[1.0, 1.0, 1.0, 1.0],
+        description=["BAD"] * 4,
+    )
+    raw_all_bad = _get_raw(preload=True).set_annotations(annot_all_bad).crop(0, 8)
+    raw_all_bad.pick(np.arange(10))
+    raw_all_bad.del_proj()
+    fig = ica.plot_properties(raw_all_bad, picks=[0], **topoargs)
+    assert_equal(len(fig), 1)
+    plt.close("all")
+
 
 def test_plot_ica_sources(raw_orig, browser_backend, monkeypatch):
     """Test plotting of ICA panel."""


### PR DESCRIPTION
I frequently run into the issue that calling `ica.plot_properties(raw)` fails because `raw` contains many "bad" annotations such that the fake 2 second epochs (that are part of the properties plot) cannot be contructed.

Here's a minimal reproducible example:

```python
from pathlib import Path

import mne
from mne import Annotations
from mne.io import read_raw_fif
from mne.preprocessing import ICA

raw_fname = Path(mne.__file__).parent / "io" / "tests" / "data" / "test_raw.fif"

raw = read_raw_fif(raw_fname, preload=True, verbose=False)
raw.crop(0, 8).pick("eeg")
raw.del_proj()

annot = Annotations(
    onset=[0.5, 2.5, 4.5, 6.5],
    duration=[1.0, 1.0, 1.0, 1.0],
    description=["BAD"] * 4,
)
raw.set_annotations(annot)

ica = ICA(n_components=2, max_iter=1, random_state=0)
ica.fit(raw)

ica.plot_properties(raw, picks=[0])
```

Here, I am fitting ICA on the good segments only (because the default is `reject_by_annotation=True`), which works fine. However, when trying to visualize the ICA properties with the same data that I fit the model with, I get the following error:

```
<stdin-15>:1: RuntimeWarning: All epochs were dropped!
You might need to alter reject/flat-criteria or drop bad channels to avoid this. You can use Epochs.plot_drop_log() to see which channels are responsible for the dropping of epochs.
<stdin-15>:1: RuntimeWarning: epochs._get_data() can't run because this Epochs-object is empty. You might want to check Epochs.drop_log or Epochs.plot_drop_log() to see why epochs were dropped.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    ica.plot_properties(raw, picks=[0])
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/Users/clemens/Projects/mne-python/mne/preprocessing/ica.py", line 2558, in plot_properties
    return plot_ica_properties(
        self,
    ...<14 lines>...
        verbose=verbose,
    )
  File "<decorator-gen-297>", line 12, in plot_ica_properties
  File "/Users/clemens/Projects/mne-python/mne/viz/ica.py", line 516, in plot_ica_properties
    return _fast_plot_ica_properties(
        ica,
    ...<15 lines>...
        precomputed_data=None,
    )
  File "/Users/clemens/Projects/mne-python/mne/viz/ica.py", line 621, in _fast_plot_ica_properties
    spectrum = epochs_src.compute_psd(picks=picks, **psd_args)
  File "<decorator-gen-249>", line 12, in compute_psd
  File "/Users/clemens/Projects/mne-python/mne/epochs.py", line 2588, in compute_psd
    return EpochsSpectrum(
        self,
    ...<11 lines>...
        **method_kw,
    )
  File "/Users/clemens/Projects/mne-python/mne/time_frequency/spectrum.py", line 1448, in __init__
    data = self.inst._get_data(picks=self._picks, on_empty="raise")[
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<decorator-gen-243>", line 12, in _get_data
  File "/Users/clemens/Projects/mne-python/mne/epochs.py", line 1662, in _get_data
    self._handle_empty(on_empty, "_get_data")
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/clemens/Projects/mne-python/mne/epochs.py", line 1623, in _handle_empty
    _on_missing(on_empty, msg, error_klass=RuntimeError)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/clemens/Projects/mne-python/mne/utils/check.py", line 1221, in _on_missing
    raise error_klass(msg)
RuntimeError: epochs._get_data() can't run because this Epochs-object is empty. You might want to check Epochs.drop_log or Epochs.plot_drop_log() to see why epochs were dropped.
```

I fixed this issue by constructing the fake 2s epochs a bit more cleverly. If the normal approach yields empty epochs, I first stitch together the good segments and only then create the fake epochs.