### PR TITLE
FORWARD: assert invariant for unreachable rref branch in _lead_dots

### DIFF
--- a/doc/changes/dev/13764.bugfix.rst
+++ b/doc/changes/dev/13764.bugfix.rst
@@ -1,0 +1,1 @@
+Clarified an internal forward-model invariant in ``mne.forward._lead_dots`` by asserting that ``rref`` is ``None`` on the current code path, by `Pragnya Khandelwal`_.

--- a/mne/forward/_lead_dots.py
+++ b/mne/forward/_lead_dots.py
@@ -602,10 +602,5 @@ def _do_surface_dots_subset(
         n_fact,
         ch_type,
     ).T
-    if rref is not None:
-        raise NotImplementedError  # we don't ever use this, isn't tested
-        # vres = _fast_sphere_dot_r0(
-        #     intrad, rref, rmags, refl, rlens, this_nn, cosmags, None, ws,
-        #     volume, lut, n_fact, ch_type)
-        # products -= vres
+    assert rref is None  # guaranteed by our code path
     return products


### PR DESCRIPTION
Reference issue: #13755

This PR follows @larsoner guidance from #13755.

## What changed
- Replaced the unreachable `NotImplementedError` branch in `mne/forward/_lead_dots.py` with:
  - `assert rref is None  # guaranteed by our code path`
- Removed dead/commented code in that branch.

## Why
Based on current call paths, `rref is not None` should be unreachable.  
An explicit invariant assert better documents intent than keeping an untested fallback branch.

## Validation
- `python -m pytest mne/forward/tests -k "sphere_dot or sensitivity or forward" -q`
  - 25 passed, 9 skipped
- `python -m pre_commit run --files mne/forward/_lead_dots.py`
  - passed