### PR TITLE
FIX: remap lowpass <= 0 to Nyquist in GDF/EDF reader

### DIFF
--- a/doc/changes/dev/13769.bugfix.rst
+++ b/doc/changes/dev/13769.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug in :mod:`mne.io.edf` where non-positive lowpass values were not handled correctly, now mapping them to the Nyquist frequency to prevent errors during plotting, by :newcontrib:`Hansuja Budhiraja`_.
+Fix bug in :mod:`mne.io.edf` where non-positive lowpass values were not handled correctly, now mapping them to the Nyquist frequency to prevent errors during plotting, by :newcontrib:`Hansuja Budhiraja`.

--- a/doc/changes/dev/13769.bugfix.rst
+++ b/doc/changes/dev/13769.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug in :mod:`mne.io.edf` where non-positive lowpass values were not handled correctly, now mapping them to the Nyquist frequency to prevent errors during plotting, by `Hansuja Budhiraja`_.

--- a/doc/changes/dev/13769.bugfix.rst
+++ b/doc/changes/dev/13769.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug in EDF reader where non-positive lowpass values were not handled correctly, now mapping them to the Nyquist frequency to prevent errors during plotting, by :newcontrib:`Hansuja Budhiraja`_.
+Fix bug in :mod:`mne.io.edf` where non-positive lowpass values were not handled correctly, now mapping them to the Nyquist frequency to prevent errors during plotting, by :newcontrib:`Hansuja Budhiraja`_.

--- a/doc/changes/dev/13769.bugfix.rst
+++ b/doc/changes/dev/13769.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug in :mod:`mne.io.edf` where non-positive lowpass values were not handled correctly, now mapping them to the Nyquist frequency to prevent errors during plotting, by :newcontrib:`Hansuja Budhiraja`.
+Fix bug in when reading EDF/GDF files where non-positive lowpass values were not handled correctly, now mapping them to the Nyquist frequency to prevent errors during plotting, by :newcontrib:`Hansuja Budhiraja`.

--- a/doc/changes/dev/13769.bugfix.rst
+++ b/doc/changes/dev/13769.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug in :mod:`mne.io.edf` where non-positive lowpass values were not handled correctly, now mapping them to the Nyquist frequency to prevent errors during plotting, by `Hansuja Budhiraja`_.
+Fix bug in EDF reader where non-positive lowpass values were not handled correctly, now mapping them to the Nyquist frequency to prevent errors during plotting, by :newcontrib:`Hansuja Budhiraja`_.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -116,6 +116,7 @@
 .. _Hakimeh Pourakbari: https://github.com/Hpakbari
 .. _Hamid Maymandi: https://github.com/HamidMandi
 .. _Hamza Abdelhedi: https://github.com/BabaSanfour
+.. _Hansuja Budhiraja: https://github.com/HansujaB
 .. _Hari Bharadwaj: https://github.com/haribharadwaj
 .. _Harrison Ritz: https://github.com/harrisonritz
 .. _Hasrat Ali Arzoo: https://github.com/hasrat17

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -975,7 +975,7 @@ def _get_info(
         _set_prefilter(info, edf_info, filt_ch_idxs, "highpass")
         _set_prefilter(info, edf_info, filt_ch_idxs, "lowpass")
 
-    if np.isnan(info["lowpass"]):
+    if np.isnan(info["lowpass"]) or info["lowpass"] <= 0: 
         info["lowpass"] = info["sfreq"] / 2.0
 
     if info["highpass"] > info["lowpass"]:

--- a/mne/io/edf/edf.py
+++ b/mne/io/edf/edf.py
@@ -975,7 +975,7 @@ def _get_info(
         _set_prefilter(info, edf_info, filt_ch_idxs, "highpass")
         _set_prefilter(info, edf_info, filt_ch_idxs, "lowpass")
 
-    if np.isnan(info["lowpass"]) or info["lowpass"] <= 0: 
+    if np.isnan(info["lowpass"]) or info["lowpass"] <= 0:
         info["lowpass"] = info["sfreq"] / 2.0
 
     if info["highpass"] > info["lowpass"]:


### PR DESCRIPTION


#### Reference issue 

Fixes #12517

#### What does this implement/fix?

Fixes ZeroDivisionError in raw.plot() when GDF file has lowpass=0.0.
##### before
`if np.isnan(info["lowpass"]):`

##### after
`if np.isnan(info["lowpass"]) or info["lowpass"] <= 0:`

Existing test test_edf_lowpass_zero covers this.
