### PR TITLE
FIX: raise clear ValueError when no ECG events found in create_ecg_epochs

### DIFF
--- a/doc/changes/dev/13771.bugfix.rst
+++ b/doc/changes/dev/13771.bugfix.rst
@@ -1,0 +1,1 @@
+Fix misleading :exc:`TypeError` when no ECG events are found in :func:`~mne.preprocessing.find_ecg_events` by correcting empty array dtype, and raise a clear :exc:`ValueError` early in :func:`~mne.preprocessing.create_ecg_epochs` when no events are found, by :newcontrib:`Hansuja Budhiraja`.

--- a/doc/changes/dev/13771.bugfix.rst
+++ b/doc/changes/dev/13771.bugfix.rst
@@ -1,1 +1,1 @@
-Fix misleading :exc:`TypeError` when no ECG events are found in :func:`~mne.preprocessing.find_ecg_events` by correcting empty array dtype, and raise a clear :exc:`ValueError` early in :func:`~mne.preprocessing.create_ecg_epochs` when no events are found, by :newcontrib:`Hansuja Budhiraja`.
+Clearer error message when no ECG events are found in :func:`~mne.preprocessing.find_ecg_events`, by :newcontrib:`Hansuja Budhiraja`.

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -278,7 +278,7 @@ def find_ecg_events(
     if ecg_events.size > 0:
         ecg_events = remap[ecg_events]
     else:
-        ecg_events = np.array([],int)
+        ecg_events = np.array([], int)
     n_events = len(ecg_events)
     duration_sec = len(ecg) / raw.info["sfreq"] - tstart
     duration_min = duration_sec / 60.0

--- a/mne/preprocessing/ecg.py
+++ b/mne/preprocessing/ecg.py
@@ -278,8 +278,7 @@ def find_ecg_events(
     if ecg_events.size > 0:
         ecg_events = remap[ecg_events]
     else:
-        ecg_events = np.array([])
-
+        ecg_events = np.array([],int)
     n_events = len(ecg_events)
     duration_sec = len(ecg) / raw.info["sfreq"] - tstart
     duration_min = duration_sec / 60.0
@@ -429,6 +428,9 @@ def create_ecg_epochs(
         return_ecg=True,
         reject_by_annotation=reject_by_annotation,
     )
+
+    if len(events) == 0:
+        raise ValueError("No ECG events could be found.")
 
     picks = _picks_to_idx(raw.info, picks, "all", exclude=())
 

--- a/mne/preprocessing/tests/test_ecg.py
+++ b/mne/preprocessing/tests/test_ecg.py
@@ -118,6 +118,10 @@ def test_find_ecg():
     assert average_pulse == 0
     assert np.allclose(ecg, np.zeros_like(ecg))
 
+    # Test that create_ecg_epochs raises clear error when no ECG events found
+    with pytest.raises(ValueError, match="No ECG events could be found."):
+        create_ecg_epochs(raw, ch_name=raw.ch_names[ecg_idx])
+
     # Needs MEG
     with pytest.raises(ValueError, match="Generating an artificial"):
         find_ecg_events(read_raw_fif(raw_fname, preload=False).pick("eeg"))


### PR DESCRIPTION
#### Reference issue 

Fixes #12201 

#### What does this implement/fix?

Fixes misleading TypeError when no ECG events are found.

Changes:

- find_ecg_events: fix dtype np.array([]) → np.array([], int)
- create_ecg_epochs: raise early with clear message if no events found
