### PR TITLE
DOC: Remove invalid ndarray option from colormap docstrings

### DIFF
--- a/doc/changes/dev/13797.other.rst
+++ b/doc/changes/dev/13797.other.rst
@@ -1,1 +1,1 @@
-Remove :class:`numpy.ndarray` from `colormap` parameter in :func:`mne.viz.plot_source_estimates` to solve documentation conflict , by :newcontrib:`Lifeng Qiu Lin`.
+Remove :class:`numpy.ndarray` from ``colormap`` parameter in :func:`mne.viz.plot_source_estimates` to solve documentation conflict , by :newcontrib:`Lifeng Qiu Lin`.

--- a/doc/changes/dev/13797.other.rst
+++ b/doc/changes/dev/13797.other.rst
@@ -1,0 +1,1 @@
+Remove :class:`numpy.ndarray` from `colormap` parameter in :func:`mne.viz.plot_source_estimates` to solve documentation conflict , by :newcontrib:`Lifeng Qiu Lin`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -186,6 +186,7 @@
 .. _Leonardo Barbosa: https://github.com/noreun
 .. _Leonardo Rochael Almeida: https://github.com/leorochael
 .. _Liberty Hamilton: https://github.com/libertyh
+.. _Lifeng Qiu Lin: https://github.com/Gnefil
 .. _Lorenzo Desantis: https://github.com/lorenzo-desantis/
 .. _Lukas Breuer: https://www.researchgate.net/profile/Lukas-Breuer-2
 .. _Lukas Gemein: https://github.com/gemeinl

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -836,8 +836,8 @@ colorbar : bool
 
 docdict["colormap"] = """
 colormap : str | matplotlib.colors.Colormap
-    Name of colormap to use or a custom look up table. If passing a custom
-    colormap, it must be an instance of :class:`matplotlib.colors.Colormap`
+    Name of colormap to use or a custom Matplotlib colormap instance. If passing
+    a custom colormap, it must be an instance of :class:`matplotlib.colors.Colormap`
     (e.g., :class:`matplotlib.colors.ListedColormap`).
 """
 

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -835,10 +835,10 @@ colorbar : bool
 """
 
 docdict["colormap"] = """
-colormap : str | np.ndarray of float, shape(n_colors, 3 | 4)
-    Name of colormap to use or a custom look up table. If array, must
-    be (n x 3) or (n x 4) array for with RGB or RGBA values between
-    0 and 255.
+colormap : str | matplotlib.colors.Colormap
+    Name of colormap to use or a custom look up table. If passing a custom
+    colormap, it must be an instance of :class:`matplotlib.colors.Colormap`
+    (e.g., :class:`matplotlib.colors.ListedColormap`).
 """
 
 _combine_template = """


### PR DESCRIPTION
#### Reference issue 

Fixes [#13189 ](https://github.com/mne-tools/mne-python/issues/13189).

#### What does this implement/fix?
This PR solves the conflict between the documentation and the actual signature of `mne.viz.plot_source_estimates`, which doesn't accept a numpy array for colormap.

#### Additional information
A possible future minor enhancement would be to include a numpy array option and transform to colormap using matplotlib as suggested by [larsoner](https://github.com/larsoner) in [comments](https://github.com/mne-tools/mne-python/issues/13189#issuecomment-2778893824). If agreed, that could be my next PR.

Additionally, this is my first time contributing. I looked at the contributing guidelines, played with the code, and viewed how others create issues and PRs. But still, I might miss something, so don't hesitate to point out any mistakes! Finally, this is a work by Lifeng, a 2026 GSoC applicant for project 2.