### PR TITLE
DOC: Correct colormap types in global docdict

### DIFF
--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -835,10 +835,8 @@ colorbar : bool
 """
 
 docdict["colormap"] = """
-colormap : str | np.ndarray of float, shape(n_colors, 3 | 4)
-    Name of colormap to use or a custom look up table. If array, must
-    be (n x 3) or (n x 4) array for with RGB or RGBA values between
-    0 and 255.
+colormap : str | matplotlib.colors.Colormap
+    Name of colormap to use or a custom look up table.
 """
 
 _combine_template = """


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

<!-- Example:

Fixes #13189.

-->


#### What does this implement/fix?

I updated the global docdict for the colormap parameter to reflect that np.ndarray is no longer supported and added matplotlib.colors.Colormap as a valid type.


#### Additional information

<!-- Any additional information you think is important. -->
