### PR TITLE
DOC: Clarify add_reference_channels usage with average reference

### DIFF
--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -812,6 +812,12 @@ class UpdateChannelsMixin:
         -------
         inst : same type as the input data
                The modified instance.
+               
+        note:: If you are adding a new reference channel to data that
+                will eventually be used with an average reference,
+                you should also call :meth:`mne.io.Raw.set_eeg_reference`
+                (or the equivalent Epochs/Evoked method) to ensure the
+                mathematical reference is updated correctly.
         """
         return add_reference_channels(self, ref_channels, copy=False)
 

--- a/mne/channels/channels.py
+++ b/mne/channels/channels.py
@@ -812,7 +812,7 @@ class UpdateChannelsMixin:
         -------
         inst : same type as the input data
                The modified instance.
-               
+
         note:: If you are adding a new reference channel to data that
                 will eventually be used with an average reference,
                 you should also call :meth:`mne.io.Raw.set_eeg_reference`


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

<!-- Example:

Fixes #13618.

-->


#### What does this implement/fix?

Added a note:: to the add_reference_channels docstring in mne/channels/channels.py. This clarifies that users should mathematically update their EEG reference using set_eeg_reference after adding new reference channels to ensure correct average reference calculations.


#### Additional information

This was identified as a necessary documentation improvement user errors during EEG preprocessing workflows.
