### PR TITLE
ENH: broaden OPM coil handling for colocated topomaps

### DIFF
--- a/doc/changes/dev/13825.bugfix.rst
+++ b/doc/changes/dev/13825.bugfix.rst
@@ -1,0 +1,1 @@
+Improved colocated OPM topomap handling by recognizing additional OPM coil types (FieldLine and Kernel), by `Pragnya Khandelwal`_.

--- a/mne/_fiff/constants.py
+++ b/mne/_fiff/constants.py
@@ -1183,6 +1183,7 @@ _ch_coil_type_named = {
         FIFF.FIFFV_COIL_QUSPIN_ZFOPM_MAG2,
         FIFF.FIFFV_COIL_FIELDLINE_OPM_MAG_GEN1,
         FIFF.FIFFV_COIL_KERNEL_OPM_MAG_GEN1,
+        # If more OPM coil types are added here, update mne/viz/topomap.py too.
         FIFF.FIFFV_COIL_KRISS_GRAD,
         FIFF.FIFFV_COIL_COMPUMEDICS_ADULT_GRAD,
         FIFF.FIFFV_COIL_COMPUMEDICS_PEDIATRIC_GRAD,

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -799,13 +799,15 @@ def test_plot_topomap_opm():
 
 def test_prepare_topomap_plot_opm_non_quspin_coils():
     """Test colocated OPM handling for non-QuSpin OPM coil types."""
-    ch_names = ["OPM001", "OPM002", "OPM003", "OPM004"]
+    ch_names = ["OPM001", "OPM002", "OPM003", "OPM004", "OPM005", "OPM006"]
     info = create_info(ch_names, 1000.0, ch_types="mag")
-    # Two colocated pairs with different orientations.
+    # Two colocated trios with different orientations.
     positions = np.array(
         [
             [0.03, 0.00, 0.05],
             [0.03, 0.00, 0.05],
+            [0.03, 0.00, 0.05],
+            [-0.03, 0.00, 0.05],
             [-0.03, 0.00, 0.05],
             [-0.03, 0.00, 0.05],
         ]
@@ -814,8 +816,10 @@ def test_prepare_topomap_plot_opm_non_quspin_coils():
         [
             [0.5145, 0.0000, 0.8575],  # radial-ish
             [0.0000, 1.0000, 0.0000],  # tangential-ish
+            [0.0000, 0.0000, 1.0000],  # tangential-ish
             [-0.5145, 0.0000, 0.8575],  # radial-ish
             [0.0000, 1.0000, 0.0000],  # tangential-ish
+            [0.0000, 0.0000, 1.0000],  # tangential-ish
         ]
     )
     with info._unlock():
@@ -829,9 +833,11 @@ def test_prepare_topomap_plot_opm_non_quspin_coils():
         evoked, "mag"
     )
 
-    assert len(picks) == 4
+    assert len(picks) == 6
     assert merge_channels
-    assert sum(name.endswith("MERGE-REMOVE") for name in merged_names) == 2
+    assert len(merge_channels) == 2
+    assert all(len(set_) == 3 for set_ in merge_channels)
+    assert sum(name.endswith("MERGE-REMOVE") for name in merged_names) == 4
 
 
 def test_plot_topomap_nirs_overlap(fnirs_epochs):

--- a/mne/viz/tests/test_topomap.py
+++ b/mne/viz/tests/test_topomap.py
@@ -797,6 +797,43 @@ def test_plot_topomap_opm():
     assert len(fig_evoked.axes) == 5
 
 
+def test_prepare_topomap_plot_opm_non_quspin_coils():
+    """Test colocated OPM handling for non-QuSpin OPM coil types."""
+    ch_names = ["OPM001", "OPM002", "OPM003", "OPM004"]
+    info = create_info(ch_names, 1000.0, ch_types="mag")
+    # Two colocated pairs with different orientations.
+    positions = np.array(
+        [
+            [0.03, 0.00, 0.05],
+            [0.03, 0.00, 0.05],
+            [-0.03, 0.00, 0.05],
+            [-0.03, 0.00, 0.05],
+        ]
+    )
+    orientations = np.array(
+        [
+            [0.5145, 0.0000, 0.8575],  # radial-ish
+            [0.0000, 1.0000, 0.0000],  # tangential-ish
+            [-0.5145, 0.0000, 0.8575],  # radial-ish
+            [0.0000, 1.0000, 0.0000],  # tangential-ish
+        ]
+    )
+    with info._unlock():
+        for idx, ch in enumerate(info["chs"]):
+            ch["coil_type"] = FIFF.FIFFV_COIL_FIELDLINE_OPM_MAG_GEN1
+            ch["loc"][:3] = positions[idx]
+            ch["loc"][9:12] = orientations[idx]
+    evoked = EvokedArray(np.zeros((len(ch_names), 5)), info)
+
+    picks, _pos, merge_channels, merged_names, *_ = topomap._prepare_topomap_plot(
+        evoked, "mag"
+    )
+
+    assert len(picks) == 4
+    assert merge_channels
+    assert sum(name.endswith("MERGE-REMOVE") for name in merged_names) == 2
+
+
 def test_plot_topomap_nirs_overlap(fnirs_epochs):
     """Test plotting nirs topomap with overlapping channels (gh-7414)."""
     fig = fnirs_epochs["A"].average(picks="hbo").plot_topomap()

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -77,7 +77,12 @@ from .utils import (
 )
 
 _fnirs_types = ("hbo", "hbr", "fnirs_cw_amplitude", "fnirs_od")
-_opm_coils = (FIFF.FIFFV_COIL_QUSPIN_ZFOPM_MAG, FIFF.FIFFV_COIL_QUSPIN_ZFOPM_MAG2)
+_opm_coils = (
+    FIFF.FIFFV_COIL_QUSPIN_ZFOPM_MAG,
+    FIFF.FIFFV_COIL_QUSPIN_ZFOPM_MAG2,
+    FIFF.FIFFV_COIL_FIELDLINE_OPM_MAG_GEN1,
+    FIFF.FIFFV_COIL_KERNEL_OPM_MAG_GEN1,
+)
 
 
 # 3.8+ uses a single Collection artist rather than .collections


### PR DESCRIPTION
#### Reference issue (if any)
Related to #13781 

Hi @larsoner, @drammock 
I tried to start with a small incremental fix to keep the scope reviewable and testable. This branch now handles `colocated OPM` topomap detection more robustly, and I’ll continue with the orientation-grouping part next once I get guidance on the preferred direction.
