### PR TITLE
BUG: Fix bug with backward compat

### DIFF
--- a/examples/inverse/psf_ctf_label_leakage.py
+++ b/examples/inverse/psf_ctf_label_leakage.py
@@ -97,7 +97,7 @@ rh_labels = [label[:-2] + "rh" for label in lh_labels]
 # spatial extents of labels.
 n_comp = 5
 stcs_psf_mne, pca_vars_mne = get_point_spread(
-    rm_mne, src, labels, mode="pca", n_comp=n_comp, norm=None, return_pca_vars=True
+    rm_mne, src, labels, mode="svd", n_comp=n_comp, norm=None, return_pca_vars=True
 )
 n_verts = rm_mne.shape[0]
 del rm_mne

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -998,6 +998,7 @@ def brain_gc(request):
     from mne.viz import Brain
 
     ignore = set(id(o) for o in gc.get_objects())
+    vtk_ignores = ("vtkBuffer_IhE",)
     yield
     close_func()
     if not _test_passed(request):
@@ -1012,7 +1013,11 @@ def brain_gc(request):
         except Exception:  # old Python, probably
             pass
         else:
-            if name.startswith("vtk") and id(o) not in ignore:
+            if (
+                name.startswith("vtk")
+                and name not in vtk_ignores
+                and id(o) not in ignore
+            ):
                 bad.append(name)
         del o
     del objs, ignore, Brain

--- a/mne/decoding/tests/test_csp.py
+++ b/mne/decoding/tests/test_csp.py
@@ -24,7 +24,7 @@ from sklearn.utils.estimator_checks import parametrize_with_checks
 from mne import Epochs, compute_proj_raw, io, pick_types, read_events
 from mne.decoding import CSP, LinearModel, Scaler, SPoC, get_coef, read_csp, read_spoc
 from mne.decoding.csp import _ajd_pham
-from mne.utils import catch_logging
+from mne.utils import catch_logging, check_version
 
 data_dir = Path(__file__).parents[2] / "io" / "tests" / "data"
 raw_fname = data_dir / "test_raw.fif"
@@ -320,8 +320,12 @@ def test_regularized_csp(ch_type, rank, reg):
     epochs_data = sc.fit_transform(epochs_data)
     csp = CSP(n_components=n_components, reg=reg, norm_trace=False, rank=rank)
     if rank == "full" and reg is None:
-        with pytest.raises(np.linalg.LinAlgError, match="leading minor"):
-            csp.fit(epochs_data, epochs.events[:, -1])
+        # TODO: Figure out why SciPy 1.18 is different:
+        # R_restr differs enough (but only by ~1e-13!) that it doesn't hit the
+        # "leading minor" error here...
+        if not check_version("scipy", "1.18.0.dev0"):
+            with pytest.raises(np.linalg.LinAlgError, match="leading minor"):
+                csp.fit(epochs_data, epochs.events[:, -1])
         return
     with catch_logging(verbose=True) as log:
         X = csp.fit_transform(epochs_data, epochs.events[:, -1])

--- a/mne/minimum_norm/resolution_matrix.py
+++ b/mne/minimum_norm/resolution_matrix.py
@@ -17,7 +17,7 @@ from ..forward.forward import Forward, convert_forward_solution
 from ..label import Label
 from ..source_estimate import _get_src_type, _make_stc, _prepare_label_extraction
 from ..source_space._source_space import SourceSpaces, _get_vertno
-from ..utils import _validate_type, logger, verbose
+from ..utils import _check_option, _validate_type, logger, verbose
 from .inverse import apply_inverse
 
 
@@ -159,12 +159,9 @@ def _get_psf_ctf(
             _mode_map = {
                 "max": "maxnorm",
                 "svd": "pca",
-                "mean": "mean",
-                "sum": "sum",
-                "maxval": "maxval",
             }
             funcs, pca_var = _summarise_psf_ctf(
-                funcs, _mode_map[mode], n_comp, return_pca_vars, nn
+                funcs, _mode_map.get(mode, mode), n_comp, return_pca_vars, nn
             )
 
         if not vector:  # if one value per vertex requested
@@ -201,15 +198,15 @@ def _get_psf_ctf(
 
 def _check_get_psf_ctf_params(mode, n_comp, return_pca_vars):
     """Check input parameters of _get_psf_ctf() for consistency."""
-    valid_modes = (None, "mean", "max", "svd", "sum", "maxval")
-    if mode not in valid_modes:
-        raise ValueError(f"mode must be one of {valid_modes}, got {mode!r} instead.")
+    _validate_type(mode, (str, None), "mode")
+    # provide backward compatibility for old mode names
+    mode = {"pca": "svd", "maxnorm": "max"}.get(mode, mode)
+    _check_option("mode", mode, (None, "mean", "max", "svd", "sum", "maxval"))
     if mode in [None, "mean", "sum"] and n_comp > 1:
         msg = f"n_comp must be 1 for mode={mode}."
         raise ValueError(msg)
     if mode != "svd" and return_pca_vars:
-        msg = "SVD variances can only be returned if mode='svd'."
-        raise ValueError(msg)
+        raise ValueError("SVD variances can only be returned if mode='svd'.")
 
 
 def _vertices_for_get_psf_ctf(idx, src):

--- a/mne/minimum_norm/tests/test_resolution_matrix.py
+++ b/mne/minimum_norm/tests/test_resolution_matrix.py
@@ -68,7 +68,7 @@ def test_resolution_matrix_free(src_type, fwd_volume_small):
     )
     assert_array_almost_equal(rm_mne_free, rm_mne_free.T)
     # check various summary and normalisation options
-    for mode in [None, "mean", "max", "svd", "sum", "maxval"]:
+    for mode in [None, "mean", "max", "svd", "sum", "maxval", "pca"]:
         n_comps = [1, 3]
         if mode in [None, "mean", "sum"]:
             n_comps = [1]
@@ -114,7 +114,7 @@ def test_resolution_matrix_free(src_type, fwd_volume_small):
                 # There is an ambiguity in the sign flip from the PCA here.
                 # Ideally we would use the normals to fix it, but it's not
                 # trivial.
-                if mode == "svd" and n_comp == 3:
+                if mode in ("svd", "pca") and n_comp == 3:
                     stc_psf_free = abs(stc_psf_free)
                     stc_ctf_free = abs(stc_psf_free)
                 assert_array_almost_equal(

--- a/tools/install_pre_requirements.sh
+++ b/tools/install_pre_requirements.sh
@@ -38,8 +38,7 @@ echo "::endgroup::"
 # No Numba because it forces an old NumPy version
 
 echo "::group::VTK"
-# TODO: Max-pin until https://gitlab.kitware.com/vtk/vtk/-/issues/19996
-python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://wheels.vtk.org" "vtk<9.6.20260314.dev0"
+python -m pip install $STD_ARGS --only-binary ":all:" --extra-index-url "https://wheels.vtk.org" "vtk>=9.6.20260405.dev0"
 python -c "import vtk"
 echo "::endgroup::"
 


### PR DESCRIPTION
#13754 broke backward compat with undocumented options `maxnorm` and `pca`, it's easy enough for us to continue supporting them.