### PR TITLE
TST: Add regression coverage for OPM topomap grouping via `plot_joint()` and `ICA`

### DIFF
--- a/doc/changes/dev/13842.other.rst
+++ b/doc/changes/dev/13842.other.rst
@@ -1,0 +1,1 @@
+Added regression coverage for colocated triaxial OPM topomap handling in ``plot_joint()`` and ``ICA.plot_components()``, by `Pragnya Khandelwal`_.

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -28,13 +28,12 @@ register_assert_rewrite("mne.utils._testing")
 # ruff: noqa: E402
 import mne
 from mne import Epochs, create_info, make_fixed_length_epochs, pick_types, read_events
+from mne._fiff.constants import FIFF
 from mne.channels import read_layout
 from mne.coreg import create_default_subject
 from mne.datasets import testing
 from mne.fixes import _compare_version, has_numba
-from mne._fiff.constants import FIFF
-from mne.io import read_raw_ctf, read_raw_fif, read_raw_nirx, read_raw_snirf
-from mne.io import RawArray
+from mne.io import RawArray, read_raw_ctf, read_raw_fif, read_raw_nirx, read_raw_snirf
 from mne.stats import cluster_level
 from mne.utils import (
     Bunch,

--- a/mne/conftest.py
+++ b/mne/conftest.py
@@ -27,12 +27,14 @@ register_assert_rewrite("mne.utils._testing")
 
 # ruff: noqa: E402
 import mne
-from mne import Epochs, pick_types, read_events
+from mne import Epochs, create_info, make_fixed_length_epochs, pick_types, read_events
 from mne.channels import read_layout
 from mne.coreg import create_default_subject
 from mne.datasets import testing
 from mne.fixes import _compare_version, has_numba
+from mne._fiff.constants import FIFF
 from mne.io import read_raw_ctf, read_raw_fif, read_raw_nirx, read_raw_snirf
+from mne.io import RawArray
 from mne.stats import cluster_level
 from mne.utils import (
     Bunch,
@@ -544,6 +546,47 @@ def _bias_params(evoked, noise_cov, fwd):
     if not mne.forward.is_fixed_orient(fwd):
         want //= 3
     return evoked, fwd, noise_cov, data_cov, want
+
+
+@pytest.fixture
+def triaxial_raw():
+    """Create a small triaxial OPM raw for regression tests."""
+    ch_names = ["OPM001", "OPM002", "OPM003", "OPM004", "OPM005", "OPM006"]
+    info = create_info(ch_names, 1000.0, ch_types="mag")
+    positions = np.array(
+        [
+            [0.03, 0.00, 0.05],
+            [0.03, 0.00, 0.05],
+            [0.03, 0.00, 0.05],
+            [-0.03, 0.00, 0.05],
+            [-0.03, 0.00, 0.05],
+            [-0.03, 0.00, 0.05],
+        ]
+    )
+    orientations = np.array(
+        [
+            [0.5145, 0.0000, 0.8575],
+            [0.0000, 1.0000, 0.0000],
+            [0.0000, 0.0000, 1.0000],
+            [-0.5145, 0.0000, 0.8575],
+            [0.0000, 1.0000, 0.0000],
+            [0.0000, 0.0000, 1.0000],
+        ]
+    )
+    with info._unlock():
+        for idx, ch in enumerate(info["chs"]):
+            ch["coil_type"] = FIFF.FIFFV_COIL_FIELDLINE_OPM_MAG_GEN1
+            ch["loc"][:3] = positions[idx]
+            ch["loc"][9:12] = orientations[idx]
+    rng = np.random.default_rng(0)
+    data = rng.standard_normal((len(ch_names), 2000))
+    return RawArray(data, info, verbose="error")
+
+
+@pytest.fixture
+def triaxial_evoked(triaxial_raw):
+    """Create a small triaxial OPM evoked for regression tests."""
+    return make_fixed_length_epochs(triaxial_raw).average()
 
 
 @pytest.fixture

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -13,16 +13,14 @@ from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 from mne import (
     Annotations,
     Epochs,
-    create_info,
     make_fixed_length_events,
     pick_types,
     read_cov,
     read_events,
     read_evokeds,
 )
-from mne._fiff.constants import FIFF
 from mne.datasets import testing
-from mne.io import RawArray, read_raw_fif
+from mne.io import read_raw_fif
 from mne.preprocessing import ICA, create_ecg_epochs, create_eog_epochs
 from mne.utils import _record_warnings, catch_logging
 from mne.viz.ica import _create_properties_layout, plot_ica_properties
@@ -55,39 +53,6 @@ def _get_events():
 def _get_picks(raw):
     """Get picks."""
     return [0, 1, 2, 6, 7, 8, 12, 13, 14]  # take a only few channels
-
-
-def _make_opm_triaxial_raw(n_times=200):
-    """Create a small triaxial OPM raw for regression tests."""
-    ch_names = ["OPM001", "OPM002", "OPM003", "OPM004", "OPM005", "OPM006"]
-    info = create_info(ch_names, 1000.0, ch_types="mag")
-    positions = np.array(
-        [
-            [0.03, 0.00, 0.05],
-            [0.03, 0.00, 0.05],
-            [0.03, 0.00, 0.05],
-            [-0.03, 0.00, 0.05],
-            [-0.03, 0.00, 0.05],
-            [-0.03, 0.00, 0.05],
-        ]
-    )
-    orientations = np.array(
-        [
-            [0.5145, 0.0000, 0.8575],
-            [0.0000, 1.0000, 0.0000],
-            [0.0000, 0.0000, 1.0000],
-            [-0.5145, 0.0000, 0.8575],
-            [0.0000, 1.0000, 0.0000],
-            [0.0000, 0.0000, 1.0000],
-        ]
-    )
-    with info._unlock():
-        for idx, ch in enumerate(info["chs"]):
-            ch["coil_type"] = FIFF.FIFFV_COIL_FIELDLINE_OPM_MAG_GEN1
-            ch["loc"][:3] = positions[idx]
-            ch["loc"][9:12] = orientations[idx]
-    data = np.random.RandomState(0).randn(len(ch_names), n_times)
-    return RawArray(data, info, verbose="error")
 
 
 def _get_epochs():
@@ -615,10 +580,9 @@ def test_plot_components_opm():
 @pytest.mark.filterwarnings(
     "ignore:FastICA did not converge.*:sklearn.exceptions.ConvergenceWarning"
 )
-def test_plot_components_opm_triaxial():
+def test_plot_components_opm_triaxial(triaxial_raw):
     """Test OPM component topomaps with colocated triaxial channels."""
-    raw = _make_opm_triaxial_raw()
     ica = ICA(max_iter=1, random_state=0, n_components=3)
-    ica.fit(raw, picks="mag", verbose="error")
+    ica.fit(triaxial_raw, picks="mag", verbose="error")
     fig = ica.plot_components()
     assert len(fig.axes) == 3

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -13,9 +13,8 @@ from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 from mne import (
     Annotations,
     Epochs,
-    make_fixed_length_events,
-    EvokedArray,
     create_info,
+    make_fixed_length_events,
     pick_types,
     read_cov,
     read_events,

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -14,11 +14,14 @@ from mne import (
     Annotations,
     Epochs,
     make_fixed_length_events,
+    EvokedArray,
+    create_info,
     pick_types,
     read_cov,
     read_events,
     read_evokeds,
 )
+from mne._fiff.constants import FIFF
 from mne.datasets import testing
 from mne.io import RawArray, read_raw_fif
 from mne.preprocessing import ICA, create_ecg_epochs, create_eog_epochs
@@ -53,6 +56,39 @@ def _get_events():
 def _get_picks(raw):
     """Get picks."""
     return [0, 1, 2, 6, 7, 8, 12, 13, 14]  # take a only few channels
+
+
+def _make_opm_triaxial_raw(n_times=200):
+    """Create a small triaxial OPM raw for regression tests."""
+    ch_names = ["OPM001", "OPM002", "OPM003", "OPM004", "OPM005", "OPM006"]
+    info = create_info(ch_names, 1000.0, ch_types="mag")
+    positions = np.array(
+        [
+            [0.03, 0.00, 0.05],
+            [0.03, 0.00, 0.05],
+            [0.03, 0.00, 0.05],
+            [-0.03, 0.00, 0.05],
+            [-0.03, 0.00, 0.05],
+            [-0.03, 0.00, 0.05],
+        ]
+    )
+    orientations = np.array(
+        [
+            [0.5145, 0.0000, 0.8575],
+            [0.0000, 1.0000, 0.0000],
+            [0.0000, 0.0000, 1.0000],
+            [-0.5145, 0.0000, 0.8575],
+            [0.0000, 1.0000, 0.0000],
+            [0.0000, 0.0000, 1.0000],
+        ]
+    )
+    with info._unlock():
+        for idx, ch in enumerate(info["chs"]):
+            ch["coil_type"] = FIFF.FIFFV_COIL_FIELDLINE_OPM_MAG_GEN1
+            ch["loc"][:3] = positions[idx]
+            ch["loc"][9:12] = orientations[idx]
+    data = np.random.RandomState(0).randn(len(ch_names), n_times)
+    return RawArray(data, info, verbose="error")
 
 
 def _get_epochs():
@@ -574,3 +610,16 @@ def test_plot_components_opm():
     ica.fit(RawArray(evoked.data, evoked.info), picks="mag", verbose="error")
     fig = ica.plot_components()
     assert len(fig.axes) == 10
+
+
+@pytest.mark.slowtest
+@pytest.mark.filterwarnings(
+    "ignore:FastICA did not converge.*:sklearn.exceptions.ConvergenceWarning"
+)
+def test_plot_components_opm_triaxial():
+    """Test OPM component topomaps with colocated triaxial channels."""
+    raw = _make_opm_triaxial_raw()
+    ica = ICA(max_iter=1, random_state=0, n_components=3)
+    ica.fit(raw, picks="mag", verbose="error")
+    fig = ica.plot_components()
+    assert len(fig.axes) == 3

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -20,7 +20,7 @@ from mne import (
     read_evokeds,
 )
 from mne.datasets import testing
-from mne.io import read_raw_fif
+from mne.io import RawArray, read_raw_fif
 from mne.preprocessing import ICA, create_ecg_epochs, create_eog_epochs
 from mne.utils import _record_warnings, catch_logging
 from mne.viz.ica import _create_properties_layout, plot_ica_properties

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -12,13 +12,10 @@ import pytest
 
 from mne import (
     Epochs,
-    EvokedArray,
     compute_proj_evoked,
-    create_info,
     read_cov,
     read_events,
 )
-from mne._fiff.constants import FIFF
 from mne.channels import read_layout
 from mne.io import read_raw_fif
 from mne.time_frequency.tfr import AverageTFRArray
@@ -40,39 +37,6 @@ event_name = base_dir / "test-eve.fif"
 cov_fname = base_dir / "test-cov.fif"
 event_id, tmin, tmax = 1, -0.2, 0.2
 layout = read_layout("Vectorview-all")
-
-
-def _make_opm_triaxial_evoked(n_times=20):
-    """Create a small triaxial OPM evoked for regression tests."""
-    ch_names = ["OPM001", "OPM002", "OPM003", "OPM004", "OPM005", "OPM006"]
-    info = create_info(ch_names, 1000.0, ch_types="mag")
-    positions = np.array(
-        [
-            [0.03, 0.00, 0.05],
-            [0.03, 0.00, 0.05],
-            [0.03, 0.00, 0.05],
-            [-0.03, 0.00, 0.05],
-            [-0.03, 0.00, 0.05],
-            [-0.03, 0.00, 0.05],
-        ]
-    )
-    orientations = np.array(
-        [
-            [0.5145, 0.0000, 0.8575],
-            [0.0000, 1.0000, 0.0000],
-            [0.0000, 0.0000, 1.0000],
-            [-0.5145, 0.0000, 0.8575],
-            [0.0000, 1.0000, 0.0000],
-            [0.0000, 0.0000, 1.0000],
-        ]
-    )
-    with info._unlock():
-        for idx, ch in enumerate(info["chs"]):
-            ch["coil_type"] = FIFF.FIFFV_COIL_FIELDLINE_OPM_MAG_GEN1
-            ch["loc"][:3] = positions[idx]
-            ch["loc"][9:12] = orientations[idx]
-    data = np.random.RandomState(0).randn(len(ch_names), n_times)
-    return EvokedArray(data, info)
 
 
 def _get_events():
@@ -172,10 +136,9 @@ def test_plot_joint():
     plt.close("all")
 
 
-def test_plot_joint_opm_triaxial():
+def test_plot_joint_opm_triaxial(triaxial_evoked):
     """Test joint plot with triaxial colocated OPM channels."""
-    evoked = _make_opm_triaxial_evoked()
-    fig = evoked.plot_joint(
+    fig = triaxial_evoked.plot_joint(
         times=[0.0],
         picks="mag",
         show=False,

--- a/mne/viz/tests/test_topo.py
+++ b/mne/viz/tests/test_topo.py
@@ -10,7 +10,15 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-from mne import Epochs, compute_proj_evoked, read_cov, read_events
+from mne import (
+    Epochs,
+    EvokedArray,
+    compute_proj_evoked,
+    create_info,
+    read_cov,
+    read_events,
+)
+from mne._fiff.constants import FIFF
 from mne.channels import read_layout
 from mne.io import read_raw_fif
 from mne.time_frequency.tfr import AverageTFRArray
@@ -32,6 +40,39 @@ event_name = base_dir / "test-eve.fif"
 cov_fname = base_dir / "test-cov.fif"
 event_id, tmin, tmax = 1, -0.2, 0.2
 layout = read_layout("Vectorview-all")
+
+
+def _make_opm_triaxial_evoked(n_times=20):
+    """Create a small triaxial OPM evoked for regression tests."""
+    ch_names = ["OPM001", "OPM002", "OPM003", "OPM004", "OPM005", "OPM006"]
+    info = create_info(ch_names, 1000.0, ch_types="mag")
+    positions = np.array(
+        [
+            [0.03, 0.00, 0.05],
+            [0.03, 0.00, 0.05],
+            [0.03, 0.00, 0.05],
+            [-0.03, 0.00, 0.05],
+            [-0.03, 0.00, 0.05],
+            [-0.03, 0.00, 0.05],
+        ]
+    )
+    orientations = np.array(
+        [
+            [0.5145, 0.0000, 0.8575],
+            [0.0000, 1.0000, 0.0000],
+            [0.0000, 0.0000, 1.0000],
+            [-0.5145, 0.0000, 0.8575],
+            [0.0000, 1.0000, 0.0000],
+            [0.0000, 0.0000, 1.0000],
+        ]
+    )
+    with info._unlock():
+        for idx, ch in enumerate(info["chs"]):
+            ch["coil_type"] = FIFF.FIFFV_COIL_FIELDLINE_OPM_MAG_GEN1
+            ch["loc"][:3] = positions[idx]
+            ch["loc"][9:12] = orientations[idx]
+    data = np.random.RandomState(0).randn(len(ch_names), n_times)
+    return EvokedArray(data, info)
 
 
 def _get_events():
@@ -116,7 +157,6 @@ def test_plot_joint():
     evoked.plot_joint(
         ts_args=dict(proj="reconstruct"), topomap_args=dict(proj="reconstruct")
     )
-    plt.close("all")
 
     # test sEEG (gh:8733)
     evoked.del_proj().pick("mag")  # avoid overlapping positions error
@@ -130,6 +170,19 @@ def test_plot_joint():
     evoked.set_channel_types(mapping, on_unit_change="ignore")
     evoked.plot_joint()
     plt.close("all")
+
+
+def test_plot_joint_opm_triaxial():
+    """Test joint plot with triaxial colocated OPM channels."""
+    evoked = _make_opm_triaxial_evoked()
+    fig = evoked.plot_joint(
+        times=[0.0],
+        picks="mag",
+        show=False,
+        ts_args=dict(time_unit="s"),
+        topomap_args=dict(time_unit="s", contours=0, res=8, sensors=False),
+    )
+    assert len(fig.axes) >= 2
 
 
 def test_plot_topo():


### PR DESCRIPTION
#### Reference issue (if any)

Related to #13781 (OPM topomap handling)
Follows merged PR #13825 


#### What does this implement/fix?

Follow-up to merged PR #13825 (which broadened OPM coil detection).
This PR adds regression test coverage for the topomap overlap handling 
when used via other plotting callers (`plot_joint`, `plot_components`).


#### Additional information
added helper + test methods in `test_topo.py` and `test_ica.py`

Part of incremental OPM topomap grouping effort
