### PR TITLE
fix env var in actions

### DIFF
--- a/tools/github_actions_download.sh
+++ b/tools/github_actions_download.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ef
 
-if [ "${DEPS}" != "minimal" ]; then
+if [ "${MNE_CI_KIND}" != "minimal" ]; then
 	python -c 'import mne; mne.datasets.testing.data_path(verbose=True)';
 	python -c "import mne; mne.datasets.misc.data_path(verbose=True)";
 fi


### PR DESCRIPTION
@scott-huberty pointed out to me that in `github_actions_download` we reference an env var that seems not to exist. Upshot is that test data is getting unnecessarily downloaded within the `minimal` CI job (see output of the download step here, for example: https://github.com/mne-tools/mne-python/actions/runs/24396331636/job/71255135612?pr=13838#step:20:19)

This should fix it

@larsoner note the `skip` trailers on the commit, no auto-merge on this one