### PR TITLE
Add Zuna to related software list

### DIFF
--- a/doc/sphinxext/related_software.py
+++ b/doc/sphinxext/related_software.py
@@ -35,6 +35,7 @@ PYPI_PACKAGES = {
     "niseq",
     "sesameeg",
     "mne-kit-gui",  # moved to its own env in the installers
+    "zuna",
 }
 
 # If it's not available on PyPI, add it to this dict:

--- a/doc/sphinxext/related_software.py
+++ b/doc/sphinxext/related_software.py
@@ -5,6 +5,10 @@ To add a package to the list:
 1. Add it to the MNE-installers if possible, and it will automatically appear.
 2. If it's on PyPI and not in the MNE-installers, add it to the PYPI_PACKAGES set.
 3. If it's not on PyPI, add it to the MANUAL_PACKAGES dictionary.
+
+If PyPI or manual, also add package name to `related_software.txt` or
+`related_software_nodeps.txt` so that it's installed at doc-build time (for package
+metadata querying).
 """
 
 # Authors: The MNE-Python contributors.

--- a/doc/sphinxext/related_software.py
+++ b/doc/sphinxext/related_software.py
@@ -222,7 +222,7 @@ class RelatedSoftwareDirective(Directive):
         return [my_list]
 
 
-def setup(app):
+def setup(app):  # noqa: D103
     app.add_directive("related-software", RelatedSoftwareDirective)
     # Run it as soon as this is added as a Sphinx extension so that any errors
     # / new packages are reported early. The next call in run() will be cached.

--- a/doc/sphinxext/related_software_nodeps.txt
+++ b/doc/sphinxext/related_software_nodeps.txt
@@ -4,3 +4,4 @@ fsleyes
 mne-kit-gui
 mne-videobrowser
 hedtools  # because it limits our Pandas version currently
+zuna  # requires pytorch


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

<!-- Example:

na

-->


#### What does this implement/fix?


Adds [Zuna](https://github.com/Zyphra/zuna) to the list of MNE-related software in doc/sphinxext/related_software.py.

#### Additional information

This addition was discussed with Daniel McCloy, who gave his okay to include Zuna in the related software list.
