### PR TITLE
Fix versionadded for annotation_colors

### DIFF
--- a/mne/viz/epochs.py
+++ b/mne/viz/epochs.py
@@ -874,7 +874,7 @@ def plot_epochs(
         specification. Keys that do not match any annotation description in the data
         will trigger a warning. If ``None`` (default), automatic colors are used.
 
-        .. versionadded:: 1.13
+        .. versionadded:: 1.12.1
 
     Returns
     -------

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -119,7 +119,7 @@ def plot_raw(
         specification. Keys that do not match any annotation description in the data
         will trigger a warning. If ``None`` (default), automatic colors are used.
 
-        .. versionadded:: 1.13
+        .. versionadded:: 1.12.1
     annotation_regex : str
         A regex pattern applied to each annotation's label.
         Matching labels remain visible, non-matching labels are hidden.


### PR DESCRIPTION
Since this parameter is going to be available in 1.12.1, I've adapted the docstrings (the backport already correctly mentions this version). Thanks @larsoner for taking care of this! Although there are probably not many changes, I'd appreciate a quick 1.12.1 release so that I can follow up with MNELAB (and use this feature).