### PR TITLE
FIX: Correct fNIRS interpolation with reordered picks

### DIFF
--- a/doc/changes/dev/13856.bugfix.rst
+++ b/doc/changes/dev/13856.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an indexing bug in :func:`mne.channels.interpolation._interpolate_bads_nirs` that could use the wrong donor channels when :func:`mne.io.Raw.interpolate_bads` interpolated fNIRS channels reordered by :func:`mne.preprocessing.nirs._validate_nirs_info`, by :newcontrib:`Kalle Makela`.

--- a/doc/changes/dev/13856.bugfix.rst
+++ b/doc/changes/dev/13856.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed an indexing bug in :func:`mne.channels.interpolation._interpolate_bads_nirs` that could use the wrong donor channels when :func:`mne.io.Raw.interpolate_bads` interpolated fNIRS channels reordered by :func:`mne.preprocessing.nirs._validate_nirs_info`, by :newcontrib:`Kalle Makela`.
+Fixed an indexing bug in ``_interpolate_bads_nirs`` that could use the wrong donor channels when :func:`mne.io.Raw.interpolate_bads` interpolated fNIRS channels reordered by ``_validate_nirs_info``, by :newcontrib:`Kalle Makela`.

--- a/doc/changes/dev/13856.bugfix.rst
+++ b/doc/changes/dev/13856.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed an indexing bug in ``_interpolate_bads_nirs`` that could use the wrong donor channels when :func:`mne.io.Raw.interpolate_bads` interpolated fNIRS channels reordered by ``_validate_nirs_info``, by :newcontrib:`Kalle Makela`.
+Fixed an indexing bug in fNIRS support in :meth:`mne.io.BaseRaw.interpolate_bads` (and related methods) that could errantly use incorrect donor channels, by :newcontrib:`Kalle Makela`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -172,6 +172,7 @@
 .. _Jukka Nenonen: https://www.linkedin.com/pub/jukka-nenonen/28/b5a/684
 .. _Jussi Nurminen: https://github.com/jjnurminen
 .. _Kaisu Lankinen: http://bishoplab.berkeley.edu/Kaisu.html
+.. _Kalle Makela: https://github.com/Kallemakela
 .. _Katarina Slama: https://github.com/katarinaslama
 .. _Katia Al-Amir: https://github.com/katia-sentry
 .. _Kay Robbins: https://github.com/VisLab

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -278,15 +278,22 @@ def _interpolate_bads_nirs(inst, exclude=(), verbose=None):
     dist = pdist(locs3d)
     dist = squareform(dist)
 
-    for bad in picks_bad:
-        dists_to_bad = dist[bad]
+    # Maps channel indices in raw object to channel indices in dist matrix
+    raw_idx_to_dist_idx = {
+        raw_idx: dist_idx for dist_idx, raw_idx in enumerate(picks_nirs)
+    }
+
+    for bad_raw_idx in picks_bad:
+        bad_dist_idx = raw_idx_to_dist_idx[bad_raw_idx]
+        dists_to_bad = dist[bad_dist_idx].copy()
         # Ignore distances to self
         dists_to_bad[dists_to_bad == 0] = np.inf
         # Ignore distances to other bad channels
         dists_to_bad[bads_mask] = np.inf
         # Find closest remaining channels for same frequency
-        closest_idx = np.argmin(dists_to_bad) + (bad % 2)
-        inst._data[bad] = inst._data[closest_idx]
+        closest_dist_idx = np.argmin(dists_to_bad) + (bad_dist_idx % 2)
+        closest_raw_idx = picks_nirs[closest_dist_idx]
+        inst._data[bad_raw_idx] = inst._data[closest_raw_idx]
 
     # TODO: this seems like a bug because it does not respect reset_bads
     inst.info["bads"] = [ch for ch in inst.info["bads"] if ch in exclude]

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -278,13 +278,8 @@ def _interpolate_bads_nirs(inst, exclude=(), verbose=None):
     dist = pdist(locs3d)
     dist = squareform(dist)
 
-    # Maps channel indices in raw object to channel indices in dist matrix
-    raw_idx_to_dist_idx = {
-        raw_idx: dist_idx for dist_idx, raw_idx in enumerate(picks_nirs)
-    }
-
     for bad_raw_idx in picks_bad:
-        bad_dist_idx = raw_idx_to_dist_idx[bad_raw_idx]
+        bad_dist_idx = np.where(picks_nirs == bad_raw_idx)[0][0]
         dists_to_bad = dist[bad_dist_idx].copy()
         # Ignore distances to self
         dists_to_bad[dists_to_bad == 0] = np.inf

--- a/mne/channels/interpolation.py
+++ b/mne/channels/interpolation.py
@@ -279,6 +279,8 @@ def _interpolate_bads_nirs(inst, exclude=(), verbose=None):
     dist = squareform(dist)
 
     for bad_raw_idx in picks_bad:
+        # `bad_raw_idx` is the index of the bad channel in `inst`
+        # `bad_dist_idx` is the index of the bad channel in `dist`
         bad_dist_idx = np.where(picks_nirs == bad_raw_idx)[0][0]
         dists_to_bad = dist[bad_dist_idx].copy()
         # Ignore distances to self

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -10,7 +10,7 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
 import mne.channels.channels
-from mne import Epochs, pick_channels, pick_types, read_events
+from mne import Epochs, create_info, pick_channels, pick_types, read_events
 from mne._fiff.constants import FIFF
 from mne._fiff.proj import _has_eeg_average_ref_proj
 from mne.channels import make_dig_montage, make_standard_montage
@@ -331,6 +331,42 @@ def test_interpolation_nirs():
     assert raw_haemo.info["bads"] == ["S1_D2 hbo", "S1_D2 hbr"]
     raw_haemo.interpolate_bads()
     assert raw_haemo.info["bads"] == []
+
+
+def test_interpolation_nirs_reordered_picks():
+    """Test NIRS interpolation uses the closest donor in raw channel space."""
+    ch_names = [
+        "S1_D1 760",
+        "S1_D1 850",
+        "S2_D2 760",
+        "S2_D2 850",
+        "S3_D3 760",
+        "S3_D3 850",
+        "S10_D10 760",
+        "S10_D10 850",
+    ]
+    info = create_info(ch_names, sfreq=1.0, ch_types=["fnirs_cw_amplitude"] * 8)
+    pair_positions = {
+        "S1_D1": (0.009, 0.0, 0.0),
+        "S2_D2": (0.010, 0.0, 0.0),
+        "S3_D3": (0.030, 0.0, 0.0),
+        "S10_D10": (0.040, 0.0, 0.0),
+    }
+    for idx, ch in enumerate(info["chs"]):
+        pair = ch["ch_name"].rsplit(" ", 1)[0]
+        ch["loc"][:3] = pair_positions[pair]
+        ch["loc"][9] = 760.0 if idx % 2 == 0 else 850.0
+    data = np.tile(np.arange(len(ch_names))[:, np.newaxis], (1, 5)).astype(float)
+    raw = RawArray(data, info, verbose=False)
+    raw.info["bads"] = ["S2_D2 760", "S2_D2 850"]
+
+    raw.interpolate_bads(
+        method=dict(fnirs="nearest"), origin=(0.0, 0.0, 0.0), verbose=False
+    )
+
+    picks_bad = pick_channels(raw.ch_names, ["S2_D2 760", "S2_D2 850"], exclude=[])
+    # Bad S2_D2 should copy from the nearest good pair, S1_D1.
+    assert_allclose(raw.get_data(picks=picks_bad)[:, 0], [0.0, 1.0])
 
 
 @testing.requires_testing_data

--- a/mne/channels/tests/test_interpolation.py
+++ b/mne/channels/tests/test_interpolation.py
@@ -356,7 +356,8 @@ def test_interpolation_nirs_reordered_picks():
         pair = ch["ch_name"].rsplit(" ", 1)[0]
         ch["loc"][:3] = pair_positions[pair]
         ch["loc"][9] = 760.0 if idx % 2 == 0 else 850.0
-    data = np.tile(np.arange(len(ch_names))[:, np.newaxis], (1, 5)).astype(float)
+    data = np.arange(len(ch_names), dtype=float).reshape(-1, 1)
+    data = np.repeat(data, 5, axis=1)
     raw = RawArray(data, info, verbose=False)
     raw.info["bads"] = ["S2_D2 760", "S2_D2 850"]
 
@@ -364,9 +365,10 @@ def test_interpolation_nirs_reordered_picks():
         method=dict(fnirs="nearest"), origin=(0.0, 0.0, 0.0), verbose=False
     )
 
-    picks_bad = pick_channels(raw.ch_names, ["S2_D2 760", "S2_D2 850"], exclude=[])
     # Bad S2_D2 should copy from the nearest good pair, S1_D1.
-    assert_allclose(raw.get_data(picks=picks_bad)[:, 0], [0.0, 1.0])
+    picks_bad = pick_channels(raw.ch_names, ["S2_D2 760", "S2_D2 850"], exclude=[])
+    picks_want = pick_channels(raw.ch_names, ["S1_D1 760", "S1_D1 850"], exclude=[])
+    assert_allclose(raw.get_data(picks=picks_bad), raw.get_data(picks=picks_want))
 
 
 @testing.requires_testing_data


### PR DESCRIPTION
#### Reference issue (if any)

Fixes #13857.

#### What does this implement/fix?

Fixes an indexing bug in `_interpolate_bads_nirs`

Before this change, `_interpolate_bads_nirs` mixed up channel indices in the underlying raw object and a local distance matrix when fNIRS channels were reordered by `_validate_nirs_info()`. This resulted in interpolation based on wrong channels.

This fix maps raw object indices to local distance matrix indices when reading and writing data.