### PR TITLE
DOC: Enable Sphinx-Gallery example recommender

### DIFF
--- a/doc/changes/dev/13867.other.rst
+++ b/doc/changes/dev/13867.other.rst
@@ -1,0 +1,1 @@
+Enable the Sphinx-Gallery example recommender so each gallery page links to the most similar examples, by :newcontrib:`Kidus Abebe`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -177,6 +177,7 @@
 .. _Katia Al-Amir: https://github.com/katia-sentry
 .. _Kay Robbins: https://github.com/VisLab
 .. _Keith Doelling: https://github.com/kdoelling1919
+.. _Kidus Abebe: https://github.com/kidusabe1
 .. _Konstantinos Tsilimparis: https://contsili.github.io/
 .. _Kostiantyn Maksymenko: https://github.com/makkostya
 .. _Kristijan Armeni: https://github.com/kristijanarmeni

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -569,6 +569,7 @@ sphinx_gallery_conf = {
     ),
     "copyfile_regex": r".*index\.rst",  # allow custom index.rst files
     "parallel": sphinx_gallery_parallel,
+    "recommender": {"enable": True},
 }
 assert is_serializable(sphinx_gallery_conf)
 # Files were renamed from plot_* with:


### PR DESCRIPTION
#### Reference issue (if any)

Fixes #13864.

#### What does this implement/fix?

Enables the [Sphinx-Gallery example recommender](https://sphinx-gallery.github.io/stable/configuration.html#enabling-the-example-recommender-system) by adding `"recommender": {"enable": True}` to `sphinx_gallery_conf` in `doc/conf.py`. Each gallery page will gain a "Related examples" block at the bottom, computed via TF-IDF over example source text.

#### Additional information

- I verified against `sphinx-gallery==0.21.0` that `recommender` is a valid `sphinx_gallery_conf` key and that `{"enable": True}` is sufficient — SG falls back to `ExampleRecommender` defaults (`n_examples=5`, `min_df=3`, `max_df=0.9`), which match what sphinx-gallery's own tinybuild uses. Happy to pin values explicitly if preferred.
- No dependency changes required: `scikit-learn` (the recommender's only extra dependency) is already in the `doc` group, and `numpy` is a core dep. I also checked that the new config passes `sphinx.config.is_serializable`, which is asserted at `doc/conf.py:574`.
- I didn't attempt a local full doc build for this change (config-only, and the full build needs the sample data + sphinx env). Could a reviewer please confirm the CircleCI doc artifact shows a "Related examples" section at the bottom of a gallery page? Happy to adjust parameters if output looks off on smaller subsections.
- First-time contributor — added name to `doc/changes/names.inc` and used `:newcontrib:` in the changelog fragment per the contributing guide.