### PR TITLE
DOC: Fix apply_function shape description for Epochs (#13118)

### DIFF
--- a/doc/changes/dev/13891.other.rst
+++ b/doc/changes/dev/13891.other.rst
@@ -1,0 +1,1 @@
+Fixed the ``fun`` shape description in :meth:`mne.Epochs.apply_function`'s docstring, by :newcontrib:`Bhargav Kowshik`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -40,6 +40,7 @@
 .. _Beige Jin: https://github.com/BeiGeJin
 .. _Ben Beasley: https://github.com/musicinmybrain
 .. _Benedikt Ehinger: https://www.benediktehinger.de
+.. _Bhargav Kowshik: https://github.com/bkowshik
 .. _Bradley Voytek: https://github.com/voytek
 .. _Britta Westner: https://britta-wstnr.github.io
 .. _Bruno Aristimunha: https://bruaristimunha.github.io

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1974,7 +1974,7 @@ class BaseEpochs(
 
         Parameters
         ----------
-        %(fun_applyfun)s
+        %(fun_applyfun_epochs)s
         %(picks_all_data_noref)s
         %(dtype_applyfun)s
         %(n_jobs)s Ignored if ``channel_wise=False`` as the workload

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1920,7 +1920,9 @@ docdict["fun_applyfun"] = applyfun_fun_base.format(
     " if ``channel_wise=True`` and ``(len(picks), n_times)`` otherwise"
 )
 docdict["fun_applyfun_epochs"] = applyfun_fun_base.format(
-    " if ``channel_wise=True`` and ``(n_epochs, n_channels, n_times)`` otherwise"
+    " if ``channel_wise=True`` (because it will apply to 1-D"
+    " slices along the times axis) and"
+    " ``(n_epochs, len(picks), n_times)`` otherwise"
 )
 docdict["fun_applyfun_evoked"] = applyfun_fun_base.format(
     " because it will apply channel-wise"

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1919,6 +1919,9 @@ fun : callable
 docdict["fun_applyfun"] = applyfun_fun_base.format(
     " if ``channel_wise=True`` and ``(len(picks), n_times)`` otherwise"
 )
+docdict["fun_applyfun_epochs"] = applyfun_fun_base.format(
+    " if ``channel_wise=True`` and ``(n_epochs, n_channels, n_times)`` otherwise"
+)
 docdict["fun_applyfun_evoked"] = applyfun_fun_base.format(
     " because it will apply channel-wise"
 )


### PR DESCRIPTION
#### Reference issue (if any)

- Fixes #13118
- Ref: #13136

#### What does this implement/fix?

The `fun` parameter docstring for `mne.Epochs.apply_function` incorrectly stated that the array passed to the user's function when `channel_wise=False` has shape `(len(picks), n_times)`. The actual shape is `(n_epochs, n_channels, n_times)`. Adds a new `fun_applyfun_epochs` docdict entry alongside `fun_applyfun_evoked` and `fun_applyfun_stc`, leaving the Raw docstring (where `(len(picks), n_times)` is correct) untouched.

> Related (out of scope): https://mne.discourse.group/t/epochs-apply-function-channel-wise-false-picks-silently-ignores-picks/11828 — separate question about whether `picks` should be honored when `channel_wise=False` on Epochs.

Documentation post the fix looks like below:

```bash
cd doc
make html-noplot
make show
```

<img width="2048" height="1155" alt="image" src="https://github.com/user-attachments/assets/45ce47ec-0d9e-4423-a47a-3bb307d35359" />


#### Additional information

Have used Claude Code to understand the issue, identify the location of fix, commands to build locally for testing.