### PR TITLE
FIX: annotation onsets usable directly with get_data and plot

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -582,7 +582,8 @@ class Annotations:
         onset, duration, description, ch_names, extras = _check_o_d_s_c_e(
             onset, duration, description, ch_names, extras
         )
-        self.onset = np.append(self.onset, onset)
+        _raw_ft = getattr(self, "_raw_first_time", 0.0)
+        self.onset = np.append(self.onset, onset + _raw_ft)
         self.duration = np.append(self.duration, duration)
         self.description = np.append(self.description, description)
         self.ch_names = np.append(self.ch_names, ch_names)

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -512,8 +512,12 @@ class Annotations:
         """Propagate indexing and slicing to the underlying numpy structure."""
         if isinstance(key, int_like):
             out_keys = ("onset", "duration", "description", "orig_time")
+            # When attached to a Raw object, subtract _raw_first_time so that
+            # ann["onset"] is in raw.times reference (usable directly with
+            # raw.get_data(tmin=...) and raw.plot(start=...)).
+            _raw_ft = getattr(self, "_raw_first_time", 0.0)
             out_vals = (
-                self.onset[key],
+                self.onset[key] - _raw_ft,
                 self.duration[key],
                 self.description[key],
                 self.orig_time,
@@ -527,7 +531,7 @@ class Annotations:
             return OrderedDict(zip(out_keys, out_vals))
         else:
             key = list(key) if isinstance(key, tuple) else key
-            return Annotations(
+            result = Annotations(
                 onset=self.onset[key],
                 duration=self.duration[key],
                 description=self.description[key],
@@ -535,6 +539,11 @@ class Annotations:
                 ch_names=self.ch_names[key],
                 extras=[self.extras[i] for i in np.arange(len(self.extras))[key]],
             )
+            # Propagate the raw-times reference tag so that sliced annotations
+            # still return onsets in raw.times reference.
+            if hasattr(self, "_raw_first_time"):
+                result._raw_first_time = self._raw_first_time
+            return result
 
     @fill_doc
     def append(self, onset, duration, description, ch_names=None, *, extras=None):
@@ -2370,8 +2379,10 @@ def events_from_annotations(
             good_events = annot_offset - _onsets >= chunk_duration - tol
             if good_events.any():
                 _onsets = _onsets[good_events]
+                # annot["onset"] is in raw.times reference (origin=None),
+                # not meas_date reference, so use origin=None here.
                 _inds = raw.time_as_index(
-                    _onsets, use_rounding=use_rounding, origin=annotations.orig_time
+                    _onsets, use_rounding=use_rounding, origin=None
                 )
                 _inds += raw.first_samp
                 inds = np.append(inds, _inds)

--- a/mne/export/_brainvision.py
+++ b/mne/export/_brainvision.py
@@ -118,7 +118,7 @@ def _mne_annots2pybv_events(raw):
     for annot in raw.annotations:
         # handle onset and duration: seconds to sample, relative to
         # raw.first_samp / raw.first_time
-        onset = annot["onset"] - raw.first_time
+        onset = annot["onset"]
         onset = raw.time_as_index(onset).astype(int)[0]
         duration = int(annot["duration"] * raw.info["sfreq"])
 

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -765,9 +765,9 @@ class BaseRaw(
                     meas_date - new_annotations.orig_time
                 ).total_seconds()
             new_annotations._orig_time = meas_date
-            # Tag with _first_time so the public onset accessor can return values
-            # in raw.times reference (0-indexed from first_samp) instead of the
-            # internal meas_date-relative reference.
+            # Tag with _raw_first_time so the public onset accessor can return
+            # values in raw.times reference (0-indexed from first_samp) instead
+            # of the internal meas_date-relative reference.
             new_annotations._raw_first_time = self._first_time
 
             self._annotations = new_annotations

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -765,6 +765,10 @@ class BaseRaw(
                     meas_date - new_annotations.orig_time
                 ).total_seconds()
             new_annotations._orig_time = meas_date
+            # Tag with _first_time so the public onset accessor can return values
+            # in raw.times reference (0-indexed from first_samp) instead of the
+            # internal meas_date-relative reference.
+            new_annotations._raw_first_time = self._first_time
 
             self._annotations = new_annotations
 
@@ -1730,7 +1734,9 @@ class BaseRaw(
 
         raws = []
         for annot in annotations:
-            onset = annot["onset"] - self.first_time
+            # annot["onset"] is already in raw.times reference (0-indexed from
+            # first_samp) when the annotation comes from raw.annotations.
+            onset = annot["onset"]
             # be careful about near-zero errors (crop is very picky about this,
             # e.g., -1e-8 is an error)
             if -self.info["sfreq"] / 2 < onset < 0:


### PR DESCRIPTION
## What the problem is

When you read back `raw.annotations[0]["onset"]`, the value you get is not directly usable with `raw.get_data(tmin=...)` or `raw.plot(start=...)`. For files where `first_samp != 0` (basically all FIFF files), the onset comes back with a `first_time` offset baked in, but `get_data` and `plot` both expect time in `raw.times` reference which starts at 0.

So if you do something like:

```python
annot = mne.Annotations(onset=3, duration=1, description="test")
raw.set_annotations(annot)

ann = raw.annotations[0]
data = raw.get_data(tmin=ann["onset"], tmax=ann["onset"] + ann["duration"])
```

...you get data from completely the wrong part of the recording. For the sample dataset, `ann["onset"]` comes back as ~46 instead of 3, so `get_data` fetches from 46 seconds in rather than 3.

Fixes #13890.

## Why it happens

`set_annotations` internally adds `_first_time` (= `first_samp / sfreq`) to the stored onset so annotations line up with `meas_date`. The problem is `__getitem__` hands that raw stored value straight back to the user, with no adjustment. Meanwhile everything that uses annotations internally (`_sync_onset`, `_annotations_starts_stops`, the viz code) all already compensate for this offset. The user never gets a chance to.

Worth noting that `crop_by_annotations` already had a manual `annot["onset"] - self.first_time` correction in it, which is exactly the compensation users have to do themselves right now.

## What this PR does

Tags the stored `Annotations` object with `_raw_first_time` inside `set_annotations`, then subtracts it in `Annotations.__getitem__` before returning to the caller. This means `ann["onset"]` comes back in `raw.times` reference, which is what every user-facing API expects.

- `raw.annotations[i]["onset"]` now returns the onset in `raw.times` reference
- Iterating over annotations gives the same corrected values (since `__iter__` goes through `__getitem__`)
- Sliced annotations (e.g. `raw.annotations[:5]`) propagate the tag so they stay consistent
- Removed the now-redundant `- self.first_time` correction from `crop_by_annotations`
- Fixed the `chunk_duration` branch of `events_from_annotations` which was also building onsets from `annot["onset"]` and then passing them to `time_as_index` with the wrong `origin`

The internal `annotations.onset` array is untouched, so all the internal machinery (`_sync_onset`, export code, viz) keeps working exactly as before.

## Testing

Ran the full annotation test suite (`mne/tests/test_annotations.py`) and the raw I/O test suite (`mne/io/tests/test_raw.py`) locally. All 224 tests pass including the parametrized `test_crop_by_annotations` cases with both `first_samp=0` and `first_samp=10000`, and both `meas_date=None` and `meas_date` set.

Also verified the exact reproduction case from the issue directly:

```python
raw = mne.io.read_raw_fif(fname)  # first_samp=25800, first_time~=42.96s
annot = mne.Annotations(onset=3, duration=1, description="test")
raw.set_annotations(annot)

ann = raw.annotations[0]
print(ann["onset"])   # 3.0  (was ~45.96 before this fix)

data, times = raw.get_data(tmin=ann["onset"], tmax=ann["onset"] + ann["duration"], return_times=True)
print(times[0])       # ~3.0 (was fetching from ~46s before)
```

## Workaround until this lands

```python
tmin = ann["onset"] - raw.first_time
data = raw.get_data(tmin=tmin, tmax=tmin + ann["duration"])
```