### PR TITLE
Update describing changes in contributing guide

### DIFF
--- a/doc/development/contributing.rst
+++ b/doc/development/contributing.rst
@@ -587,12 +587,14 @@ deprecation period when the stated release is being prepared:
   parameter, and (if found) update them to use the new function / parameter.
 
 
+.. _`changelog-guide`:
+
 Describe your changes in the changelog
 --------------------------------------
 
-Include in your changeset a brief description of the change in the
-:ref:`changelog <whats_new>` using towncrier_ format, which aggregates small,
-properly-named ``.rst`` files to create a changelog. This can be
+Include in your changeset a brief description of the changes, which will appear in the
+:ref:`changelog <whats_new>`, using towncrier_ format. This aggregates small,
+properly named ``.rst`` files to create a changelog. This can be
 skipped for very minor changes like correcting typos in the documentation.
 
 There are six separate sections for changes, based on change type.
@@ -1024,8 +1026,9 @@ down the road. Here are the guidelines:
   you are specifically asked by a maintainer to PR into another branch (e.g.,
   for backports or maintenance bugfixes to the current stable version).
 
-- Don't forget to include in your PR a brief description of the change in the
-  :ref:`changelog <whats_new>` (:file:`doc/whats_new.rst`).
+- Don't forget to include in your PR a brief description of the change in a
+  changelog entry (see :ref:`the changelog section <changelog-guide>` above
+  for instructions).
 
 - Our community uses the following commit tags and conventions:
 


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-python/blob/main/CONTRIBUTING.md)
and the [detailed contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

If you used AI to help prepare this pull request, please pay special attention to
our **Policy on AI Assistance in Contributions** in
[CONTRIBUTING.md](https://github.com/mne-tools/mne-python/blob/main/CONTRIBUTING.md).
Here are some examples of what we expect for "tool, manner, and scope" disclosure:

- "I implemented the code changes myself, and Claude Sonnet 4.6 wrote the test."
- "I prompted Gemini 3.1 Pro to get a first draft implementation, then refined it
  manually until I was satisfied."
- "I wrote the code and asked Kimi K2.5 to write the docstring for me."
- "I fed GPT 5.4 the paper where the algorithm is described, and asked it to implement
  it for me. Then I had it write an example script using the `sample` dataset, and I
  wrote the narrative text of the tutorial myself."

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->


#### What does this implement/fix?

The changelog description in the GitHub workflow section is outdated in that it seems to suggest editing `whats_new.rst` directly. Have changed it so it now references the changelog entry instructions.

Have also slightly reworded the first paragraph of the instructions for creating the changelog entry, as I feel there could be some confusion about needing to edit `whats_new.rst`.