### PR TITLE
Fix interpolate_blinks ignoring match parameter (#13880)

### DIFF
--- a/doc/changes/dev/13880.bugfix.rst
+++ b/doc/changes/dev/13880.bugfix.rst
@@ -1,0 +1,1 @@
+Fix :func:`mne.preprocessing.eyetracking.interpolate_blinks` silently ignoring the ``match`` argument: the internal helper hardcoded ``"BAD_blink"`` when fetching annotation start/stop indices, so any extra descriptions in ``match`` (for example ``"BAD_NAN"`` produced by :func:`mne.preprocessing.annotate_nan`) were dropped, by :newcontrib:`Macdara Ó Murchú`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -197,6 +197,7 @@
 .. _Luke Bloy: https://www.research.chop.edu/imaging/team
 .. _Lukáš Hejtmánek: https://github.com/hejtmy
 .. _Lx37: https://github.com/Lx37
+.. _Macdara Ó Murchú: https://github.com/m4cd4r4
 .. _Mads Jensen: https://github.com/MadsJensen
 .. _Maggie Clarke: https://github.com/mdclarke
 .. _Mainak Jas: https://jasmainak.github.io

--- a/mne/preprocessing/eyetracking/_pupillometry.py
+++ b/mne/preprocessing/eyetracking/_pupillometry.py
@@ -63,7 +63,9 @@ def interpolate_blinks(raw, buffer=0.05, match="BAD_blink", interpolate_gaze=Fal
     if not blink_annots:
         warn(f"No annotations matching {match} found. Aborting.")
         return raw
-    _interpolate_blinks(raw, buffer, blink_annots, interpolate_gaze=interpolate_gaze)
+    _interpolate_blinks(
+        raw, buffer, blink_annots, match, interpolate_gaze=interpolate_gaze
+    )
 
     # remove bad from the annotation description
     for desc in match:
@@ -73,7 +75,7 @@ def interpolate_blinks(raw, buffer=0.05, match="BAD_blink", interpolate_gaze=Fal
     return raw
 
 
-def _interpolate_blinks(raw, buffer, blink_annots, interpolate_gaze):
+def _interpolate_blinks(raw, buffer, blink_annots, match, interpolate_gaze):
     """Interpolate eyetracking signals during blinks in-place."""
     logger.info("Interpolating missing data during blinks...")
     pre_buffer, post_buffer = buffer
@@ -88,7 +90,7 @@ def _interpolate_blinks(raw, buffer, blink_annots, interpolate_gaze):
                 continue
         # Create an empty boolean mask
         mask = np.zeros_like(raw.times, dtype=bool)
-        starts, ends = _annotations_starts_stops(raw, "BAD_blink")
+        starts, ends = _annotations_starts_stops(raw, match)
         starts = np.divide(starts, raw.info["sfreq"])
         ends = np.divide(ends, raw.info["sfreq"])
         for annot, start, end in zip(blink_annots, starts, ends):

--- a/mne/preprocessing/eyetracking/tests/test_pupillometry.py
+++ b/mne/preprocessing/eyetracking/tests/test_pupillometry.py
@@ -5,6 +5,7 @@
 import numpy as np
 import pytest
 
+import mne
 from mne import create_info
 from mne.annotations import _annotations_starts_stops
 from mne.datasets.testing import data_path, requires_testing_data
@@ -71,3 +72,39 @@ def test_interpolate_blinks(buffer, match, cause_error, interpolate_gaze, crop):
     if interpolate_gaze:
         assert not np.isnan(data[0, blink_ind]).any()  # left eye
         assert not np.isnan(data[1, blink_ind]).any()  # right eye
+
+
+def test_interpolate_blinks_match_list(eyetrack_raw):
+    """Test that ``match`` argument is honoured for non-default descriptions.
+
+    Regression test for the bug where `_interpolate_blinks` hardcoded the
+    ``BAD_blink`` description when fetching annotation starts/stops, causing
+    any extra descriptions in ``match`` (such as ``BAD_NAN`` produced by
+    `~mne.preprocessing.annotate_nan`) to be silently dropped.
+    """
+    raw = eyetrack_raw
+    pupil_idx = raw.ch_names.index("pupil")
+    # Place blink-style zero gaps and NaN-style gaps in disjoint windows so we
+    # can tell which were interpolated.
+    raw._data[pupil_idx, 10:20] = 0.0
+    raw._data[pupil_idx, 40:50] = np.nan
+    sfreq = raw.info["sfreq"]
+    raw.set_annotations(
+        mne.Annotations(
+            onset=[10 / sfreq, 40 / sfreq],
+            duration=[10 / sfreq, 10 / sfreq],
+            description=["BAD_blink", "BAD_NAN"],
+            ch_names=[("pupil",), ("pupil",)],
+        )
+    )
+
+    interpolate_blinks(raw, buffer=0.0, match=["BAD_blink", "BAD_NAN"])
+
+    pupil = raw._data[pupil_idx]
+    # The NaN window must no longer contain NaNs - this is the bug under test.
+    # Before the fix, only BAD_blink windows were interpolated and the BAD_NAN
+    # window was silently left untouched.
+    assert not np.isnan(pupil[40:50]).any(), (
+        "BAD_NAN window was not interpolated; match argument was ignored"
+    )
+    assert not np.isnan(pupil[10:20]).any()


### PR DESCRIPTION
#### Reference issue

Fixes #13880.

#### What does this implement/fix?

`interpolate_blinks()` accepts a `match` parameter that controls which annotation descriptions are interpolated, defaulting to `'BAD_blink'`. The public function correctly filtered its local `blink_annots` list by `match`, but the internal `_interpolate_blinks` helper hardcoded `'BAD_blink'` when fetching annotation start/stop indices, so:

- any extra descriptions in `match` (for example `'BAD_NAN'` from `mne.preprocessing.annotate_nan`) were silently dropped
- the `zip()` of `blink_annots` against the (potentially shorter) `starts`/`ends` arrays could mis-pair entries when cardinalities differed
- the original Discourse report dates back to Sept 2025 ([thread](https://mne.discourse.group/t/dealing-with-nans-and-missing-data-in-pupil-and-eyetracking-data/11470))

The fix passes `match` through to `_annotations_starts_stops` so the helper honours the same descriptions the public function filtered by. Two-line behaviour change.

A regression test (`test_interpolate_blinks_match_list`) uses the existing `eyetrack_raw` fixture and places disjoint `BAD_blink` (zero) and `BAD_NAN` (NaN) windows on the pupil channel. The test fails before this change (the `BAD_NAN` window stays NaN) and passes after.

#### Additional information

I left the existing `_annotations_starts_stops` startswith semantics in place rather than rewriting the helper to iterate `blink_annots` directly. There is a separate latent edge case where prefix-match (in `_annotations_starts_stops`) and exact-match (in the `blink_annots` comprehension) could yield different cardinalities for unusual description strings like `'BAD_blink_left'`; that is out of scope here and worth a follow-up if anyone hits it.

#### AI assistance disclosure

Per MNE's policy: this PR was drafted with Claude Opus 4.7. I (the human contributor) directed the agent to issue #13880, the agent located the offending hardcoded string in `_pupillometry.py:91`, drafted the two-line fix, wrote the regression test against the existing `eyetrack_raw` fixture, and produced this PR body. I reviewed each change, ran the test suite locally (verifying the test fails before the fix and passes after), and approved the diff before pushing. Scope: bug fix + regression test + changelog entry + names.inc entry.
