### PR TITLE
FIX: Avoid iteration errors caused by None when reading Nihon Kohden .LOG files

### DIFF
--- a/doc/changes/dev/13915.bugfix.rst
+++ b/doc/changes/dev/13915.bugfix.rst
@@ -1,0 +1,1 @@
+Fix iteration errors caused by `_read_event_log_block` returning `None` when reading Nihon Kohden log files, by `Tom Ma`_.

--- a/doc/changes/dev/13915.bugfix.rst
+++ b/doc/changes/dev/13915.bugfix.rst
@@ -1,1 +1,1 @@
-Fix iteration errors caused by `_read_event_log_block` returning `None` when reading Nihon Kohden log files, by `Tom Ma`_.
+Fix iteration errors in :func:`mne.io.read_raw_nihon` when reading log files, by `Tom Ma`_.

--- a/mne/io/nihon/nihon.py
+++ b/mne/io/nihon/nihon.py
@@ -289,21 +289,23 @@ def _read_nihon_header(fname):
 
 
 def _read_event_log_block(fid, t_block, version):
+    empty_logs = np.empty(0, dtype="|S45")
+
     fid.seek(0x92 + t_block * 20)
     data = np.fromfile(fid, np.uint32, 1)
     if data.size == 0 or data[0] == 0:
-        return
+        return empty_logs
     t_blk_address = data[0]
 
     fid.seek(t_blk_address + 0x1)
     data = np.fromfile(fid, "|S16", 1).astype("U16")
     if data.size == 0 or data[0] != version:
-        return
+        warn(f"Event log version mismatch: expected '{version}', got '{data}'")
 
     fid.seek(t_blk_address + 0x12)
     data = np.fromfile(fid, np.uint8, 1)
     if data.size == 0:
-        return
+        return empty_logs
     n_logs = data[0]
 
     fid.seek(t_blk_address + 0x14)


### PR DESCRIPTION
#### Reference issue (if any)

Reported by @eulerleibniz .

---

Hello there @larsoner . Not sure if i need to create a new issue for this, but the new code has a bug here:
in line 341 here:
```python
            for li, t_log in enumerate(t_logs): # Chek if t_logs Is None
                t_desc, t_onset = _parse_event_log(t_log)
                if t_sub_logs is not None and t_sub_logs.size == t_logs.size:
                    t_sub_desc, t_sub_onset = _parse_sub_event_log(t_sub_logs[li])
                    t_desc += t_sub_desc
                    t_onset += t_sub_onset
```
 You did not check if t_logs is None, so we get errors on enumerate.

_Originally posted by @eulerleibniz in https://github.com/mne-tools/mne-python/issues/13251#issuecomment-4525303003_

---

@myd7349 I just did what you asked. using mne.__version__ = 1.12.1

The error doesn't happen with my files which have `EEG-1100A V01.00` in their header.
It only happens with EEG files which have header `EEG-1200A V01.00`.
I also checked the mne version=1.10.0 of the mne which also had issues with this old format and they clearly wrote this in nihon file in line 50:
```python
_valid_headers = [
    "EEG-1100A V01.00",
    "EEG-1100B V01.00",
    "EEG-1100C V01.00",
    "QI-403A   V01.00",
    "QI-403A   V02.00",
    "EEG-2100  V01.00",
    "EEG-2100  V02.00",
    "DAE-2100D V01.30",
    "DAE-2100D V02.00",
    # 'EEG-1200A V01.00',  # Not working for the moment.
]
```
where it was clearly mentioned that they don't support that specific version yet.
here is the output of the prints you asked on these files:
```
🪲 Failed to read version: [''], expected: EEG-1200A V01.00.
🪲 Failed to read version: [''], expected: EEG-1200A V01.00.
Traceback (most recent call last):
  File "c:\GitHub\Vigilant\vigilant\emu\sop_v0_1_0\nihon.py", line 460, in <module>
    raw_mne = mne.io.read_raw_nihon(path, preload=False)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Titania\anaconda3\envs\devenv\Lib\site-packages\mne\io\nihon\nihon.py", line 52, in read_raw_nihon
    return RawNihon(fname, preload, encoding=encoding, verbose=verbose)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<decorator-gen-207>", line 12, in __init__
  File "C:\Users\Titania\anaconda3\envs\devenv\Lib\site-packages\mne\io\nihon\nihon.py", line 506, in __init__
    annots = _read_nihon_annotations(fname, encoding)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Titania\anaconda3\envs\devenv\Lib\site-packages\mne\io\nihon\nihon.py", line 375, in _read_nihon_annotations
    for li, t_log in enumerate(t_logs):
                     ^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

_Originally posted by @eulerleibniz in https://github.com/mne-tools/mne-python/issues/13251#issuecomment-4528068700_

#### What does this implement/fix?

This is a follow-up to #13251. In #13251, some additional checks were added to `_read_event_log_block` (including a version check), which could cause `_read_event_log_block` to return `None`, leading to iteration errors.

This change avoids that issue by returning an empty array instead of `None` when reading fails. In addition, when the version does not match, a warning is now issued instead of returning `None`.

#### Additional information

<!-- Any additional information you think is important. -->
