### PR TITLE
FIX: Make set_eeg_reference working with a string for a channel name

### DIFF
--- a/doc/changes/dev/13917.bugfix.rst
+++ b/doc/changes/dev/13917.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug with :func:`mne.set_eeg_reference` not working when passing a single channel name as string, by `Michael Straube`_.

--- a/mne/_fiff/reference.py
+++ b/mne/_fiff/reference.py
@@ -414,6 +414,10 @@ def set_eeg_reference(
         logger.info("Applying a custom dict-based reference.")
         return _apply_dict_reference(inst, ref_channels)
 
+    # We need 'ref_channels' to be a list, even for a single channel name.
+    if isinstance(ref_channels, str) and ref_channels not in ("average", "REST"):
+        ref_channels = [ref_channels]
+
     ch_type = _get_ch_type(inst, ch_type)
 
     if projection:  # average reference projector

--- a/mne/_fiff/tests/test_reference.py
+++ b/mne/_fiff/tests/test_reference.py
@@ -257,6 +257,10 @@ def test_set_eeg_reference():
     with pytest.raises(ValueError, match='supported for ref_channels="averag'):
         set_eeg_reference(raw, ["EEG 001"], True, True)
 
+    # Test passing a single channel name as string
+    reref, ref_data = set_eeg_reference(raw, "EEG 001", copy=True)
+    _test_reference(raw, reref, ref_data, ["EEG 001"])
+
 
 @pytest.mark.parametrize(
     "ch_type, msg",

--- a/tutorials/intro/15_inplace.py
+++ b/tutorials/intro/15_inplace.py
@@ -83,7 +83,7 @@ print(f"after picking, it has {original_raw.info['nchan']} channels.")
 # we specified ``copy=True``:
 
 # sphinx_gallery_thumbnail_number=2
-rereferenced_raw, ref_data = mne.set_eeg_reference(original_raw, ["EEG 003"], copy=True)
+rereferenced_raw, ref_data = mne.set_eeg_reference(original_raw, "EEG 003", copy=True)
 fig_orig = original_raw.plot()
 fig_reref = rereferenced_raw.plot()
 

--- a/tutorials/preprocessing/55_setting_eeg_reference.py
+++ b/tutorials/preprocessing/55_setting_eeg_reference.py
@@ -85,7 +85,7 @@ raw.pick([f"EEG 0{n:02}" for n in range(41, 60)])
 # raw.set_eeg_reference(ref_channels=['M1', 'M2'])
 
 # use a bipolar reference (contralateral)
-# raw.set_bipolar_reference(anode=['F3'], cathode=['F4'])
+# raw.set_bipolar_reference(anode='F3', cathode='F4')
 
 # %%
 # If a scalp electrode was used as reference but was not saved alongside the
@@ -109,7 +109,7 @@ raw.plot()
 # ``copy=False``.
 
 # add new reference channel (all zero)
-raw_new_ref = mne.add_reference_channels(raw, ref_channels=["EEG 999"])
+raw_new_ref = mne.add_reference_channels(raw, ref_channels="EEG 999")
 raw_new_ref.plot()
 
 # %%
@@ -218,7 +218,7 @@ for title, _raw in zip(["Original", "REST (∞)"], [raw, raw_rest]):
 # :footcite:`YaoEtAl2019` which creates a new virtual channel
 # named ``EEG 054-EEG 055``.
 
-raw_bip_ref = mne.set_bipolar_reference(raw, anode=["EEG 054"], cathode=["EEG 055"])
+raw_bip_ref = mne.set_bipolar_reference(raw, anode="EEG 054", cathode="EEG 055")
 raw_bip_ref.plot()
 
 # %%

--- a/tutorials/preprocessing/55_setting_eeg_reference.py
+++ b/tutorials/preprocessing/55_setting_eeg_reference.py
@@ -79,7 +79,7 @@ raw.pick([f"EEG 0{n:02}" for n in range(41, 60)])
 # earlobe or mastoid channels, so this is just for demonstration purposes:
 
 # use a single channel reference (left earlobe)
-# raw.set_eeg_reference(ref_channels=['A1'])
+# raw.set_eeg_reference(ref_channels='A1')
 
 # use average of mastoid channels as reference
 # raw.set_eeg_reference(ref_channels=['M1', 'M2'])
@@ -116,7 +116,7 @@ raw_new_ref.plot()
 # .. KEEP THESE BLOCKS SEPARATE SO FIGURES ARE BIG ENOUGH TO READ
 
 # set reference to `EEG 050`
-raw_new_ref.set_eeg_reference(ref_channels=["EEG 050"])
+raw_new_ref.set_eeg_reference(ref_channels="EEG 050")
 raw_new_ref.plot()
 
 # %%

--- a/tutorials/preprocessing/55_setting_eeg_reference.py
+++ b/tutorials/preprocessing/55_setting_eeg_reference.py
@@ -85,7 +85,7 @@ raw.pick([f"EEG 0{n:02}" for n in range(41, 60)])
 # raw.set_eeg_reference(ref_channels=['M1', 'M2'])
 
 # use a bipolar reference (contralateral)
-# raw.set_bipolar_reference(anode='[F3'], cathode=['F4'])
+# raw.set_bipolar_reference(anode=['F3'], cathode=['F4'])
 
 # %%
 # If a scalp electrode was used as reference but was not saved alongside the


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-python/blob/main/CONTRIBUTING.md)
and the [detailed contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

If you used AI to help prepare this pull request, please pay special attention to
our **Policy on AI Assistance in Contributions** in
[CONTRIBUTING.md](https://github.com/mne-tools/mne-python/blob/main/CONTRIBUTING.md).
Here are some examples of what we expect for "tool, manner, and scope" disclosure:

- "I implemented the code changes myself, and Claude Sonnet 4.6 wrote the test."
- "I prompted Gemini 3.1 Pro to get a first draft implementation, then refined it
  manually until I was satisfied."
- "I wrote the code and asked Kimi K2.5 to write the docstring for me."
- "I fed GPT 5.4 the paper where the algorithm is described, and asked it to implement
  it for me. Then I had it write an example script using the `sample` dataset, and I
  wrote the narrative text of the tutorial myself."

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)
Fixes #13887.

#### What does this implement/fix?
- Detect single channel names passed as string and convert them to a list, as internally a list is required. 
- Add a test case for this.


#### Additional information
None.