### PR TITLE
Fix drop_log dtype

### DIFF
--- a/doc/changes/dev/13923.other.rst
+++ b/doc/changes/dev/13923.other.rst
@@ -1,0 +1,1 @@
+Convert non-empty ``drop_log`` entries from ``numpy.str_`` to regular Python strings, by `Clemens Brunner`_.

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -562,7 +562,7 @@ class BaseRaw(
             )
             for descr in annot.description[overlaps]:
                 if descr.lower().startswith("bad"):
-                    return descr
+                    return str(descr)
         return self._getitem((picks, slice(start, stop)), return_times=False)
 
     @verbose

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -482,8 +482,9 @@ def _assert_drop_log_types(drop_log):
     assert all(isinstance(log, tuple) for log in drop_log), (
         "drop_log[ii] should be tuple"
     )
-    assert all(isinstance(s, str) for log in drop_log for s in log), (
-        "drop_log[ii][jj] should be str"
+    # enforce exact built-in str (reject np.str_ and other str subclasses)
+    assert all(type(s) is str for log in drop_log for s in log), (
+        "drop_log[ii][jj] should be built-in str"
     )
 
 
@@ -775,6 +776,7 @@ def test_reject_by_annotations_reject_tmin_reject_tmax():
         epochs = mne.Epochs(
             raw, events, tmin=-1, tmax=1, preload=True, reject_by_annotation=True
         )
+    _assert_drop_log_types(epochs.drop_log)
     assert len(epochs) == 0
 
     # Setting `reject_tmin` to prevent rejection of epoch.
@@ -787,6 +789,7 @@ def test_reject_by_annotations_reject_tmin_reject_tmax():
         preload=True,
         reject_by_annotation=True,
     )
+    _assert_drop_log_types(epochs.drop_log)
     assert len(epochs) == 1
 
     # Same check but bad segment overlapping from 2.5s to 3s: use `reject_tmax`
@@ -800,6 +803,7 @@ def test_reject_by_annotations_reject_tmin_reject_tmax():
         preload=True,
         reject_by_annotation=True,
     )
+    _assert_drop_log_types(epochs.drop_log)
     assert len(epochs) == 1
 
 


### PR DESCRIPTION
The non-empty entries are now `str` instead of `np.str_`, which results in a nicer representation.

Example:

```python
import numpy as np

from mne import Annotations, Epochs, create_info
from mne.io.array import RawArray

sfreq = 100
duration = 10
n_samples = sfreq * duration
n_channels = 3

data = np.random.randn(n_channels, n_samples)
info = create_info(n_channels, sfreq, ch_types="eeg")
raw = RawArray(data, info)

annotations = Annotations(
    onset=[0.2],
    duration=[0.5],
    description=["bad_movement"],
)
raw.set_annotations(annotations)

epochs = Epochs(
    raw,
    np.array([[30, 0, 1], [500, 0, 1]], dtype=int),
    tmin=-0.3,
    tmax=0.3,
    preload=True,
)

print(epochs.drop_log)
```

Output on `main`:

```
((np.str_('bad_movement'),), ())
```

Output on this branch:

```
(('bad_movement',), ())
```