### PR TITLE
Remove `test_io_set_preload_false_is_faster`

### DIFF
--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -768,26 +768,6 @@ def test_eeglab_drop_nan_annotations(tmp_path):
         raw = read_raw_eeglab(file_path, preload=True)
 
 
-@pytest.mark.flaky
-@testing.requires_testing_data
-@pytest.mark.timeout(10)
-@pytest.mark.slowtest  # has the advantage of not running on macOS where it errs a lot
-def test_io_set_preload_false_is_faster():
-    """Using preload=False should skip the expensive data read branch."""
-    # warm start
-    read_raw_eeglab(raw_fname_mat, preload=False)
-
-    durations = {}
-    for preload in (True, False):
-        start = time.perf_counter()
-        _ = read_raw_eeglab(raw_fname_mat, preload=preload)
-        durations[preload] = time.perf_counter() - start
-
-    # preload=True should not be faster than preload=False (timings may vary
-    # across systems, so avoid strict thresholds)
-    assert durations[True] > durations[False]
-
-
 @testing.requires_testing_data
 def test_lazy_vs_preload_integrity():
     """Test that lazy loading produces identical data to preload."""

--- a/mne/io/eeglab/tests/test_eeglab.py
+++ b/mne/io/eeglab/tests/test_eeglab.py
@@ -4,7 +4,6 @@
 
 import os
 import shutil
-import time
 from copy import deepcopy
 
 import numpy as np


### PR DESCRIPTION
I suggest removing the test `mne/io/eeglab/tests/test_eeglab.py::test_io_set_preload_false_is_faster` for the following reasons:

1. The correctness of not preloading is already tested in `test_io_set_preload_false_uses_lazy_loading`.
2. A test relying on timing is by definition flaky (and it was also marked as such), which isn't good practice.
3. The `pytest.mark.flaky` decorator without any args means `reruns=1`, which sometimes isn't enough.

This test just hit me in https://github.com/mne-tools/mne-python/actions/runs/26574036684/job/78288529573?pr=13680 and I really think it should be removed.