### PR TITLE
Add pyside6 to dev dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "hatchling.build"
 requires = ["hatch-vcs", "hatchling >= 1.27"]
 
 [dependency-groups]
-dev = ["pip >= 25.1", "rcssmin >= 1.1", {include-group = "doc"}, {include-group = "test_extra"}]
+dev = ["pip >= 25.1", "pyside6 >= 6.11.1", "rcssmin >= 1.1", {include-group = "doc"}, {include-group = "test_extra"}]
 # Dependencies for building the documentation
 doc = [
   "graphviz",
@@ -138,7 +138,7 @@ full = ["mne[full-no-qt]", "PyQt6 != 6.6.0", "PyQt6-Qt6 != 6.6.0, != 6.7.0"]
 # Dependencies for full MNE-Python functionality (other than raw/epochs export)
 # We first define a variant without any Qt bindings. The "complete" variant, mne[full],
 # makes an opinionated choice and installs PyQt6.
-# We also offter two more variants: mne[full-qt6] (which is equivalent to mne[full]),
+# We also offer two more variants: mne[full-qt6] (which is equivalent to mne[full]),
 # and mne[full-pyside6], which will install PySide6 instead of PyQt6.
 full-no-qt = [
   "antio >= 0.5.0",


### PR DESCRIPTION
Following up on the discussion in #12709, the problem I currently have as a developer is that doing `uv sync` will not install any Qt backend. This means that I always have to manually add `pyside6`, which I think is an unnecessary step. (Side note: this is not necessary on macOS, because the default `macosx` backend works out of the box, but Linux and Windows users have to install a suitable backend.)

Therefore, I've added `pyside6` to the (default) `dev` dependency group, which means that this package is now installed automatically with `uv sync`. Note that this does *not* add it as a project dependency, so users will still have to take care of installing a suitable backend themselves.

Let me know what you think!

As an optional follow-up to this PR, I'm also happy to discuss replacing the current opinionated choice of `pyqt6` with `pyside6`, as the latter should now work across all our use cases, and as discussed in #12709, should be the better default choice.