### PR TITLE
FIX: read_annotations(.txt) on a single channel-specific annotation

### DIFF
--- a/doc/changes/dev/13962.bugfix.rst
+++ b/doc/changes/dev/13962.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug in :func:`mne.read_annotations` where reading a ``.txt`` file containing a single channel-specific annotation raised an ``AttributeError``, by :newcontrib:`Piotr Durka`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -272,6 +272,7 @@
 .. _Pierre Guetschel: https://github.com/PierreGtch
 .. _Pierre-Antoine Bannier: https://github.com/PABannier
 .. _Ping-Keng Jao: https://github.com/nafraw
+.. _Piotr Durka: https://github.com/pjdurka
 .. _Pragnya Khandelwal: https://github.com/PragnyaKhandelwal
 .. _Proloy Das: https://github.com/proloyd
 .. _Qian Chu: https://github.com/qian-chu

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -2105,7 +2105,7 @@ def _read_annotations_txt(fname):
     if ch_names is not None:
         ch_names = [
             _safe_name_list(ch.decode().strip(), "read", f"ch_names[{ci}]")
-            for ci, ch in enumerate(ch_names)
+            for ci, ch in enumerate(np.atleast_1d(ch_names))
         ]
 
     annotations = Annotations(

--- a/mne/tests/test_annotations.py
+++ b/mne/tests/test_annotations.py
@@ -1084,6 +1084,18 @@ def test_io_annotation(dummy_annotation_file, tmp_path, fmt, ch_names, with_extr
     _assert_annotations_equal(annot, annot2)
 
 
+def test_read_annotations_txt_single_channel_specific(tmp_path):
+    """Read a .txt with a SINGLE channel-specific annotation (gh-13961)."""
+    # np.loadtxt(..., unpack=True) squeezes a 1-row file to 0-D scalars;
+    # ch_names (unlike onset/duration/description) was not wrapped in
+    # np.atleast_1d, so it was iterated as bytes-ints -> AttributeError.
+    annot = Annotations([1.0], [0.5], ["BAD_x"], ch_names=[["EEG001"]])
+    fname = tmp_path / "annotations.txt"
+    annot.save(fname)
+    annot_read = read_annotations(fname)
+    assert list(annot_read.ch_names) == [("EEG001",)]
+
+
 @pytest.mark.parametrize("fmt", [pytest.param("csv", marks=needs_pandas), "txt"])
 def test_write_annotation_warn_heterogeneous(tmp_path, fmt):
     """Test that CSV, and TXT annotation writers warn on heterogeneous dtypes."""


### PR DESCRIPTION
Claude Code found the bug while working on another project (IDE4EEG, gitlab, using MNE format and some functions) and proposed fix, which  I submitted as an issue. Then I was asked in an email to create a pull request, which I hereby did, also with assistance from Claude Code.

#### Reference issue 

Closes #13961


#### What does this implement/fix?

one-line change in annotations.py 

for ci, ch in enumerate(ch_names) 
->
for ci, ch in enumerate(np.atleast_1d(ch_names))

and test in test_annotations.py

— test passed locally.