### PR TITLE
Preserve Matplotlib backend across sys_info()

### DIFF
--- a/doc/changes/dev/13963.bugfix.rst
+++ b/doc/changes/dev/13963.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug where :func:`mne.sys_info` would silently change the active Matplotlib backend (e.g. when ``ipympl`` is installed) as an import-time side effect, by `Stefan Appelhoff`_.

--- a/mne/utils/config.py
+++ b/mne/utils/config.py
@@ -880,6 +880,15 @@ def sys_info(
         unicode = False
     mne_version_good = True
     import_names = dict(hedtools="hed")
+    # ``import_module`` below imports each optional dependency purely to read its
+    # version. Some packages change global state at import time -- most notably
+    # ``ipympl``, which switches the Matplotlib backend. Snapshot the backend so
+    # that merely calling ``sys_info`` does not mutate the caller's backend.
+    mpl_backend = None
+    with contextlib.suppress(Exception):
+        import matplotlib
+
+        mpl_backend = matplotlib.get_backend()
     for mi, mod_name in enumerate(use_mod_names):
         # upcoming break
         if mod_name == "":  # break
@@ -954,6 +963,15 @@ def sys_info(
                     pre = " | "
                 out(f"\n{pre}{' ' * ljust}{op.dirname(mod.__file__)}")
             out("\n")
+
+    # Restore the Matplotlib backend in case importing a dependency above
+    # (e.g. ipympl) changed it as an import-time side effect.
+    if mpl_backend is not None:
+        with contextlib.suppress(Exception):
+            import matplotlib
+
+            if matplotlib.get_backend() != mpl_backend:
+                matplotlib.use(mpl_backend, force=True)
 
     if not mne_version_good:
         out(


### PR DESCRIPTION
Found and fixed this problem with the help of Claude.

- On my pipeline, I was noticing a severe memory leak
- I was processing one subj at a time, creating an mne report with figs, moving on to next subj
- at each subj iteration, the memory of the previous subj would leak over
- this was due to me inserting a `sys_info` call into the report, which switched the MPL backend, which resulted in figs not being closed as I planned

This PR prevents sys_info from inadvertendly switching the backend.

**MWE below:**

```python
"""MWE: ``mne.sys_info()`` silently changes the active Matplotlib backend.

``sys_info()`` reports installed versions by importing each optional dependency.
Importing ``ipympl`` runs ``matplotlib.use("module://ipympl.backend_nbagg")`` in
its ``__init__``, so merely *calling* ``sys_info()`` switches the process
backend away from whatever the caller had configured.

Why it matters: code that sets a headless backend (``Agg``) and then renders
many figures in a loop (e.g. building one MNE report per subject in a batch job)
will, after the first ``sys_info()`` / ``Report.add_sys_info()`` call, create
every subsequent figure under the interactive nbagg backend. That backend's
figure manager never releases figures in a frontend-less process, so figures
(and the data they reference) accumulate until the process runs out of memory.

Requires ``ipympl`` to be installed (the trigger dependency).

    # current main -> "backend changed: Agg -> module://ipympl.backend_nbagg"
    # with this PR -> "backend preserved: Agg"
"""

import io

import matplotlib

matplotlib.use("Agg")

import mne  # noqa: E402

before = matplotlib.get_backend()
mne.sys_info(fid=io.StringIO())  # discard the version table; we only need the backend
after = matplotlib.get_backend()

if before == after:
    print(f"backend preserved: {after}")
else:
    print(f"backend changed: {before} -> {after}")

```