### PR TITLE
ENH: return label and description fields from read_raw_egi

### DIFF
--- a/doc/changes/dev/13967.newfeature.rst
+++ b/doc/changes/dev/13967.newfeature.rst
@@ -1,0 +1,1 @@
+Include label and description fields when reading EGI mff files, by `Martin Oberg`_.

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -526,7 +526,7 @@ class RawMff(BaseRaw):
         first_samps = [0]
         last_samps = [egi_info["last_samps"][-1] - 1]
 
-        annot = dict(onset=list(), duration=list(), description=list())
+        annot = dict(onset=list(), duration=list(), description=list(), extras=list())
 
         if len(idx["pns"]):
             # PNS Data is present and should be read:
@@ -566,16 +566,22 @@ class RawMff(BaseRaw):
                 annot["onset"].append((prev_last - 0.5) / egi_info["sfreq"])
                 annot["duration"].append(gap / egi_info["sfreq"])
                 annot["description"].append("BAD_ACQ_SKIP")
+                annot["extras"].append({})
 
         # create events from annotations
         if events_as_annotations:
-            for code, samples in mff_events.items():
+            for code, dicts in mff_events.items():
                 if code not in include:
                     continue
+                samples = [d["start_sample"] for d in dicts]
+                extras = [d["extras"] for d in dicts]
                 annot["onset"].extend(np.array(samples) / egi_info["sfreq"])
                 annot["duration"].extend([0.0] * len(samples))
                 annot["description"].extend([code] * len(samples))
+                annot["extras"].extend(extras)
 
+        if annot["extras"] == []:
+            annot["extras"] = None
         if len(annot["onset"]):
             self.set_annotations(Annotations(**annot))
 

--- a/mne/io/egi/events.py
+++ b/mne/io/egi/events.py
@@ -28,7 +28,8 @@ def _read_events(input_fname, info):
     info["event_codes"] = event_codes
     events = np.zeros([info["n_events"], info["n_segments"] * n_samples])
     for n, event in enumerate(event_codes):
-        for i in mff_events[event]:
+        for dct in mff_events[event]:
+            i = dct["start_sample"]
             if (i < 0) or (i >= events.shape[1]):
                 continue
             events[n][i] = n + 1
@@ -74,6 +75,14 @@ def _read_mff_events(filename, sfreq, start_time):
             event_start = event["beginTime"]
             start_sec = (event_start - start_time).total_seconds()
             duration = event["duration"] / 1e9
+            if "label" in event or "description" in event:
+                extras = dict(
+                    label=event["label"],
+                    # description is reserved by mne/annotations.py
+                    desc=event["description"],
+                )
+            else:
+                extras = {}
 
             markers.append(
                 {
@@ -82,11 +91,16 @@ def _read_mff_events(filename, sfreq, start_time):
                     "start_sample": int(np.trunc(start_sec * sfreq)),
                     "end": start_sec + duration,
                     "chan": None,
+                    "extras": extras,
                 }
             )
 
     events_tims = {
-        ev: [marker["start_sample"] for marker in markers if marker["name"] == ev]
+        ev: [
+            dict(start_sample=marker["start_sample"], extras=marker["extras"])
+            for marker in markers
+            if marker["name"] == ev
+        ]
         for ev in code
     }
     return events_tims, code

--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -189,7 +189,11 @@ def test_io_egi_mff(events_as_annotations):
         assert "STI 014" not in raw.ch_names
         assert raw.event_id is None
         event_id = {"DIN1": 1, "DIN2": 2, "DIN3": 3, "DIN4": 4, "DIN5": 5, "DIN7": 7}
+        id_event = {v: k for k, v in event_id.items()}
         events, _ = events_from_annotations(raw, event_id=event_id)
+        labels_annot = [a["extras"]["label"] for a in raw.annotations]
+        labels_events = [id_event[int(x)] for x in events[:, 2]]
+        assert labels_annot == labels_events
     else:
         assert "STI 014" in raw.ch_names
         events = find_events(raw, stim_channel="STI 014")


### PR DESCRIPTION
#### Reference issue
Fixes #10121

A resurrection! 

#### What does this implement/fix?
This PR ensures that read_raw_egi() returns the label and description fields from EGI's Events_ECI TCP-IP 55513.xml file as a dictionary in the Annotations.extra field.

I wrote this code myself, no AI.

#### Additional information
I feel it's good to populate the Annotations.extra field directly here in the events.py file as opposed to reading the file a second time from an external function and ensuring that timestamps match up.

I changed the data type returned in event_tims by _read_mff_events() from a list to a dict. I felt this was better than returning an extra variable.

Since the original #10121, I see #8038 has been opened and this data is being read by mffpy. These changes allow the eventTrack data to make its way into Annotations.