### PR TITLE
MAINT: Convert remaining percent-format strings to f-strings

### DIFF
--- a/doc/changes/dev/13974.other.rst
+++ b/doc/changes/dev/13974.other.rst
@@ -1,0 +1,1 @@
+Converted the remaining percent-style string formatting to f-strings in internal code, by :newcontrib:`Théo Castillo`.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -353,6 +353,7 @@
 .. _Thomas Caswell: https://tacaswell.github.io
 .. _Thomas Hartmann: https://github.com/thht
 .. _Thomas Radman: https://github.com/tradman
+.. _Théo Castillo: https://github.com/theosorus
 .. _Théodore Papadopoulo: https://github.com/papadop
 .. _Timothy Gates: https://au.linkedin.com/in/tim-gates-0528a4199
 .. _Timur Sokhin: https://github.com/Qwinpin

--- a/mne/_ola.py
+++ b/mne/_ola.py
@@ -173,7 +173,7 @@ class _Interp2:
         if self.control_points[self._left_idx] <= self._position:
             n_use = stop - self._position
             if n_use > 0:
-                logger.debug(f"    ~   {self.name} Right ZOH %s" % n_use)
+                logger.debug(f"    ~   {self.name} Right ZOH {n_use}")
                 this_sl = slice(n_pts - n_use, None)
                 assert not used[this_sl].any()
                 used[this_sl] = True

--- a/mne/dipole.py
+++ b/mne/dipole.py
@@ -963,7 +963,7 @@ def _make_guesses(surf, grid, exclude, mindist, n_jobs=None, verbose=None):
             f"Making a spherical guess space with radius {1000 * surf.radius:7.1f} "
             "mm..."
         )
-    logger.info("Filtering (grid = %6.f mm)..." % (1000 * grid))
+    logger.info(f"Filtering (grid = {1000 * grid:6.0f} mm)...")
     src = _make_volume_source_space(
         surf, grid, exclude, 1000 * mindist, do_neighbors=False, n_jobs=n_jobs
     )[0]
@@ -1387,12 +1387,12 @@ def _fit_dipole(
         sensors=sensors, rd=rd_final, Q=Q, ori=ori, whitener=whitener, fwd_data=fwd_data
     )
 
-    msg = "---- Fitted : %7.1f ms" % (1000.0 * t)
+    msg = f"---- Fitted : {1000.0 * t:7.1f} ms"
     if surf is not None:
         dist_to_inner_skull = _compute_nearest(
             surf["rr"], rd_final[np.newaxis, :], return_dists=True
         )[1][0]
-        msg += ", distance to inner skull : %2.4f mm" % (dist_to_inner_skull * 1000.0)
+        msg += f", distance to inner skull : {dist_to_inner_skull * 1000.0:2.4f} mm"
 
     logger.info(msg)
     return rd_final, amp, ori, gof, conf, khi2, nfree, residual_noproj

--- a/mne/inverse_sparse/mxne_optim.py
+++ b/mne/inverse_sparse/mxne_optim.py
@@ -552,7 +552,7 @@ def mixed_norm_solver(
         bias = compute_bias(M, G[:, active_set], X, n_orient=n_orient)
         X *= bias[:, np.newaxis]
 
-    logger.info("Final active set size: %s" % (np.sum(active_set) // n_orient))
+    logger.info(f"Final active set size: {np.sum(active_set) // n_orient}")
 
     if return_gap:
         return X, active_set, E, gap

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -565,9 +565,9 @@ class _BaseSourceEstimate(TimeMixin, FilterMixin):
         s = f"{sum(len(v) for v in self.vertices)} vertices"
         if self.subject is not None:
             s += f", subject : {self.subject}"
-        s += ", tmin : %s (ms)" % (1e3 * self.tmin)
-        s += ", tmax : %s (ms)" % (1e3 * self.times[-1])
-        s += ", tstep : %s (ms)" % (1e3 * self.tstep)
+        s += f", tmin : {1e3 * self.tmin} (ms)"
+        s += f", tmax : {1e3 * self.times[-1]} (ms)"
+        s += f", tstep : {1e3 * self.tstep} (ms)"
         s += f", data shape : {self.shape}"
         sz = sum(object_size(x) for x in (self.vertices + [self.data]))
         s += f", ~{sizeof_fmt(sz)}"

--- a/mne/source_space/_source_space.py
+++ b/mne/source_space/_source_space.py
@@ -2086,7 +2086,7 @@ def _make_volume_source_space(
     logger.info(
         f"Surface CM = ({1000 * cm[0]:6.1f} {1000 * cm[1]:6.1f} {1000 * cm[2]:6.1f}) mm"
     )
-    logger.info("Surface fits inside a sphere with radius %6.1f mm" % (1000 * maxdist))
+    logger.info(f"Surface fits inside a sphere with radius {1000 * maxdist:6.1f} mm")
     logger.info("Surface extent:")
     for c, mi, ma in zip("xyz", mins, maxs):
         logger.info(f"    {c} = {1000 * mi:6.1f} ... {1000 * ma:6.1f} mm")


### PR DESCRIPTION
#### Reference issue (if any)
Closes #12360 

converts the percent-format strings that ruff's UP031 rule does not detect.

#### What does this implement/fix?
Converts the remaining operator-style `"..." % (...)` string formatting to f-strings in
`source_estimate.py`, `dipole.py`, `_ola.py`, `mxne_optim.py` and `_source_space.py`.
Output is unchanged: format specs like `%6.1f` become `{...:6.1f}`. Also cleans up one
mixed f-string + `%` formatting in `_ola.py`. The tabular `%`-format specs in `chpi.py`
(printf-style over numeric arrays) are intentionally kept.

#### Additional information
AI assistance: I used an AI assistant to help locate the remaining percent-format strings
and draft the conversions; I reviewed and verified each change myself.

