### PR TITLE
Fix IndexError when plotting Raw data with single time point

### DIFF
--- a/mne/viz/_figure.py
+++ b/mne/viz/_figure.py
@@ -113,6 +113,12 @@ class BrowserBase(ABC):
         self.mne.epoch_traces = list()
         self.mne.bad_epochs = list()
         if inst is not None:
+            if inst.times.size < 2:
+                raise ValueError(
+                    "Cannot plot Raw data with fewer than 2 time points "
+                    f"(got {inst.times.size}). Please provide data with "
+                    "a longer duration."
+                )
             self.mne.sampling_period = np.diff(inst.times[:2])[0] / inst.info["sfreq"]
         # annotations
         self.mne.annotations = list()


### PR DESCRIPTION
## Problem
Plotting a Raw object with only 1 time point caused a cryptic IndexError 
because `np.diff(inst.times[:2])` returned an empty array, making `[0]` 
fail with "index 0 is out of bounds for axis 0 with size 0".

## Fix
Added a check in `_figure.py` that raises a clear ValueError before 
reaching the problematic line, with a helpful message explaining the issue.

## Steps to reproduce
```python
import numpy as np
from mne import create_info
from mne.io import RawArray

data = np.random.randn(3, 1) * 5e-6
info = create_info(3, 250, "eeg")
raw = RawArray(data, info)
raw.plot()