### PR TITLE
Fix CircleCI on Ubuntu 24.04 and mne-gui-addons error

### DIFF
--- a/mne/viz/backends/_pyvista.py
+++ b/mne/viz/backends/_pyvista.py
@@ -968,8 +968,11 @@ class _PyVistaRenderer(_AbstractRenderer):
         resolution,
         blending,
         center,
-        interpolation,
+        interpolation="linear",
     ):
+        # Note: this method is used by mne-gui-addons, so we should be mindful of
+        # backwards compatibility when changing it.
+
         # Now we can actually construct the visualization
         grid = pyvista.ImageData(
             dimensions=dimensions,

--- a/tools/circleci_bash_env.sh
+++ b/tools/circleci_bash_env.sh
@@ -4,7 +4,13 @@ set -e
 set -o pipefail
 
 ./tools/setup_xvfb.sh
-sudo apt install -qq graphviz optipng python3-venv libxft2 ffmpeg r-base libtirpc-dev libgvplugin-neato-layout8
+# Need different installs for 24.04 and 26.04
+if [[ $(lsb_release -rs) == "26.04" ]]; then
+    EXTRA_DEPS="libgvplugin-neato-layout8"
+else
+    EXTRA_DEPS=""
+fi
+sudo apt install -qq graphviz optipng python3-venv libxft2 ffmpeg r-base libtirpc-dev $EXTRA_DEPS
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 sudo apt install ./google-chrome-stable_current_amd64.deb
 python -m venv ~/python_env


### PR DESCRIPTION
CircleCI runs on Ubuntu 24.04 were failing following #13978 (e.g., https://app.circleci.com/pipelines/github/mne-tools/mne-connectivity/1833/workflows/9471a25c-a089-4d01-a954-3b484d35d491/jobs/2032).

This expands the conditional dependencies, which should retain the functionality for 24.04.

Also fixes an error in `mne-gui-addons` following a change to the PyVista renderer in #13966. Adds a note to be wary of backwards compatibility when making similar changes.