### PR TITLE
Add support for mouse wheel scrolling in raw.plot()

### DIFF
--- a/doc/changes/dev/13988.newfeature.rst
+++ b/doc/changes/dev/13988.newfeature.rst
@@ -1,0 +1,1 @@
+Add mouse wheel scrolling support to the ``'matplotlib'`` browser backend to navigate through channels, by `Clemens Brunner`_.

--- a/mne/viz/_mpl_figure.py
+++ b/mne/viz/_mpl_figure.py
@@ -220,6 +220,10 @@ class MNEFigure(Figure):
         """Handle buttonpress events."""
         pass
 
+    def _scroll(self, event):
+        """Handle scroll wheel events."""
+        pass
+
     def _pick(self, event):
         """Handle matplotlib pick events."""
         pass
@@ -241,6 +245,7 @@ class MNEFigure(Figure):
             resize_event=self._resize,
             key_press_event=self._keypress,
             button_press_event=self._buttonpress,
+            scroll_event=self._scroll,
             close_event=self._close,
             pick_event=self._pick,
         )
@@ -958,6 +963,17 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
             elif event.inaxes == ax_main:
                 self._toggle_vline(False)
 
+    def _scroll(self, event):
+        """Handle scroll wheel events for channel navigation."""
+        if self.mne.butterfly or self.mne.fig_selection is not None:
+            return
+        direction = -1 if event.button == "up" else 1
+        ceiling = len(self.mne.ch_order) - self.mne.n_channels
+        self.mne.ch_start = np.clip(self.mne.ch_start + direction, 0, ceiling)
+        self._update_picks()
+        self._update_vscroll()
+        self._redraw()
+
     def _pick(self, event):
         """Handle matplotlib pick events."""
         from matplotlib.text import Text
@@ -1111,6 +1127,7 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
                 ("?", "Open this help window"),
                 ("esc", "Close focused figure or dialog window"),
                 ("_MOUSE INTERACTION", " "),
+                ("Scroll wheel", "Scroll channels up/down"),
                 (f"Left-click {ch_cmp} name", lclick_name),
                 (f"Left-click {ch_cmp} data", lclick_data),
                 ("Left-click-and-drag on plot", ldrag),

--- a/mne/viz/_mpl_figure.py
+++ b/mne/viz/_mpl_figure.py
@@ -969,7 +969,10 @@ class MNEBrowseFigure(BrowserBase, MNEFigure):
             return
         direction = -1 if event.button == "up" else 1
         ceiling = len(self.mne.ch_order) - self.mne.n_channels
+        old_start = self.mne.ch_start
         self.mne.ch_start = np.clip(self.mne.ch_start + direction, 0, ceiling)
+        if self.mne.ch_start == old_start:
+            return
         self._update_picks()
         self._update_vscroll()
         self._redraw()

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -596,20 +596,22 @@ def test_plot_raw_scroll(raw, browser_backend):
     # use n_channels < total so there is room to scroll
     fig = raw.plot(n_channels=3)
     assert len(fig.mne.ch_order) > fig.mne.n_channels  # sanity check
+    # the sign of "step" that means "scroll down" differs between backends
+    down, up = (-1, 1) if browser_backend.name == "matplotlib" else (1, -1)
     # scroll down moves ch_start forward by 1
     ch_start_before = fig.mne.ch_start
-    fig._fake_scroll(0.5, 0.5, -1)
+    fig._fake_scroll(0.5, 0.5, down)
     assert fig.mne.ch_start == ch_start_before + 1
     # scroll up moves ch_start back by 1
-    fig._fake_scroll(0.5, 0.5, 1)
+    fig._fake_scroll(0.5, 0.5, up)
     assert fig.mne.ch_start == ch_start_before
     # scroll up at the top is a no-op (already at 0)
     assert fig.mne.ch_start == 0
-    fig._fake_scroll(0.5, 0.5, 1)
+    fig._fake_scroll(0.5, 0.5, up)
     assert fig.mne.ch_start == 0
     # scroll is a no-op in butterfly mode
     fig._fake_keypress("b")
-    fig._fake_scroll(0.5, 0.5, -1)
+    fig._fake_scroll(0.5, 0.5, down)
     assert fig.mne.ch_start == 0
 
 

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -589,6 +589,30 @@ def test_plot_raw_keypresses(raw, browser_backend):
         fig._fake_keypress(key)
 
 
+def test_plot_raw_scroll(raw, browser_backend):
+    """Test scroll wheel channel navigation in raw.plot()."""
+    with raw.info._unlock():
+        raw.info["lowpass"] = 10.0
+    # use n_channels < total so there is room to scroll
+    fig = raw.plot(n_channels=3)
+    assert len(fig.mne.ch_order) > fig.mne.n_channels  # sanity check
+    # scroll down moves ch_start forward by 1
+    ch_start_before = fig.mne.ch_start
+    fig._fake_scroll(0.5, 0.5, -1)
+    assert fig.mne.ch_start == ch_start_before + 1
+    # scroll up moves ch_start back by 1
+    fig._fake_scroll(0.5, 0.5, 1)
+    assert fig.mne.ch_start == ch_start_before
+    # scroll up at the top is a no-op (already at 0)
+    assert fig.mne.ch_start == 0
+    fig._fake_scroll(0.5, 0.5, 1)
+    assert fig.mne.ch_start == 0
+    # scroll is a no-op in butterfly mode
+    fig._fake_keypress("b")
+    fig._fake_scroll(0.5, 0.5, -1)
+    assert fig.mne.ch_start == 0
+
+
 def test_plot_raw_traces(raw, events, browser_backend):
     """Test plotting of raw data."""
     ismpl = browser_backend.name == "matplotlib"


### PR DESCRIPTION
I've always found the lack of mouse wheel support for scrolling channels in `raw.plot()` (only for the Matplotlib backend) a rather big usability issue, so I've added it in this PR.

We could also add support for horizontal scrolling for Shift + mouse wheel, but that's not as important I think.

Small example to demonstrate the new feature:

```python
from numpy.random import default_rng

from mne import create_info
from mne.io import RawArray
from mne.viz import use_browser_backend


def create_toy_data(n_channels=3, duration=25, sfreq=250, seed=None):
    rng = default_rng(seed)
    data = rng.standard_normal(size=(n_channels, int(duration * sfreq))) * 5e-6
    info = create_info(n_channels, sfreq, "eeg")
    return RawArray(data, info)


raw = create_toy_data(n_channels=20, seed=0)

with use_browser_backend("matplotlib"):
    fig = raw.plot(n_channels=5, block=True)
```