### PR TITLE
ENH: add shape validation for scalars in LayeredMesh.update_overlay

### DIFF
--- a/mne/viz/_3d_overlay.py
+++ b/mne/viz/_3d_overlay.py
@@ -286,6 +286,15 @@ class LayeredMesh:
         if overlay is None:
             return
         if scalars is not None:
+            scalars = np.asarray(scalars)
+            if self.smooth_mat is not None:
+                expected = self.smooth_mat.shape[1]
+            else:
+                expected = len(overlay._scalars)
+            if scalars.shape != (expected,):
+                raise ValueError(
+                    f"scalars must have shape ({expected},), got {scalars.shape}"
+                )
             if self.smooth_mat is not None:
                 scalars = self.smooth_mat.dot(scalars)
             overlay._scalars = scalars


### PR DESCRIPTION
#### Reference issue (if any)

Follow-up to #13970, based on @larsoner's review comment: "at some point we should add some checks on `scalars` shape."

#### What does this implement/fix?

Adds a `ValueError` in `LayeredMesh.update_overlay` when `scalars` has the wrong  shape, so users get a clear message.


#### Additional information

"I implemented the code changes myself, and Claude Sonnet 4.6 reviewed it."


