### PR TITLE
MAINT: Replace `defusedxml` with `mffpy` in `_get_ep_info` and `_get_signalfname`

### DIFF
--- a/doc/changes/dev/13991.other.rst
+++ b/doc/changes/dev/13991.other.rst
@@ -1,0 +1,1 @@
+Replace ``defusedxml``-backed implementations of ``_get_ep_info`` and ``_get_signalfname`` in the EGI MFF reader with ``mffpy``-backed parsing via :func:`mne.io.read_raw_egi`, by `Pragnya Khandelwal`_.

--- a/mne/io/egi/general.py
+++ b/mne/io/egi/general.py
@@ -52,23 +52,16 @@ def _get_gains(filepath):
 
 def _get_ep_info(filepath):
     """Get epoch info."""
-    _soft_import("defusedxml", "reading EGI MFF data")
-    from defusedxml.minidom import parse
+    from mffpy.xml_files import XML
 
-    epochfile = filepath + "/epochs.xml"
-    epochlist = parse(epochfile)
-    epochs = epochlist.getElementsByTagName("epoch")
+    ep_obj = XML.from_file(os.path.join(filepath, "epochs.xml"))
     keys = ("first_samps", "last_samps", "first_blocks", "last_blocks")
     epoch_info = {key: list() for key in keys}
-    for epoch in epochs:
-        ep_begin = int(epoch.getElementsByTagName("beginTime")[0].firstChild.data)
-        ep_end = int(epoch.getElementsByTagName("endTime")[0].firstChild.data)
-        first_block = int(epoch.getElementsByTagName("firstBlock")[0].firstChild.data)
-        last_block = int(epoch.getElementsByTagName("lastBlock")[0].firstChild.data)
-        epoch_info["first_samps"].append(ep_begin)
-        epoch_info["last_samps"].append(ep_end)
-        epoch_info["first_blocks"].append(first_block)
-        epoch_info["last_blocks"].append(last_block)
+    for ep in ep_obj.epochs:
+        epoch_info["first_samps"].append(ep.beginTime)
+        epoch_info["last_samps"].append(ep.endTime)
+        epoch_info["first_blocks"].append(ep.firstBlock)
+        epoch_info["last_blocks"].append(ep.lastBlock)
     # Don't turn into ndarray here, keep native int because it can deal with
     # huge numbers (could use np.uint64 but it's more work)
     return epoch_info
@@ -132,8 +125,7 @@ def _get_blocks(filepath):
 
 def _get_signalfname(filepath):
     """Get filenames."""
-    _soft_import("defusedxml", "reading EGI MFF data")
-    from defusedxml.minidom import parse
+    from mffpy.xml_files import XML
 
     listfiles = os.listdir(filepath)
     binfiles = list(
@@ -145,16 +137,14 @@ def _get_signalfname(filepath):
         bin_num_str = re.search(r"\d+", binfile).group()
         infofile = "info" + bin_num_str + ".xml"
         infofiles.append(infofile)
-        infobjfile = os.path.join(filepath, infofile)
-        infobj = parse(infobjfile)
-        if len(infobj.getElementsByTagName("EEG")):
-            signal_type = "EEG"
-        elif len(infobj.getElementsByTagName("PNSData")):
-            signal_type = "PNS"
-        all_files[signal_type] = {
-            "signal": f"signal{bin_num_str}.bin",
-            "info": infofile,
-        }
+        info_obj = XML.from_file(os.path.join(filepath, infofile))
+        channel_type = (
+            info_obj.get_content().get("generalInformation", {}).get("channel_type", "")
+        )
+        if channel_type == "EEG":
+            all_files["EEG"] = {"signal": f"signal{bin_num_str}.bin", "info": infofile}
+        elif channel_type == "PNSData":
+            all_files["PNS"] = {"signal": f"signal{bin_num_str}.bin", "info": infofile}
     if "EEG" not in all_files:
         infofiles_str = "\n".join(infofiles)
         raise FileNotFoundError(


### PR DESCRIPTION
#### Reference issue (if any)

Part of #13926.

Follow-up to #13932, #13945, and #13973.

#### What does this implement/fix?

Replaces the `defusedxml`-backed implementations of `_get_ep_info` and `_get_signalfname` in `mne/io/egi/general.py` with `mffpy.xml_files.XML.from_file()`.

- `_get_ep_info`: now reads `epochs.xml` via `mffpy`'s `Epochs` object, accessing `ep.beginTime`, `ep.endTime`, `ep.firstBlock`, and `ep.lastBlock` directly.

- `_get_signalfname`: now reads each `infoN.xml` via `mffpy`'s `DataInfo` object, using `get_content()['generalInformation']['channel_type']` to distinguish EEG from PNS signal files instead of scanning raw XML tags.

Both functions produce identical output to the legacy implementations, verified against all 7 test MFF files in the testing dataset.

#### Additional information

All 24 tests in `mne/io/egi/tests/test_egi.py` pass locally. No changes to callers in `egimff.py`.
