### PR TITLE
DOC: move eLORETA-specific note out of the template %(depth)s docstring

### DIFF
--- a/mne/minimum_norm/inverse.py
+++ b/mne/minimum_norm/inverse.py
@@ -1893,7 +1893,10 @@ def make_inverse_operator(
         :func:`~mne.compute_covariance` to compute the noise covariance matrix on
         :class:`~mne.io.Raw` and :class:`~mne.Epochs` respectively.
     %(loose)s
-    %(depth)s
+    %(depth)s This is effectively ignored when ``method='eLORETA'``.
+
+        .. versionchanged:: 0.20
+            Depth bias ignored for ``method='eLORETA'``.
     fixed : bool | 'auto'
         Use fixed source orientations normal to the cortical mantle. If True,
         the loose parameter must be ``"auto"`` or ``0``. If ``'auto'``, the loose value

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1170,7 +1170,7 @@ docdict["depth"] = """
 depth : None | float | dict
     How to weight (or normalize) the forward using a depth prior.
     If float (default 0.8), it acts as the depth weighting exponent (``exp``)
-    to use None is equivalent to 0, meaning no depth weighting is performed.
+    to use. None is equivalent to 0, meaning no depth weighting is performed.
     It can also be a :class:`dict` containing keyword arguments to pass to
     :func:`mne.forward.compute_depth_prior` (see docstring for details and
     defaults).

--- a/mne/utils/docs.py
+++ b/mne/utils/docs.py
@@ -1173,10 +1173,7 @@ depth : None | float | dict
     to use None is equivalent to 0, meaning no depth weighting is performed.
     It can also be a :class:`dict` containing keyword arguments to pass to
     :func:`mne.forward.compute_depth_prior` (see docstring for details and
-    defaults). This is effectively ignored when ``method='eLORETA'``.
-
-    .. versionchanged:: 0.20
-       Depth bias ignored for ``method='eLORETA'``.
+    defaults).
 """
 
 docdict["destination_maxwell_dest"] = """


### PR DESCRIPTION
#### Reference issue (if any)

None.

#### What does this implement/fix?

This small PR moves one sentence ("This is effectively ignored when ``method='eLORETA'``") from the docstring of `depth` parameter to `mne.minimum_norm.make_inverse_operator`, which is the only place where it actually applies. The docstring itself is also re-used in `mne.beamformer.make_lcmv`, `mne.beamformer.make_dics`, `mne.inverse_sparse.gamma_map`, `mne.inverse_sparse.mixed_norm`, and `mne.inverse_sparse.tf_mixed_norm`, but in all those places it is rather a bit confusing, since none of the functions have a `method` parameter.

#### Additional information

I built the docs locally, and the changes also look as intended in the rendered HTML. Due to small scope, I omitted the changelog entry, but I can add it if you think it's worth mentioning. For the same reason, I skipped creating an issue on this, which is hopefully fine.
