### PR TITLE
MAINT: Replace `defusedxml` with `mffpy` in `_get_gains` and remove `_extract`

### DIFF
--- a/doc/changes/dev/14007.other.rst
+++ b/doc/changes/dev/14007.other.rst
@@ -1,0 +1,1 @@
+Replace ``defusedxml``-backed ``_get_gains`` with ``mffpy``-backed parsing via :func:`mne.io.read_raw_egi` and remove the internal ``_extract`` helper, fully eliminating ``defusedxml`` from the EGI MFF reader, by `Pragnya Khandelwal`_.

--- a/mne/io/egi/general.py
+++ b/mne/io/egi/general.py
@@ -11,42 +11,23 @@ import numpy as np
 from ...utils import _pl, _soft_import
 
 
-def _extract(tags, filepath=None, obj=None):
-    """Extract info from XML."""
-    _soft_import("defusedxml", "reading EGI MFF data")
-    from defusedxml.minidom import parse
-
-    if obj is not None:
-        fileobj = obj
-    elif filepath is not None:
-        fileobj = parse(filepath)
-    else:
-        raise ValueError("There is not object or file to extract data")
-    infoxml = dict()
-    for tag in tags:
-        value = fileobj.getElementsByTagName(tag)
-        infoxml[tag] = []
-        for i in range(len(value)):
-            infoxml[tag].append(value[i].firstChild.data)
-    return infoxml
-
-
 def _get_gains(filepath):
     """Parse gains."""
-    _soft_import("defusedxml", "reading EGI MFF data")
-    from defusedxml.minidom import parse
+    from mffpy.xml_files import XML
 
-    file_obj = parse(filepath)
-    objects = file_obj.getElementsByTagName("calibration")
-    gains = dict()
-    for ob in objects:
-        value = ob.getElementsByTagName("type")
-        if value[0].firstChild.data == "GCAL":
-            data_g = _extract(["ch"], obj=ob)["ch"]
-            gains.update(gcal=np.asarray(data_g, dtype=np.float64))
-        elif value[0].firstChild.data == "ICAL":
-            data_g = _extract(["ch"], obj=ob)["ch"]
-            gains.update(ical=np.asarray(data_g, dtype=np.float64))
+    obj = XML.from_file(filepath)
+    cals = obj.get_content().get("calibrations", {})
+    gains = {}
+    if "GCAL" in cals:
+        ch_dict = cals["GCAL"]["channels"]
+        gains["gcal"] = np.asarray(
+            [ch_dict[k] for k in sorted(ch_dict)], dtype=np.float64
+        )
+    if "ICAL" in cals:
+        ch_dict = cals["ICAL"]["channels"]
+        gains["ical"] = np.asarray(
+            [ch_dict[k] for k in sorted(ch_dict)], dtype=np.float64
+        )
     return gains
 
 

--- a/mne/io/egi/general.py
+++ b/mne/io/egi/general.py
@@ -8,7 +8,7 @@ import re
 
 import numpy as np
 
-from ...utils import _pl, _soft_import
+from ...utils import _pl
 
 
 def _get_gains(filepath):


### PR DESCRIPTION
#### Reference issue (if any)

Part of #13926 (Phase 1 — legacy helper cleanup).
Follows #13991 (which migrated `_get_ep_info` and `_get_signalfname`).

#### What does this implement/fix?

Replaces the `defusedxml`-backed `_get_gains` with `mffpy`-backed parsing and removes the internal `_extract` helper that was only ever called by `_get_gains`.
`_get_gains` previously parsed `info[N].xml` calibration data by walking raw XML nodes via `defusedxml.minidom`. It now delegates to `mffpy.xml_files.XML.from_file()` and reads the structured `calibrations` dict from `get_content()`, which is the same mffpy API already used throughout the module after #13991.
With `_extract` gone and `_get_gains` migrated, `defusedxml` is now fully eliminated from `mne/io/egi/general.py` and `_soft_import` for it is removed as well.

#### Additional information

`_get_blocks` and `_block_r` remain — they handle binary `.bin` block parsing which has no `mffpy` equivalent yet (targeted for Phase 2 / PNS migration).