### PR TITLE
Add missing f-string prefixes to error messages

### DIFF
--- a/doc/changes/dev/14008.bugfix.rst
+++ b/doc/changes/dev/14008.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed several error messages that displayed literal ``{...}`` placeholder text instead of the intended values, due to a missing ``f`` string prefix (in :class:`mne.SourceEstimate`, :func:`mne.io.read_raw_hitachi`, :func:`mne.preprocessing.compute_current_source_density`, and :func:`mne.preprocessing.maxwell_filter`), by `Cedric Conday`_.

--- a/mne/io/hitachi/hitachi.py
+++ b/mne/io/hitachi/hitachi.py
@@ -95,7 +95,7 @@ class RawHitachi(BaseRaw):
             info = infos[0]
         if len(set(last_samps)) != 1:
             raise RuntimeError(
-                "All files must have the same number of samples, got: {last_samps}"
+                f"All files must have the same number of samples, got: {last_samps}"
             )
         last_samps = [last_samps[0]]
         raw_extras = [dict(probes=probes)]

--- a/mne/preprocessing/_csd.py
+++ b/mne/preprocessing/_csd.py
@@ -153,7 +153,7 @@ def compute_current_source_density(
     _validate_type(z, "numeric", "z")
     _validate_type(radius, "numeric", "radius")
     if radius <= 0:
-        raise ValueError("sphere radius must be greater than 0, got {radius}")
+        raise ValueError(f"sphere radius must be greater than 0, got {radius}")
 
     pos = np.array([inst.info["chs"][pick]["loc"][:3] for pick in picks])
     if not np.isfinite(pos).all() or np.isclose(pos, 0.0).all(1).any():

--- a/mne/preprocessing/maxwell.py
+++ b/mne/preprocessing/maxwell.py
@@ -1527,7 +1527,7 @@ def _check_usable(inst, ignore_ref):
         raise RuntimeError(
             "Maxwell filter cannot be done on compensated "
             "channels (data have been compensated with "
-            "grade {current_comp}) when ignore_ref=True"
+            f"grade {current_comp}) when ignore_ref=True"
         )
 
 

--- a/mne/source_estimate.py
+++ b/mne/source_estimate.py
@@ -513,7 +513,7 @@ class _BaseSourceEstimate(TimeMixin, FilterMixin):
                 )
             if sens_data.ndim != 2:
                 raise ValueError(
-                    "The sensor data must have 2 dimensions, got {sens_data.ndim}"
+                    f"The sensor data must have 2 dimensions, got {sens_data.ndim}"
                 )
 
         _validate_type(vertices, list, "vertices")


### PR DESCRIPTION
Four error messages pass a plain (non-`f`) string containing `{placeholders}` straight to `raise(...)`, so when triggered they emit the literal placeholder text instead of the value:

- `mne/source_estimate.py` — `"The sensor data must have 2 dimensions, got {sens_data.ndim}"`
- `mne/io/hitachi/hitachi.py` — `"All files must have the same number of samples, got: {last_samps}"`
- `mne/preprocessing/_csd.py` — `"sphere radius must be greater than 0, got {radius}"`
- `mne/preprocessing/maxwell.py` — `"...compensated with grade {current_comp}) when ignore_ref=True"`

In each case the referenced variable is in scope — the strings just lost their `f` prefix. Added it so the values interpolate. A scan of `mne/` shows no remaining cases.
