### PR TITLE
MAINT: Remove `_get_eeg_calibration_info` and delegate GCAL scaling to `mffpy`

### DIFF
--- a/doc/changes/dev/14011.other.rst
+++ b/doc/changes/dev/14011.other.rst
@@ -1,0 +1,1 @@
+Remove ``_get_eeg_calibration_info`` from the EGI MFF reader and delegate per-channel GCAL scaling to ``mffpy``'s native calibration, simplifying EEG channel calibration in :func:`mne.io.read_raw_egi`, by `Pragnya Khandelwal`_.

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -279,7 +279,6 @@ def _read_header(input_fname):
     return info
 
 
-
 def _read_locs(filepath, egi_info, channel_naming):
     """Read channel locations."""
     _soft_import("mffpy", "reading EGI MFF data")

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -32,6 +32,7 @@ from .general import (
 )
 
 REFERENCE_NAMES = ("VREF", "Vertex Reference")
+_cal_scales = {"uV": 1e-6, "V": 1}
 
 
 def _get_mff_reader(input_fname):
@@ -279,7 +280,6 @@ def _read_header(input_fname):
     return info
 
 
-
 def _read_locs(filepath, egi_info, channel_naming):
     """Read channel locations."""
     _soft_import("mffpy", "reading EGI MFF data")
@@ -419,7 +419,6 @@ class RawMff(BaseRaw):
 
         logger.info("    Reading events ...")
         egi_events, egi_info, mff_events = _read_events(input_fname, egi_info)
-        _cal_scales = {"uV": 1e-6, "V": 1}
         cals = np.array([_cal_scales[t] for t in egi_info["chan_unit"]])
         logger.info("    Assembling measurement info ...")
         event_codes = egi_info["event_codes"]
@@ -863,7 +862,6 @@ def _read_evoked_mff(fname, condition, channel_naming="E%d", verbose=None):
         info["nchan"] = sum(mff.num_channels.values())
 
     # Add individual channel info
-    _cal_scales = {"uV": 1e-6, "V": 1}
     cals = np.array([_cal_scales[t] for t in egi_info["chan_unit"]])
     cals = np.concatenate([cals, np.repeat(1, len(egi_info["pns_names"]))])
     ch_coil = FIFF.FIFFV_COIL_EEG

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -28,7 +28,6 @@ from .general import (
     _block_r,
     _get_blocks,
     _get_ep_info,
-    _get_gains,
     _get_signalfname,
 )
 
@@ -36,16 +35,9 @@ REFERENCE_NAMES = ("VREF", "Vertex Reference")
 
 
 def _get_mff_reader(input_fname):
-    """Open an mffpy.Reader for the MFF directory, with raw (uncalibrated) EEG.
-
-    mffpy applies its own GCAL scaling by default, but MNE's ``cals`` already
-    incorporate that gain (see ``_get_eeg_calibration_info``), so it is
-    disabled here to avoid applying it twice.
-    """
+    """Open an mffpy.Reader for the MFF directory."""
     mffpy = _import_mffpy("read EGI MFF data")
-    mff_reader = mffpy.Reader(input_fname)
-    mff_reader.set_calibration("EEG", None)
-    return mff_reader
+    return mffpy.Reader(input_fname)
 
 
 def _disk_range_to_epochs(egi_info, disk_start, disk_stop):
@@ -287,20 +279,6 @@ def _read_header(input_fname):
     return info
 
 
-def _get_eeg_calibration_info(filepath, egi_info):
-    """Calculate calibration info for EEG channels."""
-    gains = _get_gains(op.join(filepath, egi_info["info_fname"]))
-    if egi_info["value_range"] != 0 and egi_info["bits"] != 0:
-        cals = [egi_info["value_range"] / 2 ** egi_info["bits"]] * len(
-            egi_info["chan_type"]
-        )
-    else:
-        cal_scales = {"uV": 1e-6, "V": 1}
-        cals = [cal_scales[t] for t in egi_info["chan_unit"]]
-    if "gcal" in gains:
-        cals *= gains["gcal"]
-    return cals
-
 
 def _read_locs(filepath, egi_info, channel_naming):
     """Read channel locations."""
@@ -441,7 +419,8 @@ class RawMff(BaseRaw):
 
         logger.info("    Reading events ...")
         egi_events, egi_info, mff_events = _read_events(input_fname, egi_info)
-        cals = _get_eeg_calibration_info(input_fname, egi_info)
+        _cal_scales = {"uV": 1e-6, "V": 1}
+        cals = np.array([_cal_scales[t] for t in egi_info["chan_unit"]])
         logger.info("    Assembling measurement info ...")
         event_codes = egi_info["event_codes"]
         include = _triage_include_exclude(include, exclude, egi_events, egi_info)
@@ -884,9 +863,8 @@ def _read_evoked_mff(fname, condition, channel_naming="E%d", verbose=None):
         info["nchan"] = sum(mff.num_channels.values())
 
     # Add individual channel info
-    # Get calibration info for EEG channels
-    cals = _get_eeg_calibration_info(fname, egi_info)
-    # Initialize calibration for PNS channels, will be updated later
+    _cal_scales = {"uV": 1e-6, "V": 1}
+    cals = np.array([_cal_scales[t] for t in egi_info["chan_unit"]])
     cals = np.concatenate([cals, np.repeat(1, len(egi_info["pns_names"]))])
     ch_coil = FIFF.FIFFV_COIL_EEG
     ch_kind = FIFF.FIFFV_EEG_CH

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -32,7 +32,7 @@ from .general import (
 )
 
 REFERENCE_NAMES = ("VREF", "Vertex Reference")
-_cal_scales = {"uV": 1e-6, "V": 1}
+CAL_SCALES = {"uV": 1e-6, "V": 1}
 
 
 def _get_mff_reader(input_fname):
@@ -419,7 +419,7 @@ class RawMff(BaseRaw):
 
         logger.info("    Reading events ...")
         egi_events, egi_info, mff_events = _read_events(input_fname, egi_info)
-        cals = np.array([_cal_scales[t] for t in egi_info["chan_unit"]])
+        cals = np.array([CAL_SCALES[t] for t in egi_info["chan_unit"]])
         logger.info("    Assembling measurement info ...")
         event_codes = egi_info["event_codes"]
         include = _triage_include_exclude(include, exclude, egi_events, egi_info)
@@ -862,7 +862,7 @@ def _read_evoked_mff(fname, condition, channel_naming="E%d", verbose=None):
         info["nchan"] = sum(mff.num_channels.values())
 
     # Add individual channel info
-    cals = np.array([_cal_scales[t] for t in egi_info["chan_unit"]])
+    cals = np.array([CAL_SCALES[t] for t in egi_info["chan_unit"]])
     cals = np.concatenate([cals, np.repeat(1, len(egi_info["pns_names"]))])
     ch_coil = FIFF.FIFFV_COIL_EEG
     ch_kind = FIFF.FIFFV_EEG_CH

--- a/mne/io/egi/general.py
+++ b/mne/io/egi/general.py
@@ -11,25 +11,6 @@ import numpy as np
 from ...utils import _pl
 
 
-def _get_gains(filepath):
-    """Parse gains."""
-    from mffpy.xml_files import XML
-
-    obj = XML.from_file(filepath)
-    cals = obj.get_content().get("calibrations", {})
-    gains = {}
-    if "GCAL" in cals:
-        ch_dict = cals["GCAL"]["channels"]
-        gains["gcal"] = np.asarray(
-            [ch_dict[k] for k in sorted(ch_dict)], dtype=np.float64
-        )
-    if "ICAL" in cals:
-        ch_dict = cals["ICAL"]["channels"]
-        gains["ical"] = np.asarray(
-            [ch_dict[k] for k in sorted(ch_dict)], dtype=np.float64
-        )
-    return gains
-
 
 def _get_ep_info(filepath):
     """Get epoch info."""

--- a/mne/io/egi/general.py
+++ b/mne/io/egi/general.py
@@ -11,7 +11,6 @@ import numpy as np
 from ...utils import _pl
 
 
-
 def _get_ep_info(filepath):
     """Get epoch info."""
     from mffpy.xml_files import XML


### PR DESCRIPTION
#### Reference issue (if any)

Part of #13926 (Phase 1 — legacy helper cleanup).
Follows #14007.

#### What does this implement/fix?

Removes `_get_eeg_calibration_info` from `egimff.py` and lets `mffpy` apply per-channel GCAL scaling natively instead.
Previously, `_get_mff_reader` disabled `mffpy'`s built-in GCAL calibration (`set_calibration("EEG", None)`) because `_get_eeg_calibration_info` was already baking GCAL into MNE's `cals` array. This split the calibration responsibility across two places. Now `mffpy` handles GCAL directly (as it does by default), and MNE's cals for EEG channels are simplified to a flat unit conversion (1e-6 for µV channels, 1 for V channels).
As a result, `_get_gains` in `general.py` loses its only caller and is removed entirely.

#### Additional information

The `value_range/bits` branch inside `_get_eeg_calibration_info` was dead code — both fields are hardcoded to 0 in `_read_header` and never updated.