### PR TITLE
Fix ' old ' CI lockfile validation for SPEC0 workflow

### DIFF
--- a/.github/workflows/spec_zero.yml
+++ b/.github/workflows/spec_zero.yml
@@ -1,6 +1,7 @@
 name: SPEC0
 
 on:  # yamllint disable-line rule:truthy
+  pull_request:
   schedule:
     - cron: '0 0 * * 1'  # At 00:00 every Monday
   workflow_dispatch:

--- a/.github/workflows/spec_zero.yml
+++ b/.github/workflows/spec_zero.yml
@@ -1,7 +1,6 @@
 name: SPEC0
 
 on:  # yamllint disable-line rule:truthy
-  pull_request:
   schedule:
     - cron: '0 0 * * 1'  # At 00:00 every Monday
   workflow_dispatch:

--- a/tools/dev/spec_zero_update_versions.py
+++ b/tools/dev/spec_zero_update_versions.py
@@ -113,7 +113,7 @@ def update_specifiers(dependencies, releases, changed=None, label=None):
             [
                 f"{label} dependency ``{new}``"
                 for new, old in zip(dependencies, old_deps)
-                if new != old
+                if new.replace(" ", "") != old.replace(" ", "")
             ]
         )
     return changed

--- a/tools/github_actions_check_old_env.py
+++ b/tools/github_actions_check_old_env.py
@@ -32,17 +32,21 @@ for dep in check_deps:
     mod_name, pyproject_ver = get_min_pinned_ver(dep)
     mod_import_name = mod_name_mapping.get(mod_name, mod_name)
 
-    # Need to handle logic for checking Python version vs. module versions differently.
+    # Be wary of uv treating lowest Python vs. module versions differently.
     # For Python, the latest micro version for the major.minor release specified will be
     # used. E.g., if we ask for 3.10 when creating the old env, we will get 3.10.19.
     # However, for modules, uv's `lowest-direct` option will resolve to the lowest
     # major.minor.micro version, even if a micro version isn't specified. E.g., if
     # `pyproject.toml` asks for numpy >= 1.26, the lockfile will have 1.26.0.
+    # However, the non-lowest micro version of a module may be selected for
+    # compatibility reasons. E.g., if `pyproject.toml` asks for pandas >= 2.2 and numpy
+    # >= 2.0, pandas 2.2.2 will be placed in the lockfile, as that was the first version
+    # to support numpy 2.0. Non-lowest micro versions of modules may also not be used if
+    # they were yanked.
+    # Therefore, if the micro version of a module isn't specified in `pyproject.toml`,
+    # we don't check the micro version of the module in the environment.
     if mod_name == "python":
         env_ver = sys.version_info[:3]  # take major, minor, and micro info
-        if len(Version(pyproject_ver).release) == 2:  # only major and minor specified
-            env_ver = env_ver[:2]  # only compare major and minor info
-        env_ver = ".".join(str(x) for x in env_ver)
     else:
         try:
             importlib.import_module(mod_import_name)
@@ -55,7 +59,14 @@ for dep in check_deps:
 
     if pyproject_ver is None:
         continue  # no min version specified, so no check needed
-    if Version(env_ver) != Version(pyproject_ver):
+    pyproject_ver = Version(pyproject_ver)
+    env_ver = Version(env_ver)
+
+    # Discard micro info from env version if it's not specified in pyproject.toml
+    if len(pyproject_ver.release) == 2:
+        env_ver = Version(f"{env_ver.major}.{env_ver.minor}")
+
+    if env_ver != pyproject_ver:
         bad_version.append(
             f"{mod_name}: is {env_ver}; {pyproject_ver} expected from `pyproject.toml`"
         )

--- a/tools/github_actions_check_old_env.py
+++ b/tools/github_actions_check_old_env.py
@@ -47,6 +47,7 @@ for dep in check_deps:
     # we don't check the micro version of the module in the environment.
     if mod_name == "python":
         env_ver = sys.version_info[:3]  # take major, minor, and micro info
+        env_ver = ".".join(str(x) for x in env_ver)
     else:
         try:
             importlib.import_module(mod_import_name)

--- a/tools/github_actions_check_old_lockfile.py
+++ b/tools/github_actions_check_old_lockfile.py
@@ -38,6 +38,16 @@ lockfile_modules.update(
 )
 
 # Check that the versions in the lockfile match the minimum versions in pyproject.toml
+# For modules, uv's `lowest-direct` option will resolve to the lowest
+# major.minor.micro version, even if a micro version isn't specified. E.g., if
+# `pyproject.toml` asks for numpy >= 1.26, the lockfile will have 1.26.0.
+# However, the non-lowest micro version of a module may be selected for
+# compatibility reasons. E.g., if `pyproject.toml` asks for pandas >= 2.2 and numpy
+# >= 2.0, pandas 2.2.2 will be placed in the lockfile, as that was the first version
+# to support numpy 2.0. Non-lowest micro versions of modules may also not be used if
+# they were yanked.
+# Therefore, if the micro version of a module isn't specified in `pyproject.toml`,
+# we don't check the micro version of the module in the environment.
 mod_name_mapping = {"lazy_loader": "lazy-loader"}
 bad_missing = []
 bad_version = []
@@ -45,14 +55,20 @@ for dep in check_deps:
     mod_name, pyproject_ver = get_min_pinned_ver(dep)
     if pyproject_ver is None:
         continue  # no min version specified, so no check needed
+    pyproject_ver = Version(pyproject_ver)
     name = mod_name_mapping.get(mod_name, mod_name)
 
     if name not in lockfile_modules.keys():
         bad_missing.append(name)
         continue
     lockfile_ver = lockfile_modules[name]
+    lockfile_ver = Version(lockfile_ver)
 
-    if Version(lockfile_ver) != Version(pyproject_ver):
+    # Discard micro info from lockfile version if it's not specified in pyproject.toml
+    if len(pyproject_ver.release) == 2:
+        lockfile_ver = Version(f"{lockfile_ver.major}.{lockfile_ver.minor}")
+
+    if lockfile_ver != pyproject_ver:
         bad_version.append(
             f"lower pin on {name} in `pyproject.toml` is {pyproject_ver}, "
             f"but `pylock.ci-old.toml` has {lockfile_ver}"


### PR DESCRIPTION
The SPEC0 workflow hasn't been able to run the last 2 weeks due to the 'old' CI lockfile validation failing.

uv's logic for generating lockfiles with `lowest-direct` is to pin modules to the earliest major.minor.micro version, even if a micro version isn't specified. E.g., if `pyproject.toml` asks for `pandas >= 2.2`, the lockfile will log `2.2.0`. When validating the lockfile against `pyproject.toml`, we had been checking that `Version("2.2.0") == Version("2.2")`, so just assuming that the earliest compatible micro version will be `x.y.0`.

In the last weeks, the numpy dependency was (going to be) bumped to `>= 2.0`. However, pandas 2.2.2 was the first release to support numpy 2.0. pandas 2.2.2 was added to the lockfile, but `Version("2.2.2") != Version("2.2")` , so the lockfile validation failed.

This PR updates the logic so that we don't check micro versions in the lockfile when they aren't explicitly provided in `pyproject.toml`. This could also be relevant if `x.y.0` releases got yanked.

Set SPEC0 workflow to run on PRs to check changes. Reminder to revert before merging.