### PR TITLE
FIX: Keep extras when combining Annotations

### DIFF
--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1738,12 +1738,14 @@ def _combine_annotations(
     duration = np.concatenate([one.duration, two.duration])
     description = np.concatenate([one.description, two.description])
     ch_names = np.concatenate([one.ch_names, two.ch_names])
-    
+
     # --- BİZİM EKLEDİĞİMİZ SATIR (Extras listelerini birleştir): ---
     extras = list(one.extras) + list(two.extras)
-    
+
     # --- EN SONA "extras=extras" PARAMETRESİNİ EKLEDİK: ---
-    return Annotations(onset, duration, description, one.orig_time, ch_names, extras=extras)
+    return Annotations(
+        onset, duration, description, one.orig_time, ch_names, extras=extras
+    )
 
 
 def _handle_meas_date(meas_date):

--- a/mne/annotations.py
+++ b/mne/annotations.py
@@ -1738,7 +1738,12 @@ def _combine_annotations(
     duration = np.concatenate([one.duration, two.duration])
     description = np.concatenate([one.description, two.description])
     ch_names = np.concatenate([one.ch_names, two.ch_names])
-    return Annotations(onset, duration, description, one.orig_time, ch_names)
+    
+    # --- BİZİM EKLEDİĞİMİZ SATIR (Extras listelerini birleştir): ---
+    extras = list(one.extras) + list(two.extras)
+    
+    # --- EN SONA "extras=extras" PARAMETRESİNİ EKLEDİK: ---
+    return Annotations(onset, duration, description, one.orig_time, ch_names, extras=extras)
 
 
 def _handle_meas_date(meas_date):


### PR DESCRIPTION


Fixes #14022     What does this implement/fix?

When combining annotations using `_combine_annotations` (e.g., during raw concatenations or appending), the `extras` list associated with the annotations was being dropped. While `onset`, `duration`, and `description` arrays were properly concatenated, the new `Annotations` object was constructed without passing the combined `extras` keyword argument.

This PR fixes the issue by:
- Merging the `extras` lists from the input annotation objects (`list(one.extras) + list(two.extras)`).
- Passing the merged `extras` list to the returned `Annotations` constructor so that metadata like response times or stimulus details are preserved after concatenation.


#### Additional information

Here is a minimal script to verify the fix:
`import mne
a1 = mne.Annotations([1], [1], ['stim'], extras=[{'res': 1}])
a2 = mne.Annotations([2], [2], ['stim'], extras=[{'res': 2}])
print((a1 + a2).extras)
# Output is now correctly: [{'res': 1}, {'res': 2}] instead of [{}]