### PR TITLE
Loosen tolerance for our rotation calc in viz

### DIFF
--- a/mne/transforms.py
+++ b/mne/transforms.py
@@ -1296,12 +1296,12 @@ def quat_to_rot(quat):
 
 
 @jit()
-def _one_rot_to_quat(rot):
+def _one_rot_to_quat(rot, *, tol=1e-3):
     """Convert a rotation matrix to quaternions."""
     # see e.g. http://www.euclideanspace.com/maths/geometry/rotations/
     #                 conversions/matrixToQuaternion/
     det = np.linalg.det(np.reshape(rot, (3, 3)))
-    if np.abs(det - 1.0) > 1e-3:
+    if np.abs(det - 1.0) > tol:
         raise ValueError("Matrix is not a pure rotation, got determinant != 1")
     t = 1.0 + rot[0] + rot[4] + rot[8]
     if t > np.finfo(rot.dtype).eps:
@@ -1331,13 +1331,16 @@ def _one_rot_to_quat(rot):
     return np.array((qx, qy, qz))
 
 
-def rot_to_quat(rot):
+def rot_to_quat(rot, *, tol=1e-3):
     """Convert a set of rotations to quaternions.
 
     Parameters
     ----------
     rot : array, shape (..., 3, 3)
         The rotation matrices to convert.
+    tol : float
+        Tolerance for the determinant checking that the rotation matrices are valid.
+        The default (1e-3) should be suitable for most cases.
 
     Returns
     -------
@@ -1350,7 +1353,7 @@ def rot_to_quat(rot):
     quat_to_rot
     """
     rot = rot.reshape(rot.shape[:-2] + (9,))
-    return np.apply_along_axis(_one_rot_to_quat, -1, rot)
+    return np.apply_along_axis(_one_rot_to_quat, -1, rot, tol=tol)
 
 
 def _quat_to_affine(quat):

--- a/mne/viz/_3d.py
+++ b/mne/viz/_3d.py
@@ -1149,7 +1149,9 @@ def _ch_pos_in_coord_frame(info, to_cf_t, warn_meg=True, verbose=None):
                 frame_trans = to_cf_t[_frame_to_str[ch_coord_frame]]["trans"]
                 transform = frame_trans @ coil_trans
                 position = transform[:3, 3]
-                quat = rot_to_quat(transform[:3, :3])
+                # Some MEG systems have rotation matrices that are not exactly
+                # orthonormal, so be a bit more tolerant than usual here
+                quat = rot_to_quat(transform[:3, :3], tol=2e-3)
                 shape_key = (local_rr.round(10).tobytes(), triangles.tobytes())
                 chs[type_name][info.ch_names[idx]] = (
                     local_rr,

--- a/mne/viz/tests/test_3d.py
+++ b/mne/viz/tests/test_3d.py
@@ -457,6 +457,19 @@ def test_plot_alignment_meg(renderer, system):
     pytest.importorskip("nibabel")
     if system == "Neuromag":
         this_info = read_info(evoked_fname)
+        # Test regression for somato dataset, which has less than ideal rot encoded
+        idx = this_info["ch_names"].index("MEG 0322")
+        this_info["chs"][idx]["loc"][3:] = [
+            -0.351594,
+            0.118898,
+            -0.92858398,
+            -0.370994,
+            -0.92838401,
+            0.0216,
+            -0.85886598,
+            0.37848499,
+            0.34239799,
+        ]
     elif system == "CTF":
         this_info = read_raw_ctf(ctf_fname).info
     elif system == "BTi":


### PR DESCRIPTION
Should fix the failures from https://github.com/mne-tools/mne-bids-pipeline/pull/1266, I pulled the values from there using `pdb` (and verified the test fails on `main` but passes on this PR)