### PR TITLE
MAINT: remove dead gain/bits/value_range fields from _read_header in …

### DIFF
--- a/doc/changes/dev/14047.other.rst
+++ b/doc/changes/dev/14047.other.rst
@@ -1,0 +1,1 @@
+Remove dead placeholder keys ``gain``, ``bits``, and ``value_range`` from ``_read_header`` in ``egimff.py``; these were hardcoded to zero and unused since MFF calibration is handled via ``CAL_SCALES`` (:gh:`14047`), by `Pragnya Khandelwal`_.

--- a/doc/changes/dev/14047.other.rst
+++ b/doc/changes/dev/14047.other.rst
@@ -1,1 +1,1 @@
-Remove dead placeholder keys ``gain``, ``bits``, and ``value_range`` from ``_read_header`` in ``egimff.py``; these were hardcoded to zero and unused since MFF calibration is handled via ``CAL_SCALES`` (:gh:`14047`), by `Pragnya Khandelwal`_.
+Remove dead placeholder keys ``gain``, ``bits``, and ``value_range`` from ``_read_header`` in ``egimff.py``; these were hardcoded to zero and unused since MFF calibration is handled via ``CAL_SCALES``, by `Pragnya Khandelwal`_.

--- a/mne/io/egi/egimff.py
+++ b/mne/io/egi/egimff.py
@@ -262,9 +262,6 @@ def _read_header(input_fname):
         version=version,
         meas_dt_local=time_n,
         utc_offset=time_n.strftime("%z"),
-        gain=0,
-        bits=0,
-        value_range=0,
     )
     info.update(
         n_categories=0,


### PR DESCRIPTION
#### Reference issue (if any)

Part of #13926 (Phase 2 — clean up dead header fields).

#### What does this implement/fix?

Removes three placeholder keys (`gain=0`, `bits=0`, `value_range=0`) that were hardcoded to zero in `_read_header` inside `egimff.py` and never read anywhere in the MFF code path. Calibration in the MFF reader has always been handled via
`CAL_SCALES = {"uV": 1e-6, "V": 1}` — these fields were copied over from the old simple-binary EGI reader (`egi.py`) when `egimff.py` was first written and became dead weight once the MFF calibration path was established.

#### Additional information