### PR TITLE
Ensure epochs being concatenated have compatible event ids

### DIFF
--- a/doc/changes/dev/14051.bugfix.rst
+++ b/doc/changes/dev/14051.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where :func:`mne.concatenate_epochs` could silently concatenate epochs with conflicting ``event_id`` dicts, by `Eric Larson`_.

--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -4622,15 +4622,26 @@ def _concatenate_epochs(
             )
 
         # compare event_id
-        common_keys = list(set(event_id).intersection(set(epochs.event_id)))
-        for key in common_keys:
-            if not event_id[key] == epochs.event_id[key]:
-                msg = (
-                    "event_id values must be the same for identical keys "
-                    'for all concatenated epochs. Key "{}" maps to {} in '
-                    "some epochs and to {} in others."
-                )
-                raise ValueError(msg.format(key, event_id[key], epochs.event_id[key]))
+        for kind in ("keys", "values"):
+            a = event_id
+            b = epochs.event_id
+            if kind == "keys":
+                other = "values"
+                what = "maps to"
+            else:
+                assert kind == "values"
+                other = "keys"
+                what = "is mapped from"
+                a = {v: k for k, v in a.items()}
+                b = {v: k for k, v in b.items()}
+            common = list(set(a).intersection(set(b)))
+            for k_v in common:
+                if not a[k_v] == b[k_v]:
+                    raise ValueError(
+                        f"event_id {other} must be the same for identical {kind} "
+                        f'for all concatenated epochs. {other} "{k_v}" {what} {a[k_v]} '
+                        f"in epochs_list[0] and to {b[k_v]} in epochs_list[{ii}]."
+                    )
 
         if with_data:
             epochs.drop_bad()

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -3842,6 +3842,16 @@ def test_concatenate_epochs():
     epochs2.event_id = dict(a=2)
     with pytest.raises(ValueError, match="identical keys"):
         concatenate_epochs([epochs1, epochs2])
+    # corruption check
+    with pytest.raises(ValueError, match="has values that do not match any"):
+        epochs2["a"]
+    epochs2.event_id = dict(a=1, b=1)
+    with pytest.raises(ValueError, match="has duplicate values"):
+        epochs2["a"]
+    # mismatch check
+    epochs2.event_id = dict(b=1)
+    with pytest.raises(ValueError, match="identical values"):
+        concatenate_epochs([epochs1, epochs2])
 
     # check concatenating epochs where one of the objects is empty
     epochs2 = epochs.copy()[:0]

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -4726,7 +4726,7 @@ def test_make_fixed_length_epochs():
     assert "2" in epochs.event_id and len(epochs.event_id) == 1
 
 
-def test_epochs_huge_events(tmp_path):
+def test_epochs_huge_events(tmp_path, monkeypatch):
     """Test epochs with event numbers that are too large."""
     data = np.zeros((1, 1, 1000))
     info = create_info(1, 1000.0, "eeg")
@@ -4738,6 +4738,7 @@ def test_epochs_huge_events(tmp_path):
         EpochsArray(data, info, events)
     epochs = EpochsArray(data, info)
     epochs.events = events
+    epochs.event_id["1"] = 2147483648
     with pytest.raises(TypeError, match="exceeds maximum"):
         epochs.save(tmp_path / "temp-epo.fif")
 

--- a/mne/utils/mixin.py
+++ b/mne/utils/mixin.py
@@ -166,6 +166,24 @@ class GetEpochsMixin:
                 select = np.array([], int)
         return select
 
+    def _sanity_check_event_id(self):
+        for kind in ("keys", "values"):
+            a = list(getattr(self.event_id, kind)())
+            if len(set(a)) != len(a):
+                raise ValueError(
+                    f"The event_id dictionary has duplicate {kind}. Please ensure that "
+                    f"all {kind} are unique: {a}"
+                )
+            if kind == "values":
+                missing = sorted(set(self.events[:, 2][~np.isin(self.events[:, 2], a)]))
+                if len(missing):
+                    raise ValueError(
+                        "The event_id dictionary has values that do not match any "
+                        "event codes in self.events. Please ensure that all values "
+                        "in event_id are present in self.events[:, 2]. "
+                        f"Missing event codes: {missing}"
+                    )
+
     def _getitem(
         self,
         item,
@@ -201,6 +219,7 @@ class GetEpochsMixin:
         `Epochs` or tuple(Epochs, np.ndarray) if `return_indices` is True
             subset of epochs (and optionally array with kept epoch indices)
         """
+        self._sanity_check_event_id()
         inst = self.copy() if copy else self
         if self._data is not None:
             np.copyto(inst._data, self._data, casting="no")


### PR DESCRIPTION
I hit a sneaky little bug where I had a variant of
```
epochs1.event_id == {"a": 1, "b": 2}
epochs2.event_id == {"c": 1}
```
and MNE-Python silently allowed me to concatenate these using `concatenate_epochs`. It led to really weird scenarios where `__getitem__` access (e.g., to `epochs_concat["b"]`) would result in a mixture of events. This adds a check both at the `concatenate_epochs` stage (public API) and at the `__getitem__` stage (in case users have messed with `event_id`... which they aren't really supposed to do but might as a workaround) to do some sanity checks.