### PR TITLE
Reduce padding between title and topomap in `ICA.plot_components()`

### DIFF
--- a/doc/changes/dev/14058.newfeature.rst
+++ b/doc/changes/dev/14058.newfeature.rst
@@ -1,0 +1,1 @@
+:func:`mne.viz.plot_ica_components` and :meth:`mne.preprocessing.ICA.plot_components` now set the window title to "Independent Components" instead of adding a suptitle and append the plotted component range when it is contiguous, by `Clemens Brunner`_.

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -82,7 +82,7 @@ def test_plot_ica_components():
         )
     plt.close("all")
 
-    # TODO: non-GUI FigureManagerBase.get_window_title() always returned "image" before
+    # TODO VERSION: non-GUI get_window_title() always returned "image" before
     # matplotlib 3.10.3; simplify once that's the minimum supported version (currently
     # the "old" job pins matplotlib 3.9.0)
     if check_version("matplotlib", "3.10.3"):

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -82,6 +82,15 @@ def test_plot_ica_components():
         )
     plt.close("all")
 
+    # window title shows the component range when picks are contiguous
+    fig = ica.plot_components(None, **fast_test)
+    assert fig.canvas.manager.get_window_title() == "Independent Components (0-7)"
+    fig = ica.plot_components([3], **fast_test)  # single component
+    assert fig.canvas.manager.get_window_title() == "Independent Components (3)"
+    fig = ica.plot_components([0, 1] * 2, **fast_test)  # not contiguous
+    assert fig.canvas.manager.get_window_title() == "Independent Components"
+    plt.close("all")
+
     # test interactive mode (passing 'inst' arg)
     with catch_logging() as log:
         ica.plot_components(

--- a/mne/viz/tests/test_ica.py
+++ b/mne/viz/tests/test_ica.py
@@ -23,7 +23,7 @@ from mne import (
 from mne.datasets import testing
 from mne.io import RawArray, read_raw_fif
 from mne.preprocessing import ICA, create_ecg_epochs, create_eog_epochs
-from mne.utils import _record_warnings, catch_logging
+from mne.utils import _record_warnings, catch_logging, check_version
 from mne.viz.ica import _create_properties_layout, plot_ica_properties
 from mne.viz.utils import _fake_click, _fake_keypress
 
@@ -82,14 +82,18 @@ def test_plot_ica_components():
         )
     plt.close("all")
 
-    # window title shows the component range when picks are contiguous
-    fig = ica.plot_components(None, **fast_test)
-    assert fig.canvas.manager.get_window_title() == "Independent Components (0-7)"
-    fig = ica.plot_components([3], **fast_test)  # single component
-    assert fig.canvas.manager.get_window_title() == "Independent Components (3)"
-    fig = ica.plot_components([0, 1] * 2, **fast_test)  # not contiguous
-    assert fig.canvas.manager.get_window_title() == "Independent Components"
-    plt.close("all")
+    # TODO: non-GUI FigureManagerBase.get_window_title() always returned "image" before
+    # matplotlib 3.10.3; simplify once that's the minimum supported version (currently
+    # the "old" job pins matplotlib 3.9.0)
+    if check_version("matplotlib", "3.10.3"):
+        # window title shows the component range when picks are contiguous
+        fig = ica.plot_components(None, **fast_test)
+        assert fig.canvas.manager.get_window_title() == "Independent Components (0-7)"
+        fig = ica.plot_components([3], **fast_test)  # single component
+        assert fig.canvas.manager.get_window_title() == "Independent Components (3)"
+        fig = ica.plot_components([0, 1] * 2, **fast_test)  # not contiguous
+        assert fig.canvas.manager.get_window_title() == "Independent Components"
+        plt.close("all")
 
     # test interactive mode (passing 'inst' arg)
     with catch_logging() as log:

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1882,7 +1882,9 @@ def plot_ica_components(
                 plot_title = comp_title
                 if group_label is not None:
                     plot_title += f" [{group_label}]"
-                subplot_titles.append(ax.set_title(plot_title, fontsize=12, **kwargs))
+                subplot_titles.append(
+                    ax.set_title(plot_title, fontsize=12, pad=0, **kwargs)
+                )
                 _vlim = _setup_vmin_vmax(group_data[:, 0], *vlim, norm=group_norm)
                 group_cmap = _setup_cmap(cmap, n_axes=len(picks), norm=group_norm)
                 im = plot_topomap(

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -70,6 +70,7 @@ from .utils import (
     _prepare_trellis,
     _process_times,
     _set_3d_axes_equal,
+    _set_window_title,
     _setup_cmap,
     _setup_vmin_vmax,
     _validate_if_list_of_axes,
@@ -1743,8 +1744,8 @@ def plot_ica_components(
         with the number of subplots per figure controlled by ``nrows`` and
         ``ncols``.
     title : str | None
-        The title of the generated figure. If ``None`` (default) and
-        ``axes=None``, a default title of "ICA Components" will be used.
+        The window title of the generated figure. If ``None`` (default) and
+        ``axes=None``, a default title of "Independent Components" will be used.
     %(nrows_ncols_ica_components)s
 
         .. versionadded:: 1.3
@@ -1836,13 +1837,13 @@ def plot_ica_components(
         n_group_axes = 2 if use_opm_orientation_groups else 1
 
         if title is None:
-            title = "ICA components"
+            title = "Independent Components"
         user_passed_axes = _axes is not None
         if not user_passed_axes:
             fig, _axes, _, _ = _prepare_trellis(
                 len(data) * n_group_axes, ncols=ncols, nrows=nrows
             )
-            fig.suptitle(title)
+            _set_window_title(fig, title)
         else:
             _axes = [_axes] if isinstance(_axes, Axes) else _axes
             if len(_axes) != len(data) * n_group_axes:

--- a/mne/viz/topomap.py
+++ b/mne/viz/topomap.py
@@ -1746,6 +1746,8 @@ def plot_ica_components(
     title : str | None
         The window title of the generated figure. If ``None`` (default) and
         ``axes=None``, a default title of "Independent Components" will be used.
+        If ``axes=None`` and the components shown in a given figure form a
+        contiguous range, that range is appended to the title.
     %(nrows_ncols_ica_components)s
 
         .. versionadded:: 1.3
@@ -1843,7 +1845,17 @@ def plot_ica_components(
             fig, _axes, _, _ = _prepare_trellis(
                 len(data) * n_group_axes, ncols=ncols, nrows=nrows
             )
-            _set_window_title(fig, title)
+            picks_arr = np.asarray(picks)
+            if picks_arr.size and np.array_equal(
+                picks_arr, np.arange(picks_arr[0], picks_arr[-1] + 1)
+            ):
+                if picks_arr.size == 1:
+                    window_title = f"{title} ({picks_arr[0]})"
+                else:
+                    window_title = f"{title} ({picks_arr[0]}-{picks_arr[-1]})"
+            else:
+                window_title = title
+            _set_window_title(fig, window_title)
         else:
             _axes = [_axes] if isinstance(_axes, Axes) else _axes
             if len(_axes) != len(data) * n_group_axes:


### PR DESCRIPTION
Sometimes (depending a little bit on the size and aspect ratio of the figure), it is a little hard to associate the labels (ICA000, ...) with their topomaps right below them. This PR reduces the padding from 6pt to 0 to make this association clearer.

_Before:_
<img width="975" height="967" alt="ica-before" src="https://github.com/user-attachments/assets/186edc37-91a7-4f95-91ff-7a8d7dafee7b" />

_After:_
<img width="975" height="967" alt="ica-after" src="https://github.com/user-attachments/assets/e5a3ac68-66b1-438e-b962-9cd02b34ca7c" />

Bonus question: Would you be OK if we removed the overall title ("ICA components")? It should be really clear even without the title what the figure is showing.

<details>

```python
import mne
from mne.preprocessing import ICA

path = mne.datasets.sample.data_path() / "MEG" / "sample" / "sample_audvis_raw.fif"
raw = mne.io.read_raw_fif(path, preload=True)
raw.pick("eeg").crop(tmax=60).filter(1, None)

ica = ICA(random_state=97)
ica.fit(raw)
ica.plot_components(picks=range(20))
```
</details>