### PR TITLE
Speed up CircleCI with parallelism and uv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,10 +110,10 @@ jobs:
             curl https://codeload.github.com/adobe-fonts/source-sans/tar.gz/3.028R | tar xz -C $HOME/.fonts
             fc-cache -f
 
-      # Load pip cache
+      # Load uv cache
       - restore_cache:
           keys:
-            - pip-cache-1
+            - uv-cache-0
       - restore_cache:
           keys:
             - user-install-bin-cache-310
@@ -125,9 +125,9 @@ jobs:
             ./tools/circleci_dependencies.sh
 
       - save_cache:
-          key: pip-cache-1
+          key: uv-cache-0
           paths:
-            - ~/.cache/pip
+            - ~/.cache/uv
       - save_cache:
           key: user-install-bin-cache-310
           paths:
@@ -442,7 +442,7 @@ jobs:
           command: ./tools/circleci_bash_env.sh
       - restore_cache:
           keys:
-            - pip-cache-1
+            - uv-cache-0
       - run:
           name: Get Python running
           command: |

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -nWT --keep-going
+SPHINXOPTS    = -nWT --keep-going -j auto
 SPHINXBUILD   = sphinx-build
 MPROF         = SG_STAMP_STARTS=true mprof run -E --python sphinx
 

--- a/doc/sphinxext/contrib_avatars.py
+++ b/doc/sphinxext/contrib_avatars.py
@@ -47,4 +47,4 @@ MNE_ADD_CONTRIBUTOR_IMAGE=true in your environment to generate it.</p>"""
 def setup(app):
     """Set up the Sphinx app."""
     app.connect("config-inited", generate_contrib_avatars)
-    return
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/doc/sphinxext/directive_formatting.py
+++ b/doc/sphinxext/directive_formatting.py
@@ -10,6 +10,7 @@ from mne_doc_utils import sphinx_logger
 def setup(app):
     app.connect("source-read", check_directive_formatting)
     app.connect("autodoc-process-docstring", check_directive_formatting)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}
 
 
 def setup_module():

--- a/doc/sphinxext/gen_commands.py
+++ b/doc/sphinxext/gen_commands.py
@@ -11,6 +11,7 @@ from mne.utils import ArgvSetter, _replace_md5
 
 def setup(app):
     app.connect("builder-inited", generate_commands_rst)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}
 
 
 def setup_module():

--- a/doc/sphinxext/gen_names.py
+++ b/doc/sphinxext/gen_names.py
@@ -8,6 +8,7 @@ from os import path as op
 
 def setup(app):
     app.connect("builder-inited", generate_name_links_rst)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}
 
 
 def setup_module():

--- a/doc/sphinxext/gh_substitutions.py
+++ b/doc/sphinxext/gh_substitutions.py
@@ -45,4 +45,4 @@ def gh_role(name, rawtext, text, lineno, inliner, options={}, content=[]):  # no
 
 def setup(app):
     app.add_role("gh", gh_role)
-    return
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/doc/sphinxext/newcontrib_substitutions.py
+++ b/doc/sphinxext/newcontrib_substitutions.py
@@ -24,4 +24,4 @@ def newcontrib_role(name, rawtext, text, lineno, inliner, options={}, content=[]
 
 def setup(app):
     app.add_role("newcontrib", newcontrib_role)
-    return
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/doc/sphinxext/unit_role.py
+++ b/doc/sphinxext/unit_role.py
@@ -31,4 +31,4 @@ def unit_role(name, rawtext, text, lineno, inliner, options={}, content=[]):  # 
 
 def setup(app):
     app.add_role("unit", unit_role)
-    return
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -1,13 +1,17 @@
 #!/bin/bash -ef
 
 set -x
-python -m pip install --upgrade "pip>=25.1" build
+# Bootstrap uv and use it for all installs: its resolver and hardlink-based
+# installs are dramatically faster than pip, and the venv is recreated each run
+# so this "Get Python running" step reinstalls everything every time. uv's
+# download cache lives in ~/.cache/uv (cached separately in the CircleCI config).
+python -m pip install --upgrade "pip>=25.1" uv build
 # rpy2 3.6.7 (or its deps) cause problems with our installed R version, so pin them
 # also install colormath because it doesn't have a binary wheel
-python -m pip install --upgrade --only-binary=numpy,scipy \
+uv pip install --upgrade --only-binary=numpy,scipy \
     "rpy2==3.6.6" "rpy2-rinterface==3.6.5" "rpy2-robjects==3.6.4" mne-ari colormath
-python -m pip install --upgrade --only-binary=:all: \
-    -ve .[full-pyside6] \
+uv pip install --upgrade --overrides tools/circleci_uv_overrides.txt \
+    -e .[full-pyside6] \
     --group=test \
     --group=doc-full \
     "mne-bids @ https://github.com/mne-tools/mne-bids/archive/refs/heads/main.zip" \
@@ -16,5 +20,5 @@ python -m pip install --upgrade --only-binary=:all: \
     "pyvistaqt @ https://github.com/pyvista/pyvistaqt/archive/refs/heads/main.zip" \
     "sphinx-gallery @ https://github.com/sphinx-gallery/sphinx-gallery/archive/refs/heads/master.zip" \
     -r doc/sphinxext/related_software.txt
-python -m pip install --upgrade --no-deps --only-binary=:all: \
+uv pip install --upgrade --no-deps \
     -r doc/sphinxext/related_software_nodeps.txt

--- a/tools/circleci_uv_overrides.txt
+++ b/tools/circleci_uv_overrides.txt
@@ -1,0 +1,7 @@
+# uv override list for the CircleCI doc build (used by tools/circleci_dependencies.sh,
+# which runs from the repo root). Overriding mne to our local editable checkout forces
+# every mne requirement to resolve to it. `.` is relative to the working directory
+# (the repo root when this is used), not to this file. Keep the `[full-pyside6]` extra
+# so uv does not drop those dependencies (the override takes precedence over the
+# command line, including its extras).
+-e .[full-pyside6]


### PR DESCRIPTION
1. Mark our sphinx extensions parallel safe
2. Run doc build in parallel
3. Use `uv` for CircleCI

These changes take CircleCI from 15->8 min

Part of https://github.com/mne-tools/mne-python/pull/14063. Investigated speedups and drafted changes using Claude Fable 5 and Opus 4.8, then I revised (and understand + vouch for all changes).